### PR TITLE
feat(node-gi): container + compound-out marshalling

### DIFF
--- a/packages/node-gi/node-gi/conformance/golden/array-in-out.txt
+++ b/packages/node-gi/node-gi/conformance/golden/array-in-out.txt
@@ -1,0 +1,11 @@
+getenv B: two
+getenv missing: null
+setenv has D: true
+setenv len: 4
+joined: usr/local/bin
+b64 array: aGkh
+b64 typed: AQIDBA==
+b64 decoded: [104,105,33]
+parse ok: true
+parse argv: ["prog","--flag","value"]
+uris: ["http://a.example","http://b.example"]

--- a/packages/node-gi/node-gi/conformance/golden/list-hash.txt
+++ b/packages/node-gi/node-gi/conformance/golden/list-hash.txt
@@ -1,0 +1,8 @@
+hash a: 1
+hash b: two
+hash c: 3
+hash d: ""
+hash keys: ["a","b","c","d"]
+registered isArray: true
+registered all strings: true
+semi x: 10 semi y: 20

--- a/packages/node-gi/node-gi/conformance/golden/struct-out.txt
+++ b/packages/node-gi/node-gi/conformance/golden/struct-out.txt
@@ -1,0 +1,9 @@
+tz id: UTC
+year: 2006
+month: 1
+day: 2
+hour: 15
+ymd: [2006,1,2]
+plus hour: 16
+diff us: 3600000000
+format: 2006-01-02 15:04:05

--- a/packages/node-gi/node-gi/conformance/programs/array-in-out.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/array-in-out.conf.mjs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// Container IN + compound array OUT via headless GLib (no test typelib needed).
+// Exercises the phase-2.2 marshalling: a JS array rebuilt as a C array / GStrv IN,
+// a byte array IN with an autofilled length, a byte array OUT sized by an OUT
+// length arg, and a C string array OUT alongside a gboolean return — each surfaced
+// exactly as GJS does. The golden is the gjs output; node/bun/deno must match it
+// byte-for-byte.
+import GLib from 'gi://GLib?version=2.0';
+
+// GStrv IN (transfer none) + string return: the JS string[] becomes a
+// NULL-terminated char** the callee borrows; the returned value points into it.
+const envp = ['A=1', 'B=two', 'C=3'];
+print('getenv B:', GLib.environ_getenv(envp, 'B'));
+print('getenv missing:', GLib.environ_getenv(envp, 'NOPE'));
+
+// GStrv IN (transfer full) + GStrv return: the callee adopts the array we built
+// and hands back a fresh one — surfaced as a string[].
+const updated = GLib.environ_setenv(envp, 'D', '4', true);
+print('setenv has D:', updated.includes('D=4'));
+print('setenv len:', updated.length);
+
+// GStrv IN + string return (strjoinv joins a NULL-terminated char**).
+print('joined:', GLib.strjoinv('/', ['usr', 'local', 'bin']));
+
+// C byte array IN with an AUTOFILLED length arg: base64_encode(data, len) has len
+// annotated as data's length, so it is consumed from the array — the idiomatic
+// single-arg call (GJS auto-fills it too). The input is a plain JS number[].
+print('b64 array:', GLib.base64_encode([104, 105, 33]));
+// …and from a typed array (Uint8Array → raw bytes).
+print('b64 typed:', GLib.base64_encode(Uint8Array.from([1, 2, 3, 4])));
+
+// C byte array OUT sized by an OUT length arg → a Node Buffer / GJS Uint8Array;
+// spread to a plain number[] so the printed form is identical across runtimes.
+const decoded = GLib.base64_decode('aGkh');
+print('b64 decoded:', JSON.stringify([...decoded]));
+
+// gboolean return + C string array (GStrv) OUT + the argc length arg consumed:
+// [ok, argv]. shell_parse_argv is deterministic for a fixed command line.
+const [ok, argv] = GLib.shell_parse_argv('prog --flag value');
+print('parse ok:', ok);
+print('parse argv:', JSON.stringify(argv));
+
+// zero-terminated, transfer-full C string array return.
+const uris = GLib.uri_list_extract_uris('http://a.example\r\nhttp://b.example\r\n');
+print('uris:', JSON.stringify(uris));

--- a/packages/node-gi/node-gi/conformance/programs/list-hash.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/list-hash.conf.mjs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// GList / GSList / GHashTable OUT via headless GLib (no test typelib needed).
+// Exercises phase-2.3: a transfer-full GHashTable<utf8,utf8> read into a plain
+// object, and GSList/GList string returns read into arrays — surfaced exactly as
+// GJS does. The golden is the gjs output; node/bun/deno must match byte-for-byte.
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+// GHashTable<utf8,utf8> OUT (transfer full: keys + values both owned + decoded).
+const params = GLib.Uri.parse_params('a=1&b=two&c=3&d=', -1, '&', 0);
+print('hash a:', params.a);
+print('hash b:', params.b);
+print('hash c:', params.c);
+print('hash d:', JSON.stringify(params.d));
+print('hash keys:', JSON.stringify(Object.keys(params).sort()));
+
+// GList<utf8> return (registered content types). Empty on a minimal host, non-empty
+// otherwise — either way a string[]; assert the SHAPE only (deterministic across
+// runtimes on the same machine), never the host-dependent values.
+const registered = Gio.content_types_get_registered();
+print('registered isArray:', Array.isArray(registered));
+print('registered all strings:', registered.every((t) => typeof t === 'string'));
+
+// GHashTable round-trips a fixed input deterministically — a second parse with a
+// different separator proves the key/value decoding is content-driven, not cached.
+const semi = GLib.Uri.parse_params('x=10;y=20', -1, ';', 0);
+print('semi x:', semi.x, 'semi y:', semi.y);

--- a/packages/node-gi/node-gi/conformance/programs/struct-out.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/struct-out.conf.mjs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+// Struct / boxed OUT via headless GLib (no test typelib needed). Exercises phase-2.4
+// compound OUT: a boxed struct returned as a handle and assembled into the return
+// tuple, void-return + multiple int OUT params on a boxed instance, and the boxed
+// handle round-tripping back into a method as an IN arg. The golden is the gjs
+// output; node/bun/deno must match it byte-for-byte.
+import GLib from 'gi://GLib?version=2.0';
+
+// Boxed struct RETURN (GLib.TimeZone is a boxed type) → a method-routing handle.
+const utc = GLib.TimeZone.new_utc();
+print('tz id:', utc.get_identifier());
+
+// Boxed struct RETURN (GLib.DateTime is boxed). 1136214245 = 2006-01-02 15:04:05 UTC.
+const dt = GLib.DateTime.new_from_unix_utc(1136214245);
+print('year:', dt.get_year());
+print('month:', dt.get_month());
+print('day:', dt.get_day_of_month());
+print('hour:', dt.get_hour());
+
+// void return + three int OUT params on the boxed instance → [y, m, d]. This is the
+// compound OUT tuple: no return value, three OUT ints surfaced as an array.
+print('ymd:', JSON.stringify(dt.get_ymd()));
+
+// Boxed method returning a NEW boxed (chained struct OUT) + a boxed IN round-trip:
+// add an hour, then diff the two boxed DateTimes (the older one passed back IN).
+const dtPlus = dt.add_hours(1);
+print('plus hour:', dtPlus.get_hour());
+print('diff us:', dtPlus.difference(dt));
+
+// Boxed RETURN that can be NULL is surfaced as null (not a dangling handle):
+// an out-of-range unix time still yields a valid boxed handle here, so format it.
+print('format:', dt.format('%Y-%m-%d %H:%M:%S'));

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -168,6 +168,13 @@ function wrapReturn(value) {
   // to give it the Variant ergonomics rather than a plain method-routing proxy.
   if (native.isVariantHandle(value)) return wrapVariant(value);
   if (native.isBoxedHandle(value)) return wrapBoxed(value);
+  // A multi-value OUT tuple (return value + OUT params) — or a container OUT — is a
+  // plain JS Array whose ELEMENTS may themselves be GObject/boxed/variant handles
+  // (e.g. GLib.Regex.match → [matched, GLib.MatchInfo]; an array-of-objects OUT).
+  // Recurse so a handle sitting inside the tuple is wrapped into a usable proxy,
+  // not left as a raw External. A Node Buffer (byte array) is NOT Array.isArray, so
+  // it passes through untouched; primitives/strings map to themselves.
+  if (Array.isArray(value)) return value.map(wrapReturn);
   return value;
 }
 

--- a/packages/node-gi/node-gi/gimarshalling/jasmine-shim.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/jasmine-shim.mjs
@@ -161,7 +161,14 @@ function equals(a, b) {
   }
   if (ArrayBuffer.isView(a) || ArrayBuffer.isView(b)) {
     if (!ArrayBuffer.isView(a) || !ArrayBuffer.isView(b)) return false;
-    if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b) || a.length !== b.length) return false;
+    // Compare by TypedArray FAMILY (via the toStringTag) + length + elements, NOT
+    // prototype identity: node-gi surfaces a byte array as a Node `Buffer` (a
+    // Uint8Array subclass) where GJS returns a plain `Uint8Array` — byte-identical
+    // content, different prototype. `Object.prototype.toString` reports both as
+    // `[object Uint8Array]` while still distinguishing Int8Array/Float32Array/…,
+    // so this accepts the Buffer↔Uint8Array pair without weakening element checks.
+    const tag = (x) => Object.prototype.toString.call(x);
+    if (tag(a) !== tag(b) || a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
       if (!Object.is(a[i], b[i])) return false;
     }

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -65,6 +65,7 @@ import {
     expect,
     it,
     itSkip,
+    jasmine,
     pending,
 } from './jasmine-shim.mjs';
 
@@ -169,6 +170,47 @@ function testTransferMarshalling(root, value, inoutValue, defaultValue, options 
         testSimpleMarshalling(`${root}_full`, value, inoutValue, defaultValue, fullOptions);
     });
 }
+
+// Ported verbatim from upstream (installed-tests/js/testGIMarshalling.js): the
+// container helper adds a `with transfer container` block on top of none/full.
+// Container-IN + container-INOUT are the upstream gjs#44 skips (rebuilding a
+// caller-owned container the callee then adopts element-by-element is unsupported
+// there too); node-gi additionally defers ALL container INOUT (phase 2.5), which
+// testSimpleMarshalling already routes through the per-call skip options below.
+function testContainerMarshalling(root, value, inoutValue, defaultValue, options = {}) {
+    testTransferMarshalling(root, value, inoutValue, defaultValue, options);
+    describe('with transfer container', function () {
+        const containerOptions = {
+            in: {
+                skip: 'https://gitlab.gnome.org/GNOME/gjs/issues/44',
+            },
+            inout: {
+                skip: 'https://gitlab.gnome.org/GNOME/gjs/issues/44',
+            },
+        };
+        Object.assign(containerOptions, options.container);
+        testSimpleMarshalling(`${root}_container`, value, inoutValue, defaultValue, containerOptions);
+    });
+}
+
+// ---- phase-2.2/2.3/2.4 skip reasons (scoped OUT of this container/compound-OUT
+// PR; each cites the roadmap item that will land it). INOUT containers (2.5),
+// struct FIELD access (2.6) and GLib.Variant/GParamSpec element marshalling (2.7)
+// are the deferred pieces the sections below route their sub-specs through. ----
+const SKIP_INOUT_CONTAINER =
+    'phase 2.5 INOUT containers — read-modify-write of a caller-built container ' +
+    '(GArray/GList/GHashTable/array inout) is a later PR; pure IN + compound OUT are live';
+const SKIP_STRUCT_FIELDS =
+    'phase 2.6 struct field access — the value marshals (a boxed handle is returned/passed), ' +
+    'but reading GIMarshallingTests struct fields (.long_/.int8) to VERIFY it needs field access, a later PR';
+const SKIP_ENUM_FLAGS_ARRAY =
+    'phase 2.2 arrays — enum/flags array elements are not yet marshalled (element-type gap), a later PR';
+const SKIP_UNICHAR_ARRAY =
+    'phase 2.2 arrays — unichar array elements (gunichar<->string) are not yet marshalled, a later PR';
+const SKIP_GVARIANT_ARRAY =
+    'phase 2.7 — arrays of GLib.Variant (boxed/variant elements) are not yet marshalled, a later PR';
+const SKIP_GVALUE_ARRAY =
+    'phase 2.5 GValue — arrays of GValue elements are not yet marshalled, a later PR';
 
 // Integer limits, defined without reference to GLib (because the GLib.MAXINT8
 // etc. constants are also subject to marshalling)
@@ -458,30 +500,450 @@ describe('UTF-8 string', function () {
     });
 });
 
-describeSkip('phase 2.2 arrays — gtk_init-style inout string array (init_function)',
-    'In-out array in the style of gtk_init()');
-describeSkip('phase 2.2 arrays — fixed-size C arrays of ints/shorts (+ caller-allocated out)',
-    'Fixed-size C array');
-describeSkip('phase 2.2 arrays — length-annotated C arrays (bool/unichar/int8..int64/struct/enum/flags/string)',
-    'C array with length');
-describeSkip('phase 2.2 arrays — zero-terminated C arrays (string/glist/uint8)',
-    'Zero-terminated C array');
-describeSkip('phase 2.2 arrays — utf8 arrays × {length,fixed,zero-terminated} × {none,container,full}',
-    'Exhaustive test of UTF-8 sequences');
-describeSkip('phase 2.2 arrays — GArray of int/uint64/utf8 (+ bool/unichar in)',
-    'GArray');
-describeSkip('phase 2.2 arrays — GPtrArray of utf8',
-    'GPtrArray');
-describeSkip('phase 2.2 arrays — GByteArray in/out/return',
-    'GByteArray');
-describeSkip('phase 2.2 arrays — GBytes in/out/return + Uint8Array round-trips',
+// INOUT array (a caller-owned array the callee reallocates) is the phase-2.5
+// read-modify-write container case — deferred.
+describeSkip(SKIP_INOUT_CONTAINER, 'In-out array in the style of gtk_init()');
+
+describe('Fixed-size C array', function () {
+    describe('of ints', function () {
+        testReturnValue('array_fixed_int', [-1, 0, 1, 2]);
+        testInParameter('array_fixed_int', [-1, 0, 1, 2]);
+        testOutParameter('array_fixed', [-1, 0, 1, 2]);
+        testUninitializedOutParameter('array_fixed', null);
+        testOutParameter('array_fixed_caller_allocated', [-1, 0, 1, 2]);
+        testInoutParameter('array_fixed', [-1, 0, 1, 2], [2, 1, 0, -1], {skip: SKIP_INOUT_CONTAINER});
+    });
+
+    describe('of shorts', function () {
+        testReturnValue('array_fixed_short', [-1, 0, 1, 2]);
+        testInParameter('array_fixed_short', [-1, 0, 1, 2]);
+    });
+
+    // array_fixed_out_struct returns a fixed array of structs BY VALUE — reading it
+    // needs per-element struct field access (2.6). The struct OUT marshalling itself
+    // is exercised by the boxed_struct_out_uninitialized case below.
+    itSkip(SKIP_STRUCT_FIELDS, 'marshals a struct array as an out parameter', function () {
+        expect(GIMarshallingTests.array_fixed_out_struct()).toEqual([
+            jasmine.objectContaining({long_: 7, int8: 6}),
+            jasmine.objectContaining({long_: 6, int8: 7}),
+        ]);
+    });
+
+    it('picks a reasonable default for struct array out param when uninitialized', function () {
+        expect(GIMarshallingTests.array_fixed_out_struct_uninitialized()).toEqual([false, null]);
+    });
+
+    itSkip(SKIP_STRUCT_FIELDS, 'marshals a fixed-size struct array as caller allocated out param', function () {
+        expect(GIMarshallingTests.array_fixed_caller_allocated_struct_out()).toEqual([
+            jasmine.objectContaining({long_: -2, int8: -1}),
+            jasmine.objectContaining({long_: 1, int8: 2}),
+            jasmine.objectContaining({long_: 3, int8: 4}),
+            jasmine.objectContaining({long_: 5, int8: 6}),
+        ]);
+    });
+
+    for (const marshal of ['return', 'out']) {
+        it(`handles a ${marshal} array with odd alignment`, function () {
+            const arr = GIMarshallingTests[`array_fixed_${marshal}_unaligned`]();
+            expect(arr.length).toEqual(32);
+            expect(Array.prototype.slice.call(arr, 0, 4)).toEqual([1, 2, 3, 4]);
+            GIMarshallingTests.cleanup_unaligned_buffer();
+        });
+    }
+});
+
+describe('C array with length', function () {
+    testSimpleMarshalling('array', [-1, 0, 1, 2], [-2, -1, 0, 1, 2], [], {
+        inout: {skip: SKIP_INOUT_CONTAINER},
+    });
+
+    it('can be returned along with other arguments', function () {
+        let [array, sum] = GIMarshallingTests.array_return_etc(9, 5);
+        expect(sum).toEqual(14);
+        expect(array).toEqual([9, 0, 1, 5]);
+    });
+
+    it('can be passed to a function with its length parameter before it', function () {
+        expect(() => GIMarshallingTests.array_in_len_before([-1, 0, 1, 2])).not.toThrow();
+    });
+
+    it('can be passed to a function with zero terminator', function () {
+        expect(() => GIMarshallingTests.array_in_len_zero_terminated([-1, 0, 1, 2])).not.toThrow();
+    });
+
+    describe('of strings', function () {
+        testInParameter('array_string', ['foo', 'bar']);
+    });
+
+    it('marshals a byte array as an in parameter', function () {
+        expect(() => GIMarshallingTests.array_uint8_in('abcd')).not.toThrow();
+        expect(() => GIMarshallingTests.array_uint8_in([97, 98, 99, 100])).not.toThrow();
+        expect(() => GIMarshallingTests.array_uint8_in(new TextEncoder().encode('abcd'))).not.toThrow();
+    });
+
+    describe('of signed 64-bit ints', function () {
+        testInParameter('array_int64', [-1, 0, 1, 2]);
+    });
+
+    describe('of unsigned 64-bit ints', function () {
+        testInParameter('array_uint64', [-1, 0, 1, 2]);
+    });
+
+    describe('of unichars', function () {
+        itSkip(SKIP_UNICHAR_ARRAY, 'marshals as an in parameter', function () {
+            expect(() => GIMarshallingTests.array_unichar_in('const ♥ utf8')).not.toThrow();
+        });
+        itSkip(SKIP_UNICHAR_ARRAY, 'marshals as an out parameter', function () {
+            expect(GIMarshallingTests.array_unichar_out()).toEqual('const ♥ utf8');
+        });
+        itSkip(SKIP_UNICHAR_ARRAY, 'marshals from an array of codepoints', function () {
+            const codepoints = [...'const ♥ utf8'].map(c => c.codePointAt(0));
+            expect(() => GIMarshallingTests.array_unichar_in(codepoints)).not.toThrow();
+        });
+    });
+
+    describe('of booleans', function () {
+        testInParameter('array_bool', [true, false, true, true]);
+        testOutParameter('array_bool', [true, false, true, true]);
+
+        it('marshals from an array of numbers', function () {
+            expect(() => GIMarshallingTests.array_bool_in([-1, 0, 1, 2])).not.toThrow();
+        });
+    });
+
+    // Boxed/simple struct array IN builds the input with `new StructType(); struct.long_ = n`
+    // — struct field WRITE access (2.6). Deferred with the struct-fields reason.
+    describeSkip(SKIP_STRUCT_FIELDS, 'of boxed structs');
+    describeSkip(SKIP_STRUCT_FIELDS, 'of simple structs');
+
+    itSkip(SKIP_GVALUE_ARRAY, 'marshals two arrays with the same length parameter', function () {
+        // multi_array_key_value_in(length, const gchar** keys, const GValue* values)
+        // — the values are a GValue array (2.5), not a plain int array.
+        const keys = ['one', 'two', 'three'];
+        const values = [1, 2, 3];
+        expect(() => GIMarshallingTests.multi_array_key_value_in(keys, values)).not.toThrow();
+    });
+
+    itSkip(SKIP_STRUCT_FIELDS, 'copies correctly on transfer full', function () {
+        // array_struct_take_in takes a boxed-struct array built via field writes (2.6).
+        expect(() => {}).not.toThrow();
+    });
+
+    describe('of enums', function () {
+        testInParameter('array_enum', [
+            GIMarshallingTests.Enum.VALUE1,
+            GIMarshallingTests.Enum.VALUE2,
+            GIMarshallingTests.Enum.VALUE3,
+        ], {skip: SKIP_ENUM_FLAGS_ARRAY});
+    });
+
+    describe('of flags', function () {
+        testInParameter('array_flags', [
+            GIMarshallingTests.Flags.VALUE1,
+            GIMarshallingTests.Flags.VALUE2,
+            GIMarshallingTests.Flags.VALUE3,
+        ], {skip: SKIP_ENUM_FLAGS_ARRAY});
+    });
+
+    it('marshals an array with a 64-bit length parameter', function () {
+        expect(() => GIMarshallingTests.array_in_guint64_len([-1, 0, 1, 2])).not.toThrow();
+    });
+
+    it('marshals an array with an 8-bit length parameter', function () {
+        expect(() => GIMarshallingTests.array_in_guint8_len([-1, 0, 1, 2])).not.toThrow();
+    });
+
+    itSkip(SKIP_INOUT_CONTAINER, 'can be an in-out argument', function () {
+        const array = GIMarshallingTests.array_inout([-1, 0, 1, 2]);
+        expect(array).toEqual([-2, -1, 0, 1, 2]);
+    });
+
+    it('can be an out argument along with other arguments', function () {
+        let [array, sum] = GIMarshallingTests.array_out_etc(9, 5);
+        expect(sum).toEqual(14);
+        expect(array).toEqual([9, 0, 1, 5]);
+    });
+
+    itSkip(SKIP_INOUT_CONTAINER, 'can be an in-out argument along with other arguments', function () {
+        let [array, sum] = GIMarshallingTests.array_inout_etc(9, [-1, 0, 1, 2], 5);
+        expect(sum).toEqual(14);
+        expect(array).toEqual([9, -1, 0, 1, 5]);
+    });
+
+    it('does not interpret an unannotated integer as a length parameter', function () {
+        expect(() => GIMarshallingTests.array_in_nonzero_nonlen(42, 'abcd')).not.toThrow();
+    });
+
+    for (const marshal of ['return', 'out']) {
+        it(`handles a ${marshal} array with odd alignment`, function () {
+            const arr = GIMarshallingTests[`array_${marshal}_unaligned`]();
+            expect(arr.length).toEqual(32);
+            expect(Array.prototype.slice.call(arr, 0, 4)).toEqual([1, 2, 3, 4]);
+            GIMarshallingTests.cleanup_unaligned_buffer();
+        });
+    }
+
+    itSkip(SKIP_INOUT_CONTAINER, 'supports optional inout array with length', function () {
+        expect(GIMarshallingTests.length_array_utf8_optional_inout(['🅰', 'β', 'c', 'd']))
+            .toEqual(['a', 'b', '¢', '🔠']);
+    });
+});
+
+describe('Zero-terminated C array', function () {
+    describe('of strings', function () {
+        testSimpleMarshalling('array_zero_terminated', ['0', '1', '2'],
+            ['-1', '0', '1', '2'], null, {inout: {skip: SKIP_INOUT_CONTAINER}});
+    });
+
+    it('marshals null as a zero-terminated array return value', function () {
+        expect(GIMarshallingTests.array_zero_terminated_return_null()).toEqual(null);
+    });
+
+    // The struct return specs (.map(e => e.long_)) need struct field access (2.6).
+    itSkip(SKIP_STRUCT_FIELDS, 'marshals an array of structs as a return value', function () {
+        let structArray = GIMarshallingTests.array_zero_terminated_return_struct();
+        expect(structArray.map(e => e.long_)).toEqual([42, 43, 44]);
+    });
+
+    itSkip(SKIP_STRUCT_FIELDS, 'marshals an array of sequential structs as a return value', function () {
+        let structArray = GIMarshallingTests.array_zero_terminated_return_sequential_struct();
+        expect(structArray.map(e => e.long_)).toEqual([42, 43, 44]);
+    });
+
+    itSkip(SKIP_UNICHAR_ARRAY, 'marshals an array of unichars as a return value', function () {
+        expect(GIMarshallingTests.array_zero_terminated_return_unichar()).toEqual('const ♥ utf8');
+    });
+
+    describeSkip(SKIP_GVARIANT_ARRAY, 'of GLib.Variants');
+});
+
+describe('Exhaustive test of UTF-8 sequences', function () {
+    ['length', 'fixed', 'zero_terminated'].forEach(arrayKind =>
+        ['none', 'container', 'full'].forEach(transfer => {
+            const testFunction = returnMode => {
+                const commonName = 'array_utf8';
+                const funcName = [arrayKind, commonName, transfer, returnMode].join('_');
+                return GIMarshallingTests[funcName];
+            };
+
+            ['out', 'return'].forEach(returnMode =>
+                it(`${arrayKind} ${returnMode} transfer ${transfer}`, function () {
+                    const func = testFunction(returnMode);
+                    expect(func()).toEqual(['a', 'b', '¢', '🔠']);
+                }));
+
+            it(`${arrayKind} in transfer ${transfer}`, function () {
+                const func = testFunction('in');
+                if (transfer === 'container')
+                    pending('https://gitlab.gnome.org/GNOME/gjs/-/issues/44');
+
+                expect(() => func(['🅰', 'β', 'c', 'd'])).not.toThrow();
+            });
+
+            it(`${arrayKind} inout transfer ${transfer}`, function () {
+                pending(SKIP_INOUT_CONTAINER);
+            });
+        }));
+});
+
+describe('GArray', function () {
+    describe('of ints with transfer none', function () {
+        testReturnValue('garray_int_none', [-1, 0, 1, 2]);
+        testInParameter('garray_int_none', [-1, 0, 1, 2]);
+    });
+
+    it('marshals BigInt int64s as a transfer-none in value', function () {
+        GIMarshallingTests.garray_uint64_none_in([0, BigIntLimits.int64.umax]);
+    });
+
+    it('marshals int64s as a transfer-none return value', function () {
+        expect(warn64(true, GIMarshallingTests.garray_uint64_none_return))
+            .toEqual([0, Limits.int64.umax]);
+    });
+
+    describe('of strings', function () {
+        testContainerMarshalling('garray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null, {
+            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
+        });
+
+        // caller-allocated GArray out (gjs#106/#344) — the callee reallocates a
+        // caller-provided GArray; that INOUT-shaped case is out of scope here.
+        itSkip(SKIP_INOUT_CONTAINER, 'marshals as a transfer-full caller-allocated out parameter', function () {
+            expect(GIMarshallingTests.garray_utf8_full_out_caller_allocated())
+                .toEqual(['0', '1', '2']);
+        });
+    });
+
+    // .map(e => e.long_) — struct field access (2.6).
+    itSkip(SKIP_STRUCT_FIELDS, 'marshals boxed structs as a transfer-full return value', function () {
+        expect(GIMarshallingTests.garray_boxed_struct_full_return().map(e => e.long_))
+            .toEqual([42, 43, 44]);
+    });
+
+    describe('of booleans with transfer none', function () {
+        testInParameter('garray_bool_none', [-1, 0, 1, 2]);
+    });
+
+    describe('of unichars', function () {
+        itSkip(SKIP_UNICHAR_ARRAY, 'can be passed in with transfer none', function () {
+            expect(() => GIMarshallingTests.garray_unichar_none_in('const ♥ utf8')).not.toThrow();
+        });
+    });
+});
+
+describe('GPtrArray', function () {
+    describe('of strings', function () {
+        testContainerMarshalling('gptrarray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null, {
+            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
+        });
+    });
+
+    describe('of structs', function () {
+        // .map(e => e.long_) — struct field access (2.6).
+        itSkip(SKIP_STRUCT_FIELDS, 'can be returned with transfer full', function () {
+            expect(GIMarshallingTests.gptrarray_boxed_struct_full_return().map(e => e.long_))
+                .toEqual([42, 43, 44]);
+        });
+    });
+});
+
+describe('GByteArray', function () {
+    const refByteArray = Uint8Array.from([0, 49, 0xFF, 51]);
+
+    testReturnValue('bytearray_full', refByteArray);
+    testOutParameter('bytearray_full', refByteArray);
+    testInoutParameter('bytearray_full', refByteArray, Uint8Array.from([104, 101, 108, 0, 0xFF]),
+        {skip: SKIP_INOUT_CONTAINER});
+
+    it('can be passed in with transfer none', function () {
+        expect(() => GIMarshallingTests.bytearray_none_in(refByteArray)).not.toThrow();
+        expect(() => GIMarshallingTests.bytearray_none_in([0, 49, 0xFF, 51])).not.toThrow();
+    });
+});
+
+// GBytes marshalling (GLib.Bytes.new + .toArray() + implicit Uint8Array→GBytes) is
+// its own phase (2.7) alongside GParamSpec — deferred.
+describeSkip('phase 2.7 — GBytes marshalling (GLib.Bytes.new / .toArray() / Uint8Array→GBytes), a later PR',
     'GBytes');
-describeSkip('phase 2.2 arrays — NULL-terminated string arrays (GStrv)',
-    'GStrv');
-describeSkip('phase 2.2 arrays — length-annotated arrays of GStrv',
+
+describe('GStrv', function () {
+    testSimpleMarshalling('gstrv', ['0', '1', '2'], ['-1', '0', '1', '2'], null,
+        {inout: {skip: SKIP_INOUT_CONTAINER}});
+});
+
+// Arrays whose ELEMENTS are themselves GStrv (nested container elements) are a
+// nested-container case still deferred.
+describeSkip('phase 2.2 arrays — length-annotated arrays of GStrv (nested container elements), a later PR',
     'Array of GStrv');
-describeSkip('phase 2.3 hash-list — GHashTable int/utf8/double/int64/uint64 variants',
-    'GHashTable');
+
+['GList', 'GSList'].forEach(listKind => {
+    const list = listKind.toLowerCase();
+
+    describe(listKind, function () {
+        describe('of ints with transfer none', function () {
+            testReturnValue(`${list}_int_none`, [-1, 0, 1, 2]);
+            testInParameter(`${list}_int_none`, [-1, 0, 1, 2]);
+        });
+
+        if (listKind === 'GList') {
+            describe('of unsigned 32-bit ints with transfer none', function () {
+                testReturnValue('glist_uint32_none', [0, Limits.int32.umax]);
+                testInParameter('glist_uint32_none', [0, Limits.int32.umax]);
+            });
+        }
+
+        describe('of strings', function () {
+            testContainerMarshalling(`${list}_utf8`, ['0', '1', '2'],
+                ['-2', '-1', '0', '1'], [], {
+                    none: {inout: {skip: SKIP_INOUT_CONTAINER}},
+                    full: {inout: {skip: SKIP_INOUT_CONTAINER}},
+                    container: {inout: {skip: SKIP_INOUT_CONTAINER}},
+                });
+        });
+    });
+});
+
+describe('GHashTable', function () {
+    const numberDict = {
+        '-1': -0.1,
+        0: 0,
+        1: 0.1,
+        2: 0.2,
+    };
+
+    describe('with integer values', function () {
+        const intDict = {
+            '-1': 1,
+            0: 0,
+            1: -1,
+            2: -2,
+        };
+        testReturnValue('ghashtable_int_none', intDict);
+        testInParameter('ghashtable_int_none', intDict);
+    });
+
+    describe('with string values', function () {
+        const stringDict = {
+            '-1': '1',
+            0: '0',
+            1: '-1',
+            2: '-2',
+        };
+        const stringDictOut = {
+            '-1': '1',
+            0: '0',
+            1: '1',
+        };
+        testContainerMarshalling('ghashtable_utf8', stringDict, stringDictOut, null, {
+            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
+            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
+        });
+    });
+
+    describe('with double values', function () {
+        testInParameter('ghashtable_double', numberDict);
+    });
+
+    describe('with float values', function () {
+        testInParameter('ghashtable_float', numberDict);
+    });
+
+    describe('with 64-bit int values', function () {
+        const int64Dict = {
+            '-1': -1,
+            0: 0,
+            1: 1,
+            2: 0x100000000,
+        };
+        testInParameter('ghashtable_int64', int64Dict);
+    });
+
+    describe('with unsigned 64-bit int values', function () {
+        const uint64Dict = {
+            '-1': 0x100000000,
+            0: 0,
+            1: 1,
+            2: 2,
+        };
+        testInParameter('ghashtable_uint64', uint64Dict);
+    });
+
+    it('symbol keys are ignored', function () {
+        const symbolDict = {
+            [Symbol('foo')]: 2,
+            '-1': 1,
+            0: 0,
+            1: -1,
+            2: -2,
+        };
+        expect(() => GIMarshallingTests.ghashtable_int_none_in(symbolDict)).not.toThrow();
+    });
+});
 describeSkip('phase 2.5 GValue — GValue in/out/return, flat GValue arrays, boxed round-trips',
     'GValue');
 describeSkip('phase 2.7 callbacks — GClosure in/return + callbacks with out-params + owned boxed',
@@ -533,16 +995,15 @@ describe('Bare flags type', function () {
     });
 });
 
-describeSkip('phase 2.4 structs — SimpleStruct return (objectContaining) + method/inv calls',
-    'Simple struct');
-describeSkip('phase 2.4 structs — PointerStruct return + method call',
-    'Pointer struct');
-describeSkip('phase 2.4 structs — BoxedStruct return/out/inout + method call',
-    'Boxed struct');
-describeSkip('phase 2.4 structs — union return + methods',
-    'Union');
-describeSkip('phase 2.4 structs — structured unions (single/double pointer members, …)',
-    'Structured union');
+// Struct/boxed/union OUT marshalling now LANDS (a boxed handle is returned — see
+// boxed_struct_out_uninitialized in the Fixed-size C array section, and the tier-A
+// struct-out conformance program), but these sections verify via struct FIELD reads
+// (objectContaining({long_, int8}), simpleStruct.long_) which is phase 2.6.
+describeSkip(SKIP_STRUCT_FIELDS, 'Simple struct');
+describeSkip(SKIP_STRUCT_FIELDS, 'Pointer struct');
+describeSkip(SKIP_STRUCT_FIELDS, 'Boxed struct');
+describeSkip(SKIP_STRUCT_FIELDS, 'Union');
+describeSkip(SKIP_STRUCT_FIELDS, 'Structured union');
 
 describe('GObject', function () {
     it('has a static method that can be called', function () {
@@ -574,22 +1035,19 @@ describe('GObject', function () {
             o = new GIMarshallingTests.Object();
         });
 
-        const SKIP_OBJECT_ARRAY_METHODS =
-            'phase 2.2 arrays — Object.method_array_{in,out,inout,return} take/return length-annotated int arrays';
-
-        itSkip(SKIP_OBJECT_ARRAY_METHODS, 'marshals an int array as an in parameter', function () {
+        it('marshals an int array as an in parameter', function () {
             expect(() => o.method_array_in([-1, 0, 1, 2])).not.toThrow();
         });
 
-        itSkip(SKIP_OBJECT_ARRAY_METHODS, 'marshals an int array as an out parameter', function () {
+        it('marshals an int array as an out parameter', function () {
             expect(o.method_array_out()).toEqual([-1, 0, 1, 2]);
         });
 
-        itSkip(SKIP_OBJECT_ARRAY_METHODS, 'marshals an int array as an inout parameter', function () {
+        itSkip(SKIP_INOUT_CONTAINER, 'marshals an int array as an inout parameter', function () {
             expect(o.method_array_inout([-1, 0, 1, 2])).toEqual([-2, -1, 0, 1, 2]);
         });
 
-        itSkip(SKIP_OBJECT_ARRAY_METHODS, 'marshals an int array as a return value', function () {
+        it('marshals an int array as a return value', function () {
             expect(o.method_array_return()).toEqual([-1, 0, 1, 2]);
         });
 

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -36,6 +36,7 @@ import { fileURLToPath } from 'node:url';
 // Files verified green on BOTH bun and deno (per-file). Keep alphabetical.
 const CONFORMANCE = [
   'arrays',
+  'boxed-out',
   'async-error',
   'call-function',
   'callbacks',

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -246,10 +246,11 @@ static NodeGiCallback* CreateCallback(Napi::Env env, Napi::Function fn, GICallab
 }
 
 // Whether `type` is a supported OUT/INOUT marshalling type for this milestone:
-// fundamentals (numbers/bool), strings (utf8/filename), and GObject/interface +
-// enums/flags. Compound OUT types — arrays, GList/GSList/GHashTable, GError, and
-// structs/unions (their own roadmap PR) — are deferred: they get a clear error
-// rather than silent mis-handling. *why receives a short type label on refusal.
+// fundamentals (numbers/bool), strings (utf8/filename), GObject/interface +
+// enums/flags, struct/boxed/union (wrapped as boxed handles on return), and the
+// containers (arrays, GList/GSList/GHashTable). GError (its own roadmap PR) is
+// deferred: a clear error rather than silent mis-handling. *why receives a short
+// type label on refusal.
 static bool IsSupportedOutType(GITypeInfo* type, std::string* why) {
   switch (gi_type_info_get_tag(type)) {
     case GI_TYPE_TAG_BOOLEAN:
@@ -267,14 +268,14 @@ static bool IsSupportedOutType(GITypeInfo* type, std::string* why) {
     case GI_TYPE_TAG_FILENAME:
       return true;
     case GI_TYPE_TAG_INTERFACE: {
+      // struct/union OUT are read back via WrapBoxed (a boxed handle); enum/flags
+      // as numbers; object/interface as GObject wrappers. Field ACCESS on the
+      // returned struct is a later PR, but the OUT marshalling itself is here.
       GIBaseInfo* iface = gi_type_info_get_interface(type);
       bool ok = iface != nullptr && (GI_IS_OBJECT_INFO(iface) || GI_IS_INTERFACE_INFO(iface) ||
-                                     GI_IS_ENUM_INFO(iface) || GI_IS_FLAGS_INFO(iface));
-      if (!ok && why != nullptr) {
-        *why = (iface != nullptr && (GI_IS_STRUCT_INFO(iface) || GI_IS_UNION_INFO(iface)))
-                   ? "struct/union"
-                   : "interface";
-      }
+                                     GI_IS_ENUM_INFO(iface) || GI_IS_FLAGS_INFO(iface) ||
+                                     GI_IS_STRUCT_INFO(iface) || GI_IS_UNION_INFO(iface));
+      if (!ok && why != nullptr) *why = "interface";
       if (iface != nullptr) gi_base_info_unref(iface);
       return ok;
     }
@@ -431,6 +432,11 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     gi_base_info_unref(rt);
   }
 
+  // Caller-allocates OUT storage (fixed C array or boxed struct): blob != nullptr
+  // marks the arg; boxedGType != 0 selects the boxed copy/free path on read-back.
+  std::vector<gpointer> callerAllocBlob(n_args, nullptr);
+  std::vector<GType> callerAllocGType(n_args, 0);
+
   std::vector<InContainer> inContainers;   // IN containers to free after the invoke
   // g_strdup'd transfer-full scalar string IN/INOUT args. The callee adopts + frees
   // them only on a SUCCESSFUL invoke; if a later arg fails to marshal (the early
@@ -464,12 +470,55 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     if ((dir == GI_DIRECTION_OUT || dir == GI_DIRECTION_INOUT) && !isCallback) {
       std::string why;
       if (gi_arg_info_is_caller_allocates(ai)) {
-        // Caller-allocates is the compound-struct path (the callee fills storage
-        // we provide); the supported OUT types here are all callee-set. Defer it.
-        Napi::TypeError::New(
-            env, displayName + ": caller-allocates OUT parameters are not yet supported")
-            .ThrowAsJavaScriptException();
-        ok = false;
+        // Caller-allocates: the callee fills storage WE provide (a single
+        // pointer, not a **). gi_callable_info_invoke passes out_args[k].v_pointer
+        // straight through as the arg, so the blob pointer goes there directly.
+        // Supported: a fixed-size C array (size = fixed_size × element_size) and a
+        // boxed struct/union (size = gi_struct/union_info_get_size). Reference:
+        // refs/gjs/gi/arg-cache.cpp build_arg CALLER_ALLOCATES branch.
+        GITypeTag tg = gi_type_info_get_tag(ti);
+        size_t size = 0;
+        GType boxedGType = 0;
+        if (tg == GI_TYPE_TAG_ARRAY && gi_type_info_get_array_type(ti) == GI_ARRAY_TYPE_C) {
+          size_t fixed = 0;
+          if (gi_type_info_get_array_fixed_size(ti, &fixed) && fixed > 0) {
+            GITypeInfo* el = gi_type_info_get_param_type(ti, 0);
+            // Only fundamental (non-interface) element types: CElementSize is the
+            // true storage size for them. A struct-by-value element array would
+            // need gi_struct_info_get_size per element + field-access read-back
+            // (a later PR), so leave size=0 to defer it cleanly.
+            if (el != nullptr && gi_type_info_get_tag(el) != GI_TYPE_TAG_INTERFACE)
+              size = CElementSize(el) * fixed;
+            if (el != nullptr) gi_base_info_unref(el);
+          }
+        } else if (tg == GI_TYPE_TAG_INTERFACE) {
+          GIBaseInfo* si = gi_type_info_get_interface(ti);
+          if (si != nullptr && GI_IS_STRUCT_INFO(si)) {
+            size = gi_struct_info_get_size(reinterpret_cast<GIStructInfo*>(si));
+          } else if (si != nullptr && GI_IS_UNION_INFO(si)) {
+            size = gi_union_info_get_size(reinterpret_cast<GIUnionInfo*>(si));
+          }
+          if (si != nullptr) {
+            GType gt = gi_registered_type_info_get_g_type(
+                reinterpret_cast<GIRegisteredTypeInfo*>(si));
+            if (gt != G_TYPE_INVALID && G_TYPE_IS_BOXED(gt)) boxedGType = gt;
+            gi_base_info_unref(si);
+          }
+          // A non-boxed struct OUT can be caller-allocated + filled, but wrapping
+          // it needs field access (a later PR) to be useful — defer those.
+          if (boxedGType == 0) size = 0;
+        }
+        if (size == 0) {
+          Napi::TypeError::New(
+              env, displayName + ": caller-allocates OUT parameter type is not yet supported")
+              .ThrowAsJavaScriptException();
+          ok = false;
+        } else {
+          gpointer blob = g_malloc0(size);
+          callerAllocBlob[i] = blob;
+          callerAllocGType[i] = boxedGType;
+          out_args[outPos[i]].v_pointer = blob;
+        }
       } else if (!IsSupportedOutType(ti, &why)) {
         Napi::TypeError::New(env, displayName + ": OUT " + why +
                                       " parameters are not yet supported")
@@ -599,6 +648,10 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     for (NodeGiCallback* cb : created) NodeGiCallbackFree(cb);
     for (const InContainer& c : inContainers) FreeInContainer(c);
     for (gpointer s : ownedInStrings) g_free(s);  // never reached the callee (#658)
+    // Caller-allocated blobs never reached the callee (or it was never called) —
+    // they are zeroed g_malloc0 storage, so a plain g_free is correct here.
+    for (gpointer b : callerAllocBlob)
+      if (b != nullptr) g_free(b);
     return env.Null();
   }
 
@@ -614,6 +667,11 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     // A failed invoke did not adopt the transfer-full IN/INOUT strings we g_strdup'd
     // for it → free them here so the error path doesn't leak (#658).
     for (gpointer s : ownedInStrings) g_free(s);
+    // Free the caller-allocated OUT storage (the callee may have partially filled
+    // it; g_free releases the block — a boxed free-func on a half-initialised blob
+    // is riskier than the small leak of any internal pointer it set).
+    for (gpointer b : callerAllocBlob)
+      if (b != nullptr) g_free(b);
     // ThrowGError reads the GError's domain/code/message, frees it, and throws a
     // real GLib.Error (instanceof, with .matches()) via the L1 builder.
     ThrowGError(env, error, displayName);
@@ -648,6 +706,33 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
     GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
     GITypeInfo* ti = gi_arg_info_get_type_info(ai);
     GITransfer transfer = gi_arg_info_get_ownership_transfer(ai);
+    if (callerAllocBlob[i] != nullptr) {
+      // Caller-allocated OUT: the callee filled the blob IN PLACE (the blob is the
+      // data, not a pointer to it). Wrap it, then release the blob — mirroring
+      // gjs's CallerAllocatesOut (read the value out, then free the storage).
+      gpointer blob = callerAllocBlob[i];
+      if (gi_type_info_get_tag(ti) == GI_TYPE_TAG_ARRAY) {
+        // A fixed-size C array: read length from the fixed size (len=-1), transfer
+        // NOTHING (we own + free the blob ourselves right below).
+        GIArgument a;
+        memset(&a, 0, sizeof(a));
+        a.v_pointer = blob;
+        results.push_back(ReadOutOrReturn(env, callable, ti, &a, GI_TRANSFER_NOTHING, &slots));
+        g_free(blob);
+      } else {
+        // A boxed struct/union: hand the JS side an independent boxed COPY it owns
+        // (finalizer g_boxed_free's it), then free the caller-allocated blob (also
+        // via g_boxed_free — matches gjs BoxedCallerAllocatesOut::release).
+        GType gt = callerAllocGType[i];
+        gpointer owned = g_boxed_copy(gt, blob);
+        results.push_back(MakeBoxedHandle(env, owned, gt, true));
+        g_boxed_free(gt, blob);
+      }
+      callerAllocBlob[i] = nullptr;
+      gi_base_info_unref(ti);
+      gi_base_info_unref(ai);
+      continue;
+    }
     results.push_back(ReadOutOrReturn(env, callable, ti, &slots[i], transfer, &slots));
     gi_base_info_unref(ti);
     gi_base_info_unref(ai);

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -161,6 +161,7 @@ struct InContainer {
 };
 
 bool IsSupportedContainerType(GITypeInfo* type, std::string* why);
+size_t CElementSize(GITypeInfo* elem);
 void WriteLengthValue(GITypeInfo* lenType, GIArgument* slot, long n);
 Napi::Value ReadOutOrReturn(Napi::Env env, GICallableInfo* callable, GITypeInfo* ti,
                             GIArgument* arg, GITransfer transfer,

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -410,9 +410,15 @@ bool IsSupportedContainerType(GITypeInfo* type, std::string* why) {
       GITypeInfo* kt = gi_type_info_get_param_type(type, 0);
       GITypeInfo* vt = gi_type_info_get_param_type(type, 1);
       GITypeTag ktag = kt != nullptr ? gi_type_info_get_tag(kt) : GI_TYPE_TAG_VOID;
-      bool kok = ktag == GI_TYPE_TAG_UTF8 || ktag == GI_TYPE_TAG_FILENAME;
+      // Supported hash key tags — a subset of GJS's is_supported_ghash_key_type
+      // (refs/gjs/gi/arg.cpp): strings + the pointer-fitting integers. 64-bit keys
+      // (which don't fit a pointer) + unichar keys are out of scope.
+      bool kok = ktag == GI_TYPE_TAG_UTF8 || ktag == GI_TYPE_TAG_FILENAME ||
+                 ktag == GI_TYPE_TAG_INT8 || ktag == GI_TYPE_TAG_UINT8 ||
+                 ktag == GI_TYPE_TAG_INT16 || ktag == GI_TYPE_TAG_UINT16 ||
+                 ktag == GI_TYPE_TAG_INT32 || ktag == GI_TYPE_TAG_UINT32;
       bool vok = vt != nullptr && IsSupportedElementType(vt, nullptr);
-      if (!kok && why != nullptr) *why = "non-string GHashTable key";
+      if (!kok && why != nullptr) *why = "unsupported GHashTable key";
       else if (!vok && why != nullptr) *why = "unsupported GHashTable value";
       if (kt != nullptr) gi_base_info_unref(kt);
       if (vt != nullptr) gi_base_info_unref(vt);
@@ -425,7 +431,7 @@ bool IsSupportedContainerType(GITypeInfo* type, std::string* why) {
 }
 
 // In-memory size of one C-array element. 0 for an unsupported element type.
-static size_t CElementSize(GITypeInfo* elem) {
+size_t CElementSize(GITypeInfo* elem) {
   switch (gi_type_info_get_tag(elem)) {
     case GI_TYPE_TAG_BOOLEAN: return sizeof(gboolean);
     case GI_TYPE_TAG_INT8:
@@ -540,24 +546,49 @@ static Napi::Value GIArrayToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
   void* data = container;
   size_t elemSize = CElementSize(elem);
   bool isByte = etag == GI_TYPE_TAG_UINT8 || etag == GI_TYPE_TAG_INT8;
+  // A NULL container maps to `null` for every array kind EXCEPT a length-annotated
+  // C array (an explicit length was passed → an empty array, matching GJS's
+  // gjs_array_from_basic_c_array_internal "null pointer takes precedence over
+  // length" for the length path vs the fixed/zero-terminated/GArray/GPtrArray/
+  // GByteArray readers, which each return null on a NULL container).
+  bool hasExplicitLength = length >= 0;
 
   // Resolve data + length for the boxed array kinds (their own struct carries it).
+  // A NULL boxed container → JS null (GJS gjs_value_from_basic_{garray,gptrarray,
+  // byte_array}_gi_argument each null-guard before reading).
   if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
     GByteArray* ba = static_cast<GByteArray*>(container);
-    data = ba != nullptr ? ba->data : nullptr;
-    length = ba != nullptr ? static_cast<long>(ba->len) : 0;
+    if (ba == nullptr) {
+      if (elem != nullptr) gi_base_info_unref(elem);
+      return env.Null();
+    }
+    data = ba->data;
+    length = static_cast<long>(ba->len);
     isByte = true;
     elemSize = 1;
   } else if (at == GI_ARRAY_TYPE_ARRAY) {
     GArray* ga = static_cast<GArray*>(container);
-    data = ga != nullptr ? ga->data : nullptr;
-    length = ga != nullptr ? static_cast<long>(ga->len) : 0;
-    if (ga != nullptr) elemSize = g_array_get_element_size(ga);
+    if (ga == nullptr) {
+      if (elem != nullptr) gi_base_info_unref(elem);
+      return env.Null();
+    }
+    data = ga->data;
+    length = static_cast<long>(ga->len);
+    elemSize = g_array_get_element_size(ga);
   } else if (at == GI_ARRAY_TYPE_PTR_ARRAY) {
     GPtrArray* pa = static_cast<GPtrArray*>(container);
-    data = pa != nullptr ? pa->pdata : nullptr;
-    length = pa != nullptr ? static_cast<long>(pa->len) : 0;
+    if (pa == nullptr) {
+      if (elem != nullptr) gi_base_info_unref(elem);
+      return env.Null();
+    }
+    data = pa->pdata;
+    length = static_cast<long>(pa->len);
     elemSize = sizeof(gpointer);
+  } else if (data == nullptr) {
+    // NULL C-array pointer: a fixed/zero-terminated array (no length param) → null;
+    // a length-annotated array (explicit length given) → an empty array below.
+    if (elem != nullptr) gi_base_info_unref(elem);
+    return hasExplicitLength ? static_cast<Napi::Value>(Napi::Array::New(env, 0)) : env.Null();
   } else if (length < 0) {  // C array, length not given by a length arg
     if (gi_type_info_is_zero_terminated(type)) {
       length = 0;
@@ -655,6 +686,9 @@ static Napi::Value GListToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
 static Napi::Value GHashToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
                              GITransfer transfer) {
   GHashTable* ht = static_cast<GHashTable*>(arg->v_pointer);
+  // A NULL GHashTable maps to `null` (GJS gjs_value_from_basic_ghash null-guards
+  // the table before reading) — NOT an empty object; e.g. an uninitialized OUT.
+  if (ht == nullptr) return env.Null();
   Napi::Object out = Napi::Object::New(env);
   if (ht != nullptr) {
     GITypeInfo* kt = gi_type_info_get_param_type(type, 0);
@@ -757,9 +791,9 @@ static bool ElementToGIArgument(Napi::Env env, GITypeInfo* elem, Napi::Value v, 
   }
 }
 
-// Build a C array / GStrv / GByteArray from a JS value. *outCount = element
-// count (for the IN length autofill + later free). GArray/GPtrArray IN are
-// deferred. Throws + returns false on refusal (BEFORE the invoke).
+// Build a C array / GStrv / GByteArray / GArray / GPtrArray from a JS value.
+// *outCount = element count (for the IN length autofill + later free). Throws +
+// returns false on refusal (BEFORE the invoke).
 static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer* outPtr,
                        long* outCount) {
   GIArrayType at = gi_type_info_get_array_type(type);
@@ -808,15 +842,13 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
     return true;
   }
 
-  if (at != GI_ARRAY_TYPE_C) {
-    gi_base_info_unref(elem);
-    Napi::TypeError::New(env, "GArray/GPtrArray IN parameters are not yet supported")
-        .ThrowAsJavaScriptException();
-    return false;
-  }
+  // C / GArray / GPtrArray share the element-marshalling loop below; only their
+  // final container wrapping differs. The byte-specific fast paths (TypedArray /
+  // string → bytes) are C-array-only ergonomics (a GArray/GPtrArray of bytes is
+  // not something GJS accepts a TypedArray for), so gate them on the C kind.
 
   // Byte C array from a TypedArray / Buffer.
-  if (isByte && rawBytes != nullptr) {
+  if (at == GI_ARRAY_TYPE_C && isByte && rawBytes != nullptr) {
     void* buf = g_malloc0(elemSize * (rawLen + (zt ? 1 : 0)));
     memcpy(buf, rawBytes, rawLen);
     *outPtr = buf;
@@ -832,7 +864,7 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
   // a zero-terminated array still gets its trailing NUL slot from g_malloc0.
   // Verified against gjs 1.88: GIMarshallingTests.utf8_as_uint8array_in('const ♥ utf8')
   // is accepted (no throw). A real Uint8Array/Array still works via the paths around this.
-  if (isByte && v.IsString()) {
+  if (at == GI_ARRAY_TYPE_C && isByte && v.IsString()) {
     std::string s = v.As<Napi::String>().Utf8Value();
     size_t n = s.size();
     void* buf = g_malloc0(elemSize * (n + (zt ? 1 : 0)));
@@ -851,6 +883,10 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
   }
   Napi::Array arr = v.As<Napi::Array>();
   long count = static_cast<long>(arr.Length());
+  // Build the flat element buffer first (the storage a C array uses directly).
+  // GArray / GPtrArray then wrap this buffer — mirroring gjs, which marshals the
+  // JS array into a C buffer and hands it to g_array_append_vals / the GPtrArray
+  // pdata memcpy (refs/gjs/gi/arg.cpp gjs_value_to_basic_array_gi_argument).
   void* buf = g_malloc0(elemSize * (count + (zt ? 1 : 0)));
   bool ok = true;
   for (long i = 0; i < count && ok; i++) {
@@ -868,7 +904,28 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
     gi_base_info_unref(elem);
     return false;
   }
-  *outPtr = buf;
+
+  if (at == GI_ARRAY_TYPE_ARRAY) {
+    // GArray: a zero-terminated, sized GArray over `elemSize` elements
+    // (garray_new_for_basic_type in gjs uses zero_terminated=true). append_vals
+    // COPIES the buffer, so free our scratch buffer afterwards. String elements
+    // (g_strdup'd pointers) now live in the GArray data; freed per-transfer in
+    // FreeInContainer.
+    GArray* ga = g_array_sized_new(TRUE, FALSE, static_cast<guint>(elemSize),
+                                   static_cast<guint>(count));
+    if (count > 0) g_array_append_vals(ga, buf, static_cast<guint>(count));
+    g_free(buf);
+    *outPtr = ga;
+  } else if (at == GI_ARRAY_TYPE_PTR_ARRAY) {
+    // GPtrArray: element pointers copied into pdata (gjs memcpy's the same way).
+    GPtrArray* pa = g_ptr_array_sized_new(static_cast<guint>(count));
+    g_ptr_array_set_size(pa, static_cast<int>(count));
+    if (count > 0) memcpy(pa->pdata, buf, sizeof(gpointer) * static_cast<size_t>(count));
+    g_free(buf);
+    *outPtr = pa;
+  } else {
+    *outPtr = buf;  // GI_ARRAY_TYPE_C
+  }
   *outCount = count;
   gi_base_info_unref(elem);
   return true;
@@ -901,8 +958,17 @@ static bool JsToGListLike(Napi::Env env, Napi::Value v, GITypeInfo* type, bool i
   return ok;
 }
 
-// Build a GHashTable (string keys) from a JS object. Value type ∈ {string,
-// object}. Keys + (string) values are g_strdup'd and owned by the table.
+// Build a GHashTable from a JS object. Keys ∈ {string, pointer-fitting int};
+// values ∈ {string, object, int, and the heap-boxed int64/uint64/float/double}.
+// Mirrors GJS (refs/gjs/gi/arg.cpp gjs_object_to_g_hash + value_to_ghashtable_key):
+//   * string keys → g_strdup + g_str_hash/equal; integer keys → GINT_TO_POINTER
+//     via gi_type_info_hash_pointer_from_argument + g_direct_hash/equal.
+//   * int/int32/string/object values fit a pointer (hash_pointer_from_argument);
+//     int64/uint64/float/double do NOT, so they are heap-allocated (g_new) and a
+//     pointer to the heap value is stored (the hash owns + g_free's it).
+// Key/value GDestroyNotify funcs are attached so a transfer-none teardown
+// (g_hash_table_unref in FreeInContainer) releases everything; a transfer-full
+// hash is adopted by the callee, which frees it (and thus runs the notifies).
 static bool JsToGHashIn(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer* outPtr) {
   *outPtr = nullptr;
   if (!v.IsObject() || v.IsArray()) {
@@ -910,31 +976,73 @@ static bool JsToGHashIn(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer
         .ThrowAsJavaScriptException();
     return false;
   }
+  GITypeInfo* kt = gi_type_info_get_param_type(type, 0);
   GITypeInfo* vt = gi_type_info_get_param_type(type, 1);
+  GITypeTag ktag = gi_type_info_get_tag(kt);
   GITypeTag vtag = gi_type_info_get_tag(vt);
+  bool keyIsString = ktag == GI_TYPE_TAG_UTF8 || ktag == GI_TYPE_TAG_FILENAME;
   bool valueIsString = vtag == GI_TYPE_TAG_UTF8 || vtag == GI_TYPE_TAG_FILENAME;
-  // String values get g_free'd by the table; borrowed object pointers do not.
-  GHashTable* ht =
-      g_hash_table_new_full(g_str_hash, g_str_equal, g_free, valueIsString ? g_free : nullptr);
+  bool valueHeap = vtag == GI_TYPE_TAG_INT64 || vtag == GI_TYPE_TAG_UINT64 ||
+                   vtag == GI_TYPE_TAG_FLOAT || vtag == GI_TYPE_TAG_DOUBLE;
+  GDestroyNotify keyFree = keyIsString ? g_free : nullptr;
+  GDestroyNotify valFree = (valueIsString || valueHeap) ? g_free : nullptr;
+  GHashTable* ht = g_hash_table_new_full(keyIsString ? g_str_hash : g_direct_hash,
+                                         keyIsString ? g_str_equal : g_direct_equal,
+                                         keyFree, valFree);
   Napi::Object obj = v.As<Napi::Object>();
   Napi::Array keys = obj.GetPropertyNames();
   bool ok = true;
   for (uint32_t i = 0; i < keys.Length() && ok; i++) {
     Napi::Value key = keys.Get(i);
-    std::string ks = key.ToString().Utf8Value();
+    std::string ks = key.ToString().Utf8Value();  // JS property keys are strings
+
+    // Key pointer: g_strdup for strings, else the integer key parsed from the
+    // (string) property name and GINT_TO_POINTER-encoded per its tag.
+    gpointer kp = nullptr;
+    if (keyIsString) {
+      kp = g_strdup(ks.c_str());
+    } else {
+      GIArgument ka;
+      Napi::Value keyNum = Napi::Number::New(env, static_cast<double>(g_ascii_strtoll(ks.c_str(), nullptr, 10)));
+      ok = ElementToGIArgument(env, kt, keyNum, &ka);
+      if (!ok) break;
+      kp = gi_type_info_hash_pointer_from_argument(kt, &ka);
+    }
+
+    // Value pointer: heap-box the wide/float values (they don't fit a pointer),
+    // else pointer-encode via hash_pointer_from_argument (strings g_strdup'd by
+    // ElementToGIArgument, ints GINT_TO_POINTER, objects the borrowed handle).
     Napi::Value val = obj.Get(key);
     gpointer vp = nullptr;
-    if (valueIsString) {
-      vp = (val.IsNull() || val.IsUndefined()) ? nullptr : g_strdup(val.ToString().Utf8Value().c_str());
-    } else {
-      GIArgument a;
-      ok = ElementToGIArgument(env, vt, val, &a);
-      if (!ok) break;
-      vp = a.v_pointer;
+    GIArgument va;
+    ok = ElementToGIArgument(env, vt, val, &va);
+    if (!ok) {
+      g_free(kp);
+      break;
     }
-    g_hash_table_insert(ht, g_strdup(ks.c_str()), vp);
+    if (vtag == GI_TYPE_TAG_INT64) {
+      gint64* p = g_new(gint64, 1);
+      *p = va.v_int64;
+      vp = p;
+    } else if (vtag == GI_TYPE_TAG_UINT64) {
+      guint64* p = g_new(guint64, 1);
+      *p = va.v_uint64;
+      vp = p;
+    } else if (vtag == GI_TYPE_TAG_FLOAT) {
+      gfloat* p = g_new(gfloat, 1);
+      *p = va.v_float;
+      vp = p;
+    } else if (vtag == GI_TYPE_TAG_DOUBLE) {
+      gdouble* p = g_new(gdouble, 1);
+      *p = va.v_double;
+      vp = p;
+    } else {
+      vp = gi_type_info_hash_pointer_from_argument(vt, &va);
+    }
+    g_hash_table_insert(ht, kp, vp);
   }
   *outPtr = ht;
+  gi_base_info_unref(kt);
   gi_base_info_unref(vt);
   return ok;
 }
@@ -951,10 +1059,26 @@ void FreeInContainer(const InContainer& c) {
     GIArrayType at = gi_type_info_get_array_type(c.type);
     GITypeInfo* elem = gi_type_info_get_param_type(c.type, 0);
     GITypeTag etag = elem != nullptr ? gi_type_info_get_tag(elem) : GI_TYPE_TAG_VOID;
+    bool freeStrings = etag == GI_TYPE_TAG_UTF8 || etag == GI_TYPE_TAG_FILENAME;
     if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
       g_byte_array_unref(static_cast<GByteArray*>(c.ptr));
+    } else if (at == GI_ARRAY_TYPE_ARRAY) {
+      // GArray: free the g_strdup'd string elements first (g_array_free's
+      // free_segment=TRUE releases the data block but not what its pointers
+      // point at), then the GArray + its data segment.
+      GArray* ga = static_cast<GArray*>(c.ptr);
+      if (freeStrings)
+        for (guint i = 0; i < ga->len; i++) g_free(g_array_index(ga, char*, i));
+      g_array_free(ga, TRUE);
+    } else if (at == GI_ARRAY_TYPE_PTR_ARRAY) {
+      // GPtrArray: same — free owned string elements, then the array. Object
+      // elements are borrowed handle pointers (never freed here).
+      GPtrArray* pa = static_cast<GPtrArray*>(c.ptr);
+      if (freeStrings)
+        for (guint i = 0; i < pa->len; i++) g_free(g_ptr_array_index(pa, i));
+      g_ptr_array_free(pa, TRUE);
     } else {  // C array
-      if (etag == GI_TYPE_TAG_UTF8 || etag == GI_TYPE_TAG_FILENAME) {
+      if (freeStrings) {
         char** s = static_cast<char**>(c.ptr);
         if (gi_type_info_is_zero_terminated(c.type)) {
           g_strfreev(s);

--- a/packages/node-gi/node-gi/test/boxed-out.test.mjs
+++ b/packages/node-gi/node-gi/test/boxed-out.test.mjs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Struct / boxed OUT marshalling for @gjsify/node-gi against headless GLib —
+// the compound-OUT slice of the container drop (phase 2.4), cross-runtime safe
+// (no display, no test typelib; runs on node/bun/deno via cross-runtime.mjs).
+//
+// Exercises:
+//  * boxed struct RETURN → a method-routing handle (GLib.TimeZone / GLib.DateTime)
+//  * void return + multiple int OUT params → a tuple (DateTime.get_ymd)
+//  * a boxed OUT PARAMETER inside a multi-value tuple (GLib.Regex.match →
+//    [matched, GLib.MatchInfo]) — the struct-OUT-param path widened in this drop,
+//    plus the L1 wrapReturn recursion that wraps a handle sitting in the tuple
+//  * boxed handle round-trip: an OUT boxed handed back IN to a method
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { callStaticMethod, requireNamespace } from '../index.js';
+import { requireGi } from '../gi.js';
+
+test('boxed struct return → method-routing handle: GLib.TimeZone.new_utc()', () => {
+  const GLib = requireGi('GLib', '2.0');
+  const utc = GLib.TimeZone.new_utc();
+  assert.equal(typeof utc, 'object');
+  assert.equal(utc.get_identifier(), 'UTC');
+});
+
+test('boxed struct return + int OUT tuple + boxed round-trip: GLib.DateTime', () => {
+  const GLib = requireGi('GLib', '2.0');
+  // Boxed RETURN. 1136214245 = 2006-01-02 15:04:05 UTC (timezone-independent).
+  const dt = GLib.DateTime.new_from_unix_utc(1136214245);
+  assert.equal(dt.get_year(), 2006);
+  assert.equal(dt.get_month(), 1);
+  assert.equal(dt.get_day_of_month(), 2);
+
+  // void return + three int OUT params → [y, m, d].
+  assert.deepEqual(dt.get_ymd(), [2006, 1, 2]);
+
+  // A boxed method returning a NEW boxed, then the older boxed handed back IN.
+  const dtPlus = dt.add_hours(1);
+  assert.equal(dtPlus.get_hour(), dt.get_hour() + 1);
+  assert.equal(dtPlus.difference(dt), 3600000000); // 1h in microseconds
+});
+
+test('boxed OUT parameter in a multi-value tuple is marshalled + wrapped: GLib.Regex.match', () => {
+  const GLib = requireGi('GLib', '2.0');
+  // g_regex_match(regex, string, flags, GMatchInfo** match_info /*(out)*/) → the
+  // MatchInfo is a boxed (transfer full) OUT arg — a struct OUT that was deferred
+  // before this drop; it now marshals into the [matched, info] return tuple.
+  const re = GLib.Regex.new('\\d+', 0, 0);
+  const result = re.match('abc 123 def', 0);
+  assert.ok(Array.isArray(result), 'match returns a [matched, matchInfo] tuple');
+  const [matched, info] = result;
+  assert.equal(matched, true);
+  // The boxed OUT element is wrapped into a method-routing proxy (L1 wrapReturn now
+  // recurses into the OUT tuple), NOT left as a raw handle. Assert the wrapping
+  // structurally — the MatchInfo retains a pointer to the input string, so reading
+  // match data (fetch) is a separate scalar-string-lifetime concern, out of scope.
+  assert.equal(typeof info, 'object');
+  assert.equal(typeof info.fetch, 'function');
+  assert.equal(typeof info.get_match_count, 'function');
+});
+
+test('struct/boxed OUT via callStaticMethod: GLib.DateTime.new_from_unix_utc', () => {
+  requireNamespace('GLib', '2.0');
+  // The low-level entry point also returns the boxed handle (a raw External here,
+  // since callStaticMethod bypasses the L1 wrapper) — non-null, method-callable via
+  // the boxed engine. Proven by round-tripping it through the high-level wrapper.
+  const dt = callStaticMethod('GLib', 'DateTime', 'new_from_unix_utc', [0]);
+  assert.notEqual(dt, null);
+  assert.equal(typeof dt, 'object');
+});


### PR DESCRIPTION
## Summary

Implements container + compound-OUT marshalling (Phase 2.2/2.3/2.4), un-skipping the biggest GIMarshallingTests block. Every behavior verified against `gjs -m` (gold standard); valgrind-clean.

- **GArray/GPtrArray IN** (`marshal.cc` `JsToCArray`): flat element buffer → `g_array_sized_new`+append / `g_ptr_array`, freed per-transfer.
- **GHashTable IN extended**: integer keys + heap-boxed int64/uint64/float/double values, type-aware `GDestroyNotify`.
- **Caller-allocates OUT** (the `:2322` throw): fixed C array or boxed struct/union — `g_malloc0(size)`, pointer handed through, read back + freed per transfer (matches gjs `BoxedCallerAllocatesOut`). GTK gate (GdkRectangle-style).
- **Compound OUT widened** (`calls.cc` `IsSupportedOutType`): struct/union OUT as boxed handles; C-array-with-length / GList / GSList / GHashTable OUT.
- **Uninitialized-array OUT null-semantics** fixed to match gjs byte-for-byte (`[false,null]` / `[false,[]]` / null), + L1 `wrapReturn` tuple recursion for handles inside multi-value OUT tuples.

## GIMarshallingTests: 176 → **318 pass** (+142), 0 fail
Un-skipped: arrays (fixed/length/zero-term/UTF-8/GArray/GPtrArray/GByteArray/GStrv/Object array in-out-return), hashtable (int/utf8/double/float/int64/uint64), **added** the missing GList/GSList section, struct-out (boxed/fixed uninitialized + caller-allocated).
**Kept skipped (precise reasons):** INOUT containers (2.5), struct FIELD access (2.6), GBytes/Variant/enum/flags/unichar/GValue array elements (2.7).

## Ownership/transfer
Transfer-none IN freed after read; full/container adopted by callee; hashtable type-aware destructors; caller-alloc blobs freed on all paths. **valgrind** (300-iter driver over every new alloc/free): 0 bytes lost (only V8 GC stack-scan noise, 0 node-gi frames).

## Tests
- [x] `npm run rebuild`: 0 warnings · `npm test`: 263/0 · `npm run test:gimarshalling`: 318/0/71-skip
- [x] tier-A `array-in-out`/`list-hash`/`struct-out` + `test/boxed-out.test.mjs`: 10 programs byte-identical gjs/node/bun/deno; bun 30/30, deno 30/30

## Notes
- Boxed-struct caller-alloc read (`g_boxed_copy`+`g_boxed_free`, the GdkRectangle gate) is code-reviewed vs gjs but not runtime-exercised (no headless single-pointer caller-alloc boxed OUT exists; the fixed-array caller-alloc path IS tested).
- Port shim typed-array equality compares by TypedArray-family+bytes so node's `Buffer` (a `Uint8Array` subclass) equals gjs's `Uint8Array` — documented adaptation, all byte values still asserted.