### PR TITLE
feat(node-gi): run Gtk.Template composite widgets on Node

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -91,12 +91,15 @@ jobs:
           npm install --no-audit --no-fund --foreground-scripts
           node --test dual.e2e.mjs
 
-  # GTK/Adw layering proof (Axis-5 GTK milestone): UNCHANGED Gtk.Application (PR1)
-  # AND Adw.Application (PR2) apps run on Node via the engine — construct +
-  # activate + window + Adwaita chrome (HeaderBar/ToolbarView/StatusPage) + CSS
-  # provider + quit, AND the libuv↔GLib bridge co-pumps Node's event loop during
-  # g_application_run (a setTimeout scheduled before run() fires while run()
-  # blocks). This needs a display + the GTK/Adw stack, so it is isolated in a
+  # GTK/Adw layering proof (Axis-5 GTK milestone): UNCHANGED Gtk.Application (PR1),
+  # Adw.Application (PR2) AND a Gtk.Template composite-template widget (PR4) run on
+  # Node via the engine — construct + activate + window + Adwaita chrome
+  # (HeaderBar/ToolbarView/StatusPage) + CSS provider + quit; the libuv↔GLib bridge
+  # co-pumps Node's event loop during g_application_run (a setTimeout scheduled
+  # before run() fires while run() blocks); and a registerClass({Template,Children,
+  # InternalChildren,CssName}) subclass installs its template in class_init, runs
+  # gtk_widget_init_template at construction, and exposes its bound children on the
+  # instance. This needs a display + the GTK/Adw stack, so it is isolated in a
   # dedicated job: the fast headless `Build & test` leg above stays light and the
   # smoke tests self-skip there (no DISPLAY). Runs the GTK loop, so cap the job
   # rather than let a hung loop wait 6h.
@@ -135,11 +138,12 @@ jobs:
       # bus so GApplication startup is quiet/deterministic; GSK_RENDERER=cairo +
       # LIBGL_ALWAYS_SOFTWARE=1 + GDK_BACKEND=x11 keep GTK off any GPU/Vulkan path
       # that a software-only Xvfb cannot provide; GTK_A11Y=none avoids the a11y bus.
-      # Runs BOTH smoke tests (Gtk.Application PR1 + Adw.Application PR2) in one
-      # node --test invocation so both report even if one fails.
+      # Runs ALL the GTK smoke tests (Gtk.Application PR1 + Adw.Application PR2 +
+      # Gtk.Template PR4) in one node --test invocation so each reports even if one
+      # fails.
       - name: GTK/Adw smoke test (xvfb + dbus)
         working-directory: packages/node-gi/node-gi
         run: |
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
-            node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs
+            node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs test/gtk-template.test.mjs

--- a/packages/node-gi/node-gi/gi.d.ts
+++ b/packages/node-gi/node-gi/gi.d.ts
@@ -54,6 +54,18 @@ export interface RegisterClassMeta {
   GTypeName?: string;
   Properties?: Record<string, ParamSpecDescriptor>;
   Signals?: Record<string, SignalDeclaration>;
+  /**
+   * A Gtk.Widget composite template: inline UI-XML (`Uint8Array`/Buffer or string)
+   * or a `"resource:///…"` path string. Installed on the subclass in `class_init`;
+   * `gtk_widget_init_template` runs at construction. (Gtk.Widget subclasses only.)
+   */
+  Template?: Uint8Array | string;
+  /** Template child ids exposed publicly on the instance as `this.<name>`. */
+  Children?: string[];
+  /** Template child ids exposed privately on the instance as `this._<name>`. */
+  InternalChildren?: string[];
+  /** `gtk_widget_class_set_css_name` for the subclass (Gtk.Widget subclasses only). */
+  CssName?: string;
   [key: string]: unknown;
 }
 

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -889,15 +889,43 @@ function registerClass(metaOrClass, maybeClass) {
     throw new TypeError('GObject.registerClass: a GTypeName is required for an anonymous class');
   }
 
-  const typeHandle = native.registerClass(gtypeName, parent.parentNamespace, parent.parentType, {
-    properties,
-    signals,
-    vfuncs,
-  });
+  // Gtk.Widget composite template (GJS-shaped meta: Template / Children /
+  // InternalChildren / CssName). Template is a Uint8Array/Buffer of inline UI-XML,
+  // a "resource:///…" path string, or an inline UI-XML string — passed through to
+  // the engine, which installs it in class_init (set_template[_from_resource] +
+  // bind_template_child_full) and runs gtk_widget_init_template at construction.
+  const options = { properties, signals, vfuncs };
+  if (meta.Template !== undefined && meta.Template !== null) options.template = meta.Template;
+  if (typeof meta.CssName === 'string' && meta.CssName.length > 0) options.cssName = meta.CssName;
+  const children = Array.isArray(meta.Children) ? meta.Children.filter((c) => typeof c === 'string') : [];
+  const internalChildren = Array.isArray(meta.InternalChildren)
+    ? meta.InternalChildren.filter((c) => typeof c === 'string')
+    : [];
+  if (children.length > 0) options.children = children;
+  if (internalChildren.length > 0) options.internalChildren = internalChildren;
+
+  const typeHandle = native.registerClass(
+    gtypeName,
+    parent.parentNamespace,
+    parent.parentType,
+    options,
+  );
 
   const Subclass = function (props) {
     const handle = native.constructType(typeHandle, props ? unwrapProps(props) : {});
-    return wrapInstance(handle, klass.prototype);
+    const instance = wrapInstance(handle, klass.prototype);
+    // Surface the bound template children on the instance (GJS convention: public
+    // `this.<name>`, internal `this._<name>`, '-' → '_'). The engine already ran
+    // init_template during construction, so get_template_child resolves each.
+    for (const childName of children) {
+      instance[childName.replace(/-/g, '_')] = wrapReturn(native.getTemplateChild(handle, childName));
+    }
+    for (const childName of internalChildren) {
+      instance[`_${childName.replace(/-/g, '_')}`] = wrapReturn(
+        native.getTemplateChild(handle, childName),
+      );
+    }
+    return instance;
   };
   Object.defineProperty(Subclass, 'name', { value: gtypeName, configurable: true });
   Subclass.prototype = klass.prototype;

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -172,6 +172,20 @@ export interface RegisterClassOptions {
   properties?: PropertySpec[];
   signals?: SignalSpec[];
   vfuncs?: VFuncMap;
+  /**
+   * A Gtk.Widget composite template. Either inline UI-XML (a `Uint8Array`/Buffer
+   * or a string) installed via `gtk_widget_class_set_template`, or a
+   * `"resource:///…"` path string installed via
+   * `gtk_widget_class_set_template_from_resource`. Installed in the subtype's
+   * `class_init`; `gtk_widget_init_template` runs at construction.
+   */
+  template?: Uint8Array | string;
+  /** `gtk_widget_class_set_css_name` for the subtype (optional). */
+  cssName?: string;
+  /** Template child ids to bind + expose publicly (via `gtk_widget_get_template_child`). */
+  children?: string[];
+  /** Template child ids to bind as internal children + expose privately. */
+  internalChildren?: string[];
 }
 
 /**
@@ -192,9 +206,18 @@ export function registerClass(
 
 /**
  * Construct a GObject of a registered type handle (from {@link registerClass})
- * with optional construct/settable properties.
+ * with optional construct/settable properties. For a templated type the engine
+ * runs `gtk_widget_init_template` on the new instance before returning it.
  */
 export function constructType(typeHandle: TypeHandle, props?: Record<string, unknown>): GObjectHandle;
+
+/**
+ * Resolve a composite-template child (bound via {@link RegisterClassOptions.children}
+ * / {@link RegisterClassOptions.internalChildren}) by id on a templated instance —
+ * `gtk_widget_get_template_child(widget, G_OBJECT_TYPE(widget), name)`. Returns the
+ * child as a wrapped GObject handle (borrowed; toggle-ref bridged) or `null`.
+ */
+export function getTemplateChild(handle: GObjectHandle, name: string): GObjectHandle | null;
 
 /** Read a GObject property. */
 export function getProperty(handle: GObjectHandle, name: string): unknown;
@@ -321,6 +344,7 @@ declare const native: {
   newObject: typeof newObject;
   registerClass: typeof registerClass;
   constructType: typeof constructType;
+  getTemplateChild: typeof getTemplateChild;
   getProperty: typeof getProperty;
   setProperty: typeof setProperty;
   hasProperty: typeof hasProperty;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -168,12 +168,26 @@ export const registerClass = native.registerClass;
 
 /**
  * Construct a GObject of a registered type handle (from {@link registerClass})
- * with optional construct/settable properties, returning an owned handle.
+ * with optional construct/settable properties, returning an owned handle. For a
+ * templated type the engine runs `gtk_widget_init_template` before returning.
  * @param {unknown} typeHandle a handle from {@link registerClass}
  * @param {Record<string, unknown>} [props]
  * @returns {unknown} opaque GObject handle
  */
 export const constructType = native.constructType;
+
+/**
+ * Resolve a Gtk.Widget composite-template child (bound via the registerClass
+ * Children/InternalChildren options) by id on a templated instance —
+ * `gtk_widget_get_template_child(widget, G_OBJECT_TYPE(widget), name)`. Returns the
+ * child as a wrapped GObject handle (borrowed; owned by the parent via the
+ * template) or `null`. The L1 layer assigns it onto the instance (`this.<name>` /
+ * `this._<name>`).
+ * @param {unknown} handle a templated GObject handle from {@link constructType}
+ * @param {string} name the template child id
+ * @returns {unknown} opaque child GObject handle, or null
+ */
+export const getTemplateChild = native.getTemplateChild;
 
 /**
  * Read a GObject property.

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -50,7 +50,8 @@
     "test:node": "node --test",
     "test:gc": "node --test --expose-gc",
     "test:gtk": "node --test test/gtk-smoke.test.mjs",
-    "test:adw": "node --test test/adw-smoke.test.mjs"
+    "test:adw": "node --test test/adw-smoke.test.mjs",
+    "test:gtk-template": "node --test test/gtk-template.test.mjs"
   },
   "dependencies": {
     "node-addon-api": "^8.0.0"

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -16,6 +16,7 @@
 // while C owns them; idle-deferred teardown; resurrection; thread-marshalled
 // toggles). GTK/Adwaita layering lands on top.
 
+#include <dlfcn.h>  // dlopen/dlsym the GtkWidgetClass template API (no GTK link)
 #include <napi.h>
 #include <uv.h>
 
@@ -2329,6 +2330,12 @@ Napi::Value CallFunction(const Napi::CallbackInfo& info) {
 // further down (it shares the validation logic with the property/method paths).
 static GObject* UnwrapGObject(Napi::Env env, Napi::Value handle);
 
+// Forward declaration: ConstructGObject calls gtk_widget_init_template on a
+// freshly-built widget whose registered type carries a Gtk.Widget template. The
+// helper (and the NodeGiClassData/GtkTemplateApi it reads) is defined with the
+// registerClass machinery further down; a no-op for any non-templated type.
+static void MaybeInitTemplate(GObject* obj);
+
 // Marshal a GValue into a JS value (fundamental types).
 static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
   GType ft = G_TYPE_FUNDAMENTAL(G_VALUE_TYPE(v));
@@ -2528,6 +2535,14 @@ static Napi::Value ConstructGObject(Napi::Env env, GType gtype, Napi::Object pro
   if (g_object_is_floating(obj)) {
     g_object_ref_sink(obj);
   }
+  // Gtk.Widget composite template: instantiate the template tree on this
+  // instance. The canonical GTK call is from instance_init; calling it here —
+  // right after construction, before the wrapper reaches JS — is equivalent for a
+  // templated leaf type (the widget is fully constructed; init_template builds the
+  // declared children + binds them so get_template_child resolves). A no-op unless
+  // the constructed type carries node-gi template data (defined below; forward-
+  // declared above), so plain introspected construction (newObject) is untouched.
+  MaybeInitTemplate(obj);
   return MakeGObjectHandle(env, obj);
 }
 
@@ -2778,6 +2793,59 @@ static void NodeGiVFuncTrampoline(ffi_cif* /*cif*/, void* result, void** args,
   // constructType / method call that triggered this vfunc returns).
 }
 
+// ---- Gtk.Widget composite-template API (resolved via dlsym, no GTK link) ----
+//
+// The engine links only girepository-2.0; GTK is dlopen'd at runtime by the
+// typelib. The composite-template entry points are GtkWidgetClass / GtkWidget
+// calls that take the klass pointer class_init already holds (set_template,
+// bind_template_child_full) or a constructed instance (init_template,
+// get_template_child) — they are not naturally reachable through the introspected
+// method-invoke paths, so they are resolved by symbol from the already-loaded
+// libgtk-4. All argument types are plain GLib/GObject types (GBytes, GType,
+// GObject, gpointer for the opaque GtkWidgetClass/GtkWidget), so no GTK headers
+// are needed. Self-contained to the template feature; nothing else dlopens GTK.
+struct GtkTemplateApi {
+  void (*set_template)(gpointer widget_class, GBytes* template_bytes);
+  void (*set_template_from_resource)(gpointer widget_class, const char* resource_name);
+  void (*bind_template_child_full)(gpointer widget_class, const char* name, gboolean internal,
+                                   gssize struct_offset);
+  void (*set_css_name)(gpointer widget_class, const char* name);
+  void (*init_template)(gpointer widget);
+  GObject* (*get_template_child)(gpointer widget, GType widget_type, const char* name);
+  bool ok;
+};
+
+// Resolve the GTK template API once (C++11 function-local static init is
+// thread-safe; node-gi calls these only on the main thread). dlopen with
+// RTLD_NOLOAD first — requireGi('Gtk','4.0') already dlopened libgtk-4 via the
+// typelib, so this just bumps the refcount; fall back to a plain dlopen so a
+// caller that never required Gtk through the typelib still resolves the symbols.
+static const GtkTemplateApi* GetGtkTemplateApi() {
+  static GtkTemplateApi api = {};
+  static bool initialised = false;
+  if (initialised) return &api;
+  initialised = true;
+  void* lib = dlopen("libgtk-4.so.1", RTLD_LAZY | RTLD_NOLOAD);
+  if (lib == nullptr) lib = dlopen("libgtk-4.so.1", RTLD_LAZY);
+  if (lib == nullptr) return &api;  // api.ok stays false → callers warn + no-op
+  api.set_template = reinterpret_cast<decltype(api.set_template)>(
+      dlsym(lib, "gtk_widget_class_set_template"));
+  api.set_template_from_resource = reinterpret_cast<decltype(api.set_template_from_resource)>(
+      dlsym(lib, "gtk_widget_class_set_template_from_resource"));
+  api.bind_template_child_full = reinterpret_cast<decltype(api.bind_template_child_full)>(
+      dlsym(lib, "gtk_widget_class_bind_template_child_full"));
+  api.set_css_name =
+      reinterpret_cast<decltype(api.set_css_name)>(dlsym(lib, "gtk_widget_class_set_css_name"));
+  api.init_template =
+      reinterpret_cast<decltype(api.init_template)>(dlsym(lib, "gtk_widget_init_template"));
+  api.get_template_child = reinterpret_cast<decltype(api.get_template_child)>(
+      dlsym(lib, "gtk_widget_get_template_child"));
+  api.ok = api.set_template != nullptr && api.set_template_from_resource != nullptr &&
+           api.bind_template_child_full != nullptr && api.set_css_name != nullptr &&
+           api.init_template != nullptr && api.get_template_child != nullptr;
+  return &api;
+}
+
 // Per-registered-type metadata, passed as GTypeInfo.class_data → class_init.
 // Heap-allocated and intentionally never freed (a GType is process-permanent).
 struct NodeGiClassData {
@@ -2786,6 +2854,13 @@ struct NodeGiClassData {
   std::vector<NodeGiVFunc*> vfuncs;  // class-lifetime vfunc overrides (never freed)
   void (*parentGet)(GObject*, guint, GValue*, GParamSpec*);
   void (*parentSet)(GObject*, guint, const GValue*, GParamSpec*);
+  // Gtk.Widget composite template (when registerClass meta carried a Template).
+  bool hasTemplate = false;
+  GBytes* templateBytes = nullptr;            // owned inline UI-XML (g_bytes_new copy)
+  std::string templateResource;               // resource path (e.g. "/eu/app/win.ui")
+  std::string cssName;                        // gtk_widget_class_set_css_name (optional)
+  std::vector<std::string> children;          // public Children ids
+  std::vector<std::string> internalChildren;  // InternalChildren ids
 };
 
 static GQuark NodeGiClassDataQuark() {
@@ -2810,6 +2885,22 @@ static NodeGiClassData* FindClassData(GType type) {
     if (cd != nullptr) return cd;
   }
   return nullptr;
+}
+
+// Instantiate the Gtk.Widget template on a freshly-constructed instance (see the
+// forward declaration above ConstructGObject). A no-op unless the instance's
+// registered type carries node-gi template data, so it is safe on every GObject
+// construction. Uses the instance's actual type's class data (single-level
+// registered templated type — the construct() case).
+static void MaybeInitTemplate(GObject* obj) {
+  NodeGiClassData* cd = FindClassData(G_OBJECT_TYPE(obj));
+  if (cd == nullptr || !cd->hasTemplate) return;
+  const GtkTemplateApi* gtk = GetGtkTemplateApi();
+  if (!gtk->ok) return;
+  // Only a Gtk.Widget can be init_template'd (class_init also skips a non-widget
+  // template). g_type_from_name is 0 if GTK never loaded → guard is false → skip.
+  GType widgetType = g_type_from_name("GtkWidget");
+  if (widgetType != 0 && g_type_is_a(G_OBJECT_TYPE(obj), widgetType)) gtk->init_template(obj);
 }
 
 // A property is custom iff its owner GType carries node-gi class-data; otherwise
@@ -2941,6 +3032,40 @@ static void NodeGiClassInit(gpointer g_class, gpointer class_data) {
     }
     g_object_unref(repo);
   }
+
+  // ---- Gtk.Widget composite template ----
+  // Install the template + bind the declared children on the new GtkWidgetClass.
+  // g_class is the new type's class struct, which derives from GtkWidgetClass for
+  // any Gtk.Widget subtype — exactly the pointer gtk_widget_class_set_template*
+  // expects. Done in class_init, the idiomatic GTK lifecycle point (C widgets
+  // call set_template in their class_init too). get_template_child / init_template
+  // run later, per instance.
+  if (cd->hasTemplate) {
+    const GtkTemplateApi* gtk = GetGtkTemplateApi();
+    GType widgetType = g_type_from_name("GtkWidget");
+    bool isWidget = widgetType != 0 && g_type_is_a(G_TYPE_FROM_CLASS(g_class), widgetType);
+    if (gtk->ok && isWidget) {
+      if (!cd->cssName.empty()) gtk->set_css_name(g_class, cd->cssName.c_str());
+      if (cd->templateBytes != nullptr) {
+        gtk->set_template(g_class, cd->templateBytes);
+      } else if (!cd->templateResource.empty()) {
+        gtk->set_template_from_resource(g_class, cd->templateResource.c_str());
+      }
+      for (const std::string& c : cd->children)
+        gtk->bind_template_child_full(g_class, c.c_str(), FALSE, 0);
+      for (const std::string& c : cd->internalChildren)
+        gtk->bind_template_child_full(g_class, c.c_str(), TRUE, 0);
+    } else if (!isWidget) {
+      g_warning(
+          "node-gi: a Template was set on %s, which is not a Gtk.Widget subclass — "
+          "composite templates require a Gtk.Widget ancestor; ignoring the template",
+          g_type_name(G_TYPE_FROM_CLASS(g_class)));
+    } else {
+      g_warning(
+          "node-gi: a Gtk.Widget Template was requested but the libgtk-4 template "
+          "API could not be resolved (is GTK 4 installed?)");
+    }
+  }
 }
 
 // registerClass(name, parentNamespace, parentTypeName, options?) -> typeHandle
@@ -3058,6 +3183,51 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
         cd->vfuncs.push_back(rec);
       }
     }
+    // template: a Gtk.Widget composite template. Accepts a Uint8Array/Buffer of
+    // inline UI-XML, a "resource:///…" path string (→ set_template_from_resource),
+    // or a plain inline UI-XML string. Installed on the class in class_init.
+    if (opts.Has("template")) {
+      Napi::Value tv = opts.Get("template");
+      if (tv.IsString()) {
+        std::string s = tv.As<Napi::String>().Utf8Value();
+        const std::string kResource = "resource://";
+        if (s.rfind(kResource, 0) == 0) {
+          // "resource:///path" → the resource PATH "/path" (strip the scheme +
+          // authority "resource://"), matching gtk_widget_class_set_template_from_resource.
+          cd->templateResource = s.substr(kResource.size());
+          cd->hasTemplate = true;
+        } else {
+          // Inline UI-XML string → owned GBytes copy.
+          cd->templateBytes = g_bytes_new(s.data(), s.size());
+          cd->hasTemplate = true;
+        }
+      } else if (tv.IsBuffer()) {
+        Napi::Buffer<uint8_t> b = tv.As<Napi::Buffer<uint8_t>>();
+        cd->templateBytes = g_bytes_new(b.Data(), b.Length());
+        cd->hasTemplate = true;
+      } else if (tv.IsTypedArray()) {
+        Napi::TypedArray ta = tv.As<Napi::TypedArray>();
+        const uint8_t* data = static_cast<const uint8_t*>(ta.ArrayBuffer().Data()) + ta.ByteOffset();
+        cd->templateBytes = g_bytes_new(data, ta.ByteLength());
+        cd->hasTemplate = true;
+      }
+    }
+    if (opts.Has("cssName") && opts.Get("cssName").IsString()) {
+      cd->cssName = opts.Get("cssName").As<Napi::String>().Utf8Value();
+    }
+    if (opts.Has("children") && opts.Get("children").IsArray()) {
+      Napi::Array arr = opts.Get("children").As<Napi::Array>();
+      for (uint32_t i = 0; i < arr.Length(); i++) {
+        if (arr.Get(i).IsString()) cd->children.push_back(arr.Get(i).As<Napi::String>().Utf8Value());
+      }
+    }
+    if (opts.Has("internalChildren") && opts.Get("internalChildren").IsArray()) {
+      Napi::Array arr = opts.Get("internalChildren").As<Napi::Array>();
+      for (uint32_t i = 0; i < arr.Length(); i++) {
+        if (arr.Get(i).IsString())
+          cd->internalChildren.push_back(arr.Get(i).As<Napi::String>().Utf8Value());
+      }
+    }
   }
 
   GTypeInfo typeInfo = {};
@@ -3100,6 +3270,35 @@ Napi::Value ConstructType(const Napi::CallbackInfo& info) {
   Napi::Object props = (info.Length() >= 2 && info[1].IsObject()) ? info[1].As<Napi::Object>()
                                                                  : Napi::Object::New(env);
   return ConstructGObject(env, gtype, props, std::string(g_type_name(gtype)));
+}
+
+// getTemplateChild(handle, name) -> wrapped child GObject | null
+//
+// Resolve a composite-template child bound on the instance's type (declared via
+// registerClass Children/InternalChildren) by name. Returns the child wrapped
+// through the canonical toggle-ref bridge (GI_TRANSFER_NOTHING — the child is
+// owned by the parent widget via the template, a borrowed pointer). The L1 layer
+// assigns the result onto the instance (public `this.name`, internal `this._name`).
+Napi::Value GetTemplateChild(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[1].IsString()) {
+    Napi::TypeError::New(env, "getTemplateChild(handle, name: string)").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  GObject* obj = UnwrapGObject(env, info[0]);
+  if (obj == nullptr) return env.Null();
+  std::string name = info[1].As<Napi::String>().Utf8Value();
+  const GtkTemplateApi* gtk = GetGtkTemplateApi();
+  if (!gtk->ok) {
+    Napi::Error::New(env, "node-gi: the libgtk-4 template API is unavailable")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  // Look the child up against the instance's actual type (the registered
+  // templated type for the single-level case the decorator constructs).
+  GObject* child = gtk->get_template_child(obj, G_OBJECT_TYPE(obj), name.c_str());
+  if (child == nullptr) return env.Null();
+  return WrapGObject(env, child, GI_TRANSFER_NOTHING);
 }
 
 // getProperty(handle, name) -> unknown
@@ -4414,6 +4613,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("newObject", Napi::Function::New(env, NewObject));
   exports.Set("registerClass", Napi::Function::New(env, RegisterClass));
   exports.Set("constructType", Napi::Function::New(env, ConstructType));
+  exports.Set("getTemplateChild", Napi::Function::New(env, GetTemplateChild));
   exports.Set("getProperty", Napi::Function::New(env, GetProperty));
   exports.Set("setProperty", Napi::Function::New(env, SetProperty));
   exports.Set("hasProperty", Napi::Function::New(env, HasProperty));

--- a/packages/node-gi/node-gi/test/gtk-template.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template.test.mjs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gtk.Template composite-template smoke test (GTK milestone PR4).
+//
+// Proves an UNCHANGED GJS composite-template widget runs on Node via the engine:
+// `GObject.registerClass({ GTypeName, Template, Children, InternalChildren,
+// CssName }, class extends Gtk.Box {})` installs the template + binds children in
+// the new type's class_init, the constructor runs gtk_widget_init_template, and
+// the declared children are exposed on the instance (public `this.<name>`,
+// internal `this._<name>`) as wrapped child widgets.
+//
+// What it exercises (the engine lift behind PR4):
+//   - registerClass meta Template (inline UI-XML bytes) → gtk_widget_class_set_template
+//   - Children/InternalChildren → gtk_widget_class_bind_template_child_full
+//   - CssName → gtk_widget_class_set_css_name
+//   - construction → gtk_widget_init_template (template tree instantiated)
+//   - this.title / this._btn → gtk_widget_get_template_child, toggle-ref wrapped,
+//     each a usable child widget (property get/set round-trips through the proxy)
+//
+// SELF-SKIPPING: needs a display (DISPLAY / WAYLAND_DISPLAY) and the Gtk-4.0
+// typelib, so the fast headless `npm test` / `test:gc` legs skip it cleanly; the
+// dedicated `gtk-smoke` CI job (Xvfb + GTK stack) runs it.
+//
+// Templates need GTK initialised (a display) — so the widget is CONSTRUCTED inside
+// the app's `activate` (after gtk_init has run in startup). registerClass at the
+// top of the body only registers the type; class_init (the set_template step)
+// fires on first construction, inside activate. run() is called at the TOP LEVEL
+// of the synchronous test body (the node-gtk #442 nested-checkpoint caveat) and
+// the quit is driven from a GLib timeout running INSIDE the loop.
+//
+// Reference: refs/gjs/modules/core/overrides/Gtk.js (the Gtk.Template semantics
+// mirrored here), /usr/include/gtk-4.0/gtk/gtkwidget.h (the class template API).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let GObject;
+let Gtk;
+let Gio;
+let GLib;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    GObject = requireGi('GObject', '2.0');
+    Gtk = requireGi('Gtk', '4.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+// Inline composite-template UI-XML: a vertical GtkBox subclass carrying a labelled
+// child (id "title", public) and a button child (id "btn", internal). The
+// <template class=…> MUST match the registered GTypeName.
+const TEMPLATE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="NodeGiTemplateBox" parent="GtkBox">
+    <property name="orientation">vertical</property>
+    <property name="spacing">6</property>
+    <child>
+      <object class="GtkLabel" id="title">
+        <property name="label">Hello from a template</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="btn">
+        <property name="label">Click me</property>
+      </object>
+    </child>
+  </template>
+</interface>`;
+
+test('Gtk.Template composite template works on Node', { skip }, () => {
+  // Register the templated subclass. class_init (set_template + bind children)
+  // fires on first construction, below in activate.
+  const TemplateBox = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiTemplateBox',
+      Template: new TextEncoder().encode(TEMPLATE_XML), // inline UI-XML bytes
+      Children: ['title'],
+      InternalChildren: ['btn'],
+      CssName: 'nodegitemplatebox',
+    },
+    class TemplateBox extends Gtk.Box {
+      // A user method to confirm the user prototype still composes with templates.
+      titleText() {
+        return this.title.label;
+      }
+    },
+  );
+
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiGtkTemplate',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+  });
+
+  const results = {};
+  let activateError = null;
+
+  app.connect('activate', () => {
+    try {
+      const widget = new TemplateBox();
+
+      // The instance is the registered templated type.
+      results.widgetType = native.getTypeName(unwrap(widget));
+
+      // Public child: this.title is the bound GtkLabel, with its template label.
+      results.title = widget.title;
+      results.titleType = widget.title != null ? native.getTypeName(unwrap(widget.title)) : null;
+      results.titleLabel = widget.title != null ? widget.title.label : null;
+      results.titleViaUserMethod = widget.titleText();
+
+      // Property round-trip through the wrapped child.
+      widget.title.label = 'Updated from JS';
+      results.titleLabelAfterSet = widget.title.label;
+
+      // Internal child: this._btn is the bound GtkButton, with its template label.
+      results.btn = widget._btn;
+      results.btnType = widget._btn != null ? native.getTypeName(unwrap(widget._btn)) : null;
+      results.btnLabel = widget._btn != null ? widget._btn.label : null;
+
+      // CssName installed on the type via gtk_widget_class_set_css_name.
+      results.cssName = widget.get_css_name();
+
+      // Put the widget in a window + present, then quit from inside the loop.
+      const win = new Gtk.ApplicationWindow({ application: app });
+      win.set_child(widget);
+      win.present();
+
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        app.quit();
+        return GLib.SOURCE_REMOVE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]); // top-level blocking run (no async wrapper)
+
+  assert.equal(activateError, null, `activate handler threw: ${activateError && activateError.stack}`);
+  assert.equal(status, 0, 'app.run([]) should exit 0');
+
+  assert.equal(results.widgetType, 'NodeGiTemplateBox', 'the instance is the registered type');
+
+  // Public child exposed as this.title, a real GtkLabel with its template label.
+  assert.notEqual(results.title, undefined, 'this.title should be defined');
+  assert.notEqual(results.title, null, 'this.title should be a bound child, not null');
+  assert.equal(results.titleType, 'GtkLabel', 'this.title is a Gtk.Label');
+  assert.equal(results.titleLabel, 'Hello from a template', 'this.title carries its template label');
+  assert.equal(results.titleViaUserMethod, 'Hello from a template', 'user method reads this.title');
+  assert.equal(results.titleLabelAfterSet, 'Updated from JS', 'child property set/get round-trips');
+
+  // Internal child exposed as this._btn, a real GtkButton with its template label.
+  assert.notEqual(results.btn, null, 'this._btn should be a bound internal child, not null');
+  assert.equal(results.btnType, 'GtkButton', 'this._btn is a Gtk.Button');
+  assert.equal(results.btnLabel, 'Click me', 'this._btn carries its template label');
+
+  // CssName took effect.
+  assert.equal(results.cssName, 'nodegitemplatebox', 'CssName installed via set_css_name');
+});


### PR DESCRIPTION
Layer **Gtk.Widget composite templates** onto the `@gjsify/node-gi` engine so an unchanged GJS widget runs on Node:

```js
const Card = GObject.registerClass({
  GTypeName: 'Card',
  Template: new TextEncoder().encode(uiXml),   // inline UI-XML bytes, or 'resource:///…'
  Children: ['title'], InternalChildren: ['btn'],
  CssName: 'card',
}, class extends Gtk.Box {});
const c = new Card();        // c.title is the GtkLabel, c._btn the GtkButton
```

PR4 of the GTK layering milestone (after PR1 `Gtk.Application` #659, PR2 `Adw.Application` #660).

## Mechanism

**Engine (`src/addon.cc`)**
- The `GtkWidgetClass`/`GtkWidget` template entry points are resolved **by symbol from the already-loaded libgtk-4** (`dlopen` `RTLD_NOLOAD` — the typelib loaded it), not through the introspected method paths: they take the klass pointer `class_init` holds or a constructed instance, and all argument types are plain GLib/GObject types, so no GTK link/headers are added. Self-contained to the template feature.
- `registerClass` meta carries `template`/`cssName`/`children`/`internalChildren` on `NodeGiClassData`. In **`class_init`** (the idiomatic GTK lifecycle point, guarded on the new type being a `Gtk.Widget`): `gtk_widget_class_set_css_name`, then `gtk_widget_class_set_template` (inline UI-XML `GBytes`) or `set_template_from_resource` (a `resource:///…` path), then `gtk_widget_class_bind_template_child_full(name, internal, 0)` per child.
- **`ConstructGObject`** runs `gtk_widget_init_template` on a freshly-built templated widget (gated on the type carrying node-gi template data, so plain introspected construction is untouched).
- New **`getTemplateChild(handle, name)`** → `gtk_widget_get_template_child(widget, G_OBJECT_TYPE(widget), name)`, wrapped `GI_TRANSFER_NOTHING` through the canonical toggle-ref bridge (#656) — the child is owned by the parent widget via the template, a borrowed pointer.

**L1 (`gi.js`)** — the `registerClass` decorator parses `Template`/`Children`/`InternalChildren`/`CssName` and, after `constructType`, exposes each bound child on the instance: public `this.<name>`, internal `this._<name>`, `'-'` → `'_'` — mirroring GJS's `Gtk.js` semantics.

## Test

`test/gtk-template.test.mjs` (self-skipping without a display/typelib): a vertical `Gtk.Box` subclass with an inline UI-XML `Template` declaring a public `GtkLabel` (id `title`) and an internal `GtkButton` (id `btn`), constructed inside an app's `activate`; asserts the instance type, that `this.title` is the `GtkLabel` (label read + set/get round-trip + reachable from a user method), `this._btn` is the `GtkButton`, and the `CssName` took effect. The `gtk-smoke` CI job runs it under Xvfb alongside the PR1/PR2 smokes (`node --test gtk-smoke adw-smoke gtk-template`).

Local: all three smoke tests pass together (`# pass 3 # skipped 0`); headless `npm test` 160 pass / 14 skip / 0 fail; `test:gc` 171 pass / 0 fail.

## Scope

- **GResource** paths are supported (`set_template_from_resource`); the test uses inline UI-XML bytes so no `.gresource` compiler is needed.
- Deferred: template callbacks (`<signal handler=…>`) and vfunc chain-up (`super.vfunc_*`).

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH