### PR TITLE
ci: pre-baked Fedora image — skip dnf install on every job

### DIFF
--- a/.docker/ci-fedora.Dockerfile
+++ b/.docker/ci-fedora.Dockerfile
@@ -1,0 +1,90 @@
+# CI base image — Fedora + every GJS / GNOME devel package the test
+# workflow installs. We bake all of `dnf install` from `.github/workflows/
+# main.yml` into the image so each CI job skips the 3-5 minute install
+# step at job start.
+#
+# Built per Fedora major (43, 44) by `.github/workflows/build-ci-image.yml`
+# on a weekly cron + on pushes that touch this Dockerfile, then pushed to
+# `ghcr.io/gjsify/ci-fedora:<major>`. The main test workflow consumes the
+# image via `container: ghcr.io/gjsify/ci-fedora:<fedora-version>`.
+#
+# Build args:
+#   FEDORA_VERSION   — major release (43, 44, …). Defaults to 43 so a
+#                       `docker build .docker/ci-fedora.Dockerfile` without
+#                       --build-arg produces a useable image locally.
+#
+# Refresh cadence:
+#   - Weekly on the schedule below — picks up Fedora security errata.
+#   - On every push that touches this Dockerfile.
+#   - Manual `workflow_dispatch` for ad-hoc rebuilds.
+
+ARG FEDORA_VERSION=43
+FROM fedora:${FEDORA_VERSION}
+
+# Container prerequisites (used by actions/checkout, actions/setup-node,
+# the install step, and the test runners). Pre-install here so the main
+# workflow's "Install container prerequisites" step becomes a no-op.
+RUN dnf install -y --setopt=install_weak_deps=False \
+    git \
+    tar \
+    xz \
+    findutils \
+    && dnf clean all
+
+# GJS + GNOME devel libs. gstreamer1-{,plugins-base-,plugins-bad-free-}
+# devel provide the gstreamer-1.0 / gstreamer-sdp-1.0 / gstreamer-webrtc-1.0
+# pkg-config files + headers needed to compile @gjsify/webrtc-native at
+# Vala build time. libnice-gstreamer1 provides the `nice` plugin webrtcbin
+# needs at runtime for the WebRTC test suite.
+RUN dnf install -y --setopt=install_weak_deps=False \
+    gjs \
+    glib2-devel \
+    gobject-introspection-devel \
+    gtk4-devel \
+    libsoup3-devel \
+    webkitgtk6.0-devel \
+    libadwaita-devel \
+    gdk-pixbuf2-devel \
+    libepoxy-devel \
+    gstreamer1-devel \
+    gstreamer1-plugins-base-devel \
+    gstreamer1-plugins-bad-free-devel \
+    libnice-gstreamer1 \
+    libgda \
+    libgda-sqlite \
+    xorg-x11-server-Xvfb \
+    mesa-dri-drivers \
+    mesa-libGL \
+    && dnf clean all
+
+# Meson + Vala + Blueprint compiler for the native bridge builds
+# (@gjsify/{webrtc-native, tls-native, terminal-native, sab-native,
+# http2-native, http-soup-bridge}).
+RUN dnf install -y --setopt=install_weak_deps=False \
+    meson \
+    vala \
+    gcc \
+    pkgconf \
+    blueprint-compiler \
+    && dnf clean all
+
+# Node.js — the main workflow uses actions/setup-node which downloads its
+# own copy, so this is more about having a sane default for interactive
+# debugging in the container. Skip if it bloats the image too much.
+RUN dnf install -y --setopt=install_weak_deps=False nodejs npm && dnf clean all
+
+# Marker so the workflow can verify it picked up the right image
+# (`/etc/gjsify-ci-fedora-version`). Helps debug "why didn't my dnf install
+# get skipped" — if this file is missing, the container is the bare
+# upstream `fedora:N`, not the baked image.
+ARG FEDORA_VERSION
+RUN echo "${FEDORA_VERSION}" > /etc/gjsify-ci-fedora-version
+
+# Set a non-interactive default. dnf is already configured via the
+# install commands above; this just keeps interactive prompts quiet
+# when a contributor runs the image manually for debugging.
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /workspace

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -38,7 +38,7 @@ jobs:
         fedora-version: [43, 44]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up QEMU (for cross-arch where needed)
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,74 @@
+name: Build CI Fedora image
+
+# Builds `.docker/ci-fedora.Dockerfile` for every supported Fedora major
+# and pushes the result to `ghcr.io/gjsify/ci-fedora:<major>`. The main
+# test workflow (`main.yml`) consumes the resulting image instead of
+# pulling `fedora:<major>` and running `dnf install` from scratch every
+# job — saves 3-5 minutes per matrix entry.
+#
+# Triggers:
+#   - Weekly cron (Sundays 04:00 UTC). Picks up Fedora security errata.
+#   - Push to main that touches the Dockerfile or this workflow.
+#   - Manual `workflow_dispatch` for ad-hoc rebuilds.
+#
+# Permissions: writes to GHCR via the workflow-issued GITHUB_TOKEN.
+# `packages: write` is required for `docker push ghcr.io/...`.
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'
+  push:
+    branches:
+      - main
+    paths:
+      - '.docker/ci-fedora.Dockerfile'
+      - '.github/workflows/build-ci-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & push Fedora ${{ matrix.fedora-version }} image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora-version: [43, 44]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU (for cross-arch where needed)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "image=ghcr.io/${REPO_LC%/*}/ci-fedora:${{ matrix.fedora-version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .docker
+          file: .docker/ci-fedora.Dockerfile
+          build-args: FEDORA_VERSION=${{ matrix.fedora-version }}
+          # Single-arch (amd64) — main.yml runs on ubuntu-latest x86_64.
+          # When we add aarch64 runners we'll grow this list.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tag.outputs.image }}
+          cache-from: type=registry,ref=${{ steps.tag.outputs.image }}-cache
+          cache-to: type=registry,ref=${{ steps.tag.outputs.image }}-cache,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,39 +22,11 @@ jobs:
     name: Fedora ${{ matrix.fedora-version }} (${{ matrix.gjs-info }})
     runs-on: ubuntu-latest
     container:
-      # Pre-baked image (`.docker/ci-fedora.Dockerfile`) with every
-      # GJS/GNOME devel package, meson/vala/blueprint, and gstreamer
-      # plugin we need already installed. Built by
-      # `.github/workflows/build-ci-image.yml` on a weekly cron + on
-      # pushes to the Dockerfile, so the `dnf install` steps we used
-      # to run here at job start (3-5 min × 2 matrix entries) become
-      # no-ops. Fallback path: if the image isn't published yet (first
-      # PR before the cron lands), `build-ci-image.yml` can be triggered
-      # manually via `workflow_dispatch`.
-      image: ghcr.io/gjsify/ci-fedora:${{ matrix.fedora-version }}
+      image: fedora:${{ matrix.fedora-version }}
 
     steps:
-      - name: Verify pre-baked image (debug aid)
-        # The Dockerfile writes the Fedora major into a marker file.
-        # If this step shows "Bare fedora image" the container was not
-        # picked up from GHCR and the build-ci-image workflow needs to
-        # run first.
-        run: |
-          if [ -f /etc/gjsify-ci-fedora-version ]; then
-            echo "Pre-baked CI image — Fedora $(cat /etc/gjsify-ci-fedora-version)"
-          else
-            echo "::warning::Bare fedora image — devel packages are NOT pre-installed."
-            echo "::warning::Re-run .github/workflows/build-ci-image.yml to publish the baked image."
-            dnf install -y --setopt=install_weak_deps=False \
-              git tar xz findutils \
-              gjs glib2-devel gobject-introspection-devel gtk4-devel \
-              libsoup3-devel webkitgtk6.0-devel libadwaita-devel \
-              gdk-pixbuf2-devel libepoxy-devel \
-              gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel \
-              libnice-gstreamer1 libgda libgda-sqlite \
-              xorg-x11-server-Xvfb mesa-dri-drivers mesa-libGL \
-              meson vala gcc pkgconf blueprint-compiler
-          fi
+      - name: Install container prerequisites
+        run: dnf install -y git tar xz findutils
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -63,6 +35,37 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Install GJS and GNOME development libraries
+        # gstreamer1-{,plugins-base-,plugins-bad-free-}devel provide the
+        # gstreamer-1.0 / gstreamer-sdp-1.0 / gstreamer-webrtc-1.0 pkg-config
+        # files + headers needed to compile @gjsify/webrtc-native at Vala
+        # build time. libnice-gstreamer1 provides the `nice` plugin that
+        # webrtcbin needs at runtime for the WebRTC test suite.
+        run: >
+          dnf install -y
+          gjs
+          glib2-devel
+          gobject-introspection-devel
+          gtk4-devel
+          libsoup3-devel
+          webkitgtk6.0-devel
+          libadwaita-devel
+          gdk-pixbuf2-devel
+          libepoxy-devel
+          gstreamer1-devel
+          gstreamer1-plugins-base-devel
+          gstreamer1-plugins-bad-free-devel
+          libnice-gstreamer1
+          libgda
+          libgda-sqlite
+          xorg-x11-server-Xvfb
+          mesa-dri-drivers
+          mesa-libGL
+
+
+      - name: Install Meson, Vala and Blueprint Compiler
+        run: dnf install -y meson vala gcc pkgconf blueprint-compiler
 
       - name: Create non-root user for tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,39 @@ jobs:
     name: Fedora ${{ matrix.fedora-version }} (${{ matrix.gjs-info }})
     runs-on: ubuntu-latest
     container:
-      image: fedora:${{ matrix.fedora-version }}
+      # Pre-baked image (`.docker/ci-fedora.Dockerfile`) with every
+      # GJS/GNOME devel package, meson/vala/blueprint, and gstreamer
+      # plugin we need already installed. Built by
+      # `.github/workflows/build-ci-image.yml` on a weekly cron + on
+      # pushes to the Dockerfile, so the `dnf install` steps we used
+      # to run here at job start (3-5 min × 2 matrix entries) become
+      # no-ops. Fallback path: if the image isn't published yet (first
+      # PR before the cron lands), `build-ci-image.yml` can be triggered
+      # manually via `workflow_dispatch`.
+      image: ghcr.io/gjsify/ci-fedora:${{ matrix.fedora-version }}
 
     steps:
-      - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils
+      - name: Verify pre-baked image (debug aid)
+        # The Dockerfile writes the Fedora major into a marker file.
+        # If this step shows "Bare fedora image" the container was not
+        # picked up from GHCR and the build-ci-image workflow needs to
+        # run first.
+        run: |
+          if [ -f /etc/gjsify-ci-fedora-version ]; then
+            echo "Pre-baked CI image — Fedora $(cat /etc/gjsify-ci-fedora-version)"
+          else
+            echo "::warning::Bare fedora image — devel packages are NOT pre-installed."
+            echo "::warning::Re-run .github/workflows/build-ci-image.yml to publish the baked image."
+            dnf install -y --setopt=install_weak_deps=False \
+              git tar xz findutils \
+              gjs glib2-devel gobject-introspection-devel gtk4-devel \
+              libsoup3-devel webkitgtk6.0-devel libadwaita-devel \
+              gdk-pixbuf2-devel libepoxy-devel \
+              gstreamer1-devel gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel \
+              libnice-gstreamer1 libgda libgda-sqlite \
+              xorg-x11-server-Xvfb mesa-dri-drivers mesa-libGL \
+              meson vala gcc pkgconf blueprint-compiler
+          fi
 
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -35,37 +63,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Install GJS and GNOME development libraries
-        # gstreamer1-{,plugins-base-,plugins-bad-free-}devel provide the
-        # gstreamer-1.0 / gstreamer-sdp-1.0 / gstreamer-webrtc-1.0 pkg-config
-        # files + headers needed to compile @gjsify/webrtc-native at Vala
-        # build time. libnice-gstreamer1 provides the `nice` plugin that
-        # webrtcbin needs at runtime for the WebRTC test suite.
-        run: >
-          dnf install -y
-          gjs
-          glib2-devel
-          gobject-introspection-devel
-          gtk4-devel
-          libsoup3-devel
-          webkitgtk6.0-devel
-          libadwaita-devel
-          gdk-pixbuf2-devel
-          libepoxy-devel
-          gstreamer1-devel
-          gstreamer1-plugins-base-devel
-          gstreamer1-plugins-bad-free-devel
-          libnice-gstreamer1
-          libgda
-          libgda-sqlite
-          xorg-x11-server-Xvfb
-          mesa-dri-drivers
-          mesa-libGL
-
-
-      - name: Install Meson, Vala and Blueprint Compiler
-        run: dnf install -y meson vala gcc pkgconf blueprint-compiler
 
       - name: Create non-root user for tests
         run: |


### PR DESCRIPTION
First of 3 PRs in the CI optimization plan.

## Why

Every \`main.yml\` matrix entry currently spends 3-5 min running \`dnf install\` for gjs / gtk4-devel / gstreamer / webkitgtk6.0-devel / meson / vala / blueprint-compiler / xvfb / mesa — every job, every PR. On 2 matrix entries (Fedora 43 + 44) that's 6-10 min before any gjsify work even starts.

## What

Bakes those packages into a custom image \`ghcr.io/gjsify/ci-fedora:<fedora-major>\` and uses it as the job container:

- \`.docker/ci-fedora.Dockerfile\` — base on \`fedora:N\` + all dnf deps
- \`.github/workflows/build-ci-image.yml\` — weekly cron + Dockerfile push + manual dispatch builds the image and pushes to GHCR
- \`.github/workflows/main.yml\` — \`container.image\` switched to the baked image; the per-step \`dnf install\` blocks are gone

## Fallback during bootstrap

The first PR to land before the image is published would otherwise be red. To avoid that, the job opens with a verification step that checks \`/etc/gjsify-ci-fedora-version\` (a marker the Dockerfile writes). If the file is missing — i.e. the container is the bare upstream \`fedora:N\` — the step falls back to the full \`dnf install\` so the workflow stays green during the bootstrap window. After the \`build-ci-image\` workflow has run once (manually triggered or on schedule), the fallback is dead code.

## Expected savings

3-5 min per Fedora-matrix entry, so **6-10 min off every workflow run**.

## Test plan

- [x] YAML syntax valid (\`yaml.safe_load\` both files).
- [ ] Manually trigger \`build-ci-image.yml\` after merge to populate GHCR.
- [ ] Subsequent PR shows \`Pre-baked CI image — Fedora …\` instead of the warning + dnf install.

## Follow-ups (separate PRs per plan)

- PR 2: \`actions/cache\` for \`lib/\` + \`tsbuildinfo\` (content-addressable per workspace, turborepo-style)
- PR 3: flaky \`detached child runs and exits normally\` root-cause fix + matrix sharding