### PR TITLE
feat(runtimes): declare nativescript none for node set

### DIFF
--- a/packages/node/child_process/package.json
+++ b/packages/node/child_process/package.json
@@ -50,7 +50,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/cluster/package.json
+++ b/packages/node/cluster/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/dgram/package.json
+++ b/packages/node/dgram/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/globals/package.json
+++ b/packages/node/globals/package.json
@@ -79,7 +79,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/http-soup-bridge/package.json
+++ b/packages/node/http-soup-bridge/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "scripts": {

--- a/packages/node/http2-native/package.json
+++ b/packages/node/http2-native/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "scripts": {

--- a/packages/node/http2/package.json
+++ b/packages/node/http2/package.json
@@ -51,7 +51,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/inspector/package.json
+++ b/packages/node/inspector/package.json
@@ -44,7 +44,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/net/package.json
+++ b/packages/node/net/package.json
@@ -54,7 +54,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/os/package.json
+++ b/packages/node/os/package.json
@@ -51,7 +51,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/perf_hooks/package.json
+++ b/packages/node/perf_hooks/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/readline/package.json
+++ b/packages/node/readline/package.json
@@ -51,7 +51,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/sab-native/package.json
+++ b/packages/node/sab-native/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "scripts": {

--- a/packages/node/terminal-native/package.json
+++ b/packages/node/terminal-native/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "keywords": [

--- a/packages/node/tls-native/package.json
+++ b/packages/node/tls-native/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "keywords": [

--- a/packages/node/tls/package.json
+++ b/packages/node/tls/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/tty/package.json
+++ b/packages/node/tty/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/url/package.json
+++ b/packages/node/url/package.json
@@ -50,7 +50,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/v8/package.json
+++ b/packages/node/v8/package.json
@@ -42,7 +42,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/ws/package.json
+++ b/packages/node/ws/package.json
@@ -57,7 +57,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/zlib/package.json
+++ b/packages/node/zlib/package.json
@@ -51,7 +51,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Declares the `nativescript` runtime slot as `none` for the GJS-only Node API packages (net, tls, dgram, http2, readline, tty, inspector, cluster, v8, …).

These depend on Gio/GLib value imports and can't run on NativeScript's V8, so they are marked unavailable for that target. package.json metadata only — no behavior change; `audit-runtimes --check` stays green.