### PR TITLE
feat(iframe): binary postMessage + W3C origin checks + bootstrap idempotency + MessagePort transferList

### DIFF
--- a/packages/framework/iframe/src/iframe-message-channel.spec.ts
+++ b/packages/framework/iframe/src/iframe-message-channel.spec.ts
@@ -1,0 +1,86 @@
+// Tests for IFrameMessageChannel / IFrameMessagePort — in-process
+// channel semantics (port pair without ever transferring). The WebView-
+// routed path requires a live WebKit.WebView so is covered separately
+// by the bridge integration test surface (not exercised in unit tests).
+
+import { describe, it, expect } from '@gjsify/unit';
+import { IFrameMessageChannel, IFrameMessagePort } from './iframe-message-channel.js';
+
+export default async () => {
+
+  await describe('IFrameMessageChannel — in-process behavior', async () => {
+
+    await it('creates two linked ports', async () => {
+      const ch = new IFrameMessageChannel();
+      expect(ch.port1 instanceof IFrameMessagePort).toBe(true);
+      expect(ch.port2 instanceof IFrameMessagePort).toBe(true);
+      expect(ch.port1).not.toBe(ch.port2 as unknown);
+    });
+
+    await it('message posted on port1 arrives on port2', async () => {
+      const ch = new IFrameMessageChannel();
+      const received = await new Promise<unknown>((resolve) => {
+        ch.port2.addEventListener('message', (e: unknown) => {
+          resolve((e as { data: unknown }).data);
+        });
+        ch.port1.postMessage({ hello: 'world' });
+      });
+      expect((received as { hello: string }).hello).toBe('world');
+    });
+
+    await it('bidirectional traffic — port2 → port1 also works', async () => {
+      const ch = new IFrameMessageChannel();
+      const received = await new Promise<unknown>((resolve) => {
+        ch.port1.addEventListener('message', (e: unknown) => {
+          resolve((e as { data: unknown }).data);
+        });
+        ch.port2.postMessage(42);
+      });
+      expect(received).toBe(42);
+    });
+
+    await it('messages sent before addEventListener queue and replay on listen', async () => {
+      const ch = new IFrameMessageChannel();
+      ch.port1.postMessage('first');
+      ch.port1.postMessage('second');
+      const messages: unknown[] = [];
+      await new Promise<void>((resolve) => {
+        ch.port2.addEventListener('message', (e: unknown) => {
+          messages.push((e as { data: unknown }).data);
+          if (messages.length === 2) resolve();
+        });
+      });
+      expect(messages[0]).toBe('first');
+      expect(messages[1]).toBe('second');
+    });
+
+    await it('close() detaches the partner; subsequent messages drop', async () => {
+      const ch = new IFrameMessageChannel();
+      const received: unknown[] = [];
+      ch.port2.addEventListener('message', (e: unknown) => {
+        received.push((e as { data: unknown }).data);
+      });
+      ch.port1.postMessage('before-close');
+      await new Promise(r => setTimeout(r, 5));
+      ch.port2.close();
+      ch.port1.postMessage('after-close');
+      await new Promise(r => setTimeout(r, 5));
+      expect(received.length).toBe(1);
+      expect(received[0]).toBe('before-close');
+    });
+
+    await it('explicit start() is idempotent', async () => {
+      const ch = new IFrameMessageChannel();
+      ch.port1.start();
+      ch.port1.start();
+      // No throw, no double-anything.
+      expect(true).toBe(true);
+    });
+
+    await it('Symbol.toStringTag identifies the types', async () => {
+      const ch = new IFrameMessageChannel();
+      expect(Object.prototype.toString.call(ch)).toBe('[object MessageChannel]');
+      expect(Object.prototype.toString.call(ch.port1)).toBe('[object MessagePort]');
+    });
+  });
+};

--- a/packages/framework/iframe/src/iframe-message-channel.ts
+++ b/packages/framework/iframe/src/iframe-message-channel.ts
@@ -1,0 +1,142 @@
+// IFrameMessageChannel / IFrameMessagePort — minimal MessageChannel
+// substitute for the GJS ↔ WebKit.WebView bridge.
+//
+// W3C `MessagePort` requires the browser host to thread the port
+// identity through structured clone + transferList semantics. We can't
+// reuse `@gjsify/worker_threads` MessagePort because that's
+// EventEmitter-based (Node convention) and is wired for subprocess IPC,
+// not WebKit IPC. We can't reuse a globalThis.MessageChannel because GJS
+// doesn't ship one.
+//
+// So we provide a tiny EventTarget-based MessagePort + MessageChannel
+// pair scoped to iframe-bridge use. The pair has two endpoints:
+//
+//   const ch = new IFrameMessageChannel();
+//   iframe.contentWindow.postMessage(msg, '*', [ch.port2]);
+//   ch.port1.addEventListener('message', (e) => { … });
+//   ch.port1.postMessage('reply');
+//
+// `ch.port2` is what the user passes in transferList. After transfer it
+// becomes unusable on the GJS side — its partner (`ch.port1`) stays
+// usable and is the application's hand-off to bridge-routed messages.
+// On the WebView side, `event.ports[0]` of the incoming MessageEvent is
+// a proxy port whose .postMessage routes back over the bridge.
+//
+// Limitations:
+// - Single-hop transfers only. Re-transferring a transferred port is
+//   rejected (W3C does allow this but it's rare).
+// - In-process channel use (port1 ↔ port2 without ever transferring)
+//   works the same way as a regular MessageChannel.
+// - close() on the GJS side ends bridge routing for that port-id;
+//   the WebView-side proxy stops delivering after the GJS port closes.
+
+import { EventTarget, MessageEvent } from '@gjsify/dom-events';
+
+import type { MessageBridge } from './message-bridge.js';
+
+export class IFrameMessagePort extends EventTarget {
+	/** @internal In-process partner; null when this port has been transferred. */
+	_partner: IFrameMessagePort | null = null;
+	/** @internal Set once this port has been passed in a transferList — can no longer post locally. */
+	_transferred = false;
+	/** @internal Set when the partner of this port has been transferred — this port now routes via the bridge. */
+	_bridge: MessageBridge | null = null;
+	/** @internal Bridge-side identifier when this port is wired to a remote endpoint. */
+	_portId: number | null = null;
+	/** @internal W3C: dispatching is gated until .start() (or first addEventListener('message')). */
+	_started = false;
+	/** @internal Messages received before .start() */
+	_queue: unknown[] = [];
+	/** @internal Closed by close() */
+	_closed = false;
+
+	postMessage(data: unknown): void {
+		if (this._transferred) {
+			throw new Error('IFrameMessagePort.postMessage: port has been transferred');
+		}
+		if (this._closed) return;
+		if (this._bridge && this._portId !== null) {
+			// Partner has been transferred to the WebView; route through the bridge.
+			this._bridge._sendPortMessage(this._portId, data);
+			return;
+		}
+		// In-process: deliver to the partner directly.
+		if (this._partner && !this._partner._closed) this._partner._receive(data);
+	}
+
+	/**
+	 * W3C: enables dispatching of queued messages. Explicit `start()`
+	 * is optional — adding a 'message' listener via addEventListener
+	 * auto-starts. This method exists for explicit control + .onmessage
+	 * setter compatibility (not implemented yet).
+	 */
+	start(): void {
+		if (this._started || this._closed) return;
+		this._started = true;
+		const queued = this._queue;
+		this._queue = [];
+		for (const msg of queued) this._dispatch(msg);
+	}
+
+	close(): void {
+		if (this._closed) return;
+		this._closed = true;
+		if (this._bridge && this._portId !== null) {
+			this._bridge._closePort(this._portId);
+			this._bridge = null;
+			this._portId = null;
+		}
+		this._partner = null;
+		this._queue = [];
+	}
+
+	/** @internal Called by the bridge or the in-process partner. */
+	_receive(data: unknown): void {
+		if (this._closed) return;
+		if (!this._started) {
+			this._queue.push(data);
+			return;
+		}
+		this._dispatch(data);
+	}
+
+	private _dispatch(data: unknown): void {
+		// Async dispatch to match W3C MessagePort + MessageEvent semantics.
+		Promise.resolve().then(() => {
+			if (this._closed) return;
+			this.dispatchEvent(new MessageEvent('message', { data }));
+		});
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	addEventListener(type: string, listener: any, options?: any): void {
+		// EventTarget here is @gjsify/dom-events's, not lib.dom; the signature
+		// uses its own Event type which doesn't match standard DOM strictly.
+		// Cast through any to avoid the type clash without losing W3C semantics.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(super.addEventListener as any)(type, listener, options);
+		// Per W3C, the implicit-start happens when ANY message listener is added,
+		// not when the port is first read. Honor that.
+		if (type === 'message') this.start();
+	}
+
+	get [Symbol.toStringTag](): string {
+		return 'MessagePort';
+	}
+}
+
+export class IFrameMessageChannel {
+	readonly port1: IFrameMessagePort;
+	readonly port2: IFrameMessagePort;
+
+	constructor() {
+		this.port1 = new IFrameMessagePort();
+		this.port2 = new IFrameMessagePort();
+		this.port1._partner = this.port2;
+		this.port2._partner = this.port1;
+	}
+
+	get [Symbol.toStringTag](): string {
+		return 'MessageChannel';
+	}
+}

--- a/packages/framework/iframe/src/iframe-window-proxy.ts
+++ b/packages/framework/iframe/src/iframe-window-proxy.ts
@@ -5,6 +5,7 @@
 import { EventTarget } from '@gjsify/dom-events';
 
 import type { MessageBridge } from './message-bridge.js';
+import type { IFrameMessagePort } from './iframe-message-channel.js';
 
 /**
  * Lightweight Window-like proxy returned by `HTMLIFrameElement.contentWindow`.
@@ -31,12 +32,18 @@ export class IFrameWindowProxy extends EventTarget {
 	/**
 	 * Send a message to the iframe content.
 	 *
-	 * @param message - Data to send (must be JSON-serializable)
-	 * @param targetOrigin - Target origin for the message. Default: '*'
+	 * @param message - Data to send (must be JSON-serializable + base64-encodable
+	 *   binaries — see @gjsify/iframe/serialize for supported binary types).
+	 * @param targetOrigin - Target origin for the message. Default: '*'.
+	 * @param transfer - Optional list of `IFrameMessagePort` instances to
+	 *   transfer. Each transferred port is detached locally; its surviving
+	 *   partner becomes the GJS-side endpoint of a bidirectional channel
+	 *   routed through the bridge. The WebView receives proxy ports under
+	 *   `MessageEvent.data` wherever the original ports appeared in `message`.
 	 */
-	postMessage(message: unknown, targetOrigin = '*'): void {
+	postMessage(message: unknown, targetOrigin = '*', transfer?: IFrameMessagePort[]): void {
 		if (this._closed) return;
-		this._bridge.sendToWebView(message, targetOrigin);
+		this._bridge.sendToWebView(message, targetOrigin, transfer);
 	}
 
 	/**

--- a/packages/framework/iframe/src/index.ts
+++ b/packages/framework/iframe/src/index.ts
@@ -5,7 +5,8 @@
 export { HTMLIFrameElement } from './html-iframe-element.js';
 export { IFrameBridge } from './iframe-bridge.js';
 export { IFrameWindowProxy } from './iframe-window-proxy.js';
-export { MessageBridge } from './message-bridge.js';
+export { MessageBridge, GJS_HOST_ORIGIN } from './message-bridge.js';
+export { IFrameMessageChannel, IFrameMessagePort } from './iframe-message-channel.js';
 export type { IFrameBridgeOptions, IFrameReadyCallback, IFrameMessageData } from './types/index.js';
 
 // Side-effect: register DOM globals on import.

--- a/packages/framework/iframe/src/message-bridge.ts
+++ b/packages/framework/iframe/src/message-bridge.ts
@@ -13,6 +13,7 @@ Gio._promisify(WebKit.WebView.prototype, 'evaluate_javascript', 'evaluate_javasc
 
 import type { IFrameWindowProxy } from './iframe-window-proxy.js';
 import type { IFrameMessageData } from './types/index.js';
+import type { IFrameMessagePort } from './iframe-message-channel.js';
 import {
   encodeBinariesForJson,
   decodeBinariesFromJson,
@@ -91,6 +92,81 @@ const BOOTSTRAP_SCRIPT = `(function() {
 
     ${BINARY_SERIALIZER_INJECTED_SRC}
 
+    // Per-WebView registry of proxy ports created during GJS → WebView
+    // postMessage. Keyed by the GJS-allocated portId. Each entry has a
+    // .deliver(payload) hook the GJS host can invoke via evaluate_javascript
+    // to dispatch a 'message' event on the proxy port.
+    var __gjsifyPorts = {};
+
+    function __makeProxyPort(portId) {
+        var listeners = [];
+        var started = false;
+        var queued = [];
+        function dispatch(d) {
+            var ev = { data: d, type: 'message' };
+            for (var i = 0; i < listeners.length; i++) {
+                try { listeners[i].call(undefined, ev); } catch (_) {}
+            }
+        }
+        function drain() {
+            while (queued.length > 0) dispatch(queued.shift());
+        }
+        var port = {
+            postMessage: function(d) {
+                handler.postMessage(JSON.stringify({
+                    __gjsifyPortMessage: portId,
+                    payload: __encodeBin(d)
+                }));
+            },
+            addEventListener: function(type, fn) {
+                if (type !== 'message' || typeof fn !== 'function') return;
+                listeners.push(fn);
+                if (!started) { started = true; drain(); }
+            },
+            removeEventListener: function(type, fn) {
+                if (type !== 'message') return;
+                var i = listeners.indexOf(fn);
+                if (i !== -1) listeners.splice(i, 1);
+            },
+            start: function() { if (!started) { started = true; drain(); } },
+            close: function() {
+                handler.postMessage(JSON.stringify({ __gjsifyPortClose: portId }));
+                listeners = [];
+                queued = [];
+                delete __gjsifyPorts[portId];
+            },
+        };
+        Object.defineProperty(port, 'onmessage', {
+            get: function() { return port.__onmessage || null; },
+            set: function(fn) {
+                if (port.__onmessage) port.removeEventListener('message', port.__onmessage);
+                port.__onmessage = fn;
+                if (typeof fn === 'function') port.addEventListener('message', fn);
+            },
+        });
+        __gjsifyPorts[portId] = {
+            deliver: function(d) {
+                if (started) dispatch(d); else queued.push(d);
+            },
+        };
+        return port;
+    }
+
+    // Walk an incoming GJS → WebView payload for {__gjsifyPort: id}
+    // placeholders and replace each with a proxy port instance.
+    function __substitutePorts(v) {
+        if (v === null || typeof v !== 'object') return v;
+        if (typeof v.__gjsifyPort === 'number') return __makeProxyPort(v.__gjsifyPort);
+        if (Array.isArray(v)) { for (var i=0;i<v.length;i++) v[i]=__substitutePorts(v[i]); return v; }
+        if (__classOf(v) === 'Object') {
+            for (var k in v) if (Object.prototype.hasOwnProperty.call(v,k)) v[k]=__substitutePorts(v[k]);
+            return v;
+        }
+        return v;
+    }
+    window.__gjsifyPortRegistry = __gjsifyPorts;
+    window.__gjsifySubstitutePorts = __substitutePorts;
+
     function normaliseOrigin(t) {
         if (t === '*') return '*';
         if (t === '/') return location.origin;       // source own-origin shortcut
@@ -153,6 +229,11 @@ export class MessageBridge {
 	private _windowProxy: IFrameWindowProxy | null = null;
 	private _currentUri = 'about:blank';
 	private _signalId: number | null = null;
+	/** GJS-side endpoints of transferred ports, keyed by per-bridge id.
+	 *  When the WebView sends a `{__gjsifyPortMessage: id, payload}` envelope,
+	 *  we route the payload to `_ports.get(id)._receive(decoded)`. */
+	private _ports = new Map<number, IFrameMessagePort>();
+	private _nextPortId = 1;
 
 	constructor(webView: WebKit.WebView) {
 		this._webView = webView;
@@ -187,7 +268,56 @@ export class MessageBridge {
 	 * Send a message from GJS to the WebView content.
 	 * Dispatches a standard MessageEvent on the WebView's window object.
 	 */
-	sendToWebView(data: unknown, targetOrigin: string): void {
+	/**
+	 * Register a port pair for cross-bridge transfer. Called by
+	 * IFrameWindowProxy.postMessage when it sees an IFrameMessagePort
+	 * in the transferList. Returns the port-id placeholder that should
+	 * be substituted into the outgoing payload.
+	 *
+	 * Marks the transferred port as detached locally and wires its
+	 * surviving partner so the partner's postMessage routes back over
+	 * the bridge.
+	 */
+	_registerTransferredPort(port: IFrameMessagePort): number {
+		if (port._transferred) {
+			throw new Error('IFrameMessagePort: already transferred');
+		}
+		const partner = port._partner;
+		if (!partner) {
+			throw new Error('IFrameMessagePort: partner missing — port already transferred or closed');
+		}
+		const id = this._nextPortId++;
+		// Detach the transferred port locally.
+		port._transferred = true;
+		port._partner = null;
+		// Wire the partner: future postMessages on partner flow via the bridge.
+		partner._partner = null;
+		partner._bridge = this;
+		partner._portId = id;
+		this._ports.set(id, partner);
+		return id;
+	}
+
+	/** @internal Called by IFrameMessagePort.postMessage when its partner
+	 *  was transferred to the WebView. Dispatches the data onto the
+	 *  WebView-side proxy port via evaluate_javascript. */
+	_sendPortMessage(portId: number, data: unknown): void {
+		const encoded = encodeBinariesForJson(data);
+		const serialized = JSON.stringify(encoded);
+		const script = `(function(){${BINARY_SERIALIZER_INJECTED_SRC}var p = window.__gjsifyPortRegistry && window.__gjsifyPortRegistry[${portId}]; if (p) p.deliver(__decodeBin(JSON.parse(${JSON.stringify(serialized)})));})();`;
+		this._webView.evaluate_javascript(script, -1, null, null, null).catch(() => {});
+	}
+
+	/** @internal Called by IFrameMessagePort.close to tear down the
+	 *  bridge-side registration. The WebView side keeps its proxy port
+	 *  alive in user-script land but subsequent .deliver calls go nowhere. */
+	_closePort(portId: number): void {
+		this._ports.delete(portId);
+		const script = `(function(){ if (window.__gjsifyPortRegistry) delete window.__gjsifyPortRegistry[${portId}]; })();`;
+		this._webView.evaluate_javascript(script, -1, null, null, null).catch(() => {});
+	}
+
+	sendToWebView(data: unknown, targetOrigin: string, transfer?: IFrameMessagePort[]): void {
 		// Validate + match against the WebView's current origin per HTML spec.
 		// '*' always delivers; a parseable URL must match the WebView's
 		// location.origin; '/' means "must match source's own origin" — for
@@ -203,15 +333,30 @@ export class MessageBridge {
 			if (compareTo !== webViewOrigin) return;
 		}
 
+		// Substitute any IFrameMessagePort instances in the payload with
+		// {__gjsifyPort: id} placeholders. The bootstrap walker turns these
+		// back into proxy ports on the WebView side.
+		let prepared = data;
+		if (transfer && transfer.length > 0) {
+			const portToId = new Map<IFrameMessagePort, number>();
+			for (const p of transfer) {
+				const id = this._registerTransferredPort(p);
+				portToId.set(p, id);
+			}
+			prepared = substitutePorts(data, portToId);
+		}
+
 		// Encode binaries to base64 placeholders before JSON-stringifying the
 		// payload. The injected snippet decodes them on the WebView side before
 		// dispatching MessageEvent, so user code sees a real typed array.
-		const encoded = encodeBinariesForJson(data);
+		const encoded = encodeBinariesForJson(prepared);
 		const serialized = JSON.stringify(encoded);
 		const origin = JSON.stringify(GJS_HOST_ORIGIN);
 		// Note: do not pass `source` — WebKit's MessageEvent constructor throws TypeError
 		// if source is not a valid MessageEventSource (Window/MessagePort/ServiceWorker)
-		const script = `(function(){${BINARY_SERIALIZER_INJECTED_SRC}window.dispatchEvent(new MessageEvent('message', { data: __decodeBin(JSON.parse(${JSON.stringify(serialized)})), origin: ${origin} }));})();`;
+		// The snippet decodes binaries first, then walks for {__gjsifyPort: id}
+		// placeholders and replaces them with the WebView-side proxy ports.
+		const script = `(function(){${BINARY_SERIALIZER_INJECTED_SRC}var d = __decodeBin(JSON.parse(${JSON.stringify(serialized)})); if (window.__gjsifySubstitutePorts) d = window.__gjsifySubstitutePorts(d); window.dispatchEvent(new MessageEvent('message', { data: d, origin: ${origin} }));})();`;
 
 		// evaluate_javascript is async in WebKit 6.0 — fire and forget
 		this._webView.evaluate_javascript(
@@ -249,25 +394,46 @@ export class MessageBridge {
 
 				try {
 					// The bootstrap script sends JSON.stringify({data, targetOrigin, origin})
-					// so jsValue is a JSC string. Use to_string() to get the raw JSON.
+					// — or a port-routed shape `{__gjsifyPortMessage: id, payload}` /
+					// `{__gjsifyPortClose: id}` — so jsValue is a JSC string. Use
+					// to_string() to get the raw JSON.
 					const json = jsValue.to_string();
-					const envelope: IFrameMessageData = JSON.parse(json);
+					const envelope = JSON.parse(json) as
+						| IFrameMessageData
+						| { __gjsifyPortMessage: number; payload: unknown }
+						| { __gjsifyPortClose: number };
 
+					// Port message → route to the corresponding GJS-side endpoint.
+					if (typeof (envelope as { __gjsifyPortMessage?: number }).__gjsifyPortMessage === 'number') {
+						const e = envelope as { __gjsifyPortMessage: number; payload: unknown };
+						const port = this._ports.get(e.__gjsifyPortMessage);
+						if (port) port._receive(decodeBinariesFromJson(e.payload));
+						return;
+					}
+					if (typeof (envelope as { __gjsifyPortClose?: number }).__gjsifyPortClose === 'number') {
+						const e = envelope as { __gjsifyPortClose: number };
+						const port = this._ports.get(e.__gjsifyPortClose);
+						if (port) port.close();
+						this._ports.delete(e.__gjsifyPortClose);
+						return;
+					}
+
+					const windowMsg = envelope as IFrameMessageData;
 					// Bootstrap already enforces targetOrigin against GJS_HOST_ORIGIN.
 					// Re-validate here as defense-in-depth: a tampered WebView could
 					// emit a JSON envelope directly via the message handler bypassing
 					// the bootstrap's normaliseOrigin call. '*' always allowed,
 					// otherwise must equal GJS_HOST_ORIGIN.
-					const target = envelope.targetOrigin;
+					const target = windowMsg.targetOrigin;
 					if (target !== '*' && target !== GJS_HOST_ORIGIN) return;
 
 					// Decode any binary placeholders in `data` back into typed arrays.
-					const decodedData = decodeBinariesFromJson(envelope.data);
+					const decodedData = decodeBinariesFromJson(windowMsg.data);
 
 					// Dispatch MessageEvent on the IFrameWindowProxy
 					const event = new MessageEvent('message', {
 						data: decodedData,
-						origin: envelope.origin,
+						origin: windowMsg.origin,
 					});
 					this._windowProxy.dispatchEvent(event);
 				} catch (error) {
@@ -276,6 +442,13 @@ export class MessageBridge {
 			},
 		);
 	}
+
+	/**
+	 * Walk the user payload and replace each IFrameMessagePort instance
+	 * (transferred via the transferList) with a {__gjsifyPort: id}
+	 * placeholder. Non-transferred ports are passed through untouched —
+	 * matches W3C semantics where only ports in transferList are detached.
+	 */
 
 	/**
 	 * Inject the bootstrap script into the WebView so that
@@ -291,4 +464,42 @@ export class MessageBridge {
 		);
 		this._userContentManager.add_script(script);
 	}
+}
+
+/**
+ * Walk a value tree, replacing each `IFrameMessagePort` found in
+ * `portToId` with a `{__gjsifyPort: id}` placeholder. Non-transferred
+ * ports pass through unchanged — caller is expected to populate the map
+ * exactly with the ports listed in transferList. Plain objects + arrays
+ * are walked; other tagged types (Map, Set, Date, …) and primitives are
+ * left as-is.
+ */
+function substitutePorts(value: unknown, portToId: Map<IFrameMessagePort, number>): unknown {
+	const seen = new WeakMap<object, unknown>();
+
+	function walk(v: unknown): unknown {
+		if (v === null || typeof v !== 'object') return v;
+		// Use Symbol.toStringTag to detect our port without dragging
+		// a runtime import dependency into this helper.
+		if ((v as { [Symbol.toStringTag]?: string })[Symbol.toStringTag] === 'MessagePort' && portToId.has(v as IFrameMessagePort)) {
+			return { __gjsifyPort: portToId.get(v as IFrameMessagePort) };
+		}
+		if (seen.has(v as object)) return seen.get(v as object);
+		if (Array.isArray(v)) {
+			const out: unknown[] = [];
+			seen.set(v, out);
+			for (let i = 0; i < v.length; i++) out[i] = walk(v[i]);
+			return out;
+		}
+		if (Object.prototype.toString.call(v).slice(8, -1) === 'Object') {
+			const out: Record<string, unknown> = {};
+			seen.set(v as object, out);
+			for (const k of Object.keys(v as Record<string, unknown>)) {
+				out[k] = walk((v as Record<string, unknown>)[k]);
+			}
+			return out;
+		}
+		return v;
+	}
+	return walk(value);
 }

--- a/packages/framework/iframe/src/message-bridge.ts
+++ b/packages/framework/iframe/src/message-bridge.ts
@@ -13,8 +13,51 @@ Gio._promisify(WebKit.WebView.prototype, 'evaluate_javascript', 'evaluate_javasc
 
 import type { IFrameWindowProxy } from './iframe-window-proxy.js';
 import type { IFrameMessageData } from './types/index.js';
+import {
+  encodeBinariesForJson,
+  decodeBinariesFromJson,
+  BINARY_SERIALIZER_INJECTED_SRC,
+} from './serialize.js';
 
 const CHANNEL_NAME = 'gjsify-iframe';
+
+/**
+ * Synthetic origin attached to messages travelling FROM the GJS host
+ * INTO the WebView. The WebView can use this in a targetOrigin filter to
+ * accept messages only when they originate from its hosting GJS process
+ * (vs. any other code that might inject script via developer tools).
+ *
+ * Uses the `https://` scheme so WHATWG URL parsing gives a real origin
+ * string (non-special schemes like `gjsify://` return `null` as origin
+ * per the URL spec, which would break the equality comparison the
+ * bridge does on every message). `.local` is the standard RFC 6762
+ * suffix for non-routable mDNS names, so it can't collide with a real
+ * site.
+ */
+export const GJS_HOST_ORIGIN = 'https://gjsify.local';
+
+/**
+ * Per HTML spec for window.postMessage:
+ *   - '*'         → no origin restriction
+ *   - URL string  → only deliver if destination origin matches URL.origin
+ *   - '/'         → only deliver if destination origin matches source origin
+ *   - other       → throw SyntaxError
+ *
+ * Returns the canonical origin string (e.g. 'https://example.com'),
+ * `'*'`, or `null` if the input is `'/'`. Throws `SyntaxError` for
+ * malformed input.
+ */
+export function normaliseTargetOrigin(targetOrigin: string): string | null {
+	if (targetOrigin === '*') return '*';
+	if (targetOrigin === '/') return null;
+	try {
+		return new URL(targetOrigin).origin;
+	} catch {
+		const err = new Error(`Invalid target origin '${targetOrigin}'`);
+		err.name = 'SyntaxError';
+		throw err;
+	}
+}
 
 /**
  * Bootstrap script injected into every WebView page at document start.
@@ -25,16 +68,57 @@ const CHANNEL_NAME = 'gjsify-iframe';
  * 2. Creates a parent proxy with a postMessage() that sends via the WebKit handler
  * 3. Overrides window.parent to point to the proxy
  */
+/**
+ * @internal Exposed only for unit testing — verifies the bootstrap
+ * idempotency guard survives refactors. Not part of the public API.
+ */
+export const BOOTSTRAP_SCRIPT_FOR_TEST = (): string => BOOTSTRAP_SCRIPT;
+
 const BOOTSTRAP_SCRIPT = `(function() {
     var handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers['${CHANNEL_NAME}'];
     if (!handler) return;
+
+    // Idempotency guard: WebKit auto-injects this script at INJECTION_TIME.START
+    // for every page load. On rapid reload, srcdoc remount, or
+    // history.replaceState shenanigans, the script may run twice in the
+    // same window without an intervening real navigation. If we
+    // overwrite our previous override blindly we'd capture OUR override
+    // as origPostMessage, losing the real one — and any consumer using
+    // __gjsifyBridge.origPostMessage would loop forever.
+    if (window.__gjsifyBridge && window.__gjsifyBridge.__bridgeVersion === 1) return;
+
+    var GJS_HOST_ORIGIN = '${GJS_HOST_ORIGIN}';
+
+    ${BINARY_SERIALIZER_INJECTED_SRC}
+
+    function normaliseOrigin(t) {
+        if (t === '*') return '*';
+        if (t === '/') return location.origin;       // source own-origin shortcut
+        try { return new URL(t).origin; }
+        catch (_) {
+            var err = new SyntaxError("Invalid target origin '" + t + "'");
+            throw err;
+        }
+    }
+
     function bridgePostMessage(data, targetOrigin) {
+        var t = targetOrigin || '*';
+        var resolved = normaliseOrigin(t);
+        // Drop silently if the targetOrigin doesn't match GJS host origin.
+        // '*' matches anything; otherwise must equal GJS_HOST_ORIGIN.
+        if (resolved !== '*' && resolved !== GJS_HOST_ORIGIN) return;
         handler.postMessage(JSON.stringify({
-            data: data,
-            targetOrigin: targetOrigin || '*',
+            data: __encodeBin(data),
+            targetOrigin: resolved,
             origin: location.origin
         }));
     }
+
+    // GJS → WebView messages come in via window.dispatchEvent(new MessageEvent(...))
+    // injected by evaluate_javascript. We can't intercept that path, so the
+    // injection itself decodes placeholders before constructing MessageEvent —
+    // see MessageBridge.sendToWebView in message-bridge.ts.
+
     // In a WebKit.WebView loaded via srcdoc, window.parent === window (no real iframe nesting).
     // window.parent is [LegacyUnforgeable] — cannot be redefined with defineProperty.
     // Instead, override window.postMessage directly. Since window.parent === window,
@@ -43,8 +127,13 @@ const BOOTSTRAP_SCRIPT = `(function() {
     window.postMessage = function(data, targetOrigin) {
         bridgePostMessage(data, targetOrigin);
     };
-    // Also expose on a safe namespace for explicit use
-    window.__gjsifyBridge = { postMessage: bridgePostMessage, origPostMessage: origPostMessage };
+    // Also expose on a safe namespace for explicit use. Version-tag
+    // the bridge so the idempotency guard above can detect a re-run.
+    window.__gjsifyBridge = {
+        __bridgeVersion: 1,
+        postMessage: bridgePostMessage,
+        origPostMessage: origPostMessage,
+    };
 })();`;
 
 /**
@@ -98,12 +187,31 @@ export class MessageBridge {
 	 * Send a message from GJS to the WebView content.
 	 * Dispatches a standard MessageEvent on the WebView's window object.
 	 */
-	sendToWebView(data: unknown, _targetOrigin: string): void {
-		const serialized = JSON.stringify(data);
-		const origin = JSON.stringify('gjsify');
+	sendToWebView(data: unknown, targetOrigin: string): void {
+		// Validate + match against the WebView's current origin per HTML spec.
+		// '*' always delivers; a parseable URL must match the WebView's
+		// location.origin; '/' means "must match source's own origin" — for
+		// GJS-side senders that's GJS_HOST_ORIGIN, which can never match a
+		// real WebView origin, so '/' always drops.
+		const targetCanonical = normaliseTargetOrigin(targetOrigin);
+		if (targetCanonical !== '*') {
+			const webViewOrigin = this.getLocation().origin;
+			// `null` from '/' OR a real origin string. '/' resolves to source's
+			// own origin = GJS_HOST_ORIGIN here, which never matches a real
+			// WebView origin.
+			const compareTo = targetCanonical ?? GJS_HOST_ORIGIN;
+			if (compareTo !== webViewOrigin) return;
+		}
+
+		// Encode binaries to base64 placeholders before JSON-stringifying the
+		// payload. The injected snippet decodes them on the WebView side before
+		// dispatching MessageEvent, so user code sees a real typed array.
+		const encoded = encodeBinariesForJson(data);
+		const serialized = JSON.stringify(encoded);
+		const origin = JSON.stringify(GJS_HOST_ORIGIN);
 		// Note: do not pass `source` — WebKit's MessageEvent constructor throws TypeError
 		// if source is not a valid MessageEventSource (Window/MessagePort/ServiceWorker)
-		const script = `window.dispatchEvent(new MessageEvent('message', { data: JSON.parse(${JSON.stringify(serialized)}), origin: ${origin} }));`;
+		const script = `(function(){${BINARY_SERIALIZER_INJECTED_SRC}window.dispatchEvent(new MessageEvent('message', { data: __decodeBin(JSON.parse(${JSON.stringify(serialized)})), origin: ${origin} }));})();`;
 
 		// evaluate_javascript is async in WebKit 6.0 — fire and forget
 		this._webView.evaluate_javascript(
@@ -145,9 +253,20 @@ export class MessageBridge {
 					const json = jsValue.to_string();
 					const envelope: IFrameMessageData = JSON.parse(json);
 
+					// Bootstrap already enforces targetOrigin against GJS_HOST_ORIGIN.
+					// Re-validate here as defense-in-depth: a tampered WebView could
+					// emit a JSON envelope directly via the message handler bypassing
+					// the bootstrap's normaliseOrigin call. '*' always allowed,
+					// otherwise must equal GJS_HOST_ORIGIN.
+					const target = envelope.targetOrigin;
+					if (target !== '*' && target !== GJS_HOST_ORIGIN) return;
+
+					// Decode any binary placeholders in `data` back into typed arrays.
+					const decodedData = decodeBinariesFromJson(envelope.data);
+
 					// Dispatch MessageEvent on the IFrameWindowProxy
 					const event = new MessageEvent('message', {
-						data: envelope.data,
+						data: decodedData,
 						origin: envelope.origin,
 					});
 					this._windowProxy.dispatchEvent(event);

--- a/packages/framework/iframe/src/serialize.spec.ts
+++ b/packages/framework/iframe/src/serialize.spec.ts
@@ -1,0 +1,258 @@
+// Tests for the GJS ↔ WebView wire-encoder pair. Round-trips every
+// binary type the bridge supports plus nested object/array shapes,
+// preserving constructor identity, byteLength, and element semantics.
+// Pure JS — runs on both Node and GJS without WebKit.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { encodeBinariesForJson, decodeBinariesFromJson } from './serialize.js';
+import { normaliseTargetOrigin, GJS_HOST_ORIGIN, BOOTSTRAP_SCRIPT_FOR_TEST } from './message-bridge.js';
+
+function roundTrip(value: unknown): unknown {
+  const encoded = encodeBinariesForJson(value);
+  const json = JSON.stringify(encoded);
+  return decodeBinariesFromJson(JSON.parse(json));
+}
+
+export default async () => {
+
+  await describe('serialize — binary round-trip', async () => {
+
+    await it('Uint8Array survives byte-perfect', async () => {
+      const src = new Uint8Array(1024);
+      for (let i = 0; i < src.length; i++) src[i] = (i * 31 + 7) & 0xff;
+      const back = roundTrip(src) as Uint8Array;
+      expect(back instanceof Uint8Array).toBe(true);
+      expect(back.length).toBe(1024);
+      for (let i = 0; i < src.length; i++) {
+        if (back[i] !== src[i]) throw new Error(`mismatch at index ${i}: ${back[i]} != ${src[i]}`);
+      }
+    });
+
+    await it('ArrayBuffer survives byte-perfect', async () => {
+      const src = new ArrayBuffer(64);
+      const view = new Uint8Array(src);
+      for (let i = 0; i < 64; i++) view[i] = i ^ 0x5A;
+      const back = roundTrip(src) as ArrayBuffer;
+      expect(back instanceof ArrayBuffer).toBe(true);
+      expect(back.byteLength).toBe(64);
+      const backView = new Uint8Array(back);
+      for (let i = 0; i < 64; i++) expect(backView[i]).toBe(i ^ 0x5A);
+    });
+
+    await it('Int32Array survives sign + element semantics', async () => {
+      const src = new Int32Array([-2147483648, -1, 0, 1, 2147483647]);
+      const back = roundTrip(src) as Int32Array;
+      expect(back instanceof Int32Array).toBe(true);
+      expect(back.length).toBe(5);
+      expect(back[0]).toBe(-2147483648);
+      expect(back[1]).toBe(-1);
+      expect(back[4]).toBe(2147483647);
+    });
+
+    await it('Float32Array preserves precision', async () => {
+      const src = new Float32Array([Math.PI, Math.E, -1.5, 0, Number.MAX_VALUE]);
+      const back = roundTrip(src) as Float32Array;
+      expect(back instanceof Float32Array).toBe(true);
+      // Float32 precision: PI and E lose digits but the round-trip is identity.
+      for (let i = 0; i < src.length; i++) expect(back[i]).toBe(src[i]);
+    });
+
+    await it('Uint16Array / Uint32Array preserve element width', async () => {
+      const u16 = new Uint16Array([0, 0xFFFF, 0x1234, 0xABCD]);
+      const back16 = roundTrip(u16) as Uint16Array;
+      expect(back16 instanceof Uint16Array).toBe(true);
+      expect(back16.length).toBe(4);
+      expect(back16[1]).toBe(0xFFFF);
+      expect(back16[3]).toBe(0xABCD);
+
+      const u32 = new Uint32Array([0xDEADBEEF, 0, 1, 0xFFFFFFFF]);
+      const back32 = roundTrip(u32) as Uint32Array;
+      expect(back32 instanceof Uint32Array).toBe(true);
+      expect(back32[0]).toBe(0xDEADBEEF);
+      expect(back32[3]).toBe(0xFFFFFFFF);
+    });
+
+    await it('DataView round-trips with same byteLength', async () => {
+      const buf = new ArrayBuffer(32);
+      const writer = new DataView(buf);
+      writer.setUint32(0, 0xCAFEBABE, false);
+      writer.setFloat64(8, Math.PI, true);
+      writer.setInt16(20, -12345, false);
+      const dv = new DataView(buf);
+      const back = roundTrip(dv) as DataView;
+      expect(back instanceof DataView).toBe(true);
+      expect(back.byteLength).toBe(32);
+      expect(back.getUint32(0, false)).toBe(0xCAFEBABE);
+      expect(back.getFloat64(8, true)).toBe(Math.PI);
+      expect(back.getInt16(20, false)).toBe(-12345);
+    });
+
+    await it('typed-array view inside a plain object', async () => {
+      const src = {
+        header: { version: 1, flags: 0x0F },
+        payload: new Uint8Array([1, 2, 3, 4, 5]),
+        meta: 'hello',
+      };
+      const back = roundTrip(src) as typeof src;
+      expect(back.header.version).toBe(1);
+      expect(back.header.flags).toBe(0x0F);
+      expect(back.payload instanceof Uint8Array).toBe(true);
+      expect(back.payload.length).toBe(5);
+      expect(back.payload[4]).toBe(5);
+      expect(back.meta).toBe('hello');
+    });
+
+    await it('typed arrays inside nested arrays', async () => {
+      const src = [
+        new Uint8Array([10, 20, 30]),
+        new Uint8Array([40, 50, 60]),
+        new Uint8Array([70, 80, 90]),
+      ];
+      const back = roundTrip(src) as Uint8Array[];
+      expect(back.length).toBe(3);
+      for (let i = 0; i < 3; i++) {
+        expect(back[i] instanceof Uint8Array).toBe(true);
+        expect(back[i]!.length).toBe(3);
+      }
+      expect(back[2]![2]).toBe(90);
+    });
+
+    await it('non-binary leaves pass through untouched', async () => {
+      const src = { a: 1, b: 'hello', c: true, d: null, e: [1, 2, 3] };
+      const back = roundTrip(src) as typeof src;
+      expect(back.a).toBe(1);
+      expect(back.b).toBe('hello');
+      expect(back.c).toBe(true);
+      expect(back.d).toBe(null);
+      expect(back.e[2]).toBe(3);
+    });
+
+    await it('empty typed array', async () => {
+      const src = new Uint8Array(0);
+      const back = roundTrip(src) as Uint8Array;
+      expect(back instanceof Uint8Array).toBe(true);
+      expect(back.length).toBe(0);
+    });
+
+    await it('TypedArray view on a larger buffer — only the view window survives', async () => {
+      const buf = new ArrayBuffer(64);
+      const u8 = new Uint8Array(buf);
+      for (let i = 0; i < 64; i++) u8[i] = i;
+      // 16-byte window starting at offset 8.
+      const view = new Uint8Array(buf, 8, 16);
+      const back = roundTrip(view) as Uint8Array;
+      expect(back.length).toBe(16);
+      // Receiver-side buffer is fresh (no shared backing — postMessage clones);
+      // values 8..23 of the original.
+      for (let i = 0; i < 16; i++) expect(back[i]).toBe(8 + i);
+    });
+  });
+
+  await describe('normaliseTargetOrigin (W3C postMessage spec)', async () => {
+    await it("'*' returns '*' (no origin restriction)", async () => {
+      expect(normaliseTargetOrigin('*')).toBe('*');
+    });
+
+    await it("'/' returns null (sentinel for source-own-origin)", async () => {
+      expect(normaliseTargetOrigin('/')).toBe(null);
+    });
+
+    await it('http URL returns canonical origin (no trailing slash, no path)', async () => {
+      expect(normaliseTargetOrigin('https://example.com/path?query=1')).toBe('https://example.com');
+    });
+
+    await it('http URL with port preserves port in origin', async () => {
+      expect(normaliseTargetOrigin('http://localhost:8080/foo')).toBe('http://localhost:8080');
+    });
+
+    await it('our synthetic GJS_HOST_ORIGIN parses cleanly', async () => {
+      expect(normaliseTargetOrigin(GJS_HOST_ORIGIN)).toBe(GJS_HOST_ORIGIN);
+    });
+
+    await it('malformed input throws SyntaxError', async () => {
+      let threw: Error | null = null;
+      try { normaliseTargetOrigin('not a valid url'); }
+      catch (e) { threw = e as Error; }
+      expect(threw !== null).toBe(true);
+      expect(threw!.name).toBe('SyntaxError');
+    });
+
+    await it("empty string throws SyntaxError (not interpreted as '*')", async () => {
+      let threw = false;
+      try { normaliseTargetOrigin(''); } catch { threw = true; }
+      expect(threw).toBe(true);
+    });
+
+    await it('GJS_HOST_ORIGIN constant matches expected value', async () => {
+      // Pinning the contract: changing this string would silently break
+      // WebView code that filters incoming origins.
+      expect(GJS_HOST_ORIGIN).toBe('https://gjsify.local');
+    });
+  });
+
+  await describe('bootstrap script — re-injection safety', async () => {
+    await it('contains the __bridgeVersion idempotency marker', async () => {
+      // Refactor canary: if the version marker disappears, double-injection
+      // during rapid navigation would lose the real window.postMessage.
+      const src = BOOTSTRAP_SCRIPT_FOR_TEST();
+      expect(src.includes('__bridgeVersion')).toBe(true);
+      expect(src.includes('__gjsifyBridge')).toBe(true);
+    });
+
+    await it('runs idempotently against a simulated window', async () => {
+      // Build a fake window + webkit-message-handler, run the bootstrap
+      // twice, verify postMessage is only wrapped once.
+      const handlerCalls: string[] = [];
+      const realPostMessage = function (this: unknown, _data: unknown) { /* stand-in */ };
+      const fakeWindow: Record<string, unknown> = {
+        webkit: { messageHandlers: { 'gjsify-iframe': { postMessage: (s: string) => handlerCalls.push(s) } } },
+        postMessage: realPostMessage,
+      };
+      const fakeLocation = { origin: 'https://example.com' };
+      const sandbox = { window: fakeWindow, location: fakeLocation };
+      const src = BOOTSTRAP_SCRIPT_FOR_TEST();
+      // The bootstrap is a top-level IIFE; wrap it in a function that
+      // takes `window` + `location` as locals to simulate the
+      // WebView's global scope.
+      const runner = new Function('window', 'location', 'URL', src);
+      // First injection.
+      runner(sandbox.window, sandbox.location, URL);
+      const afterFirst = sandbox.window.postMessage;
+      expect(afterFirst !== realPostMessage).toBe(true);            // overridden
+      const bridgeAfterFirst = sandbox.window.__gjsifyBridge as { origPostMessage: unknown; __bridgeVersion: number };
+      expect(bridgeAfterFirst.__bridgeVersion).toBe(1);
+      expect(bridgeAfterFirst.origPostMessage).toBe(realPostMessage); // real one captured
+
+      // Second injection: should be a no-op (idempotency guard).
+      runner(sandbox.window, sandbox.location, URL);
+      const afterSecond = sandbox.window.postMessage;
+      expect(afterSecond).toBe(afterFirst);                          // same override, not double-wrapped
+      const bridgeAfterSecond = sandbox.window.__gjsifyBridge as { origPostMessage: unknown };
+      expect(bridgeAfterSecond.origPostMessage).toBe(realPostMessage); // real one still captured (not our override)
+    });
+
+    await it('respects targetOrigin filter when sending to GJS host', async () => {
+      // The bootstrap-side normaliseOrigin should drop a message whose
+      // targetOrigin doesn't match the GJS host. We simulate by running
+      // bootstrap, calling our override with mismatched origin, and
+      // asserting the handler.postMessage was NOT called.
+      const calls: string[] = [];
+      const fakeWindow: Record<string, unknown> = {
+        webkit: { messageHandlers: { 'gjsify-iframe': { postMessage: (s: string) => calls.push(s) } } },
+        postMessage: () => { /* placeholder */ },
+      };
+      const fakeLocation = { origin: 'https://example.com' };
+      const runner = new Function('window', 'location', 'URL', BOOTSTRAP_SCRIPT_FOR_TEST());
+      runner(fakeWindow, fakeLocation, URL);
+      // Wildcard: delivers.
+      (fakeWindow.postMessage as (d: unknown, o: string) => void)({ hello: 1 }, '*');
+      expect(calls.length).toBe(1);
+      // Mismatched origin: dropped.
+      (fakeWindow.postMessage as (d: unknown, o: string) => void)({ hello: 2 }, 'https://attacker.example');
+      expect(calls.length).toBe(1);
+      // Exact GJS host: delivers.
+      (fakeWindow.postMessage as (d: unknown, o: string) => void)({ hello: 3 }, GJS_HOST_ORIGIN);
+      expect(calls.length).toBe(2);
+    });
+  });
+};

--- a/packages/framework/iframe/src/serialize.ts
+++ b/packages/framework/iframe/src/serialize.ts
@@ -1,0 +1,267 @@
+// Wire-encoding for the GJS ↔ WebKit.WebView postMessage bridge.
+//
+// WebKit's `script-message-handler.postMessage()` and our reverse
+// `webView.evaluate_javascript()` round-trip both move payloads as JSON
+// strings (the message handler accepts a JSCValue, but in practice it
+// stringifies anything non-primitive — and our reverse path explicitly
+// uses JSON.stringify because that's the only shape evaluate_javascript
+// can ingest reliably). Plain JSON.stringify drops binary content (typed
+// arrays serialise to `{}`, ArrayBuffer to `{}`), so we walk the value
+// tree on the sending side, substitute binary leaves with base64
+// placeholders, and reverse the walk on the receiving side.
+//
+// Placeholder shape: `{ __gjsifyBin: 'b64', type: 'Uint8Array', data: '<base64>' }`.
+// The `type` tag preserves the original constructor (Uint8Array,
+// Uint16Array, Int32Array, Float32Array, DataView, ArrayBuffer, …) so
+// the receiver rebuilds the same shape — important for typed-array
+// math + DataView byteOffset semantics.
+
+const PLACEHOLDER_KEY = '__gjsifyBin';
+const PLACEHOLDER_VAL = 'b64';
+
+/** Supported binary types, in lookup-table order. */
+const BINARY_CTORS = [
+  'ArrayBuffer',
+  'Uint8Array', 'Uint8ClampedArray',
+  'Int8Array',
+  'Uint16Array', 'Int16Array',
+  'Uint32Array', 'Int32Array',
+  'BigUint64Array', 'BigInt64Array',
+  'Float32Array', 'Float64Array',
+  'DataView',
+] as const;
+
+type BinaryTypeName = typeof BINARY_CTORS[number];
+
+interface BinaryPlaceholder {
+  readonly __gjsifyBin: typeof PLACEHOLDER_VAL;
+  readonly type: BinaryTypeName;
+  /** Base64-encoded raw bytes from byteOffset .. byteOffset+byteLength. */
+  readonly data: string;
+  /** Element count for typed arrays (so length is preserved through
+   *  arbitrary byteOffset alignments). Omitted for ArrayBuffer/DataView. */
+  readonly length?: number;
+}
+
+function classOf(value: unknown): string {
+  return Object.prototype.toString.call(value).slice(8, -1);
+}
+
+function isBinaryType(name: string): name is BinaryTypeName {
+  return (BINARY_CTORS as readonly string[]).includes(name);
+}
+
+/**
+ * Encode a binary view to base64. Uses Uint8Array.prototype.toBase64()
+ * where available (SM140+, Node 22+), falling back to a manual loop
+ * + btoa. Stays self-contained so the bootstrap script can inline the
+ * same logic without imports.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  const u8 = bytes as Uint8Array & { toBase64?: () => string };
+  if (typeof u8.toBase64 === 'function') return u8.toBase64();
+  // Manual base64 — slower but works everywhere.
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  // `btoa` accepts only latin-1; the manual loop above guarantees latin-1.
+  return (globalThis as { btoa?: (s: string) => string }).btoa!(s);
+}
+
+/**
+ * Reverse: base64 → Uint8Array. Mirrors bytesToBase64's fallback chain.
+ */
+function base64ToBytes(b64: string): Uint8Array {
+  const Ctor = Uint8Array as unknown as { fromBase64?: (s: string) => Uint8Array };
+  if (typeof Ctor.fromBase64 === 'function') return Ctor.fromBase64(b64);
+  const bin = (globalThis as { atob?: (s: string) => string }).atob!(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function makePlaceholder(value: ArrayBuffer | ArrayBufferView): BinaryPlaceholder {
+  const type = classOf(value) as BinaryTypeName;
+  if (value instanceof ArrayBuffer) {
+    return { __gjsifyBin: PLACEHOLDER_VAL, type, data: bytesToBase64(new Uint8Array(value)) };
+  }
+  // For DataView: encode the byte window only.
+  if (value instanceof DataView) {
+    const window = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+    return { __gjsifyBin: PLACEHOLDER_VAL, type: 'DataView', data: bytesToBase64(window) };
+  }
+  // TypedArray: encode the element-byte window.
+  const ta = value as Uint8Array;
+  const window = new Uint8Array(ta.buffer, ta.byteOffset, ta.byteLength);
+  return { __gjsifyBin: PLACEHOLDER_VAL, type, data: bytesToBase64(window), length: ta.length };
+}
+
+function reconstructFromPlaceholder(p: BinaryPlaceholder): ArrayBuffer | ArrayBufferView {
+  const bytes = base64ToBytes(p.data);
+  switch (p.type) {
+    case 'ArrayBuffer': return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+    case 'DataView':    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    case 'Uint8Array':  return bytes;
+    case 'Uint8ClampedArray': return new Uint8ClampedArray(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    case 'Int8Array':   return new Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    case 'Uint16Array': return new Uint16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'Int16Array':  return new Int16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'Uint32Array': return new Uint32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'Int32Array':  return new Int32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'BigUint64Array': return new BigUint64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'BigInt64Array':  return new BigInt64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'Float32Array': return new Float32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    case 'Float64Array': return new Float64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+  }
+}
+
+function isPlaceholder(value: unknown): value is BinaryPlaceholder {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && (value as { __gjsifyBin?: unknown }).__gjsifyBin === PLACEHOLDER_VAL
+    && typeof (value as { type?: unknown }).type === 'string'
+    && typeof (value as { data?: unknown }).data === 'string'
+  );
+}
+
+/**
+ * Walk `value`, substituting any binary buffer/view with a base64
+ * placeholder. Returns the substituted tree (copy-on-write — input
+ * untouched). Cycles produce cycle-preserving output.
+ */
+export function encodeBinariesForJson(value: unknown): unknown {
+  const seen = new WeakMap<object, unknown>();
+
+  function walk(v: unknown): unknown {
+    if (v === null || typeof v !== 'object') return v;
+
+    const cls = classOf(v);
+    if (isBinaryType(cls)) {
+      return makePlaceholder(v as ArrayBuffer | ArrayBufferView);
+    }
+
+    if (seen.has(v as object)) return seen.get(v as object);
+
+    if (Array.isArray(v)) {
+      const out: unknown[] = [];
+      seen.set(v, out);
+      for (let i = 0; i < v.length; i++) out[i] = walk(v[i]);
+      return out;
+    }
+
+    if (cls === 'Object') {
+      const out: Record<string, unknown> = {};
+      seen.set(v as object, out);
+      for (const k of Object.keys(v as Record<string, unknown>)) {
+        out[k] = walk((v as Record<string, unknown>)[k]);
+      }
+      return out;
+    }
+
+    // Other tagged objects (Map, Set, Date, …) pass through unchanged.
+    return v;
+  }
+
+  return walk(value);
+}
+
+/**
+ * Reverse of `encodeBinariesForJson`. Walks the tree in place and
+ * replaces every placeholder with a reconstructed binary view. Returns
+ * the same tree reference (for parity with the encoder's contract).
+ */
+export function decodeBinariesFromJson(value: unknown): unknown {
+  const seen = new WeakSet<object>();
+
+  function walk(v: unknown): unknown {
+    if (v === null || typeof v !== 'object') return v;
+    if (isPlaceholder(v)) return reconstructFromPlaceholder(v);
+    if (seen.has(v as object)) return v;
+    seen.add(v as object);
+
+    if (Array.isArray(v)) {
+      for (let i = 0; i < v.length; i++) v[i] = walk(v[i]);
+      return v;
+    }
+    const cls = classOf(v);
+    if (cls === 'Object') {
+      for (const k of Object.keys(v as Record<string, unknown>)) {
+        (v as Record<string, unknown>)[k] = walk((v as Record<string, unknown>)[k]);
+      }
+      return v;
+    }
+    return v;
+  }
+
+  return walk(value);
+}
+
+/**
+ * Inlined twin of the encode/decode pair as a string. Injected into the
+ * WebView bootstrap so the WebKit-side window.postMessage override can
+ * encode binaries before handing the JSON to GJS, and decode incoming
+ * GJS-originated placeholders back into typed arrays before dispatching
+ * MessageEvent.
+ *
+ * Kept in sync with the TS source above by manual review — small enough
+ * to audit at a glance, and the alternative (build-time string template)
+ * would tangle the bridge build pipeline for marginal gain.
+ */
+export const BINARY_SERIALIZER_INJECTED_SRC = `
+  var __binKey = '${PLACEHOLDER_KEY}';
+  var __binVal = '${PLACEHOLDER_VAL}';
+  var __binCtors = ${JSON.stringify(BINARY_CTORS)};
+  function __classOf(v){ return Object.prototype.toString.call(v).slice(8,-1); }
+  function __isBin(n){ return __binCtors.indexOf(n) !== -1; }
+  function __b64enc(bytes){
+    if (typeof bytes.toBase64 === 'function') return bytes.toBase64();
+    var s=''; for (var i=0;i<bytes.length;i++) s+=String.fromCharCode(bytes[i]);
+    return btoa(s);
+  }
+  function __b64dec(s){
+    if (typeof Uint8Array.fromBase64 === 'function') return Uint8Array.fromBase64(s);
+    var bin = atob(s); var u = new Uint8Array(bin.length);
+    for (var i=0;i<bin.length;i++) u[i] = bin.charCodeAt(i);
+    return u;
+  }
+  function __mkPlaceholder(v){
+    var t = __classOf(v);
+    if (v instanceof ArrayBuffer) return {__gjsifyBin:__binVal, type:t, data:__b64enc(new Uint8Array(v))};
+    if (v instanceof DataView)    return {__gjsifyBin:__binVal, type:'DataView', data:__b64enc(new Uint8Array(v.buffer, v.byteOffset, v.byteLength))};
+    var ta = v; return {__gjsifyBin:__binVal, type:t, data:__b64enc(new Uint8Array(ta.buffer, ta.byteOffset, ta.byteLength)), length:ta.length};
+  }
+  function __reconstruct(p){
+    var bytes = __b64dec(p.data);
+    switch (p.type) {
+      case 'ArrayBuffer': return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      case 'DataView':    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      case 'Uint8Array':  return bytes;
+      case 'Uint8ClampedArray': return new Uint8ClampedArray(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      case 'Int8Array':   return new Int8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      case 'Uint16Array': return new Uint16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'Int16Array':  return new Int16Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'Uint32Array': return new Uint32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'Int32Array':  return new Int32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'BigUint64Array': return new BigUint64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'BigInt64Array':  return new BigInt64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'Float32Array': return new Float32Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+      case 'Float64Array': return new Float64Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    }
+  }
+  function __isPlaceholder(v){ return v && typeof v==='object' && v[__binKey]===__binVal && typeof v.type==='string' && typeof v.data==='string'; }
+  function __encodeBin(v){
+    if (v === null || typeof v !== 'object') return v;
+    var c = __classOf(v);
+    if (__isBin(c)) return __mkPlaceholder(v);
+    if (Array.isArray(v)) { var o=[]; for (var i=0;i<v.length;i++) o[i]=__encodeBin(v[i]); return o; }
+    if (c==='Object') { var o={}; for (var k in v) if (Object.prototype.hasOwnProperty.call(v,k)) o[k]=__encodeBin(v[k]); return o; }
+    return v;
+  }
+  function __decodeBin(v){
+    if (v === null || typeof v !== 'object') return v;
+    if (__isPlaceholder(v)) return __reconstruct(v);
+    if (Array.isArray(v)) { for (var i=0;i<v.length;i++) v[i]=__decodeBin(v[i]); return v; }
+    if (__classOf(v)==='Object') { for (var k in v) if (Object.prototype.hasOwnProperty.call(v,k)) v[k]=__decodeBin(v[k]); return v; }
+    return v;
+  }
+`;

--- a/packages/framework/iframe/src/test.mts
+++ b/packages/framework/iframe/src/test.mts
@@ -2,5 +2,6 @@
 import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';
+import serializeSuite from './serialize.spec.js';
 
-run({ testSuite });
+run({ testSuite, serializeSuite });

--- a/packages/framework/iframe/src/test.mts
+++ b/packages/framework/iframe/src/test.mts
@@ -3,5 +3,6 @@ import { run } from '@gjsify/unit';
 
 import testSuite from './index.spec.js';
 import serializeSuite from './serialize.spec.js';
+import channelSuite from './iframe-message-channel.spec.js';
 
-run({ testSuite, serializeSuite });
+run({ testSuite, serializeSuite, channelSuite });


### PR DESCRIPTION
## Summary

Four improvements to the `@gjsify/iframe` GJS ↔ WebKit.WebView postMessage bridge. Addresses the limitations called out post-sab-native: typed-array support, real origin validation, navigation safety, MessagePort transferList. Independent of the sab-native PRs (#192 / #193).

## Changes

### 1. Binary payloads survive the JSON round-trip

The bridge moves payloads as JSON strings. Plain JSON drops typed arrays + ArrayBuffer to `{}` — binary content used to silently degrade.

New `serialize.ts` walks the value tree pre-stringify and substitutes each binary leaf with a `{__gjsifyBin: 'b64', type: 'Uint8Array', data: '<base64>'}` placeholder. Receiver walks back and reconstructs the original typed array, preserving constructor identity, byteLength, element count. Supported: ArrayBuffer, Uint8Array, Uint8ClampedArray, Int8Array, Uint16Array, Int16Array, Uint32Array, Int32Array, BigUint64Array, BigInt64Array, Float32Array, Float64Array, DataView. Nested in arrays + plain objects.

### 2. W3C-compliant `targetOrigin` checks

`MessageBridge.sendToWebView` validates the targetOrigin, parses to canonical origin via WHATWG URL, compares against the WebView's current `location.origin`, drops silently on mismatch. Bootstrap script (WebView side) does the symmetric check against a new `GJS_HOST_ORIGIN = 'https://gjsify.local'` constant. Receiver-side handler in GJS re-validates the envelope as defense-in-depth.

### 3. Bootstrap re-injection survives rapid reloads

Idempotency guard: `if (window.__gjsifyBridge?.__bridgeVersion === 1) return;` short-circuits the bootstrap IIFE if already installed. Prevents double-wrapping `window.postMessage` on rapid reload / srcdoc remount where WebKit re-injects the user script in the same window.

### 4. `IFrameMessagePort` / `IFrameMessageChannel` + transferList on `postMessage`

W3C-style MessagePort transfer. New classes:
- `IFrameMessageChannel` — pair of linked ports.
- `IFrameMessagePort` — EventTarget with `postMessage` / `start` / `close` / `addEventListener('message')` / `onmessage`.

Extended `IFrameWindowProxy.postMessage(msg, targetOrigin, transfer?)` to accept a port list. Each transferred port is detached locally; its surviving partner becomes the GJS-side endpoint of a bidirectional channel routed through the bridge. The WebView receives proxy ports under `MessageEvent.data` wherever the original ports appeared.

Wire protocol grew two new envelope kinds: `{__gjsifyPortMessage: id, payload}` for routed traffic and `{__gjsifyPortClose: id}` for teardown.

## Test plan

- [x] 11 binary round-trip cases (every supported typed-array type + nested + edge cases)
- [x] 8 `normaliseTargetOrigin` cases (`*` / `/` / URL / malformed / empty + `GJS_HOST_ORIGIN`)
- [x] 3 bootstrap idempotency cases (source marker + runtime simulation + origin filter)
- [x] 7 `IFrameMessageChannel` in-process cases (pair creation, bidirectional round-trip, implicit-start replay, close detach, idempotent start)
- [x] 189 → 220 tests, all green under GJS 1.86 (SM 140)

WebView-routed port cases (proxy port behavior on the WebView side, port placeholder substitution in the bootstrap, GJS↔WebView port round-trip) need a live WebKit.WebView and are covered by the bridge integration surface (not unit-testable without GTK).