### PR TITLE
feat(node-gi): registerClass mutate-in-place + ctor body

### DIFF
--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -378,6 +378,46 @@ function findProtoDescriptor(proto, prop) {
 // turn keeps this WeakMap entry — and the proxy + its fields — alive).
 const instanceCache = new WeakMap();
 
+// ---- G3 mutate-in-place registry ----
+//
+// registerClass registers the GType for the GIVEN class and returns that SAME
+// class (GJS-faithful — refs/gjs/modules/core/overrides/GObject.js mutates `klass`
+// and returns it), so both `const X = registerClass(…,C)` and
+// `static { registerClass(…,C) }` (return discarded) leave the same symbol bound
+// to the registered GType. The construction that produces the registered GType is
+// moved to the introspected base ctor (makeClass), keyed on `new.target`: when
+// `new Sub(args)` runs and `Sub` is registered here, the base ctor builds the
+// registered GType via constructType + wraps it, and RETURNS that wrapper. Because
+// a base constructor that returns an object substitutes `this` in every derived
+// ctor (ES `super` semantics), this single routing point makes the whole super()
+// chain construct the right GType, return the canonical toggle-ref wrapper carrying
+// the leaf's prototype, and run every user ctor body against it — exactly how GJS
+// instantiates `new.target`'s `$gtype` rather than the literal base. Keyed by the
+// JS class → { typeHandle, children?, internalChildren? } (children move here from
+// the old throwaway Subclass so init_template'd children are surfaced on the
+// instance). SCOPE: single-level only (a class extending an INTROSPECTED base);
+// multi-level registered-of-registered is rejected at registration (findParentGType
+// guard) until G2.
+const registeredClasses = new Map();
+
+// Surface a templated type's bound children on a freshly-constructed instance
+// (GJS convention: public `this.<name>`, internal `this._<name>`, '-' → '_'). The
+// engine already ran init_template during constructType, so getTemplateChild
+// resolves each. Assigned through the proxy (set trap → stored as an instance
+// expando), exactly as the old Subclass did.
+function assignTemplateChildren(instance, handle, reg) {
+  if (reg.children !== undefined) {
+    for (const childName of reg.children) {
+      instance[childName.replace(/-/g, '_')] = wrapReturn(native.getTemplateChild(handle, childName));
+    }
+  }
+  if (reg.internalChildren !== undefined) {
+    for (const childName of reg.internalChildren) {
+      instance[`_${childName.replace(/-/g, '_')}`] = wrapReturn(native.getTemplateChild(handle, childName));
+    }
+  }
+}
+
 // Wrap a live GObject handle as a GJS-shaped instance. When `userProto` is given
 // (a registerClass subclass's prototype) the wrapper resolves the user class's
 // own prototype members FIRST — so `inst.myMethod()` runs the JS method with the
@@ -540,6 +580,24 @@ function defineLazyGType(ctor, namespace, typeName) {
 
 function makeClass(namespace, typeName) {
   const ctor = function ctor(props) {
+    // G3 construction routing. `new.target` is the leaf class the `new` was applied
+    // to and is preserved through every super() hop, so when a registerClass'd
+    // subclass is being constructed (directly or up a super() chain) we build the
+    // REGISTERED GType and return its canonical toggle-ref wrapper (carrying the
+    // leaf's prototype as USER_PROTO) — which then substitutes `this` in every
+    // derived ctor body. An unregistered new.target (the introspected class itself,
+    // or `new.target === undefined` from a call without `new`) falls through to the
+    // unchanged introspected construction.
+    const nt = new.target;
+    if (nt !== undefined) {
+      const reg = registeredClasses.get(nt);
+      if (reg !== undefined) {
+        const handle = native.constructType(reg.typeHandle, props ? unwrapProps(props) : {});
+        const instance = wrapInstance(handle, nt.prototype);
+        assignTemplateChildren(instance, handle, reg);
+        return instance;
+      }
+    }
     const handle = native.newObject(namespace, typeName, props ? unwrapProps(props) : {});
     return wrapInstance(handle);
   };
@@ -559,14 +617,22 @@ function makeClass(namespace, typeName) {
   // Expose constructor/static methods lazily: Ns.Class.new(...) /
   // Ns.Class.new_for_path(...) (and the camelCase aliases). `new Ns.Class({...})`
   // still goes through the target's [[Construct]] (the default Proxy behaviour).
-  return new Proxy(ctor, {
-    get(t, prop) {
+  const proxy = new Proxy(ctor, {
+    get(t, prop, receiver) {
+      // #667: a raw (UNregistered) subclass that `extends` this introspected class
+      // must NOT inherit-read the parent's GType. A registered subclass has its OWN
+      // `$gtype` (set in place by registerClass, so it shadows + never reaches this
+      // trap); a raw subclass is not a GType, so an inherited read (receiver is the
+      // subclass, not this proxy) resolves to undefined. A direct read on the
+      // introspected class itself (receiver === proxy) resolves the real lazy GType.
+      if (prop === '$gtype' && receiver !== proxy) return undefined;
       if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
       const giName = camelToSnake(prop);
       return (...args) =>
         wrapReturn(native.callStaticMethod(namespace, typeName, giName, unwrapArgs(args)));
     },
   });
+  return proxy;
 }
 
 // Surface a boxed/struct type (e.g. GLib.MainLoop) as a class-like object whose
@@ -578,8 +644,11 @@ function makeStruct(namespace, typeName) {
   Object.defineProperty(base, 'name', { value: typeName, configurable: true });
   base.$gtypeName = `${namespace}.${typeName}`;
   defineLazyGType(base, namespace, typeName);
-  return new Proxy(base, {
-    get(t, prop) {
+  const proxy = new Proxy(base, {
+    get(t, prop, receiver) {
+      // #667: guard inherited `$gtype` reads (see makeClass) — a raw subclass of a
+      // boxed/struct type does not inherit the parent's GType.
+      if (prop === '$gtype' && receiver !== proxy) return undefined;
       if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
       const giName = camelToSnake(prop);
       return (...args) =>
@@ -589,6 +658,7 @@ function makeStruct(namespace, typeName) {
       return wrapReturn(native.callStaticMethod(namespace, typeName, 'new', unwrapArgs(args)));
     },
   });
+  return proxy;
 }
 
 // Build a frozen enum/flags object keyed GJS-style: member names UPPER_CASED
@@ -749,30 +819,36 @@ function resolvePromisified(handle, methodName) {
 //
 // The Node twin of GJS's `GObject.registerClass(meta, class)`. It accepts both
 // `registerClass(class)` and `registerClass({ GTypeName?, Properties?, Signals?,
-// ... }, class)`, registers a GObject subtype via the native engine, and returns
-// a constructor whose `new`-ed instances are usable as GObjects (property get/
-// set, `.connect/.emit/.disconnect`) AND expose the user class's own prototype
-// methods (resolved before the GObject routing — see wrapInstance).
+// ... }, class)`, registers a GObject subtype via the native engine, registers the
+// GIVEN class IN PLACE, and returns that SAME class (GJS-faithful — see the G3
+// registry above). So both `const X = registerClass(…,C)` and the GJS
+// `static { registerClass(…,C) }` idiom (return discarded) leave the same symbol
+// bound to the registered GType. `new`-ed instances are usable as GObjects
+// (property get/set, `.connect/.emit/.disconnect`) AND expose the user class's own
+// prototype methods (resolved before the GObject routing — see wrapInstance).
 //
-// Caveats (documented, same spirit as the signals/vfunc class-level model):
-//  - The user class's JS constructor body is NOT run; GObject-idiomatic init
-//    belongs in `vfunc_constructed` (which fires during construction). `super()`
-//    chaining maps conceptually to the engine's constructType, not a JS call.
+// G3 contract (the user JS constructor body now RUNS):
+//  - The construction routing lives in the introspected base ctor (makeClass),
+//    keyed on `new.target`. `new X(args)` runs X's ctor body against the canonical
+//    toggle-ref wrapper, with working `super(args)` semantics (the base ctor
+//    returns the wrapper → it substitutes `this` up the whole chain). This REVERSES
+//    the previous "ctor body is not run" caveat. `vfunc_constructed` still fires
+//    once during construction; a class that inits in BOTH a ctor body and
+//    `vfunc_constructed` will run both (normal GJS behaviour) — do not duplicate.
+//  - Toggle-ref identity (#656): the `this` in the ctor body, the post-construct
+//    wrapper, a vfunc's `this` and a signal-handler's `this` are all the SAME
+//    canonical wrapper (===), and a plain JS field set on it survives a round-trip
+//    + GC while C owns the object. (A GObject PROPERTY is still the right choice for
+//    state that must also be visible to C / other bindings.)
 //  - Instances are Proxies over a native handle, not real `instanceof` instances.
-//  - Plain (non-GObject-property) JS instance fields do NOT cross the
-//    vfunc<->instance boundary in this milestone: inside a vfunc, `this` is a
-//    DISTINCT wrapper over the same GObject (the native engine mints a fresh
-//    handle per call, so there is no shared per-instance JS object yet). Use
-//    GObject PROPERTIES for any state that must be visible both inside a vfunc
-//    and on the instance — those live in C and ARE consistent. The unified
-//    instance identity (a per-GObject wrapper cache) arrives with the toggle-ref
-//    work, tracked separately.
-//  - No toggle-ref: a JS↔GObject reference cycle on a custom instance leaks (the
-//    same cycle-leak caveat the signal/vfunc layer carries).
+//  - Ordering caveat: a `vfunc_constructed` that fires DURING constructType sees a
+//    wrapper whose USER_PROTO is attached by the vfunc trampoline (collectVfuncs),
+//    so its own user-proto methods resolve; the post-construct `wrapInstance(handle,
+//    nt.prototype)` then upgrades the same cached wrapper in place (identity kept).
 //  - Multi-level registered subclassing (registering a subclass of a
-//    registerClass'd type) is not yet supported — the native engine resolves the
-//    parent by namespace+type, which a registered (non-introspected) parent has
-//    no entry for.
+//    registerClass'd type) is not yet supported (G2) — the native engine resolves
+//    the parent by namespace+type, which a registered (non-introspected) parent has
+//    no entry for; findParentGType throws a clear error.
 
 // GObject.ParamFlags — the GParamFlags bits the native property builder consumes.
 const ParamFlags = Object.freeze({
@@ -959,13 +1035,16 @@ function collectVfuncs(klass) {
 /**
  * GObject.registerClass — register a GObject subclass declared as a JS class.
  * Supports `registerClass(class)` and `registerClass(meta, class)` where meta is
- * `{ GTypeName?, Properties?, Signals?, ... }` (GJS allows both). Returns a
- * constructor; `new Subclass(props)` constructs the GObject and wraps it so the
- * user class's own prototype methods + the GObject property/signal surface are
- * both usable. See the block comment above for the (documented) caveats.
+ * `{ GTypeName?, Properties?, Signals?, ... }` (GJS allows both). Registers the
+ * GType for the GIVEN class IN PLACE and returns that SAME class (GJS-faithful), so
+ * `static { registerClass(…, X) }` (return discarded) leaves `X` itself bound to
+ * the registered GType. `new X(props)` constructs the registered GType (routed via
+ * the introspected base ctor on `new.target`), runs the user ctor body against the
+ * canonical wrapper, and exposes the user class's own prototype methods + the
+ * GObject property/signal surface. See the block comment above for the G3 contract.
  * @param {Function|Record<string, unknown>} metaOrClass
  * @param {Function} [maybeClass]
- * @returns {Function}
+ * @returns {Function} the same `klass` (now registered)
  */
 function registerClass(metaOrClass, maybeClass) {
   let meta;
@@ -1034,31 +1113,35 @@ function registerClass(metaOrClass, maybeClass) {
     options,
   );
 
-  const Subclass = function (props) {
-    const handle = native.constructType(typeHandle, props ? unwrapProps(props) : {});
-    const instance = wrapInstance(handle, klass.prototype);
-    // Surface the bound template children on the instance (GJS convention: public
-    // `this.<name>`, internal `this._<name>`, '-' → '_'). The engine already ran
-    // init_template during construction, so get_template_child resolves each.
-    for (const childName of children) {
-      instance[childName.replace(/-/g, '_')] = wrapReturn(native.getTemplateChild(handle, childName));
-    }
-    for (const childName of internalChildren) {
-      instance[`_${childName.replace(/-/g, '_')}`] = wrapReturn(
-        native.getTemplateChild(handle, childName),
-      );
-    }
-    return instance;
-  };
-  Object.defineProperty(Subclass, 'name', { value: gtypeName, configurable: true });
-  Subclass.prototype = klass.prototype;
-  Subclass.$gtypeName = gtypeName;
-  // The native registerClass returns the registered GType as a node-gi GType
-  // handle (G4) — surface it as `$gtype` (GObject.type_ensure(MyClass.$gtype),
-  // ParamSpec.object(..., MyClass) all read it). It is the SAME handle constructType
-  // already consumes, so registration and `$gtype` share one carrier.
-  Subclass.$gtype = typeHandle;
-  return Subclass;
+  // G3: register the GType for the GIVEN class IN PLACE (no throwaway Subclass) and
+  // return that same class. `$gtypeName`/`$gtype` are defined as OWN properties:
+  // `klass` inherits a getter-only `$gtype` accessor from the introspected base ctor
+  // (via the makeClass Proxy), so a plain `klass.$gtype = …` assignment would throw
+  // in strict mode — defineProperty installs an own data property that shadows it.
+  Object.defineProperty(klass, '$gtypeName', {
+    value: gtypeName,
+    configurable: true,
+    writable: true,
+  });
+  // native.registerClass returns the registered GType as a tag-distinct node-gi
+  // GType handle (G4) — surface it as `$gtype` (GObject.type_ensure(X.$gtype),
+  // ParamSpec.object(..., X) all read it). It is the SAME handle constructType
+  // consumes, so registration and `$gtype` share one carrier.
+  Object.defineProperty(klass, '$gtype', {
+    value: typeHandle,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+  // Record the registration so the introspected base ctor (makeClass) routes
+  // `new X(args)` (where new.target === klass) to constructType(typeHandle, …) +
+  // the canonical wrapper. Template children move here from the old Subclass.
+  registeredClasses.set(klass, {
+    typeHandle,
+    children: children.length > 0 ? children : undefined,
+    internalChildren: internalChildren.length > 0 ? internalChildren : undefined,
+  });
+  return klass;
 }
 
 // Merge convenience flag names UNDER an introspected enum: the introspected

--- a/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
+++ b/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+// G3 — GObject.registerClass mutate-in-place + `new.target` construction routing.
+//
+// `GObject.registerClass(meta, X)` registers the GType for the GIVEN class and
+// returns that SAME class (GJS-faithful — refs/gjs/modules/core/overrides/
+// GObject.js mutates `klass` and returns it). So the GJS idiom
+// `static { GObject.registerClass({…}, X) }` (return discarded) leaves `X` itself
+// bound to the registered GType, and `new X(args)`:
+//   - constructs the REGISTERED GType (routed via the introspected base ctor on
+//     `new.target`), not a plain instance of the introspected base,
+//   - RUNS the user JS constructor body against the canonical toggle-ref wrapper
+//     (this REVERSES the old "ctor body is not run" caveat),
+//   - chains construct props through `super(args)`,
+//   - keeps ONE canonical wrapper identity (=== across the ctor `this`, the
+//     constructed instance, and a vfunc `this`).
+// A 2-level JS hierarchy where BOTH levels are registered is still rejected (G2).
+//
+// GTypes are process-global + permanent, so every test registers a uniquely-named
+// type. Reference: refs/gjs/modules/core/overrides/GObject.js (registerClass
+// mutates + returns klass; the `static { registerClass(...) }` idiom).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+const RW = GObject.ParamFlags.READWRITE;
+
+test('static{} registerClass(meta, X) makes X itself the registered GType', () => {
+  class InPlaceStatic extends GObject.Object {
+    static {
+      // The return is DISCARDED — the GJS static-block idiom. X must still BE the
+      // registered GType.
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiInPlaceStatic',
+          Properties: {
+            label: GObject.ParamSpec.string('label', 'Label', 'a label', RW, 'def'),
+          },
+          Signals: { pinged: { param_types: ['int'] } },
+        },
+        InPlaceStatic,
+      );
+    }
+    greet() {
+      return 'hi ' + this.label;
+    }
+  }
+
+  // X itself carries the registered GType identity (return discarded).
+  assert.equal(InPlaceStatic.$gtypeName, 'NodeGiInPlaceStatic');
+  assert.equal(GObject.type_name(InPlaceStatic.$gtype), 'NodeGiInPlaceStatic');
+
+  // `new X(props)` constructs the REGISTERED type (not a plain GObject.Object).
+  const obj = new InPlaceStatic({ label: 'world' });
+  assert.equal(native.getTypeName(unwrap(obj)), 'NodeGiInPlaceStatic');
+
+  // Custom property + user prototype method.
+  assert.equal(obj.label, 'world');
+  assert.equal(obj.greet(), 'hi world');
+  obj.label = 'changed';
+  assert.equal(obj.greet(), 'hi changed');
+
+  // The declared signal connects + emits on the registered type.
+  let received = null;
+  const id = obj.connect('pinged', (n) => {
+    received = n;
+  });
+  obj.emit('pinged', 7);
+  assert.equal(received, 7);
+  obj.disconnect(id);
+  obj.emit('pinged', 99);
+  assert.equal(received, 7, 'a disconnected handler does not fire again');
+});
+
+test('registerClass returns the SAME class (mutate-in-place)', () => {
+  class InPlaceReturn extends GObject.Object {}
+  const ret = GObject.registerClass({ GTypeName: 'NodeGiInPlaceReturn' }, InPlaceReturn);
+  // GJS-faithful: the returned constructor IS the class passed in.
+  assert.equal(ret === InPlaceReturn, true);
+  // The const-assignment form still constructs the registered type.
+  const obj = new ret();
+  assert.equal(native.getTypeName(unwrap(obj)), 'NodeGiInPlaceReturn');
+});
+
+test('the JS constructor body RUNS against the canonical wrapper', () => {
+  let thisInCtor = null;
+  class InPlaceCtor extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiInPlaceCtor' }, InPlaceCtor);
+    }
+    constructor() {
+      super();
+      this.tag = 'ran'; // a plain JS expando written in the ctor body
+      thisInCtor = this;
+    }
+  }
+  const obj = new InPlaceCtor();
+  // The ctor body executed (reversing the old "ctor body not run" caveat) and its
+  // expando survives on the canonical wrapper.
+  assert.equal(obj.tag, 'ran');
+  // `this` inside the ctor IS the constructed instance.
+  assert.equal(thisInCtor === obj, true);
+});
+
+test('super(args) chaining applies construct props passed to the base', () => {
+  class InPlaceSuper extends GObject.Object {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiInPlaceSuper',
+          Properties: {
+            title: GObject.ParamSpec.string('title', 'Title', 't', RW, 'untitled'),
+          },
+        },
+        InPlaceSuper,
+      );
+    }
+    constructor(title) {
+      // A subclass ctor passing args UP to the introspected base via super(): the
+      // base ctor must apply the construct prop, then return the wrapper.
+      super(title === undefined ? {} : { title });
+    }
+  }
+  const obj = new InPlaceSuper('chained');
+  assert.equal(obj.title, 'chained', 'the prop passed through super({...}) was applied');
+  // A super({}) with no title still falls back to the declared default.
+  const def = new InPlaceSuper(undefined);
+  assert.equal(def.title, 'untitled');
+});
+
+test('toggle-ref identity: ctor `this`, vfunc `this`, and the instance are all ===', () => {
+  let thisInCtor = null;
+  let thisInVfunc = null;
+  class InPlaceIdentity extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiInPlaceIdentity' }, InPlaceIdentity);
+    }
+    constructor() {
+      super();
+      this.marker = 'M';
+      thisInCtor = this;
+    }
+    self() {
+      return this;
+    }
+    vfunc_constructed() {
+      // Fires DURING construction; `this` must be the same canonical wrapper.
+      thisInVfunc = this;
+    }
+  }
+  const obj = new InPlaceIdentity();
+  // The ctor `this`, the constructed instance, a method returning `this`, and the
+  // vfunc `this` are ALL the one canonical toggle-ref wrapper (===).
+  assert.equal(thisInCtor === obj, true, 'ctor `this` === the instance');
+  assert.equal(obj.self() === obj, true, 'a method returning `this` === the instance');
+  assert.equal(thisInVfunc === obj, true, 'vfunc `this` === the instance');
+  assert.equal(obj.marker, 'M');
+});
+
+test('a 2-level registered hierarchy is still rejected (G2 guard)', () => {
+  class InPlaceMultiBase extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiInPlaceMultiBase' }, InPlaceMultiBase);
+    }
+  }
+  // The base registered fine (single-level over an introspected parent).
+  assert.equal(GObject.type_name(InPlaceMultiBase.$gtype), 'NodeGiInPlaceMultiBase');
+
+  // Registering a subclass of a REGISTERED class is G2 — the static block runs at
+  // class-definition time and must throw the clear multi-level guard error.
+  assert.throws(() => {
+    class InPlaceMultiChild extends InPlaceMultiBase {
+      static {
+        GObject.registerClass({ GTypeName: 'NodeGiInPlaceMultiChild' }, InPlaceMultiChild);
+      }
+    }
+    return InPlaceMultiChild;
+  }, /multi-level registerClass subclassing is not yet supported/);
+});
+
+test('#667: a raw (unregistered) subclass does not inherit the parent GType', () => {
+  // An introspected class resolves its real $gtype on a direct read.
+  assert.notEqual(Gio.SimpleAction.$gtype, undefined);
+  // A raw subclass that NEVER called registerClass is not a GType — an inherited
+  // read must NOT leak the parent's GType.
+  class RawUnregistered extends Gio.SimpleAction {}
+  assert.equal(RawUnregistered.$gtype, undefined);
+  // A registered subclass DOES carry its own $gtype.
+  const Registered = GObject.registerClass(class NodeGiInPlace667 extends Gio.SimpleAction {});
+  assert.notEqual(Registered.$gtype, undefined);
+  assert.equal(GObject.type_name(Registered.$gtype), 'NodeGiInPlace667');
+});


### PR DESCRIPTION
## node-gi G3 — `GObject.registerClass` mutate-in-place + `new.target` construction routing

Adopt GJS's `registerClass` contract: `GObject.registerClass(meta, X)` now **registers the GType for the GIVEN class and returns that same class**, so the GJS idiom `static { GObject.registerClass({…}, X) }` (return discarded) leaves `X` itself bound to the registered GType. `new X()` constructs the registered type and **runs the user JS constructor body** — instead of building a throwaway `Subclass` wrapper whose ctor body never ran.

### Mechanism
- A module-level `registeredClasses` Map records each class → `{ typeHandle, children?, internalChildren? }`.
- The introspected base ctor (`makeClass`) routes construction on `new.target`: when the leaf is a registered class it builds via `constructType(reg.typeHandle, …)` and returns `wrapInstance(handle, new.target.prototype)`. `new.target` survives every `super()` hop, and an ES base ctor that returns an object substitutes `this` up the whole chain — so every user ctor body runs against the canonical toggle-ref wrapper, with working `super(args)` construct-prop flow and `USER_PROTO` method resolution.
- `registerClass` stamps `$gtypeName` + the real `$gtype` (G4 handle) as **own** properties (`defineProperty`, since the inherited getter-only `$gtype` accessor would reject a plain assignment in strict mode), drops the throwaway `Subclass`, and returns `klass`. Template children move into the base ctor.

### Backward compat
The user JS constructor body now **runs** (reverses the old "ctor body is not run" caveat). `vfunc_constructed` still fires once; toggle-ref identity (#656) is unchanged — the ctor `this`, the constructed instance, and a vfunc `this` are all the same canonical wrapper (`===`). **Single-level only** (a class extending an INTROSPECTED base); multi-level registered-of-registered stays rejected by the `findParentGType` guard (G2, next PR).

Also fixes the #667 nit: `makeClass`/`makeStruct` guard inherited `$gtype` reads via the proxy receiver, so a raw (unregistered) subclass no longer leaks the parent's GType.

**No `addon.cc` change** — `constructType` already builds the registered GType.

### Tests
- New `test/registerclass-inplace.test.mjs`: `static{}` form (X is the registered GType, props/signals work), ctor body runs, `super(args)` chaining, `===` identity (ctor `this` / instance / vfunc `this`), the G2 rejection, the #667 guard.
- All existing suites stay green: **219 headless + 5 GTK under Wayland**, 0 failures (the registerClass-decorator / vfunc / signals / template / GTK-smoke / Adw suites).

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH