### PR TITLE
fix(dgram): reject mismatched-family sends with EINVAL before hitting Gio

### DIFF
--- a/packages/node/dgram/src/index.spec.ts
+++ b/packages/node/dgram/src/index.spec.ts
@@ -269,9 +269,51 @@ export default async () => {
           });
         });
       });
+
     });
 
     // --- Additional tests ---
+
+    // Cross-platform fix: mismatched address-family sends must fail cleanly
+    // via the callback with EINVAL. On Node this matches the kernel errno;
+    // on GJS, Gio.Socket.send_to would otherwise throw NOT_SUPPORTED with a
+    // German message before our fix. Numeric IPs skip the DNS path so these
+    // run without MainLoop — safe for GJS even without a bind.
+    await describe('address-family mismatch (numeric IP, sync path)', async () => {
+      await it('udp4 + ::1 → EINVAL via callback', async () => {
+        const client = createSocket('udp4');
+        await new Promise<void>((resolve, reject) => {
+          client.send('x', 12345, '::1', (err) => {
+            try {
+              expect(err).not.toBeNull();
+              expect((err as NodeJS.ErrnoException).code).toBe('EINVAL');
+              client.close();
+              resolve();
+            } catch (e) {
+              client.close();
+              reject(e);
+            }
+          });
+        });
+      });
+
+      await it('udp6 + 127.0.0.1 → EINVAL via callback', async () => {
+        const client = createSocket('udp6');
+        await new Promise<void>((resolve, reject) => {
+          client.send('x', 12345, '127.0.0.1', (err) => {
+            try {
+              expect(err).not.toBeNull();
+              expect((err as NodeJS.ErrnoException).code).toBe('EINVAL');
+              client.close();
+              resolve();
+            } catch (e) {
+              client.close();
+              reject(e);
+            }
+          });
+        });
+      });
+    });
 
     await describe('createSocket with reuseAddr option', async () => {
       await it('should create a socket with reuseAddr true', async () => {

--- a/packages/node/dgram/src/index.ts
+++ b/packages/node/dgram/src/index.ts
@@ -199,6 +199,29 @@ export class Socket extends EventEmitter {
     ensureMainLoop();
   }
 
+  /** Socket family that matches `this.type` (udp4 → IPv4, udp6 → IPv6). */
+  private _socketFamily(): Gio.SocketFamily {
+    return this.type === 'udp6' ? Gio.SocketFamily.IPV6 : Gio.SocketFamily.IPV4;
+  }
+
+  /** True when `addr` can be sent to from a socket bound with `this._socketFamily()`. */
+  private _isAddressCompatible(addr: Gio.InetAddress): boolean {
+    return addr.get_family() === this._socketFamily();
+  }
+
+  /** Build an EINVAL error for a destination whose family doesn't match the socket.
+   *  Matches Node.js dgram behavior (node reports EINVAL from sendto(2) when the
+   *  destination address family is incompatible with the bound socket). */
+  private _mismatchError(destAddress: string): NodeJS.ErrnoException {
+    const want = this.type === 'udp6' ? 'IPv6' : 'IPv4';
+    const err = new Error(
+      `EINVAL: cannot send to ${destAddress} from a ${want} socket (address-family mismatch)`,
+    ) as NodeJS.ErrnoException;
+    err.code = 'EINVAL';
+    err.syscall = 'send';
+    return err;
+  }
+
   private _resolveAndSend(destAddress: string, destPort: number, buf: Buffer, cb: ((err: Error | null, bytes: number) => void) | undefined): void {
     if (this._closed || !this._socket) {
       if (cb) cb(new Error('Socket is closed'), 0);
@@ -209,6 +232,18 @@ export class Socket extends EventEmitter {
     let inetAddr = Gio.InetAddress.new_from_string(destAddress);
 
     const doSend = (addr: Gio.InetAddress) => {
+      // Address-family mismatch — e.g. IPv6 destination, IPv4-bound socket.
+      // Gio.Socket.send_to would throw Gio.IOErrorEnum.NOT_SUPPORTED
+      // ("Die Adressfamilie wird von der Protokollfamilie nicht unterstützt").
+      // DHT/tracker code treats this as a recoverable warning and keeps going;
+      // surface it as ENETUNREACH so consumers see a familiar Node errno
+      // instead of a raw GLib German message.
+      if (!this._isAddressCompatible(addr)) {
+        const err = this._mismatchError(destAddress);
+        if (cb) cb(err, 0);
+        else this.emit('error', err);
+        return;
+      }
       try {
         this._autoBind();
         const sockAddr = new Gio.InetSocketAddress({ address: addr, port: destPort });
@@ -237,7 +272,18 @@ export class Socket extends EventEmitter {
           else this.emit('error', err);
           return;
         }
-        doSend(addresses[0]);
+        // Prefer an address whose family matches this socket. Without this,
+        // picking addresses[0] (which can be IPv6) for an IPv4-bound socket
+        // hits EAFNOSUPPORT deep in Gio.Socket.send_to. DHT code queries many
+        // tracker/bootstrap hostnames that return mixed A / AAAA records.
+        const compatible = addresses.find(a => this._isAddressCompatible(a));
+        if (!compatible) {
+          const err = this._mismatchError(destAddress);
+          if (cb) cb(err, 0);
+          else this.emit('error', err);
+          return;
+        }
+        doSend(compatible);
       } catch (err) {
         if (cb) cb(err instanceof Error ? err : new Error(String(err)), 0);
         else this.emit('error', err);


### PR DESCRIPTION
## Problem

DHT/tracker bootstraps (e.g. in the webtorrent-player example) issue many UDP sends to hostnames that resolve to a mix of A (IPv4) and AAAA (IPv6) records. Our `dgram.Socket.send()` picked `addresses[0]` verbatim; when an IPv4-bound socket got an AAAA (or vice versa), `Gio.Socket.send_to()` threw `Gio.IOErrorEnum.NOT_SUPPORTED` and the German message "Die Adressfamilie wird von der Protokollfamilie nicht unterstützt" bubbled to user code.

## Fix

Two changes in `_resolveAndSend()`:

1. **Numeric-IP path:** check the `Gio.InetAddress` family against the socket's family up-front and fail the send with `EINVAL` (matches Node.js dgram errno) via the callback — no raw Gio error surfaces.
2. **DNS path:** pick the first resolved address whose family matches the socket. If none matches, fail with the same `EINVAL`. DHT queries tolerate trackers that publish AAAA records while we're on an IPv4-only stack (and vice versa).

## Tests

Cross-platform, numeric-IP path (no MainLoop needed):
- `udp4 + ::1` → `EINVAL` via callback
- `udp6 + 127.0.0.1` → `EINVAL` via callback

Node.js's native dgram exhibits the same `EINVAL` behavior, so tests are shared between runtimes.

## Non-goals

- Dual-stack sockets (bind `::` with `IPV6_V6ONLY=0` so one socket handles both families). That's a bigger API change and should be a separate PR.
- Retrying a different address from the resolved list on failure — currently we still only try the first compatible one.
