### PR TITLE
docs(showcases): polish canvas2d-fireworks page

### DIFF
--- a/website/src/content/docs/showcases/canvas2d-fireworks.mdx
+++ b/website/src/content/docs/showcases/canvas2d-fireworks.mdx
@@ -35,7 +35,7 @@ Same code — the `<canvas>` is a real browser canvas, not a bridge.
 
 ## Source
 
-[`showcases/dom/canvas2d-fireworks/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/canvas2d-fireworks) — entry points: `src/gjs/main.ts` (GTK shell), `src/browser/browser.ts` (mount), `src/shared/fireworks.ts` (the particle simulation, runs unchanged in both targets).
+[`showcases/dom/canvas2d-fireworks/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/canvas2d-fireworks) — entry points: `src/gjs/gjs.ts` (GTK shell), `src/browser/browser.ts` (mount), `src/browser/browser-main.ts` (standalone fullscreen browser entry), `src/fireworks.ts` (the particle simulation, runs unchanged in both targets).
 
 The shared module is the value: it imports nothing platform-specific, only the standard `Canvas 2D` API surface. That surface is the contract between the browser and `@gjsify/canvas2d` — every method it uses must hold up identically in both runtimes.
 


### PR DESCRIPTION
## Summary
- Fix three stale source paths in `## Source` of `canvas2d-fireworks.mdx` so they match the actual on-disk layout: `src/gjs/main.ts` -> `src/gjs/gjs.ts`, `src/shared/fireworks.ts` -> `src/fireworks.ts`.
- Mention the existing `src/browser/browser-main.ts` standalone fullscreen browser entry alongside the `browser.ts` mount module.
- Smoke-tested the showcase against both targets (see Test plan below).

Part of the open STATUS.md TODO `Test + extend the new showcases, then embed them on the website.` — `canvas2d-fireworks` verified clean on 2026-05-24, page polished.

## Test plan
- [x] `gjsify build src/gjs/gjs.ts --app gjs` -> 473 KB bundle, no warnings.
- [x] `gjsify build src/browser/browser-main.ts --app browser` -> 544 KB bundle, no warnings.
- [x] `cd website && npx astro build` -> 30 pages built, no errors.