### PR TITLE
ci: raise nofile limit to fix Fedora 43 test EMFILE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,14 @@ jobs:
     timeout-minutes: 240
     container:
       image: fedora:${{ matrix.fedora.v }}
+      # Raise the open-file limit for every step. The parallel GJS `foreach`
+      # test run opens many fds (GStreamer/webrtc pipelines, in-process bundler
+      # eventfds), exhausting the default nofile soft limit on the Fedora 43 leg
+      # — it aborts with `GLib-ERROR: Creating pipes for GWakeup: Too many open
+      # files`. Fedora 44's higher default hides it, so PRs (44-only) stay green
+      # while push-to-main (43 + 44) goes red. Setting it on the container fixes
+      # both legs uniformly.
+      options: --ulimit nofile=1048576:1048576
 
     steps:
       - name: Install container prerequisites


### PR DESCRIPTION
## Problem
`main` (push-to-main, full Fedora **43 + 44** matrix) has been **red since `#558` (node-free multi-package orchestration)**. The **Fedora 43 leg** aborts the parallel `gjsify foreach test` run with:

```
GLib-ERROR **: Creating pipes for GWakeup: Too many open files
gjs exited with code null
```

That's `EMFILE` — the GJS test run opens many file descriptors (GStreamer/webrtc pipelines, in-process bundler eventfds) and exhausts **Fedora 43's default `nofile` soft limit**. Fedora 44's higher default hides it — which is why **PRs (Fedora-44-only leg) stay green while `main` (43 + 44) goes red**. Every commit since #558 (the v0.10.0 release, the refs bumps, the recent CLI + iframe merges) is red purely by inheriting this — none of them is the cause.

## Fix
Set `--ulimit nofile=1048576:1048576` on the test job's container, so **both** legs get ample fds. Doing it at the `container:` level (not a single step) means Test, integration, and WebGL steps all benefit.

## Validation
PRs only run the Fedora 44 leg, so this PR's own run can't exercise F43 — but it confirms the container still starts with the `--ulimit` option. The real validation is the **push-to-main full matrix** after merge (F43 should go green). If a genuine unbounded fd *leak* exists in the #558 orchestration it should be investigated separately, but 146 workspaces × the per-process fd count stays far under 1M, so this resolves the red.