### PR TITLE
fix(devtools-mcp): align zod range to ^4.4.3

### DIFF
--- a/packages/framework/devtools-mcp/package.json
+++ b/packages/framework/devtools-mcp/package.json
@@ -40,7 +40,7 @@
         "@girs/glib-2.0": "2.88.0-4.0.4",
         "@gjsify/devtools-protocol": "workspace:^",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "zod": "4.3.6"
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",


### PR DESCRIPTION
## Problem
After #557 merged, `main`'s **dependency-consistency gate** fails on both Fedora legs (before the test step even runs):
```
gjsify upgrade --check: FAIL. 1 dep(s) declared at inconsistent ranges:
  zod
    ^4.4.3  — @gjsify/example-node-cli-mcp-server, @gjsify/example-node-net-mcp-server
    4.3.6   — @gjsify/devtools-mcp
```
`@gjsify/devtools-mcp` pinned `zod@4.3.6` (from when it was first authored, matching the MCP-SDK integration test), but the workspace standard moved to `^4.4.3`.

## Fix
Align `devtools-mcp`'s `zod` to `^4.4.3` (via `gjsify upgrade --align`). It resolves to the `4.4.3` already in `gjsify-lock.json` (the example packages use it), so **the lockfile is unchanged** and `gjsify install --immutable` still validates. `gjsify upgrade --check` now reports `OK. 103 dep(s) consistently declared`.

## Context
This is one of two regressions that reddened `main` after the devtools work landed; the other (Fedora-43 FD/EMFILE exhaustion in the test run) is already fixed by #563. The earlier run got *past* bundle-verify/build/examples and only died at this dep-check, so the rebuilt CLI bundle is fine — once this merges, the next main run reaches the Test step and validates the nofile fix too.