### PR TITLE
ci: drop fedora 43, standardise on fedora 44

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,27 +19,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Matrix planner — decides which Fedora legs the build/test jobs run.
-  # A GitHub matrix axis cannot read `github.event_name` directly, so we
-  # emit the leg list as a JSON job output and `fromJSON` it into the matrix.
-  # Each entry is a full object {v, gjs} — we do NOT use a static `include:`
-  # for the gjs label, because a static include for a version that ISN'T in
-  # the (PR-reduced) axis would spawn a phantom extra job.
-  #   - pull_request    → Fedora 44 only (GJS 1.88, the newest platform).
-  #   - push / schedule → FULL matrix (43 + 44), so the documented minimum
-  #                       runtime (GJS 1.86 / Fedora 43) is always re-covered.
+  # Matrix planner — emits the Fedora legs the build/test jobs run as a JSON job
+  # output that the matrix `fromJSON`s (a matrix axis can't be built inline here).
+  # Each entry is a full object {v, gjs}. Standardised on Fedora 44 (GJS 1.88 /
+  # SM 140), the supported platform — the Fedora 43 / GJS 1.86 leg was dropped.
   setup:
     runs-on: ubuntu-latest
     outputs:
       fedora-matrix: ${{ steps.plan.outputs.fedora-matrix }}
     steps:
       - id: plan
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo 'fedora-matrix=[{"v":"44","gjs":"GJS 1.88 / SM 140"}]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'fedora-matrix=[{"v":"43","gjs":"GJS 1.86 / SM 140"},{"v":"44","gjs":"GJS 1.88 / SM 140"}]' >> "$GITHUB_OUTPUT"
-          fi
+        run: echo 'fedora-matrix=[{"v":"44","gjs":"GJS 1.88 / SM 140"}]' >> "$GITHUB_OUTPUT"
 
   # Classifier job — diffs HEAD vs the PR's base SHA, emits per-test-tier
   # gates as job outputs. Runs in seconds on plain ubuntu-latest with no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,24 @@ jobs:
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest
-    container:
-      image: fedora:43
     permissions:
       # contents: write so softprops/action-gh-release can upload install.mjs
       # + cli.gjs.mjs + .sha256 as assets onto the release record that
       # triggered this workflow. id-token: write keeps OIDC provenance
-      # available for future signed-publish work.
+      # available for future signed-publish work. packages: read lets the job
+      # pull the prebuilt ci-fedora image from ghcr (same as main.yml).
       contents: write
       id-token: write
+      packages: read
+    container:
+      # Build + publish on the SAME prebuilt CI image main.yml builds/tests on —
+      # it bundles every build dependency (gjs, gtk4 / libadwaita / blueprint,
+      # libatomic, …), so this job needs no manual `dnf install`. Standardised on
+      # Fedora 44; the bare fedora:43 image was dropped (its Node 26 binary failed
+      # to load libatomic.so.1, and f44 is the supported platform).
+      image: ghcr.io/gjsify/ci-fedora:44
 
     steps:
-      - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils meson vala gcc pkgconf gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel libadwaita-devel blueprint-compiler
-
       # `release` event auto-checks-out the tag. `workflow_dispatch` with a
       # `release_tag` input must explicitly target that tag so the rebuilt
       # bundle + install.mjs match what shipped (not main HEAD).


### PR DESCRIPTION
## Why

The v0.13.0 `release.yml` publish run failed at **Build packages** with:

```
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file
```

The Node 26 binary (`actions/setup-node`, since #617) links against `libatomic.so.1`, which the **bare `fedora:43`** image used by the publish job doesn't include — so `node` can't start and the build dies before anything is published. (This is why **0.13.0 is tagged + GitHub-released but absent from npm**.) `main.yml` was unaffected because it runs on the prebuilt `ghcr.io/gjsify/ci-fedora` image, which already bundles libatomic.

## What (per maintainer direction: drop f43, f44 is sufficient)

- **release.yml**: publish on the prebuilt `ghcr.io/gjsify/ci-fedora:44` image that `main.yml` already builds/tests on (bundles every build dep incl. libatomic) → the manual `dnf install` step is removed; `packages: read` added to pull the image.
- **main.yml**: build/test matrix is **Fedora 44 only** (the push/schedule f43 leg removed; the planner no longer branches on event type).

## Out of scope (flagged)

`deploy-docs.yml` and `prebuilds.yml` still reference `fedora:43` — separate concerns (prebuilds deliberately uses it for ppc64/s390x arch base images). Left untouched; can follow up if you want them dropped too.

After merge I'll re-run the publish for v0.13.0 (`workflow_dispatch`, `release_tag=v0.13.0`, `skip_publish=false`).