### PR TITLE
test(integration-deepkit-type-compiler): add suite — Phase D self-hosting (Stream W)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -627,6 +627,32 @@
   `rolldown` / `lightningcss` that fall through to D-2 research).
   Tracked in STATUS.md "Integration Test Coverage → minify-xml".
 
+* **integration-deepkit-type-compiler (2026-05-09):** Phase D-1
+  Workstream W — new `tests/integration/deepkit-type-compiler/` suite
+  (`@gjsify/integration-deepkit-type-compiler`, private). 2 spec files
+  / 13 cases covering [`@deepkit/type-compiler@^1`](https://github.com/deepkit/deepkit-framework)
+  — the TypeScript reflection emitter consumed by
+  `@gjsify/rolldown-plugin-deepkit` (opt-in via `reflection: true`).
+  Suites: `loader` (`DeepkitLoader` constructor + `transform()`
+  round-trip on plain code, empty input, class+interface declarations,
+  two-transforms-don't-interfere, no-typeOf-call no-instrumentation
+  invariant), `transform` (`typeOf<T>()` instrumentation signal —
+  call rewritten to `typeOf<T>([], …)` — per-kind metadata emission
+  shapes: named interface (hoisted `const __ΩName`), class (`static
+  __type` member), primitive type alias (hoisted `__ΩName`), inline
+  structural type (in-place encoded string), round-trip safety,
+  syntactically broken input handling). Total: **29/29 green on Node,
+  29/29 green on GJS, 0 skips.** No `@gjsify/*` fixes required —
+  Deepkit + its `typescript@^5` peer + `@marcj/ts-clone-node`
+  transitive bundle and run cleanly on SpiderMonkey 140 through the
+  standard `@gjsify/cli` build path. The test bundle alone is ≈8 MiB
+  (TypeScript itself dominates), confirming Rolldown's tree-shaking
+  + the `--app gjs` config don't choke on the deepest dep we ship.
+  Clears the next-to-last of the 11 Phase D-1 npm runtime-deps the
+  future GJS-hosted `@gjsify/cli` build needs (excluding the Rust
+  blockers `rolldown` / `lightningcss`). Tracked in STATUS.md
+  "Integration Test Coverage → @deepkit/type-compiler".
+
 ## [0.3.21](https://github.com/gjsify/gjsify/compare/v0.3.20...v0.3.21) (2026-05-08)
 
 ### Bug Fixes

--- a/STATUS.md
+++ b/STATUS.md
@@ -727,6 +727,17 @@ The published `minify-xml` tarball strips its own `test/` directory (the package
 
 Clears the last of the 11 Phase D-1 npm runtime-deps the future GJS-hosted `@gjsify/cli` build needs (excluding the Rust blockers `rolldown` / `lightningcss` that fall through to D-2 research). The Blueprint consumer path — `@gjsify/vite-plugin-blueprint` calls `minify(xml)` on the XML string blueprint-compiler emits — is now end-to-end-validated, so the existing GTK examples that bundle `.blp` resources are protected against any future RegExp-engine-divergence regressions.
 
+### @deepkit/type-compiler (`tests/integration/deepkit-type-compiler/`)
+
+Phase D-1 Workstream W — validates the Deepkit TypeScript type compiler consumed by `@gjsify/rolldown-plugin-deepkit`. The plugin is opt-in (`reflection: true` in `.gjsifyrc.js`), but when enabled it instruments user code via `DeepkitLoader.transform()` — the same TypeScript Compiler API surface this suite exercises end-to-end. **Node: 29/29 green. GJS: 29/29 green, 0 skips.** No `@gjsify/*` fixes required — Deepkit + its `typescript@^5` peer + `@marcj/ts-clone-node` transitive bundle and run cleanly on SpiderMonkey 140 through the standard `@gjsify/cli` build path.
+
+| Suite | Node | GJS | Exercises |
+|---|---|---|---|
+| loader.spec.ts | ✅ (6) | ✅ (6) | `DeepkitLoader` constructor + `transform()` round-trip on plain code, empty input, class+interface declarations, two-transforms-don't-interfere, no-typeOf-call no-instrumentation invariant |
+| transform.spec.ts | ✅ (7) | ✅ (7) | `typeOf<T>()` instrumentation signal (call rewritten to `typeOf<T>([], …)`), per-kind metadata emission shapes — named interface (hoisted `const __ΩName`), class (`static __type` member), primitive type alias (hoisted `__ΩName`), inline structural type (in-place encoded string), round-trip safety, syntactically broken input handling |
+
+The TypeScript Compiler API code path inside Deepkit + `@marcj/ts-clone-node` walks `Program`, `SourceFile`, `Printer`, and `CustomTransformerFactory` shapes — the heaviest single TS-API exercise we've put through the GJS bundle path. Bundle size for the test alone is ≈8 MiB (TypeScript itself is the dominant cost), confirming Rolldown's tree-shaking + the `--app gjs` config don't choke on the deepest dep we ship. Clears the next-to-last of the 11 Phase D-1 npm runtime-deps the future GJS-hosted `@gjsify/cli` build needs (excluding the Rust blockers `rolldown` / `lightningcss`).
+
 ## Open TODOs
 
 Tracked follow-up work that has been deliberately deferred. Every "out of scope" or "follow-up" note from a PR or implementation plan must end up here so future sessions can pick it up.

--- a/tests/integration/deepkit-type-compiler/.gitignore
+++ b/tests/integration/deepkit-type-compiler/.gitignore
@@ -1,0 +1,2 @@
+dist/
+tsconfig.tsbuildinfo

--- a/tests/integration/deepkit-type-compiler/package.json
+++ b/tests/integration/deepkit-type-compiler/package.json
@@ -1,0 +1,31 @@
+{
+    "name": "@gjsify/integration-deepkit-type-compiler",
+    "description": "Integration tests: @deepkit/type-compiler on GJS and Node. Validates @gjsify/* TypeScript-compiler-API surface against the Deepkit reflection emitter used by @gjsify/rolldown-plugin-deepkit.",
+    "type": "module",
+    "private": true,
+    "engines": {
+        "node": ">=22.12.0"
+    },
+    "scripts": {
+        "clear": "rm -rf dist tsconfig.tsbuildinfo || exit 0",
+        "check": "tsc --noEmit",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile dist/test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile dist/test.node.mjs",
+        "build:test": "yarn build:test:node && yarn build:test:gjs",
+        "test": "yarn build:test && yarn test:node && yarn test:gjs",
+        "test:node": "node dist/test.node.mjs",
+        "test:gjs": "gjsify run dist/test.gjs.mjs"
+    },
+    "devDependencies": {
+        "@deepkit/type-compiler": "^1.0.19",
+        "@girs/gjs": "4.0.0-rc.14",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/node-globals": "workspace:^",
+        "@gjsify/runtime": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@types/node": "^25.6.2",
+        "typescript": "^5.4.5"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT"
+}

--- a/tests/integration/deepkit-type-compiler/src/loader.spec.ts
+++ b/tests/integration/deepkit-type-compiler/src/loader.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Inspired by node_modules/@deepkit/type-compiler/dist/cjs/src/loader.* (the
+// loader is part of the public API but the package's tests/ are not shipped
+// in the npm tarball). Re-derived from the documented DeepkitLoader API.
+// Original: Copyright (c) Deepkit. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { DeepkitLoader } from '@deepkit/type-compiler';
+
+export default async () => {
+  await describe('@deepkit/type-compiler — DeepkitLoader', async () => {
+
+    await it('exports DeepkitLoader as a constructor', async () => {
+      expect(typeof DeepkitLoader).toBe('function');
+      const loader = new DeepkitLoader();
+      expect(loader).toBeTruthy();
+      expect(typeof loader.transform).toBe('function');
+    });
+
+    await it('passes through code that does not use the Type API', async () => {
+      const loader = new DeepkitLoader();
+      const src = 'export const foo = 42;\n';
+      const out = loader.transform(src, '/virtual/foo.ts');
+      expect(typeof out).toBe('string');
+      // Plain code with no reflection markers should be returned unchanged
+      // (or with at most cosmetic Printer normalization). Either way, the
+      // declaration must survive.
+      expect(out.includes('foo')).toBe(true);
+      expect(out.includes('42')).toBe(true);
+    });
+
+    await it('handles empty input without throwing', async () => {
+      const loader = new DeepkitLoader();
+      const out = loader.transform('', '/virtual/empty.ts');
+      expect(typeof out).toBe('string');
+    });
+
+    await it('handles a code path that uses TypeScript class + interface declarations', async () => {
+      // Deepkit only emits __ΩX/typeOf metadata when typeOf<...>() is called;
+      // a plain class+interface declaration must round-trip cleanly with no
+      // emitted metadata side effects.
+      const loader = new DeepkitLoader();
+      const src = `
+        interface User { id: number; name: string }
+        export class Repo {
+          users: User[] = [];
+          add(u: User): void { this.users.push(u); }
+        }
+      `;
+      const out = loader.transform(src, '/virtual/repo.ts');
+      expect(typeof out).toBe('string');
+      expect(out.includes('Repo')).toBe(true);
+      expect(out.includes('add')).toBe(true);
+    });
+
+    await it('two transforms in a row do not interfere with each other', async () => {
+      const loader = new DeepkitLoader();
+      const a = loader.transform('export const a = 1;\n', '/virtual/a.ts');
+      const b = loader.transform('export const b = 2;\n', '/virtual/b.ts');
+      expect(a.includes('a')).toBe(true);
+      expect(a.includes('1')).toBe(true);
+      expect(b.includes('b')).toBe(true);
+      expect(b.includes('2')).toBe(true);
+    });
+
+    await it('does not instrument typeOf callsites when none are present', async () => {
+      const loader = new DeepkitLoader();
+      const src = `
+        export type Foo = { x: number };
+        export const v: Foo = { x: 1 };
+      `;
+      const out = loader.transform(src, '/virtual/no-typeof.ts');
+      // Note: Deepkit DOES emit `__ΩFoo` metadata for any exported type
+      // alias (so library consumers can `typeOf` them later). What it does
+      // NOT do without a typeOf callsite is rewrite a `typeOf<…>()` call
+      // into `typeOf<…>([], …)`. That instrumentation is what the runtime
+      // actually consumes — the bare metadata constant is harmless on its
+      // own. Assert on the absence of the rewritten call signature.
+      expect(/typeOf\s*<[^>]*>\s*\(\s*\[\s*\]\s*,/.test(out)).toBe(false);
+      expect(out.includes('Foo')).toBe(true);
+      expect(out.includes('v')).toBe(true);
+    });
+
+  });
+};

--- a/tests/integration/deepkit-type-compiler/src/test.mts
+++ b/tests/integration/deepkit-type-compiler/src/test.mts
@@ -1,0 +1,18 @@
+// Integration-test entry for @gjsify/integration-deepkit-type-compiler.
+// Builds once per runtime (gjs/node) via `gjsify build src/test.mts`.
+//
+// Validates that @deepkit/type-compiler — the TypeScript transformer
+// consumed by @gjsify/rolldown-plugin-deepkit — runs end-to-end on GJS.
+// Pillars exercised: the TypeScript Compiler API surface that
+// @marcj/ts-clone-node + Deepkit's reflection emitter walk
+// (Program, SourceFile, Printer, custom transformers).
+
+import '@gjsify/node-globals/register';
+import { run } from '@gjsify/unit';
+import loaderSuite from './loader.spec.js';
+import transformSuite from './transform.spec.js';
+
+run({
+  loaderSuite,
+  transformSuite,
+});

--- a/tests/integration/deepkit-type-compiler/src/transform.spec.ts
+++ b/tests/integration/deepkit-type-compiler/src/transform.spec.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// Inspired by Deepkit's documented reflection API — re-derived from the
+// `typeOf<T>()` emission contract that @gjsify/rolldown-plugin-deepkit
+// hands user code through.
+// Original: Copyright (c) Deepkit. MIT.
+// Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { DeepkitLoader } from '@deepkit/type-compiler';
+
+export default async () => {
+  await describe('@deepkit/type-compiler — typeOf<T>() emission', async () => {
+
+    // Deepkit's instrumentation signal is that it rewrites `typeOf<T>()`
+    // (zero-arg call site) into `typeOf<T>([], [...metadata])` — adding two
+    // synthetic arguments. The exact metadata shape varies by input kind:
+    // named interfaces / type aliases produce a hoisted `const __ΩName = […]`
+    // (note the Greek capital omega Ω, U+03A9); classes get a `static __type`
+    // member; inline structural types emit an in-place encoded string. The
+    // common signal across all of these is the rewritten `typeOf<…>([], …)`
+    // call.
+    function isInstrumented(src: string): boolean {
+      // Strict signal: there must be at least one `>([], ` sequence — i.e.
+      // the `typeOf<…>(…)` callsite gained a leading empty array argument
+      // before any other arg. Using `>([]` instead of `typeOf<…>([]` lets
+      // multi-line type literals (e.g. `<{ items: ... }>`) match without
+      // needing a balanced-bracket parser.
+      return /typeOf\b/.test(src) && />\s*\(\s*\[\s*\]\s*,/.test(src);
+    }
+
+    await it('emits reflection metadata when typeOf<T>() is called on an interface', async () => {
+      const loader = new DeepkitLoader();
+      const src = `
+        import { typeOf } from '@deepkit/type';
+        interface User { id: number; name: string }
+        export const t = typeOf<User>();
+      `;
+      const out = loader.transform(src, '/virtual/typeof-interface.ts');
+      // Instrumentation signal + named-interface-specific metadata constant.
+      expect(isInstrumented(out)).toBe(true);
+      expect(out.includes('__ΩUser')).toBe(true);
+    });
+
+    await it('emits reflection metadata when typeOf<T>() is called on a class', async () => {
+      const loader = new DeepkitLoader();
+      const src = `
+        import { typeOf } from '@deepkit/type';
+        export class Order {
+          id!: number;
+          total!: number;
+        }
+        export const t = typeOf<Order>();
+      `;
+      const out = loader.transform(src, '/virtual/typeof-class.ts');
+      expect(isInstrumented(out)).toBe(true);
+      // Class-specific Deepkit signal: a `static __type` member is added.
+      expect(out.includes('Order')).toBe(true);
+      expect(out.includes('static __type')).toBe(true);
+    });
+
+    await it('emits reflection metadata for primitive type aliases', async () => {
+      const loader = new DeepkitLoader();
+      const src = `
+        import { typeOf } from '@deepkit/type';
+        export type Id = string;
+        export const t = typeOf<Id>();
+      `;
+      const out = loader.transform(src, '/virtual/typeof-primitive.ts');
+      expect(isInstrumented(out)).toBe(true);
+      expect(out.includes('__ΩId')).toBe(true);
+    });
+
+    await it('emits reflection metadata for inline structural types (no hoisted constant)', async () => {
+      const loader = new DeepkitLoader();
+      const src = `
+        import { typeOf } from '@deepkit/type';
+        export const t = typeOf<{ items: Array<{ x: number }> }>();
+      `;
+      const out = loader.transform(src, '/virtual/typeof-generic.ts');
+      // Inline structural types don't get a hoisted __Ω constant — Deepkit
+      // emits the metadata as an in-place encoded string in the second
+      // argument array. The instrumentation signal still holds.
+      expect(isInstrumented(out)).toBe(true);
+      expect(out.includes('items')).toBe(true);
+    });
+
+    await it('round-trip: re-running the transform on already-transformed output is safe', async () => {
+      const loader1 = new DeepkitLoader();
+      const loader2 = new DeepkitLoader();
+      const src = `
+        import { typeOf } from '@deepkit/type';
+        interface Foo { a: number }
+        export const t = typeOf<Foo>();
+      `;
+      const once = loader1.transform(src, '/virtual/round-trip.ts');
+      // A second pass shouldn't crash; we don't assert exact equality —
+      // only that the re-transform produces a string and the instrumentation
+      // signal stays present.
+      const twice = loader2.transform(once, '/virtual/round-trip.ts');
+      expect(typeof twice).toBe('string');
+      expect(isInstrumented(twice)).toBe(true);
+    });
+
+    await it('handles syntactically broken input without exiting the process', async () => {
+      // The Deepkit loader internally swallows TS diagnostics and keeps
+      // transforming. We just verify no uncaught exception escapes.
+      const loader = new DeepkitLoader();
+      let returnedString = '';
+      try {
+        returnedString = loader.transform('export const foo: ; // intentionally invalid\n', '/virtual/broken.ts');
+      } catch {
+        // Even if it throws, the GJS process should not have died — we'd
+        // never reach this point if it had.
+      }
+      expect(typeof returnedString).toBe('string');
+    });
+
+  });
+};

--- a/tests/integration/deepkit-type-compiler/tsconfig.json
+++ b/tests/integration/deepkit-type-compiler/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "types": ["@girs/gjs", "node"],
+        "target": "ESNext",
+        "moduleResolution": "NodeNext",
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "files": [
+        "src/test.mts",
+        "src/loader.spec.ts",
+        "src/transform.spec.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3262,6 +3262,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/integration-deepkit-type-compiler@workspace:tests/integration/deepkit-type-compiler":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-deepkit-type-compiler@workspace:tests/integration/deepkit-type-compiler"
+  dependencies:
+    "@deepkit/type-compiler": "npm:^1.0.19"
+    "@girs/gjs": "npm:4.0.0-rc.14"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/node": "npm:^25.6.2"
+    typescript: "npm:^5.4.5"
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/integration-fast-glob@workspace:tests/integration/fast-glob":
   version: 0.0.0-use.local
   resolution: "@gjsify/integration-fast-glob@workspace:tests/integration/fast-glob"
@@ -17650,6 +17665,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.4.5":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
@@ -17657,6 +17682,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Phase D-1 **Workstream W** — integration suite for [`@deepkit/type-compiler@^1`](https://github.com/deepkit/deepkit-framework), the TypeScript reflection emitter consumed by `@gjsify/rolldown-plugin-deepkit` (opt-in via `reflection: true` in `.gjsifyrc.js`).

- 2 spec files / 13 cases — `loader` (6) + `transform` (7)
- **29/29 green on Node, 29/29 green on GJS, 0 skips**
- No `@gjsify/*` fixes required — Deepkit + its `typescript@^5` peer + `@marcj/ts-clone-node` transitive bundle and run cleanly on SpiderMonkey 140 through the standard `@gjsify/cli` build path

The TypeScript Compiler API code path inside Deepkit + ts-clone-node walks `Program` / `SourceFile` / `Printer` / `CustomTransformerFactory` shapes — the heaviest single TS-API exercise we've put through the GJS bundle path. Bundle size for the test alone is ≈8 MiB (TypeScript itself dominates), confirming Rolldown's tree-shaking + the `--app gjs` config don't choke on the deepest dep we ship.

Clears the next-to-last of the 11 Phase D-1 npm runtime-deps the future GJS-hosted `@gjsify/cli` build needs (excluding the Rust blockers `rolldown` / `lightningcss` that fall through to D-2 research).

Plan: `.claude/plans/erstelle-einen-umsetzungsplan-f-r-fluttering-barto.md`. Tracker: `STATUS.md` "Integration Test Coverage → @deepkit/type-compiler".

## Test plan

- [x] `cd tests/integration/deepkit-type-compiler && yarn build:test && yarn test:node` — 29/29
- [x] `cd tests/integration/deepkit-type-compiler && yarn test:gjs` — 29/29
- [x] STATUS.md "Integration Test Coverage" updated with new deepkit section
- [x] CHANGELOG.md "Tests" entry added under Unreleased
- [ ] CI: Fedora 43 + Fedora 44 GJS jobs green

## Notes for reviewers

- The published `@deepkit/type-compiler` tarball strips its own `tests/` directory, so the spec files are derived from the documented `DeepkitLoader` API (which is part of the public surface — re-exported from `index.cjs`) plus the `typeOf<T>()` emission contract documented in Deepkit's reflection guide rather than ported verbatim.
- The metadata emission shape varies by input kind: named interfaces / type aliases produce a hoisted `const __ΩName = […]` (note the Greek capital omega Ω, U+03A9); classes get a `static __type` member; inline structural types emit an in-place encoded string. The common signal across all of these is the rewritten `typeOf<…>([], …)` call — that's what the suite asserts on.
- The `@deepkit/type-compiler` package eagerly imports `typescript` through `@marcj/ts-clone-node`. To keep this from cascading into every gjsify consumer, `@gjsify/rolldown-plugin-deepkit` lazy-imports the loader (it stays uninstalled until `reflection: true`) — this suite explicitly opts in by listing both as devDeps.