### PR TITLE
feat(node-gi): marshal GStrv construct properties

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -140,15 +140,17 @@ jobs:
       # LIBGL_ALWAYS_SOFTWARE=1 + GDK_BACKEND=x11 keep GTK off any GPU/Vulkan path
       # that a software-only Xvfb cannot provide; GTK_A11Y=none avoids the a11y bus.
       # Runs ALL the GTK smoke tests (Gtk.Application PR1 + Adw.Application PR2 +
-      # Gtk.Template PR4 + Template signal callbacks & menu breadth) in one
-      # node --test invocation so each reports even if one fails.
+      # Gtk.Template PR4 + Template signal callbacks & menu breadth + the GStrv
+      # construct-property cases, which need the Gtk-4.0 typelib the fast headless
+      # leg lacks) in one node --test invocation so each reports even if one fails.
       - name: GTK/Adw smoke test (xvfb + dbus)
         working-directory: packages/node-gi/node-gi
         run: |
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs \
-              test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs
+              test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs \
+              test/strv-construct.test.mjs
 
       # GTK capstone: ONE unchanged Adwaita gi:// source builds + runs
       # byte-identically on BOTH gjs and node under one display — the GTK analog of

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -1897,6 +1897,55 @@ static int ArgDestroyIndex(GIArgInfo* ai) {
   return gi_arg_info_get_destroy_index(ai, &idx) ? static_cast<int>(idx) : -1;
 }
 
+// Depth of a synchronous emitSignal() in progress on the (main) thread. While
+// > 0, a signal-handler exception must PROPAGATE to the JS emit() caller (the
+// node-gi contract — see test/signals.test.mjs "a handler exception propagates
+// out of emit"). At depth 0 the closure was dispatched from the GLib main loop (a
+// GTK signal, a notify::, a template handler) where there is NO JS caller to
+// catch it, so it is surfaced + cleared (below) to keep the loop alive instead of
+// wedging libuv on a never-cleared pending exception.
+static int g_syncEmitDepth = 0;
+
+// Surface (log) + clear a pending JS exception left by a C-invoked callback so it
+// cannot wedge the GLib/libuv main loop. A signal handler / idle / timeout that
+// throws is reported to stderr (message + stack) and swallowed — mirroring how
+// GJS reports an uncaught signal-handler exception (gjs_log_exception) instead of
+// crashing the loop. Uses g_printerr, NOT g_warning, so a G_DEBUG=fatal-warnings
+// test environment cannot turn a reported handler bug into an abort. No-op when
+// nothing is pending. Returns true if it cleared an exception.
+static bool SurfacePendingException(napi_env env, const char* context) {
+  bool pending = false;
+  if (napi_is_exception_pending(env, &pending) != napi_ok || !pending) return false;
+  napi_value ex = nullptr;
+  if (napi_get_and_clear_last_exception(env, &ex) != napi_ok || ex == nullptr) return false;
+
+  // Prefer Error.stack (message + trace); fall back to String(ex).
+  std::string text;
+  napi_value field = nullptr;
+  napi_valuetype vt = napi_undefined;
+  if (napi_get_named_property(env, ex, "stack", &field) == napi_ok &&
+      napi_typeof(env, field, &vt) == napi_ok && vt == napi_string) {
+    size_t len = 0;
+    if (napi_get_value_string_utf8(env, field, nullptr, 0, &len) == napi_ok) {
+      text.resize(len);
+      napi_get_value_string_utf8(env, field, text.data(), len + 1, &len);
+    }
+  }
+  if (text.empty()) {
+    napi_value str = nullptr;
+    if (napi_coerce_to_string(env, ex, &str) == napi_ok) {
+      size_t len = 0;
+      if (napi_get_value_string_utf8(env, str, nullptr, 0, &len) == napi_ok) {
+        text.resize(len);
+        napi_get_value_string_utf8(env, str, text.data(), len + 1, &len);
+      }
+    }
+  }
+  g_printerr("\n(node-gi) Unhandled exception in %s:\n%s\n", context,
+             text.empty() ? "<no message>" : text.c_str());
+  return true;
+}
+
 // The ffi closure entry point: marshal C args -> JS, call the JS fn, marshal the
 // JS return -> C. Runs on the main thread (the GLib loop the bridge pumps).
 static void NodeGiCallbackTrampoline(ffi_cif* /*cif*/, void* result, void** args,
@@ -1956,8 +2005,17 @@ static void NodeGiCallbackTrampoline(ffi_cif* /*cif*/, void* result, void** args
     }
   }
   gi_base_info_unref(retType);
-  // A pending JS exception surfaces at the next N-API boundary (e.g. when the
-  // blocking run() that pumped this callback returns).
+  // A CALL-scope callback (e.g. a list `foreach`) runs synchronously inside a
+  // JS-initiated GI invoke, so a pending exception must propagate to that JS
+  // caller — leave it to surface at the invoke's N-API boundary. A NOTIFIED/ASYNC
+  // callback (idle/timeout/GAsyncReadyCallback) is dispatched FROM the GLib loop
+  // with no JS caller to catch it; a left-pending exception would wedge the
+  // libuv↔GLib pump (DrainMicrotasks stops draining while one is pending). Surface
+  // + clear it so the loop keeps running (GJS logs an uncaught callback exception
+  // rather than stalling the loop).
+  if (napiEnv.IsExceptionPending() && cb->scope != GI_SCOPE_TYPE_CALL) {
+    SurfacePendingException(env, "GI callback (idle/timeout/async)");
+  }
 
   // scope=async (e.g. a GAsyncReadyCallback) fires EXACTLY once and carries no
   // destroy-notify, so it is the trampoline's job to free it. It is NOT in
@@ -2539,6 +2597,34 @@ static bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
     GType gt = 0;
     if (!UnwrapGTypeArg(env, js, &gt)) return false;
     g_value_set_gtype(v, gt);
+    return true;
+  }
+  // G_TYPE_STRV (a GStrv / NULL-terminated char** boxed property, e.g.
+  // Gtk.Widget:css-classes). G_TYPE_FUNDAMENTAL(G_TYPE_STRV) == G_TYPE_BOXED, so
+  // the switch below would route it to the boxed-HANDLE case and reject a JS array
+  // ("expected a boxed handle for a GStrv property"). Special-case it FIRST — a JS
+  // string[] → a freshly-allocated GStrv — exactly as GJS does before its generic
+  // g_type_is_a(gtype, G_TYPE_BOXED) handling (refs/gjs/gi/value.cpp:704-725).
+  // Ownership: g_value_take_boxed makes the GValue OWN the GStrv; g_object_new
+  // COPIES it into the property (g_strdupv), and ConstructGObject's g_value_unset
+  // frees the GValue's copy via g_strfreev — no double-free, no leak.
+  if (G_VALUE_HOLDS(v, G_TYPE_STRV)) {
+    if (js.IsNull() || js.IsUndefined()) {
+      g_value_set_boxed(v, nullptr);
+      return true;
+    }
+    if (!js.IsArray()) {
+      Napi::TypeError::New(env, "expected a string[] for a GStrv property")
+          .ThrowAsJavaScriptException();
+      return false;
+    }
+    Napi::Array arr = js.As<Napi::Array>();
+    guint len = arr.Length();
+    gchar** strv = g_new0(gchar*, len + 1);  // +1 for the NULL terminator
+    for (guint i = 0; i < len; i++) {
+      strv[i] = g_strdup(arr.Get(i).ToString().Utf8Value().c_str());
+    }
+    g_value_take_boxed(v, strv);
     return true;
   }
   switch (ft) {
@@ -4811,13 +4897,26 @@ static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_pa
   args.reserve(n_param_values > 0 ? n_param_values - 1 : 0);
   for (guint i = 1; i < n_param_values; i++) {
     Napi::Value v = GValueToJs(env, &param_values[i]);
-    if (env.IsExceptionPending()) return;
+    if (env.IsExceptionPending()) {
+      // An arg-marshal failure: propagate to a synchronous emit() caller, or
+      // surface + clear when dispatched from the loop (see g_syncEmitDepth).
+      if (g_syncEmitDepth == 0) SurfacePendingException(jc->env, "signal handler");
+      return;
+    }
     args.push_back(v);
   }
 
   napi_value result = nullptr;
   napi_status st = napi_call_function(jc->env, env.Undefined(), cbv, args.size(), args.data(), &result);
-  if (st != napi_ok) return;  // JS threw — leave the pending exception to surface
+  if (st != napi_ok) {
+    // The handler threw. A synchronous emitSignal() (g_syncEmitDepth > 0) must
+    // propagate it to the JS emit() caller (node-gi contract). A loop-dispatched
+    // signal (a GTK click, a notify::, a GtkBuilder template handler — depth 0)
+    // has no JS caller; surface + clear so the GLib/libuv loop keeps running
+    // instead of wedging on the never-cleared pending exception.
+    if (g_syncEmitDepth == 0) SurfacePendingException(jc->env, "signal handler");
+    return;
+  }
 
   if (return_value != nullptr && (G_VALUE_TYPE(return_value) != G_TYPE_INVALID)) {
     JsToGValue(env, Napi::Value(jc->env, result), return_value);
@@ -4908,7 +5007,12 @@ Napi::Value EmitSignal(const Napi::CallbackInfo& info) {
   Napi::Value result = env.Undefined();
   if (ok) {
     if (hasReturn) g_value_init(&ret, rt);
+    // Mark this as a SYNCHRONOUS emit so a handler exception propagates back to
+    // this JS caller (JsClosureMarshal checks g_syncEmitDepth) rather than being
+    // surfaced + swallowed like a loop-dispatched signal.
+    g_syncEmitDepth++;
     g_signal_emitv(params.data(), sigid, 0, hasReturn ? &ret : nullptr);
+    g_syncEmitDepth--;
     if (hasReturn && !env.IsExceptionPending()) {
       result = GValueToJs(env, &ret);
       g_value_unset(&ret);

--- a/packages/node-gi/node-gi/test/strv-construct.test.mjs
+++ b/packages/node-gi/node-gi/test/strv-construct.test.mjs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — G_TYPE_STRV construct-property marshalling + loop-dispatched
+// handler-exception surfacing.
+//
+// FIX 1 — JsToGValue had no G_TYPE_STRV case. Because
+// G_TYPE_FUNDAMENTAL(G_TYPE_STRV) == G_TYPE_BOXED, a GStrv-typed construct
+// property (e.g. Gtk.Widget:css-classes, Gtk.StringList:strings) fell into the
+// boxed-HANDLE case and threw "expected a boxed handle for a GStrv property" on a
+// plain JS array. The new branch marshals a JS string[] → a freshly-allocated
+// GStrv (g_value_take_boxed; g_object_new copies it; g_value_unset frees the
+// copy). null/undefined clears it; a non-array throws a clean TypeError.
+//
+// FIX 2 — a JS exception thrown inside a C-invoked GClosure (a signal handler /
+// notify:: / idle / timeout) was left pending, which WEDGED the GLib/libuv main
+// loop (DrainMicrotasks stops draining while an exception is pending — that is why
+// the FIX-1 throw became a multi-second hang instead of a clean error). The
+// trampolines now surface + clear an uncaught LOOP-DISPATCHED handler exception
+// (logged to stderr, GJS-style) so the loop keeps running; a SYNCHRONOUS emit()
+// still propagates it to the JS caller (covered by test/signals.test.mjs).
+//
+// The GStrv-via-Gtk cases need the Gtk-4.0 typelib (only the dedicated gtk-smoke
+// CI job installs it), so they self-skip on the fast headless leg. The css_classes
+// widget case additionally needs a display. The FIX-2 cases are fully headless
+// (GLib + Gio) and run on every leg.
+//
+// Reference: refs/gjs/gi/value.cpp:704-725 (the gtype == G_TYPE_STRV special-case)
+// + refs/gjs closure marshalling (gjs_log_exception reports, never crashes the loop).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+// Gtk only if its typelib is present (gtk-smoke job); else the GStrv-via-Gtk cases
+// self-skip rather than throw on the headless leg.
+let Gtk = null;
+let gtkLoadError = null;
+try {
+  Gtk = requireGi('Gtk', '4.0');
+} catch (err) {
+  gtkLoadError = err;
+}
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
+const widgetSkip = gtkSkip || (!haveDisplay ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)' : false);
+
+// ---- FIX 1: G_TYPE_STRV construct property ---------------------------------
+
+// Headless GStrv construct property: Gtk.StringList:strings is construct-only,
+// type G_TYPE_STRV, and GtkStringList is a plain GObject (GListModel) — no display
+// or gtk_init needed.
+test('GStrv construct prop: a JS string[] round-trips (Gtk.StringList:strings)', { skip: gtkSkip }, () => {
+  const list = new Gtk.StringList({ strings: ['alpha', 'beta', 'gamma'] });
+  assert.equal(list.get_n_items(), 3, 'all three strings were marshalled into the GStrv');
+  assert.equal(list.get_string(0), 'alpha');
+  assert.equal(list.get_string(1), 'beta');
+  assert.equal(list.get_string(2), 'gamma');
+});
+
+test('GStrv construct prop: an empty array yields an empty GStrv', { skip: gtkSkip }, () => {
+  const list = new Gtk.StringList({ strings: [] });
+  assert.equal(list.get_n_items(), 0);
+});
+
+test('GStrv construct prop: null/undefined clears it (empty list, no throw)', { skip: gtkSkip }, () => {
+  const fromNull = new Gtk.StringList({ strings: null });
+  assert.equal(fromNull.get_n_items(), 0);
+  const fromUndefined = new Gtk.StringList({ strings: undefined });
+  assert.equal(fromUndefined.get_n_items(), 0);
+});
+
+test('GStrv construct prop: a non-array value throws a clean TypeError', { skip: gtkSkip }, () => {
+  assert.throws(
+    () => new Gtk.StringList({ strings: 'not-an-array' }),
+    /expected a string\[\] for a GStrv property/,
+  );
+});
+
+// The reported repro: a Gtk widget css_classes construct property. Needs a display
+// (gtk_init) so it is gated to the gtk-smoke leg, but it is the exact failing case
+// from the bug report (new Gtk.ScrolledWindow({ css_classes: ['foo'] })).
+test('GStrv construct prop: Gtk widget css_classes round-trips', { skip: widgetSkip }, () => {
+  if (typeof Gtk.init === 'function') Gtk.init();
+  const sw = new Gtk.ScrolledWindow({ css_classes: ['foo', 'bar'] });
+  assert.deepEqual(sw.get_css_classes(), ['foo', 'bar'], 'css_classes read back via get_css_classes()');
+});
+
+// ---- FIX 2: a loop-dispatched handler exception must not wedge the loop -------
+
+test('FIX2: a throwing notify handler dispatched in the loop does not wedge it', () => {
+  // Gio.SimpleAction is a headless GObject; toggling :enabled emits notify::enabled
+  // and the handler is dispatched at g_syncEmitDepth == 0 (no JS emit() wrapping it)
+  // — exactly the signal-closure path that used to leave a pending exception.
+  const action = new Gio.SimpleAction({ name: 'strv-fix2' });
+  let handlerRan = false;
+  let secondFired = false;
+  action.connect('notify::enabled', () => {
+    handlerRan = true;
+    throw new Error('boom from a loop-dispatched notify handler');
+  });
+
+  const loop = GLib.MainLoop.new(null, false);
+  // T1: flips the property → notify::enabled fires → the handler throws.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10, () => {
+    action.set_enabled(false);
+    return GLib.SOURCE_REMOVE;
+  });
+  // T2: must STILL fire after T1's handler threw → proves the loop kept running.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 40, () => {
+    secondFired = true;
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+  // Backstop: a regression that wedges the loop hits this cap instead of hanging.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 3000, () => {
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+
+  loop.run();
+
+  assert.equal(handlerRan, true, 'the throwing notify handler ran');
+  assert.equal(secondFired, true, 'the loop survived the throwing handler and dispatched the next source');
+});
+
+test('FIX2: a throwing timeout callback does not wedge the main loop', () => {
+  const loop = GLib.MainLoop.new(null, false);
+  let firstRan = false;
+  let secondFired = false;
+  // T1 throws from inside the loop dispatch (a NOTIFIED-scope GSourceFunc).
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10, () => {
+    firstRan = true;
+    throw new Error('boom from a loop-dispatched timeout');
+  });
+  // T2 must still fire AFTER T1 threw.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 40, () => {
+    secondFired = true;
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 3000, () => {
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+
+  loop.run();
+
+  assert.equal(firstRan, true, 'the throwing timeout callback ran');
+  assert.equal(secondFired, true, 'the loop survived the throwing callback');
+});


### PR DESCRIPTION
## Summary

Constructing a widget with a `G_TYPE_STRV` array construct property — e.g. `new Gtk.ScrolledWindow({ css_classes: ['foo'] })` under `--app node` / `@gjsify/node-gi` — threw `TypeError: expected a boxed handle for a GStrv property`. This was the **last gap** blocking the GJS Adwaita storybook window chrome from rendering on Node.

## FIX 1 — `G_TYPE_STRV` in `JsToGValue` (root cause)

`JsToGValue` dispatched on `G_TYPE_FUNDAMENTAL(value_type)`, and `G_TYPE_FUNDAMENTAL(G_TYPE_STRV) == G_TYPE_BOXED`, so a GStrv property fell into the boxed-**handle** case (`TryGetBoxedHandle` on a JS array → nullptr → throw). node-gi had a JS-array→GStrv builder in the function-argument path but **no `G_TYPE_STRV` case in the property/GValue marshaller**.

Added a `G_TYPE_STRV` branch **before** the `switch(G_TYPE_FUNDAMENTAL(...))` (right after the `G_VALUE_HOLDS_GTYPE` early-return), mirroring GJS `refs/gjs/gi/value.cpp:704-725`, which special-cases `gtype == G_TYPE_STRV` before its generic `g_type_is_a(gtype, G_TYPE_BOXED)` case. A JS `string[]` → a freshly-allocated GStrv via `g_value_take_boxed`. `null`/`undefined` clears it; a non-array throws a clean `TypeError` (`expected a string[] for a GStrv property`).

**Ownership:** `g_value_take_boxed` → the GValue owns the GStrv → `g_object_new` copies it into the property (`g_strdupv`) → `ConstructGObject`'s `g_value_unset` frees the GValue's copy via `g_strfreev`. No double-free, no leak.

## FIX 2 — surface uncaught loop-dispatched GClosure exceptions

A JS exception thrown inside a C-invoked GClosure (signal handler / `notify::` / idle / timeout) was left **pending**, which wedged the GLib/libuv loop — `DrainMicrotasks` stops draining while an exception is pending, so nextTick/promises/timers never advance again (that's why the FIX-1 throw became a multi-second hang instead of a clean error).

The trampolines now **surface (log to stderr, GJS-style via `gjs_log_exception` semantics) + clear** an uncaught **loop-dispatched** handler exception so the loop keeps running, while a **synchronous `emitSignal()`** still propagates it to the JS caller (tracked via a `g_syncEmitDepth` counter, so the existing `signals.test.mjs` "a handler exception propagates out of emit" invariant stays green). Covers both `JsClosureMarshal` (signal closure) and `NodeGiCallbackTrampoline` (ffi callback, NOTIFIED/ASYNC scope only — CALL scope stays synchronous and propagates).

## Tests

`test/strv-construct.test.mjs`:
- GStrv `string[]` round-trip (`Gtk.StringList:strings`, headless) + read-back
- empty array, `null`/`undefined` → empty, non-array → clean `TypeError`
- the `css_classes` widget repro (`get_css_classes()` round-trip; gtk-smoke leg)
- FIX 2: a throwing `notify` handler (depth 0) and a throwing timeout callback do **not** wedge the loop — a subsequent GLib timeout still fires

Wired the Gtk-dependent cases into the `gtk-smoke` CI job (the fast headless leg lacks the Gtk-4.0 typelib). Full suite green locally: 249 node + 249 gc, sync-emit propagation intact.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH