### PR TITLE
ci(release): drop NODE_AUTH_TOKEN — switch to npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,11 +122,20 @@ jobs:
       # Publish to npm on the `release` event (always) or on
       # workflow_dispatch with skip_publish=false. Never runs in
       # `verify_only` mode — that path is a pure audit.
+      # Authentication mode: npm Trusted Publishing (OIDC). `gjsify publish`
+      # auto-detects the GitHub Actions OIDC env vars (the workflow has
+      # `id-token: write` above) and, with no NODE_AUTH_TOKEN present,
+      # exchanges the runner-minted JWT at npm's
+      # `/-/npm/v1/oidc/token/exchange/package/<name>` endpoint for a
+      # short-lived publish token per package. The 104 stable @gjsify/*
+      # packages have Trusted Publisher entries configured for this
+      # repo + workflow on npmjs.com (verified via the `verify_only`
+      # audit before this cutover). Long-lived `NPM_TOKEN` secret can
+      # be removed once a real OIDC release completes successfully.
       - name: Publish packages to npm
         if: ${{ (github.event_name == 'release' || inputs.skip_publish == false) && inputs.verify_only != true }}
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run npm:publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GJSIFY_PUBLISH_DEBUG: "1"
 
       # Phase F: ship install.mjs + cli.gjs.mjs as GitHub-release assets so end


### PR DESCRIPTION
## Summary

Removes the `NODE_AUTH_TOKEN` env var from `release.yml`'s publish step. `gjsify publish` then auto-detects OIDC mode and exchanges the GitHub Actions id-token for a short-lived npm publish token per package. End of long-lived NPM_TOKEN automation secrets for the gjsify/gjsify repo.

## Audit result (104/104)

Verified via `gh workflow run release.yml -f verify_only=true` (run 26188291064):

| Status              | Count |
|---------------------|-------|
| ✓ Configured        | 104   |
| ✗ Misconfigured     | 0     |
| - Skipped (private) | 0     |

## Out of scope

- `gjsify/ts-for-gir release-app.yml` (@ts-for-gir/* + @gi.ts/*) — separate workflow + repo; needs its own OIDC switch PR after the same verification process is run there.
- `gjsify/ts-for-gir release-types.yml` (@girs/* — ~700 packages) — stays on the scoped `NPM_TOKEN_GIRS` automation token; per-package Trusted Publisher setup isn't feasible at that scale.

## Test plan

- [ ] Merge this PR
- [ ] Run release-it patch to ship v0.4.17 — first OIDC-published version
- [ ] Verify all 104 packages reach npm at v0.4.17
- [ ] After 1-2 OIDC releases prove clean: delete the temporary `NPM_TOKEN` GitHub secret from the gjsify/gjsify repo