### PR TITLE
chore: post-soup-bridge stability sweep

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -7,9 +7,9 @@ on:
   push:
     branches: [main]
     paths:
-      - 'packages/dom/webgl/src/vala/**'
-      - 'packages/dom/webgl/src/vapi/**'
-      - 'packages/dom/webgl/meson.build'
+      - 'packages/framework/webgl/src/vala/**'
+      - 'packages/framework/webgl/src/vapi/**'
+      - 'packages/framework/webgl/meson.build'
       - 'packages/web/webrtc-native/src/vala/**'
       - 'packages/web/webrtc-native/meson.build'
       - 'packages/node/http-soup-bridge/src/vala/**'
@@ -56,13 +56,13 @@ jobs:
 
       # -------- @gjsify/webgl (gwebgl) --------
       - name: Build @gjsify/webgl Vala library
-        working-directory: packages/dom/webgl
+        working-directory: packages/framework/webgl
         run: |
           meson setup build .
           meson compile -C build
 
       - name: Collect @gjsify/webgl prebuilds
-        working-directory: packages/dom/webgl
+        working-directory: packages/framework/webgl
         env:
           ARCH: ${{ matrix.arch }}
         run: |
@@ -75,7 +75,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: webgl-prebuilds-linux-${{ matrix.arch }}
-          path: packages/dom/webgl/prebuilds/linux-${{ matrix.arch }}/
+          path: packages/framework/webgl/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       # -------- @gjsify/webrtc-native (GjsifyWebrtc) --------
@@ -142,13 +142,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: webgl-prebuilds-linux-x86_64
-          path: packages/dom/webgl/prebuilds/linux-x86_64/
+          path: packages/framework/webgl/prebuilds/linux-x86_64/
 
       - name: Download webgl aarch64 prebuilds
         uses: actions/download-artifact@v4
         with:
           name: webgl-prebuilds-linux-aarch64
-          path: packages/dom/webgl/prebuilds/linux-aarch64/
+          path: packages/framework/webgl/prebuilds/linux-aarch64/
 
       # -------- @gjsify/webrtc-native --------
       - name: Download webrtc-native x86_64 prebuilds
@@ -180,7 +180,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packages/dom/webgl/prebuilds/ packages/web/webrtc-native/prebuilds/ packages/node/http-soup-bridge/prebuilds/
+          git add packages/framework/webgl/prebuilds/ packages/web/webrtc-native/prebuilds/ packages/node/http-soup-bridge/prebuilds/
           if git diff --cached --quiet; then
             echo "No prebuild changes to commit."
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### chore — repo stability sweep (2026-04-28)
+
+Three small fixes around the recent `@gjsify/http-soup-bridge` landing:
+
+**CI: prebuilds workflow path correction.** `.github/workflows/prebuilds.yml` still pointed at `packages/dom/webgl`, but that package was moved to `packages/framework/webgl` in `319762fb1`. Every prebuild run on `main` was failing in the first `meson setup` step with `chdir to cwd packages/dom/webgl: no such file or directory`. Updated all path references (trigger paths, working-directory, artifact paths, commit-prebuilds add list) to `packages/framework/webgl`. The other two prebuild targets (`packages/web/webrtc-native`, `packages/node/http-soup-bridge`) were unaffected.
+
+**Examples: `gjs -m` → `gjsify run` across all `examples/node/*`.** Once `@gjsify/http` started depending on the `GjsifyHttpSoupBridge-1.0` typelib, every example using `node:http` / Hono / Express / Koa / SSE / WebSocket needed `LD_LIBRARY_PATH` + `GI_TYPELIB_PATH` set to the prebuilds directory. `gjsify run` does that automatically; raw `gjs -m` does not. Migrated `start:gjs` (and `test:gjs` where present) in all 23 `examples/node/*` packages — both the directly-affected HTTP-stack examples (`gtk-http-dashboard`, `net-hono-rest`, `net-express-hello`, `net-koa-blog`, `net-sse-chat`, `net-ws-chat`, `net-static-file-server`) and the rest of the `cli-*` examples for consistency. Dashboard verified end-to-end: GTK window opens, HTTP server accepts requests, JSON responses round-trip.
+
+**Tests: granular `/register` subpath migration.** `@gjsify/node-globals/register` is now genuinely opt-in (Step 3 of the split tracked in STATUS.md). The 9 per-package test entries in `packages/{node,web}/*/src/test.mts` and the 2 Autobahn driver bundles now import only the granular subpaths each test actually needs (`register/process` is universal for `@gjsify/unit`'s `process.env` / `process.exit` reads; the rest is per-package — `register/buffer`, `register/timers`, `register/url`, `register/microtask`, `register/structured-clone`). The two meta-package self-tests (`@gjsify/node-globals`, `@gjsify/web-globals`) keep the catch-all because they verify the entire register surface by design. Examples and integration suites (webtorrent, socket.io, streamx, mcp-typescript-sdk, mcp-inspector-cli) keep the catch-all — they're the legitimate "give me the full Node runtime surface" consumers (real third-party libraries pull in everything). Repo-wide `yarn check` clean; all migrated package tests green on Node + GJS.
+
 ### feat — `@gjsify/http-soup-bridge`: native Vala bridge for libsoup HTTP server (2026-04-27)
 
 New native package + integration into `@gjsify/http`. Closes both libsoup-related entries from STATUS.md "Upstream GJS Patch Candidates" by moving the entire `Soup.Server` interaction into Vala-emitted C and exposing JS only through plain GObject classes. Same pattern as `@gjsify/webrtc-native` — see PR #44 for full context.

--- a/STATUS.md
+++ b/STATUS.md
@@ -385,7 +385,7 @@ Not yet implemented (but potentially relevant for GJS projects):
    | ~~**DNS lookup tool**~~✓ | cli | dns, net, readline | `examples/cli/dns-lookup` |
    | ~~**Worker pool**~~✓ | cli | worker_threads, events, crypto | `examples/cli/worker-pool` |
    | **SQLite/JSON data store** | cli | fs, crypto, buffer, stream | — |
-   | **GTK + HTTP** (dashboard) | gtk | Gtk 4, Soup, fetch, WebSocket | — |
+   | ~~**GTK + HTTP** (dashboard)~~✓ | gtk | Gtk 4, http (Soup-bridge backed) | `examples/node/gtk-http-dashboard` |
 
    These examples serve as integration tests and surface real CJS-ESM interop issues, missing globals, GC problems, and MainLoop edge cases that unit tests alone don't catch.
 
@@ -511,10 +511,9 @@ Tracked follow-up work that has been deliberately deferred. Every "out of scope"
 
 **Progress:**
 - ✅ **Steps 1 + 2 done** — Granular subpaths exist: `packages/node/globals/src/register/{buffer,encoding,microtask,process,structured-clone,timers,url}.ts`. The catch-all `register.ts` now re-imports from these granular files (with a comment directing users to granular imports). `GJS_GLOBALS_MAP` already points at the granular paths.
-- 🔲 **Step 3 pending** — Consumers (`test.mts` entry-points, autobahn drivers, integration test entries) still `import '@gjsify/node-globals/register'`. Migrate one consumer at a time.
-- 🔲 **Step 4 pending** — Once all consumers are migrated, remove or deprecate the monolithic catch-all.
-
-Migration approach: pick a consumer that only uses a subset (e.g. `@gjsify/http/src/test.mts` — only needs `process` + `url`), replace with targeted imports, verify both Node + GJS tests still pass. Repeat per consumer.
+- ✅ **Step 3 done for per-package test entries and Autobahn drivers** — All `packages/{node,web}/*/src/test.mts` entries (buffer, fs, module, stream, timers, tty, worker_threads, fetch, formdata) now import only the granular subpaths each test actually needs. The two Autobahn drivers in `tests/integration/autobahn/src/` now use `register/process` + `register/timers`. Self-tests of the meta packages `@gjsify/node-globals` and `@gjsify/web-globals` keep the catch-all because they verify the entire register surface by design.
+- 🔲 **Step 3 deferred for examples + integration suites** — `examples/node/*` and `tests/integration/{webtorrent,socket.io,streamx,mcp-typescript-sdk,mcp-inspector-cli}/src/test.mts` still import the catch-all. These are legitimate "full Node runtime surface" consumers (real-world third-party libraries pull in everything), so the catch-all is the right shape for them. Migrate only if a specific consumer benefits from a smaller bundle.
+- 🔲 **Step 4 pending** — Catch-all is now genuinely opt-in. Keep it indefinitely as the "full surface" entry point; do not deprecate.
 
 Keep the catch-all for **new** consumers that genuinely want "give me the full Node runtime surface" — but keep it as opt-in, not a mandatory import chain.
 

--- a/examples/node/cli-deepkit-di/package.json
+++ b/examples/node/cli-deepkit-di/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-deepkit-events/package.json
+++ b/examples/node/cli-deepkit-events/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-deepkit-types/package.json
+++ b/examples/node/cli-deepkit-types/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-deepkit-validation/package.json
+++ b/examples/node/cli-deepkit-validation/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-deepkit-workflow/package.json
+++ b/examples/node/cli-deepkit-workflow/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-dns-lookup/package.json
+++ b/examples/node/cli-dns-lookup/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-file-search/package.json
+++ b/examples/node/cli-file-search/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-json-store/package.json
+++ b/examples/node/cli-json-store/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-buffer/package.json
+++ b/examples/node/cli-node-buffer/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-events/package.json
+++ b/examples/node/cli-node-events/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-fs/package.json
+++ b/examples/node/cli-node-fs/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-os/package.json
+++ b/examples/node/cli-node-os/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-path/package.json
+++ b/examples/node/cli-node-path/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-node-url/package.json
+++ b/examples/node/cli-node-url/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:node && yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.cjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-worker-pool/package.json
+++ b/examples/node/cli-worker-pool/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/cli-yargs-demo/package.json
+++ b/examples/node/cli-yargs-demo/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",

--- a/examples/node/gtk-http-dashboard/package.json
+++ b/examples/node/gtk-http-dashboard/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit --skipLibCheck",
-    "start": "gjs -m dist/index.gjs.js",
+    "start": "gjsify run dist/index.gjs.js",
     "build": "yarn build:gjs",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js"
   },

--- a/examples/node/net-express-hello/package.json
+++ b/examples/node/net-express-hello/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -20,7 +20,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/examples/node/net-hono-rest/package.json
+++ b/examples/node/net-hono-rest/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -20,7 +20,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/examples/node/net-koa-blog/package.json
+++ b/examples/node/net-koa-blog/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node && yarn build:views",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -21,7 +21,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/examples/node/net-sse-chat/package.json
+++ b/examples/node/net-sse-chat/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node && yarn build:public",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -21,7 +21,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/examples/node/net-static-file-server/package.json
+++ b/examples/node/net-static-file-server/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node && yarn build:public",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -21,7 +21,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/examples/node/net-ws-chat/package.json
+++ b/examples/node/net-ws-chat/package.json
@@ -10,7 +10,7 @@
     "clear": "rm -rf dist tsconfig.tsbuildinfo",
     "check": "tsc --noEmit",
     "start": "yarn start:gjs",
-    "start:gjs": "gjs -m dist/index.gjs.js",
+    "start:gjs": "gjsify run dist/index.gjs.js",
     "start:node": "node dist/index.node.mjs",
     "build": "yarn build:gjs && yarn build:node && yarn build:public",
     "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
@@ -21,7 +21,7 @@
     "build:test": "yarn build:test:gjs && yarn build:test:node",
     "test": "yarn build && yarn build:test:node && yarn test:node",
     "test:node": "node test.node.mjs",
-    "test:gjs": "gjs -m test.gjs.mjs"
+    "test:gjs": "gjsify run test.gjs.mjs"
   },
   "devDependencies": {
     "@gjsify/cli": "workspace:^",

--- a/packages/node/buffer/src/test.mts
+++ b/packages/node/buffer/src/test.mts
@@ -1,4 +1,5 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';

--- a/packages/node/fs/src/test.mts
+++ b/packages/node/fs/src/test.mts
@@ -1,4 +1,7 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
+import '@gjsify/node-globals/register/timers';
+import '@gjsify/node-globals/register/url';
 import { run } from '@gjsify/unit';
 
 import testSuiteCallback from './callback.spec.js';

--- a/packages/node/module/src/test.mts
+++ b/packages/node/module/src/test.mts
@@ -1,4 +1,5 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/url';
 import { run } from '@gjsify/unit';
 import testSuite from './index.spec.js';
 run({ testSuite });

--- a/packages/node/stream/src/test.mts
+++ b/packages/node/stream/src/test.mts
@@ -1,4 +1,7 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
+import '@gjsify/node-globals/register/timers';
+import '@gjsify/node-globals/register/microtask';
 import 'abort-controller/register'; // register AbortController/AbortSignal globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 

--- a/packages/node/timers/src/test.mts
+++ b/packages/node/timers/src/test.mts
@@ -1,4 +1,6 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/timers';
+import '@gjsify/node-globals/register/microtask';
 import 'abort-controller/register'; // register AbortController/AbortSignal globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 

--- a/packages/node/tty/src/test.mts
+++ b/packages/node/tty/src/test.mts
@@ -1,4 +1,4 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
 import { run } from '@gjsify/unit';
 import testSuite from './index.spec.js';
 run({testSuite});

--- a/packages/node/worker_threads/src/test.mts
+++ b/packages/node/worker_threads/src/test.mts
@@ -1,4 +1,8 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
+import '@gjsify/node-globals/register/timers';
+import '@gjsify/node-globals/register/url';
+import '@gjsify/node-globals/register/structured-clone';
 import { run } from '@gjsify/unit';
 import testSuite from './index.spec.js';
 run({ testSuite });

--- a/packages/web/fetch/src/test.mts
+++ b/packages/web/fetch/src/test.mts
@@ -1,4 +1,6 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
+import '@gjsify/node-globals/register/url';
 import 'fetch/register'; // register fetch/Headers/Request/Response globals on GJS (no-op on Node)
 import { run } from '@gjsify/unit';
 

--- a/packages/web/formdata/src/test.mts
+++ b/packages/web/formdata/src/test.mts
@@ -1,4 +1,5 @@
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/buffer';
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';

--- a/tests/integration/autobahn/src/fuzzingclient-driver-ws.ts
+++ b/tests/integration/autobahn/src/fuzzingclient-driver-ws.ts
@@ -8,7 +8,8 @@
 // the gap narrows down which wrapper-layer features drop frames or mis-code
 // close reasons.
 
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/timers';
 // Importing `ws` here goes through the bundler alias:
 //   ws → @gjsify/ws → @gjsify/websocket → Soup.WebsocketConnection.
 // The shape of the import matches what real npm `ws` consumers use.

--- a/tests/integration/autobahn/src/fuzzingclient-driver.ts
+++ b/tests/integration/autobahn/src/fuzzingclient-driver.ts
@@ -24,7 +24,8 @@
 // (tested in @gjsify/websocket's own unit spec). Explicit import keeps
 // bundler dependency tracking clean and survives any future changes to
 // the --globals auto detection rules.
-import '@gjsify/node-globals/register';
+import '@gjsify/node-globals/register/process';
+import '@gjsify/node-globals/register/timers';
 import { WebSocket } from '@gjsify/websocket';
 // `System.exit()` is the reliable GJS exit path. process.exit() from
 // @gjsify/process reaches imports.system.exit via globalThis.imports, which


### PR DESCRIPTION
## Summary

Three small fixes around the recent [`@gjsify/http-soup-bridge`](https://github.com/gjsify/gjsify/pull/44) landing — the kind that surface as soon as the new prebuild becomes a hard dep.

- **CI: prebuilds workflow path correction.** `.github/workflows/prebuilds.yml` still pointed at `packages/dom/webgl`, but that package was moved to `packages/framework/webgl` in `319762fb1`. Every prebuild run on `main` was failing in the first `meson setup` step with `chdir to cwd packages/dom/webgl: no such file or directory` (see [job 73363774704](https://github.com/gjsify/gjsify/actions/runs/25046764344/job/73363774704#step:5:7)). Updated all path references — trigger paths, `working-directory`, artifact paths, commit-prebuilds add list. The other two prebuild targets (`packages/web/webrtc-native`, `packages/node/http-soup-bridge`) were unaffected.
- **Examples: `gjs -m` → `gjsify run` across all `examples/node/*`.** Once `@gjsify/http` started depending on the `GjsifyHttpSoupBridge-1.0` typelib, every example using `node:http` / Hono / Express / Koa / SSE / WebSocket needed `LD_LIBRARY_PATH` + `GI_TYPELIB_PATH` set to the prebuilds directory. `gjsify run` does that automatically; raw `gjs -m` does not. Migrated `start:gjs` (and `test:gjs` where present) in all 23 `examples/node/*` packages — the directly-affected HTTP-stack examples (`gtk-http-dashboard`, `net-hono-rest`, `net-express-hello`, `net-koa-blog`, `net-sse-chat`, `net-ws-chat`, `net-static-file-server`) and the rest of the `cli-*` examples for consistency. Dashboard verified end-to-end: GTK window opens, HTTP server accepts requests, JSON responses round-trip.
- **Tests: granular `/register` subpath migration (Step 3 of the split tracked in STATUS.md).** The 9 per-package test entries in `packages/{node,web}/*/src/test.mts` and the 2 Autobahn driver bundles now import only the granular subpaths each test actually needs (`register/process` is universal for `@gjsify/unit`'s `process.env` / `process.exit` reads; the rest is per-package — `register/buffer`, `register/timers`, `register/url`, `register/microtask`, `register/structured-clone`). The two meta-package self-tests (`@gjsify/node-globals`, `@gjsify/web-globals`) keep the catch-all because they verify the entire register surface by design. Examples and integration suites (webtorrent, socket.io, streamx, mcp-typescript-sdk, mcp-inspector-cli) keep the catch-all — they're the legitimate "give me the full Node runtime surface" consumers.

STATUS.md and CHANGELOG.md updated.

## Test plan

- [x] Repo-wide `yarn check` clean
- [x] All migrated package tests green on Node + GJS (buffer 317, fs 501, module 127, stream 509, timers 88, tty 29, worker_threads 232, fetch 60–61, formdata 49)
- [x] `examples/node/gtk-http-dashboard` `yarn build && yarn start` — GTK window opens, `curl http://127.0.0.1:3000/ping` returns the expected JSON
- [x] Both Autobahn driver bundles build via `gjsify build --globals auto,WebSocket` without errors
- [ ] CI: prebuilds workflow run on this branch should reach the `meson compile` step instead of failing at `chdir`