### PR TITLE
fix(release-it): preRelease=false so /releases/latest resolves correctly

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -8,7 +8,7 @@
   "github": {
     "release": true,
     "releaseName": "v${version}",
-    "preRelease": true,
+    "preRelease": false,
     "autoGenerate": false
   },
   "npm": {


### PR DESCRIPTION
## Why

Every release-it patch we've shipped marked the GitHub release as a Pre-release because \`.release-it.json\` had \`github.preRelease: true\` — a leftover from the v0.4.0-pre phase. We've been on stable v0.4.x for a while.

## Impact

GitHub's \`releases/latest/download/<asset>\` redirect resolves to the most-recent **non**-prerelease tag. Every consumer that bootstraps via \`curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs\` was getting a 2-3 versions-back install.mjs / cli.gjs.mjs — manifesting as e.g. \`Unknown argument: trusted\` in ts-for-gir's release-app.yml CI log, even though npm's dist-tag \`latest\` was already at v0.4.18.

## Fix

Flip \`github.preRelease: false\`. Next release-it run produces a stable release by default, so \`releases/latest/...\` resolves correctly.

(Manually marked v0.4.18 as Latest on github.com to unblock the immediate ts-for-gir publish retry; this PR removes the bug source itself.)