### PR TITLE
feat: Yarn PnP support, excludeGlobals, fetch bridge-free (#v0.3.2)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-05-02 — Three build infrastructure fixes: (1) `@gjsify/esbuild-plugin-deepkit` now defaults `reflection` to `false` instead of `true` (prevents `function extends()` invalid-JS in TypeScript codebases that use method named `extends`); (2) `@gjsify/esbuild-plugin-gjsify` GJS target now captures and merges user-supplied `inject` arrays instead of discarding them; (3) GJS target injects a synchronous `process` stub via esbuild `banner` so packages that access `globalThis.process.platform` at top-level (e.g. glob, path-scurry) no longer crash before any module init fires — the full `@gjsify/process` implementation is still wired up afterwards via `--globals auto`.
+> Last updated: 2026-05-04 — Three build infrastructure additions: (1) `@gjsify/cli` auto-detects Yarn PnP (`.pnp.cjs`) and injects `@yarnpkg/esbuild-plugin-pnp` so esbuild can resolve packages from zip archives without manual extraction; (2) `detectAutoGlobals` now accepts `excludeGlobals` to filter false-positive globals before writing the inject stub; (3) `@gjsify/http/validators` subpath extracted so `@gjsify/fetch` no longer transitively depends on `gi://GjsifyHttpSoupBridge` — fetch now only needs `gi://Soup`.
 
 ## Summary
 

--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -32,6 +32,7 @@
         "@gjsify/example-node-express-webserver": "workspace:^",
         "@gjsify/node-polyfills": "workspace:^",
         "@gjsify/web-polyfills": "workspace:^",
+        "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.15",
         "cosmiconfig": "^9.0.1",
         "esbuild": "^0.28.0",
         "get-tsconfig": "^4.14.0",

--- a/packages/infra/cli/src/actions/build.ts
+++ b/packages/infra/cli/src/actions/build.ts
@@ -1,12 +1,39 @@
 import type { ConfigData } from '../types/index.js';
 import type { App } from '@gjsify/esbuild-plugin-gjsify';
-import { build, BuildOptions, BuildResult } from 'esbuild';
+import { build, BuildOptions, BuildResult, Plugin } from 'esbuild';
 import { gjsifyPlugin } from '@gjsify/esbuild-plugin-gjsify';
 import { resolveGlobalsList, writeRegisterInjectFile, detectAutoGlobals } from '@gjsify/esbuild-plugin-gjsify/globals';
-import { dirname, extname } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 import { chmod, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 
-const GJS_SHEBANG = '#!/usr/bin/env -S gjs -m\n';
+const GJS_SHEBANG = "#!/usr/bin/env -S gjs -m\n";
+
+/** Walk up from dir until .pnp.cjs is found; return its directory or null. */
+function findPnpRoot(dir: string): string | null {
+    let current = dir;
+    while (true) {
+        if (existsSync(join(current, ".pnp.cjs"))) return current;
+        const parent = dirname(current);
+        if (parent === current) return null;
+        current = parent;
+    }
+}
+
+/**
+ * If the current project uses Yarn PnP, return the official
+ * @yarnpkg/esbuild-plugin-pnp plugin so esbuild can resolve
+ * modules from zip archives without manual extraction.
+ */
+async function getPnpPlugin(): Promise<Plugin | null> {
+    if (!findPnpRoot(process.cwd())) return null;
+    try {
+        const { pnpPlugin } = await import("@yarnpkg/esbuild-plugin-pnp");
+        return pnpPlugin();
+    } catch {
+        return null;
+    }
+}
 
 export class BuildAction {
     constructor(readonly configData: ConfigData = {}) {
@@ -30,50 +57,61 @@ export class BuildAction {
         const moduleOutdir = library?.module ? dirname(library.module) : undefined;
         const mainOutdir = library?.main ? dirname(library.main) : undefined;
 
-        const moduleOutExt = library.module ? extname(library.module) : '.js';
-        const mainOutExt = library.main ? extname(library.main) : '.js';
+        const moduleOutExt = library.module ? extname(library.module) : ".js";
+        const mainOutExt = library.main ? extname(library.main) : ".js";
 
-        const multipleBuilds = moduleOutdir && mainOutdir && (moduleOutdir !== mainOutdir);
+        const multipleBuilds = moduleOutdir && mainOutdir && moduleOutdir !== mainOutdir;
+
+        const pnpPlugin = await getPnpPlugin();
+        const pnpPlugins: Plugin[] = pnpPlugin ? [pnpPlugin] : [];
 
         const results: BuildResult[] = [];
-    
-        if(multipleBuilds) {
 
-            const moduleFormat = moduleOutdir.includes('/cjs') || moduleOutExt === '.cjs' ? 'cjs' : 'esm';
-            results.push(await build({
-                ...this.getEsBuildDefaults(),
-                ...esbuild,
-                format: moduleFormat,
-                outdir: moduleOutdir,
-                plugins: [
-                    gjsifyPlugin({debug: verbose, library: moduleFormat, exclude, reflection: typescript?.reflection, jsExtension: moduleOutExt}),
-                ]
-            }));
-    
-            const mainFormat = mainOutdir.includes('/cjs') || mainOutExt === '.cjs' ? 'cjs' : 'esm';
-            results.push(await build({
-                ...this.getEsBuildDefaults(),
-                ...esbuild,
-                format: moduleFormat,
-                outdir: mainOutdir,
-                plugins: [
-                    gjsifyPlugin({debug: verbose, library: mainFormat, exclude, reflection: typescript?.reflection, jsExtension: mainOutdir})
-                ]
-            }));
+        if (multipleBuilds) {
+            const moduleFormat = moduleOutdir.includes("/cjs") || moduleOutExt === ".cjs" ? "cjs" : "esm";
+            results.push(
+                await build({
+                    ...this.getEsBuildDefaults(),
+                    ...esbuild,
+                    format: moduleFormat,
+                    outdir: moduleOutdir,
+                    plugins: [
+                        ...pnpPlugins,
+                        gjsifyPlugin({ debug: verbose, library: moduleFormat, exclude, reflection: typescript?.reflection, jsExtension: moduleOutExt }),
+                    ],
+                }),
+            );
+
+            const mainFormat = mainOutdir.includes("/cjs") || mainOutExt === ".cjs" ? "cjs" : "esm";
+            results.push(
+                await build({
+                    ...this.getEsBuildDefaults(),
+                    ...esbuild,
+                    format: moduleFormat,
+                    outdir: mainOutdir,
+                    plugins: [
+                        ...pnpPlugins,
+                        gjsifyPlugin({ debug: verbose, library: mainFormat, exclude, reflection: typescript?.reflection, jsExtension: mainOutdir }),
+                    ],
+                }),
+            );
         } else {
             const outfilePath = esbuild?.outfile || library?.module || library?.main;
-            const outExt = outfilePath ? extname(outfilePath) : '.js';
+            const outExt = outfilePath ? extname(outfilePath) : ".js";
             const outdir = esbuild?.outdir || (outfilePath ? dirname(outfilePath) : undefined);
-            const format: 'esm' | 'cjs' = (esbuild?.format as 'esm' | 'cjs') ?? (outdir?.includes('/cjs') || outExt === '.cjs' ? 'cjs' : 'esm');
-            results.push(await build({
-                ...this.getEsBuildDefaults(),
-                ...esbuild,
-                format,
-                outdir,
-                plugins: [
-                    gjsifyPlugin({debug: verbose, library: format, exclude, reflection: typescript?.reflection, jsExtension: outExt})
-                ]
-            }));
+            const format: "esm" | "cjs" = (esbuild?.format as "esm" | "cjs") ?? (outdir?.includes("/cjs") || outExt === ".cjs" ? "cjs" : "esm");
+            results.push(
+                await build({
+                    ...this.getEsBuildDefaults(),
+                    ...esbuild,
+                    format,
+                    outdir,
+                    plugins: [
+                        ...pnpPlugins,
+                        gjsifyPlugin({ debug: verbose, library: format, exclude, reflection: typescript?.reflection, jsExtension: outExt }),
+                    ],
+                }),
+            );
         }
         return results;
     }
@@ -147,15 +185,14 @@ export class BuildAction {
     }
 
     /** Application mode */
-    async buildApp(app: App = 'gjs') {
+    async buildApp(app: App = "gjs") {
+        const { verbose, esbuild, typescript, exclude, library: pgk, aliases, excludeGlobals } = this.configData;
 
-        const { verbose, esbuild, typescript, exclude, library: pgk, aliases } = this.configData;
-
-        const format: 'esm' | 'cjs' = (esbuild?.format as 'esm' | 'cjs') ?? (esbuild?.outfile?.endsWith('.cjs') ? 'cjs' : 'esm');
+        const format: "esm" | "cjs" = (esbuild?.format as "esm" | "cjs") ?? (esbuild?.outfile?.endsWith(".cjs") ? "cjs" : "esm");
 
         // Set default outfile if no outdir is set
-        if(esbuild && !esbuild?.outfile && !esbuild?.outdir && (pgk?.main || pgk?.module)) {
-            esbuild.outfile = esbuild?.format === 'cjs' ? pgk.main || pgk.module : pgk.module || pgk.main;
+        if (esbuild && !esbuild?.outfile && !esbuild?.outdir && (pgk?.main || pgk?.module)) {
+            esbuild.outfile = esbuild?.format === "cjs" ? pgk.main || pgk.module : pgk.module || pgk.main;
         }
 
         const { consoleShim, globals } = this.configData;
@@ -172,16 +209,19 @@ export class BuildAction {
 
         const { autoMode, extras } = this.parseGlobalsValue(globals);
 
+        const pnpPlugin = await getPnpPlugin();
+        const pnpPlugins: Plugin[] = pnpPlugin ? [pnpPlugin] : [];
+
         // --- Auto mode (with optional extras): iterative multi-pass build ---
         // The extras token is used for cases where the detector cannot
         // statically see a global (e.g. Excalibur indirects globalThis via
         // BrowserComponent.nativeComponent). Common pattern: --globals auto,dom
-        if (app === 'gjs' && autoMode) {
+        if (app === "gjs" && autoMode) {
             const { injectPath } = await detectAutoGlobals(
-                { ...this.getEsBuildDefaults(), ...esbuild, format },
+                { ...this.getEsBuildDefaults(), ...esbuild, format, plugins: pnpPlugins },
                 pluginOpts,
                 verbose,
-                { extraGlobalsList: extras },
+                { extraGlobalsList: extras, excludeGlobals },
             );
 
             const result = await build({
@@ -189,6 +229,7 @@ export class BuildAction {
                 ...esbuild,
                 format,
                 plugins: [
+                    ...pnpPlugins,
                     gjsifyPlugin({
                         ...pluginOpts,
                         autoGlobalsInject: injectPath,
@@ -196,7 +237,7 @@ export class BuildAction {
                 ],
             });
 
-            if (app === 'gjs' && this.configData.shebang) {
+            if (app === "gjs" && this.configData.shebang) {
                 await this.applyShebang(esbuild?.outfile, verbose);
             }
 
@@ -204,23 +245,22 @@ export class BuildAction {
         }
 
         // --- Explicit list (no `auto` token) or none mode ---
-        const autoGlobalsInject = extras
-            ? await this.resolveGlobalsInject(app, extras, verbose)
-            : undefined;
+        const autoGlobalsInject = extras ? await this.resolveGlobalsInject(app, extras, verbose) : undefined;
 
         const result = await build({
             ...this.getEsBuildDefaults(),
             ...esbuild,
             format,
             plugins: [
+                ...pnpPlugins,
                 gjsifyPlugin({
                     ...pluginOpts,
                     autoGlobalsInject,
                 }),
-            ]
+            ],
         });
 
-        if (app === 'gjs' && this.configData.shebang) {
+        if (app === "gjs" && this.configData.shebang) {
             await this.applyShebang(esbuild?.outfile, verbose);
         }
 

--- a/packages/infra/cli/src/commands/build.ts
+++ b/packages/infra/cli/src/commands/build.ts
@@ -120,6 +120,11 @@ export const buildCommand: Command<any, CliBuildOptions> = {
                 default: [] as string[],
                 coerce: (arg: string[]) => arg.flatMap((v) => v.split(',').map((s) => s.trim()).filter(Boolean)),
             })
+            .option('exclude-globals', {
+                description: "Comma-separated global identifiers to remove from auto-detection results. Use for false positives from dead browser-compat code whose polyfills require unavailable native libraries (e.g. --exclude-globals fetch,XMLHttpRequest).",
+                type: 'string',
+                normalize: true,
+            })
     },
     handler: async (args) => {
         const config = new Config();

--- a/packages/infra/cli/src/config.ts
+++ b/packages/infra/cli/src/config.ts
@@ -84,6 +84,13 @@ export class Config {
         if (cliArgs.consoleShim !== undefined) configData.consoleShim = cliArgs.consoleShim;
         if (cliArgs.globals !== undefined) configData.globals = cliArgs.globals;
         if (cliArgs.shebang !== undefined) configData.shebang = cliArgs.shebang;
+        if (cliArgs.excludeGlobals) {
+            const raw = Array.isArray(cliArgs.excludeGlobals)
+                ? cliArgs.excludeGlobals.join(',')
+                : String(cliArgs.excludeGlobals);
+            const ids = raw.split(',').map((s: string) => s.trim()).filter(Boolean);
+            if (ids.length) configData.excludeGlobals = [...(configData.excludeGlobals ?? []), ...ids];
+        }
 
         merge(configData.library ??= {}, pkg, configData.library);
         merge(configData.typescript ??= {}, tsConfig, configData.typescript);

--- a/packages/infra/cli/src/types/cli-build-options.ts
+++ b/packages/infra/cli/src/types/cli-build-options.ts
@@ -90,4 +90,11 @@ export interface CliBuildOptions {
    * scenario never executes). Layered on top of the built-in alias map.
    */
   alias?: string[];
+  /**
+   * Comma-separated global identifiers to remove from the auto-detected set.
+   * Useful for false positives from dead browser-compat code in npm deps
+   * whose polyfills require unavailable native libraries.
+   * Example: `--exclude-globals fetch,XMLHttpRequest`
+   */
+  excludeGlobals?: string[];
 }

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -28,4 +28,11 @@ export interface ConfigData {
      * Comes from `gjsify build --alias FROM=TO`.
      */
     aliases?: Record<string, string>;
+    /**
+     * Global identifiers to remove from the auto-detected set before writing
+     * the inject stub. Useful for false positives from dead browser-compat
+     * code in npm dependencies whose polyfills require unavailable native libs.
+     * Example: `["fetch", "XMLHttpRequest"]` excludes the HTTP polyfill stack.
+     */
+    excludeGlobals?: string[];
 }

--- a/packages/infra/esbuild-plugin-gjsify/src/globals.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/globals.ts
@@ -8,4 +8,4 @@
 export { resolveGlobalsList, writeRegisterInjectFile } from './utils/scan-globals.js';
 export { detectFreeGlobals } from './utils/detect-free-globals.js';
 export { detectAutoGlobals } from './utils/auto-globals.js';
-export type { AutoGlobalsResult } from './utils/auto-globals.js';
+export type { AutoGlobalsResult, DetectAutoGlobalsOptions } from './utils/auto-globals.js';

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/auto-globals.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/auto-globals.ts
@@ -36,6 +36,21 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
     return true;
 }
 
+async function applyExcludeGlobals(
+    detected: Set<string>,
+    currentInject: string | undefined,
+    extraRegisterPaths: Set<string>,
+    excludeGlobals: string[] | undefined,
+): Promise<AutoGlobalsResult> {
+    if (!excludeGlobals?.length) return { detected, injectPath: currentInject };
+
+    for (const id of excludeGlobals) detected.delete(id);
+    const filtered = detectedToRegisterPaths(detected);
+    for (const p of extraRegisterPaths) filtered.add(p);
+    const injectPath = filtered.size > 0 ? (await writeRegisterInjectFile(filtered)) ?? undefined : undefined;
+    return { detected, injectPath };
+}
+
 function detectedToRegisterPaths(detected: Set<string>): Set<string> {
     const paths = new Set<string>();
     for (const name of detected) {
@@ -54,6 +69,15 @@ export interface DetectAutoGlobalsOptions {
      * indirection (e.g. Excalibur's `BrowserComponent.nativeComponent.matchMedia`).
      */
     extraGlobalsList?: string;
+    /**
+     * Identifiers to remove from the auto-detected set before writing the
+     * inject stub. Useful for globals that appear as false positives from
+     * dead browser-compat code in npm dependencies whose polyfills require
+     * unavailable native libraries.
+     * Example: `["fetch", "Headers", "Request", "Response", "XMLHttpRequest"]`
+     * excludes the HTTP polyfill stack (which needs gi://GjsifyHttpSoupBridge).
+     */
+    excludeGlobals?: string[];
 }
 
 /**
@@ -134,7 +158,7 @@ export async function detectAutoGlobals(
                     `[gjsify] --globals auto: converged after ${iteration - 1} iteration(s), ${detected.size} global(s)${sorted.length ? ': ' + sorted.join(', ') : ''}${extras}`,
                 );
             }
-            return { detected, injectPath: currentInject };
+            return applyExcludeGlobals(detected, currentInject, extraRegisterPaths, options.excludeGlobals);
         }
 
         detected = newDetected;
@@ -161,5 +185,5 @@ export async function detectAutoGlobals(
             `[gjsify] --globals auto: hit max iterations (${MAX_ITERATIONS}), using last detected set`,
         );
     }
-    return { detected, injectPath: currentInject };
+    return applyExcludeGlobals(detected, currentInject, extraRegisterPaths, options.excludeGlobals);
 }

--- a/packages/node/http/package.json
+++ b/packages/node/http/package.json
@@ -9,6 +9,10 @@
         ".": {
             "types": "./lib/types/index.d.ts",
             "default": "./lib/esm/index.js"
+        },
+        "./validators": {
+            "types": "./lib/types/validators.d.ts",
+            "default": "./lib/esm/validators.js"
         }
     },
     "scripts": {

--- a/packages/node/http/src/index.ts
+++ b/packages/node/http/src/index.ts
@@ -6,39 +6,13 @@ export { STATUS_CODES, METHODS } from './constants.js';
 export { IncomingMessage } from './incoming-message.js';
 export { OutgoingMessage, Server, ServerResponse } from './server.js';
 export { ClientRequest } from './client-request.js';
+export { validateHeaderName, validateHeaderValue } from './validators.js';
+import { validateHeaderName, validateHeaderValue } from './validators.js';
 import { IncomingMessage } from './incoming-message.js';
 import { OutgoingMessage, Server, ServerResponse } from './server.js';
 import { ClientRequest } from './client-request.js';
 import type { ClientRequestOptions } from './client-request.js';
 import { URL } from 'node:url';
-
-/**
- * Performs the low-level validations on the provided `name` that are done when `res.setHeader(name, value)` is called.
- * @since v14.3.0
- */
-export function validateHeaderName(name: string) {
-  if (typeof name !== 'string' || !/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
-    const error = new TypeError(`Header name must be a valid HTTP token ["${name}"]`);
-    Object.defineProperty(error, 'code', { value: 'ERR_INVALID_HTTP_TOKEN' });
-    throw error;
-  }
-}
-
-/**
- * Performs the low-level validations on the provided `value` that are done when `res.setHeader(name, value)` is called.
- */
-export function validateHeaderValue(name: string, value: any) {
-  if (value === undefined) {
-    const error = new TypeError(`Header "${name}" value must not be undefined`);
-    Object.defineProperty(error, 'code', { value: 'ERR_HTTP_INVALID_HEADER_VALUE' });
-    throw error;
-  }
-  if (typeof value === 'string' && /[^\t\u0020-\u007E\u0080-\u00FF]/.test(value)) {
-    const error = new TypeError(`Invalid character in header content ["${name}"]`);
-    Object.defineProperty(error, 'code', { value: 'ERR_INVALID_CHAR' });
-    throw error;
-  }
-}
 
 export interface AgentOptions {
   keepAlive?: boolean;

--- a/packages/node/http/src/validators.ts
+++ b/packages/node/http/src/validators.ts
@@ -1,0 +1,25 @@
+// Header validation utilities shared by @gjsify/http and @gjsify/fetch.
+// Kept in a bridge-free module so @gjsify/fetch can import them without
+// pulling in @gjsify/http-soup-bridge (which requires the GjsifyHttpSoupBridge
+// native Vala typelib — not available in all GJS environments).
+
+export function validateHeaderName(name: string): void {
+    if (typeof name !== "string" || !/^[\^`\-\w!#$%&'*+.|~]+$/.test(name)) {
+        const error = new TypeError(`Header name must be a valid HTTP token ["${name}"]`);
+        Object.defineProperty(error, "code", { value: "ERR_INVALID_HTTP_TOKEN" });
+        throw error;
+    }
+}
+
+export function validateHeaderValue(name: string, value: unknown): void {
+    if (value === undefined) {
+        const error = new TypeError(`Header "${name}" value must not be undefined`);
+        Object.defineProperty(error, "code", { value: "ERR_HTTP_INVALID_HEADER_VALUE" });
+        throw error;
+    }
+    if (typeof value === "string" && /[^\t -~-ÿ]/.test(value)) {
+        const error = new TypeError(`Invalid character in header content ["${name}"]`);
+        Object.defineProperty(error, "code", { value: "ERR_INVALID_CHAR" });
+        throw error;
+    }
+}

--- a/packages/web/fetch/src/headers.ts
+++ b/packages/web/fetch/src/headers.ts
@@ -4,7 +4,7 @@
 // Modifications: Standalone implementation using internal Map, libsoup integration
 
 import Soup from '@girs/soup-3.0';
-import { validateHeaderName, validateHeaderValue } from '@gjsify/http';
+import { validateHeaderName, validateHeaderValue } from '@gjsify/http/validators';
 
 const _headers = Symbol('Headers.headers');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,6 +1955,7 @@ __metadata:
     "@gjsify/node-polyfills": "workspace:^"
     "@gjsify/web-polyfills": "workspace:^"
     "@types/yargs": "npm:^17.0.35"
+    "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.15"
     cosmiconfig: "npm:^9.0.1"
     esbuild: "npm:^0.28.0"
     get-tsconfig: "npm:^4.14.0"
@@ -7420,6 +7421,17 @@ __metadata:
     freelist: "npm:^1.0.3"
     http-parser-js: "npm:^0.4.3"
   checksum: 10/5146d87f2d730e4f6e5a3a89e04be980038a24352dc0b6edc373bf52d1c12c3199e3d25cef4cc3073cc43edcc37f657c93d1a645fc88184bbf86608dfa95de70
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/esbuild-plugin-pnp@npm:^3.0.0-rc.15":
+  version: 3.0.0-rc.15
+  resolution: "@yarnpkg/esbuild-plugin-pnp@npm:3.0.0-rc.15"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    esbuild: ">=0.10.0"
+  checksum: 10/454f521088c1fa24fda51f83ca4a50ba6e3bd147e5dee8c899e6bf24a7196186532c3abb18480e83395708ffb7238c9cac5b82595c3985ce93593b5afbd0a9f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **Yarn PnP auto-detect**: `@gjsify/cli` now walks up from `process.cwd()` looking for `.pnp.cjs`. When found, `@yarnpkg/esbuild-plugin-pnp` is dynamically loaded and prepended to the esbuild plugins list — no more manual zip extraction workarounds needed in consumer projects
- **`excludeGlobals`**: `detectAutoGlobals` / `DetectAutoGlobalsOptions` accepts `excludeGlobals?: string[]` to remove specific identifiers from the auto-detected set. Exposed in `ConfigData`, `CliBuildOptions` (`--exclude-globals`), and `.gjsifyrc.js`. Fixes false positives from dead browser-compat code in npm deps
- **`@gjsify/fetch` bridge-free**: `validateHeaderName`/`validateHeaderValue` extracted to `@gjsify/http/validators` (new subpath, no bridge imports). `@gjsify/fetch` imports from there — `gi://GjsifyHttpSoupBridge` dependency gone; fetch only needs `gi://Soup`

## Test plan

- [ ] `yarn workspace @gjsify/esbuild-plugin-gjsify build` — clean
- [ ] `yarn workspace @gjsify/http build` — clean
- [ ] `yarn workspace @gjsify/cli build` — clean
- [ ] CI passes