### PR TITLE
refactor(readline): internal TTY-extended stream interfaces to remove as-any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,37 @@
 
 ### Refactoring
 
+* **readline (2026-05-09):** type-safety pass on
+  `packages/node/readline/src/index.ts` (Workstream L). `as any`
+  reduced from 26 → 0 in production source. New internal-only
+  helper module `src/internal/stream-types.ts` (per AGENTS.md
+  Rule 2c — not exported from `package.json#exports`) declares
+  `GjsReadableTty` and `GjsWritableTty` interfaces that augment
+  `node:stream`'s `Readable`/`Writable` with the TTY-specific
+  runtime members (`isRaw`, `isTTY`, `setRawMode`, `columns`,
+  `rows`, `getColorDepth`, `hasColors`) that exist on both
+  `tty.ReadStream`/`WriteStream` and `@gjsify/process`'s
+  `ProcessReadStream`/`ProcessWriteStream` but are absent from the
+  base `Readable`/`Writable` types. A third helper
+  `KeypressTaggedStream` (intersection type — `Readable &
+  { [key: symbol]: ... }`, modelled as intersection rather than
+  `extends Readable` to avoid colliding with `Readable`'s built-in
+  symbol keys like `Symbol.asyncDispose` /
+  `EventEmitter.captureRejectionSymbol`) replaces the
+  `(stream as any)[_KEYPRESS_DECODER]` casts in
+  `emitKeypressEvents`. Public API of `Interface` unchanged
+  (`_input: Readable | null`, `_output: Writable | null`); only
+  internal usage narrows. The `emitKeypressEvents(stream, iface)`
+  signature was tightened from `Readable & Record<symbol, unknown>`
+  to plain `Readable` (Node-spec compatible) with the symbol-tagged
+  view applied internally. Side-effects: `Interface` now exposes
+  the `escapeCodeTimeout?: number` field already declared on
+  `InterfaceOptions` so `emitKeypressEvents(stream, this)`
+  satisfies the structural `{ escapeCodeTimeout?: number }`
+  parameter without `as any` (also a behavior parity improvement —
+  Node readline forwards `opts.escapeCodeTimeout`). All 145 tests
+  green on both Node and GJS (unchanged baseline).
+
 * **zlib (2026-05-09):** type-safety pass on
   `packages/node/zlib/src/index.spec.ts` (Workstream J). `as any`
   reduced from 20 → 0. All 20 occurrences were `gzipSync(str as

--- a/packages/node/readline/src/index.ts
+++ b/packages/node/readline/src/index.ts
@@ -4,6 +4,12 @@
 import { EventEmitter } from 'node:events';
 import { StringDecoder } from 'node:string_decoder';
 import type { Readable, Writable } from 'node:stream';
+import type {
+  GjsReadableTty,
+  GjsWritableTty,
+  KeypressEmitter,
+  KeypressTaggedStream,
+} from './internal/stream-types.js';
 
 export interface InterfaceOptions {
   input?: Readable;
@@ -24,6 +30,10 @@ export class Interface extends EventEmitter {
   terminal: boolean;
   line = '';
   cursor = 0;
+  // Mirrors `InterfaceOptions.escapeCodeTimeout` so that
+  // `emitKeypressEvents(stream, this)` can read it via the structural
+  // `{ escapeCodeTimeout?: number }` parameter shape.
+  escapeCodeTimeout?: number;
 
   private _input: Readable | null;
   private _output: Writable | null;
@@ -63,6 +73,7 @@ export class Interface extends EventEmitter {
     this._historySize = opts.historySize ?? 30;
     this.history = [];
     this._crlfDelay = opts.crlfDelay ?? 100;
+    this.escapeCodeTimeout = opts.escapeCodeTimeout;
 
     if (this._input) {
       this._boundOnData = (chunk: Buffer | string) => this._onData(chunk);
@@ -77,12 +88,13 @@ export class Interface extends EventEmitter {
       }
 
       if (this.terminal) {
-        emitKeypressEvents(this._input as Readable & Record<symbol, unknown>, this as any);
-        if ('setRawMode' in this._input && typeof (this._input as any).setRawMode === 'function') {
-          if (!(this._input as any).isRaw) (this._input as any).setRawMode(true);
+        emitKeypressEvents(this._input, this);
+        const ttyInput = this._input as GjsReadableTty;
+        if (typeof ttyInput.setRawMode === 'function') {
+          if (!ttyInput.isRaw) ttyInput.setRawMode(true);
         }
-        if ('resume' in this._input && typeof (this._input as any).resume === 'function') {
-          (this._input as any).resume();
+        if (typeof this._input.resume === 'function') {
+          this._input.resume();
         }
 
         this._boundOnKeypress = (str: string | undefined, key: Key) => {
@@ -176,7 +188,7 @@ export class Interface extends EventEmitter {
   write(data: string | Buffer | null, key?: { ctrl?: boolean; meta?: boolean; shift?: boolean; name?: string }): void {
     if (this._closed) return;
     if (key) {
-      if (this._input) (this._input as any).emit('keypress', data ?? '', key);
+      if (this._input) this._input.emit('keypress', data ?? '', key);
       return;
     }
     if (data !== null && data !== undefined) {
@@ -207,16 +219,16 @@ export class Interface extends EventEmitter {
       this._boundOnError = null;
       this._boundOnKeypress = null;
 
-      if (this.terminal && (this._input as any).isRaw &&
-          'setRawMode' in this._input && typeof (this._input as any).setRawMode === 'function') {
-        (this._input as any).setRawMode(false);
+      const ttyInput = this._input as GjsReadableTty;
+      if (this.terminal && ttyInput.isRaw && typeof ttyInput.setRawMode === 'function') {
+        ttyInput.setRawMode(false);
       }
 
       // Pause stdin so ProcessReadStream releases the GLib main loop via
       // quitMainLoop(). Mirrors Node.js readline: close() pauses the stream
       // so the event loop can drain and the process exits when no more prompts follow.
-      if ('pause' in this._input && typeof (this._input as any).pause === 'function') {
-        (this._input as any).pause();
+      if (typeof this._input.pause === 'function') {
+        this._input.pause();
       }
     }
 
@@ -244,7 +256,7 @@ export class Interface extends EventEmitter {
   }
 
   getCursorPos(): { rows: number; cols: number } {
-    const columns = (this._output as any)?.columns ?? 80;
+    const columns = (this._output as GjsWritableTty | null)?.columns ?? 80;
     const len = this._prompt.length + this.cursor;
     return { rows: Math.floor(len / columns), cols: len % columns };
   }
@@ -495,42 +507,47 @@ const _ESCAPE_DECODER   = Symbol('escape-decoder');
 
 // Idempotent — calling twice on the same stream is a no-op.
 // Ported from refs/node/lib/internal/readline/emitKeypressEvents.js.
-export function emitKeypressEvents(stream: Readable & Record<symbol, unknown>, iface: { escapeCodeTimeout?: number } = {}): void {
-  if ((stream as any)[_KEYPRESS_DECODER]) return;
+export function emitKeypressEvents(stream: Readable, iface: { escapeCodeTimeout?: number } = {}): void {
+  // Cast once to the symbol-tagged shape; runtime augmentation is tracked
+  // via two private symbols (decoder + escape-state generator).
+  const tagged = stream as KeypressTaggedStream;
+  if (tagged[_KEYPRESS_DECODER]) return;
 
-  (stream as any)[_KEYPRESS_DECODER] = new StringDecoder('utf8');
-  (stream as any)[_ESCAPE_DECODER] = emitKeys(stream as any);
-  (stream as any)[_ESCAPE_DECODER].next();
+  tagged[_KEYPRESS_DECODER] = new StringDecoder('utf8');
+  tagged[_ESCAPE_DECODER] = emitKeys(stream as KeypressEmitter);
+  (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next();
 
   const escTimeout = iface.escapeCodeTimeout ?? ESCAPE_CODE_TIMEOUT;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const triggerEscape = () => (stream as any)[_ESCAPE_DECODER].next('');
+  const triggerEscape = () =>
+    (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next('');
 
   function onData(input: Buffer | string): void {
-    if ((stream as any).listenerCount('keypress') > 0) {
-      const str: string = (stream as any)[_KEYPRESS_DECODER].write(
+    if (stream.listenerCount('keypress') > 0) {
+      const decoder = tagged[_KEYPRESS_DECODER] as StringDecoder;
+      const str: string = decoder.write(
         typeof input === 'string' ? Buffer.from(input) : input,
       );
       if (str) {
         clearTimeout(timeoutId);
         for (const ch of str) {
           try {
-            (stream as any)[_ESCAPE_DECODER].next(ch);
+            (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next(ch);
             if (ch === '\x1b') timeoutId = setTimeout(triggerEscape, escTimeout);
           } catch {
-            (stream as any)[_ESCAPE_DECODER] = emitKeys(stream as any);
-            (stream as any)[_ESCAPE_DECODER].next();
+            tagged[_ESCAPE_DECODER] = emitKeys(stream as KeypressEmitter);
+            (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next();
           }
         }
       }
     } else {
-      (stream as any).removeListener('data', onData);
-      delete (stream as any)[_KEYPRESS_DECODER];
-      delete (stream as any)[_ESCAPE_DECODER];
+      stream.removeListener('data', onData);
+      delete tagged[_KEYPRESS_DECODER];
+      delete tagged[_ESCAPE_DECODER];
     }
   }
 
-  (stream as any).on('data', onData);
+  stream.on('data', onData);
 }
 
 export default {

--- a/packages/node/readline/src/internal/stream-types.ts
+++ b/packages/node/readline/src/internal/stream-types.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Internal type helpers for readline — narrowing Node's Readable/Writable
+// to the TTY-extended runtime shape we get on both Node tty streams and
+// @gjsify/process's stdin/stdout/stderr. NOT exported from the package's
+// public surface (per AGENTS.md Rule 2c).
+//
+// `tty.ReadStream` / `tty.WriteStream` extend `net.Socket` (which extends
+// `Readable`/`Writable` via `Duplex`) and add the TTY-specific runtime
+// methods used by readline (setRawMode, isRaw, isTTY, columns, rows,
+// getColorDepth, hasColors). The standalone `Readable`/`Writable` types
+// in `node:stream` do not declare these — but at runtime our public API
+// accepts any `Readable`/`Writable`, and either falls back gracefully or
+// uses `in`/`typeof` guards before invoking. These interfaces let us
+// narrow without `as any`.
+//
+// Additionally, the keypress parser stores its `StringDecoder` and
+// `emitKeys` generator on the input stream via two private symbols
+// (`_KEYPRESS_DECODER`, `_ESCAPE_DECODER`). The `KeypressTaggedStream`
+// type describes that runtime augmentation.
+
+import type { Readable, Writable } from 'node:stream';
+import type { StringDecoder } from 'node:string_decoder';
+
+/**
+ * `Readable` augmented with the TTY-specific runtime methods that exist
+ * on `tty.ReadStream` and on `@gjsify/process`'s `ProcessReadStream`.
+ * All members are optional — readline always guards with `'method' in stream`
+ * + `typeof stream.method === 'function'` before calling.
+ */
+export interface GjsReadableTty extends Readable {
+  isRaw?: boolean;
+  isTTY?: boolean;
+  setRawMode?(enable: boolean): this;
+}
+
+/**
+ * `Writable` augmented with the TTY-specific runtime properties that exist
+ * on `tty.WriteStream` and on `@gjsify/process`'s `ProcessWriteStream`.
+ * All members are optional for the same reason as `GjsReadableTty`.
+ */
+export interface GjsWritableTty extends Writable {
+  columns?: number;
+  rows?: number;
+  isTTY?: boolean;
+  getColorDepth?(env?: NodeJS.ProcessEnv): number;
+  hasColors?(count?: number, env?: NodeJS.ProcessEnv): boolean;
+}
+
+/**
+ * Symbol-keyed runtime state that `emitKeypressEvents` attaches to the
+ * input stream. The two private symbols carry the per-stream
+ * `StringDecoder` and the live `emitKeys` generator, plus a re-entrancy
+ * guard so the second call on the same stream is a no-op.
+ *
+ * Modeled as an intersection (rather than `extends Readable` with a
+ * `[key: symbol]` index signature) because `Readable` already declares
+ * built-in symbol keys — `EventEmitter.captureRejectionSymbol`,
+ * `Symbol.asyncDispose`, `Symbol.asyncIterator` — whose value types
+ * would conflict with a narrow union signature.
+ */
+export type KeypressTaggedStream = Readable & {
+  [key: symbol]: StringDecoder | Generator<void, void, string> | undefined;
+};
+
+/**
+ * Minimal `EventEmitter`-like shape used by the keypress parser to dispatch
+ * `'keypress'` events back onto the stream. `Readable` already satisfies
+ * this via its `EventEmitter` ancestry.
+ */
+export interface KeypressEmitter {
+  emit(event: string | symbol, ...args: unknown[]): boolean;
+}


### PR DESCRIPTION
## Summary

Drives `as any` in `packages/node/readline/src/index.ts` from **26 → 0** using **AGENTS.md Rule 2c** — internal-only helper interfaces under `src/internal/`. **Workstream L** of the type-safety wave.

## Approach

New internal module `src/internal/stream-types.ts` declares:

- `GjsReadableTty extends Readable` — adds optional `isRaw`, `isTTY`, `setRawMode()`
- `GjsWritableTty extends Writable` — adds optional `columns`, `rows`, `isTTY`, `getColorDepth()`, `hasColors()`
- `KeypressTaggedStream = Readable & { [key: symbol]: ... }` — symbol-keyed runtime state for the keypress decoder. Modeled as **intersection** (not `extends`) because `Readable` already has built-in symbol keys (`Symbol.asyncDispose`, `EventEmitter.captureRejectionSymbol`, `Symbol.asyncIterator`) whose value types would conflict with the union.
- `KeypressEmitter` — minimal `{ emit }` shape for `emitKeys`.

NOT in `package.json#exports` (verified — only `.` and `./promises` exposed). Per Rule 2c, internal helpers don't leak to consumers.

Public API of `Interface` class unchanged (`_input: Readable | null`, `_output: Writable | null`). `emitKeypressEvents(stream, iface)` signature tightened: `Readable & Record<symbol, unknown>` → plain `Readable` (Node-spec compatible). Added `escapeCodeTimeout?: number` field on `Interface` (already on `InterfaceOptions`) for both Node behavior parity AND so `emitKeypressEvents(stream, this)` satisfies the structural `{ escapeCodeTimeout?: number }` parameter without `as any`.

## `as any` count

| Scope | Before | After |
|---|---|---|
| `src/index.ts` | 26 | **0** |

No casts had to be retained — target reached cleanly.

## Out of scope

- `src/promises.ts` (1 cast) — instructions specified production source `index.ts` only
- `src/index.spec.ts` (1 cast) — same

## Test plan

- [x] `cd packages/node/readline && yarn build && yarn check && yarn test:gjs && yarn test:node` — **145/145 green** on both Node and GJS (unchanged baseline)
- [ ] CI green