### PR TITLE
refactor(http): hybrid type-only @gjsify/http imports in spec to remove as-any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,39 @@
 
 ### Refactoring
 
+* **webcrypto (2026-05-09):** type-safety pass on
+  `packages/web/webcrypto/src/index.spec.ts` (Workstream M). `as any`
+  reduced from 26 → 0. Pattern-(a) algorithm narrowings — `(key.algorithm
+  as any).length` / `.hash.name` / `.namedCurve` (19 occurrences) — now
+  use the impl-side `AesKeyAlgorithm` / `HmacKeyAlgorithm` /
+  `EcKeyAlgorithm` interfaces, type-only-imported from `@gjsify/webcrypto`
+  (Rule 2b — the spec is cross-platform and runs in the Node bundle, so a
+  runtime `import { … } from '@gjsify/webcrypto'` would drag GJS-only
+  `@girs/*` code in via `subtle.ts`'s `import('crypto')` path; type-only
+  imports are erased at compile time). Three `getRandomValues(<invalid>
+  as any)` casts on `Float32Array` / `Float64Array` / `DataView` retyped
+  to `as unknown as ArrayBufferView<ArrayBuffer>` (preserves the
+  intentional invalid-input test). Two `KeyUsage[]` casts (`['encrypt']
+  as any` for HMAC, `['sign'] as any` for AES) tightened to `as unknown
+  as KeyUsage[]`. The five remaining `as any`s on first arguments to
+  `generateKey({ name: 'CHACHA20' } as any, …)` / `{ name: 'AES-CBC',
+  length: 100 } as any` / `'pkcs8' as any` were dead weight — the public
+  signatures (`AlgorithmIdentifier = string | { name: string; [key:
+  string]: unknown }`, `format: 'raw' | 'jwk' | 'pkcs8' | 'spki'`)
+  already accept these shapes, so the casts were stripped entirely. New
+  type-only re-exports from `packages/web/webcrypto/src/index.ts`:
+  `AesKeyAlgorithm`, `HmacKeyAlgorithm`, `EcKeyAlgorithm`,
+  `RsaHashedKeyAlgorithm`, plus the full set of algorithm-parameter
+  interfaces (`AesKeyGenParams`, `HmacKeyGenParams`, `EcKeyGenParams`,
+  `HmacImportParams`, `EcKeyImportParams`, `AesCbcParams`, `AesCtrParams`,
+  `AesGcmParams`, `RsaOaepParams`, `EcdsaParams`, `RsaPssParams`,
+  `Pbkdf2Params`, `HkdfParams`, `EcdhKeyDeriveParams`,
+  `AlgorithmIdentifier`) — these were already declared in `crypto-key.ts`
+  but only `KeyAlgorithm` / `KeyUsage` / `KeyType` / `CryptoKeyPair` were
+  re-exported from the package root. All 486 tests green on Node, all
+  GJS tests green (unchanged baseline). Pure type-safety; no runtime
+  change.
+
 * **readline (2026-05-09):** type-safety pass on
   `packages/node/readline/src/index.ts` (Workstream L). `as any`
   reduced from 26 → 0 in production source. New internal-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,39 @@
 
 ### Refactoring
 
+* **http (2026-05-09):** type-safety pass on
+  `packages/node/http/src/index.spec.ts` (Workstream K). `as any`
+  reduced from 50 → 0 (one comment-only mention of the term remains in
+  the file header explaining the strategy). Same hybrid pattern as
+  Workstream G (`@gjsify/http2`): the spec is cross-platform and runs
+  in both the Node and GJS test bundles, so the runtime source stays
+  `import http from 'node:http'` — a direct
+  `import { … } from '@gjsify/http'` would drag `gi://Soup/Gio/GLib`
+  into the Node bundle and crash it at load. Impl-private symbols
+  (`OutgoingMessage`, `IncomingMessage`, `Agent`, `validateHeaderName`,
+  `validateHeaderValue`, `setMaxIdleHTTPParsers`) come in via
+  `import type { … } from '@gjsify/http'` (stripped at compile time)
+  and are exposed through a single `gjsHttp = http as unknown as
+  Omit<typeof http, …> & { … }` boundary cast at the top of the file.
+  Replacements: `(http as any).OutgoingMessage`/`setMaxIdleHTTPParsers`/
+  `validateHeaderName`/`validateHeaderValue` → `gjsHttp.<name>`;
+  `new (http.IncomingMessage as any)(null)` (15×) →
+  `new gjsHttp.IncomingMessage(null)` (constructor typed as
+  `(socket?: unknown) => IncomingMessage` to model the GJS impl's
+  zero-arg constructor); `(agent as any).protocol`/`maxFreeSockets`/
+  `keepAliveMsecs`/`keepAlive` → bare property access on
+  `new gjsHttp.Agent()`; `(http.globalAgent as any).protocol` →
+  `gjsHttp.globalAgent.protocol`; `(res as any).appendHeader`/
+  `writeContinue`/`flushHeaders` → bare method calls (these are
+  already in `@types/node`'s `ServerResponse`, so the casts were dead
+  weight). One `100 as any` (negative-test for `validateHeaderName`)
+  tightened to `100 as unknown as string`. Two `catch (error: any)`
+  blocks reduced to bare `catch (error)`. No new exports from
+  `@gjsify/http` were needed — every symbol was already exported. All
+  1040 Node tests + 1038 GJS tests green (unchanged baseline). Pure
+  type-safety; no runtime change. Hygiene check: `dist/test.node.mjs`
+  contains zero `gi://` imports.
+
 * **webcrypto (2026-05-09):** type-safety pass on
   `packages/web/webcrypto/src/index.spec.ts` (Workstream M). `as any`
   reduced from 26 → 0. Pattern-(a) algorithm narrowings — `(key.algorithm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,37 @@
 
 ### Refactoring
 
+* **readline (2026-05-09):** type-safety pass on
+  `packages/node/readline/src/index.ts` (Workstream L). `as any`
+  reduced from 26 → 0 in production source. New internal-only
+  helper module `src/internal/stream-types.ts` (per AGENTS.md
+  Rule 2c — not exported from `package.json#exports`) declares
+  `GjsReadableTty` and `GjsWritableTty` interfaces that augment
+  `node:stream`'s `Readable`/`Writable` with the TTY-specific
+  runtime members (`isRaw`, `isTTY`, `setRawMode`, `columns`,
+  `rows`, `getColorDepth`, `hasColors`) that exist on both
+  `tty.ReadStream`/`WriteStream` and `@gjsify/process`'s
+  `ProcessReadStream`/`ProcessWriteStream` but are absent from the
+  base `Readable`/`Writable` types. A third helper
+  `KeypressTaggedStream` (intersection type — `Readable &
+  { [key: symbol]: ... }`, modelled as intersection rather than
+  `extends Readable` to avoid colliding with `Readable`'s built-in
+  symbol keys like `Symbol.asyncDispose` /
+  `EventEmitter.captureRejectionSymbol`) replaces the
+  `(stream as any)[_KEYPRESS_DECODER]` casts in
+  `emitKeypressEvents`. Public API of `Interface` unchanged
+  (`_input: Readable | null`, `_output: Writable | null`); only
+  internal usage narrows. The `emitKeypressEvents(stream, iface)`
+  signature was tightened from `Readable & Record<symbol, unknown>`
+  to plain `Readable` (Node-spec compatible) with the symbol-tagged
+  view applied internally. Side-effects: `Interface` now exposes
+  the `escapeCodeTimeout?: number` field already declared on
+  `InterfaceOptions` so `emitKeypressEvents(stream, this)`
+  satisfies the structural `{ escapeCodeTimeout?: number }`
+  parameter without `as any` (also a behavior parity improvement —
+  Node readline forwards `opts.escapeCodeTimeout`). All 145 tests
+  green on both Node and GJS (unchanged baseline).
+
 * **zlib (2026-05-09):** type-safety pass on
   `packages/node/zlib/src/index.spec.ts` (Workstream J). `as any`
   reduced from 20 → 0. All 20 occurrences were `gzipSync(str as

--- a/packages/node/http/src/index.spec.ts
+++ b/packages/node/http/src/index.spec.ts
@@ -1,13 +1,51 @@
 // Ported from refs/node-test/parallel/test-http-*.js
 // Original: MIT license, Node.js contributors
-import { describe, it, expect, on } from '@gjsify/unit';
+//
+// Type strategy (Workstream K): runtime values come from `node:http` so the Node
+// bundle stays free of `gi://*` imports (this file is loaded by the same
+// `test.mts` aggregator that also drives `test:node`; a direct
+// `import { … } from '@gjsify/http'` would drag `gi://Soup/Gio/GLib` into the
+// Node bundle and crash it at load). For static typing we pull the
+// impl-private symbols (`OutgoingMessage`, `validateHeaderName`,
+// `validateHeaderValue`, `setMaxIdleHTTPParsers`) from `@gjsify/http` via
+// type-only imports — stripped at compile time, so the Node bundle is
+// unaffected, but TypeScript sees the real shapes (concrete subclasses of
+// `Writable`/`Readable`) and the entire `as any` chain that `@types/node`
+// would force disappears.
+
+import { describe, it, expect } from '@gjsify/unit';
 import { Buffer } from 'node:buffer';
 
-import * as http from 'node:http';
-import type { validateHeaderName as gjsifyValidateHeaderName, validateHeaderValue as gjsifyValidateHeaderValue } from 'node:http';
+import http from 'node:http';
+import type {
+  OutgoingMessage as OurOutgoingMessage,
+  IncomingMessage as OurIncomingMessage,
+  Agent as OurAgent,
+  validateHeaderName as ourValidateHeaderName,
+  validateHeaderValue as ourValidateHeaderValue,
+  setMaxIdleHTTPParsers as ourSetMaxIdleHTTPParsers,
+} from '@gjsify/http';
 
-const validateHeaderName: typeof gjsifyValidateHeaderName = (http as any).validateHeaderName;
-const validateHeaderValue: typeof gjsifyValidateHeaderValue = (http as any).validateHeaderValue;
+// Local view of `node:http`'s default export retyped against our impl-private
+// classes. `node:http` is the runtime source on both Node and GJS (alias-mapped
+// to `@gjsify/http` on the GJS target by the build), but its declarations come
+// from `@types/node` and don't expose the GJS-only shapes we want to assert
+// against. This cast is the single boundary between the two views.
+const gjsHttp = http as unknown as Omit<
+  typeof http,
+  'OutgoingMessage' | 'IncomingMessage' | 'Agent' | 'globalAgent'
+> & {
+  OutgoingMessage: typeof OurOutgoingMessage;
+  IncomingMessage: new (socket?: unknown) => OurIncomingMessage;
+  Agent: new (options?: ConstructorParameters<typeof OurAgent>[0]) => OurAgent;
+  globalAgent: OurAgent;
+  validateHeaderName: typeof ourValidateHeaderName;
+  validateHeaderValue: typeof ourValidateHeaderValue;
+  setMaxIdleHTTPParsers: typeof ourSetMaxIdleHTTPParsers;
+};
+
+const validateHeaderName = gjsHttp.validateHeaderName;
+const validateHeaderValue = gjsHttp.validateHeaderValue;
 
 export default async () => {
 
@@ -39,7 +77,7 @@ export default async () => {
       let threw = false;
       try {
         validateHeaderName('');
-      } catch (error: any) {
+      } catch (error) {
         threw = true;
         expect(error instanceof TypeError).toBe(true);
       }
@@ -61,8 +99,8 @@ export default async () => {
     await it('should throw for number input', async () => {
       let threw = false;
       try {
-        validateHeaderName(100 as any);
-      } catch (error: any) {
+        validateHeaderName(100 as unknown as string);
+      } catch (error) {
         threw = true;
         expect(error instanceof TypeError).toBe(true);
       }
@@ -260,7 +298,7 @@ export default async () => {
     });
 
     await it('should export OutgoingMessage', async () => {
-      expect(typeof (http as any).OutgoingMessage).toBe('function');
+      expect(typeof gjsHttp.OutgoingMessage).toBe('function');
     });
 
     await it('should export ClientRequest', async () => {
@@ -273,14 +311,14 @@ export default async () => {
     });
 
     await it('should export setMaxIdleHTTPParsers', async () => {
-      expect(typeof (http as any).setMaxIdleHTTPParsers).toBe('function');
+      expect(typeof gjsHttp.setMaxIdleHTTPParsers).toBe('function');
       // Should not throw
-      (http as any).setMaxIdleHTTPParsers(256);
+      gjsHttp.setMaxIdleHTTPParsers(256);
     });
 
     await it('should export validateHeaderName and validateHeaderValue', async () => {
-      expect(typeof (http as any).validateHeaderName).toBe('function');
-      expect(typeof (http as any).validateHeaderValue).toBe('function');
+      expect(typeof gjsHttp.validateHeaderName).toBe('function');
+      expect(typeof gjsHttp.validateHeaderValue).toBe('function');
     });
 
     await it('should have a default export', async () => {
@@ -292,7 +330,7 @@ export default async () => {
   // --- OutgoingMessage ---
   await describe('http.OutgoingMessage', async () => {
     await it('should be constructable', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg).toBeDefined();
       expect(msg.headersSent).toBe(false);
@@ -300,7 +338,7 @@ export default async () => {
     });
 
     await it('should support setHeader/getHeader/hasHeader/removeHeader', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('X-Test', 'value');
       expect(msg.getHeader('x-test')).toBe('value');
@@ -310,7 +348,7 @@ export default async () => {
     });
 
     await it('should support getHeaderNames and getHeaders', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('Content-Type', 'text/plain');
       msg.setHeader('X-Custom', 'val');
@@ -322,7 +360,7 @@ export default async () => {
     });
 
     await it('should support appendHeader', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('Set-Cookie', 'a=1');
       msg.appendHeader('Set-Cookie', 'b=2');
@@ -331,19 +369,19 @@ export default async () => {
     });
 
     await it('should have sendDate property', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(typeof msg.sendDate).toBe('boolean');
     });
 
     await it('should have sendDate as boolean', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(typeof msg.sendDate).toBe('boolean');
     });
 
     await it('should store headers case-insensitively', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('Content-Type', 'text/html');
       expect(msg.getHeader('content-type')).toBe('text/html');
@@ -352,7 +390,7 @@ export default async () => {
     });
 
     await it('should overwrite existing header with setHeader', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('X-Test', 'first');
       msg.setHeader('X-Test', 'second');
@@ -360,19 +398,19 @@ export default async () => {
     });
 
     await it('should return undefined for non-existent header', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg.getHeader('x-nonexistent')).toBeUndefined();
     });
 
     await it('should return false for hasHeader on non-existent header', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg.hasHeader('x-nonexistent')).toBe(false);
     });
 
     await it('should handle removeHeader for non-existent header without error', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       // Should not throw
       msg.removeHeader('x-nonexistent');
@@ -380,7 +418,7 @@ export default async () => {
     });
 
     await it('should return empty arrays when no headers set', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg.getHeaderNames().length).toBe(0);
       const headers = msg.getHeaders();
@@ -388,16 +426,16 @@ export default async () => {
     });
 
     await it('should accept numeric header values via setHeader', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('Content-Length', 42);
       const val = msg.getHeader('content-length');
       // Node.js stores as number, GJS stores as string -- both are valid
-      expect(val == 42).toBe(true);
+      expect(val as unknown as number == 42).toBe(true);
     });
 
     await it('should accept array header values via setHeader', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('Set-Cookie', ['a=1', 'b=2']);
       const val = msg.getHeader('set-cookie');
@@ -405,7 +443,7 @@ export default async () => {
     });
 
     await it('should support appendHeader with array value', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.setHeader('X-Multi', 'first');
       msg.appendHeader('X-Multi', ['second', 'third']);
@@ -414,20 +452,20 @@ export default async () => {
     });
 
     await it('should support appendHeader on non-existent header', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       msg.appendHeader('X-New', 'value');
       expect(msg.getHeader('x-new')).toBe('value');
     });
 
     await it('should have headersSent default to false', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg.headersSent).toBe(false);
     });
 
     await it('should have socket property default to null', async () => {
-      const OutgoingMessage = (http as any).OutgoingMessage;
+      const OutgoingMessage = gjsHttp.OutgoingMessage;
       const msg = new OutgoingMessage();
       expect(msg.socket).toBeNull();
     });
@@ -452,23 +490,23 @@ export default async () => {
     });
 
     await it('should have protocol property', async () => {
-      const agent = new http.Agent();
-      expect((agent as any).protocol).toBe('http:');
+      const agent = new gjsHttp.Agent();
+      expect(agent.protocol).toBe('http:');
     });
 
     await it('should have maxFreeSockets property', async () => {
-      const agent = new http.Agent();
-      expect((agent as any).maxFreeSockets).toBe(256);
+      const agent = new gjsHttp.Agent();
+      expect(agent.maxFreeSockets).toBe(256);
     });
 
     await it('should have keepAliveMsecs property', async () => {
-      const agent = new http.Agent();
-      expect((agent as any).keepAliveMsecs).toBe(1000);
+      const agent = new gjsHttp.Agent();
+      expect(agent.keepAliveMsecs).toBe(1000);
     });
 
     await it('should have keepAlive property', async () => {
-      const agent = new http.Agent();
-      expect((agent as any).keepAlive).toBe(false);
+      const agent = new gjsHttp.Agent();
+      expect(agent.keepAlive).toBe(false);
     });
 
     await it('should not throw when destroy is called', async () => {
@@ -497,7 +535,7 @@ export default async () => {
     });
 
     await it('should have protocol http:', async () => {
-      expect((http.globalAgent as any).protocol).toBe('http:');
+      expect(gjsHttp.globalAgent.protocol).toBe('http:');
     });
 
     await it('should have destroy method', async () => {
@@ -508,87 +546,88 @@ export default async () => {
   // --- IncomingMessage standalone ---
   await describe('http.IncomingMessage standalone', async () => {
     await it('should be constructable', async () => {
-      // Node.js requires a socket arg; GJS does not — use (null as any) for compat
-      const msg = new (http.IncomingMessage as any)(null);
+      // Node.js requires a socket arg; GJS does not — gjsHttp.IncomingMessage's
+      // constructor signature is `(socket?: unknown)` so passing null is fine.
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(msg).toBeDefined();
     });
 
     await it('should have httpVersion property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to null, GJS defaults to '1.1' — both are valid initial values
       expect(msg.httpVersion === null || msg.httpVersion === '1.1').toBe(true);
     });
 
     await it('should have httpVersionMajor and httpVersionMinor properties', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to null, GJS defaults to 1
       expect(msg.httpVersionMajor === null || msg.httpVersionMajor === 1).toBe(true);
       expect(msg.httpVersionMinor === null || msg.httpVersionMinor === 1).toBe(true);
     });
 
     await it('should have empty headers object', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(typeof msg.headers).toBe('object');
       expect(Object.keys(msg.headers).length).toBe(0);
     });
 
     await it('should have empty rawHeaders array', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(Array.isArray(msg.rawHeaders)).toBe(true);
       expect(msg.rawHeaders.length).toBe(0);
     });
 
     await it('should have method property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to null, GJS defaults to undefined
       expect(msg.method === null || msg.method === undefined).toBe(true);
     });
 
     await it('should have url property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to '', GJS defaults to undefined — both are falsy
       expect(!msg.url || msg.url === '').toBe(true);
     });
 
     await it('should have statusCode property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to null, GJS defaults to undefined
       expect(msg.statusCode === null || msg.statusCode === undefined).toBe(true);
     });
 
     await it('should have statusMessage property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       // Node.js defaults to null, GJS defaults to undefined
       expect(msg.statusMessage === null || msg.statusMessage === undefined || msg.statusMessage === '').toBe(true);
     });
 
     await it('should have complete default to false', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(msg.complete).toBe(false);
     });
 
     await it('should have aborted default to false', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(msg.aborted).toBe(false);
     });
 
     await it('should have socket property', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(msg.socket).toBeNull();
     });
 
     await it('should have setTimeout method', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(typeof msg.setTimeout).toBe('function');
     });
 
     await it('should have destroy method', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(typeof msg.destroy).toBe('function');
     });
 
     await it('should be a Readable stream', async () => {
-      const msg = new (http.IncomingMessage as any)(null);
+      const msg = new gjsHttp.IncomingMessage(null);
       expect(typeof msg.on).toBe('function');
       expect(typeof msg.read).toBe('function');
       expect(typeof msg.pipe).toBe('function');
@@ -808,7 +847,7 @@ export default async () => {
     await it('should support appendHeader', async () => {
       const server = http.createServer((req, res) => {
         res.setHeader('X-Multi', 'first');
-        (res as any).appendHeader('X-Multi', 'second');
+        res.appendHeader('X-Multi', 'second');
         const val = res.getHeader('X-Multi');
         expect(Array.isArray(val)).toBeTruthy();
         res.writeHead(200);
@@ -830,7 +869,7 @@ export default async () => {
     await it('should support writeContinue', async () => {
       const server = http.createServer((req, res) => {
         let continueCalled = false;
-        (res as any).writeContinue(() => { continueCalled = true; });
+        res.writeContinue(() => { continueCalled = true; });
         res.writeHead(200);
         res.end('ok');
       });
@@ -850,7 +889,7 @@ export default async () => {
     await it('should support flushHeaders', async () => {
       const server = http.createServer((req, res) => {
         res.writeHead(200, { 'X-Flush': 'test' });
-        (res as any).flushHeaders();
+        res.flushHeaders();
         expect(res.headersSent).toBeTruthy();
         res.end('ok');
       });

--- a/packages/node/readline/src/index.ts
+++ b/packages/node/readline/src/index.ts
@@ -4,6 +4,12 @@
 import { EventEmitter } from 'node:events';
 import { StringDecoder } from 'node:string_decoder';
 import type { Readable, Writable } from 'node:stream';
+import type {
+  GjsReadableTty,
+  GjsWritableTty,
+  KeypressEmitter,
+  KeypressTaggedStream,
+} from './internal/stream-types.js';
 
 export interface InterfaceOptions {
   input?: Readable;
@@ -24,6 +30,10 @@ export class Interface extends EventEmitter {
   terminal: boolean;
   line = '';
   cursor = 0;
+  // Mirrors `InterfaceOptions.escapeCodeTimeout` so that
+  // `emitKeypressEvents(stream, this)` can read it via the structural
+  // `{ escapeCodeTimeout?: number }` parameter shape.
+  escapeCodeTimeout?: number;
 
   private _input: Readable | null;
   private _output: Writable | null;
@@ -63,6 +73,7 @@ export class Interface extends EventEmitter {
     this._historySize = opts.historySize ?? 30;
     this.history = [];
     this._crlfDelay = opts.crlfDelay ?? 100;
+    this.escapeCodeTimeout = opts.escapeCodeTimeout;
 
     if (this._input) {
       this._boundOnData = (chunk: Buffer | string) => this._onData(chunk);
@@ -77,12 +88,13 @@ export class Interface extends EventEmitter {
       }
 
       if (this.terminal) {
-        emitKeypressEvents(this._input as Readable & Record<symbol, unknown>, this as any);
-        if ('setRawMode' in this._input && typeof (this._input as any).setRawMode === 'function') {
-          if (!(this._input as any).isRaw) (this._input as any).setRawMode(true);
+        emitKeypressEvents(this._input, this);
+        const ttyInput = this._input as GjsReadableTty;
+        if (typeof ttyInput.setRawMode === 'function') {
+          if (!ttyInput.isRaw) ttyInput.setRawMode(true);
         }
-        if ('resume' in this._input && typeof (this._input as any).resume === 'function') {
-          (this._input as any).resume();
+        if (typeof this._input.resume === 'function') {
+          this._input.resume();
         }
 
         this._boundOnKeypress = (str: string | undefined, key: Key) => {
@@ -176,7 +188,7 @@ export class Interface extends EventEmitter {
   write(data: string | Buffer | null, key?: { ctrl?: boolean; meta?: boolean; shift?: boolean; name?: string }): void {
     if (this._closed) return;
     if (key) {
-      if (this._input) (this._input as any).emit('keypress', data ?? '', key);
+      if (this._input) this._input.emit('keypress', data ?? '', key);
       return;
     }
     if (data !== null && data !== undefined) {
@@ -207,16 +219,16 @@ export class Interface extends EventEmitter {
       this._boundOnError = null;
       this._boundOnKeypress = null;
 
-      if (this.terminal && (this._input as any).isRaw &&
-          'setRawMode' in this._input && typeof (this._input as any).setRawMode === 'function') {
-        (this._input as any).setRawMode(false);
+      const ttyInput = this._input as GjsReadableTty;
+      if (this.terminal && ttyInput.isRaw && typeof ttyInput.setRawMode === 'function') {
+        ttyInput.setRawMode(false);
       }
 
       // Pause stdin so ProcessReadStream releases the GLib main loop via
       // quitMainLoop(). Mirrors Node.js readline: close() pauses the stream
       // so the event loop can drain and the process exits when no more prompts follow.
-      if ('pause' in this._input && typeof (this._input as any).pause === 'function') {
-        (this._input as any).pause();
+      if (typeof this._input.pause === 'function') {
+        this._input.pause();
       }
     }
 
@@ -244,7 +256,7 @@ export class Interface extends EventEmitter {
   }
 
   getCursorPos(): { rows: number; cols: number } {
-    const columns = (this._output as any)?.columns ?? 80;
+    const columns = (this._output as GjsWritableTty | null)?.columns ?? 80;
     const len = this._prompt.length + this.cursor;
     return { rows: Math.floor(len / columns), cols: len % columns };
   }
@@ -495,42 +507,47 @@ const _ESCAPE_DECODER   = Symbol('escape-decoder');
 
 // Idempotent — calling twice on the same stream is a no-op.
 // Ported from refs/node/lib/internal/readline/emitKeypressEvents.js.
-export function emitKeypressEvents(stream: Readable & Record<symbol, unknown>, iface: { escapeCodeTimeout?: number } = {}): void {
-  if ((stream as any)[_KEYPRESS_DECODER]) return;
+export function emitKeypressEvents(stream: Readable, iface: { escapeCodeTimeout?: number } = {}): void {
+  // Cast once to the symbol-tagged shape; runtime augmentation is tracked
+  // via two private symbols (decoder + escape-state generator).
+  const tagged = stream as KeypressTaggedStream;
+  if (tagged[_KEYPRESS_DECODER]) return;
 
-  (stream as any)[_KEYPRESS_DECODER] = new StringDecoder('utf8');
-  (stream as any)[_ESCAPE_DECODER] = emitKeys(stream as any);
-  (stream as any)[_ESCAPE_DECODER].next();
+  tagged[_KEYPRESS_DECODER] = new StringDecoder('utf8');
+  tagged[_ESCAPE_DECODER] = emitKeys(stream as KeypressEmitter);
+  (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next();
 
   const escTimeout = iface.escapeCodeTimeout ?? ESCAPE_CODE_TIMEOUT;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const triggerEscape = () => (stream as any)[_ESCAPE_DECODER].next('');
+  const triggerEscape = () =>
+    (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next('');
 
   function onData(input: Buffer | string): void {
-    if ((stream as any).listenerCount('keypress') > 0) {
-      const str: string = (stream as any)[_KEYPRESS_DECODER].write(
+    if (stream.listenerCount('keypress') > 0) {
+      const decoder = tagged[_KEYPRESS_DECODER] as StringDecoder;
+      const str: string = decoder.write(
         typeof input === 'string' ? Buffer.from(input) : input,
       );
       if (str) {
         clearTimeout(timeoutId);
         for (const ch of str) {
           try {
-            (stream as any)[_ESCAPE_DECODER].next(ch);
+            (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next(ch);
             if (ch === '\x1b') timeoutId = setTimeout(triggerEscape, escTimeout);
           } catch {
-            (stream as any)[_ESCAPE_DECODER] = emitKeys(stream as any);
-            (stream as any)[_ESCAPE_DECODER].next();
+            tagged[_ESCAPE_DECODER] = emitKeys(stream as KeypressEmitter);
+            (tagged[_ESCAPE_DECODER] as Generator<void, void, string>).next();
           }
         }
       }
     } else {
-      (stream as any).removeListener('data', onData);
-      delete (stream as any)[_KEYPRESS_DECODER];
-      delete (stream as any)[_ESCAPE_DECODER];
+      stream.removeListener('data', onData);
+      delete tagged[_KEYPRESS_DECODER];
+      delete tagged[_ESCAPE_DECODER];
     }
   }
 
-  (stream as any).on('data', onData);
+  stream.on('data', onData);
 }
 
 export default {

--- a/packages/node/readline/src/internal/stream-types.ts
+++ b/packages/node/readline/src/internal/stream-types.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Internal type helpers for readline — narrowing Node's Readable/Writable
+// to the TTY-extended runtime shape we get on both Node tty streams and
+// @gjsify/process's stdin/stdout/stderr. NOT exported from the package's
+// public surface (per AGENTS.md Rule 2c).
+//
+// `tty.ReadStream` / `tty.WriteStream` extend `net.Socket` (which extends
+// `Readable`/`Writable` via `Duplex`) and add the TTY-specific runtime
+// methods used by readline (setRawMode, isRaw, isTTY, columns, rows,
+// getColorDepth, hasColors). The standalone `Readable`/`Writable` types
+// in `node:stream` do not declare these — but at runtime our public API
+// accepts any `Readable`/`Writable`, and either falls back gracefully or
+// uses `in`/`typeof` guards before invoking. These interfaces let us
+// narrow without `as any`.
+//
+// Additionally, the keypress parser stores its `StringDecoder` and
+// `emitKeys` generator on the input stream via two private symbols
+// (`_KEYPRESS_DECODER`, `_ESCAPE_DECODER`). The `KeypressTaggedStream`
+// type describes that runtime augmentation.
+
+import type { Readable, Writable } from 'node:stream';
+import type { StringDecoder } from 'node:string_decoder';
+
+/**
+ * `Readable` augmented with the TTY-specific runtime methods that exist
+ * on `tty.ReadStream` and on `@gjsify/process`'s `ProcessReadStream`.
+ * All members are optional — readline always guards with `'method' in stream`
+ * + `typeof stream.method === 'function'` before calling.
+ */
+export interface GjsReadableTty extends Readable {
+  isRaw?: boolean;
+  isTTY?: boolean;
+  setRawMode?(enable: boolean): this;
+}
+
+/**
+ * `Writable` augmented with the TTY-specific runtime properties that exist
+ * on `tty.WriteStream` and on `@gjsify/process`'s `ProcessWriteStream`.
+ * All members are optional for the same reason as `GjsReadableTty`.
+ */
+export interface GjsWritableTty extends Writable {
+  columns?: number;
+  rows?: number;
+  isTTY?: boolean;
+  getColorDepth?(env?: NodeJS.ProcessEnv): number;
+  hasColors?(count?: number, env?: NodeJS.ProcessEnv): boolean;
+}
+
+/**
+ * Symbol-keyed runtime state that `emitKeypressEvents` attaches to the
+ * input stream. The two private symbols carry the per-stream
+ * `StringDecoder` and the live `emitKeys` generator, plus a re-entrancy
+ * guard so the second call on the same stream is a no-op.
+ *
+ * Modeled as an intersection (rather than `extends Readable` with a
+ * `[key: symbol]` index signature) because `Readable` already declares
+ * built-in symbol keys — `EventEmitter.captureRejectionSymbol`,
+ * `Symbol.asyncDispose`, `Symbol.asyncIterator` — whose value types
+ * would conflict with a narrow union signature.
+ */
+export type KeypressTaggedStream = Readable & {
+  [key: symbol]: StringDecoder | Generator<void, void, string> | undefined;
+};
+
+/**
+ * Minimal `EventEmitter`-like shape used by the keypress parser to dispatch
+ * `'keypress'` events back onto the stream. `Readable` already satisfies
+ * this via its `EventEmitter` ancestry.
+ */
+export interface KeypressEmitter {
+  emit(event: string | symbol, ...args: unknown[]): boolean;
+}

--- a/packages/web/webcrypto/src/index.spec.ts
+++ b/packages/web/webcrypto/src/index.spec.ts
@@ -4,6 +4,12 @@
 // Original: MIT license (Deno), 3-Clause BSD license (WPT), MIT license (Node.js contributors)
 
 import { describe, it, expect, on } from '@gjsify/unit';
+import type {
+  AesKeyAlgorithm,
+  HmacKeyAlgorithm,
+  EcKeyAlgorithm,
+  KeyUsage,
+} from '@gjsify/webcrypto';
 
 export default async () => {
 
@@ -101,7 +107,7 @@ export default async () => {
     await it('should throw for Float32Array', async () => {
       let threw = false;
       try {
-        crypto.getRandomValues(new Float32Array(1) as any);
+        crypto.getRandomValues(new Float32Array(1) as unknown as ArrayBufferView<ArrayBuffer>);
       } catch {
         threw = true;
       }
@@ -111,7 +117,7 @@ export default async () => {
     await it('should throw for Float64Array', async () => {
       let threw = false;
       try {
-        crypto.getRandomValues(new Float64Array(1) as any);
+        crypto.getRandomValues(new Float64Array(1) as unknown as ArrayBufferView<ArrayBuffer>);
       } catch {
         threw = true;
       }
@@ -121,7 +127,7 @@ export default async () => {
     await it('should throw for DataView', async () => {
       let threw = false;
       try {
-        crypto.getRandomValues(new DataView(new ArrayBuffer(1)) as any);
+        crypto.getRandomValues(new DataView(new ArrayBuffer(1)) as unknown as ArrayBufferView<ArrayBuffer>);
       } catch {
         threw = true;
       }
@@ -327,7 +333,7 @@ export default async () => {
         ['encrypt', 'decrypt'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).length).toBe(128);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(128);
     });
 
     await it('should generate AES-CTR 192 key', async () => {
@@ -337,7 +343,7 @@ export default async () => {
         ['encrypt', 'decrypt'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).length).toBe(192);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(192);
     });
 
     await it('should generate AES-GCM 256 key', async () => {
@@ -348,7 +354,7 @@ export default async () => {
       ) as CryptoKey;
       expect(key.type).toBe('secret');
       expect(key.algorithm.name).toBe('AES-GCM');
-      expect((key.algorithm as any).length).toBe(256);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(256);
     });
 
     await it('should generate AES-CBC 128 key', async () => {
@@ -358,7 +364,7 @@ export default async () => {
         ['encrypt', 'decrypt'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).length).toBe(128);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(128);
     });
 
     await it('should generate non-extractable key', async () => {
@@ -398,7 +404,7 @@ export default async () => {
       ) as CryptoKey;
       expect(key.type).toBe('secret');
       expect(key.algorithm.name).toBe('HMAC');
-      expect((key.algorithm as any).hash.name).toBe('SHA-256');
+      expect((key.algorithm as HmacKeyAlgorithm).hash.name).toBe('SHA-256');
     });
 
     await it('should generate HMAC key with SHA-1', async () => {
@@ -408,7 +414,7 @@ export default async () => {
         ['sign', 'verify'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).hash.name).toBe('SHA-1');
+      expect((key.algorithm as HmacKeyAlgorithm).hash.name).toBe('SHA-1');
     });
 
     await it('should generate HMAC key with SHA-384', async () => {
@@ -418,7 +424,7 @@ export default async () => {
         ['sign', 'verify'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).hash.name).toBe('SHA-384');
+      expect((key.algorithm as HmacKeyAlgorithm).hash.name).toBe('SHA-384');
     });
 
     await it('should generate HMAC key with SHA-512', async () => {
@@ -428,7 +434,7 @@ export default async () => {
         ['sign', 'verify'],
       ) as CryptoKey;
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).hash.name).toBe('SHA-512');
+      expect((key.algorithm as HmacKeyAlgorithm).hash.name).toBe('SHA-512');
     });
   });
 
@@ -538,7 +544,7 @@ export default async () => {
         'raw', rawKey, { name: 'AES-CBC' }, true, ['encrypt', 'decrypt'],
       );
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).length).toBe(128);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(128);
     });
 
     await it('should import raw AES-192 key', async () => {
@@ -547,7 +553,7 @@ export default async () => {
         'raw', rawKey, { name: 'AES-CBC' }, true, ['encrypt', 'decrypt'],
       );
       expect(key.type).toBe('secret');
-      expect((key.algorithm as any).length).toBe(192);
+      expect((key.algorithm as AesKeyAlgorithm).length).toBe(192);
     });
 
     await it('should import and export JWK HMAC key', async () => {
@@ -1250,7 +1256,7 @@ export default async () => {
 
       expect(derivedKey.type).toBe('secret');
       expect(derivedKey.algorithm.name).toBe('AES-GCM');
-      expect((derivedKey.algorithm as any).length).toBe(256);
+      expect((derivedKey.algorithm as AesKeyAlgorithm).length).toBe(256);
 
       // Verify derived key works for encryption
       const iv = crypto.getRandomValues(new Uint8Array(12));
@@ -1273,7 +1279,7 @@ export default async () => {
       );
       expect(derivedKey.type).toBe('secret');
       expect(derivedKey.algorithm.name).toBe('AES-CBC');
-      expect((derivedKey.algorithm as any).length).toBe(128);
+      expect((derivedKey.algorithm as AesKeyAlgorithm).length).toBe(128);
     });
 
     await it('should derive HMAC key from HKDF', async () => {
@@ -1333,7 +1339,7 @@ export default async () => {
       expect(keyPair.publicKey.type).toBe('public');
       expect(keyPair.privateKey.type).toBe('private');
       expect(keyPair.publicKey.algorithm.name).toBe('ECDH');
-      expect((keyPair.publicKey.algorithm as any).namedCurve).toBe('P-256');
+      expect((keyPair.publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
     });
 
     await it('should derive shared secret between two key pairs', async () => {
@@ -1402,7 +1408,7 @@ export default async () => {
 
       expect(keyPair.publicKey.type).toBe('public');
       expect(keyPair.privateKey.type).toBe('private');
-      expect((keyPair.publicKey.algorithm as any).namedCurve).toBe('P-384');
+      expect((keyPair.publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-384');
     });
 
     await it('ECDH P-384 shared secret', async () => {
@@ -1509,7 +1515,7 @@ export default async () => {
         ['sign', 'verify'],
       ) as CryptoKey;
       expect(key.algorithm.name).toBe('HMAC');
-      expect((key.algorithm as any).hash.name).toBe('SHA-512');
+      expect((key.algorithm as HmacKeyAlgorithm).hash.name).toBe('SHA-512');
     });
 
     await it('EC key pair should have namedCurve in algorithm', async () => {
@@ -1518,8 +1524,8 @@ export default async () => {
         true,
         ['sign', 'verify'],
       ) as CryptoKeyPair;
-      expect((keyPair.publicKey.algorithm as any).namedCurve).toBe('P-256');
-      expect((keyPair.privateKey.algorithm as any).namedCurve).toBe('P-256');
+      expect((keyPair.publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
+      expect((keyPair.privateKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
     });
   });
 
@@ -1536,7 +1542,7 @@ export default async () => {
       expect(keyPair.publicKey.type).toBe('public');
       expect(keyPair.privateKey.type).toBe('private');
       expect(keyPair.publicKey.algorithm.name).toBe('ECDSA');
-      expect((keyPair.publicKey.algorithm as any).namedCurve).toBe('P-256');
+      expect((keyPair.publicKey.algorithm as EcKeyAlgorithm).namedCurve).toBe('P-256');
     });
 
     await it('should sign and verify with ECDSA P-256 SHA-256', async () => {
@@ -1714,7 +1720,7 @@ export default async () => {
       let threw = false;
       try {
         await subtle.generateKey(
-          { name: 'CHACHA20' } as any, true, ['encrypt', 'decrypt'],
+          { name: 'CHACHA20' }, true, ['encrypt', 'decrypt'],
         );
       } catch {
         threw = true;
@@ -1752,7 +1758,7 @@ export default async () => {
       let threw = false;
       try {
         await subtle.generateKey(
-          { name: 'AES-CBC', length: 100 } as any, true, ['encrypt', 'decrypt'],
+          { name: 'AES-CBC', length: 100 }, true, ['encrypt', 'decrypt'],
         );
       } catch {
         threw = true;
@@ -1786,7 +1792,7 @@ export default async () => {
       try {
         // encrypt is not valid for HMAC
         await subtle.generateKey(
-          { name: 'HMAC', hash: 'SHA-256' }, true, ['encrypt'] as any,
+          { name: 'HMAC', hash: 'SHA-256' }, true, ['encrypt'] as unknown as KeyUsage[],
         );
       } catch {
         threw = true;
@@ -1799,7 +1805,7 @@ export default async () => {
       try {
         // sign is not valid for AES
         await subtle.generateKey(
-          { name: 'AES-CBC', length: 256 }, true, ['sign'] as any,
+          { name: 'AES-CBC', length: 256 }, true, ['sign'] as unknown as KeyUsage[],
         );
       } catch {
         threw = true;
@@ -1811,7 +1817,7 @@ export default async () => {
       let threw = false;
       try {
         await subtle.importKey(
-          'pkcs8' as any, new Uint8Array(32), { name: 'AES-CBC' }, true, ['encrypt'],
+          'pkcs8', new Uint8Array(32), { name: 'AES-CBC' }, true, ['encrypt'],
         );
       } catch {
         threw = true;

--- a/packages/web/webcrypto/src/index.ts
+++ b/packages/web/webcrypto/src/index.ts
@@ -9,7 +9,31 @@
 
 import { SubtleCrypto } from './subtle.js';
 import { CryptoKey } from './crypto-key.js';
-export type { CryptoKeyPair, KeyUsage, KeyAlgorithm, KeyType } from './crypto-key.js';
+export type {
+  CryptoKeyPair,
+  KeyUsage,
+  KeyAlgorithm,
+  KeyType,
+  AesKeyAlgorithm,
+  HmacKeyAlgorithm,
+  EcKeyAlgorithm,
+  RsaHashedKeyAlgorithm,
+  AesKeyGenParams,
+  HmacKeyGenParams,
+  EcKeyGenParams,
+  HmacImportParams,
+  EcKeyImportParams,
+  AesCbcParams,
+  AesCtrParams,
+  AesGcmParams,
+  RsaOaepParams,
+  EcdsaParams,
+  RsaPssParams,
+  Pbkdf2Params,
+  HkdfParams,
+  EcdhKeyDeriveParams,
+  AlgorithmIdentifier,
+} from './crypto-key.js';
 
 // Save reference to native crypto BEFORE any overwriting to avoid recursion
 const _nativeCrypto = typeof globalThis.crypto !== 'undefined' ? globalThis.crypto : null;


### PR DESCRIPTION
## Summary

Drives `as any` in `packages/node/http/src/index.spec.ts` from **50 → 0** (one comment-only mention remains in the file-header strategy doc). **Workstream K** of the type-safety wave 2.

Same hybrid pattern as Workstream G (PR #108, http2): keep `node:http` as the runtime source so the Node test bundle stays free of `gi://*` imports, then pull impl-private symbols (`OutgoingMessage`, `IncomingMessage`, `Agent`, `validateHeaderName`, `validateHeaderValue`, `setMaxIdleHTTPParsers`) via `import type` from `@gjsify/http`. A single boundary cast at the top:

```ts
const gjsHttp = http as unknown as Omit<typeof http, 'OutgoingMessage' | 'IncomingMessage' | 'Agent' | 'globalAgent'> & {
  OutgoingMessage: typeof OurOutgoingMessage;
  IncomingMessage: typeof OurIncomingMessage;
  Agent: typeof OurAgent;
  globalAgent: OurAgent;
  validateHeaderName(name: string): void;
  validateHeaderValue(name: string, value: string): void;
  setMaxIdleHTTPParsers(n: number): void;
};
```

The `Omit<typeof http, …>` is load-bearing — `typeof http` already declares those four names against `@types/node`'s narrower types and a plain intersection let the Node ones win at property access.

## No new exports

Every impl-private symbol the spec touches was already exported from `@gjsify/http/src/index.ts`.

## Hygiene

`grep 'gi://' dist/test.node.mjs` — clean (0 matches). Type-only imports are stripped at compile time. The single `@girs/gjs` import that comes in via `@gjsify/unit`'s GJS bootstrap is the same pre-existing pattern as #108 and is benign on Node.

## Test plan

- [x] `cd packages/node/http && yarn build && yarn check && yarn test:gjs && yarn test:node` — **1040/1040 Node, 1038/1038 GJS** (unchanged baseline)
- [x] No `gi://` in Node test bundle
- [ ] CI green