### PR TITLE
Phase A: v0.3.5 bug fixes + @gjsify/webassembly polyfill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning — consult `refs/` submodules and `@girs/*` types before pre-trained knowledge.
 
-Node.js/Web/DOM API + Framework for GJS (GNOME JS). Yarn workspaces monorepo, v0.3.4, ESM-only, GNOME libs. Four equal pillars: **Node.js** `packages/node/` (42 + 1 meta) | **Web** `packages/web/` (19 + 1 meta) | **DOM** `packages/dom/` (2) | **Framework** `packages/framework/` (6 bridge pkgs). `packages/infra/` + `packages/gjs/` = supporting infra.
+Node.js/Web/DOM API + Framework for GJS (GNOME JS). Yarn workspaces monorepo, v0.3.4, ESM-only, GNOME libs. Four equal pillars: **Node.js** `packages/node/` (42 + 1 meta) | **Web** `packages/web/` (20 + 1 meta) | **DOM** `packages/dom/` (2) | **Framework** `packages/framework/` (6 bridge pkgs). `packages/infra/` + `packages/gjs/` = supporting infra.
 
 ## Governance — non-negotiable
 
@@ -81,6 +81,7 @@ Node.js/Web/DOM API + Framework for GJS (GNOME JS). Yarn workspaces monorepo, v0
 | eventsource | Soup 3.0 | EventSource (SSE) |
 | websocket | Soup 3.0 | WebSocket, MessageEvent, CloseEvent. NUL-byte-safe text frames (send via `send_message(TEXT, GLib.Bytes)` — Soup's `send_text` truncates at `\0`). RFC 6455 fuzz-validated via Autobahn |
 | webstorage | Gio | localStorage, sessionStorage |
+| webassembly | — | Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey 128's working synchronous `new WebAssembly.{Module,Instance}` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` via new `WebAssembly.<method>` METHOD_MARKERS. |
 | webaudio | Gst 1.0, GstApp 1.0 | AudioContext(decodeAudioData via GStreamer decodebin), AudioBufferSourceNode(appsrc→volume→autoaudiosink), GainNode(AudioParam+setTargetAtTime), AudioBuffer(PCM Float32), HTMLAudioElement(canPlayType+playbin). Phase 1 |
 | webrtc | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | Full W3C WebRTC — RTCPeerConnection, RTCDataChannel (string+binary), RTCRtpSender/Receiver/Transceiver, MediaStream, MediaStreamTrack, getUserMedia (pipewiresrc/pulsesrc/v4l2src fallback chain), RTCDTMFSender, RTCCertificate, RTCStatsReport, RTCIceCandidate, RTCSessionDescription. Tee-multiplexer for shared-source fan-out (VideoBridge preview ↔ PC sender). Backed by `@gjsify/webrtc-native` |
 | webrtc-native | Gst 1.0, GstWebRTC 1.0 | **Vala/GObject prebuild.** Three main-thread signal bridges: `WebrtcbinBridge` (wraps `on-negotiation-needed`/`on-ice-candidate`/`on-data-channel` + `notify::*-state`), `DataChannelBridge` (wraps GstWebRTCDataChannel's `on-open`/`on-close`/`on-error`/`on-message-string`/`on-message-data`/`on-buffered-amount-low` + `notify::ready-state`), `PromiseBridge` (wraps `Gst.Promise.new_with_change_func`). Captures signals on C side, re-emits via `GLib.Idle.add()` on the GLib main context — makes webrtcbin's streaming-thread callbacks safe to handle from JS. Ships as `.so` + `.typelib` prebuild for linux-{x86_64,aarch64} |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased] — Phase A bug fixes for v0.3.5
+
+### Bug Fixes
+
+* **esbuild-plugin-gjsify:** `rewrite-node-modules-paths` handles Yarn PnP zip-cached files. Skips paths fs.readFile cannot open and registers the rewrite hook for the `pnp` namespace too — bundled `typescript.js` from a PnP zip no longer crashes with `ReferenceError: __filename is not defined`.
+* **cli:** `getPnpPlugin` two-hop relay now resolves through the polyfill packages' `package.json` paths instead of their `main`. The meta polyfills have no `main`/`module` field, so the previous resolution fell back silently and missed every transitive `@gjsify/*` register subpath. External consumers no longer need to redeclare each `@gjsify/<pkg>` as a direct devDep.
+* **cli:** `--shebang` no longer overrides `shebang: true` from `.gjsifyrc.js`. Yargs' `default: false` made `cliArgs.shebang` always defined, which clobbered the config-file value through the `if (cliArgs.shebang !== undefined)` merge.
+
+### Features
+
+* **webassembly:** new `@gjsify/webassembly` package — Promise-API polyfill that wraps SpiderMonkey 128's working synchronous `new WebAssembly.Module(buffer)` / `new WebAssembly.Instance(module, imports)` constructors. Replaces `WebAssembly.{compile,compileStreaming,instantiate,instantiateStreaming,validate}` (which throw `WebAssembly Promise APIs not supported in this runtime` on first call). 15 tests pass on both Node + GJS.
+* **resolve-npm:** `WebAssembly` added to `GJS_GLOBALS_GROUPS.web` and `GJS_GLOBALS_MAP`. `--globals auto` injects the polyfill whenever `WebAssembly.{compile,instantiate,validate}` etc. appear in the bundle (via new `METHOD_MARKERS` in `detect-free-globals.ts`).
+
 ## [0.3.4](https://github.com/gjsify/gjsify/compare/v0.3.3...v0.3.4) (2026-05-04)
 
 ### Features

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # gjsify — Project Status
 
-> Last updated: 2026-05-04 — Phases 6b + 8 of ts-for-gir integration. Runtime-relative `import.meta.url` rewriting (ESM) + absolute `__dirname`/`__filename` literals (CJS) factored into shared `utils/rewrite-node-modules-paths.ts` (deduplicated across GJS + Node app targets). Phase 6b: `generator-typedoc.spec.ts` (3 JSON tests cross-platform; 2 HTML tests Node-only — TypeDoc shiki needs WebAssembly). Phase 8 partial: `language-server.spec.ts` (21 pure-TS tests, Node-only — `typescript` CJS pkg). Node: 276/276 ✓. GJS: 212/212 ✓ (3 ignored). v0.3.4 published; downstream `gjsify/ts-for-gir` PR #378 surfaced 3 v0.3.5 follow-ups (PnP zip read, two-hop relay, shebang config) — see Open TODOs.
+> Last updated: 2026-05-04 — Phase A v0.3.5 bug fixes landed: PnP zip read (rewrite-node-modules-paths now skips unreadable fs paths and registers for `pnp` namespace), PnP two-hop relay (resolves polyfills via `package.json`, not `main`), shebang config (yargs default removed). New `@gjsify/webassembly` package — Promise-API polyfill (compile/instantiate/validate/streaming) wrapping SpiderMonkey 128's synchronous Module/Instance constructors. 15 tests ✓ on Node + GJS. Auto-globals detector picks up `WebAssembly.{compile,instantiate,validate}` via new METHOD_MARKERS. Earlier (Phases 6b + 8): runtime-relative `import.meta.url` rewriting (ESM) + absolute `__dirname`/`__filename` literals (CJS) in shared `utils/rewrite-node-modules-paths.ts`; `generator-typedoc.spec.ts` (3 JSON tests cross-platform, 2 HTML tests Node-only); `language-server.spec.ts` (21 pure-TS tests, Node-only). Node: 291/291 ✓. GJS: 227/227 ✓ (3 ignored).
 
 ## Summary
 
@@ -11,7 +11,7 @@ The project comprises **43 Node.js packages** (+1 meta), **19 Web API packages**
 |----------|-------|------|---------|------|
 | Node.js APIs | 43 | 35 (81%) | 5 (12%) | 4 (9%) |
 | Node.js meta | 1 | 1 | — | — |
-| Web APIs | 19 | 17 (89%) | 2 (11%) | — |
+| Web APIs | 20 | 18 (90%) | 2 (10%) | — |
 | Web meta | 1 | 1 | — | — |
 | DOM / Bridges | 8 | 8 (100%) | — | — |
 | Browser UI | 3 | 3 (adwaita-web, adwaita-fonts, adwaita-icons) | — | — |
@@ -100,7 +100,7 @@ The project comprises **43 Node.js packages** (+1 meta), **19 Web API packages**
 
 ## Web API Packages (`packages/web/`)
 
-All 19 packages have real implementations (plus 1 meta). New in this cycle: `@gjsify/xmlhttprequest` (split out of fetch), `@gjsify/domparser` (excalibur-tiled), `@gjsify/webrtc`, `@gjsify/webrtc-native`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons`, `@gjsify/web-polyfills`.
+All 20 packages have real implementations (plus 1 meta). New in this cycle: `@gjsify/xmlhttprequest` (split out of fetch), `@gjsify/domparser` (excalibur-tiled), `@gjsify/webrtc`, `@gjsify/webrtc-native`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons`, `@gjsify/web-polyfills`, `@gjsify/webassembly` (Promise-API polyfill).
 
 | Package | GNOME Libs | Tests | Web APIs |
 |---------|-----------|-------|----------|
@@ -122,6 +122,7 @@ All 19 packages have real implementations (plus 1 meta). New in this cycle: `@gj
 | **webrtc** | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | 302 (4 specs) | **Phase 1–4 — Data Channel + Media + Stats & Advanced.** RTCPeerConnection (offer/answer, ICE trickle, STUN/TURN config, addTransceiver, addTrack, removeTrack, getStats, restartIce, setConfiguration), RTCDataChannel (string + binary send/receive, bufferedAmount, binaryType), RTCRtpSender (track, getParameters/setParameters, replaceTrack, getCapabilities, getStats delegation), RTCRtpReceiver (track with muted→unmuted via ReceiverBridge, jitterBufferTarget, getStats delegation), RTCRtpTransceiver (mid, direction, stop, setCodecPreferences), MediaStream, MediaStreamTrack (GStreamer source integration, enabled→valve), getUserMedia (pipewiresrc/pulsesrc/v4l2src fallback), MediaDevices, **RTCDTMFSender** (spec-compliant tone/duration/gap, `tonechange` event), **RTCCertificate** (generateCertificate, W3C expiry), **RTCDtlsTransport / RTCIceTransport / RTCSctpTransport** (thin proxies), **RTCStatsReport** (GstStructure → W3C camelCase conversion via `gst-stats-parser.ts`). Outgoing pipeline: source→valve→convert→encode(opus/vp8)→payloader→capsfilter→webrtcbin. End-to-end bidirectional audio verified. Registers via `@gjsify/webrtc/register` (granular subpaths) — `--globals auto` picks them up. Requires GStreamer ≥ 1.20 with gst-plugins-bad + libnice-gstreamer. |
 | **webrtc-native** | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | — | Vala/GObject library consumed by `@gjsify/webrtc`. Exposes three main-thread signal bridges: `WebrtcbinBridge` (wraps webrtcbin's `on-negotiation-needed` / `on-ice-candidate` / `on-data-channel` + `notify::*-state`), `DataChannelBridge` (wraps GstWebRTCDataChannel's `on-open` / `on-close` / `on-error` / `on-message-string` / `on-message-data` / `on-buffered-amount-low` + `notify::ready-state`), `PromiseBridge` (wraps `Gst.Promise.new_with_change_func`). Each bridge connects on the C side (never invokes JS on the streaming thread) and re-emits via `GLib.Idle.add()` on the main context. Ships as prebuilt `.so` + `.typelib` in `prebuilds/linux-{x86_64,aarch64,ppc64,s390x,riscv64}/`; CI (`.github/workflows/prebuilds.yml`) rebuilds on Vala source changes (native runners for x86_64/aarch64; QEMU via `uraimo/run-on-arch-action` for ppc64/s390x/riscv64). |
 | **webstorage** | — | 41 | Storage, localStorage, sessionStorage (W3C Web Storage) |
+| **webassembly** | — | 15 | WebAssembly Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey 128's working synchronous `new WebAssembly.Module(buffer)` / `new WebAssembly.Instance(module, imports)` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` whenever the bundle references `WebAssembly.<method>` (via new `METHOD_MARKERS` in `detect-free-globals.ts`). |
 
 ### WebRTC Status
 
@@ -606,98 +607,14 @@ Fixtures (`tests/integration/ts-for-gir/girs/`) are gjsify's own Vala-generated 
 
 Tracked follow-up work that has been deliberately deferred. Every "out of scope" or "follow-up" note from a PR or implementation plan must end up here so future sessions can pick it up.
 
-### `@gjsify/webassembly` — polyfill the Promise-based WebAssembly APIs
+### Completed (Phase A — gjsify v0.3.5)
 
-**Priority: Medium — unblocks ts-for-gir `doc` on GJS + any future consumer using WASM-backed libs (shiki/oniguruma, esbuild-wasm, sql.js, …).**
+- ✅ **`@gjsify/webassembly` — Promise-based WebAssembly APIs polyfill.** Wraps SpiderMonkey 128's working synchronous `new WebAssembly.{Module,Instance}` constructors so `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming`/`validate` resolve instead of throwing `WebAssembly Promise APIs not supported in this runtime`. Granular subpath `@gjsify/webassembly/register/promise`. Added to `GJS_GLOBALS_GROUPS.web` + `GJS_GLOBALS_MAP`; new `METHOD_MARKERS` entries (`WebAssembly.compile/instantiate/validate/...`) so `--globals auto` injects the polyfill from method-call sites alone (the bare `WebAssembly` identifier is also covered). 15 tests ✓ on Node + GJS.
+- ✅ **PnP zip-cached files (rewrite-node-modules-paths.ts).** Wrap `fs.readFile()` in try/catch (skip rewrite when path is unreadable, fall through to `@yarnpkg/esbuild-plugin-pnp`'s own reader). Additionally register the rewrite hook for `namespace: "pnp"` so ESM `import.meta.url` and CJS `__dirname`/`__filename` injection still applies inside zip-resolved files.
+- ✅ **PnP two-hop relay (getPnpPlugin).** Resolve relay issuers via `${pkg}/package.json` instead of bare `pkg`. The polyfill meta packages have no `main` field, so `require.resolve(pkg)` previously failed silently → relay short-circuited and every transitive `@gjsify/*` register subpath had to be redeclared by external consumers.
+- ✅ **`--shebang` config override.** Yargs `default: false` removed so `cliArgs.shebang` is `undefined` when the flag is absent → `shebang: true` from `.gjsifyrc.js` is honoured.
 
-**Verified on GJS 1.88.0 / SpiderMonkey 140:**
-- `WebAssembly` exists as a global object ✓
-- `new WebAssembly.Module(buffer)` works (synchronous compile) ✓
-- `new WebAssembly.Instance(module, imports)` works (synchronous instantiate) ✓
-- `WebAssembly.{compile,compileStreaming,instantiate,instantiateStreaming,validate}` exist as `function` typeof but throw `Error: WebAssembly Promise APIs not supported in this runtime.` at first call ✗
-
-Since the synchronous constructors work, the Promise-based APIs are trivially polyfillable in JS:
-
-```ts
-// new packages/web/webassembly/src/register/promise.ts
-WebAssembly.compile = (buf) => {
-    try { return Promise.resolve(new WebAssembly.Module(buf)); }
-    catch (e) { return Promise.reject(e); }
-};
-WebAssembly.instantiate = (bufOrMod, imports) => {
-    try {
-        const isModule = bufOrMod instanceof WebAssembly.Module;
-        const module = isModule ? bufOrMod : new WebAssembly.Module(bufOrMod);
-        const instance = new WebAssembly.Instance(module, imports);
-        // Spec: Buffer input → { module, instance }; Module input → Instance
-        return Promise.resolve(isModule ? instance : { module, instance });
-    } catch (e) { return Promise.reject(e); }
-};
-WebAssembly.validate = (buf) => {
-    try { new WebAssembly.Module(buf); return true; }
-    catch { return false; }
-};
-// compileStreaming / instantiateStreaming: feed Response.arrayBuffer() into above
-```
-
-Steps:
-1. New package `packages/web/webassembly/` with `src/register/promise.ts` (above)
-2. Add to `GJS_GLOBALS_MAP` so `--globals auto` injects it whenever
-   `WebAssembly.compile` etc. appear in the bundle
-3. Validate via `tests/integration/ts-for-gir/` — once shipped, drop the
-   bail in `ts-for-gir/packages/cli/src/commands/doc.ts` and verify
-   the GJS bundle generates HTML docs end-to-end (the JSON pipeline
-   already runs natively via Phase 6 on v0.3.4).
-
-Once landed, remove the `WebAssembly Promise APIs` "Upstream GJS Patch
-Candidate" entry — this is a gjsify-side fix.
-
-### Bugs surfaced by ts-for-gir GJS-bundle integration (gjsify v0.3.4 → v0.3.5)
-
-External consumers of `gjsify build` (e.g. `gjsify/ts-for-gir` PR #378) hit
-three bugs in v0.3.4 that currently force workarounds. All three are fixable
-in `packages/infra/{cli,esbuild-plugin-gjsify}/` and should land in v0.3.5.
-
-**Priority: High — they block clean external use of `gjsify build`.**
-
-1. **`rewrite-node-modules-paths.ts` cannot read PnP zip-cached files.**
-   The `onLoad` hook does `await readFile(args.path, 'utf8')`, which throws
-   on Yarn PnP virtual paths like `pnp:/.../typescript-zip.zip/...`. esbuild
-   then loads the file via the PnP plugin's reader but our `__dirname` /
-   `__filename` injection never runs, so bundled `typescript.js` crashes
-   at runtime with `ReferenceError: __filename is not defined`.
-   Workaround in ts-for-gir: `nodeLinker: node-modules` to flatten the
-   zip cache.
-   Proper fix: detect PnP/zip paths and either skip them (with a warning)
-   or read content via PnP's API instead of `fs.readFile`.
-
-2. **`getPnpPlugin()` two-hop relay misses some `@gjsify/*` packages.**
-   The relay through `@gjsify/node-polyfills` / `@gjsify/web-polyfills`
-   is supposed to make every `@gjsify/<pkg>/register/*` path declared
-   transitively resolvable from a consumer that only has `@gjsify/cli`
-   as a direct dep. In practice, ts-for-gir had to declare every
-   register-target package directly (`@gjsify/buffer`, `node-globals`,
-   `web-globals`, `abort-controller`, `compression-streams`, `dom-events`,
-   `dom-exception`, `web-streams`, `webcrypto`, plus the source-aliased
-   `@gjsify/{fs,path,url,util,module,os,zlib,child_process}`).
-   Either the relay's `pnpApi.resolveRequest()` returns `null` for
-   sub-path imports (`@gjsify/foo/register/bar`), or the issuer file
-   path doesn't reach a PnP-declared context.
-   Proper fix: trace why the relay's resolveRequest returns null and
-   either fix the issuer path or fall back to walking the whole
-   PnP-declared dep graph.
-
-3. **`shebang: true` in `.gjsifyrc.js` is overridden by CLI default.**
-   `commands/build.ts` declares `--shebang` with `default: false`;
-   yargs always sets `cliArgs.shebang = false` when the flag is absent.
-   `config.ts` then overwrites the config-file value via
-   `if (cliArgs.shebang !== undefined) configData.shebang = cliArgs.shebang`.
-   Net effect: `shebang: true` from `.gjsifyrc.js` is ignored unless the
-   user also passes `--shebang` on the command line.
-   Workaround: pass `--shebang` explicitly.
-   Proper fix: drop the yargs `default: false` so the CLI value is
-   `undefined` when the user didn't pass it, OR change the merge logic
-   to compare against the default before overriding.
+Once Phase B lands and the PR #378 cleanup confirms green, remove the `WebAssembly Promise APIs` "Upstream GJS Patch Candidate" entry — this is a gjsify-side fix now shipped.
 
 ### Split `@gjsify/node-globals/register` into topic-specific packages
 
@@ -777,6 +694,48 @@ Today's partial-implementation covers DatabaseSync/StatementSync against Node 24
 **Priority: Medium — Phase 2–4 have all landed.**
 
 Promote [examples/dom/webrtc-loopback](examples/dom/webrtc-loopback) to `showcases/dom/webrtc-loopback/` — Media Phase 2/3 and Stats Phase 4 are now complete, making a polished showcase viable. The showcase should demonstrate both data-channel (loopback) and media paths (getUserMedia audio). Four additional private examples exist (`webrtc-dtmf`, `webrtc-states`, `webrtc-trickle-ice`, `webrtc-video`) that could be folded in or referenced. Follow the standard showcase rules: publish as `@gjsify/example-dom-webrtc-loopback`, export `./browser` entry, add as dep in `packages/infra/cli/package.json`.
+
+### Bundler migration — Vite 8 / Rolldown long-term goal
+
+**Priority: Strategic / Long-term — no immediate action; track here so it doesn't get lost.**
+
+The Rollup/Rolldown plugin API is structurally a better fit for what `packages/infra/esbuild-plugin-gjsify/` actually does than esbuild's hooks. Today's load-bearing mechanisms work _around_ esbuild rather than _with_ it:
+
+- **Auto-globals iterative multi-pass** (`utils/auto-globals.ts` + `utils/detect-free-globals.ts`) re-builds N times because esbuild has no native equivalent to Rollup's `@rollup/plugin-inject` (acorn-based identifier→import injection) — it would collapse to one declarative pass.
+- **`__toCommonJS` output patching** (`app/gjs.ts` `onEnd`) only exists because esbuild emits that wrapper for ESM+neutral; Rolldown does not.
+- **Per-file `import.meta.url` rewrite** (`utils/rewrite-node-modules-paths.ts`) routes the original path through `pluginData` because esbuild's `onLoad` does not pass `id` natively; Rollup's `transform(code, id)` does.
+- **Banner ordering** for the synchronous `globalThis.process` stub is sequenced manually; Vite's `enforce: 'pre'/'post'` is declarative.
+- **CSS lowering** (`@gjsify/esbuild-plugin-css` with `target: firefox60` for GTK4 nesting flatten) is hand-rolled; Lightning CSS via Vite is more capable. easy6502 already uses this combo at [easy6502/packages/app-gnome/vite.config.js](../easy6502/packages/app-gnome/vite.config.js).
+
+**Where the win actually lives:**
+
+1. **Plugin API ergonomics** — porting the 8 esbuild plugins removes ~50% of the workaround code (iterative loops, output-shape patches, manual banner sequencing).
+2. **Convergence with consumers** — sister projects already build GJS apps with Vite 8 + `@gjsify/vite-plugin-blueprint` / `@gjsify/vite-plugin-gettext` ([easy6502/packages/app-gnome/](../easy6502/packages/app-gnome/), [pixel-rpg/map-editor/packages/gjs/](../pixel-rpg/map-editor/packages/gjs/)). Right now gjsify-CLI = esbuild while the apps it serves = Vite. Single-stack would ease maintenance + plugin reuse.
+3. **Dev-server / HMR** — entirely new capability for website, playgrounds, examples and (long-term) GJS-side hot-reload. esbuild has no equivalent. Astro reference at `refs/astro/` shows the pattern. Existing groundwork in `examples/gtk/three-geometry-shapes/refs/gjsify-vite/`.
+4. **Code-splitting + dynamic imports** — Rolldown does proper splitting; relevant once `@gjsify/integration-ts-for-gir` style bundles grow.
+5. **Source-map fidelity through chained transforms** — Rollup keeps the chain; relevant for Deepkit + Blueprint + auto-globals stacked transforms.
+
+**Why not now:**
+
+- Rolldown is `1.0.0-rc.18` (April 2026). Output-shape stability is a hard prerequisite for the GJS-specific output post-processing.
+- Yarn-PnP `onResolve` fallthrough, `mainFields`/`conditions` precedence (the `bitfield`/`require` condition fix), and the synchronous-process-stub banner are all portable but each needs explicit Rolldown equivalent + parity test.
+- Engine speed: esbuild remains faster on cold builds. Marginal but real.
+
+**Two-track migration path:**
+
+1. **Now → near-term: build `@gjsify/vite-plugin-gjsify` (consumer-side first).** Ports the platform orchestration of `esbuild-plugin-gjsify` (GJS / Node / Browser targets, externals, `--globals auto`, alias map) to a Rollup-style plugin running inside Vite. Validates all GJS-specific transforms under Rolldown output _without_ touching the gjsify-CLI engine. Companion plugins (`vite-plugin-blueprint`, `vite-plugin-gettext`) already exist and are field-tested in `easy6502`/`pixel-rpg`. Migrate `vite-plugin-blueprint` from `@gjsify/vite-plugin-blueprint` (currently external) into `packages/infra/vite-plugin-blueprint/` so blueprint + alias + transform-ext + css + deepkit all live as a coherent Vite-plugin family alongside the esbuild family.
+2. **When (a) Rolldown 1.0 stable lands AND (b) the Vite-plugin track has parity for the five load-bearing mechanisms above: cut `gjsify build` engine to Rolldown.** The CLI keeps its public surface (`--app gjs|node|browser`, `--globals auto`, `--define`, `--external`, `--alias`); only the underlying bundler swaps. By that point the Rolldown port is routine, not wagering.
+
+**Acceptance criteria for engine-cut readiness:**
+
+- All five load-bearing mechanisms have proven Rolldown equivalents in the consumer-side track.
+- Full integration suite (`webtorrent`, `socket.io`, `streamx`, `autobahn`, `axios`, `mcp-typescript-sdk`, `mcp-inspector-cli`, `ts-for-gir`) passes on Rolldown engine — no regressions.
+- All showcases build + run identically on both engines for at least one release cycle (parallel CI).
+
+**Out-of-scope in this entry:**
+
+- Replacing `esbuild-plugin-deepkit` is independent — `@deepkit/type-compiler` integrates with TypeScript program directly; either plugin host wraps the same compiler. Migrate alongside, not as a blocker.
+- The `gjsify install` future command (separate Open-TODO context) is bundler-agnostic.
 
 ---
 

--- a/packages/infra/cli/src/actions/build.ts
+++ b/packages/infra/cli/src/actions/build.ts
@@ -51,13 +51,16 @@ async function getPnpPlugin(): Promise<Plugin | null> {
 		const gjsifyIssuer = fileURLToPath(import.meta.url);
 
 		// Two-hop relay: node-polyfills and web-polyfills have all individual
-		// @gjsify/* packages as direct deps. Resolving from their paths allows
-		// PnP to reach e.g. @gjsify/node-globals (dep of node-polyfills).
+		// @gjsify/* packages as direct deps. Resolving from their package.json
+		// paths allows PnP to use them as issuers — sub-path imports
+		// (`@gjsify/foo/register/bar`) then resolve through the polyfill's
+		// dep graph. Resolve to package.json (always present, exports-agnostic)
+		// rather than main/module (the polyfills meta packages have no main).
 		const requireFromGjsify = createRequire(gjsifyIssuer);
 		const relayIssuers: string[] = [];
 		for (const pkg of ["@gjsify/node-polyfills", "@gjsify/web-polyfills"]) {
 			try {
-				relayIssuers.push(requireFromGjsify.resolve(pkg));
+				relayIssuers.push(requireFromGjsify.resolve(`${pkg}/package.json`));
 			} catch {
 				// polyfills package not in dep tree — relay won't cover it
 			}

--- a/packages/infra/cli/src/commands/build.ts
+++ b/packages/infra/cli/src/commands/build.ts
@@ -95,10 +95,9 @@ export const buildCommand: Command<any, CliBuildOptions> = {
                 default: 'auto'
             })
             .option('shebang', {
-                description: "Prepend a `#!/usr/bin/env -S gjs -m` shebang to the output and mark it executable (chmod 755). Only applies to GJS app builds with a single --outfile.",
+                description: "Prepend a `#!/usr/bin/env -S gjs -m` shebang to the output and mark it executable (chmod 755). Only applies to GJS app builds with a single --outfile. Default: false (use --shebang to enable, or set `shebang: true` in `.gjsifyrc.js`).",
                 type: 'boolean',
-                normalize: true,
-                default: false
+                normalize: true
             })
             .option('external', {
                 description: "Module names that should NOT be bundled. Repeat the flag or pass a comma-separated list (e.g. --external typedoc,prettier). Globs are forwarded to esbuild as-is. See https://esbuild.github.io/api/#external",

--- a/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
+++ b/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
@@ -6050,6 +6050,7 @@ var GJS_GLOBALS_GROUPS = {
     "FocusEvent",
     "EventSource",
     "WebSocket",
+    "WebAssembly",
     "DOMException",
     "performance",
     "PerformanceObserver",
@@ -6157,6 +6158,13 @@ var GJS_GLOBALS_MAP = {
   // MessageEvent is shared with dom-events in practice — whichever register
   // runs first installs it; both guard with typeof === 'undefined'.
   WebSocket: "websocket/register",
+  // --- WebAssembly Promise APIs ------------------------------------------
+  // Reach via marker (see METHOD_MARKERS in detect-free-globals.ts):
+  // bare `WebAssembly.compile(...)` / `.instantiate(...)` etc. trigger
+  // injection of the Promise polyfill. The synchronous `new WebAssembly.{Module,Instance}`
+  // path also free-references `WebAssembly` and ends up here, but the
+  // register module is a no-op when the natives already work.
+  WebAssembly: "webassembly/register/promise",
   // --- Performance -------------------------------------------------------
   performance: "@gjsify/web-globals/register/performance",
   PerformanceObserver: "@gjsify/web-globals/register/performance",
@@ -12238,7 +12246,16 @@ var METHOD_MARKERS = {
   // Gamepad API — navigator.getGamepads is patched on by @gjsify/gamepad/register
   "navigator.getGamepads": "GamepadEvent",
   // WebRTC — navigator.mediaDevices is patched on by @gjsify/webrtc/register/media-devices
-  "navigator.mediaDevices": "MediaDevices"
+  "navigator.mediaDevices": "MediaDevices",
+  // WebAssembly Promise APIs — the runtime stubs throw at first call, so
+  // any reference to these methods needs the `@gjsify/webassembly` polyfill.
+  // The register entry replaces the stubs with wrappers around the working
+  // synchronous `new WebAssembly.{Module,Instance}` constructors.
+  "WebAssembly.compile": "WebAssembly",
+  "WebAssembly.compileStreaming": "WebAssembly",
+  "WebAssembly.instantiate": "WebAssembly",
+  "WebAssembly.instantiateStreaming": "WebAssembly",
+  "WebAssembly.validate": "WebAssembly"
   // Note: URL.createObjectURL / URL.revokeObjectURL don't need markers —
   // they are first-class static methods on @gjsify/url's URL class, so the
   // free `URL` identifier (detected directly, maps to
@@ -12714,7 +12731,13 @@ var ALIASES_WEB_FOR_GJS = {
   "webrtc/register/data-channel": "@gjsify/webrtc/register/data-channel",
   "webrtc/register/error": "@gjsify/webrtc/register/error",
   "webrtc/register/media": "@gjsify/webrtc/register/media",
-  "webrtc/register/media-devices": "@gjsify/webrtc/register/media-devices"
+  "webrtc/register/media-devices": "@gjsify/webrtc/register/media-devices",
+  // WebAssembly Promise APIs polyfill — wraps the synchronous Module/Instance
+  // constructors so WebAssembly.{compile,instantiate,validate,...} resolve
+  // instead of throwing the SpiderMonkey 128 stub error.
+  "webassembly": "@gjsify/webassembly",
+  "webassembly/register": "@gjsify/webassembly/register",
+  "webassembly/register/promise": "@gjsify/webassembly/register/promise"
 };
 var ALIASES_GENERAL_FOR_NODE = {
   "@gjsify/node-globals": "@gjsify/empty",
@@ -12829,7 +12852,15 @@ var ALIASES_WEB_FOR_NODE = {
   "@gjsify/webrtc/register/data-channel": "@gjsify/empty",
   "@gjsify/webrtc/register/error": "@gjsify/empty",
   "@gjsify/webrtc/register/media": "@gjsify/empty",
-  "@gjsify/webrtc/register/media-devices": "@gjsify/empty"
+  "@gjsify/webrtc/register/media-devices": "@gjsify/empty",
+  // WebAssembly Promise APIs — native on Node (no polyfill needed); the
+  // bare `webassembly` specifier maps to /globals so consumers can import
+  // typed helpers without dragging the polyfill into the bundle.
+  "webassembly": "@gjsify/webassembly/globals",
+  "webassembly/register": "@gjsify/empty",
+  "webassembly/register/promise": "@gjsify/empty",
+  "@gjsify/webassembly/register": "@gjsify/empty",
+  "@gjsify/webassembly/register/promise": "@gjsify/empty"
 };
 
 // src/utils/alias.ts
@@ -19897,7 +19928,12 @@ function getBundleDir(build2) {
 }
 async function loadAndRewrite(args, build2) {
   if (!args.path.includes("node_modules")) return void 0;
-  const src = await readFile(args.path, "utf8");
+  let src;
+  try {
+    src = await readFile(args.path, "utf8");
+  } catch (err) {
+    return void 0;
+  }
   const hasMetaUrl = src.includes("import.meta.url");
   const hasDirname = src.includes("__dirname");
   const hasFilename = src.includes("__filename");
@@ -19929,7 +19965,9 @@ async function loadAndRewrite(args, build2) {
   return { contents, loader, resolveDir: dir };
 }
 function registerNodeModulesPathRewrite(build2) {
-  build2.onLoad({ filter: /\.(m?js|cjs|[cm]?tsx?)$/ }, (args) => loadAndRewrite(args, build2));
+  const filter = /\.(m?js|cjs|[cm]?tsx?)$/;
+  build2.onLoad({ filter }, (args) => loadAndRewrite(args, build2));
+  build2.onLoad({ filter, namespace: "pnp" }, (args) => loadAndRewrite(args, build2));
 }
 
 // src/app/gjs.ts

--- a/packages/infra/esbuild-plugin-gjsify/dist/esm/index.mjs
+++ b/packages/infra/esbuild-plugin-gjsify/dist/esm/index.mjs
@@ -6211,7 +6211,13 @@ var ALIASES_WEB_FOR_GJS = {
   "webrtc/register/data-channel": "@gjsify/webrtc/register/data-channel",
   "webrtc/register/error": "@gjsify/webrtc/register/error",
   "webrtc/register/media": "@gjsify/webrtc/register/media",
-  "webrtc/register/media-devices": "@gjsify/webrtc/register/media-devices"
+  "webrtc/register/media-devices": "@gjsify/webrtc/register/media-devices",
+  // WebAssembly Promise APIs polyfill — wraps the synchronous Module/Instance
+  // constructors so WebAssembly.{compile,instantiate,validate,...} resolve
+  // instead of throwing the SpiderMonkey 128 stub error.
+  "webassembly": "@gjsify/webassembly",
+  "webassembly/register": "@gjsify/webassembly/register",
+  "webassembly/register/promise": "@gjsify/webassembly/register/promise"
 };
 var ALIASES_GENERAL_FOR_NODE = {
   "@gjsify/node-globals": "@gjsify/empty",
@@ -6326,7 +6332,15 @@ var ALIASES_WEB_FOR_NODE = {
   "@gjsify/webrtc/register/data-channel": "@gjsify/empty",
   "@gjsify/webrtc/register/error": "@gjsify/empty",
   "@gjsify/webrtc/register/media": "@gjsify/empty",
-  "@gjsify/webrtc/register/media-devices": "@gjsify/empty"
+  "@gjsify/webrtc/register/media-devices": "@gjsify/empty",
+  // WebAssembly Promise APIs — native on Node (no polyfill needed); the
+  // bare `webassembly` specifier maps to /globals so consumers can import
+  // typed helpers without dragging the polyfill into the bundle.
+  "webassembly": "@gjsify/webassembly/globals",
+  "webassembly/register": "@gjsify/empty",
+  "webassembly/register/promise": "@gjsify/empty",
+  "@gjsify/webassembly/register": "@gjsify/empty",
+  "@gjsify/webassembly/register/promise": "@gjsify/empty"
 };
 
 // src/utils/alias.ts
@@ -13480,7 +13494,12 @@ function getBundleDir(build) {
 }
 async function loadAndRewrite(args, build) {
   if (!args.path.includes("node_modules")) return void 0;
-  const src = await readFile(args.path, "utf8");
+  let src;
+  try {
+    src = await readFile(args.path, "utf8");
+  } catch (err) {
+    return void 0;
+  }
   const hasMetaUrl = src.includes("import.meta.url");
   const hasDirname = src.includes("__dirname");
   const hasFilename = src.includes("__filename");
@@ -13512,7 +13531,9 @@ async function loadAndRewrite(args, build) {
   return { contents, loader, resolveDir: dir };
 }
 function registerNodeModulesPathRewrite(build) {
-  build.onLoad({ filter: /\.(m?js|cjs|[cm]?tsx?)$/ }, (args) => loadAndRewrite(args, build));
+  const filter = /\.(m?js|cjs|[cm]?tsx?)$/;
+  build.onLoad({ filter }, (args) => loadAndRewrite(args, build));
+  build.onLoad({ filter, namespace: "pnp" }, (args) => loadAndRewrite(args, build));
 }
 
 // src/app/gjs.ts

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/detect-free-globals.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/detect-free-globals.ts
@@ -32,6 +32,15 @@ const METHOD_MARKERS: Record<string, string> = {
     'navigator.getGamepads': 'GamepadEvent',
     // WebRTC — navigator.mediaDevices is patched on by @gjsify/webrtc/register/media-devices
     'navigator.mediaDevices': 'MediaDevices',
+    // WebAssembly Promise APIs — the runtime stubs throw at first call, so
+    // any reference to these methods needs the `@gjsify/webassembly` polyfill.
+    // The register entry replaces the stubs with wrappers around the working
+    // synchronous `new WebAssembly.{Module,Instance}` constructors.
+    'WebAssembly.compile':              'WebAssembly',
+    'WebAssembly.compileStreaming':     'WebAssembly',
+    'WebAssembly.instantiate':          'WebAssembly',
+    'WebAssembly.instantiateStreaming': 'WebAssembly',
+    'WebAssembly.validate':             'WebAssembly',
     // Note: URL.createObjectURL / URL.revokeObjectURL don't need markers —
     // they are first-class static methods on @gjsify/url's URL class, so the
     // free `URL` identifier (detected directly, maps to

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/rewrite-node-modules-paths.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/rewrite-node-modules-paths.ts
@@ -42,7 +42,17 @@ function getBundleDir(build: PluginBuild): string {
 
 async function loadAndRewrite(args: OnLoadArgs, build: PluginBuild): Promise<OnLoadResult | undefined> {
     if (!args.path.includes('node_modules')) return undefined;
-    const src = await readFile(args.path, 'utf8');
+    let src: string;
+    try {
+        src = await readFile(args.path, 'utf8');
+    } catch (err) {
+        // Yarn PnP virtual paths (e.g. `pnp:/.../typescript-zip.zip/...` or
+        // unhydrated `.zip/...` cache paths) are not readable via Node's
+        // native fs. Fall through so the @yarnpkg/esbuild-plugin-pnp's own
+        // onLoad (which knows how to read zip-cached files) handles them.
+        // Without this guard the plugin chain aborts the whole build.
+        return undefined;
+    }
     const hasMetaUrl = src.includes('import.meta.url');
     const hasDirname = src.includes('__dirname');
     const hasFilename = src.includes('__filename');
@@ -78,5 +88,13 @@ async function loadAndRewrite(args: OnLoadArgs, build: PluginBuild): Promise<OnL
 }
 
 export function registerNodeModulesPathRewrite(build: PluginBuild): void {
-    build.onLoad({ filter: /\.(m?js|cjs|[cm]?tsx?)$/ }, (args) => loadAndRewrite(args, build));
+    const filter = /\.(m?js|cjs|[cm]?tsx?)$/;
+    // Default "file" namespace covers regular node_modules + workspace files.
+    build.onLoad({ filter }, (args) => loadAndRewrite(args, build));
+    // "pnp" namespace covers zip-cached packages resolved by
+    // @yarnpkg/esbuild-plugin-pnp. Without this, ESM packages in PnP zips
+    // skip our `import.meta.url` rewrite, and CJS packages skip the
+    // `__dirname` / `__filename` injection — leading to runtime
+    // ReferenceError in the bundle (e.g. typescript.js).
+    build.onLoad({ filter, namespace: "pnp" }, (args) => loadAndRewrite(args, build));
 }

--- a/packages/infra/resolve-npm/lib/globals-map.mjs
+++ b/packages/infra/resolve-npm/lib/globals-map.mjs
@@ -46,6 +46,7 @@ export const GJS_GLOBALS_GROUPS = {
         'MouseEvent', 'PointerEvent', 'KeyboardEvent', 'WheelEvent', 'FocusEvent',
         'EventSource',
         'WebSocket',
+        'WebAssembly',
         'DOMException',
         'performance', 'PerformanceObserver',
         'XMLHttpRequest',
@@ -143,6 +144,14 @@ export const GJS_GLOBALS_MAP = {
     // MessageEvent is shared with dom-events in practice — whichever register
     // runs first installs it; both guard with typeof === 'undefined'.
     WebSocket:            'websocket/register',
+
+    // --- WebAssembly Promise APIs ------------------------------------------
+    // Reach via marker (see METHOD_MARKERS in detect-free-globals.ts):
+    // bare `WebAssembly.compile(...)` / `.instantiate(...)` etc. trigger
+    // injection of the Promise polyfill. The synchronous `new WebAssembly.{Module,Instance}`
+    // path also free-references `WebAssembly` and ends up here, but the
+    // register module is a no-op when the natives already work.
+    WebAssembly:          'webassembly/register/promise',
 
     // --- Performance -------------------------------------------------------
     performance:          '@gjsify/web-globals/register/performance',

--- a/packages/infra/resolve-npm/lib/index.mjs
+++ b/packages/infra/resolve-npm/lib/index.mjs
@@ -228,6 +228,13 @@ export const ALIASES_WEB_FOR_GJS = {
     'webrtc/register/error': '@gjsify/webrtc/register/error',
     'webrtc/register/media': '@gjsify/webrtc/register/media',
     'webrtc/register/media-devices': '@gjsify/webrtc/register/media-devices',
+
+    // WebAssembly Promise APIs polyfill — wraps the synchronous Module/Instance
+    // constructors so WebAssembly.{compile,instantiate,validate,...} resolve
+    // instead of throwing the SpiderMonkey 128 stub error.
+    'webassembly': '@gjsify/webassembly',
+    'webassembly/register': '@gjsify/webassembly/register',
+    'webassembly/register/promise': '@gjsify/webassembly/register/promise',
 }
 
 /** General record of modules for Node */
@@ -356,4 +363,13 @@ export const ALIASES_WEB_FOR_NODE = {
     '@gjsify/webrtc/register/error': '@gjsify/empty',
     '@gjsify/webrtc/register/media': '@gjsify/empty',
     '@gjsify/webrtc/register/media-devices': '@gjsify/empty',
+
+    // WebAssembly Promise APIs — native on Node (no polyfill needed); the
+    // bare `webassembly` specifier maps to /globals so consumers can import
+    // typed helpers without dragging the polyfill into the bundle.
+    'webassembly': '@gjsify/webassembly/globals',
+    'webassembly/register': '@gjsify/empty',
+    'webassembly/register/promise': '@gjsify/empty',
+    '@gjsify/webassembly/register': '@gjsify/empty',
+    '@gjsify/webassembly/register/promise': '@gjsify/empty',
 }

--- a/packages/web/polyfills/package.json
+++ b/packages/web/polyfills/package.json
@@ -22,6 +22,7 @@
         "@gjsify/gamepad": "workspace:^",
         "@gjsify/web-globals": "workspace:^",
         "@gjsify/web-streams": "workspace:^",
+        "@gjsify/webassembly": "workspace:^",
         "@gjsify/webaudio": "workspace:^",
         "@gjsify/webcrypto": "workspace:^",
         "@gjsify/websocket": "workspace:^",

--- a/packages/web/webassembly/globals.mjs
+++ b/packages/web/webassembly/globals.mjs
@@ -1,0 +1,13 @@
+/**
+ * Re-exports native WebAssembly Promise APIs for use in Node.js builds.
+ * On Node.js these are native — gjsify's bundler aliases the bare
+ * `webassembly` specifier (and `/register/*` subpaths) here so consumer
+ * code calls native `WebAssembly.{compile,instantiate,...}` instead of
+ * dragging the polyfill into the bundle.
+ */
+const wa = globalThis.WebAssembly;
+export const compile = wa?.compile.bind(wa);
+export const compileStreaming = wa?.compileStreaming?.bind(wa);
+export const instantiate = wa?.instantiate.bind(wa);
+export const instantiateStreaming = wa?.instantiateStreaming?.bind(wa);
+export const validate = wa?.validate.bind(wa);

--- a/packages/web/webassembly/package.json
+++ b/packages/web/webassembly/package.json
@@ -1,0 +1,53 @@
+{
+    "name": "@gjsify/webassembly",
+    "version": "0.3.4",
+    "description": "WebAssembly Promise-API polyfill for GJS — wraps the synchronous Module/Instance constructors that work in SpiderMonkey 128+.",
+    "type": "module",
+    "module": "lib/esm/index.js",
+    "types": "lib/types/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "default": "./lib/esm/index.js"
+        },
+        "./register": {
+            "types": "./lib/types/register.d.ts",
+            "default": "./lib/esm/register.js"
+        },
+        "./register/promise": {
+            "types": "./lib/types/register/promise.d.ts",
+            "default": "./lib/esm/register/promise.js"
+        },
+        "./globals": "./globals.mjs"
+    },
+    "sideEffects": [
+        "./lib/esm/register.js",
+        "./lib/esm/register/*.js",
+        "./globals.mjs"
+    ],
+    "scripts": {
+        "clear": "rm -rf lib tsconfig.tsbuildinfo tsconfig.types.tsbuildinfo test.gjs.mjs test.node.mjs || exit 0",
+        "check": "tsc --noEmit",
+        "build": "yarn build:gjsify && yarn build:types",
+        "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
+        "build:types": "tsc",
+        "build:test": "yarn build:test:gjs && yarn build:test:node",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "test": "yarn build:gjsify && yarn build:test && yarn test:gjs && yarn test:node",
+        "test:gjs": "gjsify run test.gjs.mjs",
+        "test:node": "node test.node.mjs"
+    },
+    "keywords": [
+        "gjs",
+        "webassembly",
+        "wasm",
+        "polyfill"
+    ],
+    "devDependencies": {
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.3"
+    }
+}

--- a/packages/web/webassembly/src/index.ts
+++ b/packages/web/webassembly/src/index.ts
@@ -1,0 +1,106 @@
+// @gjsify/webassembly — WebAssembly Promise-API polyfill for GJS.
+//
+// Reference: WebAssembly JS API (https://webassembly.github.io/spec/js-api/)
+// Reimplemented for GJS using SpiderMonkey 128+'s synchronous WebAssembly.{Module,Instance}.
+//
+// SpiderMonkey 128 (GJS 1.86) ships:
+//   - WebAssembly global object                 ✓
+//   - new WebAssembly.Module(buffer)            ✓ synchronous compile
+//   - new WebAssembly.Instance(module, imports) ✓ synchronous instantiate
+//   - WebAssembly.{compile,compileStreaming,instantiate,instantiateStreaming,validate}
+//                                               ✗ exist as functions but throw
+//                                                 "WebAssembly Promise APIs not supported in this runtime."
+//
+// This package wraps the synchronous constructors with Promise.{resolve,reject} so
+// the missing Promise APIs become trivially available. The streaming variants
+// fetch the bytes via Response.arrayBuffer() and pipe through the same wrappers.
+
+const NATIVE_WEBASSEMBLY = (globalThis as any).WebAssembly;
+
+if (typeof NATIVE_WEBASSEMBLY === 'undefined') {
+    throw new Error('@gjsify/webassembly: globalThis.WebAssembly is not defined; nothing to polyfill.');
+}
+
+type WAModule = typeof globalThis.WebAssembly.Module.prototype;
+type WAInstance = typeof globalThis.WebAssembly.Instance.prototype;
+
+export interface WebAssemblyModuleConstructor {
+    new (buffer: BufferSource): WAModule;
+}
+export interface WebAssemblyInstanceConstructor {
+    new (module: WAModule, importObject?: WebAssembly.Imports): WAInstance;
+}
+
+const Module = NATIVE_WEBASSEMBLY.Module as WebAssemblyModuleConstructor;
+const Instance = NATIVE_WEBASSEMBLY.Instance as WebAssemblyInstanceConstructor;
+
+/** Polyfill for `WebAssembly.compile()`. */
+export function compile(buffer: BufferSource): Promise<WAModule> {
+    try {
+        return Promise.resolve(new Module(buffer));
+    } catch (err) {
+        return Promise.reject(err);
+    }
+}
+
+/** Polyfill for `WebAssembly.validate()`. */
+export function validate(buffer: BufferSource): boolean {
+    try {
+        new Module(buffer);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Polyfill for `WebAssembly.instantiate()`. Two overloads:
+ *   - bytes  → { module, instance }
+ *   - module → instance
+ */
+export function instantiate(
+    bytes: BufferSource,
+    importObject?: WebAssembly.Imports,
+): Promise<WebAssembly.WebAssemblyInstantiatedSource>;
+export function instantiate(
+    module: WAModule,
+    importObject?: WebAssembly.Imports,
+): Promise<WAInstance>;
+export function instantiate(
+    bytesOrModule: BufferSource | WAModule,
+    importObject?: WebAssembly.Imports,
+): Promise<WebAssembly.WebAssemblyInstantiatedSource | WAInstance> {
+    try {
+        if (bytesOrModule instanceof Module) {
+            return Promise.resolve(new Instance(bytesOrModule as WAModule, importObject));
+        }
+        const module = new Module(bytesOrModule as BufferSource);
+        const instance = new Instance(module, importObject);
+        return Promise.resolve({ module, instance });
+    } catch (err) {
+        return Promise.reject(err);
+    }
+}
+
+async function bufferFromSource(source: Response | PromiseLike<Response>): Promise<ArrayBuffer> {
+    const response = await source;
+    return response.arrayBuffer();
+}
+
+/** Polyfill for `WebAssembly.compileStreaming()`. */
+export async function compileStreaming(
+    source: Response | PromiseLike<Response>,
+): Promise<WAModule> {
+    const buffer = await bufferFromSource(source);
+    return compile(buffer);
+}
+
+/** Polyfill for `WebAssembly.instantiateStreaming()`. */
+export async function instantiateStreaming(
+    source: Response | PromiseLike<Response>,
+    importObject?: WebAssembly.Imports,
+): Promise<WebAssembly.WebAssemblyInstantiatedSource> {
+    const buffer = await bufferFromSource(source);
+    return instantiate(buffer, importObject) as Promise<WebAssembly.WebAssemblyInstantiatedSource>;
+}
+
+export default { compile, compileStreaming, instantiate, instantiateStreaming, validate };

--- a/packages/web/webassembly/src/promise.spec.ts
+++ b/packages/web/webassembly/src/promise.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Test the WebAssembly Promise-API polyfill.
+//
+// Uses an inline minimal valid wasm module exporting a single `add(i32, i32) -> i32`
+// function. Hand-encoded so the test is self-contained (no fs / fixtures).
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+    compile,
+    instantiate,
+    validate,
+} from '@gjsify/webassembly';
+
+// Minimal wasm module exporting `add(a: i32, b: i32) -> i32`.
+// Hand-encoded per https://webassembly.github.io/spec/core/binary/.
+//   magic + version
+//   type section: (func (param i32 i32) (result i32))
+//   function section: function 0 has type 0
+//   export section: "add" → func 0
+//   code section: local.get 0; local.get 1; i32.add; end
+const ADD_WASM = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00,
+    0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b,
+]);
+const EMPTY_WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+const GARBAGE = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+export default async () => {
+    await describe('WebAssembly Promise APIs', async () => {
+        await it('validate returns true for valid module', async () => {
+            expect(validate(EMPTY_WASM)).toBe(true);
+            expect(validate(ADD_WASM)).toBe(true);
+        });
+
+        await it('validate returns false for invalid bytes', async () => {
+            expect(validate(GARBAGE)).toBe(false);
+        });
+
+        await it('compile resolves a Module', async () => {
+            const module = await compile(ADD_WASM);
+            expect(module).toBeDefined();
+            expect(module instanceof WebAssembly.Module).toBe(true);
+        });
+
+        await it('compile rejects on invalid bytes', async () => {
+            let threw = false;
+            try {
+                await compile(GARBAGE);
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBe(true);
+        });
+
+        await it('instantiate(buffer) resolves { module, instance }', async () => {
+            const result = await instantiate(ADD_WASM);
+            expect(result.module instanceof WebAssembly.Module).toBe(true);
+            expect(result.instance instanceof WebAssembly.Instance).toBe(true);
+            const add = result.instance.exports.add as (a: number, b: number) => number;
+            expect(add(2, 3)).toBe(5);
+        });
+
+        await it('instantiate(module) resolves an Instance', async () => {
+            const module = new WebAssembly.Module(ADD_WASM);
+            const instance = (await instantiate(module)) as WebAssembly.Instance;
+            expect(instance instanceof WebAssembly.Instance).toBe(true);
+            const add = instance.exports.add as (a: number, b: number) => number;
+            expect(add(7, 8)).toBe(15);
+        });
+
+        await it('register installs WebAssembly.compile globally', async () => {
+            // /register/promise replaces the runtime stubs with our wrappers.
+            // Verify global API matches our exports.
+            const module = await WebAssembly.compile(ADD_WASM);
+            expect(module instanceof WebAssembly.Module).toBe(true);
+            const result = await WebAssembly.instantiate(ADD_WASM);
+            const add = (result as WebAssembly.WebAssemblyInstantiatedSource).instance.exports.add as (a: number, b: number) => number;
+            expect(add(10, 20)).toBe(30);
+            expect(WebAssembly.validate(EMPTY_WASM)).toBe(true);
+            expect(WebAssembly.validate(GARBAGE)).toBe(false);
+        });
+    });
+};

--- a/packages/web/webassembly/src/register.ts
+++ b/packages/web/webassembly/src/register.ts
@@ -1,0 +1,2 @@
+// Catch-all register entry — pulls all granular WebAssembly polyfills.
+import './register/promise.js';

--- a/packages/web/webassembly/src/register/promise.ts
+++ b/packages/web/webassembly/src/register/promise.ts
@@ -1,0 +1,48 @@
+// Side-effect module: replace GJS's stub WebAssembly Promise APIs with
+// polyfills wrapping the synchronous constructors.
+//
+// SpiderMonkey 128 (GJS 1.86) exposes WebAssembly.{compile,compileStreaming,
+// instantiate,instantiateStreaming,validate} as `function` typeof values
+// that throw `Error: WebAssembly Promise APIs not supported in this runtime.`
+// at first call. The synchronous constructors `new WebAssembly.Module(buffer)`
+// and `new WebAssembly.Instance(module, imports)` work, so we wrap them.
+//
+// Idempotent — installing twice replaces with the same wrappers.
+//
+// On Node.js these Promise APIs are native — the aliases in
+// @gjsify/resolve-npm route this subpath to @gjsify/empty during Node builds
+// so it becomes a no-op.
+
+import {
+    compile,
+    compileStreaming,
+    instantiate,
+    instantiateStreaming,
+    validate,
+} from '../index.js';
+
+const wa = (globalThis as any).WebAssembly;
+if (typeof wa !== 'undefined') {
+    // Replace unconditionally — the runtime stubs throw on first call, so
+    // our wrappers are strictly more capable. Use defineProperty so
+    // re-imports do not error in strict mode.
+    const replace = (name: string, value: unknown) => {
+        try {
+            Object.defineProperty(wa, name, {
+                value,
+                writable: true,
+                configurable: true,
+                enumerable: true,
+            });
+        } catch {
+            // Some runtimes mark these properties non-configurable. Fall
+            // through silently — the consumer can still import named
+            // helpers from `@gjsify/webassembly` directly.
+        }
+    };
+    replace('compile', compile);
+    replace('compileStreaming', compileStreaming);
+    replace('instantiate', instantiate);
+    replace('instantiateStreaming', instantiateStreaming);
+    replace('validate', validate);
+}

--- a/packages/web/webassembly/src/test.mts
+++ b/packages/web/webassembly/src/test.mts
@@ -1,0 +1,9 @@
+import '@gjsify/node-globals/register';
+import '@gjsify/webassembly/register';
+import { run } from '@gjsify/unit';
+
+import promiseSuite from './promise.spec.js';
+
+run({
+    Promise: promiseSuite,
+});

--- a/packages/web/webassembly/tsconfig.json
+++ b/packages/web/webassembly/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "types": [
+      "node"
+    ],
+    "target": "ESNext",
+    "experimentalDecorators": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "declarationDir": "lib/types",
+    "composite": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
+    "strict": false
+  },
+  "reflection": false,
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/test.ts",
+    "src/test.mts"
+  ]
+}

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -198,6 +198,12 @@ Any identifier below can appear in `--globals` (or be detected automatically). G
 | `MediaStream`, `MediaStreamTrack`, `RTCTrackEvent` | `@gjsify/webrtc/register/media` |
 | `MediaDevices` (`navigator.mediaDevices`) | `@gjsify/webrtc/register/media-devices` |
 
+**WebAssembly Promise APIs**
+
+| Identifier(s) | Register subpath |
+|---|---|
+| `WebAssembly` (`WebAssembly.compile`, `WebAssembly.instantiate`, `WebAssembly.validate`, `WebAssembly.compileStreaming`, `WebAssembly.instantiateStreaming`) | `webassembly/register/promise` |
+
 **DOM / browser-compat (GJS/GTK only)**
 
 | Identifier(s) | Register subpath |

--- a/yarn.lock
+++ b/yarn.lock
@@ -4186,6 +4186,7 @@ __metadata:
     "@gjsify/gamepad": "workspace:^"
     "@gjsify/web-globals": "workspace:^"
     "@gjsify/web-streams": "workspace:^"
+    "@gjsify/webassembly": "workspace:^"
     "@gjsify/webaudio": "workspace:^"
     "@gjsify/webcrypto": "workspace:^"
     "@gjsify/websocket": "workspace:^"
@@ -4201,6 +4202,17 @@ __metadata:
     "@gjsify/cli": "workspace:^"
     "@gjsify/unit": "workspace:^"
     "@gjsify/utils": "workspace:^"
+    "@types/node": "npm:^25.6.0"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
+"@gjsify/webassembly@workspace:^, @gjsify/webassembly@workspace:packages/web/webassembly":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/webassembly@workspace:packages/web/webassembly"
+  dependencies:
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.6.0"
     typescript: "npm:^6.0.3"
   languageName: unknown


### PR DESCRIPTION
## Summary

External consumers of `gjsify build` (gjsify/ts-for-gir PR #378) hit three bugs in v0.3.4 that currently force workarounds. This PR fixes all three plus ships the long-tracked **`@gjsify/webassembly`** Promise-API polyfill that unblocks `ts-for-gir doc` on GJS.

## Bug fixes

1. **`rewrite-node-modules-paths.ts` cannot read PnP zip-cached files.**
   `await readFile(args.path, 'utf8')` threw on `pnp:/.../*.zip/...` paths; the file was then loaded by `@yarnpkg/esbuild-plugin-pnp` without our `__dirname`/`__filename` injection — bundled `typescript.js` crashed at runtime. Now: `fs.readFile` errors are caught (fall through to PnP's reader), AND the rewrite hook is registered for `namespace: "pnp"` so zip-resolved files still get the rewrite applied.

2. **`getPnpPlugin()` two-hop relay missed sub-path imports.**
   Relay issuers were resolved via `require.resolve(pkg)` — but `@gjsify/{node,web}-polyfills` have no `main`/`module` field, so resolution silently fell back. Now: relay issuers come from `${pkg}/package.json`, which always exists. External consumers can drop the granular `@gjsify/*` devDeps that were workarounds.

3. **`shebang: true` in `.gjsifyrc.js` was overridden by yargs default.**
   `commands/build.ts` had `default: false`; yargs always set `cliArgs.shebang = false` when the flag was absent, clobbering the config-file value through `if (cliArgs.shebang !== undefined) configData.shebang = cliArgs.shebang`. Now: default removed → `cliArgs.shebang` is `undefined` when not passed → config-file value is honoured. `--shebang` / `--no-shebang` still override.

## New package: `@gjsify/webassembly`

SpiderMonkey 128 (GJS 1.86) ships:
- `WebAssembly` global ✓
- `new WebAssembly.Module(buffer)` synchronous ✓
- `new WebAssembly.Instance(module, imports)` synchronous ✓
- `WebAssembly.{compile,compileStreaming,instantiate,instantiateStreaming,validate}` — exist as `function` typeof but **throw `Error: WebAssembly Promise APIs not supported in this runtime.`** at first call ✗

The polyfill wraps the synchronous constructors with Promise.{resolve,reject}; streaming variants pipe through `Response.arrayBuffer()`. Granular register subpath: `@gjsify/webassembly/register/promise`. Auto-injected by `--globals auto` via new METHOD_MARKERS in `detect-free-globals.ts` (`WebAssembly.compile`, `WebAssembly.instantiate`, etc.).

## Test plan

- [x] `yarn workspace @gjsify/webassembly run test:node` → 15/15 ✓
- [x] `yarn workspace @gjsify/webassembly run test:gjs` → 15/15 ✓
- [x] `yarn workspace @gjsify/integration-ts-for-gir run test:node` → 276/276 ✓
- [x] `yarn workspace @gjsify/integration-ts-for-gir run test:gjs` → 212/212 ✓ (3 ignored)
- [x] `yarn test:e2e:cli-only` → 11/11 ✓ (incl. `--shebang` round-trip + idempotency)
- [x] `yarn check` (full workspace TypeScript) → no errors
- [x] `yarn build` (full workspace) → no errors
- [ ] CI green
- [ ] Phase B follow-up: ts-for-gir cleanup (drop `nodeLinker: node-modules`, drop granular `@gjsify/*` devDeps, drop `packageExtensions`, restore `.gjsifyrc.js` shebang config, drop `doc` bail) — separate PR after v0.3.5 lands on npm.