### PR TITLE
ci(release): allow asset (re)upload via workflow_dispatch + skip_publish toggle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,27 @@ name: Release to NPM
 on:
   release:
     types: [published]
-  # Allow manual triggering for testing
+  # Manual reruns. Two scenarios:
+  #   1. Re-publish + (re-)upload assets for a real existing release whose
+  #      original `release`-event run didn't finish (e.g. asset upload was
+  #      skipped because an earlier manual rerun trampled the release
+  #      context). Pass the tag in `release_tag`; the workflow checks out
+  #      that tag, rebuilds, and uploads the assets to the named release.
+  #      Defaults to skip_publish=true so npm isn't republished (already
+  #      done by the original run).
+  #   2. Ad-hoc smoke test from main with no release attached. Leave
+  #      `release_tag` empty.
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to use for commit message'
+        description: 'Existing release tag to (re)upload assets to (e.g. v0.4.15). Leave empty for a no-op dispatch from main.'
         required: false
-        default: 'manual'
+        default: ''
+      skip_publish:
+        description: 'Skip the npm publish step (default true — re-uploads are for fixing missing release assets; npm side already published).'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   publish:
@@ -30,8 +44,13 @@ jobs:
       - name: Install container prerequisites
         run: dnf install -y git tar xz findutils meson vala gcc pkgconf gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel libadwaita-devel blueprint-compiler
 
+      # `release` event auto-checks-out the tag. `workflow_dispatch` with a
+      # `release_tag` input must explicitly target that tag so the rebuilt
+      # bundle + install.mjs match what shipped (not main HEAD).
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -50,7 +69,12 @@ jobs:
       - name: Build examples
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run build:examples
 
+      # Publish to npm on the `release` event (always) and on
+      # workflow_dispatch only when the operator explicitly opts in by
+      # toggling skip_publish off. Re-running an existing release should
+      # leave npm alone (each version is published exactly once).
       - name: Publish packages to npm
+        if: ${{ github.event_name == 'release' || inputs.skip_publish == false }}
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run npm:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -60,17 +84,28 @@ jobs:
       # users can bootstrap gjsify (or any gjsify-based GJS app) with a single
       # `curl ... | gjs -m -` line, no npm/Node required. The bundle was
       # rebuilt above by `gjsify run build` (executes build:gjs-bundle).
+      #
+      # Asset upload fires on the original `release` event and on manual
+      # reruns that target a specific tag — the second path is the fix for
+      # the v0.4.15 incident (release-event run failed, the manual reruns
+      # that followed silently skipped the upload because the original
+      # gate was hard-pinned to `event_name == 'release'`).
       - name: Generate cli.gjs.mjs.sha256
-        if: github.event_name == 'release'
+        if: ${{ github.event_name == 'release' || inputs.release_tag != '' }}
         run: |
           cd packages/infra/cli/dist
           sha256sum cli.gjs.mjs | awk '{print $1}' > cli.gjs.mjs.sha256
           cat cli.gjs.mjs.sha256
 
       - name: Upload installer + bootstrap bundle to GitHub release
-        if: github.event_name == 'release'
+        if: ${{ github.event_name == 'release' || inputs.release_tag != '' }}
         uses: softprops/action-gh-release@v2
         with:
+          # On `release` softprops infers tag_name from the event payload.
+          # On `workflow_dispatch` we must pass it explicitly so the action
+          # targets the operator-specified tag instead of attempting to
+          # create a new release from HEAD.
+          tag_name: ${{ github.event.release.tag_name || inputs.release_tag }}
           files: |
             install.mjs
             packages/infra/cli/dist/cli.gjs.mjs
@@ -78,7 +113,7 @@ jobs:
 
       - name: Summary
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag || 'manual' }}
         run: |
           echo "Packages successfully published to npm for release ${RELEASE_TAG}"
           echo "Published packages: @gjsify/*"


### PR DESCRIPTION
## Summary

The v0.4.15 release shipped with **0 GitHub-release assets**, breaking every downstream consumer that fetches `releases/latest/download/install.mjs` (ts-for-gir CI in particular). Root cause: the original `release`-event run failed, manual reruns via `workflow_dispatch` silently skipped the upload step because it was hard-gated to `github.event_name == 'release'`. This PR makes the upload step reusable from `workflow_dispatch` so the same incident can be fixed in-CI next time, without `gh release upload` from a maintainer's laptop.

## Changes

1. **Drop the hard `event_name == 'release'` gate** on the sha256 generation + softprops upload steps. They now fire on the release event AND on any `workflow_dispatch` run that names an `inputs.release_tag` — the explicit signal "this rerun targets an existing release".

2. **`actions/checkout` ref**: under `workflow_dispatch` with a tag, check out that tag instead of `main` HEAD. Without this, the rebuilt `cli.gjs.mjs` would diverge from the npm-published tarballs for that version.

3. **`tag_name`** passed explicitly to `softprops/action-gh-release`. Required for the dispatch path — without an event payload softprops would attempt to create a new release from HEAD instead of attaching to the named tag.

4. **`skip_publish` input** (default `true`). Manual reruns don't accidentally re-publish to npm. Each version publishes exactly once; operators rerun for asset fixes, not npm fixes. Set to `false` only if the operator genuinely wants to redo the npm side.

## Rerun procedure

For a release that shipped without assets:

```bash
gh workflow run release.yml -f release_tag=v0.4.15
```

This checks out v0.4.15, rebuilds, skips `npm publish` (already done), and uploads `install.mjs` + `cli.gjs.mjs` + `cli.gjs.mjs.sha256` to the v0.4.15 release page.

## v0.4.15 hotfix

The missing assets were already uploaded by hand via `gh release upload v0.4.15 …` to unblock ts-for-gir CI immediately — verified `curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs` now returns 200. This PR is the durable fix so the next release-event failure doesn't need a manual hotfix.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` clean.
- [x] Diff scope: only `.github/workflows/release.yml`, +41/-6.
- [ ] After merge: dry-run `gh workflow run release.yml -f release_tag=v0.4.15` to confirm the dispatch path uploads to the existing release without creating a new one. (Won't add new files since they already exist on v0.4.15 from the hotfix; softprops with `update_existing` default behavior is a no-op there.)

## Companion work

- gjsify#226 — CLI launcher native-env paths (unrelated, in flight).
- ts-for-gir#399 — ts-for-gir launcher fix (was blocked by this asset gap; unblocked by the manual upload).
- ts-for-gir#400 — README detail restore (unblocked by the manual upload).