### PR TITLE
fix(devtools-mcp): decouple cdp profile from peer types

### DIFF
--- a/packages/framework/devtools-mcp/src/profiles/cdp.ts
+++ b/packages/framework/devtools-mcp/src/profiles/cdp.ts
@@ -13,15 +13,35 @@
 import GLib from '@girs/glib-2.0';
 import { z } from 'zod';
 
-// `@gjsify/devtools-cdp` is an OPTIONAL PEER (Tier 3, experimental). It is kept
-// OUT of the static import graph so `@gjsify/devtools-mcp` can stay Tier 2 —
-// only the CDP profile pulls the experimental package, and only when it is
-// actually used (ADR 0003 dependency-direction rule). The type-only import
-// below is erased at build time and creates no runtime edge; the value surface
-// is loaded lazily in `loadDevtoolsCdp()`.
-import type { CdpJsType } from '@gjsify/devtools-cdp';
-
 import type { DevtoolsToolProfile, McpToolContext } from '../profile.js';
+
+// `@gjsify/devtools-cdp` is an OPTIONAL PEER (Tier 3, experimental) loaded lazily
+// in `loadDevtoolsCdp()`. It is kept OUT of the static import graph entirely — not
+// even at the TYPE level — so `@gjsify/devtools-mcp` compiles WITHOUT the peer being
+// present or pre-built (build-order-independent) and stays Tier 2 (ADR 0003). The
+// narrow surface we use is mirrored locally below; the real package's shapes are the
+// source of truth — keep these compatible.
+type CdpJsType = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'unknown';
+interface CdpToolParam {
+    name: string;
+    jsType: CdpJsType;
+    enum?: string[];
+    description?: string;
+    optional?: boolean;
+}
+interface CdpToolDescriptor {
+    name: string;
+    method: string;
+    description?: string;
+    parameters: CdpToolParam[];
+}
+interface DevtoolsCdpModule {
+    PROTOCOL_SPEC: unknown;
+    generateCdpTools(
+        spec: unknown,
+        options: { include: (domain: string, command: string) => boolean },
+    ): CdpToolDescriptor[];
+}
 
 const strv = (value: string): GLib.Variant => GLib.Variant.new_string(value);
 const instanceArg = {
@@ -51,9 +71,13 @@ const CURATED = new Set<string>([
  * (and buildable) without it — the generic / storybook / browser profiles never
  * touch this path, so they do not require the experimental package.
  */
-async function loadDevtoolsCdp(): Promise<typeof import('@gjsify/devtools-cdp')> {
+async function loadDevtoolsCdp(): Promise<DevtoolsCdpModule> {
     try {
-        return await import('@gjsify/devtools-cdp');
+        // The specifier is widened to `string` so tsc does not statically resolve
+        // the optional peer's (possibly-unbuilt or absent) declarations; the module
+        // is loaded at runtime and typed via the local DevtoolsCdpModule mirror.
+        const cdpModuleId: string = '@gjsify/devtools-cdp';
+        return (await import(cdpModuleId)) as DevtoolsCdpModule;
     } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);
         throw new Error(


### PR DESCRIPTION
**Fixes the v0.15.0 release build failure.** The `release.yml` publish for v0.15.0 failed at the *Build packages* step:
```
[@gjsify/devtools-mcp] src/profiles/cdp.ts:22 — TS2307: Cannot find module '@gjsify/devtools-cdp'
                       src/profiles/cdp.ts:208 — TS7006: Parameter 'd'/'c' implicitly has an 'any' type
```
(so nothing published at 0.15.0 — npm is still at 0.14.0; the manual `@gjsify/adwaita-core@0.14.0` bootstrap is live.)

## Root cause
#689 made `@gjsify/devtools-cdp` (Tier 3) an optional peer / lazy `import()` to drop the hard dep edge and restore devtools-mcp to Tier 2. But `cdp.ts` still coupled to the peer **at compile time** — `import type { CdpJsType }` and `loadDevtoolsCdp(): Promise<typeof import('@gjsify/devtools-cdp')>`. devtools-cdp's `types` resolve to its built `lib/types` (not `src`), and since it's no longer a *production* dependency, the prod-dep topological build order no longer builds it before devtools-mcp → its `.d.ts` is absent → TS2307 (and `generateCdpTools` falls to `any` → TS7006). The **selective PR CI masked it** (devtools-cdp happened to be built); only a clean full build fails (the `reference_clean_build_masks_ci` gotcha).

## Fix
Complete #689's stated intent ("kept OUT of the static import graph") by making devtools-mcp **compile-time-independent** of the optional Tier-3 peer:
- Mirror the narrow surface locally (`CdpJsType`, `CdpToolParam`, `CdpToolDescriptor`, `DevtoolsCdpModule`) — no `import type` from the peer.
- Widen the dynamic-import specifier to `string` (`const cdpModuleId: string = '@gjsify/devtools-cdp'`) so tsc does not statically resolve the peer's (unbuilt/absent) declarations; it is still loaded lazily at runtime and cast to the local mirror.

No package.json / dependency changes → devtools-mcp stays Tier 2 (audit green). Runtime behavior unchanged (lazy load + clear error when the peer is absent).

## Verified
- **Full clean build** (`gjsify run build`, all 99 packages, facades built first) → **exit 0, zero TS errors** — this is the condition the release build runs and the original CI masked.
- `scripts/audit-runtimes.mjs --check --strict` → OK (devtools-mcp Tier 2, dependency-direction holds).

After merge, the release is re-cut as v0.15.1.