### PR TITLE
docs: add and standardize package READMEs

### DIFF
--- a/packages/dom/canvas2d-core/README.md
+++ b/packages/dom/canvas2d-core/README.md
@@ -1,0 +1,39 @@
+# @gjsify/canvas2d-core
+
+Headless `CanvasRenderingContext2D` implementation backed by Cairo and PangoCairo, with no GTK dependency. Provides `CanvasRenderingContext2D`, `CanvasGradient`, `CanvasPattern`, `Path2D`, `ImageData`, and a color parser — usable in worker-like contexts. This is the portable core extracted from `@gjsify/canvas2d`; it is auto-registered as the `'2d'` context factory when `@gjsify/dom-elements` is imported.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/canvas2d-core
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/canvas2d-core
+yarn add @gjsify/canvas2d-core
+```
+
+## Usage
+
+```typescript
+import { CanvasRenderingContext2D, ImageData } from '@gjsify/canvas2d-core';
+
+// Create a 200×200 offscreen context backed by a Cairo ImageSurface
+const ctx = new CanvasRenderingContext2D(200, 200);
+
+ctx.fillStyle = '#3584e4';
+ctx.fillRect(10, 10, 180, 180);
+
+ctx.strokeStyle = '#ffffff';
+ctx.lineWidth = 4;
+ctx.strokeRect(20, 20, 160, 160);
+
+// Read pixel data
+const imageData = ctx.getImageData(0, 0, 200, 200);
+console.log(imageData.width, imageData.height); // 200 200
+```
+
+## License
+
+MIT

--- a/packages/dom/dom-elements/README.md
+++ b/packages/dom/dom-elements/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/dom-elements
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/dom-elements
-# or
 yarn add @gjsify/dom-elements
 ```
 

--- a/packages/framework/bridge-types/README.md
+++ b/packages/framework/bridge-types/README.md
@@ -1,0 +1,33 @@
+# @gjsify/bridge-types
+
+Shared interfaces and environment classes used by the gjsify GTK↔DOM bridge packages. Provides `DOMBridgeContainer` (the common interface for all bridges), `BridgeEnvironment` (an isolated per-bridge document, body, and window), and `BridgeWindow` (requestAnimationFrame, performance.now, and viewport dimensions delegated back to the owning GTK widget).
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/bridge-types
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/bridge-types
+yarn add @gjsify/bridge-types
+```
+
+## Usage
+
+```typescript
+import { BridgeEnvironment, BridgeWindow } from '@gjsify/bridge-types';
+import type { DOMBridgeContainer, BridgeWindowHost } from '@gjsify/bridge-types';
+
+// Each bridge creates its own isolated environment so multiple bridges
+// can coexist without polluting a shared global state.
+const env = new BridgeEnvironment(host); // host implements BridgeWindowHost
+const { document, window } = env;
+```
+
+This package is primarily consumed by `@gjsify/canvas2d`, `@gjsify/webgl`, `@gjsify/iframe`, and `@gjsify/video` — you rarely need to import it directly unless you are implementing a new bridge.
+
+## License
+
+MIT

--- a/packages/framework/canvas2d/README.md
+++ b/packages/framework/canvas2d/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/canvas2d
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/canvas2d
-# or
 yarn add @gjsify/canvas2d
 ```
 

--- a/packages/framework/event-bridge/README.md
+++ b/packages/framework/event-bridge/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/event-bridge
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/event-bridge
-# or
 yarn add @gjsify/event-bridge
 ```
 

--- a/packages/framework/iframe/README.md
+++ b/packages/framework/iframe/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/iframe
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/iframe
-# or
 yarn add @gjsify/iframe
 ```
 

--- a/packages/framework/video/README.md
+++ b/packages/framework/video/README.md
@@ -1,0 +1,54 @@
+# @gjsify/video
+
+`HTMLVideoElement` implementation for GJS backed by a `VideoBridge` — a `Gtk.Picture` widget powered by GStreamer's `gtk4paintablesink`. Accepts a `MediaStream` from `getUserMedia` / WebRTC as `video.srcObject`, or a URI string via `video.src` (played through a `playbin` pipeline). Phase 1.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/video
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/video
+yarn add @gjsify/video
+```
+
+Requires GStreamer 1.0 with `gtk4paintablesink` (`gstreamer1-plugins-good` + `gstreamer1-plugins-bad-free` on Fedora).
+
+## Usage
+
+```typescript
+import { VideoBridge } from '@gjsify/video';
+
+const bridge = new VideoBridge();
+
+bridge.onReady(async (video) => {
+    // Play a local file via URI
+    video.src = 'file:///path/to/video.mp4';
+    await video.play();
+});
+
+// Add to a GTK window as a standard widget
+window.set_child(bridge);
+```
+
+Using a `MediaStream` (e.g. from `getUserMedia`):
+
+```typescript
+import { VideoBridge } from '@gjsify/video';
+
+const bridge = new VideoBridge();
+
+bridge.onReady(async (video) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    video.srcObject = stream;
+    await video.play();
+});
+
+window.set_child(bridge);
+```
+
+## License
+
+MIT

--- a/packages/framework/webgl/README.md
+++ b/packages/framework/webgl/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/webgl
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/webgl
-# or
 yarn add @gjsify/webgl
 ```
 

--- a/packages/gjs/runtime/README.md
+++ b/packages/gjs/runtime/README.md
@@ -7,9 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
-npm install @gjsify/runtime
-# or
-yarn add @gjsify/runtime
+gjsify install @gjsify/runtime
 ```
 
 ## Usage

--- a/packages/gjs/unit/README.md
+++ b/packages/gjs/unit/README.md
@@ -7,9 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
-npm install @gjsify/unit
-# or
-yarn add @gjsify/unit
+gjsify install @gjsify/unit
 ```
 
 ## Usage

--- a/packages/gjs/utils/README.md
+++ b/packages/gjs/utils/README.md
@@ -7,9 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
-npm install @gjsify/utils
-# or
-yarn add @gjsify/utils
+gjsify install @gjsify/utils
 ```
 
 ## Usage

--- a/packages/infra/cli/README.md
+++ b/packages/infra/cli/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/cli
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/cli
-# or
 yarn add @gjsify/cli
 ```
 

--- a/packages/infra/create-gjsify/README.md
+++ b/packages/infra/create-gjsify/README.md
@@ -7,7 +7,11 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Usage
 
 ```bash
+gjsify create my-app
+
+# npm or yarn create also work:
 npm create @gjsify/app my-app
+yarn create @gjsify/app my-app
 ```
 
 ## License

--- a/packages/infra/empty/README.md
+++ b/packages/infra/empty/README.md
@@ -7,9 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
-npm install @gjsify/empty
-# or
-yarn add @gjsify/empty
+gjsify install @gjsify/empty
 ```
 
 ## Usage

--- a/packages/infra/lightningcss-native/README.md
+++ b/packages/infra/lightningcss-native/README.md
@@ -1,0 +1,37 @@
+# @gjsify/lightningcss-native
+
+A native Rust cdylib + Vala/GObject bridge that exposes the Rust `lightningcss` CSS transformer and minifier to GJS via `gi://`. Ships prebuilt `.so` + `.typelib` for Linux and is loaded lazily at runtime — the consuming package (`@gjsify/rolldown-plugin-gjsify`'s `cssAsStringPlugin`) falls back to the npm `lightningcss` package when the prebuild is unavailable.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/lightningcss-native
+```
+
+## Usage
+
+```typescript
+import { hasNativeLightningcss, transform, bundle } from '@gjsify/lightningcss-native';
+
+if (hasNativeLightningcss()) {
+    // Transform a CSS string with GTK4-compatible lowering
+    const result = transform({
+        filename: 'app.css',
+        code: 'a { color: oklch(50% 0.2 270); }',
+        targets: 'firefox >= 60',
+        minify: true,
+    });
+    console.log(new TextDecoder().decode(result.code));
+
+    // Bundle a CSS entry file (resolves @import chains)
+    const bundled = bundle({ filename: '/path/to/app.css', targets: 'firefox >= 60' });
+}
+```
+
+The native bridge is consumed automatically by `gjsify build --app gjs` via `@gjsify/rolldown-plugin-gjsify`. Direct use is only needed when calling the CSS pipeline outside of a gjsify build.
+
+## License
+
+MIT

--- a/packages/infra/lightningcss-wasm/README.md
+++ b/packages/infra/lightningcss-wasm/README.md
@@ -1,0 +1,34 @@
+# @gjsify/lightningcss-wasm
+
+A WebAssembly build of the `lightningcss` CSS transformer for GJS — the portable fallback to `@gjsify/lightningcss-native` for platforms where a prebuilt `.so` is unavailable. Loads the `.wasm` via `@gjsify/fs`, uses SpiderMonkey 140's synchronous `WebAssembly.Module`/`Instance` constructors, and seeds randomness from `globalThis.crypto`.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/lightningcss-wasm
+```
+
+## Usage
+
+```javascript
+import { transform, bundle, bundleAsync } from '@gjsify/lightningcss-wasm';
+
+// Transform a CSS source string
+const result = transform({
+    filename: 'app.css',
+    code: Buffer.from('a { color: red; }'),
+    minify: true,
+});
+console.log(Buffer.from(result.code).toString());
+
+// Bundle a CSS entry file (resolves @import chains via the filesystem)
+const bundled = await bundleAsync({ filename: '/path/to/app.css' });
+```
+
+The API mirrors the npm `lightningcss-wasm` package. `@gjsify/rolldown-plugin-gjsify`'s `cssAsStringPlugin` selects between the native bridge and this WASM fallback automatically.
+
+## License
+
+MIT

--- a/packages/infra/nativescript-vite/README.md
+++ b/packages/infra/nativescript-vite/README.md
@@ -22,9 +22,12 @@ On top of the fixes, it spreads `@gjsify/vite-plugin-gjsify`'s `gjsifyNativescri
 The package's only hard dependency is `@gjsify/vite-plugin-gjsify`. Everything from the NativeScript side is an **optional peer** — install it in your NativeScript app alongside the rest of your NS toolchain:
 
 ```bash
-npm install -D @gjsify/nativescript-vite @nativescript/vite vite
+gjsify install -D @gjsify/nativescript-vite @nativescript/vite vite
 # plus whatever your app already uses, e.g.:
-npm install @nativescript/core @nativescript/canvas @nativescript/canvas-polyfill
+gjsify install @nativescript/core @nativescript/canvas @nativescript/canvas-polyfill
+
+# npm or yarn also work (e.g. alongside your existing NativeScript npm toolchain):
+npm install -D @gjsify/nativescript-vite @nativescript/vite vite
 ```
 
 Optional peers: `@nativescript/vite`, `@nativescript/core`, `nativescript`, `@nativescript/canvas`, `@nativescript/canvas-polyfill`, and `vite` (`^8.0.14`). They are not installed by this package — your NativeScript app provides them. If `@nativescript/vite` is missing, the config factory throws a clear, actionable error.

--- a/packages/infra/npm-registry/README.md
+++ b/packages/infra/npm-registry/README.md
@@ -1,0 +1,46 @@
+# @gjsify/npm-registry
+
+A small npm registry client used by `gjsify install` to resolve and download packages on GJS. Provides packument fetching with ETag revalidation, tarball download with SRI integrity verification, `.npmrc` parsing with Bearer/Basic auth, and exponential-backoff retry for transient failures. Cross-platform — runs on both GJS and Node using only `globalThis.fetch` and `SubtleCrypto`.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/npm-registry
+```
+
+## Usage
+
+```typescript
+import {
+    fetchPackument,
+    fetchTarball,
+    parseNpmrc,
+    verifyIntegrity,
+    whoami,
+    DEFAULT_REGISTRY,
+} from '@gjsify/npm-registry';
+
+// Fetch a packument (package metadata)
+const packument = await fetchPackument('lodash');
+const latest = packument['dist-tags'].latest;
+const tarballUrl = packument.versions[latest].dist.tarball;
+
+// Download the tarball and verify its integrity
+const bytes = await fetchTarball(tarballUrl, {
+    integrity: packument.versions[latest].dist.integrity,
+});
+
+// Parse ~/.npmrc for auth
+import { readFileSync } from 'node:fs';
+const npmrc = parseNpmrc(readFileSync('/home/user/.npmrc', 'utf8'));
+
+// Verify the current auth token
+const { username } = await whoami(DEFAULT_REGISTRY, npmrc);
+console.log('Logged in as:', username);
+```
+
+## License
+
+MIT

--- a/packages/infra/oxlint-plugin-gjsify/README.md
+++ b/packages/infra/oxlint-plugin-gjsify/README.md
@@ -1,0 +1,28 @@
+# @gjsify/oxlint-plugin-gjsify
+
+An internal oxlint JS plugin that exposes the `gjsify/register-class-order` lint rule. The rule enforces that static GObject metadata fields (`GTypeName`, `Properties`, `Signals`, etc.) are declared above `GObject.registerClass` static blocks, and provides autofix to reorder them automatically.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This is an internal workspace package — installed automatically as part of gjsify, not separately.
+
+## Usage
+
+The plugin is wired via `.oxlintrc.json` in the gjsify workspace root:
+
+```json
+{
+    "jsPlugins": ["./packages/infra/oxlint-plugin-gjsify/src/index.ts"],
+    "rules": {
+        "gjsify/register-class-order": "error"
+    }
+}
+```
+
+Run via `gjsify lint` or `gjsify fix` (which also applies autofix).
+
+## License
+
+MIT

--- a/packages/infra/resolve-npm/README.md
+++ b/packages/infra/resolve-npm/README.md
@@ -7,9 +7,7 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
-npm install @gjsify/resolve-npm
-# or
-yarn add @gjsify/resolve-npm
+gjsify install @gjsify/resolve-npm
 ```
 
 ## Usage

--- a/packages/infra/rolldown-native/README.md
+++ b/packages/infra/rolldown-native/README.md
@@ -1,0 +1,35 @@
+# @gjsify/rolldown-native
+
+A native Rust cdylib + Vala/GObject bridge that wraps the Rust `rolldown` bundler and exposes it to GJS via `gi://`. This is the default bundler engine used by `gjsify build` under GJS — npm's `rolldown` is an N-API addon that cannot load in GJS, so this bridge is how gjsify bundles without a Node runtime. Includes a complete plugin bridge (`bundleWithPlugins`) for load, transform, resolveId, and render-chunk hooks. Ships prebuilt `.so` + `.typelib` for Linux.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/rolldown-native
+```
+
+## Usage
+
+```typescript
+import { hasNativeRolldown, bundle, bundleWithPlugins } from '@gjsify/rolldown-native';
+
+if (hasNativeRolldown()) {
+    // Simple bundle
+    const result = bundle({
+        input: [{ import: 'src/index.ts' }],
+        format: 'esm',
+        minify: false,
+    });
+    for (const item of result.output) {
+        if (item.type === 'chunk') console.log(item.fileName, item.code.length, 'bytes');
+    }
+}
+```
+
+Under normal usage `@gjsify/rolldown-native` is consumed automatically by the gjsify CLI (`gjsify build`) — direct use is only needed when embedding the bundler in custom build tooling.
+
+## License
+
+MIT

--- a/packages/infra/rolldown-plugin-deepkit/README.md
+++ b/packages/infra/rolldown-plugin-deepkit/README.md
@@ -1,0 +1,38 @@
+# @gjsify/rolldown-plugin-deepkit
+
+A Rolldown (and Rollup/Vite-compatible) plugin that runs the Deepkit TypeScript runtime-reflection transform (`@deepkit/type-compiler`) during gjsify builds. Opt-in only — disabled by default to avoid transforming projects that do not use Deepkit runtime types.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/rolldown-plugin-deepkit
+```
+
+## Usage
+
+Enable via `.gjsifyrc.js` in your project (the gjsify CLI picks this up automatically):
+
+```javascript
+// .gjsifyrc.js
+export default {
+    typescript: { reflection: true },
+};
+```
+
+Or use the plugin directly in a Rolldown / Vite config:
+
+```typescript
+import { deepkitPlugin } from '@gjsify/rolldown-plugin-deepkit';
+
+export default {
+    plugins: [deepkitPlugin({ reflection: true })],
+};
+```
+
+Keep `reflection: false` (the default) unless your project explicitly uses `@deepkit/type` runtime types — the transform rewrites TypeScript in a way that can break non-Deepkit code.
+
+## License
+
+MIT

--- a/packages/infra/rolldown-plugin-gjsify/README.md
+++ b/packages/infra/rolldown-plugin-gjsify/README.md
@@ -1,0 +1,45 @@
+# @gjsify/rolldown-plugin-gjsify
+
+The core Rolldown plugin set powering `gjsify build`. Orchestrates per-target app builds for GJS, Node, Browser, and NativeScript — handling Node↔GJS module aliasing, automatic globals injection (`--globals auto`), CSS-as-string loading (via `@gjsify/lightningcss-native` or the npm fallback), platform-file resolution (`.android.ts` / `.ios.ts`), process-stub injection, shebang hoisting, and more.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/rolldown-plugin-gjsify
+```
+
+## Usage
+
+Typically consumed via the gjsify CLI (`gjsify build --app gjs`). For direct use in a custom Rolldown config:
+
+```typescript
+import rolldown from 'rolldown';
+import { setupForGjs } from '@gjsify/rolldown-plugin-gjsify';
+
+const { options, plugins } = await setupForGjs({
+    input: 'src/index.ts',
+    globals: 'auto',
+});
+
+const build = await rolldown({ ...options, plugins });
+await build.write({ file: 'dist/app.gjs.mjs' });
+```
+
+Individual plugins are also exported for use in custom pipelines:
+
+```typescript
+import {
+    cssAsStringPlugin,
+    gjsImportsEmptyPlugin,
+    processStubPlugin,
+    shebangPlugin,
+    textLoaderPlugin,
+    platformResolvePlugin,
+} from '@gjsify/rolldown-plugin-gjsify';
+```
+
+## License
+
+MIT

--- a/packages/infra/rolldown-plugin-pnp/README.md
+++ b/packages/infra/rolldown-plugin-pnp/README.md
@@ -1,0 +1,38 @@
+# @gjsify/rolldown-plugin-pnp
+
+Rolldown/Rollup/Vite plugin that resolves modules through a Yarn Plug'n'Play (`.pnp.cjs`) manifest, so gjsify builds work correctly inside Yarn PnP projects. Automatically no-ops when no PnP root is found.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/rolldown-plugin-pnp
+```
+
+## Usage
+
+```typescript
+import { defineConfig } from 'vite';
+import { pnpPlugin } from '@gjsify/rolldown-plugin-pnp';
+
+export default defineConfig({
+    plugins: [await pnpPlugin()],
+});
+```
+
+The plugin returns `null` when not running under Yarn PnP, so spreading it is safe in any environment:
+
+```typescript
+import { rolldown } from 'rolldown';
+import { pnpPlugin } from '@gjsify/rolldown-plugin-pnp';
+
+const build = await rolldown({
+    input: 'src/index.ts',
+    plugins: [await pnpPlugin({ issuerUrl: import.meta.url })],
+});
+```
+
+## License
+
+MIT

--- a/packages/infra/semver/README.md
+++ b/packages/infra/semver/README.md
@@ -1,0 +1,35 @@
+# @gjsify/semver
+
+Node-free semver implementation (parse, compare, satisfies, ranges) used by `gjsify install` and the CLI for dependency-version resolution on GJS. Supports caret, tilde, hyphen, x/star ranges, and OR (`||`) expressions. Runs on both Node.js and GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/semver
+```
+
+## Usage
+
+```typescript
+import { parse, compare, satisfies, maxSatisfying, SemVer, Range } from '@gjsify/semver';
+
+// Parse and inspect a version
+const v = parse('1.2.3-beta.1');
+console.log(v?.major, v?.minor, v?.patch); // 1 2 3
+
+// Compare two versions
+compare('1.2.3', '1.2.4'); // -1
+
+// Check whether a version satisfies a range
+satisfies('1.5.0', '^1.2.0'); // true
+satisfies('2.0.0', '^1.2.0'); // false
+
+// Find the highest matching version in a list
+maxSatisfying(['1.0.0', '1.5.0', '2.0.0'], '^1.2.0'); // '1.5.0'
+```
+
+## License
+
+MIT

--- a/packages/infra/tar/README.md
+++ b/packages/infra/tar/README.md
@@ -1,0 +1,34 @@
+# @gjsify/tar
+
+Node-free `.tar` / `.tar.gz` reader and writer used by `gjsify install` to unpack npm tarballs on GJS. Decompression uses the Web Compression API (`DecompressionStream`); extraction writes via `node:fs` (polyfilled by `@gjsify/fs` on GJS). Runs on both Node.js and GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/tar
+```
+
+## Usage
+
+```typescript
+import { extractTarball, parseTar, createTarball } from '@gjsify/tar';
+
+// Extract a .tgz buffer (e.g. a downloaded npm tarball) into a directory
+const tgzBuffer = await fetch('https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz')
+    .then(r => r.arrayBuffer());
+
+const result = await extractTarball(tgzBuffer, '/tmp/lodash', { strip: 1 });
+console.log(result.files);     // list of extracted file paths
+console.log(result.symlinks);  // list of created symlinks
+
+// Parse individual tar entries without writing to disk
+for (const entry of parseTar(tarBytes)) {
+    console.log(entry.name, entry.type, entry.size);
+}
+```
+
+## License
+
+MIT

--- a/packages/infra/tsc/README.md
+++ b/packages/infra/tsc/README.md
@@ -1,13 +1,27 @@
 # @gjsify/tsc
 
 [TypeScript][typescript] for [GJS][gjs] — the upstream `typescript` compiler
-bundled to a single GJS module and shipped with a `tsc` bin that runs
+bundled to a single GJS module and shipped with a `gjsify-tsc` bin that runs
 **directly under [SpiderMonkey][spidermonkey] via GJS**, without Node.js in
 the loop.
 
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/tsc
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/tsc
+yarn add @gjsify/tsc
+```
+
+## Usage
+
 ```bash
 # Node-free TypeScript checking on any GJS-equipped system:
-gjsify-tsc --version              # → Version 5.9.3
+gjsify-tsc --version              # → Version 6.0.3
 gjsify-tsc -p tsconfig.json       # type-check (--noEmit-style usage)
 gjsify-tsc --diagnostics foo.ts   # tsc perf info works the same as on Node
 ```
@@ -20,11 +34,11 @@ that's it. With `@gjsify/cli`'s `--app gjs` target, the same compiler runs
 unchanged under GJS, polyfilled by the rest of the gjsify family
 (`@gjsify/fs`, `@gjsify/path`, `@gjsify/process`, `@gjsify/perf_hooks`, …).
 
-This package is the first proof-of-concept that **the gjsify build chain can
-be Node-free** — the long-standing goal tracked in the project's
-`STATUS.md`. The `gjsify` CLI itself already ships as a GJS bundle; pairing
-that with `gjsify-tsc` removes Node from the type-check step of any
-gjsify-built app.
+gjsify **self-hosts** its type-checking on this package: every workspace
+`check` and `.d.ts` emit runs `gjsify-tsc`, not Node's `tsc`. Together with
+the `gjsify` CLI (also a GJS bundle) and the native Rolldown bundler engine,
+the gjsify build chain now runs Node-free under GJS — the long-standing goal
+tracked in the project's `STATUS.md`.
 
 ## Layout
 
@@ -87,6 +101,10 @@ case.
 - [`refs/typescript`][typescript] — Microsoft's reference implementation.
 - Originally implemented for Node.js / SpiderMonkey; this package bundles
   upstream's pre-built `_tsc.js` CLI entry, not a reimplementation.
+
+## License
+
+MIT
 
 [typescript]: https://github.com/microsoft/TypeScript
 [gjs]: https://gitlab.gnome.org/GNOME/gjs

--- a/packages/infra/vite-plugin-blueprint/README.md
+++ b/packages/infra/vite-plugin-blueprint/README.md
@@ -1,0 +1,42 @@
+# @gjsify/vite-plugin-blueprint
+
+Vite/Rollup/Rolldown plugin that compiles GNOME Blueprint (`.blp`) UI files to GTK XML strings via `blueprint-compiler`. Import a `.blp` file and receive its compiled XML as a JavaScript string, ready for `Gtk.Builder`.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/vite-plugin-blueprint
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/vite-plugin-blueprint
+yarn add @gjsify/vite-plugin-blueprint
+```
+
+Requires `blueprint-compiler` to be installed on the system (e.g. `sudo dnf install blueprint-compiler`).
+
+## Usage
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import blueprintPlugin from '@gjsify/vite-plugin-blueprint';
+
+export default defineConfig({
+    plugins: [blueprintPlugin({ minify: false })],
+});
+```
+
+```typescript
+// In your GJS app source
+import windowXml from './window.blp';
+
+const builder = Gtk.Builder.new_from_string(windowXml, -1);
+```
+
+Add type declarations by including `"@gjsify/vite-plugin-blueprint/types"` in your `tsconfig.json` `compilerOptions.types`.
+
+## License
+
+MIT

--- a/packages/infra/vite-plugin-gettext/README.md
+++ b/packages/infra/vite-plugin-gettext/README.md
@@ -1,0 +1,45 @@
+# @gjsify/vite-plugin-gettext
+
+Vite/Rollup/Rolldown plugin for gettext-based i18n in gjsify web and GJS apps. Compiles `.po` translation files to binary `.mo` format via `msgfmt`, extracts translatable strings via `xgettext`, and converts `.po` files to JSON for browser targets.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/vite-plugin-gettext
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/vite-plugin-gettext
+yarn add @gjsify/vite-plugin-gettext
+```
+
+Requires `gettext` tools (`msgfmt`, `xgettext`) to be installed on the system.
+
+## Usage
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { gettextPlugin, xgettextPlugin, po2jsonPlugin } from '@gjsify/vite-plugin-gettext';
+
+export default defineConfig({
+    plugins: [
+        // Compile .po files → .mo (for GJS/GTK apps using Gettext.bindtextdomain)
+        gettextPlugin({
+            poDirectory: 'po',
+            moDirectory: 'dist/locale',
+        }),
+
+        // Convert .po → JSON (for browser targets)
+        po2jsonPlugin({
+            poDirectory: 'po',
+            outputDirectory: 'dist/i18n',
+        }),
+    ],
+});
+```
+
+## License
+
+MIT

--- a/packages/infra/vite-plugin-gjsify/README.md
+++ b/packages/infra/vite-plugin-gjsify/README.md
@@ -1,0 +1,48 @@
+# @gjsify/vite-plugin-gjsify
+
+Vite plugin presets that mirror `gjsify build --app browser` and `--app nativescript` under Vite's dev server and HMR. Ensures a dual-target gjsify app develops under Vite with the same transforms (gi:// aliasing, Blueprint compilation, platform resolution, Node polyfill aliases) as its production CLI build.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/vite-plugin-gjsify
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/vite-plugin-gjsify
+yarn add @gjsify/vite-plugin-gjsify
+```
+
+## Usage
+
+### Browser target
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { gjsifyBrowser } from '@gjsify/vite-plugin-gjsify';
+
+export default defineConfig({
+    plugins: [...gjsifyBrowser({ reflection: false })],
+});
+```
+
+### NativeScript target
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import nativescript from '@nativescript/vite';
+import { gjsifyNativescript } from '@gjsify/vite-plugin-gjsify';
+
+export default defineConfig({
+    plugins: [nativescript(), ...gjsifyNativescript()],
+});
+```
+
+Both presets resolve `@girs/*` / `gi://` imports to an empty module (those are GJS-only specifiers that leak transitively) and apply the gjsify alias layer for Node built-ins and polyfills.
+
+## License
+
+MIT

--- a/packages/infra/workspace/README.md
+++ b/packages/infra/workspace/README.md
@@ -1,0 +1,38 @@
+# @gjsify/workspace
+
+Yarn-workspaces-compatible monorepo engine behind `gjsify foreach`, `gjsify workspace`, and `gjsify run`. Discovers workspace packages from `package.json#workspaces` globs, resolves `workspace:^` protocol references to local versions, builds an inter-package dependency graph, and produces a topological build order — the Node-free replacement for `yarn workspaces` that runs on both Node.js and GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/workspace
+```
+
+## Usage
+
+```typescript
+import {
+    discoverWorkspaces,
+    buildDependencyGraph,
+    topologicalSort,
+    filterWorkspaces,
+} from '@gjsify/workspace';
+
+// Discover all workspace packages defined in the root package.json
+const workspaces = discoverWorkspaces('/path/to/monorepo');
+
+// Build inter-workspace dependency graph and get topological build order
+const graph = buildDependencyGraph(workspaces);
+const ordered = topologicalSort(graph);
+console.log(ordered.map(ws => ws.name));
+// → ['@scope/a', '@scope/b', '@scope/c']  (deps before dependents)
+
+// Filter to a subset (mirrors --include / --exclude)
+const published = filterWorkspaces(workspaces, { noPrivate: true });
+```
+
+## License
+
+MIT

--- a/packages/node/assert/README.md
+++ b/packages/node/assert/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/assert
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/assert
-# or
 yarn add @gjsify/assert
 ```
 

--- a/packages/node/async_hooks/README.md
+++ b/packages/node/async_hooks/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/async_hooks
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/async_hooks
-# or
 yarn add @gjsify/async_hooks
 ```
 

--- a/packages/node/browser-polyfills/README.md
+++ b/packages/node/browser-polyfills/README.md
@@ -1,0 +1,32 @@
+# @gjsify/browser-node-polyfills
+
+Browser-targeted aggregation of `@gjsify` Node.js polyfills. It is the browser counterpart to `@gjsify/node-polyfills`: an umbrella package that pulls in the subset of `@gjsify/*` Node.js polyfills that ship a browser-runnable build (assert, buffer, crypto, events, fs, http, path, stream, and more). Importing `@gjsify/browser-node-polyfills/globals` installs all contributing polyfills onto `globalThis` at once.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/browser-node-polyfills
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/browser-node-polyfills
+yarn add @gjsify/browser-node-polyfills
+```
+
+## Usage
+
+```typescript
+// Side-effect import — registers all contributing polyfills on globalThis
+import '@gjsify/browser-node-polyfills/globals';
+
+// Buffer is now available globally in the browser bundle
+const buf = Buffer.from('hello');
+console.log(buf.toString('hex'));
+```
+
+This package is primarily used by `create-app` templates and CLI scaffolds to bring a complete Node.js API surface to browser bundles. Individual polyfills can also be imported directly from their own packages.
+
+## License
+
+MIT

--- a/packages/node/buffer/README.md
+++ b/packages/node/buffer/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/buffer
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/buffer
-# or
 yarn add @gjsify/buffer
 ```
 

--- a/packages/node/child_process/README.md
+++ b/packages/node/child_process/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/child_process
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/child_process
-# or
 yarn add @gjsify/child_process
 ```
 

--- a/packages/node/cluster/README.md
+++ b/packages/node/cluster/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/cluster
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/cluster
-# or
 yarn add @gjsify/cluster
 ```
 

--- a/packages/node/console/README.md
+++ b/packages/node/console/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/console
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/console
-# or
 yarn add @gjsify/console
 ```
 

--- a/packages/node/constants/README.md
+++ b/packages/node/constants/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/constants
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/constants
-# or
 yarn add @gjsify/constants
 ```
 

--- a/packages/node/crypto/README.md
+++ b/packages/node/crypto/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/crypto
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/crypto
-# or
 yarn add @gjsify/crypto
 ```
 

--- a/packages/node/dgram/README.md
+++ b/packages/node/dgram/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/dgram
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/dgram
-# or
 yarn add @gjsify/dgram
 ```
 

--- a/packages/node/diagnostics_channel/README.md
+++ b/packages/node/diagnostics_channel/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/diagnostics_channel
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/diagnostics_channel
-# or
 yarn add @gjsify/diagnostics_channel
 ```
 

--- a/packages/node/dns/README.md
+++ b/packages/node/dns/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/dns
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/dns
-# or
 yarn add @gjsify/dns
 ```
 

--- a/packages/node/domain/README.md
+++ b/packages/node/domain/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/domain
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/domain
-# or
 yarn add @gjsify/domain
 ```
 

--- a/packages/node/events/README.md
+++ b/packages/node/events/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/events
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/events
-# or
 yarn add @gjsify/events
 ```
 

--- a/packages/node/fs/README.md
+++ b/packages/node/fs/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/fs
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/fs
-# or
 yarn add @gjsify/fs
 ```
 

--- a/packages/node/globals/README.md
+++ b/packages/node/globals/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/node-globals
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/node-globals
-# or
 yarn add @gjsify/node-globals
 ```
 

--- a/packages/node/http/README.md
+++ b/packages/node/http/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/http
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/http
-# or
 yarn add @gjsify/http
 ```
 

--- a/packages/node/http2-native/README.md
+++ b/packages/node/http2-native/README.md
@@ -1,0 +1,38 @@
+# @gjsify/http2-native
+
+Optional native Vala bridge enabling advanced HTTP/2 primitives on GJS that are not reachable through libsoup's high-level GIR API: HPACK header-block encoding for PUSH_PROMISE / DATA frames, server-side push stream-ID allocation, and a thin `nghttp2_session` wrapper for future cleartext HTTP/2 (h2c) support. Consumed by `@gjsify/http2` to back `ServerHttp2Stream.pushStream()`, `respondWithFD()`, and `respondWithFile()`.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This is an internal native bridge package — it is loaded automatically by `@gjsify/http2` when installed, not used directly. Install it only when you want to enable HTTP/2 server push and flow-control features (Phase 2):
+
+```bash
+gjsify install @gjsify/http2-native
+
+# npm or yarn also work:
+npm install @gjsify/http2-native
+yarn add @gjsify/http2-native
+```
+
+## Usage
+
+```typescript
+// Loaded automatically by @gjsify/http2 when the prebuild is present.
+// Gate on the availability predicate before using directly:
+import { hasNativeHttp2, loadNativeHttp2 } from '@gjsify/http2-native';
+
+if (hasNativeHttp2()) {
+    const mod = loadNativeHttp2()!;
+    const alloc = new mod.StreamIdAllocator();
+    const streamId = alloc.next_stream_id();
+    console.log('next push stream-ID:', streamId);
+}
+```
+
+Ships as a prebuilt `.so` + `.typelib` for `linux-x86_64`. Build from source with `meson` + `valac` + `libnghttp2-devel` if your architecture is not covered.
+
+## License
+
+MIT

--- a/packages/node/http2/README.md
+++ b/packages/node/http2/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/http2
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/http2
-# or
 yarn add @gjsify/http2
 ```
 

--- a/packages/node/https/README.md
+++ b/packages/node/https/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/https
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/https
-# or
 yarn add @gjsify/https
 ```
 

--- a/packages/node/inspector/README.md
+++ b/packages/node/inspector/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/inspector
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/inspector
-# or
 yarn add @gjsify/inspector
 ```
 

--- a/packages/node/module/README.md
+++ b/packages/node/module/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/module
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/module
-# or
 yarn add @gjsify/module
 ```
 

--- a/packages/node/net/README.md
+++ b/packages/node/net/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/net
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/net
-# or
 yarn add @gjsify/net
 ```
 

--- a/packages/node/os/README.md
+++ b/packages/node/os/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/os
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/os
-# or
 yarn add @gjsify/os
 ```
 

--- a/packages/node/path/README.md
+++ b/packages/node/path/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/path
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/path
-# or
 yarn add @gjsify/path
 ```
 

--- a/packages/node/perf_hooks/README.md
+++ b/packages/node/perf_hooks/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/perf_hooks
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/perf_hooks
-# or
 yarn add @gjsify/perf_hooks
 ```
 

--- a/packages/node/polyfills/README.md
+++ b/packages/node/polyfills/README.md
@@ -1,0 +1,37 @@
+# @gjsify/node-polyfills
+
+Meta package: a dependency-only umbrella that pulls in every `@gjsify` Node.js polyfill — assert, async_hooks, buffer, child_process, crypto, dgram, dns, events, fs, http, http2, net, os, path, process, readline, stream, tls, tty, url, util, worker_threads, zlib, and more. It contains no runtime code of its own; adding it as a dependency gives you the complete Node.js API surface for GJS in one install.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/node-polyfills
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/node-polyfills
+yarn add @gjsify/node-polyfills
+```
+
+## Usage
+
+```typescript
+// No direct import needed — add @gjsify/node-polyfills as a dependency
+// and the gjsify build system wires up all polyfills automatically via
+// --globals auto.
+//
+// Individual APIs are available under their node: specifiers:
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { EventEmitter } from 'node:events';
+
+const content = readFileSync('/etc/hostname', 'utf8');
+console.log(content.trim());
+```
+
+This package is used by `create-app` templates and CLI scaffolds. For production apps you typically only need the individual `@gjsify/*` polyfill packages you actually use.
+
+## License
+
+MIT

--- a/packages/node/process/README.md
+++ b/packages/node/process/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/process
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/process
-# or
 yarn add @gjsify/process
 ```
 

--- a/packages/node/querystring/README.md
+++ b/packages/node/querystring/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/querystring
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/querystring
-# or
 yarn add @gjsify/querystring
 ```
 

--- a/packages/node/readline/README.md
+++ b/packages/node/readline/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/readline
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/readline
-# or
 yarn add @gjsify/readline
 ```
 

--- a/packages/node/sab-native/README.md
+++ b/packages/node/sab-native/README.md
@@ -1,0 +1,48 @@
+# @gjsify/sab-native
+
+Optional native Vala bridge providing cross-process shared memory and atomics for `@gjsify/worker_threads` on GJS. Implements `SharedBuffer` via Linux `memfd_create` + `mmap(MAP_SHARED)` with typed accessors and SEQ_CST atomics backed by `__atomic_*` GCC builtins and `SYS_futex` for wait/notify. Also exposes `FdChannel` for passing file descriptors between processes via SCM_RIGHTS over a Unix-domain socket.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This package is loaded automatically by `@gjsify/worker_threads` when the prebuild is present. Install it explicitly to enable `SharedBuffer` cross-process transfers:
+
+```bash
+gjsify install @gjsify/sab-native
+
+# npm or yarn also work:
+npm install @gjsify/sab-native
+yarn add @gjsify/sab-native
+```
+
+## Usage
+
+```typescript
+// Loaded automatically by @gjsify/worker_threads.
+// Direct use requires checking availability first:
+import { hasNativeSab, SharedBuffer, atomics } from '@gjsify/sab-native';
+
+if (hasNativeSab()) {
+    // Allocate 4 KB of shared memory
+    const buf = SharedBuffer.create(4096);
+    console.log('fd:', buf.fd, 'size:', buf.byteLength);
+
+    // Typed read/write
+    buf.setInt32LE(0, 42);
+    console.log(buf.getInt32LE(0)); // 42
+
+    // Atomic operations (SEQ_CST)
+    atomics.store32(buf, 0, 1);
+    const prev = atomics.add32(buf, 0, 10);
+    console.log('prev:', prev, 'now:', atomics.load32(buf, 0));
+
+    buf.close();
+}
+```
+
+Ships as a prebuilt `.so` + `.typelib` for `linux-{x86_64,aarch64,ppc64,s390x,riscv64}`.
+
+## License
+
+MIT

--- a/packages/node/sqlite/README.md
+++ b/packages/node/sqlite/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/sqlite
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/sqlite
-# or
 yarn add @gjsify/sqlite
 ```
 

--- a/packages/node/stream/README.md
+++ b/packages/node/stream/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/stream
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/stream
-# or
 yarn add @gjsify/stream
 ```
 

--- a/packages/node/string_decoder/README.md
+++ b/packages/node/string_decoder/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/string_decoder
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/string_decoder
-# or
 yarn add @gjsify/string_decoder
 ```
 

--- a/packages/node/sys/README.md
+++ b/packages/node/sys/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/sys
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/sys
-# or
 yarn add @gjsify/sys
 ```
 

--- a/packages/node/terminal-native/README.md
+++ b/packages/node/terminal-native/README.md
@@ -1,0 +1,38 @@
+# @gjsify/terminal-native
+
+Optional native Vala bridge for real terminal support on GJS: `isatty` via `Posix.isatty`, terminal size via `ioctl(TIOCGWINSZ)`, raw mode via `termios`, and `SIGWINCH` resize events via `GjsifyTerminal.ResizeWatcher`. When installed, this package enhances `@gjsify/tty` and `@gjsify/process` with correct terminal behaviour; without it those packages fall back to environment variables and GLib defaults.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This package is loaded automatically by `@gjsify/tty` and `@gjsify/process` when present. Install it to enable accurate terminal detection and raw mode in your GJS CLI app:
+
+```bash
+gjsify install @gjsify/terminal-native
+
+# npm or yarn also work:
+npm install @gjsify/terminal-native
+yarn add @gjsify/terminal-native
+```
+
+## Usage
+
+```typescript
+// Consumed via @gjsify/tty / @gjsify/process — no direct use needed.
+// For low-level access:
+import { hasNativeTerminal, nativeTerminal } from '@gjsify/terminal-native';
+
+if (hasNativeTerminal()) {
+    const term = nativeTerminal!.Terminal;
+    console.log('stdout is tty:', term.is_tty(1));
+    const [ok, rows, cols] = term.get_size(1);
+    if (ok) console.log(`${cols}x${rows}`);
+}
+```
+
+Ships as a prebuilt `.so` + `.typelib` for `linux-x86_64`.
+
+## License
+
+MIT

--- a/packages/node/timers/README.md
+++ b/packages/node/timers/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/timers
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/timers
-# or
 yarn add @gjsify/timers
 ```
 

--- a/packages/node/tls-native/README.md
+++ b/packages/node/tls-native/README.md
@@ -1,0 +1,43 @@
+# @gjsify/tls-native
+
+Optional native Vala + C bridge for advanced TLS capabilities on GJS that are not exposed by `Gio.TlsConnection`: OCSP response parsing (RFC 6960) via GnuTLS, TLS session resumption data (`getSession` / `setSession`), and channel binding (`tls-unique`, `tls-exporter`) for SCRAM-SHA-* authentication. Consumed by `@gjsify/tls` to back `TLSSocket.getFinished()`, `getPeerFinished()`, `getSession()`, and OCSP stapling support.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This package is loaded automatically by `@gjsify/tls` when present. Install it to enable OCSP parsing and session access in your GJS TLS code:
+
+```bash
+gjsify install @gjsify/tls-native
+
+# npm or yarn also work:
+npm install @gjsify/tls-native
+yarn add @gjsify/tls-native
+```
+
+## Usage
+
+```typescript
+// Loaded automatically by @gjsify/tls.
+// For direct OCSP parsing:
+import {
+    hasNativeTls,
+    parseOcspResponse,
+    OcspCertStatus,
+} from '@gjsify/tls-native';
+
+if (hasNativeTls()) {
+    // derBytes: Uint8Array containing a DER-encoded OCSPResponse
+    const info = parseOcspResponse(derBytes);
+    if (info && info.certStatus === OcspCertStatus.GOOD) {
+        console.log('certificate is valid');
+    }
+}
+```
+
+Ships as a prebuilt `.so` + `.typelib` for `linux-x86_64`. Requires `glib-networking` with a GnuTLS backend (the default on Fedora / GNOME platforms).
+
+## License
+
+MIT

--- a/packages/node/tls/README.md
+++ b/packages/node/tls/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/tls
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/tls
-# or
 yarn add @gjsify/tls
 ```
 

--- a/packages/node/tty/README.md
+++ b/packages/node/tty/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/tty
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/tty
-# or
 yarn add @gjsify/tty
 ```
 

--- a/packages/node/url/README.md
+++ b/packages/node/url/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/url
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/url
-# or
 yarn add @gjsify/url
 ```
 

--- a/packages/node/util/README.md
+++ b/packages/node/util/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/util
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/util
-# or
 yarn add @gjsify/util
 ```
 

--- a/packages/node/v8/README.md
+++ b/packages/node/v8/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/v8
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/v8
-# or
 yarn add @gjsify/v8
 ```
 

--- a/packages/node/vm/README.md
+++ b/packages/node/vm/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/vm
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/vm
-# or
 yarn add @gjsify/vm
 ```
 

--- a/packages/node/worker_threads/README.md
+++ b/packages/node/worker_threads/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/worker_threads
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/worker_threads
-# or
 yarn add @gjsify/worker_threads
 ```
 

--- a/packages/node/ws/README.md
+++ b/packages/node/ws/README.md
@@ -1,0 +1,38 @@
+# @gjsify/ws
+
+Drop-in implementation of the npm `ws` WebSocket library for GJS, built on `@gjsify/websocket` (Soup.WebsocketConnection) for the client side and `Soup.Server` for `WebSocketServer`. Aliases both `ws` and `isomorphic-ws` so existing npm packages that depend on either resolve to this implementation automatically when bundled for GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/ws
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/ws
+yarn add @gjsify/ws
+```
+
+## Usage
+
+```typescript
+import WebSocket, { WebSocketServer } from '@gjsify/ws';
+
+// Client
+const ws = new WebSocket('wss://echo.websocket.org');
+ws.on('open', () => ws.send('hello'));
+ws.on('message', (data) => console.log('received:', data));
+
+// Server
+const wss = new WebSocketServer({ port: 8080 });
+wss.on('connection', (client) => {
+    client.on('message', (msg) => client.send(`echo: ${msg}`));
+});
+```
+
+`WebSocketServer` supports `{ port }`, `{ server }` shared-port, and `{ noServer: true }` + `handleUpgrade()` modes, as well as `verifyClient`, `handleProtocols`, and `createWebSocketStream` (Duplex bridge). Validated against the Autobahn test suite: 510 OK / 4 NON-STRICT / 3 INFO / 0 FAILED.
+
+## License
+
+MIT

--- a/packages/node/zlib/README.md
+++ b/packages/node/zlib/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/zlib
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/zlib
-# or
 yarn add @gjsify/zlib
 ```
 

--- a/packages/web/abort-controller/README.md
+++ b/packages/web/abort-controller/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/abort-controller
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/abort-controller
-# or
 yarn add @gjsify/abort-controller
 ```
 

--- a/packages/web/adwaita-fonts/README.md
+++ b/packages/web/adwaita-fonts/README.md
@@ -1,0 +1,38 @@
+# @gjsify/adwaita-fonts
+
+Adwaita Sans TTF font files plus `@font-face` CSS (fontsource-style) for browser builds. Carries the GNOME/Libadwaita typographic identity to the web, sourced from the upstream Adwaita fonts project.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/adwaita-fonts
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/adwaita-fonts
+yarn add @gjsify/adwaita-fonts
+```
+
+## Usage
+
+```css
+/* Import the full @font-face declaration (weight 400, normal) */
+@import '@gjsify/adwaita-fonts';
+
+/* Or import a specific weight variant directly */
+@import '@gjsify/adwaita-fonts/400.css';
+@import '@gjsify/adwaita-fonts/400-italic.css';
+```
+
+```typescript
+// When used with a bundler that handles CSS imports
+import '@gjsify/adwaita-fonts';
+
+// Then use the font family in CSS
+// font-family: 'Adwaita Sans', sans-serif;
+```
+
+## License
+
+OFL-1.1

--- a/packages/web/adwaita-icons/README.md
+++ b/packages/web/adwaita-icons/README.md
@@ -1,0 +1,35 @@
+# @gjsify/adwaita-icons
+
+The Adwaita symbolic icon set as importable SVG strings for browser builds. Covers all icon categories (actions, devices, mimetypes, places, status, ui) sourced from the GNOME Adwaita icon theme, with a `toDataUri()` helper for use in CSS `mask-image` and `background-image` properties.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/adwaita-icons
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/adwaita-icons
+yarn add @gjsify/adwaita-icons
+```
+
+## Usage
+
+```typescript
+import { toDataUri } from '@gjsify/adwaita-icons/utils';
+
+// Import icons from a specific category
+import { folder_symbolic } from '@gjsify/adwaita-icons/places';
+import { document_new_symbolic } from '@gjsify/adwaita-icons/actions';
+
+// Use as a CSS data URI (for mask-image / background-image)
+const css = `mask-image: ${toDataUri(folder_symbolic)};`;
+
+// Or import all categories at once
+import * as icons from '@gjsify/adwaita-icons';
+```
+
+## License
+
+LGPL-3.0-or-later AND CC-BY-SA-3.0

--- a/packages/web/adwaita-web/README.md
+++ b/packages/web/adwaita-web/README.md
@@ -1,0 +1,40 @@
+# @gjsify/adwaita-web
+
+Browser Adwaita UI components as Custom Elements, bringing the Libadwaita look (light/dark) to the web with no GJS dependencies. Provides `AdwWindow`, `AdwHeaderBar`, `AdwPreferencesGroup`, `AdwCard`, `AdwSwitchRow`, `AdwComboRow`, `AdwSpinRow`, `AdwToastOverlay`, and `AdwOverlaySplitView`, backed by SCSS that mirrors the upstream `refs/adwaita-web` and `refs/libadwaita` color/sizing tokens.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/adwaita-web
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/adwaita-web
+yarn add @gjsify/adwaita-web
+```
+
+## Usage
+
+```typescript
+// Register all custom elements + load Adwaita fonts
+import '@gjsify/adwaita-web';
+
+// Import the compiled stylesheet (required for correct appearance)
+import '@gjsify/adwaita-web/style.css';
+```
+
+```html
+<adw-window>
+  <adw-header-bar slot="header">
+    <span slot="title">My App</span>
+  </adw-header-bar>
+  <adw-preferences-group title="Settings">
+    <adw-switch-row title="Dark mode"></adw-switch-row>
+  </adw-preferences-group>
+</adw-window>
+```
+
+## License
+
+MIT

--- a/packages/web/compression-streams/README.md
+++ b/packages/web/compression-streams/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/compression-streams
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/compression-streams
-# or
 yarn add @gjsify/compression-streams
 ```
 

--- a/packages/web/dom-events/README.md
+++ b/packages/web/dom-events/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/dom-events
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/dom-events
-# or
 yarn add @gjsify/dom-events
 ```
 

--- a/packages/web/dom-exception/README.md
+++ b/packages/web/dom-exception/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/dom-exception
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/dom-exception
-# or
 yarn add @gjsify/dom-exception
 ```
 

--- a/packages/web/domparser/README.md
+++ b/packages/web/domparser/README.md
@@ -1,0 +1,34 @@
+# @gjsify/domparser
+
+A minimal `DOMParser.parseFromString` implementation (XML/HTML) with a small DOM surface — `tagName`, `getAttribute`, `children`, `querySelector`/`querySelectorAll`, `textContent`, `innerHTML`. Sized for excalibur-tiled and simple config parsing; runs on GJS, Node.js, and browsers (where the native `DOMParser` is used instead).
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/domparser
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/domparser
+yarn add @gjsify/domparser
+```
+
+## Usage
+
+```typescript
+import { DOMParser } from '@gjsify/domparser';
+
+const parser = new DOMParser();
+const doc = parser.parseFromString('<map width="20" height="15"><layer name="bg"/></map>', 'text/xml');
+
+const map = doc.querySelector('map');
+console.log(map?.getAttribute('width')); // "20"
+
+const layers = doc.querySelectorAll('layer');
+console.log(layers[0]?.getAttribute('name')); // "bg"
+```
+
+## License
+
+MIT

--- a/packages/web/eventsource/README.md
+++ b/packages/web/eventsource/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/eventsource
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/eventsource
-# or
 yarn add @gjsify/eventsource
 ```
 

--- a/packages/web/fetch/README.md
+++ b/packages/web/fetch/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/fetch
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/fetch
-# or
 yarn add @gjsify/fetch
 ```
 

--- a/packages/web/formdata/README.md
+++ b/packages/web/formdata/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/formdata
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/formdata
-# or
 yarn add @gjsify/formdata
 ```
 

--- a/packages/web/gamepad/README.md
+++ b/packages/web/gamepad/README.md
@@ -1,0 +1,44 @@
+# @gjsify/gamepad
+
+The W3C Gamepad API for GJS, backed by libmanette 0.2. Provides `navigator.getGamepads()` polling, `Gamepad`, `GamepadButton`, `gamepadconnected`/`gamepaddisconnected` events, and dual-rumble haptics via `GamepadHapticActuator`. The Manette monitor is lazily initialised and degrades gracefully when libmanette is unavailable.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/gamepad
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/gamepad
+yarn add @gjsify/gamepad
+```
+
+## Usage
+
+```typescript
+import { GamepadManager, GamepadEvent } from '@gjsify/gamepad';
+
+// Start monitoring connected gamepads
+const manager = new GamepadManager();
+
+window.addEventListener('gamepadconnected', (e) => {
+    const event = e as GamepadEvent;
+    const pad = event.gamepad;
+    console.log(`Connected: ${pad.id}, buttons: ${pad.buttons.length}`);
+});
+
+window.addEventListener('gamepaddisconnected', (e) => {
+    console.log(`Disconnected: ${(e as GamepadEvent).gamepad.id}`);
+});
+
+// Poll the current state
+const gamepads = navigator.getGamepads();
+for (const pad of gamepads) {
+    if (pad) console.log(pad.axes, pad.buttons.map((b) => b.pressed));
+}
+```
+
+## License
+
+MIT

--- a/packages/web/message-channel/README.md
+++ b/packages/web/message-channel/README.md
@@ -1,0 +1,38 @@
+# @gjsify/message-channel
+
+W3C `MessageChannel` and `MessagePort` for GJS — EventTarget-based and transport-pluggable. Stock GJS exposes neither; this package provides the full `postMessage` / `start` / `close` / `onmessage` surface with async (microtask) dispatch. The pluggable transport hook backs the `@gjsify/iframe` WebKit bridge and future cross-process workers.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/message-channel
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/message-channel
+yarn add @gjsify/message-channel
+```
+
+## Usage
+
+```typescript
+import { MessageChannel, MessagePort } from '@gjsify/message-channel';
+
+const { port1, port2 } = new MessageChannel();
+
+port2.onmessage = (event) => {
+    console.log('received:', event.data);
+};
+
+port1.postMessage({ hello: 'world' });
+// → received: { hello: 'world' }
+
+// Explicit start() is only needed when deferring listener attachment
+port2.start();
+port2.close();
+```
+
+## License
+
+MIT

--- a/packages/web/polyfills/README.md
+++ b/packages/web/polyfills/README.md
@@ -1,0 +1,27 @@
+# @gjsify/web-polyfills
+
+Meta package that pulls every `@gjsify` Web API polyfill as a single dependency — fetch, streams, webcrypto, websocket, XMLHttpRequest, WebAssembly, Web Audio, WebRTC, EventSource, WebStorage, and more. Contains no runtime code of its own; used by `create-app` templates and CLI scaffolds.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/web-polyfills
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/web-polyfills
+yarn add @gjsify/web-polyfills
+```
+
+## Usage
+
+```typescript
+// Import once to pull all Web API polyfills into your dependency tree.
+// Individual packages register their globals via --globals auto at build time.
+import '@gjsify/web-polyfills';
+```
+
+## License
+
+MIT

--- a/packages/web/streams/README.md
+++ b/packages/web/streams/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/web-streams
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/web-streams
-# or
 yarn add @gjsify/web-streams
 ```
 

--- a/packages/web/web-globals/README.md
+++ b/packages/web/web-globals/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/web-globals
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/web-globals
-# or
 yarn add @gjsify/web-globals
 ```
 

--- a/packages/web/webassembly/README.md
+++ b/packages/web/webassembly/README.md
@@ -1,0 +1,37 @@
+# @gjsify/webassembly
+
+Promise-API polyfill for `WebAssembly` on GJS. SpiderMonkey ships working synchronous `new WebAssembly.Module` and `new WebAssembly.Instance` constructors but the async methods (`compile`, `instantiate`, `compileStreaming`, `instantiateStreaming`) throw at runtime. This package wraps the synchronous constructors so async-API consumers work unmodified on GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/webassembly
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/webassembly
+yarn add @gjsify/webassembly
+```
+
+## Usage
+
+```typescript
+import { compile, instantiate, instantiateStreaming, validate } from '@gjsify/webassembly';
+
+// Compile from a buffer
+const module = await compile(wasmBuffer);
+
+// Compile and instantiate in one step
+const { instance } = await instantiate(wasmBuffer, importObject);
+
+// Stream-instantiate from a fetch Response
+const { instance: inst } = await instantiateStreaming(fetch('/app.wasm'), importObject);
+
+// Validate a buffer without throwing
+const ok = validate(wasmBuffer);
+```
+
+## License
+
+MIT

--- a/packages/web/webaudio/README.md
+++ b/packages/web/webaudio/README.md
@@ -1,0 +1,41 @@
+# @gjsify/webaudio
+
+Web Audio API implementation for GJS backed by GStreamer 1.0. Provides `AudioContext` (with `decodeAudioData` via GStreamer's `decodebin`), `AudioBufferSourceNode`, `GainNode`, `AudioParam`, `AudioBuffer`, and `HTMLAudioElement`. Phase 1 implementation.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/webaudio
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/webaudio
+yarn add @gjsify/webaudio
+```
+
+## Usage
+
+```typescript
+import { AudioContext, AudioBuffer, GainNode } from '@gjsify/webaudio';
+
+const ctx = new AudioContext();
+
+// Decode audio data fetched from disk or network
+const response = await fetch('/sound.ogg');
+const arrayBuffer = await response.arrayBuffer();
+const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+
+// Play it with a gain node
+const source = ctx.createBufferSource();
+source.buffer = audioBuffer;
+const gain = ctx.createGain();
+gain.gain.value = 0.8;
+source.connect(gain);
+gain.connect(ctx.destination);
+source.start();
+```
+
+## License
+
+MIT

--- a/packages/web/webcrypto/README.md
+++ b/packages/web/webcrypto/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/webcrypto
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/webcrypto
-# or
 yarn add @gjsify/webcrypto
 ```
 

--- a/packages/web/webrtc-native/README.md
+++ b/packages/web/webrtc-native/README.md
@@ -1,0 +1,20 @@
+# @gjsify/webrtc-native
+
+Native Vala/GObject prebuild that makes GStreamer's `webrtcbin` signals safe to handle from GJS. Provides three main-thread signal bridges — `WebrtcbinBridge`, `DataChannelBridge`, and `PromiseBridge` — that capture callbacks fired on GStreamer's streaming thread and re-emit them via `GLib.Idle.add()` on the GLib main context. Consumed internally by `@gjsify/webrtc`; not intended for direct use.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+This is an internal native bridge package — installed automatically as a dependency of `@gjsify/webrtc`, not separately.
+
+```typescript
+// Use @gjsify/webrtc instead:
+import { RTCPeerConnection } from '@gjsify/webrtc';
+```
+
+The `@gjsify/webrtc-native` prebuild (`.so` + `.typelib`) is loaded automatically by `gjsify run` via the `GI_TYPELIB_PATH`/`LD_LIBRARY_PATH` detection in the CLI.
+
+## License
+
+MIT

--- a/packages/web/webrtc/README.md
+++ b/packages/web/webrtc/README.md
@@ -1,0 +1,45 @@
+# @gjsify/webrtc
+
+Full W3C WebRTC implementation for GJS backed by GStreamer's `webrtcbin`. Provides `RTCPeerConnection`, `RTCDataChannel` (string and binary), `RTCRtpSender`/`Receiver`/`Transceiver`, `MediaStream`, `MediaStreamTrack`, `getUserMedia` (PipeWire/PulseAudio/V4L2 fallback chain), `RTCDTMFSender`, `RTCCertificate`, `RTCStatsReport`, and `RTCIceCandidate`.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/webrtc
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/webrtc
+yarn add @gjsify/webrtc
+```
+
+## Usage
+
+```typescript
+import { RTCPeerConnection, RTCSessionDescription, getUserMedia } from '@gjsify/webrtc';
+
+const pc = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+});
+
+// Add a local media track
+const stream = await getUserMedia({ video: true, audio: true });
+for (const track of stream.getTracks()) {
+    pc.addTrack(track, stream);
+}
+
+// Create and set an SDP offer
+const offer = await pc.createOffer();
+await pc.setLocalDescription(offer);
+
+pc.onicecandidate = (event) => {
+    if (event.candidate) {
+        // Send event.candidate to the remote peer via your signalling channel
+    }
+};
+```
+
+## License
+
+MIT

--- a/packages/web/websocket/README.md
+++ b/packages/web/websocket/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/websocket
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/websocket
-# or
 yarn add @gjsify/websocket
 ```
 

--- a/packages/web/webstorage/README.md
+++ b/packages/web/webstorage/README.md
@@ -7,8 +7,10 @@ Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and W
 ## Installation
 
 ```bash
+gjsify install @gjsify/webstorage
+
+# npm or yarn also work (e.g. adding it to an existing project):
 npm install @gjsify/webstorage
-# or
 yarn add @gjsify/webstorage
 ```
 

--- a/packages/web/xmlhttprequest/README.md
+++ b/packages/web/xmlhttprequest/README.md
@@ -1,0 +1,34 @@
+# @gjsify/xmlhttprequest
+
+XMLHttpRequest API for GJS backed by Soup 3.0 and GLib. Supports all `responseType` values (`arraybuffer`, `blob`, `json`, `text`), `file://` URLs (read directly via GLib), root-relative URL rewriting, and `URL.createObjectURL`/`revokeObjectURL` via temp files. Used as the asset loader backing for Excalibur.js on GJS.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Installation
+
+```bash
+gjsify install @gjsify/xmlhttprequest
+
+# npm or yarn also work (e.g. adding it to an existing project):
+npm install @gjsify/xmlhttprequest
+yarn add @gjsify/xmlhttprequest
+```
+
+## Usage
+
+```typescript
+import { XMLHttpRequest } from '@gjsify/xmlhttprequest';
+
+const xhr = new XMLHttpRequest();
+xhr.responseType = 'json';
+xhr.open('GET', 'https://api.example.com/data.json');
+xhr.onload = () => {
+    console.log(xhr.response); // parsed JSON object
+};
+xhr.onerror = (e) => console.error('XHR error', e);
+xhr.send();
+```
+
+## License
+
+MIT

--- a/showcases/dom/canvas2d-fireworks/README.md
+++ b/showcases/dom/canvas2d-fireworks/README.md
@@ -1,0 +1,30 @@
+# @gjsify/example-dom-canvas2d-fireworks
+
+A polished Canvas 2D fireworks animation running on both GJS/GTK (via `@gjsify/canvas2d`'s `Canvas2DBridge` over Cairo) and in the browser — from the same shared source. Adapted from [juliangarnier's fireworks pen](https://codepen.io/juliangarnier/pen/gmOwJX). The GJS variant renders inside a native Adwaita window with GTK controls; the browser variant uses the same animation code with `@gjsify/adwaita-web` components.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Run
+
+```bash
+# Build first
+gjsify run build
+
+# GJS / GTK4 native window
+gjsify showcase canvas2d-fireworks
+# or: gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
+
+## What it demonstrates
+
+- Canvas 2D rendering on GJS via `@gjsify/canvas2d` (Cairo + PangoCairo backend)
+- Shared animation logic between GJS and browser targets
+- Adwaita design language in both variants (`@gjsify/adwaita-web` for browser, native Adw widgets for GJS)
+- `gjsify build --app gjs` and `--app browser` dual-target build
+
+## License
+
+MIT

--- a/showcases/dom/three-geometry-teapot/README.md
+++ b/showcases/dom/three-geometry-teapot/README.md
@@ -1,0 +1,31 @@
+# @gjsify/example-dom-three-geometry-teapot
+
+A three.js Utah Teapot showcase running on GJS/GTK (via `@gjsify/webgl`'s `WebGLBridge` over `Gtk.GLArea`) and in the browser — from a shared `start(canvas)` entry point. Ported from [`three/examples/webgl_geometry_teapot`](https://threejs.org/examples/#webgl_geometry_teapot). The GJS variant renders inside a native Adwaita window; the browser variant uses `@gjsify/adwaita-web` components.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Run
+
+```bash
+# Build first
+gjsify run build
+
+# GJS / GTK4 native window (WebGL via Gtk.GLArea)
+gjsify showcase three-geometry-teapot
+# or: gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
+
+## What it demonstrates
+
+- WebGL rendering on GJS via `@gjsify/webgl` (Vala bridge over `Gtk.GLArea` + libepoxy)
+- three.js (`THREE.WebGLRenderer`) running unmodified on GJS
+- Shared `start(canvas)` pattern — identical entry for GJS and browser
+- Adwaita design language in both variants
+- `gjsify build --app gjs` and `--app browser` dual-target build
+
+## License
+
+MIT

--- a/showcases/dom/three-postprocessing-pixel/README.md
+++ b/showcases/dom/three-postprocessing-pixel/README.md
@@ -1,0 +1,31 @@
+# @gjsify/example-dom-three-postprocessing-pixel
+
+A three.js pixel post-processing showcase running on GJS/GTK (via `@gjsify/webgl`'s `WebGLBridge` over `Gtk.GLArea`) and in the browser — from a shared `start(canvas)` entry point. Ported from [`three/examples/webgl_postprocessing_pixel`](https://threejs.org/examples/#webgl_postprocessing_pixel). Demonstrates three.js `EffectComposer` with a custom pixel/posterize shader running on native GJS WebGL.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Run
+
+```bash
+# Build first
+gjsify run build
+
+# GJS / GTK4 native window (WebGL via Gtk.GLArea)
+gjsify showcase three-postprocessing-pixel
+# or: gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
+
+## What it demonstrates
+
+- three.js post-processing (`EffectComposer` + pixel shader) on GJS
+- WebGL rendering via `@gjsify/webgl` (Vala bridge over `Gtk.GLArea` + libepoxy)
+- Shared `start(canvas)` pattern — identical entry for GJS and browser
+- Adwaita design language in both variants
+- `gjsify build --app gjs` and `--app browser` dual-target build
+
+## License
+
+MIT

--- a/showcases/node/express-webserver/README.md
+++ b/showcases/node/express-webserver/README.md
@@ -1,0 +1,32 @@
+# @gjsify/example-node-express-webserver
+
+An Express 5 blog showcase — JSON API + static frontend — running on GJS using gjsify's Node.js polyfills (`@gjsify/http`, etc.). The same source also builds for Node.js, demonstrating that a real Express web application runs unmodified on GJS via the `@gjsify/*` Node API layer.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Run
+
+```bash
+# Build first
+gjsify run build
+
+# GJS (Express over GJS + Soup HTTP)
+gjsify showcase express-webserver
+# or: gjsify run start
+
+# Node.js (for comparison)
+gjsify run start:node
+```
+
+Then open `http://localhost:3000` in a browser.
+
+## What it demonstrates
+
+- Express 5 running on GJS with gjsify's `@gjsify/http` (Soup 3.0 backend)
+- JSON REST API + static file serving from a single Express app
+- Same source building for both `--app gjs` and `--app node` targets
+- Node.js polyfill layer compatibility with an unmodified npm package
+
+## License
+
+MIT


### PR DESCRIPTION
Adds a `README.md` to the **40 packages** that lacked one and standardizes install instructions across **106** package READMEs.

## Install policy
- **Consumer packages** (`node`/`web`/`dom`/`framework` + `cli`, `tsc`, `vite-plugin-*`, `create-app`, `nativescript-vite`) lead with `gjsify install` and note that npm/yarn also work (for adding to an existing, possibly non-gjsify project).
- **gjsify-internal plumbing** (`semver`, `tar`, `npm-registry`, `resolve-npm`, `rolldown-native`, `rolldown-plugin-*`, `lightningcss-*`, `workspace`, `empty`, `gjs/*`) shows `gjsify install` only.
- **Optional native bridges** (`tls/http2/sab/terminal-native`) keep their "loaded automatically by `@gjsify/X`" note, gjsify-first; `webrtc-native`/`http-soup-bridge` stay install-less (consumed transitively).
- **`create-app`** leads with `gjsify create`; **private** (`oxlint-plugin-gjsify`) + **showcases** keep their internal note / `gjsify showcase` run commands.

## Corrections surfaced while writing
- `@gjsify/rolldown-native` documented as the **default GJS bundler engine** (its `package.json` description was a stale "Phase D-2 POC").
- `@gjsify/tsc` README brought onto the standard schema: version `6.0.3` (was `5.9.3`), `gjsify-tsc` bin name, self-host framing.
- Licenses verified from each `package.json` (e.g. adwaita-fonts `OFL-1.1`, adwaita-icons `LGPL-3.0-or-later AND CC-BY-SA-3.0`).

Docs-only — no code/tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)