### PR TITLE
test: add browser-target specs for dns, sqlite, module

### DIFF
--- a/packages/node/dns/package.json
+++ b/packages/node/dns/package.json
@@ -31,6 +31,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/dns/src/index.browser.spec.ts
+++ b/packages/node/dns/src/index.browser.spec.ts
@@ -1,0 +1,177 @@
+// oxlint-disable typescript/no-explicit-any -- spec inspects DNS callback/promise error .code on the browser stub
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/dns.
+//
+// Imports the browser implementation directly (`./browser.js`) rather than
+// `node:dns` — the package's `exports` map has no `browser` condition, so a
+// bare `node:dns` import would not select the stub. Importing the file under
+// test directly also keeps the bundle free of the GJS impl's `gi://*` deps.
+//
+// Locks in the current honest browser behavior (slot: browser:partial):
+//   - IP literals (v4/v6) + `localhost` resolve via lookup (callback + promise).
+//   - Real names report a structured ENOTSUP through the error channel — no
+//     crash, no lying loopback answer.
+//   - Every `resolve*` / `reverse` (callback + promise) reports ENOTSUP.
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+    lookup,
+    resolve4,
+    reverse,
+    promises,
+    NOTFOUND,
+    CONNREFUSED,
+} from './browser.js';
+
+export default async () => {
+    await describe('dns (browser)', async () => {
+        await describe('constants', async () => {
+            await it('re-exports the canonical error-code strings', async () => {
+                expect(NOTFOUND).toBe('ENOTFOUND');
+                expect(CONNREFUSED).toBe('ECONNREFUSED');
+            });
+        });
+
+        await describe('lookup — callback', async () => {
+            await it('resolves an IPv4 literal to itself', async () => {
+                await new Promise<void>((res, rej) => {
+                    lookup('127.0.0.1', (err, address, family) => {
+                        try {
+                            expect(err).toBeNull();
+                            expect(address).toBe('127.0.0.1');
+                            expect(family).toBe(4);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+
+            await it('resolves an IPv6 literal to itself', async () => {
+                await new Promise<void>((res, rej) => {
+                    lookup('::1', (err, address, family) => {
+                        try {
+                            expect(err).toBeNull();
+                            expect(address).toBe('::1');
+                            expect(family).toBe(6);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+
+            await it('resolves localhost to IPv4 loopback by default', async () => {
+                await new Promise<void>((res, rej) => {
+                    lookup('localhost', (err, address, family) => {
+                        try {
+                            expect(err).toBeNull();
+                            expect(address).toBe('127.0.0.1');
+                            expect(family).toBe(4);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+
+            await it('resolves localhost to IPv6 loopback when family is 6', async () => {
+                await new Promise<void>((res, rej) => {
+                    lookup('localhost', { family: 6 }, (err, address, family) => {
+                        try {
+                            expect(err).toBeNull();
+                            expect(address).toBe('::1');
+                            expect(family).toBe(6);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+
+            await it('reports ENOTSUP for a real name instead of crashing or lying', async () => {
+                await new Promise<void>((res, rej) => {
+                    lookup('example.com', (err, _address, _family) => {
+                        try {
+                            expect(err).toBeDefined();
+                            expect((err as any).code).toBe('ENOTSUP');
+                            expect((err as any).syscall).toBe('lookup');
+                            expect((err as any).hostname).toBe('example.com');
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+        });
+
+        await describe('resolve* / reverse — callback', async () => {
+            await it('resolve4 reports ENOTSUP via callback', async () => {
+                await new Promise<void>((res, rej) => {
+                    resolve4('example.com', (err) => {
+                        try {
+                            expect(err).toBeDefined();
+                            expect((err as any).code).toBe('ENOTSUP');
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+
+            await it('reverse reports ENOTSUP via callback', async () => {
+                await new Promise<void>((res, rej) => {
+                    reverse('8.8.8.8', (err) => {
+                        try {
+                            expect(err).toBeDefined();
+                            expect((err as any).code).toBe('ENOTSUP');
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+        });
+
+        await describe('promises surface', async () => {
+            await it('lookup resolves an IPv4 literal', async () => {
+                const result = (await promises.lookup('10.0.0.1')) as { address: string; family: number };
+                expect(result.address).toBe('10.0.0.1');
+                expect(result.family).toBe(4);
+            });
+
+            await it('lookup resolves localhost', async () => {
+                const result = (await promises.lookup('localhost')) as { address: string; family: number };
+                expect(result.address).toBe('127.0.0.1');
+                expect(result.family).toBe(4);
+            });
+
+            await it('lookup rejects a real name with ENOTSUP', async () => {
+                let code: string | undefined;
+                try {
+                    await promises.lookup('example.com');
+                } catch (e) {
+                    code = (e as any).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('resolve4 rejects with ENOTSUP', async () => {
+                let code: string | undefined;
+                try {
+                    await promises.resolve4('example.com');
+                } catch (e) {
+                    code = (e as any).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+    });
+};

--- a/packages/node/dns/src/test.browser.mts
+++ b/packages/node/dns/src/test.browser.mts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/dns — runs the browser-target conformance
+// spec under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+//
+// Unlike the canonical browser tests (which exercise real browser globals),
+// `node:dns` has no browser-native equivalent, so the spec imports the partial
+// browser stub directly (`./browser.js`) and locks in its honest behavior.
+
+import { run } from '@gjsify/unit';
+
+import testSuiteDnsBrowser from './index.browser.spec.js';
+
+run({ testSuiteDnsBrowser });

--- a/packages/node/module/package.json
+++ b/packages/node/module/package.json
@@ -27,6 +27,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/module/src/index.browser.spec.ts
+++ b/packages/node/module/src/index.browser.spec.ts
@@ -1,0 +1,97 @@
+// oxlint-disable typescript/no-explicit-any -- spec inspects thrown error .code on the browser stub
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/module.
+//
+// Imports the browser implementation directly (`./browser.js`) rather than
+// `node:module` — the package's `exports` map has no `browser` condition, so a
+// bare `node:module` import would not select the stub.
+//
+// Locks in the current honest browser behavior (slot: browser:partial):
+//   - `builtinModules` is the real Node built-in catalog (a static list — a
+//     browser's inability to resolve a built-in does not change which names ARE
+//     built-ins).
+//   - `isBuiltin` is subpath-aware: `fs`, `node:fs`, `fs/promises` → true; npm
+//     names → false.
+//   - `createRequire(url)` returns a `require`-shaped function that throws
+//     ERR_REQUIRE_ESM for built-in specifiers and ERR_MODULE_NOT_FOUND for
+//     everything else; its `cache` / `resolve` props are present so static
+//     reads don't crash before the call.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { builtinModules, isBuiltin, createRequire } from './browser.js';
+
+function thrownCode(fn: () => unknown): string | undefined {
+    try {
+        fn();
+    } catch (e) {
+        return (e as any).code;
+    }
+    return undefined;
+}
+
+export default async () => {
+    await describe('module (browser)', async () => {
+        await describe('builtinModules', async () => {
+            await it('is the real Node built-in catalog', async () => {
+                expect(Array.isArray(builtinModules)).toBe(true);
+                expect(builtinModules).toContain('fs');
+                expect(builtinModules).toContain('path');
+                expect(builtinModules).toContain('stream');
+                expect(builtinModules).toContain('module');
+            });
+
+            await it('does not include npm package names', async () => {
+                expect(builtinModules.includes('express')).toBe(false);
+            });
+        });
+
+        await describe('isBuiltin', async () => {
+            await it('returns true for a bare built-in name', async () => {
+                expect(isBuiltin('fs')).toBe(true);
+            });
+
+            await it('returns true for the node: prefixed form', async () => {
+                expect(isBuiltin('node:fs')).toBe(true);
+            });
+
+            await it('returns true for a built-in subpath', async () => {
+                expect(isBuiltin('fs/promises')).toBe(true);
+            });
+
+            await it('returns false for an npm package name', async () => {
+                expect(isBuiltin('lodash')).toBe(false);
+            });
+
+            await it('returns false for the empty string', async () => {
+                expect(isBuiltin('')).toBe(false);
+            });
+        });
+
+        await describe('createRequire', async () => {
+            await it('returns a require-shaped function with cache/resolve props', async () => {
+                const req = createRequire('file:///app/index.js');
+                expect(typeof req).toBe('function');
+                expect(typeof req.resolve).toBe('function');
+                expect(typeof req.cache).toBe('object');
+                expect(req.main).toBeUndefined();
+            });
+
+            await it('throws ERR_REQUIRE_ESM when requiring a built-in', async () => {
+                const req = createRequire('file:///app/index.js');
+                expect(thrownCode(() => req('fs'))).toBe('ERR_REQUIRE_ESM');
+                expect(thrownCode(() => req('node:path'))).toBe('ERR_REQUIRE_ESM');
+            });
+
+            await it('throws ERR_MODULE_NOT_FOUND for a non-built-in specifier', async () => {
+                const req = createRequire('file:///app/index.js');
+                expect(thrownCode(() => req('lodash'))).toBe('ERR_MODULE_NOT_FOUND');
+            });
+
+            await it('require.resolve throws the same codes', async () => {
+                const req = createRequire('file:///app/index.js');
+                expect(thrownCode(() => req.resolve('fs'))).toBe('ERR_REQUIRE_ESM');
+                expect(thrownCode(() => req.resolve('lodash'))).toBe('ERR_MODULE_NOT_FOUND');
+            });
+        });
+    });
+};

--- a/packages/node/module/src/test.browser.mts
+++ b/packages/node/module/src/test.browser.mts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/module — runs the browser-target conformance
+// spec under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+//
+// `node:module` has no browser-native equivalent, so the spec imports the
+// partial browser stub directly (`./browser.js`) and locks in its honest
+// behavior (real builtinModules/isBuiltin; createRequire throws structured
+// ERR_REQUIRE_ESM / ERR_MODULE_NOT_FOUND).
+
+import { run } from '@gjsify/unit';
+
+import testSuiteModuleBrowser from './index.browser.spec.js';
+
+run({ testSuiteModuleBrowser });

--- a/packages/node/sqlite/package.json
+++ b/packages/node/sqlite/package.json
@@ -27,6 +27,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/sqlite/src/index.browser.spec.ts
+++ b/packages/node/sqlite/src/index.browser.spec.ts
@@ -1,0 +1,78 @@
+// oxlint-disable typescript/no-explicit-any -- spec inspects thrown error .code on the browser stub
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/sqlite.
+//
+// Imports the browser implementation directly (`./browser.js`) rather than
+// `node:sqlite` — the package's `exports` map has no `browser` condition, so a
+// bare `node:sqlite` import would not select the stub, and the GJS impl drags
+// in `gi://Gda` which has no browser equivalent.
+//
+// Locks in the current honest browser behavior (slot: browser:partial — the
+// capability-slot stub):
+//   - The module imports without throwing (consumers can type-check + ship
+//     code that conditionally uses SQLite).
+//   - `constants` is present (re-exported from the GJS constants table).
+//   - Constructing a `DatabaseSync` / `StatementSync`, or calling any database
+//     op, throws a structured ERR_NOT_SUPPORTED.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { DatabaseSync, StatementSync, constants } from './browser.js';
+
+function thrownCode(fn: () => unknown): string | undefined {
+    try {
+        fn();
+    } catch (e) {
+        return (e as any).code;
+    }
+    return undefined;
+}
+
+export default async () => {
+    await describe('sqlite (browser)', async () => {
+        await describe('module surface', async () => {
+            await it('imports without throwing and exposes the classes', async () => {
+                expect(typeof DatabaseSync).toBe('function');
+                expect(typeof StatementSync).toBe('function');
+            });
+
+            await it('exposes the SQLite constants table', async () => {
+                expect(constants).toBeDefined();
+                expect(constants.SQLITE_CHANGESET_OMIT).toBe(0);
+            });
+        });
+
+        await describe('DatabaseSync', async () => {
+            await it('constructor throws ERR_NOT_SUPPORTED', async () => {
+                expect(thrownCode(() => new DatabaseSync(':memory:'))).toBe('ERR_NOT_SUPPORTED');
+            });
+
+            await it('constructor error message points at a WASM backend', async () => {
+                let message = '';
+                try {
+                    // eslint-disable-next-line no-new
+                    new DatabaseSync(':memory:');
+                } catch (e) {
+                    message = (e as Error).message;
+                }
+                expect(message).toContain('not available in the browser polyfill');
+            });
+        });
+
+        await describe('StatementSync', async () => {
+            await it('constructor throws ERR_NOT_SUPPORTED', async () => {
+                expect(thrownCode(() => new StatementSync())).toBe('ERR_NOT_SUPPORTED');
+            });
+
+            await it('prototype ops throw ERR_NOT_SUPPORTED when invoked directly', async () => {
+                // The constructor throws, so reach the unreachable prototype
+                // methods via the prototype to lock in their failure contract.
+                const proto = StatementSync.prototype as unknown as {
+                    all: (this: unknown) => unknown;
+                    run: (this: unknown) => unknown;
+                };
+                expect(thrownCode(() => proto.all.call({}))).toBe('ERR_NOT_SUPPORTED');
+                expect(thrownCode(() => proto.run.call({}))).toBe('ERR_NOT_SUPPORTED');
+            });
+        });
+    });
+};

--- a/packages/node/sqlite/src/test.browser.mts
+++ b/packages/node/sqlite/src/test.browser.mts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/sqlite — runs the browser-target conformance
+// spec under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+//
+// `node:sqlite` has no browser-native equivalent, so the spec imports the
+// partial browser stub directly (`./browser.js`) and locks in its honest
+// behavior (import without throwing; database ops throw ERR_NOT_SUPPORTED).
+
+import { run } from '@gjsify/unit';
+
+import testSuiteSqliteBrowser from './index.browser.spec.js';
+
+run({ testSuiteSqliteBrowser });


### PR DESCRIPTION
Adds browser-target conformance tests that lock in the current honest browser behavior of the `@gjsify/dns`, `@gjsify/sqlite`, and `@gjsify/module` browser implementations.

Each package gains:
- `src/index.browser.spec.ts` — a focused `@gjsify/unit` spec importing the browser impl directly via `./browser.js` (the `exports` map has no `browser` condition, and direct import keeps the bundle free of `gi://*` deps).
- `src/test.browser.mts` — the browser entry that runs the spec under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
- `build:test:browser` package script (`--outfile dist/test.browser.mjs`, `dist/` gitignored).

What the specs assert:
- **dns** — IPv4/IPv6 literals and `localhost` resolve via `lookup` (callback + promise); real names report a structured `ENOTSUP` through the callback/rejected promise (no crash, no loopback lie); `resolve*`/`reverse` report `ENOTSUP`.
- **sqlite** — module imports without throwing; `constants` present; `DatabaseSync`/`StatementSync` constructors and ops throw a structured `ERR_NOT_SUPPORTED`.
- **module** — `builtinModules` is the real Node catalog; `isBuiltin` handles `fs`/`node:fs`/`fs/promises`/npm names; `createRequire` returns a `require`-shaped fn that throws `ERR_REQUIRE_ESM` for built-ins and `ERR_MODULE_NOT_FOUND` otherwise.

Verification: `tsc --noEmit` clean for all three packages; browser bundles build cleanly with no leaked `gi://`/`@girs` specifiers; the specs are platform-neutral, so they also build + pass under `--app node` (28 + 9 + 20 = 57 assertions green).