### PR TITLE
fix(ci): release.yml needs contents:write to upload GH release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,11 @@ jobs:
     container:
       image: fedora:43
     permissions:
-      contents: read
+      # contents: write so softprops/action-gh-release can upload install.mjs
+      # + cli.gjs.mjs + .sha256 as assets onto the release record that
+      # triggered this workflow. id-token: write keeps OIDC provenance
+      # available for future signed-publish work.
+      contents: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

Phase F's release-asset upload step (softprops/action-gh-release@v2 for `install.mjs` + `cli.gjs.mjs` + `.sha256`) needs to PATCH the release record to attach assets. The previous `contents: read` permission only let it fetch — npm publish completed but the asset upload step failed with `HttpError: Resource not accessible by integration` on v0.4.10.

## Background

Assets for v0.4.10 were uploaded manually with `gh release upload` so the Node-free install flow works today against `https://github.com/gjsify/gjsify/releases/download/v0.4.10/install.mjs`. This PR prevents the same manual step on the next release.

## Test plan

- [x] verified manual upload worked: `curl -fsSL https://github.com/gjsify/gjsify/releases/download/v0.4.10/install.mjs` → 200, 9791 bytes
- [x] end-to-end Phase F bootstrap against v0.4.10 assets: installed `@gjsify/cli@0.4.10` under `~/.local/share/gjsify/global/`, launcher works
- [ ] next release after merge auto-uploads assets without manual intervention