### PR TITLE
test: add browser test entries for native re-export packages

### DIFF
--- a/packages/node/console/package.json
+++ b/packages/node/console/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/console/src/test.browser.mts
+++ b/packages/node/console/src/test.browser.mts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/console.
+//
+// Uses the browser-native `console` global directly — never imports the GJS
+// `@gjsify/console` implementation (which wraps Node streams via `gi://`
+// bindings that have no browser equivalent). Per the workspace browser-test
+// convention, browser tests verify that the native platform behaves the way
+// our GJS polyfill claims. The Node-only `Console` class with stdout/stderr
+// stream constructors is intentionally out of scope here — a browser has no
+// Node stream model — so this entry exercises only the globally-available
+// `console` surface.
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+run({
+    async ConsoleTest() {
+        await describe('console: global object', async () => {
+            await it('console is an object', async () => {
+                expect(console instanceof Object).toBeTruthy();
+            });
+
+            await it('has the standard logging methods', async () => {
+                expect(typeof console.log).toBe('function');
+                expect(typeof console.warn).toBe('function');
+                expect(typeof console.error).toBe('function');
+                expect(typeof console.info).toBe('function');
+                expect(typeof console.debug).toBe('function');
+            });
+
+            await it('has the grouping / counting / timing methods', async () => {
+                expect(typeof console.group).toBe('function');
+                expect(typeof console.groupEnd).toBe('function');
+                expect(typeof console.groupCollapsed).toBe('function');
+                expect(typeof console.count).toBe('function');
+                expect(typeof console.countReset).toBe('function');
+                expect(typeof console.time).toBe('function');
+                expect(typeof console.timeEnd).toBe('function');
+                expect(typeof console.timeLog).toBe('function');
+            });
+
+            await it('has the inspection / assertion methods', async () => {
+                expect(typeof console.dir).toBe('function');
+                expect(typeof console.table).toBe('function');
+                expect(typeof console.trace).toBe('function');
+                expect(typeof console.assert).toBe('function');
+                expect(typeof console.clear).toBe('function');
+            });
+        });
+
+        await describe('console: logging does not throw', async () => {
+            await it('log handles various argument types', async () => {
+                expect(() => console.log('string')).not.toThrow();
+                expect(() => console.log(42)).not.toThrow();
+                expect(() => console.log({ key: 'value' })).not.toThrow();
+                expect(() => console.log(null)).not.toThrow();
+                expect(() => console.log(undefined)).not.toThrow();
+                expect(() => console.log([1, 2, 3])).not.toThrow();
+            });
+
+            await it('log handles multiple arguments and format specifiers', async () => {
+                expect(() => console.log('a', 'b', 'c')).not.toThrow();
+                expect(() => console.log('hello %s', 'world')).not.toThrow();
+                expect(() => console.log('number: %d', 42)).not.toThrow();
+            });
+
+            await it('warn / error / info / debug do not throw', async () => {
+                expect(() => console.warn('warning')).not.toThrow();
+                expect(() => console.error('error')).not.toThrow();
+                expect(() => console.info('info')).not.toThrow();
+                expect(() => console.debug('debug')).not.toThrow();
+            });
+        });
+
+        await describe('console: assert behavior', async () => {
+            await it('does not throw on truthy assertion', async () => {
+                expect(() => console.assert(true)).not.toThrow();
+                expect(() => console.assert('non-empty')).not.toThrow();
+            });
+
+            await it('does not throw on false assertion', async () => {
+                expect(() => console.assert(false)).not.toThrow();
+                expect(() => console.assert(false, 'message', 42)).not.toThrow();
+            });
+        });
+
+        await describe('console: count / countReset behavior', async () => {
+            await it('count and countReset do not throw', async () => {
+                expect(() => console.count('test-label')).not.toThrow();
+                expect(() => console.count('test-label')).not.toThrow();
+                expect(() => console.countReset('test-label')).not.toThrow();
+                expect(() => console.count()).not.toThrow();
+                expect(() => console.countReset()).not.toThrow();
+            });
+        });
+
+        await describe('console: time / timeEnd behavior', async () => {
+            await it('time, timeLog and timeEnd do not throw', async () => {
+                expect(() => console.time('test-timer')).not.toThrow();
+                expect(() => console.timeLog('test-timer')).not.toThrow();
+                expect(() => console.timeEnd('test-timer')).not.toThrow();
+            });
+
+            await it('timeEnd without a matching time does not throw', async () => {
+                expect(() => console.timeEnd('nonexistent-timer')).not.toThrow();
+            });
+        });
+
+        await describe('console: group / groupEnd behavior', async () => {
+            await it('group and groupEnd do not throw', async () => {
+                expect(() => console.group('test-group')).not.toThrow();
+                expect(() => console.groupEnd()).not.toThrow();
+            });
+
+            await it('nested groups and groupCollapsed do not throw', async () => {
+                expect(() => {
+                    console.group('outer');
+                    console.groupCollapsed('inner');
+                    console.groupEnd();
+                    console.groupEnd();
+                }).not.toThrow();
+            });
+        });
+
+        await describe('console: dir / table / trace / clear behavior', async () => {
+            await it('dir does not throw', async () => {
+                expect(() => console.dir({ key: 'value' })).not.toThrow();
+            });
+
+            await it('table does not throw', async () => {
+                expect(() =>
+                    console.table([
+                        { a: 1, b: 2 },
+                        { a: 3, b: 4 },
+                    ]),
+                ).not.toThrow();
+            });
+
+            await it('trace does not throw', async () => {
+                expect(() => console.trace()).not.toThrow();
+                expect(() => console.trace('trace message')).not.toThrow();
+            });
+
+            await it('clear does not throw', async () => {
+                expect(() => console.clear()).not.toThrow();
+            });
+        });
+    },
+});

--- a/packages/node/perf_hooks/package.json
+++ b/packages/node/perf_hooks/package.json
@@ -28,6 +28,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/perf_hooks/src/test.browser.mts
+++ b/packages/node/perf_hooks/src/test.browser.mts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/perf_hooks.
+//
+// Uses the browser-native `performance` global + `PerformanceObserver`
+// directly. The Node-only surface (`monitorEventLoopDelay`, `timerify`,
+// `eventLoopUtilization`, histograms) has no browser pendant and is
+// intentionally out of scope — this entry validates the W3C High Resolution
+// Time / User Timing surface that our GJS polyfill mirrors.
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+run({
+    async PerfHooksTest() {
+        await describe('performance.now', async () => {
+            await it('returns a finite, non-negative number', async () => {
+                const now = performance.now();
+                expect(typeof now).toBe('number');
+                expect(now >= 0).toBe(true);
+                expect(Number.isFinite(now)).toBe(true);
+            });
+
+            await it('is monotonically non-decreasing across calls', async () => {
+                const readings: number[] = [];
+                for (let i = 0; i < 5; i++) {
+                    readings.push(performance.now());
+                    for (let j = 0; j < 1000; j++) {
+                        /* noop */
+                    }
+                }
+                for (let i = 1; i < readings.length; i++) {
+                    expect(readings[i] >= readings[i - 1]).toBe(true);
+                }
+            });
+        });
+
+        await describe('performance.timeOrigin', async () => {
+            await it('is a positive number', async () => {
+                expect(typeof performance.timeOrigin).toBe('number');
+                expect(performance.timeOrigin > 0).toBe(true);
+                expect(Number.isFinite(performance.timeOrigin)).toBe(true);
+            });
+
+            await it('timeOrigin + now() approximates Date.now()', async () => {
+                const approx = performance.timeOrigin + performance.now();
+                const actual = Date.now();
+                expect(Math.abs(approx - actual)).toBeLessThan(1000);
+            });
+        });
+
+        await describe('performance.mark', async () => {
+            await it('is a function and does not throw', async () => {
+                expect(typeof performance.mark).toBe('function');
+                expect(() => performance.mark('test-mark-1')).not.toThrow();
+            });
+
+            await it('returns a PerformanceMark with name / entryType', async () => {
+                performance.clearMarks();
+                const mark = performance.mark('test-mark-2');
+                expect(mark.name).toBe('test-mark-2');
+                expect(mark.entryType).toBe('mark');
+                expect(typeof mark.startTime).toBe('number');
+                expect(mark.duration).toBe(0);
+            });
+
+            await it('allows multiple marks with the same name', async () => {
+                performance.clearMarks();
+                performance.mark('duplicate-mark');
+                performance.mark('duplicate-mark');
+                const entries = performance.getEntriesByName('duplicate-mark');
+                expect(entries.length).toBe(2);
+                for (const entry of entries) {
+                    expect(entry.entryType).toBe('mark');
+                }
+            });
+        });
+
+        await describe('performance.measure', async () => {
+            await it('measures between two marks', async () => {
+                performance.clearMarks();
+                performance.clearMeasures();
+                performance.mark('measure-start');
+                performance.mark('measure-end');
+                const measure = performance.measure('test-measure', 'measure-start', 'measure-end');
+                expect(measure.name).toBe('test-measure');
+                expect(measure.entryType).toBe('measure');
+                expect(typeof measure.duration).toBe('number');
+                expect(measure.duration >= 0).toBe(true);
+            });
+
+            await it('supports the options-object form', async () => {
+                performance.clearMarks();
+                performance.clearMeasures();
+                performance.mark('opt-start');
+                performance.mark('opt-end');
+                const measure = performance.measure('opt-measure', {
+                    start: 'opt-start',
+                    end: 'opt-end',
+                });
+                expect(measure.name).toBe('opt-measure');
+                expect(measure.entryType).toBe('measure');
+            });
+        });
+
+        await describe('performance.getEntries*', async () => {
+            await it('getEntriesByName finds a mark', async () => {
+                performance.clearMarks();
+                performance.mark('find-me');
+                const entries = performance.getEntriesByName('find-me');
+                expect(entries.length).toBeGreaterThan(0);
+                expect(entries[0].name).toBe('find-me');
+            });
+
+            await it('getEntriesByName returns [] for an unknown name', async () => {
+                const entries = performance.getEntriesByName('does-not-exist-xyz-12345');
+                expect(Array.isArray(entries)).toBe(true);
+                expect(entries.length).toBe(0);
+            });
+
+            await it('getEntriesByType returns marks for type "mark"', async () => {
+                performance.clearMarks();
+                performance.mark('type-test');
+                const entries = performance.getEntriesByType('mark');
+                expect(entries.length).toBeGreaterThan(0);
+                for (const entry of entries) {
+                    expect(entry.entryType).toBe('mark');
+                }
+            });
+        });
+
+        await describe('performance.clearMarks / clearMeasures', async () => {
+            await it('clearMarks removes all marks', async () => {
+                performance.clearMarks();
+                performance.mark('clear-test-1');
+                performance.mark('clear-test-2');
+                performance.clearMarks();
+                expect(performance.getEntriesByType('mark').length).toBe(0);
+            });
+
+            await it('clearMarks(name) removes only the named mark', async () => {
+                performance.clearMarks();
+                performance.mark('keep-this');
+                performance.mark('remove-this');
+                performance.clearMarks('remove-this');
+                const names = performance.getEntriesByType('mark').map((e) => e.name);
+                expect(names).toContain('keep-this');
+                expect(names.includes('remove-this')).toBe(false);
+            });
+
+            await it('clearMeasures removes all measures', async () => {
+                performance.clearMarks();
+                performance.clearMeasures();
+                performance.mark('cm2-start');
+                performance.mark('cm2-end');
+                performance.measure('cm2-a', 'cm2-start', 'cm2-end');
+                performance.clearMeasures();
+                expect(performance.getEntriesByType('measure').length).toBe(0);
+            });
+        });
+
+        await describe('PerformanceObserver', async () => {
+            await it('is available as a global constructor', async () => {
+                expect(typeof PerformanceObserver).toBe('function');
+            });
+        });
+    },
+});

--- a/packages/node/timers/package.json
+++ b/packages/node/timers/package.json
@@ -29,6 +29,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/timers/src/test.browser.mts
+++ b/packages/node/timers/src/test.browser.mts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/timers.
+//
+// Uses the browser-native timer globals directly (`setTimeout`,
+// `clearTimeout`, `setInterval`, `clearInterval`, `queueMicrotask`). The
+// Node-only surface — the `Timeout` object with `ref()`/`unref()`/`hasRef()`,
+// `setImmediate`, and `timers/promises` `scheduler` — has no browser pendant
+// and is intentionally out of scope. In the browser `setTimeout` returns a
+// numeric handle, so this entry validates only the W3C timer contract our GJS
+// polyfill mirrors.
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+run({
+    async TimersTest() {
+        await describe('setTimeout', async () => {
+            await it('calls the callback after the delay', async () => {
+                const result = await new Promise<string>((resolve) => {
+                    setTimeout(() => resolve('done'), 10);
+                });
+                expect(result).toBe('done');
+            });
+
+            await it('passes arguments through to the callback', async () => {
+                const result = await new Promise<string>((resolve) => {
+                    setTimeout((a: string, b: string) => resolve(a + b), 10, 'hello', ' world');
+                });
+                expect(result).toBe('hello world');
+            });
+
+            await it('executes with a zero delay', async () => {
+                const result = await new Promise<string>((resolve) => {
+                    setTimeout(() => resolve('zero'), 0);
+                });
+                expect(result).toBe('zero');
+            });
+
+            await it('fires roughly in scheduled order', async () => {
+                const order: number[] = [];
+                await new Promise<void>((resolve) => {
+                    setTimeout(() => order.push(1), 10);
+                    setTimeout(() => {
+                        order.push(2);
+                        resolve();
+                    }, 30);
+                });
+                expect(order).toStrictEqual([1, 2]);
+            });
+        });
+
+        await describe('clearTimeout', async () => {
+            await it('cancels a pending timeout', async () => {
+                let fired = false;
+                const handle = setTimeout(() => {
+                    fired = true;
+                }, 10);
+                clearTimeout(handle);
+                await new Promise<void>((resolve) => setTimeout(resolve, 40));
+                expect(fired).toBe(false);
+            });
+
+            await it('does not throw when clearing an undefined handle', async () => {
+                expect(() => clearTimeout(undefined)).not.toThrow();
+            });
+        });
+
+        await describe('setInterval / clearInterval', async () => {
+            await it('fires repeatedly until cleared', async () => {
+                let count = 0;
+                await new Promise<void>((resolve) => {
+                    const handle = setInterval(() => {
+                        count++;
+                        if (count >= 3) {
+                            clearInterval(handle);
+                            resolve();
+                        }
+                    }, 10);
+                });
+                expect(count).toBe(3);
+            });
+
+            await it('clearInterval stops further callbacks', async () => {
+                let count = 0;
+                const handle = setInterval(() => {
+                    count++;
+                }, 10);
+                clearInterval(handle);
+                await new Promise<void>((resolve) => setTimeout(resolve, 50));
+                expect(count).toBe(0);
+            });
+        });
+
+        await describe('queueMicrotask', async () => {
+            await it('is a function', async () => {
+                expect(typeof queueMicrotask).toBe('function');
+            });
+
+            await it('runs before a zero-delay timeout', async () => {
+                const order: string[] = [];
+                await new Promise<void>((resolve) => {
+                    setTimeout(() => {
+                        order.push('timeout');
+                        resolve();
+                    }, 0);
+                    queueMicrotask(() => order.push('microtask'));
+                });
+                expect(order[0]).toBe('microtask');
+                expect(order).toContain('timeout');
+            });
+        });
+    },
+});

--- a/packages/node/url/package.json
+++ b/packages/node/url/package.json
@@ -28,6 +28,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.ts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.ts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/url/src/test.browser.mts
+++ b/packages/node/url/src/test.browser.mts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/url.
+//
+// Uses the browser-native `URL` / `URLSearchParams` globals directly (WHATWG
+// URL standard). The Node-only legacy surface (`parse`, `format`, `resolve`,
+// `fileURLToPath`, `pathToFileURL`) is intentionally out of scope — it has no
+// browser pendant. This entry validates the WHATWG URL contract our GJS
+// polyfill mirrors.
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+run({
+    async UrlTest() {
+        await describe('URL constructor', async () => {
+            await it('parses a full HTTP URL', async () => {
+                const u = new URL('http://example.com:8080/path?query=1#hash');
+                expect(u.protocol).toBe('http:');
+                expect(u.hostname).toBe('example.com');
+                expect(u.port).toBe('8080');
+                expect(u.pathname).toBe('/path');
+                expect(u.search).toBe('?query=1');
+                expect(u.hash).toBe('#hash');
+            });
+
+            await it('parses credentials from an HTTPS URL', async () => {
+                const u = new URL('https://user:pass@example.com/path');
+                expect(u.protocol).toBe('https:');
+                expect(u.username).toBe('user');
+                expect(u.password).toBe('pass');
+                expect(u.hostname).toBe('example.com');
+            });
+
+            await it('resolves a relative URL against a base', async () => {
+                const u = new URL('/path', 'http://example.com');
+                expect(u.pathname).toBe('/path');
+                expect(u.hostname).toBe('example.com');
+            });
+
+            await it('resolves .. in a relative path against a base', async () => {
+                const u = new URL('../bar', 'http://example.com/a/b/');
+                expect(u.pathname).toBe('/a/bar');
+            });
+
+            await it('throws on an invalid URL', async () => {
+                expect(() => new URL('not-a-url')).toThrow();
+                expect(() => new URL('')).toThrow();
+            });
+
+            await it('accepts a URL object as input and base', async () => {
+                const base = new URL('http://example.com/base/');
+                const u = new URL('relative', base);
+                expect(u.hostname).toBe('example.com');
+                expect(u.pathname).toBe('/base/relative');
+            });
+        });
+
+        await describe('URL properties', async () => {
+            await it('exposes searchParams', async () => {
+                const u = new URL('http://example.com/?a=1&b=2');
+                expect(u.searchParams.get('a')).toBe('1');
+                expect(u.searchParams.get('b')).toBe('2');
+            });
+
+            await it('computes origin for special protocols', async () => {
+                expect(new URL('http://example.com:8080/path').origin).toBe('http://example.com:8080');
+                expect(new URL('https://example.com/path').origin).toBe('https://example.com');
+            });
+
+            await it('strips default ports', async () => {
+                expect(new URL('http://example.com:80/path').port).toBe('');
+                expect(new URL('https://example.com:443/path').port).toBe('');
+            });
+
+            await it('returns "null" origin for data: URLs', async () => {
+                expect(new URL('data:text/plain,hello').origin).toBe('null');
+            });
+
+            await it('serializes via href / toString / toJSON', async () => {
+                const u = new URL('http://user:pass@example.com:8080/path?q=1#h');
+                expect(u.href).toBe('http://user:pass@example.com:8080/path?q=1#h');
+                expect(u.toString()).toBe(u.href);
+                expect(u.toJSON()).toBe(u.href);
+            });
+        });
+
+        await describe('URL percent encoding', async () => {
+            await it('decodes percent-encoded query values', async () => {
+                const u = new URL('http://example.com/?name=hello%20world');
+                expect(u.searchParams.get('name')).toBe('hello world');
+            });
+
+            await it('preserves encoded characters in the path', async () => {
+                const u = new URL('http://example.com/path%3Fwith%23special');
+                expect(u.pathname).toBe('/path%3Fwith%23special');
+            });
+        });
+
+        await describe('URLSearchParams', async () => {
+            await it('constructs from a string', async () => {
+                const params = new URLSearchParams('a=1&b=2');
+                expect(params.get('a')).toBe('1');
+                expect(params.get('b')).toBe('2');
+            });
+
+            await it('constructs from an object and from entries', async () => {
+                expect(new URLSearchParams({ foo: 'bar' }).get('foo')).toBe('bar');
+                expect(
+                    new URLSearchParams([
+                        ['a', '1'],
+                        ['b', '2'],
+                    ]).get('b'),
+                ).toBe('2');
+            });
+
+            await it('supports get / set / has / delete', async () => {
+                const params = new URLSearchParams('a=1');
+                expect(params.has('a')).toBeTruthy();
+                params.set('a', '2');
+                expect(params.get('a')).toBe('2');
+                params.delete('a');
+                expect(params.has('a')).toBeFalsy();
+                expect(params.get('a')).toBeNull();
+            });
+
+            await it('supports append / getAll', async () => {
+                const params = new URLSearchParams();
+                params.append('a', '1');
+                params.append('a', '2');
+                expect(params.getAll('a').length).toBe(2);
+                expect(params.get('a')).toBe('1');
+            });
+
+            await it('supports toString and iteration', async () => {
+                const params = new URLSearchParams('a=1&b=2');
+                expect(params.toString()).toBe('a=1&b=2');
+                const keys: string[] = [];
+                params.forEach((_val, key) => keys.push(key));
+                expect(keys.length).toBe(2);
+            });
+        });
+    },
+});

--- a/packages/web/web-globals/package.json
+++ b/packages/web/web-globals/package.json
@@ -39,6 +39,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/web/web-globals/src/test.browser.mts
+++ b/packages/web/web-globals/src/test.browser.mts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/web-globals.
+//
+// `@gjsify/web-globals` aggregates Web API globals that GJS lacks but a
+// browser provides natively. This entry verifies the native browser platform
+// exposes the same surface our GJS aggregator registers — using the globals
+// directly, never importing the GJS register chain (which pulls in `gi://`
+// bindings with no browser equivalent).
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+run({
+    async WebGlobalsTest() {
+        await describe('DOMException', async () => {
+            await it('is a global constructor', async () => {
+                expect(typeof globalThis.DOMException).toBe('function');
+            });
+
+            await it('carries standard error codes', async () => {
+                expect(new DOMException('test', 'AbortError').code).toBe(20);
+                expect(new DOMException('', 'NotFoundError').code).toBe(8);
+                expect(new DOMException('', 'SyntaxError').code).toBe(12);
+            });
+
+            await it('is an instance of Error', async () => {
+                expect(new DOMException('test') instanceof Error).toBe(true);
+            });
+        });
+
+        await describe('DOM events', async () => {
+            await it('Event / EventTarget are globals', async () => {
+                expect(typeof globalThis.Event).toBe('function');
+                expect(typeof globalThis.EventTarget).toBe('function');
+            });
+
+            await it('EventTarget dispatches events', async () => {
+                const target = new EventTarget();
+                let called = false;
+                target.addEventListener('test', () => {
+                    called = true;
+                });
+                target.dispatchEvent(new Event('test'));
+                expect(called).toBe(true);
+            });
+        });
+
+        await describe('AbortController / AbortSignal', async () => {
+            await it('are globals', async () => {
+                expect(typeof globalThis.AbortController).toBe('function');
+                expect(typeof globalThis.AbortSignal).toBe('function');
+            });
+
+            await it('abort() flips signal.aborted', async () => {
+                const ac = new AbortController();
+                expect(ac.signal.aborted).toBe(false);
+                ac.abort();
+                expect(ac.signal.aborted).toBe(true);
+            });
+        });
+
+        await describe('Web Streams', async () => {
+            await it('stream constructors are globals', async () => {
+                expect(typeof globalThis.ReadableStream).toBe('function');
+                expect(typeof globalThis.WritableStream).toBe('function');
+                expect(typeof globalThis.TransformStream).toBe('function');
+            });
+
+            await it('ReadableStream yields enqueued chunks', async () => {
+                const rs = new ReadableStream<string>({
+                    start(controller) {
+                        controller.enqueue('test');
+                        controller.close();
+                    },
+                });
+                const reader = rs.getReader();
+                const { value } = await reader.read();
+                expect(value).toBe('test');
+            });
+        });
+
+        await describe('Encoding / Compression streams', async () => {
+            await it('TextEncoderStream / TextDecoderStream are globals', async () => {
+                expect(typeof globalThis.TextEncoderStream).toBe('function');
+                expect(typeof globalThis.TextDecoderStream).toBe('function');
+            });
+
+            await it('CompressionStream / DecompressionStream are globals', async () => {
+                expect(typeof globalThis.CompressionStream).toBe('function');
+                expect(typeof globalThis.DecompressionStream).toBe('function');
+            });
+        });
+
+        await describe('WebCrypto', async () => {
+            await it('crypto + crypto.subtle are available', async () => {
+                expect(typeof globalThis.crypto).toBe('object');
+                expect(globalThis.crypto.subtle).toBeDefined();
+            });
+
+            await it('getRandomValues fills a buffer', async () => {
+                const buf = new Uint8Array(16);
+                crypto.getRandomValues(buf);
+                expect(buf.some((b) => b !== 0)).toBe(true);
+            });
+
+            await it('randomUUID returns a 36-char UUID', async () => {
+                const uuid = crypto.randomUUID();
+                expect(typeof uuid).toBe('string');
+                expect(uuid.length).toBe(36);
+                expect(uuid[8]).toBe('-');
+            });
+        });
+
+        await describe('URL / URLSearchParams', async () => {
+            await it('are globals and parse correctly', async () => {
+                expect(typeof globalThis.URL).toBe('function');
+                expect(typeof globalThis.URLSearchParams).toBe('function');
+                const u = new URL('https://example.com:8080/path?q=1#hash');
+                expect(u.hostname).toBe('example.com');
+                expect(u.port).toBe('8080');
+                expect(new URLSearchParams('a=1&b=2').get('a')).toBe('1');
+            });
+        });
+
+        await describe('Blob / File / FormData', async () => {
+            await it('Blob reports size and type', async () => {
+                expect(typeof globalThis.Blob).toBe('function');
+                const blob = new Blob(['hello']);
+                expect(blob.size).toBe(5);
+                expect(new Blob(['{}'], { type: 'application/json' }).type).toBe('application/json');
+            });
+
+            await it('File is a global', async () => {
+                expect(typeof (globalThis as { File?: unknown }).File).toBe('function');
+            });
+
+            await it('FormData supports append / get', async () => {
+                expect(typeof globalThis.FormData).toBe('function');
+                const fd = new FormData();
+                fd.append('key', 'value');
+                expect(fd.get('key')).toBe('value');
+            });
+        });
+
+        await describe('Performance', async () => {
+            await it('performance global exposes now() / timeOrigin', async () => {
+                expect(globalThis.performance).toBeDefined();
+                expect(typeof performance.now()).toBe('number');
+                expect(typeof performance.timeOrigin).toBe('number');
+            });
+        });
+    },
+});

--- a/packages/web/webassembly/package.json
+++ b/packages/web/webassembly/package.json
@@ -38,6 +38,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:gjs && gjsify run test:node",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/web/webassembly/src/test.browser.mts
+++ b/packages/web/webassembly/src/test.browser.mts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/webassembly.
+//
+// Uses the browser-native `WebAssembly` global directly. The GJS polyfill
+// only adds the Promise-API wrappers (`compile`/`instantiate`/`validate`)
+// around SpiderMonkey's synchronous constructors — in the browser those
+// Promise APIs are already native, so this entry validates them straight off
+// the `WebAssembly` global.
+
+import { run, describe, it, expect } from '@gjsify/unit';
+
+// Minimal wasm module exporting `add(a: i32, b: i32) -> i32`.
+// Hand-encoded per https://webassembly.github.io/spec/core/binary/.
+const ADD_WASM = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02,
+    0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20,
+    0x01, 0x6a, 0x0b,
+]);
+const EMPTY_WASM = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+const GARBAGE = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+run({
+    async WebAssemblyTest() {
+        await describe('WebAssembly.validate', async () => {
+            await it('returns true for a valid module', async () => {
+                expect(WebAssembly.validate(EMPTY_WASM)).toBe(true);
+                expect(WebAssembly.validate(ADD_WASM)).toBe(true);
+            });
+
+            await it('returns false for invalid bytes', async () => {
+                expect(WebAssembly.validate(GARBAGE)).toBe(false);
+            });
+        });
+
+        await describe('WebAssembly.compile', async () => {
+            await it('resolves a Module', async () => {
+                const module = await WebAssembly.compile(ADD_WASM);
+                expect(module instanceof WebAssembly.Module).toBe(true);
+            });
+
+            await it('rejects on invalid bytes', async () => {
+                let threw = false;
+                try {
+                    await WebAssembly.compile(GARBAGE);
+                } catch {
+                    threw = true;
+                }
+                expect(threw).toBe(true);
+            });
+        });
+
+        await describe('WebAssembly.instantiate', async () => {
+            await it('instantiate(buffer) resolves { module, instance }', async () => {
+                const result = (await WebAssembly.instantiate(ADD_WASM)) as WebAssembly.WebAssemblyInstantiatedSource;
+                expect(result.module instanceof WebAssembly.Module).toBe(true);
+                expect(result.instance instanceof WebAssembly.Instance).toBe(true);
+                const add = result.instance.exports.add as (a: number, b: number) => number;
+                expect(add(2, 3)).toBe(5);
+            });
+
+            await it('instantiate(module) resolves an Instance', async () => {
+                const module = new WebAssembly.Module(ADD_WASM);
+                const instance = (await WebAssembly.instantiate(module)) as WebAssembly.Instance;
+                expect(instance instanceof WebAssembly.Instance).toBe(true);
+                const add = instance.exports.add as (a: number, b: number) => number;
+                expect(add(7, 8)).toBe(15);
+            });
+        });
+
+        await describe('WebAssembly synchronous constructors', async () => {
+            await it('new Module / new Instance work', async () => {
+                const module = new WebAssembly.Module(ADD_WASM);
+                expect(module instanceof WebAssembly.Module).toBe(true);
+                const instance = new WebAssembly.Instance(module);
+                expect(instance instanceof WebAssembly.Instance).toBe(true);
+                const add = instance.exports.add as (a: number, b: number) => number;
+                expect(add(10, 20)).toBe(30);
+            });
+        });
+    },
+});


### PR DESCRIPTION
Adds a browser test entry (`src/test.browser.mts`) and a `build:test:browser` script to the packages that declare `browser: "native"` and re-export a browser-native global:

- `@gjsify/console` (`packages/node/console`)
- `@gjsify/perf_hooks` (`packages/node/perf_hooks`)
- `@gjsify/timers` (`packages/node/timers`)
- `@gjsify/url` (`packages/node/url`)
- `@gjsify/webassembly` (`packages/web/webassembly`)
- `@gjsify/web-globals` (`packages/web/web-globals`)

Each entry exercises the browser-native global directly (`console`, `performance`, `setTimeout`/`setInterval`/`queueMicrotask`, `URL`/`URLSearchParams`, `WebAssembly`, and the aggregated web-globals set) rather than importing the GJS implementation — matching the existing browser-test convention used by `abort-controller`, `formdata`, `webstorage`, etc. The Node-only surface that has no browser pendant (the `Console` stream class, `monitorEventLoopDelay`/`timerify`, the Node `Timeout` object, legacy `url.parse`/`format`, etc.) is intentionally left out of scope so each bundle builds clean.

Verification:
- `tsc --noEmit` clean in all six packages
- `gjsify build --app browser` produces a valid non-empty bundle for each, with no `gi://` / `@girs/*` leakage
- portability: the same suites build + pass under `--app node` (console 53, perf_hooks 37, timers 11, url 41, webassembly 13, web-globals 40)
- `audit-runtimes --check`: OK

Only `src/test.browser.mts` + `package.json` are committed (`dist/` is gitignored).