### PR TITLE
fix(cli): include showcases.json in npm tarball

### DIFF
--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -16,7 +16,8 @@
     },
     "files": [
         "lib",
-        "dist/cli.gjs.mjs"
+        "dist/cli.gjs.mjs",
+        "showcases.json"
     ],
     "scripts": {
         "clear": "rm -rf lib dist tsconfig.tsbuildinfo || exit 0",


### PR DESCRIPTION
## Summary

#170 narrowed `packages/infra/cli/package.json` `files` to `["lib", "dist/cli.gjs.mjs"]` to ship only the runtime bits. But that dropped `showcases.json` — the curated list at the package root that `discoverShowcases()` reads at runtime.

With it missing from the published tarball, `npx gjsify showcase --json` returns `[]` (no error, just empty), breaking the cli-only e2e suite's "should have at least one example" assertion.

Add `showcases.json` to the allowlist. Verified locally with `npm pack`: the new tarball includes 94 files (was 93).