### PR TITLE
fix(node-gi): GJS-exact BigInt 64-bit marshalling

### DIFF
--- a/packages/node-gi/node-gi/conformance/golden/int64.txt
+++ b/packages/node-gi/node-gi/conformance/golden/int64.txt
@@ -1,0 +1,11 @@
+scalar to_unix: 1234567890 number
+scalar to_unix (BigInt in): 1234567890 number
+x small: 42
+x min: -9223372036854776000
+x max: 9223372036854776000
+x safe: 9007199254740991
+x typeof: number
+t small: 7
+t max: 18446744073709552000
+t safe: 9007199254740991
+t typeof: number

--- a/packages/node-gi/node-gi/conformance/programs/int64.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/int64.conf.mjs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// 64-bit integer marshalling — the GJS-exact BigInt-in / Number-out contract.
+//
+// GLib-only (no GIMarshallingTests typelib) so it runs UNCHANGED on all four
+// runtimes and its STDOUT must be byte-identical to the gjs golden:
+//   • GLib.DateTime.new_from_unix_utc(gint64) + .to_unix() — the scalar gint64
+//     IN/OUT marshalling path (marshal.cc), driven by both a Number and a BigInt;
+//   • GLib.Variant 'x'/'t' pack (BigInt in) + unpack (Number out) — the GVariant
+//     64-bit path (variant.cc).
+//
+// A 64-bit value ALWAYS comes back as a JS Number (never a BigInt), matching GJS.
+// A value outside ±2^53 additionally emits a "cannot be safely stored" g_warning
+// on STDERR — not compared here (conformance diffs stdout only), but the values
+// below are chosen so the rounded double stringifies identically on SpiderMonkey
+// (gjs) and V8 (node/bun/deno).
+import GLib from 'gi://GLib?version=2.0';
+
+// ---- scalar gint64 round-trip (DateTime.new_from_unix_utc + to_unix) ---------
+const t = GLib.DateTime.new_from_unix_utc(1234567890).to_unix();
+print('scalar to_unix:', t, typeof t);
+// A BigInt argument marshals losslessly into the same gint64 slot as the Number.
+const tb = GLib.DateTime.new_from_unix_utc(1234567890n).to_unix();
+print('scalar to_unix (BigInt in):', tb, typeof tb);
+
+// ---- GVariant int64 ('x') — BigInt in, Number out ----------------------------
+print('x small:', new GLib.Variant('x', 42n).deepUnpack());
+print('x min:', new GLib.Variant('x', -9223372036854775808n).deepUnpack());
+print('x max:', new GLib.Variant('x', 9223372036854775807n).deepUnpack());
+print('x safe:', new GLib.Variant('x', 9007199254740991n).deepUnpack());
+print('x typeof:', typeof new GLib.Variant('x', 42n).deepUnpack());
+
+// ---- GVariant uint64 ('t') — BigInt in, Number out ---------------------------
+print('t small:', new GLib.Variant('t', 7n).deepUnpack());
+print('t max:', new GLib.Variant('t', 18446744073709551615n).deepUnpack());
+print('t safe:', new GLib.Variant('t', 9007199254740991n).deepUnpack());
+print('t typeof:', typeof new GLib.Variant('t', 7n).deepUnpack());

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -38,11 +38,14 @@
 //   • gi:// imports → requireGi (the same rewrite the tier-A conformance twins
 //     use); Gio/GObject/System imports are only needed by stubbed sections and
 //     return with them.
-//   • warn64/skip64: upstream's warn64 wraps 64-bit calls in GJS's log-capture
-//     machinery (GLib.test_expect_message('Gjs', …) + g_test_assert) around the
-//     GJS "cannot be safely stored" warning; node-gi emits no such warning and
-//     the unmatched assert would abort the process, so 64-bit paths pend with
-//     the phase-2.1 reason instead. All 32-bit paths run verbatim.
+//   • warn64/skip64: upstream's warn64 wraps 64-bit OUT/RETURN calls in GJS's
+//     log-capture machinery (GLib.test_expect_message('Gjs', …) + g_test_assert)
+//     around the "cannot be safely stored" warning; node-gi now emits that exact
+//     g_warning (to stderr, non-fatal) but has no such capture harness, so warn64
+//     just runs the call and checks the value. skip64 (64-bit IN/INOUT via a plain,
+//     inaccurate JS Number) stays skipped for the SAME reason GJS skips it
+//     (installed-tests skip64 → pending(gjs#271)); the accurate 64-bit IN path is
+//     the now-live BigInt block. All 32-bit paths run verbatim.
 //   • dev_t skipInOut: upstream passes `skipInOut: true`; the shim's skip
 //     contract requires a reason, so the gjs#673 URL the upstream comment cites
 //     is passed instead.
@@ -222,24 +225,31 @@ if (GLib.SIZEOF_SSIZE_T === 8) {
     Object.assign(Limits.ssize, Limits.int32);
 }
 
-// Functions for dealing with tests that require or return unsafe 64-bit ints,
-// until we get BigInts.
+// Functions for dealing with tests that require or return unsafe 64-bit ints.
 //
-// ADAPTATION (see header): under node-gi the 64-bit paths pend with the
-// phase-2.1 reason instead of arming GJS's log-capture machinery.
-const SKIP_64BIT =
-    'phase 2.1 BigInt-64-bit — unsafe 64-bit int marshalling (GJS warns via its Gjs log ' +
-    'domain, https://gitlab.gnome.org/GNOME/gjs/issues/271; node-gi has neither yet)';
-
+// warn64: OUT/RETURN of a 64-bit int. node-gi now returns a JS Number and emits
+// the GJS-exact "cannot be safely stored" g_warning (to stderr, non-fatal), so the
+// call RUNS and the value is checked — it round-trips through the same double
+// rounding as the expected JS Number. Unlike upstream we do not assert the warning
+// via GLib.test_expect_message (node-gi's L1 has no such capture harness); a
+// warning on stderr is harmless and node:test does not fail on it.
 function warn64(is64bit, func, ...args) {
-    if (is64bit)
-        pending(SKIP_64BIT);
     return func(...args);
 }
 
+// skip64: IN/INOUT of a 64-bit int passed as a PLAIN JS Number. A Number cannot
+// represent 2^63-1 / 2^64-1 exactly, so it can never be verified against the C
+// side — GJS skips these identically (installed-tests skip64 → pending(gjs#271)).
+// The accurate 64-bit IN path is the BigInt block below (now live). NOT a node-gi
+// gap: the same inherent Number-precision limitation GJS documents.
+const SKIP_64BIT_NUMBER =
+    'https://gitlab.gnome.org/GNOME/gjs/issues/271 — a 64-bit int IN/INOUT via a ' +
+    'plain (inaccurate) JS Number cannot be verified against C; the accurate path is the ' +
+    'now-live BigInt block. GJS skips these identically (installed-tests skip64).';
+
 function skip64(is64bit) {
     if (is64bit)
-        pending(SKIP_64BIT);
+        pending(SKIP_64BIT_NUMBER);
 }
 
 describe('Boolean', function () {
@@ -318,23 +328,21 @@ describe('Integer', function () {
     });
 });
 
-// FIDELITY-BUG (must not even run): a BigInt argument fatally aborts the addon
-// — Napi::Error::New(napi_get_last_error_info) inside JsToGIArgument, a
-// process-level abort, not a catchable throw — where GJS marshals BigInt
-// 64-bit values exactly. Bodies are kept verbatim for the phase-2.1 un-skip.
-const SKIP_BIGINT =
-    'phase 2.1 BigInt-64-bit — FIDELITY-BUG: BigInt args fatally abort the addon ' +
-    '(napi abort in JsToGIArgument) instead of marshalling like GJS; body must not run';
-
+// node-gi now marshals a BigInt 64-bit argument LOSSLESSLY (GJS-exact:
+// JS::ToBigInt64 / ToBigUint64), so these run live. Before the fix a BigInt arg
+// fatally aborted the addon: the marshaller called ToNumber() on the BigInt, which
+// sets a pending N-API error under NAPI_DISABLE_CPP_EXCEPTIONS, and the follow-up
+// Napi::Error::New(napi_get_last_error_info) in JsToGIArgument became a process
+// abort. The marshaller now branches on IsBigInt before any ToNumber().
 describe('BigInt', function () {
     Object.entries(BigIntLimits).forEach(([type, {min, max, umax, utype = `u${type}`}]) => {
         describe(`${type}-typed`, function () {
-            itSkip(SKIP_BIGINT, 'marshals signed value as an in parameter', function () {
+            it('marshals signed value as an in parameter', function () {
                 expect(() => GIMarshallingTests[`${type}_in_max`](max)).not.toThrow();
                 expect(() => GIMarshallingTests[`${type}_in_min`](min)).not.toThrow();
             });
 
-            itSkip(SKIP_BIGINT, 'marshals unsigned value as an in parameter', function () {
+            it('marshals unsigned value as an in parameter', function () {
                 expect(() => GIMarshallingTests[`${utype}_in`](umax)).not.toThrow();
             });
         });

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -47,6 +47,7 @@ const CONFORMANCE = [
   'globals',
   'gobject',
   'gtype',
+  'int64',
   'methods',
   'multilevel-subclass',
   'out-params',

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -90,6 +90,55 @@ Napi::Value MakeGTypeHandle(Napi::Env env, GType gtype);
 GType ReadGTypeHandle(Napi::Value v);
 bool UnwrapGTypeArg(Napi::Env env, Napi::Value v, GType* out);
 
+// ---- GJS-exact 64-bit integer marshalling helpers (shared) -------------------
+//
+// Single source of truth for BigInt/Number ⇄ 64-bit C int, used by the GI scalar
+// + array-element marshaller (marshal.cc), the GValue property marshaller
+// (object.cc), and the GVariant packer/unpacker (variant.cc).
+//
+// IN (JsValueTo{Int,Uint}64): a BigInt is read LOSSLESSLY — GJS uses
+// JS::ToBigInt64 / JS::ToBigUint64 (refs/gjs/gi/js-value-inl.h:126-146): a BigInt
+// is exact by construction, a wrapping conversion, NOT an error, so `lossless` is
+// intentionally ignored. A plain Number is truncated via node-addon-api's
+// Int64Value (GJS truncates a Number via JS::ToInt64 — also not an error). The
+// BigInt branch is load-bearing: `ToNumber()` on a BigInt sets a pending N-API
+// error under NAPI_DISABLE_CPP_EXCEPTIONS, and the follow-up `Napi::Error::New`
+// would fatally abort the process (exit 134) instead of marshalling — a crash the
+// repo invariant forbids.
+inline int64_t JsValueToInt64(Napi::Value v) {
+  if (v.IsBigInt()) {
+    bool lossless = false;
+    return v.As<Napi::BigInt>().Int64Value(&lossless);
+  }
+  return v.ToNumber().Int64Value();
+}
+inline uint64_t JsValueToUint64(Napi::Value v) {
+  if (v.IsBigInt()) {
+    bool lossless = false;
+    return v.As<Napi::BigInt>().Uint64Value(&lossless);
+  }
+  return static_cast<uint64_t>(v.ToNumber().Int64Value());
+}
+
+// OUT (WarnIfUnsafe{Int,Uint}64): GJS ALWAYS returns a JS Number for a 64-bit int
+// (never a BigInt) and emits this g_warning when the value falls outside the range
+// a double represents exactly (|v| > 2^53 - 1 == Number.MAX_SAFE_INTEGER), because
+// the returned double may be rounded. Mirrors refs/gjs/gi/arg-inl.h:222-228 +
+// js-value-inl.h:223-236, where max_safe_big_number == (1 << DBL_MANT_DIG) - 1 and
+// DBL_MANT_DIG (std::numeric_limits<double>::digits) == 53. The message text is
+// byte-for-byte GJS's so a warning-capturing consumer sees the identical string.
+constexpr int64_t kMaxSafeJsInteger = (int64_t{1} << 53) - 1;  // 9007199254740991
+inline void WarnIfUnsafeInt64(int64_t v) {
+  if (v > kMaxSafeJsInteger || v < -kMaxSafeJsInteger)
+    g_warning("Value %s cannot be safely stored in a JS Number and may be rounded",
+              std::to_string(v).c_str());
+}
+inline void WarnIfUnsafeUint64(uint64_t v) {
+  if (v > static_cast<uint64_t>(kMaxSafeJsInteger))
+    g_warning("Value %s cannot be safely stored in a JS Number and may be rounded",
+              std::to_string(v).c_str());
+}
+
 // `ownedStrings` (optional): when a transfer-full string IN/INOUT arg is g_strdup'd
 // here, the freshly-allocated pointer is appended so the caller can g_free it if the
 // invoke never adopts it (an arg-marshal error before the call, or a failed invoke).

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -158,8 +158,10 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
     case GI_TYPE_TAG_UINT16: out->v_uint16 = static_cast<uint16_t>(v.ToNumber().Uint32Value()); return true;
     case GI_TYPE_TAG_INT32: out->v_int32 = v.ToNumber().Int32Value(); return true;
     case GI_TYPE_TAG_UINT32: out->v_uint32 = v.ToNumber().Uint32Value(); return true;
-    case GI_TYPE_TAG_INT64: out->v_int64 = v.ToNumber().Int64Value(); return true;
-    case GI_TYPE_TAG_UINT64: out->v_uint64 = static_cast<uint64_t>(v.ToNumber().Int64Value()); return true;
+    // 64-bit: accept a BigInt losslessly (else a Number, truncated) — never let a
+    // BigInt reach ToNumber() (fatal abort). See JsValueTo{Int,Uint}64 in common.h.
+    case GI_TYPE_TAG_INT64: out->v_int64 = JsValueToInt64(v); return true;
+    case GI_TYPE_TAG_UINT64: out->v_uint64 = JsValueToUint64(v); return true;
     case GI_TYPE_TAG_FLOAT: out->v_float = static_cast<float>(v.ToNumber().DoubleValue()); return true;
     case GI_TYPE_TAG_DOUBLE: out->v_double = v.ToNumber().DoubleValue(); return true;
     case GI_TYPE_TAG_UTF8:
@@ -276,8 +278,14 @@ Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
     case GI_TYPE_TAG_UINT16: return Napi::Number::New(env, arg->v_uint16);
     case GI_TYPE_TAG_INT32: return Napi::Number::New(env, arg->v_int32);
     case GI_TYPE_TAG_UINT32: return Napi::Number::New(env, arg->v_uint32);
-    case GI_TYPE_TAG_INT64: return Napi::Number::New(env, static_cast<double>(arg->v_int64));
-    case GI_TYPE_TAG_UINT64: return Napi::Number::New(env, static_cast<double>(arg->v_uint64));
+    // 64-bit: GJS always returns a Number, warning when the value is not exactly
+    // representable (|v| > 2^53-1). See WarnIfUnsafe{Int,Uint}64 in common.h.
+    case GI_TYPE_TAG_INT64:
+      WarnIfUnsafeInt64(arg->v_int64);
+      return Napi::Number::New(env, static_cast<double>(arg->v_int64));
+    case GI_TYPE_TAG_UINT64:
+      WarnIfUnsafeUint64(arg->v_uint64);
+      return Napi::Number::New(env, static_cast<double>(arg->v_uint64));
     case GI_TYPE_TAG_FLOAT: return Napi::Number::New(env, arg->v_float);
     case GI_TYPE_TAG_DOUBLE: return Napi::Number::New(env, arg->v_double);
     case GI_TYPE_TAG_UTF8:
@@ -719,8 +727,8 @@ static bool ElementToGIArgument(Napi::Env env, GITypeInfo* elem, Napi::Value v, 
     case GI_TYPE_TAG_UINT16: a->v_uint16 = static_cast<guint16>(v.ToNumber().Uint32Value()); return true;
     case GI_TYPE_TAG_INT32: a->v_int32 = v.ToNumber().Int32Value(); return true;
     case GI_TYPE_TAG_UINT32: a->v_uint32 = v.ToNumber().Uint32Value(); return true;
-    case GI_TYPE_TAG_INT64: a->v_int64 = v.ToNumber().Int64Value(); return true;
-    case GI_TYPE_TAG_UINT64: a->v_uint64 = static_cast<guint64>(v.ToNumber().Int64Value()); return true;
+    case GI_TYPE_TAG_INT64: a->v_int64 = JsValueToInt64(v); return true;
+    case GI_TYPE_TAG_UINT64: a->v_uint64 = JsValueToUint64(v); return true;
     case GI_TYPE_TAG_FLOAT: a->v_float = static_cast<gfloat>(v.ToNumber().DoubleValue()); return true;
     case GI_TYPE_TAG_DOUBLE: a->v_double = v.ToNumber().DoubleValue(); return true;
     case GI_TYPE_TAG_UTF8:

--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -46,10 +46,27 @@ Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
     case G_TYPE_UCHAR: return Napi::Number::New(env, g_value_get_uchar(v));
     case G_TYPE_INT: return Napi::Number::New(env, g_value_get_int(v));
     case G_TYPE_UINT: return Napi::Number::New(env, g_value_get_uint(v));
-    case G_TYPE_LONG: return Napi::Number::New(env, static_cast<double>(g_value_get_long(v)));
-    case G_TYPE_ULONG: return Napi::Number::New(env, static_cast<double>(g_value_get_ulong(v)));
-    case G_TYPE_INT64: return Napi::Number::New(env, static_cast<double>(g_value_get_int64(v)));
-    case G_TYPE_UINT64: return Napi::Number::New(env, static_cast<double>(g_value_get_uint64(v)));
+    // 64-bit OUT: GJS returns a Number, warning when it can't be stored exactly.
+    case G_TYPE_LONG: {
+      glong x = g_value_get_long(v);
+      WarnIfUnsafeInt64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
+    case G_TYPE_ULONG: {
+      gulong x = g_value_get_ulong(v);
+      WarnIfUnsafeUint64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
+    case G_TYPE_INT64: {
+      gint64 x = g_value_get_int64(v);
+      WarnIfUnsafeInt64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
+    case G_TYPE_UINT64: {
+      guint64 x = g_value_get_uint64(v);
+      WarnIfUnsafeUint64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
     case G_TYPE_FLOAT: return Napi::Number::New(env, g_value_get_float(v));
     case G_TYPE_DOUBLE: return Napi::Number::New(env, g_value_get_double(v));
     case G_TYPE_ENUM: return Napi::Number::New(env, g_value_get_enum(v));
@@ -163,10 +180,13 @@ bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
     case G_TYPE_UCHAR: g_value_set_uchar(v, static_cast<guchar>(js.ToNumber().Uint32Value())); return true;
     case G_TYPE_INT: g_value_set_int(v, js.ToNumber().Int32Value()); return true;
     case G_TYPE_UINT: g_value_set_uint(v, js.ToNumber().Uint32Value()); return true;
-    case G_TYPE_LONG: g_value_set_long(v, static_cast<glong>(js.ToNumber().Int64Value())); return true;
-    case G_TYPE_ULONG: g_value_set_ulong(v, static_cast<gulong>(js.ToNumber().Int64Value())); return true;
-    case G_TYPE_INT64: g_value_set_int64(v, js.ToNumber().Int64Value()); return true;
-    case G_TYPE_UINT64: g_value_set_uint64(v, static_cast<guint64>(js.ToNumber().Int64Value())); return true;
+    // 64-bit (glong/gulong are 64-bit on LP64): accept a BigInt losslessly, else a
+    // truncated Number — never let a BigInt reach ToNumber(). Shared with the GI
+    // scalar marshaller via JsValueTo{Int,Uint}64 (common.h).
+    case G_TYPE_LONG: g_value_set_long(v, static_cast<glong>(JsValueToInt64(js))); return true;
+    case G_TYPE_ULONG: g_value_set_ulong(v, static_cast<gulong>(JsValueToUint64(js))); return true;
+    case G_TYPE_INT64: g_value_set_int64(v, JsValueToInt64(js)); return true;
+    case G_TYPE_UINT64: g_value_set_uint64(v, JsValueToUint64(js)); return true;
     case G_TYPE_FLOAT: g_value_set_float(v, static_cast<float>(js.ToNumber().DoubleValue())); return true;
     case G_TYPE_DOUBLE: g_value_set_double(v, js.ToNumber().DoubleValue()); return true;
     case G_TYPE_ENUM: g_value_set_enum(v, js.ToNumber().Int32Value()); return true;

--- a/packages/node-gi/node-gi/src/variant.cc
+++ b/packages/node-gi/node-gi/src/variant.cc
@@ -159,22 +159,11 @@ static GVariant* VariantPack(Napi::Env env, const std::string& sig, size_t* pos,
     case 'q': return g_variant_new_uint16(static_cast<guint16>(value.ToNumber().Uint32Value()));
     case 'i': return g_variant_new_int32(value.ToNumber().Int32Value());
     case 'u': return g_variant_new_uint32(value.ToNumber().Uint32Value());
-    case 'x': {
-      // GJS accepts a BigInt for 64-bit types (its js_value_to_c<int64_t> branches
-      // on isBigInt before ToInt64). ToNumber() throws on a BigInt and rounds a
-      // large double — branch on IsBigInt to round-trip the full int64 range.
-      bool lossless = false;
-      gint64 i = value.IsBigInt() ? value.As<Napi::BigInt>().Int64Value(&lossless)
-                                  : value.ToNumber().Int64Value();
-      return g_variant_new_int64(i);
-    }
-    case 't': {
-      bool lossless = false;
-      guint64 u = value.IsBigInt()
-                      ? value.As<Napi::BigInt>().Uint64Value(&lossless)
-                      : static_cast<guint64>(value.ToNumber().Int64Value());
-      return g_variant_new_uint64(u);
-    }
+    // GJS accepts a BigInt for 64-bit types (js_value_to_c<int64_t> branches on
+    // isBigInt before ToInt64); a BigInt must never reach ToNumber() (fatal abort).
+    // Shared with the GI/GValue marshallers via JsValueTo{Int,Uint}64 (common.h).
+    case 'x': return g_variant_new_int64(JsValueToInt64(value));
+    case 't': return g_variant_new_uint64(JsValueToUint64(value));
     case 'h': return g_variant_new_handle(value.ToNumber().Int32Value());
     case 'd': return g_variant_new_double(value.ToNumber().DoubleValue());
     case 's': {
@@ -432,10 +421,18 @@ static Napi::Value VariantToJs(Napi::Env env, GVariant* v, bool deep, bool recur
     case G_VARIANT_CLASS_UINT16: return Napi::Number::New(env, g_variant_get_uint16(v));
     case G_VARIANT_CLASS_INT32: return Napi::Number::New(env, g_variant_get_int32(v));
     case G_VARIANT_CLASS_UINT32: return Napi::Number::New(env, g_variant_get_uint32(v));
-    case G_VARIANT_CLASS_INT64:
-      return Napi::Number::New(env, static_cast<double>(g_variant_get_int64(v)));
-    case G_VARIANT_CLASS_UINT64:
-      return Napi::Number::New(env, static_cast<double>(g_variant_get_uint64(v)));
+    // GJS unpacks a 64-bit variant to a Number, warning when it can't be stored
+    // exactly (|v| > 2^53-1) — same as every other 64-bit OUT path.
+    case G_VARIANT_CLASS_INT64: {
+      gint64 x = g_variant_get_int64(v);
+      WarnIfUnsafeInt64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
+    case G_VARIANT_CLASS_UINT64: {
+      guint64 x = g_variant_get_uint64(v);
+      WarnIfUnsafeUint64(x);
+      return Napi::Number::New(env, static_cast<double>(x));
+    }
     case G_VARIANT_CLASS_HANDLE: return Napi::Number::New(env, g_variant_get_handle(v));
     case G_VARIANT_CLASS_DOUBLE: return Napi::Number::New(env, g_variant_get_double(v));
     case G_VARIANT_CLASS_STRING:

--- a/packages/node-gi/node-gi/test/int64.test.mjs
+++ b/packages/node-gi/node-gi/test/int64.test.mjs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+// 64-bit integer marshalling — the GJS-exact BigInt-in / Number-out contract,
+// exercised against STOCK GLib/GObject APIs only (no GIMarshallingTests typelib),
+// so `npm test` (which discovers test/) stays typelib-free and this file also runs
+// on bun + deno. The exhaustive GIMarshallingTests specs live in
+// gimarshalling/testGIMarshalling.port.mjs (the BigInt + Integer 64-bit sections).
+//
+// Regression it guards: passing a JS BigInt (or a Number too large for int64) as a
+// 64-bit GI argument used to fatally ABORT the addon — the marshaller called
+// ToNumber() on the BigInt, which sets a pending N-API error under
+// NAPI_DISABLE_CPP_EXCEPTIONS, and the follow-up Napi::Error::New became a process
+// abort (exit 134). The marshaller now branches on IsBigInt FIRST and reads it
+// losslessly (JS::ToBigInt64 / ToBigUint64), exactly like GJS
+// (refs/gjs/gi/js-value-inl.h:126-146). On OUT, a 64-bit value ALWAYS comes back as
+// a JS Number (never a BigInt) and, when it exceeds ±2^53, emits GJS's
+// "cannot be safely stored" g_warning (refs/gjs/gi/arg-inl.h:224).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { requireGi } from '../gi.js';
+import { registerClass, constructType, getProperty, setProperty, requireNamespace } from '../index.js';
+
+const GLib = requireGi('GLib', '2.0');
+
+const MAX_INT64 = 9223372036854775807n; // G_MAXINT64
+const MIN_INT64 = -9223372036854775808n; // G_MININT64
+const MAX_UINT64 = 18446744073709551615n; // G_MAXUINT64
+// G_MAXINT64 / G_MININT64 / G_MAXUINT64 rounded to the nearest IEEE-754 double —
+// identical on SpiderMonkey (gjs) and V8 (node/bun/deno).
+const MAX_INT64_AS_DOUBLE = 9223372036854776000;
+const MIN_INT64_AS_DOUBLE = -9223372036854776000;
+const MAX_UINT64_AS_DOUBLE = 18446744073709552000;
+
+const isNode = typeof globalThis.Deno === 'undefined' && typeof globalThis.Bun === 'undefined';
+
+test('GVariant int64 (x): a BigInt marshals in, a Number marshals out — no abort', () => {
+  // Before the fix, constructing this variant from a BigInt aborted the process.
+  const x = new GLib.Variant('x', MAX_INT64).deepUnpack();
+  assert.equal(typeof x, 'number', 'a 64-bit value comes back as a Number, never a BigInt');
+  assert.equal(x, MAX_INT64_AS_DOUBLE);
+
+  const min = new GLib.Variant('x', MIN_INT64).deepUnpack();
+  assert.equal(typeof min, 'number');
+  assert.equal(min, MIN_INT64_AS_DOUBLE);
+});
+
+test('GVariant uint64 (t): a BigInt marshals in, a Number marshals out — no abort', () => {
+  const t = new GLib.Variant('t', MAX_UINT64).deepUnpack();
+  assert.equal(typeof t, 'number');
+  assert.equal(t, MAX_UINT64_AS_DOUBLE);
+});
+
+test('GVariant 64-bit: a safe-range BigInt round-trips exactly', () => {
+  const safe = 9007199254740991n; // Number.MAX_SAFE_INTEGER — representable exactly
+  assert.equal(new GLib.Variant('x', safe).deepUnpack(), 9007199254740991);
+  assert.equal(new GLib.Variant('t', safe).deepUnpack(), 9007199254740991);
+});
+
+test('scalar gint64 (DateTime): a BigInt and a Number marshal identically', () => {
+  // GLib.DateTime.new_from_unix_utc takes a gint64 (marshal.cc scalar IN path);
+  // .to_unix() returns a gint64 (scalar OUT path).
+  const fromNumber = GLib.DateTime.new_from_unix_utc(1234567890).to_unix();
+  const fromBigInt = GLib.DateTime.new_from_unix_utc(1234567890n).to_unix();
+  assert.equal(fromNumber, 1234567890);
+  assert.equal(fromBigInt, 1234567890);
+  assert.equal(typeof fromBigInt, 'number', 'a gint64 OUT value is a Number');
+});
+
+test('a Number too large for int64 no longer crashes the process', () => {
+  // A huge FINITE Number is truncated (not a BigInt), so it never touches the
+  // ToNumber()-on-BigInt abort path — assert it marshals without an uncatchable
+  // crash. (GLib.DateTime rejects the out-of-range instant → null; that is fine —
+  // the point is that the addon survives.)
+  assert.doesNotThrow(() => {
+    const dt = GLib.DateTime.new_from_unix_utc(9e18);
+    void dt;
+  });
+  assert.doesNotThrow(() => new GLib.Variant('x', 9e15).deepUnpack());
+});
+
+test('GObject int64/uint64 property: BigInt in → Number out (GValue path)', () => {
+  requireNamespace('GObject', '2.0');
+  const Int64Thing = registerClass('NodeGiInt64Prop', 'GObject', 'Object', {
+    properties: [{ name: 'big', type: 'int64', default: 0 }],
+  });
+  const o = constructType(Int64Thing, {});
+  setProperty(o, 'big', MAX_INT64); // BigInt → g_value_set_int64 (object.cc JsToGValue)
+  const got = getProperty(o, 'big'); // g_value_get_int64 → Number (object.cc GValueToJs)
+  assert.equal(typeof got, 'number', 'an int64 property reads back as a Number');
+  assert.equal(got, MAX_INT64_AS_DOUBLE);
+  setProperty(o, 'big', 123); // a plain Number still works
+  assert.equal(getProperty(o, 'big'), 123);
+
+  const Uint64Thing = registerClass('NodeGiUint64Prop', 'GObject', 'Object', {
+    properties: [{ name: 'ubig', type: 'uint64', default: 0 }],
+  });
+  const u = constructType(Uint64Thing, {});
+  setProperty(u, 'ubig', MAX_UINT64);
+  const ugot = getProperty(u, 'ubig');
+  assert.equal(typeof ugot, 'number');
+  assert.equal(ugot, MAX_UINT64_AS_DOUBLE);
+});
+
+// The GJS-exact "cannot be safely stored" g_warning is written to fd 2 by the C
+// library (bypassing the JS stderr stream), so capturing it needs a child process.
+// This also re-proves the child EXITS 0 — i.e. the unsafe value warns instead of
+// aborting. Node-only (spawn argv differs per runtime); the assertions above are
+// what qualify this file for the bun/deno cross-runtime subset.
+if (isNode) {
+  test('a too-large 64-bit value logs the "cannot be safely stored" warning (not an abort)', () => {
+    const pkgRoot = fileURLToPath(new URL('..', import.meta.url));
+    const code =
+      "import { requireGi } from './gi.js';" +
+      "const GLib = requireGi('GLib','2.0');" +
+      "const v = new GLib.Variant('x', 9223372036854775807n).deepUnpack();" +
+      "if (typeof v !== 'number') process.exit(3);";
+    const res = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
+      cwd: pkgRoot,
+      env: { ...process.env, NODE_GI_NATIVE: 'build' },
+      encoding: 'utf8',
+    });
+    assert.equal(res.status, 0, `child must exit 0 (warn, not abort); got ${res.status}\n${res.stderr}`);
+    assert.match(
+      res.stderr,
+      /Value 9223372036854775807 cannot be safely stored in a JS Number and may be rounded/,
+      'the OUT path emits the GJS-exact unsafe-integer warning',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a **hard process abort** (exit 134) when a JS **BigInt** — or a Number too large for int64 — is passed as a 64-bit GI argument, and brings 64-bit marshalling to GJS-exact semantics. Caught by the tier-B GIMarshallingTests scaffold (#726).

**Root cause:** `JsToGIArgument` called `v.ToNumber()` on a BigInt; under `NAPI_DISABLE_CPP_EXCEPTIONS` that sets a pending N-API error, and the follow-up `Napi::Error::New(napi_get_last_error_info)` became a fatal `napi_fatal_error` abort instead of a catchable throw. **A crash violates the repo invariant "every gap is a clear error, never a crash."**

## GJS-exact semantics (verified against `gjs -m`, not guessed)
- **IN**: BigInt → lossless (`Napi::BigInt::Int64Value/Uint64Value(&lossless)`); a JS Number is truncated (as GJS's `ToInt64`/`ToUint64` do), never an error. (`refs/gjs/gi/js-value-inl.h:126-146`)
- **OUT**: always a JS **Number** (never BigInt) + `g_warning("Value … cannot be safely stored in a JS Number and may be rounded")` past `Number.MAX_SAFE_INTEGER`. (`refs/gjs/gi/js-value-inl.h:225,417`, `arg-inl.h:225`)

`gjs -m` probe: `GLib.Variant('x'/'t', BigInt).deepUnpack()` → node-gi matches gjs **byte-for-byte** (values + warning text).

## Changes
- `src/common.h`: shared `JsValueToInt64/Uint64` (IN, `IsBigInt`-first) + `WarnIfUnsafeInt64/Uint64` (OUT) + `kMaxSafeJsInteger`.
- `src/marshal.cc`, `src/object.cc` (incl. LP64 `glong`/`gulong`), `src/variant.cc` (`'x'`/`'t'`) routed through the helpers. 8/16/32-bit paths untouched; `class.cc` sites are `IsNumber()`-guarded already.

## GIMarshallingTests specs (the 30 `phase 2.1` skips)
**18 now pass** (all int64/long/ssize RETURN/OUT + the 6 BigInt-IN specs). **12 stay skipped** — the IN/INOUT specs that pass a plain, inexact JS Number (2^63-1 / 2^64-1 aren't representable), which **GJS itself skips identically**; their reason was retargeted from `phase 2.1` to the upstream `gjs#271` limitation. No upstream assertion weakened.

## Tests
- `test/int64.test.mjs` — typelib-free (keeps `npm test` green; runs node/bun/deno): BigInt round-trips via `GLib.Variant`, scalar gint64 via `GLib.DateTime`, a `registerClass` int64/uint64 GObject property (the GValue path); asserts OUT is a Number, a huge Number no longer crashes, and the OUT warning fires (child-process assertion).
- `conformance/programs/int64.conf.mjs` + golden — tier-A, byte-identical on gjs/node/bun/deno.
- `scripts/cross-runtime.mjs`: `int64` joins the Bun/Deno subset.

## Test plan
- [x] `npm run rebuild`: clean, 0 warnings
- [x] `npm test`: 270/0 fail
- [x] `npm run test:gimarshalling`: 194/0 (30-spec block: 18 pass / 12 gjs#271 skips)
- [x] `npm run test:conformance`: 5 programs × 4 runtimes ✓
- [x] `npm run test:bun` / `test:deno`: 29/29 each