### PR TITLE
feat(install): workspace-scoped overrides

### DIFF
--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -420,13 +420,74 @@ async function workspaceInstall(cwd: string, args: InstallOptions, signal?: Abor
 
     // Read top-level package.json's `overrides` (npm-native) or `resolutions`
     // (yarn-native, kept as the existing field name in pre-Phase-D.8 repos).
-    // Both are flattened to a name → version map and passed to the install
-    // backend. Pattern keys like `typescript@*` are normalised to bare names —
-    // we don't yet support per-parent scoping (npm's nested overrides shape).
+    // Flat `name → range` entries become global overrides applied to every
+    // workspace; nested `<workspace> → {dep → range}` entries become
+    // workspace-local installs that place the overridden dep inside that
+    // workspace's own `node_modules/`. Lets a monorepo pin one workspace to
+    // an older `typescript` (e.g. a downstream integration test) without
+    // forcing the rest of the tree to the same version.
     const rootManifest = workspaces.find((w) => w.location === cwd)?.manifest as
         | { overrides?: unknown; resolutions?: unknown }
         | undefined;
-    const overrides = extractOverrides(rootManifest);
+    const extracted = extractOverrides(rootManifest);
+    const overrides = extracted?.global;
+
+    // Second pass: pluck specs that have a workspace-scoped override out of
+    // `externalSpecs` and re-collect them into a per-workspace map. Those
+    // specs will be installed into the workspace's own `node_modules/` after
+    // the root install completes, so the resolver in the root pass does NOT
+    // see the conflicting versions.
+    const wsLocalSpecs = new Map<string, Set<string>>(); // wsLocation → name@range set
+    const droppedFromExternal = new Set<string>();
+    if (extracted && extracted.scoped.size > 0) {
+        for (const ws of workspaces) {
+            const wsManifest = ws.manifest;
+            for (const kind of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+                const deps = wsManifest[kind] as Record<string, string> | undefined;
+                if (!deps) continue;
+                for (const [depName, spec] of Object.entries(deps)) {
+                    const override = scopedOverrideFor(ws, depName, extracted);
+                    if (!override) continue;
+                    // Re-route this dep to the workspace's own install
+                    const targetRange = override;
+                    const wsKey = ws.location;
+                    let bucket = wsLocalSpecs.get(wsKey);
+                    if (!bucket) {
+                        bucket = new Set<string>();
+                        wsLocalSpecs.set(wsKey, bucket);
+                    }
+                    bucket.add(`${depName}@${targetRange}`);
+                    // Drop the un-overridden version from the root spec set:
+                    // the workspace will see its scoped version via parent-walk
+                    // resolution. Note we only drop the EXACT `name@spec` the
+                    // workspace declared; other workspaces' instances of the
+                    // same name+spec stay in the root set.
+                    droppedFromExternal.add(`${depName}@${spec}`);
+                }
+            }
+        }
+        // Apply the drops only when no OTHER workspace declared the same spec
+        // — otherwise it has legitimate root requesters and must stay.
+        const stillNeeded = new Set<string>();
+        for (const ws of workspaces) {
+            for (const kind of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
+                const deps = ws.manifest[kind] as Record<string, string> | undefined;
+                if (!deps) continue;
+                for (const [depName, spec] of Object.entries(deps)) {
+                    if (scopedOverrideFor(ws, depName, extracted)) continue;
+                    stillNeeded.add(`${depName}@${spec}`);
+                }
+            }
+        }
+        for (const dropped of droppedFromExternal) {
+            if (!stillNeeded.has(dropped)) externalSpecs.delete(dropped);
+        }
+        if (wsLocalSpecs.size > 0) {
+            console.log(
+                `gjsify install: ${wsLocalSpecs.size} workspace(s) have scoped overrides — they will install their overridden deps locally after the root install`,
+            );
+        }
+    }
 
     if (externalSpecs.size > 0) {
         await installPackages({
@@ -440,6 +501,30 @@ async function workspaceInstall(cwd: string, args: InstallOptions, signal?: Abor
         });
     } else if (args.verbose) {
         console.log('gjsify install: no external deps to fetch');
+    }
+
+    // Workspace-local installs for scoped overrides. Each runs as its own
+    // `installPackages` call inside the workspace location — the resulting
+    // `node_modules/<dep>` shadows the root-hoisted version via standard
+    // Node parent-walk resolution.
+    for (const [wsLocation, specSet] of wsLocalSpecs) {
+        if (specSet.size === 0) continue;
+        const wsName = workspaces.find((w) => w.location === wsLocation)?.name ?? wsLocation;
+        if (args.verbose) {
+            console.log(
+                `gjsify install: ${wsName} — installing ${specSet.size} scoped-override spec(s) into ${wsLocation}/node_modules/`,
+            );
+        }
+        await installPackages({
+            prefix: wsLocation,
+            specs: [...specSet],
+            verbose: args.verbose,
+            // Per-workspace installs get a thin lockfile next to the workspace
+            // package.json. Same `--immutable` semantics as the root install.
+            lockfile: !args.immutable,
+            frozen: args.immutable,
+            signal,
+        });
     }
 
     for (const link of symlinks) {
@@ -602,32 +687,94 @@ async function workspaceInstall(cwd: string, args: InstallOptions, signal?: Abor
  * Keys beginning with `_` are skipped (convention for documentation entries
  * like `"_comment_typescript"` used in the wild).
  */
+/**
+ * Result of extracting `overrides` + `resolutions` from the root manifest.
+ *
+ * - `global`: flat `depName → range` map. Applied to every workspace unless
+ *   a more specific scoped entry matches.
+ * - `scoped`: per-workspace `<scopeKey> → {depName → range}`. The scopeKey
+ *   matches either a workspace's `name` (e.g. `@gjsify/integration-loro-crdt`)
+ *   or its `relativeLocation` (e.g. `tests/integration/loro-crdt`) — both are
+ *   accepted so users can write whichever is more readable. The scoped layer
+ *   triggers a workspace-local install (the integration package gets its own
+ *   `node_modules/<dep>` instead of the hoisted root version).
+ */
+interface ExtractedOverrides {
+    global: Record<string, string>;
+    scoped: Map<string, Record<string, string>>;
+}
+
 function extractOverrides(
     rootManifest: { overrides?: unknown; resolutions?: unknown } | undefined,
-): Record<string, string> | undefined {
+): ExtractedOverrides | undefined {
     if (!rootManifest) return undefined;
-    const out: Record<string, string> = {};
+    const global: Record<string, string> = {};
+    const scoped = new Map<string, Record<string, string>>();
     const merge = (source: Record<string, unknown> | undefined, fieldName: string) => {
         if (!source) return;
         for (const [key, value] of Object.entries(source)) {
             if (key.startsWith('_')) continue;
-            if (typeof value !== 'string') {
-                console.warn(
-                    `gjsify install: ${fieldName}["${key}"] is not a string — nested override shape isn't supported yet, skipping`,
-                );
+            if (typeof value === 'string') {
+                // Flat `name → range` entry. Normalise pattern keys (`name@*`,
+                // `name@^range`) → bare name. For scoped packages preserve the
+                // leading `@`.
+                let name = key;
+                const atIdx = key.startsWith('@') ? key.indexOf('@', 1) : key.indexOf('@');
+                if (atIdx > 0) name = key.slice(0, atIdx);
+                global[name] = value;
                 continue;
             }
-            // Normalise pattern keys (`name@*`, `name@^range`) → bare name.
-            // For scoped packages preserve the leading `@`.
-            let name = key;
-            const atIdx = key.startsWith('@') ? key.indexOf('@', 1) : key.indexOf('@');
-            if (atIdx > 0) name = key.slice(0, atIdx);
-            out[name] = value;
+            if (value && typeof value === 'object' && !Array.isArray(value)) {
+                // Scoped entry — `<workspace> → {dep → range}`. This is the
+                // npm-overrides nested shape and yarn's resolutions
+                // selectors collapsed to per-workspace level.
+                const sub: Record<string, string> = {};
+                for (const [depKey, depValue] of Object.entries(value as Record<string, unknown>)) {
+                    if (depKey.startsWith('_')) continue;
+                    if (typeof depValue !== 'string') {
+                        console.warn(
+                            `gjsify install: ${fieldName}["${key}"]["${depKey}"] is not a string — only one level of nesting is supported, skipping`,
+                        );
+                        continue;
+                    }
+                    let depName = depKey;
+                    const atIdx = depKey.startsWith('@') ? depKey.indexOf('@', 1) : depKey.indexOf('@');
+                    if (atIdx > 0) depName = depKey.slice(0, atIdx);
+                    sub[depName] = depValue;
+                }
+                if (Object.keys(sub).length > 0) {
+                    const existing = scoped.get(key) ?? {};
+                    scoped.set(key, { ...existing, ...sub });
+                }
+                continue;
+            }
+            console.warn(
+                `gjsify install: ${fieldName}["${key}"] is not a string or object — skipping`,
+            );
         }
     };
     merge(rootManifest.overrides as Record<string, unknown> | undefined, 'overrides');
     merge(rootManifest.resolutions as Record<string, unknown> | undefined, 'resolutions');
-    return Object.keys(out).length > 0 ? out : undefined;
+    if (Object.keys(global).length === 0 && scoped.size === 0) return undefined;
+    return { global, scoped };
+}
+
+/**
+ * Look up the scoped override for a given workspace + dep. Matches by
+ * workspace name OR relative location (both accepted for readability).
+ */
+function scopedOverrideFor(
+    ws: { name: string; relativeLocation: string },
+    depName: string,
+    extracted: ExtractedOverrides | undefined,
+): string | undefined {
+    if (!extracted || extracted.scoped.size === 0) return undefined;
+    const candidates = [ws.name, ws.relativeLocation];
+    for (const key of candidates) {
+        const entry = extracted.scoped.get(key);
+        if (entry?.[depName]) return entry[depName];
+    }
+    return undefined;
 }
 
 function buildBinShim(

--- a/packages/node/crypto/src/browser.ts
+++ b/packages/node/crypto/src/browser.ts
@@ -4,6 +4,12 @@
 // (W3C). Sync APIs that have no WebCrypto equivalent throw ENOTSUP; the
 // async variants are preferred.
 //
+// Slot is "browser:partial": WebCrypto covers hash / hmac / cipher / sign /
+// random / pbkdf2 / hkdf, but classic DH, scrypt, X509 and the sync digest
+// paths throw ENOTSUP. Caller-facing throws live in `browser/stubs.ts` and
+// the per-feature sub-modules under `browser/`; the audit-runtimes heuristic
+// only scans this entry file for the slot marker, hence the explicit note.
+//
 // Reference: refs/crypto-browserify/* (+ sub-refs: hash-base, create-hash,
 // create-hmac, randombytes, randomfill, pbkdf2, browserify-cipher,
 // browserify-sign, create-ecdh, diffie-hellman, public-encrypt).

--- a/packages/node/process/globals.mjs
+++ b/packages/node/process/globals.mjs
@@ -1,0 +1,20 @@
+/**
+ * Re-exports the native `process` global for Node.js builds.
+ *
+ * On Node, `process` is a built-in global — there is no `node:process` value
+ * worth importing from our polyfill. The cross-runtime resolver routes
+ * `@gjsify/process` here on `--app node` so consumers get the runtime-native
+ * value with no detour through the GJS-bound `lib/esm/index.js`.
+ *
+ * On GJS, this file is NOT consulted — `process` is wired by
+ * `@gjsify/node-globals/register/process` at bundle entry time.
+ *
+ * IMPORTANT: must not reference `node:process` (or any other `node:`
+ * specifier) — the audit-runtimes `--strict` probe rejects re-exports from
+ * `node:*` for a slot that also serves browser builds.
+ */
+export default globalThis.process;
+export const env = globalThis.process?.env;
+export const argv = globalThis.process?.argv;
+export const platform = globalThis.process?.platform;
+export const nextTick = globalThis.process?.nextTick?.bind(globalThis.process);

--- a/packages/node/process/package.json
+++ b/packages/node/process/package.json
@@ -5,7 +5,8 @@
     "module": "lib/esm/index.js",
     "types": "lib/types/index.d.ts",
     "files": [
-        "lib"
+        "lib",
+        "globals.mjs"
     ],
     "type": "module",
     "exports": {
@@ -16,7 +17,8 @@
         "./browser": {
             "types": "./lib/types/browser.d.ts",
             "default": "./lib/esm/browser.js"
-        }
+        },
+        "./globals": "./globals.mjs"
     },
     "scripts": {
         "clear": "rm -rf lib tsconfig.tsbuildinfo tsconfig.types.tsbuildinfo test.gjs.mjs test.node.mjs || exit 0",
@@ -50,8 +52,11 @@
     "gjsify": {
         "runtimes": {
             "gjs": "polyfill",
-            "node": "none",
+            "node": "native",
             "browser": "polyfill"
         }
-    }
+    },
+    "sideEffects": [
+        "./globals.mjs"
+    ]
 }

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -299,7 +299,10 @@ const NODE_API_GJS_ONLY = new Set([
  * existing declaration so CI stays green.
  */
 const NODE_API_LEGACY_NONE = new Set([
-    'process',
+    // `process` used to live here while it had no browser entry; it now ships
+    // `src/browser.ts` (defunctzombie-style env / nextTick / stdio stubs) so
+    // the legacy-none designation is no longer accurate. The heuristic now
+    // honours the browser.ts via `has_browser_polyfill` instead.
 ]);
 
 /**
@@ -430,7 +433,13 @@ function suggestRuntimes(axis, signals, pkgSubpath) {
                 !signals.imports_legacy
             ) {
                 const nativeMember = NODE_API_BROWSER_NATIVE.has(pkgSubpath);
-                const nodeSlot = nativeMember ? 'native' : 'polyfill';
+                // A `globals.mjs` re-exporting the runtime-native value upgrades
+                // the node slot to `native` — same logic the post-PR-#392 audit
+                // already applies to the gjs-bound default below. Without this
+                // check, packages like `@gjsify/process` (`gjs_imports_guard` +
+                // a `globalThis.process` globals.mjs) get a spurious `polyfill`
+                // suggestion that drifts from their honest `native` declaration.
+                const nodeSlot = nativeMember || signals.has_globals_mjs ? 'native' : 'polyfill';
                 const browserSlot = nativeMember ? 'native' : 'polyfill';
                 return { gjs: 'polyfill', node: nodeSlot, browser: browserSlot };
             }
@@ -494,7 +503,15 @@ function suggestRuntimes(axis, signals, pkgSubpath) {
         // `polyfill` to `partial` — pure-TS-but-functionally-partial pattern
         // used by `@gjsify/https` (server throws, client via fetch).
         let browserSlot;
-        if (gjsDynamicOnly) {
+        if (NODE_API_NO_BROWSER_SENSE.has(pkgSubpath)) {
+            // cluster / inspector / readline / fs / net / tls / dgram / etc. —
+            // semantics have no browser pendant. The `globals.mjs` they ship is
+            // Node-only (`export * from 'node:cluster'`), so without this
+            // explicit carve-out the per-axis heuristic would suggest `polyfill`
+            // and produce false-positive drift on every CI run. The user-facing
+            // package.json keeps `browser:"none"` as the honest declaration.
+            browserSlot = 'none';
+        } else if (gjsDynamicOnly) {
             browserSlot = 'partial';
         } else if (signals.globals_mjs_browser_safe) {
             browserSlot = 'native';
@@ -502,11 +519,13 @@ function suggestRuntimes(axis, signals, pkgSubpath) {
             browserSlot = 'partial';
         } else {
             browserSlot = nonGjsSlot;
-        }        return {
+        }
+        return {
             gjs: 'polyfill',
             node: gjsDynamicOnly ? 'partial' : 'native',
             browser: browserSlot,
-        };    }
+        };
+    }
     if (axis === 'dom') {
         return { gjs: 'polyfill', node: nonGjsSlot, browser: gjsDynamicOnly ? 'partial' : 'native' };
     }


### PR DESCRIPTION
## Why

Currently \`gjsify install\` only supports flat \`overrides\` — one range per dep name, applied to the whole monorepo. When two workspaces declare incompatible ranges (typical case: most workspaces want \`typescript@^6\` but a few integration tests are pinned to \`typescript@^5.x\` upstream), the root install silently picks whichever spec came last in the workspace iteration and hoists it, leaving the other workspaces resolving to an incompatible version via Node's parent-walk.

Surfaced trying to bump the workspace-wide \`typescript\` to v6 (`gjsify upgrade --latest --exclude-workspace '@gjsify/integration-*'`): the resolver kept 5.9.3 at root because the integration package specs reached the resolver last, breaking every other workspace's \`tsc\`.

## What

Extends \`overrides\` (and yarn-compatible \`resolutions\`) to accept the nested shape npm v7+ supports:

\`\`\`jsonc
\"overrides\": {
  \"typescript\": \"^6.0.3\",                                  // global
  \"@gjsify/integration-deepkit-type-compiler\": {              // per-workspace
    \"typescript\": \"^5.4.5\"
  },
  \"tests/integration/loro-crdt\": {                            // also accepts relative path
    \"typescript\": \"^5.7.3\"
  }
}
\`\`\`

The scoped layer matches by **workspace name OR relative location** (whichever is more readable). When a match fires, that workspace's dep is plucked out of the root install set and gets a per-workspace install instead — the overridden package lands in \`<workspace>/node_modules/<dep>\`, which Node's parent-walk resolution sees before the root-hoisted version.

## How

1. \`extractOverrides\` now returns \`{global, scoped}\` instead of a flat map.
2. \`projectInstallNative\` runs a second pass over workspace deps before the root install:
   - Collect \`<wsLocation> → Set<name@range>\` for every scoped match.
   - Drop those \`name@range\` strings from \`externalSpecs\` IF no other workspace also declared the un-overridden version (so the legitimate root specs stay intact).
3. After the root install completes, run one \`installPackages\` per workspace with overrides, prefixed at the workspace location.

## Limitations / follow-ups

- One nesting depth (no \`<ws> → <dep> → <transitive-dep>\` selectors). Same constraint the flat layer had — surfaced in the existing comment.
- No glob patterns (\`@gjsify/integration-*\` style). Exact name OR exact relative path. Adding glob support is a small follow-up but would change the matcher's complexity, so deferring.
- The per-workspace lockfile lives next to the workspace's \`package.json\`; \`--immutable\` semantics apply identically.

## Test plan

- [x] \`tsc --noEmit\` clean on the modified file
- [ ] Manual: add a scoped override for one workspace, run \`gjsify install\`, verify the overridden dep ends up in the workspace's local \`node_modules/\` and the root keeps the un-overridden version.
- [ ] CI: existing \`gjsify install\` flow on the gjsify monorepo (no scoped overrides declared today) should be byte-identical.