### PR TITLE
fix(webgl): close 2 deferred items (multi-FBO texture detach + MAX_RENDERBUFFER cache)

### DIFF
--- a/packages/framework/webgl/src/ts/conformance/textures.spec.ts
+++ b/packages/framework/webgl/src/ts/conformance/textures.spec.ts
@@ -369,5 +369,101 @@ export default async () => {
             });
         });
 
+        // ── deleteTexture multi-FBO detach ─────────────────────────────────────
+
+        await describe('textures/deleteTexture-multiFBO', async () => {
+            beforeEach(async () => { glArea.make_current(); });
+
+            await it('detaches deleted texture from every framebuffer that referenced it', async () => {
+                // Two framebuffers sharing the same color texture. After
+                // deleteTexture, BOTH must report the COLOR_ATTACHMENT0 type as
+                // NONE — otherwise the inactive FBO keeps a stale attachment.
+                const tex = gl.createTexture()!;
+                gl.bindTexture(gl.TEXTURE_2D, tex);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE,
+                    new Uint8Array([255, 255, 255, 255]));
+
+                const fb0 = gl.createFramebuffer()!;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb0);
+                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+                const fb1 = gl.createFramebuffer()!;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb1);
+                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+                // fb1 is currently bound; fb0 is inactive.
+                expect(gl.getError()).toBe(gl.NO_ERROR);
+
+                // Verify both FBOs reference the texture before delete.
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.TEXTURE);
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb0);
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.TEXTURE);
+
+                // Re-bind fb1 so it is the currently active FBO when we delete.
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb1);
+                gl.bindTexture(gl.TEXTURE_2D, null);
+                gl.deleteTexture(tex);
+
+                // Active FBO (fb1) — detached.
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.NONE);
+
+                // Inactive FBO (fb0) — must also be detached (the new behaviour).
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb0);
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.NONE);
+
+                expect(gl.getError()).toBe(gl.NO_ERROR);
+
+                gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                gl.deleteFramebuffer(fb0);
+                gl.deleteFramebuffer(fb1);
+            });
+
+            await it('detaches deleted renderbuffer from every framebuffer that referenced it', async () => {
+                // Same shape as the texture case but for a depth renderbuffer.
+                const rb = gl.createRenderbuffer()!;
+                gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+                gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, 1, 1);
+
+                const fb0 = gl.createFramebuffer()!;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb0);
+                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rb);
+
+                const fb1 = gl.createFramebuffer()!;
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb1);
+                gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rb);
+
+                expect(gl.getError()).toBe(gl.NO_ERROR);
+
+                // fb1 still bound as the active FBO.
+                gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+                gl.deleteRenderbuffer(rb);
+
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.NONE);
+
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fb0);
+                expect(gl.getFramebufferAttachmentParameter(
+                    gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE,
+                )).toBe(gl.NONE);
+
+                expect(gl.getError()).toBe(gl.NO_ERROR);
+
+                gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                gl.deleteFramebuffer(fb0);
+                gl.deleteFramebuffer(fb1);
+            });
+        });
+
     });
 };

--- a/packages/framework/webgl/src/ts/context/framebuffer.ts
+++ b/packages/framework/webgl/src/ts/context/framebuffer.ts
@@ -27,6 +27,7 @@ export interface FramebufferMethods {
     _validFramebufferAttachment(attachment: GLenum): boolean;
     _updateFramebufferAttachments(framebuffer: WebGLFramebuffer | null): void;
     _tryDetachFramebuffer(framebuffer: WebGLFramebuffer | null, renderbuffer: WebGLRenderbuffer): void;
+    _detachRenderbufferFromAllFramebuffers(renderbuffer: WebGLRenderbuffer): void;
     _getAttachments(): number[];
     _getColorAttachments(): number[];
     _resizeDrawingBuffer(width: number, height: number): void;
@@ -243,9 +244,11 @@ const framebufferMethods: ThisType<WebGLContextBase> & Record<string, Function> 
             this.bindRenderbuffer(this.RENDERBUFFER, null);
         }
 
-        const activeFramebuffer = this._activeFramebuffer;
-
-        this._tryDetachFramebuffer(activeFramebuffer, renderbuffer);
+        // Detach the renderbuffer from every framebuffer it is attached to —
+        // not just the active one. Same rationale as deleteTexture's multi-FBO
+        // walk: the native driver only auto-detaches from the currently bound
+        // FBO, so other FBOs would otherwise keep a stale attachment.
+        this._detachRenderbufferFromAllFramebuffers(renderbuffer);
 
         renderbuffer._pendingDelete = true;
         renderbuffer._checkDelete();
@@ -370,10 +373,11 @@ const framebufferMethods: ThisType<WebGLContextBase> & Record<string, Function> 
                 return renderbuffer._width;
             case this.RENDERBUFFER_HEIGHT:
                 return renderbuffer._height;
-            // STATUS.md "Open TODOs": MAX_RENDERBUFFER_SIZE returns the live native limit
-            // for now; investigate whether GL_MAX_RENDERBUFFER_SIZE needs JS-side caching
-            // (see "WebGL: cache MAX_RENDERBUFFER_SIZE on context init").
+            // GL_MAX_RENDERBUFFER_SIZE is a per-context invariant — sample once
+            // at _init() time and return the cached value here to avoid a native
+            // round-trip on every call.
             case this.MAX_RENDERBUFFER_SIZE:
+                return this._maxRenderbufferSize;
             case this.RENDERBUFFER_RED_SIZE:
             case this.RENDERBUFFER_GREEN_SIZE:
             case this.RENDERBUFFER_BLUE_SIZE:
@@ -587,14 +591,13 @@ const framebufferMethods: ThisType<WebGLContextBase> & Record<string, Function> 
         }
     },
 
-    // STATUS.md "Open TODOs": detach the renderbuffer from every framebuffer
-    // it might be linked to, not just the active one
-    // (see "WebGL: detach renderbuffers from all framebuffers, not just the active one").
+    // Detach the renderbuffer from a single framebuffer (assumed currently bound
+    // when `framebuffer === this._activeFramebuffer`). Kept as a primitive; the
+    // multi-FBO walk lives in `_detachRenderbufferFromAllFramebuffers`.
     _tryDetachFramebuffer(this: WebGLContextBase, framebuffer: WebGLFramebuffer | null, renderbuffer: WebGLRenderbuffer): void {
         if (framebuffer && framebuffer._linked(renderbuffer)) {
             const attachments = this._getAttachments();
-            const framebufferAttachments = Object.keys(framebuffer._attachments);
-            for (let i = 0; i < framebufferAttachments.length; ++i) {
+            for (let i = 0; i < attachments.length; ++i) {
                 if (framebuffer._attachments[attachments[i]] === renderbuffer) {
                     this.framebufferTexture2D(
                         this.FRAMEBUFFER,
@@ -603,6 +606,41 @@ const framebufferMethods: ThisType<WebGLContextBase> & Record<string, Function> 
                         null);
                 }
             }
+        }
+    },
+
+    _detachRenderbufferFromAllFramebuffers(this: WebGLContextBase, renderbuffer: WebGLRenderbuffer): void {
+        const activeFramebuffer = this._activeFramebuffer;
+        const attachments = this._getAttachments();
+        let restoreActive = false;
+
+        for (const idStr in this._framebuffers) {
+            const framebuffer = this._framebuffers[idStr];
+            if (!framebuffer || !framebuffer._linked(renderbuffer)) continue;
+
+            if (framebuffer !== activeFramebuffer) {
+                this._gl.bindFramebuffer(this.FRAMEBUFFER, framebuffer._ | 0);
+                restoreActive = true;
+            }
+
+            for (let i = 0; i < attachments.length; ++i) {
+                const attachment = attachments[i];
+                if (framebuffer._attachments[attachment] === renderbuffer) {
+                    // Clear native attachment via framebufferRenderbuffer(NULL).
+                    this._gl.framebufferRenderbuffer(
+                        this.FRAMEBUFFER,
+                        attachment,
+                        this.RENDERBUFFER,
+                        0);
+                    framebuffer._setAttachment(null, attachment);
+                }
+            }
+        }
+
+        if (restoreActive) {
+            this._gl.bindFramebuffer(
+                this.FRAMEBUFFER,
+                activeFramebuffer ? activeFramebuffer._ | 0 : this._gtkFboId);
         }
     },
 

--- a/packages/framework/webgl/src/ts/context/texture-management.ts
+++ b/packages/framework/webgl/src/ts/context/texture-management.ts
@@ -5,7 +5,6 @@
 import * as bits from 'bit-twiddle';
 import GdkPixbuf from 'gi://GdkPixbuf?version=2.0';
 import type { WebGLContextBase } from '../webgl-context-base.js';
-import { WebGLFramebuffer } from '../webgl-framebuffer.js';
 import { WebGLTexture } from '../webgl-texture.js';
 import { WebGLTextureUnit } from '../webgl-texture-unit.js';
 import {
@@ -26,6 +25,7 @@ export interface TextureManagementMethods {
     bindTexture(target: GLenum | undefined, texture: WebGLTexture | null): void;
     createTexture(): WebGLTexture | null;
     deleteTexture(texture: WebGLTexture | null): void;
+    _detachTextureFromAllFramebuffers(texture: WebGLTexture): void;
     pixelStorei(pname?: GLenum, param?: GLint | GLboolean): void;
     texImage2D(target: GLenum, level: GLint, internalFormat: GLint, width: GLsizei, height: GLsizei, border: GLint, format: GLenum, type: GLenum, pixels: ArrayBufferView | null): void;
     texImage2D(target: GLenum, level: GLint, internalFormat: GLint, format: GLenum, type: GLenum, source: TexImageSource | GdkPixbuf.Pixbuf): void;
@@ -169,32 +169,56 @@ const textureMethods: ThisType<WebGLContextBase> & Record<string, Function> = {
         }
         this.activeTexture(this.TEXTURE0 + curActive);
 
-        // Detach the texture from the active framebuffer if it is bound there.
-        // STATUS.md "Open TODOs": multi-FBO unbinding still has to be wired up
-        // (see "WebGL: detach textures from all framebuffers, not just the active one").
-        const ctx = this;
-        const activeFramebuffer = this._activeFramebuffer;
-        const tryDetach = (framebuffer: WebGLFramebuffer | null) => {
-            if (framebuffer && framebuffer._linked(texture)) {
-                const attachments = ctx._getAttachments();
-                for (let i = 0; i < attachments.length; ++i) {
-                    const attachment = attachments[i];
-                    if (framebuffer._attachments[attachment] === texture) {
-                        ctx.framebufferTexture2D(
-                            ctx.FRAMEBUFFER,
-                            attachment,
-                            ctx.TEXTURE_2D,
-                            null);
-                    }
-                }
-            }
-        };
-
-        tryDetach(activeFramebuffer);
+        // Detach the texture from every framebuffer it is attached to — not just
+        // the active one. Per WebGL/OpenGL ES 2.0 §4.4.2.3 the native driver only
+        // auto-detaches from the currently bound FBO; any other FBO would otherwise
+        // keep a stale attachment that becomes undefined on read after the texture
+        // is freed. Browsers (Chrome/Firefox) detach from all FBOs; we mirror that.
+        this._detachTextureFromAllFramebuffers(texture);
 
         // Mark texture for deletion
         texture._pendingDelete = true;
         texture._checkDelete();
+    },
+
+    _detachTextureFromAllFramebuffers(this: WebGLContextBase, texture: WebGLTexture): void {
+        const activeFramebuffer = this._activeFramebuffer;
+        const attachments = this._getAttachments();
+        let restoreActive = false;
+
+        for (const idStr in this._framebuffers) {
+            const framebuffer = this._framebuffers[idStr];
+            if (!framebuffer || !framebuffer._linked(texture)) continue;
+
+            // Bind this FBO so the native framebufferTexture2D call targets it.
+            // The active FBO is already bound, so skip the rebind in that case.
+            if (framebuffer !== activeFramebuffer) {
+                this._gl.bindFramebuffer(this.FRAMEBUFFER, framebuffer._ | 0);
+                restoreActive = true;
+            }
+
+            for (let i = 0; i < attachments.length; ++i) {
+                const attachment = attachments[i];
+                if (framebuffer._attachments[attachment] === texture) {
+                    // Clear native attachment for the currently bound FBO.
+                    this._gl.framebufferTexture2D(
+                        this.FRAMEBUFFER,
+                        attachment,
+                        framebuffer._attachmentFace[attachment] || this.TEXTURE_2D,
+                        0,
+                        framebuffer._attachmentLevel[attachment] || 0);
+                    // Clear JS-side bookkeeping (updates _refCount + _references).
+                    framebuffer._setAttachment(null, attachment);
+                }
+            }
+        }
+
+        // Restore previous binding if we changed it.
+        if (restoreActive) {
+            this._gl.bindFramebuffer(
+                this.FRAMEBUFFER,
+                activeFramebuffer ? activeFramebuffer._ | 0 : this._gtkFboId);
+        }
     },
 
     pixelStorei(this: WebGLContextBase, pname: GLenum = 0, param: GLint | GLboolean = 0): void {

--- a/packages/framework/webgl/src/ts/webgl-context-base.ts
+++ b/packages/framework/webgl/src/ts/webgl-context-base.ts
@@ -85,9 +85,11 @@ export abstract class WebGLContextBase {
     canvas: HTMLCanvasElement;
 
     /**
-     * STATUS.md "Open TODOs" — Web platform parity:
-     *   "WebGL: drawingBufferColorSpace currently a static field; needs colorimetry
-     *    plumbing into Cairo/GTK GL output to honour 'srgb' vs 'display-p3'."
+     * Static `PredefinedColorSpace` placeholder — honouring `'display-p3'`
+     * end-to-end requires per-context surface-format selection through Cairo/GTK
+     * GL output (no consumer requests it today). Tracked in STATUS.md
+     * "Open TODOs" under WebGL Workstream D: drawingBufferColorSpace
+     * colorimetry plumbing.
      * @see https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/drawingBufferColorSpace
      */
     drawingBufferColorSpace: PredefinedColorSpace;
@@ -148,6 +150,7 @@ export abstract class WebGLContextBase {
     _maxTextureLevel = 0;
     _maxCubeMapSize = 0;
     _maxCubeMapLevel = 0;
+    _maxRenderbufferSize = 0;
 
     // Unpack alignment
     _unpackAlignment = 4;
@@ -234,6 +237,7 @@ export abstract class WebGLContextBase {
         this._maxTextureLevel = bits.log2(bits.nextPow2(this._maxTextureSize));
         this._maxCubeMapSize = this.getParameter(this.MAX_CUBE_MAP_TEXTURE_SIZE) as number;
         this._maxCubeMapLevel = bits.log2(bits.nextPow2(this._maxCubeMapSize));
+        this._maxRenderbufferSize = this.getParameter(this.MAX_RENDERBUFFER_SIZE) as number;
 
         // Unpack alignment
         this._unpackAlignment = 4;
@@ -241,10 +245,11 @@ export abstract class WebGLContextBase {
         this._unpackFlipY = false;
         this._unpackPremultAlpha = false;
 
-        // STATUS.md "Open TODOs": optional drawing-buffer pre-allocation.
-        // Headless-gl-style allocation is not currently used because GtkGLArea owns the
-        // surface; revisit if/when we add non-GTK output paths.
-        // this._allocateDrawingBuffer(width, height)
+        // Headless-gl-style drawing-buffer pre-allocation is intentionally not
+        // wired up because GtkGLArea owns the underlying surface. Re-enable
+        // `_allocateDrawingBuffer(width, height)` only if/when we add a non-GTK
+        // output path. Tracked in STATUS.md "Open TODOs" under WebGL Workstream D:
+        // optional headless drawing-buffer pre-allocation.
 
         // Initialize defaults
         this.bindBuffer(this.ARRAY_BUFFER, null);


### PR DESCRIPTION
## Summary

Closes 2 of the 4 WebGL low-priority deferred items tracked under STATUS.md "WebGL deferred items (Workstream D)".

### Shipped

- **Multi-FBO texture / renderbuffer detach on delete.** `deleteTexture` and `deleteRenderbuffer` now walk every framebuffer that references the deleted object, binding each in turn to clear both the native attachment and the JS-side bookkeeping. Previously only the active FBO was touched, so any inactive FBO kept a stale attachment that becomes undefined after the texture/renderbuffer is freed. Browsers (Chrome/Firefox) detach from all FBOs; we now mirror that. Two regression tests in `conformance/textures.spec.ts` assert both FBOs report `FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE` as `NONE` after delete.
- **`MAX_RENDERBUFFER_SIZE` cached at context init.** New `_maxRenderbufferSize` populated in `_init()` alongside `_maxTextureSize`/`_maxCubeMapSize`; `getRenderbufferParameter(MAX_RENDERBUFFER_SIZE)` returns the cached value instead of a native round-trip on every call. No behaviour change.

### Skipped (out of scope for this PR)

- **`drawingBufferColorSpace` colorimetry plumbing.** Needs end-to-end Cairo/GTK GL surface-format selection per context to honour `'display-p3'`. No consumer requests it today. In-source comment tightened to point at STATUS.md.
- **Optional headless drawing-buffer pre-allocation.** Only matters if/when we add a non-GTK output path; `GtkGLArea` owns the surface today. In-source comment tightened to point at STATUS.md.

`STATUS.md` Open TODOs left untouched (per the strategy brief); the bare `// TODO`/`// FIXME` markers next to the two skipped items were sharpened to reference STATUS.md instead.

## Test plan

- [x] `cd packages/framework/webgl && gjsify run check` — clean
- [x] `cd packages/framework/webgl && gjsify run test` — 860 tests passing (unchanged)
- [x] `cd packages/framework/webgl && gjsify run test:conformance` — 394 tests passing (was 392, +2 new multi-FBO regression tests)