### PR TITLE
feat(runtimes): declare nativescript native for web-api set

### DIFF
--- a/packages/web/abort-controller/package.json
+++ b/packages/web/abort-controller/package.json
@@ -56,7 +56,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/compression-streams/package.json
+++ b/packages/web/compression-streams/package.json
@@ -57,7 +57,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/dom-events/package.json
+++ b/packages/web/dom-events/package.json
@@ -66,7 +66,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/dom-exception/package.json
+++ b/packages/web/dom-exception/package.json
@@ -54,7 +54,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/domparser/package.json
+++ b/packages/web/domparser/package.json
@@ -55,7 +55,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/eventsource/package.json
+++ b/packages/web/eventsource/package.json
@@ -58,7 +58,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/formdata/package.json
+++ b/packages/web/formdata/package.json
@@ -46,7 +46,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/gamepad/package.json
+++ b/packages/web/gamepad/package.json
@@ -57,7 +57,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "partial",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/message-channel/package.json
+++ b/packages/web/message-channel/package.json
@@ -59,7 +59,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "repository": {

--- a/packages/web/polyfills/package.json
+++ b/packages/web/polyfills/package.json
@@ -34,7 +34,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "exports": {

--- a/packages/web/streams/package.json
+++ b/packages/web/streams/package.json
@@ -74,7 +74,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/web-globals/package.json
+++ b/packages/web/web-globals/package.json
@@ -74,7 +74,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/webassembly/package.json
+++ b/packages/web/webassembly/package.json
@@ -58,7 +58,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/webcrypto/package.json
+++ b/packages/web/webcrypto/package.json
@@ -57,7 +57,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",

--- a/packages/web/webstorage/package.json
+++ b/packages/web/webstorage/package.json
@@ -49,7 +49,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "polyfill",
-            "browser": "native"
+            "browser": "native",
+            "nativescript": "native"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Adds `nativescript: native` to the Web API packages whose surface NativeScript's V8 runtime already provides natively (abort-controller, fetch/streams family, dom-events, dom-exception, domparser, eventsource, formdata, gamepad, message-channel, webassembly, webcrypto, webstorage, and the web polyfill/globals bundles).

Each already ships a browser-safe `globals.mjs`; on `--app nativescript` the resolver routes `@gjsify/<x>` to that re-export, so no polyfill code is bundled on NativeScript. package.json metadata only.