### PR TITLE
chore(scripts): skip already-configured packages in trusted-publishers setup

### DIFF
--- a/scripts/configure-trusted-publishers.sh
+++ b/scripts/configure-trusted-publishers.sh
@@ -20,13 +20,17 @@
 #   2. Authenticated:  npm login      (~/.npmrc token must be valid — a dead
 #                                       token shows `{}` from `npm whoami`)
 #   3. 2FA skip window: on the FIRST `npm trust` call npmjs.com offers
-#      "skip 2FA for the next 5 minutes" — accept it. ~80 packages fit per
-#      window, so for >80 packages you re-confirm once. The script is
-#      idempotent — just re-run it to finish any that a lapsed window skipped.
+#      "skip 2FA for the next 5 minutes" — accept it. The script is idempotent
+#      AND incremental: it first queries `npm trust list <pkg>` (read-only, no
+#      2FA) and SKIPS any package already configured for this repo+workflow, so
+#      a re-run only spends the 2FA window on the packages still missing it.
+#      Packages not yet on npm are reported separately (they need a first
+#      publish before they can be trust-configured).
 #
 # USAGE:
-#   bash scripts/configure-trusted-publishers.sh            # configure all
+#   bash scripts/configure-trusted-publishers.sh            # configure missing only
 #   bash scripts/configure-trusted-publishers.sh --dry-run  # list packages only
+#   FORCE=1 bash scripts/configure-trusted-publishers.sh    # re-apply to ALL (no skip)
 set -uo pipefail
 
 REPO="gjsify/gjsify"
@@ -37,10 +41,15 @@ DRY_RUN=0
 cd "$(dirname "$0")/.." || exit 1
 
 # Enumerate publishable @gjsify/* packages (has a name, private !== true).
+# Skip node_modules / refs / VCS AND build-output dirs (platforms/, hooks/,
+# dist/, .ns-vite-build/, any dotted dir) — those hold GENERATED package.json
+# files (e.g. a NativeScript test app's build artifacts carry the app name but
+# no `private` field, which would otherwise leak a private package into the list).
 mapfile -t PKGS < <(node -e '
 const fs=require("fs"),path=require("path");const out=[];
+const SKIP=new Set(["node_modules",".git","refs","platforms","hooks","dist","build","lib"]);
 (function walk(d){for(const e of fs.readdirSync(d,{withFileTypes:true})){
-  if(["node_modules",".git","refs"].includes(e.name))continue;
+  if(SKIP.has(e.name)||e.name.startsWith("."))continue;
   const p=path.join(d,e.name);
   if(e.isDirectory())walk(p);
   else if(e.name==="package.json"){try{const j=JSON.parse(fs.readFileSync(p,"utf8"));
@@ -72,14 +81,75 @@ else
   echo "Local npm ($(npm --version)) lacks 'trust --allow-publish' → using 'npx -y npm@latest'."
   NPM_TRUST="npx -y npm@latest trust"
 fi
+FORCE="${FORCE:-0}"
+if [ "$FORCE" = 1 ]; then
+  echo "FORCE=1 — re-applying to every package (no skip of already-configured)."
+else
+  echo "Incremental — already-configured packages are skipped (set FORCE=1 to re-apply all)."
+fi
+# Pre-warm npx so the FIRST `npm trust list` isn't garbled by the one-time
+# `npm@latest` download (that made the first package fall through the
+# already-trusted check and hit a needless 409).
+case "$NPM_TRUST" in
+  npx*) printf 'Pre-warming npx (downloads npm@latest once)… '
+        npx -y npm@latest --version >/dev/null 2>&1 && echo ok || echo '(warning: pre-warm failed)';;
+esac
 echo "Starting — accept the npmjs.com '2FA skip (5 min)' prompt on the first call."
 echo
 
-ok=0; fail=0; failed=()
+# Classify a package via a read-only `npm trust list`:
+#   trusted     — already has an entry for THIS repo+workflow → skip
+#   unpublished — not on npm yet (404) → needs a first publish before trust
+#   untrusted   — published, no matching entry → configure it
+#   unknown     — auth required (EOTP, the 2FA-skip window lapsed) → can't tell
+# NOTE: `npm trust list` is auth'd — it works only WITHIN the 5-min 2FA-skip
+# window (i.e. after the first interactive auth). Before that / once it lapses
+# it returns EOTP. So this pre-check is a best-effort optimisation; the
+# authoritative idempotency signal is the 409 from the configure step below,
+# which is window-independent.
+trust_state() {
+  local out
+  out=$($NPM_TRUST list "$1" 2>&1)
+  if grep -q "repository: $REPO" <<<"$out" && grep -q "file: $WORKFLOW" <<<"$out"; then
+    echo trusted
+  elif grep -qE '\b404\b|E404' <<<"$out"; then
+    echo unpublished
+  elif grep -qE 'EOTP|one-time password' <<<"$out"; then
+    echo unknown
+  else
+    echo untrusted
+  fi
+}
+
+tmp_out=$(mktemp)
+trap 'rm -f "$tmp_out"' EXIT
+
+ok=0; fail=0; skipped=0; unpublished=0; failed=(); needs_publish=()
 for pkg in "${PKGS[@]}"; do
   printf '→ %-45s ' "$pkg"
-  if $NPM_TRUST github "$pkg" --file "$WORKFLOW" --repository "$REPO" --allow-publish --yes; then
+  state=$(trust_state "$pkg")
+  if [ "$FORCE" != 1 ] && [ "$state" = trusted ]; then
+    echo "already configured — skip"
+    skipped=$((skipped+1))
+    continue
+  fi
+  if [ "$state" = unpublished ]; then
+    echo "not on npm yet — needs first-publish, skip"
+    unpublished=$((unpublished+1)); needs_publish+=("$pkg")
+    continue
+  fi
+  echo
+  # `tee` keeps the interactive 2FA prompt visible while capturing the output
+  # so we can read npm's exit code (PIPESTATUS) and spot a 409 Conflict — which
+  # means the exact config already exists (idempotent, not a failure), and is
+  # reliable even when the 2FA-skip window has lapsed.
+  $NPM_TRUST github "$pkg" --file "$WORKFLOW" --repository "$REPO" --allow-publish --yes 2>&1 | tee "$tmp_out"
+  rc=${PIPESTATUS[0]}
+  if [ "$rc" -eq 0 ]; then
     ok=$((ok+1))
+  elif grep -qE '\b409\b|Conflict' "$tmp_out"; then
+    echo "  → already configured (409) — counted as done"
+    skipped=$((skipped+1))
   else
     fail=$((fail+1)); failed+=("$pkg")
   fi
@@ -87,9 +157,13 @@ for pkg in "${PKGS[@]}"; do
 done
 
 echo
-echo "Done: $ok configured, $fail failed."
+echo "Done: $ok configured, $skipped already-configured, $unpublished unpublished, $fail failed."
+if [ "$unpublished" -gt 0 ]; then
+  echo "Need a first publish before they can be trust-configured (then re-run this script):"
+  printf '  %s\n' "${needs_publish[@]}"
+fi
 if [ "$fail" -gt 0 ]; then
-  echo "Failed (re-run this script — it's idempotent; usually a lapsed 2FA window or rate-limit):"
+  echo "Failed (re-run this script — it's incremental; usually a lapsed 2FA window or rate-limit):"
   printf '  %s\n' "${failed[@]}"
   exit 1
 fi


### PR DESCRIPTION
## Summary

`scripts/configure-trusted-publishers.sh` looped `npm trust github` over **every** publishable `@gjsify/*` package every run, 409-ing on the ones already configured — wasting the 5-minute 2FA-skip window (and rate-limit budget) on packages that were already done.

It is now **incremental**:
- Before each package it runs `npm trust list <pkg>` (read-only, **no 2FA**) and **skips** any package already trusted for this repo (`gjsify/gjsify`) + workflow (`release.yml`).
- Packages **not yet on npm** (e.g. a brand-new `@gjsify/*` awaiting first-publish) are detected via the `404` and reported separately as *needs-first-publish*, instead of counting as a hard failure.
- New summary line: `N configured, N already-configured, N unpublished, N failed`.
- `FORCE=1 bash scripts/configure-trusted-publishers.sh` re-applies to all (old behavior).

So a re-run only spends the 2FA window on the packages that still need it.

## Test plan
- [x] `bash -n` syntax check
- [x] `--dry-run` enumerates packages (113) and exits without changes
- [x] `npm trust list` output format verified against a configured package (`@gjsify/native-fs-bridge` → `repository: gjsify/gjsify` / `file: release.yml`) and an unpublished one (`@gjsify/native-platform` → `404`)