### PR TITLE
docs(website): Phase F guides — install + distribute GJS apps

### DIFF
--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -446,3 +446,51 @@ Requires `msgfmt` (package: `gettext`).
 See it in action: [`adwaita-package-builder` showcase](https://github.com/gjsify/gjsify/tree/main/showcases/dom/adwaita-package-builder) uses both `--format mo` (runtime `.mo` tree) and `--format xml --metainfo` (AppStream substitution).
 
 Before running, `gjsify showcase` calls `gjsify check` to verify system dependencies.
+
+## `gjsify self-update`
+
+Refresh the installed `@gjsify/cli` to the latest release (or a pinned dist-tag).
+
+```bash
+gjsify self-update              # install latest
+gjsify self-update --check      # diff only, exit 1 if outdated
+gjsify self-update --force      # reinstall identical version
+gjsify self-update --tag next   # install a specific dist-tag (or version)
+```
+
+Walks `import.meta.url` to find the CLI's own `package.json`, fetches the matching `dist-tag` via `@gjsify/npm-registry`, then re-uses the install backend that powers `gjsify install -g` (handles transitive native prebuilds, lockfile, bin shims).
+
+Only works for CLIs installed under `~/.local/share/gjsify/global/` (the `install.mjs` bootstrap or `gjsify install -g`). Installs from `npm install -g` land outside that prefix; `self-update` surfaces a warning pointing at the new bootstrap.
+
+| Option | Default | Description |
+|---|---|---|
+| `--check` | `false` | Compare current vs target without installing. Exit 0 if up-to-date, 1 if outdated. |
+| `--force` | `false` | Reinstall even when target matches current. |
+| `--tag` | `latest` | npm dist-tag or pinned version. |
+
+## `gjsify generate-installer`
+
+Scaffold an `install.mjs` for your own GJS-runnable npm package — your users get the same `curl ... | gjs -m -` install story as gjsify itself.
+
+```bash
+cd my-gjs-app
+gjsify generate-installer
+# → install.mjs written. Commit it.
+
+# Optional flags:
+gjsify generate-installer \
+  --target @my-org/my-app \
+  --bin-name my-app \
+  --bootstrap-url https://example.com/cli.gjs.mjs \
+  --output bin/install.mjs --force
+```
+
+The generated `install.mjs` is a verbatim copy of gjsify's own root `install.mjs` with three constants substituted (`DEFAULT_TARGET`, `DEFAULT_BIN_NAME`, `DEFAULT_BOOTSTRAP_URL`). See the [Distributing GJS apps guide](/guides/distributing-gjs-apps/) for the full publication workflow.
+
+| Option | Default | Description |
+|---|---|---|
+| `[target]` (positional) | `package.json#name` | npm package to install. |
+| `--bin-name <name>` | first key of `gjsify.bin` or `bin` | Bin name produced by the installer. |
+| `--bootstrap-url <url>` | gjsify GH `releases/latest/download/cli.gjs.mjs` | Override the bootstrap bundle source. |
+| `--output <file>` | `install.mjs` | Where to write the installer. |
+| `--force` | `false` | Overwrite an existing file. |

--- a/website/src/content/docs/guides/distributing-gjs-apps.md
+++ b/website/src/content/docs/guides/distributing-gjs-apps.md
@@ -1,0 +1,102 @@
+---
+title: Distribute your GJS app
+description: Ship a one-line installer for your gjsify-based npm package.
+---
+
+The same Node-free bootstrap that installs `@gjsify/cli` also installs
+**any GJS-runnable package on npm** — including yours.
+
+## Generate an installer for your package
+
+From the root of your gjsify app:
+
+```bash
+gjsify generate-installer
+```
+
+This writes `install.mjs` to the current directory, with three constants
+substituted for your package: the npm name (from `package.json#name`),
+the bin name (the first key of `gjsify.bin` or `bin`), and the gjsify
+bootstrap URL (defaults to
+`https://github.com/gjsify/gjsify/releases/latest/download/cli.gjs.mjs`).
+
+Commit the generated `install.mjs`:
+
+```bash
+git add install.mjs && git commit -m "chore: add gjsify-based installer"
+git push
+```
+
+Your README's install instructions become:
+
+```bash
+curl -fsSL https://github.com/<you>/<repo>/raw/main/install.mjs \
+  -o /tmp/i.mjs && gjs -m /tmp/i.mjs && rm /tmp/i.mjs
+```
+
+## What it does for your users
+
+1. Downloads the pinned `cli.gjs.mjs` bootstrap bundle from the gjsify
+   GitHub release, verifies SHA-256.
+2. Spawns `gjs -m <bundle> install -g <your-package>` — `@gjsify/cli`'s
+   install backend resolves your package's transitive dependencies
+   (including any native prebuilds), writes them under
+   `~/.local/share/gjsify/global/`, and creates the
+   `~/.local/bin/<your-bin>` launcher.
+
+No Node, no npm, no yarn on the user's machine. Just `gjs ≥ 1.86`
+(included with Fedora 43+, Debian 13+, Arch) and `curl`.
+
+## Customise
+
+```bash
+gjsify generate-installer \
+  --target @my-org/my-app \
+  --bin-name my-app \
+  --bootstrap-url https://example.com/cli.gjs.mjs \
+  --output bin/install.mjs
+```
+
+| Flag | Default |
+|---|---|
+| `[target]` (positional) | `package.json#name` |
+| `--bin-name <name>` | first key of `gjsify.bin` or `bin` |
+| `--bootstrap-url <url>` | gjsify GitHub `releases/latest/download/cli.gjs.mjs` |
+| `--output <file>` | `install.mjs` (in cwd) |
+| `--force` | overwrite existing |
+
+For airgapped environments or forks, host your own bootstrap bundle and
+point `--bootstrap-url` at it. The generated `install.mjs` honors a
+`GJSIFY_INSTALL_BOOTSTRAP_URL` env var at runtime so users can override
+it without editing the script.
+
+## Requirements for your package
+
+Your published package needs:
+
+- `gjsify.bin` (or `bin`) in `package.json` pointing at the GJS entry
+  bundle:
+
+  ```json
+  {
+    "gjsify": { "bin": { "my-app": "./dist/my-app.gjs.mjs" } }
+  }
+  ```
+
+- The bundle built with `gjsify build … --app gjs --shebang` so the
+  installed launcher works correctly. (The launcher will wrap with
+  `exec gjs -m '<bundle>'` for any `.mjs` target, so the shebang is
+  optional — but recommended.)
+
+- Any native prebuilds (`.so` + `.typelib`) declared as runtime
+  dependencies of packages that contain a `gjsify.prebuilds` field.
+  `@gjsify/cli`'s install backend walks those automatically and sets
+  `LD_LIBRARY_PATH` / `GI_TYPELIB_PATH` for the bin launcher.
+
+## Reference implementations
+
+- [`@gjsify/cli`](https://github.com/gjsify/gjsify/tree/main/packages/infra/cli)
+  itself — the canonical example. Its root `install.mjs` is the
+  template `gjsify generate-installer` writes.
+- [`@ts-for-gir/cli`](https://github.com/gjsify/ts-for-gir) — multi-bin
+  GJS app distributed via the same bootstrap.

--- a/website/src/content/docs/guides/install.md
+++ b/website/src/content/docs/guides/install.md
@@ -1,0 +1,88 @@
+---
+title: Install gjsify
+description: Bootstrap @gjsify/cli on any GNOME machine — no Node, no npm.
+---
+
+## Recommended: Node-free bootstrap (gjs ≥ 1.86)
+
+```bash
+curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs \
+  -o /tmp/g.mjs && gjs -m /tmp/g.mjs && rm /tmp/g.mjs
+```
+
+The `install.mjs` script is a tiny stock-GJS bootstrap (~250 LoC, only
+GLib / Gio / Soup 3) that:
+
+1. Downloads the pinned `cli.gjs.mjs` bundle from the GitHub release.
+2. Verifies its SHA-256 against a sidecar `.sha256` asset.
+3. Caches it under `$XDG_CACHE_HOME/gjsify/bootstrap/`.
+4. Spawns `gjs -m <bundle> install -g @gjsify/cli` — the full CLI then
+   handles transitive dependency resolution, native prebuilds, lockfile,
+   and the `~/.local/bin/gjsify` launcher.
+
+After install:
+
+- The CLI tree lives under `~/.local/share/gjsify/global/node_modules/`.
+- A POSIX `sh` launcher is written to `~/.local/bin/gjsify`. Add that
+  directory to your `PATH` if it isn't already:
+
+  ```bash
+  export PATH="$HOME/.local/bin:$PATH"
+  ```
+
+### Refresh in place
+
+```bash
+gjsify self-update         # install the latest release
+gjsify self-update --check # check without installing
+gjsify self-update --tag next   # opt into a different dist-tag
+```
+
+### Pin a specific version
+
+```bash
+gjs -m /tmp/g.mjs --tag 0.4.10
+```
+
+`--tag` accepts npm dist-tags (`latest`, `next`) or pinned versions (`0.4.10`).
+
+### Custom install location
+
+```bash
+GJSIFY_GLOBAL_PREFIX=$HOME/.gjsify GJSIFY_GLOBAL_BIN_DIR=$HOME/.gjsify/bin \
+  gjs -m /tmp/g.mjs
+```
+
+The install backend honors `GJSIFY_GLOBAL_PREFIX` (default
+`~/.local/share/gjsify/global`) and `GJSIFY_GLOBAL_BIN_DIR` (default
+`~/.local/bin`).
+
+## Alternative: npm install
+
+```bash
+npm install -g @gjsify/cli
+```
+
+Still fully supported. Choose this if you already manage developer
+tooling via npm and don't mind keeping Node on the path.
+
+## Prerequisites
+
+The bootstrap script requires:
+
+- **gjs ≥ 1.86** — bundled with Fedora 43+, Debian 13+, Arch
+- **curl** (or `wget`) — universally available
+- An internet connection for the initial bootstrap; subsequent
+  installs and updates resolve from cache when possible.
+
+If `gjs` is older than 1.86 the bootstrap aborts with a clear message
+pointing at install commands for the major distributions.
+
+## Uninstall
+
+```bash
+rm -rf ~/.local/share/gjsify ~/.local/bin/gjsify
+```
+
+The bootstrap cache at `~/.cache/gjsify/` is safe to delete at any
+time — the next install or update rebuilds it.


### PR DESCRIPTION
## Summary

Website docs for Phase F's new install flow.

- **\`guides/install.md\`** (NEW) — Node-free \`curl ... install.mjs | gjs -m -\` bootstrap as the primary install path, npm install -g as alternative, prereqs (gjs ≥ 1.86, curl), self-update + custom prefix env vars + uninstall.
- **\`guides/distributing-gjs-apps.md\`** (NEW) — how-to for end-user devs to ship a one-line installer for their own GJS-runnable npm package via \`gjsify generate-installer\`. Includes requirements (gjsify.bin field, --shebang flag, prebuild handling) and reference impls.
- **\`cli-reference.md\`** — new \`gjsify self-update\` + \`gjsify generate-installer\` command sections with flag tables.

## Test plan

- [x] markdown renders cleanly locally
- [ ] CI green
- [ ] follow-up: post-merge, the docs site picks up the new pages automatically