### PR TITLE
test: add browser conformance entries for gamepad and xhr

### DIFF
--- a/packages/web/gamepad/package.json
+++ b/packages/web/gamepad/package.json
@@ -32,6 +32,7 @@
         "build:types": "tsc",
         "build:test": "gjsify run build:test:gjs",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs"
     },

--- a/packages/web/gamepad/src/test.browser.mts
+++ b/packages/web/gamepad/src/test.browser.mts
@@ -1,0 +1,42 @@
+// Browser test entry for @gjsify/gamepad.
+// In a real browser the Gamepad API is provided natively, so this entry
+// exercises the native `navigator.getGamepads()` surface rather than the
+// libmanette-backed GJS implementation (which imports `gi://Manette` and is
+// GJS-only). Assertions stay valid in a plain browser without any gamepad
+// hardware connected: `getGamepads()` returns an array whose slots are all
+// `null`, and the `GamepadEvent` constructor is available.
+import { run, describe, it, expect } from '@gjsify/unit';
+
+const testSuite = async () => {
+    await describe('navigator.getGamepads()', async () => {
+        await it('is a function', async () => {
+            expect(typeof navigator.getGamepads).toBe('function');
+        });
+
+        await it('returns an array', async () => {
+            const pads = navigator.getGamepads();
+            expect(Array.isArray(pads)).toBe(true);
+        });
+
+        await it('has no connected device in a headless browser', async () => {
+            const pads = navigator.getGamepads();
+            const connected = pads.filter((p) => p !== null);
+            expect(connected.length).toBe(0);
+        });
+    });
+
+    await describe('GamepadEvent', async () => {
+        await it('is a constructor', async () => {
+            expect(typeof GamepadEvent).toBe('function');
+        });
+
+        await it('exposes the event type and is an Event', async () => {
+            // A GamepadEvent requires a Gamepad in its init dict; since no
+            // device is connected we cannot construct a real Gamepad, but we
+            // can still verify the type relationship against Event.
+            expect(GamepadEvent.prototype instanceof Event).toBe(true);
+        });
+    });
+};
+
+run({ testSuite });

--- a/packages/web/xmlhttprequest/package.json
+++ b/packages/web/xmlhttprequest/package.json
@@ -29,7 +29,8 @@
         "check": "tsc --noEmit",
         "build": "gjsify run build:gjsify && gjsify run build:types",
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
-        "build:types": "tsc"
+        "build:types": "tsc",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs"
     },
     "keywords": [
         "gjs",

--- a/packages/web/xmlhttprequest/src/test.browser.mts
+++ b/packages/web/xmlhttprequest/src/test.browser.mts
@@ -1,0 +1,57 @@
+// Browser test entry for @gjsify/xmlhttprequest.
+// In a real browser XMLHttpRequest is provided natively, so this entry
+// exercises the native global rather than the GJS implementation (which is
+// backed by `gi://GLib`, `system` and `@gjsify/fetch` and is GJS-only).
+// Assertions stay valid in a plain browser without any live network: we only
+// construct an XHR, inspect its initial state, the readyState transition on
+// open(), and the standard readyState constants.
+import { run, describe, it, expect } from '@gjsify/unit';
+
+const testSuite = async () => {
+    await describe('XMLHttpRequest (constructor)', async () => {
+        await it('is a constructor', async () => {
+            expect(typeof XMLHttpRequest).toBe('function');
+        });
+
+        await it('constructs an instance', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr instanceof XMLHttpRequest).toBe(true);
+        });
+    });
+
+    await describe('XMLHttpRequest (instance API)', async () => {
+        await it('exposes open() and send() methods', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(typeof xhr.open).toBe('function');
+            expect(typeof xhr.send).toBe('function');
+            expect(typeof xhr.abort).toBe('function');
+            expect(typeof xhr.setRequestHeader).toBe('function');
+        });
+
+        await it('starts in the UNSENT state', async () => {
+            const xhr = new XMLHttpRequest();
+            expect(xhr.readyState).toBe(XMLHttpRequest.UNSENT);
+            expect(xhr.readyState).toBe(0);
+        });
+
+        await it('transitions to OPENED after open()', async () => {
+            const xhr = new XMLHttpRequest();
+            // file: scheme keeps this offline — no network request is sent.
+            xhr.open('GET', 'about:blank');
+            expect(xhr.readyState).toBe(XMLHttpRequest.OPENED);
+            expect(xhr.readyState).toBe(1);
+        });
+    });
+
+    await describe('XMLHttpRequest (readyState constants)', async () => {
+        await it('exposes the standard readyState constants', async () => {
+            expect(XMLHttpRequest.UNSENT).toBe(0);
+            expect(XMLHttpRequest.OPENED).toBe(1);
+            expect(XMLHttpRequest.HEADERS_RECEIVED).toBe(2);
+            expect(XMLHttpRequest.LOADING).toBe(3);
+            expect(XMLHttpRequest.DONE).toBe(4);
+        });
+    });
+};
+
+run({ testSuite });


### PR DESCRIPTION
## What

Adds browser-target test entries for `@gjsify/gamepad` and `@gjsify/xmlhttprequest`. Both packages declare `browser: native` — the browser provides these APIs natively (`navigator.getGamepads`, `XMLHttpRequest`) — so each gets a small browser conformance spec plus a `build:test:browser` script.

## Details

The GJS implementations of both packages are GJS-only (gamepad imports `gi://Manette`; xmlhttprequest is backed by `gi://GLib`, `system` and `@gjsify/fetch`), so the standard GJS spec is not browser-portable. Each browser entry instead exercises the native global directly, asserting only what holds in a plain browser without hardware or a live network:

- **gamepad** (`src/test.browser.mts`): `navigator.getGamepads()` is a function and returns an array; no device is connected in a headless browser; the `GamepadEvent` constructor exists and extends `Event`.
- **xmlhttprequest** (`src/test.browser.mts`): native `XMLHttpRequest` is a constructor and constructs an instance; exposes `open`/`send`/`abort`/`setRequestHeader`; starts in `UNSENT`, transitions to `OPENED` after `open()`; readyState constants match the spec.

Both add:

```json
"build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs"
```

## Verification

- `tsc --noEmit` clean in both packages
- browser test bundle builds for both packages
- `scripts/audit-runtimes.mjs --check` OK