### PR TITLE
chore(tests,showcases): cover PR #17/#18 + adwaita-package-builder showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **showcases:** new `adwaita-package-builder` showcase — minimal Adwaita app demonstrating `gjsify gresource`, `gjsify gettext`, and `gjsify build --shebang` in a single build pipeline. Produces a directly-executable binary with an embedded GResource (CSS) and per-language `.mo` translations (de/es). Serves as the `gjsify showcase adwaita-package-builder` reference for "how to package a GJS/GNOME app with the gjsify CLI alone"
+
+### Bug Fixes
+
+* **cli/gettext:** `--format mo` no longer passes an invalid `--mo` flag to `msgfmt`. `msgfmt` produces a `.mo` file by default when no format flag is given; the `--mo` pseudo-flag never worked and caused every `gettext --format mo` invocation to fail with "Unbekannte Option »--mo«"
+* **cli/gresource:** create the target directory automatically before invoking `glib-compile-resources`. Previously a target like `dist/app.gresource` failed with ENOENT when `dist/` did not exist, because `glib-compile-resources` writes a temp file next to the target
+
+### Tests
+
+* **event-bridge:** new `event-bridge.spec.ts` regression suite verifying the `motion` handler reads widget-local coords from the signal callback (NOT from `controller.get_current_event().get_position()`, which returns surface-local coords and produced a drag-jump on first move after click). Covers coord forwarding, clamping to widget allocation, and movementX/Y tracking across successive motions
+* **cli-only E2E:** added coverage for `gjsify build --shebang` (shebang prepend + `chmod 0o755` + idempotence on repeated builds), `gjsify gresource` (binary bundle produced, `gresource list` lists the embedded path), and `gjsify gettext --format mo` (per-language locale tree under `<outDir>/<lang>/LC_MESSAGES/<domain>.mo`). Skips gracefully when `glib-compile-resources` / `msgfmt` are not installed
+
 ## [0.1.10](https://github.com/gjsify/gjsify/compare/v0.1.9...v0.1.10) (2026-04-11)
 
 ### Features

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,7 +13,7 @@ The project comprises **39 Node.js packages**, **15 Web API packages**, **5 DOM 
 | Web APIs | 15 | 14 (93%) | 1 (7%) | — |
 | DOM APIs | 5 | 5 (100%) | — | — |
 | Browser UI | 1 | 1 | — | — |
-| Showcases | 5 | 5 | — | — |
+| Showcases | 6 | 6 | — | — |
 | GJS Infrastructure | 4 | 3 | 1 (types) | — |
 | Build/Infra Tools | 9 | 9 | — | — |
 
@@ -221,7 +221,7 @@ Not yet implemented (but potentially relevant for GJS projects):
 | Build tools | 9 (infra/) |
 | Total test cases | 10,100+ |
 | Spec files | 106 |
-| Showcases | 5 (Canvas2D Fireworks, Three.js Teapot, Three.js Pixel Post-Processing, Excalibur Jelly Jumper, Express Webserver) |
+| Showcases | 6 (Canvas2D Fireworks, Three.js Teapot, Three.js Pixel Post-Processing, Excalibur Jelly Jumper, Express Webserver, Adwaita Package Builder) |
 | Real-world examples | 11+ (Express, Koa, Static file server, SSE chat, Hono REST, WS chat, file search, DNS lookup, worker pool, GTK dashboard, Three.js teapot) |
 | GNOME-integrated packages | 13 (25%) |
 | Alias mappings (GJS) | 60+ |

--- a/packages/dom/event-bridge/package.json
+++ b/packages/dom/event-bridge/package.json
@@ -12,11 +12,15 @@
         }
     },
     "scripts": {
-        "clear": "rm -rf lib tmp tsconfig.tsbuildinfo || exit 0",
+        "clear": "rm -rf lib tmp tsconfig.tsbuildinfo test.gjs.mjs || exit 0",
         "check": "tsc --noEmit",
         "build": "yarn build:gjsify && yarn build:types",
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
-        "build:types": "tsc"
+        "build:types": "tsc",
+        "build:test": "yarn build:test:gjs",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "test": "yarn build:gjsify && yarn build:test && yarn test:gjs",
+        "test:gjs": "gjs -m test.gjs.mjs"
     },
     "keywords": [
         "gjs",
@@ -34,6 +38,7 @@
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/node": "^25.6.0",
         "typescript": "^6.0.2"
     }

--- a/packages/dom/event-bridge/src/event-bridge.spec.ts
+++ b/packages/dom/event-bridge/src/event-bridge.spec.ts
@@ -1,0 +1,142 @@
+// GJS-only regression tests for @gjsify/event-bridge.
+//
+// These verify the handlers keep their contract with GTK4 event controllers.
+// The primary target is the `motion` handler: after the PR #17 fix it must
+// read widget-local coords from the signal callback args, NOT from the
+// surface-local `controller.get_current_event().get_position()` pathway.
+// The coord-frame mismatch caused a visible drag-jump on first move after
+// click in the pixel-rpg/map-editor consumer.
+//
+// Requires a GTK display (the CI workflow wraps tests in `xvfb-run`).
+
+import { describe, it, expect, on } from '@gjsify/unit';
+
+import Gtk from 'gi://Gtk?version=4.0';
+import Gdk from 'gi://Gdk?version=4.0';
+
+import { attachEventControllers } from './event-bridge.js';
+
+// Minimal stub that records dispatched events.
+function makeFakeCanvas() {
+    const events: any[] = [];
+    const el = {
+        events,
+        dispatchEvent(e: any): boolean {
+            events.push(e);
+            return true;
+        },
+    };
+    return el;
+}
+
+function getMotionController(widget: Gtk.Widget): Gtk.EventControllerMotion | null {
+    const list = widget.observe_controllers();
+    for (let i = 0; i < list.get_n_items(); i++) {
+        const ctrl = list.get_item(i);
+        if (ctrl instanceof Gtk.EventControllerMotion) {
+            return ctrl;
+        }
+    }
+    return null;
+}
+
+// Allocate the widget a real size so `get_allocated_width()`/`get_allocated_height()`
+// used by the motion handler's clamp return non-zero values. Without this the
+// clamp would squash every coord to 0 and we could not tell whether the handler
+// actually forwarded the signal args.
+function allocateWidget(widget: Gtk.Widget, w: number, h: number): void {
+    const rect = new Gdk.Rectangle();
+    rect.x = 0;
+    rect.y = 0;
+    rect.width = w;
+    rect.height = h;
+    widget.size_allocate(rect, -1);
+}
+
+export default async () => {
+    await on('Gjs', async () => {
+        // Ensure GTK is initialised exactly once for the suite.
+        Gtk.init();
+
+        await describe('attachEventControllers — motion', async () => {
+            await it('forwards signal-provided x/y as clientX/clientY/offsetX/offsetY', async () => {
+                const widget = new Gtk.DrawingArea();
+                const canvas = makeFakeCanvas();
+
+                attachEventControllers(widget, () => canvas as any);
+                allocateWidget(widget, 400, 300);
+
+                const motionCtrl = getMotionController(widget);
+                expect(motionCtrl).not.toBeNull();
+
+                // Emit the signal with explicit widget-local coords. If the
+                // implementation regressed to `controller.get_current_event()`
+                // there is no event bound to this synthetic emission and the
+                // handler would produce different values than 42/17.
+                motionCtrl!.emit('motion', 42, 17);
+
+                const moveEvents = canvas.events.filter((e: any) => e.type === 'pointermove');
+                expect(moveEvents.length).toBe(1);
+                const ev = moveEvents[0];
+                expect(ev.clientX).toBe(42);
+                expect(ev.clientY).toBe(17);
+                expect(ev.offsetX).toBe(42);
+                expect(ev.offsetY).toBe(17);
+                // screenX/Y mirror clientX/Y per this bridge's contract.
+                expect(ev.screenX).toBe(42);
+                expect(ev.screenY).toBe(17);
+            });
+
+            await it('also dispatches mousemove with matching clientX/clientY', async () => {
+                const widget = new Gtk.DrawingArea();
+                const canvas = makeFakeCanvas();
+
+                attachEventControllers(widget, () => canvas as any);
+                allocateWidget(widget, 400, 300);
+
+                getMotionController(widget)!.emit('motion', 100, 50);
+
+                const mousemoveEvents = canvas.events.filter((e: any) => e.type === 'mousemove');
+                expect(mousemoveEvents.length).toBe(1);
+                expect(mousemoveEvents[0].clientX).toBe(100);
+                expect(mousemoveEvents[0].clientY).toBe(50);
+            });
+
+            await it('clamps coords outside the widget allocation', async () => {
+                const widget = new Gtk.DrawingArea();
+                const canvas = makeFakeCanvas();
+
+                attachEventControllers(widget, () => canvas as any);
+                allocateWidget(widget, 400, 300);
+
+                // Negative + above-allocation coords should be clamped to
+                // [0, allocW]×[0, allocH] — protects consumers against
+                // out-of-range values GTK sometimes reports at widget edges.
+                getMotionController(widget)!.emit('motion', -5, 999);
+
+                const moveEvents = canvas.events.filter((e: any) => e.type === 'pointermove');
+                expect(moveEvents.length).toBe(1);
+                const ev = moveEvents[0];
+                expect(ev.clientX).toBe(0);
+                expect(ev.clientY).toBe(300);
+            });
+
+            await it('tracks movementX/movementY across successive motions', async () => {
+                const widget = new Gtk.DrawingArea();
+                const canvas = makeFakeCanvas();
+
+                attachEventControllers(widget, () => canvas as any);
+                allocateWidget(widget, 400, 300);
+
+                const motionCtrl = getMotionController(widget)!;
+                motionCtrl.emit('motion', 10, 20);
+                motionCtrl.emit('motion', 13, 25);
+
+                const moveEvents = canvas.events.filter((e: any) => e.type === 'pointermove');
+                expect(moveEvents.length).toBe(2);
+                expect(moveEvents[1].movementX).toBe(3);
+                expect(moveEvents[1].movementY).toBe(5);
+            });
+        });
+    });
+};

--- a/packages/dom/event-bridge/src/test.mts
+++ b/packages/dom/event-bridge/src/test.mts
@@ -1,0 +1,5 @@
+import { run } from '@gjsify/unit';
+
+import eventBridgeSuite from './event-bridge.spec.js';
+
+run({ eventBridgeSuite });

--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -25,6 +25,7 @@
     "dependencies": {
         "@gjsify/create-app": "workspace:^",
         "@gjsify/esbuild-plugin-gjsify": "workspace:^",
+        "@gjsify/example-dom-adwaita-package-builder": "workspace:^",
         "@gjsify/example-dom-canvas2d-fireworks": "workspace:^",
         "@gjsify/example-dom-excalibur-jelly-jumper": "workspace:^",
         "@gjsify/example-dom-three-geometry-teapot": "workspace:^",

--- a/packages/infra/cli/src/commands/gettext.ts
+++ b/packages/infra/cli/src/commands/gettext.ts
@@ -103,7 +103,13 @@ async function compilePerLanguage(opts: {
         await ensureDir(langDir);
         const outputFile = join(langDir, opts.filename);
 
-        const args = [`--output-file=${outputFile}`, `--${opts.format}`, poFile];
+        // msgfmt produces the binary .mo format by default — there is no
+        // `--mo` flag (only --xml, --desktop, --properties-output, ...).
+        const args = [`--output-file=${outputFile}`];
+        if (opts.format !== 'mo') {
+            args.push(`--${opts.format}`);
+        }
+        args.push(poFile);
 
         if (opts.verbose) {
             console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`);

--- a/packages/infra/cli/src/commands/gresource.ts
+++ b/packages/infra/cli/src/commands/gresource.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
 import { basename, dirname, extname, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { Command } from '../types/index.js';
@@ -67,6 +68,10 @@ export const gresourceCommand: Command<any, GResourceOptions> = {
         if (args.verbose) {
             console.log(`[gjsify gresource] glib-compile-resources ${cmdArgs.join(' ')}`);
         }
+
+        // Ensure the target directory exists — glib-compile-resources writes
+        // a temporary file next to the target and fails with ENOENT otherwise.
+        await mkdir(dirname(target), { recursive: true });
 
         try {
             const { stdout, stderr } = await execFileAsync('glib-compile-resources', cmdArgs);

--- a/showcases/dom/adwaita-package-builder/README.md
+++ b/showcases/dom/adwaita-package-builder/README.md
@@ -1,0 +1,41 @@
+# Adwaita Package Builder
+
+Minimal Adwaita application that demonstrates how to package a GJS app using only `@gjsify/cli`. Three build steps correspond to three CLI commands:
+
+| Step | Command | Produces |
+|---|---|---|
+| `build:resources` | `gjsify gresource` | `dist/com.gjsify.ShowcasePackageBuilder.data.gresource` (binary bundle with `style.css`) |
+| `build:i18n` | `gjsify gettext --format mo` | `dist/locale/<lang>/LC_MESSAGES/com.gjsify.ShowcasePackageBuilder.mo` (runtime translations) |
+| `build:metainfo` | `gjsify gettext --format xml --metainfo …` | `dist/metainfo/com.gjsify.ShowcasePackageBuilder.metainfo.xml` (AppStream metadata) |
+| `build:app` | `gjsify build --shebang` | `dist/com.gjsify.ShowcasePackageBuilder` (directly executable binary) |
+
+## Run it
+
+```bash
+# Build everything
+yarn build
+
+# Launch via gjsify run (standard)
+yarn start
+
+# OR launch the binary directly — no wrapper needed, the --shebang flag
+# prepended `#!/usr/bin/env -S gjs -m` and chmod'd the outfile to 0o755.
+./dist/com.gjsify.ShowcasePackageBuilder
+```
+
+## See translations
+
+```bash
+LANG=de_DE.UTF-8 yarn start        # Hallo von gjsify
+LANG=es_ES.UTF-8 yarn start        # Hola desde gjsify
+LANG=C yarn start                  # Hello from gjsify (source string)
+```
+
+## What to look at
+
+- [src/gjs/main.ts](src/gjs/main.ts) — `Gio.Resource.load` + `Gettext.bindtextdomain` wiring resolved relative to the binary.
+- [src/gjs/main-window.ts](src/gjs/main-window.ts) — `Gtk.CssProvider.load_from_resource` and `Gettext.gettext` wrapping translated strings.
+- [data/](data/) — the source CSS + GResource descriptor + metainfo template.
+- [po/](po/) — `.po` files (one per language) consumed by `msgfmt`.
+
+Related documentation: [CLI Reference — `gresource` / `gettext` / `build --shebang`](https://gjsify.org/docs/cli-reference/).

--- a/showcases/dom/adwaita-package-builder/data/com.gjsify.ShowcasePackageBuilder.data.gresource.xml
+++ b/showcases/dom/adwaita-package-builder/data/com.gjsify.ShowcasePackageBuilder.data.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/com/gjsify/ShowcasePackageBuilder">
+    <file>style.css</file>
+  </gresource>
+</gresources>

--- a/showcases/dom/adwaita-package-builder/data/com.gjsify.ShowcasePackageBuilder.metainfo.xml.in
+++ b/showcases/dom/adwaita-package-builder/data/com.gjsify.ShowcasePackageBuilder.metainfo.xml.in
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.gjsify.ShowcasePackageBuilder</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Adwaita Package Builder</name>
+  <summary>gjsify showcase demonstrating app packaging</summary>
+  <description>
+    <p>
+      Minimal Adwaita application that demonstrates how to package a GJS
+      application using only the @gjsify/cli commands: gresource, gettext,
+      and build --shebang.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/gjsify/gjsify</url>
+  <launchable type="desktop-id">com.gjsify.ShowcasePackageBuilder.desktop</launchable>
+</component>

--- a/showcases/dom/adwaita-package-builder/data/style.css
+++ b/showcases/dom/adwaita-package-builder/data/style.css
@@ -1,0 +1,6 @@
+.greeting {
+  font-size: 24pt;
+  font-weight: 800;
+  color: @accent_color;
+  margin: 0;
+}

--- a/showcases/dom/adwaita-package-builder/package.json
+++ b/showcases/dom/adwaita-package-builder/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "@gjsify/example-dom-adwaita-package-builder",
+    "version": "0.1.0",
+    "description": "Minimal Adwaita app showing how to package GResource bundles, gettext translations, and an executable binary with gjsify CLI alone",
+    "main": "dist/com.gjsify.ShowcasePackageBuilder",
+    "type": "module",
+    "files": [
+        "dist"
+    ],
+    "exports": {
+        "./package.json": "./package.json"
+    },
+    "scripts": {
+        "clear": "rm -rf dist tsconfig.tsbuildinfo",
+        "check": "tsc --noEmit --skipLibCheck",
+        "build:resources": "gjsify gresource data/com.gjsify.ShowcasePackageBuilder.data.gresource.xml --sourcedir data --target dist/com.gjsify.ShowcasePackageBuilder.data.gresource",
+        "build:i18n": "gjsify gettext po dist/locale --domain com.gjsify.ShowcasePackageBuilder --format mo",
+        "build:metainfo": "gjsify gettext po dist/metainfo --domain com.gjsify.ShowcasePackageBuilder --format xml --metainfo data/com.gjsify.ShowcasePackageBuilder.metainfo.xml.in --filename com.gjsify.ShowcasePackageBuilder.metainfo.xml",
+        "build:app": "gjsify build src/gjs/main.ts --app gjs --shebang --outfile dist/com.gjsify.ShowcasePackageBuilder --globals auto,dom",
+        "build": "yarn build:resources && yarn build:i18n && yarn build:metainfo && yarn build:app",
+        "start": "gjsify run dist/com.gjsify.ShowcasePackageBuilder"
+    },
+    "keywords": [
+        "gjs",
+        "gtk",
+        "adwaita",
+        "showcase",
+        "gresource",
+        "gettext",
+        "shebang"
+    ],
+    "devDependencies": {
+        "@girs/adw-1": "^1.10.0-4.0.0-rc.2",
+        "@girs/gdk-4.0": "^4.0.0-4.0.0-rc.2",
+        "@girs/gio-2.0": "^2.88.0-4.0.0-rc.2",
+        "@girs/gjs": "^4.0.0-rc.2",
+        "@girs/glib-2.0": "^2.88.0-4.0.0-rc.2",
+        "@girs/gobject-2.0": "^2.88.0-4.0.0-rc.2",
+        "@girs/gtk-4.0": "^4.23.0-4.0.0-rc.2",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/esbuild-plugin-blueprint": "workspace:^",
+        "typescript": "^6.0.2"
+    }
+}

--- a/showcases/dom/adwaita-package-builder/po/POTFILES.in
+++ b/showcases/dom/adwaita-package-builder/po/POTFILES.in
@@ -1,0 +1,3 @@
+src/gjs/main-window.blp
+src/gjs/main-window.ts
+data/com.gjsify.ShowcasePackageBuilder.metainfo.xml.in

--- a/showcases/dom/adwaita-package-builder/po/de.po
+++ b/showcases/dom/adwaita-package-builder/po/de.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: de\n"
+
+msgid "Hello from gjsify"
+msgstr "Hallo von gjsify"
+
+msgid "CSS from GResource · Text from Gettext · Binary from --shebang"
+msgstr "CSS aus GResource · Text aus Gettext · Binary mit --shebang"
+
+msgid "Adwaita Package Builder"
+msgstr "Adwaita-Paketbauer"
+
+msgid "gjsify showcase demonstrating app packaging"
+msgstr "gjsify-Showcase für das App-Packaging"

--- a/showcases/dom/adwaita-package-builder/po/es.po
+++ b/showcases/dom/adwaita-package-builder/po/es.po
@@ -1,0 +1,16 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: es\n"
+
+msgid "Hello from gjsify"
+msgstr "Hola desde gjsify"
+
+msgid "CSS from GResource · Text from Gettext · Binary from --shebang"
+msgstr "CSS desde GResource · Texto desde Gettext · Binario desde --shebang"
+
+msgid "Adwaita Package Builder"
+msgstr "Constructor de paquetes Adwaita"
+
+msgid "gjsify showcase demonstrating app packaging"
+msgstr "Ejemplo de gjsify que demuestra el empaquetado de aplicaciones"

--- a/showcases/dom/adwaita-package-builder/src/gjs/main-window.blp
+++ b/showcases/dom/adwaita-package-builder/src/gjs/main-window.blp
@@ -1,0 +1,33 @@
+using Gtk 4.0;
+using Adw 1;
+
+template $MainWindow: Adw.ApplicationWindow {
+  title: _("Adwaita Package Builder");
+  default-width: 480;
+  default-height: 240;
+
+  content: Adw.ToolbarView {
+    [top]
+    Adw.HeaderBar {}
+
+    content: Box {
+      orientation: vertical;
+      halign: center;
+      valign: center;
+      spacing: 12;
+      margin-start: 24;
+      margin-end: 24;
+      margin-top: 24;
+      margin-bottom: 24;
+
+      Label greeting {
+        styles [ "greeting" ]
+      }
+
+      Label detail {
+        wrap: true;
+        justify: center;
+      }
+    };
+  };
+}

--- a/showcases/dom/adwaita-package-builder/src/gjs/main-window.ts
+++ b/showcases/dom/adwaita-package-builder/src/gjs/main-window.ts
@@ -1,0 +1,45 @@
+// Adwaita window for the Package Builder showcase.
+//
+// - Blueprint template → compiled by `@gjsify/esbuild-plugin-blueprint`.
+// - CSS → loaded from the GResource bundle (see build:resources).
+// - Translated strings → looked up via Gettext against dist/locale (build:i18n).
+
+import GObject from 'gi://GObject?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+import Gdk from 'gi://Gdk?version=4.0';
+import Gettext from 'gettext';
+
+import Template from './main-window.blp';
+
+const _ = Gettext.gettext;
+
+export class MainWindow extends Adw.ApplicationWindow {
+    declare private _greeting: Gtk.Label;
+    declare private _detail: Gtk.Label;
+
+    static {
+        GObject.registerClass({
+            GTypeName: 'MainWindow',
+            Template,
+            InternalChildren: ['greeting', 'detail'],
+        }, this);
+    }
+
+    constructor(application: Adw.Application) {
+        super({ application });
+
+        // CSS lives inside the embedded GResource under the app's resource path.
+        const provider = new Gtk.CssProvider();
+        provider.load_from_resource('/com/gjsify/ShowcasePackageBuilder/style.css');
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default()!,
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+
+        // Translated strings — the msgid values must also appear in po/*.po.
+        this._greeting.set_label(_('Hello from gjsify'));
+        this._detail.set_label(_('CSS from GResource · Text from Gettext · Binary from --shebang'));
+    }
+}

--- a/showcases/dom/adwaita-package-builder/src/gjs/main.ts
+++ b/showcases/dom/adwaita-package-builder/src/gjs/main.ts
@@ -1,0 +1,54 @@
+// Adwaita Package Builder Showcase — GJS entry point.
+//
+// Demonstrates the three packaging steps of a GNOME/GJS app built entirely
+// through `@gjsify/cli`:
+//
+//   1. `gjsify gresource` compiles `data/*.gresource.xml` into a binary bundle
+//      loaded here via `Gio.Resource.load` + `Gio.resources_register`.
+//   2. `gjsify gettext --format mo` produces a per-language locale tree loaded
+//      here via `bindtextdomain(domain, dist/locale)`.
+//   3. `gjsify build --shebang` post-processes the outfile so this script runs
+//      as `./dist/com.gjsify.ShowcasePackageBuilder` without a wrapper.
+
+import '@girs/gjs';
+import '@girs/gtk-4.0';
+
+import Adw from 'gi://Adw?version=1';
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+import System from 'system';
+import Gettext from 'gettext';
+
+import { MainWindow } from './main-window.js';
+
+const APP_ID = 'com.gjsify.ShowcasePackageBuilder';
+
+// Resolve runtime asset paths relative to the executable. Works both for
+// `gjsify run dist/<bin>` (programInvocationName points at the bin) and for
+// the shebanged binary invoked directly as `./dist/<bin>`.
+const binDir = GLib.path_get_dirname(System.programInvocationName);
+
+// Load + register the GResource bundle produced by `yarn build:resources`.
+const resPath = GLib.build_filenamev([binDir, `${APP_ID}.data.gresource`]);
+const resource = Gio.Resource.load(resPath);
+Gio.resources_register(resource);
+
+// Point gettext at the locale tree produced by `yarn build:i18n`.
+const localeDir = GLib.build_filenamev([binDir, 'locale']);
+Gettext.bindtextdomain(APP_ID, localeDir);
+Gettext.textdomain(APP_ID);
+
+const app = new Adw.Application({
+    application_id: APP_ID,
+    flags: Gio.ApplicationFlags.FLAGS_NONE,
+});
+
+app.connect('activate', () => {
+    let win = app.get_active_window();
+    if (!win) {
+        win = new MainWindow(app);
+    }
+    win.present();
+});
+
+app.run([]);

--- a/showcases/dom/adwaita-package-builder/tsconfig.json
+++ b/showcases/dom/adwaita-package-builder/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "types": [
+            "@girs/gjs",
+            "@girs/gtk-4.0",
+            "@girs/adw-1",
+            "@gjsify/esbuild-plugin-blueprint/types"
+        ],
+        "target": "ESNext",
+        "moduleResolution": "NodeNext",
+        "outDir": "dist",
+        "rootDir": "src",
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "files": ["src/gjs/main.ts"]
+}

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -6,7 +6,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execSync, execFileSync } from 'node:child_process';
-import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -14,6 +14,16 @@ import {
   cleanupTestEnvironment,
   setupProject,
 } from '../helpers.mjs';
+
+/** Returns true when `cmd` is resolvable on the current PATH. */
+function hasCommand(cmd) {
+  try {
+    execFileSync('which', [cmd], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, () => {
   let tmpDir;
@@ -146,5 +156,124 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
     const examples = JSON.parse(out);
     assert.ok(Array.isArray(examples), 'showcase --json should return an array');
     assert.ok(examples.length > 0, 'should have at least one example');
+  });
+
+  // -- PR #18: gjsify build --shebang -------------------------------------
+  it('gjsify build --shebang prepends GJS shebang and sets +x', () => {
+    writeFileSync(join(projectDir, 'src', 'shebang-app.ts'),
+      "console.log('hello from shebanged app');\n"
+    );
+    execFileSync('npx', [
+      'gjsify', 'build', 'src/shebang-app.ts',
+      '--app', 'gjs', '--shebang',
+      '--outfile', 'dist/shebang-app.mjs',
+    ], {
+      cwd: projectDir,
+      stdio: 'pipe',
+      timeout: 60 * 1000,
+    });
+
+    const outPath = join(projectDir, 'dist', 'shebang-app.mjs');
+    assert.ok(existsSync(outPath), 'dist/shebang-app.mjs missing');
+
+    const content = readFileSync(outPath, 'utf-8');
+    const firstLine = content.split('\n', 1)[0];
+    assert.equal(firstLine, '#!/usr/bin/env -S gjs -m', 'first line should be the GJS shebang');
+
+    const mode = statSync(outPath).mode & 0o777;
+    assert.equal(mode, 0o755, `outfile mode should be 0o755, got 0o${mode.toString(8)}`);
+  });
+
+  it('gjsify build --shebang is idempotent on repeated builds', () => {
+    // Builds twice and verifies only ONE shebang line exists — the CLI's
+    // applyShebang() skips the prepend step if the file already starts with `#!`.
+    writeFileSync(join(projectDir, 'src', 'shebang-idem.ts'),
+      "console.log('idempotent');\n"
+    );
+    const args = [
+      'gjsify', 'build', 'src/shebang-idem.ts',
+      '--app', 'gjs', '--shebang',
+      '--outfile', 'dist/shebang-idem.mjs',
+    ];
+    const opts = { cwd: projectDir, stdio: 'pipe', timeout: 60 * 1000 };
+    execFileSync('npx', args, opts);
+    execFileSync('npx', args, opts);
+
+    const content = readFileSync(join(projectDir, 'dist', 'shebang-idem.mjs'), 'utf-8');
+    const shebangLines = content.split('\n').filter(line => line.startsWith('#!'));
+    assert.equal(shebangLines.length, 1, `expected exactly 1 shebang line, got ${shebangLines.length}`);
+  });
+
+  // -- PR #18: gjsify gresource -------------------------------------------
+  it('gjsify gresource compiles XML descriptor into binary bundle', { skip: !hasCommand('glib-compile-resources') && 'glib-compile-resources not installed' }, () => {
+    const dataDir = join(projectDir, 'gresource-data');
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, 'hello.txt'), 'world\n');
+    writeFileSync(join(dataDir, 'app.gresource.xml'),
+      `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<gresources>\n` +
+      `  <gresource prefix="/test">\n` +
+      `    <file>hello.txt</file>\n` +
+      `  </gresource>\n` +
+      `</gresources>\n`
+    );
+
+    const outFile = join(projectDir, 'dist', 'app.gresource');
+    mkdirSync(join(projectDir, 'dist'), { recursive: true });
+
+    execFileSync('npx', [
+      'gjsify', 'gresource',
+      join(dataDir, 'app.gresource.xml'),
+      '--sourcedir', dataDir,
+      '--target', outFile,
+    ], {
+      cwd: projectDir,
+      stdio: 'pipe',
+      timeout: 60 * 1000,
+    });
+
+    assert.ok(existsSync(outFile), 'binary .gresource missing');
+
+    // If the `gresource` inspection tool is available, verify the embedded path
+    // is actually present in the bundle. Usually shipped together with
+    // glib-compile-resources, so this is nearly always reachable.
+    if (hasCommand('gresource')) {
+      const listing = execFileSync('gresource', ['list', outFile], {
+        encoding: 'utf-8',
+        timeout: 30 * 1000,
+      });
+      assert.match(listing, /\/test\/hello\.txt/, 'embedded file should be listed');
+    }
+  });
+
+  // -- PR #18: gjsify gettext ---------------------------------------------
+  it('gjsify gettext --format mo produces a per-language locale tree', { skip: !hasCommand('msgfmt') && 'msgfmt not installed' }, () => {
+    const poDir = join(projectDir, 'po');
+    mkdirSync(poDir, { recursive: true });
+    writeFileSync(join(poDir, 'de.po'),
+      'msgid ""\n' +
+      'msgstr ""\n' +
+      '"Content-Type: text/plain; charset=UTF-8\\n"\n' +
+      '"Language: de\\n"\n\n' +
+      'msgid "Hello"\n' +
+      'msgstr "Hallo"\n'
+    );
+
+    const outDir = join(projectDir, 'gettext-out');
+    execFileSync('npx', [
+      'gjsify', 'gettext', poDir, outDir,
+      '--domain', 'com.test.app',
+      '--format', 'mo',
+    ], {
+      cwd: projectDir,
+      stdio: 'pipe',
+      timeout: 60 * 1000,
+    });
+
+    const moFile = join(outDir, 'de', 'LC_MESSAGES', 'com.test.app.mo');
+    assert.ok(existsSync(moFile), 'compiled .mo file missing at expected locale path');
+
+    const moSize = statSync(moFile).size;
+    assert.ok(moSize > 0, 'compiled .mo file should be non-empty');
   });
 });

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -330,6 +330,8 @@ npx @gjsify/cli gresource data/org.example.App.data.gresource.xml \
 
 Requires `glib-compile-resources` (package: `glib2-devel` on Fedora, `libglib2.0-dev-bin` on Debian/Ubuntu).
 
+See it in action: [`adwaita-package-builder` showcase](https://github.com/gjsify/gjsify/tree/main/showcases/dom/adwaita-package-builder) embeds `style.css` this way.
+
 ## `gjsify gettext`
 
 Compile gettext `.po` files for GNOME apps. Wraps `msgfmt` with the common output shapes — per-language locale tree (`.mo`), metainfo template substitution (`.xml`), and two less-common formats (`.desktop`, `.json`).
@@ -357,5 +359,7 @@ npx @gjsify/cli gettext translations dist/metainfo \
 | `--verbose` | `false` | Print each `msgfmt` invocation |
 
 Requires `msgfmt` (package: `gettext`).
+
+See it in action: [`adwaita-package-builder` showcase](https://github.com/gjsify/gjsify/tree/main/showcases/dom/adwaita-package-builder) uses both `--format mo` (runtime `.mo` tree) and `--format xml --metainfo` (AppStream substitution).
 
 Before running, `gjsify showcase` calls `gjsify check` to verify system dependencies.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,7 @@ __metadata:
   dependencies:
     "@gjsify/create-app": "workspace:^"
     "@gjsify/esbuild-plugin-gjsify": "workspace:^"
+    "@gjsify/example-dom-adwaita-package-builder": "workspace:^"
     "@gjsify/example-dom-canvas2d-fireworks": "workspace:^"
     "@gjsify/example-dom-excalibur-jelly-jumper": "workspace:^"
     "@gjsify/example-dom-three-geometry-teapot": "workspace:^"
@@ -1933,6 +1934,7 @@ __metadata:
     "@girs/gtk-4.0": "npm:^4.23.0-4.0.0-rc.2"
     "@gjsify/cli": "workspace:^"
     "@gjsify/dom-events": "workspace:^"
+    "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.6.0"
     typescript: "npm:^6.0.2"
   languageName: unknown
@@ -1959,6 +1961,23 @@ __metadata:
     "@gjsify/unit": "workspace:^"
     "@gjsify/web-streams": "workspace:^"
     "@types/node": "npm:^25.6.0"
+    typescript: "npm:^6.0.2"
+  languageName: unknown
+  linkType: soft
+
+"@gjsify/example-dom-adwaita-package-builder@workspace:^, @gjsify/example-dom-adwaita-package-builder@workspace:showcases/dom/adwaita-package-builder":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/example-dom-adwaita-package-builder@workspace:showcases/dom/adwaita-package-builder"
+  dependencies:
+    "@girs/adw-1": "npm:^1.10.0-4.0.0-rc.2"
+    "@girs/gdk-4.0": "npm:^4.0.0-4.0.0-rc.2"
+    "@girs/gio-2.0": "npm:^2.88.0-4.0.0-rc.2"
+    "@girs/gjs": "npm:^4.0.0-rc.2"
+    "@girs/glib-2.0": "npm:^2.88.0-4.0.0-rc.2"
+    "@girs/gobject-2.0": "npm:^2.88.0-4.0.0-rc.2"
+    "@girs/gtk-4.0": "npm:^4.23.0-4.0.0-rc.2"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/esbuild-plugin-blueprint": "workspace:^"
     typescript: "npm:^6.0.2"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Follow-up to [#17](https://github.com/gjsify/gjsify/pull/17), [#18](https://github.com/gjsify/gjsify/pull/18), and [#19](https://github.com/gjsify/gjsify/pull/19) — fills test gaps identified post-merge, fixes two CLI bugs the new tests uncovered, and adds a showcase that demonstrates every new PR #18 packaging command in one place.

## Summary

### 4 commits, one logical unit each

1. **`test(event-bridge)`** — regression suite for the PR #17 motion-handler refactor. New `event-bridge.spec.ts` with 4 tests that verify the `motion` handler uses widget-local coords from the signal callback (not the surface-local `get_current_event().get_position()` that caused the drag-jump). Adds `@gjsify/unit` + `test:gjs` script to the previously-testless package.

2. **`fix(cli)`** — two genuine bugs surfaced by the new E2E tests:
   - `gjsify gettext --format mo` was passing a non-existent `--mo` flag to `msgfmt` → every mo build failed with "Unbekannte Option »--mo«". Fix: omit the format flag (default produces .mo).
   - `gjsify gresource` crashed with ENOENT when the target directory did not exist yet (e.g. fresh `dist/`). Fix: `mkdir -p dirname(target)` before invoking `glib-compile-resources`.

   Same commit adds cli-only E2E coverage for all three PR #18 features — `--shebang` prepend + chmod + idempotence, `gresource` binary bundle output (with a `gresource list` assertion when available), and `gettext --format mo` per-language locale tree. Tests skip gracefully when the host binaries are not installed.

3. **`feat(showcases)`** — new `adwaita-package-builder` showcase. ~180 LOC minimal Adwaita app that ties all three PR #18 commands into one `yarn build`:
   - `build:resources` → `gjsify gresource` embeds `style.css`
   - `build:i18n` → `gjsify gettext --format mo` (de/es)
   - `build:metainfo` → `gjsify gettext --format xml --metainfo …` substitutes AppStream metadata
   - `build:app` → `gjsify build --shebang` produces a directly-executable binary

   Runtime wires up `Gio.Resource.load` + `Gettext.bindtextdomain` relative to `System.programInvocationName` so the binary works both via `gjsify run` and when launched directly. First Adwaita-focused showcase in the repo; serves as the reference for "how to package a GJS/GNOME app with @gjsify/cli alone". Registered on the CLI so `gjsify showcase adwaita-package-builder` discovers it.

4. **`docs`** — CHANGELOG Unreleased section, `STATUS.md` showcase count 5→6, website `cli-reference.md` cross-links to the new showcase from both `gresource` and `gettext` sections.

## Test plan

- [x] `yarn workspace @gjsify/event-bridge run test` — 4 new tests pass (17 assertions). Requires a display; CI already wraps tests in `xvfb-run`.
- [x] `yarn test:e2e:cli-only` — 11 / 11 (was 7; +4 for the new commands). Verified on a system with and without `gresource` installed for the skip path.
- [x] `yarn workspace @gjsify/example-dom-adwaita-package-builder run build` — produces dist/ with binary (shebang, `stat -c %a` = 755), `.gresource` bundle (346 bytes, `gresource list` shows `/com/gjsify/ShowcasePackageBuilder/style.css`), `locale/de/LC_MESSAGES/<app>.mo`, and substituted `metainfo/<app>.metainfo.xml`.
- [x] `./dist/com.gjsify.ShowcasePackageBuilder` launches without stderr (Adw main loop); `LANG=de_DE.UTF-8 yarn start` shows the translated label.
- [x] `yarn check` clean.

## Why this PR

The three merged PRs landed with uneven test coverage — #17 was 2/3, #18 was 0/3, #19 was already fully covered. This closes the test gap AND demonstrates the features in a copy-paste-able reference app. The two CLI bugs are genuine regressions that only manifest on first use of each command (which is why they slipped through review — no one had exercised them end-to-end yet).