### PR TITLE
feat(iframe): host-control + debugging methods on IFrameBridge

### DIFF
--- a/packages/framework/iframe/src/eval.spec.ts
+++ b/packages/framework/iframe/src/eval.spec.ts
@@ -1,0 +1,65 @@
+// Tests for the pure evaluateJavaScript helpers (eval.ts).
+// WebView-free — these exercise the wrapper-build + result-parse pipeline that
+// IFrameBridge.evaluateJavaScript composes. The live-WebView round-trip is
+// covered separately (needs a GDK display, see the package's testing notes).
+
+import { describe, it, expect } from '@gjsify/unit';
+
+import { buildEvalScript, parseEvalResult } from './eval.js';
+
+export default async () => {
+    await describe('buildEvalScript', async () => {
+        await it('embeds the expression and the result markers', async () => {
+            const script = buildEvalScript('document.title');
+            expect(script).toContain('document.title');
+            expect(script).toContain('__gjsifyEval');
+            expect(script).toContain("'ok'");
+            expect(script).toContain("'undefined'");
+            expect(script).toContain("'error'");
+        });
+
+        await it('produces a self-invoking expression (no statements required)', async () => {
+            const script = buildEvalScript('1 + 1');
+            expect(script.startsWith('(function(){')).toBe(true);
+            expect(script.endsWith('})()')).toBe(true);
+        });
+    });
+
+    await describe('parseEvalResult', async () => {
+        await it('returns the value for an ok envelope', async () => {
+            expect(parseEvalResult(JSON.stringify({ __gjsifyEval: 'ok', value: 3 }))).toBe(3);
+        });
+
+        await it('returns deep objects for an ok envelope', async () => {
+            const json = JSON.stringify({ __gjsifyEval: 'ok', value: { x: [1, 2], y: 'z' } });
+            expect(parseEvalResult(json)).toStrictEqual({ x: [1, 2], y: 'z' });
+        });
+
+        await it('returns undefined for an undefined envelope', async () => {
+            expect(parseEvalResult(JSON.stringify({ __gjsifyEval: 'undefined' }))).toBeUndefined();
+        });
+
+        await it('returns undefined for an ok envelope with no value (non-serialisable)', async () => {
+            // JSON.stringify({__gjsifyEval:'ok', value: fn}) drops the value key.
+            expect(parseEvalResult(JSON.stringify({ __gjsifyEval: 'ok' }))).toBeUndefined();
+        });
+
+        await it('throws an EvalError for an error envelope', async () => {
+            expect(() => parseEvalResult(JSON.stringify({ __gjsifyEval: 'error', message: 'boom' }))).toThrow();
+        });
+
+        await it('returns undefined for malformed JSON', async () => {
+            expect(parseEvalResult('not json {')).toBeUndefined();
+        });
+
+        await it('returns undefined for null / undefined input', async () => {
+            expect(parseEvalResult(null)).toBeUndefined();
+            expect(parseEvalResult(undefined)).toBeUndefined();
+        });
+
+        await it('returns undefined for a non-envelope JSON value', async () => {
+            expect(parseEvalResult(JSON.stringify({ some: 'object' }))).toBeUndefined();
+            expect(parseEvalResult(JSON.stringify(42))).toBeUndefined();
+        });
+    });
+};

--- a/packages/framework/iframe/src/eval.ts
+++ b/packages/framework/iframe/src/eval.ts
@@ -1,0 +1,70 @@
+// Pure helpers for IFrameBridge.evaluateJavaScript — original implementation.
+//
+// Building the in-page wrapper script and parsing its JSON result are kept
+// WebView-free so they unit-test headless (CI has no GDK display to
+// instantiate a real WebKit.WebView, see the package's other specs).
+//
+// Contract (mirrors Playwright/Puppeteer `page.evaluate`): the caller passes
+// a JavaScript *expression*. Its value is serialised to JSON in-page and read
+// back on the GJS host. Multi-statement scripts wrap themselves in an IIFE
+// that returns a value, e.g. `(() => { const a = 1; return a + 1; })()`.
+// No `eval` is used in-page, so the wrapper stays compatible with strict CSP.
+
+/** JSON envelope the in-page wrapper returns. */
+export type EvalResult =
+    | { __gjsifyEval: 'ok'; value: unknown }
+    | { __gjsifyEval: 'undefined' }
+    | { __gjsifyEval: 'error'; message: string };
+
+/**
+ * Wrap a user expression so its value comes back as a JSON string.
+ *
+ * The wrapper always evaluates to a JSON string of one {@link EvalResult}
+ * shape — `ok` with the JSON-serialised value, `undefined` when the value is
+ * `undefined`, or `error` with the thrown message. A value that is not
+ * JSON-serialisable (function, circular object) collapses to `undefined`.
+ */
+export function buildEvalScript(expression: string): string {
+    return (
+        '(function(){try{' +
+        'var __v=(' +
+        expression +
+        ');' +
+        "if(__v===undefined)return JSON.stringify({__gjsifyEval:'undefined'});" +
+        "return JSON.stringify({__gjsifyEval:'ok',value:__v});" +
+        '}catch(__e){' +
+        "return JSON.stringify({__gjsifyEval:'error',message:String((__e&&__e.message)||__e)});" +
+        '}})()'
+    );
+}
+
+/**
+ * Parse the JSON string returned by {@link buildEvalScript} (read off the
+ * JSCValue via `to_string()`).
+ *
+ * - `ok` → the deserialised value.
+ * - `undefined` → `undefined`.
+ * - `error` → throws an `Error` (name `EvalError`) carrying the page message.
+ * - malformed / `null` / non-envelope JSON → `undefined` (defensive — a
+ *   tampered page or a non-wrapper result must not crash the host).
+ */
+export function parseEvalResult(json: string | null | undefined): unknown {
+    if (json === null || json === undefined) return undefined;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(json);
+    } catch {
+        return undefined;
+    }
+    if (parsed === null || typeof parsed !== 'object') return undefined;
+    const tag = (parsed as { __gjsifyEval?: unknown }).__gjsifyEval;
+    if (tag === 'error') {
+        const message = (parsed as { message?: unknown }).message;
+        const err = new Error(typeof message === 'string' ? message : 'evaluateJavaScript failed');
+        err.name = 'EvalError';
+        throw err;
+    }
+    if (tag === 'undefined') return undefined;
+    if (tag === 'ok') return (parsed as { value?: unknown }).value;
+    return undefined;
+}

--- a/packages/framework/iframe/src/iframe-bridge.ts
+++ b/packages/framework/iframe/src/iframe-bridge.ts
@@ -1,17 +1,29 @@
 // IFrameBridge — GTK container for HTMLIFrameElement backed by WebKit.WebView.
 // Provides a WebKit.WebView subclass that bundles all iframe bootstrapping.
 
+import GLib from 'gi://GLib?version=2.0';
 import GObject from 'gi://GObject';
 import WebKit from 'gi://WebKit?version=6.0';
 
 import { notifyElementResize } from '@gjsify/dom-elements';
 
+import { buildEvalScript, parseEvalResult } from './eval.js';
 import { HTMLIFrameElement } from './html-iframe-element.js';
 import { IFrameWindowProxy } from './iframe-window-proxy.js';
 import { MessageBridge } from './message-bridge.js';
 import * as PS from './property-symbol.js';
+// Install the Promise-returning overloads of evaluate_javascript / get_snapshot.
+import './promisify.js';
 
-import type { IFrameBridgeOptions, IFrameReadyCallback } from './types/index.js';
+import type { IFrameBridgeOptions, IFrameReadyCallback, LoadErrorCallback, LoadErrorInfo } from './types/index.js';
+
+/** A pending {@link IFrameBridge.waitForNavigation} promise. `sourceId` is the
+ *  GLib timeout source backing its deadline (null when no timeout). */
+interface NavigationWaiter {
+    resolve: () => void;
+    reject: (error: Error) => void;
+    sourceId: number | null;
+}
 
 /**
  * A `WebKit.WebView` subclass that handles iframe bootstrapping:
@@ -41,6 +53,11 @@ export const IFrameBridge = GObject.registerClass(
         _messageBridge: MessageBridge;
         _readyCallbacks: IFrameReadyCallback[] = [];
         _options: IFrameBridgeOptions;
+        /** Pending waitForNavigation() promises, settled on the next load. */
+        _navigationWaiters: NavigationWaiter[] = [];
+        /** Detail of the most recent failed load, or null after a fresh start. */
+        _lastLoadError: LoadErrorInfo | null = null;
+        _loadErrorCallbacks: LoadErrorCallback[] = [];
 
         constructor(options?: IFrameBridgeOptions & Partial<WebKit.WebView.ConstructorProps>) {
             const { enableDeveloperExtras, enableJavascript, ...webViewProps } = options ?? {};
@@ -73,6 +90,11 @@ export const IFrameBridge = GObject.registerClass(
             // Track load state
             this.connect('load-changed', (_webView: WebKit.WebView, event: WebKit.LoadEvent) => {
                 switch (event) {
+                    case WebKit.LoadEvent.STARTED:
+                        // A fresh navigation began — clear the stale error so
+                        // lastLoadError only ever reflects the current page.
+                        this._lastLoadError = null;
+                        break;
                     case WebKit.LoadEvent.COMMITTED: {
                         const uri = this.get_uri();
                         if (uri) this._messageBridge.updateUri(uri);
@@ -84,14 +106,26 @@ export const IFrameBridge = GObject.registerClass(
                             cb(this._iframe as unknown as globalThis.HTMLIFrameElement);
                         }
                         this._readyCallbacks = [];
+                        // Resolve any waitForNavigation() promises waiting for
+                        // this load to finish.
+                        this._settleNavigationWaiters(null);
                         break;
                 }
             });
 
-            this.connect('load-failed', () => {
-                this._iframe._onError();
-                return false;
-            });
+            this.connect(
+                'load-failed',
+                (_webView: WebKit.WebView, _event: WebKit.LoadEvent, failingUri: string, error: GLib.Error) => {
+                    const info: LoadErrorInfo = { uri: failingUri, message: error?.message ?? 'load failed' };
+                    this._lastLoadError = info;
+                    for (const cb of this._loadErrorCallbacks) cb(info);
+                    this._iframe._onError();
+                    // A main-resource failure may produce no subsequent FINISHED,
+                    // so reject pending waiters rather than let them hang.
+                    this._settleNavigationWaiters(new Error(`load failed for ${failingUri}: ${info.message}`));
+                    return false;
+                },
+            );
 
             // Surface WebKit.WebView allocation changes to any ResizeObserver
             // observing the paired HTMLIFrameElement (or any ancestor of it —
@@ -191,6 +225,106 @@ export const IFrameBridge = GObject.registerClass(
          *  Reflects WebKit's `can-go-forward` state. */
         get canGoForward(): boolean {
             return this.can_go_forward();
+        }
+
+        /** WebKit's ground-truth current URI (`about:blank` before any load).
+         *  Distinct from any application-side history the embedder maintains. */
+        get currentUri(): string {
+            return this.get_uri() ?? 'about:blank';
+        }
+
+        /** The loaded document's title (empty string before it is known).
+         *  Reflects WebKit's tracked `<title>`. */
+        get pageTitle(): string {
+            return this.get_title() ?? '';
+        }
+
+        /** Detail of the most recent failed load, or null when the current
+         *  page loaded without a main-resource failure. */
+        get lastLoadError(): LoadErrorInfo | null {
+            return this._lastLoadError;
+        }
+
+        /** Subscribe to load failures (network / main-resource errors). */
+        onLoadError(cb: LoadErrorCallback): void {
+            this._loadErrorCallbacks.push(cb);
+        }
+
+        /**
+         * Evaluate a JavaScript *expression* in the page and return its value.
+         *
+         * The value is serialised to JSON in-page and parsed on the GJS host,
+         * so objects/arrays/strings/numbers/booleans/null round-trip. A value
+         * that is not JSON-serialisable (DOM node, function, circular object)
+         * comes back as `undefined`. A thrown page error rejects the promise.
+         *
+         * Pass an expression, not statements — wrap multi-statement logic in an
+         * IIFE that returns a value, e.g.
+         * `evaluateJavaScript('(() => { const a = 1; return a + 1; })()')`.
+         * This mirrors Playwright/Puppeteer `page.evaluate` ergonomics.
+         */
+        async evaluateJavaScript(expression: string): Promise<unknown> {
+            const value = await this.evaluate_javascript(buildEvalScript(expression), -1, null, null, null);
+            return parseEvalResult(value?.to_string() ?? null);
+        }
+
+        /**
+         * Capture the rendered web content as PNG bytes.
+         *
+         * `'full'` (default) snapshots the whole scrollable document; `'visible'`
+         * snapshots only the current viewport. This goes through WebKit's own
+         * `get_snapshot` — NOT a GSK widget snapshot — because WebKit composites
+         * its content in a separate process, so a GTK-tree snapshot of the
+         * WebView can come back blank or stale.
+         */
+        async takeScreenshot(region: 'full' | 'visible' = 'full'): Promise<Uint8Array> {
+            const snapshotRegion =
+                region === 'visible' ? WebKit.SnapshotRegion.VISIBLE : WebKit.SnapshotRegion.FULL_DOCUMENT;
+            const texture = await this.get_snapshot(snapshotRegion, WebKit.SnapshotOptions.NONE, null);
+            const data = texture.save_to_png_bytes().get_data();
+            return data ? new Uint8Array(data) : new Uint8Array(0);
+        }
+
+        /**
+         * Resolve on the next load that finishes (`LoadEvent.FINISHED`).
+         *
+         * `onReady()` fires only once and is drained per load, so a
+         * page-initiated navigation (link click, JS redirect, form submit,
+         * meta-refresh) never re-triggers it. Register a `waitForNavigation()`
+         * *before* triggering such a navigation. Rejects on a main-resource
+         * load failure, or after `timeoutMs` (0 disables the timeout).
+         */
+        waitForNavigation(timeoutMs = 30000): Promise<void> {
+            return new Promise<void>((resolve, reject) => {
+                const waiter: NavigationWaiter = { resolve, reject, sourceId: null };
+                if (timeoutMs > 0) {
+                    waiter.sourceId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, timeoutMs, () => {
+                        const index = this._navigationWaiters.indexOf(waiter);
+                        if (index !== -1) this._navigationWaiters.splice(index, 1);
+                        waiter.sourceId = null;
+                        reject(new Error(`waitForNavigation: timed out after ${timeoutMs}ms`));
+                        return GLib.SOURCE_REMOVE;
+                    });
+                }
+                this._navigationWaiters.push(waiter);
+            });
+        }
+
+        /** Settle (and clear) every pending waitForNavigation() promise,
+         *  removing its timeout source. Resolves them on success; rejects with
+         *  `error` on a load failure. */
+        _settleNavigationWaiters(error: Error | null): void {
+            if (this._navigationWaiters.length === 0) return;
+            const waiters = this._navigationWaiters;
+            this._navigationWaiters = [];
+            for (const waiter of waiters) {
+                if (waiter.sourceId !== null) {
+                    GLib.source_remove(waiter.sourceId);
+                    waiter.sourceId = null;
+                }
+                if (error) waiter.reject(error);
+                else waiter.resolve();
+            }
         }
 
         /**

--- a/packages/framework/iframe/src/message-bridge.ts
+++ b/packages/framework/iframe/src/message-bridge.ts
@@ -3,13 +3,13 @@
 // Copyright (c) PixelRPG contributors. MIT license.
 // Modifications: Simplified to standard postMessage semantics (no JSON-RPC layer)
 
-import Gio from 'gi://Gio?version=2.0';
 import WebKit from 'gi://WebKit?version=6.0';
 import type JavaScriptCore from 'gi://JavaScriptCore?version=6.0';
 import { MessageEvent } from '@gjsify/dom-events';
 
-// Promisify evaluate_javascript so it returns a Promise in GJS
-Gio._promisify(WebKit.WebView.prototype, 'evaluate_javascript', 'evaluate_javascript_finish');
+// Install the Promise-returning overloads of the WebKit.WebView async methods
+// (evaluate_javascript / get_snapshot) used across this package.
+import './promisify.js';
 
 import type { IFrameWindowProxy } from './iframe-window-proxy.js';
 import type { IFrameMessageData } from './types/index.js';

--- a/packages/framework/iframe/src/promisify.ts
+++ b/packages/framework/iframe/src/promisify.ts
@@ -1,0 +1,15 @@
+// Centralised Gio._promisify of the WebKit.WebView async methods used across
+// @gjsify/iframe — original implementation.
+//
+// Importing this module once installs the Promise-returning overloads on the
+// prototype. ES modules are singletons, so the patch runs exactly once no
+// matter how many sibling modules import it — which is why both
+// `message-bridge.ts` (postMessage delivery) and `iframe-bridge.ts`
+// (evaluateJavaScript / takeScreenshot) import it instead of patching
+// independently (a double `_promisify` of the same method is avoided).
+
+import Gio from 'gi://Gio?version=2.0';
+import WebKit from 'gi://WebKit?version=6.0';
+
+Gio._promisify(WebKit.WebView.prototype, 'evaluate_javascript', 'evaluate_javascript_finish');
+Gio._promisify(WebKit.WebView.prototype, 'get_snapshot', 'get_snapshot_finish');

--- a/packages/framework/iframe/src/test.mts
+++ b/packages/framework/iframe/src/test.mts
@@ -3,5 +3,6 @@ import { run } from '@gjsify/unit';
 import testSuite from './index.spec.js';
 import serializeSuite from './serialize.spec.js';
 import channelSuite from './iframe-message-channel.spec.js';
+import evalSuite from './eval.spec.js';
 
-run({ testSuite, serializeSuite, channelSuite });
+run({ testSuite, serializeSuite, channelSuite, evalSuite });

--- a/packages/framework/iframe/src/types/index.ts
+++ b/packages/framework/iframe/src/types/index.ts
@@ -17,3 +17,16 @@ export interface IFrameMessageData {
 
 /** Callback for when the IFrameBridge is ready */
 export type IFrameReadyCallback = (iframe: globalThis.HTMLIFrameElement) => void;
+
+/** Detail of the most recent failed load (a network / main-resource failure
+ *  surfaced by WebKit's `load-failed` signal, distinct from an HTTP error
+ *  page which still loads and reports `FINISHED`). */
+export interface LoadErrorInfo {
+    /** The URI that failed to load. */
+    uri: string;
+    /** Human-readable failure message from WebKit / GLib. */
+    message: string;
+}
+
+/** Callback invoked when a load fails. */
+export type LoadErrorCallback = (info: LoadErrorInfo) => void;


### PR DESCRIPTION
Adds host-control / debugging methods to `IFrameBridge` (the `@gjsify/iframe` WebKit.WebView wrapper) so a GJS host can **drive and inspect** the embedded web content. This is the **core (Phase 1)** of a larger effort: a minimal, MCP-controllable Adwaita web browser for debugging gjsify-built web apps. It ships standalone and benefits *every* `IFrameBridge` consumer (e.g. the `minimalist-browser` showcase) regardless of that follow-up.

## New `IFrameBridge` API

| Method | Purpose |
|---|---|
| `evaluateJavaScript(expr)` | Evaluate a JS **expression** in the page; value JSON-round-tripped to the host (`undefined` for non-serialisable, throws on page error). Playwright-style ergonomics. |
| `takeScreenshot('full' \| 'visible')` | PNG bytes via WebKit `get_snapshot` (full scrollable document or viewport). |
| `waitForNavigation(timeout?)` | Resolve on the next `FINISHED` load — for page-initiated navigations (link click / JS redirect / form submit) that `onReady()` never re-fires for. |
| `get currentUri` / `get pageTitle` | WebKit ground-truth URI / title. |
| `lastLoadError` + `onLoadError(cb)` | Capture `load-failed` detail (failing URI + message), reset on each new load. |

## Why WebKit `get_snapshot`, not a GSK widget snapshot
WebKit composites web content in a **separate process**, so a GSK snapshot of the WebView's GTK tree can come back blank/stale. `takeScreenshot` goes through WebKit's own snapshot path; `FULL_DOCUMENT` also captures the whole scrollable page.

## Implementation notes
- The eval wrapper-build + result-parse are extracted into a **WebView-free** `eval.ts` and unit-tested headlessly (CI has no GDK display to instantiate a real WebView — same constraint the existing specs work within). The live-WebView round-trip is covered by the downstream browser tool's e2e.
- `Gio._promisify` of `evaluate_javascript` + `get_snapshot` is centralised in a new `promisify.ts` imported by both `message-bridge` and `iframe-bridge` (runs once; no double-promisify).

## Tests
`gjsify run test` → **237 pass** (10 new eval specs). `gjsify tsc --noEmit` clean; oxlint + oxfmt clean.

No new dependencies. `@gjsify/iframe`-only; no behavior change to existing methods.