### PR TITLE
fix(cli): flatpak init — gjsify.flatpak.name overrides display-name

### DIFF
--- a/packages/infra/cli/src/commands/flatpak/init.ts
+++ b/packages/infra/cli/src/commands/flatpak/init.ts
@@ -189,10 +189,10 @@ export const flatpakInitCommand: Command<unknown, FlatpakInitOptions> = {
         const manifestPath = resolve(cwd, manifestOut);
         writeIfFresh(manifestPath, JSON.stringify(manifest, null, 4) + '\n', args.force ?? false, 'manifest');
 
-        const name = (pkg.name as string | undefined) ?? appId;
+        const pkgName = (pkg.name as string | undefined) ?? appId;
         const scaffold: ScaffoldInputs = {
             appId,
-            name: friendlyName(name, appId),
+            name: flatpak.name ?? friendlyName(pkgName, appId),
             command,
             kind,
             flatpak,

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -243,6 +243,14 @@ export interface ConfigDataFlatpak {
      */
     kind?: 'app' | 'cli';
     /**
+     * App display name (`.desktop` `Name=` + MetaInfo `<name>`). Defaults
+     * to a friendly derivation of `package.json#name` — that works when
+     * `name` is the reverse-DNS app id, but breaks when it's an npm
+     * package name like `learn6502`. Set this explicitly to the
+     * human-readable name shown in app stores (e.g. `"Learn 6502 Assembly"`).
+     */
+    name?: string;
+    /**
      * Developer attribution required by Flathub. `id` must be reverse-DNS.
      * `email` (optional) becomes `<email>` inside `<developer>`.
      * `nameTranslatable: false` (default) emits `translate="no"` on the

--- a/tests/e2e/flatpak/run.mjs
+++ b/tests/e2e/flatpak/run.mjs
@@ -256,6 +256,7 @@ describe('CLI flatpak subcommand group E2E', { timeout: 10 * 60 * 1000 }, () => 
         flatpak: {
           appId: 'org.example.AppFull',
           kind: 'app',
+          name: 'App Full Title',
           developer: { id: 'org.example', name: 'Example Developer' },
           summary: 'A test desktop app',
           description: 'First paragraph here.\n\nSecond paragraph with <special> & "chars".',
@@ -299,9 +300,13 @@ describe('CLI flatpak subcommand group E2E', { timeout: 10 * 60 * 1000 }, () => 
     assert.match(metainfo, /scheme_preference="light">#5b81b8</);
     assert.match(metainfo, /<content_rating type="oars-1\.1"/);
 
+    // Display-name override lands in both MetaInfo + .desktop
+    assert.match(metainfo, /<name>App Full Title<\/name>/);
+
     // .desktop content sanity
     const desktop = readFileSync(desktopPath, 'utf-8');
     assert.match(desktop, /\[Desktop Entry\]/);
+    assert.match(desktop, /Name=App Full Title/);
     assert.match(desktop, /Exec=org\.example\.AppFull/);
     assert.match(desktop, /Icon=org\.example\.AppFull/);
     assert.match(desktop, /Categories=Utility;Development;/);

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -582,6 +582,7 @@ npx @gjsify/cli flatpak init --kind cli
 |---|---|---|
 | `appId` | both | Reverse-DNS. |
 | `kind` | both | `"app"` (default) or `"cli"`. |
+| `name` | optional | Human-readable display name for `<name>` + `.desktop` `Name=`. Defaults to a friendly derivation of `package.json#name` — set explicitly when the npm name doesn't match the display name (e.g. npm name `learn6502` vs display name `"Learn 6502 Assembly"`). |
 | `developer.id` / `developer.name` | metainfo | AppStream OARS 1.1+ requires `<developer id="…">`. |
 | `developer.email` | optional | Emits `<email>` inside `<developer>`. |
 | `developer.nameTranslatable` | optional | Default `false` → emits `translate="no"`. Set `true` for descriptive names. |


### PR DESCRIPTION
## Summary

`gjsify flatpak init` was deriving the MetaInfo `<name>` + `.desktop` `Name=` from a `friendlyName(pkgName, appId)` helper. That works when the npm package name matches the reverse-DNS app id (test fixtures do this), but breaks for real-world projects where they differ.

Surfaced while migrating [easy6502](https://github.com/JumpLink/easy6502) to use `gjsify flatpak init` — its `package.json#name` is `learn6502`, so the regenerated metainfo had `<name>learn6502</name>` instead of `<name>Learn 6502 Assembly</name>`.

## Fix

New optional `gjsify.flatpak.name` config field. When set, overrides the derived friendly name in both MetaInfo `<name>` and `.desktop` `Name=`. When unset, the existing derivation runs unchanged — full backwards compatibility.

## Test plan

- [x] e2e suite extended: existing `flatpak init --kind app with full config` test now passes `name: 'App Full Title'` and asserts it lands in both MetaInfo and .desktop. 14/14 green locally.
- [x] tsc clean.
- [x] CLI bundle refreshed.
- [ ] CI on this branch.

## Follow-up

Unblocks the easy6502 migration PR currently in flight (will pin `@gjsify/cli@^0.4.13` once this lands).