### PR TITLE
ci: cache lib/ + tsbuildinfo between runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,14 +153,19 @@ jobs:
       # Per-Fedora-major scope because the bundler output (rolldown) can
       # diverge by host libs; Fedora 43 vs 44 would otherwise share the
       # same cache and produce stale bundles.
+      # IMPORTANT: paths use `packages/*/*/...` (pillar/name), NOT
+      # `packages/**/...`. The double-star globs into node_modules and
+      # blew up the cache POST upload to multi-gigabyte tars that hung
+      # for hours. The pillar/name shape covers every real workspace
+      # while skipping the deps tree.
       - name: Cache build output (lib/ + tsbuildinfo)
         uses: actions/cache@v4
         with:
           path: |
-            packages/**/lib
-            packages/**/tsconfig.tsbuildinfo
-            packages/**/tsconfig.*.tsbuildinfo
-            packages/**/dist
+            packages/*/*/lib
+            packages/*/*/tsconfig.tsbuildinfo
+            packages/*/*/tsconfig.*.tsbuildinfo
+            packages/*/*/dist
           key: build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', 'package.json', 'packages/*/*/tsconfig*.json', 'packages/*/*/package.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
           restore-keys: |
             build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', 'package.json', 'packages/*/*/tsconfig*.json', 'packages/*/*/package.json') }}-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,38 @@ jobs:
           fi
           echo "@gjsify/tsc bundle OK — reports v$ACTUAL matching TYPESCRIPT_VERSION."
 
+      # Restore previously-built `lib/` directories + `tsbuildinfo` files.
+      # TypeScript with `composite: true` (the standard tsconfig template in
+      # this monorepo) reads `tsconfig.tsbuildinfo` and only re-emits files
+      # whose source signature changed. The cache key is content-addressable
+      # over every input that affects build output, so a PR touching only
+      # docs / a single workspace's src lands on a near-perfect cache hit:
+      #
+      #   primary key: includes the hash of all `packages/**/src/**` files.
+      #                exact-hit only on a perfect no-source-change PR.
+      #   restore-key 1: drops the src hash → restores the most-recent
+      #                  cached lib/ for the same lockfile+tsconfig set.
+      #                  tsc + rolldown then re-emit only the files whose
+      #                  src changed; the rest stay byte-identical.
+      #   restore-key 2: just the Fedora version → ultimate fallback,
+      #                  useful when the lockfile bumps en masse.
+      #
+      # Per-Fedora-major scope because the bundler output (rolldown) can
+      # diverge by host libs; Fedora 43 vs 44 would otherwise share the
+      # same cache and produce stale bundles.
+      - name: Cache build output (lib/ + tsbuildinfo)
+        uses: actions/cache@v6
+        with:
+          path: |
+            packages/**/lib
+            packages/**/tsconfig.tsbuildinfo
+            packages/**/tsconfig.*.tsbuildinfo
+            packages/**/dist
+          key: build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', '**/tsconfig*.json', '**/package.json') }}-${{ hashFiles('packages/**/src/**/*.ts', 'packages/**/src/**/*.mts', 'packages/**/src/**/*.cts') }}
+          restore-keys: |
+            build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', '**/tsconfig*.json', '**/package.json') }}-
+            build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-
+
       - name: Build
         run: su testuser -c 'PATH="$PWD/node_modules/.bin:$PATH" gjsify run build'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
       # diverge by host libs; Fedora 43 vs 44 would otherwise share the
       # same cache and produce stale bundles.
       - name: Cache build output (lib/ + tsbuildinfo)
-        uses: actions/cache@v6
+        uses: actions/cache@v4
         with:
           path: |
             packages/**/lib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,9 +161,9 @@ jobs:
             packages/**/tsconfig.tsbuildinfo
             packages/**/tsconfig.*.tsbuildinfo
             packages/**/dist
-          key: build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', '**/tsconfig*.json', '**/package.json') }}-${{ hashFiles('packages/**/src/**/*.ts', 'packages/**/src/**/*.mts', 'packages/**/src/**/*.cts') }}
+          key: build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', 'package.json', 'packages/*/*/tsconfig*.json', 'packages/*/*/package.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
           restore-keys: |
-            build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', '**/tsconfig*.json', '**/package.json') }}-
+            build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-${{ hashFiles('gjsify-lock.json', 'package.json', 'packages/*/*/tsconfig*.json', 'packages/*/*/package.json') }}-
             build-${{ runner.os }}-fedora${{ matrix.fedora-version }}-
 
       - name: Build


### PR DESCRIPTION
Second of 3 PRs in the CI optimization plan.

## Why

TypeScript with \`composite: true\` (the standard tsconfig template in this monorepo) reads \`tsconfig.tsbuildinfo\` and only re-emits files whose source signature changed. Persisting that file between CI runs lets tsc skip the unchanged majority of the workspace — a typical PR touching one workspace re-emits ~1 % of \`lib/\` and copies the rest from cache.

## What

\`actions/cache@v6\` step inserted before the \`Build\` step.

| Layer | Key | Effect |
|---|---|---|
| **primary** | includes hash of \`packages/**/src/**\` | exact hit only when no src changed (docs-only / spec-only / package.json tweak) |
| **restore-key 1** | drops src hash, keeps lockfile + tsconfig hash | restores most recent cache for same lockfile + tsconfig set; tsc + rolldown re-emit only changed files |
| **restore-key 2** | just Fedora version | fallback when lockfile bumps en masse |

Per-Fedora-major scope because rolldown output can diverge by host libs.

## Expected savings

3-5 min off the \`Build\` step on a typical PR, depending on how much src changed.

## Test plan

- [x] YAML syntax valid.
- [ ] First PR after merge writes the cache (empty restore).
- [ ] Subsequent PR shows restore-key fallback path firing and tsc skipping unchanged work.

## Follow-up

- PR 3: flaky \`detached child runs and exits normally\` root-cause + matrix sharding for the remaining test time.