### PR TITLE
docs(showcases): website page for webrtc-video

### DIFF
--- a/showcases/dom/webrtc-video/package.json
+++ b/showcases/dom/webrtc-video/package.json
@@ -14,7 +14,7 @@
     "start:browser": "http-server dist -o -c-1",
     "build": "gjsify run build:gjs && gjsify run build:browser && gjsify run build:assets",
     "build:gjs": "gjsify build src/gjs/gjs.ts --app gjs --outfile dist/gjs.js",
-    "build:browser": "gjsify build src/browser/browser.ts --app browser --outfile dist/browser.js",
+    "build:browser": "gjsify build src/browser/browser-main.ts --app browser --outfile dist/browser-main.js",
     "build:assets": "mkdir -p dist && cp -f src/browser/index.html dist/index.html"
   },
   "devDependencies": {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
             { slug: 'showcases/three-postprocessing-pixel' },
             { slug: 'showcases/minimalist-browser' },
             { slug: 'showcases/webrtc-loopback' },
+            { slug: 'showcases/webrtc-video' },
             { slug: 'showcases/express-webserver' },
           ],
         },

--- a/website/src/content/docs/showcases/index.mdx
+++ b/website/src/content/docs/showcases/index.mdx
@@ -20,6 +20,7 @@ If something runs on GJS through gjsify, it also runs in the browser unmodified 
 | [`three-postprocessing-pixel`](./three-postprocessing-pixel/) | DOM + `@gjsify/webgl` + post FX | Three.js pixel-art post-processing pipeline |
 | [`minimalist-browser`](./minimalist-browser/) | DOM + `@gjsify/iframe` | URL bar + `<iframe>` (WebKit on GJS, real `<iframe>` in browser) |
 | [`webrtc-loopback`](./webrtc-loopback/) | `@gjsify/webrtc` | Two local peers exchange offer/answer + RTCDataChannel |
+| [`webrtc-video`](./webrtc-video/) | `@gjsify/webrtc` + `@gjsify/video` | Webcam preview — `getUserMedia` stream rendered through `VideoBridge` / native `<video>` |
 | [`express-webserver`](./express-webserver/) | Node — `@gjsify/http` + `express` | Express HTTP server running unmodified on GJS |
 
 ## Running a showcase locally

--- a/website/src/content/docs/showcases/webrtc-video.mdx
+++ b/website/src/content/docs/showcases/webrtc-video.mdx
@@ -1,0 +1,68 @@
+---
+title: webrtc-video
+description: Webcam preview via getUserMedia — same MediaStream code drives a native browser <video> element and a GJS Gtk.Picture through @gjsify/video's VideoBridge.
+---
+
+A live webcam preview built on the standard `navigator.mediaDevices.getUserMedia({ video: true })` call. The resulting `MediaStream` is assigned to a `<video>` element's `srcObject` — and that single line is the entire cross-platform surface. In the browser it lights up a real `<video>`; on GJS it flows through [`@gjsify/video`](https://github.com/gjsify/gjsify/tree/main/packages/framework/video)'s `VideoBridge` into a GTK4 `Gtk.Picture` backed by GStreamer's `gtk4paintablesink`.
+
+## What it exercises
+
+| Pillar | What it needs |
+|---|---|
+| [`@gjsify/webrtc`](https://github.com/gjsify/gjsify/tree/main/packages/web/webrtc) | `navigator.mediaDevices.getUserMedia`, `MediaStream`, `MediaStreamTrack` — capture via GStreamer's `pipewiresrc` / `pulsesrc` / `v4l2src` fallback chain |
+| [`@gjsify/video`](https://github.com/gjsify/gjsify/tree/main/packages/framework/video) | `HTMLVideoElement.srcObject = MediaStream`, `VideoBridge` → `Gtk.Picture` (gtk4paintablesink) |
+| [`@gjsify/webrtc-native`](https://github.com/gjsify/gjsify/tree/main/packages/web/webrtc-native) | Vala bridges re-emitting GStreamer streaming-thread callbacks on the GLib main context |
+| `gst-1.0` + `gtk4paintablesink` | The capture + paintable rendering path on GJS |
+| Adwaita widgets (GJS) | `Adw.ApplicationWindow` + `Adw.HeaderBar` + `Adw.ToolbarView` hosting the bridge |
+
+The shared [`video-demo.ts`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/webrtc-video/src/video-demo.ts) is six lines of business logic: request a stream, assign it to `video.srcObject`, log the result. Every line is standard Web platform API — nothing references `@gjsify/*` directly.
+
+## Prerequisites
+
+- A webcam (or a virtual video device such as `v4l2loopback`).
+- PipeWire or PulseAudio on the host for capture; the showcase falls back through `pipewiresrc` → `pulsesrc` → `v4l2src` automatically.
+
+## Run it on GJS
+
+```bash
+gjsify showcase webrtc-video
+```
+
+A GTK4 window opens with an `Adw.ToolbarView` whose body is the `VideoBridge` widget. Once `getUserMedia` resolves, the `MediaStream` is handed to the bridge and the GStreamer pipeline transitions to `PLAYING` — the picture appears in the GTK4 widget at the frame clock's vsync. Close the window to release the camera (each `MediaStreamTrack` is stopped explicitly).
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-dom-webrtc-video/browser';
+mount(document.getElementById('app')!);
+```
+
+Same code path — the browser's native `getUserMedia` populates a real `<video>` element. The `mount()` handle exposes `pause()` / `resume()` / `stop()` so a host (slideshow, embed, parent app) can suspend status updates or release the webcam without unmounting the surrounding DOM.
+
+## Source
+
+[`showcases/dom/webrtc-video/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/webrtc-video)
+
+- `src/video-demo.ts` — the shared `startVideo(video, log)` helper. Imports nothing platform-specific.
+- `src/gjs/gjs.ts` — Adwaita window host wiring the `VideoBridge`.
+- `src/browser/browser.ts` — exports `mount()` for slideshow / website embedding.
+- `src/browser/browser-main.ts` — standalone runner that calls `mount(document.body)` for `yarn start:browser`.
+
+## Why this showcase is non-trivial
+
+`MediaStream`-as-`srcObject` is the only Web API that hands a live media handle from one subsystem (`@gjsify/webrtc`'s GStreamer capture) into another (`@gjsify/video`'s rendering bridge). Making the contract hold up requires:
+
+1. **`getUserMedia` returning a real `MediaStream`** whose `MediaStreamTrack`s wrap actual GstWebRTC track sources — not just an empty shim.
+2. **`HTMLVideoElement.srcObject` setter** recognising a `MediaStream` (vs a `Blob`/URL string) and rerouting the underlying GStreamer pipeline to consume from the stream's tracks instead of a `playbin` source.
+3. **Tee-multiplexing** in `@gjsify/webrtc` so the same capture source can fan out to both the `VideoBridge` preview and (when added later) a `RTCPeerConnection` sender without instantiating two cameras.
+4. **Lifecycle cleanup** — when the consumer stops the tracks (`track.stop()`), the GStreamer source must release the camera so a subsequent `getUserMedia` call can re-acquire it.
+
+If any of those layers misfires, the bridge stays black or the pipeline gets stuck in `PAUSED`. A live preview is the end-to-end proof.
+
+## Related
+
+- [`webrtc-loopback`](./webrtc-loopback/) — sibling showcase that exercises the full `RTCPeerConnection` + `RTCDataChannel` surface (no media tracks).
+- [`@gjsify/video`](https://github.com/gjsify/gjsify/tree/main/packages/framework/video) — the bridge package that adapts `<video>` ↔ `Gtk.Picture`.
+- [`refs/showtime/`](https://github.com/gjsify/gjsify/tree/main/refs/showtime) — GNOME's video player, reference for the `Gtk.Picture` + `gtk4paintablesink` pattern.
+- [`refs/webrtc-samples/`](https://github.com/gjsify/gjsify/tree/main/refs/webrtc-samples) — MDN / Google reference samples for the browser-side `getUserMedia` contract.
+- [Bridge widgets pattern](../../patterns/bridges/) — how `VideoBridge` ties a DOM element to a GTK4 widget.


### PR DESCRIPTION
## Summary

- New MDX page at `website/src/content/docs/showcases/webrtc-video.mdx` documenting the webrtc-video showcase (the only showcase in `showcases/dom/`+`showcases/node/` that was still missing a website page).
- Catalog row + sidebar entry so the page is discoverable.
- Small build-script fix in the showcase's `package.json` so `gjsify run build:browser` actually produces the bundle that `dist/index.html` references.

## What was tested vs documented

- **GJS smoke test** — `gjsify run dist/gjs.js` in `showcases/dom/webrtc-video/`. Pipeline starts, `getUserMedia` returns a `MediaStream`, `VideoBridge` receives `srcObject`, GStreamer transitions through PAUSED. The runtime error in the sandbox (`pipewiresrc … target not found`) is environmental — no actual webcam / PipeWire device on the host. The end-to-end JS path executes cleanly.
- **Browser bundle** — `gjsify run build:browser` produces `dist/browser-main.js` cleanly after the build-script fix. (Pre-fix it produced `dist/browser.js`, which `dist/index.html` doesn't load.)
- **Website build** — `npx astro build` produces `dist/showcases/webrtc-video/index.html` alongside the other showcase pages; full build completes in 8.34 s (31 pages).

## Known follow-ups (out of scope for this PR)

1. **`@gjsify/example-dom-webrtc-video` is still `"private": true`** — without `"exports": { "./browser": ... }` and without being added to `packages/infra/cli/showcases.json` + `packages/infra/cli/package.json` deps, neither `gjsify showcase webrtc-video` nor `import { mount } from '@gjsify/example-dom-webrtc-video/browser'` will resolve outside a local checkout. The MDX page documents the intended public surface; promoting the package to a published showcase is a separate follow-up (matches `webrtc-loopback`'s published shape — exports map + drop `private` + register in showcases.json + add to CLI deps).
2. **`gjsify showcase` discoverability** — once the package is published, also add it to `astro.config.mjs`'s `vite.optimizeDeps.exclude` if/when the website ever does a live embed (the other 4 published showcases are excluded today; webrtc-video doesn't need it yet because the MDX page is doc-only, like `webrtc-loopback`'s).

## Test plan

- [ ] CI green
- [ ] `cd website && npx astro build` succeeds locally and emits `dist/showcases/webrtc-video/index.html`
- [ ] Spot-check the rendered page in `astro dev` for layout parity with `webrtc-loopback`