### PR TITLE
ci(release): bump softprops/action-gh-release v2 → v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload installer + bootstrap bundle to GitHub release
         if: ${{ (github.event_name == 'release' || inputs.release_tag != '') && inputs.verify_only != true }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # On `release` softprops infers tag_name from the event payload.
           # On `workflow_dispatch` we must pass it explicitly so the action


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning emitted by every release workflow run:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: softprops/action-gh-release@v2. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

v3 (released 2026-04-12) runs on Node 24 — drop-in version bump, same inputs (\`tag_name\`, \`files\`).