### PR TITLE
feat(website): showcase pages — index + 7 per-showcase deep-dives

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -82,6 +82,19 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Showcases',
+          items: [
+            { slug: 'showcases' },
+            { slug: 'showcases/canvas2d-fireworks' },
+            { slug: 'showcases/excalibur-jelly-jumper' },
+            { slug: 'showcases/three-geometry-teapot' },
+            { slug: 'showcases/three-postprocessing-pixel' },
+            { slug: 'showcases/minimalist-browser' },
+            { slug: 'showcases/webrtc-loopback' },
+            { slug: 'showcases/express-webserver' },
+          ],
+        },
+        {
           label: 'Contributing',
           items: [
             { slug: 'contributing/development-setup' },

--- a/website/src/content/docs/showcases/canvas2d-fireworks.mdx
+++ b/website/src/content/docs/showcases/canvas2d-fireworks.mdx
@@ -1,0 +1,45 @@
+---
+title: canvas2d-fireworks
+description: Particle-based fireworks rendered through Canvas 2D — same code path on GJS (Cairo via Canvas2DBridge) and the browser.
+---
+
+Animated particle fireworks on a `<canvas>` 2D context, adapted from a popular CodePen by [@juliangarnier](https://codepen.io/juliangarnier/pen/gmOwJX). Inputs are wired up through [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) so clicks fire fireworks in both runtimes.
+
+## What it exercises
+
+| Pillar | Surface used |
+|---|---|
+| [`@gjsify/canvas2d`](https://github.com/gjsify/gjsify/tree/main/packages/framework/canvas2d) | `Canvas2DBridge` → `Gtk.DrawingArea` (Cairo + PangoCairo) |
+| [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement`, `getBoundingClientRect()`, `ResizeObserver` |
+| [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) | GTK4 click + pointer-move → DOM `click` / `pointermove` |
+| `@gjsify/adwaita-web` (browser only) | Adwaita-styled control panel for the browser embed |
+
+Nothing in the showcase code references `@gjsify/*` directly — it uses standard `<canvas>` + `ctx.fillRect()` + `requestAnimationFrame()` calls. The framework layer translates each call into GTK4 + Cairo at runtime.
+
+## Run it on GJS
+
+```bash
+gjsify showcase canvas2d-fireworks
+```
+
+A GTK4 window opens with a `Gtk.DrawingArea` filling its surface. Click anywhere to fire a firework; the explosion animates at the GTK frame clock's vsync via the [`requestAnimationFrame`](../../patterns/bridges/#resizeobserver-wires-through-bridges) shim.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-canvas2d-fireworks/browser';
+mount(document.getElementById('app')!);
+```
+
+Same code — the `<canvas>` is a real browser canvas, not a bridge.
+
+## Source
+
+[`showcases/dom/canvas2d-fireworks/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/canvas2d-fireworks) — entry points: `src/gjs/main.ts` (GTK shell), `src/browser/browser.ts` (mount), `src/shared/fireworks.ts` (the particle simulation, runs unchanged in both targets).
+
+The shared module is the value: it imports nothing platform-specific, only the standard `Canvas 2D` API surface. That surface is the contract between the browser and `@gjsify/canvas2d` — every method it uses must hold up identically in both runtimes.
+
+## Related
+
+- [Bridge widgets pattern](../../patterns/bridges/) — explains why `Canvas2DBridge` IS a `Gtk.DrawingArea` and how `installGlobals()` + `onReady()` lifecycle work.
+- [`@gjsify/canvas2d-core`](https://github.com/gjsify/gjsify/tree/main/packages/dom/canvas2d-core) — the headless Canvas 2D implementation behind the bridge.

--- a/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
+++ b/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
@@ -1,0 +1,50 @@
+---
+title: excalibur-jelly-jumper
+description: Excalibur.js 0.32 platformer with Tiled tilemaps — runs on GJS through @gjsify/webgl + @gjsify/xmlhttprequest + @gjsify/domparser without a Excalibur.js fork.
+---
+
+A small 2D platformer built with the unmodified [Excalibur.js](https://excaliburjs.com/) game engine and [Tiled](https://www.mapeditor.org/) tilemaps. The same `npm` package runs in the browser and on GJS — Excalibur reaches for `<canvas>`, `WebGL`, `XMLHttpRequest`, `DOMParser`, `ResizeObserver`, and `requestAnimationFrame`, and every one of those calls is served by the corresponding `@gjsify/*` package on GJS.
+
+## What it exercises
+
+| Pillar | What Excalibur needs |
+|---|---|
+| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | `WebGLBridge` → `Gtk.GLArea` (Excalibur's WebGL renderer) |
+| [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement`, `ResizeObserver` (the ancestor-walking one — see [Bridges](../../patterns/bridges/#resizeobserver-wires-through-bridges)) |
+| [`@gjsify/xmlhttprequest`](https://github.com/gjsify/gjsify/tree/main/packages/web/xmlhttprequest) | Excalibur's asset loader (`responseType: 'arraybuffer'` + `'blob'`) |
+| [`@gjsify/domparser`](https://github.com/gjsify/gjsify/tree/main/packages/web/domparser) | excalibur-tiled parses the `.tmx` XML map files |
+| [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) | Keyboard input (jump / move / restart) |
+| [`@gjsify/webaudio`](https://github.com/gjsify/gjsify/tree/main/packages/web/webaudio) | Sound effects via Excalibur's WebAudio backend (GStreamer pipeline on GJS) |
+
+This is the showcase that surfaced the [ResizeObserver-on-bridge](../../patterns/bridges/#resizeobserver-wires-through-bridges) bug in v0.4.20 — `DisplayMode.FillContainer` mode observes `canvas.parentElement`, which only fires when the bridge's GTK resize signal walks the polyfill DOM tree's ancestors. The fix lives in [`@gjsify/dom-elements`'s notify-resize](https://github.com/gjsify/gjsify/blob/main/packages/dom/dom-elements/src/notify-resize.ts) and is what makes this showcase reflow correctly on window resize.
+
+## Run it on GJS
+
+```bash
+gjsify showcase excalibur-jelly-jumper
+```
+
+Opens a GTK4 window with the GLArea-backed canvas filling it. Arrow keys move, space jumps, R restarts. The Excalibur engine ticks at the GTK frame clock's vsync.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-excalibur-jelly-jumper/browser';
+mount(document.getElementById('app')!);
+```
+
+The asset loader fetches tilemaps + spritesheets from `@gjsify/example-dom-excalibur-jelly-jumper/assets/*` (resolved via `require.resolve` in both targets — the browser bundles them via the website's Vite config).
+
+## Source
+
+[`showcases/dom/excalibur-jelly-jumper/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/excalibur-jelly-jumper) — shared scene/actors live in `src/shared/`, the `gjs/` and `browser/` entries differ only in the host wiring (Adw.Application vs `mount(container)`).
+
+## Why this showcase is load-bearing
+
+Excalibur is the canonical real-world consumer of the full WebGL + Canvas + WebAudio + XHR + DOMParser stack. Every time we promote a `@gjsify/*` package from Partial → Full, this showcase is one of the first regression checks — if Excalibur's "FillContainer" mode reflows correctly, if its asset loader resolves binary blobs without truncation, if its WebAudio mixer plays a multi-channel sound effect without artifacts, then the gjsify port of the underlying API is genuinely production-grade.
+
+## Related
+
+- [`refs/excalibur/`](https://github.com/gjsify/gjsify/tree/main/refs/excalibur) — Excalibur source, used for gap analysis against the bundled showcase.
+- [Bridge widgets pattern](../../patterns/bridges/) — covers the WebGLBridge lifecycle that this showcase uses.
+- [`pixel-rpg/map-editor`](https://github.com/PixelRPG/map-editor) — companion downstream project that built atop the same Excalibur + Tiled stack.

--- a/website/src/content/docs/showcases/express-webserver.mdx
+++ b/website/src/content/docs/showcases/express-webserver.mdx
@@ -1,0 +1,61 @@
+---
+title: express-webserver
+description: Unmodified Express 5 running on GJS through @gjsify/http — proves the http.Server / IncomingMessage / ServerResponse surface holds for the most-deployed Node web framework.
+---
+
+A small Express 5 application — `app.get('/api/echo')`, JSON middleware, a static-file route — running on GJS through [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http). Express imports unmodified from npm; gjsify's Node compat layer serves every `http.Server` / `IncomingMessage` / `ServerResponse` API call Express reaches for.
+
+## What it exercises
+
+| Pillar | What Express needs |
+|---|---|
+| [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http) | `http.createServer()`, `Server.listen()`, full `IncomingMessage` (close-only-via-destroy per Node semantics) + `ServerResponse` API |
+| [`@gjsify/stream`](https://github.com/gjsify/gjsify/tree/main/packages/node/stream) | `req.pipe(res)`, body parsing |
+| [`@gjsify/events`](https://github.com/gjsify/gjsify/tree/main/packages/node/events) | EventEmitter with enumerable prototype methods (Express 5 requires this for some middleware) |
+| [`@gjsify/url`](https://github.com/gjsify/gjsify/tree/main/packages/node/url) | URL parsing in Express's route matcher |
+| `libsoup-3.0` | The TCP listener + HTTP/1.1 parser under `@gjsify/http` |
+
+## Run it on GJS
+
+```bash
+gjsify showcase express-webserver
+```
+
+Starts a `Gtk.Application`-less GLib mainloop with Express bound to `http://127.0.0.1:3000`. Hit it with curl:
+
+```bash
+curl http://127.0.0.1:3000/api/echo?msg=hi
+# → {"echo":"hi","ts":"…"}
+```
+
+The same Express app would behave identically under Node — there's no GJS-specific branch in `app.ts`. That's the load-bearing claim.
+
+## Run it under Node (for comparison)
+
+```bash
+cd showcases/node/express-webserver
+gjsify install
+gjsify run start
+```
+
+`gjsify run` resolves the package's `gjsify.main` and invokes `gjs -m` for GJS, `node` for Node — same source, two targets.
+
+## Source
+
+[`showcases/node/express-webserver/`](https://github.com/gjsify/gjsify/tree/main/showcases/node/express-webserver)
+
+- `src/app.ts` — the Express app definition (npm `express` import, no `@gjsify/*`)
+- `src/server.ts` — `app.listen(port)` + `ensureMainLoop()` for GJS (no-op on Node)
+- `src/test/echo.spec.ts` — assertion-based smoke test (cross-platform)
+
+## Why Express specifically
+
+Express is the most-deployed Node web framework on the planet. If gjsify's `http` package can carry Express 5 unmodified — including middleware composition, error handling, route matching — then arbitrary npm web apps targeting Node tend to "just work" on GJS too. This showcase is the canary.
+
+Integration coverage for the broader npm web ecosystem (Socket.IO, axios, WebTorrent, …) lives under [`tests/integration/`](https://github.com/gjsify/gjsify/tree/main/tests/integration) — they all dovetail with the same `@gjsify/http` + `@gjsify/stream` surface.
+
+## Related
+
+- [`refs/socket.io/`](https://github.com/gjsify/gjsify/tree/main/refs/socket.io) — Socket.IO uses `http.Server` directly; the integration suite under `tests/integration/socket.io/` is the multi-client validation
+- [`refs/undici/`](https://github.com/gjsify/gjsify/tree/main/refs/undici) — Node's fetch / HTTP client reference, separate from `@gjsify/http` but the same socket plumbing
+- [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http) — the package itself

--- a/website/src/content/docs/showcases/index.mdx
+++ b/website/src/content/docs/showcases/index.mdx
@@ -1,0 +1,51 @@
+---
+title: Showcases
+description: Production-quality runnable demos that exercise the full @gjsify/* pillar set — DOM + Canvas + WebGL + WebRTC + Excalibur + Three.js + Express — on both GJS and the browser.
+---
+
+The **showcases** are end-to-end runnable applications that double as proof of the `@gjsify/*` pillar set's coverage. Every showcase runs in two places from the same source:
+
+- **In a GTK4 window** via `gjsify showcase <name>` — Cairo / WebGL / WebKit / GStreamer backing the standard DOM APIs the showcase code reaches for.
+- **In a regular browser** via `import { mount } from '@gjsify/example-dom-<name>/browser'` — same module, native browser implementations.
+
+If something runs on GJS through gjsify, it also runs in the browser unmodified (and vice versa). That cross-platform contract is the point.
+
+## Browse the catalog
+
+| Showcase | Pillar focus | Browser demo |
+|---|---|---|
+| [`canvas2d-fireworks`](./canvas2d-fireworks/) | DOM + `@gjsify/canvas2d` | Particle fireworks on a `Canvas2DBridge` / `<canvas>` |
+| [`excalibur-jelly-jumper`](./excalibur-jelly-jumper/) | DOM + `@gjsify/webgl` + `@gjsify/xmlhttprequest` | Excalibur.js 2D platformer with Tiled tilemaps |
+| [`three-geometry-teapot`](./three-geometry-teapot/) | DOM + `@gjsify/webgl` | Three.js Utah teapot with parameter controls |
+| [`three-postprocessing-pixel`](./three-postprocessing-pixel/) | DOM + `@gjsify/webgl` + post FX | Three.js pixel-art post-processing pipeline |
+| [`minimalist-browser`](./minimalist-browser/) | DOM + `@gjsify/iframe` | URL bar + `<iframe>` (WebKit on GJS, real `<iframe>` in browser) |
+| [`webrtc-loopback`](./webrtc-loopback/) | `@gjsify/webrtc` | Two local peers exchange offer/answer + RTCDataChannel |
+| [`express-webserver`](./express-webserver/) | Node — `@gjsify/http` + `express` | Express HTTP server running unmodified on GJS |
+
+## Running a showcase locally
+
+```bash
+gjsify showcase                          # list all
+gjsify showcase canvas2d-fireworks       # run on GJS (opens a GTK4 window)
+```
+
+The CLI resolves the showcase's npm package (every showcase is published as `@gjsify/example-<category>-<name>`) and launches its GJS bundle via `gjs -m`. Native dependencies (Vala typelibs) are auto-discovered from `node_modules`'s prebuild directories.
+
+## Running the browser version
+
+Every showcase ships a `./browser` export pointing at a TS module you can mount into any DOM container:
+
+```ts
+import { mount } from '@gjsify/example-dom-canvas2d-fireworks/browser';
+
+const container = document.getElementById('app')!;
+mount(container);
+```
+
+The website's `<ShowcaseEmbed>` component handles the loading and lifecycle for the live demos linked above. Source for each showcase lives under [`showcases/`](https://github.com/gjsify/gjsify/tree/main/showcases) in the gjsify repo — see the per-showcase pages for the deep dive on how each one exercises the pillar set.
+
+## Why two targets matter
+
+Showcases are how we **prove** the cross-platform contract: code written against standard DOM / Web APIs runs unmodified on both. Every gap surfaced by a showcase (a missing event, an unhandled Canvas method, a Web API stub) becomes a bug-fix in the underlying `@gjsify/*` package — never patched at the consumer level. The browser entry is the ground truth, the GJS entry validates we match it.
+
+When the matrix grows (new pillars, new bridges, new Vala extensions), showcases grow with it.

--- a/website/src/content/docs/showcases/minimalist-browser.mdx
+++ b/website/src/content/docs/showcases/minimalist-browser.mdx
@@ -1,0 +1,55 @@
+---
+title: minimalist-browser
+description: URL bar + back/forward + iframe — same code runs in browser (real <iframe>) and GJS (IFrameBridge over WebKit.WebView).
+---
+
+A bare-bones browser shell — URL bar, back / forward / reload buttons, an `<iframe>` filling the rest. The same TS source compiles for the browser (where the iframe is a real iframe) and for GJS (where it's an `IFrameBridge` wrapping a full `WebKit.WebView`).
+
+## What it exercises
+
+| Pillar | What it needs |
+|---|---|
+| [`@gjsify/iframe`](https://github.com/gjsify/gjsify/tree/main/packages/framework/iframe) | `HTMLIFrameElement` + `IFrameBridge` → `WebKit.WebView` |
+| [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLInputElement` for the URL bar, click handling |
+| [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) | GTK click events on the toolbar buttons |
+| Adwaita widgets (GJS) | `Adw.HeaderBar` + `Gtk.Entry` for the chrome |
+
+## Run it on GJS
+
+```bash
+gjsify showcase minimalist-browser
+```
+
+Opens a GTK4 window. The chrome is an `Adw.HeaderBar` with native GTK buttons; the content area below is the `IFrameBridge` widget. Type a URL, hit Enter — WebKit loads it (full browser-grade web compat: cookies, JavaScript, CSS, the lot).
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-minimalist-browser/browser';
+mount(document.getElementById('app')!);
+```
+
+The same `<input>` + button handlers, the same `<iframe>` element. The browser embed is fully self-contained.
+
+## Source
+
+[`showcases/dom/minimalist-browser/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/minimalist-browser)
+
+- `src/shared/url-bar.ts` — URL parsing + normalization (shared)
+- `src/shared/history.ts` — back / forward stack management (shared)
+- `src/gjs/main.ts` — `Adw.ApplicationWindow` host
+- `src/browser/browser.ts` — DOM mount
+
+## The IFrameBridge story
+
+Unlike `Canvas2DBridge` / `WebGLBridge` / `VideoBridge`, which are pure-JS polyfills wrapping native GTK widgets, `IFrameBridge` IS [WebKit.WebView](https://webkitgtk.org/reference/webkit2gtk/stable/class.WebView.html). That's the entire point — we don't reimplement HTML rendering; for embedded web content the right tool is a real browser engine.
+
+The bridge exposes the standard `HTMLIFrameElement` API surface (`src`, `srcdoc`, `contentWindow.postMessage`, navigation events) so that **code shaped like browser code** works without a special "you're in GJS" branch. The `WebKit.WebView` is the engine; the iframe element is the contract.
+
+See [Bridge widgets pattern](../../patterns/bridges/#iframebridge-is-the-one-bridge-that-does-ship-a-browser) for when to reach for this — pretty much any time you embed third-party web content or a sandboxed report inside a GJS app.
+
+## Related
+
+- [Bridge widgets pattern](../../patterns/bridges/) — the four bridges side by side
+- [`refs/epiphany/`](https://github.com/gjsify/gjsify/tree/main/refs/epiphany) — GNOME Web, the canonical real-world consumer of `WebKit.WebView` in a GTK4 host
+- [`refs/webkit/`](https://github.com/gjsify/gjsify/tree/main/refs/webkit) — WebKit source for spec-behavior references

--- a/website/src/content/docs/showcases/three-geometry-teapot.mdx
+++ b/website/src/content/docs/showcases/three-geometry-teapot.mdx
@@ -1,0 +1,54 @@
+---
+title: three-geometry-teapot
+description: Three.js Utah teapot with parameter controls — proves Three's full WebGL2 pipeline runs on GJS through @gjsify/webgl's Vala bridge.
+---
+
+The Utah teapot rendered with [Three.js](https://threejs.org/), with live Adwaita-styled controls for tessellation level, body / lid / bottom toggles, and material switching. Ported from [`refs/three/examples/webgl_geometry_teapot.html`](https://github.com/gjsify/gjsify/tree/main/refs/three/examples/webgl_geometry_teapot.html).
+
+## What it exercises
+
+| Pillar | What Three.js needs |
+|---|---|
+| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | Full WebGL 2.0 surface — Three's renderer reaches for VAOs, uniform buffer objects, `texStorage2D`, `drawElementsInstanced`. All routed through the [`gwebgl` Vala bridge](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) → libepoxy → GLES 3.2. |
+| [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | `HTMLCanvasElement`, `requestAnimationFrame`, `ResizeObserver`, `OrbitControls` mouse events |
+| [`@gjsify/event-bridge`](https://github.com/gjsify/gjsify/tree/main/packages/framework/event-bridge) | Mouse drag → camera orbit |
+| `@gjsify/adwaita-web` | Browser embed's control panel styling |
+| Adwaita widgets (GJS) | `Adw.PreferencesGroup` + `Adw.SwitchRow` + `Adw.SpinRow` for the same controls |
+
+## Run it on GJS
+
+```bash
+gjsify showcase three-geometry-teapot
+```
+
+A GTK4 window opens with an `Adw.ToolbarView` shell: the toolbar holds the controls (tessellation 1-20, body/lid/bottom switches, material dropdown), the content area is the WebGL canvas. Drag with the mouse to orbit the camera; scroll to zoom.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-three-geometry-teapot/browser';
+mount(document.getElementById('app')!);
+```
+
+Same shared scene logic. The browser embed renders the same controls through `@gjsify/adwaita-web`'s custom elements so the visual story is identical.
+
+## Source
+
+[`showcases/dom/three-geometry-teapot/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/three-geometry-teapot)
+
+- `src/three-demo.ts` — the Three.js scene (shared between targets, no GJS-specific imports)
+- `src/gjs/window.ts` — `Adw.ApplicationWindow` with Blueprint UI definitions
+- `src/browser/browser.ts` — DOM mount + Adwaita-web wiring
+- `src/assets/UtahTeapot.glb` — the model (shipped as an npm asset via `exports['./assets/*']`)
+
+## Why this matters
+
+`@gjsify/webgl`'s Vala bridge maps each WebGL call into libepoxy's GLES 3.2 surface — but Three.js does NOT target GLES, it targets desktop WebGL. The fact that it runs unmodified is the load-bearing claim: the bridge handles every format / type / blit / buffer-storage difference between WebGL and GLES, so consumer code stays browser-shaped.
+
+When new Three.js features land (e.g. WebGPU paths, new post-processing passes), this showcase is one of the first regression targets — the matrix of WebGL calls Three reaches for is the broadest realistic surface available.
+
+## Related
+
+- [`three-postprocessing-pixel`](./three-postprocessing-pixel/) — same engine, different rendering pipeline (post-FX framebuffers + custom shaders)
+- [Bridge widgets pattern](../../patterns/bridges/) — covers the `WebGLBridge` lifecycle, including the resize → reframe flow
+- [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) — the package itself, where every new Three.js requirement gets implemented

--- a/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
+++ b/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
@@ -1,0 +1,55 @@
+---
+title: three-postprocessing-pixel
+description: Three.js post-processing pixel-art renderer — proves the full EffectComposer + custom shader passes pipeline runs on GJS.
+---
+
+A spinning crystal sphere rendered through Three.js's [`EffectComposer`](https://threejs.org/docs/#examples/en/postprocessing/EffectComposer) with the [`RenderPixelatedPass`](https://threejs.org/docs/#examples/en/postprocessing/RenderPixelatedPass) addon — chunky retro pixels with antialiased edges. Ported from `refs/three/examples/webgl_postprocessing_pixel.html`.
+
+## What it exercises
+
+| Pillar | What it needs |
+|---|---|
+| [`@gjsify/webgl`](https://github.com/gjsify/gjsify/tree/main/packages/framework/webgl) | Multiple framebuffers (`WebGLRenderTarget`), custom shaders compiled at runtime, `OrbitControls` |
+| [`@gjsify/dom-elements`](https://github.com/gjsify/gjsify/tree/main/packages/dom/dom-elements) | The standard canvas/RAF/Resize trio |
+| `@gjsify/adwaita-web` | Browser embed's resolution-tier controls |
+| Adwaita widgets (GJS) | `Adw.PreferencesGroup` + `Adw.SpinRow` for pixel-size + render-resolution controls |
+
+## Run it on GJS
+
+```bash
+gjsify showcase three-postprocessing-pixel
+```
+
+Opens a GTK4 window with an `Adw.ToolbarView`. Adjust pixel-size to crush the resolution into chunky cells; the `RenderPixelatedPass` writes into a low-res framebuffer then upscales with nearest-neighbor sampling for the retro look.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-three-postprocessing-pixel/browser';
+mount(document.getElementById('app')!);
+```
+
+Same scene logic. Browser-side resolution controls live in `@gjsify/adwaita-web` web components for visual parity with the GJS shell.
+
+## Source
+
+[`showcases/dom/three-postprocessing-pixel/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/three-postprocessing-pixel)
+
+The shared `three-demo.ts` drives the scene + post-processing pipeline. Both targets re-use it; the only target-specific code is the host shell.
+
+## Why this is the harder Three.js showcase
+
+The plain `three-geometry-teapot` exercises a single forward render pass. This one threads the render through:
+
+1. **Custom-resolution `WebGLRenderTarget`** — the pixelated buffer
+2. **`RenderPass` → `RenderPixelatedPass`** — multi-stage composition
+3. **`OutputPass`** — final blit to the screen framebuffer
+4. **Custom GLSL shaders** for the pixel-art edge detection
+
+Each step has its own buffer / texture state. If `@gjsify/webgl` mishandles ANY framebuffer attachment or read-back, the pipeline produces a black canvas. Smoke-testing this showcase verifies the bridge's framebuffer / texture state-tracking is intact across the full WebGL2 surface.
+
+## Related
+
+- [`three-geometry-teapot`](./three-geometry-teapot/) — simpler companion (single render pass)
+- [`refs/three/`](https://github.com/gjsify/gjsify/tree/main/refs/three) — Three.js source, used as the gap-analysis reference
+- [Bridge widgets pattern](../../patterns/bridges/) — `WebGLBridge` lifecycle

--- a/website/src/content/docs/showcases/webrtc-loopback.mdx
+++ b/website/src/content/docs/showcases/webrtc-loopback.mdx
@@ -1,0 +1,57 @@
+---
+title: webrtc-loopback
+description: Two local peers exchange offer/answer + ICE, then echo messages over an RTCDataChannel — proves @gjsify/webrtc's full PeerConnection + DataChannel surface.
+---
+
+A WebRTC data-channel loopback: two `RTCPeerConnection` instances sit in the same process, exchange SDP offer / answer + ICE candidates, open an `RTCDataChannel`, and echo whatever the user types back through it. No signaling server, no remote peer — but the entire `RTCPeerConnection` state machine runs through GStreamer's webrtcbin on GJS.
+
+## What it exercises
+
+| Pillar | What it needs |
+|---|---|
+| [`@gjsify/webrtc`](https://github.com/gjsify/gjsify/tree/main/packages/web/webrtc) | `RTCPeerConnection`, `createOffer` / `createAnswer` / `setLocalDescription` / `setRemoteDescription`, ICE event firing, `RTCDataChannel` with `send` + `onmessage` |
+| [`@gjsify/webrtc-native`](https://github.com/gjsify/gjsify/tree/main/packages/web/webrtc-native) | Vala signal bridges that re-emit GStreamer's streaming-thread callbacks onto the GLib main context (otherwise they'd fire from a wrong thread and crash SpiderMonkey) |
+| `gst-1.0` + `gst-webrtc-1.0` | The actual WebRTC implementation (DTLS, SCTP, ICE) on GJS |
+| Adwaita widgets (GJS) | `Adw.PreferencesGroup` for the message log and input |
+
+## Run it on GJS
+
+```bash
+gjsify showcase webrtc-loopback
+```
+
+A GTK4 window opens. Click "Connect" — two `RTCPeerConnection` instances are created, both `oniceconnectionstatechange` handlers wire up, the offer / answer dance happens internally, and the data channel reaches `'open'`. Type into the input → echoes back.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-webrtc-loopback/browser';
+mount(document.getElementById('app')!);
+```
+
+Exact same flow — uses the browser's native `RTCPeerConnection`. The contract is whether `@gjsify/webrtc`'s GJS implementation behaves identically.
+
+## Source
+
+[`showcases/dom/webrtc-loopback/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/webrtc-loopback)
+
+- `src/shared/loopback.ts` — the loopback dance (peer setup, signaling, data-channel wiring). Imports only `RTCPeerConnection` + `RTCSessionDescription` + `RTCIceCandidate` from the global namespace.
+- `src/gjs/main.ts` — Adwaita window host
+- `src/browser/browser.ts` — DOM mount
+
+## Why this showcase is non-trivial
+
+WebRTC is the second-broadest API surface in the Web platform (after the DOM itself). To match it on GJS, `@gjsify/webrtc` has to:
+
+1. Translate every `RTCSessionDescription` / `RTCIceCandidate` JSON object into the GstWebRTC equivalent + back
+2. Bridge GStreamer's streaming threads to the GLib main context so JS callbacks fire safely
+3. Wrap `RTCDataChannel`'s `'open'` / `'close'` / `'message'` events without dropping any (GstWebRTCDataChannel fires from yet another thread)
+4. Keep the `Gst.Promise.new_with_change_func` lifecycle aligned with the JS `Promise` lifecycle so SDP / ICE async calls don't leak
+
+If any of those layers misfires, the channel never reaches `'open'` and the showcase hangs at "Connecting…". A successful round-trip echo is the end-to-end proof that the full stack holds.
+
+## Related
+
+- [`refs/node-gst-webrtc/`](https://github.com/gjsify/gjsify/tree/main/refs/node-gst-webrtc) — the GStreamer-WebRTC reference impl
+- [`refs/webrtc-samples/`](https://github.com/gjsify/gjsify/tree/main/refs/webrtc-samples) — MDN / Google's reference samples for browser-side behavior
+- [`@gjsify/webrtc-native`](https://github.com/gjsify/gjsify/tree/main/packages/web/webrtc-native) — the Vala bridge package


### PR DESCRIPTION
## Closes the website-side of Track C

Each page documents one showcase: what \`@gjsify/*\` pillars it exercises, how to run it on both GJS + browser, what makes the showcase non-trivial as a regression target, and where the source lives.

## New pages under \`docs/showcases/\`

| Page | Pillar focus |
|---|---|
| \`index\` | Catalog overview + cross-platform contract pitch |
| \`canvas2d-fireworks\` | Cairo via Canvas2DBridge |
| \`excalibur-jelly-jumper\` | Excalibur.js + Tiled (load-bearing for the ResizeObserver-on-bridge fix in v0.4.20) |
| \`three-geometry-teapot\` | Three.js WebGL2 via gwebgl Vala |
| \`three-postprocessing-pixel\` | Multi-pass EffectComposer + custom shaders pipeline |
| \`minimalist-browser\` | IFrameBridge over WebKit.WebView |
| \`webrtc-loopback\` | RTCPeerConnection + DataChannel through GStreamer webrtcbin |
| \`express-webserver\` | Unmodified Express 5 on @gjsify/http |

Cross-links to packages/source + patterns/ page + refs/ reference projects so the gap-analysis chain is one click away.

## Sidebar

New "Showcases" section between Projects and Contributing. Build: 22 → 30 pages.

## Open follow-ups (separate PRs)

- Live \`<ShowcaseEmbed>\` Astro component to mount each browser entry inline on the detail pages (currently text + import snippet only — the same content the visitor would copy-paste, just not running on the page).
- \`webrtc-video\` showcase is in the source tree but not in \`showcases.json\` — register it once the GStreamer pipeline lands the multi-track support.
- \`gjsify showcase\` in the global GJS-bundled CLI says "No showcases found" — \`discoverShowcases\`'s \`import.meta.url\` path resolution needs to work from inside the bundle (Node CLI works fine).

## Test plan

- [x] \`yarn build\` clean — 30 pages built (was 22)
- [x] Sidebar registers all 8 entries under Showcases
- [x] Cross-links in each page resolve (patterns/bridges, packages/dom, projects/ts-for-gir)