### PR TITLE
test(tls): CI probe for IPv6 SAN false-fail (temporary)

### DIFF
--- a/packages/node/tls/src/index.spec.ts
+++ b/packages/node/tls/src/index.spec.ts
@@ -626,6 +626,39 @@ export default async () => {
                     expect(result).toBeUndefined();
                 });
 
+                // CI-PROBE (temporary): root-causing a CI-only false-fail of the
+                // IPv6 SAN test (provably-deterministic-pass locally). Prints the
+                // exact runtime values to stderr so we can see, on CI, whether the
+                // parse, the compare, or the impl diverges. Always passes.
+                await it('CI-PROBE IPv6 SAN diagnostic', async () => {
+                    const alt = 'IP Address:::1';
+                    const host = '::1';
+                    const cert = fakeCert({ subject: {}, subjectaltname: alt });
+                    const result = checkServerIdentity(host, cert);
+                    const parsed = alt
+                        .split(', ')
+                        .filter((n) => n.startsWith('IP Address:'))
+                        .map((n) => n.slice(11).trim());
+                    const inlineValid = parsed.some((ip) => ip.toLowerCase() === host.toLowerCase());
+                    console.error(
+                        'CI_PROBE_IPV6 ' +
+                            JSON.stringify({
+                                altCodes: Array.from(alt).map((c) => c.charCodeAt(0)),
+                                parsed,
+                                parsedLens: parsed.map((s) => s.length),
+                                host,
+                                hostLen: host.length,
+                                inlineValid,
+                                implUndef: result === undefined,
+                                implType: typeof result,
+                                implReason: (result && (result as { reason?: string }).reason) || null,
+                                implHost: (result && (result as { host?: string }).host) || null,
+                                fnLen: checkServerIdentity.toString().length,
+                            }),
+                    );
+                    expect(inlineValid).toBe(true);
+                });
+
                 await it('should handle IPv6 in IP Address SAN', async () => {
                     const result = checkServerIdentity(
                         '::1',
@@ -634,6 +667,15 @@ export default async () => {
                             subjectaltname: 'IP Address:::1',
                         }),
                     );
+                    if (result !== undefined) {
+                        console.error(
+                            'CI_PROBE_IPV6_FAIL ' +
+                                JSON.stringify({
+                                    reason: (result as { reason?: string }).reason ?? null,
+                                    host: (result as { host?: string }).host ?? null,
+                                }),
+                        );
+                    }
                     expect(result).toBeUndefined();
                 });
 

--- a/packages/node/tls/src/index.spec.ts
+++ b/packages/node/tls/src/index.spec.ts
@@ -16,6 +16,8 @@ import tls, {
     DEFAULT_MIN_VERSION,
     DEFAULT_MAX_VERSION,
     DEFAULT_CIPHERS,
+    // @ts-expect-error CI-PROBE temporary freshness marker (not in @types/node)
+    __TLS_BUILD_MARKER,
 } from 'node:tls';
 import type { PeerCertificate } from 'node:tls';
 import type { Socket } from 'node:net';
@@ -654,6 +656,9 @@ export default async () => {
                                 implReason: (result && (result as { reason?: string }).reason) || null,
                                 implHost: (result && (result as { host?: string }).host) || null,
                                 fnLen: checkServerIdentity.toString().length,
+                                // If undefined → the bundled tls is a STALE shadow copy
+                                // that predates this marker (not the rebuilt source).
+                                buildMarker: (__TLS_BUILD_MARKER as string | undefined) ?? null,
                             }),
                     );
                     expect(inlineValid).toBe(true);

--- a/packages/node/tls/src/index.spec.ts
+++ b/packages/node/tls/src/index.spec.ts
@@ -16,9 +16,8 @@ import tls, {
     DEFAULT_MIN_VERSION,
     DEFAULT_MAX_VERSION,
     DEFAULT_CIPHERS,
-    // @ts-expect-error CI-PROBE temporary freshness marker (not in @types/node)
-    __TLS_BUILD_MARKER,
 } from 'node:tls';
+import { readFileSync } from 'node:fs';
 import type { PeerCertificate } from 'node:tls';
 import type { Socket } from 'node:net';
 
@@ -656,10 +655,30 @@ export default async () => {
                                 implReason: (result && (result as { reason?: string }).reason) || null,
                                 implHost: (result && (result as { host?: string }).host) || null,
                                 fnLen: checkServerIdentity.toString().length,
-                                // If undefined → the bundled tls is a STALE shadow copy
-                                // that predates this marker (not the rebuilt source).
-                                buildMarker: (__TLS_BUILD_MARKER as string | undefined) ?? null,
                             }),
+                    );
+                    // Read the ON-DISK workspace lib the build refreshes — does it
+                    // carry the marker (→ build refreshed it, staleness is in module
+                    // RESOLUTION elsewhere) or not (→ build never refreshed it)?
+                    const candidates = [
+                        'lib/esm/internal/hostname.js',
+                        '../tls/lib/esm/internal/hostname.js',
+                        'node_modules/@gjsify/tls/lib/esm/internal/hostname.js',
+                    ];
+                    const onDisk: Record<string, unknown> = {};
+                    for (const p of candidates) {
+                        try {
+                            const c = readFileSync(p, 'utf-8');
+                            onDisk[p] = {
+                                hasMarker: c.includes('__TLS_BUILD_MARKER'),
+                                hasIPv6: c.includes("includes(':')") || c.includes('includes(`:`)'),
+                                len: c.length,
+                            };
+                        } catch (e) {
+                            onDisk[p] = 'ERR ' + (e as Error).message;
+                        }
+                    }
+                    console.error('CI_PROBE_ONDISK ' + JSON.stringify(onDisk),
                     );
                     expect(inlineValid).toBe(true);
                 });

--- a/packages/node/tls/src/index.ts
+++ b/packages/node/tls/src/index.ts
@@ -76,7 +76,7 @@ export const rootCertificates: string[] = [];
 // Type + class re-exports
 export type { CertSubject, PeerCertificate } from './internal/cert-utils.js';
 export type { CertAltNameError } from './internal/hostname.js';
-export { checkServerIdentity } from './internal/hostname.js';
+export { checkServerIdentity, __TLS_BUILD_MARKER } from './internal/hostname.js';
 export type { SecureContext, SecureContextOptions } from './secure-context.js';
 export { createSecureContext } from './secure-context.js';
 export type { TlsConnectOptions } from './tls-socket.js';

--- a/packages/node/tls/src/internal/hostname.ts
+++ b/packages/node/tls/src/internal/hostname.ts
@@ -8,6 +8,10 @@
 
 import type { PeerCertificate } from './cert-utils.js';
 
+/** CI-PROBE (temporary): freshness marker — if the bundled tls is rebuilt from
+ *  the current source, this is present; a stale shadow copy lacks it. */
+export const __TLS_BUILD_MARKER = 'ipv6-fresh-001';
+
 /** Removes a trailing dot from a fully-qualified domain name. */
 export function unfqdn(host: string): string {
     return host.endsWith('.') ? host.slice(0, -1) : host;


### PR DESCRIPTION
Temporary draft to capture the IPv6-SAN false-fail's runtime values on CI. Not for merge — will be closed once diagnosed. https://claude.ai/code/session_01DHDNnU6EAnX4t5fPtpJYMc