### PR TITLE
fix(sqlite): store file DBs at the exact path, not <path>.db

### DIFF
--- a/packages/node/sqlite/src/database-sync.spec.ts
+++ b/packages/node/sqlite/src/database-sync.spec.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from '@gjsify/unit';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 
 let cnt = 0;
@@ -300,6 +300,18 @@ export default async () => {
             const db = new DatabaseSync(dbPath);
             expect(db.location()).toBe(dbPath);
             db.close();
+        });
+
+        await it('stores the on-disk file at the exact path, not <path>.db', async () => {
+            // Regression: libgda's SQLite provider names the file `<DB_NAME>.db`, so passing the
+            // `.db` basename verbatim stored the DB at `<path>.db.db` — existsSync(path) was false
+            // on GJS even though the DB existed. The path handed to DatabaseSync must be the real file.
+            const dbPath = nextDb();
+            const db = new DatabaseSync(dbPath);
+            db.exec('CREATE TABLE t (id INTEGER)');
+            db.close();
+            expect(existsSync(dbPath)).toBe(true);
+            expect(existsSync(`${dbPath}.db`)).toBe(false);
         });
     });
 

--- a/packages/node/sqlite/src/database-sync.ts
+++ b/packages/node/sqlite/src/database-sync.ts
@@ -256,7 +256,12 @@ export class DatabaseSync {
                 const lastSlash = this.#path.lastIndexOf('/');
                 const dir = lastSlash >= 0 ? this.#path.substring(0, lastSlash) : '.';
                 const name = lastSlash >= 0 ? this.#path.substring(lastSlash + 1) : this.#path;
-                const cncString = `DB_DIR=${dir};DB_NAME=${name}`;
+                // libgda's SQLite provider always stores the database as `<DB_DIR>/<DB_NAME>.db`, so
+                // strip a trailing `.db` from DB_NAME: node:sqlite uses the given path verbatim, and
+                // passing `foo.db` as DB_NAME would land the file at `foo.db.db` — making the real
+                // file disagree with the requested path (existsSync(path) false, location() wrong).
+                const dbName = name.endsWith('.db') ? name.slice(0, -3) : name;
+                const cncString = `DB_DIR=${dir};DB_NAME=${dbName}`;
                 const connOpts = this.#options.readOnly ? Gda.ConnectionOptions.READ_ONLY : Gda.ConnectionOptions.NONE;
 
                 this.#connection = Gda.Connection.new_from_string('SQLite', cncString, null, connOpts);


### PR DESCRIPTION
## Problem

libgda's SQLite provider names the on-disk file `<DB_DIR>/<DB_NAME>.db`, and `DatabaseSync.open()` passed the full basename (including a `.db` extension) as `DB_NAME`. So `new DatabaseSync('x/foo.db')` stored the database at **`x/foo.db.db`**.

`node:sqlite` uses the given path verbatim, so on GJS:
- `existsSync(path)` was **false** even though the DB existed;
- `location()` disagreed with the real on-disk file;
- two consumers reasoning about the DB by its path (a fresh-store guard, a backup, a portable file) broke.

Verified with a `--app gjs` probe: opening `DatabaseSync('/tmp/x/ledger.db')` writes the file to `/tmp/x/ledger.db.db`.

## Fix

Strip a trailing `.db` from `DB_NAME` before handing it to libgda, so the file lands at the exact requested path (libgda re-adds the `.db`). Paths without a `.db` extension are unchanged. Added a regression test asserting the on-disk file is at the path (and not at `<path>.db`) — green on both Node and GJS (`packages/node/sqlite`, 105 tests).

## Breaking

For a GJS-created file DB previously stored at `<path>.db.db`, the data is no longer found at `<path>`. Consumers with such files must rename `<path>.db.db` (and any `-wal`/`-shm`/`-journal` sidecars) to `<path>` once. In practice only file-DB consumers are affected (the buchhaltung ledger); a one-time migration is handled consumer-side.

https://claude.ai/code/session_01EkqoHijfLjkYTcL8DFPLu5