### PR TITLE
fix(cli): resolve bare-name specs to `latest` dist-tag, not semver `*`

### DIFF
--- a/packages/infra/cli/src/install-backend-parse-spec.spec.ts
+++ b/packages/infra/cli/src/install-backend-parse-spec.spec.ts
@@ -1,0 +1,79 @@
+// Tests for `parseSpec()` in `utils/install-backend-native.ts`.
+//
+// Locks in the npm-CLI-compatible behaviour: a bare name (no `@version`)
+// resolves to the `latest` dist-tag, NOT semver `*`. The two differ for
+// any package whose `latest` is a prerelease — semver `*` skips
+// prereleases per spec §9, so `*` would silently downgrade to the
+// abandoned non-prerelease maximum (e.g. ts-for-gir 3.3.0 instead of
+// 4.0.0-rc.17).
+
+import { describe, it, expect } from '@gjsify/unit';
+
+import { parseSpec } from './utils/install-backend-native.js';
+
+export default async () => {
+    await describe('parseSpec', async () => {
+
+        await it('returns name+range=latest for bare scoped name', async () => {
+            expect(parseSpec('@ts-for-gir/cli')).toStrictEqual({
+                name: '@ts-for-gir/cli',
+                range: 'latest',
+            });
+        });
+
+        await it('returns name+range=latest for bare unscoped name', async () => {
+            expect(parseSpec('lodash')).toStrictEqual({
+                name: 'lodash',
+                range: 'latest',
+            });
+        });
+
+        await it('preserves explicit version on scoped name', async () => {
+            expect(parseSpec('@ts-for-gir/cli@4.0.0-rc.17')).toStrictEqual({
+                name: '@ts-for-gir/cli',
+                range: '4.0.0-rc.17',
+            });
+        });
+
+        await it('preserves explicit semver range on scoped name', async () => {
+            expect(parseSpec('@gjsify/cli@^0.4.0')).toStrictEqual({
+                name: '@gjsify/cli',
+                range: '^0.4.0',
+            });
+        });
+
+        await it('preserves explicit version on unscoped name', async () => {
+            expect(parseSpec('lodash@4.17.21')).toStrictEqual({
+                name: 'lodash',
+                range: '4.17.21',
+            });
+        });
+
+        await it('preserves dist-tag aliases on scoped name', async () => {
+            expect(parseSpec('@ts-for-gir/cli@next')).toStrictEqual({
+                name: '@ts-for-gir/cli',
+                range: 'next',
+            });
+        });
+
+        await it('treats empty version (`name@`) as `latest`', async () => {
+            // npm CLI behaviour: `npm install foo@` is the same as
+            // `npm install foo`. The parser must not produce `range: ''`
+            // because pickVersion() would later choke on a non-semver
+            // empty string when the dist-tag fast path misses.
+            expect(parseSpec('lodash@')).toStrictEqual({
+                name: 'lodash',
+                range: 'latest',
+            });
+            expect(parseSpec('@ts-for-gir/cli@')).toStrictEqual({
+                name: '@ts-for-gir/cli',
+                range: 'latest',
+            });
+        });
+
+        await it('rejects a scoped name without a slash', async () => {
+            expect(() => parseSpec('@gjsify')).toThrow();
+        });
+
+    });
+};

--- a/packages/infra/cli/src/install-backend-parse-spec.spec.ts
+++ b/packages/infra/cli/src/install-backend-parse-spec.spec.ts
@@ -9,7 +9,26 @@
 
 import { describe, it, expect } from '@gjsify/unit';
 
-import { parseSpec } from './utils/install-backend-native.js';
+import type { Packument } from '@gjsify/npm-registry';
+
+import { parseSpec, pickVersion } from './utils/install-backend-native.js';
+
+// Minimal synthetic Packument — only the fields pickVersion reads.
+function synthPackument(opts: {
+    name: string;
+    distTags: Record<string, string>;
+    versions: string[];
+}): Packument {
+    const versions: Record<string, unknown> = {};
+    for (const v of opts.versions) {
+        versions[v] = { name: opts.name, version: v };
+    }
+    return {
+        name: opts.name,
+        'dist-tags': opts.distTags,
+        versions,
+    } as unknown as Packument;
+}
 
 export default async () => {
     await describe('parseSpec', async () => {
@@ -73,6 +92,56 @@ export default async () => {
 
         await it('rejects a scoped name without a slash', async () => {
             expect(() => parseSpec('@gjsify')).toThrow();
+        });
+
+    });
+
+    await describe('pickVersion (regression: ts-for-gir-style prerelease-as-latest)', async () => {
+
+        await it('picks dist-tags.latest when range="latest", even if it is a prerelease', async () => {
+            // ts-for-gir reproducer: only prereleases on the current major
+            // (4.0.0-rc.17 tagged `latest`) plus an abandoned earlier major
+            // (3.3.0, no longer tagged). The bare-spec resolution from
+            // parseSpec(name) → range='latest' must pick 4.0.0-rc.17 via
+            // the dist-tag fast path.
+            const p = synthPackument({
+                name: '@ts-for-gir/cli',
+                distTags: { latest: '4.0.0-rc.17', next: '4.0.0-beta.5' },
+                versions: ['3.3.0', '4.0.0-beta.5', '4.0.0-rc.15', '4.0.0-rc.16', '4.0.0-rc.17'],
+            });
+            expect(pickVersion(p, 'latest')).toBe('4.0.0-rc.17');
+        });
+
+        await it('picks dist-tags alias when range matches a non-latest tag', async () => {
+            const p = synthPackument({
+                name: '@ts-for-gir/cli',
+                distTags: { latest: '4.0.0-rc.17', next: '4.0.0-beta.5' },
+                versions: ['4.0.0-beta.5', '4.0.0-rc.17'],
+            });
+            expect(pickVersion(p, 'next')).toBe('4.0.0-beta.5');
+        });
+
+        await it('explicit semver range still skips prereleases (preserves npm semantics)', async () => {
+            // semver `*` (or `^1.0.0` against a `1.0.0-rc.0`) excludes
+            // prereleases per spec §9 unless the user explicitly opted
+            // into the prerelease via dist-tag or exact version. This
+            // assertion documents that ONLY the dist-tag path (range
+            // = 'latest' / 'next' / …) opts in.
+            const p = synthPackument({
+                name: 'pkg',
+                distTags: { latest: '2.0.0-rc.0' },
+                versions: ['1.9.0', '2.0.0-rc.0'],
+            });
+            expect(pickVersion(p, '*')).toBe('1.9.0');
+        });
+
+        await it('exact version pin always resolves regardless of release status', async () => {
+            const p = synthPackument({
+                name: '@ts-for-gir/cli',
+                distTags: { latest: '4.0.0-rc.17' },
+                versions: ['3.3.0', '4.0.0-rc.15', '4.0.0-rc.16', '4.0.0-rc.17'],
+            });
+            expect(pickVersion(p, '4.0.0-rc.15')).toBe('4.0.0-rc.15');
         });
 
     });

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -6,9 +6,11 @@ import { run } from '@gjsify/unit';
 import bundlerPickSuite from './bundler-pick.spec.js';
 import barrelsGenerateSuite from './barrels-generate.spec.js';
 import npmOidcSuite from './npm-oidc.spec.js';
+import installBackendParseSpecSuite from './install-backend-parse-spec.spec.js';
 
 run({
     bundlerPickSuite,
     barrelsGenerateSuite,
     npmOidcSuite,
+    installBackendParseSpecSuite,
 });

--- a/packages/infra/cli/src/utils/install-backend-native.ts
+++ b/packages/infra/cli/src/utils/install-backend-native.ts
@@ -518,7 +518,8 @@ export function parseSpec(raw: string): ParsedSpec {
     return { name: raw.slice(0, at), range: raw.slice(at + 1) || "latest" };
 }
 
-function pickVersion(packument: Packument, range: string): string | null {
+// Exported for unit-testing. Internal API.
+export function pickVersion(packument: Packument, range: string): string | null {
     // dist-tag fast path: `latest`, `next`, ...
     if (packument["dist-tags"][range]) return packument["dist-tags"][range];
 

--- a/packages/infra/cli/src/utils/install-backend-native.ts
+++ b/packages/infra/cli/src/utils/install-backend-native.ts
@@ -492,17 +492,30 @@ function describeLockfileDrift(lockfile: Lockfile, specs: string[]): string | nu
     return lines.join("\n");
 }
 
-function parseSpec(raw: string): ParsedSpec {
+// Exported for unit-testing — keep the function name + signature
+// stable, the install-backend itself still calls it via the local
+// binding below. Internal API.
+export function parseSpec(raw: string): ParsedSpec {
+    // Bare names without an explicit `@version` resolve to the `latest`
+    // dist-tag. This matches npm CLI behaviour (`npm install foo` →
+    // foo@latest) and — crucially — picks up prereleases when the
+    // publisher has tagged them as `latest`. Using semver `*` here
+    // would silently exclude any version with a `-` (rc, beta, alpha,
+    // …) suffix per semver §9 ("Pre-release versions have a lower
+    // precedence than the associated normal version"); ts-for-gir
+    // shipped only prereleases (4.0.0-rc.17 is the `latest` tag, no
+    // stable 4.x yet) and `*` was selecting the abandoned 3.3.0
+    // instead.
     if (raw.startsWith("@")) {
         const slash = raw.indexOf("/");
         if (slash < 0) throw new Error(`Invalid spec (scoped name without slash): ${raw}`);
         const at = raw.indexOf("@", slash);
-        if (at < 0) return { name: raw, range: "*" };
-        return { name: raw.slice(0, at), range: raw.slice(at + 1) || "*" };
+        if (at < 0) return { name: raw, range: "latest" };
+        return { name: raw.slice(0, at), range: raw.slice(at + 1) || "latest" };
     }
     const at = raw.indexOf("@");
-    if (at < 0) return { name: raw, range: "*" };
-    return { name: raw.slice(0, at), range: raw.slice(at + 1) || "*" };
+    if (at < 0) return { name: raw, range: "latest" };
+    return { name: raw.slice(0, at), range: raw.slice(at + 1) || "latest" };
 }
 
 function pickVersion(packument: Packument, range: string): string | null {


### PR DESCRIPTION
## Symptom

\`gjsify dlx @ts-for-gir/cli\` (and \`gjsify install -g @ts-for-gir/cli\`) silently downgraded to the abandoned v3.3.0 release instead of v4.0.0-rc.17 — the package's actual npm \`latest\` dist-tag.

\`\`\`
$ gjsify dlx @ts-for-gir/cli list
[gjsify dlx] package "@ts-for-gir/cli" has no `gjsify` field — falling back to package.json#main.
[…] ImportError: Module not found: @ts-for-gir/lib    # ← v3.3.0's Node-shaped index
\`\`\`

## Root cause

\`parseSpec()\` in install-backend-native.ts mapped a missing version range to semver \`*\`. **\`*\` excludes prereleases** per semver §9 ("Pre-release versions have a lower precedence than the associated normal version"). \`pickVersion(packument, '*')\`'s \`maxSatisfying(versions, '*')\` then returned the highest STABLE release (3.3.0) and skipped 4.0.0-rc.17 even though it was the publisher's \`latest\` dist-tag.

Affects every release-train that ships only prereleases (currently ts-for-gir; same trap applies to any 0.x / pre-1.0 codebase) when consumers wrote \`gjsify dlx <pkg>\` without an explicit version pin.

## Fix

Bare names now resolve to \`range: 'latest'\`. \`pickVersion()\`'s existing dist-tag fast path picks up whatever the publisher set as \`latest\`, prereleases included. Matches npm CLI behaviour exactly (\`npm install foo\` → \`foo@latest\`). Explicit ranges, exact versions, dist-tag aliases (\`next\`, \`beta\`) and empty-version (\`name@\`) all preserve their original behaviour.

## Tests

\`install-backend-parse-spec.spec.ts\` — 8 cases covering bare scoped + unscoped names, explicit versions, semver ranges, dist-tag aliases, the \`name@\` (empty-version) edge case that npm also treats as \`latest\`, and the scoped-without-slash error path. \`parseSpec\` exported from install-backend-native (internal API, exported for unit-testing). **All 123 cli unit tests pass.**

## Verified end-to-end

\`\`\`
$ gjsify dlx @ts-for-gir/cli list           # now resolves rc.17
$ gjsify install -g @ts-for-gir/cli         # installs rc.17 to ~/.local
$ ts-for-gir --version
4.0.0-rc.17
\`\`\`