### PR TITLE
refactor(webgl): replace as-any with concrete @gjsify/webgl types in webgl2.spec.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,31 @@
   (the single pre-existing `@girs/gjs` import comes from
   `@gjsify/unit`'s GJS code path and is unaffected).
 
+* **webgl (2026-05-09):** type-safety pass on
+  `packages/framework/webgl/src/ts/webgl2.spec.ts` (Workstream I).
+  `as any` reduced from 2 → 0 in `webgl2.spec.ts`. Replaced
+  `(c as any).getContext('webgl2')` with `c as unknown as
+  OurHTMLCanvasElement` — the bridge callback types `c` as
+  `globalThis.HTMLCanvasElement` (DOM spec), but at runtime it is the
+  GTK-backed `@gjsify/webgl` `HTMLCanvasElement` whose `getContext()`
+  overload returns the concrete `WebGL2RenderingContext`. Replaced
+  `getExtension('OES_texture_half_float') as any` with `as unknown as
+  OESTextureHalfFloat | null` — the extension class is now exposed via
+  the package barrel, so the test reaches `HALF_FLOAT_OES` through a
+  typed property instead of an untyped indexer. New named exports on
+  `@gjsify/webgl`: `OESTextureHalfFloat`, `OESTextureFloat`,
+  `OESTextureFloatLinear`, `OESStandardDerivatives`,
+  `OESElementIndexUint`, `EXTBlendMinMax`, `EXTColorBufferFloat`,
+  `EXTColorBufferHalfFloat`, `EXTTextureFilterAnisotropic`,
+  `STACKGLDestroyContext`, `STACKGLResizeDrawingBuffer` — the
+  extension classes were already on disk under
+  `src/ts/extensions/` but never re-exported from the index, leaving
+  consumers no choice but `as any` on `getExtension()` results. Pure
+  type-safety refactor — no runtime change. 860/860 GJS tests green
+  (unchanged baseline). Per CLAUDE.md Testing → Rules 2 + 2b: this
+  spec is GJS-only (relies on Gtk.GLArea + libgwebgl), so direct
+  `@gjsify/webgl` imports are sanctioned and impl-private types
+  (extension classes) are the right vocabulary instead of casts.
 
 * **canvas2d-core (2026-05-09):** type-safety pass on
   `packages/dom/canvas2d-core/src/canvas-rendering-context-2d.ts` (Workstream H).

--- a/packages/framework/webgl/src/ts/index.ts
+++ b/packages/framework/webgl/src/ts/index.ts
@@ -31,3 +31,17 @@ export * from './webgl-texture-unit.js';
 export * from './webgl-texture.js';
 export * from './webgl-uniform-location.js';
 export * from './webgl-vertex-attribute.js';
+
+// Extensions — exposed so consumers (and *.spec.ts) can use the concrete
+// extension class as a type instead of `as any` casts on getExtension() results.
+export * from './extensions/ext-blend-minmax.js';
+export * from './extensions/ext-color-buffer-float.js';
+export * from './extensions/ext-color-buffer-half-float.js';
+export * from './extensions/ext-texture-filter-anisotropic.js';
+export * from './extensions/oes-element-index-unit.js';
+export * from './extensions/oes-standard-derivatives.js';
+export * from './extensions/oes-texture-float-linear.js';
+export * from './extensions/oes-texture-float.js';
+export * from './extensions/oes-texture-half-float.js';
+export * from './extensions/stackgl-destroy-context.js';
+export * from './extensions/stackgl-resize-drawing-buffer.js';

--- a/packages/framework/webgl/src/ts/webgl2.spec.ts
+++ b/packages/framework/webgl/src/ts/webgl2.spec.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, on } from '@gjsify/unit';
 
-import { WebGL2RenderingContext as OurWebGL2RenderingContext, WebGLBridge } from '@gjsify/webgl';
+import { WebGL2RenderingContext as OurWebGL2RenderingContext, WebGLBridge, HTMLCanvasElement as OurHTMLCanvasElement, OESTextureHalfFloat } from '@gjsify/webgl';
 import { makeProgram, drawTriangle, readPixel, pixelClose,
          makeTestFBO, destroyTestFBO, makeTestFBOWithDepth,
          makeTestFBOFloat, makeTestFBOWithDepthTexture,
@@ -29,7 +29,10 @@ export default async () => {
 		glArea = new WebGLBridge();
 		glArea.onReady((c, _g) => {
 			// Ask the canvas for a WebGL2 context instead of the default WebGL1
-			gl2 = (c as any).getContext('webgl2') as WebGL2RenderingContext;
+			// `c` is typed as DOM `globalThis.HTMLCanvasElement` by the bridge callback,
+			// but at runtime it is our GTK-backed `OurHTMLCanvasElement`. Reach the
+			// concrete getContext('webgl2') overload via the impl class.
+			gl2 = (c as unknown as OurHTMLCanvasElement).getContext('webgl2') as WebGL2RenderingContext;
 			readyLoop.quit();
 		});
 
@@ -678,9 +681,9 @@ export default async () => {
 			});
 
 			await it('OES_texture_half_float exposes HALF_FLOAT_OES constant', async () => {
-				const ext = gl2.getExtension('OES_texture_half_float') as any;
+				const ext = gl2.getExtension('OES_texture_half_float') as unknown as OESTextureHalfFloat | null;
 				expect(ext).toBeTruthy();
-				expect(ext.HALF_FLOAT_OES).toBe(0x8D61);
+				expect(ext!.HALF_FLOAT_OES).toBe(0x8D61);
 			});
 		});
 


### PR DESCRIPTION
## Summary

Drives `as any` in `packages/framework/webgl/src/ts/webgl2.spec.ts` from **2 → 0**. **Workstream I** of the type-safety wave. Smaller than expected — the file was mostly already cleaned during the Workstream-D pass that recently landed; only two stragglers remained.

## Changes

- Replaced `(c as any).getContext('webgl2')` with `c as unknown as OurHTMLCanvasElement` — the bridge callback types `c` as `globalThis.HTMLCanvasElement` (DOM spec), but at runtime it is the GTK-backed `@gjsify/webgl` `HTMLCanvasElement` whose `getContext()` returns the impl-private context.
- Re-exported the previously-internal extension classes from `@gjsify/webgl/src/ts/index.ts`:
  `EXTBlendMinMax`, `EXTColorBufferFloat`, `EXTColorBufferHalfFloat`, `EXTTextureFilterAnisotropic`, `OESElementIndexUint`, `OESStandardDerivatives`, `OESTextureFloatLinear`, `OESTextureFloat`, `OESTextureHalfFloat`, `STACKGLDestroyContext`, `STACKGLResizeDrawingBuffer` — plus their `get*` factory functions via `export *`. (`HTMLCanvasElement` GTK-backed was already exported.)

This applies the new **Rule 2 / 2b** allowance from #107 — `@gjsify/webgl` is a GJS-only package, so direct `@gjsify/webgl` imports are permitted in its specs without going through `node:`-prefix aliases.

## `as any` count

| Scope | Before | After |
|---|---|---|
| `webgl2.spec.ts` | 2 | 0 |
| `packages/framework/webgl/src/ts/` (overall) | 44 | 42 |

Remaining 42 are intentional: spec files for negative tests, `webgl-bridge.ts` globalThis bootstrap, a few `_native` reach-throughs in conformance specs.

## Test plan

- [x] `cd packages/framework/webgl && yarn build && yarn check && yarn test:gjs` — **860/860 GJS tests pass** (baseline preserved)
- [ ] CI green