### PR TITLE
chore(refs): add glib-networking submodule (TLS Phase 2 vendored struct source)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -221,3 +221,6 @@
 [submodule "refs/node-gtk"]
 	path = refs/node-gtk
 	url = https://github.com/romgrk/node-gtk
+[submodule "refs/glib-networking"]
+	path = refs/glib-networking
+	url = https://gitlab.gnome.org/GNOME/glib-networking.git


### PR DESCRIPTION
## Summary

Formalises the `refs/glib-networking` submodule added locally to source the `GTlsConnectionGnutls` private-struct layout that backs the TLS Phase 2 Path-A C shim landed in #360.

PR #360's `packages/node/tls-native/src/c/gjsify-tls-private.c` vendors the 4-pointer `{credentials, session, interaction_id, cancellable}` layout from `refs/glib-networking/tls/gnutls/gtlsconnection-gnutls.c` @ `be1c870` (master at submodule-add time). Without this submodule on \`main\`, future maintainers refreshing the layout (when bumping the glib-networking pin) have no in-repo source of truth to read from.

## Changes

- `.gitmodules` — adds the submodule entry pointing at `https://gitlab.gnome.org/GNOME/glib-networking.git`
- `refs/glib-networking` — submodule pin at `be1c870` (= tag `2.80.0.97-45-gbe1c870`, master HEAD when added)

## Supported window

The 4-pointer layout is stable across glib-networking 2.74–2.84, covering Fedora 43 (2.80.x) + 44 (2.82.x). If a future bump moves a field, update the vendored layout in the C shim + bump the pin together (per `docs/poc/tls-phase2-session-access.md`).

## Disk impact

Submodule is ~30 MB. Read-only ref like every other `refs/*` entry — never modified per the `DO NOT modify refs/` rule.