### PR TITLE
fix: restore docs deploy build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  # Pull the private ci-fedora image from ghcr (same as main.yml / release.yml).
+  packages: read
 
 concurrency:
   group: pages
@@ -22,11 +24,15 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     container:
-      image: fedora:43
+      # Prebuilt CI image (`.docker/ci-fedora.Dockerfile`) baking gjs + the
+      # full GNOME devel stack AND `libatomic` — the same image main.yml /
+      # release.yml standardised on. `libatomic.so.1` is required by the
+      # Node >= 26 binary that actions/setup-node downloads; the bare
+      # `fedora:43` container lacked it, so the docs build died at
+      # `node: error while loading shared libraries: libatomic.so.1`.
+      # Using the image also skips the 3-5 min `dnf install` at job start.
+      image: ghcr.io/gjsify/ci-fedora:44
     steps:
-      - name: Install container prerequisites
-        run: dnf install -y git tar xz findutils gjs glib2-devel gobject-introspection-devel gtk4-devel libsoup3-devel libepoxy-devel gdk-pixbuf2-devel libadwaita-devel blueprint-compiler meson vala gcc pkgconf
-
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/packages/framework/storybook-core/package.json
+++ b/packages/framework/storybook-core/package.json
@@ -8,6 +8,7 @@
     "exports": {
         ".": {
             "types": "./lib/types/index.d.ts",
+            "browser": "./src/index.ts",
             "default": "./lib/esm/index.js"
         }
     },


### PR DESCRIPTION
## Problem

`deploy-docs.yml` has been red since 2026-06-25 — two stacked failures the second masked by the first:

1. **libatomic** — the job ran on a bare `fedora:43` container with a manual `dnf install` that omitted `libatomic`. `actions/setup-node` downloads Node ≥ 26, whose binary links `libatomic.so.1`, so the docs build died at load with `node: error while loading shared libraries: libatomic.so.1`.
2. **storybook-core resolution** — once libatomic was fixed, the Astro build failed with `[commonjs--resolver] Failed to resolve entry for package "@gjsify/storybook-core"`. Every workspace package the site imports resolves from **source** on browser builds (showcases → `src/browser`, `adwaita-web`/`adwaita-storybook` → `src/index`, `stories` → `browser:src`), but `@gjsify/storybook-core` had no `browser` export condition, so a browser bundle resolved it to `lib/esm/index.js` — absent on a fresh install (install ≠ build).

## Fix

- **Container**: point the docs build at the prebuilt `ghcr.io/gjsify/ci-fedora:44` image (bakes `libatomic` before setup-node + the full GNOME devel stack — the same image `main.yml`/`release.yml` standardised on) and drop the redundant `dnf install`. Add `packages: read` so the job can pull the private image.
- **storybook-core**: add `"browser": "./src/index.ts"` to its exports (matching its sibling `@gjsify/stories`). It's `runtimes.browser: polyfill` and pure TS (zero platform imports), so browser builds now resolve it from source — no lib build needed. GJS/Node keep the `default` → lib resolution unchanged.

## Verification

- `workflow_dispatch` on this branch: **Build Documentation job fully green** (image pull, install, `Build documentation site`, upload all succeed). The `Deploy to GitHub Pages` job fails only on the environment branch policy (Pages deploys are restricted to `main`) — expected from a feature branch; it runs from `main` on merge.
- Locally reproduced the fresh-install state (hid `storybook-core`/`stories` `lib/`) and confirmed `gjsify workspace @gjsify/website build` builds all 36 pages from source.

https://claude.ai/code/session_01M447HZHo6YgQem4K3TXq9r