### PR TITLE
feat(cli): GJS app packaging — --shebang + gresource + gettext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * **event-bridge:** wire keyboard input to window-level listeners
 * **fetch:** support file:// URIs + root-relative URL rewrite for GJS
 * **gamepad:** new `@gjsify/gamepad` package — Gamepad Web API for GJS backed by libmanette 0.2. Implements Gamepad, GamepadButton, GamepadEvent, GamepadHapticActuator (dual-rumble). Bridges libmanette's event-driven signals to W3C polling-based navigator.getGamepads(). Button/axis mapping from Manette enums to W3C standard layout. Lazy Monitor init + graceful degradation. 19 tests. Enables controller support in excalibur-jelly-jumper showcase
+* **cli:** `--shebang` flag on `gjsify build` — after a successful GJS app build, prepends `#!/usr/bin/env -S gjs -m` to the outfile and sets it executable (`chmod 0o755`). Turns the bundle into a standalone, directly-executable GJS binary (e.g. `./org.myapp.Maker`) without a separate launcher script
+* **cli:** new `gjsify gresource <xml>` command — thin wrapper around `glib-compile-resources` with `--sourcedir` and `--target` options. Default target is derived from the XML descriptor filename. Mirrors the meson/autotools step for packaging UI templates and assets into a binary `.gresource` bundle
+* **cli:** new `gjsify gettext <poDir> <outDir>` command — wraps `msgfmt` for translation workflows. Supports `--format mo` (per-language locale tree `<outDir>/<lang>/LC_MESSAGES/<domain>.mo`, default), `xml` (metainfo template substitution via `msgfmt --template`, with optional `--remove-xml-comments`), `desktop`, and `json`. Replaces hand-rolled shell scripts in GNOME app build pipelines
 
 ### Bug Fixes
 

--- a/packages/infra/cli/src/actions/build.ts
+++ b/packages/infra/cli/src/actions/build.ts
@@ -3,7 +3,10 @@ import type { App } from '@gjsify/esbuild-plugin-gjsify';
 import { build, BuildOptions, BuildResult } from 'esbuild';
 import { gjsifyPlugin } from '@gjsify/esbuild-plugin-gjsify';
 import { resolveGlobalsList, writeRegisterInjectFile, detectAutoGlobals } from '@gjsify/esbuild-plugin-gjsify/globals';
-import { dirname, extname } from 'path';
+import { dirname, extname } from 'node:path';
+import { chmod, readFile, writeFile } from 'node:fs/promises';
+
+const GJS_SHEBANG = '#!/usr/bin/env -S gjs -m\n';
 
 export class BuildAction {
     constructor(readonly configData: ConfigData = {}) {
@@ -123,6 +126,26 @@ export class BuildAction {
         return injectPath ?? undefined;
     }
 
+    /**
+     * Post-processing: prepend GJS shebang and mark the output file executable.
+     * Only runs for GJS app builds with a resolvable single outfile.
+     */
+    private async applyShebang(outfile: string | undefined, verbose: boolean | undefined): Promise<void> {
+        if (!outfile) {
+            if (verbose) console.warn('[gjsify] --shebang skipped: no single outfile (use --outfile for GJS executables)');
+            return;
+        }
+
+        const content = await readFile(outfile, 'utf-8');
+        if (content.startsWith('#!')) {
+            if (verbose) console.debug(`[gjsify] --shebang skipped: ${outfile} already starts with a shebang`);
+        } else {
+            await writeFile(outfile, GJS_SHEBANG + content);
+        }
+        await chmod(outfile, 0o755);
+        if (verbose) console.debug(`[gjsify] --shebang: wrote shebang + chmod 0o755 to ${outfile}`);
+    }
+
     /** Application mode */
     async buildApp(app: App = 'gjs') {
 
@@ -172,6 +195,10 @@ export class BuildAction {
                 ],
             });
 
+            if (app === 'gjs' && this.configData.shebang) {
+                await this.applyShebang(esbuild?.outfile, verbose);
+            }
+
             return [result];
         }
 
@@ -191,6 +218,10 @@ export class BuildAction {
                 }),
             ]
         });
+
+        if (app === 'gjs' && this.configData.shebang) {
+            await this.applyShebang(esbuild?.outfile, verbose);
+        }
 
         return [result];
     }

--- a/packages/infra/cli/src/commands/build.ts
+++ b/packages/infra/cli/src/commands/build.ts
@@ -94,6 +94,12 @@ export const buildCommand: Command<any, CliBuildOptions> = {
                 normalize: true,
                 default: 'auto'
             })
+            .option('shebang', {
+                description: "Prepend a `#!/usr/bin/env -S gjs -m` shebang to the output and mark it executable (chmod 755). Only applies to GJS app builds with a single --outfile.",
+                type: 'boolean',
+                normalize: true,
+                default: false
+            })
     },
     handler: async (args) => {
         const config = new Config();

--- a/packages/infra/cli/src/commands/gettext.ts
+++ b/packages/infra/cli/src/commands/gettext.ts
@@ -1,0 +1,252 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { Command } from '../types/index.js';
+
+const execFileAsync = promisify(execFile);
+
+type GettextFormat = 'mo' | 'xml' | 'desktop' | 'json';
+
+interface GettextOptions {
+    poDir: string;
+    outDir: string;
+    domain: string;
+    format?: GettextFormat;
+    metainfo?: string;
+    filename?: string;
+    removeXmlComments?: boolean;
+    verbose?: boolean;
+}
+
+async function listLanguages(poDir: string): Promise<string[]> {
+    const entries = await readdir(poDir);
+    return entries
+        .filter((name) => name.endsWith('.po') && !name.startsWith('.'))
+        .map((name) => name.slice(0, -3))
+        .sort();
+}
+
+function stripXmlComments(source: string): string {
+    return source.replace(/<!--[\s\S]*?-->/g, '');
+}
+
+async function ensureDir(path: string): Promise<void> {
+    await mkdir(path, { recursive: true });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+    try {
+        await stat(path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function compileBulkXml(opts: {
+    poDir: string;
+    outDir: string;
+    domain: string;
+    template: string;
+    filename: string;
+    removeXmlComments: boolean;
+    verbose: boolean;
+}): Promise<void> {
+    const outputFile = join(opts.outDir, opts.filename);
+    await ensureDir(opts.outDir);
+
+    const args = [
+        `--output-file=${outputFile}`,
+        '--xml',
+        `--template=${opts.template}`,
+        '-d',
+        opts.poDir,
+    ];
+
+    if (opts.verbose) {
+        console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`);
+    }
+
+    await execFileAsync('msgfmt', args);
+
+    if (opts.removeXmlComments) {
+        const content = await readFile(outputFile, 'utf-8');
+        await writeFile(outputFile, stripXmlComments(content));
+    }
+
+    if (opts.verbose) {
+        console.log(`[gjsify gettext] wrote ${outputFile}`);
+    }
+}
+
+async function compilePerLanguage(opts: {
+    poDir: string;
+    outDir: string;
+    domain: string;
+    format: GettextFormat;
+    filename: string;
+    verbose: boolean;
+}): Promise<void> {
+    const languages = await listLanguages(opts.poDir);
+    if (languages.length === 0) {
+        console.warn(`[gjsify gettext] no .po files found in ${opts.poDir}`);
+        return;
+    }
+
+    for (const lang of languages) {
+        const poFile = join(opts.poDir, `${lang}.po`);
+        const langDir =
+            opts.format === 'mo'
+                ? join(opts.outDir, lang, 'LC_MESSAGES')
+                : join(opts.outDir, lang);
+        await ensureDir(langDir);
+        const outputFile = join(langDir, opts.filename);
+
+        const args = [`--output-file=${outputFile}`, `--${opts.format}`, poFile];
+
+        if (opts.verbose) {
+            console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`);
+        }
+
+        await execFileAsync('msgfmt', args);
+    }
+
+    if (opts.verbose) {
+        console.log(
+            `[gjsify gettext] compiled ${languages.length} language(s) into ${opts.outDir}`,
+        );
+    }
+}
+
+function defaultFilename(domain: string, format: GettextFormat, metainfoTemplate?: string): string {
+    switch (format) {
+        case 'mo':
+            return `${domain}.mo`;
+        case 'json':
+            return `${domain}.json`;
+        case 'desktop':
+            return `${domain}.desktop`;
+        case 'xml': {
+            // Mirror the template filename but without the trailing `.in` (convention for
+            // pre-processed metainfo templates: `org.foo.Bar.metainfo.xml.in`).
+            if (metainfoTemplate) {
+                const base = metainfoTemplate.replace(/\.in$/, '');
+                const slash = base.lastIndexOf('/');
+                return slash >= 0 ? base.slice(slash + 1) : base;
+            }
+            return `${domain}.xml`;
+        }
+    }
+}
+
+export const gettextCommand: Command<any, GettextOptions> = {
+    command: 'gettext <poDir> <outDir>',
+    description:
+        'Compile gettext .po files to .mo (per-language locale tree) or substitute a metainfo template via msgfmt --xml.',
+    builder: (yargs) => {
+        return yargs
+            .positional('poDir', {
+                description: 'Directory containing <lang>.po files',
+                type: 'string',
+                normalize: true,
+                demandOption: true,
+            })
+            .positional('outDir', {
+                description:
+                    'Output directory (locale tree for --format=mo, plain dir for xml/desktop/json)',
+                type: 'string',
+                normalize: true,
+                demandOption: true,
+            })
+            .option('domain', {
+                description: 'Text domain / application ID (e.g. `org.pixelrpg.maker`)',
+                type: 'string',
+                normalize: true,
+                demandOption: true,
+            })
+            .option('format', {
+                description: 'Output format',
+                type: 'string',
+                choices: ['mo', 'xml', 'desktop', 'json'] as const,
+                default: 'mo' as const,
+            })
+            .option('metainfo', {
+                description:
+                    'For --format=xml: path to the template (`.metainfo.xml.in`) used as msgfmt --template',
+                type: 'string',
+                normalize: true,
+            })
+            .option('filename', {
+                description: 'Override the output filename (defaults to <domain>.<ext>)',
+                type: 'string',
+                normalize: true,
+            })
+            .option('remove-xml-comments', {
+                description: 'For --format=xml: strip XML comments from the compiled output',
+                type: 'boolean',
+                default: true,
+            })
+            .option('verbose', {
+                description: 'Print each msgfmt invocation',
+                type: 'boolean',
+                default: false,
+            });
+    },
+    handler: async (args) => {
+        const poDir = resolve(args.poDir as string);
+        const outDir = resolve(args.outDir as string);
+        const domain = args.domain as string;
+        const format = (args.format as GettextFormat | undefined) ?? 'mo';
+        const metainfo = args.metainfo ? resolve(args.metainfo as string) : undefined;
+        const filename = args.filename ?? defaultFilename(domain, format, metainfo);
+        const verbose = !!args.verbose;
+        const removeXmlComments = !!args['remove-xml-comments'];
+
+        if (!(await fileExists(poDir))) {
+            console.error(`[gjsify gettext] PO directory does not exist: ${poDir}`);
+            process.exitCode = 1;
+            return;
+        }
+
+        try {
+            if (format === 'xml' && metainfo) {
+                await compileBulkXml({
+                    poDir,
+                    outDir,
+                    domain,
+                    template: metainfo,
+                    filename,
+                    removeXmlComments,
+                    verbose,
+                });
+            } else {
+                if (format === 'xml') {
+                    console.warn(
+                        '[gjsify gettext] --format=xml without --metainfo: falling back to per-language XML files',
+                    );
+                }
+                await compilePerLanguage({
+                    poDir,
+                    outDir,
+                    domain,
+                    format,
+                    filename,
+                    verbose,
+                });
+            }
+        } catch (err: any) {
+            if (err?.code === 'ENOENT') {
+                console.error(
+                    '[gjsify gettext] msgfmt not found. Install it via your distro (package: gettext).',
+                );
+            } else {
+                if (err?.stderr) process.stderr.write(err.stderr);
+                console.error(
+                    `[gjsify gettext] msgfmt failed${err?.code !== undefined ? ` (exit ${err.code})` : ''}`,
+                );
+            }
+            process.exitCode = typeof err?.code === 'number' ? err.code : 1;
+        }
+    },
+};

--- a/packages/infra/cli/src/commands/gresource.ts
+++ b/packages/infra/cli/src/commands/gresource.ts
@@ -1,0 +1,92 @@
+import { execFile } from 'node:child_process';
+import { basename, dirname, extname, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import type { Command } from '../types/index.js';
+
+const execFileAsync = promisify(execFile);
+
+interface GResourceOptions {
+    xml: string;
+    sourcedir?: string;
+    target?: string;
+    verbose?: boolean;
+}
+
+/**
+ * Derive a default `.gresource` target path from the XML descriptor.
+ * `foo.gresource.xml` → `foo.gresource` in the same directory.
+ */
+function defaultTargetFor(xmlPath: string): string {
+    const ext = extname(xmlPath);
+    const stem = basename(xmlPath, ext);
+    return resolve(dirname(xmlPath), stem);
+}
+
+export const gresourceCommand: Command<any, GResourceOptions> = {
+    command: 'gresource <xml>',
+    description:
+        'Compile a GResource XML descriptor into a binary .gresource bundle (wraps `glib-compile-resources`).',
+    builder: (yargs) => {
+        return yargs
+            .positional('xml', {
+                description: 'Path to the .gresource.xml descriptor',
+                type: 'string',
+                normalize: true,
+                demandOption: true,
+            })
+            .option('sourcedir', {
+                description: 'Directory containing the resource files referenced by <xml>',
+                type: 'string',
+                normalize: true,
+            })
+            .option('target', {
+                alias: 't',
+                description: 'Output .gresource file (default: <xml-without-.xml> next to <xml>)',
+                type: 'string',
+                normalize: true,
+            })
+            .option('verbose', {
+                description: 'Print the underlying glib-compile-resources invocation',
+                type: 'boolean',
+                default: false,
+            });
+    },
+    handler: async (args) => {
+        const xmlPath = resolve(args.xml as string);
+        const target = args.target ? resolve(args.target as string) : defaultTargetFor(xmlPath);
+        const sourcedir = args.sourcedir
+            ? resolve(args.sourcedir as string)
+            : dirname(xmlPath);
+
+        const cmdArgs = [
+            `--sourcedir=${sourcedir}`,
+            `--target=${target}`,
+            xmlPath,
+        ];
+
+        if (args.verbose) {
+            console.log(`[gjsify gresource] glib-compile-resources ${cmdArgs.join(' ')}`);
+        }
+
+        try {
+            const { stdout, stderr } = await execFileAsync('glib-compile-resources', cmdArgs);
+            if (stdout) process.stdout.write(stdout);
+            if (stderr) process.stderr.write(stderr);
+            if (args.verbose) {
+                console.log(`[gjsify gresource] wrote ${target}`);
+            }
+        } catch (err: any) {
+            if (err?.code === 'ENOENT') {
+                console.error(
+                    '[gjsify gresource] glib-compile-resources not found. Install it via your distro (package: glib2-devel / libglib2.0-dev).',
+                );
+            } else {
+                if (err?.stderr) process.stderr.write(err.stderr);
+                console.error(
+                    `[gjsify gresource] glib-compile-resources failed${err?.code !== undefined ? ` (exit ${err.code})` : ''}`,
+                );
+            }
+            process.exitCode = typeof err?.code === 'number' ? err.code : 1;
+        }
+    },
+};

--- a/packages/infra/cli/src/commands/index.ts
+++ b/packages/infra/cli/src/commands/index.ts
@@ -4,3 +4,5 @@ export * from './info.js';
 export * from './check.js';
 export * from './showcase.js';
 export * from './create.js';
+export * from './gresource.js';
+export * from './gettext.js';

--- a/packages/infra/cli/src/config.ts
+++ b/packages/infra/cli/src/config.ts
@@ -83,6 +83,7 @@ export class Config {
         configData.exclude = cliArgs.exclude || [];
         if (cliArgs.consoleShim !== undefined) configData.consoleShim = cliArgs.consoleShim;
         if (cliArgs.globals !== undefined) configData.globals = cliArgs.globals;
+        if (cliArgs.shebang !== undefined) configData.shebang = cliArgs.shebang;
 
         merge(configData.library ??= {}, pkg, configData.library);
         merge(configData.typescript ??= {}, tsConfig, configData.typescript);

--- a/packages/infra/cli/src/index.ts
+++ b/packages/infra/cli/src/index.ts
@@ -2,18 +2,28 @@
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
-import { buildCommand as build, runCommand as run, infoCommand as info, checkCommand as check, showcaseCommand as showcase, createCommand as create } from './commands/index.js'
+import {
+    buildCommand as build,
+    runCommand as run,
+    infoCommand as info,
+    checkCommand as check,
+    showcaseCommand as showcase,
+    createCommand as create,
+    gresourceCommand as gresource,
+    gettextCommand as gettext,
+} from './commands/index.js'
 import { APP_NAME } from './constants.js'
 
 void yargs(hideBin(process.argv))
     .scriptName(APP_NAME)
     .strict()
-    // .usage(Config.usage)
     .command(create.command, create.description, create.builder, create.handler)
     .command(build.command, build.description, build.builder, build.handler)
     .command(run.command, run.description, run.builder, run.handler)
     .command(info.command, info.description, info.builder, info.handler)
     .command(check.command, check.description, check.builder, check.handler)
     .command(showcase.command, showcase.description, showcase.builder, showcase.handler)
+    .command(gresource.command, gresource.description, gresource.builder, gresource.handler)
+    .command(gettext.command, gettext.description, gettext.builder, gettext.handler)
     .demandCommand(1)
     .help().argv

--- a/packages/infra/cli/src/types/cli-build-options.ts
+++ b/packages/infra/cli/src/types/cli-build-options.ts
@@ -55,4 +55,10 @@ export interface CliBuildOptions {
    * bundle. Only applies to GJS app builds.
    */
   globals?: string;
+  /**
+   * Prepend a `#!/usr/bin/env -S gjs -m` shebang to the output file and mark
+   * it executable (chmod 755). Only applies to GJS app builds with a single
+   * `--outfile`. Default: false.
+   */
+  shebang?: boolean;
 }

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -19,4 +19,8 @@ export interface ConfigData {
      * See CliBuildOptions for format.
      */
     globals?: string;
+    /**
+     * Prepend GJS shebang to output and mark executable. See CliBuildOptions.
+     */
+    shebang?: boolean;
 }

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -37,6 +37,7 @@ npx @gjsify/cli build src/index.ts --outfile dist/index.js
 | `--outdir`, `-d` | path | from `package.json` | Output directory (library mode) |
 | `--minify` | bool | `false` | Minify the output |
 | `--globals` | string | `"auto"` | Globals mode (see below) |
+| `--shebang` | bool | `false` | Prepend `#!/usr/bin/env -S gjs -m` to the outfile and chmod it `0o755`. Only with `--app gjs` and a single `--outfile`. |
 | `--verbose` | bool | `false` | Show detected globals and build details |
 
 <details>
@@ -309,5 +310,52 @@ npx @gjsify/cli showcase three-geometry-teapot
 | `[name]` | — | Showcase name to run. Omit to list available showcases |
 | `--list` | `false` | Force list mode |
 | `--json` | `false` | Output as JSON (list mode only) |
+
+## `gjsify gresource`
+
+Compile a GResource XML descriptor into a binary `.gresource` bundle. Thin wrapper around `glib-compile-resources` — useful when you want to package UI templates and assets into the app bundle without pulling in meson/autotools.
+
+```bash
+npx @gjsify/cli gresource data/org.example.App.data.gresource.xml \
+  --sourcedir data \
+  --target dist/org.example.App.data.gresource
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `<xml>` | — | Path to the `.gresource.xml` descriptor (required) |
+| `--sourcedir` | `dirname(<xml>)` | Directory containing the resource files referenced by `<xml>` |
+| `--target`, `-t` | `<xml-without-.xml>` next to `<xml>` | Output `.gresource` file |
+| `--verbose` | `false` | Print the underlying `glib-compile-resources` invocation |
+
+Requires `glib-compile-resources` (package: `glib2-devel` on Fedora, `libglib2.0-dev-bin` on Debian/Ubuntu).
+
+## `gjsify gettext`
+
+Compile gettext `.po` files for GNOME apps. Wraps `msgfmt` with the common output shapes — per-language locale tree (`.mo`), metainfo template substitution (`.xml`), and two less-common formats (`.desktop`, `.json`).
+
+```bash
+# Compile to runtime .mo locale tree
+npx @gjsify/cli gettext translations dist/locale --domain org.example.App
+
+# Substitute a metainfo template via msgfmt --xml --template
+npx @gjsify/cli gettext translations dist/metainfo \
+  --domain org.example.App \
+  --format xml \
+  --metainfo data/metainfo/org.example.App.metainfo.xml.in
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `<poDir>` | — | Directory containing `<lang>.po` files (required) |
+| `<outDir>` | — | Output directory (locale tree for `--format=mo`, plain dir otherwise) (required) |
+| `--domain` | — | Text domain / application ID (required) |
+| `--format` | `mo` | One of `mo`, `xml`, `desktop`, `json` |
+| `--metainfo` | — | For `--format=xml`: path to the template (`.metainfo.xml.in`) used as `msgfmt --template` |
+| `--filename` | `<domain>.<ext>` | Override the output filename |
+| `--remove-xml-comments` | `true` | For `--format=xml`: strip XML comments from the compiled output |
+| `--verbose` | `false` | Print each `msgfmt` invocation |
+
+Requires `msgfmt` (package: `gettext`).
 
 Before running, `gjsify showcase` calls `gjsify check` to verify system dependencies.


### PR DESCRIPTION
## Summary

Three new building blocks for packaging GNOME/GJS apps from `@gjsify/cli` alone, so projects no longer need hand-rolled Vite plugins or shell scripts for the \"make a runnable GJS app\" workflow.

- **`gjsify build --shebang`** — prepends `#!/usr/bin/env -S gjs -m` to the outfile and chmods it `0o755`. Idempotent. Only with `--app gjs` + single `--outfile`.
- **`gjsify gresource <xml>`** — wraps `glib-compile-resources` with sensible `--sourcedir` / `--target` defaults. ENOENT error prints a distro-specific install hint.
- **`gjsify gettext <poDir> <outDir> --domain <id>`** — wraps `msgfmt`. Formats: `mo` (per-language locale tree, default), `xml` (metainfo template substitution via `--xml --template`), `desktop`, `json`.

Together these let a GNOME app build look like:

```bash
gjsify build src/main.ts --app gjs --shebang --outfile org.example.App
gjsify gresource data/org.example.App.data.gresource.xml --sourcedir data
gjsify gettext translations dist/locale --domain org.example.App
```

## Why

Every GJS app maintained in this monorepo's orbit (pixel-rpg/map-editor, easy6502/app-gnome, etc.) currently reinvents the same four things: Blueprint compilation (already solved by `@gjsify/esbuild-plugin-blueprint`), gettext `.po`→`.mo`, `glib-compile-resources`, and an executable-with-shebang step. Blueprint is in; these three complete the set.

Design intent is to keep these as thin wrappers — they share yargs + config plumbing with the existing `build`/`run`/`info`/`showcase` commands, so the CLI stays a single install. Each falls through to the native tool (`glib-compile-resources`, `msgfmt`) and propagates its exit code.

## Files

- \`packages/infra/cli/src/actions/build.ts\` — `applyShebang()` post-processing step after `buildApp()`.
- \`packages/infra/cli/src/commands/build.ts\` — `--shebang` yargs option.
- \`packages/infra/cli/src/commands/gresource.ts\` — new command.
- \`packages/infra/cli/src/commands/gettext.ts\` — new command (formats: mo, xml, desktop, json).
- \`packages/infra/cli/src/commands/index.ts\`, \`packages/infra/cli/src/index.ts\` — wire up new commands.
- \`packages/infra/cli/src/config.ts\`, \`packages/infra/cli/src/types/{cli-build-options,config-data}.ts\` — plumb `shebang` through config.
- \`CHANGELOG.md\` — 3 Unreleased entries.
- \`website/src/content/docs/cli-reference.md\` — `--shebang` row + two new top-level sections with full option tables.

## Test plan

- [x] \`yarn workspace @gjsify/cli run check\` — clean
- [x] \`yarn workspace @gjsify/cli run build\` — clean
- [x] End-to-end verified in pixel-rpg/map-editor: \`yarn build\` now runs \`gjsify gresource\` + \`gjsify gettext\` + \`gjsify build --shebang\` and produces a directly-executable \`./org.pixelrpg.maker\`
- [ ] Smoke test `--shebang` idempotence (run twice, verify no double shebang) — trivial manual check, can be added as a targeted spec in a follow-up

## Follow-ups (not in this PR)

- Port easy6502/app-gnome from its Vite plugin stack to the new CLI commands.
- Add dedicated specs for `gresource` / `gettext` once a CLI test harness pattern is established (all three wrappers currently verified via consuming-app end-to-end).

## Related

- gjsify#17 — fix(dom,event-bridge): close input gaps surfaced by Excalibur in GJS (separate PR; different scope but same downstream consumer)