### PR TITLE
feat(cli): Phase D-3.1 — bundler-pick defaults to native under GJS

### DIFF
--- a/packages/infra/cli/src/bundler-pick.spec.ts
+++ b/packages/infra/cli/src/bundler-pick.spec.ts
@@ -13,7 +13,7 @@
 // mis-translating filters when real-world plugin shapes change.
 
 import { describe, expect, it } from '@gjsify/unit';
-import { toNativePlugin, isPluginObject, type NativePlugin } from './bundler-pick.js';
+import { toNativePlugin, isPluginObject, shouldUseNative, type NativePlugin } from './bundler-pick.js';
 import {
     cssAsStringPlugin,
     shebangPlugin,
@@ -198,6 +198,58 @@ export default async () => {
             } as Record<string, unknown>);
             expect((native as unknown as Record<string, unknown>).api).toBe(undefined);
             expect((native as unknown as Record<string, unknown>).resolveDynamicImport).toBe(undefined);
+        });
+    });
+
+    await describe('shouldUseNative — Phase D-3.1 runtime default', async () => {
+        // The Node-side test sees:
+        //   - process.env.GJSIFY_BUNDLER respected (env-var overrides)
+        //   - globalThis.imports?.gi UNDEFINED (we're under Node) → default returns false
+        // We mutate process.env around each assertion; restore on exit so the
+        // suite stays hermetic with the rest of the file.
+
+        await it('GJSIFY_BUNDLER=npm forces npm path even when native is loadable', async () => {
+            const prev = process.env.GJSIFY_BUNDLER;
+            process.env.GJSIFY_BUNDLER = 'npm';
+            try {
+                const result = await shouldUseNative();
+                expect(result).toBe(false);
+            } finally {
+                if (prev === undefined) delete process.env.GJSIFY_BUNDLER;
+                else process.env.GJSIFY_BUNDLER = prev;
+            }
+        });
+
+        await it('GJSIFY_BUNDLER=native throws under Node when prebuild not loadable', async () => {
+            const prev = process.env.GJSIFY_BUNDLER;
+            process.env.GJSIFY_BUNDLER = 'native';
+            try {
+                let thrown: Error | null = null;
+                try {
+                    await shouldUseNative();
+                } catch (e) {
+                    thrown = e as Error;
+                }
+                expect(thrown !== null).toBe(true);
+                expect((thrown as Error).message.includes('not loadable')).toBe(true);
+            } finally {
+                if (prev === undefined) delete process.env.GJSIFY_BUNDLER;
+                else process.env.GJSIFY_BUNDLER = prev;
+            }
+        });
+
+        await it('default under Node = false (no imports.gi, npm rolldown wins)', async () => {
+            const prev = process.env.GJSIFY_BUNDLER;
+            delete process.env.GJSIFY_BUNDLER;
+            try {
+                // Under Node test runner, globalThis.imports?.gi is undefined,
+                // so the new D-3.1 runtime-detect logic correctly returns false
+                // and the npm rolldown path is taken in runBundle.
+                const result = await shouldUseNative();
+                expect(result).toBe(false);
+            } finally {
+                if (prev !== undefined) process.env.GJSIFY_BUNDLER = prev;
+            }
         });
     });
 };

--- a/packages/infra/cli/src/bundler-pick.ts
+++ b/packages/infra/cli/src/bundler-pick.ts
@@ -83,16 +83,29 @@ export async function runBundle(finalOpts: BundlerOptions): Promise<RolldownOutp
 
 let _nativeProbe: Promise<NativeRolldownSurface | null> | null = null;
 
-async function shouldUseNative(): Promise<boolean> {
+export async function shouldUseNative(): Promise<boolean> {
     const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
     const choice = env.GJSIFY_BUNDLER;
+
+    // Explicit env-var override always wins.
     if (choice === 'npm') return false;
-    if (choice !== 'native') return false; // default = npm; native is opt-in
-    const native = await tryLoadNative();
-    if (!native) {
-        throw new Error('GJSIFY_BUNDLER=native but @gjsify/rolldown-native is not loadable (no prebuild for this architecture, or not running under GJS).');
+    if (choice === 'native') {
+        const native = await tryLoadNative();
+        if (!native) {
+            throw new Error('GJSIFY_BUNDLER=native but @gjsify/rolldown-native is not loadable (no prebuild for this architecture, or not running under GJS).');
+        }
+        return true;
     }
-    return true;
+
+    // Phase D-3.1 — runtime-aware default.
+    //   Node:    use npm rolldown (no FFI loading cost at install time).
+    //   GJS:     try @gjsify/rolldown-native — it's the only engine
+    //            that can actually run here (npm rolldown is a Rust
+    //            crate). Fall back to npm only on Node.
+    const isGjs = typeof (globalThis as { imports?: { gi?: unknown } }).imports?.gi !== 'undefined';
+    if (!isGjs) return false;
+    const native = await tryLoadNative();
+    return native !== null;
 }
 
 async function tryLoadNative(): Promise<NativeRolldownSurface | null> {


### PR DESCRIPTION
## Summary

Prep step for self-hosting (Phase D-3). When \`@gjsify/cli\` runs UNDER GJS (e.g. the GJS-bundled CLI from D-3.2+), npm rolldown isn't loadable (it's a Rust crate). Today the CLI requires \`GJSIFY_BUNDLER=native\` explicitly to use \`@gjsify/rolldown-native\`; under GJS that's the only viable engine, so make it the runtime-detected default.

### Behavior matrix

| \`process.env.GJSIFY_BUNDLER\` | Under Node | Under GJS |
|---|---|---|
| unset (default) | npm (unchanged) | **native** (new) |
| \`'npm'\` | npm | npm (forced) |
| \`'native'\` | throws if not loadable | native |

Detection via \`globalThis.imports?.gi\` — same probe already used in \`tryLoadNative()\`. **Node-side npm consumers see zero behavior change.** Under GJS the CLI now uses \`@gjsify/rolldown-native\` without the user having to remember an env-var flag.

## Test plan

- [x] \`yarn check\` passes
- [x] \`yarn workspace @gjsify/cli test\` — **19 specs / 54 assertions** (up from 16/50), all green under Node
- [x] Three new spec blocks under \`shouldUseNative — Phase D-3.1 runtime default\`:
  - GJSIFY_BUNDLER=npm forces npm path
  - GJSIFY_BUNDLER=native throws under Node when prebuild not loadable (existing behavior preserved)
  - default under Node returns false (no imports.gi → npm wins)

## Roadmap context

This is the first PR in Phase D-3 (self-host loop):
- D-3.1: bundler-pick defaults — **this PR**
- D-3.2: Bootstrap CLI build for GJS (\`gjsify build packages/infra/cli/src/index.ts --app gjs\`)
- D-3.3: GJS-CLI bundles a simple ESM project
- D-3.4: GJS-CLI bundles a real fixture (yargs integration tests)
- D-3.5: Byte-equivalence diff GJS-CLI vs Node-CLI
- D-3.6: Permanent \`tests/e2e/self-host/\` suite + STATUS.md update

Plan: \`.claude/plans/erstelle-einen-umsetzungsplan-f-r-fluttering-barto.md\`