### PR TITLE
docs(showcases): fix stale source paths in excalibur-jelly-jumper + minimalist-browser pages

### DIFF
--- a/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
+++ b/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
@@ -37,7 +37,7 @@ The asset loader fetches tilemaps + spritesheets from `@gjsify/example-dom-excal
 
 ## Source
 
-[`showcases/dom/excalibur-jelly-jumper/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/excalibur-jelly-jumper) — shared scene/actors live in `src/shared/`, the `gjs/` and `browser/` entries differ only in the host wiring (Adw.Application vs `mount(container)`).
+[`showcases/dom/excalibur-jelly-jumper/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/excalibur-jelly-jumper) — entry points: `src/gjs/gjs.ts` (Adw.Application + `JellyJumperWindow`), `src/browser/browser.ts` (mount module — Adwaita-styled shell + `startGame(canvas)`), `src/browser/browser-main.ts` (standalone fullscreen browser entry). Shared scene/actor code lives at the top level — `src/game.ts`, `src/resources.ts`, `src/scenes/`, `src/actors/`, `src/components/`, `src/physics/`, `src/state/`, `src/ui/` — and runs unchanged in both targets.
 
 ## Why this showcase is load-bearing
 

--- a/website/src/content/docs/showcases/minimalist-browser.mdx
+++ b/website/src/content/docs/showcases/minimalist-browser.mdx
@@ -35,10 +35,10 @@ The same `<input>` + button handlers, the same `<iframe>` element. The browser e
 
 [`showcases/dom/minimalist-browser/`](https://github.com/gjsify/gjsify/tree/main/showcases/dom/minimalist-browser)
 
-- `src/shared/url-bar.ts` — URL parsing + normalization (shared)
-- `src/shared/history.ts` — back / forward stack management (shared)
-- `src/gjs/main.ts` — `Adw.ApplicationWindow` host
-- `src/browser/browser.ts` — DOM mount
+- `src/browser-demo.ts` — shared `BrowserCore` (history stack, postMessage wiring, built-in `page:<name>` library) — runs unchanged in both targets
+- `src/gjs/gjs.ts` — `Adw.Application` + `Adw.ApplicationWindow` host driving `IFrameBridge`
+- `src/browser/browser.ts` — `mount(container)` module: DOM shell + real `<iframe>`
+- `src/browser/browser-main.ts` — standalone fullscreen browser entry (calls `mount(document.body)`)
 
 ## The IFrameBridge story
 


### PR DESCRIPTION
## Summary

Sibling cleanup to #302 (which fixed `canvas2d-fireworks.mdx`). Both of these pages described a `src/shared/` layout and `src/gjs/main.ts` entrypoints that never matched the actual on-disk source tree.

### `excalibur-jelly-jumper.mdx`

Old `## Source` blurb claimed "shared scene/actors live in `src/shared/`" and implied unspecified `gjs/`/`browser/` entry files. Reality:

- entry: `src/gjs/gjs.ts` (Adw.Application + `JellyJumperWindow`), NOT `src/gjs/main.ts`
- mount module: `src/browser/browser.ts` (Adwaita-styled shell + `startGame(canvas)`)
- standalone browser entry: `src/browser/browser-main.ts` (was not mentioned — added it alongside the mount module, matching #302's pattern)
- shared code lives at the top level (`src/game.ts`, `src/resources.ts`, `src/scenes/`, `src/actors/`, `src/components/`, `src/physics/`, `src/state/`, `src/ui/`), NOT in `src/shared/`

### `minimalist-browser.mdx`

Old `## Source` list named four files, none of which exist:

- `src/shared/url-bar.ts` and `src/shared/history.ts` -> there is no `src/shared/`; the shared core is a single file `src/browser-demo.ts` (`BrowserCore` + history stack + built-in `page:<name>` library)
- `src/gjs/main.ts` -> actual entry is `src/gjs/gjs.ts`
- `src/browser/browser.ts` -> still correct, kept; added `src/browser/browser-main.ts` standalone entry alongside it

## Forbidden-files audit

No changes to `packages/`, `webrtc-loopback.mdx`, `canvas2d-fireworks.mdx`, `webrtc-video.mdx`, `framework/bridges.mdx`, `STATUS.md`, `AGENTS.md`, `CLAUDE.md`, `website/astro.config.mjs`, or `showcases/index.mdx`. Frontmatter left untouched.

## Test plan

- [x] `cd website && npx astro build` -> 30 pages built, both pages emitted (`/showcases/excalibur-jelly-jumper/index.html`, `/showcases/minimalist-browser/index.html`).