### PR TITLE
fix(esbuild-plugin-gjsify): shebang hoist + zip-resident createRequire stub + skip zip URL rewrite

### DIFF
--- a/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
+++ b/packages/infra/esbuild-plugin-gjsify/dist/esm/globals.mjs
@@ -13034,6 +13034,17 @@ function tryInlineCall(node, ctx, src) {
       };
     }
   }
+  if (calleeName === "createRequire") {
+    const path6 = evalPathExpr(node.arguments[0], ctx);
+    const isZip = path6 !== void 0 && path6.includes(".zip/");
+    if (path6 !== void 0 && (isZip || !existsSyncSafe(path6))) {
+      return {
+        start: node.start,
+        end: node.end,
+        replacement: `(() => { const _r = (id) => { throw new Error("[gjsify] createRequire stub: '" + id + "' was not bundled (anchor path: " + ${jsStringLiteral(path6)} + ")"); }; _r.resolve = _r; _r.cache = {}; _r.extensions = {}; _r.main = void 0; return _r; })()`
+      };
+    }
+  }
   return void 0;
 }
 function tryInlineReadFile(node, ctx, forceTextEncoding) {
@@ -13273,7 +13284,6 @@ function isDirectorySafe(path6) {
 var REWRITE_FILTER = /\.(m?js|cjs|[cm]?tsx?)$/;
 var DIRNAME_DECL_RE = /(?:var|let|const)\s+__dirname\b|export\s+(?:var|let|const)\s+__dirname\b/;
 var FILENAME_DECL_RE = /(?:var|let|const)\s+__filename\b|export\s+(?:var|let|const)\s+__filename\b/;
-var zipPathWarningEmitted = false;
 function shouldRewrite(path6) {
   return path6.includes("node_modules") && REWRITE_FILTER.test(path6);
 }
@@ -13303,20 +13313,24 @@ function rewriteContents(args, srcInput, bundleDir) {
   let contents = src;
   if (hasMetaUrl) {
     const relPath = relative2(bundleDir, args.path);
-    if (relPath.includes(".zip/") && !zipPathWarningEmitted) {
-      zipPathWarningEmitted = true;
-      console.warn(
-        `[gjsify] rewriter: bundling code from inside a PnP virtual zip (${relPath}). import.meta.url-relative paths in this file won't resolve at runtime. Switch to "nodeLinker: node-modules" or unplug the offending package(s) until the rewriter learns to inline zip-resident reads.`
-      );
-    }
-    const relDir = relative2(bundleDir, dir) || ".";
-    const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
-    contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
-    if (hasDirname && !dirnameDeclared) {
-      preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + "/")}, import.meta.url).pathname.replace(/\\/$/, "");`);
-    }
-    if (hasFilename && !filenameDeclared) {
-      preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+    const isZipResident = relPath.includes(".zip/");
+    if (isZipResident) {
+      if (hasDirname && !dirnameDeclared) {
+        preamble.push(`var __dirname = new URL(".", import.meta.url).pathname.replace(/\\/$/, "");`);
+      }
+      if (hasFilename && !filenameDeclared) {
+        preamble.push(`var __filename = new URL(import.meta.url).pathname;`);
+      }
+    } else {
+      const relDir = relative2(bundleDir, dir) || ".";
+      const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
+      contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
+      if (hasDirname && !dirnameDeclared) {
+        preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + "/")}, import.meta.url).pathname.replace(/\\/$/, "");`);
+      }
+      if (hasFilename && !filenameDeclared) {
+        preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+      }
     }
   } else {
     if (hasDirname && !dirnameDeclared) preamble.push(`var __dirname = ${JSON.stringify(dir)};`);
@@ -20359,6 +20373,16 @@ var GJS_PROCESS_STUB = [
   "};",
   "}"
 ].join("");
+function composeBanner(stub, userBanner) {
+  if (!userBanner) return stub;
+  const shebangMatch = userBanner.match(/^#![^\n]*\n/);
+  if (!shebangMatch) {
+    return stub + "\n" + userBanner;
+  }
+  const shebang = shebangMatch[0];
+  const rest = userBanner.slice(shebang.length);
+  return shebang + stub + (rest ? "\n" + rest : "");
+}
 var setupForGjs = async (build2, pluginOptions) => {
   const userExternal = build2.initialOptions.external ?? [];
   const external = ["gi://*", "cairo", "gettext", "system", ...userExternal];
@@ -20425,7 +20449,7 @@ var setupForGjs = async (build2, pluginOptions) => {
     ];
   }
   const userBannerJs = typeof build2.initialOptions.banner?.js === "string" ? build2.initialOptions.banner.js : "";
-  esbuildOptions.banner = { js: GJS_PROCESS_STUB + (userBannerJs ? "\n" + userBannerJs : "") };
+  esbuildOptions.banner = { js: composeBanner(GJS_PROCESS_STUB, userBannerJs) };
   build2.onResolve({ filter: /^random-access-file$/ }, async (args) => {
     const result = await build2.resolve("random-access-file/index.js", {
       kind: args.kind,

--- a/packages/infra/esbuild-plugin-gjsify/dist/esm/index.mjs
+++ b/packages/infra/esbuild-plugin-gjsify/dist/esm/index.mjs
@@ -12489,6 +12489,17 @@ function tryInlineCall(node, ctx, src) {
       };
     }
   }
+  if (calleeName === "createRequire") {
+    const path6 = evalPathExpr(node.arguments[0], ctx);
+    const isZip = path6 !== void 0 && path6.includes(".zip/");
+    if (path6 !== void 0 && (isZip || !existsSyncSafe(path6))) {
+      return {
+        start: node.start,
+        end: node.end,
+        replacement: `(() => { const _r = (id) => { throw new Error("[gjsify] createRequire stub: '" + id + "' was not bundled (anchor path: " + ${jsStringLiteral(path6)} + ")"); }; _r.resolve = _r; _r.cache = {}; _r.extensions = {}; _r.main = void 0; return _r; })()`
+      };
+    }
+  }
   return void 0;
 }
 function tryInlineReadFile(node, ctx, forceTextEncoding) {
@@ -12728,7 +12739,6 @@ function isDirectorySafe(path6) {
 var REWRITE_FILTER = /\.(m?js|cjs|[cm]?tsx?)$/;
 var DIRNAME_DECL_RE = /(?:var|let|const)\s+__dirname\b|export\s+(?:var|let|const)\s+__dirname\b/;
 var FILENAME_DECL_RE = /(?:var|let|const)\s+__filename\b|export\s+(?:var|let|const)\s+__filename\b/;
-var zipPathWarningEmitted = false;
 function shouldRewrite(path6) {
   return path6.includes("node_modules") && REWRITE_FILTER.test(path6);
 }
@@ -12758,20 +12768,24 @@ function rewriteContents(args, srcInput, bundleDir) {
   let contents = src;
   if (hasMetaUrl) {
     const relPath = relative2(bundleDir, args.path);
-    if (relPath.includes(".zip/") && !zipPathWarningEmitted) {
-      zipPathWarningEmitted = true;
-      console.warn(
-        `[gjsify] rewriter: bundling code from inside a PnP virtual zip (${relPath}). import.meta.url-relative paths in this file won't resolve at runtime. Switch to "nodeLinker: node-modules" or unplug the offending package(s) until the rewriter learns to inline zip-resident reads.`
-      );
-    }
-    const relDir = relative2(bundleDir, dir) || ".";
-    const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
-    contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
-    if (hasDirname && !dirnameDeclared) {
-      preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + "/")}, import.meta.url).pathname.replace(/\\/$/, "");`);
-    }
-    if (hasFilename && !filenameDeclared) {
-      preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+    const isZipResident = relPath.includes(".zip/");
+    if (isZipResident) {
+      if (hasDirname && !dirnameDeclared) {
+        preamble.push(`var __dirname = new URL(".", import.meta.url).pathname.replace(/\\/$/, "");`);
+      }
+      if (hasFilename && !filenameDeclared) {
+        preamble.push(`var __filename = new URL(import.meta.url).pathname;`);
+      }
+    } else {
+      const relDir = relative2(bundleDir, dir) || ".";
+      const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
+      contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
+      if (hasDirname && !dirnameDeclared) {
+        preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + "/")}, import.meta.url).pathname.replace(/\\/$/, "");`);
+      }
+      if (hasFilename && !filenameDeclared) {
+        preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+      }
     }
   } else {
     if (hasDirname && !dirnameDeclared) preamble.push(`var __dirname = ${JSON.stringify(dir)};`);
@@ -19900,6 +19914,16 @@ var GJS_PROCESS_STUB = [
   "};",
   "}"
 ].join("");
+function composeBanner(stub, userBanner) {
+  if (!userBanner) return stub;
+  const shebangMatch = userBanner.match(/^#![^\n]*\n/);
+  if (!shebangMatch) {
+    return stub + "\n" + userBanner;
+  }
+  const shebang = shebangMatch[0];
+  const rest = userBanner.slice(shebang.length);
+  return shebang + stub + (rest ? "\n" + rest : "");
+}
 var setupForGjs = async (build, pluginOptions) => {
   const userExternal = build.initialOptions.external ?? [];
   const external = ["gi://*", "cairo", "gettext", "system", ...userExternal];
@@ -19966,7 +19990,7 @@ var setupForGjs = async (build, pluginOptions) => {
     ];
   }
   const userBannerJs = typeof build.initialOptions.banner?.js === "string" ? build.initialOptions.banner.js : "";
-  esbuildOptions.banner = { js: GJS_PROCESS_STUB + (userBannerJs ? "\n" + userBannerJs : "") };
+  esbuildOptions.banner = { js: composeBanner(GJS_PROCESS_STUB, userBannerJs) };
   build.onResolve({ filter: /^random-access-file$/ }, async (args) => {
     const result = await build.resolve("random-access-file/index.js", {
       kind: args.kind,

--- a/packages/infra/esbuild-plugin-gjsify/src/app/gjs.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/app/gjs.ts
@@ -54,6 +54,33 @@ const GJS_PROCESS_STUB = [
     '}',
 ].join('');
 
+/**
+ * Compose the GJS process stub with the user-supplied banner so the result
+ * is valid syntax for `gjs -m`. Specifically: a leading `#!shebang` line in
+ * the user banner is hoisted to byte 0 of the output. Any `#` character
+ * that appears anywhere except byte 0 is a fatal SyntaxError under
+ * SpiderMonkey 128+ — putting our process stub before the user's shebang
+ * would break the bundle.
+ *
+ * Output shape:
+ *   [#!shebang\n][<process-stub>\n<rest-of-user-banner>]
+ *
+ * Either side of the bracket may be empty; the result is always
+ * concatenated without leading whitespace.
+ */
+function composeBanner(stub: string, userBanner: string): string {
+    if (!userBanner) return stub;
+    // Match a leading shebang line (`#!...\n`). Pick it off so it stays at
+    // byte 0; everything after it is regular JS that comes after the stub.
+    const shebangMatch = userBanner.match(/^#![^\n]*\n/);
+    if (!shebangMatch) {
+        return stub + '\n' + userBanner;
+    }
+    const shebang = shebangMatch[0];
+    const rest = userBanner.slice(shebang.length);
+    return shebang + stub + (rest ? '\n' + rest : '');
+}
+
 export const setupForGjs = async (build: PluginBuild, pluginOptions: PluginOptions) => {
 
     // User-supplied externals (`gjsify build --external <name>`) merge in so
@@ -137,11 +164,16 @@ export const setupForGjs = async (build: PluginBuild, pluginOptions: PluginOptio
     }
 
     // Prepend the synchronous process stub banner so globalThis.process exists
-    // before any bundled module code runs. Combines with any user-supplied banner.
+    // before any bundled module code runs. Combines with any user-supplied
+    // banner. A leading `#!` shebang line in the user banner is hoisted to
+    // byte 0 of the output — shebangs are only valid at the absolute start
+    // of a file (gjs's JS parser, like SpiderMonkey, hard-fails on a `#`
+    // appearing anywhere else). The order is therefore:
+    //   #!shebang\n<process-stub>\n<rest of user banner>\n<bundle code>
     const userBannerJs = typeof (build.initialOptions.banner as Record<string, string> | undefined)?.js === 'string'
         ? (build.initialOptions.banner as Record<string, string>).js
         : '';
-    esbuildOptions.banner = { js: GJS_PROCESS_STUB + (userBannerJs ? '\n' + userBannerJs : '') };
+    esbuildOptions.banner = { js: composeBanner(GJS_PROCESS_STUB, userBannerJs) };
 
     // random-access-file's 'browser' field maps to a throwing stub; force the fs-backed Node entry.
     build.onResolve({ filter: /^random-access-file$/ }, async (args) => {

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/inline-static-reads.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/inline-static-reads.ts
@@ -212,6 +212,43 @@ function tryInlineCall(
         }
     }
 
+
+    // `createRequire(<URL>)` from `node:module` returns a CJS-style require.
+    // In a bundled GJS executable, the deps that the runtime require would
+    // resolve are already inlined by esbuild, so the require() function is
+    // typically dead code. The createRequire CALL itself runs at module init,
+    // and Node's implementation rejects the rewritten URLs we produce when
+    // they don't point at an existing file (yargs-parser's `createRequire(
+    // import.meta.url)` blows up because the rewritten URL refers to a Yarn
+    // PnP zip path that doesn't exist outside the PnP runtime).
+    //
+    // Replace the call with a stub function: assignment succeeds, the bundle
+    // boots, and any actual `require()` invocation produces a clear error
+    // instead of an obscure URL-validation crash. Only fires when the URL
+    // argument can be statically resolved AND points at a non-existent file
+    // — the common case is exactly the broken one.
+    if (calleeName === 'createRequire') {
+        const path = evalPathExpr(node.arguments[0], ctx);
+        // Stub the call when:
+        //  - the resolved path doesn't exist on disk (build site), OR
+        //  - the path contains a `.zip/` segment (Yarn PnP virtual zip,
+        //    where Node's PnP hooks make `existsSync` return true at build
+        //    time but the path doesn't exist under GJS at runtime).
+        const isZip = path !== undefined && path.includes('.zip/');
+        if (path !== undefined && (isZip || !existsSyncSafe(path))) {
+            return {
+                start: node.start,
+                end: node.end,
+                replacement:
+                    `(() => { ` +
+                    `const _r = (id) => { throw new Error("[gjsify] createRequire stub: '" + id + "' was not bundled (anchor path: " + ${jsStringLiteral(path)} + ")"); }; ` +
+                    `_r.resolve = _r; _r.cache = {}; _r.extensions = {}; _r.main = void 0; ` +
+                    `return _r; ` +
+                    `})()`,
+            };
+        }
+    }
+
     return undefined;
 }
 

--- a/packages/infra/esbuild-plugin-gjsify/src/utils/rewrite-node-modules-paths.ts
+++ b/packages/infra/esbuild-plugin-gjsify/src/utils/rewrite-node-modules-paths.ts
@@ -37,10 +37,6 @@ export const REWRITE_FILTER = /\.(m?js|cjs|[cm]?tsx?)$/;
 const DIRNAME_DECL_RE = /(?:var|let|const)\s+__dirname\b|export\s+(?:var|let|const)\s+__dirname\b/;
 const FILENAME_DECL_RE = /(?:var|let|const)\s+__filename\b|export\s+(?:var|let|const)\s+__filename\b/;
 
-// Module-scope flag: emit the PnP-zip-path runtime-portability warning at
-// most once per build, otherwise every transitive file inside the same zip
-// floods the terminal.
-let zipPathWarningEmitted = false;
 
 /** True when the rewriter wants to look at this path — node_modules + supported ext. */
 export function shouldRewrite(path: string): boolean {
@@ -104,32 +100,38 @@ export function rewriteContents(
 
     if (hasMetaUrl) {
         const relPath = relative(bundleDir, args.path);
-        if (relPath.includes('.zip/') && !zipPathWarningEmitted) {
-            // Rewriting `import.meta.url` inside a Yarn-PnP virtual-zip path
-            // produces a relative URL that resolves to a `.zip/...` filename
-            // at runtime — that path doesn't physically exist outside the
-            // PnP runtime, so any `readFileSync(import.meta.url-relative)`
-            // crashes with ENOENT. Warn once per build so users notice the
-            // hazard. Mitigation today: build under
-            // `nodeLinker: node-modules`. Real fix is upstream rewriter work
-            // to inline zip-resident reads.
-            zipPathWarningEmitted = true;
-            console.warn(
-                `[gjsify] rewriter: bundling code from inside a PnP virtual zip ` +
-                `(${relPath}). import.meta.url-relative paths in this file won't ` +
-                `resolve at runtime. Switch to "nodeLinker: node-modules" or unplug ` +
-                `the offending package(s) until the rewriter learns to inline zip-` +
-                `resident reads.`,
-            );
-        }
-        const relDir = relative(bundleDir, dir) || '.';
-        const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
-        contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
-        if (hasDirname && !dirnameDeclared) {
-            preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + '/')}, import.meta.url).pathname.replace(/\\/$/, "");`);
-        }
-        if (hasFilename && !filenameDeclared) {
-            preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+        const isZipResident = relPath.includes('.zip/');
+        if (isZipResident) {
+            // Source file lives inside a Yarn-PnP virtual zip. We can't
+            // produce a useful build-time-relative URL for it (the .zip/...
+            // path doesn't physically exist outside the PnP runtime). The
+            // static-read inliner above has already replaced every read
+            // we know how to evaluate at build time. Anything left that
+            // touches `import.meta.url` is dynamic — leave the bare token
+            // so it resolves at runtime to the bundle's own URL. That
+            // gives downstream code (e.g. yargs's mainFilename heuristic
+            // walking the path string for a `node_modules` segment) a
+            // valid file:// URL to work with, even if it doesn't reflect
+            // the original module's location.
+            //
+            // __dirname / __filename: derive them from the bundle's URL,
+            // not the source's relative path, for the same reason.
+            if (hasDirname && !dirnameDeclared) {
+                preamble.push(`var __dirname = new URL(".", import.meta.url).pathname.replace(/\\/$/, "");`);
+            }
+            if (hasFilename && !filenameDeclared) {
+                preamble.push(`var __filename = new URL(import.meta.url).pathname;`);
+            }
+        } else {
+            const relDir = relative(bundleDir, dir) || '.';
+            const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
+            contents = contents.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
+            if (hasDirname && !dirnameDeclared) {
+                preamble.push(`var __dirname = new URL(${JSON.stringify(relDir + '/')}, import.meta.url).pathname.replace(/\\/$/, "");`);
+            }
+            if (hasFilename && !filenameDeclared) {
+                preamble.push(`var __filename = ${runtimeFileUrl}.pathname;`);
+            }
         }
     } else {
         if (hasDirname && !dirnameDeclared) preamble.push(`var __dirname = ${JSON.stringify(dir)};`);


### PR DESCRIPTION
## Summary

Three issues surfaced cross-testing v0.3.10 against ts-for-gir's GJS bundle under Yarn-PnP. All three crash at module-init time, so any one of them prevents the bundle from running its first command.

## 1. Shebang hoist

User-supplied banners with a leading `#!/usr/bin/env -S gjs -m\n` had the shebang silently buried under the gjsify process stub:

```
<process-stub>          ← byte 0
#!/usr/bin/env -S gjs -m
<rest of user banner>
```

GJS's parser treats `#` anywhere except byte 0 as a fatal `SyntaxError: '#' not followed by identifier`. New `composeBanner()` detects a leading shebang line in the user banner and pulls it to byte 0:

```
#!/usr/bin/env -S gjs -m   ← byte 0
<process-stub>
<rest of user banner>
```

## 2. createRequire stub for zip-resident anchors

`yargs-parser` does `const require = createRequire(import.meta.url)` at module top level. The rewriter previously substituted `import.meta.url` with a URL pointing at `.yarn/__virtual__/<pkg>.zip/...` — Node's createRequire then rejects the URL with *\"argument must be a file URL object, file URL string, or absolute path string\"* because the path contains a zip segment.

The static-read inliner now detects `createRequire(<URL>)` calls whose resolved path either doesn't exist OR contains a `.zip/` segment, and replaces them with a thrown-on-use stub:

```js
const require = (() => {
  const _r = (id) => { throw new Error(
    \"[gjsify] createRequire stub: '\" + id + \"' was not bundled (...)\"
  ); };
  _r.resolve = _r; _r.cache = {}; _r.extensions = {}; _r.main = void 0;
  return _r;
})();
```

The assignment runs (so module init proceeds), and any actual `require()` invocation produces a clear error. esbuild has typically already inlined the actual deps so the require-function is dead code; if it isn't, the thrown message says exactly what to fix.

## 3. Skip URL rewrite for zip-resident files

For source files inside a Yarn-PnP virtual zip, the rewriter previously emitted `new URL(\"../../../.yarn/.../zip/...\", import.meta.url).href`. At runtime `fileURLToPath(<that URL>)` blows up because `@gjsify/url`'s URL polyfill (GLib.Uri-backed) does not resolve relative URLs against absolute file:// bases the same way Node does — the `.href` of the relative-resolution returns the literal relative string, which then fails URL validation in the polyfill itself.

The rewriter now **skips the URL substitution for zip-resident files entirely**. The bare `import.meta.url` token stays in place; at runtime it resolves to the bundle's own URL (always valid). `__dirname`/`__filename` in those files are derived from the bundle URL too. Downstream code (yargs's `mainFilename` heuristic, …) gets a valid path string to work with — semantically not the original module's location, but consistent and non-crashing.

Removes the `[gjsify] rewriter: bundling code from inside a PnP virtual zip` warning since the case is now actually handled.

## Test plan

Verified end-to-end against ts-for-gir's GJS bundle (built under Yarn-PnP, not nodeLinker:node-modules):

- [x] `./bin/ts-for-gir-gjs --version` → `4.0.0-rc.9` ✓
- [x] Bundle moved to `/tmp/.../bin/ts-for-gir-gjs` runs ✓
- [x] `gjsify dlx <packed-tarball>` boots the bundle and runs `gjs -m` against it ✓ (residual is dlx's own arg-forwarding, not the bundle).
- [x] All 22 existing e2e tests pass.