### PR TITLE
feat!: bump minimum runtime to GJS 1.86 / SpiderMonkey 140

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [24.x]
-        fedora-version: [42, 43, 44]
+        fedora-version: [43, 44]
         include:
-          - fedora-version: 42
-            gjs-info: "GJS 1.84 / SM 128"
           - fedora-version: 43
             gjs-info: "GJS 1.86 / SM 140"
           - fedora-version: 44

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Node.js/Web/DOM API + Framework for GJS (GNOME JS). Yarn workspaces monorepo, v0
 | eventsource | Soup 3.0 | EventSource (SSE) |
 | websocket | Soup 3.0 | WebSocket, MessageEvent, CloseEvent. NUL-byte-safe text frames (send via `send_message(TEXT, GLib.Bytes)` — Soup's `send_text` truncates at `\0`). RFC 6455 fuzz-validated via Autobahn |
 | webstorage | Gio | localStorage, sessionStorage |
-| webassembly | — | Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey 128's working synchronous `new WebAssembly.{Module,Instance}` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` via new `WebAssembly.<method>` METHOD_MARKERS. |
+| webassembly | — | Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey's working synchronous `new WebAssembly.{Module,Instance}` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` via new `WebAssembly.<method>` METHOD_MARKERS. |
 | webaudio | Gst 1.0, GstApp 1.0 | AudioContext(decodeAudioData via GStreamer decodebin), AudioBufferSourceNode(appsrc→volume→autoaudiosink), GainNode(AudioParam+setTargetAtTime), AudioBuffer(PCM Float32), HTMLAudioElement(canPlayType+playbin). Phase 1 |
 | webrtc | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | Full W3C WebRTC — RTCPeerConnection, RTCDataChannel (string+binary), RTCRtpSender/Receiver/Transceiver, MediaStream, MediaStreamTrack, getUserMedia (pipewiresrc/pulsesrc/v4l2src fallback chain), RTCDTMFSender, RTCCertificate, RTCStatsReport, RTCIceCandidate, RTCSessionDescription. Tee-multiplexer for shared-source fan-out (VideoBridge preview ↔ PC sender). Backed by `@gjsify/webrtc-native` |
 | webrtc-native | Gst 1.0, GstWebRTC 1.0 | **Vala/GObject prebuild.** Three main-thread signal bridges: `WebrtcbinBridge` (wraps `on-negotiation-needed`/`on-ice-candidate`/`on-data-channel` + `notify::*-state`), `DataChannelBridge` (wraps GstWebRTCDataChannel's `on-open`/`on-close`/`on-error`/`on-message-string`/`on-message-data`/`on-buffered-amount-low` + `notify::ready-state`), `PromiseBridge` (wraps `Gst.Promise.new_with_change_func`). Captures signals on C side, re-emits via `GLib.Idle.add()` on the GLib main context — makes webrtcbin's streaming-thread callbacks safe to handle from JS. Ships as `.so` + `.typelib` prebuild for linux-{x86_64,aarch64} |
@@ -145,7 +145,7 @@ Dispatch: W3C UIEvents. Coords: GTK widget-relative → DOM offsetX/Y/clientX/Y.
 
 ## Build — Rolldown, platform plugins
 
-Targets: **GJS** `--app gjs` (`assert`→`@gjsify/assert`, externals `gi://*`+`cairo`+`system`+`gettext`, `firefox128`) | **Node** `--app node` (`@gjsify/process`→`process`, `node24`) | **Browser** `--app browser` (`esnext`)
+Targets: **GJS** `--app gjs` (`assert`→`@gjsify/assert`, externals `gi://*`+`cairo`+`system`+`gettext`, `firefox140`) | **Node** `--app node` (`@gjsify/process`→`process`, `node24`) | **Browser** `--app browser` (`esnext`)
 
 Engine: **Rolldown** (Vite 8's production bundler). The orchestrator returns a `{ options, plugins }` config bundle that the CLI composes into `rolldown(...)` + `.write()`. Same `gjsify build --app …` surface as before; Rollup-shaped plugins under the hood that also run under Vite for sister GJS apps.
 
@@ -605,19 +605,17 @@ Every impl → A or B. Every ported test → C. Original: `// <Module> for GJS �
 
 ## Constraints
 
-Target: GJS 1.86.0 / SpiderMonkey 128 (ES2024) / esbuild `firefox128` | ESM-only | GNOME libs + standard JS only | Tests pass on both Node + GJS | Do NOT modify `refs/`
+Target: GJS 1.86.0 / SpiderMonkey 140 (ES2024) / Rolldown `firefox140` | ESM-only | GNOME libs + standard JS only | Tests pass on both Node + GJS | Do NOT modify `refs/`
 
 ## JS Feature Availability
 
-### SM128 (GJS 1.84–1.86, current) — ES2024
+### SM140 (GJS 1.86+, current) — ES2024 + extras
 
-**Available:** Object/Map.groupBy | Promise.withResolvers | Set methods(intersection,union,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom) | Array.fromAsync | structuredClone | SharedArrayBuffer | Intl.Segmenter | globalThis | ??/?. | ??=/||=/&&= | top-level await | private/static fields | WeakRef | FinalizationRegistry
+Minimum supported runtime is **GJS 1.86 / SpiderMonkey 140** (Fedora 43+). SM128 (GJS 1.84) is no longer supported.
 
-**NOT available:** Error.captureStackTrace (polyfill: `packages/gjs/utils/src/error.ts`) | Error.stackTraceLimit (typeof guard) | queueMicrotask (use `Promise.resolve().then()`) | Float16Array, Math.f16round() | Iterator helpers | Uint8Array.{fromBase64,toBase64,fromHex,toHex} | RegExp.escape() | Promise.try() | JSON.rawJSON/isRawJSON | Intl.DurationFormat | Math.sumPrecise | Atomics.pause | Error.isError | Temporal | `import...with{type:"json"}`
+**Available:** Object/Map.groupBy | Promise.withResolvers | Set methods(intersection,union,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom) | Array.fromAsync | structuredClone | SharedArrayBuffer | Intl.Segmenter | globalThis | ??/?. | ??=/||=/&&= | top-level await | private/static fields | WeakRef | FinalizationRegistry | **Error.captureStackTrace native** | **Iterator helpers** | **`import...with{type:"json"}`** | **Temporal** (preview) | Float16Array, Math.f16round() | Uint8Array.{fromBase64,toBase64,fromHex,toHex} | RegExp.escape() | Promise.try() | JSON.rawJSON/isRawJSON | Intl.DurationFormat | Math.sumPrecise | Atomics.pause | Error.isError
 
-### SM140 (GJS 1.85.2+/1.87+, upcoming)
-
-All SM128-missing features become available. Notable: Error.captureStackTrace native (drop polyfill) | Temporal | Iterator helpers | `import...with{type:"json"}`
+Polyfills inherited from the SM128 era still load on SM140 (idempotent, no-op when native exists). They will be retired package by package as native SM140 paths are validated.
 
 ## Writing agent context files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 
 * **rolldown-plugin-gjsify:** codeSplitting: false instead of inlineDynamicImports ([5985c7a](https://github.com/gjsify/gjsify/commit/5985c7aa6a580c1cab90310b9d9d9903a6194100))
 
-## [0.4.0-pre](https://github.com/gjsify/gjsify/compare/v0.3.13...v0.4.0-pre) (2026-05-06)
+## [0.4.0-pre](https://github.com/gjsify/gjsify/compare/v0.3.13...v0.4.0-pre) (2026-05-07)
 
 ### ⚠ BREAKING CHANGES
 
+* **runtime:** minimum supported runtime is now **GJS 1.86 / SpiderMonkey 140** (Fedora 43+). GJS 1.84 / SpiderMonkey 128 (Fedora 42) is no longer tested or supported. The Rolldown JS target moves from `firefox128` to `firefox140` so SM140-only language features (Iterator helpers, `Error.captureStackTrace` native, `import...with{type:"json"}`, Temporal preview, …) are emitted unchanged. Consumer projects pinning `firefox128` in `.gjsifyrc.js` should bump to `firefox140`. CI matrix dropped Fedora 42; Fedora 43 (GJS 1.86) and Fedora 44 (GJS 1.88) remain.
 * **bundler:** the build engine has been swapped from esbuild to **Rolldown** (Vite 8's production bundler). The CLI flag surface is preserved exactly (`gjsify build --app gjs|node|browser --globals auto …`), but `.gjsifyrc.js`'s `esbuild?: BuildOptions` field is renamed to `bundler?: RolldownOptions`. Setting the old `esbuild` field still works for one release (deprecation warning + key remap); drop in 0.5.0. The 6 esbuild-plugin packages are deleted — replaced by `@gjsify/{rolldown-plugin-gjsify, rolldown-plugin-deepkit, rolldown-plugin-pnp, vite-plugin-blueprint, vite-plugin-gettext}`. The new plugins are Rollup-shaped, so the same packages run under both `gjsify build` and Vite (sister GJS apps).
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ Every test runs on both Node.js and GJS. Node.js validates test correctness; GJS
 
 ## Target Environment
 
-- GJS 1.84+ (SpiderMonkey 128 / ES2024)
+- GJS 1.86+ (SpiderMonkey 140 / ES2024)
 - Node.js 24.x (for test validation)
-- Rolldown target: `firefox128`
+- Rolldown target: `firefox140`
 - ESM-only, TypeScript 6.x
 
 ## License

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,7 +17,7 @@
 
 ## Summary
 
-gjsify implements Node.js, Web Standard, and DOM APIs for GJS (GNOME JavaScript / SpiderMonkey 128).
+gjsify implements Node.js, Web Standard, and DOM APIs for GJS (GNOME JavaScript / SpiderMonkey 140).
 The project comprises **43 Node.js packages** (+1 meta), **19 Web API packages** (+1 meta), **8 DOM/bridge packages**, **4 GJS infrastructure packages**, and **9 build/infra tools**.
 
 | Category | Total | Full | Partial | Stub |
@@ -33,7 +33,7 @@ The project comprises **43 Node.js packages** (+1 meta), **19 Web API packages**
 | Build/Infra Tools | 9 | 9 | — | — |
 | Integration test suites | 4 | 4 (webtorrent, socket.io, streamx, autobahn) | — | — |
 
-**Test coverage:** 10,570+ test cases in 112+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 42/43). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
+**Test coverage:** 10,570+ test cases in 112+ spec files (each test runs on both Node.js and GJS). CI via GitHub Actions (Node.js 24.x + GJS on Fedora 43/44 — minimum supported runtime: GJS 1.86 / SpiderMonkey 140). Integration suites (`yarn test:integration`) are opt-in and exercise curated upstream tests from webtorrent / socket.io / streamx, plus the Autobahn fuzzingserver for RFC 6455 compliance.
 
 ---
 
@@ -135,7 +135,7 @@ All 20 packages have real implementations (plus 1 meta). New in this cycle: `@gj
 | **webrtc** | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | 302 (4 specs) | **Phase 1–4 — Data Channel + Media + Stats & Advanced.** RTCPeerConnection (offer/answer, ICE trickle, STUN/TURN config, addTransceiver, addTrack, removeTrack, getStats, restartIce, setConfiguration), RTCDataChannel (string + binary send/receive, bufferedAmount, binaryType), RTCRtpSender (track, getParameters/setParameters, replaceTrack, getCapabilities, getStats delegation), RTCRtpReceiver (track with muted→unmuted via ReceiverBridge, jitterBufferTarget, getStats delegation), RTCRtpTransceiver (mid, direction, stop, setCodecPreferences), MediaStream, MediaStreamTrack (GStreamer source integration, enabled→valve), getUserMedia (pipewiresrc/pulsesrc/v4l2src fallback), MediaDevices, **RTCDTMFSender** (spec-compliant tone/duration/gap, `tonechange` event), **RTCCertificate** (generateCertificate, W3C expiry), **RTCDtlsTransport / RTCIceTransport / RTCSctpTransport** (thin proxies), **RTCStatsReport** (GstStructure → W3C camelCase conversion via `gst-stats-parser.ts`). Outgoing pipeline: source→valve→convert→encode(opus/vp8)→payloader→capsfilter→webrtcbin. End-to-end bidirectional audio verified. Registers via `@gjsify/webrtc/register` (granular subpaths) — `--globals auto` picks them up. Requires GStreamer ≥ 1.20 with gst-plugins-bad + libnice-gstreamer. |
 | **webrtc-native** | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | — | Vala/GObject library consumed by `@gjsify/webrtc`. Exposes three main-thread signal bridges: `WebrtcbinBridge` (wraps webrtcbin's `on-negotiation-needed` / `on-ice-candidate` / `on-data-channel` + `notify::*-state`), `DataChannelBridge` (wraps GstWebRTCDataChannel's `on-open` / `on-close` / `on-error` / `on-message-string` / `on-message-data` / `on-buffered-amount-low` + `notify::ready-state`), `PromiseBridge` (wraps `Gst.Promise.new_with_change_func`). Each bridge connects on the C side (never invokes JS on the streaming thread) and re-emits via `GLib.Idle.add()` on the main context. Ships as prebuilt `.so` + `.typelib` in `prebuilds/linux-{x86_64,aarch64,ppc64,s390x,riscv64}/`; CI (`.github/workflows/prebuilds.yml`) rebuilds on Vala source changes (native runners for x86_64/aarch64; QEMU via `uraimo/run-on-arch-action` for ppc64/s390x/riscv64). |
 | **webstorage** | — | 41 | Storage, localStorage, sessionStorage (W3C Web Storage) |
-| **webassembly** | — | 15 | WebAssembly Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey 128's working synchronous `new WebAssembly.Module(buffer)` / `new WebAssembly.Instance(module, imports)` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` whenever the bundle references `WebAssembly.<method>` (via new `METHOD_MARKERS` in `detect-free-globals.ts`). |
+| **webassembly** | — | 15 | WebAssembly Promise-API polyfill — `compile`, `compileStreaming`, `instantiate`, `instantiateStreaming`, `validate` wrap SpiderMonkey's working synchronous `new WebAssembly.Module(buffer)` / `new WebAssembly.Instance(module, imports)` constructors. Granular `/register/promise` subpath. Auto-injected by `--globals auto` whenever the bundle references `WebAssembly.<method>` (via new `METHOD_MARKERS` in `detect-free-globals.ts`). |
 
 ### WebRTC Status
 

--- a/packages/gjs/utils/src/structured-clone.ts
+++ b/packages/gjs/utils/src/structured-clone.ts
@@ -1,7 +1,7 @@
 // structuredClone polyfill for GJS
 // Reference: HTML Living Standard §2.7.1 StructuredSerializeInternal
 // Reference: refs/deno/ext/web/02_structured_clone.js, refs/ungap-structured-clone/
-// Reimplemented for GJS using standard JavaScript (SpiderMonkey 128)
+// Reimplemented for GJS using standard JavaScript (SpiderMonkey 140)
 
 const { toString } = Object.prototype;
 

--- a/packages/infra/rolldown-plugin-gjsify/src/app/gjs.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/gjs.ts
@@ -2,7 +2,7 @@
 //
 // Mirrors the esbuild predecessor's `setupForGjs` exactly in terms of the
 // effective build behaviour: same externals, same alias map, same target
-// (firefox128 for JS, firefox60 for CSS), same console-shim injection,
+// (firefox140 for JS, firefox60 for CSS), same console-shim injection,
 // same process-stub banner, same `random-access-file` fs-backed-fallback.
 //
 // Returns a partial `RolldownOptions` template plus the plugin array the
@@ -111,8 +111,8 @@ export const setupForGjs = async (input: GjsFactoryInput): Promise<GjsBuildConfi
             conditionNames: format === 'esm' ? ['browser', 'import'] : ['browser', 'require', 'import'],
         },
         transform: {
-            // Compile target: GJS 1.86 / SpiderMonkey 128 ≈ firefox128.
-            target: 'firefox128',
+            // Compile target: GJS 1.86 / SpiderMonkey 140 ≈ firefox140.
+            target: 'firefox140',
             define: {
                 global: 'globalThis',
                 window: 'globalThis',

--- a/packages/node/globals/src/register/timers.ts
+++ b/packages/node/globals/src/register/timers.ts
@@ -64,9 +64,7 @@ class GjsifyTimeout {
         // introspection wraps it as 3-arg `(priority, interval, function)`
         // (notify is auto-managed). Passing an explicit `null` triggers
         // `Too many arguments to function GLib.timeout_add: expected 3,
-        // got 4` warnings on every scheduled tick — quiet on GJS 1.86+,
-        // but spammed by GJS 1.84 (Fedora 42), where the warning hot path
-        // slows the test runner enough to push 5-second timeouts over.
+        // got 4` warnings on every scheduled tick under GJS 1.86+.
         // Drop the `null` (cast away the typing-vs-runtime divergence).
         const timeoutAdd = GLib.timeout_add.bind(GLib) as unknown as (
             priority: number,

--- a/packages/node/perf_hooks/src/index.ts
+++ b/packages/node/perf_hooks/src/index.ts
@@ -1,5 +1,5 @@
 // Node.js perf_hooks module for GJS
-// Wraps the Web Performance API available in SpiderMonkey 128
+// Wraps the Web Performance API available in SpiderMonkey 140
 // Reference: Node.js lib/perf_hooks.js
 
 // Entry types for the GLib-based performance shim

--- a/packages/web/webassembly/src/index.ts
+++ b/packages/web/webassembly/src/index.ts
@@ -3,7 +3,7 @@
 // Reference: WebAssembly JS API (https://webassembly.github.io/spec/js-api/)
 // Reimplemented for GJS using SpiderMonkey 128+'s synchronous WebAssembly.{Module,Instance}.
 //
-// SpiderMonkey 128 (GJS 1.86) ships:
+// SpiderMonkey 140 (GJS 1.86) ships:
 //   - WebAssembly global object                 ✓
 //   - new WebAssembly.Module(buffer)            ✓ synchronous compile
 //   - new WebAssembly.Instance(module, imports) ✓ synchronous instantiate

--- a/packages/web/webassembly/src/register/promise.ts
+++ b/packages/web/webassembly/src/register/promise.ts
@@ -1,7 +1,7 @@
 // Side-effect module: replace GJS's stub WebAssembly Promise APIs with
 // polyfills wrapping the synchronous constructors.
 //
-// SpiderMonkey 128 (GJS 1.86) exposes WebAssembly.{compile,compileStreaming,
+// SpiderMonkey 140 (GJS 1.86) exposes WebAssembly.{compile,compileStreaming,
 // instantiate,instantiateStreaming,validate} as `function` typeof values
 // that throw `Error: WebAssembly Promise APIs not supported in this runtime.`
 // at first call. The synchronous constructors `new WebAssembly.Module(buffer)`

--- a/tests/browser/playwright.config.ts
+++ b/tests/browser/playwright.config.ts
@@ -18,8 +18,9 @@ export default defineConfig({
         baseURL: `http://localhost:${PORT}`,
         trace: 'on-first-retry',
     },
-    // Firefox is the primary browser: GJS and Firefox both use SpiderMonkey (SM128),
-    // so these tests directly validate the same engine behavior as GJS.
+    // Firefox is the primary browser: GJS and Firefox both use SpiderMonkey (SM140
+    // for GJS 1.86+; Firefox tracks the latest), so these tests directly validate
+    // the same engine behavior as GJS.
     projects: [
         {
             name: 'firefox',

--- a/tests/integration/ts-for-gir/package.json
+++ b/tests/integration/ts-for-gir/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gjsify/integration-ts-for-gir",
-    "description": "Integration tests: ts-for-gir packages on GJS and Node. Phase 1 covers @gi.ts/parser against gjsify's own Vala-generated GIR fixtures (validates fast-xml-parser on SpiderMonkey 128).",
+    "description": "Integration tests: ts-for-gir packages on GJS and Node. Phase 1 covers @gi.ts/parser against gjsify's own Vala-generated GIR fixtures (validates fast-xml-parser on SpiderMonkey 140).",
     "type": "module",
     "private": true,
     "engines": {

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -55,7 +55,7 @@ npx @gjsify/cli build src/index.ts --outfile dist/index.js
 | `--define` | `KEY=VALUE`[] | `[]` | Bundler `define` pass-through. VALUE is a JS expression — string literals must be JSON-quoted (`--define VERSION='"1.2.3"'`). Repeatable. Merged with built-in defines like `global: 'globalThis'`. |
 | `--alias` | `FROM=TO`[] | `[]` | Layered on top of the built-in alias map. Useful for stubbing heavy deps (`--alias typedoc=@gjsify/empty`). Repeatable. |
 
-For `--app gjs`, the target is `firefox128` (SpiderMonkey 128) and `gi://*`, `cairo`, `system` and `gettext` are externalised. For `--app node`, the target is `node24`.
+For `--app gjs`, the target is `firefox140` (SpiderMonkey 140) and `gi://*`, `cairo`, `system` and `gettext` are externalised. For `--app node`, the target is `node24`.
 
 </details>
 

--- a/website/src/content/docs/contributing/architecture.md
+++ b/website/src/content/docs/contributing/architecture.md
@@ -25,7 +25,7 @@ gjsify/
 
 GJSify uses **Rolldown** (Vite 8's production bundler) with platform-specific plugins to produce different bundles from the same source:
 
-- **GJS build** (`gjsify build --app gjs`): Aliases `node:*` and Web API imports to `@gjsify/*`, externalises `gi://*`, `cairo`, `system` and `gettext`. Target: `firefox128`.
+- **GJS build** (`gjsify build --app gjs`): Aliases `node:*` and Web API imports to `@gjsify/*`, externalises `gi://*`, `cairo`, `system` and `gettext`. Target: `firefox140`.
 - **Node build** (`gjsify build --app node`): Aliases `@gjsify/process` → `process` and maps aliased Web packages to their Node equivalents. Target: `node24`.
 - **Browser build** (`gjsify build --app browser`): Standard browser target. Target: `esnext`.
 

--- a/website/src/content/docs/contributing/development-setup.md
+++ b/website/src/content/docs/contributing/development-setup.md
@@ -7,7 +7,7 @@ This page is for **contributors** working on the GJSify monorepo itself. If you 
 
 ## Prerequisites
 
-- **GJS** 1.84+ (GNOME 46+)
+- **GJS** 1.86+ (GNOME 49+)
 - **Node.js** 24+
 - **Yarn** 4.x (via Corepack)
 - GNOME development libraries: `glib2-devel`, `gobject-introspection-devel`, `gtk4-devel`, `libsoup3-devel`, `vala`, `blueprint-compiler`

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -19,7 +19,7 @@ That's it — a GTK 4 window running your TypeScript, natively on Linux.
 
 You need a few system packages:
 
-- **GJS** 1.84+ — the GNOME JavaScript runtime
+- **GJS** 1.86+ — the GNOME JavaScript runtime (SpiderMonkey 140)
 - **GTK 4** — the UI toolkit
 - **Node.js** 24+ — build time only (for `npm`/`npx`)
 - **libsoup3** — HTTP, WebSocket and `fetch` at runtime

--- a/website/src/content/docs/guides/dlx-packaging.md
+++ b/website/src/content/docs/guides/dlx-packaging.md
@@ -148,7 +148,7 @@ You can split the config across both — `package.json#gjsify` stays minimal (`b
 export default {
   bundler: {
     output: { file: 'dist/gjs.js' },
-    transform: { target: 'firefox128' },
+    transform: { target: 'firefox140' },
   },
 };
 ```

--- a/website/src/content/docs/how-it-works.md
+++ b/website/src/content/docs/how-it-works.md
@@ -32,7 +32,7 @@ Two things follow from this:
 - **You do not install `@gjsify/*` packages yourself.** The GJSify CLI pulls them in on demand and the plugin resolves the aliases during the build.
 - **The bare specifier `import fs from 'node:fs'` is the canonical form.** No GJSify-specific imports leak into your source code, so the same file can be type-checked with `@types/node` and shipped to GJS or Node.js depending on the `--app` target.
 
-The GJS build targets `firefox128` (SpiderMonkey 128, shipped with GJS 1.86) and externalises `gi://*`, `cairo`, `system` and `gettext` — those are resolved by the GJS runtime itself.
+The GJS build targets `firefox140` (SpiderMonkey 140, shipped with GJS 1.86) and externalises `gi://*`, `cairo`, `system` and `gettext` — those are resolved by the GJS runtime itself.
 
 ## Automatic globals detection via `--globals auto`
 


### PR DESCRIPTION
## Summary

- Raises the minimum supported runtime from **GJS 1.84 / SpiderMonkey 128** to **GJS 1.86 / SpiderMonkey 140** (Fedora 43+).
- Drops the **Fedora 42** CI job (GJS 1.84). Matrix is now Fedora 43 (GJS 1.86 / SM 140) + Fedora 44 (GJS 1.88 / SM 140).
- Updates the Rolldown `--app gjs` JS target from `firefox128` to `firefox140` so SM140-only language features land in user bundles unchanged: native `Error.captureStackTrace`, Iterator helpers, `import...with{type:"json"}`, Temporal preview, …
- Refreshes docs (README, AGENTS.md, STATUS.md, getting-started, development-setup, how-it-works, cli-reference, architecture, dlx-packaging) and the JS Feature Availability matrix.

## Why

GJS 1.86 (GNOME 49, Fedora 43) is now the oldest GNOME release we want to validate against. SM140 lands native versions of features we currently polyfill (e.g. `Error.captureStackTrace`) and unlocks features that can't be polyfilled (Iterator helpers, JSON modules, Temporal). Keeping the SM128 floor would prevent us from emitting that bytecode.

## Breaking changes

- Consumer projects pinning `firefox128` in `.gjsifyrc.js` should bump to `firefox140`.
- Anyone running `gjsify`-built bundles on GJS 1.84 / Fedora 42 should upgrade to GJS 1.86+.
- The `@gjsify/node-globals` 4-arg `GLib.timeout_add` workaround stays — the typing-vs-runtime divergence still emits warnings on 1.86+ (Fedora-42-specific rationale removed from the comment).

## Test plan

- [ ] CI matrix runs cleanly on Fedora 43 + Fedora 44 (Node 24 + GJS).
- [ ] `yarn build` produces working `--app gjs` bundles with `target: firefox140`.
- [ ] `yarn check` + full `yarn test` pass on both runners.
- [ ] Browser tests still green under Firefox.
- [ ] Integration suites (`yarn test:integration`) opt-in.

Closes the "drop Fedora 42 / SM128 floor" task in the project memory.