### PR TITLE
feat: round out browser paths and declare nativescript slots

### DIFF
--- a/packages/node/dns/package.json
+++ b/packages/node/dns/package.json
@@ -56,7 +56,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/dns/src/browser.ts
+++ b/packages/node/dns/src/browser.ts
@@ -3,13 +3,19 @@
 //
 // Reference: refs/node/lib/dns.js (surface mirror)
 //
-// Slot: "browser:partial" — `lookup()` works (loopback), every real DNS
-// resolver method throws ENOTSUP. Mirrors `node-stdlib-browser`'s `dns mock`.
+// Slot: "browser:partial" — `lookup()` resolves only what a browser can
+// honestly resolve without a DNS API (IP literals + `localhost`); every real
+// name resolution (and every `resolve*`/`reverse`) returns a structured
+// ENOTSUP. Mirrors `node-stdlib-browser`'s `dns mock`.
 //
-// Browser has no DNS resolver API surface. We supply a `lookup()` that
-// resolves to 127.0.0.1 (loopback) so consumers performing a perfunctory
-// "is this even a hostname"-style check don't blow up, and `ENOTSUP`-coded
-// throws for every real-resolution method.
+// A browser sandbox exposes no DNS resolver. Earlier versions of this stub
+// resolved *every* hostname to 127.0.0.1, which silently lied about names
+// like `example.com`. We now only short-circuit cases that are correct
+// without a resolver:
+//   - IP-address literals (v4/v6) — no DNS needed, the answer is the input.
+//   - the reserved name `localhost` — always loopback per RFC 6761.
+// Anything that would require a real DNS query reports ENOTSUP through the
+// usual error channel (callback / rejected promise) instead of crashing.
 
 type ErrnoLike = Error & { code?: string; errno?: number; syscall?: string; hostname?: string };
 
@@ -20,6 +26,32 @@ function makeNotSupported(syscall: string, hostname?: string): ErrnoLike {
     err.syscall = syscall;
     if (hostname !== undefined) err.hostname = hostname;
     return err;
+}
+
+// Minimal `node:net.isIP`-style probe (0 = not an IP, 4 = IPv4, 6 = IPv6).
+// Inlined so the browser entry stays dependency-free — we only need the
+// coarse classification, not full canonicalization.
+function classifyIP(host: string): 0 | 4 | 6 {
+    // IPv4: four 0-255 dotted octets.
+    const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+    if (v4) {
+        if (v4.slice(1).every((o) => Number(o) <= 255)) return 4;
+        return 0;
+    }
+    // IPv6: at least one ':' and only hex digits / ':' / '.' (v4-mapped tail).
+    if (host.includes(':') && /^[0-9a-fA-F:.]+$/.test(host)) return 6;
+    return 0;
+}
+
+// Hostnames a browser can resolve to loopback without any DNS query.
+function loopbackFor(hostname: string, family: 4 | 6): { address: string; family: 4 | 6 } | null {
+    const ip = classifyIP(hostname);
+    if (ip === 4) return { address: hostname, family: 4 };
+    if (ip === 6) return { address: hostname, family: 6 };
+    if (hostname === 'localhost') {
+        return family === 6 ? { address: '::1', family: 6 } : { address: '127.0.0.1', family: 4 };
+    }
+    return null;
 }
 
 // ─── Public error code re-exports (subset; matches @gjsify/dns) ──────────
@@ -92,17 +124,25 @@ export function lookup(
         throw new TypeError('The "cb" argument must be of type function');
     }
     const family = opts.family === 6 ? 6 : 4;
-    const address = family === 6 ? '::1' : '127.0.0.1';
+    const resolved = loopbackFor(hostname, family);
     queueMicrotask(() => {
+        if (!resolved) {
+            // A real DNS query — not possible in the browser. Report through
+            // the callback rather than lying with a loopback address.
+            (callback as (err: ErrnoLike | null, addr: string, fam: number) => void)(
+                makeNotSupported('lookup', hostname),
+                '',
+                family,
+            );
+            return;
+        }
         if (opts.all) {
-            (callback as (err: ErrnoLike | null, addrs: LookupAddress[]) => void)(null, [
-                { address, family },
-            ]);
+            (callback as (err: ErrnoLike | null, addrs: LookupAddress[]) => void)(null, [resolved]);
         } else {
             (callback as (err: ErrnoLike | null, addr: string, fam: number) => void)(
                 null,
-                address,
-                family,
+                resolved.address,
+                resolved.family,
             );
         }
     });
@@ -163,12 +203,16 @@ function _throwingPromise(syscall: string) {
 
 export const promises = {
     lookup(hostname: string, opts: LookupOptions = {}): Promise<LookupAddress | LookupAddress[]> {
-        return new Promise((resolveP) => {
+        return new Promise((resolveP, rejectP) => {
             const family = opts.family === 6 ? 6 : 4;
-            const address = family === 6 ? '::1' : '127.0.0.1';
+            const resolved = loopbackFor(hostname, family);
             queueMicrotask(() => {
-                if (opts.all) resolveP([{ address, family }]);
-                else resolveP({ address, family });
+                if (!resolved) {
+                    rejectP(makeNotSupported('lookup', hostname));
+                    return;
+                }
+                if (opts.all) resolveP([resolved]);
+                else resolveP(resolved);
             });
         });
     },

--- a/packages/node/module/package.json
+++ b/packages/node/module/package.json
@@ -52,7 +52,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/module/src/browser.ts
+++ b/packages/node/module/src/browser.ts
@@ -3,23 +3,29 @@
 //
 // Reference: refs/node/lib/internal/modules/cjs/loader.js (surface mirror)
 //
-// Slot: "browser:partial" — `builtinModules`/`isBuiltin` work; `createRequire`
-// returns a function that throws ERR_MODULE_NOT_FOUND for every specifier.
-// Matches what `vite-plugin-node-polyfills` ships for `module`.
+// Slot: "browser:partial" — `builtinModules`/`isBuiltin` work (they report the
+// real Node built-in set, same as the GJS impl); `createRequire` returns a
+// function that throws because a browser ESM bundle has no synchronous CommonJS
+// `require`. Matches what `vite-plugin-node-polyfills` ships for `module`.
 //
 // `node:module` in the browser is a partial stub. We expose:
-//   - `builtinModules` as an empty array (no built-ins resolvable from a
-//     browser bundle — every Node built-in is statically aliased at build
-//     time by `--app browser`).
-//   - `isBuiltin(name)` returns `false` (consistent with builtinModules=[]).
-//   - `createRequire(url)` returns a function that throws ERR_MODULE_NOT_FOUND
-//     for any specifier it's called with. The function carries the `cache`,
-//     `extensions`, `resolve` properties Node's `require` has so static
-//     property-reads don't crash before the call hits.
+//   - `builtinModules` — the canonical Node built-in name list (same as the GJS
+//     impl). `module.builtinModules` is a static catalog in Node, independent of
+//     whether a given runtime can resolve a built-in, so reporting the real list
+//     is the honest answer (`isBuiltin('fs') === true` matches every other
+//     runtime). The names themselves are statically aliased at build time by
+//     `--app browser`.
+//   - `isBuiltin(name)` — subpath-aware membership test against `builtinModules`
+//     (`fs`, `node:fs`, `fs/promises` → true; npm packages → false).
+//   - `createRequire(url)` returns a function that throws when called: built-in
+//     specifiers throw ERR_REQUIRE_ESM (a browser ESM bundle can't synchronously
+//     require a built-in), everything else throws ERR_MODULE_NOT_FOUND. The
+//     function carries the `cache`, `extensions`, `resolve` properties Node's
+//     `require` has so static property-reads don't crash before the call hits.
 //   - `syncBuiltinESMExports()` no-op.
 //
 // `node-stdlib-browser` lists `module` as `(none)`; `vite-plugin-node-polyfills`
-// ships exactly this minimal shape so that npm packages that *probe* for
+// ships a comparable minimal shape so that npm packages that *probe* for
 // `createRequire` (typescript, ts-node, …) at bundle time don't blow up.
 
 type ErrnoLike = Error & { code?: string; requireStack?: string[] };
@@ -32,8 +38,67 @@ function moduleNotFound(specifier: string): ErrnoLike {
     return err;
 }
 
-export const builtinModules: string[] = [];
-export const isBuiltin = (_name: string): boolean => false;
+function requireEsm(specifier: string): ErrnoLike {
+    const err: ErrnoLike = new Error(
+        `Cannot require built-in module '${specifier}' synchronously from a browser ESM bundle. Use 'import' (or its async dynamic form) instead.`,
+    );
+    err.code = 'ERR_REQUIRE_ESM';
+    return err;
+}
+
+// Canonical Node built-in catalog (mirrors the GJS impl's list). Kept as a
+// static list because `module.builtinModules` is a fixed catalog in Node —
+// browser resolvability does not change which names ARE built-ins.
+export const builtinModules: string[] = [
+    'assert',
+    'async_hooks',
+    'buffer',
+    'child_process',
+    'cluster',
+    'console',
+    'constants',
+    'crypto',
+    'dgram',
+    'diagnostics_channel',
+    'dns',
+    'domain',
+    'events',
+    'fs',
+    'http',
+    'http2',
+    'https',
+    'inspector',
+    'module',
+    'net',
+    'os',
+    'path',
+    'perf_hooks',
+    'process',
+    'punycode',
+    'querystring',
+    'readline',
+    'repl',
+    'stream',
+    'string_decoder',
+    'sys',
+    'timers',
+    'tls',
+    'tty',
+    'url',
+    'util',
+    'v8',
+    'vm',
+    'wasi',
+    'worker_threads',
+    'zlib',
+];
+
+export const isBuiltin = (name: string): boolean => {
+    if (!name) return false;
+    const n = name.startsWith('node:') ? name.slice(5) : name;
+    const base = n.split('/')[0];
+    return builtinModules.includes(n) || builtinModules.includes(base);
+};
 
 // Minimal NodeRequire-shaped function (subset). Bundles that statically
 // reference `require.resolve(...)` will get an ENOTFOUND for any specifier;
@@ -50,11 +115,11 @@ interface BrowserRequireFn {
 
 export function createRequire(_filename: string | URL): BrowserRequireFn {
     const requireFn = ((specifier: string): unknown => {
-        throw moduleNotFound(specifier);
+        throw isBuiltin(specifier) ? requireEsm(specifier) : moduleNotFound(specifier);
     }) as BrowserRequireFn;
     requireFn.resolve = Object.assign(
         (specifier: string, _opts?: { paths?: string[] }): string => {
-            throw moduleNotFound(specifier);
+            throw isBuiltin(specifier) ? requireEsm(specifier) : moduleNotFound(specifier);
         },
         { paths: (_req: string): string[] | null => null },
     );
@@ -80,9 +145,9 @@ export class Module {
         this.parent = parent;
     }
     require(specifier: string): never {
-        throw moduleNotFound(specifier);
+        throw isBuiltin(specifier) ? requireEsm(specifier) : moduleNotFound(specifier);
     }
-    static builtinModules: string[] = [];
+    static builtinModules: string[] = builtinModules;
     static isBuiltin: typeof isBuiltin = isBuiltin;
     static createRequire: typeof createRequire = createRequire;
     static syncBuiltinESMExports(): void {}

--- a/packages/node/sqlite/package.json
+++ b/packages/node/sqlite/package.json
@@ -52,7 +52,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/sqlite/src/browser.ts
+++ b/packages/node/sqlite/src/browser.ts
@@ -20,18 +20,14 @@
 //   the module, inspect the `constants`, type-check against the API,
 //   and ship code that conditionally uses SQLite. Calling
 //   `new DatabaseSync(...)` or `new StatementSync(...)` throws a
-//   structured ENOTSUP that points at the wiring strategy for a real
-//   WASM backend.
+//   structured ERR_NOT_SUPPORTED that points at the intended backend.
 //
-// Follow-up (tracked under "Open TODOs"):
-//   A future welle will add a `@gjsify/sqlite/wasm-backend` registration
-//   hook that wires `refs/wa-sqlite` (Roy Hashimoto, MIT) or `refs/sql.js`
-//   (Apache-2.0 / MIT) at runtime when the consumer opts in. The
-//   `DatabaseSync` / `StatementSync` classes here will then delegate to
-//   the registered backend instead of throwing.
+// Intended backend: wa-sqlite (Roy Hashimoto, MIT — vendored read-only
+//   under `refs/wa-sqlite`). A future opt-in `@gjsify/sqlite` WASM backend
+//   would delegate the classes below to it instead of throwing.
 //
 // Known gaps (slot: partial):
-//   - Calling any DB / statement constructor throws ENOTSUP.
+//   - Calling any DB / statement constructor throws ERR_NOT_SUPPORTED.
 //   - No `constants.SQLITE_*` errno table (the existing GJS constants
 //     module is re-exported as-is; values mirror Node's node:sqlite).
 
@@ -46,11 +42,10 @@ export type { DatabaseSyncOptions, StatementSyncOptions, RunResult, ColumnInfo, 
 function _enotsup(api: string): Error {
     const err = new Error(
         `@gjsify/sqlite: ${api} is not available in the browser polyfill. ` +
-            `Ship a WebAssembly SQLite backend (refs/wa-sqlite or refs/sql.js) and ` +
-            `wire it via the @gjsify/sqlite/wasm-backend hook (follow-up — tracked in ` +
-            `STATUS.md "Open TODOs").`,
+            `Ship a WebAssembly SQLite backend (the intended backend is wa-sqlite, ` +
+            `vendored read-only under refs/wa-sqlite) and delegate to it.`,
     ) as Error & { code?: string };
-    err.code = 'ENOTSUP';
+    err.code = 'ERR_NOT_SUPPORTED';
     return err;
 }
 

--- a/packages/node/vm/package.json
+++ b/packages/node/vm/package.json
@@ -48,7 +48,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "native",
-            "browser": "polyfill"
+            "browser": "polyfill",
+            "nativescript": "polyfill"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
Tightens the browser paths for four node-API polyfills and declares each package's `nativescript` runtime slot.

- **@gjsify/dns**: `lookup()` now only short-circuits cases a browser can honestly resolve without a DNS query — IP-address literals (returned as-is) and the reserved name `localhost` (loopback). Any real name resolution reports a structured `ENOTSUP` through the callback / rejected promise instead of lying with a `127.0.0.1` answer. NS slot: `none`.
- **@gjsify/sqlite**: keeps the honest explicit-failure browser stub; constructors throw a structured `ERR_NOT_SUPPORTED` with a one-line pointer at the intended wa-sqlite backend. NS slot: `none`.
- **@gjsify/module**: `builtinModules` / `isBuiltin` now report the real Node built-in catalog (matching the GJS impl) instead of an empty list; `createRequire(...)` throws `ERR_REQUIRE_ESM` for built-ins and `ERR_MODULE_NOT_FOUND` for other specifiers. NS slot: `none`.
- **@gjsify/vm**: browser `Function`/`eval` sandbox is already honest about the lack of realm isolation; declares NS slot `polyfill` (portable).

Each browser entry type-checks, bundles cleanly via `--app browser` with no `gi://` / `@girs/*` leakage, and `audit-runtimes --check` stays green.