### PR TITLE
ci: bump main.yml cache to v6 + slim CI image

### DIFF
--- a/.docker/ci-fedora.Dockerfile
+++ b/.docker/ci-fedora.Dockerfile
@@ -82,10 +82,9 @@ RUN dnf install -y \
     blueprint-compiler \
     && dnf clean all
 
-# Node.js — the main workflow uses actions/setup-node which downloads its
-# own copy, so this is more about having a sane default for interactive
-# debugging in the container. Skip if it bloats the image too much.
-RUN dnf install -y --setopt=install_weak_deps=False nodejs npm && dnf clean all
+# NOTE: no nodejs/npm baked in — the workflow uses actions/setup-node (Node
+# 26.x) which downloads its own copy + corepack, so Fedora's node would only
+# be dead weight in the pull. (Was here purely for interactive debugging.)
 
 # Marker so the workflow can verify it picked up the right image
 # (`/etc/gjsify-ci-fedora-version`). Helps debug "why didn't my dnf install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
       # MUST run BEFORE "Create non-root user" so the chown -R below hands the
       # restored tree to testuser (the install + build user).
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -365,7 +365,7 @@ jobs:
       # for hours. The pillar/name shape covers every real workspace
       # while skipping the deps tree.
       - name: Cache build output (lib/ + tsbuildinfo)
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           # NEVER cache git-committed, version-locked artifacts. `@gjsify/tsc`'s
           # `lib/` (the ~108 default `lib.*.d.ts`) and the committed `.gjs.mjs`


### PR DESCRIPTION
## Why
Closes the **last** `Node 20 is being deprecated` source and trims the image pull.

## What
- `main.yml`'s two `actions/cache@v4` (node20) → **`@v6`** (node24 runtime; inputs identical, reads existing v4-saved caches). With #617 the whole workflow set is now node24.
- Drop `nodejs`/`npm` from the prebuilt CI image — the workflow uses `actions/setup-node` (Node 26.x) + corepack, so Fedora's node was dead weight in the ~30s pull. The Dockerfile change rebuilds + pushes the image on merge.

`actionlint` clean.