### PR TITLE
docs: document devtools control plane + debug/browse/storybook CLI

### DIFF
--- a/packages/framework/devtools-browser/README.md
+++ b/packages/framework/devtools-browser/README.md
@@ -1,0 +1,75 @@
+# @gjsify/devtools-browser
+
+A minimalist **Adwaita web browser** for debugging the web apps you build with gjsify — remotely controllable over MCP. Open a URL (or a `page:*` built-in page), then drive it from an AI agent: navigate, screenshot the rendered page, evaluate JS in the page, inspect elements, and read the DOM / network / accessibility trees.
+
+It is built on [`@gjsify/iframe`](../iframe) (a `WebKit.WebView` postMessage bridge) and exposes the [`@gjsify/devtools`](../devtools) control plane through a **browser tool profile**, so the same `gjsify debug` MCP bridge that drives GTK apps drives the browser too.
+
+## Quick start — `gjsify browse`
+
+```bash
+gjsify browse                                     # open page:welcome
+gjsify browse https://localhost:8080              # open your gjsify web app
+gjsify browse https://localhost:8080 --devtools   # + the MCP control plane
+```
+
+With `--devtools`, point an MCP client at the browser profile:
+
+```jsonc
+// .mcp.json
+{ "mcpServers": { "browser": { "command": "gjsify", "args": ["debug", "--profile", "browser"] } } }
+```
+
+## Programmatic launch
+
+```ts
+import { runBrowserDevtools } from '@gjsify/devtools-browser';
+
+await runBrowserDevtools({
+    applicationId: 'org.example.Browser',
+    homeUrl: 'https://localhost:8080',
+    // title: 'My Debug Browser',
+    // devtools: true,   // force-enable; otherwise gated on GJSIFY_DEVTOOLS
+});
+```
+
+## The browser MCP tools (profile `browser`)
+
+On top of the generic devtools tools (`get_status`, `screenshot`, …), the browser profile adds:
+
+- **Navigation:** `navigate`, `back`, `forward`, `reload`, `get_page_info`, `wait_for_load`
+- **Capture:** `page_screenshot` (PNG of the rendered **web content** via the WebKit compositor — the generic `screenshot` is blank because WebKit composites out-of-process; `region=full|visible`), `set_viewport`
+- **Scripting / DOM:** `eval_js`, `get_links`, `follow_link`, `query_dom`, `get_console`
+- **Inspector data (Tier B):** `inspect_element` (tag/id/class + attributes + bounding rect + box model + curated computed styles), `dom_tree`, `get_network` (Resource Timing API), `get_accessibility`
+- **Inspector panel:** `open_inspector`, `close_inspector` (toggle the WebKit Web Inspector)
+
+Because the apps you debug are themselves gjsify-built, you can render one here and assert against its real output in-page — no separate browser-automation stack. See the [Debugging & remote control guide](https://gjsify.github.io/gjsify/guides/devtools/).
+
+## Inspector-data builders (Tier B)
+
+The inspector tools are powered by **pure JS-expression builders** handed to `IFrameBridge.evaluateJavaScript` — the same headless-testable pattern as `@gjsify/iframe`'s DOM helpers. They are exported so you can reuse them:
+
+```ts
+import { buildInspectElementExpression, buildDomTreeExpression } from '@gjsify/devtools-browser';
+
+const expr = buildInspectElementExpression('main .card');
+const data = await bridge.evaluateJavaScript(expr); // { found, tagName, boxModel, computedStyle, … }
+```
+
+`buildInspectElementExpression`, `buildDomTreeExpression`, `buildNetworkExpression`, `buildAccessibilityExpression` (selectors are `JSON.stringify`'d so they can't break out of the generated expression).
+
+## Exports
+
+- `runBrowserDevtools(options)` / `BrowserApplication` — the one-call launcher + the `Adw.Application` host.
+- `BrowserWindow` — the Adwaita shell (URL bar + the `IFrameBridge` content area).
+- `BrowserCore` — the platform-agnostic navigation core (history stack, `navigate` / `back` / `forward` / `reload`, `onStateChange` / `onPageLoaded`); `BUILTIN_PAGE_URLS`, `DEFAULT_HOME_URL`.
+- `browserDevtoolsExtension(...)` — the `DevtoolsExtension` that adds the `Browser*` methods to the control plane.
+- the inspector-data expression builders + their result types (`InspectedElement`, `DomNode`, `AccessibilityNode`, `NetworkEntry`, `BoxModel`, …).
+
+## Build / test
+
+```bash
+gjsify workspace @gjsify/devtools-browser build
+gjsify workspace @gjsify/devtools-browser test
+```
+
+Requires `webkitgtk-6.0` (via `@gjsify/iframe`). The inspector-expression builders are covered by `src/inspector.spec.ts`; the navigation core by `src/browser-core.spec.ts`.

--- a/packages/framework/devtools-mcp/README.md
+++ b/packages/framework/devtools-mcp/README.md
@@ -1,0 +1,66 @@
+# @gjsify/devtools-mcp
+
+The **MCP bridge** for the gjsify devtools control plane. It speaks JSON-RPC on stdio to an MCP client (Claude Code, the MCP Inspector, …) and translates each tool call to the app's `org.gjsify.Devtools` DBus interface. The result: an AI agent can inspect, screenshot, and drive any [`@gjsify/devtools`](../devtools)-enabled GJS app.
+
+You usually don't import this directly — `gjsify debug` generates a bridge entry that calls `runDevtoolsMcp(profile)` and builds/launches it. Reach for the library API only when wiring a custom bridge.
+
+## Quick start — `gjsify debug`
+
+1. Enable devtools in your app (see [`@gjsify/devtools`](../devtools)) and run it with `GJSIFY_DEVTOOLS=1`.
+2. Point your MCP client at the bridge. The CLI builds it on demand:
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "my-app": { "command": "gjsify", "args": ["debug", "--bus-name", "org.example.App"] }
+  }
+}
+```
+
+The bridge auto-selects a **tool profile** from your `package.json` deps: `storybook` if `@gjsify/storybook` is present, `browser` if `@gjsify/devtools-browser` is, else the `generic` profile. Override with `--profile`.
+
+For a fixed binary path (no rebuild per launch), build once and point at the bundle:
+
+```bash
+gjsify debug --build-only --out dist/bridge.gjs.mjs
+# .mcp.json → { "command": "dist/bridge.gjs.mjs" }
+```
+
+## Profiles
+
+A `DevtoolsToolProfile` maps the generic + app-specific DBus methods to MCP tools:
+
+- **generic** — `get_status`, `screenshot`, `list_actions`, `activate_action`, `resize_window`, `present_window`, and the introspection tools.
+- **storybook** — `list_stories`, `get_current_story`, `open_story`, `set_story_arg` (+ generics; screenshot via the generic `screenshot`).
+- **browser** — the [`@gjsify/devtools-browser`](../devtools-browser) web-debugging tools: `navigate`, `page_screenshot`, `eval_js`, `inspect_element`, `dom_tree`, `get_network`, … (+ generics).
+
+## Library API
+
+```ts
+import { runDevtoolsMcp, storybookProfile } from '@gjsify/devtools-mcp';
+
+// A built-in profile:
+await runDevtoolsMcp(storybookProfile('org.example.Storybook'));
+
+// Or the generic profile for any devtools-enabled app:
+await runDevtoolsMcp({ name: 'my-app-devtools', version: '0.10.0', busNameBase: 'org.example.App' });
+```
+
+## Exports
+
+- `runDevtoolsMcp(profile)` — build the MCP server, register the profile's tools, serve over `GjsStdioTransport`.
+- `DbusDevtoolsClient` — the DBus client (`control()` for raw GVariant replies, `jsonCall()` for `…->s` JSON methods).
+- `registerGenericTools`, `storybookProfile` / `registerStorybookTools`.
+- `GjsStdioTransport` — stdio transport (Node's `StdioServerTransport` does not work under the GJS bundle).
+- `ok` / `fail` / `image` (`ToolResult` helpers; `image` takes base64), `dbusError` (error mapping).
+- `DevtoolsToolProfile`, `McpToolContext`, `GenericToolName`, and the re-exported `@gjsify/devtools-protocol` contract.
+
+> **MCP gotcha:** stdout is the JSON-RPC channel — the bridge and `gjsify debug` log to **stderr only**. Keep any custom logging off stdout.
+
+## Build / test
+
+```bash
+gjsify workspace @gjsify/devtools-mcp build
+gjsify workspace @gjsify/devtools-mcp test
+```

--- a/packages/framework/devtools-protocol/README.md
+++ b/packages/framework/devtools-protocol/README.md
@@ -1,0 +1,47 @@
+# @gjsify/devtools-protocol
+
+The **transport-agnostic contract** for the gjsify devtools control plane — pure TypeScript, no platform imports, no side effects. It defines the method surface, the pause classification, the JSON envelope, the server/client transport interfaces, instance routing, and the well-known DBus interface name.
+
+Every adapter and bridge imports it so they always agree:
+
+- [`@gjsify/devtools`](../devtools) — the in-app **DBus** adapter (GTK/GJS).
+- [`@gjsify/devtools-mcp`](../devtools-mcp) — the **MCP bridge** an agent talks to.
+- A future `@gjsify/devtools-web` — a **WebSocket** adapter for web apps.
+
+Because it is pure, browser web apps can import it too — the same envelope maps 1:1 onto WebSocket-JSON-RPC.
+
+## The contract
+
+The surface is **commands + state + introspection**, not "GActions" — so it is toolkit-neutral.
+
+```ts
+import { DEVTOOLS_INTERFACE, GENERIC_METHODS, type MethodKind } from '@gjsify/devtools-protocol';
+
+DEVTOOLS_INTERFACE; // 'org.gjsify.Devtools' — constant across apps; each app uses its own bus name + path
+```
+
+### Generic methods and the pause policy
+
+Each method carries a **kind** that the pause guard enforces. When a host pauses external control, `mutating` methods are rejected; `read-only` and `presence` always pass.
+
+| Kind | Meaning | While paused |
+|---|---|---|
+| `read-only` | Observation / diagnostics (`GetStatus`, `Screenshot`, `DumpTree`, …) | allowed |
+| `presence` | An external driver's own awareness channel (cursor / label) | allowed |
+| `mutating` | Edits app state or the user's UI (`ActivateAction`, `SetProperty`, `SwapCss`, …) | rejected |
+
+`GENERIC_METHODS` is the toolkit-neutral baseline (core control + full introspection). Adapters implement the subset they support; the bridge advertises only the implemented ones. App-specific methods are added via extensions with their own kinds — **the registry rejects an unclassified method name**, so a new method cannot silently bypass the pause policy.
+
+## Exports
+
+- `DEVTOOLS_INTERFACE` — the well-known interface name.
+- `GENERIC_METHODS`, `MethodKind`, `GenericMethodName` — the method surface + classification.
+- `DevtoolsServerTransport` / `DevtoolsClientTransport` — the app-side (`serve(handler)` / `close()`) and bridge-side (`connect()` / `request(req)` / `close()`) transport seams, plus the `DevtoolsHandler` type.
+- envelope + error types, the method registry, instance-routing helpers, and shared introspection types.
+
+## Build / test
+
+```bash
+gjsify workspace @gjsify/devtools-protocol build
+gjsify workspace @gjsify/devtools-protocol test
+```

--- a/packages/framework/devtools/README.md
+++ b/packages/framework/devtools/README.md
@@ -1,0 +1,85 @@
+# @gjsify/devtools
+
+The in-app **DBus devtools control plane** for GTK/GJS apps. Opt in with one call and your running app exposes `org.gjsify.Devtools` — a control plane you can drive from `gdbus`, d-feet, GNOME Builder, headless CI, or (via [`@gjsify/devtools-mcp`](../devtools-mcp)) an AI agent.
+
+It implements the toolkit-neutral [`@gjsify/devtools-protocol`](../devtools-protocol) contract over DBus and re-exports it, so a consumer needs one import.
+
+## Install it in your app
+
+`installDevtools` is a no-op unless `GJSIFY_DEVTOOLS=1` (or `enabled: true`). Call it from `onStartup`/`vfunc_startup`, after the actions and the active window exist.
+
+```ts
+import Adw from '@girs/adw-1';
+import GObject from '@girs/gobject-2.0';
+import { installDevtools } from '@gjsify/devtools';
+
+export class MyApplication extends Adw.Application {
+    static { GObject.registerClass(MyApplication); }
+
+    vfunc_startup(): void {
+        super.vfunc_startup();
+        // … create actions + the main window …
+
+        installDevtools(this, {
+            // Adw.ApplicationWindow does NOT expose its win.* actions as a group —
+            // pass one explicitly so win.* commands are bridged.
+            winActionGroup: this._window,
+            // Optional: contribute app-specific methods (see below).
+            extend: [],
+            // Optional: gate mutating methods behind your own pause state.
+            paused: () => this._externalControlPaused,
+        });
+    }
+}
+```
+
+Then drive it without any AI:
+
+```bash
+GJSIFY_DEVTOOLS=1 gjsify run dist/index.js &
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.GetStatus
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.Screenshot 'window'   # PNG bytes as a GVariant `ay`
+```
+
+## Generic methods (out of the box)
+
+`GetStatus`, `Screenshot` (GSK widget snapshot PNG), `ListActions` / `ActivateAction` / `ChangeActionState` (GAction bridge), `PresentWindow`, `ResizeWindow`, plus full introspection: `ListToplevels`, `DumpTree`, `GetProperty` (by index path), `GetFocused`, `DumpGSettings`, `DumpCss` / `SwapCss` (live CSS hot-swap).
+
+GActions are auto-bridged into the command registry (handling the `Adw.ApplicationWindow` non-export gotcha via `winActionGroup`).
+
+## App-specific methods — a `DevtoolsExtension`
+
+Add your own methods without forking the core. The `<method>` XML is merged into the interface, handlers attach as DBus methods, and each method declares a kind the pause guard enforces.
+
+```ts
+import type { DevtoolsExtension } from '@gjsify/devtools';
+
+const myExtension: DevtoolsExtension = {
+    methodsXml: ['<method name="DoThing"><arg type="s" direction="in" name="what"/></method>'],
+    handlers: { DoThing: (what: string) => { /* … */ } },
+    methodKinds: { DoThing: 'mutating' },
+    contributeStatus: () => ({ thing: currentThing }),
+};
+
+installDevtools(this, { extend: [myExtension] });
+```
+
+## Exports
+
+- `installDevtools(app, options)` → returns a `DevtoolsService` (or `null` when the env gate is off); `uninstallDevtools(service)` — opt-in lifecycle.
+- `DevtoolsService` — the exported service object `installDevtools` returns and `uninstallDevtools` accepts.
+- `DevtoolsExtension`, `InstallDevtoolsOptions` — the extension + options types.
+- `captureWidgetPng` (GSK screenshot), `buildVariant` / `variantKindFor` / `VariantKind` (GVariant), `activateAction` / `changeActionState` / `describeActions` (GAction bridge).
+- widget-tree helpers (`dumpTree`, `getWidgetProperty`, `listToplevels`, `resolveWidgetPath`, …), `dumpCss` / `swapCss` / `removeCss`, `dumpGSettings`, `buildDevtoolsIfaceXml`.
+- the re-exported `@gjsify/devtools-protocol` contract.
+
+> **GJS gotcha:** the long-lived `Gio.DBusExportedObject` is reachable only through a self-cycle, which SpiderMonkey's GC can collect mid-run. `installDevtools` roots the service in a module-level set to defeat this — keep that rooting if you wire the service by hand.
+
+## Build / test
+
+```bash
+gjsify workspace @gjsify/devtools build
+gjsify workspace @gjsify/devtools test
+```

--- a/packages/framework/storybook/README.md
+++ b/packages/framework/storybook/README.md
@@ -82,6 +82,17 @@ await runStorybook({
 });
 ```
 
+## Debug it over MCP
+
+Run the storybook with `GJSIFY_DEVTOOLS=1` and it exposes the [`@gjsify/devtools`](../devtools) control plane, so an AI agent can drive it:
+
+```bash
+GJSIFY_DEVTOOLS=1 gjsify storybook        # exposes org.gjsify.Devtools
+gjsify debug --profile storybook          # MCP bridge: list_stories / get_current_story / open_story / set_story_arg (+ generic screenshot)
+```
+
+See the [Debugging & remote control guide](https://gjsify.github.io/gjsify/guides/devtools/).
+
 ## Exports
 
 - `StoryWidget` — Adw.Bin base class; `fromMeta()`, `addContent()`, `initialize()`/`updateArgs()`/`teardown()` hooks

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -58,6 +58,7 @@ export default defineConfig({
                         { slug: 'guides/self-executing-package' },
                         { slug: 'guides/flatpak-app' },
                         { slug: 'guides/flatpak-cli-tool' },
+                        { slug: 'guides/devtools' },
                     ],
                 },
                 {

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -586,6 +586,73 @@ npx @gjsify/cli showcase three-geometry-teapot
 | `--list` | `false` | Force list mode |
 | `--json` | `false` | Output as JSON (list mode only) |
 
+## `gjsify storybook`
+
+Discover every `*.story.ts` in the project and launch the GTK/Adwaita component browser from [`@gjsify/storybook`](https://www.npmjs.com/package/@gjsify/storybook) — a sidebar grouped by category, a live preview pane, and an auto-generated controls panel. No per-project storybook *application* to maintain.
+
+```bash
+gjsify storybook                       # discover src/**/*.story.ts and launch
+gjsify storybook --stories packages    # scan a different directory
+gjsify storybook --watch               # rebuild + relaunch on story change
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--stories <dir>` | `src` or `gjsify.storybook.stories` | Directory scanned recursively for `*.story.ts`. |
+| `--app-id <id>` | `gjsify.storybook.applicationId` or derived from the package name | GApplication id. |
+| `--title <text>` | — | Window title. |
+| `--globals <value>` | `auto` | Value for `gjsify build --globals` (use `auto,dom` for canvas/DOM stories). |
+| `--out <path>` | `node_modules/.cache/gjsify-storybook` | Output bundle path. |
+| `--watch` | `false` | Rebuild and relaunch when a story file changes. |
+| `--build-only` | `false` | Build the bundle but do not launch it. |
+
+Configure defaults in `package.json#gjsify.storybook` (`applicationId`, `title`, `stories`, `globals`). With `GJSIFY_DEVTOOLS=1`, the storybook host also exposes the devtools control plane, so an agent can drive it via `gjsify debug --profile storybook`. See the [Debugging & remote control guide](./guides/devtools/).
+
+## `gjsify debug`
+
+Launch an **MCP↔devtools bridge** for a running, devtools-enabled gjsify app (its `org.gjsify.Devtools` DBus control plane). An MCP client (e.g. Claude Code) uses this as its server command; the bridge speaks JSON-RPC on stdio and translates each tool call to the app's DBus interface. Provided by [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp).
+
+```bash
+# Point an MCP client at it (.mcp.json):
+#   { "mcpServers": { "my-app": { "command": "gjsify", "args": ["debug", "--bus-name", "org.example.App"] } } }
+
+gjsify debug --bus-name org.example.App         # generic profile
+gjsify debug --profile storybook                # storybook tools (list/open/set-arg/screenshot)
+gjsify debug --build-only --out dist/bridge.gjs.mjs   # build once; point .mcp.json at the bundle
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--bus-name <name>` | `gjsify.devtools.busNameBase`, or the storybook/browser app-id | App DBus base name. |
+| `--profile <kind>` | auto | `generic` \| `storybook` \| `browser`. Auto: `storybook` if `@gjsify/storybook` is a dep, `browser` if `@gjsify/devtools-browser` is, else `generic`. |
+| `--globals <value>` | `auto` | Value for `gjsify build --globals`. |
+| `--out <path>` | `node_modules/.cache/gjsify-debug` | Output bundle path. |
+| `--build-only` | `false` | Build the bridge bundle but do not launch it (for a `.mcp.json` command pointing at the bundle). |
+
+> **MCP cleanliness:** `gjsify debug` logs **only to stderr** — stdout is the JSON-RPC channel. The bridge resolves `@gjsify/devtools-mcp` from the *consumer's* `node_modules`. Full workflow: [Debugging & remote control guide](./guides/devtools/).
+
+## `gjsify browse`
+
+Launch the minimalist **Adwaita web browser** from [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser), optionally pointed at a URL. With `--devtools` it exposes the same `org.gjsify.Devtools` control plane (browser profile), so an agent can navigate, screenshot the rendered page, eval JS, inspect elements, and read the DOM/network/accessibility trees over MCP — purpose-built for debugging gjsify-built **web** apps.
+
+```bash
+gjsify browse                              # open page:welcome
+gjsify browse https://gnome.org            # open a URL
+gjsify browse https://localhost:8080 --devtools   # + MCP control plane (drive via `gjsify debug --profile browser`)
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `[url]` | `page:welcome` | Initial URL (a `page:*` built-in page or `https://…`). |
+| `--app-id <id>` | `gjsify.browse.applicationId` or derived from the package name | GApplication id. |
+| `--title <text>` | — | Window title. |
+| `--globals <value>` | `auto,dom` | Value for `gjsify build --globals` (WebKit/iframe need DOM globals). |
+| `--out <path>` | `node_modules/.cache/gjsify-browse` | Output bundle path. |
+| `--devtools` | `false` | Enable the MCP devtools control plane (sets `GJSIFY_DEVTOOLS=1`). |
+| `--build-only` | `false` | Build the bundle but do not launch it. |
+
+The browser is built on [`@gjsify/iframe`](https://www.npmjs.com/package/@gjsify/iframe) (a `WebKit.WebView` postMessage bridge). See the [Debugging & remote control guide](./guides/devtools/) for the agent workflow.
+
 ## `gjsify gresource`
 
 Compile a GResource XML descriptor into a binary `.gresource` bundle. Thin wrapper around `glib-compile-resources` — useful when you want to package UI templates and assets into the app bundle without pulling in meson/autotools.

--- a/website/src/content/docs/guides/devtools.md
+++ b/website/src/content/docs/guides/devtools.md
@@ -1,0 +1,158 @@
+---
+title: Debugging & remote control (DBus + MCP)
+description: Inspect, screenshot and drive a running gjsify app — by hand with gdbus or from an AI agent over MCP — for GTK and web apps alike
+---
+
+gjsify ships a **devtools control plane**: opt your app in with one call and it exposes a stable `org.gjsify.Devtools` interface you can drive three ways —
+
+- **By hand** with `gdbus` / d-feet / GNOME Builder — no AI, no dev server.
+- **From an AI agent** (Claude Code, the MCP Inspector, …) over **MCP**, via `gjsify debug`.
+- **Headless in CI** — the same calls make a no-AI end-to-end UI test harness.
+
+It works for **GTK apps** (DBus is the idiomatic GNOME transport) and, through the bundled Adwaita web browser, for **web apps you build with gjsify** too. The contract — *commands + state + introspection* — is the same across both.
+
+## The packages
+
+| Package | Role |
+|---|---|
+| [`@gjsify/devtools-protocol`](https://www.npmjs.com/package/@gjsify/devtools-protocol) | The transport-agnostic contract (pure TS): methods, pause classification, envelope, interface name. |
+| [`@gjsify/devtools`](https://www.npmjs.com/package/@gjsify/devtools) | The in-app **DBus** adapter for GTK/GJS. `installDevtools(app, …)`. |
+| [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp) | The **MCP bridge** an agent talks to. Powers `gjsify debug`. |
+| [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser) | The minimalist Adwaita **web browser** for debugging gjsify web apps. Powers `gjsify browse`. |
+
+Two CLI commands tie it together: [`gjsify debug`](../../cli-reference/#gjsify-debug) (the MCP bridge) and [`gjsify browse`](../../cli-reference/#gjsify-browse) (the web browser). The GTK [`gjsify storybook`](../../cli-reference/#gjsify-storybook) is debuggable through the same plane.
+
+## 1. Enable devtools in your app
+
+Add the dependency and call `installDevtools` from startup. It is a **no-op unless `GJSIFY_DEVTOOLS=1`** (or you pass `enabled: true`), so it is safe to leave in release builds.
+
+```ts
+import Adw from '@girs/adw-1';
+import GObject from '@girs/gobject-2.0';
+import { installDevtools } from '@gjsify/devtools';
+
+export class MyApplication extends Adw.Application {
+    static { GObject.registerClass(MyApplication); }
+
+    vfunc_startup(): void {
+        super.vfunc_startup();
+        // … register actions + create the main window first …
+
+        installDevtools(this, {
+            // Adw.ApplicationWindow does not expose its win.* actions as a group —
+            // pass it explicitly so win.* commands are bridged.
+            winActionGroup: this._window,
+        });
+    }
+}
+```
+
+Run it with the gate on:
+
+```bash
+GJSIFY_DEVTOOLS=1 gjsify run dist/index.js
+```
+
+## 2. Drive it by hand (gdbus — no AI)
+
+The control plane is plain DBus, so you can poke it from a shell:
+
+```bash
+# A JSON snapshot: app id, active window, toplevel count, focused widget,
+# pause state (+ any keys an extension contributes via contributeStatus)
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.GetStatus
+
+# The active window as PNG bytes (returned as a GVariant `ay`; gdbus prints
+# them as text — use the MCP `screenshot` tool for a ready-to-save PNG file)
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.Screenshot 'window'
+
+# List GActions, then invoke one
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.ListActions
+gdbus call --session -d org.example.App -o /org/example/App/devtools \
+  -m org.gjsify.Devtools.ActivateAction 'app' 'about' ''
+```
+
+This is also the basis for **headless UI tests**: script a sequence of `ActivateAction` / `ChangeActionState` / `Screenshot` calls and assert on `GetStatus` — no agent required.
+
+## 3. Drive it from an AI agent (MCP)
+
+`gjsify debug` builds and launches the MCP bridge. Point your MCP client at it with a `.mcp.json` at the project root:
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "my-app": { "command": "gjsify", "args": ["debug", "--bus-name", "org.example.App"] }
+  }
+}
+```
+
+Now an agent has tools like `get_status`, `screenshot`, `list_actions`, `activate_action`, `change_action_state`, `resize_window`, plus introspection (`dump_tree`, `get_property`). The typical loop:
+
+> launch the app with `GJSIFY_DEVTOOLS=1` → `get_status` to see where it is → `screenshot` to see it → `activate_action` / `change_action_state` to drive it → `screenshot` again to confirm.
+
+For a fixed binary path (so the client doesn't rebuild on every launch), build once and point at the bundle:
+
+```bash
+gjsify debug --build-only --out dist/bridge.gjs.mjs
+# .mcp.json → { "mcpServers": { "my-app": { "command": "dist/bridge.gjs.mjs" } } }
+```
+
+The bridge auto-detects a **tool profile** from your `package.json` dependencies — `storybook`, `browser`, or `generic` — or you can force one with `--profile`.
+
+## 4. Debug web apps — `gjsify browse`
+
+Because the apps you debug are **themselves built with gjsify**, you can render them in the bundled Adwaita web browser and drive *its* devtools plane. Launch with `--devtools`:
+
+```bash
+gjsify browse https://localhost:8080 --devtools
+```
+
+Then bridge it with the **browser profile**:
+
+```jsonc
+{ "mcpServers": { "browser": { "command": "gjsify", "args": ["debug", "--profile", "browser"] } } }
+```
+
+The browser profile adds web-debugging tools on top of the generics:
+
+| Tool | What it does |
+|---|---|
+| `navigate` / `back` / `forward` / `reload` | Drive history; keeps the URL bar in sync. |
+| `get_page_info` | Current page state: uri, appUrl, title, canGoBack, canGoForward, lastLoadError. |
+| `wait_for_load` | Wait for the next navigation to finish (ms; default 30000). |
+| `page_screenshot` | PNG of the rendered **web content** via the WebKit compositor (the generic `screenshot` is blank — WebKit composites out-of-process). `region=full\|visible`. |
+| `set_viewport` | Resize the content region for responsive testing. |
+| `eval_js` | Evaluate a JS expression in the page; JSON round-trip. |
+| `get_links` / `follow_link` | Enumerate `<a href>`; click + await the navigation. |
+| `query_dom` | Metadata for elements matching a CSS selector. |
+| `get_console` | Buffered `console.*` output captured from the page. |
+| `inspect_element` | Tag/id/class + attributes + bounding rect + box model + curated computed styles (Elements + Computed + Box Model in one call). |
+| `dom_tree` | The Elements tree from a selector down to a depth. |
+| `get_network` | Page network activity via the Resource Timing API. |
+| `get_accessibility` | An approximate accessibility tree (role + name + aria-*). |
+| `open_inspector` / `close_inspector` | Toggle the WebKit Web Inspector panel. |
+
+This is purpose-built for the gjsify web-app workflow: a developer (or an agent) opens the app, screenshots the real rendered output, evaluates assertions in-page, and inspects layout/network/a11y — without a separate browser-automation stack.
+
+## 5. Storybook
+
+[`gjsify storybook`](../../cli-reference/#gjsify-storybook) is debuggable the same way. Run it with `GJSIFY_DEVTOOLS=1` and bridge with `--profile storybook`; the agent gets `list_stories`, `get_current_story`, `open_story`, and `set_story_arg` — drive a component in isolation, flip its args, and `screenshot` (the generic tool) each variant.
+
+## The pause policy (read-only vs mutating)
+
+Every method is classified so a host can **pause external control** without going dark:
+
+- `read-only` (`get_status`, `screenshot`, `dump_tree`, `inspect_element`, …) — always allowed.
+- `presence` — an external driver's own awareness channel (cursor/label) — allowed.
+- `mutating` (`activate_action`, `change_action_state`, `eval_js`, `navigate`, `swap_css`, …) — rejected while paused.
+
+The registry **rejects an unclassified method**, so a new app-specific method can't silently bypass the policy. Add your own methods with a `DevtoolsExtension` (see the [`@gjsify/devtools` README](https://www.npmjs.com/package/@gjsify/devtools)).
+
+## See also
+
+- [CLI reference → `gjsify debug`](../../cli-reference/#gjsify-debug), [`gjsify browse`](../../cli-reference/#gjsify-browse), [`gjsify storybook`](../../cli-reference/#gjsify-storybook)
+- Package READMEs: [devtools](https://www.npmjs.com/package/@gjsify/devtools) · [devtools-protocol](https://www.npmjs.com/package/@gjsify/devtools-protocol) · [devtools-mcp](https://www.npmjs.com/package/@gjsify/devtools-mcp) · [devtools-browser](https://www.npmjs.com/package/@gjsify/devtools-browser)


### PR DESCRIPTION
Documents the developer tooling shipped in #557 (devtools control plane) and #566 (web browser) — none of it was documented before.

## Package READMEs (new)
- **@gjsify/devtools** — `installDevtools(app, …)`, the `org.gjsify.Devtools` DBus surface, `DevtoolsExtension`, the GC-rooting gotcha.
- **@gjsify/devtools-protocol** — the transport-agnostic contract: `DEVTOOLS_INTERFACE`, `GENERIC_METHODS` + pause classification, the server/client transport interfaces.
- **@gjsify/devtools-mcp** — the MCP bridge, `runDevtoolsMcp`, the storybook/browser/generic profiles, `.mcp.json` wiring.
- **@gjsify/devtools-browser** — the Adwaita web browser, `gjsify browse`, the browser MCP tools, the Tier-B inspector-expression builders.
- **@gjsify/storybook** — added a "Debug it over MCP" note.

## Website
- **CLI reference** — new `gjsify storybook`, `gjsify debug`, `gjsify browse` sections (flags + defaults from the yargs builders).
- **New guide** `guides/devtools.md` — *Debugging & remote control (DBus + MCP)*: enable devtools → drive by hand with `gdbus` → drive from an agent via `.mcp.json` + `gjsify debug` → debug web apps with `gjsify browse --devtools` → storybook profile → the pause policy. Wired into the sidebar.

## Accuracy
Every claim (CLI flags, MCP tool names, DBus method signatures + object path, exported symbols, internal links) was cross-checked against the source by a multi-agent verification pass; the round-1 findings (e.g. a nonexistent `screenshot_story`/`set_property`/`DevtoolsTransport`, the `…/devtools` object path, `uninstallDevtools(service)`, relative-link depth) are fixed. Final pass: 0 critical, 0 major.