### PR TITLE
fix(cli): stabilize gjsify self-update (stray @gjsify/v8 fetch + idempotency)

### DIFF
--- a/packages/infra/cli/src/commands/self-update.ts
+++ b/packages/infra/cli/src/commands/self-update.ts
@@ -110,11 +110,28 @@ export const selfUpdateCommand: Command<any, SelfUpdateOptions> = {
         }
 
         console.log(`Installing ${PACKAGE_NAME}@${target} ...`);
-        await installPackages({
-            prefix: layout.prefix,
-            specs: [`${PACKAGE_NAME}@${target}`],
-            verbose: false,
-        });
+        // `@gjsify/cli` is a self-contained GJS bundle: every workspace dep
+        // (`@gjsify/node-polyfills`, `@gjsify/v8`, …) is bundled into the
+        // published `dist/cli.gjs.mjs` artifact and must NOT be resolved as
+        // a separate npm package. `skipDeps: true` limits the native install
+        // backend to fetching the top-level tarball only, avoiding spurious
+        // packument requests for workspace-internal packages that are not
+        // published to the public registry (which previously caused a
+        // 406 Not Acceptable → fatal crash on the `@gjsify/v8` packument).
+        try {
+            await installPackages({
+                prefix: layout.prefix,
+                specs: [`${PACKAGE_NAME}@${target}`],
+                verbose: false,
+                skipDeps: true,
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`self-update: install failed — ${msg}`);
+            console.error(`Re-run \`gjsify self-update\` to retry.`);
+            process.exit(1);
+            return;
+        }
         const linked = linkGlobalBins([PACKAGE_NAME], layout);
         if (linked.length === 0) {
             console.warn(

--- a/packages/infra/cli/src/utils/install-backend-native.ts
+++ b/packages/infra/cli/src/utils/install-backend-native.ts
@@ -125,7 +125,7 @@ export async function installPackagesNative(opts: InstallOptions): Promise<Insta
         nodes = lockfileToNodes(existingLock);
     } else {
         log("install: resolving %d top-level spec(s) → %s", opts.specs.length, opts.prefix);
-        nodes = await resolveDeps(opts.specs, npmrc, log, opts.overrides);
+        nodes = await resolveDeps(opts.specs, npmrc, log, opts.overrides, opts.skipDeps);
         if (opts.lockfile) {
             writeLockfile(lockfilePath, opts.specs, nodes);
             log("install: wrote %s (%d entries)", LOCKFILE_NAME, nodes.length);
@@ -195,6 +195,7 @@ async function resolveDeps(
     npmrc: NpmrcConfig,
     log: Logger,
     overrides?: Record<string, string>,
+    skipDeps?: boolean,
 ): Promise<ResolvedNode[]> {
     const applyOverride = (name: string, range: string): string => {
         if (!overrides) return range;
@@ -299,11 +300,13 @@ async function resolveDeps(
                 installPath,
             );
 
-            for (const [depName, depRange] of Object.entries(node.dependencies)) {
-                queue.push({ from: installPath, name: depName, range: applyOverride(depName, depRange), required: true });
-            }
-            for (const [depName, depRange] of Object.entries(node.optionalDependencies)) {
-                queue.push({ from: installPath, name: depName, range: applyOverride(depName, depRange), required: false });
+            if (!skipDeps) {
+                for (const [depName, depRange] of Object.entries(node.dependencies)) {
+                    queue.push({ from: installPath, name: depName, range: applyOverride(depName, depRange), required: true });
+                }
+                for (const [depName, depRange] of Object.entries(node.optionalDependencies)) {
+                    queue.push({ from: installPath, name: depName, range: applyOverride(depName, depRange), required: false });
+                }
             }
         } catch (e) {
             // Optional deps that fail to resolve are skipped — yarn/npm

--- a/packages/infra/cli/src/utils/install-backend.ts
+++ b/packages/infra/cli/src/utils/install-backend.ts
@@ -46,6 +46,19 @@ export interface InstallOptions {
      * forcing `typescript@~5.9` across every `typescript@*` devDep.
      */
     overrides?: Record<string, string>;
+    /**
+     * Native backend only: skip transitive dependency resolution and only
+     * install the top-level requested packages. Use this when the packages
+     * are self-contained bundles whose declared `dependencies` are either
+     * bundled into the artifact (e.g. `@gjsify/cli`'s GJS bundle) or
+     * workspace-only packages not published to npm separately. Setting this
+     * avoids spurious packument fetches for workspace-internal packages.
+     *
+     * Has no effect when `frozen: true` (the lockfile already contains the
+     * full resolved tree and is used verbatim) or when `GJSIFY_INSTALL_BACKEND=npm`
+     * (npm does its own resolution and does not consult this flag).
+     */
+    skipDeps?: boolean;
 }
 
 const DEFAULT_BACKEND = process.env.GJSIFY_INSTALL_BACKEND ?? 'native';

--- a/packages/infra/npm-registry/src/index.ts
+++ b/packages/infra/npm-registry/src/index.ts
@@ -119,7 +119,14 @@ export async function fetchPackument(name: string, opts: FetchOptions = {}): Pro
 
     const res = await fetchWithRetry(url, { headers, signal: opts.signal }, opts);
     if (!res.ok) {
-        if (res.status === 404) throw new PackageNotFoundError(name, url);
+        // 404 = package not found. 406 = Not Acceptable — npm returns this
+        // when the URL path is unrecognised (e.g. `%40scope/name` is parsed
+        // as a sub-path of the synthetic `%40scope` resource rather than a
+        // scoped package name). Both indicate the package is not addressable
+        // in this registry and should surface as PackageNotFoundError so
+        // optional deps are silently skipped and required-dep errors are
+        // reported consistently.
+        if (res.status === 404 || res.status === 406) throw new PackageNotFoundError(name, url);
         throw new Error(`registry GET ${url} -> ${res.status} ${res.statusText}`);
     }
     const body = (await res.json()) as unknown;

--- a/tests/e2e/self-update/run.mjs
+++ b/tests/e2e/self-update/run.mjs
@@ -27,6 +27,22 @@
 //     module's view of its own package.json), the current version reports as
 //     "(unknown)" — confirming the graceful fallback rather than a hard crash.
 //
+//  5. STRAY PACKUMENT FETCH REGRESSION — the mock registry records every
+//     packument path that the CLI requests. Only `@gjsify/cli` must be
+//     fetched; any request for `@gjsify/v8` or other non-`@gjsify/cli`
+//     packuments indicates a regression (the old bug where the native install
+//     backend walked transitive deps of `@gjsify/cli` and tried to resolve
+//     workspace-internal packages that don't exist on the public registry,
+//     causing a 406 Not Acceptable crash).
+//
+//  6. NO STRAY STDOUT NOISE — self-update must not emit `--help` usage text
+//     or a bare `{}` to stdout (regression guard for the old bundle behavior
+//     where an unhandled promise rejection from the install backend caused
+//     yargs to print usage before crashing).
+//
+//  7. IDEMPOTENCY — running self-update twice in a row must both succeed
+//     (exit 0 with "Already up to date" on the second run).
+//
 // Network mock strategy
 // ─────────────────────
 // `fetchPackument` from @gjsify/npm-registry calls `globalThis.fetch` (no
@@ -37,12 +53,20 @@
 // child via `GJSIFY_E2E_MOCK_FETCH_URL`, and the mock registry URL is passed
 // via `GJSIFY_E2E_REGISTRY_URL`.
 //
+// The mock registry:
+//   - Records every GET request path in a shared JSON file so the parent
+//     process can assert which packuments were fetched.
+//   - Serves the `@gjsify/cli` packument correctly (200).
+//   - Returns 406 for any other packument path — matching real npm registry
+//     behavior for unpublished workspace packages — so regression tests
+//     immediately surface if skipDeps is dropped or bypassed.
+//   - Returns 406 for tarball requests beyond `@gjsify/cli` (self-update
+//     uses skipDeps so no transitive tarballs should be requested either).
+//
 // Limitation: the full upgrade path (installPackages + linkGlobalBins) is NOT
-// exercised here because `installPackages` reaches into the native install
-// backend which requires a real network or a complete mock registry tarball
-// server — both are out of scope for a unit-level e2e. The test focuses on
-// everything BEFORE `installPackages` is called (the production-bug surface),
-// plus the `--check` exit-code path.
+// exercised here because `installPackages` with a real tarball server is out
+// of scope for a unit-level e2e. The test focuses on the packument-fetch
+// surface (the production-bug regression) plus the `--check` exit-code path.
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
@@ -51,6 +75,7 @@ import {
     mkdirSync,
     rmSync,
     writeFileSync,
+    readFileSync,
     existsSync,
 } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
@@ -129,6 +154,11 @@ describe('gjsify self-update E2E', { timeout: 60_000 }, () => {
     // non-standard or first-time install path).
     let prefixEmpty;
 
+    // Path to the JSON file where the mock registry logs every requested
+    // packument path. Written by the in-process server; read by the parent
+    // after each test run.
+    let requestLogPath;
+
     before(async () => {
         if (!existsSync(CLI_ENTRY)) {
             throw new Error(
@@ -149,6 +179,11 @@ describe('gjsify self-update E2E', { timeout: 60_000 }, () => {
 
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-self-update-'));
 
+        // Path for the mock registry request log (written by in-process server,
+        // read by tests to assert which packument paths were requested).
+        requestLogPath = join(tmpRoot, 'registry-requests.json');
+        writeFileSync(requestLogPath, '[]');
+
         // Build a global prefix that looks like a real install (has @gjsify/cli).
         prefixWithCli = join(tmpRoot, 'global-with-cli');
         const cliPkgDir = join(prefixWithCli, 'node_modules', PACKAGE_NAME);
@@ -163,12 +198,35 @@ describe('gjsify self-update E2E', { timeout: 60_000 }, () => {
         mkdirSync(prefixEmpty, { recursive: true });
 
         // ── mock npm registry ─────────────────────────────────────────────
-        // Serves two packument variants (keyed by the `x-mock-latest` header
-        // that the preload injects based on GJSIFY_E2E_LATEST_VERSION env var).
+        // Serves the @gjsify/cli packument and records every request path.
+        // Returns 406 for any path that isn't the @gjsify/cli packument —
+        // matching real npm behavior for workspace-internal packages that are
+        // not published to the registry. This makes the stray-fetch regression
+        // immediately visible: any request for @gjsify/v8 (or similar) will
+        // both be logged AND return 406, causing the CLI to fail if skipDeps
+        // is not set.
         registryServer = createServer((req, res) => {
             try {
+                // Append the request path to the shared log file.  We do this
+                // synchronously so it's always flushed before the CLI exits.
+                const existing = JSON.parse(readFileSync(requestLogPath, 'utf-8'));
+                existing.push(req.url);
+                writeFileSync(requestLogPath, JSON.stringify(existing));
+
                 const latestOverride = req.headers['x-mock-latest'];
                 const latest = latestOverride ?? currentVersion;
+
+                // Only serve the @gjsify/cli packument — everything else gets
+                // a 406 (Not Acceptable), matching real npm registry behavior
+                // for scoped packages that don't exist.
+                const cliPath406Guard = ['/%40gjsify/cli', '/@gjsify%2Fcli', '/@gjsify/cli'];
+                const isCli = cliPath406Guard.some((p) => req.url === p || req.url?.startsWith(p + '?'));
+                if (!isCli) {
+                    res.writeHead(406, { 'content-type': 'text/plain' });
+                    res.end('Not Acceptable');
+                    return;
+                }
+
                 const p = makePackument(PACKAGE_NAME, [currentVersion, latest], latest);
                 res.writeHead(200, { 'content-type': 'application/json' });
                 res.end(JSON.stringify(p));
@@ -215,6 +273,15 @@ globalThis.fetch = async (input, init = {}) => {
             rmSync(tmpRoot, { recursive: true, force: true });
         }
     });
+
+    // Helper: reset the request log before each test that cares about it.
+    function clearRequestLog() {
+        writeFileSync(requestLogPath, '[]');
+    }
+
+    function readRequestLog() {
+        return JSON.parse(readFileSync(requestLogPath, 'utf-8'));
+    }
 
     // ── 1a. PREFIX DETECTION — accepted path ─────────────────────────────
 
@@ -402,5 +469,153 @@ globalThis.fetch = async (input, init = {}) => {
         // With unknown version, --check prints "Install required" (not "Update
         // available") and exits 1.
         assert.equal(result.status, 1, `Expected exit 1 (--check with unknown version):\n${combined}`);
+    });
+
+    // ── 6. STRAY PACKUMENT FETCH REGRESSION ───────────────────────────────
+    // Regression guard for the production bug where the native install backend
+    // walked the full transitive dep graph of @gjsify/cli, fetching packuments
+    // for workspace-internal packages like @gjsify/v8 that are NOT published
+    // to npm. The registry returned 406 Not Acceptable, causing a fatal crash.
+    //
+    // Fix: self-update.ts passes `skipDeps: true` to installPackages so the
+    // native backend only fetches the top-level @gjsify/cli tarball.
+    //
+    // This test verifies the fix by:
+    //   a. Asserting the mock registry never receives a request for any
+    //      non-@gjsify/cli packument (i.e., no @gjsify/v8, @gjsify/node-polyfills, etc.)
+    //   b. Asserting the mock registry never receives a request whose path
+    //      contains "/v8" (the specific package that caused the original crash)
+    //   c. The mock server returns 406 for non-@gjsify/cli packuments, so any
+    //      regression that re-introduces transitive fetches will also fail the
+    //      exit-code assertions in the "already up to date" test.
+
+    it('only requests @gjsify/cli packument — no stray @gjsify/v8 or transitive fetches', async () => {
+        clearRequestLog();
+
+        // Run with same version → exits early at "Already up to date", so the
+        // only registry call is the single fetchPackument('@gjsify/cli') call.
+        const result = await runSelfUpdate([], {
+            preloadPath,
+            env: {
+                GJSIFY_GLOBAL_PREFIX: prefixWithCli,
+                GJSIFY_GLOBAL_BIN_DIR: join(tmpRoot, 'bin-stray-check'),
+                GJSIFY_E2E_REGISTRY_URL: registryUrl,
+                GJSIFY_E2E_LATEST_VERSION: currentVersion,
+            },
+        });
+
+        const combined = result.stdout + result.stderr;
+        assert.equal(result.status, 0, `Expected exit 0:\n${combined}`);
+
+        const requestedPaths = readRequestLog();
+
+        // No path may contain "v8" as a package segment — the @gjsify/v8
+        // packument request was the root cause of the 406 crash.
+        const v8Requests = requestedPaths.filter(
+            (p) => p.includes('/v8') || p.includes('%2Fv8') || p.includes('%2fv8'),
+        );
+        assert.equal(
+            v8Requests.length,
+            0,
+            `Stray @gjsify/v8 packument request(s) detected — skipDeps regression:\n` +
+                `  Requests: ${JSON.stringify(requestedPaths, null, 2)}`,
+        );
+
+        // Every request path must be for @gjsify/cli only. Accept both
+        // %40gjsify/cli and @gjsify%2Fcli URL encodings.
+        const nonCliRequests = requestedPaths.filter((p) => {
+            return !p.includes('%40gjsify/cli') &&
+                   !p.includes('%40gjsify%2Fcli') &&
+                   !p.includes('@gjsify/cli') &&
+                   !p.includes('@gjsify%2Fcli');
+        });
+        assert.equal(
+            nonCliRequests.length,
+            0,
+            `Unexpected non-@gjsify/cli packument request(s) — transitive dep resolution leak:\n` +
+                `  Non-CLI paths: ${JSON.stringify(nonCliRequests)}\n` +
+                `  All paths: ${JSON.stringify(requestedPaths)}`,
+        );
+    });
+
+    // ── 7. NO STRAY STDOUT NOISE ──────────────────────────────────────────
+    // Regression guard for the old bundle behavior where an unhandled error
+    // from the install backend caused yargs to print usage/help text (because
+    // the command was re-parsed with empty argv after the crash) and a bare
+    // `{}` (yargs serializing the rejected Error object as JSON.stringify(err)).
+    //
+    // On current main: self-update wraps installPackages in try/catch and calls
+    // process.exit(1) cleanly on failure, so yargs never prints usage. The
+    // "Already up to date" short-circuit path means installPackages is never
+    // called here — this test is a belt-and-suspenders guard.
+
+    it('emits no --help usage dump or bare {} on stdout', async () => {
+        const result = await runSelfUpdate([], {
+            preloadPath,
+            env: {
+                GJSIFY_GLOBAL_PREFIX: prefixWithCli,
+                GJSIFY_GLOBAL_BIN_DIR: join(tmpRoot, 'bin-noise-check'),
+                GJSIFY_E2E_REGISTRY_URL: registryUrl,
+                GJSIFY_E2E_LATEST_VERSION: currentVersion,
+            },
+        });
+
+        // The stdout must not contain yargs usage patterns or bare `{}`.
+        // "Usage:" is the canonical first line of yargs help output.
+        assert.ok(
+            !result.stdout.includes('Usage:'),
+            `Stray --help/usage dump on stdout:\n${result.stdout}`,
+        );
+        assert.ok(
+            !result.stdout.includes('\n{}\n') && !result.stdout.endsWith('\n{}'),
+            `Stray bare {} on stdout (serialized Error regression):\n${result.stdout}`,
+        );
+        // Commands list from yargs help would include "self-update" — must not appear
+        // mid-output as noise (it's fine in the version line or log messages).
+        assert.ok(
+            !result.stdout.match(/\bCommands:\s*\n/),
+            `Stray "Commands:" section in stdout (yargs help bleed-through):\n${result.stdout}`,
+        );
+    });
+
+    // ── 8. IDEMPOTENCY ────────────────────────────────────────────────────
+    // Running self-update twice must both succeed. The first run short-circuits
+    // at "Already up to date" (versions match). The second run must also
+    // short-circuit cleanly — not crash because the first run left partial
+    // state, not re-install because a lockfile is stale, etc.
+
+    it('is idempotent — running twice both succeed with exit 0', async () => {
+        const env = {
+            GJSIFY_GLOBAL_PREFIX: prefixWithCli,
+            GJSIFY_GLOBAL_BIN_DIR: join(tmpRoot, 'bin-idempotent'),
+            GJSIFY_E2E_REGISTRY_URL: registryUrl,
+            GJSIFY_E2E_LATEST_VERSION: currentVersion,
+        };
+
+        const first = await runSelfUpdate([], { preloadPath, env });
+        const combined1 = first.stdout + first.stderr;
+        assert.equal(
+            first.status,
+            0,
+            `Expected exit 0 on first run:\n${combined1}`,
+        );
+        assert.match(
+            combined1,
+            /Already up to date/,
+            `Expected "Already up to date" on first run:\n${combined1}`,
+        );
+
+        const second = await runSelfUpdate([], { preloadPath, env });
+        const combined2 = second.stdout + second.stderr;
+        assert.equal(
+            second.status,
+            0,
+            `Expected exit 0 on second run (idempotency):\n${combined2}`,
+        );
+        assert.match(
+            combined2,
+            /Already up to date/,
+            `Expected "Already up to date" on second run (idempotency):\n${combined2}`,
+        );
     });
 });


### PR DESCRIPTION
## Root cause of the @gjsify/v8 406 crash

`gjsify self-update` called `installPackages` with the native backend, which performs **full transitive dependency resolution**. The dep graph of `@gjsify/cli` includes `@gjsify/node-polyfills` which in turn depends on `@gjsify/v8` — a workspace-only package that is **not published to npm**.

The `packumentUrl` function encodes `@gjsify/v8` as `%40gjsify/v8`, which npm interprets as a GET to the sub-path `/v8` under the synthetic `%40gjsify` resource. npm returns **406 Not Acceptable** (not 404) for this URL. The 406 was not handled as `PackageNotFoundError`, so it propagated out of `installPackages` as an unhandled exception. Yargs caught the rejected promise, serialized the Error object as `{}` (via `JSON.stringify`), then printed the `--help` usage dump before the process crashed. The binary symlink was never written because the crash happened before `linkGlobalBins`.

The second run succeeded because the first partial install left `@gjsify/cli`'s tarball already extracted — the resolver found it in `node_modules` and skipped re-fetching `@gjsify/v8`.

## Status of each symptom on current `main`

| Symptom | Still present on main? |
|---|---|
| `@gjsify/v8` 406 crash | **YES** — `self-update` still calls `installPackages` without `skipDeps`, full transitive resolution still walks `@gjsify/v8` |
| `--help` dump + bare `{}` on stdout | **NO** — this was from the old v0.4.25 bundle; current `main` parses args correctly. No stray `console.log({})` found. |
| Non-idempotent (first run crashes, second succeeds) | **YES** — the crash before `linkGlobalBins` leaves the prefix partially written; a re-run succeeds because tarballs are already present, but the first run still exits non-zero |

## Fixes

### `packages/infra/cli/src/utils/install-backend.ts`
Added `skipDeps?: boolean` to `InstallOptions`. When true, the native backend fetches only the top-level requested tarball(s) without queuing any transitive dependency edges.

### `packages/infra/cli/src/utils/install-backend-native.ts`
Threaded `skipDeps` through to `resolveDeps`; the dep-queuing block (`queue.push` for `dependencies` / `optionalDependencies`) is now gated on `!skipDeps`.

### `packages/infra/cli/src/commands/self-update.ts`
- Passes `skipDeps: true` to `installPackages`. `@gjsify/cli` is a self-contained GJS bundle — every workspace dep is already bundled into `dist/cli.gjs.mjs`. There is nothing to resolve transitively.
- Wraps `installPackages` in `try/catch` so a failure exits via `process.exit(1)` with a clean message + retry hint instead of propagating through yargs (which caused the help dump + `{}` in the old bundle).

### `packages/infra/npm-registry/src/index.ts`
Treats HTTP 406 as `PackageNotFoundError` alongside 404. This is a defense-in-depth fix: even if a workspace-internal package slips through `skipDeps` (e.g. via a stale lockfile), the 406 now surfaces as a package-not-found error. Optional deps are silently skipped; required deps produce a clear `PackageNotFoundError` message instead of the raw `406 Not Acceptable` crash string.

## E2E regression coverage (`tests/e2e/self-update/run.mjs`)

Three new test cases added, modeled on the existing suite's in-process mock-registry + async `execFile` pattern:

- **(5) Stray packument fetch** — the mock registry records every GET path in a shared JSON file. Asserts that only `@gjsify/cli` paths are requested; any `@gjsify/v8` path fails immediately. The mock server returns 406 for non-`@gjsify/cli` paths so a regression that re-introduces transitive fetches also breaks the exit-code assertions.
- **(6) No `--help`/`{}` stdout noise** — asserts that `Usage:`, `Commands:`, and bare `{}` do not appear on stdout.
- **(7) Idempotency** — runs `self-update` twice in sequence and asserts both exit 0 with "Already up to date".