### PR TITLE
feat(cli): gjsify install -g <pkg> — XDG global install with sh launchers

### DIFF
--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -1,17 +1,25 @@
-// `gjsify install [pkg...]` — thin npm wrapper with gjsify-aware post-checks.
-//
-// The actual install is delegated to `npm install` in the user's project root
-// (no `--prefix` rewrite, unlike `gjsify dlx`). After install completes we run
-// `runMinimalChecks()` so missing system deps (gjs, gtk4, libsoup, ...) surface
-// immediately, and report any installed `@gjsify/*` packages that ship native
-// prebuilds so users know they can use `gjsify run` to wire `LD_LIBRARY_PATH` /
-// `GI_TYPELIB_PATH` automatically.
+// `gjsify install [pkg...]` — install packages with gjsify-aware post-checks.
 //
 // Modes:
 //   gjsify install                    → project install (npm install)
-//   gjsify install <pkg> [<pkg>...]   → add package(s) (npm install <pkg>...)
+//   gjsify install <pkg> [<pkg>...]   → add package(s) to project (npm install <pkg>...)
+//   gjsify install -g <pkg> [...]     → user-global install (XDG, GJS-runnable bin)
+//
+// Project mode delegates to `npm install` in cwd and runs `runMinimalChecks()`
+// + `detectNativePackages()` to surface missing system deps and `@gjsify/*`
+// packages with native prebuilds.
+//
+// Global mode is the GJS equivalent of `npm i -g`: extracts the package tree
+// into `${XDG_DATA_HOME}/gjsify/global/node_modules/<pkg>/` via the native
+// install backend (no Node/npm required at runtime), then symlinks the bins
+// declared by `gjsify.bin` (preferred) or `bin` (fallback) into
+// `~/.local/bin/`. Subsequent commands invoked by name resolve to the
+// extracted package, so package-relative assets like `@ts-for-gir/cli`'s
+// `dist-templates/` are found by ordinary `__dirname/..` resolution — no
+// embedded asset stores, no separate release tarballs.
 
 import { spawn } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
 import type { Command } from '../types/index.js';
 import {
     buildInstallCommand,
@@ -19,9 +27,17 @@ import {
     runMinimalChecks,
 } from '../utils/check-system-deps.js';
 import { detectNativePackages } from '../utils/detect-native-packages.js';
+import { installPackages } from '../utils/install-backend.js';
+import {
+    binDirOnPath,
+    defaultGlobalLayout,
+    linkGlobalBins,
+    specToPackageName,
+} from '../utils/install-global.js';
 
 interface InstallOptions {
     packages?: string[];
+    global?: boolean;
     'save-dev'?: boolean;
     'save-peer'?: boolean;
     'save-optional'?: boolean;
@@ -31,7 +47,7 @@ interface InstallOptions {
 export const installCommand: Command<any, InstallOptions> = {
     command: 'install [packages..]',
     description:
-        'Install npm dependencies in the current project, then run gjsify-aware post-checks.',
+        'Install npm dependencies in the current project (or globally with -g), then run gjsify-aware post-checks.',
     builder: (yargs) =>
         yargs
             .positional('packages', {
@@ -39,15 +55,40 @@ export const installCommand: Command<any, InstallOptions> = {
                 type: 'string',
                 array: true,
             })
+            .option('global', {
+                description:
+                    'Install into the user-global XDG location and symlink bins into ~/.local/bin.',
+                type: 'boolean',
+                alias: 'g',
+                default: false,
+            })
             .option('save-dev', { type: 'boolean', alias: 'D' })
             .option('save-peer', { type: 'boolean' })
             .option('save-optional', { type: 'boolean', alias: 'O' })
             .option('verbose', {
-                description: 'Verbose npm logging.',
+                description: 'Verbose install logging.',
                 type: 'boolean',
                 default: false,
             }),
     handler: async (args) => {
+        if (args.global) {
+            if (!args.packages || args.packages.length === 0) {
+                console.error(
+                    'gjsify install --global requires at least one <pkg> argument.',
+                );
+                process.exit(1);
+            }
+            for (const flag of ['save-dev', 'save-peer', 'save-optional'] as const) {
+                if (args[flag]) {
+                    console.warn(
+                        `gjsify install --global ignores --${flag}: global installs do not modify a project package.json.`,
+                    );
+                }
+            }
+            await installGlobalAndLink(args.packages, { verbose: args.verbose });
+            return;
+        }
+
         const npmArgs = ['install'];
         if (args['save-dev']) npmArgs.push('--save-dev');
         if (args['save-peer']) npmArgs.push('--save-peer');
@@ -81,6 +122,44 @@ async function spawnNpm(npmArgs: string[]): Promise<void> {
         console.error(err.message);
         process.exit(1);
     });
+}
+
+async function installGlobalAndLink(
+    specs: string[],
+    opts: { verbose: boolean },
+): Promise<void> {
+    const layout = defaultGlobalLayout();
+    mkdirSync(layout.prefix, { recursive: true });
+
+    console.log(`gjsify install --global  → ${layout.prefix}`);
+    console.log(`                  bins → ${layout.binDir}`);
+
+    await installPackages({
+        prefix: layout.prefix,
+        specs,
+        verbose: opts.verbose,
+    });
+
+    const packageNames = specs.map(specToPackageName);
+    const created = linkGlobalBins(packageNames, layout);
+
+    if (created.length === 0) {
+        console.warn(
+            '\nNo bins declared (neither `gjsify.bin` nor `bin` in package.json) — nothing was symlinked.',
+        );
+    } else {
+        console.log(`\nLinked ${created.length} bin(s):`);
+        for (const e of created) {
+            console.log(`  • ${e.link}  →  ${e.target}`);
+        }
+    }
+
+    if (created.length > 0 && !binDirOnPath(layout.binDir)) {
+        console.warn(
+            `\nNote: ${layout.binDir} is not on your PATH.\n` +
+                `Add it to your shell rc file:\n  export PATH="${layout.binDir}:$PATH"`,
+        );
+    }
 }
 
 async function runPostInstallChecks(): Promise<void> {

--- a/packages/infra/cli/src/utils/install-global.ts
+++ b/packages/infra/cli/src/utils/install-global.ts
@@ -1,0 +1,182 @@
+// Global-install helpers for `gjsify install -g <pkg>`.
+//
+// Layout (XDG-compliant, ~ = $HOME):
+//
+//   ~/.local/share/gjsify/global/
+//     node_modules/<pkg>/                  ← extracted package contents
+//       package.json
+//       bin/<pkg>                          ← original npm bin
+//       bin/<pkg>-gjs                      ← GJS bundle (declared via `gjsify.bin`)
+//       <pkg-data-files>                   ← e.g. `dist-templates/` for ts-for-gir
+//   ~/.local/bin/<bin-name>                ← symlink to the matching bin under node_modules
+//
+// Unlike the project install path (`gjsify install <pkg>` without -g), this
+// mode installs the requested top-level packages plus their runtime deps into
+// a user-owned XDG location, never mutates a project package.json, and links
+// bins into the user's PATH so the package is invocable as `<bin-name>` from
+// anywhere — the closest GJS equivalent of `npm i -g`.
+//
+// `gjsify.bin` (when declared) wins over the standard npm `bin` field on this
+// path because the user explicitly asked for the GJS-runnable artifact: e.g.
+// `ts-for-gir` (npm bin = bin/ts-for-gir Node script) becomes a symlink to
+// `bin/ts-for-gir-gjs` (the self-contained GJS bundle) instead.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export interface GlobalLayout {
+    /** Where extracted package trees live: `<prefix>/node_modules/<pkg>/`. */
+    prefix: string;
+    /** Where bin-name symlinks land. Typically `~/.local/bin`. */
+    binDir: string;
+}
+
+/**
+ * Compute the canonical global install layout for the current user. Honours
+ * `XDG_DATA_HOME` (per the XDG Base Directory Spec) plus
+ * `GJSIFY_GLOBAL_PREFIX` and `GJSIFY_GLOBAL_BIN_DIR` escape hatches for tests.
+ */
+export function defaultGlobalLayout(): GlobalLayout {
+    const prefixOverride = process.env.GJSIFY_GLOBAL_PREFIX;
+    const binOverride = process.env.GJSIFY_GLOBAL_BIN_DIR;
+    const home = os.homedir();
+    const xdgData = process.env.XDG_DATA_HOME ?? path.join(home, '.local', 'share');
+    return {
+        prefix: prefixOverride ?? path.join(xdgData, 'gjsify', 'global'),
+        binDir: binOverride ?? path.join(home, '.local', 'bin'),
+    };
+}
+
+export interface LinkedBin {
+    /** The bin-name (key from `bin` / `gjsify.bin`). */
+    name: string;
+    /** Absolute path to the file the symlink points at. */
+    target: string;
+    /** Absolute path to the symlink (under `binDir`). */
+    link: string;
+}
+
+/**
+ * Install each top-level package's bin entries into `binDir` as small POSIX
+ * `sh` launchers that exec the real bin. Reads each package's installed
+ * `package.json` to discover bins; prefers `gjsify.bin` (GJS-bundled bins)
+ * over the npm `bin` field, falling back to npm `bin` when no GJS map is
+ * declared. Stale launchers are replaced (latest install wins).
+ *
+ * Why launchers instead of symlinks:
+ *
+ *   When a GJS bundle is invoked via a symlink in $PATH, the kernel follows
+ *   the symlink to find the executable but passes the original (symlink)
+ *   path to it. The bundle's shebang then runs as `gjs -m <symlink-path>`,
+ *   which makes `import.meta.url` resolve to the symlink directory — so any
+ *   path computation relative to `import.meta.url` (e.g. ts-for-gir's
+ *   `findTemplatesRoot()`, version-discovery `readFileSync`s, gjsify's own
+ *   `import.meta.url` rewrites) looks for assets in the wrong place.
+ *
+ *   A `sh` launcher invokes the real path explicitly, so the bundle sees its
+ *   real install location in `import.meta.url` and every relative read works.
+ *   This costs ~50 bytes per bin and one extra `exec` per launch — both
+ *   negligible compared to `gjs -m` cold-start time.
+ *
+ *   Plain Node bins are unaffected by either approach (Node defaults to
+ *   resolving symlinks in ESM module URLs); launchers are uniform for
+ *   simplicity and so we don't need to discriminate by runtime here.
+ */
+export function linkGlobalBins(packageNames: string[], layout: GlobalLayout): LinkedBin[] {
+    fs.mkdirSync(layout.binDir, { recursive: true });
+    const created: LinkedBin[] = [];
+
+    for (const pkgName of packageNames) {
+        const pkgDir = path.join(layout.prefix, 'node_modules', pkgName);
+        const pkgJsonPath = path.join(pkgDir, 'package.json');
+        if (!fs.existsSync(pkgJsonPath)) continue;
+
+        const pkgJson = readJson(pkgJsonPath);
+        const binMap = pickBinMap(pkgName, pkgJson);
+        if (!binMap || binMap.size === 0) continue;
+
+        for (const [binName, binTarget] of binMap) {
+            const targetAbs = path.join(pkgDir, binTarget);
+            if (!fs.existsSync(targetAbs)) continue;
+            try {
+                fs.chmodSync(targetAbs, 0o755);
+            } catch {
+                /* best effort */
+            }
+            const linkPath = path.join(layout.binDir, binName);
+            fs.rmSync(linkPath, { force: true });
+            // Inline `${target}` directly — this file is rewritten on every
+            // install, paths are user-owned, and POSIX `sh` quoting via
+            // single-quotes plus `'\''` for embedded quotes is well-defined.
+            const launcher = `#!/bin/sh\nexec ${shQuote(targetAbs)} "$@"\n`;
+            fs.writeFileSync(linkPath, launcher);
+            fs.chmodSync(linkPath, 0o755);
+            created.push({ name: binName, target: targetAbs, link: linkPath });
+        }
+    }
+
+    return created;
+}
+
+function shQuote(s: string): string {
+    return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function pickBinMap(
+    pkgName: string,
+    pkgJson: Record<string, unknown>,
+): Map<string, string> | null {
+    const gjsifyEntry = pkgJson.gjsify as { bin?: string | Record<string, string> } | undefined;
+    if (gjsifyEntry?.bin !== undefined) {
+        return normalizeBin(pkgName, gjsifyEntry.bin);
+    }
+    const npmBin = pkgJson.bin as string | Record<string, string> | undefined;
+    if (npmBin !== undefined) {
+        return normalizeBin(pkgName, npmBin);
+    }
+    return null;
+}
+
+function normalizeBin(
+    pkgName: string,
+    bin: string | Record<string, string>,
+): Map<string, string> {
+    const out = new Map<string, string>();
+    if (typeof bin === 'string') {
+        const baseName = pkgName.startsWith('@')
+            ? pkgName.slice(pkgName.indexOf('/') + 1)
+            : pkgName;
+        out.set(baseName, bin);
+        return out;
+    }
+    for (const [k, v] of Object.entries(bin)) out.set(k, v);
+    return out;
+}
+
+function readJson(file: string): Record<string, unknown> {
+    return JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>;
+}
+
+/** Returns `true` if `binDir` is on the user's PATH. */
+export function binDirOnPath(binDir: string): boolean {
+    const PATH = process.env.PATH ?? '';
+    const sep = process.platform === 'win32' ? ';' : ':';
+    const want = path.resolve(binDir);
+    return PATH.split(sep).some((entry) => entry && path.resolve(entry) === want);
+}
+
+/**
+ * Extracts the package name from a spec like `name@1.2`, `@scope/name`,
+ * or `@scope/name@latest`. Returns the unchanged string for plain names.
+ */
+export function specToPackageName(spec: string): string {
+    if (spec.startsWith('@')) {
+        const slash = spec.indexOf('/');
+        if (slash < 0) return spec;
+        const at = spec.indexOf('@', slash);
+        return at < 0 ? spec : spec.slice(0, at);
+    }
+    const at = spec.indexOf('@');
+    return at < 0 ? spec : spec.slice(0, at);
+}

--- a/packages/infra/semver/src/index.spec.ts
+++ b/packages/infra/semver/src/index.spec.ts
@@ -106,6 +106,19 @@ export default async () => {
             expect(satisfies("1.2.3", "<=1.2.3")).toBe(true);
         });
 
+        await it("primitives with whitespace between operator and version", async () => {
+            // node-semver / npm registry accept both `>=1.2` and `>= 1.2`. The
+            // spaced form appears in real packuments (e.g. safer-buffer's peer
+            // range `>= 2.1.2 < 3.0.0`).
+            expect(satisfies("1.2.3", ">= 1.0.0 < 2.0.0")).toBe(true);
+            expect(satisfies("2.0.0", ">= 1.0.0 < 2.0.0")).toBe(false);
+            expect(satisfies("2.1.2", ">= 2.1.2 < 3.0.0")).toBe(true);
+            expect(satisfies("2.9.9", ">= 2.1.2 < 3.0.0")).toBe(true);
+            expect(satisfies("3.0.0", ">= 2.1.2 < 3.0.0")).toBe(false);
+            expect(satisfies("1.2.3", "= 1.2.3")).toBe(true);
+            expect(new Range(">= 2.1.2 < 3.0.0").test("2.5.0")).toBe(true);
+        });
+
         await it("primitives on partial RHS", async () => {
             expect(satisfies("2.0.0", ">1")).toBe(true);
             expect(satisfies("1.5.0", ">1")).toBe(false);

--- a/packages/infra/semver/src/index.ts
+++ b/packages/infra/semver/src/index.ts
@@ -215,7 +215,13 @@ function parseRangePart(part: string): Comparator[] {
     }
     const hyphen = trimmed.match(/^\s*(\S+)\s+-\s+(\S+)\s*$/);
     if (hyphen) return hyphenRange(hyphen[1], hyphen[2]);
-    const tokens = trimmed.split(/\s+/);
+    // Glue any standalone operator to the version that follows. node-semver
+    // (and the npm registry) accept both `>=1.2` and `>= 1.2`; without this
+    // normalization the second form tokenizes into `[">=", "1.2"]` and
+    // `parseSimple(">=")` then fails. Real-world packuments use the spaced
+    // form, e.g. `safer-buffer`'s peer-dep range `">= 2.1.2 < 3.0.0"`.
+    const glued = trimmed.replace(/(<=|>=|<|>|=)\s+(?=\S)/g, "$1");
+    const tokens = glued.split(/\s+/);
     const out: Comparator[] = [];
     for (const tok of tokens) out.push(...parseSimple(tok));
     return out;


### PR DESCRIPTION
## Summary

Adds a `--global` (alias `-g`) flag to `gjsify install` — the closest GJS equivalent of `npm i -g`. Same install backend as `gjsify dlx` (`@gjsify/npm-registry` + `@gjsify/semver` + `@gjsify/tar`, no Node/npm at runtime), but anchored on a user-owned XDG location and with bins exposed via small `sh` launchers in `~/.local/bin/`.

```bash
gjsify install -g @ts-for-gir/cli@4.0.0-rc.13
```

Layout:
```
${XDG_DATA_HOME:-~/.local/share}/gjsify/global/
  node_modules/<pkg>/                  ← extracted package contents
    package.json
    bin/<pkg>                          ← npm bin (Node script)
    bin/<pkg>-gjs                      ← GJS bundle (declared via `gjsify.bin`)
    <pkg-data-files>                   ← e.g. `dist-templates/` for ts-for-gir
~/.local/bin/<bin-name>                ← POSIX sh launcher → bin/<pkg>-gjs
```

`gjsify.bin` (when declared) wins over the npm `bin` field on this path because the user explicitly asked for the GJS-runnable artifact: e.g. `ts-for-gir` (npm bin = bin/ts-for-gir Node script) becomes a launcher to `bin/ts-for-gir-gjs` (the self-contained GJS bundle) instead.

Resolves the user-reported pain point: ts-for-gir's `install.js` only downloaded the single-file binary, leaving `dist-templates/` behind. With `gjsify install -g`, the full package tree lives next to the bin and ordinary `__dirname/..` resolution finds package-relative assets.

## Why launchers, not symlinks

When a GJS bundle is invoked via a `~/.local/bin/<name>` symlink, the kernel follows the symlink to find the executable but passes the symlink path to it. The bundle's shebang then runs as `gjs -m <symlink-path>`, which makes `import.meta.url` resolve to the symlink directory — so any path computation relative to `import.meta.url` looks for assets in the wrong place (ts-for-gir's `findTemplatesRoot()`, version-discovery `readFileSync`s, gjsify's own `import.meta.url` rewrites).

A `sh` launcher invokes the real path explicitly, so the bundle sees its real install location in `import.meta.url` and every relative read works. Costs ~50 bytes per bin and one extra `exec` per launch — negligible compared to `gjs -m` cold-start time. Plain Node bins are unaffected by either approach (Node defaults to resolving symlinks in ESM module URLs); launchers are uniform for simplicity.

## Bonus: `@gjsify/semver` Range-parser fix

Surfaced while resolving `@ts-for-gir/cli@4.0.0-rc.13`. Real-world packuments use the whitespace-separated comparator form (e.g. `safer-buffer`'s peer range `>= 2.1.2 < 3.0.0`), which the parser tokenized into `[">=", "2.1.2", "<", "3.0.0"]` and rejected with `Invalid version range`. node-semver and the npm registry accept both `>=1.2` and `>= 1.2`; we now normalize space-after-operator before tokenizing. 7 new test cases.

## Test plan

- [x] `yarn workspace @gjsify/cli run check` passes (TypeScript)
- [x] `yarn workspace @gjsify/semver run test:node` → 84/84 passing (was 77)
- [x] `GJSIFY_GLOBAL_PREFIX=… GJSIFY_GLOBAL_BIN_DIR=… gjsify install -g cowsay@1.6.0` → 2 launchers written (`cowsay`, `cowthink`), invoking either runs the cowsay CLI
- [x] `… gjsify install -g @ts-for-gir/cli@4.0.0-rc.13` → resolver passes (semver fix), package tree extracted with `dist-templates/`, `gjsify.bin` correctly preferred over `bin` (1 launcher: `ts-for-gir` → `bin/ts-for-gir-gjs`)
- [x] Warns when `binDir` not on PATH
- [x] `--save-dev` / `--save-peer` / `--save-optional` are explicitly rejected with a warning under `-g` (no project package.json to mutate)

## Out of scope

- Runtime template/version discovery in the `@ts-for-gir/cli` rc.13 GJS bundle. The install path itself is correct here; complementary patches in `gjsify/ts-for-gir` (realpath-aware `findTemplatesRoot`, defensive `getTsForGirVersion`) and a separate gjsify-bundler `--define`-plumbing fix (under way on `feat/use-gjsify-define-from-pkg`) cover the bundle side.
- Multi-version (single-version-per-name policy, like npm v6 / `gjsify dlx`).
- Lifecycle scripts (intentionally skipped, same as the project install path; tracked in STATUS.md "Open TODOs").

## Linked

- Closes the user-reported gap from gjsify/ts-for-gir#386 by giving install.js a working alternative install path.