### PR TITLE
fix(stories): resolve from source for browser bundlers so the docs site builds

### DIFF
--- a/packages/framework/stories/package.json
+++ b/packages/framework/stories/package.json
@@ -8,6 +8,7 @@
     "exports": {
         ".": {
             "types": "./lib/types/index.d.ts",
+            "browser": "./src/index.ts",
             "default": "./lib/esm/index.js"
         }
     },

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "copy:assets": "node scripts/copy-showcase-assets.mjs",
     "generate:coverage": "node scripts/generate-coverage.mjs",
-    "build:deps": "gjsify workspace @gjsify/adwaita-web build:scss && gjsify workspace @gjsify/stories build",
+    "build:deps": "gjsify workspace @gjsify/adwaita-web build:scss",
     "start": "gjsify run build:deps && gjsify run generate:coverage && gjsify run copy:assets && astro dev",
     "build": "gjsify run build:deps && gjsify run generate:coverage && gjsify run copy:assets && astro build",
     "serve": "astro preview",


### PR DESCRIPTION
Follow-up to #583/#584 — gets the **Deploy Documentation** build green.

#584 tried to build `@gjsify/stories` in the website's `build:deps`, but the docs build runs the gjsify CLI **under GJS**, which has no usable bundler engine (`@gjsify/rolldown-native` isn't loadable there) — so that build step fails outright.

This reverts that and instead adds a `browser` export condition to `@gjsify/stories` pointing at its TypeScript source:

```jsonc
"exports": { ".": {
  "types":   "./lib/types/index.d.ts",
  "browser": "./src/index.ts",   // ← Vite client build compiles this — no lib/ needed
  "default": "./lib/esm/index.js"
} }
```

- The website's Vite client build uses `browser` conditions → resolves `@gjsify/stories` from source, so a fresh CI tree (no built `lib/`) resolves fine.
- The native gjs build and `gjsify build --library` never use `browser` → still resolve `default` → `lib/esm/index.js`, **unchanged**.
- TypeScript checks the `types` condition first → still `lib/types`, so typecheck is unaffected.

Verified: deleted `lib/`+`tmp/` and rebuilt the site clean (33 pages, no resolve error), showcase typecheck green, live embed renders.