### PR TITLE
feat(http): complete fetch-backed browser client path

### DIFF
--- a/packages/node/http/package.json
+++ b/packages/node/http/package.json
@@ -31,6 +31,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"
@@ -62,7 +63,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/http/src/browser.ts
+++ b/packages/node/http/src/browser.ts
@@ -12,11 +12,13 @@
 // (`./index.js`) drives libsoup and cannot run in a browser.
 //
 // Strategy: client paths (`request`, `get`) ride on top of the native browser
-// `fetch()`. Streaming the request body uses `ReadableStream` (or buffers when
-// the consumer never streamed). Streaming the response body re-emits chunks on
-// an EventEmitter-shaped `IncomingMessage`. Server paths
-// (`createServer`, `Server`, `ServerResponse`) throw ENOTSUP — a browser cannot
-// listen on a socket. Slot: browser:"partial". < 350 LOC.
+// `fetch()`. The request body is buffered into a `Blob` and posted; the response
+// body is streamed through a Readable-shaped `IncomingMessage` that supports the
+// surface Node consumers expect — flowing `'data'`/`'end'`, paused `read()` +
+// `'readable'`, `pause()`/`resume()` backpressure, `setEncoding()` decoding,
+// `pipe()`, and async iteration. Server paths (`createServer`, `Server`,
+// `ServerResponse`) throw a structured ENOTSUP — a browser cannot listen on a
+// socket and faking it would be dishonest. Slot: browser:"partial".
 
 import { EventEmitter } from '@gjsify/events';
 
@@ -110,6 +112,12 @@ function buildUrl(opts: RequestOptions): string {
 
 // ─── IncomingMessage (browser response wrapper) ───────────────────────────
 
+// A minimal Readable-stream shape over the fetch Response body. Self-contained
+// (no `@gjsify/stream` dependency) so it stays bundle-light, but implements the
+// surface Node consumers rely on: flowing-mode `'data'`/`'end'` events,
+// paused-mode `read()` + `'readable'`, backpressure via `pause()`/`resume()`,
+// `setEncoding()` decoding, `pipe()`, and async iteration. The `ClientRequest`
+// flush loop drives it through `_push()` / `_push(null)`.
 export class IncomingMessage extends EventEmitter {
     statusCode: number;
     statusMessage: string;
@@ -125,6 +133,13 @@ export class IncomingMessage extends EventEmitter {
     readable = true;
     destroyed = false;
     complete = false;
+    aborted = false;
+
+    private _buffer: (Uint8Array | string)[] = [];
+    private _flowing: boolean | null = null;
+    private _paused = false;
+    private _ended = false;
+    private _decoder: TextDecoder | null = null;
 
     constructor(response: Response) {
         super();
@@ -136,24 +151,122 @@ export class IncomingMessage extends EventEmitter {
         });
     }
 
-    setEncoding(_enc: string): this {
+    // ── stream ingestion (driven by ClientRequest._flush) ──
+    /** Feed one body chunk, or `null` to signal end-of-stream. */
+    _push(chunk: Uint8Array | null): void {
+        if (chunk === null) {
+            // Flush any partial multibyte char held by the streaming decoder.
+            if (this._decoder) {
+                const tail = this._decoder.decode();
+                if (tail) this._emitChunk(tail);
+            }
+            this._ended = true;
+            this._maybeEnd();
+            return;
+        }
+        this._emitChunk(this._decoder ? this._decoder.decode(chunk, { stream: true }) : chunk);
+    }
+
+    private _emitChunk(out: Uint8Array | string): void {
+        if (this._flowing) {
+            this.emit('data', out);
+        } else {
+            this._buffer.push(out);
+            this.emit('readable');
+        }
+    }
+
+    private _maybeEnd(): void {
+        if (this._ended && this._buffer.length === 0 && !this.complete) {
+            this.complete = true;
+            this.readable = false;
+            this.emit('end');
+        }
+    }
+
+    private _drain(): void {
+        while (this._flowing && !this._paused && this._buffer.length > 0) {
+            this.emit('data', this._buffer.shift());
+        }
+        this._maybeEnd();
+    }
+
+    // ── public Readable surface ──
+    setEncoding(enc: string): this {
+        this._decoder = new TextDecoder(enc === 'binary' ? 'latin1' : enc);
         return this;
     }
+
+    read(): Uint8Array | string | null {
+        return this._buffer.length === 0 ? null : (this._buffer.shift() as Uint8Array | string);
+    }
+
     pause(): this {
+        this._paused = true;
+        this._flowing = false;
+        this.emit('pause');
         return this;
     }
+
     resume(): this {
+        this._paused = false;
+        this._flowing = true;
+        queueMicrotask(() => this._drain());
+        this.emit('resume');
         return this;
     }
+
+    pipe<T extends { write(c: unknown): unknown; end(): unknown }>(dest: T): T {
+        this.on('data', (chunk: unknown) => dest.write(chunk));
+        this.on('end', () => dest.end());
+        this.resume();
+        return dest;
+    }
+
+    override on(event: string, listener: (...args: unknown[]) => void): this {
+        super.on(event, listener);
+        if (event === 'data' && this._flowing === null) {
+            this._flowing = true;
+            queueMicrotask(() => this._drain());
+        }
+        return this;
+    }
+
     destroy(err?: Error): this {
         if (this.destroyed) return this;
         this.destroyed = true;
         this.readable = false;
+        this.aborted = true;
         queueMicrotask(() => {
             if (err) this.emit('error', err);
             this.emit('close');
         });
         return this;
+    }
+
+    async *[Symbol.asyncIterator](): AsyncIterableIterator<Uint8Array | string> {
+        const queue: (Uint8Array | string)[] = [];
+        let done = false;
+        let err: Error | null = null;
+        let wake: (() => void) | null = null;
+        const onData = (c: Uint8Array | string): void => { queue.push(c); wake?.(); };
+        const onEnd = (): void => { done = true; wake?.(); };
+        const onError = (e: Error): void => { err = e; wake?.(); };
+        this.on('data', onData as (...a: unknown[]) => void);
+        this.once('end', onEnd);
+        this.once('error', onError as (...a: unknown[]) => void);
+        try {
+            while (true) {
+                if (err) throw err;
+                if (queue.length > 0) { yield queue.shift() as Uint8Array | string; continue; }
+                if (done) return;
+                await new Promise<void>((res) => { wake = res; });
+            }
+        } finally {
+            this.removeListener('data', onData as (...a: unknown[]) => void);
+            this.removeListener('end', onEnd);
+            this.removeListener('error', onError as (...a: unknown[]) => void);
+        }
     }
 }
 
@@ -175,6 +288,7 @@ export class ClientRequest extends EventEmitter {
     connection = null;
     writable = true;
     destroyed = false;
+    aborted = false;
 
     constructor(options: RequestOptions, callback?: (res: IncomingMessage) => void) {
         super();
@@ -226,8 +340,13 @@ export class ClientRequest extends EventEmitter {
     abort(): void {
         if (this._aborted) return;
         this._aborted = true;
+        this.aborted = true;
+        this.writable = false;
         this._abortCtrl.abort();
-        this.emit('abort');
+        queueMicrotask(() => {
+            this.emit('abort');
+            this.emit('close');
+        });
     }
 
     destroy(err?: Error): this {
@@ -263,12 +382,13 @@ export class ClientRequest extends EventEmitter {
                 credentials: 'same-origin',
             });
             const incoming = new IncomingMessage(response);
+            incoming.method = this.method;
+            incoming.url = this.path;
             this.emit('response', incoming);
             if (cb) queueMicrotask(cb);
             const reader = response.body?.getReader();
             if (!reader) {
-                incoming.complete = true;
-                queueMicrotask(() => incoming.emit('end'));
+                queueMicrotask(() => incoming._push(null));
                 return;
             }
             const pump = async (): Promise<void> => {
@@ -276,11 +396,9 @@ export class ClientRequest extends EventEmitter {
                     while (true) {
                         const { done, value } = await reader.read();
                         if (done) break;
-                        incoming.emit('data', value);
+                        incoming._push(value);
                     }
-                    incoming.complete = true;
-                    incoming.emit('end');
-                    incoming.emit('close');
+                    incoming._push(null);
                 } catch (err) {
                     incoming.emit('error', err);
                 }
@@ -332,6 +450,10 @@ export function get(
 }
 
 // ─── Server paths — ENOTSUP in the browser ────────────────────────────────
+//
+// A browser cannot bind a TCP listening socket, so there is no honest way to
+// implement an HTTP server. These throw a structured `ENOTSUP` rather than
+// pretending to work — faking it would hide the real platform limit.
 
 function notSupported(syscall: string): never {
     const err = new Error(`http.${syscall} is not supported in the browser`) as Error & { code: string; errno: number; syscall: string };
@@ -362,6 +484,7 @@ export class OutgoingMessage extends EventEmitter {
     }
 }
 
+/** Throws structured `ENOTSUP` — a browser cannot listen on a TCP socket. */
 export function createServer(..._args: unknown[]): Server {
     return notSupported('createServer');
 }

--- a/packages/node/http/src/test.browser.mts
+++ b/packages/node/http/src/test.browser.mts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/http — exercises the fetch-backed client path
+// (`request`/`get` → ClientRequest → IncomingMessage) against the same
+// http-server that serves the Playwright harness. The browser-target alias
+// layer (`ALIASES_NODE_FOR_BROWSER`, PR #388) routes `node:http` → this module,
+// and `tests/browser/` discovers the resulting `dist/test.browser.mjs` bundle.
+//
+// Only the client path is covered: a browser cannot listen on a socket, so the
+// server path throws a structured ENOTSUP (asserted below).
+
+import { run, describe, it, expect } from '@gjsify/unit';
+import http, { request, get, createServer, type IncomingMessage } from './browser.js';
+
+// Same-origin URL served by the Playwright http-server (repo root). The harness
+// index.html is guaranteed to exist; a missing path yields a real 404.
+const origin = globalThis.location?.origin ?? 'http://localhost:8087';
+const OK_URL = `${origin}/tests/browser/harness/index.html`;
+const MISSING_URL = `${origin}/tests/browser/__http_nonexistent__.html`;
+
+run({
+    async HttpBrowserClientTest() {
+        await describe('http.get — response event + status', async () => {
+            await it('resolves a 200 with a status message and headers', async () => {
+                const res = await new Promise<IncomingMessage>((resolve, reject) => {
+                    const req = get(OK_URL, resolve);
+                    req.on('error', reject);
+                });
+                expect(res.statusCode).toBe(200);
+                expect(typeof res.statusMessage).toBe('string');
+                // fetch always exposes content-type for a served HTML file.
+                expect(typeof res.headers['content-type']).toBe('string');
+            });
+        });
+
+        await describe('IncomingMessage — flowing-mode data/end', async () => {
+            await it("concatenates 'data' chunks and fires 'end'", async () => {
+                const body = await new Promise<string>((resolve, reject) => {
+                    get(OK_URL, (res) => {
+                        const chunks: Uint8Array[] = [];
+                        res.on('data', (c: unknown) => chunks.push(c as Uint8Array));
+                        res.on('end', () => {
+                            const total = chunks.reduce((n, c) => n + c.length, 0);
+                            const merged = new Uint8Array(total);
+                            let off = 0;
+                            for (const c of chunks) { merged.set(c, off); off += c.length; }
+                            resolve(new TextDecoder().decode(merged));
+                        });
+                        res.on('error', reject);
+                    });
+                });
+                expect(body).toContain('<!DOCTYPE html>');
+            });
+        });
+
+        await describe('IncomingMessage — setEncoding decodes to string', async () => {
+            await it("emits string chunks after setEncoding('utf8')", async () => {
+                const body = await new Promise<string>((resolve, reject) => {
+                    get(OK_URL, (res) => {
+                        res.setEncoding('utf8');
+                        let acc = '';
+                        let allStrings = true;
+                        res.on('data', (c: unknown) => {
+                            if (typeof c !== 'string') allStrings = false;
+                            acc += c as string;
+                        });
+                        res.on('end', () => {
+                            expect(allStrings).toBe(true);
+                            resolve(acc);
+                        });
+                        res.on('error', reject);
+                    });
+                });
+                expect(body).toContain('<!DOCTYPE html>');
+            });
+        });
+
+        await describe('IncomingMessage — async iteration', async () => {
+            await it('yields body chunks via for-await', async () => {
+                const res = await new Promise<IncomingMessage>((resolve, reject) => {
+                    const req = get(OK_URL, resolve);
+                    req.on('error', reject);
+                });
+                let bytes = 0;
+                for await (const chunk of res) {
+                    bytes += (chunk as Uint8Array).length;
+                }
+                expect(bytes).toBeGreaterThan(0);
+            });
+        });
+
+        await describe('http.request — non-existent path is a 404', async () => {
+            await it('reports statusCode 404', async () => {
+                const res = await new Promise<IncomingMessage>((resolve, reject) => {
+                    const req = request(MISSING_URL, resolve);
+                    req.on('error', reject);
+                    req.end();
+                });
+                expect(res.statusCode).toBe(404);
+            });
+        });
+
+        await describe('http.request — write body before end', async () => {
+            await it('accepts a written body and still resolves a response', async () => {
+                const res = await new Promise<IncomingMessage>((resolve, reject) => {
+                    const req = request(OK_URL, { method: 'POST' }, resolve);
+                    req.on('error', reject);
+                    req.write('hello');
+                    req.end();
+                });
+                // The static server may reject POST (405) or accept it — either way
+                // the client path produced a real IncomingMessage with a status.
+                expect(typeof res.statusCode).toBe('number');
+            });
+        });
+
+        await describe('http.createServer — ENOTSUP in the browser', async () => {
+            await it('throws a structured ENOTSUP error', async () => {
+                let code: string | undefined;
+                try {
+                    createServer();
+                } catch (err) {
+                    code = (err as { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+
+        await describe('default export shape', async () => {
+            await it('exposes request/get/createServer', async () => {
+                expect(typeof http.request).toBe('function');
+                expect(typeof http.get).toBe('function');
+                expect(typeof http.createServer).toBe('function');
+            });
+        });
+    },
+});


### PR DESCRIPTION
Completes the browser implementation of `@gjsify/http`. The browser `IncomingMessage` is now a proper readable stream over the fetch `Response` body — supporting flowing-mode `'data'`/`'end'` events, paused-mode `read()` + `'readable'`, `pause()`/`resume()` backpressure, `setEncoding()` decoding, `pipe()`, and async iteration — so `http.request`/`http.get` behave like Node over fetch.

Server paths (`createServer`, `Server`, `ServerResponse`) keep throwing a structured `ENOTSUP` because a browser cannot listen on a socket; faking it would be dishonest. Also declares `nativescript: "none"` and adds a `src/test.browser.mts` client-path suite.