### PR TITLE
fix(adwaita-web): match native spinner/banner/avatar colours and group-title case

### DIFF
--- a/packages/web/adwaita-web/scss/_banner.scss
+++ b/packages/web/adwaita-web/scss/_banner.scss
@@ -12,8 +12,9 @@ adw-banner {
   padding: var(--spacing-xs) var(--spacing-m);
   width: 100%;
   box-sizing: border-box;
-  background-color: var(--accent-bg-color);
-  color: var(--accent-fg-color);
+  // Adw.Banner uses a neutral elevated surface, not the accent colour.
+  background-color: var(--sidebar-bg-color);
+  color: var(--window-fg-color);
 
   // Adw.Banner stays hidden until revealed.
   &:not(.revealed) {
@@ -31,15 +32,15 @@ adw-banner {
     border: none;
     border-radius: var(--button-radius);
     padding: 4px 14px;
-    background: rgba(255, 255, 255, 0.25);
-    color: var(--accent-fg-color);
+    background: var(--button-bg-color);
+    color: var(--window-fg-color);
     font-family: var(--font-family);
     font-size: var(--font-size-base);
     font-weight: 700;
     cursor: pointer;
 
     &:hover {
-      background: rgba(255, 255, 255, 0.35);
+      background: var(--button-hover-color);
     }
   }
 }

--- a/packages/web/adwaita-web/scss/_preferences.scss
+++ b/packages/web/adwaita-web/scss/_preferences.scss
@@ -13,11 +13,8 @@ adw-preferences-group {
   }
 
   .adw-preferences-group-title {
-    font-size: var(--font-size-small);
+    font-size: var(--font-size-base);
     font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    opacity: var(--dim-opacity);
     margin: 0;
     color: var(--window-fg-color);
   }

--- a/packages/web/adwaita-web/scss/_spinner.scss
+++ b/packages/web/adwaita-web/scss/_spinner.scss
@@ -1,4 +1,4 @@
-// _spinner.scss — adw-spinner styling (ring with a spinning accent arc).
+// _spinner.scss — adw-spinner styling (ring with a spinning arc).
 // Reference: refs/adwaita-web/adwaita-web/scss/_spinner.scss
 // Reference: refs/libadwaita (Adw.Spinner)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
@@ -9,8 +9,10 @@ adw-spinner {
   box-sizing: border-box;
   width: 24px;
   height: 24px;
+  // Neutral arc (currentColor, theme-aware) over a faint track — Adw.Spinner
+  // is a neutral indicator, NOT accent-coloured.
   border: 3px solid rgba(127, 127, 127, 0.25);
-  border-top-color: var(--accent-color);
+  border-top-color: currentColor;
   border-radius: 50%;
   animation: adw-spinner-spin 0.8s linear infinite;
 

--- a/packages/web/adwaita-web/src/elements/adw-avatar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-avatar.ts
@@ -8,17 +8,24 @@
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
 // A subset of the libadwaita avatar palette (saturated background + light text).
-const AVATAR_COLORS: ReadonlyArray<{ bg: string; fg: string }> = [
-    { bg: '#3584e4', fg: '#ffffff' }, // blue
-    { bg: '#2596be', fg: '#ffffff' }, // cyan
-    { bg: '#3a944a', fg: '#ffffff' }, // green
-    { bg: '#c0bb35', fg: '#000000' }, // lime
-    { bg: '#cd9309', fg: '#ffffff' }, // yellow
-    { bg: '#ed5b00', fg: '#ffffff' }, // orange
-    { bg: '#e62d42', fg: '#ffffff' }, // red
-    { bg: '#d56199', fg: '#ffffff' }, // pink
-    { bg: '#9141ac', fg: '#ffffff' }, // purple
-    { bg: '#b5835a', fg: '#ffffff' }, // brown
+// The exact libadwaita avatar palette: 14 entries of { fg (a light tint), and a
+// start→stop gradient background }. Reference:
+// refs/libadwaita/src/stylesheet/widgets/_avatar.scss ($avatarcolorlist).
+const AVATAR_COLORS: ReadonlyArray<{ fg: string; start: string; stop: string }> = [
+    { fg: '#cfe1f5', start: '#83b6ec', stop: '#337fdc' }, // blue
+    { fg: '#caeaf2', start: '#7ad9f1', stop: '#0f9ac8' }, // cyan
+    { fg: '#cef8d8', start: '#8de6b1', stop: '#29ae74' }, // green
+    { fg: '#e6f9d7', start: '#b5e98a', stop: '#6ab85b' }, // lime
+    { fg: '#f9f4e1', start: '#f8e359', stop: '#d29d09' }, // yellow
+    { fg: '#ffead1', start: '#ffcb62', stop: '#d68400' }, // gold
+    { fg: '#ffe5c5', start: '#ffa95a', stop: '#ed5b00' }, // orange
+    { fg: '#f8d2ce', start: '#f78773', stop: '#e62d42' }, // raspberry
+    { fg: '#fac7de', start: '#e973ab', stop: '#e33b6a' }, // magenta
+    { fg: '#e7c2e8', start: '#cb78d4', stop: '#9945b5' }, // purple
+    { fg: '#d5d2f5', start: '#9e91e8', stop: '#7a59ca' }, // violet
+    { fg: '#f2eade', start: '#e3cf9c', stop: '#b08952' }, // beige
+    { fg: '#e5d6ca', start: '#be916d', stop: '#785336' }, // brown
+    { fg: '#d8d7d3', start: '#c0bfbc', stop: '#6e6d71' }, // gray
 ];
 
 function initialsOf(text: string): string {
@@ -28,10 +35,16 @@ function initialsOf(text: string): string {
     return (words[0][0] + words[words.length - 1][0]).toUpperCase();
 }
 
-function colorFor(text: string): { bg: string; fg: string } {
-    let hash = 0;
-    for (let i = 0; i < text.length; i++) hash = (hash * 31 + text.charCodeAt(i)) >>> 0;
-    return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+// GLib's g_str_hash (DJB2 variant: h = h*33 + c, as uint32) so the picked colour
+// matches Adw.Avatar exactly (it uses g_str_hash(text) % 14).
+function gStrHash(text: string): number {
+    let h = 5381;
+    for (let i = 0; i < text.length; i++) h = (Math.imul(h, 33) + text.charCodeAt(i)) >>> 0;
+    return h >>> 0;
+}
+
+function colorFor(text: string): { fg: string; start: string; stop: string } {
+    return AVATAR_COLORS[gStrHash(text) % AVATAR_COLORS.length];
 }
 
 export class AdwAvatar extends HTMLElement {
@@ -73,14 +86,14 @@ export class AdwAvatar extends HTMLElement {
         const showInitials = this.hasAttribute('show-initials') && initials.length > 0;
 
         if (showInitials) {
-            const { bg, fg } = colorFor(text || 'default');
-            this.style.backgroundColor = bg;
+            const { fg, start, stop } = colorFor(text || 'default');
+            this.style.backgroundImage = `linear-gradient(${start}, ${stop})`;
             this.style.color = fg;
             this._textEl.textContent = initials;
             this._textEl.hidden = false;
             this._iconEl.hidden = true;
         } else {
-            this.style.backgroundColor = '';
+            this.style.backgroundImage = '';
             this.style.color = '';
             this._textEl.hidden = true;
             const icon = (this.getAttribute('icon') ?? 'avatar-default').replace(/-symbolic$/, '');


### PR DESCRIPTION
Polish from a per-story native↔web comparison (9 stories compared in parallel; 4 matched perfectly, the rest flagged these widget-level colour/text divergences):

- **Spinner** — neutral `currentColor` arc (theme-aware) instead of the accent colour; Adw.Spinner is a neutral indicator.
- **Banner** — neutral elevated background + button, not accent blue (Adw.Banner is neutral).
- **Avatar** — ported the exact libadwaita 14-colour avatar palette and pick it with GLib's `g_str_hash(text) % 14`, so a name derives the **same** colour as `Adw.Avatar` (e.g. "Ada Lovelace" → the purple gradient), with the light gradient-tint text instead of black/white.
- **Preferences-group title** — title-case, not uppercased, matching `Adw.PreferencesGroup` (fixes the controls panel rendering "CONTROLS").

Verified by re-capturing native vs web: avatar (same purple + light "AL"), banner (neutral gray), and the title-case "Controls" header now match. tsc/oxfmt/oxlint clean.
