### PR TITLE
test: add browser-target tests for process and os

### DIFF
--- a/packages/node/os/package.json
+++ b/packages/node/os/package.json
@@ -27,6 +27,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/os/src/index.browser.spec.ts
+++ b/packages/node/os/src/index.browser.spec.ts
@@ -1,0 +1,160 @@
+// Browser-target spec for @gjsify/os.
+//
+// The standard `index.spec.ts` asserts host-OS-specific values (platform() ===
+// 'linux', type() === 'Linux', cpus().length > 0, totalmem() > 0, real signal
+// numbers, …) that only hold under Node/GJS on a real machine. The browser
+// entry (`./browser.ts`) is intentionally constant — there is no POSIX uname /
+// sysctl / /proc surface in a browser, so platform/arch are 'browser', cpus()
+// is `[]`, mem readings are 0, hostname is 'localhost', etc.
+//
+// This reduced spec therefore imports the browser impl directly and only
+// asserts what is actually true under `gjsify build --app browser`: the public
+// API shape, types, and the documented browser constants.
+
+import { describe, it, expect } from '@gjsify/unit';
+import * as os from './browser.js';
+
+export default async () => {
+    await describe('os (browser): constants', async () => {
+        await it('EOL should be \\n', async () => {
+            expect(os.EOL).toBe('\n');
+        });
+
+        await it('devNull should be /dev/null', async () => {
+            expect(os.devNull).toBe('/dev/null');
+        });
+    });
+
+    await describe('os (browser): identity readings', async () => {
+        await it('platform() should be "browser"', async () => {
+            expect(os.platform()).toBe('browser');
+        });
+
+        await it('arch() should be "browser"', async () => {
+            expect(os.arch()).toBe('browser');
+        });
+
+        await it('type() should be "Browser"', async () => {
+            expect(os.type()).toBe('Browser');
+        });
+
+        await it('machine() should be "browser"', async () => {
+            expect(os.machine()).toBe('browser');
+        });
+
+        await it('release() should be an empty string', async () => {
+            expect(os.release()).toBe('');
+        });
+
+        await it('version() should be an empty string', async () => {
+            expect(os.version()).toBe('');
+        });
+    });
+
+    await describe('os (browser): paths', async () => {
+        await it('homedir() should be "/"', async () => {
+            expect(os.homedir()).toBe('/');
+        });
+
+        await it('hostname() should be "localhost"', async () => {
+            expect(os.hostname()).toBe('localhost');
+        });
+
+        await it('tmpdir() should be "/tmp"', async () => {
+            expect(os.tmpdir()).toBe('/tmp');
+        });
+    });
+
+    await describe('os (browser): endianness', async () => {
+        await it('should return BE or LE', async () => {
+            const endianness = os.endianness();
+            expect(endianness === 'BE' || endianness === 'LE').toBeTruthy();
+        });
+    });
+
+    await describe('os (browser): cpus / memory / load', async () => {
+        await it('cpus() should be an empty array', async () => {
+            const cpus = os.cpus();
+            expect(Array.isArray(cpus)).toBeTruthy();
+            expect(cpus.length).toBe(0);
+        });
+
+        await it('totalmem() should be 0', async () => {
+            expect(os.totalmem()).toBe(0);
+        });
+
+        await it('freemem() should be 0', async () => {
+            expect(os.freemem()).toBe(0);
+        });
+
+        await it('loadavg() should be [0, 0, 0]', async () => {
+            const avg = os.loadavg();
+            expect(avg.length).toBe(3);
+            expect(avg[0]).toBe(0);
+            expect(avg[1]).toBe(0);
+            expect(avg[2]).toBe(0);
+        });
+
+        await it('uptime() should be 0', async () => {
+            expect(os.uptime()).toBe(0);
+        });
+    });
+
+    await describe('os (browser): availableParallelism', async () => {
+        await it('should return a positive number', async () => {
+            const n = os.availableParallelism();
+            expect(typeof n).toBe('number');
+            expect(n > 0).toBeTruthy();
+        });
+    });
+
+    await describe('os (browser): userInfo', async () => {
+        await it('should describe the browser user', async () => {
+            const info = os.userInfo();
+            expect(info.uid).toBe(-1);
+            expect(info.gid).toBe(-1);
+            expect(info.username).toBe('browser');
+            expect(info.homedir).toBe('/');
+            expect(info.shell).toBe('');
+        });
+    });
+
+    await describe('os (browser): networkInterfaces', async () => {
+        await it('should return an empty object', async () => {
+            const ifaces = os.networkInterfaces();
+            expect(typeof ifaces).toBe('object');
+            expect(Object.keys(ifaces).length).toBe(0);
+        });
+    });
+
+    await describe('os (browser): priority no-ops', async () => {
+        await it('getPriority() should return 0', async () => {
+            expect(os.getPriority()).toBe(0);
+        });
+
+        await it('setPriority() should not throw', async () => {
+            const fn = () => os.setPriority(0, 0);
+            expect(fn).not.toThrow();
+        });
+    });
+
+    await describe('os (browser): constants shape', async () => {
+        await it('constants.signals should be an object', async () => {
+            expect(typeof os.constants.signals).toBe('object');
+        });
+
+        await it('constants.errno should be an object', async () => {
+            expect(typeof os.constants.errno).toBe('object');
+        });
+
+        await it('constants.UV_UDP_REUSEADDR should be a number', async () => {
+            expect(typeof os.constants.UV_UDP_REUSEADDR).toBe('number');
+        });
+
+        await it('constants.priority should expose the standard levels', async () => {
+            expect(os.constants.priority.PRIORITY_NORMAL).toBe(0);
+            expect(os.constants.priority.PRIORITY_LOW).toBe(19);
+            expect(os.constants.priority.PRIORITY_HIGHEST).toBe(-20);
+        });
+    });
+};

--- a/packages/node/os/src/test.browser.mts
+++ b/packages/node/os/src/test.browser.mts
@@ -1,0 +1,13 @@
+// Browser test entry for @gjsify/os — runs the reduced browser-target spec
+// (`index.browser.spec.ts`) under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+//
+// Unlike the standard `test.mts`, this does NOT re-export `index.spec.ts`: that
+// suite asserts host-OS-specific values (platform === 'linux', cpus().length >
+// 0, real memory readings, …) that cannot hold in a browser. The browser entry
+// (`./browser.ts`) returns constant 'browser'/0/[]/'localhost' values, so we
+// exercise it with a dedicated spec that only asserts what is true there.
+
+import { run } from '@gjsify/unit';
+import testSuite from './index.browser.spec.js';
+run({ testSuite });

--- a/packages/node/process/package.json
+++ b/packages/node/process/package.json
@@ -29,6 +29,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/process/src/index.browser.spec.ts
+++ b/packages/node/process/src/index.browser.spec.ts
@@ -1,0 +1,246 @@
+// Browser-target spec for @gjsify/process.
+//
+// The standard `index.spec.ts` / `extended.spec.ts` assert host-process values
+// (pid > 0, version starts with 'v', process.env.PATH defined, memoryUsage().rss
+// > 0, chdir() round-trips, EventEmitter actually emits, …) that only hold under
+// Node/GJS. The browser entry (`./browser.ts`) is the minimal defunctzombie-style
+// shim: pid/ppid are 0, version/env are empty, platform/arch are 'browser', cwd()
+// is '/', chdir()/exit()/abort() throw, the EventEmitter surface is a no-op, and
+// the stream stubs only expose a structural subset.
+//
+// This reduced spec imports the browser impl directly and asserts only what is
+// true under `gjsify build --app browser`.
+
+import { describe, it, expect } from '@gjsify/unit';
+import process from './browser.js';
+
+export default async () => {
+    await describe('process (browser): identity', async () => {
+        await it('platform should be "browser"', async () => {
+            expect(process.platform).toBe('browser');
+        });
+
+        await it('arch should be "browser"', async () => {
+            expect(process.arch).toBe('browser');
+        });
+
+        await it('browser flag should be true', async () => {
+            expect(process.browser).toBe(true);
+        });
+
+        await it('title should be "browser"', async () => {
+            expect(process.title).toBe('browser');
+        });
+
+        await it('pid should be 0', async () => {
+            expect(process.pid).toBe(0);
+        });
+
+        await it('ppid should be 0', async () => {
+            expect(process.ppid).toBe(0);
+        });
+
+        await it('version should be an empty string', async () => {
+            expect(process.version).toBe('');
+        });
+
+        await it('versions should be an empty object', async () => {
+            expect(typeof process.versions).toBe('object');
+            expect(Object.keys(process.versions).length).toBe(0);
+        });
+
+        await it('argv should be an empty array', async () => {
+            expect(Array.isArray(process.argv)).toBeTruthy();
+            expect(process.argv.length).toBe(0);
+        });
+
+        await it('execArgv should be an empty array', async () => {
+            expect(Array.isArray(process.execArgv)).toBeTruthy();
+            expect(process.execArgv.length).toBe(0);
+        });
+
+        await it('argv0 should be "browser"', async () => {
+            expect(process.argv0).toBe('browser');
+        });
+
+        await it('execPath should be an empty string', async () => {
+            expect(process.execPath).toBe('');
+        });
+
+        await it('config should be an object', async () => {
+            expect(typeof process.config).toBe('object');
+        });
+    });
+
+    await describe('process (browser): env', async () => {
+        await it('env should be an (empty) object', async () => {
+            expect(typeof process.env).toBe('object');
+            expect(Object.keys(process.env).length).toBe(0);
+        });
+
+        await it('should set, read and delete env variables', async () => {
+            process.env.TEST_GJSIFY_VAR = 'test_value';
+            expect(process.env.TEST_GJSIFY_VAR).toBe('test_value');
+            delete process.env.TEST_GJSIFY_VAR;
+            expect(process.env.TEST_GJSIFY_VAR).toBeUndefined();
+        });
+    });
+
+    await describe('process (browser): cwd / lifecycle', async () => {
+        await it('cwd() should return "/"', async () => {
+            expect(process.cwd()).toBe('/');
+        });
+
+        await it('umask() should return 0', async () => {
+            expect(process.umask()).toBe(0);
+        });
+
+        await it('chdir() should throw (unsupported)', async () => {
+            const fn = () => process.chdir('/tmp');
+            expect(fn).toThrow();
+        });
+
+        await it('exit() should throw (unsupported)', async () => {
+            const fn = () => process.exit(0);
+            expect(fn).toThrow();
+        });
+
+        await it('abort() should throw (unsupported)', async () => {
+            const fn = () => process.abort();
+            expect(fn).toThrow();
+        });
+
+        await it('kill() should return false', async () => {
+            expect(process.kill(0)).toBe(false);
+        });
+
+        await it('binding() should throw (unsupported)', async () => {
+            const fn = () => process.binding('os');
+            expect(fn).toThrow();
+        });
+    });
+
+    await describe('process (browser): timing', async () => {
+        await it('uptime() should be 0', async () => {
+            expect(process.uptime()).toBe(0);
+        });
+
+        await it('hrtime() should return [0, 0]', async () => {
+            const hr = process.hrtime();
+            expect(Array.isArray(hr)).toBeTruthy();
+            expect(hr.length).toBe(2);
+            expect(hr[0]).toBe(0);
+            expect(hr[1]).toBe(0);
+        });
+
+        await it('hrtime.bigint() should return 0n', async () => {
+            expect(process.hrtime.bigint()).toBe(0n);
+        });
+
+        await it('memoryUsage() should return zeroed fields', async () => {
+            const mem = process.memoryUsage();
+            expect(mem.rss).toBe(0);
+            expect(mem.heapTotal).toBe(0);
+            expect(mem.heapUsed).toBe(0);
+            expect(mem.external).toBe(0);
+        });
+
+        await it('cpuUsage() should return zeroed user/system', async () => {
+            const usage = process.cpuUsage();
+            expect(usage.user).toBe(0);
+            expect(usage.system).toBe(0);
+        });
+    });
+
+    await describe('process (browser): nextTick', async () => {
+        await it('should be a function', async () => {
+            expect(typeof process.nextTick).toBe('function');
+        });
+
+        await it('should be deferred, not synchronous', async () => {
+            let ranInNextTick = false;
+            process.nextTick(() => {
+                ranInNextTick = true;
+            });
+            const ranSynchronously = !ranInNextTick;
+            await new Promise<void>((resolve) => process.nextTick(resolve));
+            expect(ranSynchronously).toBeTruthy();
+            expect(ranInNextTick).toBeTruthy();
+        });
+
+        await it('should execute callbacks in FIFO order', async () => {
+            const order: number[] = [];
+            await new Promise<void>((resolve) => {
+                process.nextTick(() => order.push(1));
+                process.nextTick(() => order.push(2));
+                process.nextTick(() => {
+                    order.push(3);
+                    resolve();
+                });
+            });
+            expect(order[0]).toBe(1);
+            expect(order[1]).toBe(2);
+            expect(order[2]).toBe(3);
+        });
+
+        await it('should pass arguments to the callback', async () => {
+            const result = await new Promise<string>((resolve) => {
+                process.nextTick((a: string, b: string) => resolve(a + b), 'hello', ' world');
+            });
+            expect(result).toBe('hello world');
+        });
+    });
+
+    await describe('process (browser): streams', async () => {
+        await it('stdout/stderr/stdin should be defined', async () => {
+            expect(process.stdout).toBeDefined();
+            expect(process.stderr).toBeDefined();
+            expect(process.stdin).toBeDefined();
+        });
+
+        await it('stdout.write should be a function returning true', async () => {
+            expect(typeof process.stdout.write).toBe('function');
+            expect(process.stdout.write('')).toBe(true);
+        });
+
+        await it('stderr.write should be a function', async () => {
+            expect(typeof process.stderr.write).toBe('function');
+        });
+
+        await it('streams should report isTTY === false', async () => {
+            expect(process.stdout.isTTY).toBe(false);
+            expect(process.stderr.isTTY).toBe(false);
+            expect(process.stdin.isTTY).toBe(false);
+        });
+    });
+
+    await describe('process (browser): EventEmitter no-op surface', async () => {
+        await it('should expose the listener registration methods', async () => {
+            expect(typeof process.on).toBe('function');
+            expect(typeof process.once).toBe('function');
+            expect(typeof process.off).toBe('function');
+            expect(typeof process.emit).toBe('function');
+            expect(typeof process.removeListener).toBe('function');
+            expect(typeof process.removeAllListeners).toBe('function');
+        });
+
+        await it('emit() should return false (never fires)', async () => {
+            expect(process.emit('test-event')).toBe(false);
+        });
+
+        await it('listeners() should return an empty array', async () => {
+            process.on('test-event', () => {});
+            expect(process.listeners('test-event').length).toBe(0);
+        });
+
+        await it('listenerCount() should return 0', async () => {
+            expect(process.listenerCount('test-event')).toBe(0);
+        });
+    });
+
+    await describe('process (browser): misc functions', async () => {
+        await it('emitWarning should be a function', async () => {
+            expect(typeof process.emitWarning).toBe('function');
+        });
+    });
+};

--- a/packages/node/process/src/test.browser.mts
+++ b/packages/node/process/src/test.browser.mts
@@ -1,0 +1,14 @@
+// Browser test entry for @gjsify/process — runs the reduced browser-target spec
+// (`index.browser.spec.ts`) under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+//
+// Unlike the standard `test.mts`, this does NOT re-export `index.spec.ts` /
+// `extended.spec.ts`: those suites assert host-process values (pid > 0, version
+// starting with 'v', process.env.PATH, real memoryUsage, working chdir, a live
+// EventEmitter, …) that cannot hold in a browser. The browser entry
+// (`./browser.ts`) is the minimal defunctzombie-style shim, so we exercise it
+// with a dedicated spec that only asserts what is true there.
+
+import { run } from '@gjsify/unit';
+import testSuite from './index.browser.spec.js';
+run({ testSuite });


### PR DESCRIPTION
Adds browser-target test entries for `@gjsify/process` and `@gjsify/os`, mirroring the `packages/node/buffer/src/test.browser.mts` pattern.

Both packages ship a `browser.ts` entry whose readings are intentionally constant for a browser runtime (no POSIX uname / sysctl / /proc surface, no process model). The standard specs assert host-specific values (`process.platform === 'linux'`, `os.cpus().length > 0`, real memory readings, a live EventEmitter, working `chdir`, …) that cannot hold in a browser, so each package gets a dedicated **reduced** browser spec rather than re-exporting the host spec:

- `src/index.browser.spec.ts` imports the browser impl directly (`./browser.js`) and asserts only what is true under `gjsify build --app browser` (e.g. `platform === 'browser'`, `cpus()` is `[]`, `totalmem()` is `0`, `process.pid === 0`, the no-op EventEmitter surface, the documented constants and stubs).
- `src/test.browser.mts` runs that spec via `@gjsify/unit`.
- `build:test:browser` script added to each `package.json`.

`dist/` is gitignored, so only the source files and `package.json` script entries are committed.

### Verification
- `tsc --noEmit` clean for both packages.
- Browser bundles build via `gjsify build --app browser` (process: 65 assertions, os: 38 assertions — all pass when run).
- Standard node tests still build and pass (process: 148, os: 276).
- `audit-runtimes --check`: OK.