### PR TITLE
Add the Adwaita storybook to the website (showcase + slideshow) and fix minimalist-browser parity

### DIFF
--- a/showcases/dom/minimalist-browser/src/browser/browser.ts
+++ b/showcases/dom/minimalist-browser/src/browser/browser.ts
@@ -41,7 +41,6 @@ const SHOWCASE_CSS = `
     color: var(--window-fg-color); opacity: var(--dim-opacity);
     font-size: var(--font-size-small);
 }
-.mb-quicknav .adw-button { min-height: 26px; padding: 2px 10px; font-weight: normal; }
 .mb-iframe { flex: 1; min-height: 0; border: none; width: 100%; background: var(--view-bg-color); }
 .mb-status {
     padding: 4px 12px;
@@ -129,8 +128,45 @@ export function mount(container: HTMLElement, options?: MountOptions): ShowcaseH
         quicknav.appendChild(b);
     }
 
-    // Wire the shared navigation core.
-    const core = new BrowserCore(iframe as unknown as IFrameHandle);
+    // Wire the shared navigation core. The built-in `page:*` documents announce
+    // themselves with `window.parent.postMessage(...)` — which, in a real
+    // browser, dispatches the `message` event on the HOST window, NOT on the
+    // iframe's own `contentWindow`. And because the iframe is a sandboxed
+    // (allow-scripts, no allow-same-origin) cross-origin frame, even *reading*
+    // `iframe.contentWindow.addEventListener` throws a SecurityError. So instead
+    // of handing `BrowserCore` the raw iframe (whose `contentWindow` is the
+    // wrong, inaccessible target), we wrap it in an `IFrameHandle` whose
+    // `contentWindow.addEventListener` subscribes on `window`, filtered to
+    // messages originating from this iframe. The GJS variant doesn't need this:
+    // its `IFrameBridge.iframeElement.contentWindow` is a same-process proxy that
+    // bridges WebKit's script-message-handler, so listening there is correct.
+    const iframeHandle: IFrameHandle = {
+        get src() {
+            return iframe.src;
+        },
+        set src(value: string) {
+            iframe.src = value;
+        },
+        get srcdoc() {
+            return iframe.srcdoc;
+        },
+        set srcdoc(value: string) {
+            iframe.srcdoc = value;
+        },
+        get contentWindow() {
+            return {
+                addEventListener(_type: 'message', listener: (event: { data: unknown }) => void): void {
+                    window.addEventListener('message', (event) => {
+                        // Identity-compare the source WindowProxy (allowed even
+                        // for cross-origin frames; reading its properties is not)
+                        // so we only surface messages from our own iframe.
+                        if (event.source === iframe.contentWindow) listener(event);
+                    });
+                },
+            };
+        },
+    };
+    const core = new BrowserCore(iframeHandle);
     let paused = false;
 
     core.onStateChange((state) => {

--- a/showcases/gtk/adwaita-storybook/package.json
+++ b/showcases/gtk/adwaita-storybook/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "Interactive component browser for Libadwaita widgets — a native Adwaita storybook built on @gjsify/storybook, debuggable over DBus/MCP via @gjsify/devtools",
   "type": "module",
+  "exports": {
+    "./browser": "./src/browser/embed.ts",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "clear": "rm -rf dist tsconfig.tsbuildinfo node_modules/.cache/gjsify-storybook",
     "check": "gjsify tsc --noEmit",

--- a/showcases/gtk/adwaita-storybook/src/browser/embed.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/embed.ts
@@ -1,0 +1,46 @@
+// Embeddable browser target — `mount(container)` renders the Adwaita storybook
+// into any DOM element, mirroring the `mount()` contract the DOM showcases
+// expose (e.g. `@gjsify/example-dom-minimalist-browser/browser`). The gjsify
+// website uses it to embed the storybook live in its showcase pages and the
+// home-page slideshow.
+//
+// The storybook's root is an `<adw-window class="sb-window">`; the website's
+// embed CSS sizes any `adw-window` to fill its slot, so the storybook fills the
+// container the same way the native window fills its toplevel. The renderer is
+// responsive (it collapses to single-pane navigation below 720px, like the
+// native `Adw.Breakpoint`), so it adapts to both the wide doc-page embed and
+// narrow mobile layouts.
+
+import { mountStorybook } from '@gjsify/adwaita-storybook';
+import { stories } from './stories.js';
+
+export interface ShowcaseHandle {
+    /** No-op: the storybook renders no animation, so there's nothing to pause. */
+    pause(): void;
+    resume(): void;
+    readonly isPaused: boolean;
+}
+
+export interface MountOptions {
+    /** Window title shown in the sidebar header (default "Adwaita Storybook"). */
+    title?: string;
+}
+
+export function mount(container: HTMLElement, options?: MountOptions): ShowcaseHandle {
+    mountStorybook(container, { title: options?.title ?? 'Adwaita Storybook', stories });
+
+    // The storybook is static (no rAF loop), so pause/resume are inert — they
+    // exist only to satisfy the slideshow's optional ShowcaseHandle contract.
+    let paused = false;
+    return {
+        pause(): void {
+            paused = true;
+        },
+        resume(): void {
+            paused = false;
+        },
+        get isPaused(): boolean {
+            return paused;
+        },
+    };
+}

--- a/showcases/gtk/adwaita-storybook/src/browser/main.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/main.ts
@@ -3,82 +3,12 @@
 // (launched via `gjsify storybook`). Each *.web.ts story shares its metadata
 // with the GTK *.story.ts twin, so the two targets expose identical controls
 // and can be compared 1:1 via screenshots.
+//
+// The story list lives in `./stories.ts` so the standalone entry here and the
+// embeddable `mount(container)` (`./embed.ts`, used by the gjsify website) stay
+// in lockstep.
 
-import { mountStorybook, type WebStoryModule } from '@gjsify/adwaita-storybook';
-import { AvatarWebStories } from './presentation/avatar.web.js';
-import { BannerWebStories } from './presentation/banner.web.js';
-import { SpinnerWebStories } from './presentation/spinner.web.js';
-import { StatusPageWebStories } from './presentation/status-page.web.js';
-import { WindowTitleWebStories } from './presentation/window-title.web.js';
-import { ActionRowWebStories } from './rows/action-row.web.js';
-import { ButtonRowWebStories } from './rows/button-row.web.js';
-import { ComboRowWebStories } from './rows/combo-row.web.js';
-import { EntryRowWebStories } from './rows/entry-row.web.js';
-import { ExpanderRowWebStories } from './rows/expander-row.web.js';
-import { PasswordEntryRowWebStories } from './rows/password-entry-row.web.js';
-import { PreferencesGroupWebStories } from './rows/preferences-group.web.js';
-import { SpinRowWebStories } from './rows/spin-row.web.js';
-import { SwitchRowWebStories } from './rows/switch-row.web.js';
-import { ButtonContentWebStories } from './buttons/button-content.web.js';
-import { ButtonStylesWebStories } from './buttons/button-styles.web.js';
-import { SplitButtonWebStories } from './buttons/split-button.web.js';
-import { ToggleGroupWebStories } from './buttons/toggle-group.web.js';
-import { ClampWebStories } from './layout/clamp.web.js';
-import { HeaderBarWebStories } from './layout/header-bar.web.js';
-import { ToolbarViewWebStories } from './layout/toolbar-view.web.js';
-import { WrapBoxWebStories } from './layout/wrap-box.web.js';
-import { CarouselWebStories } from './view-switching/carousel.web.js';
-import { InlineViewSwitcherWebStories } from './view-switching/inline-view-switcher.web.js';
-import { TabViewWebStories } from './view-switching/tab-view.web.js';
-import { ViewSwitcherWebStories } from './view-switching/view-switcher.web.js';
-import { BottomSheetWebStories } from './navigation/bottom-sheet.web.js';
-import { NavigationSplitViewWebStories } from './navigation/navigation-split-view.web.js';
-import { NavigationViewWebStories } from './navigation/navigation-view.web.js';
-import { OverlaySplitViewWebStories } from './navigation/overlay-split-view.web.js';
-import { SidebarWebStories } from './navigation/sidebar.web.js';
-import { AboutDialogWebStories } from './feedback/about-dialog.web.js';
-import { AlertDialogWebStories } from './feedback/alert-dialog.web.js';
-import { PreferencesDialogWebStories } from './feedback/preferences-dialog.web.js';
-import { ToastWebStories } from './feedback/toast.web.js';
-
-// Order mirrors the native sidebar's category order (Presentation, Boxed
-// Lists, Buttons, …).
-const stories: WebStoryModule[] = [
-    AvatarWebStories,
-    BannerWebStories,
-    SpinnerWebStories,
-    StatusPageWebStories,
-    WindowTitleWebStories,
-    ActionRowWebStories,
-    ButtonRowWebStories,
-    ComboRowWebStories,
-    EntryRowWebStories,
-    ExpanderRowWebStories,
-    PasswordEntryRowWebStories,
-    PreferencesGroupWebStories,
-    SpinRowWebStories,
-    SwitchRowWebStories,
-    ButtonContentWebStories,
-    ButtonStylesWebStories,
-    SplitButtonWebStories,
-    ToggleGroupWebStories,
-    ClampWebStories,
-    HeaderBarWebStories,
-    ToolbarViewWebStories,
-    WrapBoxWebStories,
-    CarouselWebStories,
-    InlineViewSwitcherWebStories,
-    TabViewWebStories,
-    ViewSwitcherWebStories,
-    BottomSheetWebStories,
-    NavigationSplitViewWebStories,
-    NavigationViewWebStories,
-    OverlaySplitViewWebStories,
-    SidebarWebStories,
-    AboutDialogWebStories,
-    AlertDialogWebStories,
-    PreferencesDialogWebStories,
-    ToastWebStories,
-];
+import { mountStorybook } from '@gjsify/adwaita-storybook';
+import { stories } from './stories.js';
 
 mountStorybook(document.body, { title: 'Adwaita Storybook', stories });

--- a/showcases/gtk/adwaita-storybook/src/browser/stories.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/stories.ts
@@ -1,0 +1,82 @@
+// Shared story list for the Adwaita storybook's browser target. Both the
+// standalone entry (`main.ts`, `mountStorybook(document.body, …)`) and the
+// embeddable `mount(container)` (`embed.ts`, used by the gjsify website) draw
+// from this single list so the two stay in lockstep.
+//
+// Order mirrors the native sidebar's category order (Presentation, Boxed
+// Lists, Buttons, …).
+
+import type { WebStoryModule } from '@gjsify/adwaita-storybook';
+import { AvatarWebStories } from './presentation/avatar.web.js';
+import { BannerWebStories } from './presentation/banner.web.js';
+import { SpinnerWebStories } from './presentation/spinner.web.js';
+import { StatusPageWebStories } from './presentation/status-page.web.js';
+import { WindowTitleWebStories } from './presentation/window-title.web.js';
+import { ActionRowWebStories } from './rows/action-row.web.js';
+import { ButtonRowWebStories } from './rows/button-row.web.js';
+import { ComboRowWebStories } from './rows/combo-row.web.js';
+import { EntryRowWebStories } from './rows/entry-row.web.js';
+import { ExpanderRowWebStories } from './rows/expander-row.web.js';
+import { PasswordEntryRowWebStories } from './rows/password-entry-row.web.js';
+import { PreferencesGroupWebStories } from './rows/preferences-group.web.js';
+import { SpinRowWebStories } from './rows/spin-row.web.js';
+import { SwitchRowWebStories } from './rows/switch-row.web.js';
+import { ButtonContentWebStories } from './buttons/button-content.web.js';
+import { ButtonStylesWebStories } from './buttons/button-styles.web.js';
+import { SplitButtonWebStories } from './buttons/split-button.web.js';
+import { ToggleGroupWebStories } from './buttons/toggle-group.web.js';
+import { ClampWebStories } from './layout/clamp.web.js';
+import { HeaderBarWebStories } from './layout/header-bar.web.js';
+import { ToolbarViewWebStories } from './layout/toolbar-view.web.js';
+import { WrapBoxWebStories } from './layout/wrap-box.web.js';
+import { CarouselWebStories } from './view-switching/carousel.web.js';
+import { InlineViewSwitcherWebStories } from './view-switching/inline-view-switcher.web.js';
+import { TabViewWebStories } from './view-switching/tab-view.web.js';
+import { ViewSwitcherWebStories } from './view-switching/view-switcher.web.js';
+import { BottomSheetWebStories } from './navigation/bottom-sheet.web.js';
+import { NavigationSplitViewWebStories } from './navigation/navigation-split-view.web.js';
+import { NavigationViewWebStories } from './navigation/navigation-view.web.js';
+import { OverlaySplitViewWebStories } from './navigation/overlay-split-view.web.js';
+import { SidebarWebStories } from './navigation/sidebar.web.js';
+import { AboutDialogWebStories } from './feedback/about-dialog.web.js';
+import { AlertDialogWebStories } from './feedback/alert-dialog.web.js';
+import { PreferencesDialogWebStories } from './feedback/preferences-dialog.web.js';
+import { ToastWebStories } from './feedback/toast.web.js';
+
+export const stories: WebStoryModule[] = [
+    AvatarWebStories,
+    BannerWebStories,
+    SpinnerWebStories,
+    StatusPageWebStories,
+    WindowTitleWebStories,
+    ActionRowWebStories,
+    ButtonRowWebStories,
+    ComboRowWebStories,
+    EntryRowWebStories,
+    ExpanderRowWebStories,
+    PasswordEntryRowWebStories,
+    PreferencesGroupWebStories,
+    SpinRowWebStories,
+    SwitchRowWebStories,
+    ButtonContentWebStories,
+    ButtonStylesWebStories,
+    SplitButtonWebStories,
+    ToggleGroupWebStories,
+    ClampWebStories,
+    HeaderBarWebStories,
+    ToolbarViewWebStories,
+    WrapBoxWebStories,
+    CarouselWebStories,
+    InlineViewSwitcherWebStories,
+    TabViewWebStories,
+    ViewSwitcherWebStories,
+    BottomSheetWebStories,
+    NavigationSplitViewWebStories,
+    NavigationViewWebStories,
+    OverlaySplitViewWebStories,
+    SidebarWebStories,
+    AboutDialogWebStories,
+    AlertDialogWebStories,
+    PreferencesDialogWebStories,
+    ToastWebStories,
+];

--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "@gjsify/example-dom-three-geometry-teapot": "workspace:^",
     "@gjsify/example-dom-three-postprocessing-pixel": "workspace:^",
     "@gjsify/example-dom-webrtc-loopback": "workspace:^",
+    "@gjsify/example-gtk-adwaita-storybook": "workspace:^",
     "astro": "^6.4.5",
     "excalibur": "0.32.0",
     "three": "0.184.0"

--- a/website/src/components/ShowcaseEmbed.astro
+++ b/website/src/components/ShowcaseEmbed.astro
@@ -24,10 +24,11 @@ interface MountOpts {
 
 interface Props {
   /**
-   * Showcase package suffix — combined with `@gjsify/example-dom-` to import
-   * the browser entry. Must correspond to a workspace package declared as a
-   * dependency of @gjsify/website AND a directory under `showcases/dom/<name>/`
-   * exporting `./browser` with a named `mount()` function.
+   * Showcase identifier. Most map to `@gjsify/example-dom-<name>` and a
+   * directory under `showcases/dom/<name>/`; `adwaita-storybook` is the one
+   * GTK-category showcase (`@gjsify/example-gtk-adwaita-storybook`, under
+   * `showcases/gtk/`). Each must be a dependency of @gjsify/website and export
+   * `./browser` with a named `mount()` function.
    */
   name:
     | 'three-postprocessing-pixel'
@@ -35,7 +36,8 @@ interface Props {
     | 'excalibur-jelly-jumper'
     | 'canvas2d-fireworks'
     | 'minimalist-browser'
-    | 'webrtc-loopback';
+    | 'webrtc-loopback'
+    | 'adwaita-storybook';
   /**
    * DOM id for the mount container. Defaults to the showcase name. Override
    * if a single page renders multiple embeds of the same showcase.
@@ -101,7 +103,8 @@ const mountOptsJson = JSON.stringify(resolvedMountOpts);
     | 'excalibur-jelly-jumper'
     | 'canvas2d-fireworks'
     | 'minimalist-browser'
-    | 'webrtc-loopback';
+    | 'webrtc-loopback'
+    | 'adwaita-storybook';
 
   const mounted = new WeakSet<Element>();
   const handles = new WeakMap<Element, ShowcaseHandle>();
@@ -178,6 +181,13 @@ const mountOptsJson = JSON.stringify(resolvedMountOpts);
       case 'webrtc-loopback': {
         const { mount } = await import(
           '@gjsify/example-dom-webrtc-loopback/browser'
+        );
+        handle = mount(container, opts as { title?: string });
+        break;
+      }
+      case 'adwaita-storybook': {
+        const { mount } = await import(
+          '@gjsify/example-gtk-adwaita-storybook/browser'
         );
         handle = mount(container, opts as { title?: string });
         break;

--- a/website/src/components/ShowcaseSlideshow.astro
+++ b/website/src/components/ShowcaseSlideshow.astro
@@ -39,6 +39,12 @@ interface Slide {
   terminalOutput?: string;
   /** For terminal variant: title shown in the terminal headerbar. */
   terminalTitle?: string;
+  /**
+   * Override the "try it" terminal command. Defaults to
+   * `npx @gjsify/cli showcase <name>`. Showcases that launch differently
+   * (e.g. the storybook, run via `gjsify storybook`) set this explicitly.
+   */
+  tryIt?: string;
 }
 
 const slides: Slide[] = [
@@ -88,6 +94,26 @@ app.listen(3000, () => {
 [12:34:56] GET /app.js
 [12:34:56] GET /api/runtime
 [12:34:56] GET /api/posts`,
+  },
+  {
+    id: 'storybook',
+    name: 'adwaita-storybook',
+    title: 'storybook.ts',
+    github: 'showcases/gtk/adwaita-storybook',
+    tryIt: 'gjsify storybook',
+    annotations: [
+      { text: 'Real Libadwaita widgets,\nlive in the browser', top: '-90px', right: '8%' },
+    ],
+    code: `import { mountStorybook } from '@gjsify/adwaita-storybook';
+import { stories } from './stories.js';
+
+// The same Libadwaita widgets that render natively under GJS —
+// AdwSwitchRow, AdwAvatar, AdwCarousel … — here in the browser
+// as @gjsify/adwaita-web custom elements, from one shared story.
+mountStorybook(document.body, {
+  title: 'Adwaita Storybook',
+  stories,
+});`,
   },
   {
     id: 'pixel',
@@ -267,7 +293,7 @@ app.connect('activate', () => {
             </div>
             <div class="slide-try-it focusable" tabindex="0">
               <Code
-                code={`npx @gjsify/cli showcase ${slide.name}`}
+                code={slide.tryIt ?? `npx @gjsify/cli showcase ${slide.name}`}
                 lang="sh"
                 title="Terminal"
                 frame="terminal"
@@ -279,6 +305,38 @@ app.connect('activate', () => {
     })}
   </div>
 </div>
+
+<script is:inline>
+  // Randomize which showcase is shown first — a different one each visit.
+  // This runs inline (synchronously, before first paint) so swapping the
+  // `.active` slide produces no load-time flash: the chosen slide simply
+  // renders active from the start, and CSS transitions don't fire on the
+  // initial render. We avoid repeating the previous visit's slide via
+  // sessionStorage so it visibly rotates. The deferred module script below
+  // then picks up whichever slide ended up active.
+  (function () {
+    var slides = document.querySelectorAll('.slideshow .slideshow-slide');
+    if (slides.length < 2) return;
+    var last = -1;
+    try {
+      last = parseInt(sessionStorage.getItem('gjsify-slideshow-last') || '-1', 10);
+    } catch (e) {
+      /* sessionStorage may be unavailable (private mode) — fall back to pure random */
+    }
+    var idx;
+    do {
+      idx = Math.floor(Math.random() * slides.length);
+    } while (idx === last);
+    try {
+      sessionStorage.setItem('gjsify-slideshow-last', String(idx));
+    } catch (e) {
+      /* ignore */
+    }
+    for (var i = 0; i < slides.length; i++) {
+      slides[i].classList.toggle('active', i === idx);
+    }
+  })();
+</script>
 
 <script>
   // Lazy-mount showcases on first view.
@@ -305,6 +363,12 @@ app.connect('activate', () => {
     if (!container) return;
 
     switch (id) {
+      case 'storybook': {
+        const { mount } = await import('@gjsify/example-gtk-adwaita-storybook/browser');
+        const handle = mount(container);
+        if (handle) handles.set(id, handle);
+        break;
+      }
       case 'pixel': {
         const { mount } = await import('@gjsify/example-dom-three-postprocessing-pixel/browser');
         const handle = mount(container, { assetBase: `${base}demos/pixel/` });
@@ -338,7 +402,9 @@ app.connect('activate', () => {
     const slides = slideshow.querySelectorAll<HTMLElement>('.slideshow-slide');
     const prevBtn = slideshow.querySelector('.slideshow-arrow-prev');
     const nextBtn = slideshow.querySelector('.slideshow-arrow-next');
-    let activeIndex = 0;
+    // The active slide is randomized before paint by the inline script below, so
+    // start from whichever slide actually carries `.active` (falling back to 0).
+    let activeIndex = Math.max(0, Array.from(slides).findIndex((s) => s.classList.contains('active')));
     let animating = false;
 
     function showSlide(targetIndex: number, direction: 'next' | 'prev') {
@@ -397,8 +463,8 @@ app.connect('activate', () => {
       showSlide((activeIndex + 1) % slides.length, 'next');
     });
 
-    // Mount the first slide immediately
-    const firstId = slides[0]?.dataset.slideId;
+    // Mount the active slide immediately (random per visit — see inline script).
+    const firstId = slides[activeIndex]?.dataset.slideId;
     if (firstId) mountSlide(firstId);
   }
 

--- a/website/src/content/docs/showcases/adwaita-storybook.mdx
+++ b/website/src/content/docs/showcases/adwaita-storybook.mdx
@@ -1,0 +1,62 @@
+---
+title: "Adwaita Storybook"
+description: An interactive component browser for Libadwaita widgets — the same stories render natively under GJS/GTK and in the browser as @gjsify/adwaita-web custom elements.
+---
+
+import ShowcaseEmbed from '../../../components/ShowcaseEmbed.astro';
+
+A component browser for the GNOME Libadwaita widget set: a sidebar of stories grouped by category, a live preview, and a controls panel that binds to each story's args. Every widget renders **natively under GJS/GTK** and — from the *same* renderer-free story metadata — **in the browser** as [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web) custom elements.
+
+## Live demo
+
+<ShowcaseEmbed name="adwaita-storybook" />
+
+The embed above is the real browser storybook: pick a widget in the sidebar, tweak its controls, watch it update. It is built from the identical stories the native GTK storybook shows.
+
+## What it exercises
+
+| Pillar | What it needs |
+|---|---|
+| [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web) | The full Adwaita widget set as light-DOM custom elements (rows, buttons, carousel, tab/view switchers, navigation, dialogs …) |
+| [`@gjsify/adwaita-storybook`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-storybook) | The browser storybook renderer — sidebar, preview, live controls, responsive collapse |
+| [`@gjsify/storybook`](https://github.com/gjsify/gjsify/tree/main/packages/framework/storybook) | The native GTK storybook (`gjsify storybook`) |
+| [`@gjsify/stories`](https://github.com/gjsify/gjsify/tree/main/packages/framework/stories) | The renderer-free `StoryMeta` contract shared by both targets |
+| [`@gjsify/devtools`](https://github.com/gjsify/gjsify/tree/main/packages/framework/devtools) | DBus/MCP control plane for screenshotting + driving the native window |
+
+## Run it on GJS
+
+```bash
+gjsify storybook
+```
+
+Run from the showcase directory, this opens the native GTK4 storybook window — real `Adw.*` widgets, an `Adw.NavigationSplitView` sidebar, and an `Adw.Breakpoint` that collapses to single-pane navigation on narrow widths.
+
+## Run it in the browser
+
+```ts
+import { mount } from '@gjsify/example-gtk-adwaita-storybook/browser';
+mount(document.getElementById('app')!);
+```
+
+`mount()` renders the storybook into any container via `@gjsify/adwaita-storybook`'s `mountStorybook`, drawing from the same story list. The renderer is responsive — it collapses to single-pane navigation below 720px, mirroring the native breakpoint.
+
+## Source
+
+[`showcases/gtk/adwaita-storybook/`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/adwaita-storybook)
+
+- `src/<category>/<name>.meta.ts` — the renderer-free `StoryMeta` (title, category, controls) — the single source of truth
+- `src/<category>/<name>.story.ts` — the native GTK twin (`{ ...meta, component: Adw.X.$gtype }`)
+- `src/browser/<category>/<name>.web.ts` — the browser twin (a `StoryElement` building `@gjsify/adwaita-web` elements)
+- `src/browser/stories.ts` — the shared story list consumed by both `main.ts` (standalone) and `embed.ts` (`mount()`)
+
+## One story, two renderers
+
+The point of this showcase is the **shared contract**. A story's metadata — its title, category, and the controls that drive it — lives in a `*.meta.ts` file that imports no renderer. The native `*.story.ts` and the browser `*.web.ts` each consume that metadata and bind it to their respective widget toolkit. Because the controls are declared once, the two targets expose identical knobs, so a native screenshot and a browser screenshot can be compared 1:1 — which is exactly how the widget port is validated.
+
+If a widget renders correctly in the GTK window but not in the browser (or vice-versa), that divergence is a bug to fix in `@gjsify/adwaita-web` — never a per-story patch.
+
+## Related
+
+- [Showcases overview](../) — the full cross-platform catalog
+- [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web) — the browser Adwaita widget library this storybook exercises
+- [`refs/libadwaita/`](https://github.com/gjsify/gjsify/tree/main/refs/libadwaita) — the upstream Libadwaita source the widgets mirror

--- a/website/src/content/docs/showcases/index.mdx
+++ b/website/src/content/docs/showcases/index.mdx
@@ -14,6 +14,7 @@ If something runs on GJS through gjsify, it also runs in the browser unmodified 
 
 | Showcase | Pillar focus | Browser demo |
 |---|---|---|
+| [`adwaita-storybook`](./adwaita-storybook/) | Adwaita + `@gjsify/adwaita-web` + `@gjsify/storybook` | Interactive Libadwaita component browser (native GTK + browser, one shared story) |
 | [`canvas2d-fireworks`](./canvas2d-fireworks/) | DOM + `@gjsify/canvas2d` | Particle fireworks on a `Canvas2DBridge` / `<canvas>` |
 | [`excalibur-jelly-jumper`](./excalibur-jelly-jumper/) | DOM + `@gjsify/webgl` + `@gjsify/xmlhttprequest` | Excalibur.js 2D platformer with Tiled tilemaps |
 | [`three-geometry-teapot`](./three-geometry-teapot/) | DOM + `@gjsify/webgl` | Three.js Utah teapot with parameter controls |


### PR DESCRIPTION
## Summary

Two related pieces of website/showcase work:

### Adwaita storybook on the website
- The `adwaita-storybook` showcase now exposes a `mount(container)` browser entry (`./browser` → `embed.ts`), built on `@gjsify/adwaita-storybook`'s `mountStorybook` with the showcase's story list (extracted to a shared `stories.ts` so the standalone `main.ts` and the embed stay in lockstep).
- `@gjsify/website` depends on the showcase, and `ShowcaseEmbed` learned to import the one GTK-category showcase package.
- New **showcase docs page** (`/showcases/adwaita-storybook/`) with a live embed + a catalog row on the showcases index. The embed renders the full 3-pane storybook when wide and collapses to single-pane navigation on narrow widths — exactly like the native `Adw.Breakpoint` (and it's interactive: tap a widget → preview → back).
- New **home-page slideshow slide** that mounts the live storybook, with a `gjsify storybook` try-it command (the `Slide` type gains an optional `tryIt` override for showcases that don't launch via `gjsify showcase`).
- The slideshow now **shows a random showcase per visit**. A pre-paint inline script swaps the active slide before first paint (no transition flash) and avoids repeating the previous visit via `sessionStorage`; the deferred script mounts whichever slide ended up active.

### minimalist-browser browser parity
The browser target diverged from its native GJS/GTK twin:
- **Status line was stuck at "Ready".** The built-in `page:*` documents announce via `window.parent.postMessage(...)`, which in a real browser fires on the *host* window, not the iframe's `contentWindow` — and reading `iframe.contentWindow.addEventListener` on the sandboxed, cross-origin frame threw a `SecurityError`. Fixed by wrapping the iframe in an `IFrameHandle` whose `contentWindow` subscribes on `window`, filtered to this iframe. The GJS variant is unchanged (its `IFrameBridge` proxy is the correct target there).
- **Quick-nav buttons were shrunk** by a custom override, making the toolbar tighter/lighter than native. Dropped it so they use adwaita-web's default Adwaita button metrics, matching the native flat toolbar.

## Verification
- Native (GSK `Screenshot` via `@gjsify/devtools`) ↔ browser (Playwright) comparison of the minimalist-browser: status, URL bar, back/forward and chrome now match.
- Website builds (`astro build`, 33 pages incl. the new showcase page); both showcases typecheck (`check:examples`) and build (`build:examples`); `gjsify install` added the workspace edge with zero lockfile churn.
- Storybook embed verified on the docs page (interactive) and in the slideshow (full 3-pane: sidebar + Avatar preview + live controls). Slideshow randomization verified across fresh loads.