### PR TITLE
fix(zlib): silence writer teardown rejection on GJS

### DIFF
--- a/packages/node/zlib/src/browser.ts
+++ b/packages/node/zlib/src/browser.ts
@@ -104,8 +104,12 @@ async function runStream(
     const transform = new StreamCtor(format);
     const writer = transform.writable.getWriter();
     const reader = transform.readable.getReader();
-    void writer.write(data as BufferSource);
-    void writer.close();
+    // Fire-and-forget: we drive the stream via the reader below.
+    // `.catch(() => {})` silences the "Unhandled promise rejection" GJS warning
+    // that fires during teardown when the readable side is already closed before
+    // the writer Promises settle (benign — data was already fully consumed).
+    void writer.write(data as BufferSource).catch(() => {});
+    void writer.close().catch(() => {});
     const chunks: Uint8Array[] = [];
     let total = 0;
     // eslint-disable-next-line no-constant-condition

--- a/packages/node/zlib/src/index.ts
+++ b/packages/node/zlib/src/index.ts
@@ -158,8 +158,11 @@ function decompressWithGio(data: Uint8Array, format: GioFormat): Uint8Array {
 async function compressWithWeb(data: Uint8Array, format: CompressionFormat): Promise<Uint8Array> {
     const cs = new CompressionStream(format);
     const writer = cs.writable.getWriter();
-    writer.write(new Uint8Array(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength));
-    writer.close();
+    // Fire-and-forget: driven by the reader below. `.catch(() => {})` silences
+    // the GJS "Unhandled promise rejection" warning that fires on teardown when
+    // the readable side is already closed before these Promises settle.
+    writer.write(new Uint8Array(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength)).catch(() => {});
+    writer.close().catch(() => {});
 
     const chunks: Uint8Array[] = [];
     const reader = cs.readable.getReader();
@@ -182,8 +185,10 @@ async function compressWithWeb(data: Uint8Array, format: CompressionFormat): Pro
 async function decompressWithWeb(data: Uint8Array, format: CompressionFormat): Promise<Uint8Array> {
     const ds = new DecompressionStream(format);
     const writer = ds.writable.getWriter();
-    writer.write(new Uint8Array(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength));
-    writer.close();
+    // Fire-and-forget: driven by the reader below. `.catch(() => {})` silences
+    // the GJS "Unhandled promise rejection" warning on inflate teardown.
+    writer.write(new Uint8Array(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength)).catch(() => {});
+    writer.close().catch(() => {});
 
     const chunks: Uint8Array[] = [];
     const reader = ds.readable.getReader();


### PR DESCRIPTION
## Summary

### Nit #1 — tsc type error `Property 'push' does not exist on type 'ZlibTransform'`

**Status: does NOT reproduce on current main.**

The error was a build-artifact gap in the worktree: `@gjsify/stream/browser`'s declaration file (`lib/types/browser.d.ts`) imports from `@gjsify/events`, and the worktree's `packages/node/events/lib/` was not pre-built. Once built, tsc resolves `Transform → Duplex → Readable.push()` correctly and the error disappears. PR #508 is already merged and `transform-streams.ts` now exports `ZlibBase as ZlibTransform`, which extends Node's `Transform` directly — `push()` was never missing at the source level. No fix needed here.

### Nit #2 — Unhandled promise rejection on GJS inflate teardown

**Status: still reproduces on current main.**

**Root cause:** `writer.write()` and `writer.close()` return Promises that were dropped (either via `void` or silently). On GJS, when the stream tears down after the reader has consumed all data, these Promises can reject (e.g. if the writable side is closed/cancelled before they settle). GJS then logs an "Unhandled promise rejection" warning. This affects three call sites:

- `runStream()` in `src/browser.ts` (lines 107-108): the browser entry's `void writer.write()` / `void writer.close()`
- `compressWithWeb()` in `src/index.ts` (lines 161-162): the GJS web-path compress helper
- `decompressWithWeb()` in `src/index.ts` (lines 185-186): the GJS web-path inflate helper

**Fix:** Attach `.catch(() => {})` to each dropped Promise. Same fire-and-forget semantics — the stream is driven exclusively by the reader side — but any teardown rejection is now silenced rather than becoming an unhandled rejection warning.

### Relationship to PR #508

PR #508 was already merged into main before this branch was cut. Nit #1 tracked `ZlibTransform.push` being invisible to tsc; #508 restructured `transform-streams.ts` and made `ZlibBase extends Transform` the real implementation, but the type error was purely a missing build-artifact issue and not something #508 introduced or needs to fix.

## Test plan

- [x] `gjsify tsc --noEmit` in `packages/node/zlib` — only `@gjsify/unit` (devdep, unbuilt in worktree) remains; the `push` error and all main-code errors are gone
- [x] `node test.node.mjs` — 53,374 tests pass on Node
- [x] Built output (`lib/esm/browser.js`, `lib/esm/index.js`) confirmed to contain `.catch(()=>{})` on both writer calls
- [ ] GJS test run blocked by worktree dep chain not being fully built; the main repo's `test.gjs.js` passes its 6 streaming-class tests (those don't exercise the web path). The fix is structural — `.catch(() => {})` has no observable effect when the Promise resolves normally.