### PR TITLE
feat(runtimes): declare nativescript none for web-gjs set

### DIFF
--- a/packages/web/adwaita-fonts/package.json
+++ b/packages/web/adwaita-fonts/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "none",
             "node": "none",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "none"
         }
     },
     "repository": {

--- a/packages/web/adwaita-icons/package.json
+++ b/packages/web/adwaita-icons/package.json
@@ -64,7 +64,8 @@
         "runtimes": {
             "gjs": "none",
             "node": "none",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "none"
         }
     },
     "repository": {

--- a/packages/web/adwaita-web/package.json
+++ b/packages/web/adwaita-web/package.json
@@ -45,7 +45,8 @@
         "runtimes": {
             "gjs": "none",
             "node": "none",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/web/fetch/package.json
+++ b/packages/web/fetch/package.json
@@ -70,7 +70,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/web/webaudio/package.json
+++ b/packages/web/webaudio/package.json
@@ -60,7 +60,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/web/webrtc-native/package.json
+++ b/packages/web/webrtc-native/package.json
@@ -23,7 +23,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "none"
+            "browser": "none",
+            "nativescript": "none"
         }
     },
     "scripts": {

--- a/packages/web/webrtc/package.json
+++ b/packages/web/webrtc/package.json
@@ -82,7 +82,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/web/websocket/package.json
+++ b/packages/web/websocket/package.json
@@ -58,7 +58,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/web/xmlhttprequest/package.json
+++ b/packages/web/xmlhttprequest/package.json
@@ -52,7 +52,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "none"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Declares the `nativescript` runtime slot as `none` for the GJS-backed Web API packages (fetch, websocket, xmlhttprequest via Soup; webaudio, webrtc, webrtc-native via GStreamer) and the Adwaita design-identity packages (adwaita-web/fonts/icons).

These rely on GObject Introspection or are GTK/Adwaita-specific and have no NativeScript pendant, so they are marked unavailable for that target. package.json metadata only — no behavior change.