### PR TITLE
add Gtk.Template signal-callback dispatch to node-gi

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -140,14 +140,15 @@ jobs:
       # LIBGL_ALWAYS_SOFTWARE=1 + GDK_BACKEND=x11 keep GTK off any GPU/Vulkan path
       # that a software-only Xvfb cannot provide; GTK_A11Y=none avoids the a11y bus.
       # Runs ALL the GTK smoke tests (Gtk.Application PR1 + Adw.Application PR2 +
-      # Gtk.Template PR4) in one node --test invocation so each reports even if one
-      # fails.
+      # Gtk.Template PR4 + Template signal callbacks & menu breadth) in one
+      # node --test invocation so each reports even if one fails.
       - name: GTK/Adw smoke test (xvfb + dbus)
         working-directory: packages/node-gi/node-gi
         run: |
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
-            node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs test/gtk-template.test.mjs
+            node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs \
+              test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs
 
       # GTK capstone: ONE unchanged Adwaita gi:// source builds + runs
       # byte-identically on BOTH gjs and node under one display — the GTK analog of

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -163,6 +163,36 @@ function wrapSignalCallback(cb) {
   return (...args) => cb(...args.map(wrapReturn));
 }
 
+// Resolve a Gtk.Template `<signal handler="…">` handler NAME to a dispatcher that
+// calls the instance's bound JS method, for the native template-callback scope
+// (engine: NodeGiScopeCreateClosure via set_template_scope). Mirrors GJS's
+// `_createClosure` (refs/gjs/modules/core/overrides/Gtk.js).
+//
+// LAZY by necessity: the engine resolves template signals during the C-side
+// constructType (init_template → create_closure), which runs BEFORE this layer
+// attaches the user-class prototype to the instance proxy. So the dispatcher
+// defers the method lookup to FIRE time, by which point the instance proxy is the
+// full, userProto-carrying, toggle-ref-canonical L1 wrapper. `this` inside the
+// handler is therefore the widget — the SAME cached proxy the user constructed
+// (wrapInstance is cached by the canonical handle). Native signal args are wrapped
+// (wrapReturn) into chainable instances, exactly like wrapSignalCallback. (The
+// engine drops the emitter at param 0, node-gi's signal convention.) A handler name
+// with no matching user-prototype method throws a clear error when the signal fires.
+function resolveTemplateCallback(handle, handlerName) {
+  return (...args) => {
+    const proxy = wrapInstance(handle);
+    const userProto = proxy[USER_PROTO];
+    const desc = userProto !== undefined ? findProtoDescriptor(userProto, handlerName) : undefined;
+    if (desc === undefined || typeof desc.value !== 'function') {
+      throw new Error(
+        `Gtk.Template: signal handler '${handlerName}' is not defined on ${proxy.constructor?.name ?? 'the instance'}`,
+      );
+    }
+    return desc.value.apply(proxy, args.map(wrapReturn));
+  };
+}
+native.setTemplateCallbackResolver(resolveTemplateCallback);
+
 // Wrap a boxed/struct handle so its methods are callable GJS-style
 // (`mainLoop.run()`, `mainLoop.quit()`, snake_case or camelCase). Boxed types
 // have no GObject properties/signals, so only method routing is provided.

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -346,6 +346,17 @@ export function emitSignal(handle: GObjectHandle, signalName: string, args?: unk
 /** Disconnect a previously connected signal handler. */
 export function disconnectSignal(handle: GObjectHandle, handlerId: number): void;
 
+/**
+ * Register the L1 resolver mapping a Gtk.Template `<signal handler="…">` handler
+ * name to the instance's bound JS method (engine template-callback scope).
+ */
+export function setTemplateCallbackResolver(
+  resolver: (
+    handle: GObjectHandle,
+    handlerName: string,
+  ) => ((...args: unknown[]) => unknown) | undefined,
+): void;
+
 declare const native: {
   requireNamespace: typeof requireNamespace;
   listInfoNames: typeof listInfoNames;
@@ -378,5 +389,6 @@ declare const native: {
   connectSignal: typeof connectSignal;
   emitSignal: typeof emitSignal;
   disconnectSignal: typeof disconnectSignal;
+  setTemplateCallbackResolver: typeof setTemplateCallbackResolver;
 };
 export default native;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -362,4 +362,12 @@ export const emitSignal = native.emitSignal;
  */
 export const disconnectSignal = native.disconnectSignal;
 
+/**
+ * Register the L1 resolver that maps a Gtk.Template `<signal handler="…">` handler
+ * name to the instance's bound JS method, for the engine's template-callback scope.
+ * @param {(handle: unknown, handlerName: string) => ((...args: unknown[]) => unknown) | undefined} resolver
+ * @returns {void}
+ */
+export const setTemplateCallbackResolver = native.setTemplateCallbackResolver;
+
 export default native;

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -63,7 +63,8 @@
     "test:gc": "node --test --expose-gc",
     "test:gtk": "node --test test/gtk-smoke.test.mjs",
     "test:adw": "node --test test/adw-smoke.test.mjs",
-    "test:gtk-template": "node --test test/gtk-template.test.mjs"
+    "test:gtk-template": "node --test test/gtk-template.test.mjs",
+    "test:gtk-template-callbacks": "node --test test/gtk-template-callbacks.test.mjs"
   },
   "dependencies": {
     "node-addon-api": "^8.0.0"

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -52,12 +52,19 @@ GIRepository* DupDefaultRepository() { return gi_repository_dup_default(); }
 // Init, freed by the instance-data finalizer at env teardown.
 struct NodeGiEnvData {
   napi_ref errorBuilder = nullptr;
+  // L1-registered resolver for Gtk.Template `<signal handler="…">` callbacks: given
+  // (instanceHandle, handlerName) it returns the instance's bound JS method (or
+  // undefined). Stored per-env for the same reason as errorBuilder (a napi_ref is
+  // env-specific). See the Gtk.Widget composite-template scope further down.
+  napi_ref templateCallbackResolver = nullptr;
 };
 
 static void NodeGiEnvDataFinalize(napi_env env, void* data, void* /*hint*/) {
   NodeGiEnvData* d = static_cast<NodeGiEnvData*>(data);
   if (d == nullptr) return;
   if (d->errorBuilder != nullptr) napi_delete_reference(env, d->errorBuilder);
+  if (d->templateCallbackResolver != nullptr)
+    napi_delete_reference(env, d->templateCallbackResolver);
   delete d;
 }
 
@@ -2391,8 +2398,17 @@ static GObject* UnwrapGObject(Napi::Env env, Napi::Value handle);
 // Forward declaration: ConstructGObject calls gtk_widget_init_template on a
 // freshly-built widget whose registered type carries a Gtk.Widget template. The
 // helper (and the NodeGiClassData/GtkTemplateApi it reads) is defined with the
-// registerClass machinery further down; a no-op for any non-templated type.
-static void MaybeInitTemplate(GObject* obj);
+// registerClass machinery further down; a no-op for any non-templated type. The
+// env is threaded through so the per-construction JS env can be stamped on the
+// template-callback scope before init_template builds (and connects) the tree.
+struct NodeGiClassData;
+static void MaybeInitTemplate(Napi::Env env, GObject* obj);
+
+// Forward declarations for the Gtk.Widget composite-template callback scope. The
+// implementation lives further down (alongside the JsClosure signal machinery it
+// reuses), but NodeGiClassInit installs the scope and MaybeInitTemplate refreshes
+// its env, both above that point.
+static void NodeGiInstallTemplateScopeOnClass(NodeGiClassData* cd, gpointer g_class);
 
 // Marshal a GValue into a JS value (fundamental types).
 static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
@@ -2619,7 +2635,7 @@ static Napi::Value ConstructGObject(Napi::Env env, GType gtype, Napi::Object pro
   // declared children + binds them so get_template_child resolves). A no-op unless
   // the constructed type carries node-gi template data (defined below; forward-
   // declared above), so plain introspected construction (newObject) is untouched.
-  MaybeInitTemplate(obj);
+  MaybeInitTemplate(env, obj);
   return MakeGObjectHandle(env, obj);
 }
 
@@ -2899,6 +2915,14 @@ struct GtkTemplateApi {
   void (*set_css_name)(gpointer widget_class, const char* name);
   void (*init_template)(gpointer widget);
   GObject* (*get_template_child)(gpointer widget, GType widget_type, const char* name);
+  // Template-callback dispatch (`<signal handler="…">`): a custom GtkBuilderScope
+  // is set on the class so GtkBuilder resolves any handler name to the instance's
+  // JS method (mirrors GJS's TemplateBuilderScope). set_template_scope installs it;
+  // builder_get_current_object yields the widget being built (the handler `this`);
+  // builder_scope_get_type is the interface GType our scope subtype implements.
+  void (*set_template_scope)(gpointer widget_class, gpointer scope);
+  GObject* (*builder_get_current_object)(gpointer builder);
+  GType (*builder_scope_get_type)(void);
   bool ok;
 };
 
@@ -2927,6 +2951,12 @@ static const GtkTemplateApi* GetGtkTemplateApi() {
       reinterpret_cast<decltype(api.init_template)>(dlsym(lib, "gtk_widget_init_template"));
   api.get_template_child = reinterpret_cast<decltype(api.get_template_child)>(
       dlsym(lib, "gtk_widget_get_template_child"));
+  api.set_template_scope = reinterpret_cast<decltype(api.set_template_scope)>(
+      dlsym(lib, "gtk_widget_class_set_template_scope"));
+  api.builder_get_current_object = reinterpret_cast<decltype(api.builder_get_current_object)>(
+      dlsym(lib, "gtk_builder_get_current_object"));
+  api.builder_scope_get_type = reinterpret_cast<decltype(api.builder_scope_get_type)>(
+      dlsym(lib, "gtk_builder_scope_get_type"));
   api.ok = api.set_template != nullptr && api.set_template_from_resource != nullptr &&
            api.bind_template_child_full != nullptr && api.set_css_name != nullptr &&
            api.init_template != nullptr && api.get_template_child != nullptr;
@@ -2948,6 +2978,10 @@ struct NodeGiClassData {
   std::string cssName;                        // gtk_widget_class_set_css_name (optional)
   std::vector<std::string> children;          // public Children ids
   std::vector<std::string> internalChildren;  // InternalChildren ids
+  // The generic template-callback scope set on the class (set_template_scope). Owned
+  // for the class lifetime (process-permanent, like cd itself); its JS env qdata is
+  // refreshed per construction so create_closure resolves handlers in the live env.
+  GObject* templateScope = nullptr;
 
   // The cold `delete cd` failure paths (a bad GParamSpec, or g_type_register_static
   // returning 0) must not leak the owned inline-template GBytes. A destructor frees
@@ -2967,6 +3001,16 @@ static GQuark NodeGiClassDataQuark() {
 }
 static GQuark NodeGiInstancePropsQuark() {
   static GQuark q = g_quark_from_static_string("node-gi-instance-props");
+  return q;
+}
+// The live JS env stamped on a template-callback scope (refreshed each construct).
+static GQuark NodeGiScopeEnvQuark() {
+  static GQuark q = g_quark_from_static_string("node-gi-scope-env");
+  return q;
+}
+// GError domain for template-callback resolution failures surfaced to GtkBuilder.
+static GQuark NodeGiBuilderErrorQuark() {
+  static GQuark q = g_quark_from_static_string("node-gi-builder-error");
   return q;
 }
 
@@ -3006,7 +3050,7 @@ static NodeGiVFunc* FindVFuncRecord(GType type, const std::string& name) {
 // registered type carries node-gi template data, so it is safe on every GObject
 // construction. Uses the instance's actual type's class data (single-level
 // registered templated type — the construct() case).
-static void MaybeInitTemplate(GObject* obj) {
+static void MaybeInitTemplate(Napi::Env env, GObject* obj) {
   NodeGiClassData* cd = FindClassData(G_OBJECT_TYPE(obj));
   if (cd == nullptr || !cd->hasTemplate) return;
   const GtkTemplateApi* gtk = GetGtkTemplateApi();
@@ -3014,7 +3058,19 @@ static void MaybeInitTemplate(GObject* obj) {
   // Only a Gtk.Widget can be init_template'd (class_init also skips a non-widget
   // template). g_type_from_name is 0 if GTK never loaded → guard is false → skip.
   GType widgetType = g_type_from_name("GtkWidget");
-  if (widgetType != 0 && g_type_is_a(G_OBJECT_TYPE(obj), widgetType)) gtk->init_template(obj);
+  if (widgetType == 0 || !g_type_is_a(G_OBJECT_TYPE(obj), widgetType)) return;
+  // Stamp the live JS env on the template-callback scope BEFORE init_template runs:
+  // GtkBuilder resolves every `<signal handler="…">` synchronously inside
+  // init_template by calling the scope's create_closure, which needs this env to
+  // call back into the L1 resolver. Refreshed each construct so the scope always
+  // dispatches in the env that built this instance (GTK template construction is
+  // main-thread/single-env; a stale capture would only matter for a cross-env
+  // build, which GTK does not do).
+  if (cd->templateScope != nullptr) {
+    g_object_set_qdata(cd->templateScope, NodeGiScopeEnvQuark(),
+                       reinterpret_cast<void*>(static_cast<napi_env>(env)));
+  }
+  gtk->init_template(obj);
 }
 
 // A property is custom iff its owner GType carries node-gi class-data; otherwise
@@ -3175,6 +3231,12 @@ static void NodeGiClassInit(gpointer g_class, gpointer class_data) {
         gtk->bind_template_child_full(g_class, c.c_str(), FALSE, 0);
       for (const std::string& c : cd->internalChildren)
         gtk->bind_template_child_full(g_class, c.c_str(), TRUE, 0);
+      // Install a generic template-callback scope so any `<signal handler="…">` in
+      // the template resolves to the instance's JS method (mirrors GJS's
+      // set_template_scope path). Must follow set_template; used during
+      // init_template. Independent of the child binding above — Children /
+      // InternalChildren behaviour is unchanged.
+      NodeGiInstallTemplateScopeOnClass(cd, g_class);
     } else if (!isWidget) {
       g_warning(
           "node-gi: a Template was set on %s, which is not a Gtk.Widget subclass — "
@@ -4671,6 +4733,204 @@ Napi::Value DisconnectSignal(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+// ---- Gtk.Widget composite-template callback dispatch -----------------------
+//
+// Mirrors GJS's TemplateBuilderScope (refs/gjs/modules/core/overrides/Gtk.js): a
+// custom GtkBuilderScope is set on a templated widget class via
+// gtk_widget_class_set_template_scope, so when GtkBuilder (run by init_template)
+// hits a `<signal name="clicked" handler="on_click"/>` it asks the scope to
+// create a closure for the handler NAME. We resolve that name to the instance's
+// JS method and connect a closure that dispatches to it.
+//
+// Why a scope (generic resolver) and not gtk_widget_class_bind_template_callback
+// (per-name C symbol): a GtkBuilderScope's create_closure returns a *GClosure*,
+// which is signature-agnostic — GObject marshals the signal's GValue params into
+// it at emit time, so one mechanism handles ANY signal shape without a per-signal
+// libffi cif. A bound C-symbol callback would instead be invoked with the live
+// signal ABI, which we cannot know at bind time. The returned closure reuses the
+// existing JsClosure machinery (JsClosureMarshal/JsClosureFinalize), so the marshal
+// + GValue→JS arg conversion + lifetime are identical to a normal `.connect()`.
+//
+// Handler name → JS method + `this`: create_closure calls the L1 resolver
+// (gi.js resolveTemplateCallback) with the canonical wrapper of the widget being
+// built (gtk_builder_get_current_object) and the handler name; L1 returns the
+// user-prototype method already bound to that instance proxy (so `this` is the
+// template widget — the same cached, toggle-ref-canonical L1 proxy the user holds)
+// and wrapping each native signal arg into a chainable wrapper. The returned JS
+// function is wrapped in a JsClosure here. arg marshalling: JsClosureMarshal skips
+// the emitter (param 0, node-gi's signal convention) and passes the rest.
+
+// The GtkBuilderScopeInterface vtable layout (stable public ABI — replicated so the
+// addon needs no GTK headers; it only links girepository-2.0 and dlsym's GTK).
+typedef GType (*NodeGiScopeTypeFromNameFn)(void*, void*, const char*);
+typedef GType (*NodeGiScopeTypeFromFuncFn)(void*, void*, const char*);
+typedef GClosure* (*NodeGiScopeCreateClosureFn)(void*, void*, const char*, guint, GObject*,
+                                                GError**);
+struct NodeGiBuilderScopeIface {
+  GTypeInterface g_iface;
+  NodeGiScopeTypeFromNameFn get_type_from_name;
+  NodeGiScopeTypeFromFuncFn get_type_from_function;
+  NodeGiScopeCreateClosureFn create_closure;
+};
+
+// create_closure: resolve `function_name` to the widget instance's JS method and
+// return a JsClosure dispatching to it. Returns NULL + sets *error on any failure
+// (handler not found, swapped flag, no env/resolver) so GtkBuilder aborts the build
+// with a clear message instead of silently dropping the handler.
+static GClosure* NodeGiScopeCreateClosure(void* selfScope, void* builder,
+                                          const char* function_name, guint flags,
+                                          GObject* object, GError** error) {
+  const char* name = function_name != nullptr ? function_name : "?";
+  // SWAPPED is unsupported (matches GJS's "_createClosure" guard).
+  if (flags & 1u /* GTK_BUILDER_CLOSURE_SWAPPED */) {
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: template signal flag 'swapped' is not supported (handler '%s')", name);
+    return nullptr;
+  }
+  napi_env rawEnv = static_cast<napi_env>(
+      g_object_get_qdata(G_OBJECT(selfScope), NodeGiScopeEnvQuark()));
+  if (rawEnv == nullptr) {
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: template scope has no live JS env to resolve handler '%s'", name);
+    return nullptr;
+  }
+  const GtkTemplateApi* gtk = GetGtkTemplateApi();
+  GObject* thisObj = object;
+  if (thisObj == nullptr && gtk->builder_get_current_object != nullptr)
+    thisObj = gtk->builder_get_current_object(builder);
+  if (thisObj == nullptr) {
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: no current object to bind template handler '%s'", name);
+    return nullptr;
+  }
+
+  Napi::Env env(rawEnv);
+  Napi::HandleScope hscope(env);
+
+  NodeGiEnvData* d = EnvData(rawEnv);
+  napi_value resolver = nullptr;
+  if (d == nullptr || d->templateCallbackResolver == nullptr ||
+      napi_get_reference_value(rawEnv, d->templateCallbackResolver, &resolver) != napi_ok ||
+      resolver == nullptr) {
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: no template-callback resolver registered (handler '%s')", name);
+    return nullptr;
+  }
+
+  Napi::Value handleVal = WrapGObject(env, thisObj, GI_TRANSFER_NOTHING);
+  napi_value args[2] = {handleVal, nullptr};
+  napi_create_string_utf8(rawEnv, name, NAPI_AUTO_LENGTH, &args[1]);
+  napi_value undef = nullptr;
+  napi_get_undefined(rawEnv, &undef);
+  napi_value resolved = nullptr;
+  napi_status st = napi_call_function(rawEnv, undef, resolver, 2, args, &resolved);
+  if (st != napi_ok) {
+    // The resolver threw — never leave a pending JS exception across the return to
+    // GTK (C). Clear it and fold its message into the GError so the build fails
+    // cleanly.
+    napi_value ex = nullptr;
+    std::string detail;
+    if (napi_get_and_clear_last_exception(rawEnv, &ex) == napi_ok && ex != nullptr) {
+      napi_value msg = nullptr;
+      if (napi_get_named_property(rawEnv, ex, "message", &msg) == napi_ok) {
+        size_t len = 0;
+        if (napi_get_value_string_utf8(rawEnv, msg, nullptr, 0, &len) == napi_ok) {
+          detail.resize(len);
+          napi_get_value_string_utf8(rawEnv, msg, detail.data(), len + 1, &len);
+        }
+      }
+    }
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: template handler '%s' resolver threw%s%s", name,
+                detail.empty() ? "" : ": ", detail.c_str());
+    return nullptr;
+  }
+  napi_valuetype rt = napi_undefined;
+  napi_typeof(rawEnv, resolved, &rt);
+  if (rt != napi_function) {
+    g_set_error(error, NodeGiBuilderErrorQuark(), 0,
+                "node-gi: no template handler '%s' defined on the instance", name);
+    return nullptr;
+  }
+
+  // Wrap the resolved (instance-bound, arg-wrapping) JS function in a JsClosure —
+  // the same closure type a `.connect()` produces. The closure owns a strong ref to
+  // the function; g_object_watch_closure ties its lifetime to the widget (the
+  // handler `this`) and invalidates it when the widget is finalized, exactly like
+  // GtkBuilderCScope's own create_closure.
+  JsClosureData* jc = g_new0(JsClosureData, 1);
+  jc->env = rawEnv;
+  napi_create_reference(rawEnv, resolved, 1, &jc->callback);
+  GClosure* closure = g_closure_new_simple(sizeof(GClosure), jc);
+  g_closure_set_marshal(closure, JsClosureMarshal);
+  g_closure_add_finalize_notifier(closure, jc, JsClosureFinalize);
+  g_object_watch_closure(thisObj, closure);
+  return closure;
+}
+
+static void NodeGiBuilderScopeIfaceInit(gpointer g_iface, gpointer /*data*/) {
+  // The per-type interface vtable is pre-filled with the GtkBuilderScope interface
+  // defaults (get_type_from_name = g_type_from_name, etc.) before this runs, so we
+  // only override create_closure — type resolution keeps GTK's default behaviour
+  // (sufficient for templates whose object types are already registered).
+  NodeGiBuilderScopeIface* iface = static_cast<NodeGiBuilderScopeIface*>(g_iface);
+  iface->create_closure = NodeGiScopeCreateClosure;
+}
+
+// The GObject subtype implementing GtkBuilderScope (registered once). Returns 0 if
+// the GTK scope API is unavailable (old/missing GTK) → callers skip the scope.
+static GType NodeGiBuilderScopeGetType() {
+  static GType type = 0;
+  if (type != 0) return type;
+  const GtkTemplateApi* gtk = GetGtkTemplateApi();
+  if (gtk->builder_scope_get_type == nullptr || gtk->set_template_scope == nullptr) return 0;
+  GType ifaceType = gtk->builder_scope_get_type();
+  if (ifaceType == 0) return 0;
+
+  GTypeInfo info = {};
+  info.class_size = sizeof(GObjectClass);
+  info.instance_size = sizeof(GObject);
+  type = g_type_register_static(G_TYPE_OBJECT, "NodeGiBuilderScope", &info,
+                                static_cast<GTypeFlags>(0));
+  if (type == 0) return 0;
+  GInterfaceInfo ifaceInfo = {NodeGiBuilderScopeIfaceInit, nullptr, nullptr};
+  g_type_add_interface_static(type, ifaceType, &ifaceInfo);
+  return type;
+}
+
+// Create the class's template-callback scope and install it (class_init). Holds the
+// scope for the class lifetime (process-permanent, like NodeGiClassData) so its env
+// qdata can be refreshed per construction. A no-op when the GTK scope API is absent.
+static void NodeGiInstallTemplateScopeOnClass(NodeGiClassData* cd, gpointer g_class) {
+  const GtkTemplateApi* gtk = GetGtkTemplateApi();
+  if (gtk->set_template_scope == nullptr) return;  // older GTK: callbacks unsupported
+  GType scopeType = NodeGiBuilderScopeGetType();
+  if (scopeType == 0) return;
+  GObject* scope = static_cast<GObject*>(g_object_new(scopeType, nullptr));
+  if (scope == nullptr) return;
+  gtk->set_template_scope(g_class, scope);  // the class takes its own ref
+  cd->templateScope = scope;                // our class-lifetime ref (env-refresh target)
+}
+
+// setTemplateCallbackResolver(fn) -> void. L1 registers the resolver that maps a
+// (instanceHandle, handlerName) to the instance's bound JS method (see gi.js).
+Napi::Value SetTemplateCallbackResolver(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) {
+    Napi::TypeError::New(env, "setTemplateCallbackResolver(resolver: function)")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr) return env.Undefined();
+  if (d->templateCallbackResolver != nullptr) {
+    napi_delete_reference(env, d->templateCallbackResolver);
+    d->templateCallbackResolver = nullptr;
+  }
+  napi_create_reference(env, info[0], 1, &d->templateCallbackResolver);
+  return env.Undefined();
+}
+
 // ---- libuv <-> GLib main loop bridge (milestone: mainloop) ----
 //
 // Port of node-gtk's src/loop.cc (romgrk and contributors, MIT) to N-API. Nests
@@ -4886,6 +5146,8 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("connectSignal", Napi::Function::New(env, ConnectSignal));
   exports.Set("emitSignal", Napi::Function::New(env, EmitSignal));
   exports.Set("disconnectSignal", Napi::Function::New(env, DisconnectSignal));
+  exports.Set("setTemplateCallbackResolver",
+              Napi::Function::New(env, SetTemplateCallbackResolver));
   return exports;
 }
 

--- a/packages/node-gi/node-gi/test/gtk-template-callbacks.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template-callbacks.test.mjs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gtk.Template signal-callback + menu breadth smoke test.
+//
+// Task A (engine): proves a composite-template `<signal name="clicked"
+// handler="on_click"/>` dispatches to the registered instance's `on_click` JS
+// method, with `this` === the template widget instance (the canonical toggle-ref
+// L1 proxy). The engine installs a generic GtkBuilderScope on the class via
+// gtk_widget_class_set_template_scope (mirroring GJS's TemplateBuilderScope): when
+// GtkBuilder (run by init_template) hits the `<signal>`, the scope's create_closure
+// resolves the handler NAME to the instance's bound JS method and connects a closure
+// dispatching to it. No per-name registration — any handler name auto-resolves from
+// the class prototype, GJS-style.
+//
+// Task B (breadth): Gio.Menu (append / append_item+Gio.MenuItem / append_submenu /
+// append_section), Gtk.MenuButton.set_menu_model, Gtk.PopoverMenu.new_from_model,
+// Gio.SimpleAction + app.add_action, app.set_accels_for_action (GStrv). These are
+// GObject methods + constructors the engine already marshals; this validates them
+// end-to-end and closes any gap.
+//
+// SELF-SKIPPING: needs a display (DISPLAY / WAYLAND_DISPLAY) and the Gtk-4.0 /
+// libadwaita typelibs, so the fast headless legs skip cleanly; the dedicated
+// `gtk-smoke` CI job (Xvfb + GTK stack) runs it.
+//
+// Reference: refs/gjs/modules/core/overrides/Gtk.js (TemplateBuilderScope /
+// _createClosure semantics), /usr/include/gtk-4.0/gtk/gtkbuilderscope.h.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let GObject;
+let Gtk;
+let Gio;
+let GLib;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    GObject = requireGi('GObject', '2.0');
+    Gtk = requireGi('Gtk', '4.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+// A composite-template GtkBox subclass: a label child (id "title", public) and a
+// button child (id "btn", internal) whose `clicked` signal is wired to the instance
+// method `on_click` purely through the template's `<signal>` element.
+const TEMPLATE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="NodeGiCallbackBox" parent="GtkBox">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkLabel" id="title">
+        <property name="label">Hello from a template</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkButton" id="btn">
+        <property name="label">Click me</property>
+        <signal name="clicked" handler="on_click"/>
+      </object>
+    </child>
+  </template>
+</interface>`;
+
+test('Gtk.Template <signal> dispatches to the instance JS method', { skip }, () => {
+  // Captured from inside the handler to prove `this` identity + that the handler ran.
+  let clickCount = 0;
+  let handlerThis = null;
+  let handlerSawTitle = null;
+
+  const CallbackBox = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiCallbackBox',
+      Template: new TextEncoder().encode(TEMPLATE_XML),
+      Children: ['title'],
+      InternalChildren: ['btn'],
+    },
+    class CallbackBox extends Gtk.Box {
+      on_click() {
+        clickCount += 1;
+        handlerThis = this; // must be the template widget instance
+        // `this` is the FULL widget: a bound child + a user method are reachable.
+        handlerSawTitle = this.title ? this.title.label : null;
+        this.clickedExpando = true;
+      }
+    },
+  );
+
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiGtkTemplateCallbacks',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  let widget = null;
+  let activateError = null;
+  const results = {};
+
+  app.connect('activate', () => {
+    try {
+      widget = new CallbackBox();
+      results.widgetType = native.getTypeName(unwrap(widget));
+
+      // Fire the button's `clicked` signal — the template-wired handler runs
+      // synchronously inside emit.
+      widget._btn.emit('clicked');
+      // Emit a second time to confirm the connection persists (not one-shot).
+      widget._btn.emit('clicked');
+
+      results.clickCount = clickCount;
+      results.handlerThisIsWidget = handlerThis === widget;
+      results.handlerSawTitle = handlerSawTitle;
+      results.expandoOnWidget = widget.clickedExpando === true;
+
+      const win = new Gtk.ApplicationWindow({ application: app });
+      win.set_child(widget);
+      win.present();
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        app.quit();
+        return GLib.SOURCE_REMOVE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]);
+
+  assert.equal(activateError, null, `activate threw: ${activateError && activateError.stack}`);
+  assert.equal(status, 0, 'app.run([]) should exit 0');
+  assert.equal(results.widgetType, 'NodeGiCallbackBox', 'the instance is the registered type');
+
+  // The template <signal> dispatched to on_click — twice, with the right `this`.
+  assert.equal(results.clickCount, 2, 'on_click ran once per clicked emit (connection persists)');
+  assert.equal(results.handlerThisIsWidget, true, '`this` in the handler IS the template widget');
+  assert.equal(results.handlerSawTitle, 'Hello from a template', '`this` reaches the bound child');
+  assert.equal(results.expandoOnWidget, true, 'a field set on `this` lands on the widget instance');
+});
+
+test('Gio.Menu model + Gtk.MenuButton / PopoverMenu / actions breadth', { skip }, () => {
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiGtkMenuBreadth',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  let activateError = null;
+  const results = {};
+
+  app.connect('activate', () => {
+    try {
+      // Gio.SimpleAction + app.add_action + set_accels_for_action (GStrv).
+      const quitAction = new Gio.SimpleAction({ name: 'quit' });
+      let actionFired = false;
+      quitAction.connect('activate', () => {
+        actionFired = true;
+      });
+      app.add_action(quitAction);
+      app.set_accels_for_action('app.quit', ['<Ctrl>q']);
+      results.accels = app.get_accels_for_action('app.quit'); // GStrv round-trip
+      quitAction.activate(null);
+      results.actionFired = actionFired;
+
+      // Gio.Menu: append, append_item (Gio.MenuItem), append_submenu, append_section.
+      const menu = new Gio.Menu();
+      menu.append('Quit', 'app.quit');
+
+      const item = new Gio.MenuItem(); // Gio.MenuItem.new(label, detailed_action)
+      item.set_label('About');
+      item.set_detailed_action('app.about');
+      menu.append_item(item);
+
+      const submenu = new Gio.Menu();
+      submenu.append('Sub A', 'app.subA');
+      submenu.append('Sub B', 'app.subB');
+      menu.append_submenu('More', submenu);
+
+      const section = new Gio.Menu();
+      section.append('Section item', 'app.sect');
+      menu.append_section(null, section);
+
+      results.menuItemCount = menu.get_n_items(); // append + append_item + submenu + section = 4
+      results.submenuItemCount = submenu.get_n_items();
+
+      // Gtk.MenuButton.set_menu_model — takes a GMenuModel (GObject arg marshalling).
+      const menuButton = new Gtk.MenuButton();
+      menuButton.set_menu_model(menu);
+      const got = menuButton.get_menu_model();
+      results.menuButtonModelSet = got != null;
+      results.menuButtonModelIsMenu = got != null && unwrap(got) === unwrap(menu);
+
+      // Gtk.PopoverMenu.new_from_model(menu) — static constructor taking the model.
+      const popover = Gtk.PopoverMenu.new_from_model(menu);
+      results.popoverIsWidget = popover != null && native.isGObjectHandle(unwrap(popover));
+      results.popoverType = popover != null ? native.getTypeName(unwrap(popover)) : null;
+
+      const win = new Gtk.ApplicationWindow({ application: app });
+      win.set_child(menuButton);
+      win.present();
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        app.quit();
+        return GLib.SOURCE_REMOVE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]);
+
+  assert.equal(activateError, null, `activate threw: ${activateError && activateError.stack}`);
+  assert.equal(status, 0, 'app.run([]) should exit 0');
+
+  // GStrv round-trips: we set ['<Ctrl>q'] and read back a one-element GStrv (GTK
+  // canonicalises the accel string, e.g. '<Ctrl>q' → '<Control>q' — exact spelling
+  // is GTK's, what matters is the array marshalled in AND out).
+  assert.ok(
+    Array.isArray(results.accels) && results.accels.length === 1 &&
+      typeof results.accels[0] === 'string' && results.accels[0].toLowerCase().includes('q'),
+    `set/get_accels_for_action round-trips (GStrv): got ${JSON.stringify(results.accels)}`,
+  );
+  assert.equal(results.actionFired, true, 'Gio.SimpleAction::activate fired via app.add_action');
+  assert.equal(results.menuItemCount, 4, 'Gio.Menu append/append_item/append_submenu/append_section');
+  assert.equal(results.submenuItemCount, 2, 'submenu carries its two items');
+  assert.equal(results.menuButtonModelSet, true, 'Gtk.MenuButton.set_menu_model accepted the model');
+  assert.equal(results.menuButtonModelIsMenu, true, 'get_menu_model returns the same Gio.Menu');
+  assert.equal(results.popoverIsWidget, true, 'Gtk.PopoverMenu.new_from_model built a widget');
+  assert.equal(results.popoverType, 'GtkPopoverMenu', 'new_from_model yields a GtkPopoverMenu');
+});


### PR DESCRIPTION
Wires Gtk.Template `<signal name="clicked" handler="on_click"/>` to the registered instance's JS method on the Node GI engine (Axis 5), mirroring GJS's `TemplateBuilderScope`. Also validates menu breadth (Gio.Menu / Gtk.MenuButton / Gtk.PopoverMenu / Gio.SimpleAction / accels) end-to-end.

## Task A — template callbacks (engine)

A generic `GtkBuilderScope` GType is registered and set on every templated class via `gtk_widget_class_set_template_scope` (dlsym'd, no GTK link). Its `create_closure` overrides the interface default; type resolution keeps GTK's default (`g_type_from_name`). When GtkBuilder (run by `init_template`) hits a `<signal>`, the scope resolves the handler **name** to a closure that dispatches to the instance method — no per-name binding, any handler auto-resolves from the class prototype (GJS-style).

- `this` inside the handler is the widget being built (`gtk_builder_get_current_object`), wrapped to the canonical toggle-ref L1 proxy — the **same** proxy the user constructed (verified `this === widget`).
- Reuses the existing `JsClosure` marshal (GValue→JS arg conversion; emitter dropped per node-gi's signal convention); `g_object_watch_closure` ties closure lifetime to the widget, exactly like `GtkBuilderCScope`.
- L1 resolver (`gi.js`) is **lazy**: `create_closure` runs inside `constructType`, before the user prototype is attached, so the method lookup defers to fire time.
- Children / InternalChildren behaviour unchanged.

## Task B — menu breadth (validate)

`Gio.Menu` (`append` / `append_item`+`Gio.MenuItem` / `append_submenu` / `append_section`), `Gtk.MenuButton.set_menu_model`, `Gtk.PopoverMenu.new_from_model`, `Gio.SimpleAction` + `app.add_action`, `set/get_accels_for_action` (GStrv) — all already function via the engine; added as a validating showcase. No engine fix needed.

## Testing

`test/gtk-template-callbacks.test.mjs` (self-skips without a display), wired into the `gtk-smoke` CI job (Xvfb). Verified locally under a real Wayland display:
- callback `this`-identity + double-emit (connection persists) ✓
- menu breadth ✓
- existing GTK tests (gtk-smoke, adw-smoke, gtk-template) all green ✓
- dual gjs/node Adwaita capstone (`example-gtk`) still byte-identical ✓
- headless suite 203/203, GTK tests self-skip ✓

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH