### PR TITLE
fix(child_process): set STDIN_INHERIT for stdio:'inherit'

### DIFF
--- a/packages/node/child_process/src/index.ts
+++ b/packages/node/child_process/src/index.ts
@@ -545,7 +545,15 @@ export function spawn(
       ? [stdioOpt, stdioOpt, stdioOpt]
       : ['pipe', 'pipe', 'pipe'];
   let flags = Gio.SubprocessFlags.NONE;
+  // stdin asymmetry vs stdout/stderr: Gio.Subprocess defaults stdin to
+  // /dev/null when neither STDIN_PIPE nor STDIN_INHERIT is set, while
+  // stdout/stderr default to *inherited* (only PIPE / SILENCE flip them).
+  // So `stdio: 'inherit'` must explicitly request STDIN_INHERIT — without
+  // it, TTY-aware children (release-it / enquirer prompts, password
+  // readers, …) see closed stdin and bail with "0 null" before any user
+  // input is possible.
   if (stdioTriple[0] === 'pipe') flags |= Gio.SubprocessFlags.STDIN_PIPE;
+  else if (stdioTriple[0] === 'inherit') flags |= Gio.SubprocessFlags.STDIN_INHERIT;
   if (stdioTriple[1] === 'pipe') flags |= Gio.SubprocessFlags.STDOUT_PIPE;
   if (stdioTriple[1] === 'ignore') flags |= Gio.SubprocessFlags.STDOUT_SILENCE;
   if (stdioTriple[2] === 'pipe') flags |= Gio.SubprocessFlags.STDERR_PIPE;


### PR DESCRIPTION
## Summary

`Gio.Subprocess` has asymmetric stdin handling vs stdout/stderr: when neither `STDIN_PIPE` nor `STDIN_INHERIT` is set, the child's stdin is redirected to `/dev/null`. stdout/stderr default to inherited (only `PIPE` / `SILENCE` flip them) — but stdin defaults to closed.

The previous impl mapped `stdio: 'inherit'` to `flags = NONE`, which is what `/dev/null` produces. TTY-aware children (release-it / enquirer prompts, password readers, anything reading interactively) then see closed stdin and bail with `User force closed the prompt with 0 null` before any user input is possible — even though the parent was running in a real TTY.

## Reproducer

```
cd <any repo with release-it>
gjsify run release
```

Right after the first prompt is rendered:

```
? Commit (chore: release vX.Y.Z)? (Y/n) Rolling back changes...
ERROR User force closed the prompt with 0 null
```

After this fix, prompts receive keypresses normally and the release completes interactively.

## Fix

Emit `STDIN_INHERIT` for the `'inherit'` case. stdout/stderr semantics unchanged (their defaults already match Node).

```ts
if (stdioTriple[0] === 'pipe')         flags |= STDIN_PIPE;
else if (stdioTriple[0] === 'inherit') flags |= STDIN_INHERIT;  // ← new
```

## Test plan

- [x] `tsc --noEmit` clean on `@gjsify/child_process`.
- [x] Manually verified by running `gjsify run release` against a project using release-it interactive prompts (the same case that broke v4.0.0-rc.16 and v0.4.17 release attempts).
- [ ] Existing `child_process.spec.ts` should still pass under `gjsify run test:gjs`.