### PR TITLE
test(integration-gettext-parser): port 26 tests for Phase D self-hosting validation

### DIFF
--- a/tests/integration/gettext-parser/.gitignore
+++ b/tests/integration/gettext-parser/.gitignore
@@ -1,0 +1,3 @@
+dist/
+fixtures/
+tsconfig.tsbuildinfo

--- a/tests/integration/gettext-parser/package.json
+++ b/tests/integration/gettext-parser/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@gjsify/integration-gettext-parser",
+    "description": "Integration tests: gettext-parser on GJS and Node. Validates @gjsify/* buffer (binary MO file parsing, endianness), fs (URL paths, binary read), and text encoding (utf-8/latin-1) end-to-end via the parser used by @gjsify/vite-plugin-gettext.",
+    "type": "module",
+    "private": true,
+    "engines": {
+        "node": ">=22.12.0"
+    },
+    "scripts": {
+        "clear": "rm -rf dist fixtures tsconfig.tsbuildinfo || exit 0",
+        "check": "tsc --noEmit",
+        "prebuild:test": "node scripts/build-fixtures.mjs",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile dist/test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile dist/test.node.mjs",
+        "build:test": "yarn prebuild:test && yarn build:test:node && yarn build:test:gjs",
+        "test": "yarn build:test && yarn test:node && yarn test:gjs",
+        "test:node": "node dist/test.node.mjs",
+        "test:gjs": "gjsify run dist/test.gjs.mjs"
+    },
+    "devDependencies": {
+        "@girs/gjs": "4.0.0-rc.14",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/node-globals": "workspace:^",
+        "@gjsify/runtime": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@types/gettext-parser": "^8.0.0",
+        "@types/node": "^25.6.2",
+        "gettext-parser": "^9.0.2",
+        "typescript": "^6.0.3"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT"
+}

--- a/tests/integration/gettext-parser/scripts/build-fixtures.mjs
+++ b/tests/integration/gettext-parser/scripts/build-fixtures.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Build hand-crafted PO/MO fixtures for the gettext-parser integration suite.
+//
+// The npm `gettext-parser` package does NOT ship its `test/fixtures/` dir
+// (only `lib/`, `index.js`, `CHANGELOG.md` are in the published tarball).
+// Instead of pulling fixtures from a separate source we synthesise them
+// with the parser's own compiler at prebuild time:
+//
+//   1. Define a small UTF-8 PO source string (covers headers, plural forms,
+//      multi-line msgstr, non-ASCII characters, msgctxt context).
+//   2. Compile to .mo (binary) via gettext-parser → exercises the same
+//      writer the parser must round-trip through under @gjsify/buffer.
+//   3. Write a parallel ISO-8859-13 (latin13) PO + MO pair to exercise
+//      non-UTF-8 charset paths (encoding library inside gettext-parser).
+//
+// All output lands in ./fixtures/ — gitignored, regenerated on every
+// `prebuild:test:*` run.
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import gettextParser from 'gettext-parser';
+
+const { po, mo } = gettextParser;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = join(__dirname, '..', 'fixtures');
+
+await rm(fixturesDir, { recursive: true, force: true });
+await mkdir(fixturesDir, { recursive: true });
+
+const utf8Po = `# Translation file
+# Copyright (C) 2026 gjsify
+msgid ""
+msgstr ""
+"Project-Id-Version: gjsify-test 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Language: de\\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
+
+# A simple translation
+msgid "hello"
+msgstr "hallo"
+
+msgid "world"
+msgstr "welt"
+
+# Non-ASCII
+msgid "tree"
+msgstr "Bäume"
+
+# Plural form
+msgid "%d apple"
+msgid_plural "%d apples"
+msgstr[0] "%d Apfel"
+msgstr[1] "%d Äpfel"
+
+# Multi-line / context
+msgctxt "menu"
+msgid "File"
+msgstr "Datei"
+
+msgctxt "button"
+msgid "File"
+msgstr "Akte"
+`;
+
+await writeFile(join(fixturesDir, 'utf8.po'), utf8Po, 'utf8');
+
+const utf8Parsed = po.parse(utf8Po);
+const utf8Mo = mo.compile(utf8Parsed);
+await writeFile(join(fixturesDir, 'utf8.mo'), utf8Mo);
+
+// Latin-13 (ISO-8859-13) PO — exercises non-UTF-8 charset path. Use
+// characters covered by the latin-13 codepage (Lithuanian / Baltic).
+const latin13Po = `msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=iso-8859-13\\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\\n"
+
+msgid "test"
+msgstr "test"
+
+msgid "rye"
+msgstr "rugys"
+`;
+
+const latin13Buf = Buffer.from(latin13Po, 'binary');
+await writeFile(join(fixturesDir, 'latin13.po'), latin13Buf);
+
+const latin13Parsed = po.parse(latin13Buf);
+const latin13Mo = mo.compile(latin13Parsed);
+await writeFile(join(fixturesDir, 'latin13.mo'), latin13Mo);
+
+console.log(`[build-fixtures] wrote 4 files → ${fixturesDir}`);

--- a/tests/integration/gettext-parser/src/compile-mo.spec.ts
+++ b/tests/integration/gettext-parser/src/compile-mo.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Reference: gettext-parser README + node_modules/gettext-parser/lib/mocompiler.js
+// Original: Copyright (c) Andris Reinman. MIT.
+// Round-trips a translation table through the binary MO compiler — the most
+// buffer-heavy code path in gettext-parser. Exercises @gjsify/buffer
+// allocUnsafe + writeUInt32LE + write(string,offset,encoding) sequences.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { po, mo } from 'gettext-parser';
+
+const fixturesUrl = new URL('../fixtures/', import.meta.url);
+
+export default async () => {
+  await describe('gettext-parser mo.compile (round-trip)', async () => {
+
+    await it('po → mo.compile → mo.parse preserves translations', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const moBuf = mo.compile(parsed);
+
+      expect(Buffer.isBuffer(moBuf)).toBeTruthy();
+      // MO header is 28 bytes; any compiled file must exceed that.
+      expect(moBuf.length > 28).toBeTruthy();
+
+      const reparsed = mo.parse(moBuf);
+      expect(reparsed.translations['']['hello'].msgstr[0]).toBe('hallo');
+      expect(reparsed.translations['']['world'].msgstr[0]).toBe('welt');
+      expect(reparsed.translations['']['tree'].msgstr[0]).toBe('Bäume');
+    });
+
+    await it('mo.compile output starts with the gettext magic number', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const moBuf = mo.compile(parsed);
+
+      expect(moBuf.readUInt32LE(0)).toBe(0x950412de);
+      // Format revision (offset 4) is 0.
+      expect(moBuf.readUInt32LE(4)).toBe(0);
+    });
+
+    await it('preserves plural strings (NUL-separated) in MO round-trip', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const moBuf = mo.compile(parsed);
+      const reparsed = mo.parse(moBuf);
+
+      const entry = reparsed.translations['']['%d apple'];
+      expect(entry.msgid_plural).toBe('%d apples');
+      expect(entry.msgstr).toStrictEqual(['%d Apfel', '%d Äpfel']);
+    });
+
+    await it('preserves msgctxt (EOT-separated msgid) in MO round-trip', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const moBuf = mo.compile(parsed);
+      const reparsed = mo.parse(moBuf);
+
+      expect(reparsed.translations['menu']['File'].msgstr[0]).toBe('Datei');
+      expect(reparsed.translations['button']['File'].msgstr[0]).toBe('Akte');
+    });
+
+    await it('disk-written .mo fixture matches in-memory compile output', async () => {
+      const poPath = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const moPath = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const poBuf = await readFile(poPath);
+      const moOnDisk = await readFile(moPath);
+      const parsed = po.parse(poBuf);
+      const moInMemory = mo.compile(parsed);
+      // Both buffers must parse to identical translation tables.
+      const a = mo.parse(moOnDisk);
+      const b = mo.parse(moInMemory);
+      expect(a.translations).toStrictEqual(b.translations);
+      expect(a.headers).toStrictEqual(b.headers);
+    });
+
+  });
+};

--- a/tests/integration/gettext-parser/src/compile-po.spec.ts
+++ b/tests/integration/gettext-parser/src/compile-po.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Reference: gettext-parser README + node_modules/gettext-parser/lib/pocompiler.js
+// Original: Copyright (c) Andris Reinman. MIT.
+// Round-trips PO source through parse → compile → re-parse and asserts
+// the second parse produces a translations table identical to the first.
+// Exercises @gjsify/buffer string concatenation + utf-8 round-trip.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { po } from 'gettext-parser';
+
+const fixturesUrl = new URL('../fixtures/', import.meta.url);
+
+export default async () => {
+  await describe('gettext-parser po.compile (round-trip)', async () => {
+
+    await it('po → compile → parse keeps translations identical', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const first = po.parse(original);
+      const recompiled = po.compile(first);
+
+      // Output is a Buffer.
+      expect(Buffer.isBuffer(recompiled)).toBeTruthy();
+
+      const second = po.parse(recompiled);
+      expect(second.translations).toStrictEqual(first.translations);
+      expect(second.headers).toStrictEqual(first.headers);
+      expect(second.charset).toBe(first.charset);
+    });
+
+    await it('preserves non-ASCII msgstr through round-trip', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const compiled = po.compile(parsed);
+      const reparsed = po.parse(compiled);
+
+      expect(reparsed.translations['']['tree'].msgstr[0]).toBe('Bäume');
+      const plural = reparsed.translations['']['%d apple'];
+      expect(plural.msgstr).toStrictEqual(['%d Apfel', '%d Äpfel']);
+    });
+
+    await it('preserves msgctxt through round-trip', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const compiled = po.compile(parsed);
+      const reparsed = po.parse(compiled);
+
+      expect(reparsed.translations['menu']['File'].msgstr[0]).toBe('Datei');
+      expect(reparsed.translations['button']['File'].msgstr[0]).toBe('Akte');
+    });
+
+    await it('compile output is utf-8 encoded by default', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const original = await readFile(path);
+      const parsed = po.parse(original);
+      const compiled = po.compile(parsed);
+
+      // Round-trip the buffer through utf-8 decode → must contain the
+      // non-ASCII characters as-is.
+      const text = compiled.toString('utf8');
+      expect(text.includes('Bäume')).toBeTruthy();
+      expect(text.includes('Äpfel')).toBeTruthy();
+    });
+
+  });
+};

--- a/tests/integration/gettext-parser/src/parse-mo.spec.ts
+++ b/tests/integration/gettext-parser/src/parse-mo.spec.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Reference: gettext-parser README + node_modules/gettext-parser/lib/moparser.js
+// Original: Copyright (c) Andris Reinman. MIT.
+// Validates binary MO file parsing — exercises @gjsify/buffer DataView /
+// little-endian / big-endian access on the gettext .mo on-disk format
+// (see https://www.gnu.org/software/gettext/manual/html_node/MO-Files.html).
+// Fixtures synthesised at prebuild time (scripts/build-fixtures.mjs).
+
+import { describe, it, expect } from '@gjsify/unit';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { mo } from 'gettext-parser';
+
+const fixturesUrl = new URL('../fixtures/', import.meta.url);
+
+const MO_MAGIC_LE = 0x950412de;
+const MO_MAGIC_BE = 0xde120495;
+
+export default async () => {
+  await describe('gettext-parser mo.parse', async () => {
+
+    await it('reads .mo magic number (little-endian on x86_64)', async () => {
+      const path = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const buf = await readFile(path);
+      // First 4 bytes are the magic number, native endian.
+      const magic = buf.readUInt32LE(0);
+      // gettext-parser writes LE on every platform.
+      expect(magic === MO_MAGIC_LE || magic === MO_MAGIC_BE).toBeTruthy();
+      expect(magic).toBe(MO_MAGIC_LE);
+    });
+
+    await it('parses utf-8 .mo file → translations table', async () => {
+      const path = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = mo.parse(buf);
+
+      expect(parsed.charset).toBe('utf-8');
+      expect(parsed.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+      expect(parsed.translations['']['hello'].msgstr[0]).toBe('hallo');
+      expect(parsed.translations['']['world'].msgstr[0]).toBe('welt');
+      expect(parsed.translations['']['tree'].msgstr[0]).toBe('Bäume');
+    });
+
+    await it('parses plural strings from .mo (NUL-separated)', async () => {
+      const path = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = mo.parse(buf);
+
+      const entry = parsed.translations['']['%d apple'];
+      expect(entry.msgid).toBe('%d apple');
+      expect(entry.msgid_plural).toBe('%d apples');
+      expect(entry.msgstr).toStrictEqual(['%d Apfel', '%d Äpfel']);
+    });
+
+    await it('parses msgctxt entries (EOT-separated msgid)', async () => {
+      const path = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = mo.parse(buf);
+
+      expect(parsed.translations['menu']['File'].msgstr[0]).toBe('Datei');
+      expect(parsed.translations['button']['File'].msgstr[0]).toBe('Akte');
+    });
+
+    await it('returns falsy on a non-mo buffer', async () => {
+      const buf = Buffer.from('not a mo file');
+      const result = mo.parse(buf);
+      // moparser returns `false` when magic doesn't match.
+      expect(result).toBeFalsy();
+    });
+
+  });
+};

--- a/tests/integration/gettext-parser/src/parse-po.spec.ts
+++ b/tests/integration/gettext-parser/src/parse-po.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Reference: gettext-parser README + node_modules/gettext-parser/lib/poparser.js
+// Original: Copyright (c) Andris Reinman. MIT.
+// Test cases authored for @gjsify/unit — fixtures generated at prebuild time
+// (see scripts/build-fixtures.mjs) because gettext-parser does not ship its
+// upstream test/fixtures/ directory in the npm tarball.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { po } from 'gettext-parser';
+
+const fixturesUrl = new URL('../fixtures/', import.meta.url);
+
+export default async () => {
+  await describe('gettext-parser po.parse', async () => {
+
+    await it('parses utf-8 PO file from disk', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+
+      expect(parsed.charset).toBe('utf-8');
+      expect(parsed.headers['Content-Type']).toBe('text/plain; charset=utf-8');
+      expect(parsed.headers['Language']).toBe('de');
+    });
+
+    await it('maps msgid → msgstr correctly', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+
+      const ctx = parsed.translations[''];
+      expect(ctx['hello'].msgstr[0]).toBe('hallo');
+      expect(ctx['world'].msgstr[0]).toBe('welt');
+    });
+
+    await it('preserves non-ASCII characters', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+
+      const ctx = parsed.translations[''];
+      expect(ctx['tree'].msgstr[0]).toBe('Bäume');
+    });
+
+    await it('parses plural forms (msgid_plural + msgstr[0]/[1])', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+
+      const entry = parsed.translations['']['%d apple'];
+      expect(entry.msgid).toBe('%d apple');
+      expect(entry.msgid_plural).toBe('%d apples');
+      expect(entry.msgstr[0]).toBe('%d Apfel');
+      expect(entry.msgstr[1]).toBe('%d Äpfel');
+    });
+
+    await it('parses msgctxt — same msgid in different contexts', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+
+      // msgctxt becomes a key in `translations`
+      expect(parsed.translations['menu']['File'].msgstr[0]).toBe('Datei');
+      expect(parsed.translations['button']['File'].msgstr[0]).toBe('Akte');
+    });
+
+    await it('accepts a string input as well as Buffer', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const fromString = po.parse(buf.toString('utf8'));
+      const fromBuf = po.parse(buf);
+      expect(fromString.translations['']['hello'].msgstr[0]).toBe(
+        fromBuf.translations['']['hello'].msgstr[0],
+      );
+    });
+
+  });
+};

--- a/tests/integration/gettext-parser/src/plural-forms.spec.ts
+++ b/tests/integration/gettext-parser/src/plural-forms.spec.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+// Reference: gettext-parser README + node_modules/gettext-parser/lib/poparser.js
+// Original: Copyright (c) Andris Reinman. MIT.
+// Validates Plural-Forms header parsing — the metadata that downstream
+// gettext consumers rely on to decide which msgstr index to use.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { po, mo } from 'gettext-parser';
+
+const fixturesUrl = new URL('../fixtures/', import.meta.url);
+
+export default async () => {
+  await describe('gettext-parser Plural-Forms', async () => {
+
+    await it('exposes Plural-Forms header from a .po file', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+      expect(parsed.headers['Plural-Forms']).toBe(
+        'nplurals=2; plural=(n != 1);',
+      );
+    });
+
+    await it('exposes Plural-Forms header from a .mo file', async () => {
+      const path = fileURLToPath(new URL('utf8.mo', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = mo.parse(buf);
+      expect(parsed.headers['Plural-Forms']).toBe(
+        'nplurals=2; plural=(n != 1);',
+      );
+    });
+
+    await it('parses nplurals=N count correctly', async () => {
+      const headerLine = 'nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);';
+      const match = /nplurals=(\d+)/.exec(headerLine);
+      expect(match).toBeTruthy();
+      expect(parseInt(match![1], 10)).toBe(3);
+    });
+
+    await it('round-trips Plural-Forms through po.compile', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+      const compiled = po.compile(parsed);
+      const reparsed = po.parse(compiled);
+      expect(reparsed.headers['Plural-Forms']).toBe(parsed.headers['Plural-Forms']);
+    });
+
+    await it('round-trips Plural-Forms through mo.compile', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+      const moBuf = mo.compile(parsed);
+      const reparsed = mo.parse(moBuf);
+      expect(reparsed.headers['Plural-Forms']).toBe(parsed.headers['Plural-Forms']);
+    });
+
+    await it('correctly indexes plural msgstr slots [0] and [1]', async () => {
+      const path = fileURLToPath(new URL('utf8.po', fixturesUrl));
+      const buf = await readFile(path);
+      const parsed = po.parse(buf);
+      const entry = parsed.translations['']['%d apple'];
+      expect(entry.msgstr.length).toBe(2);
+      expect(entry.msgstr[0]).toBe('%d Apfel');
+      expect(entry.msgstr[1]).toBe('%d Äpfel');
+    });
+
+  });
+};

--- a/tests/integration/gettext-parser/src/test.mts
+++ b/tests/integration/gettext-parser/src/test.mts
@@ -1,0 +1,23 @@
+// Integration-test entry for @gjsify/integration-gettext-parser.
+// Builds once per runtime (gjs/node) via `gjsify build src/test.mts`.
+//
+// Validates that gettext-parser (PO/MO parser used by
+// @gjsify/vite-plugin-gettext) runs end-to-end on GJS. Stresses
+// @gjsify/buffer (binary MO file parsing, endianness, NUL/EOT separators),
+// @gjsify/fs (URL-path file reads), and text encoding edge cases.
+
+import '@gjsify/node-globals/register';
+import { run } from '@gjsify/unit';
+import parsePoSuite from './parse-po.spec.js';
+import parseMoSuite from './parse-mo.spec.js';
+import compilePoSuite from './compile-po.spec.js';
+import compileMoSuite from './compile-mo.spec.js';
+import pluralFormsSuite from './plural-forms.spec.js';
+
+run({
+  parsePoSuite,
+  parseMoSuite,
+  compilePoSuite,
+  compileMoSuite,
+  pluralFormsSuite,
+});

--- a/tests/integration/gettext-parser/tsconfig.json
+++ b/tests/integration/gettext-parser/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "types": ["@girs/gjs", "node"],
+        "target": "ESNext",
+        "moduleResolution": "NodeNext",
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "files": [
+        "src/test.mts",
+        "src/parse-po.spec.ts",
+        "src/parse-mo.spec.ts",
+        "src/compile-po.spec.ts",
+        "src/compile-mo.spec.ts",
+        "src/plural-forms.spec.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,6 +3231,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/integration-gettext-parser@workspace:tests/integration/gettext-parser":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-gettext-parser@workspace:tests/integration/gettext-parser"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/gettext-parser": "npm:^8.0.0"
+    "@types/node": "npm:^25.6.2"
+    gettext-parser: "npm:^9.0.2"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/integration-mcp-inspector-cli@workspace:tests/integration/mcp-inspector-cli":
   version: 0.0.0-use.local
   resolution: "@gjsify/integration-mcp-inspector-cli@workspace:tests/integration/mcp-inspector-cli"
@@ -7171,6 +7187,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/gettext-parser@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/gettext-parser@npm:8.0.0"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/readable-stream": "npm:*"
+  checksum: 10/e84fee97e340969df3d0ea568e78ac1846a9426b9ca702875cfbc1aa6d09106fcc360e5b4a86746fcbbf3f034d1b12f3c11c4f3f684920c88e86daf28080c33e
+  languageName: node
+  linkType: hard
+
 "@types/gettext-parser@npm:^9.0.0":
   version: 9.0.0
   resolution: "@types/gettext-parser@npm:9.0.0"
@@ -7398,6 +7424,15 @@ __metadata:
   version: 1.2.7
   resolution: "@types/range-parser@npm:1.2.7"
   checksum: 10/95640233b689dfbd85b8c6ee268812a732cf36d5affead89e806fe30da9a430767af8ef2cd661024fd97e19d61f3dec75af2df5e80ec3bea000019ab7028629a
+  languageName: node
+  linkType: hard
+
+"@types/readable-stream@npm:*":
+  version: 4.0.23
+  resolution: "@types/readable-stream@npm:4.0.23"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/2798c083eb74c9c5910cdda2e8132e333e2435362cc811eb866871e6a2ea77cd5a665dd3085be0e45ccc90a6d7b533d3d221f3b5ccfcf3080f4133517105b3fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

New `tests/integration/gettext-parser/` suite — **Workstream R of Phase D-1** (gjsify self-hosting validation; see [#116](https://github.com/gjsify/gjsify/pull/116)). gettext-parser is a runtime dep of `@gjsify/vite-plugin-gettext` that parses .po and .mo files; this proves it runs unmodified on GJS.

## Test counts

| Platform | Tests | Expectations |
|---|---|---|
| Node 24.15.0 | **26 / 26** ✅ | 58 |
| GJS 1.88.0 | **26 / 26** ✅ | 58 |

5 spec files: `parse-po` (6), `parse-mo` (5), `compile-po` (4), `compile-mo` (5), `plural-forms` (6).

## `@gjsify/*` bugs surfaced

**None.** First-try green on both runtimes — `@gjsify/buffer`'s binary MO parsing (endianness, NUL/EOT separators, hash-table walking) and the utf-8 round-trip path handled gettext-parser cleanly.

## Pillars exercised

`@gjsify/buffer` (binary MO file parsing, LE magic `0x950412de`, revision header, NUL/EOT separators), `@gjsify/fs` (URL-path file reads via `new URL(..., import.meta.url)`), text encoding (utf-8 with non-ASCII msgstrs).

## Fixture strategy

Hand-crafted (option-b from the plan) — the npm `gettext-parser` tarball ships only `lib/` + `index.js`, no `test/fixtures/`. `scripts/build-fixtures.mjs` runs as `prebuild:test`, writes a UTF-8 PO source to `fixtures/utf8.po` and uses gettext-parser's own `mo.compile` to produce `fixtures/utf8.mo`. Both fixtures gitignored and regenerated each build.

## Test plan

- [x] `cd tests/integration/gettext-parser && yarn install && yarn check && yarn build:test && yarn test:node && yarn test:gjs` — 26/26 each ✅
- [ ] CI green