### PR TITLE
feat(node-gi): add ParamSpec.object/.boxed + real $gtype

### DIFF
--- a/packages/node-gi/node-gi/gi.d.ts
+++ b/packages/node-gi/node-gi/gi.d.ts
@@ -17,7 +17,7 @@ export type GiNamespace = Record<string, unknown>;
  */
 export interface ParamSpecDescriptor {
   $paramSpec: true;
-  type: 'string' | 'boolean' | 'int' | 'uint' | 'int64' | 'uint64' | 'double' | 'float';
+  type: 'string' | 'boolean' | 'int' | 'uint' | 'int64' | 'uint64' | 'double' | 'float' | 'object' | 'boxed';
   name: string;
   nick?: string;
   blurb?: string;
@@ -25,6 +25,8 @@ export interface ParamSpecDescriptor {
   default?: string | number | boolean;
   minimum?: number;
   maximum?: number;
+  /** For `object`/`boxed`: the value GType handle (resolved from a class ctor's `$gtype`). */
+  gtype?: unknown;
 }
 
 /** The `GObject.ParamSpec.*` factories surfaced on the GObject namespace. */
@@ -37,6 +39,10 @@ export interface ParamSpecFactories {
   uint64(name: string, nick: string, blurb: string, flags: number, minimum: number, maximum: number, defaultValue?: number): ParamSpecDescriptor;
   double(name: string, nick: string, blurb: string, flags: number, minimum: number, maximum: number, defaultValue?: number): ParamSpecDescriptor;
   float(name: string, nick: string, blurb: string, flags: number, minimum: number, maximum: number, defaultValue?: number): ParamSpecDescriptor;
+  /** A GObject-typed property; `gtype` is a class ctor (its `$gtype` is read) or a GType handle. */
+  object(name: string, nick: string, blurb: string, flags: number, gtype: unknown): ParamSpecDescriptor;
+  /** A boxed-typed property; `gtype` is a boxed class ctor (its `$gtype` is read) or a GType handle. */
+  boxed(name: string, nick: string, blurb: string, flags: number, gtype: unknown): ParamSpecDescriptor;
 }
 
 /** A `meta.Signals` entry for {@link GObjectNamespace.registerClass}. */

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -514,6 +514,30 @@ const vfuncChainProto = new Proxy(Object.create(Object.prototype), {
   },
 });
 
+// Surface a lazy `$gtype` getter on an introspected class/struct ctor: the real
+// GObject GType (a node-gi GType handle), resolved on first read via the engine
+// and then cached as a value. GJS exposes `SomeClass.$gtype`; the storybook reads
+// `Adw.Clamp.$gtype` + passes `StoryWidget.$gtype` to GObject.type_ensure. Lazy
+// (defineProperty getter) so it costs nothing until accessed. `null` (unknown type)
+// is also cached. The makeClass/makeStruct Proxy forwards `'$gtype' in t` → the
+// target getter (it returns `t[prop]` when `prop in t`).
+function defineLazyGType(ctor, namespace, typeName) {
+  Object.defineProperty(ctor, '$gtype', {
+    configurable: true,
+    enumerable: false,
+    get() {
+      const gt = native.getGType(namespace, typeName);
+      Object.defineProperty(ctor, '$gtype', {
+        value: gt,
+        configurable: true,
+        enumerable: false,
+        writable: false,
+      });
+      return gt;
+    },
+  });
+}
+
 function makeClass(namespace, typeName) {
   const ctor = function ctor(props) {
     const handle = native.newObject(namespace, typeName, props ? unwrapProps(props) : {});
@@ -521,6 +545,7 @@ function makeClass(namespace, typeName) {
   };
   Object.defineProperty(ctor, 'name', { value: typeName, configurable: true });
   ctor.$gtypeName = `${namespace}.${typeName}`;
+  defineLazyGType(ctor, namespace, typeName);
   // Put the vfunc chain-up Proxy beneath this base class's prototype so a
   // registerClass subclass's `super.vfunc_<name>(...)` resolves (see above).
   Object.setPrototypeOf(ctor.prototype, vfuncChainProto);
@@ -552,6 +577,7 @@ function makeStruct(namespace, typeName) {
   const base = function () {};
   Object.defineProperty(base, 'name', { value: typeName, configurable: true });
   base.$gtypeName = `${namespace}.${typeName}`;
+  defineLazyGType(base, namespace, typeName);
   return new Proxy(base, {
     get(t, prop) {
       if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
@@ -794,6 +820,35 @@ function paramSpecRanged(type) {
   });
 }
 
+// Resolve a GObject.ParamSpec.object/.boxed `gtype` argument to a native GType
+// handle the engine's BuildParamSpec can consume. The arg is GJS-shaped: a class
+// ctor (introspected `Adw.Bin` / `GObject.Object`, or a registered class) whose
+// real `$gtype` is the GType handle (G4), or an already-resolved GType handle.
+function resolveGTypeArg(gtype) {
+  if (gtype === null || gtype === undefined) return gtype;
+  if (typeof gtype === 'function' || typeof gtype === 'object') {
+    const gt = gtype.$gtype;
+    if (gt !== undefined) return gt;
+  }
+  return gtype; // assume it is already a GType handle
+}
+
+// object/boxed ParamSpec factories: `(name, nick, blurb, flags, gtype)` — matching
+// GJS's GObject.ParamSpec.object/.boxed argument order. `gtype` is a class ctor
+// (its `$gtype` is read) or a GType handle. Produces a real g_param_spec_object /
+// g_param_spec_boxed via the engine's BuildParamSpec.
+function paramSpecGTyped(type) {
+  return (name, nick, blurb, flags, gtype) => ({
+    $paramSpec: true,
+    type,
+    name,
+    nick,
+    blurb,
+    flags,
+    gtype: resolveGTypeArg(gtype),
+  });
+}
+
 const ParamSpec = Object.freeze({
   string: paramSpecPlain('string'),
   boolean: paramSpecPlain('boolean'),
@@ -803,6 +858,8 @@ const ParamSpec = Object.freeze({
   uint64: paramSpecRanged('uint64'),
   double: paramSpecRanged('double'),
   float: paramSpecRanged('float'),
+  object: paramSpecGTyped('object'),
+  boxed: paramSpecGTyped('boxed'),
 });
 
 // Walk up the JS class's prototype chain to the nearest node-gi base wrapper
@@ -844,6 +901,9 @@ function paramSpecToNative(desc, key) {
   if (desc.default !== undefined) spec.default = desc.default;
   if (typeof desc.minimum === 'number') spec.minimum = desc.minimum;
   if (typeof desc.maximum === 'number') spec.maximum = desc.maximum;
+  // object/boxed ParamSpecs carry a value GType handle (passed straight to the
+  // engine's BuildParamSpec → g_param_spec_object / g_param_spec_boxed).
+  if (desc.gtype !== undefined) spec.gtype = desc.gtype;
   return spec;
 }
 
@@ -993,6 +1053,11 @@ function registerClass(metaOrClass, maybeClass) {
   Object.defineProperty(Subclass, 'name', { value: gtypeName, configurable: true });
   Subclass.prototype = klass.prototype;
   Subclass.$gtypeName = gtypeName;
+  // The native registerClass returns the registered GType as a node-gi GType
+  // handle (G4) — surface it as `$gtype` (GObject.type_ensure(MyClass.$gtype),
+  // ParamSpec.object(..., MyClass) all read it). It is the SAME handle constructType
+  // already consumes, so registration and `$gtype` share one carrier.
+  Subclass.$gtype = typeHandle;
   return Subclass;
 }
 

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -253,6 +253,15 @@ export function hasProperty(handle: GObjectHandle, name: string): boolean;
 export function getTypeName(handle: GObjectHandle): string;
 
 /**
+ * The runtime GType of an introspected registered type, as an opaque node-gi
+ * GType handle ({@link TypeHandle} — a tag-distinct External carrying the GType,
+ * NOT a number/pointer). The L1 layer surfaces it as a lazy `Ns.Type.$gtype`
+ * getter and feeds it to GType-typed GI arguments (`GObject.type_ensure`,
+ * `g_param_spec_object`'s value type, …). Returns `null` for an unknown name.
+ */
+export function getGType(namespace: string, name: string): TypeHandle | null;
+
+/**
  * Whether a GObject handle's GType is-a `namespace.typeName` (g_type_is_a — also
  * true when the type implements an interface). Used by the L1 wrapper to pick the
  * right `Gio._promisify` registration when two classes promisify a same-named method.
@@ -377,6 +386,7 @@ declare const native: {
   setProperty: typeof setProperty;
   hasProperty: typeof hasProperty;
   getTypeName: typeof getTypeName;
+  getGType: typeof getGType;
   isInstanceOf: typeof isInstanceOf;
   isGObjectHandle: typeof isGObjectHandle;
   callBoxedMethod: typeof callBoxedMethod;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -240,6 +240,18 @@ export const hasProperty = native.hasProperty;
 export const getTypeName = native.getTypeName;
 
 /**
+ * The runtime GType of an introspected registered type, as an opaque node-gi
+ * GType handle (a tag-distinct External carrying the GType — NOT a number/pointer).
+ * The L1 layer surfaces it as a lazy `Ns.Type.$gtype` getter and feeds it to
+ * GType-typed GI arguments (`GObject.type_ensure`, `g_param_spec_object`'s value
+ * type, …). Returns `null` for an unknown/unregistered name.
+ * @param {string} namespace e.g. "Adw"
+ * @param {string} name e.g. "Clamp"
+ * @returns {unknown} opaque GType handle, or null
+ */
+export const getGType = native.getGType;
+
+/**
  * Whether a GObject handle's GType is-a `namespace.typeName` (g_type_is_a — also
  * true when the type implements an interface). Used by the L1 wrapper to pick the
  * right `Gio._promisify` registration when two classes promisify a method of the

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -444,6 +444,54 @@ static bool TryGetBoxedPtr(Napi::Value v, gpointer* out) {
   return true;
 }
 
+// ---- GType value handle ----
+//
+// A GType is represented in JS as a dedicated, type-tagged External holding the
+// `GType` (a `gsize`) directly in its Data() pointer slot — NOT a plain number
+// (a number is indistinguishable from an enum value at a GI_TYPE_TAG_GTYPE arg)
+// and NOT a GObject/boxed handle (a GType is a small integer, dereferencing it as
+// a pointer would crash). The tag lets the marshaller recognise it structurally
+// without touching the value. GJS's richer GType *object* (refs/gjs gi/gtype.cpp)
+// carries a name slot too; node-gi's tagged External is the minimal equivalent —
+// the L1 layer can layer `.name` ergonomics on top if needed. GTypes are
+// process-stable (static registration, never freed), so the handle has no
+// finalizer. This is also the handle registerClass returns (so a registered
+// class's `$gtype` and the constructType type-handle are one and the same).
+static const napi_type_tag kGTypeHandleTag = {0x3a7f1c9e5b2d4860ULL,
+                                              0xc4e8a1b3d5f72096ULL};
+
+static Napi::Value MakeGTypeHandle(Napi::Env env, GType gtype) {
+  Napi::External<void> ext = Napi::External<void>::New(env, reinterpret_cast<void*>(gtype));
+  ext.TypeTag(&kGTypeHandleTag);
+  return ext;
+}
+
+// Read a GType from a kGTypeHandleTag External (the GType representation above),
+// without dereferencing. Returns 0 (G_TYPE_INVALID) when `v` is not a GType handle.
+static GType ReadGTypeHandle(Napi::Value v) {
+  if (!v.IsExternal()) return 0;
+  Napi::External<void> ext = v.As<Napi::External<void>>();
+  if (!ext.CheckTypeTag(&kGTypeHandleTag)) return 0;
+  return reinterpret_cast<GType>(ext.Data());
+}
+
+// Marshal a JS GType argument (a GType handle, or null → 0) into a GType, throwing
+// a clean TypeError otherwise. Shared by the GI_TYPE_TAG_GTYPE / G_TYPE_GTYPE
+// marshalling paths.
+static bool UnwrapGTypeArg(Napi::Env env, Napi::Value v, GType* out) {
+  if (v.IsNull() || v.IsUndefined()) {
+    *out = 0;
+    return true;
+  }
+  if (v.IsExternal() && v.As<Napi::External<void>>().CheckTypeTag(&kGTypeHandleTag)) {
+    *out = reinterpret_cast<GType>(v.As<Napi::External<void>>().Data());
+    return true;
+  }
+  Napi::TypeError::New(env, "expected a GType handle (e.g. Class.$gtype)")
+      .ThrowAsJavaScriptException();
+  return false;
+}
+
 // `ownedStrings` (optional): when a transfer-full string IN/INOUT arg is g_strdup'd
 // here, the freshly-allocated pointer is appended so the caller can g_free it if the
 // invoke never adopts it (an arg-marshal error before the call, or a failed invoke).
@@ -539,6 +587,14 @@ static bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArg
             .ThrowAsJavaScriptException();
         return false;
       }
+      return true;
+    }
+    case GI_TYPE_TAG_GTYPE: {
+      // A GType argument (e.g. GObject.type_ensure, g_type_name): read the GType
+      // from a node-gi GType handle and write it into the GType slot (gsize-wide).
+      GType gt = 0;
+      if (!UnwrapGTypeArg(env, v, &gt)) return false;
+      out->v_size = static_cast<gsize>(gt);
       return true;
     }
     default:
@@ -1082,6 +1138,13 @@ static Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* a
       }
       if (iface != nullptr) gi_base_info_unref(iface);
       return result;
+    }
+    case GI_TYPE_TAG_GTYPE: {
+      // A GType return value (e.g. g_type_from_name): wrap the GType slot
+      // (gsize-wide) as a node-gi GType handle so it round-trips back into the
+      // engine. A 0 GType (not found) becomes null.
+      GType gt = static_cast<GType>(arg->v_size);
+      return gt != 0 ? MakeGTypeHandle(env, gt) : env.Null();
     }
     default:
       Napi::TypeError::New(env, "Unsupported return type tag " +
@@ -2413,6 +2476,13 @@ static void NodeGiInstallTemplateScopeOnClass(NodeGiClassData* cd, gpointer g_cl
 // Marshal a GValue into a JS value (fundamental types).
 static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
   GType ft = G_TYPE_FUNDAMENTAL(G_VALUE_TYPE(v));
+  // G_TYPE_GTYPE is a runtime-resolved type (g_gtype_get_type()), so it cannot be
+  // a switch case label — handle it up front. A GType-valued GValue marshals to a
+  // node-gi GType handle (0 → null).
+  if (G_VALUE_HOLDS_GTYPE(v)) {
+    GType gt = g_value_get_gtype(v);
+    return gt != 0 ? MakeGTypeHandle(env, gt) : env.Null();
+  }
   switch (ft) {
     case G_TYPE_BOOLEAN: return Napi::Boolean::New(env, g_value_get_boolean(v));
     case G_TYPE_CHAR: return Napi::Number::New(env, g_value_get_schar(v));
@@ -2463,6 +2533,14 @@ static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
 // Marshal a JS value into an already-g_value_init'd GValue.
 static bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
   GType ft = G_TYPE_FUNDAMENTAL(G_VALUE_TYPE(v));
+  // G_TYPE_GTYPE is a runtime-resolved type (not constexpr) → handle before the
+  // switch. A GType handle (or null → 0) into a GType-valued GValue.
+  if (G_VALUE_HOLDS_GTYPE(v)) {
+    GType gt = 0;
+    if (!UnwrapGTypeArg(env, js, &gt)) return false;
+    g_value_set_gtype(v, gt);
+    return true;
+  }
   switch (ft) {
     case G_TYPE_BOOLEAN: g_value_set_boolean(v, js.ToBoolean().Value()); return true;
     case G_TYPE_CHAR: g_value_set_schar(v, static_cast<gint8>(js.ToNumber().Int32Value())); return true;
@@ -2680,14 +2758,17 @@ Napi::Value NewObject(const Napi::CallbackInfo& info) {
 // (the GType) for constructType().
 
 // GTypes are process-stable and never freed (static registration), so the
-// handle carries no finalizer.
+// handle carries no finalizer. registerClass returns a kGTypeHandleTag External,
+// so validate the tag (a GObject/boxed handle is also an External, but holds a
+// non-GType pointer — reinterpreting it as a GType would be type-confusion).
 static GType UnwrapGType(Napi::Env env, Napi::Value v) {
-  if (!v.IsExternal()) {
+  GType gt = ReadGTypeHandle(v);
+  if (gt == 0) {
     Napi::TypeError::New(env, "expected a node-gi type handle from registerClass()")
         .ThrowAsJavaScriptException();
     return 0;
   }
-  return reinterpret_cast<GType>(v.As<Napi::External<void>>().Data());
+  return gt;
 }
 
 // ---- registerClass custom properties + signals (class_init) ----
@@ -2778,6 +2859,31 @@ static GParamSpec* BuildParamSpec(Napi::Env env, Napi::Object spec, std::string*
                               def.IsNumber() ? static_cast<gfloat>(def.As<Napi::Number>().DoubleValue())
                                              : 0,
                               flags);
+  }
+  if (type == "object" || type == "boxed") {
+    // An object- or boxed-typed property (GObject.ParamSpec.object / .boxed). The
+    // value GType comes from the spec's `gtype` field — a node-gi GType handle
+    // (the L1 resolves a class ctor's `$gtype` to it). g_param_spec_object/boxed
+    // own no default beyond NULL, so `default`/`minimum`/`maximum` are ignored.
+    GType valueGType = spec.Has("gtype") ? ReadGTypeHandle(spec.Get("gtype")) : 0;
+    if (valueGType == 0) {
+      *err = "a '" + type + "' property requires a gtype (a class or GType handle)";
+      return nullptr;
+    }
+    if (type == "object") {
+      if (!g_type_is_a(valueGType, G_TYPE_OBJECT)) {
+        *err = std::string("an 'object' property gtype must be a GObject type, got ") +
+               g_type_name(valueGType);
+        return nullptr;
+      }
+      return g_param_spec_object(nm, nm, nm, valueGType, flags);
+    }
+    if (!G_TYPE_IS_BOXED(valueGType)) {
+      *err = std::string("a 'boxed' property gtype must be a boxed type, got ") +
+             g_type_name(valueGType);
+      return nullptr;
+    }
+    return g_param_spec_boxed(nm, nm, nm, valueGType, flags);
   }
   *err = "unsupported property type '" + type + "'";
   return nullptr;
@@ -3561,7 +3667,10 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
         .ThrowAsJavaScriptException();
     return env.Null();
   }
-  return Napi::External<void>::New(env, reinterpret_cast<void*>(newType));
+  // Tag the returned type handle as a GType handle so it doubles as the class's
+  // `$gtype` (G4): the same External feeds constructType (UnwrapGType) AND the
+  // GType marshalling (GObject.type_ensure, g_param_spec_object's value gtype, …).
+  return MakeGTypeHandle(env, newType);
 }
 
 // constructType(typeHandle, props?: Record<string, unknown>) -> External<GObject>
@@ -3666,6 +3775,31 @@ Napi::Value GetTypeName(const Napi::CallbackInfo& info) {
   GObject* obj = UnwrapGObject(env, info[0]);
   if (obj == nullptr) return env.Null();
   return Napi::String::New(env, G_OBJECT_TYPE_NAME(obj));
+}
+
+// getGType(namespace, name) -> GType handle | null
+// The runtime GType of an introspected registered type (object/interface/struct/
+// union/enum/flags), as a node-gi GType handle. The L1 layer surfaces it as a
+// lazy `Ns.Type.$gtype` getter (so `Adw.Clamp.$gtype` / `GObject.type_ensure(...)`
+// work). Returns null for an unknown or unregistered name.
+Napi::Value GetGType(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsString() || !info[1].IsString()) {
+    Napi::TypeError::New(env, "getGType(namespace: string, name: string)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string ns = info[0].As<Napi::String>().Utf8Value();
+  std::string nm = info[1].As<Napi::String>().Utf8Value();
+  GIRepository* repo = DupDefaultRepository();
+  GIBaseInfo* base = gi_repository_find_by_name(repo, ns.c_str(), nm.c_str());
+  GType gt = (base != nullptr && GI_IS_REGISTERED_TYPE_INFO(base))
+                 ? gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(base))
+                 : G_TYPE_INVALID;
+  if (base != nullptr) gi_base_info_unref(base);
+  g_object_unref(repo);
+  if (gt == G_TYPE_INVALID || gt == G_TYPE_NONE) return env.Null();
+  return MakeGTypeHandle(env, gt);
 }
 
 // isInstanceOf(handle, namespace, typeName) -> boolean
@@ -5129,6 +5263,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("setProperty", Napi::Function::New(env, SetProperty));
   exports.Set("hasProperty", Napi::Function::New(env, HasProperty));
   exports.Set("getTypeName", Napi::Function::New(env, GetTypeName));
+  exports.Set("getGType", Napi::Function::New(env, GetGType));
   exports.Set("isInstanceOf", Napi::Function::New(env, IsInstanceOf));
   exports.Set("isGObjectHandle", Napi::Function::New(env, IsGObjectHandle));
   // Test-only (cross-thread GC stress) — see StressRefUnrefOffThread.

--- a/packages/node-gi/node-gi/test/gtype.test.mjs
+++ b/packages/node-gi/node-gi/test/gtype.test.mjs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Real `Class.$gtype` + G_TYPE_GTYPE / GI_TYPE_TAG_GTYPE marshalling (G4) for
+// @gjsify/node-gi.
+//
+// A GType is represented as a dedicated, tag-distinct External (NOT a number, NOT
+// a GObject/boxed handle). Every introspected class/struct ctor gains a lazy
+// `$gtype` getter (the engine's getGType), and a registerClass'd type's `$gtype`
+// is the same handle constructType consumes. GType-typed GI arguments marshal both
+// ways (`GObject.type_ensure(X.$gtype)`, `GObject.type_name(gt)` IN;
+// `GObject.type_from_name(name)` returning a GType). This unblocks the storybook's
+// module-top-level `GObject.type_ensure(StoryWidget.$gtype)` + `Adw.Clamp.$gtype`.
+//
+// Reference: GJS's GType marshalling (refs/gjs/gi/{gtype,arg}.cpp). GTypes are
+// process-global + permanent, so each registered type uses a unique name.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+import { isGObjectHandle, isBoxedHandle, getGType } from '../index.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+test('an introspected class exposes a real $gtype (a tag-distinct handle)', () => {
+  const gt = Gio.SimpleAction.$gtype;
+  // Not undefined, not a string ($gtypeName), not a GObject/boxed handle.
+  assert.notEqual(gt, undefined);
+  assert.notEqual(typeof gt, 'string');
+  assert.equal(typeof gt, 'object');
+  assert.equal(isGObjectHandle(gt), false);
+  assert.equal(isBoxedHandle(gt), false);
+  // It names the right GType.
+  assert.equal(GObject.type_name(gt), 'GSimpleAction');
+  // $gtypeName stays the namespaced string (unchanged by $gtype).
+  assert.equal(Gio.SimpleAction.$gtypeName, 'Gio.SimpleAction');
+});
+
+test('$gtype is cached (lazily memoised) — stable identity across reads', () => {
+  const a = Gio.SimpleAction.$gtype;
+  const b = Gio.SimpleAction.$gtype;
+  assert.equal(a, b, 'the lazy getter caches the handle as a value after first read');
+});
+
+test('an introspected struct (boxed) exposes a $gtype', () => {
+  const GLib = requireGi('GLib', '2.0');
+  assert.equal(GObject.type_name(GLib.DateTime.$gtype), 'GDateTime');
+});
+
+test('a registerClass type exposes its own real $gtype', () => {
+  const Thing = GObject.registerClass(class NodeGiGTypeThing extends GObject.Object {});
+  const gt = Thing.$gtype;
+  assert.notEqual(gt, undefined);
+  assert.equal(typeof gt, 'object');
+  assert.equal(GObject.type_name(gt), 'NodeGiGTypeThing');
+});
+
+test('GObject.type_ensure(X.$gtype) runs without error (GType IN arg)', () => {
+  const Thing = GObject.registerClass(class NodeGiGTypeEnsure extends GObject.Object {});
+  // type_ensure takes a single GI_TYPE_TAG_GTYPE arg; returns void.
+  assert.doesNotThrow(() => GObject.type_ensure(Thing.$gtype));
+  assert.doesNotThrow(() => GObject.type_ensure(Gio.SimpleAction.$gtype));
+});
+
+test('a GI call taking AND returning a GType round-trips', () => {
+  const Thing = GObject.registerClass(class NodeGiGTypeRoundTrip extends GObject.Object {});
+  // IN: type_name(GType) -> string.
+  const name = GObject.type_name(Thing.$gtype);
+  assert.equal(name, 'NodeGiGTypeRoundTrip');
+  // RETURN: type_from_name(string) -> GType (a handle), which marshals back.
+  const back = GObject.type_from_name(name);
+  assert.notEqual(back, null);
+  assert.equal(typeof back, 'object');
+  assert.equal(GObject.type_name(back), 'NodeGiGTypeRoundTrip');
+});
+
+test('type_parent(X.$gtype) returns a GType handle (return marshalling)', () => {
+  // Gio.SimpleAction's parent is GObject; type_parent returns a GType.
+  const parent = GObject.type_parent(Gio.SimpleAction.$gtype);
+  assert.notEqual(parent, null);
+  assert.equal(GObject.type_name(parent), 'GObject');
+});
+
+test('type_is_a(X.$gtype, GObject.$gtype) — two GType IN args', () => {
+  assert.equal(GObject.type_is_a(Gio.SimpleAction.$gtype, GObject.Object.$gtype), true);
+});
+
+test('the native getGType returns null for an unknown name', () => {
+  assert.equal(getGType('Gio', 'NoSuchType_xyz'), null);
+});
+
+test('type_from_name of an unregistered name returns null (0 GType → null)', () => {
+  assert.equal(GObject.type_from_name('NodeGiNoSuchGType_xyz'), null);
+});

--- a/packages/node-gi/node-gi/test/paramspec-object.test.mjs
+++ b/packages/node-gi/node-gi/test/paramspec-object.test.mjs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// GObject.ParamSpec.object / .boxed (G1) for @gjsify/node-gi.
+//
+// The scalar ParamSpec kinds (string/boolean/int/…) gained two GType-valued
+// siblings: `GObject.ParamSpec.object(name, nick, blurb, flags, gtype)` and
+// `.boxed(...)`, where `gtype` is a class ctor (its real `$gtype` is read, G4) or
+// a GType handle. They build a real g_param_spec_object / g_param_spec_boxed via
+// the engine's BuildParamSpec, so a registerClass property typed as a GObject can
+// be set + read back as a wrapped instance (round-tripping identity). This is the
+// storybook's first crash (`StoryWidget`'s `meta`/`args` are ParamSpec.object).
+//
+// Reference: GJS's GObject.ParamSpec.object/.boxed argument order
+// (refs/gjs/modules/core/overrides/GObject.js). GTypes are process-global +
+// permanent, so each test registers a uniquely-named type.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+const GLib = requireGi('GLib', '2.0');
+const RW = GObject.ParamFlags.READWRITE;
+
+test('GObject.ParamSpec.object/.boxed are surfaced as factories', () => {
+  assert.equal(typeof GObject.ParamSpec.object, 'function');
+  assert.equal(typeof GObject.ParamSpec.boxed, 'function');
+  // The factory returns a GJS-shaped descriptor carrying the resolved value gtype.
+  const desc = GObject.ParamSpec.object('meta', 'Meta', 'an object prop', RW, GObject.Object);
+  assert.equal(desc.$paramSpec, true);
+  assert.equal(desc.type, 'object');
+  assert.equal(desc.name, 'meta');
+  assert.notEqual(desc.gtype, undefined); // GObject.Object.$gtype handle
+});
+
+test('an object property set+get round-trips a wrapped instance (identity)', () => {
+  const Holder = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiParamSpecObjectHolder',
+      Properties: {
+        meta: GObject.ParamSpec.object('meta', 'Meta', 'a GObject-typed prop', RW, GObject.Object),
+      },
+    },
+    class Holder extends GObject.Object {},
+  );
+
+  const h = new Holder();
+  const payload = new Gio.SimpleAction({ name: 'act' });
+
+  // set then get round-trips the SAME wrapper (the toggle-ref identity cache).
+  h.meta = payload;
+  const got = h.meta;
+  assert.equal(got === payload, true, 'the object property reads back the identical wrapper');
+  assert.equal(got.get_name(), 'act', 'the round-tripped GObject is the real instance');
+
+  // a different instance replaces it.
+  const other = new Gio.SimpleAction({ name: 'other' });
+  h.meta = other;
+  assert.equal(h.meta === other, true);
+
+  // null clears it.
+  h.meta = null;
+  assert.equal(h.meta, null);
+});
+
+test('an object property accepts the value at construction time', () => {
+  const Holder = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiParamSpecObjectCtor',
+      Properties: {
+        meta: GObject.ParamSpec.object('meta', '', '', RW, GObject.Object),
+      },
+    },
+    class Holder extends GObject.Object {},
+  );
+  const payload = new Gio.SimpleAction({ name: 'ctor' });
+  const h = new Holder({ meta: payload });
+  assert.equal(h.meta === payload, true);
+});
+
+test('a .boxed ParamSpec builds and installs (GLib.DateTime is a boxed type)', () => {
+  const desc = GObject.ParamSpec.boxed('when', 'When', 'a boxed prop', RW, GLib.DateTime);
+  assert.equal(desc.$paramSpec, true);
+  assert.equal(desc.type, 'boxed');
+  assert.notEqual(desc.gtype, undefined);
+
+  const Boxer = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiParamSpecBoxer',
+      Properties: { when: desc },
+    },
+    class Boxer extends GObject.Object {},
+  );
+  // The class registered (so the boxed pspec installed without error).
+  assert.equal(GObject.type_name(Boxer.$gtype), 'NodeGiParamSpecBoxer');
+});
+
+test('error: an object/boxed ParamSpec without a gtype is rejected clearly', () => {
+  assert.throws(
+    () =>
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiParamSpecObjectNoGType',
+          Properties: { x: GObject.ParamSpec.object('x', '', '', RW, undefined) },
+        },
+        class extends GObject.Object {},
+      ),
+    /requires a gtype/,
+  );
+});
+
+test('error: an object ParamSpec gtype that is not a GObject type is rejected', () => {
+  assert.throws(
+    () =>
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiParamSpecObjectBadGType',
+          // GLib.DateTime is a boxed (not GObject) type → invalid for .object.
+          Properties: { x: GObject.ParamSpec.object('x', '', '', RW, GLib.DateTime) },
+        },
+        class extends GObject.Object {},
+      ),
+    /must be a GObject type/,
+  );
+});


### PR DESCRIPTION
Two small, independent node-gi GJS-compat enablers (G1 + G4) needed for the GJS Adwaita storybook to load on Node. Additive — scalar ParamSpec + existing GValue/arg cases unchanged.

## G1 — `GObject.ParamSpec.object` / `.boxed`
- New L1 factories `(name, nick, blurb, flags, gtype)` (GJS argument order). `gtype` is a class ctor (its real `$gtype` is read, via G4) or a GType handle.
- `BuildParamSpec` (addon.cc) handles the `object`/`boxed` kinds → `g_param_spec_object` / `g_param_spec_boxed`, type-checked (`object` requires a GObject type, `boxed` a boxed type) with clean error messages.
- A GObject-typed `registerClass` property set+get round-trips a wrapped instance both directions (rides the existing `JsToGValue`/`GValueToJs` `G_TYPE_OBJECT` from #659; toggle-ref identity preserved, `===` holds).

## G4 — real `Class.$gtype` + `G_TYPE_GTYPE` marshalling
- A GType is represented as a dedicated **tag-distinct External** (`kGTypeHandleTag`) carrying the `GType` — not a number (indistinguishable from an enum at a GType arg), not a GObject/boxed handle (a GType is a small integer; a blind deref would crash).
- `GI_TYPE_TAG_GTYPE` added to `JsToGIArgument`/`GIArgumentToJs`; `G_TYPE_GTYPE` to `JsToGValue`/`GValueToJs` (both directions; `gsize`-wide `v_size` slot; `G_TYPE_GTYPE` handled before the switch since it is a runtime-resolved type, not a constexpr label).
- Native `getGType(namespace, name)` backs a **lazy `Ns.Type.$gtype` getter** on introspected class/struct ctors. `registerClass` now returns (and the L1 stamps) the registered GType as the **same** tagged handle — so `$gtype` and the `constructType` type-handle are one carrier.
- `UnwrapGType` now tag-validates (removes a latent GObject/boxed type-confusion footgun).
- Unblocks `GObject.type_ensure(StoryWidget.$gtype)` and `component: Adw.Clamp.$gtype` at storybook module top-level.

## Tests
`test/paramspec-object.test.mjs` + `test/gtype.test.mjs` (16 new): object pspec builds + property round-trips a wrapped instance (identity + construct-time), boxed pspec builds, `$gtype` is a real tag-distinct handle (introspected + registered + struct), `type_ensure($gtype)` runs, and GType IN/return round-trips (`type_name`/`type_from_name`/`type_parent`/`type_is_a`). Full suite **219 pass / 11 self-skip** (GTK/Adw + templates run green under Wayland), `test:gc` green.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH