### PR TITLE
feat(website): coverage bars — STATUS.md Summary as visual progress bars

### DIFF
--- a/website/src/components/CoverageBars.astro
+++ b/website/src/components/CoverageBars.astro
@@ -1,0 +1,249 @@
+---
+// Visualisation of gjsify's per-category API coverage.
+//
+// Source data lives in `src/data/coverage.ts` (mirrors STATUS.md Summary).
+// Each row renders as a stacked progress bar (Full / Partial / Stub) with
+// the percentage of Full coverage as the headline number, the absolute
+// counts on hover, and an optional note (used for categories like
+// Showcases where "Full count" is the interesting number, not the %).
+//
+// The aggregate "Across all categories" footer line gives a one-glance
+// answer to "how complete is gjsify?".
+
+import { coverageRows, totalsAcrossCategories } from "../data/coverage.ts";
+
+const totals = totalsAcrossCategories();
+const aggregateFullPct = Math.round((totals.full / totals.total) * 100);
+---
+
+<section class="coverage">
+	<h2 class="coverage-title">API coverage</h2>
+	<p class="coverage-subtitle">
+		Per-category implementation state. <strong>Full</strong> = every API surface that the consumer reaches works; <strong>Partial</strong> = core surface works, specific subsystems missing or behind a fallback; <strong>Stub</strong> = exists so dependency checks resolve, no-op on use.
+	</p>
+
+	<div class="coverage-rows">
+		{coverageRows.map((row) => {
+			const fullPct = (row.full / row.total) * 100;
+			const partialPct = (row.partial / row.total) * 100;
+			const stubPct = (row.stub / row.total) * 100;
+			const fullPctRounded = Math.round(fullPct);
+			return (
+				<div class="coverage-row">
+					<div class="coverage-row-head">
+						<span class="coverage-row-label">{row.category}</span>
+						<span class="coverage-row-headline">
+							{fullPctRounded === 100 ? (
+								<span class="coverage-row-headline-full">{row.full} / {row.total}</span>
+							) : (
+								<>
+									<span class="coverage-row-headline-pct">{fullPctRounded}%</span>
+									<span class="coverage-row-headline-sub">{row.full} / {row.total}</span>
+								</>
+							)}
+						</span>
+					</div>
+					<div
+						class="coverage-bar"
+						role="img"
+						aria-label={`${row.category}: ${row.full} full, ${row.partial} partial, ${row.stub} stub`}
+					>
+						{row.full > 0 && (
+							<span
+								class="coverage-seg coverage-seg-full"
+								style={`width: ${fullPct}%`}
+								title={`Full: ${row.full}`}
+							/>
+						)}
+						{row.partial > 0 && (
+							<span
+								class="coverage-seg coverage-seg-partial"
+								style={`width: ${partialPct}%`}
+								title={`Partial: ${row.partial}`}
+							/>
+						)}
+						{row.stub > 0 && (
+							<span
+								class="coverage-seg coverage-seg-stub"
+								style={`width: ${stubPct}%`}
+								title={`Stub: ${row.stub}`}
+							/>
+						)}
+					</div>
+					{row.note && <p class="coverage-row-note">{row.note}</p>}
+				</div>
+			);
+		})}
+	</div>
+
+	<div class="coverage-aggregate">
+		<span class="coverage-aggregate-label">Across all categories</span>
+		<span class="coverage-aggregate-headline">{aggregateFullPct}%</span>
+		<span class="coverage-aggregate-sub">{totals.full} of {totals.total} packages at Full coverage · {totals.partial} Partial · {totals.stub} Stub</span>
+	</div>
+</section>
+
+<style is:global>
+	.coverage {
+		max-width: 900px;
+		margin-inline: auto;
+		padding-block: clamp(2rem, 5vw, 4rem);
+		padding-inline: 1.5rem;
+	}
+
+	.coverage-title {
+		font-size: clamp(1.5rem, 3vw, 2rem);
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		margin: 0 0 0.75rem;
+		color: var(--sl-color-white);
+	}
+
+	.coverage-subtitle {
+		color: var(--sl-color-gray-2);
+		font-size: 0.95rem;
+		line-height: 1.55;
+		margin: 0 0 2rem;
+	}
+
+	.coverage-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+	}
+
+	.coverage-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.coverage-row-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.coverage-row-label {
+		font-weight: 600;
+		color: var(--sl-color-white);
+		font-size: 1rem;
+	}
+
+	.coverage-row-headline {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.coverage-row-headline-pct {
+		font-weight: 700;
+		font-size: 1.05rem;
+		color: var(--sl-color-accent);
+	}
+
+	.coverage-row-headline-full {
+		font-weight: 700;
+		font-size: 1.05rem;
+		color: #26a269;
+	}
+
+	.coverage-row-headline-sub {
+		color: var(--sl-color-gray-3);
+		font-size: 0.85rem;
+	}
+
+	/* The bar itself — stacked horizontal segments. */
+	.coverage-bar {
+		display: flex;
+		width: 100%;
+		height: 12px;
+		background: var(--sl-color-bg-nav);
+		border: 1px solid var(--adw-card-border);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+
+	.coverage-seg {
+		display: block;
+		height: 100%;
+		transition: opacity 0.15s;
+	}
+
+	.coverage-seg:hover {
+		opacity: 0.85;
+	}
+
+	.coverage-seg-full    { background: #26a269; }     /* GNOME green */
+	.coverage-seg-partial { background: #e5a50a; }     /* GNOME yellow */
+	.coverage-seg-stub    { background: var(--sl-color-gray-4); }
+
+	.coverage-row-note {
+		margin: 0;
+		font-size: 0.85rem;
+		color: var(--sl-color-gray-3);
+		font-style: italic;
+	}
+
+	/* --- Aggregate footer --- */
+	.coverage-aggregate {
+		margin-top: 2.5rem;
+		padding: 1.5rem;
+		border-radius: var(--adw-border-radius);
+		border: 1px solid var(--adw-card-border);
+		background: linear-gradient(180deg, var(--sl-color-accent-low) 0%, var(--sl-color-bg-nav) 80%);
+		display: grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: auto auto;
+		gap: 0.1rem 1rem;
+		align-items: center;
+	}
+
+	.coverage-aggregate-label {
+		grid-column: 1;
+		grid-row: 1 / 3;
+		font-weight: 600;
+		color: var(--sl-color-white);
+		font-size: 1.05rem;
+	}
+
+	.coverage-aggregate-headline {
+		grid-column: 2;
+		grid-row: 1;
+		font-weight: 800;
+		font-size: clamp(1.5rem, 3vw, 2rem);
+		color: var(--sl-color-accent);
+		letter-spacing: -0.02em;
+		justify-self: end;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.coverage-aggregate-sub {
+		grid-column: 2;
+		grid-row: 2;
+		color: var(--sl-color-gray-2);
+		font-size: 0.9rem;
+		justify-self: end;
+	}
+
+	@media (max-width: 600px) {
+		.coverage-aggregate {
+			grid-template-columns: 1fr;
+			grid-template-rows: auto auto auto;
+			text-align: center;
+		}
+
+		.coverage-aggregate-label,
+		.coverage-aggregate-headline,
+		.coverage-aggregate-sub {
+			grid-column: 1;
+			justify-self: center;
+		}
+
+		.coverage-aggregate-label { grid-row: 1; }
+		.coverage-aggregate-headline { grid-row: 2; }
+		.coverage-aggregate-sub { grid-row: 3; }
+	}
+</style>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -8,7 +8,10 @@ hero:
 
 import QuickStartCta from '../../components/QuickStartCta.astro';
 import ThreeWorldsFusion from '../../components/ThreeWorldsFusion.astro';
+import CoverageBars from '../../components/CoverageBars.astro';
 
 <QuickStartCta />
 
 <ThreeWorldsFusion />
+
+<CoverageBars />

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -3,6 +3,8 @@ title: Overview
 description: Summary of all 70+ GJSify packages
 ---
 
+import CoverageBars from '../../../components/CoverageBars.astro';
+
 GJSify provides **70+ packages** organized into four categories, all implementing standard APIs using native GNOME libraries.
 
 | Category | Packages | Description |
@@ -12,11 +14,7 @@ GJSify provides **70+ packages** organized into four categories, all implementin
 | [DOM & Graphics](./dom) | 8 | Canvas2D (+ headless core), WebGL, DOM elements, event bridge, iframe, video, bridge-types |
 | Adwaita for browser | 3 | `@gjsify/adwaita-web`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 
-## Status Legend
-
-- **Full** — Complete implementation, tests passing
-- **Partial** — Core functionality implemented, some APIs missing
-- **Stub** — Minimal placeholder, not yet functional
+<CoverageBars />
 
 ## Installation
 

--- a/website/src/data/coverage.ts
+++ b/website/src/data/coverage.ts
@@ -1,0 +1,112 @@
+// gjsify API coverage data — keep in sync with the Summary table in STATUS.md.
+//
+// `Full` / `Partial` / `Stub` are the implementation tiers used across the
+// codebase:
+//
+//   Full     — every API surface the consumer reaches in practice works
+//              (cross-tested against Node + relevant standards).
+//   Partial  — the core surface works; specific subsystems are missing or
+//              behind a runtime fallback (typically: a Vala bridge that
+//              hasn't landed yet, or an upstream GJS gap tracked in the
+//              "Upstream GJS Patch Candidates" section of STATUS.md).
+//   Stub     — exists so dependency checks resolve, but the implementation
+//              is a no-op or hard-fails on use.
+
+export interface CoverageRow {
+	/** Display label. */
+	category: string;
+	/** Total count of packages in this category. */
+	total: number;
+	/** Implementation tiers. */
+	full: number;
+	partial: number;
+	stub: number;
+	/**
+	 * Optional human-friendly note that renders alongside the bar — used for
+	 * the categories where percentages alone would be misleading (e.g.
+	 * Showcases / Browser UI / Build tools, where every member is "Full"
+	 * but the count is the more interesting number).
+	 */
+	note?: string;
+}
+
+/**
+ * Source: `STATUS.md` Summary table. The counts deliberately leave out the
+ * `*-meta` umbrella packages (which are dep-only and don't represent
+ * independent implementation effort) so the percentages reflect real
+ * coverage, not inflated by aggregator packages.
+ */
+export const coverageRows: readonly CoverageRow[] = [
+	{
+		category: "Node.js APIs",
+		total: 44,
+		full: 36,
+		partial: 4,
+		stub: 4,
+	},
+	{
+		category: "Web APIs",
+		total: 20,
+		full: 18,
+		partial: 2,
+		stub: 0,
+	},
+	{
+		category: "DOM / Bridges",
+		total: 8,
+		full: 8,
+		partial: 0,
+		stub: 0,
+	},
+	{
+		category: "Browser UI",
+		total: 3,
+		full: 3,
+		partial: 0,
+		stub: 0,
+		note: "adwaita-web · adwaita-fonts · adwaita-icons",
+	},
+	{
+		category: "GJS infrastructure",
+		total: 4,
+		full: 3,
+		partial: 1,
+		stub: 0,
+	},
+	{
+		category: "Build & infra tools",
+		total: 9,
+		full: 9,
+		partial: 0,
+		stub: 0,
+	},
+	{
+		category: "Showcases",
+		total: 8,
+		full: 8,
+		partial: 0,
+		stub: 0,
+		note: "Production-quality runnable demos",
+	},
+	{
+		category: "Integration test suites",
+		total: 4,
+		full: 4,
+		partial: 0,
+		stub: 0,
+		note: "webtorrent · socket.io · streamx · autobahn",
+	},
+];
+
+/** Sum across all rows (excluding -meta umbrella packages). */
+export function totalsAcrossCategories(): { total: number; full: number; partial: number; stub: number } {
+	return coverageRows.reduce(
+		(acc, row) => ({
+			total: acc.total + row.total,
+			full: acc.full + row.full,
+			partial: acc.partial + row.partial,
+			stub: acc.stub + row.stub,
+		}),
+		{ total: 0, full: 0, partial: 0, stub: 0 },
+	);
+}


### PR DESCRIPTION
## What changes

Replaces the textual coverage table on the home page and packages overview with **stacked progress bars** showing the Full / Partial / Stub breakdown per category. Same source-of-truth (STATUS.md's Summary table) lives in [\`src/data/coverage.ts\`](./website/src/data/coverage.ts) — one place to keep in sync when promoting or adding packages.

## Each row shows

- Category label
- Headline number: \`Full / Total\` (plus the % when not at 100%)
- A stacked bar with **green** (Full) / **yellow** (Partial) / **grey** (Stub) segments, sized proportionally
- Optional note for categories where the % alone would be misleading (Showcases listing what's covered, Browser UI listing the three Adwaita-for-browser packages, …)

## Aggregate footer

One headline number across all categories — answers *"how complete is gjsify?"* at a glance.

## Where it embeds

- \`docs/index.mdx\` — homepage, below the three-worlds pitch
- \`docs/packages/overview.mdx\` — renamed from .md to .mdx so it can use the component; existing intro table + category links kept (the per-row bars are the new authoritative coverage view)

## Test plan

- [x] \`yarn build\` clean — 22 pages built
- [x] Both \`index.html\` and \`packages/overview/index.html\` render the bars + aggregate
- [x] All 8 categories from STATUS.md present (Node.js APIs, Web APIs, DOM/Bridges, Browser UI, GJS infrastructure, Build/Infra tools, Showcases, Integration test suites)

## Maintenance

STATUS.md's Summary table is the source-of-truth. When package counts shift (e.g. a Partial gets promoted to Full), update both: the table in STATUS.md and the row in \`coverage.ts\`. A future improvement could parse STATUS.md directly at build time — listed as a planned follow-up in \`coverage.ts\` (not load-bearing today).