### PR TITLE
feat(cli): gjsify publish --trusted (npm Trusted Publishing via OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,27 @@ name: Release to NPM
 on:
   release:
     types: [published]
-  # Allow manual triggering for testing
+  # Manual reruns. Two scenarios:
+  #   1. Re-publish + (re-)upload assets for a real existing release whose
+  #      original `release`-event run didn't finish (e.g. asset upload was
+  #      skipped because an earlier manual rerun trampled the release
+  #      context). Pass the tag in `release_tag`; the workflow checks out
+  #      that tag, rebuilds, and uploads the assets to the named release.
+  #      Defaults to skip_publish=true so npm isn't republished (already
+  #      done by the original run).
+  #   2. Ad-hoc smoke test from main with no release attached. Leave
+  #      `release_tag` empty.
   workflow_dispatch:
     inputs:
       release_tag:
-        description: 'Release tag to use for commit message'
+        description: 'Existing release tag to (re)upload assets to (e.g. v0.4.15). Leave empty for a no-op dispatch from main.'
         required: false
-        default: 'manual'
+        default: ''
+      skip_publish:
+        description: 'Skip the npm publish step (default true — re-uploads are for fixing missing release assets; npm side already published).'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   publish:
@@ -30,8 +44,13 @@ jobs:
       - name: Install container prerequisites
         run: dnf install -y git tar xz findutils meson vala gcc pkgconf gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel libadwaita-devel blueprint-compiler
 
+      # `release` event auto-checks-out the tag. `workflow_dispatch` with a
+      # `release_tag` input must explicitly target that tag so the rebuilt
+      # bundle + install.mjs match what shipped (not main HEAD).
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -50,7 +69,12 @@ jobs:
       - name: Build examples
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run build:examples
 
+      # Publish to npm on the `release` event (always) and on
+      # workflow_dispatch only when the operator explicitly opts in by
+      # toggling skip_publish off. Re-running an existing release should
+      # leave npm alone (each version is published exactly once).
       - name: Publish packages to npm
+        if: ${{ github.event_name == 'release' || inputs.skip_publish == false }}
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run npm:publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -60,17 +84,28 @@ jobs:
       # users can bootstrap gjsify (or any gjsify-based GJS app) with a single
       # `curl ... | gjs -m -` line, no npm/Node required. The bundle was
       # rebuilt above by `gjsify run build` (executes build:gjs-bundle).
+      #
+      # Asset upload fires on the original `release` event and on manual
+      # reruns that target a specific tag — the second path is the fix for
+      # the v0.4.15 incident (release-event run failed, the manual reruns
+      # that followed silently skipped the upload because the original
+      # gate was hard-pinned to `event_name == 'release'`).
       - name: Generate cli.gjs.mjs.sha256
-        if: github.event_name == 'release'
+        if: ${{ github.event_name == 'release' || inputs.release_tag != '' }}
         run: |
           cd packages/infra/cli/dist
           sha256sum cli.gjs.mjs | awk '{print $1}' > cli.gjs.mjs.sha256
           cat cli.gjs.mjs.sha256
 
       - name: Upload installer + bootstrap bundle to GitHub release
-        if: github.event_name == 'release'
+        if: ${{ github.event_name == 'release' || inputs.release_tag != '' }}
         uses: softprops/action-gh-release@v2
         with:
+          # On `release` softprops infers tag_name from the event payload.
+          # On `workflow_dispatch` we must pass it explicitly so the action
+          # targets the operator-specified tag instead of attempting to
+          # create a new release from HEAD.
+          tag_name: ${{ github.event.release.tag_name || inputs.release_tag }}
           files: |
             install.mjs
             packages/infra/cli/dist/cli.gjs.mjs
@@ -78,7 +113,7 @@ jobs:
 
       - name: Summary
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.release_tag || 'unknown' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag || 'manual' }}
         run: |
           echo "Packages successfully published to npm for release ${RELEASE_TAG}"
           echo "Published packages: @gjsify/*"


### PR DESCRIPTION
## Summary

Adds OIDC token exchange to `gjsify publish` so the `@gjsify/*` + companion release workflows can drop their long-lived `NPM_TOKEN` automation secrets in favour of [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers).

Triggered by npm's recent advisory: *"As a precaution to help prevent further supply chain attacks following the pattern of 'Mini Shai-Hulud' we are rotating npm granular access tokens with write access that bypass 2FA."*

## Flow

Two-step OIDC exchange, mirroring `refs/npm-cli/lib/utils/oidc.js`:

1. `GET $ACTIONS_ID_TOKEN_REQUEST_URL?audience=npm:<registry-host>` with the runner's bearer → returns a GitHub OIDC JWT.
2. `POST $REGISTRY/-/npm/v1/oidc/token/exchange/package/<escaped-name>` with that JWT → returns a short-lived (~5min) npm publish token.

The short-lived token replaces the long-lived NPM_TOKEN in the publish PUT's `Authorization` header — drop-in, no other changes to the request shape.

## Caller modes

| Flag | Behavior |
|---|---|
| `--trusted` | Force OIDC; fail loudly if env vars missing |
| (no flag) | **Auto-detect**: OIDC iff `ACTIONS_ID_TOKEN_REQUEST_URL`+`_TOKEN` are set AND no `NODE_AUTH_TOKEN` is exported (preserves explicit-token opt-in) |
| `--check-trusted` | Diagnostic — exchange + report, skip pack + PUT. Designed for bulk verification via `gjsify foreach publish --check-trusted` |

## Two typed error classes

- `OidcUnavailableError` — "OIDC isn't an option here" (missing env, GitHub non-2xx, missing JWT). Auto-detect falls back to token auth.
- `OidcExchangeError` — "OIDC was attempted and npm rejected the identity" (typically a Trusted Publisher misconfig). Fails loudly with a pointer at the package's `/access` settings page.

## Test plan

- [x] All 114 unit tests pass (`yarn run test` in `packages/infra/cli`)
- [x] 17 new tests in `src/npm-oidc.spec.ts`: env-var probing, GitHub id-token GET shape (URL + audience + Bearer), npm exchange POST shape (escaped scoped name, Bearer-id-token header, trailing-slash normalization), full chained flow, audience derivation for self-hosted registries, every error path (missing env, GitHub non-2xx, missing `.value`, npm 4xx, malformed response, no `.token`)
- [x] `tsc --noEmit` clean
- [ ] After merge + v0.4.16 release: switch `release.yml` (and the ts-for-gir companion) from `NODE_AUTH_TOKEN` to OIDC and verify all 102 hand-configured Trusted Publishers actually publish

## Follow-ups (separate PRs)

1. Update `gjsify/release.yml` to use OIDC (drop `NODE_AUTH_TOKEN`)
2. Update `ts-for-gir/release-app.yml` to use OIDC (drop `NODE_AUTH_TOKEN`, keep `NPM_TOKEN_GIRS` for `release-types.yml`)
3. After 30 days of clean OIDC publishes: delete the temporary `NPM_TOKEN` GitHub secret in the `gjsify/gjsify` repo