### PR TITLE
marshal arrays/lists/hashes + GStrv in node-gi

### DIFF
--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -475,6 +475,670 @@ static Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* a
   }
 }
 
+// ====================================================================
+// ---- array / GList / GSList / GHashTable / GStrv marshalling --------
+// ====================================================================
+//
+// Compound container marshalling for IN, return, and OUT directions. Reference:
+// refs/node-gtk src/{value,function}.cc (romgrk, MIT), retargeted to the
+// girepository-2.0 API and the dense in_args/out_args layout this addon uses.
+//
+// SCOPE (the common cases real GJS code hits): C arrays + GStrv, GByteArray,
+// GArray, GPtrArray (read), GList/GSList, GHashTable with string keys. Element
+// types: utf8/filename (strings), the numeric fundamentals + boolean, and
+// GObject/interface instances. EXOTIC combos (struct/union/enum/flags/nested-
+// container elements, non-string hash keys, GArray/GPtrArray as IN, INOUT
+// containers) are DEFERRED with a clear "<type> not yet supported" thrown BEFORE
+// the invoke — mirroring the #652 IsSupportedOutType pattern.
+//
+// OWNERSHIP (the leak/UAF surface — scrutinise here):
+//  * Returns / OUT (caller-owns per gi_arg_info_get_ownership_transfer /
+//    gi_callable_info_get_caller_owns): TRANSFER_EVERYTHING frees both the
+//    container AND its elements after the read (strings g_free'd, object refs
+//    adopted by the JS wrapper); TRANSFER_CONTAINER frees only the container
+//    (elements stay callee-owned); TRANSFER_NOTHING frees nothing.
+//  * IN: TRANSFER_NOTHING means the callee borrows — we build the container,
+//    pass it, and free it (container + any g_strdup'd strings) AFTER the invoke.
+//    TRANSFER_EVERYTHING / TRANSFER_CONTAINER means the callee adopts what we
+//    built — we must NOT free it (that would UAF / double-free).
+
+// Element-type support shared by every container kind. *why receives a short
+// label on refusal (so the caller can throw a precise deferral message).
+static bool IsSupportedElementType(GITypeInfo* elem, std::string* why) {
+  switch (gi_type_info_get_tag(elem)) {
+    case GI_TYPE_TAG_BOOLEAN:
+    case GI_TYPE_TAG_INT8:
+    case GI_TYPE_TAG_UINT8:
+    case GI_TYPE_TAG_INT16:
+    case GI_TYPE_TAG_UINT16:
+    case GI_TYPE_TAG_INT32:
+    case GI_TYPE_TAG_UINT32:
+    case GI_TYPE_TAG_INT64:
+    case GI_TYPE_TAG_UINT64:
+    case GI_TYPE_TAG_FLOAT:
+    case GI_TYPE_TAG_DOUBLE:
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME:
+      return true;
+    case GI_TYPE_TAG_INTERFACE: {
+      GIBaseInfo* iface = gi_type_info_get_interface(elem);
+      bool ok = iface != nullptr && (GI_IS_OBJECT_INFO(iface) || GI_IS_INTERFACE_INFO(iface));
+      if (!ok && why != nullptr) *why = "struct/union/enum element";
+      if (iface != nullptr) gi_base_info_unref(iface);
+      return ok;
+    }
+    default:
+      if (why != nullptr) *why = "nested-container element";
+      return false;
+  }
+}
+
+// Whether a container type (ARRAY/GLIST/GSLIST/GHASH) is marshallable. Used by
+// IsSupportedOutType (OUT/return) and the IN path to defer the unsupported cases
+// up front. Array-type kind is intentionally NOT restricted here — the read side
+// (GIArrayToJs) handles C/BYTE_ARRAY/GArray/GPtrArray; the IN side rejects
+// GArray/GPtrArray separately (they're rare as IN in headless GLib).
+static bool IsSupportedContainerType(GITypeInfo* type, std::string* why) {
+  switch (gi_type_info_get_tag(type)) {
+    case GI_TYPE_TAG_ARRAY:
+    case GI_TYPE_TAG_GLIST:
+    case GI_TYPE_TAG_GSLIST: {
+      GITypeInfo* elem = gi_type_info_get_param_type(type, 0);
+      if (elem == nullptr) {
+        if (why != nullptr) *why = "untyped container";
+        return false;
+      }
+      bool ok = IsSupportedElementType(elem, why);
+      gi_base_info_unref(elem);
+      return ok;
+    }
+    case GI_TYPE_TAG_GHASH: {
+      GITypeInfo* kt = gi_type_info_get_param_type(type, 0);
+      GITypeInfo* vt = gi_type_info_get_param_type(type, 1);
+      GITypeTag ktag = kt != nullptr ? gi_type_info_get_tag(kt) : GI_TYPE_TAG_VOID;
+      bool kok = ktag == GI_TYPE_TAG_UTF8 || ktag == GI_TYPE_TAG_FILENAME;
+      bool vok = vt != nullptr && IsSupportedElementType(vt, nullptr);
+      if (!kok && why != nullptr) *why = "non-string GHashTable key";
+      else if (!vok && why != nullptr) *why = "unsupported GHashTable value";
+      if (kt != nullptr) gi_base_info_unref(kt);
+      if (vt != nullptr) gi_base_info_unref(vt);
+      return kok && vok;
+    }
+    default:
+      if (why != nullptr) *why = "container";
+      return false;
+  }
+}
+
+// In-memory size of one C-array element. 0 for an unsupported element type.
+static size_t CElementSize(GITypeInfo* elem) {
+  switch (gi_type_info_get_tag(elem)) {
+    case GI_TYPE_TAG_BOOLEAN: return sizeof(gboolean);
+    case GI_TYPE_TAG_INT8:
+    case GI_TYPE_TAG_UINT8: return 1;
+    case GI_TYPE_TAG_INT16:
+    case GI_TYPE_TAG_UINT16: return 2;
+    case GI_TYPE_TAG_INT32:
+    case GI_TYPE_TAG_UINT32: return 4;
+    case GI_TYPE_TAG_INT64:
+    case GI_TYPE_TAG_UINT64: return 8;
+    case GI_TYPE_TAG_FLOAT: return sizeof(gfloat);
+    case GI_TYPE_TAG_DOUBLE: return sizeof(gdouble);
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME:
+    case GI_TYPE_TAG_INTERFACE: return sizeof(gpointer);
+    default: return 0;
+  }
+}
+
+// Write the array's element count into a length arg's GIArgument slot (IN length
+// autofill). The field is selected by the length arg's own tag; the slot is
+// zero-initialised so writing the matching field is correct on little-endian
+// (the only targets — Fedora x86_64/aarch64).
+static void WriteLengthValue(GITypeInfo* lenType, GIArgument* slot, long n) {
+  switch (gi_type_info_get_tag(lenType)) {
+    case GI_TYPE_TAG_INT8: slot->v_int8 = static_cast<gint8>(n); break;
+    case GI_TYPE_TAG_UINT8: slot->v_uint8 = static_cast<guint8>(n); break;
+    case GI_TYPE_TAG_INT16: slot->v_int16 = static_cast<gint16>(n); break;
+    case GI_TYPE_TAG_UINT16: slot->v_uint16 = static_cast<guint16>(n); break;
+    case GI_TYPE_TAG_INT32: slot->v_int32 = static_cast<gint32>(n); break;
+    case GI_TYPE_TAG_UINT32: slot->v_uint32 = static_cast<guint32>(n); break;
+    case GI_TYPE_TAG_INT64: slot->v_int64 = static_cast<gint64>(n); break;
+    case GI_TYPE_TAG_UINT64: slot->v_uint64 = static_cast<guint64>(n); break;
+    default: slot->v_int64 = static_cast<gint64>(n); break;  // gsize/gtype: LE-safe
+  }
+}
+
+// Read a length value the callee wrote into a length arg's slot (OUT length).
+static long ReadLengthValue(GITypeInfo* lenType, GIArgument* slot) {
+  switch (gi_type_info_get_tag(lenType)) {
+    case GI_TYPE_TAG_INT8: return slot->v_int8;
+    case GI_TYPE_TAG_UINT8: return slot->v_uint8;
+    case GI_TYPE_TAG_INT16: return slot->v_int16;
+    case GI_TYPE_TAG_UINT16: return slot->v_uint16;
+    case GI_TYPE_TAG_INT32: return slot->v_int32;
+    case GI_TYPE_TAG_UINT32: return static_cast<long>(slot->v_uint32);
+    case GI_TYPE_TAG_INT64: return static_cast<long>(slot->v_int64);
+    case GI_TYPE_TAG_UINT64: return static_cast<long>(slot->v_uint64);
+    default: return static_cast<long>(slot->v_int64);  // gsize/gtype: LE-safe
+  }
+}
+
+// Read one C-array element from raw storage into a JS value, honouring the
+// per-element transfer (EVERYTHING frees strings / adopts object refs).
+static Napi::Value ReadCElement(Napi::Env env, GITypeInfo* elem, const void* src,
+                                GITransfer elemTransfer) {
+  GIArgument a;
+  memset(&a, 0, sizeof(a));
+  switch (gi_type_info_get_tag(elem)) {
+    case GI_TYPE_TAG_BOOLEAN: a.v_boolean = *static_cast<const gboolean*>(src); break;
+    case GI_TYPE_TAG_INT8: a.v_int8 = *static_cast<const gint8*>(src); break;
+    case GI_TYPE_TAG_UINT8: a.v_uint8 = *static_cast<const guint8*>(src); break;
+    case GI_TYPE_TAG_INT16: a.v_int16 = *static_cast<const gint16*>(src); break;
+    case GI_TYPE_TAG_UINT16: a.v_uint16 = *static_cast<const guint16*>(src); break;
+    case GI_TYPE_TAG_INT32: a.v_int32 = *static_cast<const gint32*>(src); break;
+    case GI_TYPE_TAG_UINT32: a.v_uint32 = *static_cast<const guint32*>(src); break;
+    case GI_TYPE_TAG_INT64: a.v_int64 = *static_cast<const gint64*>(src); break;
+    case GI_TYPE_TAG_UINT64: a.v_uint64 = *static_cast<const guint64*>(src); break;
+    case GI_TYPE_TAG_FLOAT: a.v_float = *static_cast<const gfloat*>(src); break;
+    case GI_TYPE_TAG_DOUBLE: a.v_double = *static_cast<const gdouble*>(src); break;
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME: a.v_string = *static_cast<char* const*>(src); break;
+    case GI_TYPE_TAG_INTERFACE: a.v_pointer = *static_cast<gpointer const*>(src); break;
+    default: return env.Undefined();
+  }
+  return GIArgumentToJs(env, elem, &a, elemTransfer);
+}
+
+// Free a read-side array container after marshalling out its elements. For
+// TRANSFER_EVERYTHING the elements were already released per-element during the
+// read; this frees the container itself. NOTHING frees nothing (callee owns).
+static void FreeReadArrayContainer(gpointer container, GIArrayType at, GITransfer transfer) {
+  if (container == nullptr || transfer == GI_TRANSFER_NOTHING) return;
+  switch (at) {
+    case GI_ARRAY_TYPE_C: g_free(container); break;
+    case GI_ARRAY_TYPE_BYTE_ARRAY: g_byte_array_free(static_cast<GByteArray*>(container), TRUE); break;
+    case GI_ARRAY_TYPE_ARRAY:
+      g_array_free(static_cast<GArray*>(container), transfer == GI_TRANSFER_EVERYTHING);
+      break;
+    case GI_ARRAY_TYPE_PTR_ARRAY:
+      g_ptr_array_free(static_cast<GPtrArray*>(container), transfer == GI_TRANSFER_EVERYTHING);
+      break;
+  }
+}
+
+// Marshal a C array / GStrv / GByteArray / GArray / GPtrArray into a JS value.
+// `length` is the resolved element count (or -1 = derive from zero-terminated /
+// fixed-size). guint8/gint8 arrays surface as a Node Buffer; everything else as
+// a JS Array. Frees the container per `transfer`.
+static Napi::Value GIArrayToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
+                               GITransfer transfer, long length) {
+  GIArrayType at = gi_type_info_get_array_type(type);
+  GITypeInfo* elem = gi_type_info_get_param_type(type, 0);
+  GITypeTag etag = elem != nullptr ? gi_type_info_get_tag(elem) : GI_TYPE_TAG_VOID;
+  GITransfer elemTransfer =
+      transfer == GI_TRANSFER_EVERYTHING ? GI_TRANSFER_EVERYTHING : GI_TRANSFER_NOTHING;
+  gpointer container = arg->v_pointer;
+  void* data = container;
+  size_t elemSize = CElementSize(elem);
+  bool isByte = etag == GI_TYPE_TAG_UINT8 || etag == GI_TYPE_TAG_INT8;
+
+  // Resolve data + length for the boxed array kinds (their own struct carries it).
+  if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
+    GByteArray* ba = static_cast<GByteArray*>(container);
+    data = ba != nullptr ? ba->data : nullptr;
+    length = ba != nullptr ? static_cast<long>(ba->len) : 0;
+    isByte = true;
+    elemSize = 1;
+  } else if (at == GI_ARRAY_TYPE_ARRAY) {
+    GArray* ga = static_cast<GArray*>(container);
+    data = ga != nullptr ? ga->data : nullptr;
+    length = ga != nullptr ? static_cast<long>(ga->len) : 0;
+    if (ga != nullptr) elemSize = g_array_get_element_size(ga);
+  } else if (at == GI_ARRAY_TYPE_PTR_ARRAY) {
+    GPtrArray* pa = static_cast<GPtrArray*>(container);
+    data = pa != nullptr ? pa->pdata : nullptr;
+    length = pa != nullptr ? static_cast<long>(pa->len) : 0;
+    elemSize = sizeof(gpointer);
+  } else if (length < 0) {  // C array, length not given by a length arg
+    if (gi_type_info_is_zero_terminated(type)) {
+      length = 0;
+      if (data != nullptr) {
+        if (etag == GI_TYPE_TAG_UTF8 || etag == GI_TYPE_TAG_FILENAME ||
+            etag == GI_TYPE_TAG_INTERFACE) {
+          gpointer* p = static_cast<gpointer*>(data);
+          while (p[length] != nullptr) length++;
+        } else {  // numeric: scan for an all-zero element
+          for (;; length++) {
+            const char* e = static_cast<const char*>(data) + length * elemSize;
+            bool zero = true;
+            for (size_t b = 0; b < elemSize; b++)
+              if (e[b] != 0) {
+                zero = false;
+                break;
+              }
+            if (zero) break;
+          }
+        }
+      }
+    } else {
+      size_t fixed = 0;
+      length = gi_type_info_get_array_fixed_size(type, &fixed) ? static_cast<long>(fixed) : 0;
+    }
+  }
+
+  // Byte arrays → a Node Buffer (a Uint8Array subclass).
+  if (isByte) {
+    Napi::Value buf = (data == nullptr || length <= 0)
+                          ? static_cast<Napi::Value>(Napi::Buffer<uint8_t>::New(env, 0))
+                          : static_cast<Napi::Value>(Napi::Buffer<uint8_t>::Copy(
+                                env, static_cast<const uint8_t*>(data), static_cast<size_t>(length)));
+    FreeReadArrayContainer(container, at, transfer);
+    if (elem != nullptr) gi_base_info_unref(elem);
+    return buf;
+  }
+
+  Napi::Array out = Napi::Array::New(env, (data != nullptr && length > 0) ? length : 0);
+  for (long i = 0; data != nullptr && i < length && !env.IsExceptionPending(); i++) {
+    if (at == GI_ARRAY_TYPE_PTR_ARRAY) {
+      GIArgument a;
+      memset(&a, 0, sizeof(a));
+      a.v_pointer = static_cast<gpointer*>(data)[i];
+      out.Set(static_cast<uint32_t>(i), GIArgumentToJs(env, elem, &a, elemTransfer));
+    } else {
+      out.Set(static_cast<uint32_t>(i),
+              ReadCElement(env, elem, static_cast<const char*>(data) + i * elemSize, elemTransfer));
+    }
+  }
+  FreeReadArrayContainer(container, at, transfer);
+  if (elem != nullptr) gi_base_info_unref(elem);
+  return out;
+}
+
+// Marshal a GList / GSList into a JS Array. Elements are unpacked from each
+// node's data pointer via the introspection helper (strings/objects keep the
+// pointer, fundamentals are GPOINTER_TO_INT-style unpacked). Frees the node
+// chain (not the elements — those follow `transfer` per element) for
+// EVERYTHING/CONTAINER.
+static Napi::Value GListToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
+                             GITransfer transfer, bool isSList) {
+  GITypeInfo* elem = gi_type_info_get_param_type(type, 0);
+  GITransfer elemTransfer =
+      transfer == GI_TRANSFER_EVERYTHING ? GI_TRANSFER_EVERYTHING : GI_TRANSFER_NOTHING;
+  Napi::Array out = Napi::Array::New(env);
+  uint32_t i = 0;
+  if (!isSList) {
+    for (GList* l = static_cast<GList*>(arg->v_pointer); l != nullptr && !env.IsExceptionPending();
+         l = l->next) {
+      GIArgument a;
+      gi_type_info_argument_from_hash_pointer(elem, l->data, &a);
+      out.Set(i++, GIArgumentToJs(env, elem, &a, elemTransfer));
+    }
+  } else {
+    for (GSList* l = static_cast<GSList*>(arg->v_pointer); l != nullptr && !env.IsExceptionPending();
+         l = l->next) {
+      GIArgument a;
+      gi_type_info_argument_from_hash_pointer(elem, l->data, &a);
+      out.Set(i++, GIArgumentToJs(env, elem, &a, elemTransfer));
+    }
+  }
+  if (transfer == GI_TRANSFER_EVERYTHING || transfer == GI_TRANSFER_CONTAINER) {
+    if (!isSList) g_list_free(static_cast<GList*>(arg->v_pointer));
+    else g_slist_free(static_cast<GSList*>(arg->v_pointer));
+  }
+  if (elem != nullptr) gi_base_info_unref(elem);
+  return out;
+}
+
+// Marshal a GHashTable into a plain JS object (string keys). Keys + values are
+// read with TRANSFER_NOTHING (copied / ref'd) because, for an owned table, the
+// table's own GDestroyNotify funcs free the originals when we g_hash_table_unref
+// below — freeing here too would double-free.
+static Napi::Value GHashToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
+                             GITransfer transfer) {
+  GHashTable* ht = static_cast<GHashTable*>(arg->v_pointer);
+  Napi::Object out = Napi::Object::New(env);
+  if (ht != nullptr) {
+    GITypeInfo* kt = gi_type_info_get_param_type(type, 0);
+    GITypeInfo* vt = gi_type_info_get_param_type(type, 1);
+    GHashTableIter it;
+    gpointer k = nullptr;
+    gpointer v = nullptr;
+    g_hash_table_iter_init(&it, ht);
+    while (g_hash_table_iter_next(&it, &k, &v) && !env.IsExceptionPending()) {
+      GIArgument ka;
+      GIArgument va;
+      gi_type_info_argument_from_hash_pointer(kt, k, &ka);
+      gi_type_info_argument_from_hash_pointer(vt, v, &va);
+      Napi::Value key = GIArgumentToJs(env, kt, &ka, GI_TRANSFER_NOTHING);
+      Napi::Value value = GIArgumentToJs(env, vt, &va, GI_TRANSFER_NOTHING);
+      if (env.IsExceptionPending()) break;
+      out.Set(key, value);
+    }
+    if (kt != nullptr) gi_base_info_unref(kt);
+    if (vt != nullptr) gi_base_info_unref(vt);
+  }
+  if (ht != nullptr && (transfer == GI_TRANSFER_EVERYTHING || transfer == GI_TRANSFER_CONTAINER))
+    g_hash_table_unref(ht);
+  return out;
+}
+
+// Dispatch a return / OUT GIArgument to the right reader. `slots` lets an array
+// resolve its length from the (already-populated) length arg slot. Scalars fall
+// through to GIArgumentToJs.
+static Napi::Value ReadOutOrReturn(Napi::Env env, GICallableInfo* callable, GITypeInfo* ti,
+                                   GIArgument* arg, GITransfer transfer,
+                                   std::vector<GIArgument>* slots) {
+  switch (gi_type_info_get_tag(ti)) {
+    case GI_TYPE_TAG_ARRAY: {
+      long len = -1;
+      unsigned int L = 0;
+      if (gi_type_info_get_array_length_index(ti, &L) && slots != nullptr && L < slots->size()) {
+        GIArgInfo* la = gi_callable_info_get_arg(callable, L);
+        GITypeInfo* lt = gi_arg_info_get_type_info(la);
+        len = ReadLengthValue(lt, &(*slots)[L]);
+        gi_base_info_unref(lt);
+        gi_base_info_unref(la);
+      }
+      return GIArrayToJs(env, ti, arg, transfer, len);
+    }
+    case GI_TYPE_TAG_GLIST: return GListToJs(env, ti, arg, transfer, false);
+    case GI_TYPE_TAG_GSLIST: return GListToJs(env, ti, arg, transfer, true);
+    case GI_TYPE_TAG_GHASH: return GHashToJs(env, ti, arg, transfer);
+    default: return GIArgumentToJs(env, ti, arg, transfer);
+  }
+}
+
+// ---- IN container building -----------------------------------------
+//
+// Each built container is recorded so it can be freed after the invoke for
+// TRANSFER_NOTHING (the callee borrowed it). TRANSFER_EVERYTHING/CONTAINER are
+// adopted by the callee → never freed here.
+struct InContainer {
+  GITypeInfo* type;  // ref'd; unref'd in FreeInContainer
+  gpointer ptr;
+  GITransfer transfer;
+  long count;  // element count (to free C-array strings)
+};
+
+// Fill a GIArgument for a single list/hash element from a JS value. Strings are
+// g_strdup'd (the container owns them); objects contribute their borrowed
+// handle pointer. Throws + returns false on an unsupported element.
+static bool ElementToGIArgument(Napi::Env env, GITypeInfo* elem, Napi::Value v, GIArgument* a) {
+  memset(a, 0, sizeof(*a));
+  switch (gi_type_info_get_tag(elem)) {
+    case GI_TYPE_TAG_BOOLEAN: a->v_boolean = v.ToBoolean().Value(); return true;
+    case GI_TYPE_TAG_INT8: a->v_int8 = static_cast<gint8>(v.ToNumber().Int32Value()); return true;
+    case GI_TYPE_TAG_UINT8: a->v_uint8 = static_cast<guint8>(v.ToNumber().Uint32Value()); return true;
+    case GI_TYPE_TAG_INT16: a->v_int16 = static_cast<gint16>(v.ToNumber().Int32Value()); return true;
+    case GI_TYPE_TAG_UINT16: a->v_uint16 = static_cast<guint16>(v.ToNumber().Uint32Value()); return true;
+    case GI_TYPE_TAG_INT32: a->v_int32 = v.ToNumber().Int32Value(); return true;
+    case GI_TYPE_TAG_UINT32: a->v_uint32 = v.ToNumber().Uint32Value(); return true;
+    case GI_TYPE_TAG_INT64: a->v_int64 = v.ToNumber().Int64Value(); return true;
+    case GI_TYPE_TAG_UINT64: a->v_uint64 = static_cast<guint64>(v.ToNumber().Int64Value()); return true;
+    case GI_TYPE_TAG_FLOAT: a->v_float = static_cast<gfloat>(v.ToNumber().DoubleValue()); return true;
+    case GI_TYPE_TAG_DOUBLE: a->v_double = v.ToNumber().DoubleValue(); return true;
+    case GI_TYPE_TAG_UTF8:
+    case GI_TYPE_TAG_FILENAME:
+      a->v_string = (v.IsNull() || v.IsUndefined())
+                        ? nullptr
+                        : g_strdup(v.ToString().Utf8Value().c_str());
+      return true;
+    case GI_TYPE_TAG_INTERFACE: {
+      if (v.IsNull() || v.IsUndefined()) {
+        a->v_pointer = nullptr;
+        return true;
+      }
+      if (v.IsExternal() && v.As<Napi::External<GObject>>().CheckTypeTag(&kGObjectHandleTag)) {
+        a->v_pointer = v.As<Napi::External<GObject>>().Data();
+        return true;
+      }
+      Napi::TypeError::New(env, "expected a GObject handle as a container element")
+          .ThrowAsJavaScriptException();
+      return false;
+    }
+    default:
+      Napi::TypeError::New(env, "unsupported container element type")
+          .ThrowAsJavaScriptException();
+      return false;
+  }
+}
+
+// Build a C array / GStrv / GByteArray from a JS value. *outCount = element
+// count (for the IN length autofill + later free). GArray/GPtrArray IN are
+// deferred. Throws + returns false on refusal (BEFORE the invoke).
+static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer* outPtr,
+                       long* outCount) {
+  GIArrayType at = gi_type_info_get_array_type(type);
+  GITypeInfo* elem = gi_type_info_get_param_type(type, 0);
+  GITypeTag etag = gi_type_info_get_tag(elem);
+  bool zt = gi_type_info_is_zero_terminated(type);
+  size_t elemSize = CElementSize(elem);
+  bool isByte = etag == GI_TYPE_TAG_UINT8 || etag == GI_TYPE_TAG_INT8;
+  *outPtr = nullptr;
+  *outCount = 0;
+
+  // Raw bytes from a TypedArray / Buffer (Uint8Array round-trips, etc.).
+  const uint8_t* rawBytes = nullptr;
+  size_t rawLen = 0;
+  if (v.IsBuffer()) {
+    Napi::Buffer<uint8_t> b = v.As<Napi::Buffer<uint8_t>>();
+    rawBytes = b.Data();
+    rawLen = b.Length();
+  } else if (v.IsTypedArray()) {
+    Napi::TypedArray ta = v.As<Napi::TypedArray>();
+    rawBytes = static_cast<const uint8_t*>(ta.ArrayBuffer().Data()) + ta.ByteOffset();
+    rawLen = ta.ByteLength();
+  }
+
+  if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
+    GByteArray* ba = g_byte_array_new();
+    if (rawBytes != nullptr) {
+      g_byte_array_append(ba, rawBytes, static_cast<guint>(rawLen));
+      *outCount = static_cast<long>(rawLen);
+    } else if (v.IsArray()) {
+      Napi::Array arr = v.As<Napi::Array>();
+      for (uint32_t i = 0; i < arr.Length(); i++) {
+        guint8 byte = static_cast<guint8>(arr.Get(i).ToNumber().Uint32Value());
+        g_byte_array_append(ba, &byte, 1);
+      }
+      *outCount = static_cast<long>(arr.Length());
+    } else {
+      g_byte_array_unref(ba);
+      gi_base_info_unref(elem);
+      Napi::TypeError::New(env, "expected an array or Uint8Array for the GByteArray argument")
+          .ThrowAsJavaScriptException();
+      return false;
+    }
+    *outPtr = ba;
+    gi_base_info_unref(elem);
+    return true;
+  }
+
+  if (at != GI_ARRAY_TYPE_C) {
+    gi_base_info_unref(elem);
+    Napi::TypeError::New(env, "GArray/GPtrArray IN parameters are not yet supported")
+        .ThrowAsJavaScriptException();
+    return false;
+  }
+
+  // Byte C array from a TypedArray / Buffer.
+  if (isByte && rawBytes != nullptr) {
+    void* buf = g_malloc0(elemSize * (rawLen + (zt ? 1 : 0)));
+    memcpy(buf, rawBytes, rawLen);
+    *outPtr = buf;
+    *outCount = static_cast<long>(rawLen);
+    gi_base_info_unref(elem);
+    return true;
+  }
+
+  if (!v.IsArray()) {
+    gi_base_info_unref(elem);
+    Napi::TypeError::New(env, "expected an array for the array argument")
+        .ThrowAsJavaScriptException();
+    return false;
+  }
+  Napi::Array arr = v.As<Napi::Array>();
+  long count = static_cast<long>(arr.Length());
+  void* buf = g_malloc0(elemSize * (count + (zt ? 1 : 0)));
+  bool ok = true;
+  for (long i = 0; i < count && ok; i++) {
+    GIArgument a;
+    ok = ElementToGIArgument(env, elem, arr.Get(static_cast<uint32_t>(i)), &a);
+    if (!ok) break;
+    void* dst = static_cast<char*>(buf) + i * elemSize;
+    // Copy the element's storage bytes (LE: the low elemSize bytes of the union
+    // alias the active field — v_string/v_pointer for pointers, the scalar
+    // otherwise).
+    memcpy(dst, &a, elemSize);
+  }
+  if (!ok) {
+    g_free(buf);  // partial g_strdup'd strings leak on this error path (pre-checked, rare)
+    gi_base_info_unref(elem);
+    return false;
+  }
+  *outPtr = buf;
+  *outCount = count;
+  gi_base_info_unref(elem);
+  return true;
+}
+
+// Build a GList / GSList from a JS array.
+static bool JsToGListLike(Napi::Env env, Napi::Value v, GITypeInfo* type, bool isSList,
+                          gpointer* outPtr) {
+  *outPtr = nullptr;
+  if (!v.IsArray()) {
+    Napi::TypeError::New(env, "expected an array for the list argument").ThrowAsJavaScriptException();
+    return false;
+  }
+  Napi::Array arr = v.As<Napi::Array>();
+  GITypeInfo* elem = gi_type_info_get_param_type(type, 0);
+  GList* glist = nullptr;
+  GSList* gslist = nullptr;
+  bool ok = true;
+  for (uint32_t i = 0; i < arr.Length() && ok; i++) {
+    GIArgument a;
+    ok = ElementToGIArgument(env, elem, arr.Get(i), &a);
+    if (!ok) break;
+    gpointer p = gi_type_info_hash_pointer_from_argument(elem, &a);
+    if (!isSList) glist = g_list_prepend(glist, p);
+    else gslist = g_slist_prepend(gslist, p);
+  }
+  if (!isSList) *outPtr = g_list_reverse(glist);
+  else *outPtr = g_slist_reverse(gslist);
+  gi_base_info_unref(elem);
+  return ok;
+}
+
+// Build a GHashTable (string keys) from a JS object. Value type ∈ {string,
+// object}. Keys + (string) values are g_strdup'd and owned by the table.
+static bool JsToGHashIn(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer* outPtr) {
+  *outPtr = nullptr;
+  if (!v.IsObject() || v.IsArray()) {
+    Napi::TypeError::New(env, "expected an object for the GHashTable argument")
+        .ThrowAsJavaScriptException();
+    return false;
+  }
+  GITypeInfo* vt = gi_type_info_get_param_type(type, 1);
+  GITypeTag vtag = gi_type_info_get_tag(vt);
+  bool valueIsString = vtag == GI_TYPE_TAG_UTF8 || vtag == GI_TYPE_TAG_FILENAME;
+  // String values get g_free'd by the table; borrowed object pointers do not.
+  GHashTable* ht =
+      g_hash_table_new_full(g_str_hash, g_str_equal, g_free, valueIsString ? g_free : nullptr);
+  Napi::Object obj = v.As<Napi::Object>();
+  Napi::Array keys = obj.GetPropertyNames();
+  bool ok = true;
+  for (uint32_t i = 0; i < keys.Length() && ok; i++) {
+    Napi::Value key = keys.Get(i);
+    std::string ks = key.ToString().Utf8Value();
+    Napi::Value val = obj.Get(key);
+    gpointer vp = nullptr;
+    if (valueIsString) {
+      vp = (val.IsNull() || val.IsUndefined()) ? nullptr : g_strdup(val.ToString().Utf8Value().c_str());
+    } else {
+      GIArgument a;
+      ok = ElementToGIArgument(env, vt, val, &a);
+      if (!ok) break;
+      vp = a.v_pointer;
+    }
+    g_hash_table_insert(ht, g_strdup(ks.c_str()), vp);
+  }
+  *outPtr = ht;
+  gi_base_info_unref(vt);
+  return ok;
+}
+
+// Free an IN container after the invoke. Only TRANSFER_NOTHING is freed here —
+// EVERYTHING/CONTAINER were adopted by the callee.
+static void FreeInContainer(const InContainer& c) {
+  if (c.ptr == nullptr || c.transfer != GI_TRANSFER_NOTHING) {
+    gi_base_info_unref(c.type);
+    return;
+  }
+  GITypeTag tag = gi_type_info_get_tag(c.type);
+  if (tag == GI_TYPE_TAG_ARRAY) {
+    GIArrayType at = gi_type_info_get_array_type(c.type);
+    GITypeInfo* elem = gi_type_info_get_param_type(c.type, 0);
+    GITypeTag etag = elem != nullptr ? gi_type_info_get_tag(elem) : GI_TYPE_TAG_VOID;
+    if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
+      g_byte_array_unref(static_cast<GByteArray*>(c.ptr));
+    } else {  // C array
+      if (etag == GI_TYPE_TAG_UTF8 || etag == GI_TYPE_TAG_FILENAME) {
+        char** s = static_cast<char**>(c.ptr);
+        if (gi_type_info_is_zero_terminated(c.type)) {
+          g_strfreev(s);
+        } else {
+          for (long i = 0; i < c.count; i++) g_free(s[i]);
+          g_free(s);
+        }
+      } else {
+        g_free(c.ptr);
+      }
+    }
+    if (elem != nullptr) gi_base_info_unref(elem);
+  } else if (tag == GI_TYPE_TAG_GLIST || tag == GI_TYPE_TAG_GSLIST) {
+    GITypeInfo* elem = gi_type_info_get_param_type(c.type, 0);
+    GITypeTag etag = elem != nullptr ? gi_type_info_get_tag(elem) : GI_TYPE_TAG_VOID;
+    bool freeStrings = etag == GI_TYPE_TAG_UTF8 || etag == GI_TYPE_TAG_FILENAME;
+    if (tag == GI_TYPE_TAG_GLIST) {
+      if (freeStrings)
+        for (GList* l = static_cast<GList*>(c.ptr); l != nullptr; l = l->next) g_free(l->data);
+      g_list_free(static_cast<GList*>(c.ptr));
+    } else {
+      if (freeStrings)
+        for (GSList* l = static_cast<GSList*>(c.ptr); l != nullptr; l = l->next) g_free(l->data);
+      g_slist_free(static_cast<GSList*>(c.ptr));
+    }
+    if (elem != nullptr) gi_base_info_unref(elem);
+  } else if (tag == GI_TYPE_TAG_GHASH) {
+    g_hash_table_unref(static_cast<GHashTable*>(c.ptr));  // destroy funcs free keys/values
+  }
+  gi_base_info_unref(c.type);
+}
+
+// Build any supported IN container from a JS value, recording cleanup. The
+// container type must already have passed IsSupportedContainerType. Throws +
+// returns false on refusal (BEFORE the invoke).
+static bool JsToInContainer(Napi::Env env, Napi::Value v, GITypeInfo* type, GITransfer transfer,
+                            gpointer* outPtr, long* outCount,
+                            std::vector<InContainer>* containers) {
+  GITypeTag tag = gi_type_info_get_tag(type);
+  *outCount = 0;
+  bool ok = false;
+  if (tag == GI_TYPE_TAG_ARRAY) {
+    ok = JsToCArray(env, v, type, outPtr, outCount);
+  } else if (tag == GI_TYPE_TAG_GLIST || tag == GI_TYPE_TAG_GSLIST) {
+    ok = JsToGListLike(env, v, type, tag == GI_TYPE_TAG_GSLIST, outPtr);
+  } else if (tag == GI_TYPE_TAG_GHASH) {
+    ok = JsToGHashIn(env, v, type, outPtr);
+  }
+  if (ok && *outPtr != nullptr) {
+    containers->push_back(InContainer{
+        reinterpret_cast<GITypeInfo*>(gi_base_info_ref(type)), *outPtr, transfer, *outCount});
+  }
+  return ok;
+}
+
 // Shared invocation core: marshal the JS args into a GIArgument vector (the
 // instance prepended for methods), call gi_function_info_invoke, marshal the
 // return + any OUT/INOUT values. IN is passed by value; OUT/INOUT route through
@@ -634,6 +1298,14 @@ static bool IsSupportedOutType(GITypeInfo* type, std::string* why) {
       if (iface != nullptr) gi_base_info_unref(iface);
       return ok;
     }
+    case GI_TYPE_TAG_ARRAY:
+    case GI_TYPE_TAG_GLIST:
+    case GI_TYPE_TAG_GSLIST:
+    case GI_TYPE_TAG_GHASH:
+      // Container OUT/return — arrays (incl. GStrv / byte arrays), GList/GSList,
+      // and string-keyed GHashTable. Element-type support is checked here so an
+      // exotic combo defers cleanly before the invoke.
+      return IsSupportedContainerType(type, why);
     default:
       if (why != nullptr)
         *why = "type tag " + std::to_string(static_cast<int>(gi_type_info_get_tag(type)));
@@ -696,12 +1368,52 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     gi_base_info_unref(ai);
   }
 
+  // Pre-scan: array-length args. An array IN/OUT arg — or the return value — may
+  // carry a separate introspectable length arg. Mark it skip (not JS-consumed)
+  // and flag it so its OUT slot is wired below / its IN value is autofilled from
+  // the array's JS length when the array arg is marshalled. This extends the same
+  // skip mechanism the callback closure/destroy slots already use.
+  std::vector<bool> isLenArg(n_args, false);
+  for (unsigned int i = 0; i < n_args; i++) {
+    GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
+    GITypeInfo* ti = gi_arg_info_get_type_info(ai);
+    if (gi_type_info_get_tag(ti) == GI_TYPE_TAG_ARRAY) {
+      unsigned int L = 0;
+      if (gi_type_info_get_array_length_index(ti, &L) && L < n_args) {
+        skip[L] = true;
+        isLenArg[L] = true;
+      }
+    }
+    gi_base_info_unref(ti);
+    gi_base_info_unref(ai);
+  }
+  {
+    GITypeInfo* rt = gi_callable_info_get_return_type(callable);
+    if (gi_type_info_get_tag(rt) == GI_TYPE_TAG_ARRAY) {
+      unsigned int L = 0;
+      if (gi_type_info_get_array_length_index(rt, &L) && L < n_args) {
+        skip[L] = true;
+        isLenArg[L] = true;
+      }
+    }
+    gi_base_info_unref(rt);
+  }
+
+  std::vector<InContainer> inContainers;   // IN containers to free after the invoke
   std::vector<NodeGiCallback*> created;    // all callbacks made this call
   std::vector<NodeGiCallback*> callScope;  // scope=call → freed after the invoke
   bool ok = true;
   size_t jsCursor = 0;
   for (unsigned int i = 0; i < n_args && ok; i++) {
-    if (skip[i]) continue;  // a user_data / destroy slot — set via its callback
+    if (skip[i]) {
+      // A length arg that is OUT/INOUT: the callee writes the array length into
+      // our stable slot, which we read back to size the array. (IN length args
+      // are autofilled when their array arg is marshalled, below.) Callback
+      // closure/destroy slots (always IN) are filled by the callback handler.
+      if (isLenArg[i] && (dirs[i] == GI_DIRECTION_OUT || dirs[i] == GI_DIRECTION_INOUT))
+        out_args[outPos[i]].v_pointer = &slots[i];
+      continue;
+    }
     GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
     GIDirection dir = dirs[i];
     GITypeInfo* ti = gi_arg_info_get_type_info(ai);
@@ -727,15 +1439,27 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
             .ThrowAsJavaScriptException();
         ok = false;
       } else if (dir == GI_DIRECTION_INOUT) {
-        // INOUT: marshal the JS input into the slot (like IN); the invoker hands
-        // the slot's address to the callee, which reads it and writes back.
-        Napi::Value v = jsCursor < args.Length() ? args.Get(jsCursor) : env.Undefined();
-        jsCursor++;
-        if (JsToGIArgument(env, v, ti, &slots[i], &held[i])) {
-          in_args[inPos[i]].v_pointer = &slots[i];
-          out_args[outPos[i]].v_pointer = &slots[i];
+        GITypeTag tg = gi_type_info_get_tag(ti);
+        if (tg == GI_TYPE_TAG_ARRAY || tg == GI_TYPE_TAG_GLIST || tg == GI_TYPE_TAG_GSLIST ||
+            tg == GI_TYPE_TAG_GHASH) {
+          // INOUT containers (read-modify-write a caller-built container) are the
+          // rare, ownership-tricky case — defer cleanly. Pure-OUT containers fall
+          // through to the slot-wiring branch below.
+          Napi::TypeError::New(
+              env, displayName + ": INOUT container parameters are not yet supported")
+              .ThrowAsJavaScriptException();
+          ok = false;
         } else {
-          ok = false;  // JsToGIArgument already threw
+          // INOUT scalar: marshal the JS input into the slot (like IN); the
+          // invoker hands the slot's address to the callee, which reads + writes.
+          Napi::Value v = jsCursor < args.Length() ? args.Get(jsCursor) : env.Undefined();
+          jsCursor++;
+          if (JsToGIArgument(env, v, ti, &slots[i], &held[i])) {
+            in_args[inPos[i]].v_pointer = &slots[i];
+            out_args[outPos[i]].v_pointer = &slots[i];
+          } else {
+            ok = false;  // JsToGIArgument already threw
+          }
         }
       } else {
         // Pure OUT: the callee writes into the slot; no JS arg is consumed.
@@ -778,7 +1502,39 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
         break;
       }
     } else {
-      ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i]);
+      GITypeTag tg = gi_type_info_get_tag(ti);
+      if (tg == GI_TYPE_TAG_ARRAY || tg == GI_TYPE_TAG_GLIST || tg == GI_TYPE_TAG_GSLIST ||
+          tg == GI_TYPE_TAG_GHASH) {
+        std::string why;
+        if (!IsSupportedContainerType(ti, &why)) {
+          Napi::TypeError::New(env, displayName + ": IN " + why +
+                                        " parameters are not yet supported")
+              .ThrowAsJavaScriptException();
+          ok = false;
+        } else {
+          GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
+          gpointer cptr = nullptr;
+          long ccount = 0;
+          ok = JsToInContainer(env, v, ti, tr, &cptr, &ccount, &inContainers);
+          if (ok) {
+            in_args[inPos[i]].v_pointer = cptr;
+            // Autofill an IN length arg from the array's element count.
+            if (tg == GI_TYPE_TAG_ARRAY) {
+              unsigned int L = 0;
+              if (gi_type_info_get_array_length_index(ti, &L) && L < n_args &&
+                  dirs[L] == GI_DIRECTION_IN && inPos[L] >= 0) {
+                GIArgInfo* la = gi_callable_info_get_arg(callable, L);
+                GITypeInfo* lt = gi_arg_info_get_type_info(la);
+                WriteLengthValue(lt, &in_args[inPos[L]], ccount);
+                gi_base_info_unref(lt);
+                gi_base_info_unref(la);
+              }
+            }
+          }
+        }
+      } else {
+        ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i]);
+      }
     }
 
     if (iface != nullptr) gi_base_info_unref(iface);
@@ -787,6 +1543,7 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   }
   if (!ok) {
     for (NodeGiCallback* cb : created) NodeGiCallbackFree(cb);
+    for (const InContainer& c : inContainers) FreeInContainer(c);
     return env.Null();
   }
 
@@ -798,6 +1555,7 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   // now (notified/async closures are owned by the callee / self-freeing).
   for (NodeGiCallback* cb : callScope) NodeGiCallbackFree(cb);
   if (!success) {
+    for (const InContainer& c : inContainers) FreeInContainer(c);
     std::string message = error != nullptr ? error->message : "invocation failed";
     if (error != nullptr) g_error_free(error);
     Napi::Error::New(env, "Calling " + displayName + ": " + message).ThrowAsJavaScriptException();
@@ -811,19 +1569,27 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   GITypeInfo* return_type = gi_callable_info_get_return_type(callable);
   GITransfer return_transfer = gi_callable_info_get_caller_owns(callable);
   if (gi_type_info_get_tag(return_type) != GI_TYPE_TAG_VOID) {
-    results.push_back(GIArgumentToJs(env, return_type, &retval, return_transfer));
+    results.push_back(ReadOutOrReturn(env, callable, return_type, &retval, return_transfer, &slots));
   }
   gi_base_info_unref(return_type);
 
   for (unsigned int i = 0; i < n_args && !env.IsExceptionPending(); i++) {
     if (dirs[i] != GI_DIRECTION_OUT && dirs[i] != GI_DIRECTION_INOUT) continue;
+    if (skip[i]) continue;  // an array length arg — surfaced via its array, not on its own
     GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
     GITypeInfo* ti = gi_arg_info_get_type_info(ai);
     GITransfer transfer = gi_arg_info_get_ownership_transfer(ai);
-    results.push_back(GIArgumentToJs(env, ti, &slots[i], transfer));
+    results.push_back(ReadOutOrReturn(env, callable, ti, &slots[i], transfer, &slots));
     gi_base_info_unref(ti);
     gi_base_info_unref(ai);
   }
+
+  // Free the transfer-nothing IN containers now that the results are marshalled
+  // into JS — a transfer-none return/OUT (e.g. g_environ_getenv) can point INTO
+  // a transfer-none IN container, so this MUST run after the reads above, never
+  // before. Transfer-everything/container IN were adopted by the callee, so
+  // FreeInContainer leaves those alone.
+  for (const InContainer& c : inContainers) FreeInContainer(c);
 
   if (env.IsExceptionPending()) return env.Null();
   if (results.empty()) return env.Undefined();

--- a/packages/node-gi/node-gi/test/arrays.test.mjs
+++ b/packages/node-gi/node-gi/test/arrays.test.mjs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+// Array / GList / GSList / GHashTable / GStrv marshalling for @gjsify/node-gi —
+// IN, return, and OUT directions against real headless GLib/Gio callables.
+//
+// Exercises the load-bearing pieces of the container marshalling drop:
+//  * GStrv return → string[]                       (g_get_environ)
+//  * GStrv IN (transfer none) + string return      (g_environ_getenv)
+//  * GStrv IN (transfer full) + GStrv return        (g_environ_setenv)
+//  * C byte array IN with an autofilled length arg  (g_base64_encode)
+//  * C byte array return with an OUT length arg → Buffer (g_base64_decode)
+//  * plain C utf8 array return (transfer full)      (g_uri_list_extract_uris)
+//  * GHashTable<utf8,utf8> return → object          (GLib.Uri.parse_params)
+//  * GList<utf8> return → string[]                  (g_content_types_get_registered)
+//  * deferred INOUT container throws clearly        (g_base64_decode_inplace)
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { callFunction, callStaticMethod, requireNamespace } from '../index.js';
+
+test('GStrv return → string[]: GLib.get_environ()', () => {
+  requireNamespace('GLib', '2.0');
+  // char** (NULL-terminated, transfer full) of "NAME=VALUE" entries.
+  const environ = callFunction('GLib', 'get_environ');
+  assert.ok(Array.isArray(environ));
+  assert.ok(environ.length > 0);
+  assert.ok(environ.every((e) => typeof e === 'string'));
+  assert.ok(environ.some((e) => e.startsWith('PATH=')));
+});
+
+test('GStrv IN (transfer none) + string return: GLib.environ_getenv()', () => {
+  // const char* g_environ_getenv(char** envp, const char* variable): the JS
+  // string[] is rebuilt as a NULL-terminated char** IN, and the returned value
+  // points INTO that array (transfer none) — the marshaller must read it out
+  // before freeing the IN container.
+  const environ = callFunction('GLib', 'get_environ');
+  assert.equal(callFunction('GLib', 'environ_getenv', [environ, 'PATH']), process.env.PATH);
+  assert.equal(callFunction('GLib', 'environ_getenv', [environ, 'NODE_GI_NOPE_XYZ']), null);
+});
+
+test('GStrv IN (transfer full) + GStrv return: GLib.environ_setenv()', () => {
+  // char** g_environ_setenv(char** envp /*(transfer full)*/, name, value, overwrite)
+  // — the callee adopts the IN array (we must NOT free it) and returns a fresh one.
+  const environ = callFunction('GLib', 'get_environ');
+  const updated = callFunction('GLib', 'environ_setenv', [environ, 'NODE_GI_TEST', 'present', true]);
+  assert.ok(Array.isArray(updated));
+  assert.ok(updated.includes('NODE_GI_TEST=present'));
+});
+
+test('byte array IN with autofilled length + byte return with OUT length round-trip', () => {
+  // g_base64_encode(const guchar* data /*(array length=1)*/, gsize len): the
+  // length arg is SKIPPED from the JS args and AUTO-FILLED from the input's
+  // element count. g_base64_decode(text, gsize* out_len) returns a byte array
+  // sized by the OUT length arg → a Node Buffer.
+  const bytes = Uint8Array.from([0, 1, 2, 250, 255, 42, 7]);
+  const encoded = callFunction('GLib', 'base64_encode', [bytes, bytes.length]);
+  assert.equal(typeof encoded, 'string');
+  assert.equal(encoded, Buffer.from(bytes).toString('base64'));
+
+  const decoded = callFunction('GLib', 'base64_decode', [encoded]);
+  assert.ok(Buffer.isBuffer(decoded));
+  assert.ok(Buffer.from(bytes).equals(decoded));
+});
+
+test('byte array IN also accepts a plain number[]: GLib.base64_encode()', () => {
+  const decoded = callFunction('GLib', 'base64_decode', [
+    callFunction('GLib', 'base64_encode', [[1, 2, 3], 3]),
+  ]);
+  assert.deepEqual([...decoded], [1, 2, 3]);
+});
+
+test('plain C utf8 array return (transfer full): GLib.uri_list_extract_uris()', () => {
+  // gchar** g_uri_list_extract_uris(const char*): a zero-terminated, transfer-full
+  // string array — elements + container are all caller-owned and freed after read.
+  const uris = callFunction('GLib', 'uri_list_extract_uris', [
+    'http://a.example\r\nhttp://b.example\r\n',
+  ]);
+  assert.deepEqual(uris, ['http://a.example', 'http://b.example']);
+});
+
+test('GHashTable<utf8,utf8> return → object: GLib.Uri.parse_params()', () => {
+  // GHashTable* g_uri_parse_params(params, gssize length, separators, flags):
+  // transfer-full hash with both names + values fully decoded → a plain object.
+  const params = callStaticMethod('GLib', 'Uri', 'parse_params', ['a=1&b=two&c=3', -1, '&', 0]);
+  assert.equal(typeof params, 'object');
+  assert.equal(params.a, '1');
+  assert.equal(params.b, 'two');
+  assert.equal(params.c, '3');
+});
+
+test('GList<utf8> return → string[]: Gio.content_types_get_registered()', () => {
+  requireNamespace('Gio', '2.0');
+  // GList* g_content_types_get_registered(void) (transfer full): a list of MIME
+  // type strings → a JS array; the node chain is freed after the read. The list
+  // is empty on a minimal host with no shared-mime-info database (e.g. the CI
+  // container), which exercises the NULL/empty-GList → empty-array path; on a
+  // populated host it exercises element marshalling. Either way it must be a
+  // string array, never throw or mis-handle the GList pointer.
+  const types = callFunction('Gio', 'content_types_get_registered');
+  assert.ok(Array.isArray(types));
+  assert.ok(types.every((t) => typeof t === 'string'));
+});
+
+test('deferred INOUT container throws a clear error: GLib.base64_decode_inplace()', () => {
+  // The text arg is an INOUT byte array — the rare read-modify-write container
+  // case is deferred. It must throw "not yet supported", never mis-handle it.
+  assert.throws(
+    () => callFunction('GLib', 'base64_decode_inplace', [Uint8Array.from([65, 65]), 2]),
+    /not yet supported/,
+  );
+});

--- a/packages/node-gi/node-gi/test/out-params.test.mjs
+++ b/packages/node-gi/node-gi/test/out-params.test.mjs
@@ -64,11 +64,17 @@ test('instance method with multiple OUT → array: GLib.DateTime.get_ymd()', () 
   assert.deepEqual(callBoxedMethod(dt, 'get_ymd'), [2006, 1, 2]);
 });
 
-test('deferred OUT type throws a clear error: GLib.get_filename_charsets()', () => {
-  // gboolean g_get_filename_charsets(const gchar ***): the OUT is a string array
-  // (a later roadmap PR). It must throw a clear "not yet supported", never
-  // silently mis-handle the pointer.
-  assert.throws(() => callFunction('GLib', 'get_filename_charsets'), /not yet supported/);
+test('OUT string array → [bool, string[]]: GLib.get_filename_charsets()', () => {
+  // gboolean g_get_filename_charsets(const gchar ***): the OUT is a zero-terminated
+  // string array. Once a roadmap PR (arrays/lists/hash) — now implemented, so it
+  // surfaces as [is_utf8, charsets] rather than throwing "not yet supported".
+  const res = callFunction('GLib', 'get_filename_charsets');
+  assert.ok(Array.isArray(res));
+  assert.equal(res.length, 2);
+  assert.equal(typeof res[0], 'boolean');
+  assert.ok(Array.isArray(res[1]));
+  assert.ok(res[1].length > 0);
+  assert.ok(res[1].every((c) => typeof c === 'string'));
 });
 
 test('IN-only callables are unchanged: bare scalar returns', () => {


### PR DESCRIPTION
Adds container marshalling to the `@gjsify/node-gi` N-API engine for IN, return, and OUT directions, building on the OUT/INOUT support from #652. This is item #2 on the Axis-5 endgame roadmap (arrays/lists/hash).

## Supported (IN / return / OUT)
- **C arrays + GStrv** (`GI_TYPE_TAG_ARRAY`, array_type C): zero-terminated or length-coupled. Elements: `utf8`/`filename` → `string[]`, numeric fundamentals + boolean → `number[]`, `guint8`/`gint8` → Node `Buffer` / `Uint8Array`, GObject/interface → wrapped-handle array.
- **GByteArray** (read + build), **GArray** + **GPtrArray** (read).
- **GList / GSList**: utf8 / object / fundamental elements ↔ JS array.
- **GHashTable** with string keys, string-or-object values ↔ JS object.

## Deferred (clear "not yet supported" thrown BEFORE the invoke, per #652's pattern)
struct/union/enum/flags/nested elements, non-string hash keys, GArray/GPtrArray as IN, INOUT containers.

## The length arg (the hard part)
An array's separate introspectable length arg (`gi_type_info_get_array_length_index`) is marked `skip` — so it is **not** consumed from the JS argument list — and auto-filled: an IN array's length slot is written with the JS array's element count; a return/OUT array's OUT length slot is wired so the callee writes the length, which is read back to size the result. This **extends the existing `skip[]` mechanism** the callback closure/destroy slots already use, and the length arg is never surfaced in the GJS return tuple.

## Ownership / transfer (the leak/UAF surface)
- Returns / OUT (caller-owns): `EVERYTHING` frees container + elements after the read; `CONTAINER` frees only the container; `NOTHING` frees nothing.
- IN: `NOTHING` is freed after the invoke; `EVERYTHING`/`CONTAINER` are adopted by the callee (never freed here). The IN-container free runs **after** the results are marshalled, since a transfer-none return/OUT (e.g. `g_environ_getenv`) can point into a transfer-none IN array.

## Tests
107 → 116 `node --test` cases (clean rebuild, all green). The one #652 `get_filename_charsets` deferral test now asserts the implemented behaviour. New `test/arrays.test.mjs` covers GStrv return (`g_get_environ`), GStrv IN + string return (`g_environ_getenv`), GStrv IN transfer-full + GStrv return (`g_environ_setenv`), byte-array round-trip with IN-length autofill + OUT length (`g_base64_encode`/`decode`), C utf8 array return (`g_uri_list_extract_uris`), GHashTable return (`GLib.Uri.parse_params`), GList return (`g_content_types_get_registered`), and the INOUT-container deferral. Also GC-stressed 2000 iterations with forced `global.gc()` (no corruption/crash).

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH