### PR TITLE
feat(iframe): console capture + DOM/viewport helpers on IFrameBridge

### DIFF
--- a/packages/framework/iframe/src/console-capture.spec.ts
+++ b/packages/framework/iframe/src/console-capture.spec.ts
@@ -1,0 +1,91 @@
+// Tests for console capture (console-capture.ts) — host-side parse + buffer +
+// the injected-script builder. WebView-free (the live console-mirror round-trip
+// is covered by the downstream browser tool's e2e).
+
+import { describe, it, expect } from '@gjsify/unit';
+
+import { buildConsoleCaptureScript, ConsoleBuffer, parseConsoleEnvelope } from './console-capture.js';
+
+export default async () => {
+    await describe('parseConsoleEnvelope', async () => {
+        await it('parses a valid console envelope', async () => {
+            const entry = parseConsoleEnvelope({ __gjsifyConsole: 'warn', args: ['a', 'b'] });
+            expect(entry).toStrictEqual({ level: 'warn', args: ['a', 'b'] });
+        });
+
+        await it('coerces non-string args to strings', async () => {
+            const entry = parseConsoleEnvelope({ __gjsifyConsole: 'log', args: [1, true, null] });
+            expect(entry).toStrictEqual({ level: 'log', args: ['1', 'true', 'null'] });
+        });
+
+        await it('defaults missing args to an empty array', async () => {
+            expect(parseConsoleEnvelope({ __gjsifyConsole: 'error' })).toStrictEqual({ level: 'error', args: [] });
+        });
+
+        await it('returns null for non-console envelopes', async () => {
+            expect(parseConsoleEnvelope({ data: 'x', targetOrigin: '*', origin: 'y' })).toBeNull();
+            expect(parseConsoleEnvelope({ __gjsifyPortMessage: 1, payload: {} })).toBeNull();
+            expect(parseConsoleEnvelope(null)).toBeNull();
+            expect(parseConsoleEnvelope('string')).toBeNull();
+            expect(parseConsoleEnvelope({ __gjsifyConsole: 42 })).toBeNull();
+        });
+    });
+
+    await describe('buildConsoleCaptureScript', async () => {
+        await it('embeds the channel name and wraps each level', async () => {
+            const script = buildConsoleCaptureScript('gjsify-iframe');
+            expect(script).toContain(`messageHandlers[${JSON.stringify('gjsify-iframe')}]`);
+            expect(script).toContain('__gjsifyConsole');
+            for (const level of ['log', 'warn', 'error', 'info', 'debug']) {
+                expect(script).toContain(level);
+            }
+        });
+
+        await it('carries an idempotency guard', async () => {
+            expect(buildConsoleCaptureScript('ch')).toContain('__gjsifyConsoleHook');
+        });
+
+        await it('JSON-escapes the channel name', async () => {
+            // A channel containing a quote must not break out of the string literal.
+            const script = buildConsoleCaptureScript("a'b");
+            expect(script).toContain(JSON.stringify("a'b"));
+        });
+    });
+
+    await describe('ConsoleBuffer', async () => {
+        await it('keeps entries in order', async () => {
+            const buf = new ConsoleBuffer();
+            buf.push({ level: 'log', args: ['1'] });
+            buf.push({ level: 'warn', args: ['2'] });
+            expect(buf.list()).toStrictEqual([
+                { level: 'log', args: ['1'] },
+                { level: 'warn', args: ['2'] },
+            ]);
+        });
+
+        await it('caps at max, dropping the oldest', async () => {
+            const buf = new ConsoleBuffer(2);
+            buf.push({ level: 'log', args: ['1'] });
+            buf.push({ level: 'log', args: ['2'] });
+            buf.push({ level: 'log', args: ['3'] });
+            const list = buf.list();
+            expect(list.length).toBe(2);
+            expect(list[0]!.args).toStrictEqual(['2']);
+            expect(list[1]!.args).toStrictEqual(['3']);
+        });
+
+        await it('clear() empties the buffer', async () => {
+            const buf = new ConsoleBuffer();
+            buf.push({ level: 'log', args: ['x'] });
+            buf.clear();
+            expect(buf.list()).toStrictEqual([]);
+        });
+
+        await it('list() returns a copy (mutating it does not affect the buffer)', async () => {
+            const buf = new ConsoleBuffer();
+            buf.push({ level: 'log', args: ['x'] });
+            buf.list().push({ level: 'warn', args: ['y'] });
+            expect(buf.list().length).toBe(1);
+        });
+    });
+};

--- a/packages/framework/iframe/src/console-capture.ts
+++ b/packages/framework/iframe/src/console-capture.ts
@@ -1,0 +1,93 @@
+// Console capture for @gjsify/iframe — original implementation.
+//
+// Forwards a page's `console.*` output to the GJS host so a debugging embedder
+// can read it. The in-page hook (a self-contained UserScript) wraps the
+// console methods, preserving their original output, and posts each call over
+// the existing WebKit message handler. The host-side parse + buffer live here
+// too so they unit-test headless (no WebView needed).
+
+import type { ConsoleLogEntry } from './types/index.js';
+
+/** Console levels the in-page hook wraps. */
+const LEVELS = ['log', 'warn', 'error', 'info', 'debug'] as const;
+
+/**
+ * Build the self-contained in-page UserScript that mirrors `console.*` to the
+ * host via `window.webkit.messageHandlers[channelName]`.
+ *
+ * Self-contained (acquires its own handler reference, own idempotency guard) so
+ * it can be injected as a separate UserScript independent of the postMessage
+ * bootstrap — it is opt-in (`captureConsole`), so it must not be entangled with
+ * the always-injected bridge script. ES5 to match the bootstrap's style.
+ *
+ * Each forwarded entry is `{__gjsifyConsole: level, args: string[]}` — args are
+ * stringified in-page (objects via JSON, Errors as `name: message`) so the host
+ * never has to traverse a live JS graph across the bridge.
+ */
+export function buildConsoleCaptureScript(channelName: string): string {
+    const channel = JSON.stringify(channelName);
+    const levels = JSON.stringify(LEVELS);
+    return `(function(){
+    var handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers[${channel}];
+    if (!handler) return;
+    if (window.__gjsifyConsoleHook) return;
+    window.__gjsifyConsoleHook = true;
+    function stringify(a){
+        if (typeof a === 'string') return a;
+        if (a instanceof Error) return (a.name || 'Error') + ': ' + (a.message || '');
+        try { return JSON.stringify(a); }
+        catch (_e) { try { return String(a); } catch (_e2) { return '[unserializable]'; } }
+    }
+    var levels = ${levels};
+    for (var i = 0; i < levels.length; i++) {
+        (function(level){
+            var orig = (console[level] && console[level].bind) ? console[level].bind(console) : function(){};
+            console[level] = function(){
+                var args = Array.prototype.slice.call(arguments);
+                try { handler.postMessage(JSON.stringify({ __gjsifyConsole: level, args: args.map(stringify) })); }
+                catch (_e) {}
+                return orig.apply(console, arguments);
+            };
+        })(levels[i]);
+    }
+})();`;
+}
+
+/**
+ * Parse a received envelope into a {@link ConsoleLogEntry}, or null when it is
+ * not a console envelope. Defensive — a tampered page must not crash the host:
+ * non-string args are coerced to strings, a missing args array becomes empty.
+ */
+export function parseConsoleEnvelope(envelope: unknown): ConsoleLogEntry | null {
+    if (envelope === null || typeof envelope !== 'object') return null;
+    const level = (envelope as { __gjsifyConsole?: unknown }).__gjsifyConsole;
+    if (typeof level !== 'string') return null;
+    const rawArgs = (envelope as { args?: unknown }).args;
+    const args = Array.isArray(rawArgs) ? rawArgs.map((a) => (typeof a === 'string' ? a : String(a))) : [];
+    return { level, args };
+}
+
+/**
+ * Bounded ring buffer of console entries. Keeps at most `max` (oldest dropped),
+ * so a chatty page can't grow host memory without bound.
+ */
+export class ConsoleBuffer {
+    private _entries: ConsoleLogEntry[] = [];
+    constructor(private readonly _max = 1000) {}
+
+    push(entry: ConsoleLogEntry): void {
+        this._entries.push(entry);
+        if (this._entries.length > this._max) {
+            this._entries.splice(0, this._entries.length - this._max);
+        }
+    }
+
+    /** A copy of the buffered entries (oldest first). */
+    list(): ConsoleLogEntry[] {
+        return this._entries.slice();
+    }
+
+    clear(): void {
+        this._entries = [];
+    }
+}

--- a/packages/framework/iframe/src/dom-queries.spec.ts
+++ b/packages/framework/iframe/src/dom-queries.spec.ts
@@ -1,0 +1,62 @@
+// Tests for the DOM-query expression builders (dom-queries.ts). WebView-free —
+// these verify the generated JS expression text (selector escaping, limit,
+// shape). Running them against a real page is the browser tool's e2e job.
+
+import { describe, it, expect } from '@gjsify/unit';
+
+import { buildClickElementExpression, buildGetLinksExpression, buildQueryDomExpression } from './dom-queries.js';
+
+export default async () => {
+    await describe('buildGetLinksExpression', async () => {
+        await it('queries a[href] and maps href/text/title', async () => {
+            const expr = buildGetLinksExpression();
+            expect(expr).toContain("querySelectorAll('a[href]')");
+            expect(expr).toContain('href:a.href');
+            expect(expr).toContain('title:a.getAttribute');
+        });
+    });
+
+    await describe('buildQueryDomExpression', async () => {
+        await it('embeds the JSON-escaped selector and the limit', async () => {
+            const expr = buildQueryDomExpression('.item > a', 50);
+            expect(expr).toContain(JSON.stringify('.item > a'));
+            expect(expr).toContain('.slice(0,50)');
+            expect(expr).toContain('getBoundingClientRect');
+        });
+
+        await it('escapes a selector containing quotes (no breakout)', async () => {
+            const expr = buildQueryDomExpression('a[data-x="y"]');
+            expect(expr).toContain(JSON.stringify('a[data-x="y"]'));
+        });
+
+        await it('floors and clamps a non-integer / negative limit', async () => {
+            expect(buildQueryDomExpression('a', 12.9)).toContain('.slice(0,12)');
+            expect(buildQueryDomExpression('a', -5)).toContain('.slice(0,0)');
+        });
+
+        await it('defaults the limit to 200', async () => {
+            expect(buildQueryDomExpression('a')).toContain('.slice(0,200)');
+        });
+    });
+
+    await describe('buildClickElementExpression', async () => {
+        await it('embeds the JSON-escaped target and a text fallback', async () => {
+            const expr = buildClickElementExpression('Home');
+            expect(expr).toContain(JSON.stringify('Home'));
+            expect(expr).toContain('querySelector');
+            expect(expr).toContain('querySelectorAll("a")');
+            expect(expr).toContain('.click()');
+        });
+
+        await it('escapes a target containing quotes (no breakout)', async () => {
+            const expr = buildClickElementExpression('a[title="Go \'home\'"]');
+            expect(expr).toContain(JSON.stringify('a[title="Go \'home\'"]'));
+        });
+
+        await it('is a self-invoking expression', async () => {
+            const expr = buildClickElementExpression('a');
+            expect(expr.startsWith('(function(){')).toBe(true);
+            expect(expr.endsWith('})()')).toBe(true);
+        });
+    });
+};

--- a/packages/framework/iframe/src/dom-queries.ts
+++ b/packages/framework/iframe/src/dom-queries.ts
@@ -1,0 +1,75 @@
+// DOM-query expression builders for @gjsify/iframe — original implementation.
+//
+// Pure string builders for the JavaScript expressions that IFrameBridge's
+// convenience helpers (getLinks / queryDom / clickElement) hand to
+// evaluateJavaScript. Kept WebView-free so they unit-test headless. Selectors
+// are embedded via JSON.stringify so quotes/backslashes can't break out of the
+// generated expression.
+
+/** A link harvested by {@link buildGetLinksExpression}. */
+export interface LinkInfo {
+    /** Resolved absolute href. */
+    href: string;
+    /** Trimmed visible text. */
+    text: string;
+    /** `title` attribute (empty when absent). */
+    title: string;
+}
+
+/** Element metadata returned by {@link buildQueryDomExpression}. */
+export interface ElementInfo {
+    tagName: string;
+    id: string;
+    className: string;
+    /** Trimmed text content, capped to keep payloads small. */
+    text: string;
+    /** `href` attribute when present. */
+    href?: string;
+    /** True when the element has a non-zero bounding box. */
+    visible: boolean;
+}
+
+/** Expression: every `<a href>` on the page as {@link LinkInfo}[]. */
+export function buildGetLinksExpression(): string {
+    return (
+        "Array.prototype.slice.call(document.querySelectorAll('a[href]')).map(function(a){" +
+        "return {href:a.href,text:(a.textContent||'').trim(),title:a.getAttribute('title')||''};})"
+    );
+}
+
+/**
+ * Expression: `querySelectorAll(selector)` mapped to {@link ElementInfo}[],
+ * capped at `limit` to bound the payload.
+ */
+export function buildQueryDomExpression(selector: string, limit = 200): string {
+    const sel = JSON.stringify(selector);
+    const cap = Math.max(0, Math.floor(limit));
+    return (
+        `Array.prototype.slice.call(document.querySelectorAll(${sel})).slice(0,${cap}).map(function(el){` +
+        'var r=el.getBoundingClientRect();' +
+        'return {tagName:el.tagName,id:el.id||"",' +
+        'className:(typeof el.className==="string"?el.className:""),' +
+        'text:(el.textContent||"").trim().slice(0,200),' +
+        'href:(el.getAttribute&&el.getAttribute("href"))||undefined,' +
+        'visible:!!(r.width||r.height)};})'
+    );
+}
+
+/**
+ * Expression (returns boolean): click the first element matching `selectorOrText`
+ * — tried first as a CSS selector, then as exact trimmed `<a>` link text. Returns
+ * false when nothing matches. An invalid selector is caught and falls through to
+ * the text match. The caller awaits navigation separately (register
+ * `waitForNavigation()` before invoking, since a fast nav could finish first).
+ */
+export function buildClickElementExpression(selectorOrText: string): string {
+    const target = JSON.stringify(selectorOrText);
+    return (
+        '(function(){' +
+        `var t=${target};var el=null;` +
+        'try{el=document.querySelector(t);}catch(_e){el=null;}' +
+        'if(!el){var links=Array.prototype.slice.call(document.querySelectorAll("a"));' +
+        'for(var i=0;i<links.length;i++){if((links[i].textContent||"").trim()===t){el=links[i];break;}}}' +
+        'if(!el)return false;el.click();return true;})()'
+    );
+}

--- a/packages/framework/iframe/src/iframe-bridge.ts
+++ b/packages/framework/iframe/src/iframe-bridge.ts
@@ -7,6 +7,13 @@ import WebKit from 'gi://WebKit?version=6.0';
 
 import { notifyElementResize } from '@gjsify/dom-elements';
 
+import {
+    buildClickElementExpression,
+    buildGetLinksExpression,
+    buildQueryDomExpression,
+    type ElementInfo,
+    type LinkInfo,
+} from './dom-queries.js';
 import { buildEvalScript, parseEvalResult } from './eval.js';
 import { HTMLIFrameElement } from './html-iframe-element.js';
 import { IFrameWindowProxy } from './iframe-window-proxy.js';
@@ -15,7 +22,14 @@ import * as PS from './property-symbol.js';
 // Install the Promise-returning overloads of evaluate_javascript / get_snapshot.
 import './promisify.js';
 
-import type { IFrameBridgeOptions, IFrameReadyCallback, LoadErrorCallback, LoadErrorInfo } from './types/index.js';
+import type {
+    ConsoleCallback,
+    ConsoleLogEntry,
+    IFrameBridgeOptions,
+    IFrameReadyCallback,
+    LoadErrorCallback,
+    LoadErrorInfo,
+} from './types/index.js';
 
 /** A pending {@link IFrameBridge.waitForNavigation} promise. `sourceId` is the
  *  GLib timeout source backing its deadline (null when no timeout). */
@@ -60,7 +74,7 @@ export const IFrameBridge = GObject.registerClass(
         _loadErrorCallbacks: LoadErrorCallback[] = [];
 
         constructor(options?: IFrameBridgeOptions & Partial<WebKit.WebView.ConstructorProps>) {
-            const { enableDeveloperExtras, enableJavascript, ...webViewProps } = options ?? {};
+            const { enableDeveloperExtras, enableJavascript, captureConsole, ...webViewProps } = options ?? {};
 
             const userContentManager = new WebKit.UserContentManager();
             const settings = new WebKit.Settings();
@@ -73,14 +87,14 @@ export const IFrameBridge = GObject.registerClass(
                 settings,
             });
 
-            this._options = { enableDeveloperExtras, enableJavascript };
+            this._options = { enableDeveloperExtras, enableJavascript, captureConsole };
 
             // Create the DOM element and link it to this widget
             this._iframe = new HTMLIFrameElement();
             this._iframe[PS.iframeWidget] = this as unknown as IFrameBridge;
 
             // Set up the message bridge
-            this._messageBridge = new MessageBridge(this);
+            this._messageBridge = new MessageBridge(this, { captureConsole });
 
             // Create the window proxy and connect it
             const windowProxy = new IFrameWindowProxy(this._messageBridge);
@@ -325,6 +339,61 @@ export const IFrameBridge = GObject.registerClass(
                 if (error) waiter.reject(error);
                 else waiter.resolve();
             }
+        }
+
+        /** Current size of the WebView content region, in widget pixels. */
+        getViewportSize(): { width: number; height: number } {
+            return { width: this.get_allocated_width(), height: this.get_allocated_height() };
+        }
+
+        /**
+         * Request a content-region size (e.g. for responsive testing). This sets
+         * the widget's size request; the actual allocation still depends on the
+         * parent layout, and `getViewportSize()` reflects the realised size.
+         */
+        setViewportSize(width: number, height: number): void {
+            this.set_size_request(width, height);
+        }
+
+        /** Buffered page `console.*` output. Empty unless the bridge was created
+         *  with `{ captureConsole: true }`. */
+        getConsoleLogs(): ConsoleLogEntry[] {
+            return this._messageBridge.getConsoleLogs();
+        }
+
+        /** Drop all buffered console entries. */
+        clearConsoleLogs(): void {
+            this._messageBridge.clearConsoleLogs();
+        }
+
+        /** Subscribe to captured console entries as they arrive. Requires
+         *  `{ captureConsole: true }` to receive anything. */
+        onConsole(cb: ConsoleCallback): void {
+            this._messageBridge.onConsole(cb);
+        }
+
+        /** Every `<a href>` on the page (resolved href, trimmed text, title). */
+        async getLinks(): Promise<LinkInfo[]> {
+            const result = await this.evaluateJavaScript(buildGetLinksExpression());
+            return Array.isArray(result) ? (result as LinkInfo[]) : [];
+        }
+
+        /** Metadata for elements matching a CSS selector (capped at `limit`). */
+        async queryDom(selector: string, limit = 200): Promise<ElementInfo[]> {
+            const result = await this.evaluateJavaScript(buildQueryDomExpression(selector, limit));
+            return Array.isArray(result) ? (result as ElementInfo[]) : [];
+        }
+
+        /**
+         * Click the first element matching `selectorOrText` — a CSS selector, or
+         * (failing that) an `<a>` matched by exact trimmed text. Resolves to true
+         * when an element was found + clicked. Does NOT wait for navigation: to
+         * await a resulting page change, register `waitForNavigation()` *before*
+         * calling this, then await it (a fast navigation may finish first).
+         */
+        async clickElement(selectorOrText: string): Promise<boolean> {
+            const result = await this.evaluateJavaScript(buildClickElementExpression(selectorOrText));
+            return result === true;
         }
 
         /**

--- a/packages/framework/iframe/src/message-bridge.ts
+++ b/packages/framework/iframe/src/message-bridge.ts
@@ -12,12 +12,20 @@ import { MessageEvent } from '@gjsify/dom-events';
 import './promisify.js';
 
 import type { IFrameWindowProxy } from './iframe-window-proxy.js';
-import type { IFrameMessageData } from './types/index.js';
+import type { ConsoleCallback, ConsoleLogEntry, IFrameMessageData } from './types/index.js';
 import type { MessagePort } from '@gjsify/message-channel';
 import { BridgePortTransport } from './iframe-message-channel.js';
 import { encodeBinariesForJson, decodeBinariesFromJson, BINARY_SERIALIZER_INJECTED_SRC } from './serialize.js';
+import { buildConsoleCaptureScript, ConsoleBuffer, parseConsoleEnvelope } from './console-capture.js';
 
 const CHANNEL_NAME = 'gjsify-iframe';
+
+/** Options for {@link MessageBridge}. */
+export interface MessageBridgeOptions {
+    /** Inject the console-capture UserScript so the page's console.* is
+     *  forwarded to the host. Default: false. */
+    captureConsole?: boolean;
+}
 
 /**
  * Synthetic origin attached to messages travelling FROM the GJS host
@@ -236,12 +244,39 @@ export class MessageBridge {
         if (this._transport === null) this._transport = new BridgePortTransport(this);
         return this._transport;
     }
+    private _captureConsole: boolean;
+    private _consoleBuffer = new ConsoleBuffer();
+    private _consoleCallbacks: ConsoleCallback[] = [];
 
-    constructor(webView: WebKit.WebView) {
+    constructor(webView: WebKit.WebView, options?: MessageBridgeOptions) {
         this._webView = webView;
+        this._captureConsole = options?.captureConsole ?? false;
         this._userContentManager = webView.get_user_content_manager();
         this._setupReceiver();
         this._injectBootstrapScript();
+        if (this._captureConsole) this._injectConsoleCaptureScript();
+    }
+
+    /** Buffered console entries captured from the page (oldest first). Empty
+     *  unless the bridge was created with `captureConsole`. */
+    getConsoleLogs(): ConsoleLogEntry[] {
+        return this._consoleBuffer.list();
+    }
+
+    /** Drop all buffered console entries. */
+    clearConsoleLogs(): void {
+        this._consoleBuffer.clear();
+    }
+
+    /** Subscribe to console entries as they arrive. */
+    onConsole(cb: ConsoleCallback): void {
+        this._consoleCallbacks.push(cb);
+    }
+
+    /** @internal Record a parsed console entry + fan out to subscribers. */
+    private _recordConsole(entry: ConsoleLogEntry): void {
+        this._consoleBuffer.push(entry);
+        for (const cb of this._consoleCallbacks) cb(entry);
     }
 
     /** Connect the IFrameWindowProxy that will receive messages from the WebView */
@@ -396,18 +431,25 @@ export class MessageBridge {
         this._signalId = this._userContentManager.connect(
             `script-message-received::${CHANNEL_NAME}`,
             (_ucm: WebKit.UserContentManager, jsValue: JavaScriptCore.Value) => {
-                if (!this._windowProxy) return;
-
                 try {
                     // The bootstrap script sends JSON.stringify({data, targetOrigin, origin})
                     // — or a port-routed shape `{__gjsifyPortMessage: id, payload}` /
-                    // `{__gjsifyPortClose: id}` — so jsValue is a JSC string. Use
+                    // `{__gjsifyPortClose: id}`, or a console shape
+                    // `{__gjsifyConsole: level, args}` — so jsValue is a JSC string. Use
                     // to_string() to get the raw JSON.
                     const json = jsValue.to_string();
                     const envelope = JSON.parse(json) as
                         | IFrameMessageData
                         | { __gjsifyPortMessage: number; payload: unknown }
-                        | { __gjsifyPortClose: number };
+                        | { __gjsifyPortClose: number }
+                        | { __gjsifyConsole: string; args: unknown };
+
+                    // Console message → buffer + fan out (no windowProxy needed).
+                    const consoleEntry = parseConsoleEnvelope(envelope);
+                    if (consoleEntry) {
+                        this._recordConsole(consoleEntry);
+                        return;
+                    }
 
                     // Port message → route to the corresponding GJS-side endpoint.
                     if (typeof (envelope as { __gjsifyPortMessage?: number }).__gjsifyPortMessage === 'number') {
@@ -424,6 +466,8 @@ export class MessageBridge {
                         return;
                     }
 
+                    // Remaining shapes target the window proxy.
+                    if (!this._windowProxy) return;
                     const windowMsg = envelope as IFrameMessageData;
                     // Bootstrap already enforces targetOrigin against GJS_HOST_ORIGIN.
                     // Re-validate here as defense-in-depth: a tampered WebView could
@@ -463,6 +507,22 @@ export class MessageBridge {
     private _injectBootstrapScript(): void {
         const script = new WebKit.UserScript(
             BOOTSTRAP_SCRIPT,
+            WebKit.UserContentInjectedFrames.ALL_FRAMES,
+            WebKit.UserScriptInjectionTime.START,
+            null, // allow list (null = all)
+            null, // block list (null = none)
+        );
+        this._userContentManager.add_script(script);
+    }
+
+    /**
+     * Inject the opt-in console-capture UserScript so the page's `console.*`
+     * output is mirrored to the host. Self-contained (own handler reference +
+     * idempotency guard), so it is independent of the bootstrap script.
+     */
+    private _injectConsoleCaptureScript(): void {
+        const script = new WebKit.UserScript(
+            buildConsoleCaptureScript(CHANNEL_NAME),
             WebKit.UserContentInjectedFrames.ALL_FRAMES,
             WebKit.UserScriptInjectionTime.START,
             null, // allow list (null = all)

--- a/packages/framework/iframe/src/test.mts
+++ b/packages/framework/iframe/src/test.mts
@@ -4,5 +4,7 @@ import testSuite from './index.spec.js';
 import serializeSuite from './serialize.spec.js';
 import channelSuite from './iframe-message-channel.spec.js';
 import evalSuite from './eval.spec.js';
+import consoleSuite from './console-capture.spec.js';
+import domQueriesSuite from './dom-queries.spec.js';
 
-run({ testSuite, serializeSuite, channelSuite, evalSuite });
+run({ testSuite, serializeSuite, channelSuite, evalSuite, consoleSuite, domQueriesSuite });

--- a/packages/framework/iframe/src/types/index.ts
+++ b/packages/framework/iframe/src/types/index.ts
@@ -6,6 +6,10 @@ export interface IFrameBridgeOptions {
     enableDeveloperExtras?: boolean;
     /** Enable JavaScript execution in the WebView. Default: true */
     enableJavascript?: boolean;
+    /** Mirror the page's `console.*` output to the host so it can be read via
+     *  `getConsoleLogs()` / `onConsole()`. Off by default — it wraps `console`
+     *  on every page, so it is opt-in. Default: false */
+    captureConsole?: boolean;
 }
 
 /** Data structure for messages crossing the GJS/WebView boundary */
@@ -30,3 +34,14 @@ export interface LoadErrorInfo {
 
 /** Callback invoked when a load fails. */
 export type LoadErrorCallback = (info: LoadErrorInfo) => void;
+
+/** A captured `console.*` call forwarded from the page. */
+export interface ConsoleLogEntry {
+    /** The console level (`log` / `warn` / `error` / `info` / `debug`). */
+    level: string;
+    /** The call arguments, stringified in-page. */
+    args: string[];
+}
+
+/** Callback invoked for each captured console entry. */
+export type ConsoleCallback = (entry: ConsoleLogEntry) => void;


### PR DESCRIPTION
**Phase 2** of the `IFrameBridge` host-control surface for the MCP-controllable web debugger (follows #560). All additions are **opt-in / additive** — no behavior change to existing methods, no new dependencies.

## New `IFrameBridge` API

| Method | Purpose |
|---|---|
| `getConsoleLogs()` / `onConsole(cb)` / `clearConsoleLogs()` | Read the page's captured `console.*` output. **Opt-in** via `new IFrameBridge({ captureConsole: true })`. |
| `getLinks()` | Every `<a href>` → `{ href, text, title }`. |
| `queryDom(selector, limit?)` | Matching elements → `{ tagName, id, className, text, href?, visible }` (capped). |
| `clickElement(selectorOrText)` | Click by CSS selector, or `<a>` by exact text. Returns whether it matched. |
| `getViewportSize()` / `setViewportSize(w, h)` | WebView content-region size (responsive testing). |

## Design notes
- **Console capture is opt-in** because it wraps `console.*` on every page. When enabled, a **self-contained** UserScript (own handler + idempotency guard) mirrors calls to the host while preserving original output. Args are stringified **in-page** (objects via JSON, Errors as `name: message`) so the host never traverses a live JS graph across the bridge. Buffered in a bounded ring (default 1000). This is deliberately **not** WebKit's `enable-write-console-messages-to-stdout` — that writes to the real stdout, which the downstream MCP bridge owns.
- **DOM helpers** build their JS via pure, unit-tested expression builders (`dom-queries.ts`); selectors are `JSON.stringify`-escaped so quotes can't break out of the generated script. `clickElement` does **not** auto-wait — callers register `waitForNavigation()` (from #560) first if a click navigates.
- The message-receiver guard was reordered so console + port envelopes are handled before the window-proxy check (console capture works regardless of proxy state).

## Tests
`gjsify run test` → **277 pass** (40 new headless specs in `console-capture.spec.ts` + `dom-queries.spec.ts`). `gjsify tsc --noEmit` clean; oxlint + oxfmt clean.