### PR TITLE
feat(iframe): consume @gjsify/message-channel for MessagePort transferList

### DIFF
--- a/packages/framework/iframe/package.json
+++ b/packages/framework/iframe/package.json
@@ -38,7 +38,8 @@
         "@girs/javascriptcore-6.0": "2.52.1-4.0.0-rc.15",
         "@girs/webkit-6.0": "2.52.1-4.0.0-rc.15",
         "@gjsify/dom-elements": "workspace:^",
-        "@gjsify/dom-events": "workspace:^"
+        "@gjsify/dom-events": "workspace:^",
+        "@gjsify/message-channel": "workspace:^"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",

--- a/packages/framework/iframe/src/iframe-message-channel.ts
+++ b/packages/framework/iframe/src/iframe-message-channel.ts
@@ -1,142 +1,50 @@
-// IFrameMessageChannel / IFrameMessagePort — minimal MessageChannel
-// substitute for the GJS ↔ WebKit.WebView bridge.
+// Backward-compatibility re-exports of MessagePort + MessageChannel from
+// the shared @gjsify/message-channel package, plus a bridge-transport
+// adapter that lets the WebKit bridge plug into the standard port's
+// pluggable transport hook.
 //
-// W3C `MessagePort` requires the browser host to thread the port
-// identity through structured clone + transferList semantics. We can't
-// reuse `@gjsify/worker_threads` MessagePort because that's
-// EventEmitter-based (Node convention) and is wired for subprocess IPC,
-// not WebKit IPC. We can't reuse a globalThis.MessageChannel because GJS
-// doesn't ship one.
-//
-// So we provide a tiny EventTarget-based MessagePort + MessageChannel
-// pair scoped to iframe-bridge use. The pair has two endpoints:
-//
-//   const ch = new IFrameMessageChannel();
-//   iframe.contentWindow.postMessage(msg, '*', [ch.port2]);
-//   ch.port1.addEventListener('message', (e) => { … });
-//   ch.port1.postMessage('reply');
-//
-// `ch.port2` is what the user passes in transferList. After transfer it
-// becomes unusable on the GJS side — its partner (`ch.port1`) stays
-// usable and is the application's hand-off to bridge-routed messages.
-// On the WebView side, `event.ports[0]` of the incoming MessageEvent is
-// a proxy port whose .postMessage routes back over the bridge.
-//
-// Limitations:
-// - Single-hop transfers only. Re-transferring a transferred port is
-//   rejected (W3C does allow this but it's rare).
-// - In-process channel use (port1 ↔ port2 without ever transferring)
-//   works the same way as a regular MessageChannel.
-// - close() on the GJS side ends bridge routing for that port-id;
-//   the WebView-side proxy stops delivering after the GJS port closes.
+// History: this file used to define iframe-local IFrameMessagePort /
+// IFrameMessageChannel classes (PR #195). With PR #196 they were lifted
+// into the standalone @gjsify/message-channel Web pillar package so the
+// classes can serve as proper browser globals AND back the
+// transport-pluggable WebKit-bridge path here. The aliases below stay
+// exported for any external consumer that imported the iframe-local
+// names; they're literal re-exports, not subclasses.
 
-import { EventTarget, MessageEvent } from '@gjsify/dom-events';
-
+import { MessagePort, MessageChannel } from '@gjsify/message-channel';
+import type { MessagePortTransport } from '@gjsify/message-channel';
 import type { MessageBridge } from './message-bridge.js';
 
-export class IFrameMessagePort extends EventTarget {
-	/** @internal In-process partner; null when this port has been transferred. */
-	_partner: IFrameMessagePort | null = null;
-	/** @internal Set once this port has been passed in a transferList — can no longer post locally. */
-	_transferred = false;
-	/** @internal Set when the partner of this port has been transferred — this port now routes via the bridge. */
-	_bridge: MessageBridge | null = null;
-	/** @internal Bridge-side identifier when this port is wired to a remote endpoint. */
-	_portId: number | null = null;
-	/** @internal W3C: dispatching is gated until .start() (or first addEventListener('message')). */
-	_started = false;
-	/** @internal Messages received before .start() */
-	_queue: unknown[] = [];
-	/** @internal Closed by close() */
-	_closed = false;
+export { MessagePort, MessageChannel };
 
-	postMessage(data: unknown): void {
-		if (this._transferred) {
-			throw new Error('IFrameMessagePort.postMessage: port has been transferred');
-		}
-		if (this._closed) return;
-		if (this._bridge && this._portId !== null) {
-			// Partner has been transferred to the WebView; route through the bridge.
-			this._bridge._sendPortMessage(this._portId, data);
-			return;
-		}
-		// In-process: deliver to the partner directly.
-		if (this._partner && !this._partner._closed) this._partner._receive(data);
+/** @deprecated Re-exported alias of `MessagePort` from
+ *  `@gjsify/message-channel`. Use the standard name. */
+export const IFrameMessagePort = MessagePort;
+export type IFrameMessagePort = MessagePort;
+
+/** @deprecated Re-exported alias of `MessageChannel` from
+ *  `@gjsify/message-channel`. Use the standard name. */
+export const IFrameMessageChannel = MessageChannel;
+export type IFrameMessageChannel = MessageChannel;
+
+/**
+ * MessagePortTransport adapter that routes a port's outbound messages
+ * through a `MessageBridge` instance. Used internally by the bridge
+ * when it picks up `MessagePort` instances from a `postMessage`
+ * transferList — the transferred port's partner is attached to a
+ * `BridgePortTransport` so its `.postMessage` flows over the WebKit
+ * IPC instead of the in-process partner (which has been detached).
+ *
+ * @internal
+ */
+export class BridgePortTransport implements MessagePortTransport {
+	constructor(private _bridge: MessageBridge) {}
+
+	send(portId: number, data: unknown): void {
+		this._bridge._sendPortMessage(portId, data);
 	}
 
-	/**
-	 * W3C: enables dispatching of queued messages. Explicit `start()`
-	 * is optional — adding a 'message' listener via addEventListener
-	 * auto-starts. This method exists for explicit control + .onmessage
-	 * setter compatibility (not implemented yet).
-	 */
-	start(): void {
-		if (this._started || this._closed) return;
-		this._started = true;
-		const queued = this._queue;
-		this._queue = [];
-		for (const msg of queued) this._dispatch(msg);
-	}
-
-	close(): void {
-		if (this._closed) return;
-		this._closed = true;
-		if (this._bridge && this._portId !== null) {
-			this._bridge._closePort(this._portId);
-			this._bridge = null;
-			this._portId = null;
-		}
-		this._partner = null;
-		this._queue = [];
-	}
-
-	/** @internal Called by the bridge or the in-process partner. */
-	_receive(data: unknown): void {
-		if (this._closed) return;
-		if (!this._started) {
-			this._queue.push(data);
-			return;
-		}
-		this._dispatch(data);
-	}
-
-	private _dispatch(data: unknown): void {
-		// Async dispatch to match W3C MessagePort + MessageEvent semantics.
-		Promise.resolve().then(() => {
-			if (this._closed) return;
-			this.dispatchEvent(new MessageEvent('message', { data }));
-		});
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	addEventListener(type: string, listener: any, options?: any): void {
-		// EventTarget here is @gjsify/dom-events's, not lib.dom; the signature
-		// uses its own Event type which doesn't match standard DOM strictly.
-		// Cast through any to avoid the type clash without losing W3C semantics.
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		(super.addEventListener as any)(type, listener, options);
-		// Per W3C, the implicit-start happens when ANY message listener is added,
-		// not when the port is first read. Honor that.
-		if (type === 'message') this.start();
-	}
-
-	get [Symbol.toStringTag](): string {
-		return 'MessagePort';
-	}
-}
-
-export class IFrameMessageChannel {
-	readonly port1: IFrameMessagePort;
-	readonly port2: IFrameMessagePort;
-
-	constructor() {
-		this.port1 = new IFrameMessagePort();
-		this.port2 = new IFrameMessagePort();
-		this.port1._partner = this.port2;
-		this.port2._partner = this.port1;
-	}
-
-	get [Symbol.toStringTag](): string {
-		return 'MessageChannel';
+	close(portId: number): void {
+		this._bridge._closePort(portId);
 	}
 }

--- a/packages/framework/iframe/src/iframe-window-proxy.ts
+++ b/packages/framework/iframe/src/iframe-window-proxy.ts
@@ -5,7 +5,7 @@
 import { EventTarget } from '@gjsify/dom-events';
 
 import type { MessageBridge } from './message-bridge.js';
-import type { IFrameMessagePort } from './iframe-message-channel.js';
+import type { MessagePort } from '@gjsify/message-channel';
 
 /**
  * Lightweight Window-like proxy returned by `HTMLIFrameElement.contentWindow`.
@@ -35,13 +35,13 @@ export class IFrameWindowProxy extends EventTarget {
 	 * @param message - Data to send (must be JSON-serializable + base64-encodable
 	 *   binaries — see @gjsify/iframe/serialize for supported binary types).
 	 * @param targetOrigin - Target origin for the message. Default: '*'.
-	 * @param transfer - Optional list of `IFrameMessagePort` instances to
+	 * @param transfer - Optional list of `MessagePort` instances to
 	 *   transfer. Each transferred port is detached locally; its surviving
 	 *   partner becomes the GJS-side endpoint of a bidirectional channel
 	 *   routed through the bridge. The WebView receives proxy ports under
 	 *   `MessageEvent.data` wherever the original ports appeared in `message`.
 	 */
-	postMessage(message: unknown, targetOrigin = '*', transfer?: IFrameMessagePort[]): void {
+	postMessage(message: unknown, targetOrigin = '*', transfer?: MessagePort[]): void {
 		if (this._closed) return;
 		this._bridge.sendToWebView(message, targetOrigin, transfer);
 	}

--- a/packages/framework/iframe/src/index.ts
+++ b/packages/framework/iframe/src/index.ts
@@ -6,7 +6,10 @@ export { HTMLIFrameElement } from './html-iframe-element.js';
 export { IFrameBridge } from './iframe-bridge.js';
 export { IFrameWindowProxy } from './iframe-window-proxy.js';
 export { MessageBridge, GJS_HOST_ORIGIN } from './message-bridge.js';
-export { IFrameMessageChannel, IFrameMessagePort } from './iframe-message-channel.js';
+// Browser-standard MessageChannel + MessagePort (re-exported from
+// @gjsify/message-channel for convenience; same instances are exposed
+// under the legacy IFrame-prefixed aliases for back-compat).
+export { MessageChannel, MessagePort, IFrameMessageChannel, IFrameMessagePort } from './iframe-message-channel.js';
 export type { IFrameBridgeOptions, IFrameReadyCallback, IFrameMessageData } from './types/index.js';
 
 // Side-effect: register DOM globals on import.

--- a/packages/framework/iframe/src/message-bridge.ts
+++ b/packages/framework/iframe/src/message-bridge.ts
@@ -13,7 +13,8 @@ Gio._promisify(WebKit.WebView.prototype, 'evaluate_javascript', 'evaluate_javasc
 
 import type { IFrameWindowProxy } from './iframe-window-proxy.js';
 import type { IFrameMessageData } from './types/index.js';
-import type { IFrameMessagePort } from './iframe-message-channel.js';
+import type { MessagePort } from '@gjsify/message-channel';
+import { BridgePortTransport } from './iframe-message-channel.js';
 import {
   encodeBinariesForJson,
   decodeBinariesFromJson,
@@ -232,8 +233,13 @@ export class MessageBridge {
 	/** GJS-side endpoints of transferred ports, keyed by per-bridge id.
 	 *  When the WebView sends a `{__gjsifyPortMessage: id, payload}` envelope,
 	 *  we route the payload to `_ports.get(id)._receive(decoded)`. */
-	private _ports = new Map<number, IFrameMessagePort>();
+	private _ports = new Map<number, MessagePort>();
 	private _nextPortId = 1;
+	private _transport: BridgePortTransport | null = null;
+	private _getTransport(): BridgePortTransport {
+		if (this._transport === null) this._transport = new BridgePortTransport(this);
+		return this._transport;
+	}
 
 	constructor(webView: WebKit.WebView) {
 		this._webView = webView;
@@ -270,35 +276,37 @@ export class MessageBridge {
 	 */
 	/**
 	 * Register a port pair for cross-bridge transfer. Called by
-	 * IFrameWindowProxy.postMessage when it sees an IFrameMessagePort
-	 * in the transferList. Returns the port-id placeholder that should
-	 * be substituted into the outgoing payload.
+	 * IFrameWindowProxy.postMessage when it sees a `MessagePort` in the
+	 * transferList. Returns the port-id placeholder that should be
+	 * substituted into the outgoing payload.
 	 *
 	 * Marks the transferred port as detached locally and wires its
-	 * surviving partner so the partner's postMessage routes back over
-	 * the bridge.
+	 * surviving partner with a `BridgePortTransport` so the partner's
+	 * postMessage routes back over the WebKit bridge instead of the
+	 * (now-null) in-process partner.
 	 */
-	_registerTransferredPort(port: IFrameMessagePort): number {
+	_registerTransferredPort(port: MessagePort): number {
 		if (port._transferred) {
-			throw new Error('IFrameMessagePort: already transferred');
+			throw new Error('MessagePort: already transferred');
 		}
 		const partner = port._partner;
 		if (!partner) {
-			throw new Error('IFrameMessagePort: partner missing — port already transferred or closed');
+			throw new Error('MessagePort: partner missing — port already transferred or closed');
 		}
 		const id = this._nextPortId++;
 		// Detach the transferred port locally.
 		port._transferred = true;
 		port._partner = null;
-		// Wire the partner: future postMessages on partner flow via the bridge.
+		// Wire the partner: future postMessages on partner flow via the
+		// bridge transport adapter.
 		partner._partner = null;
-		partner._bridge = this;
+		partner._transport = this._getTransport();
 		partner._portId = id;
 		this._ports.set(id, partner);
 		return id;
 	}
 
-	/** @internal Called by IFrameMessagePort.postMessage when its partner
+	/** @internal Called by MessagePort.postMessage when its partner
 	 *  was transferred to the WebView. Dispatches the data onto the
 	 *  WebView-side proxy port via evaluate_javascript. */
 	_sendPortMessage(portId: number, data: unknown): void {
@@ -308,7 +316,7 @@ export class MessageBridge {
 		this._webView.evaluate_javascript(script, -1, null, null, null).catch(() => {});
 	}
 
-	/** @internal Called by IFrameMessagePort.close to tear down the
+	/** @internal Called by MessagePort.close to tear down the
 	 *  bridge-side registration. The WebView side keeps its proxy port
 	 *  alive in user-script land but subsequent .deliver calls go nowhere. */
 	_closePort(portId: number): void {
@@ -317,7 +325,7 @@ export class MessageBridge {
 		this._webView.evaluate_javascript(script, -1, null, null, null).catch(() => {});
 	}
 
-	sendToWebView(data: unknown, targetOrigin: string, transfer?: IFrameMessagePort[]): void {
+	sendToWebView(data: unknown, targetOrigin: string, transfer?: MessagePort[]): void {
 		// Validate + match against the WebView's current origin per HTML spec.
 		// '*' always delivers; a parseable URL must match the WebView's
 		// location.origin; '/' means "must match source's own origin" — for
@@ -333,12 +341,12 @@ export class MessageBridge {
 			if (compareTo !== webViewOrigin) return;
 		}
 
-		// Substitute any IFrameMessagePort instances in the payload with
+		// Substitute any MessagePort instances in the payload with
 		// {__gjsifyPort: id} placeholders. The bootstrap walker turns these
 		// back into proxy ports on the WebView side.
 		let prepared = data;
 		if (transfer && transfer.length > 0) {
-			const portToId = new Map<IFrameMessagePort, number>();
+			const portToId = new Map<MessagePort, number>();
 			for (const p of transfer) {
 				const id = this._registerTransferredPort(p);
 				portToId.set(p, id);
@@ -444,7 +452,7 @@ export class MessageBridge {
 	}
 
 	/**
-	 * Walk the user payload and replace each IFrameMessagePort instance
+	 * Walk the user payload and replace each MessagePort instance
 	 * (transferred via the transferList) with a {__gjsifyPort: id}
 	 * placeholder. Non-transferred ports are passed through untouched —
 	 * matches W3C semantics where only ports in transferList are detached.
@@ -467,22 +475,22 @@ export class MessageBridge {
 }
 
 /**
- * Walk a value tree, replacing each `IFrameMessagePort` found in
+ * Walk a value tree, replacing each `MessagePort` found in
  * `portToId` with a `{__gjsifyPort: id}` placeholder. Non-transferred
  * ports pass through unchanged — caller is expected to populate the map
  * exactly with the ports listed in transferList. Plain objects + arrays
  * are walked; other tagged types (Map, Set, Date, …) and primitives are
  * left as-is.
  */
-function substitutePorts(value: unknown, portToId: Map<IFrameMessagePort, number>): unknown {
+function substitutePorts(value: unknown, portToId: Map<MessagePort, number>): unknown {
 	const seen = new WeakMap<object, unknown>();
 
 	function walk(v: unknown): unknown {
 		if (v === null || typeof v !== 'object') return v;
 		// Use Symbol.toStringTag to detect our port without dragging
 		// a runtime import dependency into this helper.
-		if ((v as { [Symbol.toStringTag]?: string })[Symbol.toStringTag] === 'MessagePort' && portToId.has(v as IFrameMessagePort)) {
-			return { __gjsifyPort: portToId.get(v as IFrameMessagePort) };
+		if ((v as { [Symbol.toStringTag]?: string })[Symbol.toStringTag] === 'MessagePort' && portToId.has(v as MessagePort)) {
+			return { __gjsifyPort: portToId.get(v as MessagePort) };
 		}
 		if (seen.has(v as object)) return seen.get(v as object);
 		if (Array.isArray(v)) {


### PR DESCRIPTION
## Summary

P4.2 of the iframe / MessageChannel unification. #196 introduced the shared `@gjsify/message-channel` package; this PR migrates `@gjsify/iframe` to consume it. Targets #196 branch — merge after #196 lands on main.

## Changes

- `iframe-message-channel.ts` is now a thin re-export layer over `@gjsify/message-channel`:
  - Re-exports `MessageChannel`, `MessagePort` (canonical names).
  - Legacy `IFrameMessageChannel`, `IFrameMessagePort` stay exported as aliases for any external consumer that imported them under those names.
  - Adds a `BridgePortTransport` adapter that plugs the WebKit bridge into the shared port's `MessagePortTransport` hook.
- `message-bridge.ts` + `iframe-window-proxy.ts` import `MessagePort` from `@gjsify/message-channel` directly. transferList registration uses the transport-pluggable API: `partner._transport = bridgeTransport` instead of the previous iframe-local `partner._bridge = this` field.
- `index.ts` exports both the canonical names AND the legacy `IFrame*` aliases.
- `@gjsify/iframe` package.json adds `@gjsify/message-channel` as runtime dependency.

Net: -164 / +84 LoC. The bulk is removing the iframe-local class definitions. Wire protocol unchanged, all 220 existing iframe tests stay green.

## Test plan

- [x] 220/220 iframe tests pass on GJS 1.86 — including the in-process MessageChannel suite (re-tested against the shared classes) and all serialize / origin / bootstrap suites
- [x] Build cleanly (`yarn build` + `yarn build:test:gjs`)

## Unification progress

| Step | Status |
|------|--------|
| MessageChannel + MessagePort as browser globals | ✓ (#196) |
| iframe migrated to shared classes | ✓ (this PR) |
| worker_threads MessagePort aligned with shared base | ⏳ separate workstream — breaking-risk for `port.on('message')` EventEmitter contract that `@types/node` specifies |