### PR TITLE
feat(workspace): reverse-dep graph + affected-closure + file→ws mapping

### DIFF
--- a/packages/infra/workspace/src/index.spec.ts
+++ b/packages/infra/workspace/src/index.spec.ts
@@ -13,6 +13,9 @@ import {
     discoverWorkspaces,
     resolveWorkspaceProtocol,
     buildDependencyGraph,
+    buildReverseDependencyGraph,
+    affectedClosure,
+    workspacesForChangedFiles,
     topologicalSort,
     filterWorkspaces,
     type Workspace,
@@ -199,6 +202,149 @@ export default async (): Promise<void> => {
             await it('--no-private drops private workspaces', () => {
                 const sel = filterWorkspaces(ws, { noPrivate: true });
                 expect(sel.find((w) => w.name === '@girs/glib-2.0')).toBeUndefined();
+            });
+        });
+
+        await describe('buildReverseDependencyGraph', async () => {
+            await it('inverts forward edges — `A → B` becomes `B → A`', () => {
+                const ws: Workspace[] = [
+                    makeWs('@gjsify/a', '1.0.0', {
+                        dependencies: { '@gjsify/b': 'workspace:*' },
+                    }),
+                    makeWs('@gjsify/b', '1.0.0'),
+                ];
+                const reverse = buildReverseDependencyGraph(ws);
+                expect(reverse.edges.get('@gjsify/b')?.has('@gjsify/a')).toBeTruthy();
+                expect(reverse.edges.get('@gjsify/a')?.size).toBe(0);
+            });
+
+            await it('every workspace appears as a key, even with no dependents', () => {
+                const ws: Workspace[] = [makeWs('@gjsify/lonely', '1.0.0')];
+                const reverse = buildReverseDependencyGraph(ws);
+                expect(reverse.edges.has('@gjsify/lonely')).toBeTruthy();
+                expect(reverse.edges.get('@gjsify/lonely')?.size).toBe(0);
+            });
+        });
+
+        await describe('affectedClosure', async () => {
+            // Diamond: A → B, A → C, B → D, C → D. A change in D
+            // should mark D, B, C, AND A as affected.
+            const ws: Workspace[] = [
+                makeWs('@gjsify/a', '1.0.0', {
+                    dependencies: { '@gjsify/b': 'workspace:*', '@gjsify/c': 'workspace:*' },
+                }),
+                makeWs('@gjsify/b', '1.0.0', {
+                    dependencies: { '@gjsify/d': 'workspace:*' },
+                }),
+                makeWs('@gjsify/c', '1.0.0', {
+                    dependencies: { '@gjsify/d': 'workspace:*' },
+                }),
+                makeWs('@gjsify/d', '1.0.0'),
+            ];
+            const reverse = buildReverseDependencyGraph(ws);
+
+            await it('seeds-only when no dependents', () => {
+                const closure = affectedClosure(reverse, ['@gjsify/a']);
+                expect(closure.size).toBe(1);
+                expect(closure.has('@gjsify/a')).toBeTruthy();
+            });
+
+            await it('walks transitive dependents through a diamond', () => {
+                const closure = affectedClosure(reverse, ['@gjsify/d']);
+                expect(closure.size).toBe(4);
+                for (const name of ['@gjsify/a', '@gjsify/b', '@gjsify/c', '@gjsify/d']) {
+                    expect(closure.has(name)).toBeTruthy();
+                }
+            });
+
+            await it('idempotent on duplicate seeds', () => {
+                const a = affectedClosure(reverse, ['@gjsify/b', '@gjsify/b', '@gjsify/b']);
+                const b = affectedClosure(reverse, ['@gjsify/b']);
+                expect(a.size).toBe(b.size);
+                for (const n of a) expect(b.has(n)).toBeTruthy();
+            });
+
+            await it('unknown seed names are silently skipped (conservative)', () => {
+                const closure = affectedClosure(reverse, ['@gjsify/ghost', '@gjsify/d']);
+                expect(closure.size).toBe(4);
+                expect(closure.has('@gjsify/ghost')).toBeFalsy();
+            });
+
+            await it('seeds = [] returns empty', () => {
+                expect(affectedClosure(reverse, []).size).toBe(0);
+            });
+        });
+
+        await describe('workspacesForChangedFiles', async () => {
+            const ws: Workspace[] = [
+                {
+                    location: '/abs/packages/node/fs',
+                    relativeLocation: 'packages/node/fs',
+                    name: '@gjsify/fs',
+                    version: '0.0.0',
+                    private: false,
+                    manifest: { name: '@gjsify/fs', version: '0.0.0' },
+                },
+                {
+                    location: '/abs/packages/node/fs-promises',
+                    relativeLocation: 'packages/node/fs-promises',
+                    name: '@gjsify/fs-promises',
+                    version: '0.0.0',
+                    private: false,
+                    manifest: { name: '@gjsify/fs-promises', version: '0.0.0' },
+                },
+                {
+                    location: '/abs/tests/integration/loro-crdt',
+                    relativeLocation: 'tests/integration/loro-crdt',
+                    name: '@gjsify/integration-loro-crdt',
+                    version: '0.0.0',
+                    private: true,
+                    manifest: { name: '@gjsify/integration-loro-crdt', version: '0.0.0' },
+                },
+            ];
+
+            await it('matches segment-aware, not prefix-of-string', () => {
+                // fs-promises is a prefix-of-string match for fs but
+                // belongs to its own workspace.
+                const r = workspacesForChangedFiles(ws, '/abs', [
+                    'packages/node/fs-promises/src/x.ts',
+                    'packages/node/fs/src/y.ts',
+                ]);
+                expect(r.matched.size).toBe(2);
+                expect(r.matched.has('@gjsify/fs-promises')).toBeTruthy();
+                expect(r.matched.has('@gjsify/fs')).toBeTruthy();
+            });
+
+            await it('unmatched files surface for caller-side classification', () => {
+                const r = workspacesForChangedFiles(ws, '/abs', [
+                    'README.md',
+                    'scripts/audit-runtimes.mjs',
+                ]);
+                expect(r.matched.size).toBe(0);
+                expect(r.unmatched.length).toBe(2);
+            });
+
+            await it('multiple files in one workspace coalesce', () => {
+                const r = workspacesForChangedFiles(ws, '/abs', [
+                    'packages/node/fs/src/a.ts',
+                    'packages/node/fs/src/b.ts',
+                    'packages/node/fs/package.json',
+                ]);
+                expect(r.matched.size).toBe(1);
+                expect(r.matched.has('@gjsify/fs')).toBeTruthy();
+            });
+
+            await it('handles backslashes (Windows-style diff)', () => {
+                const r = workspacesForChangedFiles(ws, '/abs', [
+                    'packages\\node\\fs\\src\\index.ts',
+                ]);
+                expect(r.matched.has('@gjsify/fs')).toBeTruthy();
+            });
+
+            await it('empty input → empty output', () => {
+                const r = workspacesForChangedFiles(ws, '/abs', []);
+                expect(r.matched.size).toBe(0);
+                expect(r.unmatched.length).toBe(0);
             });
         });
     });

--- a/packages/infra/workspace/src/index.ts
+++ b/packages/infra/workspace/src/index.ts
@@ -282,6 +282,140 @@ export function topologicalSort(graph: DependencyGraph): Workspace[] {
 }
 
 /**
+ * Build the REVERSE inter-workspace dependency graph. Each edge `B → A`
+ * means "A depends on B" — i.e. when B changes, A is affected and may
+ * need re-test / re-build. Same option semantics as
+ * `buildDependencyGraph`; the result feeds `affectedClosure`.
+ *
+ * Implementation note: we share the forward graph's filtering rules
+ * (workspace:* protocol, only edges where both endpoints are workspaces
+ * in this monorepo) so the two graphs stay consistent — `topologicalSort`
+ * order is the reverse of `affectedClosure` traversal order on any
+ * acyclic DAG.
+ */
+export function buildReverseDependencyGraph(
+    workspaces: readonly Workspace[],
+    options: BuildGraphOptions = {},
+): DependencyGraph {
+    const forward = buildDependencyGraph(workspaces, options);
+    const edges = new Map<string, Set<string>>();
+    for (const name of forward.edges.keys()) edges.set(name, new Set());
+    for (const [from, deps] of forward.edges) {
+        for (const dep of deps) {
+            // `from` depends on `dep`. Reverse edge: `dep` → `from`.
+            const slot = edges.get(dep);
+            if (slot) slot.add(from);
+        }
+    }
+    return { edges, byName: forward.byName };
+}
+
+/**
+ * BFS over a reverse-dep graph starting from `seeds`. Returns
+ * `seeds ∪ all transitive dependents` as a `Set<string>` of workspace
+ * names. Idempotent on duplicate seeds; unknown seed names are silently
+ * skipped (a renamed-then-deleted workspace, a file in a not-yet-discovered
+ * directory, etc. — those signal "we can't be precise here" and the
+ * caller is expected to fall back to a conservative full run, not crash).
+ *
+ * @param reverse The reverse-dep graph from `buildReverseDependencyGraph`.
+ * @param seeds Workspace names to start from.
+ */
+export function affectedClosure(
+    reverse: DependencyGraph,
+    seeds: readonly string[],
+): Set<string> {
+    const out = new Set<string>();
+    const queue: string[] = [];
+    for (const seed of seeds) {
+        if (!reverse.byName.has(seed)) continue;
+        if (out.has(seed)) continue;
+        out.add(seed);
+        queue.push(seed);
+    }
+    while (queue.length > 0) {
+        const name = queue.shift() as string;
+        const dependents = reverse.edges.get(name);
+        if (!dependents) continue;
+        for (const next of dependents) {
+            if (out.has(next)) continue;
+            out.add(next);
+            queue.push(next);
+        }
+    }
+    return out;
+}
+
+/**
+ * Map a list of changed file paths (repo-relative, `git diff --name-only`
+ * shape) to the set of workspaces that OWN those files. A file is
+ * considered owned by the deepest workspace whose `relativeLocation` is
+ * an ancestor path. Files outside every workspace are returned in
+ * `unmatched` so the caller can classify them (docs / lockfile / global
+ * trigger / etc.).
+ *
+ * Match is path-segment-based — `packages/node/fs/src/x.ts` belongs to
+ * `packages/node/fs`, NOT `packages/node/fs-promises` even though the
+ * latter is a prefix-of-string match. Each path is normalised to forward
+ * slashes before comparison so Windows-style diffs are handled too.
+ *
+ * @returns `matched` — Set of `Workspace.name` strings. `unmatched` — the
+ *   subset of input paths that did not fall under any workspace.
+ */
+export function workspacesForChangedFiles(
+    workspaces: readonly Workspace[],
+    rootDir: string,
+    changedFiles: readonly string[],
+): { matched: Set<string>; unmatched: string[] } {
+    // Build a longest-prefix lookup: split each workspace.relativeLocation
+    // into segments, then match changed-file segments from the root.
+    const matched = new Set<string>();
+    const unmatched: string[] = [];
+    // Index workspaces by segment prefix for O(depth) lookup per file.
+    // Tree shape: `Map<string, {ws?: string, children: Map<...>}>`.
+    interface Node {
+        ws?: string;
+        children: Map<string, Node>;
+    }
+    const root: Node = { children: new Map() };
+    for (const ws of workspaces) {
+        if (ws.relativeLocation === '.' || ws.relativeLocation === '') continue;
+        const segments = ws.relativeLocation.split('/').filter(Boolean);
+        let cur = root;
+        for (const seg of segments) {
+            let next = cur.children.get(seg);
+            if (!next) {
+                next = { children: new Map() };
+                cur.children.set(seg, next);
+            }
+            cur = next;
+        }
+        cur.ws = ws.name;
+    }
+
+    for (const raw of changedFiles) {
+        if (!raw) continue;
+        const path = raw.replace(/\\/g, '/');
+        const segments = path.split('/').filter(Boolean);
+        let cur: Node | undefined = root;
+        let bestMatch: string | undefined;
+        for (const seg of segments) {
+            cur = cur.children.get(seg);
+            if (!cur) break;
+            // Deepest match wins — a file inside a nested workspace
+            // belongs to that workspace, not its grandparent.
+            if (cur.ws) bestMatch = cur.ws;
+        }
+        if (bestMatch) {
+            matched.add(bestMatch);
+        } else {
+            unmatched.push(raw);
+        }
+    }
+    return { matched, unmatched };
+}
+
+/**
  * Filter workspaces by glob-pattern include/exclude (mirrors
  * `yarn workspaces foreach --include '@gjsify/example-*' --exclude
  * '@gjsify/example-*-net'` shape). Uses a minimal glob: only `*` is


### PR DESCRIPTION
Three new exports in \`@gjsify/workspace\`, all building on the existing forward graph + discovery code — zero behaviour change for anything already using the package.

## What

- \`buildReverseDependencyGraph(workspaces, options)\` — inverts \`buildDependencyGraph\` so callers can ask "who depends on X" instead of "what does X depend on". Same \`workspace:*\` / private / dev-include semantics; same \`{edges, byName}\` shape.

- \`affectedClosure(reverse, seeds)\` — BFS that returns \`seeds ∪ transitive dependents\`. Idempotent on duplicate seeds, silently skips unknown names (the conservative "caller falls back to full run if we can't be precise" contract).

- \`workspacesForChangedFiles(workspaces, rootDir, changedFiles)\` — maps a flat list of \`git diff\` paths to the workspaces that own them. Segment-aware longest-prefix matching so \`packages/node/fs-promises\` is not falsely attributed to \`packages/node/fs\`. Backslash paths (Windows-style diff) are normalised. Unmatched files surface so callers can classify (docs, lockfile, infra trigger, …).

## Why

Foundation for a \`gjsify affected\` CLI command that diffs HEAD against a base SHA and prints the closure to test — first piece of the selective-CI workstream that should drop typical PR run times from ~25 min to under 5.

## Test plan

- [x] 13 new unit specs (diamond closure, idempotent seeds, segment-aware path matching, Windows backslashes, empty inputs). \`56/56\` workspace specs pass on Node + GJS via \`gjsify build src/test.mts --app node && node test.node.mjs\`.
- [x] Existing 43 specs unchanged.
- [x] \`tsc --noEmit\` clean.

## Follow-ups (separate PRs per plan)

- New \`gjsify affected\` CLI subcommand consuming these exports.
- \`main.yml\` integration gating tests on the classifier output.