### PR TITLE
fix(adwaita-nativescript): normalize SVG arc flags for Android PathParser

### DIFF
--- a/packages/nativescript-bridge/adwaita/src/index.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/index.spec.ts
@@ -34,7 +34,7 @@ import { attachRowPressFeedback } from './widgets/row-press.js';
 import type { TouchGestureEventData, View } from '@nativescript/core';
 // `icon-path.js` is pure (no `@nativescript/core` import), so the real symbolic-icon
 // path extraction is unit-testable off-device.
-import { extractIconPaths, extractPathData } from './widgets/icon-path.js';
+import { extractIconPaths, extractPathData, normalizeArcFlags } from './widgets/icon-path.js';
 import { DEFAULT_ICON_COLOR, DEFAULT_ICON_COLOR_DARK } from './widgets/icon-path.js';
 import {
     adwaitaColorScheme,
@@ -996,6 +996,29 @@ export default async () => {
 
         await it('extractPathData concatenates every path d', () => {
             expect(extractPathData(MULTI)).toBe('m 10 13 v -10 z m 13 1 c 1 1 1 1 z');
+        });
+
+        await it('normalizeArcFlags space-separates glued arc flags (the PathParser crash)', () => {
+            // The real crash: `a3.84 3.84 0 00-1.662-.132` packs large-arc=0, sweep=0,
+            // x=-1.662, y=-.132. PathParser throws on the glued `00`.
+            expect(normalizeArcFlags('a3.84 3.84 0 00-1.662-.132')).toBe('a 3.84 3.84 0 0 0 -1.662 -.132');
+            // Flag glued to the trailing coordinate (`01.5`).
+            expect(normalizeArcFlags('A5 5 0 01.5 2')).toBe('A 5 5 0 0 1 .5 2');
+        });
+
+        await it('normalizeArcFlags leaves non-arc / already-spaced paths unchanged', () => {
+            // No arc command at all → byte-for-byte identity (glued curve numbers are
+            // fine for PathParser; only arc FLAGS need splitting).
+            const curve = 'M9.57 1.184c-.567.078-1.251.35-2.015.753z';
+            expect(normalizeArcFlags(curve)).toBe(curve);
+            // Already space-separated arc → preserved (idempotent shape).
+            expect(normalizeArcFlags('a 5 5 0 0 1 .5 2')).toBe('a 5 5 0 0 1 .5 2');
+        });
+
+        await it('normalizeArcFlags handles multiple arc groups + trailing command', () => {
+            expect(normalizeArcFlags('a3 3 0 11-2-2 1 1 0 00.5.5L4 4')).toBe(
+                'a 3 3 0 1 1 -2 -2 1 1 0 0 0 .5 .5L4 4',
+            );
         });
     });
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/icon-path.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/icon-path.ts
@@ -56,7 +56,9 @@ export function extractIconPaths(svg: string): IconPath[] {
         if (!d) continue;
         const opAttr = /\bfill-opacity="([^"]*)"/.exec(tag[0])?.[1];
         const opacity = opAttr !== undefined ? Number.parseFloat(opAttr) : 1;
-        paths.push({ d, opacity: Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : 1 });
+        // Space-separate arc flags so Android's PathParser can read the compact form
+        // (see normalizeArcFlags) — a no-op for paths without arcs / glued flags.
+        paths.push({ d: normalizeArcFlags(d), opacity: Number.isFinite(opacity) ? Math.min(1, Math.max(0, opacity)) : 1 });
     }
     return paths;
 }
@@ -71,4 +73,74 @@ export function extractPathData(svg: string): string {
     return extractIconPaths(svg)
         .map((p) => p.d)
         .join(' ');
+}
+
+/**
+ * Space-separate the two single-digit ARC FLAGS (large-arc, sweep) in every
+ * elliptical-arc command (`A`/`a`) of an SVG path-data string.
+ *
+ * Android's `androidx.core.graphics.PathParser` (and `VectorDrawable`) tokenise
+ * arc flags as standalone numbers and THROW ("Error in parsing …") when the SVG
+ * compact form glues a flag to the next flag or coordinate — e.g.
+ * `a3 3 0 00-1.6-.1` packs `large-arc=0`, `sweep=0`, `x=-1.6`. The SVG grammar
+ * permits this (each flag is a single `0`/`1` digit), and many Adwaita symbolic
+ * icons (notably the `legacy` set) use it, so they crash the renderer. This
+ * re-emits each arc argument group with explicit spaces; every other command
+ * passes through unchanged. (Assumes the standard `x-axis-rotation 0` Adwaita
+ * icons use — a multi-digit rotation glued directly to the flags is not split.)
+ */
+export function normalizeArcFlags(d: string): string {
+    if (d.indexOf('a') === -1 && d.indexOf('A') === -1) return d; // no arcs → unchanged
+    const n = d.length;
+    const isWs = (c: string): boolean => c === ' ' || c === ',' || c === '\t' || c === '\n' || c === '\r';
+    const isNumStart = (c: string): boolean => (c >= '0' && c <= '9') || c === '.' || c === '+' || c === '-';
+    let i = 0;
+    let out = '';
+    const skipWs = (): void => {
+        while (i < n && isWs(d[i] as string)) i++;
+    };
+    const readNumber = (): string => {
+        const start = i;
+        if (d[i] === '+' || d[i] === '-') i++;
+        while (i < n && (d[i] as string) >= '0' && (d[i] as string) <= '9') i++;
+        if (d[i] === '.') {
+            i++;
+            while (i < n && (d[i] as string) >= '0' && (d[i] as string) <= '9') i++;
+        }
+        if (d[i] === 'e' || d[i] === 'E') {
+            i++;
+            if (d[i] === '+' || d[i] === '-') i++;
+            while (i < n && (d[i] as string) >= '0' && (d[i] as string) <= '9') i++;
+        }
+        return d.slice(start, i);
+    };
+    while (i < n) {
+        const c = d[i] as string;
+        if (c === 'a' || c === 'A') {
+            out += c;
+            i++;
+            // Each arc group: rx ry x-axis-rotation large-arc-flag sweep-flag x y.
+            for (;;) {
+                skipWs();
+                if (i >= n || !isNumStart(d[i] as string)) break;
+                out += ' ' + readNumber(); // rx
+                skipWs();
+                out += ' ' + readNumber(); // ry
+                skipWs();
+                out += ' ' + readNumber(); // x-axis-rotation
+                skipWs();
+                out += ' ' + (d[i++] as string); // large-arc-flag (single digit, may be glued)
+                skipWs();
+                out += ' ' + (d[i++] as string); // sweep-flag (single digit, may be glued)
+                skipWs();
+                out += ' ' + readNumber(); // x
+                skipWs();
+                out += ' ' + readNumber(); // y
+            }
+        } else {
+            out += c;
+            i++;
+        }
+    }
+    return out;
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/icons.android.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/icons.android.ts
@@ -91,7 +91,16 @@ export function renderSymbolicIcon(svg: string, options?: SymbolicIconOptions): 
     // the non-zero winding rule — concatenating them into one fill destroys both.
     let drew = false;
     for (const { d, opacity } of iconPaths) {
-        const path = parser.createPathFromPathData(d);
+        // `extractIconPaths` already runs `normalizeArcFlags` over `d`; still guard
+        // the native call — a path PathParser cannot tokenise THROWS a Java
+        // exception, which must NOT crash the whole view (onCreateView). Skip the
+        // offending sub-path and render the rest of the icon.
+        let path: AndroidPath | null = null;
+        try {
+            path = parser.createPathFromPathData(d);
+        } catch {
+            path = null;
+        }
         if (!path) continue;
         const matrix = new gfx.Matrix();
         matrix.setScale(scale, scale);


### PR DESCRIPTION
## Problem

Android's `androidx.core.graphics.PathParser` — used by `renderSymbolicIcon` to rasterise Adwaita symbolic icons — tokenises the two single-digit **arc flags** (large-arc, sweep) of an elliptical-arc command as standalone numbers, and **throws** when the SVG *compact* form glues a flag to the next flag or coordinate:

```
a3.84 3.84 0 00-1.662-.132   ← large-arc=0, sweep=0, x=-1.662 (the "00")
```
```
java.lang.RuntimeException: Error in parsing M9.57 1.184c… a3.84 3.84 0 00-1.662-.132
```

The SVG grammar permits the compact form (each flag is a single `0`/`1` digit), and many Adwaita symbolic icons — notably the `legacy` set (e.g. `accessoriesDictionarySymbolic`) — use it. The throw propagates out of `onCreateView` and **crashes the whole app at launch** (NativeScript `ErrorReportActivity`) the moment such an icon renders — e.g. an `AdwViewSwitcherBar` tab icon.

## Fix (two layers in the icon renderer)

1. **`normalizeArcFlags(d)`** (`icon-path.ts`, pure + unit-tested) re-emits each `A`/`a` argument group with explicit spaces. `extractIconPaths` runs it over every path's `d`. A no-op for paths with no arcs / already-spaced flags / non-arc commands.
2. **`icons.android.ts`** wraps `createPathFromPathData` in try/catch — any path PathParser still can't tokenise skips that sub-path instead of crashing the view.

## Tests

3 unit tests (glued flags → spaced; non-arc identity; multi-group + trailing command). **154 specs pass.**

**Verified on-device:** the ported Learn6502 Android app launches and renders all view-switcher tab icons, the `AdwMenuButton` icon, and the FAB icon (previously crashed at launch).