### PR TITLE
ci(prebuilds): install json-glib-devel for rolldown-native build

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -63,6 +63,7 @@ jobs:
           gstreamer1-plugins-bad-free-devel
           libsoup3-devel
           libnghttp2-devel
+          json-glib-devel
 
       - name: Install Rust toolchain (rustup, stable)
         # Fedora 43's `dnf install cargo` ships rustc ~1.79 — too old for
@@ -308,7 +309,8 @@ jobs:
                 gstreamer1-plugins-base-devel \
                 gstreamer1-plugins-bad-free-devel \
                 libsoup3-devel \
-                libnghttp2-devel
+                libnghttp2-devel \
+                json-glib-devel
             else
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -321,7 +323,8 @@ jobs:
                 libgstreamer-plugins-base1.0-dev \
                 libgstreamer-plugins-bad1.0-dev \
                 libsoup-3.0-dev \
-                libnghttp2-dev
+                libnghttp2-dev \
+                libjson-glib-dev
             fi
 
           run: |


### PR DESCRIPTION
## Summary

Follow-up to the workspace-safe-directory fix in #149. The next failure surfaced once the submodule init was unblocked:

\`\`\`
Run-time dependency json-glib-1.0 found: NO (tried pkgconfig)
meson.build:21:4: ERROR: Dependency "json-glib-1.0" not found
\`\`\`

\`@gjsify/rolldown-native\`'s Vala bridge added a \`json-glib-1.0\` dependency in Phase B.1 (the plugin_proxy uses json-glib to peek at the request envelope's hook/reqId/pluginIndex on the way to the GObject signal). The CI containers were missing the package.

This PR adds \`json-glib-devel\` (Fedora) and \`libjson-glib-dev\` (Debian/Ubuntu QEMU runners) to both the native and emulated install steps.

## Test plan

- [x] One-line addition to existing dnf/apt-get install lists
- [ ] CI green on this PR confirms the fix