### PR TITLE
feat(node-gi): dual gjs+node Adwaita GTK capstone

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -113,10 +113,11 @@ jobs:
       - name: Install toolchain + GTK4/Adwaita + Xvfb + dbus
         run: |
           dnf install -y --setopt=install_weak_deps=False \
-            git gcc-c++ make python3 pkgconf-pkg-config tar xz \
+            git gcc-c++ make python3 pkgconf-pkg-config tar xz gjs \
             glib2-devel gobject-introspection-devel gobject-introspection \
             gtk4-devel libadwaita-devel \
             xorg-x11-server-Xvfb dbus-daemon dbus-x11 mesa-dri-drivers
+          gjs --version
           echo "gtk4: $(pkg-config --modversion gtk4)"
           echo "libadwaita: $(pkg-config --modversion libadwaita-1)"
 
@@ -147,3 +148,21 @@ jobs:
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs test/gtk-template.test.mjs
+
+      # GTK capstone: ONE unchanged Adwaita gi:// source builds + runs
+      # byte-identically on BOTH gjs and node under one display — the GTK analog of
+      # the headless L3 capstone. `npm install` builds @gjsify/node-gi via the
+      # file:../node-gi dependency (node-gyp), so the example exercises the in-tree
+      # runtime + addon. dual.e2e.mjs builds `--app gjs` (real bundler) + runs on
+      # gjs, and runs the same source on node (the real `--app node` bundle when
+      # the installed CLI carries the gi://→requireGi rewrite, else the
+      # @gjsify/node-gi runtime), asserting both equal the golden. Both runtimes
+      # run under the SAME Xvfb display + software render env; the gjs binary is
+      # installed above for the gjs side.
+      - name: GTK dual gjs+node Adwaita example (capstone)
+        working-directory: packages/node-gi/example-gtk
+        run: |
+          npm install --no-audit --no-fund --foreground-scripts
+          xvfb-run -a dbus-run-session -- \
+            env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
+            node --test dual.e2e.mjs

--- a/packages/node-gi/example-gtk/.gitignore
+++ b/packages/node-gi/example-gtk/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/packages/node-gi/example-gtk/README.md
+++ b/packages/node-gi/example-gtk/README.md
@@ -1,0 +1,110 @@
+# @gjsify/node-gi — one Adwaita source, two runtimes (GTK capstone)
+
+The GTK analog of the headless [`../example`](../example) capstone: a single,
+**unchanged** GJS / Libadwaita application ([`src/app.ts`](src/app.ts)) that
+builds and runs **identically** on both GJS and Node.js.
+
+```
+gjsify build src/app.ts --app gjs   → gjs  -m dist/app.gjs.mjs   (native gi://)
+gjsify build src/app.ts --app node  → node    dist/app.node.mjs  (@gjsify/node-gi)
+```
+
+The `gjsify` bundler keeps the `gi://` imports native for the GJS target and
+rewrites them onto the node-gi L1 runtime (`requireGi`) for the Node target. The
+GJS ambient `print` global is injected for the Node build by `--globals auto`
+(the `@gjsify/node-gi/globals` shim) — no `/register` import in the source.
+
+Both builds print the same fixed sequence of lines (the GOLDEN output asserted by
+[`dual.e2e.mjs`](dual.e2e.mjs)):
+
+```
+gtk-dual: start
+activated
+child: template
+title: hello
+css: applied
+action: hello
+quit
+done
+```
+
+## What the shared source exercises
+
+| GTK / Adwaita feature | API in `src/app.ts` |
+|---|---|
+| Adw.Application + the libuv↔GLib loop bridge | `new Adw.Application({ application_id, flags: NON_UNIQUE })`, `app.run([])`, quit from a `GLib.timeout_add` |
+| Composite template (window subclass) | `GObject.registerClass({ GTypeName, Template: <inline UI-XML bytes>, Children: ['heading'] }, class extends Adw.ApplicationWindow {})` |
+| Adwaita chrome (in the template) | `Adw.ToolbarView` + `Adw.HeaderBar` + `Adw.WindowTitle` over a `Gtk.Label` content |
+| Bound template child | `win.heading` (the labelled child), read + write its `label` |
+| CSS | `Gtk.CssProvider.load_from_string` → `Gdk.Display.get_default` → `Gtk.StyleContext.add_provider_for_display(display, provider, STYLE_PROVIDER_PRIORITY_APPLICATION)` → `add_css_class` / `has_css_class` |
+| Gio.SimpleAction | `new Gio.SimpleAction({ name })`, `app.add_action(action)`, `action.connect('activate', …)`, `action.activate(null)` |
+
+Every value is **deterministic** — no hostname, no machine paths — and never
+depends on a signal callback's arguments (the Node runtime omits the emitter as
+the first callback arg, so the example only ever prints closure-captured
+constants). That is what lets the two runtimes produce byte-identical output.
+
+### Dual-safety findings (gjs vs node)
+
+Two genuine cross-runtime constraints surfaced while building this capstone — both
+are reasons the source is shaped the way it is:
+
+1. **A composite-template child id must not collide with a GObject property of the
+   widget.** A child id `title` on this `Adw.ApplicationWindow` (which has a
+   `title` string property) crashes **both** runtimes — GJS with an uncatchable
+   exception, node-gi with a fatal abort — because the bound-child accessor
+   clashes with the property. The child is therefore named `heading`. (This is a
+   GTK/GJS-level footgun, identical on native GJS — not a node-gi-specific defect.)
+2. **There is no dual-safe way to read an introspected instance's GType name.**
+   `constructor.$gtype` is undefined on node-gi, `GObject.type_name_from_instance`
+   is not marshallable, and `constructor.name` differs (`Object` vs
+   `Gio_SimpleAction`). The bound child is therefore proved via property
+   round-trips (`child: <template label>` then `title: <value we set>`), not by
+   printing its type.
+
+## Run it
+
+```bash
+npm install      # builds @gjsify/node-gi's native addon via the file: dependency
+npm run build    # builds both the gjs and node bundles
+npm run start:gjs
+npm run start:node
+npm test         # node --test dual.e2e.mjs — asserts gjs === node === GOLDEN
+```
+
+GTK needs a display. On a headless machine run the build + start + test under a
+virtual display with the software render env:
+
+```bash
+xvfb-run -a dbus-run-session -- \
+  env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
+  npm test
+```
+
+`dual.e2e.mjs` self-skips when no display is present, so a plain headless
+`node --test` stays green; the dedicated `gtk-smoke` CI job runs it under Xvfb.
+
+> The dependency here is `"@gjsify/node-gi": "file:../node-gi"` so the example
+> validates the in-tree runtime. The real consumer form is the published package:
+> `"@gjsify/node-gi": "^0.13.0"`.
+
+> **CLI note.** `npm run build:node` (the `gjsify build --app node` rewrite of
+> `gi://` → `requireGi` + the `@gjsify/node-gi/globals` injection) needs a
+> `gjsify` CLI that carries the node-gi bundler integration. That ships on the
+> gjsify `main` branch; it may be newer than the `@gjsify/cli` on npm's `latest`
+> tag. With an older CLI the node bundle is produced but stubs `gi://`, so
+> `npm run start:node` would not run. `dual.e2e.mjs` handles this automatically:
+> it runs the real `--app node` bundle when the CLI supports the rewrite, and
+> otherwise runs the same source through the `@gjsify/node-gi` runtime — either
+> way asserting byte-identical output. `npm run build:gjs` / `start:gjs` work with
+> any CLI (`gi://` stays native under GJS).
+
+## Requirements
+
+- Node.js ≥ 20 and the `gjs` binary on `PATH`.
+- A C++ toolchain + the GLib ≥ 2.80 / `girepository-2.0` development headers (so
+  `npm install` can build the node-gi native addon) — see the
+  [`@gjsify/node-gi` README](../node-gi/README.md#requirements).
+- The GTK stack + typelibs: `gtk4` / `gtk4-devel`, `libadwaita` /
+  `libadwaita-devel` (these provide the `Gtk-4.0` / `Gdk-4.0` / `Adw-1`
+  typelibs), and a display (real, or `Xvfb`).

--- a/packages/node-gi/example-gtk/dual.e2e.mjs
+++ b/packages/node-gi/example-gtk/dual.e2e.mjs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+//
+// The @gjsify/node-gi GTK capstone proof: ONE unchanged `gi://` Adwaita source
+// ([`src/app.ts`](src/app.ts)) builds AND runs with byte-identical output on BOTH
+// runtimes.
+//
+//   gjsify build src/app.ts --app gjs   → gjs  -m dist/app.gjs.mjs   (native gi://)
+//   gjsify build src/app.ts --app node  → node    dist/app.node.mjs  (@gjsify/node-gi)
+//
+// The test asserts the two stdout streams are byte-identical AND equal to the
+// fixed GOLDEN output below. Run via `node --test dual.e2e.mjs`.
+//
+// GTK needs a display + the Gtk-4.0 / Adw-1 typelibs, so BOTH builds are run under
+// the same display (Xvfb in CI), with the software-only render env
+// (GSK_RENDERER=cairo, LIBGL_ALWAYS_SOFTWARE=1, GTK_A11Y=none). The test
+// SELF-SKIPS when no display is present (DISPLAY / WAYLAND_DISPLAY unset), so a
+// plain headless `node --test` stays green; the dedicated `gtk-smoke` CI job runs
+// it under `xvfb-run -a dbus-run-session`.
+//
+// GJS side: always built by the real `gjsify build --app gjs` bundler (the `gjs`
+// binary must be on PATH).
+//
+// Node side: built by the real `gjsify build --app node` bundler when the
+// installed `gjsify` CLI carries the `gi://` → `requireGi` rewrite + the
+// `@gjsify/node-gi/globals` injection. The npm-published `@gjsify/cli` on the
+// `latest` tag may still PREDATE that rewrite (it ships on `main`), so when an
+// older CLI is installed the test runs the SAME source through the
+// `@gjsify/node-gi` runtime directly via the exact module shape the bundler emits
+// — `import '@gjsify/node-gi/globals'` plus `requireGi('Ns','ver')` in place of
+// each `gi://` import. Either way the node output must equal the golden and the
+// gjs output byte-for-byte. Once a rewrite-capable CLI is installed (locally
+// today, or from npm once released) this automatically upgrades to the real
+// `--app node` bundle.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+const gjsify = join(here, 'node_modules', '.bin', 'gjsify');
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+// The fixed sequence of lines both runtimes must print, in order.
+const GOLDEN = [
+    'gtk-dual: start',
+    'activated',
+    'child: template',
+    'title: hello',
+    'css: applied',
+    'action: hello',
+    'quit',
+    'done',
+].join('\n');
+
+// The software-only GTK render env for the run children. The display (DISPLAY)
+// comes from the surrounding xvfb-run / real session; these keep GTK off any
+// GPU/Vulkan path a headless Xvfb cannot provide and off the a11y bus. Merged
+// over the inherited env (which already carries DISPLAY + whatever the CI wrapper
+// set), so a value already present is preserved.
+const RUN_ENV = {
+    GSK_RENDERER: 'cairo',
+    LIBGL_ALWAYS_SOFTWARE: '1',
+    GTK_A11Y: 'none',
+    ...process.env,
+};
+
+// Run a command, capturing stdout+stderr; on failure re-throw with both streams
+// attached so a CI failure shows the real error (execFileSync otherwise hides
+// the child's stderr behind a generic "Command failed" message).
+function exec(cmd, args, timeoutMs, env) {
+    try {
+        return execFileSync(cmd, args, {
+            cwd: here,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: timeoutMs,
+            encoding: 'utf-8',
+            env: env ?? process.env,
+        });
+    } catch (err) {
+        const out = (err.stdout || '').toString();
+        const e = (err.stderr || '').toString();
+        throw new Error(
+            `${cmd} ${args.join(' ')} failed (code ${err.status ?? err.code})\n--- stdout ---\n${out}\n--- stderr ---\n${e}`,
+        );
+    }
+}
+
+function build(app, outfile) {
+    exec(gjsify, ['build', 'src/app.ts', '--app', app, '--outfile', outfile], 120 * 1000);
+    const outPath = join(here, outfile);
+    assert.ok(existsSync(outPath), `${outfile} was not produced`);
+    return outPath;
+}
+
+// Run a built GTK bundle under the software render env, then keep ONLY the golden
+// lifecycle lines: a headless GTK/dbus session prints assorted portal / a11y /
+// gvfs warnings to stdout+stderr that vary by host, so the assertion is on the
+// app's own deterministic lines (each carries a known prefix), not the raw stream.
+const GOLDEN_PREFIXES = ['gtk-dual:', 'activated', 'child:', 'title:', 'css:', 'action:', 'quit', 'done', 'activate-error:'];
+function run(cmd, args) {
+    const raw = exec(cmd, args, 60 * 1000, RUN_ENV);
+    return raw
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => GOLDEN_PREFIXES.some((p) => l === p || l.startsWith(p)))
+        .join('\n');
+}
+
+// Produce the node-gi runtime twin of the bundler's `--app node` output from the
+// shared source: prepend the globals shim + rewrite each `gi://Ns?version=X`
+// default import to `requireGi('Ns','X')`. This is exactly what the bundler
+// emits; it lets the @gjsify/node-gi runtime run the UNCHANGED source on Node
+// when the installed CLI is older than the bundler rewrite.
+function writeRuntimeTwin() {
+    const src = readFileSync(join(here, 'src', 'app.ts'), 'utf-8');
+    const rewritten = src.replace(
+        /import\s+(\w+)\s+from\s+['"]gi:\/\/(\w+)\?version=([\d.]+)['"];?/g,
+        (_m, ident, ns, ver) => `const ${ident} = requireGi('${ns}', '${ver}');`,
+    );
+    const body =
+        "import '@gjsify/node-gi/globals';\n" +
+        "import { requireGi } from '@gjsify/node-gi/gi';\n" +
+        rewritten;
+    mkdirSync(join(here, 'dist'), { recursive: true });
+    const out = join(here, 'dist', 'app.node-runtime.mjs');
+    writeFileSync(out, body);
+    return out;
+}
+
+test(
+    'one gi:// Adwaita source builds + runs byte-identically on gjs and node',
+    { skip: haveDisplay ? false : 'no display (DISPLAY / WAYLAND_DISPLAY unset)' },
+    (t) => {
+        // --- GJS: the real bundler, native gi:// ---
+        const gjsBundle = build('gjs', 'dist/app.gjs.mjs');
+        const gjsOut = run('gjs', ['-m', gjsBundle]);
+        assert.equal(gjsOut, GOLDEN, 'gjs output diverged from the golden');
+
+        // --- Node: the real bundler when available, else the node-gi runtime twin ---
+        const nodeBundle = build('node', 'dist/app.node.mjs');
+        const capable = readFileSync(nodeBundle, 'utf-8').includes('requireGi');
+        let nodeEntry;
+        if (capable) {
+            t.diagnostic('node target: real `gjsify build --app node` bundle (rewrite-capable CLI)');
+            nodeEntry = nodeBundle;
+        } else {
+            t.diagnostic(
+                'node target: installed @gjsify/cli predates the gi://→requireGi rewrite (unreleased on npm); running the same source through the @gjsify/node-gi runtime',
+            );
+            nodeEntry = writeRuntimeTwin();
+        }
+        const nodeOut = run('node', [nodeEntry]);
+
+        assert.equal(nodeOut, GOLDEN, 'node output diverged from the golden');
+        assert.equal(gjsOut, nodeOut, 'gjs and node outputs are not byte-identical');
+    },
+);

--- a/packages/node-gi/example-gtk/package.json
+++ b/packages/node-gi/example-gtk/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@gjsify/example-node-gi-gtk-dual",
+  "description": "One Adwaita source, two runtimes — the same gi:// Gtk/Adw application built and run on both GJS and Node.js via @gjsify/node-gi.",
+  "version": "0.13.0",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "gjsify": {
+    "runtimes": {
+      "gjs": "polyfill",
+      "node": "none",
+      "browser": "none",
+      "nativescript": "none"
+    }
+  },
+  "scripts": {
+    "build": "npm run build:gjs && npm run build:node",
+    "build:gjs": "gjsify build src/app.ts --app gjs --outfile dist/app.gjs.mjs",
+    "build:node": "gjsify build src/app.ts --app node --outfile dist/app.node.mjs",
+    "start:gjs": "gjs -m dist/app.gjs.mjs",
+    "start:node": "node dist/app.node.mjs",
+    "test": "node --test dual.e2e.mjs",
+    "clear": "rm -rf dist"
+  },
+  "dependencies": {
+    "@gjsify/node-gi": "file:../node-gi"
+  },
+  "devDependencies": {
+    "@gjsify/cli": "^0.13.0",
+    "@girs/gjs": "4.0.4",
+    "@girs/glib-2.0": "2.88.0-4.0.4",
+    "@girs/gobject-2.0": "2.88.0-4.0.4",
+    "@girs/gio-2.0": "2.88.0-4.0.4",
+    "@girs/gdk-4.0": "4.0.0-4.0.4",
+    "@girs/gtk-4.0": "4.23.0-4.0.4",
+    "@girs/adw-1": "1.10.0-4.0.4"
+  },
+  "author": "Pascal Garber <pascal@artandcode.studio>",
+  "license": "MIT"
+}

--- a/packages/node-gi/example-gtk/src/app.ts
+++ b/packages/node-gi/example-gtk/src/app.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+//
+// One Adwaita source, two runtimes — the @gjsify/node-gi GTK capstone.
+//
+// This file is BYTE-IDENTICAL input to both builds:
+//   gjsify build src/app.ts --app gjs   → native `gi://` Gtk/Adw under GJS
+//   gjsify build src/app.ts --app node  → `@gjsify/node-gi` under Node.js
+//
+// It is the GTK analog of the headless L3 capstone (../example): an UNCHANGED
+// Libadwaita application that builds AND runs identically on GJS (native
+// `gi://Gtk` / `gi://Adw`) and on Node (the node-gi engine). The `gi://` imports
+// are rewritten by the bundler — kept native for `--app gjs`, routed to the
+// node-gi L1 runtime (`requireGi`) for `--app node`. The `print` global is
+// ambient under GJS and injected by `--globals auto` (the
+// `@gjsify/node-gi/globals` shim) for the node build — NO `/register` import.
+//
+// It exercises everything the GTK layering milestone landed:
+//   - Adw.Application (NON_UNIQUE) driving g_application_run under the libuv↔GLib
+//     bridge (the loop co-pumps Node's event loop while run() blocks);
+//   - a composite-template Adw.ApplicationWindow subclass (GObject.registerClass
+//     with inline UI-XML Template + a bound `Children` child);
+//   - Adwaita chrome inside the template: Adw.ToolbarView + Adw.HeaderBar +
+//     Adw.WindowTitle over a Gtk.Label content;
+//   - a Gtk.CssProvider applied display-wide + a CSS class added to a widget;
+//   - a Gio.SimpleAction added to the app and activated programmatically.
+//
+// Every value printed below is DETERMINISTIC — no hostname, no varying paths, no
+// dependence on signal-callback arguments (Node's node-gi omits the emitter as
+// the first callback arg, so handlers only ever print closure-captured
+// constants). Running either build prints the same fixed sequence of lines — the
+// golden output asserted by `dual.e2e.mjs`.
+//
+// DUAL-SAFETY FINDING (composite-template child naming). A template child id MUST
+// NOT collide with a real GObject property of the widget class. A child id
+// `title` on this Adw.ApplicationWindow (which has a `title` string property)
+// crashes BOTH runtimes — GJS with an uncatchable exception, node-gi with a fatal
+// abort — because the bound-child accessor clashes with the property. The child
+// here is therefore named `heading` (no GObject property of that name), so the
+// bound child resolves cleanly on both. Likewise there is NO dual-safe way to
+// read an introspected instance's GType name (`constructor.$gtype` is undefined
+// on node-gi, `GObject.type_name_from_instance` is not marshallable,
+// `constructor.name` differs), so the bound child is proved via property
+// round-trips (`child: <template label>` then `title: <value we set>`), not by
+// printing its type.
+
+import GObject from 'gi://GObject?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import Gdk from 'gi://Gdk?version=4.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import Adw from 'gi://Adw?version=1';
+
+// Inline composite-template UI-XML: an Adw.ApplicationWindow whose content is an
+// Adw.ToolbarView carrying an Adw.HeaderBar (with an Adw.WindowTitle) above a
+// Gtk.Label content. The label's id is `heading` (Children: ['heading']) so it is
+// exposed as `win.heading` — deliberately NOT `title` (see the finding above).
+// The <template class=…> MUST match the registered GTypeName.
+const TEMPLATE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="NodeGiGtkDualWindow" parent="AdwApplicationWindow">
+    <property name="default-width">360</property>
+    <property name="default-height">240</property>
+    <property name="content">
+      <object class="AdwToolbarView">
+        <child type="top">
+          <object class="AdwHeaderBar">
+            <property name="title-widget">
+              <object class="AdwWindowTitle">
+                <property name="title">node-gi GTK dual</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <property name="content">
+          <object class="GtkLabel" id="heading">
+            <property name="label">template</property>
+          </object>
+        </property>
+      </object>
+    </property>
+  </template>
+</interface>`;
+
+// A composite-template window subclass. registerClass installs the template +
+// binds the `heading` child in the new type's class_init; construction runs
+// gtk_widget_init_template and exposes the bound child as `win.heading`. The
+// class body is empty — the lifecycle is driven from `activate`, sidestepping
+// vfunc chain-up. `new TextEncoder().encode(...)` yields the inline UI-XML bytes
+// (TextEncoder is native on both GJS and Node).
+const DualWindow = GObject.registerClass(
+    {
+        GTypeName: 'NodeGiGtkDualWindow',
+        Template: new TextEncoder().encode(TEMPLATE_XML),
+        Children: ['heading'],
+    },
+    class DualWindow extends Adw.ApplicationWindow {},
+);
+
+const app = new Adw.Application({
+    application_id: 'eu.jumplink.NodeGiGtkDual',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+});
+
+// A Gio.SimpleAction added to the app; its handler prints a closure-captured
+// constant (never the callback args — those differ across runtimes). Activated
+// programmatically from `activate` below.
+const action = new Gio.SimpleAction({ name: 'hello' });
+app.add_action(action);
+action.connect('activate', () => {
+    print('action: hello');
+});
+
+app.connect('activate', () => {
+    try {
+        print('activated');
+
+        // The composite-template window. `application` is an object-typed
+        // (G_TYPE_OBJECT) construct property.
+        const win = new DualWindow({ application: app });
+
+        // The bound template child, exposed as `win.heading`. Read its
+        // template-defined label first (proves the binding + template parse), then
+        // write a new value and read it back (proves a property round-trip on the
+        // bound child).
+        print(`child: ${win.heading.label}`);
+        win.heading.label = 'hello';
+        print(`title: ${win.heading.label}`);
+
+        // CSS: a provider applied display-wide, then a class added to a widget,
+        // asserted to have taken effect.
+        const provider = new Gtk.CssProvider();
+        provider.load_from_string('.node-gi-card { padding: 12px; background: #3584e4; }');
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
+        win.heading.add_css_class('node-gi-card');
+        print(`css: ${win.heading.has_css_class('node-gi-card') ? 'applied' : 'missing'}`);
+
+        // Fire the action; its handler prints `action: hello`.
+        action.activate(null);
+
+        win.present();
+
+        // Quit from a GLib timeout running INSIDE the loop → run() returns cleanly.
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+            print('quit');
+            app.quit();
+            return GLib.SOURCE_REMOVE;
+        });
+    } catch (error) {
+        // Surface a failure as a deterministic line so the golden mismatch points
+        // at the cause instead of hanging the loop.
+        print(`activate-error: ${error instanceof Error ? error.message : String(error)}`);
+        app.quit();
+    }
+});
+
+print('gtk-dual: start');
+app.run([]); // top-level blocking run (no async wrapper — the #442 caveat)
+print('done');

--- a/packages/node-gi/example-gtk/tsconfig.json
+++ b/packages/node-gi/example-gtk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ESNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "types.d.ts"]
+}

--- a/packages/node-gi/example-gtk/types.d.ts
+++ b/packages/node-gi/example-gtk/types.d.ts
@@ -1,0 +1,13 @@
+// Editor-only ambient types for the shared `gi://` source. These references
+// surface the `gi://GObject`/`gi://GLib`/`gi://Gio`/`gi://Gdk`/`gi://Gtk`/`gi://Adw`
+// module declarations and the GJS ambient globals (`print`, …) from the `@girs/*`
+// packages WITHOUT importing any of them at runtime — the bundle is built from
+// `src/app.ts` alone, so no `@girs/*` code ever reaches the GJS or Node output.
+// They are pure typings.
+/// <reference types="@girs/gjs/ambient" />
+/// <reference types="@girs/glib-2.0/ambient" />
+/// <reference types="@girs/gobject-2.0/ambient" />
+/// <reference types="@girs/gio-2.0/ambient" />
+/// <reference types="@girs/gdk-4.0/ambient" />
+/// <reference types="@girs/gtk-4.0/ambient" />
+/// <reference types="@girs/adw-1/ambient" />


### PR DESCRIPTION
## What

The GTK analog of the headless L3 marshalling capstone: ONE unchanged
Libadwaita source ([`packages/node-gi/example-gtk/src/app.ts`](packages/node-gi/example-gtk/src/app.ts))
builds AND runs **byte-identically** on BOTH GJS (native `gi://Gtk` / `gi://Adw`)
and Node (`@gjsify/node-gi`).

New private example `packages/node-gi/example-gtk/` + a CI step that runs its
dual e2e under Xvfb.

## What the app exercises

- **Adw.Application** (`NON_UNIQUE`) driving `g_application_run` under the
  libuv↔GLib loop bridge.
- A **composite-template** `Adw.ApplicationWindow` subclass —
  `GObject.registerClass({ GTypeName, Template: <inline UI-XML bytes>, Children })`.
- **Adwaita chrome** in the template: `Adw.ToolbarView` + `Adw.HeaderBar` +
  `Adw.WindowTitle` over a `Gtk.Label` content; the bound child read + written.
- **CSS**: `Gtk.CssProvider.load_from_string` → `Gdk.Display.get_default` →
  `Gtk.StyleContext.add_provider_for_display(…, STYLE_PROVIDER_PRIORITY_APPLICATION)`
  → `add_css_class` / `has_css_class`.
- **Gio.SimpleAction**: `app.add_action(action)` + `action.activate(null)`.

`dual.e2e.mjs` builds `--app gjs` (the real bundler) and `--app node` (the real
`--app node` bundle when the installed CLI carries the `gi://`→`requireGi`
rewrite, else the `@gjsify/node-gi` runtime twin — same fallback as the L3 e2e)
and asserts `gjs === node === GOLDEN`. It self-skips without a display.

```
gtk-dual: start
activated
child: template
title: hello
css: applied
action: hello
quit
done
```

## CI

Extends the `node-gi.yml` `gtk-smoke` job: adds `gjs` to the dnf install (for
the gjs side) and runs the capstone dual e2e under
`xvfb-run -a dbus-run-session -- env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none node --test dual.e2e.mjs`,
alongside the existing GTK/Adw smoke tests. No engine changes; the headless
`Build & test` job is untouched.

## Dual-safety findings (the valuable part)

1. **A composite-template child id must not collide with a GObject property of
   the widget.** A child id `title` on the `Adw.ApplicationWindow` (which has a
   `title` string property) crashes **both** runtimes — GJS with an uncatchable
   exception, node-gi with a fatal abort — because the bound-child accessor
   clashes with the property. The child is named `heading` instead. This is a
   GTK/GJS-level footgun (identical on native GJS), not a node-gi-specific defect,
   so it is avoided in the source rather than papered over in the engine (which
   would make node tolerate something that still breaks on GJS — the opposite of
   parity).
2. **No dual-safe way to read an introspected instance's GType name**
   (`constructor.$gtype` is undefined on node-gi, `GObject.type_name_from_instance`
   isn't marshallable, `constructor.name` differs). The bound child is proved via
   property round-trips, not by printing its type.

## Verification

Verified locally on both runtimes (byte-identical golden). The node side runs the
runtime twin when the installed CLI predates the rewrite — same as the L3 e2e in
CI.

Do NOT merge — for coordinator review.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH
