### PR TITLE
fix(cli): gjsify tsc — fall back to upstream tsc when gjs is absent (was exit 254)

### DIFF
--- a/packages/infra/cli/src/commands/tsc.ts
+++ b/packages/infra/cli/src/commands/tsc.ts
@@ -147,12 +147,22 @@ export const tscCommand: Command<unknown, TscOptions> = {
         // `gjs` is not on PATH (ENOENT), transparently fall back to upstream
         // `typescript` under Node when available.
         if (bundlePath) {
+            // A failed spawn (notably ENOENT when `gjs` is absent) emits BOTH
+            // 'error' AND 'close'. The 'error' handler owns the outcome (Node
+            // fallback or a clear exit), so the 'close' handler must NOT also
+            // exit — otherwise it races and exits with the spawn errno (e.g.
+            // ENOENT → -2), which surfaced as a misleading 254 and pre-empted the
+            // fallback (gjsify tsc died instead of degrading to upstream tsc on a
+            // gjs-less host such as a CI runner).
+            let gjsSpawnFailed = false;
             const child = spawn('gjs', ['-m', bundlePath, ...tscArgs], { env, stdio: 'inherit' });
             await new Promise<void>((resolvePromise) => {
                 child.on('close', (code) => {
+                    if (gjsSpawnFailed) return;
                     process.exit(code ?? 1);
                 });
                 child.on('error', (err: NodeJS.ErrnoException) => {
+                    gjsSpawnFailed = true;
                     if (err.code === 'ENOENT' && nodeTscPath) {
                         // No gjs on PATH — run upstream typescript under Node.
                         runNodeTsc();


### PR DESCRIPTION
## Problem

On a host **without `gjs`** (e.g. an `ubuntu-latest` CI runner), `gjsify tsc` died with **exit 254** instead of transparently falling back to upstream `typescript`.

## Root cause

In `packages/infra/cli/src/commands/tsc.ts`, when the GJS bundle resolves we `spawn('gjs', …)`. If `gjs` is missing, Node emits **both** `'error'` **and** `'close'`:

- `'error'` → owns the outcome (`runNodeTsc()` fallback, or a clear exit). ✅
- `'close'` → also ran `process.exit(code ?? 1)` — but with the spawn's ENOENT errno (`-2`), so the process exited **254** and pre-empted the fallback. ❌

Confirmed via `node --trace-exit`: the `-2` exit originated in the `'close'` handler.

## Fix

Guard the `'close'` handler with a `gjsSpawnFailed` flag set by `'error'`, so a failed spawn leaves the outcome to the error handler and the Node fallback runs. 10-line change, `tsc.ts` only.

## Repro

```
# host without gjs:
gjsify tsc --noEmit      # before: exit 254 ;  after: falls back to node tsc, type-checks
```

Surfaced by the `buchhaltung` project's CI (gjs-less ubuntu runner) — `gjsify tsc` exited 254 and broke the Typecheck step.

## ⚠️ Bundle regen needed

The committed bootstrap bundle `packages/infra/cli/dist/cli.gjs.mjs` must be regenerated from this src change (`.githooks/pre-commit` / `npm run build:gjs-bundle`) or the bundle-freshness check will go red. I couldn't bootstrap a full gjsify dev env to rebuild it in isolation — the Node-free `gjs -m cli.gjs.mjs install` itself crashed (Gjs-CRITICAL), which is a **separate** GJS-toolchain issue (gjs bundler / native prebuilds) that other branches already track. This PR deliberately scopes to only the tsc-fallback bug to avoid colliding with that work.