### PR TITLE
test(tls): gjs-scope IPv6 IP-SAN check (native node regression)

### DIFF
--- a/packages/node/tls/src/index.spec.ts
+++ b/packages/node/tls/src/index.spec.ts
@@ -4,7 +4,7 @@
 // Original: Copyright (c) Node.js contributors. MIT.
 // Rewritten for @gjsify/unit — behavior preserved, assertion dialect adapted.
 
-import { describe, it, expect } from '@gjsify/unit';
+import { describe, it, expect, on } from '@gjsify/unit';
 import tls, {
     TLSSocket,
     connect,
@@ -626,15 +626,28 @@ export default async () => {
                     expect(result).toBeUndefined();
                 });
 
-                await it('should handle IPv6 in IP Address SAN', async () => {
-                    const result = checkServerIdentity(
-                        '::1',
-                        fakeCert({
-                            subject: {},
-                            subjectaltname: 'IP Address:::1',
-                        }),
-                    );
-                    expect(result).toBeUndefined();
+                // GJS-only: this validates OUR IPv6 IP-SAN matching. Newer native
+                // Node (24.16+) cannot match an IPv6 IP-SAN at all: its
+                // `checkServerIdentity` runs the host through `domainToASCII()`
+                // before the `net.isIP()` gate (refs/node/lib/tls.js:412/434), and
+                // `domainToASCII('::1') === ''` (an IPv6 literal is not a valid
+                // domain) → `net.isIP('') === 0` → it skips IP matching and returns
+                // `Cert does not contain a DNS name`. IPv4 is unaffected (dotted-
+                // decimal survives `domainToASCII`). `@gjsify/tls` matches the IPv6
+                // host directly (no `domainToASCII`), so it is correct here while
+                // native Node regressed — running this on `test:node` would assert
+                // our (correct) result against native Node's broken one and fail.
+                await on('Gjs', async () => {
+                    await it('should handle IPv6 in IP Address SAN', async () => {
+                        const result = checkServerIdentity(
+                            '::1',
+                            fakeCert({
+                                subject: {},
+                                subjectaltname: 'IP Address:::1',
+                            }),
+                        );
+                        expect(result).toBeUndefined();
+                    });
                 });
 
                 await it('should fail IPv4 in DNS SAN (IP should use IP Address SAN)', async () => {


### PR DESCRIPTION
## Root cause (the long-standing "tls IPv6 flake")

The `should handle IPv6 in IP Address SAN` check is in the cross-platform `index.spec.ts`, so it runs on **both** axes: `test:node` (native Node) and `test:gjs` (`@gjsify/tls`). It became a CI-only red because CI pins `node-version: [24.x]` and setup-node installs the **latest** 24.x — and **newer native Node (24.16+) regressed IPv6 IP-SAN matching**:

`checkServerIdentity` now runs the host through `domainToASCII()` before the `net.isIP()` gate (`refs/node/lib/tls.js:412/434`). `domainToASCII('::1') === ''` (an IPv6 literal is not a valid domain) → `net.isIP('') === 0` → it skips IP matching entirely and returns `Cert does not contain a DNS name`. IPv4 survives `domainToASCII` (dotted-decimal), so only the IPv6 case broke.

Because the package's `test` script is `… && test:node && test:gjs`, the `test:node` failure ran **first** and masked the passing GJS run — surfacing as a mystery "❌ 1 of 273 tests failed" that re-runs never greened (deterministic on the newer Node) and no older *local* Node (24.15.0, which still matched) could reproduce. This is what blocked main + #596/#598/#599.

## Fix

`@gjsify/tls` matches the IPv6 host directly (no `domainToASCII`), so it is **correct** here while native Node regressed. Scope this one assertion to GJS — it validates *our* IPv6 handling; native Node's newer behavior is a divergence we should not replicate by degrading our impl. IPv4 IP-SAN checks stay cross-platform.

## Verified

`test:node` → IPv6 check skipped (cannot fail on any Node version); `test:gjs` → IPv6 check runs and passes (✔). No production code change.

https://claude.ai/code/session_01DHDNnU6EAnX4t5fPtpJYMc