### PR TITLE
test: classifier scope-check probe (throwaway)

### DIFF
--- a/packages/node/v8/src/index.ts
+++ b/packages/node/v8/src/index.ts
@@ -133,3 +133,5 @@ export default {
     GCProfiler,
     startCpuProfile,
 };
+
+// CI classifier scope-check probe — throwaway (PR will be closed, branch deleted).


### PR DESCRIPTION
Throwaway probe: a one-line comment change in @gjsify/v8 (a leaf stub) to verify the affected classifier now scopes tightly and to read the changes-job reason (FORCE_FULL still set vs. real closure). **Will be closed + branch deleted** — do not merge.