### PR TITLE
feat(node-gi): scaffold N-API GI engine + CI

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1,0 +1,53 @@
+name: node-gi
+
+# Dedicated CI for @gjsify/node-gi — the Node-native GObject-Introspection
+# engine (Axis 5). It is NOT a gjsify workspace member (the GJS-first
+# install/foreach tooling can't build a node-gyp addon), so the main GJS
+# workflow does not build or test it; this workflow is its source of truth.
+# Builds the N-API addon against girepository-2.0 and runs the smoke tests on
+# Node, mirroring the Fedora 44 environment the rest of CI uses.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/node-gi/**'
+      - '.github/workflows/node-gi.yml'
+  pull_request:
+    paths:
+      - 'packages/node-gi/**'
+      - '.github/workflows/node-gi.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-gi-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & test (Node / Fedora 44)
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:44
+    steps:
+      - name: Install toolchain + GObject-Introspection dev headers
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git nodejs npm gcc-c++ make python3 pkgconf-pkg-config \
+            glib2-devel gobject-introspection-devel gobject-introspection
+          node --version
+          npm --version
+          echo "girepository-2.0: $(pkg-config --modversion girepository-2.0)"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build native addon (node-gyp)
+        working-directory: packages/node-gi/node-gi
+        run: npm install --no-audit --no-fund --foreground-scripts
+
+      - name: Smoke test (node --test)
+        working-directory: packages/node-gi/node-gi
+        run: npm test

--- a/packages/node-gi/node-gi/.gitignore
+++ b/packages/node-gi/node-gi/.gitignore
@@ -1,0 +1,5 @@
+build/
+prebuilds/
+node_modules/
+*.node
+*.o

--- a/packages/node-gi/node-gi/LICENSE
+++ b/packages/node-gi/node-gi/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 gjsify contributors
+
+Portions of this package are derived from node-gtk
+(https://github.com/romgrk/node-gtk):
+Copyright (c) romgrk and node-gtk contributors.
+node-gtk is licensed under the MIT License.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -1,0 +1,61 @@
+# @gjsify/node-gi
+
+**GObject-Introspection runtime for Node.js** — the native engine that lets
+unchanged GJS / GObject-Introspection code run under Node.js, the inverse of
+gjsify's Node/Web/DOM → GJS direction (see the gjsify `AGENTS.md`
+`### Axis 5 active track`).
+
+It loads `gi://` namespaces (GLib, GObject, Gio, …) via `libgirepository` and
+exposes them with GJS-compatible semantics, so the same source builds and runs
+on both GJS and Node via `gjsify build --app {gjs,node}`.
+
+> **Status: milestone 1 (headless core) — scaffold.** This first drop proves the
+> native toolchain and the modern `girepository-2.0` API end to end: resolve the
+> default repository, `require` a namespace, read its resolved version + info
+> count, and enumerate top-level info names. Value marshalling, GObject classes /
+> signals / the GC ownership model, `GObject.registerClass`, and the
+> libuv↔GLib mainloop bridge land in subsequent drops.
+
+## Provenance
+
+Derived from [node-gtk](https://github.com/romgrk/node-gtk) (romgrk and
+contributors, MIT) — vendored and rewritten under MIT (see `LICENSE`). The
+native binding is **retargeted to `girepository-2.0`** (the GIRepository merged
+into GLib ≥ 2.80); the standalone `libgirepository-1.0` node-gtk linked is no
+longer shipped on modern systems. GJS's own `gi/repo.cpp` is the reference for
+the `girepository-2.0` API surface. node-gtk's own examples and tests are **not**
+vendored as-is — gjsify ships its own dual (GJS + Node) example/test infra.
+
+## Requirements
+
+- Node.js ≥ 20
+- A C++ toolchain (`g++`/`clang`, `make`), `node-gyp`
+- GLib ≥ 2.80 development headers exposing `girepository-2.0`
+  (Fedora: `glib2-devel gobject-introspection-devel gcc-c++`;
+   Debian/Ubuntu: `libglib2.0-dev libgirepository-2.0-dev g++`)
+- At runtime, the target libraries' typelibs must be installed (same as `gi://`
+  under GJS).
+
+## Build & test
+
+```bash
+npm install          # builds the native addon via node-gyp (install script)
+npm test             # node --test (smoke tests)
+# or rebuild explicitly:
+npm run rebuild
+```
+
+## Usage (milestone 1)
+
+```js
+import { requireNamespace, listInfoNames } from '@gjsify/node-gi';
+
+const glib = requireNamespace('GLib', '2.0');
+console.log(glib);                // { namespace: 'GLib', version: '2.0', infoCount: <n> }
+console.log(listInfoNames('GLib').includes('MainLoop')); // true
+```
+
+The GJS-compatible surface (`import GLib from 'gi://GLib?version=2.0'`,
+`const GLib = imports.gi.GLib`, the core overrides, signals, `registerClass`,
+`_promisify`, the mainloop) is layered on top of this engine in the
+`@gjsify/*` runtime packages and the gjsify bundler integration.

--- a/packages/node-gi/node-gi/binding.gyp
+++ b/packages/node-gi/node-gi/binding.gyp
@@ -1,0 +1,34 @@
+{
+  "targets": [
+    {
+      "target_name": "node_gi",
+      "sources": [
+        "src/addon.cc"
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "cflags": [
+        "<!@(pkg-config --cflags girepository-2.0)"
+      ],
+      "cflags_cc": [
+        "<!@(pkg-config --cflags girepository-2.0)",
+        "-std=c++17"
+      ],
+      "libraries": [
+        "<!@(pkg-config --libs girepository-2.0)"
+      ],
+      "defines": [
+        "NAPI_VERSION=8",
+        "NAPI_DISABLE_CPP_EXCEPTIONS"
+      ],
+      "xcode_settings": {
+        "OTHER_CFLAGS": [
+          "<!@(pkg-config --cflags girepository-2.0)"
+        ],
+        "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
+        "GCC_ENABLE_CPP_EXCEPTIONS": "NO"
+      }
+    }
+  ]
+}

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — public type surface (milestone 1: headless-core scaffold).
+
+/** Result of requiring a GObject-Introspection namespace. */
+export interface RequiredNamespace {
+  /** The namespace name, e.g. "GLib". */
+  namespace: string;
+  /** The resolved typelib version, e.g. "2.0". */
+  version: string;
+  /** Number of top-level introspection infos in the namespace. */
+  infoCount: number;
+}
+
+/**
+ * Require a GObject-Introspection namespace and report its resolved version and
+ * top-level info count. The Node twin of GJS's `gi://` / `imports.gi` load step.
+ */
+export function requireNamespace(namespace: string, version?: string): RequiredNamespace;
+
+/** Enumerate the top-level introspection-info names of an already-required namespace. */
+export function listInfoNames(namespace: string): string[];
+
+/** Prepend a directory to the GIRepository typelib search path. */
+export function prependSearchPath(path: string): void;
+
+declare const native: {
+  requireNamespace: typeof requireNamespace;
+  listInfoNames: typeof listInfoNames;
+  prependSearchPath: typeof prependSearchPath;
+};
+export default native;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — thin ESM loader for the native GObject-Introspection addon.
+//
+// Reference: refs/node-gtk (romgrk, MIT). Hand-authored loader shim — a native
+// package's JS entry is a loader, not a tsc artifact, and the repo ignores
+// `lib/`, so it lives at the package root. The native binary is built by
+// node-gyp into build/{Release,Debug}.
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url)); // package root
+
+function loadNative() {
+  const candidates = [
+    join(here, 'build', 'Release', 'node_gi.node'),
+    join(here, 'build', 'Debug', 'node_gi.node'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return require(candidate);
+  }
+  throw new Error(
+    '@gjsify/node-gi: native addon not built. Run `node-gyp rebuild` in ' +
+      here +
+      ' (requires a C++ toolchain and the girepository-2.0 / glib-2.0 development headers).',
+  );
+}
+
+const native = loadNative();
+
+/**
+ * Require a GObject-Introspection namespace and report its resolved version
+ * and top-level info count. The Node twin of GJS's gi:// / imports.gi load step.
+ * @param {string} namespace e.g. "GLib"
+ * @param {string} [version] e.g. "2.0" (omit to let GIRepository resolve)
+ * @returns {{ namespace: string, version: string, infoCount: number }}
+ */
+export const requireNamespace = native.requireNamespace;
+
+/**
+ * Enumerate the top-level introspection-info names of an already-required namespace.
+ * @param {string} namespace
+ * @returns {string[]}
+ */
+export const listInfoNames = native.listInfoNames;
+
+/**
+ * Prepend a directory to the GIRepository typelib search path (call before
+ * requireNamespace for non-system typelibs).
+ * @param {string} path
+ * @returns {void}
+ */
+export const prependSearchPath = native.prependSearchPath;
+
+export default native;

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@gjsify/node-gi",
+  "version": "0.13.0",
+  "description": "GObject-Introspection runtime for Node.js — load gi:// namespaces (GLib/GObject/Gio/…) with GJS-compatible semantics. Vendored + rewritten from node-gtk under MIT.",
+  "type": "module",
+  "license": "MIT",
+  "gypfile": true,
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    }
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "src",
+    "binding.gyp",
+    "prebuilds"
+  ],
+  "gjsify": {
+    "runtimes": {
+      "gjs": "none",
+      "node": "polyfill",
+      "browser": "none",
+      "nativescript": "none"
+    }
+  },
+  "scripts": {
+    "install": "node-gyp rebuild",
+    "build": "node-gyp rebuild",
+    "build:native": "node-gyp rebuild",
+    "rebuild": "node-gyp rebuild",
+    "clean": "node-gyp clean",
+    "test": "node --test",
+    "test:node": "node --test"
+  },
+  "dependencies": {
+    "node-addon-api": "^8.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gjsify/gjsify.git",
+    "directory": "packages/node-gi/node-gi"
+  }
+}

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — GObject-Introspection runtime for Node.js.
+//
+// Reference: refs/node-gtk (romgrk and node-gtk contributors, MIT). The design
+// of this binding derives from node-gtk; this file is an original N-API
+// implementation retargeted to the modern girepository-2.0 API (the
+// GLib-integrated `gi_*` GIRepository merged into GLib >= 2.80; the standalone
+// libgirepository-1.0 node-gtk linked no longer ships). GJS's gi/repo.cpp is
+// the reference for the girepository-2.0 API surface.
+//
+// Milestone 1 (headless core, scaffold step): prove the toolchain + the modern
+// GIRepository API end to end — resolve the default repository, require a
+// namespace, read back its resolved version + introspection-info count, and
+// enumerate the top-level info names. Marshalling, GObject/signals, the
+// toggle-ref GC dance, and the mainloop bridge land in subsequent steps.
+
+#include <napi.h>
+
+#include <girepository/girepository.h>
+#include <glib-object.h>
+#include <glib.h>
+
+#include <string>
+
+namespace {
+
+// gi_repository_dup_default() returns a new owning ref to the process-default
+// GIRepository (lazily created). Callers must g_object_unref() it.
+GIRepository* DupDefaultRepository() { return gi_repository_dup_default(); }
+
+// requireNamespace(namespace: string, version?: string)
+//   -> { namespace: string, version: string, infoCount: number }
+//
+// Mirrors the load step every GJS gi:// / imports.gi access performs:
+// gi_repository_require() with an optional pinned version (null = let
+// GIRepository resolve the system default), then read back the resolved
+// version and the top-level info count.
+Napi::Value RequireNamespace(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "requireNamespace(namespace: string, version?: string)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::string ns = info[0].As<Napi::String>().Utf8Value();
+  bool has_version = info.Length() >= 2 && info[1].IsString();
+  std::string version = has_version ? info[1].As<Napi::String>().Utf8Value() : std::string();
+
+  GIRepository* repo = DupDefaultRepository();
+  GError* error = nullptr;
+  GITypelib* typelib = gi_repository_require(
+      repo, ns.c_str(), has_version ? version.c_str() : nullptr,
+      GI_REPOSITORY_LOAD_FLAG_NONE, &error);
+
+  if (typelib == nullptr) {
+    std::string message = error != nullptr ? error->message : "unknown error";
+    if (error != nullptr) g_error_free(error);
+    g_object_unref(repo);
+    Napi::Error::New(env, "Failed to require " + ns +
+                              (has_version ? (" " + version) : "") + ": " + message)
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const char* resolved = gi_repository_get_version(repo, ns.c_str());
+  unsigned int n_infos = gi_repository_get_n_infos(repo, ns.c_str());
+
+  Napi::Object result = Napi::Object::New(env);
+  result.Set("namespace", Napi::String::New(env, ns));
+  result.Set("version", Napi::String::New(env, resolved != nullptr ? resolved : ""));
+  result.Set("infoCount", Napi::Number::New(env, static_cast<double>(n_infos)));
+
+  g_object_unref(repo);
+  return result;
+}
+
+// listInfoNames(namespace: string) -> string[]
+// Enumerates the top-level introspection infos of an already-required
+// namespace. Proves gi_repository_get_info() + gi_base_info_get_name()/unref().
+Napi::Value ListInfoNames(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "listInfoNames(namespace: string)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  std::string ns = info[0].As<Napi::String>().Utf8Value();
+  GIRepository* repo = DupDefaultRepository();
+  unsigned int n_infos = gi_repository_get_n_infos(repo, ns.c_str());
+
+  Napi::Array names = Napi::Array::New(env, n_infos);
+  for (unsigned int i = 0; i < n_infos; i++) {
+    GIBaseInfo* base = gi_repository_get_info(repo, ns.c_str(), i);
+    const char* name = gi_base_info_get_name(base);
+    names.Set(i, Napi::String::New(env, name != nullptr ? name : ""));
+    gi_base_info_unref(base);
+  }
+
+  g_object_unref(repo);
+  return names;
+}
+
+// prependSearchPath(path: string) -> void
+// Lets a caller add a typelib search directory before requiring (the Node twin
+// of GIRepository.prepend_search_path(); needed for non-system typelibs).
+Napi::Value PrependSearchPath(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "prependSearchPath(path: string)")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  std::string path = info[0].As<Napi::String>().Utf8Value();
+  GIRepository* repo = DupDefaultRepository();
+  gi_repository_prepend_search_path(repo, path.c_str());
+  g_object_unref(repo);
+  return env.Undefined();
+}
+
+}  // namespace
+
+static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("requireNamespace", Napi::Function::New(env, RequireNamespace));
+  exports.Set("listInfoNames", Napi::Function::New(env, ListInfoNames));
+  exports.Set("prependSearchPath", Napi::Function::New(env, PrependSearchPath));
+  return exports;
+}
+
+NODE_API_MODULE(node_gi, Init)

--- a/packages/node-gi/node-gi/test/smoke.test.mjs
+++ b/packages/node-gi/node-gi/test/smoke.test.mjs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Smoke test for the @gjsify/node-gi native addon (milestone 1, headless core).
+// Uses node:test so it has zero build-pipeline dependencies — it runs against
+// the freshly node-gyp-built binary on plain Node.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireNamespace, listInfoNames, prependSearchPath } from '../index.js';
+
+test('requireNamespace(GLib, 2.0) resolves version + info count', () => {
+  const result = requireNamespace('GLib', '2.0');
+  assert.equal(result.namespace, 'GLib');
+  assert.equal(result.version, '2.0');
+  assert.ok(result.infoCount > 100, `expected GLib to expose many infos, got ${result.infoCount}`);
+});
+
+test('requireNamespace without version resolves a version', () => {
+  const result = requireNamespace('Gio');
+  assert.equal(result.namespace, 'Gio');
+  assert.match(result.version, /^\d+\.\d+$/);
+  assert.ok(result.infoCount > 100);
+});
+
+test('listInfoNames(GLib) includes well-known symbols', () => {
+  requireNamespace('GLib', '2.0');
+  const names = listInfoNames('GLib');
+  assert.ok(Array.isArray(names));
+  assert.ok(names.includes('MainLoop'), 'GLib should expose MainLoop');
+  assert.ok(names.includes('Variant'), 'GLib should expose Variant');
+});
+
+test('requireNamespace throws a clear error for a missing namespace', () => {
+  assert.throws(() => requireNamespace('NoSuchNamespaceXYZ', '9.9'), /Failed to require NoSuchNamespaceXYZ/);
+});
+
+test('prependSearchPath is callable', () => {
+  assert.doesNotThrow(() => prependSearchPath('/tmp'));
+});


### PR DESCRIPTION
## What

First implementation drop for **Axis 5 — GI/GObject runtime for Node** (goal recorded in #628): `@gjsify/node-gi`, the Node-native GObject-Introspection engine that will let unchanged GJS code run under Node.js.

**Milestone 1 (headless core) — scaffold step.** This proves the native toolchain and the modern `girepository-2.0` API end to end.

## Contents

- **N-API addon** (`src/addon.cc`, node-addon-api) linking `girepository-2.0` — the GIRepository merged into GLib ≥ 2.80. node-gtk linked the standalone `girepository-1.0`, which no longer ships; GJS's own `gi/repo.cpp` is the reference for the modern `gi_*` API.
- Exposes `requireNamespace(ns, version?)`, `listInfoNames(ns)`, `prependSearchPath(path)` — resolve the default repository, `require` a namespace, read its resolved version + info count, enumerate top-level info names.
- **Provenance:** derived from [node-gtk](https://github.com/romgrk/node-gtk) (romgrk, MIT) under MIT with credits (`LICENSE` + per-file headers), retargeted to `girepository-2.0`.
- **Not a gjsify workspace member** — the GJS-first `gjsify install`/`foreach` tooling can't build a node-gyp addon. A dedicated **`.github/workflows/node-gi.yml`** builds + smoke-tests it on Node in a Fedora 44 container (installs `glib2-devel`/`gobject-introspection-devel`).

## Validation

- `node-gyp rebuild` + `node --test` locally: **5/5 smoke tests pass** (GLib/Gio require, version resolution, `MainLoop`/`Variant` enumeration, error path).
- The dedicated `node-gi` workflow reproduces this in CI.

> Note: because node-gi is intentionally not a workspace, the main GJS workflow's affected-classifier sees its files as "unmatched" and falls back to a conservative full run — green, but heavier than needed. A follow-up will teach the classifier to IGNORE `packages/node-gi/**` (the `flatpak/` precedent), so future node-gi PRs are validated solely by `node-gi.yml`.

## Next

Marshalling (GIArgument/GValue) → GObject classes/signals/GC ownership dance → `registerClass`/vfunc → libuv↔GLib mainloop → the GJS-compat runtime (`gi` module, core overrides, `imports.*`) → bundler integration → dual GJS+Node examples/tests.