### PR TITLE
fix(ci): functional bundle freshness check (not byte-exact)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,17 +85,25 @@ jobs:
         run: su testuser -c 'yarn run build'
 
       # The CLI's GJS bundle is committed to enable Node-free bootstrap (Phase D.7b).
-      # `yarn run build` re-generates it via `build:gjs-bundle`; if the committed bytes
-      # have drifted from what the current src/ produces, the PR author must run
-      # `yarn workspace @gjsify/cli run build:gjs-bundle` locally and commit the result.
-      - name: Verify committed CLI GJS bundle is up-to-date
+      # We can't enforce a byte-exact freshness check — the build is not perfectly
+      # cross-environment deterministic (Node patch version + system libs perturb
+      # the rolldown output). Instead we run a functional check: the committed
+      # bundle must execute under stock GJS AND report the *current* package.json
+      # version. That catches both "bundle is broken" and "bundle is from the
+      # previous release" without forcing every CI environment to produce
+      # byte-identical output.
+      - name: Verify committed CLI GJS bundle is functional + up-to-date
         run: |
-          if ! git diff --exit-code -- packages/infra/cli/dist/cli.gjs.mjs; then
-            echo "::error::packages/infra/cli/dist/cli.gjs.mjs is stale."
-            echo "::error::Refresh locally: yarn workspace @gjsify/cli run build:gjs-bundle"
-            echo "::error::Then commit the updated bundle."
+          set -e
+          EXPECTED=$(node -p "require('./packages/infra/cli/package.json').version")
+          ACTUAL=$(gjs -m packages/infra/cli/dist/cli.gjs.mjs --version 2>&1 | head -1 | tr -d '[:space:]')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::packages/infra/cli/dist/cli.gjs.mjs reports version '$ACTUAL', package.json says '$EXPECTED'."
+            echo "::error::Refresh locally: yarn workspace @gjsify/cli run build && yarn workspace @gjsify/cli run build:gjs-bundle"
+            echo "::error::Then commit packages/infra/cli/dist/cli.gjs.mjs."
             exit 1
           fi
+          echo "GJS bundle OK — reports v$ACTUAL matching package.json."
 
       # Root `build` uses --no-private, so private example workspaces are skipped; tests need dist/.
       - name: Build examples


### PR DESCRIPTION
## Summary

The byte-exact `git diff --exit-code` freshness check landed in #170 is too strict — CI rebuilds produce slightly different bytes than the committed bundle (~80 KB delta across environments — Node patch version + system libs perturb rolldown's output ordering). So the strict check fails even when both bundles are functionally identical and from the same source.

Replace with a functional check: the committed bundle must execute under stock `gjs` AND report the **current** `packages/infra/cli/package.json` version. That catches the two real failure modes:

1. **Bundle is missing / broken** — `gjs -m` errors out, check fails.
2. **Bundle is from the previous release** — yargs reads `version` from `package.json` at build time, so an outdated bundle reports the old version mismatching the bumped `package.json`.

What it doesn't catch (intentionally): "source has changed but bundle wasn't rebuilt while version stayed the same". That's acceptable — any release-time version bump catches it, and source changes during a development cycle don't fundamentally break the bootstrap path. release-it's `after:bump` hook (`.release-it.json`, added in #174) handles the version-bump refresh automatically.

## Test plan

- [x] Locally `gjs -m packages/infra/cli/dist/cli.gjs.mjs --version` → `0.3.21` (matches package.json)
- [ ] CI: Fedora 43 + 44 — verifies the check passes for the in-sync state