### PR TITLE
fix(unit): throw matchers no longer corrupt the failure count

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -336,7 +336,7 @@ Not yet implemented (but potentially relevant for GJS projects):
 
 | Package | Function | Status |
 |---------|----------|--------|
-| **@gjsify/unit** | Test framework (describe/it/expect) | Full |
+| **@gjsify/unit** | Test framework (describe/it/expect) + vitest-compat surface (`vi.fn`/`stubGlobal`/`stubEnv`, `toMatchObject`/`toBeNaN`/`toHaveBeenCalled*`, `expect().rejects.toThrow`/`.resolves.toResolve`) | Full |
 | **@gjsify/utils** | Gio wrappers, process info, encoding, ensureMainLoop | Full |
 | **@gjsify/runtime** | Platform-independent runtime detection (isGJS, isNode, runtimeName) | Full |
 | **@gjsify/types** | GIR TypeScript bindings | Manual |

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -50,6 +50,22 @@ const mainloop: GLib.MainLoop | undefined = runtimeGlobals().imports?.mainloop;
 let countTestsOverall = 0;
 let countTestsFailed = 0;
 let countTestsIgnored = 0;
+
+/**
+ * A branded matcher-failure caught by a throw/rejection matcher (`toThrow`,
+ * `toReject`, `toResolve`) is used as a control-flow signal — those matchers
+ * assert that a throw/rejection *happens*, so the inner assertion's throw is the
+ * expected outcome, not a failure. `triggerResult` already did `++countTestsFailed`
+ * at the inner throw site, so roll that eager increment back here and let the
+ * catching matcher's own `triggerResult` decide the real result. Without this,
+ * `expect(() => expect(x).toMatchObject(y)).toThrow()` leaks a phantom failure
+ * into the global tally even though the test itself passes.
+ */
+const uncountBrandedFailure = (e: unknown): void => {
+    if (e && (e as _CountedError).__testFailureCounted) {
+        --countTestsFailed;
+    }
+};
 let runtime = '';
 let runStartTime = 0;
 let currentSuite = '';
@@ -498,6 +514,7 @@ class MatcherFactory {
             fn();
             didThrow = false;
         } catch (e) {
+            uncountBrandedFailure(e);
             errorMessage = (e as { message?: string })?.message || '';
             didThrow = true;
             if (typeof expected === 'function') {
@@ -539,6 +556,7 @@ class MatcherFactory {
             await this.actualValue;
             didReject = false;
         } catch (e) {
+            uncountBrandedFailure(e);
             didReject = true;
             errorMessage = e?.message || String(e);
             if (typeof expected === 'function') {
@@ -573,6 +591,7 @@ class MatcherFactory {
             await this.actualValue;
             didResolve = true;
         } catch (e) {
+            uncountBrandedFailure(e);
             didResolve = false;
             errorMessage = e?.message || String(e);
         }

--- a/packages/gjs/unit/src/vitest-compat.spec.ts
+++ b/packages/gjs/unit/src/vitest-compat.spec.ts
@@ -96,4 +96,22 @@ export default async () => {
             await expect(Promise.resolve(1)).resolves.toResolve();
         });
     });
+
+    // Regression guard: a matcher-failure caught by a throw/rejection matcher must
+    // NOT leak into the global failure tally. Each inner assertion below fails on
+    // purpose and is consumed as the expected throw/rejection — the suite summary
+    // must stay at "0 failed". A reintroduced leak turns the whole run red (exit 1)
+    // even though every it() here reports a pass.
+    await describe('throwing matchers do not corrupt the failure count', async () => {
+        await it('toThrow wrapping a failing matcher counts as one pass, not a failure', async () => {
+            expect(() => expect(1).toBe(2)).toThrow();
+            expect(() => expect({ a: 1 }).toMatchObject({ a: 2 })).toThrow();
+        });
+        await it('rejects.toThrow wrapping a matcher-rejection does not leak a failure', async () => {
+            const rejectsViaMatcher = (async () => {
+                expect('actual').toBe('expected');
+            })();
+            await expect(rejectsViaMatcher).rejects.toThrow();
+        });
+    });
 };


### PR DESCRIPTION
## What

`@gjsify/unit`'s throw/rejection matchers (`toThrow`, `toReject`, `toResolve`) catch the thrown error as the expected-throw signal — but a **branded** matcher-failure caught there had already run `++countTestsFailed` at its inner throw site (in `triggerResult`). So the idiom

```ts
expect(() => expect(x).toMatchObject(y)).toThrow();
```

leaked a phantom failure into the global tally **even though the test passes**. The whole run reported `❌ 2 of 216 tests failed` → exit 1 → red CI, with **no per-test `❌`** printed (the throw is consumed by `toThrow` and never reaches `it()`'s catch, which is the only place that prints).

This shipped in #544 (vitest compatibility): the two `toMatchObject` failure-case tests use exactly this idiom, so `@gjsify/unit`'s own suite went red the moment it merged — and rode into the v0.7.4 release.

## Fix

A small `uncountBrandedFailure(e)` helper rolls back the eager increment in each of the three catchers, so only the catching matcher's own `triggerResult` decides the outcome. Non-branded throws (real errors) are unaffected.

## Coverage

New regression guard in `vitest-compat.spec.ts` ("throwing matchers do not corrupt the failure count") covering both the sync `toThrow` and async `rejects.toThrow` paths wrapping deliberate inner failures. A reintroduced leak turns the whole run red again.

## Verification

- **Node: 222/222 green, exit 0**
- **GJS: 222/222 green, exit 0**
- `gjsify tsc --noEmit` clean

`@gjsify/unit` is a GLOBAL_TRIGGER (`packages/gjs/unit/**`), so this runs the full CI suite.