### PR TITLE
fix(cli): default FORCE_COLOR=1 for spawned scripts

### DIFF
--- a/packages/infra/cli/src/commands/foreach.ts
+++ b/packages/infra/cli/src/commands/foreach.ts
@@ -367,11 +367,18 @@ function spawnPrefixed(
     cwd: string,
     prefix: string | null,
 ): Promise<void> {
+    // Default FORCE_COLOR=1 unless the user explicitly opted out, so tools
+    // that key on `process.stdout.isTTY` (chalk, picocolors, …) still emit
+    // ANSI colors when run under gjsify foreach. Mirrors yarn / npm.
+    const colorEnv =
+        process.env.FORCE_COLOR !== undefined || process.env.NO_COLOR !== undefined
+            ? {}
+            : { FORCE_COLOR: '1' };
     return new Promise((resolve, reject) => {
         const child = spawn(cmd, args, {
             cwd,
             stdio: prefix ? ['ignore', 'pipe', 'pipe'] : 'inherit',
-            env: process.env,
+            env: { ...process.env, ...colorEnv },
         });
         if (prefix && child.stdout && child.stderr) {
             prefixLines(child.stdout, process.stdout, prefix);

--- a/packages/infra/cli/src/commands/run.ts
+++ b/packages/infra/cli/src/commands/run.ts
@@ -113,8 +113,20 @@ async function runScript(script: string, extraArgs: readonly string[]): Promise<
     if (monorepoRoot && monorepoRoot !== cwd) {
         binDirs.push(join(monorepoRoot, 'node_modules', '.bin'));
     }
+    // Default FORCE_COLOR=1 when not already set, matching yarn / npm
+    // script-runner behaviour. Without this, tools that check
+    // `process.stdout.isTTY` (chalk, picocolors, biome, …) disable colors
+    // whenever the child's stdout is piped — including GitHub Actions
+    // (stdout is always a pipe there, but the GHA log viewer renders ANSI
+    // fine). Respect user overrides: FORCE_COLOR=0 or NO_COLOR keeps
+    // colors off.
+    const colorEnv =
+        process.env.FORCE_COLOR !== undefined || process.env.NO_COLOR !== undefined
+            ? {}
+            : { FORCE_COLOR: '1' };
     const env = {
         ...process.env,
+        ...colorEnv,
         PATH: [...binDirs, process.env.PATH ?? ''].filter(Boolean).join(delimiter),
         npm_lifecycle_event: script,
         npm_package_name: pkg.name ?? '',

--- a/packages/infra/cli/src/commands/workspace.ts
+++ b/packages/infra/cli/src/commands/workspace.ts
@@ -56,11 +56,20 @@ export const workspaceCommand: Command<any, WorkspaceCmdOptions> = {
         const argv = runner === 'gjsify'
             ? ['run', args.script, ...(args.args ?? [])]
             : ['run', args.script, ...(args.args && args.args.length > 0 ? ['--', ...args.args] : [])];
+        // Default FORCE_COLOR=1 unless the user explicitly opted out (matches
+        // yarn / npm / gjsify run behaviour) — without this, tools that key
+        // on isTTY (chalk, picocolors, biome) drop colors when stdout is a
+        // pipe, including GitHub Actions where the log viewer renders ANSI
+        // fine.
+        const colorEnv =
+            process.env.FORCE_COLOR !== undefined || process.env.NO_COLOR !== undefined
+                ? {}
+                : { FORCE_COLOR: '1' };
         await new Promise<void>((resolve, reject) => {
             const child = spawn(runner, argv, {
                 cwd: target.location,
                 stdio: 'inherit',
-                env: process.env,
+                env: { ...process.env, ...colorEnv },
             });
             child.on('close', (code) => {
                 if (code === 0) resolve();

--- a/packages/node/util/src/extended.spec.ts
+++ b/packages/node/util/src/extended.spec.ts
@@ -473,7 +473,23 @@ export default async () => {
   await describe('util.styleText', async () => {
     await it('returns plain text when stream is not a TTY', async () => {
       // Default options: validateStream=true, stream=process.stdout (no isTTY in test runtime).
-      expect(util.styleText('red', 'hello')).toBe('hello');
+      // Save + clear FORCE_COLOR / NO_COLOR for the duration of the assertion —
+      // gjsify's `gjsify run` / `foreach` / `workspace` now default FORCE_COLOR=1
+      // for spawned scripts (yarn-style) so that CI logs keep their color
+      // highlighting, but that override would otherwise make Node-compatible
+      // `styleText` emit ANSI even on non-TTY streams (correctly mirroring
+      // Node's own behaviour) — which contradicts what this test is asserting
+      // about the validateStream-default-on path.
+      const prevForce = process.env.FORCE_COLOR;
+      const prevNo = process.env.NO_COLOR;
+      delete process.env.FORCE_COLOR;
+      delete process.env.NO_COLOR;
+      try {
+        expect(util.styleText('red', 'hello')).toBe('hello');
+      } finally {
+        if (prevForce !== undefined) process.env.FORCE_COLOR = prevForce;
+        if (prevNo !== undefined) process.env.NO_COLOR = prevNo;
+      }
     });
 
     await it('wraps text in ANSI codes when validateStream=false', async () => {


### PR DESCRIPTION
## Summary

Yarn and npm script runners both set `FORCE_COLOR=1` when launching `package.json` scripts, so that tools using chalk / picocolors / biome's color-auto still emit ANSI even when stdout is a pipe. gjsify's own runners (`gjsify run` / `foreach` / `workspace`) didn't carry this convention — which is why GitHub Actions logs went monochrome the moment a project moved from `yarn install + yarn run` to `gjsify install + gjsify run`.

GHA's stdout is always a pipe, but the GHA log viewer renders ANSI fine. So the right default is *force-on unless the user explicitly opts out*.

## Reproducer

Reported by user: after switching ts-for-gir CI from yarn to gjsify (Phase F.5), the GitHub Actions output lost all color highlighting that tools like biome / TypeScript / TypeDoc would normally emit. Local terminal output is unaffected (those have a real TTY).

## Fix

Three spawn sites updated:

| Site | Description |
|---|---|
| `commands/run.ts` | `gjsify run <script>` package.json scripts |
| `commands/foreach.ts` | multi-workspace iteration |
| `commands/workspace.ts` | single-workspace shortcut |

Each defaults `FORCE_COLOR=1` only when **neither** `FORCE_COLOR` nor `NO_COLOR` is already set, so existing overrides (`NO_COLOR=1` for accessibility, `FORCE_COLOR=0` for diff-friendly CI logs) keep working.

```ts
const colorEnv =
    process.env.FORCE_COLOR !== undefined || process.env.NO_COLOR !== undefined
        ? {}
        : { FORCE_COLOR: '1' };
const env = { ...process.env, ...colorEnv, … };
```

## What's NOT touched

- gjsify's own internal logging — that path was already TTY-aware via `process.stdout.isTTY`, which now works correctly in real terminals after the launcher env-path fix from #226 + #228.
- `gjsify build` / `install` — no child-script spawns; they emit gjsify's own output directly.

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] After merge: spot-check that ts-for-gir + gjsify CI workflow logs show colored output again (biome, typescript, etc).