### PR TITLE
fix(node-gi): harden GI/GVariant marshalling

### DIFF
--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -265,6 +265,18 @@ function makeVariantClass() {
   Object.defineProperty(ctor, 'name', { value: 'Variant', configurable: true });
   ctor.$gtypeName = 'GLib.Variant';
   ctor.new = (signature, value) => packVariant(signature, value);
+  // `value instanceof GLib.Variant` — a wrapped Variant is a Proxy over a bare
+  // `{[HANDLE]}` target (no class prototype), so the default instanceof always
+  // returned false. Recognise any wrapper whose [HANDLE] is a native GVariant
+  // boxed handle. Real GAction/GSettings/GLib.log_structured code branches on it.
+  Object.defineProperty(ctor, Symbol.hasInstance, {
+    value(instance) {
+      if (instance === null || typeof instance !== 'object') return false;
+      const handle = instance[HANDLE];
+      return handle !== undefined && native.isVariantHandle(handle);
+    },
+    configurable: true,
+  });
   return new Proxy(ctor, {
     get(t, prop) {
       if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -425,7 +425,8 @@ static bool TryGetBoxedPtr(Napi::Value v, gpointer* out) {
 }
 
 static bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* out,
-                           std::string* heldString) {
+                           std::string* heldString,
+                           GITransfer transfer = GI_TRANSFER_NOTHING) {
   GITypeTag tag = gi_type_info_get_tag(type);
   switch (tag) {
     case GI_TYPE_TAG_BOOLEAN: out->v_boolean = v.ToBoolean().Value(); return true;
@@ -445,8 +446,15 @@ static bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArg
         out->v_string = nullptr;
         return true;
       }
-      *heldString = v.ToString().Utf8Value();
-      out->v_string = const_cast<char*>(heldString->c_str());
+      if (transfer == GI_TRANSFER_EVERYTHING) {
+        // The callee adopts the string and g_free's it. heldString points into a
+        // std::string buffer (NOT g_malloc'd) → an invalid free. Hand over a
+        // g_strdup'd copy the callee can legally free; we keep no reference.
+        out->v_string = g_strdup(v.ToString().Utf8Value().c_str());
+      } else {
+        *heldString = v.ToString().Utf8Value();
+        out->v_string = const_cast<char*>(heldString->c_str());
+      }
       return true;
     case GI_TYPE_TAG_INTERFACE: {
       // Object/interface instances arrive as opaque External<GObject> handles;
@@ -1223,7 +1231,11 @@ static void FreeReadArrayContainer(gpointer container, GIArrayType at, GITransfe
   if (container == nullptr || transfer == GI_TRANSFER_NOTHING) return;
   switch (at) {
     case GI_ARRAY_TYPE_C: g_free(container); break;
-    case GI_ARRAY_TYPE_BYTE_ARRAY: g_byte_array_free(static_cast<GByteArray*>(container), TRUE); break;
+    case GI_ARRAY_TYPE_BYTE_ARRAY:
+      // CONTAINER frees only the GByteArray wrapper (callee keeps the bytes);
+      // EVERYTHING frees the segment too. Mirrors the GArray/GPtrArray cases.
+      g_byte_array_free(static_cast<GByteArray*>(container), transfer == GI_TRANSFER_EVERYTHING);
+      break;
     case GI_ARRAY_TYPE_ARRAY:
       g_array_free(static_cast<GArray*>(container), transfer == GI_TRANSFER_EVERYTHING);
       break;
@@ -1384,8 +1396,15 @@ static Napi::Value GHashToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
     if (kt != nullptr) gi_base_info_unref(kt);
     if (vt != nullptr) gi_base_info_unref(vt);
   }
-  if (ht != nullptr && (transfer == GI_TRANSFER_EVERYTHING || transfer == GI_TRANSFER_CONTAINER))
+  if (ht != nullptr && (transfer == GI_TRANSFER_EVERYTHING || transfer == GI_TRANSFER_CONTAINER)) {
+    // CONTAINER transfers the table but NOT its keys/values (callee keeps them).
+    // g_hash_table_unref would run the key/value destroy-notifiers → over-free,
+    // so steal the entries first; the unref then frees only the table itself.
+    // EVERYTHING keeps the destroy-notifiers (we own keys + values). Mirrors the
+    // C-array / GList CONTAINER handling that frees only the container.
+    if (transfer == GI_TRANSFER_CONTAINER) g_hash_table_steal_all(ht);
     g_hash_table_unref(ht);
+  }
   return out;
 }
 
@@ -1701,6 +1720,15 @@ static bool JsToInContainer(Napi::Env env, Napi::Value v, GITypeInfo* type, GITr
   if (ok && *outPtr != nullptr) {
     containers->push_back(InContainer{
         reinterpret_cast<GITypeInfo*>(gi_base_info_ref(type)), *outPtr, transfer, *outCount});
+  } else if (!ok && *outPtr != nullptr) {
+    // An element conversion threw mid-build (JsToGListLike / JsToGHashIn still
+    // published the partial container). It was never recorded for cleanup, so
+    // the nodes (and any g_strdup'd keys/string values) would leak. Free it now
+    // with NOTHING semantics — we still own all of it; the callee never saw it.
+    InContainer partial{reinterpret_cast<GITypeInfo*>(gi_base_info_ref(type)), *outPtr,
+                        GI_TRANSFER_NOTHING, *outCount};
+    FreeInContainer(partial);  // unrefs the type ref taken above
+    *outPtr = nullptr;
   }
   return ok;
 }
@@ -2091,7 +2119,8 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
           // invoker hands the slot's address to the callee, which reads + writes.
           Napi::Value v = jsCursor < args.Length() ? args.Get(jsCursor) : env.Undefined();
           jsCursor++;
-          if (JsToGIArgument(env, v, ti, &slots[i], &held[i])) {
+          GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
+          if (JsToGIArgument(env, v, ti, &slots[i], &held[i], tr)) {
             in_args[inPos[i]].v_pointer = &slots[i];
             out_args[outPos[i]].v_pointer = &slots[i];
           } else {
@@ -2170,7 +2199,8 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
           }
         }
       } else {
-        ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i]);
+        GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
+        ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i], tr);
       }
     }
 
@@ -2205,7 +2235,10 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   std::vector<Napi::Value> results;
   GITypeInfo* return_type = gi_callable_info_get_return_type(callable);
   GITransfer return_transfer = gi_callable_info_get_caller_owns(callable);
-  if (gi_type_info_get_tag(return_type) != GI_TYPE_TAG_VOID) {
+  // A (skip)-annotated return is omitted from BOTH the count and the tuple — the
+  // OUT params alone shape the result (mirrors GJS/node-gtk ShouldSkipReturn).
+  if (gi_type_info_get_tag(return_type) != GI_TYPE_TAG_VOID &&
+      !gi_callable_info_skip_return(callable)) {
     results.push_back(ReadOutOrReturn(env, callable, return_type, &retval, return_transfer, &slots));
   }
   gi_base_info_unref(return_type);
@@ -3563,15 +3596,43 @@ static GVariant* VariantPack(Napi::Env env, const std::string& sig, size_t* pos,
     case 'q': return g_variant_new_uint16(static_cast<guint16>(value.ToNumber().Uint32Value()));
     case 'i': return g_variant_new_int32(value.ToNumber().Int32Value());
     case 'u': return g_variant_new_uint32(value.ToNumber().Uint32Value());
-    case 'x': return g_variant_new_int64(value.ToNumber().Int64Value());
-    case 't': return g_variant_new_uint64(static_cast<guint64>(value.ToNumber().Int64Value()));
+    case 'x': {
+      // GJS accepts a BigInt for 64-bit types (its js_value_to_c<int64_t> branches
+      // on isBigInt before ToInt64). ToNumber() throws on a BigInt and rounds a
+      // large double — branch on IsBigInt to round-trip the full int64 range.
+      bool lossless = false;
+      gint64 i = value.IsBigInt() ? value.As<Napi::BigInt>().Int64Value(&lossless)
+                                  : value.ToNumber().Int64Value();
+      return g_variant_new_int64(i);
+    }
+    case 't': {
+      bool lossless = false;
+      guint64 u = value.IsBigInt()
+                      ? value.As<Napi::BigInt>().Uint64Value(&lossless)
+                      : static_cast<guint64>(value.ToNumber().Int64Value());
+      return g_variant_new_uint64(u);
+    }
     case 'h': return g_variant_new_handle(value.ToNumber().Int32Value());
     case 'd': return g_variant_new_double(value.ToNumber().DoubleValue());
     case 's': {
+      // GJS marshals 's' via new_string, whose UTF8 arg is type-strict (isString
+      // or null), so `new GLib.Variant('s', 42)` throws rather than packing "42".
+      if (!value.IsString()) {
+        Napi::TypeError::New(env, "GVariant 's' expects a string")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
       std::string s = value.ToString().Utf8Value();
       return g_variant_new_string(s.c_str());
     }
     case 'o': {
+      if (!value.IsString()) {
+        Napi::TypeError::New(env, "GVariant 'o' expects an object-path string")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
       std::string s = value.ToString().Utf8Value();
       if (!g_variant_is_object_path(s.c_str())) {
         Napi::TypeError::New(env, std::string("Invalid GVariant object path: ") + s)
@@ -3582,6 +3643,12 @@ static GVariant* VariantPack(Napi::Env env, const std::string& sig, size_t* pos,
       return g_variant_new_object_path(s.c_str());
     }
     case 'g': {
+      if (!value.IsString()) {
+        Napi::TypeError::New(env, "GVariant 'g' expects a signature string")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
       std::string s = value.ToString().Utf8Value();
       if (!g_variant_is_signature(s.c_str())) {
         Napi::TypeError::New(env, std::string("Invalid GVariant signature string: ") + s)
@@ -3708,29 +3775,30 @@ static GVariant* VariantPack(Napi::Env env, const std::string& sig, size_t* pos,
         return nullptr;
       }
       Napi::Array a = value.As<Napi::Array>();
+      uint32_t n = a.Length();
       GVariantBuilder builder;
       g_variant_builder_init(&builder, G_VARIANT_TYPE_TUPLE);
-      uint32_t i = 0;
-      while (true) {
-        if (*pos < sig.size() && sig[*pos] == ')') {
-          (*pos)++;
-          break;
-        }
-        if (*pos >= sig.size()) {
-          g_variant_builder_clear(&builder);
-          Napi::TypeError::New(env, "Invalid GVariant signature for type TUPLE (expected \")\")")
-              .ThrowAsJavaScriptException();
-          *ok = false;
-          return nullptr;
-        }
+      // Drive children off the JS array length (GJS: `for i < value.length`), not
+      // the signature — a missing position must NOT coerce undefined→garbage.
+      for (uint32_t i = 0; i < n; i++) {
+        if (*pos < sig.size() && sig[*pos] == ')') break;  // more values than types: stop
         GVariant* child = VariantPack(env, sig, pos, a.Get(i), ok);
         if (!*ok) {
           g_variant_builder_clear(&builder);
           return nullptr;
         }
         g_variant_builder_add_value(&builder, child);
-        i++;
       }
+      // Every value consumed: the signature must now close the tuple. If types
+      // remain (too few values) this throws, exactly as GJS does.
+      if (*pos >= sig.size() || sig[*pos] != ')') {
+        g_variant_builder_clear(&builder);
+        Napi::TypeError::New(env, "Invalid GVariant signature for type TUPLE (expected \")\")")
+            .ThrowAsJavaScriptException();
+        *ok = false;
+        return nullptr;
+      }
+      (*pos)++;  // consume ')'
       return g_variant_builder_end(&builder);
     }
     case '{': {  // dict-entry: value is [key, val]

--- a/packages/node-gi/node-gi/test/out-params.test.mjs
+++ b/packages/node-gi/node-gi/test/out-params.test.mjs
@@ -77,6 +77,29 @@ test('OUT string array → [bool, string[]]: GLib.get_filename_charsets()', () =
   assert.ok(res[1].every((c) => typeof c === 'string'));
 });
 
+test('(skip) return is omitted from the tuple: GLib.uri_split()', () => {
+  // gboolean g_uri_split(uri_ref, flags, scheme, userinfo, host, port, path,
+  //   query, fragment, GError**) — the gboolean return is annotated (skip), so
+  //   the result is the 7 OUT values ALONE, with NO leading boolean. Without the
+  //   skip handling this would be an 8-element [true, scheme, …] tuple.
+  const res = callFunction('GLib', 'uri_split', ['http://user@host:80/p?q=1#frag', 0]);
+  assert.ok(Array.isArray(res));
+  assert.equal(res.length, 7);
+  assert.deepEqual(res, ['http', 'user', 'host', 80, '/p', 'q=1', 'frag']);
+  assert.notEqual(res[0], true); // the skipped gboolean must not lead the tuple
+});
+
+test('transfer-full string IN is g_strdup`d, not a freed std::string buffer', () => {
+  // g_string_new_take(gchar* init) ADOPTS init (transfer full) and g_free's it on
+  // realloc/free. A std::string-buffer pointer would be an invalid free; the fix
+  // hands over a g_strdup'd copy. append() reallocs → frees the adopted buffer
+  // (the crash trigger pre-fix); equal() then confirms the content is intact.
+  const s = callStaticMethod('GLib', 'String', 'new_take', ['héllo']);
+  callBoxedMethod(s, 'append', [' world']);
+  const other = callStaticMethod('GLib', 'String', 'new', ['héllo world']);
+  assert.equal(callBoxedMethod(s, 'equal', [other]), true);
+});
+
 test('IN-only callables are unchanged: bare scalar returns', () => {
   // The OUT/INOUT routing must leave the IN-only path byte-for-byte: a non-void
   // return with no OUT args still comes back bare, not wrapped in an array.

--- a/packages/node-gi/node-gi/test/variant.test.mjs
+++ b/packages/node-gi/node-gi/test/variant.test.mjs
@@ -49,7 +49,7 @@ test('native: isVariantHandle distinguishes variants', () => {
 
 test('native: invalid signatures throw clear errors', () => {
   assert.throws(() => variantNew('', 'x'), /signature cannot be empty/);
-  assert.throws(() => variantNew('ss', ['a', 'b']), /more than one single complete type/);
+  assert.throws(() => variantNew('ss', 'a'), /more than one single complete type/);
   assert.throws(() => variantNew('Z', 1), /Invalid GVariant signature/);
 });
 
@@ -156,6 +156,54 @@ test('L1: GLib.Variant.new(sig, value) deprecated alias works', () => {
 test('L1: a built Variant routes other GVariant methods (n_children)', () => {
   const v = new GLib.Variant('as', ['a', 'b', 'c']);
   assert.equal(v.n_children(), 3);
+});
+
+// ---- hardening: instanceof / BigInt / tuple arity / scalar strictness -------
+
+test('L1: a wrapped Variant satisfies `instanceof GLib.Variant`', () => {
+  // The wrapper is a Proxy over a bare `{[HANDLE]}` target; instanceof now works
+  // via Symbol.hasInstance keyed on the native variant handle.
+  assert.ok(new GLib.Variant('s', 'x') instanceof GLib.Variant);
+  assert.ok(GLib.Variant.new('i', 1) instanceof GLib.Variant);
+  assert.ok(new GLib.Variant('a{sv}', {}) instanceof GLib.Variant);
+  assert.ok(!({} instanceof GLib.Variant));
+  assert.ok(!(null instanceof GLib.Variant));
+  assert.ok(!('x' instanceof GLib.Variant));
+  // A non-Variant boxed handle (GLib.MainLoop) is NOT a Variant.
+  assert.ok(!(GLib.MainLoop.new(null, false) instanceof GLib.Variant));
+});
+
+test('L1: "x"/"t" accept a BigInt (GJS parity, beyond Int32)', () => {
+  // 2^53 — representable as a JS double, so it round-trips exactly through unpack;
+  // the point is that a BigInt is ACCEPTED (ToNumber would throw on it before).
+  const big = 9007199254740992n;
+  assert.equal(new GLib.Variant('x', big).deepUnpack(), 9007199254740992);
+  assert.equal(new GLib.Variant('t', big).deepUnpack(), 9007199254740992);
+  // Small BigInt + plain Number both still work.
+  assert.equal(new GLib.Variant('x', 42n).deepUnpack(), 42);
+  assert.equal(new GLib.Variant('t', 7n).deepUnpack(), 7);
+  assert.equal(new GLib.Variant('x', -5).deepUnpack(), -5);
+});
+
+test('native: tuple bounds by value length — too few values throws', () => {
+  // A missing position must NOT coerce undefined→garbage; the leftover type makes
+  // it throw, exactly as GJS does.
+  assert.throws(() => variantNew('(ii)', [1]), /Invalid GVariant signature for type TUPLE/);
+  assert.throws(() => new GLib.Variant('(sib)', ['x', 1]), /signature for type TUPLE/);
+  // Exact arity still round-trips; an empty tuple is fine.
+  assert.deepEqual(variantUnpack(variantNew('(ii)', [1, 2]), true), [1, 2]);
+  assert.deepEqual(variantUnpack(variantNew('()', []), true), []);
+});
+
+test('native: scalar pack rejects obvious type mismatches (GJS strictness)', () => {
+  // `new GLib.Variant('s', 42)` must not silently pack "42" (GJS new_string is
+  // type-strict). 'o'/'g' are likewise string-typed.
+  assert.throws(() => variantNew('s', 42), /'s' expects a string/);
+  assert.throws(() => new GLib.Variant('o', 5), /'o' expects an object-path string/);
+  assert.throws(() => new GLib.Variant('g', 1), /'g' expects a signature string/);
+  // Booleans stay lenient (GJS new_boolean = ToBoolean) — coerce, never throw.
+  assert.equal(new GLib.Variant('b', 1).deepUnpack(), true);
+  assert.equal(new GLib.Variant('b', 0).deepUnpack(), false);
 });
 
 // ---- end-to-end: Gio.SimpleAction carrying a built Variant -----------------


### PR DESCRIPTION
Residual correctness fixes from the node-gi marshalling review panels (#652/#653/#654). Each is independent and surgical; the completed marshalling foundation is unchanged.

## Marshalling (addon.cc)
1. **skip_return** — a `(skip)`-annotated function return is now omitted from BOTH the count and the result tuple, so the OUT params alone shape the result (mirrors GJS/node-gtk `ShouldSkipReturn`). Previously a `(skip)` return with OUT params mis-shaped the tuple.
2. **transfer-full string IN/INOUT** — `g_strdup` the string when the callee adopts it (transfer EVERYTHING). It was handing over a `std::string` buffer the callee would `g_free` → invalid free / heap corruption.
3. **GList/GSList/GHashTable IN error path** — free the partial container the builder published before throwing (it was set in `*outPtr` but only recorded for cleanup on success → leak of nodes / `g_strdup`'d keys+values).
4. **GHashTable transfer-CONTAINER return** — `g_hash_table_steal_all` before `unref` so the key/value destroy-notifiers don't over-free callee-owned contents (mirrors the C-array/GList CONTAINER handling).
5. **GByteArray read free** — honour transfer (free the segment only for EVERYTHING) instead of always `g_byte_array_free(..., TRUE)`, aligning with the GArray/GPtrArray siblings.

## GVariant (gi.js + addon.cc)
6. **`instanceof GLib.Variant`** — add `Symbol.hasInstance` keyed on the native variant handle so wrapped Variants satisfy it (the wrapper is a Proxy over a bare `{[HANDLE]}` target, so it was always `false`). Real GAction/GSettings/`GLib.log_structured` code branches on this.
7. **`x`/`t` BigInt** — accept a BigInt for 64-bit types (`ToNumber` threw on BigInt and rounded large doubles); branch on `IsBigInt` first.
8. **tuple pack arity** — bound children by the JS array length and throw `Invalid GVariant signature for type TUPLE` when types remain (was coercing missing positions undefined→garbage).
9. **scalar pack strictness** — reject obvious type mismatches for `s`/`o`/`g` (GJS `new_string` strictness: `new GLib.Variant('s', 42)` now throws instead of packing `"42"`); booleans stay lenient (GJS `new_boolean` = `ToBoolean`).

## Tests
- skip-return shape via `GLib.uri_split` (skip gboolean + 7 OUT → 7-element tuple).
- transfer-full string round-trip via `GLib.String.new_take` + `append` (the realloc that frees the adopted buffer — confirmed to crash with `mremap_chunk(): invalid pointer` pre-fix).
- `instanceof GLib.Variant` (positive + negatives, incl. a non-Variant boxed handle).
- BigInt round-trip for `x`/`t`.
- tuple-too-few throws; scalar strictness for `s`/`o`/`g`.

171 tests green (160 + 11 GC-stress), all green under `--expose-gc`. One existing test (`variantNew('ss', ['a','b'])`) was retargeted to a string value so it still isolates the multi-type-signature rejection under the new `s` strictness.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH