### PR TITLE
fix(adwaita-nativescript): declare native-platform dependency

### DIFF
--- a/packages/nativescript-bridge/adwaita/package.json
+++ b/packages/nativescript-bridge/adwaita/package.json
@@ -48,7 +48,8 @@
     ],
     "dependencies": {
         "@gjsify/adwaita-fonts": "workspace:^",
-        "@gjsify/adwaita-icons": "workspace:^"
+        "@gjsify/adwaita-icons": "workspace:^",
+        "@gjsify/native-platform": "workspace:^"
     },
     "peerDependencies": {
         "@nativescript/core": "*"


### PR DESCRIPTION
## Problem

The **v0.12.0 release build failed** at `Build packages`:

```
[@gjsify/adwaita-nativescript] src/fonts.ts:22:32 - error TS2307:
  Cannot find module '@gjsify/native-platform' or its corresponding type declarations.
```

`@gjsify/adwaita-nativescript` imports `isNativeScript` / `assertNativeScript` from `@gjsify/native-platform` (`src/index.ts`, `src/fonts.ts`, `src/index.spec.ts`) but never declared it in `dependencies`.

Locally this stayed green because `native-platform`'s `lib/types` was already on disk. In CI's clean parallel `gjsify foreach build`, the missing dependency edge let the topological sort schedule `adwaita-nativescript` in the **first** wave (alongside `adwaita-web`/`async_hooks`/`buffer`) **before** `native-platform` was built → `gjsify tsc` failed with TS2307 and aborted the release.

## Fix

Declare the edge (`workspace:^`, matching siblings `@gjsify/devtools-nativescript` + `@gjsify/native-fs-bridge`) so the topological build always builds `native-platform` first. `workspace:^` deps resolve via symlink → lockfile unchanged.

## Verification

- Build `adwaita-nativescript` with `native-platform`'s `lib/` removed → fails TS2307 (reproduces CI).
- Build `native-platform` first, then `adwaita-nativescript` → green.

Unblocks the v0.12.0 npm publish (all packages currently stuck at 0.11.0).

https://claude.ai/code/session_01DHDNnU6EAnX4t5fPtpJYMc