### PR TITLE
feat(node-gi): value marshalling + function calls

### DIFF
--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -23,9 +23,17 @@ export function listInfoNames(namespace: string): string[];
 /** Prepend a directory to the GIRepository typelib search path. */
 export function prependSearchPath(path: string): void;
 
+/**
+ * Invoke a namespace-level GObject-Introspection function (not an instance
+ * method) with IN-only primitive/string arguments. Returns the marshalled
+ * return value. Milestone 1: numbers, booleans and strings.
+ */
+export function callFunction(namespace: string, functionName: string, args?: unknown[]): unknown;
+
 declare const native: {
   requireNamespace: typeof requireNamespace;
   listInfoNames: typeof listInfoNames;
   prependSearchPath: typeof prependSearchPath;
+  callFunction: typeof callFunction;
 };
 export default native;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -54,4 +54,15 @@ export const listInfoNames = native.listInfoNames;
  */
 export const prependSearchPath = native.prependSearchPath;
 
+/**
+ * Invoke a namespace-level GObject-Introspection function (not an instance
+ * method) with IN-only primitive/string arguments. The first marshalling slice;
+ * instance methods, OUT/INOUT params and compound types follow.
+ * @param {string} namespace e.g. "GLib"
+ * @param {string} functionName e.g. "get_host_name"
+ * @param {unknown[]} [args]
+ * @returns {unknown}
+ */
+export const callFunction = native.callFunction;
+
 export default native;

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -21,6 +21,7 @@
 #include <glib.h>
 
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -121,12 +122,176 @@ Napi::Value PrependSearchPath(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+// ---- value marshalling (milestone 1: primitives + strings) ----
+//
+// The minimal GIArgument <-> JS boundary. This is the seam node-gtk's value.cc
+// fills out exhaustively; here it covers the numeric + string + boolean tags so
+// real GI function calls work end to end. Compound tags (ARRAY/INTERFACE/GLIST/
+// GHASH/…) and OUT/INOUT directions land with the GObject + full-marshalling
+// drops.
+
+// Marshal a JS value into a GIArgument for an IN argument of `type`.
+// `heldString` keeps UTF-8 storage alive for the duration of the call.
+static bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* out,
+                           std::string* heldString) {
+  GITypeTag tag = gi_type_info_get_tag(type);
+  switch (tag) {
+    case GI_TYPE_TAG_BOOLEAN: out->v_boolean = v.ToBoolean().Value(); return true;
+    case GI_TYPE_TAG_INT8: out->v_int8 = static_cast<int8_t>(v.ToNumber().Int32Value()); return true;
+    case GI_TYPE_TAG_UINT8: out->v_uint8 = static_cast<uint8_t>(v.ToNumber().Uint32Value()); return true;
+    case GI_TYPE_TAG_INT16: out->v_int16 = static_cast<int16_t>(v.ToNumber().Int32Value()); return true;
+    case GI_TYPE_TAG_UINT16: out->v_uint16 = static_cast<uint16_t>(v.ToNumber().Uint32Value()); return true;
+    case GI_TYPE_TAG_INT32: out->v_int32 = v.ToNumber().Int32Value(); return true;
+    case GI_TYPE_TAG_UINT32: out->v_uint32 = v.ToNumber().Uint32Value(); return true;
+    case GI_TYPE_TAG_INT64: out->v_int64 = v.ToNumber().Int64Value(); return true;
+    case GI_TYPE_TAG_UINT64: out->v_uint64 = static_cast<uint64_t>(v.ToNumber().Int64Value()); return true;
+    case GI_TYPE_TAG_FLOAT: out->v_float = static_cast<float>(v.ToNumber().DoubleValue()); return true;
+    case GI_TYPE_TAG_DOUBLE: out->v_double = v.ToNumber().DoubleValue(); return true;
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME:
+      if (v.IsNull() || v.IsUndefined()) {
+        out->v_string = nullptr;
+        return true;
+      }
+      *heldString = v.ToString().Utf8Value();
+      out->v_string = const_cast<char*>(heldString->c_str());
+      return true;
+    default:
+      Napi::TypeError::New(
+          env, "Unsupported IN argument type tag " + std::to_string(static_cast<int>(tag)) +
+                   " (milestone 1 supports numbers, booleans and strings)")
+          .ThrowAsJavaScriptException();
+      return false;
+  }
+}
+
+// Marshal a return-value GIArgument into a JS value, honouring transfer.
+static Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
+                                  GITransfer transfer) {
+  GITypeTag tag = gi_type_info_get_tag(type);
+  switch (tag) {
+    case GI_TYPE_TAG_VOID: return env.Undefined();
+    case GI_TYPE_TAG_BOOLEAN: return Napi::Boolean::New(env, arg->v_boolean);
+    case GI_TYPE_TAG_INT8: return Napi::Number::New(env, arg->v_int8);
+    case GI_TYPE_TAG_UINT8: return Napi::Number::New(env, arg->v_uint8);
+    case GI_TYPE_TAG_INT16: return Napi::Number::New(env, arg->v_int16);
+    case GI_TYPE_TAG_UINT16: return Napi::Number::New(env, arg->v_uint16);
+    case GI_TYPE_TAG_INT32: return Napi::Number::New(env, arg->v_int32);
+    case GI_TYPE_TAG_UINT32: return Napi::Number::New(env, arg->v_uint32);
+    case GI_TYPE_TAG_INT64: return Napi::Number::New(env, static_cast<double>(arg->v_int64));
+    case GI_TYPE_TAG_UINT64: return Napi::Number::New(env, static_cast<double>(arg->v_uint64));
+    case GI_TYPE_TAG_FLOAT: return Napi::Number::New(env, arg->v_float);
+    case GI_TYPE_TAG_DOUBLE: return Napi::Number::New(env, arg->v_double);
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME: {
+      if (arg->v_string == nullptr) return env.Null();
+      Napi::Value str = Napi::String::New(env, arg->v_string);
+      if (transfer == GI_TRANSFER_EVERYTHING) g_free(arg->v_string);
+      return str;
+    }
+    default:
+      Napi::TypeError::New(env, "Unsupported return type tag " +
+                                    std::to_string(static_cast<int>(tag)) + " (milestone 1)")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+  }
+}
+
+// callFunction(namespace, functionName, args?: unknown[]) -> unknown
+// Invokes a namespace-level GI function (not an instance method) with IN-only
+// primitive/string args. The first proof of the marshalling + invocation path;
+// instance methods, OUT/INOUT params, and compound types follow.
+Napi::Value CallFunction(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsString() || !info[1].IsString()) {
+    Napi::TypeError::New(env, "callFunction(namespace: string, functionName: string, args?: unknown[])")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string ns = info[0].As<Napi::String>().Utf8Value();
+  std::string fn = info[1].As<Napi::String>().Utf8Value();
+  Napi::Array args = (info.Length() >= 3 && info[2].IsArray()) ? info[2].As<Napi::Array>()
+                                                              : Napi::Array::New(env, 0);
+
+  GIRepository* repo = DupDefaultRepository();
+  GIBaseInfo* base = gi_repository_find_by_name(repo, ns.c_str(), fn.c_str());
+  if (base == nullptr) {
+    g_object_unref(repo);
+    Napi::Error::New(env, "No such symbol: " + ns + "." + fn).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  if (!GI_IS_FUNCTION_INFO(base)) {
+    gi_base_info_unref(base);
+    g_object_unref(repo);
+    Napi::TypeError::New(env, ns + "." + fn + " is not a function").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  GIFunctionInfo* func = reinterpret_cast<GIFunctionInfo*>(base);
+  GICallableInfo* callable = reinterpret_cast<GICallableInfo*>(base);
+
+  if (gi_callable_info_is_method(callable)) {
+    gi_base_info_unref(base);
+    g_object_unref(repo);
+    Napi::TypeError::New(env, fn + ": instance methods are not yet supported (milestone 1: namespace functions only)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  unsigned int n_args = gi_callable_info_get_n_args(callable);
+  std::vector<GIArgument> in_args(n_args);
+  std::vector<std::string> held(n_args);
+  bool ok = true;
+  for (unsigned int i = 0; i < n_args; i++) {
+    GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
+    GIDirection dir = gi_arg_info_get_direction(ai);
+    if (dir != GI_DIRECTION_IN) {
+      gi_base_info_unref(ai);
+      Napi::TypeError::New(env, fn + ": OUT/INOUT parameters are not yet supported (milestone 1)")
+          .ThrowAsJavaScriptException();
+      ok = false;
+      break;
+    }
+    GITypeInfo* ti = gi_arg_info_get_type_info(ai);
+    Napi::Value v = i < args.Length() ? args.Get(i) : env.Undefined();
+    ok = JsToGIArgument(env, v, ti, &in_args[i], &held[i]);
+    gi_base_info_unref(ti);
+    gi_base_info_unref(ai);
+    if (!ok) break;
+  }
+  if (!ok) {
+    gi_base_info_unref(base);
+    g_object_unref(repo);
+    return env.Null();
+  }
+
+  GIArgument retval;
+  GError* error = nullptr;
+  gboolean success = gi_function_info_invoke(func, in_args.data(), n_args, nullptr, 0, &retval, &error);
+  if (!success) {
+    std::string message = error != nullptr ? error->message : "invocation failed";
+    if (error != nullptr) g_error_free(error);
+    gi_base_info_unref(base);
+    g_object_unref(repo);
+    Napi::Error::New(env, "Calling " + ns + "." + fn + ": " + message).ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  GITypeInfo* return_type = gi_callable_info_get_return_type(callable);
+  GITransfer return_transfer = gi_callable_info_get_caller_owns(callable);
+  Napi::Value result = GIArgumentToJs(env, return_type, &retval, return_transfer);
+  gi_base_info_unref(return_type);
+  gi_base_info_unref(base);
+  g_object_unref(repo);
+  return result;
+}
+
 }  // namespace
 
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("requireNamespace", Napi::Function::New(env, RequireNamespace));
   exports.Set("listInfoNames", Napi::Function::New(env, ListInfoNames));
   exports.Set("prependSearchPath", Napi::Function::New(env, PrependSearchPath));
+  exports.Set("callFunction", Napi::Function::New(env, CallFunction));
   return exports;
 }
 

--- a/packages/node-gi/node-gi/test/call-function.test.mjs
+++ b/packages/node-gi/node-gi/test/call-function.test.mjs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Function-call / value-marshalling tests for @gjsify/node-gi (milestone 1).
+// Exercises the GIArgument <-> JS boundary through real GLib functions:
+// number args/returns, string (utf8/filename) args/returns with transfer-full
+// free, and boolean returns.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { hostname } from 'node:os';
+
+import { callFunction, requireNamespace } from '../index.js';
+
+test('string return, no args: GLib.get_host_name()', () => {
+  requireNamespace('GLib', '2.0');
+  const name = callFunction('GLib', 'get_host_name');
+  assert.equal(typeof name, 'string');
+  assert.ok(name.length > 0);
+  assert.equal(name, hostname());
+});
+
+test('int args + int return: GLib.random_int_range(5, 6) === 5', () => {
+  // [begin, end) with begin=5, end=6 deterministically yields 5.
+  const n = callFunction('GLib', 'random_int_range', [5, 6]);
+  assert.equal(n, 5);
+});
+
+test('filename arg + transfer-full filename return: GLib.path_get_basename', () => {
+  const base = callFunction('GLib', 'path_get_basename', ['/foo/bar/baz.txt']);
+  assert.equal(base, 'baz.txt');
+});
+
+test('utf8 args + boolean return: GLib.str_has_prefix', () => {
+  assert.equal(callFunction('GLib', 'str_has_prefix', ['hello', 'he']), true);
+  assert.equal(callFunction('GLib', 'str_has_prefix', ['hello', 'xy']), false);
+});
+
+test('clear error for a non-function symbol', () => {
+  assert.throws(() => callFunction('GLib', 'MainLoop'), /is not a function/);
+});
+
+test('clear error for a missing symbol', () => {
+  assert.throws(() => callFunction('GLib', 'no_such_function_xyz'), /No such symbol/);
+});


### PR DESCRIPTION
## What

Milestone-1 **value marshalling** for `@gjsify/node-gi` (Axis 5): the `GIArgument` ↔ JS boundary plus real namespace-level GI **function invocation**.

Stacked on #629 (the scaffold) — GitHub will retarget this to `main` once #629 merges.

## Contents

- `callFunction(namespace, name, args?)`: resolves a `GIFunctionInfo` via `gi_repository_find_by_name`, marshals IN args into `GIArgument[]`, invokes via `gi_function_info_invoke`, and marshals the return value back.
- Value tags both directions: `boolean`, `int8/16/32/64`, `uint8/16/32/64`, `float`, `double`, `utf8`, `filename`. Transfer-full string returns are `g_free`'d after copy (`gi_callable_info_get_caller_owns`).
- Honest boundaries: clear errors for non-function / missing symbols; **instance methods** and **OUT/INOUT** params are explicitly deferred to the GObject drop.

## Validation

- 6 new tests with real GLib calls (`get_host_name` → matches `os.hostname()`, `random_int_range(5,6)===5`, `path_get_basename`, `str_has_prefix`, error paths). **11/11 `node --test` pass locally**; the dedicated `node-gi` workflow re-validates in CI.

## Next

GObject classes / properties / signals / closures + the toggle-ref GC ownership dance (the load-bearing piece), then `registerClass`/vfunc, then the libuv↔GLib mainloop.