### PR TITLE
feat(cli): TTY-aware progress bar for install + dlx

### DIFF
--- a/packages/infra/cli/src/commands/dlx.ts
+++ b/packages/infra/cli/src/commands/dlx.ts
@@ -23,7 +23,7 @@ import {
     resolveInstalledPkgDir,
     symlinkSwap,
 } from '../utils/dlx-cache.js';
-import { installPackages } from '../utils/install-backend.js';
+import { installPackages, makeProgressReporter } from '../utils/install-backend.js';
 
 interface DlxOptions {
     spec: string;
@@ -155,6 +155,12 @@ async function ensurePkgDir(
     }
 
     const prepareDir = makePrepareDir(cacheDir);
+    // First-run dlx (cache miss) downloads & extracts the package + its tree.
+    // For `npx @gjsify/cli showcase excalibur-jelly-jumper` and similar first-
+    // contact entry points the user otherwise sees no feedback for 10+ seconds
+    // (cold packument fetch + tarball extract + prebuild detection); the
+    // progress reporter renders a live bar via stderr.
+    const progress = makeProgressReporter({ enabled: !opts.verbose });
     await installPackages({
         prefix: prepareDir,
         specs: [parsed.spec],
@@ -165,6 +171,7 @@ async function ensurePkgDir(
         // and lets `--frozen` short-circuit the resolver entirely.
         lockfile: true,
         frozen: opts.frozen,
+        progress,
     });
 
     const liveTarget = symlinkSwap(cacheDir, prepareDir);

--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -26,7 +26,7 @@ import { discoverWorkspaces } from '@gjsify/workspace';
 import type { Command } from '../types/index.js';
 import { buildInstallCommand, detectPackageManager, runMinimalChecks } from '../utils/check-system-deps.js';
 import { detectNativePackages } from '../utils/detect-native-packages.js';
-import { installPackages } from '../utils/install-backend.js';
+import { installPackages, makeProgressReporter } from '../utils/install-backend.js';
 import { binDirOnPath, defaultGlobalLayout, linkGlobalBins, specToPackageName } from '../utils/install-global.js';
 import {
     addDependencyEntry,
@@ -46,6 +46,8 @@ interface InstallOptions {
     'save-optional'?: boolean;
     immutable?: boolean;
     verbose: boolean;
+    quiet?: boolean;
+    progress?: boolean;
     backend?: 'native' | 'npm';
     timeout: number;
 }
@@ -89,6 +91,17 @@ export const installCommand: Command<unknown, InstallOptions> = {
                 description: 'Verbose install logging.',
                 type: 'boolean',
                 default: false,
+            })
+            .option('quiet', {
+                description: 'Silence the progress bar.',
+                type: 'boolean',
+                default: false,
+            })
+            .option('progress', {
+                description:
+                    'Show a TTY-aware progress bar for resolve / download / extract phases. Auto-enabled when stderr is a TTY (override with --no-progress). Implicitly off under --verbose (per-package log lines replace the bar) or --quiet.',
+                type: 'boolean',
+                default: true,
             })
             .option('backend', {
                 description:
@@ -281,6 +294,12 @@ async function projectInstallNative(args: InstallOptions, signal?: AbortSignal):
     }
 
     mkdirSync(cwd, { recursive: true });
+    // Progress bar is auto-enabled when stderr is a TTY (and `--verbose` /
+    // `--quiet` / `--no-progress` aren't set). When piped to a log file the
+    // reporter falls back to one line per phase begin/end.
+    const progress = makeProgressReporter({
+        enabled: !args.verbose && !args.quiet && args.progress !== false,
+    });
     const result = await installPackages({
         prefix: cwd,
         specs,
@@ -290,6 +309,7 @@ async function projectInstallNative(args: InstallOptions, signal?: AbortSignal):
         lockfile: !args.immutable,
         frozen: args.immutable,
         signal,
+        progress,
     });
 
     // Update package.json only when the user passed explicit packages
@@ -429,6 +449,9 @@ async function workspaceInstall(cwd: string, args: InstallOptions, signal?: Abor
     const overrides = extractOverrides(rootManifest);
 
     if (externalSpecs.size > 0) {
+        const progress = makeProgressReporter({
+            enabled: !args.verbose && !args.quiet && args.progress !== false,
+        });
         await installPackages({
             prefix: cwd,
             specs: [...externalSpecs],
@@ -437,6 +460,7 @@ async function workspaceInstall(cwd: string, args: InstallOptions, signal?: Abor
             frozen: args.immutable,
             overrides,
             signal,
+            progress,
         });
     } else if (args.verbose) {
         console.log('gjsify install: no external deps to fetch');

--- a/packages/infra/cli/src/utils/install-backend-native.ts
+++ b/packages/infra/cli/src/utils/install-backend-native.ts
@@ -88,6 +88,7 @@ export async function installPackagesNative(opts: InstallOptions): Promise<Insta
     fs.mkdirSync(opts.prefix, { recursive: true });
     const npmrc = await loadNpmrc(opts);
     const log = makeLogger(opts.verbose ?? false);
+    const progress = opts.progress;
 
     const lockfilePath = path.join(opts.prefix, LOCKFILE_NAME);
     const existingLock = readLockfile(lockfilePath);
@@ -119,7 +120,7 @@ export async function installPackagesNative(opts: InstallOptions): Promise<Insta
         nodes = lockfileToNodes(existingLock);
     } else {
         log('install: resolving %d top-level spec(s) → %s', opts.specs.length, opts.prefix);
-        nodes = await resolveDeps(opts.specs, npmrc, log, opts.overrides, opts.skipDeps, opts.signal);
+        nodes = await resolveDeps(opts.specs, npmrc, log, opts.overrides, opts.skipDeps, opts.signal, progress);
         if (opts.lockfile) {
             writeLockfile(lockfilePath, opts.specs, nodes);
             log('install: wrote %s (%d entries)', LOCKFILE_NAME, nodes.length);
@@ -127,7 +128,7 @@ export async function installPackagesNative(opts: InstallOptions): Promise<Insta
     }
 
     log('install: downloading %d tarball(s)', nodes.length);
-    await downloadAndExtractAll(nodes, opts.prefix, npmrc, log, opts.signal);
+    await downloadAndExtractAll(nodes, opts.prefix, npmrc, log, opts.signal, progress);
     await linkBins(nodes, opts.prefix, log);
     log('install: done');
 
@@ -191,7 +192,9 @@ async function resolveDeps(
     overrides?: Record<string, string>,
     skipDeps?: boolean,
     signal?: AbortSignal,
+    progress?: import('./install-progress.js').ProgressReporter,
 ): Promise<ResolvedNode[]> {
+    progress?.beginPhase('resolve', specs.length);
     const applyOverride = (name: string, range: string): string => {
         if (!overrides) return range;
         const override = overrides[name];
@@ -285,6 +288,16 @@ async function resolveDeps(
                 root.set(edge.name, node);
             }
             log('resolve: %s@%s ← %s (at %s)', edge.name, version, edge.range, installPath);
+            // Soft-total tracks the dep graph as it grows. We use
+            // byPath.size (resolved so far) + queue.length (still to
+            // process) as a moving estimate that converges as work
+            // finishes — yarn/pnpm use the same pattern.
+            progress?.update({
+                phase: 'resolve',
+                current: byPath.size,
+                total: byPath.size + queue.length,
+                name: `${edge.name}@${version}`,
+            });
 
             if (!skipDeps) {
                 for (const [depName, depRange] of Object.entries(node.dependencies)) {
@@ -315,6 +328,7 @@ async function resolveDeps(
         }
     }
 
+    progress?.endPhase('resolve');
     return Array.from(byPath.values());
 }
 
@@ -542,6 +556,7 @@ async function downloadAndExtractAll(
     npmrc: NpmrcConfig,
     log: Logger,
     signal?: AbortSignal,
+    progress?: import('./install-progress.js').ProgressReporter,
 ): Promise<void> {
     // Sort by install-path depth ascending so parents extract before
     // children. Extracting a parent on top of an existing child would
@@ -551,6 +566,17 @@ async function downloadAndExtractAll(
     );
     const workers: Array<Promise<void>> = [];
     const concurrency = Math.max(1, Math.min(DEFAULT_CONCURRENCY, queue.length));
+    progress?.beginPhase('download', queue.length);
+    let completed = 0;
+    const tickProgress = (node: ResolvedNode) => {
+        completed++;
+        progress?.update({
+            phase: 'download',
+            current: completed,
+            total: queue.length,
+            name: `${node.name}@${node.version}`,
+        });
+    };
     // Parents (depth 1) are extracted serially first to avoid concurrent
     // `rm -rf` + extract races with their children. Once depth-1 is done,
     // depths >=2 run with full concurrency.
@@ -563,6 +589,7 @@ async function downloadAndExtractAll(
         const node = queue[cursor++];
         if (!node) break;
         await extractOne(node, prefix, npmrc, log, signal);
+        tickProgress(node);
     }
 
     // Concurrent nested pass.
@@ -575,11 +602,13 @@ async function downloadAndExtractAll(
                     const node = queue[idx];
                     if (!node) return;
                     await extractOne(node, prefix, npmrc, log, signal);
+                    tickProgress(node);
                 }
             })(),
         );
     }
     await Promise.all(workers);
+    progress?.endPhase('download');
 }
 
 async function extractOne(

--- a/packages/infra/cli/src/utils/install-backend.ts
+++ b/packages/infra/cli/src/utils/install-backend.ts
@@ -17,6 +17,11 @@ import { spawn } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import type { ProgressReporter } from './install-progress.js';
+
+export type { ProgressEvent, ProgressPhase, ProgressReporter } from './install-progress.js';
+export { makeProgressReporter } from './install-progress.js';
+
 export interface InstallOptions {
     /** Directory to install into (npm `--prefix`). Created by caller. */
     prefix: string;
@@ -68,6 +73,13 @@ export interface InstallOptions {
      * timeouts in @gjsify/npm-registry still apply.
      */
     signal?: AbortSignal;
+    /**
+     * Native backend only: progress reporter for resolve / download / extract /
+     * link phases. The CLI auto-creates a TTY-aware reporter by default; pass
+     * a custom reporter (or the `NOOP` from `makeProgressReporter({enabled:false})`)
+     * to override.
+     */
+    progress?: ProgressReporter;
 }
 
 const DEFAULT_BACKEND = process.env.GJSIFY_INSTALL_BACKEND ?? 'native';

--- a/packages/infra/cli/src/utils/install-progress.ts
+++ b/packages/infra/cli/src/utils/install-progress.ts
@@ -1,0 +1,140 @@
+// Progress reporter for `gjsify install` + `gjsify dlx`.
+//
+// Auto-enables on TTY stderr. Renders a single-line progress bar that gets
+// overwritten via `\r`, mirroring what `yarn install` / `pnpm install` show:
+//
+//     resolving [████████░░░░░░░░] 234/500 typescript@^6.0.3
+//
+// Falls back to a chatty mode (one line per completed step) when stderr is
+// not a TTY, e.g. when piped into a log file or running on CI.
+//
+// Caller plumbing — the install backend calls `report({phase, current, total,
+// name})` after every resolve/download/extract step; the renderer rate-limits
+// to ~30fps so a tight inner loop doesn't drown the terminal.
+
+export type ProgressPhase = 'resolve' | 'download' | 'extract' | 'link';
+
+export interface ProgressEvent {
+    phase: ProgressPhase;
+    current: number;
+    total: number;
+    /** Package name being processed, surfaced in the right-hand side of the bar. */
+    name?: string;
+}
+
+export interface ProgressReporter {
+    /** Called for each step within a phase. */
+    update(event: ProgressEvent): void;
+    /** Called once when a phase begins; lets the reporter print a header line. */
+    beginPhase(phase: ProgressPhase, total: number): void;
+    /** Called once when a phase completes; clears the inline progress bar. */
+    endPhase(phase: ProgressPhase): void;
+}
+
+const PHASE_LABEL: Record<ProgressPhase, string> = {
+    resolve: 'resolving',
+    download: 'downloading',
+    extract: 'extracting',
+    link: 'linking bins',
+};
+
+const NOOP_REPORTER: ProgressReporter = {
+    update() {},
+    beginPhase() {},
+    endPhase() {},
+};
+
+/**
+ * Make a progress reporter that auto-targets `process.stderr`.
+ * - `enabled=false` → silent.
+ * - stderr is not a TTY → fall back to one line per phase (begin + end).
+ * - stderr is a TTY → live single-line progress bar (\r-updated, 30fps).
+ */
+export function makeProgressReporter(opts: {
+    enabled?: boolean;
+    stream?: NodeJS.WriteStream;
+} = {}): ProgressReporter {
+    if (opts.enabled === false) return NOOP_REPORTER;
+    const stream = opts.stream ?? process.stderr;
+    const isTty = Boolean(stream.isTTY);
+    const enabled = opts.enabled ?? true;
+    if (!enabled) return NOOP_REPORTER;
+    return isTty ? makeTtyReporter(stream) : makePlainReporter(stream);
+}
+
+// ──── TTY reporter — single-line, \r-updated, 30fps rate-limit ────────────
+
+function makeTtyReporter(stream: NodeJS.WriteStream): ProgressReporter {
+    let lastRender = 0;
+    let lastLine = '';
+    const FRAME_MS = 33; // ~30fps
+
+    function render(line: string, force = false) {
+        const now = Date.now();
+        if (!force && now - lastRender < FRAME_MS && line === lastLine) return;
+        lastRender = now;
+        lastLine = line;
+        // Clear current line, write new content. \x1b[2K = erase entire line.
+        stream.write('\r\x1b[2K' + line);
+    }
+
+    function clearLine() {
+        stream.write('\r\x1b[2K');
+        lastLine = '';
+    }
+
+    return {
+        beginPhase(phase, total) {
+            // First frame so the user sees immediate feedback.
+            render(formatBar(phase, 0, total, undefined, stream.columns ?? 80), true);
+        },
+        update(ev) {
+            render(formatBar(ev.phase, ev.current, ev.total, ev.name, stream.columns ?? 80));
+        },
+        endPhase(phase) {
+            // Replace the live bar with a completion line so the user sees
+            // a definitive "done" after the spinner stops.
+            const label = PHASE_LABEL[phase];
+            clearLine();
+            stream.write(`gjsify install: ${label} done\n`);
+        },
+    };
+}
+
+// ──── Plain reporter — one line per phase begin + end (non-TTY) ────────────
+
+function makePlainReporter(stream: NodeJS.WriteStream): ProgressReporter {
+    return {
+        beginPhase(phase, total) {
+            stream.write(`gjsify install: ${PHASE_LABEL[phase]} ${total} package(s)\n`);
+        },
+        update() {
+            // Per-package output would flood logs; skip on non-TTY.
+        },
+        endPhase(phase) {
+            stream.write(`gjsify install: ${PHASE_LABEL[phase]} done\n`);
+        },
+    };
+}
+
+// ──── Bar formatter ────────────────────────────────────────────────────────
+
+function formatBar(phase: ProgressPhase, current: number, total: number, name: string | undefined, columns: number): string {
+    const label = PHASE_LABEL[phase];
+    const ratio = total > 0 ? Math.min(1, current / total) : 0;
+    const pct = `${current}/${total}`;
+    // Reserve: "gjsify install: " (16) + label (max ~12) + " [" (2) + "] " (2) + pct (~8) + " " + name
+    const prefix = `gjsify install: ${label} `;
+    const suffix = ` ${pct}` + (name ? ` ${name}` : '');
+    const barWidth = Math.max(8, Math.min(40, columns - prefix.length - suffix.length - 4));
+    const filled = Math.round(ratio * barWidth);
+    const bar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+    let line = `${prefix}[${bar}]${suffix}`;
+    if (line.length > columns) {
+        // Truncate name if the terminal is narrow.
+        const overflow = line.length - columns + 1;
+        const truncatedName = name && name.length > overflow ? name.slice(0, name.length - overflow - 1) + '…' : '';
+        line = `${prefix}[${bar}] ${pct}${truncatedName ? ' ' + truncatedName : ''}`;
+    }
+    return line;
+}


### PR DESCRIPTION
## Why

A fresh `gjsify install` on this monorepo takes 10-15 minutes (213 workspaces, deep dep graphs, 600+ resolved packages). `npx @gjsify/cli showcase excalibur-jelly-jumper` (cold dlx) takes 10-30 seconds before any UI appears. Without feedback users assume gjsify is broken or kill it.

This change adds the same kind of live progress bar yarn / pnpm show.

## What

New module `utils/install-progress.ts`:

- `ProgressReporter` interface — `beginPhase(phase, total)` / `update({phase, current, total, name?})` / `endPhase(phase)`.
- `makeProgressReporter({enabled?, stream?})` factory:
  - `enabled=false` → no-op
  - stderr is a TTY → live single-line bar, 30fps rate-limit, `\r`-updated
  - stderr is not a TTY (CI, piped to log) → one header + one done line per phase

```
gjsify install: resolving [████████░░░░░░░░] 234/500 typescript@^6.0.3
```

## Plumbing

- `installPackagesNative` calls `beginPhase` / `update` / `endPhase` at the right seams:
  - `resolveDeps`: soft-total via `byPath.size + queue.length` (converges as resolution finishes — same pattern yarn uses for transitive resolves)
  - `downloadAndExtractAll`: hard-total via queue length
- `installPackages` re-exports the factory so callers don't need a separate import.
- `gjsify install` gains `--quiet` and `--progress` (default `true`) flags. Auto-implied off under `--verbose` (per-package log lines replace the bar).
- `gjsify dlx` enables the reporter by default.
- `gjsify showcase` delegates to `dlx` so it picks it up for free.

## Test plan

- [x] `tsc --noEmit` clean on the 5 modified files
- [ ] Manual: `gjsify install` on a fresh checkout shows the bar
- [ ] Manual: `npx @gjsify/cli showcase excalibur-jelly-jumper` shows the bar during cold-cache prepare
- [ ] CI: piped-to-file mode shows the plain `header + done` lines, no escape codes