### PR TITLE
test(integration-lightningcss): byte-equality suite across all 3 backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@
 
 ### Features
 
+* **integration-lightningcss byte-equality suite (2026-05-10):**
+  Phase D-2 follow-up. New `tests/integration/lightningcss/` suite
+  (`@gjsify/integration-lightningcss`, private) turns the
+  decision-matrix's load-bearing byte-equality property into a
+  permanent regression guard. 6 fixtures × 2 backend pairs = 12
+  assertions covering all three backends transitively:
+    - Node: `@gjsify/lightningcss-wasm` vs npm `lightningcss` (6/6)
+    - GJS:  `@gjsify/lightningcss-native` vs `@gjsify/lightningcss-wasm` (6/6)
+  Fixtures exercise distinct paths: plain selector, longhand
+  collapse, CSS nesting flatten for `firefox >= 60`, `lch()` color
+  lowering, pretty-print, nested `@media` flatten. Source maps are
+  intentionally NOT part of the contract (mappings indexes
+  legitimately differ between backends). Wired into `yarn
+  test:integration`.
 * **Multi-arch CI prebuilds for lightningcss-native + rolldown-native
   (2026-05-10):** Extended `.github/workflows/prebuilds.yml` so the
   Phase D-2 native packages get prebuilt and committed alongside the

--- a/STATUS.md
+++ b/STATUS.md
@@ -465,6 +465,17 @@ Not yet implemented (but potentially relevant for GJS projects):
 
 `tests/integration/` validates `@gjsify/*` implementations by running curated upstream tests from popular npm packages. Opt-in target: `yarn test:integration`.
 
+### lightningcss (`tests/integration/lightningcss/`)
+
+6 fixtures × 2 backend pairs = **12/12 byte-equality assertions green** (6/6 Node, 6/6 GJS). Locks in the load-bearing Phase D-2 decision-matrix property (`docs/poc/lightningcss-decision.md`): every backend gjsify wires through `cssAsStringPlugin` produces byte-identical output for the same input.
+
+| Runtime | Backends compared | Pass |
+|---|---|---|
+| Node | `@gjsify/lightningcss-wasm` vs npm `lightningcss` | 6/6 |
+| GJS | `@gjsify/lightningcss-native` vs `@gjsify/lightningcss-wasm` | 6/6 |
+
+Together those two diffs cover all three backends — a transitive byte-equality chain from native → wasm → npm. Fixtures exercise distinct lowering / minification paths (plain selector, longhand collapse, CSS nesting flatten for `firefox >= 60`, `lch()` color lowering, pretty-print, nested `@media` flatten) so a drift in any single transform surfaces as one failing assertion. Source maps are intentionally NOT part of the contract — `mappings` strings encode source indexes that legitimately differ between backends; code-only equality is what `cssAsStringPlugin` consumers observe.
+
 ### webtorrent (`tests/integration/webtorrent/`)
 
 7 test files ported from `refs/webtorrent/test/` into `@gjsify/unit` style. **Node: 185/185 green. GJS: 185/185 green, 0 skips.**

--- a/tests/integration/lightningcss/.gitignore
+++ b/tests/integration/lightningcss/.gitignore
@@ -1,0 +1,3 @@
+dist/
+wasm/
+*.tsbuildinfo

--- a/tests/integration/lightningcss/package.json
+++ b/tests/integration/lightningcss/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "@gjsify/integration-lightningcss",
+    "description": "Integration tests: byte-equality across the three lightningcss backends gjsify wires through cssAsStringPlugin. Compares @gjsify/lightningcss-native (Vala+Rust FFI) and @gjsify/lightningcss-wasm (vendored WASM) under GJS, and @gjsify/lightningcss-wasm vs npm `lightningcss` under Node. Locks in the load-bearing Phase D-2 decision-matrix claim that all three backends produce byte-identical output for the same input.",
+    "type": "module",
+    "private": true,
+    "engines": {
+        "node": ">=22.12.0"
+    },
+    "scripts": {
+        "clear": "rm -rf dist wasm tsconfig.tsbuildinfo || exit 0",
+        "check": "tsc --noEmit",
+        "prebuild:test": "mkdir -p wasm && cp ../../../packages/infra/lightningcss-wasm/wasm/lightningcss_node.wasm wasm/",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile dist/test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile dist/test.node.mjs",
+        "build:test": "yarn prebuild:test && yarn build:test:node && yarn build:test:gjs",
+        "test": "yarn build:test && yarn test:node && yarn test:gjs",
+        "test:node": "node dist/test.node.mjs",
+        "test:gjs": "gjsify run dist/test.gjs.mjs"
+    },
+    "devDependencies": {
+        "@girs/gjs": "4.0.0-rc.15",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/lightningcss-native": "workspace:^",
+        "@gjsify/lightningcss-wasm": "workspace:^",
+        "@gjsify/node-globals": "workspace:^",
+        "@gjsify/runtime": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@types/node": "^25.6.2",
+        "lightningcss": "^1.32.0",
+        "typescript": "^6.0.3"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT"
+}

--- a/tests/integration/lightningcss/src/byte-equality.spec.ts
+++ b/tests/integration/lightningcss/src/byte-equality.spec.ts
@@ -1,0 +1,177 @@
+// Byte-equality across the lightningcss backends gjsify wires through
+// cssAsStringPlugin.
+//
+// The Phase D-2 decision matrix (`docs/poc/lightningcss-decision.md`)
+// rests on two load-bearing facts:
+//   1. The native (FFI) and WASM tracks produce byte-identical output
+//      for the same input (verified manually during the matrix work).
+//   2. Both the native and WASM tracks match npm `lightningcss` so
+//      cssAsStringPlugin can route between them transparently.
+//
+// This suite turns those one-off checks into permanent regression
+// guards. The backend pair we compare is runtime-dependent:
+//
+//   GJS:  @gjsify/lightningcss-native  vs  @gjsify/lightningcss-wasm
+//   Node: @gjsify/lightningcss-wasm    vs  npm `lightningcss`
+//
+// Together those two diffs cover all three backends. Each fixture is
+// designed to exercise a different lowering / minification path so a
+// drift in any one transform surfaces as a single failing assertion.
+//
+// Output is normalised before comparison: trailing whitespace stripped
+// (some backends emit a trailing `\n`, some don't). Source maps are NOT
+// part of the byte-equality contract — `mappings` strings encode source
+// indexes that legitimately differ between backends. Code-only equality
+// is what cssAsStringPlugin consumers (CSS-as-string default exports)
+// observe.
+
+import { describe, expect, it, on } from '@gjsify/unit';
+
+interface Fixture {
+  label: string;
+  input: string;
+  minify: boolean;
+  /** Pre-resolved Targets bitfield for npm / WASM (`{ firefox: 60 << 16 }`). */
+  targetsObj?: Record<string, number>;
+  /** Equivalent browserslist query for the native bridge (`firefox >= 60`). */
+  targetsQuery?: string;
+}
+
+interface BackendModule {
+  name: string;
+  transform(fx: Fixture): Uint8Array;
+}
+
+function normalise(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes).replace(/\s+$/, '');
+}
+
+const FIXTURES: ReadonlyArray<Fixture> = [
+  {
+    label: 'plain selector + property — minified',
+    input: '.foo { color: red; }',
+    minify: true,
+  },
+  {
+    label: 'redundant longhand collapses under minify',
+    input: '.x { margin: 0 0 0 0; padding: 0 0; }',
+    minify: true,
+  },
+  {
+    label: 'nesting flatten for firefox60',
+    input: '.btn { color: red; & .icon { padding: 4px; } &:hover { color: blue; } }',
+    minify: true,
+    targetsObj: { firefox: 60 << 16 },
+    targetsQuery: 'firefox >= 60',
+  },
+  {
+    label: 'lch color lowered for firefox60',
+    input: '.x { color: lch(50% 100 30); }',
+    minify: true,
+    targetsObj: { firefox: 60 << 16 },
+    targetsQuery: 'firefox >= 60',
+  },
+  {
+    label: 'pretty-printed (no minify)',
+    input: '.foo { color: red; }',
+    minify: false,
+  },
+  {
+    label: 'nested at-rule inside selector — flattened for firefox60',
+    input: '.card { @media (min-width: 600px) { padding: 16px; } padding: 8px; }',
+    minify: true,
+    targetsObj: { firefox: 60 << 16 },
+    targetsQuery: 'firefox >= 60',
+  },
+];
+
+async function loadGjsBackends(): Promise<[BackendModule, BackendModule]> {
+  const native = await import('@gjsify/lightningcss-native');
+  if (!native.hasNativeLightningcss()) {
+    throw new Error('integration-lightningcss: @gjsify/lightningcss-native prebuild not loadable on this arch');
+  }
+  const wasm = await import('@gjsify/lightningcss-wasm');
+  await wasm.default();
+
+  return [
+    {
+      name: '@gjsify/lightningcss-native',
+      transform: ({ input, minify, targetsQuery }) =>
+        native.transform({
+          filename: 'fixture.css',
+          code: input,
+          minify,
+          targets: targetsQuery,
+        }).code,
+    },
+    {
+      name: '@gjsify/lightningcss-wasm',
+      transform: ({ input, minify, targetsObj }) =>
+        wasm.transform({
+          filename: 'fixture.css',
+          code: new TextEncoder().encode(input),
+          minify,
+          targets: targetsObj,
+        }).code,
+    },
+  ];
+}
+
+async function loadNodeBackends(): Promise<[BackendModule, BackendModule]> {
+  const wasm = await import('@gjsify/lightningcss-wasm');
+  await wasm.default();
+  const npm = await import('lightningcss');
+
+  return [
+    {
+      name: '@gjsify/lightningcss-wasm',
+      transform: ({ input, minify, targetsObj }) =>
+        wasm.transform({
+          filename: 'fixture.css',
+          code: new TextEncoder().encode(input),
+          minify,
+          targets: targetsObj,
+        }).code,
+    },
+    {
+      name: 'npm lightningcss',
+      transform: ({ input, minify, targetsObj }) =>
+        npm.transform({
+          filename: 'fixture.css',
+          code: new TextEncoder().encode(input),
+          minify,
+          targets: targetsObj,
+        }).code,
+    },
+  ];
+}
+
+export default async () => {
+  await on('Gjs', async () => {
+    await describe('lightningcss byte-equality (native vs wasm) — GJS', async () => {
+      const [a, b] = await loadGjsBackends();
+
+      for (const fx of FIXTURES) {
+        await it(`${fx.label}`, async () => {
+          const ao = normalise(a.transform(fx));
+          const bo = normalise(b.transform(fx));
+          expect(ao).toBe(bo);
+        });
+      }
+    });
+  });
+
+  await on('Node.js', async () => {
+    await describe('lightningcss byte-equality (wasm vs npm) — Node', async () => {
+      const [a, b] = await loadNodeBackends();
+
+      for (const fx of FIXTURES) {
+        await it(`${fx.label}`, async () => {
+          const ao = normalise(a.transform(fx));
+          const bo = normalise(b.transform(fx));
+          expect(ao).toBe(bo);
+        });
+      }
+    });
+  });
+};

--- a/tests/integration/lightningcss/src/declarations.d.ts
+++ b/tests/integration/lightningcss/src/declarations.d.ts
@@ -1,0 +1,2 @@
+// Ambient fallback for packages without bundled types in this workspace.
+declare module '@gjsify/lightningcss-wasm';

--- a/tests/integration/lightningcss/src/test.mts
+++ b/tests/integration/lightningcss/src/test.mts
@@ -1,0 +1,16 @@
+// Integration-test entry for @gjsify/integration-lightningcss.
+// Builds once per runtime (gjs/node) via `gjsify build src/test.mts`.
+//
+// Locks in the byte-equality property the Phase D-2 lightningcss
+// decision matrix (`docs/poc/lightningcss-decision.md`) rests on.
+// Each runtime compares the two backends accessible to it and
+// asserts identical output across a fixture corpus that exercises
+// distinct lowering / minification paths.
+
+import '@gjsify/node-globals/register';
+import { run } from '@gjsify/unit';
+import byteEqualitySuite from './byte-equality.spec.js';
+
+run({
+    byteEqualitySuite,
+});

--- a/tests/integration/lightningcss/tsconfig.json
+++ b/tests/integration/lightningcss/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "types": ["@girs/gjs", "node"],
+        "target": "ESNext",
+        "moduleResolution": "NodeNext",
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "files": [
+        "src/test.mts",
+        "src/declarations.d.ts",
+        "src/byte-equality.spec.ts"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,6 +3075,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@gjsify/integration-lightningcss@workspace:tests/integration/lightningcss":
+  version: 0.0.0-use.local
+  resolution: "@gjsify/integration-lightningcss@workspace:tests/integration/lightningcss"
+  dependencies:
+    "@girs/gjs": "npm:4.0.0-rc.15"
+    "@gjsify/cli": "workspace:^"
+    "@gjsify/lightningcss-native": "workspace:^"
+    "@gjsify/lightningcss-wasm": "workspace:^"
+    "@gjsify/node-globals": "workspace:^"
+    "@gjsify/runtime": "workspace:^"
+    "@gjsify/unit": "workspace:^"
+    "@types/node": "npm:^25.6.2"
+    lightningcss: "npm:^1.32.0"
+    typescript: "npm:^6.0.3"
+  languageName: unknown
+  linkType: soft
+
 "@gjsify/integration-mcp-inspector-cli@workspace:tests/integration/mcp-inspector-cli":
   version: 0.0.0-use.local
   resolution: "@gjsify/integration-mcp-inspector-cli@workspace:tests/integration/mcp-inspector-cli"
@@ -3253,7 +3270,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/lightningcss-native@workspace:packages/infra/lightningcss-native":
+"@gjsify/lightningcss-native@workspace:^, @gjsify/lightningcss-native@workspace:packages/infra/lightningcss-native":
   version: 0.0.0-use.local
   resolution: "@gjsify/lightningcss-native@workspace:packages/infra/lightningcss-native"
   dependencies:
@@ -3267,7 +3284,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gjsify/lightningcss-wasm@workspace:packages/infra/lightningcss-wasm":
+"@gjsify/lightningcss-wasm@workspace:^, @gjsify/lightningcss-wasm@workspace:packages/infra/lightningcss-wasm":
   version: 0.0.0-use.local
   resolution: "@gjsify/lightningcss-wasm@workspace:packages/infra/lightningcss-wasm"
   dependencies:


### PR DESCRIPTION
## Summary

Phase D-2 follow-up. Turns the decision-matrix's load-bearing byte-equality property (`docs/poc/lightningcss-decision.md`, #135) into a permanent regression guard.

## Coverage

6 fixtures × 2 backend pairs = **12/12 byte-equality assertions green** (verified locally on Node 24 + GJS 1.88).

| Runtime | Backends compared | Pass |
|---|---|---|
| Node | `@gjsify/lightningcss-wasm` vs npm `lightningcss` | 6/6 |
| GJS | `@gjsify/lightningcss-native` vs `@gjsify/lightningcss-wasm` | 6/6 |

Together those two diffs cover all three backends transitively: native ≡ wasm (GJS) and wasm ≡ npm (Node), so all three must agree.

## Fixtures

Each one exercises a distinct lowering / minification path so a drift in any single transform surfaces as one failing assertion:

- plain selector + property — minified
- redundant longhand collapses under minify (`margin: 0 0 0 0` → `margin:0`)
- nesting flatten for `firefox >= 60` (`& .icon`, `&:hover` → flat selectors)
- `lch()` color lowered for `firefox >= 60`
- pretty-printed (no minify)
- nested `@media` inside selector — flattened for `firefox >= 60`

## Out of scope

Source maps are intentionally NOT part of the contract. `mappings` strings encode source indexes that legitimately differ between backends; code-only equality is what `cssAsStringPlugin` consumers (CSS-as-string default exports) observe.

## Test plan
- [x] Local: 6/6 Node + 6/6 GJS green
- [x] `yarn check` passes
- [x] STATUS.md + CHANGELOG.md updated
- [ ] CI passes (Fedora 43/44)
- [ ] Wired into `yarn test:integration` aggregator (already done — picked up via the `tests/integration/*` workspace glob)