### PR TITLE
feat(adwaita-web): complete the storybook port (layout, view switching, navigation, feedback)

### DIFF
--- a/packages/web/adwaita-web/scripts/build-scss.mjs
+++ b/packages/web/adwaita-web/scripts/build-scss.mjs
@@ -11,6 +11,7 @@ import {
     documentEditSymbolic,
     documentOpenSymbolic,
     documentSaveSymbolic,
+    editCopySymbolic,
     editPasteSymbolic,
     goDownSymbolic,
     goHomeSymbolic,
@@ -31,8 +32,9 @@ import {
     viewRevealSymbolic,
 } from '@gjsify/adwaita-icons/actions';
 import { cameraPhotoSymbolic, networkWirelessSymbolic } from '@gjsify/adwaita-icons/devices';
-import { folderDownloadSymbolic, folderSymbolic, userTrashSymbolic } from '@gjsify/adwaita-icons/places';
+import { folderDownloadSymbolic, folderMusicSymbolic, folderSymbolic, userTrashSymbolic } from '@gjsify/adwaita-icons/places';
 import { avatarDefaultSymbolic, mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
+import { emblemSystemSymbolic } from '@gjsify/adwaita-icons/legacy';
 import { toDataUri } from '@gjsify/adwaita-icons/utils';
 
 // view-columns-symbolic is not in the vendored icon theme @gjsify/adwaita-icons
@@ -84,6 +86,9 @@ const ICONS = {
     'view-columns': viewColumnsSymbolic,
     'list-remove': listRemoveSymbolic,
     'send-to': sendToSymbolic,
+    'folder-music': folderMusicSymbolic,
+    'edit-copy': editCopySymbolic,
+    'emblem-system': emblemSystemSymbolic,
 };
 
 const iconVars = Object.entries(ICONS)

--- a/packages/web/adwaita-web/scripts/build-scss.mjs
+++ b/packages/web/adwaita-web/scripts/build-scss.mjs
@@ -35,6 +35,8 @@ import { cameraPhotoSymbolic, networkWirelessSymbolic } from '@gjsify/adwaita-ic
 import { folderDownloadSymbolic, folderMusicSymbolic, folderSymbolic, userTrashSymbolic } from '@gjsify/adwaita-icons/places';
 import { avatarDefaultSymbolic, mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
 import { emblemSystemSymbolic } from '@gjsify/adwaita-icons/legacy';
+import { preferencesSystemSymbolic } from '@gjsify/adwaita-icons/categories';
+import { applicationXExecutableSymbolic } from '@gjsify/adwaita-icons/mimetypes';
 import { toDataUri } from '@gjsify/adwaita-icons/utils';
 
 // view-columns-symbolic is not in the vendored icon theme @gjsify/adwaita-icons
@@ -89,6 +91,8 @@ const ICONS = {
     'folder-music': folderMusicSymbolic,
     'edit-copy': editCopySymbolic,
     'emblem-system': emblemSystemSymbolic,
+    'preferences-system': preferencesSystemSymbolic,
+    'application-x-executable': applicationXExecutableSymbolic,
 };
 
 const iconVars = Object.entries(ICONS)

--- a/packages/web/adwaita-web/scripts/build-scss.mjs
+++ b/packages/web/adwaita-web/scripts/build-scss.mjs
@@ -17,9 +17,11 @@ import {
     goNextSymbolic,
     goPreviousSymbolic,
     listAddSymbolic,
+    listRemoveSymbolic,
     mailReplySenderSymbolic,
     mailSendSymbolic,
     openMenuSymbolic,
+    sendToSymbolic,
     sidebarShowSymbolic,
     systemSearchSymbolic,
     viewConcealSymbolic,
@@ -80,6 +82,8 @@ const ICONS = {
     'view-grid': viewGridSymbolic,
     'view-list': viewListSymbolic,
     'view-columns': viewColumnsSymbolic,
+    'list-remove': listRemoveSymbolic,
+    'send-to': sendToSymbolic,
 };
 
 const iconVars = Object.entries(ICONS)

--- a/packages/web/adwaita-web/scss/_about_dialog.scss
+++ b/packages/web/adwaita-web/scss/_about_dialog.scss
@@ -1,0 +1,257 @@
+// _about_dialog.scss — adw-about-dialog styling (a modal AdwDialog floating
+// sheet hosting the About navigation view: a full-cover scrim + a centred,
+// rounded, scrollable sheet box). Mirrors libadwaita's AdwDialog floating-sheet
+// node tree (dimming + rounded sheet with the outline + layered shadow) and the
+// AdwAboutDialog main page layout (large icon, title-1 name, dimmed developer
+// line, the version pill, then the navigation rows).
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss
+//   (floating-sheet > dimming / > sheet radius + box-shadow + outline)
+// Reference: refs/libadwaita/src/adw-about-dialog.ui (page tree, content-width 360)
+// Reference: refs/adwaita-web/adwaita-web/scss/_about_dialog.scss (web layout)
+// Copyright (c) 2022-2024 GNOME Foundation Inc. / Purism SPC (libadwaita). LGPLv2.1+.
+// Copyright (c) 2025 csm (adwaita-web). MIT License.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-about-dialog {
+  // The host is inert until presented; `.open` reveals the scrim + sheet.
+  display: none;
+
+  &.open {
+    display: block;
+  }
+
+  // --- Full-cover modal scrim ---
+  // libadwaita: floating-sheet > dimming { background shade-color × 2 }.
+  .adw-about-dialog-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background-color: rgba(0, 0, 6, 0.32);
+    animation: adw-about-dialog-scrim-in 200ms ease;
+  }
+
+  // --- Centred floating sheet ---
+  // libadwaita: floating-sheet > sheet { dialog radius; layered shadow; 1px
+  // outline -1px offset }. content-width 360 → a comfortable ~360px sheet.
+  .adw-about-dialog-sheet {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    width: 360px;
+    max-width: calc(100vw - 48px);
+    max-height: calc(100vh - 48px);
+    overflow: hidden;
+    background-color: var(--window-bg-color);
+    color: var(--window-fg-color);
+    border-radius: var(--window-radius);
+    outline: 1px solid var(--separator-color);
+    outline-offset: -1px;
+    box-shadow:
+      0 0 14px 2px rgba(0, 0, 6, 0.03),
+      0 0 5px 2px rgba(0, 0, 6, 0.1),
+      0 0 0 1px rgba(0, 0, 0, 0.05);
+    animation: adw-about-dialog-sheet-in 200ms cubic-bezier(0, 0, 0.2, 1);
+
+    &:focus {
+      outline: 1px solid var(--separator-color);
+      outline-offset: -1px;
+    }
+  }
+
+  // The navigation view fills the sheet; each page is a column.
+  adw-navigation-view,
+  .adw-navigation-view-pages,
+  .adw-navigation-page {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  // --- Toolbar view (flat header bar over the window background + scroller) ---
+  .adw-about-dialog-toolbar-view {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  // The dialog header bar is flat: transparent over the window background, no
+  // bottom separator (libadwaita: window.about headerbar.titlebar { flat }).
+  adw-header-bar {
+    background-color: transparent;
+    box-shadow: none;
+    min-height: 47px;
+  }
+
+  // The close button — a flat circular button drawing a "×" glyph (no
+  // window-close symbolic icon ships in @gjsify/adwaita-icons).
+  .adw-about-dialog-close {
+    width: 34px;
+    height: 34px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    line-height: 1;
+
+    &::before {
+      content: '\00d7'; // ×
+    }
+  }
+
+  // --- Scrolling content area ---
+  .adw-about-dialog-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .adw-about-dialog-clamp {
+    width: 100%;
+    max-width: 360px;
+    margin-inline: auto;
+    box-sizing: border-box;
+  }
+
+  .adw-about-dialog-page-body {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    padding: 0 var(--spacing-m) var(--spacing-l);
+  }
+
+  // --- Main page header title: hidden until the content scrolls ---
+  // Mirrors AdwAboutDialog's update_headerbar_cb (show title once scrolled > 0).
+  .main-page {
+    adw-header-bar .adw-header-bar-title {
+      opacity: 0;
+      transition: opacity 150ms ease;
+    }
+
+    &.scrolled adw-header-bar .adw-header-bar-title {
+      opacity: 1;
+    }
+  }
+
+  // --- App icon (the large recessed glyph) ---
+  .adw-about-dialog-icon {
+    align-self: center;
+    width: 96px;
+    height: 96px;
+    margin-top: var(--spacing-s);
+    margin-bottom: var(--spacing-m);
+    // Mask-driven adw-icon scaled up to the about-dialog app-icon size.
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    background-color: currentColor;
+  }
+
+  // --- App name (title-1) ---
+  .adw-about-dialog-name {
+    align-self: center;
+    text-align: center;
+    font-size: 18pt;
+    font-weight: 800;
+    line-height: 1.2;
+    margin-bottom: var(--spacing-xs);
+  }
+
+  // --- Developer / vendor line ---
+  .adw-about-dialog-developer {
+    align-self: center;
+    text-align: center;
+    font-size: var(--font-size-base);
+    opacity: var(--dim-opacity);
+    margin-bottom: var(--spacing-m);
+  }
+
+  // --- Version pill ---
+  // libadwaita: .app-version { small accent chip }.
+  .adw-about-dialog-version {
+    align-self: center;
+    padding: 2px 12px;
+    margin-bottom: var(--spacing-l);
+    border-radius: 99px;
+    font-size: var(--font-size-small);
+    line-height: 1.4;
+    background-color: color-mix(in srgb, var(--accent-bg-color) 14%, transparent);
+    color: var(--accent-color);
+  }
+
+  // --- Row groups (Details / Credits / Legal navigation, link rows) ---
+  .adw-about-dialog-rows {
+    width: 100%;
+    margin-top: var(--spacing-m);
+
+    & + .adw-about-dialog-rows {
+      margin-top: var(--spacing-l);
+    }
+  }
+
+  // The trailing chevron / link affordance on a navigation or link row.
+  .adw-about-dialog-chevron {
+    width: 16px;
+    height: 16px;
+    opacity: var(--dim-opacity);
+  }
+
+  // --- Subpage content (Details / Credits / Legal) ---
+  .adw-about-dialog-comments {
+    margin: var(--spacing-s) 0 0;
+    font-size: var(--font-size-base);
+    line-height: 1.5;
+    text-align: start;
+    white-space: pre-wrap;
+  }
+
+  .adw-about-dialog-copyright {
+    margin: var(--spacing-s) 0 0;
+    font-size: var(--font-size-small);
+    opacity: var(--dim-opacity);
+    text-align: center;
+  }
+
+  .adw-about-dialog-license {
+    margin: var(--spacing-s) 0 0;
+    font-size: var(--font-size-small);
+    opacity: var(--dim-opacity);
+    text-align: center;
+
+    a {
+      color: var(--accent-color);
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}
+
+@keyframes adw-about-dialog-scrim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes adw-about-dialog-sheet-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}

--- a/packages/web/adwaita-web/scss/_alert_dialog.scss
+++ b/packages/web/adwaita-web/scss/_alert_dialog.scss
@@ -1,0 +1,151 @@
+// _alert_dialog.scss — adw-alert-dialog: a modal scrim + centred dialog box with
+// a bold heading, body text and a row/column of response buttons.
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss (floating-sheet,
+//   AdwDialog sheet shadow + radius)
+// Reference: refs/adwaita-web/adwaita-web/scss/_dialog.scss (alert layout)
+// Reference: refs/libadwaita/src/adw-alert-dialog.c (response button layout)
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented for @gjsify/adwaita-web Web Components.
+
+// Host: lay the scrim + box out as a full-cover overlay only while open.
+adw-alert-dialog {
+  display: none;
+
+  &.open {
+    display: block;
+  }
+}
+
+// The scrim — a fixed full-cover dimming layer behind the dialog box.
+.adw-alert-dialog-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 1050;
+  background-color: rgba(0, 0, 6, 0.32);
+  // Centre the dialog box (the box is the scrim's flex child).
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-l);
+  // Mirror the AdwDialog present transition (a quick fade + scale).
+  animation: adw-alert-dialog-fade-in 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+// The dialog box — the AdwDialog "sheet": rounded window-colored surface with a
+// soft shadow + hairline outline, centred above the scrim.
+.adw-alert-dialog-box {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 1051;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 300px;
+  max-height: calc(100vh - 2 * var(--spacing-xl));
+  overflow: hidden;
+
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+  border-radius: var(--window-radius);
+  outline: 1px solid var(--separator-color);
+  outline-offset: -1px;
+  box-shadow:
+    0 0 14px 2px rgba(0, 0, 6, 0.03),
+    0 0 5px 2px rgba(0, 0, 6, 0.1),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
+
+  font-family: var(--font-family);
+
+  animation: adw-alert-dialog-pop-in 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+// Wider layout when responses are laid out horizontally (prefer-wide-layout).
+.adw-alert-dialog-box:has(.adw-alert-dialog-responses.horizontal) {
+  max-width: 360px;
+}
+
+// The scrollable message area: heading + body + optional extra child.
+.adw-alert-dialog-message {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-xl) var(--spacing-xl) var(--spacing-l);
+  overflow-y: auto;
+}
+
+.adw-alert-dialog-heading {
+  margin: 0;
+  // Matches the GTK .title-2 typography style (bold heading).
+  font-size: 15pt;
+  font-weight: 800;
+  line-height: 1.3;
+  text-align: center;
+}
+
+.adw-alert-dialog-body {
+  margin: var(--spacing-s) 0 0;
+  font-size: var(--font-size-base);
+  line-height: 1.4;
+  text-align: center;
+}
+
+// Extra child slot, displayed below the body.
+.adw-alert-dialog-child {
+  margin-top: var(--spacing-m);
+
+  &:empty {
+    display: none;
+  }
+}
+
+// Response button area. Vertical (stacked) by default; horizontal when the
+// dialog opts into the wide layout.
+.adw-alert-dialog-responses {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-s);
+  padding: var(--spacing-m) var(--spacing-l) var(--spacing-l);
+
+  &.horizontal {
+    flex-direction: row;
+    justify-content: stretch;
+
+    .adw-alert-dialog-response {
+      flex: 1 1 0;
+    }
+  }
+}
+
+// The response buttons — full-width pills within the stacked layout. They reuse
+// the .adw-button skin (incl. .suggested-action / .destructive-action), so only
+// the full width needs adding here. The default response is NOT accent-tinted —
+// libadwaita only colours suggested/destructive responses; the default one is
+// just the Enter-activated button and keeps the neutral button style.
+.adw-alert-dialog-response.adw-button {
+  width: 100%;
+  justify-content: center;
+}
+
+@keyframes adw-alert-dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes adw-alert-dialog-pop-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}

--- a/packages/web/adwaita-web/scss/_bottom_sheet.scss
+++ b/packages/web/adwaita-web/scss/_bottom_sheet.scss
@@ -1,0 +1,113 @@
+// _bottom_sheet.scss — adw-bottom-sheet styling (a content area with a sheet
+// that slides up from the bottom edge over the content, with an overlaid drag
+// handle). Mirrors libadwaita's AdwBottomSheet CSS node tree: a persistent
+// content layer, a dimming layer that fades in over it while open (modal), and
+// the sheet itself anchored to the bottom edge with rounded top corners + the
+// pill-shaped drag handle.
+// Reference: refs/libadwaita/src/stylesheet/widgets/_bottom-sheet.scss
+//   (dimming / sheet box-shadow / drag-handle pill / dialog top radius)
+// Reference: refs/libadwaita/src/adw-bottom-sheet.c (open / modal / can-close)
+// Copyright (c) 2023-2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-bottom-sheet {
+  display: block;
+  position: relative;
+  box-sizing: border-box;
+  overflow: hidden;
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+
+  // --- Persistent content layer ---
+  .adw-bottom-sheet-content {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+  }
+
+  // --- Dimming layer (modal scrim over the content) ---
+  // libadwaita: > dimming { background: shade-color × 2 }. Non-interactive +
+  // transparent when the sheet is closed.
+  .adw-bottom-sheet-dimming {
+    position: absolute;
+    inset: 0;
+    box-sizing: border-box;
+    background-color: rgba(0, 0, 6, 0.32);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition:
+      opacity 200ms ease,
+      visibility 0s linear 200ms;
+
+    &.visible {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+      transition:
+        opacity 200ms ease,
+        visibility 0s;
+    }
+  }
+
+  // --- The slide-up sheet ---
+  // Anchored to the bottom edge, full-width, rounded top corners (dialog
+  // radius), slid off-screen when closed. The spring-driven AdwBottomSheet uses
+  // a translate; the web port uses an eased transform for the same effect.
+  .adw-bottom-sheet-sheet {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    box-sizing: border-box;
+    max-height: 100%;
+    overflow: auto;
+    background-color: var(--view-bg-color);
+    color: var(--view-fg-color);
+    border-top-left-radius: var(--window-radius);
+    border-top-right-radius: var(--window-radius);
+    box-shadow:
+      0 0 14px 2px rgba(0, 0, 6, 0.03),
+      0 0 5px 2px rgba(0, 0, 6, 0.1),
+      0 0 0 1px rgba(0, 0, 0, 0.05);
+    transform: translateY(100%);
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease;
+    will-change: transform;
+  }
+
+  // --- Drag handle (overlaid pill at the top of the sheet) ---
+  // libadwaita: > drag-handle { min-width 54px; min-height 6px; margin 15px;
+  // border-radius 99px; background currentColor @ 25% }.
+  .adw-bottom-sheet-drag-handle {
+    flex-shrink: 0;
+    box-sizing: border-box;
+    width: 54px;
+    min-height: 6px;
+    height: 6px;
+    margin: 15px auto;
+    border-radius: 99px;
+    background-color: color-mix(in srgb, currentColor 25%, transparent);
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: 4px;
+    }
+  }
+
+  .adw-bottom-sheet-sheet-body {
+    box-sizing: border-box;
+  }
+
+  // --- Open state ---
+  &.open .adw-bottom-sheet-sheet {
+    transform: translateY(0);
+  }
+
+  // A non-modal sheet must not block the content beneath it.
+  &:not(.modal) .adw-bottom-sheet-dimming {
+    display: none;
+  }
+}

--- a/packages/web/adwaita-web/scss/_carousel.scss
+++ b/packages/web/adwaita-web/scss/_carousel.scss
@@ -1,0 +1,130 @@
+// _carousel.scss — adw-carousel + its dot/line page indicators.
+//
+// A horizontal scroll-snap pager (adw-carousel) plus two indicator widgets that
+// bind to it. The indicators reproduce libadwaita's snapshot drawing as CSS: a
+// per-marker `--adw-carousel-progress` (0 = inactive, 1 = focused) lerps between
+// the inactive and selected size/opacity exactly as AdwCarousel does.
+//
+// Dots:  DOTS_RADIUS 3 → DOTS_RADIUS_SELECTED 4 (6px → 8px), DOTS_SPACING 7,
+//        DOTS_OPACITY 0.3 → DOTS_OPACITY_SELECTED 0.9, active fill = accent.
+// Lines: LINE_LENGTH 35, LINE_WIDTH 3, LINE_SPACING 5, LINE_OPACITY 0.3 →
+//        LINE_OPACITY_ACTIVE 0.9, active fill = accent.
+//
+// Reference: refs/libadwaita/src/adw-carousel.c
+// Reference: refs/libadwaita/src/adw-carousel-indicator-dots.c
+// Reference: refs/libadwaita/src/adw-carousel-indicator-lines.c
+// Reference: refs/adwaita-web/adwaita-web/scss/_carousel_indicators.scss
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-carousel {
+  display: block;
+  overflow: hidden;
+
+  .adw-carousel-track {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    // Hide the scrollbar — the carousel is paged, not scrolled by chrome.
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  .adw-carousel-page {
+    flex: 0 0 100%;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+}
+
+// Shared layout for both indicator kinds — a centered, horizontally-laid-out
+// row of markers (matching the AdwCarouselIndicator* widgets).
+adw-carousel-indicator-dots,
+adw-carousel-indicator-lines {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs);
+
+  // The clickable marker resets the button chrome — the visible shape is drawn
+  // by the per-kind rules below.
+  button {
+    appearance: none;
+    -webkit-appearance: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+    flex: 0 0 auto;
+  }
+}
+
+// Dots — DOTS_SPACING 7px between centers; base diameter 6px (radius 3) growing
+// to 8px (radius 4) on the focused dot, opacity ramping 0.3 → 0.9.
+adw-carousel-indicator-dots {
+  gap: 7px;
+
+  .adw-carousel-dot {
+    width: 8px;
+    height: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    // The painted disc lives in ::before so the 8px hit-target stays constant
+    // while the visible dot grows from 6px → 8px with progress.
+    &::before {
+      content: '';
+      display: block;
+      // 6px + (8px - 6px) * progress
+      width: calc(6px + 2px * var(--adw-carousel-progress, 0));
+      height: calc(6px + 2px * var(--adw-carousel-progress, 0));
+      border-radius: 50%;
+      background-color: var(--window-fg-color);
+      // 0.3 + (0.9 - 0.3) * progress
+      opacity: calc(0.3 + 0.6 * var(--adw-carousel-progress, 0));
+      transition:
+        width 0.2s ease,
+        height 0.2s ease,
+        opacity 0.2s ease,
+        background-color 0.2s ease;
+    }
+
+    &.active::before {
+      background-color: var(--window-fg-color);
+    }
+  }
+}
+
+// Lines — LINE_LENGTH 35px, LINE_WIDTH 3px, LINE_SPACING 5px; opacity ramps
+// 0.3 → 0.9; the active line recolors to the accent.
+adw-carousel-indicator-lines {
+  gap: 5px;
+
+  .adw-carousel-line {
+    width: 35px;
+    height: 3px;
+    border-radius: 1.5px;
+    background-color: var(--window-fg-color);
+    // 0.3 + (0.9 - 0.3) * progress
+    opacity: calc(0.3 + 0.6 * var(--adw-carousel-progress, 0));
+    transition:
+      opacity 0.2s ease,
+      background-color 0.2s ease;
+
+    &.active {
+      background-color: var(--window-fg-color);
+    }
+  }
+}

--- a/packages/web/adwaita-web/scss/_inline_view_switcher.scss
+++ b/packages/web/adwaita-web/scss/_inline_view_switcher.scss
@@ -1,0 +1,174 @@
+// _inline_view_switcher.scss — adw-inline-view-switcher styling (a compact view
+// switcher: a toggle-group-style bar of one toggle per page over a single
+// stacked content area, with the active toggle drawn as the raised Adwaita
+// active-toggle chip). The bar's per-display-mode sizing (labels / icons / both)
+// mirrors libadwaita's `inline-view-switcher > toggle-group.{labels,icons,both}`.
+// Reference: refs/libadwaita/src/adw-inline-view-switcher.c (AdwInlineViewSwitcher)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_toggle-group.scss (inline-view-switcher > toggle-group)
+// Reference: refs/adwaita-web/adwaita-web/scss/_viewswitcher.scss
+// Copyright (c) 2023 Maximiliano Sandoval / 2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Copyright (c) 2025 csm (adwaita-web). MIT License.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+// The active toggle uses a white-on-fg "raised" chip — the same tokens the
+// toggle-group uses (defined there; _theme.scss overrides them for dark).
+
+adw-inline-view-switcher {
+    // libadwaita's ---group-padding: a small inset so the active chip floats
+    // inside the group's pill, leaving a hairline of group background around it.
+    --group-padding: 3px;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    // The switcher bar — a toggle-group pill, sized to its content.
+    .adw-inline-view-switcher-group {
+        display: inline-flex;
+        box-sizing: border-box;
+        align-items: stretch;
+        gap: var(--group-padding);
+        padding: var(--group-padding);
+        border-radius: var(--button-radius);
+        background-color: var(--button-bg-color);
+    }
+
+    // Each toggle is a button-shaped chip with the group's inner radius.
+    .adw-inline-view-switcher-toggle {
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--spacing-xs);
+        min-width: 34px;
+        min-height: 28px;
+        margin: 0;
+        padding: 4px 11px;
+        border: none;
+        border-radius: calc(var(--button-radius) - var(--group-padding));
+        background-color: transparent;
+        color: var(--window-fg-color);
+        font-family: var(--font-family);
+        font-size: var(--font-size-base);
+        font-weight: 700;
+        line-height: 1;
+        cursor: pointer;
+        transition:
+            color 0.2s ease,
+            background-color 0.2s ease,
+            box-shadow 0.2s ease;
+        user-select: none;
+        -webkit-user-select: none;
+
+        &:hover {
+            background-color: var(--button-hover-color);
+        }
+
+        &:active {
+            background-color: var(--button-active-color);
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--accent-color);
+            outline-offset: 1px;
+        }
+
+        // The active toggle — a raised white chip, the way libadwaita draws it.
+        &.active {
+            background-color: var(--active-toggle-bg-color);
+            color: var(--active-toggle-fg-color);
+            box-shadow:
+                0 1px 3px 1px rgba(0, 0, 6, 0.07),
+                0 2px 6px 2px rgba(0, 0, 6, 0.03);
+
+            &:hover {
+                background-color: var(--active-toggle-bg-color);
+            }
+        }
+    }
+
+    // The switcher's symbolic icon — a currentColor mask, sized like a toolbar
+    // icon (matches the .adw-icon base used across @gjsify/adwaita-web).
+    .adw-inline-view-switcher-icon {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        flex: none;
+        background-color: currentColor;
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        mask-position: center;
+        -webkit-mask-size: contain;
+        -webkit-mask-repeat: no-repeat;
+        -webkit-mask-position: center;
+    }
+
+    .adw-inline-view-switcher-label {
+        white-space: nowrap;
+    }
+
+    // The stacked content area below the bar — exactly one page is visible.
+    .adw-inline-view-switcher-pages {
+        width: 100%;
+    }
+
+    .adw-inline-view-switcher-page {
+        &:not(.active-view) {
+            display: none;
+        }
+    }
+
+    // Per-display-mode sizing, mirroring libadwaita's
+    // inline-view-switcher > toggle-group.{icons,labels,both}.
+    .adw-inline-view-switcher-group.icons .adw-inline-view-switcher-toggle {
+        min-width: 34px;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
+    .adw-inline-view-switcher-group.labels .adw-inline-view-switcher-toggle {
+        min-width: calc(18px + var(--group-padding) * 2);
+    }
+
+    // Round — group + toggles become pill-shaped.
+    &.round {
+        .adw-inline-view-switcher-group {
+            border-radius: 17px;
+        }
+
+        .adw-inline-view-switcher-toggle {
+            border-radius: calc(17px - var(--group-padding));
+            padding-left: calc(15px - var(--group-padding));
+            padding-right: calc(15px - var(--group-padding));
+        }
+    }
+
+    // Flat — no group background; the active toggle uses a subtle fill instead
+    // of the raised white chip.
+    &.flat {
+        --group-padding: 0px;
+
+        .adw-inline-view-switcher-group {
+            padding: 0;
+            background: none;
+        }
+
+        .adw-inline-view-switcher-toggle {
+            border-radius: var(--button-radius);
+
+            &.active {
+                background-color: var(--button-active-color);
+                color: inherit;
+                box-shadow: none;
+
+                &:hover {
+                    background-color: var(--button-active-color);
+                }
+            }
+        }
+
+        &.round .adw-inline-view-switcher-toggle {
+            border-radius: 17px;
+        }
+    }
+}

--- a/packages/web/adwaita-web/scss/_navigation_view.scss
+++ b/packages/web/adwaita-web/scss/_navigation_view.scss
@@ -1,0 +1,80 @@
+// _navigation_view.scss — adw-navigation-view styling (a page-based navigation
+// container; one page visible at a time, controlled with push/pop). The visible
+// page fills the view on the window background; an automatic back button is
+// drawn flat at the start of the visible page's header bar.
+// Reference: refs/libadwaita/src/adw-navigation-view.c (css node "navigation-view")
+// Reference: refs/adwaita-web/adwaita-web/docs/widgets/navigationview.md
+// Copyright (c) 2022-2023 Purism SPC / GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-navigation-view {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+
+  // The page stack — fills the view; positioned so pages can stack.
+  .adw-navigation-view-pages {
+    flex: 1 1 auto;
+    position: relative;
+    box-sizing: border-box;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  // A single navigation page — the visible one fills the view, the rest are
+  // hidden. Positioned absolutely so a transition can overlap two pages.
+  .adw-navigation-page {
+    box-sizing: border-box;
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    background-color: var(--window-bg-color);
+    color: var(--window-fg-color);
+
+    &[hidden] {
+      display: none;
+    }
+
+    &.visible-page {
+      display: flex;
+    }
+
+    // Let a page whose direct child fills (a toolbar-view / status-page)
+    // stretch to the full height.
+    > * {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+  }
+
+  // The injected automatic back button — flat, sits at the start of the visible
+  // page's header bar (mirrors AdwHeaderBar's grown-in back button).
+  .adw-navigation-back-button {
+    flex-shrink: 0;
+  }
+
+  // Slide transition for the visible page when transitions are animated. The
+  // entering page fades up from a slight horizontal offset (LTR push), matching
+  // libadwaita's spring-driven slide closely enough for the web target.
+  &.animated .adw-navigation-page.visible-page {
+    animation: adw-navigation-page-in 200ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+}
+
+@keyframes adw-navigation-page-in {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/packages/web/adwaita-web/scss/_preferences_dialog.scss
+++ b/packages/web/adwaita-web/scss/_preferences_dialog.scss
@@ -1,0 +1,154 @@
+// _preferences_dialog.scss — adw-preferences-dialog styling (scrim + dialog box).
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss (floating-sheet
+//   scrim/dimming + sheet radius + box-shadow + outline)
+// Reference: refs/libadwaita/src/adw-preferences-dialog.ui (flat header + title)
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-preferences-dialog {
+  // Hidden until presented (the `open` class is toggled by the component). The
+  // element itself contributes nothing to layout while closed.
+  display: none;
+
+  &.open {
+    display: block;
+  }
+
+  // Full-cover scrim — a fixed dimming layer behind the dialog box. Adwaita
+  // dims with `--shade-color` at double alpha (see _dialogs.scss `floating-sheet
+  // > dimming`); --shade-color isn't in the adwaita-web token subset, so use the
+  // equivalent neutral wash.
+  .adw-preferences-dialog-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background-color: rgba(0, 0, 6, 0.32);
+  }
+
+  // The centred floating dialog box. Mirrors `floating-sheet > sheet`: the
+  // dialog radius (= --window-radius in Adwaita), the layered drop shadow and a
+  // 1px window outline.
+  .adw-preferences-dialog-box {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1001;
+    display: flex;
+    flex-direction: column;
+    width: min(var(--adw-dialog-content-width, 640px), calc(100vw - 48px));
+    max-height: calc(100vh - 48px);
+    overflow: hidden;
+    background-color: var(--window-bg-color);
+    color: var(--window-fg-color);
+    border-radius: var(--window-radius);
+    outline: 1px solid var(--separator-color);
+    outline-offset: -1px;
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.05),
+      0 0 5px 2px rgba(0, 0, 6, 0.1),
+      0 0 14px 2px rgba(0, 0, 6, 0.03);
+  }
+
+  // Flat header bar — transparent over the window background (Adw's preferences
+  // dialog header uses a flat AdwHeaderBar), title centred against the trailing
+  // close button.
+  .adw-preferences-dialog-header {
+    display: flex;
+    align-items: center;
+    min-height: 47px;
+    padding: 0 6px;
+    flex-shrink: 0;
+  }
+
+  // Equal-width sides keep the title optically centred (strict centering).
+  .adw-preferences-dialog-header-side {
+    display: flex;
+    align-items: center;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .adw-preferences-dialog-header-side--end {
+    justify-content: flex-end;
+  }
+
+  .adw-preferences-dialog-title {
+    flex: 0 0 auto;
+    font-weight: bold;
+    font-size: var(--font-size-base);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 6px;
+  }
+
+  // Round flat close button drawing a CSS "×" glyph (no symbolic close icon
+  // ships in @gjsify/adwaita-icons — same approach as <adw-tab-view>).
+  .adw-preferences-dialog-close {
+    appearance: none;
+    border: none;
+    margin: 0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border-radius: 50%;
+    background-color: transparent;
+    color: var(--window-fg-color);
+    cursor: pointer;
+    position: relative;
+    transition: background-color 0.1s ease;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 12px;
+      height: 1.5px;
+      background-color: currentColor;
+      border-radius: 1px;
+    }
+
+    &::before {
+      transform: translate(-50%, -50%) rotate(45deg);
+    }
+
+    &::after {
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
+
+    &:hover {
+      background-color: var(--button-hover-color);
+    }
+
+    &:active {
+      background-color: var(--button-active-color);
+    }
+
+    &.locked {
+      opacity: var(--dim-opacity);
+      cursor: default;
+    }
+  }
+
+  // Scrolled body holding the stacked pages. Adwaita preferences pages sit on
+  // the window background (the boxed-list groups carry their own card surface).
+  .adw-preferences-dialog-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+  }
+
+  // Clamped column of preferences groups — Adw.PreferencesPage clamps content to
+  // a comfortable reading width and stacks groups with generous spacing.
+  .adw-preferences-dialog-pages {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xl);
+    max-width: 600px;
+    margin: 0 auto;
+    padding: var(--spacing-xl) var(--spacing-m);
+  }
+}

--- a/packages/web/adwaita-web/scss/_sidebar.scss
+++ b/packages/web/adwaita-web/scss/_sidebar.scss
@@ -1,0 +1,213 @@
+// _sidebar.scss — adw-sidebar styling (a selectable navigation sidebar built
+// from titled sections of icon + title + subtitle items). In sidebar mode it
+// renders as the flat AdwSidebar navigation list (`.navigation-sidebar`); in
+// page mode it renders as boxed lists with a trailing chevron on each row (the
+// AdwPreferencesPage look the native widget switches to when collapsed).
+// Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss (.navigation-sidebar, sidebar)
+// Reference: refs/libadwaita/src/adw-sidebar.c (row/header/section structure)
+// Copyright (c) 2025 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-sidebar {
+  display: block;
+  box-sizing: border-box;
+  overflow-y: auto;
+  background-color: var(--sidebar-bg-color, var(--window-bg-color));
+  color: var(--sidebar-fg-color, var(--window-fg-color));
+
+  .adw-sidebar-list {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+    // libadwaita's menu margins around the navigation list.
+    padding: var(--spacing-xs) 0;
+  }
+
+  .adw-sidebar-section {
+    display: flex;
+    flex-direction: column;
+  }
+
+  // --- Section headers (heading or separator) ---
+  .adw-sidebar-section-header {
+    &[hidden] {
+      display: none;
+    }
+
+    // Untitled section → a horizontal separator before its rows (the way the
+    // AdwSidebar header stack shows its "separator" child).
+    &.separator {
+      height: 1px;
+      margin: var(--spacing-xs) var(--spacing-s);
+      background-color: var(--separator-color, var(--card-shade-color));
+    }
+
+    &.has-title {
+      padding: var(--spacing-s) calc(var(--spacing-s) + 6px) var(--spacing-xs);
+
+      // The first header sits flush with the top (mirrors `.header.first`).
+      &.first {
+        padding-top: 0;
+      }
+    }
+  }
+
+  .adw-sidebar-section-heading {
+    font-size: var(--font-size-small);
+    font-weight: 700;
+    opacity: var(--dim-opacity);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // --- A single item row ---
+  .adw-sidebar-item {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-m);
+    width: 100%;
+    min-height: 36px;
+    // The native row has a context menu, so padding lives on the inner box and
+    // the row itself carries the menu margin + radius.
+    margin: 0 var(--spacing-xs) 2px;
+    padding: 3px 14px;
+    border: none;
+    border-radius: var(--button-radius, 6px);
+    background-color: transparent;
+    color: inherit;
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    text-align: start;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    transition:
+      background-color 150ms ease-in-out,
+      color 150ms ease-in-out;
+
+    &:hover {
+      background-color: var(--button-hover-color);
+    }
+
+    &:active {
+      background-color: var(--button-active-color, var(--button-hover-color));
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: -2px;
+    }
+
+    // Selected row — a neutral filled highlight; libadwaita's AdwSidebar
+    // selection is a subtle fill with the normal foreground, not accent.
+    &.selected {
+      background-color: var(--button-active-color);
+      color: var(--window-fg-color);
+
+      &:hover,
+      &:active {
+        background-color: var(--button-active-color);
+      }
+    }
+  }
+
+  .adw-sidebar-item-icon {
+    flex-shrink: 0;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  .adw-sidebar-item-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .adw-sidebar-item-title {
+    font-size: var(--font-size-base);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  .adw-sidebar-item-subtitle {
+    font-size: var(--font-size-small);
+    opacity: var(--dim-opacity);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  // The trailing chevron is only drawn in page (boxed-list) mode.
+  .adw-sidebar-item-arrow {
+    flex-shrink: 0;
+    opacity: var(--dim-opacity);
+    display: none;
+  }
+
+  // --- Page mode (boxed lists) ---
+  // Sections become bordered, rounded cards (the AdwPreferencesGroup look) and
+  // each row gains its trailing chevron; selection no longer fills the row with
+  // the accent color, matching how the native widget drops the list selection
+  // in page mode.
+  &.page {
+    .adw-sidebar-list {
+      padding: var(--spacing-m);
+      gap: var(--spacing-xs);
+    }
+
+    .adw-sidebar-section {
+      border: 1px solid var(--card-shade-color);
+      border-radius: var(--card-radius, 12px);
+      background-color: var(--card-bg-color);
+      color: var(--card-fg-color);
+      overflow: hidden;
+    }
+
+    .adw-sidebar-section-header.has-title {
+      padding: var(--spacing-m) var(--spacing-xs) var(--spacing-xs);
+
+      &.first {
+        padding-top: var(--spacing-m);
+      }
+    }
+
+    .adw-sidebar-item {
+      margin: 0;
+      padding: var(--spacing-s) var(--spacing-m);
+      border-radius: 0;
+      border-bottom: 1px solid var(--card-shade-color);
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &.selected {
+        background-color: transparent;
+        color: var(--card-fg-color);
+
+        &:hover {
+          background-color: var(--button-hover-color);
+        }
+      }
+    }
+
+    .adw-sidebar-item-arrow {
+      display: inline-block;
+    }
+  }
+}

--- a/packages/web/adwaita-web/scss/_tab_view.scss
+++ b/packages/web/adwaita-web/scss/_tab_view.scss
@@ -1,0 +1,193 @@
+// _tab_view.scss — adw-tab-view styling (a dynamic tabbed container with a tab
+// bar header; one page visible at a time). The bar is a headerbar-colored strip
+// of rounded chips; the selected chip is raised onto the view background, the
+// way libadwaita draws AdwTabBar over an AdwTabView.
+// Reference: refs/libadwaita/src/stylesheet/widgets/_tab-view.scss (tabbar/tabbox/tab)
+// Reference: refs/adwaita-web/adwaita-web/scss/_tabs.scss
+// Copyright (c) 2020-2022 Purism SPC / GNOME contributors (libadwaita). LGPLv2.1+.
+// Copyright (c) 2025 csm (adwaita-web). MIT License.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-tab-view {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  overflow: hidden;
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+
+  // --- Tab bar (the AdwTabBar strip) ---
+  .adw-tab-bar {
+    display: flex;
+    align-items: flex-end;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    padding: 0 var(--spacing-xs);
+    background-color: var(--headerbar-bg-color);
+    color: var(--headerbar-fg-color);
+    // libadwaita's inset bottom shade under the bar.
+    box-shadow: inset 0 -1px var(--headerbar-shade-color);
+    overflow-x: auto;
+    scrollbar-width: thin;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  .adw-tab-box {
+    display: flex;
+    align-items: stretch;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) 0;
+    min-height: 34px;
+  }
+
+  // --- A single tab chip ---
+  .adw-tab {
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    max-width: 200px;
+    min-height: 26px;
+    margin: 0;
+    padding: 4px var(--spacing-s);
+    border: none;
+    border-radius: var(--button-radius);
+    background-color: transparent;
+    color: var(--headerbar-fg-color);
+    font-family: var(--font-family);
+    font-size: var(--font-size-base);
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+    transition:
+      background-color 150ms ease-in-out,
+      color 150ms ease-in-out,
+      box-shadow 150ms ease-in-out;
+
+    &:hover {
+      background-color: var(--button-hover-color);
+    }
+
+    &:active {
+      background-color: var(--button-active-color, var(--button-hover-color));
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: -1px;
+    }
+
+    // The selected tab — a raised chip on the view background, the way
+    // libadwaita lifts the active tab off the bar.
+    &.active {
+      background-color: var(--view-bg-color);
+      color: var(--view-fg-color);
+      box-shadow:
+        0 1px 3px 1px rgba(0, 0, 6, 0.07),
+        0 2px 6px 2px rgba(0, 0, 6, 0.03);
+
+      &:hover {
+        background-color: var(--view-bg-color);
+      }
+    }
+  }
+
+  .adw-tab-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  // --- Close affordance (CSS-drawn "×", no symbolic icon ships) ---
+  .adw-tab-close {
+    box-sizing: border-box;
+    flex-shrink: 0;
+    position: relative;
+    width: 18px;
+    height: 18px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 9999px;
+    background-color: transparent;
+    color: inherit;
+    cursor: pointer;
+    opacity: 0.7;
+    transition:
+      background-color 150ms ease-in-out,
+      opacity 150ms ease-in-out;
+
+    &:hover {
+      opacity: 1;
+      background-color: var(--button-hover-color);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: 1px;
+    }
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 9px;
+      height: 1.5px;
+      background-color: currentColor;
+      border-radius: 1px;
+    }
+
+    &::before {
+      transform: translate(-50%, -50%) rotate(45deg);
+    }
+
+    &::after {
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
+  }
+
+  // Single-tab bars dim the close affordance (libadwaita keeps a lone tab
+  // non-interactive-looking).
+  .adw-tab-bar.single-tab .adw-tab {
+    &,
+    &:hover,
+    &:active {
+      background: none;
+      box-shadow: none;
+      color: var(--headerbar-fg-color);
+    }
+  }
+
+  // --- Pages (the AdwTabView content area) ---
+  .adw-tab-view-pages {
+    flex: 1 1 auto;
+    position: relative;
+    box-sizing: border-box;
+    overflow: hidden;
+    background-color: var(--view-bg-color);
+    color: var(--view-fg-color);
+  }
+
+  .adw-tab-page {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+
+    &[hidden] {
+      display: none;
+    }
+
+    &.active-page {
+      display: block;
+    }
+  }
+}

--- a/packages/web/adwaita-web/scss/_toast.scss
+++ b/packages/web/adwaita-web/scss/_toast.scss
@@ -1,4 +1,8 @@
 // _toast.scss — adw-toast and adw-toast-overlay styling.
+// adw-toast-overlay wraps content and layers transient `.adw-toast` banners over
+// the bottom of its own bounds (the Adw.ToastOverlay model). Each banner carries
+// a title, an optional action button and a CSS-drawn "×" close button, and slides
+// up on show / down on dismiss (mirroring Adw.Toast).
 // Reference: refs/adwaita-web/adwaita-web/scss/_toast.scss
 // Reference: refs/adwaita-web/adwaita-web/scss/_toast_overlay.scss
 // Reference: refs/libadwaita/src/stylesheet/widgets/_toast.scss
@@ -7,27 +11,40 @@
 // Modifications: Adapted for @gjsify/adwaita-web Web Components.
 
 adw-toast-overlay {
-  position: fixed;
-  bottom: 24px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 9999;
-  display: flex;
-  flex-direction: column-reverse;
-  gap: 9px;
-  align-items: center;
-  pointer-events: none;
+  position: relative;
+  display: block;
+
+  // The wrapped content (Adw.ToastOverlay :child) occupies the overlay's box.
+  .adw-toast-overlay-content {
+    width: 100%;
+    height: 100%;
+  }
+
+  // Toasts are layered over the bottom edge of the overlay, stacked newest-last
+  // and centered, the way AdwToastOverlay floats them above its child.
+  .adw-toast-overlay-toasts {
+    position: absolute;
+    bottom: var(--spacing-m);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9999;
+    display: flex;
+    flex-direction: column-reverse;
+    gap: var(--spacing-s);
+    align-items: center;
+    pointer-events: none;
+  }
 }
 
 .adw-toast {
   background-color: #3d3846;
   color: #ffffff;
-  padding: 9px 12px;
+  padding: var(--spacing-s) var(--spacing-m);
   border-radius: var(--card-radius);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.25);
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: var(--spacing-s);
   width: max-content;
   max-width: 400px;
   min-height: 36px;
@@ -53,8 +70,101 @@ adw-toast-overlay {
     transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
   }
 
+  .adw-toast-content-wrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
   .adw-toast-title {
     font-weight: normal;
     line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Action button — a flat pill tinted with the accent color so it reads as
+  // suggested against the dark toast surface (Adw.Toast:button-label).
+  .adw-toast-action-button {
+    flex-shrink: 0;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 4px var(--spacing-m);
+    border: none;
+    border-radius: var(--button-radius);
+    background-color: rgba(255, 255, 255, 0.12);
+    color: #ffffff;
+    font-family: inherit;
+    font-size: var(--font-size-base);
+    font-weight: 700;
+    line-height: 1;
+    cursor: pointer;
+    transition: background-color 150ms ease-in-out;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.2);
+    }
+
+    &:active {
+      background-color: rgba(255, 255, 255, 0.26);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: 1px;
+    }
+  }
+
+  // Close affordance — a CSS-drawn "×" (mirrors adw-tab-view's .adw-tab-close;
+  // no symbolic close icon ships in the curated adwaita-web icon set).
+  .adw-toast-close-button {
+    box-sizing: border-box;
+    flex-shrink: 0;
+    position: relative;
+    width: 24px;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 9999px;
+    background-color: transparent;
+    color: #ffffff;
+    cursor: pointer;
+    opacity: 0.7;
+    transition:
+      background-color 150ms ease-in-out,
+      opacity 150ms ease-in-out;
+
+    &:hover {
+      opacity: 1;
+      background-color: rgba(255, 255, 255, 0.12);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--accent-color);
+      outline-offset: 1px;
+    }
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 11px;
+      height: 1.5px;
+      background-color: currentColor;
+      border-radius: 1px;
+    }
+
+    &::before {
+      transform: translate(-50%, -50%) rotate(45deg);
+    }
+
+    &::after {
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
   }
 }

--- a/packages/web/adwaita-web/scss/_view_switcher.scss
+++ b/packages/web/adwaita-web/scss/_view_switcher.scss
@@ -1,0 +1,133 @@
+// _view_switcher.scss — adw-view-switcher styling: an adaptive, tab-style
+// switcher (single `viewswitcher` node) above a content area showing one page
+// at a time. Buttons are always icon + label, laid out side by side (`.wide`)
+// or stacked (`.narrow`), matching libadwaita's policy style classes.
+// Reference: refs/libadwaita/src/stylesheet/widgets/_view-switcher.scss (AdwViewSwitcher)
+// Reference: refs/adwaita-web/adwaita-web/scss/_viewswitcher.scss
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Copyright (c) 2025 csm (adwaita-web). MIT License.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+adw-view-switcher {
+    display: flex;
+    flex-direction: column;
+    box-sizing: border-box;
+
+    // The segmented button bar — the single `viewswitcher` node in libadwaita.
+    // Homogeneous tabs (equal width via flex:1) with a small gutter between them.
+    .adw-view-switcher-bar {
+        display: flex;
+        align-items: stretch;
+        gap: 3px; // libadwaita's `border-spacing: 3px`
+        min-height: 34px;
+    }
+
+    // Each tab is a flat, transparent toggle that lights up with a subtle fill
+    // when hovered and shows the active page with an accent-tinted background.
+    .adw-view-switcher-button {
+        box-sizing: border-box;
+        display: inline-flex;
+        flex: 1 1 0; // homogeneous — every tab gets equal width
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+        padding: 2px 12px;
+        border: none;
+        border-radius: var(--button-radius);
+        background-color: transparent;
+        color: var(--window-fg-color);
+        font-family: var(--font-family);
+        font-size: var(--font-size-base);
+        font-weight: 700;
+        line-height: 1.2;
+        cursor: pointer;
+        transition:
+            color 0.2s ease,
+            background-color 0.2s ease;
+        user-select: none;
+        -webkit-user-select: none;
+
+        .adw-icon {
+            width: 16px;
+            height: 16px;
+            flex: none;
+        }
+
+        .adw-view-switcher-label {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        &:hover {
+            background-color: var(--button-hover-color);
+        }
+
+        &:active {
+            background-color: var(--button-active-color);
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--accent-color);
+            outline-offset: -2px;
+        }
+
+        // The selected view — a neutral filled chip (libadwaita darkens the
+        // whole button; the icon/label keep the normal foreground colour
+        // rather than turning accent).
+        &.active {
+            background-color: var(--button-active-color);
+            color: var(--window-fg-color);
+
+            &:hover {
+                background-color: var(--button-active-color);
+            }
+        }
+    }
+
+    // Wide policy — icon and label side by side.
+    &.wide .adw-view-switcher-button {
+        flex-direction: row;
+        gap: var(--spacing-xs);
+    }
+
+    // Narrow policy — icon stacked above a smaller label, the compact layout
+    // libadwaita drops to in a header bar at narrow window widths.
+    &.narrow {
+        .adw-view-switcher-bar {
+            min-height: 6px;
+        }
+
+        .adw-view-switcher-button {
+            flex-direction: column;
+            gap: 1px;
+            padding-top: 4px;
+            padding-bottom: 2px;
+            font-size: 0.75rem;
+
+            .adw-view-switcher-label {
+                min-height: 18px;
+                line-height: 18px;
+            }
+        }
+    }
+
+    // The paired content area showing the active page — a card-like surface
+    // below the switcher (the web stand-in for the Adw.ViewStack body).
+    .adw-view-switcher-content {
+        flex: 1 1 auto;
+        margin-top: var(--spacing-s);
+        padding: var(--spacing-m);
+        background-color: var(--view-bg-color);
+        border: 1px solid var(--separator-color);
+        border-radius: var(--card-radius);
+    }
+
+    .adw-view-switcher-page {
+        display: none;
+
+        &.active-view {
+            display: block;
+        }
+    }
+}

--- a/packages/web/adwaita-web/scss/_wrap_box.scss
+++ b/packages/web/adwaita-web/scss/_wrap_box.scss
@@ -1,0 +1,20 @@
+// _wrap_box.scss — adw-wrap-box styling (a box that wraps its children onto new
+// lines, the web analog of flexbox `flex-wrap: wrap`). Mirrors Adw.WrapBox.
+// Reference: refs/adwaita-web/adwaita-web/scss/_wrap_box.scss
+// Reference: refs/libadwaita/src/adw-wrap-box.c / adw-wrap-layout.c (Adw.WrapBox)
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+// Layout (flex-direction, gaps, justify-content, align-items, align-content) is
+// driven imperatively by the component from its attributes — these are the
+// libadwaita defaults (horizontal, packed to the start of each line, lines
+// wrapping downwards from the top). A wrap box is a pure layout container, so it
+// carries no background of its own; children handle their own theming.
+adw-wrap-box {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+  align-content: flex-start;
+}

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -38,6 +38,10 @@
 @use 'wrap_box';
 @use 'overlay_split_view';
 @use 'navigation_split_view';
+@use 'carousel';
+@use 'tab_view';
+@use 'view_switcher';
+@use 'inline_view_switcher';
 
 // Ensure the `hidden` attribute always wins: components that toggle visibility
 // via `element.hidden = true` set the HTML attribute, but a custom `display`

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -42,6 +42,9 @@
 @use 'tab_view';
 @use 'view_switcher';
 @use 'inline_view_switcher';
+@use 'navigation_view';
+@use 'bottom_sheet';
+@use 'sidebar';
 
 // Ensure the `hidden` attribute always wins: components that toggle visibility
 // via `element.hidden = true` set the HTML attribute, but a custom `display`

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -35,6 +35,7 @@
 @use 'password_entry_row';
 @use 'toast';
 @use 'toolbar_view';
+@use 'wrap_box';
 @use 'overlay_split_view';
 @use 'navigation_split_view';
 

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -45,6 +45,9 @@
 @use 'navigation_view';
 @use 'bottom_sheet';
 @use 'sidebar';
+@use 'about_dialog';
+@use 'alert_dialog';
+@use 'preferences_dialog';
 
 // Ensure the `hidden` attribute always wins: components that toggle visibility
 // via `element.hidden = true` set the HTML attribute, but a custom `display`

--- a/packages/web/adwaita-web/src/elements/adw-about-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-about-dialog.ts
@@ -1,0 +1,629 @@
+// <adw-about-dialog> — The standard Adwaita "About" dialog (the web counterpart
+// of Adw.AboutDialog). It is a modal AdwDialog (a full-cover scrim + a centred,
+// scrollable floating sheet) hosting a navigation view: the main page shows the
+// app icon, name, developer name and a version pill, with preference rows that
+// navigate to the Details, Credits and Legal subpages.
+//
+// Like Adw.AboutDialog the dialog is presented imperatively — `present()` (or
+// setting the `open` attribute) reveals it; Escape, a scrim click, the header
+// close button, or `close()` dismisses it. The header title fades in once the
+// main page is scrolled (mirroring AdwAboutDialog's update_headerbar_cb).
+//
+// Properties / attributes (all reflected, mirroring the AdwAboutDialog GObject
+// properties of the same name, hyphenated):
+//   application-name   the application's display name (shown as a title-1)
+//   application-icon   a symbolic icon name (with or without -symbolic) — the
+//                        large app icon; falls back to a generic glyph
+//   developer-name     the developer / vendor line below the name
+//   version            the version, shown as a clickable pill
+//   comments           a longer description (shown on the Details page)
+//   website            the application's website URL (a Website link row)
+//   support-url        a support-forum URL (a Support Questions link row)
+//   issue-url          an issue-tracker URL (a Report an Issue link row)
+//   copyright          the copyright line (shown on the Legal page)
+//   license            the license text/name (shown on the Legal page); when a
+//                        `license-url` is also given the name becomes a link
+//   license-url        a URL the license name links to
+//   open               (boolean) whether the dialog is presented
+//
+// List-valued credits are set via properties (string arrays), mirroring the
+// AdwAboutDialog `developers` / `designers` / `artists` / `documenters`
+// properties — entries may be `Name`, `Name <email>` or `Name https://url`,
+// matching the AdwAboutDialog credit syntax.
+//
+// Events (CustomEvent, bubbles):
+//   `notify::open` (detail = { open }) when the presented state changes —
+//     mirrors the Adw.Dialog `open` notification.
+//   `closed` when the dialog is dismissed — mirrors Adw.Dialog::closed.
+//   `activate-link` (detail = { uri }) when a link row is activated — mirrors
+//     AdwAboutDialog::activate-link (not cancelled here; the browser navigates).
+//
+// Reference: refs/libadwaita/src/adw-about-dialog.c (AdwAboutDialog behaviour)
+// Reference: refs/libadwaita/src/adw-about-dialog.ui (navigation page tree)
+// Reference: refs/libadwaita/src/adw-dialog.c (floating-sheet present/close)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss (floating sheet)
+// Reference: refs/adwaita-web/adwaita-web/scss/_about_dialog.scss (web layout)
+// Copyright (c) 2022-2024 GNOME Foundation Inc. / Purism SPC (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** A credit person — a plain name, or a name paired with a link (email / URL). */
+interface CreditEntry {
+    name: string;
+    uri: string | null;
+}
+
+/** Parse an AdwAboutDialog credit string: `Name`, `Name <email>`, `Name https://…`. */
+function parseCredit(raw: string): CreditEntry {
+    const trimmed = raw.trim();
+    // `Name <email-or-url>` — the bracketed part is the link target.
+    const angle = /^(.*?)\s*<([^>]+)>$/.exec(trimmed);
+    if (angle) {
+        const target = angle[2].trim();
+        const uri = target.includes('@') && !/^[a-z][a-z0-9+.-]*:/i.test(target) ? `mailto:${target}` : target;
+        return { name: angle[1].trim(), uri };
+    }
+    // `Name https://url` — a trailing bare URL is the link target.
+    const url = /^(.*?)\s+((?:https?|mailto):\S+)$/.exec(trimmed);
+    if (url) {
+        return { name: url[1].trim(), uri: url[2].trim() };
+    }
+    return { name: trimmed, uri: null };
+}
+
+export class AdwAboutDialog extends HTMLElement {
+    private _initialized = false;
+
+    // Layout nodes (rebuilt from attributes on each render).
+    private _scrimEl!: HTMLDivElement;
+    private _sheetEl!: HTMLDivElement;
+    private _navView!: HTMLElement;
+    private _scrollEl!: HTMLDivElement;
+    private _mainToolbarEl!: HTMLDivElement;
+
+    // List-valued credit properties (no attribute form — set imperatively).
+    private _developers: string[] = [];
+    private _designers: string[] = [];
+    private _artists: string[] = [];
+    private _documenters: string[] = [];
+
+    static get observedAttributes() {
+        return [
+            'application-name',
+            'application-icon',
+            'developer-name',
+            'version',
+            'comments',
+            'website',
+            'support-url',
+            'issue-url',
+            'copyright',
+            'license',
+            'license-url',
+            'open',
+        ];
+    }
+
+    // --- Reflected scalar properties ---
+
+    get applicationName(): string {
+        return this.getAttribute('application-name') ?? '';
+    }
+
+    set applicationName(value: string) {
+        this.setAttribute('application-name', value);
+    }
+
+    get applicationIcon(): string {
+        return this.getAttribute('application-icon') ?? '';
+    }
+
+    set applicationIcon(value: string) {
+        this.setAttribute('application-icon', value);
+    }
+
+    get developerName(): string {
+        return this.getAttribute('developer-name') ?? '';
+    }
+
+    set developerName(value: string) {
+        this.setAttribute('developer-name', value);
+    }
+
+    get version(): string {
+        return this.getAttribute('version') ?? '';
+    }
+
+    set version(value: string) {
+        this.setAttribute('version', value);
+    }
+
+    get comments(): string {
+        return this.getAttribute('comments') ?? '';
+    }
+
+    set comments(value: string) {
+        this.setAttribute('comments', value);
+    }
+
+    get website(): string {
+        return this.getAttribute('website') ?? '';
+    }
+
+    set website(value: string) {
+        this.setAttribute('website', value);
+    }
+
+    get supportUrl(): string {
+        return this.getAttribute('support-url') ?? '';
+    }
+
+    set supportUrl(value: string) {
+        this.setAttribute('support-url', value);
+    }
+
+    get issueUrl(): string {
+        return this.getAttribute('issue-url') ?? '';
+    }
+
+    set issueUrl(value: string) {
+        this.setAttribute('issue-url', value);
+    }
+
+    get copyright(): string {
+        return this.getAttribute('copyright') ?? '';
+    }
+
+    set copyright(value: string) {
+        this.setAttribute('copyright', value);
+    }
+
+    get license(): string {
+        return this.getAttribute('license') ?? '';
+    }
+
+    set license(value: string) {
+        this.setAttribute('license', value);
+    }
+
+    get licenseUrl(): string {
+        return this.getAttribute('license-url') ?? '';
+    }
+
+    set licenseUrl(value: string) {
+        this.setAttribute('license-url', value);
+    }
+
+    /** Whether the dialog is presented. */
+    get open(): boolean {
+        return this.hasAttribute('open');
+    }
+
+    set open(value: boolean) {
+        if (value) this.setAttribute('open', '');
+        else this.removeAttribute('open');
+    }
+
+    // --- List-valued credit properties (no attribute form) ---
+
+    get developers(): string[] {
+        return this._developers;
+    }
+
+    set developers(value: string[]) {
+        this._developers = [...value];
+        if (this._initialized) this._render();
+    }
+
+    get designers(): string[] {
+        return this._designers;
+    }
+
+    set designers(value: string[]) {
+        this._designers = [...value];
+        if (this._initialized) this._render();
+    }
+
+    get artists(): string[] {
+        return this._artists;
+    }
+
+    set artists(value: string[]) {
+        this._artists = [...value];
+        if (this._initialized) this._render();
+    }
+
+    get documenters(): string[] {
+        return this._documenters;
+    }
+
+    set documenters(value: string[]) {
+        this._documenters = [...value];
+        if (this._initialized) this._render();
+    }
+
+    /** Present the dialog (the web counterpart of Adw.Dialog.present()). */
+    present(): void {
+        this.open = true;
+    }
+
+    /** Dismiss the dialog (the web counterpart of Adw.Dialog.close()). */
+    close(): void {
+        this.open = false;
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // The full-cover modal scrim — clicking it dismisses the dialog.
+        this._scrimEl = document.createElement('div');
+        this._scrimEl.className = 'adw-about-dialog-scrim';
+        this._scrimEl.addEventListener('click', () => this.close());
+
+        // The centred floating sheet.
+        this._sheetEl = document.createElement('div');
+        this._sheetEl.className = 'adw-about-dialog-sheet';
+        this._sheetEl.setAttribute('role', 'dialog');
+        this._sheetEl.setAttribute('aria-modal', 'true');
+
+        this.replaceChildren(this._scrimEl, this._sheetEl);
+
+        // Escape dismisses while open (mirrors AdwDialog's close shortcut).
+        this.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.open) {
+                event.stopPropagation();
+                this.close();
+            }
+        });
+
+        this._render();
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+        if (!this._initialized) return;
+        if (oldValue === newValue) return;
+        if (name === 'open') {
+            this._syncOpen();
+            this.dispatchEvent(new CustomEvent('notify::open', { bubbles: true, detail: { open: this.open } }));
+            if (!this.open) this.dispatchEvent(new CustomEvent('closed', { bubbles: true }));
+            return;
+        }
+        this._render();
+    }
+
+    /** Reflect the presented state onto the host + reset the navigation stack. */
+    private _syncOpen(): void {
+        this.classList.toggle('open', this.open);
+        if (this.open) {
+            // Always present the main page; subpages are reached via the rows.
+            const nav = this._navView as unknown as { replace?: (tags: string[]) => void };
+            nav.replace?.(['main']);
+            this._scrollEl.scrollTop = 0;
+            this._updateHeaderTitle();
+            // Move focus into the sheet for keyboard dismissal.
+            requestAnimationFrame(() => this._sheetEl.focus());
+        }
+    }
+
+    /** Rebuild the sheet contents from the current attributes / credit lists. */
+    private _render(): void {
+        const appName = this.applicationName || 'Application';
+        this._sheetEl.setAttribute('aria-label', `About ${appName}`);
+
+        // The navigation view (main page + subpages) lives inside the sheet.
+        this._navView = document.createElement('adw-navigation-view');
+        this._navView.append(this._buildMainPage(appName));
+
+        const detailsPage = this._buildDetailsPage();
+        if (detailsPage) this._navView.append(detailsPage);
+
+        const creditsPage = this._buildCreditsPage();
+        if (creditsPage) this._navView.append(creditsPage);
+
+        const legalPage = this._buildLegalPage();
+        if (legalPage) this._navView.append(legalPage);
+
+        this._sheetEl.replaceChildren(this._navView);
+        this._sheetEl.tabIndex = -1;
+
+        this.classList.toggle('open', this.open);
+    }
+
+    /** A navigation page wrapping a header bar (with the close button) + content. */
+    private _buildPage(tag: string, title: string, showClose: boolean): {
+        page: HTMLElement;
+        body: HTMLDivElement;
+        header: HTMLElement;
+    } {
+        const page = document.createElement('adw-navigation-page');
+        page.setAttribute('title', title);
+        page.setAttribute('tag', tag);
+
+        const header = document.createElement('adw-header-bar');
+        // The main page's title is hidden until the page is scrolled (CSS), the
+        // subpages always show it (AdwAboutDialog update_headerbar_cb).
+        header.setAttribute('title', title);
+
+        if (showClose) {
+            // The close button — drawn with a CSS "×" glyph (no window-close
+            // symbolic icon ships in @gjsify/adwaita-icons, the same approach as
+            // adw-tab-view's close affordance).
+            const close = document.createElement('button');
+            close.type = 'button';
+            close.className = 'adw-button flat circular adw-about-dialog-close';
+            close.setAttribute('aria-label', 'Close');
+            close.addEventListener('click', () => this.close());
+            const endApply = () => {
+                const end = (header as { endSection?: HTMLElement | null }).endSection ?? null;
+                if (end) end.appendChild(close);
+            };
+            // The header bar builds its sections in its own connectedCallback;
+            // append the close button once that has run.
+            queueMicrotask(endApply);
+        }
+
+        const scroll = document.createElement('div');
+        scroll.className = 'adw-about-dialog-scroll';
+
+        const clamp = document.createElement('div');
+        clamp.className = 'adw-about-dialog-clamp';
+        const body = document.createElement('div');
+        body.className = 'adw-about-dialog-page-body';
+        clamp.appendChild(body);
+        scroll.appendChild(clamp);
+
+        const toolbar = document.createElement('div');
+        toolbar.className = 'adw-about-dialog-toolbar-view';
+        toolbar.append(header, scroll);
+        page.appendChild(toolbar);
+
+        if (tag === 'main') {
+            this._scrollEl = scroll;
+            this._mainToolbarEl = toolbar;
+            // The main page's header title fades in once the content scrolls.
+            toolbar.classList.add('main-page');
+            scroll.addEventListener('scroll', () => this._updateHeaderTitle());
+        }
+
+        return { page, body, header };
+    }
+
+    /** The main page: icon, name, developer, version pill, navigation rows. */
+    private _buildMainPage(appName: string): HTMLElement {
+        const { page, body } = this._buildPage('main', `About ${appName}`, true);
+
+        // App icon — a large symbolic glyph. A given application-icon resolves
+        // to its `.adw-icon--<name>` mask class; absent one, fall back to the
+        // GTK default generic `application-x-executable` glyph.
+        const icon = (this.applicationIcon || 'application-x-executable').replace(/-symbolic$/, '');
+        const iconEl = document.createElement('span');
+        iconEl.className = `adw-about-dialog-icon adw-icon adw-icon--${icon}`;
+        iconEl.setAttribute('aria-hidden', 'true');
+        body.appendChild(iconEl);
+
+        // App name — title-1.
+        const nameEl = document.createElement('span');
+        nameEl.className = 'adw-about-dialog-name';
+        nameEl.textContent = appName;
+        body.appendChild(nameEl);
+
+        // Developer / vendor.
+        if (this.developerName) {
+            const devEl = document.createElement('span');
+            devEl.className = 'adw-about-dialog-developer';
+            devEl.textContent = this.developerName;
+            body.appendChild(devEl);
+        }
+
+        // Version pill.
+        if (this.version) {
+            const versionEl = document.createElement('span');
+            versionEl.className = 'adw-about-dialog-version';
+            versionEl.textContent = this.version;
+            body.appendChild(versionEl);
+        }
+
+        // The navigation preference rows (Details / Credits / Legal). Only the
+        // rows whose corresponding subpage has content are shown — mirroring the
+        // AdwAboutDialog group visibility bindings.
+        const group = document.createElement('adw-preferences-group');
+        let hasRows = false;
+
+        if (this._hasDetails()) {
+            group.appendChild(this._buildNavRow('Details', 'details'));
+            hasRows = true;
+        }
+        if (this._hasCredits()) {
+            group.appendChild(this._buildNavRow('Credits', 'credits'));
+            hasRows = true;
+        }
+        if (this._hasLegal()) {
+            group.appendChild(this._buildNavRow('Legal', 'legal'));
+            hasRows = true;
+        }
+
+        if (hasRows) {
+            const groupWrap = document.createElement('div');
+            groupWrap.className = 'adw-about-dialog-rows';
+            groupWrap.appendChild(group);
+            body.appendChild(groupWrap);
+        }
+
+        return page;
+    }
+
+    /** An activatable row that pushes a subpage, with a trailing go-next chevron. */
+    private _buildNavRow(title: string, tag: string): HTMLElement {
+        const row = document.createElement('adw-action-row');
+        row.setAttribute('title', title);
+        row.setAttribute('activatable', '');
+
+        const chevron = document.createElement('span');
+        chevron.setAttribute('slot', 'suffix');
+        chevron.className = 'adw-icon adw-icon--go-next adw-about-dialog-chevron';
+        chevron.setAttribute('aria-hidden', 'true');
+        row.appendChild(chevron);
+
+        row.addEventListener('activated', () => {
+            const nav = this._navView as unknown as { push?: (tag: string) => void };
+            nav.push?.(tag);
+        });
+
+        return row;
+    }
+
+    private _hasDetails(): boolean {
+        return Boolean(this.comments || this.website || this.supportUrl || this.issueUrl);
+    }
+
+    private _hasCredits(): boolean {
+        return (
+            this._developers.length > 0 ||
+            this._designers.length > 0 ||
+            this._artists.length > 0 ||
+            this._documenters.length > 0
+        );
+    }
+
+    private _hasLegal(): boolean {
+        return Boolean(this.copyright || this.license);
+    }
+
+    /** The Details page: comments + website / support / issue link rows. */
+    private _buildDetailsPage(): HTMLElement | null {
+        if (!this._hasDetails()) return null;
+        const { page, body } = this._buildPage('details', 'Details', false);
+
+        if (this.comments) {
+            const comments = document.createElement('p');
+            comments.className = 'adw-about-dialog-comments';
+            comments.textContent = this.comments;
+            body.appendChild(comments);
+        }
+
+        const links: Array<[string, string]> = [];
+        if (this.website) links.push(['Website', this.website]);
+        if (this.supportUrl) links.push(['Support Questions', this.supportUrl]);
+        if (this.issueUrl) links.push(['Report an Issue', this.issueUrl]);
+
+        if (links.length > 0) {
+            const group = document.createElement('adw-preferences-group');
+            for (const [title, uri] of links) group.appendChild(this._buildLinkRow(title, uri));
+            const wrap = document.createElement('div');
+            wrap.className = 'adw-about-dialog-rows';
+            wrap.appendChild(group);
+            body.appendChild(wrap);
+        }
+
+        return page;
+    }
+
+    /** A link row that opens a URL in a new tab and emits `activate-link`. */
+    private _buildLinkRow(title: string, uri: string): HTMLElement {
+        const row = document.createElement('adw-action-row');
+        row.setAttribute('title', title);
+        row.setAttribute('activatable', '');
+        row.classList.add('adw-about-dialog-link-row');
+
+        const chevron = document.createElement('span');
+        chevron.setAttribute('slot', 'suffix');
+        chevron.className = 'adw-icon adw-icon--go-next adw-about-dialog-chevron';
+        chevron.setAttribute('aria-hidden', 'true');
+        row.appendChild(chevron);
+
+        row.addEventListener('activated', () => {
+            this.dispatchEvent(new CustomEvent('activate-link', { bubbles: true, detail: { uri } }));
+            window.open(uri, '_blank', 'noopener,noreferrer');
+        });
+
+        return row;
+    }
+
+    /** The Credits page: a group per non-empty credit section. */
+    private _buildCreditsPage(): HTMLElement | null {
+        if (!this._hasCredits()) return null;
+        const { page, body } = this._buildPage('credits', 'Credits', false);
+
+        const sections: Array<[string, string[]]> = [
+            ['Code by', this._developers],
+            ['Design by', this._designers],
+            ['Artwork by', this._artists],
+            ['Documentation by', this._documenters],
+        ];
+
+        for (const [title, people] of sections) {
+            if (people.length === 0) continue;
+            const group = document.createElement('adw-preferences-group');
+            group.setAttribute('title', title);
+            for (const person of people) group.appendChild(this._buildCreditRow(person));
+            const wrap = document.createElement('div');
+            wrap.className = 'adw-about-dialog-rows';
+            wrap.appendChild(group);
+            body.appendChild(wrap);
+        }
+
+        return page;
+    }
+
+    /** A credit row — a plain title, or a link row when the entry carries a URI. */
+    private _buildCreditRow(raw: string): HTMLElement {
+        const { name, uri } = parseCredit(raw);
+        const row = document.createElement('adw-action-row');
+        row.setAttribute('title', name);
+
+        if (uri) {
+            row.setAttribute('activatable', '');
+            row.classList.add('adw-about-dialog-link-row');
+            const chevron = document.createElement('span');
+            chevron.setAttribute('slot', 'suffix');
+            chevron.className = 'adw-icon adw-icon--go-next adw-about-dialog-chevron';
+            chevron.setAttribute('aria-hidden', 'true');
+            row.appendChild(chevron);
+            row.addEventListener('activated', () => {
+                this.dispatchEvent(new CustomEvent('activate-link', { bubbles: true, detail: { uri } }));
+                window.open(uri, '_blank', 'noopener,noreferrer');
+            });
+        }
+
+        return row;
+    }
+
+    /** The Legal page: copyright + license text. */
+    private _buildLegalPage(): HTMLElement | null {
+        if (!this._hasLegal()) return null;
+        const { page, body } = this._buildPage('legal', 'Legal', false);
+
+        if (this.copyright) {
+            const copyright = document.createElement('p');
+            copyright.className = 'adw-about-dialog-copyright';
+            copyright.textContent = this.copyright;
+            body.appendChild(copyright);
+        }
+
+        if (this.license) {
+            const license = document.createElement('p');
+            license.className = 'adw-about-dialog-license';
+            if (this.licenseUrl) {
+                const link = document.createElement('a');
+                link.href = this.licenseUrl;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.textContent = this.license;
+                license.appendChild(link);
+            } else {
+                license.textContent = this.license;
+            }
+            body.appendChild(license);
+        }
+
+        return page;
+    }
+
+    /** Show the header title only once the main page is scrolled (AdwAboutDialog). */
+    private _updateHeaderTitle(): void {
+        if (!this._scrollEl || !this._mainToolbarEl) return;
+        this._mainToolbarEl.classList.toggle('scrolled', this._scrollEl.scrollTop > 0);
+    }
+}
+
+customElements.define('adw-about-dialog', AdwAboutDialog);

--- a/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
@@ -1,0 +1,385 @@
+// <adw-alert-dialog> — A modal dialog presenting a message or a question (the
+// web counterpart of Adw.AlertDialog). It renders a fixed full-cover scrim with
+// a centred dialog box on top, holding a bold heading, body text, an optional
+// extra-child slot, and one or more response buttons. Each response is a button
+// with a unique string ID and a label; one may carry the suggested or
+// destructive appearance.
+//
+// Responses are declared imperatively via add_response() / addResponse() (the
+// Adw.AlertDialog API), or via <adw-alert-response> children consumed at connect
+// time. The dialog is hidden until `present()` (or setting the `open` attribute)
+// reveals it; Escape / scrim-click dismiss it — respecting the `close-response`
+// — unless can-close is suppressed by the close response.
+//
+// Attributes:
+//   heading    (the bold heading text)
+//   body       (the body text below the heading)
+//   open       (boolean — whether the dialog is shown; default closed)
+//   prefer-wide-layout (boolean — lay responses out horizontally when they fit)
+//
+// Buttons are stacked vertically by default (the Adw.AlertDialog default at
+// medium sizes) and laid out horizontally when prefer-wide-layout is set and
+// there are no more than two of them — mirroring the libadwaita measure/allocate
+// heuristic in spirit.
+//
+// Events:
+//   `response` (CustomEvent, bubbles, `detail = { response }`) when a response
+//     button is activated OR the dialog is dismissed (then `response` is the
+//     close-response ID) — mirrors the Adw.AlertDialog::response signal.
+//   `notify::heading` / `notify::body` / `notify::open` (CustomEvent, bubbles)
+//     mirroring the matching GObject properties.
+//
+// Reference: refs/libadwaita/src/adw-alert-dialog.c (AdwAlertDialog behaviour)
+// Reference: refs/libadwaita/src/adw-dialog.c (shared dialog base — Escape/close)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss (floating-sheet)
+// Reference: refs/adwaita-web/adwaita-web/scss/_dialog.scss (alert layout)
+// Copyright (c) 2022 Purism SPC / 2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** Response button appearance — mirrors Adw.ResponseAppearance. */
+export type AdwResponseAppearance = 'default' | 'suggested' | 'destructive';
+
+interface ResponseInfo {
+    id: string;
+    label: string;
+    appearance: AdwResponseAppearance;
+    enabled: boolean;
+    button: HTMLButtonElement;
+}
+
+/**
+ * A single response declared in markup. Child of <adw-alert-dialog>; its `id`
+ * attribute is the response ID, its text content the label. Optional
+ * `appearance="suggested|destructive"` and `enabled="false"` mirror the
+ * GtkBuildable `<response>` element attributes. Consumed at connect time.
+ */
+export class AdwAlertResponse extends HTMLElement {
+    static get observedAttributes() {
+        return ['id', 'appearance', 'enabled'];
+    }
+}
+
+export class AdwAlertDialog extends HTMLElement {
+    private _initialized = false;
+    private _scrimEl!: HTMLDivElement;
+    private _dialogEl!: HTMLDivElement;
+    private _headingEl!: HTMLHeadingElement;
+    private _bodyEl!: HTMLParagraphElement;
+    private _childEl!: HTMLDivElement;
+    private _responseAreaEl!: HTMLDivElement;
+
+    private _responses: ResponseInfo[] = [];
+    private _byId = new Map<string, ResponseInfo>();
+    private _defaultResponse: string | null = null;
+    private _closeResponse = 'close';
+    // Set while a response is being emitted from a button so the close handler
+    // does not also fire the close-response (mirrors AdwAlertDialog's
+    // block_close_response flag).
+    private _blockCloseResponse = false;
+
+    static get observedAttributes() {
+        return ['heading', 'body', 'open', 'prefer-wide-layout'];
+    }
+
+    /** The heading of the dialog. */
+    get heading(): string {
+        return this.getAttribute('heading') ?? '';
+    }
+
+    set heading(value: string) {
+        this.setAttribute('heading', value);
+    }
+
+    /** The body text of the dialog. */
+    get body(): string {
+        return this.getAttribute('body') ?? '';
+    }
+
+    set body(value: string) {
+        this.setAttribute('body', value);
+    }
+
+    /** Whether the dialog is currently shown. */
+    get open(): boolean {
+        return this.hasAttribute('open');
+    }
+
+    set open(value: boolean) {
+        if (value) this.setAttribute('open', '');
+        else this.removeAttribute('open');
+    }
+
+    /** Whether to prefer horizontal button layout when the buttons fit. */
+    get preferWideLayout(): boolean {
+        return this.hasAttribute('prefer-wide-layout');
+    }
+
+    set preferWideLayout(value: boolean) {
+        if (value) this.setAttribute('prefer-wide-layout', '');
+        else this.removeAttribute('prefer-wide-layout');
+    }
+
+    /** The ID of the default response (its button is highlighted). */
+    get defaultResponse(): string | null {
+        return this._defaultResponse;
+    }
+
+    set defaultResponse(value: string | null) {
+        this.setDefaultResponse(value);
+    }
+
+    /** The ID passed to `response` when the dialog is dismissed. */
+    get closeResponse(): string {
+        return this._closeResponse;
+    }
+
+    set closeResponse(value: string) {
+        this.setCloseResponse(value);
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot any declared <adw-alert-response> children before we take
+        // over the subtree; everything else becomes the extra child.
+        const declared = Array.from(this.querySelectorAll(':scope > adw-alert-response')) as AdwAlertResponse[];
+        const declaredSet = new Set<Node>(declared);
+        const extraChildren = Array.from(this.childNodes).filter((n) => !declaredSet.has(n));
+
+        // The fixed full-cover scrim. Clicking it dismisses the dialog.
+        this._scrimEl = document.createElement('div');
+        this._scrimEl.className = 'adw-alert-dialog-scrim';
+        this._scrimEl.addEventListener('click', () => this._dismiss());
+
+        // The centred dialog box.
+        this._dialogEl = document.createElement('div');
+        this._dialogEl.className = 'adw-alert-dialog-box';
+        this._dialogEl.setAttribute('role', 'alertdialog');
+        this._dialogEl.setAttribute('aria-modal', 'true');
+        // Clicks inside the box must not bubble to the scrim's dismiss handler.
+        this._dialogEl.addEventListener('click', (event) => event.stopPropagation());
+
+        // The scrolled message area (heading + body + extra child).
+        const messageArea = document.createElement('div');
+        messageArea.className = 'adw-alert-dialog-message';
+
+        this._headingEl = document.createElement('h2');
+        this._headingEl.className = 'adw-alert-dialog-heading';
+
+        this._bodyEl = document.createElement('p');
+        this._bodyEl.className = 'adw-alert-dialog-body';
+
+        this._childEl = document.createElement('div');
+        this._childEl.className = 'adw-alert-dialog-child';
+        for (const child of extraChildren) this._childEl.appendChild(child);
+
+        messageArea.append(this._headingEl, this._bodyEl, this._childEl);
+
+        // The response button area.
+        this._responseAreaEl = document.createElement('div');
+        this._responseAreaEl.className = 'adw-alert-dialog-responses';
+
+        this._dialogEl.append(messageArea, this._responseAreaEl);
+        this.replaceChildren(this._scrimEl, this._dialogEl);
+
+        // Escape dismisses the dialog when open (mirrors the AdwDialog Escape
+        // shortcut → close-response).
+        this.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.open) {
+                event.stopPropagation();
+                this._dismiss();
+            }
+        });
+
+        // Adopt declared responses now that the response area exists.
+        for (const el of declared) {
+            const id = el.getAttribute('id');
+            if (!id) continue;
+            const appearance = (el.getAttribute('appearance') ?? 'default') as AdwResponseAppearance;
+            this.addResponse(id, (el.textContent ?? '').trim());
+            if (appearance !== 'default') this.setResponseAppearance(id, appearance);
+            if (el.getAttribute('enabled') === 'false') this.setResponseEnabled(id, false);
+        }
+
+        this._render();
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+        if (!this._initialized) return;
+        if (oldValue === newValue) return;
+        this._render();
+        if (name === 'heading') {
+            this.dispatchEvent(new CustomEvent('notify::heading', { bubbles: true, detail: { heading: this.heading } }));
+        } else if (name === 'body') {
+            this.dispatchEvent(new CustomEvent('notify::body', { bubbles: true, detail: { body: this.body } }));
+        } else if (name === 'open') {
+            this.dispatchEvent(new CustomEvent('notify::open', { bubbles: true, detail: { open: this.open } }));
+            if (this.open) this._focusInitial();
+        }
+    }
+
+    /** Present the dialog. `parent` is accepted for API parity; unused. */
+    present(_parent?: unknown): void {
+        this.open = true;
+    }
+
+    /** Adds a response button with the given ID and label. */
+    addResponse(id: string, label: string): void {
+        if (this._byId.has(id)) {
+            // Mirror AdwAlertDialog's g_critical without throwing.
+            console.warn(
+                `[adw-alert-dialog] Trying to add a response with id '${id}', but such a response already exists`,
+            );
+            return;
+        }
+
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'adw-button adw-alert-dialog-response';
+        button.textContent = label;
+
+        const info: ResponseInfo = { id, label, appearance: 'default', enabled: true, button };
+        button.addEventListener('click', () => this._activateResponse(info));
+
+        this._responses.push(info);
+        this._byId.set(id, info);
+        if (this._responseAreaEl) this._responseAreaEl.appendChild(button);
+        this._render();
+    }
+
+    /** Adds multiple responses at once — id/label pairs (Adw.add_responses parity). */
+    addResponses(...idLabelPairs: string[]): void {
+        for (let i = 0; i + 1 < idLabelPairs.length; i += 2) {
+            this.addResponse(idLabelPairs[i], idLabelPairs[i + 1]);
+        }
+    }
+
+    /** Removes a response. */
+    removeResponse(id: string): void {
+        const info = this._byId.get(id);
+        if (!info) return;
+        info.button.remove();
+        this._responses = this._responses.filter((r) => r !== info);
+        this._byId.delete(id);
+        if (this._defaultResponse === id) this._defaultResponse = null;
+        this._render();
+    }
+
+    /** Whether a response with the given ID exists. */
+    hasResponse(id: string): boolean {
+        return this._byId.has(id);
+    }
+
+    /** Gets a response's label. */
+    getResponseLabel(id: string): string | null {
+        return this._byId.get(id)?.label ?? null;
+    }
+
+    /** Sets a response's label. */
+    setResponseLabel(id: string, label: string): void {
+        const info = this._byId.get(id);
+        if (!info) return;
+        info.label = label;
+        info.button.textContent = label;
+    }
+
+    /** Gets a response's appearance. */
+    getResponseAppearance(id: string): AdwResponseAppearance | null {
+        return this._byId.get(id)?.appearance ?? null;
+    }
+
+    /** Sets a response's appearance (default / suggested / destructive). */
+    setResponseAppearance(id: string, appearance: AdwResponseAppearance): void {
+        const info = this._byId.get(id);
+        if (!info) return;
+        info.appearance = appearance;
+        info.button.classList.toggle('suggested-action', appearance === 'suggested');
+        info.button.classList.toggle('destructive-action', appearance === 'destructive');
+    }
+
+    /** Gets whether a response is enabled. */
+    getResponseEnabled(id: string): boolean {
+        return this._byId.get(id)?.enabled ?? false;
+    }
+
+    /** Sets whether a response is enabled (disabled buttons can't be activated). */
+    setResponseEnabled(id: string, enabled: boolean): void {
+        const info = this._byId.get(id);
+        if (!info) return;
+        info.enabled = enabled;
+        info.button.disabled = !enabled;
+    }
+
+    /** Sets the default response — its button is highlighted as the suggested one. */
+    setDefaultResponse(id: string | null): void {
+        this._defaultResponse = id;
+        this._render();
+    }
+
+    /** Sets the close response — emitted on dismissal (Escape / scrim click). */
+    setCloseResponse(id: string): void {
+        this._closeResponse = id;
+    }
+
+    // ── internals ──────────────────────────────────────────────────────────
+
+    /** A response button was activated: close, then emit `response`. */
+    private _activateResponse(info: ResponseInfo): void {
+        if (!info.enabled) return;
+        this._blockCloseResponse = true;
+        this.open = false;
+        this._blockCloseResponse = false;
+        this._emitResponse(info.id);
+    }
+
+    /** Dismissal (Escape / scrim) — close, then emit the close-response. */
+    private _dismiss(): void {
+        if (!this.open) return;
+        this.open = false;
+        if (this._blockCloseResponse) return;
+        this._emitResponse(this._closeResponse);
+    }
+
+    private _emitResponse(response: string): void {
+        this.dispatchEvent(new CustomEvent('response', { bubbles: true, detail: { response } }));
+    }
+
+    /** Move focus to the default response button (or the first enabled one). */
+    private _focusInitial(): void {
+        const target =
+            (this._defaultResponse ? this._byId.get(this._defaultResponse)?.button : undefined) ??
+            this._responses.find((r) => r.enabled)?.button;
+        target?.focus();
+    }
+
+    private _render(): void {
+        this.classList.toggle('open', this.open);
+
+        const heading = this.heading;
+        this._headingEl.textContent = heading;
+        this._headingEl.hidden = heading.length === 0;
+
+        const body = this.body;
+        this._bodyEl.textContent = body;
+        this._bodyEl.hidden = body.length === 0;
+
+        this._childEl.hidden = this._childEl.childElementCount === 0;
+
+        // Layout: stack vertically by default; lay out horizontally only when
+        // prefer-wide-layout is set and there are at most two responses (the
+        // AdwAlertDialog heuristic for keeping wide buttons readable).
+        const horizontal = this.preferWideLayout && this._responses.length <= 2;
+        this._responseAreaEl.classList.toggle('horizontal', horizontal);
+
+        // Reflect the default response on its button (suggested highlight) unless
+        // the response already carries an explicit appearance.
+        for (const info of this._responses) {
+            const isDefault = info.id === this._defaultResponse && info.appearance === 'default';
+            info.button.classList.toggle('default-response', isDefault);
+        }
+    }
+}
+
+customElements.define('adw-alert-response', AdwAlertResponse);
+customElements.define('adw-alert-dialog', AdwAlertDialog);

--- a/packages/web/adwaita-web/src/elements/adw-bottom-sheet.ts
+++ b/packages/web/adwaita-web/src/elements/adw-bottom-sheet.ts
@@ -1,0 +1,205 @@
+// <adw-bottom-sheet> — A content area with a sheet that slides up from the
+// bottom edge over the content (the web counterpart of Adw.BottomSheet). The
+// content is shown persistently; the sheet is displayed above it when `open` is
+// set, with an overlaid drag handle by default. When `modal` is set, a dimming
+// layer covers the content and dismisses the sheet on click (unless `can-close`
+// is false, in which case a close attempt is signalled instead).
+//
+// Children are declared as <adw-bottom-sheet-content> (the persistent content)
+// and <adw-bottom-sheet-sheet> (the slide-up sheet); both are consumed at
+// connect time. Unslotted children fall back to the content, mirroring the
+// AdwBottomSheet GtkBuildable default (omitting the child type sets content).
+//
+// Attributes:
+//   open             (boolean — whether the sheet is revealed; default closed)
+//   modal            (boolean — dim + block the content while open; default on)
+//   can-close        (boolean — user can dismiss via the handle / dimming / Esc;
+//                       default on. When off, a dismissal raises `close-attempt`
+//                       instead of closing — mirrors Adw.BottomSheet:can-close)
+//   show-drag-handle (boolean — overlay the drag handle on the sheet; default on)
+//
+// Events:
+//   `notify::open` (CustomEvent, bubbles, `detail = { open }`) when the revealed
+//     state changes — mirrors the Adw.BottomSheet `open` GObject property.
+//   `close-attempt` (CustomEvent, bubbles) when a dismissal is attempted while
+//     `can-close` is false — mirrors the Adw.BottomSheet `close-attempt` signal.
+//
+// Reference: refs/libadwaita/src/adw-bottom-sheet.c (AdwBottomSheet behaviour)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_bottom-sheet.scss
+// Copyright (c) 2023-2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** The persistent content. Child of <adw-bottom-sheet>; consumed at connect time. */
+export class AdwBottomSheetContent extends HTMLElement {}
+
+/** The slide-up sheet. Child of <adw-bottom-sheet>; consumed at connect time. */
+export class AdwBottomSheetSheet extends HTMLElement {}
+
+export class AdwBottomSheet extends HTMLElement {
+    private _initialized = false;
+    private _contentEl!: HTMLDivElement;
+    private _dimmingEl!: HTMLDivElement;
+    private _sheetEl!: HTMLDivElement;
+    private _dragHandleEl!: HTMLDivElement;
+
+    static get observedAttributes() {
+        return ['open', 'modal', 'can-close', 'show-drag-handle'];
+    }
+
+    /** Whether the sheet is revealed. */
+    get open(): boolean {
+        return this.hasAttribute('open');
+    }
+
+    set open(value: boolean) {
+        if (value) this.setAttribute('open', '');
+        else this.removeAttribute('open');
+    }
+
+    /** Whether the content is dimmed + blocked while the sheet is open. */
+    get modal(): boolean {
+        return this._boolAttr('modal');
+    }
+
+    set modal(value: boolean) {
+        this._setBoolAttr('modal', value);
+    }
+
+    /** Whether the user can dismiss the sheet (handle / dimming / Escape). */
+    get canClose(): boolean {
+        return this._boolAttr('can-close');
+    }
+
+    set canClose(value: boolean) {
+        this._setBoolAttr('can-close', value);
+    }
+
+    /** Whether the overlaid drag handle is shown. */
+    get showDragHandle(): boolean {
+        return this._boolAttr('show-drag-handle');
+    }
+
+    set showDragHandle(value: boolean) {
+        this._setBoolAttr('show-drag-handle', value);
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot declared children before taking over the subtree. The sheet
+        // and content are placed by slot; anything unslotted falls back to the
+        // content (the AdwBottomSheet GtkBuildable default).
+        const sheetChildren = this._collectSlot('adw-bottom-sheet-sheet', 'sheet');
+        const contentChildren = this._collectSlot('adw-bottom-sheet-content', 'content');
+        const claimed = new Set<Node>([...sheetChildren, ...contentChildren]);
+        const unslotted = Array.from(this.childNodes).filter((n) => !claimed.has(n));
+
+        // Persistent content layer.
+        this._contentEl = document.createElement('div');
+        this._contentEl.className = 'adw-bottom-sheet-content';
+        for (const child of contentChildren) this._contentEl.appendChild(child);
+        for (const child of unslotted) this._contentEl.appendChild(child);
+
+        // Dimming layer — covers the content while the sheet is open (modal).
+        // Clicking it dismisses the sheet (or raises close-attempt when locked).
+        this._dimmingEl = document.createElement('div');
+        this._dimmingEl.className = 'adw-bottom-sheet-dimming';
+        this._dimmingEl.addEventListener('click', () => this._attemptClose());
+
+        // The slide-up sheet with its overlaid drag handle.
+        this._sheetEl = document.createElement('div');
+        this._sheetEl.className = 'adw-bottom-sheet-sheet';
+
+        this._dragHandleEl = document.createElement('div');
+        this._dragHandleEl.className = 'adw-bottom-sheet-drag-handle';
+        this._dragHandleEl.setAttribute('role', 'button');
+        this._dragHandleEl.setAttribute('aria-label', 'Drag handle');
+        this._dragHandleEl.tabIndex = 0;
+        // The handle is the primary pointer affordance for closing the sheet.
+        this._dragHandleEl.addEventListener('click', () => this._attemptClose());
+        this._dragHandleEl.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                this._attemptClose();
+            }
+        });
+
+        const sheetBody = document.createElement('div');
+        sheetBody.className = 'adw-bottom-sheet-sheet-body';
+        for (const child of sheetChildren) sheetBody.appendChild(child);
+
+        this._sheetEl.append(this._dragHandleEl, sheetBody);
+
+        this.replaceChildren(this._contentEl, this._dimmingEl, this._sheetEl);
+
+        // Escape closes the sheet when open (mirrors AdwBottomSheet's Escape
+        // shortcut → maybe_close_cb).
+        this.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.open) {
+                event.stopPropagation();
+                this._attemptClose();
+            }
+        });
+
+        this._render();
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+        if (!this._initialized) return;
+        if (oldValue === newValue) return;
+        this._render();
+        if (name === 'open') {
+            this.dispatchEvent(new CustomEvent('notify::open', { bubbles: true, detail: { open: this.open } }));
+        }
+    }
+
+    private _attemptClose(): void {
+        if (!this.open) return;
+        if (!this.canClose) {
+            this.dispatchEvent(new CustomEvent('close-attempt', { bubbles: true }));
+            return;
+        }
+        // Keep the attribute in sync without re-entering the guarded callback
+        // (it no-ops on an unchanged value, but the notify::open fires from the
+        // attribute write below).
+        this.open = false;
+    }
+
+    private _render(): void {
+        this.classList.toggle('open', this.open);
+        this.classList.toggle('modal', this.modal);
+        this.classList.toggle('has-drag-handle', this.showDragHandle);
+
+        // The dimming layer is only meaningful while modal; it fades in with the
+        // sheet and is non-interactive when closed.
+        this._dimmingEl.classList.toggle('visible', this.open && this.modal);
+        this._dragHandleEl.hidden = !this.showDragHandle;
+    }
+
+    /** Read a boolean attribute that defaults to `true` when absent. */
+    private _boolAttr(name: string): boolean {
+        const value = this.getAttribute(name);
+        // Absent attribute → default on; explicit `="false"` → off.
+        if (value === null) return name === 'modal' || name === 'can-close' || name === 'show-drag-handle';
+        return value !== 'false';
+    }
+
+    private _setBoolAttr(name: string, value: boolean): void {
+        if (value) this.setAttribute(name, '');
+        else this.setAttribute(name, 'false');
+    }
+
+    /** Move declared slot children out of the light-DOM tree into a list. */
+    private _collectSlot(tag: string, slot: string): Node[] {
+        const byElement = Array.from(this.querySelectorAll(`:scope > ${tag}`)).flatMap((el) =>
+            Array.from(el.childNodes),
+        );
+        const bySlotAttr = Array.from(this.querySelectorAll(`:scope > [slot="${slot}"]`));
+        return [...byElement, ...bySlotAttr];
+    }
+}
+
+customElements.define('adw-bottom-sheet-content', AdwBottomSheetContent);
+customElements.define('adw-bottom-sheet-sheet', AdwBottomSheetSheet);
+customElements.define('adw-bottom-sheet', AdwBottomSheet);

--- a/packages/web/adwaita-web/src/elements/adw-carousel.ts
+++ b/packages/web/adwaita-web/src/elements/adw-carousel.ts
@@ -1,0 +1,321 @@
+// <adw-carousel> — a horizontally swipeable pager (the web counterpart of
+// Adw.Carousel). Pages are declared as direct children; the carousel lays them
+// out in a horizontal scroll-snap strip, tracks the fractional scroll position,
+// and exposes a `position` (fractional page index) + `n-pages`, mirroring the
+// AdwCarousel properties. Navigation: drag/scroll-snap (touch + trackpad),
+// optional scroll-wheel paging, and `scroll-to(index)`.
+//
+// Indicators are SEPARATE elements bound to a carousel (exactly as the native
+// Adw.CarouselIndicatorDots / Adw.CarouselIndicatorLines bind to an
+// Adw.Carousel via their `carousel` property): set `el.carousel = carouselEl`
+// or place a `for` attribute referencing the carousel's id. The indicator
+// listens to the carousel's `notify::position` / `notify::n-pages` events and
+// repaints; clicking an indicator scrolls the carousel to that page.
+//
+// adw-carousel
+//   Attributes: allow-scroll-wheel (bool, default present), allow-long-swipes
+//     (bool — a flick can skip multiple pages at once), position (number,
+//     fractional page index — reflected, settable to snap to a page).
+//   Events: `notify::position` (fractional scroll position changed),
+//     `notify::n-pages` (page count changed), `page-changed` (settled on a new
+//     page; `detail = { index }`) — mirroring the AdwCarousel signals the native
+//     story uses.
+// adw-carousel-indicator-dots / adw-carousel-indicator-lines
+//   Properties: carousel (the bound AdwCarousel element), or a `for` attribute
+//     with the carousel element's id.
+//
+// Reference: refs/libadwaita/src/adw-carousel.c (AdwCarousel behaviour)
+// Reference: refs/libadwaita/src/adw-carousel-indicator-dots.c
+//   (DOTS_RADIUS 3, DOTS_RADIUS_SELECTED 4, DOTS_OPACITY 0.3,
+//    DOTS_OPACITY_SELECTED 0.9, DOTS_SPACING 7)
+// Reference: refs/libadwaita/src/adw-carousel-indicator-lines.c
+//   (LINE_WIDTH 3, LINE_LENGTH 35, LINE_SPACING 5,
+//    LINE_OPACITY 0.3, LINE_OPACITY_ACTIVE 0.9)
+// Reference: refs/adwaita-web/adwaita-web/scss/_carousel_indicators.scss
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as Web Components for @gjsify/adwaita-web.
+
+/** Common surface an indicator binds to. The concrete element is AdwCarousel. */
+interface CarouselHost extends HTMLElement {
+    readonly nPages: number;
+    readonly position: number;
+    scrollToPage(index: number): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void;
+}
+
+export class AdwCarousel extends HTMLElement implements CarouselHost {
+    private _trackEl!: HTMLDivElement;
+    private _pages: HTMLElement[] = [];
+    private _position = 0;
+    private _scrollRaf = 0;
+    private _wheelAccum = 0;
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['allow-scroll-wheel', 'allow-long-swipes', 'position'];
+    }
+
+    /** Number of pages in the carousel. */
+    get nPages(): number {
+        return this._pages.length;
+    }
+
+    /** Fractional scroll position (0 = first page, 1 = second, …). */
+    get position(): number {
+        return this._position;
+    }
+
+    set position(value: number) {
+        const clamped = Math.min(Math.max(value, 0), Math.max(0, this.nPages - 1));
+        this.scrollToPage(Math.round(clamped));
+    }
+
+    /** Whether the scroll wheel navigates between pages. */
+    get allowScrollWheel(): boolean {
+        return this.hasAttribute('allow-scroll-wheel');
+    }
+
+    set allowScrollWheel(value: boolean) {
+        this.toggleAttribute('allow-scroll-wheel', value);
+    }
+
+    /** Whether a single flick can skip more than one page. */
+    get allowLongSwipes(): boolean {
+        return this.hasAttribute('allow-long-swipes');
+    }
+
+    set allowLongSwipes(value: boolean) {
+        this.toggleAttribute('allow-long-swipes', value);
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // The declared children become the carousel's pages. Snapshot them
+        // before we move them into the scroll track.
+        this._pages = Array.from(this.children).filter((c): c is HTMLElement => c instanceof HTMLElement);
+
+        this._trackEl = document.createElement('div');
+        this._trackEl.className = 'adw-carousel-track';
+        for (const page of this._pages) {
+            const slot = document.createElement('div');
+            slot.className = 'adw-carousel-page';
+            slot.appendChild(page);
+            this._trackEl.appendChild(slot);
+        }
+        this.replaceChildren(this._trackEl);
+
+        this._trackEl.addEventListener('scroll', this._onScroll, { passive: true });
+        this._trackEl.addEventListener('wheel', this._onWheel, { passive: false });
+
+        // Surface the page count once the DOM is wired so indicators can paint.
+        this.dispatchEvent(new CustomEvent('notify::n-pages', { bubbles: true, detail: { nPages: this.nPages } }));
+        this._emitPosition();
+    }
+
+    attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null) {
+        if (!this._initialized) return;
+        if (name === 'position' && newValue !== null) {
+            const next = Number.parseInt(newValue, 10);
+            if (!Number.isNaN(next) && next !== Math.round(this._position)) this.scrollToPage(next);
+        }
+        // allow-scroll-wheel / allow-long-swipes are read live in the handlers.
+    }
+
+    /** Scroll (snap) to the page at `index`, clamped to the valid range. */
+    scrollToPage(index: number): void {
+        if (!this._trackEl) return;
+        const clamped = Math.min(Math.max(index, 0), Math.max(0, this.nPages - 1));
+        const slot = this._trackEl.children[clamped] as HTMLElement | undefined;
+        if (!slot) return;
+        this._trackEl.scrollTo({ left: slot.offsetLeft, behavior: 'smooth' });
+    }
+
+    private _onScroll = (): void => {
+        if (this._scrollRaf) return;
+        this._scrollRaf = requestAnimationFrame(() => {
+            this._scrollRaf = 0;
+            this._updatePositionFromScroll();
+        });
+    };
+
+    private _onWheel = (event: WheelEvent): void => {
+        if (!this.allowScrollWheel || this.nPages === 0) return;
+        // A horizontal scroll already pans the snap strip natively; only the
+        // vertical wheel needs translating into page steps (mirrors AdwCarousel,
+        // which lets vertical scrolling page a horizontal carousel).
+        if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+        event.preventDefault();
+        this._wheelAccum += event.deltaY;
+        const threshold = 40;
+        if (Math.abs(this._wheelAccum) < threshold) return;
+        const step = this._wheelAccum > 0 ? 1 : -1;
+        this._wheelAccum = 0;
+        const current = Math.round(this._position);
+        const target = this.allowLongSwipes ? current + step * 1 : current + step;
+        this.scrollToPage(target);
+    };
+
+    private _updatePositionFromScroll(): void {
+        if (!this._trackEl) return;
+        const slotWidth = this._slotWidth();
+        if (slotWidth <= 0) return;
+        const next = this._trackEl.scrollLeft / slotWidth;
+        const settledBefore = Math.round(this._position);
+        this._position = next;
+        this._emitPosition();
+        const settledAfter = Math.round(next);
+        // Snap landed cleanly on a page boundary → page-changed (within 0.02 of
+        // an integer index, matching a finished scroll-snap).
+        if (settledAfter !== settledBefore && Math.abs(next - settledAfter) < 0.02) {
+            this.dispatchEvent(new CustomEvent('page-changed', { bubbles: true, detail: { index: settledAfter } }));
+        }
+    }
+
+    private _slotWidth(): number {
+        const first = this._trackEl?.children[0] as HTMLElement | undefined;
+        return first ? first.offsetWidth : 0;
+    }
+
+    private _emitPosition(): void {
+        this.dispatchEvent(new CustomEvent('notify::position', { bubbles: true, detail: { position: this._position } }));
+    }
+}
+
+/** Shared base for the dot / line indicator elements. */
+abstract class AdwCarouselIndicator extends HTMLElement {
+    protected _carousel: CarouselHost | null = null;
+    protected _initialized = false;
+
+    static get observedAttributes() {
+        return ['for'];
+    }
+
+    /** The bound carousel. Mirrors AdwCarouselIndicator*'s `carousel` property. */
+    get carousel(): CarouselHost | null {
+        return this._carousel;
+    }
+
+    set carousel(value: CarouselHost | null) {
+        if (value === this._carousel) return;
+        this._detach();
+        this._carousel = value;
+        this._attach();
+    }
+
+    connectedCallback() {
+        this._initialized = true;
+        if (!this._carousel) this._resolveForAttr();
+        this._attach();
+        this._render();
+    }
+
+    disconnectedCallback() {
+        this._detach();
+    }
+
+    attributeChangedCallback(name: string) {
+        if (name === 'for' && this._initialized) {
+            this._detach();
+            this._carousel = null;
+            this._resolveForAttr();
+            this._attach();
+            this._render();
+        }
+    }
+
+    private _resolveForAttr(): void {
+        const id = this.getAttribute('for');
+        if (!id) return;
+        const root = this.getRootNode() as Document | ShadowRoot;
+        const el = root.getElementById?.(id) ?? document.getElementById(id);
+        if (el instanceof AdwCarousel) this._carousel = el;
+    }
+
+    private _attach(): void {
+        if (!this._carousel || !this._initialized) return;
+        this._carousel.addEventListener('notify::position', this._onChange);
+        this._carousel.addEventListener('notify::n-pages', this._onChange);
+        this._render();
+    }
+
+    private _detach(): void {
+        if (!this._carousel) return;
+        this._carousel.removeEventListener('notify::position', this._onChange);
+        this._carousel.removeEventListener('notify::n-pages', this._onChange);
+    }
+
+    private _onChange = (): void => {
+        this._render();
+    };
+
+    protected nPages(): number {
+        return this._carousel?.nPages ?? 0;
+    }
+
+    protected position(): number {
+        return this._carousel?.position ?? 0;
+    }
+
+    protected goTo(index: number): void {
+        this._carousel?.scrollToPage(index);
+    }
+
+    protected abstract _render(): void;
+}
+
+export class AdwCarouselIndicatorDots extends AdwCarouselIndicator {
+    protected _render(): void {
+        renderIndicator(this, 'adw-carousel-dot', this.nPages(), this.position(), (i) => this.goTo(i));
+    }
+}
+
+export class AdwCarouselIndicatorLines extends AdwCarouselIndicator {
+    protected _render(): void {
+        renderIndicator(this, 'adw-carousel-line', this.nPages(), this.position(), (i) => this.goTo(i));
+    }
+}
+
+/**
+ * Shared rebuild for both indicator kinds: one child per page, the marker
+ * closest to the fractional position carries `.active`, and clicking scrolls
+ * the carousel. The dot/line look (size, growth, opacity ramp) is in SCSS; the
+ * `--adw-carousel-progress` custom property carries the per-marker proximity so
+ * the active marker can grow/brighten the way libadwaita lerps between the
+ * inactive and selected states.
+ */
+function renderIndicator(
+    host: HTMLElement,
+    markerClass: string,
+    nPages: number,
+    position: number,
+    onClick: (index: number) => void,
+): void {
+    if (host.childElementCount !== nPages) {
+        const markers: HTMLButtonElement[] = [];
+        for (let i = 0; i < nPages; i++) {
+            const marker = document.createElement('button');
+            marker.type = 'button';
+            marker.className = markerClass;
+            marker.setAttribute('aria-label', `Page ${i + 1}`);
+            marker.addEventListener('click', () => onClick(i));
+            markers.push(marker);
+        }
+        host.replaceChildren(...markers);
+    }
+    Array.from(host.children).forEach((child, i) => {
+        // Proximity in [0,1]: 1 on the focused page, ramping to 0 one page away
+        // (matches AdwCarousel's per-dot lerp progress = 1 - |position - i|).
+        const progress = Math.max(0, 1 - Math.abs(position - i));
+        const marker = child as HTMLElement;
+        marker.style.setProperty('--adw-carousel-progress', progress.toFixed(3));
+        marker.classList.toggle('active', progress > 0.5);
+        marker.setAttribute('aria-current', progress > 0.5 ? 'true' : 'false');
+    });
+}
+
+customElements.define('adw-carousel', AdwCarousel);
+customElements.define('adw-carousel-indicator-dots', AdwCarouselIndicatorDots);
+customElements.define('adw-carousel-indicator-lines', AdwCarouselIndicatorLines);

--- a/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
@@ -1,0 +1,222 @@
+// <adw-inline-view-switcher> — A compact, toolbar-friendly view switcher (the
+// web counterpart of Adw.InlineViewSwitcher). It pairs a toggle-group-style
+// switcher bar with a stack of pages: each declared <adw-view-stack-page> child
+// (with a `title` and/or `icon-name` attribute plus arbitrary content) becomes a
+// toggle in the bar and a panel in the stack, and exactly one page is visible at
+// a time. The toggles can show labels, icons, or both via `display-mode`, just
+// like the native widget's AdwInlineViewSwitcherDisplayMode.
+// Attributes:
+//   active (zero-based index of the visible page, default 0)
+//   display-mode (labels | icons | both, default both) — what the toggles show
+//   flat / round (mirroring the Adw.InlineViewSwitcher `.flat` / `.round` style
+//     classes, which it inherits from Adw.ToggleGroup)
+// Events:
+//   `notify::active` (CustomEvent, bubbles, `detail = { active }`) when the
+//     visible page changes — mirrors selecting a page in the paired Adw.ViewStack.
+//   `notify::display-mode` (CustomEvent, bubbles, `detail = { displayMode }`)
+//     when the display mode changes — mirrors the Adw.InlineViewSwitcher
+//     `display-mode` GObject property.
+// Reference: refs/libadwaita/src/adw-inline-view-switcher.c (AdwInlineViewSwitcher behaviour)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_toggle-group.scss (inline-view-switcher > toggle-group)
+// Reference: refs/adwaita-web/adwaita-web/scss/_viewswitcher.scss
+// Copyright (c) 2023 Maximiliano Sandoval / 2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** The three display modes, mirroring AdwInlineViewSwitcherDisplayMode. */
+const DISPLAY_MODES = ['labels', 'icons', 'both'] as const;
+type DisplayMode = (typeof DISPLAY_MODES)[number];
+
+/** A single page. Children of <adw-inline-view-switcher>; consumed at connect time. */
+export class AdwViewStackPage extends HTMLElement {
+    static get observedAttributes() {
+        return ['title', 'icon-name'];
+    }
+}
+
+export class AdwInlineViewSwitcher extends HTMLElement {
+    private _groupEl!: HTMLDivElement;
+    private _pagesEl!: HTMLDivElement;
+    private _toggles: HTMLButtonElement[] = [];
+    private _pages: HTMLDivElement[] = [];
+    private _active = 0;
+    private _displayMode: DisplayMode = 'both';
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['active', 'display-mode', 'flat', 'round'];
+    }
+
+    /** Zero-based index of the visible page. */
+    get active(): number {
+        return this._active;
+    }
+
+    set active(value: number) {
+        this.setAttribute('active', String(value));
+    }
+
+    /** What the toggles display: 'labels', 'icons' or 'both'. */
+    get displayMode(): DisplayMode {
+        return this._displayMode;
+    }
+
+    set displayMode(value: DisplayMode) {
+        this.setAttribute('display-mode', value);
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared <adw-view-stack-page> children before we take
+        // over the subtree — their title / icon-name + content become the
+        // rendered toggles and panels.
+        const pages = Array.from(this.querySelectorAll('adw-view-stack-page')) as AdwViewStackPage[];
+
+        // The switcher bar — a toggle-group of one toggle per page.
+        this._groupEl = document.createElement('div');
+        this._groupEl.className = 'adw-inline-view-switcher-group';
+        this._groupEl.setAttribute('role', 'tablist');
+
+        this._pagesEl = document.createElement('div');
+        this._pagesEl.className = 'adw-inline-view-switcher-pages';
+
+        this._toggles = [];
+        this._pages = [];
+
+        pages.forEach((page, index) => {
+            const title = page.getAttribute('title') ?? '';
+            const icon = (page.getAttribute('icon-name') ?? '').replace(/-symbolic$/, '');
+
+            const toggle = document.createElement('button');
+            toggle.type = 'button';
+            toggle.className = 'adw-inline-view-switcher-toggle';
+            toggle.setAttribute('role', 'tab');
+            // The toggle stores both title + icon; _render() shows the parts the
+            // current display mode calls for (mirrors libadwaita rebuilding the
+            // toggle child on a display-mode change).
+            toggle.dataset.title = title;
+            toggle.dataset.icon = icon;
+
+            const iconEl = document.createElement('span');
+            iconEl.className = `adw-icon${icon ? ` adw-icon--${icon}` : ''} adw-inline-view-switcher-icon`;
+            iconEl.setAttribute('aria-hidden', 'true'); // decorative (mask-image only)
+            toggle.appendChild(iconEl);
+
+            const labelEl = document.createElement('span');
+            labelEl.className = 'adw-inline-view-switcher-label';
+            labelEl.textContent = title;
+            toggle.appendChild(labelEl);
+
+            toggle.addEventListener('click', () => this._selectIndex(index));
+            this._groupEl.appendChild(toggle);
+            this._toggles.push(toggle);
+
+            // The page content area — the declared element's children are moved
+            // into a panel that the switcher toggles visible.
+            const panel = document.createElement('div');
+            panel.className = 'adw-inline-view-switcher-page';
+            panel.setAttribute('role', 'tabpanel');
+            for (const child of Array.from(page.childNodes)) panel.appendChild(child);
+            this._pagesEl.appendChild(panel);
+            this._pages.push(panel);
+        });
+
+        this.replaceChildren(this._groupEl, this._pagesEl);
+
+        this._active = this._readActiveAttr();
+        this._displayMode = this._readDisplayModeAttr();
+        this._render();
+    }
+
+    attributeChangedCallback(name: string) {
+        if (!this._initialized) return;
+        if (name === 'active') {
+            const next = this._readActiveAttr();
+            if (next !== this._active) {
+                this._active = next;
+                this._render();
+            }
+            return;
+        }
+        if (name === 'display-mode') {
+            const next = this._readDisplayModeAttr();
+            if (next !== this._displayMode) {
+                this._displayMode = next;
+                this._render();
+            }
+            return;
+        }
+        // flat / round are styling-only.
+        this._render();
+    }
+
+    private _readActiveAttr(): number {
+        const raw = Number.parseInt(this.getAttribute('active') ?? '0', 10);
+        if (Number.isNaN(raw)) return 0;
+        const max = Math.max(0, this._pages.length - 1);
+        return Math.min(Math.max(raw, 0), max);
+    }
+
+    private _readDisplayModeAttr(): DisplayMode {
+        const raw = this.getAttribute('display-mode') ?? 'both';
+        return (DISPLAY_MODES as readonly string[]).includes(raw) ? (raw as DisplayMode) : 'both';
+    }
+
+    private _selectIndex(index: number): void {
+        if (index === this._active) return;
+        this._active = index;
+        // Keep the attribute in sync without re-entering via the guarded
+        // attributeChangedCallback (value already matches, so it no-ops).
+        this.setAttribute('active', String(index));
+        this._render();
+        this.dispatchEvent(new CustomEvent('notify::active', { bubbles: true, detail: { active: index } }));
+    }
+
+    private _render(): void {
+        this.classList.toggle('flat', this.hasAttribute('flat'));
+        this.classList.toggle('round', this.hasAttribute('round'));
+
+        // The bar carries the active display mode as a class — mirrors
+        // libadwaita's inline-view-switcher > toggle-group.{labels,icons,both}.
+        for (const mode of DISPLAY_MODES) this._groupEl.classList.toggle(mode, mode === this._displayMode);
+
+        const showIcon = this._displayMode !== 'labels';
+        const showLabel = this._displayMode !== 'icons';
+
+        this._toggles.forEach((toggle, index) => {
+            const isActive = index === this._active;
+            toggle.classList.toggle('active', isActive);
+            toggle.setAttribute('aria-selected', String(isActive));
+            toggle.tabIndex = isActive ? 0 : -1;
+
+            const iconEl = toggle.querySelector('.adw-inline-view-switcher-icon') as HTMLElement | null;
+            const labelEl = toggle.querySelector('.adw-inline-view-switcher-label') as HTMLElement | null;
+            const hasIcon = (toggle.dataset.icon ?? '').length > 0;
+            const title = toggle.dataset.title ?? '';
+
+            if (iconEl) iconEl.hidden = !showIcon || !hasIcon;
+            if (labelEl) labelEl.hidden = !showLabel || title.length === 0;
+
+            // In icons-only mode the toggle has no visible text — surface the
+            // title as an accessible name + a hover tooltip (the native widget
+            // sets the toggle tooltip to the page title in ICONS mode).
+            if (!showLabel && title) {
+                toggle.setAttribute('aria-label', title);
+                toggle.title = title;
+            } else {
+                toggle.removeAttribute('aria-label');
+                toggle.removeAttribute('title');
+            }
+        });
+
+        this._pages.forEach((panel, index) => {
+            const isActive = index === this._active;
+            panel.classList.toggle('active-view', isActive);
+            panel.hidden = !isActive;
+        });
+    }
+}
+
+customElements.define('adw-view-stack-page', AdwViewStackPage);
+customElements.define('adw-inline-view-switcher', AdwInlineViewSwitcher);

--- a/packages/web/adwaita-web/src/elements/adw-navigation-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-view.ts
@@ -1,0 +1,344 @@
+// <adw-navigation-view> — A page-based navigation container (the web
+// counterpart of Adw.NavigationView). It presents one page at a time and keeps
+// a navigation stack controlled with push()/pop()/replace(); the visible page
+// fills the view. Only <adw-navigation-page> children are managed.
+//
+// Pages are declared as <adw-navigation-page> children (each with a `title` and
+// optional `tag` attribute). The view snapshots them at connect time. Like
+// Adw.NavigationView, a statically-added page is kept around but not shown until
+// pushed (the first added page is pushed automatically). push() accepts a page
+// element OR an existing page's tag (push-by-tag); a dynamically-pushed page is
+// removed from the DOM again once it is popped.
+//
+// Header Bar integration: mirroring libadwaita, when the visible page is above
+// the root the view surfaces an automatic back button at the start of that
+// page's header bar (the first <adw-header-bar> found in the page content),
+// unless the page sets `no-back-button` (the equivalent of
+// AdwHeaderBar:show-back-button = FALSE) or `can-pop` is "false".
+//
+// Attributes (on <adw-navigation-view>):
+//   animate-transitions (boolean, default present — slide animation on push/pop;
+//     mirrors Adw.NavigationView:animate-transitions)
+// Attributes (on <adw-navigation-page>):
+//   title (the page title — shown in the header bar's window title)
+//   tag (a unique identifier for push-by-tag)
+//   can-pop ("false" disables the back button / popping; mirrors
+//     AdwNavigationPage:can-pop)
+//   no-back-button (boolean — suppresses the automatic back button only)
+// Events (CustomEvent, bubbles):
+//   `pushed` (detail = { tag }) after a page is pushed — mirrors
+//     AdwNavigationView::pushed.
+//   `popped` (detail = { tag }) after a page is popped — mirrors
+//     AdwNavigationView::popped.
+//   `replaced` after the whole stack is replaced — mirrors
+//     AdwNavigationView::replaced.
+//   `notify::visible-page` (detail = { tag }) whenever the visible page changes
+//     — mirrors the Adw.NavigationView:visible-page property.
+// Reference: refs/libadwaita/src/adw-navigation-view.c (AdwNavigationView behaviour)
+// Reference: refs/adwaita-web/adwaita-web/docs/widgets/navigationview.md
+// Copyright (c) 2022-2023 Purism SPC / GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** A single navigation page. Children of <adw-navigation-view>. */
+export class AdwNavigationPage extends HTMLElement {
+    static get observedAttributes() {
+        return ['title', 'tag', 'can-pop', 'no-back-button'];
+    }
+
+    get title(): string {
+        return this.getAttribute('title') ?? '';
+    }
+
+    set title(value: string) {
+        this.setAttribute('title', value);
+    }
+
+    get tag(): string | null {
+        return this.getAttribute('tag');
+    }
+
+    set tag(value: string | null) {
+        if (value === null) this.removeAttribute('tag');
+        else this.setAttribute('tag', value);
+    }
+
+    /** Whether the page can be popped (and thus shows a back button). */
+    get canPop(): boolean {
+        return this.getAttribute('can-pop') !== 'false';
+    }
+
+    set canPop(value: boolean) {
+        this.setAttribute('can-pop', value ? 'true' : 'false');
+    }
+}
+
+export class AdwNavigationView extends HTMLElement {
+    private _pagesEl!: HTMLDivElement;
+    // Every page known to the view (static + dynamically pushed), in DOM order.
+    private _pages: AdwNavigationPage[] = [];
+    // The navigation stack — references into _pages, bottom-first.
+    private _stack: AdwNavigationPage[] = [];
+    // Pages added dynamically via push() (destroyed when popped off).
+    private _dynamic = new Set<AdwNavigationPage>();
+    // The back button injected into each visible page (so we can remove it).
+    private _backButtons = new WeakMap<AdwNavigationPage, HTMLElement>();
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['animate-transitions'];
+    }
+
+    /** Whether push/pop transitions are animated. */
+    get animateTransitions(): boolean {
+        // Absent attribute defaults to true (matches Adw.NavigationView).
+        return this.getAttribute('animate-transitions') !== 'false';
+    }
+
+    set animateTransitions(value: boolean) {
+        this.setAttribute('animate-transitions', value ? 'true' : 'false');
+    }
+
+    /** The currently-visible page (top of the stack), or null when empty. */
+    get visiblePage(): AdwNavigationPage | null {
+        return this._stack.length > 0 ? this._stack[this._stack.length - 1] : null;
+    }
+
+    /** The tag of the visible page, or null. */
+    get visiblePageTag(): string | null {
+        return this.visiblePage?.tag ?? null;
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared <adw-navigation-page> children — they become the
+        // statically-added pages. The first one is pushed automatically.
+        const pages = Array.from(this.querySelectorAll(':scope > adw-navigation-page')) as AdwNavigationPage[];
+
+        this._pagesEl = document.createElement('div');
+        this._pagesEl.className = 'adw-navigation-view-pages';
+
+        this._pages = [];
+        this._stack = [];
+
+        for (const page of pages) {
+            page.classList.add('adw-navigation-page');
+            this._pagesEl.appendChild(page);
+            this._pages.push(page);
+        }
+
+        this.replaceChildren(this._pagesEl);
+
+        // Auto-push the first added page (Adw.NavigationView behaviour).
+        if (this._pages.length > 0) {
+            this._stack.push(this._pages[0]);
+        }
+
+        this._syncClasses();
+        this._render();
+    }
+
+    attributeChangedCallback() {
+        if (!this._initialized) return;
+        // animate-transitions only affects future transitions; just keep the
+        // class in sync so CSS can gate the slide animation.
+        this._syncClasses();
+    }
+
+    /**
+     * Add a static page without pushing it (mirrors AdwNavigationView.add). The
+     * view keeps a reference; the page becomes reachable via push-by-tag. Named
+     * `addPage` rather than `add` to avoid clashing with any DOM method.
+     */
+    addPage(page: AdwNavigationPage): void {
+        if (this._pages.includes(page)) return;
+        page.classList.add('adw-navigation-page');
+        this._pagesEl.appendChild(page);
+        this._pages.push(page);
+        this._render();
+    }
+
+    /**
+     * Remove a static page (mirrors AdwNavigationView.remove). Named `removePage`
+     * to avoid overriding HTMLElement.remove() (which takes no arguments).
+     */
+    removePage(page: AdwNavigationPage): void {
+        if (this._stack.includes(page)) return; // can't remove a page on the stack
+        const index = this._pages.indexOf(page);
+        if (index === -1) return;
+        this._pages.splice(index, 1);
+        this._dynamic.delete(page);
+        if (page.parentNode === this._pagesEl) this._pagesEl.removeChild(page);
+        this._render();
+    }
+
+    /**
+     * Push a page onto the navigation stack (mirrors AdwNavigationView.push).
+     * Accepts a page element or, when given a string, the tag of a known page
+     * (push-by-tag, mirrors AdwNavigationView.push_by_tag). A page that is not
+     * already known is added dynamically and destroyed when it is popped.
+     */
+    push(pageOrTag: AdwNavigationPage | string): void {
+        const page = this._resolvePage(pageOrTag);
+        if (!page) {
+            console.warn(`[adw-navigation-view] No page found for "${String(pageOrTag)}"`);
+            return;
+        }
+        if (this._stack.includes(page)) {
+            console.warn('[adw-navigation-view] Page is already in the navigation stack');
+            return;
+        }
+        if (!this._pages.includes(page)) {
+            // A brand-new dynamic page — keep a reference + mark for cleanup.
+            page.classList.add('adw-navigation-page');
+            this._pagesEl.appendChild(page);
+            this._pages.push(page);
+            this._dynamic.add(page);
+        }
+        this._stack.push(page);
+        this._render();
+        this.dispatchEvent(new CustomEvent('pushed', { bubbles: true, detail: { tag: page.tag } }));
+        this.dispatchEvent(new CustomEvent('notify::visible-page', { bubbles: true, detail: { tag: page.tag } }));
+    }
+
+    /**
+     * Pop the visible page off the stack (mirrors AdwNavigationView.pop).
+     * Returns true when a page was popped. A dynamically-pushed page is removed
+     * from the DOM. The root page cannot be popped.
+     */
+    pop(): boolean {
+        if (this._stack.length <= 1) return false;
+        const visible = this.visiblePage;
+        if (visible && !visible.canPop) return false;
+
+        const popped = this._stack.pop() as AdwNavigationPage;
+        // Destroy dynamically-pushed pages once they leave the stack.
+        if (this._dynamic.has(popped)) {
+            this._dynamic.delete(popped);
+            const index = this._pages.indexOf(popped);
+            if (index !== -1) this._pages.splice(index, 1);
+            if (popped.parentNode === this._pagesEl) this._pagesEl.removeChild(popped);
+        }
+        this._render();
+        this.dispatchEvent(new CustomEvent('popped', { bubbles: true, detail: { tag: popped.tag } }));
+        const next = this.visiblePage;
+        this.dispatchEvent(new CustomEvent('notify::visible-page', { bubbles: true, detail: { tag: next?.tag ?? null } }));
+        return true;
+    }
+
+    /** Pop every page down to (and including pushing) the given tag's page. */
+    popToTag(tag: string): boolean {
+        const target = this._pages.find((p) => p.tag === tag);
+        if (!target) return false;
+        const index = this._stack.indexOf(target);
+        if (index === -1 || index === this._stack.length - 1) return false;
+        let popped = false;
+        while (this._stack.length - 1 > index) {
+            if (!this.pop()) break;
+            popped = true;
+        }
+        return popped;
+    }
+
+    /**
+     * Replace the whole navigation stack with the given pages (mirrors
+     * AdwNavigationView.replace). The last page becomes visible.
+     */
+    replace(pages: Array<AdwNavigationPage | string>): void {
+        // Clear the current stack first (without firing popped events — replace
+        // is its own signal in libadwaita).
+        for (const page of this._stack) {
+            if (this._dynamic.has(page)) {
+                this._dynamic.delete(page);
+                const index = this._pages.indexOf(page);
+                if (index !== -1) this._pages.splice(index, 1);
+                if (page.parentNode === this._pagesEl) this._pagesEl.removeChild(page);
+            }
+        }
+        this._stack = [];
+
+        for (const entry of pages) {
+            const page = this._resolvePage(entry);
+            if (!page) continue;
+            if (!this._pages.includes(page)) {
+                page.classList.add('adw-navigation-page');
+                this._pagesEl.appendChild(page);
+                this._pages.push(page);
+                this._dynamic.add(page);
+            }
+            this._stack.push(page);
+        }
+
+        this._render();
+        this.dispatchEvent(new CustomEvent('replaced', { bubbles: true }));
+        this.dispatchEvent(
+            new CustomEvent('notify::visible-page', { bubbles: true, detail: { tag: this.visiblePageTag } }),
+        );
+    }
+
+    private _resolvePage(pageOrTag: AdwNavigationPage | string): AdwNavigationPage | null {
+        if (typeof pageOrTag === 'string') {
+            return this._pages.find((p) => p.tag === pageOrTag) ?? null;
+        }
+        return pageOrTag;
+    }
+
+    private _syncClasses(): void {
+        this.classList.toggle('animated', this.animateTransitions);
+    }
+
+    private _render(): void {
+        const visible = this.visiblePage;
+
+        for (const page of this._pages) {
+            const isVisible = page === visible;
+            page.classList.toggle('visible-page', isVisible);
+            page.hidden = !isVisible;
+            // The back button only belongs on the visible page; clean up the
+            // others so a stale button never lingers when the stack shrinks.
+            if (!isVisible) this._removeBackButton(page);
+        }
+
+        if (visible) this._syncBackButton(visible);
+    }
+
+    /** Inject (or remove) the automatic back button on the visible page. */
+    private _syncBackButton(page: AdwNavigationPage): void {
+        // Pop is possible only when there is a page below this one on the stack.
+        const poppable = this._stack.indexOf(page) > 0 && page.canPop && !page.hasAttribute('no-back-button');
+        if (!poppable) {
+            this._removeBackButton(page);
+            return;
+        }
+        if (this._backButtons.has(page)) return;
+
+        // Find the page's header bar's start section. We surface the button into
+        // the first <adw-header-bar> inside the page content, the way
+        // AdwHeaderBar grows a back button when placed inside an AdwNavigationView.
+        const headerBar = page.querySelector('adw-header-bar') as HTMLElement | null;
+        if (!headerBar) return;
+        const start = (headerBar as { startSection?: HTMLElement | null }).startSection ?? null;
+        if (!start) return;
+
+        const back = document.createElement('adw-button');
+        back.classList.add('adw-navigation-back-button');
+        back.setAttribute('icon', 'go-previous');
+        back.setAttribute('flat', '');
+        back.setAttribute('tooltip', 'Back');
+        back.addEventListener('click', () => this.pop());
+        // Place the back button at the very start of the header.
+        start.insertBefore(back, start.firstChild);
+        this._backButtons.set(page, back);
+    }
+
+    private _removeBackButton(page: AdwNavigationPage): void {
+        const back = this._backButtons.get(page);
+        if (!back) return;
+        if (back.parentNode) back.parentNode.removeChild(back);
+        this._backButtons.delete(page);
+    }
+}
+
+customElements.define('adw-navigation-page', AdwNavigationPage);
+customElements.define('adw-navigation-view', AdwNavigationView);

--- a/packages/web/adwaita-web/src/elements/adw-preferences-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-preferences-dialog.ts
@@ -1,0 +1,240 @@
+// <adw-preferences-dialog> — A modal preferences dialog (the web counterpart of
+// Adw.PreferencesDialog). It is a centred floating dialog over a full-cover
+// scrim, hosting one or more <adw-preferences-page> children — each a scrollable
+// clamp of <adw-preferences-group> boxed lists — under a flat header bar that
+// shows the dialog title and a trailing close button.
+//
+// Pages are declared as <adw-preferences-page> children (each with optional
+// `title` / `icon-name` attributes + arbitrary group content); the dialog
+// snapshots them at connect time and stacks their content in the scrolled body.
+// (Adw shows a view-switcher when there is more than one page and the window is
+// wide; the web port renders the pages stacked, matching the single-page common
+// case the storybook exercises.)
+//
+// Like Adw.Dialog the dialog starts hidden; `present()` / setting the `open`
+// attribute reveals it. It is dismissed by Escape, by clicking the scrim, or by
+// the header close button — each routed through the same close path. When
+// `can-close` is false a dismissal raises `close-attempt` instead of closing,
+// mirroring Adw.Dialog:can-close / ::close-attempt. The content width follows
+// the `content-width` attribute (Adw.Dialog:content-width, default 640 — the
+// AdwPreferencesDialog template default).
+//
+// Attributes:
+//   title         (the dialog title shown in the header — Adw.Dialog:title)
+//   open          (boolean — whether the dialog is revealed; default hidden)
+//   can-close     (boolean — user can dismiss via scrim / Escape / close button;
+//                    default on. When off a dismissal raises `close-attempt`
+//                    instead — mirrors Adw.Dialog:can-close)
+//   content-width (the dialog's preferred width in px; default 640)
+//
+// Events:
+//   `notify::open` (CustomEvent, bubbles, `detail = { open }`) when the revealed
+//     state changes — mirrors the Adw.Dialog `open`-ness (presented/closed).
+//   `closed` (CustomEvent, bubbles) when the dialog finishes closing — mirrors
+//     the Adw.Dialog `closed` signal.
+//   `close-attempt` (CustomEvent, bubbles) when a dismissal is attempted while
+//     `can-close` is false — mirrors the Adw.Dialog `close-attempt` signal.
+//
+// Reference: refs/libadwaita/src/adw-preferences-dialog.c (AdwPreferencesDialog)
+// Reference: refs/libadwaita/src/adw-preferences-dialog.ui (toolbar/title layout)
+// Reference: refs/libadwaita/src/adw-dialog.c (present/close/can-close, Escape)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_dialogs.scss (floating sheet)
+// Copyright (c) 2023-2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+const DEFAULT_CONTENT_WIDTH = 640;
+
+/**
+ * A single preferences page. Child of <adw-preferences-dialog>; consumed at
+ * connect time. Carries optional `title` / `icon-name` attributes and any
+ * <adw-preferences-group> content — mirrors Adw.PreferencesPage.
+ */
+export class AdwPreferencesPage extends HTMLElement {
+    static get observedAttributes() {
+        return ['title', 'icon-name', 'open'];
+    }
+}
+
+export class AdwPreferencesDialog extends HTMLElement {
+    private _initialized = false;
+    private _scrimEl!: HTMLDivElement;
+    private _dialogEl!: HTMLDivElement;
+    private _titleEl!: HTMLSpanElement;
+    private _bodyEl!: HTMLDivElement;
+    private _closeBtn!: HTMLButtonElement;
+
+    static get observedAttributes() {
+        return ['title', 'open', 'can-close', 'content-width'];
+    }
+
+    /** Whether the dialog is revealed. */
+    get open(): boolean {
+        return this.hasAttribute('open');
+    }
+
+    set open(value: boolean) {
+        if (value) this.setAttribute('open', '');
+        else this.removeAttribute('open');
+    }
+
+    /** Whether the user can dismiss the dialog (scrim / Escape / close button). */
+    get canClose(): boolean {
+        const value = this.getAttribute('can-close');
+        // Absent → default on; explicit `="false"` → off.
+        if (value === null) return true;
+        return value !== 'false';
+    }
+
+    set canClose(value: boolean) {
+        if (value) this.setAttribute('can-close', '');
+        else this.setAttribute('can-close', 'false');
+    }
+
+    /** The dialog's preferred content width in px (Adw.Dialog:content-width). */
+    get contentWidth(): number {
+        const raw = Number.parseInt(this.getAttribute('content-width') ?? '', 10);
+        return Number.isNaN(raw) ? DEFAULT_CONTENT_WIDTH : raw;
+    }
+
+    set contentWidth(value: number) {
+        this.setAttribute('content-width', String(value));
+    }
+
+    /** Reveal the dialog (mirrors Adw.Dialog.present). */
+    present(): void {
+        this.open = true;
+    }
+
+    /** Dismiss the dialog, respecting `can-close` (mirrors Adw.Dialog.close). */
+    close(): void {
+        this._attemptClose();
+    }
+
+    /** Dismiss the dialog regardless of `can-close` (mirrors Adw.Dialog.force_close). */
+    forceClose(): void {
+        if (!this.open) return;
+        this.open = false;
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared pages before taking over the subtree. Each page's
+        // content (its groups) is stacked in the scrolled body; any unwrapped
+        // children fall back to the body too (Adw.PreferencesDialog's buildable
+        // default adds a child as a page).
+        const pages = Array.from(this.querySelectorAll(':scope > adw-preferences-page')) as AdwPreferencesPage[];
+        const pageContent = pages.flatMap((page) => Array.from(page.childNodes));
+        const claimed = new Set<Node>([...pages, ...pageContent]);
+        const unwrapped = Array.from(this.childNodes).filter((node) => !claimed.has(node));
+
+        // Full-cover scrim — clicking it dismisses the dialog (or raises
+        // close-attempt when locked).
+        this._scrimEl = document.createElement('div');
+        this._scrimEl.className = 'adw-preferences-dialog-scrim';
+        this._scrimEl.addEventListener('click', () => this._attemptClose());
+
+        // The centred dialog box: a flat header bar (title + close button) above
+        // a scrolled preferences body.
+        this._dialogEl = document.createElement('div');
+        this._dialogEl.className = 'adw-preferences-dialog-box';
+        this._dialogEl.setAttribute('role', 'dialog');
+        this._dialogEl.setAttribute('aria-modal', 'true');
+        // Clicks inside the dialog must not bubble to the scrim's dismiss handler.
+        this._dialogEl.addEventListener('click', (event) => event.stopPropagation());
+
+        const header = document.createElement('div');
+        header.className = 'adw-preferences-dialog-header';
+
+        // A leading spacer keeps the title visually centred against the trailing
+        // close button (the AdwHeaderBar `centering-policy: strict` behaviour).
+        const leading = document.createElement('div');
+        leading.className = 'adw-preferences-dialog-header-side';
+
+        this._titleEl = document.createElement('span');
+        this._titleEl.className = 'adw-preferences-dialog-title';
+
+        const trailing = document.createElement('div');
+        trailing.className = 'adw-preferences-dialog-header-side adw-preferences-dialog-header-side--end';
+
+        this._closeBtn = document.createElement('button');
+        this._closeBtn.type = 'button';
+        this._closeBtn.className = 'adw-preferences-dialog-close';
+        this._closeBtn.setAttribute('aria-label', 'Close');
+        // No symbolic close icon ships in @gjsify/adwaita-icons; draw the "×"
+        // glyph in CSS (same approach as <adw-tab-view>'s close affordance).
+        this._closeBtn.addEventListener('click', () => this._attemptClose());
+        trailing.appendChild(this._closeBtn);
+
+        header.append(leading, this._titleEl, trailing);
+
+        // Scrolled body — a clamped column of the declared pages' content.
+        this._bodyEl = document.createElement('div');
+        this._bodyEl.className = 'adw-preferences-dialog-body';
+
+        const clamp = document.createElement('div');
+        clamp.className = 'adw-preferences-dialog-pages';
+        for (const child of pageContent) clamp.appendChild(child);
+        for (const child of unwrapped) clamp.appendChild(child);
+        this._bodyEl.appendChild(clamp);
+
+        this._dialogEl.append(header, this._bodyEl);
+
+        this.replaceChildren(this._scrimEl, this._dialogEl);
+
+        // Escape closes the dialog while open (mirrors Adw.Dialog's Escape
+        // shortcut → maybe_close_cb). The element is focusable so it can receive
+        // the key event when the dialog has focus.
+        if (!this.hasAttribute('tabindex')) this.tabIndex = -1;
+        this.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && this.open) {
+                event.stopPropagation();
+                this._attemptClose();
+            }
+        });
+
+        this._render();
+    }
+
+    attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+        if (!this._initialized) return;
+        if (oldValue === newValue) return;
+        this._render();
+        if (name === 'open') {
+            this.dispatchEvent(new CustomEvent('notify::open', { bubbles: true, detail: { open: this.open } }));
+            if (!this.open) this.dispatchEvent(new CustomEvent('closed', { bubbles: true }));
+        }
+    }
+
+    private _attemptClose(): void {
+        if (!this.open) return;
+        if (!this.canClose) {
+            this.dispatchEvent(new CustomEvent('close-attempt', { bubbles: true }));
+            return;
+        }
+        // Drives attributeChangedCallback → notify::open + closed.
+        this.open = false;
+    }
+
+    private _render(): void {
+        this.classList.toggle('open', this.open);
+
+        const title = this.getAttribute('title') ?? '';
+        this._titleEl.textContent = title;
+
+        this._dialogEl.style.setProperty('--adw-dialog-content-width', `${this.contentWidth}px`);
+
+        // While locked the close button has no effect; reflect that visually +
+        // for assistive tech.
+        const locked = !this.canClose;
+        this._closeBtn.disabled = locked;
+        this._closeBtn.classList.toggle('locked', locked);
+
+        // Move focus into the dialog on present so Escape works immediately.
+        if (this.open) this.focus();
+    }
+}
+
+customElements.define('adw-preferences-page', AdwPreferencesPage);
+customElements.define('adw-preferences-dialog', AdwPreferencesDialog);

--- a/packages/web/adwaita-web/src/elements/adw-sidebar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-sidebar.ts
@@ -1,0 +1,238 @@
+// <adw-sidebar> — A selectable navigation sidebar (the web counterpart of
+// Adw.Sidebar). It holds <adw-sidebar-section> groups, each of which holds
+// <adw-sidebar-item> children (icon + title + optional subtitle). Zero or one
+// item is selected at a time; clicking an item selects it and activates it. In
+// `sidebar` mode it renders as a flat navigation list (the AdwSidebar
+// `navigation-sidebar`); in `page` mode it renders as boxed lists with a
+// chevron arrow on each row (the AdwPreferencesPage look the native widget
+// switches to when collapsed).
+// Sub-elements (declared as children, consumed at connect time — mirrors
+// adw-tab-page in adw-tab-view):
+//   <adw-sidebar-section title="…"> — a titled group of items. An untitled
+//     section renders a separator before its rows (first section: nothing),
+//     mirroring AdwSidebar's stack header (title vs separator child).
+//   <adw-sidebar-item title="…" subtitle="…" icon-name="…"> — one row.
+// Attributes (on <adw-sidebar>):
+//   mode (sidebar | page, default sidebar) — mirrors Adw.Sidebar:mode.
+//   selected (zero-based flat item index, default 0; -1 = no selection,
+//     mirroring Gtk.INVALID_LIST_POSITION) — mirrors Adw.Sidebar:selected.
+// Events:
+//   `notify::selected` (CustomEvent, bubbles, `detail = { selected }`) when the
+//     selected index changes — mirrors the Adw.Sidebar:selected property.
+//   `activated` (CustomEvent, bubbles, `detail = { index }`) when an item is
+//     activated (clicked) — mirrors the Adw.Sidebar::activated signal.
+// Reference: refs/libadwaita/src/adw-sidebar.c (AdwSidebar behaviour)
+// Reference: refs/libadwaita/src/adw-sidebar-item.h (AdwSidebarItem properties)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss (.navigation-sidebar, sidebar)
+// Copyright (c) 2025 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** Index meaning "no selection" — the web mirror of Gtk.INVALID_LIST_POSITION. */
+const NO_SELECTION = -1;
+
+/** GTK symbolic name (e.g. "folder-symbolic") → adwaita-web icon class. */
+function iconClass(gtkName: string): string {
+    const name = gtkName.replace(/-symbolic$/, '');
+    return name ? `adw-icon adw-icon--${name}` : 'adw-icon';
+}
+
+/** A single sidebar item. Child of <adw-sidebar-section>; consumed at connect time. */
+export class AdwSidebarItem extends HTMLElement {
+    static get observedAttributes() {
+        return ['title', 'subtitle', 'icon-name'];
+    }
+}
+
+/** A titled group of items. Child of <adw-sidebar>; consumed at connect time. */
+export class AdwSidebarSection extends HTMLElement {
+    static get observedAttributes() {
+        return ['title'];
+    }
+}
+
+export class AdwSidebar extends HTMLElement {
+    private _listEl!: HTMLDivElement;
+    private _rows: HTMLButtonElement[] = [];
+    private _selected = 0;
+    private _mode: 'sidebar' | 'page' = 'sidebar';
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['mode', 'selected'];
+    }
+
+    /** Zero-based flat index of the selected item, or -1 for no selection. */
+    get selected(): number {
+        return this._selected;
+    }
+
+    set selected(value: number) {
+        this.setAttribute('selected', String(value));
+    }
+
+    /** 'sidebar' (flat navigation list) or 'page' (boxed lists). */
+    get mode(): 'sidebar' | 'page' {
+        return this._mode;
+    }
+
+    set mode(value: 'sidebar' | 'page') {
+        this.setAttribute('mode', value);
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared <adw-sidebar-section> children before we take
+        // over the subtree — their title + <adw-sidebar-item> descendants become
+        // the rendered sections and rows.
+        const sections = Array.from(this.querySelectorAll('adw-sidebar-section')) as AdwSidebarSection[];
+
+        this._listEl = document.createElement('div');
+        this._listEl.className = 'adw-sidebar-list';
+        this._listEl.setAttribute('role', 'listbox');
+
+        this._rows = [];
+
+        sections.forEach((section, sectionIndex) => {
+            const title = section.getAttribute('title') ?? '';
+            const items = Array.from(section.querySelectorAll('adw-sidebar-item')) as AdwSidebarItem[];
+
+            // The section header — a heading when titled, an empty separator
+            // otherwise (mirrors AdwSidebar's header stack: "title" vs
+            // "separator" child). The very first section never draws a leading
+            // separator (matches the `.header.first` rule).
+            const header = document.createElement('div');
+            header.className = 'adw-sidebar-section-header';
+            if (title) {
+                header.classList.add('has-title');
+                const heading = document.createElement('span');
+                heading.className = 'adw-sidebar-section-heading';
+                heading.textContent = title;
+                header.appendChild(heading);
+                if (sectionIndex === 0) header.classList.add('first');
+            } else {
+                header.classList.add('separator');
+                if (sectionIndex === 0) header.hidden = true;
+            }
+            this._listEl.appendChild(header);
+
+            const sectionEl = document.createElement('div');
+            sectionEl.className = 'adw-sidebar-section';
+
+            items.forEach((item) => {
+                const flatIndex = this._rows.length;
+                const itemTitle = item.getAttribute('title') ?? '';
+                const subtitle = item.getAttribute('subtitle') ?? '';
+                const icon = item.getAttribute('icon-name') ?? '';
+
+                const row = document.createElement('button');
+                row.type = 'button';
+                row.className = 'adw-sidebar-item';
+                row.setAttribute('role', 'option');
+
+                const iconEl = document.createElement('span');
+                iconEl.className = `${iconClass(icon)} adw-sidebar-item-icon`;
+                iconEl.setAttribute('aria-hidden', 'true'); // decorative (mask-image only)
+                iconEl.hidden = icon.length === 0;
+                row.appendChild(iconEl);
+
+                const textEl = document.createElement('span');
+                textEl.className = 'adw-sidebar-item-text';
+
+                const titleEl = document.createElement('span');
+                titleEl.className = 'adw-sidebar-item-title';
+                titleEl.textContent = itemTitle;
+                titleEl.hidden = itemTitle.length === 0;
+                textEl.appendChild(titleEl);
+
+                const subtitleEl = document.createElement('span');
+                subtitleEl.className = 'adw-sidebar-item-subtitle';
+                subtitleEl.textContent = subtitle;
+                subtitleEl.hidden = subtitle.length === 0;
+                textEl.appendChild(subtitleEl);
+
+                row.appendChild(textEl);
+
+                // Page mode adds a trailing chevron on every row, the way the
+                // boxed-list AdwActionRow carries a `go-next-symbolic` arrow.
+                const arrowEl = document.createElement('span');
+                arrowEl.className = 'adw-icon adw-icon--go-next adw-sidebar-item-arrow';
+                arrowEl.setAttribute('aria-hidden', 'true');
+                row.appendChild(arrowEl);
+
+                row.addEventListener('click', () => this._activateIndex(flatIndex));
+                sectionEl.appendChild(row);
+                this._rows.push(row);
+            });
+
+            this._listEl.appendChild(sectionEl);
+        });
+
+        this.replaceChildren(this._listEl);
+
+        this._mode = this._readModeAttr();
+        this._selected = this._readSelectedAttr();
+        this._render();
+    }
+
+    attributeChangedCallback(name: string) {
+        if (!this._initialized) return;
+        if (name === 'selected') {
+            const next = this._readSelectedAttr();
+            if (next !== this._selected) {
+                this._selected = next;
+                this._render();
+            }
+            return;
+        }
+        if (name === 'mode') {
+            const next = this._readModeAttr();
+            if (next !== this._mode) {
+                this._mode = next;
+                this._render();
+            }
+        }
+    }
+
+    private _readModeAttr(): 'sidebar' | 'page' {
+        return this.getAttribute('mode') === 'page' ? 'page' : 'sidebar';
+    }
+
+    private _readSelectedAttr(): number {
+        const raw = Number.parseInt(this.getAttribute('selected') ?? '0', 10);
+        if (Number.isNaN(raw)) return 0;
+        if (raw < 0) return NO_SELECTION;
+        const max = Math.max(0, this._rows.length - 1);
+        return Math.min(raw, max);
+    }
+
+    /** Click handler — selects the row (if changed) and always emits `activated`. */
+    private _activateIndex(index: number): void {
+        if (index !== this._selected) {
+            this._selected = index;
+            // Keep the attribute in sync without re-entering via the guarded
+            // attributeChangedCallback (value already matches, so it no-ops).
+            this.setAttribute('selected', String(index));
+            this._render();
+            this.dispatchEvent(new CustomEvent('notify::selected', { bubbles: true, detail: { selected: index } }));
+        }
+        this.dispatchEvent(new CustomEvent('activated', { bubbles: true, detail: { index } }));
+    }
+
+    private _render(): void {
+        this.classList.toggle('page', this._mode === 'page');
+        this.classList.toggle('mode-sidebar', this._mode === 'sidebar');
+
+        this._rows.forEach((row, index) => {
+            const isSelected = index === this._selected;
+            row.classList.toggle('selected', isSelected);
+            row.setAttribute('aria-selected', String(isSelected));
+            row.tabIndex = isSelected || (this._selected === NO_SELECTION && index === 0) ? 0 : -1;
+        });
+    }
+}
+
+customElements.define('adw-sidebar-item', AdwSidebarItem);
+customElements.define('adw-sidebar-section', AdwSidebarSection);
+customElements.define('adw-sidebar', AdwSidebar);

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -1,0 +1,184 @@
+// <adw-tab-view> — A dynamic tabbed container with a tab bar header (the web
+// counterpart of Adw.TabView + Adw.TabBar). One page is shown at a time; the
+// tab bar renders one chip per page (title + close affordance) over a
+// headerbar-colored strip, with the selected chip raised onto the view
+// background. Pages are declared as <adw-tab-page> children (each with a
+// `title` attribute and arbitrary content); the view snapshots them at connect
+// time, builds the bar, and toggles the active page's visibility.
+// Attributes:
+//   selected (zero-based index of the visible page, default 0)
+//   autohide (boolean — hide the tab bar when only one page remains, mirroring
+//     the Adw.TabBar `autohide` property)
+// Events:
+//   `notify::selected-page` (CustomEvent, bubbles, `detail = { selected }`) when
+//     the visible page changes — mirrors the Adw.TabView `selected-page` property.
+//   `close-page` (CustomEvent, bubbles, `detail = { index }`) when a page's close
+//     affordance is activated — mirrors the Adw.TabView `close-page` signal.
+// Reference: refs/libadwaita/src/adw-tab-view.c (AdwTabView behaviour)
+// Reference: refs/libadwaita/src/adw-tab-bar.c (AdwTabBar autohide)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_tab-view.scss
+// Reference: refs/adwaita-web/adwaita-web/scss/_tabs.scss
+// Copyright (c) 2020-2022 Purism SPC / GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** A single page. Children of <adw-tab-view>; consumed at connect time. */
+export class AdwTabPage extends HTMLElement {
+    static get observedAttributes() {
+        return ['title'];
+    }
+}
+
+export class AdwTabView extends HTMLElement {
+    private _barEl!: HTMLDivElement;
+    private _pagesEl!: HTMLDivElement;
+    private _tabs: HTMLButtonElement[] = [];
+    private _pages: HTMLDivElement[] = [];
+    private _selected = 0;
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['selected', 'autohide'];
+    }
+
+    /** Zero-based index of the visible page. */
+    get selected(): number {
+        return this._selected;
+    }
+
+    set selected(value: number) {
+        this.setAttribute('selected', String(value));
+    }
+
+    /** Whether the tab bar hides itself when only one page remains. */
+    get autohide(): boolean {
+        return this.hasAttribute('autohide');
+    }
+
+    set autohide(value: boolean) {
+        if (value) this.setAttribute('autohide', '');
+        else this.removeAttribute('autohide');
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared <adw-tab-page> children before we take over the
+        // subtree — their title attribute + content become the rendered pages.
+        const pages = Array.from(this.querySelectorAll('adw-tab-page')) as AdwTabPage[];
+
+        // The tab bar (headerbar-colored strip of chips), built first so it sits
+        // above the pages.
+        this._barEl = document.createElement('div');
+        this._barEl.className = 'adw-tab-bar';
+        this._barEl.setAttribute('role', 'tablist');
+
+        const tabBox = document.createElement('div');
+        tabBox.className = 'adw-tab-box';
+        this._barEl.appendChild(tabBox);
+
+        this._pagesEl = document.createElement('div');
+        this._pagesEl.className = 'adw-tab-view-pages';
+
+        this._tabs = [];
+        this._pages = [];
+
+        pages.forEach((page, index) => {
+            const title = page.getAttribute('title') ?? '';
+
+            const tab = document.createElement('button');
+            tab.type = 'button';
+            tab.className = 'adw-tab';
+            tab.setAttribute('role', 'tab');
+
+            const label = document.createElement('span');
+            label.className = 'adw-tab-title';
+            label.textContent = title;
+            tab.appendChild(label);
+
+            // Close affordance — a small flat button drawn with a CSS "×" glyph
+            // (no symbolic close icon ships in @gjsify/adwaita-icons).
+            const close = document.createElement('button');
+            close.type = 'button';
+            close.className = 'adw-tab-close';
+            close.setAttribute('aria-label', 'Close tab');
+            close.addEventListener('click', (event) => {
+                event.stopPropagation();
+                this.dispatchEvent(new CustomEvent('close-page', { bubbles: true, detail: { index } }));
+            });
+            tab.appendChild(close);
+
+            tab.addEventListener('click', () => this._selectIndex(index));
+            tabBox.appendChild(tab);
+            this._tabs.push(tab);
+
+            // The page content area — the declared element's children are moved
+            // into a panel that the view toggles visible.
+            const panel = document.createElement('div');
+            panel.className = 'adw-tab-page';
+            panel.setAttribute('role', 'tabpanel');
+            for (const child of Array.from(page.childNodes)) panel.appendChild(child);
+            this._pagesEl.appendChild(panel);
+            this._pages.push(panel);
+        });
+
+        this.replaceChildren(this._barEl, this._pagesEl);
+
+        this._selected = this._readSelectedAttr();
+        this._render();
+    }
+
+    attributeChangedCallback(name: string) {
+        if (!this._initialized) return;
+        if (name === 'selected') {
+            const next = this._readSelectedAttr();
+            if (next !== this._selected) {
+                this._selected = next;
+                this._render();
+            }
+            return;
+        }
+        // autohide is styling/visibility-only.
+        this._render();
+    }
+
+    private _readSelectedAttr(): number {
+        const raw = Number.parseInt(this.getAttribute('selected') ?? '0', 10);
+        if (Number.isNaN(raw)) return 0;
+        const max = Math.max(0, this._pages.length - 1);
+        return Math.min(Math.max(raw, 0), max);
+    }
+
+    private _selectIndex(index: number): void {
+        if (index === this._selected) return;
+        this._selected = index;
+        // Keep the attribute in sync without re-entering via the guarded
+        // attributeChangedCallback (value already matches, so it no-ops).
+        this.setAttribute('selected', String(index));
+        this._render();
+        this.dispatchEvent(new CustomEvent('notify::selected-page', { bubbles: true, detail: { selected: index } }));
+    }
+
+    private _render(): void {
+        // Autohide: collapse the bar when only one page (or none) remains.
+        const hidden = this.autohide && this._pages.length <= 1;
+        this._barEl.hidden = hidden;
+        this._barEl.classList.toggle('single-tab', this._pages.length <= 1);
+
+        this._tabs.forEach((tab, index) => {
+            const isActive = index === this._selected;
+            tab.classList.toggle('active', isActive);
+            tab.setAttribute('aria-selected', String(isActive));
+            tab.tabIndex = isActive ? 0 : -1;
+        });
+
+        this._pages.forEach((panel, index) => {
+            const isActive = index === this._selected;
+            panel.classList.toggle('active-page', isActive);
+            panel.hidden = !isActive;
+        });
+    }
+}
+
+customElements.define('adw-tab-page', AdwTabPage);
+customElements.define('adw-tab-view', AdwTabView);

--- a/packages/web/adwaita-web/src/elements/adw-toast-overlay.ts
+++ b/packages/web/adwaita-web/src/elements/adw-toast-overlay.ts
@@ -1,44 +1,123 @@
 // <adw-toast-overlay> — Adwaita toast notification overlay.
-// Displays temporary feedback messages at the bottom of the viewport.
+// The web counterpart of Adw.ToastOverlay: it wraps arbitrary content and shows
+// transient `.adw-toast` banners (the Adw.Toast equivalent — a title, an
+// optional action button and a close affordance) layered over the bottom of its
+// own bounds, each auto-dismissing after a timeout.
 // Adapted from Adwaita Web UI Framework (https://github.com/mclellac/adwaita-web).
 // Reference: refs/adwaita-web/adwaita-web/scss/_toast.scss, _toast_overlay.scss
-// Reference: refs/libadwaita/src/adw-toast-overlay.c
+// Reference: refs/libadwaita/src/adw-toast-overlay.c, adw-toast.c (Adw.Toast.add_toast)
 // Copyright (c) 2025 csm (adwaita-web). MIT License.
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
-// Modifications: Reimplemented as Web Component for @gjsify/adwaita-web.
+// Modifications: Reimplemented as Web Component for @gjsify/adwaita-web;
+// extended addToast() with action button + close button + options API.
+
+/** Options for {@link AdwToastOverlay.addToast}, mirroring Adw.Toast's properties. */
+export interface AdwToastOptions {
+    /** Seconds before the toast auto-dismisses; `0` keeps it until dismissed. Mirrors Adw.Toast:timeout (default 5). */
+    timeout?: number;
+    /** Label for the action button; omitted/empty means no button. Mirrors Adw.Toast:button-label. */
+    buttonLabel?: string;
+    /** Invoked when the action button is pressed. Mirrors the activation of Adw.Toast:action-name. */
+    onAction?: () => void;
+}
 
 export class AdwToastOverlay extends HTMLElement {
+    private _toasts!: HTMLDivElement;
+    private _initialized = false;
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Adopt the declared children as the wrapped content (the Adw.ToastOverlay
+        // :child) and layer a dedicated toast container over the bottom edge.
+        const content = document.createElement('div');
+        content.className = 'adw-toast-overlay-content';
+        for (const child of Array.from(this.childNodes)) content.appendChild(child);
+
+        this._toasts = document.createElement('div');
+        this._toasts.className = 'adw-toast-overlay-toasts';
+
+        this.replaceChildren(content, this._toasts);
+    }
+
     /**
-     * Show a toast notification.
-     * @param title - The text to display.
-     * @param timeout - Time in ms before the toast auto-dismisses (default 2000).
+     * Show a toast notification — the web equivalent of Adw.ToastOverlay.add_toast()
+     * with a freshly-built Adw.Toast.
+     *
+     * @param title   The text to display.
+     * @param options Either a timeout in seconds (legacy shorthand) or an
+     *                {@link AdwToastOptions} bag (title text already supplied here).
      */
-    addToast(title: string, timeout = 2000): void {
+    addToast(title: string, options: number | AdwToastOptions = {}): void {
+        // Ensure the toast container exists even if addToast() races a not-yet
+        // connected element (mirrors Adw.ToastOverlay queuing before realize).
+        if (!this._toasts) this.connectedCallback();
+
+        // Back-compat: the original signature was addToast(title, timeoutMs).
+        const opts: AdwToastOptions =
+            typeof options === 'number' ? { timeout: options / 1000 } : options;
+        const timeoutSeconds = opts.timeout ?? 5;
+
         const toast = document.createElement('div');
         toast.className = 'adw-toast';
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'adw-toast-content-wrapper';
 
         const titleEl = document.createElement('span');
         titleEl.className = 'adw-toast-title';
         titleEl.textContent = title;
-        toast.appendChild(titleEl);
+        wrapper.appendChild(titleEl);
+        toast.appendChild(wrapper);
 
-        this.appendChild(toast);
+        let dismissTimer = 0;
+        const dismiss = (): void => {
+            if (dismissTimer) {
+                clearTimeout(dismissTimer);
+                dismissTimer = 0;
+            }
+            toast.classList.remove('visible');
+            toast.classList.add('hiding');
+            toast.addEventListener('transitionend', () => toast.remove(), { once: true });
+            // Fallback if transitionend doesn't fire (e.g. reduced motion).
+            setTimeout(() => {
+                if (toast.parentNode) toast.remove();
+            }, 300);
+        };
 
-        // Trigger enter animation on next frame
+        if (opts.buttonLabel) {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'adw-toast-action-button';
+            button.textContent = opts.buttonLabel;
+            button.addEventListener('click', () => {
+                opts.onAction?.();
+                dismiss();
+            });
+            toast.appendChild(button);
+        }
+
+        // Close affordance — a CSS-drawn "×" (no symbolic close icon ships in the
+        // curated @gjsify/adwaita-icons set), mirroring adw-tab-view's .adw-tab-close.
+        const close = document.createElement('button');
+        close.type = 'button';
+        close.className = 'adw-toast-close-button';
+        close.setAttribute('aria-label', 'Close');
+        close.addEventListener('click', dismiss);
+        toast.appendChild(close);
+
+        this._toasts.appendChild(toast);
+
+        // Trigger the enter animation on the next frame.
         requestAnimationFrame(() => {
             toast.classList.add('visible');
         });
 
-        // Auto-dismiss after timeout
-        setTimeout(() => {
-            toast.classList.remove('visible');
-            toast.classList.add('hiding');
-            toast.addEventListener('transitionend', () => toast.remove(), { once: true });
-            // Fallback if transitionend doesn't fire
-            setTimeout(() => {
-                if (toast.parentNode) toast.remove();
-            }, 300);
-        }, timeout);
+        // Auto-dismiss after the timeout (0 = stay until manually dismissed).
+        if (timeoutSeconds > 0) {
+            dismissTimer = setTimeout(dismiss, timeoutSeconds * 1000) as unknown as number;
+        }
     }
 }
 

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
@@ -1,0 +1,200 @@
+// <adw-view-switcher> — An adaptive, tab-style switcher driving a set of named
+// pages (the web counterpart of Adw.ViewSwitcher paired with an Adw.ViewStack).
+// Pages are declared as <adw-view-switcher-page> children with `name`, `title`
+// and `icon-name` attributes; their own children become the page body. The
+// switcher renders one toggle button per page (always icon + label) and shows
+// exactly one page at a time, exactly like libadwaita's single `viewswitcher`
+// CSS node with the `.wide` / `.narrow` policy style classes.
+//   - wide:   icon and label side by side (horizontal button layout)
+//   - narrow: icon stacked above the label (vertical button layout)
+// Attributes:
+//   policy — 'wide' | 'narrow' (default 'narrow', matching libadwaita's default).
+//   active — zero-based index of the selected page (default 0).
+// Events:
+//   `notify::visible-child` (CustomEvent, bubbles, detail = { name, index }) when
+//     the selected page changes — mirrors Adw.ViewStack's `visible-child-name`.
+//   `notify::policy` (CustomEvent, bubbles, detail = { policy }) when the policy
+//     changes — mirrors the Adw.ViewSwitcher `policy` GObject property.
+// Reference: refs/libadwaita/src/adw-view-switcher.c (AdwViewSwitcher behaviour)
+// Reference: refs/libadwaita/src/stylesheet/widgets/_view-switcher.scss
+// Reference: refs/adwaita-web/adwaita-web/scss/_viewswitcher.scss
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+type Policy = 'wide' | 'narrow';
+
+interface PageInfo {
+    name: string;
+    title: string;
+    icon: string;
+    body: HTMLElement;
+    button: HTMLButtonElement;
+}
+
+/** A single page. Children of <adw-view-switcher>; consumed at connect time. */
+export class AdwViewSwitcherPage extends HTMLElement {
+    static get observedAttributes() {
+        return ['name', 'title', 'icon-name'];
+    }
+}
+
+export class AdwViewSwitcher extends HTMLElement {
+    private _barEl!: HTMLDivElement;
+    private _contentEl!: HTMLDivElement;
+    private _pages: PageInfo[] = [];
+    private _active = 0;
+    private _policy: Policy = 'narrow';
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return ['policy', 'active'];
+    }
+
+    /** The policy controlling the button layout ('wide' | 'narrow'). */
+    get policy(): Policy {
+        return this._policy;
+    }
+
+    set policy(value: Policy) {
+        this.setAttribute('policy', value);
+    }
+
+    /** Zero-based index of the active page. */
+    get active(): number {
+        return this._active;
+    }
+
+    set active(value: number) {
+        this.setAttribute('active', String(value));
+    }
+
+    /** The name of the currently visible page, or null when there are none. */
+    get visibleChildName(): string | null {
+        return this._pages[this._active]?.name ?? null;
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+
+        // Snapshot the declared <adw-view-switcher-page> children before we take
+        // over the subtree — their name / title / icon-name + their own child
+        // nodes become the rendered tabs and page bodies.
+        const declaredPages = Array.from(this.querySelectorAll('adw-view-switcher-page')) as AdwViewSwitcherPage[];
+
+        // The single `viewswitcher` node holds the segmented button bar; a sibling
+        // content area shows the active page (the web stand-in for the paired
+        // Adw.ViewStack the switcher would otherwise drive).
+        this._barEl = document.createElement('div');
+        this._barEl.className = 'adw-view-switcher-bar';
+        this._barEl.setAttribute('role', 'tablist');
+
+        this._contentEl = document.createElement('div');
+        this._contentEl.className = 'adw-view-switcher-content';
+
+        this._pages = declaredPages.map((pageEl, index) => {
+            const name = pageEl.getAttribute('name') ?? `page-${index}`;
+            const title = pageEl.getAttribute('title') ?? '';
+            const icon = (pageEl.getAttribute('icon-name') ?? '').replace(/-symbolic$/, '');
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'adw-view-switcher-button';
+            button.setAttribute('role', 'tab');
+
+            const iconEl = document.createElement('span');
+            iconEl.className = `adw-icon${icon ? ` adw-icon--${icon}` : ''}`;
+            iconEl.setAttribute('aria-hidden', 'true'); // decorative (mask-image only)
+            iconEl.hidden = icon.length === 0;
+
+            const labelEl = document.createElement('span');
+            labelEl.className = 'adw-view-switcher-label';
+            labelEl.textContent = title;
+            labelEl.hidden = title.length === 0;
+
+            button.append(iconEl, labelEl);
+            // An icon-only tab has no visible text — give it an accessible name.
+            if (icon && !title) button.setAttribute('aria-label', icon);
+
+            button.addEventListener('click', () => this._selectIndex(index));
+
+            const body = document.createElement('div');
+            body.className = 'adw-view-switcher-page';
+            body.dataset.name = name;
+            for (const child of Array.from(pageEl.childNodes)) body.appendChild(child);
+
+            return { name, title, icon, body, button };
+        });
+
+        this._barEl.append(...this._pages.map((p) => p.button));
+        this._contentEl.append(...this._pages.map((p) => p.body));
+        this.replaceChildren(this._barEl, this._contentEl);
+
+        this._policy = this._readPolicyAttr();
+        this._active = this._readActiveAttr();
+        this._render();
+    }
+
+    attributeChangedCallback(name: string) {
+        if (!this._initialized) return;
+        if (name === 'policy') {
+            const next = this._readPolicyAttr();
+            if (next !== this._policy) {
+                this._policy = next;
+                this._render();
+            }
+            return;
+        }
+        if (name === 'active') {
+            const next = this._readActiveAttr();
+            if (next !== this._active) {
+                this._active = next;
+                this._render();
+            }
+        }
+    }
+
+    private _readPolicyAttr(): Policy {
+        return this.getAttribute('policy') === 'wide' ? 'wide' : 'narrow';
+    }
+
+    private _readActiveAttr(): number {
+        const raw = Number.parseInt(this.getAttribute('active') ?? '0', 10);
+        if (Number.isNaN(raw)) return 0;
+        const max = Math.max(0, this._pages.length - 1);
+        return Math.min(Math.max(raw, 0), max);
+    }
+
+    private _selectIndex(index: number): void {
+        if (index === this._active) return;
+        this._active = index;
+        // Keep the attribute in sync without re-entering the guarded callback
+        // (value already matches, so attributeChangedCallback no-ops).
+        this.setAttribute('active', String(index));
+        this._render();
+        const page = this._pages[index];
+        this.dispatchEvent(
+            new CustomEvent('notify::visible-child', {
+                bubbles: true,
+                detail: { name: page?.name ?? null, index },
+            }),
+        );
+    }
+
+    private _render(): void {
+        // Single `viewswitcher` node carries the `.wide` / `.narrow` policy class.
+        this.classList.toggle('wide', this._policy === 'wide');
+        this.classList.toggle('narrow', this._policy === 'narrow');
+
+        this._pages.forEach((page, index) => {
+            const isActive = index === this._active;
+            page.button.classList.toggle('active', isActive);
+            page.button.setAttribute('aria-selected', String(isActive));
+            page.button.tabIndex = isActive ? 0 : -1;
+            page.body.classList.toggle('active-view', isActive);
+        });
+    }
+}
+
+customElements.define('adw-view-switcher-page', AdwViewSwitcherPage);
+customElements.define('adw-view-switcher', AdwViewSwitcher);

--- a/packages/web/adwaita-web/src/elements/adw-wrap-box.ts
+++ b/packages/web/adwaita-web/src/elements/adw-wrap-box.ts
@@ -1,0 +1,139 @@
+// <adw-wrap-box> — A box-like container that lays its children out in a line and
+// wraps them onto new lines when they run out of room (the web analog of
+// flexbox `flex-wrap: wrap` with a gap). Mirrors Adw.WrapBox.
+// Attributes:
+//   child-spacing   (px, default 0) — spacing between children on the same line
+//                                      → CSS column-gap
+//   line-spacing    (px, default 0) — spacing between lines → CSS row-gap
+//   orientation     ("horizontal" | "vertical", default "horizontal") — the main
+//                                      axis children are packed along
+//   align           (0..1, default 0) — alignment of children within each line
+//                                      (cross axis); 0 = start, 0.5 = center, 1 = end
+//   justify         ("none" | "fill" | "spread", default "none") — whether/how
+//                                      each line is stretched to fill the widget
+//   justify-last-line (boolean) — also justify the last (incomplete) line
+//   line-homogeneous  (boolean) — make every line take the same amount of space
+//   pack-direction  ("start-to-end" | "end-to-start", default "start-to-end") —
+//                                      direction children are packed within a line
+//   wrap-reverse    (boolean) — reverse the wrap direction (lines wrap upwards)
+// Events: notify::child-spacing, notify::line-spacing (CustomEvent, bubbles —
+//   mirrors GObject signal naming).
+// Reference: refs/libadwaita/src/adw-wrap-box.c / adw-wrap-layout.c (Adw.WrapBox)
+// Reference: refs/adwaita-web/adwaita-web/scss/_wrap_box.scss
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+
+/** Adw.JustifyMode → flexbox justify-content. */
+const JUSTIFY_MAP: Record<string, string> = {
+    none: 'flex-start',
+    fill: 'space-between',
+    spread: 'space-between',
+};
+
+export class AdwWrapBox extends HTMLElement {
+    private _initialized = false;
+
+    static get observedAttributes() {
+        return [
+            'child-spacing',
+            'line-spacing',
+            'orientation',
+            'align',
+            'justify',
+            'justify-last-line',
+            'line-homogeneous',
+            'pack-direction',
+            'wrap-reverse',
+        ];
+    }
+
+    /** Spacing between children on the same line, in px (CSS column-gap). */
+    get childSpacing(): number {
+        return parseFloat(this.getAttribute('child-spacing') || '0');
+    }
+
+    set childSpacing(value: number) {
+        this.setAttribute('child-spacing', String(value));
+    }
+
+    /** Spacing between lines, in px (CSS row-gap). */
+    get lineSpacing(): number {
+        return parseFloat(this.getAttribute('line-spacing') || '0');
+    }
+
+    set lineSpacing(value: number) {
+        this.setAttribute('line-spacing', String(value));
+    }
+
+    connectedCallback() {
+        if (this._initialized) return;
+        this._initialized = true;
+        this._sync();
+    }
+
+    attributeChangedCallback(name: string, old: string | null, value: string | null) {
+        if (!this._initialized) return;
+        this._sync();
+        if (old === value) return;
+        if (name === 'child-spacing') {
+            this.dispatchEvent(
+                new CustomEvent('notify::child-spacing', {
+                    bubbles: true,
+                    detail: { childSpacing: this.childSpacing },
+                }),
+            );
+        } else if (name === 'line-spacing') {
+            this.dispatchEvent(
+                new CustomEvent('notify::line-spacing', {
+                    bubbles: true,
+                    detail: { lineSpacing: this.lineSpacing },
+                }),
+            );
+        }
+    }
+
+    private _sync() {
+        const style = this.style;
+        const vertical = this.getAttribute('orientation') === 'vertical';
+        const reverseWrap = this.hasAttribute('wrap-reverse');
+        const packEndToStart = this.getAttribute('pack-direction') === 'end-to-start';
+
+        // Main axis is the packing direction; lines wrap along the cross axis.
+        const direction = vertical ? 'column' : 'row';
+        const reversed = packEndToStart ? `${direction}-reverse` : direction;
+        style.flexDirection = reversed;
+        style.flexWrap = reverseWrap ? 'wrap-reverse' : 'wrap';
+
+        // child-spacing is along the line (main axis), line-spacing is between
+        // lines (cross axis). For a horizontal box that maps to column-gap /
+        // row-gap respectively; the mapping flips for a vertical box.
+        const childGap = `${this.childSpacing}px`;
+        const lineGap = `${this.lineSpacing}px`;
+        if (vertical) {
+            style.rowGap = childGap;
+            style.columnGap = lineGap;
+        } else {
+            style.columnGap = childGap;
+            style.rowGap = lineGap;
+        }
+
+        // justify-content stretches each complete line along the main axis; the
+        // last (incomplete) line is only stretched when justify-last-line is set.
+        const justify = this.getAttribute('justify') ?? 'none';
+        style.justifyContent = JUSTIFY_MAP[justify] ?? 'flex-start';
+
+        // align (0..1) positions children within each line on the cross axis.
+        // It is only honoured when the line is not justified.
+        const align = Math.max(0, Math.min(1, parseFloat(this.getAttribute('align') || '0')));
+        let crossAlign = 'flex-start';
+        if (align >= 0.75) crossAlign = 'flex-end';
+        else if (align >= 0.25) crossAlign = 'center';
+        style.alignItems = crossAlign;
+
+        // line-homogeneous makes every line take the same amount of space, which
+        // flexbox approximates by stretching the lines across the cross axis.
+        style.alignContent = this.hasAttribute('line-homogeneous') ? 'stretch' : 'flex-start';
+    }
+}
+
+customElements.define('adw-wrap-box', AdwWrapBox);

--- a/packages/web/adwaita-web/src/index.ts
+++ b/packages/web/adwaita-web/src/index.ts
@@ -49,3 +49,7 @@ export { AdwToolbarView } from './elements/adw-toolbar-view.js';
 export { AdwWrapBox } from './elements/adw-wrap-box.js';
 export { AdwOverlaySplitView } from './elements/adw-overlay-split-view.js';
 export { AdwNavigationSplitView } from './elements/adw-navigation-split-view.js';
+export { AdwCarousel, AdwCarouselIndicatorDots, AdwCarouselIndicatorLines } from './elements/adw-carousel.js';
+export { AdwTabPage, AdwTabView } from './elements/adw-tab-view.js';
+export { AdwViewSwitcher, AdwViewSwitcherPage } from './elements/adw-view-switcher.js';
+export { AdwInlineViewSwitcher, AdwViewStackPage } from './elements/adw-inline-view-switcher.js';

--- a/packages/web/adwaita-web/src/index.ts
+++ b/packages/web/adwaita-web/src/index.ts
@@ -56,3 +56,6 @@ export { AdwInlineViewSwitcher, AdwViewStackPage } from './elements/adw-inline-v
 export { AdwNavigationPage, AdwNavigationView } from './elements/adw-navigation-view.js';
 export { AdwBottomSheet, AdwBottomSheetContent, AdwBottomSheetSheet } from './elements/adw-bottom-sheet.js';
 export { AdwSidebar, AdwSidebarItem, AdwSidebarSection } from './elements/adw-sidebar.js';
+export { AdwAboutDialog } from './elements/adw-about-dialog.js';
+export { AdwAlertDialog, AdwAlertResponse } from './elements/adw-alert-dialog.js';
+export { AdwPreferencesDialog, AdwPreferencesPage } from './elements/adw-preferences-dialog.js';

--- a/packages/web/adwaita-web/src/index.ts
+++ b/packages/web/adwaita-web/src/index.ts
@@ -53,3 +53,6 @@ export { AdwCarousel, AdwCarouselIndicatorDots, AdwCarouselIndicatorLines } from
 export { AdwTabPage, AdwTabView } from './elements/adw-tab-view.js';
 export { AdwViewSwitcher, AdwViewSwitcherPage } from './elements/adw-view-switcher.js';
 export { AdwInlineViewSwitcher, AdwViewStackPage } from './elements/adw-inline-view-switcher.js';
+export { AdwNavigationPage, AdwNavigationView } from './elements/adw-navigation-view.js';
+export { AdwBottomSheet, AdwBottomSheetContent, AdwBottomSheetSheet } from './elements/adw-bottom-sheet.js';
+export { AdwSidebar, AdwSidebarItem, AdwSidebarSection } from './elements/adw-sidebar.js';

--- a/packages/web/adwaita-web/src/index.ts
+++ b/packages/web/adwaita-web/src/index.ts
@@ -46,5 +46,6 @@ export { AdwExpanderRow } from './elements/adw-expander-row.js';
 export { AdwPasswordEntryRow } from './elements/adw-password-entry-row.js';
 export { AdwToastOverlay } from './elements/adw-toast-overlay.js';
 export { AdwToolbarView } from './elements/adw-toolbar-view.js';
+export { AdwWrapBox } from './elements/adw-wrap-box.js';
 export { AdwOverlaySplitView } from './elements/adw-overlay-split-view.js';
 export { AdwNavigationSplitView } from './elements/adw-navigation-split-view.js';

--- a/showcases/gtk/adwaita-storybook/src/browser/feedback/about-dialog.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/feedback/about-dialog.web.ts
@@ -1,0 +1,82 @@
+// Browser port of the About Dialog story. Shares metadata with about-dialog.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { aboutDialogMeta } from '../../feedback/about-dialog.meta.js';
+
+/** Imperatively-set list/scalar properties on the <adw-about-dialog> element. */
+interface AboutDialogElement extends HTMLElement {
+    developers: string[];
+    designers: string[];
+    present(): void;
+}
+
+export class AboutDialogWebStory extends StoryElement {
+    private _dialog: AboutDialogElement | null = null;
+
+    constructor() {
+        super(AboutDialogWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return aboutDialogMeta;
+    }
+
+    initialize(): void {
+        // The persistent content — a centered pill button that presents the
+        // dialog (mirrors the native story's "Show dialog" button).
+        const center = document.createElement('div');
+        center.style.display = 'flex';
+        center.style.alignItems = 'center';
+        center.style.justifyContent = 'center';
+        center.style.minHeight = '160px';
+
+        const button = document.createElement('adw-button');
+        button.textContent = 'Show dialog';
+        button.setAttribute('pill', '');
+        button.setAttribute('suggested', '');
+        button.addEventListener('click', () => this._present());
+        center.append(button);
+
+        // The dialog is a fixed full-cover overlay — mount it on the body so the
+        // scrim covers the whole viewport, not just the clamped story stage.
+        this._dialog = document.createElement('adw-about-dialog') as AboutDialogElement;
+        document.body.appendChild(this._dialog);
+
+        this.addContent(center);
+    }
+
+    private _present(): void {
+        if (!this._dialog) return;
+        const dialog = this._dialog;
+        dialog.setAttribute('application-name', (this.args.applicationName as string) ?? 'Adwaita Storybook');
+        // The native story uses `application-x-executable-symbolic`; that glyph
+        // does not ship in the web icon set, so leave it unset to fall back to
+        // the component's generic application icon (emblem-system).
+        dialog.setAttribute('developer-name', 'A GJSify Project');
+        dialog.setAttribute('version', (this.args.version as string) ?? '0.11.0');
+        dialog.setAttribute('comments', 'A live catalogue of native GTK and Adwaita widgets, rendered under GJS.');
+        dialog.setAttribute('website', 'https://github.com/gjsify/gjsify');
+        dialog.setAttribute('issue-url', 'https://github.com/gjsify/gjsify/issues');
+        dialog.setAttribute('license', 'The MIT License (MIT)');
+        dialog.setAttribute('license-url', 'https://opensource.org/licenses/mit-license.php');
+        dialog.setAttribute('copyright', '© 2026 The GJSify Project');
+        dialog.developers = ['Ada Lovelace', 'Grace Hopper'];
+        dialog.designers = ['Margaret Hamilton'];
+        dialog.present();
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        // The dialog reads the latest args each time it is presented; nothing to mutate live.
+    }
+
+    teardown(): void {
+        // The dialog lives on the body, not the story stage — remove it when the
+        // story is deselected so it does not leak across navigations.
+        if (this._dialog && this._dialog.parentNode) {
+            this._dialog.parentNode.removeChild(this._dialog);
+        }
+        this._dialog = null;
+    }
+}
+
+export const AboutDialogWebStories: WebStoryModule = { stories: [AboutDialogWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/feedback/alert-dialog.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/feedback/alert-dialog.web.ts
@@ -1,0 +1,72 @@
+// Browser port of the Alert Dialog story. Shares metadata with alert-dialog.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { alertDialogMeta } from '../../feedback/alert-dialog.meta.js';
+
+/**
+ * Story: adw-alert-dialog presented from a button, with cancel/destructive
+ * responses — a 1:1 port of the GTK AlertDialogStory.
+ */
+export class AlertDialogWebStory extends StoryElement {
+    constructor() {
+        super(AlertDialogWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return alertDialogMeta;
+    }
+
+    initialize(): void {
+        const button = document.createElement('adw-button');
+        button.textContent = 'Show dialog';
+        button.setAttribute('pill', '');
+        button.setAttribute('suggested', '');
+        button.addEventListener('click', () => this._present());
+
+        // Centre the trigger button so the preview matches the GTK story's
+        // centred halign/valign placement.
+        const center = document.createElement('div');
+        center.style.display = 'flex';
+        center.style.alignItems = 'center';
+        center.style.justifyContent = 'center';
+        center.style.minHeight = '160px';
+        center.append(button);
+
+        this.addContent(center);
+    }
+
+    /** Build + present a fresh dialog, reading the latest args (as the GTK story does). */
+    private _present(): void {
+        const dialog = document.createElement('adw-alert-dialog') as HTMLElement & {
+            addResponse(id: string, label: string): void;
+            setResponseAppearance(id: string, appearance: 'default' | 'suggested' | 'destructive'): void;
+            setDefaultResponse(id: string | null): void;
+            setCloseResponse(id: string): void;
+            present(): void;
+        };
+        dialog.setAttribute('heading', this.args.heading as string);
+        dialog.setAttribute('body', this.args.body as string);
+
+        // The custom element only wires up its responses once connected, so add
+        // it to the document before driving the imperative API.
+        document.body.appendChild(dialog);
+
+        dialog.addResponse('cancel', 'Cancel');
+        dialog.addResponse('delete', 'Delete');
+        dialog.setResponseAppearance('delete', 'destructive');
+        dialog.setDefaultResponse('cancel');
+        dialog.setCloseResponse('cancel');
+
+        // Remove the dialog from the DOM once the user responds — the GTK dialog
+        // is likewise destroyed on response.
+        dialog.addEventListener('response', () => dialog.remove(), { once: true });
+
+        dialog.present();
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        // The dialog reads the latest args each time it is presented; nothing to mutate live.
+    }
+}
+
+export const AlertDialogWebStories: WebStoryModule = { stories: [AlertDialogWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/feedback/preferences-dialog.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/feedback/preferences-dialog.web.ts
@@ -1,0 +1,106 @@
+// Browser port of the Preferences Dialog story. Shares metadata with
+// preferences-dialog.story.ts and presents the same single-page dialog from a
+// "Show dialog" pill button.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { preferencesDialogMeta } from '../../feedback/preferences-dialog.meta.js';
+
+export class PreferencesDialogWebStory extends StoryElement {
+    private _dialog: HTMLElement | null = null;
+
+    constructor() {
+        super(PreferencesDialogWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return preferencesDialogMeta;
+    }
+
+    /** Build the single page of grouped rows, mirroring the native story. */
+    private _buildDialog(): HTMLElement {
+        const dialog = document.createElement('adw-preferences-dialog');
+        dialog.setAttribute('title', 'Preferences');
+
+        const page = document.createElement('adw-preferences-page');
+        page.setAttribute('title', (this.args.pageTitle as string) ?? 'General');
+        page.setAttribute('icon-name', 'preferences-system-symbolic');
+
+        const group = document.createElement('adw-preferences-group');
+        group.setAttribute('title', (this.args.groupTitle as string) ?? 'Appearance');
+        group.setAttribute('description', 'Control how the application looks and behaves.');
+
+        // Dark style — a switch row, on by default (matches the native SwitchRow).
+        const darkStyle = document.createElement('adw-switch-row');
+        darkStyle.setAttribute('title', 'Dark style');
+        darkStyle.setAttribute('subtitle', 'Use a dark colour scheme');
+        darkStyle.setAttribute('active', '');
+        group.append(darkStyle);
+
+        // Accent colour — a combo row over the same five options.
+        const accent = document.createElement('adw-combo-row');
+        accent.setAttribute('title', 'Accent colour');
+        accent.setAttribute('items', JSON.stringify(['Blue', 'Teal', 'Green', 'Orange', 'Purple']));
+        accent.setAttribute('selected', '0');
+        group.append(accent);
+
+        // Font size — a spin row bounded 8–24, defaulting to 12.
+        const fontSize = document.createElement('adw-spin-row');
+        fontSize.setAttribute('title', 'Font size');
+        fontSize.setAttribute('min', '8');
+        fontSize.setAttribute('max', '24');
+        fontSize.setAttribute('step', '1');
+        fontSize.setAttribute('value', '12');
+        group.append(fontSize);
+
+        page.append(group);
+        dialog.append(page);
+        return dialog;
+    }
+
+    initialize(): void {
+        // The persistent story content: a centered pill button that presents the
+        // dialog (the native story's "Show dialog" trigger).
+        const center = document.createElement('div');
+        center.style.display = 'flex';
+        center.style.alignItems = 'center';
+        center.style.justifyContent = 'center';
+        center.style.width = '100%';
+        center.style.height = '100%';
+        center.style.minHeight = '200px';
+
+        const button = document.createElement('adw-button');
+        button.textContent = 'Show dialog';
+        button.setAttribute('pill', '');
+        button.setAttribute('suggested', '');
+        button.addEventListener('click', () => this._present());
+
+        center.append(button);
+        this.addContent(center);
+    }
+
+    private _present(): void {
+        // Rebuild the dialog from the latest args each time it is presented (the
+        // native story does the same), then reveal it. The dialog appends itself
+        // to <body> so its fixed scrim covers the whole viewport.
+        if (this._dialog) this._dialog.remove();
+        this._dialog = this._buildDialog();
+        this._dialog.addEventListener('closed', () => {
+            this._dialog?.remove();
+            this._dialog = null;
+        });
+        document.body.appendChild(this._dialog);
+        // Reveal after connect so the element is upgraded + initialized.
+        requestAnimationFrame(() => this._dialog?.setAttribute('open', ''));
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        // The dialog is rebuilt from the latest args each time it is presented.
+    }
+
+    teardown(): void {
+        this._dialog?.remove();
+        this._dialog = null;
+    }
+}
+
+export const PreferencesDialogWebStories: WebStoryModule = { stories: [PreferencesDialogWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/feedback/toast.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/feedback/toast.web.ts
@@ -1,0 +1,62 @@
+// Browser port of the Toast story. Shares metadata with toast.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { toastMeta } from '../../feedback/toast.meta.js';
+
+/** The <adw-toast-overlay> exposes addToast(title, opts) — see @gjsify/adwaita-web. */
+interface ToastOverlayElement extends HTMLElement {
+    addToast(title: string, options?: { timeout?: number; buttonLabel?: string; onAction?: () => void }): void;
+}
+
+/** Story: an Adw.Toast presented through an adw-toast-overlay on button press. */
+export class ToastWebStory extends StoryElement {
+    private _overlay: ToastOverlayElement | null = null;
+
+    constructor() {
+        super(ToastWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return toastMeta;
+    }
+
+    initialize(): void {
+        this._overlay = document.createElement('adw-toast-overlay') as ToastOverlayElement;
+        // Match the native story's fixed 360×220 viewport so the toast has a
+        // bounded overlay area to float over.
+        this._overlay.style.width = '360px';
+        this._overlay.style.height = '220px';
+
+        const center = document.createElement('div');
+        center.style.display = 'flex';
+        center.style.alignItems = 'center';
+        center.style.justifyContent = 'center';
+        center.style.width = '100%';
+        center.style.height = '100%';
+
+        const button = document.createElement('adw-button');
+        button.textContent = 'Show toast';
+        button.setAttribute('pill', '');
+        button.setAttribute('suggested', '');
+        button.addEventListener('click', () => this._showToast());
+        center.append(button);
+
+        this._overlay.append(center);
+        this.addContent(this._overlay);
+    }
+
+    private _showToast(): void {
+        if (!this._overlay) return;
+        const hasButton = this.args.hasButton as boolean;
+        this._overlay.addToast(this.args.title as string, {
+            timeout: this.args.timeout as number,
+            buttonLabel: hasButton ? (this.args.buttonLabel as string) : undefined,
+        });
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        // Toasts are built on demand in _showToast(); nothing to re-apply to the overlay.
+    }
+}
+
+export const ToastWebStories: WebStoryModule = { stories: [ToastWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/layout/clamp.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/layout/clamp.web.ts
@@ -1,0 +1,45 @@
+// Browser port of the Clamp story. Shares metadata with clamp.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { clampMeta } from '../../layout/clamp.meta.js';
+
+export class ClampWebStory extends StoryElement {
+    private _clamp: HTMLElement | null = null;
+
+    constructor() {
+        super(ClampWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return clampMeta;
+    }
+
+    initialize(): void {
+        // The card fills the clamp, which caps its width at maximum-size and
+        // centres it — so the text wraps within the clamped width (a fixed
+        // width wider than the clamp would overflow and clip instead).
+        const inner = document.createElement('adw-card');
+        inner.style.width = '100%';
+        inner.style.boxSizing = 'border-box';
+        inner.style.padding = '18px';
+        inner.textContent =
+            'This content is clamped — it stops growing past the maximum size and stays centred.';
+
+        this._clamp = document.createElement('adw-clamp');
+        this._clamp.append(inner);
+        this._syncClamp();
+
+        this.addContent(this._clamp);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._syncClamp();
+    }
+
+    private _syncClamp(): void {
+        if (!this._clamp) return;
+        this._clamp.setAttribute('maximum-size', String(this.args.maximumSize as number));
+    }
+}
+
+export const ClampWebStories: WebStoryModule = { stories: [ClampWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/layout/header-bar.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/layout/header-bar.web.ts
@@ -1,0 +1,56 @@
+// Browser port of the Header Bar story. Shares metadata with header-bar.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { headerBarMeta } from '../../layout/header-bar.meta.js';
+
+export class HeaderBarWebStory extends StoryElement {
+    private _headerBar: HTMLElement | null = null;
+    private _title: HTMLElement | null = null;
+
+    constructor() {
+        super(HeaderBarWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return headerBarMeta;
+    }
+
+    initialize(): void {
+        // Center title widget — the equivalent of Adw.HeaderBar's title-widget.
+        this._title = document.createElement('adw-window-title');
+        this._title.setAttribute('slot', 'center');
+
+        // Start control — a flat back button.
+        const backButton = document.createElement('adw-button');
+        backButton.setAttribute('slot', 'start');
+        backButton.setAttribute('icon', 'go-previous');
+        backButton.setAttribute('flat', '');
+
+        // End control — a flat menu button.
+        const menuButton = document.createElement('adw-button');
+        menuButton.setAttribute('slot', 'end');
+        menuButton.setAttribute('icon', 'open-menu');
+        menuButton.setAttribute('flat', '');
+
+        this._headerBar = document.createElement('adw-header-bar');
+        this._headerBar.style.width = '460px';
+        this._headerBar.append(backButton, this._title, menuButton);
+
+        this._sync();
+        this.addContent(this._headerBar);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._sync();
+    }
+
+    private _sync(): void {
+        if (!this._title) return;
+        this._title.setAttribute('title', this.args.title as string);
+        this._title.setAttribute('subtitle', this.args.subtitle as string);
+        // Adw.HeaderBar.showTitle toggles visibility of the title widget.
+        this._title.hidden = !(this.args.showTitle as boolean);
+    }
+}
+
+export const HeaderBarWebStories: WebStoryModule = { stories: [HeaderBarWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/layout/toolbar-view.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/layout/toolbar-view.web.ts
@@ -1,0 +1,95 @@
+// Browser port of the Toolbar View story. Shares metadata with toolbar-view.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { toolbarViewMeta } from '../../layout/toolbar-view.meta.js';
+
+export class ToolbarViewWebStory extends StoryElement {
+    private _topBar: HTMLElement | null = null;
+    private _bottomBar: HTMLElement | null = null;
+
+    constructor() {
+        super(ToolbarViewWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return toolbarViewMeta;
+    }
+
+    initialize(): void {
+        const view = document.createElement('adw-toolbar-view');
+        view.style.width = '460px';
+        view.style.height = '320px';
+
+        // Top header bar with a window title (matches Adw.HeaderBar + WindowTitle).
+        const header = document.createElement('adw-header-bar');
+        header.setAttribute('slot', 'top');
+        const title = document.createElement('adw-window-title');
+        title.setAttribute('slot', 'center');
+        title.setAttribute('title', 'Documents');
+        title.setAttribute('subtitle', '12 items');
+        header.appendChild(title);
+        view.appendChild(header);
+        this._topBar = header;
+
+        // Scrollable content — a status page sits between the toolbars.
+        const content = document.createElement('adw-status-page');
+        content.setAttribute('icon', 'folder');
+        content.setAttribute('title', 'Your library');
+        content.setAttribute(
+            'description',
+            'Content sits between the toolbars and scrolls independently of them.',
+        );
+        view.appendChild(content);
+
+        // Bottom action bar — flat start buttons, a centered label and an end button
+        // (mirrors the native Gtk.ActionBar with pack_start / center / pack_end).
+        const bottomBar = document.createElement('div');
+        bottomBar.setAttribute('slot', 'bottom');
+        bottomBar.className = 'adw-action-bar';
+        bottomBar.style.display = 'flex';
+        bottomBar.style.alignItems = 'center';
+        bottomBar.style.gap = 'var(--spacing-xs, 6px)';
+        bottomBar.style.padding = 'var(--spacing-xs, 6px)';
+        bottomBar.style.borderTop = '1px solid var(--separator-color, rgba(0, 0, 0, 0.15))';
+
+        const addButton = document.createElement('adw-button');
+        addButton.setAttribute('icon', 'list-add');
+        addButton.setAttribute('flat', '');
+        addButton.setAttribute('tooltip', 'Add');
+
+        const removeButton = document.createElement('adw-button');
+        removeButton.setAttribute('icon', 'list-remove');
+        removeButton.setAttribute('flat', '');
+        removeButton.setAttribute('tooltip', 'Remove');
+
+        const selectionLabel = document.createElement('span');
+        selectionLabel.textContent = 'Selection: none';
+        selectionLabel.style.flex = '1 1 auto';
+        selectionLabel.style.textAlign = 'center';
+
+        const shareButton = document.createElement('adw-button');
+        shareButton.setAttribute('icon', 'send-to');
+        shareButton.setAttribute('flat', '');
+        shareButton.setAttribute('tooltip', 'Share');
+
+        bottomBar.append(addButton, removeButton, selectionLabel, shareButton);
+        view.appendChild(bottomBar);
+        this._bottomBar = bottomBar;
+
+        this._sync();
+        this.addContent(view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._sync();
+    }
+
+    private _sync(): void {
+        // The web toolbar view has no reveal properties; mirror revealTopBars /
+        // revealBottomBars by collapsing the top/bottom bars themselves.
+        if (this._topBar) this._topBar.hidden = !(this.args.revealTopBars as boolean);
+        if (this._bottomBar) this._bottomBar.hidden = !(this.args.revealBottomBars as boolean);
+    }
+}
+
+export const ToolbarViewWebStories: WebStoryModule = { stories: [ToolbarViewWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/layout/wrap-box.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/layout/wrap-box.web.ts
@@ -1,0 +1,45 @@
+// Browser port of the Wrap Box story. Shares metadata with wrap-box.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { wrapBoxMeta } from '../../layout/wrap-box.meta.js';
+
+const TAGS = ['Design', 'Adwaita', 'GNOME', 'GTK', 'Typescript', 'Storybook', 'Wrapping', 'Layout'];
+
+export class WrapBoxWebStory extends StoryElement {
+    private _wrap: HTMLElement | null = null;
+
+    constructor() {
+        super(WrapBoxWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return wrapBoxMeta;
+    }
+
+    initialize(): void {
+        this._wrap = document.createElement('adw-wrap-box');
+        this._wrap.style.width = '460px';
+
+        for (const tag of TAGS) {
+            const chip = document.createElement('adw-button');
+            chip.setAttribute('label', tag);
+            chip.setAttribute('pill', '');
+            this._wrap.append(chip);
+        }
+
+        this._syncWrap();
+        this.addContent(this._wrap);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._syncWrap();
+    }
+
+    private _syncWrap(): void {
+        if (!this._wrap) return;
+        this._wrap.setAttribute('child-spacing', String(this.args.childSpacing as number));
+        this._wrap.setAttribute('line-spacing', String(this.args.lineSpacing as number));
+    }
+}
+
+export const WrapBoxWebStories: WebStoryModule = { stories: [WrapBoxWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/main.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/main.ts
@@ -27,6 +27,10 @@ import { ClampWebStories } from './layout/clamp.web.js';
 import { HeaderBarWebStories } from './layout/header-bar.web.js';
 import { ToolbarViewWebStories } from './layout/toolbar-view.web.js';
 import { WrapBoxWebStories } from './layout/wrap-box.web.js';
+import { CarouselWebStories } from './view-switching/carousel.web.js';
+import { InlineViewSwitcherWebStories } from './view-switching/inline-view-switcher.web.js';
+import { TabViewWebStories } from './view-switching/tab-view.web.js';
+import { ViewSwitcherWebStories } from './view-switching/view-switcher.web.js';
 
 // Order mirrors the native sidebar's category order (Presentation, Boxed
 // Lists, Buttons, …).
@@ -53,6 +57,10 @@ const stories: WebStoryModule[] = [
     HeaderBarWebStories,
     ToolbarViewWebStories,
     WrapBoxWebStories,
+    CarouselWebStories,
+    InlineViewSwitcherWebStories,
+    TabViewWebStories,
+    ViewSwitcherWebStories,
 ];
 
 mountStorybook(document.body, { title: 'Adwaita Storybook', stories });

--- a/showcases/gtk/adwaita-storybook/src/browser/main.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/main.ts
@@ -23,6 +23,10 @@ import { ButtonContentWebStories } from './buttons/button-content.web.js';
 import { ButtonStylesWebStories } from './buttons/button-styles.web.js';
 import { SplitButtonWebStories } from './buttons/split-button.web.js';
 import { ToggleGroupWebStories } from './buttons/toggle-group.web.js';
+import { ClampWebStories } from './layout/clamp.web.js';
+import { HeaderBarWebStories } from './layout/header-bar.web.js';
+import { ToolbarViewWebStories } from './layout/toolbar-view.web.js';
+import { WrapBoxWebStories } from './layout/wrap-box.web.js';
 
 // Order mirrors the native sidebar's category order (Presentation, Boxed
 // Lists, Buttons, …).
@@ -45,6 +49,10 @@ const stories: WebStoryModule[] = [
     ButtonStylesWebStories,
     SplitButtonWebStories,
     ToggleGroupWebStories,
+    ClampWebStories,
+    HeaderBarWebStories,
+    ToolbarViewWebStories,
+    WrapBoxWebStories,
 ];
 
 mountStorybook(document.body, { title: 'Adwaita Storybook', stories });

--- a/showcases/gtk/adwaita-storybook/src/browser/main.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/main.ts
@@ -36,6 +36,10 @@ import { NavigationSplitViewWebStories } from './navigation/navigation-split-vie
 import { NavigationViewWebStories } from './navigation/navigation-view.web.js';
 import { OverlaySplitViewWebStories } from './navigation/overlay-split-view.web.js';
 import { SidebarWebStories } from './navigation/sidebar.web.js';
+import { AboutDialogWebStories } from './feedback/about-dialog.web.js';
+import { AlertDialogWebStories } from './feedback/alert-dialog.web.js';
+import { PreferencesDialogWebStories } from './feedback/preferences-dialog.web.js';
+import { ToastWebStories } from './feedback/toast.web.js';
 
 // Order mirrors the native sidebar's category order (Presentation, Boxed
 // Lists, Buttons, …).
@@ -71,6 +75,10 @@ const stories: WebStoryModule[] = [
     NavigationViewWebStories,
     OverlaySplitViewWebStories,
     SidebarWebStories,
+    AboutDialogWebStories,
+    AlertDialogWebStories,
+    PreferencesDialogWebStories,
+    ToastWebStories,
 ];
 
 mountStorybook(document.body, { title: 'Adwaita Storybook', stories });

--- a/showcases/gtk/adwaita-storybook/src/browser/main.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/main.ts
@@ -31,6 +31,11 @@ import { CarouselWebStories } from './view-switching/carousel.web.js';
 import { InlineViewSwitcherWebStories } from './view-switching/inline-view-switcher.web.js';
 import { TabViewWebStories } from './view-switching/tab-view.web.js';
 import { ViewSwitcherWebStories } from './view-switching/view-switcher.web.js';
+import { BottomSheetWebStories } from './navigation/bottom-sheet.web.js';
+import { NavigationSplitViewWebStories } from './navigation/navigation-split-view.web.js';
+import { NavigationViewWebStories } from './navigation/navigation-view.web.js';
+import { OverlaySplitViewWebStories } from './navigation/overlay-split-view.web.js';
+import { SidebarWebStories } from './navigation/sidebar.web.js';
 
 // Order mirrors the native sidebar's category order (Presentation, Boxed
 // Lists, Buttons, …).
@@ -61,6 +66,11 @@ const stories: WebStoryModule[] = [
     InlineViewSwitcherWebStories,
     TabViewWebStories,
     ViewSwitcherWebStories,
+    BottomSheetWebStories,
+    NavigationSplitViewWebStories,
+    NavigationViewWebStories,
+    OverlaySplitViewWebStories,
+    SidebarWebStories,
 ];
 
 mountStorybook(document.body, { title: 'Adwaita Storybook', stories });

--- a/showcases/gtk/adwaita-storybook/src/browser/navigation/bottom-sheet.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/navigation/bottom-sheet.web.ts
@@ -1,0 +1,119 @@
+// Browser port of the Bottom Sheet story. Shares metadata with bottom-sheet.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { bottomSheetMeta } from '../../navigation/bottom-sheet.meta.js';
+
+/** GTK symbolic name (e.g. "list-add-symbolic") → adwaita-web icon class. */
+function iconClass(gtkName: string): string {
+    return `adw-icon adw-icon--${gtkName.replace(/-symbolic$/, '')}`;
+}
+
+export class BottomSheetWebStory extends StoryElement {
+    private _sheet: HTMLElement | null = null;
+
+    constructor() {
+        super(BottomSheetWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return bottomSheetMeta;
+    }
+
+    /** The persistent content — a centered pill button that toggles the sheet. */
+    private _buildContent(): HTMLElement {
+        const content = document.createElement('adw-bottom-sheet-content');
+
+        const center = document.createElement('div');
+        center.style.display = 'flex';
+        center.style.alignItems = 'center';
+        center.style.justifyContent = 'center';
+        center.style.width = '100%';
+        center.style.height = '100%';
+
+        const toggle = document.createElement('adw-button');
+        toggle.textContent = 'Toggle sheet';
+        toggle.setAttribute('pill', '');
+        toggle.setAttribute('suggested', '');
+        toggle.addEventListener('click', () => {
+            if (this._sheet) this._sheet.toggleAttribute('open');
+        });
+
+        center.append(toggle);
+        content.append(center);
+        return content;
+    }
+
+    /** The sheet — a title above a preferences group of share actions. */
+    private _buildSheet(): HTMLElement {
+        const sheet = document.createElement('adw-bottom-sheet-sheet');
+
+        const box = document.createElement('div');
+        box.style.display = 'flex';
+        box.style.flexDirection = 'column';
+        box.style.gap = '12px';
+        box.style.margin = '18px 18px 24px';
+
+        // Match the GTK .title-2 typography style (bold heading) inline — the
+        // adwaita-web skin has no typography utility class for it.
+        const title = document.createElement('span');
+        title.textContent = 'Share track';
+        title.style.fontSize = '15pt';
+        title.style.fontWeight = '800';
+        box.append(title);
+
+        const group = document.createElement('adw-preferences-group');
+        for (const [rowTitle, icon] of [
+            ['Copy link', 'edit-copy-symbolic'],
+            ['Send to a friend', 'mail-send-symbolic'],
+            ['Add to playlist', 'list-add-symbolic'],
+        ] as const) {
+            const row = document.createElement('adw-action-row');
+            row.setAttribute('title', rowTitle);
+            row.setAttribute('activatable', '');
+
+            const prefix = document.createElement('span');
+            prefix.setAttribute('slot', 'prefix');
+            prefix.className = iconClass(icon);
+            row.append(prefix);
+
+            group.append(row);
+        }
+        box.append(group);
+
+        sheet.append(box);
+        return sheet;
+    }
+
+    initialize(): void {
+        this._sheet = document.createElement('adw-bottom-sheet');
+        // Match the native story's fixed 480×340 viewport so the sheet has a
+        // bounded content area to slide over.
+        this._sheet.style.width = '480px';
+        this._sheet.style.height = '340px';
+
+        this._sheet.append(this._buildContent(), this._buildSheet());
+
+        this._sync();
+        this.addContent(this._sheet);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._sync();
+    }
+
+    private _sync(): void {
+        if (!this._sheet) return;
+        this._sheet.toggleAttribute('open', this.args.open as boolean);
+        this._setBool('modal', this.args.modal as boolean);
+        this._setBool('can-close', this.args.canClose as boolean);
+    }
+
+    /** Boolean attributes that default on are encoded as `="false"` when off. */
+    private _setBool(name: string, value: boolean): void {
+        if (!this._sheet) return;
+        if (value) this._sheet.setAttribute(name, '');
+        else this._sheet.setAttribute(name, 'false');
+    }
+}
+
+export const BottomSheetWebStories: WebStoryModule = { stories: [BottomSheetWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/navigation/navigation-split-view.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/navigation/navigation-split-view.web.ts
@@ -1,0 +1,99 @@
+// Browser port of the Navigation Split View story. Shares metadata with
+// navigation-split-view.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { navigationSplitViewMeta } from '../../navigation/navigation-split-view.meta.js';
+
+/** GTK symbolic name (e.g. "folder-symbolic") → adwaita-web icon class. */
+function iconClass(gtkName: string): string {
+    return `adw-icon adw-icon--${gtkName.replace(/-symbolic$/, '')}`;
+}
+
+export class NavigationSplitViewWebStory extends StoryElement {
+    private _view: HTMLElement | null = null;
+
+    constructor() {
+        super(NavigationSplitViewWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return navigationSplitViewMeta;
+    }
+
+    /** A boxed-list of mailboxes inside a toolbar view — the sidebar page. */
+    private buildSidebar(): HTMLElement {
+        const group = document.createElement('adw-preferences-group');
+        for (const [title, subtitle, icon] of [
+            ['All Mail', '128 messages', 'mail-unread-symbolic'],
+            ['Starred', '6 messages', 'starred-symbolic'],
+            ['Drafts', '2 messages', 'document-edit-symbolic'],
+            ['Archive', '512 messages', 'folder-symbolic'],
+        ] as const) {
+            const row = document.createElement('adw-action-row');
+            row.setAttribute('title', title);
+            row.setAttribute('subtitle', subtitle);
+            row.setAttribute('activatable', '');
+
+            const image = document.createElement('span');
+            image.setAttribute('slot', 'prefix');
+            image.className = iconClass(icon);
+            row.appendChild(image);
+
+            group.appendChild(row);
+        }
+
+        const header = document.createElement('adw-header-bar');
+        header.setAttribute('slot', 'top');
+        const title = document.createElement('adw-window-title');
+        title.setAttribute('slot', 'center');
+        title.setAttribute('title', 'Mailboxes');
+        header.appendChild(title);
+
+        const toolbarView = document.createElement('adw-toolbar-view');
+        toolbarView.setAttribute('slot', 'sidebar');
+        toolbarView.append(header, group);
+        return toolbarView;
+    }
+
+    /** A status page inside a toolbar view — the content page. */
+    private buildContent(): HTMLElement {
+        const status = document.createElement('adw-status-page');
+        status.setAttribute('icon', 'mail-unread-symbolic');
+        status.setAttribute('title', 'All Mail');
+        status.setAttribute('description', 'Select a conversation from the list to read it here.');
+
+        const header = document.createElement('adw-header-bar');
+        header.setAttribute('slot', 'top');
+        const title = document.createElement('adw-window-title');
+        title.setAttribute('slot', 'center');
+        title.setAttribute('title', 'All Mail');
+        header.appendChild(title);
+
+        const toolbarView = document.createElement('adw-toolbar-view');
+        toolbarView.setAttribute('slot', 'content');
+        toolbarView.append(header, status);
+        return toolbarView;
+    }
+
+    initialize(): void {
+        this._view = document.createElement('adw-navigation-split-view');
+        this._view.style.width = '480px';
+        this._view.style.height = '340px';
+        this._view.append(this.buildSidebar(), this.buildContent());
+
+        this._sync();
+        this.addContent(this._view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._sync();
+    }
+
+    private _sync(): void {
+        if (!this._view) return;
+        this._view.toggleAttribute('show-content', this.args.showContent as boolean);
+        this._view.toggleAttribute('collapsed', this.args.collapsed as boolean);
+    }
+}
+
+export const NavigationSplitViewWebStories: WebStoryModule = { stories: [NavigationSplitViewWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/navigation/navigation-view.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/navigation/navigation-view.web.ts
@@ -1,0 +1,104 @@
+// Browser port of the Navigation View story. Shares metadata with
+// navigation-view.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { navigationViewMeta } from '../../navigation/navigation-view.meta.js';
+
+interface AdwNavigationViewEl extends HTMLElement {
+    push(pageOrTag: HTMLElement | string): void;
+}
+
+export class NavigationViewWebStory extends StoryElement {
+    private _view: AdwNavigationViewEl | null = null;
+    private _rootTitle: HTMLElement | null = null;
+    private _detailPage: HTMLElement | null = null;
+    private _detailTitle: HTMLElement | null = null;
+    private _detailStatus: HTMLElement | null = null;
+
+    constructor() {
+        super(NavigationViewWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return navigationViewMeta;
+    }
+
+    initialize(): void {
+        this._view = document.createElement('adw-navigation-view') as AdwNavigationViewEl;
+        this._view.style.width = '480px';
+        this._view.style.height = '340px';
+        this._view.setAttribute(
+            'animate-transitions',
+            (this.args.animateTransitions as boolean) ? 'true' : 'false',
+        );
+
+        // --- Detail page: a status page describing the contact. ---
+        this._detailTitle = document.createElement('adw-window-title');
+        this._detailTitle.setAttribute('title', this.args.detailTitle as string);
+        this._detailTitle.setAttribute('slot', 'center');
+
+        this._detailStatus = document.createElement('adw-status-page');
+        this._detailStatus.setAttribute('icon', 'avatar-default');
+        this._detailStatus.setAttribute('title', this.args.detailTitle as string);
+        this._detailStatus.setAttribute('description', 'Mathematician and writer, the first computer programmer.');
+
+        const detailHeader = document.createElement('adw-header-bar');
+        detailHeader.setAttribute('slot', 'top');
+        detailHeader.appendChild(this._detailTitle);
+
+        const detailToolbar = document.createElement('adw-toolbar-view');
+        detailToolbar.append(detailHeader, this._detailStatus);
+
+        this._detailPage = document.createElement('adw-navigation-page');
+        this._detailPage.setAttribute('tag', 'detail');
+        this._detailPage.setAttribute('title', this.args.detailTitle as string);
+        this._detailPage.appendChild(detailToolbar);
+
+        // --- Root page: an "Open contact" pill button that pushes the detail. ---
+        this._rootTitle = document.createElement('adw-window-title');
+        this._rootTitle.setAttribute('title', this.args.rootTitle as string);
+        this._rootTitle.setAttribute('slot', 'center');
+
+        const openButton = document.createElement('adw-button');
+        openButton.setAttribute('label', 'Open contact');
+        openButton.setAttribute('pill', '');
+        openButton.setAttribute('suggested', '');
+        openButton.classList.add('adw-navigation-view-root-action');
+        openButton.addEventListener('click', () => {
+            this._view?.push('detail');
+        });
+
+        const rootHeader = document.createElement('adw-header-bar');
+        rootHeader.setAttribute('slot', 'top');
+        rootHeader.appendChild(this._rootTitle);
+
+        const rootToolbar = document.createElement('adw-toolbar-view');
+        rootToolbar.append(rootHeader, openButton);
+
+        const rootPage = document.createElement('adw-navigation-page');
+        rootPage.setAttribute('tag', 'root');
+        rootPage.setAttribute('title', this.args.rootTitle as string);
+        rootPage.appendChild(rootToolbar);
+
+        // Root is the first child (auto-pushed); the detail is a static page made
+        // reachable via push-by-tag.
+        this._view.append(rootPage, this._detailPage);
+
+        this.addContent(this._view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._view) return;
+        this._view.setAttribute(
+            'animate-transitions',
+            (this.args.animateTransitions as boolean) ? 'true' : 'false',
+        );
+        this._rootTitle?.setAttribute('title', this.args.rootTitle as string);
+        const detailTitle = this.args.detailTitle as string;
+        this._detailTitle?.setAttribute('title', detailTitle);
+        this._detailStatus?.setAttribute('title', detailTitle);
+        this._detailPage?.setAttribute('title', detailTitle);
+    }
+}
+
+export const NavigationViewWebStories: WebStoryModule = { stories: [NavigationViewWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/navigation/overlay-split-view.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/navigation/overlay-split-view.web.ts
@@ -1,0 +1,106 @@
+// Browser port of the Overlay Split View story. Shares metadata with
+// overlay-split-view.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { overlaySplitViewMeta } from '../../navigation/overlay-split-view.meta.js';
+
+/**
+ * Sidebar rows — title plus the symbolic icon shown as the row prefix. Icon
+ * names mirror the native story's GTK names 1:1 (the `-symbolic` suffix is
+ * dropped to form the adwaita-web mask class, as elsewhere in the browser port).
+ */
+const SIDEBAR_ROWS: ReadonlyArray<readonly [string, string]> = [
+    ['Home', 'go-home'],
+    ['Discover', 'system-search'],
+    ['Library', 'folder-music'],
+    ['Settings', 'emblem-system'],
+];
+
+export class OverlaySplitViewWebStory extends StoryElement {
+    private _view: HTMLElement | null = null;
+
+    constructor() {
+        super(OverlaySplitViewWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return overlaySplitViewMeta;
+    }
+
+    private buildSidebar(): HTMLElement {
+        // A boxed list of activatable rows, each with a leading symbolic icon —
+        // the equivalent of the native story's Adw.PreferencesGroup of ActionRows.
+        const group = document.createElement('adw-preferences-group');
+        for (const [title, icon] of SIDEBAR_ROWS) {
+            const row = document.createElement('adw-action-row');
+            row.setAttribute('title', title);
+            row.setAttribute('activatable', '');
+
+            const iconEl = document.createElement('span');
+            iconEl.setAttribute('slot', 'prefix');
+            iconEl.className = `adw-icon adw-icon--${icon}`;
+            row.appendChild(iconEl);
+
+            group.appendChild(row);
+        }
+
+        // Toolbar view with a title-less header bar, framing the boxed list.
+        // `sidebar` styling mirrors the native add_css_class('sidebar').
+        const toolbarView = document.createElement('adw-toolbar-view');
+        toolbarView.classList.add('sidebar');
+
+        const header = document.createElement('adw-header-bar');
+        header.setAttribute('slot', 'top');
+        toolbarView.appendChild(header);
+        toolbarView.appendChild(group);
+
+        return toolbarView;
+    }
+
+    private buildContent(): HTMLElement {
+        const status = document.createElement('adw-status-page');
+        status.setAttribute('icon', 'folder-music');
+        status.setAttribute('title', 'Your Library');
+        status.setAttribute(
+            'description',
+            'Toggle the sidebar to browse sections. Collapse it to overlay the content.',
+        );
+
+        const toolbarView = document.createElement('adw-toolbar-view');
+        const header = document.createElement('adw-header-bar');
+        header.setAttribute('slot', 'top');
+        toolbarView.appendChild(header);
+        toolbarView.appendChild(status);
+
+        return toolbarView;
+    }
+
+    initialize(): void {
+        this._view = document.createElement('adw-overlay-split-view');
+        this._view.style.width = '480px';
+        this._view.style.height = '340px';
+
+        const sidebar = this.buildSidebar();
+        sidebar.setAttribute('slot', 'sidebar');
+
+        const content = this.buildContent();
+        content.setAttribute('slot', 'content');
+
+        this._view.append(sidebar, content);
+
+        this._sync();
+        this.addContent(this._view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._sync();
+    }
+
+    private _sync(): void {
+        if (!this._view) return;
+        this._view.toggleAttribute('show-sidebar', this.args.showSidebar as boolean);
+        this._view.toggleAttribute('collapsed', this.args.collapsed as boolean);
+    }
+}
+
+export const OverlaySplitViewWebStories: WebStoryModule = { stories: [OverlaySplitViewWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/navigation/sidebar.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/navigation/sidebar.web.ts
@@ -1,0 +1,84 @@
+// Browser port of the Sidebar story. Shares metadata with sidebar.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { sidebarMeta } from '../../navigation/sidebar.meta.js';
+
+export class SidebarWebStory extends StoryElement {
+    private _sidebar: HTMLElement | null = null;
+    private _status: HTMLElement | null = null;
+
+    private readonly items: readonly { title: string; subtitle: string; icon: string }[] = [
+        { title: 'Inbox', subtitle: '3 unread', icon: 'mail-unread-symbolic' },
+        { title: 'Starred', subtitle: 'Favourites', icon: 'starred-symbolic' },
+        { title: 'Sent', subtitle: 'Outgoing mail', icon: 'mail-send-symbolic' },
+        { title: 'Archive', subtitle: 'Older mail', icon: 'folder-symbolic' },
+    ];
+
+    constructor() {
+        super(SidebarWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return sidebarMeta;
+    }
+
+    initialize(): void {
+        const section = document.createElement('adw-sidebar-section');
+        section.setAttribute('title', 'Mailboxes');
+        for (const entry of this.items) {
+            const item = document.createElement('adw-sidebar-item');
+            item.setAttribute('title', entry.title);
+            item.setAttribute('subtitle', entry.subtitle);
+            item.setAttribute('icon-name', entry.icon);
+            section.append(item);
+        }
+
+        this._sidebar = document.createElement('adw-sidebar');
+        this._sidebar.setAttribute('mode', this.args.mode as string);
+        this._sidebar.setAttribute('selected', String(this.args.selected as number));
+        this._sidebar.style.width = '220px';
+        this._sidebar.append(section);
+        this._sidebar.addEventListener('notify::selected', () => this._syncContent());
+
+        this._status = document.createElement('adw-status-page');
+        this._status.style.flex = '1 1 auto';
+
+        const box = document.createElement('div');
+        box.style.display = 'flex';
+        box.style.width = '480px';
+        box.style.height = '340px';
+        box.style.border = '1px solid var(--card-shade-color)';
+        box.style.borderRadius = 'var(--card-radius, 12px)';
+        box.style.overflow = 'hidden';
+
+        const separator = document.createElement('div');
+        separator.style.width = '1px';
+        separator.style.alignSelf = 'stretch';
+        separator.style.backgroundColor = 'var(--separator-color, var(--card-shade-color))';
+
+        box.append(this._sidebar, separator, this._status);
+
+        this._syncContent();
+        this.addContent(box);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._sidebar) return;
+        this._sidebar.setAttribute('mode', this.args.mode as string);
+        this._sidebar.setAttribute('selected', String(this.args.selected as number));
+        this._syncContent();
+    }
+
+    private _syncContent(): void {
+        if (!this._sidebar || !this._status) return;
+        const selected = Number((this._sidebar as unknown as { selected: number }).selected);
+        const item = this.items[selected] ?? this.items[0];
+        this._status.setAttribute('title', item.title);
+        // adw-status-page's `icon` attribute is a plain symbolic name (it strips
+        // -symbolic and builds the adw-icon class itself).
+        this._status.setAttribute('icon', item.icon.replace(/-symbolic$/, ''));
+        this._status.setAttribute('description', item.subtitle);
+    }
+}
+
+export const SidebarWebStories: WebStoryModule = { stories: [SidebarWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/view-switching/carousel.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/view-switching/carousel.web.ts
@@ -1,0 +1,106 @@
+// Browser port of the Carousel stories — adw-carousel with three card pages,
+// paired with the dot / line page indicators. Shares its metadata/controls with
+// the GTK twin (carousel.story.ts). Adw.Carousel has two indicator widgets, so
+// this module exports two stories (Dots + Lines), mirroring the native file.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { carouselDotsMeta, carouselLinesMeta } from '../../view-switching/carousel.meta.js';
+
+// Subtle tints over the window background — libadwaita's .card.accent/.success/
+// .warning are a faint colour wash on the card, not a saturated fill.
+const PAGES: ReadonlyArray<{ title: string; accent: string }> = [
+    { title: 'Welcome', accent: 'color-mix(in srgb, var(--accent-bg-color) 14%, var(--window-bg-color))' },
+    { title: 'Discover', accent: 'color-mix(in srgb, #2ec27e 14%, var(--window-bg-color))' },
+    { title: 'Get started', accent: 'color-mix(in srgb, #e5a50a 14%, var(--window-bg-color))' },
+];
+
+let nextCarouselId = 0;
+
+/** Build a single accent-tinted card page, sized like the native demo. */
+function buildPage(title: string, accent: string): HTMLElement {
+    const card = document.createElement('adw-card');
+    card.style.cssText = [
+        'width:440px',
+        'height:260px',
+        'display:flex',
+        'align-items:center',
+        'justify-content:center',
+        `background-color:${accent}`,
+        'color:#ffffff',
+        'box-sizing:border-box',
+    ].join(';');
+
+    const label = document.createElement('span');
+    label.textContent = title;
+    // .title-1 in libadwaita ≈ 24pt bold.
+    label.style.cssText = 'font-size:24pt;font-weight:800;';
+    card.appendChild(label);
+    return card;
+}
+
+/** Shared body for both indicator variants — only the indicator tag differs. */
+abstract class CarouselWebStoryBase extends StoryElement {
+    private _carousel: HTMLElement | null = null;
+
+    /** The indicator tag this variant pairs with the carousel. */
+    protected abstract indicatorTag(): string;
+
+    initialize(): void {
+        const carousel = document.createElement('adw-carousel');
+        carousel.id = `adw-carousel-${nextCarouselId++}`;
+        carousel.style.cssText = 'width:480px;height:280px;';
+        carousel.toggleAttribute('allow-scroll-wheel', this.args.allowScrollWheel as boolean);
+        carousel.toggleAttribute('allow-long-swipes', this.args.allowLongSwipes as boolean);
+        for (const page of PAGES) {
+            carousel.appendChild(buildPage(page.title, page.accent));
+        }
+        this._carousel = carousel;
+
+        const indicator = document.createElement(this.indicatorTag());
+        indicator.setAttribute('for', carousel.id);
+
+        const box = document.createElement('div');
+        box.style.cssText = 'display:flex;flex-direction:column;gap:12px;width:480px;align-items:center;';
+        box.append(carousel, indicator);
+
+        this.addContent(box);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._carousel) return;
+        this._carousel.toggleAttribute('allow-scroll-wheel', this.args.allowScrollWheel as boolean);
+        this._carousel.toggleAttribute('allow-long-swipes', this.args.allowLongSwipes as boolean);
+    }
+}
+
+/** Story: adw-carousel with dot indicators. */
+export class CarouselDotsWebStory extends CarouselWebStoryBase {
+    constructor() {
+        super(CarouselDotsWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return carouselDotsMeta;
+    }
+
+    protected indicatorTag(): string {
+        return 'adw-carousel-indicator-dots';
+    }
+}
+
+/** Story: adw-carousel with line indicators. */
+export class CarouselLinesWebStory extends CarouselWebStoryBase {
+    constructor() {
+        super(CarouselLinesWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return carouselLinesMeta;
+    }
+
+    protected indicatorTag(): string {
+        return 'adw-carousel-indicator-lines';
+    }
+}
+
+export const CarouselWebStories: WebStoryModule = { stories: [CarouselDotsWebStory, CarouselLinesWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/view-switching/inline-view-switcher.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/view-switching/inline-view-switcher.web.ts
@@ -1,0 +1,55 @@
+// Browser port of the Inline View Switcher story — adw-inline-view-switcher
+// driving a stack of three adw-view-stack-page children, with the display-mode
+// control (labels / icons / both). Shares its metadata/controls with the GTK
+// twin (inline-view-switcher.story.ts).
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { inlineViewSwitcherMeta } from '../../view-switching/inline-view-switcher.meta.js';
+
+// The three pages, mirroring the native demo (Overview / Activity / Settings).
+const PAGES: ReadonlyArray<{ id: string; title: string; icon: string; body: string }> = [
+    { id: 'overview', title: 'Overview', icon: 'view-grid', body: 'A quick summary of your project.' },
+    { id: 'activity', title: 'Activity', icon: 'document-edit', body: 'Recent edits and changes.' },
+    { id: 'settings', title: 'Settings', icon: 'emblem-system', body: 'Configure how things behave.' },
+];
+
+export class InlineViewSwitcherWebStory extends StoryElement {
+    private _switcher: HTMLElement | null = null;
+
+    constructor() {
+        super(InlineViewSwitcherWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return inlineViewSwitcherMeta;
+    }
+
+    initialize(): void {
+        const switcher = document.createElement('adw-inline-view-switcher');
+        for (const { id, title, icon, body } of PAGES) {
+            const page = document.createElement('adw-view-stack-page');
+            page.setAttribute('title', title);
+            page.setAttribute('icon-name', icon);
+
+            // A status-page body per page (mirrors the native Adw.StatusPage pages).
+            const status = document.createElement('adw-status-page');
+            status.id = id;
+            status.setAttribute('icon', icon);
+            status.setAttribute('title', title);
+            status.setAttribute('description', body);
+            page.appendChild(status);
+
+            switcher.appendChild(page);
+        }
+        switcher.setAttribute('display-mode', this.args.displayMode as string);
+        this._switcher = switcher;
+        this.addContent(switcher);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._switcher) return;
+        this._switcher.setAttribute('display-mode', this.args.displayMode as string);
+    }
+}
+
+export const InlineViewSwitcherWebStories: WebStoryModule = { stories: [InlineViewSwitcherWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/view-switching/tab-view.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/view-switching/tab-view.web.ts
@@ -1,0 +1,64 @@
+// Browser port of the Tab View story — an adw-tab-view with three adw-tab-page
+// children, each holding an adw-status-page body, plus the autohide control.
+// Shares its metadata/controls with the GTK twin (tab-view.story.ts).
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { tabViewMeta } from '../../view-switching/tab-view.meta.js';
+
+const TABS: ReadonlyArray<{ title: string; body: string }> = [
+    { title: 'Overview', body: 'A summary of everything at a glance.' },
+    { title: 'Details', body: 'The specifics, broken down line by line.' },
+    { title: 'History', body: 'A log of every change made so far.' },
+];
+
+export class TabViewWebStory extends StoryElement {
+    private _tabView: HTMLElement | null = null;
+
+    constructor() {
+        super(TabViewWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return tabViewMeta;
+    }
+
+    initialize(): void {
+        const tabView = document.createElement('adw-tab-view');
+        tabView.style.width = '480px';
+        tabView.style.height = '340px';
+
+        for (const tab of TABS) {
+            const page = document.createElement('adw-tab-page');
+            page.setAttribute('title', tab.title);
+            page.appendChild(this._buildPageBody(tab.title, tab.body));
+            tabView.appendChild(page);
+        }
+
+        this._tabView = tabView;
+        this._applyAutohide(this.args.autohide as boolean);
+        this.addContent(tabView);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._tabView) return;
+        this._applyAutohide(this.args.autohide as boolean);
+    }
+
+    // `view-grid` stands in for the native `view-paged-symbolic` — the closest
+    // icon in @gjsify/adwaita-icons.
+    private _buildPageBody(title: string, body: string): HTMLElement {
+        const status = document.createElement('adw-status-page');
+        status.setAttribute('icon', 'view-grid');
+        status.setAttribute('title', title);
+        status.setAttribute('description', body);
+        return status;
+    }
+
+    private _applyAutohide(autohide: boolean): void {
+        if (!this._tabView) return;
+        if (autohide) this._tabView.setAttribute('autohide', '');
+        else this._tabView.removeAttribute('autohide');
+    }
+}
+
+export const TabViewWebStories: WebStoryModule = { stories: [TabViewWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/view-switching/view-switcher.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/view-switching/view-switcher.web.ts
@@ -1,0 +1,55 @@
+// Browser port of the View Switcher story — adw-view-switcher with three
+// adw-view-switcher-page children (each an adw-status-page body) and the
+// wide/narrow policy. Shares its metadata/controls with the GTK twin
+// (view-switcher.story.ts).
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { viewSwitcherMeta } from '../../view-switching/view-switcher.meta.js';
+
+// The three pages, mirroring the native demo (Inbox / Starred / Archive).
+const PAGES: ReadonlyArray<{ name: string; title: string; icon: string; description: string }> = [
+    { name: 'inbox', title: 'Inbox', icon: 'mail-unread', description: 'You have three unread conversations.' },
+    { name: 'starred', title: 'Starred', icon: 'starred', description: 'Messages you have marked as important.' },
+    { name: 'archive', title: 'Archive', icon: 'folder', description: 'Older conversations kept for reference.' },
+];
+
+export class ViewSwitcherWebStory extends StoryElement {
+    private _switcher: HTMLElement | null = null;
+
+    constructor() {
+        super(ViewSwitcherWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return viewSwitcherMeta;
+    }
+
+    initialize(): void {
+        const switcher = document.createElement('adw-view-switcher');
+        for (const { name, title, icon, description } of PAGES) {
+            const page = document.createElement('adw-view-switcher-page');
+            page.setAttribute('name', name);
+            page.setAttribute('title', title);
+            page.setAttribute('icon-name', icon);
+
+            const status = document.createElement('adw-status-page');
+            status.setAttribute('icon', icon);
+            status.setAttribute('title', title);
+            status.setAttribute('description', description);
+            page.appendChild(status);
+
+            switcher.appendChild(page);
+        }
+        switcher.setAttribute('policy', this.args.policy as string);
+        switcher.style.width = '480px';
+        this._switcher = switcher;
+        this.addContent(switcher);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        if (!this._switcher) return;
+        this._switcher.setAttribute('policy', this.args.policy as string);
+    }
+}
+
+export const ViewSwitcherWebStories: WebStoryModule = { stories: [ViewSwitcherWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/feedback/about-dialog.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/about-dialog.meta.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic metadata for the About Dialog story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const aboutDialogMeta: StoryMeta = {
+    title: 'Feedback/About Dialog',
+    description:
+        'Adw.AboutDialog — the standard Adwaita about window with application name, version, credits and license.',
+    controls: [
+        { name: 'applicationName', label: 'Application name', type: ControlType.TEXT, defaultValue: 'Adwaita Storybook' },
+        { name: 'version', label: 'Version', type: ControlType.TEXT, defaultValue: '0.11.0' },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/feedback/about-dialog.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/about-dialog.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { aboutDialogMeta } from './about-dialog.meta.js';
 
 /** Story: Adw.AboutDialog presented from a button, with app metadata + credits. */
 export class AboutDialogStory extends StoryWidget {
@@ -19,21 +20,7 @@ export class AboutDialogStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Feedback/About Dialog',
-            description:
-                'Adw.AboutDialog — the standard Adwaita about window with application name, version, credits and license.',
-            component: Adw.AboutDialog.$gtype,
-            controls: [
-                {
-                    name: 'applicationName',
-                    label: 'Application name',
-                    type: ControlType.TEXT,
-                    defaultValue: 'Adwaita Storybook',
-                },
-                { name: 'version', label: 'Version', type: ControlType.TEXT, defaultValue: '0.11.0' },
-            ],
-        };
+        return { ...aboutDialogMeta, component: Adw.AboutDialog.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/feedback/alert-dialog.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/alert-dialog.meta.ts
@@ -1,0 +1,19 @@
+// Shared, renderer-agnostic metadata for the Alert Dialog story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const alertDialogMeta: StoryMeta = {
+    title: 'Feedback/Alert Dialog',
+    description:
+        'Adw.AlertDialog — a modal dialog with a heading, body text and responses, including a destructive action.',
+    controls: [
+        { name: 'heading', label: 'Heading', type: ControlType.TEXT, defaultValue: 'Delete Project?' },
+        {
+            name: 'body',
+            label: 'Body',
+            type: ControlType.TEXT,
+            defaultValue:
+                'This will permanently remove the project and all of its files. This action cannot be undone.',
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/feedback/alert-dialog.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/alert-dialog.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { alertDialogMeta } from './alert-dialog.meta.js';
 
 /** Story: Adw.AlertDialog presented from a button, with cancel/destructive responses. */
 export class AlertDialogStory extends StoryWidget {
@@ -19,22 +20,7 @@ export class AlertDialogStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Feedback/Alert Dialog',
-            description:
-                'Adw.AlertDialog — a modal dialog with a heading, body text and responses, including a destructive action.',
-            component: Adw.AlertDialog.$gtype,
-            controls: [
-                { name: 'heading', label: 'Heading', type: ControlType.TEXT, defaultValue: 'Delete Project?' },
-                {
-                    name: 'body',
-                    label: 'Body',
-                    type: ControlType.TEXT,
-                    defaultValue:
-                        'This will permanently remove the project and all of its files. This action cannot be undone.',
-                },
-            ],
-        };
+        return { ...alertDialogMeta, component: Adw.AlertDialog.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/feedback/preferences-dialog.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/preferences-dialog.meta.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic metadata for the Preferences Dialog story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const preferencesDialogMeta: StoryMeta = {
+    title: 'Feedback/Preferences Dialog',
+    description:
+        'Adw.PreferencesDialog — a preferences window with a page, a group and a handful of boxed-list rows.',
+    controls: [
+        { name: 'pageTitle', label: 'Page title', type: ControlType.TEXT, defaultValue: 'General' },
+        { name: 'groupTitle', label: 'Group title', type: ControlType.TEXT, defaultValue: 'Appearance' },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/feedback/preferences-dialog.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/preferences-dialog.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { preferencesDialogMeta } from './preferences-dialog.meta.js';
 
 /** Story: Adw.PreferencesDialog presented from a button, with one page of rows. */
 export class PreferencesDialogStory extends StoryWidget {
@@ -19,16 +20,7 @@ export class PreferencesDialogStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Feedback/Preferences Dialog',
-            description:
-                'Adw.PreferencesDialog — a preferences window with a page, a group and a handful of boxed-list rows.',
-            component: Adw.PreferencesDialog.$gtype,
-            controls: [
-                { name: 'pageTitle', label: 'Page title', type: ControlType.TEXT, defaultValue: 'General' },
-                { name: 'groupTitle', label: 'Group title', type: ControlType.TEXT, defaultValue: 'Appearance' },
-            ],
-        };
+        return { ...preferencesDialogMeta, component: Adw.PreferencesDialog.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/feedback/toast.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/toast.meta.ts
@@ -1,0 +1,23 @@
+// Shared, renderer-agnostic metadata for the Toast story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const toastMeta: StoryMeta = {
+    title: 'Feedback/Toast',
+    description:
+        'Adw.Toast — a transient notification, with an optional action button, shown over an Adw.ToastOverlay.',
+    controls: [
+        { name: 'title', label: 'Toast text', type: ControlType.TEXT, defaultValue: 'File moved to Trash' },
+        {
+            name: 'timeout',
+            label: 'Timeout (s)',
+            type: ControlType.NUMBER,
+            min: 0,
+            max: 10,
+            step: 1,
+            defaultValue: 3,
+        },
+        { name: 'hasButton', label: 'Action button', type: ControlType.BOOLEAN, defaultValue: true },
+        { name: 'buttonLabel', label: 'Button label', type: ControlType.TEXT, defaultValue: 'Undo' },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/feedback/toast.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/feedback/toast.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { toastMeta } from './toast.meta.js';
 
 /** Story: Adw.Toast presented through an Adw.ToastOverlay on button press. */
 export class ToastStory extends StoryWidget {
@@ -19,26 +20,7 @@ export class ToastStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Feedback/Toast',
-            description:
-                'Adw.Toast — a transient notification, with an optional action button, shown over an Adw.ToastOverlay.',
-            component: Adw.Toast.$gtype,
-            controls: [
-                { name: 'title', label: 'Toast text', type: ControlType.TEXT, defaultValue: 'File moved to Trash' },
-                {
-                    name: 'timeout',
-                    label: 'Timeout (s)',
-                    type: ControlType.NUMBER,
-                    min: 0,
-                    max: 10,
-                    step: 1,
-                    defaultValue: 3,
-                },
-                { name: 'hasButton', label: 'Action button', type: ControlType.BOOLEAN, defaultValue: true },
-                { name: 'buttonLabel', label: 'Button label', type: ControlType.TEXT, defaultValue: 'Undo' },
-            ],
-        };
+        return { ...toastMeta, component: Adw.Toast.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/layout/clamp.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/clamp.meta.ts
@@ -1,0 +1,29 @@
+// Shared, renderer-agnostic metadata for the Clamp story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const clampMeta: StoryMeta = {
+    title: 'Layout/Clamp',
+    description:
+        'Adw.Clamp limits its child to a maximum width and centres it, tightening the layout as space shrinks.',
+    controls: [
+        {
+            name: 'maximumSize',
+            label: 'Maximum size',
+            type: ControlType.RANGE,
+            min: 200,
+            max: 600,
+            step: 10,
+            defaultValue: 400,
+        },
+        {
+            name: 'tighteningThreshold',
+            label: 'Tightening threshold',
+            type: ControlType.RANGE,
+            min: 100,
+            max: 600,
+            step: 10,
+            defaultValue: 300,
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/layout/clamp.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/clamp.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { clampMeta } from './clamp.meta.js';
 
 /** Story: Adw.Clamp constraining a wide child so the clamping is visible. */
 export class ClampStory extends StoryWidget {
@@ -19,32 +20,7 @@ export class ClampStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Layout/Clamp',
-            description:
-                'Adw.Clamp limits its child to a maximum width and centres it, tightening the layout as space shrinks.',
-            component: Adw.Clamp.$gtype,
-            controls: [
-                {
-                    name: 'maximumSize',
-                    label: 'Maximum size',
-                    type: ControlType.RANGE,
-                    min: 200,
-                    max: 600,
-                    step: 10,
-                    defaultValue: 400,
-                },
-                {
-                    name: 'tighteningThreshold',
-                    label: 'Tightening threshold',
-                    type: ControlType.RANGE,
-                    min: 100,
-                    max: 600,
-                    step: 10,
-                    defaultValue: 300,
-                },
-            ],
-        };
+        return { ...clampMeta, component: Adw.Clamp.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/layout/header-bar.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/header-bar.meta.ts
@@ -1,0 +1,14 @@
+// Shared, renderer-agnostic metadata for the Header Bar story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const headerBarMeta: StoryMeta = {
+    title: 'Layout/Header Bar',
+    description:
+        'Adw.HeaderBar hosts a custom title widget with start and end controls — the standard top chrome of an Adwaita window.',
+    controls: [
+        { name: 'title', label: 'Title', type: ControlType.TEXT, defaultValue: 'Text Editor' },
+        { name: 'subtitle', label: 'Subtitle', type: ControlType.TEXT, defaultValue: 'notes.md' },
+        { name: 'showTitle', label: 'Show title', type: ControlType.BOOLEAN, defaultValue: true },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/layout/header-bar.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/header-bar.story.ts
@@ -5,7 +5,8 @@ import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import Gio from '@girs/gio-2.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { headerBarMeta } from './header-bar.meta.js';
 
 /** Story: Adw.HeaderBar with an Adw.WindowTitle, a start icon button and an end menu button. */
 export class HeaderBarStory extends StoryWidget {
@@ -21,17 +22,7 @@ export class HeaderBarStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Layout/Header Bar',
-            description:
-                'Adw.HeaderBar hosts a custom title widget with start and end controls — the standard top chrome of an Adwaita window.',
-            component: Adw.HeaderBar.$gtype,
-            controls: [
-                { name: 'title', label: 'Title', type: ControlType.TEXT, defaultValue: 'Text Editor' },
-                { name: 'subtitle', label: 'Subtitle', type: ControlType.TEXT, defaultValue: 'notes.md' },
-                { name: 'showTitle', label: 'Show title', type: ControlType.BOOLEAN, defaultValue: true },
-            ],
-        };
+        return { ...headerBarMeta, component: Adw.HeaderBar.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/layout/toolbar-view.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/toolbar-view.meta.ts
@@ -1,0 +1,18 @@
+// Shared, renderer-agnostic metadata for the Toolbar View story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const toolbarViewMeta: StoryMeta = {
+    title: 'Layout/Toolbar View',
+    description:
+        'Adw.ToolbarView pins a top header bar and a bottom toolbar around its content, each independently revealable.',
+    controls: [
+        { name: 'revealTopBars', label: 'Reveal top bars', type: ControlType.BOOLEAN, defaultValue: true },
+        {
+            name: 'revealBottomBars',
+            label: 'Reveal bottom bars',
+            type: ControlType.BOOLEAN,
+            defaultValue: true,
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/layout/toolbar-view.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/toolbar-view.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { toolbarViewMeta } from './toolbar-view.meta.js';
 
 /** Story: Adw.ToolbarView with a header bar, status-page content and a bottom action bar. */
 export class ToolbarViewStory extends StoryWidget {
@@ -19,21 +20,7 @@ export class ToolbarViewStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Layout/Toolbar View',
-            description:
-                'Adw.ToolbarView pins a top header bar and a bottom toolbar around its content, each independently revealable.',
-            component: Adw.ToolbarView.$gtype,
-            controls: [
-                { name: 'revealTopBars', label: 'Reveal top bars', type: ControlType.BOOLEAN, defaultValue: true },
-                {
-                    name: 'revealBottomBars',
-                    label: 'Reveal bottom bars',
-                    type: ControlType.BOOLEAN,
-                    defaultValue: true,
-                },
-            ],
-        };
+        return { ...toolbarViewMeta, component: Adw.ToolbarView.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/layout/wrap-box.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/wrap-box.meta.ts
@@ -1,0 +1,29 @@
+// Shared, renderer-agnostic metadata for the Wrap Box story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const wrapBoxMeta: StoryMeta = {
+    title: 'Layout/Wrap Box',
+    description:
+        'Adw.WrapBox flows its children horizontally and wraps them onto new lines when they run out of room.',
+    controls: [
+        {
+            name: 'childSpacing',
+            label: 'Child spacing',
+            type: ControlType.RANGE,
+            min: 0,
+            max: 36,
+            step: 1,
+            defaultValue: 8,
+        },
+        {
+            name: 'lineSpacing',
+            label: 'Line spacing',
+            type: ControlType.RANGE,
+            min: 0,
+            max: 36,
+            step: 1,
+            defaultValue: 8,
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/layout/wrap-box.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/layout/wrap-box.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { wrapBoxMeta } from './wrap-box.meta.js';
 
 /** Story: Adw.WrapBox flowing a set of chip-like buttons across multiple lines. */
 export class WrapBoxStory extends StoryWidget {
@@ -19,32 +20,7 @@ export class WrapBoxStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Layout/Wrap Box',
-            description:
-                'Adw.WrapBox flows its children horizontally and wraps them onto new lines when they run out of room.',
-            component: Adw.WrapBox.$gtype,
-            controls: [
-                {
-                    name: 'childSpacing',
-                    label: 'Child spacing',
-                    type: ControlType.RANGE,
-                    min: 0,
-                    max: 36,
-                    step: 1,
-                    defaultValue: 8,
-                },
-                {
-                    name: 'lineSpacing',
-                    label: 'Line spacing',
-                    type: ControlType.RANGE,
-                    min: 0,
-                    max: 36,
-                    step: 1,
-                    defaultValue: 8,
-                },
-            ],
-        };
+        return { ...wrapBoxMeta, component: Adw.WrapBox.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/navigation/bottom-sheet.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/bottom-sheet.meta.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic metadata for the Bottom Sheet story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const bottomSheetMeta: StoryMeta = {
+    title: 'Navigation/Bottom Sheet',
+    description: 'Adw.BottomSheet — a sheet that slides up over the content. Toggle "Open" to reveal it.',
+    controls: [
+        { name: 'open', label: 'Open', type: ControlType.BOOLEAN, defaultValue: true },
+        { name: 'modal', label: 'Modal', type: ControlType.BOOLEAN, defaultValue: true },
+        { name: 'canClose', label: 'Can close', type: ControlType.BOOLEAN, defaultValue: true },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/navigation/bottom-sheet.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/bottom-sheet.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { bottomSheetMeta } from './bottom-sheet.meta.js';
 
 /** Story: Adw.BottomSheet with a toggleable sheet child. */
 export class BottomSheetStory extends StoryWidget {
@@ -19,16 +20,7 @@ export class BottomSheetStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Navigation/Bottom Sheet',
-            description: 'Adw.BottomSheet — a sheet that slides up over the content. Toggle "Open" to reveal it.',
-            component: Adw.BottomSheet.$gtype,
-            controls: [
-                { name: 'open', label: 'Open', type: ControlType.BOOLEAN, defaultValue: true },
-                { name: 'modal', label: 'Modal', type: ControlType.BOOLEAN, defaultValue: true },
-                { name: 'canClose', label: 'Can close', type: ControlType.BOOLEAN, defaultValue: true },
-            ],
-        };
+        return { ...bottomSheetMeta, component: Adw.BottomSheet.$gtype };
     }
 
     private buildContent(): Gtk.Widget {

--- a/showcases/gtk/adwaita-storybook/src/navigation/navigation-split-view.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/navigation-split-view.meta.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic metadata for the Navigation Split View story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const navigationSplitViewMeta: StoryMeta = {
+    title: 'Navigation/Navigation Split View',
+    description:
+        'Adw.NavigationSplitView — a resizable sidebar beside a content pane. When collapsed it folds into a navigation stack.',
+    controls: [
+        { name: 'showContent', label: 'Show content', type: ControlType.BOOLEAN, defaultValue: true },
+        { name: 'collapsed', label: 'Collapsed', type: ControlType.BOOLEAN, defaultValue: false },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/navigation/navigation-split-view.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/navigation-split-view.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { navigationSplitViewMeta } from './navigation-split-view.meta.js';
 
 /** Story: Adw.NavigationSplitView with a boxed-list sidebar and a content page. */
 export class NavigationSplitViewStory extends StoryWidget {
@@ -19,16 +20,7 @@ export class NavigationSplitViewStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Navigation/Navigation Split View',
-            description:
-                'Adw.NavigationSplitView — a resizable sidebar beside a content pane. When collapsed it folds into a navigation stack.',
-            component: Adw.NavigationSplitView.$gtype,
-            controls: [
-                { name: 'showContent', label: 'Show content', type: ControlType.BOOLEAN, defaultValue: true },
-                { name: 'collapsed', label: 'Collapsed', type: ControlType.BOOLEAN, defaultValue: false },
-            ],
-        };
+        return { ...navigationSplitViewMeta, component: Adw.NavigationSplitView.$gtype };
     }
 
     private buildSidebar(): Adw.NavigationPage {

--- a/showcases/gtk/adwaita-storybook/src/navigation/navigation-view.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/navigation-view.meta.ts
@@ -1,0 +1,19 @@
+// Shared, renderer-agnostic metadata for the Navigation View story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const navigationViewMeta: StoryMeta = {
+    title: 'Navigation/Navigation View',
+    description:
+        'Adw.NavigationView — a navigation stack. The root page pushes a detail page, which gets an automatic back button.',
+    controls: [
+        { name: 'rootTitle', label: 'Root title', type: ControlType.TEXT, defaultValue: 'Contacts' },
+        { name: 'detailTitle', label: 'Detail title', type: ControlType.TEXT, defaultValue: 'Ada Lovelace' },
+        {
+            name: 'animateTransitions',
+            label: 'Animate transitions',
+            type: ControlType.BOOLEAN,
+            defaultValue: true,
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/navigation/navigation-view.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/navigation-view.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { navigationViewMeta } from './navigation-view.meta.js';
 
 /** Story: Adw.NavigationView with a root page that pushes a detail page. */
 export class NavigationViewStory extends StoryWidget {
@@ -19,22 +20,7 @@ export class NavigationViewStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Navigation/Navigation View',
-            description:
-                'Adw.NavigationView — a navigation stack. The root page pushes a detail page, which gets an automatic back button.',
-            component: Adw.NavigationView.$gtype,
-            controls: [
-                { name: 'rootTitle', label: 'Root title', type: ControlType.TEXT, defaultValue: 'Contacts' },
-                { name: 'detailTitle', label: 'Detail title', type: ControlType.TEXT, defaultValue: 'Ada Lovelace' },
-                {
-                    name: 'animateTransitions',
-                    label: 'Animate transitions',
-                    type: ControlType.BOOLEAN,
-                    defaultValue: true,
-                },
-            ],
-        };
+        return { ...navigationViewMeta, component: Adw.NavigationView.$gtype };
     }
 
     private buildPage(title: string, body: Gtk.Widget): Adw.NavigationPage {

--- a/showcases/gtk/adwaita-storybook/src/navigation/overlay-split-view.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/overlay-split-view.meta.ts
@@ -1,0 +1,13 @@
+// Shared, renderer-agnostic metadata for the Overlay Split View story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const overlaySplitViewMeta: StoryMeta = {
+    title: 'Navigation/Overlay Split View',
+    description:
+        'Adw.OverlaySplitView — a sidebar shown beside the content, or overlaid on top of it when collapsed.',
+    controls: [
+        { name: 'showSidebar', label: 'Show sidebar', type: ControlType.BOOLEAN, defaultValue: true },
+        { name: 'collapsed', label: 'Collapsed', type: ControlType.BOOLEAN, defaultValue: false },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/navigation/overlay-split-view.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/overlay-split-view.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { overlaySplitViewMeta } from './overlay-split-view.meta.js';
 
 /** Story: Adw.OverlaySplitView with a boxed-list sidebar and a status-page content. */
 export class OverlaySplitViewStory extends StoryWidget {
@@ -19,16 +20,7 @@ export class OverlaySplitViewStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Navigation/Overlay Split View',
-            description:
-                'Adw.OverlaySplitView — a sidebar shown beside the content, or overlaid on top of it when collapsed.',
-            component: Adw.OverlaySplitView.$gtype,
-            controls: [
-                { name: 'showSidebar', label: 'Show sidebar', type: ControlType.BOOLEAN, defaultValue: true },
-                { name: 'collapsed', label: 'Collapsed', type: ControlType.BOOLEAN, defaultValue: false },
-            ],
-        };
+        return { ...overlaySplitViewMeta, component: Adw.OverlaySplitView.$gtype };
     }
 
     private buildSidebar(): Gtk.Widget {

--- a/showcases/gtk/adwaita-storybook/src/navigation/sidebar.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/sidebar.meta.ts
@@ -1,0 +1,30 @@
+// Shared, renderer-agnostic metadata for the Sidebar story.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const sidebarMeta: StoryMeta = {
+    title: 'Navigation/Sidebar',
+    description:
+        'Adw.Sidebar — a selectable list of Adw.SidebarItem grouped into sections. Selecting an item updates the content.',
+    controls: [
+        {
+            name: 'mode',
+            label: 'Mode',
+            type: ControlType.SELECT,
+            options: [
+                { label: 'Sidebar', value: 'sidebar' },
+                { label: 'Page', value: 'page' },
+            ],
+            defaultValue: 'sidebar',
+        },
+        {
+            name: 'selected',
+            label: 'Selected index',
+            type: ControlType.NUMBER,
+            min: 0,
+            max: 3,
+            step: 1,
+            defaultValue: 0,
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/navigation/sidebar.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/navigation/sidebar.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { sidebarMeta } from './sidebar.meta.js';
 
 /** Story: Adw.Sidebar with a titled Adw.SidebarSection driving a content pane. */
 export class SidebarStory extends StoryWidget {
@@ -20,33 +21,7 @@ export class SidebarStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'Navigation/Sidebar',
-            description:
-                'Adw.Sidebar — a selectable list of Adw.SidebarItem grouped into sections. Selecting an item updates the content.',
-            component: Adw.Sidebar.$gtype,
-            controls: [
-                {
-                    name: 'mode',
-                    label: 'Mode',
-                    type: ControlType.SELECT,
-                    options: [
-                        { label: 'Sidebar', value: 'sidebar' },
-                        { label: 'Page', value: 'page' },
-                    ],
-                    defaultValue: 'sidebar',
-                },
-                {
-                    name: 'selected',
-                    label: 'Selected index',
-                    type: ControlType.NUMBER,
-                    min: 0,
-                    max: 3,
-                    step: 1,
-                    defaultValue: 0,
-                },
-            ],
-        };
+        return { ...sidebarMeta, component: Adw.Sidebar.$gtype };
     }
 
     private readonly items: readonly { title: string; subtitle: string; icon: string }[] = [

--- a/showcases/gtk/adwaita-storybook/src/view-switching/carousel.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/carousel.meta.ts
@@ -1,0 +1,35 @@
+// Shared, renderer-agnostic metadata for the Carousel stories. Imported by both
+// the GTK renderer (carousel.story.ts) and the browser renderer
+// (browser/view-switching/carousel.web.ts) so the two expose identical controls.
+// Adw.Carousel ships two indicator widgets, so there are two stories — one
+// paired with dot indicators, one with line indicators.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+const carouselControls: StoryMeta['controls'] = [
+    {
+        name: 'allowScrollWheel',
+        label: 'Allow scroll wheel',
+        type: ControlType.BOOLEAN,
+        defaultValue: true,
+    },
+    {
+        name: 'allowLongSwipes',
+        label: 'Allow long swipes',
+        type: ControlType.BOOLEAN,
+        defaultValue: false,
+    },
+];
+
+export const carouselDotsMeta: StoryMeta = {
+    title: 'View Switching/Carousel (Dots)',
+    description:
+        'Adw.Carousel — a horizontally swipeable pager with three pages, paired with Adw.CarouselIndicatorDots.',
+    controls: carouselControls,
+};
+
+export const carouselLinesMeta: StoryMeta = {
+    title: 'View Switching/Carousel (Lines)',
+    description: 'Adw.Carousel — the same swipeable pager paired with Adw.CarouselIndicatorLines instead of dots.',
+    controls: carouselControls,
+};

--- a/showcases/gtk/adwaita-storybook/src/view-switching/carousel.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/carousel.story.ts
@@ -3,7 +3,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { carouselDotsMeta, carouselLinesMeta } from './carousel.meta.js';
 
 const PAGES: ReadonlyArray<{ title: string; css: string }> = [
     { title: 'Welcome', css: 'accent' },
@@ -42,21 +43,7 @@ export class CarouselDotsStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'View Switching/Carousel (Dots)',
-            description:
-                'Adw.Carousel — a horizontally swipeable pager with three pages, paired with Adw.CarouselIndicatorDots.',
-            component: Adw.Carousel.$gtype,
-            controls: [
-                {
-                    name: 'allowScrollWheel',
-                    label: 'Allow scroll wheel',
-                    type: ControlType.BOOLEAN,
-                    defaultValue: true,
-                },
-                { name: 'allowLongSwipes', label: 'Allow long swipes', type: ControlType.BOOLEAN, defaultValue: false },
-            ],
-        };
+        return { ...carouselDotsMeta, component: Adw.Carousel.$gtype };
     }
 
     initialize(): void {
@@ -105,21 +92,7 @@ export class CarouselLinesStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'View Switching/Carousel (Lines)',
-            description:
-                'Adw.Carousel — the same swipeable pager paired with Adw.CarouselIndicatorLines instead of dots.',
-            component: Adw.Carousel.$gtype,
-            controls: [
-                {
-                    name: 'allowScrollWheel',
-                    label: 'Allow scroll wheel',
-                    type: ControlType.BOOLEAN,
-                    defaultValue: true,
-                },
-                { name: 'allowLongSwipes', label: 'Allow long swipes', type: ControlType.BOOLEAN, defaultValue: false },
-            ],
-        };
+        return { ...carouselLinesMeta, component: Adw.Carousel.$gtype };
     }
 
     initialize(): void {

--- a/showcases/gtk/adwaita-storybook/src/view-switching/inline-view-switcher.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/inline-view-switcher.meta.ts
@@ -1,0 +1,25 @@
+// Shared, renderer-agnostic metadata for the Inline View Switcher story.
+// Imported by both the GTK renderer (inline-view-switcher.story.ts) and the
+// browser renderer (browser/view-switching/inline-view-switcher.web.ts) so the
+// two expose identical controls.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const inlineViewSwitcherMeta: StoryMeta = {
+    title: 'View Switching/Inline View Switcher',
+    description:
+        'Adw.InlineViewSwitcher — a compact inline switcher that can show labels, icons, or both for an Adw.ViewStack.',
+    controls: [
+        {
+            name: 'displayMode',
+            label: 'Display mode',
+            type: ControlType.SELECT,
+            options: [
+                { label: 'Labels', value: 'labels' },
+                { label: 'Icons', value: 'icons' },
+                { label: 'Both', value: 'both' },
+            ],
+            defaultValue: 'both',
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/view-switching/inline-view-switcher.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/inline-view-switcher.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { inlineViewSwitcherMeta } from './inline-view-switcher.meta.js';
 
 /** Story: Adw.InlineViewSwitcher driving an Adw.ViewStack of three pages. */
 export class InlineViewSwitcherStory extends StoryWidget {
@@ -19,25 +20,7 @@ export class InlineViewSwitcherStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'View Switching/Inline View Switcher',
-            description:
-                'Adw.InlineViewSwitcher — a compact inline switcher that can show labels, icons, or both for an Adw.ViewStack.',
-            component: Adw.InlineViewSwitcher.$gtype,
-            controls: [
-                {
-                    name: 'displayMode',
-                    label: 'Display mode',
-                    type: ControlType.SELECT,
-                    options: [
-                        { label: 'Labels', value: 'labels' },
-                        { label: 'Icons', value: 'icons' },
-                        { label: 'Both', value: 'both' },
-                    ],
-                    defaultValue: 'both',
-                },
-            ],
-        };
+        return { ...inlineViewSwitcherMeta, component: Adw.InlineViewSwitcher.$gtype };
     }
 
     private buildPage(title: string, icon: string, body: string): Gtk.Widget {

--- a/showcases/gtk/adwaita-storybook/src/view-switching/tab-view.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/tab-view.meta.ts
@@ -1,0 +1,12 @@
+// Shared, renderer-agnostic metadata for the Tab View story. Imported by both
+// the GTK renderer (tab-view.story.ts) and the browser renderer
+// (browser/view-switching/tab-view.web.ts) so the two expose identical controls.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const tabViewMeta: StoryMeta = {
+    title: 'View Switching/Tab View',
+    description:
+        'Adw.TabView with an Adw.TabBar header — three tabbed pages; the tab bar can auto-hide when only one tab remains.',
+    controls: [{ name: 'autohide', label: 'Autohide tab bar', type: ControlType.BOOLEAN, defaultValue: false }],
+};

--- a/showcases/gtk/adwaita-storybook/src/view-switching/tab-view.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/tab-view.story.ts
@@ -3,7 +3,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { tabViewMeta } from './tab-view.meta.js';
 
 const TABS: ReadonlyArray<{ title: string; body: string }> = [
     { title: 'Overview', body: 'A summary of everything at a glance.' },
@@ -24,13 +25,7 @@ export class TabViewStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'View Switching/Tab View',
-            description:
-                'Adw.TabView with an Adw.TabBar header — three tabbed pages; the tab bar can auto-hide when only one tab remains.',
-            component: Adw.TabView.$gtype,
-            controls: [{ name: 'autohide', label: 'Autohide tab bar', type: ControlType.BOOLEAN, defaultValue: false }],
-        };
+        return { ...tabViewMeta, component: Adw.TabView.$gtype };
     }
 
     private buildPageBody(title: string, body: string): Gtk.Widget {

--- a/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher.meta.ts
@@ -1,0 +1,23 @@
+// Shared, renderer-agnostic metadata for the View Switcher story. Imported by
+// both the GTK renderer (view-switcher.story.ts) and the browser renderer
+// (browser/view-switching/view-switcher.web.ts) so the two expose identical
+// controls.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const viewSwitcherMeta: StoryMeta = {
+    title: 'View Switching/View Switcher',
+    description: 'Adw.ViewSwitcher — a segmented switcher whose buttons select pages in a paired Adw.ViewStack.',
+    controls: [
+        {
+            name: 'policy',
+            label: 'Policy',
+            type: ControlType.SELECT,
+            options: [
+                { label: 'Wide', value: 'wide' },
+                { label: 'Narrow', value: 'narrow' },
+            ],
+            defaultValue: 'wide',
+        },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher.story.ts
@@ -4,7 +4,8 @@
 import Adw from '@girs/adw-1';
 import Gtk from '@girs/gtk-4.0';
 import GObject from '@girs/gobject-2.0';
-import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { viewSwitcherMeta } from './view-switcher.meta.js';
 
 /** Story: Adw.ViewSwitcher mounted above an Adw.ViewStack with three pages. */
 export class ViewSwitcherStory extends StoryWidget {
@@ -19,24 +20,7 @@ export class ViewSwitcherStory extends StoryWidget {
     }
 
     static getMetadata(): StoryMeta {
-        return {
-            title: 'View Switching/View Switcher',
-            description:
-                'Adw.ViewSwitcher — a segmented switcher whose buttons select pages in a paired Adw.ViewStack.',
-            component: Adw.ViewSwitcher.$gtype,
-            controls: [
-                {
-                    name: 'policy',
-                    label: 'Policy',
-                    type: ControlType.SELECT,
-                    options: [
-                        { label: 'Wide', value: 'wide' },
-                        { label: 'Narrow', value: 'narrow' },
-                    ],
-                    defaultValue: 'wide',
-                },
-            ],
-        };
+        return { ...viewSwitcherMeta, component: Adw.ViewSwitcher.$gtype };
     }
 
     private buildPage(title: string, icon: string, body: string): Gtk.Widget {


### PR DESCRIPTION
Completes the Adwaita storybook port to `@gjsify/adwaita-web` — the remaining four categories, each drafted by the porting workflow, wired up, and validated native↔web with the comparison workflow + screenshots/inspector. Consolidated into one PR (after #579/#580/#581) so the slow CI runs once.

## Layout
- `adw-wrap-box` (new) + stories for clamp, header-bar, toolbar-view.

## View Switching
- `adw-carousel` + `adw-carousel-indicator-dots`/`-lines`, `adw-tab-view` + `adw-tab-page`, `adw-view-switcher` (+ page), `adw-inline-view-switcher` (+ view-stack-page).

## Navigation
- `adw-navigation-view` + `adw-navigation-page` (page stack + back button), `adw-bottom-sheet` (+ content/sheet), `adw-sidebar` + `adw-sidebar-section`/`-item`; stories for the two split views.

## Feedback
- `adw-about-dialog`, `adw-alert-dialog` (+ response), `adw-preferences-dialog` (+ page); a toast story over the existing toast-overlay.

## Parity fixes from the native comparison
- carousel pages use libadwaita's subtle `.card` tints + a white (not accent) active indicator; view-switcher + sidebar selected states are neutral fills, not accent; clamp text wraps within the clamp; toolbar-view uses list-remove/send-to; the alert default response stays neutral; preferences-dialog now observes `open` so `present()` reveals it.
- New icons wired: list-remove, send-to, folder-music, edit-copy, emblem-system, preferences-system, application-x-executable, view-grid/list, a view-columns glyph, document-open/save, mail-send/reply, folder-download.

## Verified
`gjsify tsc` (both packages), oxfmt, oxlint, `audit-runtimes --strict` clean across all four batches; each widget compared to its native GTK twin (carousel/view-switcher/sidebar/clamp/toolbar/bottom-sheet fixes confirmed; dialogs verified open + correctly positioned via the inspector — WebKit's snapshot doesn't capture dynamically-added modal overlays).
