### PR TITLE
fix(nativescript-vite): repoint mis-targeted @nativescript/core alias

### DIFF
--- a/packages/infra/nativescript-vite/src/index.ts
+++ b/packages/infra/nativescript-vite/src/index.ts
@@ -93,6 +93,10 @@ export function defineNativescriptConfig(
     return async (env: ConfigEnv): Promise<UserConfig> => {
         const base = await loadUpstreamConfig(env);
         const fixed = applyVite8Fixes(base);
+        // Correct `@nativescript/vite`'s fragile "monorepo `packages/core` IS
+        // @nativescript/core" heuristic when the HOST monorepo's own packages/core
+        // is a DIFFERENT package (see {@link repointMistargetedCoreAlias}).
+        repointMistargetedCoreAlias(fixed);
         // Layer gjsify's NS transforms (a Vite plugin array whose `config()` hook
         // supplies the gi:// → empty redirect, platform resolution, defines, and
         // node-builtin aliases) — the same composition proven to produce a
@@ -107,6 +111,81 @@ export function defineNativescriptConfig(
 }
 
 export default defineNativescriptConfig;
+
+/**
+ * Repoint a mis-targeted `@nativescript/core` resolve.alias.
+ *
+ * `@nativescript/vite`'s base config (`configuration/base.js`) sets the
+ * @nativescript/core root to `<project>/../../packages/core` whenever that path
+ * EXISTS — without verifying the directory's package name. It assumes the
+ * NativeScript monorepo layout, where `packages/core` IS @nativescript/core. In
+ * ANY OTHER monorepo whose own `packages/core` is a DIFFERENT package — e.g.
+ * `@learn6502/core` in the Learn6502 workspace, or any `packages/core` — that
+ * heuristic mis-fires: @nativescript/core is aliased to the wrong package, and
+ * every `@nativescript/core/<sub>` import (`globals/index`, `application`,
+ * `ui/frame/activity.android`, `inspector_modules`, …) fails to resolve with
+ * "No such file or directory", breaking the bundle. (A non-monorepo app, or one
+ * without a sibling `packages/core`, falls through to node_modules resolution and
+ * is unaffected — which is why it bites only some layouts.)
+ *
+ * Fix: scan the composed `resolve.alias` and, for any entry targeting
+ * @nativescript/core whose replacement directory's `package.json#name` is NOT
+ * `@nativescript/core`, repoint the replacement at the REAL installed
+ * @nativescript/core (resolved from the project root, `process.cwd()` — where
+ * Vite runs the config). Correctly-targeted aliases (a real @nativescript/core,
+ * source or node_modules) are left untouched, so this is a safe no-op outside the
+ * name-collision case.
+ */
+function repointMistargetedCoreAlias(config: UserConfig): void {
+    const alias = config.resolve?.alias;
+    if (!Array.isArray(alias)) return;
+    let realRoot: string;
+    try {
+        const req = createRequire(import.meta.url);
+        realRoot = dirname(
+            req.resolve('@nativescript/core/package.json', { paths: [process.cwd()] }),
+        ).replace(/\\/g, '/');
+    } catch {
+        return; // @nativescript/core not resolvable from the project — leave config as-is
+    }
+    repointCoreAliasEntries(alias as Alias[], realRoot, (dir) => {
+        try {
+            return (JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { name?: string }).name;
+        } catch {
+            return undefined; // unreadable target → treat as mis-targeted
+        }
+    });
+}
+
+/**
+ * Pure core of {@link repointMistargetedCoreAlias} (exported for testing, since
+ * the wrapper resolves the real `@nativescript/core` from disk).
+ *
+ * Mutates `aliases` in place: for every entry whose `find` matches
+ * `@nativescript/core`, repoint its string `replacement` at `realRoot` UNLESS the
+ * replacement's current root directory already resolves to a real
+ * `@nativescript/core` — decided by `nameOf(dir)` returning `'@nativescript/core'`.
+ * A trailing `/$1` capture-group suffix is preserved.
+ *
+ * @internal
+ */
+export function repointCoreAliasEntries(
+    aliases: Alias[],
+    realRoot: string,
+    nameOf: (dir: string) => string | undefined,
+): void {
+    for (const entry of aliases) {
+        const { find, replacement } = entry;
+        if (typeof replacement !== 'string') continue;
+        // `find` is a RegExp like /^@nativescript\/core$/; strip escapes to match.
+        if (!String(find).replace(/\\/g, '').includes('@nativescript/core')) continue;
+        // Replacements look like `${ROOT}` or `${ROOT}/$1` — recover the root dir.
+        const currentRoot = replacement.replace(/\/\$1$/, '').replace(/\/+$/, '');
+        if (currentRoot === realRoot) continue; // already correct
+        if (nameOf(currentRoot) === '@nativescript/core') continue; // a real core elsewhere — keep it
+        entry.replacement = replacement.endsWith('/$1') ? `${realRoot}/$1` : realRoot;
+    }
+}
 
 /**
  * Resolve `@nativescript/vite`'s TypeScript config factory (an optional peer).

--- a/tests/e2e/ns-vite-fixes/run.mjs
+++ b/tests/e2e/ns-vite-fixes/run.mjs
@@ -602,3 +602,75 @@ describe('gjsifyNativescript xmlns barrels E2E', () => {
         assert.equal(plugin.transform(UPSTREAM_CODE, BUNDLER_CONTEXT_ID), null, 'no barrels → transform returns null');
     });
 });
+
+// `@nativescript/vite`'s base config aliases @nativescript/core to
+// `<project>/../../packages/core` whenever that path exists, WITHOUT verifying
+// the directory's package name. In a monorepo whose own `packages/core` is a
+// DIFFERENT package (e.g. @learn6502/core), @nativescript/core is aliased to the
+// wrong package and its subpaths fail to resolve. `repointCoreAliasEntries` (the
+// pure core of the composer's `repointMistargetedCoreAlias` fix) repoints those
+// entries at the real installed @nativescript/core.
+describe('@gjsify/nativescript-vite repointCoreAliasEntries (core-alias collision)', () => {
+    let repointCoreAliasEntries;
+
+    before(async () => {
+        ({ repointCoreAliasEntries } = await import(LIB_URL));
+        assert.equal(
+            typeof repointCoreAliasEntries,
+            'function',
+            `repointCoreAliasEntries is not exported from the built lib at ${fileURLToPath(LIB_URL)} — rebuild @gjsify/nativescript-vite`,
+        );
+    });
+
+    const WRONG = '/ws/packages/core'; // a sibling @learn6502/core (the collision)
+    const REAL = '/ws/node_modules/@nativescript/core'; // the real installed core
+
+    // The three @nativescript/core alias entries @nativescript/vite emits (with the
+    // capture-group replacements), plus unrelated `~`/`@` source aliases that must
+    // survive untouched.
+    function makeAliases(root) {
+        return [
+            { find: '~', replacement: '/abs/app/src' },
+            { find: /^@nativescript\/core\/(.+)\/index$/, replacement: `${root}/$1` },
+            { find: /^@nativescript\/core$/, replacement: root },
+            { find: /^@nativescript\/core\/(.*)$/, replacement: `${root}/$1` },
+            { find: '@', replacement: '/abs/app/src' },
+        ];
+    }
+    const nameOf = (dir) => (dir === REAL ? '@nativescript/core' : dir === WRONG ? '@learn6502/core' : undefined);
+
+    it('repoints @nativescript/core aliases that target the wrong package', () => {
+        const aliases = makeAliases(WRONG);
+        repointCoreAliasEntries(aliases, REAL, nameOf);
+        // The three core entries now resolve to the real core; `/$1` is preserved.
+        assert.equal(aliases[1].replacement, `${REAL}/$1`);
+        assert.equal(aliases[2].replacement, REAL);
+        assert.equal(aliases[3].replacement, `${REAL}/$1`);
+        // Unrelated source aliases are untouched.
+        assert.equal(aliases[0].replacement, '/abs/app/src');
+        assert.equal(aliases[4].replacement, '/abs/app/src');
+    });
+
+    it('leaves a correctly-targeted @nativescript/core alias untouched (real core elsewhere)', () => {
+        // Already points at a real @nativescript/core source root (NS's OWN monorepo,
+        // where `packages/core` really is @nativescript/core) — name verifies, so it
+        // is kept even though `realRoot` differs.
+        const aliases = makeAliases(REAL);
+        const snapshot = aliases.map((a) => a.replacement);
+        repointCoreAliasEntries(aliases, '/some/other/core', nameOf);
+        assert.deepEqual(
+            aliases.map((a) => a.replacement),
+            snapshot,
+        );
+    });
+
+    it('is a no-op when the alias already points at realRoot', () => {
+        const aliases = makeAliases(REAL);
+        const snapshot = aliases.map((a) => a.replacement);
+        repointCoreAliasEntries(aliases, REAL, () => '@learn6502/core');
+        assert.deepEqual(
+            aliases.map((a) => a.replacement),
+            snapshot,
+        );
+    });
+});


### PR DESCRIPTION
## Problem

`@nativescript/vite`'s base config (`configuration/base.js`) resolves the `@nativescript/core` root like this:

```js
const workspaceCorePkg = path.resolve(projectRoot, '../../packages/core/package.json');
if (existsSync(workspaceCorePkg)) { NS_CORE_ROOT = dirname(workspaceCorePkg); }   // ← no name check!
else { NS_CORE_ROOT = dirname(require.resolve('@nativescript/core/package.json', …)); }
```

It assumes any `<project>/../../packages/core` **is** `@nativescript/core` (true in NativeScript's own monorepo). In **any other monorepo** whose own `packages/core` is a *different* package — e.g. **`@learn6502/core`** in the Learn6502 workspace — `@nativescript/core` gets aliased to the wrong package, and every `@nativescript/core/<sub>` import (`globals/index`, `application`, `ui/frame/activity.android`, `inspector_modules`, …) fails to resolve:

```
[UNLOADABLE_DEPENDENCY] Could not load ../core/globals — No such file or directory (os error 2)
```

An app **without** a sibling `packages/core` falls through to node_modules resolution and is unaffected — which is why it bites only some layouts (the storybook showcase builds; `easy6502/app-android`, which has `@learn6502/core` at `packages/core`, did not).

## Fix

`defineNativescriptConfig` now post-processes the composed `resolve.alias`: **`repointMistargetedCoreAlias`** repoints any `@nativescript/core` alias whose target directory's `package.json#name` is **not** `'@nativescript/core'` to the real installed `@nativescript/core` (resolved from the project root). Correctly-targeted aliases — a real `@nativescript/core`, in source or node_modules — are left untouched, so it's a **safe no-op** outside the name-collision case.

The pure core (`repointCoreAliasEntries(aliases, realRoot, nameOf)`) is exported for testing.

## Verification

- **app-android** (which has `@learn6502/core` at `packages/core`) now bundles cleanly — **545 modules, "Project successfully prepared (android)"** — where it previously failed on every `@nativescript/core` subpath.
- 3 new unit tests in the `ns-vite-fixes` e2e suite (repoint a wrong target, keep a real core elsewhere, no-op when already at realRoot). **19/19 pass.**