### PR TITLE
chore(lint): clear remaining consistent-type-imports warnings

### DIFF
--- a/packages/dom/dom-elements/src/element.ts
+++ b/packages/dom/dom-elements/src/element.ts
@@ -5,6 +5,7 @@
 
 import type { Event } from '@gjsify/dom-events';
 
+import type { Attr } from './attr.js';
 import { Node } from './node.js';
 import { NodeType } from './node-type.js';
 import { NamedNodeMap } from './named-node-map.js';
@@ -165,7 +166,7 @@ export class Element extends Node {
     }
 
     setAttributeNode(attr: unknown): unknown {
-        return this[PS.attributes].setNamedItem(attr as import('./attr.js').Attr);
+        return this[PS.attributes].setNamedItem(attr as Attr);
     }
 
     removeAttributeNode(attr: unknown): unknown {

--- a/packages/dom/dom-elements/src/index.spec.ts
+++ b/packages/dom/dom-elements/src/index.spec.ts
@@ -541,7 +541,7 @@ export default async () => {
             el.onwheel = (ev: unknown) => {
                 deltaY = (ev as { deltaY: number }).deltaY;
             };
-            el.dispatchEvent(new Event('wheel') as unknown as import('@gjsify/dom-events').Event);
+            el.dispatchEvent(new Event('wheel') as unknown as Event);
             // The handler fires even without a deltaY; verifies wiring
             expect(typeof el.onwheel).toBe('function');
             el.onwheel = null;

--- a/packages/framework/event-bridge/src/event-bridge.spec.ts
+++ b/packages/framework/event-bridge/src/event-bridge.spec.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, on } from '@gjsify/unit';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 
-import { Event as OurEvent } from '@gjsify/dom-events';
+import type { Event as OurEvent } from '@gjsify/dom-events';
 import { attachEventControllers } from './event-bridge.js';
 
 /** Pointer/Mouse event shape the bridge dispatches — the union of fields the tests read. */

--- a/packages/framework/event-bridge/src/event-bridge.ts
+++ b/packages/framework/event-bridge/src/event-bridge.ts
@@ -7,7 +7,7 @@
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 import {
-    Event as OurEvent,
+    type Event as OurEvent,
     MouseEvent as OurMouseEvent,
     PointerEvent as OurPointerEvent,
     KeyboardEvent as OurKeyboardEvent,

--- a/packages/framework/iframe/src/index.spec.ts
+++ b/packages/framework/iframe/src/index.spec.ts
@@ -7,7 +7,7 @@ import { describe, it, expect } from '@gjsify/unit';
 import { HTMLIFrameElement, IFrameWindowProxy } from './index.js';
 import { Document } from '@gjsify/dom-elements';
 import { HTMLElement, Element, Node } from '@gjsify/dom-elements';
-import { Event, MessageEvent } from '@gjsify/dom-events';
+import { MessageEvent, type Event } from '@gjsify/dom-events';
 import type { MessageBridge } from './message-bridge.js';
 
 /** Minimal MessageBridge stand-in for unit tests — only the methods IFrameWindowProxy reads. */

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -5,6 +5,7 @@ import '@girs/gjs';
 import type GLib from '@girs/glib-2.0';
 export * from './spy.js';
 import nodeAssert from 'node:assert';
+import type { AssertPredicate } from 'node:assert';
 import { quitMainLoop } from '@gjsify/utils/main-loop';
 
 /**
@@ -615,7 +616,7 @@ assert.strictEqual = function <T>(actual: unknown, expected: T, message?: string
     }
 };
 
-assert.throws = function (promiseFn: () => unknown, ...args: [import('node:assert').AssertPredicate?, string?]) {
+assert.throws = function (promiseFn: () => unknown, ...args: [AssertPredicate?, string?]) {
     ++countTestsOverall;
     let error: unknown;
     try {

--- a/packages/node/http/src/streaming.spec.ts
+++ b/packages/node/http/src/streaming.spec.ts
@@ -7,6 +7,7 @@ import { createServer, request as httpRequest, get as httpGet } from 'node:http'
 import { Readable, PassThrough, Transform } from 'node:stream';
 import { Buffer } from 'node:buffer';
 import type { Server, IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 /** Helper: start a server and return its URL + cleanup function */
 function startServer(
@@ -609,7 +610,7 @@ export default async () => {
             await new Promise<void>((resolve) => {
                 server.listen(0, '127.0.0.1', () => resolve());
             });
-            const addr = server.address() as import('node:net').AddressInfo | null;
+            const addr = server.address() as AddressInfo | null;
             expect(addr).toBeDefined();
             expect(typeof addr!.port).toBe('number');
             expect(addr!.port).toBeGreaterThan(0);


### PR DESCRIPTION
## What

Clear the last 7 `typescript/consistent-type-imports` warnings reported by oxlint:

| File | Fix |
|---|---|
| `packages/framework/iframe/src/index.spec.ts` | `Event` → inline `type` keyword (kept `MessageEvent` as value-import; it's constructed with `new`) |
| `packages/framework/event-bridge/src/event-bridge.ts` | `OurEvent` → inline `type` keyword in the multi-import list |
| `packages/framework/event-bridge/src/event-bridge.spec.ts` | full `import type` (only `OurEvent` was used type-only) |
| `packages/dom/dom-elements/src/element.ts` | inline `import('./attr.js').Attr` → top-level `import type { Attr }` |
| `packages/dom/dom-elements/src/index.spec.ts` | dropped redundant `as unknown as import('@gjsify/dom-events').Event` (the local `Event` symbol from the existing value-import is the same type) |
| `packages/node/http/src/streaming.spec.ts` | inline `import('node:net').AddressInfo` → top-level `import type { AddressInfo } from 'node:net'` |
| `packages/gjs/unit/src/index.ts` | inline `import('node:assert').AssertPredicate` → top-level `import type { AssertPredicate } from 'node:assert'` |

## Why

`consistent-type-imports` flags both:

1. value-shaped `import { T }` declarations where `T` is only used as a type, and
2. `import()` type annotations (TypeScript-only syntax for inline imports inside type positions).

Type-only imports give the bundler a clear signal that nothing needs to be loaded at runtime — same emit shape today, but it locks the contract so a future refactor that accidentally pulls a runtime side-effect via one of these symbols surfaces as a lint error rather than a silent bundle-size regression.

## Verification

- `oxlint` repo-wide: **0 warnings, 0 errors** (down from 7 `consistent-type-imports` warnings; `no-explicit-any` already at 0 after #346–#358).
- `tsc --noEmit` clean on every touched package (`@gjsify/iframe`, `@gjsify/event-bridge`, `@gjsify/dom-elements`, `@gjsify/http`, `@gjsify/unit`).
- No runtime change — every fix is either a type-position annotation or a syntactic rephrase of an already-correct import.
