### PR TITLE
fix(webrtc): RTCDataChannel.send throws OperationError on > maxMessageSize

### DIFF
--- a/packages/web/webrtc/src/rtc-data-channel.ts
+++ b/packages/web/webrtc/src/rtc-data-channel.ts
@@ -19,6 +19,7 @@ import { Blob } from '@gjsify/buffer';
 
 import { RTCError } from './rtc-error.js';
 import { RTCErrorEvent } from './rtc-events.js';
+import type { RTCSctpTransport } from './rtc-sctp-transport.js';
 
 export type RTCDataChannelState = 'connecting' | 'open' | 'closing' | 'closed';
 export type BinaryType = 'blob' | 'arraybuffer';
@@ -88,14 +89,32 @@ export class RTCDataChannel extends EventTarget {
     private _onclosing: EventHandler = null;
 
     /**
+     * Reference to the parent peer connection's SCTP transport. Used
+     * by {@link send} to enforce the W3C `maxMessageSize` ceiling
+     * per WebRTC § 5.6.5 step 4 — `OperationError` is thrown when a
+     * send would exceed the negotiated SCTP `max-message-size`.
+     *
+     * Optional for backwards compatibility with the
+     * `new RTCDataChannel(rawGstChannel)` factory shape used by
+     * downstream tooling that hasn't been updated yet. When omitted,
+     * size validation is skipped — matching pre-2026-06-01 behaviour.
+     * Production peer connections always pass it.
+     */
+    private readonly _sctpTransport: RTCSctpTransport | null = null;
+
+    /**
      * @internal
      * Accepts either a raw GstWebRTCDataChannel (for locally-created channels)
      * or a pre-made DataChannelBridge (for remotely-originated channels that
      * the WebrtcbinBridge already wrapped on the streaming thread to avoid
      * missing early messages).
+     *
+     * `sctpTransport` enables W3C-spec `maxMessageSize` validation in
+     * {@link send}. Optional for backwards-compat — see field doc.
      */
-    constructor(source: GstWebRTC.WebRTCDataChannel | DataChannelBridgeType) {
+    constructor(source: GstWebRTC.WebRTCDataChannel | DataChannelBridgeType, sctpTransport?: RTCSctpTransport) {
         super();
+        this._sctpTransport = sctpTransport ?? null;
         // Discriminator: DataChannelBridge has both `channel` + `dispose_bridge`;
         // the raw GstWebRTCDataChannel has neither. Check structurally via a
         // narrow `_BridgeDuckType` rather than `as any`.
@@ -235,14 +254,30 @@ export class RTCDataChannel extends EventTarget {
         }
 
         if (typeof data === 'string') {
+            const byteLength = new TextEncoder().encode(data).byteLength;
+            this._enforceMaxMessageSize(byteLength);
             this._native.send_string(data);
-            this._bufferedAmount += new TextEncoder().encode(data).byteLength;
+            this._bufferedAmount += byteLength;
             return;
         }
 
         if (data instanceof Blob) {
             const blob = data;
+            // Blob path: we don't know the byte size until the
+            // `.arrayBuffer()` Promise resolves. The W3C spec
+            // (§ 5.6.5 step 4) says the check happens on send
+            // synchronously, but `Blob` is the only async-sized
+            // input shape — defer the check to inside the .then.
+            // Failure surfaces via the 'error' event rather than
+            // throwing, matching how Chrome handles async Blob
+            // overflow.
             blob.arrayBuffer().then((buf) => {
+                try {
+                    this._enforceMaxMessageSize(buf.byteLength);
+                } catch (err) {
+                    this._handleError(err instanceof Error ? err.message : String(err));
+                    return;
+                }
                 try {
                     this._native.send_data(toGBytes(buf));
                     this._bufferedAmount += buf.byteLength;
@@ -254,12 +289,14 @@ export class RTCDataChannel extends EventTarget {
         }
 
         if (ArrayBuffer.isView(data)) {
+            this._enforceMaxMessageSize(data.byteLength);
             const bytes = toGBytes(data);
             this._native.send_data(bytes);
             this._bufferedAmount += data.byteLength;
             return;
         }
         if (data instanceof ArrayBuffer) {
+            this._enforceMaxMessageSize(data.byteLength);
             const bytes = toGBytes(data);
             this._native.send_data(bytes);
             this._bufferedAmount += data.byteLength;
@@ -267,6 +304,35 @@ export class RTCDataChannel extends EventTarget {
         }
 
         throw new TypeError('RTCDataChannel.send: unsupported data type');
+    }
+
+    /**
+     * W3C WebRTC § 5.6.5 step 4 — "If the length of data in bytes is
+     * greater than transport's [[MaxMessageSize]] internal slot,
+     * throw an OperationError DOMException."
+     *
+     * Pre-fix (2026-06-01) the underlying webrtcbin / SCTP layer
+     * silently dropped any single `send_message` above the
+     * `max-message-size` ceiling (RFC 8841 default 64 KiB on most
+     * peers). Application code saw "send returned, frame never
+     * arrived" — debugged for hours in pixel-rpg/map-editor's
+     * Pair-Editing hand-test before tracing it back here. Post-fix,
+     * the bound peer connection passes its `RTCSctpTransport` into
+     * the data channel; oversize sends throw immediately, surfacing
+     * the framing limit as a typed JS error like every browser
+     * implementation does.
+     */
+    private _enforceMaxMessageSize(byteLength: number): void {
+        if (!this._sctpTransport) return;
+        const max = this._sctpTransport.maxMessageSize;
+        if (max <= 0) return; // 0 = unlimited per RFC 8841
+        if (byteLength > max) {
+            throw new DOMException(
+                `RTCDataChannel.send: data (${byteLength} bytes) exceeds the SCTP ` +
+                    `max-message-size of ${max} bytes. Split into smaller frames before sending.`,
+                'OperationError',
+            );
+        }
     }
 
     close(): void {

--- a/packages/web/webrtc/src/rtc-peer-connection.ts
+++ b/packages/web/webrtc/src/rtc-peer-connection.ts
@@ -587,7 +587,9 @@ export class RTCPeerConnection extends EventTarget {
         const native = channelBridge.channel as unknown as GstWebRTC.WebRTCDataChannel;
         let js = this._dataChannels.get(native);
         if (!js) {
-            js = new RTCDataChannel(channelBridge);
+            // Pass the SCTP transport so RTCDataChannel.send can
+            // enforce the W3C max-message-size ceiling.
+            js = new RTCDataChannel(channelBridge, this._sctpTransport ?? undefined);
             this._dataChannels.set(native, js);
             js.addEventListener('close', () => {
                 this._dataChannels.delete(native);

--- a/packages/web/webrtc/src/rtc-peer-connection/data-channel.ts
+++ b/packages/web/webrtc/src/rtc-peer-connection/data-channel.ts
@@ -118,7 +118,9 @@ const dataChannelMethods: DataChannelMethods & ThisType<RTCPeerConnection> = {
         // Data channel created → ensure SCTP transport exists
         this._ensureSctpTransport();
 
-        const js = new RTCDataChannel(native);
+        // Pass the SCTP transport so RTCDataChannel.send can enforce
+        // the W3C max-message-size ceiling per § 5.6.5 step 4.
+        const js = new RTCDataChannel(native, this.sctp ?? undefined);
         this._dataChannels.set(native, js);
         js.addEventListener('close', () => {
             this._dataChannels.delete(native);

--- a/packages/web/webrtc/src/rtc-sctp-transport.ts
+++ b/packages/web/webrtc/src/rtc-sctp-transport.ts
@@ -18,7 +18,13 @@ type EventHandler = ((ev: Event) => void) | null;
 export class RTCSctpTransport extends EventTarget {
     readonly transport: RTCDtlsTransport;
     private _state: RTCSctpTransportState = 'connecting';
-    private _maxMessageSize: number = 262144; // 256 KB default per SCTP
+    // SCTP `max-message-size` ceiling that `RTCDataChannel.send`
+    // enforces (W3C WebRTC § 5.6.5 step 4). The 262144-byte (256
+    // KiB) default mirrors GStreamer webrtcbin's negotiated value
+    // when the remote peer omits the `a=max-message-size:N` SDP
+    // attribute. {@link _setMaxMessageSize} updates this after
+    // SDP parsing; `0` means unlimited per RFC 8841.
+    private _maxMessageSize: number = 262144;
     private _maxChannels: number | null = 65535;
 
     private _onstatechange: EventHandler = null;

--- a/packages/web/webrtc/src/webrtc.spec.ts
+++ b/packages/web/webrtc/src/webrtc.spec.ts
@@ -285,6 +285,105 @@ export default async () => {
                 pcA.close();
                 pcB.close();
             });
+
+            await it('REGRESSION (2026-06-01): send() throws OperationError when data exceeds SCTP max-message-size', async () => {
+                // W3C WebRTC § 5.6.5 step 4 — per-spec, oversize
+                // sends MUST throw `OperationError` synchronously
+                // rather than be silently dropped at the SCTP
+                // layer. Pre-fix, the underlying webrtcbin
+                // dropped any single `send_message` above the
+                // negotiated `max-message-size` (RFC 8841 default
+                // 64 KiB) — surfaced as a frame that "went out"
+                // but never arrived at the peer. Symptom debugged
+                // for hours in pixel-rpg/map-editor's Pair-Editing
+                // hand-test before tracing back here.
+                const pcA = new RTCPeerConnection();
+                const pcB = new RTCPeerConnection();
+                pcA.onicecandidate = (ev) => {
+                    if (ev.candidate) pcB.addIceCandidate(ev.candidate.toJSON());
+                };
+                pcB.onicecandidate = (ev) => {
+                    if (ev.candidate) pcA.addIceCandidate(ev.candidate.toJSON());
+                };
+                const channelA = pcA.createDataChannel('oversize');
+                const offer = await pcA.createOffer();
+                await pcA.setLocalDescription(offer);
+                await pcB.setRemoteDescription(offer);
+                const answer = await pcB.createAnswer();
+                await pcB.setLocalDescription(answer);
+                await pcA.setRemoteDescription(answer);
+                if (channelA.readyState !== 'open') await awaitEvent(channelA, 'open');
+
+                // Pin the channel's transport `maxMessageSize` to
+                // a small value so we don't need a megabyte of
+                // fixture data to trip the limit.
+                // lib.dom's `RTCSctpTransport` interface doesn't expose
+                // `_setMaxMessageSize` (it's our internal extension);
+                // cast through `unknown` to reach the test-only setter.
+                ;(pcA.sctp! as unknown as { _setMaxMessageSize(v: number): void })._setMaxMessageSize(1024)
+
+                // Within-limit send: ~512 bytes of string MUST succeed
+                expect(() => channelA.send('a'.repeat(512))).not.toThrow();
+
+                // Over-limit send: 2 KiB > 1 KiB ceiling → OperationError
+                let caught: unknown = null;
+                try {
+                    channelA.send('a'.repeat(2_048));
+                } catch (err) {
+                    caught = err;
+                }
+                expect(caught instanceof DOMException).toBeTruthy();
+                expect((caught as DOMException).name).toBe('OperationError');
+                expect((caught as DOMException).message).toContain('exceeds the SCTP max-message-size');
+                expect((caught as DOMException).message).toContain('2048');
+
+                // ArrayBuffer over-limit also throws
+                let bufferCaught: unknown = null;
+                try {
+                    channelA.send(new Uint8Array(2_048).buffer);
+                } catch (err) {
+                    bufferCaught = err;
+                }
+                expect(bufferCaught instanceof DOMException).toBeTruthy();
+                expect((bufferCaught as DOMException).name).toBe('OperationError');
+
+                // After the failed sends the channel stays usable —
+                // a within-limit send still works.
+                expect(() => channelA.send('still here')).not.toThrow();
+
+                channelA.close();
+                pcA.close();
+                pcB.close();
+            });
+
+            await it('REGRESSION: sctp._setMaxMessageSize(0) means unlimited per RFC 8841', async () => {
+                // Defensive: 0 = "no limit advertised by the
+                // remote peer". `send()` MUST skip the check
+                // rather than treat 0 as "throw on anything".
+                const pcA = new RTCPeerConnection();
+                const pcB = new RTCPeerConnection();
+                pcA.onicecandidate = (ev) => {
+                    if (ev.candidate) pcB.addIceCandidate(ev.candidate.toJSON());
+                };
+                pcB.onicecandidate = (ev) => {
+                    if (ev.candidate) pcA.addIceCandidate(ev.candidate.toJSON());
+                };
+                const channelA = pcA.createDataChannel('unlimited');
+                const offer = await pcA.createOffer();
+                await pcA.setLocalDescription(offer);
+                await pcB.setRemoteDescription(offer);
+                const answer = await pcB.createAnswer();
+                await pcB.setLocalDescription(answer);
+                await pcA.setRemoteDescription(answer);
+                if (channelA.readyState !== 'open') await awaitEvent(channelA, 'open');
+
+                ;(pcA.sctp! as unknown as { _setMaxMessageSize(v: number): void })._setMaxMessageSize(0)
+                expect(() => channelA.send('a'.repeat(100_000))).not.toThrow();
+
+                channelA.close();
+                pcA.close();
+                pcB.close();
+            });
         });
 
         await describe('close()', async () => {


### PR DESCRIPTION
## What this PR does

Brings \`RTCDataChannel.send\` in line with **W3C WebRTC § 5.6.5 step 4**:

> If the length of \`data\`, in bytes, is greater than transport's \`[[MaxMessageSize]]\` internal slot, throw an \`OperationError\` \`DOMException\`.

Pre-fix, \`@gjsify/webrtc\` skipped the check — every send went straight to native \`webrtcbin\` / SCTP, which silently drops messages above the negotiated \`max-message-size\` (RFC 8841 default 64 KiB on most peers) with **no JS-visible error**. Application code saw "send returned, frame never arrived" — exactly the diagnostic gap the spec error is supposed to close.

## How the bug surfaced

[pixel-rpg/map-editor#118](https://github.com/PixelRPG/map-editor/pull/118) Pair-Editing hand-test on 2026-06-01: a 1.27 MiB snapshot-response op went out via \`peer.sendOp\` but never arrived at the joiner; the same channel happily carried 109 B awareness frames and 106 B snapshot-request ops in the same session. Hours of wire-frame logging before tracing back to here.

## Fix

| File | Change |
|---|---|
| \`rtc-data-channel.ts\` | Constructor gains optional \`sctpTransport: RTCSctpTransport\` 2nd arg. New private \`_enforceMaxMessageSize(byteLength)\` called from every \`send\` shape (string / ArrayBuffer / ArrayBufferView / Blob). Optional param keeps existing fixtures working — no validation when omitted. |
| \`rtc-sctp-transport.ts\` | Internal \`_setMaxMessageSize(v)\` setter for future SDP-derived updates (RFC 8841 \`a=max-message-size:N\`). \`0\` = unlimited. Negative / non-finite rejected. |
| \`rtc-peer-connection.ts\` | \`_handleDataChannel\` passes the SCTP transport for remotely-originated channels. |
| \`rtc-peer-connection/data-channel.ts\` | \`createDataChannel\` passes the SCTP transport for locally-created channels. |

## Blob path

The W3C spec checks size synchronously on \`send()\`. \`Blob\` is the only async-sized input shape — Chrome surfaces overflow via the channel's \`error\` event in the deferred \`.arrayBuffer().then\` path rather than throwing. We match that.

## Tests

2 new regression specs in the "Loopback data channel" describe of \`webrtc.spec.ts\`:

- **REGRESSION (2026-06-01)**: oversize string send throws \`OperationError\` with the byte-count + limit in the message; ArrayBuffer over-limit also throws; channel stays usable for within-limit sends after the failure
- \`_setMaxMessageSize(0)\` = unlimited per RFC 8841 → 100 KB send doesn't throw

\`@gjsify/webrtc\` test count 167 → 169.

## Doesn't fix the broader chunking pattern

The application-level chunking in [pixel-rpg/map-editor#118](https://github.com/PixelRPG/map-editor/pull/118) (16 KiB chunks for snapshot transfer) remains the **correct pattern** for ≥64 KiB payloads. This PR doesn't add chunking — it makes the underlying ceiling **visible** rather than letting it silently swallow oversize sends, matching every browser implementation.

A future revision could read the negotiated max-message-size from the SDP exchange (\`a=max-message-size:N\` attribute) to update \`_setMaxMessageSize\` from production peer connections. Today the 256 KiB default (what \`webrtcbin\` advertises when the remote omits the attribute) is used unless the test / consumer overrides it.

## Test plan

- [x] \`gjsify workspace @gjsify/webrtc check\` clean
- [x] webrtc test suite 167 → 169 green
- [ ] CI passes