### PR TITLE
chore(deps): align rolldown + vite ranges across workspace

### DIFF
--- a/packages/infra/rolldown-plugin-deepkit/package.json
+++ b/packages/infra/rolldown-plugin-deepkit/package.json
@@ -42,7 +42,7 @@
         "typescript": "^6.0.3"
     },
     "peerDependencies": {
-        "rolldown": "^1.0.0-rc.18"
+        "rolldown": "^1.0.0"
     },
     "peerDependenciesMeta": {
         "rolldown": {

--- a/packages/infra/rolldown-plugin-gjsify/package.json
+++ b/packages/infra/rolldown-plugin-gjsify/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "@gjsify/lightningcss-native": "workspace:^",
-        "rolldown": "^1.0.0-rc.18"
+        "rolldown": "^1.0.0"
     },
     "peerDependenciesMeta": {
         "@gjsify/lightningcss-native": {

--- a/packages/infra/rolldown-plugin-pnp/package.json
+++ b/packages/infra/rolldown-plugin-pnp/package.json
@@ -38,7 +38,7 @@
     ],
     "license": "MIT",
     "peerDependencies": {
-        "rolldown": "^1.0.0-rc.18"
+        "rolldown": "^1.0.0"
     },
     "peerDependenciesMeta": {
         "rolldown": {

--- a/packages/infra/vite-plugin-blueprint/package.json
+++ b/packages/infra/vite-plugin-blueprint/package.json
@@ -46,8 +46,8 @@
         "minify-xml": "^4.5.2"
     },
     "peerDependencies": {
-        "rolldown": "^1.0.0-rc.18",
-        "vite": "^8.0.0"
+        "rolldown": "^1.0.0",
+        "vite": "^8.0.11"
     },
     "peerDependenciesMeta": {
         "rolldown": {

--- a/packages/infra/vite-plugin-gettext/package.json
+++ b/packages/infra/vite-plugin-gettext/package.json
@@ -43,8 +43,8 @@
         "gettext-parser": "^9.0.2"
     },
     "peerDependencies": {
-        "rolldown": "^1.0.0-rc.18",
-        "vite": "^8.0.0"
+        "rolldown": "^1.0.0",
+        "vite": "^8.0.11"
     },
     "peerDependenciesMeta": {
         "rolldown": {

--- a/packages/infra/vite-plugin-gjsify/package.json
+++ b/packages/infra/vite-plugin-gjsify/package.json
@@ -44,7 +44,7 @@
         "@gjsify/vite-plugin-blueprint": "workspace:^"
     },
     "peerDependencies": {
-        "vite": "^8.0.0"
+        "vite": "^8.0.11"
     },
     "peerDependenciesMeta": {
         "vite": {


### PR DESCRIPTION
## What

Workspace-wide alignment of two dependency ranges surfaced by `gjsify upgrade --check` (the workspace-aware drift detector landed in #371).

| Dep | Before | After | Affected |
|---|---|---|---|
| `rolldown` (peerDeps) | `^1.0.0-rc.18` in 3 plugin packages | `^1.0.0` (matches the existing consensus) | `rolldown-plugin-deepkit`, `rolldown-plugin-gjsify`, `rolldown-plugin-pnp`, `vite-plugin-blueprint`, `vite-plugin-gettext` |
| `vite` (devDeps) | `^8.0.0` in 3 plugin packages | `^8.0.11` (matches the existing consensus) | `vite-plugin-blueprint`, `vite-plugin-gettext`, `vite-plugin-gjsify` |

Both alignments are pre-release / loose-range → stable / consensus-range moves. No actual installed version changes (the lockfile already resolves to the higher value); only the declared range catches up.

## How

Produced mechanically by `gjsify upgrade --align --filter rolldown,vite` from the workspace root, then verified with `gjsify upgrade --check --filter rolldown,vite` (now exits 0 for those two deps).

## Out of scope

`gjsify upgrade --check` also surfaces these inconsistencies — they are **intentional** and NOT touched here:

- `zod: "4.3.6"` (literal pin) in `@gjsify/integration-mcp-typescript-sdk` — integration tests against the exact bundled version of `mcp-typescript-sdk`.
- `typescript: "^5.4.5"` / `"^5.7.3"` in `@gjsify/integration-{deepkit-type-compiler,loro-crdt,typescript-tsc}` — those upstream packages don't support TS 6 yet, so the integration tests are pinned to TS 5.

The follow-up CI workflow (separate PR) will add `gjsify upgrade --check --exclude-workspace '@gjsify/integration-*'` so the intentional drift in integration tests doesn't fail the gate.

## Verification

- `gjsify upgrade --check --filter rolldown,vite` exits 0 after the alignment.
- Pure `package.json` range updates; no source-code change.
