### PR TITLE
fix(website): build @gjsify/stories before the docs build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "copy:assets": "node scripts/copy-showcase-assets.mjs",
     "generate:coverage": "node scripts/generate-coverage.mjs",
-    "build:deps": "gjsify workspace @gjsify/adwaita-web build:scss",
+    "build:deps": "gjsify workspace @gjsify/adwaita-web build:scss && gjsify workspace @gjsify/stories build",
     "start": "gjsify run build:deps && gjsify run generate:coverage && gjsify run copy:assets && astro dev",
     "build": "gjsify run build:deps && gjsify run generate:coverage && gjsify run copy:assets && astro build",
     "serve": "astro preview",


### PR DESCRIPTION
Follow-up to #583. The post-merge **Deploy Documentation** build went red:

```
[commonjs--resolver] Failed to resolve entry for package "@gjsify/stories".
```

The Adwaita storybook embed added in #583 pulls `@gjsify/adwaita-storybook` → `@gjsify/stories`. Unlike the website's other deps (`adwaita-web`, `adwaita-storybook`, the DOM showcases) which export their TypeScript source, `@gjsify/stories` exports only its built `lib/`. On a fresh CI tree that `lib/` doesn't exist yet, so Vite can't resolve the entry — it built locally only because `lib/` was already present.

`@gjsify/stories` is dual-target (consumed at GJS runtime by the native storybook), so it can't switch to a source export. Instead, build it in `build:deps`, next to the `adwaita-web` SCSS the docs build already compiles.

Verified by deleting `packages/framework/stories/lib` and rebuilding the site from clean — 33 pages build, no resolve error.