### PR TITLE
ci: verify-trusted-publishers workflow for bulk Trusted Publisher audit

### DIFF
--- a/.github/workflows/verify-trusted-publishers.yml
+++ b/.github/workflows/verify-trusted-publishers.yml
@@ -1,0 +1,96 @@
+name: Verify Trusted Publishers
+
+# Manual on-demand workflow to verify that every published @gjsify/* package
+# has a working Trusted Publisher configuration on npmjs.com. Runs
+# `gjsify foreach publish --check-trusted` inside a GitHub Actions runner
+# (so the OIDC env vars are available) and reports which packages exchange
+# the OIDC id-token for an npm publish token vs. which 4xx — the latter
+# indicates a missing or misconfigured Trusted Publisher entry.
+#
+# Trigger: gh workflow run verify-trusted-publishers.yml
+# (or via the Actions UI). The workflow exits 0 either way — read the
+# log for the `✓` / `✗` lines per package. Set the `strict` input to
+# true if you want CI to also fail on misconfigured packages.
+
+on:
+  workflow_dispatch:
+    inputs:
+      strict:
+        description: "Fail the workflow when any package reports a misconfigured Trusted Publisher."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  verify:
+    name: Verify Trusted Publishers
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:43
+    permissions:
+      # `id-token: write` is the load-bearing permission — without it,
+      # ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN env vars are not injected by
+      # the runner and `gjsify publish --check-trusted` falls back to
+      # `OidcUnavailableError(no-env)`.
+      id-token: write
+
+    steps:
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils meson vala gcc pkgconf gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel libadwaita-devel blueprint-compiler
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies (gjsify install --immutable)
+        run: gjs -m packages/infra/cli/dist/cli.gjs.mjs install --immutable
+
+      - name: Verify Trusted Publishers across all @gjsify/* packages
+        id: check
+        env:
+          GJSIFY_PUBLISH_DEBUG: "1"
+        run: |
+          set -o pipefail
+          PATH="$PWD/node_modules/.bin:$PATH"             gjsify foreach -v --no-private               --exclude '@girs/*'               --exclude '@gjsify/example-node-cli-axios-http-client'               --exec -- gjsify publish --check-trusted             2>&1 | tee /tmp/check-trusted.log
+
+          # Per-package report — count `✗` lines from --check-trusted output.
+          # `gjsify foreach` prefixes child stdout with `[<workspace>]`,
+          # so we grep both with and without the prefix.
+          MISCONFIGURED=$(grep -cE "(^|\] )✗ " /tmp/check-trusted.log || true)
+          OK=$(grep -cE "(^|\] )✓ " /tmp/check-trusted.log || true)
+          SKIPPED=$(grep -cE "(^|\] )- " /tmp/check-trusted.log || true)
+
+          echo "ok=$OK"             >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED"   >> "$GITHUB_OUTPUT"
+          echo "misconfigured=$MISCONFIGURED" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Trusted Publisher verification"
+            echo ""
+            echo "| Status | Count |"
+            echo "|---|---|"
+            echo "| ✓ Configured     | $OK |"
+            echo "| ✗ Misconfigured  | $MISCONFIGURED |"
+            echo "| - Skipped (private) | $SKIPPED |"
+            echo ""
+            if [ "$MISCONFIGURED" -gt 0 ]; then
+              echo "### Misconfigured packages"
+              echo ""
+              echo '```'
+              grep -E "(^|\] )✗ " /tmp/check-trusted.log || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail on misconfigured packages (strict mode)
+        if: ${{ inputs.strict && steps.check.outputs.misconfigured != '0' }}
+        env:
+          MISCONFIGURED: ${{ steps.check.outputs.misconfigured }}
+        run: |
+          echo "::error::${MISCONFIGURED} package(s) have a missing or misconfigured Trusted Publisher — see step summary"
+          exit 1


### PR DESCRIPTION
## Summary

Adds a workflow_dispatch-only workflow that uses the new `gjsify publish --check-trusted` (shipped in v0.4.16 via #230) to audit every published `@gjsify/*` package's Trusted Publisher configuration in one click.

## How to use

```
gh workflow run verify-trusted-publishers.yml
```

The workflow runs `gjsify foreach --no-private --exclude '@girs/*' --exec -- gjsify publish --check-trusted` and emits a GitHub Step Summary like:

| Status | Count |
|---|---|
| ✓ Configured | 104 |
| ✗ Misconfigured | 0 |
| - Skipped (private) | 47 |

Misconfigured packages appear in an expandable section with the exact npm error response, so the operator can click straight to the package's `/access` page and fix it.

## Why workflow_dispatch only

The OIDC env vars (`ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) are only injected by the runner when the workflow has `permissions: id-token: write` AND the workflow itself runs in CI. This is exactly the GitHub Actions context that `gjsify publish --trusted` mimics during a real publish.

By default the workflow exits 0 regardless of result (read the summary) — pass `strict=true` to fail CI on any `✗`.

## Test plan

- [ ] Trigger via `gh workflow run verify-trusted-publishers.yml`
- [ ] Verify Step Summary shows `✓ 104 / ✗ 0` (all 104 `@gjsify/*` packages currently published)
- [ ] If any `✗` appears: open the package's npmjs.com `/access` page, add a Trusted Publisher for `gjsify/gjsify` + `release.yml`, re-run the workflow