### PR TITLE
fix(node-gi): pin local tests to the fresh build

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -160,13 +160,20 @@ jobs:
           bun --version
           deno --version
 
+      # NODE_GI_NATIVE=prebuild keeps this job validating the prebuild LOAD PATH
+      # (Deno's install path) explicitly — the runner otherwise defaults to the
+      # just-built addon so stale local prebuilds can't shadow verification.
       - name: Conformance on Bun
         working-directory: packages/node-gi/node-gi
         run: npm run test:bun
+        env:
+          NODE_GI_NATIVE: prebuild
 
       - name: Conformance on Deno
         working-directory: packages/node-gi/node-gi
         run: npm run test:deno
+        env:
+          NODE_GI_NATIVE: prebuild
 
   # GTK/Adw layering proof (Axis-5 GTK milestone): UNCHANGED Gtk.Application (PR1),
   # Adw.Application (PR2) AND a Gtk.Template composite-template widget (PR4) run on

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -131,6 +131,15 @@ npm run build:prebuild   # node-gyp rebuild + stage prebuilds/<platform>-<arch>/
 npm run rebuild
 ```
 
+The load order prefers a staged `prebuilds/<platform>-<arch>/node_gi.node` over
+`build/Release` (the consumer/Deno install path). Local verification always runs
+the **just-built** addon instead: the Node test scripts pin `NODE_GI_NATIVE=build`
+and the bun/deno runner defaults to it — without that, a stale staged prebuild
+silently shadows your build. CI's cross-runtime job sets `NODE_GI_NATIVE=prebuild`
+to keep validating the prebuild load path with a freshly staged binary.
+`NODE_GI_NATIVE` accepts `build`, `prebuild`, or an explicit path to a
+`node_gi.node`.
+
 ## Usage (milestone 1)
 
 ```js

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -37,14 +37,21 @@ export const RUNTIME =
 export const isNodeRuntime = RUNTIME === 'node';
 
 function nativeCandidates() {
-  // Prefer a shipped prebuild so a consumer needs no C toolchain and no node-gyp
-  // — the only install path Deno supports (it runs no postinstall build script).
-  // Fall back to a locally built addon (Release, then Debug).
-  return [
-    join(here, 'prebuilds', `${process.platform}-${process.arch}`, 'node_gi.node'),
-    join(here, 'build', 'Release', 'node_gi.node'),
-    join(here, 'build', 'Debug', 'node_gi.node'),
-  ];
+  const prebuild = join(here, 'prebuilds', `${process.platform}-${process.arch}`, 'node_gi.node');
+  const release = join(here, 'build', 'Release', 'node_gi.node');
+  const debug = join(here, 'build', 'Debug', 'node_gi.node');
+  // NODE_GI_NATIVE pins which binary loads. The package's own test scripts set
+  // `build` so local verification always exercises the JUST-BUILT addon — a stale
+  // staged prebuild would otherwise shadow build/Release and silently validate
+  // the wrong binary (the consumer-facing default below prefers the prebuild).
+  const prefer = process.env.NODE_GI_NATIVE;
+  if (prefer === 'build') return [release, debug, prebuild];
+  if (prefer === 'prebuild') return [prebuild];
+  if (prefer) return [prefer]; // an explicit path to a node_gi.node
+  // Default: prefer a shipped prebuild so a consumer needs no C toolchain and no
+  // node-gyp — the only install path Deno supports (it runs no postinstall build
+  // script). Fall back to a locally built addon (Release, then Debug).
+  return [prebuild, release, debug];
 }
 
 function loadNative() {

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -60,15 +60,15 @@
     "build:prebuild": "node-gyp rebuild && node scripts/stage-prebuild.mjs",
     "rebuild": "node-gyp rebuild",
     "clean": "node-gyp clean",
-    "test": "node --test",
-    "test:node": "node --test",
-    "test:gc": "node --test --expose-gc",
+    "test": "NODE_GI_NATIVE=build node --test",
+    "test:node": "NODE_GI_NATIVE=build node --test",
+    "test:gc": "NODE_GI_NATIVE=build node --test --expose-gc",
     "test:bun": "node scripts/cross-runtime.mjs bun",
     "test:deno": "node scripts/cross-runtime.mjs deno",
-    "test:gtk": "node --test test/gtk-smoke.test.mjs",
-    "test:adw": "node --test test/adw-smoke.test.mjs",
-    "test:gtk-template": "node --test test/gtk-template.test.mjs",
-    "test:gtk-template-callbacks": "node --test test/gtk-template-callbacks.test.mjs"
+    "test:gtk": "NODE_GI_NATIVE=build node --test test/gtk-smoke.test.mjs",
+    "test:adw": "NODE_GI_NATIVE=build node --test test/adw-smoke.test.mjs",
+    "test:gtk-template": "NODE_GI_NATIVE=build node --test test/gtk-template.test.mjs",
+    "test:gtk-template-callbacks": "NODE_GI_NATIVE=build node --test test/gtk-template-callbacks.test.mjs"
   },
   "dependencies": {
     "node-addon-api": "^8.0.0"

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -70,11 +70,21 @@ const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const argsFor = (file) =>
   runtime === 'bun' ? ['test', file] : ['test', '-A', '--node-modules-dir=auto', file];
 
+// Which native binary the children load (see index.js nativeCandidates). Default
+// to the JUST-BUILT addon so a stale staged prebuild can't shadow local
+// verification; CI's cross-runtime job overrides with NODE_GI_NATIVE=prebuild to
+// keep validating the prebuild load path (Deno's install path) explicitly.
+const nativePref = process.env.NODE_GI_NATIVE ?? 'build';
+
 console.log(`node-gi: running ${CONFORMANCE.length} conformance files on ${runtime} (one process per file)\n`);
 let failed = 0;
 for (const base of CONFORMANCE) {
   const file = join('test', `${base}.test.mjs`);
-  const res = spawnSync(runtime, argsFor(file), { cwd: pkgRoot, encoding: 'utf8' });
+  const res = spawnSync(runtime, argsFor(file), {
+    cwd: pkgRoot,
+    encoding: 'utf8',
+    env: { ...process.env, NODE_GI_NATIVE: nativePref },
+  });
   if (res.status === 0) {
     console.log(`  ✓ ${base}`);
   } else {

--- a/packages/node-gi/node-gi/test/native-override.test.mjs
+++ b/packages/node-gi/node-gi/test/native-override.test.mjs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// NODE_GI_NATIVE pins which native binary index.js loads (build | prebuild |
+// explicit path). Regression guard for the stale-prebuild footgun: the test
+// scripts pin `build`, so local verification always runs the just-built addon
+// instead of a stale staged prebuilds/<platform>-<arch>/node_gi.node.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function loadWith(nativeEnv) {
+  return spawnSync(process.execPath, ['-e', "import('./index.js').then(() => console.log('LOADED'))"], {
+    cwd: pkgRoot,
+    encoding: 'utf8',
+    env: { ...process.env, NODE_GI_NATIVE: nativeEnv },
+  });
+}
+
+test('NODE_GI_NATIVE=build loads the locally built addon', () => {
+  const res = loadWith('build');
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stdout, /LOADED/);
+});
+
+test('NODE_GI_NATIVE=<bogus path> fails loudly instead of falling back', () => {
+  const res = loadWith(join(pkgRoot, 'no', 'such', 'node_gi.node'));
+  assert.notEqual(res.status, 0);
+  assert.match(res.stderr, /native addon not found/);
+});


### PR DESCRIPTION
## Summary

Kills the local-dev footgun found while verifying #721: `index.js` prefers a staged `prebuilds/<platform>-<arch>/node_gi.node` over `build/Release` (correct for consumers/Deno), so a **stale staged prebuild silently shadows the just-built addon** — every local `npm test` since Jul 2 validated the old binary, including the addon.cc-split baseline/post-split runs (both trivially identical because both loaded the same stale prebuild; see the #721 re-verification comment).

- **`index.js`**: new `NODE_GI_NATIVE` pin — `build` (prefer `build/Release|Debug`, fall back to prebuild), `prebuild` (prebuild only; loud `native addon not found` otherwise), or an explicit path to a `node_gi.node`. Default order unchanged.
- **`package.json`**: all Node test scripts pin `NODE_GI_NATIVE=build`.
- **`scripts/cross-runtime.mjs`**: spawned bun/deno children default to `build`, overridable via env.
- **`node-gi.yml` cross-runtime job**: sets `NODE_GI_NATIVE=prebuild` on the two conformance steps, so CI keeps validating the **prebuild load path** (Deno's install path) explicitly — previously that intent was implicit in candidate order.
- **`test/native-override.test.mjs`**: env-independent regression guard (`build` loads; bogus explicit path fails loudly, no silent fallback).

CI itself was never affected: a fresh checkout has no prebuild, and the cross-runtime job stages its own from the same build.

## Test plan
- [x] `npm test`: 263 tests (261 + 2 new), 0 fail
- [x] `npm run test:bun` / `test:deno` (default → `build`): 26/26 each
- [x] `NODE_GI_NATIVE=prebuild npm run test:bun` with no prebuild staged: fails loudly (only the 2 addon-free files pass) — confirms the override reaches child processes and there is no silent fallback