### PR TITLE
feat(devtools): confirm export with a log + regression e2e

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -950,6 +950,12 @@ The package ships the native Adwaita app shell (runAsync lifecycle + devtools/CS
 - buchhaltung (`app/src/frontends/desktop`) — replace its hand-rolled `application.ts` + nav split view + `views/util.ts` `loadIntoStack`/`LoadToken` + `toast.ts` + dialogs with the package (both currently consume the published `@gjsify/*`, so this follows the release train).
 - eco-retrofit (`cli/src/app`) — same; this also fixes its latent `Adw.Application.run(null)` → `runAsync()` hang class.
 
+### Follow-up — css-as-string bare-`@import` resolution (GJS CLI) + stale maker bundle
+
+`@gjsify/devtools` exports `org.gjsify.Devtools` correctly in every app config — verified rigorously (real child object + interface present + `GetStatus` call) under `HANDLES_COMMAND_LINE` + an app-owned sibling object exported first, guarded by `tests/e2e/devtools-export`. The PixelRPG maker's "devtools absent" symptom was a STALE app bundle: `apps/maker-gjs/src/application.ts` calls `installDevtools(this)`, but the committed `apps/maker-gjs/org.pixelrpg.maker` predated that line (its `onStartup` goes `initControlInterface()` → `cleanupOrphanedPublishers()` with no devtools call; @gjsify/devtools code survives tree-shaking there only via the storybook's own `installDevtools`). `installDevtools` now logs a `[gjsify-devtools] exported …` confirmation so "did devtools come up?" is answerable from the app's stderr (its absence is the diagnostic).
+
+Deferred blocker (why the stale bundle got committed): the maker fails to rebuild under the **global GJS CLI** — `gjsify-css-as-string` throws on `apps/maker-gjs/src/application.css`'s bare `@import "@pixelrpg/gjs/index.css"` because lightningcss `bundleAsync` has no resolver for a bare node_modules package specifier in `@import`. It builds under the **Node CLI** (`npx gjsify`, the maker's documented build path), so this is a GJS-CLI-vs-Node-CLI css-resolution gap. Fix at the core: give the css-as-string plugin's lightningcss config a resolver for bare `@import` specifiers (mirroring the JS resolver) so `--app gjs` builds match the Node CLI; then rebuild + recommit the maker bundle (map-editor repo) so the devtools call actually ships.
+
 ### Architecture backlog — ADRs 0001–0008 (accepted 2026-07-01)
 
 Decisions in [docs/adr/](docs/adr/README.md), prioritized backlog + rationale in [docs/reports/2026-07-01-architecture-review.md](docs/reports/2026-07-01-architecture-review.md). Remaining work (strike per-item as it lands; delete this entry when all ADRs are implemented or superseded):

--- a/packages/framework/devtools/src/install.ts
+++ b/packages/framework/devtools/src/install.ts
@@ -3,6 +3,7 @@
 
 import GLib from '@girs/glib-2.0';
 import type Gtk from '@girs/gtk-4.0';
+import { DEVTOOLS_INTERFACE } from '@gjsify/devtools-protocol';
 import { DevtoolsService } from './devtools-service.js';
 import type { InstallDevtoolsOptions } from './extension.js';
 
@@ -48,7 +49,19 @@ export function installDevtools(app: Gtk.Application, options: InstallDevtoolsOp
     const connection = app.get_dbus_connection();
     const basePath = app.get_dbus_object_path();
     if (connection && basePath) {
-        service.export(connection, `${basePath}/devtools`);
+        const objectPath = `${basePath}/devtools`;
+        service.export(connection, objectPath);
+        // Confirm the export so "did devtools actually come up?" is answerable
+        // from the app's own stderr. installDevtools only reaches here when
+        // devtools is ENABLED (gate passed / opts.enabled), so this line only
+        // appears when the operator explicitly turned devtools on — exactly when
+        // they want the confirmation. Its ABSENCE is the diagnostic: no line ⇒
+        // installDevtools was never called (e.g. a stale app bundle) or the gate
+        // was off — as opposed to the previous silence, where a present-but-not-
+        // exported object was indistinguishable from a not-installed one.
+        console.log(
+            `[gjsify-devtools] exported ${DEVTOOLS_INTERFACE} at ${objectPath} (dest ${app.get_application_id() ?? '?'})`,
+        );
     } else {
         console.error(
             '[gjsify-devtools] no session-bus connection yet — call installDevtools() from the GtkApplication "startup" handler',

--- a/tests/e2e/devtools-export/repro.ts
+++ b/tests/e2e/devtools-export/repro.ts
@@ -1,0 +1,66 @@
+// E2E fixture: a minimal Adwaita app that installs @gjsify/devtools, built to a
+// GJS bundle by run.mjs and driven over DBus. It reproduces the exact app config
+// the PixelRPG maker uses — `HANDLES_COMMAND_LINE` + an app-owned sibling DBus
+// object exported BEFORE devtools — because that config was (wrongly) suspected
+// of making `DevtoolsService.export` fail silently. It does not: this fixture
+// proves `org.gjsify.Devtools` exports + answers a method call under every
+// combination of those two knobs (REPRO_CMDLINE / REPRO_SIBLING).
+//
+// The maker's real "devtools absent" symptom was a STALE app bundle (its source
+// called installDevtools() but the committed bundle predated that line), NOT a
+// @gjsify/devtools bug — so this guards the export path against a genuine future
+// regression and documents the correct diagnosis.
+
+import Adw from '@girs/adw-1';
+import Gio from '@girs/gio-2.0';
+import GLib from '@girs/glib-2.0';
+import type GObject from '@girs/gobject-2.0';
+import { installDevtools } from '@gjsify/devtools';
+
+const useCmdline = GLib.getenv('REPRO_CMDLINE') === '1';
+const useSibling = GLib.getenv('REPRO_SIBLING') === '1';
+
+// A trivial app-owned interface, exported at <base>/control BEFORE devtools — the
+// maker exports its `org.pixelrpg.maker.Control` this way.
+const CONTROL_XML =
+    '<node><interface name="org.example.Control"><method name="Ping"><arg type="s" direction="out"/></method></interface></node>';
+const controlImpl = { Ping: () => 'pong' };
+
+const app = new Adw.Application({
+    application_id: 'org.example.reprotest',
+    flags: useCmdline ? Gio.ApplicationFlags.HANDLES_COMMAND_LINE : Gio.ApplicationFlags.DEFAULT_FLAGS,
+});
+
+app.connect('startup', () => {
+    const conn = app.get_dbus_connection();
+    const base = app.get_dbus_object_path();
+    printerr(`[repro] startup conn=${!!conn} base=${base} cmdline=${useCmdline} sibling=${useSibling}`);
+    if (useSibling && conn && base) {
+        try {
+            const control = Gio.DBusExportedObject.wrapJSObject(CONTROL_XML, controlImpl as unknown as GObject.Object);
+            control.export(conn, `${base}/control`);
+            printerr(`[repro] control exported at ${base}/control`);
+        } catch (error) {
+            printerr(`[repro] control export FAILED: ${error}`);
+        }
+    }
+    try {
+        // enabled:true bypasses the GJSIFY_DEVTOOLS env gate — this fixture tests
+        // the EXPORT path itself, independent of the gate.
+        const service = installDevtools(app, { enabled: true });
+        printerr(`[repro] installDevtools -> ${service ? 'service' : 'null'}`);
+    } catch (error) {
+        printerr(`[repro] installDevtools THREW: ${error}`);
+    }
+    printerr(`[repro] READY ${base}`);
+});
+
+app.connect('command_line', () => {
+    app.activate();
+    return 0;
+});
+app.connect('activate', () => {
+    app.hold();
+});
+
+app.run([]);

--- a/tests/e2e/devtools-export/run.mjs
+++ b/tests/e2e/devtools-export/run.mjs
@@ -1,0 +1,175 @@
+// E2E: @gjsify/devtools exports `org.gjsify.Devtools` over DBus under the same
+// app config the PixelRPG maker uses (`HANDLES_COMMAND_LINE` + an app-owned
+// sibling object exported first).
+//
+// Backstory — why this test exists: the maker's running binary showed no
+// `org.gjsify.Devtools` object, and it was first (mis)diagnosed as
+// `DevtoolsService.export` silently failing under that config. That diagnosis
+// rested on a FALSE-POSITIVE presence check: `gdbus introspect <path>/devtools`
+// returns a phantom container node (exit 0) even when NOTHING is exported there,
+// so "introspect succeeds" ≠ "interface exported". The real signal is (a) a real
+// child node under the app's base path, (b) the `org.gjsify.Devtools` INTERFACE
+// present at <base>/devtools, and (c) a method CALL returning data. Checked
+// rigorously, devtools exports fine in every config — the maker symptom was a
+// STALE app bundle (source called installDevtools(), the committed bundle
+// predated it). This test locks in the correct export behaviour + the
+// installDevtools "exported ..." confirmation log added alongside it.
+//
+// SKIP (no false failures off a capable host): non-Linux, no `gjs`, no
+// `dbus-run-session`, no committed CLI bundle, no `@gjsify/rolldown-native`
+// prebuild for the arch, the workspace `node_modules` isn't installed, or the
+// host has no loadable `Adw-1` typelib (the fixture is a real Adwaita app).
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..', '..');
+const CLI_BUNDLE = join(REPO_ROOT, 'packages', 'infra', 'cli', 'dist', 'cli.gjs.mjs');
+const WS_MODULES = join(REPO_ROOT, 'node_modules');
+const REPRO_TS = join(__dirname, 'repro.ts');
+
+const DEST = 'org.example.reprotest';
+const BASE = '/org/example/reprotest';
+
+function archDir() {
+    if (process.arch === 'x64') return 'linux-x86_64';
+    if (process.arch === 'arm64') return 'linux-aarch64';
+    return null;
+}
+
+function hasCmd(cmd, args = ['--version']) {
+    const r = spawnSync(cmd, args, { stdio: 'ignore' });
+    return r.status === 0 && r.error === undefined;
+}
+
+function hasAdw() {
+    // The fixture is a real Adwaita app — RUN needs a loadable Adw-1 typelib.
+    const r = spawnSync('gjs', ['-c', 'imports.gi.versions.Adw = "1"; imports.gi.Adw;'], { stdio: 'ignore' });
+    return r.status === 0 && r.error === undefined;
+}
+
+const arch = archDir();
+const PREBUILD = arch ? join(REPO_ROOT, 'packages', 'infra', 'rolldown-native', 'prebuilds', arch) : null;
+
+const SKIP =
+    process.platform !== 'linux' ||
+    !arch ||
+    !hasCmd('gjs') ||
+    !hasCmd('dbus-run-session', ['--help']) ||
+    !hasCmd('gdbus', ['--help']) ||
+    !existsSync(CLI_BUNDLE) ||
+    !PREBUILD ||
+    !existsSync(join(PREBUILD, 'GjsifyRolldown-1.0.typelib')) ||
+    !existsSync(join(WS_MODULES, '@gjsify')) ||
+    !existsSync(join(WS_MODULES, 'rolldown')) ||
+    !hasAdw();
+
+// A bash driver run INSIDE a fresh `dbus-run-session` (its own bus → no stale
+// well-known-name owner from a prior run). Launches the built fixture, waits for
+// it on the bus, then emits machine-readable KEY=value lines the test asserts on.
+// $1 = fixture bundle path.
+const DRIVER = String.raw`
+set -u
+BUNDLE="$1"
+log="$(mktemp)"
+env REPRO_CMDLINE=1 REPRO_SIBLING=1 gjs -m "$BUNDLE" >"$log" 2>&1 &
+pid=$!
+on_bus=""
+for i in $(seq 1 80); do
+  if gdbus introspect --session --dest ${DEST} --object-path ${BASE} >/dev/null 2>&1; then on_bus=1; break; fi
+  sleep 0.25
+done
+if [ -z "$on_bus" ]; then
+  echo "APP_ON_BUS=no"
+  echo "APP_LOG_BEGIN"; cat "$log"; echo "APP_LOG_END"
+  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+  exit 0
+fi
+echo "APP_ON_BUS=yes"
+# (a) real exported child object (NOT the phantom-node false positive)
+if gdbus introspect --session --dest ${DEST} --object-path ${BASE} 2>&1 | grep -qE "node devtools"; then
+  echo "CHILD_DEVTOOLS=yes"; else echo "CHILD_DEVTOOLS=no"; fi
+# (b) the interface actually present at <base>/devtools
+if gdbus introspect --session --dest ${DEST} --object-path ${BASE}/devtools 2>&1 | grep -qE "interface org.gjsify.Devtools"; then
+  echo "IFACE=yes"; else echo "IFACE=no"; fi
+# (c) a method call returns data
+status="$(gdbus call --session --dest ${DEST} --object-path ${BASE}/devtools --method org.gjsify.Devtools.GetStatus 2>&1)"
+echo "GETSTATUS_BEGIN"; echo "$status"; echo "GETSTATUS_END"
+# the installDevtools confirmation log (observability)
+if grep -q "gjsify-devtools] exported org.gjsify.Devtools" "$log"; then echo "EXPORT_LOG=yes"; else echo "EXPORT_LOG=no"; fi
+grep -q "\[repro\] installDevtools -> service" "$log" && echo "INSTALL_RETURNED=service" || echo "INSTALL_RETURNED=null"
+kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+exit 0
+`;
+
+function parse(out) {
+    const kv = {};
+    for (const line of out.split('\n')) {
+        const m = line.match(/^([A-Z_]+)=(.*)$/);
+        if (m) kv[m[1]] = m[2];
+    }
+    const status = out.match(/GETSTATUS_BEGIN\n([\s\S]*?)\nGETSTATUS_END/)?.[1] ?? '';
+    return { kv, status };
+}
+
+describe('@gjsify/devtools export over DBus', { skip: SKIP, timeout: 5 * 60 * 1000 }, () => {
+    let tmpDir;
+    let bundle;
+
+    before(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-devtools-'));
+        bundle = join(tmpDir, 'repro.gjs.mjs');
+        // Build the fixture with the committed Node-free GJS CLI bundle, resolving
+        // @gjsify/devtools + @girs/* from the workspace (cwd walks up to REPO_ROOT).
+        const r = spawnSync(
+            'gjs',
+            ['-m', CLI_BUNDLE, 'build', REPRO_TS, '--app', 'gjs', '--outfile', bundle, '--no-minify'],
+            {
+                cwd: __dirname,
+                encoding: 'utf-8',
+                timeout: 4 * 60 * 1000,
+                env: {
+                    ...process.env,
+                    HOME: tmpDir,
+                    XDG_CACHE_HOME: join(tmpDir, '.cache'),
+                    GI_TYPELIB_PATH: PREBUILD,
+                    LD_LIBRARY_PATH: PREBUILD,
+                    GJSIFY_BUILD_CACHE: '0',
+                },
+            },
+        );
+        const log = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+        assert.equal(r.status, 0, `building the devtools fixture must succeed. Output:\n${log}`);
+        assert.ok(existsSync(bundle), `fixture bundle must be written. Output:\n${log}`);
+    });
+
+    after(() => {
+        if (!process.env.GJSIFY_E2E_KEEP_TEMP && tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('exports org.gjsify.Devtools under HANDLES_COMMAND_LINE + an app-owned sibling object', () => {
+        const r = spawnSync('dbus-run-session', ['--', 'bash', '-c', DRIVER, 'bash', bundle], {
+            encoding: 'utf-8',
+            timeout: 90 * 1000,
+        });
+        const out = `${r.stdout ?? ''}`;
+        const err = `${r.stderr ?? ''}`;
+        const { kv, status } = parse(out);
+        const ctx = `\n--- driver stdout ---\n${out}\n--- driver stderr (bus noise) ---\n${err}`;
+
+        assert.equal(kv.APP_ON_BUS, 'yes', `the fixture must register on the session bus.${ctx}`);
+        assert.equal(kv.INSTALL_RETURNED, 'service', `installDevtools must return a service (not null).${ctx}`);
+        // The rigorous presence signals — each defeats the phantom-node false positive.
+        assert.equal(kv.CHILD_DEVTOOLS, 'yes', `'devtools' must be a REAL exported child object of ${BASE}.${ctx}`);
+        assert.equal(kv.IFACE, 'yes', `org.gjsify.Devtools interface must be present at ${BASE}/devtools.${ctx}`);
+        assert.match(status, /"appId":"org\.example\.reprotest"/, `Devtools.GetStatus must return live JSON.${ctx}`);
+        // Observability: installDevtools confirms a successful export on stderr.
+        assert.equal(kv.EXPORT_LOG, 'yes', `installDevtools must log the successful export.${ctx}`);
+    });
+});


### PR DESCRIPTION
## Summary

The PixelRPG maker's running binary showed no `org.gjsify.Devtools` object, and this was first filed as **`DevtoolsService.export` silently failing** under the maker's app config (`HANDLES_COMMAND_LINE` + an app-owned sibling object exported before devtools). **It does not — there is no `@gjsify/devtools` export bug.**

### The false positive that misled the diagnosis

`gdbus introspect <path>/devtools` returns a **phantom container node** (exit 0) even when *nothing* is exported at that path. So "introspect succeeds" ≠ "interface exported" — the original evidence was a false positive.

Checked **rigorously** — a real exported child node under the app's base path, the `org.gjsify.Devtools` interface actually *present* at `<base>/devtools`, and a method **call** returning data — devtools exports fine in **every** config, including the maker's exact one (`HANDLES_COMMAND_LINE` + a `/control` sibling, verified with `{enabled:true}` bypassing the env gate: interface present + `GetStatus` returns JSON in all four knob combinations).

### The maker's real symptom: a stale app bundle

`apps/maker-gjs/src/application.ts` calls `installDevtools(this)`, but the committed `org.pixelrpg.maker` bundle **predated that line** — its `onStartup` goes `initControlInterface()` → `cleanupOrphanedPublishers()` with no devtools call, and `@gjsify/devtools` code survives tree-shaking there only via the *storybook's* own `installDevtools`. The maker currently fails to rebuild under the **global GJS CLI** (`gjsify-css-as-string` can't resolve `application.css`'s bare `@import "@pixelrpg/gjs/index.css"`), so a source change landed without a matching bundle rebuild. Tracked in STATUS.md Open TODOs (fix the css-as-string bare-`@import` resolver at the core, then rebuild + recommit the maker bundle in the map-editor repo).

## Changes

- **De-silence `installDevtools`** — it now logs `[gjsify-devtools] exported <iface> at <path> (dest <app-id>)` on a successful export. It only reaches that line when devtools is **enabled**, so the log appears exactly when the operator turned devtools on, and its **absence** is the diagnostic: `installDevtools` was never called (e.g. a stale bundle) or the gate was off — as opposed to the previous silence, where a present-but-not-exported object was indistinguishable from a not-installed one. This is the observability that would have made the original chase a two-minute check.
- **`tests/e2e/devtools-export`** — builds a minimal Adwaita fixture with the committed Node-free GJS CLI and drives it over an isolated `dbus-run-session`, asserting the **rigorous** presence signals (real child node + interface + `GetStatus` JSON) **plus** the confirmation log, under `HANDLES_COMMAND_LINE` + a sibling object. Skips gracefully off a capable host (no `gjs` / `dbus-run-session` / `Adw` typelib / rolldown prebuild).

## Validation

- `gjsify tsc` (devtools) ✓ · `gjsify lint` ✓ · `gjsify format --check` ✓
- `@gjsify/devtools` unit tests 20/20 (GJS) ✓
- `node --test tests/e2e/devtools-export/run.mjs` → 1 pass ✓