### PR TITLE
feat(@gjsify/fs): implement cp, Dir/opendir, and globSync/glob/promises.glob

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-04-29 (`@gjsify/fs` adds `cpSync`/`cp`/`promises.cp` + `Dir`/`opendir`/`opendirSync`/`promises.opendir` via Gio (30 new tests, 540 total); `@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams; `@gjsify/unit` runtime detection fixed.)
+> Last updated: 2026-04-29 (`@gjsify/fs` adds `globSync`/`glob`/`promises.glob` with full glob-to-regex engine (17 new tests, 557 total); previously: `cpSync`/`cp`/`promises.cp` + `Dir`/`opendir`/`opendirSync`/`promises.opendir` via Gio; `@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams; `@gjsify/unit` runtime detection fixed.)
 
 ## Summary
 
@@ -41,7 +41,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | **diagnostics_channel** | — | 137 | Channel, TracingChannel, subscribe/unsubscribe |
 | **dns** | Gio, GLib | 121 (2 specs) | lookup, resolve4/6, reverse via Gio.Resolver + dns/promises |
 | **events** | — | 255+ (2 specs) | EventEmitter, once, on, listenerCount, setMaxListeners, errorMonitor, captureRejections, getEventListeners, prependListener, eventNames, rawListeners, Symbol events, async iterator, **makeCallable** (`.call(this)` + `util.inherits` CJS compat) |
-| **fs** | Gio, GLib | 540 (11 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/cp/cpSync/promises.cp/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, **Dir/opendir/opendirSync/promises.opendir** (async iterator, read/readSync, close/closeSync), ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
+| **fs** | Gio, GLib | 557 (12 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/cp/cpSync/promises.cp/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, **Dir/opendir/opendirSync/promises.opendir** (async iterator, read/readSync, close/closeSync), **globSync/glob/promises.glob** (*, **, ?, {a,b}, extglob, exclude fn/array), ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
 | **globals** | — | 221 | process, Buffer, structuredClone (full polyfill), TextEncoder/Decoder, atob/btoa, URL, setImmediate. Root export is pure; side effects live in `@gjsify/node-globals/register`. Users opt in via the `--globals` CLI flag (default-wired in the `@gjsify/create-app` template) or an explicit `import '@gjsify/node-globals/register'`. |
 | **http** | Soup 3.0, Gio, GLib | 1038 (7 specs) | Server (Soup.Server, **chunked streaming**, **upgrade event**, **`SoupMessageLifecycle` per-request helper**: GC guard for in-flight Soup messages + `'wrote-chunk'`-driven re-unpause + `'disconnected'`/`'finished'` → req/res `'close'`/`'aborted'` translation), ClientRequest (Soup.Session, **timeout events**, **auth option**, **signal option**), IncomingMessage (**timeout events**), ServerResponse (**setTimeout**, chunked transfer), OutgoingMessage, **`ServerRequestSocket`** (Duplex-typed `req.socket` with working `pause`/`resume`/`destroySoon` for Hono backpressure), STATUS_CODES, METHODS, Agent (**constructor options**, keepAlive, maxSockets, scheduling), validateHeaderName/Value, maxHeaderSize, round-trip on GJS. **Known limitation:** libsoup stops polling the input stream while a server message is paused, so `'disconnected'` does not fire for long-poll/SSE clients that hang up — see "Upstream GJS Patch Candidates" |
 | **https** | Soup 3.0 | 99 | Agent (defaultPort, protocol, maxSockets, destroy, options, keepAlive, scheduling), globalAgent, request (URL/options/headers/timeout/methods), get, createServer, Server |
@@ -344,7 +344,7 @@ Not yet implemented (but potentially relevant for GJS projects):
 | Browser UI packages | 3 (adwaita-web, adwaita-fonts, adwaita-icons) |
 | GJS infrastructure packages | 4 (unit, utils, runtime, types) |
 | Build tools | 9 (infra/) |
-| Total test cases | 10,500+ (unit) + 706+ (integration: 185 webtorrent + 112 socket.io + 156 streamx + 131 autobahn + 108 mcp-typescript-sdk + 14 mcp-inspector-cli) |
+| Total test cases | 10,517+ (unit) + 706+ (integration: 185 webtorrent + 112 socket.io + 156 streamx + 131 autobahn + 108 mcp-typescript-sdk + 14 mcp-inspector-cli) |
 | Spec files | 110+ |
 | Integration test suites | 6 (webtorrent, socket.io, streamx, autobahn, mcp-typescript-sdk, mcp-inspector-cli) |
 | Showcases | 6 (Canvas2D Fireworks, Three.js Teapot, Three.js Pixel Post-Processing, Excalibur Jelly Jumper, Express Webserver, Adwaita Package Builder) |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-04-29 (`@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams via `GioInputStreamReadable`; Hono REST API example now passes on GJS (4/4 tests); `@gjsify/unit` runtime detection fixed to check `process.versions.gjs` before `globalThis.document`.)
+> Last updated: 2026-04-29 (`@gjsify/fs` adds `cpSync`/`cp`/`promises.cp` via Gio.File.copy + enumerate_children (11 tests, 521 total); `@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams via `GioInputStreamReadable`; Hono REST API example now passes on GJS; `@gjsify/unit` runtime detection fixed.)
 
 ## Summary
 
@@ -20,7 +20,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | Build/Infra Tools | 9 | 9 | — | — |
 | Integration test suites | 4 | 4 (webtorrent, socket.io, streamx, autobahn) | — | — |
 
-**Test coverage:** 10,500+ test cases in 110+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 42/43). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
+**Test coverage:** 10,550+ test cases in 111+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 42/43). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
 
 ---
 
@@ -41,7 +41,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | **diagnostics_channel** | — | 137 | Channel, TracingChannel, subscribe/unsubscribe |
 | **dns** | Gio, GLib | 121 (2 specs) | lookup, resolve4/6, reverse via Gio.Resolver + dns/promises |
 | **events** | — | 255+ (2 specs) | EventEmitter, once, on, listenerCount, setMaxListeners, errorMonitor, captureRejections, getEventListeners, prependListener, eventNames, rawListeners, Symbol events, async iterator, **makeCallable** (`.call(this)` + `util.inherits` CJS compat) |
-| **fs** | Gio, GLib | 465 (9 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
+| **fs** | Gio, GLib | 521 (10 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/cp/cpSync/promises.cp/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
 | **globals** | — | 221 | process, Buffer, structuredClone (full polyfill), TextEncoder/Decoder, atob/btoa, URL, setImmediate. Root export is pure; side effects live in `@gjsify/node-globals/register`. Users opt in via the `--globals` CLI flag (default-wired in the `@gjsify/create-app` template) or an explicit `import '@gjsify/node-globals/register'`. |
 | **http** | Soup 3.0, Gio, GLib | 1038 (7 specs) | Server (Soup.Server, **chunked streaming**, **upgrade event**, **`SoupMessageLifecycle` per-request helper**: GC guard for in-flight Soup messages + `'wrote-chunk'`-driven re-unpause + `'disconnected'`/`'finished'` → req/res `'close'`/`'aborted'` translation), ClientRequest (Soup.Session, **timeout events**, **auth option**, **signal option**), IncomingMessage (**timeout events**), ServerResponse (**setTimeout**, chunked transfer), OutgoingMessage, **`ServerRequestSocket`** (Duplex-typed `req.socket` with working `pause`/`resume`/`destroySoon` for Hono backpressure), STATUS_CODES, METHODS, Agent (**constructor options**, keepAlive, maxSockets, scheduling), validateHeaderName/Value, maxHeaderSize, round-trip on GJS. **Known limitation:** libsoup stops polling the input stream while a server message is paused, so `'disconnected'` does not fire for long-poll/SSE clients that hang up — see "Upstream GJS Patch Candidates" |
 | **https** | Soup 3.0 | 99 | Agent (defaultPort, protocol, maxSockets, destroy, options, keepAlive, scheduling), globalAgent, request (URL/options/headers/timeout/methods), get, createServer, Server |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-04-28 (`@gjsify/unit` extended with `browserSignalDone` so browser bundles signal test completion to Playwright; `tests/browser` promoted to a yarn workspace; all 13 browser test bundles verified green in Firefox (11 web + dom-elements + canvas2d-core); SQLite todo store example cross-validated on GJS and Node.js.)
+> Last updated: 2026-04-29 (`@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams via `GioInputStreamReadable`; Hono REST API example now passes on GJS (4/4 tests); `@gjsify/unit` runtime detection fixed to check `process.versions.gjs` before `globalThis.document`.)
 
 ## Summary
 
@@ -33,7 +33,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | **assert** | — | 117 | AssertionError, deepEqual, throws, strict mode |
 | **async_hooks** | — | 130 | AsyncLocalStorage (run, enterWith, snapshot, exit), AsyncResource (bind, runInAsyncScope, triggerAsyncId), createHook |
 | **buffer** | — | 317 | Buffer via Blob/atob/btoa, alloc, from, concat, encodings, fill, indexOf/lastIndexOf, slice/subarray, copy, int/float read/write, swap16/32/64, equals, compare |
-| **child_process** | Gio, GLib | 110 | exec/execSync, execFile/execFileSync, spawn/spawnSync via Gio.Subprocess; cwd/env via Gio.SubprocessLauncher |
+| **child_process** | Gio, GLib | 116 | exec/execSync, execFile/execFileSync, spawn/spawnSync via Gio.Subprocess; cwd/env via Gio.SubprocessLauncher; `spawn()` now provides `child.stdout`/`child.stderr` as Readable streams (GioInputStreamReadable) |
 | **console** | — | 124 | Console class with stream support, format specifiers, table, dir, time/timeLog, count, group, assert, trace, stdout/stderr routing |
 | **constants** | — | 27 | Flattened re-export of `os.constants` (errno, signals, priority, dlopen) + `fs.constants` + legacy crypto constants — the deprecated Node `constants` alias |
 | **crypto** | GLib | 571 (13 specs) | Hash (SHA256/384/512, MD5, SHA1, known vectors), Hmac (extended edge cases), randomBytes/UUID/Int (v4 format, uniqueness), PBKDF2, HKDF, scrypt, AES (CBC/CTR/ECB/GCM), DH, ECDH, Sign/Verify, publicEncrypt/privateDecrypt, **KeyObject (JWK import/export)**, **X509Certificate**, timingSafeEqual, getHashes/getCiphers/getCurves, constants |
@@ -393,7 +393,7 @@ Not yet implemented (but potentially relevant for GJS projects):
    |---------|----------|-----------------|--------|
    | ~~**Static file server**~~✓ | net | http, fs, path, stream, zlib | `examples/net/static-file-server` |
    | ~~**SSE chat**~~✓ | net | http, events, fs, SSE protocol | `examples/net/sse-chat` |
-   | ~~**Hono REST API**~~✓ | net | hono, http, JSON CRUD | `examples/net/hono-rest` (GJS WIP) |
+   | ~~**Hono REST API**~~✓ | net | hono, http, JSON CRUD | `examples/node/net-hono-rest` (Node + GJS ✓) |
    | ~~**CLI file search**~~✓ | cli | fs, path, readline, process | `examples/cli/file-search` |
    | ~~**DNS lookup tool**~~✓ | cli | dns, net, readline | `examples/cli/dns-lookup` |
    | ~~**Worker pool**~~✓ | cli | worker_threads, events, crypto | `examples/cli/worker-pool` |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-04-29 (`@gjsify/fs` adds `cpSync`/`cp`/`promises.cp` via Gio.File.copy + enumerate_children (11 tests, 521 total); `@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams via `GioInputStreamReadable`; Hono REST API example now passes on GJS; `@gjsify/unit` runtime detection fixed.)
+> Last updated: 2026-04-29 (`@gjsify/fs` adds `cpSync`/`cp`/`promises.cp` + `Dir`/`opendir`/`opendirSync`/`promises.opendir` via Gio (30 new tests, 540 total); `@gjsify/child_process` `spawn()` now sets `child.stdout`/`child.stderr` as Readable streams; `@gjsify/unit` runtime detection fixed.)
 
 ## Summary
 
@@ -20,7 +20,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | Build/Infra Tools | 9 | 9 | — | — |
 | Integration test suites | 4 | 4 (webtorrent, socket.io, streamx, autobahn) | — | — |
 
-**Test coverage:** 10,550+ test cases in 111+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 42/43). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
+**Test coverage:** 10,570+ test cases in 112+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 42/43). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
 
 ---
 
@@ -41,7 +41,7 @@ The project comprises **42 Node.js packages** (+1 meta), **19 Web API packages**
 | **diagnostics_channel** | — | 137 | Channel, TracingChannel, subscribe/unsubscribe |
 | **dns** | Gio, GLib | 121 (2 specs) | lookup, resolve4/6, reverse via Gio.Resolver + dns/promises |
 | **events** | — | 255+ (2 specs) | EventEmitter, once, on, listenerCount, setMaxListeners, errorMonitor, captureRejections, getEventListeners, prependListener, eventNames, rawListeners, Symbol events, async iterator, **makeCallable** (`.call(this)` + `util.inherits` CJS compat) |
-| **fs** | Gio, GLib | 521 (10 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/cp/cpSync/promises.cp/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
+| **fs** | Gio, GLib | 540 (11 specs) | sync, callback, promises, streams, FSWatcher, symlinks, FileHandle (read/write/truncate/writeFile/stat/readFile/appendFile), access/copyFile/cp/cpSync/promises.cp/rename/lstat, mkdir/rmdir/mkdtemp/chmod/truncate, **Dir/opendir/opendirSync/promises.opendir** (async iterator, read/readSync, close/closeSync), ENOENT error mapping, fs.constants (O_RDONLY/WRONLY/RDWR/CREAT/EXCL/S_IFMT/S_IFREG), readdir options (withFileTypes, encoding), appendFileSync, mkdirSync recursive edge cases |
 | **globals** | — | 221 | process, Buffer, structuredClone (full polyfill), TextEncoder/Decoder, atob/btoa, URL, setImmediate. Root export is pure; side effects live in `@gjsify/node-globals/register`. Users opt in via the `--globals` CLI flag (default-wired in the `@gjsify/create-app` template) or an explicit `import '@gjsify/node-globals/register'`. |
 | **http** | Soup 3.0, Gio, GLib | 1038 (7 specs) | Server (Soup.Server, **chunked streaming**, **upgrade event**, **`SoupMessageLifecycle` per-request helper**: GC guard for in-flight Soup messages + `'wrote-chunk'`-driven re-unpause + `'disconnected'`/`'finished'` → req/res `'close'`/`'aborted'` translation), ClientRequest (Soup.Session, **timeout events**, **auth option**, **signal option**), IncomingMessage (**timeout events**), ServerResponse (**setTimeout**, chunked transfer), OutgoingMessage, **`ServerRequestSocket`** (Duplex-typed `req.socket` with working `pause`/`resume`/`destroySoon` for Hono backpressure), STATUS_CODES, METHODS, Agent (**constructor options**, keepAlive, maxSockets, scheduling), validateHeaderName/Value, maxHeaderSize, round-trip on GJS. **Known limitation:** libsoup stops polling the input stream while a server message is paused, so `'disconnected'` does not fire for long-poll/SSE clients that hang up — see "Upstream GJS Patch Candidates" |
 | **https** | Soup 3.0 | 99 | Agent (defaultPort, protocol, maxSockets, destroy, options, keepAlive, scheduling), globalAgent, request (URL/options/headers/timeout/methods), get, createServer, Server |

--- a/examples/node/net-hono-rest/src/index.spec.ts
+++ b/examples/node/net-hono-rest/src/index.spec.ts
@@ -4,20 +4,30 @@
 import { describe, it, expect } from '@gjsify/unit';
 import { spawn } from 'node:child_process';
 import { get as httpGet, request as httpRequest } from 'node:http';
-import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ChildProcess } from 'node:child_process';
 import type { IncomingMessage } from 'node:http';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = 13002;
 
+// Resolve the server bundle and gjsify binary relative to this bundle's URL,
+// matching the pattern used in tests/integration/mcp-inspector-cli/src/helpers.ts.
+// The test bundle lives at examples/node/net-hono-rest/test.{gjs,node}.mjs.
+const _here = fileURLToPath(import.meta.url);
+const _distUrl = new URL('dist/', `file://${_here}`);
+const SERVER_BUNDLES = {
+  gjs: fileURLToPath(new URL('index.gjs.js', _distUrl)),
+  node: fileURLToPath(new URL('index.node.mjs', _distUrl)),
+} as const;
+
+// Full path to gjsify binary (auto-sets LD_LIBRARY_PATH / GI_TYPELIB_PATH for prebuilds).
+const GJSIFY_BIN = fileURLToPath(new URL('../../../node_modules/.bin/gjsify', `file://${_here}`));
+
 function getServerCmd(): { cmd: string; args: string[] } {
-  const isGJS = typeof (globalThis as any).imports?.gi !== 'undefined';
-  const dist = isGJS ? 'dist/index.gjs.js' : 'dist/index.node.mjs';
+  const isGJS = typeof (globalThis as any).process?.versions?.gjs === 'string';
   return isGJS
-    ? { cmd: 'gjs', args: ['-m', join(__dirname, dist)] }
-    : { cmd: 'node', args: [join(__dirname, dist)] };
+    ? { cmd: GJSIFY_BIN, args: ['run', SERVER_BUNDLES.gjs] }
+    : { cmd: 'node', args: [SERVER_BUNDLES.node] };
 }
 
 function startServer(): Promise<{ proc: ChildProcess; kill: () => void }> {
@@ -27,20 +37,40 @@ function startServer(): Promise<{ proc: ChildProcess; kill: () => void }> {
       env: { ...process.env, PORT: String(PORT) },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    let stdout = '';
-    const timeout = setTimeout(() => {
-      proc.kill('SIGTERM');
-      reject(new Error(`Server startup timeout. stdout: ${stdout}`));
-    }, 15000);
 
-    proc.stdout!.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
-      if (/running at|listening/i.test(stdout)) {
-        clearTimeout(timeout);
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    proc.stdout!.on('data', (b: Buffer) => { stdoutBuf += b.toString('utf8'); });
+    proc.stderr!.on('data', (b: Buffer) => { stderrBuf += b.toString('utf8'); });
+
+    const timeoutMs = 15000;
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error(
+        `Server did not log "running at" within ${timeoutMs}ms.\nstdout: ${stdoutBuf}\nstderr: ${stderrBuf}`,
+      ));
+    }, timeoutMs);
+
+    // Poll every 50 ms so the GLib event loop has time to process I/O events.
+    const check = setInterval(() => {
+      if (/running at|listening/i.test(stdoutBuf)) {
+        clearTimeout(timer);
+        clearInterval(check);
         resolve({ proc, kill: () => proc.kill('SIGTERM') });
+      } else if ((proc as any).exitCode !== null) {
+        clearTimeout(timer);
+        clearInterval(check);
+        reject(new Error(
+          `Server exited before listening.\nstdout: ${stdoutBuf}\nstderr: ${stderrBuf}`,
+        ));
       }
+    }, 50);
+
+    proc.on('error', (e) => {
+      clearTimeout(timer);
+      clearInterval(check);
+      reject(e);
     });
-    proc.on('error', (e) => { clearTimeout(timeout); reject(e); });
   });
 }
 

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -106,7 +106,10 @@ export type Runtime = 'Gjs' | 'Deno' | 'Node.js' | 'Unknown' | 'Browser' | 'Disp
 // Makes this work on Gjs and Node.js
 // In browsers, globalThis.print is window.print() (the print dialog), not text output.
 // Use console.log in browser contexts to avoid triggering print dialogs.
-export const print = (typeof (globalThis as any).document !== 'undefined')
+// GJS check takes priority: @gjsify/dom-elements can set globalThis.document on GJS,
+// which would otherwise cause a false-positive browser detection.
+const _isGjsProcess = typeof (globalThis as any).process?.versions?.gjs === 'string';
+export const print = (!_isGjsProcess && typeof (globalThis as any).document !== 'undefined')
     ? console.log
     : (globalThis.print || console.log);
 
@@ -642,36 +645,40 @@ const getRuntime = async () => {
 		return runtime;
 	}
 
-	// Check browser before attempting dynamic import('process') — dynamic imports
-	// are NOT aliased by esbuild, so import('process') throws in the browser,
-	// which previously caused the catch block to set runtime='Unknown' before
-	// reaching the document check.
-	if (typeof (globalThis as any).document !== 'undefined') {
-		runtime = 'Browser';
-		return runtime;
-	}
-
 	if(globalThis.Deno?.version?.deno) {
 		return 'Deno ' + globalThis.Deno?.version?.deno;
-	} else {
+	}
+
+	// Check process (GJS / Node) BEFORE document: @gjsify/dom-elements can set
+	// globalThis.document on GJS, which would otherwise cause a false browser-positive.
+	// dynamic import('process') throws in the browser so this stays safe there.
+	{
 		let process = globalThis.process;
 
 		if(!process) {
 			try {
 				process = await import('process');
-			} catch (error) {
-				console.error(error)
-				console.warn(error.message);
-				runtime = 'Unknown'
+			} catch (_e) {
+				// browser or runtime without process — fall through to document check
 			}
 		}
 
 		if(process?.versions?.gjs) {
 			runtime = 'Gjs ' + process.versions.gjs;
+			return runtime;
 		} else if (process?.versions?.node) {
 			runtime = 'Node.js ' + process.versions.node;
+			return runtime;
 		}
 	}
+
+	// Only treat as Browser after confirming no Node/GJS process is present.
+	// dynamic imports throw in browsers, so we are safely past that path here.
+	if (typeof (globalThis as any).document !== 'undefined') {
+		runtime = 'Browser';
+		return runtime;
+	}
+
 	return runtime || 'Unknown';
 }
 

--- a/packages/node/child_process/src/index.spec.ts
+++ b/packages/node/child_process/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from '@gjsify/unit';
 // Testing the child_process module API — all commands are hardcoded safe literals
-import { execSync, execFileSync, spawnSync, exec, execFile } from 'node:child_process';
+import { execSync, execFileSync, spawnSync, exec, execFile, spawn } from 'node:child_process';
 
 // Ported from refs/node/test/parallel/test-child-process-exec*.js
 // Original: MIT license, Node.js contributors
@@ -678,6 +678,42 @@ export default async () => {
 			const lines = (result as string).trim().split('\n');
 			expect(lines[0]).toBe('combined');
 			expect(lines[1]).toBe('/tmp');
+		});
+	});
+
+	// ==================== spawn() with streaming stdout/stderr ====================
+
+	await describe('child_process.spawn stdout/stderr streaming', async () => {
+		await it('spawn() sets proc.stdout as a Readable', async () => {
+			const proc = spawn('echo', ['streaming_test']);
+			expect(proc.stdout).toBeDefined();
+			expect(typeof proc.stdout!.on).toBe('function');
+		});
+
+		await it('spawn() stdout emits data event with subprocess output', async () => {
+			const output = await new Promise<string>((resolve, reject) => {
+				const proc = spawn('echo', ['hello_stream']);
+				expect(proc.stdout).toBeDefined();
+				let buf = '';
+				proc.stdout!.on('data', (chunk: Buffer) => { buf += chunk.toString(); });
+				proc.stdout!.on('end', () => resolve(buf.trim()));
+				proc.on('error', reject);
+				setTimeout(() => reject(new Error('spawn stdout timeout')), 5000);
+			});
+			expect(output).toBe('hello_stream');
+		});
+
+		await it('spawn() stderr emits data event with subprocess stderr output', async () => {
+			const output = await new Promise<string>((resolve, reject) => {
+				const proc = spawn('sh', ['-c', 'echo err_stream >&2']);
+				expect(proc.stderr).toBeDefined();
+				let buf = '';
+				proc.stderr!.on('data', (chunk: Buffer) => { buf += chunk.toString(); });
+				proc.stderr!.on('end', () => resolve(buf.trim()));
+				proc.on('error', reject);
+				setTimeout(() => reject(new Error('spawn stderr timeout')), 5000);
+			});
+			expect(output).toBe('err_stream');
 		});
 	});
 };

--- a/packages/node/child_process/src/index.ts
+++ b/packages/node/child_process/src/index.ts
@@ -6,8 +6,49 @@ import Gio from '@girs/gio-2.0';
 import GLib from '@girs/glib-2.0';
 import { EventEmitter } from 'node:events';
 import { Buffer } from 'node:buffer';
-import type { Readable, Writable } from 'node:stream';
+import { Readable } from 'node:stream';
+import type { Writable } from 'node:stream';
 import { gbytesToUint8Array, deferEmit } from '@gjsify/utils';
+
+// Wraps a Gio.InputStream as a Node.js Readable so proc.stdout/stderr work
+// with standard stream consumers (.on('data', ...), pipe, async iteration).
+class GioInputStreamReadable extends Readable {
+  private _stream: Gio.InputStream;
+  private _cancellable = new Gio.Cancellable();
+
+  constructor(stream: Gio.InputStream) {
+    super();
+    this._stream = stream;
+  }
+
+  override _read(size: number): void {
+    this._stream.read_bytes_async(
+      Math.max(size, 4096),
+      GLib.PRIORITY_DEFAULT,
+      this._cancellable,
+      (_source, result) => {
+        try {
+          const gbytes = this._stream.read_bytes_finish(result);
+          const data = gbytes.get_data();
+          if (!data || data.length === 0) {
+            this.push(null);
+          } else {
+            this.push(Buffer.from(data));
+          }
+        } catch (err) {
+          if (!this._cancellable.is_cancelled()) {
+            this.destroy(err as Error);
+          }
+        }
+      },
+    );
+  }
+
+  override _destroy(error: Error | null, callback: (err?: Error | null) => void): void {
+    this._cancellable.cancel();
+    callback(error);
+  }
+}
 
 interface ExecError extends Error {
   status?: number;
@@ -353,6 +394,12 @@ export function spawn(command: string, args?: string[], options?: SpawnOptions):
     const proc = _spawnSubprocess(argv, flags, options);
     child._setSubprocess(proc);
     _activeProcesses.add(child);
+
+    const stdoutPipe = proc.get_stdout_pipe();
+    if (stdoutPipe) child.stdout = new GioInputStreamReadable(stdoutPipe);
+
+    const stderrPipe = proc.get_stderr_pipe();
+    if (stderrPipe) child.stderr = new GioInputStreamReadable(stderrPipe);
 
     proc.wait_async(null, (_source: Gio.Subprocess | null, result: Gio.AsyncResult) => {
       try {

--- a/packages/node/fs/src/cp.spec.ts
+++ b/packages/node/fs/src/cp.spec.ts
@@ -1,0 +1,181 @@
+// Ported from refs/bun/test/js/node/fs/cp.test.ts and
+// refs/node-test/parallel/test-fs-cp-sync-*.mjs
+// Original: MIT, Oven & contributors / Node.js contributors.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { cpSync, promises, existsSync, mkdirSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'gjsify-cp-'));
+}
+
+export default async () => {
+  await describe('fs.cpSync', async () => {
+    await it('copies a single file', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.txt'), 'hello');
+
+      cpSync(join(tmp, 'a.txt'), join(tmp, 'b.txt'));
+
+      expect(readFileSync(join(tmp, 'b.txt'), 'utf8')).toBe('hello');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('throws EISDIR when src is directory and recursive is false', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src'));
+
+      let threw = false;
+      try {
+        cpSync(join(tmp, 'src'), join(tmp, 'dest'));
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ERR_FS_EISDIR');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('recursively copies a directory tree', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src', 'sub'), { recursive: true });
+      writeFileSync(join(tmp, 'src', 'a.txt'), 'a');
+      writeFileSync(join(tmp, 'src', 'sub', 'b.txt'), 'b');
+
+      cpSync(join(tmp, 'src'), join(tmp, 'dst'), { recursive: true });
+
+      expect(readFileSync(join(tmp, 'dst', 'a.txt'), 'utf8')).toBe('a');
+      expect(readFileSync(join(tmp, 'dst', 'sub', 'b.txt'), 'utf8')).toBe('b');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('overwrites existing file by default (force=true)', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'src.txt'), 'new');
+      writeFileSync(join(tmp, 'dst.txt'), 'old');
+
+      cpSync(join(tmp, 'src.txt'), join(tmp, 'dst.txt'));
+
+      expect(readFileSync(join(tmp, 'dst.txt'), 'utf8')).toBe('new');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('does not overwrite when force=false', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'src.txt'), 'new');
+      writeFileSync(join(tmp, 'dst.txt'), 'old');
+
+      cpSync(join(tmp, 'src.txt'), join(tmp, 'dst.txt'), { force: false });
+
+      expect(readFileSync(join(tmp, 'dst.txt'), 'utf8')).toBe('old');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('throws EEXIST when force=false and errorOnExist=true', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'src.txt'), 'new');
+      writeFileSync(join(tmp, 'dst.txt'), 'old');
+
+      let threw = false;
+      try {
+        cpSync(join(tmp, 'src.txt'), join(tmp, 'dst.txt'), { force: false, errorOnExist: true });
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ERR_FS_CP_EEXIST');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('applies filter function — skips excluded entries', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src'));
+      writeFileSync(join(tmp, 'src', 'keep.txt'), 'keep');
+      writeFileSync(join(tmp, 'src', 'skip.log'), 'skip');
+
+      cpSync(join(tmp, 'src'), join(tmp, 'dst'), {
+        recursive: true,
+        filter: (_src, _dst) => !_src.endsWith('.log'),
+      });
+
+      expect(existsSync(join(tmp, 'dst', 'keep.txt'))).toBe(true);
+      expect(existsSync(join(tmp, 'dst', 'skip.log'))).toBe(false);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('throws ENOENT when src does not exist', async () => {
+      const tmp = makeTmp();
+
+      let threw = false;
+      try {
+        cpSync(join(tmp, 'nonexistent.txt'), join(tmp, 'dst.txt'));
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ENOENT');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+
+  await describe('fs.promises.cp', async () => {
+    await it('copies a single file', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.txt'), 'hello');
+
+      await promises.cp(join(tmp, 'a.txt'), join(tmp, 'b.txt'));
+
+      expect(readFileSync(join(tmp, 'b.txt'), 'utf8')).toBe('hello');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('throws EISDIR when src is directory and recursive is false', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src'));
+
+      let threw = false;
+      try {
+        await promises.cp(join(tmp, 'src'), join(tmp, 'dest'));
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ERR_FS_EISDIR');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('recursively copies a directory tree', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src', 'sub'), { recursive: true });
+      writeFileSync(join(tmp, 'src', 'a.txt'), 'a');
+      writeFileSync(join(tmp, 'src', 'sub', 'b.txt'), 'b');
+
+      await promises.cp(join(tmp, 'src'), join(tmp, 'dst'), { recursive: true });
+
+      expect(readFileSync(join(tmp, 'dst', 'a.txt'), 'utf8')).toBe('a');
+      expect(readFileSync(join(tmp, 'dst', 'sub', 'b.txt'), 'utf8')).toBe('b');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('applies async filter function', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src'));
+      writeFileSync(join(tmp, 'src', 'keep.ts'), 'ts');
+      writeFileSync(join(tmp, 'src', 'skip.js'), 'js');
+
+      await promises.cp(join(tmp, 'src'), join(tmp, 'dst'), {
+        recursive: true,
+        filter: async (_src, _dst) => {
+          return !_src.endsWith('.js');
+        },
+      });
+
+      expect(existsSync(join(tmp, 'dst', 'keep.ts'))).toBe(true);
+      expect(existsSync(join(tmp, 'dst', 'skip.js'))).toBe(false);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+};

--- a/packages/node/fs/src/cp.ts
+++ b/packages/node/fs/src/cp.ts
@@ -1,0 +1,328 @@
+// fs.cp / fs.cpSync / fs.promises.cp — recursive copy
+// Reference: Node.js lib/internal/fs/cpSync.js
+// Reimplemented for GJS using Gio.File synchronous operations
+
+import Gio from '@girs/gio-2.0';
+import { join } from 'node:path';
+import { normalizePath } from './utils.js';
+import { createNodeError } from './errors.js';
+
+import type { PathLike } from 'node:fs';
+
+export interface CpSyncOptions {
+  dereference?: boolean;
+  errorOnExist?: boolean;
+  filter?: (src: string, dest: string) => boolean;
+  force?: boolean;
+  mode?: number;
+  preserveTimestamps?: boolean;
+  recursive?: boolean;
+  verbatimSymlinks?: boolean;
+}
+
+export interface CpOptions extends Omit<CpSyncOptions, 'filter'> {
+  filter?: (src: string, dest: string) => boolean | Promise<boolean>;
+}
+
+function makeEEXIST(destStr: string): NodeJS.ErrnoException {
+  const e: NodeJS.ErrnoException = new Error(`ERR_FS_CP_EEXIST: file already exists, copyfile '${destStr}'`);
+  e.code = 'ERR_FS_CP_EEXIST';
+  e.syscall = 'copyfile';
+  e.path = destStr;
+  return e;
+}
+
+function makeEISDIR(srcStr: string): NodeJS.ErrnoException {
+  const e: NodeJS.ErrnoException = new Error(`ERR_FS_EISDIR: illegal operation on a directory, copyfile '${srcStr}'`);
+  e.code = 'ERR_FS_EISDIR';
+  e.syscall = 'copyfile';
+  e.path = srcStr;
+  return e;
+}
+
+function makeENOTDIR(srcStr: string, destStr: string): NodeJS.ErrnoException {
+  const e: NodeJS.ErrnoException = new Error(`ENOTDIR: not a directory, copyfile '${srcStr}' -> '${destStr}'`);
+  e.code = 'ENOTDIR';
+  e.syscall = 'copyfile';
+  e.path = srcStr;
+  (e as any).dest = destStr;
+  return e;
+}
+
+function makeSYMLINKLOOP(srcStr: string, destStr: string): NodeJS.ErrnoException {
+  const e: NodeJS.ErrnoException = new Error(`ELOOP: too many levels of symbolic links, copyfile '${srcStr}' -> '${destStr}'`);
+  e.code = 'ELOOP';
+  e.syscall = 'copyfile';
+  e.path = srcStr;
+  (e as any).dest = destStr;
+  return e;
+}
+
+function queryCopyFlags(opts: CpSyncOptions | CpOptions): Gio.FileCopyFlags {
+  const force = opts.force ?? true;
+  let flags = Gio.FileCopyFlags.NONE;
+  if (force) flags |= Gio.FileCopyFlags.OVERWRITE;
+  if (opts.preserveTimestamps) flags |= Gio.FileCopyFlags.TARGET_DEFAULT_MODIFIED_TIME;
+  if (!opts.dereference) flags |= Gio.FileCopyFlags.NOFOLLOW_SYMLINKS;
+  return flags;
+}
+
+function copyOneSyncFile(srcFile: Gio.File, destFile: Gio.File, srcStr: string, destStr: string, opts: CpSyncOptions | CpOptions): void {
+  const force = opts.force ?? true;
+
+  // Check dest is not a directory
+  try {
+    const destInfo = destFile.query_info('standard::type', Gio.FileQueryInfoFlags.NONE, null);
+    if (destInfo.get_file_type() === Gio.FileType.DIRECTORY) {
+      throw makeENOTDIR(srcStr, destStr);
+    }
+    if (!force) {
+      if (opts.errorOnExist) throw makeEEXIST(destStr);
+      return; // silent skip when force=false and no errorOnExist
+    }
+  } catch (e: any) {
+    if (typeof e.code === 'string') throw e; // re-throw Node-style errors (string codes)
+    // Gio errors have numeric codes (e.g. NOT_FOUND=1) — dest doesn't exist, fine
+  }
+
+  const flags = queryCopyFlags(opts);
+  try {
+    srcFile.copy(destFile, flags, null, null);
+  } catch (err: unknown) {
+    throw createNodeError(err, 'copyfile', srcStr, destStr);
+  }
+}
+
+function cpOneDirSync(srcFile: Gio.File, destFile: Gio.File, srcStr: string, destStr: string, opts: CpSyncOptions | CpOptions): void {
+  // Detect src ⊂ dest cycle (if dest path starts with srcStr + separator)
+  const sep = srcStr.endsWith('/') ? '' : '/';
+  if (destStr.startsWith(srcStr + sep) && destStr !== srcStr) {
+    throw makeSYMLINKLOOP(srcStr, destStr);
+  }
+
+  // Create dest directory if it doesn't exist
+  if (!destFile.query_exists(null)) {
+    try {
+      destFile.make_directory_with_parents(null);
+    } catch (err: unknown) {
+      throw createNodeError(err, 'mkdir', destStr);
+    }
+  } else {
+    // dest exists — must be a directory
+    try {
+      const destInfo = destFile.query_info('standard::type', Gio.FileQueryInfoFlags.NONE, null);
+      if (destInfo.get_file_type() !== Gio.FileType.DIRECTORY) {
+        throw makeENOTDIR(destStr, srcStr);
+      }
+    } catch (e: any) {
+      if (typeof e.code === 'string') throw e;
+    }
+  }
+
+  // Enumerate children
+  let enumerator: Gio.FileEnumerator;
+  try {
+    enumerator = srcFile.enumerate_children(
+      'standard::name,standard::type,standard::is-symlink',
+      opts.dereference ? Gio.FileQueryInfoFlags.NONE : Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    );
+  } catch (err: unknown) {
+    throw createNodeError(err, 'scandir', srcStr);
+  }
+
+  let childInfo = enumerator.next_file(null);
+  while (childInfo !== null) {
+    const name = childInfo.get_name();
+    const childSrc = join(srcStr, name);
+    const childDest = join(destStr, name);
+
+    const filter = (opts as CpSyncOptions).filter;
+    if (filter && !filter(childSrc, childDest)) {
+      childInfo = enumerator.next_file(null);
+      continue;
+    }
+
+    cpSyncInternal(childSrc, childDest, opts);
+    childInfo = enumerator.next_file(null);
+  }
+}
+
+function cpSyncInternal(srcStr: string, destStr: string, opts: CpSyncOptions | CpOptions): void {
+  const srcFile = Gio.File.new_for_path(srcStr);
+  const destFile = Gio.File.new_for_path(destStr);
+
+  let info: Gio.FileInfo;
+  try {
+    info = srcFile.query_info(
+      'standard::type,standard::is-symlink',
+      opts.dereference ? Gio.FileQueryInfoFlags.NONE : Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    );
+  } catch (err: unknown) {
+    throw createNodeError(err, 'stat', srcStr);
+  }
+
+  const type = info.get_file_type();
+
+  if (type === Gio.FileType.DIRECTORY) {
+    if (!opts.recursive) throw makeEISDIR(srcStr);
+    cpOneDirSync(srcFile, destFile, srcStr, destStr, opts);
+  } else {
+    copyOneSyncFile(srcFile, destFile, srcStr, destStr, opts);
+  }
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+export function cpSync(src: PathLike, dest: PathLike, options?: CpSyncOptions): void {
+  const srcStr = normalizePath(src);
+  const destStr = normalizePath(dest);
+  const opts: CpSyncOptions = options ?? {};
+
+  const srcFile = Gio.File.new_for_path(srcStr);
+
+  // Apply top-level filter before doing anything
+  const filter = opts.filter;
+  if (filter && !filter(srcStr, destStr)) return;
+
+  // Check src is a directory without recursive option
+  try {
+    const info = srcFile.query_info(
+      'standard::type',
+      opts.dereference ? Gio.FileQueryInfoFlags.NONE : Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    );
+    if (info.get_file_type() === Gio.FileType.DIRECTORY && !opts.recursive) {
+      throw makeEISDIR(srcStr);
+    }
+  } catch (e: any) {
+    if (typeof e.code === 'string') throw e;
+    throw createNodeError(e, 'stat', srcStr);
+  }
+
+  cpSyncInternal(srcStr, destStr, opts);
+}
+
+export function cp(
+  src: PathLike,
+  dest: PathLike,
+  options: CpOptions | ((err: NodeJS.ErrnoException | null) => void),
+  callback?: (err: NodeJS.ErrnoException | null) => void,
+): void {
+  let opts: CpOptions;
+  let cb: (err: NodeJS.ErrnoException | null) => void;
+
+  if (typeof options === 'function') {
+    cb = options;
+    opts = {};
+  } else {
+    cb = callback!;
+    opts = options;
+  }
+
+  const asyncFilter = opts.filter;
+  if (asyncFilter) {
+    // Wrap async filter through a sync-compatible adapter by running
+    // a mini async pipeline: resolve filter for each entry, then cpSync.
+    // For simplicity, resolve the top-level filter and then run cpSync
+    // with a synchronous shim. Full async recursive filtering uses the
+    // promise variant.
+    Promise.resolve(asyncFilter(normalizePath(src), normalizePath(dest))).then((include) => {
+      if (!include) { cb(null); return; }
+      try {
+        // For directories, we must run asynchronously through promises.cp
+        cpPromises(src, dest, opts).then(() => cb(null)).catch(cb);
+      } catch (e: any) {
+        cb(e);
+      }
+    }).catch(cb);
+    return;
+  }
+
+  // No async filter — use synchronous implementation on next tick
+  Promise.resolve().then(() => {
+    try {
+      cpSync(src, dest, opts as CpSyncOptions);
+      cb(null);
+    } catch (e: any) {
+      cb(e);
+    }
+  });
+}
+
+// ─── promises.cp ─────────────────────────────────────────────────────────────
+
+async function cpPromisesDir(srcStr: string, destStr: string, opts: CpOptions): Promise<void> {
+  const sep = srcStr.endsWith('/') ? '' : '/';
+  if (destStr.startsWith(srcStr + sep) && destStr !== srcStr) {
+    throw makeSYMLINKLOOP(srcStr, destStr);
+  }
+
+  const destFile = Gio.File.new_for_path(destStr);
+  if (!destFile.query_exists(null)) {
+    try {
+      destFile.make_directory_with_parents(null);
+    } catch (err: unknown) {
+      throw createNodeError(err, 'mkdir', destStr);
+    }
+  }
+
+  const srcFile = Gio.File.new_for_path(srcStr);
+  let enumerator: Gio.FileEnumerator;
+  try {
+    enumerator = srcFile.enumerate_children(
+      'standard::name,standard::type',
+      opts.dereference ? Gio.FileQueryInfoFlags.NONE : Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    );
+  } catch (err: unknown) {
+    throw createNodeError(err, 'scandir', srcStr);
+  }
+
+  let childInfo = enumerator.next_file(null);
+  while (childInfo !== null) {
+    const name = childInfo.get_name();
+    const childSrc = join(srcStr, name);
+    const childDest = join(destStr, name);
+
+    const filter = opts.filter;
+    if (filter) {
+      const include = await Promise.resolve(filter(childSrc, childDest));
+      if (!include) {
+        childInfo = enumerator.next_file(null);
+        continue;
+      }
+    }
+
+    await cpPromises(childSrc, childDest, opts);
+    childInfo = enumerator.next_file(null);
+  }
+}
+
+async function cpPromises(src: PathLike, dest: PathLike, opts: CpOptions = {}): Promise<void> {
+  const srcStr = normalizePath(src);
+  const destStr = normalizePath(dest);
+
+  const srcFile = Gio.File.new_for_path(srcStr);
+  let info: Gio.FileInfo;
+  try {
+    info = srcFile.query_info(
+      'standard::type',
+      opts.dereference ? Gio.FileQueryInfoFlags.NONE : Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    );
+  } catch (err: unknown) {
+    throw createNodeError(err, 'stat', srcStr);
+  }
+
+  if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+    if (!opts.recursive) throw makeEISDIR(srcStr);
+    await cpPromisesDir(srcStr, destStr, opts);
+  } else {
+    const destFile = Gio.File.new_for_path(destStr);
+    copyOneSyncFile(srcFile, destFile, srcStr, destStr, opts);
+  }
+}
+
+export { cpPromises as cpAsync };

--- a/packages/node/fs/src/dir.spec.ts
+++ b/packages/node/fs/src/dir.spec.ts
@@ -1,0 +1,204 @@
+// Ported from refs/bun/test/js/node/fs/dir.test.ts
+// Original: MIT, Oven & contributors.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+  Dir,
+  opendirSync,
+  opendir,
+  promises,
+  mkdirSync,
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'gjsify-dir-'));
+}
+
+export default async () => {
+  await describe('fs.opendirSync', async () => {
+    await it('returns a Dir instance', async () => {
+      const tmp = makeTmp();
+      const dir = opendirSync(tmp);
+      expect(dir).toBeDefined();
+      expect(dir instanceof Dir).toBe(true);
+      dir.closeSync();
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('dir.path reflects the opened path', async () => {
+      const tmp = makeTmp();
+      const dir = opendirSync(tmp);
+      expect(dir.path).toBe(tmp);
+      dir.closeSync();
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('readSync returns null on empty directory', async () => {
+      const tmp = makeTmp();
+      const dir = opendirSync(tmp);
+      const entry = dir.readSync();
+      expect(entry).toBeNull();
+      dir.closeSync();
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('readSync returns Dirent entries for directory contents', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.txt'), 'a');
+      writeFileSync(join(tmp, 'b.txt'), 'b');
+
+      const dir = opendirSync(tmp);
+      const names: string[] = [];
+      let entry = dir.readSync();
+      while (entry !== null) {
+        names.push(entry.name);
+        entry = dir.readSync();
+      }
+      dir.closeSync();
+
+      expect(names.sort()).toStrictEqual(['a.txt', 'b.txt']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('Dirent has correct type flags', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'file.txt'), 'x');
+      mkdirSync(join(tmp, 'subdir'));
+
+      const dir = opendirSync(tmp);
+      const entries: { name: string; isFile: boolean; isDirectory: boolean }[] = [];
+      let entry = dir.readSync();
+      while (entry !== null) {
+        entries.push({ name: entry.name, isFile: entry.isFile(), isDirectory: entry.isDirectory() });
+        entry = dir.readSync();
+      }
+      dir.closeSync();
+
+      entries.sort((a, b) => a.name.localeCompare(b.name));
+      expect(entries).toStrictEqual([
+        { name: 'file.txt', isFile: true, isDirectory: false },
+        { name: 'subdir', isFile: false, isDirectory: true },
+      ]);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('closeSync throws after close', async () => {
+      const tmp = makeTmp();
+      const dir = opendirSync(tmp);
+      dir.closeSync();
+
+      let threw = false;
+      try {
+        dir.closeSync();
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ERR_DIR_CLOSED');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('readSync throws after close', async () => {
+      const tmp = makeTmp();
+      const dir = opendirSync(tmp);
+      dir.closeSync();
+
+      let threw = false;
+      try {
+        dir.readSync();
+      } catch (e: any) {
+        threw = true;
+        expect(e.code).toBe('ERR_DIR_CLOSED');
+      }
+      expect(threw).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('read() returns Dirent or null asynchronously', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'hello.txt'), 'hi');
+
+      const dir = opendirSync(tmp);
+      const entry = await dir.read();
+      expect(entry).toBeDefined();
+      expect(entry!.name).toBe('hello.txt');
+
+      const next = await dir.read();
+      expect(next).toBeNull();
+      await dir.close();
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('[Symbol.asyncIterator] iterates all entries', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'x.ts'), '');
+      writeFileSync(join(tmp, 'y.ts'), '');
+
+      const dir = opendirSync(tmp);
+      const names: string[] = [];
+      for await (const entry of dir) {
+        names.push(entry.name);
+      }
+
+      expect(names.sort()).toStrictEqual(['x.ts', 'y.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+
+  await describe('fs.opendir (callback)', async () => {
+    await it('opens directory and returns Dir instance via callback', async () => {
+      const tmp = makeTmp();
+      await new Promise<void>((resolve, reject) => {
+        opendir(tmp, (err, dir) => {
+          if (err) return reject(err);
+          expect(dir instanceof Dir).toBe(true);
+          expect(dir.path).toBe(tmp);
+          dir.closeSync();
+          rmSync(tmp, { recursive: true, force: true });
+          resolve();
+        });
+      });
+    });
+
+    await it('throws if callback is not a function', async () => {
+      let threw = false;
+      try {
+        (opendir as any)('/tmp');
+      } catch (e: any) {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    });
+  });
+
+  await describe('fs.promises.opendir', async () => {
+    await it('opens directory and returns Dir instance', async () => {
+      const tmp = makeTmp();
+      const dir = await promises.opendir(tmp);
+      expect(dir instanceof Dir).toBe(true);
+      await dir.close();
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('async iterates directory entries', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'alpha.txt'), '');
+      writeFileSync(join(tmp, 'beta.txt'), '');
+
+      const dir = await promises.opendir(tmp);
+      const names: string[] = [];
+      for await (const entry of dir) {
+        names.push(entry.name);
+      }
+
+      expect(names.sort()).toStrictEqual(['alpha.txt', 'beta.txt']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+};

--- a/packages/node/fs/src/dir.ts
+++ b/packages/node/fs/src/dir.ts
@@ -1,0 +1,199 @@
+// Reference: Node.js lib/internal/fs/dir.js
+// Reimplemented for GJS using Gio.FileEnumerator
+
+import Gio from '@girs/gio-2.0';
+import GLib from '@girs/glib-2.0';
+import { normalizePath } from './utils.js';
+import { Dirent } from './dirent.js';
+import { createNodeError } from './errors.js';
+import type { PathLike } from 'node:fs';
+
+const DIR_ATTRS = 'standard::name,standard::type,standard::is-symlink,standard::size,standard::symlink-target,unix::uid,unix::gid,unix::mode,time::modified,time::access,time::created';
+
+export class Dir {
+  readonly path: string;
+  private _enumerator: Gio.FileEnumerator | null;
+  private _closed = false;
+
+  constructor(path: string, enumerator: Gio.FileEnumerator) {
+    this.path = path;
+    this._enumerator = enumerator;
+  }
+
+  private _assertOpen(): void {
+    if (this._closed) {
+      const err = new Error('Directory handle was closed') as NodeJS.ErrnoException;
+      err.code = 'ERR_DIR_CLOSED';
+      throw err;
+    }
+  }
+
+  readSync(): Dirent | null {
+    this._assertOpen();
+    try {
+      const info = this._enumerator!.next_file(null);
+      if (info === null) return null;
+      const name = info.get_name();
+      const fileType = info.get_file_type();
+      const childPath = this.path.endsWith('/') ? this.path + name : this.path + '/' + name;
+      return new Dirent(childPath, name, fileType);
+    } catch (err: unknown) {
+      throw createNodeError(err, 'readdir', this.path);
+    }
+  }
+
+  read(): Promise<Dirent | null>;
+  read(callback: (err: NodeJS.ErrnoException | null, dirent: Dirent | null) => void): void;
+  read(callback?: (err: NodeJS.ErrnoException | null, dirent: Dirent | null) => void): Promise<Dirent | null> | void {
+    if (callback !== undefined) {
+      if (typeof callback !== 'function') {
+        throw new TypeError('The "callback" argument must be of type function');
+      }
+      try {
+        this._assertOpen();
+        const dirent = this.readSync();
+        Promise.resolve().then(() => callback(null, dirent));
+      } catch (err: unknown) {
+        Promise.resolve().then(() => callback(err as NodeJS.ErrnoException, null));
+      }
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        this._assertOpen();
+        resolve(this.readSync());
+      } catch (err: unknown) {
+        reject(err);
+      }
+    });
+  }
+
+  closeSync(): void {
+    this._assertOpen();
+    this._closed = true;
+    try {
+      this._enumerator!.close(null);
+    } catch {
+      // ignore close errors
+    }
+    this._enumerator = null;
+  }
+
+  close(): Promise<void>;
+  close(callback: (err: NodeJS.ErrnoException | null) => void): void;
+  close(callback?: (err: NodeJS.ErrnoException | null) => void): Promise<void> | void {
+    if (callback !== undefined) {
+      if (typeof callback !== 'function') {
+        throw new TypeError('The "callback" argument must be of type function');
+      }
+      try {
+        this.closeSync();
+        Promise.resolve().then(() => callback(null));
+      } catch (err: unknown) {
+        Promise.resolve().then(() => callback(err as NodeJS.ErrnoException));
+      }
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.closeSync();
+        resolve();
+      } catch (err: unknown) {
+        reject(err);
+      }
+    });
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<Dirent> {
+    try {
+      while (true) {
+        const dirent = await this.read();
+        if (dirent === null) break;
+        yield dirent;
+      }
+    } finally {
+      if (!this._closed) {
+        await this.close();
+      }
+    }
+  }
+}
+
+function _openDir(pathStr: string): Dir {
+  const file = Gio.File.new_for_path(pathStr);
+  let enumerator: Gio.FileEnumerator;
+  try {
+    enumerator = file.enumerate_children(DIR_ATTRS, Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null);
+  } catch (err: unknown) {
+    throw createNodeError(err, 'opendir', pathStr);
+  }
+  return new Dir(pathStr, enumerator);
+}
+
+export function opendirSync(path: PathLike): Dir {
+  return _openDir(normalizePath(path));
+}
+
+export function opendir(
+  path: PathLike,
+  callback: (err: NodeJS.ErrnoException | null, dir: Dir) => void,
+): void;
+export function opendir(
+  path: PathLike,
+  options: { encoding?: BufferEncoding | null; bufferSize?: number; recursive?: boolean },
+  callback: (err: NodeJS.ErrnoException | null, dir: Dir) => void,
+): void;
+export function opendir(
+  path: PathLike,
+  optionsOrCallback:
+    | { encoding?: BufferEncoding | null; bufferSize?: number; recursive?: boolean }
+    | ((err: NodeJS.ErrnoException | null, dir: Dir) => void),
+  callback?: (err: NodeJS.ErrnoException | null, dir: Dir) => void,
+): void {
+  let cb: (err: NodeJS.ErrnoException | null, dir: Dir) => void;
+  if (typeof optionsOrCallback === 'function') {
+    cb = optionsOrCallback;
+  } else {
+    cb = callback!;
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('The "callback" argument must be of type function');
+  }
+
+  Promise.resolve().then(() => {
+    try {
+      const dir = opendirSync(path);
+      cb(null, dir);
+    } catch (err: unknown) {
+      cb(err as NodeJS.ErrnoException, null as unknown as Dir);
+    }
+  });
+}
+
+// promises.opendir
+export async function opendirAsync(
+  path: PathLike,
+  _options?: { encoding?: BufferEncoding | null; bufferSize?: number; recursive?: boolean },
+): Promise<Dir> {
+  return new Promise<Dir>((resolve, reject) => {
+    const pathStr = normalizePath(path);
+    const file = Gio.File.new_for_path(pathStr);
+    file.enumerate_children_async(
+      DIR_ATTRS,
+      Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      GLib.PRIORITY_DEFAULT,
+      null,
+      (_source: unknown, result: Gio.AsyncResult) => {
+        try {
+          const enumerator = file.enumerate_children_finish(result);
+          resolve(new Dir(pathStr, enumerator));
+        } catch (err: unknown) {
+          reject(createNodeError(err, 'opendir', pathStr));
+        }
+      },
+    );
+  });
+}

--- a/packages/node/fs/src/glob.spec.ts
+++ b/packages/node/fs/src/glob.spec.ts
@@ -1,0 +1,201 @@
+// Ported from refs/bun/test/js/node/fs/glob.test.ts
+// Original: MIT, Oven & contributors.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+  globSync,
+  glob,
+  promises,
+  mkdirSync,
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function makeTmp(): string {
+  return mkdtempSync(join(tmpdir(), 'gjsify-glob-'));
+}
+
+export default async () => {
+  await describe('fs.globSync', async () => {
+    await it('matches *.ts files in flat directory', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.ts'), '');
+      writeFileSync(join(tmp, 'c.txt'), '');
+
+      const results = globSync('*.ts', { cwd: tmp });
+      expect(results.sort()).toStrictEqual(['a.ts', 'b.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('matches **/*.ts recursively', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'sub'));
+      writeFileSync(join(tmp, 'root.ts'), '');
+      writeFileSync(join(tmp, 'sub', 'nested.ts'), '');
+      writeFileSync(join(tmp, 'sub', 'other.txt'), '');
+
+      const results = globSync('**/*.ts', { cwd: tmp });
+      expect(results.sort()).toStrictEqual(['root.ts', 'sub/nested.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('matches files in a subdirectory pattern', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'src'));
+      writeFileSync(join(tmp, 'src', 'index.ts'), '');
+      writeFileSync(join(tmp, 'src', 'util.ts'), '');
+      writeFileSync(join(tmp, 'index.ts'), '');
+
+      const results = globSync('src/*.ts', { cwd: tmp });
+      expect(results.sort()).toStrictEqual(['src/index.ts', 'src/util.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('supports {a,b} alternation', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.ts'), '');
+      writeFileSync(join(tmp, 'c.ts'), '');
+
+      const results = globSync('*.{ts,js}', { cwd: tmp });
+      expect(results.sort()).toStrictEqual(['a.ts', 'b.ts', 'c.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('** matches all files and directories', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'sub'));
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'sub', 'b.ts'), '');
+
+      const results = globSync('**', { cwd: tmp });
+      // Should include '.', 'a.ts', 'sub', 'sub/b.ts'
+      expect(results.includes('a.ts')).toBe(true);
+      expect(results.includes('sub/b.ts')).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('a/** matches the directory itself and its contents', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'sub'));
+      writeFileSync(join(tmp, 'sub', 'x.ts'), '');
+      writeFileSync(join(tmp, 'root.ts'), '');
+
+      const results = globSync('sub/**', { cwd: tmp });
+      expect(results.includes('sub')).toBe(true);
+      expect(results.includes('sub/x.ts')).toBe(true);
+      expect(results.includes('root.ts')).toBe(false);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('accepts array of patterns', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.js'), '');
+      writeFileSync(join(tmp, 'c.txt'), '');
+
+      const results = globSync(['*.ts', '*.js'], { cwd: tmp });
+      expect(results.sort()).toStrictEqual(['a.ts', 'b.js']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('exclude function filters out matching paths', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.ts'), '');
+      writeFileSync(join(tmp, 'b.ts'), '');
+
+      // Use **/*.ts so Node.js native also invokes the exclude function
+      // (flat patterns like *.ts skip directory traversal and exclude is not called)
+      const results = globSync('**/*.ts', {
+        cwd: tmp,
+        exclude: (p) => p === 'a.ts',
+      });
+      expect(results).toStrictEqual(['b.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('returns empty array when no files match', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'a.txt'), '');
+
+      const results = globSync('*.ts', { cwd: tmp });
+      expect(results).toStrictEqual([]);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('returns empty array for non-existent cwd', async () => {
+      const results = globSync('*.ts', { cwd: '/nonexistent-dir-gjsify-test' });
+      expect(results).toStrictEqual([]);
+    });
+  });
+
+  await describe('fs.glob (callback)', async () => {
+    await it('calls back with matched files', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'hello.ts'), '');
+      writeFileSync(join(tmp, 'world.ts'), '');
+
+      const results = await new Promise<string[]>((resolve, reject) => {
+        glob('*.ts', { cwd: tmp }, (err, matches) => {
+          if (err) return reject(err);
+          resolve(matches);
+        });
+      });
+
+      expect(results.sort()).toStrictEqual(['hello.ts', 'world.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('accepts callback as second argument (no options)', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'file.ts'), '');
+
+      const results = await new Promise<string[]>((resolve, reject) => {
+        (glob as any)('*.ts', (err: any, matches: string[]) => {
+          if (err) return reject(err);
+          resolve(matches);
+        });
+      });
+
+      // No cwd given — just verify it completes without error
+      expect(Array.isArray(results)).toBe(true);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+
+  await describe('fs.promises.glob', async () => {
+    await it('async iterates matched files', async () => {
+      const tmp = makeTmp();
+      writeFileSync(join(tmp, 'alpha.ts'), '');
+      writeFileSync(join(tmp, 'beta.ts'), '');
+
+      const results: string[] = [];
+      for await (const match of promises.glob('*.ts', { cwd: tmp })) {
+        results.push(match);
+      }
+
+      expect(results.sort()).toStrictEqual(['alpha.ts', 'beta.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    await it('async iterates recursively with **/*.ts', async () => {
+      const tmp = makeTmp();
+      mkdirSync(join(tmp, 'lib'));
+      writeFileSync(join(tmp, 'index.ts'), '');
+      writeFileSync(join(tmp, 'lib', 'helper.ts'), '');
+
+      const results: string[] = [];
+      for await (const match of promises.glob('**/*.ts', { cwd: tmp })) {
+        results.push(match);
+      }
+
+      expect(results.sort()).toStrictEqual(['index.ts', 'lib/helper.ts']);
+      rmSync(tmp, { recursive: true, force: true });
+    });
+  });
+};

--- a/packages/node/fs/src/glob.ts
+++ b/packages/node/fs/src/glob.ts
@@ -1,0 +1,205 @@
+// Reference: Node.js lib/internal/fs/glob.js
+// Reimplemented for GJS using readdirSync (recursive) + pattern matching
+
+import { readdirSync } from './sync.js';
+import { normalizePath } from './utils.js';
+import type { PathLike } from 'node:fs';
+
+export interface GlobOptions {
+  cwd?: string | URL;
+  exclude?: string | string[] | ((path: string) => boolean);
+  withFileTypes?: boolean;
+}
+
+// ─── Pattern → RegExp conversion ─────────────────────────────────────────────
+
+/** Convert a single glob segment (no `/`) to a regex source string */
+function segmentToRegexSrc(seg: string): string {
+  // Handle extglob: !(pattern), *(pattern), +(pattern), ?(pattern), @(pattern)
+  const extglob = /^([!*+?@])\((.+)\)$/.exec(seg);
+  if (extglob) {
+    const [, type, inner] = extglob;
+    const parts = inner.split('|').map(p => segmentToRegexSrc(p));
+    const group = '(?:' + parts.join('|') + ')';
+    switch (type) {
+      case '!': return '(?!(?:' + parts.join('|') + '))[^/]*';
+      case '*': return group + '*';
+      case '+': return group + '+';
+      case '?': return group + '?';
+      case '@': return group;
+    }
+  }
+
+  let result = '';
+  let i = 0;
+  while (i < seg.length) {
+    const c = seg[i];
+    if (c === '*') { result += '[^/]*'; i++; continue; }
+    if (c === '?') { result += '[^/]'; i++; continue; }
+    if (c === '[') {
+      // Character class — pass through to regex
+      const end = seg.indexOf(']', i + 1);
+      if (end === -1) { result += '\\['; i++; continue; }
+      result += seg.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+    if (c === '{') {
+      // Alternation
+      const end = seg.indexOf('}', i + 1);
+      if (end === -1) { result += '\\{'; i++; continue; }
+      const alts = seg.slice(i + 1, end).split(',').map(a => segmentToRegexSrc(a.trim()));
+      result += '(?:' + alts.join('|') + ')';
+      i = end + 1;
+      continue;
+    }
+    // Escape regex special chars
+    if ('.+^$|()[]{}'.includes(c)) {
+      result += '\\' + c;
+    } else {
+      result += c;
+    }
+    i++;
+  }
+  return result;
+}
+
+/**
+ * Convert a glob pattern to a RegExp that matches relative POSIX paths.
+ */
+function globToRegex(pattern: string): RegExp {
+  // Normalize: collapse multiple slashes, remove leading './'
+  pattern = pattern.replace(/\/+/g, '/').replace(/^\.\//, '');
+
+  const segments = pattern.split('/');
+  const parts: string[] = [];
+
+  for (let si = 0; si < segments.length; si++) {
+    const seg = segments[si];
+    const isLast = si === segments.length - 1;
+
+    if (seg === '**') {
+      if (isLast) {
+        if (parts.length > 0 && parts[parts.length - 1] === '/') {
+          // Remove the trailing '/' so "a/" becomes optional: "a(?:/.*)?
+          parts.pop();
+          parts.push('(?:/.+)?');
+        } else {
+          // '**' at root level: match '.' or anything
+          parts.push('(?:.+)?');
+        }
+      } else {
+        // Not last: match zero or more path segments with trailing slash
+        parts.push('(?:[^/]+/)*');
+      }
+    } else {
+      parts.push(segmentToRegexSrc(seg));
+      if (!isLast) parts.push('/');
+    }
+  }
+
+  return new RegExp('^(?:' + parts.join('') + ')$');
+}
+
+// ─── Exclude logic ────────────────────────────────────────────────────────────
+
+function buildExcludePredicate(exclude: GlobOptions['exclude']): ((path: string) => boolean) | null {
+  if (!exclude) return null;
+  if (typeof exclude === 'function') return exclude;
+  const patterns = Array.isArray(exclude) ? exclude : [exclude];
+  const regexes = patterns.map(p => globToRegex(p));
+  return (path: string) => regexes.some(rx => rx.test(path));
+}
+
+// ─── Walk + match ─────────────────────────────────────────────────────────────
+
+function matchAll(pattern: string, cwd: string, exclude: GlobOptions['exclude']): string[] {
+  const regex = globToRegex(pattern);
+  const isExcluded = buildExcludePredicate(exclude);
+
+  // Get all entries recursively (files + directories)
+  let allEntries: string[];
+  try {
+    allEntries = readdirSync(cwd, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+
+  // Include '.' itself for patterns like '**' that match the root
+  const candidates = ['.', ...allEntries];
+
+  const results: string[] = [];
+  for (const entry of candidates) {
+    // Normalize separators for matching
+    const normalized = entry.replace(/\\/g, '/');
+    if (!regex.test(normalized)) continue;
+    if (isExcluded && isExcluded(normalized)) continue;
+    results.push(entry);
+  }
+
+  return results;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function globSync(
+  pattern: string | string[],
+  options?: GlobOptions,
+): string[] {
+  const patterns = Array.isArray(pattern) ? pattern : [pattern];
+  const cwd = options?.cwd
+    ? normalizePath(options.cwd as PathLike)
+    : (globalThis as any).process?.cwd?.() ?? '/';
+  const exclude = options?.exclude;
+
+  const seen = new Set<string>();
+  const results: string[] = [];
+
+  for (const p of patterns) {
+    for (const match of matchAll(p, cwd, exclude)) {
+      if (!seen.has(match)) {
+        seen.add(match);
+        results.push(match);
+      }
+    }
+  }
+
+  return results;
+}
+
+export function glob(
+  pattern: string | string[],
+  options: GlobOptions | ((err: NodeJS.ErrnoException | null, matches: string[]) => void),
+  callback?: (err: NodeJS.ErrnoException | null, matches: string[]) => void,
+): void {
+  let opts: GlobOptions;
+  let cb: (err: NodeJS.ErrnoException | null, matches: string[]) => void;
+
+  if (typeof options === 'function') {
+    cb = options;
+    opts = {};
+  } else {
+    cb = callback!;
+    opts = options || {};
+  }
+
+  Promise.resolve().then(() => {
+    try {
+      const matches = globSync(pattern, opts);
+      cb(null, matches);
+    } catch (err: unknown) {
+      cb(err as NodeJS.ErrnoException, []);
+    }
+  });
+}
+
+// promises.glob returns an async iterator
+export async function* globAsync(
+  pattern: string | string[],
+  options?: GlobOptions,
+): AsyncIterableIterator<string> {
+  const matches = globSync(pattern, options);
+  for (const m of matches) {
+    yield m;
+  }
+}

--- a/packages/node/fs/src/index.ts
+++ b/packages/node/fs/src/index.ts
@@ -64,6 +64,7 @@ import {
 } from './write-stream.js';
 import * as promises from './promises.js';
 import { cpSync, cp } from './cp.js';
+import { Dir, opendir, opendirSync } from './dir.js';
 import { Stats, BigIntStats } from './stats.js';
 import { Dirent } from './dirent.js';
 
@@ -119,6 +120,7 @@ export {
   Stats,
   BigIntStats,
   Dirent,
+  Dir,
   // Sync API
   existsSync,
   readdirSync,
@@ -144,6 +146,7 @@ export {
   chmodSync,
   chownSync,
   cpSync,
+  opendirSync,
   watch,
   // Streams
   createReadStream,
@@ -178,6 +181,7 @@ export {
   writeFile,
   unlink,
   link,
+  opendir,
 };
 
 export default {
@@ -185,6 +189,7 @@ export default {
   Stats,
   BigIntStats,
   Dirent,
+  Dir,
   constants,
   existsSync,
   readdirSync,
@@ -210,6 +215,7 @@ export default {
   chmodSync,
   chownSync,
   cpSync,
+  opendirSync,
   watch,
   createReadStream,
   ReadStream,
@@ -241,4 +247,5 @@ export default {
   writeFile,
   unlink,
   link,
+  opendir,
 };

--- a/packages/node/fs/src/index.ts
+++ b/packages/node/fs/src/index.ts
@@ -63,6 +63,7 @@ import {
   WriteStream
 } from './write-stream.js';
 import * as promises from './promises.js';
+import { cpSync, cp } from './cp.js';
 import { Stats, BigIntStats } from './stats.js';
 import { Dirent } from './dirent.js';
 
@@ -142,6 +143,7 @@ export {
   truncateSync,
   chmodSync,
   chownSync,
+  cpSync,
   watch,
   // Streams
   createReadStream,
@@ -163,6 +165,7 @@ export {
   stat,
   rename,
   copyFile,
+  cp,
   access,
   appendFile,
   readlink,
@@ -206,6 +209,7 @@ export default {
   truncateSync,
   chmodSync,
   chownSync,
+  cpSync,
   watch,
   createReadStream,
   ReadStream,
@@ -224,6 +228,7 @@ export default {
   stat,
   rename,
   copyFile,
+  cp,
   access,
   appendFile,
   readlink,

--- a/packages/node/fs/src/index.ts
+++ b/packages/node/fs/src/index.ts
@@ -65,6 +65,7 @@ import {
 import * as promises from './promises.js';
 import { cpSync, cp } from './cp.js';
 import { Dir, opendir, opendirSync } from './dir.js';
+import { glob, globSync } from './glob.js';
 import { Stats, BigIntStats } from './stats.js';
 import { Dirent } from './dirent.js';
 
@@ -147,6 +148,8 @@ export {
   chownSync,
   cpSync,
   opendirSync,
+  globSync,
+  glob,
   watch,
   // Streams
   createReadStream,
@@ -216,6 +219,8 @@ export default {
   chownSync,
   cpSync,
   opendirSync,
+  globSync,
+  glob,
   watch,
   createReadStream,
   ReadStream,

--- a/packages/node/fs/src/promises.ts
+++ b/packages/node/fs/src/promises.ts
@@ -7,6 +7,7 @@ import { join, dirname } from 'node:path';
 import { getEncodingFromOptions, encodeUint8Array, decode } from './encoding.js';
 import { realpathSync, readdirSync as readdirSyncFn, renameSync, copyFileSync, accessSync, appendFileSync, readlinkSync, truncateSync, chmodSync, chownSync, linkSync } from './sync.js';
 import { cpAsync } from './cp.js';
+import { opendirAsync, Dir } from './dir.js';
 import { FileHandle } from './file-handle.js';
 import { tempDirPath, normalizePath } from './utils.js';
 import { Dirent } from './dirent.js';
@@ -576,6 +577,8 @@ async function link(existingPath: PathLike, newPath: PathLike): Promise<void> {
   linkSync(existingPath, newPath);
 }
 
+export type { Dir };
+
 export {
   readFile,
   mkdir,
@@ -601,6 +604,7 @@ export {
   chown,
   link,
   cpAsync as cp,
+  opendirAsync as opendir,
 };
 
 export default {
@@ -628,4 +632,5 @@ export default {
   chown,
   link,
   cp: cpAsync,
+  opendir: opendirAsync,
 };

--- a/packages/node/fs/src/promises.ts
+++ b/packages/node/fs/src/promises.ts
@@ -8,6 +8,7 @@ import { getEncodingFromOptions, encodeUint8Array, decode } from './encoding.js'
 import { realpathSync, readdirSync as readdirSyncFn, renameSync, copyFileSync, accessSync, appendFileSync, readlinkSync, truncateSync, chmodSync, chownSync, linkSync } from './sync.js';
 import { cpAsync } from './cp.js';
 import { opendirAsync, Dir } from './dir.js';
+import { globAsync } from './glob.js';
 import { FileHandle } from './file-handle.js';
 import { tempDirPath, normalizePath } from './utils.js';
 import { Dirent } from './dirent.js';
@@ -605,6 +606,7 @@ export {
   link,
   cpAsync as cp,
   opendirAsync as opendir,
+  globAsync as glob,
 };
 
 export default {
@@ -633,4 +635,5 @@ export default {
   link,
   cp: cpAsync,
   opendir: opendirAsync,
+  glob: globAsync,
 };

--- a/packages/node/fs/src/promises.ts
+++ b/packages/node/fs/src/promises.ts
@@ -6,6 +6,7 @@ import GLib from '@girs/glib-2.0';
 import { join, dirname } from 'node:path';
 import { getEncodingFromOptions, encodeUint8Array, decode } from './encoding.js';
 import { realpathSync, readdirSync as readdirSyncFn, renameSync, copyFileSync, accessSync, appendFileSync, readlinkSync, truncateSync, chmodSync, chownSync, linkSync } from './sync.js';
+import { cpAsync } from './cp.js';
 import { FileHandle } from './file-handle.js';
 import { tempDirPath, normalizePath } from './utils.js';
 import { Dirent } from './dirent.js';
@@ -599,6 +600,7 @@ export {
   chmod,
   chown,
   link,
+  cpAsync as cp,
 };
 
 export default {
@@ -625,4 +627,5 @@ export default {
   chmod,
   chown,
   link,
+  cp: cpAsync,
 };

--- a/packages/node/fs/src/test.mts
+++ b/packages/node/fs/src/test.mts
@@ -15,5 +15,6 @@ import testSuiteExtended from './extended.spec.js';
 
 import testSuiteErrors from './errors.spec.js';
 import testSuiteStreams from './streams.spec.js';
+import testSuiteCp from './cp.spec.js';
 
-run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams});
+run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams, testSuiteCp});

--- a/packages/node/fs/src/test.mts
+++ b/packages/node/fs/src/test.mts
@@ -17,5 +17,6 @@ import testSuiteErrors from './errors.spec.js';
 import testSuiteStreams from './streams.spec.js';
 import testSuiteCp from './cp.spec.js';
 import testSuiteDir from './dir.spec.js';
+import testSuiteGlob from './glob.spec.js';
 
-run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams, testSuiteCp, testSuiteDir});
+run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams, testSuiteCp, testSuiteDir, testSuiteGlob});

--- a/packages/node/fs/src/test.mts
+++ b/packages/node/fs/src/test.mts
@@ -16,5 +16,6 @@ import testSuiteExtended from './extended.spec.js';
 import testSuiteErrors from './errors.spec.js';
 import testSuiteStreams from './streams.spec.js';
 import testSuiteCp from './cp.spec.js';
+import testSuiteDir from './dir.spec.js';
 
-run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams, testSuiteCp});
+run({testSuiteCallback, testSuiteFileHandle, testSuitePromise, testSuiteSync, testSuiteSymlink, testSuiteStat, testSuiteNewApis, testSuiteExtended, testSuiteErrors, testSuiteStreams, testSuiteCp, testSuiteDir});


### PR DESCRIPTION
## Summary

Implements three missing Node.js `fs` API families in `@gjsify/fs`:

### 1. `fs.cp` / `fs.cpSync` / `fs.promises.cp`
- Full recursive directory copy via `Gio.File.copy()` + `Gio.File.enumerate_children()`
- Supports: `recursive`, `force`, `errorOnExist`, `filter` (sync + async), `preserveTimestamps`
- Correct Node.js error codes: `ERR_FS_EISDIR`, `ERR_FS_CP_EEXIST`, `ENOENT`
- Correctly distinguishes Gio numeric error codes from Node string error codes in catch blocks

### 2. `fs.Dir` / `fs.opendir` / `fs.opendirSync` / `fs.promises.opendir`
- `Dir` class backed by `Gio.FileEnumerator` from `file.enumerate_children()`
- `readSync()` / `read()` → `Dirent | null` with correct file type flags
- `closeSync()` / `close()` → throws `ERR_DIR_CLOSED` after close
- `[Symbol.asyncIterator]` auto-closes on completion
- `opendirAsync` uses `enumerate_children_async` for true async

### 3. `fs.globSync` / `fs.glob` / `fs.promises.glob`
- Pure-JS glob-to-regex engine: `*`, `**`, `?`, `[class]`, `{a,b}`, extglob `!(x)` `*(x)` `+(x)` `?(x)` `@(x)`
- `exclude` accepts a function (relative-path string) or string array
- `promises.glob` returns `AsyncIterableIterator<string>`
- Uses `readdirSync(cwd, {recursive:true})` as the filesystem walker

## Test plan

- [x] 557 tests passing on Node.js 24
- [x] 557 tests passing on GJS (Fedora local)
- [x] CI running on Fedora 42 (GJS 1.84 / SM 128), Fedora 43 (GJS 1.86 / SM 140), Fedora 44 (GJS 1.88 / SM 140)