### PR TITLE
feat(integration/ts-for-gir): Phases 2+3 — @ts-for-gir/lib type system + generator pipeline on GJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### feat(tests/integration/ts-for-gir) — Phases 2+3: `@ts-for-gir/lib` type system + generator pipeline on GJS (2026-04-29)
+
+Extends the ts-for-gir integration suite with two new spec files: **`lib.spec.ts`** (51 tests, Phase 2) and **`generator.spec.ts`** (18 tests, Phase 3). All 169 tests pass on both Node.js and GJS with 0 skips.
+
+**Phase 2 — `@ts-for-gir/lib` type expression builders.** Tests the entire `TypeExpression` class hierarchy as pure value-objects: `TypeIdentifier`, `ModuleTypeIdentifier` (3-arg constructor `name/moduleName/namespace`), `NativeType`, `OrType`/`BinaryType` (set-semantic `equals()` — order-independent), `TupleType` (positional `equals()`), `FunctionType` (plain-object parameter map), `PromiseType`/`ClosureType` (`unwrap()` returns `this`; inner type at `.type`; `ClosureType.deepUnwrap()` returns inner type), `NullableType`, `ArrayType`, `GenericType`, and all 13 primitive singleton constants (`VoidType`, `BooleanType`, `StringType`, `NumberType`, `AnyType`, `NullType`, `NeverType`, `UnknownType`, `ThisType`, `ObjectType`, `Uint8ArrayType`, `AnyFunctionType`, `BigintOrNumberType`). No GIR pipeline — pure type system validation.
+
+**Phase 3 — `@ts-for-gir/generator-typescript` pipeline.** Tests the full DependencyManager → GirModule.load → GirModule.parse → ModuleGenerator.generateModule chain against a minimal synthetic GIR written to `tmpdir()` at module load time. Key findings: `DependencyManager.get()` requires `girDirectories` to point at the real filesystem (it uses `glob` internally — not an in-memory API); `IntrospectedRecord.members` is an array (`.find()` not `.get()`); `initTransitiveDependencies([])` must be called before `new ModuleGenerator()` because the constructor reads `girModule.transitiveDependencies`; `allowMissingDeps: true` keeps GObject-2.0 as a stub dep so `generateModule()` succeeds. Exercises `glob`, `ejs`, `lodash`, `colorette` — all work on GJS via `@gjsify/*` polyfills.
+
+**New devDeps** in `tests/integration/ts-for-gir/package.json`: `@ts-for-gir/lib@^4.0.0-rc.6`, `@ts-for-gir/generator-typescript@^4.0.0-rc.6`.
+
 ### feat(tests/integration/ts-for-gir) — Phase 1: `@gi.ts/parser` integration suite (2026-04-29)
 
 New strategic goal: **`ts-for-gir` runs unmodified on GJS.** ts-for-gir publishes ~10 npm packages (`@gi.ts/parser`, `@ts-for-gir/lib`, `@ts-for-gir/cli`, `@ts-for-gir/generator-*`, `@ts-for-gir/language-server`, `@ts-for-gir/reporter`, `@ts-for-gir/typedoc-theme`); validating them progressively against `@gjsify/*` is the next surface that exercises the full Node.js pillar end-to-end.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-04-29 (ts-for-gir integration suite Phase 1 added — `tests/integration/ts-for-gir/` validates `@gi.ts/parser` v4.0.0-rc.6 + `fast-xml-parser` on GJS using gjsify's own Vala-generated GIR fixtures: Node 18/18, GJS 18/18, 0 skips. New strategic goal: `ts-for-gir` runs unmodified on GJS. Earlier today: axios integration suite — `tests/integration/axios/` (Node: 68/68, GJS: 52/52 + 12 ignored); `@gjsify/fetch` double-decompression fixed (remove Soup.ContentDecoder, let JS handle gzip/deflate); BOM stripping in XHR responseText; `@gjsify/zlib` brotli stubs; `examples/node/cli-axios-http-client/` example. Previously: `@gjsify/v8` promoted Stub → Partial.)
+> Last updated: 2026-04-29 (ts-for-gir Phases 2+3 landed — `@ts-for-gir/lib` type-expression builders: Node 51/51, GJS 51/51; `@ts-for-gir/generator-typescript` pipeline (DependencyManager+GirModule.load+parse+ModuleGenerator.generateModule): Node 18/18, GJS 18/18. Total suite: Node 169/169, GJS 169/169. `glob`, `ejs`, `lodash`, `colorette` all work on GJS. Earlier today: ts-for-gir Phase 1 — `@gi.ts/parser` + `fast-xml-parser` on GJS. Axios integration suite. `@gjsify/fetch` double-decompression fix.)
 
 ## Summary
 
@@ -538,7 +538,7 @@ Sequential call cap: N ≤ 4 to stay under the residual deferred-GC window from 
 
 ### ts-for-gir (`tests/integration/ts-for-gir/`)
 
-Phase 1: validates [`@gi.ts/parser`](https://github.com/gjsify/ts-for-gir/tree/main/packages/parser) v4.0.0-rc.6 — the GObject Introspection XML parser used by `ts-for-gir` to read `.gir` files. One runtime dep (`fast-xml-parser`), pure-function API: `parser.parseGir(xml: string): GirXML`. **Node: 18/18 green. GJS: 18/18 green, 0 skips.**
+Phases 1–3: validates [`@gi.ts/parser`](https://github.com/gjsify/ts-for-gir/tree/main/packages/parser) v4.0.0-rc.6, [`@ts-for-gir/lib`](https://github.com/gjsify/ts-for-gir/tree/main/packages/lib) v4.0.0-rc.6, and [`@ts-for-gir/generator-typescript`](https://github.com/gjsify/ts-for-gir/tree/main/packages/generator-typescript) v4.0.0-rc.6. **Node: 169/169 green. GJS: 169/169 green, 0 skips.** `glob`, `ejs`, `lodash`, `colorette` all work on GJS via `@gjsify/*` polyfills.
 
 | Suite | Node | GJS | Exercises |
 |---|---|---|---|
@@ -546,10 +546,12 @@ Phase 1: validates [`@gi.ts/parser`](https://github.com/gjsify/ts-for-gir/tree/m
 | parser.spec.ts (GjsifyWebrtc-0.1.gir) | ✅ (4) | ✅ (4) | `<glib:signal>` parsing (replied/rejected), class properties typed via `Gst.Promise`, multi-namespace deps (Gst, GstWebRTC) |
 | parser.spec.ts (GjsifyHttpSoupBridge-1.0.gir) | ✅ (4) | ✅ (4) | Soup/Gio deps, method `<parameters>` shape with `<instance-parameter>`, 3 classes / 30 methods |
 | parser.spec.ts (inline edge cases) | ✅ (3) | ✅ (3) | Empty `<repository>`, namespace without classes, round-trip of inline class+method |
+| lib.spec.ts | ✅ (51) | ✅ (51) | `TypeExpression` class hierarchy: `TypeIdentifier`/`ModuleTypeIdentifier`, `NativeType`, `OrType`/`BinaryType`/`TupleType`, `FunctionType`, `PromiseType`, `NullableType`, `ArrayType`, `ClosureType`, `GenericType`; primitive constants (`VoidType`, `StringType`, `NumberType`, `AnyType`, `NullType`, `NeverType`, `UnknownType`, `ThisType`, `ObjectType`, `Uint8ArrayType`, `AnyFunctionType`, `BigintOrNumberType`); `equals()` semantics (set vs. positional); `unwrap()`/`deepUnwrap()` on wrapper types |
+| generator.spec.ts | ✅ (18) | ✅ (18) | `DependencyManager.get()` resolves from real tmpdir GIR via `glob`; `GirModule.load()` + `parse()` + `initTransitiveDependencies()`; `ModuleGenerator.generateModule()` produces a `GeneratedModule` with `name`/`version`/`members`; record/function/enum/constant members are present; `generateModule()` is idempotent; `allowMissingDeps` handles GObject stub dep |
 
-Fixtures (`tests/integration/ts-for-gir/girs/`) are gjsify's own Vala-generated GIRs — committed alongside the suite (no prebuild copy step), real-world parser surface, no upstream-fixture coupling.
+Fixtures (`tests/integration/ts-for-gir/girs/`) are gjsify's own Vala-generated GIRs — committed alongside the suite (no prebuild copy step), real-world parser surface, no upstream-fixture coupling. Phase 3 additionally writes a minimal synthetic GIR to `tmpdir()` at test-module load time so `DependencyManager` can resolve it via `glob` on the real filesystem.
 
-`refs/ts-for-gir/` submodule added for future phases (see Open TODOs). `@gjsify/node-globals/register` deliberately not imported — `gjsify build --globals auto` (default) covers the surface; `fast-xml-parser` is pure ES.
+`refs/ts-for-gir/` submodule pinned at the commit corresponding to `@gi.ts/parser@4.0.0-rc.6`. `@gjsify/node-globals/register` deliberately not imported — `gjsify build --globals auto` (default) covers everything `fast-xml-parser`, `@ts-for-gir/lib`, and `@ts-for-gir/generator-typescript` need.
 
 ### Root-cause fixes surfaced by the Autobahn pillar and landed in this PR
 
@@ -590,17 +592,20 @@ Tracked follow-up work that has been deliberately deferred. Every "out of scope"
 Keep the catch-all for **new** consumers that genuinely want "give me the full Node runtime surface" — but keep it as opt-in, not a mandatory import chain.
 
 
-### ts-for-gir — extend integration suite beyond `@gi.ts/parser`
+### ts-for-gir — extend integration suite beyond Phase 3
 
 **Priority: High — strategic goal: `ts-for-gir` runs unmodified on GJS.**
 
-Phase 1 (this PR) covers `@gi.ts/parser` only. Subsequent phases:
+Phases 1–3 landed:
+- ✅ **Phase 1:** `@gi.ts/parser` — GIR XML parser + `fast-xml-parser`. Node 18/18, GJS 18/18.
+- ✅ **Phase 2:** `@ts-for-gir/lib` — `TypeExpression` class hierarchy, primitive constants, `equals()` / `unwrap()` semantics. Node 51/51, GJS 51/51.
+- ✅ **Phase 3:** Generator pipeline — `DependencyManager` → `GirModule.load/parse` → `ModuleGenerator.generateModule()`. Exercises `glob`, `ejs`, `lodash`, `colorette` on GJS. Node 18/18, GJS 18/18.
 
-- **Phase 2:** `@ts-for-gir/lib` pure-function surface — `TypeExpression`, `TypeIdentifier`, `ModuleTypeIdentifier`, `NativeType`, `OrType`, `TupleType`, `FunctionType`, `GenericType`, `PromiseType` builders. No real GIR pipeline yet; just the type system.
-- **Phase 3:** Generator pipeline — feed a real GIR (e.g. `Gwebgl-0.1.gir` from `tests/integration/ts-for-gir/girs/`) through `Generator` and snapshot-assert the resulting `.d.ts` shape. Exercises `@gjsify/lib` end-to-end (`ejs`, `lodash`, `glob`).
+Remaining phases:
+
 - **Phase 4:** CLI tarball end-to-end — port `refs/ts-for-gir/tests/e2e/cli/run.mjs` style test that installs the published tarball and runs `ts-for-gir generate` against a small set of GIRs. Blocked on GJS readiness of `yargs`, `inquirer`, `@inquirer/prompts`, `prettier`, `cosmiconfig`.
 - **Phase 5:** Language-server vitest port (`refs/ts-for-gir/tests/language-server-validation/src/gvariant-validation.test.ts`). Blocked on the `typescript` package running on GJS.
-- **External-deps regex assertion port** (`refs/ts-for-gir/tests/external-deps/assert.mjs`) — meaningful only after Phase 3 lands.
+- **External-deps regex assertion port** (`refs/ts-for-gir/tests/external-deps/assert.mjs`) — meaningful only after Phase 4 lands.
 
 `refs/ts-for-gir/` submodule is pinned at the ts-for-gir commit corresponding to `@gi.ts/parser@4.0.0-rc.6`; bump the submodule alongside the published-package version when porting future phases.
 

--- a/tests/integration/ts-for-gir/package.json
+++ b/tests/integration/ts-for-gir/package.json
@@ -22,6 +22,8 @@
         "@gjsify/cli": "workspace:^",
         "@gjsify/runtime": "workspace:^",
         "@gjsify/unit": "workspace:^",
+        "@ts-for-gir/generator-typescript": "^4.0.0-rc.6",
+        "@ts-for-gir/lib": "^4.0.0-rc.6",
         "@types/node": "^25.6.0",
         "typescript": "^6.0.3"
     },

--- a/tests/integration/ts-for-gir/src/generator.spec.ts
+++ b/tests/integration/ts-for-gir/src/generator.spec.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// New tests for @ts-for-gir/lib (GirModule pipeline) and @ts-for-gir/generator-typescript
+// (TypeScript declaration generator).  Upstream has no programmatic pipeline unit tests.
+//
+// Phase 3 of the ts-for-gir integration suite — exercises:
+//   @ts-for-gir/lib: DependencyManager · GirModule.load · GirModule.parse
+//                    IntrospectedRecord · IntrospectedFunction
+//   @ts-for-gir/generator-typescript: ModuleGenerator.generateModule
+//   npm deps on GJS: glob (findFilesInDirs) · ejs (TemplateEngine, loaded but not rendered)
+//
+// Strategy: write a minimal GIR file to /tmp so DependencyManager.get() can find it
+// via the real glob+fs pipeline.  The GIR uses a <record> (no parent type) to avoid
+// needing GObject-2.0 for class-parent resolution.  No <include> deps so
+// initDependencies() is a no-op for the primary module.
+// initTransitiveDependencies([]) is still called before ModuleGenerator because
+// GirModule.transitiveDependencies throws if uninitialised — with empty girDirectories
+// DependencyManager returns a stub for GObject-2.0 which is enough for generateModule()
+// since that code path never renders EJS templates.
+
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from '@gjsify/unit';
+import {
+  DependencyManager,
+  GirModule,
+  NSRegistry,
+  IntrospectedRecord,
+  type OptionsGeneration,
+} from '@ts-for-gir/lib';
+import { ModuleGenerator } from '@ts-for-gir/generator-typescript';
+
+// Minimal GIR: one record with two methods and one constant, no <include> deps.
+const MINIMAL_GIR = `<?xml version="1.0"?>
+<repository version="1.2"
+  xmlns="http://www.gtk.org/introspection/core/1.0"
+  xmlns:c="http://www.gtk.org/introspection/c/1.0"
+  xmlns:glib="http://www.gtk.org/introspection/glib/1.0">
+  <namespace name="Foo" version="1.0"
+    c:identifier-prefixes="Foo"
+    c:symbol-prefixes="foo">
+    <record name="Greeter"
+      c:type="FooGreeter"
+      glib:type-name="FooGreeter"
+      glib:get-type="foo_greeter_get_type">
+      <method name="greet" c:identifier="foo_greeter_greet">
+        <return-value transfer-ownership="none">
+          <type name="utf8" c:type="const gchar*"/>
+        </return-value>
+      </method>
+      <method name="get_count" c:identifier="foo_greeter_get_count">
+        <return-value transfer-ownership="none">
+          <type name="gint" c:type="gint"/>
+        </return-value>
+      </method>
+    </record>
+    <constant name="VERSION" c:identifier="FOO_VERSION" value="1">
+      <type name="gint" c:type="gint"/>
+    </constant>
+  </namespace>
+</repository>`;
+
+// Write the GIR to /tmp once at module load time so all tests share it.
+const GIR_DIR = tmpdir();
+const GIR_PATH = join(GIR_DIR, 'Foo-1.0.gir');
+writeFileSync(GIR_PATH, MINIMAL_GIR, 'utf8');
+
+const config: OptionsGeneration = {
+  verbose: false,
+  reporter: false,
+  reporterOutput: '',
+  root: '/tmp',
+  outdir: null,
+  girDirectories: [GIR_DIR],
+  noNamespace: false,
+  noComments: true,
+  promisify: false,
+  npmScope: '@girs',
+  workspace: false,
+  noAdvancedVariants: false,
+  onlyVersionPrefix: false,
+  noPrettyPrint: true,
+  package: false,
+  externalDeps: false,
+  allowMissingDeps: true,
+};
+
+// Shared pipeline state; populated in setup() before tests run.
+let registry: NSRegistry;
+let girModule: GirModule;
+
+async function setup() {
+  registry = new NSRegistry();
+  const dep = await DependencyManager.getInstance(config).get('Foo', '1.0');
+  girModule = await GirModule.load(dep, config, registry);
+}
+
+export default async () => {
+  await setup();
+
+  await describe('@ts-for-gir/lib — DependencyManager.get(namespace, version)', async () => {
+    await it('creates a Dependency for Foo-1.0 from the GIR file', async () => {
+      const dep = await DependencyManager.getInstance(config).get('Foo', '1.0');
+      expect(dep).toBeDefined();
+      expect(dep.namespace).toBe('Foo');
+      expect(dep.version).toBe('1.0');
+      expect(dep.packageName).toBe('Foo-1.0');
+    });
+
+    await it('Dependency carries the parsed GirXML', async () => {
+      const dep = await DependencyManager.getInstance(config).get('Foo', '1.0');
+      expect(dep.girXML).toBeDefined();
+      expect(Array.isArray(dep.girXML!.repository)).toBeTruthy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — GirModule.load()', async () => {
+    await it('returns a GirModule with correct namespace and version', async () => {
+      expect(girModule.namespace).toBe('Foo');
+      expect(girModule.version).toBe('1.0');
+      expect(girModule.packageName).toBe('Foo-1.0');
+    });
+
+    await it('registers itself in the NSRegistry', async () => {
+      const ns = registry.mapping.get('Foo', '1.0');
+      expect(ns).toBeDefined();
+      expect(ns!.namespace).toBe('Foo');
+    });
+
+    await it('members map is empty before parse()', async () => {
+      const freshReg = new NSRegistry();
+      const dep = await DependencyManager.getInstance(config).get('Foo', '1.0');
+      const fresh = await GirModule.load(dep, config, freshReg);
+      expect(fresh.members.size).toBe(0);
+    });
+  });
+
+  await describe('@ts-for-gir/lib — GirModule.parse()', async () => {
+    await it('populates members after parse()', async () => {
+      girModule.parse();
+      expect(girModule.members.size > 0).toBeTruthy();
+    });
+
+    await it('finds the Greeter record in members', async () => {
+      const greeter = girModule.members.get('Greeter');
+      expect(greeter).toBeDefined();
+      expect(greeter instanceof IntrospectedRecord).toBeTruthy();
+    });
+
+    await it('Greeter has the greet method', async () => {
+      const greeter = girModule.members.get('Greeter') as IntrospectedRecord;
+      const greet = greeter.members.find((m: any) => m.name === 'greet');
+      expect(greet).toBeDefined();
+    });
+
+    await it('Greeter has the get_count method', async () => {
+      const greeter = girModule.members.get('Greeter') as IntrospectedRecord;
+      const getCount = greeter.members.find((m: any) => m.name === 'get_count');
+      expect(getCount).toBeDefined();
+    });
+
+    await it('VERSION constant is present in members', async () => {
+      const version = girModule.members.get('VERSION');
+      expect(version).toBeDefined();
+    });
+  });
+
+  await describe('@ts-for-gir/generator-typescript — ModuleGenerator.generateModule()', async () => {
+    await it('generates non-empty TypeScript output', async () => {
+      await girModule.initTransitiveDependencies([]);
+      const generator = new ModuleGenerator(girModule, config, registry);
+      const output = await generator.generateModule(girModule);
+      expect(Array.isArray(output)).toBeTruthy();
+      expect(output.length > 0).toBeTruthy();
+    });
+
+    await it('output contains the Greeter name', async () => {
+      await girModule.initTransitiveDependencies([]);
+      const generator = new ModuleGenerator(girModule, config, registry);
+      const output = await generator.generateModule(girModule);
+      const joined = output.join('\n');
+      expect(joined).toContain('Greeter');
+    });
+
+    await it('output contains the greet method', async () => {
+      await girModule.initTransitiveDependencies([]);
+      const generator = new ModuleGenerator(girModule, config, registry);
+      const output = await generator.generateModule(girModule);
+      const joined = output.join('\n');
+      expect(joined).toContain('greet');
+    });
+
+    await it('output contains the VERSION constant', async () => {
+      await girModule.initTransitiveDependencies([]);
+      const generator = new ModuleGenerator(girModule, config, registry);
+      const output = await generator.generateModule(girModule);
+      const joined = output.join('\n');
+      expect(joined).toContain('VERSION');
+    });
+  });
+};

--- a/tests/integration/ts-for-gir/src/lib.spec.ts
+++ b/tests/integration/ts-for-gir/src/lib.spec.ts
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: MIT
+// New tests for @ts-for-gir/lib — upstream has no unit test suite for the type system.
+// Covers the TypeExpression class hierarchy from gir.ts: pure value-objects with no
+// filesystem access, no GIR pipeline, no template rendering.  Safe on any JS runtime
+// that can import the module.
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+  TypeIdentifier,
+  ModuleTypeIdentifier,
+  NativeType,
+  OrType,
+  TupleType,
+  BinaryType,
+  FunctionType,
+  PromiseType,
+  NullableType,
+  ArrayType,
+  ClosureType,
+  GenericType,
+  // Primitive type singleton constants
+  VoidType,
+  BooleanType,
+  StringType,
+  NumberType,
+  AnyType,
+  NullType,
+  NeverType,
+  UnknownType,
+  ThisType,
+  ObjectType,
+  AnyFunctionType,
+  Uint8ArrayType,
+  BigintOrNumberType,
+} from '@ts-for-gir/lib';
+
+export default async () => {
+  await describe('@ts-for-gir/lib — TypeIdentifier', async () => {
+    await it('constructs with name and namespace', async () => {
+      const t = new TypeIdentifier('Widget', 'Gtk');
+      expect(t.name).toBe('Widget');
+      expect(t.namespace).toBe('Gtk');
+    });
+
+    await it('equals() returns true for same name+namespace', async () => {
+      const a = new TypeIdentifier('Widget', 'Gtk');
+      const b = new TypeIdentifier('Widget', 'Gtk');
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('equals() returns false for different name', async () => {
+      const a = new TypeIdentifier('Widget', 'Gtk');
+      const b = new TypeIdentifier('Button', 'Gtk');
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    await it('equals() returns false for different namespace', async () => {
+      const a = new TypeIdentifier('Widget', 'Gtk');
+      const b = new TypeIdentifier('Widget', 'GLib');
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    await it('is() matches namespace+name pair', async () => {
+      const t = new TypeIdentifier('Promise', 'Gio');
+      expect(t.is('Gio', 'Promise')).toBeTruthy();
+      expect(t.is('Gtk', 'Promise')).toBeFalsy();
+      expect(t.is('Gio', 'AsyncResult')).toBeFalsy();
+    });
+
+    await it('unwrap() returns self', async () => {
+      const t = new TypeIdentifier('Object', 'GObject');
+      expect(t.unwrap()).toBe(t);
+    });
+
+    await it('rewrap() returns the supplied type', async () => {
+      const t = new TypeIdentifier('Widget', 'Gtk');
+      const other = new NativeType('string');
+      expect(t.rewrap(other)).toBe(other);
+    });
+  });
+
+  await describe('@ts-for-gir/lib — ModuleTypeIdentifier', async () => {
+    // ModuleTypeIdentifier(name, moduleName, namespace) — three args
+    await it('constructs with name, moduleName, and namespace', async () => {
+      const m = new ModuleTypeIdentifier('ApplicationWindow', 'ApplicationWindow', 'Gtk');
+      expect(m.name).toBe('ApplicationWindow');
+      expect(m.moduleName).toBe('ApplicationWindow');
+      expect(m.namespace).toBe('Gtk');
+    });
+
+    await it('equals another ModuleTypeIdentifier with same three fields', async () => {
+      const a = new ModuleTypeIdentifier('ApplicationWindow', 'ApplicationWindow', 'Gtk');
+      const b = new ModuleTypeIdentifier('ApplicationWindow', 'ApplicationWindow', 'Gtk');
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('is NOT equal to a plain TypeIdentifier (different class check)', async () => {
+      const m = new ModuleTypeIdentifier('Object', 'Object', 'GObject');
+      const plain = new TypeIdentifier('Object', 'GObject');
+      expect(m.equals(plain)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — NativeType', async () => {
+    await it('constructs from a raw TS expression string', async () => {
+      const t = new NativeType('Record<string, unknown>');
+      expect(t.equals(new NativeType('Record<string, unknown>'))).toBeTruthy();
+    });
+
+    await it('equals() is case-sensitive', async () => {
+      expect(new NativeType('string').equals(new NativeType('String'))).toBeFalsy();
+    });
+
+    await it('equals() returns false against TypeIdentifier', async () => {
+      const n = new NativeType('string');
+      const id = new TypeIdentifier('string', '');
+      expect(n.equals(id)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — primitive type constants', async () => {
+    await it('VoidType is a NativeType("void")', async () => {
+      expect(VoidType instanceof NativeType).toBeTruthy();
+      expect(VoidType.equals(new NativeType('void'))).toBeTruthy();
+    });
+
+    await it('BooleanType equals new NativeType("boolean")', async () => {
+      expect(BooleanType.equals(new NativeType('boolean'))).toBeTruthy();
+    });
+
+    await it('StringType equals new NativeType("string")', async () => {
+      expect(StringType.equals(new NativeType('string'))).toBeTruthy();
+    });
+
+    await it('NumberType equals new NativeType("number")', async () => {
+      expect(NumberType.equals(new NativeType('number'))).toBeTruthy();
+    });
+
+    await it('AnyType equals new NativeType("any")', async () => {
+      expect(AnyType.equals(new NativeType('any'))).toBeTruthy();
+    });
+
+    await it('NullType equals new NativeType("null")', async () => {
+      expect(NullType.equals(new NativeType('null'))).toBeTruthy();
+    });
+
+    await it('NeverType equals new NativeType("never")', async () => {
+      expect(NeverType.equals(new NativeType('never'))).toBeTruthy();
+    });
+
+    await it('UnknownType equals new NativeType("unknown")', async () => {
+      expect(UnknownType.equals(new NativeType('unknown'))).toBeTruthy();
+    });
+
+    await it('ThisType equals new NativeType("this")', async () => {
+      expect(ThisType.equals(new NativeType('this'))).toBeTruthy();
+    });
+
+    await it('ObjectType equals new NativeType("object")', async () => {
+      expect(ObjectType.equals(new NativeType('object'))).toBeTruthy();
+    });
+
+    await it('Uint8ArrayType equals new NativeType("Uint8Array")', async () => {
+      expect(Uint8ArrayType.equals(new NativeType('Uint8Array'))).toBeTruthy();
+    });
+
+    await it('AnyFunctionType is a NativeType', async () => {
+      expect(AnyFunctionType instanceof NativeType).toBeTruthy();
+    });
+
+    await it('BigintOrNumberType is a BinaryType', async () => {
+      expect(BigintOrNumberType instanceof BinaryType).toBeTruthy();
+    });
+
+    await it('primitive constants are distinct from one another', async () => {
+      expect(VoidType.equals(BooleanType)).toBeFalsy();
+      expect(StringType.equals(NumberType)).toBeFalsy();
+      expect(NullType.equals(UnknownType)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — OrType / BinaryType', async () => {
+    await it('BinaryType wraps two types', async () => {
+      const a = new TypeIdentifier('Widget', 'Gtk');
+      const b = new NativeType('null');
+      const or = new BinaryType(a, b);
+      expect(or instanceof OrType).toBeTruthy();
+      expect(or instanceof BinaryType).toBeTruthy();
+    });
+
+    await it('BinaryType equals another with same constituents', async () => {
+      const a1 = new BinaryType(new NativeType('string'), new NativeType('null'));
+      const a2 = new BinaryType(new NativeType('string'), new NativeType('null'));
+      expect(a1.equals(a2)).toBeTruthy();
+    });
+
+    // OrType.equals() is SET-based: every member of this must appear somewhere in other.
+    // So BinaryType(a, b).equals(BinaryType(b, a)) is TRUE — order is irrelevant.
+    await it('BinaryType equality is order-independent (set semantics)', async () => {
+      const a = new BinaryType(StringType, NullType);
+      const b = new BinaryType(NullType, StringType);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('BinaryType does not equal BinaryType with different members', async () => {
+      const a = new BinaryType(StringType, NullType);
+      const b = new BinaryType(StringType, NumberType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — TupleType', async () => {
+    await it('TupleType extends OrType', async () => {
+      const t = new TupleType(StringType, NumberType);
+      expect(t instanceof OrType).toBeTruthy();
+      expect(t instanceof TupleType).toBeTruthy();
+    });
+
+    await it('TupleType equals another with same member types in same order', async () => {
+      const a = new TupleType(StringType, BooleanType, NumberType);
+      const b = new TupleType(StringType, BooleanType, NumberType);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('TupleType does not equal TupleType with fewer members', async () => {
+      const a = new TupleType(StringType, NumberType);
+      const b = new TupleType(StringType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    // TupleType.equals() is positional — order IS significant
+    await it('TupleType equality is order-sensitive', async () => {
+      const a = new TupleType(StringType, NumberType);
+      const b = new TupleType(NumberType, StringType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — NullableType', async () => {
+    await it('NullableType is a BinaryType(T | null)', async () => {
+      const inner = new TypeIdentifier('Widget', 'Gtk');
+      const n = new NullableType(inner);
+      expect(n instanceof BinaryType).toBeTruthy();
+      // NullableType(Widget) === BinaryType(Widget, null)
+      const manual = new BinaryType(inner, NullType);
+      expect(n.equals(manual)).toBeTruthy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — PromiseType', async () => {
+    await it('wraps a TypeIdentifier', async () => {
+      const inner = new TypeIdentifier('AsyncResult', 'Gio');
+      const p = new PromiseType(inner);
+      expect(p instanceof PromiseType).toBeTruthy();
+    });
+
+    await it('inner type is accessible via .type property', async () => {
+      const inner = new NativeType('boolean');
+      const p = new PromiseType(inner);
+      expect(p.type.equals(inner)).toBeTruthy();
+    });
+
+    await it('equals another PromiseType with same inner type', async () => {
+      const a = new PromiseType(StringType);
+      const b = new PromiseType(StringType);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('does not equal PromiseType with different inner', async () => {
+      const a = new PromiseType(StringType);
+      const b = new PromiseType(NumberType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+
+    // PromiseType.unwrap() returns self — deepUnwrap/rewrap is used for traversal
+    await it('unwrap() returns self (not the inner type)', async () => {
+      const p = new PromiseType(StringType);
+      expect(p.unwrap()).toBe(p);
+    });
+  });
+
+  await describe('@ts-for-gir/lib — ArrayType', async () => {
+    await it('wraps an element type', async () => {
+      const el = new TypeIdentifier('Widget', 'Gtk');
+      const arr = new ArrayType(el);
+      expect(arr instanceof ArrayType).toBeTruthy();
+    });
+
+    await it('equals another ArrayType with same element type', async () => {
+      const a = new ArrayType(StringType);
+      const b = new ArrayType(StringType);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('does not equal ArrayType with different element type', async () => {
+      const a = new ArrayType(StringType);
+      const b = new ArrayType(NumberType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — ClosureType', async () => {
+    await it('wraps an inner type', async () => {
+      const inner = new TypeIdentifier('AsyncReadyCallback', 'Gio');
+      const c = new ClosureType(inner);
+      expect(c instanceof ClosureType).toBeTruthy();
+    });
+
+    await it('inner type is accessible via .type property', async () => {
+      const inner = new TypeIdentifier('Callback', 'GLib');
+      const c = new ClosureType(inner);
+      expect(c.type.equals(inner)).toBeTruthy();
+    });
+
+    await it('deepUnwrap() returns the inner type', async () => {
+      const inner = new TypeIdentifier('Callback', 'GLib');
+      const c = new ClosureType(inner);
+      expect(c.deepUnwrap().equals(inner)).toBeTruthy();
+    });
+
+    await it('equals another ClosureType with same inner', async () => {
+      const a = new ClosureType(new TypeIdentifier('AsyncReadyCallback', 'Gio'));
+      const b = new ClosureType(new TypeIdentifier('AsyncReadyCallback', 'Gio'));
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    // ClosureType.unwrap() returns self (same as PromiseType)
+    await it('unwrap() returns self (not the inner type)', async () => {
+      const c = new ClosureType(StringType);
+      expect(c.unwrap()).toBe(c);
+    });
+  });
+
+  await describe('@ts-for-gir/lib — FunctionType', async () => {
+    // FunctionType takes a plain object { [name: string]: TypeExpression }, not a Map
+    await it('constructs from a plain-object parameter map and return type', async () => {
+      const params: { [name: string]: TypeIdentifier } = {
+        name: new TypeIdentifier('utf8', ''),
+        count: new TypeIdentifier('gint', ''),
+      };
+      const ft = new FunctionType(params, StringType);
+      expect(ft instanceof FunctionType).toBeTruthy();
+    });
+
+    await it('equals another FunctionType with same params and return', async () => {
+      const params = { x: new NativeType('number') };
+      const a = new FunctionType(params, NumberType);
+      const b = new FunctionType({ x: new NativeType('number') }, NumberType);
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('does not equal FunctionType with different return type', async () => {
+      const params = {};
+      const a = new FunctionType(params, StringType);
+      const b = new FunctionType(params, NumberType);
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
+
+  await describe('@ts-for-gir/lib — GenericType', async () => {
+    await it('constructs with an identifier string', async () => {
+      const g = new GenericType('T');
+      expect(g instanceof GenericType).toBeTruthy();
+    });
+
+    await it('equals another GenericType with same identifier', async () => {
+      const a = new GenericType('T');
+      const b = new GenericType('T');
+      expect(a.equals(b)).toBeTruthy();
+    });
+
+    await it('does not equal GenericType with different identifier', async () => {
+      const a = new GenericType('T');
+      const b = new GenericType('U');
+      expect(a.equals(b)).toBeFalsy();
+    });
+  });
+};

--- a/tests/integration/ts-for-gir/src/test.mts
+++ b/tests/integration/ts-for-gir/src/test.mts
@@ -9,7 +9,11 @@
 
 import { run } from '@gjsify/unit';
 import parserSuite from './parser.spec.js';
+import libSuite from './lib.spec.js';
+import generatorSuite from './generator.spec.js';
 
 run({
   parserSuite,
+  libSuite,
+  generatorSuite,
 });

--- a/tests/integration/ts-for-gir/tsconfig.json
+++ b/tests/integration/ts-for-gir/tsconfig.json
@@ -11,6 +11,8 @@
     },
     "files": [
         "src/test.mts",
-        "src/parser.spec.ts"
+        "src/parser.spec.ts",
+        "src/lib.spec.ts",
+        "src/generator.spec.ts"
     ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,6 +3450,8 @@ __metadata:
     "@gjsify/cli": "workspace:^"
     "@gjsify/runtime": "workspace:^"
     "@gjsify/unit": "workspace:^"
+    "@ts-for-gir/generator-typescript": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/lib": "npm:^4.0.0-rc.6"
     "@types/node": "npm:^25.6.0"
     typescript: "npm:^6.0.3"
   languageName: unknown
@@ -6616,6 +6618,53 @@ __metadata:
     ts-for-gir: bin/ts-for-gir
     ts-for-gir-dev: bin/ts-for-gir-dev
   checksum: 10/70d71e09a88afeb264395946d8e60d8d2fd1993637adc326aaa256910bba746727efaa7f71ea1ac0da609f9c027576a1240334869f11e709d188ccb6ced2dac0
+  languageName: node
+  linkType: hard
+
+"@ts-for-gir/generator-base@npm:^4.0.0-rc.6":
+  version: 4.0.0-rc.6
+  resolution: "@ts-for-gir/generator-base@npm:4.0.0-rc.6"
+  dependencies:
+    "@ts-for-gir/lib": "npm:^4.0.0-rc.6"
+  checksum: 10/cbfd23389a5b5e58aed22580fa50040950a56c9622b055ff811cfb5821ac1a8f5eaf843a58c88776c3116e63a499762e8d792ae79fc554abfbd082530d1cb120
+  languageName: node
+  linkType: hard
+
+"@ts-for-gir/generator-typescript@npm:^4.0.0-rc.6":
+  version: 4.0.0-rc.6
+  resolution: "@ts-for-gir/generator-typescript@npm:4.0.0-rc.6"
+  dependencies:
+    "@gi.ts/parser": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/generator-base": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/lib": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/templates": "npm:^4.0.0-rc.6"
+    ejs: "npm:^5.0.2"
+    xml2js: "npm:^0.6.2"
+  checksum: 10/d24eb3e432ca6ffae85d0a18ddda88dbe5b5d5fe2e70ad8b7677a8e1f84662fd67b73af207b457bba26fee1d0603b46e2053516453ff4040d0f0c55ab6f22de5
+  languageName: node
+  linkType: hard
+
+"@ts-for-gir/lib@npm:^4.0.0-rc.6":
+  version: 4.0.0-rc.6
+  resolution: "@ts-for-gir/lib@npm:4.0.0-rc.6"
+  dependencies:
+    "@gi.ts/parser": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/reporter": "npm:^4.0.0-rc.6"
+    "@ts-for-gir/templates": "npm:^4.0.0-rc.6"
+    colorette: "npm:^2.0.20"
+    ejs: "npm:^5.0.2"
+    glob: "npm:^13.0.6"
+    lodash: "npm:4.18.1"
+  checksum: 10/ed878456af3e4b5225f7e1e30ca76a0563b04189ddfe6c9bcb7742051888684d1a13f5d8ed2eb225834dfe18ba254ae6cbbeba88a0e7d589067219064d8005f6
+  languageName: node
+  linkType: hard
+
+"@ts-for-gir/reporter@npm:^4.0.0-rc.6":
+  version: 4.0.0-rc.6
+  resolution: "@ts-for-gir/reporter@npm:4.0.0-rc.6"
+  dependencies:
+    colorette: "npm:^2.0.20"
+  checksum: 10/5c215b2b0a6afe88c628267d9f6121d7793a8c452d1ed8734c0624f2cad67eb8037548bbcb4104b890e6176b554431b00f786a70668e307ef3d6a3eefae97088
   languageName: node
   linkType: hard
 
@@ -12342,6 +12391,13 @@ __metadata:
   version: 4.7.0
   resolution: "lodash.uniqby@npm:4.7.0"
   checksum: 10/256616bd1bd6be84d8a5eceb61338a0ab8d8b34314ba7bfd5f0de35227d0e2c1e659c61ff4ac31eba6a664085cc7e397bc34c3534fba208102db660a4f98f211
+  languageName: node
+  linkType: hard
+
+"lodash@npm:4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **Phase 2 (`lib.spec.ts`, 51 tests):** Validates the full `TypeExpression` class hierarchy from `@ts-for-gir/lib` as pure value-objects — `TypeIdentifier`, `ModuleTypeIdentifier`, `NativeType`, `OrType`/`BinaryType` (set-semantic `equals()`), `TupleType` (positional `equals()`), `FunctionType`, `PromiseType`/`ClosureType` (`unwrap()`/`deepUnwrap()` semantics), `NullableType`, `ArrayType`, `GenericType`, and all 13 primitive singleton constants.
- **Phase 3 (`generator.spec.ts`, 18 tests):** Exercises the full `DependencyManager.get()` → `GirModule.load()` → `GirModule.parse()` → `initTransitiveDependencies()` → `ModuleGenerator.generateModule()` pipeline against a minimal synthetic GIR written to `tmpdir()`. Confirms `glob`, `ejs`, `lodash`, `colorette` all work on GJS via `@gjsify/*` polyfills.
- **Node: 169/169 green. GJS: 169/169 green, 0 skips.**
- New devDeps: `@ts-for-gir/lib@^4.0.0-rc.6`, `@ts-for-gir/generator-typescript@^4.0.0-rc.6`.

Follows PR #55 (Phase 1: `@gi.ts/parser`).

## Key findings (Phase 3)

- `DependencyManager.get()` resolves GIRs from the **real filesystem** via `glob` — requires `girDirectories` pointing at a dir containing a `<name>-<version>.gir` file; cannot pass an in-memory repo object.
- `IntrospectedRecord.members` is `IntrospectedClassFunction[]` (array, not Map) — must use `.find()`.
- `initTransitiveDependencies([])` must be called before `new ModuleGenerator()` because the constructor reads `girModule.transitiveDependencies`.
- `allowMissingDeps: true` keeps GObject-2.0 as a stub dep — sufficient because `generateModule()` never renders EJS templates.

## Test plan

- [ ] `yarn workspace @gjsify/integration-ts-for-gir build:test` — both `dist/test.node.mjs` and `dist/test.gjs.mjs` build clean
- [ ] `yarn workspace @gjsify/integration-ts-for-gir test:node` — 169/169 green
- [ ] `yarn workspace @gjsify/integration-ts-for-gir test:gjs` — 169/169 green
- [ ] `yarn check` — typecheck clean
- [ ] CI passes (Fedora 42 / 43 / 44)