### PR TITLE
feat(node-gi): marshal GVariant build + unpack

### DIFF
--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -202,6 +202,43 @@ The mainloop bridge (`startMainLoop`) is auto-attached the first time `requireGi
 loads a namespace, so `GLib.MainLoop.run()` / `Gio.Application.run()` block as
 they do under GJS while Node's timers, I/O and signal handlers keep running.
 
+#### `GLib.Variant` (build + unpack, GJS semantics)
+
+`new GLib.Variant(signature, value)` recursively builds a GVariant from a type
+signature, and the wrapper exposes the GJS unpack flavours — the contract
+GAction / GSettings / DBus payloads expect:
+
+```js
+const GLib = requireGi('GLib', '2.0');
+
+new GLib.Variant('s', 'hi').deepUnpack();      // 'hi'
+new GLib.Variant('as', ['a', 'b']).deepUnpack(); // ['a', 'b']
+new GLib.Variant('(si)', ['x', 1]).deepUnpack(); // ['x', 1]
+
+const v = new GLib.Variant('a{sv}', {
+  name: new GLib.Variant('s', 'Ada'),
+  age: new GLib.Variant('i', 36),
+});
+v.get_type_string();   // 'a{sv}'
+v.deepUnpack();        // { name: Variant, age: Variant }  (one level; values stay Variants)
+v.recursiveUnpack();   // { name: 'Ada', age: 36 }          (fully plain JS)
+v.unpack();            // single level; children stay Variants
+```
+
+Supported type strings: the basics `b y n q i u x t h d s o g`, `v` (variant),
+`m*` (maybe), `a*` arrays (incl. the `as` strv + `ay` bytestring fast-paths and
+`a{..}` dictionaries), `(...)` tuples and `{kv}` dict-entries. Built Variants
+round-trip as GObject arguments/properties/signal values — e.g. a
+`Gio.SimpleAction` state:
+
+```js
+const Gio = requireGi('Gio', '2.0');
+const action = Gio.SimpleAction.new_stateful('counter', null, new GLib.Variant('i', 0));
+action.get_state().deepUnpack();              // 0
+action.change_state(new GLib.Variant('i', 5));
+action.get_state().deepUnpack();              // 5
+```
+
 #### `GObject.registerClass` (GJS-shaped decorator)
 
 `requireGi('GObject')` carries the GJS runtime statics — `registerClass`,

--- a/packages/node-gi/node-gi/gi.d.ts
+++ b/packages/node-gi/node-gi/gi.d.ts
@@ -92,6 +92,48 @@ export interface GObjectNamespace extends GiNamespace {
 }
 
 /**
+ * A GJS-shaped GLib.Variant instance (reached via `new GLib.Variant(sig, value)`
+ * or returned/unpacked from the engine). Mirrors the GJS GLib.Variant override.
+ */
+export interface Variant {
+  /** Single-level unpack: container children stay {@link Variant}s. */
+  unpack(): unknown;
+  /**
+   * Deep unpack: container children are unpacked to JS, but a nested `v`
+   * (variant) value — e.g. an `a{sv}` value — STAYS a {@link Variant}.
+   */
+  deepUnpack(): unknown;
+  /** Backwards-compatible alias of {@link Variant.deepUnpack}. */
+  deep_unpack(): unknown;
+  /** Fully recursive unpack to plain JS (nested `v` variants are unwrapped). */
+  recursiveUnpack(): unknown;
+  /** The GVariant type string (e.g. `"a{sv}"`). */
+  get_type_string(): string;
+  toString(): string;
+  /** Other GVariant methods (n_children, get_child_value, print, …). */
+  [method: string]: unknown;
+}
+
+/**
+ * `GLib.Variant` as a class-like constructor surfaced on the GLib namespace.
+ * The deprecated `GLib.Variant.new(sig, value)` alias is reached via the static
+ * index signature.
+ */
+export interface VariantConstructor {
+  new (signature: string, value?: unknown): Variant;
+  [staticMethod: string]: unknown;
+}
+
+/**
+ * The extra statics the `GLib` namespace carries on top of its introspected
+ * members (reached via `requireGi('GLib')`) — the GJS-shaped `GLib.Variant`
+ * ergonomics replace the introspected struct-based Variant.
+ */
+export interface GLibNamespace extends GiNamespace {
+  Variant: VariantConstructor;
+}
+
+/**
  * Require a GObject-Introspection namespace and return a GJS-shaped namespace
  * object. The Node twin of `import Ns from 'gi://Ns?version=X'` /
  * `imports.gi.Ns`. Members are resolved lazily from introspection: namespace
@@ -100,7 +142,8 @@ export interface GObjectNamespace extends GiNamespace {
  *
  * The `GObject` namespace additionally carries the GJS runtime statics
  * (`registerClass`, `ParamSpec`, `ParamFlags`, `SignalFlags`) — see
- * {@link GObjectNamespace}.
+ * {@link GObjectNamespace}. The `GLib` namespace carries the GJS-shaped
+ * `GLib.Variant` ergonomics — see {@link GLibNamespace}.
  */
 export function requireGi(namespace: string, version?: string): GiNamespace;
 

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -59,8 +59,20 @@ function unwrapProps(props) {
 // (primitives, strings, null) passes through.
 function wrapReturn(value) {
   if (native.isGObjectHandle(value)) return wrapInstance(value);
+  // A GLib.Variant is ALSO a boxed handle (by tag), so it must be checked first
+  // to give it the Variant ergonomics rather than a plain method-routing proxy.
+  if (native.isVariantHandle(value)) return wrapVariant(value);
   if (native.isBoxedHandle(value)) return wrapBoxed(value);
   return value;
+}
+
+// Wrap a user's signal callback so each native signal argument is passed through
+// {@link wrapReturn} — a GObject arg becomes a chainable instance, a GVariant
+// arg (e.g. the value on Gio.SimpleAction::change-state) becomes a GLib.Variant
+// wrapper, primitives/plain objects pass through. (The emitter instance is not
+// passed in this milestone — see connectSignal.)
+function wrapSignalCallback(cb) {
+  return (...args) => cb(...args.map(wrapReturn));
 }
 
 // Wrap a boxed/struct handle so its methods are callable GJS-style
@@ -77,6 +89,122 @@ function wrapBoxed(handle) {
     },
     has(t, prop) {
       return prop === HANDLE || prop in t;
+    },
+  });
+}
+
+// ---- GLib.Variant ergonomics (the GJS GLib.Variant override, L1) ----
+//
+// Mirrors gjs/modules/core/overrides/GLib.js: `new GLib.Variant(sig, value)`
+// recursively packs (native variantNew), and the wrapper exposes `.unpack()`,
+// `.deepUnpack()`/`.deep_unpack`, `.recursiveUnpack()`, `.get_type_string()` and
+// the GJS toString, plus routing of any other GVariant method (n_children,
+// get_child_value, print, …) through the boxed-method engine. The deep-vs-
+// recursive distinction is honoured in the native unpacker (variantUnpack):
+//   unpack()           → variantUnpack(h, false, false): children stay Variants
+//   deepUnpack()       → variantUnpack(h, true,  false): one level; nested `v`
+//                        values (e.g. an a{sv} value) STAY Variants
+//   recursiveUnpack()  → variantUnpack(h, true,  true):  fully plain JS, no
+//                        Variants (discards `v` type info)
+
+// Re-wrap the result of variantUnpack: any GLib.Variant handle that the native
+// unpacker left in place (an `a{sv}` value under deepUnpack, every child under
+// unpack(), …) becomes a GLib.Variant wrapper; arrays/plain dicts are walked.
+function wrapVariantResult(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (native.isVariantHandle(value)) return wrapVariant(value);
+  if (value instanceof Uint8Array) return value; // `ay` bytes
+  if (Array.isArray(value)) return value.map(wrapVariantResult);
+  const out = {};
+  for (const key of Object.keys(value)) out[key] = wrapVariantResult(value[key]);
+  return out;
+}
+
+// Wrap a boxed GLib.Variant handle with the GJS-shaped Variant surface. Carries
+// [HANDLE] so it round-trips back into the engine as a GVariant IN argument
+// (action.activate(variant), new_stateful state, change_state value, …).
+function wrapVariant(handle) {
+  const target = { [HANDLE]: handle };
+  const api = {
+    unpack: () => wrapVariantResult(native.variantUnpack(handle, false, false)),
+    deepUnpack: () => wrapVariantResult(native.variantUnpack(handle, true, false)),
+    deep_unpack: () => wrapVariantResult(native.variantUnpack(handle, true, false)),
+    recursiveUnpack: () => native.variantUnpack(handle, true, true),
+    get_type_string: () => native.variantGetTypeString(handle),
+    toString: () => `[object variant of type "${native.variantGetTypeString(handle)}"]`,
+  };
+  return new Proxy(target, {
+    get(t, prop) {
+      if (prop === HANDLE) return handle;
+      if (typeof prop !== 'string') return t[prop];
+      if (Object.hasOwn(api, prop)) return api[prop];
+      if (RESERVED.has(prop)) return t[prop];
+      // Any other GVariant method (n_children, get_child_value, print, …).
+      return (...args) =>
+        wrapReturn(native.callBoxedMethod(handle, camelToSnake(prop), unwrapArgs(args)));
+    },
+    has(t, prop) {
+      return prop === HANDLE || (typeof prop === 'string' && Object.hasOwn(api, prop)) || prop in t;
+    },
+  });
+}
+
+// Deep-unwrap a pack value so any nested GLib.Variant wrapper (carried at a `v`
+// position, e.g. an a{sv} value) reaches the native packer as its raw handle —
+// the native `v` case reads a raw boxed handle, not an L1 Proxy. Primitives,
+// byte arrays, plain arrays and dict objects are walked; HANDLE-carrying
+// wrappers collapse to their handle.
+function unwrapVariantValue(value) {
+  if (value === null || typeof value !== 'object') return value;
+  if (value[HANDLE] !== undefined) return value[HANDLE];
+  if (value instanceof Uint8Array) return value; // `ay` bytes
+  if (Array.isArray(value)) return value.map(unwrapVariantValue);
+  const out = {};
+  for (const key of Object.keys(value)) out[key] = unwrapVariantValue(value[key]);
+  return out;
+}
+
+function packVariant(signature, value) {
+  return wrapVariant(native.variantNew(signature, unwrapVariantValue(value)));
+}
+
+// `GLib.Variant` as a class-like object: `new GLib.Variant(sig, value)` and the
+// deprecated `GLib.Variant.new(sig, value)` both pack via the native engine.
+function makeVariantClass() {
+  const ctor = function Variant(signature, value) {
+    return packVariant(signature, value);
+  };
+  Object.defineProperty(ctor, 'name', { value: 'Variant', configurable: true });
+  ctor.$gtypeName = 'GLib.Variant';
+  ctor.new = (signature, value) => packVariant(signature, value);
+  return new Proxy(ctor, {
+    get(t, prop) {
+      if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
+      // Other static constructors (e.g. new_from_bytes) route through the engine.
+      const giName = camelToSnake(prop);
+      return (...args) =>
+        wrapReturn(native.callStaticMethod('GLib', 'Variant', giName, unwrapArgs(args)));
+    },
+    construct(_t, args) {
+      return packVariant(args[0], args[1]);
+    },
+  });
+}
+
+const variantClass = makeVariantClass();
+
+// Overlay the GJS Variant ergonomics on the introspected GLib namespace, leaving
+// every other member resolving from introspection. (Additive, like the GObject
+// overlay; the introspected struct-based `GLib.Variant` is replaced by the
+// ergonomic wrapper class so `new GLib.Variant(...)` + `.deepUnpack()` work.)
+function decorateGLibNamespace(baseNs) {
+  return new Proxy(baseNs, {
+    get(t, prop) {
+      if (prop === 'Variant') return variantClass;
+      return t[prop];
+    },
+    has(t, prop) {
+      return prop === 'Variant' || prop in t;
     },
   });
 }
@@ -105,9 +233,9 @@ function wrapInstance(handle, userProto) {
       if (typeof prop !== 'string' || RESERVED.has(prop)) return t[prop];
       switch (prop) {
         case 'connect':
-          return (signal, cb) => native.connectSignal(handle, signal, cb, false);
+          return (signal, cb) => native.connectSignal(handle, signal, wrapSignalCallback(cb), false);
         case 'connect_after':
-          return (signal, cb) => native.connectSignal(handle, signal, cb, true);
+          return (signal, cb) => native.connectSignal(handle, signal, wrapSignalCallback(cb), true);
         case 'emit':
           return (signal, ...args) =>
             wrapReturn(native.emitSignal(handle, signal, unwrapArgs(args)));
@@ -578,6 +706,9 @@ export function requireGi(namespace, version) {
     // The GObject namespace also carries the GJS runtime statics (registerClass +
     // ParamSpec/ParamFlags/SignalFlags) layered over its introspected members.
     if (namespace === 'GObject') ns = decorateGObjectNamespace(ns);
+    // The GLib namespace carries the GJS-shaped GLib.Variant ergonomics
+    // (new GLib.Variant(sig, value) + deepUnpack/unpack/recursiveUnpack).
+    else if (namespace === 'GLib') ns = decorateGLibNamespace(ns);
     namespaceCache.set(key, ns);
   }
   return ns;

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -224,6 +224,39 @@ export function callBoxedMethod(handle: BoxedHandle, methodName: string, args?: 
 export function isBoxedHandle(value: unknown): boolean;
 
 /**
+ * Opaque handle to a GLib.Variant (a boxed handle tagged with the GVariant
+ * GType). Reference-counted via GVariant's (de)floating refcount and released on
+ * GC. Pass it to {@link variantUnpack} / {@link variantGetTypeString}.
+ */
+export type VariantHandle = BoxedHandle & { readonly __nodeGiVariant: unique symbol };
+
+/**
+ * Build a GVariant from a GVariant type signature + JS value, returning an owned
+ * GLib.Variant handle (the floating ref is sunk; released on GC). The recursive
+ * native packer behind `new GLib.Variant(signature, value)`. Supports the basics
+ * `b y n q i u x t h d s o g`, `v`, `m*` maybe, `a*` arrays (incl. `as`, `ay`,
+ * `a{..}` dicts), `(...)` tuples and `{kv}` dict-entries.
+ */
+export function variantNew(signature: string, value?: unknown): VariantHandle;
+
+/**
+ * Unpack a GLib.Variant handle to a JS value. `deep` unpacks container children
+ * (a nested `v` stays a Variant unless `recursive`); `recursive` additionally
+ * unwraps nested `v` variants to plain JS. Drives the L1 `.unpack()` (deep=false),
+ * `.deepUnpack()` (deep=true) and `.recursiveUnpack()` (deep=true, recursive=true).
+ */
+export function variantUnpack(handle: VariantHandle, deep?: boolean, recursive?: boolean): unknown;
+
+/** The GVariant type string of a GLib.Variant handle (e.g. `"a{sv}"`). */
+export function variantGetTypeString(handle: VariantHandle): string;
+
+/**
+ * Whether `value` is one of node-gi's GLib.Variant handles (a boxed handle tagged
+ * with the GVariant GType; tag-checked, no dereference).
+ */
+export function isVariantHandle(value: unknown): boolean;
+
+/**
  * Attach the libuv-backed GSource to the default GLib main context so a blocking
  * GLib main loop (`GLib.MainLoop.run()`, `Gio.Application.run()`) keeps Node's
  * timers, promises and I/O alive — the Node twin of GJS running the GLib loop as
@@ -269,6 +302,10 @@ declare const native: {
   isGObjectHandle: typeof isGObjectHandle;
   callBoxedMethod: typeof callBoxedMethod;
   isBoxedHandle: typeof isBoxedHandle;
+  variantNew: typeof variantNew;
+  variantUnpack: typeof variantUnpack;
+  variantGetTypeString: typeof variantGetTypeString;
+  isVariantHandle: typeof isVariantHandle;
   startMainLoop: typeof startMainLoop;
   connectSignal: typeof connectSignal;
   emitSignal: typeof emitSignal;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -218,6 +218,47 @@ export const callBoxedMethod = native.callBoxedMethod;
 export const isBoxedHandle = native.isBoxedHandle;
 
 /**
+ * Build a GVariant from a GVariant type signature + JS value, returning an owned
+ * boxed GLib.Variant handle (the floating ref is sunk; released on GC). The
+ * recursive native packer behind `new GLib.Variant(signature, value)`. Supports
+ * the basics `b y n q i u x t h d s o g`, `v`, `m*` maybe, `a*` arrays (incl.
+ * `as`, `ay`, `a{..}` dicts), `(...)` tuples and `{kv}` dict-entries.
+ * @param {string} signature a GVariant type string, e.g. "a{sv}", "(si)", "s"
+ * @param {unknown} [value]
+ * @returns {unknown} boxed GLib.Variant handle
+ */
+export const variantNew = native.variantNew;
+
+/**
+ * Unpack a GLib.Variant handle to a JS value. `deep` unpacks container children
+ * (one level for nested `v` variants, which stay Variants unless `recursive`);
+ * `recursive` additionally unwraps nested `v` variants to plain JS. Drives the
+ * L1 `.unpack()` (deep=false), `.deepUnpack()` (deep=true) and
+ * `.recursiveUnpack()` (deep=true, recursive=true).
+ * @param {unknown} handle a handle from {@link variantNew} (or a returned Variant)
+ * @param {boolean} [deep]
+ * @param {boolean} [recursive]
+ * @returns {unknown}
+ */
+export const variantUnpack = native.variantUnpack;
+
+/**
+ * The GVariant type string of a GLib.Variant handle (e.g. "a{sv}").
+ * @param {unknown} handle
+ * @returns {string}
+ */
+export const variantGetTypeString = native.variantGetTypeString;
+
+/**
+ * Whether `value` is one of node-gi's GLib.Variant handles (a boxed handle
+ * tagged with the GVariant GType; tag-checked, no dereference). The L1 wrapper
+ * uses it to give returned/unpacked variants the GLib.Variant ergonomics.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export const isVariantHandle = native.isVariantHandle;
+
+/**
  * Attach the libuv-backed GSource to the default GLib main context so a blocking
  * GLib main loop (`GLib.MainLoop.run()`, `Gio.Application.run()`) keeps Node's
  * timers, promises and I/O alive — the Node twin of GJS running the GLib loop as

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -283,14 +283,36 @@ static Napi::Value MakeBoxedHandle(Napi::Env env, gpointer ptr, GType gtype, boo
   BoxedHandle* bh = new BoxedHandle{ptr, gtype, owns};
   Napi::External<BoxedHandle> ext =
       Napi::External<BoxedHandle>::New(env, bh, [](Napi::Env, BoxedHandle* h) {
-        if (h->owns && h->ptr != nullptr && h->gtype != G_TYPE_INVALID &&
-            G_TYPE_IS_BOXED(h->gtype)) {
-          g_boxed_free(h->gtype, h->ptr);
+        if (h->owns && h->ptr != nullptr && h->gtype != G_TYPE_INVALID) {
+          // GVariant is a fundamental (NOT a boxed) GType, so it cannot go
+          // through g_boxed_free — it is reference-counted via g_variant_unref.
+          // (GLib.Variant flows through this handle so it reuses the boxed
+          // method-resolution + IN-arg-unwrap path; only the free differs.)
+          if (h->gtype == G_TYPE_VARIANT) {
+            g_variant_unref(static_cast<GVariant*>(h->ptr));
+          } else if (G_TYPE_IS_BOXED(h->gtype)) {
+            g_boxed_free(h->gtype, h->ptr);
+          }
         }
         delete h;
       });
   ext.TypeTag(&kBoxedHandleTag);
   return ext;
+}
+
+// Wrap a GVariant pointer as a node-gi boxed handle tagged with G_TYPE_VARIANT.
+// GVariant is a fundamental ref-counted (de)floating type, so ownership differs
+// from g_boxed types: TAKE the handed ref on transfer-full (sinking a floating
+// one), else add our own ref on a borrow. The finalizer (MakeBoxedHandle) drops
+// exactly the one ref we end up owning via g_variant_unref. The L1 layer turns
+// this handle into a GLib.Variant wrapper (deepUnpack/unpack/recursiveUnpack/…).
+static Napi::Value WrapVariant(Napi::Env env, GVariant* var, GITransfer transfer) {
+  if (var == nullptr) return env.Null();
+  if (transfer == GI_TRANSFER_EVERYTHING)
+    g_variant_take_ref(var);
+  else
+    g_variant_ref_sink(var);
+  return MakeBoxedHandle(env, var, G_TYPE_VARIANT, true);
 }
 
 // Wrap a returned struct/boxed pointer. `structInfo` is the GIStructInfo (or
@@ -303,6 +325,7 @@ static Napi::Value WrapBoxed(Napi::Env env, gpointer ptr, GIBaseInfo* structInfo
   if (structInfo != nullptr && (GI_IS_STRUCT_INFO(structInfo) || GI_IS_UNION_INFO(structInfo))) {
     gt = gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(structInfo));
   }
+  if (gt == G_TYPE_VARIANT) return WrapVariant(env, static_cast<GVariant*>(ptr), transfer);
   bool boxed = gt != G_TYPE_INVALID && gt != G_TYPE_NONE && G_TYPE_IS_BOXED(gt);
   bool owns = boxed && transfer == GI_TRANSFER_EVERYTHING;
   return MakeBoxedHandle(env, ptr, boxed ? gt : G_TYPE_INVALID, owns);
@@ -1678,6 +1701,14 @@ static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
       const char* s = g_value_get_string(v);
       return s != nullptr ? Napi::Value(Napi::String::New(env, s)) : env.Null();
     }
+    case G_TYPE_VARIANT: {
+      // A GVariant-typed property (e.g. Gio.SimpleAction:state) or signal
+      // parameter (Gio.SimpleAction::change-state). g_value_get_variant borrows
+      // (transfer none) → wrap as a node-gi GLib.Variant handle (own a ref).
+      GVariant* var = g_value_get_variant(v);
+      if (var == nullptr) return env.Null();
+      return WrapVariant(env, var, GI_TRANSFER_NOTHING);
+    }
     case G_TYPE_OBJECT:
       // Signal/property object values are transfer-none borrows; WrapGObject refs.
       return WrapGObject(env, static_cast<GObject*>(g_value_get_object(v)), GI_TRANSFER_NOTHING);
@@ -1724,6 +1755,23 @@ static bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
         g_value_set_string(v, s.c_str());  // g_value_set_string copies
       }
       return true;
+    case G_TYPE_VARIANT: {
+      // A GLib.Variant handle (or null) into a GVariant-typed GValue.
+      // g_value_set_variant refs (and sinks a floating ref); our handle keeps
+      // its own ref, so no double-free.
+      if (js.IsNull() || js.IsUndefined()) {
+        g_value_set_variant(v, nullptr);
+        return true;
+      }
+      gpointer p = nullptr;
+      if (!TryGetBoxedPtr(js, &p) || p == nullptr) {
+        Napi::TypeError::New(env, "expected a GLib.Variant for a GVariant value")
+            .ThrowAsJavaScriptException();
+        return false;
+      }
+      g_value_set_variant(v, static_cast<GVariant*>(p));
+      return true;
+    }
     default:
       Napi::TypeError::New(env, std::string("Unsupported property GType ") +
                                     g_type_name(G_VALUE_TYPE(v)))
@@ -2658,6 +2706,542 @@ Napi::Value IsBoxedHandle(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is);
 }
 
+// ====================================================================
+// ---- GVariant build / unpack (the GLib.Variant ergonomics) ---------
+// ====================================================================
+//
+// The native half of GJS's `GLib.Variant` override (gjs/modules/core/overrides/
+// GLib.js): a recursive packer `new GLib.Variant(signature, value)` and an
+// unpacker driving `.unpack()` / `.deepUnpack()` / `.recursiveUnpack()`. The L1
+// layer (gi.js) wires the GJS-shaped surface on top of these primitives.
+//
+// SCOPE — the common signatures real GAction/GSettings/DBus code hits: the
+// basics `b y n q i u x t h d s o g`, `v` (variant), `m*` (maybe), `a*` arrays
+// (with the `as` strv + `ay` bytestring fast-paths and `a{..}` dictionaries via
+// dict-entries), `(...)` tuples, and `{kv}` dict-entries. Genuinely exotic
+// element types fall out of the type grammar with a clear "Invalid GVariant
+// signature" error.
+//
+// OWNERSHIP (the leak/UAF surface — scrutinise here): every `g_variant_new_*`
+// and `g_variant_builder_end` returns a FLOATING ref. A child handed to
+// g_variant_builder_add_value / g_variant_new_maybe / g_variant_new_dict_entry
+// is CONSUMED (its floating ref is taken), so the success path never leaks. The
+// single top-level result is g_variant_ref_sink'd exactly once and owned by the
+// boxed handle (g_variant_unref on GC). On the UNPACK side g_variant_get_child_
+// value / get_variant / get_maybe each return a NEW ref (transfer full): a child
+// that "stays a Variant" hands that ref straight to the boxed handle (no extra
+// ref), and a child we recurse into is unref'd after the read.
+
+static bool VariantIsSimpleType(char c) {
+  switch (c) {
+    case 'b': case 'y': case 'n': case 'q': case 'i': case 'u':
+    case 'x': case 't': case 'h': case 'd': case 's': case 'o': case 'g':
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Consume one complete type from `sig` starting at *pos, advancing *pos past it,
+// and return that type's string (mirrors GJS `_readSingleType`). `forceSimple`
+// rejects a non-basic type (dict keys must be basic). Throws + sets *ok=false on
+// a malformed signature.
+static std::string VariantReadSingleType(Napi::Env env, const std::string& sig, size_t* pos,
+                                         bool forceSimple, bool* ok) {
+  if (*pos >= sig.size()) {
+    Napi::TypeError::New(env, "Invalid GVariant signature (reached end while expecting a type)")
+        .ThrowAsJavaScriptException();
+    *ok = false;
+    return "";
+  }
+  char c = sig[(*pos)++];
+  bool simple = VariantIsSimpleType(c);
+  if (!simple && forceSimple) {
+    Napi::TypeError::New(env, "Invalid GVariant signature (a simple type was expected)")
+        .ThrowAsJavaScriptException();
+    *ok = false;
+    return "";
+  }
+  if (c == 'm' || c == 'a') {
+    std::string inner = VariantReadSingleType(env, sig, pos, false, ok);
+    if (!*ok) return "";
+    return std::string(1, c) + inner;
+  }
+  if (c == '{') {
+    std::string key = VariantReadSingleType(env, sig, pos, true, ok);
+    if (!*ok) return "";
+    std::string val = VariantReadSingleType(env, sig, pos, false, ok);
+    if (!*ok) return "";
+    if (*pos >= sig.size() || sig[*pos] != '}') {
+      Napi::TypeError::New(env, "Invalid GVariant signature for type DICT_ENTRY (expected \"}\")")
+          .ThrowAsJavaScriptException();
+      *ok = false;
+      return "";
+    }
+    (*pos)++;
+    return std::string("{") + key + val + "}";
+  }
+  if (c == '(') {
+    std::string res = "(";
+    while (true) {
+      if (*pos >= sig.size()) {
+        Napi::TypeError::New(env, "Invalid GVariant signature for type TUPLE (expected \")\")")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return "";
+      }
+      if (sig[*pos] == ')') {
+        (*pos)++;
+        res += ")";
+        return res;
+      }
+      std::string el = VariantReadSingleType(env, sig, pos, false, ok);
+      if (!*ok) return "";
+      res += el;
+    }
+  }
+  if (!simple && c != 'v') {
+    Napi::TypeError::New(env, std::string("Invalid GVariant signature (") + c + " is not a valid type)")
+        .ThrowAsJavaScriptException();
+    *ok = false;
+    return "";
+  }
+  return std::string(1, c);
+}
+
+// Read a JS value into a byte vector for an `ay` array (Uint8Array/Buffer/
+// number[]; a string is UTF-8 encoded with a trailing NUL, matching GJS).
+static bool VariantExtractBytes(Napi::Env env, Napi::Value v, std::vector<guint8>* out) {
+  if (v.IsBuffer()) {
+    Napi::Buffer<uint8_t> b = v.As<Napi::Buffer<uint8_t>>();
+    out->assign(b.Data(), b.Data() + b.Length());
+    return true;
+  }
+  if (v.IsTypedArray()) {
+    Napi::TypedArray ta = v.As<Napi::TypedArray>();
+    const uint8_t* base = static_cast<uint8_t*>(ta.ArrayBuffer().Data()) + ta.ByteOffset();
+    out->assign(base, base + ta.ByteLength());
+    return true;
+  }
+  if (v.IsArray()) {
+    Napi::Array a = v.As<Napi::Array>();
+    uint32_t n = a.Length();
+    out->resize(n);
+    for (uint32_t i = 0; i < n; i++)
+      (*out)[i] = static_cast<guint8>(a.Get(i).ToNumber().Uint32Value());
+    return true;
+  }
+  if (v.IsString()) {
+    std::string s = v.As<Napi::String>().Utf8Value();
+    out->assign(s.begin(), s.end());
+    out->push_back(0);
+    return true;
+  }
+  Napi::TypeError::New(env, "GVariant 'ay' expects a Uint8Array, Buffer, number[] or string")
+      .ThrowAsJavaScriptException();
+  return false;
+}
+
+// Recursively build a (floating) GVariant from `sig` (starting at *pos) + `value`
+// — the C twin of GJS `_packVariant`. Returns a FLOATING ref (or nullptr with a
+// pending exception + *ok=false). The caller consumes the float.
+static GVariant* VariantPack(Napi::Env env, const std::string& sig, size_t* pos,
+                             Napi::Value value, bool* ok) {
+  if (*pos >= sig.size()) {
+    Napi::TypeError::New(env, "GVariant signature cannot be empty").ThrowAsJavaScriptException();
+    *ok = false;
+    return nullptr;
+  }
+  char c = sig[(*pos)++];
+  switch (c) {
+    case 'b': return g_variant_new_boolean(value.ToBoolean().Value());
+    case 'y': return g_variant_new_byte(static_cast<guint8>(value.ToNumber().Uint32Value()));
+    case 'n': return g_variant_new_int16(static_cast<gint16>(value.ToNumber().Int32Value()));
+    case 'q': return g_variant_new_uint16(static_cast<guint16>(value.ToNumber().Uint32Value()));
+    case 'i': return g_variant_new_int32(value.ToNumber().Int32Value());
+    case 'u': return g_variant_new_uint32(value.ToNumber().Uint32Value());
+    case 'x': return g_variant_new_int64(value.ToNumber().Int64Value());
+    case 't': return g_variant_new_uint64(static_cast<guint64>(value.ToNumber().Int64Value()));
+    case 'h': return g_variant_new_handle(value.ToNumber().Int32Value());
+    case 'd': return g_variant_new_double(value.ToNumber().DoubleValue());
+    case 's': {
+      std::string s = value.ToString().Utf8Value();
+      return g_variant_new_string(s.c_str());
+    }
+    case 'o': {
+      std::string s = value.ToString().Utf8Value();
+      if (!g_variant_is_object_path(s.c_str())) {
+        Napi::TypeError::New(env, std::string("Invalid GVariant object path: ") + s)
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      return g_variant_new_object_path(s.c_str());
+    }
+    case 'g': {
+      std::string s = value.ToString().Utf8Value();
+      if (!g_variant_is_signature(s.c_str())) {
+        Napi::TypeError::New(env, std::string("Invalid GVariant signature string: ") + s)
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      return g_variant_new_signature(s.c_str());
+    }
+    case 'v': {
+      gpointer p = nullptr;
+      if (!TryGetBoxedPtr(value, &p) || p == nullptr) {
+        Napi::TypeError::New(env, "GVariant 'v' expects a GLib.Variant value")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      return g_variant_new_variant(static_cast<GVariant*>(p));
+    }
+    case 'm': {
+      if (!value.IsNull() && !value.IsUndefined()) {
+        GVariant* child = VariantPack(env, sig, pos, value, ok);
+        if (!*ok) return nullptr;
+        return g_variant_new_maybe(nullptr, child);  // consumes the floating child
+      }
+      std::string elem = VariantReadSingleType(env, sig, pos, false, ok);
+      if (!*ok) return nullptr;
+      GVariantType* t = g_variant_type_new(elem.c_str());
+      GVariant* r = g_variant_new_maybe(t, nullptr);
+      g_variant_type_free(t);
+      return r;
+    }
+    case 'a': {
+      std::string elemType = VariantReadSingleType(env, sig, pos, false, ok);
+      if (!*ok) return nullptr;
+      char e0 = elemType.empty() ? '\0' : elemType[0];
+      if (e0 == 's') {  // array of strings → g_variant_new_strv
+        if (!value.IsArray()) {
+          Napi::TypeError::New(env, "GVariant 'as' expects an array of strings")
+              .ThrowAsJavaScriptException();
+          *ok = false;
+          return nullptr;
+        }
+        Napi::Array a = value.As<Napi::Array>();
+        uint32_t n = a.Length();
+        std::vector<std::string> store(n);
+        std::vector<const gchar*> ptrs(n + 1, nullptr);
+        for (uint32_t i = 0; i < n; i++) {
+          store[i] = a.Get(i).ToString().Utf8Value();
+          ptrs[i] = store[i].c_str();
+        }
+        return g_variant_new_strv(ptrs.data(), static_cast<gssize>(n));  // copies
+      }
+      if (e0 == 'y') {  // byte array
+        std::vector<guint8> bytes;
+        if (!VariantExtractBytes(env, value, &bytes)) {
+          *ok = false;
+          return nullptr;
+        }
+        return g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, bytes.data(), bytes.size(),
+                                         sizeof(guint8));  // copies
+      }
+      std::string fullType = "a" + elemType;
+      GVariantType* at = g_variant_type_new(fullType.c_str());
+      GVariantBuilder builder;
+      g_variant_builder_init(&builder, at);
+      if (e0 == '{') {  // dictionary: a plain object keyed by the entry's key type
+        if (!value.IsObject()) {
+          g_variant_builder_clear(&builder);
+          g_variant_type_free(at);
+          Napi::TypeError::New(env, "GVariant dictionary expects a plain object")
+              .ThrowAsJavaScriptException();
+          *ok = false;
+          return nullptr;
+        }
+        Napi::Object obj = value.As<Napi::Object>();
+        Napi::Array keys = obj.GetPropertyNames();
+        uint32_t n = keys.Length();
+        for (uint32_t i = 0; i < n; i++) {
+          Napi::Value k = keys.Get(i);
+          Napi::Array pair = Napi::Array::New(env, 2);
+          pair.Set(static_cast<uint32_t>(0), k);
+          pair.Set(static_cast<uint32_t>(1), obj.Get(k));
+          size_t p2 = 0;
+          GVariant* child = VariantPack(env, elemType, &p2, pair, ok);  // packs the {kv} entry
+          if (!*ok) {
+            g_variant_builder_clear(&builder);
+            g_variant_type_free(at);
+            return nullptr;
+          }
+          g_variant_builder_add_value(&builder, child);  // consumes the floating entry
+        }
+      } else {  // generic array: re-parse elemType per element
+        if (!value.IsArray()) {
+          g_variant_builder_clear(&builder);
+          g_variant_type_free(at);
+          Napi::TypeError::New(env, "GVariant array expects an array value")
+              .ThrowAsJavaScriptException();
+          *ok = false;
+          return nullptr;
+        }
+        Napi::Array a = value.As<Napi::Array>();
+        uint32_t n = a.Length();
+        for (uint32_t i = 0; i < n; i++) {
+          size_t p2 = 0;
+          GVariant* child = VariantPack(env, elemType, &p2, a.Get(i), ok);
+          if (!*ok) {
+            g_variant_builder_clear(&builder);
+            g_variant_type_free(at);
+            return nullptr;
+          }
+          g_variant_builder_add_value(&builder, child);
+        }
+      }
+      GVariant* r = g_variant_builder_end(&builder);
+      g_variant_type_free(at);
+      return r;
+    }
+    case '(': {  // tuple: drive children off the signature until ')'
+      if (!value.IsArray()) {
+        Napi::TypeError::New(env, "GVariant tuple expects an array value")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      Napi::Array a = value.As<Napi::Array>();
+      GVariantBuilder builder;
+      g_variant_builder_init(&builder, G_VARIANT_TYPE_TUPLE);
+      uint32_t i = 0;
+      while (true) {
+        if (*pos < sig.size() && sig[*pos] == ')') {
+          (*pos)++;
+          break;
+        }
+        if (*pos >= sig.size()) {
+          g_variant_builder_clear(&builder);
+          Napi::TypeError::New(env, "Invalid GVariant signature for type TUPLE (expected \")\")")
+              .ThrowAsJavaScriptException();
+          *ok = false;
+          return nullptr;
+        }
+        GVariant* child = VariantPack(env, sig, pos, a.Get(i), ok);
+        if (!*ok) {
+          g_variant_builder_clear(&builder);
+          return nullptr;
+        }
+        g_variant_builder_add_value(&builder, child);
+        i++;
+      }
+      return g_variant_builder_end(&builder);
+    }
+    case '{': {  // dict-entry: value is [key, val]
+      if (!value.IsArray()) {
+        Napi::TypeError::New(env, "GVariant dict-entry expects a [key, value] array")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      Napi::Array a = value.As<Napi::Array>();
+      GVariant* key = VariantPack(env, sig, pos, a.Get(static_cast<uint32_t>(0)), ok);
+      if (!*ok) return nullptr;
+      GVariant* val = VariantPack(env, sig, pos, a.Get(static_cast<uint32_t>(1)), ok);
+      if (!*ok) {
+        g_variant_unref(g_variant_take_ref(key));
+        return nullptr;
+      }
+      if (*pos >= sig.size() || sig[*pos] != '}') {
+        g_variant_unref(g_variant_take_ref(key));
+        g_variant_unref(g_variant_take_ref(val));
+        Napi::TypeError::New(env, "Invalid GVariant signature for type DICT_ENTRY (expected \"}\")")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      (*pos)++;
+      return g_variant_new_dict_entry(key, val);  // consumes both floating children
+    }
+    default:
+      Napi::TypeError::New(
+          env, std::string("Invalid GVariant signature (unexpected character ") + c + ")")
+          .ThrowAsJavaScriptException();
+      *ok = false;
+      return nullptr;
+  }
+}
+
+static Napi::Value VariantToJs(Napi::Env env, GVariant* v, bool deep, bool recursive);
+
+// Shared array/tuple/dict-entry reader: each child either fully unpacks (deep) or
+// stays a Variant handle (shallow). The shallow handle adopts the new ref from
+// g_variant_get_child_value; the deep path unrefs after the recursive read.
+static Napi::Array VariantContainerToArray(Napi::Env env, GVariant* v, bool deep, bool recursive) {
+  gsize n = g_variant_n_children(v);
+  Napi::Array out = Napi::Array::New(env, n);
+  for (gsize i = 0; i < n; i++) {
+    GVariant* child = g_variant_get_child_value(v, i);  // transfer full
+    if (deep) {
+      Napi::Value cj = VariantToJs(env, child, deep, recursive);
+      g_variant_unref(child);
+      out.Set(static_cast<uint32_t>(i), cj);
+    } else {
+      out.Set(static_cast<uint32_t>(i), MakeBoxedHandle(env, child, G_TYPE_VARIANT, true));
+    }
+  }
+  return out;
+}
+
+// The C twin of GJS `_unpackVariant(variant, deep, recursive)`. `deep` controls
+// whether container children are unpacked at all; `recursive` ONLY affects `v`
+// (variant) values — deep keeps a nested `v` as a Variant, recursive unwraps it.
+// This is the exact distinction behind unpack() / deepUnpack() / recursiveUnpack.
+static Napi::Value VariantToJs(Napi::Env env, GVariant* v, bool deep, bool recursive) {
+  switch (g_variant_classify(v)) {
+    case G_VARIANT_CLASS_BOOLEAN: return Napi::Boolean::New(env, g_variant_get_boolean(v));
+    case G_VARIANT_CLASS_BYTE: return Napi::Number::New(env, g_variant_get_byte(v));
+    case G_VARIANT_CLASS_INT16: return Napi::Number::New(env, g_variant_get_int16(v));
+    case G_VARIANT_CLASS_UINT16: return Napi::Number::New(env, g_variant_get_uint16(v));
+    case G_VARIANT_CLASS_INT32: return Napi::Number::New(env, g_variant_get_int32(v));
+    case G_VARIANT_CLASS_UINT32: return Napi::Number::New(env, g_variant_get_uint32(v));
+    case G_VARIANT_CLASS_INT64:
+      return Napi::Number::New(env, static_cast<double>(g_variant_get_int64(v)));
+    case G_VARIANT_CLASS_UINT64:
+      return Napi::Number::New(env, static_cast<double>(g_variant_get_uint64(v)));
+    case G_VARIANT_CLASS_HANDLE: return Napi::Number::New(env, g_variant_get_handle(v));
+    case G_VARIANT_CLASS_DOUBLE: return Napi::Number::New(env, g_variant_get_double(v));
+    case G_VARIANT_CLASS_STRING:
+    case G_VARIANT_CLASS_OBJECT_PATH:
+    case G_VARIANT_CLASS_SIGNATURE:
+      return Napi::String::New(env, g_variant_get_string(v, nullptr));
+    case G_VARIANT_CLASS_VARIANT: {
+      GVariant* inner = g_variant_get_variant(v);  // transfer full
+      if (deep && recursive) {
+        Napi::Value r = VariantToJs(env, inner, deep, recursive);
+        g_variant_unref(inner);
+        return r;
+      }
+      return MakeBoxedHandle(env, inner, G_TYPE_VARIANT, true);  // stays a Variant
+    }
+    case G_VARIANT_CLASS_MAYBE: {
+      GVariant* inner = g_variant_get_maybe(v);  // transfer full, or NULL
+      if (inner == nullptr) return env.Null();
+      if (deep) {
+        Napi::Value r = VariantToJs(env, inner, deep, recursive);
+        g_variant_unref(inner);
+        return r;
+      }
+      return MakeBoxedHandle(env, inner, G_TYPE_VARIANT, true);
+    }
+    case G_VARIANT_CLASS_ARRAY: {
+      if (g_variant_is_of_type(v, G_VARIANT_TYPE_DICTIONARY)) {  // a{?*}
+        Napi::Object out = Napi::Object::New(env);
+        gsize n = g_variant_n_children(v);
+        for (gsize i = 0; i < n; i++) {
+          GVariant* entry = g_variant_get_child_value(v, i);
+          GVariant* keyv = g_variant_get_child_value(entry, 0);
+          GVariant* valv = g_variant_get_child_value(entry, 1);
+          // The key is always fully unpacked (it must be usable as an object
+          // key); the value follows the deep/recursive rule.
+          Napi::Value keyJs = VariantToJs(env, keyv, true, recursive);
+          Napi::Value valJs = deep
+              ? VariantToJs(env, valv, deep, recursive)
+              : MakeBoxedHandle(env, g_variant_ref(valv), G_TYPE_VARIANT, true);
+          out.Set(keyJs, valJs);
+          g_variant_unref(keyv);
+          g_variant_unref(valv);
+          g_variant_unref(entry);
+        }
+        return out;
+      }
+      if (g_variant_is_of_type(v, G_VARIANT_TYPE_BYTESTRING)) {  // ay
+        gsize n = 0;
+        const void* data = g_variant_get_fixed_array(v, &n, sizeof(guint8));
+        Napi::Uint8Array arr = Napi::Uint8Array::New(env, n);
+        if (n > 0 && data != nullptr) memcpy(arr.Data(), data, n);
+        return arr;
+      }
+      return VariantContainerToArray(env, v, deep, recursive);
+    }
+    case G_VARIANT_CLASS_TUPLE:
+    case G_VARIANT_CLASS_DICT_ENTRY:
+      return VariantContainerToArray(env, v, deep, recursive);
+    default:
+      Napi::Error::New(env, "Unsupported GVariant type in unpack").ThrowAsJavaScriptException();
+      return env.Undefined();
+  }
+}
+
+// Read a GVariant pointer from a node-gi GLib.Variant handle (a boxed handle
+// tagged with G_TYPE_VARIANT). Throws + returns nullptr otherwise.
+static GVariant* UnwrapVariant(Napi::Env env, Napi::Value handle) {
+  if (!handle.IsExternal() ||
+      !handle.As<Napi::External<BoxedHandle>>().CheckTypeTag(&kBoxedHandleTag)) {
+    Napi::TypeError::New(env, "expected a node-gi GLib.Variant handle").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  BoxedHandle* h = handle.As<Napi::External<BoxedHandle>>().Data();
+  if (h == nullptr || h->ptr == nullptr || h->gtype != G_TYPE_VARIANT) {
+    Napi::TypeError::New(env, "expected a node-gi GLib.Variant handle").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<GVariant*>(h->ptr);
+}
+
+// variantNew(signature, value?) -> boxed GLib.Variant handle
+Napi::Value VariantNew(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "variantNew(signature: string, value?: unknown)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string sig = info[0].As<Napi::String>().Utf8Value();
+  if (sig.empty()) {
+    Napi::TypeError::New(env, "GVariant signature cannot be empty").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  Napi::Value value = info.Length() >= 2 ? info[1] : env.Undefined();
+  size_t pos = 0;
+  bool ok = true;
+  GVariant* v = VariantPack(env, sig, &pos, value, &ok);
+  if (!ok) return env.Null();  // exception already pending
+  if (pos != sig.size()) {
+    if (v != nullptr) g_variant_unref(g_variant_take_ref(v));
+    Napi::TypeError::New(env, "Invalid GVariant signature (more than one single complete type)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  g_variant_ref_sink(v);  // sink the floating ref → own exactly one
+  return MakeBoxedHandle(env, v, G_TYPE_VARIANT, true);
+}
+
+// variantUnpack(handle, deep?, recursive?) -> unknown
+Napi::Value VariantUnpack(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GVariant* v = UnwrapVariant(env, info.Length() >= 1 ? info[0] : env.Undefined());
+  if (v == nullptr) return env.Null();
+  bool deep = info.Length() >= 2 && info[1].ToBoolean().Value();
+  bool recursive = info.Length() >= 3 && info[2].ToBoolean().Value();
+  return VariantToJs(env, v, deep, recursive);
+}
+
+// variantGetTypeString(handle) -> string
+Napi::Value VariantGetTypeString(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GVariant* v = UnwrapVariant(env, info.Length() >= 1 ? info[0] : env.Undefined());
+  if (v == nullptr) return env.Null();
+  return Napi::String::New(env, g_variant_get_type_string(v));
+}
+
+// isVariantHandle(value) -> boolean (a boxed handle tagged with G_TYPE_VARIANT)
+Napi::Value IsVariantHandle(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  bool is = false;
+  if (info.Length() >= 1 && info[0].IsExternal()) {
+    Napi::External<BoxedHandle> ext = info[0].As<Napi::External<BoxedHandle>>();
+    if (ext.CheckTypeTag(&kBoxedHandleTag)) {
+      BoxedHandle* h = ext.Data();
+      is = h != nullptr && h->gtype == G_TYPE_VARIANT;
+    }
+  }
+  return Napi::Boolean::New(env, is);
+}
+
 // ---- signals (milestone 1) ----
 //
 // A GClosure that wraps a JS callback. The callback is held by a strong
@@ -2983,6 +3567,10 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("isGObjectHandle", Napi::Function::New(env, IsGObjectHandle));
   exports.Set("callBoxedMethod", Napi::Function::New(env, CallBoxedMethod));
   exports.Set("isBoxedHandle", Napi::Function::New(env, IsBoxedHandle));
+  exports.Set("variantNew", Napi::Function::New(env, VariantNew));
+  exports.Set("variantUnpack", Napi::Function::New(env, VariantUnpack));
+  exports.Set("variantGetTypeString", Napi::Function::New(env, VariantGetTypeString));
+  exports.Set("isVariantHandle", Napi::Function::New(env, IsVariantHandle));
   exports.Set("startMainLoop", Napi::Function::New(env, StartMainLoop));
   exports.Set("connectSignal", Napi::Function::New(env, ConnectSignal));
   exports.Set("emitSignal", Napi::Function::New(env, EmitSignal));

--- a/packages/node-gi/node-gi/test/variant.test.mjs
+++ b/packages/node-gi/node-gi/test/variant.test.mjs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+// GVariant build + unpack for @gjsify/node-gi — the GJS GLib.Variant ergonomics.
+//
+// Reference: gjs/modules/core/overrides/GLib.js (_packVariant / _unpackVariant /
+// unpack / deepUnpack / recursiveUnpack). Exercises both the native primitives
+// (variantNew / variantUnpack / variantGetTypeString) and the L1 GLib.Variant
+// surface (new GLib.Variant(sig, value) + .deepUnpack()/.unpack()/.recursive-
+// Unpack()/.get_type_string()), plus an end-to-end Gio.SimpleAction round-trip
+// (a built Variant carried through new_stateful / change_state / get_state and
+// observed on the change-state signal). Headless — no main loop needed.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { variantNew, variantUnpack, variantGetTypeString, isVariantHandle } from '../index.js';
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+
+// ---- native primitives ----------------------------------------------------
+
+test('native: basic round-trips (b/y/n/q/i/u/x/t/d/s/o/g)', () => {
+  assert.equal(variantUnpack(variantNew('b', true)), true);
+  assert.equal(variantUnpack(variantNew('b', false)), false);
+  assert.equal(variantUnpack(variantNew('y', 200)), 200);
+  assert.equal(variantUnpack(variantNew('n', -1234)), -1234);
+  assert.equal(variantUnpack(variantNew('q', 4321)), 4321);
+  assert.equal(variantUnpack(variantNew('i', -42)), -42);
+  assert.equal(variantUnpack(variantNew('u', 42)), 42);
+  assert.equal(variantUnpack(variantNew('x', 9000)), 9000);
+  assert.equal(variantUnpack(variantNew('t', 9000)), 9000);
+  assert.equal(variantUnpack(variantNew('d', 3.5)), 3.5);
+  assert.equal(variantUnpack(variantNew('s', 'hello')), 'hello');
+  assert.equal(variantUnpack(variantNew('o', '/org/example/Foo')), '/org/example/Foo');
+  assert.equal(variantUnpack(variantNew('g', 'a{sv}')), 'a{sv}');
+});
+
+test('native: get_type_string reflects the built type', () => {
+  assert.equal(variantGetTypeString(variantNew('s', 'x')), 's');
+  assert.equal(variantGetTypeString(variantNew('a{sv}', {})), 'a{sv}');
+  assert.equal(variantGetTypeString(variantNew('(si)', ['a', 1])), '(si)');
+});
+
+test('native: isVariantHandle distinguishes variants', () => {
+  assert.equal(isVariantHandle(variantNew('s', 'x')), true);
+  assert.equal(isVariantHandle('x'), false);
+  assert.equal(isVariantHandle({}), false);
+  assert.equal(isVariantHandle(null), false);
+});
+
+test('native: invalid signatures throw clear errors', () => {
+  assert.throws(() => variantNew('', 'x'), /signature cannot be empty/);
+  assert.throws(() => variantNew('ss', ['a', 'b']), /more than one single complete type/);
+  assert.throws(() => variantNew('Z', 1), /Invalid GVariant signature/);
+});
+
+// ---- L1 GLib.Variant: new GLib.Variant(sig, value) + unpack flavours -------
+
+test('L1: new GLib.Variant("s", "x").deepUnpack() === "x"', () => {
+  assert.equal(new GLib.Variant('s', 'x').deepUnpack(), 'x');
+});
+
+test('L1: boolean / int32 / double round-trip', () => {
+  assert.equal(new GLib.Variant('b', true).deepUnpack(), true);
+  assert.equal(new GLib.Variant('i', -7).deepUnpack(), -7);
+  assert.equal(new GLib.Variant('d', 2.25).deepUnpack(), 2.25);
+});
+
+test('L1: "as" → string[] (deepUnpack)', () => {
+  const v = new GLib.Variant('as', ['a', 'b', 'c']);
+  assert.deepEqual(v.deepUnpack(), ['a', 'b', 'c']);
+  assert.equal(v.get_type_string(), 'as');
+});
+
+test('L1: "ai" → number[] (deepUnpack)', () => {
+  assert.deepEqual(new GLib.Variant('ai', [1, 2, 3]).deepUnpack(), [1, 2, 3]);
+});
+
+test('L1: "ay" → bytes (Uint8Array)', () => {
+  const v = new GLib.Variant('ay', [1, 2, 250, 255]);
+  const bytes = v.deepUnpack();
+  assert.ok(bytes instanceof Uint8Array);
+  assert.deepEqual(Array.from(bytes), [1, 2, 250, 255]);
+});
+
+test('L1: "(si)" tuple → array', () => {
+  const v = new GLib.Variant('(si)', ['answer', 42]);
+  assert.deepEqual(v.deepUnpack(), ['answer', 42]);
+  assert.equal(v.get_type_string(), '(si)');
+});
+
+test('L1: "(sib)" mixed tuple → array', () => {
+  assert.deepEqual(new GLib.Variant('(sib)', ['x', -1, true]).deepUnpack(), ['x', -1, true]);
+});
+
+test('L1: "a{ss}" dict → plain object (deepUnpack)', () => {
+  const v = new GLib.Variant('a{ss}', { one: '1', two: '2' });
+  assert.deepEqual(v.deepUnpack(), { one: '1', two: '2' });
+});
+
+// The headline deep-vs-recursive distinction for a{sv}.
+test('L1: "a{sv}" deepUnpack yields { key: Variant }; recursiveUnpack yields plain', () => {
+  const v = new GLib.Variant('a{sv}', {
+    name: new GLib.Variant('s', 'Ada'),
+    age: new GLib.Variant('i', 36),
+  });
+  assert.equal(v.get_type_string(), 'a{sv}');
+
+  // deepUnpack: one level — keys are JS, but the `v` values STAY Variants.
+  const deep = v.deepUnpack();
+  assert.deepEqual(Object.keys(deep).sort(), ['age', 'name']);
+  assert.equal(typeof deep.name.deepUnpack, 'function'); // a GLib.Variant wrapper
+  assert.equal(deep.name.deepUnpack(), 'Ada');
+  assert.equal(deep.age.deepUnpack(), 36);
+
+  // recursiveUnpack: fully plain JS, no Variants.
+  assert.deepEqual(v.recursiveUnpack(), { name: 'Ada', age: 36 });
+});
+
+test('L1: unpack() keeps children as Variants (single level)', () => {
+  const v = new GLib.Variant('as', ['x', 'y']);
+  const shallow = v.unpack();
+  assert.ok(Array.isArray(shallow));
+  assert.equal(shallow.length, 2);
+  // Each element is still a Variant wrapper.
+  assert.equal(typeof shallow[0].deepUnpack, 'function');
+  assert.equal(shallow[0].deepUnpack(), 'x');
+  assert.equal(shallow[1].deepUnpack(), 'y');
+});
+
+test('L1: nested "v" — deepUnpack keeps it a Variant, recursiveUnpack unwraps', () => {
+  const v = new GLib.Variant('v', new GLib.Variant('i', 5));
+  assert.equal(v.get_type_string(), 'v');
+  // deepUnpack of a top-level `v` returns the inner Variant (still a Variant).
+  const inner = v.deepUnpack();
+  assert.equal(typeof inner.deepUnpack, 'function');
+  assert.equal(inner.deepUnpack(), 5);
+  // recursiveUnpack unwraps fully.
+  assert.equal(v.recursiveUnpack(), 5);
+});
+
+test('L1: "mi" maybe — value and null', () => {
+  assert.equal(new GLib.Variant('mi', 7).deepUnpack(), 7);
+  assert.equal(new GLib.Variant('mi', null).deepUnpack(), null);
+});
+
+test('L1: deep_unpack alias + GJS toString shape', () => {
+  const v = new GLib.Variant('i', 11);
+  assert.equal(v.deep_unpack(), 11);
+  assert.equal(v.toString(), '[object variant of type "i"]');
+});
+
+test('L1: GLib.Variant.new(sig, value) deprecated alias works', () => {
+  assert.equal(GLib.Variant.new('s', 'legacy').deepUnpack(), 'legacy');
+});
+
+test('L1: a built Variant routes other GVariant methods (n_children)', () => {
+  const v = new GLib.Variant('as', ['a', 'b', 'c']);
+  assert.equal(v.n_children(), 3);
+});
+
+// ---- end-to-end: Gio.SimpleAction carrying a built Variant -----------------
+
+test('e2e: SimpleAction state round-trips through built Variants + the change-state signal', () => {
+  const Gio = requireGi('Gio', '2.0');
+
+  // A stateful action whose state is a built GLib.Variant (parameter_type null).
+  const action = Gio.SimpleAction.new_stateful('counter', null, new GLib.Variant('i', 0));
+  assert.equal(action.get_name(), 'counter');
+  // get_state() returns a GVariant → wrapped as a GLib.Variant → deepUnpack.
+  assert.equal(action.get_state().deepUnpack(), 0);
+
+  // The change-state signal carries the requested value Variant (marshalled
+  // through GValue → wrapped) — observe it, then let the default handler apply.
+  let observed = null;
+  action.connect('change-state', (value) => {
+    observed = value.deepUnpack();
+    action.set_state(value); // commit (SimpleAction has no default change-state handler)
+  });
+
+  action.change_state(new GLib.Variant('i', 5));
+  assert.equal(observed, 5);
+  assert.equal(action.get_state().deepUnpack(), 5);
+});
+
+test('e2e: a{sv} payload (the GAction/GSettings/DBus shape) survives a full round-trip', () => {
+  const built = new GLib.Variant('a{sv}', {
+    enabled: new GLib.Variant('b', true),
+    label: new GLib.Variant('s', 'Run'),
+    count: new GLib.Variant('i', 3),
+  });
+  assert.equal(built.get_type_string(), 'a{sv}');
+  assert.deepEqual(built.recursiveUnpack(), { enabled: true, label: 'Run', count: 3 });
+});


### PR DESCRIPTION
Make `new GLib.Variant(signature, value)` and the GJS unpack flavours work on Node, matching `gjs/modules/core/overrides/GLib.js` — the contract GAction / GSettings / DBus payloads expect (the next ENDGAME-roadmap item after OUT params #652 + arrays #653).

## Native vs L1 split

**Native engine (`src/addon.cc`)** — the recursive build/unpack the type grammar makes awkward to drive purely through introspection:
- `variantNew(sig, value)` — the C twin of `_packVariant` (recursive `g_variant_new_*` / `GVariantBuilder`).
- `variantUnpack(handle, deep, recursive)` — the C twin of `_unpackVariant`.
- `variantGetTypeString(handle)`, `isVariantHandle(value)`.

**L1 (`gi.js`)** — the GLib namespace is decorated so `GLib.Variant` is an ergonomic class: `new GLib.Variant(...)` packs, and the wrapper exposes `.unpack()` / `.deepUnpack()` / `.deep_unpack` / `.recursiveUnpack()` / `.get_type_string()` + the GJS `toString`, routing any other GVariant method through the boxed engine.

## Supported vs deferred

Supported type strings: basics `b y n q i u x t h d s o g`, `v` (variant), `m*` (maybe), `a*` arrays (with the `as` strv + `ay` bytestring fast-paths and `a{..}` dictionaries via dict-entries), `(...)` tuples and `{kv}` dict-entries. Genuinely exotic types fall out of the type grammar with a clear `Invalid GVariant signature` error.

## deepUnpack vs recursiveUnpack

Matched exactly to GJS by mirroring its two-flag `_unpackVariant(deep, recursive)`: `deep` controls whether container children are unpacked; `recursive` ONLY affects `v` values. So `deepUnpack()` unpacks one level but leaves a nested `v` (e.g. an `a{sv}` value) a Variant, while `recursiveUnpack()` unwraps it to plain JS. `unpack()` keeps all children as Variants. Pack values are deep-unwrapped at the L1 boundary so a nested Variant wrapper reaches the native `v` case as its raw handle.

## GVariant ref/float ownership (scrutiny surface)

GVariant is a fundamental (NOT boxed) ref-counted (de)floating GType, so it reuses the boxed-handle tag (method resolution + IN-arg unwrap) but the finalizer drops it via `g_variant_unref`, not `g_boxed_free`. `WrapVariant` owns exactly one strong, non-floating ref: `g_variant_take_ref` on transfer-full (sinking a floating one), `g_variant_ref_sink` on a borrow, and `g_variant_ref_sink` on the freshly-built floating top-level. Unpack children that "stay Variants" adopt the new ref from `g_variant_get_child_value`/`get_variant`/`get_maybe`; deep children are unref'd after the read. Validated with a 3000-iteration GC-stress run (stable RSS, no crash).

## Tests

`test/variant.test.mjs` (21 cases): native + L1 round-trips (`s`/`b`/`i`/`d`, `as`, `ai`, `ay`, `a{ss}`, `a{sv}` deep-vs-recursive, `(si)`/`(sib)` tuples, `v`, `mi` maybe, `get_type_string`), plus an **end-to-end** `Gio.SimpleAction` whose state is carried through built Variants (`new_stateful` / `change_state` / `get_state().deepUnpack()`) and observed on the `change-state` signal. `GValueToJs`/`JsToGValue` also learn the `G_TYPE_VARIANT` case (variant-typed properties + signal params).

All 137 node-gi tests pass (116 prior + 21 new); the dual gjs+node capstone e2e passes; existing boxed/struct/signal paths unchanged.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH