### PR TITLE
fix(adwaita-storybook): stop build leaking compiled JS into src/

### DIFF
--- a/packages/web/adwaita-storybook/README.md
+++ b/packages/web/adwaita-storybook/README.md
@@ -52,6 +52,8 @@ mountStorybook(document.body, {
 
 `mountStorybook` builds the full chrome — a sidebar of stories grouped by category, a preview pane, and a controls panel that renders the story's `controls` as live-bound adwaita-web rows.
 
+The package entry is TypeScript (`src/index.ts`), consumed via a TypeScript-compiling build — `gjsify build --app browser` / the `gjsifyBrowser()` Vite preset (or any Vite/bundler setup), same as `@gjsify/adwaita-web`. Type declarations are shipped pre-built at `lib/types/index.d.ts`, so `gjsify tsc` consumers resolve the package's types without compiling its source.
+
 ## Driving it programmatically
 
 `mountStorybook` exposes a small control surface on `window.__storybook` (`listStories`, `openStory`, `getCurrentStory`, `setArg`, `getArgs`), so a host browser's MCP `eval_js` (see [`@gjsify/devtools-browser`](../../framework/devtools-browser)) can drive and screenshot stories without an in-page devtools channel.

--- a/packages/web/adwaita-storybook/package.json
+++ b/packages/web/adwaita-storybook/package.json
@@ -3,11 +3,11 @@
     "version": "0.14.0",
     "description": "Browser renderer for the @gjsify/stories contract — the web counterpart of @gjsify/storybook, built on @gjsify/adwaita-web",
     "type": "module",
-    "main": "src/index.ts",
-    "types": "src/index.ts",
+    "main": "./src/index.ts",
+    "types": "./lib/types/index.d.ts",
     "exports": {
         ".": {
-            "types": "./src/index.ts",
+            "types": "./lib/types/index.d.ts",
             "default": "./src/index.ts"
         }
     },
@@ -18,8 +18,7 @@
     "scripts": {
         "clear": "rm -rf lib tsconfig.tsbuildinfo || exit 0",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify run build:gjsify && gjsify run build:types",
-        "build:gjsify": "gjsify build --library 'src/**/*.ts' --exclude 'src/**/*.spec.ts'",
+        "build": "gjsify run build:types",
         "build:types": "gjsify tsc"
     },
     "keywords": [


### PR DESCRIPTION
## Problem

`@gjsify/adwaita-storybook`'s `build:gjsify` step ran
`gjsify build --library 'src/**/*.ts'`, which compiles output **alongside**
its sources: `BuildAction.buildLibrary` (`packages/infra/cli/src/actions/build.ts`)
derives the library output dir from `dirname(lib.module ?? lib.main)`, and
`main` was `src/index.ts`. Every build therefore wrote compiled JS **into
`src/`** — duplicate `*2.js` / plain `.js` siblings for each module plus a
`src/_virtual/_rolldown/` tree:

```
?? src/_virtual/            ?? src/app.js    ?? src/app2.js
?? src/controls.js          ?? src/controls2.js
?? src/index.js             ?? src/registry.js  ?? src/registry2.js
?? src/story-element.js     ?? src/story-element2.js
?? src/styles.js            ?? src/styles2.js
?? src/types.js             ?? src/types2.js
```

Unlike `@gjsify/adwaita-web`, this package has **no SCSS build** (its
`styles.ts` is hand-written) and **no `src/**/*.js` gitignore mask**, so the
leak surfaced as untracked files rather than being hidden.

## Fix

Same root-cause class as the `@gjsify/adwaita-web` fix in #687 — mirror it:

- Drop the leaking `build:gjsify` step (`build` = `build:types` only), so
  nothing compiles into `src/`.
- Keep `main` / `exports["."].default` at the source entry `./src/index.ts`.
  All consumers compile TypeScript (`gjsify build --app browser` / the
  `gjsifyBrowser()` Vite preset), so the raw-TS entry **is** the intended
  runtime entry — no separate JS bundle is needed. The runtime entry is
  byte-identical (no `src/` file was touched).
- Point `types` / `exports["."].types` at the already-built
  `./lib/types/index.d.ts` (emitted by `build:types` = `gjsify tsc`), so
  `gjsify tsc` consumers resolve types without compiling the source.

No CLI change here — this is the per-package fix, mirroring #687.

## Verification

- Clean rebuild (`gjsify workspace @gjsify/adwaita-storybook build -d`) leaves
  `git status --short packages/web/adwaita-storybook/` clean apart from the two
  intended edits; `src/` holds only `.ts` again; `lib/types/index.d.ts` is
  produced.
- `gjsify workspace @gjsify/adwaita-storybook check` — exit 0.
- `node scripts/audit-runtimes.mjs --check --strict` — OK.
- Stylesheet unchanged: `injectStorybookStyles()` / `STORYBOOK_WEB_CSS` in
  `src/styles.ts` still self-inject on mount.

## Follow-up (out of scope here)

The true fix belongs in the CLI's `BuildAction.buildLibrary`: when a package's
`main` points inside a source dir, `--library` output should not co-locate with
the sources (or the library dir should never resolve to a directory containing
`.ts` sources). Doing that centrally would stop any package from leaking build
output into a source dir — but this PR keeps to the per-package fix mirroring
#687.