### PR TITLE
ci(prebuilds): mark workspace as safe before refs/rolldown submodule init

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -207,7 +207,14 @@ jobs:
       # cold cargo build is ~5 min CPU on x86_64. Submodule init alone
       # downloads several hundred MB.
       - name: Init refs/rolldown submodule (rolldown-native source dep)
-        run: git submodule update --init --recursive refs/rolldown
+        # GitHub-Actions Fedora containers run as root while the
+        # repo is bind-mounted as a different uid → git refuses with
+        # "dubious ownership" unless the dir is whitelisted. Mirror
+        # the same `safe.directory` workaround the other Fedora
+        # workflows use before invoking submodule update.
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git submodule update --init --recursive refs/rolldown
 
       - name: Build @gjsify/rolldown-native (Rust cdylib + Vala bridge)
         working-directory: packages/infra/rolldown-native


### PR DESCRIPTION
## Summary

The \`Build Native Prebuilds\` workflow has been failing on every rolldown-native push since the job was added (PRs #138, #140, #141) with:

\`\`\`
fatal: detected dubious ownership in repository at '/__w/gjsify/gjsify'
\`\`\`

GitHub-Actions Fedora containers run as root while the repo is bind-mounted as a different uid → git refuses to operate on it unless the directory is whitelisted via \`safe.directory\`.

This adds the same workaround the other Fedora workflows already use, immediately before \`git submodule update --init --recursive refs/rolldown\`.

## Test plan

- [x] Single-line YAML change, gated to the existing rolldown-native step
- [ ] CI green on this PR will confirm the fix