### PR TITLE
test(integration-rollup-pluginutils): add suite — Phase D self-hosting (Stream V)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,6 +577,28 @@
   (tracked in STATUS.md "Integration Test Coverage → pkg-types +
   get-tsconfig").
 
+* **integration-rollup-pluginutils (2026-05-09):** Phase D-1 Workstream V
+  — new `tests/integration/rollup-pluginutils/` suite
+  (`@gjsify/integration-rollup-pluginutils`, private). 5 spec files /
+  54 cases covering [`@rollup/pluginutils@^5`](https://github.com/rollup/plugins/tree/master/packages/pluginutils)
+  — the helper toolkit consumed by `@gjsify/rolldown-plugin-gjsify`
+  itself: `createFilter` (include/exclude with globs, RegExp,
+  mixed arrays, `cwd` resolution), `dataToEsm` (named exports +
+  default wrapper, `preferConst`, `compact`, `objectShorthand`,
+  Date/RegExp/BigInt/NaN/Infinity/-0/U+2028/U+2029 serialization),
+  `makeLegalIdentifier` (kebab→camel, illegal-char `_`-replace,
+  reserved/global prefix), `attachScopes` (function/class/catch/
+  block/for-init scope handling, ancestor lookups), and
+  `extractAssignedNames` (Identifier, ObjectPattern incl. renames +
+  rest, ArrayPattern incl. holes + RestElement, AssignmentPattern
+  defaults, MemberExpression `[]` fallback). Total: **138/138 green
+  on Node, 138/138 green on GJS, 0 skips.** No `@gjsify/*` fixes
+  required — pure JS over `node:path` + the picomatch glob library;
+  picomatch's heavy RegExp surface also runs unmodified on
+  SpiderMonkey 140. Clears another of the 11 Phase D-1 npm runtime-
+  deps the future GJS-hosted `@gjsify/cli` build needs (tracked in
+  STATUS.md "Integration Test Coverage → @rollup/pluginutils").
+
 ## [0.3.21](https://github.com/gjsify/gjsify/compare/v0.3.20...v0.3.21) (2026-05-08)
 
 ### Bug Fixes

--- a/STATUS.md
+++ b/STATUS.md
@@ -697,6 +697,22 @@ Fixtures generated at prebuild time by `scripts/setup-fixtures.mjs` — two Type
 
 Clears two more of the 11 Phase D-1 npm runtime-deps that the future GJS-hosted `@gjsify/cli` build needs. The `@gjsify/fs` URL-path + readdir paths shipped in earlier streams (webtorrent, fast-glob) covered everything `pkg-types`/`get-tsconfig` exercise — no new pillar gaps surfaced.
 
+### @rollup/pluginutils (`tests/integration/rollup-pluginutils/`)
+
+Phase D-1 Workstream V — validates the helper toolkit consumed by `@gjsify/rolldown-plugin-gjsify` itself. **Node: 138/138 green. GJS: 138/138 green, 0 skips.** No `@gjsify/*` fixes required — `@rollup/pluginutils@^5` is pure JS over `node:path` + the picomatch glob library and runs unmodified on SpiderMonkey 140.
+
+The published `@rollup/pluginutils` tarball strips its own `test/` directory (the package.json `files` filter excludes everything outside `dist/`), so the spec files are derived from `pluginutils`'s [documented public API](https://github.com/rollup/plugins/tree/master/packages/pluginutils) rather than ported verbatim.
+
+| Suite | Node | GJS | Exercises |
+|---|---|---|---|
+| create-filter.spec.ts | ✅ (15) | ✅ (15) | `createFilter` glob/RegExp include + exclude, RegExp instances, mixed RegExp/glob arrays, exclude precedence, empty patterns, `**`-prefix patterns, `cwd` resolution |
+| data-to-esm.spec.ts | ✅ (12) | ✅ (12) | `dataToEsm` named exports + default wrapper, `preferConst`, `compact`, `objectShorthand`, illegal-key fallback, top-level array/primitive default-only, Date/RegExp/BigInt/NaN/Infinity/-0 serialization, U+2028/U+2029 escaping, custom indent |
+| make-legal-identifier.spec.ts | ✅ (8) | ✅ (8) | Identity for valid identifiers, kebab→camel, illegal-char → `_`, leading-digit prefix, reserved-word + global prefix, empty fallback, non-ASCII replacement |
+| attach-scopes.spec.ts | ✅ (9) | ✅ (9) | Root `Scope` registration, `FunctionDeclaration`/`ClassDeclaration` binding, function param scope, let/const block-scope vs var, catch-clause scope, `FunctionExpression` name, custom `propertyName`, ancestor lookups, for-loop initializer scope |
+| extract-assigned-names.spec.ts | ✅ (10) | ✅ (10) | `Identifier`, `ObjectPattern` (incl. renames + rest), `ArrayPattern` (incl. holes + RestElement), `AssignmentPattern` defaults, deeply-nested patterns, `MemberExpression` returns `[]` |
+
+Clears another of the 11 Phase D-1 npm runtime-deps the future GJS-hosted `@gjsify/cli` build needs. The picomatch transitive dep used by `createFilter` also bundles + runs cleanly on GJS — additional indirect coverage that `@gjsify/path` + the SpiderMonkey 140 RegExp surface match Node's behavior for the heavy regex paths inside `picomatch`.
+
 ## Open TODOs
 
 Tracked follow-up work that has been deliberately deferred. Every "out of scope" or "follow-up" note from a PR or implementation plan must end up here so future sessions can pick it up.

--- a/tests/integration/rollup-pluginutils/.gitignore
+++ b/tests/integration/rollup-pluginutils/.gitignore
@@ -1,0 +1,2 @@
+dist/
+tsconfig.tsbuildinfo

--- a/tests/integration/rollup-pluginutils/package.json
+++ b/tests/integration/rollup-pluginutils/package.json
@@ -1,0 +1,32 @@
+{
+    "name": "@gjsify/integration-rollup-pluginutils",
+    "description": "Integration tests: @rollup/pluginutils on GJS and Node. Validates @gjsify/path + picomatch glob (transitive) — same code paths used by @gjsify/rolldown-plugin-gjsify.",
+    "type": "module",
+    "private": true,
+    "engines": {
+        "node": ">=22.12.0"
+    },
+    "scripts": {
+        "clear": "rm -rf dist tsconfig.tsbuildinfo || exit 0",
+        "check": "tsc --noEmit",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile dist/test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile dist/test.node.mjs",
+        "build:test": "yarn build:test:node && yarn build:test:gjs",
+        "test": "yarn build:test && yarn test:node && yarn test:gjs",
+        "test:node": "node dist/test.node.mjs",
+        "test:gjs": "gjsify run dist/test.gjs.mjs"
+    },
+    "devDependencies": {
+        "@girs/gjs": "4.0.0-rc.14",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/node-globals": "workspace:^",
+        "@gjsify/runtime": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@rollup/pluginutils": "^5.3.0",
+        "@types/node": "^25.6.2",
+        "acorn": "^8.16.0",
+        "typescript": "^6.0.3"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT"
+}

--- a/tests/integration/rollup-pluginutils/src/attach-scopes.spec.ts
+++ b/tests/integration/rollup-pluginutils/src/attach-scopes.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Reference: @rollup/pluginutils public API.
+// Original: Copyright (c) 2019 RollupJS Plugin Contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Exercises attachScopes() — walks an acorn AST via estree-walker, attaches
+// Scope objects to nodes that introduce a new lexical scope. Confirms scope
+// chain (block / function / catch / for) and Scope.contains() lookup.
+//
+// Pillars: pure JS, depends on the acorn parser already validated by the
+// `acorn` integration suite.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { parse } from 'acorn';
+import { attachScopes, type AttachedScope } from '@rollup/pluginutils';
+
+const PARSE_OPTS = { ecmaVersion: 2024 as const, sourceType: 'module' as const };
+
+function parseModule(src: string): any {
+  return parse(src, PARSE_OPTS);
+}
+
+export default async () => {
+  await describe('@rollup/pluginutils attachScopes', async () => {
+
+    await it('returns a root Scope and registers top-level vars', async () => {
+      const ast = parseModule('var foo = 1; const bar = 2; let baz = 3;');
+      const root = attachScopes(ast, 'scope');
+      expect(typeof root.contains).toBe('function');
+      expect(root.contains('foo')).toBe(true);
+      expect(root.contains('bar')).toBe(true);
+      expect(root.contains('baz')).toBe(true);
+      expect(root.contains('absent')).toBe(false);
+    });
+
+    await it('records FunctionDeclaration + ClassDeclaration names', async () => {
+      const ast = parseModule(`
+        function foo() {}
+        class Bar {}
+      `);
+      const root = attachScopes(ast, 'scope');
+      expect(root.contains('foo')).toBe(true);
+      expect(root.contains('Bar')).toBe(true);
+    });
+
+    await it('attaches a child scope to a FunctionDeclaration with params', async () => {
+      const ast = parseModule(`function add(a, b) { return a + b; }`);
+      attachScopes(ast, 'scope');
+      const fnNode = ast.body[0];
+      const fnScope = (fnNode as any).scope as AttachedScope;
+      expect(fnScope).toBeDefined();
+      expect(fnScope.contains('a')).toBe(true);
+      expect(fnScope.contains('b')).toBe(true);
+      // Function name is in the parent (root) scope, reachable via contains().
+      expect(fnScope.contains('add')).toBe(true);
+    });
+
+    await it('block-scopes let/const but not var', async () => {
+      const ast = parseModule(`{ var v = 1; let l = 2; const c = 3; }`);
+      const root = attachScopes(ast, 'scope');
+      const blockNode = ast.body[0];
+      const blockScope = (blockNode as any).scope as AttachedScope;
+      expect(blockScope).toBeDefined();
+      // var hoists out to the parent scope.
+      expect(root.contains('v')).toBe(true);
+      // let/const stay in the block scope.
+      expect(blockScope.contains('l')).toBe(true);
+      expect(blockScope.contains('c')).toBe(true);
+      // l/c should NOT exist in the root scope (block-scoped).
+      expect(root.declarations.l).toBeFalsy();
+      expect(root.declarations.c).toBeFalsy();
+    });
+
+    await it('creates a new scope for catch clauses with the param bound', async () => {
+      const ast = parseModule(`try {} catch (err) { let inner = 1; }`);
+      attachScopes(ast, 'scope');
+      const tryStmt: any = ast.body[0];
+      const catchNode: any = tryStmt.handler;
+      const catchScope = catchNode.scope as AttachedScope;
+      expect(catchScope).toBeDefined();
+      expect(catchScope.contains('err')).toBe(true);
+    });
+
+    await it('creates a fresh scope for FunctionExpression name', async () => {
+      const ast = parseModule(`const f = function namedFn(a) { return a; };`);
+      attachScopes(ast, 'scope');
+      const decl: any = ast.body[0];
+      const fn: any = decl.declarations[0].init;
+      const fnScope = fn.scope as AttachedScope;
+      expect(fnScope).toBeDefined();
+      expect(fnScope.contains('namedFn')).toBe(true);
+      expect(fnScope.contains('a')).toBe(true);
+    });
+
+    await it('honours a custom propertyName', async () => {
+      const ast = parseModule(`function f(){}`);
+      attachScopes(ast, '__myScope');
+      const fn: any = ast.body[0];
+      expect(fn.__myScope).toBeDefined();
+      expect(fn.scope).toBeUndefined();
+    });
+
+    await it('parent scope lookups bubble up to ancestors', async () => {
+      const ast = parseModule(`
+        const top = 1;
+        function outer() {
+          function inner() {
+            return top;
+          }
+        }
+      `);
+      attachScopes(ast, 'scope');
+      const outerFn: any = ast.body[1];
+      const innerFn: any = outerFn.body.body[0];
+      const innerScope: AttachedScope = innerFn.scope;
+      expect(innerScope.contains('top')).toBe(true);
+    });
+
+    await it('creates a fresh scope for for-loop initializers', async () => {
+      const ast = parseModule(`for (let i = 0; i < 10; i++) { let j = i; }`);
+      attachScopes(ast, 'scope');
+      const forStmt: any = ast.body[0];
+      const forScope: AttachedScope = forStmt.scope;
+      expect(forScope).toBeDefined();
+      // The loop body's `j` is in a nested block scope under the for-scope.
+    });
+  });
+};

--- a/tests/integration/rollup-pluginutils/src/create-filter.spec.ts
+++ b/tests/integration/rollup-pluginutils/src/create-filter.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// Reference: @rollup/pluginutils public API (LICENSE: refs is not vendored —
+// upstream tests live at https://github.com/rollup/plugins/tree/master/packages/pluginutils/test).
+// Original: Copyright (c) 2019 RollupJS Plugin Contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Exercises createFilter() — resolves include/exclude patterns against
+// process.cwd(), defers to picomatch for glob matching. Also stresses
+// node:path resolve() + sep handling (Win32 paths normalized to posix).
+
+import { describe, it, expect } from '@gjsify/unit';
+import { resolve } from 'node:path';
+import { createFilter } from '@rollup/pluginutils';
+
+export default async () => {
+  await describe('@rollup/pluginutils createFilter', async () => {
+
+    await it('returns true for any string when include/exclude are omitted', async () => {
+      const filter = createFilter();
+      expect(filter('foo.js')).toBe(true);
+      expect(filter('/abs/path/file.ts')).toBe(true);
+      expect(filter('relative/path.json')).toBe(true);
+    });
+
+    await it('rejects strings containing NUL bytes (virtual modules)', async () => {
+      const filter = createFilter();
+      expect(filter('\0commonjs-helpers')).toBe(false);
+      expect(filter('plain.js\0suffix')).toBe(false);
+    });
+
+    await it('returns false for non-string ids', async () => {
+      const filter = createFilter();
+      expect(filter(undefined)).toBe(false);
+      expect(filter(null)).toBe(false);
+      expect(filter(123)).toBe(false);
+      expect(filter({})).toBe(false);
+    });
+
+    await it('matches a single basic glob pattern', async () => {
+      const filter = createFilter('*.js');
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'foo.js'))).toBe(true);
+      expect(filter(resolve(cwd, 'foo.ts'))).toBe(false);
+    });
+
+    await it('matches an array of patterns', async () => {
+      const filter = createFilter(['*.js', '*.ts']);
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'a.js'))).toBe(true);
+      expect(filter(resolve(cwd, 'b.ts'))).toBe(true);
+      expect(filter(resolve(cwd, 'c.json'))).toBe(false);
+    });
+
+    await it('honours exclude patterns', async () => {
+      const filter = createFilter('*.js', '*.spec.js');
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'app.js'))).toBe(true);
+      expect(filter(resolve(cwd, 'app.spec.js'))).toBe(false);
+    });
+
+    await it('returns false when only an exclude pattern matches', async () => {
+      // No include + matching exclude => filter returns false.
+      const filter = createFilter(null, '*.spec.js');
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'app.spec.js'))).toBe(false);
+      // No include and no matching exclude => filter falls through to true
+      // because !includeMatchers.length is the final return.
+      expect(filter(resolve(cwd, 'app.js'))).toBe(true);
+    });
+
+    await it('matches recursive ** globs', async () => {
+      const filter = createFilter('**/*.ts');
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'src/a.ts'))).toBe(true);
+      expect(filter(resolve(cwd, 'src/nested/deep/b.ts'))).toBe(true);
+      expect(filter(resolve(cwd, 'src/a.js'))).toBe(false);
+    });
+
+    await it('matches brace-expansion globs', async () => {
+      const filter = createFilter('**/*.{js,ts}');
+      const cwd = process.cwd();
+      expect(filter(resolve(cwd, 'src/a.js'))).toBe(true);
+      expect(filter(resolve(cwd, 'src/a.ts'))).toBe(true);
+      expect(filter(resolve(cwd, 'src/a.json'))).toBe(false);
+    });
+
+    await it('treats absolute include patterns as already resolved', async () => {
+      const abs = resolve('/tmp/project/src/*.js');
+      const filter = createFilter(abs);
+      expect(filter(resolve('/tmp/project/src/index.js'))).toBe(true);
+      expect(filter(resolve('/tmp/project/src/index.ts'))).toBe(false);
+      expect(filter(resolve('/tmp/other/src/index.js'))).toBe(false);
+    });
+
+    await it('options.resolve picks a different base directory', async () => {
+      const filter = createFilter('*.js', null, { resolve: '/tmp/proj' });
+      expect(filter('/tmp/proj/foo.js')).toBe(true);
+      expect(filter('/tmp/other/foo.js')).toBe(false);
+    });
+
+    await it('options.resolve = false leaves patterns unresolved (virtual ids)', async () => {
+      const filter = createFilter('virtual:*', null, { resolve: false });
+      expect(filter('virtual:my-module')).toBe(true);
+      expect(filter('real-module')).toBe(false);
+    });
+
+    await it('accepts RegExp patterns directly', async () => {
+      const filter = createFilter(/\.tsx?$/);
+      expect(filter('/abs/foo.ts')).toBe(true);
+      expect(filter('/abs/foo.tsx')).toBe(true);
+      expect(filter('/abs/foo.js')).toBe(false);
+    });
+
+    await it('mixes RegExp and glob patterns in the same array', async () => {
+      const filter = createFilter([/\.tsx?$/, '**/*.json']);
+      const cwd = process.cwd();
+      expect(filter('/abs/file.ts')).toBe(true);
+      expect(filter(resolve(cwd, 'a/b/c.json'))).toBe(true);
+      expect(filter('/abs/file.js')).toBe(false);
+    });
+
+    await it('include patterns that start with ** stay unresolved', async () => {
+      const filter = createFilter('**/*.svelte');
+      expect(filter('/some/abs/path/Component.svelte')).toBe(true);
+      expect(filter('/some/abs/path/Component.vue')).toBe(false);
+    });
+  });
+};

--- a/tests/integration/rollup-pluginutils/src/data-to-esm.spec.ts
+++ b/tests/integration/rollup-pluginutils/src/data-to-esm.spec.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Reference: @rollup/pluginutils public API.
+// Original: Copyright (c) 2019 RollupJS Plugin Contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Exercises dataToEsm() — turns plain objects into tree-shakable ES Module
+// source. Covers compact mode, named exports, indent control, primitive
+// + special-value handling. Pure JS — no GNOME deps.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { dataToEsm } from '@rollup/pluginutils';
+
+export default async () => {
+  await describe('@rollup/pluginutils dataToEsm', async () => {
+
+    await it('emits named exports for top-level keys with default export wrapper', async () => {
+      const out = dataToEsm({ a: 1, b: 'two' });
+      expect(out).toContain('export var a = 1;');
+      expect(out).toContain('export var b = "two";');
+      expect(out).toContain('export default {');
+      expect(out).toContain('a: a');
+      expect(out).toContain('b: b');
+    });
+
+    await it('preferConst switches the declaration kind to const', async () => {
+      const out = dataToEsm({ a: 1 }, { preferConst: true });
+      expect(out).toContain('export const a = 1;');
+      expect(out).not.toContain('export var a');
+    });
+
+    await it('compact: true strips whitespace + newlines', async () => {
+      const out = dataToEsm({ a: 1, b: 2 }, { compact: true });
+      expect(out).toBe('export var a=1;export var b=2;export default{a:a,b:b};');
+    });
+
+    await it('objectShorthand collapses {a: a} to {a}', async () => {
+      const out = dataToEsm({ a: 1 }, { compact: true, objectShorthand: true });
+      expect(out).toBe('export var a=1;export default{a};');
+    });
+
+    await it('quotes keys that are not legal identifiers (no named export)', async () => {
+      const out = dataToEsm({ '1abc': 'x' }, { compact: true });
+      // '1abc' is not a legal identifier so it gets serialized as a quoted
+      // string property in the default export and no named export is emitted.
+      expect(out).toBe('export default{"1abc":"x"};');
+      expect(out).not.toContain('export var');
+    });
+
+    await it('top-level array yields a single default export', async () => {
+      // Compact-mode primitives that start with one of [ { - / get no space
+      // after `default` (the leading bracket disambiguates).
+      const out = dataToEsm([1, 2, 3], { compact: true });
+      expect(out).toBe('export default[1,2,3];');
+    });
+
+    await it('top-level primitives yield a single default export', async () => {
+      // Strings/numbers/null/true must keep a space after `default` because
+      // their leading char is not in the [ { - / set.
+      expect(dataToEsm('hello', { compact: true })).toBe('export default "hello";');
+      expect(dataToEsm(42, { compact: true })).toBe('export default 42;');
+      expect(dataToEsm(null, { compact: true })).toBe('export default null;');
+      expect(dataToEsm(true, { compact: true })).toBe('export default true;');
+    });
+
+    await it('namedExports: false collapses everything into the default export', async () => {
+      // Object literal starts with `{` so compact mode skips the space.
+      const out = dataToEsm({ a: 1, b: 2 }, { compact: true, namedExports: false });
+      expect(out).toBe('export default{a:1,b:2};');
+      expect(out).not.toContain('export var');
+    });
+
+    await it('serializes Date instances via new Date(<ms>)', async () => {
+      const d = new Date(1700000000000);
+      const out = dataToEsm({ ts: d }, { compact: true });
+      expect(out).toContain('export var ts=new Date(1700000000000);');
+    });
+
+    await it('serializes RegExp via toString()', async () => {
+      const out = dataToEsm({ re: /foo/gi }, { compact: true });
+      expect(out).toContain('export var re=/foo/gi;');
+    });
+
+    await it('emits special numeric tokens (NaN, Infinity, -Infinity, -0)', async () => {
+      const out = dataToEsm(
+        { a: NaN, b: Infinity, c: -Infinity, d: -0 },
+        { compact: true },
+      );
+      expect(out).toContain('a=NaN');
+      expect(out).toContain('b=Infinity');
+      expect(out).toContain('c=-Infinity');
+      expect(out).toContain('d=-0');
+    });
+
+    await it('emits bigint with the n suffix', async () => {
+      const out = dataToEsm({ big: 9007199254740993n }, { compact: true });
+      expect(out).toContain('export var big=9007199254740993n;');
+    });
+
+    await it('serializes nested objects with the configured indent', async () => {
+      const out = dataToEsm({ nested: { a: 1, b: 2 } }, { indent: '  ' });
+      // Two-space indent, top-level export, nested braces follow same indent.
+      expect(out).toContain('export var nested = {\n  a: 1,\n  b: 2\n};');
+    });
+
+    await it('escapes U+2028 and U+2029 in serialized strings', async () => {
+      const out = dataToEsm({ s: 'a b c' }, { compact: true });
+      // String must not contain the raw line separators.
+      expect(out).not.toContain(' ');
+      expect(out).not.toContain(' ');
+      expect(out).toContain('\\u2028');
+      expect(out).toContain('\\u2029');
+    });
+  });
+};

--- a/tests/integration/rollup-pluginutils/src/extract-assigned-names.spec.ts
+++ b/tests/integration/rollup-pluginutils/src/extract-assigned-names.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Reference: @rollup/pluginutils public API.
+// Original: Copyright (c) 2019 RollupJS Plugin Contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Exercises extractAssignedNames() — given an acorn pattern node (Identifier,
+// ObjectPattern, ArrayPattern, AssignmentPattern, RestElement,
+// MemberExpression), returns the list of bindings that pattern introduces.
+// Pure JS — depends on the acorn parser already validated by the `acorn`
+// integration suite.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { parse } from 'acorn';
+import { extractAssignedNames } from '@rollup/pluginutils';
+
+const PARSE_OPTS = { ecmaVersion: 2024 as const, sourceType: 'module' as const };
+
+// Helper: parse `let <pattern> = ...;` and return the pattern node.
+function patternFromLet(src: string): any {
+  const ast: any = parse(`let ${src} = 0;`, PARSE_OPTS);
+  return ast.body[0].declarations[0].id;
+}
+
+export default async () => {
+  await describe('@rollup/pluginutils extractAssignedNames', async () => {
+
+    await it('extracts a single Identifier', async () => {
+      const id = patternFromLet('foo');
+      expect(extractAssignedNames(id)).toStrictEqual(['foo']);
+    });
+
+    await it('extracts names from an ObjectPattern', async () => {
+      const pat = patternFromLet('{ a, b, c }');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    await it('extracts renamed properties from an ObjectPattern', async () => {
+      const pat = patternFromLet('{ a: x, b: y }');
+      expect(extractAssignedNames(pat)).toStrictEqual(['x', 'y']);
+    });
+
+    await it('extracts names from an ArrayPattern', async () => {
+      const pat = patternFromLet('[a, b, c]');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    await it('skips holes in an ArrayPattern', async () => {
+      const pat = patternFromLet('[a, , c]');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'c']);
+    });
+
+    await it('extracts the RestElement target', async () => {
+      const pat = patternFromLet('[a, ...rest]');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'rest']);
+    });
+
+    await it('extracts the rest property of an ObjectPattern', async () => {
+      const pat = patternFromLet('{ a, ...rest }');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'rest']);
+    });
+
+    await it('extracts identifier from AssignmentPattern (default values)', async () => {
+      const pat = patternFromLet('{ a = 1, b = "x" }');
+      expect(extractAssignedNames(pat)).toStrictEqual(['a', 'b']);
+    });
+
+    await it('handles deeply nested patterns', async () => {
+      const pat = patternFromLet('{ a: [{ b }, c], d: { e = 1 } }');
+      expect(extractAssignedNames(pat)).toStrictEqual(['b', 'c', 'e']);
+    });
+
+    await it('returns [] for a MemberExpression target', async () => {
+      // Build the AST for `foo.bar = 1;` and extract from the assignment LHS.
+      const ast: any = parse('foo.bar = 1;', PARSE_OPTS);
+      const lhs = ast.body[0].expression.left;
+      expect(lhs.type).toBe('MemberExpression');
+      expect(extractAssignedNames(lhs)).toStrictEqual([]);
+    });
+  });
+};

--- a/tests/integration/rollup-pluginutils/src/make-legal-identifier.spec.ts
+++ b/tests/integration/rollup-pluginutils/src/make-legal-identifier.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// Reference: @rollup/pluginutils public API.
+// Original: Copyright (c) 2019 RollupJS Plugin Contributors. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+//
+// Exercises makeLegalIdentifier() — turns arbitrary strings into bundle-safe
+// JS identifiers. Pure JS — exercises regex + Set membership.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { makeLegalIdentifier } from '@rollup/pluginutils';
+
+export default async () => {
+  await describe('@rollup/pluginutils makeLegalIdentifier', async () => {
+
+    await it('passes through valid identifiers unchanged', async () => {
+      expect(makeLegalIdentifier('foo')).toBe('foo');
+      expect(makeLegalIdentifier('foo_bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('$jq')).toBe('$jq');
+      expect(makeLegalIdentifier('_underscore')).toBe('_underscore');
+      expect(makeLegalIdentifier('camelCase')).toBe('camelCase');
+      expect(makeLegalIdentifier('CONST123')).toBe('CONST123');
+    });
+
+    await it('camelCases hyphen-segments (kebab → camel)', async () => {
+      expect(makeLegalIdentifier('foo-bar')).toBe('fooBar');
+      expect(makeLegalIdentifier('foo-bar-baz')).toBe('fooBarBaz');
+      expect(makeLegalIdentifier('rollup-plugin-utils')).toBe('rollupPluginUtils');
+    });
+
+    await it('replaces other illegal characters with underscores', async () => {
+      expect(makeLegalIdentifier('foo.bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('foo bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('foo/bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('foo+bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('foo:bar')).toBe('foo_bar');
+      expect(makeLegalIdentifier('@scope/pkg')).toBe('_scope_pkg');
+    });
+
+    await it('prefixes leading-digit identifiers with an underscore', async () => {
+      expect(makeLegalIdentifier('1foo')).toBe('_1foo');
+      expect(makeLegalIdentifier('123')).toBe('_123');
+      expect(makeLegalIdentifier('9lives')).toBe('_9lives');
+    });
+
+    await it('prefixes reserved words with an underscore', async () => {
+      expect(makeLegalIdentifier('class')).toBe('_class');
+      expect(makeLegalIdentifier('return')).toBe('_return');
+      expect(makeLegalIdentifier('await')).toBe('_await');
+      expect(makeLegalIdentifier('yield')).toBe('_yield');
+      expect(makeLegalIdentifier('default')).toBe('_default');
+    });
+
+    await it('prefixes built-in globals with an underscore', async () => {
+      expect(makeLegalIdentifier('undefined')).toBe('_undefined');
+      expect(makeLegalIdentifier('NaN')).toBe('_NaN');
+      expect(makeLegalIdentifier('Infinity')).toBe('_Infinity');
+      expect(makeLegalIdentifier('Object')).toBe('_Object');
+      expect(makeLegalIdentifier('Array')).toBe('_Array');
+      expect(makeLegalIdentifier('Promise')).toBe('_Promise');
+    });
+
+    await it('returns "_" for empty input', async () => {
+      expect(makeLegalIdentifier('')).toBe('_');
+    });
+
+    await it('replaces non-ASCII characters with underscores', async () => {
+      // Source identifiers from package names like "café" or "naïve" become
+      // underscored — only [$_a-zA-Z0-9] survives.
+      expect(makeLegalIdentifier('café')).toBe('caf_');
+      expect(makeLegalIdentifier('naïve')).toBe('na_ve');
+    });
+  });
+};

--- a/tests/integration/rollup-pluginutils/src/test.mts
+++ b/tests/integration/rollup-pluginutils/src/test.mts
@@ -1,0 +1,25 @@
+// Integration-test entry for @gjsify/integration-rollup-pluginutils.
+// Builds once per runtime (gjs/node) via `gjsify build src/test.mts`.
+//
+// Validates that @rollup/pluginutils — the helper toolkit consumed by
+// @gjsify/rolldown-plugin-gjsify — runs end-to-end on GJS. Pillars exercised:
+// path (createFilter resolves include/exclude against process.cwd()),
+// picomatch glob (transitive dep used by createFilter), and pure-JS string +
+// AST helpers (dataToEsm, makeLegalIdentifier, attachScopes,
+// extractAssignedNames).
+
+import '@gjsify/node-globals/register';
+import { run } from '@gjsify/unit';
+import createFilterSuite from './create-filter.spec.js';
+import dataToEsmSuite from './data-to-esm.spec.js';
+import makeLegalIdentifierSuite from './make-legal-identifier.spec.js';
+import attachScopesSuite from './attach-scopes.spec.js';
+import extractAssignedNamesSuite from './extract-assigned-names.spec.js';
+
+run({
+  createFilterSuite,
+  dataToEsmSuite,
+  makeLegalIdentifierSuite,
+  attachScopesSuite,
+  extractAssignedNamesSuite,
+});

--- a/tests/integration/rollup-pluginutils/tsconfig.json
+++ b/tests/integration/rollup-pluginutils/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "types": ["@girs/gjs", "node"],
+        "target": "ESNext",
+        "moduleResolution": "NodeNext",
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "files": [
+        "src/test.mts",
+        "src/create-filter.spec.ts",
+        "src/data-to-esm.spec.ts",
+        "src/make-legal-identifier.spec.ts",
+        "src/attach-scopes.spec.ts",
+        "src/extract-assigned-names.spec.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3339,6 +3339,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/integration-rollup-pluginutils@workspace:tests/integration/rollup-pluginutils":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-rollup-pluginutils@workspace:tests/integration/rollup-pluginutils"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@rollup/pluginutils": "npm:^5.3.0"
+    "@types/node": "npm:^25.6.2"
+    acorn: "npm:^8.16.0"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/integration-socket.io@workspace:tests/integration/socket.io":
   version: 0.0.0-use.local
   resolution: "@gjsify/integration-socket.io@workspace:tests/integration/socket.io"


### PR DESCRIPTION
## Summary

Phase D-1 **Workstream V** — integration suite for [`@rollup/pluginutils@^5`](https://github.com/rollup/plugins/tree/master/packages/pluginutils), the helper toolkit that `@gjsify/rolldown-plugin-gjsify` itself depends on (`createFilter`, `dataToEsm`, `makeLegalIdentifier`, `attachScopes`, `extractAssignedNames`).

- 5 spec files / 54 cases — covering the full documented public API
- **138/138 green on Node, 138/138 green on GJS, 0 skips**
- No `@gjsify/*` fixes required — pure JS over `node:path` + picomatch; both bundle and run unmodified on SpiderMonkey 140

The picomatch transitive dep used by `createFilter` is exercised end-to-end as well — additional indirect coverage that `@gjsify/path` + the SpiderMonkey 140 RegExp surface match Node's behavior for picomatch's heavy regex paths.

Clears another of the 11 Phase D-1 npm runtime-deps the future GJS-hosted `@gjsify/cli` build needs. Plan: `.claude/plans/erstelle-einen-umsetzungsplan-f-r-fluttering-barto.md`. Tracker: `STATUS.md` "Integration Test Coverage → @rollup/pluginutils".

## Test plan

- [x] `cd tests/integration/rollup-pluginutils && yarn build:test && yarn test:node` — 138/138
- [x] `cd tests/integration/rollup-pluginutils && yarn test:gjs` — 138/138
- [x] STATUS.md "Integration Test Coverage" updated with new pluginutils section
- [x] CHANGELOG.md "Tests" entry added under Unreleased
- [ ] CI: Fedora 43 + Fedora 44 GJS jobs green

## Notes for reviewers

- Like Stream U (#124), the yarn.lock additions also include the workspace entries for the already-merged Batch 1 suites (yargs, acorn, gettext-parser) that are missing from main due to lockfile drift — same fix as #122. After #122 + #124 merge, this PR's lock diff shrinks to just the `@gjsify/integration-rollup-pluginutils` entry on rebase.
- The published `@rollup/pluginutils` tarball strips its own `test/` directory, so the spec files are derived from the documented public API rather than ported verbatim.