### PR TITLE
chore(release): rebuild CLI + GJS bundle in after:bump hook

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -15,7 +15,7 @@
     "publish": false
   },
   "hooks": {
-    "after:bump": "node scripts/bump-docs-version.mjs ${latestVersion} ${version}"
+    "after:bump": "node scripts/bump-docs-version.mjs ${latestVersion} ${version} && yarn workspace @gjsify/cli run build && yarn workspace @gjsify/cli run build:gjs-bundle && git add packages/infra/cli/dist/cli.gjs.mjs"
   },
   "plugins": {
     "@release-it/bumper": {


### PR DESCRIPTION
## Summary

`packages/infra/cli/dist/cli.gjs.mjs` embeds yargs's read of `package.json#version` at build time. When release-it bumps the version, the existing bundle still reports the OLD version under `gjs -m cli.gjs.mjs --version` — wrong for end-users who pull the published bundle.

Hook now does: bump docs → rebuild CLI (`tsc`) → rebuild GJS bundle → `git add` the bundle so release-it stages it for the release commit.

Without this, the published tarball + GitHub release artefacts would ship a bundle pinned to the previous version.

## Test plan

Validated mechanically (string change to the hook). Real validation happens at the next release run.