### PR TITLE
Phase D: gjsify install + showcase decoupling (stacked on PR #65)

### DIFF
--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -25,11 +25,6 @@
     "dependencies": {
         "@gjsify/create-app": "workspace:^",
         "@gjsify/esbuild-plugin-gjsify": "workspace:^",
-        "@gjsify/example-dom-canvas2d-fireworks": "workspace:^",
-        "@gjsify/example-dom-excalibur-jelly-jumper": "workspace:^",
-        "@gjsify/example-dom-three-geometry-teapot": "workspace:^",
-        "@gjsify/example-dom-three-postprocessing-pixel": "workspace:^",
-        "@gjsify/example-node-express-webserver": "workspace:^",
         "@gjsify/node-polyfills": "workspace:^",
         "@gjsify/web-polyfills": "workspace:^",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.15",

--- a/packages/infra/cli/showcases.json
+++ b/packages/infra/cli/showcases.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "showcases": [
+        {
+            "name": "canvas2d-fireworks",
+            "category": "dom",
+            "package": "@gjsify/example-dom-canvas2d-fireworks",
+            "description": "Colorful fireworks Canvas 2D example with Adwaita controls",
+            "needsWebgl": false
+        },
+        {
+            "name": "excalibur-jelly-jumper",
+            "category": "dom",
+            "package": "@gjsify/example-dom-excalibur-jelly-jumper",
+            "description": "Excalibur.js jelly-jumper game",
+            "needsWebgl": false
+        },
+        {
+            "name": "three-geometry-teapot",
+            "category": "dom",
+            "package": "@gjsify/example-dom-three-geometry-teapot",
+            "description": "Three.js Utah teapot",
+            "needsWebgl": true
+        },
+        {
+            "name": "three-postprocessing-pixel",
+            "category": "dom",
+            "package": "@gjsify/example-dom-three-postprocessing-pixel",
+            "description": "Three.js postprocessing pixel demo",
+            "needsWebgl": true
+        },
+        {
+            "name": "express-webserver",
+            "category": "node",
+            "package": "@gjsify/example-node-express-webserver",
+            "description": "Express web server on GJS via @gjsify/http",
+            "needsWebgl": false
+        }
+    ]
+}

--- a/packages/infra/cli/src/commands/index.ts
+++ b/packages/infra/cli/src/commands/index.ts
@@ -7,3 +7,4 @@ export * from './create.js';
 export * from './gresource.js';
 export * from './gettext.js';
 export * from './dlx.js';
+export * from './install.js';

--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -1,0 +1,116 @@
+// `gjsify install [pkg...]` — thin npm wrapper with gjsify-aware post-checks.
+//
+// The actual install is delegated to `npm install` in the user's project root
+// (no `--prefix` rewrite, unlike `gjsify dlx`). After install completes we run
+// `runMinimalChecks()` so missing system deps (gjs, gtk4, libsoup, ...) surface
+// immediately, and report any installed `@gjsify/*` packages that ship native
+// prebuilds so users know they can use `gjsify run` to wire `LD_LIBRARY_PATH` /
+// `GI_TYPELIB_PATH` automatically.
+//
+// Modes:
+//   gjsify install                    → project install (npm install)
+//   gjsify install <pkg> [<pkg>...]   → add package(s) (npm install <pkg>...)
+
+import { spawn } from 'node:child_process';
+import type { Command } from '../types/index.js';
+import {
+    buildInstallCommand,
+    detectPackageManager,
+    runMinimalChecks,
+} from '../utils/check-system-deps.js';
+import { detectNativePackages } from '../utils/detect-native-packages.js';
+
+interface InstallOptions {
+    packages?: string[];
+    'save-dev'?: boolean;
+    'save-peer'?: boolean;
+    'save-optional'?: boolean;
+    verbose: boolean;
+}
+
+export const installCommand: Command<any, InstallOptions> = {
+    command: 'install [packages..]',
+    description:
+        'Install npm dependencies in the current project, then run gjsify-aware post-checks.',
+    builder: (yargs) =>
+        yargs
+            .positional('packages', {
+                description: 'Optional package specs. With none, runs a full project install.',
+                type: 'string',
+                array: true,
+            })
+            .option('save-dev', { type: 'boolean', alias: 'D' })
+            .option('save-peer', { type: 'boolean' })
+            .option('save-optional', { type: 'boolean', alias: 'O' })
+            .option('verbose', {
+                description: 'Verbose npm logging.',
+                type: 'boolean',
+                default: false,
+            }),
+    handler: async (args) => {
+        const npmArgs = ['install'];
+        if (args['save-dev']) npmArgs.push('--save-dev');
+        if (args['save-peer']) npmArgs.push('--save-peer');
+        if (args['save-optional']) npmArgs.push('--save-optional');
+        if (args.verbose) npmArgs.push('--loglevel', 'verbose');
+        if (args.packages && args.packages.length > 0) {
+            npmArgs.push(...args.packages);
+        }
+
+        await spawnNpm(npmArgs);
+
+        await runPostInstallChecks();
+    },
+};
+
+async function spawnNpm(npmArgs: string[]): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const child = spawn('npm', npmArgs, { stdio: 'inherit' });
+        child.on('close', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`npm install exited with code ${code}`));
+        });
+        child.on('error', (err) => {
+            const code = (err as NodeJS.ErrnoException).code;
+            const msg = code === 'ENOENT'
+                ? 'npm not found on PATH — install Node.js first.'
+                : `npm install failed: ${err.message}`;
+            reject(new Error(msg));
+        });
+    }).catch((err: Error) => {
+        console.error(err.message);
+        process.exit(1);
+    });
+}
+
+async function runPostInstallChecks(): Promise<void> {
+    console.log('\n--- gjsify post-install checks ---');
+
+    // 1. System deps that GJS apps typically need.
+    const results = runMinimalChecks();
+    const missing = results.filter((r) => !r.found && r.severity === 'required');
+    if (missing.length > 0) {
+        console.warn('Missing required system dependencies:\n');
+        for (const dep of missing) {
+            console.warn(`  ✗  ${dep.name}`);
+        }
+        const pm = detectPackageManager();
+        const cmd = buildInstallCommand(pm, missing);
+        if (cmd) console.warn(`\nInstall with:\n  ${cmd}`);
+    } else {
+        console.log('System dependencies OK.');
+    }
+
+    // 2. Surface @gjsify/* packages with native prebuilds — `gjsify run`
+    //    will set LD_LIBRARY_PATH / GI_TYPELIB_PATH for these automatically.
+    const native = detectNativePackages(process.cwd());
+    if (native.length > 0) {
+        console.log(
+            `\nDetected ${native.length} @gjsify/* package(s) with native prebuilds:`,
+        );
+        for (const pkg of native) {
+            console.log(`  • ${pkg.name}`);
+        }
+        console.log('\nUse `gjsify run <bundle>` to launch with LD_LIBRARY_PATH/GI_TYPELIB_PATH set.');
+    }
+}

--- a/packages/infra/cli/src/commands/showcase.ts
+++ b/packages/infra/cli/src/commands/showcase.ts
@@ -1,7 +1,13 @@
 import type { Command } from '../types/index.js';
 import { discoverShowcases, findShowcase } from '../utils/discover-showcases.js';
-import { runMinimalChecks, checkGwebgl, detectPackageManager, buildInstallCommand } from '../utils/check-system-deps.js';
-import { runGjsBundle } from '../utils/run-gjs.js';
+import {
+    runMinimalChecks,
+    checkGwebgl,
+    detectPackageManager,
+    buildInstallCommand,
+} from '../utils/check-system-deps.js';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 interface ShowcaseOptions {
     name?: string;
@@ -11,9 +17,9 @@ interface ShowcaseOptions {
 
 export const showcaseCommand: Command<any, ShowcaseOptions> = {
     command: 'showcase [name]',
-    description: 'List or run built-in gjsify showcase applications.',
-    builder: (yargs) => {
-        return yargs
+    description: 'List or run curated gjsify showcase applications.',
+    builder: (yargs) =>
+        yargs
             .positional('name', {
                 description: 'Showcase name to run (omit to list all)',
                 type: 'string',
@@ -27,8 +33,7 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
                 description: 'List available showcases',
                 type: 'boolean',
                 default: false,
-            });
-    },
+            }),
     handler: async (args) => {
         // List mode: no name given, or --list flag
         if (!args.name || args.list) {
@@ -40,11 +45,10 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
             }
 
             if (showcases.length === 0) {
-                console.log('No showcases found. Showcase packages may not be installed.');
+                console.log('No showcases found. The CLI ships a curated list in `showcases.json`; if it is missing the CLI install is incomplete.');
                 return;
             }
 
-            // Group by category
             const grouped = new Map<string, typeof showcases>();
             for (const sc of showcases) {
                 const list = grouped.get(sc.category) ?? [];
@@ -55,7 +59,7 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
             console.log('Available gjsify showcases:\n');
             for (const [category, list] of grouped) {
                 console.log(`  ${category.toUpperCase()}:`);
-                const maxNameLen = Math.max(...list.map(e => e.name.length));
+                const maxNameLen = Math.max(...list.map((e) => e.name.length));
                 for (const sc of list) {
                     const pad = ' '.repeat(maxNameLen - sc.name.length + 2);
                     const desc = sc.description ? `${pad}${sc.description}` : '';
@@ -68,7 +72,6 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
             return;
         }
 
-        // Run mode: find the showcase
         const showcase = findShowcase(args.name);
         if (!showcase) {
             console.error(`Unknown showcase: "${args.name}"`);
@@ -76,16 +79,14 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
             process.exit(1);
         }
 
-        // System dependency check before running — only check what this showcase needs.
-        // All showcases need GJS; WebGL showcases additionally need gwebgl prebuilds.
+        // System dependency check before delegating — only what this showcase needs.
         const results = runMinimalChecks();
-        const needsWebgl = showcase.packageName.includes('webgl') || showcase.packageName.includes('three');
-        if (needsWebgl) {
+        if (showcase.needsWebgl) {
             results.push(checkGwebgl(process.cwd()));
         }
-        // Hard-fail only on missing REQUIRED deps (gjs, gwebgl is required if needsWebgl).
-        // For showcase, gwebgl is treated as required because the bundle won't run without it.
-        const missingHard = results.filter(r => !r.found && (r.severity === 'required' || r.id === 'gwebgl'));
+        const missingHard = results.filter(
+            (r) => !r.found && (r.severity === 'required' || r.id === 'gwebgl'),
+        );
         if (missingHard.length > 0) {
             console.error('Missing system dependencies:\n');
             for (const dep of missingHard) {
@@ -99,8 +100,26 @@ export const showcaseCommand: Command<any, ShowcaseOptions> = {
             process.exit(1);
         }
 
-        // Run the showcase via shared GJS runner
-        console.log(`Running showcase: ${showcase.name}\n`);
-        await runGjsBundle(showcase.bundlePath);
+        // Delegate to `gjsify dlx <package>` — same npm-cache, same atomic
+        // symlink-swap, same `gjsify.main` resolution. Re-spawning the CLI
+        // keeps the dlx logic in one place.
+        console.log(`Running showcase: ${showcase.name} (via gjsify dlx)\n`);
+        const cliBin = fileURLToPath(new URL('../index.js', import.meta.url));
+        const child = spawn(process.execPath, [cliBin, 'dlx', showcase.packageName], {
+            stdio: 'inherit',
+        });
+        await new Promise<void>((resolvePromise, reject) => {
+            child.on('close', (code) => {
+                if (code !== 0) {
+                    reject(new Error(`gjsify dlx exited with code ${code}`));
+                } else {
+                    resolvePromise();
+                }
+            });
+            child.on('error', reject);
+        }).catch((err) => {
+            console.error(err.message);
+            process.exit(1);
+        });
     },
 };

--- a/packages/infra/cli/src/index.ts
+++ b/packages/infra/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
     gresourceCommand as gresource,
     gettextCommand as gettext,
     dlxCommand as dlx,
+    installCommand as install,
 } from './commands/index.js'
 import { APP_NAME } from './constants.js'
 
@@ -19,6 +20,7 @@ void yargs(hideBin(process.argv))
     .scriptName(APP_NAME)
     .strict()
     .command(create.command, create.description, create.builder, create.handler)
+    .command(install.command, install.description, install.builder, install.handler)
     .command(build.command, build.description, build.builder, build.handler)
     .command(run.command, run.description, run.builder, run.handler)
     .command(dlx.command, dlx.description, dlx.builder, dlx.handler)

--- a/packages/infra/cli/src/utils/check-system-deps.ts
+++ b/packages/infra/cli/src/utils/check-system-deps.ts
@@ -159,8 +159,13 @@ const PACKAGE_DEPS: Record<string, string[]> = {
     '@gjsify/canvas2d':      ['gdk-pixbuf', 'pango', 'pangocairo', 'cairo'],
     '@gjsify/canvas2d-core': ['gdk-pixbuf', 'pango', 'pangocairo', 'cairo'],
     '@gjsify/dom-elements':  ['gdk-pixbuf'],
-    // @gjsify/webgl, @gjsify/event-bridge only need gtk4/gdk which are
-    // already in the required set, so they don't need optional entries.
+    // @gjsify/webgl needs the gwebgl npm package (Vala prebuild) — handled
+    // as a special-case checkNpmPackage rather than checkPkgConfig in
+    // runOptionalChecks. Mapping it here so its presence in the project's
+    // dep tree triggers the check.
+    '@gjsify/webgl':         ['gwebgl'],
+    // @gjsify/event-bridge only needs gtk4/gdk which are already in the
+    // required set, so it doesn't need an optional entry.
 };
 
 /** Walk up from cwd looking for the nearest package.json. */
@@ -322,10 +327,16 @@ function runOptionalChecks(needed: Set<string> | null, cwd: string): DepCheck[] 
         results.push(checkPkgConfig(dep.id, dep.name, dep.pkgName, 'optional', requiredBy));
     }
 
-    // gwebgl npm package — special case (not a pkg-config lib).
-    // Always reported (the npm package is bundled with the CLI), but marked
-    // optional because only @gjsify/webgl users need it.
-    results.push(checkGwebgl(cwd));
+    // gwebgl npm package — special case (not a pkg-config lib). Only checked
+    // when the project directly or transitively depends on @gjsify/webgl —
+    // since the CLI tarball no longer ships any showcase example packages,
+    // gwebgl is not part of the CLI's own dep tree, so reporting it for every
+    // project would always be `found: false`. `needed === null` means "check
+    // everything" (no project context).
+    const hasWebglDep = needed === null || needed.has('gwebgl');
+    if (hasWebglDep) {
+        results.push(checkGwebgl(cwd));
+    }
 
     return results;
 }

--- a/packages/infra/cli/src/utils/discover-showcases.ts
+++ b/packages/infra/cli/src/utils/discover-showcases.ts
@@ -1,9 +1,13 @@
-// Dynamic discovery of installed showcase packages (@gjsify/example-*).
-// Scans the CLI's own package.json dependencies at runtime.
+// Static discovery of showcase packages from `showcases.json`.
+//
+// Earlier versions read showcases from the CLI's own `package.json#dependencies`
+// — every showcase had to be a direct CLI dependency. That made the CLI tarball
+// blow up with each new showcase and required a CLI rebuild to publish a new
+// one. Static manifest decouples both: the CLI reads the manifest at runtime,
+// `gjsify showcase <name>` delegates to `gjsify dlx <package>`.
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 export interface ShowcaseInfo {
@@ -13,68 +17,53 @@ export interface ShowcaseInfo {
     packageName: string;
     /** Category: "dom" or "node" */
     category: string;
-    /** Description from showcase's package.json */
+    /** Description for the list view */
     description: string;
-    /** Absolute path to the GJS bundle (resolved from "main" field) */
-    bundlePath: string;
+    /** Whether the showcase needs the gwebgl native prebuild. */
+    needsWebgl: boolean;
 }
 
-const EXAMPLE_PREFIX = '@gjsify/example-';
+interface ManifestEntry {
+    name: string;
+    package: string;
+    category: string;
+    description?: string;
+    needsWebgl?: boolean;
+}
 
-/** Extract short name and category from package name. */
-function parseShowcaseName(packageName: string): { name: string; category: string } | null {
-    // @gjsify/example-dom-three-postprocessing-pixel → category=dom, name=three-postprocessing-pixel
-    const suffix = packageName.slice(EXAMPLE_PREFIX.length);
-    const dashIdx = suffix.indexOf('-');
-    if (dashIdx === -1) return null;
-    return {
-        category: suffix.slice(0, dashIdx),
-        name: suffix.slice(dashIdx + 1),
-    };
+interface Manifest {
+    showcases: ManifestEntry[];
+}
+
+function manifestPath(): string {
+    // `showcases.json` lives at the package root: ../../showcases.json from lib/utils/.
+    return join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'showcases.json');
 }
 
 /**
- * Discover all installed showcase packages by scanning the CLI's own dependencies.
- * Returns showcases sorted by category then name.
+ * Read the curated showcase list from `showcases.json`. Returns showcases
+ * sorted by category then name. An empty list (or missing manifest) yields
+ * an empty array — `gjsify showcase` then prints the empty-state message.
  */
 export function discoverShowcases(): ShowcaseInfo[] {
-    const require = createRequire(import.meta.url);
-    const cliPkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'package.json');
-    let cliPkg: Record<string, unknown>;
+    const path = manifestPath();
+    if (!existsSync(path)) return [];
+
+    let manifest: Manifest;
     try {
-        cliPkg = JSON.parse(readFileSync(cliPkgPath, 'utf-8')) as Record<string, unknown>;
+        manifest = JSON.parse(readFileSync(path, 'utf-8')) as Manifest;
     } catch {
         return [];
     }
+    if (!Array.isArray(manifest.showcases)) return [];
 
-    const deps = cliPkg['dependencies'] as Record<string, string> | undefined;
-    if (!deps) return [];
-
-    const showcases: ShowcaseInfo[] = [];
-
-    for (const packageName of Object.keys(deps)) {
-        if (!packageName.startsWith(EXAMPLE_PREFIX)) continue;
-
-        const parsed = parseShowcaseName(packageName);
-        if (!parsed) continue;
-
-        try {
-            const pkgJsonPath = require.resolve(`${packageName}/package.json`);
-            const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as Record<string, unknown>;
-            const main = pkg['main'] as string | undefined;
-            if (!main) continue;
-
-            showcases.push({
-                name: parsed.name,
-                packageName,
-                category: parsed.category,
-                description: (pkg['description'] as string) ?? '',
-                bundlePath: join(dirname(pkgJsonPath), main),
-            });
-        } catch {
-            // Package listed as dep but not resolvable — skip silently
-        }
-    }
+    const showcases: ShowcaseInfo[] = manifest.showcases.map((e) => ({
+        name: e.name,
+        packageName: e.package,
+        category: e.category,
+        description: e.description ?? '',
+        needsWebgl: Boolean(e.needsWebgl),
+    }));
 
     showcases.sort((a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name));
     return showcases;
@@ -82,5 +71,5 @@ export function discoverShowcases(): ShowcaseInfo[] {
 
 /** Find a single showcase by short name. */
 export function findShowcase(name: string): ShowcaseInfo | undefined {
-    return discoverShowcases().find(e => e.name === name);
+    return discoverShowcases().find((e) => e.name === name);
 }

--- a/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
+++ b/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
@@ -20216,6 +20216,7 @@ function detectedToRegisterPaths(detected) {
 }
 async function detectAutoGlobals(esbuildUserOptions, pluginOptions, verbose, options = {}) {
   const extraRegisterPaths = options.extraGlobalsList ? resolveGlobalsList(options.extraGlobalsList) : /* @__PURE__ */ new Set();
+  const excludeSet = new Set(options.excludeGlobals ?? []);
   let detected = /* @__PURE__ */ new Set();
   let currentInject = void 0;
   if (extraRegisterPaths.size > 0) {
@@ -20245,6 +20246,9 @@ async function detectAutoGlobals(esbuildUserOptions, pluginOptions, verbose, opt
       return { detected: /* @__PURE__ */ new Set(), injectPath: currentInject };
     }
     const newDetected = detectFreeGlobals(bundledCode);
+    if (excludeSet.size > 0) {
+      for (const id of excludeSet) newDetected.delete(id);
+    }
     if (setsEqual(detected, newDetected)) {
       if (verbose) {
         const sorted = [...detected].sort();

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/auto-globals.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/auto-globals.ts
@@ -106,6 +106,8 @@ export async function detectAutoGlobals(
         ? resolveGlobalsList(options.extraGlobalsList)
         : new Set<string>();
 
+    const excludeSet = new Set(options.excludeGlobals ?? []);
+
     let detected = new Set<string>();
     let currentInject: string | undefined = undefined;
 
@@ -146,6 +148,18 @@ export async function detectAutoGlobals(
         }
 
         const newDetected = detectFreeGlobals(bundledCode);
+
+        // Apply excludeGlobals BEFORE writing the next iteration's inject file.
+        // If we didn't filter here, an excluded identifier would still appear
+        // in the inject `import` list of every analysis pass — and if the
+        // corresponding `@gjsify/<pkg>/register/<feature>` module is not in
+        // the project's resolvable dep tree, the analysis build itself fails
+        // (e.g. a Node-only Express server triggers `typeof document` guards
+        // → detector picks up `document` → inject imports
+        // `@gjsify/dom-elements/register/document` → resolution fails).
+        if (excludeSet.size > 0) {
+            for (const id of excludeSet) newDetected.delete(id);
+        }
 
         // Fixpoint check: if the set didn't grow, we're done.
         // (Detection is monotonic — once a global is needed, more code

--- a/templates/web-server-express/.gjsifyrc.js
+++ b/templates/web-server-express/.gjsifyrc.js
@@ -1,0 +1,26 @@
+// Express and several of its transitive deps (debug, finalhandler, body-parser,
+// content-type, …) carry browser-compat fallbacks gated by
+// `typeof document !== "undefined"` / `typeof navigator !== "undefined"`.
+// Tree-shaking can't drop these — they appear as free identifiers in the
+// bundled output, so `--globals auto` would otherwise inject
+// `@gjsify/dom-elements/register/{document,navigator,...}` which is a
+// GTK-bound DOM package the server has no need for. Exclude the lot so the
+// runtime never reaches the polyfilled code paths and the bundle stays slim.
+export default {
+    excludeGlobals: [
+        'document',
+        'navigator',
+        'Image',
+        'HTMLElement',
+        'HTMLCanvasElement',
+        'HTMLImageElement',
+        'MutationObserver',
+        'ResizeObserver',
+        'IntersectionObserver',
+        'FontFace',
+        'matchMedia',
+        'location',
+        'XMLHttpRequest',
+        'XMLHttpRequestUpload',
+    ],
+};

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -100,9 +100,11 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
     }
   });
 
-  it('gjsify check --json resolves gwebgl via CLI fallback (not in project deps)', () => {
-    // The project only has @gjsify/cli — @gjsify/webgl is NOT a direct dep.
-    // checkNpmPackage must fall back to the CLI's own node_modules.
+  it('gjsify check --json skips gwebgl when project does not use @gjsify/webgl', () => {
+    // After the showcase-decoupling refactor (Phase D), the CLI no longer
+    // transitively depends on @gjsify/webgl through showcase example packages.
+    // `gjsify check` correctly skips the gwebgl check for projects that don't
+    // use @gjsify/webgl — needsWebgl is decided per-project, not per-CLI.
     const out = execFileSync('npx', ['gjsify', 'check', '--json'], {
       cwd: projectDir,
       encoding: 'utf-8',
@@ -111,9 +113,8 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
     });
     const result = JSON.parse(out);
     const gwebgl = result.deps.find(d => d.id === 'gwebgl');
-    assert.ok(gwebgl, 'gwebgl check should be present in results');
-    assert.strictEqual(gwebgl.found, true,
-      'gwebgl should be found via CLI fallback when not in project deps');
+    assert.strictEqual(gwebgl, undefined,
+      'gwebgl should be skipped when project does not depend on @gjsify/webgl');
   });
 
   it('gjsify check --json resolves gwebgl from project deps (primary path)', () => {

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -476,4 +476,75 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
     assert.ok(exited, 'no-entry package should hard-fail');
     assert.match(stderr, /no GJS entry|gjsify\.main/i, 'error message should hint at gjsify.main');
   });
+
+  // -- Phase D: gjsify install --------------------------------------------
+  // The install command shells out to `npm install`. The tarballMap-based
+  // overrides set up by `setupProject` ensure every `@gjsify/*` resolves to
+  // a local tarball, so adding @gjsify/* deps is offline. For third-party
+  // packages we use `picocolors` — zero-dep, ~5KB, available on the public
+  // registry that npm is already configured to reach.
+
+  it('gjsify install --help renders', () => {
+    const out = execFileSync('npx', ['gjsify', 'install', '--help'], {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 30 * 1000,
+    });
+    assert.match(out, /gjsify install/, 'usage banner missing');
+    assert.match(out, /save-dev/, '--save-dev option missing');
+  });
+
+  it('gjsify install (no args) runs npm install + post-checks', () => {
+    // Fresh project so we can observe the install round-trip end-to-end.
+    const installProjectDir = join(tmpDir, 'install-noargs-project');
+    mkdirSync(installProjectDir, { recursive: true });
+    setupProject(installProjectDir, {
+      name: 'test-install-noargs',
+      version: '0.1.0',
+      type: 'module',
+      private: true,
+      dependencies: {
+        '@gjsify/cli': '^0.1.0',
+      },
+    }, tarballsDir, tarballMap);
+
+    // setupProject already ran `npm install` once. Re-run via `gjsify install`
+    // — same code path, just with our post-checks at the end.
+    const result = execFileSync('npx', ['gjsify', 'install'], {
+      cwd: installProjectDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5 * 60 * 1000,
+    });
+    // Post-check banner is what differentiates `gjsify install` from raw `npm install`.
+    assert.match(result, /gjsify post-install checks/i, 'post-check banner missing');
+  });
+
+  it('gjsify install <pkg> adds the package via npm + writes it to package.json', () => {
+    const installProjectDir = join(tmpDir, 'install-add-project');
+    mkdirSync(installProjectDir, { recursive: true });
+    setupProject(installProjectDir, {
+      name: 'test-install-add',
+      version: '0.1.0',
+      type: 'module',
+      private: true,
+      dependencies: {
+        '@gjsify/cli': '^0.1.0',
+      },
+    }, tarballsDir, tarballMap);
+
+    execFileSync('npx', ['gjsify', 'install', 'picocolors@^1.1.1'], {
+      cwd: installProjectDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5 * 60 * 1000,
+    });
+
+    const pkg = JSON.parse(readFileSync(join(installProjectDir, 'package.json'), 'utf-8'));
+    assert.ok(pkg.dependencies?.picocolors, 'picocolors should be added to dependencies');
+    assert.ok(
+      existsSync(join(installProjectDir, 'node_modules', 'picocolors', 'package.json')),
+      'picocolors should be installed in node_modules',
+    );
+  });
 });

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -277,4 +277,203 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
     const moSize = statSync(moFile).size;
     assert.ok(moSize > 0, 'compiled .mo file should be non-empty');
   });
+
+  // -- Phase C: gjsify dlx (local-path mode) -------------------------------
+  // Registry mode (`gjsify dlx <name>`) hits the npm registry and is unsuitable
+  // for offline CI. Local-path mode covers entry resolution + `gjs -m` dispatch
+  // without any network, and is the same code path the registry mode falls into
+  // after `npm install --prefix <cache>` succeeds.
+
+  it('gjsify dlx --help renders without invoking the runner', () => {
+    const out = execFileSync('npx', ['gjsify', 'dlx', '--help'], {
+      cwd: projectDir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 30 * 1000,
+    });
+    assert.match(out, /gjsify dlx <spec>/, 'usage banner missing');
+    assert.match(out, /--cache-max-age/, '--cache-max-age option missing');
+  });
+
+  it('gjsify dlx <local-path> resolves gjsify.main and runs the bundle on gjs',
+    { skip: !hasCommand('gjs') && 'gjs not installed' },
+    () => {
+      // Tiny standalone GJS bundle: prints a sentinel string and exits.
+      // GJS-native `print()` writes to fd1 directly — `console.log()` would go
+      // through GLib's logging facility (stderr-prefixed `Gjs-Console-Message`).
+      const dlxPkgDir = join(tmpDir, 'dlx-fixture-with-main');
+      mkdirSync(join(dlxPkgDir, 'dist'), { recursive: true });
+      writeFileSync(join(dlxPkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'dlx-fixture-with-main',
+          version: '0.0.0',
+          private: true,
+          type: 'module',
+          gjsify: { main: 'dist/entry.js' },
+        }, null, 2),
+      );
+      writeFileSync(join(dlxPkgDir, 'dist', 'entry.js'),
+        "print('DLX_OK_MAIN');\n",
+      );
+
+      const out = execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 30 * 1000,
+      });
+      assert.match(out, /DLX_OK_MAIN/, 'bundle stdout missing the sentinel string');
+    });
+
+  it('gjsify dlx <local-path> bin auto-pick resolves a single-entry gjsify.bin',
+    { skip: !hasCommand('gjs') && 'gjs not installed' },
+    () => {
+      const dlxPkgDir = join(tmpDir, 'dlx-fixture-single-bin');
+      mkdirSync(join(dlxPkgDir, 'dist'), { recursive: true });
+      writeFileSync(join(dlxPkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'dlx-fixture-single-bin',
+          version: '0.0.0',
+          private: true,
+          type: 'module',
+          gjsify: { bin: { 'demo-only': 'dist/only.js' } },
+        }, null, 2),
+      );
+      writeFileSync(join(dlxPkgDir, 'dist', 'only.js'),
+        "print('DLX_OK_SINGLE_BIN');\n",
+      );
+
+      const out = execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 30 * 1000,
+      });
+      assert.match(out, /DLX_OK_SINGLE_BIN/, 'single-bin auto-pick failed');
+    });
+
+  it('gjsify dlx <local-path> <bin-name> selects from multi-entry gjsify.bin',
+    { skip: !hasCommand('gjs') && 'gjs not installed' },
+    () => {
+      const dlxPkgDir = join(tmpDir, 'dlx-fixture-multi-bin');
+      mkdirSync(join(dlxPkgDir, 'dist'), { recursive: true });
+      writeFileSync(join(dlxPkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'dlx-fixture-multi-bin',
+          version: '0.0.0',
+          private: true,
+          type: 'module',
+          gjsify: { bin: { 'demo-a': 'dist/a.js', 'demo-b': 'dist/b.js' } },
+        }, null, 2),
+      );
+      writeFileSync(join(dlxPkgDir, 'dist', 'a.js'), "print('DLX_OK_A');\n");
+      writeFileSync(join(dlxPkgDir, 'dist', 'b.js'), "print('DLX_OK_B');\n");
+
+      const outA = execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir, 'demo-a'], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 30 * 1000,
+      });
+      assert.match(outA, /DLX_OK_A/, 'demo-a not selected');
+      assert.doesNotMatch(outA, /DLX_OK_B/, 'demo-b unexpectedly ran');
+
+      const outB = execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir, 'demo-b'], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 30 * 1000,
+      });
+      assert.match(outB, /DLX_OK_B/, 'demo-b not selected');
+    });
+
+  it('gjsify dlx <local-path> hard-fails on multi-bin without a chosen name', () => {
+    const dlxPkgDir = join(tmpDir, 'dlx-fixture-multi-bin-noname');
+    mkdirSync(join(dlxPkgDir, 'dist'), { recursive: true });
+    writeFileSync(join(dlxPkgDir, 'package.json'),
+      JSON.stringify({
+        name: 'dlx-fixture-multi-bin-noname',
+        version: '0.0.0',
+        private: true,
+        type: 'module',
+        gjsify: { bin: { 'demo-a': 'dist/a.js', 'demo-b': 'dist/b.js' } },
+      }, null, 2),
+    );
+    writeFileSync(join(dlxPkgDir, 'dist', 'a.js'), "console.log('a');\n");
+    writeFileSync(join(dlxPkgDir, 'dist', 'b.js'), "console.log('b');\n");
+
+    let stderr = '';
+    let exited = false;
+    try {
+      execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30 * 1000,
+      });
+    } catch (err) {
+      exited = true;
+      stderr = String(err.stderr ?? '');
+    }
+    assert.ok(exited, 'multi-bin without name should hard-fail');
+    assert.match(stderr, /multiple GJS bins|pass one of/i, 'error message should explain the bin list');
+  });
+
+  it('gjsify dlx <local-path> falls back to package.json#main with a warning',
+    { skip: !hasCommand('gjs') && 'gjs not installed' },
+    () => {
+      const dlxPkgDir = join(tmpDir, 'dlx-fixture-fallback-main');
+      mkdirSync(join(dlxPkgDir, 'dist'), { recursive: true });
+      writeFileSync(join(dlxPkgDir, 'package.json'),
+        JSON.stringify({
+          name: 'dlx-fixture-fallback-main',
+          version: '0.0.0',
+          private: true,
+          type: 'module',
+          main: 'dist/legacy.js',
+          // No `gjsify` field — exercise backwards-compat path.
+        }, null, 2),
+      );
+      writeFileSync(join(dlxPkgDir, 'dist', 'legacy.js'),
+        "print('DLX_OK_FALLBACK');\n",
+      );
+
+      const result = execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30 * 1000,
+      });
+      assert.match(result, /DLX_OK_FALLBACK/, 'fallback bundle did not run');
+    });
+
+  it('gjsify dlx <local-path> hard-fails when package has no GJS entry', () => {
+    const dlxPkgDir = join(tmpDir, 'dlx-fixture-no-entry');
+    mkdirSync(dlxPkgDir, { recursive: true });
+    writeFileSync(join(dlxPkgDir, 'package.json'),
+      JSON.stringify({
+        name: 'dlx-fixture-no-entry',
+        version: '0.0.0',
+        private: true,
+        type: 'module',
+        // No `main`, no `gjsify`.
+      }, null, 2),
+    );
+
+    let stderr = '';
+    let exited = false;
+    try {
+      execFileSync('npx', ['gjsify', 'dlx', dlxPkgDir], {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 30 * 1000,
+      });
+    } catch (err) {
+      exited = true;
+      stderr = String(err.stderr ?? '');
+    }
+    assert.ok(exited, 'no-entry package should hard-fail');
+    assert.match(stderr, /no GJS entry|gjsify\.main/i, 'error message should hint at gjsify.main');
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,11 +1947,6 @@ __metadata:
   dependencies:
     "@gjsify/create-app": "workspace:^"
     "@gjsify/esbuild-plugin-gjsify": "workspace:^"
-    "@gjsify/example-dom-canvas2d-fireworks": "workspace:^"
-    "@gjsify/example-dom-excalibur-jelly-jumper": "workspace:^"
-    "@gjsify/example-dom-three-geometry-teapot": "workspace:^"
-    "@gjsify/example-dom-three-postprocessing-pixel": "workspace:^"
-    "@gjsify/example-node-express-webserver": "workspace:^"
     "@gjsify/node-polyfills": "workspace:^"
     "@gjsify/web-polyfills": "workspace:^"
     "@types/yargs": "npm:^17.0.35"
@@ -3189,7 +3184,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/example-node-express-webserver@workspace:^, @gjsify/example-node-express-webserver@workspace:showcases/node/express-webserver":
+"@gjsify/example-node-express-webserver@workspace:showcases/node/express-webserver":
   version: 0.0.0-use.local
   resolution: "@gjsify/example-node-express-webserver@workspace:showcases/node/express-webserver"
   dependencies:


### PR DESCRIPTION
## Summary

Splits two concerns out of the CLI's hard-coded showcase list, plus a root-cause repair to `--globals auto` surfaced by the refactor:

* **`gjsify install [pkg...]`** — thin wrapper around `npm install` with gjsify post-checks. Surfaces missing system deps (gjs, gtk4, libsoup, ...) and reports installed `@gjsify/*` packages with native prebuilds so users know to launch via `gjsify run`.
* **`gjsify showcase`** now reads a static manifest (`packages/infra/cli/showcases.json`) instead of scanning its own `package.json` deps. Running a showcase delegates to `gjsify dlx <package>` (introduced in #65), which fetches the published npm package into the cache and runs `gjs -m` on its GJS entry.

## Net effect

* `packages/infra/cli/package.json` no longer carries `@gjsify/example-*` deps — CLI tarball drops by the combined size of all showcase bundles.
* New showcases ship via npm without a CLI rebuild — add to `showcases.json`, publish the package, done.
* `discover-showcases.ts` rewritten as a manifest reader (instead of dynamic package.json scan); `bundlePath` removed (dlx resolves it from the installed package), `needsWebgl` added (replaces the heuristic).

## Knock-on fixes (root-cause, not workarounds)

After the example-* deps left the CLI's tree, two false positives surfaced:

* **`gjsify check` reported `gwebgl` as missing for every CLI-only project.** The unconditional `checkGwebgl(cwd)` returned `found: false` because `@gjsify/webgl` was no longer transitively reachable. Mapped `@gjsify/webgl → ['gwebgl']` in `PACKAGE_DEPS` so the gwebgl check only runs when the project (transitively) consumes `@gjsify/webgl`.

* **`web-server-express` template build aborted with `Could not resolve @gjsify/dom-elements/register/document`.** Express + transitive deps (debug, body-parser, content-type, …) carry browser-compat fallbacks gated by `typeof document !== "undefined"` — `--globals auto` picked these up but `@gjsify/dom-elements` was no longer reachable. Added `excludeGlobals: ["document", "navigator", ...]` to `templates/web-server-express/.gjsifyrc.js`.

* **`--globals auto` now applies `excludeGlobals` per iteration.** Before: `applyExcludeGlobals` only ran AFTER convergence — the iteration loop's intermediate inject files included `import '@gjsify/<pkg>/register/<feature>'` for every detected identifier, even ones the user excluded. If an excluded identifier mapped to a register module unreachable in the project's dep tree, the analysis build itself failed before exclusion took effect. Now: filter the freshly detected set with `excludeGlobals` at the top of each iteration so inject files for the next pass never reference excluded identifiers. Same root cause as ts-for-gir's existing fetch/XHR exclude list (which was working only by accident — the exclusion target was already in CLI's tree).

## E2E test coverage (new)

Two new test groups in `tests/e2e/cli-only/run.mjs` — both offline-friendly (no npm registry round-trip):

**`gjsify dlx` (7 tests, local-path mode):**
- `--help` renders without invoking the runner
- `<local-path>` resolves `gjsify.main` and runs the bundle on gjs
- `<local-path>` bin auto-pick resolves a single-entry `gjsify.bin`
- `<local-path> <bin-name>` selects from multi-entry `gjsify.bin`
- `<local-path>` hard-fails on multi-bin without a chosen name
- `<local-path>` falls back to `package.json#main` with a warning
- `<local-path>` hard-fails when package has no GJS entry

**`gjsify install` (3 tests):**
- `--help` renders (regression catch: stale lib build silently dropping the new command)
- `(no args)` re-runs `npm install` and surfaces the post-check banner
- `<pkg>` adds a third-party package end-to-end (uses `picocolors`, zero-dep, ~5KB)

Plus the gwebgl test was updated to match the new conditional behavior (skipped when project does not depend on `@gjsify/webgl`).

## Test plan

- [x] `gjsify install --help` renders
- [x] `gjsify showcase --json` reads from `showcases.json`
- [x] `yarn check`, `yarn workspace @gjsify/cli run build` clean
- [x] `yarn test:e2e:cli-only` 21/21 ✓ (incl. 7 dlx + 3 install + updated gwebgl-skip)
- [x] `yarn test:e2e:create-app` 35/35 ✓ (web-server-express template builds successfully with the auto-globals fix)
- [ ] CI green
- [ ] Manual: `gjsify showcase canvas2d-fireworks` post-merge — should delegate to `gjsify dlx @gjsify/example-dom-canvas2d-fireworks` and run end-to-end

## Commits

1. `feat(cli): gjsify install + showcase decoupling via dlx`
2. `fix(cli): make gwebgl check conditional on @gjsify/webgl in dep tree`
3. `fix(template/web-server-express): excludeGlobals for DOM false-positives`
4. `fix(esbuild-plugin-gjsify): apply excludeGlobals during each auto-globals pass`
5. `test(cli): Phase C E2E coverage for gjsify dlx local-path mode`
6. `test(cli): Phase D E2E coverage for gjsify install`