### PR TITLE
ci: bump to Node 26 + node24-runtime actions

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24.x
+          node-version: 26.x
 
       # `scripts/audit-runtimes.mjs` is pure Node (zero deps beyond builtins),
       # so no `yarn install` / `npm install` is needed. The script walks

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -38,7 +38,7 @@ jobs:
         fedora-version: [43, 44]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU (for cross-arch where needed)
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '26'
 
       # Phase D.7d: Node-free install via the committed GJS bundle.
       # Mirrors main.yml — see that workflow for rationale.
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -102,7 +102,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/webgl prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: webgl-prebuilds-linux-${{ matrix.arch }}
           path: packages/framework/webgl/prebuilds/linux-${{ matrix.arch }}/
@@ -126,7 +126,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/webrtc-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: webrtc-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/web/webrtc-native/prebuilds/linux-${{ matrix.arch }}/
@@ -150,7 +150,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/http-soup-bridge prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: http-soup-bridge-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/http-soup-bridge/prebuilds/linux-${{ matrix.arch }}/
@@ -174,7 +174,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/http2-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: http2-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/http2-native/prebuilds/linux-${{ matrix.arch }}/
@@ -201,7 +201,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/sab-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sab-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/sab-native/prebuilds/linux-${{ matrix.arch }}/
@@ -229,7 +229,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/tls-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tls-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/tls-native/prebuilds/linux-${{ matrix.arch }}/
@@ -257,7 +257,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/lightningcss-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lightningcss-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/infra/lightningcss-native/prebuilds/linux-${{ matrix.arch }}/
@@ -296,7 +296,7 @@ jobs:
           ls -lh "prebuilds/linux-${ARCH}/"
 
       - name: Upload @gjsify/rolldown-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rolldown-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/infra/rolldown-native/prebuilds/linux-${{ matrix.arch }}/
@@ -486,49 +486,49 @@ jobs:
             # rather than QEMU userspace. Tracked in STATUS.md "Open TODOs".
 
       - name: Upload @gjsify/webgl prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: webgl-prebuilds-linux-${{ matrix.arch }}
           path: packages/framework/webgl/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/webrtc-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: webrtc-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/web/webrtc-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/http-soup-bridge prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: http-soup-bridge-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/http-soup-bridge/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/http2-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: http2-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/http2-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/sab-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sab-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/sab-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/tls-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tls-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/tls-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
       - name: Upload @gjsify/lightningcss-native prebuilds artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lightningcss-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/infra/lightningcss-native/prebuilds/linux-${{ matrix.arch }}/
@@ -550,230 +550,230 @@ jobs:
 
       # -------- @gjsify/webgl --------
       - name: Download webgl x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webgl-prebuilds-linux-x86_64
           path: packages/framework/webgl/prebuilds/linux-x86_64/
 
       - name: Download webgl aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webgl-prebuilds-linux-aarch64
           path: packages/framework/webgl/prebuilds/linux-aarch64/
 
       - name: Download webgl ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webgl-prebuilds-linux-ppc64
           path: packages/framework/webgl/prebuilds/linux-ppc64/
 
       - name: Download webgl s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webgl-prebuilds-linux-s390x
           path: packages/framework/webgl/prebuilds/linux-s390x/
 
       - name: Download webgl riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webgl-prebuilds-linux-riscv64
           path: packages/framework/webgl/prebuilds/linux-riscv64/
 
       # -------- @gjsify/webrtc-native --------
       - name: Download webrtc-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webrtc-native-prebuilds-linux-x86_64
           path: packages/web/webrtc-native/prebuilds/linux-x86_64/
 
       - name: Download webrtc-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webrtc-native-prebuilds-linux-aarch64
           path: packages/web/webrtc-native/prebuilds/linux-aarch64/
 
       - name: Download webrtc-native ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webrtc-native-prebuilds-linux-ppc64
           path: packages/web/webrtc-native/prebuilds/linux-ppc64/
 
       - name: Download webrtc-native s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webrtc-native-prebuilds-linux-s390x
           path: packages/web/webrtc-native/prebuilds/linux-s390x/
 
       - name: Download webrtc-native riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: webrtc-native-prebuilds-linux-riscv64
           path: packages/web/webrtc-native/prebuilds/linux-riscv64/
 
       # -------- @gjsify/http-soup-bridge --------
       - name: Download http-soup-bridge x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http-soup-bridge-prebuilds-linux-x86_64
           path: packages/node/http-soup-bridge/prebuilds/linux-x86_64/
 
       - name: Download http-soup-bridge aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http-soup-bridge-prebuilds-linux-aarch64
           path: packages/node/http-soup-bridge/prebuilds/linux-aarch64/
 
       - name: Download http-soup-bridge ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http-soup-bridge-prebuilds-linux-ppc64
           path: packages/node/http-soup-bridge/prebuilds/linux-ppc64/
 
       - name: Download http-soup-bridge s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http-soup-bridge-prebuilds-linux-s390x
           path: packages/node/http-soup-bridge/prebuilds/linux-s390x/
 
       - name: Download http-soup-bridge riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http-soup-bridge-prebuilds-linux-riscv64
           path: packages/node/http-soup-bridge/prebuilds/linux-riscv64/
 
       # -------- @gjsify/http2-native --------
       - name: Download http2-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http2-native-prebuilds-linux-x86_64
           path: packages/node/http2-native/prebuilds/linux-x86_64/
 
       - name: Download http2-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http2-native-prebuilds-linux-aarch64
           path: packages/node/http2-native/prebuilds/linux-aarch64/
 
       - name: Download http2-native ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http2-native-prebuilds-linux-ppc64
           path: packages/node/http2-native/prebuilds/linux-ppc64/
 
       - name: Download http2-native s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http2-native-prebuilds-linux-s390x
           path: packages/node/http2-native/prebuilds/linux-s390x/
 
       - name: Download http2-native riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: http2-native-prebuilds-linux-riscv64
           path: packages/node/http2-native/prebuilds/linux-riscv64/
 
       # -------- @gjsify/sab-native --------
       - name: Download sab-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sab-native-prebuilds-linux-x86_64
           path: packages/node/sab-native/prebuilds/linux-x86_64/
 
       - name: Download sab-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sab-native-prebuilds-linux-aarch64
           path: packages/node/sab-native/prebuilds/linux-aarch64/
 
       - name: Download sab-native ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sab-native-prebuilds-linux-ppc64
           path: packages/node/sab-native/prebuilds/linux-ppc64/
 
       - name: Download sab-native s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sab-native-prebuilds-linux-s390x
           path: packages/node/sab-native/prebuilds/linux-s390x/
 
       - name: Download sab-native riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sab-native-prebuilds-linux-riscv64
           path: packages/node/sab-native/prebuilds/linux-riscv64/
 
       # -------- @gjsify/tls-native --------
       - name: Download tls-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tls-native-prebuilds-linux-x86_64
           path: packages/node/tls-native/prebuilds/linux-x86_64/
 
       - name: Download tls-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tls-native-prebuilds-linux-aarch64
           path: packages/node/tls-native/prebuilds/linux-aarch64/
 
       - name: Download tls-native ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tls-native-prebuilds-linux-ppc64
           path: packages/node/tls-native/prebuilds/linux-ppc64/
 
       - name: Download tls-native s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tls-native-prebuilds-linux-s390x
           path: packages/node/tls-native/prebuilds/linux-s390x/
 
       - name: Download tls-native riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tls-native-prebuilds-linux-riscv64
           path: packages/node/tls-native/prebuilds/linux-riscv64/
 
       # -------- @gjsify/lightningcss-native --------
       - name: Download lightningcss-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lightningcss-native-prebuilds-linux-x86_64
           path: packages/infra/lightningcss-native/prebuilds/linux-x86_64/
 
       - name: Download lightningcss-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lightningcss-native-prebuilds-linux-aarch64
           path: packages/infra/lightningcss-native/prebuilds/linux-aarch64/
 
       - name: Download lightningcss-native ppc64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lightningcss-native-prebuilds-linux-ppc64
           path: packages/infra/lightningcss-native/prebuilds/linux-ppc64/
 
       - name: Download lightningcss-native s390x prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lightningcss-native-prebuilds-linux-s390x
           path: packages/infra/lightningcss-native/prebuilds/linux-s390x/
 
       - name: Download lightningcss-native riscv64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: lightningcss-native-prebuilds-linux-riscv64
           path: packages/infra/lightningcss-native/prebuilds/linux-riscv64/
 
       # -------- @gjsify/rolldown-native (native runners only) --------
       - name: Download rolldown-native x86_64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rolldown-native-prebuilds-linux-x86_64
           path: packages/infra/rolldown-native/prebuilds/linux-x86_64/
 
       - name: Download rolldown-native aarch64 prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rolldown-native-prebuilds-linux-aarch64
           path: packages/infra/rolldown-native/prebuilds/linux-aarch64/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          node-version: '26.x'
 
       # Phase D.7d: Node-free install via the committed GJS bundle.
       # Mirrors main.yml — see that workflow for rationale.


### PR DESCRIPTION
## Why
The runner warns `Node 20 is being deprecated. This workflow is running with Node 24 by default`, and several workflows still pinned `node-version: 24` while `main.yml` already moved to the Node 26 line.

## What
- **node-version 24 → 26**: `deploy-docs`, `release`, `audit-runtimes`.
- **node20 → node24 action runtimes** (verified each major's `runs.using`):
  - `actions/checkout@v4 → v6` (build-ci-image)
  - `actions/deploy-pages@v4 → v5` (deploy-docs)
  - `actions/upload-artifact@v4 → v7`, `actions/download-artifact@v4 → v8` (prebuilds, 52 sites). Inputs are supersets of v4 (`name`/`path`/`pattern`/`merge-multiple` unchanged); upload@v7 + download@v8 stay format-compatible within a run.

`actionlint` clean.

## Deferred
`main.yml`'s `actions/cache@v4 → v6` (2 sites) — done in a follow-up to avoid conflicting with the in-flight selective-build PR #614 that also edits `main.yml`.