### PR TITLE
fix(yarn.lock): regenerate after Phase D-1 Batch 1 merges (clean)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,6 +3201,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/integration-acorn@workspace:tests/integration/acorn":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-acorn@workspace:tests/integration/acorn"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/node": "npm:^25.6.2"
+    acorn: "npm:^8.16.0"
+    acorn-walk: "npm:^8.3.5"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/integration-autobahn@workspace:tests/integration/autobahn":
   version: 0.0.0-use.local
   resolution: "@gjsify/integration-autobahn@workspace:tests/integration/autobahn"
@@ -3242,6 +3258,22 @@ __metadata:
     "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.6.2"
     fast-glob: "npm:^3.3.3"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
+"@gjsify/integration-gettext-parser@workspace:tests/integration/gettext-parser":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-gettext-parser@workspace:tests/integration/gettext-parser"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/gettext-parser": "npm:^8.0.0"
+    "@types/node": "npm:^25.6.2"
+    gettext-parser: "npm:^9.0.2"
     typescript: "npm:^6.0.3"
   languageName: unknown
   linkType: soft
@@ -3358,6 +3390,22 @@ __metadata:
     "@gjsify/unit": "workspace:^"
     "@types/node": "npm:^25.6.2"
     typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
+"@gjsify/integration-yargs@workspace:tests/integration/yargs":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-yargs@workspace:tests/integration/yargs"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/node": "npm:^25.6.2"
+    "@types/yargs": "npm:^17.0.33"
+    typescript: "npm:^6.0.3"
+    yargs: "npm:^18.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7186,6 +7234,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/gettext-parser@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@types/gettext-parser@npm:8.0.0"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/readable-stream": "npm:*"
+  checksum: 10/e84fee97e340969df3d0ea568e78ac1846a9426b9ca702875cfbc1aa6d09106fcc360e5b4a86746fcbbf3f034d1b12f3c11c4f3f684920c88e86daf28080c33e
+  languageName: node
+  linkType: hard
+
 "@types/gettext-parser@npm:^9.0.0":
   version: 9.0.0
   resolution: "@types/gettext-parser@npm:9.0.0"
@@ -7416,6 +7474,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/readable-stream@npm:*":
+  version: 4.0.23
+  resolution: "@types/readable-stream@npm:4.0.23"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/2798c083eb74c9c5910cdda2e8132e333e2435362cc811eb866871e6a2ea77cd5a665dd3085be0e45ccc90a6d7b533d3d221f3b5ccfcf3080f4133517105b3fd
+  languageName: node
+  linkType: hard
+
 "@types/sax@npm:^1.2.1":
   version: 1.2.7
   resolution: "@types/sax@npm:1.2.7"
@@ -7539,7 +7606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.35":
+"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.35":
   version: 17.0.35
   resolution: "@types/yargs@npm:17.0.35"
   dependencies:


### PR DESCRIPTION
## Summary

PR #117 (yargs), #118 (gettext-parser), #119 (acorn) merged with stale yarn.lock contents — the rebase-with-theirs strategy used to resolve cross-PR CHANGELOG conflicts accidentally took the older yarn.lock that was missing the new workspace entries. CI on main fails with **YN0028 hardened-mode lockfile mismatch**.

This regenerates yarn.lock against a clean main checkout (no Batch 2 WIP files in tree). Adds entries for:
- `@gjsify/integration-acorn`
- `@gjsify/integration-gettext-parser`
- `@gjsify/integration-yargs`

(`@gjsify/integration-fast-glob` was already added by PR #120's final rebase.)

Replaces the now-closed broken PR #121 which had accidentally included WIP entries from Batch 2 agents (cosmiconfig/execa/pkg-types/rollup-pluginutils — those are not yet on main).

Pure lockfile change, no code touched.

## Test plan

- [x] `yarn install` clean against main + 4 Batch-1 workspaces
- [ ] CI green