### PR TITLE
feat(node-gi): marshal interface-typed properties

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -141,8 +141,9 @@ jobs:
       # that a software-only Xvfb cannot provide; GTK_A11Y=none avoids the a11y bus.
       # Runs ALL the GTK smoke tests (Gtk.Application PR1 + Adw.Application PR2 +
       # Gtk.Template PR4 + Template signal callbacks & menu breadth + the GStrv
-      # construct-property cases, which need the Gtk-4.0 typelib the fast headless
-      # leg lacks) in one node --test invocation so each reports even if one fails.
+      # construct-property cases + the GListModel interface-typed property cases,
+      # which need the Gtk-4.0 typelib the fast headless leg lacks) in one
+      # node --test invocation so each reports even if one fails.
       - name: GTK/Adw smoke test (xvfb + dbus)
         working-directory: packages/node-gi/node-gi
         run: |
@@ -150,7 +151,7 @@ jobs:
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs \
               test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs \
-              test/strv-construct.test.mjs
+              test/strv-construct.test.mjs test/interface-props.test.mjs
 
       # GTK capstone: ONE unchanged Adwaita gi:// source builds + runs
       # byte-identically on BOTH gjs and node under one display — the GTK analog of

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -2541,6 +2541,20 @@ static Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
     GType gt = g_value_get_gtype(v);
     return gt != 0 ? MakeGTypeHandle(env, gt) : env.Null();
   }
+  // An interface-typed property/signal value (e.g. Adw.ComboRow:model →
+  // GListModel, a GObject INTERFACE). G_TYPE_FUNDAMENTAL(an interface) ==
+  // G_TYPE_INTERFACE, which has no switch case below → the default branch would
+  // reject it ("Unsupported property GType GListModel"). The object lives in the
+  // value's pointer slot: the interface inherits GObject's GTypeValueTable via
+  // its GObject prerequisite, so the slot IS an owned-object ref. Read it
+  // directly — g_value_get_object g_return_val_if_fail's G_VALUE_HOLDS_OBJECT,
+  // which is FALSE for an interface type (g_type_is_a(GListModel, G_TYPE_OBJECT)
+  // == false). Mirrors GJS (refs/gjs/gi/value.cpp:1071 + gi/value.h:110) +
+  // JsToGValue's interface branch. Borrow (transfer-none; WrapGObject refs).
+  if (G_TYPE_IS_INTERFACE(G_VALUE_TYPE(v))) {
+    return WrapGObject(env, static_cast<GObject*>(v->data[0].v_pointer),
+                       GI_TRANSFER_NOTHING);
+  }
   switch (ft) {
     case G_TYPE_BOOLEAN: return Napi::Boolean::New(env, g_value_get_boolean(v));
     case G_TYPE_CHAR: return Napi::Number::New(env, g_value_get_schar(v));
@@ -2625,6 +2639,37 @@ static bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
       strv[i] = g_strdup(arr.Get(i).ToString().Utf8Value().c_str());
     }
     g_value_take_boxed(v, strv);
+    return true;
+  }
+  // An interface-typed property (e.g. Adw.ComboRow:model is GListModel, a GObject
+  // INTERFACE; Gtk.MenuButton:menu-model, …). G_TYPE_FUNDAMENTAL(an interface) ==
+  // G_TYPE_INTERFACE, which has no switch case below → the default branch would
+  // reject it ("Unsupported property GType GListModel"). The JS value is a wrapped
+  // GObject that IMPLEMENTS the interface (e.g. a Gtk.StringList / Gio.ListStore
+  // implementing GListModel). GObject's g_value_set_object g_return_if_fail's
+  // G_VALUE_HOLDS_OBJECT, which is FALSE for an interface-typed GValue
+  // (g_type_is_a(GListModel, G_TYPE_OBJECT) == false), so mirror GJS
+  // (refs/gjs/gi/value.cpp:684 + gi/value.h:165): set the value's object slot
+  // directly with g_set_object — the interface inherits GObject's value table via
+  // its GObject prerequisite, so the slot IS an owned-object ref. Same ownership
+  // as the G_TYPE_OBJECT case (#659): g_set_object refs the object (our wrapper
+  // keeps its own ref → no double-free), ConstructGObject's g_value_unset drops
+  // the GValue's ref. null/undefined → clear; a non-implementing / non-GObject
+  // value → clean TypeError.
+  if (G_TYPE_IS_INTERFACE(G_VALUE_TYPE(v))) {
+    GObject* obj = nullptr;
+    if (!(js.IsNull() || js.IsUndefined())) {
+      obj = UnwrapGObject(env, js);
+      if (obj == nullptr) return false;  // UnwrapGObject threw a TypeError
+      if (!g_type_is_a(G_OBJECT_TYPE(obj), G_VALUE_TYPE(v))) {
+        Napi::TypeError::New(env, std::string("expected an object implementing ") +
+                                      g_type_name(G_VALUE_TYPE(v)) + ", got " +
+                                      g_type_name(G_OBJECT_TYPE(obj)))
+            .ThrowAsJavaScriptException();
+        return false;
+      }
+    }
+    g_set_object(&v->data[0].v_pointer, obj);
     return true;
   }
   switch (ft) {

--- a/packages/node-gi/node-gi/test/interface-props.test.mjs
+++ b/packages/node-gi/node-gi/test/interface-props.test.mjs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — interface-typed (G_TYPE_INTERFACE) construct/writable
+// property marshalling.
+//
+// JsToGValue / GValueToJs dispatch on G_TYPE_FUNDAMENTAL(value_type). A GObject
+// INTERFACE (e.g. GListModel) has fundamental G_TYPE_INTERFACE, which matched no
+// case → both directions fell into the "Unsupported property GType <name>" reject.
+// That wall surfaced building the Adwaita storybook on Node: Adw.ComboRow:model is
+// a GListModel-typed construct property, so `new Adw.ComboRow({ model })` threw
+// `TypeError: Unsupported property GType GListModel`.
+//
+// FIX — an explicit G_TYPE_IS_INTERFACE branch (BEFORE the fundamental switch) in
+// both marshallers. The JS value is a wrapped GObject that IMPLEMENTS the
+// interface (e.g. a Gtk.StringList / Gio.ListStore implementing GListModel).
+// g_value_set_object / g_value_get_object g_return_if_fail on G_VALUE_HOLDS_OBJECT,
+// which is FALSE for an interface-typed GValue (g_type_is_a(GListModel,
+// G_TYPE_OBJECT) == false), so — mirroring GJS (refs/gjs/gi/value.cpp:684/1071 +
+// gi/value.h:110/165) — the object slot is read/written directly via g_set_object:
+// the interface inherits GObject's GTypeValueTable through its GObject prerequisite,
+// so the slot IS an owned-object ref. Same ownership as the G_TYPE_OBJECT case
+// (#659): set refs (our wrapper keeps its own ref), null/undefined clears, a
+// non-implementing / non-GObject value throws a clean TypeError.
+//
+// These cases use a GListModel-typed property on a real GI class, so they need the
+// Gtk-4.0 typelib (only the dedicated gtk-smoke CI job installs it) and self-skip
+// on the fast headless leg. Gtk.SingleSelection:model is a non-widget GObject
+// (typelib only, no display); the Adw.ComboRow repro additionally needs a display.
+//
+// Reference: refs/gjs/gi/value.cpp:684-702 (the
+// g_type_is_a(gtype, G_TYPE_INTERFACE) branch shared with G_TYPE_OBJECT).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const Gio = requireGi('Gio', '2.0');
+
+// Gtk only if its typelib is present (gtk-smoke job); else the GListModel-typed
+// cases self-skip rather than throw on the headless leg.
+let Gtk = null;
+let gtkLoadError = null;
+try {
+  Gtk = requireGi('Gtk', '4.0');
+} catch (err) {
+  gtkLoadError = err;
+}
+let Adw = null;
+try {
+  Adw = requireGi('Adw', '1');
+} catch {
+  // Adwaita is optional — the ComboRow repro self-skips without it.
+}
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
+const widgetSkip = gtkSkip || (!Adw ? 'Adwaita-1 typelib unavailable' : false) ||
+  (!haveDisplay ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)' : false);
+
+// A fresh Gio.ListStore (a plain GObject implementing GListModel) to feed into a
+// GListModel-typed property.
+function makeListStore(n) {
+  const store = Gio.ListStore.new(Gio.SimpleAction.$gtype);
+  for (let i = 0; i < n; i++) store.append(new Gio.SimpleAction({ name: `a${i}` }));
+  return store;
+}
+
+test('interface prop: a GListModel impl round-trips at construction (Gtk.SingleSelection:model)', { skip: gtkSkip }, () => {
+  const store = makeListStore(3);
+  const sel = new Gtk.SingleSelection({ model: store });
+  assert.equal(sel.get_n_items(), 3, 'the GListModel was marshalled into the interface-typed property');
+});
+
+test('interface prop: reads back the identical wrapper', { skip: gtkSkip }, () => {
+  const store = makeListStore(2);
+  const sel = new Gtk.SingleSelection({ model: store });
+  const back = sel.model;
+  assert.equal(back === store, true, 'the interface-typed property reads back the identical wrapper');
+  assert.equal(back.get_n_items(), 2, 'the round-tripped GListModel is the real instance');
+});
+
+test('interface prop: assignment replaces the model and reads back', { skip: gtkSkip }, () => {
+  const sel = new Gtk.SingleSelection({ model: makeListStore(1) });
+  const other = makeListStore(4);
+  sel.model = other;
+  assert.equal(sel.model === other, true);
+  assert.equal(sel.model.get_n_items(), 4);
+});
+
+test('interface prop: null clears it (model reads back as null)', { skip: gtkSkip }, () => {
+  const sel = new Gtk.SingleSelection({ model: makeListStore(1) });
+  sel.model = null;
+  assert.equal(sel.model, null, 'null cleared the interface-typed property');
+});
+
+test('interface prop: a non-implementing GObject throws a clean TypeError', { skip: gtkSkip }, () => {
+  // Gio.SimpleAction is a GObject that does NOT implement GListModel.
+  assert.throws(
+    () => new Gtk.SingleSelection({ model: new Gio.SimpleAction({ name: 'x' }) }),
+    /expected an object implementing GListModel, got GSimpleAction/,
+  );
+});
+
+test('interface prop: a non-GObject value throws a clean TypeError', { skip: gtkSkip }, () => {
+  assert.throws(
+    () => new Gtk.SingleSelection({ model: 'not-a-gobject' }),
+    /expected a node-gi GObject handle/,
+  );
+});
+
+// The exact storybook repro: Adw.ComboRow:model is a GListModel-typed construct
+// property. This is a widget, so it needs a display (gtk_init).
+test('interface prop: the storybook repro — Adw.ComboRow({ model: Gtk.StringList })', { skip: widgetSkip }, () => {
+  if (typeof Gtk.init === 'function') Gtk.init();
+  const list = new Gtk.StringList({ strings: ['alpha', 'beta', 'gamma'] });
+  const combo = new Adw.ComboRow({ model: list });
+  assert.equal(combo.model.get_n_items(), 3, 'Adw.ComboRow accepted the GListModel-typed model and reads it back');
+});


### PR DESCRIPTION
## Summary

node-gi's `JsToGValue` / `GValueToJs` dispatch on `G_TYPE_FUNDAMENTAL(value_type)`. A GObject **interface** (e.g. `GListModel`) has fundamental `G_TYPE_INTERFACE`, which matched no switch case, so both marshallers fell into the `Unsupported property GType <name>` reject.

This was the next wall building the Adwaita storybook on Node: `Adw.ComboRow`'s `model` construct property is typed `GListModel`, so populating the sidebar threw `TypeError: Unsupported property GType GListModel`.

## Fix

Add an explicit `G_TYPE_IS_INTERFACE` branch (before the fundamental switch) in both directions. The JS value is a wrapped GObject that implements the interface (a `Gtk.StringList` / `Gio.ListStore` implementing `GListModel`). `g_value_set_object` / `g_value_get_object` `g_return_if_fail` on `G_VALUE_HOLDS_OBJECT`, which is **false** for an interface-typed GValue (`g_type_is_a(GListModel, G_TYPE_OBJECT) == false`), so — mirroring GJS (`refs/gjs/gi/value.cpp:684`/`1071`) — the object slot is read/written directly via `g_set_object`: the interface inherits GObject's value table through its GObject prerequisite, so the slot is an owned-object ref. Same ownership as the `G_TYPE_OBJECT` case (#659): set refs (the wrapper keeps its own ref), null/undefined clears, a non-implementing / non-GObject value throws a clean `TypeError`.

## Render verdict — RENDERED

With this fix the Adwaita storybook **renders on Node**: `_onActivate` completes, `window.present()` runs, the app stays alive with no uncaught error. A 3s render probe reports:

```
RENDER windows=1
```

clean exit 0 (not a timeout).

## Tests

`test/interface-props.test.mjs` (7 cases): construction round-trip + read-back identity, reassignment, null-clears, a non-implementing GObject and a non-GObject value (clean `TypeError`), plus the exact `Adw.ComboRow({ model: Gtk.StringList })` storybook repro. The `GListModel`-typed cases need the Gtk-4.0 typelib, so they self-skip on the fast headless leg and are added to the gtk-smoke job's file list. Full `node --test` (256) and `node --test --expose-gc` (256) stay green.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH