### PR TITLE
refactor(webrtc): internal GStreamer-object interfaces to remove as-any in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,64 @@
   Node readline forwards `opts.escapeCodeTimeout`). All 145 tests
   green on both Node and GJS (unchanged baseline).
 
+* **webrtc (2026-05-09):** type-safety pass on
+  `packages/web/webrtc/src/{rtc-peer-connection,rtc-rtp-sender,rtc-rtp-transceiver}.ts`
+  (Workstream N). `as any` reduced from 40 → 0 across the three
+  production files (peer-connection 20→0, rtp-sender 16→0,
+  rtp-transceiver 4→0). New internal-only helper module
+  `src/internal/gst-types.ts` (per AGENTS.md Rule 2c — not exported
+  from `package.json#exports`) declares thin element-specific
+  interfaces extending the broad `Gst.Element` / `Gst.Pad` typings:
+  `WebRtcBin` exposes the 14 GObject properties the
+  `RTCPeerConnection` impl reads or writes on the `webrtcbin`
+  element (`stun_server`, `turn_server`, `ice_transport_policy`,
+  `bundle_policy`, the four `*_state` enums, and the six SDP
+  `*_description` slots); `WebRtcSrcPad` exposes the `transceiver`
+  back-pointer that webrtcbin attaches to its SRC pads;
+  `ValveElement`, `RtpPayloaderElement`, `CapsFilterElement`, and
+  `Vp8EncElement` cover the encoder-chain elements
+  (`@gjsify/webrtc`'s `_wirePipeline` builds explicit
+  `valve → convert → encode → payloader → capsfilter` chains for
+  audio/video). Each interface ships a paired `asXxx(el)` narrowing
+  helper used at the single creation site. `RTCPeerConnection`
+  also tightens `_findNewGstTransceiver(): any` →
+  `GstWebRTCRTPTransceiver | null`, `_createTransceiverWrapper(any)`
+  → `(GstWebRTCRTPTransceiver)`, and adds a literal-union prop type
+  to `_descProp(prop)` so the six SDP-getter call sites are checked
+  against the `WebRtcBin` interface. Three remaining `as unknown as
+  …` cross-castings stay because they are not the GStreamer-property
+  pattern but webrtcbin's GObject *action* signals (`emit('create-data-channel')`,
+  `emit('add-transceiver')`, `emit('get-transceiver')`) — the GIR
+  generator types `emit()` overloads as `void`-returning, so the
+  signal's actual return value flows back through `as unknown` (a
+  comment documents this at each site). Dropped two `iceState as
+  any` / `gatheringState as any` casts on `RTCIceTransport._setState`
+  / `_setGatheringState` — the source and target string unions are
+  identical (`'new' | 'checking' | 'connected' | …`), so the casts
+  were dead weight. `WebrtcbinBridge as any` constructor cast also
+  removed — `@gjsify/webrtc-native`'s typings already declare the
+  `Partial<{ bin: Gst.Element }>` constructor-properties shape. In
+  `RTCRtpSender`, the five `private _pipeline: any` / `_webrtcbin:
+  any` / `_elements: any[]` / `_valve: any` / `_teeSrcPad: any`
+  fields plus the constructor's `pipeline?: any, webrtcbin?: any`
+  parameters are now typed as `GstNs.Pipeline | null` /
+  `GstNs.Element | null` / `GstNs.Element[]` / `ValveElement | null`
+  / `GstNs.Pad | null` (with `GstNs` aliasing `gi://Gst?version=1.0`
+  to avoid colliding with the runtime `Gst` import from `gst-init.js`).
+  Two local `trackAny` views inside `_wirePipeline` and `replaceTrack`
+  are narrowed to the four `_gstSource` / `_gstPipeline` / `_gstTee`
+  / `_teeMultiplexer` GStreamer-attached fields on `MediaStreamTrack`
+  (these remain `any` on the class itself — that is a separate
+  refactoring target outside this stream's scope: `media-stream-track.ts`
+  declares them `any` because they are runtime-attached by the
+  get-user-media / VideoBridge code paths). One ergonomic upstream
+  fix: `gstDirectionToW3C(d): number` → `: GstWebRTC.WebRTCRTPTransceiverDirection`
+  in `gst-enum-maps.ts` so the writeback `gstTrans.direction =
+  w3cDirectionToGst(d)` typechecks against the GIR enum-typed
+  property without a cast. Pure type-safety; runtime behavior
+  unchanged. `yarn check` + `yarn build` + `yarn test:gjs` all
+  green on Fedora 43 (GJS 1.86 / SpiderMonkey 140).
+
 * **zlib (2026-05-09):** type-safety pass on
   `packages/node/zlib/src/index.spec.ts` (Workstream J). `as any`
   reduced from 20 → 0. All 20 occurrences were `gzipSync(str as

--- a/packages/web/webrtc/src/gst-enum-maps.ts
+++ b/packages/web/webrtc/src/gst-enum-maps.ts
@@ -90,7 +90,7 @@ export function gstDirectionToW3C(v: number): RTCRtpTransceiverDirection {
     return DIRECTION_GST_TO_W3C[v] ?? 'inactive';
 }
 
-export function w3cDirectionToGst(d: RTCRtpTransceiverDirection): number {
+export function w3cDirectionToGst(d: RTCRtpTransceiverDirection): GstWebRTC.WebRTCRTPTransceiverDirection {
     return DIRECTION_W3C_TO_GST[d] ?? GstWebRTC.WebRTCRTPTransceiverDirection.NONE;
 }
 

--- a/packages/web/webrtc/src/internal/gst-types.ts
+++ b/packages/web/webrtc/src/internal/gst-types.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// Internal type helpers for @gjsify/webrtc — narrowing the broad
+// Gst.Element / Gst.Pad surface to the concrete element shapes our
+// implementation reads and writes at runtime.
+//
+// Background: `@girs/gst-1.0` declares every GStreamer element as the
+// base `Gst.Element` class — element-specific GObject properties (e.g.
+// `webrtcbin`'s `stun_server`, `signaling_state`, or `vp8enc`'s
+// `keyframe_max_dist`) are not exposed in the GIR-generated typings
+// because they are registered at element-class init time, not on the
+// base class. Rather than reach for `(el as any).foo` at every call
+// site, we declare thin interfaces here and narrow once through helper
+// casts.
+//
+// These types are PURE compile-time constructs — no runtime behavior is
+// added. Following AGENTS.md Rule 2c, this module lives under
+// `src/internal/` and is NOT in `package.json#exports`; it is a private
+// implementation helper, not part of the public API surface.
+//
+// References:
+//  - GStreamer webrtcbin element properties:
+//      https://gstreamer.freedesktop.org/documentation/webrtc/index.html
+//  - vp8enc / opusenc / capsfilter / valve / payloader properties:
+//      https://gstreamer.freedesktop.org/documentation/
+
+import type Gst from 'gi://Gst?version=1.0';
+import type GstWebRTC from 'gi://GstWebRTC?version=1.0';
+
+/**
+ * The `webrtcbin` GStreamer element — declares every GObject property
+ * our implementation accesses. The base `Gst.Element` class is preserved
+ * so all the inherited methods (`emit`, `get_parent`, `set_state`,
+ * `request_pad_simple`, `sync_state_with_parent`, …) keep their proper
+ * typings.
+ *
+ * All properties below correspond to runtime GObject properties on
+ * `webrtcbin` (verify with `gst-inspect-1.0 webrtcbin`).
+ */
+export interface WebRtcBin extends Gst.Element {
+    stun_server: string | null;
+    turn_server: string | null;
+    ice_transport_policy: GstWebRTC.WebRTCICETransportPolicy;
+    bundle_policy: GstWebRTC.WebRTCBundlePolicy;
+    signaling_state: GstWebRTC.WebRTCSignalingState;
+    connection_state: GstWebRTC.WebRTCPeerConnectionState;
+    ice_connection_state: GstWebRTC.WebRTCICEConnectionState;
+    ice_gathering_state: GstWebRTC.WebRTCICEGatheringState;
+    local_description: GstWebRTC.WebRTCSessionDescription | null;
+    remote_description: GstWebRTC.WebRTCSessionDescription | null;
+    current_local_description: GstWebRTC.WebRTCSessionDescription | null;
+    current_remote_description: GstWebRTC.WebRTCSessionDescription | null;
+    pending_local_description: GstWebRTC.WebRTCSessionDescription | null;
+    pending_remote_description: GstWebRTC.WebRTCSessionDescription | null;
+}
+
+/**
+ * Narrow a `Gst.Element` returned by `Gst.ElementFactory.make('webrtcbin', …)`
+ * to the augmented `WebRtcBin` shape. Pure type-level cast — no runtime
+ * validation is performed because every webrtcbin instance has these
+ * properties (they are class-installed by GstWebRTCBin).
+ */
+export const asWebRtcBin = (el: Gst.Element): WebRtcBin => el as WebRtcBin;
+
+/**
+ * GStreamer pad augmented with the `transceiver` field that webrtcbin's
+ * SRC pads carry. The base `Gst.Pad` typing has no concept of this — it
+ * is set at pad-creation time inside webrtcbin and points back to the
+ * `GstWebRTCRTPTransceiver` the pad serves.
+ */
+export interface WebRtcSrcPad extends Gst.Pad {
+    transceiver: GstWebRTC.WebRTCRTPTransceiver | null;
+}
+
+/** Narrow a webrtcbin SRC `Gst.Pad` to the augmented shape. */
+export const asWebRtcSrcPad = (pad: Gst.Pad): WebRtcSrcPad => pad as WebRtcSrcPad;
+
+/**
+ * GStreamer element with a settable `drop` GObject property — the
+ * `valve` element used to gate media flow when a track is disabled.
+ */
+export interface ValveElement extends Gst.Element {
+    drop: boolean;
+}
+
+/** Narrow a `valve` element to the augmented shape. */
+export const asValveElement = (el: Gst.Element): ValveElement => el as ValveElement;
+
+/**
+ * GStreamer element with a settable `pt` GObject property — RTP payloader
+ * elements (`rtpopuspay`, `rtpvp8pay`, …) accept the payload type.
+ */
+export interface RtpPayloaderElement extends Gst.Element {
+    pt: number;
+}
+
+/** Narrow an RTP payloader element to the augmented shape. */
+export const asRtpPayloaderElement = (el: Gst.Element): RtpPayloaderElement =>
+    el as RtpPayloaderElement;
+
+/**
+ * GStreamer `capsfilter` element — exposes a settable `caps` property
+ * that pins the negotiated caps of a pipeline branch.
+ */
+export interface CapsFilterElement extends Gst.Element {
+    caps: Gst.Caps;
+}
+
+/** Narrow a `capsfilter` element to the augmented shape. */
+export const asCapsFilterElement = (el: Gst.Element): CapsFilterElement =>
+    el as CapsFilterElement;
+
+/**
+ * GStreamer `vp8enc` encoder — the small set of properties we tune for
+ * realtime WebRTC video encoding.
+ */
+export interface Vp8EncElement extends Gst.Element {
+    deadline: number;
+    keyframe_max_dist: number;
+}
+
+/** Narrow a `vp8enc` element to the augmented shape. */
+export const asVp8EncElement = (el: Gst.Element): Vp8EncElement => el as Vp8EncElement;

--- a/packages/web/webrtc/src/rtc-peer-connection.ts
+++ b/packages/web/webrtc/src/rtc-peer-connection.ts
@@ -22,6 +22,7 @@ import {
     gstToIceGatheringState,
     w3cDirectionToGst,
 } from './gst-enum-maps.js';
+import { asWebRtcBin, asWebRtcSrcPad } from './internal/gst-types.js';
 import { DOMException } from '@gjsify/dom-exception';
 import { RTCSessionDescription, type RTCSessionDescriptionInit } from './rtc-session-description.js';
 import { RTCIceCandidate, type RTCIceCandidateInit } from './rtc-ice-candidate.js';
@@ -179,7 +180,7 @@ export class RTCPeerConnection extends EventTarget {
         // Connect via @gjsify/webrtc-native's WebrtcbinBridge — webrtcbin fires
         // its signals from the streaming thread, GJS would block direct JS
         // callbacks. The bridge hops to the main context on the C side.
-        this._bridge = new (WebrtcbinBridge as any)({ bin: this._webrtcbin });
+        this._bridge = new WebrtcbinBridge({ bin: this._webrtcbin });
         this._bridge.connect('negotiation-needed', () => this._handleNegotiationNeeded());
         this._bridge.connect('icecandidate', (_b, mlineIndex, candidate) =>
             this._handleIceCandidate(mlineIndex, candidate));
@@ -225,7 +226,7 @@ export class RTCPeerConnection extends EventTarget {
 
                 if (proto === 'stun:' || proto === 'stuns:') {
                     if (stunSet) continue; // webrtcbin supports only one STUN server
-                    (this._webrtcbin as any).stun_server = `${proto}//${hostPort}`;
+                    asWebRtcBin(this._webrtcbin).stun_server = `${proto}//${hostPort}`;
                     stunSet = true;
                 } else if (proto === 'turn:' || proto === 'turns:') {
                     if (typeof server.username !== 'string' || typeof server.credential !== 'string') {
@@ -237,7 +238,7 @@ export class RTCPeerConnection extends EventTarget {
                     try {
                         this._webrtcbin.emit('add-turn-server', turnUrl);
                     } catch {
-                        (this._webrtcbin as any).turn_server = turnUrl;
+                        asWebRtcBin(this._webrtcbin).turn_server = turnUrl;
                     }
                 } else {
                     throw new TypeError(`Unsupported ICE server protocol "${proto}"`);
@@ -251,49 +252,53 @@ export class RTCPeerConnection extends EventTarget {
         const gstPolicy = policy === 'relay'
             ? GstWebRTC.WebRTCICETransportPolicy.RELAY
             : GstWebRTC.WebRTCICETransportPolicy.ALL;
-        try { (this._webrtcbin as any).ice_transport_policy = gstPolicy; } catch { /* ignore */ }
+        try { asWebRtcBin(this._webrtcbin).ice_transport_policy = gstPolicy; } catch { /* ignore */ }
     }
 
     private _applyBundlePolicy(policy?: RTCBundlePolicy): void {
         if (!policy) return;
-        let gstPolicy: number;
+        let gstPolicy: GstWebRTC.WebRTCBundlePolicy;
         switch (policy) {
             case 'balanced':   gstPolicy = GstWebRTC.WebRTCBundlePolicy.BALANCED; break;
             case 'max-compat': gstPolicy = GstWebRTC.WebRTCBundlePolicy.MAX_COMPAT; break;
             case 'max-bundle': gstPolicy = GstWebRTC.WebRTCBundlePolicy.MAX_BUNDLE; break;
             default: return;
         }
-        try { (this._webrtcbin as any).bundle_policy = gstPolicy; } catch { /* ignore */ }
+        try { asWebRtcBin(this._webrtcbin).bundle_policy = gstPolicy; } catch { /* ignore */ }
     }
 
     // ---- Properties --------------------------------------------------------
 
     get signalingState(): RTCSignalingState {
         if (this._closed) return 'closed';
-        try { return gstToSignalingState((this._webrtcbin as any).signaling_state); }
+        try { return gstToSignalingState(asWebRtcBin(this._webrtcbin).signaling_state); }
         catch { return 'stable'; }
     }
 
     get connectionState(): RTCPeerConnectionState {
         if (this._closed) return 'closed';
-        try { return gstToConnectionState((this._webrtcbin as any).connection_state); }
+        try { return gstToConnectionState(asWebRtcBin(this._webrtcbin).connection_state); }
         catch { return 'new'; }
     }
 
     get iceConnectionState(): RTCIceConnectionState {
         if (this._closed) return 'closed';
-        try { return gstToIceConnectionState((this._webrtcbin as any).ice_connection_state); }
+        try { return gstToIceConnectionState(asWebRtcBin(this._webrtcbin).ice_connection_state); }
         catch { return 'new'; }
     }
 
     get iceGatheringState(): RTCIceGatheringState {
-        try { return gstToIceGatheringState((this._webrtcbin as any).ice_gathering_state); }
+        try { return gstToIceGatheringState(asWebRtcBin(this._webrtcbin).ice_gathering_state); }
         catch { return 'new'; }
     }
 
-    private _descProp(prop: string): RTCSessionDescription | null {
+    private _descProp(
+        prop: 'local_description' | 'remote_description'
+            | 'current_local_description' | 'current_remote_description'
+            | 'pending_local_description' | 'pending_remote_description',
+    ): RTCSessionDescription | null {
         try {
-            const desc = (this._webrtcbin as any)[prop] as GstWebRTC.WebRTCSessionDescription | null;
+            const desc = asWebRtcBin(this._webrtcbin)[prop];
             if (!desc) return null;
             return RTCSessionDescription.fromGstDesc(desc);
         } catch { return null; }
@@ -453,7 +458,11 @@ export class RTCPeerConnection extends EventTarget {
 
         let native: GstWebRTC.WebRTCDataChannel | null = null;
         try {
-            native = this._webrtcbin.emit('create-data-channel', label, gstOpts) as any;
+            // webrtcbin's `create-data-channel` is an action signal that returns
+            // a `GstWebRTCDataChannel`. The GIR-generated `emit()` overloads
+            // declare a `void` return for action signals, but at runtime the
+            // value flows back. Cast through `unknown` to acknowledge the gap.
+            native = this._webrtcbin.emit('create-data-channel', label, gstOpts) as unknown as GstWebRTC.WebRTCDataChannel | null;
         } catch (err: any) {
             throw new Error(`create-data-channel failed: ${err?.message ?? err}`);
         }
@@ -572,10 +581,10 @@ export class RTCPeerConnection extends EventTarget {
                 `Failed to execute 'addTransceiver' on 'RTCPeerConnection': The provided value '${direction}' is not a valid enum value of type RTCRtpTransceiverDirection.`,
             );
         }
-        const hasGstSource = trackOrKind instanceof MediaStreamTrack && (trackOrKind as any)._gstSource;
+        const hasGstSource = trackOrKind instanceof MediaStreamTrack && trackOrKind._gstSource;
         const wantsSend = direction === 'sendrecv' || direction === 'sendonly';
 
-        let gstTrans: any;
+        let gstTrans: GstWebRTC.WebRTCRTPTransceiver;
         let jsTrans: RTCRtpTransceiver;
 
         if (hasGstSource && wantsSend) {
@@ -594,10 +603,11 @@ export class RTCPeerConnection extends EventTarget {
             sender._wirePipeline(track);
 
             // Find the GstTransceiver that request_pad_simple created
-            gstTrans = this._findNewGstTransceiver();
-            if (!gstTrans) {
+            const found = this._findNewGstTransceiver();
+            if (!found) {
                 throw new Error('webrtcbin did not create a transceiver for the send pad');
             }
+            gstTrans = found;
 
             // Create wrapper with the pre-wired sender
             const gstReceiver = gstTrans.receiver ?? null;
@@ -618,7 +628,7 @@ export class RTCPeerConnection extends EventTarget {
             this._receivers.push(receiver);
 
             // Apply direction
-            (gstTrans as any).direction = w3cDirectionToGst(direction);
+            gstTrans.direction = w3cDirectionToGst(direction);
         } else {
             // Path B: No GStreamer source, or receive-only/inactive.
             // Use emit('add-transceiver') which creates a transceiver without pads.
@@ -629,17 +639,20 @@ export class RTCPeerConnection extends EventTarget {
                 ? w3cDirectionToGst('sendrecv')
                 : w3cDirectionToGst(direction);
 
-            gstTrans = this._webrtcbin.emit('add-transceiver', createDirection, caps) as any;
-            if (!gstTrans) {
+            // `add-transceiver` is an action signal returning the new
+            // GstWebRTCRTPTransceiver — see comment on `create-data-channel` above.
+            const result = this._webrtcbin.emit('add-transceiver', createDirection, caps) as unknown as GstWebRTC.WebRTCRTPTransceiver | null;
+            if (!result) {
                 throw new Error('webrtcbin did not create a transceiver');
             }
+            gstTrans = result;
 
             jsTrans = this._transceivers.get(gstTrans)!;
             if (!jsTrans) {
                 jsTrans = this._createTransceiverWrapper(gstTrans);
             }
 
-            (gstTrans as any).direction = w3cDirectionToGst(direction);
+            gstTrans.direction = w3cDirectionToGst(direction);
 
             if (trackOrKind instanceof MediaStreamTrack) {
                 jsTrans.sender._setTrack(trackOrKind);
@@ -797,9 +810,11 @@ export class RTCPeerConnection extends EventTarget {
     // ---- Transceiver helper -------------------------------------------------
 
     /** Find a GstWebRTCRTPTransceiver not yet in our map (created by request_pad_simple). */
-    private _findNewGstTransceiver(): any {
+    private _findNewGstTransceiver(): GstWebRTC.WebRTCRTPTransceiver | null {
         for (let i = 0; ; i++) {
-            const gt = this._webrtcbin.emit('get-transceiver', i) as any;
+            // `get-transceiver` is an action signal — return value flows back at
+            // runtime even though the GIR `emit()` overload is typed `void`.
+            const gt = this._webrtcbin.emit('get-transceiver', i) as unknown as GstWebRTC.WebRTCRTPTransceiver | null;
             if (!gt) return null;
             if (!this._transceivers.has(gt)) return gt;
         }
@@ -821,7 +836,7 @@ export class RTCPeerConnection extends EventTarget {
         this._sctpTransport = new RTCSctpTransport(dtls);
     }
 
-    private _createTransceiverWrapper(gstTrans: any): RTCRtpTransceiver {
+    private _createTransceiverWrapper(gstTrans: GstWebRTC.WebRTCRTPTransceiver): RTCRtpTransceiver {
         let kind: 'audio' | 'video' = 'audio';
         try {
             const gstKind = gstTrans.kind;
@@ -848,7 +863,7 @@ export class RTCPeerConnection extends EventTarget {
 
         // Pass mline index to sender for sink pad naming
         try {
-            const mline = (gstTrans as any).mlineindex;
+            const mline = gstTrans.mlineindex;
             if (typeof mline === 'number' && mline >= 0) {
                 sender._setMlineIndex(mline);
             }
@@ -892,7 +907,7 @@ export class RTCPeerConnection extends EventTarget {
         // Only process SRC pads (incoming media from remote peer)
         if (pad.direction !== Gst.PadDirection.SRC) return;
 
-        const gstTrans = (pad as any).transceiver;
+        const gstTrans = asWebRtcSrcPad(pad).transceiver;
         if (!gstTrans) return;
 
         let jsTrans = this._transceivers.get(gstTrans);
@@ -974,14 +989,15 @@ export class RTCPeerConnection extends EventTarget {
     private _syncIceState(): void {
         if (!this._iceTransport) return;
         const iceState = this.iceConnectionState;
-        this._iceTransport._setState(iceState as any);
+        // RTCIceConnectionState ≡ RTCIceTransportState (same string union).
+        this._iceTransport._setState(iceState);
     }
 
     /** Map PC ICE gathering state → ICE transport gathering state. */
     private _syncIceGatheringState(): void {
         if (!this._iceTransport) return;
         const gatheringState = this.iceGatheringState;
-        this._iceTransport._setGatheringState(gatheringState as any);
+        this._iceTransport._setGatheringState(gatheringState);
     }
 
     // ---- on<event> attribute handlers --------------------------------------

--- a/packages/web/webrtc/src/rtc-rtp-sender.ts
+++ b/packages/web/webrtc/src/rtc-rtp-sender.ts
@@ -8,12 +8,20 @@
 // Reference: refs/node-gst-webrtc/src/webrtc/RTCRtpSender.ts (ISC)
 // Reference: W3C WebRTC spec § 5.2
 
+import type GstNs from 'gi://Gst?version=1.0';
 import type GstWebRTC from 'gi://GstWebRTC?version=1.0';
 
 import { Gst } from './gst-init.js';
 import { getRtpCapabilities } from './rtp-capabilities.js';
 import { RTCDTMFSender } from './rtc-dtmf-sender.js';
 import { TeeMultiplexer } from './tee-multiplexer.js';
+import {
+    asValveElement,
+    asRtpPayloaderElement,
+    asCapsFilterElement,
+    asVp8EncElement,
+    type ValveElement,
+} from './internal/gst-types.js';
 import type { RTCStatsReport } from './rtc-stats-report.js';
 import type { RTCDtlsTransport } from './rtc-dtls-transport.js';
 import type { MediaStreamTrack } from './media-stream-track.js';
@@ -84,14 +92,14 @@ export class RTCRtpSender {
     private _lastParams: RTCRtpSendParameters | null = null;
 
     /** @internal GStreamer pipeline references (set by RTCPeerConnection) */
-    private _pipeline: any = null;
-    private _webrtcbin: any = null;
+    private _pipeline: GstNs.Pipeline | null = null;
+    private _webrtcbin: GstNs.Element | null = null;
     private _mlineIndex: number = -1;
-    private _elements: any[] = [];
-    private _valve: any = null;
+    private _elements: GstNs.Element[] = [];
+    private _valve: ValveElement | null = null;
     _linked = false;
     /** @internal — tee src pad if this sender uses a shared source */
-    private _teeSrcPad: any = null;
+    private _teeSrcPad: GstNs.Pad | null = null;
     /** @internal — stats callback set by RTCPeerConnection */
     _getStatsForTrack: ((track: MediaStreamTrack) => Promise<RTCStatsReport>) | null = null;
     /** @internal — set by RTCPeerConnection */
@@ -103,9 +111,13 @@ export class RTCRtpSender {
     /** @internal — back-reference for DTMF stopped/direction checks */
     _transceiver: { stopped: boolean; currentDirection: string | null } | null = null;
     /** @internal — callback to notify RTCPeerConnection when pipeline changes (cross-pipeline fix) */
-    _onPipelineChanged: ((newPipeline: any) => void) | null = null;
+    _onPipelineChanged: ((newPipeline: GstNs.Pipeline) => void) | null = null;
 
-    constructor(gstSender: GstWebRTC.WebRTCRTPSender | null, pipeline?: any, webrtcbin?: any) {
+    constructor(
+        gstSender: GstWebRTC.WebRTCRTPSender | null,
+        pipeline?: GstNs.Pipeline,
+        webrtcbin?: GstNs.Element,
+    ) {
         this._gstSender = gstSender;
         this._pipeline = pipeline ?? null;
         this._webrtcbin = webrtcbin ?? null;
@@ -143,19 +155,28 @@ export class RTCRtpSender {
     /** @internal — build the outgoing encoder chain and link to webrtcbin */
     _wirePipeline(track: MediaStreamTrack): void {
         if (this._linked || !this._pipeline || !this._webrtcbin) return;
-        const source = (track as any)._gstSource;
+        const source = track._gstSource as GstNs.Element | null;
         if (!source) return; // No GStreamer backing — nothing to wire
 
-        const trackAny = track as any;
-        let sourceForChain: any; // What to link to the valve (source directly or tee branch)
+        // MediaStreamTrack's GStreamer-backing fields are intentionally typed
+        // `any` on the track itself (they are runtime-attached by the
+        // get-user-media / VideoBridge code paths). We narrow them locally
+        // here to keep the rest of this method strongly typed.
+        const trackGst = track as MediaStreamTrack & {
+            _gstSource: GstNs.Element | null;
+            _gstPipeline: GstNs.Pipeline | null;
+            _gstTee: GstNs.Element | null;
+            _teeMultiplexer: TeeMultiplexer | null;
+        };
+        let sourceForChain: GstNs.Element | null; // source directly or null when tee branch
 
-        if (trackAny._gstTee && trackAny._gstPipeline && trackAny._gstPipeline !== this._pipeline) {
+        if (trackGst._gstTee && trackGst._gstPipeline && trackGst._gstPipeline !== this._pipeline) {
             // Source has a tee from VideoBridge (preview) in a different pipeline.
             // Instead of moving the source, we add our encoder chain elements to
             // the SOURCE's pipeline and request a new branch from its tee.
             // The webrtcbin must also move to the source pipeline.
-            const sourcePipeline = trackAny._gstPipeline;
-            const tee = trackAny._gstTee;
+            const sourcePipeline = trackGst._gstPipeline;
+            const tee = trackGst._gstTee;
 
             // Move webrtcbin to the source pipeline so everything is in one pipeline
             if (this._webrtcbin.get_parent() === this._pipeline) {
@@ -176,17 +197,17 @@ export class RTCRtpSender {
                 : tee.get_request_pad('src_%u');
             this._teeSrcPad = teeSrcPad;
             sourceForChain = null; // We'll link via pad below
-        } else if (trackAny._teeMultiplexer) {
+        } else if (trackGst._teeMultiplexer) {
             // Track already has a TeeMultiplexer (shared with another PC) — request a new branch
-            const tee = trackAny._teeMultiplexer as TeeMultiplexer;
+            const tee = trackGst._teeMultiplexer as TeeMultiplexer;
             const teeSrcPad = tee.requestSrcPad();
             this._teeSrcPad = teeSrcPad;
             sourceForChain = null; // We'll link via pad below
-        } else if (trackAny._gstPipeline && trackAny._gstPipeline !== this._pipeline) {
+        } else if (trackGst._gstPipeline && trackGst._gstPipeline !== this._pipeline) {
             // Source is in another pipeline (no tee from VideoBridge) — this is the
             // second PC using this track. Insert a tee between source and the
             // existing consumer. Move source to this pipeline and create a tee.
-            const oldPipeline = trackAny._gstPipeline;
+            const oldPipeline = trackGst._gstPipeline;
 
             // First, unlink source from its current peer (the first sender's valve)
             const sourceSrcPad = source.get_static_pad('src');
@@ -196,11 +217,11 @@ export class RTCRtpSender {
             source.set_state(Gst.State.NULL);
             oldPipeline.remove(source);
             this._pipeline.add(source);
-            trackAny._gstPipeline = this._pipeline;
+            trackGst._gstPipeline = this._pipeline;
 
             // Create tee in this pipeline
             const tee = new TeeMultiplexer(this._pipeline, source);
-            trackAny._teeMultiplexer = tee;
+            trackGst._teeMultiplexer = tee;
 
             // Reconnect the old consumer (first sender) via a tee branch
             if (oldPeer) {
@@ -214,11 +235,11 @@ export class RTCRtpSender {
             sourceForChain = null;
         } else {
             // First PC to use this track — move source directly
-            const oldPipeline = trackAny._gstPipeline;
+            const oldPipeline = trackGst._gstPipeline;
             if (oldPipeline && oldPipeline !== this._pipeline) {
                 source.set_state(Gst.State.NULL);
                 oldPipeline.remove(source);
-                trackAny._gstPipeline = this._pipeline;
+                trackGst._gstPipeline = this._pipeline;
             }
             if (source.get_parent() !== this._pipeline) {
                 this._pipeline.add(source);
@@ -227,25 +248,25 @@ export class RTCRtpSender {
         }
 
         // Valve element for Track.enabled control
-        const valve = Gst.ElementFactory.make('valve', null)!;
-        (valve as any).drop = !track.enabled;
+        const valve = asValveElement(Gst.ElementFactory.make('valve', null)!);
+        valve.drop = !track.enabled;
         this._valve = valve;
         this._pipeline.add(valve);
 
-        const elements: any[] = [valve];
-        let lastElement: any;
+        const elements: GstNs.Element[] = [valve];
+        let lastElement: GstNs.Element;
 
         if (track.kind === 'audio') {
             const convert = Gst.ElementFactory.make('audioconvert', null)!;
             const resample = Gst.ElementFactory.make('audioresample', null)!;
             const encoder = Gst.ElementFactory.make('opusenc', null)!;
-            const payloader = Gst.ElementFactory.make('rtpopuspay', null)!;
-            (payloader as any).pt = OPUS_PAYLOAD_TYPE;
+            const payloader = asRtpPayloaderElement(Gst.ElementFactory.make('rtpopuspay', null)!);
+            payloader.pt = OPUS_PAYLOAD_TYPE;
 
             // capsfilter tells webrtcbin the RTP caps immediately so createOffer
             // can generate the m=audio line without waiting for data to flow.
-            const capsfilter = Gst.ElementFactory.make('capsfilter', null)!;
-            (capsfilter as any).caps = Gst.Caps.from_string(
+            const capsfilter = asCapsFilterElement(Gst.ElementFactory.make('capsfilter', null)!);
+            capsfilter.caps = Gst.Caps.from_string(
                 `application/x-rtp,media=audio,encoding-name=OPUS,clock-rate=48000,payload=${OPUS_PAYLOAD_TYPE}`,
             );
 
@@ -269,14 +290,14 @@ export class RTCRtpSender {
             // Video
             const convert = Gst.ElementFactory.make('videoconvert', null)!;
             const scale = Gst.ElementFactory.make('videoscale', null)!;
-            const encoder = Gst.ElementFactory.make('vp8enc', null)!;
-            (encoder as any).deadline = 1; // Realtime encoding
-            (encoder as any).keyframe_max_dist = 60;
-            const payloader = Gst.ElementFactory.make('rtpvp8pay', null)!;
-            (payloader as any).pt = VP8_PAYLOAD_TYPE;
+            const encoder = asVp8EncElement(Gst.ElementFactory.make('vp8enc', null)!);
+            encoder.deadline = 1; // Realtime encoding
+            encoder.keyframe_max_dist = 60;
+            const payloader = asRtpPayloaderElement(Gst.ElementFactory.make('rtpvp8pay', null)!);
+            payloader.pt = VP8_PAYLOAD_TYPE;
 
-            const capsfilter = Gst.ElementFactory.make('capsfilter', null)!;
-            (capsfilter as any).caps = Gst.Caps.from_string(
+            const capsfilter = asCapsFilterElement(Gst.ElementFactory.make('capsfilter', null)!);
+            capsfilter.caps = Gst.Caps.from_string(
                 `application/x-rtp,media=video,encoding-name=VP8,clock-rate=90000,payload=${VP8_PAYLOAD_TYPE}`,
             );
 
@@ -321,7 +342,7 @@ export class RTCRtpSender {
 
         // Wire Track.enabled → valve.drop
         track._setEnableCallback((enabled: boolean) => {
-            if (this._valve) (this._valve as any).drop = !enabled;
+            if (this._valve) this._valve.drop = !enabled;
         });
     }
 
@@ -388,30 +409,36 @@ export class RTCRtpSender {
         if (this._track !== null && track.kind !== this._track.kind) {
             throw new TypeError('Cannot replace track with different kind');
         }
-        if (this._linked && (track as any)._gstSource) {
+        // Same narrowing as `_wirePipeline` — the GStreamer-backing fields on
+        // `MediaStreamTrack` are runtime-attached and typed `any` on the class.
+        const trackGst = track as MediaStreamTrack & {
+            _gstSource: GstNs.Element | null;
+            _gstPipeline: GstNs.Pipeline | null;
+        };
+        if (this._linked && trackGst._gstSource) {
             // Atomic source swap: old source → new source, keep rest of chain
             const oldSource = this._elements[0];
-            const newSource = (track as any)._gstSource;
+            const newSource = trackGst._gstSource;
 
             // Move new source from its pipeline
-            const oldPipeline = (track as any)._gstPipeline;
+            const oldPipeline = trackGst._gstPipeline;
             if (oldPipeline && oldPipeline !== this._pipeline) {
                 newSource.set_state(Gst.State.NULL);
                 oldPipeline.remove(newSource);
-                (track as any)._gstPipeline = this._pipeline;
+                trackGst._gstPipeline = this._pipeline;
             }
 
             // Swap: unlink old, link new
             oldSource.set_state(Gst.State.NULL);
-            oldSource.unlink(this._valve);
-            this._pipeline.remove(oldSource);
+            if (this._valve) oldSource.unlink(this._valve);
+            this._pipeline?.remove(oldSource);
 
-            this._pipeline.add(newSource);
-            newSource.link(this._valve);
+            this._pipeline?.add(newSource);
+            if (this._valve) newSource.link(this._valve);
             newSource.sync_state_with_parent();
 
             this._elements[0] = newSource;
-        } else if ((track as any)._gstSource) {
+        } else if (trackGst._gstSource) {
             this._wirePipeline(track);
         }
 
@@ -420,7 +447,7 @@ export class RTCRtpSender {
         this._track = track;
         if (this._linked) {
             track._setEnableCallback((enabled: boolean) => {
-                if (this._valve) (this._valve as any).drop = !enabled;
+                if (this._valve) this._valve.drop = !enabled;
             });
         }
     }

--- a/packages/web/webrtc/src/rtc-rtp-transceiver.ts
+++ b/packages/web/webrtc/src/rtc-rtp-transceiver.ts
@@ -31,13 +31,13 @@ export class RTCRtpTransceiver {
 
     get mid(): string | null {
         if (this._stopped) return null;
-        const m = (this._gstTrans as any).mid;
+        const m = this._gstTrans.mid;
         return (m === '' || m == null) ? null : String(m);
     }
 
     get direction(): RTCRtpTransceiverDirection {
         if (this._stopped) return 'stopped';
-        return gstDirectionToW3C((this._gstTrans as any).direction);
+        return gstDirectionToW3C(this._gstTrans.direction);
     }
 
     set direction(d: RTCRtpTransceiverDirection) {
@@ -54,12 +54,16 @@ export class RTCRtpTransceiver {
         if (!valid.includes(d)) {
             throw new TypeError(`The provided value '${d}' is not a valid enum value of type RTCRtpTransceiverDirection.`);
         }
-        (this._gstTrans as any).direction = w3cDirectionToGst(d);
+        this._gstTrans.direction = w3cDirectionToGst(d);
     }
 
     get currentDirection(): RTCRtpTransceiverDirection | null {
         if (this._stopped) return null;
-        const cd = (this._gstTrans as any).current_direction ?? (this._gstTrans as any).currentDirection;
+        // GIR exposes both snake_case `current_direction` and camelCase
+        // `currentDirection` getters — they refer to the same GObject
+        // property. Read snake_case first; fall back to camelCase for
+        // older GstWebRTC bindings that omitted the snake_case alias.
+        const cd = this._gstTrans.current_direction ?? this._gstTrans.currentDirection;
         if (cd == null) return null;
         const w3c = gstDirectionToW3C(cd);
         return w3c === 'inactive' ? null : w3c;


### PR DESCRIPTION
## Summary

Type-safety pass on `@gjsify/webrtc` production code. **Workstream N** of the type-safety wave 2.

## `as any` count

| File | Before | After |
|---|---|---|
| `packages/web/webrtc/src/rtc-peer-connection.ts` | 20 | **0** |
| `packages/web/webrtc/src/rtc-rtp-sender.ts` | 16 | **0** |
| `packages/web/webrtc/src/rtc-rtp-transceiver.ts` | 4 | **0** |
| **Total** | **40** | **0** |

## New file (Rule 2c — internal helper)

`packages/web/webrtc/src/internal/gst-types.ts` — declares thin element-specific interfaces extending the broad `Gst.Element` / `Gst.Pad` typings. NOT in `package.json#exports`:

- **`WebRtcBin extends Gst.Element`** — 14 GObject properties our `RTCPeerConnection` impl reads/writes (`stun_server`, `turn_server`, `ice_transport_policy`, `bundle_policy`, the four `*_state` enums, the six SDP `*_description` slots) + `asWebRtcBin()` helper
- **`WebRtcSrcPad extends Gst.Pad`** — `transceiver` back-pointer that webrtcbin attaches to its SRC pads + `asWebRtcSrcPad()`
- **`ValveElement` / `RtpPayloaderElement` / `CapsFilterElement` / `Vp8EncElement`** — encoder-chain elements (`@gjsify/webrtc`'s `_wirePipeline` builds explicit `valve → convert → encode → payloader → capsfilter` chains for audio/video) + paired `asXxx(el)` narrowing helpers used at the single creation site

## Other changes

- `RTCPeerConnection`: tightened `_findNewGstTransceiver(): any` → `GstWebRTCRTPTransceiver | null`, `_createTransceiverWrapper(any)` → typed; literal-union prop type added to `_descProp(prop)` so the six SDP-getter call sites are checked against `WebRtcBin`
- `RTCRtpSender`: five private fields (`_pipeline`, `_webrtcbin`, `_elements`, `_valve`, `_teeSrcPad`) + constructor params now typed (`GstNs.Pipeline | null` / `Element[]` / `ValveElement | null` etc.)
- Two local `trackAny` views inside `_wirePipeline` and `replaceTrack` narrowed to the four `_gst*` GStreamer-attached fields on `MediaStreamTrack`
- `gst-enum-maps.ts`: `gstDirectionToW3C(): number` → `: GstWebRTC.WebRTCRTPTransceiverDirection` so the writeback `gstTrans.direction = w3cDirectionToGst(d)` typechecks against the GIR enum-typed property without a cast
- Dropped two dead `iceState as any` / `gatheringState as any` casts (source and target string unions are identical)
- `WebrtcbinBridge as any` constructor cast removed — `@gjsify/webrtc-native`'s typings already declare the `Partial<{ bin: Gst.Element }>` constructor-properties shape

## Casts kept (not `as any`)

3× `as unknown as …` for webrtcbin's GObject *action* signals (`emit('create-data-channel')`, `emit('add-transceiver')`, `emit('get-transceiver')`) — the GIR generator types `emit()` overloads as `void`-returning, but action signals return values at runtime. Each site has an explanatory comment.

## Out of scope (follow-up candidates)

- `MediaStreamTrack._gstSource` / `_gstPipeline` / `_gstTee` / `_teeMultiplexer` are still `any` on the class itself in `media-stream-track.ts` (runtime-attached by getUserMedia / VideoBridge code paths). Same Rule 2c fix would apply.
- `rtc-data-channel.ts` (`bytes.toArray?.()`) and `rtc-rtp-receiver.ts` (`ReceiverBridge as any` / `DataChannelBridge as any` constructor casts).

## Test plan

- [x] `cd packages/web/webrtc && yarn check && yarn build && yarn test:gjs` — all pass on Fedora 43 (GJS 1.86 / SpiderMonkey 140), no regressions
- [ ] CI green