### PR TITLE
test(node): add browser test entries for async_hooks/diagnostics_channel/sys

### DIFF
--- a/packages/node/async_hooks/package.json
+++ b/packages/node/async_hooks/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/async_hooks/src/test.browser.mts
+++ b/packages/node/async_hooks/src/test.browser.mts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/async_hooks — re-exports the standard test.mts
+// suite so the existing assertions also run under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+//
+// The impl is platform-neutral pure-TS (AsyncLocalStorage / AsyncResource /
+// createHook over plain JS), so the same spec exercises both runtimes. The
+// browser-target alias layer (`ALIASES_NODE_FOR_BROWSER`) routes
+// `node:async_hooks` → `@gjsify/async_hooks` so the spec's imports resolve
+// transparently.
+
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/diagnostics_channel/package.json
+++ b/packages/node/diagnostics_channel/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/diagnostics_channel/src/test.browser.mts
+++ b/packages/node/diagnostics_channel/src/test.browser.mts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/diagnostics_channel — re-exports the standard
+// test.mts suite so the existing assertions also run under
+// `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+//
+// The impl is platform-neutral pure-TS (Channel / TracingChannel over plain
+// JS), so the same spec exercises both runtimes. The browser-target alias
+// layer (`ALIASES_NODE_FOR_BROWSER`) routes `node:diagnostics_channel` →
+// `@gjsify/diagnostics_channel` so the spec's imports resolve transparently.
+
+export * from './test.mjs';
+import './test.mjs';

--- a/packages/node/sys/package.json
+++ b/packages/node/sys/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/sys/src/test.browser.mts
+++ b/packages/node/sys/src/test.browser.mts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/sys — re-exports the standard test.mts suite
+// so the existing assertions also run under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+//
+// The impl is platform-neutral pure-TS (the deprecated util alias over plain
+// JS), so the same spec exercises both runtimes. The browser-target alias
+// layer (`ALIASES_NODE_FOR_BROWSER`) routes `node:sys` → `@gjsify/sys` so the
+// spec's imports resolve transparently.
+
+export * from './test.mjs';
+import './test.mjs';


### PR DESCRIPTION
Adds a `src/test.browser.mts` browser test entry and a `build:test:browser` script to `@gjsify/async_hooks`, `@gjsify/diagnostics_channel`, and `@gjsify/sys`, mirroring the `@gjsify/buffer` exemplar. Each re-exports its existing `test.mts` suite so the same assertions run under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey); all three are platform-neutral pure-TS and their browser bundles build cleanly and run every test. `stream` and `domain` were not included because their browser bundles fail to load (unresolvable `abort-controller/register` and an eagerly-executed GJS `imports.byteArray` access, respectively).