### PR TITLE
fix(release): drop actions/setup-node registry-url for OIDC mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,21 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
 
+      # OIDC mode: no `registry-url` here. When set, actions/setup-node
+      # injects `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` as a literal
+      # placeholder into the job env so the generated .npmrc has SOME
+      # token reference to expand. That placeholder leaks into every
+      # subprocess as a non-empty NODE_AUTH_TOKEN, which `gjsify publish`
+      # auto-detect (`!process.env.NODE_AUTH_TOKEN`) then interprets as
+      # "user opted into token auth" and skips OIDC — defeating the
+      # entire Trusted Publishing setup. Dropping `registry-url` makes
+      # setup-node not write the placeholder npmrc; gjsify publish reads
+      # the registry from the package's own `publishConfig.registry`
+      # (or DEFAULT_REGISTRY) and authenticates via OIDC exchange.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org'
 
       # Phase D.7d: Node-free install via the committed GJS bundle.
       # Mirrors main.yml — see that workflow for rationale.


### PR DESCRIPTION
## Bug

First OIDC publish (v0.4.18 release run) failed because actions/setup-node@v6 with \`registry-url\` injects \`NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX\` as a literal placeholder env. That leaks into every subprocess as a non-empty NODE_AUTH_TOKEN, and \`gjsify publish\` auto-detect treats any non-empty token as opt-in to token-auth — skipping OIDC entirely.

Run 26191202204:
\`\`\`
PUT /@gjsify%2fcanvas2d-core (@gjsify/canvas2d-core@0.4.18)
  authorization: (set)
  auth-mode:     token       ← should have been \`oidc\`
→ 404 Not Found
\`\`\`

## Fix

Drop \`registry-url: 'https://registry.npmjs.org'\` from the setup-node step. gjsify publish doesn't need the generated .npmrc — it constructs the registry URL from \`publishConfig.registry\` or \`DEFAULT_REGISTRY\` and authenticates via OIDC.

## Recovery

After this PR merges:

\`\`\`bash
gh workflow run release.yml -f release_tag=v0.4.18 -f skip_publish=false
\`\`\`

That re-runs publish for the v0.4.18 release using the new (fixed) workflow file from main. \`gjsify publish\` auto-detect should now pick OIDC mode for all 104 packages.