### PR TITLE
chore: prepare v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,4 +61,4 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
         run: |
           echo "Packages successfully published to npm for release ${RELEASE_TAG}"
-          echo "Published packages: @gjsify/* and create-gjsify"
+          echo "Published packages: @gjsify/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+# Workflow to automatically publish packages to npm on new releases
+name: Release to NPM
+
+on:
+  release:
+    types: [published]
+  # Allow manual triggering for testing
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to use for commit message'
+        required: false
+        default: 'manual'
+
+jobs:
+  publish:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:43
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils meson vala gcc pkgconf gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+
+      - name: Configure Yarn for npm publishing
+        run: |
+          corepack enable
+          yarn config set npmRegistryServer "https://registry.npmjs.org"
+          yarn config set npmAlwaysAuth true
+          yarn config set npmAuthToken "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn run build
+
+      - name: Publish packages to npm
+        run: yarn workspaces foreach -v --no-private --exclude '@girs/*' npm publish --tolerate-republish --tag latest --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+        run: |
+          echo "Packages successfully published to npm for release ${RELEASE_TAG}"
+          echo "Published packages: @gjsify/* and create-gjsify"

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # gjsify
 
-Node.js and Web Standard APIs for [GJS](https://gjs.guide/) (GNOME JavaScript).
+**The full JavaScript ecosystem, native on GNOME.**
 
-Use npm packages and familiar Node.js APIs in GNOME desktop applications. gjsify bridges the gap between the Node.js ecosystem and GJS by providing native implementations of Node.js core modules backed by GNOME libraries (GLib, Gio, Soup).
+Use Node.js APIs, Web APIs, and DOM interfaces in GNOME desktop applications. gjsify provides native implementations backed by GNOME libraries (GLib, Gio, Soup, Cairo, GTK) — so you can use the npm packages and patterns you already know to build native Linux apps.
 
 ## Features
 
-- **39 Node.js modules** (32 fully implemented, 3 partial, 4 stubs)
-- **15 Web API packages** (fetch, WebSocket, WebCrypto, Streams, EventSource, and more)
-- **9,200+ tests** passing on both Node.js and GJS
-- **ESM-only**, TypeScript-first
-- Native GNOME library bindings: `Gio` for I/O, `Soup 3.0` for HTTP, `GLib` for crypto/process
-- esbuild-based build system with platform-specific resolution
+- **40 Node.js modules** — fs, net, http, crypto, streams, child_process, and more
+- **12 Web API packages** — fetch, WebSocket, WebCrypto, Streams, EventSource, AbortController
+- **5 DOM packages** — Canvas2D (Cairo), WebGL (OpenGL ES), DOM elements, event bridge, iframes (WebKit)
+- **ESM-only**, TypeScript-first, esbuild-based build system
+- Native GNOME library bindings: `Gio` for I/O, `Soup 3.0` for HTTP, `GLib` for crypto/process, `Cairo` for 2D, `GTK 4` for UI
+- Every test runs on both Node.js and GJS
 
 ## Quick Start
 
+### Create a new project
+
+```bash
+npm create @gjsify/app my-app
+cd my-app
+npm install
+npm run build
+npm start
+```
+
+This scaffolds a GTK 4 application with TypeScript, ready to build and run.
+
 ### Prerequisites
 
-**Node.js 24+** and **Yarn 4** (via Corepack) are required.
+**Node.js 24+** is required. Your system also needs GJS and GNOME development libraries.
 
 Fedora:
 
@@ -25,7 +37,6 @@ Fedora:
 sudo dnf install gjs glib2-devel gobject-introspection-devel gtk4-devel \
   libsoup3-devel webkitgtk6.0-devel libadwaita-devel gdk-pixbuf2-devel \
   libepoxy-devel libgda libgda-sqlite meson vala gcc pkgconf nodejs
-corepack enable
 ```
 
 Ubuntu:
@@ -34,33 +45,19 @@ Ubuntu:
 sudo apt install gjs libglib2.0-dev libgirepository1.0-dev libgtk-4-dev \
   libsoup-3.0-dev libwebkitgtk-6.0-dev libadwaita-1-dev libgdk-pixbuf-2.0-dev \
   libepoxy-dev libgda-6.0-dev meson valac gcc pkg-config nodejs
-corepack enable
 ```
 
-### Setup
+### Using the CLI directly
 
 ```bash
-git clone https://github.com/nickvision-studios/gjsify.git
-cd gjsify
-yarn install
-yarn build
-```
+# Install the CLI
+npm install -g @gjsify/cli
 
-### Build for GJS
-
-```bash
-# Build a single-file GJS app from TypeScript
-gjsify build src/index.ts --app gjs --outfile app.gjs.mjs
+# Build a TypeScript file for GJS (default target)
+gjsify build src/index.ts --outfile dist/app.js
 
 # Run it
-gjs -m app.gjs.mjs
-```
-
-### Build for Node.js (for testing)
-
-```bash
-gjsify build src/index.ts --app node --outfile app.node.mjs
-node app.node.mjs
+gjsify run dist/app.js
 ```
 
 ## Usage
@@ -99,7 +96,17 @@ console.log(text);
 
 ### Web APIs
 
-All 15 packages fully implemented: abort-controller, compression-streams, dom-elements, dom-events, dom-exception, eventsource, fetch, formdata, html-image-element, streams, webcrypto, webgl, web-globals, websocket, webstorage.
+abort-controller, compression-streams, dom-events, dom-exception, eventsource, fetch, formdata, streams, webcrypto, web-globals, websocket, webstorage.
+
+### DOM
+
+| Package | Backed by | Provides |
+|---------|-----------|----------|
+| canvas2d | Cairo, PangoCairo | CanvasRenderingContext2D, Canvas2DWidget → Gtk.DrawingArea |
+| dom-elements | GdkPixbuf | Node, Element, HTMLCanvasElement, HTMLImageElement, Document |
+| event-bridge | GTK 4, Gdk 4 | GTK → DOM event mapping (Mouse, Pointer, Keyboard, Wheel, Focus) |
+| iframe | WebKit 6.0 | HTMLIFrameElement, IFrameWidget → WebKit.WebView |
+| webgl | gwebgl (Vala) | WebGL 1.0/2.0, CanvasWebGLWidget → Gtk.GLArea |
 
 ### GNOME Library Mappings
 
@@ -119,13 +126,15 @@ All 15 packages fully implemented: abort-controller, compression-streams, dom-el
 
 ```
 packages/
-  node/       # 39 Node.js API packages (@gjsify/<name>)
-  web/        # 15 Web API packages
+  node/       # 40 Node.js API packages (@gjsify/<name>)
+  web/        # 12 Web API packages (fetch, WebSocket, etc.)
+  dom/        # 5 DOM packages (Canvas2D, WebGL, DOM elements, etc.)
   gjs/        # GJS utilities, types, test framework
-  infra/      # Build tools, esbuild plugins, CLI
+  infra/      # Build tools, esbuild plugins, CLI, create-app
 examples/
   cli/        # CLI examples (fs, path, events, etc.)
-  gtk/        # GTK/WebGL examples
+  gtk/        # GTK, Canvas2D, WebGL, and three.js examples
+  net/        # Network examples (Express, Hono, Koa, WebSocket)
 refs/         # Read-only reference submodules (Node.js, Deno, Bun, etc.)
 ```
 

--- a/examples/cli/deepkit-di/package.json
+++ b/examples/cli/deepkit-di/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-deepkit-di",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/deepkit-events/package.json
+++ b/examples/cli/deepkit-events/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-deepkit-events",
   "private": true,
-  "version": "0.0.4",
   "description": "Demonstrates Deepkit event-driven architecture on GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/deepkit-types/package.json
+++ b/examples/cli/deepkit-types/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-deepkit-types",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/deepkit-validation/package.json
+++ b/examples/cli/deepkit-validation/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-deepkit-validation",
   "private": true,
-  "version": "0.0.4",
   "description": "Demonstrates Deepkit runtime type validation with constraints on GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/deepkit-workflow/package.json
+++ b/examples/cli/deepkit-workflow/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-deepkit-workflow",
   "private": true,
-  "version": "0.0.4",
   "description": "Demonstrates Deepkit workflow/state machine on GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/dns-lookup/package.json
+++ b/examples/cli/dns-lookup/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-dns-lookup",
   "private": true,
-  "version": "0.0.4",
   "description": "Interactive DNS lookup tool for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/esbuild-plugin-deepkit/package.json
+++ b/examples/cli/esbuild-plugin-deepkit/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-esbuild-plugin-deepkit",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/examples/cli/esbuild-plugin-transform-ext/package.json
+++ b/examples/cli/esbuild-plugin-transform-ext/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-esbuild-plugin-transform-ext",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.js",
   "type": "module",

--- a/examples/cli/file-search/package.json
+++ b/examples/cli/file-search/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-file-search",
   "private": true,
-  "version": "0.0.4",
   "description": "Recursive file search (simplified grep) for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/gio-cat/package.json
+++ b/examples/cli/gio-cat/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@gjsify/example-cli-gio-cat",
-  "version": "0.0.4",
   "type": "module",
   "module": "dist/index.js",
   "private": true,

--- a/examples/cli/json-store/package.json
+++ b/examples/cli/json-store/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-json-store",
   "private": true,
-  "version": "0.0.4",
   "description": "JSON file-based data store for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-buffer/package.json
+++ b/examples/cli/node-buffer/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-buffer",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-events/package.json
+++ b/examples/cli/node-events/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-events",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-fs/package.json
+++ b/examples/cli/node-fs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-fs",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-os/package.json
+++ b/examples/cli/node-os/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-os",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-path/package.json
+++ b/examples/cli/node-path/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-path",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/node-url/package.json
+++ b/examples/cli/node-url/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-node-url",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/worker-pool/package.json
+++ b/examples/cli/worker-pool/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-worker-pool",
   "private": true,
-  "version": "0.0.4",
   "description": "Worker pool example using worker_threads for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/cli/yargs-demo/package.json
+++ b/examples/cli/yargs-demo/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-cli-yargs-demo",
   "private": true,
-  "version": "0.0.4",
   "description": "CLI calculator using yargs for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/gtk/canvas2d-confetti/package.json
+++ b/examples/gtk/canvas2d-confetti/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@gjsify/example-gtk-canvas2d-confetti",
     "private": true,
-    "version": "0.0.4",
     "description": "Falling confetti Canvas 2D example, adapted from https://codepen.io/linrock/pen/nMadjQ",
     "main": "dist/gjs.js",
     "type": "module",

--- a/examples/gtk/canvas2d-fireworks/package.json
+++ b/examples/gtk/canvas2d-fireworks/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@gjsify/example-gtk-canvas2d-fireworks",
     "private": true,
-    "version": "0.0.4",
     "description": "Colorful fireworks Canvas 2D example, adapted from https://codepen.io/juliangarnier/pen/gmOwJX",
     "main": "dist/gjs.js",
     "type": "module",

--- a/examples/gtk/http-dashboard/package.json
+++ b/examples/gtk/http-dashboard/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-http-dashboard",
   "private": true,
-  "version": "0.0.4",
   "description": "GTK4 dashboard with embedded HTTP server (GJS only)",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/gtk/iframe-basic/package.json
+++ b/examples/gtk/iframe-basic/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@gjsify/example-gtk-iframe-basic",
     "private": true,
-    "version": "0.0.4",
     "description": "Basic iframe example demonstrating HTMLIFrameElement with WebKit.WebView and bidirectional postMessage",
     "main": "dist/index.gjs.js",
     "type": "module",

--- a/examples/gtk/three-extrude-shapes/package.json
+++ b/examples/gtk/three-extrude-shapes/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-three-extrude-shapes",
   "private": true,
-  "version": "0.0.4",
   "description": "Three.js extrude shapes example ported from refs/three/examples/webgl_geometry_extrude_shapes.html",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/three-geometry-cube/package.json
+++ b/examples/gtk/three-geometry-cube/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-three-geometry-cube",
   "private": true,
-  "version": "0.0.4",
   "description": "Three.js geometry cube example ported from refs/three/examples/webgl_geometry_cube.html",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/three-geometry-shapes/package.json
+++ b/examples/gtk/three-geometry-shapes/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-three-geometry-shapes",
   "private": true,
-  "version": "0.0.4",
   "description": "Three.js geometry shapes example ported from refs/three/examples/webgl_geometry_shapes.html",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/three-morphtargets/package.json
+++ b/examples/gtk/three-morphtargets/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-three-morphtargets",
   "private": true,
-  "version": "0.0.4",
   "description": "Three.js morph targets example ported from refs/three/examples/webgl_morphtargets.html",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-demo-fade/package.json
+++ b/examples/gtk/webgl-demo-fade/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-demo-fade",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-01/package.json
+++ b/examples/gtk/webgl-tutorial-01/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-01",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-02/package.json
+++ b/examples/gtk/webgl-tutorial-02/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-02",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-03/package.json
+++ b/examples/gtk/webgl-tutorial-03/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-03",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-04/package.json
+++ b/examples/gtk/webgl-tutorial-04/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-04",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-05/package.json
+++ b/examples/gtk/webgl-tutorial-05/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-05",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-06/package.json
+++ b/examples/gtk/webgl-tutorial-06/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-06",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/gtk/webgl-tutorial-07/package.json
+++ b/examples/gtk/webgl-tutorial-07/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-gtk-webgl-tutorial-07",
   "private": true,
-  "version": "0.0.4",
   "description": "",
   "main": "dist/gjs.js",
   "type": "module",

--- a/examples/net/express-hello/package.json
+++ b/examples/net/express-hello/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-net-express-hello",
   "private": true,
-  "version": "0.0.4",
   "description": "Simple Express.js HTTP server example for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/net/hono-rest/package.json
+++ b/examples/net/hono-rest/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-net-hono-rest",
   "private": true,
-  "version": "0.0.4",
   "description": "Hono REST API example for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/net/koa-blog/package.json
+++ b/examples/net/koa-blog/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@gjsify/example-net-koa-blog",
-  "version": "0.0.4",
   "private": true,
   "type": "module",
   "main": "dist/index.gjs.js",

--- a/examples/net/sse-chat/package.json
+++ b/examples/net/sse-chat/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-net-sse-chat",
   "private": true,
-  "version": "0.0.4",
   "description": "Real-time chat using Server-Sent Events for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/net/static-file-server/package.json
+++ b/examples/net/static-file-server/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-net-static-file-server",
   "private": true,
-  "version": "0.0.4",
   "description": "Static file server example for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/examples/net/ws-chat/package.json
+++ b/examples/net/ws-chat/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@gjsify/example-net-ws-chat",
   "private": true,
-  "version": "0.0.4",
   "description": "WebSocket chat using Soup.Server for Node.js and GJS",
   "main": "dist/index.gjs.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gjsify",
-  "version": "0.0.4",
-  "description": "Combine the power of Typescript with the power of GJS",
+  "version": "0.1.0",
+  "description": "The full JavaScript ecosystem, native on GNOME",
   "type": "module",
   "private": true,
   "keywords": [
@@ -16,7 +16,7 @@
     "check:examples": "yarn workspaces foreach -ptv -A --include '@gjsify/example-*' run check",
     "clear": "yarn workspaces foreach -v --no-private --all --parallel run clear",
     "clear:examples": "yarn workspaces foreach -v -A -p --include '@gjsify/example-*' run clear",
-    "npm:publish": "yarn run build && yarn workspaces foreach -v --no-private npm publish --tolerate-republish --tag latest --access public",
+    "npm:publish": "yarn run build && yarn workspaces foreach -v --no-private --exclude '@girs/*' npm publish --tolerate-republish --tag latest --access public",
     "build": "yarn run build:infra && yarn workspaces foreach --topological -p --no-private --all --exclude '@girs/*' run build",
     "build:infra": "yarn workspaces foreach -pR --topological-dev --from '@gjsify/cli' run build",
     "build:examples": "yarn workspaces foreach -ptv -A --include '@gjsify/example-*' run build"

--- a/packages/dom/canvas2d/README.md
+++ b/packages/dom/canvas2d/README.md
@@ -1,0 +1,33 @@
+# @gjsify/canvas2d
+
+GJS implementation of CanvasRenderingContext2D using Cairo and PangoCairo. Provides Canvas2DWidget extending Gtk.DrawingArea.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/canvas2d
+# or
+yarn add @gjsify/canvas2d
+```
+
+## Usage
+
+```typescript
+import { Canvas2DWidget } from '@gjsify/canvas2d';
+
+const widget = new Canvas2DWidget();
+widget.installGlobals();
+
+widget.onReady((canvas, ctx) => {
+  ctx.fillStyle = 'red';
+  ctx.fillRect(0, 0, 100, 100);
+});
+
+window.set_child(widget);
+```
+
+## License
+
+MIT

--- a/packages/dom/canvas2d/package.json
+++ b/packages/dom/canvas2d/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/canvas2d",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Canvas 2D rendering context for GJS, backed by Cairo",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/dom/dom-elements/README.md
+++ b/packages/dom/dom-elements/README.md
@@ -1,0 +1,31 @@
+# @gjsify/dom-elements
+
+GJS implementation of DOM elements including Node, Element, HTMLElement, HTMLCanvasElement, HTMLImageElement, Document, and more. Backed by GdkPixbuf.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/dom-elements
+# or
+yarn add @gjsify/dom-elements
+```
+
+## Usage
+
+```typescript
+import '@gjsify/dom-elements';
+
+// Registers globalThis.document, globalThis.Image, globalThis.HTMLCanvasElement
+const img = new Image();
+img.src = 'path/to/image.png';
+
+const canvas = document.createElement('canvas');
+canvas.width = 800;
+canvas.height = 600;
+```
+
+## License
+
+MIT

--- a/packages/dom/dom-elements/package.json
+++ b/packages/dom/dom-elements/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/dom-elements",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "DOM element hierarchy (Node, Element, HTMLElement, HTMLImageElement) for GJS",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/dom/event-bridge/README.md
+++ b/packages/dom/event-bridge/README.md
@@ -1,0 +1,36 @@
+# @gjsify/event-bridge
+
+GTK to DOM event bridge for GJS. Maps GTK4 event controllers to standard DOM events (MouseEvent, PointerEvent, KeyboardEvent, WheelEvent, FocusEvent).
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/event-bridge
+# or
+yarn add @gjsify/event-bridge
+```
+
+## Usage
+
+```typescript
+import { attachEventControllers } from '@gjsify/event-bridge';
+
+// Attach GTK4 event controllers that dispatch DOM events
+attachEventControllers(gtkWidget, () => domElement);
+```
+
+### Supported Event Mappings
+
+| GTK Controller | DOM Events |
+|---|---|
+| EventControllerMotion | pointermove, mousemove, pointer/mouse enter/leave/over/out |
+| GestureClick | pointer/mouse down/up, click, dblclick, contextmenu |
+| EventControllerScroll | wheel |
+| EventControllerKey | keydown, keyup |
+| EventControllerFocus | focus, focusin, blur, focusout |
+
+## License
+
+MIT

--- a/packages/dom/event-bridge/package.json
+++ b/packages/dom/event-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/event-bridge",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Bridge GTK event controllers to standard DOM events (MouseEvent, KeyboardEvent, etc.)",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/dom/iframe/README.md
+++ b/packages/dom/iframe/README.md
@@ -1,0 +1,34 @@
+# @gjsify/iframe
+
+GJS implementation of HTMLIFrameElement using WebKit 6.0. Provides IFrameWidget extending WebKit.WebView with postMessage bridge.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/iframe
+# or
+yarn add @gjsify/iframe
+```
+
+## Usage
+
+```typescript
+import { IFrameWidget } from '@gjsify/iframe';
+
+const widget = new IFrameWidget();
+
+widget.onReady((iframe) => {
+  iframe.contentWindow?.addEventListener('message', (event) => {
+    console.log(event.data);
+  });
+});
+
+widget.iframeElement.srcdoc = '<h1>Hello</h1>';
+window.set_child(widget);
+```
+
+## License
+
+MIT

--- a/packages/dom/iframe/package.json
+++ b/packages/dom/iframe/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/iframe",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "HTMLIFrameElement for GJS, backed by WebKit.WebView",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/dom/webgl/README.md
+++ b/packages/dom/webgl/README.md
@@ -1,19 +1,31 @@
 # @gjsify/webgl
 
-WebGL module for GJS (GNOME JavaScript). Implements the WebGL 1.0 API via a Vala-compiled native library (`libgwebgl`) that wraps OpenGL ES 2.0.
+GJS implementation of WebGL 1.0/2.0 using a custom Vala extension (gwebgl). Provides CanvasWebGLWidget extending Gtk.GLArea.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/webgl
+# or
+yarn add @gjsify/webgl
+```
 
 ## Usage
 
-```ts
-import { GjsifyHTMLCanvasElement } from '@gjsify/webgl';
-import Gtk from 'gi://Gtk?version=4.0';
-import GLib from 'gi://GLib';
+```typescript
+import { CanvasWebGLWidget } from '@gjsify/webgl';
 
-Gtk.init();
+const widget = new CanvasWebGLWidget();
+widget.installGlobals();
 
-const canvas = new GjsifyHTMLCanvasElement(800, 600);
-const gl = canvas.getContext('webgl');
-// ... use WebGL API as in the browser
+widget.onReady((canvas, gl) => {
+  gl.clearColor(0, 0, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+});
+
+window.set_child(widget);
 ```
 
 ## Running GJS apps that use this package
@@ -68,3 +80,7 @@ to the repository. They are included in the npm package via the `files` field.
 - [realh/gwebgl](https://github.com/realh/gwebgl)
 - [stackgl/headless-gl](https://github.com/stackgl/headless-gl)
 - [Maia-Everett/valagl](https://github.com/Maia-Everett/valagl)
+
+## License
+
+MIT

--- a/packages/dom/webgl/package.json
+++ b/packages/dom/webgl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/webgl",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "WebGL module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
@@ -39,18 +39,17 @@
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
         "@gjsify/unit": "workspace:^",
+        "@types/bit-twiddle": "^1.0.3",
         "@types/node": "^25.5.0",
         "typescript": "^6.0.2"
     },
     "dependencies": {
-        "@girs/gio-2.0": "^2.88.0-4.0.0-beta.42",
         "@girs/gjs": "^4.0.0-beta.42",
-        "@girs/gtk-4.0": "4.22.1-4.0.0-beta.42",
+        "@girs/gtk-4.0": "^4.22.1-4.0.0-beta.42",
         "@girs/gwebgl-0.1": "workspace:^",
         "@gjsify/dom-elements": "workspace:^",
         "@gjsify/event-bridge": "workspace:^",
         "@gjsify/utils": "workspace:^",
-        "@types/bit-twiddle": "^1.0.3",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5"
     }

--- a/packages/gjs/runtime/README.md
+++ b/packages/gjs/runtime/README.md
@@ -1,0 +1,23 @@
+# @gjsify/runtime
+
+GJS runtime utilities for the gjsify project.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/runtime
+# or
+yarn add @gjsify/runtime
+```
+
+## Usage
+
+```typescript
+import { runtime } from '@gjsify/runtime';
+```
+
+## License
+
+MIT

--- a/packages/gjs/runtime/package.json
+++ b/packages/gjs/runtime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/runtime",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Platform-independent runtime detection for GJS and Node.js",
     "keywords": [
         "gjs",

--- a/packages/gjs/types/README.md
+++ b/packages/gjs/types/README.md
@@ -1,1 +1,9 @@
 # @gjsify/types
+
+Private meta-package for generating GJS type definitions using ts-for-gir.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## License
+
+MIT

--- a/packages/gjs/unit/README.md
+++ b/packages/gjs/unit/README.md
@@ -1,96 +1,73 @@
 # @gjsify/unit
 
-A BDD-style testing framework for Gjs, Deno and Node.js, forked from [gjsunit](https://github.com/philipphoffmann/gjsunit).
+Lightweight testing framework for GJS and Node.js. Provides describe, it, expect with cross-platform support.
 
-## What it is
-unit is a BDD-style testing framework for the gjs Javascript binding for Gnome 4x which can be used to write Gnome 4x applications and extensions. It's syntax is totally stolen from [Jasmine](http://jasmine.github.io/) ;-).
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
-## How to use it
-
-First you need to install the package together with `@gjsify/cli`:
+## Installation
 
 ```bash
-yarn install @gjsify/cli @gjsify/unit -D
+npm install @gjsify/unit
+# or
+yarn add @gjsify/unit
 ```
 
-After that you can build and run your tests:
+## Usage
+
+```typescript
+import { describe, it, expect } from '@gjsify/unit';
+
+export default async () => {
+  await describe('MyModule', async () => {
+    await it('should do something', async () => {
+      expect(42).toBe(42);
+      expect('hello').not.toEqual('world');
+    });
+  });
+};
+```
+
+### Running tests
 
 ```bash
+# Build and run on GJS
 gjsify build test-runner.ts --platform gjs --outfile test.gjs.js
 gjs -m test.gjs.js
+
+# Run on Node.js
+node test-runner.mjs
 ```
 
-## Writing test suites
+### Available matchers
 
-In your test directory you can have as many subdirectories and test files as you wish. unit will just run all of them.
-A test suite could look like this:
+- `toBe(value)` — strict equality (`===`)
+- `toEqual(value)` — loose equality (`==`)
+- `toMatch(regex)` — regex match
+- `toBeDefined()` / `toBeUndefined()`
+- `toBeNull()`
+- `toBeTruthy()` / `toBeFalsy()`
+- `toContain(needle)` — array contains
+- `toBeLessThan(value)` / `toBeGreaterThan(value)`
+- `toBeCloseTo(value, precision)` — float comparison
+- `toThrow()` — expects function to throw
+- `to(callback)` — custom matcher
 
-```js
-// my-module.spec.ts
+All matchers support `.not` for negation.
 
-import { describe, it, expect } from '@gjsify/unit';
-import MyModule from './my-module.js';
+### Spy
 
-export default async () => {
+```typescript
+import { spy } from '@gjsify/unit';
 
-	await describe('MyModule', async () => {
-		await it('should say hello', async () => {
-			var module = new MyModule();
-
-			expect(module.hello()).toEqual('hello');
-			expect(module.hello()).not.toEqual('hi');
-		});
-	});
-
-}
+const f = spy();
+f();
+expect(f.calls.length).toBe(1);
 ```
 
-```js
-// test-runner.ts
+## Credits
 
-import { run } from '@gjsify/unit';
-import myTestSuite from './my-module.spec.ts';
+Forked from [gjsunit](https://github.com/philipphoffmann/gjsunit). Spy functionality forked from [mysticatea/spy](https://github.com/mysticatea/spy).
 
-run({myTestSuite});
-```
+## License
 
-
-Your test files must expose a function. This is the function you will call in your test runner. In your test suite you can use `describe` and `it` to cluster your test suite. You can then use `expect` to capture the value you want to express expectations on. The available methods for expressing expectations are:
-- `toBe(value)` (checks using ===)
-- `toEqual(value)` (checks using ==)
-- `toMatch(regex)` (checks using String.prototype.match and a regular expression)
-- `toBeDefined()` (checks whether the actual value is defined)
-- `toBeUndefined()` (opposite of the above)
-- `toBeNull()` (checks whether the actual value is null)
-- `toBeTruthy()` (checks whether the actual value is castable to true)
-- `toBeFalsy()` (checks whether the actual value is castable to false)
-- `toContain(needle)` (checks whether an array contains the needle value)
-- `toBeLessThan(value)`
-- `toBeGreaterThan(value)`
-- `toBeCloseTo(value, precision)` (can check float values until a given precision)
-- `to(callback)` (checks the value using the provided callback (which gets passed the actual value as first parameter))
-
-There is also a `spy` method with which the call of methods can be checked, this is forked from [mysticatea/spy](https://github.com/mysticatea/spy).
-
-```js
-// spy.spec.ts
-
-import { describe, it, expect, spy } from '@gjsify/unit';
-
-export default async () => {
-    await describe("'spy' function", async () => {
-        await it("should have a calls length of 1 after called one time.", async () => {
-            const f = spy()
-            f()
-
-            expect(f.calls.length).toBe(1)
-        })
-	})
-}
-```
-
-I recommend looking at the test suite for examples.
-
-Happy testing!
-
-
+MIT

--- a/packages/gjs/unit/package.json
+++ b/packages/gjs/unit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/unit",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "A BDD-style testing framework for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/gjs/utils/README.md
+++ b/packages/gjs/utils/README.md
@@ -1,0 +1,26 @@
+# @gjsify/utils
+
+Shared utility functions for gjsify packages including error polyfills, structured clone, and GNOME library helpers.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/utils
+# or
+yarn add @gjsify/utils
+```
+
+## Usage
+
+```typescript
+import { ensureMainLoop } from '@gjsify/utils';
+
+// Start GLib MainLoop if not already running (no-op on Node.js)
+ensureMainLoop();
+```
+
+## License
+
+MIT

--- a/packages/gjs/utils/package.json
+++ b/packages/gjs/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/utils",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Utils module for gjsify",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/infra/cli/README.md
+++ b/packages/infra/cli/README.md
@@ -1,0 +1,30 @@
+# @gjsify/cli
+
+CLI tool for building and running GJS applications. Bundles TypeScript/JavaScript using esbuild with automatic Node.js to GJS module aliasing.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/cli
+# or
+yarn add @gjsify/cli
+```
+
+## Usage
+
+```bash
+# Build a GJS application
+npx @gjsify/cli build src/index.ts
+
+# Run a built GJS application (sets up LD_LIBRARY_PATH, GI_TYPELIB_PATH, etc.)
+npx @gjsify/cli run dist/index.js
+
+# Show environment info for a bundle
+npx @gjsify/cli info dist/index.js
+```
+
+## License
+
+MIT

--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/cli",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "CLI for Gjsify",
     "type": "module",
     "main": "lib/index.js",
@@ -23,7 +23,6 @@
         "cli"
     ],
     "dependencies": {
-        "@gjsify/esbuild-plugin-deepkit": "workspace:^",
         "@gjsify/esbuild-plugin-gjsify": "workspace:^",
         "cosmiconfig": "^9.0.1",
         "esbuild": "^0.27.4",

--- a/packages/infra/create-gjsify/README.md
+++ b/packages/infra/create-gjsify/README.md
@@ -1,4 +1,4 @@
-# create-gjsify
+# @gjsify/create-app
 
 Scaffolding tool for creating new Gjsify projects.
 
@@ -7,7 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Usage
 
 ```bash
-npm create gjsify my-app
+npm create @gjsify/app my-app
 ```
 
 ## License

--- a/packages/infra/create-gjsify/README.md
+++ b/packages/infra/create-gjsify/README.md
@@ -1,0 +1,15 @@
+# create-gjsify
+
+Scaffolding tool for creating new Gjsify projects.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Usage
+
+```bash
+npm create gjsify my-app
+```
+
+## License
+
+MIT

--- a/packages/infra/create-gjsify/package.json
+++ b/packages/infra/create-gjsify/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "create-gjsify",
+    "name": "@gjsify/create-app",
     "version": "0.1.0",
     "description": "Create a new Gjsify project",
     "type": "module",

--- a/packages/infra/create-gjsify/package.json
+++ b/packages/infra/create-gjsify/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "create-gjsify",
+    "version": "0.1.0",
+    "description": "Create a new Gjsify project",
+    "type": "module",
+    "main": "lib/index.js",
+    "bin": "./lib/index.js",
+    "scripts": {
+        "clear": "rm -rf lib tsconfig.tsbuildinfo || exit 0",
+        "check": "tsc --noEmit",
+        "build": "tsc && chmod +x ./lib/index.js",
+        "test": "echo 'nothing to do'"
+    },
+    "keywords": [
+        "gjs",
+        "gjsify",
+        "create",
+        "scaffold",
+        "gnome"
+    ],
+    "files": [
+        "lib",
+        "templates"
+    ],
+    "dependencies": {
+        "yargs": "^18.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^25.5.0",
+        "@types/yargs": "^17.0.35",
+        "typescript": "^6.0.2"
+    }
+}

--- a/packages/infra/create-gjsify/src/create.ts
+++ b/packages/infra/create-gjsify/src/create.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync, cpSync } from 'node:fs'
+import { resolve, join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export async function createProject(projectName: string): Promise<void> {
+    const targetDir = resolve(process.cwd(), projectName)
+
+    if (existsSync(targetDir)) {
+        console.error(`Error: Directory "${projectName}" already exists.`)
+        process.exit(1)
+    }
+
+    console.log(`Creating new Gjsify project in ${targetDir}...`)
+
+    // Create directory structure
+    mkdirSync(join(targetDir, 'src'), { recursive: true })
+
+    // Copy template files
+    const templatesDir = resolve(__dirname, '..', 'templates')
+
+    // Generate package.json from template
+    const packageJsonTemplate = readFileSync(join(templatesDir, 'package.json.tmpl'), 'utf-8')
+    const packageJson = packageJsonTemplate.replace(/\{\{projectName\}\}/g, projectName)
+    writeFileSync(join(targetDir, 'package.json'), packageJson)
+
+    // Copy tsconfig.json
+    cpSync(join(templatesDir, 'tsconfig.json.tmpl'), join(targetDir, 'tsconfig.json'))
+
+    // Copy src/index.ts
+    cpSync(join(templatesDir, 'src', 'index.ts.tmpl'), join(targetDir, 'src', 'index.ts'))
+
+    console.log('')
+    console.log('Project created successfully!')
+    console.log('')
+    console.log('Next steps:')
+    console.log(`  cd ${projectName}`)
+    console.log('  npm install')
+    console.log('  npm run build')
+    console.log('  npm start')
+    console.log('')
+}

--- a/packages/infra/create-gjsify/src/index.ts
+++ b/packages/infra/create-gjsify/src/index.ts
@@ -4,7 +4,7 @@ import { hideBin } from 'yargs/helpers'
 import { createProject } from './create.js'
 
 void yargs(hideBin(process.argv))
-    .scriptName('create-gjsify')
+    .scriptName('@gjsify/create-app')
     .usage('$0 [project-name]', 'Create a new Gjsify project', (yargs) => {
         return yargs.positional('project-name', {
             describe: 'Name of the project directory to create',

--- a/packages/infra/create-gjsify/src/index.ts
+++ b/packages/infra/create-gjsify/src/index.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { createProject } from './create.js'
+
+void yargs(hideBin(process.argv))
+    .scriptName('create-gjsify')
+    .usage('$0 [project-name]', 'Create a new Gjsify project', (yargs) => {
+        return yargs.positional('project-name', {
+            describe: 'Name of the project directory to create',
+            type: 'string',
+            default: 'my-gjs-app'
+        })
+    }, async (argv) => {
+        const projectName = argv['project-name'] as string
+        await createProject(projectName)
+    })
+    .help()
+    .argv

--- a/packages/infra/create-gjsify/templates/package.json.tmpl
+++ b/packages/infra/create-gjsify/templates/package.json.tmpl
@@ -1,0 +1,20 @@
+{
+    "name": "{{projectName}}",
+    "version": "0.1.0",
+    "type": "module",
+    "private": true,
+    "scripts": {
+        "build": "gjsify build src/index.ts --outfile dist/index.js",
+        "start": "gjsify run dist/index.js",
+        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+    },
+    "devDependencies": {
+        "@gjsify/cli": "^0.1.0",
+        "@types/node": "^25.5.0",
+        "typescript": "^6.0.2"
+    },
+    "dependencies": {
+        "@girs/gtk-4.0": "^4.22.1-4.0.0-beta.42",
+        "@gjsify/node-globals": "^0.1.0"
+    }
+}

--- a/packages/infra/create-gjsify/templates/src/index.ts.tmpl
+++ b/packages/infra/create-gjsify/templates/src/index.ts.tmpl
@@ -1,0 +1,23 @@
+import Gtk from 'gi://Gtk?version=4.0'
+
+const app = new Gtk.Application({
+    applicationId: 'org.gjsify.example',
+})
+
+app.connect('activate', () => {
+    const window = new Gtk.ApplicationWindow({
+        application: app,
+        title: 'Hello from Gjsify',
+        defaultWidth: 400,
+        defaultHeight: 300,
+    })
+
+    const label = new Gtk.Label({
+        label: 'Hello from Gjsify!',
+    })
+
+    window.setChild(label)
+    window.present()
+})
+
+app.run([])

--- a/packages/infra/create-gjsify/templates/tsconfig.json.tmpl
+++ b/packages/infra/create-gjsify/templates/tsconfig.json.tmpl
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "target": "ESNext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "types": ["node", "@girs/gtk-4.0"],
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "include": ["src"]
+}

--- a/packages/infra/create-gjsify/tsconfig.json
+++ b/packages/infra/create-gjsify/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "lib",
+        "declarationDir": "lib",
+        "declaration": true,
+        "target": "ESNext",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "types": ["node"],
+        "esModuleInterop": true,
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "files": ["src/index.ts"]
+}

--- a/packages/infra/empty/README.md
+++ b/packages/infra/empty/README.md
@@ -1,3 +1,23 @@
 # @gjsify/empty
 
-Just an empty module, used to resolve modules that are not needed
+Empty placeholder package used as a replacement for unsupported Node.js modules in GJS builds.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/empty
+# or
+yarn add @gjsify/empty
+```
+
+## Usage
+
+```typescript
+import '@gjsify/empty';
+```
+
+## License
+
+MIT

--- a/packages/infra/empty/package.json
+++ b/packages/infra/empty/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/empty",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Empty module for Gjs",
     "type": "module",
     "main": "index.mjs",

--- a/packages/infra/esbuild-plugin-alias/README.md
+++ b/packages/infra/esbuild-plugin-alias/README.md
@@ -1,1 +1,33 @@
 # @gjsify/esbuild-plugin-alias
+
+esbuild plugin for module aliasing. Used internally by @gjsify/esbuild-plugin-gjsify.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/esbuild-plugin-alias
+# or
+yarn add @gjsify/esbuild-plugin-alias
+```
+
+## Usage
+
+```typescript
+import { build } from 'esbuild';
+import { aliasPlugin } from '@gjsify/esbuild-plugin-alias';
+
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  outfile: 'dist/index.js',
+  plugins: [aliasPlugin({
+    'original-module': 'replacement-module',
+  })],
+});
+```
+
+## License
+
+MIT

--- a/packages/infra/esbuild-plugin-alias/package.json
+++ b/packages/infra/esbuild-plugin-alias/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/esbuild-plugin-alias",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "",
     "type": "module",
     "main": "dist/esm/index.mjs",

--- a/packages/infra/esbuild-plugin-deepkit/README.md
+++ b/packages/infra/esbuild-plugin-deepkit/README.md
@@ -1,56 +1,54 @@
 # @gjsify/esbuild-plugin-deepkit
 
-A [esbuild](https://esbuild.github.io/) plugin for the the compiler/transformer of [@deepkit/type](https://deepkit.io/library/type).
+esbuild plugin for Deepkit type compiler integration.
 
-## Example
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/esbuild-plugin-deepkit
+# or
+yarn add @gjsify/esbuild-plugin-deepkit
+```
+
+## Usage
+
+```typescript
+import { build } from 'esbuild';
+import { deepkitPlugin } from '@gjsify/esbuild-plugin-deepkit';
+
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  outfile: 'dist/index.js',
+  format: 'esm',
+  platform: 'node',
+  plugins: [deepkitPlugin()],
+});
+```
+
+### Example
 
 src/index.ts:
-```ts
+```typescript
 import { deserialize } from '@deepkit/type';
 
-interface Config {
-    color: string;
-}
-
 interface User {
-    id: number;
-    createdAt: Date;
-    firstName?: string;
-    lastName?: string;
-    config: Config;
-    username: string;
+  id: number;
+  createdAt: Date;
+  username: string;
 }
 
-//deserialize JSON object to real instances
 const user = deserialize<User>({
-    id: 0,
-    username: 'peter',
-    createdAt: '2021-06-26T12:34:41.061Z',
-    config: {color: '#221122'},
+  id: 0,
+  username: 'peter',
+  createdAt: '2021-06-26T12:34:41.061Z',
 });
-
 
 console.log(user.createdAt instanceof Date); // true
 ```
 
-esbuild.mjs:
-```js
-import { build } from 'esbuild';
-import { deepkitPlugin } from '@gjsify/esbuild-plugin-deepkit';
+## License
 
-build({
-    entryPoints: ['src/index.ts'],
-    bundle: true,
-    minify: true,
-    outfile: 'dist/index.js',
-    format: 'esm',
-    platform: "node",
-    external: ['@deepkit/type'],
-    plugins: [deepkitPlugin()],
-});
-```
-Start:
-```bash
-node dist/index.js
--> true
-```
+MIT

--- a/packages/infra/esbuild-plugin-deepkit/package.json
+++ b/packages/infra/esbuild-plugin-deepkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/esbuild-plugin-deepkit",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Deepkit type compiler plugin for esbuild",
     "type": "module",
     "main": "dist/esm/index.mjs",

--- a/packages/infra/esbuild-plugin-gjsify/README.md
+++ b/packages/infra/esbuild-plugin-gjsify/README.md
@@ -1,0 +1,32 @@
+# @gjsify/esbuild-plugin-gjsify
+
+Main esbuild plugin for Gjsify. Handles Node.js to GJS module aliasing, CJS-ESM interop patching, and extension transforms.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/esbuild-plugin-gjsify
+# or
+yarn add @gjsify/esbuild-plugin-gjsify
+```
+
+## Usage
+
+```typescript
+import { build } from 'esbuild';
+import { gjsifyPlugin } from '@gjsify/esbuild-plugin-gjsify';
+
+await build({
+  entryPoints: ['src/index.ts'],
+  bundle: true,
+  outfile: 'dist/index.js',
+  format: 'esm',
+  plugins: [gjsifyPlugin()],
+});
+```
+
+## License
+
+MIT

--- a/packages/infra/esbuild-plugin-gjsify/package.json
+++ b/packages/infra/esbuild-plugin-gjsify/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/esbuild-plugin-gjsify",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Deepkit type compiler plugin for esbuild",
     "type": "module",
     "main": "dist/esm/index.mjs",
@@ -28,6 +28,7 @@
         "@gjsify/esbuild-plugin-alias": "workspace:^",
         "@gjsify/esbuild-plugin-deepkit": "workspace:^",
         "@gjsify/esbuild-plugin-transform-ext": "workspace:^",
+        "@gjsify/resolve-npm": "workspace:^",
         "fast-glob": "^3.3.3"
     },
     "devDependencies": {

--- a/packages/infra/esbuild-plugin-transform-ext/README.md
+++ b/packages/infra/esbuild-plugin-transform-ext/README.md
@@ -1,38 +1,46 @@
 # @gjsify/esbuild-plugin-transform-ext
 
-Transform import file extensions plugin for `esbuild`.
-This can be useful if you want to bundle a module for Deno and Node.js. 
+esbuild plugin for transforming file extensions in import paths.
 
-## Example
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
-This example transforms the typescript entrypoint with `.ts` imports into a javascript file with `.js` imports.
+## Installation
 
-index:ts:
-```ts
-import { a } from './a.ts';
-import { b } from './b.ts';
-a();
-b();
+```bash
+npm install @gjsify/esbuild-plugin-transform-ext
+# or
+yarn add @gjsify/esbuild-plugin-transform-ext
 ```
 
-esbuild.mjs:
-```js
-import esbuild from 'esbuild';
-import { transformExtPlugin } from "@gjsify/esbuild-plugin-transform-ext";
+## Usage
 
-await esbuild.build({
-  plugins: [transformExtPlugin({ outExtension: {'.ts': '.js'}})],
-  entryPoints: ["./src/index.ts"],
-  outdir: "./dist/",
+```typescript
+import { build } from 'esbuild';
+import { transformExtPlugin } from '@gjsify/esbuild-plugin-transform-ext';
+
+await build({
+  entryPoints: ['src/index.ts'],
+  outdir: 'dist/',
   bundle: false,
-  format: "esm",
+  format: 'esm',
+  plugins: [transformExtPlugin({ outExtension: { '.ts': '.js' } })],
 });
 ```
 
-output index:js:
-```ts
+### Example
+
+Input (`index.ts`):
+```typescript
+import { a } from './a.ts';
+import { b } from './b.ts';
+```
+
+Output (`index.js`):
+```javascript
 import { a } from './a.js';
 import { b } from './b.js';
-a();
-b();
 ```
+
+## License
+
+MIT

--- a/packages/infra/esbuild-plugin-transform-ext/package.json
+++ b/packages/infra/esbuild-plugin-transform-ext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/esbuild-plugin-transform-ext",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Transform import file extensions plugin for esbuild",
     "type": "module",
     "main": "dist/esm/index.mjs",

--- a/packages/infra/resolve-npm/README.md
+++ b/packages/infra/resolve-npm/README.md
@@ -1,0 +1,26 @@
+# @gjsify/resolve-npm
+
+Module resolution utilities for mapping Node.js and Web API modules to their @gjsify/* equivalents.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/resolve-npm
+# or
+yarn add @gjsify/resolve-npm
+```
+
+## Usage
+
+```typescript
+import { resolveNpm } from '@gjsify/resolve-npm';
+
+// Maps Node.js module names to @gjsify/* packages
+const resolved = resolveNpm('fs'); // '@gjsify/fs'
+```
+
+## License
+
+MIT

--- a/packages/infra/resolve-npm/package.json
+++ b/packages/infra/resolve-npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/resolve-npm",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Resolve NPM package aliases",
     "type": "module",
     "main": "lib/index.mjs",

--- a/packages/node/assert/README.md
+++ b/packages/node/assert/README.md
@@ -1,7 +1,31 @@
 # @gjsify/assert
 
-Node.js assert module for Gjs
+GJS implementation of the Node.js `assert` module. Provides assertion functions for testing including deepEqual, throws, and strict mode.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/assert
+# or
+yarn add @gjsify/assert
+```
+
+## Usage
+
+```typescript
+import { strictEqual, deepStrictEqual, throws } from '@gjsify/assert';
+
+strictEqual(1 + 1, 2);
+deepStrictEqual({ a: 1 }, { a: 1 });
+throws(() => { throw new Error('fail'); });
+```
 
 ## Inspirations and credits
+
 - https://deno.land/std/node/assert.ts
 
+## License
+
+MIT

--- a/packages/node/assert/package.json
+++ b/packages/node/assert/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/assert",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js assert module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/async_hooks/README.md
+++ b/packages/node/async_hooks/README.md
@@ -1,0 +1,28 @@
+# @gjsify/async_hooks
+
+GJS implementation of the Node.js `async_hooks` module. Provides AsyncLocalStorage, AsyncResource, and createHook.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/async_hooks
+# or
+yarn add @gjsify/async_hooks
+```
+
+## Usage
+
+```typescript
+import { AsyncLocalStorage, AsyncResource } from '@gjsify/async_hooks';
+
+const storage = new AsyncLocalStorage();
+storage.run({ requestId: '123' }, () => {
+  console.log(storage.getStore()); // { requestId: '123' }
+});
+```
+
+## License
+
+MIT

--- a/packages/node/async_hooks/package.json
+++ b/packages/node/async_hooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/async_hooks",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js async_hooks module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/buffer/README.md
+++ b/packages/node/buffer/README.md
@@ -1,7 +1,31 @@
 # @gjsify/buffer
 
-Node.js buffer module for Gjs
+GJS implementation of the Node.js `buffer` module using Blob, File, atob, and btoa.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/buffer
+# or
+yarn add @gjsify/buffer
+```
+
+## Usage
+
+```typescript
+import { Buffer } from '@gjsify/buffer';
+
+const buf = Buffer.from('hello world', 'utf-8');
+console.log(buf.toString('base64'));
+```
 
 ## Inspirations and credits
+
 - https://deno.land/std/node/buffer.ts
 - https://github.com/feross/buffer
+
+## License
+
+MIT

--- a/packages/node/buffer/package.json
+++ b/packages/node/buffer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/buffer",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js buffer module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/child_process/README.md
+++ b/packages/node/child_process/README.md
@@ -1,0 +1,26 @@
+# @gjsify/child_process
+
+GJS implementation of the Node.js `child_process` module using Gio.Subprocess. Supports exec, execSync, spawn, and spawnSync.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/child_process
+# or
+yarn add @gjsify/child_process
+```
+
+## Usage
+
+```typescript
+import { execSync, spawn } from '@gjsify/child_process';
+
+const output = execSync('echo hello').toString();
+const child = spawn('ls', ['-la']);
+```
+
+## License
+
+MIT

--- a/packages/node/child_process/package.json
+++ b/packages/node/child_process/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/child_process",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js child_process module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/cluster/README.md
+++ b/packages/node/cluster/README.md
@@ -1,0 +1,27 @@
+# @gjsify/cluster
+
+GJS stub implementation of the Node.js `cluster` module. Provides isPrimary and isWorker.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/cluster
+# or
+yarn add @gjsify/cluster
+```
+
+## Usage
+
+```typescript
+import cluster from '@gjsify/cluster';
+
+if (cluster.isPrimary) {
+  console.log('This is the primary process');
+}
+```
+
+## License
+
+MIT

--- a/packages/node/cluster/package.json
+++ b/packages/node/cluster/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/cluster",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js cluster module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/console/README.md
+++ b/packages/node/console/README.md
@@ -1,6 +1,31 @@
 # @gjsify/console
 
-Node.js console module for Gjs
+GJS implementation of the Node.js `console` module with stream support.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/console
+# or
+yarn add @gjsify/console
+```
+
+## Usage
+
+```typescript
+import { Console } from '@gjsify/console';
+
+const logger = new Console(process.stdout, process.stderr);
+logger.log('hello');
+logger.error('something went wrong');
+```
 
 ## Inspirations and credits
+
 - https://github.com/denoland/deno/tree/main/ext/console
+
+## License
+
+MIT

--- a/packages/node/console/package.json
+++ b/packages/node/console/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/console",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js console module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/node/constants/README.md
+++ b/packages/node/constants/README.md
@@ -1,0 +1,25 @@
+# @gjsify/constants
+
+GJS implementation of the Node.js `constants` module.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/constants
+# or
+yarn add @gjsify/constants
+```
+
+## Usage
+
+```typescript
+import constants from '@gjsify/constants';
+
+console.log(constants.O_RDONLY);
+```
+
+## License
+
+MIT

--- a/packages/node/constants/package.json
+++ b/packages/node/constants/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/constants",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js constants module for Gjs (deprecated, re-exports from os/fs/crypto)",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/crypto/README.md
+++ b/packages/node/crypto/README.md
@@ -1,0 +1,27 @@
+# @gjsify/crypto
+
+GJS partial implementation of the Node.js `crypto` module using GLib.Checksum and GLib.Hmac. Supports Hash, Hmac, randomBytes, and UUID.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/crypto
+# or
+yarn add @gjsify/crypto
+```
+
+## Usage
+
+```typescript
+import { createHash, randomBytes, randomUUID } from '@gjsify/crypto';
+
+const hash = createHash('sha256').update('hello').digest('hex');
+const bytes = randomBytes(16);
+const uuid = randomUUID();
+```
+
+## License
+
+MIT

--- a/packages/node/crypto/package.json
+++ b/packages/node/crypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/crypto",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js crypto module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/dgram/README.md
+++ b/packages/node/dgram/README.md
@@ -1,0 +1,29 @@
+# @gjsify/dgram
+
+GJS implementation of the Node.js `dgram` module using Gio.Socket for UDP networking.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/dgram
+# or
+yarn add @gjsify/dgram
+```
+
+## Usage
+
+```typescript
+import { createSocket } from '@gjsify/dgram';
+
+const socket = createSocket('udp4');
+socket.bind(41234);
+socket.on('message', (msg, rinfo) => {
+  console.log(`Received: ${msg} from ${rinfo.address}:${rinfo.port}`);
+});
+```
+
+## License
+
+MIT

--- a/packages/node/dgram/package.json
+++ b/packages/node/dgram/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/dgram",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js dgram module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/diagnostics_channel/README.md
+++ b/packages/node/diagnostics_channel/README.md
@@ -1,0 +1,29 @@
+# @gjsify/diagnostics_channel
+
+GJS implementation of the Node.js `diagnostics_channel` module. Provides Channel and TracingChannel.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/diagnostics_channel
+# or
+yarn add @gjsify/diagnostics_channel
+```
+
+## Usage
+
+```typescript
+import { channel } from '@gjsify/diagnostics_channel';
+
+const ch = channel('my-channel');
+ch.subscribe((message) => {
+  console.log('Received:', message);
+});
+ch.publish({ data: 'hello' });
+```
+
+## License
+
+MIT

--- a/packages/node/diagnostics_channel/package.json
+++ b/packages/node/diagnostics_channel/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/diagnostics_channel",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js diagnostics_channel module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/dns/README.md
+++ b/packages/node/dns/README.md
@@ -1,0 +1,29 @@
+# @gjsify/dns
+
+GJS implementation of the Node.js `dns` module using Gio.Resolver. Supports lookup, resolve4/6, reverse, and promises API.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/dns
+# or
+yarn add @gjsify/dns
+```
+
+## Usage
+
+```typescript
+import { lookup, promises } from '@gjsify/dns';
+
+lookup('example.com', (err, address, family) => {
+  console.log(`Address: ${address}, Family: ${family}`);
+});
+
+const result = await promises.resolve4('example.com');
+```
+
+## License
+
+MIT

--- a/packages/node/dns/package.json
+++ b/packages/node/dns/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/dns",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js dns module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/domain/README.md
+++ b/packages/node/domain/README.md
@@ -1,0 +1,25 @@
+# @gjsify/domain
+
+GJS stub implementation of the deprecated Node.js `domain` module.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/domain
+# or
+yarn add @gjsify/domain
+```
+
+## Usage
+
+```typescript
+import domain from '@gjsify/domain';
+```
+
+> **Note:** The `domain` module is deprecated in Node.js. This package provides a stub for compatibility.
+
+## License
+
+MIT

--- a/packages/node/domain/package.json
+++ b/packages/node/domain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/domain",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js domain module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/events/README.md
+++ b/packages/node/events/README.md
@@ -1,9 +1,34 @@
 # @gjsify/events
 
-Node.js events module for Gjs
+GJS implementation of the Node.js `events` module. Provides EventEmitter, once, on, and listenerCount.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/events
+# or
+yarn add @gjsify/events
+```
+
+## Usage
+
+```typescript
+import { EventEmitter } from '@gjsify/events';
+
+const emitter = new EventEmitter();
+emitter.on('data', (msg) => console.log(msg));
+emitter.emit('data', 'hello');
+```
 
 ## Inspirations and credits
+
 - https://github.com/EventEmitter2/EventEmitter2
 - https://github.com/browserify/events
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/events.js
 - https://github.com/denoland/deno_std/blob/main/node/_events.mjs
+
+## License
+
+MIT

--- a/packages/node/events/package.json
+++ b/packages/node/events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/events",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js events module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/fs/README.md
+++ b/packages/node/fs/README.md
@@ -1,7 +1,36 @@
 # @gjsify/fs
 
-## Inspirations
+GJS implementation of the Node.js `fs` module using Gio. Supports sync, callback, and promises APIs, streams, and FSWatcher.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/fs
+# or
+yarn add @gjsify/fs
+```
+
+## Usage
+
+```typescript
+import { readFileSync, writeFileSync } from '@gjsify/fs';
+import { readFile } from '@gjsify/fs/promises';
+
+const content = readFileSync('/path/to/file', 'utf-8');
+writeFileSync('/path/to/output', 'hello world');
+
+const data = await readFile('/path/to/file', 'utf-8');
+```
+
+## Inspirations and credits
+
 - https://github.com/cgjs/cgjs/blob/master/packages/fs/index.js
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/fs.js
 - https://github.com/mafintosh/level-filesystem/blob/master/index.js
 - https://github.com/denoland/deno_std/blob/main/node/fs.ts
+
+## License
+
+MIT

--- a/packages/node/fs/package.json
+++ b/packages/node/fs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/fs",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js fs module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
@@ -40,6 +40,7 @@
         "typescript": "^6.0.2"
     },
     "dependencies": {
+        "@girs/gio-2.0": "^2.88.0-4.0.0-beta.42",
         "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42",
         "@gjsify/buffer": "workspace:^",
         "@gjsify/events": "workspace:^",

--- a/packages/node/globals/README.md
+++ b/packages/node/globals/README.md
@@ -1,3 +1,27 @@
 # @gjsify/node-globals
 
-Node.js globals module for Gjs
+GJS implementation of Node.js global objects including process, Buffer, structuredClone, TextEncoder/Decoder, atob/btoa, URL, and setImmediate.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/node-globals
+# or
+yarn add @gjsify/node-globals
+```
+
+## Usage
+
+```typescript
+import '@gjsify/node-globals';
+
+// Global objects are now available:
+// process, Buffer, structuredClone, TextEncoder, TextDecoder,
+// atob, btoa, URL, setImmediate
+```
+
+## License
+
+MIT

--- a/packages/node/globals/package.json
+++ b/packages/node/globals/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/node-globals",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js globals module for Gjs",
     "keywords": [
         "gjs",
@@ -31,9 +31,12 @@
         "test:node": "node test.node.mjs"
     },
     "dependencies": {
+        "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42",
+        "@gjsify/abort-controller": "workspace:^",
         "@gjsify/buffer": "workspace:^",
         "@gjsify/fetch": "workspace:^",
         "@gjsify/process": "workspace:^",
+        "@gjsify/url": "workspace:^",
         "@gjsify/utils": "workspace:^"
     },
     "devDependencies": {

--- a/packages/node/http/README.md
+++ b/packages/node/http/README.md
@@ -1,4 +1,33 @@
 # @gjsify/http
 
-## Inspirations
+GJS partial implementation of the Node.js `http` module using Soup 3.0. Provides Server, IncomingMessage, and ServerResponse.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/http
+# or
+yarn add @gjsify/http
+```
+
+## Usage
+
+```typescript
+import { createServer } from '@gjsify/http';
+
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello World');
+});
+server.listen(3000);
+```
+
+## Inspirations and credits
+
 - https://github.com/node-fetch/node-fetch/blob/main/src/headers.js
+
+## License
+
+MIT

--- a/packages/node/http/package.json
+++ b/packages/node/http/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/http",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js http module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/node/http2/README.md
+++ b/packages/node/http2/README.md
@@ -1,0 +1,25 @@
+# @gjsify/http2
+
+GJS stub implementation of the Node.js `http2` module. Currently provides constants only.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/http2
+# or
+yarn add @gjsify/http2
+```
+
+## Usage
+
+```typescript
+import { constants } from '@gjsify/http2';
+
+console.log(constants.HTTP2_HEADER_STATUS);
+```
+
+## License
+
+MIT

--- a/packages/node/http2/package.json
+++ b/packages/node/http2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/http2",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js http2 module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/https/README.md
+++ b/packages/node/https/README.md
@@ -1,0 +1,25 @@
+# @gjsify/https
+
+GJS partial implementation of the Node.js `https` module. Provides Agent with stub request/get.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/https
+# or
+yarn add @gjsify/https
+```
+
+## Usage
+
+```typescript
+import { Agent } from '@gjsify/https';
+
+const agent = new Agent({ keepAlive: true });
+```
+
+## License
+
+MIT

--- a/packages/node/https/package.json
+++ b/packages/node/https/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/https",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js https module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/inspector/README.md
+++ b/packages/node/inspector/README.md
@@ -1,0 +1,25 @@
+# @gjsify/inspector
+
+GJS stub implementation of the Node.js `inspector` module.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/inspector
+# or
+yarn add @gjsify/inspector
+```
+
+## Usage
+
+```typescript
+import inspector from '@gjsify/inspector';
+```
+
+> **Note:** This package provides a stub for compatibility. Full inspector functionality is not available in GJS.
+
+## License
+
+MIT

--- a/packages/node/inspector/package.json
+++ b/packages/node/inspector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/inspector",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js inspector module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/module/README.md
+++ b/packages/node/module/README.md
@@ -1,0 +1,28 @@
+# @gjsify/module
+
+GJS implementation of the Node.js `module` module using Gio and GLib. Provides builtinModules, isBuiltin, and createRequire.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/module
+# or
+yarn add @gjsify/module
+```
+
+## Usage
+
+```typescript
+import { builtinModules, isBuiltin, createRequire } from '@gjsify/module';
+
+console.log(builtinModules);
+console.log(isBuiltin('fs')); // true
+
+const require = createRequire(import.meta.url);
+```
+
+## License
+
+MIT

--- a/packages/node/module/package.json
+++ b/packages/node/module/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/module",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js module module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/net/README.md
+++ b/packages/node/net/README.md
@@ -1,5 +1,33 @@
 # @gjsify/net
 
-Node.js net module for Gjs
+GJS implementation of the Node.js `net` module using Gio.SocketClient and Gio.SocketService. Provides Socket and Server.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/net
+# or
+yarn add @gjsify/net
+```
+
+## Usage
+
+```typescript
+import { createServer, createConnection } from '@gjsify/net';
+
+const server = createServer((socket) => {
+  socket.on('data', (data) => console.log(data.toString()));
+  socket.end('goodbye');
+});
+server.listen(8080);
+```
+
 ## Inspirations and credits
+
 - https://nodejs.org/api/net.html
+
+## License
+
+MIT

--- a/packages/node/net/package.json
+++ b/packages/node/net/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/net",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js net module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/os/README.md
+++ b/packages/node/os/README.md
@@ -1,3 +1,28 @@
 # @gjsify/os
 
-Node.js os module for Gjs
+GJS implementation of the Node.js `os` module using GLib. Provides homedir, hostname, cpus, and more.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/os
+# or
+yarn add @gjsify/os
+```
+
+## Usage
+
+```typescript
+import { homedir, hostname, platform, cpus } from '@gjsify/os';
+
+console.log(homedir());
+console.log(hostname());
+console.log(platform());
+console.log(cpus().length);
+```
+
+## License
+
+MIT

--- a/packages/node/os/package.json
+++ b/packages/node/os/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/os",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js os module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
@@ -30,7 +30,8 @@
         "os"
     ],
     "dependencies": {
-        "@girs/gjs": "^4.0.0-beta.42",
+        "@girs/gio-2.0": "^2.88.0-4.0.0-beta.42",
+        "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42",
         "@gjsify/utils": "workspace:^"
     },
     "devDependencies": {

--- a/packages/node/path/README.md
+++ b/packages/node/path/README.md
@@ -1,0 +1,27 @@
+# @gjsify/path
+
+GJS implementation of the Node.js `path` module. Provides full POSIX and Win32 path utilities.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/path
+# or
+yarn add @gjsify/path
+```
+
+## Usage
+
+```typescript
+import { join, resolve, basename, dirname, extname } from '@gjsify/path';
+
+console.log(join('/home', 'user', 'file.txt'));
+console.log(resolve('relative/path'));
+console.log(basename('/home/user/file.txt')); // 'file.txt'
+```
+
+## License
+
+MIT

--- a/packages/node/path/package.json
+++ b/packages/node/path/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/path",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js path module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/perf_hooks/README.md
+++ b/packages/node/perf_hooks/README.md
@@ -1,0 +1,27 @@
+# @gjsify/perf_hooks
+
+GJS implementation of the Node.js `perf_hooks` module using the Web Performance API with GLib fallback.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/perf_hooks
+# or
+yarn add @gjsify/perf_hooks
+```
+
+## Usage
+
+```typescript
+import { performance } from '@gjsify/perf_hooks';
+
+const start = performance.now();
+// ... do work ...
+console.log(`Elapsed: ${performance.now() - start}ms`);
+```
+
+## License
+
+MIT

--- a/packages/node/perf_hooks/package.json
+++ b/packages/node/perf_hooks/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/perf_hooks",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js perf_hooks module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/process/README.md
+++ b/packages/node/process/README.md
@@ -1,10 +1,35 @@
 # @gjsify/process
 
-Node.js process module for Gjs
+GJS implementation of the Node.js `process` module using GLib. Extends EventEmitter with env, cwd, platform, and more.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/process
+# or
+yarn add @gjsify/process
+```
+
+## Usage
+
+```typescript
+import process from '@gjsify/process';
+
+console.log(process.cwd());
+console.log(process.env.HOME);
+console.log(process.platform);
+```
 
 ## Inspirations and credits
+
 - https://github.com/cgjs/cgjs/tree/master/packages/process
 - https://github.com/denoland/deno_std/blob/main/node/process.ts
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/process.js
 - https://github.com/aleclarson/process-browserify
 - https://github.com/defunctzombie/node-process
+
+## License
+
+MIT

--- a/packages/node/process/package.json
+++ b/packages/node/process/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/process",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js process module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/node/querystring/README.md
+++ b/packages/node/querystring/README.md
@@ -1,7 +1,34 @@
 # @gjsify/querystring
 
-Node.js querystring module for Gjs
+GJS implementation of the Node.js `querystring` module. Provides parse and stringify.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/querystring
+# or
+yarn add @gjsify/querystring
+```
+
+## Usage
+
+```typescript
+import { parse, stringify } from '@gjsify/querystring';
+
+const obj = parse('foo=bar&baz=qux');
+console.log(obj); // { foo: 'bar', baz: 'qux' }
+
+const str = stringify({ name: 'test', value: '123' });
+console.log(str); // 'name=test&value=123'
+```
 
 ## Inspirations and credits
- * https://github.com/SpainTrain/querystring-es3
- * https://github.com/denoland/deno_std/blob/main/node/querystring.ts
+
+- https://github.com/SpainTrain/querystring-es3
+- https://github.com/denoland/deno_std/blob/main/node/querystring.ts
+
+## License
+
+MIT

--- a/packages/node/querystring/package.json
+++ b/packages/node/querystring/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/querystring",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js querystring module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",
@@ -31,9 +31,7 @@
     ],
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
-        "@gjsify/esbuild-plugin-gjsify": "workspace:^",
         "@gjsify/unit": "workspace:^",
-        "@types/inherits": "^2.0.0",
         "@types/node": "^25.5.0",
         "typescript": "^6.0.2"
     }

--- a/packages/node/readline/README.md
+++ b/packages/node/readline/README.md
@@ -1,0 +1,33 @@
+# @gjsify/readline
+
+GJS implementation of the Node.js `readline` module. Provides Interface, createInterface, question, prompt, and async iterator support.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/readline
+# or
+yarn add @gjsify/readline
+```
+
+## Usage
+
+```typescript
+import { createInterface } from '@gjsify/readline';
+
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+rl.question('What is your name? ', (answer) => {
+  console.log(`Hello, ${answer}!`);
+  rl.close();
+});
+```
+
+## License
+
+MIT

--- a/packages/node/readline/package.json
+++ b/packages/node/readline/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/readline",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js readline module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/sqlite/README.md
+++ b/packages/node/sqlite/README.md
@@ -1,0 +1,23 @@
+# @gjsify/sqlite
+
+GJS implementation of the Node.js `sqlite` module.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/sqlite
+# or
+yarn add @gjsify/sqlite
+```
+
+## Usage
+
+```typescript
+import sqlite from '@gjsify/sqlite';
+```
+
+## License
+
+MIT

--- a/packages/node/sqlite/package.json
+++ b/packages/node/sqlite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/sqlite",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js sqlite module for Gjs using libgda",
     "type": "module",
     "module": "lib/esm/index.js",
@@ -38,8 +38,7 @@
     },
     "dependencies": {
         "@girs/gda-6.0": "^6.0.0-4.0.0-beta.42",
-        "@girs/gio-2.0": "^2.88.0-4.0.0-beta.42",
         "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42",
-        "@gjsify/utils": "workspace:^"
+        "@girs/gobject-2.0": "^2.88.0-4.0.0-beta.42"
     }
 }

--- a/packages/node/stream/README.md
+++ b/packages/node/stream/README.md
@@ -1,10 +1,34 @@
 # @gjsify/stream
 
-Node.js stream module for Gjs
+GJS implementation of the Node.js `stream` module. Provides Readable, Writable, Duplex, Transform, and PassThrough streams.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/stream
+# or
+yarn add @gjsify/stream
+```
+
+## Usage
+
+```typescript
+import { Readable, Writable, Transform } from '@gjsify/stream';
+
+const readable = Readable.from(['hello', 'world']);
+readable.on('data', (chunk) => console.log(chunk));
+```
 
 ## Inspirations and credits
+
 - https://github.com/browserify/stream-browserify
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/stream.js
 - https://github.com/exogee-technology/readable-stream
 - https://github.com/nodejs/readable-stream
 - https://github.com/denoland/deno_std/blob/main/node/stream.ts
+
+## License
+
+MIT

--- a/packages/node/stream/package.json
+++ b/packages/node/stream/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/stream",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js stream module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/string_decoder/README.md
+++ b/packages/node/string_decoder/README.md
@@ -1,0 +1,27 @@
+# @gjsify/string_decoder
+
+GJS implementation of the Node.js `string_decoder` module. Supports UTF-8, Base64, hex, and streaming decoding.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/string_decoder
+# or
+yarn add @gjsify/string_decoder
+```
+
+## Usage
+
+```typescript
+import { StringDecoder } from '@gjsify/string_decoder';
+
+const decoder = new StringDecoder('utf-8');
+console.log(decoder.write(Buffer.from([0xe2, 0x82])));
+console.log(decoder.end(Buffer.from([0xac])));
+```
+
+## License
+
+MIT

--- a/packages/node/string_decoder/package.json
+++ b/packages/node/string_decoder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/string_decoder",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js string_decoder module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/sys/README.md
+++ b/packages/node/sys/README.md
@@ -1,0 +1,26 @@
+# @gjsify/sys
+
+GJS implementation of the Node.js `sys` module (alias for util).
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/sys
+# or
+yarn add @gjsify/sys
+```
+
+## Usage
+
+```typescript
+import sys from '@gjsify/sys';
+
+// sys is an alias for util
+console.log(sys.inspect({ key: 'value' }));
+```
+
+## License
+
+MIT

--- a/packages/node/sys/package.json
+++ b/packages/node/sys/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/sys",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js sys module for Gjs (alias for util)",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/timers/README.md
+++ b/packages/node/timers/README.md
@@ -1,0 +1,29 @@
+# @gjsify/timers
+
+GJS implementation of the Node.js `timers` module. Provides setTimeout, setInterval, setImmediate, and their promises API.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/timers
+# or
+yarn add @gjsify/timers
+```
+
+## Usage
+
+```typescript
+import { setTimeout, setInterval, setImmediate } from '@gjsify/timers';
+import { setTimeout as delay } from '@gjsify/timers/promises';
+
+setTimeout(() => console.log('hello'), 1000);
+
+await delay(1000);
+console.log('1 second later');
+```
+
+## License
+
+MIT

--- a/packages/node/timers/package.json
+++ b/packages/node/timers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/timers",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js timers module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/tls/README.md
+++ b/packages/node/tls/README.md
@@ -1,0 +1,27 @@
+# @gjsify/tls
+
+GJS partial implementation of the Node.js `tls` module using Gio.TlsClientConnection.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/tls
+# or
+yarn add @gjsify/tls
+```
+
+## Usage
+
+```typescript
+import { TLSSocket, connect } from '@gjsify/tls';
+
+const socket = connect({ host: 'example.com', port: 443 }, () => {
+  console.log('Connected');
+});
+```
+
+## License
+
+MIT

--- a/packages/node/tls/package.json
+++ b/packages/node/tls/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/tls",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js tls module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/tty/README.md
+++ b/packages/node/tty/README.md
@@ -1,8 +1,33 @@
 # @gjsify/tty
 
-## Inspirations
+GJS implementation of the Node.js `tty` module. Provides ReadStream, WriteStream, and ANSI escape support.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/tty
+# or
+yarn add @gjsify/tty
+```
+
+## Usage
+
+```typescript
+import { isatty, ReadStream, WriteStream } from '@gjsify/tty';
+
+console.log(isatty(0)); // true if stdin is a TTY
+```
+
+## Inspirations and credits
+
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/tty.js
 - https://github.com/browserify/tty-browserify
 - https://github.com/denoland/deno_std/blob/main/node/tty.ts
 - https://github.com/jvilk/bfs-process/blob/master/ts/tty.ts
 - https://nodejs.org/api/tty.html
+
+## License
+
+MIT

--- a/packages/node/tty/package.json
+++ b/packages/node/tty/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/tty",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js tty module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
@@ -31,6 +31,7 @@
     ],
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/node": "^25.5.0",
         "typescript": "^6.0.2"
     },

--- a/packages/node/url/README.md
+++ b/packages/node/url/README.md
@@ -1,6 +1,32 @@
 # @gjsify/url
 
-Node.js url module for Gjs
-## Inspirations
+GJS implementation of the Node.js `url` module using GLib.Uri. Provides URL and URLSearchParams.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/url
+# or
+yarn add @gjsify/url
+```
+
+## Usage
+
+```typescript
+import { URL, URLSearchParams } from '@gjsify/url';
+
+const url = new URL('https://example.com/path?foo=bar');
+console.log(url.hostname); // 'example.com'
+console.log(url.searchParams.get('foo')); // 'bar'
+```
+
+## Inspirations and credits
+
 - https://github.com/defunctzombie/node-url
 - https://github.com/denoland/deno_std/blob/main/node/url.ts
+
+## License
+
+MIT

--- a/packages/node/url/package.json
+++ b/packages/node/url/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/url",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js url module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",
@@ -29,6 +29,9 @@
         "node",
         "fs"
     ],
+    "dependencies": {
+        "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42"
+    },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
         "@gjsify/unit": "workspace:^",

--- a/packages/node/util/README.md
+++ b/packages/node/util/README.md
@@ -1,6 +1,32 @@
 # @gjsify/util
 
-Node.js util module for Gjs
+GJS implementation of the Node.js `util` module. Provides inspect, format, promisify, types, and more.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/util
+# or
+yarn add @gjsify/util
+```
+
+## Usage
+
+```typescript
+import { inspect, format, promisify, types } from '@gjsify/util';
+
+console.log(inspect({ key: 'value' }));
+console.log(format('Hello %s', 'world'));
+console.log(types.isPromise(Promise.resolve()));
+```
+
 ## Inspirations and credits
- * https://github.com/browserify/node-util
- * https://github.com/denoland/deno_std/blob/main/node/util.ts
+
+- https://github.com/browserify/node-util
+- https://github.com/denoland/deno_std/blob/main/node/util.ts
+
+## License
+
+MIT

--- a/packages/node/util/package.json
+++ b/packages/node/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/util",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js util module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/v8/README.md
+++ b/packages/node/v8/README.md
@@ -1,0 +1,28 @@
+# @gjsify/v8
+
+GJS stub implementation of the Node.js `v8` module. Provides getHeapStatistics and JSON-based serialize/deserialize.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/v8
+# or
+yarn add @gjsify/v8
+```
+
+## Usage
+
+```typescript
+import { getHeapStatistics, serialize, deserialize } from '@gjsify/v8';
+
+console.log(getHeapStatistics());
+
+const buf = serialize({ hello: 'world' });
+const obj = deserialize(buf);
+```
+
+## License
+
+MIT

--- a/packages/node/v8/package.json
+++ b/packages/node/v8/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/v8",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js v8 module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/vm/README.md
+++ b/packages/node/vm/README.md
@@ -1,0 +1,26 @@
+# @gjsify/vm
+
+GJS stub implementation of the Node.js `vm` module. Provides runInThisContext via eval and Script.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/vm
+# or
+yarn add @gjsify/vm
+```
+
+## Usage
+
+```typescript
+import { runInThisContext, Script } from '@gjsify/vm';
+
+const result = runInThisContext('1 + 2');
+console.log(result); // 3
+```
+
+## License
+
+MIT

--- a/packages/node/vm/package.json
+++ b/packages/node/vm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/vm",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js vm module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/worker_threads/README.md
+++ b/packages/node/worker_threads/README.md
@@ -1,0 +1,27 @@
+# @gjsify/worker_threads
+
+GJS stub implementation of the Node.js `worker_threads` module. Currently provides isMainThread only.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/worker_threads
+# or
+yarn add @gjsify/worker_threads
+```
+
+## Usage
+
+```typescript
+import { isMainThread } from '@gjsify/worker_threads';
+
+if (isMainThread) {
+  console.log('Running in the main thread');
+}
+```
+
+## License
+
+MIT

--- a/packages/node/worker_threads/package.json
+++ b/packages/node/worker_threads/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/worker_threads",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js worker_threads module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/node/zlib/README.md
+++ b/packages/node/zlib/README.md
@@ -1,8 +1,34 @@
 # @gjsify/zlib
 
-Node.js zlib module for Gjs
+GJS implementation of the Node.js `zlib` module. Provides gzip/deflate via Web Compression API with Gio.ZlibCompressor fallback.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/zlib
+# or
+yarn add @gjsify/zlib
+```
+
+## Usage
+
+```typescript
+import { gzipSync, gunzipSync, deflateSync, inflateSync } from '@gjsify/zlib';
+
+const compressed = gzipSync(Buffer.from('hello world'));
+const decompressed = gunzipSync(compressed);
+console.log(decompressed.toString()); // 'hello world'
+```
+
 ## Inspirations and credits
+
 - https://nodejs.org/api/zlib.html
 - https://github.com/geut/brode/blob/main/packages/browser-node-core/src/zlib.js
 - https://github.com/browserify/browserify-zlib
 - https://github.com/denoland/deno_std/blob/main/node/zlib.ts
+
+## License
+
+MIT

--- a/packages/node/zlib/package.json
+++ b/packages/node/zlib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/zlib",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Node.js zlib module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/web/abort-controller/README.md
+++ b/packages/web/abort-controller/README.md
@@ -1,4 +1,32 @@
 # @gjsify/abort-controller
 
-Web abort-controller module for Gjs
+GJS implementation of the AbortController and AbortSignal Web APIs.
 
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/abort-controller
+# or
+yarn add @gjsify/abort-controller
+```
+
+## Usage
+
+```typescript
+import { AbortController, AbortSignal } from '@gjsify/abort-controller';
+
+const controller = new AbortController();
+const signal = controller.signal;
+
+signal.addEventListener('abort', () => {
+  console.log('Aborted!');
+});
+
+controller.abort();
+```
+
+## License
+
+MIT

--- a/packages/web/abort-controller/package.json
+++ b/packages/web/abort-controller/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/abort-controller",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Web AbortController module for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/compression-streams/README.md
+++ b/packages/web/compression-streams/README.md
@@ -1,0 +1,26 @@
+# @gjsify/compression-streams
+
+GJS implementation of the Web Compression Streams API using Gio.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/compression-streams
+# or
+yarn add @gjsify/compression-streams
+```
+
+## Usage
+
+```typescript
+import { CompressionStream, DecompressionStream } from '@gjsify/compression-streams';
+
+const compressionStream = new CompressionStream('gzip');
+const decompressionStream = new DecompressionStream('gzip');
+```
+
+## License
+
+MIT

--- a/packages/web/compression-streams/package.json
+++ b/packages/web/compression-streams/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/compression-streams",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "W3C Compression Streams API for GJS",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/dom-events/README.md
+++ b/packages/web/dom-events/README.md
@@ -1,6 +1,35 @@
 # @gjsify/dom-events
 
+GJS implementation of Web DOM Events including Event, CustomEvent, EventTarget, UIEvent, MouseEvent, PointerEvent, KeyboardEvent, WheelEvent, FocusEvent, and DOMException.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/dom-events
+# or
+yarn add @gjsify/dom-events
+```
+
+## Usage
+
+```typescript
+import { Event, CustomEvent, EventTarget } from '@gjsify/dom-events';
+
+const target = new EventTarget();
+target.addEventListener('custom', (e) => {
+  console.log(e.detail);
+});
+target.dispatchEvent(new CustomEvent('custom', { detail: 'hello' }));
+```
+
 ## Inspirations and credits
+
 - https://deno.land/manual@v1.29.2/runtime/web_platform_apis#customevent-eventtarget-and-eventlistener
 - https://github.com/jsdom/jsdom/tree/master/lib/jsdom/living/events
 - https://github.com/capricorn86/happy-dom/tree/master/packages/happy-dom/src/event
+
+## License
+
+MIT

--- a/packages/web/dom-events/package.json
+++ b/packages/web/dom-events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/dom-events",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Web events module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/web/dom-exception/README.md
+++ b/packages/web/dom-exception/README.md
@@ -1,0 +1,25 @@
+# @gjsify/dom-exception
+
+GJS implementation of the Web DOMException API.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/dom-exception
+# or
+yarn add @gjsify/dom-exception
+```
+
+## Usage
+
+```typescript
+import { DOMException } from '@gjsify/dom-exception';
+
+throw new DOMException('Operation not supported', 'NotSupportedError');
+```
+
+## License
+
+MIT

--- a/packages/web/dom-exception/package.json
+++ b/packages/web/dom-exception/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/dom-exception",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "DOMException polyfill for GJS (WebIDL standard)",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/web/eventsource/README.md
+++ b/packages/web/eventsource/README.md
@@ -1,0 +1,28 @@
+# @gjsify/eventsource
+
+GJS implementation of the Web EventSource (Server-Sent Events) API using Soup 3.0.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/eventsource
+# or
+yarn add @gjsify/eventsource
+```
+
+## Usage
+
+```typescript
+import { EventSource } from '@gjsify/eventsource';
+
+const source = new EventSource('https://example.com/events');
+source.onmessage = (event) => {
+  console.log(event.data);
+};
+```
+
+## License
+
+MIT

--- a/packages/web/eventsource/package.json
+++ b/packages/web/eventsource/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/eventsource",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "W3C EventSource (Server-Sent Events) for GJS",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/fetch/README.md
+++ b/packages/web/fetch/README.md
@@ -1,9 +1,34 @@
 # @gjsify/fetch
 
-Web and Node.js >= 18 fetch module for Gjs
+GJS implementation of the Web Fetch API using Soup 3.0 and Gio. Provides fetch(), Request, Response, and Headers.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/fetch
+# or
+yarn add @gjsify/fetch
+```
+
+## Usage
+
+```typescript
+import { fetch, Request, Response, Headers } from '@gjsify/fetch';
+
+const response = await fetch('https://example.com');
+const text = await response.text();
+console.log(text);
+```
 
 ## Inspirations and credits
+
 - https://github.com/sonnyp/troll/blob/main/src/std/fetch.js
 - https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node-fetch
 - https://github.com/node-fetch/node-fetch
 - https://github.com/denoland/deno/tree/main/ext/fetch
+
+## License
+
+MIT

--- a/packages/web/fetch/package.json
+++ b/packages/web/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/fetch",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Web and Node.js fetch module for Gjs",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
@@ -32,7 +32,6 @@
     ],
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
-        "@gjsify/http": "workspace:^",
         "@gjsify/unit": "workspace:^",
         "@types/node": "^25.5.0",
         "typescript": "^6.0.2"
@@ -42,7 +41,6 @@
         "@girs/gjs": "^4.0.0-beta.42",
         "@girs/glib-2.0": "^2.88.0-4.0.0-beta.42",
         "@girs/soup-3.0": "^3.6.6-4.0.0-beta.42",
-        "@gjsify/dom-events": "workspace:^",
         "@gjsify/formdata": "workspace:^",
         "@gjsify/http": "workspace:^",
         "@gjsify/url": "workspace:^",

--- a/packages/web/formdata/README.md
+++ b/packages/web/formdata/README.md
@@ -1,0 +1,27 @@
+# @gjsify/formdata
+
+GJS implementation of the Web FormData and File APIs.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/formdata
+# or
+yarn add @gjsify/formdata
+```
+
+## Usage
+
+```typescript
+import { FormData, File } from '@gjsify/formdata';
+
+const form = new FormData();
+form.append('name', 'value');
+form.append('file', new File(['content'], 'file.txt', { type: 'text/plain' }));
+```
+
+## License
+
+MIT

--- a/packages/web/formdata/package.json
+++ b/packages/web/formdata/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/formdata",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Web FormData implementation for Gjs",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/streams/README.md
+++ b/packages/web/streams/README.md
@@ -1,0 +1,30 @@
+# @gjsify/web-streams
+
+GJS implementation of the Web Streams API (ReadableStream, WritableStream, TransformStream).
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/web-streams
+# or
+yarn add @gjsify/web-streams
+```
+
+## Usage
+
+```typescript
+import { ReadableStream, WritableStream, TransformStream } from '@gjsify/web-streams';
+
+const readable = new ReadableStream({
+  start(controller) {
+    controller.enqueue('hello');
+    controller.close();
+  }
+});
+```
+
+## License
+
+MIT

--- a/packages/web/streams/package.json
+++ b/packages/web/streams/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/web-streams",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "WHATWG Streams API (ReadableStream, WritableStream, TransformStream) for GJS",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/web-globals/README.md
+++ b/packages/web/web-globals/README.md
@@ -1,6 +1,26 @@
-# @gjsify/web-events
+# @gjsify/web-globals
 
-## Inspirations and credits
-- https://deno.land/manual@v1.25.0/runtime/program_lifecycle
-- https://github.com/jsdom/jsdom/tree/master/lib/jsdom/living/events
-- https://github.com/capricorn86/happy-dom/tree/master/packages/happy-dom/src/event
+Re-exports Web API globals from dom-events and abort-controller for GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/web-globals
+# or
+yarn add @gjsify/web-globals
+```
+
+## Usage
+
+```typescript
+import '@gjsify/web-globals';
+
+// Web API globals like Event, CustomEvent, EventTarget,
+// AbortController, and AbortSignal are now available.
+```
+
+## License
+
+MIT

--- a/packages/web/web-globals/package.json
+++ b/packages/web/web-globals/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/web-globals",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "Unified Web API globals for GJS — single import for all Web standard polyfills",
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",

--- a/packages/web/webcrypto/README.md
+++ b/packages/web/webcrypto/README.md
@@ -1,0 +1,28 @@
+# @gjsify/webcrypto
+
+GJS implementation of the Web Crypto API using GLib.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/webcrypto
+# or
+yarn add @gjsify/webcrypto
+```
+
+## Usage
+
+```typescript
+import { crypto } from '@gjsify/webcrypto';
+
+const array = new Uint8Array(16);
+crypto.getRandomValues(array);
+
+const uuid = crypto.randomUUID();
+```
+
+## License
+
+MIT

--- a/packages/web/webcrypto/package.json
+++ b/packages/web/webcrypto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/webcrypto",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "W3C WebCrypto API (SubtleCrypto) for GJS using @gjsify/crypto primitives",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/websocket/README.md
+++ b/packages/web/websocket/README.md
@@ -1,0 +1,31 @@
+# @gjsify/websocket
+
+GJS implementation of the Web WebSocket API using Soup 3.0. Provides WebSocket, MessageEvent, and CloseEvent.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/websocket
+# or
+yarn add @gjsify/websocket
+```
+
+## Usage
+
+```typescript
+import { WebSocket } from '@gjsify/websocket';
+
+const ws = new WebSocket('wss://example.com/socket');
+ws.onopen = () => {
+  ws.send('hello');
+};
+ws.onmessage = (event) => {
+  console.log(event.data);
+};
+```
+
+## License
+
+MIT

--- a/packages/web/websocket/package.json
+++ b/packages/web/websocket/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/websocket",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "W3C WebSocket API for GJS using Soup 3.0",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/packages/web/webstorage/README.md
+++ b/packages/web/webstorage/README.md
@@ -1,0 +1,26 @@
+# @gjsify/webstorage
+
+GJS implementation of the Web Storage API (localStorage, sessionStorage) using Gio.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+npm install @gjsify/webstorage
+# or
+yarn add @gjsify/webstorage
+```
+
+## Usage
+
+```typescript
+import { localStorage, sessionStorage } from '@gjsify/webstorage';
+
+localStorage.setItem('key', 'value');
+console.log(localStorage.getItem('key'));
+```
+
+## License
+
+MIT

--- a/packages/web/webstorage/package.json
+++ b/packages/web/webstorage/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/webstorage",
-    "version": "0.0.4",
+    "version": "0.1.0",
     "description": "W3C Web Storage API (localStorage, sessionStorage) for GJS",
     "type": "module",
     "module": "lib/esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -723,7 +723,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/cli@workspace:packages/infra/cli"
   dependencies:
-    "@gjsify/esbuild-plugin-deepkit": "workspace:^"
     "@gjsify/esbuild-plugin-gjsify": "workspace:^"
     "@types/yargs": "npm:^17.0.35"
     cosmiconfig: "npm:^9.0.1"
@@ -927,6 +926,7 @@ __metadata:
     "@gjsify/esbuild-plugin-alias": "workspace:^"
     "@gjsify/esbuild-plugin-deepkit": "workspace:^"
     "@gjsify/esbuild-plugin-transform-ext": "workspace:^"
+    "@gjsify/resolve-npm": "workspace:^"
     esbuild: "npm:^0.27.4"
     fast-glob: "npm:^3.3.3"
     typescript: "npm:^6.0.2"
@@ -1575,7 +1575,6 @@ __metadata:
     "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@girs/soup-3.0": "npm:^3.6.6-4.0.0-beta.42"
     "@gjsify/cli": "workspace:^"
-    "@gjsify/dom-events": "workspace:^"
     "@gjsify/formdata": "workspace:^"
     "@gjsify/http": "workspace:^"
     "@gjsify/unit": "workspace:^"
@@ -1601,6 +1600,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/fs@workspace:packages/node/fs"
   dependencies:
+    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@gjsify/buffer": "workspace:^"
     "@gjsify/cli": "workspace:^"
@@ -1723,11 +1723,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/node-globals@workspace:packages/node/globals"
   dependencies:
+    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
+    "@gjsify/abort-controller": "workspace:^"
     "@gjsify/buffer": "workspace:^"
     "@gjsify/cli": "workspace:^"
     "@gjsify/fetch": "workspace:^"
     "@gjsify/process": "workspace:^"
     "@gjsify/unit": "workspace:^"
+    "@gjsify/url": "workspace:^"
     "@gjsify/utils": "workspace:^"
     "@types/node": "npm:^25.5.0"
     typescript: "npm:^6.0.2"
@@ -1738,7 +1741,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/os@workspace:packages/node/os"
   dependencies:
-    "@girs/gjs": "npm:^4.0.0-beta.42"
+    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-beta.42"
+    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@gjsify/cli": "workspace:^"
     "@gjsify/unit": "workspace:^"
     "@gjsify/utils": "workspace:^"
@@ -1786,9 +1790,7 @@ __metadata:
   resolution: "@gjsify/querystring@workspace:packages/node/querystring"
   dependencies:
     "@gjsify/cli": "workspace:^"
-    "@gjsify/esbuild-plugin-gjsify": "workspace:^"
     "@gjsify/unit": "workspace:^"
-    "@types/inherits": "npm:^2.0.0"
     "@types/node": "npm:^25.5.0"
     typescript: "npm:^6.0.2"
   languageName: unknown
@@ -1806,7 +1808,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/resolve-npm@workspace:packages/infra/resolve-npm":
+"@gjsify/resolve-npm@workspace:^, @gjsify/resolve-npm@workspace:packages/infra/resolve-npm":
   version: 0.0.0-use.local
   resolution: "@gjsify/resolve-npm@workspace:packages/infra/resolve-npm"
   languageName: unknown
@@ -1827,11 +1829,10 @@ __metadata:
   resolution: "@gjsify/sqlite@workspace:packages/node/sqlite"
   dependencies:
     "@girs/gda-6.0": "npm:^6.0.0-4.0.0-beta.42"
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
+    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@gjsify/cli": "workspace:^"
     "@gjsify/unit": "workspace:^"
-    "@gjsify/utils": "workspace:^"
     "@types/node": "npm:^25.5.0"
     typescript: "npm:^6.0.2"
   languageName: unknown
@@ -1908,6 +1909,7 @@ __metadata:
     "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@gjsify/cli": "workspace:^"
     "@gjsify/stream": "workspace:^"
+    "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.5.0"
     typescript: "npm:^6.0.2"
   languageName: unknown
@@ -1940,6 +1942,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/url@workspace:packages/node/url"
   dependencies:
+    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@gjsify/cli": "workspace:^"
     "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.5.0"
@@ -2044,9 +2047,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/webgl@workspace:packages/dom/webgl"
   dependencies:
-    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-beta.42"
     "@girs/gjs": "npm:^4.0.0-beta.42"
-    "@girs/gtk-4.0": "npm:4.22.1-4.0.0-beta.42"
+    "@girs/gtk-4.0": "npm:^4.22.1-4.0.0-beta.42"
     "@girs/gwebgl-0.1": "workspace:^"
     "@gjsify/cli": "workspace:^"
     "@gjsify/dom-elements": "workspace:^"
@@ -3257,6 +3259,19 @@ __metadata:
   checksum: 10/89fcac84d062f0710091bb2d6a6175bcde22f5448877db9c43429694408191d3d4e215193b3ac4d54f7f89ef188d55cd481c7a2295b0dc572e65b528bf6fec01
   languageName: node
   linkType: hard
+
+"create-gjsify@workspace:packages/infra/create-gjsify":
+  version: 0.0.0-use.local
+  resolution: "create-gjsify@workspace:packages/infra/create-gjsify"
+  dependencies:
+    "@types/node": "npm:^25.5.0"
+    "@types/yargs": "npm:^17.0.35"
+    typescript: "npm:^6.0.2"
+    yargs: "npm:^18.0.0"
+  bin:
+    create-gjsify: ./lib/index.js
+  languageName: unknown
+  linkType: soft
 
 "debug@npm:^3.2.7":
   version: 3.2.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -785,6 +785,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/create-app@workspace:packages/infra/create-gjsify":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/create-app@workspace:packages/infra/create-gjsify"
+  dependencies:
+    "@types/node": "npm:^25.5.0"
+    "@types/yargs": "npm:^17.0.35"
+    typescript: "npm:^6.0.2"
+    yargs: "npm:^18.0.0"
+  bin:
+    create-app: ./lib/index.js
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/crypto@workspace:^, @gjsify/crypto@workspace:packages/node/crypto":
   version: 0.0.0-use.local
   resolution: "@gjsify/crypto@workspace:packages/node/crypto"
@@ -3259,19 +3272,6 @@ __metadata:
   checksum: 10/89fcac84d062f0710091bb2d6a6175bcde22f5448877db9c43429694408191d3d4e215193b3ac4d54f7f89ef188d55cd481c7a2295b0dc572e65b528bf6fec01
   languageName: node
   linkType: hard
-
-"create-gjsify@workspace:packages/infra/create-gjsify":
-  version: 0.0.0-use.local
-  resolution: "create-gjsify@workspace:packages/infra/create-gjsify"
-  dependencies:
-    "@types/node": "npm:^25.5.0"
-    "@types/yargs": "npm:^17.0.35"
-    typescript: "npm:^6.0.2"
-    yargs: "npm:^18.0.0"
-  bin:
-    create-gjsify: ./lib/index.js
-  languageName: unknown
-  linkType: soft
 
 "debug@npm:^3.2.7":
   version: 3.2.7


### PR DESCRIPTION
First release since the major restructuring of the gjsify monorepo. This PR prepares all packages for a clean v0.1.0 publish to npm.

### Version Bumps
- All 67 `@gjsify/*` packages bumped from `0.0.4` → `0.1.0`
- Root package bumped to `0.1.0`
- Version field removed from all 41 example packages (private, not published)
- `@girs/*` type packages remain on their own versioning scheme

### Dependency Audit
- **Added missing deps:** `@girs/gio-2.0` (fs), `@girs/glib-2.0` (globals, os, url), `@girs/gobject-2.0` (sqlite), `@gjsify/abort-controller` + `@gjsify/url` (globals), `@gjsify/unit` (tty), `@gjsify/resolve-npm` (esbuild-plugin-gjsify)
- **Removed unused deps:** `@gjsify/dom-events` (fetch), `@gjsify/esbuild-plugin-deepkit` (cli), `@girs/gio-2.0` (sqlite, webgl), `@gjsify/esbuild-plugin-gjsify` + `@types/inherits` (querystring)
- **Moved to devDeps:** `@types/bit-twiddle` (webgl)
- Publish script now excludes `@girs/*` packages

### New: Release Workflow
- `.github/workflows/release.yml` — triggers on GitHub release publication
- Builds in Fedora 43 container (native prebuilds support)
- Publishes all non-private `@gjsify/*` packages to npm

### New: `create-gjsify` Scaffolding Package
- `npm create gjsify my-app` scaffolds a new GJS project
- Generates GTK4 Hello World app with TypeScript, `@gjsify/cli` and `@gjsify/node-globals`

### README.md for All Packages
- Created 42 new README files, updated 27 existing ones
- Consistent English format: description, installation, usage example, license

## Test Plan
- [x] `yarn install` — lockfile updated successfully
- [x] `yarn build` — all packages build without errors
- [x] `yarn check` — TypeScript type check passes
- [x] `yarn test` — all tests pass
- [ ] Verify `NPM_TOKEN` secret is configured in GitHub repo settings
- [ ] After merge: create GitHub release `v0.1.0` to trigger publish workflow
