### PR TITLE
feat(devtools-cdp): add WebKit Remote Inspector Protocol client

### DIFF
--- a/packages/framework/devtools-cdp/README.md
+++ b/packages/framework/devtools-cdp/README.md
@@ -1,0 +1,59 @@
+# @gjsify/devtools-cdp
+
+A client for the **WebKit Remote Inspector Protocol** — the CDP-shaped (Chrome DevTools Protocol-shaped) JSON-RPC protocol that WebKitGTK speaks over a per-target WebSocket. It is the foundation for driving a real WebKitGTK page's devtools (Runtime / DOM / CSS / Network / Console / Debugger) from an agent over MCP — the "Tier C" companion to [`@gjsify/devtools-browser`](../devtools-browser)'s in-page eval tools.
+
+> **CDP?** WebKit's protocol is *shaped like* Chrome's CDP (same domain/command/event structure, many identical names) but is **not** CDP — it's WebKit's own "Remote Inspector Protocol", with real differences (`DOM.getOuterHTML`, no `Page.navigate`, …). The `-cdp` name is the widely-recognized shorthand for "this family of protocols".
+
+This package (P1 of the Tier C roadmap) ships the **transport-pure** pieces — the protocol client and target discovery. The in-app DBus bridge, the protocol→MCP tool generator, and the `cdpProfile` land in later phases.
+
+## Protocol client
+
+```ts
+import { InspectorProtocolClient } from '@gjsify/devtools-cdp';
+
+const client = new InspectorProtocolClient('ws://127.0.0.1:9222/socket/1/1/web-page');
+await client.connect();
+await client.enableDomains(['Inspector', 'Runtime', 'DOM', 'Console']);
+
+const result = await client.send('Runtime.evaluate', { expression: '1 + 1', returnByValue: true });
+// → { result: { type: 'number', value: 2 }, wasThrown: false }
+
+client.on('Console.messageAdded', (params) => console.log('console:', params));
+const events = client.drainEvents(); // poll buffered events (for a stateless MCP bridge)
+client.close();
+```
+
+- **`send(method, params?)`** — id-correlated request; resolves with the `result`, rejects with a `ProtocolError` on a protocol error or on timeout.
+- **`on(method, cb)` / `awaitEvent(method, predicate?, timeoutMs?)`** — subscribe to pushed events.
+- **`drainEvents()`** — return + clear a bounded ring buffer of events (the poll a request/response MCP transport uses for pushed notifications).
+- **`enableDomains([...])`** — send `<Domain>.enable` for each (tolerates domains with no `enable`).
+
+One client == one WebSocket == one target (WebKit has no session multiplexing). The client is written against a minimal `WebSocketLike` surface with an injectable factory, so it is **fully unit-testable headless** — and under GJS it uses the global `WebSocket` from [`@gjsify/websocket`](../../web/websocket) (libsoup).
+
+## Target discovery
+
+WebKit's inspector HTTP server (enabled with `WEBKIT_INSPECTOR_HTTP_SERVER=host:port`) has **no `/json` endpoint** — `GET /` returns an HTML listing of `<a href="/socket/{conn}/{target}/{type}">` anchors. This package parses them:
+
+```ts
+import { discoverInspectorTargets } from '@gjsify/devtools-cdp';
+
+const targets = await discoverInspectorTargets(9222); // [{ connectionId, targetId, targetType, wsUrl, title }]
+const page = targets.find((t) => t.targetType === 'web-page');
+const client = new InspectorProtocolClient(page!.wsUrl);
+```
+
+Targets only appear once a page has begun loading, so a caller racing startup should poll — an empty array is a valid "not ready yet". `parseInspectorTargetsHtml(html, host, port)` is the pure, exported core (`fetch` is injectable for tests).
+
+## Exports
+
+- `InspectorProtocolClient`, `ProtocolError` (+ types `InspectorProtocolClientOptions`, `ProtocolEvent`, `ProtocolEventListener`, `WebSocketLike`, `WebSocketFactory`)
+- `discoverInspectorTargets`, `parseInspectorTargetsHtml` (+ types `InspectorTarget`, `DiscoverInspectorTargetsOptions`)
+
+## Build / test
+
+```bash
+gjsify workspace @gjsify/devtools-cdp build
+gjsify workspace @gjsify/devtools-cdp test
+```
+
+The protocol client is covered by `src/inspector-protocol-client.spec.ts` (mock WebSocket — id correlation, events, timeout, close); discovery by `src/target-discovery.spec.ts` (captured WebKit listing + injected fetch).

--- a/packages/framework/devtools-cdp/package.json
+++ b/packages/framework/devtools-cdp/package.json
@@ -1,0 +1,61 @@
+{
+    "name": "@gjsify/devtools-cdp",
+    "version": "0.11.0",
+    "description": "WebKit Remote Inspector Protocol (CDP-shaped) client for GJS — JSON-RPC over a per-target WebSocket + HTML target discovery, the basis for driving WebKitGTK devtools over MCP",
+    "type": "module",
+    "module": "lib/esm/index.js",
+    "types": "lib/types/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "default": "./lib/esm/index.js"
+        }
+    },
+    "files": [
+        "lib"
+    ],
+    "scripts": {
+        "clear": "rm -rf lib tmp tsconfig.tsbuildinfo test.gjs.mjs || exit 0",
+        "check": "gjsify tsc --noEmit",
+        "build": "gjsify run build:gjsify && gjsify run build:types",
+        "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
+        "build:types": "gjsify tsc",
+        "build:test": "gjsify run build:test:gjs",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:gjs",
+        "test:gjs": "gjsify run test.gjs.mjs"
+    },
+    "keywords": [
+        "gjs",
+        "webkit",
+        "inspector",
+        "cdp",
+        "devtools",
+        "mcp"
+    ],
+    "dependencies": {},
+    "devDependencies": {
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
+        "@types/node": "^25.9.2",
+        "typescript": "^6.0.3"
+    },
+    "gjsify": {
+        "runtimes": {
+            "gjs": "polyfill",
+            "node": "none",
+            "browser": "none",
+            "nativescript": "none"
+        }
+    },
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/framework/devtools-cdp"
+    },
+    "bugs": {
+        "url": "https://github.com/gjsify/gjsify/issues"
+    },
+    "homepage": "https://github.com/gjsify/gjsify/tree/main/packages/framework/devtools-cdp#readme"
+}

--- a/packages/framework/devtools-cdp/src/index.ts
+++ b/packages/framework/devtools-cdp/src/index.ts
@@ -1,0 +1,18 @@
+// @gjsify/devtools-cdp — WebKit Remote Inspector Protocol client for GJS.
+// Pure named exports; no globalThis writes, no side effects at import.
+//
+// P1 surface: the transport-pure protocol client + target discovery. The in-app
+// DBus bridge, the protocol→MCP tool generator, and the `cdpProfile` land in
+// later phases.
+
+export { InspectorProtocolClient, ProtocolError } from './inspector-protocol-client.js';
+export type {
+    InspectorProtocolClientOptions,
+    ProtocolEvent,
+    ProtocolEventListener,
+    WebSocketFactory,
+    WebSocketLike,
+} from './inspector-protocol-client.js';
+
+export { discoverInspectorTargets, parseInspectorTargetsHtml } from './target-discovery.js';
+export type { DiscoverInspectorTargetsOptions, InspectorTarget } from './target-discovery.js';

--- a/packages/framework/devtools-cdp/src/inspector-protocol-client.spec.ts
+++ b/packages/framework/devtools-cdp/src/inspector-protocol-client.spec.ts
@@ -1,0 +1,260 @@
+// @gjsify/devtools-cdp — InspectorProtocolClient — original implementation.
+// Headless: a mock WebSocket drives the protocol, no real inspector/libsoup.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { InspectorProtocolClient, ProtocolError, type WebSocketLike } from './inspector-protocol-client.js';
+
+/** A controllable WebSocket double implementing the WebSocketLike surface. */
+class MockWebSocket implements WebSocketLike {
+    readyState = 0; // CONNECTING
+    readonly sent: string[] = [];
+    closed = false;
+    private readonly handlers: Record<string, Array<(arg: unknown) => void>> = {
+        open: [],
+        message: [],
+        close: [],
+        error: [],
+    };
+
+    addEventListener(type: 'open' | 'message' | 'close' | 'error', listener: (arg: never) => void): void {
+        this.handlers[type].push(listener as (arg: unknown) => void);
+    }
+
+    send(data: string): void {
+        this.sent.push(data);
+    }
+
+    close(): void {
+        this.closed = true;
+        this.readyState = 3;
+        for (const h of this.handlers.close) h({});
+    }
+
+    // --- test drivers ---
+    emitOpen(): void {
+        this.readyState = 1;
+        for (const h of this.handlers.open) h(undefined);
+    }
+    emitMessage(obj: unknown): void {
+        for (const h of this.handlers.message) h({ data: JSON.stringify(obj) });
+    }
+    emitError(): void {
+        for (const h of this.handlers.error) h(new Error('mock error'));
+    }
+    lastSent(): { id?: number; method?: string; params?: unknown } {
+        return JSON.parse(this.sent[this.sent.length - 1]);
+    }
+}
+
+function makeClient(timeoutMs = 0): { client: InspectorProtocolClient; ws: MockWebSocket } {
+    const ws = new MockWebSocket();
+    const client = new InspectorProtocolClient('ws://test/socket/1/2/web-page', {
+        createWebSocket: () => ws,
+        requestTimeoutMs: timeoutMs,
+    });
+    return { client, ws };
+}
+
+export default async () => {
+    await describe('InspectorProtocolClient.connect', async () => {
+        await it('resolves on the open event', async () => {
+            const { client, ws } = makeClient();
+            const p = client.connect();
+            ws.emitOpen();
+            await p;
+            expect(client.connected).toBeTruthy();
+        });
+
+        await it('rejects when the socket closes before opening', async () => {
+            const { client, ws } = makeClient();
+            const p = client.connect();
+            ws.close();
+            let threw = false;
+            try {
+                await p;
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBeTruthy();
+        });
+
+        await it('connect() is idempotent (same promise)', async () => {
+            const { client, ws } = makeClient();
+            const a = client.connect();
+            const b = client.connect();
+            ws.emitOpen();
+            await a;
+            expect(a).toBe(b);
+        });
+    });
+
+    await describe('InspectorProtocolClient.send', async () => {
+        await it('resolves with the result for a matching id', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.send('Runtime.evaluate', { expression: '1+1' });
+            const req = ws.lastSent();
+            expect(req.method).toBe('Runtime.evaluate');
+            expect(typeof req.id).toBe('number');
+            ws.emitMessage({ id: req.id, result: { value: 2 } });
+            expect(await p).toStrictEqual({ value: 2 });
+        });
+
+        await it('rejects with a ProtocolError on a protocol error reply', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.send('DOM.querySelector', { selector: '###' });
+            const req = ws.lastSent();
+            ws.emitMessage({ id: req.id, error: { code: -32000, message: 'bad selector' } });
+            let err: unknown;
+            try {
+                await p;
+            } catch (e) {
+                err = e;
+            }
+            expect(err instanceof ProtocolError).toBeTruthy();
+            expect((err as ProtocolError).message).toBe('bad selector');
+            expect((err as ProtocolError).code).toBe(-32000);
+        });
+
+        await it('correlates concurrent requests to the right results (out-of-order replies)', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const pA = client.send('A.one');
+            const idA = ws.lastSent().id;
+            const pB = client.send('B.two');
+            const idB = ws.lastSent().id;
+            expect(idA).not.toBe(idB);
+            // reply B first, then A
+            ws.emitMessage({ id: idB, result: { who: 'B' } });
+            ws.emitMessage({ id: idA, result: { who: 'A' } });
+            expect(await pA).toStrictEqual({ who: 'A' });
+            expect(await pB).toStrictEqual({ who: 'B' });
+        });
+
+        await it('rejects after the request timeout when no reply arrives', async () => {
+            const { client, ws } = makeClient(40);
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            let threw = false;
+            try {
+                await client.send('Never.replies');
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBeTruthy();
+        });
+    });
+
+    await describe('InspectorProtocolClient events', async () => {
+        await it('dispatches a pushed event to on() listeners', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            let got: unknown;
+            client.on('Console.messageAdded', (params) => {
+                got = params;
+            });
+            ws.emitMessage({ method: 'Console.messageAdded', params: { message: { text: 'hi' } } });
+            expect(got).toStrictEqual({ message: { text: 'hi' } });
+        });
+
+        await it('off() / the unsubscribe stops delivery', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            let count = 0;
+            const off = client.on('X.evt', () => {
+                count++;
+            });
+            ws.emitMessage({ method: 'X.evt', params: {} });
+            off();
+            ws.emitMessage({ method: 'X.evt', params: {} });
+            expect(count).toBe(1);
+        });
+
+        await it('awaitEvent resolves on the next matching event', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.awaitEvent('Page.frameNavigated');
+            ws.emitMessage({ method: 'Page.frameNavigated', params: { url: 'https://x' } });
+            expect(await p).toStrictEqual({ url: 'https://x' });
+        });
+
+        await it('awaitEvent honours the predicate', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.awaitEvent('N.tick', (params) => (params as { n: number }).n === 2);
+            ws.emitMessage({ method: 'N.tick', params: { n: 1 } });
+            ws.emitMessage({ method: 'N.tick', params: { n: 2 } });
+            expect(await p).toStrictEqual({ n: 2 });
+        });
+
+        await it('drainEvents returns then clears the ring buffer', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            ws.emitMessage({ method: 'E.a', params: { i: 1 } });
+            ws.emitMessage({ method: 'E.b', params: { i: 2 } });
+            const drained = client.drainEvents();
+            expect(drained.length).toBe(2);
+            expect(drained[0]).toStrictEqual({ method: 'E.a', params: { i: 1 } });
+            expect(client.drainEvents().length).toBe(0);
+        });
+    });
+
+    await describe('InspectorProtocolClient.enableDomains', async () => {
+        await it('sends <Domain>.enable for each domain', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.enableDomains(['Inspector', 'Runtime', 'DOM']);
+            // enableDomains sends sequentially (awaits each reply). Reply to each
+            // message by index once it appears, yielding microtasks so the next
+            // send's continuation can run.
+            for (let i = 0; i < 3; i++) {
+                while (ws.sent.length < i + 1) await Promise.resolve();
+                const req = JSON.parse(ws.sent[i]);
+                ws.emitMessage({ id: req.id, result: {} });
+            }
+            await p;
+            const methods = ws.sent.map((s) => JSON.parse(s).method);
+            expect(methods).toStrictEqual(['Inspector.enable', 'Runtime.enable', 'DOM.enable']);
+        });
+    });
+
+    await describe('InspectorProtocolClient.close', async () => {
+        await it('rejects all in-flight requests', async () => {
+            const { client, ws } = makeClient();
+            const c = client.connect();
+            ws.emitOpen();
+            await c;
+            const p = client.send('Will.beAborted');
+            client.close();
+            let threw = false;
+            try {
+                await p;
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBeTruthy();
+            expect(client.connected).toBeFalsy();
+        });
+    });
+};

--- a/packages/framework/devtools-cdp/src/inspector-protocol-client.ts
+++ b/packages/framework/devtools-cdp/src/inspector-protocol-client.ts
@@ -1,0 +1,297 @@
+// InspectorProtocolClient — a JSON-RPC client for the WebKit Remote Inspector
+// Protocol (the CDP-shaped protocol WebKitGTK speaks over a per-target
+// WebSocket). It correlates request ids to responses, fans pushed events out to
+// listeners + a bounded ring buffer (so a stateless MCP bridge can poll them),
+// and exposes `enableDomains()` for the usual Inspector/Runtime/DOM/Console
+// bootstrap.
+//
+// It is written against a minimal {@link WebSocketLike} surface (the W3C subset
+// `@gjsify/websocket` and browsers both provide) + an injectable factory, so the
+// whole protocol layer is unit-testable headless with a mock socket — no real
+// libsoup connection, no running inspector. The app wiring (set
+// `WEBKIT_INSPECTOR_HTTP_SERVER`, default the factory to the global `WebSocket`)
+// lands in a later phase; this module stays transport-pure.
+
+/** The minimal WebSocket surface the client uses (W3C `WebSocket` subset). */
+export interface WebSocketLike {
+    send(data: string): void;
+    close(code?: number, reason?: string): void;
+    /** W3C ready states: 0 CONNECTING, 1 OPEN, 2 CLOSING, 3 CLOSED. */
+    readyState: number;
+    addEventListener(type: 'open', listener: () => void): void;
+    addEventListener(type: 'message', listener: (event: { data: unknown }) => void): void;
+    addEventListener(type: 'close', listener: (event: { code?: number; reason?: string }) => void): void;
+    addEventListener(type: 'error', listener: (event: unknown) => void): void;
+}
+
+/** Builds a {@link WebSocketLike} for a `ws://…` URL. Defaults to the global `WebSocket`. */
+export type WebSocketFactory = (url: string) => WebSocketLike;
+
+/** A pushed protocol event (`{method, params}` with no `id`). */
+export interface ProtocolEvent {
+    method: string;
+    params: unknown;
+}
+
+/** A protocol error as surfaced to the caller (from `{error:{code,message}}` or `{error:"…"}`). */
+export class ProtocolError extends Error {
+    readonly code?: number;
+    constructor(message: string, code?: number) {
+        super(message);
+        this.name = 'ProtocolError';
+        this.code = code;
+    }
+}
+
+/** A per-method event listener; receives the event's `params`. */
+export type ProtocolEventListener = (params: unknown) => void;
+
+export interface InspectorProtocolClientOptions {
+    /** WebSocket factory (default: `globalThis.WebSocket`). Inject a mock for tests. */
+    createWebSocket?: WebSocketFactory;
+    /** Max events retained in the drain ring buffer; oldest dropped past this. Default 1000. */
+    maxBufferedEvents?: number;
+    /** Default per-request timeout in ms (0 disables). Default 30000. */
+    requestTimeoutMs?: number;
+}
+
+interface PendingRequest {
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+    timer: ReturnType<typeof setTimeout> | null;
+}
+
+interface RawMessage {
+    id?: number;
+    result?: unknown;
+    error?: { code?: number; message?: string } | string;
+    method?: string;
+    params?: unknown;
+}
+
+const DEFAULT_MAX_BUFFERED = 1000;
+const DEFAULT_REQUEST_TIMEOUT = 30000;
+
+function defaultFactory(url: string): WebSocketLike {
+    const ctor = (globalThis as { WebSocket?: new (url: string) => WebSocketLike }).WebSocket;
+    if (!ctor) {
+        throw new Error(
+            'InspectorProtocolClient: no global WebSocket — pass options.createWebSocket (GJS: register @gjsify/websocket)',
+        );
+    }
+    return new ctor(url);
+}
+
+/**
+ * Connect to a single inspector target's WebSocket and drive its JSON-RPC
+ * protocol. One client == one WS == one target (WebKit has no session
+ * multiplexing — see {@link discoverInspectorTargets}).
+ */
+export class InspectorProtocolClient {
+    private readonly url: string;
+    private readonly factory: WebSocketFactory;
+    private readonly maxBuffered: number;
+    private readonly requestTimeoutMs: number;
+
+    private ws: WebSocketLike | null = null;
+    private nextId = 1;
+    private readonly pending = new Map<number, PendingRequest>();
+    private readonly listeners = new Map<string, Set<ProtocolEventListener>>();
+    private readonly eventBuffer: ProtocolEvent[] = [];
+    private connectPromise: Promise<void> | null = null;
+    private closed = false;
+
+    constructor(url: string, options: InspectorProtocolClientOptions = {}) {
+        this.url = url;
+        this.factory = options.createWebSocket ?? defaultFactory;
+        this.maxBuffered = options.maxBufferedEvents ?? DEFAULT_MAX_BUFFERED;
+        this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT;
+    }
+
+    /** True once the socket is OPEN and not yet closed. */
+    get connected(): boolean {
+        return !this.closed && this.ws !== null && this.ws.readyState === 1;
+    }
+
+    /** Open the WebSocket; resolves on `open`, rejects on `error`/`close` before open. Idempotent. */
+    connect(): Promise<void> {
+        if (this.connectPromise) return this.connectPromise;
+        this.connectPromise = new Promise<void>((resolve, reject) => {
+            let settled = false;
+            const ws = this.factory(this.url);
+            this.ws = ws;
+            ws.addEventListener('open', () => {
+                settled = true;
+                resolve();
+            });
+            ws.addEventListener('message', (event) => this.onMessage(event.data));
+            ws.addEventListener('error', (event) => {
+                if (!settled) {
+                    settled = true;
+                    reject(new Error(`InspectorProtocolClient: WebSocket error before open (${this.url})`));
+                }
+                this.failAllPending(event);
+            });
+            ws.addEventListener('close', (event) => {
+                if (!settled) {
+                    settled = true;
+                    reject(
+                        new Error(`InspectorProtocolClient: WebSocket closed before open (code ${event.code ?? '?'})`),
+                    );
+                }
+                this.onClose();
+            });
+        });
+        return this.connectPromise;
+    }
+
+    /**
+     * Send a `Domain.command` and resolve with its `result` (rejects with a
+     * {@link ProtocolError} on a protocol `error`, or a timeout error).
+     */
+    send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+        if (this.closed) return Promise.reject(new Error('InspectorProtocolClient: client is closed'));
+        if (!this.ws) return Promise.reject(new Error('InspectorProtocolClient: connect() not called'));
+        const id = this.nextId++;
+        const payload = JSON.stringify(params === undefined ? { id, method } : { id, method, params });
+        return new Promise<unknown>((resolve, reject) => {
+            let timer: ReturnType<typeof setTimeout> | null = null;
+            if (this.requestTimeoutMs > 0) {
+                timer = setTimeout(() => {
+                    this.pending.delete(id);
+                    reject(
+                        new Error(`InspectorProtocolClient: "${method}" timed out after ${this.requestTimeoutMs}ms`),
+                    );
+                }, this.requestTimeoutMs);
+            }
+            this.pending.set(id, { resolve, reject, timer });
+            try {
+                this.ws!.send(payload);
+            } catch (error) {
+                this.pending.delete(id);
+                if (timer) clearTimeout(timer);
+                reject(error);
+            }
+        });
+    }
+
+    /** Subscribe to a `Domain.event`; returns an unsubscribe function. */
+    on(method: string, listener: ProtocolEventListener): () => void {
+        let set = this.listeners.get(method);
+        if (!set) {
+            set = new Set();
+            this.listeners.set(method, set);
+        }
+        set.add(listener);
+        return () => this.off(method, listener);
+    }
+
+    /** Remove a previously-registered event listener. */
+    off(method: string, listener: ProtocolEventListener): void {
+        this.listeners.get(method)?.delete(listener);
+    }
+
+    /** Resolve with the params of the next matching `method` event (optionally filtered). */
+    awaitEvent(
+        method: string,
+        predicate?: (params: unknown) => boolean,
+        timeoutMs = this.requestTimeoutMs,
+    ): Promise<unknown> {
+        return new Promise<unknown>((resolve, reject) => {
+            let timer: ReturnType<typeof setTimeout> | null = null;
+            const off = this.on(method, (params) => {
+                if (predicate && !predicate(params)) return;
+                if (timer) clearTimeout(timer);
+                off();
+                resolve(params);
+            });
+            if (timeoutMs > 0) {
+                timer = setTimeout(() => {
+                    off();
+                    reject(
+                        new Error(`InspectorProtocolClient: awaitEvent("${method}") timed out after ${timeoutMs}ms`),
+                    );
+                }, timeoutMs);
+            }
+        });
+    }
+
+    /** Send `<Domain>.enable` for each domain (sequentially), tolerating domains with no `enable`. */
+    async enableDomains(domains: readonly string[]): Promise<void> {
+        for (const domain of domains) {
+            try {
+                await this.send(`${domain}.enable`);
+            } catch {
+                // Some domains have no enable() (or are already enabled) — non-fatal.
+            }
+        }
+    }
+
+    /** Return all buffered events and clear the ring buffer (the poll for stateless transports). */
+    drainEvents(): ProtocolEvent[] {
+        const events = this.eventBuffer.slice();
+        this.eventBuffer.length = 0;
+        return events;
+    }
+
+    /** Close the socket and reject every in-flight request. */
+    close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        try {
+            this.ws?.close();
+        } catch {
+            /* already closed */
+        }
+        this.onClose();
+    }
+
+    private onMessage(data: unknown): void {
+        let msg: RawMessage;
+        try {
+            msg = JSON.parse(typeof data === 'string' ? data : String(data)) as RawMessage;
+        } catch {
+            return; // ignore non-JSON frames
+        }
+        if (typeof msg.id === 'number') {
+            const pending = this.pending.get(msg.id);
+            if (!pending) return;
+            this.pending.delete(msg.id);
+            if (pending.timer) clearTimeout(pending.timer);
+            if (msg.error !== undefined) {
+                const { message, code } = normalizeError(msg.error);
+                pending.reject(new ProtocolError(message, code));
+            } else {
+                pending.resolve(msg.result);
+            }
+            return;
+        }
+        if (typeof msg.method === 'string') {
+            const event: ProtocolEvent = { method: msg.method, params: msg.params };
+            this.eventBuffer.push(event);
+            if (this.eventBuffer.length > this.maxBuffered) this.eventBuffer.shift();
+            const set = this.listeners.get(msg.method);
+            // Snapshot the set so a listener that unsubscribes (e.g. awaitEvent) during
+            // dispatch doesn't disturb iteration, and a listener added mid-dispatch isn't
+            // invoked for the current event.
+            if (set) for (const listener of Array.from(set)) listener(msg.params);
+        }
+    }
+
+    private onClose(): void {
+        this.failAllPending(new Error('InspectorProtocolClient: connection closed'));
+    }
+
+    private failAllPending(reason: unknown): void {
+        for (const [, pending] of this.pending) {
+            if (pending.timer) clearTimeout(pending.timer);
+            pending.reject(reason instanceof Error ? reason : new Error('InspectorProtocolClient: socket error'));
+        }
+        this.pending.clear();
+    }
+}
+
+function normalizeError(error: { code?: number; message?: string } | string): { message: string; code?: number } {
+    if (typeof error === 'string') return { message: error };
+    return { message: error.message ?? 'protocol error', code: error.code };
+}

--- a/packages/framework/devtools-cdp/src/target-discovery.spec.ts
+++ b/packages/framework/devtools-cdp/src/target-discovery.spec.ts
@@ -1,0 +1,104 @@
+// @gjsify/devtools-cdp — target-discovery — original implementation.
+// Headless: parses a captured WebKit `GET /` listing; fetch is injected.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { discoverInspectorTargets, type InspectorTarget, parseInspectorTargetsHtml } from './target-discovery.js';
+
+// A representative WebKit remote-inspector landing page (`GET /`). WebKit lists
+// each inspectable target as an <a href="/socket/{conn}/{target}/{type}">.
+const LISTING_HTML = `<!DOCTYPE html>
+<html><head><title>Remote Inspector</title></head>
+<body>
+  <h1>Inspectable Targets</h1>
+  <ul>
+    <li><a href="/socket/1/1/web-page">Example &amp; Co — https://example.org/</a></li>
+    <li><a href="/socket/1/2/web-page">page:welcome</a></li>
+    <li><a href="/socket/1/3/service-worker">sw.js</a></li>
+  </ul>
+</body></html>`;
+
+const EMPTY_HTML = `<!DOCTYPE html><html><body><h1>Inspectable Targets</h1><p>No targets.</p></body></html>`;
+
+function fakeFetch(html: string, status = 200): typeof fetch {
+    return (async () =>
+        ({
+            ok: status >= 200 && status < 300,
+            status,
+            statusText: status === 200 ? 'OK' : 'Error',
+            text: async () => html,
+        }) as Response) as unknown as typeof fetch;
+}
+
+export default async () => {
+    await describe('parseInspectorTargetsHtml', async () => {
+        await it('parses every /socket/ anchor into a target', async () => {
+            const targets = parseInspectorTargetsHtml(LISTING_HTML, '127.0.0.1', 9222);
+            expect(targets.length).toBe(3);
+        });
+
+        await it('extracts connectionId / targetId / targetType', async () => {
+            const [first] = parseInspectorTargetsHtml(LISTING_HTML, '127.0.0.1', 9222);
+            expect(first.connectionId).toBe('1');
+            expect(first.targetId).toBe('1');
+            expect(first.targetType).toBe('web-page');
+        });
+
+        await it('builds the per-target ws:// URL with host + port', async () => {
+            const [first] = parseInspectorTargetsHtml(LISTING_HTML, '127.0.0.1', 9222);
+            expect(first.wsUrl).toBe('ws://127.0.0.1:9222/socket/1/1/web-page');
+        });
+
+        await it('decodes the anchor text into the title', async () => {
+            const [first] = parseInspectorTargetsHtml(LISTING_HTML, '127.0.0.1', 9222);
+            expect(first.title).toBe('Example & Co — https://example.org/');
+        });
+
+        await it('captures non-web-page target types', async () => {
+            const targets = parseInspectorTargetsHtml(LISTING_HTML, '127.0.0.1', 9222);
+            const sw = targets.find((t: InspectorTarget) => t.targetType === 'service-worker');
+            expect(sw).toBeDefined();
+            expect(sw!.targetId).toBe('3');
+        });
+
+        await it('returns [] for a listing with no targets', async () => {
+            expect(parseInspectorTargetsHtml(EMPTY_HTML, '127.0.0.1', 9222).length).toBe(0);
+        });
+
+        await it('dedupes repeated identical anchors', async () => {
+            const dup = `${LISTING_HTML}\n<a href="/socket/1/1/web-page">dup</a>`;
+            const targets = parseInspectorTargetsHtml(dup, '127.0.0.1', 9222);
+            expect(targets.filter((t: InspectorTarget) => t.targetId === '1').length).toBe(1);
+        });
+    });
+
+    await describe('discoverInspectorTargets', async () => {
+        await it('fetches GET / and returns parsed targets', async () => {
+            const targets = await discoverInspectorTargets(9222, { fetchImpl: fakeFetch(LISTING_HTML) });
+            expect(targets.length).toBe(3);
+            expect(targets[1].wsUrl).toBe('ws://127.0.0.1:9222/socket/1/2/web-page');
+        });
+
+        await it('honours a custom host', async () => {
+            const targets = await discoverInspectorTargets(9333, {
+                host: '0.0.0.0',
+                fetchImpl: fakeFetch(LISTING_HTML),
+            });
+            expect(targets[0].wsUrl).toBe('ws://0.0.0.0:9333/socket/1/1/web-page');
+        });
+
+        await it('returns [] when the server has no targets yet (race-safe)', async () => {
+            expect((await discoverInspectorTargets(9222, { fetchImpl: fakeFetch(EMPTY_HTML) })).length).toBe(0);
+        });
+
+        await it('throws on a non-OK response', async () => {
+            let threw = false;
+            try {
+                await discoverInspectorTargets(9222, { fetchImpl: fakeFetch('nope', 500) });
+            } catch {
+                threw = true;
+            }
+            expect(threw).toBeTruthy();
+        });
+    });
+};

--- a/packages/framework/devtools-cdp/src/target-discovery.ts
+++ b/packages/framework/devtools-cdp/src/target-discovery.ts
@@ -1,0 +1,103 @@
+// target-discovery — enumerate a WebKitGTK process's inspectable targets.
+//
+// WebKit's remote inspector HTTP server (enabled via the
+// `WEBKIT_INSPECTOR_HTTP_SERVER=host:port` env var) does NOT expose Chrome's
+// `/json` endpoint. Instead `GET /` returns an HTML page listing each target as
+// an anchor: `<a href="/socket/{connectionId}/{targetId}/{type}">title</a>`.
+// We parse those anchors into {@link InspectorTarget}s and build the per-target
+// WebSocket URL the {@link InspectorProtocolClient} connects to.
+//
+// The HTML parse is a pure, regex-based function (no DOMParser dependency), so
+// it is unit-testable headless against a captured listing; `discoverInspectorTargets`
+// adds the `fetch` (injectable) around it.
+
+/** One inspectable target from the WebKit remote-inspector listing. */
+export interface InspectorTarget {
+    /** The inspector connection id (first `/socket/` path segment). */
+    connectionId: string;
+    /** The target id (second segment) — stable for the lifetime of the target. */
+    targetId: string;
+    /** Target kind: `web-page` | `javascript` | `service-worker` | `wasm-debugger` | … */
+    targetType: string;
+    /** `ws://host:port/socket/{conn}/{target}/{type}` — pass to InspectorProtocolClient. */
+    wsUrl: string;
+    /** The anchor's visible text (page title / target name), when present. */
+    title?: string;
+}
+
+export interface DiscoverInspectorTargetsOptions {
+    /** Host the inspector HTTP server is bound to. Default `127.0.0.1`. */
+    host?: string;
+    /** `fetch` implementation (default: global `fetch`). Inject for tests. */
+    fetchImpl?: typeof fetch;
+}
+
+const DEFAULT_HOST = '127.0.0.1';
+
+// `/socket/{conn}/{target}/{type}` — segments are non-empty, non-slash, non-quote.
+const SOCKET_HREF = /\/socket\/([^/"'\s]+)\/([^/"'\s]+)\/([^/"'\s]+)/;
+// Whole anchor, to also capture the link text as the title.
+const ANCHOR = /<a\b[^>]*\bhref\s*=\s*["']([^"']*\/socket\/[^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+
+function stripTags(html: string): string {
+    return html
+        .replace(/<[^>]*>/g, '')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+/**
+ * Parse the WebKit `GET /` HTML listing into targets. Pure + deterministic —
+ * the unit-testable core of {@link discoverInspectorTargets}.
+ */
+export function parseInspectorTargetsHtml(html: string, host: string, port: number): InspectorTarget[] {
+    const targets: InspectorTarget[] = [];
+    const seen = new Set<string>();
+    for (const match of html.matchAll(ANCHOR)) {
+        const href = match[1];
+        const seg = SOCKET_HREF.exec(href);
+        if (!seg) continue;
+        const [, connectionId, targetId, targetType] = seg;
+        const key = `${connectionId}/${targetId}/${targetType}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const title = stripTags(match[2]);
+        targets.push({
+            connectionId,
+            targetId,
+            targetType,
+            wsUrl: `ws://${host}:${port}/socket/${connectionId}/${targetId}/${targetType}`,
+            title: title || undefined,
+        });
+    }
+    return targets;
+}
+
+/**
+ * Fetch `http://host:port/` and parse its target listing. Targets only appear
+ * once a page has begun loading and there is no `/json` endpoint, so callers
+ * that race startup should poll (an empty array is a valid "not ready yet").
+ */
+export async function discoverInspectorTargets(
+    port: number,
+    options: DiscoverInspectorTargetsOptions = {},
+): Promise<InspectorTarget[]> {
+    const host = options.host ?? DEFAULT_HOST;
+    const doFetch = options.fetchImpl ?? (globalThis as { fetch?: typeof fetch }).fetch;
+    if (!doFetch) {
+        throw new Error(
+            'discoverInspectorTargets: no global fetch — pass options.fetchImpl (GJS: register @gjsify/fetch)',
+        );
+    }
+    const response = await doFetch(`http://${host}:${port}/`);
+    if (!response.ok) {
+        throw new Error(`discoverInspectorTargets: GET / returned ${response.status} ${response.statusText}`);
+    }
+    const html = await response.text();
+    return parseInspectorTargetsHtml(html, host, port);
+}

--- a/packages/framework/devtools-cdp/src/test.mts
+++ b/packages/framework/devtools-cdp/src/test.mts
@@ -1,0 +1,9 @@
+import { run } from '@gjsify/unit';
+
+import inspectorProtocolClientSuite from './inspector-protocol-client.spec.js';
+import targetDiscoverySuite from './target-discovery.spec.js';
+
+run({
+    inspectorProtocolClientSuite,
+    targetDiscoverySuite,
+});

--- a/packages/framework/devtools-cdp/tsconfig.json
+++ b/packages/framework/devtools-cdp/tsconfig.json
@@ -1,0 +1,36 @@
+{
+    "compilerOptions": {
+        "outDir": "lib",
+        "declarationDir": "lib/types",
+        "rootDir": "src",
+        "tsBuildInfoFile": "tmp/.tsbuildinfo",
+        "target": "es2020",
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "removeComments": false,
+        "preserveConstEnums": true,
+        "sourceMap": true,
+        "skipLibCheck": true,
+        "composite": true,
+        "incremental": true,
+        "types": [
+            "node"
+        ],
+        "lib": [
+            "es2020"
+        ],
+        "strict": true
+    },
+    "include": [
+        "src"
+    ],
+    "exclude": [
+        "src/test.mts"
+    ]
+}


### PR DESCRIPTION
New package **`@gjsify/devtools-cdp`** — the foundation for driving a real WebKitGTK page's devtools (Runtime / DOM / CSS / Network / Console / Debugger) from an agent over MCP. It's the deep-protocol companion to `@gjsify/devtools-browser`'s in-page-eval inspector tools.

This PR is the **transport-pure** core; the in-app DBus bridge, the protocol→MCP tool generator, and the `cdpProfile` follow as separate PRs.

## What it adds
- **`InspectorProtocolClient`** — JSON-RPC client for WebKit's CDP-shaped remote inspector protocol over a per-target WebSocket: id-correlated `send()`, `on()`/`awaitEvent()` listeners, a bounded **drain ring buffer** (so a stateless MCP bridge can poll pushed events), and `enableDomains()` for the Inspector/Runtime/DOM/Console bootstrap. Rejects with a `ProtocolError` on protocol errors / timeouts.
- **`discoverInspectorTargets()` / `parseInspectorTargetsHtml()`** — WebKit's inspector HTTP server has **no `/json` endpoint**; `GET /` returns an HTML listing of `<a href="/socket/{conn}/{target}/{type}">` anchors. This parses them into `{connectionId, targetId, targetType, wsUrl, title}`.

## Design
Written against a minimal `WebSocketLike` surface + injectable `fetch`, so the whole protocol layer is **unit-testable headless** — no real libsoup socket, no running inspector. Under GJS the default factory uses the global `WebSocket` (`@gjsify/websocket`/libsoup). `"CDP"` is the widely-recognized shorthand; WebKit's protocol is CDP-*shaped* but its own (`DOM.getOuterHTML`, no `Page.navigate`, …).

## Tests
38 tests (GJS): id correlation incl. out-of-order replies, protocol-error mapping, timeout, event dispatch/unsubscribe, `awaitEvent` + predicate, `drainEvents`, `enableDomains`, `close` aborting in-flight requests; target-HTML parsing (types, ws URL, title decode, dedupe, empty) + `discoverInspectorTargets` with injected fetch. tsc + oxlint + oxfmt clean. No new external deps (lockfile unchanged).