### PR TITLE
feat(adwaita-storybook): standard gjsify showcase + medium-width controls fold

### DIFF
--- a/packages/infra/cli/showcases.json
+++ b/packages/infra/cli/showcases.json
@@ -49,6 +49,13 @@
             "package": "@gjsify/example-node-express-webserver",
             "description": "Express web server on GJS via @gjsify/http",
             "needsWebgl": false
+        },
+        {
+            "name": "adwaita-storybook",
+            "category": "gtk",
+            "package": "@gjsify/example-gtk-adwaita-storybook",
+            "description": "Interactive Libadwaita component browser — author one story per widget, rendered natively (GTK) and in the browser",
+            "needsWebgl": false
         }
     ]
 }

--- a/packages/web/adwaita-storybook/src/app.ts
+++ b/packages/web/adwaita-storybook/src/app.ts
@@ -12,6 +12,16 @@ import type { StoryElement } from './story-element.js';
 import { injectStorybookStyles } from './styles.js';
 import type { WebStoryModule } from './types.js';
 
+/**
+ * Width (px) below which the controls panel folds into an on-demand overlay so
+ * the sidebar + preview keep their room — a medium embed (e.g. the docs page)
+ * sits below this, a full storybook window above it.
+ */
+const CONTROLS_BREAKPOINT = 900;
+
+/** Width (px) below which even the sidebar folds away and nav goes single-pane. */
+const NAV_BREAKPOINT = 620;
+
 /** Options that adapt the storybook to a host project. */
 export interface StorybookWebOptions {
     /** Story modules to display. */
@@ -78,10 +88,14 @@ export class StorybookWebApp {
     }
 
     /**
-     * Collapse the split views on narrow widths, mirroring the native
-     * StorybookWindow's `Adw.Breakpoint` at 720sp: instead of squishing the
-     * three columns, the sidebar/content navigate one pane at a time and the
-     * controls become an on-demand overlay.
+     * Adapt the two split views to the available width, the way a desktop
+     * Adwaita window sheds panes as it narrows. There are two thresholds:
+     *
+     *   - below {@link CONTROLS_BREAKPOINT} the controls panel folds away into an
+     *     on-demand overlay, so the sidebar + preview keep their room (this is
+     *     what a medium embed — e.g. the docs page — wants);
+     *   - below {@link NAV_BREAKPOINT} there isn't room for the sidebar either,
+     *     so the whole thing goes single-pane and navigates one column at a time.
      */
     private _observeBreakpoint(): void {
         const apply = (): void => this._applyBreakpoint();
@@ -96,17 +110,19 @@ export class StorybookWebApp {
     private _applyBreakpoint(): void {
         const width = this._navSplit.clientWidth;
         if (width === 0) return; // not laid out yet — the observer will re-fire
-        const collapsed = width < 720;
+        const navCollapsed = width < NAV_BREAKPOINT;
+        const controlsCollapsed = width < CONTROLS_BREAKPOINT;
         const nav = this._navSplit as HTMLElement & { collapsed: boolean };
         const osv = this._controlsSplit as HTMLElement & { collapsed: boolean; showSidebar: boolean };
-        if (nav.collapsed !== collapsed) nav.collapsed = collapsed;
-        if (osv.collapsed !== collapsed) osv.collapsed = collapsed;
-        // Collapsing shows the story list first (like native); the back button
-        // only appears once a story is pushed onto the content pane.
+        if (nav.collapsed !== navCollapsed) nav.collapsed = navCollapsed;
+        if (osv.collapsed !== controlsCollapsed) osv.collapsed = controlsCollapsed;
+        // Single-pane nav shows the story list first (like native); the back
+        // button only appears once a story is pushed onto the content pane.
         this._navSplit.removeAttribute('show-content');
         this._backBtn.hidden = true;
-        // Controls are docked when expanded, an on-demand overlay when collapsed.
-        osv.showSidebar = !collapsed;
+        // The controls panel docks only when there's room; otherwise it's an
+        // on-demand overlay so the sidebar + preview keep their space.
+        osv.showSidebar = !controlsCollapsed;
     }
 
     // --- control surface (mirrors StorybookWindow; driven by host-level MCP via window.__storybook) ---

--- a/showcases/gtk/adwaita-storybook/package.json
+++ b/showcases/gtk/adwaita-storybook/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@gjsify/example-gtk-adwaita-storybook",
   "version": "0.11.0",
-  "private": true,
   "description": "Interactive component browser for Libadwaita widgets — a native Adwaita storybook built on @gjsify/storybook, debuggable over DBus/MCP via @gjsify/devtools",
   "type": "module",
+  "main": "dist/gjs.js",
+  "files": [
+    "dist",
+    "src"
+  ],
   "exports": {
     "./browser": "./src/browser/embed.ts",
     "./package.json": "./package.json"
@@ -14,13 +18,14 @@
     "start": "gjsify storybook",
     "start:watch": "gjsify storybook --watch",
     "start:browser": "http-server dist -o -c-1",
-    "build": "gjsify storybook --build-only",
+    "build": "gjsify storybook --build-only --out dist/gjs.js",
     "build:browser": "gjsify build src/browser/main.ts --app browser --outfile dist/browser-main.js",
     "build:assets": "mkdir -p dist && cp -f src/browser/index.html dist/index.html",
     "build:web": "gjsify run build:browser && gjsify run build:assets",
     "debug": "gjsify debug --profile storybook"
   },
   "gjsify": {
+    "main": "dist/gjs.js",
     "storybook": {
       "applicationId": "org.gjsify.AdwaitaStorybook",
       "title": "Adwaita Storybook",

--- a/website/src/components/ShowcaseSlideshow.astro
+++ b/website/src/components/ShowcaseSlideshow.astro
@@ -98,22 +98,24 @@ app.listen(3000, () => {
   {
     id: 'storybook',
     name: 'adwaita-storybook',
-    title: 'storybook.ts',
+    title: 'switch-row.meta.ts',
     github: 'showcases/gtk/adwaita-storybook',
-    tryIt: 'gjsify storybook',
     annotations: [
-      { text: 'Real Libadwaita widgets,\nlive in the browser', top: '-90px', right: '8%' },
+      { text: 'One story per widget —\nnative GTK and the browser', top: '-90px', right: '8%' },
     ],
-    code: `import { mountStorybook } from '@gjsify/adwaita-storybook';
-import { stories } from './stories.js';
+    code: `import { ControlType, type StoryMeta } from '@gjsify/stories';
 
-// The same Libadwaita widgets that render natively under GJS —
-// AdwSwitchRow, AdwAvatar, AdwCarousel … — here in the browser
-// as @gjsify/adwaita-web custom elements, from one shared story.
-mountStorybook(document.body, {
-  title: 'Adwaita Storybook',
-  stories,
-});`,
+// Author a widget's story once — renderer-free metadata + controls.
+// The native GTK storybook (gjsify storybook) and the browser one
+// both render it from this same source, so the two stay in lockstep.
+export const switchRowMeta: StoryMeta = {
+  title: 'Boxed Lists/Switch Row',
+  description: 'Adw.SwitchRow — a row with a trailing switch.',
+  controls: [
+    { name: 'title', label: 'Title', type: ControlType.TEXT, defaultValue: 'Automatic updates' },
+    { name: 'active', label: 'Active', type: ControlType.BOOLEAN, defaultValue: true },
+  ],
+};`,
   },
   {
     id: 'pixel',

--- a/website/src/content/docs/showcases/adwaita-storybook.mdx
+++ b/website/src/content/docs/showcases/adwaita-storybook.mdx
@@ -26,10 +26,12 @@ The embed above is the real browser storybook: pick a widget in the sidebar, twe
 ## Run it on GJS
 
 ```bash
-gjsify storybook
+gjsify showcase adwaita-storybook
 ```
 
-Run from the showcase directory, this opens the native GTK4 storybook window — real `Adw.*` widgets, an `Adw.NavigationSplitView` sidebar, and an `Adw.Breakpoint` that collapses to single-pane navigation on narrow widths.
+This opens the native GTK4 storybook window — real `Adw.*` widgets, an `Adw.NavigationSplitView` sidebar, and an `Adw.Breakpoint` that collapses to single-pane navigation on narrow widths.
+
+(From a checkout of the showcase, `gjsify storybook` does the same thing — it discovers the `*.story.ts` files and launches the GTK browser.)
 
 ## Run it in the browser
 


### PR DESCRIPTION
Two storybook follow-ups.

## 1. Controls panel folds away at medium widths
The web storybook collapsed both split views at one 720px breakpoint, so a medium embed (the docs page) squeezed all three columns or dropped to a single pane. Now there are two thresholds, the way a desktop Adwaita window sheds panes:

- below **900px** the controls panel becomes an on-demand overlay (sidebar + preview keep their room);
- below **620px** the sidebar folds away too and navigation goes single-pane.

So the docs-page embed (~712px) shows sidebar + preview with the controls auto-closed (matching the requested look), while the wider home-page slideshow keeps all three panes.

## 2. Runs as a standard `gjsify showcase`
It's a showcase, so it should launch like the others:

- The package is no longer private and is runnable: its existing `gjsify storybook --build-only` build now emits `dist/gjs.js`, set as the package entry (`main` + `gjsify.main`) and shipped via `files`, so `gjsify showcase` / `gjsify dlx` launch it like any other showcase. (Verified the built `dist/gjs.js` launches the GTK storybook.)
- Registered in the CLI's `showcases.json` (new `gtk` category).
- Docs "Run it on GJS" now shows `gjsify showcase adwaita-storybook`.

Also reframes the home-page slideshow slide — it's about **authoring one story per widget** that renders in both the native GTK storybook and the browser, not about adwaita-web. It now shows the shared renderer-free `*.meta.ts`, the annotation reads "One story per widget — native GTK and the browser", and the try-it is `npx @gjsify/cli showcase adwaita-storybook`.

Verified: clean-tree website build (35 pages), adwaita-storybook + showcase typecheck green, screenshots of the embed (controls folded), the slideshow slide, and the native `dist/gjs.js` launching.