### PR TITLE
ci: raise testuser nofile limit for Fedora 43 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,6 +225,12 @@ jobs:
       - name: Create non-root user for tests
         run: |
           useradd -m testuser
+          # Raise testuser's open-file limit via PAM. `su testuser -c` resets the
+          # soft nofile limit back to the login default (~1024), undoing the
+          # container's --ulimit — which is why the F43 test leg still hit
+          # `GLib-ERROR: Creating pipes for GWakeup: Too many open files`. A
+          # limits.conf entry is applied by pam_limits on every `su testuser`.
+          echo "testuser - nofile 1048576" >> /etc/security/limits.conf
           # Pre-create the (possibly cache-restored) gjsify cache dir so the
           # chown below hands it to testuser for the install step.
           mkdir -p .gjsify-cache
@@ -451,6 +457,8 @@ jobs:
           INCLUDE_ARGS: ${{ needs.changes.outputs.include-args }}
         run: |
           su testuser -c "PATH=\"\$PWD/node_modules/.bin:\$PATH\" LIBGL_ALWAYS_SOFTWARE=1 xvfb-run -a --server-args=\"-screen 0 1280x720x24\" sh -c '
+            ulimit -n \"\$(ulimit -Hn)\" 2>/dev/null || true
+            echo \"[ci] nofile limit: soft=\$(ulimit -Sn) hard=\$(ulimit -Hn)\"
             if [ \"\$GLOBAL\" = \"true\" ] || [ -z \"\$GLOBAL\" ]; then
               gjsify run test
             else


### PR DESCRIPTION
## Follow-up to #563
#563 set `--ulimit nofile` on the **container**, but the F43 leg **still** crashed in the Test step with `GLib-ERROR: Creating pipes for GWakeup: Too many open files` → `gjs exited with code null`. Root cause: the test runs under **`su testuser -c`**, and `su` resets the **soft** `nofile` limit back to the login default (~1024), undoing the container ceiling. So the limit has to be raised **as testuser**, not just on the container.

This run also confirmed the zod fix (#564) worked — F44 fully passed and F43 got all the way to the Test step (vs dying at the dep-check before). The `@gjsify/webrtc` failures right before the crash (enumerateDevices / SCTP / negotiation) are fd-starvation symptoms, not separate bugs — the process degrades as it runs out of fds, then aborts.

## Fix (raise the limit where it applies — as testuser)
- **`/etc/security/limits.conf`**: `testuser - nofile 1048576` — applied by `pam_limits` on every `su testuser`.
- **Test step**: explicit `ulimit -n "$(ulimit -Hn)"` + a diagnostic `echo` of the effective soft/hard limits (so the log shows what actually took, if anything still needs tuning).
- Container `--ulimit` from #563 is kept so the hard ceiling stays high.

F44 already passes; this targets the F43 leg. The diagnostic echo de-risks a further iteration — the next run's log will print the real limit.