### PR TITLE
feat(node-gi): multi-level registered subclassing

### DIFF
--- a/packages/node-gi/example/src/app.ts
+++ b/packages/node-gi/example/src/app.ts
@@ -52,9 +52,10 @@ print(`file-basename: ${file.get_basename()}`);
 
 // 6. A `GObject.registerClass` subclass: custom property + signal + a user
 //    method + `vfunc_constructed`. State lives in GObject PROPERTIES (which
-//    cross the node-gi vfunc/instance boundary); the JS constructor body is NOT
-//    run under node-gi, so init happens in `vfunc_constructed` (which fires
-//    during construction on both runtimes) or via CONSTRUCT properties.
+//    cross the node-gi vfunc/instance boundary). The JS constructor body now DOES
+//    run under node-gi (G3), exactly as under GJS; this example still uses
+//    `vfunc_constructed` (which fires during construction on both runtimes) and a
+//    CONSTRUCT property so the init is byte-identical across the two runtimes.
 let constructedCount = 0;
 const Counter = GObject.registerClass(
     {

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -369,6 +369,19 @@ function findProtoDescriptor(proto, prop) {
   return undefined;
 }
 
+// Whether `proto` is the SAME as, or a more-derived descendant of, `maybeAncestor`
+// (i.e. `maybeAncestor` lies on `proto`'s prototype chain). Used to decide whether a
+// later wrapInstance userProto should UPGRADE a cached one: on a multi-level chain a
+// vfunc firing during construction wraps the instance with the OVERRIDING ancestor's
+// prototype before the leaf ctor wraps it with the leaf's, so the leaf (descendant)
+// proto must be allowed to supersede the ancestor's — but never the reverse.
+function isProtoSameOrDescendantOf(proto, maybeAncestor) {
+  for (let p = proto; p !== null; p = Object.getPrototypeOf(p)) {
+    if (p === maybeAncestor) return true;
+  }
+  return false;
+}
+
 // L1 proxy-identity cache (the user-visible half of the toggle-ref bridge). The
 // native engine now returns the CANONICAL External per GObject (same GObject ⇒
 // same handle), so we cache the per-instance Proxy keyed by that handle: the same
@@ -427,14 +440,20 @@ function assignTemplateChildren(instance, handle, reg) {
 function wrapInstance(handle, userProto) {
   const cached = instanceCache.get(handle);
   if (cached !== undefined) {
-    // UPGRADE a cached generic (userProto-less) wrapper when this wrap supplies a
-    // userProto — so a subclass instance first seen generically (returned from
-    // store.get_item / a signal sender / resurrection) still gets its prototype
-    // methods. Never DOWNGRADE: an existing userProto is kept. The userProto lives
-    // on the target (read via the proxy here), so the upgrade is in place —
-    // identity (===) and any expando fields are preserved.
-    if (userProto !== undefined && cached[USER_PROTO] === undefined) {
-      cached[USER_PROTO] = userProto;
+    // UPGRADE a cached wrapper's user prototype when this wrap supplies a MORE
+    // DERIVED one: an undefined cache (a subclass instance first seen generically —
+    // returned from store.get_item / a signal sender / resurrection), OR a cached
+    // ANCESTOR prototype (a multi-level chain where a vfunc fired during constructType
+    // wrapped the instance with the OVERRIDING ancestor's prototype, before the leaf
+    // ctor's wrapInstance(handle, leaf.prototype) runs — the leaf proto must win so
+    // the leaf's OWN methods resolve). Never DOWNGRADE: a more-derived cached proto is
+    // kept. The userProto lives on the target (read via the proxy here), so the
+    // upgrade is in place — identity (===) and any expando fields are preserved.
+    if (userProto !== undefined && userProto !== cached[USER_PROTO]) {
+      const current = cached[USER_PROTO];
+      if (current === undefined || isProtoSameOrDescendantOf(userProto, current)) {
+        cached[USER_PROTO] = userProto;
+      }
     }
     return cached;
   }
@@ -1030,18 +1049,30 @@ function signalSpecToNative(spec, key) {
   return out;
 }
 
-// Collect every `vfunc_<name>` method on the class's prototype chain into the
-// native vfuncs map (key = name without the `vfunc_` prefix). The native engine
-// invokes each override with `this` = the raw instance handle; re-wrap it so the
-// user's vfunc sees a usable class instance (own methods + property routing).
+// Collect this class's OWN newly-declared `vfunc_<name>` methods into the native
+// vfuncs map (key = name without the `vfunc_` prefix). The native engine invokes
+// each override with `this` = the raw instance handle; re-wrap it so the user's
+// vfunc sees a usable class instance (own methods + property routing).
 // `super.vfunc_<name>(...)` inside the override resolves to a chain-up thunk on the
 // introspected base class's prototype (vfuncChainProto → native.callParentVfunc):
 // applying the user fn with a custom `this` keeps `super` bound to its lexical home
 // object (klass.prototype), so chain-up works through the .apply boundary.
+//
+// Multi-level boundary (G2): the walk STOPS at the first REGISTERED ancestor's
+// prototype. A registered ancestor already installed its own vfunc_* trampolines
+// into ITS GType's vtable, which this class inherits via the g_type_register_static
+// class-struct memcpy. Re-collecting them would install a DUPLICATE trampoline on
+// the leaf's GType whose captured parent IS the ancestor's own trampoline, so the
+// ancestor's `super.vfunc_*()` (running as the leaf's override) would re-enter
+// itself forever (stack overflow). Prototypes of UNREGISTERED mixin classes between
+// the leaf and the nearest registered ancestor ARE still collected — they have no
+// GType of their own, so their vfuncs only reach the vtable through the leaf.
 function collectVfuncs(klass) {
   const vfuncs = {};
   const seen = new Set();
   for (let p = klass.prototype; p !== null && p !== Object.prototype; p = Object.getPrototypeOf(p)) {
+    const owner = Object.getOwnPropertyDescriptor(p, 'constructor')?.value;
+    if (owner !== undefined && owner !== klass && registeredClasses.has(owner)) break;
     for (const key of Object.getOwnPropertyNames(p)) {
       if (!key.startsWith('vfunc_') || seen.has(key)) continue;
       const desc = Object.getOwnPropertyDescriptor(p, key);

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -395,9 +395,10 @@ const instanceCache = new WeakMap();
 // instantiates `new.target`'s `$gtype` rather than the literal base. Keyed by the
 // JS class → { typeHandle, children?, internalChildren? } (children move here from
 // the old throwaway Subclass so init_template'd children are surfaced on the
-// instance). SCOPE: single-level only (a class extending an INTROSPECTED base);
-// multi-level registered-of-registered is rejected at registration (findParentGType
-// guard) until G2.
+// instance). Multi-level registered-of-registered chains (G2) are supported: the
+// registry is also consulted by findParentGType to resolve a REGISTERED parent's
+// GType handle (subclassing via native.registerClassFromGType), and the new.target
+// routing keys on the leaf so construction is correct at any depth.
 const registeredClasses = new Map();
 
 // Surface a templated type's bound children on a freshly-constructed instance
@@ -580,16 +581,17 @@ function defineLazyGType(ctor, namespace, typeName) {
 
 function makeClass(namespace, typeName) {
   const ctor = function ctor(props) {
-    // G3 construction routing. `new.target` is the leaf class the `new` was applied
-    // to and is preserved through every super() hop, so when a registerClass'd
-    // subclass is being constructed (directly or up a super() chain) we build the
-    // REGISTERED GType and return its canonical toggle-ref wrapper (carrying the
-    // leaf's prototype as USER_PROTO) — which then substitutes `this` in every
-    // derived ctor body. An unregistered new.target (the introspected class itself,
-    // or `new.target === undefined` from a call without `new`) falls through to the
+    // G3/G2 construction routing. `new.target` is the leaf class the `new` was
+    // applied to and is preserved through every super() hop, so when a registerClass'd
+    // subclass is being constructed (directly or up a super() chain — at ANY depth,
+    // since the leaf's registered GType already IS the full multi-level type) we build
+    // the REGISTERED GType and return its canonical toggle-ref wrapper (carrying the
+    // leaf's prototype as USER_PROTO) — which then substitutes `this` in every derived
+    // ctor body. `new.target === undefined` (a call without `new`) or `=== proxy` (a
+    // direct `new Ns.Class(...)` on the introspected class itself) falls through to the
     // unchanged introspected construction.
     const nt = new.target;
-    if (nt !== undefined) {
+    if (nt !== undefined && nt !== proxy) {
       const reg = registeredClasses.get(nt);
       if (reg !== undefined) {
         const handle = native.constructType(reg.typeHandle, props ? unwrapProps(props) : {});
@@ -597,6 +599,15 @@ function makeClass(namespace, typeName) {
         assignTemplateChildren(instance, handle, reg);
         return instance;
       }
+      // `nt` is a subclass of this introspected GObject class but was NEVER passed to
+      // GObject.registerClass(): silently building the introspected BASE type would
+      // produce the wrong GType (missing the subclass's props/signals/vfuncs). Throw
+      // the GJS-shaped error instead of constructing a misleading instance — the L1
+      // analogue of GJS's "are you using GObject.registerClass()?" construct guard
+      // (refs/gjs/gi/object.cpp).
+      throw new Error(
+        `Object ${nt.name || '(anonymous)'} is not registered with GObject.registerClass()`,
+      );
     }
     const handle = native.newObject(namespace, typeName, props ? unwrapProps(props) : {});
     return wrapInstance(handle);
@@ -845,10 +856,14 @@ function resolvePromisified(handle, methodName) {
 //    wrapper whose USER_PROTO is attached by the vfunc trampoline (collectVfuncs),
 //    so its own user-proto methods resolve; the post-construct `wrapInstance(handle,
 //    nt.prototype)` then upgrades the same cached wrapper in place (identity kept).
-//  - Multi-level registered subclassing (registering a subclass of a
-//    registerClass'd type) is not yet supported (G2) — the native engine resolves
-//    the parent by namespace+type, which a registered (non-introspected) parent has
-//    no entry for; findParentGType throws a clear error.
+//  - Multi-level registered subclassing (registering a subclass of a registerClass'd
+//    type, at any depth) IS supported (G2): findParentGType resolves a registered
+//    parent to its runtime GType handle and registerClass subclasses from it via
+//    native.registerClassFromGType. Inherited custom properties, signals and vfuncs
+//    of registered ANCESTORS compose for free through normal GObject inheritance
+//    (g_object_class_find_property / g_signal_lookup / the owner-type-keyed property
+//    store all walk the ancestry). A registered parent must be registered BEFORE the
+//    child's static{} runs — ES module evaluation order guarantees this.
 
 // GObject.ParamFlags — the GParamFlags bits the native property builder consumes.
 const ParamFlags = Object.freeze({
@@ -938,25 +953,34 @@ const ParamSpec = Object.freeze({
   boxed: paramSpecGTyped('boxed'),
 });
 
-// Walk up the JS class's prototype chain to the nearest node-gi base wrapper
-// (carrying `$gtypeName` as "Ns.Type") and split it into the parent namespace +
-// type the native engine subclasses. A dotless `$gtypeName` belongs to a
-// registerClass'd type (no namespace) — multi-level registered subclassing is
-// not yet supported (the native engine resolves the parent by namespace+type, so
-// a registered parent can't be looked up); throw a CLEAR error rather than the
-// generic "must extend a node-gi GObject class".
+// Walk up the JS class's prototype chain to the nearest node-gi base and describe
+// the parent the native engine subclasses from. Two shapes (nearest ancestor wins):
+//   - a REGISTERED ancestor (registerClass'd, present in registeredClasses) →
+//     `{ parentGTypeHandle }` (its runtime GType handle, from #667). The registered
+//     type has no introspection entry, so it must be subclassed from its GType
+//     directly (native.registerClassFromGType) — this is what unlocks multi-level
+//     registered-of-registered subclassing (G2).
+//   - an INTROSPECTED ancestor (a makeClass wrapper carrying a dotted `$gtypeName`
+//     like "Adw.Bin") → `{ parentNamespace, parentType }` (resolved by name).
+// A registered class carries BOTH a dotless `$gtypeName` AND a registeredClasses
+// entry, so the registry check MUST come first.
 function findParentGType(klass) {
   for (let c = Object.getPrototypeOf(klass); typeof c === 'function'; c = Object.getPrototypeOf(c)) {
+    const reg = registeredClasses.get(c);
+    if (reg !== undefined) {
+      return { parentGTypeHandle: reg.typeHandle };
+    }
     const gt = c.$gtypeName;
     if (typeof gt === 'string') {
       const dot = gt.indexOf('.');
       if (dot > 0) {
         return { parentNamespace: gt.slice(0, dot), parentType: gt.slice(dot + 1) };
       }
+      // A dotless `$gtypeName` with no registeredClasses entry should never occur
+      // (only registered types are dotless, and they are in the registry); be
+      // explicit rather than mis-resolving the namespace split.
       throw new TypeError(
-        "GObject.registerClass: multi-level registerClass subclassing is not yet supported (parent '" +
-          gt +
-          "' is a registered type, not an introspected one)",
+        "GObject.registerClass: parent '" + gt + "' has no resolvable GType",
       );
     }
   }
@@ -1106,12 +1130,14 @@ function registerClass(metaOrClass, maybeClass) {
   if (children.length > 0) options.children = children;
   if (internalChildren.length > 0) options.internalChildren = internalChildren;
 
-  const typeHandle = native.registerClass(
-    gtypeName,
-    parent.parentNamespace,
-    parent.parentType,
-    options,
-  );
+  // Branch on the parent shape (findParentGType): a REGISTERED parent is subclassed
+  // from its runtime GType handle (it has no introspection entry); an INTROSPECTED
+  // parent is resolved by namespace+type. Construction (the leaf's registered GType
+  // via the makeClass new.target routing) is already multi-level-correct either way.
+  const typeHandle =
+    parent.parentGTypeHandle !== undefined
+      ? native.registerClassFromGType(gtypeName, parent.parentGTypeHandle, options)
+      : native.registerClass(gtypeName, parent.parentNamespace, parent.parentType, options);
 
   // G3: register the GType for the GIVEN class IN PLACE (no throwaway Subclass) and
   // return that same class. `$gtypeName`/`$gtype` are defined as OWN properties:

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -167,6 +167,22 @@ export const newObject = native.newObject;
 export const registerClass = native.registerClass;
 
 /**
+ * Register a new GObject subclass of an ALREADY-REGISTERED parent type, given the
+ * parent's GType handle (from a previous {@link registerClass} / its `$gtype`)
+ * rather than a `namespace.typeName`. This is the multi-level registered-of-
+ * registered path: a registered (dynamic) parent has no introspection entry, so it
+ * cannot be resolved by name. Inherited custom properties, signals and vfunc slots
+ * of registered ancestors compose for free through normal GObject inheritance. The
+ * L1 `GObject.registerClass` picks this variant (over {@link registerClass}) when
+ * the nearest base is itself a registered class.
+ * @param {string} name unique GType name, e.g. "AdwStorybookClamp"
+ * @param {unknown} parentGType a GType handle from {@link registerClass} (the parent's `$gtype`)
+ * @param {{ properties?, signals?, vfuncs?, template?, cssName?, children?, internalChildren? }} [options]
+ * @returns {unknown} opaque type handle
+ */
+export const registerClassFromGType = native.registerClassFromGType;
+
+/**
  * Construct a GObject of a registered type handle (from {@link registerClass})
  * with optional construct/settable properties, returning an owned handle. For a
  * templated type the engine runs `gtk_widget_init_template` before returning.

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -3135,20 +3135,32 @@ static NodeGiClassData* FindClassData(GType type) {
   return nullptr;
 }
 
-// Find the vfunc override record named `name` nearest the instance type — the one
-// whose trampoline owns the vtable slot the override is running in. Walks the same
-// ancestry as FindClassData but stops at the first class-data carrying a matching
-// override, returning its captured parent pointer + signature for chain-up.
-static NodeGiVFunc* FindVFuncRecord(GType type, const std::string& name) {
+// Find the DEEPEST vfunc override record named `name` walking up from the instance
+// type — the registered level CLOSEST to the introspected base (the last matching
+// record before the ancestry runs out of node-gi class-data). This is the correct
+// chain-up target for `super.vfunc_<name>()` on a multi-level registered chain:
+// `super` between two REGISTERED levels resolves via the JS PROTOTYPE chain (the
+// ancestor's `vfunc_<name>` is a real JS method, called directly), so every
+// registered level's JS impl has already run by the time the chain bottoms out at
+// the introspected base's prototype and hits the chain-up thunk → callParentVfunc.
+// At that single point we must invoke the C-side default below the deepest
+// registered level — exactly the deepest record's captured `parentPtr` (its parent
+// is introspected, so the captured slot is the C vtable entry, never another JS
+// trampoline). Returning the NEAREST record instead would point parentPtr back at
+// an intermediate level's trampoline and re-run that level (a double-run, or an
+// infinite loop when it chains up again). Single-level chains have exactly one
+// record, so deepest == nearest and behaviour is unchanged.
+static NodeGiVFunc* FindDeepestVFuncRecord(GType type, const std::string& name) {
+  NodeGiVFunc* deepest = nullptr;
   for (GType t = type; t != 0; t = g_type_parent(t)) {
     NodeGiClassData* cd = static_cast<NodeGiClassData*>(g_type_get_qdata(t, NodeGiClassDataQuark()));
     if (cd != nullptr) {
       for (NodeGiVFunc* vf : cd->vfuncs) {
-        if (vf->name == name) return vf;
+        if (vf->name == name) deepest = vf;  // keep the last (deepest) match
       }
     }
   }
-  return nullptr;
+  return deepest;
 }
 
 // Instantiate the Gtk.Widget template on a freshly-constructed instance (see the
@@ -3377,10 +3389,17 @@ static void NodeGiClassInit(gpointer g_class, gpointer class_data) {
 // also forecloses the IN-indexing mismatch (the JS caller passes IN values
 // positionally, while declared indices interleave OUT params). The dominant
 // chain-up cases (constructed/dispose/activate; IN object/primitive args) are
-// covered. FindVFuncRecord walks from the instance type up to the nearest matching
-// override, so on a multi-level registered chain (G2) parentPtr resolves to the
-// next implementation up — the parent's JS trampoline when an ancestor also
-// overrode the vfunc, or the C default otherwise.
+// covered.
+//
+// MULTI-LEVEL chain-up (registered chains, G2): chains to the DEEPEST registered
+// override's captured parent (the C-side default below the whole registered chain),
+// NOT the nearest. On a multi-level chain the level-to-level `super.vfunc_<name>()`
+// hops are resolved by the JS PROTOTYPE chain (each registered ancestor's
+// `vfunc_<name>` is a real JS method, invoked directly), so every level's JS impl
+// has already run by the time the chain bottoms out at the introspected base's
+// prototype and reaches this thunk — at which point the only thing left to call is
+// the C default. Using the nearest record would re-enter an intermediate level's
+// trampoline (a double-run / infinite loop). See FindDeepestVFuncRecord.
 Napi::Value CallParentVfunc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 2 || !info[1].IsString()) {
@@ -3394,7 +3413,7 @@ Napi::Value CallParentVfunc(const Napi::CallbackInfo& info) {
   Napi::Array args = (info.Length() >= 3 && info[2].IsArray()) ? info[2].As<Napi::Array>()
                                                               : Napi::Array::New(env, 0);
 
-  NodeGiVFunc* vf = FindVFuncRecord(G_OBJECT_TYPE(obj), vname);
+  NodeGiVFunc* vf = FindDeepestVFuncRecord(G_OBJECT_TYPE(obj), vname);
   if (vf == nullptr || vf->parentPtr == nullptr || vf->info == nullptr) {
     Napi::Error::New(env, "no parent vfunc '" + vname + "' to chain up to on " +
                               g_type_name(G_OBJECT_TYPE(obj)) +

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -3377,10 +3377,10 @@ static void NodeGiClassInit(gpointer g_class, gpointer class_data) {
 // also forecloses the IN-indexing mismatch (the JS caller passes IN values
 // positionally, while declared indices interleave OUT params). The dominant
 // chain-up cases (constructed/dispose/activate; IN object/primitive args) are
-// covered. Multi-level JS-override chains are gated out at the L1 registerClass
-// layer (multi-level registered subclassing is unsupported), so they do not reach
-// here; were they enabled, parentPtr would correctly resolve to the next JS
-// trampoline up the chain.
+// covered. FindVFuncRecord walks from the instance type up to the nearest matching
+// override, so on a multi-level registered chain (G2) parentPtr resolves to the
+// next implementation up — the parent's JS trampoline when an ancestor also
+// overrode the vfunc, or the C default otherwise.
 Napi::Value CallParentVfunc(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 2 || !info[1].IsString()) {
@@ -3485,38 +3485,27 @@ Napi::Value CallParentVfunc(const Napi::CallbackInfo& info) {
   return result;
 }
 
-// registerClass(name, parentNamespace, parentTypeName, options?) -> typeHandle
-Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
-  Napi::Env env = info.Env();
-  if (info.Length() < 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsString()) {
-    Napi::TypeError::New(
-        env,
-        "registerClass(name: string, parentNamespace: string, parentTypeName: string, options?: "
-        "{ properties?, signals?, vfuncs? })")
-        .ThrowAsJavaScriptException();
-    return env.Null();
-  }
-  std::string name = info[0].As<Napi::String>().Utf8Value();
-  std::string pns = info[1].As<Napi::String>().Utf8Value();
-  std::string ptn = info[2].As<Napi::String>().Utf8Value();
-
+// Shared registration core: subclass `name` from an ALREADY-RESOLVED parent GObject
+// GType, reading the optional { properties, signals, vfuncs, template, children, ... }
+// from `optsValue` (a non-object → no options). Returns the tagged GType handle for
+// the new type, or throws + returns env.Null(). Both entry points use it:
+//   - RegisterClass        — parent resolved from introspection (namespace+typename),
+//   - RegisterClassFromGType — parent given directly as a #667 GType handle (the
+//     multi-level registered-of-registered path; the parent has no GIR entry).
+// Everything past parent resolution is identical: g_type_register_static makes the
+// child class struct a memcpy of the parent's, so a registered ancestor's installed
+// properties/signals/vfunc slots compose for free via normal GObject inheritance.
+static Napi::Value RegisterClassImpl(Napi::Env env, const std::string& name, GType parentType,
+                                     Napi::Value optsValue) {
   if (g_type_from_name(name.c_str()) != 0) {
     Napi::Error::New(env, "a GType named '" + name + "' is already registered")
         .ThrowAsJavaScriptException();
     return env.Null();
   }
-
-  // Resolve the parent GType from its introspection info.
-  GIRepository* repo = DupDefaultRepository();
-  GIBaseInfo* base = gi_repository_find_by_name(repo, pns.c_str(), ptn.c_str());
-  bool isObject = base != nullptr && GI_IS_OBJECT_INFO(base);
-  GType parentType =
-      isObject ? gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(base))
-               : G_TYPE_INVALID;
-  if (base != nullptr) gi_base_info_unref(base);
-  g_object_unref(repo);
-  if (!isObject || !G_TYPE_IS_OBJECT(parentType)) {
-    Napi::TypeError::New(env, pns + "." + ptn + " is not a subclassable GObject type")
+  if (!G_TYPE_IS_OBJECT(parentType)) {
+    const char* pn = g_type_name(parentType);
+    Napi::TypeError::New(env, std::string(pn != nullptr ? pn : "the parent type") +
+                                  " is not a subclassable GObject type")
         .ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -3524,7 +3513,8 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
   GTypeQuery query;
   g_type_query(parentType, &query);
   if (query.type == 0) {
-    Napi::Error::New(env, "failed to query parent type " + pns + "." + ptn)
+    const char* pn = g_type_name(parentType);
+    Napi::Error::New(env, std::string("failed to query parent type ") + (pn != nullptr ? pn : "?"))
         .ThrowAsJavaScriptException();
     return env.Null();
   }
@@ -3533,8 +3523,8 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
   NodeGiClassData* cd = new NodeGiClassData();
   cd->parentGet = nullptr;
   cd->parentSet = nullptr;
-  if (info.Length() >= 4 && info[3].IsObject()) {
-    Napi::Object opts = info[3].As<Napi::Object>();
+  if (optsValue.IsObject()) {
+    Napi::Object opts = optsValue.As<Napi::Object>();
     if (opts.Has("properties") && opts.Get("properties").IsArray()) {
       Napi::Array props = opts.Get("properties").As<Napi::Array>();
       for (uint32_t i = 0; i < props.Length(); i++) {
@@ -3671,6 +3661,66 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
   // `$gtype` (G4): the same External feeds constructType (UnwrapGType) AND the
   // GType marshalling (GObject.type_ensure, g_param_spec_object's value gtype, …).
   return MakeGTypeHandle(env, newType);
+}
+
+// registerClass(name, parentNamespace, parentTypeName, options?) -> typeHandle
+//
+// Subclass an INTROSPECTED parent, resolved by namespace + typename. Used when the
+// parent class extends a `gi://`-introspected GObject (e.g. `class X extends Adw.Bin`).
+Napi::Value RegisterClass(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 3 || !info[0].IsString() || !info[1].IsString() || !info[2].IsString()) {
+    Napi::TypeError::New(
+        env,
+        "registerClass(name: string, parentNamespace: string, parentTypeName: string, options?: "
+        "{ properties?, signals?, vfuncs? })")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string name = info[0].As<Napi::String>().Utf8Value();
+  std::string pns = info[1].As<Napi::String>().Utf8Value();
+  std::string ptn = info[2].As<Napi::String>().Utf8Value();
+
+  // Resolve the parent GType from its introspection info.
+  GIRepository* repo = DupDefaultRepository();
+  GIBaseInfo* base = gi_repository_find_by_name(repo, pns.c_str(), ptn.c_str());
+  bool isObject = base != nullptr && GI_IS_OBJECT_INFO(base);
+  GType parentType =
+      isObject ? gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(base))
+               : G_TYPE_INVALID;
+  if (base != nullptr) gi_base_info_unref(base);
+  g_object_unref(repo);
+  if (!isObject || !G_TYPE_IS_OBJECT(parentType)) {
+    Napi::TypeError::New(env, pns + "." + ptn + " is not a subclassable GObject type")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  return RegisterClassImpl(env, name, parentType, info.Length() >= 4 ? info[3] : env.Undefined());
+}
+
+// registerClassFromGType(name, parentGType, options?) -> typeHandle
+//
+// Multi-level registered subclassing (G2): subclass directly from a parent GType
+// HANDLE (the #667 kGTypeHandleTag External a previous registerClass returned),
+// instead of resolving the parent through introspection. The parent is itself a
+// registered (dynamic) type with no GIR entry, so the namespace+typename path
+// (RegisterClass) cannot find it; the L1 layer (findParentGType) passes the parent's
+// `$gtype` handle here. The shared core (RegisterClassImpl) then subclasses from the
+// resolved GType identically, so a registered ancestor's properties/signals/vfunc
+// slots compose for free via GObject inheritance.
+Napi::Value RegisterClassFromGType(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2 || !info[0].IsString()) {
+    Napi::TypeError::New(
+        env, "registerClassFromGType(name: string, parentGType: handle, options?: object)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  std::string name = info[0].As<Napi::String>().Utf8Value();
+  GType parentType = UnwrapGType(env, info[1]);  // throws (returns 0) on a non-GType arg
+  if (parentType == 0) return env.Null();
+  return RegisterClassImpl(env, name, parentType, info.Length() >= 3 ? info[2] : env.Undefined());
 }
 
 // constructType(typeHandle, props?: Record<string, unknown>) -> External<GObject>
@@ -5256,6 +5306,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("callStaticMethod", Napi::Function::New(env, CallStaticMethod));
   exports.Set("newObject", Napi::Function::New(env, NewObject));
   exports.Set("registerClass", Napi::Function::New(env, RegisterClass));
+  exports.Set("registerClassFromGType", Napi::Function::New(env, RegisterClassFromGType));
   exports.Set("constructType", Napi::Function::New(env, ConstructType));
   exports.Set("callParentVfunc", Napi::Function::New(env, CallParentVfunc));
   exports.Set("getTemplateChild", Napi::Function::New(env, GetTemplateChild));

--- a/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
+++ b/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+// G2 — multi-level registered subclassing (registered-subclass-of-registered).
+//
+// `GObject.registerClass` can register a subclass whose parent is ITSELF a
+// registered (dynamic) type, at any depth. The registered parent has no
+// introspection entry, so findParentGType resolves it to the parent's runtime
+// GType handle (#667 / its `$gtype`) and registerClass subclasses from it via the
+// native `registerClassFromGType` variant (a thin wrapper around the shared
+// g_type_register_static core). Construction is already multi-level-correct: the
+// makeClass `new.target` routing keys on the LEAF class, whose registered GType is
+// the full multi-level type.
+//
+// The key property of G2 is that an ANCESTOR's custom properties, signals and
+// vfunc overrides compose for free on a leaf instance through normal GObject
+// inheritance — g_object_class_find_property / g_signal_lookup walk the ancestry,
+// and NodeGiGet/SetProperty key on the pspec's owner-type class-data + a per-
+// instance store, so an inherited custom prop reads/writes the right slot even
+// when accessed on a deeper subclass instance.
+//
+// GTypes are process-global + permanent, so every test registers uniquely-named
+// types. Reference: scratchpad/storybook-objectmodel-design.md §G2;
+// refs/gjs/modules/core/overrides/GObject.js.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+const RW = GObject.ParamFlags.READWRITE;
+
+test('2-level registered chain: an ancestor and the leaf both compose props + signals', () => {
+  class MlA extends GObject.Object {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiMlA',
+          Properties: {
+            'a-prop': GObject.ParamSpec.string('a-prop', 'A prop', 'declared on A', RW, 'a-default'),
+          },
+          Signals: { 'a-signal': { param_types: ['int'] } },
+        },
+        MlA,
+      );
+    }
+    aMethod() {
+      return `A:${this.a_prop}`;
+    }
+  }
+
+  class MlB extends MlA {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiMlB',
+          Properties: {
+            'b-prop': GObject.ParamSpec.int('b-prop', 'B prop', 'declared on B', RW, 0, 100, 7),
+          },
+          Signals: { 'b-signal': {} },
+        },
+        MlB,
+      );
+    }
+    bMethod() {
+      return `B:${this.b_prop}`;
+    }
+  }
+
+  // Both levels carry their own GType identity.
+  assert.equal(GObject.type_name(MlA.$gtype), 'NodeGiMlA');
+  assert.equal(GObject.type_name(MlB.$gtype), 'NodeGiMlB');
+
+  const b = new MlB();
+  // `new B()` is B's GType (the leaf), and B is-a the introspected root.
+  assert.equal(native.getTypeName(unwrap(b)), 'NodeGiMlB');
+  assert.equal(native.isInstanceOf(unwrap(b), 'GObject', 'Object'), true);
+
+  // An INHERITED custom property (declared on A) reads its default + is writable on a
+  // B instance — the owner-type-keyed per-instance store routes it correctly.
+  assert.equal(b.a_prop, 'a-default');
+  b.a_prop = 'set-on-b';
+  assert.equal(b.a_prop, 'set-on-b');
+  assert.equal(b.aMethod(), 'A:set-on-b');
+
+  // B's OWN property works alongside the inherited one.
+  assert.equal(b.b_prop, 7);
+  b.b_prop = 42;
+  assert.equal(b.b_prop, 42);
+  assert.equal(b.bMethod(), 'B:42');
+
+  // An A-signal connects + emits on a B instance (signals walk the ancestry).
+  let aReceived = null;
+  const aId = b.connect('a-signal', (n) => {
+    aReceived = n;
+  });
+  b.emit('a-signal', 5);
+  assert.equal(aReceived, 5);
+  b.disconnect(aId);
+
+  // A B-signal too.
+  let bFired = 0;
+  b.connect('b-signal', () => {
+    bFired += 1;
+  });
+  b.emit('b-signal');
+  assert.equal(bFired, 1);
+});
+
+test('2-level chain: an ancestor vfunc override fires when the leaf is constructed', () => {
+  let constructedCount = 0;
+  class MlVA extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlVA' }, MlVA);
+    }
+    vfunc_constructed() {
+      constructedCount += 1;
+    }
+  }
+  class MlVB extends MlVA {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlVB' }, MlVB);
+    }
+  }
+
+  const b = new MlVB();
+  assert.equal(native.getTypeName(unwrap(b)), 'NodeGiMlVB');
+  // The ancestor's vfunc_constructed fired exactly once during the leaf's
+  // construction (the vfunc slot composes through GObject inheritance).
+  assert.equal(constructedCount, 1);
+});
+
+test('3-level registered chain (storybook shape) constructs + composes every ancestor', () => {
+  // Base extends an INTROSPECTED GObject (the storybook uses Adw.Bin; GObject.Object
+  // keeps this on the headless gate). Mid extends the registered Base, Leaf extends
+  // the registered Mid — three registered levels over one introspected root.
+  class MlBase extends GObject.Object {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiMl3Base',
+          Properties: { 'base-prop': GObject.ParamSpec.string('base-prop', '', '', RW, 'base') },
+          Signals: { 'base-signal': {} },
+        },
+        MlBase,
+      );
+    }
+    baseTag() {
+      return `base:${this.base_prop}`;
+    }
+  }
+  class MlMid extends MlBase {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiMl3Mid',
+          Properties: { 'mid-prop': GObject.ParamSpec.string('mid-prop', '', '', RW, 'mid') },
+        },
+        MlMid,
+      );
+    }
+    midTag() {
+      return `mid:${this.mid_prop}`;
+    }
+  }
+  class MlLeaf extends MlMid {
+    static {
+      GObject.registerClass(
+        {
+          GTypeName: 'NodeGiMl3Leaf',
+          Properties: { 'leaf-prop': GObject.ParamSpec.int('leaf-prop', '', '', RW, 0, 9, 3) },
+        },
+        MlLeaf,
+      );
+    }
+    leafTag() {
+      return `leaf:${this.leaf_prop}`;
+    }
+  }
+
+  // Construct props span every level; the leaf builds the deepest GType.
+  const leaf = new MlLeaf({ 'base-prop': 'B', 'mid-prop': 'M', 'leaf-prop': 5 });
+  assert.equal(native.getTypeName(unwrap(leaf)), 'NodeGiMl3Leaf');
+  assert.equal(leaf.base_prop, 'B');
+  assert.equal(leaf.mid_prop, 'M');
+  assert.equal(leaf.leaf_prop, 5);
+
+  // Each ancestor's prototype method resolves on the leaf instance.
+  assert.equal(leaf.baseTag(), 'base:B');
+  assert.equal(leaf.midTag(), 'mid:M');
+  assert.equal(leaf.leafTag(), 'leaf:5');
+
+  // A signal declared two levels up (Base) fires on a Leaf instance.
+  let fired = 0;
+  leaf.connect('base-signal', () => {
+    fired += 1;
+  });
+  leaf.emit('base-signal');
+  assert.equal(fired, 1);
+
+  // A default ancestor prop is readable without being passed at construction.
+  const leaf2 = new MlLeaf();
+  assert.equal(leaf2.base_prop, 'base');
+  assert.equal(leaf2.mid_prop, 'mid');
+  assert.equal(leaf2.leaf_prop, 3);
+});
+
+test('an unregistered leaf subclass throws the clear "not registered" error', () => {
+  // A subclass of an INTROSPECTED GObject class that was NEVER passed to
+  // registerClass must not silently build the introspected base type.
+  class UnregLeaf extends Gio.SimpleAction {}
+  assert.throws(
+    () => new UnregLeaf(),
+    /Object UnregLeaf is not registered with GObject\.registerClass\(\)/,
+  );
+
+  // Same for an unregistered subclass of a REGISTERED class.
+  class MlRegBase extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlRegBase' }, MlRegBase);
+    }
+  }
+  class UnregOfRegistered extends MlRegBase {}
+  assert.throws(
+    () => new UnregOfRegistered(),
+    /Object UnregOfRegistered is not registered with GObject\.registerClass\(\)/,
+  );
+
+  // The registered base itself still constructs fine (sanity).
+  assert.equal(native.getTypeName(unwrap(new MlRegBase())), 'NodeGiMlRegBase');
+});

--- a/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
+++ b/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
@@ -130,6 +130,139 @@ test('2-level chain: an ancestor vfunc override fires when the leaf is construct
   assert.equal(constructedCount, 1);
 });
 
+test('2-level chain: each level overrides vfunc_constructed + super, runs once in order', () => {
+  // The canonical multi-level idiom (the storybook's StoryWidget shape): BOTH levels
+  // override the same vfunc and chain up with super.vfunc_*(). Each level's override
+  // must run EXACTLY ONCE, leaf-first, nesting through the ancestor to the C default
+  // — NO infinite loop (the regression this guards) and NO double-run.
+  const order = [];
+  class MlSuperA extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlSuperA' }, MlSuperA);
+    }
+    vfunc_constructed() {
+      order.push('A-before');
+      super.vfunc_constructed(); // chains to the C base (GObject's constructed)
+      order.push('A-after');
+    }
+  }
+  class MlSuperB extends MlSuperA {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlSuperB' }, MlSuperB);
+    }
+    vfunc_constructed() {
+      order.push('B-before');
+      super.vfunc_constructed(); // chains to A's vfunc_constructed
+      order.push('B-after');
+    }
+  }
+
+  const b = new MlSuperB();
+  assert.equal(native.getTypeName(unwrap(b)), 'NodeGiMlSuperB');
+  // Leaf runs first, supers into the ancestor, the ancestor supers into the C base,
+  // then each unwinds — each override body executed exactly once.
+  assert.deepEqual(order, ['B-before', 'A-before', 'A-after', 'B-after']);
+});
+
+test('3-level chain: vfunc_constructed chains up through every level once, in order', () => {
+  const order = [];
+  class MlSc3Base extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlSc3Base' }, MlSc3Base);
+    }
+    vfunc_constructed() {
+      order.push('Base<');
+      super.vfunc_constructed();
+      order.push('Base>');
+    }
+  }
+  class MlSc3Mid extends MlSc3Base {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlSc3Mid' }, MlSc3Mid);
+    }
+    vfunc_constructed() {
+      order.push('Mid<');
+      super.vfunc_constructed();
+      order.push('Mid>');
+    }
+  }
+  class MlSc3Leaf extends MlSc3Mid {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlSc3Leaf' }, MlSc3Leaf);
+    }
+    vfunc_constructed() {
+      order.push('Leaf<');
+      super.vfunc_constructed();
+      order.push('Leaf>');
+    }
+  }
+
+  const leaf = new MlSc3Leaf();
+  assert.equal(native.getTypeName(unwrap(leaf)), 'NodeGiMlSc3Leaf');
+  assert.deepEqual(order, ['Leaf<', 'Mid<', 'Base<', 'Base>', 'Mid>', 'Leaf>']);
+});
+
+test('2-level chain: vfunc_dispose chains up in order (run_dispose), no loop', () => {
+  const order = [];
+  class MlDispA extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlDispA' }, MlDispA);
+    }
+    vfunc_dispose() {
+      order.push('A-dispose');
+      super.vfunc_dispose(); // chains to the C base dispose
+    }
+  }
+  class MlDispB extends MlDispA {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlDispB' }, MlDispB);
+    }
+    vfunc_dispose() {
+      order.push('B-dispose');
+      super.vfunc_dispose(); // chains to A's dispose
+    }
+  }
+
+  const b = new MlDispB();
+  b.run_dispose(); // synchronously fires the dispose vtable chain
+  // Leaf dispose first, then the ancestor's, then the C base — each once, no loop.
+  assert.deepEqual(order, ['B-dispose', 'A-dispose']);
+});
+
+test('a leaf that does NOT override a vfunc still resolves its OWN methods', () => {
+  // When only an ANCESTOR overrides a vfunc, the leaf has no record of its own and
+  // inherits the ancestor's trampoline, which fires during constructType BEFORE the
+  // leaf ctor attaches the leaf prototype. The wrapper's user prototype must still be
+  // UPGRADED to the leaf's, so the leaf's own methods resolve (a regression the
+  // multi-level vfunc work could otherwise introduce).
+  class MlProtoBase extends GObject.Object {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlProtoBase' }, MlProtoBase);
+    }
+    vfunc_constructed() {
+      super.vfunc_constructed();
+      this._builtByBase = true;
+    }
+    baseOnly() {
+      return 'base';
+    }
+  }
+  class MlProtoLeaf extends MlProtoBase {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiMlProtoLeaf' }, MlProtoLeaf);
+    }
+    leafOnly() {
+      return `leaf+${this.baseOnly()}`;
+    }
+  }
+
+  const leaf = new MlProtoLeaf();
+  assert.equal(native.getTypeName(unwrap(leaf)), 'NodeGiMlProtoLeaf');
+  assert.equal(leaf._builtByBase, true, 'the ancestor vfunc_constructed ran');
+  assert.equal(leaf.baseOnly(), 'base', "the ancestor's own method resolves");
+  assert.equal(leaf.leafOnly(), 'leaf+base', "the LEAF's own method resolves (proto upgraded)");
+});
+
 test('3-level registered chain (storybook shape) constructs + composes every ancestor', () => {
   // Base extends an INTROSPECTED GObject (the storybook uses Adw.Bin; GObject.Object
   // keeps this on the headless gate). Mid extends the registered Base, Leaf extends

--- a/packages/node-gi/node-gi/test/register-class-decorator.test.mjs
+++ b/packages/node-gi/node-gi/test/register-class-decorator.test.mjs
@@ -15,6 +15,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
 
 const GObject = requireGi('GObject', '2.0');
 
@@ -311,12 +312,16 @@ test('a GObject property set inside a vfunc is visible on the instance', () => {
   assert.equal(s.state, 'ready');
 });
 
-test('error: multi-level registered subclassing is rejected clearly', () => {
+test('multi-level registered subclassing is supported (G2)', () => {
   const Base = GObject.registerClass(
     class NodeGiDecoratorMultiBase extends GObject.Object {},
   );
-  assert.throws(
-    () => GObject.registerClass(class NodeGiDecoratorMultiChild extends Base {}),
-    /multi-level registerClass subclassing is not yet supported/,
-  );
+  // Registering a subclass of a REGISTERED class now succeeds (decorator form): it
+  // subclasses from the base's runtime GType handle.
+  const Child = GObject.registerClass(class NodeGiDecoratorMultiChild extends Base {});
+  assert.notEqual(Child.$gtype, undefined);
+  assert.equal(GObject.type_name(Child.$gtype), 'NodeGiDecoratorMultiChild');
+  // `new Child()` constructs the leaf GType.
+  const obj = new Child();
+  assert.equal(native.getTypeName(unwrap(obj)), 'NodeGiDecoratorMultiChild');
 });

--- a/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
+++ b/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
@@ -13,7 +13,8 @@
 //   - chains construct props through `super(args)`,
 //   - keeps ONE canonical wrapper identity (=== across the ctor `this`, the
 //     constructed instance, and a vfunc `this`).
-// A 2-level JS hierarchy where BOTH levels are registered is still rejected (G2).
+// A 2-level JS hierarchy where BOTH levels are registered now registers + constructs
+// (G2); see test/multilevel-subclass.test.mjs for ancestor member composition.
 //
 // GTypes are process-global + permanent, so every test registers a uniquely-named
 // type. Reference: refs/gjs/modules/core/overrides/GObject.js (registerClass
@@ -160,7 +161,7 @@ test('toggle-ref identity: ctor `this`, vfunc `this`, and the instance are all =
   assert.equal(obj.marker, 'M');
 });
 
-test('a 2-level registered hierarchy is still rejected (G2 guard)', () => {
+test('a 2-level registered hierarchy registers + constructs (G2)', () => {
   class InPlaceMultiBase extends GObject.Object {
     static {
       GObject.registerClass({ GTypeName: 'NodeGiInPlaceMultiBase' }, InPlaceMultiBase);
@@ -169,16 +170,19 @@ test('a 2-level registered hierarchy is still rejected (G2 guard)', () => {
   // The base registered fine (single-level over an introspected parent).
   assert.equal(GObject.type_name(InPlaceMultiBase.$gtype), 'NodeGiInPlaceMultiBase');
 
-  // Registering a subclass of a REGISTERED class is G2 — the static block runs at
-  // class-definition time and must throw the clear multi-level guard error.
-  assert.throws(() => {
-    class InPlaceMultiChild extends InPlaceMultiBase {
-      static {
-        GObject.registerClass({ GTypeName: 'NodeGiInPlaceMultiChild' }, InPlaceMultiChild);
-      }
+  // Registering a subclass of a REGISTERED class is now supported (G2): the static
+  // block runs at class-definition time and registers the child's GType, subclassing
+  // from the registered base's runtime GType handle.
+  class InPlaceMultiChild extends InPlaceMultiBase {
+    static {
+      GObject.registerClass({ GTypeName: 'NodeGiInPlaceMultiChild' }, InPlaceMultiChild);
     }
-    return InPlaceMultiChild;
-  }, /multi-level registerClass subclassing is not yet supported/);
+  }
+  assert.equal(GObject.type_name(InPlaceMultiChild.$gtype), 'NodeGiInPlaceMultiChild');
+
+  // `new Child()` builds the CHILD's GType (the leaf), not the base's.
+  const obj = new InPlaceMultiChild();
+  assert.equal(native.getTypeName(unwrap(obj)), 'NodeGiInPlaceMultiChild');
 });
 
 test('#667: a raw (unregistered) subclass does not inherit the parent GType', () => {


### PR DESCRIPTION
Register a GObject subclass whose parent is itself a `registerClass`'d type, at any depth (G2) — the storybook's `ClampStory extends StoryWidget extends Adw.Bin` shape. Construction was already multi-level-correct (the G3 `new.target` routing keys on the leaf's registered GType); this is the registration side.

## What changed

- **`findParentGType` (gi.js):** when the nearest base is a REGISTERED class (present in `registeredClasses`), resolve it to that class's runtime GType handle instead of throwing. The registry is consulted before the dotless-`$gtypeName` check (a registered class carries both); an introspected ancestor keeps the namespace+typename path.
- **`registerClass` (gi.js):** branches to a new native `registerClassFromGType(name, parentGTypeHandle, options)` for a registered parent; keeps `registerClass(name, ns, type, options)` for an introspected parent.
- **`addon.cc`:** factor the type-registration core out of `RegisterClass` into a shared `RegisterClassImpl(env, name, parentType, opts)`. `RegisterClass` resolves the parent from introspection; the new `RegisterClassFromGType` reads the #667 `kGTypeHandleTag` handle via `UnwrapGType`. `g_type_register_static` from the given parent is identical, so a registered ancestor's properties, signals and vfunc slots compose for free via normal GObject inheritance (`g_object_class_find_property` / `g_signal_lookup` / the owner-type-keyed per-instance property store all walk the ancestry). Exported in `Init`, re-exported from `index.js`.

## Folded-in #668-review minors

- **Unregistered-leaf throw (gi.js makeClass):** a GObject subclass never passed to `registerClass` now throws `Object <name> is not registered with GObject.registerClass()` instead of silently building the introspected base type (routes on `new.target !==` the introspected proxy) — the L1 analogue of GJS's construct guard.
- **Stale doc (example/src/app.ts):** the JS constructor body now runs under node-gi (G3); caveat refreshed.

## Tests

- New `test/multilevel-subclass.test.mjs`: 2-level chain (inherited A-prop set/get + A-signal emit + a B-prop on a B instance; an ancestor `vfunc_constructed` fires for the leaf), 3-level storybook-shape chain (construct props + prototype methods + an ancestor signal compose; leaf builds the deepest GType), and the unregistered-leaf throw.
- The two prior multi-level-rejection tests (`registerclass-inplace`, `register-class-decorator`) are updated to assert success.

Local: `node --test` 219 pass / 0 fail / 11 skipped, `npm run test:gc` 230/230, GTK + Adw + template tests 5/5 under Wayland.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH