### PR TITLE
add Gio.Application.runAsync to node-gi

### DIFF
--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -432,6 +432,45 @@ function assignTemplateChildren(instance, handle, reg) {
   }
 }
 
+// ---- Gio.Application.runAsync (L1, GJS-shaped) ----
+//
+// The Node twin of GJS's `Gio.Application.prototype.runAsync`
+// (refs/gjs/modules/core/overrides/Gio.js → `GLib.MainLoop.prototype.runAsync`
+// in GLib.js). GJS returns a Promise and defers the blocking run() via
+// `setMainLoopHook`, so the program's already-queued microtasks/promises settle
+// before the GLib loop takes over the thread, then resolves with run()'s integer
+// exit status when the app quits/exits.
+//
+// On Node there is no main-loop hook — libuv is always the process loop and the
+// libuv↔GLib bridge (addon.cc UvLoopSource, attached to the DEFAULT GMainContext
+// that g_application_run iterates) co-pumps libuv during a blocking run(). The
+// faithful analogue is therefore to defer the blocking run() to a MACROTASK
+// (setImmediate). This:
+//   • returns the Promise immediately — runAsync does NOT block the caller the
+//     way a bare `app.run()` would,
+//   • lets the caller's already-queued microtasks/promises drain first, and
+//   • runs run() OUTSIDE the caller's async/await scope, so the node-gtk
+//     #442/#121 nested-microtask-checkpoint caveat (see mainloop.test.mjs) does
+//     NOT bite: promise continuations queued before runAsync drain normally WHILE
+//     the app runs, because the bridge's microtask checkpoint is no longer
+//     deferred to an outer await frame.
+//
+// Mirrors GJS exactly in that the `argv` argument is ignored (GJS's runAsync
+// takes no parameters and calls `this.run()` with an empty command-line) — so an
+// `app.runAsync([programInvocationName, ...ARGV])` source behaves identically on
+// gjs and node. Resolves once; run() is invoked once (no double-run / leak).
+function applicationRunAsync(handle) {
+  return new Promise((resolve, reject) => {
+    setImmediate(() => {
+      try {
+        resolve(wrapReturn(native.callMethod(handle, 'run', unwrapArgs([[]]))));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
 // Wrap a live GObject handle as a GJS-shaped instance. When `userProto` is given
 // (a registerClass subclass's prototype) the wrapper resolves the user class's
 // own prototype members FIRST — so `inst.myMethod()` runs the JS method with the
@@ -484,6 +523,15 @@ function wrapInstance(handle, userProto) {
           if (typeof desc.get === 'function') return desc.get.call(proxy);
           return desc.value;
         }
+      }
+      // Gio.Application.runAsync — the GJS override (refs/gjs Gio.js + GLib.js):
+      // a Promise-returning run() that does NOT block the Node microtask/event
+      // loop (see applicationRunAsync). Gated to GApplication instances
+      // (g_type_is_a, so Gtk/Adw.Application and registerClass subclasses qualify);
+      // placed AFTER the userProto lookup so a subclass may still override it, and
+      // before the GI-method fallback since there is no introspected `run_async`.
+      if (prop === 'runAsync' && native.isInstanceOf(handle, 'Gio', 'Application')) {
+        return () => applicationRunAsync(handle);
       }
       const propName = toKebab(prop);
       if (native.hasProperty(handle, propName)) {

--- a/packages/node-gi/node-gi/test/runasync.test.mjs
+++ b/packages/node-gi/node-gi/test/runasync.test.mjs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gio.Application.runAsync test (G5).
+//
+// Proves the GJS `Gio.Application.prototype.runAsync` override
+// (refs/gjs/modules/core/overrides/Gio.js → `GLib.MainLoop.prototype.runAsync`
+// in GLib.js) works UNCHANGED on Node: `await app.runAsync([...])` runs the app
+// and resolves with the integer exit status when it quits, WITHOUT blocking the
+// Node microtask/event loop the way a bare blocking `app.run()` would.
+//
+// HOW IT WORKS: GJS defers the blocking run() via `setMainLoopHook`; on Node the
+// faithful analogue is to defer it to a MACROTASK (setImmediate). runAsync returns
+// the Promise immediately, the caller's already-queued microtasks/promises drain
+// first, and run() executes OUTSIDE the caller's async/await scope — so the
+// node-gtk #442/#121 nested-microtask-checkpoint caveat (see mainloop.test.mjs)
+// does NOT bite: a Promise continuation queued before runAsync drains WHILE the
+// app runs. The libuv↔GLib bridge co-pumps Node timers/promises/I/O for the
+// lifetime of the run (it attaches its GSource to the DEFAULT GMainContext, which
+// g_application_run iterates).
+//
+// HEADLESS: a plain `Gio.Application` (NON_UNIQUE) needs no display, so these run
+// in the fast `node --test` / `test:gc` gate. Mirrors GJS: the `argv` argument is
+// ignored (GJS's runAsync calls `this.run()` with an empty command-line), so an
+// `app.runAsync([programInvocationName, ...ARGV])` source behaves identically on
+// gjs and node.
+//
+// Reference: refs/gjs (Gio.js/GLib.js runAsync), refs/node-gtk src/loop.cc
+// (romgrk and contributors, MIT).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+// GLib/Gio are node-gi's core target libs (always present on the CI host); the
+// try/catch only guards a degenerate headless dev box with no typelibs at all.
+let GLib;
+let Gio;
+let loadError = null;
+try {
+  GLib = requireGi('GLib', '2.0');
+  Gio = requireGi('Gio', '2.0');
+} catch (err) {
+  loadError = err;
+}
+const skip = loadError ? `GLib/Gio typelib unavailable: ${loadError.message}` : false;
+
+// A fresh NON_UNIQUE application per test (unique id → no session-bus collisions).
+let idCounter = 0;
+function makeApp() {
+  return new Gio.Application({
+    application_id: `eu.jumplink.NodeGiRunAsync${idCounter++}`,
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+}
+
+test('runAsync returns a Promise that resolves with the exit status', { skip }, async () => {
+  const app = makeApp();
+  let activated = false;
+  app.connect('activate', () => {
+    activated = true;
+    app.hold(); // keep g_application_run iterating until the timeout quits it
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+      app.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+  });
+
+  const pending = app.runAsync([]);
+  assert.equal(typeof pending.then, 'function', 'runAsync returns a Promise (does not block)');
+
+  const status = await pending;
+  assert.equal(status, 0, 'resolves with the integer exit status (0)');
+  assert.equal(activated, true, 'the activate handler ran during the run');
+});
+
+test('runAsync keeps the Node event loop pumped while the app runs', { skip }, async () => {
+  const app = makeApp();
+  let appQuit = false;
+  let timerFiredDuringRun = false;
+  let promiseSettledDuringRun = false;
+
+  // Scheduled BEFORE runAsync — both must run WHILE the app is running (before the
+  // 150ms GLib timeout quits it). If the blocking run() starved Node (the bare
+  // run() caveat), neither would settle until run() returned (after appQuit).
+  setTimeout(() => {
+    timerFiredDuringRun = !appQuit;
+  }, 15);
+  const continuation = new Promise((resolve) => setTimeout(resolve, 25)).then(() => {
+    promiseSettledDuringRun = !appQuit;
+  });
+
+  app.connect('activate', () => {
+    app.hold();
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
+      appQuit = true;
+      app.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+  });
+
+  const status = await app.runAsync([]);
+  await continuation;
+
+  assert.equal(status, 0);
+  assert.equal(timerFiredDuringRun, true, 'a setTimeout scheduled before runAsync fired DURING the run');
+  assert.equal(
+    promiseSettledDuringRun,
+    true,
+    'a Promise continuation scheduled before runAsync settled DURING the run (loop not starved)',
+  );
+});
+
+test('the blocking run() is unchanged', { skip }, () => {
+  const app = makeApp();
+  let fired = false;
+  // Scheduled before the synchronous, top-level blocking run() — the bridge
+  // co-pumps libuv so this timer fires during the run, exactly as before.
+  setTimeout(() => {
+    fired = true;
+  }, 10);
+  app.connect('activate', () => {
+    app.hold();
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 80, () => {
+      app.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+  });
+
+  const status = app.run([]); // top-level blocking run (no async wrapper)
+  assert.equal(status, 0, 'blocking run([]) still exits 0');
+  assert.equal(fired, true, 'libuv timer fired during the blocking run() (bridge unchanged)');
+});


### PR DESCRIPTION
## Summary

Ports GJS's `Gio.Application.prototype.runAsync` override (`refs/gjs/modules/core/overrides/Gio.js` → `GLib.MainLoop.prototype.runAsync`) to the `@gjsify/node-gi` L1 runtime (Axis-5 G5). `await app.runAsync([...])` runs the application and resolves with the integer exit status when it quits, **without** blocking the Node microtask/event loop the way the bare blocking `app.run()` would.

This unblocks running unchanged GJS app bootstraps on Node — e.g. the Adwaita storybook's `run.ts` does `return app.runAsync([imports.system.programInvocationName, ...ARGV])`.

## How it works

GJS defers the blocking `run()` via `setMainLoopHook` so the program's queued microtasks/promises settle before the GLib loop takes the thread. Node has no main-loop hook (libuv is always the process loop and the libuv↔GLib bridge co-pumps it during a blocking `run()`), so the faithful analogue is to defer `run()` to a **macrotask** (`setImmediate`). This:

- returns the Promise immediately — `runAsync` does not block the caller,
- lets the caller's already-queued microtasks/promises drain first, and
- runs `run()` **outside** the caller's `async`/`await` scope, sidestepping the node-gtk #442/#121 nested-microtask-checkpoint caveat — so promise continuations queued before `runAsync` drain **while** the app runs.

The bridge's `GSource` is attached to the **default** `GMainContext` that `g_application_run` iterates, so Node timers/promises/I/O stay pumped for the lifetime of the run; `runAsync` preserves that.

`runAsync` is surfaced in `wrapInstance`'s get trap, gated to `GApplication` instances via `native.isInstanceOf` (so `Gtk`/`Adw.Application` and `registerClass` subclasses qualify) and placed **after** the `userProto` lookup so a subclass may override it. Mirrors GJS in ignoring the `argv` argument (GJS calls `this.run()` with an empty command-line), keeping an `app.runAsync([programInvocationName, ...ARGV])` source byte-identical on gjs + node. The blocking `run()` is unchanged.

## Test

`test/runasync.test.mjs` — **headless** (a plain `Gio.Application` with `NON_UNIQUE` needs no display, so it runs in the fast node-gi gate, not the gtk-smoke job). Asserts:

1. `runAsync` returns a Promise and resolves with exit status `0` on quit.
2. A `setTimeout` **and** a Promise continuation scheduled before `runAsync` both settle **during** the run (loop not starved).
3. The blocking `run()` still works.

Full suite green: `node --test` 226 pass / 0 fail, `node --test --expose-gc` 237 pass / 0 fail.

## For review

- The promise resolution path: `setImmediate` → `try { resolve(run([])) } catch { reject }` — resolves once, runs `run()` once (no double-run / leak when called once).
- `run()` is unchanged (covered by test 3 + the existing gtk/adw smoke tests).
- The `argv`-ignored behavior matches GJS exactly (documented in code + commit).

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH