### PR TITLE
fix(workspace): dedupe overlapping workspace globs

### DIFF
--- a/packages/infra/workspace/src/index.spec.ts
+++ b/packages/infra/workspace/src/index.spec.ts
@@ -112,6 +112,30 @@ export default async (): Promise<void> => {
                     rmSync(root, { recursive: true, force: true });
                 }
             });
+
+            await it('dedupes dirs matched by overlapping patterns', () => {
+                // A glob plus an explicit entry for the same dir (a real config:
+                // `["packages/*", "packages/app-android", "packages/app-web"]`).
+                // Each overlapped dir must appear exactly once — duplicates flow
+                // into double symlink plans that race to EEXIST in install.
+                const root = makeFixture({
+                    '.': {
+                        name: 'root',
+                        private: true,
+                        workspaces: ['packages/*', 'packages/app-android', 'packages/app-web'],
+                    },
+                    'packages/core': { name: 'core', version: '1.0.0' },
+                    'packages/app-android': { name: 'app-android', version: '1.0.0' },
+                    'packages/app-web': { name: 'app-web', version: '1.0.0' },
+                });
+                try {
+                    const ws = discoverWorkspaces(root);
+                    expect(ws.map((w) => w.name).sort()).toStrictEqual(['app-android', 'app-web', 'core']);
+                    expect(ws.length).toBe(3);
+                } finally {
+                    rmSync(root, { recursive: true, force: true });
+                }
+            });
         });
 
         await describe('resolveWorkspaceProtocol', async () => {

--- a/packages/infra/workspace/src/index.ts
+++ b/packages/infra/workspace/src/index.ts
@@ -80,6 +80,12 @@ export function discoverWorkspaces(root: string, options: DiscoverWorkspacesOpti
     const excludeMatchers = patterns.filter((p) => p.startsWith('!')).map((p) => globToRegex(p.slice(1)));
 
     const out: Workspace[] = [];
+    // Dedupe by directory: overlapping patterns (e.g. `packages/*` plus an
+    // explicit `packages/app-android`) match the same dir more than once. Yarn
+    // collapses these to a single workspace; without dedup the duplicate flows
+    // downstream into double symlink plans (a concurrent `rm`+`symlink` race
+    // that throws EEXIST in `gjsify install`).
+    const seenLocations = new Set<string>();
     if (options.includeRoot && rootManifest.name) {
         out.push({
             location: root,
@@ -89,10 +95,12 @@ export function discoverWorkspaces(root: string, options: DiscoverWorkspacesOpti
             manifest: rootManifest,
             private: rootManifest.private === true,
         });
+        seenLocations.add(root);
     }
 
     for (const pattern of includePatterns) {
         for (const matchedDir of expandPattern(root, pattern)) {
+            if (seenLocations.has(matchedDir)) continue;
             const relativeLocation = relative(root, matchedDir).split(sep).join('/');
             if (excludeMatchers.some((re) => re.test(relativeLocation))) continue;
             const pkgPath = join(matchedDir, 'package.json');
@@ -104,6 +112,7 @@ export function discoverWorkspaces(root: string, options: DiscoverWorkspacesOpti
                 continue;
             }
             if (!manifest.name) continue;
+            seenLocations.add(matchedDir);
             out.push({
                 location: matchedDir,
                 relativeLocation,


### PR DESCRIPTION
## Problem

`discoverWorkspaces` iterated each `workspaces` pattern independently and pushed every matched directory, with no cross-pattern dedup. A real-world overlapping config — e.g. `["packages/*", "packages/app-android", "packages/app-web"]`, where `packages/*` already matches the explicit entries — returned the same workspace **twice**.

Downstream, `gjsify install` built two identical symlink plans for one `linkPath`; the pooled, concurrent `rm`+`symlink` wiring then raced and threw:

```
EEXIST: file already exists, symlink '../../../6502' -> '.../packages/app-android/node_modules/@learn6502/6502'
```

aborting the install. (Found while validating `gjsify install` on the JumpLink/easy6502 monorepo, whose root `workspaces` listed `packages/app-android`/`packages/app-web` explicitly *and* via `packages/*`.)

## Fix

Dedupe by matched directory in `discoverWorkspaces` — a `seenLocations` Set (seeded with the root when `includeRoot` is set) — mirroring how yarn collapses overlapping patterns into a single workspace.

## Test

Adds a spec covering a glob + explicit-entry overlap (`index.spec.ts`): the overlapped dirs must each appear exactly once. Full `@gjsify/workspace` suite green (59/59) under Node.

Note: `packages/infra/workspace/**` is a CI global trigger, so the full suite runs for this change. The committed `cli.gjs.mjs` bundle is intentionally **not** rebuilt here (the pre-commit hook only rebuilds it for `cli/src` changes; it refreshes canonically at release).