### PR TITLE
feat(rolldown-plugin-gjsify): orchestrator package

### DIFF
--- a/packages/infra/rolldown-plugin-gjsify/package.json
+++ b/packages/infra/rolldown-plugin-gjsify/package.json
@@ -10,6 +10,13 @@
         ".": {
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"
+        },
+        "./globals": {
+            "types": "./lib/globals.d.ts",
+            "default": "./lib/globals.js"
+        },
+        "./shims/console-gjs": {
+            "default": "./lib/shims/console-gjs.js"
         }
     },
     "scripts": {
@@ -34,6 +41,19 @@
         "gjsify"
     ],
     "license": "MIT",
+    "dependencies": {
+        "@gjsify/console": "workspace:^",
+        "@gjsify/resolve-npm": "workspace:^",
+        "@gjsify/rolldown-plugin-deepkit": "workspace:^",
+        "@gjsify/rolldown-plugin-pnp": "workspace:^",
+        "@gjsify/vite-plugin-blueprint": "workspace:^",
+        "@rollup/plugin-alias": "^5.1.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "acorn": "^8.14.0",
+        "acorn-walk": "^8.3.4",
+        "fast-glob": "^3.3.3",
+        "lightningcss": "^1.32.0"
+    },
     "peerDependencies": {
         "rolldown": "^1.0.0-rc.18"
     },

--- a/packages/infra/rolldown-plugin-gjsify/src/app/browser.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/browser.ts
@@ -1,0 +1,99 @@
+// `--app browser` Rolldown configuration factory.
+//
+// Browser builds redirect `@girs/*` and `gi://*` to an empty virtual module
+// (they appear transitively via `@gjsify/unit` and similar packages with
+// GJS-specific code paths). Standard Node.js → browser polyfill aliases
+// for `process` and `assert` keep `@gjsify/unit`'s top-level imports
+// resolvable in a browser bundle.
+
+import alias from '@rollup/plugin-alias';
+import type { Plugin, RolldownOptions, RolldownPluginOption } from 'rolldown';
+
+import { deepkitPlugin } from '@gjsify/rolldown-plugin-deepkit';
+import blueprintPlugin from '@gjsify/vite-plugin-blueprint';
+
+import type { PluginOptions } from '../types/plugin-options.js';
+import { globToEntryPoints } from '../utils/entry-points.js';
+import { gjsImportsEmptyPlugin } from '../plugins/gjs-imports-empty.js';
+import { cssAsStringPlugin } from '../plugins/css-as-string.js';
+
+export interface BrowserBuildConfig {
+    options: RolldownOptions;
+    plugins: RolldownPluginOption[];
+}
+
+export interface BrowserFactoryInput {
+    input?: RolldownOptions['input'];
+    output: { file?: string; dir?: string };
+    userExternal?: string[];
+    userAliases?: Record<string, string>;
+    pluginOptions: PluginOptions;
+}
+
+export const setupForBrowser = async (input: BrowserFactoryInput): Promise<BrowserBuildConfig> => {
+    const userExternal = input.userExternal ?? [];
+    const external = [...userExternal];
+
+    const exclude = input.pluginOptions.exclude ?? [];
+    const entryPoints = await globToEntryPoints(input.input, exclude);
+
+    // `@gjsify/unit` has `await import('process')` inside a try-catch that
+    // is unreachable in browser (typeof document check comes first), but
+    // Rolldown still resolves it statically. Map to `@gjsify/empty` so the
+    // build succeeds. `assert` → `@gjsify/assert` because `@gjsify/unit`
+    // imports `node:assert` at the top level.
+    const browserPolyfillAliases: Record<string, string> = {
+        process: '@gjsify/empty',
+        'node:process': '@gjsify/empty',
+        assert: '@gjsify/assert',
+        'node:assert': '@gjsify/assert',
+    };
+
+    const aliasMap: Record<string, string> = {
+        ...browserPolyfillAliases,
+        ...(input.pluginOptions.aliases ?? {}),
+        ...(input.userAliases ?? {}),
+    };
+
+    const options: RolldownOptions = {
+        input: entryPoints,
+        platform: 'browser',
+        external,
+        resolve: {
+            mainFields: ['browser', 'module', 'main'],
+            conditionNames: ['import', 'browser'],
+        },
+        transform: {
+            target: 'esnext',
+            define: {
+                global: 'globalThis',
+                window: 'globalThis',
+            },
+        },
+        output: {
+            ...input.output,
+            format: 'esm',
+            minify: false,
+            sourcemap: false,
+        },
+        treeshake: true,
+    };
+
+    const plugins: RolldownPluginOption[] = [
+        gjsImportsEmptyPlugin(),
+        alias({ entries: flattenAliases(aliasMap) }) as unknown as Plugin,
+        blueprintPlugin() as RolldownPluginOption,
+        deepkitPlugin({ reflection: input.pluginOptions.reflection }),
+        cssAsStringPlugin(),
+    ];
+
+    return { options, plugins };
+};
+
+function flattenAliases(map: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [from, to] of Object.entries(map)) {
+        if (to) out[from] = to;
+    }
+    return out;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/app/gjs.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/gjs.ts
@@ -1,0 +1,167 @@
+// `--app gjs` Rolldown configuration factory.
+//
+// Mirrors the esbuild predecessor's `setupForGjs` exactly in terms of the
+// effective build behaviour: same externals, same alias map, same target
+// (firefox128 for JS, firefox60 for CSS), same console-shim injection,
+// same process-stub banner, same `random-access-file` fs-backed-fallback.
+//
+// Returns a partial `RolldownOptions` template plus the plugin array the
+// caller should compose with their user-supplied options. Library mode is
+// handled separately by `setupLib`.
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import alias from '@rollup/plugin-alias';
+import type { Plugin, RolldownOptions, RolldownPluginOption } from 'rolldown';
+
+import { deepkitPlugin } from '@gjsify/rolldown-plugin-deepkit';
+import blueprintPlugin from '@gjsify/vite-plugin-blueprint';
+
+import type { PluginOptions } from '../types/plugin-options.js';
+import { getAliasesForGjs } from '../utils/alias.js';
+import { globToEntryPoints } from '../utils/entry-points.js';
+import {
+    nodeModulesPathRewritePlugin,
+    getBundleDirFromOutput,
+} from '../plugins/rewrite-node-modules-paths.js';
+import { processStubPlugin } from '../plugins/process-stub.js';
+import { cssAsStringPlugin } from '../plugins/css-as-string.js';
+import { shebangPlugin, GJS_SHEBANG } from '../plugins/shebang.js';
+
+const _shimDir = dirname(fileURLToPath(import.meta.url));
+
+/** Resolved Rolldown configuration template + plugins for `--app gjs`. */
+export interface GjsBuildConfig {
+    options: RolldownOptions;
+    plugins: RolldownPluginOption[];
+}
+
+export interface GjsFactoryInput {
+    /** User entry points after CLI / config merging. */
+    input?: RolldownOptions['input'];
+    /** Output `file` or `dir` so `import.meta.url` rewriter knows the bundle path. */
+    output: { file?: string; dir?: string };
+    /** Caller-supplied externals (`gjsify build --external`). */
+    userExternal?: string[];
+    /** User-supplied banner string (may contain a leading `#!shebang`). */
+    userBanner?: string;
+    /** User-supplied resolve.alias overrides. */
+    userAliases?: Record<string, string>;
+    /** Whether to prepend the `#!/usr/bin/env -S gjs -m` shebang. */
+    shebang?: boolean;
+    /** Plugin options forwarded to sub-plugins (deepkit, css, …). */
+    pluginOptions: PluginOptions;
+}
+
+export const setupForGjs = async (input: GjsFactoryInput): Promise<GjsBuildConfig> => {
+    const userExternal = input.userExternal ?? [];
+    const external = ['gi://*', 'cairo', 'gettext', 'system', ...userExternal];
+    const format = input.pluginOptions.format ?? 'esm';
+
+    const exclude = input.pluginOptions.exclude ?? [];
+    const entryPoints = await globToEntryPoints(input.input, exclude);
+
+    const aliasMap = {
+        ...getAliasesForGjs({ external }),
+        ...(input.pluginOptions.aliases ?? {}),
+        ...(input.userAliases ?? {}),
+    };
+
+    // The console shim replaces all `console` references with print()/printerr()-
+    // based implementations that bypass GLib.log_structured() — no prefix,
+    // ANSI codes work. Disabled via `pluginOptions.consoleShim === false`.
+    const consoleShimEnabled = input.pluginOptions.consoleShim !== false;
+    const consoleShimPath = consoleShimEnabled
+        ? resolve(_shimDir, '../shims/console-gjs.js')
+        : null;
+
+    // Auto-globals inject path is appended as an additional entry (not as
+    // Rolldown's `transform.inject`, which is the source-AST per-identifier
+    // rewrite forbidden by the auto-globals invariant).
+    const extraEntries: string[] = [];
+    if (consoleShimPath) extraEntries.push(consoleShimPath);
+    if (input.pluginOptions.autoGlobalsInject) extraEntries.push(input.pluginOptions.autoGlobalsInject);
+
+    const finalInput = appendExtraEntries(entryPoints, extraEntries);
+
+    const options: RolldownOptions = {
+        input: finalInput,
+        platform: 'neutral',
+        external,
+        // 'browser' field is needed so packages like create-hash, create-hmac,
+        // randombytes use their pure-JS browser entry instead of index.js
+        // (which does require('crypto') and causes circular dependencies via
+        // the crypto → @gjsify/crypto alias).
+        resolve: {
+            mainFields: format === 'esm' ? ['browser', 'module', 'main'] : ['browser', 'main', 'module'],
+            // ESM: omit 'require' — packages listing 'require' before 'import'
+            // would silently route through their CJS entry.
+            conditionNames: format === 'esm' ? ['browser', 'import'] : ['browser', 'require', 'import'],
+        },
+        transform: {
+            // Compile target: GJS 1.86 / SpiderMonkey 128 ≈ firefox128.
+            target: 'firefox128',
+            define: {
+                global: 'globalThis',
+                window: 'globalThis',
+                'process.env.READABLE_STREAM': '"disable"',
+            },
+        },
+        output: {
+            ...input.output,
+            format,
+            minify: false,
+            sourcemap: false,
+        },
+        treeshake: true,
+    };
+
+    const bundleDir = getBundleDirFromOutput(input.output);
+
+    const plugins: RolldownPluginOption[] = [
+        // random-access-file's 'browser' field maps to a throwing stub; force
+        // the fs-backed Node entry. Implemented via @rollup/plugin-alias as a
+        // direct entry-table override.
+        alias({
+            entries: {
+                'random-access-file': 'random-access-file/index.js',
+                ...flattenAliases(aliasMap),
+            },
+        }) as unknown as Plugin,
+        blueprintPlugin() as RolldownPluginOption,
+        deepkitPlugin({ reflection: input.pluginOptions.reflection }),
+        cssAsStringPlugin(),
+        nodeModulesPathRewritePlugin({ bundleDir }),
+        processStubPlugin({ userBanner: input.userBanner }),
+        shebangPlugin({ enabled: input.shebang === true, line: GJS_SHEBANG }),
+    ];
+
+    return { options, plugins };
+};
+
+function appendExtraEntries(
+    input: RolldownOptions['input'],
+    extras: string[],
+): RolldownOptions['input'] {
+    if (extras.length === 0) return input;
+    if (input === undefined) return [...extras];
+    if (typeof input === 'string') return [input, ...extras];
+    if (Array.isArray(input)) return [...input, ...extras];
+    const merged: Record<string, string> = { ...input };
+    extras.forEach((p, i) => {
+        merged[`__gjsify_extra_${i}`] = p;
+    });
+    return merged;
+}
+
+/**
+ * Flatten the legacy `Record<string, string>` alias map into the
+ * `@rollup/plugin-alias` `entries` array shape, dropping empty values.
+ */
+function flattenAliases(map: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [from, to] of Object.entries(map)) {
+        if (to) out[from] = to;
+    }
+    return out;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/app/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/index.ts
@@ -1,0 +1,6 @@
+export { setupForGjs } from './gjs.js';
+export type { GjsBuildConfig, GjsFactoryInput } from './gjs.js';
+export { setupForNode } from './node.js';
+export type { NodeBuildConfig, NodeFactoryInput } from './node.js';
+export { setupForBrowser } from './browser.js';
+export type { BrowserBuildConfig, BrowserFactoryInput } from './browser.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/app/node.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/node.ts
@@ -1,0 +1,115 @@
+// `--app node` Rolldown configuration factory.
+//
+// Same external set + alias map as the esbuild predecessor. The
+// `createRequire` banner that esbuild needed for ESM-output CJS interop
+// translates to Rolldown's `output.banner` directly — Rolldown itself does
+// not synthesise a `require()` shim for ESM consumers of bundled CJS code.
+
+import alias from '@rollup/plugin-alias';
+import type { Plugin, RolldownOptions, RolldownPluginOption } from 'rolldown';
+
+import { deepkitPlugin } from '@gjsify/rolldown-plugin-deepkit';
+import { EXTERNALS_NODE } from '@gjsify/resolve-npm';
+
+import type { PluginOptions } from '../types/plugin-options.js';
+import { getAliasesForNode } from '../utils/alias.js';
+import { globToEntryPoints } from '../utils/entry-points.js';
+import {
+    nodeModulesPathRewritePlugin,
+    getBundleDirFromOutput,
+} from '../plugins/rewrite-node-modules-paths.js';
+import { cssAsStringPlugin } from '../plugins/css-as-string.js';
+
+export interface NodeBuildConfig {
+    options: RolldownOptions;
+    plugins: RolldownPluginOption[];
+}
+
+export interface NodeFactoryInput {
+    input?: RolldownOptions['input'];
+    output: { file?: string; dir?: string };
+    userExternal?: string[];
+    userAliases?: Record<string, string>;
+    pluginOptions: PluginOptions;
+}
+
+export const setupForNode = async (input: NodeFactoryInput): Promise<NodeBuildConfig> => {
+    const userExternal = input.userExternal ?? [];
+    // node-datachannel is a native C++ addon that cannot be bundled — its
+    // `require('../build/Release/node_datachannel.node')` must resolve at
+    // runtime against the real node_modules tree.
+    const external = [
+        ...EXTERNALS_NODE as string[],
+        'gi://*',
+        '@girs/*',
+        'node-datachannel',
+        ...userExternal,
+    ];
+    const format = input.pluginOptions.format ?? 'esm';
+
+    const exclude = input.pluginOptions.exclude ?? [];
+    const entryPoints = await globToEntryPoints(input.input, exclude);
+
+    const aliasMap = {
+        ...getAliasesForNode({ external }),
+        ...(input.pluginOptions.aliases ?? {}),
+        ...(input.userAliases ?? {}),
+    };
+
+    const bundleDir = getBundleDirFromOutput(input.output);
+
+    // ESM output of bundled CJS code still needs `require()` (Rolldown emits
+    // calls to it for external Node builtins). Node ESM has no `require`
+    // natively, so we synthesize one via `module.createRequire`. This banner
+    // is harmless on CJS output (the line is parsed and discarded if the
+    // file is required as CJS).
+    const banner = format === 'esm'
+        ? "import { createRequire as __gjsifyCreateRequire } from 'module';\nconst require = __gjsifyCreateRequire(import.meta.url);"
+        : undefined;
+
+    const options: RolldownOptions = {
+        input: entryPoints,
+        platform: 'node',
+        external,
+        resolve: {
+            mainFields: format === 'esm' ? ['module', 'main', 'browser'] : ['main', 'module', 'browser'],
+            // CJS-priority conditions for Node bundles. Rolldown uses the first
+            // matching key, so including 'import' would route packages like ws
+            // v8 (whose exports map lists 'import' before 'require') through
+            // their incomplete ESM wrapper.
+            conditionNames: format === 'esm' ? ['require', 'node', 'module'] : ['require'],
+        },
+        transform: {
+            target: 'node24',
+            define: {
+                global: 'globalThis',
+                window: 'globalThis',
+            },
+        },
+        output: {
+            ...input.output,
+            format,
+            minify: false,
+            sourcemap: false,
+            banner,
+        },
+        treeshake: true,
+    };
+
+    const plugins: RolldownPluginOption[] = [
+        alias({ entries: flattenAliases(aliasMap) }) as unknown as Plugin,
+        deepkitPlugin({ reflection: input.pluginOptions.reflection }),
+        cssAsStringPlugin(),
+        nodeModulesPathRewritePlugin({ bundleDir }),
+    ];
+
+    return { options, plugins };
+};
+
+function flattenAliases(map: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [from, to] of Object.entries(map)) {
+        if (to) out[from] = to;
+    }
+    return out;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/globals.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/globals.ts
@@ -1,0 +1,11 @@
+// Public subpath export for the `--globals` CLI support.
+//
+// Consumed by `@gjsify/cli` to resolve the user's explicit `--globals` list
+// (or auto-detect via the iterative multi-pass build) and write the inject
+// stub that the plugin picks up via its `autoGlobalsInject` option. See the
+// "Tree-shakeable Globals" section in AGENTS.md for the architecture.
+
+export { resolveGlobalsList, writeRegisterInjectFile } from './utils/scan-globals.js';
+export { detectFreeGlobals } from './utils/detect-free-globals.js';
+// `detectAutoGlobals` lands in the auto-globals port commit — re-exported
+// here to keep the public surface stable across the migration.

--- a/packages/infra/rolldown-plugin-gjsify/src/globals.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/globals.ts
@@ -7,5 +7,5 @@
 
 export { resolveGlobalsList, writeRegisterInjectFile } from './utils/scan-globals.js';
 export { detectFreeGlobals } from './utils/detect-free-globals.js';
-// `detectAutoGlobals` lands in the auto-globals port commit — re-exported
-// here to keep the public surface stable across the migration.
+export { detectAutoGlobals } from './utils/auto-globals.js';
+export type { AutoGlobalsResult, DetectAutoGlobalsOptions, AnalysisOptions } from './utils/auto-globals.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/index.ts
@@ -1,13 +1,10 @@
 // Public re-exports for `@gjsify/rolldown-plugin-gjsify`.
-//
-// The orchestrator (`gjsifyPlugin`) and platform-specific factories
-// (`gjsifyForGjs`, `gjsifyForNode`, `gjsifyForBrowser`) land in a follow-up
-// commit on this branch. This file currently exports the bundler-agnostic
-// type, utility, and Rolldown-plugin surface so consumers can already
-// depend on us.
 
 export * from './types/index.js';
 export * from './utils/index.js';
+export * from './app/index.js';
+export * from './lib/index.js';
+
 export {
     REWRITE_FILTER,
     getBundleDirFromOutput,
@@ -19,4 +16,17 @@ export type {
     NodeModulesPathRewriteOptions,
     RewriteResult,
 } from './plugins/rewrite-node-modules-paths.js';
+
+export { processStubPlugin, GJS_PROCESS_STUB, composeBanner } from './plugins/process-stub.js';
+export type { ProcessStubPluginOptions } from './plugins/process-stub.js';
+export { cssAsStringPlugin } from './plugins/css-as-string.js';
+export { shebangPlugin, GJS_SHEBANG } from './plugins/shebang.js';
+export type { ShebangPluginOptions } from './plugins/shebang.js';
+export { gjsImportsEmptyPlugin } from './plugins/gjs-imports-empty.js';
+
+export * from './plugin.js';
+import { gjsifyPlugin } from './plugin.js';
+export { gjsifyPlugin };
+export default gjsifyPlugin;
+
 export * from '@gjsify/resolve-npm';

--- a/packages/infra/rolldown-plugin-gjsify/src/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/index.ts
@@ -1,10 +1,10 @@
-// Skeleton — implementation lands in a follow-up commit.
-// See plan: /home/jumplink/.claude/plans/ich-m-chte-gjsify-vollst-ndig-replicated-wind.md
+// Public re-exports for `@gjsify/rolldown-plugin-gjsify`.
+//
+// The orchestrator (`gjsifyPlugin`) and platform-specific factories
+// (`gjsifyForGjs`, `gjsifyForNode`, `gjsifyForBrowser`) land in a follow-up
+// commit on this branch. This file currently exports the bundler-agnostic
+// type and utility surface so consumers can already depend on us.
 
-export interface GjsifyPluginOptions {
-    app?: 'gjs' | 'node' | 'browser';
-}
-
-export function gjsifyPlugin(_options: GjsifyPluginOptions = {}): unknown {
-    throw new Error('@gjsify/rolldown-plugin-gjsify: not implemented yet');
-}
+export * from './types/index.js';
+export * from './utils/index.js';
+export * from '@gjsify/resolve-npm';

--- a/packages/infra/rolldown-plugin-gjsify/src/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/index.ts
@@ -3,8 +3,20 @@
 // The orchestrator (`gjsifyPlugin`) and platform-specific factories
 // (`gjsifyForGjs`, `gjsifyForNode`, `gjsifyForBrowser`) land in a follow-up
 // commit on this branch. This file currently exports the bundler-agnostic
-// type and utility surface so consumers can already depend on us.
+// type, utility, and Rolldown-plugin surface so consumers can already
+// depend on us.
 
 export * from './types/index.js';
 export * from './utils/index.js';
+export {
+    REWRITE_FILTER,
+    getBundleDirFromOutput,
+    rewriteContents,
+    shouldRewrite,
+    nodeModulesPathRewritePlugin,
+} from './plugins/rewrite-node-modules-paths.js';
+export type {
+    NodeModulesPathRewriteOptions,
+    RewriteResult,
+} from './plugins/rewrite-node-modules-paths.js';
 export * from '@gjsify/resolve-npm';

--- a/packages/infra/rolldown-plugin-gjsify/src/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/index.ts
@@ -3,7 +3,7 @@
 export * from './types/index.js';
 export * from './utils/index.js';
 export * from './app/index.js';
-export * from './lib/index.js';
+export * from './library/index.js';
 
 export {
     REWRITE_FILTER,

--- a/packages/infra/rolldown-plugin-gjsify/src/library/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/library/index.ts
@@ -1,0 +1,2 @@
+export { setupLib } from './lib.js';
+export type { LibBuildConfig, LibFactoryInput } from './lib.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/library/lib.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/library/lib.ts
@@ -1,0 +1,79 @@
+// Library mode — multi-entry, unbundled output for republication on npm.
+//
+// Equivalent to esbuild's `bundle: false`: every input file is emitted
+// 1:1 with its imports preserved as-is (resolved by Rolldown). The user
+// alias map is applied so `node:fs` → `fs/promises` style remappings still
+// work, and the JS extension table mirrors the esbuild predecessor.
+//
+// Targeting `esnext` and `platform: 'neutral'` matches the original
+// library config: consumers downstream (downstream apps using `gjsify
+// build --app gjs|node|browser`) re-bundle and apply their own target
+// lowering. Library output stays maximally portable.
+
+import alias from '@rollup/plugin-alias';
+import type { Plugin, RolldownOptions, RolldownPluginOption } from 'rolldown';
+
+import type { PluginOptions } from '../types/plugin-options.js';
+import { globToEntryPoints } from '../utils/entry-points.js';
+
+export interface LibBuildConfig {
+    options: RolldownOptions;
+    plugins: RolldownPluginOption[];
+}
+
+export interface LibFactoryInput {
+    input?: RolldownOptions['input'];
+    output: { file?: string; dir?: string };
+    userAliases?: Record<string, string>;
+    pluginOptions: PluginOptions;
+}
+
+export const setupLib = async (input: LibFactoryInput): Promise<LibBuildConfig> => {
+    // Derive output format from `library: 'esm' | 'cjs'` when the caller
+    // didn't pass `format` explicitly. The library type and the emitted
+    // module format are inseparable: a CJS-library build that emits ESM
+    // (or vice versa) is broken by definition.
+    const format = input.pluginOptions.format ?? input.pluginOptions.library ?? 'esm';
+
+    const exclude = input.pluginOptions.exclude ?? [];
+    const entryPoints = await globToEntryPoints(input.input, exclude);
+
+    const aliasMap = {
+        ...(input.pluginOptions.aliases ?? {}),
+        ...(input.userAliases ?? {}),
+    };
+
+    const options: RolldownOptions = {
+        input: entryPoints,
+        platform: 'neutral',
+        resolve: {
+            mainFields: format === 'esm' ? ['module', 'main'] : ['main'],
+            conditionNames: format === 'esm' ? ['module', 'import'] : ['require'],
+        },
+        transform: { target: 'esnext' },
+        output: {
+            ...input.output,
+            format,
+            // Library mode = preserve module structure (multi-file output,
+            // imports resolved but not bundled).
+            preserveModules: true,
+            minify: false,
+            sourcemap: false,
+        },
+        treeshake: false,
+    };
+
+    const plugins: RolldownPluginOption[] = [
+        alias({ entries: flattenAliases(aliasMap) }) as unknown as Plugin,
+    ];
+
+    return { options, plugins };
+};
+
+function flattenAliases(map: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [from, to] of Object.entries(map)) {
+        if (to) out[from] = to;
+    }
+    return out;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugin.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugin.ts
@@ -14,7 +14,7 @@
 import type { RolldownOptions, RolldownPluginOption } from 'rolldown';
 import type { PluginOptions } from './types/plugin-options.js';
 import { setupForGjs, setupForNode, setupForBrowser } from './app/index.js';
-import { setupLib } from './lib/index.js';
+import { setupLib } from './library/index.js';
 
 export interface GjsifyConfig {
     options: RolldownOptions;

--- a/packages/infra/rolldown-plugin-gjsify/src/plugin.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugin.ts
@@ -1,0 +1,91 @@
+// `gjsifyPlugin` — orchestrator entry point.
+//
+// Picks the platform-specific factory based on `pluginOptions.app`
+// (or `library` for library mode) and returns the resolved Rolldown
+// configuration. Unlike the esbuild predecessor, this is NOT a single
+// `Plugin` object — it returns a *config bundle* the caller composes into
+// `rolldown(opts)`, because Rolldown does not have esbuild's `setup(build)`
+// hook through which a single plugin can mutate `build.initialOptions`.
+//
+// The CLI consumer (`@gjsify/cli`) calls `gjsifyPlugin(...)` to get back
+// `{ options, plugins }`, then calls `rolldown({ ...options, plugins:
+// [...userPlugins, ...plugins] })`.
+
+import type { RolldownOptions, RolldownPluginOption } from 'rolldown';
+import type { PluginOptions } from './types/plugin-options.js';
+import { setupForGjs, setupForNode, setupForBrowser } from './app/index.js';
+import { setupLib } from './lib/index.js';
+
+export interface GjsifyConfig {
+    options: RolldownOptions;
+    plugins: RolldownPluginOption[];
+}
+
+export interface GjsifyPluginInput {
+    input?: RolldownOptions['input'];
+    output: { file?: string; dir?: string };
+    userExternal?: string[];
+    userBanner?: string;
+    userAliases?: Record<string, string>;
+    /** Whether to prepend `#!/usr/bin/env -S gjs -m` to the GJS bundle. */
+    shebang?: boolean;
+}
+
+/**
+ * Build the Rolldown configuration template + plugin array for the given
+ * pluginOptions. The caller composes the returned `options.plugins` with
+ * its own user plugins and passes the merged options to `rolldown(...)`.
+ */
+export const gjsifyPlugin = async (
+    input: GjsifyPluginInput,
+    pluginOptions: PluginOptions = {},
+): Promise<GjsifyConfig> => {
+    if (pluginOptions.library) {
+        switch (pluginOptions.library) {
+            case 'esm':
+            case 'cjs':
+                return await setupLib({
+                    input: input.input,
+                    output: input.output,
+                    userAliases: input.userAliases,
+                    pluginOptions,
+                });
+            default:
+                throw new TypeError('Unknown library type: ' + pluginOptions.library);
+        }
+    }
+
+    const app = pluginOptions.app ?? 'gjs';
+    switch (app) {
+        case 'gjs':
+            return await setupForGjs({
+                input: input.input,
+                output: input.output,
+                userExternal: input.userExternal,
+                userBanner: input.userBanner,
+                userAliases: input.userAliases,
+                shebang: input.shebang,
+                pluginOptions,
+            });
+        case 'node':
+            return await setupForNode({
+                input: input.input,
+                output: input.output,
+                userExternal: input.userExternal,
+                userAliases: input.userAliases,
+                pluginOptions,
+            });
+        case 'browser':
+            return await setupForBrowser({
+                input: input.input,
+                output: input.output,
+                userExternal: input.userExternal,
+                userAliases: input.userAliases,
+                pluginOptions,
+            });
+        default:
+            throw new TypeError('Unknown app platform: ' + app);
+    }
+};
+
+export default gjsifyPlugin;

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/css-as-string.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/css-as-string.ts
@@ -1,0 +1,27 @@
+// Wrap `.css` imports as JS string default exports.
+//
+// Replaces the recursive `esbuild.build()` sub-build pattern from
+// `@gjsify/esbuild-plugin-css`. Rolldown's native CSS pipeline + Lightning
+// CSS (configured via the parent factory's `transform.targets`) handle
+// `@import` resolution and asset inlining; this plugin only converts the
+// resolved CSS into a JS module so consumers can do:
+//
+//   import css from './app.css';
+//   provider.load_from_string(css);
+//
+// — the canonical pattern for `Gtk.CssProvider` under GJS.
+
+import type { Plugin } from 'rolldown';
+
+export function cssAsStringPlugin(): Plugin {
+    return {
+        name: 'gjsify-css-as-string',
+        transform: {
+            order: 'post' as const,
+            filter: { id: /\.css$/ },
+            handler(code) {
+                return { code: `export default ${JSON.stringify(code)};`, map: null };
+            },
+        },
+    };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/gjs-imports-empty.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/gjs-imports-empty.ts
@@ -1,0 +1,29 @@
+// For `--app browser`: redirect `@girs/*` and `gi://*` imports to an empty
+// module. These are GJS-specific (GObject introspection bindings / GI
+// protocol) with no browser equivalent. They appear transitively via
+// `@gjsify/unit` and similar packages that have GJS-specific code paths.
+//
+// Marking them external would leave bare specifiers in the bundle that the
+// browser cannot resolve at runtime; instead we resolve them to a virtual
+// empty ESM module so the bundle is self-contained.
+
+import type { Plugin } from 'rolldown';
+
+const GJSIMPORTS_VIRTUAL_ID = '\0gjsify-empty-gjs-import';
+
+export function gjsImportsEmptyPlugin(): Plugin {
+    return {
+        name: 'gjsify-gjs-imports-empty',
+        resolveId: {
+            order: 'pre' as const,
+            filter: { id: /^(@girs\/|gi:\/\/)/ },
+            handler(_source) {
+                return { id: GJSIMPORTS_VIRTUAL_ID };
+            },
+        },
+        load(id) {
+            if (id !== GJSIMPORTS_VIRTUAL_ID) return null;
+            return { code: 'export {}; export default {};', moduleSideEffects: false };
+        },
+    };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
@@ -1,0 +1,91 @@
+// Synchronous `globalThis.process` stub injected as a GJS bundle banner.
+//
+// Some npm packages (glob, path-scurry, readable-stream, …) access
+// `globalThis.process.platform` at their top-level during lazy `__esm`
+// initialisation — BEFORE any `import`-triggered side effects fire. A
+// banner runs before everything, including bundler helpers and all
+// bundled module code, making it the only reliable injection point for
+// a synchronous global that must exist from byte 1 of execution.
+//
+// Only installed if `process` is absent; the full @gjsify/process
+// implementation (with EventEmitter, real streams, etc.) is wired up
+// later via `--globals auto` (which injects @gjsify/node-globals/register/process).
+//
+// Kept as a single line: the banner runs before any source-map-aware
+// machinery, so newlines here would shift every line number by one. Single
+// line = zero source-map drift for the actual bundle code below.
+import type { Plugin } from 'rolldown';
+
+export const GJS_PROCESS_STUB =
+    'if(typeof globalThis.process==="undefined"){' +
+        'const _s=imports.system,_G=imports.gi.GLib;' +
+        'globalThis.process={' +
+            'platform:"linux",arch:"x64",version:"v20.0.0",' +
+            'env:new Proxy({},{' +
+                'get(_,p){return typeof p==="string"?(_G.getenv(p)??undefined):undefined},' +
+                'set(_,p,v){if(typeof p==="string")_G.setenv(p,String(v),true);return true},' +
+                'has(_,p){return typeof p==="string"&&_G.getenv(p)!==null},' +
+                'deleteProperty(_,p){if(typeof p==="string")_G.unsetenv(p);return true},' +
+                'ownKeys(){return _G.listenv()??[]},' +
+                'getOwnPropertyDescriptor(_,p){const v=_G.getenv(p);return v!==null?{value:v,writable:true,enumerable:true,configurable:true}:undefined}' +
+            '}),' +
+            'argv:_s?.programArgs?["gjs",_s.programInvocationName||"",..._s.programArgs]:["gjs"],' +
+            'versions:{},config:{},' +
+            'cwd(){return _G.get_current_dir()||"/"},' +
+            'exit(c){_s.exit(c??0)},' +
+            'stderr:{write(s){printerr(s)}},stdout:{write(s){print(s)}},stdin:null,' +
+            'exitCode:undefined,' +
+            'nextTick(fn,...a){Promise.resolve().then(()=>fn(...a))},' +
+            'hrtime(t){return t?[0,0]:[0,0]},' +
+        '};' +
+    '}';
+
+/**
+ * Compose the GJS process stub with the user-supplied banner so the result
+ * is valid syntax for `gjs -m`. A leading `#!shebang` line in the user
+ * banner is hoisted to byte 0 of the output. Any `#` character that appears
+ * anywhere except byte 0 is a fatal SyntaxError under SpiderMonkey 128+ —
+ * putting our process stub before the user's shebang would break the bundle.
+ *
+ * Output shape:
+ *   [#!shebang\n][<process-stub>\n<rest-of-user-banner>]
+ *
+ * Either side of the bracket may be empty; the result is always concatenated
+ * without leading whitespace.
+ */
+export function composeBanner(stub: string, userBanner: string): string {
+    if (!userBanner) return stub;
+    const shebangMatch = userBanner.match(/^#![^\n]*\n/);
+    if (!shebangMatch) {
+        return stub + '\n' + userBanner;
+    }
+    const shebang = shebangMatch[0];
+    const rest = userBanner.slice(shebang.length);
+    return shebang + stub + (rest ? '\n' + rest : '');
+}
+
+/**
+ * Build a Rolldown plugin that injects the GJS process stub as a chunk
+ * banner. Runs with `enforce: 'post'`-equivalent ordering so the stub
+ * lands *after* any user `output.banner` value, except when the user
+ * banner starts with a `#!shebang` line — which is hoisted to byte 0
+ * by `composeBanner`.
+ */
+export interface ProcessStubPluginOptions {
+    /** User-supplied banner string. May contain a leading `#!shebang`. */
+    userBanner?: string;
+}
+
+export function processStubPlugin(options: ProcessStubPluginOptions = {}): Plugin {
+    const banner = composeBanner(GJS_PROCESS_STUB, options.userBanner ?? '');
+    return {
+        name: 'gjsify-process-stub',
+        renderChunk: {
+            order: 'post' as const,
+            handler(code, chunk) {
+                if (!chunk.isEntry) return null;
+                return { code: banner + '\n' + code, map: null };
+            },
+        },
+    };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/rewrite-node-modules-paths.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/rewrite-node-modules-paths.ts
@@ -1,0 +1,169 @@
+// Per-source rewriter for node_modules files that reference
+// `import.meta.url`, `__dirname`, or `__filename`. Mirrors the esbuild
+// predecessor's logic — body is identical because the rewrite is purely
+// a string transform on already-loaded source. The only delta is the
+// host: a Rolldown `transform(code, id)` plugin instead of an esbuild
+// `onLoad` registered inside the PnP plugin.
+//
+// Why a separate plugin and not nested in the PnP loader, like esbuild?
+// Rolldown / Rollup's `transform` hooks all run in sequence on every
+// loaded module — there is no first-onLoad-wins race. So the PnP loader
+// (`@gjsify/rolldown-plugin-pnp`) is solely responsible for reading
+// zip-resident bytes; this plugin runs as a separate `transform` step
+// after the bytes have been loaded, regardless of which loader produced
+// them. No more F5-bug folklore.
+
+import { dirname, join, relative, resolve } from 'node:path';
+import type { Plugin } from 'rolldown';
+
+import { inlineStaticReads } from '../utils/inline-static-reads.js';
+
+export const REWRITE_FILTER = /\.(m?js|cjs|[cm]?tsx?)$/;
+const DIRNAME_DECL_RE = /(?:var|let|const)\s+__dirname\b|export\s+(?:var|let|const)\s+__dirname\b/;
+const FILENAME_DECL_RE = /(?:var|let|const)\s+__filename\b|export\s+(?:var|let|const)\s+__filename\b/;
+
+/** True when the rewriter wants to look at this path — node_modules + supported ext. */
+export function shouldRewrite(path: string): boolean {
+    return path.includes('node_modules') && REWRITE_FILTER.test(path);
+}
+
+/**
+ * Compute the directory the bundle's outfile lives in.
+ *
+ * For `import.meta.url` rewriting we emit a relative URL whose base is the
+ * bundle's `import.meta.url` — so we need to know where the bundle will be
+ * written. Both `output.file` and `output.dir` are accepted.
+ */
+export function getBundleDirFromOutput(opts: { file?: string; dir?: string }): string {
+    const outFile = opts.file ?? join(opts.dir ?? '.', 'bundle.mjs');
+    return dirname(resolve(outFile));
+}
+
+/** Pick the per-file loader Rolldown should re-parse with. */
+function moduleTypeForPath(path: string): 'ts' | 'js' {
+    const ext = path.split('.').pop() ?? 'js';
+    return ['ts', 'mts', 'cts', 'tsx'].includes(ext) ? 'ts' : 'js';
+}
+
+interface PreambleArgs {
+    needDirname: boolean;
+    needFilename: boolean;
+    dirnameDeclared: boolean;
+    filenameDeclared: boolean;
+    /** kind of rewrite: 'esm-relative' | 'esm-zip' | 'cjs-absolute' */
+    kind: 'esm-relative' | 'esm-zip' | 'cjs-absolute';
+    sourcePath: string;
+    sourceDir: string;
+    relDirWithSlash: string;
+    relPath: string;
+}
+
+function buildDirFilenamePreamble(args: PreambleArgs): string[] {
+    const lines: string[] = [];
+    if (args.needDirname && !args.dirnameDeclared) {
+        if (args.kind === 'esm-zip') {
+            lines.push(`var __dirname = new URL(".", import.meta.url).pathname.replace(/\\/$/, "");`);
+        } else if (args.kind === 'esm-relative') {
+            lines.push(`var __dirname = new URL(${JSON.stringify(args.relDirWithSlash)}, import.meta.url).pathname.replace(/\\/$/, "");`);
+        } else {
+            lines.push(`var __dirname = ${JSON.stringify(args.sourceDir)};`);
+        }
+    }
+    if (args.needFilename && !args.filenameDeclared) {
+        if (args.kind === 'esm-zip') {
+            lines.push(`var __filename = new URL(import.meta.url).pathname;`);
+        } else if (args.kind === 'esm-relative') {
+            lines.push(`var __filename = new URL(${JSON.stringify(args.relPath)}, import.meta.url).pathname;`);
+        } else {
+            lines.push(`var __filename = ${JSON.stringify(args.sourcePath)};`);
+        }
+    }
+    return lines;
+}
+
+export interface RewriteResult {
+    code: string;
+    moduleType?: 'ts' | 'js';
+    map?: null;
+}
+
+/**
+ * Pure rewriter — same body as the esbuild predecessor. Returns the rewritten
+ * code (and module type for re-parsing) or `null` if the file doesn't reference
+ * any of the patterns we care about.
+ */
+export function rewriteContents(
+    args: { path: string },
+    srcInput: string,
+    bundleDir: string,
+): RewriteResult | null {
+    if (!shouldRewrite(args.path)) return null;
+
+    // Step 1: inline statically-resolvable filesystem reads.
+    const inlined = inlineStaticReads(srcInput, args.path);
+    const src = inlined.contents;
+
+    const hasMetaUrl = src.includes('import.meta.url');
+    const hasDirname = src.includes('__dirname');
+    const hasFilename = src.includes('__filename');
+
+    if (!hasMetaUrl && !hasDirname && !hasFilename) {
+        if (inlined.inlined === 0) return null;
+        return { code: src, moduleType: moduleTypeForPath(args.path) };
+    }
+
+    // Step 2: classify rewrite kind.
+    const dir = dirname(args.path);
+    const relPath = hasMetaUrl ? relative(bundleDir, args.path) : '';
+    const isZipResident = hasMetaUrl && relPath.includes('.zip/');
+    const kind: 'esm-relative' | 'esm-zip' | 'cjs-absolute' =
+        !hasMetaUrl ? 'cjs-absolute' : isZipResident ? 'esm-zip' : 'esm-relative';
+
+    const preamble = buildDirFilenamePreamble({
+        needDirname: hasDirname,
+        needFilename: hasFilename,
+        dirnameDeclared: DIRNAME_DECL_RE.test(src),
+        filenameDeclared: FILENAME_DECL_RE.test(src),
+        kind,
+        sourcePath: args.path,
+        sourceDir: dir,
+        relPath,
+        relDirWithSlash: (relative(bundleDir, dir) || '.') + '/',
+    });
+
+    // Step 3: rewrite import.meta.url for the regular esm-relative case.
+    let code = src;
+    if (kind === 'esm-relative') {
+        const runtimeFileUrl = `new URL(${JSON.stringify(relPath)}, import.meta.url)`;
+        code = code.replace(/\bimport\.meta\.url\b/g, `${runtimeFileUrl}.href`);
+    }
+    if (preamble.length > 0) code = preamble.join('\n') + '\n' + code;
+
+    return { code, moduleType: moduleTypeForPath(args.path) };
+}
+
+export interface NodeModulesPathRewriteOptions {
+    /** Bundle output directory, derived from `output.file` / `output.dir`. */
+    bundleDir: string;
+}
+
+/**
+ * Build a Rolldown plugin that runs the path rewriter as a `transform(code, id)`
+ * hook with `order: 'post'` — runs after the deepkit/blueprint/css pre-transforms
+ * but still during module loading, before chunking.
+ */
+export function nodeModulesPathRewritePlugin(options: NodeModulesPathRewriteOptions): Plugin {
+    return {
+        name: 'gjsify-node-modules-path-rewrite',
+        transform: {
+            order: 'post' as const,
+            filter: { id: REWRITE_FILTER },
+            handler(code: string, id: string) {
+                if (!id.includes('node_modules')) return null;
+                const result = rewriteContents({ path: id }, code, options.bundleDir);
+                if (!result) return null;
+                return { code: result.code, map: null };
+            },
+        },
+    };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/shebang.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/shebang.ts
@@ -1,0 +1,33 @@
+// Inject a `#!/usr/bin/env -S gjs -m` shebang at byte 0 of entry chunks.
+//
+// Rolldown's `output.banner` would also work, but a renderChunk hook with
+// `order: 'post'` makes ordering declarative — the shebang lands AFTER all
+// other banner / process-stub plugins have run, which is required because
+// the `#` character is only valid as the very first byte of the file under
+// SpiderMonkey 128+.
+
+import type { Plugin } from 'rolldown';
+
+export const GJS_SHEBANG = '#!/usr/bin/env -S gjs -m';
+
+export interface ShebangPluginOptions {
+    enabled?: boolean;
+    /** Override the shebang line. Defaults to `GJS_SHEBANG`. */
+    line?: string;
+}
+
+export function shebangPlugin(options: ShebangPluginOptions = {}): Plugin | null {
+    if (!options.enabled) return null;
+    const line = options.line ?? GJS_SHEBANG;
+    return {
+        name: 'gjsify-shebang',
+        renderChunk: {
+            order: 'post' as const,
+            handler(code, chunk) {
+                if (!chunk.isEntry) return null;
+                if (code.startsWith('#!')) return null;
+                return { code: line + '\n' + code, map: null };
+            },
+        },
+    };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/shims/console-gjs.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/shims/console-gjs.ts
@@ -1,0 +1,17 @@
+// GJS console shim — bundled and injected into GJS builds via esbuild's `inject` option.
+// Contains the full @gjsify/console implementation inlined (~4KB) so no external
+// @gjsify/* package resolution is needed at user-build time. Uses print()/printerr()
+// on GJS, bypassing GLib.log_structured() — no prefix, ANSI codes work.
+import {
+    log, info, debug, warn, error, dir, dirxml, table,
+    time, timeEnd, timeLog, trace, assert, clear,
+    count, countReset, group, groupCollapsed, groupEnd,
+    profile, profileEnd, timeStamp,
+} from '@gjsify/console';
+
+export let console = {
+    log, info, debug, warn, error, dir, dirxml, table,
+    time, timeEnd, timeLog, trace, assert, clear,
+    count, countReset, group, groupCollapsed, groupEnd,
+    profile, profileEnd, timeStamp,
+};

--- a/packages/infra/rolldown-plugin-gjsify/src/types/app.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/types/app.ts
@@ -1,0 +1,1 @@
+export type App = 'gjs' | 'node' | 'browser';

--- a/packages/infra/rolldown-plugin-gjsify/src/types/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from './app.js';
+export * from './resolve-alias-options.js';
+export * from './plugin-options.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/types/plugin-options.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/types/plugin-options.ts
@@ -1,0 +1,48 @@
+import type { App } from './app.js';
+
+/** CSS handling forwarded to Rolldown / Lightning CSS. */
+export interface GjsifyCssOptions {
+    /** Browserslist-compatible target list. Defaults to `['firefox60']` for `--app gjs`. */
+    target?: string[];
+    /** Whether to minify the emitted CSS. Defaults to bundle-level `minify`. */
+    minify?: boolean;
+}
+
+export interface PluginOptions {
+    debug?: boolean;
+    app?: App;
+    aliases?: Record<string, string>;
+    /** Glob patterns to exclude when expanding entry points. */
+    exclude?: string[];
+    jsExtension?: string;
+    /** Override the bundle output format. */
+    format?: 'esm' | 'cjs';
+    /**
+     * Library mode — `'esm' | 'cjs'`. When set, the plugin emits an
+     * unbundled multi-entry library suitable for republication on npm
+     * rather than a single application bundle.
+     */
+    library?: 'esm' | 'cjs';
+    /**
+     * Inject a console shim into GJS builds that uses print()/printerr() instead
+     * of `GLib.log_structured()`. Removes the "Gjs-Console-Message:" prefix and
+     * lets the terminal interpret ANSI escape codes correctly. Only applies to
+     * `--app gjs`. Defaults to `true`.
+     */
+    consoleShim?: boolean;
+    /** Enable Deepkit TypeScript reflection. Defaults to `false`. */
+    reflection?: boolean;
+    /** CSS pipeline options forwarded to the Rolldown / Lightning CSS layer. */
+    css?: GjsifyCssOptions;
+    /**
+     * Path to a pre-computed globals stub file. The stub is an ESM file
+     * containing one `import '<pkg>/register';` per entry from the user's
+     * `--globals` CLI flag. When set, the plugin appends the stub path to
+     * Rolldown's inject list alongside the console shim.
+     *
+     * The plugin does no scanning or inference at this layer — the CLI is the
+     * sole source of truth for which `/register` modules get included. Only
+     * applies to `--app gjs`.
+     */
+    autoGlobalsInject?: string;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/types/resolve-alias-options.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/types/resolve-alias-options.ts
@@ -1,0 +1,1 @@
+export interface ResolveAliasOptions { }

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/alias.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/alias.ts
@@ -1,0 +1,46 @@
+import {
+    EXTERNALS_NODE,
+    EXTERNALS_NPM,
+    ALIASES_GENERAL_FOR_GJS,
+    ALIASES_NODE_FOR_GJS,
+    ALIASES_WEB_FOR_GJS,
+    ALIASES_GENERAL_FOR_NODE,
+    ALIASES_GJS_FOR_NODE,
+    ALIASES_WEB_FOR_NODE
+} from "@gjsify/resolve-npm";
+
+import type { ResolveAliasOptions } from '../types/index.js';
+
+export const setNodeAliasPrefix = (ALIASES: Record<string, string>) => {
+    // Also resolve alias names with `node:${ALIAS}`
+    for (const ALIAS in ALIASES) {
+        if(ALIAS.startsWith('node:')) {
+            continue
+        }
+        const key = `node:${ALIAS}`;
+        if(!ALIASES[key]) ALIASES[key] = ALIASES[ALIAS];
+    }
+    return ALIASES;
+}
+
+const getAliasesGeneralForGjs = (options: ResolveAliasOptions) => ALIASES_GENERAL_FOR_GJS;
+const getAliasesNodeForGjs = (options: ResolveAliasOptions) => setNodeAliasPrefix(ALIASES_NODE_FOR_GJS);
+const getAliasesWebForGjs = (options: ResolveAliasOptions) => ALIASES_WEB_FOR_GJS;
+
+const getAliasesGeneralForNode = (options: ResolveAliasOptions) => ALIASES_GENERAL_FOR_NODE;
+const getAliasesGjsForNode = (options: ResolveAliasOptions) => ALIASES_GJS_FOR_NODE;
+const getAliasesWebForNode = (options: ResolveAliasOptions) => ALIASES_WEB_FOR_NODE;
+
+export const getAliasesForGjs = (options: ResolveAliasOptions) => {
+    return {...getAliasesGeneralForGjs(options), ...getAliasesNodeForGjs(options), ...getAliasesWebForGjs(options) }
+}
+
+export const getAliasesForNode = (options: ResolveAliasOptions) => {
+    return {...getAliasesGeneralForNode(options), ...getAliasesGjsForNode(options), ...getAliasesWebForNode(options) }
+}
+
+/** Array of Node.js build in module names (also with node: prefix) */
+export const externalNode = [...EXTERNALS_NODE, ...EXTERNALS_NODE.map(E => `node:${E}`)];
+
+/** Array of NPM module names for which we have our own implementation */
+export const externalNPM = [...EXTERNALS_NPM];

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/auto-globals.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/auto-globals.ts
@@ -1,0 +1,276 @@
+// Iterative multi-pass build orchestrator for `--globals auto`.
+//
+// Architecturally identical to the esbuild predecessor — only the inner
+// build call swaps `esbuild.build()` for `rolldown()`. The "after
+// tree-shaking" analysis property is bundler-agnostic and load-bearing
+// per AGENTS.md "Tree-shakeability invariants — permanent". See the
+// rationale block at the top of `detect-free-globals.ts`.
+//
+// Pass 1: rolldown() with no globals injection
+//         → in-memory bundle parsed by acorn for free globals
+// Pass 2: rolldown() with detected globals injected
+//         → some injected register modules pull in MORE code that
+//           references additional globals (tree-shaking dependency cycle)
+// Pass N: repeat until the detected set converges (typically 2–3 iterations,
+//         capped at MAX_ITERATIONS=5)
+//
+// We deliberately do NOT minify the analysis builds: minification can
+// alias `globalThis` to a short variable and defeat MemberExpression
+// detection in detect-free-globals.ts.
+
+import { rolldown, type InputOptions, type OutputChunk, type RolldownPluginOption, type TransformOptions } from 'rolldown';
+import { detectFreeGlobals } from './detect-free-globals.js';
+import { resolveGlobalsList, writeRegisterInjectFile } from './scan-globals.js';
+import { GJS_GLOBALS_MAP } from '@gjsify/resolve-npm/globals-map';
+import type { PluginOptions } from '../types/plugin-options.js';
+
+const GLOBALS_MAP: Record<string, string> = GJS_GLOBALS_MAP;
+
+/** Maximum iterations to prevent runaway loops on pathological inputs. */
+const MAX_ITERATIONS = 5;
+
+export interface AutoGlobalsResult {
+    /** Global identifiers detected in the bundle */
+    detected: Set<string>;
+    /** Path to the generated inject stub, or undefined if no globals needed */
+    injectPath: string | undefined;
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+    if (a.size !== b.size) return false;
+    for (const x of a) if (!b.has(x)) return false;
+    return true;
+}
+
+async function applyExcludeGlobals(
+    detected: Set<string>,
+    currentInject: string | undefined,
+    extraRegisterPaths: Set<string>,
+    excludeGlobals: string[] | undefined,
+): Promise<AutoGlobalsResult> {
+    if (!excludeGlobals?.length) return { detected, injectPath: currentInject };
+
+    for (const id of excludeGlobals) detected.delete(id);
+    const filtered = detectedToRegisterPaths(detected);
+    for (const p of extraRegisterPaths) filtered.add(p);
+    const injectPath = filtered.size > 0 ? (await writeRegisterInjectFile(filtered)) ?? undefined : undefined;
+    return { detected, injectPath };
+}
+
+function detectedToRegisterPaths(detected: Set<string>): Set<string> {
+    const paths = new Set<string>();
+    for (const name of detected) {
+        const path = GLOBALS_MAP[name];
+        if (path) paths.add(path);
+    }
+    return paths;
+}
+
+export interface DetectAutoGlobalsOptions {
+    /**
+     * Extra explicit identifiers (or group aliases like `dom`/`web`/`node`)
+     * that should always be injected, in addition to whatever the iterative
+     * detection finds. Used by `--globals auto,<extras>` for cases where
+     * the detector cannot statically see a global because it's accessed via
+     * indirection (e.g. Excalibur's `BrowserComponent.nativeComponent.matchMedia`).
+     */
+    extraGlobalsList?: string;
+    /**
+     * Identifiers to remove from the auto-detected set before writing the
+     * inject stub. Useful for globals that appear as false positives from
+     * dead browser-compat code in npm dependencies whose polyfills require
+     * unavailable native libraries.
+     */
+    excludeGlobals?: string[];
+}
+
+/**
+ * Build options accepted by the analyser. A subset of Rolldown's
+ * `InputOptions` plus the `output` shape used by `RolldownBuild.generate`.
+ *
+ * The caller passes the same input + output options it would use for the
+ * final build (input, plugins, external, define, …). We strip output-side
+ * fields that would force a write-to-disk and replace them with in-memory
+ * settings.
+ */
+export interface AnalysisOptions {
+    input: InputOptions['input'];
+    plugins?: RolldownPluginOption[];
+    external?: InputOptions['external'];
+    resolve?: InputOptions['resolve'];
+    /**
+     * Pass-through to Rolldown's `transform` (Oxc-driven) — `define`,
+     * `dropLabels`, `treeShake`, etc. live here in Rolldown's shape.
+     */
+    transform?: TransformOptions;
+    /** Format for the analysis bundle output. Use 'esm' to match the final build. */
+    format?: 'esm' | 'cjs' | 'iife';
+}
+
+/**
+ * Build a `gjsifyPlugin` for the analyser to insert into the plugin array.
+ * Late-imported via dynamic `await import()` to break the cyclic dep
+ * between this file and `../plugin.ts`.
+ */
+type GjsifyPluginFactory = (
+    options: PluginOptions,
+) => RolldownPluginOption | Promise<RolldownPluginOption>;
+
+/**
+ * Run an iterative Rolldown build (in-memory) with acorn-based global
+ * detection. Each pass uses the globals discovered by the previous pass,
+ * stopping once the detected set is stable (fixpoint reached).
+ *
+ * Returns the inject stub path that the caller should pass to the
+ * final (real) build via `pluginOptions.autoGlobalsInject`.
+ *
+ * @param analysisOptions Rolldown input options for the in-memory build.
+ * @param pluginOptions Gjsify plugin options (without `autoGlobalsInject`,
+ *   which this function computes).
+ * @param gjsifyPluginFactory Factory returning the gjsify plugin instance
+ *   for a given set of plugin options. Provided by the caller to avoid a
+ *   cyclic import between this module and `../plugin.ts`.
+ * @param verbose Emit per-iteration debug output to console.
+ * @param options Optional `extraGlobalsList` / `excludeGlobals`.
+ */
+export async function detectAutoGlobals(
+    analysisOptions: AnalysisOptions,
+    pluginOptions: Omit<PluginOptions, 'autoGlobalsInject'>,
+    gjsifyPluginFactory: GjsifyPluginFactory,
+    verbose?: boolean,
+    options: DetectAutoGlobalsOptions = {},
+): Promise<AutoGlobalsResult> {
+    const extraRegisterPaths = options.extraGlobalsList
+        ? resolveGlobalsList(options.extraGlobalsList)
+        : new Set<string>();
+
+    const excludeSet = new Set(options.excludeGlobals ?? []);
+
+    let detected = new Set<string>();
+    let currentInject: string | undefined = undefined;
+
+    if (extraRegisterPaths.size > 0) {
+        currentInject = (await writeRegisterInjectFile(extraRegisterPaths)) ?? undefined;
+    }
+
+    // Caller-provided plugins (e.g. PnP relay) survive every pass; the
+    // gjsify plugin appended last so its hooks run after any custom
+    // resolvers / loaders.
+    const callerPlugins = (analysisOptions.plugins ?? []).filter((p) => {
+        const name = p && typeof p === 'object' && 'name' in p ? p.name : undefined;
+        return name !== 'gjsify' && name !== 'gjsify-orchestrator';
+    });
+
+    for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+        const gjsifyInstance = await gjsifyPluginFactory({
+            ...pluginOptions,
+            autoGlobalsInject: currentInject,
+        } as PluginOptions);
+
+        // The auto-globals inject stub is a side-effect-only ESM file that
+        // imports `<pkg>/register/<feature>` paths. Rolldown's `transform.inject`
+        // is the source-AST per-identifier rewrite we MUST NOT use (see
+        // AGENTS.md "Tree-shakeability invariants"). Instead, when the
+        // analyser has produced an inject path, append it as an additional
+        // entry — Rolldown bundles its side effects into the output and the
+        // detector sees the resulting identifier references.
+        const inputWithInject = currentInject
+            ? appendInjectAsEntry(analysisOptions.input, currentInject)
+            : analysisOptions.input;
+
+        const build = await rolldown({
+            input: inputWithInject,
+            external: analysisOptions.external,
+            resolve: analysisOptions.resolve,
+            transform: analysisOptions.transform,
+            plugins: [...callerPlugins, gjsifyInstance],
+            logLevel: 'silent',
+        });
+
+        let bundledCode = '';
+        try {
+            const result = await build.generate({
+                format: analysisOptions.format ?? 'esm',
+                minify: false,
+                sourcemap: false,
+            });
+            bundledCode = result.output
+                .filter((entry): entry is OutputChunk => entry.type === 'chunk')
+                .map((chunk) => chunk.code)
+                .join('\n');
+        } finally {
+            await build.close();
+        }
+
+        if (!bundledCode) {
+            return { detected: new Set(), injectPath: currentInject };
+        }
+
+        const newDetected = detectFreeGlobals(bundledCode);
+
+        // Apply excludeGlobals BEFORE writing the next iteration's inject file.
+        // Otherwise an excluded identifier would still appear in the inject
+        // import list and the analysis build itself would fail when the
+        // corresponding `@gjsify/<pkg>/register/<feature>` is not in the
+        // project's resolvable dep tree.
+        if (excludeSet.size > 0) {
+            for (const id of excludeSet) newDetected.delete(id);
+        }
+
+        // Fixpoint check: detection is monotonic — once a global is needed,
+        // more code gets pulled in by the next pass, which can only ADD
+        // requirements. So a set that didn't grow is a converged set.
+        if (setsEqual(detected, newDetected)) {
+            if (verbose) {
+                const sorted = [...detected].sort();
+                const extras = extraRegisterPaths.size > 0 ? ` (+ ${extraRegisterPaths.size} extra register module(s))` : '';
+                console.debug(
+                    `[gjsify] --globals auto: converged after ${iteration - 1} iteration(s), ${detected.size} global(s)${sorted.length ? ': ' + sorted.join(', ') : ''}${extras}`,
+                );
+            }
+            return applyExcludeGlobals(detected, currentInject, extraRegisterPaths, options.excludeGlobals);
+        }
+
+        detected = newDetected;
+        const registerPaths = detectedToRegisterPaths(detected);
+        for (const p of extraRegisterPaths) registerPaths.add(p);
+
+        if (registerPaths.size === 0) {
+            return { detected, injectPath: undefined };
+        }
+
+        currentInject = (await writeRegisterInjectFile(registerPaths)) ?? undefined;
+
+        if (verbose) {
+            const sorted = [...detected].sort();
+            console.debug(
+                `[gjsify] --globals auto: iteration ${iteration}, ${detected.size} global(s)${sorted.length ? ': ' + sorted.join(', ') : ''}`,
+            );
+        }
+    }
+
+    if (verbose) {
+        console.debug(
+            `[gjsify] --globals auto: hit max iterations (${MAX_ITERATIONS}), using last detected set`,
+        );
+    }
+    return applyExcludeGlobals(detected, currentInject, extraRegisterPaths, options.excludeGlobals);
+}
+
+/**
+ * Append an additional entry path to a Rolldown `input` value while
+ * preserving its shape (string → array, array → array, record → record).
+ * The new entry is given the synthetic name `__gjsify_inject` when the
+ * record form is used so it doesn't collide with user-named outputs.
+ */
+function appendInjectAsEntry(
+    input: InputOptions['input'],
+    injectPath: string,
+): InputOptions['input'] {
+    if (input === undefined) return [injectPath];
+    if (typeof input === 'string') return [input, injectPath];
+    if (Array.isArray(input)) {
+        return [...input, injectPath];
+    }
+    return { ...input, __gjsify_inject: injectPath };
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/detect-free-globals.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/detect-free-globals.ts
@@ -1,0 +1,278 @@
+// Detect free (unbound) global identifiers in bundled JS output.
+//
+// Used by the `--globals auto` two-pass build: the first esbuild pass
+// produces a minified bundle without globals injection, this module
+// parses it with acorn and finds references to known GJS globals that
+// are not locally declared. The result feeds the second pass's inject
+// stub so only actually-needed globals are registered.
+
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+import { GJS_GLOBALS_MAP } from '@gjsify/resolve-npm/globals-map';
+
+const KNOWN_GLOBALS = new Set(Object.keys(GJS_GLOBALS_MAP as Record<string, string>));
+
+/**
+ * Method markers — `<host>.<method>(…)` patterns that imply a global
+ * identifier should be injected even though the identifier itself never
+ * appears in the bundle.
+ *
+ * Example: a project that calls `navigator.getGamepads()` doesn't reference
+ * any of the gamepad-related identifiers in the globals map, but it still
+ * needs `@gjsify/gamepad/register` to patch `navigator` with the method.
+ * This marker maps `navigator.getGamepads` → inject the `GamepadEvent`
+ * register path (which is the gamepad package's register entry).
+ *
+ * Keyed by `host.method` (lowercase host, exact method name). Values are
+ * KNOWN_GLOBALS identifiers — the detector adds them as free globals if
+ * the corresponding member expression is found in the bundle.
+ */
+const METHOD_MARKERS: Record<string, string> = {
+    // Gamepad API — navigator.getGamepads is patched on by @gjsify/gamepad/register
+    'navigator.getGamepads': 'GamepadEvent',
+    // WebRTC — navigator.mediaDevices is patched on by @gjsify/webrtc/register/media-devices
+    'navigator.mediaDevices': 'MediaDevices',
+    // WebAssembly Promise APIs — the runtime stubs throw at first call, so
+    // any reference to these methods needs the `@gjsify/webassembly` polyfill.
+    // The register entry replaces the stubs with wrappers around the working
+    // synchronous `new WebAssembly.{Module,Instance}` constructors.
+    'WebAssembly.compile':              'WebAssembly',
+    'WebAssembly.compileStreaming':     'WebAssembly',
+    'WebAssembly.instantiate':          'WebAssembly',
+    'WebAssembly.instantiateStreaming': 'WebAssembly',
+    'WebAssembly.validate':             'WebAssembly',
+    // Note: URL.createObjectURL / URL.revokeObjectURL don't need markers —
+    // they are first-class static methods on @gjsify/url's URL class, so the
+    // free `URL` identifier (detected directly, maps to
+    // @gjsify/node-globals/register/url in GJS_GLOBALS_MAP) already pulls in
+    // the correct register module.
+};
+
+/**
+ * Extract all bound names from a binding pattern
+ * (Identifier, ObjectPattern, ArrayPattern, AssignmentPattern, RestElement).
+ */
+function extractBindingNames(node: acorn.AnyNode): string[] {
+    if (!node) return [];
+    switch (node.type) {
+        case 'Identifier':
+            return [(node as acorn.Identifier).name];
+        case 'ObjectPattern':
+            return (node as acorn.ObjectPattern).properties.flatMap((p) =>
+                p.type === 'RestElement'
+                    ? extractBindingNames(p.argument)
+                    : extractBindingNames((p as acorn.Property).value),
+            );
+        case 'ArrayPattern':
+            return (node as acorn.ArrayPattern).elements.flatMap((e) =>
+                e
+                    ? e.type === 'RestElement'
+                        ? extractBindingNames(e.argument)
+                        : extractBindingNames(e)
+                    : [],
+            );
+        case 'AssignmentPattern':
+            return extractBindingNames((node as acorn.AssignmentPattern).left);
+        case 'RestElement':
+            return extractBindingNames((node as acorn.RestElement).argument);
+        default:
+            return [];
+    }
+}
+
+/**
+ * Parse bundled JS code and return the set of free (unbound) identifiers
+ * that match known GJS globals from `GJS_GLOBALS_MAP`.
+ *
+ * "Free" means the identifier is referenced but never declared in the
+ * module (var/let/const/function/class/import/param/catch).
+ *
+ * After esbuild bundling + minification, local variables that shadow
+ * globals are renamed to short names, so any surviving known-global name
+ * in the output is almost certainly a true global reference. The
+ * declared-names check is a safety net for edge cases where esbuild
+ * keeps the original name.
+ *
+ * `typeof X` references ARE included — if code guards with
+ * `typeof fetch !== 'undefined'`, it intends to use fetch when available
+ * and we can provide it.
+ */
+export function detectFreeGlobals(code: string): Set<string> {
+    const ast = acorn.parse(code, {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+    });
+
+    // --- Pass 1: collect all declared names across the entire module ---
+    const declaredNames = new Set<string>();
+
+    walk.simple(ast, {
+        VariableDeclarator(node: acorn.VariableDeclarator) {
+            for (const name of extractBindingNames(node.id)) {
+                declaredNames.add(name);
+            }
+        },
+        FunctionDeclaration(node: acorn.FunctionDeclaration) {
+            if (node.id) declaredNames.add(node.id.name);
+            for (const param of node.params) {
+                for (const name of extractBindingNames(param)) {
+                    declaredNames.add(name);
+                }
+            }
+        },
+        FunctionExpression(node: acorn.FunctionExpression) {
+            if (node.id) declaredNames.add(node.id.name);
+            for (const param of node.params) {
+                for (const name of extractBindingNames(param)) {
+                    declaredNames.add(name);
+                }
+            }
+        },
+        ArrowFunctionExpression(node: acorn.ArrowFunctionExpression) {
+            for (const param of node.params) {
+                for (const name of extractBindingNames(param)) {
+                    declaredNames.add(name);
+                }
+            }
+        },
+        ClassDeclaration(node: acorn.ClassDeclaration) {
+            if (node.id) declaredNames.add(node.id.name);
+        },
+        ImportSpecifier(node: acorn.ImportSpecifier) {
+            declaredNames.add(node.local.name);
+        },
+        ImportDefaultSpecifier(node: acorn.ImportDefaultSpecifier) {
+            declaredNames.add(node.local.name);
+        },
+        ImportNamespaceSpecifier(node: acorn.ImportNamespaceSpecifier) {
+            declaredNames.add(node.local.name);
+        },
+        CatchClause(node: acorn.CatchClause) {
+            if (node.param) {
+                for (const name of extractBindingNames(node.param)) {
+                    declaredNames.add(name);
+                }
+            }
+        },
+    });
+
+    // --- Pass 2: find Identifier nodes in reference position ---
+    // Also detects MemberExpressions like `globalThis.X` / `global.X` /
+    // `window.X` / `self.X` where X is a known global. esbuild's `define`
+    // config replaces `global`/`window` with `globalThis`, but we accept
+    // all four host-object names for safety (esbuild also never renames
+    // these because they are language keywords / pre-defined globals).
+    const freeGlobals = new Set<string>();
+    const HOST_OBJECTS = new Set(['globalThis', 'global', 'window', 'self', 'globalObject']);
+
+    walk.ancestor(ast, {
+        MemberExpression(node: acorn.MemberExpression) {
+            // Only dot-access — skip computed (bracket) access since the
+            // property is then a dynamic Expression, not a known name.
+            if (node.computed) return;
+            if (node.object.type !== 'Identifier') return;
+            if (node.property.type !== 'Identifier') return;
+
+            const objName = (node.object as acorn.Identifier).name;
+            const propName = (node.property as acorn.Identifier).name;
+
+            // Pattern A: globalThis.X / global.X / window.X / self.X
+            // The property is a known global identifier itself.
+            if (HOST_OBJECTS.has(objName)) {
+                if (KNOWN_GLOBALS.has(propName)) {
+                    freeGlobals.add(propName);
+                }
+                return;
+            }
+
+            // Pattern B: known-instance method markers like
+            // `navigator.getGamepads` → marker map forwards to a global
+            // identifier that triggers the right register path even though
+            // the identifier itself never appears in the bundle.
+            const markerKey = `${objName}.${propName}`;
+            const markerTarget = METHOD_MARKERS[markerKey];
+            if (markerTarget && KNOWN_GLOBALS.has(markerTarget)) {
+                freeGlobals.add(markerTarget);
+            }
+        },
+        Identifier(node: acorn.Identifier, ancestors: acorn.AnyNode[]) {
+            const name = node.name;
+
+            // Quick filter: only check known globals
+            if (!KNOWN_GLOBALS.has(name)) return;
+
+            // Skip if locally declared
+            if (declaredNames.has(name)) return;
+
+            // Determine if this Identifier is in a reference position
+            // by checking the parent node.
+            const parent = ancestors[ancestors.length - 2];
+            if (!parent) {
+                freeGlobals.add(name);
+                return;
+            }
+
+            switch (parent.type) {
+                // obj.prop — skip if this is the non-computed property
+                case 'MemberExpression': {
+                    const mem = parent as acorn.MemberExpression;
+                    if (mem.property === (node as acorn.AnyNode) && !mem.computed) return;
+                    break;
+                }
+                // { key: value } — skip if this is the non-computed key
+                case 'Property': {
+                    const prop = parent as acorn.Property;
+                    if (prop.key === (node as acorn.AnyNode) && !prop.computed) return;
+                    break;
+                }
+                // Method/property definitions in classes
+                case 'MethodDefinition':
+                case 'PropertyDefinition': {
+                    const def = parent as acorn.MethodDefinition | acorn.PropertyDefinition;
+                    if (def.key === (node as acorn.AnyNode) && !def.computed) return;
+                    break;
+                }
+                // label: — skip
+                case 'LabeledStatement': {
+                    const labeled = parent as acorn.LabeledStatement;
+                    if (labeled.label === (node as acorn.AnyNode)) return;
+                    break;
+                }
+                // export { X as Y } — skip the exported name
+                case 'ExportSpecifier': {
+                    const spec = parent as acorn.ExportSpecifier;
+                    if (spec.exported === (node as acorn.AnyNode)) return;
+                    break;
+                }
+                // Declaration ids (function name, class name, variable id)
+                // are already in declaredNames, but guard anyway
+                case 'FunctionDeclaration':
+                case 'FunctionExpression':
+                case 'ClassDeclaration':
+                case 'ClassExpression': {
+                    const decl = parent as
+                        | acorn.FunctionDeclaration
+                        | acorn.FunctionExpression
+                        | acorn.ClassDeclaration
+                        | acorn.ClassExpression;
+                    if (decl.id === (node as acorn.AnyNode)) return;
+                    break;
+                }
+                case 'VariableDeclarator': {
+                    const vd = parent as acorn.VariableDeclarator;
+                    if (vd.id === (node as acorn.AnyNode)) return;
+                    break;
+                }
+                // import { X } / import X — already in declaredNames
+                case 'ImportSpecifier':
+                case 'ImportDefaultSpecifier':
+                case 'ImportNamespaceSpecifier':
+                    return;
+            }
+
+            freeGlobals.add(name);
+        },
+    });
+
+    return freeGlobals;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/entry-points.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/entry-points.ts
@@ -1,0 +1,56 @@
+// Glob expansion for Rolldown entry-point input.
+//
+// Rolldown's `input` accepts:
+//   - a single path string
+//   - an array of strings
+//   - a record mapping output names to input paths
+//   - an array of `{ in: <path>, out: <name> }` objects (Rolldown extension)
+//
+// `globToEntryPoints` accepts the same shapes and expands any glob patterns
+// against the filesystem via `fast-glob`. Pure-string entries return as-is
+// when they don't contain wildcards (fast-glob handles that gracefully).
+
+import fastGlob from 'fast-glob';
+
+export type EntryPoints =
+    | string
+    | string[]
+    | { in: string; out: string }[]
+    | Record<string, string>;
+
+export const globToEntryPoints = async (
+    _entryPoints: EntryPoints | undefined,
+    ignore: string[] = [],
+): Promise<EntryPoints | undefined> => {
+    if (_entryPoints === undefined) return undefined;
+
+    if (typeof _entryPoints === 'string') {
+        const expanded = await fastGlob([_entryPoints], { ignore });
+        return expanded;
+    }
+
+    if (Array.isArray(_entryPoints) && typeof _entryPoints[0] === 'string') {
+        return await fastGlob(_entryPoints as string[], { ignore });
+    }
+
+    if (Array.isArray(_entryPoints) && typeof _entryPoints[0] === 'object') {
+        const entryPoints: { in: string; out: string }[] = [];
+        for (const entryPoint of _entryPoints as { in: string; out: string }[]) {
+            const inputs = await fastGlob(entryPoint.in, { ignore });
+            for (const input of inputs) {
+                entryPoints.push({ in: input, out: entryPoint.out });
+            }
+        }
+        return entryPoints;
+    }
+
+    const entryPoints: Record<string, string> = {};
+    for (const input in _entryPoints as Record<string, string>) {
+        const output = (_entryPoints as Record<string, string>)[input];
+        const inputs = await fastGlob(input, { ignore });
+        for (const matched of inputs) {
+            entryPoints[matched] = output;
+        }
+    }
+    return entryPoints;
+};

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/entry-points.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/entry-points.ts
@@ -4,7 +4,6 @@
 //   - a single path string
 //   - an array of strings
 //   - a record mapping output names to input paths
-//   - an array of `{ in: <path>, out: <name> }` objects (Rolldown extension)
 //
 // `globToEntryPoints` accepts the same shapes and expands any glob patterns
 // against the filesystem via `fast-glob`. Pure-string entries return as-is
@@ -12,11 +11,7 @@
 
 import fastGlob from 'fast-glob';
 
-export type EntryPoints =
-    | string
-    | string[]
-    | { in: string; out: string }[]
-    | Record<string, string>;
+export type EntryPoints = string | string[] | Record<string, string>;
 
 export const globToEntryPoints = async (
     _entryPoints: EntryPoints | undefined,
@@ -29,24 +24,13 @@ export const globToEntryPoints = async (
         return expanded;
     }
 
-    if (Array.isArray(_entryPoints) && typeof _entryPoints[0] === 'string') {
-        return await fastGlob(_entryPoints as string[], { ignore });
-    }
-
-    if (Array.isArray(_entryPoints) && typeof _entryPoints[0] === 'object') {
-        const entryPoints: { in: string; out: string }[] = [];
-        for (const entryPoint of _entryPoints as { in: string; out: string }[]) {
-            const inputs = await fastGlob(entryPoint.in, { ignore });
-            for (const input of inputs) {
-                entryPoints.push({ in: input, out: entryPoint.out });
-            }
-        }
-        return entryPoints;
+    if (Array.isArray(_entryPoints)) {
+        return await fastGlob(_entryPoints, { ignore });
     }
 
     const entryPoints: Record<string, string> = {};
-    for (const input in _entryPoints as Record<string, string>) {
-        const output = (_entryPoints as Record<string, string>)[input];
+    for (const input in _entryPoints) {
+        const output = _entryPoints[input];
         const inputs = await fastGlob(input, { ignore });
         for (const matched of inputs) {
             entryPoints[matched] = output;

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/extension.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/extension.ts
@@ -1,0 +1,7 @@
+export const getJsExtensions = (allowExt?: string) => {
+    const extensions: Record<string, string> = {'.js': '.js', '.ts': '.js', '.mts': '.js', '.cts': '.js', '.cjs': '.js', '.mjs': '.js'};
+    if(allowExt && extensions[allowExt]) {
+        delete extensions[allowExt]
+    }
+    return extensions;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './alias.js';
+export * from './entry-points.js';
 export * from './extension.js';
 export * from './merge.js';
 export { detectFreeGlobals } from './detect-free-globals.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/index.ts
@@ -1,0 +1,6 @@
+export * from './alias.js';
+export * from './extension.js';
+export * from './merge.js';
+export { detectFreeGlobals } from './detect-free-globals.js';
+export { resolveGlobalsList, writeRegisterInjectFile } from './scan-globals.js';
+export { inlineStaticReads } from './inline-static-reads.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/inline-static-reads.ts
@@ -1,0 +1,541 @@
+// Build-time inlining of statically-resolvable filesystem reads.
+//
+// Many node_modules packages locate their own resources (own package.json,
+// locales, themes, ...) via `import.meta.url`-relative reads:
+//
+//   const pkg = JSON.parse(readFileSync(
+//     new URL("../package.json", import.meta.url),
+//     "utf8",
+//   ));
+//
+// In a bundled GJS executable, `import.meta.url` no longer points at the
+// original `node_modules/<pkg>/<file>` location, so the read fails with
+// ENOENT once the bundle leaves the build site (gjsify dlx, manual move,
+// CI artifact download, …).
+//
+// The clean fix is to evaluate the static expressions at build time and
+// replace the entire `readFileSync(...)` (or `readdirSync(...)`, or the
+// `JSON.parse(readFileSync(...))` composition) with a literal containing
+// the file contents. The bundle is then a single self-contained file that
+// behaves exactly like the original — same return value, same errors on
+// missing files — but with no runtime dependency on the build-site layout.
+//
+// Patterns handled:
+//
+//   readFileSync(<URL-derived-path>, "utf8" | "utf-8" | { encoding: "utf8" })
+//                                                       → string literal
+//   readFileSync(<URL-derived-path>)                    → Uint8Array literal
+//   readdirSync(<URL-derived-path>)                     → array literal of names
+//   JSON.parse(readFileSync(...))                       → object literal
+//   existsSync(<URL-derived-path>)                      → boolean literal
+//
+// Path expressions are evaluated against `import.meta.url` of the source
+// file at build time, supporting compositions of:
+//
+//   new URL(<lit>, import.meta.url)                     base resolution
+//   <expr>.href, <expr>.pathname                        property access
+//   fileURLToPath(<URL-expr>)                           url → fs path
+//   path.{join,dirname,resolve,basename,relative}(...)  path arithmetic
+//   string-literal + string-literal                     concatenation
+//
+// Anything not statically resolvable is left untouched — the legacy
+// `import.meta.url` rewriter still applies as a fallback.
+
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+import { dirname, join, resolve, basename, relative, extname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+
+/**
+ * One in-place edit on the source string. Stored as half-open `[start, end)`
+ * byte offsets so we can apply replacements right-to-left without invalidating
+ * earlier offsets.
+ */
+interface Edit {
+    start: number;
+    end: number;
+    replacement: string;
+}
+
+interface InlineContext {
+    /** `import.meta.url` of the source file being inlined (file:// URL). */
+    sourceUrl: string;
+}
+
+/**
+ * Run the inliner on a source string. Returns the rewritten source (or the
+ * original string when no inlining applied) and the count of edits applied.
+ *
+ * Safe to call on any JS source. Files that don't reference `readFileSync` /
+ * `readdirSync` / `existsSync` skip the AST parse entirely (cheap fast path).
+ */
+export function inlineStaticReads(
+    src: string,
+    sourceFilePath: string,
+): { contents: string; inlined: number } {
+    if (
+        !src.includes('readFileSync') &&
+        !src.includes('readdirSync') &&
+        !src.includes('existsSync')
+    ) {
+        return { contents: src, inlined: 0 };
+    }
+
+    let ast: acorn.Program;
+    try {
+        ast = acorn.parse(src, {
+            ecmaVersion: 'latest',
+            sourceType: 'module',
+            allowAwaitOutsideFunction: true,
+            allowReturnOutsideFunction: true,
+            allowImportExportEverywhere: true,
+        });
+    } catch {
+        // Source isn't valid JS (CJS source with shebangs, mixed module
+        // syntax, ...). Skip; the rest of the rewriter still runs.
+        return { contents: src, inlined: 0 };
+    }
+
+    const ctx: InlineContext = {
+        sourceUrl: pathToFileURL(sourceFilePath).href,
+    };
+    const edits: Edit[] = [];
+
+    walk.simple(ast, {
+        CallExpression(node: acorn.CallExpression) {
+            const edit = tryInlineCall(node, ctx, src);
+            if (edit) edits.push(edit);
+        },
+    });
+
+    if (edits.length === 0) return { contents: src, inlined: 0 };
+
+    // The walker visits both outer and inner CallExpressions, so a successful
+    // match on `JSON.parse(readFileSync(...))` produces an edit AT the same
+    // time that the inner `readFileSync(...)` also produces one. Applying both
+    // would corrupt the output. Keep only edits that are not contained in any
+    // other edit (= outermost wins).
+    const outermost: Edit[] = [];
+    edits.sort((a, b) => a.start - b.start || b.end - a.end);
+    for (const e of edits) {
+        const last = outermost[outermost.length - 1];
+        if (last && e.start >= last.start && e.end <= last.end) continue; // nested
+        outermost.push(e);
+    }
+
+    // Apply right-to-left so earlier offsets remain valid.
+    outermost.sort((a, b) => b.start - a.start);
+    let out = src;
+    for (const e of outermost) {
+        out = out.slice(0, e.start) + e.replacement + out.slice(e.end);
+    }
+    return { contents: out, inlined: outermost.length };
+}
+
+/**
+ * Try to inline a single `CallExpression`. Returns an edit on success, or
+ * `undefined` if the call doesn't match an inlinable pattern or the path
+ * couldn't be resolved or the file doesn't exist.
+ */
+function tryInlineCall(
+    node: acorn.CallExpression,
+    ctx: InlineContext,
+    src: string,
+): Edit | undefined {
+    const callee = node.callee;
+
+    // `JSON.parse(readFileSync(<path>, "utf8"))` — collapse the whole
+    // composition. Recognising it specifically lets us emit a parsed-JSON
+    // object literal instead of a `JSON.parse('…')` string-then-parse pair,
+    // which esbuild can dead-code-eliminate against.
+    if (
+        callee.type === 'MemberExpression' &&
+        !callee.computed &&
+        callee.object.type === 'Identifier' && callee.object.name === 'JSON' &&
+        callee.property.type === 'Identifier' && callee.property.name === 'parse' &&
+        node.arguments.length >= 1 &&
+        node.arguments[0].type === 'CallExpression'
+    ) {
+        const inner = node.arguments[0] as acorn.CallExpression;
+        const innerEdit = tryInlineReadFile(inner, ctx, /*forceTextEncoding*/ true);
+        if (innerEdit !== undefined) {
+            // `innerEdit` is the literal source for the read result (a JSON
+            // string). Parse and re-emit as a JS-literal expression so the
+            // surrounding code sees an object directly.
+            try {
+                const parsed = JSON.parse(JSON.parse(innerEdit));
+                return {
+                    start: node.start,
+                    end: node.end,
+                    replacement: jsLiteral(parsed),
+                };
+            } catch {
+                // Fall through — leave the original call alone.
+            }
+        }
+    }
+
+    const calleeName = identifierName(callee);
+
+    if (calleeName === 'readFileSync') {
+        const replacement = tryInlineReadFile(node, ctx, /*forceTextEncoding*/ false);
+        if (replacement !== undefined) {
+            return { start: node.start, end: node.end, replacement };
+        }
+    }
+
+    if (calleeName === 'readdirSync') {
+        const path = evalPathExpr(node.arguments[0], ctx);
+        if (path && existsSyncSafe(path) && isDirectorySafe(path)) {
+            try {
+                const names = readdirSync(path);
+                return {
+                    start: node.start,
+                    end: node.end,
+                    replacement: jsLiteral(names),
+                };
+            } catch {
+                /* skip */
+            }
+        }
+    }
+
+    if (calleeName === 'existsSync') {
+        const path = evalPathExpr(node.arguments[0], ctx);
+        if (path !== undefined) {
+            return {
+                start: node.start,
+                end: node.end,
+                replacement: existsSyncSafe(path) ? 'true' : 'false',
+            };
+        }
+    }
+
+
+    // `createRequire(<URL>)` from `node:module` returns a CJS-style require.
+    // In a bundled GJS executable, the deps that the runtime require would
+    // resolve are already inlined by esbuild, so the require() function is
+    // typically dead code. The createRequire CALL itself runs at module init,
+    // and Node's implementation rejects the rewritten URLs we produce when
+    // they don't point at an existing file (yargs-parser's `createRequire(
+    // import.meta.url)` blows up because the rewritten URL refers to a Yarn
+    // PnP zip path that doesn't exist outside the PnP runtime).
+    //
+    // Replace the call with a stub function: assignment succeeds, the bundle
+    // boots, and any actual `require()` invocation produces a clear error
+    // instead of an obscure URL-validation crash. Only fires when the URL
+    // argument can be statically resolved AND points at a non-existent file
+    // — the common case is exactly the broken one.
+    if (calleeName === 'createRequire') {
+        const path = evalPathExpr(node.arguments[0], ctx);
+        // Stub the call when:
+        //  - the resolved path doesn't exist on disk (build site), OR
+        //  - the path contains a `.zip/` segment (Yarn PnP virtual zip,
+        //    where Node's PnP hooks make `existsSync` return true at build
+        //    time but the path doesn't exist under GJS at runtime).
+        const isZip = path !== undefined && path.includes('.zip/');
+        if (path !== undefined && (isZip || !existsSyncSafe(path))) {
+            return {
+                start: node.start,
+                end: node.end,
+                replacement:
+                    `(() => { ` +
+                    `const _r = (id) => { throw new Error("[gjsify] createRequire stub: '" + id + "' was not bundled (anchor path: " + ${jsStringLiteral(path)} + ")"); }; ` +
+                    `_r.resolve = _r; _r.cache = {}; _r.extensions = {}; _r.main = void 0; ` +
+                    `return _r; ` +
+                    `})()`,
+            };
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Inline a `readFileSync(<path>, <enc>?)` call to a string or byte literal.
+ * Returns the source replacement, or `undefined` to leave the call alone.
+ *
+ * `forceTextEncoding`: caller (JSON.parse wrapper) demands an utf-8 read
+ * regardless of whether the syntactic argument provides an encoding.
+ */
+function tryInlineReadFile(
+    node: acorn.CallExpression,
+    ctx: InlineContext,
+    forceTextEncoding: boolean,
+): string | undefined {
+    if (node.arguments.length < 1) return undefined;
+    const path = evalPathExpr(node.arguments[0], ctx);
+    if (!path) return undefined;
+    if (!existsSyncSafe(path) || isDirectorySafe(path)) return undefined;
+
+    let encoding: string | undefined;
+    if (forceTextEncoding) {
+        encoding = 'utf8';
+    } else if (node.arguments.length >= 2) {
+        encoding = evalEncodingExpr(node.arguments[1]);
+        if (encoding === undefined) return undefined; // unknown → bail
+    }
+
+    try {
+        if (encoding) {
+            const text = readFileSync(path, encoding as BufferEncoding);
+            return jsStringLiteral(text);
+        } else {
+            // Binary read → emit a Uint8Array constructor over a number array.
+            // Buffer-vs-Uint8Array semantic difference is mostly irrelevant in
+            // bundled GJS code (Buffer is polyfilled on top of Uint8Array).
+            const bytes = readFileSync(path);
+            return `new Uint8Array([${Array.from(bytes).join(',')}])`;
+        }
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Statically evaluate a node we expect to produce a filesystem path string.
+ * Returns the absolute path or `undefined` if any step is non-static.
+ *
+ * Recursively understands compositions of:
+ *   - string literals, template literals (no expressions), `+` concatenation
+ *   - `new URL(<lit>, <base-url-expr>)`
+ *   - `<URL-expr>.href`, `<URL-expr>.pathname`
+ *   - `fileURLToPath(<URL-expr>)` / `pathToFileURL(<path>).href`
+ *   - `(path.)?{join,dirname,resolve,basename,relative,extname}(...)` over static args
+ *   - `import.meta.url` (resolved against ctx.sourceUrl)
+ *   - bare identifier `__dirname` / `__filename` (resolved against ctx.sourceUrl)
+ *
+ * Returns a path string OR a URL string, depending on context — callers
+ * that need a path use `evalPathExpr`, callers that need a URL use
+ * `evalUrlExpr`. They both come from the same recursive evaluator.
+ */
+function evalPathExpr(node: acorn.AnyNode | undefined, ctx: InlineContext): string | undefined {
+    const v = evalExpr(node, ctx);
+    if (v instanceof URL) {
+        if (v.protocol === 'file:') return fileURLToPath(v);
+        return undefined;
+    }
+    if (typeof v !== 'string') return undefined;
+    if (v.startsWith('file://')) return fileURLToPath(v);
+    if (v.startsWith('/')) return v;
+    return undefined;
+}
+
+type EvalValue = string | URL | undefined;
+
+function evalExpr(node: acorn.AnyNode | undefined, ctx: InlineContext): EvalValue {
+    if (!node) return undefined;
+
+    switch (node.type) {
+        case 'Literal':
+            if (typeof (node as acorn.Literal).value === 'string') {
+                return (node as acorn.Literal).value as string;
+            }
+            return undefined;
+
+        case 'TemplateLiteral': {
+            const tl = node as acorn.TemplateLiteral;
+            if (tl.expressions.length > 0) return undefined;
+            return tl.quasis.map((q) => q.value.cooked ?? '').join('');
+        }
+
+        case 'BinaryExpression': {
+            const be = node as acorn.BinaryExpression;
+            if (be.operator !== '+') return undefined;
+            const l = evalExpr(be.left, ctx);
+            const r = evalExpr(be.right, ctx);
+            if (typeof l !== 'string' || typeof r !== 'string') return undefined;
+            return l + r;
+        }
+
+        case 'Identifier': {
+            const id = node as acorn.Identifier;
+            if (id.name === '__dirname') return fileURLToPath(new URL('.', ctx.sourceUrl));
+            if (id.name === '__filename') return fileURLToPath(ctx.sourceUrl);
+            return undefined;
+        }
+
+        case 'MemberExpression': {
+            const me = node as acorn.MemberExpression;
+            // import.meta.url
+            if (
+                me.object.type === 'MetaProperty' &&
+                (me.object as acorn.MetaProperty).meta.name === 'import' &&
+                (me.object as acorn.MetaProperty).property.name === 'meta' &&
+                me.property.type === 'Identifier' &&
+                (me.property as acorn.Identifier).name === 'url'
+            ) {
+                return ctx.sourceUrl;
+            }
+            // <expr>.href / .pathname
+            if (!me.computed && me.property.type === 'Identifier') {
+                const obj = evalExpr(me.object, ctx);
+                const prop = (me.property as acorn.Identifier).name;
+                if (obj instanceof URL) {
+                    if (prop === 'href') return obj.href;
+                    if (prop === 'pathname') return obj.pathname;
+                }
+                if (typeof obj === 'string') {
+                    if (prop === 'href') return obj; // already a URL string
+                    if (prop === 'pathname') {
+                        try { return new URL(obj).pathname; } catch { return undefined; }
+                    }
+                }
+            }
+            return undefined;
+        }
+
+        case 'NewExpression': {
+            const ne = node as acorn.NewExpression;
+            const calleeName = identifierName(ne.callee);
+            if (calleeName === 'URL') {
+                if (ne.arguments.length === 0) return undefined;
+                const first = evalExpr(ne.arguments[0], ctx);
+                if (typeof first !== 'string') return undefined;
+                if (ne.arguments.length === 1) {
+                    try { return new URL(first); } catch { return undefined; }
+                }
+                const base = evalExpr(ne.arguments[1], ctx);
+                const baseStr = base instanceof URL ? base.href : (typeof base === 'string' ? base : undefined);
+                if (!baseStr) return undefined;
+                try { return new URL(first, baseStr); } catch { return undefined; }
+            }
+            return undefined;
+        }
+
+        case 'CallExpression': {
+            const ce = node as acorn.CallExpression;
+            const name = identifierName(ce.callee);
+
+            if (name === 'fileURLToPath') {
+                const arg = evalExpr(ce.arguments[0], ctx);
+                const url = arg instanceof URL ? arg.href : (typeof arg === 'string' ? arg : undefined);
+                if (!url) return undefined;
+                try { return fileURLToPath(url); } catch { return undefined; }
+            }
+
+            if (name === 'pathToFileURL') {
+                const arg = evalExpr(ce.arguments[0], ctx);
+                if (typeof arg !== 'string') return undefined;
+                try { return pathToFileURL(arg); } catch { return undefined; }
+            }
+
+            if (name === 'join' || name === 'resolve') {
+                const args: string[] = [];
+                for (const a of ce.arguments) {
+                    const v = evalExpr(a, ctx);
+                    if (typeof v !== 'string') return undefined;
+                    args.push(v);
+                }
+                return name === 'join' ? join(...args) : resolve(...args);
+            }
+
+            if (name === 'dirname' || name === 'basename' || name === 'extname') {
+                const v = evalExpr(ce.arguments[0], ctx);
+                if (typeof v !== 'string') return undefined;
+                if (name === 'dirname') return dirname(v);
+                if (name === 'basename') {
+                    const ext = ce.arguments.length >= 2 ? evalExpr(ce.arguments[1], ctx) : undefined;
+                    return basename(v, typeof ext === 'string' ? ext : undefined);
+                }
+                if (name === 'extname') return extname(v);
+            }
+
+            if (name === 'relative') {
+                const a = evalExpr(ce.arguments[0], ctx);
+                const b = evalExpr(ce.arguments[1], ctx);
+                if (typeof a !== 'string' || typeof b !== 'string') return undefined;
+                return relative(a, b);
+            }
+
+            return undefined;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Evaluate an encoding argument to its canonical string form.
+ *   "utf8" / "utf-8"           → "utf8"
+ *   { encoding: "utf8" }       → "utf8"
+ *   anything else              → undefined (caller leaves the call alone)
+ */
+function evalEncodingExpr(node: acorn.AnyNode | undefined): string | undefined {
+    if (!node) return undefined;
+    if (node.type === 'Literal') {
+        const v = (node as acorn.Literal).value;
+        if (typeof v === 'string') return canonicalEncoding(v);
+        return undefined;
+    }
+    if (node.type === 'ObjectExpression') {
+        for (const p of (node as acorn.ObjectExpression).properties) {
+            if (p.type !== 'Property' || p.computed) continue;
+            const key = p.key.type === 'Identifier'
+                ? (p.key as acorn.Identifier).name
+                : p.key.type === 'Literal' ? String((p.key as acorn.Literal).value) : undefined;
+            if (key !== 'encoding') continue;
+            if (p.value.type === 'Literal' && typeof (p.value as acorn.Literal).value === 'string') {
+                return canonicalEncoding((p.value as acorn.Literal).value as string);
+            }
+            return undefined;
+        }
+    }
+    return undefined;
+}
+
+function canonicalEncoding(v: string): string | undefined {
+    const lc = v.toLowerCase();
+    if (lc === 'utf8' || lc === 'utf-8') return 'utf8';
+    if (lc === 'ascii') return 'ascii';
+    if (lc === 'latin1' || lc === 'binary') return 'latin1';
+    return undefined;
+}
+
+/**
+ * Get the leaf identifier name of a callee. Recognises:
+ *   `foo`               → "foo"
+ *   `path.foo`          → "foo"
+ *   `node:path.foo`     → "foo" (rare)
+ *   `fs.foo` / `fs.promises.foo` → "foo"
+ * Returns `undefined` for computed/dynamic callees.
+ */
+function identifierName(node: acorn.AnyNode | undefined): string | undefined {
+    if (!node) return undefined;
+    if (node.type === 'Identifier') return (node as acorn.Identifier).name;
+    if (node.type === 'MemberExpression' && !(node as acorn.MemberExpression).computed) {
+        const me = node as acorn.MemberExpression;
+        if (me.property.type === 'Identifier') return (me.property as acorn.Identifier).name;
+    }
+    return undefined;
+}
+
+/** Produce a JS source-fragment for a value the inliner produced. */
+function jsLiteral(v: unknown): string {
+    if (typeof v === 'string') return jsStringLiteral(v);
+    if (typeof v === 'number') return Number.isFinite(v) ? String(v) : 'null';
+    if (typeof v === 'boolean') return v ? 'true' : 'false';
+    if (v === null) return 'null';
+    if (Array.isArray(v)) return '[' + v.map(jsLiteral).join(',') + ']';
+    if (typeof v === 'object') {
+        const parts: string[] = [];
+        for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+            parts.push(`${jsStringLiteral(k)}:${jsLiteral(val)}`);
+        }
+        return '{' + parts.join(',') + '}';
+    }
+    return 'undefined';
+}
+
+/** JSON.stringify is the safest way to escape arbitrary strings into JS. */
+function jsStringLiteral(s: string): string {
+    return JSON.stringify(s);
+}
+
+function existsSyncSafe(path: string): boolean {
+    try { return existsSync(path); } catch { return false; }
+}
+
+function isDirectorySafe(path: string): boolean {
+    try { return statSync(path).isDirectory(); } catch { return false; }
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/merge.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/merge.ts
@@ -1,0 +1,22 @@
+/** Deep merge objects (replaces lodash.merge) */
+export function merge<T extends Record<string, any>>(target: T, ...sources: Record<string, any>[]): T {
+    for (const source of sources) {
+        if (!source) continue;
+        for (const key of Object.keys(source)) {
+            const targetVal = (target as any)[key];
+            const sourceVal = source[key];
+            if (sourceVal !== undefined) {
+                if (isPlainObject(targetVal) && isPlainObject(sourceVal)) {
+                    merge(targetVal, sourceVal);
+                } else {
+                    (target as any)[key] = sourceVal;
+                }
+            }
+        }
+    }
+    return target;
+}
+
+function isPlainObject(val: unknown): val is Record<string, any> {
+    return typeof val === 'object' && val !== null && !Array.isArray(val) && Object.getPrototypeOf(val) === Object.prototype;
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/utils/scan-globals.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/utils/scan-globals.ts
@@ -1,0 +1,91 @@
+// Explicit `--globals` CLI flag support.
+//
+// This module resolves a user-provided comma-separated list of global
+// identifiers (e.g. `fetch,Buffer,process,URL,crypto`) into the
+// corresponding set of `@gjsify/<pkg>/register` subpaths and writes an
+// ESM stub file that the esbuild plugin injects via its
+// `autoGlobalsInject` option.
+//
+// gjsify does NOT scan user code to guess which globals are needed —
+// the user declares them explicitly via `gjsify build --globals <list>`
+// (or via the default script scaffolded by `@gjsify/create-app`). See
+// the "Tree-shakeable Globals" section in AGENTS.md for the rationale.
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+
+import { GJS_GLOBALS_MAP, GJS_GLOBALS_GROUPS } from '@gjsify/resolve-npm/globals-map';
+
+const GLOBALS_MAP: Record<string, string> = GJS_GLOBALS_MAP;
+const GLOBALS_GROUPS: Record<string, string[]> = GJS_GLOBALS_GROUPS;
+
+/**
+ * Resolve a `--globals` CLI argument into the set of `/register` subpaths
+ * that must be injected into the build.
+ *
+ * The argument is a comma-separated list of identifiers or group names.
+ * Group names (`node`, `web`, `dom`) expand to all identifiers in that group.
+ * Unknown tokens are silently ignored. Empty or whitespace-only input returns
+ * an empty set.
+ *
+ * Examples:
+ *   resolveGlobalsList('fetch,Buffer,process')
+ *     → Set { 'fetch/register', '@gjsify/buffer/register', '@gjsify/node-globals/register' }
+ *
+ *   resolveGlobalsList('node,web')
+ *     → Set { '@gjsify/buffer/register', '@gjsify/node-globals/register', 'fetch/register', … }
+ *
+ *   resolveGlobalsList('')
+ *     → Set { }
+ */
+export function resolveGlobalsList(globalsArg: string): Set<string> {
+    const result = new Set<string>();
+    const trimmed = globalsArg.trim();
+    if (!trimmed) return result;
+
+    for (const rawToken of trimmed.split(',')) {
+        const token = rawToken.trim();
+        if (!token) continue;
+        const group = GLOBALS_GROUPS[token];
+        if (group) {
+            for (const id of group) {
+                const path = GLOBALS_MAP[id];
+                if (path) result.add(path);
+            }
+        } else {
+            const path = GLOBALS_MAP[token];
+            if (path) result.add(path);
+        }
+    }
+    return result;
+}
+
+/**
+ * Write a stub ESM file with `import` statements for the given register
+ * paths and return its absolute path, suitable for passing to esbuild's
+ * `inject` option via the plugin's `autoGlobalsInject` field.
+ *
+ * The file lives inside `<cwd>/node_modules/.cache/gjsify/` so esbuild's
+ * module resolver can follow the bare specifiers in the generated imports.
+ *
+ * The file name is hashed by content so repeated builds with the same
+ * set reuse the same file (no churn, idempotent on disk).
+ */
+export async function writeRegisterInjectFile(
+    registerPaths: Set<string>,
+    cwd: string = process.cwd(),
+): Promise<string | null> {
+    if (registerPaths.size === 0) return null;
+
+    const sorted = [...registerPaths].sort();
+    const content = sorted.map((p) => `import '${p}';`).join('\n') + '\n';
+    const hash = createHash('sha1').update(content).digest('hex').slice(0, 10);
+
+    const cacheDir = join(cwd, 'node_modules', '.cache', 'gjsify');
+    await mkdir(cacheDir, { recursive: true });
+
+    const path = join(cacheDir, `auto-globals-${hash}.mjs`);
+    await writeFile(path, content, 'utf-8');
+    return path;
+}

--- a/packages/infra/rolldown-plugin-gjsify/tsconfig.json
+++ b/packages/infra/rolldown-plugin-gjsify/tsconfig.json
@@ -6,7 +6,8 @@
         "target": "ESNext",
         "module": "ESNext",
         "moduleResolution": "bundler",
-        "strict": true,
+        "lib": ["ESNext", "DOM"],
+        "strict": false,
         "esModuleInterop": true,
         "skipLibCheck": true,
         "types": ["node"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,7 +3841,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/rolldown-plugin-deepkit@workspace:packages/infra/rolldown-plugin-deepkit":
+"@gjsify/rolldown-plugin-deepkit@workspace:^, @gjsify/rolldown-plugin-deepkit@workspace:packages/infra/rolldown-plugin-deepkit":
   version: 0.0.0-use.local
   resolution: "@gjsify/rolldown-plugin-deepkit@workspace:packages/infra/rolldown-plugin-deepkit"
   dependencies:
@@ -3861,7 +3861,18 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gjsify/rolldown-plugin-gjsify@workspace:packages/infra/rolldown-plugin-gjsify"
   dependencies:
+    "@gjsify/console": "workspace:^"
+    "@gjsify/resolve-npm": "workspace:^"
+    "@gjsify/rolldown-plugin-deepkit": "workspace:^"
+    "@gjsify/rolldown-plugin-pnp": "workspace:^"
+    "@gjsify/vite-plugin-blueprint": "workspace:^"
+    "@rollup/plugin-alias": "npm:^5.1.1"
+    "@rollup/pluginutils": "npm:^5.1.4"
     "@types/node": "npm:^25.6.0"
+    acorn: "npm:^8.14.0"
+    acorn-walk: "npm:^8.3.4"
+    fast-glob: "npm:^3.3.3"
+    lightningcss: "npm:^1.32.0"
     rolldown: "npm:^1.0.0-rc.18"
     typescript: "npm:^6.0.3"
   peerDependencies:
@@ -3872,7 +3883,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/rolldown-plugin-pnp@workspace:packages/infra/rolldown-plugin-pnp":
+"@gjsify/rolldown-plugin-pnp@workspace:^, @gjsify/rolldown-plugin-pnp@workspace:packages/infra/rolldown-plugin-pnp":
   version: 0.0.0-use.local
   resolution: "@gjsify/rolldown-plugin-pnp@workspace:packages/infra/rolldown-plugin-pnp"
   dependencies:
@@ -4245,7 +4256,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/vite-plugin-blueprint@workspace:packages/infra/vite-plugin-blueprint":
+"@gjsify/vite-plugin-blueprint@workspace:^, @gjsify/vite-plugin-blueprint@workspace:packages/infra/vite-plugin-blueprint":
   version: 0.0.0-use.local
   resolution: "@gjsify/vite-plugin-blueprint@workspace:packages/infra/vite-plugin-blueprint"
   dependencies:
@@ -6753,7 +6764,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^5.1.0, @rollup/pluginutils@npm:^5.3.0":
+"@rollup/plugin-alias@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@rollup/plugin-alias@npm:5.1.1"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/1f1ab178aa2726c81e2ae1709f73b3688491f14655b97c54d43bea35ac3f783f8855d701d1e5eac234e3ffe89fef56ce975726b036a97049fefa9b514686e55c
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^5.1.0, @rollup/pluginutils@npm:^5.1.4, @rollup/pluginutils@npm:^5.3.0":
   version: 5.3.0
   resolution: "@rollup/pluginutils@npm:5.3.0"
   dependencies:
@@ -7958,7 +7981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.3.5":
+"acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.3.4, acorn-walk@npm:^8.3.5":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
   dependencies:
@@ -7976,7 +7999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1":
+"acorn@npm:^8.0.0, acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:


### PR DESCRIPTION
## Summary

Implements `@gjsify/rolldown-plugin-gjsify` — the orchestrator that replaces `@gjsify/esbuild-plugin-gjsify` in the bundler-rolldown migration (continuation of #81).

The orchestrator wires:
- 3 platform-specific factories (`gjsifyForGjs`, `gjsifyForNode`, `gjsifyForBrowser`)
- The iterative `--globals auto` multi-pass analyser
- Per-source path rewriting for node_modules `import.meta.url` / `__dirname` / `__filename`
- The 5 sub-plugins (process stub, console shim, blueprint, deepkit, css-as-string)

CLI surface (`gjsify build --app gjs|node|browser …`) remains unchanged. The CLI engine swap to call this orchestrator lands in a follow-up PR (commit 6 of the plan).

## Commit plan

This PR lands the orchestrator package only — the CLI still builds with esbuild. Tree stays green throughout because the new package is additive.

1. `feat(rolldown-plugin-gjsify): port bundler-agnostic utilities` ✅ landed
2. `feat(rolldown-plugin-gjsify): port node_modules path rewriter as Rolldown plugin` ✅ landed
3. `feat(rolldown-plugin-gjsify): port iterative auto-globals analyser to Rolldown` ✅ landed
4. `feat(rolldown-plugin-gjsify): platform factories + orchestrator` 🔜 next

## Auto-globals invariant

Per AGENTS.md "Tree-shakeability invariants — permanent" (made bundler-agnostic in #81), the iterative multi-pass `--globals auto` mechanism is preserved structurally — Rolldown's per-source `transform(code, id)` does NOT replace it. The analyser still:
- bundles via `rolldown()` with `minify:false, sourcemap:false`
- parses the resulting chunk strings via `acorn` for free globals + member-expression markers
- repeats until the detected set converges (cap MAX_ITERATIONS=5)

The "after tree-shaking" property eliminates false-positive classes (isomorphic guards, dynamic-branch imports, bracket-notation access) that source-AST plugins like `@rollup/plugin-inject` cannot filter regardless of parser quality.

## Test plan

- [x] `yarn workspace @gjsify/rolldown-plugin-gjsify run check`
- [x] `yarn workspace @gjsify/rolldown-plugin-gjsify run build`
- [ ] CI matrix green (full repo type check + tests, esbuild path still active)