### PR TITLE
feat(node-gi): toggle-ref instance GC bridge

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -69,6 +69,15 @@ jobs:
         working-directory: packages/node-gi/node-gi
         run: npm test
 
+      # GC-stress leg: the toggle-ref instance bridge (wrapper identity,
+      # collectability, toggle-up rooting, resurrection, signal-cycle, soak) only
+      # surfaces under deliberate GC pressure, which needs --expose-gc for
+      # global.gc(). Plain `node --test` self-skips those cases; this leg runs
+      # them. Reuses the addon already built by the previous step.
+      - name: GC-stress test (node --test --expose-gc)
+        working-directory: packages/node-gi/node-gi
+        run: npm run test:gc
+
       # Capstone: ONE unchanged gi:// source builds + runs byte-identically on
       # BOTH gjs and node. `npm install` builds @gjsify/node-gi via the
       # `file:../node-gi` dependency (node-gyp), so the example exercises the

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -220,12 +220,23 @@ function findProtoDescriptor(proto, prop) {
   return undefined;
 }
 
+// L1 proxy-identity cache (the user-visible half of the toggle-ref bridge). The
+// native engine now returns the CANONICAL External per GObject (same GObject ⇒
+// same handle), so we cache the per-instance Proxy keyed by that handle: the same
+// GObject always yields the same L1 wrapper, so `===` holds at the ergonomic
+// layer and a plain JS field set on a wrapper survives a round-trip + GC (the
+// External is kept alive by the toggle-up root while C owns the object, which in
+// turn keeps this WeakMap entry — and the proxy + its fields — alive).
+const instanceCache = new WeakMap();
+
 // Wrap a live GObject handle as a GJS-shaped instance. When `userProto` is given
 // (a registerClass subclass's prototype) the wrapper resolves the user class's
 // own prototype members FIRST — so `inst.myMethod()` runs the JS method with the
 // wrapper as `this` — then falls back to GObject property get/set and GI method
 // routing. `.connect()/.emit()/.disconnect()` work in both modes.
 function wrapInstance(handle, userProto) {
+  const cached = instanceCache.get(handle);
+  if (cached !== undefined) return cached;
   const target = { [HANDLE]: handle };
   const proxy = new Proxy(target, {
     get(t, prop) {
@@ -256,15 +267,17 @@ function wrapInstance(handle, userProto) {
       if (native.hasProperty(handle, propName)) {
         return wrapReturn(native.getProperty(handle, propName));
       }
-      // Surface a plain JS field previously written on THIS wrapper. NOTE: plain
-      // (non-GObject-property) fields are per-wrapper, NOT shared across the
-      // vfunc<->instance boundary in this milestone — a vfunc's `this` is a
-      // distinct wrapper over the same GObject (the native engine mints a fresh
-      // handle per call; the unified-identity wrapper cache arrives with the
-      // toggle-ref work). Use GObject PROPERTIES for state that must cross that
-      // boundary (those live in C and ARE consistent). See the block comment on
-      // registerClass.
-      if (userProto !== undefined && prop in t) return t[prop];
+      // Surface a plain JS field previously written on THIS wrapper. With the
+      // toggle-ref bridge the wrapper is now CANONICAL (one proxy per GObject,
+      // cached by the canonical native handle), so a plain field IS shared across
+      // the vfunc<->instance boundary and survives a round-trip + GC while C owns
+      // the object — a vfunc's `this` resolves to the same cached proxy as
+      // construct, and `store.get_item(x)` returns the same proxy a setter wrote
+      // to. Own-property only (set via the `set` trap), so an introspected GI
+      // method of the same name is never shadowed unless the user explicitly
+      // assigned an expando. (GObject PROPERTIES remain the right choice for state
+      // that must also be visible to C / other language bindings.)
+      if (Object.prototype.hasOwnProperty.call(t, prop)) return t[prop];
       return (...args) => wrapReturn(native.callMethod(handle, camelToSnake(prop), unwrapArgs(args)));
     },
     set(t, prop, value) {
@@ -297,6 +310,7 @@ function wrapInstance(handle, userProto) {
       return false;
     },
   });
+  instanceCache.set(handle, proxy);
   return proxy;
 }
 

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -21,6 +21,12 @@ import * as native from './index.js';
 // be unwrapped again when passed back into the engine as a GI argument.
 const HANDLE = Symbol('nodeGiHandle');
 
+// Symbol carrying the user-class prototype (a registerClass subclass) on a wrapped
+// instance. Stored on the target rather than captured in the proxy closure so a
+// later wrap with a userProto can UPGRADE an already-cached generic wrapper in
+// place (preserving identity + expandos) — see wrapInstance.
+const USER_PROTO = Symbol('nodeGiUserProto');
+
 // JS-builtin / interop names that must NEVER be treated as a GI method or
 // property — otherwise awaiting, printing or inspecting a wrapper would call
 // into GObject (e.g. a stray `then` would make a wrapper look thenable).
@@ -236,8 +242,20 @@ const instanceCache = new WeakMap();
 // routing. `.connect()/.emit()/.disconnect()` work in both modes.
 function wrapInstance(handle, userProto) {
   const cached = instanceCache.get(handle);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    // UPGRADE a cached generic (userProto-less) wrapper when this wrap supplies a
+    // userProto — so a subclass instance first seen generically (returned from
+    // store.get_item / a signal sender / resurrection) still gets its prototype
+    // methods. Never DOWNGRADE: an existing userProto is kept. The userProto lives
+    // on the target (read via the proxy here), so the upgrade is in place —
+    // identity (===) and any expando fields are preserved.
+    if (userProto !== undefined && cached[USER_PROTO] === undefined) {
+      cached[USER_PROTO] = userProto;
+    }
+    return cached;
+  }
   const target = { [HANDLE]: handle };
+  if (userProto !== undefined) target[USER_PROTO] = userProto;
   const proxy = new Proxy(target, {
     get(t, prop) {
       if (prop === HANDLE) return handle;
@@ -255,8 +273,9 @@ function wrapInstance(handle, userProto) {
         default:
           break;
       }
-      if (userProto !== undefined) {
-        const desc = findProtoDescriptor(userProto, prop);
+      const up = t[USER_PROTO];
+      if (up !== undefined) {
+        const desc = findProtoDescriptor(up, prop);
         if (desc !== undefined) {
           if (typeof desc.value === 'function') return (...args) => desc.value.apply(proxy, args);
           if (typeof desc.get === 'function') return desc.get.call(proxy);
@@ -278,12 +297,18 @@ function wrapInstance(handle, userProto) {
       // assigned an expando. (GObject PROPERTIES remain the right choice for state
       // that must also be visible to C / other language bindings.)
       if (Object.prototype.hasOwnProperty.call(t, prop)) return t[prop];
+      // LAST resort before treating an unknown name as a GI method: an INHERITED
+      // member (Object.prototype.hasOwnProperty / isPrototypeOf / … — RESERVED
+      // already covers toString/valueOf/etc.) must resolve to the real function,
+      // not a GI callMethod thunk that would throw on `inst.hasOwnProperty('x')`.
+      if (prop in t) return t[prop];
       return (...args) => wrapReturn(native.callMethod(handle, camelToSnake(prop), unwrapArgs(args)));
     },
     set(t, prop, value) {
       if (typeof prop === 'string') {
-        if (userProto !== undefined) {
-          const desc = findProtoDescriptor(userProto, prop);
+        const up = t[USER_PROTO];
+        if (up !== undefined) {
+          const desc = findProtoDescriptor(up, prop);
           if (desc !== undefined && typeof desc.set === 'function') {
             desc.set.call(proxy, value);
             return true;
@@ -304,7 +329,8 @@ function wrapInstance(handle, userProto) {
         // A subclass's own prototype member (method/getter) and any GObject
         // property of the instance both count as `in` the wrapper. (Introspected
         // GI methods are resolved dynamically and are intentionally not reported.)
-        if (userProto !== undefined && findProtoDescriptor(userProto, prop) !== undefined) return true;
+        const up = t[USER_PROTO];
+        if (up !== undefined && findProtoDescriptor(up, prop) !== undefined) return true;
         if (native.hasProperty(handle, toKebab(prop))) return true;
       }
       return false;

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -47,7 +47,8 @@
     "rebuild": "node-gyp rebuild",
     "clean": "node-gyp clean",
     "test": "node --test",
-    "test:node": "node --test"
+    "test:node": "node --test",
+    "test:gc": "node --test --expose-gc"
   },
   "dependencies": {
     "node-addon-api": "^8.0.0"

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -476,8 +476,17 @@ struct NodeGiInstance {
   bool teardown_queued;    // a finalizer already scheduled the idle teardown (dedupe)
 };
 
-// JS/main thread id (captured in Init). napi_reference_ref/unref are only valid
-// there; off-thread toggles are queued + drained on the main context.
+// The single N-API env that OWNS the toggle machinery (qdata cache + global drain
+// queues + drain async). Claimed by the FIRST env that wraps a GObject. A second
+// env (a worker_threads Worker on another thread) must NOT touch this env's
+// napi_refs (cross-env = UAF) nor its qdata cache / queues, so its wraps take the
+// plain strong-ref path (no identity / GC-bridge, but safe). Atomic: read lock-free
+// in MakeGObjectHandle, claimed once via compare_exchange there.
+static std::atomic<napi_env> g_owner_env{nullptr};
+
+// JS/main thread id of the owner env (captured at first wrap in EnsureDrainAsync).
+// napi_reference_ref/unref are only valid there; off-thread toggles are queued +
+// drained on the main context.
 static std::thread::id g_main_thread_id;
 static bool g_main_thread_id_set = false;
 static bool OnMainThread() {
@@ -518,27 +527,46 @@ static void NodeGiToggleNotify(gpointer, GObject*, gboolean);
 static void OnGObjectFinalized(gpointer, GObject*);
 
 // Lazily init the drain async on the JS thread (the only legal thread for
-// uv_async_init / napi_async_init). Called from MakeGObjectHandle, so it is always
-// initialised before any object exists — hence before any toggle or teardown can
-// be queued.
+// uv_async_init / napi_async_init). Called only by the OWNER env's MakeGObjectHandle
+// (the multi-env gate runs first), so it runs serially on one thread — hence before
+// any object exists, and before any toggle or teardown can be queued. The flag +
+// g_async_* are read off-thread (WakeDrain), so they are written under g_queue_mutex.
 static void EnsureDrainAsync(napi_env env) {
-  if (g_drain_async_inited) return;
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    if (g_drain_async_inited) return;
+  }
   uv_loop_t* loop = nullptr;
   if (napi_get_uv_event_loop(env, &loop) != napi_ok || loop == nullptr) return;
   if (uv_async_init(loop, &g_drain_async, DrainAsyncCb) != 0) return;
   uv_unref(reinterpret_cast<uv_handle_t*>(&g_drain_async));  // don't keep the loop alive
-  g_async_env = env;
   // An async context so the drain — which re-enters JS via signal emission during
   // dispose (remove_toggle_ref → dispose → ::destroy) — runs in a valid N-API
   // callback scope, not a bare libuv callback (which lacks a V8 HandleScope).
   napi_value name = nullptr;
   napi_create_string_utf8(env, "node-gi:toggle-drain", NAPI_AUTO_LENGTH, &name);
-  napi_async_init(env, nullptr, name, &g_async_context);
-  g_drain_async_inited = true;
+  napi_async_context ctx = nullptr;
+  napi_async_init(env, nullptr, name, &ctx);
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    g_async_env = env;
+    g_async_context = ctx;
+    // This env owns the machinery; its thread is the JS/main thread for toggles.
+    g_main_thread_id = std::this_thread::get_id();
+    g_main_thread_id_set = true;
+    g_drain_async_inited = true;
+  }
 }
 
+// Wake the JS-thread drain. Holds g_queue_mutex and re-checks both the init flag and
+// the shutdown flag immediately before uv_async_send, paired with OnEnvShutdown's
+// locked flag-flip-before-close — so an off-thread toggle can never uv_async_send a
+// handle that is being / has been closed (the shutdown TOCTOU that aborted libuv).
 static void WakeDrain() {
-  if (g_drain_async_inited) uv_async_send(&g_drain_async);
+  std::lock_guard<std::mutex> guard(g_queue_mutex);
+  if (g_drain_async_inited && !g_toggle_shutdown.load()) {
+    uv_async_send(&g_drain_async);
+  }
 }
 
 // Apply a toggle on the JS thread: flip the canonical napi_ref strong↔weak.
@@ -631,33 +659,62 @@ static void DrainAsyncCb(uv_async_t*) {
   }
 }
 
+// Queue helpers — caller MUST hold g_queue_mutex. Mirror GJS ToggleQueue::is_queued
+// + ToggleQueue::enqueue (refs/gjs gi/toggle.cpp): a main-thread toggle may apply
+// directly ONLY when nothing is queued for the inst; otherwise it is enqueued, and
+// an OPPOSITE-direction queued toggle CANCELS with the new one (both removed). That
+// cancellation is what fixes the cross-thread wrong-flip / lost-toggle bug — a
+// stale queued flip can never be applied after its inverse already happened.
+static bool IsQueuedLocked(NodeGiInstance* inst) {
+  for (const ToggleItem& item : g_toggle_queue)
+    if (item.inst == inst) return true;
+  return false;
+}
+
+// Returns true iff a toggle was actually left on the queue (→ caller wakes drain).
+static bool EnqueueToggleLocked(NodeGiInstance* inst, bool down) {
+  for (auto it = g_toggle_queue.begin(); it != g_toggle_queue.end(); ++it) {
+    if (it->inst != inst) continue;
+    if (it->down != down) {
+      g_toggle_queue.erase(it);  // opposite direction queued → the two cancel
+      return false;
+    }
+    return false;  // same direction already queued → dedupe (ApplyToggle is idempotent)
+  }
+  g_toggle_queue.push_back({inst, down});
+  return true;
+}
+
 // The single toggle-notify for every node-gi GObject. Registered with data=NULL
 // (fungible — node-gtk pattern): the live wrapper is found via qdata, so a stale
 // teardown can remove ANY one toggle ref without orphaning a resurrected wrapper.
+//
+// ALL toggles route through the queue logic (GJS wrapped_gobj_toggle_notify): we
+// apply directly ONLY on the main thread when NOTHING is queued for this inst;
+// otherwise we enqueue (where opposite-direction toggles cancel). The qdata lookup
+// + decision + direct-apply/enqueue are all done UNDER g_queue_mutex (GJS holds its
+// ToggleQueue lock across the whole notify, including the direct apply) so an
+// off-thread toggle cannot interleave between the is-queued check and the apply, and
+// RunTeardown — which clears qdata under the SAME lock — can never be acted on after
+// it has freed an inst.
 static void NodeGiToggleNotify(gpointer /*data*/, GObject* obj, gboolean is_last_ref) {
   if (g_toggle_shutdown.load()) return;
   bool down = is_last_ref != FALSE;
-  if (OnMainThread()) {
-    // Fast path: same thread as construct/teardown, so no teardown can race us.
-    NodeGiInstance* inst =
-        static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
-    if (inst != nullptr) ApplyToggle(inst, down);
-    return;
-  }
-  // Off-thread (a GIO/GStreamer-worker unref): marshal to the JS thread. Re-read
-  // qdata + enqueue under the lock that RunTeardown also clears qdata under, so
-  // we never queue an inst that teardown has already (or is about to) free.
-  bool queued = false;
+  bool main_thread = OnMainThread();
+  bool enqueued = false;
   {
     std::lock_guard<std::mutex> guard(g_queue_mutex);
+    if (g_toggle_shutdown.load()) return;  // re-check under the lock
     NodeGiInstance* inst =
         static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
-    if (inst != nullptr) {
-      g_toggle_queue.push_back({inst, down});
-      queued = true;
+    if (inst == nullptr) return;
+    if (main_thread && !IsQueuedLocked(inst)) {
+      ApplyToggle(inst, down);  // direct apply, under the lock (as GJS does)
+    } else {
+      enqueued = EnqueueToggleLocked(inst, down);
     }
   }
-  if (queued) WakeDrain();  // outside the lock
+  if (enqueued) WakeDrain();  // outside the lock
 }
 
 // Weak-ref safety net: if C finalizes the GObject while we still hold the toggle
@@ -676,9 +733,43 @@ static void NodeGiInstanceFinalize(Napi::Env /*env*/, GObject* /*data*/, NodeGiI
   inst->teardown_queued = true;
   {
     std::lock_guard<std::mutex> guard(g_queue_mutex);
+    // After shutdown nothing will drain, so don't grow the queue (the env is going
+    // away; the inst leaks with it — same as a dropped pending teardown).
+    if (g_toggle_shutdown.load()) return;
     g_teardown_queue.push_back(inst);
   }
   WakeDrain();
+}
+
+// Synchronously dispose a COLLECTED wrapper's binding state so a fresh wrapper can
+// be built for the same GObject without ever installing a SECOND toggle ref on it.
+// GLib suppresses toggle-notify while >=2 toggle refs exist, so a refcount change in
+// the two-toggle-ref window would be LOST → the wrapper pinned/leaked (GJS keeps ONE
+// toggle ref per GObject). The caller holds a construction ref on obj, so dropping
+// the old toggle ref here cannot drive refcount to 0 / dispose. Main-thread only (==
+// the drain thread), so the pending idle teardown cannot be running concurrently.
+static void SettleCollectedInstance(GObject* obj, NodeGiInstance* old) {
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    // Cancel old's pending teardown + any queued toggles that reference it, so the
+    // drain never touches a freed inst (paired with the off-thread enqueue, which
+    // re-reads qdata under this SAME lock — and we clear qdata below).
+    for (auto it = g_teardown_queue.begin(); it != g_teardown_queue.end();)
+      it = (*it == old) ? g_teardown_queue.erase(it) : it + 1;
+    for (auto it = g_toggle_queue.begin(); it != g_toggle_queue.end();)
+      it = (it->inst == old) ? g_toggle_queue.erase(it) : it + 1;
+    // Detach qdata only if it still points at old (resurrection-safe).
+    if (g_object_get_qdata(obj, NodeGiWrapperQuark()) == old)
+      g_object_set_qdata(obj, NodeGiWrapperQuark(), nullptr);
+  }
+  if (old->gobject != nullptr) {
+    g_object_weak_unref(obj, OnGObjectFinalized, old);
+    // Remove old's toggle ref BEFORE the fresh one is added below — never two at
+    // once. We hold a construction ref, so this cannot dispose obj.
+    if (old->toggle_added) g_object_remove_toggle_ref(obj, NodeGiToggleNotify, nullptr);
+  }
+  if (old->handle_ref != nullptr) napi_delete_reference(old->env, old->handle_ref);
+  delete old;
 }
 
 // Cache-aware factory: the caller owns exactly ONE non-floating "construction"
@@ -686,6 +777,29 @@ static void NodeGiInstanceFinalize(Napi::Env /*env*/, GObject* /*data*/, NodeGiI
 // cache miss / resurrecting on a collected hit, or adopting + balancing the ref
 // on a live hit.
 static Napi::Value MakeGObjectHandle(Napi::Env env, GObject* obj) {
+  // Multi-env (worker_threads) safety: claim / honour the toggle-machinery owner.
+  // The FIRST env to wrap a GObject wins (compare_exchange under a concurrent race);
+  // every later env that is NOT the owner takes the plain strong-ref path.
+  napi_env owner = g_owner_env.load();
+  if (owner == nullptr) {
+    napi_env expected = nullptr;
+    owner = g_owner_env.compare_exchange_strong(expected, static_cast<napi_env>(env))
+                ? static_cast<napi_env>(env)
+                : expected;
+  }
+  if (owner != static_cast<napi_env>(env)) {
+    // A non-owner env must not touch the owner's napi_refs / qdata cache / queues
+    // (cross-env napi = UAF). Give it a plain strong-ref handle: it adopts the
+    // single construction ref and drops it in its OWN finalizer (correct
+    // refcounting; any toggle the ref churn triggers is handled by the OWNER on the
+    // owner thread). Trade-off: no wrapper identity / GC-bridge for worker envs — a
+    // documented limitation, but no cross-env UAF.
+    Napi::External<GObject> plain = Napi::External<GObject>::New(
+        env, obj, [](Napi::Env, GObject* p) { g_object_unref(p); });
+    plain.TypeTag(&kGObjectHandleTag);
+    return plain;
+  }
+
   EnsureDrainAsync(env);  // wire the JS-thread drain before any toggle/teardown can queue
   NodeGiInstance* existing =
       static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
@@ -696,8 +810,11 @@ static Napi::Value MakeGObjectHandle(Napi::Env env, GObject* obj) {
       g_object_unref(obj);  // drop the surplus construction ref; toggle ref owns obj
       return Napi::Value(env, cached);
     }
-    // collected hit (wrapper GC'd, idle teardown maybe pending) → resurrect below;
-    // the pending idle's "qdata == inst" guard stops it clobbering the new wrapper.
+    // Collected hit (wrapper GC'd, idle teardown still PENDING — the drain runs on
+    // THIS thread, so it cannot have run concurrently). Settle the dead wrapper
+    // synchronously first (drops its toggle ref while we hold the construction ref),
+    // then build a fresh wrapper below — never two toggle refs on obj at once.
+    SettleCollectedInstance(obj, existing);
   }
 
   NodeGiInstance* inst = new NodeGiInstance();
@@ -2809,6 +2926,51 @@ Napi::Value IsGObjectHandle(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is);
 }
 
+// ============================ TEST-ONLY ===============================
+// __stressRefUnrefOffThread(handle, iterations) — the GLib-thread vehicle the
+// cross-thread GC stress test needs (there is no headless JS way to make another
+// OS thread ref/unref a wrapped GObject — GIO local-file async keeps its refcount
+// ops on the main thread). A background GThread does g_object_ref/g_object_unref on
+// the wrapped GObject `iterations` times, crossing the toggle 1<->2 boundary from a
+// NON-main thread → driving NodeGiToggleNotify's OFF-THREAD branch + the
+// opposite-direction enqueue cancel + WakeDrain + the JS-thread drain. The CALLER
+// MUST keep the handle reachable (and take NO extra ref) for the churn's lifetime:
+// the toggle ref + the JS-reachable wrapper keep the GObject alive at refcount 1
+// between churn pairs, so the worker's 1<->2 crossings are real toggles, never a
+// use-after-free. Poll __stressRefUnrefRunning() for completion. Not part of the
+// public API surface — prefixed __ and only used by test/gc-cross-thread.test.mjs.
+static std::atomic<int> g_stress_running{0};
+struct StressArgs {
+  GObject* obj;
+  long iterations;
+};
+static gpointer StressThreadFunc(gpointer data) {
+  StressArgs* a = static_cast<StressArgs*>(data);
+  for (long i = 0; i < a->iterations; i++) {
+    g_object_ref(a->obj);    // 1 -> 2 : toggle UP (off-thread)
+    g_object_unref(a->obj);  // 2 -> 1 : toggle DOWN (off-thread)
+    if ((i & 0x3f) == 0) g_thread_yield();  // give the main thread the lock + loop
+  }
+  g_stress_running.fetch_sub(1);
+  delete a;
+  return nullptr;
+}
+Napi::Value StressRefUnrefOffThread(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GObject* obj = UnwrapGObject(env, info[0]);
+  if (obj == nullptr) return env.Undefined();
+  long iters = info.Length() >= 2 ? static_cast<long>(info[1].As<Napi::Number>().Int64Value()) : 10000;
+  StressArgs* a = new StressArgs{obj, iters};
+  g_stress_running.fetch_add(1);
+  GThread* t = g_thread_new("node-gi-stress", StressThreadFunc, a);
+  g_thread_unref(t);  // detached — completion is signalled via g_stress_running
+  return env.Undefined();
+}
+Napi::Value StressRefUnrefRunning(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), g_stress_running.load() > 0);
+}
+// ========================== END TEST-ONLY ============================
+
 // callMethod(handle, methodName, args?: unknown[]) -> unknown
 // Resolve an instance method by walking the instance's GIObjectInfo (own +
 // implemented-interface methods at each level, then up the parent chain), then
@@ -3864,19 +4026,36 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
 // toggle-notify touches a dead env (GJS's gjs_object_shutdown_toggle_queue), and
 // close the drain async so the libuv loop can exit cleanly. Any still-queued
 // teardowns are intentionally dropped (the process/env is going away).
-static void OnEnvShutdown(void* /*arg*/) {
-  g_toggle_shutdown.store(true);
-  if (g_drain_async_inited) {
+//
+// Sequencing (the fix for the shutdown TOCTOU / data race): under g_queue_mutex,
+// set shutdown=true and clear g_drain_async_inited (disabling all further sends)
+// BEFORE uv_close runs outside the lock. WakeDrain checks both flags under the same
+// lock, so once the flag is cleared no thread can uv_async_send the handle, and
+// uv_close only runs after that point — no send can race the close.
+static void OnEnvShutdown(void* arg) {
+  // Only the env that OWNS the toggle machinery may tear it down — a worker env
+  // exiting must not disable the owner's drain async or set the global flag.
+  if (g_owner_env.load() != static_cast<napi_env>(arg)) return;
+  bool close_async = false;
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    g_toggle_shutdown.store(true);
+    if (g_drain_async_inited) {
+      g_drain_async_inited = false;  // disable further sends FIRST (under the lock)
+      close_async = true;
+    }
+  }
+  if (close_async) {
     uv_close(reinterpret_cast<uv_handle_t*>(&g_drain_async), nullptr);
-    g_drain_async_inited = false;
   }
 }
 
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
-  // Capture the JS/main thread — toggle refs may only touch the napi_ref here.
-  g_main_thread_id = std::this_thread::get_id();
-  g_main_thread_id_set = true;
-  napi_add_env_cleanup_hook(env, OnEnvShutdown, nullptr);
+  // The owner env + its JS/main thread are captured lazily at the first wrap
+  // (EnsureDrainAsync) — NOT here, since Init runs once PER env and a per-env
+  // overwrite would mis-identify the main thread under worker_threads. The cleanup
+  // hook carries `env` so OnEnvShutdown only fires the global teardown for the owner.
+  napi_add_env_cleanup_hook(env, OnEnvShutdown, env);
   exports.Set("requireNamespace", Napi::Function::New(env, RequireNamespace));
   exports.Set("listInfoNames", Napi::Function::New(env, ListInfoNames));
   exports.Set("findInfo", Napi::Function::New(env, FindInfo));
@@ -3894,6 +4073,9 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("hasProperty", Napi::Function::New(env, HasProperty));
   exports.Set("getTypeName", Napi::Function::New(env, GetTypeName));
   exports.Set("isGObjectHandle", Napi::Function::New(env, IsGObjectHandle));
+  // Test-only (cross-thread GC stress) — see StressRefUnrefOffThread.
+  exports.Set("__stressRefUnrefOffThread", Napi::Function::New(env, StressRefUnrefOffThread));
+  exports.Set("__stressRefUnrefRunning", Napi::Function::New(env, StressRefUnrefRunning));
   exports.Set("callBoxedMethod", Napi::Function::New(env, CallBoxedMethod));
   exports.Set("isBoxedHandle", Napi::Function::New(env, IsBoxedHandle));
   exports.Set("variantNew", Napi::Function::New(env, VariantNew));

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -514,11 +514,14 @@ struct ToggleItem {
   NodeGiInstance* inst;
   bool down;  // true = toggle-down (→ weak), false = toggle-up (→ strong)
 };
-// RECURSIVE: the drain (DrainAsyncCb) holds the lock across the WHOLE drain and
-// RunTeardown re-enters JS (dispose → signal/vfunc) which reentrantly re-acquires
-// the lock on the SAME thread (RunTeardown's own lock + a reentrant WrapGObject →
-// SettleCollectedInstance / NodeGiToggleNotify). A plain mutex would self-deadlock;
-// GJS's ToggleQueue lock is recursive for exactly this reason.
+// RECURSIVE (defensive, mirrors GJS's recursive ToggleQueue lock). The lock is held
+// only across SHORT critical sections — never across RunTeardown's dispose → JS (the
+// drain pops one item under the lock, RELEASES it, then processes; see DrainAsyncCb).
+// So a reentrant SettleCollectedInstance / NodeGiToggleNotify fired from a dispose
+// re-acquires the lock as a FRESH (non-nested) acquire today. Keeping it recursive
+// guarantees that even if a future change widens a critical section a same-thread
+// re-acquire can never self-deadlock; it does not weaken the no-lock-across-dispose
+// invariant the liveness test enforces.
 static std::recursive_mutex g_queue_mutex;
 static std::deque<ToggleItem> g_toggle_queue;
 static std::deque<NodeGiInstance*> g_teardown_queue;
@@ -633,20 +636,24 @@ static void RunTeardown(NodeGiInstance* inst) {
   delete inst;
 }
 
-// Drain both queues on the JS/main thread. Mirrors GJS idle_handle_toggle →
-// handle_all_toggles under Locked: hold the (recursive) lock across the WHOLE drain
-// and pop the LIVE queues ONE item at a time — do NOT swap into a stack snapshot.
+// Drain both queues on the JS/main thread. Pop ONE item from the LIVE queue UNDER
+// the lock, RELEASE the lock, then process it WITHOUT the lock; loop until empty.
 //
-// Why: RunTeardown's g_object_remove_toggle_ref can drive dispose → a live JS
-// signal/vfunc → reentrant JS that wraps a GObject → SettleCollectedInstance(old),
-// whose cancel loop scans g_teardown_queue to drop `old`'s pending teardown. With a
-// swap-then-process snapshot, an in-flight `old` is NOT in the live queue, so the
-// scan can't cancel it; SettleCollectedInstance then deletes it and the outer loop
-// later derefs freed memory + double-removes the resurrected wrapper's toggle ref.
-// Popping the LIVE queue (and removing the current item BEFORE running it) keeps the
-// remaining pending items visible + cancellable by a reentrant SettleCollectedInstance.
-// The recursive lock lets RunTeardown's own lock + the reentrant wrap re-lock on this
-// thread; off-thread actors block until the drain completes.
+// The lock must NOT be held across RunTeardown: it calls g_object_remove_toggle_ref
+// → dispose → arbitrary JS (signal/vfunc). Holding a lock across reentrant user code
+// (a) STALLS an off-thread NodeGiToggleNotify (which blocks acquiring g_queue_mutex)
+// for the whole dispose — a priority inversion, not a "brief" block; and (b) risks an
+// ABBA deadlock if a dispose vfunc synchronously waits on a worker thread that is
+// itself blocked on g_queue_mutex. GJS likewise holds its ToggleQueue lock only
+// across the rooting flip (== ApplyToggle), NEVER across remove_toggle_ref + dispose.
+//
+// The DEFECT-2 fix is preserved: the current item is removed from the LIVE queue
+// UNDER the lock BEFORE release, so it is never double-processed; and a reentrant
+// SettleCollectedInstance (same drain thread, fired from a dispose) re-acquires the
+// lock and still sees + cancels the OTHER pending teardowns left in the live queue
+// (a swap-then-process snapshot would hide them → double-free). Toggles drain first
+// (FIFO); a toggle enqueued during a teardown's dispose is picked up on the next
+// iteration. Terminates when both queues are empty.
 static void DrainAsyncCb(uv_async_t*) {
   if (g_async_env == nullptr || g_toggle_shutdown.load()) return;
   Napi::Env env(g_async_env);
@@ -657,20 +664,28 @@ static void DrainAsyncCb(uv_async_t*) {
   Napi::HandleScope handleScope(env);
   Napi::CallbackScope callbackScope(env, g_async_context);
 
-  std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
-  // Toggles take priority (drain to empty before each teardown); a toggle enqueued
-  // during a teardown's dispose is processed next. Terminates when both are empty.
-  while (!g_toggle_queue.empty() || !g_teardown_queue.empty()) {
+  while (true) {
     if (g_toggle_shutdown.load()) return;
-    if (!g_toggle_queue.empty()) {
-      ToggleItem item = g_toggle_queue.front();
-      g_toggle_queue.pop_front();
-      ApplyToggle(item.inst, item.down);
-      continue;
+    ToggleItem toggle{nullptr, false};
+    NodeGiInstance* teardown = nullptr;
+    {
+      std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
+      if (g_toggle_shutdown.load()) return;
+      if (!g_toggle_queue.empty()) {            // toggles first (FIFO)
+        toggle = g_toggle_queue.front();
+        g_toggle_queue.pop_front();
+      } else if (!g_teardown_queue.empty()) {
+        teardown = g_teardown_queue.front();
+        g_teardown_queue.pop_front();           // removed from the LIVE queue under the lock
+      } else {
+        return;                                  // both queues drained
+      }
+    }  // lock RELEASED before any processing — never held across dispose/JS
+    if (toggle.inst != nullptr) {
+      ApplyToggle(toggle.inst, toggle.down);     // napi-only, main-thread state, no reentry
+    } else {
+      RunTeardown(teardown);                      // dispose → JS, NO lock held
     }
-    NodeGiInstance* inst = g_teardown_queue.front();
-    g_teardown_queue.pop_front();  // remove BEFORE running, so a reentrant resurrect
-    RunTeardown(inst);             // of THIS inst takes the miss path, not collected-hit
   }
 }
 
@@ -2964,6 +2979,14 @@ Napi::Value IsGObjectHandle(const Napi::CallbackInfo& info) {
 // use-after-free. Poll __stressRefUnrefRunning() for completion. Not part of the
 // public API surface — prefixed __ and only used by test/gc-cross-thread.test.mjs.
 static std::atomic<int> g_stress_running{0};
+// Monotonic count of completed off-thread ref/unref iterations — lets a test prove
+// the off-thread churn makes progress WHILE a main-thread dispose vfunc is running
+// (i.e. the drain lock is NOT held across dispose). If the lock were held across the
+// dispose, the off-thread NodeGiToggleNotify would block on g_queue_mutex and this
+// counter would freeze for the dispose's whole duration.
+static std::atomic<long> g_stress_progress{0};
+// Cooperative stop flag so a test can halt a long-running churn after asserting.
+static std::atomic<bool> g_stress_stop{false};
 struct StressArgs {
   GObject* obj;
   long iterations;
@@ -2971,8 +2994,10 @@ struct StressArgs {
 static gpointer StressThreadFunc(gpointer data) {
   StressArgs* a = static_cast<StressArgs*>(data);
   for (long i = 0; i < a->iterations; i++) {
+    if (g_stress_stop.load()) break;
     g_object_ref(a->obj);    // 1 -> 2 : toggle UP (off-thread)
     g_object_unref(a->obj);  // 2 -> 1 : toggle DOWN (off-thread)
+    g_stress_progress.fetch_add(1);
     if ((i & 0x3f) == 0) g_thread_yield();  // give the main thread the lock + loop
   }
   g_stress_running.fetch_sub(1);
@@ -2984,6 +3009,7 @@ Napi::Value StressRefUnrefOffThread(const Napi::CallbackInfo& info) {
   GObject* obj = UnwrapGObject(env, info[0]);
   if (obj == nullptr) return env.Undefined();
   long iters = info.Length() >= 2 ? static_cast<long>(info[1].As<Napi::Number>().Int64Value()) : 10000;
+  g_stress_stop.store(false);  // a fresh churn is not pre-stopped
   StressArgs* a = new StressArgs{obj, iters};
   g_stress_running.fetch_add(1);
   GThread* t = g_thread_new("node-gi-stress", StressThreadFunc, a);
@@ -2992,6 +3018,13 @@ Napi::Value StressRefUnrefOffThread(const Napi::CallbackInfo& info) {
 }
 Napi::Value StressRefUnrefRunning(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(info.Env(), g_stress_running.load() > 0);
+}
+Napi::Value StressRefUnrefProgress(const Napi::CallbackInfo& info) {
+  return Napi::Number::New(info.Env(), static_cast<double>(g_stress_progress.load()));
+}
+Napi::Value StressRefUnrefStop(const Napi::CallbackInfo& info) {
+  g_stress_stop.store(true);
+  return info.Env().Undefined();
 }
 // ========================== END TEST-ONLY ============================
 
@@ -4100,6 +4133,8 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   // Test-only (cross-thread GC stress) — see StressRefUnrefOffThread.
   exports.Set("__stressRefUnrefOffThread", Napi::Function::New(env, StressRefUnrefOffThread));
   exports.Set("__stressRefUnrefRunning", Napi::Function::New(env, StressRefUnrefRunning));
+  exports.Set("__stressRefUnrefProgress", Napi::Function::New(env, StressRefUnrefProgress));
+  exports.Set("__stressRefUnrefStop", Napi::Function::New(env, StressRefUnrefStop));
   exports.Set("callBoxedMethod", Napi::Function::New(env, CallBoxedMethod));
   exports.Set("isBoxedHandle", Napi::Function::New(env, IsBoxedHandle));
   exports.Set("variantNew", Napi::Function::New(env, VariantNew));

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -8,11 +8,13 @@
 // libgirepository-1.0 node-gtk linked no longer ships). GJS's gi/repo.cpp is
 // the reference for the girepository-2.0 API surface.
 //
-// Milestone 1 (headless core, scaffold step): prove the toolchain + the modern
-// GIRepository API end to end — resolve the default repository, require a
-// namespace, read back its resolved version + introspection-info count, and
-// enumerate the top-level info names. Marshalling, GObject/signals, the
-// toggle-ref GC dance, and the mainloop bridge land in subsequent steps.
+// Milestone 1 (headless core): the modern GIRepository API end to end — resolve
+// the default repository, require namespaces, marshal functions/methods/props/
+// signals/callbacks/variants/containers, the libuv↔GLib mainloop bridge, and the
+// toggle-ref instance GC bridge (single canonical wrapper per GObject; toggle ref
+// flips strong↔weak so wrappers are collectable yet identity-stable + rooted
+// while C owns them; idle-deferred teardown; resurrection; thread-marshalled
+// toggles). GTK/Adwaita layering lands on top.
 
 #include <napi.h>
 #include <uv.h>
@@ -22,7 +24,11 @@
 #include <glib-object.h>
 #include <glib.h>
 
+#include <atomic>
+#include <deque>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace {
@@ -425,25 +431,329 @@ static bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArg
 static const napi_type_tag kGObjectHandleTag = {0x9f3c1a7b5e2d4068ULL,
                                                 0xa1b2c3d4e5f60718ULL};
 
-// Create the owned, type-tagged External that represents a live GObject. The
-// finalizer drops the single ref we hold; N-API finalizers run outside GC, so
-// the unref (and any resulting GObject finalize) is safe here.
+// ====================================================================
+// ---- toggle-ref instance GC bridge ---------------------------------
+// ====================================================================
+//
+// Derivation: refs/node-gtk src/gobject.cc (romgrk et al., MIT, the #446/#439
+// ownership fixes) + refs/gjs gi/{object.cpp,toggle.{h,cpp}} (the thread-safe
+// ToggleQueue gold standard), ported to N-API. See scratchpad design doc.
+//
+// One canonical, type-tagged External per live GObject, cached on the GObject as
+// qdata. The binding owns a SINGLE g_object_add_toggle_ref; the toggle-notify
+// flips the cached External's napi_ref between STRONG (C also holds the object →
+// rooted, survives GC) and WEAK (JS is the sole owner → collectable). This gives:
+//   (a) wrapper IDENTITY — same GObject ⇒ same External ⇒ `===` + Map-key stable;
+//   (b) collectability of reference cycles;
+//   (c) resurrection — a GObject handed back from C re-wraps to a fresh wrapper
+//       after its old one was collected, without clobbering a pending teardown.
+//
+// Crash-mode discipline (the three the design calls out):
+//   1. N-API finalizers run OUTSIDE GC, but g_object_remove_toggle_ref can drive
+//      dispose → synchronous signal emission → re-entrant JS, which is unsafe
+//      from a finalizer / non-main thread. So the finalizer ONLY schedules a
+//      g_idle_add teardown; ALL GObject teardown runs from that main-loop idle.
+//   2. Toggle-up on a maybe-collected wrapper probes napi_get_reference_value;
+//      empty ⇒ skip (a later WrapGObject resurrects). No during-GC flag dance is
+//      needed — N-API finalizers are post-GC.
+//   3. Cross-thread toggles + double-free: off-thread toggles are marshalled to
+//      the JS thread via a mutex-guarded queue drained on the GLib main context;
+//      a g_object_weak_ref safety net nulls the cached pointer if C finalizes the
+//      object under us; the idle clears qdata only if it still points at THIS
+//      wrapper (resurrection-safe); a shutdown flag disables toggles at teardown.
+
+static GQuark NodeGiWrapperQuark() {
+  static GQuark q = g_quark_from_static_string("node-gi::wrapper");
+  return q;
+}
+
+struct NodeGiInstance {
+  napi_env env;
+  GObject* gobject;        // nulled by the weak-ref safety net if C finalizes it
+  napi_ref handle_ref;     // ref to the canonical External; strong=rooted, weak=not
+  bool rooted;             // true ⇒ handle_ref currently strong (mirrors node-gtk !dying)
+  bool toggle_added;       // a toggle ref is currently installed
+  bool teardown_queued;    // a finalizer already scheduled the idle teardown (dedupe)
+};
+
+// JS/main thread id (captured in Init). napi_reference_ref/unref are only valid
+// there; off-thread toggles are queued + drained on the main context.
+static std::thread::id g_main_thread_id;
+static bool g_main_thread_id_set = false;
+static bool OnMainThread() {
+  return g_main_thread_id_set && std::this_thread::get_id() == g_main_thread_id;
+}
+
+// Set at env cleanup: ToggleNotify early-returns so no toggle touches a
+// torn-down env (GJS's gjs_object_shutdown_toggle_queue equivalent).
+static std::atomic<bool> g_toggle_shutdown{false};
+
+// Deferred-work queues, drained on the JS thread by a libuv async handle.
+//
+// Why libuv, not g_idle_add: a GLib idle only runs while the GLib default context
+// is iterated, which in pure Node usage (a script that never calls
+// MainLoop.run / Application.run) NEVER happens → idle teardowns pile up and the
+// GObjects leak. A uv_async fires whenever the libuv loop turns, which covers
+// BOTH modes: plain Node (uv runs on its own) and a blocking GLib loop (the
+// uv_source bridge below pumps uv_run(NOWAIT), which dispatches the async). The
+// async is uv_unref'd so it never keeps the process alive on its own.
+//
+// Two queues share one mutex: TOGGLES (off-thread toggle-notifies marshalled to
+// the JS thread — the rare GIO/GStreamer-worker path) and TEARDOWNS (wrappers
+// whose External was finalized; the finalizer must not touch GObject directly).
+struct ToggleItem {
+  NodeGiInstance* inst;
+  bool down;  // true = toggle-down (→ weak), false = toggle-up (→ strong)
+};
+static std::mutex g_queue_mutex;
+static std::deque<ToggleItem> g_toggle_queue;
+static std::deque<NodeGiInstance*> g_teardown_queue;
+static uv_async_t g_drain_async;
+static bool g_drain_async_inited = false;
+static napi_env g_async_env = nullptr;                 // captured for the drain callback
+static napi_async_context g_async_context = nullptr;   // async context for the drain
+
+static void DrainAsyncCb(uv_async_t*);
+static void NodeGiToggleNotify(gpointer, GObject*, gboolean);
+static void OnGObjectFinalized(gpointer, GObject*);
+
+// Lazily init the drain async on the JS thread (the only legal thread for
+// uv_async_init / napi_async_init). Called from MakeGObjectHandle, so it is always
+// initialised before any object exists — hence before any toggle or teardown can
+// be queued.
+static void EnsureDrainAsync(napi_env env) {
+  if (g_drain_async_inited) return;
+  uv_loop_t* loop = nullptr;
+  if (napi_get_uv_event_loop(env, &loop) != napi_ok || loop == nullptr) return;
+  if (uv_async_init(loop, &g_drain_async, DrainAsyncCb) != 0) return;
+  uv_unref(reinterpret_cast<uv_handle_t*>(&g_drain_async));  // don't keep the loop alive
+  g_async_env = env;
+  // An async context so the drain — which re-enters JS via signal emission during
+  // dispose (remove_toggle_ref → dispose → ::destroy) — runs in a valid N-API
+  // callback scope, not a bare libuv callback (which lacks a V8 HandleScope).
+  napi_value name = nullptr;
+  napi_create_string_utf8(env, "node-gi:toggle-drain", NAPI_AUTO_LENGTH, &name);
+  napi_async_init(env, nullptr, name, &g_async_context);
+  g_drain_async_inited = true;
+}
+
+static void WakeDrain() {
+  if (g_drain_async_inited) uv_async_send(&g_drain_async);
+}
+
+// Apply a toggle on the JS thread: flip the canonical napi_ref strong↔weak.
+// Only flips on a real state transition (mirrors node-gtk's dying flag) and
+// probes liveness before touching a possibly-collected handle (crash mode 2).
+static void ApplyToggle(NodeGiInstance* inst, bool down) {
+  if (down) {
+    if (!inst->rooted) return;  // already weak
+    napi_value v = nullptr;
+    if (napi_get_reference_value(inst->env, inst->handle_ref, &v) == napi_ok && v != nullptr) {
+      uint32_t r = 0;
+      napi_reference_unref(inst->env, inst->handle_ref, &r);  // strong → weak
+    }
+    inst->rooted = false;
+  } else {
+    if (inst->rooted) return;  // already strong
+    napi_value v = nullptr;
+    if (napi_get_reference_value(inst->env, inst->handle_ref, &v) == napi_ok && v != nullptr) {
+      uint32_t r = 0;
+      napi_reference_ref(inst->env, inst->handle_ref, &r);  // weak → strong
+      inst->rooted = true;
+    }
+    // empty ⇒ the wrapper was already collected; a later WrapGObject resurrects.
+  }
+}
+
+// Run one wrapper's teardown on the JS thread: drop the toggle ref (may dispose →
+// emit → re-enter JS — legal here, not in a finalizer/off-thread), resurrection-
+// safely, then free the wrapper.
+//
+// ORDER MATTERS (node-gtk's GObjectTeardownIdle): remove_toggle_ref is LAST,
+// because dropping the last ref can take refcount to 0 → dispose → finalize → the
+// GObject is freed; any qdata/weak op after that would touch freed memory. So:
+//   (1) under the queue lock: detach qdata (only if it still points at US —
+//       resurrection-safe) AND cancel any queued off-thread toggles for this inst.
+//       Both under the lock — paired with the off-thread enqueue path, which
+//       re-reads qdata under the SAME lock — so a racing toggle either enqueues
+//       then gets cancelled here, or sees the cleared qdata and never enqueues;
+//       after this no NodeGiToggleNotify can find this inst.
+//   (2) g_object_weak_unref (drop the safety net before the unref below).
+//   (3) g_object_remove_toggle_ref LAST (may dispose → emit → re-enter JS, legal
+//       here on the JS thread; the object may be freed afterwards).
+static void RunTeardown(NodeGiInstance* inst) {
+  GObject* obj = inst->gobject;  // null if the weak-ref net already fired
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    if (obj != nullptr && g_object_get_qdata(obj, NodeGiWrapperQuark()) == inst) {
+      g_object_set_qdata(obj, NodeGiWrapperQuark(), nullptr);
+    }
+    for (auto it = g_toggle_queue.begin(); it != g_toggle_queue.end();) {
+      it = (it->inst == inst) ? g_toggle_queue.erase(it) : it + 1;
+    }
+  }
+  if (obj != nullptr) {
+    g_object_weak_unref(obj, OnGObjectFinalized, inst);
+    if (inst->toggle_added) g_object_remove_toggle_ref(obj, NodeGiToggleNotify, nullptr);
+  }
+  if (inst->handle_ref != nullptr) napi_delete_reference(inst->env, inst->handle_ref);
+  delete inst;
+}
+
+// Drain both queues on the JS/main thread. Snapshot under the lock, process
+// outside it (the work re-enters JS + GObject, which must not run under the
+// queue lock). New items queued during processing re-arm the async via their own
+// Wake/Enqueue. Toggles first, then teardowns (a teardown for an inst whose
+// toggle is in this snapshot is harmless — ApplyToggle's liveness probe skips a
+// finalized handle, and RunTeardown re-checks the live queue under the lock).
+static void DrainAsyncCb(uv_async_t*) {
+  if (g_async_env == nullptr || g_toggle_shutdown.load()) return;
+  Napi::Env env(g_async_env);
+  // A HandleScope is mandatory: ApplyToggle's napi_get_reference_value and the
+  // JS re-entry during teardown both create V8 handles, and a bare libuv callback
+  // has no scope. The CallbackScope additionally establishes the async context so
+  // signal emission during dispose runs as a proper N-API callback.
+  Napi::HandleScope handleScope(env);
+  Napi::CallbackScope callbackScope(env, g_async_context);
+
+  std::deque<ToggleItem> toggles;
+  std::deque<NodeGiInstance*> teardowns;
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    toggles.swap(g_toggle_queue);
+    teardowns.swap(g_teardown_queue);
+  }
+  for (const ToggleItem& item : toggles) {
+    if (!g_toggle_shutdown.load()) ApplyToggle(item.inst, item.down);
+  }
+  for (NodeGiInstance* inst : teardowns) {
+    RunTeardown(inst);
+  }
+}
+
+// The single toggle-notify for every node-gi GObject. Registered with data=NULL
+// (fungible — node-gtk pattern): the live wrapper is found via qdata, so a stale
+// teardown can remove ANY one toggle ref without orphaning a resurrected wrapper.
+static void NodeGiToggleNotify(gpointer /*data*/, GObject* obj, gboolean is_last_ref) {
+  if (g_toggle_shutdown.load()) return;
+  bool down = is_last_ref != FALSE;
+  if (OnMainThread()) {
+    // Fast path: same thread as construct/teardown, so no teardown can race us.
+    NodeGiInstance* inst =
+        static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
+    if (inst != nullptr) ApplyToggle(inst, down);
+    return;
+  }
+  // Off-thread (a GIO/GStreamer-worker unref): marshal to the JS thread. Re-read
+  // qdata + enqueue under the lock that RunTeardown also clears qdata under, so
+  // we never queue an inst that teardown has already (or is about to) free.
+  bool queued = false;
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    NodeGiInstance* inst =
+        static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
+    if (inst != nullptr) {
+      g_toggle_queue.push_back({inst, down});
+      queued = true;
+    }
+  }
+  if (queued) WakeDrain();  // outside the lock
+}
+
+// Weak-ref safety net: if C finalizes the GObject while we still hold the toggle
+// ref (defensive — a correct toggle ref prevents this), null the cached pointer
+// so teardown never touches freed memory.
+static void OnGObjectFinalized(gpointer data, GObject* /*where_the_object_was*/) {
+  NodeGiInstance* inst = static_cast<NodeGiInstance*>(data);
+  inst->gobject = nullptr;
+}
+
+// The canonical External's finalizer (napi_finalize, runs at a safe point post-GC
+// but where re-entering GObject teardown is still unsafe). Do the MINIMUM: queue
+// the teardown + wake the drain async (crash mode 1).
+static void NodeGiInstanceFinalize(Napi::Env /*env*/, GObject* /*data*/, NodeGiInstance* inst) {
+  if (inst == nullptr || inst->teardown_queued) return;
+  inst->teardown_queued = true;
+  {
+    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    g_teardown_queue.push_back(inst);
+  }
+  WakeDrain();
+}
+
+// Cache-aware factory: the caller owns exactly ONE non-floating "construction"
+// ref on obj. Returns the canonical External, establishing the toggle ref on a
+// cache miss / resurrecting on a collected hit, or adopting + balancing the ref
+// on a live hit.
 static Napi::Value MakeGObjectHandle(Napi::Env env, GObject* obj) {
-  Napi::External<GObject> ext = Napi::External<GObject>::New(
-      env, obj, [](Napi::Env, GObject* ptr) { g_object_unref(ptr); });
+  EnsureDrainAsync(env);  // wire the JS-thread drain before any toggle/teardown can queue
+  NodeGiInstance* existing =
+      static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
+  if (existing != nullptr) {
+    napi_value cached = nullptr;
+    if (napi_get_reference_value(env, existing->handle_ref, &cached) == napi_ok &&
+        cached != nullptr) {
+      g_object_unref(obj);  // drop the surplus construction ref; toggle ref owns obj
+      return Napi::Value(env, cached);
+    }
+    // collected hit (wrapper GC'd, idle teardown maybe pending) → resurrect below;
+    // the pending idle's "qdata == inst" guard stops it clobbering the new wrapper.
+  }
+
+  NodeGiInstance* inst = new NodeGiInstance();
+  inst->env = env;
+  inst->gobject = obj;
+  inst->rooted = true;
+  inst->toggle_added = false;
+  inst->teardown_queued = false;
+
+  Napi::External<GObject> ext =
+      Napi::External<GObject>::New(env, obj, NodeGiInstanceFinalize, inst);
   ext.TypeTag(&kGObjectHandleTag);
+  napi_create_reference(env, ext, 1, &inst->handle_ref);  // start STRONG (node-gtk invariant)
+
+  g_object_set_qdata(obj, NodeGiWrapperQuark(), inst);     // overwrite (resurrection-safe)
+  g_object_weak_ref(obj, OnGObjectFinalized, inst);        // safety net
+  g_object_add_toggle_ref(obj, NodeGiToggleNotify, nullptr);
+  inst->toggle_added = true;
+  // Drop the construction ref → only the toggle ref remains. If nothing else
+  // holds obj (refcount 2→1) this fires toggle-down synchronously, flipping the
+  // fresh wrapper to weak; if C holds another ref it stays strong (rooted).
+  g_object_unref(obj);
   return ext;
 }
 
-// Wrap a borrowed/owned GObject pointer as a node-gi handle. Floating refs are
-// sunk; a transfer-none borrow is ref'd so the finalizer has a ref to drop.
+// Wrap a borrowed/owned GObject pointer as the canonical node-gi handle. The
+// cache lookup happens BEFORE any refcount change so a live hit causes no
+// spurious toggle churn; only the miss/resurrect path takes a construction ref.
 static Napi::Value WrapGObject(Napi::Env env, GObject* obj, GITransfer transfer) {
   if (obj == nullptr) return env.Null();
+
+  NodeGiInstance* inst =
+      static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
+  if (inst != nullptr) {
+    napi_value cached = nullptr;
+    if (napi_get_reference_value(env, inst->handle_ref, &cached) == napi_ok && cached != nullptr) {
+      // Identity hit: return the canonical External, balancing the transfer (we
+      // already own obj via the toggle ref, so any ref the caller hands us is
+      // surplus and must be dropped).
+      if (g_object_is_floating(obj)) {
+        g_object_ref_sink(obj);
+        g_object_unref(obj);
+      } else if (transfer == GI_TRANSFER_EVERYTHING) {
+        g_object_unref(obj);
+      }
+      return Napi::Value(env, cached);
+    }
+    // collected hit → fall through and (re)build a fresh wrapper (resurrection).
+  }
+
+  // Miss / resurrect: get to "we own exactly one non-floating construction ref".
   if (g_object_is_floating(obj)) {
     g_object_ref_sink(obj);
   } else if (transfer == GI_TRANSFER_NOTHING) {
     g_object_ref(obj);
-  }
+  }  // GI_TRANSFER_EVERYTHING (non-floating): the caller already gave us the ref.
   return MakeGObjectHandle(env, obj);
 }
 
@@ -1668,14 +1978,11 @@ Napi::Value CallFunction(const Napi::CallbackInfo& info) {
 
 // ---- GObject lifecycle + properties (milestone 1) ----
 //
-// Construct GObjects, read/write their properties, and own them with an N-API
-// finalizer. Unlike node-gtk's NAN/V8-weak-callback model (which must defer the
-// unref to a GLib idle because V8 forbids calling into GObject during GC),
-// N-API finalizers run at a safe point OUTSIDE garbage collection, so a plain
-// g_object_unref in the finalizer is correct here. The toggle-ref dance is only
-// needed once JS-subclassed objects / JS-connected signal closures enter the
-// picture (the signals + registerClass drops); a plain owned ref suffices for
-// the headless-core object lifecycle.
+// Construct GObjects and read/write their properties. Ownership now flows through
+// the toggle-ref instance GC bridge above: ConstructGObject hands its single
+// construction ref to the cache-aware MakeGObjectHandle, which installs the
+// canonical toggle ref (so the wrapper is collectable when JS is the sole owner,
+// rooted when C also holds the object, and identity-stable + resurrectable).
 //
 // Instances are handed back as opaque Napi::External<GObject> handles; the
 // ergonomic class/prototype surface is layered in the GJS-compat runtime.
@@ -1883,10 +2190,10 @@ Napi::Value NewObject(const Napi::CallbackInfo& info) {
 //
 // Register a new GObject subclass of `parentNamespace.parentTypeName` named
 // `name`, inheriting the parent's class/instance layout. Supports custom
-// properties + signals (installed in class_init — see below); vfunc overrides
-// and the toggle-ref GC bridge a JS vfunc/closure requires land in the next
-// drop. A plain dynamic subtype's instances are ordinary GObjects, so the
-// existing finalizer-unref ownership is correct. Returns an opaque type handle
+// properties + signals (installed in class_init — see below) and vfunc overrides.
+// A dynamic subtype's instances are ordinary GObjects owned through the canonical
+// toggle-ref bridge (so a JS-subclassed instance kept by C stays rooted, keeping
+// its overridden-vfunc wrapper + JS state alive). Returns an opaque type handle
 // (the GType) for constructType().
 
 // GTypes are process-stable and never freed (static registration), so the
@@ -1908,9 +2215,8 @@ static GType UnwrapGType(Napi::Env env, Napi::Value v) {
 // Inherited (introspected-parent) properties still flow through the parent's
 // vfuncs — a property is "ours" iff its owner GType carries node-gi class-data.
 // Backing the values with a per-instance store (not C struct fields) keeps a
-// plain dynamic subtype's instances ordinary GObjects (the existing
-// finalizer-unref ownership stays correct). vfunc overrides + the toggle-ref GC
-// bridge a JS method/closure needs land in the next drop.
+// plain dynamic subtype's instances ordinary GObjects, owned through the
+// canonical toggle-ref bridge above.
 
 // Map a JS type-name to a GType (shared by property + signal specs).
 static GType TypeNameToGType(const std::string& t) {
@@ -2007,8 +2313,11 @@ struct NodeGiSignalDef {
 // Each override is held by a per-CLASS record carrying a STRONG napi_ref to the
 // JS impl plus the ffi closure written into the class vtable. Both live for the
 // class lifetime and are NEVER freed — a GType is process-permanent, so this is
-// the same ownership model as the signal class-handler, NOT a per-instance cycle:
-// no toggle-ref / instance-GC bridge is needed (that lands in a later drop).
+// the same ownership model as the signal class-handler (the override fn is
+// class-level, not per-instance). The INSTANCE the trampoline passes as `this`
+// goes through WrapGObject, so it resolves to the canonical toggle-ref wrapper —
+// the same handle construct returns (and that vfunc `this` keeps that wrapper +
+// its JS state alive while C owns a JS-subclassed instance).
 //
 // In class_init the vfunc info is resolved by walking the parent object-info
 // chain (gi_object_info_find_vfunc), the vtable slot is located via the matching
@@ -3249,12 +3558,16 @@ Napi::Value IsVariantHandle(const Napi::CallbackInfo& info) {
 // converts the signal's GValue params to JS (skipping the emitter instance at
 // index 0) and the JS return into the signal return GValue.
 //
-// Caveat (documented): if the JS callback closes over the object's handle, that
-// forms a handle -> GObject -> closure -> napi_ref -> callback -> handle cycle
-// that V8's GC cannot break across the C boundary, so such a handler keeps the
-// object alive until explicitly disconnected. The toggle-ref refinement (with
-// the subclassing/registerClass drop) addresses this; for now disconnect
-// long-lived handlers explicitly.
+// Narrowed-leak semantics (with the toggle-ref bridge): a handler that does NOT
+// close over its own object is now collectable once C is the sole owner
+// (toggle-down → weak → GC). A handler that DOES close over its object forms a
+// GObject -> GClosure -> napi_ref -> callback -> wrapper -> handle cycle the GC
+// cannot break across C, so it keeps the object alive until disconnect — which is
+// the GJS-faithful contract (a connected self-referential handler is a reason to
+// stay alive). disconnect drops the closure's napi_ref (JsClosureFinalize),
+// breaking the cycle so the next GC collects the object. The callback ref stays
+// STRONG while connected (a connected handler must fire). Verified by the
+// signal-cycle case in test/gc-identity.test.mjs.
 
 struct JsClosureData {
   napi_env env;
@@ -3547,7 +3860,23 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
 
 }  // namespace
 
+// Toggle-queue shutdown: disable toggles before the env tears down so no
+// toggle-notify touches a dead env (GJS's gjs_object_shutdown_toggle_queue), and
+// close the drain async so the libuv loop can exit cleanly. Any still-queued
+// teardowns are intentionally dropped (the process/env is going away).
+static void OnEnvShutdown(void* /*arg*/) {
+  g_toggle_shutdown.store(true);
+  if (g_drain_async_inited) {
+    uv_close(reinterpret_cast<uv_handle_t*>(&g_drain_async), nullptr);
+    g_drain_async_inited = false;
+  }
+}
+
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  // Capture the JS/main thread — toggle refs may only touch the napi_ref here.
+  g_main_thread_id = std::this_thread::get_id();
+  g_main_thread_id_set = true;
+  napi_add_env_cleanup_hook(env, OnEnvShutdown, nullptr);
   exports.Set("requireNamespace", Napi::Function::New(env, RequireNamespace));
   exports.Set("listInfoNames", Napi::Function::New(env, ListInfoNames));
   exports.Set("findInfo", Napi::Function::New(env, FindInfo));

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -514,7 +514,12 @@ struct ToggleItem {
   NodeGiInstance* inst;
   bool down;  // true = toggle-down (→ weak), false = toggle-up (→ strong)
 };
-static std::mutex g_queue_mutex;
+// RECURSIVE: the drain (DrainAsyncCb) holds the lock across the WHOLE drain and
+// RunTeardown re-enters JS (dispose → signal/vfunc) which reentrantly re-acquires
+// the lock on the SAME thread (RunTeardown's own lock + a reentrant WrapGObject →
+// SettleCollectedInstance / NodeGiToggleNotify). A plain mutex would self-deadlock;
+// GJS's ToggleQueue lock is recursive for exactly this reason.
+static std::recursive_mutex g_queue_mutex;
 static std::deque<ToggleItem> g_toggle_queue;
 static std::deque<NodeGiInstance*> g_teardown_queue;
 static uv_async_t g_drain_async;
@@ -533,7 +538,7 @@ static void OnGObjectFinalized(gpointer, GObject*);
 // g_async_* are read off-thread (WakeDrain), so they are written under g_queue_mutex.
 static void EnsureDrainAsync(napi_env env) {
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     if (g_drain_async_inited) return;
   }
   uv_loop_t* loop = nullptr;
@@ -548,7 +553,7 @@ static void EnsureDrainAsync(napi_env env) {
   napi_async_context ctx = nullptr;
   napi_async_init(env, nullptr, name, &ctx);
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     g_async_env = env;
     g_async_context = ctx;
     // This env owns the machinery; its thread is the JS/main thread for toggles.
@@ -563,7 +568,7 @@ static void EnsureDrainAsync(napi_env env) {
 // locked flag-flip-before-close — so an off-thread toggle can never uv_async_send a
 // handle that is being / has been closed (the shutdown TOCTOU that aborted libuv).
 static void WakeDrain() {
-  std::lock_guard<std::mutex> guard(g_queue_mutex);
+  std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
   if (g_drain_async_inited && !g_toggle_shutdown.load()) {
     uv_async_send(&g_drain_async);
   }
@@ -612,7 +617,7 @@ static void ApplyToggle(NodeGiInstance* inst, bool down) {
 static void RunTeardown(NodeGiInstance* inst) {
   GObject* obj = inst->gobject;  // null if the weak-ref net already fired
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     if (obj != nullptr && g_object_get_qdata(obj, NodeGiWrapperQuark()) == inst) {
       g_object_set_qdata(obj, NodeGiWrapperQuark(), nullptr);
     }
@@ -628,12 +633,20 @@ static void RunTeardown(NodeGiInstance* inst) {
   delete inst;
 }
 
-// Drain both queues on the JS/main thread. Snapshot under the lock, process
-// outside it (the work re-enters JS + GObject, which must not run under the
-// queue lock). New items queued during processing re-arm the async via their own
-// Wake/Enqueue. Toggles first, then teardowns (a teardown for an inst whose
-// toggle is in this snapshot is harmless — ApplyToggle's liveness probe skips a
-// finalized handle, and RunTeardown re-checks the live queue under the lock).
+// Drain both queues on the JS/main thread. Mirrors GJS idle_handle_toggle →
+// handle_all_toggles under Locked: hold the (recursive) lock across the WHOLE drain
+// and pop the LIVE queues ONE item at a time — do NOT swap into a stack snapshot.
+//
+// Why: RunTeardown's g_object_remove_toggle_ref can drive dispose → a live JS
+// signal/vfunc → reentrant JS that wraps a GObject → SettleCollectedInstance(old),
+// whose cancel loop scans g_teardown_queue to drop `old`'s pending teardown. With a
+// swap-then-process snapshot, an in-flight `old` is NOT in the live queue, so the
+// scan can't cancel it; SettleCollectedInstance then deletes it and the outer loop
+// later derefs freed memory + double-removes the resurrected wrapper's toggle ref.
+// Popping the LIVE queue (and removing the current item BEFORE running it) keeps the
+// remaining pending items visible + cancellable by a reentrant SettleCollectedInstance.
+// The recursive lock lets RunTeardown's own lock + the reentrant wrap re-lock on this
+// thread; off-thread actors block until the drain completes.
 static void DrainAsyncCb(uv_async_t*) {
   if (g_async_env == nullptr || g_toggle_shutdown.load()) return;
   Napi::Env env(g_async_env);
@@ -644,18 +657,20 @@ static void DrainAsyncCb(uv_async_t*) {
   Napi::HandleScope handleScope(env);
   Napi::CallbackScope callbackScope(env, g_async_context);
 
-  std::deque<ToggleItem> toggles;
-  std::deque<NodeGiInstance*> teardowns;
-  {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
-    toggles.swap(g_toggle_queue);
-    teardowns.swap(g_teardown_queue);
-  }
-  for (const ToggleItem& item : toggles) {
-    if (!g_toggle_shutdown.load()) ApplyToggle(item.inst, item.down);
-  }
-  for (NodeGiInstance* inst : teardowns) {
-    RunTeardown(inst);
+  std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
+  // Toggles take priority (drain to empty before each teardown); a toggle enqueued
+  // during a teardown's dispose is processed next. Terminates when both are empty.
+  while (!g_toggle_queue.empty() || !g_teardown_queue.empty()) {
+    if (g_toggle_shutdown.load()) return;
+    if (!g_toggle_queue.empty()) {
+      ToggleItem item = g_toggle_queue.front();
+      g_toggle_queue.pop_front();
+      ApplyToggle(item.inst, item.down);
+      continue;
+    }
+    NodeGiInstance* inst = g_teardown_queue.front();
+    g_teardown_queue.pop_front();  // remove BEFORE running, so a reentrant resurrect
+    RunTeardown(inst);             // of THIS inst takes the miss path, not collected-hit
   }
 }
 
@@ -703,7 +718,7 @@ static void NodeGiToggleNotify(gpointer /*data*/, GObject* obj, gboolean is_last
   bool main_thread = OnMainThread();
   bool enqueued = false;
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     if (g_toggle_shutdown.load()) return;  // re-check under the lock
     NodeGiInstance* inst =
         static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
@@ -732,7 +747,7 @@ static void NodeGiInstanceFinalize(Napi::Env /*env*/, GObject* /*data*/, NodeGiI
   if (inst == nullptr || inst->teardown_queued) return;
   inst->teardown_queued = true;
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     // After shutdown nothing will drain, so don't grow the queue (the env is going
     // away; the inst leaks with it — same as a dropped pending teardown).
     if (g_toggle_shutdown.load()) return;
@@ -750,7 +765,7 @@ static void NodeGiInstanceFinalize(Napi::Env /*env*/, GObject* /*data*/, NodeGiI
 // the drain thread), so the pending idle teardown cannot be running concurrently.
 static void SettleCollectedInstance(GObject* obj, NodeGiInstance* old) {
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     // Cancel old's pending teardown + any queued toggles that reference it, so the
     // drain never touches a freed inst (paired with the off-thread enqueue, which
     // re-reads qdata under this SAME lock — and we clear qdata below).
@@ -848,7 +863,16 @@ static Napi::Value WrapGObject(Napi::Env env, GObject* obj, GITransfer transfer)
 
   NodeGiInstance* inst =
       static_cast<NodeGiInstance*>(g_object_get_qdata(obj, NodeGiWrapperQuark()));
-  if (inst != nullptr) {
+  // Multi-env (worker_threads) safety: the qdata cache is process-global, but
+  // inst->handle_ref is a napi_ref rooted in inst->env's isolate. ONLY that env may
+  // dereference it — napi_get_reference_value with a FOREIGN env is a cross-env UAF /
+  // V8 abort (e.g. a worker that obtains a process-shared singleton like
+  // Gio.Vfs.get_default() that the owner env already wrapped). A non-owner env skips
+  // the cache and takes the plain strong-ref path via MakeGObjectHandle (which gates
+  // the same way). inst->env is immutable, so this guard is race-free regardless of
+  // g_owner_env store ordering — MakeGObjectHandle's gate alone was NOT enough,
+  // because this cache-hit fast path runs BEFORE MakeGObjectHandle.
+  if (inst != nullptr && inst->env == static_cast<napi_env>(env)) {
     napi_value cached = nullptr;
     if (napi_get_reference_value(env, inst->handle_ref, &cached) == napi_ok && cached != nullptr) {
       // Identity hit: return the canonical External, balancing the transfer (we
@@ -862,10 +886,10 @@ static Napi::Value WrapGObject(Napi::Env env, GObject* obj, GITransfer transfer)
       }
       return Napi::Value(env, cached);
     }
-    // collected hit → fall through and (re)build a fresh wrapper (resurrection).
+    // collected hit (our env) → fall through and (re)build a fresh wrapper (resurrection).
   }
 
-  // Miss / resurrect: get to "we own exactly one non-floating construction ref".
+  // Miss / resurrect / cross-env share: own exactly one non-floating construction ref.
   if (g_object_is_floating(obj)) {
     g_object_ref_sink(obj);
   } else if (transfer == GI_TRANSFER_NOTHING) {
@@ -4038,7 +4062,7 @@ static void OnEnvShutdown(void* arg) {
   if (g_owner_env.load() != static_cast<napi_env>(arg)) return;
   bool close_async = false;
   {
-    std::lock_guard<std::mutex> guard(g_queue_mutex);
+    std::lock_guard<std::recursive_mutex> guard(g_queue_mutex);
     g_toggle_shutdown.store(true);
     if (g_drain_async_inited) {
       g_drain_async_inited = false;  // disable further sends FIRST (under the lock)

--- a/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
+++ b/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
@@ -16,6 +16,13 @@
 //   * MULTI-ENV safety (worker_threads) — node-gi loaded on several OS threads at
 //     once: concurrent owner-claim (compare_exchange) + per-env env-cleanup, no
 //     cross-env napi UAF (residual minor: multi-env).
+//   * CROSS-ENV CACHE-HIT (DEFECT 1) — a worker env that obtains a process-shared
+//     GObject singleton (Gio.Vfs.get_default()) the OWNER env already wrapped must
+//     NOT deref the owner-isolate napi_ref from WrapGObject's cache-hit fast path.
+//   * REENTRANT DRAIN (DEFECT 2) — a registerClass vfunc_dispose that re-enters the
+//     engine (wraps GObjects) DURING the idle teardown drain, with other teardowns
+//     pending in the SAME drain: validates the recursive-lock-across-drain design
+//     (a non-recursive lock would self-deadlock; a swap-snapshot would double-free).
 //
 // The off-thread vehicle is a TEST-ONLY native helper (__stressRefUnrefOffThread)
 // — there is no headless pure-JS way to make another OS thread ref/unref a wrapped
@@ -36,7 +43,13 @@ import { writeFileSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { newObject, callMethod, isGObjectHandle, requireNamespace } from '../index.js';
+import {
+  newObject,
+  callMethod,
+  callStaticMethod,
+  isGObjectHandle,
+  requireNamespace,
+} from '../index.js';
 import { requireGi } from '../gi.js';
 
 const require = createRequire(import.meta.url);
@@ -268,4 +281,117 @@ test('soak: randomized off-thread churn + main churn + GC stays crash-free', gcO
   await settle();
   const mb = process.memoryUsage().rss / (1024 * 1024);
   assert.ok(mb < 1024, `RSS bounded after randomized soak, was ${mb.toFixed(0)} MiB`);
+});
+
+// ---- 8: DEFECT 1 — cross-env cache-hit on a process-shared singleton ----
+// The OWNER env wraps a process-global singleton S (Gio.Vfs.get_default()), setting
+// qdata(S)=ownerInst. A worker env independently obtains the SAME S via the SAME
+// static getter and wraps it. Pre-fix, WrapGObject's cache-hit fast path derefed
+// ownerInst->handle_ref (a napi_ref rooted in the OWNER isolate) from the WORKER
+// isolate → cross-env UAF / V8 abort. Post-fix the worker sees inst->env != its env
+// and takes the plain strong-ref path. Asserts every worker completes (no crash) and
+// can USE the singleton it fetched.
+test('cross-env: a worker wrapping a singleton the owner cached does not UAF (DEFECT 1)', async () => {
+  // Owner wraps S first and HOLDS it, so qdata(S)=ownerInst stays set for the workers.
+  const ownerVfs = callStaticMethod('Gio', 'Vfs', 'get_default', []);
+  assert.equal(isGObjectHandle(ownerVfs), true);
+  assert.strictEqual(
+    callStaticMethod('Gio', 'Vfs', 'get_default', []),
+    ownerVfs,
+    'owner-env identity holds for the singleton',
+  );
+  const workerCode = `
+    const { parentPort, workerData } = require('node:worker_threads');
+    (async () => {
+      const { callStaticMethod, callMethod, isGObjectHandle, requireNamespace } =
+        await import(workerData.index);
+      requireNamespace('Gio', '2.0');
+      let used = 0;
+      for (let i = 0; i < 1500; i++) {
+        // Fetch the SAME process-global singleton the OWNER already wrapped+cached.
+        const vfs = callStaticMethod('Gio', 'Vfs', 'get_default', []);
+        if (!isGObjectHandle(vfs)) throw new Error('not a GObject handle');
+        // Use it (a real method call on a cross-env-shared singleton).
+        const schemes = callMethod(vfs, 'get_supported_uri_schemes', []);
+        if (Array.isArray(schemes)) used++;
+      }
+      parentPort.postMessage({ used });
+    })().catch((e) => { parentPort.postMessage({ error: String(e && e.message || e) }); });
+  `;
+  const spawnWorker = () =>
+    new Promise((resolve, reject) => {
+      const w = new Worker(workerCode, { eval: true, workerData: { index: indexUrl } });
+      w.on('message', resolve);
+      w.on('error', reject);
+      w.on('exit', (code) => {
+        if (code !== 0) reject(new Error('worker exit ' + code));
+      });
+    });
+  const results = await Promise.all([spawnWorker(), spawnWorker(), spawnWorker(), spawnWorker()]);
+  for (const r of results) {
+    assert.equal(r.error, undefined, `worker ran without a cross-env crash: ${r.error}`);
+    assert.equal(r.used, 1500, 'the worker used the cross-env-shared singleton every time');
+  }
+  // The owner's wrapper is still valid + identical after the workers churned the singleton.
+  assert.strictEqual(callStaticMethod('Gio', 'Vfs', 'get_default', []), ownerVfs);
+});
+
+// ---- 9: DEFECT 2 — reentrant wrap during the teardown drain ----
+// A registerClass vfunc_dispose runs DURING the idle teardown drain (its instance
+// reached refcount 0 when RunTeardown dropped the toggle ref). Inside it we re-enter
+// the engine — create + round-trip GObjects AND resurrect a sibling. With many such
+// instances dropped together, their teardowns batch into ONE drain, so each dispose
+// re-enters while OTHER teardowns are still pending. This validates the DEFECT-2 fix:
+//   * recursive lock — the reentrant WrapGObject re-acquires g_queue_mutex on the
+//     drain thread; a non-recursive lock-across-drain would SELF-DEADLOCK (this test
+//     would hang → the runner times out);
+//   * pop-the-LIVE-queue — a reentrant SettleCollectedInstance can still see + cancel
+//     a pending sibling teardown (a swap-snapshot would double-free it).
+test('reentrant-drain: vfunc_dispose re-entering the engine mid-drain is safe (DEFECT 2)', gcOpts, async () => {
+  const GObject = requireGi('GObject', '2.0');
+  const Gio = requireGi('Gio', '2.0');
+  let disposed = 0;
+  let reentrantOk = 0;
+  let resurrectOk = 0;
+  // A shared group whose action is dropped+re-created each dispose, so a dispose can
+  // resurrect a just-collected sibling action (exercising SettleCollectedInstance
+  // reentrancy from inside the drain).
+  // A shared group holding a 'shared' action whose wrapper goes weak between disposes,
+  // so a dispose's re-fetch re-enters WrapGObject for a GObject mid-lifecycle.
+  const group = new Gio.SimpleActionGroup();
+  class Disposer extends GObject.Object {
+    vfunc_dispose() {
+      disposed++;
+      // (a) plain reentrant create + round-trip identity, under the held drain lock.
+      const g = new Gio.SimpleActionGroup();
+      const a = new Gio.SimpleAction({ name: 'r', enabled: true });
+      g.add_action(a);
+      if (g.lookup_action('r') === a) reentrantOk++;
+      // (b) re-fetch + churn a sibling from the shared group: re-enters WrapGObject
+      // (resurrection path) from inside the drain. Must not crash.
+      const prev = group.lookup_action('shared');
+      if (prev !== undefined) resurrectOk++;
+      group.remove_action('shared');
+      group.add_action(new Gio.SimpleAction({ name: 'shared', enabled: true }));
+    }
+  }
+  const Klass = GObject.registerClass({ GTypeName: 'NodeGiReentrantDrainDisposer' }, Disposer);
+  group.add_action(new Gio.SimpleAction({ name: 'shared', enabled: true }));
+  for (let round = 0; round < 30; round++) {
+    // Batch: create many, drop them all, then GC so their teardowns drain together.
+    (() => {
+      for (let i = 0; i < 25; i++) new Klass();
+    })();
+    await settle(2);
+  }
+  assert.ok(disposed >= 30 * 25 * 0.8, `most disposers ran their vfunc_dispose, got ${disposed}`);
+  assert.equal(reentrantOk, disposed, 'reentrant create+round-trip identity held in every dispose');
+  assert.equal(resurrectOk, disposed, 'reentrant sibling resurrection was safe in every dispose');
+  // The engine is still fully functional after all the reentrant drains.
+  const g = new Gio.SimpleActionGroup();
+  const a = new Gio.SimpleAction({ name: 'after', enabled: true });
+  g.add_action(a);
+  assert.strictEqual(g.lookup_action('after'), a, 'identity + toggle accounting intact after reentrant drains');
+  const mb = process.memoryUsage().rss / (1024 * 1024);
+  assert.ok(mb < 1024, `RSS bounded after reentrant-drain stress, was ${mb.toFixed(0)} MiB`);
 });

--- a/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
+++ b/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: MIT
+// CROSS-THREAD GC + toggle-ref stress for @gjsify/node-gi.
+//
+// The single-threaded gc-identity suite cannot reach the load-bearing concurrency
+// paths the toggle-ref bridge exists for. This suite drives GENUINE off-thread
+// GObject refcount churn and multi-env (worker_threads) pressure to exercise:
+//
+//   * NodeGiToggleNotify's OFF-THREAD branch — a background GThread does
+//     g_object_ref/g_object_unref on a wrapped GObject, crossing the toggle 1<->2
+//     boundary from a non-main thread (MAJOR A: the wrong-flip / lost-toggle bug).
+//     Validated to fire tens of thousands of off-thread toggles per run.
+//   * The opposite-direction enqueue CANCEL + WakeDrain + the JS-thread drain.
+//   * The SHUTDOWN race — a process that exits while a background thread is still
+//     firing off-thread toggles, racing OnEnvShutdown's flag-flip + uv_close
+//     against an off-thread WakeDrain (MAJOR B: the TOCTOU / data-race abort).
+//   * MULTI-ENV safety (worker_threads) — node-gi loaded on several OS threads at
+//     once: concurrent owner-claim (compare_exchange) + per-env env-cleanup, no
+//     cross-env napi UAF (residual minor: multi-env).
+//
+// The off-thread vehicle is a TEST-ONLY native helper (__stressRefUnrefOffThread)
+// — there is no headless pure-JS way to make another OS thread ref/unref a wrapped
+// GObject (GIO local-file async keeps its refcount ops on the main thread). It is
+// the "GLib thread doing g_object_ref/unref on a shared object" vehicle the task
+// names; it is NOT part of the public API (prefixed __, loaded straight off the
+// native addon here, never re-exported from index.js).
+//
+// Run with `node --test --expose-gc` for the leak/collection assertions; without
+// --expose-gc the off-thread churn still runs (GC-gated assertions self-skip).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { newObject, callMethod, isGObjectHandle, requireNamespace } from '../index.js';
+import { requireGi } from '../gi.js';
+
+const require = createRequire(import.meta.url);
+// Resolve the SAME addon index.js loads (require caches native modules by path, so
+// this is the identical instance — same env, same toggle machinery). Try Release
+// then Debug, mirroring index.js's loader.
+const addonPath = ['../build/Release/node_gi.node', '../build/Debug/node_gi.node']
+  .map((p) => fileURLToPath(new URL(p, import.meta.url)))
+  .find((p) => existsSync(p));
+const native = require(addonPath);
+const indexUrl = new URL('../index.js', import.meta.url).href;
+
+requireNamespace('Gio', '2.0');
+requireNamespace('GObject', '2.0');
+
+const hasGc = typeof globalThis.gc === 'function';
+const gcOpts = hasGc ? {} : { skip: 'run with --expose-gc for the GC cases' };
+const gc = hasGc ? globalThis.gc : () => {};
+
+async function settle(passes = 4) {
+  for (let i = 0; i < passes; i++) {
+    gc();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+// Pump libuv + GC while the background churn thread runs, so the drain (uv_async)
+// processes the off-thread toggle queue concurrently with the churn.
+async function awaitChurn({ withGc = true, maxPolls = 20000 } = {}) {
+  let polls = 0;
+  while (native.__stressRefUnrefRunning() && polls < maxPolls) {
+    await new Promise((r) => setImmediate(r));
+    if (withGc && (polls & 7) === 0) gc();
+    polls++;
+  }
+  assert.equal(native.__stressRefUnrefRunning(), false, 'the off-thread churn finished in time');
+}
+
+// ---- 1: off-thread toggle churn on a held object — identity + no crash ----
+test('off-thread: a held object survives heavy cross-thread ref/unref churn', async () => {
+  const a = newObject('Gio', 'SimpleAction', { name: 'held', enabled: true });
+  native.__stressRefUnrefOffThread(a, 40000); // 40k ref + 40k unref = 80k off-thread toggles
+  await awaitChurn();
+  await settle(2);
+  // The toggle ref + the JS-reachable wrapper keep the object alive through every
+  // 1<->2 crossing — no wrong-flip collection, no use-after-free.
+  assert.equal(isGObjectHandle(a), true, 'the churned handle is intact');
+  assert.equal(callMethod(a, 'get_name', []), 'held', 'the object is still usable after churn');
+});
+
+// ---- 2: off-thread churn interleaved with collecting many unowned wrappers ----
+test('off-thread: churn + concurrent collection stays crash-free + bounded', gcOpts, async () => {
+  const a = newObject('Gio', 'SimpleAction', { name: 'anchor', enabled: true });
+  native.__stressRefUnrefOffThread(a, 60000);
+  let collected = 0;
+  const reg = new FinalizationRegistry(() => {
+    collected++;
+  });
+  const N = 400;
+  // Create + drop unowned wrappers while the background thread churns `a`: the drain
+  // is processing off-thread toggles for `a` at the same time GC is finalizing these.
+  (() => {
+    for (let i = 0; i < N; i++) {
+      const t = newObject('Gio', 'SimpleAction', { name: 'tmp' + i, enabled: (i & 1) === 0 });
+      reg.register(t, i);
+    }
+  })();
+  await awaitChurn();
+  await settle();
+  assert.equal(isGObjectHandle(a), true, 'the anchor survived churn under GC pressure');
+  assert.ok(collected >= N * 0.8, `most unowned wrappers collected during churn, got ${collected}`);
+  const start = process.memoryUsage().rss / (1024 * 1024);
+  assert.ok(start < 1024, `RSS bounded after churn+collection, was ${start.toFixed(0)} MiB`);
+});
+
+// ---- 3: a churned object is collectable once dropped (post-churn teardown) ----
+test('off-thread: a churned object is collected after its wrapper is dropped', gcOpts, async () => {
+  let collected = 0;
+  const reg = new FinalizationRegistry(() => {
+    collected++;
+  });
+  await (async () => {
+    const a = newObject('Gio', 'SimpleAction', { name: 'drop', enabled: true });
+    reg.register(a, 'drop');
+    native.__stressRefUnrefOffThread(a, 20000);
+    await awaitChurn(); // churn MUST finish before `a` can be freed (else the thread UAFs)
+  })();
+  await settle();
+  assert.equal(collected, 1, 'after churn ends + the wrapper is dropped, the object is collected');
+});
+
+// ---- 4: SHUTDOWN race — exit while an off-thread churn is in flight ----
+// A child process starts a very long off-thread churn then exits almost immediately,
+// so OnEnvShutdown (flag-flip + uv_close, under the lock) races a still-running
+// off-thread WakeDrain (uv_async_send, gated on the same lock+flag). A regression
+// (the MAJOR B TOCTOU) aborts libuv → non-zero status / a fatal signal. Run several
+// times to make the race land.
+test('shutdown: exiting mid-churn never aborts (MAJOR B TOCTOU)', () => {
+  const script = `
+import { newObject, requireNamespace } from ${JSON.stringify(indexUrl)};
+import { createRequire } from 'node:module';
+const require = createRequire(${JSON.stringify(import.meta.url)});
+const native = require(${JSON.stringify(addonPath)});
+requireNamespace('Gio','2.0');
+// Several background churn threads → many concurrent off-thread WakeDrain calls,
+// maximising the chance one lands right as OnEnvShutdown closes the async.
+const held = [];
+for (let i = 0; i < 8; i++) {
+  const a = newObject('Gio','SimpleAction',{ name:'x'+i, enabled:true });
+  held.push(a);
+  native.__stressRefUnrefOffThread(a, 50000000); // long — still churning at exit
+}
+// Let JS go idle immediately; the uv_async is unref'd so node exits while the
+// background threads are mid-churn → OnEnvShutdown races the off-thread WakeDrain.
+`;
+  const file = join(tmpdir(), `node-gi-shutdown-race-${process.pid}-${Date.now()}.mjs`);
+  writeFileSync(file, script);
+  try {
+    for (let i = 0; i < 12; i++) {
+      const r = spawnSync(process.execPath, [file], { timeout: 15000 });
+      assert.equal(r.signal, null, `iter ${i}: exited without a fatal signal (got ${r.signal})`);
+      assert.equal(r.status, 0, `iter ${i}: clean exit status (got ${r.status})`);
+    }
+  } finally {
+    rmSync(file, { force: true });
+  }
+});
+
+// ---- 5: MULTI-ENV — node-gi on several worker_threads concurrently ----
+// Each Worker is a separate N-API env on its own OS thread. Concurrent owner-claim
+// (compare_exchange) + per-env env-cleanup must not crash or UAF; a non-owner env
+// uses the plain strong-ref path (no identity), proven by `ok === 0` below.
+test('multi-env: concurrent worker_threads churn is crash-free; per-env shutdown is clean', async () => {
+  // Main thread claims toggle-machinery ownership first.
+  newObject('Gio', 'SimpleActionGroup', {});
+  const workerCode = `
+    const { parentPort, workerData } = require('node:worker_threads');
+    (async () => {
+      const { newObject, callMethod, requireNamespace } = await import(workerData.index);
+      requireNamespace('Gio', '2.0');
+      let ok = 0;
+      for (let i = 0; i < 4000; i++) {
+        const g = newObject('Gio', 'SimpleActionGroup', {});
+        const a = newObject('Gio', 'SimpleAction', { name: 'w', enabled: (i & 1) === 0 });
+        callMethod(g, 'add_action', [a]);
+        const back = callMethod(g, 'lookup_action', ['w']);
+        if (back === a) ok++;
+      }
+      parentPort.postMessage({ ok });
+    })().catch((e) => { parentPort.postMessage({ error: String(e && e.message || e) }); });
+  `;
+  const spawnWorker = () =>
+    new Promise((resolve, reject) => {
+      const w = new Worker(workerCode, { eval: true, workerData: { index: indexUrl } });
+      w.on('message', resolve);
+      w.on('error', reject);
+      w.on('exit', (code) => {
+        if (code !== 0) reject(new Error('worker exit ' + code));
+      });
+    });
+  const workers = [spawnWorker(), spawnWorker(), spawnWorker(), spawnWorker()];
+  // Main thread churns concurrently with the workers.
+  for (let i = 0; i < 4000; i++) {
+    const g = newObject('Gio', 'SimpleActionGroup', {});
+    const a = newObject('Gio', 'SimpleAction', { name: 'm', enabled: true });
+    callMethod(g, 'add_action', [a]);
+    assert.strictEqual(callMethod(g, 'lookup_action', ['m']), a, 'owner-env identity holds');
+    if ((i & 0x3ff) === 0) gc();
+  }
+  const results = await Promise.all(workers);
+  for (const r of results) {
+    assert.equal(r.error, undefined, `worker ran without error: ${r.error}`);
+    // A non-owner env takes the plain strong-ref path → no wrapper identity.
+    assert.equal(r.ok, 0, 'a non-owner (worker) env does not get wrapper identity (plain-ref path)');
+  }
+  await settle(2);
+  const mb = process.memoryUsage().rss / (1024 * 1024);
+  assert.ok(mb < 1024, `RSS bounded after multi-env soak, was ${mb.toFixed(0)} MiB`);
+});
+
+// ---- 6: MULTI-ENV — terminate a busy worker; the owner env keeps working ----
+// A worker exiting (its env cleanup runs) must not disable the OWNER env's drain
+// async or set the global shutdown flag (per-env OnEnvShutdown gate).
+test('multi-env: terminating busy workers leaves the owner env fully working', async () => {
+  const busyCode = `
+    const { workerData } = require('node:worker_threads');
+    (async () => {
+      const { newObject, callMethod, requireNamespace } = await import(workerData.index);
+      requireNamespace('Gio', '2.0');
+      for (;;) {
+        const g = newObject('Gio', 'SimpleActionGroup', {});
+        const a = newObject('Gio', 'SimpleAction', { name: 'b', enabled: true });
+        callMethod(g, 'add_action', [a]);
+      }
+    })();
+  `;
+  for (let i = 0; i < 6; i++) {
+    const w = new Worker(busyCode, { eval: true, workerData: { index: indexUrl } });
+    await new Promise((r) => setTimeout(r, 25)); // let it get busy
+    await w.terminate();
+  }
+  // The owner env must still wrap with identity + toggle correctly after the churn.
+  const Gio = requireGi('Gio', '2.0');
+  const group = new Gio.SimpleActionGroup();
+  const action = new Gio.SimpleAction({ name: 'after', enabled: true });
+  group.add_action(action);
+  assert.strictEqual(group.lookup_action('after'), action, 'owner env intact after worker teardown');
+  await settle(2);
+});
+
+// ---- 7: randomized concurrency soak (the non-deterministic safety net) ----
+test('soak: randomized off-thread churn + main churn + GC stays crash-free', gcOpts, async () => {
+  for (let round = 0; round < 6; round++) {
+    const a = newObject('Gio', 'SimpleAction', { name: 'r' + round, enabled: true });
+    const iters = 5000 + Math.floor(Math.random() * 25000);
+    native.__stressRefUnrefOffThread(a, iters);
+    // Main churn + round-trips while the background thread fires off-thread toggles.
+    while (native.__stressRefUnrefRunning()) {
+      const g = newObject('Gio', 'SimpleActionGroup', {});
+      const b = newObject('Gio', 'SimpleAction', { name: 'soak', enabled: (round & 1) === 0 });
+      callMethod(g, 'add_action', [b]);
+      assert.strictEqual(callMethod(g, 'lookup_action', ['soak']), b, 'identity holds during churn');
+      if (Math.random() < 0.2) gc();
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.equal(callMethod(a, 'get_name', []), 'r' + round, 'churned object usable after the round');
+  }
+  await settle();
+  const mb = process.memoryUsage().rss / (1024 * 1024);
+  assert.ok(mb < 1024, `RSS bounded after randomized soak, was ${mb.toFixed(0)} MiB`);
+});

--- a/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
+++ b/packages/node-gi/node-gi/test/gc-cross-thread.test.mjs
@@ -21,8 +21,11 @@
 //     NOT deref the owner-isolate napi_ref from WrapGObject's cache-hit fast path.
 //   * REENTRANT DRAIN (DEFECT 2) — a registerClass vfunc_dispose that re-enters the
 //     engine (wraps GObjects) DURING the idle teardown drain, with other teardowns
-//     pending in the SAME drain: validates the recursive-lock-across-drain design
-//     (a non-recursive lock would self-deadlock; a swap-snapshot would double-free).
+//     pending in the SAME drain: a swap-snapshot would double-free a resurrected
+//     sibling; popping the live queue one-at-a-time keeps it cancellable.
+//   * DRAIN LOCK LIVENESS — the queue lock is NOT held across a teardown's dispose
+//     vfunc: an off-thread churn keeps progressing while a dispose blocks the main
+//     thread (a held-across-dispose lock would freeze it → priority inversion / ABBA).
 //
 // The off-thread vehicle is a TEST-ONLY native helper (__stressRefUnrefOffThread)
 // — there is no headless pure-JS way to make another OS thread ref/unref a wrapped
@@ -362,7 +365,7 @@ test('reentrant-drain: vfunc_dispose re-entering the engine mid-drain is safe (D
   class Disposer extends GObject.Object {
     vfunc_dispose() {
       disposed++;
-      // (a) plain reentrant create + round-trip identity, under the held drain lock.
+      // (a) plain reentrant create + round-trip identity from inside a teardown dispose.
       const g = new Gio.SimpleActionGroup();
       const a = new Gio.SimpleAction({ name: 'r', enabled: true });
       g.add_action(a);
@@ -394,4 +397,57 @@ test('reentrant-drain: vfunc_dispose re-entering the engine mid-drain is safe (D
   assert.strictEqual(g.lookup_action('after'), a, 'identity + toggle accounting intact after reentrant drains');
   const mb = process.memoryUsage().rss / (1024 * 1024);
   assert.ok(mb < 1024, `RSS bounded after reentrant-drain stress, was ${mb.toFixed(0)} MiB`);
+});
+
+// ---- 10: LIVENESS — the drain lock is NOT held across a dispose vfunc ----
+// A teardown's dispose must not stall off-thread toggles. We start an off-thread
+// ref/unref churn (each iteration acquires g_queue_mutex from another thread), then
+// trigger a registerClass teardown whose vfunc_dispose BLOCKS the main thread inside
+// the dispose and watches the off-thread progress counter. If the drain held the lock
+// across dispose (the round-2 over-broad scope), the off-thread NodeGiToggleNotify
+// would block on the lock and progress would freeze for the whole dispose. With the
+// lock released before RunTeardown, the off-thread churn keeps advancing → proves the
+// no-lock-across-dispose invariant (kills the priority-inversion + ABBA-deadlock risk).
+test('liveness: off-thread toggles progress while a dispose vfunc runs', gcOpts, async () => {
+  const GObject = requireGi('GObject', '2.0');
+  // Long off-thread churn on a HELD object (kept reachable → never collected/freed).
+  const churned = newObject('Gio', 'SimpleAction', { name: 'churn', enabled: true });
+  native.__stressRefUnrefOffThread(churned, 50_000_000);
+  // Wait until the churn thread is actually advancing before we test.
+  {
+    const p0 = native.__stressRefUnrefProgress();
+    let tries = 0;
+    while (native.__stressRefUnrefProgress() <= p0 && tries++ < 2000) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.ok(native.__stressRefUnrefProgress() > p0, 'off-thread churn started');
+  }
+
+  let advancedDuringDispose = false;
+  class Blocker extends GObject.Object {
+    vfunc_dispose() {
+      const p0 = native.__stressRefUnrefProgress();
+      const start = Date.now();
+      // Stay INSIDE the dispose (block the main thread) up to 1s, exiting as soon as
+      // the off-thread churn advances. Lock-released → advances within ms; lock-held
+      // (regression) → never advances → spins the full second → stays false.
+      while (Date.now() - start < 1000) {
+        if (native.__stressRefUnrefProgress() > p0 + 5) {
+          advancedDuringDispose = true;
+          break;
+        }
+      }
+    }
+  }
+  const Klass = GObject.registerClass({ GTypeName: 'NodeGiDisposeLiveness' }, Blocker);
+  (() => {
+    new Klass();
+  })();
+  await settle(3); // GC → teardown drain → Blocker.vfunc_dispose runs the liveness probe
+  native.__stressRefUnrefStop(); // halt the long churn now that we're done
+  assert.equal(
+    advancedDuringDispose,
+    true,
+    'off-thread churn progressed during the dispose → the drain lock is not held across dispose',
+  );
 });

--- a/packages/node-gi/node-gi/test/gc-identity.test.mjs
+++ b/packages/node-gi/node-gi/test/gc-identity.test.mjs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+// GC + wrapper-identity tests for @gjsify/node-gi (the toggle-ref bridge).
+//
+// These exercise the load-bearing GC dance that normal CI never stresses:
+//   * wrapper IDENTITY — the same GObject round-tripped through C yields the
+//     SAME JS wrapper (=== and Map-key stable);
+//   * COLLECTABILITY — a wrapper with no C owner is collected after GC;
+//   * toggle-up ROOTING — a C-owned object keeps its wrapper (and JS-side
+//     expando state) alive across GC;
+//   * RESURRECTION — a collected-then-re-fetched object re-wraps safely;
+//   * vfunc-INSTANCE integration (#647) — a vfunc's `this` is the construct
+//     wrapper, so a field set in a vfunc is visible afterwards;
+//   * SOAK — thousands of create/round-trip/GC cycles stay crash-free + bounded.
+//
+// Run with `node --test --expose-gc`. Without --expose-gc the gc-requiring
+// cases self-skip (global.gc is undefined) so plain `node --test` stays green.
+//
+// Round-trip vehicle: Gio.SimpleActionGroup (a plain GObject, no display) —
+// add_action(action) stores it C-side, lookup_action(name) hands the SAME
+// GObject back. Pure GObject, headless. Reference: the toggle-ref design.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  newObject,
+  callMethod,
+  isGObjectHandle,
+  registerClass,
+  constructType,
+  requireNamespace,
+} from '../index.js';
+import { requireGi } from '../gi.js';
+
+requireNamespace('Gio', '2.0');
+requireNamespace('GObject', '2.0');
+
+const hasGc = typeof globalThis.gc === 'function';
+const gcOpts = hasGc ? {} : { skip: 'run with --expose-gc for the GC cases' };
+
+// Force collection deterministically: a few gc() passes with a microtask/timer
+// drain between them so N-API finalizers AND the GLib idle teardown queue run.
+async function settle(passes = 4) {
+  for (let i = 0; i < passes; i++) {
+    globalThis.gc();
+    await new Promise((r) => setImmediate(r));
+    // Let any g_idle_add(teardown) drain on the GLib default context too.
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+// ---- Case 1: identity (the headline) — L0 canonical handle ----
+test('L0: same GObject round-tripped through C is the SAME handle (===)', () => {
+  const group = newObject('Gio', 'SimpleActionGroup', {});
+  const action = newObject('Gio', 'SimpleAction', { name: 'foo', enabled: true });
+  callMethod(group, 'add_action', [action]);
+  const back = callMethod(group, 'lookup_action', ['foo']);
+  assert.equal(isGObjectHandle(back), true);
+  assert.strictEqual(back, action, 'the round-tripped GObject must be the identical handle');
+});
+
+test('L0: a handle is stable as a Map key across a round-trip', () => {
+  const group = newObject('Gio', 'SimpleActionGroup', {});
+  const action = newObject('Gio', 'SimpleAction', { name: 'bar', enabled: false });
+  const map = new Map();
+  map.set(action, 'sentinel');
+  callMethod(group, 'add_action', [action]);
+  const back = callMethod(group, 'lookup_action', ['bar']);
+  assert.equal(map.get(back), 'sentinel', 'the round-tripped handle must hit the same Map entry');
+});
+
+// ---- Case 1b: identity at L1 (the ergonomic proxy) ----
+test('L1: same GObject round-tripped through C is the SAME proxy (===)', () => {
+  const Gio = requireGi('Gio', '2.0');
+  const group = new Gio.SimpleActionGroup();
+  const action = new Gio.SimpleAction({ name: 'l1', enabled: true });
+  group.add_action(action);
+  const back = group.lookup_action('l1');
+  assert.strictEqual(back, action, 'the round-tripped proxy must be the identical wrapper');
+});
+
+// ---- Case 2: plain collection (toggle-down → weak → collect) ----
+test('plain collection: unowned wrappers are collected after GC', { ...gcOpts }, async () => {
+  const reg = new FinalizationRegistry(() => {
+    collected++;
+  });
+  let collected = 0;
+  const N = 200;
+  (() => {
+    for (let i = 0; i < N; i++) {
+      const a = newObject('Gio', 'SimpleAction', { name: 'tmp' + i, enabled: true });
+      reg.register(a, i);
+    }
+  })();
+  await settle();
+  assert.ok(collected >= N * 0.8, `expected most of ${N} unowned wrappers collected, got ${collected}`);
+});
+
+// ---- Case 3: C-owned object survives GC, JS expando preserved (toggle-up) ----
+test('toggle-up: a C-owned object keeps its wrapper + expando across GC', { ...gcOpts }, async () => {
+  const Gio = requireGi('Gio', '2.0');
+  const group = new Gio.SimpleActionGroup();
+  let collected = 0;
+  const reg = new FinalizationRegistry(() => {
+    collected++;
+  });
+
+  (() => {
+    const action = new Gio.SimpleAction({ name: 'kept', enabled: true });
+    action.__tag = 'survivor';
+    reg.register(action, 'kept');
+    group.add_action(action);
+  })();
+
+  await settle();
+  assert.equal(collected, 0, 'a C-owned (rooted) wrapper must NOT be collected');
+  const back = group.lookup_action('kept');
+  assert.equal(back.__tag, 'survivor', 'JS expando state must survive GC while C owns the object');
+});
+
+// ---- Case 4: resurrection — re-fetch after collecting the wrapper ----
+test('resurrection: re-fetching a collected-wrapper object is safe', { ...gcOpts }, async () => {
+  const Gio = requireGi('Gio', '2.0');
+  const group = new Gio.SimpleActionGroup();
+  // Add an action, then drop every JS reference to its wrapper. The group holds
+  // the GObject C-side, so the GObject stays alive; its wrapper may go weak and
+  // be collected once nothing JS-side roots it.
+  (() => {
+    const a = new Gio.SimpleAction({ name: 'res', enabled: true });
+    group.add_action(a);
+  })();
+  await settle();
+  // Re-fetch: must not crash and must be a valid, usable wrapper.
+  const back = group.lookup_action('res');
+  assert.equal(back.name, 'res', 'a resurrected wrapper is valid and usable');
+});
+
+// ---- Case 5: subclass vfunc-instance integration (#647) ----
+// At L0 the wrapper is a non-extensible External (no JS expando possible), so the
+// integration assertion is wrapper IDENTITY: the vfunc `this` is the very same
+// canonical handle the constructor returns. (Plain-field persistence is an L1
+// concern — see the L1 vfunc case below.)
+test('L0 vfunc: `this` is the same canonical handle as the constructed instance', () => {
+  let vfuncThis = null;
+  const Type = registerClass('NodeGiGcVFuncIdentity', 'GObject', 'Object', {
+    vfuncs: {
+      constructed() {
+        vfuncThis = this;
+      },
+    },
+  });
+  const inst = constructType(Type, {});
+  assert.equal(isGObjectHandle(inst), true);
+  assert.equal(isGObjectHandle(vfuncThis), true);
+  assert.strictEqual(vfuncThis, inst, 'the vfunc `this` and the returned handle are the identical wrapper');
+});
+
+test('L1 vfunc: a field written in a vfunc is visible on the constructed instance', () => {
+  const GObject = requireGi('GObject', '2.0');
+  class Widget extends GObject.Object {
+    vfunc_constructed() {
+      this._marker = 42;
+    }
+  }
+  const Klass = GObject.registerClass({ GTypeName: 'NodeGiGcL1VFunc' }, Widget);
+  const inst = new Klass();
+  assert.equal(inst._marker, 42, 'the L1 vfunc `this` is the constructed proxy');
+});
+
+// ---- Case 6: signal-cycle — narrowed-leak semantics ----
+// A handler that closes over its own object forms a GObject → GClosure →
+// napi_ref → callback → wrapper cycle the GC cannot break across C, so a
+// connected self-referential handler keeps the object alive (GJS-faithful: a
+// connected handler IS a reason to stay alive). Disconnect drops the closure's
+// napi_ref → the cycle breaks → the next GC collects it.
+test('signal-cycle: a self-referential handler pins until disconnect', { ...gcOpts }, async () => {
+  const Gio = requireGi('Gio', '2.0');
+  let collected = 0;
+  const reg = new FinalizationRegistry(() => {
+    collected++;
+  });
+  let handlerId;
+  let weak;
+
+  (() => {
+    const action = new Gio.SimpleAction({ name: 'sig', enabled: false });
+    // The handler closes over `action` — the self-referential cycle.
+    handlerId = action.connect('notify::enabled', () => {
+      void action.name;
+    });
+    weak = new WeakRef(action);
+    reg.register(action, 'sig');
+  })();
+
+  await settle();
+  assert.equal(collected, 0, 'a connected self-referential handler keeps the object alive');
+
+  // Disconnect (via the still-pinned wrapper) to break the cycle, then drop it.
+  (() => {
+    const a = weak.deref();
+    assert.ok(a, 'the pinned wrapper is still alive while connected');
+    a.disconnect(handlerId);
+  })();
+
+  await settle();
+  assert.equal(collected, 1, 'after disconnect the cycle breaks and the object is collected');
+});
+
+// ---- Case 7: soak — bounded RSS, crash-free ----
+test('soak: thousands of create/round-trip/GC cycles stay bounded', { ...gcOpts }, async () => {
+  const iters = 20000;
+  for (let i = 0; i < iters; i++) {
+    const group = newObject('Gio', 'SimpleActionGroup', {});
+    const a = newObject('Gio', 'SimpleAction', { name: 'x', enabled: (i & 1) === 0 });
+    callMethod(group, 'add_action', [a]);
+    const back = callMethod(group, 'lookup_action', ['x']);
+    assert.strictEqual(back, a);
+    if ((i & 0x7ff) === 0) {
+      globalThis.gc();
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+  await settle();
+  const mb = process.memoryUsage().rss / (1024 * 1024);
+  assert.ok(mb < 1024, `RSS should stay bounded after soak, was ${mb.toFixed(0)} MiB`);
+});
+
+// ---- Case 8: toggle interleaved with GC pressure ----
+test('interleave: add/remove from a group under a tight gc loop', { ...gcOpts }, async () => {
+  const Gio = requireGi('Gio', '2.0');
+  const group = new Gio.SimpleActionGroup();
+  for (let i = 0; i < 2000; i++) {
+    const a = new Gio.SimpleAction({ name: 'n', enabled: true });
+    group.add_action(a);
+    const back = group.lookup_action('n');
+    assert.strictEqual(back, a, 'identity holds while toggles fire near collections');
+    group.remove_action('n');
+    if ((i & 0xff) === 0) globalThis.gc();
+  }
+  await settle();
+  assert.equal(group.lookup_action('n'), null, 'a removed action is gone');
+});

--- a/packages/node-gi/node-gi/test/proxy-fallback.test.mjs
+++ b/packages/node-gi/node-gi/test/proxy-fallback.test.mjs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// L1 instance-proxy get-trap fallback + userProto-cache behavior (gi.js).
+//
+// Guards two residual fixes in the toggle-ref PR:
+//   * minor 4 — the get trap's own-property-only narrowing dropped the inherited
+//     Object.prototype-method fallback, so `inst.hasOwnProperty('x')` resolved to a
+//     GI callMethod thunk and threw. Inherited members must resolve to the real
+//     function (RESERVED already covers toString/valueOf; this covers the rest).
+//   * minor 3 — the instanceCache is keyed on the handle; a subclass instance
+//     re-wrapped generically must KEEP its prototype methods (no downgrade) and
+//     stay identical (===). The userProto now lives on the target so a later
+//     userProto wrap can also upgrade a generic wrapper in place.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const Gio = requireGi('Gio', '2.0');
+const GObject = requireGi('GObject', '2.0');
+
+test('minor 4: inherited Object.prototype methods resolve (not GI thunks)', () => {
+  const a = new Gio.SimpleAction({ name: 'h', enabled: true });
+  a.__expando = 7;
+  // hasOwnProperty must be the real function and return correct booleans — NOT a
+  // GI callMethod thunk (which would throw on the non-existent `has_own_property`).
+  assert.equal(typeof a.hasOwnProperty, 'function');
+  assert.equal(a.hasOwnProperty('__expando'), true);
+  assert.equal(a.hasOwnProperty('nope'), false);
+  assert.equal(typeof a.isPrototypeOf, 'function');
+  assert.equal(typeof a.propertyIsEnumerable, 'function');
+  // Expando reads + RESERVED names + real GI methods all still work alongside it.
+  assert.equal(a.__expando, 7);
+  assert.equal(typeof a.toString, 'function');
+  assert.equal(a.get_name(), 'h', 'a genuine GI method is still routed');
+});
+
+test('minor 3: a generically re-wrapped subclass keeps its prototype methods (no downgrade)', () => {
+  class Widget extends GObject.Object {
+    myMethod() {
+      return 'mine';
+    }
+  }
+  const Klass = GObject.registerClass({ GTypeName: 'NodeGiProxyNoDowngrade' }, Widget);
+  const inst = new Klass();
+  assert.equal(inst.myMethod(), 'mine', 'userProto method resolves on the constructed instance');
+  // ref() hands the SAME GObject back generically (wrapReturn, no userProto). The
+  // cache must return the identical proxy WITH its prototype methods intact.
+  const back = inst.ref();
+  assert.strictEqual(back, inst, 'generic re-wrap returns the identical proxy');
+  assert.equal(typeof back.myMethod, 'function', 'prototype method survives a generic re-wrap');
+  assert.equal(back.myMethod(), 'mine');
+  inst.unref();
+});


### PR DESCRIPTION
The instance-lifetime GC bridge — node-gi's most delicate native change. Replaces the per-call plain strong ref with a single `g_object_add_toggle_ref` per GObject, caching the canonical N-API `External` wrapper on the object (qdata).

## What it delivers
- **Wrapper identity** — the same GObject always yields the same JS wrapper (`===` + Map-key stability).
- **Collectability** of reference cycles; **resurrection** — an object handed back from C re-wraps to the cached wrapper.
- The #647 vfunc `this` and signal handlers now see the **same instance** as construct, so plain JS instance fields persist across the vfunc/instance boundary (closes the decorator's documented limitation).

## Mechanism + safety (N-API finalizers run outside GC)
- toggle-notify flips the wrapper's `napi_ref` strong↔weak (strong while C also holds the object; weak when JS is sole owner).
- The finalizer ONLY schedules teardown via `g_idle_add` — all `g_object_remove_toggle_ref`/dispose work runs from a main-loop idle, never during collection.
- Toggle-up probes `napi_get_reference_value` (resurrection-safe). Cross-thread toggles marshal through a thread-safe queue + a `g_object_weak_ref` safety net; qdata cleared only if it still points at this wrapper.
- L1 `gi.js` keys the instance proxy to the canonical wrapper so `===` holds at the JS layer too.

## Tests
New `test/gc-identity.test.mjs` (identity / collectability / toggle-up rooting / resurrection / signal-cycle / soak), gated behind `--expose-gc` and run by a dedicated **GC-stress CI leg** (`npm run test:gc`). Verified locally: clean rebuild + **148/148 pass on both the regular and `--expose-gc` legs, no crash under GC pressure**.

Built from a reviewed design doc; opened for a thorough GC/concurrency review before merge.