### PR TITLE
fix: drop browser->src export in stories, storybook-core

### DIFF
--- a/packages/framework/stories/package.json
+++ b/packages/framework/stories/package.json
@@ -8,7 +8,6 @@
     "exports": {
         ".": {
             "types": "./lib/types/index.d.ts",
-            "browser": "./src/index.ts",
             "default": "./lib/esm/index.js"
         }
     },

--- a/packages/framework/storybook-core/package.json
+++ b/packages/framework/storybook-core/package.json
@@ -8,7 +8,6 @@
     "exports": {
         ".": {
             "types": "./lib/types/index.d.ts",
-            "browser": "./src/index.ts",
             "default": "./lib/esm/index.js"
         }
     },


### PR DESCRIPTION
## Problem

A native GJS app that consumes `@gjsify/storybook` and bundles with `--app gjs` crashes at runtime:

```
JS ERROR: ImportError: Module not found: @gjsify/storybook-core
```

(surfaced by the PixelRPG map-editor after its bump to 0.16.5.)

## Root cause

`@gjsify/stories` and `@gjsify/storybook-core` declare `exports["."].browser = "./src/index.ts"` but ship `files: ["lib"]` — so `src/` is **not in the published tarball**. The `--app gjs` build resolves `conditionNames: ['browser', 'import']` (browser-first), hits the missing `./src/index.ts`, and **externalizes** the bare specifier — leaving `import … from "@gjsify/storybook-core"` in the bundle, which GJS's ESM loader (no node_modules walker for bare specifiers) can't resolve.

It's invisible inside the monorepo (where `src/` exists) — a classic *works-in-workspace, breaks-when-published* bug. `@gjsify/storybook` itself inlines fine because it has no `browser` condition.

## Fix

Remove the stray `browser` condition from both packages, so they resolve to `default: ./lib/esm/index.js` — matching every other cross-runtime package (`@gjsify/dom-events`, `@gjsify/abort-controller` carry no `browser` condition; their `lib/esm` is browser-compatible).

## Verification

Against the map-editor: patched the installed copies the same way + clean rebuild → both `@gjsify/storybook-core` and `@gjsify/stories` now **inline** (no bare import left in `org.pixelrpg.maker`); `gi://`/`cairo`/`system`/`gettext` externals unchanged.

## Follow-up

A CI guard that no export **condition target** points outside `files[]` would catch this class of bug (sibling to `tests/e2e/publish-files-glob`). Noted, not in this PR.

Ships to consumers on the next release train.