### PR TITLE
test: add browser conformance tests for vm, zlib, https

### DIFF
--- a/packages/node/https/package.json
+++ b/packages/node/https/package.json
@@ -29,6 +29,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/https/src/index.browser.spec.ts
+++ b/packages/node/https/src/index.browser.spec.ts
@@ -1,0 +1,138 @@
+// Browser-target conformance spec for @gjsify/https.
+//
+// Imports the browser entry directly (`./browser.js`) — under `gjsify build
+// --app browser` the bundler picks the same file via the `"browser"` export
+// condition, so these assertions lock in the behaviour exercised in the
+// Playwright/Firefox/SpiderMonkey suite.
+//
+// The browser https client builds on the `@gjsify/http` browser entry: a
+// browser `fetch()` already negotiates TLS for `https://` URLs, so
+// `https.request`/`https.get` differ from their http counterparts only in
+// defaulting `protocol` to `https:` for an options object that omits one. The
+// returned object is the same `ClientRequest` shape as http. Server paths
+// cannot bind a TCP socket in a browser, so `Server`/`createServer` throw a
+// structured `ENOTSUP`.
+//
+// Assertions deliberately never call `req.end()` (which would trigger a real
+// `fetch`) — they only inspect the lazily-built `ClientRequest` shape.
+
+import { describe, it, expect } from '@gjsify/unit';
+import https, {
+    request,
+    get,
+    Server,
+    createServer,
+    ClientRequest,
+    Agent,
+    globalHttpsAgent,
+    METHODS,
+    STATUS_CODES,
+} from './browser.js';
+import { request as httpRequest, ClientRequest as HttpClientRequest } from '@gjsify/http/browser';
+
+export default async () => {
+    await describe('https (browser)', async () => {
+        // ==================== exports ====================
+        await describe('exports', async () => {
+            await it('should export request/get/createServer as functions', async () => {
+                expect(typeof request).toBe('function');
+                expect(typeof get).toBe('function');
+                expect(typeof createServer).toBe('function');
+            });
+
+            await it('should re-export the http constants surface', async () => {
+                expect(Array.isArray(METHODS)).toBe(true);
+                expect(typeof STATUS_CODES).toBe('object');
+                expect(typeof https.request).toBe('function');
+                expect(typeof https.get).toBe('function');
+            });
+
+            await it('should expose a browser Agent stub', async () => {
+                expect(typeof Agent).toBe('function');
+                const agent = new Agent();
+                expect(agent.keepAlive).toBe(false);
+                expect(typeof agent.destroy).toBe('function');
+                expect(globalHttpsAgent instanceof Agent).toBe(true);
+            });
+        });
+
+        // ==================== request: defaults to https, http-consistent shape ====================
+        await describe('request', async () => {
+            await it('should return a ClientRequest for an options object', async () => {
+                const req = request({ host: 'example.com', path: '/api', method: 'POST' });
+                expect(req instanceof ClientRequest).toBe(true);
+                expect(req.method).toBe('POST');
+                expect(req.path).toBe('/api');
+            });
+
+            await it('should default GET method and root path like http', async () => {
+                const req = request({ host: 'example.com' });
+                expect(req.method).toBe('GET');
+                expect(req.path).toBe('/');
+            });
+
+            await it('should accept a string URL and keep its own protocol', async () => {
+                const req = request('https://example.com/path');
+                expect(req instanceof ClientRequest).toBe(true);
+                expect(req.path).toBe('/path');
+            });
+
+            await it('should produce the same ClientRequest shape as http.request', async () => {
+                const httpsReq = request({ host: 'example.com', path: '/x' });
+                const httpReq = httpRequest({ host: 'example.com', path: '/x' });
+                // Same underlying class is re-exported from @gjsify/http.
+                expect(ClientRequest === HttpClientRequest).toBe(true);
+                expect(httpsReq.method).toBe(httpReq.method);
+                expect(httpsReq.path).toBe(httpReq.path);
+            });
+
+            await it('should expose the http client request surface', async () => {
+                const req = request({ host: 'example.com' });
+                expect(typeof req.setHeader).toBe('function');
+                expect(typeof req.getHeader).toBe('function');
+                expect(typeof req.write).toBe('function');
+                expect(typeof req.end).toBe('function');
+                req.setHeader('x-test', 'v');
+                expect(req.getHeader('x-test')).toBe('v');
+                // Avoid triggering a real fetch — tear the request down unsent.
+                req.destroy();
+            });
+        });
+
+        // ==================== get: request + end shape ====================
+        await describe('get', async () => {
+            await it('should return a ClientRequest (request followed by end)', async () => {
+                const req = get({ host: 'example.com', path: '/g' });
+                expect(req instanceof ClientRequest).toBe(true);
+                expect(req.method).toBe('GET');
+                expect(req.path).toBe('/g');
+                // get() already called end(); abort the in-flight request so the
+                // background fetch is cancelled and no network call is awaited.
+                req.abort();
+            });
+        });
+
+        // ==================== ENOTSUP: server paths ====================
+        await describe('server paths are ENOTSUP (no listening socket in a browser)', async () => {
+            await it('should throw structured ENOTSUP from new Server()', async () => {
+                let code: string | undefined;
+                try {
+                    new Server();
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP from createServer()', async () => {
+                let code: string | undefined;
+                try {
+                    createServer();
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+    });
+};

--- a/packages/node/https/src/test.browser.mts
+++ b/packages/node/https/src/test.browser.mts
@@ -1,0 +1,10 @@
+// Browser test entry for @gjsify/https — runs the browser-target conformance
+// spec (`index.browser.spec.ts`, which imports the `./browser.js` polyfill
+// directly) under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });

--- a/packages/node/vm/package.json
+++ b/packages/node/vm/package.json
@@ -29,6 +29,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/vm/src/index.browser.spec.ts
+++ b/packages/node/vm/src/index.browser.spec.ts
@@ -1,0 +1,200 @@
+// Browser-target conformance spec for @gjsify/vm.
+//
+// Imports the browser entry directly (`./browser.js`) — under `gjsify build
+// --app browser` the bundler picks the same file via the `"browser"` export
+// condition, so these assertions lock in the behaviour exercised in the
+// Playwright/Firefox/SpiderMonkey suite.
+//
+// The browser polyfill evaluates code through the Function/eval sandbox
+// (`runInThisContext` → indirect `eval`, `runInNewContext` → `new Function`
+// with the sandbox keys injected as locals). It is NOT a security boundary —
+// matching Node's own vm contract — so the assertions below check evaluation
+// semantics and context-object exposure rather than isolation guarantees.
+
+import { describe, it, expect } from '@gjsify/unit';
+import vm, {
+    runInThisContext,
+    runInNewContext,
+    runInContext,
+    createContext,
+    isContext,
+    compileFunction,
+    Script,
+    Module,
+    SourceTextModule,
+    SyntheticModule,
+    measureMemory,
+} from './browser.js';
+
+export default async () => {
+    await describe('vm (browser)', async () => {
+        // ==================== exports ====================
+        await describe('exports', async () => {
+            await it('should export the public surface as functions', async () => {
+                expect(typeof runInThisContext).toBe('function');
+                expect(typeof runInNewContext).toBe('function');
+                expect(typeof runInContext).toBe('function');
+                expect(typeof createContext).toBe('function');
+                expect(typeof isContext).toBe('function');
+                expect(typeof compileFunction).toBe('function');
+                expect(typeof Script).toBe('function');
+            });
+
+            await it('should mirror the public surface on the default export', async () => {
+                expect(typeof vm.runInThisContext).toBe('function');
+                expect(typeof vm.runInNewContext).toBe('function');
+                expect(typeof vm.runInContext).toBe('function');
+                expect(typeof vm.createContext).toBe('function');
+                expect(typeof vm.isContext).toBe('function');
+                expect(typeof vm.compileFunction).toBe('function');
+                expect(typeof vm.Script).toBe('function');
+            });
+        });
+
+        // ==================== runInThisContext (eval sandbox) ====================
+        await describe('runInThisContext', async () => {
+            await it('should evaluate expressions via the eval sandbox', async () => {
+                expect(runInThisContext('1 + 1')).toBe(2);
+                expect(runInThisContext('"a" + "b"')).toBe('ab');
+                expect(runInThisContext('[1,2,3].map(x => x * 2).join(",")')).toBe('2,4,6');
+            });
+
+            await it('should return undefined for statements', async () => {
+                expect(runInThisContext('var __vm_browser_x = 42')).toBeUndefined();
+                expect(runInThisContext('')).toBeUndefined();
+            });
+
+            await it('should propagate errors from evaluated code', async () => {
+                expect(() => runInThisContext('function(')).toThrow();
+                expect(() => runInThisContext('__no_such_var_browser_abc')).toThrow();
+            });
+        });
+
+        // ==================== runInNewContext (Function sandbox) ====================
+        await describe('runInNewContext', async () => {
+            await it('should expose context object properties as locals', async () => {
+                expect(runInNewContext('a + b', { a: 10, b: 20 })).toBe(30);
+                expect(runInNewContext('items.join("-")', { items: ['a', 'b', 'c'] })).toBe('a-b-c');
+                expect(runInNewContext('obj.nested.value', { obj: { nested: { value: 99 } } })).toBe(99);
+            });
+
+            await it('should invoke functions passed via the context object', async () => {
+                expect(runInNewContext('fn(5)', { fn: (x: number) => x * 2 })).toBe(10);
+            });
+
+            await it('should evaluate with no context argument', async () => {
+                expect(runInNewContext('typeof Object')).toBe('function');
+                expect(runInNewContext('1 + 2')).toBe(3);
+            });
+
+            await it('should not leak declarations between calls', async () => {
+                runInNewContext('var __vm_browser_isolated = 1', {});
+                expect(() => runInNewContext('__vm_browser_isolated', {})).toThrow();
+            });
+        });
+
+        // ==================== runInContext / createContext / isContext ====================
+        await describe('runInContext + createContext', async () => {
+            await it('should run code against a created context object', async () => {
+                const ctx = createContext({ x: 10 });
+                expect(runInContext('x + 5', ctx)).toBe(15);
+            });
+
+            await it('should mark created contexts and preserve their properties', async () => {
+                const ctx = createContext({ foo: 'bar' });
+                expect(isContext(ctx)).toBe(true);
+                expect(ctx.foo).toBe('bar');
+                // The context marker is non-enumerable, so only user keys remain.
+                expect(Object.keys(ctx).length).toBe(1);
+            });
+
+            await it('should return the same object when contextifying in place', async () => {
+                const sandbox: Record<string, unknown> = {};
+                expect(createContext(sandbox) === sandbox).toBe(true);
+            });
+
+            await it('isContext should reject non-contexts and non-objects', async () => {
+                expect(isContext({})).toBe(false);
+                expect(() => isContext(null as unknown as object)).toThrow();
+                expect(() => isContext(42 as unknown as object)).toThrow();
+            });
+        });
+
+        // ==================== compileFunction ====================
+        await describe('compileFunction', async () => {
+            await it('should compile a callable function with params', async () => {
+                const fn = compileFunction('return a + b', ['a', 'b']);
+                expect(typeof fn).toBe('function');
+                expect(fn(3, 4)).toBe(7);
+            });
+
+            await it('should throw for invalid bodies', async () => {
+                expect(() => compileFunction('function(')).toThrow();
+            });
+        });
+
+        // ==================== Script ====================
+        await describe('Script', async () => {
+            await it('should evaluate cached code in this/new context', async () => {
+                const script = new Script('x * y');
+                expect(script.runInNewContext({ x: 6, y: 7 })).toBe(42);
+                const expr = new Script('1 + 2');
+                expect(expr.runInThisContext()).toBe(3);
+            });
+
+            await it('should be reusable across contexts', async () => {
+                const script = new Script('n + 1');
+                expect(script.runInNewContext({ n: 1 })).toBe(2);
+                expect(script.runInNewContext({ n: 100 })).toBe(101);
+            });
+
+            await it('should expose a createCachedData stub returning a Uint8Array', async () => {
+                expect(new Script('1').createCachedData() instanceof Uint8Array).toBe(true);
+            });
+        });
+
+        // ==================== ENOTSUP: module classes have no browser equivalent ====================
+        await describe('ENOTSUP stubs', async () => {
+            await it('should throw structured ENOTSUP from vm.Module', async () => {
+                let caught: (Error & { code?: string }) | undefined;
+                try {
+                    new Module('export const x = 1');
+                } catch (e: unknown) {
+                    caught = e as Error & { code?: string };
+                }
+                expect(caught !== undefined).toBe(true);
+                expect(caught?.code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP from SourceTextModule', async () => {
+                let code: string | undefined;
+                try {
+                    new SourceTextModule('export const y = 2');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP from SyntheticModule', async () => {
+                let code: string | undefined;
+                try {
+                    new SyntheticModule([], () => {});
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should reject from measureMemory with ENOTSUP', async () => {
+                let code: string | undefined;
+                try {
+                    await measureMemory();
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+    });
+};

--- a/packages/node/vm/src/test.browser.mts
+++ b/packages/node/vm/src/test.browser.mts
@@ -1,0 +1,9 @@
+// Browser test entry for @gjsify/vm — runs the browser-target conformance spec
+// (`index.browser.spec.ts`, which imports the `./browser.js` polyfill directly)
+// under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });

--- a/packages/node/zlib/package.json
+++ b/packages/node/zlib/package.json
@@ -27,6 +27,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/zlib/src/index.browser.spec.ts
+++ b/packages/node/zlib/src/index.browser.spec.ts
@@ -1,0 +1,192 @@
+// Browser-target conformance spec for @gjsify/zlib.
+//
+// Imports the browser entry directly (`./browser.js`) — under `gjsify build
+// --app browser` the bundler picks the same file via the `"browser"` export
+// condition, so these assertions lock in the behaviour exercised in the
+// Playwright/Firefox/SpiderMonkey suite.
+//
+// gzip / deflate / deflate-raw ride the browser-native WHATWG Compression
+// Streams API (`CompressionStream` / `DecompressionStream`), which is
+// Promise-based — so the roundtrip assertions are async (callback form).
+// Brotli and zstd are NOT in that spec, so they surface a structured
+// `ENOTSUP` error rather than a fake codec; the sync variants throw the same
+// because the underlying API is async-only.
+
+import { describe, it, expect } from '@gjsify/unit';
+import zlib, {
+    gzip,
+    gunzip,
+    deflate,
+    inflate,
+    deflateRaw,
+    inflateRaw,
+    brotliCompress,
+    brotliDecompress,
+    zstdCompress,
+    zstdDecompress,
+    gzipSync,
+    deflateSync,
+    BrotliCompress,
+    BrotliDecompress,
+    constants,
+} from './browser.js';
+
+type AsyncCodec = (
+    data: string | Uint8Array | ArrayBuffer,
+    cb: (err: Error | null, result?: Uint8Array) => void,
+) => void;
+
+/** Promisify a callback-style codec for async assertions. */
+function call(fn: AsyncCodec, data: string | Uint8Array): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+        fn(data, (err, result) => {
+            if (err) reject(err);
+            else resolve(result as Uint8Array);
+        });
+    });
+}
+
+const decode = (u8: Uint8Array): string => new TextDecoder().decode(u8);
+
+export default async () => {
+    await describe('zlib (browser)', async () => {
+        // ==================== exports ====================
+        await describe('exports', async () => {
+            await it('should export the async codec surface as functions', async () => {
+                expect(typeof gzip).toBe('function');
+                expect(typeof gunzip).toBe('function');
+                expect(typeof deflate).toBe('function');
+                expect(typeof inflate).toBe('function');
+                expect(typeof deflateRaw).toBe('function');
+                expect(typeof inflateRaw).toBe('function');
+            });
+
+            await it('should expose constants on the default export', async () => {
+                expect(typeof zlib.constants).toBe('object');
+                expect(constants.Z_FINISH).toBe(4);
+            });
+        });
+
+        // ==================== gzip roundtrip (Compression Streams, async) ====================
+        await describe('gzip roundtrip', async () => {
+            await it('should gzip then gunzip back to the original bytes', async () => {
+                const input = 'hello gzip browser roundtrip';
+                const compressed = await call(gzip as AsyncCodec, input);
+                expect(compressed instanceof Uint8Array).toBe(true);
+                expect(compressed.length > 0).toBe(true);
+                const restored = await call(gunzip as AsyncCodec, compressed);
+                expect(decode(restored)).toBe(input);
+            });
+        });
+
+        // ==================== deflate roundtrip ====================
+        await describe('deflate roundtrip', async () => {
+            await it('should deflate then inflate back to the original bytes', async () => {
+                const input = 'hello deflate browser roundtrip';
+                const compressed = await call(deflate as AsyncCodec, input);
+                expect(compressed instanceof Uint8Array).toBe(true);
+                expect(compressed.length > 0).toBe(true);
+                const restored = await call(inflate as AsyncCodec, compressed);
+                expect(decode(restored)).toBe(input);
+            });
+        });
+
+        // ==================== deflateRaw roundtrip ====================
+        await describe('deflateRaw roundtrip', async () => {
+            await it('should deflateRaw then inflateRaw back to the original bytes', async () => {
+                const input = 'hello deflateRaw browser roundtrip';
+                const compressed = await call(deflateRaw as AsyncCodec, input);
+                expect(compressed instanceof Uint8Array).toBe(true);
+                expect(compressed.length > 0).toBe(true);
+                const restored = await call(inflateRaw as AsyncCodec, compressed);
+                expect(decode(restored)).toBe(input);
+            });
+        });
+
+        // ==================== ENOTSUP: brotli / zstd (no Web codec) ====================
+        await describe('brotli / zstd are ENOTSUP (no fake codec)', async () => {
+            await it('should surface structured ENOTSUP from brotliCompress', async () => {
+                let code: string | undefined;
+                try {
+                    await call(brotliCompress as AsyncCodec, 'data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should surface structured ENOTSUP from brotliDecompress', async () => {
+                let code: string | undefined;
+                try {
+                    await call(brotliDecompress as AsyncCodec, 'data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should surface structured ENOTSUP from zstdCompress', async () => {
+                let code: string | undefined;
+                try {
+                    await call(zstdCompress as AsyncCodec, 'data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should surface structured ENOTSUP from zstdDecompress', async () => {
+                let code: string | undefined;
+                try {
+                    await call(zstdDecompress as AsyncCodec, 'data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP when constructing BrotliCompress', async () => {
+                let code: string | undefined;
+                try {
+                    new BrotliCompress();
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP when constructing BrotliDecompress', async () => {
+                let code: string | undefined;
+                try {
+                    new BrotliDecompress();
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+
+        // ==================== ENOTSUP: sync variants (API is async-only) ====================
+        await describe('sync variants are ENOTSUP (Compression Streams is async-only)', async () => {
+            await it('should throw structured ENOTSUP from gzipSync', async () => {
+                let code: string | undefined;
+                try {
+                    gzipSync('data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+
+            await it('should throw structured ENOTSUP from deflateSync', async () => {
+                let code: string | undefined;
+                try {
+                    deflateSync('data');
+                } catch (e: unknown) {
+                    code = (e as Error & { code?: string }).code;
+                }
+                expect(code).toBe('ENOTSUP');
+            });
+        });
+    });
+};

--- a/packages/node/zlib/src/test.browser.mts
+++ b/packages/node/zlib/src/test.browser.mts
@@ -1,0 +1,10 @@
+// Browser test entry for @gjsify/zlib — runs the browser-target conformance
+// spec (`index.browser.spec.ts`, which imports the `./browser.js` polyfill
+// directly) under `gjsify build --app browser`
+// (Playwright/Firefox/SpiderMonkey).
+
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });


### PR DESCRIPTION
Adds browser-target conformance tests for the recently completed browser implementations of `@gjsify/vm`, `@gjsify/zlib` and `@gjsify/https`.

Each package gets a `src/index.browser.spec.ts` (importing the `./browser.js` entry directly) plus a `src/test.browser.mts` runner and a `build:test:browser` script, mirroring `@gjsify/buffer`.

## What is asserted

- **vm** — `runInThisContext` / `runInNewContext` evaluate via the Function/eval sandbox; context-object properties are exposed as locals; `createContext`/`isContext`/`compileFunction`/`Script` behave as expected; `Module`/`SourceTextModule`/`SyntheticModule`/`measureMemory` throw/reject structured `ENOTSUP`.
- **zlib** — async `gzip`/`deflate`/`deflateRaw` roundtrips through the Web Compression Streams API; `brotli`/`zstd` and the sync variants throw structured `ENOTSUP` (no fake codecs).
- **https** — `request`/`get` build the same `ClientRequest` shape as `http` (no real `fetch` triggered); `Server`/`createServer` throw structured `ENOTSUP`.

## Verification

- `tsc --noEmit` clean for all three packages.
- `gjsify build --app browser` produces a bundle for each test entry.
- Node-target builds of the specs pass: vm 49, zlib 25 (incl. real Compression Streams roundtrips), https 31.
- `audit-runtimes --check`: OK.