### PR TITLE
feat(fs): add opfs persistence to browser polyfill

### DIFF
--- a/packages/node/fs/package.json
+++ b/packages/node/fs/package.json
@@ -40,6 +40,10 @@
         "./browser/stream": {
             "types": "./lib/types/browser/stream.d.ts",
             "default": "./lib/esm/browser/stream.js"
+        },
+        "./browser/opfs": {
+            "types": "./lib/types/browser/opfs.d.ts",
+            "default": "./lib/esm/browser/opfs.js"
         }
     },
     "scripts": {
@@ -51,6 +55,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"
@@ -79,7 +84,8 @@
         "runtimes": {
             "gjs": "polyfill",
             "node": "none",
-            "browser": "partial"
+            "browser": "partial",
+            "nativescript": "none"
         }
     },
     "license": "MIT",

--- a/packages/node/fs/src/browser.ts
+++ b/packages/node/fs/src/browser.ts
@@ -2,7 +2,10 @@
 // Reimplemented for @gjsify browser target — inspired by memfs
 // (streamich + contributors, Apache-2.0).
 //
-// In-memory only. No persistence (OPFS bridge is a future iteration).
+// In-memory working layer with OPTIONAL OPFS persistence. The synchronous
+// `fs.*Sync` surface always hits an in-memory `Volume`; calling
+// `enableOpfsPersistence()` mirrors that volume to the Origin Private File
+// System so files survive a page reload (feature-detected, graceful fallback).
 // No file watching (FSWatcher is a stub). No real permission/owner enforcement.
 //
 // This file is the browser entry point selected by the package's `"browser"`
@@ -13,13 +16,19 @@
 // Strategy: a single in-memory `Volume` (default) + `memfs`-shape `Volume`
 // class export for tests that want sandboxes. Sync / callback / promise
 // surfaces are all backed by the same volume so writes in one API are
-// visible to reads in another.
+// visible to reads in another. `enableOpfsPersistence()` (browser/opfs.js)
+// hydrates the volume from OPFS on init and write-behind-flushes mutations
+// back, behind a `navigator.storage?.getDirectory` feature check.
 //
 // Known gaps (slot: partial):
-//   - No OPFS / IndexedDB persistence — page reload wipes the volume.
-//   - FSWatcher is a stub (registers events, never fires).
-//   - Symlinks are stored but never followed by `realpath` / `stat`.
-//   - chmod / chown alter mode bits but enforce nothing.
+//   - Persistence is OPT-IN + asynchronous (write-behind via OPFS). Without
+//     `enableOpfsPersistence()`, or where OPFS is unavailable, a reload wipes
+//     the volume.
+//   - FSWatcher is a stub (registers events, never fires) — not OPFS-aware.
+//   - Symlinks are stored but never followed by `realpath` / `stat`, and are
+//     NOT round-tripped through OPFS (persisted as placeholder strings only).
+//   - chmod / chown alter mode bits but enforce nothing, and mode/uid/gid are
+//     not persisted (OPFS has no POSIX metadata).
 //   - File descriptors are minimal (no readv / writev / fsync / fdatasync).
 //   - No `cp` (recursive copy) — implement on top of `readdir` + `copyFile`.
 
@@ -33,6 +42,10 @@ export {
     createReadStream, ReadStream, createWriteStream, WriteStream,
     FSWatcher, StatWatcher, watch, watchFile, unwatchFile,
 } from './browser/stream.js';
+export {
+    enableOpfsPersistence, hasOpfs,
+    type OpfsPersistenceOptions, type OpfsPersistenceController,
+} from './browser/opfs.js';
 
 import * as promises from './browser/promises.js';
 export { promises };

--- a/packages/node/fs/src/browser/opfs.ts
+++ b/packages/node/fs/src/browser/opfs.ts
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+// Reimplemented for @gjsify browser target — inspired by memfs
+// (streamich + contributors, Apache-2.0).
+//
+// Optional OPFS (Origin Private File System) persistence bridge.
+//
+// The browser `fs` surface is synchronous and backed by an in-memory `Volume`
+// (see ./volume.ts). OPFS, however, is asynchronous-only on the main thread
+// (synchronous access handles exist solely inside dedicated Web Workers). We
+// therefore cannot make the sync `fs.*Sync` calls hit OPFS directly. Instead
+// this module keeps memfs as the in-memory working layer and bridges it to
+// OPFS in two async phases:
+//
+//   1. Hydrate — on enable, the OPFS tree is read recursively into the volume
+//      so files written in a previous session reappear.
+//   2. Flush — every volume mutation schedules a debounced async flush that
+//      mirrors the volume's `toJSON()` snapshot back into OPFS (creating
+//      directories, writing changed files, deleting stale entries).
+//
+// Feature detection is `navigator.storage?.getDirectory`. When OPFS is
+// unavailable (older engines, insecure contexts, GJS) `enableOpfsPersistence`
+// resolves to a disabled controller and the volume stays purely in-memory —
+// nothing throws.
+//
+// Honest limitations (unchanged from the in-memory layer):
+//   - Symlinks: `toJSON()` serialises a symlink as a placeholder string, so
+//     symlinks are NOT round-tripped through OPFS — they survive in-memory for
+//     the session but are not persisted as links.
+//   - File watching (FSWatcher) is still a stub and is not OPFS-aware.
+//   - Permission / owner bits (mode/uid/gid) are not persisted — OPFS has no
+//     POSIX metadata; hydrated files come back with default mode bits.
+//   - Persistence is whole-file and snapshot-based (last-write-wins per flush),
+//     not byte-range journalled.
+
+import { Volume, __defaultVolume } from './volume.js';
+
+/** Options for {@link enableOpfsPersistence}. */
+export interface OpfsPersistenceOptions {
+    /** Volume to persist. Defaults to the process-wide `__defaultVolume`. */
+    volume?: Volume;
+    /**
+     * Sub-directory inside the origin's private file system to mirror the
+     * volume into. Lets multiple independent volumes share one origin without
+     * clobbering each other. Default: `'gjsify-fs'`.
+     */
+    rootDir?: string;
+    /**
+     * Debounce window (ms) before a burst of mutations is flushed to OPFS.
+     * Default: `50`. Set to `0` to flush on every microtask turn.
+     */
+    flushDelayMs?: number;
+}
+
+/** Handle returned by {@link enableOpfsPersistence}. */
+export interface OpfsPersistenceController {
+    /** Whether OPFS was available and persistence is active. */
+    readonly enabled: boolean;
+    /** If `enabled` is false, a short machine-readable reason. */
+    readonly reason?: 'no-opfs' | 'error';
+    /** Force an immediate flush of the volume to OPFS. Resolves when written. */
+    flush(): Promise<void>;
+    /** Stop persisting: unsubscribe the mutation listener (does not wipe OPFS). */
+    disable(): void;
+}
+
+/** Feature-detect the main-thread OPFS root accessor. */
+export function hasOpfs(): boolean {
+    return typeof navigator !== 'undefined'
+        && typeof navigator.storage !== 'undefined'
+        && typeof navigator.storage.getDirectory === 'function';
+}
+
+const DEFAULT_ROOT = 'gjsify-fs';
+
+/** Split an absolute POSIX path into segments (drops leading `/`). */
+function segments(absPath: string): string[] {
+    return absPath.split('/').filter(Boolean);
+}
+
+/** Resolve (creating if asked) a nested directory handle under `root`. */
+async function dirHandle(
+    root: FileSystemDirectoryHandle,
+    parts: string[],
+    create: boolean,
+): Promise<FileSystemDirectoryHandle | undefined> {
+    let cur = root;
+    for (const part of parts) {
+        try {
+            cur = await cur.getDirectoryHandle(part, { create });
+        } catch {
+            return undefined;
+        }
+    }
+    return cur;
+}
+
+/** Recursively read an OPFS directory into a flat `path -> bytes | null` map. */
+async function readOpfsTree(
+    dir: FileSystemDirectoryHandle,
+    prefix: string,
+    out: Map<string, Uint8Array | null>,
+): Promise<void> {
+    let empty = true;
+    // `entries()` is an async iterator on FileSystemDirectoryHandle.
+    for await (const [name, handle] of (dir as unknown as {
+        entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+    }).entries()) {
+        empty = false;
+        const childPath = prefix === '/' ? '/' + name : prefix + '/' + name;
+        if (handle.kind === 'directory') {
+            await readOpfsTree(handle as FileSystemDirectoryHandle, childPath, out);
+        } else {
+            const file = await (handle as FileSystemFileHandle).getFile();
+            out.set(childPath, new Uint8Array(await file.arrayBuffer()));
+        }
+    }
+    // Preserve empty directories (excluding the synthetic root).
+    if (empty && prefix !== '/') out.set(prefix, null);
+}
+
+/** Mirror the volume's current snapshot into OPFS under `root`. */
+async function flushVolumeToOpfs(
+    vol: Volume,
+    root: FileSystemDirectoryHandle,
+): Promise<void> {
+    const snapshot = vol.toJSON();
+
+    // 1. Write / create every path present in the snapshot.
+    const liveDirs = new Set<string>();
+    const liveFiles = new Set<string>();
+    for (const [path, content] of Object.entries(snapshot)) {
+        const parts = segments(path);
+        if (content === null) {
+            // Empty directory marker — keep the dir and every ancestor live so
+            // pruneStale doesn't recursively delete a nested empty directory.
+            await dirHandle(root, parts, true);
+            for (let i = 1; i <= parts.length; i++) liveDirs.add(parts.slice(0, i).join('/'));
+        } else {
+            const parent = await dirHandle(root, parts.slice(0, -1), true);
+            if (!parent) continue;
+            for (let i = 1; i < parts.length; i++) liveDirs.add(parts.slice(0, i).join('/'));
+            const fileHandle = await parent.getFileHandle(parts[parts.length - 1], { create: true });
+            const writable = await fileHandle.createWritable();
+            await writable.write(new TextEncoder().encode(content));
+            await writable.close();
+            liveFiles.add(parts.join('/'));
+        }
+    }
+
+    // 2. Prune OPFS entries no longer present in the snapshot (deletions).
+    await pruneStale(root, '', liveFiles, liveDirs);
+}
+
+/** Remove OPFS entries that are absent from the live file/dir sets. */
+async function pruneStale(
+    dir: FileSystemDirectoryHandle,
+    prefix: string,
+    liveFiles: Set<string>,
+    liveDirs: Set<string>,
+): Promise<void> {
+    const toRemove: Array<{ name: string; recursive: boolean }> = [];
+    for await (const [name, handle] of (dir as unknown as {
+        entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+    }).entries()) {
+        const childKey = prefix ? prefix + '/' + name : name;
+        if (handle.kind === 'directory') {
+            // Recurse first so we can drop a now-empty live dir's stale children.
+            await pruneStale(handle as FileSystemDirectoryHandle, childKey, liveFiles, liveDirs);
+            if (!liveDirs.has(childKey) && !liveFiles.has(childKey)) {
+                toRemove.push({ name, recursive: true });
+            }
+        } else if (!liveFiles.has(childKey)) {
+            toRemove.push({ name, recursive: false });
+        }
+    }
+    for (const { name, recursive } of toRemove) {
+        try { await dir.removeEntry(name, { recursive }); } catch { /* already gone */ }
+    }
+}
+
+/**
+ * Enable OPFS-backed persistence for a memfs `Volume`.
+ *
+ * Hydrates the volume from OPFS (so a prior session's files reappear) and then
+ * mirrors every subsequent mutation back to OPFS on a debounced schedule. The
+ * synchronous `fs.*Sync` API surface is untouched — reads and writes still hit
+ * the in-memory volume; OPFS is a write-behind durability layer.
+ *
+ * When OPFS is unavailable the returned controller has `enabled: false` and the
+ * volume continues to work purely in-memory. This never throws for a missing
+ * platform — only an actual OPFS I/O error during setup yields `reason: 'error'`.
+ */
+export async function enableOpfsPersistence(
+    options: OpfsPersistenceOptions = {},
+): Promise<OpfsPersistenceController> {
+    const vol = options.volume ?? __defaultVolume;
+
+    if (!hasOpfs()) {
+        return { enabled: false, reason: 'no-opfs', flush: async () => {}, disable: () => {} };
+    }
+
+    let root: FileSystemDirectoryHandle;
+    try {
+        const origin = await navigator.storage.getDirectory();
+        root = await origin.getDirectoryHandle(options.rootDir ?? DEFAULT_ROOT, { create: true });
+    } catch {
+        return { enabled: false, reason: 'error', flush: async () => {}, disable: () => {} };
+    }
+
+    // ── Hydrate: OPFS → volume (no flush feedback). ──────────────────────────
+    let suspendFlush = true;
+    try {
+        const tree = new Map<string, Uint8Array | null>();
+        await readOpfsTree(root, '/', tree);
+        const json: Record<string, string | Uint8Array | null> = {};
+        for (const [path, bytes] of tree) json[path] = bytes;
+        if (Object.keys(json).length > 0) vol.fromJSON(json);
+    } catch {
+        // A read failure leaves the volume in-memory-only but still flushable.
+    } finally {
+        suspendFlush = false;
+    }
+
+    // ── Flush: volume → OPFS (debounced). ────────────────────────────────────
+    const delay = options.flushDelayMs ?? 50;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let inFlight: Promise<void> = Promise.resolve();
+    let pending = false;
+
+    const doFlush = (): Promise<void> => {
+        // Serialise flushes: chain after any in-flight write to avoid interleaving.
+        inFlight = inFlight.then(() => flushVolumeToOpfs(vol, root)).catch(() => {});
+        return inFlight;
+    };
+
+    const schedule = (): void => {
+        if (suspendFlush) return;
+        pending = true;
+        if (timer !== undefined) return;
+        timer = setTimeout(() => {
+            timer = undefined;
+            pending = false;
+            void doFlush();
+        }, delay);
+    };
+
+    const unsubscribe = vol.subscribe(schedule);
+
+    return {
+        enabled: true,
+        async flush(): Promise<void> {
+            if (timer !== undefined) { clearTimeout(timer); timer = undefined; }
+            pending = false;
+            await doFlush();
+        },
+        disable(): void {
+            if (timer !== undefined) { clearTimeout(timer); timer = undefined; }
+            unsubscribe();
+            void pending; // a still-pending mutation is intentionally dropped on disable
+        },
+    };
+}

--- a/packages/node/fs/src/browser/volume.ts
+++ b/packages/node/fs/src/browser/volume.ts
@@ -57,10 +57,29 @@ export class Volume {
     private nextIno = 2;
     private fds = new Map<number, FdEntry>();
     private nextFd = 3;
+    private mutationListeners = new Set<() => void>();
 
     constructor() {
         this.root = { kind: 'dir', children: new Map(), ...this.mkBase('dir', 0o755), nlink: 2 } as DirNode;
         this.root.ino = 1;
+    }
+
+    /**
+     * Register a listener invoked after every mutation (write / mkdir / unlink /
+     * rename / chmod / …). Returns an unsubscribe function. The OPFS persistence
+     * bridge uses this to debounce-flush the volume back to the Origin Private
+     * File System; it has no effect on the in-memory semantics.
+     */
+    subscribe(listener: () => void): () => void {
+        this.mutationListeners.add(listener);
+        return () => { this.mutationListeners.delete(listener); };
+    }
+
+    /** Notify all mutation listeners. A listener failure never breaks the fs op. */
+    notifyMutation(): void {
+        for (const l of this.mutationListeners) {
+            try { l(); } catch { /* a persistence flush failure must not break fs */ }
+        }
     }
 
     private mkBase(kind: NodeKind, perm: number): BaseNode {
@@ -146,6 +165,7 @@ export class Volume {
             parent.children.set(name, file);
             parent.mtimeMs = parent.ctimeMs = now();
         }
+        this.notifyMutation();
     }
 
     appendFileSync(path: string, data: Uint8Array, mode = 0o666): void {
@@ -158,9 +178,10 @@ export class Volume {
             merged.set(data, node.data.byteLength);
             node.data = merged;
             node.mtimeMs = node.ctimeMs = now();
+            this.notifyMutation();
         } catch (e) {
             if ((e as { code?: string }).code !== 'ENOENT') throw e;
-            this.writeFileSync(abs, data, mode);
+            this.writeFileSync(abs, data, mode); // delegates → notifies
         }
     }
 
@@ -174,6 +195,7 @@ export class Volume {
             node.data = extended;
         }
         node.mtimeMs = node.ctimeMs = now();
+        this.notifyMutation();
     }
 
     // ───────────── Directory I/O ─────────────────────────────────────────────
@@ -220,6 +242,7 @@ export class Volume {
                 cur = child;
             }
         }
+        if (firstCreated !== undefined) this.notifyMutation();
         return firstCreated;
     }
 
@@ -233,6 +256,7 @@ export class Volume {
         if (!opts.recursive && node.children.size > 0) throw ENOTEMPTY('rmdir', abs);
         parent.children.delete(name);
         parent.mtimeMs = parent.ctimeMs = now();
+        this.notifyMutation();
     }
 
     unlinkSync(path: string): void {
@@ -243,6 +267,7 @@ export class Volume {
         if (node.kind === 'dir') throw EISDIR('unlink', abs);
         parent.children.delete(name);
         parent.mtimeMs = parent.ctimeMs = now();
+        this.notifyMutation();
     }
 
     rmSync(path: string, opts: { recursive?: boolean; force?: boolean } = {}): void {
@@ -281,6 +306,7 @@ export class Volume {
         oldParent.mtimeMs = oldParent.ctimeMs = t;
         newParent.mtimeMs = newParent.ctimeMs = t;
         node.ctimeMs = t;
+        this.notifyMutation();
     }
 
     copyFileSync(src: string, dest: string, flags = 0): void {
@@ -299,6 +325,7 @@ export class Volume {
         node.nlink += 1;
         parent.children.set(name, { ...node, kind: 'file' } as FileNode);
         parent.mtimeMs = parent.ctimeMs = now();
+        this.notifyMutation();
     }
 
     // ───────────── Symlinks (limited) ────────────────────────────────────────
@@ -311,6 +338,7 @@ export class Volume {
         link.target = target;
         parent.children.set(name, link);
         parent.mtimeMs = parent.ctimeMs = now();
+        this.notifyMutation();
     }
 
     readlinkSync(path: string): string {
@@ -331,6 +359,7 @@ export class Volume {
         const node = this.lookup(path, 'chmod');
         node.mode = (node.mode & ~0o7777) | (mode & 0o7777);
         node.ctimeMs = now();
+        this.notifyMutation();
     }
 
     chownSync(path: string, uid: number, gid: number): void {
@@ -338,6 +367,7 @@ export class Volume {
         node.uid = uid;
         node.gid = gid;
         node.ctimeMs = now();
+        this.notifyMutation();
     }
 
     utimesSync(path: string, atime: number, mtime: number): void {
@@ -345,6 +375,7 @@ export class Volume {
         node.atimeMs = atime;
         node.mtimeMs = mtime;
         node.ctimeMs = now();
+        this.notifyMutation();
     }
 
     // ───────────── File descriptors (minimal) ────────────────────────────────
@@ -403,6 +434,7 @@ export class Volume {
         entry.node.data.set(slice, pos);
         if (position === null) entry.position = end;
         entry.node.mtimeMs = entry.node.ctimeMs = now();
+        this.notifyMutation();
         return slice.byteLength;
     }
 

--- a/packages/node/fs/src/test.browser.mts
+++ b/packages/node/fs/src/test.browser.mts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/fs — exercises the OPFS persistence bridge
+// against a real browser's Origin Private File System (Playwright/Firefox).
+//
+// The browser fs implementation is self-contained pure-TS (an in-memory
+// `Volume` + an OPFS write-behind layer). It pulls in NO `@girs/*` / `gi://`
+// bindings, so importing the browser-entry modules directly here is safe — it
+// does not drag GJS-specific code into the browser bundle.
+//
+// OPFS round-trips are guarded by `hasOpfs()` feature detection so the suite
+// passes cleanly on engines/contexts without OPFS (the fallback contract).
+
+import { run, describe, it, expect } from '@gjsify/unit';
+import { Volume } from './browser/volume.js';
+import { enableOpfsPersistence, hasOpfs } from './browser/opfs.js';
+
+// Unique sub-directory per run so parallel test files / reruns don't collide.
+const TEST_ROOT = 'gjsify-fs-test-' + Math.random().toString(36).slice(2, 10);
+
+run({
+    async FsBrowserOpfsTest() {
+        await describe('hasOpfs()', async () => {
+            await it('returns a boolean reflecting navigator.storage.getDirectory', async () => {
+                expect(typeof hasOpfs()).toBe('boolean');
+            });
+        });
+
+        await describe('enableOpfsPersistence — fallback contract', async () => {
+            await it('always resolves to a controller (never throws)', async () => {
+                const vol = new Volume();
+                const ctl = await enableOpfsPersistence({ volume: vol, rootDir: TEST_ROOT + '-fallback' });
+                expect(typeof ctl.enabled).toBe('boolean');
+                expect(typeof ctl.flush).toBe('function');
+                expect(typeof ctl.disable).toBe('function');
+                // flush() + disable() are safe regardless of availability.
+                await ctl.flush();
+                ctl.disable();
+            });
+
+            await it('keeps the volume working in-memory irrespective of OPFS', async () => {
+                const vol = new Volume();
+                const ctl = await enableOpfsPersistence({ volume: vol, rootDir: TEST_ROOT + '-mem' });
+                vol.writeFileSync('/hello.txt', new TextEncoder().encode('hi'));
+                expect(new TextDecoder().decode(vol.readFileSync('/hello.txt'))).toBe('hi');
+                ctl.disable();
+            });
+        });
+
+        if (hasOpfs()) {
+            await describe('OPFS persistence — round-trip', async () => {
+                await it('hydrates a fresh volume from a previously flushed one', async () => {
+                    const rootDir = TEST_ROOT + '-roundtrip';
+
+                    // Session 1: write + persist.
+                    const volA = new Volume();
+                    const ctlA = await enableOpfsPersistence({ volume: volA, rootDir });
+                    expect(ctlA.enabled).toBe(true);
+                    volA.mkdirSync('/data', { recursive: true });
+                    volA.writeFileSync('/data/note.txt', new TextEncoder().encode('persisted'));
+                    volA.writeFileSync('/top.txt', new TextEncoder().encode('root-level'));
+                    await ctlA.flush();
+                    ctlA.disable();
+
+                    // Session 2: a brand-new volume hydrates from OPFS.
+                    const volB = new Volume();
+                    const ctlB = await enableOpfsPersistence({ volume: volB, rootDir });
+                    expect(ctlB.enabled).toBe(true);
+                    expect(volB.existsSync('/data/note.txt')).toBe(true);
+                    expect(new TextDecoder().decode(volB.readFileSync('/data/note.txt'))).toBe('persisted');
+                    expect(new TextDecoder().decode(volB.readFileSync('/top.txt'))).toBe('root-level');
+                    ctlB.disable();
+                });
+
+                await it('round-trips nested empty directories', async () => {
+                    const rootDir = TEST_ROOT + '-emptydirs';
+
+                    const volA = new Volume();
+                    const ctlA = await enableOpfsPersistence({ volume: volA, rootDir });
+                    volA.mkdirSync('/nested/empty', { recursive: true });
+                    await ctlA.flush();
+                    ctlA.disable();
+
+                    const volB = new Volume();
+                    const ctlB = await enableOpfsPersistence({ volume: volB, rootDir });
+                    expect(volB.existsSync('/nested')).toBe(true);
+                    expect(volB.existsSync('/nested/empty')).toBe(true);
+                    expect(volB.statSync('/nested/empty').kind).toBe('dir');
+                    ctlB.disable();
+                });
+
+                await it('propagates deletions to OPFS on flush', async () => {
+                    const rootDir = TEST_ROOT + '-delete';
+
+                    const volA = new Volume();
+                    const ctlA = await enableOpfsPersistence({ volume: volA, rootDir });
+                    volA.writeFileSync('/keep.txt', new TextEncoder().encode('keep'));
+                    volA.writeFileSync('/drop.txt', new TextEncoder().encode('drop'));
+                    await ctlA.flush();
+                    volA.unlinkSync('/drop.txt');
+                    await ctlA.flush();
+                    ctlA.disable();
+
+                    const volB = new Volume();
+                    const ctlB = await enableOpfsPersistence({ volume: volB, rootDir });
+                    expect(volB.existsSync('/keep.txt')).toBe(true);
+                    expect(volB.existsSync('/drop.txt')).toBe(false);
+                    ctlB.disable();
+                });
+
+                await it('debounced mutation flush eventually persists without explicit flush()', async () => {
+                    const rootDir = TEST_ROOT + '-auto';
+
+                    const volA = new Volume();
+                    const ctlA = await enableOpfsPersistence({ volume: volA, rootDir, flushDelayMs: 5 });
+                    volA.writeFileSync('/auto.txt', new TextEncoder().encode('auto'));
+                    // Wait past the debounce window for the write-behind flush.
+                    await new Promise((r) => setTimeout(r, 60));
+                    ctlA.disable();
+
+                    const volB = new Volume();
+                    const ctlB = await enableOpfsPersistence({ volume: volB, rootDir });
+                    expect(volB.existsSync('/auto.txt')).toBe(true);
+                    expect(new TextDecoder().decode(volB.readFileSync('/auto.txt'))).toBe('auto');
+                    ctlB.disable();
+                });
+            });
+        }
+    },
+});


### PR DESCRIPTION
Adds an optional Origin Private File System (OPFS) persistence layer behind the in-memory memfs Volume used by the `@gjsify/fs` browser entry, so files can survive a page reload. The new `enableOpfsPersistence()` (exported from `@gjsify/fs/browser` and `@gjsify/fs/browser/opfs`) hydrates the volume from OPFS on init and write-behind-flushes mutations back on a debounced schedule, all guarded by a `navigator.storage?.getDirectory` feature check that falls back cleanly to in-memory when OPFS is unavailable. The synchronous `fs.*Sync` API surface is untouched — OPFS is a durability layer, not a new code path. Symlinks/POSIX-metadata are honestly documented as not round-tripped, and `src/test.browser.mts` exercises the round-trip, deletion, debounced flush, and fallback contract (green in Playwright/Firefox).