### PR TITLE
feat: render coverage dashboards with adwaita-web (single chevron, GNOME HIG)

### DIFF
--- a/packages/web/adwaita-web/scss/_expander_row.scss
+++ b/packages/web/adwaita-web/scss/_expander_row.scss
@@ -40,6 +40,22 @@ adw-expander-row {
     text-overflow: ellipsis;
   }
 
+  // The text column takes the free space so prefix/suffix widgets, the enable
+  // switch and the chevron sit at their respective edges.
+  .adw-expander-row-header > .adw-row-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  // Header prefix / suffix widget slots (Adw.ExpanderRow add_prefix/add_suffix).
+  .adw-expander-row-prefix,
+  .adw-expander-row-suffix {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-s);
+    flex-shrink: 0;
+  }
+
   // Disclosure chevron — points down when collapsed, flips up when expanded,
   // matching libadwaita's Adw.ExpanderRow arrow.
   .adw-expander-row-chevron {

--- a/packages/web/adwaita-web/src/elements/adw-expander-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-expander-row.ts
@@ -2,7 +2,10 @@
 // with an optional enable switch. Mirrors Adw.ExpanderRow.
 // Attributes: title, subtitle, expanded (boolean), enable-expansion (boolean),
 //   show-enable-switch (boolean).
-// Slots: any child <adw-*-row> is moved into the disclosed content listbox.
+// Slots: slot="prefix" / slot="suffix" widgets sit in the header row beside the
+//   title (before the enable switch + disclosure chevron), like Adw.ExpanderRow's
+//   add_prefix / add_suffix; any other child <adw-*-row> is moved into the
+//   disclosed content listbox.
 // Properties: expanded, enableExpansion (get/set, reflect to attributes).
 // Events: notify::expanded (CustomEvent), notify::enable-expansion (CustomEvent)
 //   — mirror Adw.ExpanderRow's GObject signal names so the same code path drives
@@ -20,6 +23,8 @@ export class AdwExpanderRow extends HTMLElement {
     private _enableLabel!: HTMLLabelElement;
     private _chevronEl!: HTMLSpanElement;
     private _contentEl!: HTMLDivElement;
+    private _prefixEl!: HTMLDivElement;
+    private _suffixEl!: HTMLDivElement;
     private _initialized = false;
 
     static get observedAttributes() {
@@ -48,12 +53,26 @@ export class AdwExpanderRow extends HTMLElement {
         return this._contentEl;
     }
 
+    /** The header suffix section — append controls here imperatively. */
+    get suffixSection(): HTMLDivElement {
+        return this._suffixEl;
+    }
+
+    /** The header prefix section — append icons/widgets here imperatively. */
+    get prefixSection(): HTMLDivElement {
+        return this._prefixEl;
+    }
+
     connectedCallback() {
         if (this._initialized) return;
         this._initialized = true;
 
-        // Any pre-existing children are the nested rows to disclose.
-        const rows = Array.from(this.childNodes);
+        // Slotted prefix/suffix widgets go in the header; everything else is a
+        // nested row to disclose.
+        const prefixChildren = Array.from(this.querySelectorAll(':scope > [slot="prefix"]'));
+        const suffixChildren = Array.from(this.querySelectorAll(':scope > [slot="suffix"]'));
+        const claimed = new Set<Node>([...prefixChildren, ...suffixChildren]);
+        const rows = Array.from(this.childNodes).filter((node) => !claimed.has(node));
 
         // Header row — looks like an action row: a text column, an optional
         // enable switch, and the disclosure chevron.
@@ -82,7 +101,16 @@ export class AdwExpanderRow extends HTMLElement {
         this._chevronEl = document.createElement('span');
         this._chevronEl.className = 'adw-icon adw-icon--go-down adw-expander-row-chevron';
 
-        this._headerEl.append(textEl, this._enableLabel, this._chevronEl);
+        // Header prefix / suffix widget slots (Adw.ExpanderRow add_prefix/add_suffix).
+        this._prefixEl = document.createElement('div');
+        this._prefixEl.className = 'adw-expander-row-prefix';
+        for (const child of prefixChildren) this._prefixEl.appendChild(child);
+
+        this._suffixEl = document.createElement('div');
+        this._suffixEl.className = 'adw-expander-row-suffix';
+        for (const child of suffixChildren) this._suffixEl.appendChild(child);
+
+        this._headerEl.append(this._prefixEl, textEl, this._suffixEl, this._enableLabel, this._chevronEl);
 
         // Disclosed content — a nested listbox holding the rows.
         this._contentEl = document.createElement('div');
@@ -127,6 +155,9 @@ export class AdwExpanderRow extends HTMLElement {
         const showSwitch = this.hasAttribute('show-enable-switch');
         this._enableLabel.hidden = !showSwitch;
         this._enableSwitch.checked = this.enableExpansion;
+
+        this._prefixEl.hidden = this._prefixEl.childElementCount === 0;
+        this._suffixEl.hidden = this._suffixEl.childElementCount === 0;
 
         this.classList.toggle('expanded', this.expanded);
         this._contentEl.classList.toggle('expanded', this.expanded);

--- a/website/src/components/NodeApiCoverage.astro
+++ b/website/src/components/NodeApiCoverage.astro
@@ -1,8 +1,9 @@
 ---
-// Node.js API coverage section — same Adwaita boxed-list + accordion
-// layout as WebStandardsCoverage, but with 3-tier (full/partial/stub)
-// status instead of the 4-tier web standards model.
-//
+// Node.js API coverage — a genuine @gjsify/adwaita-web boxed list (same shape as
+// WebStandardsCoverage), with the 3-tier full/partial/stub status model. Each
+// category is an <adw-expander-row> (single native chevron) with its count +
+// coverage meter in the header suffix; each module is a nested <adw-action-row>
+// with its backing library as subtitle and a status pill in the suffix.
 // Data: src/data/node-apis.ts
 
 import {
@@ -57,53 +58,32 @@ function statusLabel(status: NodeApiStatus): string {
 		</div>
 	</div>
 
-	<style>
-		/* Hide the browser's native <summary> disclosure triangle so only the
-		   custom .adw-chevron span is shown — prevents the double-chevron bug. */
-		summary.adw-row-summary {
-			list-style: none;
-		}
-		summary.adw-row-summary::-webkit-details-marker {
-			display: none;
-		}
-	</style>
-
-	<div class="adw-boxed-list">
+	<adw-preferences-group class="adw-cov-group">
 		{nodeApiCategories.map((cat) => {
 			const t = tallyNodeCategory(cat);
 			const implemented = t.full + t.partial;
 			return (
-				<details class="adw-row adw-row-expander">
-					<summary class="adw-row-summary">
-						<span class="adw-row-title">
-							<span class="adw-chevron" aria-hidden="true" />
-							{cat.name}
+				<adw-expander-row title={cat.name}>
+					<span slot="suffix" class="adw-cov-suffix">
+						<span class="adw-meta-count">{implemented} / {t.total}</span>
+						<span class="adw-bar adw-bar-inline" role="img" aria-label={`${cat.name}: ${implemented} of ${t.total} implemented`}>
+							<span class="adw-bar-seg seg-full" style={`width: ${(t.full / t.total) * 100}%`} />
+							<span class="adw-bar-seg seg-partial" style={`width: ${(t.partial / t.total) * 100}%`} />
+							<span class="adw-bar-seg seg-out" style={`width: ${(t.stub / t.total) * 100}%`} />
 						</span>
-						<span class="adw-row-meta">
-							<span class="adw-meta-count">{implemented} / {t.total}</span>
-							<span class="adw-bar adw-bar-inline" role="img" aria-label={`${cat.name}: ${implemented} of ${t.total} implemented`}>
-								<span class="adw-bar-seg seg-full" style={`width: ${(t.full / t.total) * 100}%`} />
-								<span class="adw-bar-seg seg-partial" style={`width: ${(t.partial / t.total) * 100}%`} />
-								<span class="adw-bar-seg seg-out" style={`width: ${(t.stub / t.total) * 100}%`} />
-							</span>
-						</span>
-					</summary>
-					<ul class="adw-api-list">
-						{cat.apis.map((a) => (
-							<li class="adw-api-item">
-								<span class="adw-api-name">
-									<code>{a.name}</code>
-									{a.backed && <span class="adw-api-backed">{a.backed}</span>}
-								</span>
-								<span class="adw-api-meta">
-									{a.note && <span class="adw-api-note">{a.note}</span>}
-									<span class={pillClass(a.status)}>{statusLabel(a.status)}</span>
-								</span>
-							</li>
-						))}
-					</ul>
-				</details>
+					</span>
+					{cat.apis.map((a) => (
+						<adw-action-row title={a.name} subtitle={a.backed ?? ""}>
+							{a.note && <span slot="suffix" class="adw-api-note">{a.note}</span>}
+							<span slot="suffix" class={pillClass(a.status)}>{statusLabel(a.status)}</span>
+						</adw-action-row>
+					))}
+				</adw-expander-row>
 			);
 		})}
-	</div>
+	</adw-preferences-group>
 </section>
+
+<script>
+	import "@gjsify/adwaita-web";
+</script>

--- a/website/src/components/PillarCoverage.astro
+++ b/website/src/components/PillarCoverage.astro
@@ -1,11 +1,9 @@
 ---
-// Top-level pillar coverage — one bar per pillar (Node / Web / DOM /
-// Framework / Adwaita / Infra / Build/Infra / Showcases / Integration
-// suites). Reuses the .adw-bar / .seg-full / .seg-partial styling that
-// NodeApiCoverage and WebStandardsCoverage already define.
-//
-// Data is generated from STATUS.md by website/scripts/generate-coverage.mjs
-// so the bars always reflect the canonical Summary table.
+// Top-level pillar coverage — one @gjsify/adwaita-web boxed-list row per pillar
+// (Node / Web / DOM / Framework / Adwaita / Infra / Build / Showcases /
+// Integration). Each <adw-action-row> carries its count + progress meter in the
+// suffix. Data is generated from STATUS.md by generate-coverage.mjs so the bars
+// always reflect the canonical Summary table.
 
 import { overviewPillars, tallyOverview } from "../data/coverage.ts";
 
@@ -49,14 +47,13 @@ function shortLabel(category: string): string {
         </div>
     </div>
 
-    <div class="adw-boxed-list">
+    <adw-preferences-group class="adw-cov-group">
         {overviewPillars.map((p) => {
             const implemented = p.full + p.partial;
             const pct = p.total === 0 ? 0 : Math.round((implemented / p.total) * 100);
             return (
-                <div class="adw-row">
-                    <span class="adw-row-title">{shortLabel(p.category)}</span>
-                    <span class="adw-row-meta">
+                <adw-action-row title={shortLabel(p.category)}>
+                    <span slot="suffix" class="adw-cov-suffix">
                         <span class="adw-meta-count">{implemented} / {p.total} ({pct}%)</span>
                         <span class="adw-bar adw-bar-inline" role="img" aria-label={`${p.category}: ${p.full} full, ${p.partial} partial, ${p.stub} stub of ${p.total} total`}>
                             <span class="adw-bar-seg seg-full" style={`width: ${(p.full / p.total) * 100}%`} />
@@ -64,8 +61,12 @@ function shortLabel(category: string): string {
                             <span class="adw-bar-seg seg-out" style={`width: ${(p.stub / p.total) * 100}%`} />
                         </span>
                     </span>
-                </div>
+                </adw-action-row>
             );
         })}
-    </div>
+    </adw-preferences-group>
 </section>
+
+<script>
+    import "@gjsify/adwaita-web";
+</script>

--- a/website/src/components/WebStandardsCoverage.astro
+++ b/website/src/components/WebStandardsCoverage.astro
@@ -1,14 +1,11 @@
 ---
-// Web platform coverage section — Adwaita-styled boxed list with
-// accordion sub-categories. Data lives in `src/data/web-standards.ts`.
-//
-// Visual model:
-//   - Group header (uppercase, dim 9pt) above the card
-//   - Boxed list (card with shadow, no border) containing one <details>
-//     per category
-//   - Summary row: category name + headline pill + Adwaita progress bar
-//   - Open details: per-API list with status pills
-//   - Aggregate footer card showing total coverage
+// Web platform coverage — a genuine @gjsify/adwaita-web boxed list. Each
+// category is an <adw-expander-row> (single native disclosure chevron) carrying
+// a header suffix with its count + segmented coverage meter; each standard is a
+// nested <adw-action-row> with a status pill in its suffix. The elements are
+// registered + hydrated by the client script at the bottom (importing
+// @gjsify/adwaita-web), so the section looks and behaves like the native GTK
+// storybook's boxed lists. Data lives in `src/data/web-standards.ts`.
 
 import {
 	webStandardsCategories,
@@ -66,54 +63,35 @@ function statusLabel(status: StandardStatus): string {
 		</div>
 	</div>
 
-	<style>
-		/* Hide the browser's native <summary> disclosure triangle so only the
-		   custom .adw-chevron span is shown — prevents the double-chevron bug. */
-		summary.adw-row-summary {
-			list-style: none;
-		}
-		summary.adw-row-summary::-webkit-details-marker {
-			display: none;
-		}
-	</style>
-
-	<div class="adw-boxed-list">
+	<adw-preferences-group class="adw-cov-group">
 		{webStandardsCategories.map((cat) => {
 			const t = tallyCategory(cat);
 			const implemented = t.full + t.partial;
 			return (
-				<details class="adw-row adw-row-expander">
-					<summary class="adw-row-summary">
-						<span class="adw-row-title">
-							<span class="adw-chevron" aria-hidden="true" />
-							{cat.name}
+				<adw-expander-row title={cat.name}>
+					<span slot="suffix" class="adw-cov-suffix">
+						<span class="adw-meta-count">{implemented} / {t.total}</span>
+						<span class="adw-bar adw-bar-inline" role="img" aria-label={`${cat.name}: ${implemented} of ${t.total} implemented`}>
+							<span class="adw-bar-seg seg-full" style={`width: ${(t.full / t.total) * 100}%`} />
+							<span class="adw-bar-seg seg-partial" style={`width: ${(t.partial / t.total) * 100}%`} />
+							<span class="adw-bar-seg seg-missing" style={`width: ${(t.missing / t.total) * 100}%`} />
+							<span class="adw-bar-seg seg-out" style={`width: ${(t.outOfScope / t.total) * 100}%`} />
 						</span>
-						<span class="adw-row-meta">
-							<span class="adw-meta-count">{implemented} / {t.total}</span>
-							<span class="adw-bar adw-bar-inline" role="img" aria-label={`${cat.name}: ${implemented} of ${t.total} implemented`}>
-								<span class="adw-bar-seg seg-full" style={`width: ${(t.full / t.total) * 100}%`} />
-								<span class="adw-bar-seg seg-partial" style={`width: ${(t.partial / t.total) * 100}%`} />
-								<span class="adw-bar-seg seg-missing" style={`width: ${(t.missing / t.total) * 100}%`} />
-								<span class="adw-bar-seg seg-out" style={`width: ${(t.outOfScope / t.total) * 100}%`} />
-							</span>
-						</span>
-					</summary>
-					<ul class="adw-api-list">
-						{cat.standards.map((s) => (
-							<li class="adw-api-item">
-								<span class="adw-api-name">
-									{s.name}
-									{s.pkg && <code class="adw-api-pkg">{s.pkg}</code>}
-								</span>
-								<span class="adw-api-meta">
-									{s.note && <span class="adw-api-note">{s.note}</span>}
-									<span class={pillClass(s.status)}>{statusLabel(s.status)}</span>
-								</span>
-							</li>
-						))}
-					</ul>
-				</details>
+					</span>
+					{cat.standards.map((s) => (
+						<adw-action-row title={s.name} subtitle={s.pkg ?? ""}>
+							{s.note && <span slot="suffix" class="adw-api-note">{s.note}</span>}
+							<span slot="suffix" class={pillClass(s.status)}>{statusLabel(s.status)}</span>
+						</adw-action-row>
+					))}
+				</adw-expander-row>
 			);
 		})}
-	</div>
+	</adw-preferences-group>
 </section>
+
+<script>
+	// Register + hydrate the adwaita-web custom elements used above (and inject
+	// the Adwaita stylesheet). Idempotent across the other coverage sections.
+	import "@gjsify/adwaita-web";
+</script>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -654,6 +654,15 @@ a[aria-current='page']:hover {
   min-width: 0;
 }
 
+/* Header suffix of an adwaita-web <adw-expander-row> coverage category:
+   the count + inline coverage meter, right-aligned before the chevron. */
+.adw-cov-suffix {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--adw-spacing-m);
+  flex-shrink: 0;
+}
+
 .adw-meta-count {
   font-variant-numeric: tabular-nums;
   font-size: 0.875rem;


### PR DESCRIPTION
Follow-up to #586. Makes the coverage dashboards genuinely use `@gjsify/adwaita-web` (GNOME HIG) and removes the double-disclosure-arrow.

## What changed
The coverage sections were styled with hand-rolled `.adw-*` CSS and a raw `<details>` accordion (whose native triangle could appear next to the custom chevron — the double-arrow you saw). They now render with **real adwaita-web elements**:

- Each section is an `<adw-preferences-group>` boxed list.
- **Expandable** categories (Node.js modules, web standards) are `<adw-expander-row>`s — count + segmented coverage meter in the header **suffix**, per-API entries as nested `<adw-action-row>`s (backing package as subtitle, status pill in the suffix). The expander draws a **single** Adwaita disclosure chevron on the right, so the double-arrow is gone by construction.
- The flat pillar list is `<adw-action-row>`s with their meter in the suffix.

A tiny client script registers/hydrates the elements (and injects the Adwaita stylesheet). The segmented meter + status pills stay as lightweight custom decorations inside the row suffixes.

## Core change
`adw-expander-row` gained `slot="prefix"` / `slot="suffix"` support (mirroring `adw-action-row` and `Adw.ExpanderRow.add_prefix/add_suffix`) so the category meter can live in the header. It's **additive** — rows with no slotted children behave exactly as before.

## Verified
- Clean-tree website build (35 pages); `@gjsify/adwaita-web` + the storybook showcase typecheck green.
- Screenshots of the full coverage page (collapsed + expanded) — boxed lists + single right-side chevron, matching the native storybook's Adwaita look.