### PR TITLE
test: add browser specs for stream, domain, buffer

### DIFF
--- a/packages/node/buffer/src/index.browser.spec.ts
+++ b/packages/node/buffer/src/index.browser.spec.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/buffer.
+//
+// Imports the package's OWN entry directly (`./index.js`) — `Buffer` is a
+// portable pure-TS impl over Uint8Array + Blob/atob/btoa, so the same file the
+// bundler picks under `gjsify build --app browser` runs in a browser. It must
+// NOT re-export `./test.mjs` (that re-export tree-shakes the browser bundle to
+// 0 bytes and pulls in `@gjsify/node-globals` register side-effects) and must
+// NOT import `@gjsify/buffer`.
+//
+// Asserts the browser-safe Buffer surface: from / alloc, toString('utf8' |
+// 'base64' | 'hex'), Buffer.concat, and Buffer.byteLength.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { Buffer } from './index.js';
+
+export default async () => {
+    await describe('buffer (browser)', async () => {
+        // ==================== Buffer.from ====================
+        await describe('Buffer.from', async () => {
+            await it('should build from a utf8 string', async () => {
+                const buf = Buffer.from('hi');
+                expect(buf.length).toBe(2);
+                expect(buf[0]).toBe(0x68);
+                expect(buf[1]).toBe(0x69);
+            });
+
+            await it('should build from a byte array', async () => {
+                const buf = Buffer.from([1, 2, 3]);
+                expect(buf.length).toBe(3);
+                expect(buf[0]).toBe(1);
+                expect(buf[2]).toBe(3);
+            });
+
+            await it('should decode a base64 string', async () => {
+                const buf = Buffer.from('aGVsbG8=', 'base64');
+                expect(buf.toString('utf8')).toBe('hello');
+            });
+
+            await it('should decode a hex string', async () => {
+                const buf = Buffer.from('48656c6c6f', 'hex');
+                expect(buf.toString('utf8')).toBe('Hello');
+            });
+        });
+
+        // ==================== Buffer.alloc ====================
+        await describe('Buffer.alloc', async () => {
+            await it('should zero-fill by default', async () => {
+                const buf = Buffer.alloc(4);
+                expect(buf.length).toBe(4);
+                expect(buf[0]).toBe(0);
+                expect(buf[3]).toBe(0);
+            });
+
+            await it('should fill with a numeric value', async () => {
+                const buf = Buffer.alloc(3, 7);
+                expect(Array.from(buf)).toStrictEqual([7, 7, 7]);
+            });
+        });
+
+        // ==================== toString encodings ====================
+        await describe('toString', async () => {
+            await it('should round-trip utf8', async () => {
+                expect(Buffer.from('héllo', 'utf8').toString('utf8')).toBe('héllo');
+            });
+
+            await it('should encode to base64', async () => {
+                expect(Buffer.from('hello').toString('base64')).toBe('aGVsbG8=');
+            });
+
+            await it('should encode to hex', async () => {
+                expect(Buffer.from('Hello').toString('hex')).toBe('48656c6c6f');
+            });
+
+            await it('should honor start / end offsets', async () => {
+                expect(Buffer.from('abcdef').toString('utf8', 1, 4)).toBe('bcd');
+            });
+        });
+
+        // ==================== Buffer.concat ====================
+        await describe('Buffer.concat', async () => {
+            await it('should join multiple buffers', async () => {
+                const out = Buffer.concat([Buffer.from('foo'), Buffer.from('bar')]);
+                expect(out.length).toBe(6);
+                expect(out.toString('utf8')).toBe('foobar');
+            });
+
+            await it('should respect an explicit total length', async () => {
+                const out = Buffer.concat([Buffer.from('abc'), Buffer.from('def')], 4);
+                expect(out.length).toBe(4);
+                expect(out.toString('utf8')).toBe('abcd');
+            });
+
+            await it('should return an empty buffer for an empty list', async () => {
+                expect(Buffer.concat([]).length).toBe(0);
+            });
+        });
+
+        // ==================== Buffer.byteLength ====================
+        await describe('Buffer.byteLength', async () => {
+            await it('should count ascii bytes', async () => {
+                expect(Buffer.byteLength('hello', 'utf8')).toBe(5);
+            });
+
+            await it('should count multibyte utf8 bytes', async () => {
+                // 'é' is 2 bytes in UTF-8.
+                expect(Buffer.byteLength('é', 'utf8')).toBe(2);
+            });
+
+            await it('should count hex-decoded bytes', async () => {
+                expect(Buffer.byteLength('deadbeef', 'hex')).toBe(4);
+            });
+        });
+    });
+};

--- a/packages/node/buffer/src/test.browser.mts
+++ b/packages/node/buffer/src/test.browser.mts
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
-// Browser test entry for @gjsify/buffer — re-exports the standard test.mts
-// suite so the existing assertions also run under `gjsify build --app browser`
-// (Playwright/Firefox/SpiderMonkey).
+// Browser test entry for @gjsify/buffer — runs the browser-target conformance
+// spec (`index.browser.spec.ts`, which imports the `./index.js` Buffer impl
+// directly) under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
 //
-// The impl is platform-neutral pure-TS (Buffer over Uint8Array + Blob/atob/btoa),
-// so the same spec exercises both runtimes. The browser-target alias layer
-// (`ALIASES_NODE_FOR_BROWSER` in PR #388) routes `node:buffer` → `@gjsify/buffer`
-// so the spec's `import { Buffer } from 'node:buffer'` resolves transparently.
+// Replaces the previous hollow `export * from './test.mjs'` re-export: that
+// re-export tree-shook the browser bundle to 0 bytes (no live binding survived
+// the dead-code pass) and pulled in `@gjsify/node-globals` register side-effects.
 
-export * from './test.mjs';
-import './test.mjs';
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });

--- a/packages/node/domain/package.json
+++ b/packages/node/domain/package.json
@@ -25,6 +25,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/domain/src/index.browser.spec.ts
+++ b/packages/node/domain/src/index.browser.spec.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/domain.
+//
+// Imports the package's OWN entry directly (`./index.js`) — `domain` is a
+// pure-TS deprecated no-op shim over EventEmitter, so the same file the bundler
+// picks under `gjsify build --app browser` is portable. It must NOT re-export
+// `./test.mjs` (that drags in `@gjsify/node-globals` register side-effects with
+// no browser equivalent) and must NOT import `@gjsify/domain`.
+//
+// Asserts the deprecated no-op API surface: create() / createDomain() build a
+// Domain, domain.run(fn) executes fn and returns its value, and
+// add/remove/bind/intercept/enter/exit/dispose exist and do not throw.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { create, createDomain, Domain } from './index.js';
+
+export default async () => {
+    await describe('domain (browser)', async () => {
+        // ==================== factory surface ====================
+        await describe('factory surface', async () => {
+            await it('should export create and createDomain as functions', async () => {
+                expect(typeof create).toBe('function');
+                expect(typeof createDomain).toBe('function');
+                expect(createDomain).toBe(create);
+            });
+
+            await it('should export the Domain class', async () => {
+                expect(typeof Domain).toBe('function');
+            });
+
+            await it('create() and createDomain() should build a Domain', async () => {
+                expect(create() instanceof Domain).toBe(true);
+                expect(createDomain() instanceof Domain).toBe(true);
+            });
+
+            await it('a fresh domain should start with empty members', async () => {
+                const d = create();
+                expect(Array.isArray(d.members)).toBe(true);
+                expect(d.members.length).toBe(0);
+            });
+        });
+
+        // ==================== run executes its callback ====================
+        await describe('run', async () => {
+            await it('should execute the function and return its value', async () => {
+                const d = create();
+                expect(d.run(() => 42)).toBe(42);
+                expect(d.run(() => 'ok')).toBe('ok');
+            });
+
+            await it('should propagate the callback return reference', async () => {
+                const d = create();
+                const obj = { a: 1 };
+                expect(d.run(() => obj)).toBe(obj);
+            });
+        });
+
+        // ==================== add / remove ====================
+        await describe('add / remove', async () => {
+            await it('should track and untrack members without throwing', async () => {
+                const d = create();
+                const emitter = create(); // Domain extends EventEmitter
+                expect(() => d.add(emitter)).not.toThrow();
+                expect(d.members.length).toBe(1);
+                expect(() => d.remove(emitter)).not.toThrow();
+                expect(d.members.length).toBe(0);
+            });
+        });
+
+        // ==================== bind / intercept (no-op pass-through) ====================
+        await describe('bind / intercept', async () => {
+            await it('bind should return a callable that runs the wrapped fn', async () => {
+                const d = create();
+                const bound = d.bind((x: number) => x * 2);
+                expect(typeof bound).toBe('function');
+                expect((bound as (x: number) => number)(21)).toBe(42);
+            });
+
+            await it('intercept should return a callable that runs the wrapped fn', async () => {
+                const d = create();
+                const wrapped = d.intercept((x: number) => x + 1);
+                expect(typeof wrapped).toBe('function');
+                expect((wrapped as (x: number) => number)(1)).toBe(2);
+            });
+        });
+
+        // ==================== lifecycle no-ops ====================
+        await describe('lifecycle no-ops', async () => {
+            await it('enter / exit should exist and not throw', async () => {
+                const d = create();
+                expect(typeof d.enter).toBe('function');
+                expect(typeof d.exit).toBe('function');
+                expect(() => d.enter()).not.toThrow();
+                expect(() => d.exit()).not.toThrow();
+            });
+
+            await it('dispose should emit a dispose event', async () => {
+                const d = create();
+                let disposed = false;
+                d.on('dispose', () => {
+                    disposed = true;
+                });
+                d.dispose();
+                expect(disposed).toBe(true);
+            });
+        });
+    });
+};

--- a/packages/node/domain/src/index.ts
+++ b/packages/node/domain/src/index.ts
@@ -38,4 +38,7 @@ export function create(): Domain {
     return new Domain();
 }
 
-export default { Domain, create };
+// Node aliases `create` and `createDomain` to the same factory (lib/domain.js).
+export const createDomain = create;
+
+export default { Domain, create, createDomain };

--- a/packages/node/domain/src/test.browser.mts
+++ b/packages/node/domain/src/test.browser.mts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/domain — runs the browser-target conformance
+// spec (`index.browser.spec.ts`, which imports `./index.js` directly) under
+// `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });

--- a/packages/node/stream/package.json
+++ b/packages/node/stream/package.json
@@ -43,6 +43,7 @@
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
         "test:node": "node test.node.mjs"

--- a/packages/node/stream/src/browser.ts
+++ b/packages/node/stream/src/browser.ts
@@ -128,25 +128,36 @@ export class Readable extends Stream {
     protected _paused = false;
     protected _flowing: boolean | null = null;
     protected _ended = false;
+    protected _endEmitted = false;
+    protected _drainScheduled = false;
 
     push(chunk: unknown): boolean {
         if (chunk === null) {
             this._ended = true;
-            queueMicrotask(() => {
-                if (this._buffer.length === 0) {
-                    this.readableEnded = true;
-                    this.emit('end');
-                }
-            });
+            // Route end emission through the same drain path as data so a flowing
+            // 'end' can never overtake still-pending 'data' emits (and fires once).
+            this._scheduleDrain();
             return false;
         }
         if (this._flowing) {
-            queueMicrotask(() => this.emit('data', chunk));
+            // Buffer + coalesced drain instead of an independent per-chunk
+            // microtask: keeps data ordered ahead of 'end' on the single path.
+            this._buffer.push(chunk);
+            this._scheduleDrain();
         } else {
             this._buffer.push(chunk);
             this.emit('readable');
         }
         return !this._paused;
+    }
+
+    protected _scheduleDrain(): void {
+        if (this._drainScheduled) return;
+        this._drainScheduled = true;
+        queueMicrotask(() => {
+            this._drainScheduled = false;
+            this._drainBuffer();
+        });
     }
 
     read(): unknown {
@@ -163,14 +174,15 @@ export class Readable extends Stream {
     override resume(): this {
         this._paused = false;
         this._flowing = true;
-        queueMicrotask(() => this._drainBuffer());
+        this._scheduleDrain();
         this.emit('resume');
         return this;
     }
 
     protected _drainBuffer(): void {
         while (this._flowing && this._buffer.length > 0) this.emit('data', this._buffer.shift());
-        if (this._ended && this._buffer.length === 0) {
+        if (this._ended && this._buffer.length === 0 && !this._endEmitted) {
+            this._endEmitted = true;
             this.readableEnded = true;
             this.emit('end');
         }
@@ -190,7 +202,7 @@ export class Readable extends Stream {
         super.on(event, listener);
         if (event === 'data' && this._flowing === null) {
             this._flowing = true;
-            queueMicrotask(() => this._drainBuffer());
+            this._scheduleDrain();
         }
         return this;
     }

--- a/packages/node/stream/src/index.browser.spec.ts
+++ b/packages/node/stream/src/index.browser.spec.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: MIT
+// Browser-target conformance spec for @gjsify/stream.
+//
+// Imports the package's OWN browser entry directly (`./browser.js`) — the thin
+// EventEmitter + queue adapter the bundler picks via the `"browser"` export
+// condition under `gjsify build --app browser`. It must NOT re-export
+// `./test.mjs` (that drags in the full GJS impl + `@gjsify/node-globals`
+// register side-effects, which have no browser equivalent) and must NOT import
+// `@gjsify/stream` (the bare specifier routes back through the GJS impl).
+//
+// Asserts the browser-safe surface: Readable/Writable/Transform/PassThrough
+// construct; a Readable emits 'data' + 'end'; pipe / pipeline / finished work;
+// basic write-side backpressure. The adapter is microtask-scheduled, so the
+// event-driven assertions resolve via Promises.
+
+import { describe, it, expect } from '@gjsify/unit';
+import {
+    Stream,
+    Readable,
+    Writable,
+    Duplex,
+    Transform,
+    PassThrough,
+    pipeline,
+    finished,
+} from './browser.js';
+
+export default async () => {
+    await describe('stream (browser)', async () => {
+        // ==================== construction ====================
+        await describe('construction', async () => {
+            await it('should construct each public class', async () => {
+                expect(new Stream() instanceof Stream).toBe(true);
+                expect(new Readable() instanceof Readable).toBe(true);
+                expect(new Writable() instanceof Writable).toBe(true);
+                expect(new Duplex() instanceof Duplex).toBe(true);
+                expect(new Transform() instanceof Transform).toBe(true);
+                expect(new PassThrough() instanceof PassThrough).toBe(true);
+            });
+
+            await it('should expose helpers as functions', async () => {
+                expect(typeof pipeline).toBe('function');
+                expect(typeof finished).toBe('function');
+            });
+
+            await it('should set readable/writable flags', async () => {
+                expect(new Readable().readable).toBe(true);
+                expect(new Writable().writable).toBe(true);
+            });
+        });
+
+        // ==================== Readable emits 'data' + 'end' ====================
+        await describe('Readable data + end', async () => {
+            await it('should emit pushed chunks as data then end', async () => {
+                const r = new Readable();
+                const chunks: unknown[] = [];
+                await new Promise<void>((res, rej) => {
+                    r.on('data', (chunk) => chunks.push(chunk));
+                    r.on('end', () => {
+                        try {
+                            expect(chunks).toStrictEqual(['a', 'b', 'c']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    r.push('a');
+                    r.push('b');
+                    r.push('c');
+                    r.push(null);
+                });
+            });
+
+            await it('should yield chunks via the async iterator', async () => {
+                const r = new Readable();
+                r.push(1);
+                r.push(2);
+                r.push(null);
+                const out: unknown[] = [];
+                for await (const chunk of r) out.push(chunk);
+                expect(out).toStrictEqual([1, 2]);
+            });
+
+            await it('Readable.from should drain an iterable', async () => {
+                const r = Readable.from([10, 20, 30]);
+                const out: unknown[] = [];
+                await new Promise<void>((res, rej) => {
+                    r.on('data', (c) => out.push(c));
+                    r.on('end', () => {
+                        try {
+                            expect(out).toStrictEqual([10, 20, 30]);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                });
+            });
+        });
+
+        // ==================== Writable ====================
+        await describe('Writable', async () => {
+            await it('should collect writes via the _write hook', async () => {
+                const written: unknown[] = [];
+                const w = new Writable();
+                w._write = (chunk, _enc, cb) => {
+                    written.push(chunk);
+                    cb();
+                };
+                await new Promise<void>((res, rej) => {
+                    w.on('finish', () => {
+                        try {
+                            expect(written).toStrictEqual(['x', 'y']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    w.write('x');
+                    w.write('y');
+                    w.end();
+                });
+            });
+
+            await it('should error on write after end', async () => {
+                const w = new Writable();
+                w._write = (_chunk, _enc, cb) => cb();
+                await new Promise<void>((res, rej) => {
+                    w.on('error', (err) => {
+                        try {
+                            expect((err as Error).message).toBe('write after end');
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    w.end();
+                    w.write('late');
+                });
+            });
+        });
+
+        // ==================== Transform / PassThrough ====================
+        await describe('Transform + PassThrough', async () => {
+            await it('Transform should map chunks through _transform', async () => {
+                const t = new Transform({
+                    transform(chunk, _enc, cb) {
+                        cb(null, String(chunk).toUpperCase());
+                    },
+                });
+                const out: unknown[] = [];
+                await new Promise<void>((res, rej) => {
+                    t.on('data', (c) => out.push(c));
+                    t.on('end', () => {
+                        try {
+                            expect(out).toStrictEqual(['AB', 'CD']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    t.write('ab');
+                    t.write('cd');
+                    t.end();
+                });
+            });
+
+            await it('PassThrough should forward chunks unchanged', async () => {
+                const p = new PassThrough();
+                const out: unknown[] = [];
+                await new Promise<void>((res, rej) => {
+                    p.on('data', (c) => out.push(c));
+                    p.on('end', () => {
+                        try {
+                            expect(out).toStrictEqual(['one', 'two']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    p.write('one');
+                    p.write('two');
+                    p.end();
+                });
+            });
+        });
+
+        // ==================== pipe ====================
+        await describe('pipe', async () => {
+            await it('should pipe Readable → PassThrough and forward data', async () => {
+                const src = new Readable();
+                const dst = new PassThrough();
+                const out: unknown[] = [];
+                await new Promise<void>((res, rej) => {
+                    dst.on('data', (c) => out.push(c));
+                    dst.on('end', () => {
+                        try {
+                            expect(out).toStrictEqual(['p', 'q']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    src.pipe(dst);
+                    src.push('p');
+                    src.push('q');
+                    src.push(null);
+                });
+            });
+        });
+
+        // ==================== pipeline ====================
+        await describe('pipeline', async () => {
+            await it('should run source → transform → sink and call back', async () => {
+                const src = new Readable();
+                const through = new PassThrough();
+                const out: unknown[] = [];
+                const sink = new Writable();
+                sink._write = (chunk, _enc, cb) => {
+                    out.push(chunk);
+                    cb();
+                };
+                await new Promise<void>((res, rej) => {
+                    pipeline(src, through, sink, (err) => {
+                        try {
+                            expect(err).toBeFalsy();
+                            expect(out).toStrictEqual(['1', '2']);
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    src.push('1');
+                    src.push('2');
+                    src.push(null);
+                });
+            });
+        });
+
+        // ==================== finished ====================
+        await describe('finished', async () => {
+            await it('should call back when a Readable ends', async () => {
+                const r = new Readable();
+                await new Promise<void>((res, rej) => {
+                    finished(r, (err) => {
+                        try {
+                            expect(err).toBeFalsy();
+                            res();
+                        } catch (e) {
+                            rej(e);
+                        }
+                    });
+                    r.push('done');
+                    r.push(null);
+                    r.resume();
+                });
+            });
+        });
+
+        // ==================== backpressure ====================
+        await describe('backpressure', async () => {
+            await it('write should report not-ready while a slow _write is in flight', async () => {
+                const w = new Writable();
+                let release: (() => void) | undefined;
+                w._write = (_chunk, _enc, cb) => {
+                    release = () => cb();
+                };
+                // First write starts the in-flight _write that never calls back yet.
+                const ready = w.write('chunk');
+                expect(ready).toBe(false);
+                // Drain it so the stream can settle and no error leaks.
+                release?.();
+                await new Promise<void>((res, rej) => {
+                    w.on('drain', () => res());
+                    w.on('error', (e) => rej(e));
+                });
+            });
+        });
+    });
+};

--- a/packages/node/stream/src/test.browser.mts
+++ b/packages/node/stream/src/test.browser.mts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Browser test entry for @gjsify/stream — runs the browser-target conformance
+// spec (`index.browser.spec.ts`, which imports the `./browser.js` polyfill
+// directly) under `gjsify build --app browser` (Playwright/Firefox/SpiderMonkey).
+
+import { run } from '@gjsify/unit';
+
+import testSuite from './index.browser.spec.js';
+
+run({ testSuite });


### PR DESCRIPTION
Adds real browser-target tests for `@gjsify/stream` and `@gjsify/domain`, and fixes `@gjsify/buffer`'s hollow one.

Each spec imports the package's **own** browser entry via a relative path (stream → `./browser.js`, domain/buffer → `./index.js`) and asserts real, browser-safe behavior. None re-export `test.mts` — that re-export is what previously dragged in GJS-only register side-effects (stream/domain) or tree-shook the buffer bundle to 0 bytes.

## What's added

- **stream** — `src/index.browser.spec.ts` + `src/test.browser.mts`: Readable/Writable/Transform/PassThrough construction, a Readable emitting `data` then `end`, the async iterator, `Readable.from`, `pipe`, `pipeline`, `finished`, and write-side backpressure.
- **domain** — `src/index.browser.spec.ts` + `src/test.browser.mts`: the deprecated no-op surface — `create()`/`createDomain()` build a `Domain`, `run(fn)` executes and returns, and `add`/`remove`/`bind`/`intercept`/`enter`/`exit`/`dispose` exist and don't throw.
- **buffer** — replaces the hollow `src/test.browser.mts` with `src/index.browser.spec.ts` (direct `./index.js` import): `Buffer.from`/`alloc`, `toString('utf8'|'base64'|'hex')`, `Buffer.concat`, `Buffer.byteLength`.

`build:test:browser` scripts added to stream and domain (buffer already had one).

## Fixes surfaced by the specs

- **stream browser adapter**: a flowing Readable emitted `end` before still-pending `data` (and twice). End emission now goes through the single coalesced drain path with a once-guard, so `data` always precedes `end`.
- **domain**: added the missing `createDomain` alias (Node aliases `create` and `createDomain` to the same factory).

## Verification

- `tsc --noEmit` clean in stream, domain, buffer.
- Browser bundles: stream 59.6 KB, domain 52.0 KB, buffer 65.5 KB — all non-empty with real assertions (60+ `expect` calls each), zero `gi://`/`@girs/` references.
- Node-target build of each spec runs green: stream 22/22, domain 24/24, buffer 24/24. Existing domain suite still 10/10.
- `audit-runtimes --check`: OK.

`dist/` output is gitignored; only spec/test files + `package.json` + the two impl fixes are committed.