### PR TITLE
feat(util): add aborted(signal, resource) — Node 19+ stable API

### DIFF
--- a/packages/node/util/src/extended.spec.ts
+++ b/packages/node/util/src/extended.spec.ts
@@ -537,4 +537,56 @@ export default async () => {
       expect(() => util.stripVTControlCharacters(42 as unknown as string)).toThrow();
     });
   });
+
+  await describe('util.aborted', async () => {
+    await it('exports a function', async () => {
+      expect(typeof util.aborted).toBe('function');
+    });
+
+    await it('resolves immediately when the signal is already aborted', async () => {
+      const ctrl = new AbortController();
+      ctrl.abort();
+      const start = Date.now();
+      await util.aborted(ctrl.signal, {});
+      expect(Date.now() - start).toBeLessThan(50);
+    });
+
+    await it('resolves once the signal aborts later', async () => {
+      const ctrl = new AbortController();
+      const promise = util.aborted(ctrl.signal, {});
+      let resolved = false;
+      promise.then(() => { resolved = true; });
+      await new Promise<void>((r) => globalThis.setTimeout(r, 10));
+      expect(resolved).toBe(false);
+      ctrl.abort();
+      await new Promise<void>((r) => globalThis.setTimeout(r, 10));
+      expect(resolved).toBe(true);
+    });
+
+    await it('returns a rejected Promise when signal is not an AbortSignal', async () => {
+      // Node returns a *rejected Promise* (not a sync throw) on bad signal.
+      let caught: unknown = null;
+      try { await util.aborted(null as unknown as AbortSignal, {}); } catch (e) { caught = e; }
+      expect(caught).toBeTruthy();
+      expect((caught as Error).name).toBe('TypeError');
+
+      caught = null;
+      try { await util.aborted({} as AbortSignal, {}); } catch (e) { caught = e; }
+      expect(caught).toBeTruthy();
+      expect((caught as Error).name).toBe('TypeError');
+    });
+
+    await it('returns a rejected Promise when resource is not a non-null object', async () => {
+      const ctrl = new AbortController();
+      let caught: unknown = null;
+      try { await util.aborted(ctrl.signal, null as unknown as object); } catch (e) { caught = e; }
+      expect(caught).toBeTruthy();
+      expect((caught as Error).name).toBe('TypeError');
+
+      caught = null;
+      try { await util.aborted(ctrl.signal, 'not-an-object' as unknown as object); } catch (e) { caught = e; }
+      expect(caught).toBeTruthy();
+      expect((caught as Error).name).toBe('TypeError');
+    });
+  });
 };

--- a/packages/node/util/src/index.ts
+++ b/packages/node/util/src/index.ts
@@ -709,6 +709,45 @@ export function toUSVString(string: string): string {
   return string.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '\uFFFD');
 }
 
+// ---- aborted ----
+
+/**
+ * Returns a Promise that resolves once `signal` aborts. The optional
+ * `resource` argument is accepted for Node compatibility — Node uses it
+ * for experimental "resource cleanup" tracking; we ignore it (no-op),
+ * which matches the observable behavior of `util.aborted()` for the
+ * documented use case.
+ *
+ * Reference: https://nodejs.org/api/util.html#utilabortedsignal-resource
+ *
+ * @param signal An `AbortSignal` to wait on.
+ * @param resource Any non-null object — accepted for Node parity.
+ */
+export function aborted(signal: AbortSignal, resource: object): Promise<void> {
+  // Match Node's behaviour: validation errors come back as a rejected
+  // Promise (not a synchronous throw). Mirrors Node's `aborted` impl,
+  // which dispatches through a webidl-validated `AbortSignal` cast and
+  // produces a rejected Promise on bad input.
+  if (signal == null || typeof (signal as AbortSignal).aborted !== 'boolean') {
+    return Promise.reject(
+      new TypeError('The "signal" argument must be an instance of AbortSignal'),
+    );
+  }
+  if (resource == null || typeof resource !== 'object') {
+    return Promise.reject(
+      new TypeError('The "resource" argument must be an non-null object'),
+    );
+  }
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 // ---- Default export ----
 
 export default {
@@ -740,6 +779,7 @@ export default {
   isBuffer,
   isDeepStrictEqual,
   toUSVString,
+  aborted,
   TextDecoder: globalThis.TextDecoder,
   TextEncoder: globalThis.TextEncoder,
   getSystemErrorName,


### PR DESCRIPTION
## Summary

Add `util.aborted(signal, resource)` to `@gjsify/util` — a Promise-returning helper that resolves once the given `AbortSignal` fires. The `resource` argument is accepted for Node-parity but ignored (Node uses it for experimental \"resource cleanup\" tracking; the documented use case behaves identically when ignored).

Reference: https://nodejs.org/api/util.html#utilabortedsignal-resource

Required by `execa@^9` (and any other module bridging `AbortController` → Promise). First surfaced while exploring the Phase D-1 Stream T (execa) integration suite — landing ahead of the execa suite as a standalone fix.

This is item 2 of the Phase D-1 follow-up plan (`.claude/plans/phase-d-1-followup-fixes.md`).

## Test plan

- [x] `cd packages/node/util && yarn build && yarn test:node` — 258/258 (5 new aborted cases)
- [x] `cd packages/node/util && yarn test:gjs` — 258/258
- [ ] CI: Fedora 43 + Fedora 44 GJS jobs green

## Notes for reviewers

- Implementation is intentionally minimal (~30 LOC): validate args at the boundary, fast-path when already aborted, otherwise wire a one-shot `addEventListener('abort', …, { once: true })` that resolves the Promise.
- The `resource` argument is required (not optional) to match Node's signature exactly — passing `undefined` throws `TypeError`, same as Node.