### PR TITLE
refactor(globals)!: stage 1 — drop fetch/abort-controller from node-globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 ## Unreleased
 
+### ⚠ BREAKING CHANGES
+
+* **node-globals:** `@gjsify/node-globals` no longer auto-registers `fetch`, `Headers`, `Request`, `Response`, `AbortController` or `AbortSignal`. These are Web APIs, not Node.js globals — importing them automatically pulled the full WHATWG Streams implementation into every bundle even when unused (~80 KB dead weight on a minimal Express app). Projects that need these APIs on GJS should now either:
+  - Import `@gjsify/web-globals` to get the full Web API set, or
+  - Import the specific package side-effect bundle, e.g. `import 'fetch'` or `import 'abort-controller'` (the aliases resolve to the correct GJS/Node package automatically).
+* **node-globals:** The empty `ReadableStream`/`Blob` placeholder stubs in `@gjsify/node-globals` are removed. `Blob`/`File` remain available because `@gjsify/buffer` (still imported by node-globals) registers them. `ReadableStream` is only registered when something actually imports `@gjsify/streams` or a package that depends on it.
+
 ### Features
 
 * **cli:** add `gjsify create <name>` subcommand that delegates to `@gjsify/create-app`, so users only need to remember a single npm scope (`@gjsify/cli`) to scaffold, build and run GJSify projects
 * **create-app:** expose `createProject()` as a programmatic export (`import { createProject } from '@gjsify/create-app'`) in addition to the existing CLI entry
+
+### Refactor
+
+* **globals:** drop `fetch` and `abort-controller` side-effect imports from `@gjsify/node-globals` and `@gjsify/dom-elements`. Stage 1 of the globals tree-shaking refactor. Express showcase bundle shrinks from 1.83 MB → 1.68 MB (-157 KB, -8.5 %), WHATWG Streams references drop from 186 to 9.
+* **fs:** make `FileHandle.readableWebStream()` resolve the `ReadableStream` constructor lazily from `globalThis` instead of importing `node:stream/web` at module load time. Apps that never call `readableWebStream()` no longer ship the full WHATWG Streams polyfill. Stage 1 of the globals tree-shaking refactor.
 
 ### Bug Fixes
 

--- a/packages/dom/dom-elements/src/index.ts
+++ b/packages/dom/dom-elements/src/index.ts
@@ -26,8 +26,10 @@ export * as PropertySymbol from './property-symbol.js';
 // Side-effect: register DOM globals on import.
 // Same pattern as @gjsify/node-globals (packages/node/globals/src/index.ts)
 // and @gjsify/web-globals (packages/web/web-globals/src/index.ts).
-import '@gjsify/abort-controller'; // registers globalThis.AbortController + AbortSignal
-import '@gjsify/fetch'; // registers globalThis.fetch, Request, Response, Headers
+//
+// Note: dom-elements itself does not depend on fetch or AbortController.
+// If your app needs those Web APIs, import `@gjsify/web-globals` (or the
+// specific package like `@gjsify/fetch`) separately.
 import { Text } from './text.js';
 import { Comment } from './comment.js';
 import { DocumentFragment } from './document-fragment.js';

--- a/packages/node/fs/src/file-handle.ts
+++ b/packages/node/fs/src/file-handle.ts
@@ -8,7 +8,10 @@ import { Stats } from "./stats.js";
 import { getEncodingFromOptions, encodeUint8Array } from './encoding.js';
 import GLib from '@girs/glib-2.0';
 import Gio from '@girs/gio-2.0';
-import { ReadableStream } from "node:stream/web";
+// Type-only import for ReadableStream — the runtime constructor is resolved
+// via globalThis inside readableWebStream() to avoid bundling the entire
+// WHATWG streams implementation for apps that never call this method.
+import type { ReadableStream } from "node:stream/web";
 import { Buffer } from "node:buffer";
 
 import type { Abortable } from 'node:events';
@@ -334,7 +337,16 @@ export class FileHandle implements IFileHandle {
      * @experimental
      */
     readableWebStream(): ReadableStream {
-        return new ReadableStream();
+        // Resolve ReadableStream lazily from globalThis to keep the
+        // WHATWG streams implementation out of the bundle when this method
+        // is not actually used.
+        const Ctor = (globalThis as { ReadableStream?: typeof globalThis.ReadableStream }).ReadableStream;
+        if (typeof Ctor !== 'function') {
+            throw new Error(
+                'readableWebStream() requires a global ReadableStream. Import "node:stream/web" or "@gjsify/streams" before calling this method.',
+            );
+        }
+        return new Ctor() as unknown as ReadableStream;
     }
     /**
      * Asynchronously reads the entire contents of a file.

--- a/packages/node/globals/src/index.ts
+++ b/packages/node/globals/src/index.ts
@@ -1,12 +1,16 @@
 // Node.js globals for GJS — original implementation using GLib
+//
+// This module only registers true Node.js globals: process, Buffer, URL,
+// URLSearchParams, setImmediate/clearImmediate, btoa/atob, structuredClone,
+// queueMicrotask, global. Web APIs like fetch, AbortController, Headers,
+// Request, Response are NOT registered here — import `@gjsify/web-globals`
+// (or the specific package, e.g. `@gjsify/fetch`) if you need them.
 
 import { initErrorV8Methods, structuredClone as structuredClonePolyfill } from "@gjsify/utils";
 
 import process from '@gjsify/process';
 import { Buffer } from '@gjsify/buffer';
 import { URL, URLSearchParams } from '@gjsify/url';
-import '@gjsify/abort-controller'; // triggers global registration of AbortController/AbortSignal
-import '@gjsify/fetch';             // triggers global registration of fetch/Request/Response/Headers
 import GLib from '@girs/glib-2.0';
 
 // Promise.withResolvers polyfill for SpiderMonkey < 121 (ES2024, not in GJS < 1.81.2)
@@ -154,20 +158,6 @@ if (typeof globalThis.URLSearchParams !== 'function') {
     writable: true,
     configurable: true,
   });
-}
-
-// Web API stubs — Node.js 18+ has these as globals; GJS does not.
-// Request/Response/Headers/fetch are now registered by @gjsify/fetch (imported above).
-// ReadableStream and Blob still need stubs to prevent ReferenceErrors in frameworks.
-for (const name of ['ReadableStream', 'Blob'] as const) {
-  if (typeof (globalThis as any)[name] === 'undefined') {
-    Object.defineProperty(globalThis, name, {
-      value: class {},
-      enumerable: false,
-      writable: true,
-      configurable: true,
-    });
-  }
 }
 
 export { ensureMainLoop } from '@gjsify/utils';

--- a/packages/node/http/src/test.mts
+++ b/packages/node/http/src/test.mts
@@ -1,4 +1,5 @@
 
+import 'abort-controller'; // register AbortController/AbortSignal globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';

--- a/packages/node/stream/src/test.mts
+++ b/packages/node/stream/src/test.mts
@@ -1,4 +1,5 @@
 import '@gjsify/node-globals';
+import 'abort-controller'; // register AbortController/AbortSignal globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';

--- a/packages/node/timers/src/test.mts
+++ b/packages/node/timers/src/test.mts
@@ -1,4 +1,5 @@
 import '@gjsify/node-globals';
+import 'abort-controller'; // register AbortController/AbortSignal globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 
 import testSuiteTimers from './index.spec.js';

--- a/packages/web/fetch/src/test.mts
+++ b/packages/web/fetch/src/test.mts
@@ -1,4 +1,5 @@
 import '@gjsify/node-globals';
+import 'fetch'; // register fetch/Headers/Request/Response globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';


### PR DESCRIPTION
## Summary

**Stage 1 of the 4-stage globals tree-shaking refactor.** See the planning document at `.claude/plans/indexed-popping-sloth.md` in this branch for the full context and upcoming stages.

The current architecture forces every GJS bundle that imports `@gjsify/node-globals` to ship the full `@gjsify/fetch` stack, which transitively loads the entire WHATWG Streams implementation via `@gjsify/streams`. For apps that never touch `fetch` (for example a plain Express HTTP server), that's ~80 KB of dead code plus indirect pulls from `@gjsify/fs` that add up to ~157 KB of pure overhead.

## Changes

- `@gjsify/node-globals` no longer imports `@gjsify/fetch` or `@gjsify/abort-controller`. Those are **Web APIs**, not Node globals, and belong in `@gjsify/web-globals`.
- The empty `ReadableStream`/`Blob` placeholder stubs in `@gjsify/node-globals` are removed. `Blob`/`File` remain registered via `@gjsify/buffer`; `ReadableStream` is only registered when something actually imports `@gjsify/streams`.
- `@gjsify/dom-elements` no longer pulls in `@gjsify/fetch` or `@gjsify/abort-controller` — neither is used inside the package.
- `FileHandle.readableWebStream()` in `@gjsify/fs` resolves the `ReadableStream` constructor **lazily from globalThis** instead of importing `node:stream/web` at module load time. This breaks the largest single transitive dependency on the WHATWG Streams bundle.
- Test entry files for `@gjsify/fetch`, `@gjsify/stream`, `@gjsify/timers`, and `@gjsify/http` now explicitly register the globals their specs rely on via the bare-specifier imports `import 'fetch'` / `import 'abort-controller'` (these aliases resolve to the correct platform package on both GJS and Node).

## Bundle impact

showcases/node/express-webserver/dist/index.gjs.js:

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Size | 1,836,689 bytes (1.83 MB) | 1,679,738 bytes (1.68 MB) | **−157,951 bytes (−8.5 %)** |
| WHATWG Streams refs | 186 | 9 | **−177** |

## BREAKING CHANGE

Projects that relied on `@gjsify/node-globals` to implicitly register `fetch`, `Headers`, `Request`, `Response`, `AbortController` or `AbortSignal` must now either:

- Import `@gjsify/web-globals` to get the full Web API set, or
- Import the specific bare-specifier side-effect module, e.g. `import 'fetch'` or `import 'abort-controller'` (the aliases resolve to the correct GJS/Node package automatically).

## Test plan

- [x] All 104 workspace test suites pass (`yarn test`, exit code 0)
- [x] Full monorepo build succeeds (`yarn build`)
- [x] Express webserver showcase still runs on GJS
- [x] Bundle sizes measured and recorded

## Follow-ups

This PR is the first of four stacked PRs implementing the globals tree-shaking refactor:

1. **Stage 1** ← you are here (Quick Wins)
2. **Stage 2** — Introduce `/register` subpath exports on every global-providing package
3. **Stage 3** — Hybrid auto-injection in the esbuild plugin (regex scan + `--globals` CLI flag)
4. **Stage 4** — AST-parser experiment, decide Keep vs Rollback

The next PR will be opened against this branch so review can proceed incrementally.