### PR TITLE
test(browser): add browser test entries for core node packages

### DIFF
--- a/packages/node/assert/package.json
+++ b/packages/node/assert/package.json
@@ -31,6 +31,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/assert/src/test.browser.mts
+++ b/packages/node/assert/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/constants/package.json
+++ b/packages/node/constants/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/constants/src/test.browser.mts
+++ b/packages/node/constants/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/events/package.json
+++ b/packages/node/events/package.json
@@ -27,6 +27,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/events/src/test.browser.mts
+++ b/packages/node/events/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/path/package.json
+++ b/packages/node/path/package.json
@@ -31,6 +31,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/path/src/test.browser.mts
+++ b/packages/node/path/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/querystring/package.json
+++ b/packages/node/querystring/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/querystring/src/test.browser.mts
+++ b/packages/node/querystring/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/string_decoder/package.json
+++ b/packages/node/string_decoder/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/string_decoder/src/test.browser.mts
+++ b/packages/node/string_decoder/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/util/package.json
+++ b/packages/node/util/package.json
@@ -29,6 +29,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.ts --app gjs --no-minify --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.ts --app node --no-minify --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/util/src/test.browser.mts
+++ b/packages/node/util/src/test.browser.mts
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry — re-exports the standard spec so it also runs under `--app browser`.
+export * from './test.js';
+import './test.js';


### PR DESCRIPTION
Adds a `src/test.browser.mts` entry and a `build:test:browser` script to seven core Node polyfill packages: assert, path, events, util, querystring, string_decoder, and constants. Each entry re-exports the existing standard spec so the same assertions can also run under `gjsify build --app browser`, mirroring the established pattern from the buffer package. No implementation code changes — only test wiring. The specs are platform-neutral pure TypeScript, so they pass identically under the node target.