### PR TITLE
fix(monorepo): add @gjsify/cli to root devDependencies (CI fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "MIT",
   "devDependencies": {
+    "@gjsify/cli": "workspace:^",
     "@release-it/bumper": "^7.0.5",
     "@release-it/conventional-changelog": "^11.0.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10957,6 +10957,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "gjsify@workspace:."
   dependencies:
+    "@gjsify/cli": "workspace:^"
     "@release-it/bumper": "npm:^7.0.5"
     "@release-it/conventional-changelog": "npm:^11.0.0"
     conventional-changelog-conventionalcommits: "npm:^9.3.1"


### PR DESCRIPTION
## Summary

CI on main has been red since #168 (D.7a) with `command not found: gjsify`. Root cause identified via `yarn exec which gjsify` from the repo root:

**Yarn 4 only creates bin shims for packages declared as dependencies of the workspace whose scripts are running.** The root `package.json` never declared `@gjsify/cli`, so when `yarn run build` etc. fire root-level scripts that call `gjsify foreach …`, no `gjsify` shim is on PATH. The previous "build:infra builds the CLI first, then `node_modules/.bin/gjsify` becomes resolvable" mental model was wrong — yarn 4 builds a per-invocation virtual bin dir under `/tmp/xfs-<hash>/` and only includes shims for declared deps of the active workspace. `lib/index.js` existing doesn't help if no shim points at it.

## Fix

Declare `@gjsify/cli` as a workspace `devDependency` at the root.

## Verification

```
$ yarn exec which gjsify
/tmp/xfs-a71981e2/gjsify

$ yarn exec gjsify --version
0.3.21
```

Both from the repo root, post-`yarn install`.

This unblocks the D.7a + D.7b.1 work that's been red on main since those PRs landed.