### PR TITLE
fix: converge the native and web Adwaita storybooks (backgrounds, separators, responsive)

### DIFF
--- a/packages/framework/storybook/src/styles.ts
+++ b/packages/framework/storybook/src/styles.ts
@@ -13,11 +13,20 @@ export const STORYBOOK_CSS = `
     border-radius: 12px;
 }
 
+/* Controls panel shares the window (story) background; only the left
+   navigation sidebar keeps a distinct shade. The overlay-split-view sidebar is
+   otherwise drawn on the sidebar shade — flatten it onto the window colour. */
+.storybook-controls > .sidebar,
+.storybook-controls > .sidebar > * {
+    background-color: @window_bg_color;
+}
+
 /* Subtle dashed frame around the live preview so the widget's bounds stay
    locatable even when it is transparent or in an empty state (e.g. a collapsed
-   bottom sheet, a status page, a bare button). currentColor adapts to light/dark. */
+   bottom sheet, a status page, a bare button). @window_fg_color flips with the
+   theme (alpha(currentColor, …) does not resolve in a Gtk.CssProvider). */
 .story-stage {
-    border: 1px dashed alpha(currentColor, 0.25);
+    border: 1px dashed alpha(@window_fg_color, 0.28);
     border-radius: 12px;
     padding: 18px;
 }

--- a/packages/framework/storybook/src/window.ts
+++ b/packages/framework/storybook/src/window.ts
@@ -70,7 +70,12 @@ export class StorybookWindow extends Adw.ApplicationWindow {
             title_widget: new Adw.WindowTitle({ title: 'Stories' }),
             show_end_title_buttons: false,
         });
-        const sidebarToolbar = new Adw.ToolbarView({ content: sidebarScroll });
+        // Flat top bar so the sidebar header shares the sidebar background
+        // (the left column reads as one distinct shade).
+        const sidebarToolbar = new Adw.ToolbarView({
+            content: sidebarScroll,
+            top_bar_style: Adw.ToolbarStyle.FLAT,
+        });
         sidebarToolbar.add_top_bar(sidebarHeader);
         const sidebarPage = new Adw.NavigationPage({ title: 'Stories', tag: 'stories', child: sidebarToolbar });
 
@@ -90,6 +95,9 @@ export class StorybookWindow extends Adw.ApplicationWindow {
             max_sidebar_width: 360,
             content: contentScroll,
             sidebar: controlsScroll,
+            // Controls panel shares the window (story) background — only the
+            // left navigation sidebar keeps a distinct shade (see STORYBOOK_CSS).
+            css_classes: ['storybook-controls'],
         });
 
         // --- Preview header ---
@@ -101,7 +109,12 @@ export class StorybookWindow extends Adw.ApplicationWindow {
         });
         const previewHeader = new Adw.HeaderBar({ title_widget: this._preview_title });
         previewHeader.pack_end(this._show_controls_button);
-        const previewToolbar = new Adw.ToolbarView({ content: this._controls_split_view });
+        // Flat top bar so the preview header shares the window (story)
+        // background instead of a distinct headerbar shade.
+        const previewToolbar = new Adw.ToolbarView({
+            content: this._controls_split_view,
+            top_bar_style: Adw.ToolbarStyle.FLAT,
+        });
         previewToolbar.add_top_bar(previewHeader);
         const previewPage = new Adw.NavigationPage({ title: 'Preview', tag: 'preview', child: previewToolbar });
 

--- a/packages/web/adwaita-storybook/src/app.ts
+++ b/packages/web/adwaita-storybook/src/app.ts
@@ -47,6 +47,9 @@ export class StorybookWebApp {
     private _previewEl!: HTMLElement;
     private _previewTitle!: HTMLElement;
     private _controlsGroup!: HTMLElement;
+    private _navSplit!: HTMLElement;
+    private _controlsSplit!: HTMLElement;
+    private _backBtn!: HTMLElement;
 
     private _activeStory: StoryElement | null = null;
     private _rowByTitle = new Map<string, HTMLElement>();
@@ -65,12 +68,45 @@ export class StorybookWebApp {
         const modules = this._registry.createStoryInstances();
         this._buildUI();
         this._populateSidebar(modules);
+        this._observeBreakpoint();
         this._exposeGlobal();
 
         if (this._options.openFirst !== false) {
             const first = this._firstStory();
             if (first) this._showStory(first);
         }
+    }
+
+    /**
+     * Collapse the split views on narrow widths, mirroring the native
+     * StorybookWindow's `Adw.Breakpoint` at 720sp: instead of squishing the
+     * three columns, the sidebar/content navigate one pane at a time and the
+     * controls become an on-demand overlay.
+     */
+    private _observeBreakpoint(): void {
+        const apply = (): void => this._applyBreakpoint();
+        if (typeof ResizeObserver !== 'undefined') {
+            new ResizeObserver(apply).observe(this._navSplit);
+        } else {
+            globalThis.addEventListener?.('resize', apply);
+        }
+        apply();
+    }
+
+    private _applyBreakpoint(): void {
+        const width = this._navSplit.clientWidth;
+        if (width === 0) return; // not laid out yet — the observer will re-fire
+        const collapsed = width < 720;
+        const nav = this._navSplit as HTMLElement & { collapsed: boolean };
+        const osv = this._controlsSplit as HTMLElement & { collapsed: boolean; showSidebar: boolean };
+        if (nav.collapsed !== collapsed) nav.collapsed = collapsed;
+        if (osv.collapsed !== collapsed) osv.collapsed = collapsed;
+        // Collapsing shows the story list first (like native); the back button
+        // only appears once a story is pushed onto the content pane.
+        this._navSplit.removeAttribute('show-content');
+        this._backBtn.hidden = true;
+        // Controls are docked when expanded, an on-demand overlay when collapsed.
+        osv.showSidebar = !collapsed;
     }
 
     // --- control surface (mirrors StorybookWindow; driven by host-level MCP via window.__storybook) ---
@@ -162,6 +198,19 @@ export class StorybookWebApp {
             [previewSlot, controlsScroll],
         );
 
+        this._controlsSplit = controlsSplit;
+
+        // Back button — only shown when collapsed, returns to the story list.
+        this._backBtn = h('button', {
+            class: 'adw-header-btn sb-back-btn',
+            slot: 'start',
+            title: 'Back to stories',
+            'aria-label': 'Back to stories',
+        });
+        this._backBtn.append(h('span', { class: 'adw-icon adw-icon--go-previous' }));
+        this._backBtn.hidden = true;
+        this._backBtn.addEventListener('click', () => this._navSplit.removeAttribute('show-content'));
+
         this._previewTitle = h('adw-window-title', { slot: 'center', title: 'Preview' });
         const toggleControls = h('button', {
             class: 'adw-header-btn sb-toggle-controls',
@@ -175,18 +224,18 @@ export class StorybookWebApp {
                 controlsSplit as HTMLElement & { showSidebar: boolean }
             ).showSidebar;
         });
-        const previewHeader = h('adw-header-bar', { slot: 'top' }, [this._previewTitle, toggleControls]);
+        const previewHeader = h('adw-header-bar', { slot: 'top' }, [this._backBtn, this._previewTitle, toggleControls]);
 
         const contentPane = h('div', { slot: 'content', class: 'sb-content-pane' }, [
             h('adw-toolbar-view', {}, [previewHeader, controlsSplit]),
         ]);
 
         // --- Outer split + window ---
-        const navSplit = h('adw-navigation-split-view', { 'min-sidebar-width': '220', 'max-sidebar-width': '320' }, [
+        this._navSplit = h('adw-navigation-split-view', { 'min-sidebar-width': '220', 'max-sidebar-width': '320' }, [
             sidebarPane,
             contentPane,
         ]);
-        const window_ = h('adw-window', { class: 'sb-window' }, [navSplit]);
+        const window_ = h('adw-window', { class: 'sb-window' }, [this._navSplit]);
         this._container.replaceChildren(window_);
     }
 
@@ -232,6 +281,12 @@ export class StorybookWebApp {
 
         this._updateControlPanel(story);
         this._activeStory = story;
+
+        // When collapsed (narrow), selecting a story navigates to the content
+        // pane (push-navigation), mirroring the native split view.
+        if ((this._navSplit as HTMLElement & { collapsed: boolean }).collapsed) {
+            this._navSplit.setAttribute('show-content', '');
+        }
     }
 
     private _updateControlPanel(story: StoryElement): void {

--- a/packages/web/adwaita-storybook/src/styles.ts
+++ b/packages/web/adwaita-storybook/src/styles.ts
@@ -28,6 +28,18 @@ export const STORYBOOK_WEB_CSS = `
     overflow: hidden;
 }
 
+/* Background scheme: the content header + preview + controls all sit on the
+   window (story) background as one surface; only the left story-list column
+   (its header + list) keeps the distinct sidebar shade. Matches the native
+   renderer. The default adw-header-bar background is its own headerbar shade,
+   so override it per pane here. */
+.sb-content-pane adw-header-bar {
+    background-color: var(--window-bg-color);
+}
+.sb-sidebar-pane adw-header-bar {
+    background-color: var(--sidebar-bg-color);
+}
+
 .sb-sidebar-scroll {
     flex: 1 1 auto;
     min-height: 0;

--- a/packages/web/adwaita-web/scss/_entry_row.scss
+++ b/packages/web/adwaita-web/scss/_entry_row.scss
@@ -10,7 +10,7 @@ adw-entry-row {
   align-items: center;
   gap: var(--spacing-m);
   min-height: 50px;
-  padding: var(--spacing-s) var(--spacing-m);
+  padding: var(--spacing-xs) var(--spacing-m);
   border-bottom: 1px solid var(--card-shade-color);
 
   &:last-child {
@@ -22,22 +22,32 @@ adw-entry-row {
     box-shadow: inset 0 0 0 2px var(--accent-color);
   }
 
+  // Filled Adw.EntryRow layout: a small floating title above the value,
+  // both left-aligned in a column.
+  .adw-entry-row-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1 1 auto;
+    min-width: 0;
+    gap: 1px;
+  }
+
   .adw-row-title {
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-small);
     color: var(--card-fg-color);
     opacity: var(--dim-opacity);
-    flex-shrink: 0;
   }
 
   .adw-entry-row-input {
-    flex: 1 1 auto;
+    width: 100%;
     min-width: 0;
     border: none;
     background: transparent;
     color: var(--card-fg-color);
     font-family: var(--font-family);
     font-size: var(--font-size-base);
-    text-align: right;
+    text-align: left;
     outline: none;
     padding: 0;
   }

--- a/packages/web/adwaita-web/scss/_headerbar.scss
+++ b/packages/web/adwaita-web/scss/_headerbar.scss
@@ -12,7 +12,7 @@ adw-header-bar {
   padding: 0 6px;
   background-color: var(--headerbar-bg-color);
   color: var(--headerbar-fg-color);
-  box-shadow: inset 0 -1px var(--headerbar-shade-color);
+  box-shadow: inset 0 -1px var(--separator-color);
   // flex-shrink: 0 ensures the headerbar never collapses inside a flex-column
   // adw-window, preventing a spurious spacing band between bar and content.
   flex-shrink: 0;

--- a/packages/web/adwaita-web/scss/_navigation_split_view.scss
+++ b/packages/web/adwaita-web/scss/_navigation_split_view.scss
@@ -16,7 +16,7 @@ adw-navigation-split-view {
     flex-direction: column;
     min-height: 0;
     flex-shrink: 0;
-    border-right: 1px solid var(--headerbar-shade-color);
+    border-right: 1px solid var(--separator-color);
     background-color: var(--sidebar-bg-color);
   }
 

--- a/packages/web/adwaita-web/scss/_overlay_split_view.scss
+++ b/packages/web/adwaita-web/scss/_overlay_split_view.scss
@@ -52,7 +52,7 @@ adw-overlay-split-view {
 
     .adw-osv-sidebar {
       order: 2;
-      border-inline-start: 1px solid var(--headerbar-shade-color);
+      border-inline-start: 1px solid var(--separator-color);
     }
   }
 

--- a/packages/web/adwaita-web/scss/_theme.scss
+++ b/packages/web/adwaita-web/scss/_theme.scss
@@ -12,6 +12,7 @@
   --headerbar-bg-color: #2e2e32;
   --headerbar-fg-color: #ffffff;
   --headerbar-shade-color: rgba(0, 0, 6, 0.36);
+  --separator-color: rgba(255, 255, 255, 0.08);
   --sidebar-bg-color: #2e2e32;
   --card-bg-color: rgba(255, 255, 255, 0.08);
   --card-fg-color: #ffffff;

--- a/packages/web/adwaita-web/scss/_variables.scss
+++ b/packages/web/adwaita-web/scss/_variables.scss
@@ -19,6 +19,11 @@
   --headerbar-fg-color: rgba(0, 0, 6, 0.8);
   --headerbar-shade-color: rgba(0, 0, 6, 0.12);
 
+  // Hairline separators (header underline, sidebar/pane dividers). Subtle in
+  // BOTH themes — dark theme flips to a faint light line, the way libadwaita
+  // draws separators, instead of a harsh near-black line on a dark surface.
+  --separator-color: rgba(0, 0, 6, 0.1);
+
   // Sidebar
   --sidebar-bg-color: #ebebed;
 

--- a/packages/web/adwaita-web/src/elements/adw-entry-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-entry-row.ts
@@ -43,7 +43,12 @@ export class AdwEntryRow extends HTMLElement {
             this.dispatchEvent(new CustomEvent('changed', { bubbles: true, detail: { text: this._input.value } }));
         });
 
-        this.replaceChildren(this._titleEl, this._input);
+        // Title floats as a small label above the value (the filled
+        // Adw.EntryRow look), both left-aligned in a text column.
+        const text = document.createElement('div');
+        text.className = 'adw-entry-row-text';
+        text.append(this._titleEl, this._input);
+        this.replaceChildren(text);
     }
 
     attributeChangedCallback(name: string, _old: string | null, value: string | null) {

--- a/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
@@ -58,14 +58,26 @@ export class AdwNavigationSplitView extends HTMLElement {
     attributeChangedCallback(name: string) {
         if (!this._initialized) return;
         if (name === 'min-sidebar-width' || name === 'max-sidebar-width') this._syncWidth();
-        else this._syncClasses();
+        else {
+            this._syncClasses();
+            // Collapsing flips whether the sidebar is width-capped, so re-apply.
+            this._syncWidth();
+        }
     }
 
     private _syncWidth() {
+        // When collapsed the visible pane fills the whole view, so the sidebar's
+        // min/max width caps must not apply (an inline cap would otherwise win
+        // over any stylesheet rule and leave a dead strip beside the pane).
+        if (this.collapsed) {
+            this._sidebarEl.style.minWidth = '';
+            this._sidebarEl.style.maxWidth = '';
+            return;
+        }
         const min = this.getAttribute('min-sidebar-width');
         const max = this.getAttribute('max-sidebar-width');
-        if (min) this._sidebarEl.style.minWidth = `${parseFloat(min)}px`;
-        if (max) this._sidebarEl.style.maxWidth = `${parseFloat(max)}px`;
+        this._sidebarEl.style.minWidth = min ? `${parseFloat(min)}px` : '';
+        this._sidebarEl.style.maxWidth = max ? `${parseFloat(max)}px` : '';
     }
 
     private _syncClasses() {


### PR DESCRIPTION
A native↔web convergence pass on the Adwaita storybook, driven by comparing both versions live (native via the devtools GSK screenshot, web via `gjsify browse` + `BrowserScreenshot`/`ResizeWindow`) and fixing the divergences in the core packages.

## Fixes

**Header "black borders" (web)** — the header underline + sidebar/pane dividers used the near-black `headerbar-shade` on dark surfaces, framing the top-left header in a visible black L. New theme-aware `--separator-color` (a faint *light* line in dark theme, as libadwaita draws separators) for the header underline and the nav/overlay split borders.

**Responsive collapse (web)** — the web storybook squished its three columns at narrow widths instead of collapsing. It now mirrors native's `Adw.Breakpoint` (720): the sidebar/content navigate one pane at a time (with a back button) and the controls become an on-demand overlay, via a `ResizeObserver`. `adw-navigation-split-view` also fills the visible pane when collapsed (the inline width caps no longer leave a dead strip).

**Unified background (both renderers)** — content header + preview + controls now share the window (story) background as one surface; only the left story-list column keeps the distinct sidebar shade. Web: per-pane header background overrides. Native: flat `Adw.ToolbarView` top bars + a flattened controls split.

**Visible `.story-stage` frame (native)** — the dashed preview frame was invisible natively because `alpha(currentColor, …)` doesn't resolve in a `Gtk.CssProvider`; switched to `alpha(@window_fg_color, 0.28)`.

## Verification

Compared native vs web for Action Row and Button Styles, wide and narrow — they now match on header background, the distinct left sidebar, the controls background, the dashed frame, and the responsive collapse. `gjsify tsc` (all three packages), oxfmt, oxlint and `audit-runtimes --strict` are clean.

## Follow-up

The web `adw-entry-row` still renders a left label + value where native `Adw.EntryRow` shows a floating label + edit affordance; and a broad all-stories comparison remains. Both are good next steps for full "components behave like native" parity.
