### PR TITLE
fix(website): nicer showcase names, single chevron, coverage on subpages, live-demo chrome

### DIFF
--- a/packages/web/adwaita-web/scss/_headerbar.scss
+++ b/packages/web/adwaita-web/scss/_headerbar.scss
@@ -13,12 +13,16 @@ adw-header-bar {
   background-color: var(--headerbar-bg-color);
   color: var(--headerbar-fg-color);
   box-shadow: inset 0 -1px var(--headerbar-shade-color);
+  // flex-shrink: 0 ensures the headerbar never collapses inside a flex-column
+  // adw-window, preventing a spurious spacing band between bar and content.
   flex-shrink: 0;
 
   .adw-header-bar-center {
     flex: 1;
     display: flex;
     justify-content: center;
+    // min-width: 0 prevents the title from pushing the end buttons off-screen.
+    min-width: 0;
   }
 
   .adw-header-bar-title {
@@ -34,13 +38,20 @@ adw-header-bar {
     align-items: center;
     padding: 0 6px;
     gap: 4px;
+    // flex-shrink: 0 keeps the start buttons visible when the window is narrow.
+    flex-shrink: 0;
   }
 
   .adw-header-bar-end {
     display: flex;
     align-items: center;
+    // justify-content: flex-end aligns end buttons to the right edge of the
+    // end section, fixing the pause-button misposition bug.
+    justify-content: flex-end;
     padding: 0 6px;
     gap: 4px;
+    // flex-shrink: 0 keeps the end buttons visible when the window is narrow.
+    flex-shrink: 0;
   }
 
   .adw-header-btn {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -78,7 +78,7 @@ export default defineConfig({
         {
           label: 'Patterns',
           items: [
-            { slug: 'patterns' },
+            { slug: 'patterns', label: 'Overview' },
             { slug: 'patterns/gobject-classes' },
             { slug: 'patterns/bridges' },
           ],
@@ -92,7 +92,7 @@ export default defineConfig({
         {
           label: 'Showcases',
           items: [
-            { slug: 'showcases' },
+            { slug: 'showcases', label: 'Overview' },
             { slug: 'showcases/canvas2d-fireworks' },
             { slug: 'showcases/excalibur-jelly-jumper' },
             { slug: 'showcases/three-geometry-teapot' },

--- a/website/src/components/NodeApiCoverage.astro
+++ b/website/src/components/NodeApiCoverage.astro
@@ -57,6 +57,17 @@ function statusLabel(status: NodeApiStatus): string {
 		</div>
 	</div>
 
+	<style>
+		/* Hide the browser's native <summary> disclosure triangle so only the
+		   custom .adw-chevron span is shown — prevents the double-chevron bug. */
+		summary.adw-row-summary {
+			list-style: none;
+		}
+		summary.adw-row-summary::-webkit-details-marker {
+			display: none;
+		}
+	</style>
+
 	<div class="adw-boxed-list">
 		{nodeApiCategories.map((cat) => {
 			const t = tallyNodeCategory(cat);

--- a/website/src/components/WebStandardsCoverage.astro
+++ b/website/src/components/WebStandardsCoverage.astro
@@ -66,6 +66,17 @@ function statusLabel(status: StandardStatus): string {
 		</div>
 	</div>
 
+	<style>
+		/* Hide the browser's native <summary> disclosure triangle so only the
+		   custom .adw-chevron span is shown — prevents the double-chevron bug. */
+		summary.adw-row-summary {
+			list-style: none;
+		}
+		summary.adw-row-summary::-webkit-details-marker {
+			display: none;
+		}
+	</style>
+
 	<div class="adw-boxed-list">
 		{webStandardsCategories.map((cat) => {
 			const t = tallyCategory(cat);

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -37,7 +37,7 @@ npx @gjsify/cli build src/index.ts --outfile dist/index.js
 | `--outdir`, `-d` | path | from `package.json` | Output directory (library mode) |
 | `--minify` | bool | `false` | Minify the output |
 | `--globals` | string | `"auto"` | Globals mode (see below) |
-| `--shebang` | bool | `false` | Prepend `#!/usr/bin/env -S gjs -m` to the outfile and chmod it `0o755`. Only with `--app gjs` and a single `--outfile`. |
+| `--shebang` | bool | `false` | Prepend a target-appropriate shebang to the outfile and chmod it `0o755`: `#!/usr/bin/env -S gjs -m` for `--app gjs`, `#!/usr/bin/env node` for `--app node`. Applies to GJS and Node app builds with a single `--outfile`. |
 | `--watch`, `-w` | bool | `false` | Watch source files and rebuild on change. Logs each rebuild with duration; SIGINT cleanly stops the watcher. Rejected with `--library`. Requires the npm `rolldown` engine — run under Node. |
 | `--verbose` | bool | `false` | Show detected globals and build details |
 

--- a/website/src/content/docs/how-it-works.md
+++ b/website/src/content/docs/how-it-works.md
@@ -155,6 +155,23 @@ Use `gjsify info` without `--export` for a human-readable report of every detect
 
 Node.js servers (`http.Server.listen()`, `net.Server.listen()`, `dgram.Socket.bind()`) need a running GLib MainLoop to drive the underlying Gio async I/O. GJSify starts it for you via an internal `ensureMainLoop()` helper — you do not need to call it from application code. GTK applications keep using `Gtk.Application.runAsync()` as usual.
 
+## Vite-plugin track (browser / web-content targets)
+
+gjsify's build plugins are Rollup-shaped, which means they run under both Rolldown (via the `gjsify build` CLI) and Vite (for HMR-enabled dev servers). For web-content targets — browser extensions, GJS-WebKit hybrid apps, or games running in a WebView — you can use Vite during development for fast module reloads, then switch to `gjsify build --app browser` for the production bundle.
+
+Two plugins that always work under Vite are already published:
+
+| Plugin | Purpose |
+|---|---|
+| `@gjsify/vite-plugin-blueprint` | `.blp` → XML string via `blueprint-compiler`; `import T from './window.blp'` works in both Vite dev and Rolldown prod |
+| `@gjsify/vite-plugin-gettext` | `xgettext` / `msgfmt` / `po2json` pipeline; same plugin in both environments |
+
+The same plugins are composed by `gjsify build` under the hood — there is no divergence between your dev and prod pipelines.
+
+## Location-independent published bundles
+
+GJS bundles built with gjsify resolve their bundled dependencies' data files at runtime from the bundle's actual on-disk location. A dep that loads its own `package.json`, i18n files, or templates via `import.meta.url` continues to work after the bundle is installed globally — even if the bundle ends up at a different `node_modules` depth than where it was built. This is handled transparently by `@gjsify/module`'s PnP-aware `createRequire`; no special configuration is required.
+
 ## Where to go next
 
 - [Getting Started](/gjsify/getting-started/) — scaffold and run your first app

--- a/website/src/content/docs/packages/node.mdx
+++ b/website/src/content/docs/packages/node.mdx
@@ -3,7 +3,11 @@ title: Node.js Modules
 description: 42 Node.js API modules implemented for GJS using native GNOME libraries
 ---
 
+import NodeApiCoverage from '../../../components/NodeApiCoverage.astro';
+
 42 Node.js API modules (plus `@gjsify/node-polyfills` meta) implemented for GJS using native GNOME libraries.
+
+<NodeApiCoverage />
 
 | Package | GNOME Libs | Status | Notes |
 |---|---|---|---|

--- a/website/src/content/docs/packages/node.mdx
+++ b/website/src/content/docs/packages/node.mdx
@@ -1,11 +1,11 @@
 ---
 title: Node.js Modules
-description: 42 Node.js API modules implemented for GJS using native GNOME libraries
+description: 41 Node.js API modules implemented for GJS using native GNOME libraries
 ---
 
 import NodeApiCoverage from '../../../components/NodeApiCoverage.astro';
 
-42 Node.js API modules (plus `@gjsify/node-polyfills` meta) implemented for GJS using native GNOME libraries.
+41 Node.js API modules (plus `@gjsify/node-polyfills` meta and 5 Vala native bridges) implemented for GJS using native GNOME libraries.
 
 <NodeApiCoverage />
 
@@ -26,9 +26,9 @@ import NodeApiCoverage from '../../../components/NodeApiCoverage.astro';
 | `events` | — | Full | EventEmitter (prototype methods enumerable for socket.io v4) |
 | `fs` | Gio | Full | sync/callback/promises/streams/FSWatcher; URL path args everywhere |
 | `globals` | GLib | Full | process, Buffer, structuredClone, TextEncoder/Decoder, URL, queueMicrotask |
-| `http` | Soup 3.0 | Partial | Server (Soup.Server), IncomingMessage, ServerResponse, Agent |
-| `http2` | — | Stub | constants only |
-| `https` | — | Partial | Agent, stub request/get |
+| `http` | Soup 3.0 | Full | Server (Soup.Server), IncomingMessage, ServerResponse, Agent |
+| `http2` | Soup 3.0 | Full | h2 via ALPN; PUSH_PROMISE/HEADERS/DATA via `@gjsify/http2-native` (Vala + libnghttp2) |
+| `https` | Soup 3.0 | Full | TLS-backed Agent, request/get via Soup + GIO |
 | `inspector` | — | Stub | Session stub |
 | `module` | Gio, GLib | Full | builtinModules, isBuiltin, createRequire |
 | `net` | Gio | Full | Socket (Gio.SocketClient), Server (Gio.SocketService) |
@@ -43,13 +43,13 @@ import NodeApiCoverage from '../../../components/NodeApiCoverage.astro';
 | `string_decoder` | — | Full | UTF-8, Base64, hex, streaming |
 | `sys` | — | Full | Deprecated alias for `util` |
 | `timers` | — | Full | setTimeout/setInterval/setImmediate + promises (GLib-safe) |
-| `tls` | Gio | Partial | TLSSocket via Gio.TlsClientConnection |
+| `tls` | Gio | Full | TLSSocket via Gio.TlsClientConnection + `@gjsify/tls-native` (Vala) |
 | `tty` | — | Full | ReadStream/WriteStream, ANSI escapes |
 | `url` | GLib | Full | URL (static `createObjectURL`/`revokeObjectURL`), URLSearchParams via GLib.Uri |
 | `util` | — | Full | inspect, format, promisify, types |
-| `v8` | — | Stub | getHeapStatistics, serialize/deserialize (JSON) |
+| `v8` | — | Partial | Wire-format v15 serialize/deserialize; getHeapStatistics; no heap snapshot or CPU profile |
 | `vm` | — | Partial | runInThisContext, runInNewContext, Script, compileFunction |
-| `worker_threads` | Gio, GLib | Partial | MessageChannel/Port/BroadcastChannel, subprocess Worker — no SharedArrayBuffer |
+| `worker_threads` | Gio, GLib | Partial | MessageChannel/Port/BroadcastChannel, subprocess Worker; SharedArrayBuffer via `@gjsify/sab-native` (cross-process, file-based) |
 | `ws` (npm) | Soup 3.0 | Partial | `ws`-compat WebSocket client + WebSocketServer over `@gjsify/websocket` |
 | `zlib` | — | Full | gzip/deflate via Web Compression API, Gio fallback |
 

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -10,7 +10,7 @@ GJSify is organised into four pillars, each implementing standard APIs on top of
 | Category | Packages | Description |
 |---|---|---|
 | [Node.js Modules](./node) | 41 + 1 meta | `fs`, `net`, `http`, `crypto`, `stream`, `events`, `sqlite`, `ws`, and more |
-| [Web APIs](./web) | 18 + 1 meta | `fetch`, `XMLHttpRequest`, `WebSocket`, `WebRTC`, `WebAudio`, `Streams`, `DOMParser`, and more |
+| [Web APIs](./web) | 19 + 1 native bridge + 1 meta | `fetch`, `XMLHttpRequest`, `WebSocket`, `WebRTC`, `WebAudio`, `Streams`, `DOMParser`, `MessageChannel`, `WebAssembly`, and more |
 | [DOM & Bridges](./dom) | 2 DOM + 6 bridges | Canvas2D, WebGL, DOM elements; GTK-backed Canvas/WebGL/Video/IFrame bridges |
 | Adwaita for browser | 3 | `@gjsify/adwaita-web`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -3,8 +3,6 @@ title: Overview
 description: Summary of all GJSify packages
 ---
 
-import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro';
-import NodeApiCoverage from '../../../components/NodeApiCoverage.astro';
 import BridgesGrid from '../../../components/BridgesGrid.astro';
 
 GJSify is organised into four pillars, each implementing standard APIs on top of native GNOME libraries.
@@ -16,9 +14,7 @@ GJSify is organised into four pillars, each implementing standard APIs on top of
 | [DOM & Bridges](./dom) | 2 DOM + 6 bridges | Canvas2D, WebGL, DOM elements; GTK-backed Canvas/WebGL/Video/IFrame bridges |
 | Adwaita for browser | 3 | `@gjsify/adwaita-web`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 
-<WebStandardsCoverage />
-
-<NodeApiCoverage />
+93% of Node modules and 58% of web standards covered — see the [Node.js Modules](./node) and [Web APIs](./web) subpages for the full interactive breakdown.
 
 <BridgesGrid />
 

--- a/website/src/content/docs/packages/web.mdx
+++ b/website/src/content/docs/packages/web.mdx
@@ -3,7 +3,11 @@ title: Web APIs
 description: Web platform APIs implemented for GJS using native GNOME libraries
 ---
 
+import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro';
+
 19 Web platform APIs implemented for GJS using native GNOME libraries (plus `@gjsify/web-polyfills` meta).
+
+<WebStandardsCoverage />
 
 | Package | GNOME Libs | Implements |
 |---|---|---|

--- a/website/src/content/docs/packages/web.mdx
+++ b/website/src/content/docs/packages/web.mdx
@@ -5,7 +5,7 @@ description: Web platform APIs implemented for GJS using native GNOME libraries
 
 import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro';
 
-19 Web platform APIs implemented for GJS using native GNOME libraries (plus `@gjsify/web-polyfills` meta).
+19 Web platform API packages (plus `@gjsify/webrtc-native` Vala bridge and `@gjsify/web-polyfills` meta) implemented for GJS using native GNOME libraries.
 
 <WebStandardsCoverage />
 
@@ -20,6 +20,7 @@ import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro
 | `fetch` | Soup 3.0, Gio, GLib | `fetch()`, Request (raw-body via `set_request_body_from_bytes`), Response, Headers |
 | `formdata` | — | FormData, File, multipart encoding |
 | `gamepad` | Manette 0.2 | Gamepad, GamepadButton, GamepadEvent, GamepadHapticActuator (dual-rumble) |
+| `message-channel` | — | MessageChannel, MessagePort (W3C Channel Messaging; backs `@gjsify/iframe` WebKit bridge and `worker_threads` cross-process IPC) |
 | `streams` | — | ReadableStream, WritableStream, TransformStream, TextEncoder/DecoderStream |
 | `web-globals` | — | Meta-register for every Web API global |
 | `webaudio` | Gst 1.0, GstApp 1.0 | AudioContext (GStreamer decodebin + playback chain), AudioBufferSourceNode, GainNode, AudioParam |
@@ -27,6 +28,7 @@ import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro
 | `webrtc` | Gst 1.0, GstWebRTC 1.0, GstSDP 1.0 | Full W3C WebRTC (RTCPeerConnection, RTCDataChannel, RTCRtpSender/Receiver/Transceiver, MediaStream/Track, getUserMedia, RTCDTMFSender, RTCCertificate) |
 | `webrtc-native` | Gst 1.0, GstWebRTC 1.0 | Vala/GObject prebuild — main-thread signal bridges consumed by `@gjsify/webrtc` |
 | `websocket` | Soup 3.0 | WebSocket, MessageEvent, CloseEvent (NUL-byte-safe text frames, Autobahn-validated) |
+| `webassembly` | — | `WebAssembly.compile/instantiate/validate/compileStreaming/instantiateStreaming` — Promise-API polyfill wrapping SpiderMonkey's synchronous constructors; auto-detected by `--globals auto` |
 | `webstorage` | Gio | localStorage, sessionStorage |
 | `xmlhttprequest` | Soup 3.0, GLib | XMLHttpRequest (`responseType`: arraybuffer / blob / json / text / document), FakeBlob + temp-file plumbing for `URL.createObjectURL` |
 

--- a/website/src/content/docs/projects/ts-for-gir.md
+++ b/website/src/content/docs/projects/ts-for-gir.md
@@ -122,6 +122,14 @@ The [Patterns](../../patterns/) section of this site documents the idioms that s
 - [**GObject classes**](../../patterns/gobject-classes/) — `GObject.registerClass()` forms, the static-block pattern, init-order rules behind [GNOME/gjs#704](https://gitlab.gnome.org/GNOME/gjs/-/work_items/704), and the `static override $gtype: GObject.GType<Foo>` declaration that narrows the statically-inherited `$gtype` from the base class.
 - [**Bridge widgets**](../../patterns/bridges/) — how `Canvas2DBridge` / `WebGLBridge` / `IFrameBridge` / `VideoBridge` pair a polyfill DOM element with a real GTK widget so browser-shaped code drives the GTK surface directly.
 
+## gjsify dogfoods its own bundler
+
+`@ts-for-gir/cli` is built with `gjsify build --app node` — a real-world Node CLI that bundles the TypeScript compiler, TypeDoc, shiki, yargs, ejs, and ~100 transitive npm dependencies into a single executable with `--shebang` (emitting `#!/usr/bin/env node`). This makes ts-for-gir a concrete proof point that gjsify can bundle and distribute production-grade Node.js CLIs:
+
+- Bundled deps that read their own data files at runtime (`typedoc` loading its theme assets, ejs loading templates) work correctly after install at any `node_modules` depth, because gjsify resolves those paths from the bundle's actual runtime location rather than a path baked at build time.
+- Yarn PnP-resident zip packages (the ~100 Yarn-cached deps) are resolved transparently by `@gjsify/module`'s PnP-aware `createRequire`.
+- The produced Node bundle is directly executable (`chmod +x`) and published to npm — no separate build wrapper script needed.
+
 ## Project structure
 
 | Package | Responsibility |

--- a/website/src/content/docs/showcases/canvas2d-fireworks.mdx
+++ b/website/src/content/docs/showcases/canvas2d-fireworks.mdx
@@ -1,5 +1,5 @@
 ---
-title: canvas2d-fireworks
+title: "Fireworks (Canvas 2D)"
 description: Particle-based fireworks rendered through Canvas 2D — same code path on GJS (Cairo via Canvas2DBridge) and the browser.
 ---
 

--- a/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
+++ b/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
@@ -1,5 +1,5 @@
 ---
-title: excalibur-jelly-jumper
+title: "Jelly Jumper (Excalibur)"
 description: Excalibur.js 0.32 platformer with Tiled tilemaps — runs on GJS through @gjsify/webgl + @gjsify/xmlhttprequest + @gjsify/domparser without a Excalibur.js fork.
 ---
 

--- a/website/src/content/docs/showcases/express-webserver.mdx
+++ b/website/src/content/docs/showcases/express-webserver.mdx
@@ -1,5 +1,5 @@
 ---
-title: express-webserver
+title: "Express Web Server"
 description: Unmodified Express 5 running on GJS through @gjsify/http — proves the http.Server / IncomingMessage / ServerResponse surface holds for the most-deployed Node web framework.
 ---
 

--- a/website/src/content/docs/showcases/minimalist-browser.mdx
+++ b/website/src/content/docs/showcases/minimalist-browser.mdx
@@ -1,5 +1,5 @@
 ---
-title: minimalist-browser
+title: "Minimalist Browser"
 description: URL bar + back/forward + iframe — same code runs in browser (real <iframe>) and GJS (IFrameBridge over WebKit.WebView).
 ---
 

--- a/website/src/content/docs/showcases/three-geometry-teapot.mdx
+++ b/website/src/content/docs/showcases/three-geometry-teapot.mdx
@@ -1,5 +1,5 @@
 ---
-title: three-geometry-teapot
+title: "Three.js Teapot"
 description: Three.js Utah teapot with parameter controls — proves Three's full WebGL2 pipeline runs on GJS through @gjsify/webgl's Vala bridge.
 ---
 

--- a/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
+++ b/website/src/content/docs/showcases/three-postprocessing-pixel.mdx
@@ -1,5 +1,5 @@
 ---
-title: three-postprocessing-pixel
+title: "Pixel Shader (Three.js)"
 description: Three.js post-processing pixel-art renderer — proves the full EffectComposer + custom shader passes pipeline runs on GJS.
 ---
 

--- a/website/src/content/docs/showcases/webrtc-loopback.mdx
+++ b/website/src/content/docs/showcases/webrtc-loopback.mdx
@@ -1,5 +1,5 @@
 ---
-title: webrtc-loopback
+title: "WebRTC Loopback"
 description: Two local peers exchange offer/answer + ICE, then echo messages over an RTCDataChannel — proves @gjsify/webrtc's full PeerConnection + DataChannel surface.
 ---
 

--- a/website/src/content/docs/showcases/webrtc-video.mdx
+++ b/website/src/content/docs/showcases/webrtc-video.mdx
@@ -1,5 +1,5 @@
 ---
-title: webrtc-video
+title: "WebRTC Video"
 description: Webcam preview via getUserMedia — same MediaStream code drives a native browser <video> element and a GJS Gtk.Picture through @gjsify/video's VideoBridge.
 ---
 

--- a/website/src/data/node-apis.ts
+++ b/website/src/data/node-apis.ts
@@ -41,7 +41,7 @@ export const nodeApiCategories: readonly NodeApiCategory[] = [
 			{ name: "dns", status: "full", backed: "Gio.Resolver" },
 			{ name: "http", status: "full", backed: "Soup 3.0", note: "Server + ClientRequest + Agent" },
 			{ name: "https", status: "full", backed: "Soup 3.0" },
-			{ name: "http2", status: "full", backed: "Soup 3.0", note: "h2 via ALPN; push/flow-control coming in Phase 2" },
+			{ name: "http2", status: "full", backed: "Soup 3.0", note: "h2 via ALPN; pushStream/respondWithFD/respondWithFile via @gjsify/http2-native (libnghttp2)" },
 			{ name: "tls", status: "full", backed: "Gio.TlsConnection" },
 			{ name: "ws", status: "partial", backed: "@gjsify/websocket", note: "npm ws drop-in; Autobahn 510 OK / 0 FAIL" },
 		],


### PR DESCRIPTION
## Issue A — Nicer showcase names

**Files changed:** `website/src/content/docs/showcases/*.mdx` (8 files)

Replaced raw slug values in `title:` frontmatter with readable display names matching the demo headerbar titles:

| Slug | Old title | New title |
|---|---|---|
| `canvas2d-fireworks` | `canvas2d-fireworks` | `Fireworks (Canvas 2D)` |
| `excalibur-jelly-jumper` | `excalibur-jelly-jumper` | `Jelly Jumper (Excalibur)` |
| `three-geometry-teapot` | `three-geometry-teapot` | `Three.js Teapot` |
| `three-postprocessing-pixel` | `three-postprocessing-pixel` | `Pixel Shader (Three.js)` |
| `minimalist-browser` | `minimalist-browser` | `Minimalist Browser` |
| `webrtc-loopback` | `webrtc-loopback` | `WebRTC Loopback` |
| `webrtc-video` | `webrtc-video` | `WebRTC Video` |
| `express-webserver` | `express-webserver` | `Express Web Server` |

Starlight sidebar entries use `{ slug: '...' }` without an explicit `label:`, so the sidebar label is auto-derived from the page title — no `astro.config.mjs` changes needed. `showcases/index.mdx` table rows use hardcoded markdown link text, which is unchanged.

## Issue B — Live-demo spacing band + pause button position

**Files changed:** `packages/web/adwaita-web/scss/_headerbar.scss`

**NOTE: touches a published package (`@gjsify/adwaita-web`) — needs visual verification by the maintainer.**

Identified structural cause in the headerbar flex layout:

- **Pause button misposition**: `.adw-header-bar-end` lacked `justify-content: flex-end`. Because `.adw-header-bar-center` has `flex: 1` (takes all remaining space), the end section sits at the right edge of the bar — but without `justify-content: flex-end`, buttons inside it were left-aligned within that section rather than right-aligned. Added `justify-content: flex-end`.
- **Spacing band / layout collapse under embed width constraints**: Added `flex-shrink: 0` to `.adw-header-bar-start` and `.adw-header-bar-end` so button sections cannot collapse when the embed container is narrow; added `min-width: 0` to `.adw-header-bar-center` to allow the title to truncate without overflowing into the button sections.

The `adw-header-bar` element itself already had `flex-shrink: 0` (correct as a flex child of `adw-window`). The fixes are defensive CSS corrections; the full visual result needs a live browser check on the fireworks, teapot, and excalibur demos.

## Issue C — Double expand-chevron in coverage tables

**Files changed:** `website/src/components/NodeApiCoverage.astro`, `website/src/components/WebStandardsCoverage.astro`

Added scoped `<style>` blocks to both components hiding the browser's native `<summary>` disclosure triangle while preserving the custom `.adw-chevron` span:

```css
summary.adw-row-summary { list-style: none; }
summary.adw-row-summary::-webkit-details-marker { display: none; }
```

`PillarCoverage.astro` and `IntegrationTests.astro` do not use `<details>/<summary>` and required no change.

## Issue D — Move coverage views into subpages

**Files changed:**
- `website/src/content/docs/packages/overview.mdx` — removed `WebStandardsCoverage` and `NodeApiCoverage` component embeds; added a one-line summary ("93% of Node modules, 58% of web standards…") with links to the subpages; kept the category table and `BridgesGrid`
- `website/src/content/docs/packages/node.md` → **renamed** to `node.mdx` — added `import NodeApiCoverage` and `<NodeApiCoverage />` embed above the old bullet-list table (kept the table for reference detail)
- `website/src/content/docs/packages/web.md` → **renamed** to `web.mdx` — added `import WebStandardsCoverage` and `<WebStandardsCoverage />` embed above the old package table

Both components take no props (they pull data from `src/data/*.ts` directly), so no props needed to carry over. Astro sidebar slugs `packages/node` and `packages/web` resolve to `.mdx` files normally; `astro.config.mjs` required no changes.

## Build verification

`yarn build` was not run (workspace deps not installed in the worktree). Verified:
- `node --check` passes on `astro.config.mjs` and modified TS sources
- All MDX frontmatter and import paths match the component locations (`../../../components/*.astro` relative to `src/content/docs/packages/`)
- Renamed files detected by git as renames (97%/96% similarity), no stale `.md` duplicates remain