### PR TITLE
feat(runtimes): declare nativescript none for gjs-ui set

### DIFF
--- a/packages/dom/canvas2d-core/package.json
+++ b/packages/dom/canvas2d-core/package.json
@@ -58,7 +58,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/dom/dom-elements/package.json
+++ b/packages/dom/dom-elements/package.json
@@ -87,7 +87,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/bridge-types/package.json
+++ b/packages/framework/bridge-types/package.json
@@ -44,7 +44,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/canvas2d/package.json
+++ b/packages/framework/canvas2d/package.json
@@ -56,7 +56,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/event-bridge/package.json
+++ b/packages/framework/event-bridge/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/iframe/package.json
+++ b/packages/framework/iframe/package.json
@@ -52,7 +52,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/video/package.json
+++ b/packages/framework/video/package.json
@@ -51,7 +51,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/framework/webgl/package.json
+++ b/packages/framework/webgl/package.json
@@ -20,7 +20,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "scripts": {


### PR DESCRIPTION
Declares the `nativescript` runtime slot as `none` for the GTK/GObject-bound packages (canvas2d, event-bridge, iframe, video, webgl, bridge-types) and the GJS-backed DOM packages (canvas2d-core, dom-elements).

These render through GTK / Cairo / WebKit and depend on GObject Introspection, which NativeScript's V8 does not provide, so they are marked unavailable for that target. package.json metadata only — no behavior change.