### PR TITLE
feat(runtimes): declare nativescript polyfill for portable node set

### DIFF
--- a/packages/node/assert/package.json
+++ b/packages/node/assert/package.json
@@ -50,7 +50,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/async_hooks/package.json
+++ b/packages/node/async_hooks/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/browser-polyfills/package.json
+++ b/packages/node/browser-polyfills/package.json
@@ -45,7 +45,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "exports": {

--- a/packages/node/buffer/package.json
+++ b/packages/node/buffer/package.json
@@ -56,7 +56,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/console/package.json
+++ b/packages/node/console/package.json
@@ -44,7 +44,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/constants/package.json
+++ b/packages/node/constants/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/diagnostics_channel/package.json
+++ b/packages/node/diagnostics_channel/package.json
@@ -44,7 +44,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/domain/package.json
+++ b/packages/node/domain/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/events/package.json
+++ b/packages/node/events/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/https/package.json
+++ b/packages/node/https/package.json
@@ -52,7 +52,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/path/package.json
+++ b/packages/node/path/package.json
@@ -50,7 +50,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/polyfills/package.json
+++ b/packages/node/polyfills/package.json
@@ -56,7 +56,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "exports": {

--- a/packages/node/process/package.json
+++ b/packages/node/process/package.json
@@ -53,7 +53,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/querystring/package.json
+++ b/packages/node/querystring/package.json
@@ -44,7 +44,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/stream/package.json
+++ b/packages/node/stream/package.json
@@ -67,7 +67,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/string_decoder/package.json
+++ b/packages/node/string_decoder/package.json
@@ -47,7 +47,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/sys/package.json
+++ b/packages/node/sys/package.json
@@ -48,7 +48,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/timers/package.json
+++ b/packages/node/timers/package.json
@@ -48,7 +48,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",

--- a/packages/node/util/package.json
+++ b/packages/node/util/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Adds `nativescript: polyfill` to the portable, pure-TypeScript Node API packages (assert, buffer, events, path, stream, process, util, querystring, string_decoder, timers, console, constants, domain, async_hooks, diagnostics_channel, https, sys, and the node/browser polyfill bundles).

These ship one portable implementation that already runs on gjs/node/browser; the same code bundles cleanly under `gjsify build --app nativescript` (verified for stream and process — no GObject or `node:` imports leak into the bundle). package.json metadata only.