### PR TITLE
docs(showcases): fix stale source paths in webrtc-loopback page

### DIFF
--- a/website/src/content/docs/showcases/webrtc-loopback.mdx
+++ b/website/src/content/docs/showcases/webrtc-loopback.mdx
@@ -33,11 +33,9 @@ Exact same flow — uses the browser's native `RTCPeerConnection`. The contract 
 
 ## Source
 
-[`showcases/dom/webrtc-loopback/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/webrtc-loopback)
+[`showcases/dom/webrtc-loopback/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/webrtc-loopback) — entry points: `src/gjs/gjs.ts` (GJS shell, GLib MainLoop), `src/browser/browser.ts` (mount), `src/browser/browser-main.ts` (standalone fullscreen browser entry), `src/loopback-demo.ts` (the loopback dance — peer setup, signaling, data-channel wiring, runs unchanged in both targets).
 
-- `src/shared/loopback.ts` — the loopback dance (peer setup, signaling, data-channel wiring). Imports only `RTCPeerConnection` + `RTCSessionDescription` + `RTCIceCandidate` from the global namespace.
-- `src/gjs/main.ts` — Adwaita window host
-- `src/browser/browser.ts` — DOM mount
+The shared module imports only `RTCPeerConnection` + `RTCSessionDescription` + `RTCIceCandidate` from the global namespace. That surface is the contract between the browser's native WebRTC and `@gjsify/webrtc` — every method it uses must hold up identically in both runtimes.
 
 ## Why this showcase is non-trivial
 


### PR DESCRIPTION
## Summary

- Fix stale source paths in `## Source` of `webrtc-loopback.mdx` so they match the actual on-disk layout: drop the non-existent `src/shared/loopback.ts` (real path is `src/loopback-demo.ts`) and `src/gjs/main.ts` (real entry is `src/gjs/gjs.ts`), and mention the existing `src/browser/browser-main.ts` standalone fullscreen browser entry alongside the `browser.ts` mount module.
- Sibling fix to #302 (canvas2d-fireworks), which noted that `webrtc-loopback` had the same drift.

## Test plan

- [x] `cd website && npx astro build` -> 30 pages built, `/showcases/webrtc-loopback/index.html` emitted, no errors.