### PR TITLE
build: exclude specs from buffer/string_decoder tsc (release build fix)

### DIFF
--- a/packages/node/buffer/tsconfig.json
+++ b/packages/node/buffer/tsconfig.json
@@ -24,6 +24,8 @@
   ],
   "exclude": [
     "src/test.ts",
-    "src/test.mts"
+    "src/test.mts",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.mts"
   ]
 }

--- a/packages/node/string_decoder/tsconfig.json
+++ b/packages/node/string_decoder/tsconfig.json
@@ -24,6 +24,8 @@
   ],
   "exclude": [
     "src/test.ts",
-    "src/test.mts"
+    "src/test.mts",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.mts"
   ]
 }


### PR DESCRIPTION
## Problem

The v0.7.5 npm publish failed (3rd attempt) at *Build packages*:

```
@gjsify/buffer build → src/index.spec.ts:14 - error TS2307: Cannot find module '@gjsify/unit'
```

#550's `@gjsify/process build -d` pulls `@gjsify/buffer` + `@gjsify/string_decoder` into `build:infra`'s early bootstrap. Their `build:types` (`gjsify tsc`) type-checks **spec files**, which import `@gjsify/unit` — built **last** in `build:infra`. And `@gjsify/unit` prod-depends on `process` + `buffer`, so it **can't** be reordered earlier. Cycle → TS2307.

`process`/`utils`/`events`/`assert` already exclude specs from their tsconfig; `buffer`/`string_decoder` didn't (inconsistency this exposed).

## Fix

Exclude `src/**/*.spec.{ts,mts}` from both tsconfigs (matching the established convention). `build:gjsify` already excludes specs; this aligns `build:types`. No published-package content changes (specs never ship).

## Why PR CI can't catch this (same as #550)

Per-workspace test/check builds use the **topological** `gjsify foreach build`; only `release.yml` runs the hardcoded `build:infra`. So this was validated **out-of-band**: a clean throwaway worktree (`origin/main` + this fix) → full `gjsify install` → `gjsify run build:infra` → **green** (buffer/string_decoder/process/unit all build with `unit` absent during bootstrap, exit 0).