### PR TITLE
chore(lint): clear remaining consistent-type-imports warnings

### DIFF
--- a/packages/dom/dom-elements/src/element.ts
+++ b/packages/dom/dom-elements/src/element.ts
@@ -5,6 +5,7 @@
 
 import type { Event } from '@gjsify/dom-events';
 
+import type { Attr } from './attr.js';
 import { Node } from './node.js';
 import { NodeType } from './node-type.js';
 import { NamedNodeMap } from './named-node-map.js';
@@ -165,7 +166,7 @@ export class Element extends Node {
     }
 
     setAttributeNode(attr: unknown): unknown {
-        return this[PS.attributes].setNamedItem(attr as import('./attr.js').Attr);
+        return this[PS.attributes].setNamedItem(attr as Attr);
     }
 
     removeAttributeNode(attr: unknown): unknown {

--- a/packages/dom/dom-elements/src/index.spec.ts
+++ b/packages/dom/dom-elements/src/index.spec.ts
@@ -541,7 +541,7 @@ export default async () => {
             el.onwheel = (ev: unknown) => {
                 deltaY = (ev as { deltaY: number }).deltaY;
             };
-            el.dispatchEvent(new Event('wheel') as unknown as import('@gjsify/dom-events').Event);
+            el.dispatchEvent(new Event('wheel') as unknown as Event);
             // The handler fires even without a deltaY; verifies wiring
             expect(typeof el.onwheel).toBe('function');
             el.onwheel = null;

--- a/packages/framework/event-bridge/src/event-bridge.spec.ts
+++ b/packages/framework/event-bridge/src/event-bridge.spec.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, on } from '@gjsify/unit';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 
-import { Event as OurEvent } from '@gjsify/dom-events';
+import type { Event as OurEvent } from '@gjsify/dom-events';
 import { attachEventControllers } from './event-bridge.js';
 
 /** Pointer/Mouse event shape the bridge dispatches — the union of fields the tests read. */

--- a/packages/framework/event-bridge/src/event-bridge.ts
+++ b/packages/framework/event-bridge/src/event-bridge.ts
@@ -7,7 +7,7 @@
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 import {
-    Event as OurEvent,
+    type Event as OurEvent,
     MouseEvent as OurMouseEvent,
     PointerEvent as OurPointerEvent,
     KeyboardEvent as OurKeyboardEvent,

--- a/packages/framework/iframe/src/index.spec.ts
+++ b/packages/framework/iframe/src/index.spec.ts
@@ -7,7 +7,7 @@ import { describe, it, expect } from '@gjsify/unit';
 import { HTMLIFrameElement, IFrameWindowProxy } from './index.js';
 import { Document } from '@gjsify/dom-elements';
 import { HTMLElement, Element, Node } from '@gjsify/dom-elements';
-import { Event, MessageEvent } from '@gjsify/dom-events';
+import { MessageEvent, type Event } from '@gjsify/dom-events';
 import type { MessageBridge } from './message-bridge.js';
 
 /** Minimal MessageBridge stand-in for unit tests — only the methods IFrameWindowProxy reads. */

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -5,6 +5,7 @@ import '@girs/gjs';
 import type GLib from '@girs/glib-2.0';
 export * from './spy.js';
 import nodeAssert from 'node:assert';
+import type { AssertPredicate } from 'node:assert';
 import { quitMainLoop } from '@gjsify/utils/main-loop';
 
 /**
@@ -615,7 +616,7 @@ assert.strictEqual = function <T>(actual: unknown, expected: T, message?: string
     }
 };
 
-assert.throws = function (promiseFn: () => unknown, ...args: [import('node:assert').AssertPredicate?, string?]) {
+assert.throws = function (promiseFn: () => unknown, ...args: [AssertPredicate?, string?]) {
     ++countTestsOverall;
     let error: unknown;
     try {

--- a/packages/node/http/src/streaming.spec.ts
+++ b/packages/node/http/src/streaming.spec.ts
@@ -7,6 +7,7 @@ import { createServer, request as httpRequest, get as httpGet } from 'node:http'
 import { Readable, PassThrough, Transform } from 'node:stream';
 import { Buffer } from 'node:buffer';
 import type { Server, IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 /** Helper: start a server and return its URL + cleanup function */
 function startServer(
@@ -609,7 +610,7 @@ export default async () => {
             await new Promise<void>((resolve) => {
                 server.listen(0, '127.0.0.1', () => resolve());
             });
-            const addr = server.address() as import('node:net').AddressInfo | null;
+            const addr = server.address() as AddressInfo | null;
             expect(addr).toBeDefined();
             expect(typeof addr!.port).toBe('number');
             expect(addr!.port).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Convert type-only imports to use the `type` keyword (inline form for mixed value/type imports, full `import type` for pure-type ones)
- Replace inline `import('module').T` annotations with top-level type imports
- Touches 7 spots across 6 files

## Test plan
- [ ] `gjsify workspace @gjsify/event-bridge check` passes
- [ ] CI type check passes