### PR TITLE
fix(adwaita-storybook): keep storybook controls closed at embed widths (+ slide copy)

### DIFF
--- a/packages/web/adwaita-storybook/src/app.ts
+++ b/packages/web/adwaita-storybook/src/app.ts
@@ -14,10 +14,12 @@ import type { WebStoryModule } from './types.js';
 
 /**
  * Width (px) below which the controls panel folds into an on-demand overlay so
- * the sidebar + preview keep their room — a medium embed (e.g. the docs page)
- * sits below this, a full storybook window above it.
+ * the sidebar + preview keep their room. It docks only in a genuinely roomy
+ * standalone window — both embeds sit below this (the docs page ~712px and the
+ * home-page slideshow ~907px), so they show sidebar + preview with the controls
+ * closed by default (reopen via the header button).
  */
-const CONTROLS_BREAKPOINT = 900;
+const CONTROLS_BREAKPOINT = 1000;
 
 /** Width (px) below which even the sidebar folds away and nav goes single-pane. */
 const NAV_BREAKPOINT = 620;

--- a/website/src/components/ShowcaseSlideshow.astro
+++ b/website/src/components/ShowcaseSlideshow.astro
@@ -101,7 +101,7 @@ app.listen(3000, () => {
     title: 'switch-row.meta.ts',
     github: 'showcases/gtk/adwaita-storybook',
     annotations: [
-      { text: 'One story per widget —\nnative GTK and the browser', top: '-90px', right: '8%' },
+      { text: 'Create stories for your GTK widgets\njust as you would in web development', top: '-90px', right: '8%' },
     ],
     code: `import { ControlType, type StoryMeta } from '@gjsify/stories';
 


### PR DESCRIPTION
Two small storybook-slide refinements.

## Controls panel stays closed in embeds
The controls panel docked at ≥900px, so the home-page slideshow embed (~907px) still opened it by default and crowded the sidebar + preview. The dock threshold is raised to **1000px**, so the controls panel docks only in a genuinely roomy standalone window. Both embeds now show **sidebar + preview with the controls closed** by default (reopen via the header button):

- docs page embed: ~712px → closed
- home-page slideshow: ~907px → closed
- standalone storybook window (full viewport): docked, as before

## Slideshow tagline
The storybook slide annotation now reads:

> **Create stories for your GTK widgets just as you would in web development**

framing the showcase around the web-development-style story workflow it brings to GTK widgets (the same story renders in the native GTK storybook and the browser).

Verified by clean-tree website build (35 pages) + screenshots of the slideshow (controls closed) and the doc embed.