### PR TITLE
fix(nativescript-vite): support @nativescript/vite 8 + stub peers

### DIFF
--- a/packages/infra/nativescript-vite/src/index.ts
+++ b/packages/infra/nativescript-vite/src/index.ts
@@ -1,13 +1,15 @@
 // `@gjsify/nativescript-vite` — Vite 8 / Rolldown compatibility + gjsify
 // transforms for building NativeScript apps.
 //
-// `@nativescript/vite` (the upstream NativeScript Vite integration) does not
-// build under Vite 8 / Rolldown: its config uses two constructs Rolldown
-// rejects. This package COMPOSES the upstream config and fixes exactly those
-// two pieces on the returned config object, then layers gjsify's NS transforms
-// on top — so a NativeScript app builds under Vite 8 with `gjsify`'s stack.
+// `@nativescript/vite@2.x` (the upstream NativeScript Vite integration, the
+// Vite-7-era line) does not build under Vite 8 / Rolldown: its config uses two
+// constructs Rolldown rejects. This package COMPOSES the upstream config and
+// fixes exactly those pieces on the returned config object, then layers
+// gjsify's NS transforms on top — so a NativeScript app builds under Vite 8
+// with `gjsify`'s stack.
 //
-// The two upstream incompatibilities (verified by running real builds):
+// The upstream incompatibilities (verified by running real builds against
+// `@nativescript/vite@2.0.3`):
 //   1. Function-replacement `resolve.alias` entries (platform-`main` + tsconfig
 //      wildcard + `@nativescript/core/.../index` canonicalization) →
 //      `Failed to convert builtin plugin 'ViteAlias' … function replacement
@@ -17,6 +19,24 @@
 //   2. The explicit `@rollup/plugin-commonjs` plugin → `Cannot read properties
 //      of undefined (reading 'currentLoadingModule')`. It is DROPPED — Rolldown
 //      handles CommonJS (`@nativescript/core`'s modules) natively.
+//   3. The vite-side `ns-typescript-check` plugin → a bundler should bundle,
+//      not type-check; gjsify defers the authoritative type gate to
+//      `gjsify tsc`. It is DROPPED (the strip is no-op-if-absent).
+//
+// CONDITIONAL on the installed `@nativescript/vite` major (`detectNativescriptViteMajor()`):
+//   - major <= 2 (or UNKNOWN/unresolvable — fail-safe to "patches still needed"):
+//     apply the FULL fix set above, exactly as before. The teapot showcase on
+//     `@nativescript/vite@2.0.3` must keep building.
+//   - major >= 8: upstream `@nativescript/vite@8.x` is a ground-up Vite-8 +
+//     Rolldown + HMR rewrite that ALREADY ships native `rolldownOptions`,
+//     string-only aliases and no explicit `@rollup/plugin-commonjs`, so fixes
+//     (1) and (2) are no-ops there — they are SKIPPED (the intent is explicit;
+//     the strips were already no-op-if-absent). Fix (3) is still applied
+//     (no-op-if-absent regardless of line). A one-time informational log notes
+//     that 8.x handles Vite-8/Rolldown natively so minimal patching is applied.
+//
+// Every strip is idempotent + no-op-if-absent, so the patching stays safe on
+// either line regardless of the detected major.
 //
 // On top, it spreads `@gjsify/vite-plugin-gjsify`'s `gjsifyNativescript()`
 // preset (gi:// → empty, platform file resolution, platform defines, the
@@ -26,6 +46,10 @@
 // optional `@nativescript/canvas*` plugins and `vite` are all OPTIONAL peer
 // dependencies — installed by the consumer only when targeting NativeScript.
 
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import module, { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vite';
 import type { ConfigEnv, UserConfig, Plugin, AliasOptions, Alias } from 'vite';
 import { gjsifyNativescript as gjsifyNativescriptTransforms } from '@gjsify/vite-plugin-gjsify';
@@ -91,6 +115,20 @@ export default defineNativescriptConfig;
  * actionable error if neither resolves or the export is missing.
  */
 async function loadUpstreamConfig(env: ConfigEnv): Promise<UserConfig> {
+    // `@nativescript/vite@8.x`'s config chain (`configuration/base.js` → the HMR
+    // server → the per-framework strategies) STATICALLY imports the framework
+    // compilers (`@vue/compiler-sfc`, `react-reconciler`, `vite-plugin-solid`,
+    // `@vitejs/plugin-vue{,-jsx}`, `vue-tsc`, `@analogjs/vite-plugin-angular`,
+    // `@angular/build`) at module-eval. They are upstream `peerDependencies`, so a
+    // framework-LESS NativeScript-Core app (no Vue/Solid/React/Angular) cannot even
+    // `import('@nativescript/vite')` — Node throws a cryptic
+    // `ERR_MODULE_NOT_FOUND: Cannot find package '@vue/compiler-sfc'`. Stub the
+    // ones the project did NOT install with `@gjsify/empty`-shaped no-op modules so
+    // a Core app loads the config. Must run BEFORE the dynamic import below —
+    // `resolve.alias` (a Vite config field) would be far too late: the eager import
+    // is executed by Node's ESM loader the moment we `import()` the config module.
+    stubMissingFrameworkPeers();
+
     // String-variable specifiers: `@nativescript/vite` is an OPTIONAL peer, not
     // installed in this repo, so a literal `import('@nativescript/vite')` would
     // fail type resolution. Non-literal specifiers resolve at runtime only (the
@@ -120,8 +158,283 @@ async function loadUpstreamConfig(env: ConfigEnv): Promise<UserConfig> {
     );
 }
 
+/** One-time guard so the missing-framework-peer stub notice prints at most once per process. */
+let stubbedPeersNoticeShown = false;
+/** Idempotency guard: register the Node resolve/load hooks at most once per process. */
+let frameworkPeerHooksRegistered = false;
+
+/**
+ * Read `@nativescript/vite`'s declared framework `peerDependencies`. These are the
+ * Vue/Solid/React/Angular compilers (`@vue/compiler-sfc`, `react-reconciler`,
+ * `vite-plugin-solid`, `@vitejs/plugin-vue{,-jsx}`, `vue-tsc`,
+ * `@analogjs/vite-plugin-angular`, `@angular/build`) that the 8.x config chain
+ * STATICALLY imports at module-eval. Returns `[]` when the package can't be
+ * located (optional peer absent → nothing to stub, the upstream import will fail
+ * with its own clear error).
+ */
+function nativescriptViteFrameworkPeers(): string[] {
+    const root = resolveNativescriptViteRoot();
+    if (root === undefined) return [];
+    try {
+        const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as {
+            peerDependencies?: Record<string, unknown>;
+        };
+        return Object.keys(pkg.peerDependencies ?? {});
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Find every framework `peerDependency` of `@nativescript/vite` that the consuming
+ * project did NOT install, resolved relative to `@nativescript/vite`'s own location
+ * (peers resolve from the package that declares them) with a `process.cwd()`
+ * fallback. NEVER stubs a framework the app actually has — only the absent ones.
+ */
+function missingFrameworkPeers(): string[] {
+    const root = resolveNativescriptViteRoot();
+    if (root === undefined) return [];
+    const require = createRequire(import.meta.url);
+    const paths = [root, process.cwd()];
+    return nativescriptViteFrameworkPeers().filter((peer) => {
+        try {
+            require.resolve(peer, { paths });
+            return false; // resolvable → installed → keep it
+        } catch {
+            return true; // unresolvable → missing → stub it
+        }
+    });
+}
+
+/** Synthetic-module URL scheme for a stubbed missing framework peer. */
+const STUB_PEER_SCHEME = 'gjsify-ns-empty-peer:';
+
+/**
+ * Scan `@nativescript/vite`'s on-disk source for the NAMED imports of `spec`
+ * (`import { parse, compileScript } from '<spec>'`). ESM validates named bindings
+ * at link time, so a default-only stub (like `@gjsify/empty`) cannot satisfy
+ * `import { compileScript } from '@vue/compiler-sfc'` — the generated stub must
+ * declare exactly those names. Version-agnostic: reads whatever the installed
+ * `@nativescript/vite` actually imports.
+ */
+function collectNamedImports(root: string, spec: string): string[] {
+    const names = new Set<string>();
+    const escaped = spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const re = new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*["']${escaped}["']`, 'g');
+    const walk = (dir: string): void => {
+        let entries: string[];
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            return;
+        }
+        for (const name of entries) {
+            const p = join(dir, name);
+            let isDir: boolean;
+            try {
+                isDir = statSync(p).isDirectory();
+            } catch {
+                continue;
+            }
+            if (isDir) {
+                if (name !== 'node_modules') walk(p);
+            } else if (p.endsWith('.js') || p.endsWith('.mjs')) {
+                let code: string;
+                try {
+                    code = readFileSync(p, 'utf8');
+                } catch {
+                    continue;
+                }
+                let m: RegExpExecArray | null;
+                re.lastIndex = 0;
+                while ((m = re.exec(code)) !== null) {
+                    for (const raw of m[1].split(',')) {
+                        const imported = raw.trim().split(/\s+as\s+/)[0]?.trim();
+                        if (imported && /^[A-Za-z_$][\w$]*$/.test(imported)) names.add(imported);
+                    }
+                }
+            }
+        }
+    };
+    walk(root);
+    return [...names];
+}
+
+/**
+ * Make a framework-LESS NativeScript-Core app able to load `@nativescript/vite@8.x`'s
+ * config: stub the framework compiler `peerDependencies` the project did not install
+ * with no-op modules, so the chain's eager `import '@vue/compiler-sfc'` (etc.)
+ * resolve to empty stubs instead of throwing `ERR_MODULE_NOT_FOUND`.
+ *
+ * Uses Node's synchronous module hooks (`module.registerHooks`, Node 22.15+/24):
+ *   - a `resolve` hook redirects each missing peer specifier to a synthetic stub URL;
+ *   - a `load` hook returns ESM source exporting a no-op default Proxy PLUS a named
+ *     export (also the Proxy) for every name `@nativescript/vite` imports from that
+ *     peer — satisfying namespace / default / named imports of any shape.
+ *
+ * Idempotent (registers at most once) and a no-op when no framework peer is missing
+ * (a Vue/Solid/React/Angular app keeps its real compilers). Falls back gracefully —
+ * if `registerHooks` is unavailable (older Node) it logs the actionable
+ * `npm install` hint and lets the upstream import surface its own error.
+ */
+function stubMissingFrameworkPeers(): void {
+    if (frameworkPeerHooksRegistered) return;
+    const missing = missingFrameworkPeers();
+    if (missing.length === 0) return;
+
+    const root = resolveNativescriptViteRoot();
+    const registerHooks = (module as { registerHooks?: (h: unknown) => void }).registerHooks;
+    if (root === undefined || typeof registerHooks !== 'function') {
+        // Can't intercept — give the user the exact remedy instead of the raw
+        // `ERR_MODULE_NOT_FOUND` they'd otherwise hit at config-load.
+        console.warn(
+            `[@gjsify/nativescript-vite] @nativescript/vite eagerly imports framework compilers that are not ` +
+                `installed and they cannot be stubbed on this Node version. Install the ones your app uses, ` +
+                `or all of them to unblock the build:\n    npm install -D ${missing.join(' ')}`,
+        );
+        return;
+    }
+
+    frameworkPeerHooksRegistered = true;
+    const missingSet = new Set(missing);
+    // Pre-compute the named-export superset per missing peer so the load hook stays
+    // synchronous and cheap (the scan reads the upstream source once).
+    const namedExports = new Map<string, string[]>();
+    for (const peer of missing) namedExports.set(peer, collectNamedImports(root, peer));
+
+    if (!stubbedPeersNoticeShown) {
+        stubbedPeersNoticeShown = true;
+        // stderr (console.warn) — a build diagnostic must not pollute stdout.
+        console.warn(
+            `[@gjsify/nativescript-vite] @nativescript/vite declares framework compilers as peerDependencies and ` +
+                `imports them eagerly at config-load; stubbing the ${missing.length} not installed in this project ` +
+                `with no-op modules so a framework-less NativeScript-Core app can load the config: ${missing.join(', ')}. ` +
+                `(Install a framework's compiler to use it — only the absent ones are stubbed.)`,
+        );
+    }
+
+    registerHooks({
+        resolve(
+            specifier: string,
+            context: unknown,
+            nextResolve: (s: string, c: unknown) => unknown,
+        ): unknown {
+            if (missingSet.has(specifier)) {
+                return { url: STUB_PEER_SCHEME + encodeURIComponent(specifier), shortCircuit: true };
+            }
+            return nextResolve(specifier, context);
+        },
+        load(url: string, context: unknown, nextLoad: (u: string, c: unknown) => unknown): unknown {
+            if (url.startsWith(STUB_PEER_SCHEME)) {
+                const spec = decodeURIComponent(url.slice(STUB_PEER_SCHEME.length));
+                const named = namedExports.get(spec) ?? [];
+                let source =
+                    'const noop = () => {};\n' +
+                    'const stub = new Proxy(noop, { get: (t, p) => (p in t ? t[p] : noop) });\n' +
+                    'export default stub;\n';
+                for (const name of named) source += `export const ${name} = stub;\n`;
+                return { format: 'module', source, shortCircuit: true };
+            }
+            return nextLoad(url, context);
+        },
+    });
+}
+
 /** Upstream `@nativescript/vite` TypeScript-check plugin name (see `helpers/typescript-check.js`). */
 const TS_CHECK_PLUGIN = 'ns-typescript-check';
+
+/** First `@nativescript/vite` major that ships native Vite-8 / Rolldown support. */
+const NS_VITE_NATIVE_VITE8_MAJOR = 8;
+
+/** One-time guard so the "8.x handles Vite-8 natively" notice prints at most once per process. */
+let nativeViteNoticeShown = false;
+
+/**
+ * Locate the on-disk `@nativescript/vite` package root (the directory holding its
+ * `package.json`), or `undefined` when the optional peer is not installed.
+ *
+ * It must NOT resolve the `@nativescript/vite/package.json` SUBPATH directly:
+ * `@nativescript/vite@8.x`'s `package.json#exports` map does not expose
+ * `./package.json`, so `createRequire(...).resolve('@nativescript/vite/package.json')`
+ * (and `import.meta.resolve`) throw `ERR_PACKAGE_PATH_NOT_EXPORTED` — the bug that
+ * silently broke major detection on the 8.x line (the gate never fired, the full
+ * legacy patch set ran). Instead resolve the package's MAIN entry (always exported)
+ * and walk up to the nearest ancestor `package.json` whose `name` is
+ * `@nativescript/vite`. This is robust for both modern `exports`-only packages and
+ * classic ones.
+ */
+function resolveNativescriptViteRoot(): string | undefined {
+    const specifier = '@nativescript/vite';
+    const require = createRequire(import.meta.url);
+    // Resolve from the consumer's project root (`process.cwd()` — where Vite runs
+    // the config) FIRST, then relative to this lib's own location. In a flat npm
+    // install both find the same copy; resolving from the project root first is the
+    // honest source of truth (the app's installed `@nativescript/vite` is the one
+    // its config will load) and handles pnpm/nested layouts where the lib's
+    // `node_modules` differs from the project's.
+    let entry: string | undefined;
+    try {
+        entry = require.resolve(specifier, { paths: [process.cwd(), dirname(fileURLToPath(import.meta.url))] });
+    } catch {
+        // fall through to import.meta.resolve (location-relative)
+    }
+    if (entry === undefined) {
+        const metaResolve = (import.meta as { resolve?: (s: string) => string }).resolve;
+        if (typeof metaResolve === 'function') {
+            try {
+                const resolved = metaResolve(specifier);
+                entry = resolved.startsWith('file:') ? fileURLToPath(resolved) : resolved;
+            } catch {
+                return undefined; // genuinely not installed
+            }
+        } else {
+            return undefined;
+        }
+    }
+
+    // Walk up from the resolved entry file to the nearest `package.json` named
+    // `@nativescript/vite` (skips a possible inner `package.json` in a subdir).
+    let dir = dirname(entry);
+    for (;;) {
+        const pkgPath = join(dir, 'package.json');
+        if (existsSync(pkgPath)) {
+            try {
+                const name = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { name?: unknown }).name;
+                if (name === specifier) return dir;
+            } catch {
+                // unreadable/unparseable — keep walking up
+            }
+        }
+        const parent = dirname(dir);
+        if (parent === dir) return undefined; // reached filesystem root
+        dir = parent;
+    }
+}
+
+/**
+ * Detect the installed `@nativescript/vite` major version. `@nativescript/vite` is
+ * an OPTIONAL peer (not installed in this repo), so detection can fail — in which
+ * case we return `undefined` and the caller assumes the patches are still needed
+ * (fail-safe to the historical full-patch behavior).
+ *
+ * Reads the package root's `package.json` (located WITHOUT relying on the
+ * exports-gated `/package.json` subpath, see `resolveNativescriptViteRoot`) and
+ * parses its `version`. Any failure (unresolvable peer, unreadable/unparseable
+ * version) is swallowed → `undefined`.
+ */
+export function detectNativescriptViteMajor(): number | undefined {
+    const root = resolveNativescriptViteRoot();
+    if (root === undefined) return undefined; // not resolvable — assume patches still needed
+    try {
+        const raw = readFileSync(join(root, 'package.json'), 'utf8');
+        const version = (JSON.parse(raw) as { version?: unknown }).version;
+        if (typeof version !== 'string') return undefined;
+        const major = Number.parseInt(version.split('.', 1)[0] ?? '', 10);
+        return Number.isFinite(major) ? major : undefined;
+    } catch {
+        return undefined; // unreadable / unparseable — assume patches still needed
+    }
+}
 
 /**
  * Apply the Vite 8 / Rolldown + type-check fixes to a returned `@nativescript/vite`
@@ -129,39 +442,78 @@ const TS_CHECK_PLUGIN = 'ns-typescript-check';
  * and the vite-side `ns-typescript-check` (gjsify type-checks via `gjsify tsc`).
  * Returns a shallow copy with the fixed `resolve` and `plugins` — the input is not
  * mutated.
+ *
+ * CONDITIONAL on the installed `@nativescript/vite` major:
+ *   - `>= 8` (the Vite-8 + Rolldown + HMR rewrite): SKIP the function-alias drop
+ *     and the `@rollup/plugin-commonjs` strip — upstream already ships native
+ *     `rolldownOptions`, string-only aliases and no explicit commonjs plugin, so
+ *     those fixes are no-ops there. The `ns-typescript-check` strip is still
+ *     applied (no-op-if-absent). Emits a one-time informational notice.
+ *   - `<= 2` / UNKNOWN (unresolvable peer): apply the FULL fix set, exactly as
+ *     before — the teapot showcase on `@nativescript/vite@2.0.3` must keep building.
+ *
+ * The optional `nsViteMajor` arg overrides the auto-detected major (used by the
+ * e2e fixtures to exercise both branches without two installs).
  */
-export function applyVite8Fixes(config: UserConfig): UserConfig {
+export function applyVite8Fixes(config: UserConfig, nsViteMajor?: number): UserConfig {
+    const major = nsViteMajor ?? detectNativescriptViteMajor();
+    // Fail-safe: an unknown major (optional peer not resolvable) is treated as
+    // the legacy <= 2 line so the full patch set still applies.
+    const skipVite8Patches = major !== undefined && major >= NS_VITE_NATIVE_VITE8_MAJOR;
+
     const out: UserConfig = { ...config };
-    if (config.resolve?.alias) {
-        out.resolve = { ...config.resolve, alias: dropFunctionAliases(config.resolve.alias) };
-    }
-    if (Array.isArray(config.plugins)) {
-        const before = countPluginByName(config.plugins, 'commonjs');
-        out.plugins = stripPluginByName(config.plugins, 'commonjs');
-        // Observability: the strip depends on `@rollup/plugin-commonjs` registering
-        // exactly `name: 'commonjs'` as a synchronous, top-level (or nested-array)
-        // plugin object. If a future `@nativescript/vite` renames it or wraps it in
-        // a Promise, the strip silently misses and Rolldown crashes again with the
-        // `currentLoadingModule` error this package exists to prevent — so warn loud
-        // when the plugin we expect to remove was NOT found.
-        if (before === 0) {
-            // one-time build-time diagnostic — surfaces a silent upstream rename
-            console.warn(
-                '[@gjsify/nativescript-vite] no plugin named "commonjs" found in the upstream config — ' +
-                    'if your @nativescript/vite version renamed/wrapped @rollup/plugin-commonjs, the Rolldown ' +
-                    'CommonJS fix may not have applied.',
+
+    if (skipVite8Patches) {
+        // One-time informational notice — upstream 8.x handles Vite-8/Rolldown
+        // natively, so only the bundler-shouldn't-type-check strip is applied.
+        if (!nativeViteNoticeShown) {
+            nativeViteNoticeShown = true;
+            console.info(
+                `[@gjsify/nativescript-vite] detected @nativescript/vite@${major}.x — upstream handles ` +
+                    'Vite 8 / Rolldown natively (rolldownOptions, string-only aliases, no @rollup/plugin-commonjs), ' +
+                    'so the function-alias drop and commonjs strip are skipped; only the vite-side ' +
+                    `"${TS_CHECK_PLUGIN}" type-check plugin is removed.`,
             );
         }
+    } else {
+        // Fix (1): drop function-replacement `resolve.alias` entries (Rolldown
+        // rejects them). Only on the <= 2 / unknown line — 8.x ships string aliases.
+        if (config.resolve?.alias) {
+            out.resolve = { ...config.resolve, alias: dropFunctionAliases(config.resolve.alias) };
+        }
+        // Fix (2): remove the explicit `@rollup/plugin-commonjs` plugin (Rolldown
+        // crashes on it). Only on the <= 2 / unknown line — 8.x has no such plugin.
+        if (Array.isArray(config.plugins)) {
+            const before = countPluginByName(config.plugins, 'commonjs');
+            out.plugins = stripPluginByName(config.plugins, 'commonjs');
+            // Observability: the strip depends on `@rollup/plugin-commonjs` registering
+            // exactly `name: 'commonjs'` as a synchronous, top-level (or nested-array)
+            // plugin object. If a future `@nativescript/vite` renames it or wraps it in
+            // a Promise, the strip silently misses and Rolldown crashes again with the
+            // `currentLoadingModule` error this package exists to prevent — so warn loud
+            // when the plugin we expect to remove was NOT found.
+            if (before === 0) {
+                // one-time build-time diagnostic — surfaces a silent upstream rename
+                console.warn(
+                    '[@gjsify/nativescript-vite] no plugin named "commonjs" found in the upstream config — ' +
+                        'if your @nativescript/vite version renamed/wrapped @rollup/plugin-commonjs, the Rolldown ' +
+                        'CommonJS fix may not have applied.',
+                );
+            }
+        }
+    }
 
-        // Drop the vite-side `ns-typescript-check` plugin. A bundler should bundle,
-        // not type-check — gjsify defers the authoritative TypeScript gate to
-        // `gjsify tsc` / the app's own `check` script (the same separation Vite's
-        // esbuild/SWC pipeline already makes). The vite-side check additionally runs
-        // a SEPARATE program that loads the full `@nativescript/types` android
-        // globals and, under TS 6+, fails the build on the *standard* NativeScript
-        // `createNativeView(): android.view.View` override — a covariance the app's
-        // own `tsc --noEmit` accepts. Removing it (not silencing it) keeps the build
-        // honest; type errors surface in `gjsify tsc`, the real gate.
+    // Fix (3): drop the vite-side `ns-typescript-check` plugin on EITHER line. A
+    // bundler should bundle, not type-check — gjsify defers the authoritative
+    // TypeScript gate to `gjsify tsc` / the app's own `check` script (the same
+    // separation Vite's esbuild/SWC pipeline already makes). The vite-side check
+    // additionally runs a SEPARATE program that loads the full `@nativescript/types`
+    // android globals and, under TS 6+, fails the build on the *standard*
+    // NativeScript `createNativeView(): android.view.View` override — a covariance
+    // the app's own `tsc --noEmit` accepts. Removing it (not silencing it) keeps the
+    // build honest; type errors surface in `gjsify tsc`, the real gate. No-op when
+    // the plugin is absent (8.x may not register it).
+    if (Array.isArray(out.plugins)) {
         const tsCheckBefore = countPluginByName(out.plugins, TS_CHECK_PLUGIN);
         out.plugins = stripPluginByName(out.plugins, TS_CHECK_PLUGIN);
         if (tsCheckBefore > 0) {
@@ -173,6 +525,7 @@ export function applyVite8Fixes(config: UserConfig): UserConfig {
             );
         }
     }
+
     return out;
 }
 

--- a/tests/e2e/ns-vite-fixes/run.mjs
+++ b/tests/e2e/ns-vite-fixes/run.mjs
@@ -28,8 +28,9 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, copyFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -105,7 +106,11 @@ describe('@gjsify/nativescript-vite applyVite8Fixes E2E', () => {
     }
 
     it('drops function-replacement aliases, keeps string-replacement aliases', () => {
-        const fixed = applyVite8Fixes(makeSyntheticConfig());
+        // Pin the legacy <= 2 line explicitly: the function-alias drop is part of
+        // the FULL patch set, and `@nativescript/vite@8.x` may be installed in this
+        // workspace (auto-detect would then skip fix 1). The override arg makes the
+        // assertion deterministic regardless of what's on disk.
+        const fixed = applyVite8Fixes(makeSyntheticConfig(), 2);
 
         assert.ok(Array.isArray(fixed.resolve.alias), 'resolve.alias should remain an array');
 
@@ -159,7 +164,10 @@ describe('@gjsify/nativescript-vite applyVite8Fixes E2E', () => {
     });
 
     it("removes every 'commonjs' plugin (incl. nested), keeps all others", () => {
-        const fixed = applyVite8Fixes(makeSyntheticConfig());
+        // Pin the legacy <= 2 line explicitly (the commonjs strip is part of the
+        // FULL patch set, skipped on 8.x which may be installed here) — see the
+        // function-alias test above.
+        const fixed = applyVite8Fixes(makeSyntheticConfig(), 2);
 
         assert.ok(Array.isArray(fixed.plugins), 'plugins should remain an array');
 
@@ -210,6 +218,237 @@ describe('@gjsify/nativescript-vite applyVite8Fixes E2E', () => {
             recordAlias,
             'record-form resolve.alias must be passed through unchanged',
         );
+    });
+
+    // ─── Conditional on the @nativescript/vite major (override arg) ──────────
+    //
+    // The 2nd `nsViteMajor` argument bypasses the auto-detection (which would
+    // return `undefined` here — @nativescript/vite isn't installed in CI — and
+    // fail-safe to the full <= 2 patch set). It exercises both branches without
+    // two installs.
+
+    it('on @nativescript/vite >= 8: skips fixes 1 & 2, still strips ns-typescript-check', () => {
+        // 8.x ships native Vite-8/Rolldown support (string-only aliases, no
+        // @rollup/plugin-commonjs), so the function-alias drop + commonjs strip
+        // must be SKIPPED — but the bundler-shouldn't-type-check strip stays.
+        const fixed = applyVite8Fixes(
+            {
+                resolve: {
+                    alias: [
+                        { find: '~', replacement: '/abs/app/src' },
+                        { find: /^.*$/, replacement: () => '/resolved/platform/main' }, // would be dropped on <=2
+                    ],
+                },
+                plugins: [
+                    { name: 'nativescript-package-resolver' }, // KEEP
+                    { name: 'commonjs' }, // would be dropped on <=2 — KEPT on 8.x
+                    { name: 'ns-typescript-check' }, // DROP on either line
+                    { name: 'vite:esbuild' }, // KEEP
+                ],
+            },
+            8,
+        );
+        // Fix (1) skipped — the function-replacement alias survives untouched.
+        const hasFunctionAlias = fixed.resolve.alias.some((a) => typeof a.replacement === 'function');
+        assert.equal(hasFunctionAlias, true, 'on 8.x the function-replacement alias must be left in place (fix skipped)');
+        // Fix (2) skipped — the commonjs plugin survives.
+        const names = pluginNames(fixed.plugins);
+        assert.ok(names.includes('commonjs'), 'on 8.x the commonjs plugin must be left in place (fix skipped)');
+        // Fix (3) still applied — ns-typescript-check is gone.
+        assert.equal(
+            names.includes('ns-typescript-check'),
+            false,
+            "ns-typescript-check must still be stripped on 8.x — a bundler doesn't type-check",
+        );
+        assert.deepEqual(
+            names,
+            ['nativescript-package-resolver', 'commonjs', 'vite:esbuild'],
+            'on 8.x only ns-typescript-check is removed; commonjs + the rest survive',
+        );
+    });
+
+    it('on @nativescript/vite <= 2 (explicit major): applies the full patch set', () => {
+        // Passing 2 explicitly must reproduce the auto-detect-unknown default.
+        const fixed = applyVite8Fixes(makeSyntheticConfig(), 2);
+        const hasFunctionAlias = fixed.resolve.alias.some((a) => typeof a.replacement === 'function');
+        assert.equal(hasFunctionAlias, false, 'on <=2 every function-replacement alias must be dropped');
+        const names = pluginNames(fixed.plugins);
+        assert.equal(names.includes('commonjs'), false, 'on <=2 every commonjs plugin must be dropped');
+        assert.deepEqual(
+            names,
+            ['nativescript-package-resolver', 'vite:esbuild', 'nested-keeper', 'vite:define'],
+            'on <=2 the full patch set runs (function aliases + commonjs removed, others kept)',
+        );
+    });
+});
+
+// ── Isolated-fixture helpers (Bug 1 + Bug 2) ─────────────────────────────────
+//
+// Both Bug 1 (exports-gated detection) and Bug 2 (missing-peer stubs) must run the
+// BUILT lib against a FIXTURE `@nativescript/vite`, not the workspace's real one.
+// Because the workspace symlinks `node_modules/@gjsify/nativescript-vite` → the
+// package source, a bare import of the lib from a CWD inside the repo resolves the
+// workspace copy (and the workspace `@nativescript/vite`). So the fixture lives in
+// the OS tmp dir, OUTSIDE the repo, with a parent whose `node_modules` symlinks the
+// workspace `node_modules` (for the lib's deep deps: `vite`, `@gjsify/vite-plugin-gjsify`,
+// …) and an `app/` child whose own `node_modules` shadows with a COPY of the built
+// lib + the fixture `@nativescript/vite`. Running the lib (bare import) from `app/`
+// then resolves the fixture `@nativescript/vite` while deep deps fall through to the
+// workspace.
+const WORKSPACE_NODE_MODULES = fileURLToPath(new URL('../../../node_modules', import.meta.url));
+const ALL_TMP = [];
+
+/**
+ * Build an isolated fixture app and return its `app/` dir (the CWD to run in) plus
+ * the path to the lib copy. `nsVite` describes the fixture `@nativescript/vite`
+ * (`{ version, peerName?, eagerImport? }`); pass `null` to install NO
+ * `@nativescript/vite` at all (the genuinely-absent case).
+ */
+function makeIsolatedFixture(nsVite) {
+    const root = mkdtempSync(join(tmpdir(), 'gjsify-nsvite-'));
+    ALL_TMP.push(root);
+    if (nsVite) {
+        // Parent node_modules → the whole workspace (deep deps + a fall-through
+        // workspace `@nativescript/vite`; the fixture below shadows it in `app/`).
+        symlinkSync(WORKSPACE_NODE_MODULES, join(root, 'node_modules'), 'dir');
+    } else {
+        // GENUINELY-ABSENT case: symlink ONLY the lib's deep deps, NOT the
+        // workspace's `@nativescript/vite` — so detection sees no peer at all.
+        // A symlinked package resolves its own transitive deps from its real
+        // (workspace) location, so these two links suffice to load the lib.
+        const parentNm = join(root, 'node_modules');
+        mkdirSync(join(parentNm, '@gjsify'), { recursive: true });
+        symlinkSync(join(WORKSPACE_NODE_MODULES, 'vite'), join(parentNm, 'vite'), 'dir');
+        symlinkSync(
+            join(WORKSPACE_NODE_MODULES, '@gjsify', 'vite-plugin-gjsify'),
+            join(parentNm, '@gjsify', 'vite-plugin-gjsify'),
+            'dir',
+        );
+    }
+
+    const app = join(root, 'app');
+    const appNm = join(app, 'node_modules');
+    // Shadowing lib copy.
+    const libDir = join(appNm, '@gjsify', 'nativescript-vite');
+    mkdirSync(libDir, { recursive: true });
+    copyFileSync(fileURLToPath(LIB_URL), join(libDir, 'index.js'));
+    writeFileSync(
+        join(libDir, 'package.json'),
+        JSON.stringify({ name: '@gjsify/nativescript-vite', version: '0.0.0', type: 'module', exports: { '.': './index.js' } }),
+    );
+
+    if (nsVite) {
+        const pkg = join(appNm, '@nativescript', 'vite');
+        mkdirSync(pkg, { recursive: true });
+        const pkgJson = {
+            name: '@nativescript/vite',
+            version: nsVite.version,
+            type: 'module',
+            // exports-gated: root entry only, NO ./package.json subpath (the 8.x shape).
+            exports: { '.': { import: './index.js', default: './index.js' } },
+        };
+        if (nsVite.peerName) {
+            pkgJson.peerDependencies = { [nsVite.peerName]: '*' };
+            pkgJson.peerDependenciesMeta = { [nsVite.peerName]: { optional: true } };
+        }
+        writeFileSync(join(pkg, 'package.json'), JSON.stringify(pkgJson));
+        const body = nsVite.eagerImport
+            ? // Eager NAMED import of the (absent) peer at module-eval — the
+              // `@vue/compiler-sfc` failure shape that breaks ESM link.
+              `import { compileScript, parse } from '${nsVite.peerName}';\n` +
+                  `export const typescriptConfig = () => ({ plugins: [], _peerSeen: typeof compileScript + ',' + typeof parse });\n`
+            : `export const typescriptConfig = () => ({ plugins: [] });\n`;
+        writeFileSync(join(pkg, 'index.js'), body);
+    }
+    return { app };
+}
+
+/**
+ * Run `expr` (an async expression over the default-imported lib `mod`) from `app/`
+ * and return its result. The lib emits informational notices (e.g. the "8.x
+ * detected" one) on stdout/stderr, so the result is bracketed in a unique marker
+ * and extracted — keeping the assertion immune to that noise.
+ */
+function runInFixture(app, expr) {
+    const M = '<<<NSVITE-RESULT>>>';
+    const code =
+        `import mod, { detectNativescriptViteMajor } from '@gjsify/nativescript-vite';` +
+        `void detectNativescriptViteMajor;` +
+        `let r;` +
+        `try { r = String(await (${expr})); }` +
+        `catch (e) { r = 'ERR:' + ((e && (e.cause?.code || e.code)) || String(e && e.message)); }` +
+        `process.stdout.write('${M}' + r + '${M}');`;
+    const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+        cwd: app,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const start = out.indexOf(M);
+    const end = out.indexOf(M, start + M.length);
+    return start >= 0 && end > start ? out.slice(start + M.length, end) : out.trim();
+}
+
+after(() => {
+    for (const d of ALL_TMP) rmSync(d, { recursive: true, force: true });
+});
+
+// ─── Bug 1: major detection works against an exports-gated package ────────────
+//
+// `@nativescript/vite@8.x`'s `package.json#exports` does NOT expose the
+// `./package.json` subpath. The old detector resolved `@nativescript/vite/package.json`
+// directly → Node threw `ERR_PACKAGE_PATH_NOT_EXPORTED` → caught → `undefined`, so
+// the major-8 gate never fired and the full legacy patch set ran. The fix resolves
+// the package's MAIN entry (always exported) and walks up to its `package.json`.
+describe('@gjsify/nativescript-vite detectNativescriptViteMajor (Bug 1: exports-gated package)', () => {
+    function detect(nsVite) {
+        const { app } = makeIsolatedFixture(nsVite);
+        return runInFixture(app, 'detectNativescriptViteMajor()');
+    }
+
+    it('detects the major of an exports-gated @nativescript/vite (no ./package.json subpath)', () => {
+        // Under the OLD code this came back "undefined" (ERR_PACKAGE_PATH_NOT_EXPORTED);
+        // the fix walks up from the main entry and reads the package root.
+        assert.equal(detect({ version: '8.0.0-alpha.57' }), '8', 'major of an 8.x exports-gated package must be detected');
+        assert.equal(detect({ version: '2.0.3' }), '2', 'major of a 2.x exports-gated package must be detected');
+    });
+
+    it('returns "undefined" when @nativescript/vite is genuinely not installed', () => {
+        assert.equal(
+            detect(null),
+            'undefined',
+            'an absent optional peer must keep the graceful undefined fallback (fail-safe to full patch set)',
+        );
+    });
+});
+
+// ─── Bug 2: a framework-less Core app loads the config (missing-peer stubs) ───
+//
+// `@nativescript/vite@8.x`'s config chain STATICALLY imports the framework
+// compilers (`@vue/compiler-sfc`, etc.) at module-eval. They are `peerDependencies`,
+// so a framework-LESS NativeScript-Core app can't even `import('@nativescript/vite')`
+// — Node throws `ERR_MODULE_NOT_FOUND: Cannot find package '@vue/compiler-sfc'`.
+// `defineNativescriptConfig()` stubs the missing peers (no-op modules) so the
+// config loads. Verified against a fixture `@nativescript/vite` whose config eagerly
+// NAMED-imports a framework peer that is NOT installed.
+describe('@gjsify/nativescript-vite missing-framework-peer stubs (Bug 2: Core app)', () => {
+    function compose(nsVite) {
+        const { app } = makeIsolatedFixture(nsVite);
+        return runInFixture(
+            app,
+            `(async () => { const cfg = await mod()({ command: 'build', mode: 'production' });` +
+                ` return 'OK:' + (Array.isArray(cfg.plugins) ? 'config' : typeof cfg); })()`,
+        );
+    }
+
+    it('composes a Core-app config without throwing when a framework peer is missing', () => {
+        // Under the OLD code: `ERR_MODULE_NOT_FOUND` (Cannot find package
+        // '@gjsify/fake-vue-compiler'). With the stub: the config composes.
+        const out = compose({ version: '8.0.0-alpha.57', peerName: '@gjsify/fake-vue-compiler', eagerImport: true });
+        assert.ok(
+            out.startsWith('OK:'),
+            `a framework-less Core app must compose without throwing — got "${out}" (the missing peer should be stubbed)`,
+        );
+        assert.ok(out.includes('config'), `the composed result must be a real Vite config object — got "${out}"`);
     });
 });
 


### PR DESCRIPTION
Two fixes for building a NativeScript app against the new `@nativescript/vite@8` line under Vite 8 / Rolldown.

## 1. Major detection through the exports gate

`detectNativescriptViteMajor()` returned `undefined` on the 8.x line because `@nativescript/vite@8`'s `package.json#exports` does not expose `./package.json` — resolving the `@nativescript/vite/package.json` subpath threw `ERR_PACKAGE_PATH_NOT_EXPORTED`, so the conditional patch gate never fired and the full legacy patch set ran against a package that doesn't need it.

It now resolves the package's **main entry** (always exported) and walks up to the nearest `package.json` whose `name === '@nativescript/vite'` to read the version. Robust for both modern `exports`-only packages and classic ones.

## 2. Eager framework-peer imports break a Core app

`@nativescript/vite@8`'s config chain **statically** imports the Vue/Solid/React/Angular HMR compilers at config-load (declared as optional `peerDependencies`). A framework-less NativeScript-Core app therefore cannot even `import('@nativescript/vite')` — Node throws `ERR_MODULE_NOT_FOUND: Cannot find package '@vue/compiler-sfc'`.

A `resolve.alias` (a Vite config field) can't fix an eager ESM import — the loader executes it before Vite ever reads the config. So the composer now registers Node `module.registerHooks`:
- a `resolve` hook redirects each **missing** peer specifier to a synthetic stub URL;
- a `load` hook returns a no-op default Proxy **plus** a named export (also the Proxy) for every name the upstream source actually imports from that peer — satisfying namespace / default / named imports of any shape.

Only the *absent* peers are stubbed; an installed framework keeps its real compiler. Idempotent, and a graceful warn-with-remedy fallback when `registerHooks` is unavailable (older Node).

## Tests

`tests/e2e/ns-vite-fixes` — 16/16, including the exports-gated major-detection case and a Core-app compose-without-throw case.

https://claude.ai/code/session_01DHDNnU6EAnX4t5fPtpJYMc
