### PR TITLE
feat(node-gi): pass signal emitter to JS handlers

### DIFF
--- a/packages/node-gi/example-gtk/src/app.ts
+++ b/packages/node-gi/example-gtk/src/app.ts
@@ -24,11 +24,12 @@
 //   - a Gtk.CssProvider applied display-wide + a CSS class added to a widget;
 //   - a Gio.SimpleAction added to the app and activated programmatically.
 //
-// Every value printed below is DETERMINISTIC — no hostname, no varying paths, no
-// dependence on signal-callback arguments (Node's node-gi omits the emitter as
-// the first callback arg, so handlers only ever print closure-captured
-// constants). Running either build prints the same fixed sequence of lines — the
-// golden output asserted by `dual.e2e.mjs`.
+// Every value printed below is DETERMINISTIC — no hostname, no varying paths. The
+// signal handlers print only closure-captured constants (never the callback args)
+// so the golden output is identical regardless of arg shape. node-gi now passes
+// the emitter as the first callback arg, matching GJS (`activate` handlers ignore
+// it). Running either build prints the same fixed sequence of lines — the golden
+// output asserted by `dual.e2e.mjs`.
 //
 // DUAL-SAFETY FINDING (composite-template child naming). A template child id MUST
 // NOT collide with a real GObject property of the widget class. A child id

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -170,8 +170,11 @@ function wrapReturn(value) {
 // Wrap a user's signal callback so each native signal argument is passed through
 // {@link wrapReturn} — a GObject arg becomes a chainable instance, a GVariant
 // arg (e.g. the value on Gio.SimpleAction::change-state) becomes a GLib.Variant
-// wrapper, primitives/plain objects pass through. (The emitter instance is not
-// passed in this milestone — see connectSignal.)
+// wrapper, primitives/plain objects pass through. GJS parity: the engine prepends
+// the EMITTER (the object the signal fired on) as the first arg, so a positional
+// handler `(obj, …params) => …` binds correctly; the emitter is itself a GObject
+// arg, so wrapReturn turns it into the cached, toggle-ref-canonical instance. For
+// `notify::x` the args are (object, pspec).
 function wrapSignalCallback(cb) {
   return (...args) => cb(...args.map(wrapReturn));
 }
@@ -188,9 +191,11 @@ function wrapSignalCallback(cb) {
 // full, userProto-carrying, toggle-ref-canonical L1 wrapper. `this` inside the
 // handler is therefore the widget — the SAME cached proxy the user constructed
 // (wrapInstance is cached by the canonical handle). Native signal args are wrapped
-// (wrapReturn) into chainable instances, exactly like wrapSignalCallback. (The
-// engine drops the emitter at param 0, node-gi's signal convention.) A handler name
-// with no matching user-prototype method throws a clear error when the signal fires.
+// (wrapReturn) into chainable instances, exactly like wrapSignalCallback. GJS
+// parity: the engine prepends the emitter at param 0, so a template handler
+// `on_click(button)` receives the emitter first, then the signal's own params. A
+// handler name with no matching user-prototype method throws a clear error when
+// the signal fires.
 function resolveTemplateCallback(handle, handlerName) {
   return (...args) => {
     const proxy = wrapInstance(handle);

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -1943,8 +1944,37 @@ static bool SurfacePendingException(napi_env env, const char* context) {
   }
   g_printerr("\n(node-gi) Unhandled exception in %s:\n%s\n", context,
              text.empty() ? "<no message>" : text.c_str());
+
+  // Building `text` above can itself run user JS — a throwing `stack` getter
+  // (napi_get_named_property) or a throwing `toString` (napi_coerce_to_string) —
+  // which leaves a NEW pending exception. If we returned now the caller would be
+  // env-dirty and could wedge the loop exactly like the original throw. Re-check
+  // and clear so the env is guaranteed clean on return.
+  bool stillPending = false;
+  if (napi_is_exception_pending(env, &stillPending) == napi_ok && stillPending) {
+    napi_value ignored = nullptr;
+    napi_get_and_clear_last_exception(env, &ignored);
+  }
   return true;
 }
+
+// RAII: pin g_syncEmitDepth to 0 for the duration of a LOOP-DISPATCHED callback,
+// restoring the prior value on scope exit. g_syncEmitDepth marks "a synchronous
+// emitSignal() is on the stack" — but a synchronous handler may re-enter the GLib
+// loop (a nested loop.run() / g_main_context_iteration, or a blocking GIO call that
+// pumps the context). Any closure the NESTED loop dispatches (a notify:: from
+// g_object_set inside a timeout, a GTK signal) is genuinely loop-dispatched and has
+// no JS emit() caller to catch its throw, yet the global counter would still read
+// > 0 and JsClosureMarshal would leave the exception PENDING → DrainMicrotasks
+// early-returns → the libuv↔GLib pump wedges. Resetting to 0 across the loop-
+// dispatch boundary makes those closures evaluate at depth 0 (surface + clear),
+// while the OUTER synchronous emit() — resumed once the nested loop returns and the
+// prior depth is restored — still propagates its own handler's throw.
+struct SyncEmitDepthReset {
+  int saved;
+  SyncEmitDepthReset() : saved(g_syncEmitDepth) { g_syncEmitDepth = 0; }
+  ~SyncEmitDepthReset() { g_syncEmitDepth = saved; }
+};
 
 // The ffi closure entry point: marshal C args -> JS, call the JS fn, marshal the
 // JS return -> C. Runs on the main thread (the GLib loop the bridge pumps).
@@ -1954,6 +1984,14 @@ static void NodeGiCallbackTrampoline(ffi_cif* /*cif*/, void* result, void** args
   napi_env env = cb->env;
   Napi::Env napiEnv(env);
   Napi::HandleScope scope(napiEnv);
+  // An idle/timeout/async (NOTIFIED/ASYNC scope) callback is dispatched FROM the
+  // GLib loop. Pin the synchronous-emit depth to 0 so a signal this callback emits
+  // (e.g. a notify:: from g_object_set) is treated as loop-dispatched even when a
+  // synchronous emitSignal() is suspended higher on the stack across a nested loop.
+  // A CALL-scope callback runs synchronously inside a JS-initiated GI invoke, so it
+  // keeps the ambient depth (its exception must reach that JS caller).
+  std::unique_ptr<SyncEmitDepthReset> depthReset;
+  if (cb->scope != GI_SCOPE_TYPE_CALL) depthReset = std::make_unique<SyncEmitDepthReset>();
 
   GICallableInfo* ci = cb->info;
   unsigned int n = gi_callable_info_get_n_args(ci);
@@ -4900,8 +4938,9 @@ Napi::Value IsVariantHandle(const Napi::CallbackInfo& info) {
 //
 // A GClosure that wraps a JS callback. The callback is held by a strong
 // napi_ref; the closure's finalize notifier drops it. The generic marshal
-// converts the signal's GValue params to JS (skipping the emitter instance at
-// index 0) and the JS return into the signal return GValue.
+// converts the signal's GValue params to JS — the EMITTER instance (param 0)
+// first, then the signal's own params (1..n), matching GJS — and the JS return
+// into the signal return GValue.
 //
 // Narrowed-leak semantics (with the toggle-ref bridge): a handler that does NOT
 // close over its own object is now collectable once C is the sole owner
@@ -4937,10 +4976,15 @@ static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_pa
   napi_value cbv = nullptr;
   if (napi_get_reference_value(jc->env, jc->callback, &cbv) != napi_ok || cbv == nullptr) return;
 
-  // Signal args excluding the emitter instance (param_values[0]).
+  // GJS parity: the JS handler receives the EMITTER (the object the signal was
+  // emitted on, param_values[0]) as its first argument, then the signal's own
+  // parameters (param_values[1..n]). GJS passes the emitter first (refs/gjs
+  // gi/value.cpp / object signal invocation), so a positional handler such as
+  // `(listbox, row) => …` / `_onRowSelected(_listbox, row)` binds correctly. For
+  // a `notify::x` emission the args are therefore (object, pspec), as in GJS.
   std::vector<napi_value> args;
-  args.reserve(n_param_values > 0 ? n_param_values - 1 : 0);
-  for (guint i = 1; i < n_param_values; i++) {
+  args.reserve(n_param_values);
+  for (guint i = 0; i < n_param_values; i++) {
     Napi::Value v = GValueToJs(env, &param_values[i]);
     if (env.IsExceptionPending()) {
       // An arg-marshal failure: propagate to a synchronous emit() caller, or
@@ -4955,10 +4999,19 @@ static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_pa
   napi_status st = napi_call_function(jc->env, env.Undefined(), cbv, args.size(), args.data(), &result);
   if (st != napi_ok) {
     // The handler threw. A synchronous emitSignal() (g_syncEmitDepth > 0) must
-    // propagate it to the JS emit() caller (node-gi contract). A loop-dispatched
-    // signal (a GTK click, a notify::, a GtkBuilder template handler — depth 0)
-    // has no JS caller; surface + clear so the GLib/libuv loop keeps running
-    // instead of wedging on the never-cleared pending exception.
+    // propagate it to the JS emit() caller (node-gi contract). At depth 0 there
+    // is no JS caller to catch it, so it is surfaced + cleared (GJS-style) to keep
+    // the GLib/libuv loop alive instead of wedging on the never-cleared pending
+    // exception.
+    //
+    // BY DESIGN (GJS-aligned): depth 0 is NOT only the GLib loop's own dispatch (a
+    // GTK click, a GtkBuilder template handler) — it ALSO covers synchronous-but-
+    // not-emitSignal triggers: a notify:: from g_object_set / a property set, or an
+    // inline C emit such as action.activate(). Those reach this marshal with no
+    // emitSignal() frame on the stack (depth 0), so a handler throw is logged +
+    // swallowed here rather than rethrown to the JS code that triggered the emit —
+    // exactly as GJS reports an uncaught signal-handler exception (gjs_log_exception)
+    // instead of surfacing it to the trigger site.
     if (g_syncEmitDepth == 0) SurfacePendingException(jc->env, "signal handler");
     return;
   }

--- a/packages/node-gi/node-gi/test/closure-exception.test.mjs
+++ b/packages/node-gi/node-gi/test/closure-exception.test.mjs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — closure / signal exception hardening (the #675 review nits).
+//
+// These guard the GLib/libuv main-loop liveness when a JS exception escapes a
+// C-invoked GClosure (a signal handler / notify:: / idle / timeout). All cases are
+// fully headless (GLib + Gio, no display) so they run on every CI leg.
+//
+// FIX B1 — g_syncEmitDepth conflated "an emitSignal() is on the stack" with "THIS
+// dispatch is synchronous". A synchronous handler that re-enters the GLib loop (a
+// nested loop.run()) would make a loop-dispatched signal that throws during the
+// nested iteration look synchronous (depth > 0) → its exception was left pending →
+// DrainMicrotasks early-returns → the pump wedges. The depth is now reset to 0
+// across the loop-dispatch boundary (the idle/timeout/async trampoline), so loop-
+// dispatched closures evaluate at depth 0 while the suspended outer emit() — resumed
+// once the nested loop returns — still propagates its OWN handler's throw.
+//
+// FIX B2 — SurfacePendingException read ex.stack / coerced ex to a string, both of
+// which can run user JS (a throwing `stack` getter / `toString`) and leave a NEW
+// pending exception that the caller never cleared → the env stayed dirty → the next
+// loop-dispatched callback was skipped (its arg-marshal bails on a pending
+// exception) → wedge. SurfacePendingException now re-checks + clears at the end.
+//
+// Reference: refs/gjs closure marshalling (gjs_log_exception reports an uncaught
+// signal-handler exception, never wedging the loop).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+test('B1: a nested loop inside a synchronous emit — no wedge + the sync throw propagates', () => {
+  const action = new Gio.SimpleAction({ name: 'closure-exc-b1', enabled: true });
+  let notifyRan = false;
+
+  // A loop-dispatched notify:: handler that throws. It fires inside the NESTED loop
+  // below, while a synchronous emit() is suspended on the stack — the depth must
+  // read 0 there so this throw is surfaced + cleared (not left pending → wedge).
+  action.connect('notify::enabled', () => {
+    notifyRan = true;
+    throw new Error('boom: loop-dispatched notify during a nested iteration');
+  });
+
+  const cancellable = new Gio.Cancellable();
+  cancellable.connect('cancelled', () => {
+    const nested = GLib.MainLoop.new(null, false);
+    // A timeout (loop-dispatched via the trampoline) flips :enabled → emits the
+    // throwing notify, then quits the nested loop.
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1, () => {
+      action.set_enabled(false);
+      nested.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+    // Backstop so a regression cannot hang the nested loop forever.
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
+      nested.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+    nested.run(); // returns cleanly — the loop work left no exception pending
+    // The synchronous handler now throws its OWN error; the depth was restored to
+    // > 0 once the nested loop returned, so it MUST propagate to emit() below.
+    throw new Error('boom: the synchronous handler');
+  });
+
+  assert.throws(
+    () => cancellable.emit('cancelled'),
+    /boom: the synchronous handler/,
+    'the synchronous handler throw propagates out of emit()',
+  );
+  assert.equal(notifyRan, true, 'the loop-dispatched notify fired inside the nested iteration');
+
+  // After the wedge-prone sequence, a fresh loop must still dispatch a timeout.
+  const after = GLib.MainLoop.new(null, false);
+  let laterFired = false;
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5, () => {
+    laterFired = true;
+    after.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
+    after.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+  after.run();
+  assert.equal(laterFired, true, 'the loop survived → a later timeout still fired (no wedge)');
+});
+
+test('B2: a thrown error with a throwing `stack` getter does not wedge the loop', () => {
+  const loop = GLib.MainLoop.new(null, false);
+  let laterFired = false;
+
+  // A timeout that throws an object whose `stack` getter ALSO throws. The
+  // trampoline surfaces it via SurfacePendingException, which reads `.stack` →
+  // re-throws → a NEW pending exception. Without the end-of-function re-clear that
+  // would linger and skip the next callback (its arg-marshal bails on a pending
+  // exception) → the loop never reaches `laterFired`.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5, () => {
+    const err = { message: 'b2-thrown' };
+    Object.defineProperty(err, 'stack', {
+      get() {
+        throw new Error('boom: throwing stack getter');
+      },
+    });
+    throw err;
+  });
+
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 40, () => {
+    laterFired = true;
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+  // Backstop: a regression that wedges the loop hits this cap instead of hanging.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 2000, () => {
+    loop.quit();
+    return GLib.SOURCE_REMOVE;
+  });
+
+  loop.run();
+  assert.equal(laterFired, true, 'the loop survived a handler whose error has a throwing stack getter');
+});

--- a/packages/node-gi/node-gi/test/gi.test.mjs
+++ b/packages/node-gi/node-gi/test/gi.test.mjs
@@ -49,6 +49,36 @@ test('signals via .connect()/.emit()/.disconnect()', () => {
   assert.equal(count, 1);
 });
 
+test('a signal handler receives the emitter as its first arg (GJS parity)', () => {
+  const Gio = requireGi('Gio', '2.0');
+  const c = new Gio.Cancellable();
+  let sawEmitter = null;
+  let argCount = -1;
+  c.connect('cancelled', (...args) => {
+    argCount = args.length;
+    sawEmitter = args[0];
+  });
+  c.emit('cancelled');
+  // The 'cancelled' signal has no params, so the handler gets exactly one arg:
+  // the emitter — and it is the SAME cached, toggle-ref-canonical proxy as `c`.
+  assert.equal(argCount, 1, 'no-param signal still passes the emitter');
+  assert.equal(sawEmitter, c, 'the emitter is the connected-to instance (identity)');
+});
+
+test('notify:: handler receives (object, pspec) — GJS parity', () => {
+  const Gio = requireGi('Gio', '2.0');
+  const action = new Gio.SimpleAction({ name: 'notify-arity', enabled: true });
+  let sawObject = null;
+  let sawPspecName = null;
+  action.connect('notify::enabled', (object, pspec) => {
+    sawObject = object;
+    sawPspecName = pspec ? pspec.name : null;
+  });
+  action.enabled = false;
+  assert.equal(sawObject, action, 'notify emitter is the changed object');
+  assert.equal(sawPspecName, 'enabled', 'notify carries the changed property pspec');
+});
+
 test('a cancel() method drives the cancelled signal', () => {
   const Gio = requireGi('Gio', '2.0');
   const c = new Gio.Cancellable();

--- a/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
+++ b/packages/node-gi/node-gi/test/multilevel-subclass.test.mjs
@@ -90,8 +90,10 @@ test('2-level registered chain: an ancestor and the leaf both compose props + si
   assert.equal(b.bMethod(), 'B:42');
 
   // An A-signal connects + emits on a B instance (signals walk the ancestry).
+  // GJS parity: the handler receives the emitter first, then the signal params.
   let aReceived = null;
-  const aId = b.connect('a-signal', (n) => {
+  const aId = b.connect('a-signal', (emitter, n) => {
+    assert.equal(emitter, b, 'the emitter is the B instance the signal fired on');
     aReceived = n;
   });
   b.emit('a-signal', 5);

--- a/packages/node-gi/node-gi/test/register-class-decorator.test.mjs
+++ b/packages/node-gi/node-gi/test/register-class-decorator.test.mjs
@@ -98,9 +98,10 @@ test('the full target scenario: meta + method + prop + signal + vfunc', () => {
   assert.equal(obj.message, 'changed');
   assert.equal(obj.greet(), 'hello changed');
 
-  // The custom signal connects + emits.
+  // The custom signal connects + emits. GJS parity: emitter first, then params.
   let received = null;
-  const id = obj.connect('pinged', (n) => {
+  const id = obj.connect('pinged', (emitter, n) => {
+    assert.equal(emitter, obj, 'the emitter is the connected-to instance');
     received = n;
   });
   obj.emit('pinged', 42);
@@ -189,7 +190,8 @@ test('a value-returning custom signal returns the handler result', () => {
     class Summer extends GObject.Object {},
   );
   const s = new Summer();
-  s.connect('sum', (a, b) => a + b);
+  // GJS parity: the emitter is the first arg, so the two int params are (a, b).
+  s.connect('sum', (_emitter, a, b) => a + b);
   assert.equal(s.emit('sum', 3, 4), 7);
 });
 

--- a/packages/node-gi/node-gi/test/register-class-props.test.mjs
+++ b/packages/node-gi/node-gi/test/register-class-props.test.mjs
@@ -16,6 +16,7 @@ import {
   callMethod,
   connectSignal,
   emitSignal,
+  isGObjectHandle,
   requireNamespace,
 } from '../index.js';
 
@@ -53,14 +54,17 @@ test('custom signals: void-with-arg and a value-returning signal', () => {
   });
   const o = constructType(Type, {});
 
+  // GJS parity: the raw closure marshal prepends the emitter (the GObject the
+  // signal fired on) as the first arg, then the signal's own params.
   let received = null;
-  connectSignal(o, 'pinged', (s) => {
+  connectSignal(o, 'pinged', (emitter, s) => {
+    assert.equal(isGObjectHandle(emitter), true, 'the emitter is a GObject handle');
     received = s;
   });
   emitSignal(o, 'pinged', ['ping-arg']);
   assert.equal(received, 'ping-arg');
 
-  connectSignal(o, 'sum', (a, b) => a + b);
+  connectSignal(o, 'sum', (_emitter, a, b) => a + b);
   assert.equal(emitSignal(o, 'sum', [3, 4]), 7);
 });
 
@@ -96,8 +100,12 @@ test('property change emits notify', () => {
   });
   const o = constructType(Type, {});
   let notified = false;
-  connectSignal(o, 'notify::value', () => {
+  // GJS parity: a notify:: handler is `(object, pspec) => …` — the emitter first,
+  // then the GParamSpec of the changed property.
+  connectSignal(o, 'notify::value', (emitter, pspec) => {
     notified = true;
+    assert.equal(isGObjectHandle(emitter), true, 'notify emitter is the GObject');
+    assert.equal(pspec.name, 'value', 'notify carries the changed property pspec');
   });
   setProperty(o, 'value', 42);
   assert.equal(getProperty(o, 'value'), 42);

--- a/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
+++ b/packages/node-gi/node-gi/test/registerclass-inplace.test.mjs
@@ -64,9 +64,11 @@ test('static{} registerClass(meta, X) makes X itself the registered GType', () =
   obj.label = 'changed';
   assert.equal(obj.greet(), 'hi changed');
 
-  // The declared signal connects + emits on the registered type.
+  // The declared signal connects + emits on the registered type. GJS parity: the
+  // handler receives the emitter first, then the signal's own params.
   let received = null;
-  const id = obj.connect('pinged', (n) => {
+  const id = obj.connect('pinged', (emitter, n) => {
+    assert.equal(emitter, obj, 'the emitter is the connected-to instance');
     received = n;
   });
   obj.emit('pinged', 7);

--- a/packages/node-gi/node-gi/test/signals.test.mjs
+++ b/packages/node-gi/node-gi/test/signals.test.mjs
@@ -11,8 +11,25 @@ import {
   connectSignal,
   emitSignal,
   disconnectSignal,
+  isGObjectHandle,
   requireNamespace,
 } from '../index.js';
+
+test('the handler receives the emitter as its first arg (GJS parity)', () => {
+  requireNamespace('Gio', '2.0');
+  const c = newObject('Gio', 'Cancellable', {});
+  let argCount = -1;
+  let emitterIsGObject = false;
+  connectSignal(c, 'cancelled', (...args) => {
+    argCount = args.length;
+    emitterIsGObject = isGObjectHandle(args[0]);
+  });
+  emitSignal(c, 'cancelled');
+  // 'cancelled' has no params → the handler gets exactly one arg, the emitter
+  // (a GObject handle), matching GJS which passes the emitter first.
+  assert.equal(argCount, 1, 'no-param signal still passes the emitter');
+  assert.equal(emitterIsGObject, true, 'the first arg is the emitter GObject');
+});
 
 test('connect + emit invokes the JS callback', () => {
   requireNamespace('Gio', '2.0');

--- a/packages/node-gi/node-gi/test/variant.test.mjs
+++ b/packages/node-gi/node-gi/test/variant.test.mjs
@@ -219,8 +219,10 @@ test('e2e: SimpleAction state round-trips through built Variants + the change-st
 
   // The change-state signal carries the requested value Variant (marshalled
   // through GValue → wrapped) — observe it, then let the default handler apply.
+  // GJS parity: `change-state` handlers are `(action, value) => …`.
   let observed = null;
-  action.connect('change-state', (value) => {
+  action.connect('change-state', (emitter, value) => {
+    assert.equal(emitter, action, 'the emitter is the action that emitted change-state');
     observed = value.deepUnpack();
     action.set_state(value); // commit (SimpleAction has no default change-state handler)
   });


### PR DESCRIPTION
## PART A — signal-callback emitter argument (GJS parity)

node-gi's `JsClosureMarshal` omitted the emitter (`param_values[0]`) and passed only the signal's own params, so a GJS-style positional handler `obj.connect('row-selected', (listbox, row) => …)` / `_onRowSelected(_listbox, row)` got the wrong args (the row landed in the listbox slot). This broke the GJS Adwaita storybook's sidebar selection on Node and was a real GJS-compat bug.

The marshal now **prepends the emitter** as the first JS arg, then the signal params — matching GJS. The emitter is itself a GObject arg, so the existing `wrapReturn` turns it into the cached, toggle-ref-canonical instance. For `notify::x` the args are therefore `(object, pspec)`.

Every handler in the package + `example-gtk` that assumed the no-emitter shape was updated to the emitter-first arity, with new identity / `(object, pspec)` assertions:
- `gi.test.mjs` — emitter is the same proxy as the connected-to instance; `notify::` → `(object, pspec)`
- `signals.test.mjs` — raw `connectSignal` passes the emitter (a GObject handle) first
- `register-class-props.test.mjs` — `(emitter, s)` / `(_emitter, a, b)` + `notify::value` → `(object, pspec.name === 'value')`
- `registerclass-inplace` / `register-class-decorator` / `multilevel-subclass` / `variant` (`change-state` → `(action, value)`)
- `example-gtk/src/app.ts` — comment updated (handlers print closure constants, unaffected)

## PART B — closure exception hardening (the #675 review nits)

1. **`g_syncEmitDepth` save/restore.** The global counter conflated "an `emitSignal()` is on the stack" with "THIS dispatch is synchronous". A synchronous handler that re-enters the GLib loop (a nested `loop.run()`) made a loop-dispatched signal that throws during the nested iteration look synchronous (depth > 0) → its exception was left pending → `DrainMicrotasks` early-returns → wedge. The idle/timeout/async trampoline now pins the depth to 0 across the loop-dispatch boundary (RAII), so loop-dispatched closures evaluate at depth 0 while the suspended outer `emit()` still propagates its own handler's throw.
2. **`SurfacePendingException` re-clear.** It read `ex.stack` / coerced `ex` to a string — both can run user JS (a throwing `stack` getter / `toString`) that leaves a NEW pending exception never re-cleared → the caller returned env-dirty → wedge. It now re-checks + clears at the end.
3. **Doc-only.** A code comment at the depth-0 branch states the by-design, GJS-aligned contract: a depth-0 handler throw (incl. `notify::` via `g_object_set`, inline C emits like `action.activate()`) is logged + swallowed, not rethrown to the trigger.

## Tests

- New `test/closure-exception.test.mjs` (headless, GLib+Gio): B1 nested-loop-no-wedge + sync-propagation; B2 a thrown error with a throwing `stack` getter does not wedge the loop. **Verified B2 fails (loop wedges, 2004 ms) without the re-clear and passes (40 ms) with it.**
- Full suite green: `node --test` 250 pass / 11 skipped, `--expose-gc` 261 pass, GTK/Adw smoke 19 pass under Wayland (incl. the template-callback consumer).

## End-to-end validation

Drove a sidebar `row-selected` on the Adwaita storybook built `--app node`: the handler received exactly `(listbox, row)` with `args[0] === listbox`, `args[1] === target row`, selection applied, clean quit. The old bug would have mis-bound row → listbox.

## For review

- The emitter-arg semantics match GJS for plain signals AND `notify::`/detailed (`notify` → `(object, pspec)`, verified).
- The `g_syncEmitDepth` reset is scoped to non-CALL-scope trampoline callbacks (a CALL-scope callback keeps the ambient depth so its exception still reaches the JS invoke).
- Side note (out of scope, separate marshalling gap): `app.get_windows()` returns **unwrapped** GList elements — the probe used `get_active_window()` (a single wrapped GObject) instead.

https://claude.ai/code/session_017eAz4v5KNPbDaY6GPKbRTH