### PR TITLE
run a Gtk.Application on Node via node-gi

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -90,3 +90,53 @@ jobs:
         run: |
           npm install --no-audit --no-fund --foreground-scripts
           node --test dual.e2e.mjs
+
+  # GTK layering proof (Axis-5 GTK milestone, PR1): an UNCHANGED Gtk.Application
+  # runs on Node via the engine — construct + activate + window + button + quit,
+  # AND the libuv↔GLib bridge co-pumps Node's event loop during g_application_run
+  # (a setTimeout scheduled before run() fires while run() blocks). This needs a
+  # display + the GTK stack, so it is isolated in a dedicated job: the fast
+  # headless `Build & test` leg above stays light and `test/gtk-smoke.test.mjs`
+  # self-skips there (no DISPLAY). Runs the GTK loop, so cap the job rather than
+  # let a hung loop wait 6h.
+  gtk-smoke:
+    name: GTK smoke (Node + Xvfb / Fedora 44)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: fedora:44
+    steps:
+      - name: Install toolchain + GTK4/Adwaita + Xvfb + dbus
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git gcc-c++ make python3 pkgconf-pkg-config tar xz \
+            glib2-devel gobject-introspection-devel gobject-introspection \
+            gtk4-devel libadwaita-devel \
+            xorg-x11-server-Xvfb dbus-daemon dbus-x11 mesa-dri-drivers
+          echo "gtk4: $(pkg-config --modversion gtk4)"
+          echo "libadwaita: $(pkg-config --modversion libadwaita-1)"
+
+      # Same rationale as the build-test job: the official nodejs.org build, not
+      # Fedora's dnf node (which crashes the bundler's prebuilt napi binding).
+      - name: Use official Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build native addon (node-gyp)
+        working-directory: packages/node-gi/node-gi
+        run: npm install --no-audit --no-fund --foreground-scripts
+
+      # Xvfb gives a virtual X11 display; dbus-run-session gives a private session
+      # bus so GApplication startup is quiet/deterministic; GSK_RENDERER=cairo +
+      # LIBGL_ALWAYS_SOFTWARE=1 + GDK_BACKEND=x11 keep GTK off any GPU/Vulkan path
+      # that a software-only Xvfb cannot provide.
+      - name: GTK smoke test (xvfb + dbus)
+        working-directory: packages/node-gi/node-gi
+        run: |
+          xvfb-run -a dbus-run-session -- \
+            env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 \
+            npm run test:gtk

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -48,7 +48,8 @@
     "clean": "node-gyp clean",
     "test": "node --test",
     "test:node": "node --test",
-    "test:gc": "node --test --expose-gc"
+    "test:gc": "node --test --expose-gc",
+    "test:gtk": "node --test test/gtk-smoke.test.mjs"
   },
   "dependencies": {
     "node-addon-api": "^8.0.0"

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -2324,6 +2324,11 @@ Napi::Value CallFunction(const Napi::CallbackInfo& info) {
 // Instances are handed back as opaque Napi::External<GObject> handles; the
 // ergonomic class/prototype surface is layered in the GJS-compat runtime.
 
+// Forward declaration: JsToGValue (below) marshals object/boxed-typed property
+// values, which need to unwrap a node-gi GObject handle; UnwrapGObject is defined
+// further down (it shares the validation logic with the property/method paths).
+static GObject* UnwrapGObject(Napi::Env env, Napi::Value handle);
+
 // Marshal a GValue into a JS value (fundamental types).
 static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
   GType ft = G_TYPE_FUNDAMENTAL(G_VALUE_TYPE(v));
@@ -2414,6 +2419,39 @@ static bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
         return false;
       }
       g_value_set_variant(v, static_cast<GVariant*>(p));
+      return true;
+    }
+    case G_TYPE_OBJECT: {
+      // An object-typed property (e.g. Gtk.ApplicationWindow:application,
+      // Gtk.Widget:child, :transient-for, :model …). Mirrors GValueToJs's
+      // G_TYPE_OBJECT case in the other direction: unwrap the node-gi GObject
+      // handle and hand it to g_value_set_object, which takes its OWN ref (our
+      // wrapper keeps its handle ref → no double-free). null/undefined clears it.
+      if (js.IsNull() || js.IsUndefined()) {
+        g_value_set_object(v, nullptr);
+        return true;
+      }
+      GObject* obj = UnwrapGObject(env, js);
+      if (obj == nullptr) return false;  // UnwrapGObject threw a TypeError
+      g_value_set_object(v, obj);
+      return true;
+    }
+    case G_TYPE_BOXED: {
+      // A boxed-typed property (e.g. a GdkRGBA, Gtk.Border, …). g_value_set_boxed
+      // COPIES the boxed payload, so handing it our handle's pointer is safe — the
+      // handle retains ownership. null/undefined clears it.
+      if (js.IsNull() || js.IsUndefined()) {
+        g_value_set_boxed(v, nullptr);
+        return true;
+      }
+      gpointer p = nullptr;
+      if (!TryGetBoxedPtr(js, &p) || p == nullptr) {
+        Napi::TypeError::New(env, std::string("expected a boxed handle for a ") +
+                                      g_type_name(G_VALUE_TYPE(v)) + " property")
+            .ThrowAsJavaScriptException();
+        return false;
+      }
+      g_value_set_boxed(v, p);
       return true;
     }
     default:

--- a/packages/node-gi/node-gi/test/gtk-smoke.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-smoke.test.mjs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gtk.Application smoke test (GTK layering milestone, PR1).
+//
+// Proves an UNCHANGED Gtk.Application runs on Node via the node-gi engine:
+// construct the app, connect('activate'), build a Gtk.ApplicationWindow with a
+// Gtk.Button, present it, and quit from a GLib timeout — all under the libuv↔GLib
+// bridge. THE HEADLINE PROOF: g_application_run iterates the DEFAULT GMainContext,
+// to which the node-gi bridge attaches its GSource (g_source_attach(src, NULL)),
+// so Node's libuv (timers / I/O / microtasks) is co-pumped during the blocking
+// GTK loop. A setTimeout() scheduled BEFORE run() therefore fires while run()
+// blocks — asserted after run() returns (global.__uvTimerFired).
+//
+// Also exercises the one engine gap the idiomatic shape hits: an object-typed
+// CONSTRUCT property. `new Gtk.ApplicationWindow({ application: app })` sets the
+// G_TYPE_OBJECT `application` property — JsToGValue must marshal the node-gi
+// GObject handle into the GValue (the addon.cc fix landed alongside this test).
+//
+// SELF-SKIPPING: needs a display (DISPLAY / WAYLAND_DISPLAY) and the Gtk-4.0
+// typelib, so the fast headless `npm test` / `test:gc` legs skip it cleanly; the
+// dedicated `gtk-smoke` CI job (Xvfb + GTK stack) is where it actually runs.
+//
+// run() is called at the TOP LEVEL of a synchronous test body (not inside an
+// async scope) so the node-gtk #442 nested-microtask-checkpoint caveat does not
+// bite; the quit is driven from a GLib timeout running INSIDE the loop.
+//
+// Reference: refs/gjs (g_application_run semantics), refs/node-gtk src/loop.cc
+// (romgrk and contributors, MIT).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+// Resolve the GTK stack up front: a missing Gtk-4.0 typelib (a headless dev box
+// with no gtk4-devel) must SKIP, not throw. The GLib/Gio deps come along too.
+let Gtk;
+let Gio;
+let GLib;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    Gtk = requireGi('Gtk', '4.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+test('Gtk.Application.run() runs a real app and co-pumps libuv', { skip }, () => {
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiSmoke',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+  });
+
+  let activated = false;
+
+  // Scheduled on libuv BEFORE the blocking run(). Without the bridge co-pumping
+  // libuv during g_application_run, this 10ms timer would never fire while run()
+  // blocks → concrete proof the GTK loop advances Node's event loop.
+  global.__uvTimerFired = false;
+  setTimeout(() => {
+    global.__uvTimerFired = true;
+  }, 10);
+
+  app.connect('activate', () => {
+    activated = true;
+    // The engine fix under test: `application` is a G_TYPE_OBJECT construct-only
+    // property — JsToGValue must marshal the node-gi GObject handle into it.
+    const win = new Gtk.ApplicationWindow({ application: app });
+    win.set_default_size(200, 120);
+    win.set_child(new Gtk.Button({ label: 'hi' })); // object as a method argument
+    win.present();
+    // Quit from a timeout running INSIDE the GTK loop → run() returns cleanly.
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+      app.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+  });
+
+  const status = app.run([]); // top-level blocking run (no async wrapper)
+
+  try {
+    assert.equal(status, 0, 'app.run([]) should exit 0');
+    assert.equal(activated, true, 'the activate signal handler should have run');
+    assert.equal(
+      global.__uvTimerFired,
+      true,
+      'libuv must advance (setTimeout fires) during the blocking g_application_run',
+    );
+  } finally {
+    delete global.__uvTimerFired;
+  }
+});


### PR DESCRIPTION
First GTK-layering milestone (PR1) for the Axis-5 node-gi engine: prove an **unchanged `Gtk.Application` runs on Node**, and that the libuv↔GLib bridge co-pumps Node's event loop during the blocking GTK loop.

## Engine fix — `addon.cc`, `JsToGValue`
`JsToGValue` marshalled only fundamentals, so an object/boxed-typed **construct property** fell through to `Unsupported property GType` and threw. The idiomatic `new Gtk.ApplicationWindow({ application: app })` (the `application` prop is `G_TYPE_OBJECT`) now works, mirroring `GValueToJs` in the other direction:
- `G_TYPE_OBJECT` → `g_value_set_object(v, UnwrapGObject(...))` (takes its own ref; null/undefined clears).
- `G_TYPE_BOXED` → `g_value_set_boxed(v, TryGetBoxedPtr(...))` (copies; null/undefined clears).

Additive — the fundamentals path is unchanged and `GValueToJs` is untouched. Unblocks every object-typed prop (`child`, `transient-for`, `model`, …).

## Smoke test — `test/gtk-smoke.test.mjs` (self-skipping)
Skips cleanly without a display (`DISPLAY`/`WAYLAND_DISPLAY`) or the `Gtk-4.0` typelib, so the fast headless `npm test`/`test:gc` legs stay clean.
- Top-level synchronous `app.run([])` (avoids the node-gtk #442 nested microtask-checkpoint caveat); `connect('activate')` builds an `ApplicationWindow` + `Button`, presents it, and quits from a GLib timeout running inside the loop.
- Schedules a `setTimeout` **before** `run()` and asserts it fired after `run()` returns (`global.__uvTimerFired`) — concrete proof libuv advanced during `g_application_run`. Also asserts `run() === 0` and that the activate handler ran.

## CI — `.github/workflows/node-gi.yml`
A dedicated `gtk-smoke` job (Fedora 44, 20m cap) installs the GTK4/Adwaita stack + Xvfb + dbus and runs:
```
xvfb-run -a dbus-run-session -- env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 npm run test:gtk
```
The fast headless `Build & test` leg is untouched (the smoke self-skips there). Adds a `test:gtk` script.

## Validation
- `npx node-gyp rebuild` clean; full headless `node --test` green (172 tests, 160 pass, 12 skipped — the 11 GC cases + the self-skipped smoke).
- Ran the smoke on a real display (`dbus-run-session` + cairo renderer): **passes** — `run()` returns 0, activate handler ran, and the pre-`run()` `setTimeout` fired during the loop.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH