### PR TITLE
feat(tls): cert-chain, mTLS, SNI server, ALPN, RFC 6125 checkServerIdentity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 ### Features
 
+* **tls (2026-05-09):** Workstream B — promoted `@gjsify/tls` from Partial
+  toward Full. Added: cert-chain extraction in `getPeerCertificate(detailed)`
+  (walks `Gio.TlsCertificate.get_issuer()` recursively, returns Node-shape
+  `{subject, issuer, subjectaltname, valid_from, valid_to, fingerprint,
+  fingerprint256, raw, issuerCertificate}`); full RFC 6125 §6.4.3 hostname
+  matching in `checkServerIdentity` (wildcard prefix/suffix, xn-- A-label
+  exact-match, `*.tld` rejection, IPv4/IPv6, CN fallback, error code
+  `ERR_TLS_CERT_ALTNAME_INVALID`); mTLS — `tls.connect({cert,key})` calls
+  `Gio.TlsConnection.set_certificate()`; `tls.createServer({requestCert,
+  rejectUnauthorized,ca})` validates the client cert against `ca` via
+  `cert.verify()` and sets `Gio.TlsAuthenticationMode.REQUIRED/REQUESTED/
+  NONE` accordingly; SNI server — `addContext(host, ctx)` + `SNICallback`
+  plumbing with RFC 6125 wildcard host-pattern matching (best-effort
+  selection — Gio does not surface the ClientHello server_name extension
+  to JS pre-handshake; documented in STATUS.md "Open TODOs"); ALPN —
+  explicit `ALPNProtocols` via `set_advertised_protocols`,
+  `tlsSocket.alpnProtocol` via `get_negotiated_protocol`; rich
+  `createSecureContext({cert,key,ca,passphrase,ciphers,minVersion,
+  maxVersion})` accepting string, Buffer, Uint8Array, or array thereof —
+  splits CA bundles into individual PEM blocks via regex and parses each
+  through `Gio.TlsCertificate.new_from_pem`, exposes a Node-compat
+  `ctx.context` self-reference; custom `checkServerIdentity` override on
+  `tls.connect`. Two new spec files: `cert.spec.ts` (RFC 6125
+  depth/prefix/IDN edge cases + error.code) and `tls.gjs.spec.ts`
+  (GJS-only Gio.TlsCertificate / TlsServerConnection option plumbing).
+  All 65 `as any` removed from `packages/node/tls/src/index.spec.ts`
+  (replaced by `unknown` + type guards and a `fakeCert()` helper). Test
+  counts: 132 → 169 GJS (Node: 262 incl. Node-strict assertions). Gio
+  gaps that genuinely cannot be filled today (SNI ClientHello selection,
+  OCSP stapling, TLS session resumption, channel binding) tracked in
+  STATUS.md "Open TODOs → TLS gaps that Gio does not surface".
+
 * **worker_threads (2026-05-09):** added `transferList` support to
   `MessagePort.postMessage()` for both `ArrayBuffer` and `MessagePort`
   (Workstream C). ArrayBuffer transfer is zero-copy via SM140

--- a/packages/node/tls/src/cert.spec.ts
+++ b/packages/node/tls/src/cert.spec.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+// Ported from refs/node-test/parallel/test-tls-check-server-identity.js,
+//   refs/node-test/parallel/test-tls-canonical-ip.js,
+//   refs/node-test/parallel/test-tls-checkserveridentity-no-altnames.js.
+// Original: Copyright (c) Node.js contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Focused coverage of RFC 6125 (§6.4.3) hostname matching + getPeerCertificate
+// shape + createSecureContext PEM acceptance. Complements index.spec.ts.
+
+import { describe, it, expect, on } from '@gjsify/unit';
+import {
+  checkServerIdentity,
+  createSecureContext,
+} from 'node:tls';
+import type { PeerCertificate } from 'node:tls';
+
+function fakeCert(parts: Record<string, unknown>): PeerCertificate {
+  return parts as unknown as PeerCertificate;
+}
+
+// Self-signed PEM (cert + key) minted with `openssl req -x509 -newkey rsa:2048
+//   -keyout key.pem -out cert.pem -days 3650 -nodes -subj /CN=test.example`.
+// 2048-bit RSA, SHA256, no SAN. Used only for parser smoke-tests — never
+// trusted as a CA. Inlined so tests stay hermetic (no fixtures).
+const SAMPLE_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIDDzCCAfegAwIBAgIUO9v7luuPxFHsLdVr//dOTh474OQwDQYJKoZIhvcNAQEL
+BQAwFzEVMBMGA1UEAwwMdGVzdC5leGFtcGxlMB4XDTI2MDUwOTA2NDIyMVoXDTM2
+MDUwNjA2NDIyMVowFzEVMBMGA1UEAwwMdGVzdC5leGFtcGxlMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtnMdp3rW+bkeYoW9at2aRt70gub5siMsNOYw
+0obCo1LOkJokEOX2+9kaOUwaCmntcJdU3+JYQe7MGYwI+H9OWxnLRYJUneYB81a8
+CfJ7Uk+5FVNzQQFnYvL0G5NSq2w8K6UwV0jgXXFLEfTZOqdFdVVcwAOgCrc4LbpX
+E+5IflPoIuwBW2brYx/fIyJu2gH0uRG92R5m/3UxOqlVzIerL3YM3UTSepDtyCek
+ooD03UwLl3fYuza2iuMnxJAPshaSwiHbAopnaBSEvKMGHkLyl4zTmaioGXVRObtZ
+XAorC7ujI4F8edcmPRwAaNToHS8cRlGQJjXACfAodwNKWpbHYwIDAQABo1MwUTAd
+BgNVHQ4EFgQULhAoOyRjZxBRF8FlwTySSAXnFo0wHwYDVR0jBBgwFoAULhAoOyRj
+ZxBRF8FlwTySSAXnFo0wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAiePCYXf6PAF/m3SE9PYNLiq+ALeJ+kQgXUYp5S4vsfk2T+XmbtP0uNnTQpsT
+4GaytjMFIQiNO6mHww8SFnrEr9btcNGCg17gyK7T3XukbsXIgOYvYjJboxb6Ww1T
+YFEXqPv55of/I5+UPH88WOYR1JsPE6lR4s3MfaMMRXTIZwpob2sxEfqHfti1DrHV
+nmzZpIvZi3II+gpx6aYE8m3DjgPrxbXw78Ular/VyYAyy9XVFpcl2nrAQgpErZIr
+kweGVVMKE8qMF9SO1/pER4T7A9ZBJol00hMCL+5Rw0Pw4lCLXgGX1J9VyZ+ScLxz
+aNy5t6tyGuGk0sol4dLG8nzHGA==
+-----END CERTIFICATE-----`;
+
+const SAMPLE_KEY_PEM = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC2cx2netb5uR5i
+hb1q3ZpG3vSC5vmyIyw05jDShsKjUs6QmiQQ5fb72Ro5TBoKae1wl1Tf4lhB7swZ
+jAj4f05bGctFglSd5gHzVrwJ8ntST7kVU3NBAWdi8vQbk1KrbDwrpTBXSOBdcUsR
+9Nk6p0V1VVzAA6AKtzgtulcT7kh+U+gi7AFbZutjH98jIm7aAfS5Eb3ZHmb/dTE6
+qVXMh6svdgzdRNJ6kO3IJ6SigPTdTAuXd9i7NraK4yfEkA+yFpLCIdsCimdoFIS8
+owYeQvKXjNOZqKgZdVE5u1lcCisLu6MjgXx51yY9HABo1OgdLxxGUZAmNcAJ8Ch3
+A0palsdjAgMBAAECggEADTZAcBYmjSAWDpjHguT+cAiWXwhU2pm1CmhrVRBD9fz5
+tZT3IAlXHYO2/dRmw/KwKnAUlr9wS4EvlhLPvEotWJsa+JlogT3cgRktz4nLDmBB
+jRH+9AOJaUWIq2dVHDhfq+I8oh8TFREumEoWLpFZ9Hya+9I6lUWq5smdcEI+gHWs
+yWhq4auR2/zkhvgsjLKPK8P2M8tmm8IPecE74NSBZqxoqb4upUHpMTxasAE2UJpK
+0slvxiZtk3LT/rflco04twIqK/KmH7phrPzmoSl+Lp1Zh9y4iNznTQKBdImsGl+g
+9FWL7pdxKjVNGQsrKVvB1A78VhhteAuaebT5MicIwQKBgQDtmYfyrlGoYGkArmNL
+tGBc5afGx/mL/8BGTQfIx4b11OEr+G4hppLh/WGLUksfMfprL0YU3BM+FOsECsY0
+5AJB6oQuSE8vCIS7yCxV00V+I6n2bEMxZkDwdDuF9rHhGODFx4pPz1nJqScAa23T
+48c+hNSBLRHTSuDAi2DcuxLn4QKBgQDElDjmB/kpW50ya2M2hO5LpwMcAlTJ3nPv
+000eTfzdtDNzesvRClYZWGWs7zSkNsf/F+G0tCg4slzvHPkRJN53hHF0Kwug2aj5
+1BPuDbn3EumDO6quykz6S9vZGcPAMuNm+qtkf+42KE5Sqj3NTf6aiu4tEZbH69me
+av1sbfkHwwKBgQC5cb5g1FuZjn4F8RZBDSy09O4pQQVtlpSsigzMUabtklSY7BKR
+IyC7T/dlNTq6w1hPdhs9xrMiHlN72SjwORHl/rNiKD/dVsm6grbP2dEAbbeHROKA
+2O1Qf3fBzFTzemZdF6vFNPJAakytkCutWLe2/RebJuElx+h5f49/WGeeIQKBgQC0
+mcCUharB9ms7kTF7OzF6y5utte6T8A3vvd9SAjBYt1+1rpFmIersKixvbuycGcAw
+eo5gaEuzmxqKi8G/oHHKuCFLquhqBM6bh94vjOjXN8bVTJIJN870/ZCjqmoPQDFv
+wMiJ8oa1tt4OUF2rKwbIkO809L3kOqiaRI1Det2Z5QKBgGp4JS3OqzeIMQbUa8e8
+tOYnML+RFpo2cZ9rCQAQitm/w5P6lAnG9vv4cXAu94RbtITEuGmqEhYDMhSC2i8e
+kjwRLp5R+/pynUdTckRP8buwRSDRlPz3x8GI2Dm0z8fb/uZ8AJK/iITtsOoJtyPx
+fUZ521uRyKXnpzj1HTz5WVp0
+-----END PRIVATE KEY-----`;
+
+export default async () => {
+  await describe('tls — RFC 6125 + cert extraction', async () => {
+
+    // ---------------- RFC 6125 wildcard depth rules ----------------
+    await describe('RFC 6125 wildcard depth', async () => {
+      await it('rejects two-label wildcard *.com', async () => {
+        const err = checkServerIdentity('foo.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:*.com',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+
+      await it('rejects single-label wildcard *', async () => {
+        const err = checkServerIdentity('foo', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:*',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+
+      await it('accepts three-label wildcard *.example.com matching foo.example.com', async () => {
+        const ok = checkServerIdentity('foo.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:*.example.com',
+        }));
+        expect(ok).toBeUndefined();
+      });
+
+      await it('rejects empty wildcard label .x.example.com', async () => {
+        const err = checkServerIdentity('foo.x.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:.x.example.com',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+    });
+
+    // ---------------- RFC 6125 wildcard prefix/suffix ----------------
+    await describe('RFC 6125 wildcard prefix/suffix', async () => {
+      await it('matches f*.example.com against foo.example.com', async () => {
+        const ok = checkServerIdentity('foo.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:f*.example.com',
+        }));
+        expect(ok).toBeUndefined();
+      });
+
+      await it('rejects f*.example.com against bar.example.com', async () => {
+        const err = checkServerIdentity('bar.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:f*.example.com',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+
+      await it('matches *foo.example.com against barfoo.example.com', async () => {
+        const ok = checkServerIdentity('barfoo.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:*foo.example.com',
+        }));
+        expect(ok).toBeUndefined();
+      });
+
+      await it('rejects f*r.example.com against bar.example.com (prefix mismatch)', async () => {
+        const err = checkServerIdentity('bar.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:f*r.example.com',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+    });
+
+    // ---------------- IDN / xn-- handling ----------------
+    await describe('Punycode / IDN', async () => {
+      await it('treats xn-- labels as exact-match (no wildcard expansion)', async () => {
+        // pattern is the punycoded form; hostname must match exactly.
+        const ok = checkServerIdentity('xn--bcher-kva.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:xn--bcher-kva.example.com',
+        }));
+        expect(ok).toBeUndefined();
+      });
+
+      await it('rejects wildcard expansion against xn-- A-label leftmost', async () => {
+        // *xn--bcher-kva matched against bcher-kva: per RFC 6125 the wildcard
+        // is not allowed to expand into A-label content.
+        const err = checkServerIdentity('foo.example.com', fakeCert({
+          subject: {},
+          subjectaltname: 'DNS:xn--*.example.com',
+        }));
+        expect(err instanceof Error).toBe(true);
+      });
+    });
+
+    // ---------------- Error code shape (Node-compat) ----------------
+    await describe('error.code', async () => {
+      await it('returns ERR_TLS_CERT_ALTNAME_INVALID code on mismatch', async () => {
+        const err = checkServerIdentity('a.com', fakeCert({
+          subject: { CN: 'b.com' },
+        }));
+        expect(err instanceof Error).toBe(true);
+        const e = err as { code?: string };
+        // Node: ERR_TLS_CERT_ALTNAME_INVALID. Our impl: same.
+        expect(e.code).toBe('ERR_TLS_CERT_ALTNAME_INVALID');
+      });
+    });
+
+    // ---------------- createSecureContext PEM acceptance ----------------
+    await describe('createSecureContext', async () => {
+      await it('accepts string PEM material (cert + key)', async () => {
+        const ctx = createSecureContext({ cert: SAMPLE_CERT_PEM, key: SAMPLE_KEY_PEM });
+        expect(ctx).toBeDefined();
+      });
+
+      await it('accepts Buffer PEM material', async () => {
+        const Buffer = (globalThis as { Buffer?: { from(s: string): unknown } }).Buffer;
+        if (!Buffer) return;  // skip if Buffer unavailable
+        const ctx = createSecureContext({
+          cert: Buffer.from(SAMPLE_CERT_PEM) as never,
+          key: Buffer.from(SAMPLE_KEY_PEM) as never,
+        });
+        expect(ctx).toBeDefined();
+      });
+
+      await it('accepts array of PEM blocks for ca', async () => {
+        const ctx = createSecureContext({ ca: [SAMPLE_CERT_PEM, SAMPLE_CERT_PEM] });
+        expect(ctx).toBeDefined();
+      });
+
+      await it('returns ctx.context self-reference (Node-compat)', async () => {
+        const ctx = createSecureContext();
+        const ref = (ctx as unknown as { context?: unknown }).context;
+        expect(ref !== undefined).toBe(true);
+      });
+
+      // Our impl preserves the user-supplied options on the SecureContext;
+      // Node does not, so this is a GJS-specific guarantee we lean on for
+      // diagnostics + integration debugging.
+      await on('Gjs', async () => {
+        await it('preserves passed-through options (ciphers/minVersion/maxVersion)', async () => {
+          const ctx = createSecureContext({
+            ciphers: 'TLS_AES_128_GCM_SHA256',
+            minVersion: 'TLSv1.2',
+            maxVersion: 'TLSv1.3',
+          });
+          const o = (ctx as unknown as { options?: { ciphers?: string; minVersion?: string; maxVersion?: string } }).options;
+          expect(o).toBeDefined();
+          expect(o!.ciphers).toBe('TLS_AES_128_GCM_SHA256');
+          expect(o!.minVersion).toBe('TLSv1.2');
+          expect(o!.maxVersion).toBe('TLSv1.3');
+        });
+      });
+    });
+  });
+};

--- a/packages/node/tls/src/index.spec.ts
+++ b/packages/node/tls/src/index.spec.ts
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: MIT
 // Ported from refs/node-test/parallel/test-tls-check-server-identity.js,
-//   test-tls-basic-validations.js, refs/bun/test/js/node/tls/
-// Original: MIT license, Node.js contributors
+//   test-tls-basic-validations.js, refs/bun/test/js/node/tls/.
+// Original: Copyright (c) Node.js contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
 
 import { describe, it, expect } from '@gjsify/unit';
 import tls, {
@@ -15,9 +17,30 @@ import tls, {
   DEFAULT_MAX_VERSION,
   DEFAULT_CIPHERS,
 } from 'node:tls';
+import type { PeerCertificate } from 'node:tls';
 
-// Our implementation exports TLSServer, Node.js exports Server
-const TLSServer = (tls as any).TLSServer || (tls as any).Server;
+// Build a fake PeerCertificate from minimal fields. Lets us drive
+// `checkServerIdentity` from tests without crafting a real DER cert.
+// `@types/node`'s PeerCertificate has many more fields than we expose; the
+// `as unknown as PeerCertificate` keeps the test free of `as any`.
+function fakeCert(parts: Record<string, unknown>): PeerCertificate {
+  return parts as unknown as PeerCertificate;
+}
+
+// Our implementation also exports TLSServer; Node only exports Server.
+const tlsRecord = tls as unknown as Record<string, unknown>;
+const TLSServer = (tlsRecord.TLSServer ?? tlsRecord.Server) as new (
+  options?: unknown,
+  secureConnectionListener?: unknown,
+) => {
+  on: (ev: string, cb: (...a: unknown[]) => void) => unknown;
+  emit: (ev: string, ...a: unknown[]) => boolean;
+  once: (ev: string, cb: (...a: unknown[]) => void) => unknown;
+  addContext: (host: string, ctx: unknown) => void;
+  listen: (...a: unknown[]) => unknown;
+  close: (cb?: () => void) => unknown;
+  address: () => unknown;
+};
 
 export default async () => {
   await describe('tls', async () => {
@@ -93,77 +116,77 @@ export default async () => {
     // ===================== TLSSocket =====================
     await describe('TLSSocket', async () => {
       await it('should be constructable', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(socket).toBeDefined();
       });
 
       await it('should have encrypted property set to true', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(socket.encrypted).toBe(true);
       });
 
       await it('should have authorized property as boolean', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.authorized).toBe('boolean');
       });
 
       await it('authorized should default to false', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(socket.authorized).toBe(false);
       });
 
       await it('should have getPeerCertificate method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.getPeerCertificate).toBe('function');
       });
 
       await it('should have getProtocol method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.getProtocol).toBe('function');
       });
 
       await it('should have getCipher method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.getCipher).toBe('function');
       });
 
       await it('should have alpnProtocol property', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         // Node.js: alpnProtocol is a property (null or string), our impl: false or string
-        const val = (socket as any).alpnProtocol;
+        const val = socket.alpnProtocol;
         expect(val === false || val === null || typeof val === 'string').toBe(true);
       });
 
       await it('getPeerCertificate should return object when not connected', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         const cert = socket.getPeerCertificate();
         expect(typeof cert).toBe('object');
       });
 
       await it('getProtocol should return null when not connected', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         const proto = socket.getProtocol();
         expect(proto === null || typeof proto === 'string').toBe(true);
       });
 
       await it('getCipher should return null when not connected', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         const cipher = socket.getCipher();
         expect(cipher === null || cipher === undefined || typeof cipher === 'object').toBe(true);
       });
 
       await it('alpnProtocol should default to false', async () => {
-        const socket = new TLSSocket(undefined as any);
-        expect((socket as any).alpnProtocol === false || (socket as any).alpnProtocol === null).toBe(true);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+        expect(socket.alpnProtocol === false || socket.alpnProtocol === null).toBe(true);
       });
 
       await it('authorizationError should be undefined initially', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(socket.authorizationError === undefined || socket.authorizationError === null).toBe(true);
       });
 
       await it('should extend Socket (EventEmitter)', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.on).toBe('function');
         expect(typeof socket.emit).toBe('function');
         expect(typeof socket.once).toBe('function');
@@ -171,17 +194,17 @@ export default async () => {
       });
 
       await it('should have destroy method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.destroy).toBe('function');
       });
 
       await it('should have write method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.write).toBe('function');
       });
 
       await it('should have end method', async () => {
-        const socket = new TLSSocket(undefined as any);
+        const socket = new TLSSocket(undefined as unknown as import("net").Socket);
         expect(typeof socket.end).toBe('function');
       });
     });
@@ -259,7 +282,7 @@ export default async () => {
 
       await it('should have context property', async () => {
         const ctx = createSecureContext();
-        expect(ctx.context !== undefined).toBe(true);
+        expect((ctx as { context?: unknown }).context !== undefined).toBe(true);
       });
 
       await it('should return same type for repeated calls', async () => {
@@ -330,53 +353,53 @@ export default async () => {
       // --- CN matching ---
       await describe('CN matching', async () => {
         await it('should return undefined for exact CN match', async () => {
-          const result = checkServerIdentity('a.com', { subject: { CN: 'a.com' } } as any);
+          const result = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'a.com' } }));
           expect(result).toBeUndefined();
         });
 
         await it('should match CN case-insensitively', async () => {
-          const result = checkServerIdentity('a.com', { subject: { CN: 'A.COM' } } as any);
+          const result = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'A.COM' } }));
           expect(result).toBeUndefined();
         });
 
         await it('should return error for non-matching CN', async () => {
-          const err = checkServerIdentity('a.com', { subject: { CN: 'b.com' } } as any);
+          const err = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'b.com' } }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle trailing-dot FQDN in hostname', async () => {
-          const result = checkServerIdentity('a.com.', { subject: { CN: 'a.com' } } as any);
+          const result = checkServerIdentity('a.com.', fakeCert({ subject: { CN: 'a.com' } }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle trailing-dot FQDN in CN', async () => {
-          const result = checkServerIdentity('a.com', { subject: { CN: 'a.com.' } } as any);
+          const result = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'a.com.' } }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle trailing dots on both sides', async () => {
-          const result = checkServerIdentity('a.com.', { subject: { CN: 'a.com.' } } as any);
+          const result = checkServerIdentity('a.com.', fakeCert({ subject: { CN: 'a.com.' } }));
           expect(result).toBeUndefined();
         });
 
         await it('should match array CN values', async () => {
-          const result = checkServerIdentity('b.com', {
+          const result = checkServerIdentity('b.com', fakeCert({
             subject: { CN: ['a.com', 'b.com'] },
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should fail when hostname not in CN array', async () => {
-          const err = checkServerIdentity('c.com', {
+          const err = checkServerIdentity('c.com', fakeCert({
             subject: { CN: ['a.com', 'b.com'] },
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle single-label hostname with single-label CN', async () => {
-          const result = checkServerIdentity('localhost', {
+          const result = checkServerIdentity('localhost', fakeCert({
             subject: { CN: 'localhost' },
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
       });
@@ -384,54 +407,54 @@ export default async () => {
       // --- Wildcard matching ---
       await describe('wildcard matching', async () => {
         await it('should match *.example.com against sub.example.com', async () => {
-          const result = checkServerIdentity('sub.example.com', {
+          const result = checkServerIdentity('sub.example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should NOT match *.example.com against nested.sub.example.com', async () => {
-          const err = checkServerIdentity('nested.sub.example.com', {
+          const err = checkServerIdentity('nested.sub.example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should NOT match *.example.com against example.com itself', async () => {
-          const err = checkServerIdentity('example.com', {
+          const err = checkServerIdentity('example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should match wildcard CN when no SANs present', async () => {
-          const result = checkServerIdentity('foo.example.com', {
+          const result = checkServerIdentity('foo.example.com', fakeCert({
             subject: { CN: '*.example.com' },
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('wildcard CN should NOT match two-level deep', async () => {
-          const err = checkServerIdentity('a.b.example.com', {
+          const err = checkServerIdentity('a.b.example.com', fakeCert({
             subject: { CN: '*.example.com' },
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should match wildcard with different subdomains', async () => {
-          const result1 = checkServerIdentity('foo.example.com', {
+          const result1 = checkServerIdentity('foo.example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(result1).toBeUndefined();
 
-          const result2 = checkServerIdentity('bar.example.com', {
+          const result2 = checkServerIdentity('bar.example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(result2).toBeUndefined();
         });
       });
@@ -439,59 +462,59 @@ export default async () => {
       // --- DNS SAN matching ---
       await describe('DNS SAN matching', async () => {
         await it('should match hostname in DNS SAN', async () => {
-          const result = checkServerIdentity('foo.example.com', {
+          const result = checkServerIdentity('foo.example.com', fakeCert({
             subject: { CN: 'wrong.com' },
             subjectaltname: 'DNS:foo.example.com',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('SAN takes precedence over CN', async () => {
           // When SANs are present, CN should be ignored
-          const err = checkServerIdentity('wrong.com', {
+          const err = checkServerIdentity('wrong.com', fakeCert({
             subject: { CN: 'wrong.com' },
             subjectaltname: 'DNS:right.com',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle multiple DNS SANs', async () => {
-          const result = checkServerIdentity('b.com', {
+          const result = checkServerIdentity('b.com', fakeCert({
             subject: { CN: 'a.com' },
             subjectaltname: 'DNS:a.com, DNS:b.com',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should fail when hostname not in any DNS SAN', async () => {
-          const err = checkServerIdentity('c.com', {
+          const err = checkServerIdentity('c.com', fakeCert({
             subject: { CN: 'c.com' },
             subjectaltname: 'DNS:a.com, DNS:b.com',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should match wildcard DNS SAN', async () => {
-          const result = checkServerIdentity('bar.example.com', {
+          const result = checkServerIdentity('bar.example.com', fakeCert({
             subject: { CN: 'wrong.com' },
             subjectaltname: 'DNS:*.example.com',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle mixed DNS and IP SANs', async () => {
-          const result = checkServerIdentity('example.com', {
+          const result = checkServerIdentity('example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:example.com, IP Address:1.2.3.4',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle DNS SAN with trailing whitespace', async () => {
-          const result = checkServerIdentity('example.com', {
+          const result = checkServerIdentity('example.com', fakeCert({
             subject: {},
             subjectaltname: 'DNS:example.com ',
-          } as any);
+          }));
           // May or may not match depending on trimming
           expect(result === undefined || result instanceof Error).toBe(true);
         });
@@ -500,57 +523,57 @@ export default async () => {
       // --- IP address matching ---
       await describe('IP address matching', async () => {
         await it('should match IPv4 in IP Address SAN', async () => {
-          const result = checkServerIdentity('8.8.8.8', {
+          const result = checkServerIdentity('8.8.8.8', fakeCert({
             subject: { CN: '8.8.8.8' },
             subjectaltname: 'IP Address:8.8.8.8',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should fail IPv4 not in IP Address SAN', async () => {
-          const err = checkServerIdentity('8.8.4.4', {
+          const err = checkServerIdentity('8.8.4.4', fakeCert({
             subject: { CN: '8.8.4.4' },
             subjectaltname: 'IP Address:8.8.8.8',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should fail IPv4 with only CN (no SAN IP entry)', async () => {
-          const err = checkServerIdentity('8.8.8.8', {
+          const err = checkServerIdentity('8.8.8.8', fakeCert({
             subject: { CN: '8.8.8.8' },
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should match multiple IP addresses in SAN', async () => {
-          const result = checkServerIdentity('1.2.3.4', {
+          const result = checkServerIdentity('1.2.3.4', fakeCert({
             subject: {},
             subjectaltname: 'IP Address:1.2.3.4, IP Address:5.6.7.8',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should match second IP in SAN', async () => {
-          const result = checkServerIdentity('5.6.7.8', {
+          const result = checkServerIdentity('5.6.7.8', fakeCert({
             subject: {},
             subjectaltname: 'IP Address:1.2.3.4, IP Address:5.6.7.8',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle IPv6 in IP Address SAN', async () => {
-          const result = checkServerIdentity('::1', {
+          const result = checkServerIdentity('::1', fakeCert({
             subject: {},
             subjectaltname: 'IP Address:::1',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should fail IPv4 in DNS SAN (IP should use IP Address SAN)', async () => {
-          const err = checkServerIdentity('1.2.3.4', {
+          const err = checkServerIdentity('1.2.3.4', fakeCert({
             subject: {},
             subjectaltname: 'DNS:1.2.3.4',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
       });
@@ -558,33 +581,33 @@ export default async () => {
       // --- Error object properties ---
       await describe('error properties', async () => {
         await it('should have reason property on error', async () => {
-          const err = checkServerIdentity('a.com', { subject: { CN: 'b.com' } } as any) as any;
+          const err = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'b.com' } }));
           expect(err instanceof Error).toBe(true);
-          expect(typeof err.reason).toBe('string');
+          expect(typeof (err as { reason?: string }).reason).toBe('string');
         });
 
         await it('should have host property on error', async () => {
-          const err = checkServerIdentity('a.com', { subject: { CN: 'b.com' } } as any) as any;
-          expect(err.host).toBe('a.com');
+          const err = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'b.com' } }));
+          expect((err as { host?: string }).host).toBe('a.com');
         });
 
         await it('should have cert property on error', async () => {
-          const cert = { subject: { CN: 'b.com' } } as any;
-          const err = checkServerIdentity('a.com', cert) as any;
-          expect(err.cert).toBe(cert);
+          const cert = fakeCert({ subject: { CN: 'b.com' } });
+          const err = checkServerIdentity('a.com', cert);
+          expect((err as { cert?: unknown } | undefined)?.cert).toBe(cert);
         });
 
         await it('error message should contain hostname for CN mismatch', async () => {
-          const err = checkServerIdentity('a.com', { subject: { CN: 'b.com' } } as any);
+          const err = checkServerIdentity('a.com', fakeCert({ subject: { CN: 'b.com' } }));
           expect(err instanceof Error).toBe(true);
           expect((err as Error).message).toContain('a.com');
         });
 
         await it('error message should contain IP for IP mismatch', async () => {
-          const err = checkServerIdentity('8.8.8.8', {
+          const err = checkServerIdentity('8.8.8.8', fakeCert({
             subject: {},
             subjectaltname: 'IP Address:1.2.3.4',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
           expect((err as Error).message).toContain('8.8.8.8');
         });
@@ -593,64 +616,64 @@ export default async () => {
       // --- Edge cases ---
       await describe('edge cases', async () => {
         await it('should return error when cert has no subject and no altnames', async () => {
-          const err = checkServerIdentity('a.com', {} as any);
+          const err = checkServerIdentity('a.com', fakeCert({}));
           expect(err instanceof Error).toBe(true);
           expect((err as Error).message).toContain('DNS');
         });
 
         await it('should handle false-y host values', async () => {
-          const err = checkServerIdentity(false as unknown as string, {
+          const err = checkServerIdentity(false as unknown as string, fakeCert({
             subject: { CN: 'a.com' },
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle empty string hostname', async () => {
-          const err = checkServerIdentity('', { subject: { CN: 'a.com' } } as any);
+          const err = checkServerIdentity('', fakeCert({ subject: { CN: 'a.com' } }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle empty CN', async () => {
-          const err = checkServerIdentity('a.com', { subject: { CN: '' } } as any);
+          const err = checkServerIdentity('a.com', fakeCert({ subject: { CN: '' } }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle undefined CN', async () => {
-          const err = checkServerIdentity('a.com', { subject: {} } as any);
+          const err = checkServerIdentity('a.com', fakeCert({ subject: {} }));
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle empty subjectaltname string', async () => {
-          const err = checkServerIdentity('a.com', {
+          const err = checkServerIdentity('a.com', fakeCert({
             subject: { CN: 'a.com' },
             subjectaltname: '',
-          } as any);
+          }));
           // Empty altname means CN fallback
           expect(err === undefined || err instanceof Error).toBe(true);
         });
 
         await it('should handle numeric hostname as string', async () => {
-          const result = checkServerIdentity('127.0.0.1', {
+          const result = checkServerIdentity('127.0.0.1', fakeCert({
             subject: {},
             subjectaltname: 'IP Address:127.0.0.1',
-          } as any);
+          }));
           expect(result).toBeUndefined();
         });
 
         await it('should handle cert with only URI SAN (no DNS, no IP)', async () => {
-          const err = checkServerIdentity('a.com', {
+          const err = checkServerIdentity('a.com', fakeCert({
             subject: {},
             subjectaltname: 'URI:https://a.com',
-          } as any);
+          }));
           // URI SANs don't count for hostname verification
           expect(err instanceof Error).toBe(true);
         });
 
         await it('should handle cert with email SAN only', async () => {
-          const err = checkServerIdentity('a.com', {
+          const err = checkServerIdentity('a.com', fakeCert({
             subject: {},
             subjectaltname: 'email:admin@a.com',
-          } as any);
+          }));
           expect(err instanceof Error).toBe(true);
         });
       });

--- a/packages/node/tls/src/index.ts
+++ b/packages/node/tls/src/index.ts
@@ -1,9 +1,51 @@
-// Reference: Node.js lib/tls.js
-// Reimplemented for GJS using Gio.TlsClientConnection / Gio.TlsServerConnection
+// Reference: Node.js lib/tls.js, lib/_tls_common.js, lib/_tls_wrap.js
+// Reimplemented for GJS using Gio.TlsClientConnection / Gio.TlsServerConnection /
+//   Gio.TlsCertificate.
+//
+// Node-TLS option / API → Gio.TLS property/method mapping (authoritative for this file):
+//
+//   Node option / API                 →  Gio binding
+//   ─────────────────────────────────────────────────────────────────────────
+//   tls.createSecureContext({cert})   →  Gio.TlsCertificate.new_from_pem
+//   {key} (separate PEM)              →  PEM concatenated then new_from_pem
+//   {ca} (PEM string or array)        →  per-block Gio.TlsCertificate.new_from_pem
+//                                        used as trust anchors via cert.verify()
+//   {rejectUnauthorized: false}       →  TlsConnection 'accept-certificate'
+//                                        signal returns true
+//   {minVersion}/{maxVersion}/        →  Not exposed by Gio (handled by GnuTLS
+//   {ciphers}                            backend); stored for diagnostics only
+//   {ALPNProtocols}                   →  TlsConnection.set_advertised_protocols
+//   tlsSocket.alpnProtocol            →  TlsConnection.get_negotiated_protocol
+//   {servername} (SNI)                →  TlsClientConnection.set_server_identity
+//                                        (Gio.NetworkAddress with hostname)
+//   tls.connect({cert,key}) (mTLS)    →  TlsConnection.set_certificate(client_cert)
+//   tls.createServer({SNICallback})   →  Best-effort: see "Open TODOs" — Gio
+//                                        does not surface the ClientHello
+//                                        server_name to JS before handshake.
+//   tlsSocket.getPeerCertificate()    →  TlsConnection.get_peer_certificate +
+//                                        TlsCertificate.get_subject_name /
+//                                        get_issuer_name / get_dns_names /
+//                                        get_ip_addresses / get_not_valid_*  /
+//                                        certificate_pem
+//   detailed=true issuer chain        →  TlsCertificate.get_issuer (walked)
+//   tlsSocket.getProtocol()           →  TlsConnection.get_protocol_version
+//   tlsSocket.getCipher()             →  TlsConnection.get_ciphersuite_name
+//   server: {requestCert,             →  TlsServerConnection.authentication_mode
+//            rejectUnauthorized}         REQUESTED / REQUIRED / NONE
+//
+// Documented gaps (see STATUS.md "Open TODOs"):
+//   - SNI server-side selection from ClientHello: Gio does not expose
+//     server_name extension before handshake; SNICallback is consulted but
+//     selection is approximate.
+//   - OCSP stapling: not exposed by Gio.
+//   - TLS session resumption ('session' event, {session} option): GnuTLS
+//     resumption API is not surfaced via GI.
+//   - Custom DH/ECDH params, ticket keys: not exposed.
 
 import Gio from '@girs/gio-2.0';
 import GLib from '@girs/glib-2.0';
 import { Socket, Server } from 'node:net';
+import type { Server as NetServer } from 'node:net';
 import { createNodeError, deferEmit } from '@gjsify/utils';
 
 export const DEFAULT_MIN_VERSION = 'TLSv1.2';
@@ -18,11 +60,200 @@ export function getCiphers(): string[] {
   ];
 }
 
-export interface PeerCertificate {
-  subject?: { CN?: string | string[]; [key: string]: unknown };
-  subjectaltname?: string;
+// ============================================================================
+// PEM helpers
+// ============================================================================
+
+type PemInput = string | Buffer | Uint8Array | Array<string | Buffer | Uint8Array>;
+
+/** Coerce a PEM input (string, Buffer/Uint8Array, or array) to a single PEM string. */
+function pemToString(value: PemInput): string {
+  if (Array.isArray(value)) {
+    return value.map(pemToString).join('\n');
+  }
+  if (typeof value === 'string') return value;
+  if (value && typeof (value as Buffer).toString === 'function') {
+    try {
+      return (value as Buffer).toString('utf-8');
+    } catch {
+      return new TextDecoder('utf-8').decode(value as Uint8Array);
+    }
+  }
+  return String(value);
+}
+
+/** Split a concatenated PEM blob into individual `-----BEGIN ...-----...-----END ...-----` blocks. */
+function splitPemBlocks(pem: string): string[] {
+  const out: string[] = [];
+  const re = /-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(pem)) !== null) {
+    out.push(m[0]);
+  }
+  return out;
+}
+
+/** Build a TlsCertificate (and chain) from PEM strings. The first cert and key are the leaf. */
+function buildGioCertificate(cert: PemInput, key?: PemInput): Gio.TlsCertificate {
+  const certPem = pemToString(cert);
+  const keyPem = key ? pemToString(key) : '';
+  const pem = keyPem ? `${certPem}\n${keyPem}` : certPem;
+  return Gio.TlsCertificate.new_from_pem(pem, pem.length);
+}
+
+/** Parse a CA bundle (PEM string or array) into a list of TlsCertificate trust anchors. */
+function buildCaCertificates(ca: PemInput): Gio.TlsCertificate[] {
+  const blocks: string[] = [];
+  if (Array.isArray(ca)) {
+    for (const item of ca) blocks.push(...splitPemBlocks(pemToString(item)));
+  } else {
+    blocks.push(...splitPemBlocks(pemToString(ca)));
+  }
+  const out: Gio.TlsCertificate[] = [];
+  for (const block of blocks) {
+    try {
+      out.push(Gio.TlsCertificate.new_from_pem(block, block.length));
+    } catch {
+      // Skip blocks that aren't certificates (DH params, comments, etc).
+    }
+  }
+  return out;
+}
+
+// ============================================================================
+// Peer-certificate extraction
+// ============================================================================
+
+export interface CertSubject {
+  CN?: string | string[];
   [key: string]: unknown;
 }
+
+export interface PeerCertificate {
+  subject?: CertSubject;
+  issuer?: CertSubject;
+  subjectaltname?: string;
+  valid_from?: string;
+  valid_to?: string;
+  fingerprint?: string;
+  fingerprint256?: string;
+  serialNumber?: string;
+  raw?: Uint8Array;
+  issuerCertificate?: PeerCertificate;
+  [key: string]: unknown;
+}
+
+/** Parse a distinguished name string (e.g. "CN=example.com,O=Foo") into a key→value object. */
+function parseDistinguishedName(dn: string | null): CertSubject {
+  if (!dn) return {};
+  const out: CertSubject = {};
+  for (const part of dn.split(/,(?![^=]*=)/)) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    const existing = out[key];
+    if (existing === undefined) out[key] = value;
+    else if (Array.isArray(existing)) existing.push(value);
+    else out[key] = [existing as string, value];
+  }
+  return out;
+}
+
+/** Format a GLib.DateTime as an OpenSSL-style validity string. */
+function formatCertDate(dt: GLib.DateTime | null): string {
+  if (!dt) return '';
+  try { return dt.format('%b %d %H:%M:%S %Y GMT') ?? ''; } catch { return ''; }
+}
+
+/** Build the "subjectaltname" string from DNS names + IP addresses (Node format). */
+function formatAltNames(cert: Gio.TlsCertificate): string {
+  const parts: string[] = [];
+  try {
+    const dns = cert.get_dns_names();
+    if (dns) {
+      for (const b of dns) {
+        const data = b.get_data();
+        if (!data) continue;
+        parts.push(`DNS:${new TextDecoder('utf-8').decode(data)}`);
+      }
+    }
+  } catch { /* not all backends support this */ }
+  try {
+    const ips = cert.get_ip_addresses();
+    if (ips) for (const ip of ips) parts.push(`IP Address:${ip.to_string()}`);
+  } catch { /* same */ }
+  return parts.join(', ');
+}
+
+/** Compute SHA-1 / SHA-256 fingerprint strings from raw DER bytes (`AA:BB:CC:…`). */
+function fingerprintFromBytes(bytes: Uint8Array, algo: GLib.ChecksumType): string {
+  try {
+    const cs = new GLib.Checksum(algo);
+    cs.update(bytes);
+    const hex = cs.get_string();
+    if (!hex) return '';
+    const out: string[] = [];
+    for (let i = 0; i < hex.length; i += 2) out.push(hex.slice(i, i + 2).toUpperCase());
+    return out.join(':');
+  } catch {
+    return '';
+  }
+}
+
+/** Decode a single PEM cert block into raw DER bytes. */
+function pemToDer(pem: string): Uint8Array {
+  const m = /-----BEGIN CERTIFICATE-----([\s\S]*?)-----END CERTIFICATE-----/.exec(pem);
+  if (!m) return new Uint8Array(0);
+  const b64 = m[1].replace(/[\s\r\n]+/g, '');
+  try {
+    const atob = (globalThis as { atob?: (s: string) => string }).atob;
+    if (!atob) return new Uint8Array(0);
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return new Uint8Array(0);
+  }
+}
+
+/** Convert a single TlsCertificate to the Node `getPeerCertificate()` shape. */
+function tlsCertToPeerCert(cert: Gio.TlsCertificate, detailed: boolean): PeerCertificate {
+  const out: PeerCertificate = {};
+  try { out.subject = parseDistinguishedName(cert.get_subject_name()); } catch { /* */ }
+  try { out.issuer = parseDistinguishedName(cert.get_issuer_name()); } catch { /* */ }
+  out.subjectaltname = formatAltNames(cert);
+  try {
+    out.valid_from = formatCertDate(cert.get_not_valid_before());
+    out.valid_to = formatCertDate(cert.get_not_valid_after());
+  } catch { /* */ }
+  try {
+    const c = cert as unknown as { certificate_pem?: string; certificatePem?: string };
+    const pemProp = c.certificate_pem ?? c.certificatePem;
+    if (pemProp) {
+      const der = pemToDer(pemProp);
+      out.raw = der;
+      out.fingerprint = fingerprintFromBytes(der, GLib.ChecksumType.SHA1);
+      out.fingerprint256 = fingerprintFromBytes(der, GLib.ChecksumType.SHA256);
+    }
+  } catch { /* */ }
+  if (detailed) {
+    try {
+      const issuerCert = cert.get_issuer();
+      if (issuerCert && !issuerCert.is_same(cert)) {
+        out.issuerCertificate = tlsCertToPeerCert(issuerCert, true);
+      } else if (issuerCert) {
+        out.issuerCertificate = out;  // self-signed: Node returns self-ref
+      }
+    } catch { /* */ }
+  }
+  return out;
+}
+
+// ============================================================================
+// RFC 6125 hostname matching
+// ============================================================================
 
 /** Removes a trailing dot from a fully-qualified domain name. */
 function unfqdn(host: string): string {
@@ -34,27 +265,67 @@ function splitHost(host: string): string[] {
   return unfqdn(host).toLowerCase().split('.');
 }
 
-/** Wildcard-match a hostname part list against a pattern (supports leading *). */
-function checkWildcard(hostParts: string[], pattern: string): boolean {
-  const patParts = splitHost(pattern);
-  if (patParts.length !== hostParts.length) return false;
-  // Wildcard only valid in the leftmost label
-  if (patParts[0] === '*') {
-    // e.g. *.example.com — match any single label against *
-    return patParts.slice(1).join('.') === hostParts.slice(1).join('.');
+/** Reject control / non-ASCII bytes in pattern labels (RFC 6125 sanity). */
+function isPrintableAscii(s: string): boolean {
+  // U+0021 ('!') through U+007E ('~')
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c < 0x21 || c > 0x7E) return false;
   }
-  return patParts.every((p, i) => p === hostParts[i]);
+  return true;
+}
+
+/**
+ * Match a hostname (already split into labels) against a single pattern from
+ * a SAN DNS entry or CN. Implements RFC 6125 §6.4.3:
+ *  - wildcard valid only in the leftmost label
+ *  - wildcard label may not contain Punycode A-labels (`xn--`)
+ *  - `*.tld` (two-label patterns) are rejected
+ *  - exactly one wildcard per label
+ */
+function checkHostMatch(hostParts: string[], pattern: string): boolean {
+  if (!pattern) return false;
+  const patternParts = splitHost(pattern);
+  if (hostParts.length !== patternParts.length) return false;
+  if (patternParts.includes('')) return false;
+  if (!patternParts.every(isPrintableAscii)) return false;
+  for (let i = hostParts.length - 1; i > 0; i--) {
+    if (hostParts[i] !== patternParts[i]) return false;
+  }
+  const hostSub = hostParts[0];
+  const patSub = patternParts[0];
+  const wildSplit = patSub.split('*', 3);
+  if (wildSplit.length === 1 || patSub.includes('xn--')) {
+    return hostSub === patSub;
+  }
+  if (wildSplit.length > 2) return false;
+  if (patternParts.length <= 2) return false;
+  const prefix = wildSplit[0];
+  const suffix = wildSplit[1];
+  if (prefix.length + suffix.length > hostSub.length) return false;
+  if (!hostSub.startsWith(prefix)) return false;
+  if (!hostSub.endsWith(suffix)) return false;
+  return true;
+}
+
+/** Error returned by checkServerIdentity, with Node-compatible shape. */
+export interface CertAltNameError extends Error {
+  reason: string;
+  host: string;
+  cert: PeerCertificate;
+  code: 'ERR_TLS_CERT_ALTNAME_INVALID';
 }
 
 /**
  * Verifies that the certificate `cert` is valid for `hostname`.
- * Returns an Error if the check fails, or undefined on success.
+ * Returns an Error (with code 'ERR_TLS_CERT_ALTNAME_INVALID') if the check
+ * fails, or `undefined` on success.
  *
- * Reference: Node.js lib/tls.js exports.checkServerIdentity
+ * Reference: Node.js lib/tls.js exports.checkServerIdentity (RFC 6125 §6.4.3).
  */
-export function checkServerIdentity(hostname: string, cert: PeerCertificate): Error | undefined {
+export function checkServerIdentity(hostname: string, cert: PeerCertificate): CertAltNameError | undefined {
   const subject = cert.subject;
-  const altNames = cert.subjectaltname as string | undefined;
+  const altNames = cert.subjectaltname;
   const dnsNames: string[] = [];
   const ips: string[] = [];
 
@@ -63,11 +334,8 @@ export function checkServerIdentity(hostname: string, cert: PeerCertificate): Er
   if (altNames) {
     const parts = altNames.split(', ');
     for (const name of parts) {
-      if (name.startsWith('DNS:')) {
-        dnsNames.push(name.slice(4));
-      } else if (name.startsWith('IP Address:')) {
-        ips.push(name.slice(11).trim());
-      }
+      if (name.startsWith('DNS:')) dnsNames.push(name.slice(4));
+      else if (name.startsWith('IP Address:')) ips.push(name.slice(11).trim());
     }
   }
 
@@ -76,49 +344,87 @@ export function checkServerIdentity(hostname: string, cert: PeerCertificate): Er
 
   hostname = unfqdn(hostname);
 
-  // Check numeric IP addresses
   const isIPv4 = /^(\d{1,3}\.){3}\d{1,3}$/.test(hostname);
   const isIPv6 = hostname.includes(':');
   if (isIPv4 || isIPv6) {
     valid = ips.some(ip => ip.toLowerCase() === hostname.toLowerCase());
-    if (!valid)
+    if (!valid) {
       reason = `IP: ${hostname} is not in the cert's list: ${ips.join(', ')}`;
+    }
   } else if (dnsNames.length > 0 || subject?.CN) {
     const hostParts = splitHost(hostname);
 
     if (dnsNames.length > 0) {
-      valid = dnsNames.some(pattern => checkWildcard(hostParts, pattern));
-      if (!valid)
+      valid = dnsNames.some(pattern => checkHostMatch(hostParts, pattern.trim()));
+      if (!valid) {
         reason = `Host: ${hostname}. is not in the cert's altnames: ${altNames}`;
-    } else {
-      const cn = subject!.CN as string | string[];
-      if (Array.isArray(cn)) {
-        valid = cn.some(c => checkWildcard(hostParts, c));
-      } else if (cn) {
-        valid = checkWildcard(hostParts, cn);
       }
-      if (!valid)
+    } else {
+      const cn = subject?.CN;
+      if (Array.isArray(cn)) {
+        valid = cn.some(c => checkHostMatch(hostParts, c));
+      } else if (cn) {
+        valid = checkHostMatch(hostParts, cn);
+      }
+      if (!valid) {
         reason = `Host: ${hostname}. is not cert's CN: ${cn}`;
+      }
     }
   } else {
     reason = 'Cert does not contain a DNS name';
   }
 
   if (!valid) {
-    const err = new Error(reason) as NodeJS.ErrnoException & { reason: string; host: string; cert: PeerCertificate };
+    const err = new Error(reason) as CertAltNameError;
     err.reason = reason;
     err.host = hostname;
     err.cert = cert;
+    err.code = 'ERR_TLS_CERT_ALTNAME_INVALID';
     return err;
   }
   return undefined;
 }
 
+// ============================================================================
+// SecureContext
+// ============================================================================
+
 export interface SecureContextOptions {
-  ca?: string | Buffer | Array<string | Buffer>;
-  cert?: string | Buffer | Array<string | Buffer>;
-  key?: string | Buffer | Array<string | Buffer>;
+  ca?: PemInput;
+  cert?: PemInput;
+  key?: PemInput;
+  passphrase?: string;
   rejectUnauthorized?: boolean;
+  ciphers?: string;
+  minVersion?: string;
+  maxVersion?: string;
+  ALPNProtocols?: string[];
+}
+
+/** Internal "secure context" — parsed TLS material shared by tls.connect/createServer. */
+export interface SecureContext {
+  certificate: Gio.TlsCertificate | null;
+  caCertificates: Gio.TlsCertificate[];
+  options: SecureContextOptions;
+  /**
+   * Node-compat handle (Node returns a `SecureContext` with an internal native
+   * `context` field). We have no native handle, so this points back at the
+   * SecureContext object itself — `ctx.context !== undefined` matches Node.
+   */
+  context: SecureContext;
+}
+
+/** Build a SecureContext from PEM material. Buffer/Uint8Array/string all accepted. */
+export function createSecureContext(options?: SecureContextOptions): SecureContext {
+  const opts = options ?? {};
+  let certificate: Gio.TlsCertificate | null = null;
+  if (opts.cert) {
+    try { certificate = buildGioCertificate(opts.cert, opts.key); } catch { certificate = null; }
+  }
+  const caCertificates = opts.ca ? buildCaCertificates(opts.ca) : [];
+  const ctx = { certificate, caCertificates, options: opts } as SecureContext;
+  ctx.context = ctx;  // Node-compat self-reference
+  return ctx;
 }
 
 export interface TlsConnectOptions extends SecureContextOptions {
@@ -127,6 +433,20 @@ export interface TlsConnectOptions extends SecureContextOptions {
   socket?: Socket;
   servername?: string;
   ALPNProtocols?: string[];
+  /** Pre-built secure context from createSecureContext(). */
+  secureContext?: SecureContext;
+  /** Custom server-identity check (runs after the GnuTLS-level check). */
+  checkServerIdentity?: (host: string, cert: PeerCertificate) => Error | undefined;
+}
+
+/** Internal helper: cast a Socket to its private-field shape (we own the impl). */
+interface SocketInternals {
+  _connection: Gio.SocketConnection | null;
+  _ioStream: Gio.IOStream | null;
+  _inputStream: Gio.InputStream | null;
+  _outputStream: Gio.OutputStream | null;
+  _reading: boolean;
+  _startReading(): void;
 }
 
 /**
@@ -137,11 +457,14 @@ export class TLSSocket extends Socket {
   authorized = false;
   authorizationError?: string;
   alpnProtocol: string | false = false;
+  servername: string | undefined;
 
   /** @internal */
   _tlsConnection: Gio.TlsConnection | null = null;
+  /** @internal — preserved for diagnostics + future cert-chain verification. */
+  _secureContext: SecureContext | null = null;
 
-  constructor(socket?: Socket, options?: SecureContextOptions) {
+  constructor(_socket?: Socket, _options?: SecureContextOptions) {
     super();
   }
 
@@ -151,25 +474,23 @@ export class TLSSocket extends Socket {
    */
   _setupTlsStreams(tlsConn: Gio.TlsConnection): void {
     this._tlsConnection = tlsConn;
-    // Replace the underlying I/O streams with the TLS connection's streams
-    (this as any)._inputStream = tlsConn.get_input_stream();
-    (this as any)._outputStream = tlsConn.get_output_stream();
-    // Store connection for teardown
-    (this as any)._connection = tlsConn as unknown as Gio.SocketConnection;
+    const internals = this as unknown as SocketInternals;
+    internals._inputStream = tlsConn.get_input_stream();
+    internals._outputStream = tlsConn.get_output_stream();
+    internals._connection = tlsConn as unknown as Gio.SocketConnection;
   }
 
-  /** Get the peer certificate info. */
-  getPeerCertificate(_detailed?: boolean): any {
+  /**
+   * Get the peer certificate. When `detailed` is true, walks the issuer chain
+   * via `Gio.TlsCertificate.get_issuer()` and populates `issuerCertificate`
+   * recursively (with a self-reference on the root for compatibility).
+   */
+  getPeerCertificate(detailed = false): PeerCertificate {
     if (!this._tlsConnection) return {};
     try {
       const cert = this._tlsConnection.get_peer_certificate();
       if (!cert) return {};
-      return {
-        subject: {},
-        issuer: {},
-        valid_from: '',
-        valid_to: '',
-      };
+      return tlsCertToPeerCert(cert, detailed);
     } catch {
       return {};
     }
@@ -192,7 +513,7 @@ export class TLSSocket extends Socket {
     }
   }
 
-  /** Get the cipher info. */
+  /** Get the negotiated cipher suite name + version. */
   getCipher(): { name: string; version: string } | null {
     if (!this._tlsConnection) return null;
     try {
@@ -203,7 +524,7 @@ export class TLSSocket extends Socket {
     }
   }
 
-  /** Get the negotiated ALPN protocol. */
+  /** Get the negotiated ALPN protocol (or false if none). */
   getAlpnProtocol(): string | false {
     if (!this._tlsConnection) return false;
     try {
@@ -233,59 +554,94 @@ export function connect(options: TlsConnectOptions, callback?: () => void): TLSS
   const servername = options.servername || host;
   const rejectUnauthorized = options.rejectUnauthorized !== false;
 
-  // Listen for TCP connect, then upgrade to TLS
+  const ctx = options.secureContext ?? createSecureContext(options);
+  socket._secureContext = ctx;
+  socket.servername = servername;
+  const customCheckServerIdentity = options.checkServerIdentity;
+
   socket.once('connect', () => {
-    const rawConnection: Gio.SocketConnection | null = (socket as any)._connection;
+    const rawConnection = (socket as unknown as SocketInternals)._connection;
     if (!rawConnection) {
       socket.destroy(new Error('No underlying connection for TLS upgrade'));
       return;
     }
 
     try {
-      // Create TLS client connection wrapping the raw TCP connection
       const connectable = Gio.NetworkAddress.new(servername, port);
       const tlsConn = Gio.TlsClientConnection.new(
-        rawConnection as Gio.IOStream,
+        rawConnection as unknown as Gio.IOStream,
         connectable,
-      ) as Gio.TlsClientConnection;
+      );
 
-      // Set server identity for certificate validation
       tlsConn.set_server_identity(connectable);
 
-      // Set ALPN protocols if provided
-      if (options.ALPNProtocols && options.ALPNProtocols.length > 0) {
+      // Client certificate (mTLS)
+      if (ctx.certificate) {
         try {
-          (tlsConn as Gio.TlsClientConnection).set_advertised_protocols(options.ALPNProtocols);
-        } catch {
-          // ALPN may not be supported on all GnuTLS versions
+          tlsConn.set_certificate(ctx.certificate);
+        } catch (err: unknown) {
+          // eslint-disable-next-line no-console
+          console.warn('[tls] failed to set client certificate:', err);
         }
       }
 
-      // Handle certificate validation
-      if (!rejectUnauthorized) {
-        (tlsConn as Gio.TlsConnection).connect(
-          'accept-certificate',
-          () => true,
-        );
+      // ALPN
+      if (options.ALPNProtocols && options.ALPNProtocols.length > 0) {
+        try {
+          tlsConn.set_advertised_protocols(options.ALPNProtocols);
+        } catch {
+          // ALPN may not be supported
+        }
       }
 
-      // Perform TLS handshake asynchronously
+      // Certificate validation: by default rely on system trust store +
+      // 'accept-certificate' returning false. With a custom CA we accept
+      // peer certs that validate against `ctx.caCertificates`. With
+      // `rejectUnauthorized: false`, accept everything.
+      tlsConn.connect('accept-certificate', (
+        _conn: Gio.TlsConnection,
+        peerCert: Gio.TlsCertificate,
+        _errors: Gio.TlsCertificateFlags,
+      ): boolean => {
+        if (!rejectUnauthorized) return true;
+        if (ctx.caCertificates.length === 0) return false;
+        for (const ca of ctx.caCertificates) {
+          try {
+            const flags = peerCert.verify(connectable, ca);
+            if (flags === Gio.TlsCertificateFlags.NO_FLAGS) return true;
+          } catch { /* try next */ }
+        }
+        return false;
+      });
+
       const cancellable = new Gio.Cancellable();
-      (tlsConn as Gio.TlsConnection).handshake_async(
+      tlsConn.handshake_async(
         GLib.PRIORITY_DEFAULT,
         cancellable,
         (_source: Gio.TlsConnection | null, asyncResult: Gio.AsyncResult) => {
           try {
-            (tlsConn as Gio.TlsConnection).handshake_finish(asyncResult);
+            tlsConn.handshake_finish(asyncResult);
             socket.authorized = true;
-            socket._setupTlsStreams(tlsConn as Gio.TlsConnection);
-
-            // Get ALPN result
+            socket._setupTlsStreams(tlsConn);
             socket.alpnProtocol = socket.getAlpnProtocol();
 
-            // Restart reading with TLS streams
-            (socket as any)._reading = false;
-            (socket as any)._startReading();
+            // Custom server-identity check (post-handshake, mirrors Node).
+            if (customCheckServerIdentity) {
+              const peer = socket.getPeerCertificate();
+              const idErr = customCheckServerIdentity(servername, peer);
+              if (idErr) {
+                socket.authorized = false;
+                socket.authorizationError = idErr.message;
+                if (rejectUnauthorized) {
+                  socket.destroy(idErr);
+                  return;
+                }
+              }
+            }
+
+            const internals = socket as unknown as SocketInternals;
+            internals._reading = false;
+            internals._startReading();
 
             socket.emit('secureConnect');
           } catch (err: unknown) {
@@ -294,8 +650,7 @@ export function connect(options: TlsConnectOptions, callback?: () => void): TLSS
             if (rejectUnauthorized) {
               socket.destroy(err instanceof Error ? err : new Error(String(err)));
             } else {
-              // Still emit secureConnect but with authorized=false
-              socket._setupTlsStreams(tlsConn as Gio.TlsConnection);
+              socket._setupTlsStreams(tlsConn);
               socket.emit('secureConnect');
             }
           }
@@ -306,95 +661,114 @@ export function connect(options: TlsConnectOptions, callback?: () => void): TLSS
     }
   });
 
-  // Initiate TCP connection
   socket.connect({ port, host });
   return socket;
 }
 
-/**
- * Create a TLS secure context.
- */
-export function createSecureContext(options?: SecureContextOptions): { context: any } {
-  return { context: options || {} };
-}
-
 export const rootCertificates: string[] = [];
+
+// ============================================================================
+// TLSServer / createServer
+// ============================================================================
+
+export type SNICallback = (
+  servername: string,
+  cb: (err: Error | null, ctx?: SecureContext) => void,
+) => void;
 
 export interface TlsServerOptions extends SecureContextOptions {
   requestCert?: boolean;
   rejectUnauthorized?: boolean;
   ALPNProtocols?: string[];
+  SNICallback?: SNICallback;
 }
 
 /**
- * Build a Gio.TlsCertificate from PEM cert+key strings.
- */
-function buildGioCertificate(cert: string | Buffer | Array<string | Buffer>, key?: string | Buffer | Array<string | Buffer>): Gio.TlsCertificate {
-  const certStr = Array.isArray(cert)
-    ? cert.map((c) => (typeof c === 'string' ? c : c.toString('utf-8'))).join('\n')
-    : typeof cert === 'string' ? cert : cert.toString('utf-8');
-
-  const keyStr = key
-    ? Array.isArray(key)
-      ? key.map((k) => (typeof k === 'string' ? k : k.toString('utf-8'))).join('\n')
-      : typeof key === 'string' ? key : key.toString('utf-8')
-    : '';
-
-  const pem = keyStr ? `${certStr}\n${keyStr}` : certStr;
-  return Gio.TlsCertificate.new_from_pem(pem, pem.length);
-}
-
-/**
- * TLSServer wraps a net.Server to accept TLS connections.
+ * TLSServer accepts incoming TCP connections and upgrades each to TLS via
+ * `Gio.TlsServerConnection`. Supports mTLS via `requestCert`+`rejectUnauthorized`,
+ * SNI selection via `addContext`/`SNICallback`, and ALPN negotiation.
  */
 export class TLSServer extends Server {
   private _tlsCertificate: Gio.TlsCertificate | null = null;
   private _tlsOptions: TlsServerOptions;
-  private _sniContexts = new Map<string, Gio.TlsCertificate>();
+  private _sniContexts = new Map<string, SecureContext>();
+  /** @internal — exposed for tests. */
+  _secureContext: SecureContext;
 
   constructor(options?: TlsServerOptions, secureConnectionListener?: (socket: TLSSocket) => void) {
     super();
-    this._tlsOptions = options || {};
+    this._tlsOptions = options ?? {};
+    this._secureContext = createSecureContext(this._tlsOptions);
+    this._tlsCertificate = this._secureContext.certificate;
 
     if (secureConnectionListener) {
       this.on('secureConnection', secureConnectionListener);
     }
 
-    if (this._tlsOptions.cert) {
-      try {
-        this._tlsCertificate = buildGioCertificate(this._tlsOptions.cert, this._tlsOptions.key);
-      } catch (err: unknown) {
-        deferEmit(this, 'error', createNodeError(err, 'createServer', {}));
-      }
+    if (this._tlsOptions.cert && !this._tlsCertificate) {
+      // PEM provided but failed to parse — emit error asynchronously.
+      deferEmit(this as unknown as NetServer, 'error', createNodeError(
+        new Error('Failed to parse TLS certificate'), 'createServer', {},
+      ));
     }
   }
 
   /**
-   * Add a context for SNI (Server Name Indication).
+   * Add an additional context for SNI (Server Name Indication). Uses RFC 6125
+   * matching against the requested server name.
    */
   addContext(hostname: string, context: SecureContextOptions): void {
-    if (context.cert) {
+    try {
+      const ctx = createSecureContext(context);
+      this._sniContexts.set(hostname.toLowerCase(), ctx);
+    } catch (err: unknown) {
+      this.emit('error', createNodeError(err, 'addContext', {}));
+    }
+  }
+
+  /**
+   * Resolve a SecureContext for the given server name. Order:
+   *   1. exact match in `_sniContexts`
+   *   2. RFC 6125 wildcard match in `_sniContexts`
+   *   3. SNICallback (if provided)
+   *   4. fall through to the server's default context
+   */
+  private _resolveSniContext(servername: string | null, done: (ctx: SecureContext) => void): void {
+    const fallback = this._secureContext;
+    if (!servername) { done(fallback); return; }
+    const lower = servername.toLowerCase();
+    const exact = this._sniContexts.get(lower);
+    if (exact) { done(exact); return; }
+    const hostParts = splitHost(lower);
+    for (const [pattern, ctx] of this._sniContexts) {
+      if (checkHostMatch(hostParts, pattern)) { done(ctx); return; }
+    }
+    if (this._tlsOptions.SNICallback) {
       try {
-        const cert = buildGioCertificate(context.cert, context.key);
-        this._sniContexts.set(hostname, cert);
-      } catch (err: unknown) {
-        this.emit('error', createNodeError(err, 'addContext', {}));
+        this._tlsOptions.SNICallback(servername, (err: Error | null, ctx?: SecureContext) => {
+          if (err || !ctx) { done(fallback); return; }
+          done(ctx);
+        });
+        return;
+      } catch {
+        done(fallback);
+        return;
       }
     }
+    done(fallback);
   }
 
   listen(...args: unknown[]): this {
     this.on('connection', (socket: Socket) => {
       this._upgradeTls(socket);
     });
-    return super.listen(...(args as [any]));
+    type ListenArgs = Parameters<NetServer['listen']>;
+    return (super.listen as (...a: ListenArgs) => this)(...(args as unknown as ListenArgs));
   }
 
-  /**
-   * Upgrade a raw TCP socket to TLS using Gio.TlsServerConnection.
-   */
+  /** Upgrade a raw TCP socket to TLS using Gio.TlsServerConnection. */
   private _upgradeTls(socket: Socket): void {
-    const rawConnection: Gio.SocketConnection | null = (socket as any)._connection;
+    const rawConnection = (socket as unknown as SocketInternals)._connection;
     if (!rawConnection) {
       const err = new Error('Cannot upgrade socket: no underlying connection');
       this.emit('tlsClientError', err, socket);
@@ -402,78 +776,101 @@ export class TLSServer extends Server {
       return;
     }
 
-    if (!this._tlsCertificate) {
+    if (!this._tlsCertificate && this._sniContexts.size === 0 && !this._tlsOptions.SNICallback) {
       const err = new Error('TLS server has no certificate configured');
       this.emit('tlsClientError', err, socket);
       socket.destroy();
       return;
     }
 
-    try {
-      const tlsConn = Gio.TlsServerConnection.new(
-        rawConnection as Gio.IOStream,
-        this._tlsCertificate,
-      );
-
-      // Configure client authentication
-      if (this._tlsOptions.requestCert) {
-        tlsConn.authenticationMode = this._tlsOptions.rejectUnauthorized !== false
-          ? Gio.TlsAuthenticationMode.REQUIRED
-          : Gio.TlsAuthenticationMode.REQUESTED;
-      } else {
-        tlsConn.authenticationMode = Gio.TlsAuthenticationMode.NONE;
+    // SNI: Gio does not surface ClientHello server_name to JS pre-handshake;
+    // we use the server's default certificate. Real-world SNI multiplexing
+    // is documented in STATUS.md "Open TODOs".
+    this._resolveSniContext(null, (ctx) => {
+      const certificate = ctx.certificate ?? this._tlsCertificate;
+      if (!certificate) {
+        const err = new Error('SNI resolution returned no certificate');
+        this.emit('tlsClientError', err, socket);
+        socket.destroy();
+        return;
       }
 
-      if (this._tlsOptions.rejectUnauthorized === false) {
-        (tlsConn as Gio.TlsConnection).connect(
-          'accept-certificate',
-          () => true,
+      try {
+        const tlsConn = Gio.TlsServerConnection.new(
+          rawConnection as unknown as Gio.IOStream,
+          certificate,
         );
-      }
 
-      // Set ALPN protocols
-      if (this._tlsOptions.ALPNProtocols && this._tlsOptions.ALPNProtocols.length > 0) {
-        try {
-          (tlsConn as any).set_advertised_protocols(this._tlsOptions.ALPNProtocols);
-        } catch {
-          // ALPN may not be supported
+        // Client-cert / mTLS configuration
+        if (this._tlsOptions.requestCert) {
+          tlsConn.authenticationMode = this._tlsOptions.rejectUnauthorized !== false
+            ? Gio.TlsAuthenticationMode.REQUIRED
+            : Gio.TlsAuthenticationMode.REQUESTED;
+        } else {
+          tlsConn.authenticationMode = Gio.TlsAuthenticationMode.NONE;
         }
-      }
 
-      // Perform TLS handshake
-      const cancellable = new Gio.Cancellable();
-      (tlsConn as Gio.TlsConnection).handshake_async(
-        GLib.PRIORITY_DEFAULT,
-        cancellable,
-        (_source: Gio.TlsConnection | null, asyncResult: Gio.AsyncResult) => {
-          try {
-            (tlsConn as Gio.TlsConnection).handshake_finish(asyncResult);
+        const requireClientCert = !!this._tlsOptions.requestCert
+          && this._tlsOptions.rejectUnauthorized !== false;
+        const clientCAs = this._secureContext.caCertificates;
 
-            // Create TLSSocket with TLS I/O streams wired up
-            const tlsSocket = new TLSSocket();
-            tlsSocket.encrypted = true;
-            tlsSocket.authorized = true;
-            tlsSocket._setupTlsStreams(tlsConn as Gio.TlsConnection);
-
-            // Get ALPN result
-            tlsSocket.alpnProtocol = tlsSocket.getAlpnProtocol();
-
-            // Start reading on the TLS streams
-            (tlsSocket as any)._startReading();
-
-            this.emit('secureConnection', tlsSocket);
-          } catch (err: unknown) {
-            const nodeErr = createNodeError(err, 'handshake', {});
-            this.emit('tlsClientError', nodeErr, socket);
-            socket.destroy();
+        tlsConn.connect('accept-certificate', (
+          _conn: Gio.TlsConnection,
+          peerCert: Gio.TlsCertificate,
+          _errors: Gio.TlsCertificateFlags,
+        ): boolean => {
+          if (!requireClientCert) return true;
+          if (clientCAs.length === 0) return false;
+          for (const ca of clientCAs) {
+            try {
+              const flags = peerCert.verify(null, ca);
+              if (flags === Gio.TlsCertificateFlags.NO_FLAGS) return true;
+            } catch { /* try next */ }
           }
-        },
-      );
-    } catch (err: unknown) {
-      const nodeErr = createNodeError(err, 'tls_wrap', {});
-      this.emit('tlsClientError', nodeErr, socket);
-      socket.destroy();
-    }
+          return false;
+        });
+
+        // ALPN
+        if (this._tlsOptions.ALPNProtocols && this._tlsOptions.ALPNProtocols.length > 0) {
+          try {
+            tlsConn.set_advertised_protocols(this._tlsOptions.ALPNProtocols);
+          } catch {
+            // ALPN may not be supported
+          }
+        }
+
+        const cancellable = new Gio.Cancellable();
+        tlsConn.handshake_async(
+          GLib.PRIORITY_DEFAULT,
+          cancellable,
+          (_source: Gio.TlsConnection | null, asyncResult: Gio.AsyncResult) => {
+            try {
+              tlsConn.handshake_finish(asyncResult);
+
+              const tlsSocket = new TLSSocket();
+              tlsSocket.encrypted = true;
+              tlsSocket.authorized = true;
+              tlsSocket._secureContext = ctx;
+              tlsSocket._setupTlsStreams(tlsConn);
+              tlsSocket.alpnProtocol = tlsSocket.getAlpnProtocol();
+
+              const internals = tlsSocket as unknown as SocketInternals;
+              internals._startReading();
+
+              this.emit('secureConnection', tlsSocket);
+            } catch (err: unknown) {
+              const nodeErr = createNodeError(err, 'handshake', {});
+              this.emit('tlsClientError', nodeErr, socket);
+              socket.destroy();
+            }
+          },
+        );
+      } catch (err: unknown) {
+        const nodeErr = createNodeError(err, 'tls_wrap', {});
+        this.emit('tlsClientError', nodeErr, socket);
+        socket.destroy();
+      }
+    });
   }
 }
 
@@ -494,7 +891,7 @@ export function createServer(
 
 export { TLSServer as Server };
 
-export default {
+const tlsExports = {
   TLSSocket,
   TLSServer,
   Server: TLSServer,
@@ -508,3 +905,5 @@ export default {
   DEFAULT_MAX_VERSION,
   DEFAULT_CIPHERS,
 };
+
+export default tlsExports;

--- a/packages/node/tls/src/test.mts
+++ b/packages/node/tls/src/test.mts
@@ -2,5 +2,7 @@
 import { run } from '@gjsify/unit';
 
 import testSuiteTls from './index.spec.js';
+import testSuiteTlsCert from './cert.spec.js';
+import testSuiteTlsGjs from './tls.gjs.spec.js';
 
-run({ testSuiteTls });
+run({ testSuiteTls, testSuiteTlsCert, testSuiteTlsGjs });

--- a/packages/node/tls/src/tls.gjs.spec.ts
+++ b/packages/node/tls/src/tls.gjs.spec.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+// GJS-only TLS specs — cover paths that depend on Gio.TlsCertificate /
+// Gio.TlsServerConnection / Gio.TlsClientConnection plumbing. These are
+// skipped on Node where the @girs/* GI bindings don't resolve.
+//
+// Reference: refs/node-test/parallel/test-tls-cert-chain.js,
+//   test-tls-server-verify.js, test-tls-alpn-server-client.js,
+//   test-tls-sni-server.js — adapted to validate option plumbing rather
+//   than full TCP round-trips (which Gio's TLS backend exercises through
+//   GnuTLS in production).
+
+import { describe, it, expect, on } from '@gjsify/unit';
+import {
+  createServer,
+  createSecureContext,
+  TLSSocket,
+} from 'node:tls';
+
+// A self-signed cert+key pair generated for the gjsify test suite.
+// `openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650
+//   -nodes -subj /CN=localhost -addext "subjectAltName = DNS:localhost,IP:127.0.0.1"`
+// Embedded inline so tests stay hermetic (no fixtures).
+const TEST_CERT_AND_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDLfvlLZ4Pa3GZP
+mockmockmockmockmockmockmockmockmockmockmockmockmockmockmockmockm
+-----END PRIVATE KEY-----
+-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUEihvCxNb+vyvKNUTlfsYV5RbS8owDQYJKoZIhvcNAQEL
+mockmockmockmockmockmockmockmockmockmockmockmockmockmockmockmockm
+-----END CERTIFICATE-----
+`;
+
+export default async () => {
+  await on('Gjs', async () => {
+    await describe('tls (GJS-only) — option plumbing + cert chain', async () => {
+
+      // ---------------- ALPN configuration ----------------
+      await describe('ALPN', async () => {
+        await it('createServer accepts ALPNProtocols option without throwing', async () => {
+          const server = createServer({ ALPNProtocols: ['h2', 'http/1.1'] });
+          expect(server).toBeDefined();
+          server.close();
+        });
+
+        await it('createServer accepts empty ALPNProtocols array', async () => {
+          const server = createServer({ ALPNProtocols: [] });
+          expect(server).toBeDefined();
+          server.close();
+        });
+
+        await it('TLSSocket.alpnProtocol is false before handshake', async () => {
+          const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+          expect(socket.alpnProtocol).toBe(false);
+        });
+      });
+
+      // ---------------- SNI / addContext ----------------
+      await describe('SNI server', async () => {
+        await it('addContext accepts hostname + secure context options', async () => {
+          const server = createServer();
+          // PEM strings will fail to parse but addContext must not throw.
+          server.addContext('a.example.com', { cert: '', key: '' });
+          server.addContext('b.example.com', { cert: '', key: '' });
+          server.close();
+        });
+
+        await it('addContext accepts wildcard hostnames', async () => {
+          const server = createServer();
+          server.addContext('*.example.com', { cert: '', key: '' });
+          server.close();
+        });
+
+        await it('createServer accepts SNICallback option', async () => {
+          const server = createServer({
+            SNICallback: (_servername: string, cb: (err: Error | null, ctx?: unknown) => void) => {
+              cb(null, undefined);
+            },
+          } as unknown as Parameters<typeof createServer>[0]);
+          expect(server).toBeDefined();
+          server.close();
+        });
+      });
+
+      // ---------------- mTLS server config ----------------
+      await describe('mTLS', async () => {
+        await it('createServer accepts requestCert option', async () => {
+          const server = createServer({ requestCert: true });
+          expect(server).toBeDefined();
+          server.close();
+        });
+
+        await it('createServer accepts requestCert + rejectUnauthorized', async () => {
+          const server = createServer({ requestCert: true, rejectUnauthorized: true });
+          expect(server).toBeDefined();
+          server.close();
+        });
+
+        await it('createServer accepts ca for client-cert validation', async () => {
+          const server = createServer({
+            requestCert: true,
+            rejectUnauthorized: true,
+            ca: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
+          });
+          expect(server).toBeDefined();
+          server.close();
+        });
+      });
+
+      // ---------------- SecureContext PEM round-trip ----------------
+      await describe('SecureContext (Gio-backed)', async () => {
+        await it('createSecureContext returns an object with caCertificates array', async () => {
+          const ctx = createSecureContext({
+            ca: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n' +
+                '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----',
+          }) as unknown as { caCertificates?: unknown[] };
+          // ca is invalid PEM — expect zero entries, no throw.
+          expect(Array.isArray(ctx.caCertificates)).toBe(true);
+        });
+
+        await it('createSecureContext tolerates invalid PEM gracefully', async () => {
+          // Invalid PEM should NOT throw; consumers handle the missing cert.
+          const ctx = createSecureContext({
+            cert: 'not-pem',
+            key: 'not-pem',
+          }) as unknown as { certificate?: unknown };
+          expect(ctx.certificate === null || ctx.certificate === undefined).toBe(true);
+        });
+
+        await it('TEST_CERT_AND_KEY constant is non-empty', async () => {
+          // Sanity: ensure inline material is intact (regression guard if
+          // tooling rewrites this file).
+          expect(TEST_CERT_AND_KEY).toContain('BEGIN');
+          expect(TEST_CERT_AND_KEY).toContain('END');
+        });
+      });
+
+      // ---------------- TLSSocket pre-handshake state ----------------
+      await describe('TLSSocket pre-handshake', async () => {
+        await it('servername defaults to undefined', async () => {
+          const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+          expect(socket.servername).toBeUndefined();
+        });
+
+        await it('_tlsConnection is null before handshake', async () => {
+          const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+          expect((socket as unknown as { _tlsConnection?: unknown })._tlsConnection).toBeNull();
+        });
+
+        await it('getPeerCertificate(false) returns empty object', async () => {
+          const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+          const cert = socket.getPeerCertificate(false);
+          expect(typeof cert).toBe('object');
+          expect(Object.keys(cert).length).toBe(0);
+        });
+
+        await it('getPeerCertificate(true) returns empty object before handshake', async () => {
+          const socket = new TLSSocket(undefined as unknown as import("net").Socket);
+          const cert = socket.getPeerCertificate(true);
+          expect(typeof cert).toBe('object');
+          expect(Object.keys(cert).length).toBe(0);
+        });
+      });
+    });
+  });
+};


### PR DESCRIPTION
## Summary

Promotes `@gjsify/tls` from "Partial" to closer to "Full" by wiring up cert chain handling, mTLS (client certificates), SNI server callback, RFC 6125 hostname matching, and explicit ALPN negotiation. **Workstream B** of the parallel roadmap.

## Test counts

- Before: 132 (single spec, `index.spec.ts`)
- After: **169 GJS / 262 Node** / 1 GJS-only-skipped / 2 Node-only-skipped
- Three spec files: `index.spec.ts` (existing, expanded), `cert.spec.ts` (new), `tls.gjs.spec.ts` (new GJS-only)

## `as any` cleanup

`packages/node/tls/src/index.spec.ts`: **65 → 0** in code (one substring remains in a comment documenting the pattern). 0 in `index.ts`. 0 in the new spec files.

## Node TLS option → Gio.TLS mapping (now in file header)

| Node | Gio binding |
|---|---|
| `createSecureContext({cert})` | `Gio.TlsCertificate.new_from_pem` |
| `{key}` | PEM concatenated then `new_from_pem` |
| `{ca}` | per-block `new_from_pem`, used as trust anchors via `cert.verify()` |
| `{rejectUnauthorized: false}` | `accept-certificate` signal returns `true` |
| `{ALPNProtocols}` | `TlsConnection.set_advertised_protocols` |
| `tlsSocket.alpnProtocol` | `TlsConnection.get_negotiated_protocol` |
| `{servername}` | `TlsClientConnection.set_server_identity(NetworkAddress)` |
| `tls.connect({cert,key})` mTLS | `TlsConnection.set_certificate` |
| `getPeerCertificate()` | `get_peer_certificate` + `get_subject_name`/`get_issuer_name`/`get_dns_names`/`get_ip_addresses`/`get_not_valid_*`/`certificate_pem` |
| `getPeerCertificate(true)` chain | `TlsCertificate.get_issuer` walked recursively |
| `getProtocol()` | `TlsConnection.get_protocol_version` |
| `getCipher()` | `TlsConnection.get_ciphersuite_name` |
| server `{requestCert,rejectUnauthorized}` | `TlsServerConnection.authentication_mode = REQUIRED/REQUESTED/NONE` |

## Gaps tracked in STATUS.md "Open TODOs → TLS gaps that Gio does not surface"

1. SNI server-side ClientHello selection — Gio doesn't expose `server_name` extension before handshake. Workaround: one server per hostname or front with TCP proxy. Long-term: `@gjsify/tls-native` Vala bridge.
2. OCSP stapling — no Gio binding for `gnutls_ocsp_status_request_*`.
3. TLS session resumption (`'session'` event, `{session}` opt, ticket keys) — `gnutls_session_set_data`/`gnutls_session_ticket_*` not surfaced via GI.
4. DH/ECDH params, ticket-key rotation — no `g_tls_server_connection_set_dh_params`.
5. `getPeerFinished()`/`getFinished()` channel binding for SCRAM-SHA-* — no Gio API.

## Test plan

- [x] `cd packages/node/tls && yarn build && yarn check && yarn test:gjs && yarn test:node` ✅
- [ ] CI green

## Stack

Stacked on #103 (Workstream C). Rebase onto `main` after #100, #101, #102, #103 merge.