### PR TITLE
fix(node-gi): match gjs for uri/vtype/gtype/arrays

### DIFF
--- a/packages/node-gi/node-gi/conformance/golden/gtype-constants.txt
+++ b/packages/node-gi/node-gi/conformance/golden/gtype-constants.txt
@@ -1,0 +1,25 @@
+TYPE_NONE: void typeof=object defined=true
+TYPE_INTERFACE: GInterface typeof=object defined=true
+TYPE_CHAR: gchar typeof=object defined=true
+TYPE_UCHAR: guchar typeof=object defined=true
+TYPE_BOOLEAN: gboolean typeof=object defined=true
+TYPE_INT: gint typeof=object defined=true
+TYPE_UINT: guint typeof=object defined=true
+TYPE_LONG: glong typeof=object defined=true
+TYPE_ULONG: gulong typeof=object defined=true
+TYPE_INT64: gint64 typeof=object defined=true
+TYPE_UINT64: guint64 typeof=object defined=true
+TYPE_ENUM: GEnum typeof=object defined=true
+TYPE_FLAGS: GFlags typeof=object defined=true
+TYPE_FLOAT: gfloat typeof=object defined=true
+TYPE_DOUBLE: gdouble typeof=object defined=true
+TYPE_STRING: gchararray typeof=object defined=true
+TYPE_POINTER: gpointer typeof=object defined=true
+TYPE_BOXED: GBoxed typeof=object defined=true
+TYPE_PARAM: GParam typeof=object defined=true
+TYPE_OBJECT: GObject typeof=object defined=true
+TYPE_VARIANT: GVariant typeof=object defined=true
+TYPE_GTYPE: GType typeof=object defined=true
+none is a number: false
+type_name(type_from_name("gint")): gint
+type_name(TYPE_STRING): gchararray

--- a/packages/node-gi/node-gi/conformance/golden/out-params.txt
+++ b/packages/node-gi/node-gi/conformance/golden/out-params.txt
@@ -7,3 +7,4 @@ to_signed: [true,-7]
 get_ymd: [2006,1,2]
 filename_charsets shape: true 2
 filename_charsets types: boolean true
+uri_split: [true,"http","user","host",80,"/p","q=1","frag"]

--- a/packages/node-gi/node-gi/conformance/golden/variant-type-prop.txt
+++ b/packages/node-gi/node-gi/conformance/golden/variant-type-prop.txt
@@ -1,0 +1,8 @@
+unset parameterType is null: true
+unset parameterType typeof: object
+single set typeof: object
+single dup_string: s
+tuple dup_string: (si)
+array dup_string: ai
+array is_array: true
+single is_array: false

--- a/packages/node-gi/node-gi/conformance/programs/gtype-constants.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/gtype-constants.conf.mjs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// GObject.TYPE_* fundamental constants — the GJS GObject-override contract, L1.
+//
+// GJS's GObject override defines the fundamental GType constants by looking each
+// name up in libgobject at runtime (refs/gjs/modules/core/overrides/GObject.js
+// `_init`: `GObject.TYPE_STRING = GObject.type_from_name('gchararray')`, plus the
+// `_makeDummyClass` helper for the numeric/char/gtype family). node-gi resolves
+// them the SAME way through the introspected `GObject.type_from_name`, so each is
+// the real, process-correct GType.
+//
+// A GType is an OPAQUE handle (NOT a number) on BOTH runtimes — `typeof` is
+// 'object', never 'number'; the ABI-stable `GObject.type_name(gt)` is the only
+// scalar printed (the handle's own identity is intentionally NOT compared: GJS
+// canonicalises GType objects while node-gi hands back a fresh External per read,
+// so `type_from_name('gint') === TYPE_INT` differs by design and would not be
+// byte-identical — type_name is the stable, meaningful projection).
+import GObject from 'gi://GObject?version=2.0';
+
+// The fundamental set (task list + the standard GLib fundamentals). Order fixed.
+const NAMES = [
+  'TYPE_NONE', 'TYPE_INTERFACE', 'TYPE_CHAR', 'TYPE_UCHAR', 'TYPE_BOOLEAN',
+  'TYPE_INT', 'TYPE_UINT', 'TYPE_LONG', 'TYPE_ULONG', 'TYPE_INT64', 'TYPE_UINT64',
+  'TYPE_ENUM', 'TYPE_FLAGS', 'TYPE_FLOAT', 'TYPE_DOUBLE', 'TYPE_STRING',
+  'TYPE_POINTER', 'TYPE_BOXED', 'TYPE_PARAM', 'TYPE_OBJECT', 'TYPE_VARIANT',
+  'TYPE_GTYPE',
+];
+
+for (const name of NAMES) {
+  const gt = GObject[name];
+  print(`${name}: ${GObject.type_name(gt)} typeof=${typeof gt} defined=${gt !== undefined}`);
+}
+
+// A GType is never a number (the whole point — matches GJS's opaque GType object).
+print('none is a number:', typeof GObject.TYPE_INT === 'number');
+// The constant round-trips through type_name → the same registered name.
+print('type_name(type_from_name("gint")):', GObject.type_name(GObject.type_from_name('gint')));
+// A constant is usable as a GType IN arg (GObject.type_name reads it back).
+print('type_name(TYPE_STRING):', GObject.type_name(GObject.TYPE_STRING));

--- a/packages/node-gi/node-gi/conformance/programs/out-params.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/out-params.conf.mjs
@@ -4,11 +4,10 @@
 // surfaced as a bare value (one), an Array (several), with array-length OUT
 // params consumed (shell_parse_argv's argc never appears in the tuple).
 //
-// Deliberately NOT probed (known node-gi divergence, simplified out of the
-// seed): GLib.uri_split — GJS 1.88 KEEPS the `(skip)`-annotated gboolean return
-// in the tuple (8 elements, leading `true`); node-gi honours the annotation and
-// omits it (7). Grows its own program + ledger entry (or a node-gi fix to
-// mirror GJS exactly) once resolved.
+// Includes GLib.uri_split — GJS 1.88 KEEPS the `(skip)`-annotated gboolean return
+// as the LEADING tuple element (8 elements, `[true, …]`): the `(skip)` annotation
+// is IGNORED for the JS return. node-gi now matches (calls.cc return-tuple
+// assembly); earlier it honoured the annotation and omitted the boolean (7).
 import GLib from 'gi://GLib?version=2.0';
 
 // gboolean return + OUT strv (argc length param consumed) → [ok, argv].
@@ -33,3 +32,8 @@ print('get_ymd:', JSON.stringify(dt.get_ymd()));
 const charsets = GLib.get_filename_charsets();
 print('filename_charsets shape:', Array.isArray(charsets), charsets.length);
 print('filename_charsets types:', typeof charsets[0], Array.isArray(charsets[1]));
+
+// (skip)-annotated gboolean return + 7 OUT scheme/userinfo/host/port/path/query/
+// fragment. The boolean still LEADS the tuple (8 elements) — GJS ignores the skip
+// annotation for the JS return. The input is fixed, so the full tuple is printed.
+print('uri_split:', JSON.stringify(GLib.uri_split('http://user@host:80/p?q=1#frag', 0)));

--- a/packages/node-gi/node-gi/conformance/programs/props-casing.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/props-casing.conf.mjs
@@ -5,10 +5,9 @@
 // camelCase/snake_case for PROPERTY accessors and construct keys; METHODS stay
 // snake_case (GJS does not alias methods — the gold standard rules here).
 //
-// Deliberately NOT probed (known node-gi milestone-1 gap, simplified out of the
-// seed): reading a GVariantType-typed property (Gio.SimpleAction.parameterType)
-// throws "Unsupported property GType GVariantType" on node — grows its own
-// program + ledger entry once boxed property GTypes land.
+// GVariantType-typed property reads (Gio.SimpleAction.parameterType) are covered
+// by the sibling program variant-type-prop.conf.mjs — node-gi now surfaces them as
+// null (unset) / a GLib.VariantType (set) instead of throwing.
 import Gio from 'gi://Gio?version=2.0';
 
 const action = new Gio.SimpleAction({ name: 'demo', enabled: false });

--- a/packages/node-gi/node-gi/conformance/programs/variant-type-prop.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/variant-type-prop.conf.mjs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// GVariantType-typed GObject property reads — the GJS boxed-property contract.
+//
+// Gio.SimpleAction:parameter-type is a GVariantType-typed property (a boxed
+// `G_TYPE_VARIANT_TYPE`). GJS surfaces it as:
+//   • null                        when unset (the default);
+//   • a GLib.VariantType instance when set — `.dup_string()` is the type string.
+// node-gi's GValueToJs now marshals a boxed GValue the same way (null on a NULL
+// pointer, else a wrapped boxed handle whose L1 wrapper routes the introspected
+// GLib.VariantType methods) instead of throwing "Unsupported property GType".
+//
+// GLib/Gio only (no GIMarshallingTests typelib) so it runs UNCHANGED on all four
+// runtimes and its STDOUT must be byte-identical to the gjs golden.
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+
+// Unset → null, not a throw.
+const unset = new Gio.SimpleAction({ name: 'demo' });
+print('unset parameterType is null:', unset.parameterType === null);
+print('unset parameterType typeof:', typeof unset.parameterType);
+
+// Set via the static ctor taking a GVariantType → reads back a GLib.VariantType.
+const single = Gio.SimpleAction.new('single', GLib.VariantType.new('s'));
+print('single set typeof:', typeof single.parameterType);
+print('single dup_string:', single.parameterType.dup_string());
+
+const tuple = Gio.SimpleAction.new('tuple', GLib.VariantType.new('(si)'));
+print('tuple dup_string:', tuple.parameterType.dup_string());
+
+const array = Gio.SimpleAction.new('array', GLib.VariantType.new('ai'));
+print('array dup_string:', array.parameterType.dup_string());
+// The wrapped handle answers other introspected VariantType methods too.
+print('array is_array:', array.parameterType.is_array());
+print('single is_array:', single.parameterType.is_array());

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -1354,6 +1354,52 @@ function mergeFlags(introspected, convenience) {
 // introspection. Merged enums are cached so identity is stable.
 const OVERLAY_NAMES = new Set(['registerClass', 'ParamSpec', 'ParamFlags', 'SignalFlags']);
 
+// The fundamental GObject.TYPE_* constants. GJS defines these in its GObject
+// override by looking each name up in libgobject AT RUNTIME (not hardcoding the
+// fundamental ints): refs/gjs/modules/core/overrides/GObject.js `_init` —
+// `GObject.TYPE_STRING = GObject.type_from_name('gchararray')`, and the
+// `_makeDummyClass(obj, name, upperName, gtypeName, …)` helper for the numeric/
+// char/gtype family. We resolve them the SAME way through the introspected
+// `GObject.type_from_name`, so each constant is the real, process-correct GType —
+// an OPAQUE GType handle exactly like GJS (`typeof GObject.TYPE_INT === 'object'`,
+// NOT the number 24; `GObject.type_from_name('gint') === GObject.TYPE_INT`), never
+// a hardcoded fundamental value. Map: constant name → the registered GType name.
+// (TYPE_JSOBJECT is intentionally omitted — 'JSObject' is a GJS-internal boxed type
+// that libgobject does not register on a plain node-gi host, so it has no correct
+// value here.)
+const GTYPE_CONSTANT_NAMES = {
+  TYPE_NONE: 'void',
+  TYPE_INTERFACE: 'GInterface',
+  TYPE_CHAR: 'gchar',
+  TYPE_UCHAR: 'guchar',
+  TYPE_BOOLEAN: 'gboolean',
+  TYPE_INT: 'gint',
+  TYPE_UINT: 'guint',
+  TYPE_LONG: 'glong',
+  TYPE_ULONG: 'gulong',
+  TYPE_INT64: 'gint64',
+  TYPE_UINT64: 'guint64',
+  TYPE_ENUM: 'GEnum',
+  TYPE_FLAGS: 'GFlags',
+  TYPE_FLOAT: 'gfloat',
+  TYPE_DOUBLE: 'gdouble',
+  TYPE_STRING: 'gchararray',
+  TYPE_POINTER: 'gpointer',
+  TYPE_BOXED: 'GBoxed',
+  TYPE_PARAM: 'GParam',
+  TYPE_OBJECT: 'GObject',
+  TYPE_VARIANT: 'GVariant',
+  TYPE_GTYPE: 'GType',
+  TYPE_UNICHAR: 'gint',
+};
+
+function isGObjectOverlayName(prop) {
+  return (
+    typeof prop === 'string' &&
+    (OVERLAY_NAMES.has(prop) || Object.prototype.hasOwnProperty.call(GTYPE_CONSTANT_NAMES, prop))
+  );
+}
+
 function decorateGObjectNamespace(baseNs) {
   const cache = new Map();
   const resolve = (prop) => {
@@ -1363,15 +1409,20 @@ function decorateGObjectNamespace(baseNs) {
     else if (prop === 'ParamSpec') value = ParamSpec;
     else if (prop === 'ParamFlags') value = mergeFlags(baseNs.ParamFlags, ParamFlags);
     else if (prop === 'SignalFlags') value = mergeFlags(baseNs.SignalFlags, SignalFlags);
+    else if (Object.prototype.hasOwnProperty.call(GTYPE_CONSTANT_NAMES, prop)) {
+      // Resolve the real GType from libgobject via the introspected type_from_name
+      // (0 / unregistered → null, matching object.cc's GType marshalling).
+      value = baseNs.type_from_name(GTYPE_CONSTANT_NAMES[prop]);
+    }
     cache.set(prop, value);
     return value;
   };
   return new Proxy(baseNs, {
     get(t, prop) {
-      return typeof prop === 'string' && OVERLAY_NAMES.has(prop) ? resolve(prop) : t[prop];
+      return isGObjectOverlayName(prop) ? resolve(prop) : t[prop];
     },
     has(t, prop) {
-      return (typeof prop === 'string' && OVERLAY_NAMES.has(prop)) || prop in t;
+      return isGObjectOverlayName(prop) || prop in t;
     },
   });
 }

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -418,10 +418,23 @@ testUnixIntegerTypedefMarshalling('pid_t', 12345);
 testUnixIntegerTypedefMarshalling('socklen_t', 123);
 testUnixIntegerTypedefMarshalling('uid_t', 65534);
 
-// GObject.TYPE_NONE/TYPE_STRING come from GJS's GObject override, which the L1
-// GObject overlay does not carry yet — and gtype_in with a wrong value
-// g_asserts fatally inside the C library, so this section must not run.
-describeSkip('phase 2.6 GType — GType marshalling + GJS GObject-override constants (GObject.TYPE_*, JS-type→GType coercion)',
+// The GObject.TYPE_* fundamental constants now EXIST in the L1 GObject overlay
+// (resolved via the introspected GObject.type_from_name, like GJS's override —
+// see gi.js GTYPE_CONSTANT_NAMES) and are validated byte-for-byte against gjs by
+// the tier-A conformance program conformance/programs/gtype-constants.conf.mjs.
+// The gimarshalling GType section still cannot run, for TWO independent reasons
+// (verified against the built typelib):
+//   1. GType OUT/INOUT params are not marshalled yet — gtype_out / gtype_string_out
+//      / gtype_inout throw "OUT type tag 12 (GI_TYPE_TAG_GTYPE) parameters are not
+//      yet supported", so testSimpleMarshalling's out/inout expansions fail.
+//   2. The two "implicitly converted" specs need GJS's GObject dummy-type aliases
+//      (GObject.VoidType / Int / … carrying `$gtype`) + JS-type→GType coercion
+//      (String → G_TYPE_STRING). node-gi has neither, and gtype_in(GObject.VoidType)
+//      passes an undefined/wrong GType → the C library g_asserts FATALLY (SIGABRT,
+//      gimarshallingtests.c:1571 `gtype == G_TYPE_NONE`), which would abort the whole
+//      run. Both are out of scope for the TYPE_* constants fix — keep skipped until
+//      GType OUT marshalling + the JS-type→GType aliases land.
+describeSkip('phase 2.6 GType — needs GType OUT-param marshalling (tag 12) + GJS GObject dummy-type aliases/JS-type→GType coercion; TYPE_* constants now exist (see gtype-constants.conf.mjs). gtype_in(GObject.VoidType) g_asserts fatally in the C lib',
     'GType');
 
 describe('UTF-8 string', function () {
@@ -431,10 +444,14 @@ describe('UTF-8 string', function () {
         },
     });
 
-    itSkip('phase 2.2 arrays — a UTF-8 string arg typed as uint8 array (utf8_as_uint8array_in) is rejected: "expected an array for the array argument"',
-        'marshals value as a byte array', function () {
-            expect(() => GIMarshallingTests.utf8_as_uint8array_in('const ♥ utf8')).not.toThrow();
-        });
+    // node-gi now accepts a JS STRING for a uint8/int8-element array arg,
+    // encoding it to UTF-8 bytes exactly as GJS does (refs/gjs/gi/arg.cpp
+    // "Allow strings as int8/uint8/int16/uint16 arrays" → gjs_string_to_intarray).
+    // The rest of the array phase (2.2) stays skipped; only this string→uint8array
+    // path is live. Verified: gjs -m accepts the same call without throwing.
+    it('marshals value as a byte array', function () {
+        expect(() => GIMarshallingTests.utf8_as_uint8array_in('const ♥ utf8')).not.toThrow();
+    });
 
     it('makes a default out value for a broken C function', function () {
         expect(GIMarshallingTests.utf8_dangling_out()).toBeNull();

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -626,10 +626,18 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   std::vector<Napi::Value> results;
   GITypeInfo* return_type = gi_callable_info_get_return_type(callable);
   GITransfer return_transfer = gi_callable_info_get_caller_owns(callable);
-  // A (skip)-annotated return is omitted from BOTH the count and the tuple — the
-  // OUT params alone shape the result (mirrors GJS/node-gtk ShouldSkipReturn).
-  if (gi_type_info_get_tag(return_type) != GI_TYPE_TAG_VOID &&
-      !gi_callable_info_skip_return(callable)) {
+  // A non-void return ALWAYS leads the tuple — the `(skip)` annotation is IGNORED
+  // for the JS return, exactly as GJS does. GJS's arg-cache derives `m_has_return`
+  // purely from the return type (non-void, or a pointer) and unconditionally counts
+  // it (refs/gjs/gi/arg-cache.cpp: initialize() `m_has_return = tag != VOID || …`,
+  // build_return() `*inc_counter_out = true`); nothing in gjs's marshalling consults
+  // `gi_callable_info_skip_return`. Verified against gjs 1.88:
+  //   GLib.uri_split('http://user@host:80/p?q=1#frag', 0)
+  //     → [true, 'http', 'user', 'host', 80, '/p', 'q=1', 'frag']   (8, leading bool)
+  // even though g_uri_split's gboolean return carries `skip="1"` (and throws). node-gi
+  // previously honoured the annotation and dropped it (7) — a divergence from the gold
+  // standard. (node-gtk's ShouldSkipReturn does honour it; we match GJS, not node-gtk.)
+  if (gi_type_info_get_tag(return_type) != GI_TYPE_TAG_VOID) {
     results.push_back(ReadOutOrReturn(env, callable, return_type, &retval, return_transfer, &slots));
   }
   gi_base_info_unref(return_type);

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -825,6 +825,24 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
     return true;
   }
 
+  // A JS string as an int8/uint8 C array → its UTF-8 bytes, exactly as GJS does
+  // (refs/gjs/gi/arg.cpp: "Allow strings as int8/uint8/int16/uint16 arrays" →
+  // gjs_string_to_intarray → gjs_string_to_utf8_n for the int8/uint8 element tags).
+  // The length is the UTF-8 BYTE count (not the JS string length, not NUL-inclusive);
+  // a zero-terminated array still gets its trailing NUL slot from g_malloc0.
+  // Verified against gjs 1.88: GIMarshallingTests.utf8_as_uint8array_in('const ♥ utf8')
+  // is accepted (no throw). A real Uint8Array/Array still works via the paths around this.
+  if (isByte && v.IsString()) {
+    std::string s = v.As<Napi::String>().Utf8Value();
+    size_t n = s.size();
+    void* buf = g_malloc0(elemSize * (n + (zt ? 1 : 0)));
+    memcpy(buf, s.data(), n);
+    *outPtr = buf;
+    *outCount = static_cast<long>(n);
+    gi_base_info_unref(elem);
+    return true;
+  }
+
   if (!v.IsArray()) {
     gi_base_info_unref(elem);
     Napi::TypeError::New(env, "expected an array for the array argument")

--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -83,6 +83,26 @@ Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
       if (var == nullptr) return env.Null();
       return WrapVariant(env, var, GI_TRANSFER_NOTHING);
     }
+    case G_TYPE_BOXED: {
+      // A boxed-typed property/signal value (e.g. Gio.SimpleAction:parameter-type →
+      // GVariantType, a boxed `G_TYPE_VARIANT_TYPE`). g_value_get_boxed BORROWS the
+      // payload; copy so our handle owns its own and can g_boxed_free it on GC.
+      // An UNSET boxed property (NULL pointer) → null, matching GJS — NOT a throw.
+      // Verified against gjs 1.88:
+      //   new Gio.SimpleAction({name:'x'}).parameterType                    → null
+      //   Gio.SimpleAction.new('y', GLib.VariantType.new('s')).parameterType
+      //     .dup_string()                                                    → 's'
+      // The wrapped boxed handle carries its GType, so L1 wrapBoxed routes
+      // `.dup_string()` etc. through CallBoxedMethod (gi_repository_find_by_gtype →
+      // GLib.VariantType struct methods). (GVariant is fundamental, handled by its
+      // own G_TYPE_VARIANT case above; GStrv/GByteArray-as-array reads — a GJS
+      // niceness, refs/gjs/gi/value.cpp:1020/1029 — stay a follow-up: they land here
+      // as a boxed handle rather than a string/byte array, but no longer throw.)
+      gpointer boxed = g_value_get_boxed(v);
+      if (boxed == nullptr) return env.Null();
+      GType bt = G_VALUE_TYPE(v);
+      return MakeBoxedHandle(env, g_boxed_copy(bt, boxed), bt, true);
+    }
     case G_TYPE_OBJECT:
       // Signal/property object values are transfer-none borrows; WrapGObject refs.
       return WrapGObject(env, static_cast<GObject*>(g_value_get_object(v)), GI_TRANSFER_NOTHING);

--- a/packages/node-gi/node-gi/test/out-params.test.mjs
+++ b/packages/node-gi/node-gi/test/out-params.test.mjs
@@ -77,16 +77,24 @@ test('OUT string array → [bool, string[]]: GLib.get_filename_charsets()', () =
   assert.ok(res[1].every((c) => typeof c === 'string'));
 });
 
-test('(skip) return is omitted from the tuple: GLib.uri_split()', () => {
+test('(skip)-annotated return still LEADS the tuple (GJS ignores skip): GLib.uri_split()', () => {
   // gboolean g_uri_split(uri_ref, flags, scheme, userinfo, host, port, path,
-  //   query, fragment, GError**) — the gboolean return is annotated (skip), so
-  //   the result is the 7 OUT values ALONE, with NO leading boolean. Without the
-  //   skip handling this would be an 8-element [true, scheme, …] tuple.
+  //   query, fragment, GError**). g_uri_split's gboolean return carries `skip="1"`
+  //   in the GIR (and the function throws), yet GJS 1.88 KEEPS it as the leading
+  //   tuple element — the `(skip)` annotation is IGNORED for the JS return. GJS's
+  //   arg-cache derives `m_has_return` purely from the return type and always counts
+  //   it (refs/gjs/gi/arg-cache.cpp); nothing there consults skip_return. Verified
+  //   against the gold standard (gjs -m):
+  //     GLib.uri_split('http://user@host:80/p?q=1#frag', 0)
+  //       → [true, 'http', 'user', 'host', 80, '/p', 'q=1', 'frag']   (8 elements)
+  //   node-gi previously honoured the annotation and dropped the boolean (7); this
+  //   corrected assertion tracks the gold standard (see the calls.cc return-tuple
+  //   comment). node-gtk's ShouldSkipReturn honours skip — we match GJS, not node-gtk.
   const res = callFunction('GLib', 'uri_split', ['http://user@host:80/p?q=1#frag', 0]);
   assert.ok(Array.isArray(res));
-  assert.equal(res.length, 7);
-  assert.deepEqual(res, ['http', 'user', 'host', 80, '/p', 'q=1', 'frag']);
-  assert.notEqual(res[0], true); // the skipped gboolean must not lead the tuple
+  assert.equal(res.length, 8);
+  assert.deepEqual(res, [true, 'http', 'user', 'host', 80, '/p', 'q=1', 'frag']);
+  assert.equal(res[0], true); // the (skip)-annotated gboolean still leads the tuple
 });
 
 test('transfer-full string IN is g_strdup`d, not a freed std::string buffer', () => {


### PR DESCRIPTION
## Summary

Four small GJS-fidelity fixes, each verified byte-for-byte against `gjs -m` (the gold standard) and each un-skipping / un-blocking GIMarshallingTests coverage.

### 1. `(skip)`-annotated return still leads the tuple
`GLib.uri_split(...)` returned a 7-element tuple (dropped the gboolean); gjs returns **8** (`[true,'http',…]`). GJS's arg-cache derives the return purely from the return type and **never** consults `gi_callable_info_skip_return` for the JS tuple (grep-confirmed) — node-gtk honours skip, GJS does not, and node-gi wrongly copied node-gtk. Fixed in `src/calls.cc`; corrected the (wrong) assertion in `test/out-params.test.mjs` to match gjs.

### 2. GVariantType property → `null`/VariantType, not a throw
`Gio.SimpleAction.parameterType` threw; gjs returns `null` (unset) or a `GLib.VariantType` (set). Fixed in `src/object.cc` `GValueToJs` (`G_TYPE_BOXED`: NULL→null, else a boxed handle). Both cases verified vs gjs.

### 3. `GObject.TYPE_*` constants
Added the 22 well-known GType constants to the L1 GObject overlay, resolved through the introspected `GObject.type_from_name` (not hardcoded — GTypes are **opaque objects, not numbers**, verified vs gjs). New tier-A program covers them on 4 runtimes.

### 4. `utf8_as_uint8array_in` accepts a string
A JS string now marshals as UTF-8 bytes for int8/uint8-element C arrays (as gjs does, `refs/gjs/gi/arg.cpp`); Uint8Array/Array still work. Fixed in `src/marshal.cc` `JsToCArray`; un-skipped the matching spec.

## Kept-skipped (new precise reasons, reported not weakened)
- The gimarshalling `GType` section stays skipped: GType OUT/INOUT is unimplemented AND `gtype_in(GObject.VoidType)` `g_assert`-aborts in the C lib because `GObject.VoidType` isn't aliased yet — out of scope, must not run.
- GStrv/GByteArray property reads now surface a boxed handle (no longer throw) but aren't array-shaped yet — documented follow-up.

## New conformance programs
`gtype-constants.conf.mjs`, `variant-type-prop.conf.mjs` + `out-params` extended — all byte-identical on gjs/node/bun/deno.

## Test plan
- [x] `npm run rebuild`: 0 warnings
- [x] `npm test`: 259/0 fail
- [x] `npm run test:gimarshalling`: 176/0 (+1 un-skipped vs main)
- [x] `npm run test:conformance`: 7/7 programs × 4 runtimes
- [x] `npm run test:bun` / `test:deno`: 29/29 each