### PR TITLE
test(cli): toNativePlugin adapter regression coverage (B.5b follow-up)

### DIFF
--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -10,11 +10,14 @@
         "gjsify": "./lib/index.js"
     },
     "scripts": {
-        "clear": "rm -rf lib tsconfig.tsbuildinfo || exit 0",
+        "clear": "rm -rf lib dist tsconfig.tsbuildinfo || exit 0",
         "check": "tsc --noEmit",
         "start": "node lib/index.js",
         "build": "tsc && yarn chmod",
-        "chmod": "chmod +x ./lib/index.js"
+        "chmod": "chmod +x ./lib/index.js",
+        "build:test:node": "node lib/index.js build src/test.mts --app node --outfile dist/test.node.mjs",
+        "test:node": "node dist/test.node.mjs",
+        "test": "yarn build:test:node && yarn test:node"
     },
     "keywords": [
         "gjs",
@@ -39,6 +42,7 @@
         "yargs": "^18.0.0"
     },
     "devDependencies": {
+        "@gjsify/unit": "workspace:^",
         "@types/yargs": "^17.0.35",
         "typescript": "^6.0.3"
     },

--- a/packages/infra/cli/src/bundler-pick.spec.ts
+++ b/packages/infra/cli/src/bundler-pick.spec.ts
@@ -1,0 +1,203 @@
+// Phase D-2.B.5b — toNativePlugin adapter regression coverage.
+//
+// The native bundler itself only loads under GJS (it needs the
+// GjsifyRolldown typelib via `imports.gi`), so a real
+// `GJSIFY_BUNDLER=native` build of a Node-CLI invocation is
+// unreachable by design. The thing we CAN cover from Node is the
+// shape adapter — given a rolldown-shaped plugin, does it produce
+// the right NativePlugin envelope (function references intact, bare
+// vs. `{filter, handler}` form normalized, idFilter regex strings
+// matching the original RegExp source)?
+//
+// These tests prevent the adapter from silently dropping hooks /
+// mis-translating filters when real-world plugin shapes change.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { toNativePlugin, isPluginObject, type NativePlugin } from './bundler-pick.js';
+import {
+    cssAsStringPlugin,
+    shebangPlugin,
+    gjsImportsEmptyPlugin,
+    processStubPlugin,
+    textLoaderPlugin,
+} from '@gjsify/rolldown-plugin-gjsify';
+
+export default async () => {
+    await describe('isPluginObject', async () => {
+        await it('accepts plain plugin objects', () => {
+            expect(isPluginObject({ name: 'p', load: () => null })).toBe(true);
+        });
+        await it('rejects null / undefined / primitives / arrays', () => {
+            expect(isPluginObject(null)).toBe(false);
+            expect(isPluginObject(undefined)).toBe(false);
+            expect(isPluginObject('p')).toBe(false);
+            expect(isPluginObject(42)).toBe(false);
+            expect(isPluginObject([{ name: 'p' }])).toBe(false);
+        });
+    });
+
+    await describe('toNativePlugin — bare-function hook form', async () => {
+        await it('preserves function reference identity for each hook', () => {
+            const load = () => 'loaded';
+            const transform = (code: string) => code;
+            const resolveId = (s: string) => s;
+            const renderChunk = (c: string) => c;
+            const buildStart = () => {};
+            const native = toNativePlugin({ name: 'b', load, transform, resolveId, renderChunk, buildStart });
+            expect(native.load === (load as unknown as NativePlugin['load'])).toBe(true);
+            expect(native.transform === (transform as unknown as NativePlugin['transform'])).toBe(true);
+            expect(native.resolveId === (resolveId as unknown as NativePlugin['resolveId'])).toBe(true);
+            expect(native.renderChunk === (renderChunk as unknown as NativePlugin['renderChunk'])).toBe(true);
+            expect(native.buildStart === (buildStart as unknown as NativePlugin['buildStart'])).toBe(true);
+        });
+
+        await it('falls back to "unnamed-plugin" when name is missing', () => {
+            const native = toNativePlugin({ load: () => null });
+            expect(native.name).toBe('unnamed-plugin');
+        });
+
+        await it('omits hooks that are not functions', () => {
+            const native = toNativePlugin({ name: 'p', load: 'not a function', transform: undefined, resolveId: 42 } as Record<string, unknown>);
+            expect(native.load).toBe(undefined);
+            expect(native.transform).toBe(undefined);
+            expect(native.resolveId).toBe(undefined);
+        });
+    });
+
+    await describe('toNativePlugin — {filter, handler} hook form', async () => {
+        await it('extracts handler + converts RegExp filter.id to source string', () => {
+            const handler = () => 'css';
+            const native = toNativePlugin({
+                name: 'css',
+                load: { filter: { id: /\.css$/ }, handler },
+            } as Record<string, unknown>);
+            expect(native.load === (handler as unknown as NativePlugin['load'])).toBe(true);
+            expect(native.idFilter?.load).toBe('\\.css$');
+        });
+
+        await it('escapes string filter.id so regex metas are literal', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                transform: { filter: { id: '.config.js' }, handler: () => null },
+            } as Record<string, unknown>);
+            // Dots in input become escaped in the regex string so the
+            // server-side matcher treats them literally.
+            expect(native.idFilter?.transform).toBe('\\.config\\.js');
+        });
+
+        await it('combines an array of filter.id sources into an alternation', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                load: { filter: { id: [/\.svg$/, /\.png$/] }, handler: () => null },
+            } as Record<string, unknown>);
+            expect(native.idFilter?.load).toBe('(?:\\.svg$|\\.png$)');
+        });
+
+        await it('passes the bare regex through when array has one element', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                load: { filter: { id: [/\.txt$/] }, handler: () => null },
+            } as Record<string, unknown>);
+            expect(native.idFilter?.load).toBe('\\.txt$');
+        });
+
+        await it('emits no idFilter entry for a hook without filter', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                load: { handler: () => null },
+            } as Record<string, unknown>);
+            expect(native.idFilter).toBe(undefined);
+        });
+
+        await it('only puts idFilter on hooks where it was declared', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                load: { filter: { id: /\.txt$/ }, handler: () => null },
+                transform: () => null,
+            } as Record<string, unknown>);
+            expect(native.idFilter?.load).toBe('\\.txt$');
+            expect(native.idFilter?.transform).toBe(undefined);
+            expect(native.idFilter?.resolveId).toBe(undefined);
+        });
+    });
+
+    await describe('toNativePlugin — real-world gjsify plugin set', async () => {
+        // These walks bind the adapter to the actual plugin shapes the
+        // CLI passes to rolldown today. A drift in any plugin's hook
+        // declaration (function vs {filter,handler}, regex change, hook
+        // added/removed) surfaces here as a single failed expectation
+        // rather than as a silent runtime mis-dispatch under GJS.
+
+        await it('cssAsStringPlugin — load hook with .css idFilter', () => {
+            const native = toNativePlugin(cssAsStringPlugin() as unknown as Record<string, unknown>);
+            expect(native.name).toBe('gjsify-css-as-string');
+            expect(typeof native.load).toBe('function');
+            expect(native.idFilter?.load !== undefined).toBe(true);
+            expect(native.idFilter!.load!.includes('css')).toBe(true);
+        });
+
+        await it('shebangPlugin — renderChunk {filter, handler} form', () => {
+            const p = shebangPlugin({ enabled: true });
+            if (p === null) throw new Error('shebangPlugin({enabled:true}) returned null');
+            const native = toNativePlugin(p as unknown as Record<string, unknown>);
+            expect(native.name).toBe('gjsify-shebang');
+            // renderChunk uses the {handler, order:'post'} object form
+            // — adapter must extract `handler` even when no `filter` is set.
+            expect(typeof native.renderChunk).toBe('function');
+            expect(native.idFilter?.renderChunk).toBe(undefined);
+        });
+
+        await it('gjsImportsEmptyPlugin — resolveId + load hooks', () => {
+            const p = gjsImportsEmptyPlugin();
+            const native = toNativePlugin(p as unknown as Record<string, unknown>);
+            expect(typeof native.resolveId).toBe('function');
+            expect(typeof native.load).toBe('function');
+        });
+
+        await it('processStubPlugin — renderChunk hook', () => {
+            const p = processStubPlugin();
+            const native = toNativePlugin(p as unknown as Record<string, unknown>);
+            expect(typeof native.renderChunk).toBe('function');
+        });
+
+        await it('textLoaderPlugin with text loaders — load hook (function form)', () => {
+            const p = textLoaderPlugin({ loaders: { '.ui': 'text', '.asm': 'text' } });
+            if (p === null) throw new Error('textLoaderPlugin({loaders:{...}}) returned null');
+            const native = toNativePlugin(p as unknown as Record<string, unknown>);
+            // text-loader uses bare `load(id)` — function form with internal
+            // regex check, not {filter, handler}. So no idFilter on the
+            // adapter side either.
+            expect(typeof native.load).toBe('function');
+        });
+    });
+
+    await describe('toNativePlugin — full hook coverage', async () => {
+        await it('covers all 13 advertised hook names', () => {
+            const stub = () => null;
+            const native = toNativePlugin({
+                name: 'all',
+                load: stub, transform: stub, resolveId: stub, renderChunk: stub,
+                banner: stub, footer: stub, intro: stub, outro: stub,
+                buildStart: stub, buildEnd: stub,
+                generateBundle: stub, writeBundle: stub, closeBundle: stub,
+            });
+            for (const h of ['load', 'transform', 'resolveId', 'renderChunk',
+                             'banner', 'footer', 'intro', 'outro',
+                             'buildStart', 'buildEnd',
+                             'generateBundle', 'writeBundle', 'closeBundle'] as const) {
+                expect(typeof native[h]).toBe('function');
+            }
+        });
+
+        await it('drops unknown extra fields silently (rolldown-only options not in our facade)', () => {
+            const native = toNativePlugin({
+                name: 'p',
+                load: () => null,
+                api: { customField: 'value' },
+                resolveDynamicImport: () => null,
+            } as Record<string, unknown>);
+            expect((native as unknown as Record<string, unknown>).api).toBe(undefined);
+            expect((native as unknown as Record<string, unknown>).resolveDynamicImport).toBe(undefined);
+        });
+    });
+};

--- a/packages/infra/cli/src/bundler-pick.ts
+++ b/packages/infra/cli/src/bundler-pick.ts
@@ -41,13 +41,13 @@ interface NativeRolldownSurface {
     bundleWithPlugins(opts: unknown, plugins: NativePlugin[]): Promise<BundleResult>;
 }
 
-interface NativePluginContext {
+export interface NativePluginContext {
     resolve(specifier: string, importer?: string, opts?: { skipSelf?: boolean; isEntry?: boolean }): Promise<{ id: string; external: boolean } | null>;
     warn(message: string): void;
     error(message: string): never;
 }
 
-interface NativePlugin {
+export interface NativePlugin {
     name: string;
     idFilter?: { load?: string; transform?: string; resolveId?: string };
     load?: (this: NativePluginContext, id: string) => unknown;
@@ -153,9 +153,9 @@ async function runNativeBundle(finalOpts: BundlerOptions): Promise<RolldownOutpu
     return synthRolldownOutput(result);
 }
 
-type PluginRecord = { name?: string; [k: string]: unknown };
+export type PluginRecord = { name?: string; [k: string]: unknown };
 
-function isPluginObject(p: unknown): p is PluginRecord {
+export function isPluginObject(p: unknown): p is PluginRecord {
     return p !== null && typeof p === 'object' && !Array.isArray(p);
 }
 
@@ -196,7 +196,7 @@ function oneToSource(f: RegExp | string): string | undefined {
     return undefined;
 }
 
-function toNativePlugin(p: PluginRecord): NativePlugin {
+export function toNativePlugin(p: PluginRecord): NativePlugin {
     const name = typeof p.name === 'string' ? p.name : 'unnamed-plugin';
     const out: NativePlugin = { name };
     const idFilter: { load?: string; transform?: string; resolveId?: string } = {};

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -1,0 +1,10 @@
+// Node-side test entry for @gjsify/cli.
+// Built once via `gjsify build src/test.mts --app node --outfile dist/test.node.mjs`,
+// run via `node dist/test.node.mjs`.
+
+import { run } from '@gjsify/unit';
+import bundlerPickSuite from './bundler-pick.spec.js';
+
+run({
+    bundlerPickSuite,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,6 +1520,7 @@ __metadata:
     "@gjsify/rolldown-plugin-pnp": "workspace:^"
     "@gjsify/semver": "workspace:^"
     "@gjsify/tar": "workspace:^"
+    "@gjsify/unit": "workspace:^"
     "@gjsify/web-polyfills": "workspace:^"
     "@types/yargs": "npm:^17.0.35"
     cosmiconfig: "npm:^9.0.1"


### PR DESCRIPTION
## Summary

Follow-up to PR #150 (B.5b CLI wire-up). Adds Node-side test coverage for the \`toNativePlugin\` shape adapter that translates rolldown plugins into the \`NativePlugin\` shape \`bundleWithPlugins()\` consumes.

The native bundler itself only loads under GJS (needs the GjsifyRolldown typelib via \`imports.gi\`), so a real \`GJSIFY_BUNDLER=native\` build from a Node-CLI invocation is unreachable by design. What we CAN cover from Node is the shape adapter — given a rolldown-shaped plugin, does it produce the right \`NativePlugin\` envelope?

- 16 specs / 50 assertions, all green under Node
- New \`@gjsify/cli\` test infrastructure: \`src/test.mts\` entry, \`build:test:node\` + \`test:node\` + \`test\` scripts, \`@gjsify/unit\` devDep
- Real-world coverage exercising the actual gjsify plugin shapes: \`cssAsStringPlugin\` (\`.css\` idFilter), \`shebangPlugin\` (\`{filter,handler}\` renderChunk), \`gjsImportsEmptyPlugin\` (resolveId+load), \`processStubPlugin\` (renderChunk), \`textLoaderPlugin\` (function form)
- Exports \`toNativePlugin\` / \`isPluginObject\` / \`NativePlugin\` / \`NativePluginContext\` / \`PluginRecord\` from \`bundler-pick.ts\`

This is the largest part of B.5b that's actually testable without standing up the full self-host loop. The end-to-end \`gjsify build\` invocation against a real showcase under \`GJSIFY_BUNDLER=native\` requires the CLI itself to run under GJS — tracked separately in STATUS.md "Open TODOs".

## Test plan

- [x] \`yarn check\` passes
- [x] \`yarn build\` passes
- [x] \`yarn workspace @gjsify/cli test\` — 16 specs / 50 assertions pass under Node