### PR TITLE
feat(website): declutter the home page into documentation subpages

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -47,7 +47,13 @@ export default defineConfig({
             sidebar: [
                 {
                     label: 'Documentation',
-                    items: [{ slug: 'getting-started' }, { slug: 'cli-reference' }, { slug: 'how-it-works' }],
+                    items: [
+                        { slug: 'overview' },
+                        { slug: 'getting-started' },
+                        { slug: 'cli-reference' },
+                        { slug: 'how-it-works' },
+                        { slug: 'coverage' },
+                    ],
                 },
                 {
                     label: 'Guides',
@@ -86,6 +92,7 @@ export default defineConfig({
                     label: 'Showcases',
                     items: [
                         { slug: 'showcases', label: 'Overview' },
+                        { slug: 'showcases/adwaita-storybook' },
                         { slug: 'showcases/canvas2d-fireworks' },
                         { slug: 'showcases/excalibur-jelly-jumper' },
                         { slug: 'showcases/three-geometry-teapot' },

--- a/website/src/content/docs/coverage.mdx
+++ b/website/src/content/docs/coverage.mdx
@@ -1,0 +1,19 @@
+---
+title: Coverage
+description: How complete gjsify is — pillar entries, Node.js modules and W3C/WHATWG web standards, rendered live from STATUS.md.
+---
+
+import PillarCoverage from '../../components/PillarCoverage.astro';
+import NodeApiCoverage from '../../components/NodeApiCoverage.astro';
+import WebStandardsCoverage from '../../components/WebStandardsCoverage.astro';
+import IntegrationTests from '../../components/IntegrationTests.astro';
+
+gjsify's progress is tracked in [`STATUS.md`](https://github.com/gjsify/gjsify/blob/main/STATUS.md) and regenerated into these dashboards on every build, so the bars never lag behind reality.
+
+<PillarCoverage />
+
+<NodeApiCoverage />
+
+<WebStandardsCoverage />
+
+<IntegrationTests />

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -7,23 +7,11 @@ hero:
 ---
 
 import QuickStartCta from '../../components/QuickStartCta.astro';
-import ThreeWorldsFusion from '../../components/ThreeWorldsFusion.astro';
-import PillarCoverage from '../../components/PillarCoverage.astro';
-import WebStandardsCoverage from '../../components/WebStandardsCoverage.astro';
-import NodeApiCoverage from '../../components/NodeApiCoverage.astro';
-import BridgesGrid from '../../components/BridgesGrid.astro';
-import IntegrationTests from '../../components/IntegrationTests.astro';
+
+{/* The home page stays deliberately minimal: the hero + showcase slideshow
+    (rendered by the custom Hero override) already tell the story, followed by a
+    single "get started" call-to-action. The deeper material — what makes gjsify
+    different, the coverage dashboards, the bridge widgets — lives in the
+    documentation subpages (Overview, Coverage, Patterns/Bridges). */}
 
 <QuickStartCta />
-
-<ThreeWorldsFusion />
-
-<PillarCoverage />
-
-<WebStandardsCoverage />
-
-<NodeApiCoverage />
-
-<BridgesGrid />
-
-<IntegrationTests />

--- a/website/src/content/docs/overview.mdx
+++ b/website/src/content/docs/overview.mdx
@@ -1,0 +1,15 @@
+---
+title: Overview
+description: GNOME, Node.js and the Web in one SpiderMonkey process — what makes gjsify different.
+---
+
+import ThreeWorldsFusion from '../../components/ThreeWorldsFusion.astro';
+
+<ThreeWorldsFusion />
+
+## Where to go next
+
+- [How It Works](/gjsify/how-it-works/) — the build pipeline: auto-aliasing, `--globals auto`, native prebuilds
+- [Coverage](/gjsify/coverage/) — how complete the Node, Web and bridge surfaces already are
+- [Showcases](/gjsify/showcases/) — end-to-end apps that run unchanged on GJS and in the browser
+- [Getting Started](/gjsify/getting-started/) — scaffold and run your first app

--- a/website/src/content/docs/patterns/bridges.mdx
+++ b/website/src/content/docs/patterns/bridges.mdx
@@ -3,7 +3,11 @@ title: Bridge widgets
 description: Canvas2DBridge, WebGLBridge, IFrameBridge, VideoBridge — pairing a polyfill DOM element with a real GTK widget without the wrong layering choices.
 ---
 
+import BridgesGrid from '../../../components/BridgesGrid.astro';
+
 A *bridge* pairs one [DOM-spec polyfill](../../packages/dom/) element with a real GTK widget so that browser-shaped code — `canvas.getContext('webgl')`, `iframe.contentWindow.postMessage`, `video.srcObject = stream` — drives the GTK surface directly. No `WebKit.WebView` wrapper, no JSON-RPC, no separate renderer process. The HTML element and the GTK widget share one SpiderMonkey heap and one GLib main context.
+
+<BridgesGrid />
 
 This page documents the four bridges that ship in `@gjsify/*` today, the lifecycle they all share (`onReady` / `installGlobals` / `_canvas|_video|_iframe`), and the rough edges to recognise before they bite (ResizeObserver wiring, GC pinning, environment isolation, parent-child ordering).
 


### PR DESCRIPTION
Addresses the request to keep the home page uncluttered and move the deeper material into documentation subpages.

## Home page
Now just the custom hero + showcase slideshow + a single "Get started" CTA. The showcase slideshow already tells the story, so everything below it is removed.

## Moved into subpages
- **Overview** (new) — "Three worlds, one runtime" positioning + the browser-game-engine example (`ThreeWorldsFusion`).
- **Coverage** (new) — the pillar / Node.js / web-standards / integration-test dashboards (`PillarCoverage`, `NodeApiCoverage`, `WebStandardsCoverage`, `IntegrationTests`).
- **Patterns / Bridges** — the bridge-widgets grid (`BridgesGrid`) becomes a visual lead (page converted to MDX).

## Sidebar
- Documentation: + Overview, + Coverage.
- Showcases: + Adwaita Storybook (the entry was missing after #583).

Verified by a clean-tree build (`rm -rf` the `@gjsify/stories` `lib/`+`tmp/`, then `gjsify run build` → 35 pages, no resolve error) and screenshots of the home, Overview, Coverage and Bridges pages.

The double-chevron in the coverage expanders is already single in the current source (Chrome) — the earlier report was the stale deployed site. A follow-up will move the coverage/expander UI onto real `@gjsify/adwaita-web` elements (GNOME HIG) and make the single-chevron bulletproof cross-browser.