### PR TITLE
fix(examples): mark cli-axios-http-client as private (AGENTS.md convention)

### DIFF
--- a/examples/node/cli-axios-http-client/package.json
+++ b/examples/node/cli-axios-http-client/package.json
@@ -3,6 +3,7 @@
     "description": "axios HTTP client demo for Node.js and GJS — starts a local server and makes GET/POST/error/timeout/concurrent requests",
     "version": "0.4.15",
     "type": "module",
+    "private": true,
     "engines": {
         "node": ">=22.12.0"
     },


### PR DESCRIPTION
## Summary

Per AGENTS.md *"Example convention"*: every package under `examples/` is dev/test-only — `"private": true`, not published to npm. The recently-added `cli-axios-http-client` example was missing the flag (only one of 53 example packages without it), so the `npm:publish` workflow (which already uses `gjsify foreach --no-private --exclude '@girs/*'`) tried to publish it.

The npm registry has been returning a persistent 404 on PUT to that specific package — likely an NPM_TOKEN scope mismatch — which blocked the entire v0.4.15 publish chain (`@gjsify/cli` and all other `@gjsify/*` packages stayed at v0.4.14 on npm despite a successful release commit + GitHub release).

Adding `"private": true` aligns this example with the documented convention, lets the existing `--no-private` filter skip it cleanly, and unblocks the rest of the publish.

## Test plan

- [x] `grep '"private": true'` across all `examples/*/package.json` shows 53/53 marked private after the fix
- [ ] After merge: re-run the Release-to-NPM workflow against v0.4.15 — `@gjsify/cli@0.4.15` should land on npm
- [ ] Verify `npm view @gjsify/cli version` returns `0.4.15`