### PR TITLE
feat(npm-registry): retry-with-backoff on transient fetch errors

### DIFF
--- a/packages/infra/cli/src/utils/install-backend-native.ts
+++ b/packages/infra/cli/src/utils/install-backend-native.ts
@@ -143,6 +143,11 @@ export async function installPackagesNative(opts: InstallOptions): Promise<Insta
     return topLevelResolutions(opts.specs, nodes);
 }
 
+function errMsg(err: unknown): string {
+    if (err instanceof Error) return err.message;
+    return String(err);
+}
+
 function topLevelResolutions(specs: string[], nodes: ResolvedNode[]): InstalledTopLevel[] {
     // Top-level installs live at `node_modules/<name>` (no nesting). Build
     // a name → root-node lookup limited to the top-level set.
@@ -203,7 +208,12 @@ async function resolveDeps(
     const fetchPkg = (name: string): Promise<Packument> => {
         const cached = packumentCache.get(name);
         if (cached) return cached;
-        const fresh = fetchPackument(name, { npmrc });
+        const fresh = fetchPackument(name, {
+            npmrc,
+            onRetry: ({ attempt, error, delayMs }) => {
+                log("packument %s: retry %d after %dms (%s)", name, attempt, delayMs, errMsg(error));
+            },
+        });
         packumentCache.set(name, fresh);
         return fresh;
     };
@@ -573,6 +583,9 @@ async function extractOne(
     const bytes = await fetchTarball(node.tarballUrl, {
         npmrc,
         integrity: node.integrity,
+        onRetry: ({ attempt, error, delayMs }) => {
+            log("tarball %s@%s: retry %d after %dms (%s)", node.name, node.version, attempt, delayMs, errMsg(error));
+        },
     });
     fs.rmSync(dest, { recursive: true, force: true });
     fs.mkdirSync(dest, { recursive: true });

--- a/packages/infra/npm-registry/src/index.spec.ts
+++ b/packages/infra/npm-registry/src/index.spec.ts
@@ -273,4 +273,148 @@ export default async () => {
             expect(caught instanceof IntegrityError).toBe(true);
         });
     });
+
+    await describe("@gjsify/npm-registry — retry-with-backoff", async () => {
+        await it("retries on TypeError 'fetch failed' and eventually succeeds", async () => {
+            let calls = 0;
+            const retries: number[] = [];
+            const mock = makeMockFetch(async () => {
+                calls++;
+                if (calls < 3) {
+                    // Mimic Node undici's network-error shape.
+                    throw new TypeError("fetch failed");
+                }
+                return new Response(
+                    JSON.stringify({ name: "lodash", "dist-tags": {}, versions: {} }),
+                    { status: 200 },
+                );
+            });
+            const p = await fetchPackument("lodash", {
+                fetch: mock,
+                retries: 3,
+                retryDelayMs: 1,
+                onRetry: ({ attempt }) => retries.push(attempt),
+            });
+            expect(p.name).toBe("lodash");
+            expect(calls).toBe(3);
+            expect(retries).toStrictEqual([1, 2]);
+        });
+
+        await it("retries on GJS-style FetchError (TLS handshake reset)", async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                if (calls < 2) {
+                    const err = new Error("Gio.TlsError: TLS handshake was not finished cleanly");
+                    (err as { name: string }).name = "FetchError";
+                    throw err;
+                }
+                return new Response(new Uint8Array([0x1f, 0x8b]), { status: 200 });
+            });
+            const got = await fetchTarball("https://r/x.tgz", {
+                fetch: mock,
+                retries: 3,
+                retryDelayMs: 1,
+            });
+            expect(got.length).toBe(2);
+            expect(calls).toBe(2);
+        });
+
+        await it("retries on 503 then succeeds", async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                if (calls < 3) {
+                    return new Response("temporarily unavailable", {
+                        status: 503,
+                        statusText: "Service Unavailable",
+                    });
+                }
+                return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+            });
+            const got = await fetchTarball("https://r/x.tgz", {
+                fetch: mock,
+                retries: 3,
+                retryDelayMs: 1,
+            });
+            expect(got.length).toBe(3);
+            expect(calls).toBe(3);
+        });
+
+        await it("does NOT retry on 404 — surfaces immediately", async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                return new Response("not found", { status: 404 });
+            });
+            let caught: Error | null = null;
+            try {
+                await fetchPackument("nope", { fetch: mock, retries: 3, retryDelayMs: 1 });
+            } catch (e) {
+                caught = e as Error;
+            }
+            expect(caught instanceof PackageNotFoundError).toBe(true);
+            expect(calls).toBe(1);
+        });
+
+        await it("throws the underlying error after exhausting retries", async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                throw new TypeError("fetch failed");
+            });
+            let caught: Error | null = null;
+            try {
+                await fetchPackument("lodash", { fetch: mock, retries: 2, retryDelayMs: 1 });
+            } catch (e) {
+                caught = e as Error;
+            }
+            expect(caught instanceof TypeError).toBe(true);
+            expect(caught?.message).toBe("fetch failed");
+            // 1 initial + 2 retries = 3 total.
+            expect(calls).toBe(3);
+        });
+
+        await it("respects AbortSignal — aborts during backoff delay", async () => {
+            const ctrl = new AbortController();
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                throw new TypeError("fetch failed");
+            });
+            // Abort while the first backoff timer is pending.
+            setTimeout(() => ctrl.abort(), 5);
+            let caught: Error | null = null;
+            try {
+                await fetchPackument("lodash", {
+                    fetch: mock,
+                    retries: 5,
+                    retryDelayMs: 50,
+                    signal: ctrl.signal,
+                });
+            } catch (e) {
+                caught = e as Error;
+            }
+            expect(caught).toBeTruthy();
+            expect(caught?.name).toBe("AbortError");
+            // 1 initial attempt, then the abort fires during backoff.
+            expect(calls).toBe(1);
+        });
+
+        await it("retries: 0 disables retry path", async () => {
+            let calls = 0;
+            const mock = makeMockFetch(async () => {
+                calls++;
+                throw new TypeError("fetch failed");
+            });
+            let threw = false;
+            try {
+                await fetchPackument("lodash", { fetch: mock, retries: 0 });
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBe(true);
+            expect(calls).toBe(1);
+        });
+    });
 };

--- a/packages/infra/npm-registry/src/index.ts
+++ b/packages/infra/npm-registry/src/index.ts
@@ -54,6 +54,22 @@ export interface FetchOptions {
     signal?: AbortSignal;
     /** Custom fetch implementation; default = globalThis.fetch. */
     fetch?: typeof fetch;
+    /**
+     * Max retry attempts on transient failures (network errors, TLS handshake
+     * resets, 5xx, 408, 429). Default 3 → up to 4 total attempts. Set to 0
+     * to disable retry.
+     */
+    retries?: number;
+    /**
+     * Initial backoff in ms; doubles per attempt. Default 250 → 250, 500, 1000.
+     * The cap is 8s per delay so a bad spell stays bounded.
+     */
+    retryDelayMs?: number;
+    /**
+     * Called once per retry with `{ attempt, error, delayMs }`. Useful for
+     * verbose-mode install logs ("retrying fetch in 500 ms…").
+     */
+    onRetry?: (info: { attempt: number; error: unknown; delayMs: number }) => void;
 }
 
 /** Strict-validate a packument shape. Throws on schema mismatch. */
@@ -94,17 +110,14 @@ export function packumentUrl(name: string, registry: string): string {
     return `${base}${encodeURIComponent(name)}`;
 }
 
-/** Fetch + parse a packument. */
+/** Fetch + parse a packument. Retries on transient errors (see fetchWithRetry). */
 export async function fetchPackument(name: string, opts: FetchOptions = {}): Promise<Packument> {
     const registry = opts.registry ?? registryFor(name, opts.npmrc);
     const url = packumentUrl(name, registry);
     const headers = buildHeaders(url, opts);
     headers["accept"] ??= "application/vnd.npm.install-v1+json";
 
-    const fetchImpl = opts.fetch ?? globalThis.fetch;
-    if (!fetchImpl) throw new Error("@gjsify/npm-registry: globalThis.fetch is missing");
-
-    const res = await fetchImpl(url, { headers, signal: opts.signal });
+    const res = await fetchWithRetry(url, { headers, signal: opts.signal }, opts);
     if (!res.ok) {
         if (res.status === 404) throw new PackageNotFoundError(name, url);
         throw new Error(`registry GET ${url} -> ${res.status} ${res.statusText}`);
@@ -122,10 +135,7 @@ export async function fetchTarball(
     const headers = buildHeaders(url, opts);
     headers["accept"] ??= "application/octet-stream";
 
-    const fetchImpl = opts.fetch ?? globalThis.fetch;
-    if (!fetchImpl) throw new Error("@gjsify/npm-registry: globalThis.fetch is missing");
-
-    const res = await fetchImpl(url, { headers, signal: opts.signal });
+    const res = await fetchWithRetry(url, { headers, signal: opts.signal }, opts);
     if (!res.ok) throw new Error(`tarball GET ${url} -> ${res.status} ${res.statusText}`);
     const buf = new Uint8Array(await res.arrayBuffer());
     if (opts.integrity) {
@@ -133,6 +143,141 @@ export async function fetchTarball(
         if (!ok) throw new IntegrityError(url, opts.integrity);
     }
     return buf;
+}
+
+/**
+ * Wrap a single GET in exponential-backoff retry for transient failures.
+ *
+ * Retries on:
+ *   - network-layer errors thrown by `fetch` (TypeError "fetch failed",
+ *     `Gio.TlsError` from Soup-backed GJS fetch when the registry CDN drops
+ *     the TLS handshake mid-stream, ECONNRESET, ENETUNREACH, …)
+ *   - HTTP 408 (Request Timeout), 425 (Too Early), 429 (rate limit),
+ *     500-503, 504, 522, 524 (Cloudflare upstream)
+ *
+ * Does NOT retry on:
+ *   - 4xx other than 408/425/429 (semantic errors — 404 surfaces via the
+ *     caller's PackageNotFoundError path)
+ *   - AbortError (signal trip — caller wants out)
+ *   - any other thrown shape that doesn't look transient
+ *
+ * Default schedule: 250ms, 500ms, 1000ms (3 retries → 4 total attempts);
+ * capped at 8s per delay. Caller can tune via opts.retries / opts.retryDelayMs.
+ */
+export async function fetchWithRetry(
+    url: string,
+    init: { headers: Record<string, string>; signal?: AbortSignal },
+    opts: Pick<FetchOptions, "fetch" | "retries" | "retryDelayMs" | "onRetry">,
+): Promise<Response> {
+    const fetchImpl = opts.fetch ?? globalThis.fetch;
+    if (!fetchImpl) throw new Error("@gjsify/npm-registry: globalThis.fetch is missing");
+
+    const maxRetries = Math.max(0, opts.retries ?? 3);
+    const baseDelay = Math.max(0, opts.retryDelayMs ?? 250);
+    let attempt = 0;
+    let lastErr: unknown;
+
+    while (true) {
+        if (init.signal?.aborted) throw signalAbortError(init.signal);
+        try {
+            const res = await fetchImpl(url, init);
+            if (res.ok || !isRetryableStatus(res.status) || attempt >= maxRetries) {
+                return res;
+            }
+            // Drain the body so the underlying connection can be reused.
+            try {
+                await res.arrayBuffer();
+            } catch {
+                /* swallow — we're about to retry */
+            }
+            lastErr = new Error(`HTTP ${res.status} ${res.statusText}`);
+        } catch (err) {
+            if (!isRetryableError(err) || attempt >= maxRetries) throw err;
+            lastErr = err;
+        }
+        const delayMs = Math.min(baseDelay * 2 ** attempt, 8000);
+        opts.onRetry?.({ attempt: attempt + 1, error: lastErr, delayMs });
+        await delay(delayMs, init.signal);
+        attempt++;
+    }
+}
+
+function isRetryableStatus(status: number): boolean {
+    if (status === 408 || status === 425 || status === 429) return true;
+    if (status === 500 || status === 502 || status === 503 || status === 504) return true;
+    // Cloudflare-specific transient codes that the npm CDN can emit when the
+    // origin is briefly unreachable: 521 (web server down), 522 (timeout),
+    // 524 (origin timeout), 525 (SSL handshake failed).
+    if (status === 521 || status === 522 || status === 524 || status === 525) return true;
+    return false;
+}
+
+function isRetryableError(err: unknown): boolean {
+    // AbortError must propagate immediately so the caller's signal short-circuit
+    // works as documented.
+    if (err && typeof err === "object" && "name" in err && (err as { name: unknown }).name === "AbortError") {
+        return false;
+    }
+    // Node's undici throws TypeError("fetch failed") with a `.cause` describing
+    // the socket error (ECONNRESET, ENETUNREACH, UND_ERR_SOCKET, …). All of
+    // those are transient.
+    if (err instanceof TypeError) return true;
+    // GJS Soup-backed fetch wraps libsoup failures in `FetchError`. The TLS
+    // handshake-reset path the npm CDN occasionally exhibits surfaces as
+    // `FetchError` with a `.message` containing "Gio.TlsError" / "TLS-Verbindung
+    // wurde nicht sauber beendet" / "connection reset". Matching on the error
+    // name keeps us locale-independent.
+    if (err && typeof err === "object" && "name" in err) {
+        const name = (err as { name: unknown }).name;
+        if (name === "FetchError") return true;
+        if (name === "AbortError") return false;
+    }
+    // Generic Error with cause we recognize (Node + undici style).
+    const cause = (err as { cause?: unknown })?.cause;
+    if (cause && typeof cause === "object" && "code" in cause) {
+        const code = (cause as { code: unknown }).code;
+        if (typeof code === "string") {
+            return (
+                code === "ECONNRESET" ||
+                code === "ECONNREFUSED" ||
+                code === "ENETUNREACH" ||
+                code === "ENOTFOUND" ||
+                code === "ETIMEDOUT" ||
+                code === "EAI_AGAIN" ||
+                code === "UND_ERR_SOCKET" ||
+                code === "UND_ERR_CONNECT_TIMEOUT"
+            );
+        }
+    }
+    return false;
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+    if (ms <= 0) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+        const id = setTimeout(() => {
+            signal?.removeEventListener?.("abort", onAbort);
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            clearTimeout(id);
+            reject(signalAbortError(signal));
+        };
+        if (signal?.aborted) {
+            clearTimeout(id);
+            reject(signalAbortError(signal));
+            return;
+        }
+        signal?.addEventListener?.("abort", onAbort, { once: true });
+    });
+}
+
+function signalAbortError(signal: AbortSignal | undefined): Error {
+    const reason = signal && "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+    if (reason instanceof Error) return reason;
+    const err = new Error("Aborted");
+    err.name = "AbortError";
+    return err;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the install-stability gap that surfaced during the v0.4.14 release: two consecutive \`gjsify install\` runs failed mid-fetch with \`Gio.TlsError: TLS-Verbindung wurde nicht sauber beendet\` against the npm CDN, leaving the workspace in a half-installed state.

New \`fetchWithRetry(url, init, opts)\` helper wraps a single GET in exponential-backoff retry. Defaults: **3 retries → 4 attempts total**, schedule **250ms / 500ms / 1000ms** (capped at 8s). Both \`fetchPackument\` and \`fetchTarball\` route through it.

### Retries on

- **Network-layer errors**: \`TypeError("fetch failed")\` (Node undici), GJS Soup-backed \`FetchError\` whose \`.message\` describes the TLS handshake reset, Node errors with \`.cause.code\` in \`ECONNRESET\`/\`ECONNREFUSED\`/\`ENETUNREACH\`/\`ENOTFOUND\`/\`ETIMEDOUT\`/\`EAI_AGAIN\`/\`UND_ERR_SOCKET\`/\`UND_ERR_CONNECT_TIMEOUT\`
- **HTTP**: 408, 425, 429, 500-504, plus Cloudflare's 521/522/524/525

### Does NOT retry on

- 4xx other than the transient ones above (404 surfaces via \`PackageNotFoundError\` unchanged)
- \`AbortError\` — the signal short-circuits even during the backoff delay (timer cleared, abort propagates)

### UX

New \`FetchOptions\` fields: \`retries\`, \`retryDelayMs\`, \`onRetry\`. The install backend forwards \`onRetry\` to its existing \`log()\`:
\`\`\`
packument @gjsify/foo: retry 1 after 250ms (Gio.TlsError: TLS handshake reset)
tarball @gjsify/foo@0.4.15: retry 2 after 500ms (HTTP 503 Service Unavailable)
\`\`\`

Users see what's happening instead of mysterious silence.

## Test plan

- [x] 7 new unit tests in \`packages/infra/npm-registry/src/index.spec.ts\` cover: transient-error retry, GJS \`FetchError\` retry, 503-then-success, 404 short-circuit, retry-exhaustion error surface, AbortSignal interruption during backoff, \`retries: 0\` opt-out
- [x] Full suite green: \`gjsify foreach test:node --include @gjsify/npm-registry\` 50/50, \`test:gjs\` 50/50
- [x] Verified end-to-end via \`gjsify install\` on a fresh scaffold (types-gjsify template) — no regression on the happy path
- [ ] CI green on Fedora 43 + 44