### PR TITLE
chore(refs): add Gradia submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -215,3 +215,6 @@
 [submodule "refs/oxc"]
 	path = refs/oxc
 	url = git@github.com:oxc-project/oxc.git
+[submodule "refs/Gradia"]
+	path = refs/Gradia
+	url = git@github.com:AlexanderVanhee/Gradia.git


### PR DESCRIPTION
## Summary
- Adds `AlexanderVanhee/Gradia` as a `refs/Gradia` submodule.
- GNOME Gtk4/libadwaita screenshot annotation tool — useful reference for native Gtk4 apps with image processing pipelines (Pixbuf, Cairo) and Adwaita styling.

## Test plan
- [ ] CI green