### PR TITLE
feat(node-gi): cairo binding + foreign-struct seam

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git gcc-c++ make python3 pkgconf-pkg-config tar xz unzip \
-            glib2-devel gobject-introspection-devel gobject-introspection gjs
+            glib2-devel gobject-introspection-devel gobject-introspection gjs cairo-devel
           gjs --version
           echo "girepository-2.0: $(pkg-config --modversion girepository-2.0)"
 
@@ -154,7 +154,7 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git gcc-c++ make python3 pkgconf-pkg-config tar xz unzip \
-            glib2-devel gobject-introspection-devel gobject-introspection
+            glib2-devel gobject-introspection-devel gobject-introspection cairo-devel
           echo "girepository-2.0: $(pkg-config --modversion girepository-2.0)"
 
       # Official Node builds the addon (node-gyp) and orchestrates the runner, which

--- a/packages/infra/resolve-npm/lib/index.mjs
+++ b/packages/infra/resolve-npm/lib/index.mjs
@@ -444,27 +444,28 @@ export const ALIASES_GENERAL_FOR_NODE = {
 /**
  * Record of GJS built-in module specifiers and their replacement for the
  * `--app node` target. These are the bare ESM module names a GJS source imports
- * (`import System from 'system'`, `import Gettext from 'gettext'`) — GJS exposes
- * them as built-in modules; Node has no equivalent, so on the node target they
- * route to the `@gjsify/node-gi` reverse-bridge shims, which are kept EXTERNAL
- * (resolved at runtime against the consumer's node_modules — see
- * `app/node.ts`'s external set), never bundled. This is the analogue of the
+ * (`import System from 'system'`, `import Gettext from 'gettext'`, `import cairo
+ * from 'cairo'`) — GJS exposes them as built-in modules; Node has no equivalent,
+ * so on the node target they route to the `@gjsify/node-gi` reverse-bridge shims,
+ * which are kept EXTERNAL (resolved at runtime against the consumer's node_modules
+ * — see `app/node.ts`'s external set), never bundled. This is the analogue of the
  * `gi://` rewrite + `@gjsify/node-gi/globals` injection, and like them it is
  * NODE-TARGET-ONLY: the gjs/browser/nativescript alias maps do not include this
- * record, so a bare `system` / `gettext` import keeps resolving natively (GJS
- * built-in / npm package) on every other target. The risk of hijacking a real
- * npm package literally named `system`/`gettext` is identical to (and bounded
- * the same way as) the `gi://` design: it only applies when building a GJS/GI
- * source for Node.
+ * record, so a bare `system` / `gettext` / `cairo` import keeps resolving natively
+ * (GJS built-in / npm package) on every other target. The risk of hijacking a real
+ * npm package literally named `system`/`gettext`/`cairo` is identical to (and
+ * bounded the same way as) the `gi://` design: it only applies when building a
+ * GJS/GI source for Node.
  *
- * `cairo` is intentionally NOT mapped — it needs a real Cairo binding (out of
- * scope here), so it falls through to the normal resolver (a `cairo` npm package
- * resolves as usual, an unresolvable bare `cairo` surfaces as a build error
- * rather than silently no-op'ing).
+ * `cairo` maps to `@gjsify/node-gi/cairo`, the native cairo binding (a FOREIGN
+ * struct in GObject-Introspection — an npm cairo package cannot stand in, since a
+ * GI function taking/returning a cairo_t must marshal through the SAME cairo module
+ * the engine's foreign-struct seam knows about).
  */
 const ALIASES_GJS_FOR_NODE = {
     'system': '@gjsify/node-gi/system',
     'gettext': '@gjsify/node-gi/gettext',
+    'cairo': '@gjsify/node-gi/cairo',
 }
 
 export { ALIASES_GJS_FOR_NODE };

--- a/packages/node-gi/node-gi/.gitignore
+++ b/packages/node-gi/node-gi/.gitignore
@@ -1,6 +1,7 @@
 build/
 prebuilds/
 node_modules/
+package-lock.json
 *.node
 *.o
 deno.lock

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -461,3 +461,44 @@ The remaining GJS-compatible surface (`import GLib from 'gi://GLib?version=2.0'`
 `const GLib = imports.gi.GLib`, the core overrides, `_promisify`, the legacy
 `imports.*` modules) is layered on top of this engine in the gjsify bundler
 integration and subsequent drops.
+
+### cairo (`@gjsify/node-gi/cairo`)
+
+cairo is a **foreign struct** in GObject-Introspection: GI does not know the
+layout of `cairo_t` / `cairo_surface_t` / `cairo_pattern_t`, so it delegates their
+marshalling to a module. GJS ships a native cairo binding + a foreign-struct
+registration so that a GI function taking/returning a cairo pointer (e.g. a
+`Gtk.DrawingArea` draw-func's `cairo_t`) round-trips to/from the JS cairo objects.
+node-gi ports that seam: the same drawing code runs on GJS (native cairo) and Node
+(this binding). An npm `cairo` package cannot stand in — a foreign cairo argument
+must marshal through the SAME module the engine's foreign-struct seam knows about.
+
+```js
+import cairo from '@gjsify/node-gi/cairo'; // bare `cairo` on the --app node build
+import { requireGi } from '@gjsify/node-gi/gi';
+
+// Headless drawing — read the pixels back with getData().
+const surface = new cairo.ImageSurface(cairo.Format.ARGB32, 64, 48);
+const cr = new cairo.Context(surface);
+cr.setSourceRGB(0.8, 0.1, 0.1);
+cr.rectangle(8, 8, 20, 16);
+cr.fill();
+cr.$dispose();
+surface.flush();
+const pixels = surface.getData(); // Uint8Array (stride * height), ARGB32
+
+// The foreign seam: a GI function taking a cairo_t marshals the Context through.
+const PangoCairo = requireGi('PangoCairo', '1.0');
+const layout = PangoCairo.create_layout(new cairo.Context(surface));
+
+// A Gtk.DrawingArea draw-func receives a cairo_t → a live cairo.Context:
+//   area.set_draw_func((_area, ctx, w, h) => { ctx.setSourceRGB(1, 0, 0); … });
+```
+
+Ported this slice: `cairo.Context` (drawing + transform ops, state getters,
+`$dispose`), `cairo.Surface` + `cairo.ImageSurface` (`getData`/`getWidth`/
+`getHeight`/`getStride`/`getFormat`/`flush`/`writeToPNG`/`createFromPNG`),
+`cairo.SolidPattern`, and the enums (`Format`, `Operator`, `Content`, …). The
+native binding paints **byte-for-byte identically to GJS** (verified pixel-for-pixel
+against `gjs -m`). Deferred: gradients, path/region objects, and the PDF/SVG/PS
+surfaces.

--- a/packages/node-gi/node-gi/binding.gyp
+++ b/packages/node-gi/node-gi/binding.gyp
@@ -4,6 +4,7 @@
       "target_name": "node_gi",
       "sources": [
         "src/addon.cc",
+        "src/cairo.cc",
         "src/calls.cc",
         "src/class.cc",
         "src/loop.cc",
@@ -19,14 +20,14 @@
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
       "cflags": [
-        "<!@(pkg-config --cflags girepository-2.0)"
+        "<!@(pkg-config --cflags girepository-2.0 cairo)"
       ],
       "cflags_cc": [
-        "<!@(pkg-config --cflags girepository-2.0)",
+        "<!@(pkg-config --cflags girepository-2.0 cairo)",
         "-std=c++17"
       ],
       "libraries": [
-        "<!@(pkg-config --libs girepository-2.0)"
+        "<!@(pkg-config --libs girepository-2.0 cairo)"
       ],
       "defines": [
         "NAPI_VERSION=8",
@@ -35,7 +36,7 @@
       ],
       "xcode_settings": {
         "OTHER_CFLAGS": [
-          "<!@(pkg-config --cflags girepository-2.0)"
+          "<!@(pkg-config --cflags girepository-2.0 cairo)"
         ],
         "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
         "GCC_ENABLE_CPP_EXCEPTIONS": "NO"

--- a/packages/node-gi/node-gi/cairo.d.ts
+++ b/packages/node-gi/node-gi/cairo.d.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi/cairo — types for the GJS built-in `cairo` module on Node.
+
+export type CairoEnum = Readonly<Record<string, number>>;
+
+export const Antialias: CairoEnum;
+export const Content: CairoEnum;
+export const Extend: CairoEnum;
+export const FillRule: CairoEnum;
+export const Filter: CairoEnum;
+export const FontSlant: CairoEnum;
+export const FontWeight: CairoEnum;
+export const Format: CairoEnum;
+export const LineCap: CairoEnum;
+export const LineJoin: CairoEnum;
+export const Operator: CairoEnum;
+export const PatternType: CairoEnum;
+export const SurfaceType: CairoEnum;
+
+/** cairo drawing context (`cairo_t`). */
+export class Context {
+  constructor(surface: Surface);
+  save(): void;
+  restore(): void;
+  newPath(): void;
+  closePath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  relMoveTo(dx: number, dy: number): void;
+  relLineTo(dx: number, dy: number): void;
+  rectangle(x: number, y: number, width: number, height: number): void;
+  arc(xc: number, yc: number, radius: number, angle1: number, angle2: number): void;
+  arcNegative(xc: number, yc: number, radius: number, angle1: number, angle2: number): void;
+  curveTo(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number): void;
+  fill(): void;
+  fillPreserve(): void;
+  stroke(): void;
+  strokePreserve(): void;
+  paint(): void;
+  paintWithAlpha(alpha: number): void;
+  clip(): void;
+  clipPreserve(): void;
+  translate(tx: number, ty: number): void;
+  scale(sx: number, sy: number): void;
+  rotate(angle: number): void;
+  setSourceRGB(red: number, green: number, blue: number): void;
+  setSourceRGBA(red: number, green: number, blue: number, alpha: number): void;
+  setSource(pattern: Pattern): void;
+  setSourceSurface(surface: Surface, x: number, y: number): void;
+  setLineWidth(width: number): void;
+  getLineWidth(): number;
+  setLineCap(lineCap: number): void;
+  setLineJoin(lineJoin: number): void;
+  setFillRule(fillRule: number): void;
+  setAntialias(antialias: number): void;
+  setOperator(op: number): void;
+  setMiterLimit(limit: number): void;
+  setTolerance(tolerance: number): void;
+  status(): number;
+  $dispose(): void;
+}
+
+/** cairo surface base class (`cairo_surface_t`). */
+export class Surface {
+  getType(): number;
+  status(): number;
+  flush(): void;
+  finish(): void;
+  writeToPNG(filename: string): void;
+  $dispose(): void;
+}
+
+/** cairo image surface (`cairo_image_surface_*`). */
+export class ImageSurface extends Surface {
+  constructor(format: number, width: number, height: number);
+  static create(format: number, width: number, height: number): ImageSurface;
+  static createFromPNG(filename: string): ImageSurface;
+  getWidth(): number;
+  getHeight(): number;
+  getStride(): number;
+  getFormat(): number;
+  /** Raw pixel buffer as a fresh Uint8Array copy (length = stride * height). */
+  getData(): Uint8Array;
+}
+
+/** cairo pattern base class (`cairo_pattern_t`). */
+export class Pattern {
+  getType(): number;
+  status(): number;
+  $dispose(): void;
+}
+
+/** solid-color pattern. */
+export class SolidPattern extends Pattern {
+  static createRGB(red: number, green: number, blue: number): SolidPattern;
+  static createRGBA(red: number, green: number, blue: number, alpha: number): SolidPattern;
+}
+
+/** The GJS `cairo` module object (`import cairo from 'cairo'`). */
+declare const cairo: {
+  Antialias: CairoEnum;
+  Content: CairoEnum;
+  Extend: CairoEnum;
+  FillRule: CairoEnum;
+  Filter: CairoEnum;
+  FontSlant: CairoEnum;
+  FontWeight: CairoEnum;
+  Format: CairoEnum;
+  LineCap: CairoEnum;
+  LineJoin: CairoEnum;
+  Operator: CairoEnum;
+  PatternType: CairoEnum;
+  SurfaceType: CairoEnum;
+  Context: typeof Context;
+  Surface: typeof Surface;
+  ImageSurface: typeof ImageSurface;
+  Pattern: typeof Pattern;
+  SolidPattern: typeof SolidPattern;
+};
+
+export default cairo;

--- a/packages/node-gi/node-gi/cairo.js
+++ b/packages/node-gi/node-gi/cairo.js
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi/cairo — the GJS built-in `cairo` module on Node.
+//
+// GJS exposes a native cairo binding as `cairo` (`import cairo from 'cairo'` /
+// `gi://cairo` / `imports.cairo`): the drawing constructors (Context, Surface,
+// ImageSurface, Pattern, SolidPattern, …) plus the plain-object enums (Format,
+// Operator, Content, …). Crucially, cairo's types are FOREIGN structs in
+// GObject-Introspection, so a GI function taking/returning a cairo pointer (e.g. a
+// Gtk.DrawingArea draw-func's cairo_t) marshals through this module — which is why
+// an npm cairo package can't stand in.
+//
+// This module mirrors that surface on Node: the enums are ported verbatim from
+// GJS, the constructors wrap the native cairo binding (`src/cairo.cc`, exposed as
+// `native.__cairo`), and it registers its wrapper factories so the engine's
+// foreign-struct seam can hand a cairo pointer back as a real cairo.Context /
+// .Surface / .Pattern instance.
+//
+// The gjsify `--app node` build aliases the bare `cairo` specifier to this module
+// (kept external — `ALIASES_GJS_FOR_NODE`); `imports.cairo` (globals.js) reuses it.
+//
+// Reference: GJS's cairo module — refs/gjs/modules/core/_cairo.js (enums) +
+// refs/gjs/modules/cairo-*.cpp (constructors/methods) + refs/gjs/modules/esm/cairo.js
+// (the `Object.assign({}, imports._cairo, cairoNative)` merge shape).
+// Copyright (c) 2010 litl, LLC / GJS contributors. MIT OR LGPL-2.0-or-later.
+
+import native from './index.js';
+
+const c = native.__cairo;
+if (c === undefined) {
+  throw new Error(
+    '@gjsify/node-gi/cairo: the native cairo binding is missing from the addon. ' +
+      'Rebuild @gjsify/node-gi (node-gyp rebuild) — the addon must link libcairo.',
+  );
+}
+
+// ---- enums (ported verbatim from refs/gjs/modules/core/_cairo.js) -----------
+
+export const Antialias = { DEFAULT: 0, NONE: 1, GRAY: 2, SUBPIXEL: 3 };
+
+export const Content = { COLOR: 0x1000, ALPHA: 0x2000, COLOR_ALPHA: 0x3000 };
+
+export const Extend = { NONE: 0, REPEAT: 1, REFLECT: 2, PAD: 3 };
+
+export const FillRule = { WINDING: 0, EVEN_ODD: 1 };
+
+export const Filter = { FAST: 0, GOOD: 1, BEST: 2, NEAREST: 3, BILINEAR: 4, GAUSSIAN: 5 };
+
+export const FontSlant = { NORMAL: 0, ITALIC: 1, OBLIQUE: 2 };
+
+export const FontWeight = { NORMAL: 0, BOLD: 1 };
+
+export const Format = { ARGB32: 0, RGB24: 1, A8: 2, A1: 3, RGB16_565: 4 };
+
+export const LineCap = {
+  BUTT: 0,
+  ROUND: 1,
+  SQUARE: 2,
+  /** @deprecated Historical typo of {@link LineCap.SQUARE}, kept for compatibility. */
+  SQUASH: 2,
+};
+
+export const LineJoin = { MITER: 0, ROUND: 1, BEVEL: 2 };
+
+export const Operator = {
+  CLEAR: 0,
+  SOURCE: 1,
+  OVER: 2,
+  IN: 3,
+  OUT: 4,
+  ATOP: 5,
+  DEST: 6,
+  DEST_OVER: 7,
+  DEST_IN: 8,
+  DEST_OUT: 9,
+  DEST_ATOP: 10,
+  XOR: 11,
+  ADD: 12,
+  SATURATE: 13,
+  MULTIPLY: 14,
+  SCREEN: 15,
+  OVERLAY: 16,
+  DARKEN: 17,
+  LIGHTEN: 18,
+  COLOR_DODGE: 19,
+  COLOR_BURN: 20,
+  HARD_LIGHT: 21,
+  SOFT_LIGHT: 22,
+  DIFFERENCE: 23,
+  EXCLUSION: 24,
+  HSL_HUE: 25,
+  HSL_SATURATION: 26,
+  HSL_COLOR: 27,
+  HSL_LUMINOSITY: 28,
+};
+
+export const PatternType = { SOLID: 0, SURFACE: 1, LINEAR: 2, RADIAL: 3 };
+
+export const SurfaceType = {
+  IMAGE: 0,
+  PDF: 1,
+  PS: 2,
+  XLIB: 3,
+  XCB: 4,
+  GLITZ: 5,
+  QUARTZ: 6,
+  WIN32: 7,
+  BEOS: 8,
+  DIRECTFB: 9,
+  SVG: 10,
+  OS2: 11,
+  WIN32_PRINTING: 12,
+  QUARTZ_IMAGE: 13,
+};
+
+// ---- wrappers ---------------------------------------------------------------
+//
+// Each JS wrapper holds its native cairo handle (a type-tagged External) under a
+// non-enumerable `_ptr` property — kept in sync with kCairoPtrProp in src/cairo.cc
+// (the foreign to_func reads it; the native methods take `this._ptr` directly).
+
+const H = '_ptr';
+
+function setHandle(obj, handle) {
+  Object.defineProperty(obj, H, { value: handle, writable: true, configurable: true });
+  return obj;
+}
+
+// Build a wrapper for an existing native handle WITHOUT running the class
+// constructor (which would allocate a fresh cairo object) — used by the static
+// `create*` factories + the foreign from_func factories.
+function wrapRaw(Klass, handle) {
+  return setHandle(Object.create(Klass.prototype), handle);
+}
+
+function handleOf(x, what) {
+  const h = x != null ? x[H] : undefined;
+  if (h === undefined) throw new TypeError(`expected a ${what}`);
+  return h;
+}
+
+/** cairo drawing context. `new cairo.Context(surface)` wraps `cairo_create`. */
+export class Context {
+  constructor(surface) {
+    setHandle(this, c.contextCreate(handleOf(surface, 'cairo.Surface')));
+  }
+
+  save() {
+    c.save(this[H]);
+  }
+  restore() {
+    c.restore(this[H]);
+  }
+  newPath() {
+    c.newPath(this[H]);
+  }
+  closePath() {
+    c.closePath(this[H]);
+  }
+
+  moveTo(x, y) {
+    c.moveTo(this[H], x, y);
+  }
+  lineTo(x, y) {
+    c.lineTo(this[H], x, y);
+  }
+  relMoveTo(dx, dy) {
+    c.relMoveTo(this[H], dx, dy);
+  }
+  relLineTo(dx, dy) {
+    c.relLineTo(this[H], dx, dy);
+  }
+  rectangle(x, y, width, height) {
+    c.rectangle(this[H], x, y, width, height);
+  }
+  arc(xc, yc, radius, angle1, angle2) {
+    c.arc(this[H], xc, yc, radius, angle1, angle2);
+  }
+  arcNegative(xc, yc, radius, angle1, angle2) {
+    c.arcNegative(this[H], xc, yc, radius, angle1, angle2);
+  }
+  curveTo(x1, y1, x2, y2, x3, y3) {
+    c.curveTo(this[H], x1, y1, x2, y2, x3, y3);
+  }
+
+  fill() {
+    c.fill(this[H]);
+  }
+  fillPreserve() {
+    c.fillPreserve(this[H]);
+  }
+  stroke() {
+    c.stroke(this[H]);
+  }
+  strokePreserve() {
+    c.strokePreserve(this[H]);
+  }
+  paint() {
+    c.paint(this[H]);
+  }
+  paintWithAlpha(alpha) {
+    c.paintWithAlpha(this[H], alpha);
+  }
+  clip() {
+    c.clip(this[H]);
+  }
+  clipPreserve() {
+    c.clipPreserve(this[H]);
+  }
+
+  translate(tx, ty) {
+    c.translate(this[H], tx, ty);
+  }
+  scale(sx, sy) {
+    c.scale(this[H], sx, sy);
+  }
+  rotate(angle) {
+    c.rotate(this[H], angle);
+  }
+
+  setSourceRGB(red, green, blue) {
+    c.setSourceRGB(this[H], red, green, blue);
+  }
+  setSourceRGBA(red, green, blue, alpha) {
+    c.setSourceRGBA(this[H], red, green, blue, alpha);
+  }
+  setSource(pattern) {
+    c.setSource(this[H], handleOf(pattern, 'cairo.Pattern'));
+  }
+  setSourceSurface(surface, x, y) {
+    c.setSourceSurface(this[H], handleOf(surface, 'cairo.Surface'), x, y);
+  }
+
+  setLineWidth(width) {
+    c.setLineWidth(this[H], width);
+  }
+  getLineWidth() {
+    return c.getLineWidth(this[H]);
+  }
+  getOperator() {
+    return c.getOperator(this[H]);
+  }
+  getLineCap() {
+    return c.getLineCap(this[H]);
+  }
+  getLineJoin() {
+    return c.getLineJoin(this[H]);
+  }
+  getFillRule() {
+    return c.getFillRule(this[H]);
+  }
+  getAntialias() {
+    return c.getAntialias(this[H]);
+  }
+  getMiterLimit() {
+    return c.getMiterLimit(this[H]);
+  }
+  getTolerance() {
+    return c.getTolerance(this[H]);
+  }
+  hasCurrentPoint() {
+    return c.hasCurrentPoint(this[H]);
+  }
+  /** The current path point as `[x, y]`. */
+  getCurrentPoint() {
+    return c.getCurrentPoint(this[H]);
+  }
+  /** Current-path bounding box as `[x1, y1, x2, y2]`. */
+  pathExtents() {
+    return c.pathExtents(this[H]);
+  }
+  /** Fill bounding box as `[x1, y1, x2, y2]`. */
+  fillExtents() {
+    return c.fillExtents(this[H]);
+  }
+  /** Stroke bounding box as `[x1, y1, x2, y2]`. */
+  strokeExtents() {
+    return c.strokeExtents(this[H]);
+  }
+  /** Clip bounding box as `[x1, y1, x2, y2]`. */
+  clipExtents() {
+    return c.clipExtents(this[H]);
+  }
+  setLineCap(lineCap) {
+    c.setLineCap(this[H], lineCap);
+  }
+  setLineJoin(lineJoin) {
+    c.setLineJoin(this[H], lineJoin);
+  }
+  setFillRule(fillRule) {
+    c.setFillRule(this[H], fillRule);
+  }
+  setAntialias(antialias) {
+    c.setAntialias(this[H], antialias);
+  }
+  setOperator(op) {
+    c.setOperator(this[H], op);
+  }
+  setMiterLimit(limit) {
+    c.setMiterLimit(this[H], limit);
+  }
+  setTolerance(tolerance) {
+    c.setTolerance(this[H], tolerance);
+  }
+
+  status() {
+    return c.status(this[H]);
+  }
+
+  /** Eagerly destroy the underlying `cairo_t` (GJS `$dispose`). */
+  $dispose() {
+    c.dispose(this[H]);
+  }
+}
+
+/** cairo surface base class — the shared Surface API (flush/finish/writeToPNG/…). */
+export class Surface {
+  getType() {
+    return c.surfaceGetType(this[H]);
+  }
+  status() {
+    return c.surfaceStatus(this[H]);
+  }
+  flush() {
+    c.surfaceFlush(this[H]);
+  }
+  finish() {
+    c.surfaceFinish(this[H]);
+  }
+  writeToPNG(filename) {
+    c.surfaceWriteToPNG(this[H], filename);
+  }
+  /** Eagerly destroy the underlying `cairo_surface_t` (GJS `$dispose`). */
+  $dispose() {
+    c.dispose(this[H]);
+  }
+}
+
+/** An in-memory image surface (`cairo_image_surface_*`). */
+export class ImageSurface extends Surface {
+  constructor(format, width, height) {
+    super();
+    setHandle(this, c.imageSurfaceCreate(format, width, height));
+  }
+
+  static create(format, width, height) {
+    return new ImageSurface(format, width, height);
+  }
+  static createFromPNG(filename) {
+    return wrapRaw(ImageSurface, c.imageSurfaceCreateFromPNG(filename));
+  }
+
+  getWidth() {
+    return c.imageSurfaceGetWidth(this[H]);
+  }
+  getHeight() {
+    return c.imageSurfaceGetHeight(this[H]);
+  }
+  getStride() {
+    return c.imageSurfaceGetStride(this[H]);
+  }
+  getFormat() {
+    return c.imageSurfaceGetFormat(this[H]);
+  }
+  /**
+   * The raw pixel buffer as a fresh Uint8Array copy (length = stride * height).
+   * Note: GJS ships no `getData`; this is a node-gi convenience for headless pixel
+   * assertions. The buffer is flushed first + copied (independent of the surface).
+   */
+  getData() {
+    return c.imageSurfaceGetData(this[H]);
+  }
+}
+
+/** cairo pattern base class. */
+export class Pattern {
+  getType() {
+    return c.patternGetType(this[H]);
+  }
+  status() {
+    return c.patternStatus(this[H]);
+  }
+  /** Eagerly destroy the underlying `cairo_pattern_t` (GJS `$dispose`). */
+  $dispose() {
+    c.dispose(this[H]);
+  }
+}
+
+/** A solid-color pattern (`cairo_pattern_create_rgb[a]`). */
+export class SolidPattern extends Pattern {
+  static createRGB(red, green, blue) {
+    return wrapRaw(SolidPattern, c.solidPatternCreateRGB(red, green, blue));
+  }
+  static createRGBA(red, green, blue, alpha) {
+    return wrapRaw(SolidPattern, c.solidPatternCreateRGBA(red, green, blue, alpha));
+  }
+}
+
+// Register the wrapper factories so the engine's foreign-struct from_func can turn
+// a returned/callback cairo pointer into the right JS instance. Surface + Pattern
+// fan out to the concrete subclass by cairo runtime type (mirrors
+// CairoSurface::from_c_ptr / CairoPattern::from_c_ptr).
+c.setup({
+  context: (handle) => wrapRaw(Context, handle),
+  surface: (handle) =>
+    wrapRaw(c.surfaceGetType(handle) === SurfaceType.IMAGE ? ImageSurface : Surface, handle),
+  pattern: (handle) =>
+    wrapRaw(c.patternGetType(handle) === PatternType.SOLID ? SolidPattern : Pattern, handle),
+});
+
+// The default export mirrors GJS's ESM `cairo` object (enums + constructors), the
+// shape `import cairo from 'cairo'` returns.
+const cairo = {
+  Antialias,
+  Content,
+  Extend,
+  FillRule,
+  Filter,
+  FontSlant,
+  FontWeight,
+  Format,
+  LineCap,
+  LineJoin,
+  Operator,
+  PatternType,
+  SurfaceType,
+  Context,
+  Surface,
+  ImageSurface,
+  Pattern,
+  SolidPattern,
+};
+
+export default cairo;

--- a/packages/node-gi/node-gi/conformance/golden/cairo.txt
+++ b/packages/node-gi/node-gi/conformance/golden/cairo.txt
@@ -1,0 +1,19 @@
+Format.ARGB32: 0
+Content.COLOR_ALPHA: 12288
+Operator.OVER: 2
+PatternType.SOLID: 0
+LineCap.ROUND: 1
+surface: 64x48 stride 256 format 0
+surface type: 0
+fill extents: [8,8,28,24]
+path extents: [8,8,28,24]
+has current point: true
+current point: [30,42]
+lineWidth: 2
+operator: 2
+lineCap: 0 lineJoin: 0 fillRule: 0
+inside save lineWidth: 7 lineCap: 2
+after restore lineWidth: 2 lineCap: 0
+pattern type: 0
+setSource ok
+done

--- a/packages/node-gi/node-gi/conformance/programs/cairo.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/cairo.conf.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// cairo module — the foreign-struct binding (Context/Surface/ImageSurface/
+// SolidPattern) driven headlessly. Builds a deterministic ImageSurface scene
+// (exercising every ported drawing op — a broken op throws), then prints cairo's
+// own computed, font/zlib/display-independent state: surface geometry, the enum
+// values, the drawing context's getters (line width, cap/join/rule, current point,
+// path/fill extents), and the solid pattern's type. Byte-identical across gjs /
+// node / bun / deno (the golden is the gjs output).
+//
+// Only methods GJS's native cairo exposes are used (so gjs — the reference — runs
+// unchanged). Pixel bytes are NOT checksummed here: GJS ships no getData (pixels
+// unreadable on the reference), and cairo's PNG encoder rides the host zlib (node
+// bundles its own → not cross-runtime stable). Pixel parity vs. gjs is proven in
+// test/cairo.test.mjs (decode + compare); the foreign-struct round-trip in
+// test/cairo.test.mjs (IN, via PangoCairo) + test/cairo-drawfunc.test.mjs (FROM).
+import cairo from 'cairo';
+
+// Enum values (ported verbatim from GJS).
+print('Format.ARGB32:', cairo.Format.ARGB32);
+print('Content.COLOR_ALPHA:', cairo.Content.COLOR_ALPHA);
+print('Operator.OVER:', cairo.Operator.OVER);
+print('PatternType.SOLID:', cairo.PatternType.SOLID);
+print('LineCap.ROUND:', cairo.LineCap.ROUND);
+
+const W = 64;
+const H = 48;
+const surface = new cairo.ImageSurface(cairo.Format.ARGB32, W, H);
+print('surface:', surface.getWidth() + 'x' + surface.getHeight(), 'stride', surface.getStride(), 'format', surface.getFormat());
+print('surface type:', surface.getType());
+
+const cr = new cairo.Context(surface);
+cr.save();
+cr.setSourceRGB(1, 1, 1);
+cr.paint();
+cr.setSourceRGB(0.8, 0.1, 0.1);
+cr.rectangle(8, 8, 20, 16);
+print('fill extents:', JSON.stringify(cr.fillExtents()));
+print('path extents:', JSON.stringify(cr.pathExtents()));
+cr.fill();
+cr.setLineWidth(2);
+cr.setSourceRGB(0.1, 0.2, 0.9);
+cr.rectangle(30, 10, 20, 20);
+cr.stroke();
+cr.setSourceRGBA(0.1, 0.7, 0.2, 1);
+cr.arc(48, 36, 8, 0, 2 * Math.PI);
+cr.fill();
+cr.setLineWidth(3);
+cr.setSourceRGBA(0, 0, 0, 1);
+cr.moveTo(2, 44);
+cr.lineTo(60, 44);
+cr.curveTo(10, 40, 20, 46, 30, 42);
+print('has current point:', cr.hasCurrentPoint());
+print('current point:', JSON.stringify(cr.getCurrentPoint()));
+cr.stroke();
+cr.setOperator(cairo.Operator.OVER);
+cr.setLineCap(cairo.LineCap.ROUND);
+cr.setLineJoin(cairo.LineJoin.BEVEL);
+cr.setFillRule(cairo.FillRule.EVEN_ODD);
+cr.setMiterLimit(8);
+cr.setTolerance(0.25);
+cr.restore();
+
+// State survives restore (save/restore was balanced around the whole scene).
+print('lineWidth:', cr.getLineWidth());
+print('operator:', cr.getOperator());
+print('lineCap:', cr.getLineCap(), 'lineJoin:', cr.getLineJoin(), 'fillRule:', cr.getFillRule());
+
+// State set INSIDE save/restore then queried after restore returns to the default.
+cr.save();
+cr.setLineWidth(7);
+cr.setLineCap(cairo.LineCap.SQUARE);
+print('inside save lineWidth:', cr.getLineWidth(), 'lineCap:', cr.getLineCap());
+cr.restore();
+print('after restore lineWidth:', cr.getLineWidth(), 'lineCap:', cr.getLineCap());
+
+// A solid pattern as the context source (exercises setSource through the pattern).
+const pattern = cairo.SolidPattern.createRGBA(0.2, 0.4, 0.6, 0.8);
+print('pattern type:', pattern.getType());
+const cr2 = new cairo.Context(surface);
+cr2.setSource(pattern);
+cr2.paint();
+print('setSource ok');
+
+cr.$dispose();
+cr2.$dispose();
+print('done');

--- a/packages/node-gi/node-gi/globals.js
+++ b/packages/node-gi/node-gi/globals.js
@@ -12,12 +12,13 @@
 // Reference: GJS's global definitions (gjs/modules/{print,system,gettext}). The
 // legacy `imports.*` namespace mirrors gjs/modules/esm/gi.js's require shape.
 import { requireGi } from './gi.js';
-// `imports.system` / `imports.gettext` reuse the standalone module
-// implementations — ONE source of truth, also reachable directly as
-// `@gjsify/node-gi/system` + `@gjsify/node-gi/gettext` (and the bare `system` /
-// `gettext` specifiers on the `--app node` build).
+// `imports.system` / `imports.gettext` / `imports.cairo` reuse the standalone
+// module implementations — ONE source of truth, also reachable directly as
+// `@gjsify/node-gi/{system,gettext,cairo}` (and the bare `system` / `gettext` /
+// `cairo` specifiers on the `--app node` build).
 import system from './system.js';
 import gettext from './gettext.js';
+import cairo from './cairo.js';
 
 // GJS stringifies each argument with String() and joins with a space (no
 // util.inspect object formatting) — match that for fidelity.
@@ -86,10 +87,11 @@ function makeImports() {
     },
   );
 
-  // `imports.system` + `imports.gettext` are the standalone module objects
-  // (`./system.js` / `./gettext.js`) — the single source of truth for those
-  // surfaces, shared with the bare `system` / `gettext` specifiers on Node.
-  return { gi, system, gettext, versions: Object.create(null) };
+  // `imports.system` + `imports.gettext` + `imports.cairo` are the standalone
+  // module objects (`./system.js` / `./gettext.js` / `./cairo.js`) — the single
+  // source of truth for those surfaces, shared with the bare `system` / `gettext` /
+  // `cairo` specifiers on Node.
+  return { gi, system, gettext, cairo, versions: Object.create(null) };
 }
 
 // Side effect on import: seed the globals.

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -27,6 +27,10 @@
     "./gettext": {
       "types": "./gettext.d.ts",
       "default": "./gettext.js"
+    },
+    "./cairo": {
+      "types": "./cairo.d.ts",
+      "default": "./cairo.js"
     }
   },
   "files": [
@@ -40,6 +44,8 @@
     "system.d.ts",
     "gettext.js",
     "gettext.d.ts",
+    "cairo.js",
+    "cairo.d.ts",
     "src",
     "binding.gyp",
     "prebuilds"
@@ -67,7 +73,9 @@
     "test:conformance": "node scripts/conformance.mjs",
     "test:gimarshalling": "node scripts/gimarshalling.mjs",
     "test:deno": "node scripts/cross-runtime.mjs deno",
+    "test:cairo": "NODE_GI_NATIVE=build node --test test/cairo.test.mjs",
     "test:gtk": "NODE_GI_NATIVE=build node --test test/gtk-smoke.test.mjs",
+    "test:gtk-cairo": "NODE_GI_NATIVE=build node --test test/cairo-drawfunc.test.mjs",
     "test:adw": "NODE_GI_NATIVE=build node --test test/adw-smoke.test.mjs",
     "test:gtk-template": "NODE_GI_NATIVE=build node --test test/gtk-template.test.mjs",
     "test:gtk-template-callbacks": "NODE_GI_NATIVE=build node --test test/gtk-template-callbacks.test.mjs"

--- a/packages/node-gi/node-gi/scripts/conformance.mjs
+++ b/packages/node-gi/node-gi/scripts/conformance.mjs
@@ -163,10 +163,15 @@ for (const rt of runtimes) {
 // into this package so no node_modules layout is needed.
 function writeRuntimeTwin(name, file) {
   const src = readFileSync(file, 'utf8');
-  const rewritten = src.replace(
-    /import\s+(\w+)\s+from\s+['"]gi:\/\/(\w+)\?version=([\d.]+)['"];?/g,
-    (_m, ident, ns, ver) => `const ${ident} = requireGi('${ns}', '${ver}');`,
-  );
+  const rewritten = src
+    .replace(
+      /import\s+(\w+)\s+from\s+['"]gi:\/\/(\w+)\?version=([\d.]+)['"];?/g,
+      (_m, ident, ns, ver) => `const ${ident} = requireGi('${ns}', '${ver}');`,
+    )
+    // The GJS built-in `cairo` module: on gjs it is a native import; the node twin
+    // resolves it to this package's L1 cairo.js (the bare `cairo` specifier the
+    // gjsify --app node build aliases to @gjsify/node-gi/cairo).
+    .replace(/import\s+(\w+)\s+from\s+['"]cairo['"];?/g, (_m, ident) => `import ${ident} from '../../cairo.js';`);
   const body = "import '../../globals.js';\n" + "import { requireGi } from '../../gi.js';\n" + rewritten;
   mkdirSync(distDir, { recursive: true });
   const out = join(distDir, `${name}.node.mjs`);

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -39,6 +39,7 @@ const CONFORMANCE = [
   'boxed-out',
   'async-error',
   'bytes',
+  'cairo',
   'call-function',
   'callbacks',
   'closure-exception',

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -110,6 +110,8 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("disconnectSignal", Napi::Function::New(env, DisconnectSignal));
   exports.Set("setTemplateCallbackResolver",
               Napi::Function::New(env, SetTemplateCallbackResolver));
+  // The native cairo binding + foreign-struct registration (the `__cairo` export).
+  InitCairo(env, exports);
   return exports;
 }
 

--- a/packages/node-gi/node-gi/src/cairo.cc
+++ b/packages/node-gi/node-gi/src/cairo.cc
@@ -1,0 +1,646 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the native cairo binding + the foreign-struct seam.
+//
+// cairo's types (cairo_t / cairo_surface_t / cairo_pattern_t) are FOREIGN structs
+// in GObject-Introspection: GI does not know their layout and delegates their
+// marshalling to a module (gi_struct_info_is_foreign → true). GJS ships a
+// hand-written native cairo binding plus a foreign-struct registration so that a
+// GI function taking/returning a cairo pointer (e.g. a Gtk.DrawingArea draw-func's
+// cairo_t) round-trips to/from the JS cairo objects. This is the node-gi port of
+// that binding + registration.
+//
+// Reference: refs/gjs/modules/cairo-*.cpp (Context/Surface/ImageSurface/Pattern/
+// SolidPattern) + refs/gjs/gi/foreign.cpp (the foreign seam). Copyright (c) 2010
+// litl, LLC / GJS contributors, MIT OR LGPL-2.0-or-later. Retargeted to N-API +
+// the node-gi ownership model (adopt-or-ref, no separate release call — matching
+// WrapBoxed). Slice: Context (drawing ops), Surface + ImageSurface (headless
+// pixels), SolidPattern. Deferred: gradients, path, region, PDF/SVG/PS surfaces.
+//
+// The JS wrapper classes live in the L1 module (cairo.js); each instance holds
+// this binding's pointer as a type-tagged External under `_ptr`. The foreign
+// from_func wraps a returned/callback cairo pointer by calling the JS factory the
+// L1 module registered via `setup()` (stored per-env). The to_func reads `_ptr`
+// off the JS wrapper.
+
+#include "common.h"
+
+#include <cairo.h>
+#include <string.h>  // memcpy
+
+namespace nodegi {
+
+// The pointer kind carried by a cairo handle, so the finalizer/dispose picks the
+// matching cairo_*_destroy and the marshaller can typecheck a foreign IN arg.
+enum class CairoKind : uint8_t { Context, Surface, Pattern };
+
+// A cairo object handle: the ref-counted cairo pointer + its kind. `owns` is true
+// for every handle this binding creates (constructors own their fresh ref;
+// from_func adopts/references one) — the finalizer drops it via the kind's destroy
+// unless `disposed` already did so eagerly ($dispose).
+struct CairoHandle {
+  void* ptr;
+  CairoKind kind;
+  bool disposed;
+};
+
+// Process-unique tag so a cairo handle is never cross-dereferenced with a boxed /
+// GObject / GType External.
+static const napi_type_tag kCairoHandleTag = {0xca140b1a5e7f0011ULL,
+                                              0x9d3c7a25e6f18042ULL};
+
+// The property under which a JS cairo wrapper stores its native handle External.
+static const char kCairoPtrProp[] = "_ptr";
+
+static void DestroyCairo(CairoHandle* h) {
+  if (h->ptr == nullptr) return;
+  switch (h->kind) {
+    case CairoKind::Context: cairo_destroy(static_cast<cairo_t*>(h->ptr)); break;
+    case CairoKind::Surface: cairo_surface_destroy(static_cast<cairo_surface_t*>(h->ptr)); break;
+    case CairoKind::Pattern: cairo_pattern_destroy(static_cast<cairo_pattern_t*>(h->ptr)); break;
+  }
+}
+
+// Wrap a cairo pointer as a type-tagged External. These handles always destroy on
+// GC (unless already $dispose'd) — this binding never wraps a non-owned pointer.
+static Napi::Value MakeCairoHandle(Napi::Env env, void* ptr, CairoKind kind) {
+  CairoHandle* h = new CairoHandle{ptr, kind, false};
+  Napi::External<CairoHandle> ext =
+      Napi::External<CairoHandle>::New(env, h, [](Napi::Env, CairoHandle* d) {
+        if (!d->disposed) DestroyCairo(d);
+        delete d;
+      });
+  ext.TypeTag(&kCairoHandleTag);
+  return ext;
+}
+
+static CairoHandle* HandleFromExternal(Napi::Value v) {
+  if (!v.IsExternal()) return nullptr;
+  Napi::External<CairoHandle> ext = v.As<Napi::External<CairoHandle>>();
+  if (!ext.CheckTypeTag(&kCairoHandleTag)) return nullptr;
+  return ext.Data();
+}
+
+// ---- status checking (mirrors gjs_cairo_check_status) -----------------------
+static bool CheckStatus(Napi::Env env, cairo_status_t status, const char* name) {
+  if (status != CAIRO_STATUS_SUCCESS) {
+    Napi::Error::New(env, std::string("cairo error on ") + name + ": \"" +
+                              cairo_status_to_string(status) + "\" (" +
+                              std::to_string(static_cast<int>(status)) + ")")
+        .ThrowAsJavaScriptException();
+    return false;
+  }
+  return true;
+}
+
+// ---- native-method arg unwrapping (the handle External is info[0]) ----------
+static cairo_t* CtxArg(Napi::Env env, const Napi::CallbackInfo& info) {
+  CairoHandle* h = HandleFromExternal(info[0]);
+  if (h == nullptr || h->kind != CairoKind::Context || h->disposed || h->ptr == nullptr) {
+    Napi::TypeError::New(env, "expected a live cairo.Context").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<cairo_t*>(h->ptr);
+}
+static cairo_surface_t* SfcArg(Napi::Env env, const Napi::CallbackInfo& info) {
+  CairoHandle* h = HandleFromExternal(info[0]);
+  if (h == nullptr || h->kind != CairoKind::Surface || h->disposed || h->ptr == nullptr) {
+    Napi::TypeError::New(env, "expected a live cairo.Surface").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<cairo_surface_t*>(h->ptr);
+}
+
+// Read the cairo pointer from a JS wrapper OBJECT (the `_ptr` External) — used by
+// the foreign to_func, which receives the user's Context/Surface/Pattern instance.
+static void* PtrFromWrapper(Napi::Value v, CairoKind kind) {
+  if (!v.IsObject()) return nullptr;
+  Napi::Value p = v.As<Napi::Object>().Get(kCairoPtrProp);
+  CairoHandle* h = HandleFromExternal(p);
+  if (h == nullptr || h->kind != kind || h->disposed) return nullptr;
+  return h->ptr;
+}
+
+// Read a live cairo pointer from an External handle directly (a nested cairo arg
+// passed from JS as `other._ptr`: contextCreate's surface, setSource's pattern).
+static cairo_surface_t* SurfaceFromExt(Napi::Env env, Napi::Value v) {
+  CairoHandle* h = HandleFromExternal(v);
+  if (h == nullptr || h->kind != CairoKind::Surface || h->disposed || h->ptr == nullptr) {
+    Napi::TypeError::New(env, "expected a live cairo.Surface").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<cairo_surface_t*>(h->ptr);
+}
+static cairo_pattern_t* PatternFromExt(Napi::Env env, Napi::Value v) {
+  CairoHandle* h = HandleFromExternal(v);
+  if (h == nullptr || h->kind != CairoKind::Pattern || h->disposed || h->ptr == nullptr) {
+    Napi::TypeError::New(env, "expected a live cairo.Pattern").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<cairo_pattern_t*>(h->ptr);
+}
+
+static double Num(const Napi::CallbackInfo& info, size_t i) {
+  return info[i].ToNumber().DoubleValue();
+}
+static int Int(const Napi::CallbackInfo& info, size_t i) {
+  return info[i].ToNumber().Int32Value();
+}
+
+// ---- context drawing-method macros ------------------------------------------
+// Every op runs the cairo call then a trailing cairo_status(cr) check → throw on
+// error (the GJS FUNC-macro contract). Setters return undefined.
+#define CTX_0(CFN)                                    \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value { \
+    Napi::Env env = info.Env();                        \
+    cairo_t* cr = CtxArg(env, info);                   \
+    if (cr == nullptr) return env.Undefined();         \
+    CFN(cr);                                           \
+    CheckStatus(env, cairo_status(cr), "context");     \
+    return env.Undefined();                            \
+  }
+#define CTX_1D(CFN)                                   \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value { \
+    Napi::Env env = info.Env();                        \
+    cairo_t* cr = CtxArg(env, info);                   \
+    if (cr == nullptr) return env.Undefined();         \
+    CFN(cr, Num(info, 1));                             \
+    CheckStatus(env, cairo_status(cr), "context");     \
+    return env.Undefined();                            \
+  }
+#define CTX_2D(CFN)                                   \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value { \
+    Napi::Env env = info.Env();                        \
+    cairo_t* cr = CtxArg(env, info);                   \
+    if (cr == nullptr) return env.Undefined();         \
+    CFN(cr, Num(info, 1), Num(info, 2));               \
+    CheckStatus(env, cairo_status(cr), "context");     \
+    return env.Undefined();                            \
+  }
+#define CTX_3D(CFN)                                   \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value { \
+    Napi::Env env = info.Env();                        \
+    cairo_t* cr = CtxArg(env, info);                   \
+    if (cr == nullptr) return env.Undefined();         \
+    CFN(cr, Num(info, 1), Num(info, 2), Num(info, 3)); \
+    CheckStatus(env, cairo_status(cr), "context");     \
+    return env.Undefined();                            \
+  }
+#define CTX_4D(CFN)                                                  \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value {               \
+    Napi::Env env = info.Env();                                      \
+    cairo_t* cr = CtxArg(env, info);                                 \
+    if (cr == nullptr) return env.Undefined();                       \
+    CFN(cr, Num(info, 1), Num(info, 2), Num(info, 3), Num(info, 4)); \
+    CheckStatus(env, cairo_status(cr), "context");                   \
+    return env.Undefined();                                          \
+  }
+#define CTX_5D(CFN)                                                                 \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value {                              \
+    Napi::Env env = info.Env();                                                     \
+    cairo_t* cr = CtxArg(env, info);                                                \
+    if (cr == nullptr) return env.Undefined();                                      \
+    CFN(cr, Num(info, 1), Num(info, 2), Num(info, 3), Num(info, 4), Num(info, 5));  \
+    CheckStatus(env, cairo_status(cr), "context");                                  \
+    return env.Undefined();                                                         \
+  }
+#define CTX_6D(CFN)                                                                              \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value {                                           \
+    Napi::Env env = info.Env();                                                                  \
+    cairo_t* cr = CtxArg(env, info);                                                             \
+    if (cr == nullptr) return env.Undefined();                                                   \
+    CFN(cr, Num(info, 1), Num(info, 2), Num(info, 3), Num(info, 4), Num(info, 5), Num(info, 6)); \
+    CheckStatus(env, cairo_status(cr), "context");                                               \
+    return env.Undefined();                                                                      \
+  }
+// Integer-enum context setter (operator / line cap / line join / fill rule / antialias).
+#define CTX_ENUM(CFN, CTYPE)                                    \
+  +[](const Napi::CallbackInfo& info) -> Napi::Value {          \
+    Napi::Env env = info.Env();                                 \
+    cairo_t* cr = CtxArg(env, info);                            \
+    if (cr == nullptr) return env.Undefined();                 \
+    CFN(cr, static_cast<CTYPE>(Int(info, 1)));                  \
+    CheckStatus(env, cairo_status(cr), "context");             \
+    return env.Undefined();                                     \
+  }
+
+// ---- the foreign-struct converters (Context / Surface / Pattern) ------------
+//
+// from_func: adopt-or-ref (node-gi ownership model). transfer-nothing (a draw-func
+// cairo_t, a borrowed return) → add a ref so the JS wrapper owns one and the
+// caller's ref stays intact; transfer-everything → adopt the handed ref. Then wrap
+// the External via the L1 factory the module registered (per-env) so the result is
+// a real cairo.Context / .Surface (or .ImageSurface) / .Pattern instance.
+static Napi::Value CallWrapper(Napi::Env env, const char* kindKey, Napi::Value handle) {
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr || d->cairoWrappers == nullptr) {
+    Napi::Error::New(env, "cairo module not initialized — import 'cairo' before a GI call "
+                          "hands you a cairo object")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  napi_value wrappersV = nullptr;
+  napi_get_reference_value(env, d->cairoWrappers, &wrappersV);
+  Napi::Object wrappers(env, wrappersV);
+  Napi::Function fn = wrappers.Get(kindKey).As<Napi::Function>();
+  return fn.Call({handle});
+}
+
+static bool ContextTo(Napi::Env env, Napi::Value v, GITransfer transfer, GIArgument* arg) {
+  if (v.IsNull() || v.IsUndefined()) { arg->v_pointer = nullptr; return true; }
+  void* p = PtrFromWrapper(v, CairoKind::Context);
+  if (p == nullptr) {
+    Napi::TypeError::New(env, "expected a cairo.Context").ThrowAsJavaScriptException();
+    return false;
+  }
+  if (transfer == GI_TRANSFER_EVERYTHING) cairo_reference(static_cast<cairo_t*>(p));
+  arg->v_pointer = p;
+  return true;
+}
+static Napi::Value ContextFrom(Napi::Env env, gpointer ptr, GITransfer transfer) {
+  if (ptr == nullptr) return env.Null();
+  if (transfer == GI_TRANSFER_NOTHING) cairo_reference(static_cast<cairo_t*>(ptr));
+  return CallWrapper(env, "context", MakeCairoHandle(env, ptr, CairoKind::Context));
+}
+
+static bool SurfaceTo(Napi::Env env, Napi::Value v, GITransfer transfer, GIArgument* arg) {
+  if (v.IsNull() || v.IsUndefined()) { arg->v_pointer = nullptr; return true; }
+  void* p = PtrFromWrapper(v, CairoKind::Surface);
+  if (p == nullptr) {
+    Napi::TypeError::New(env, "expected a cairo.Surface").ThrowAsJavaScriptException();
+    return false;
+  }
+  if (transfer == GI_TRANSFER_EVERYTHING) cairo_surface_reference(static_cast<cairo_surface_t*>(p));
+  arg->v_pointer = p;
+  return true;
+}
+static Napi::Value SurfaceFrom(Napi::Env env, gpointer ptr, GITransfer transfer) {
+  if (ptr == nullptr) return env.Null();
+  if (transfer == GI_TRANSFER_NOTHING) cairo_surface_reference(static_cast<cairo_surface_t*>(ptr));
+  return CallWrapper(env, "surface", MakeCairoHandle(env, ptr, CairoKind::Surface));
+}
+
+static bool PatternTo(Napi::Env env, Napi::Value v, GITransfer transfer, GIArgument* arg) {
+  if (v.IsNull() || v.IsUndefined()) { arg->v_pointer = nullptr; return true; }
+  void* p = PtrFromWrapper(v, CairoKind::Pattern);
+  if (p == nullptr) {
+    Napi::TypeError::New(env, "expected a cairo.Pattern").ThrowAsJavaScriptException();
+    return false;
+  }
+  if (transfer == GI_TRANSFER_EVERYTHING) cairo_pattern_reference(static_cast<cairo_pattern_t*>(p));
+  arg->v_pointer = p;
+  return true;
+}
+static Napi::Value PatternFrom(Napi::Env env, gpointer ptr, GITransfer transfer) {
+  if (ptr == nullptr) return env.Null();
+  if (transfer == GI_TRANSFER_NOTHING) cairo_pattern_reference(static_cast<cairo_pattern_t*>(ptr));
+  return CallWrapper(env, "pattern", MakeCairoHandle(env, ptr, CairoKind::Pattern));
+}
+
+static const ForeignStructOps kContextOps{ContextTo, ContextFrom};
+static const ForeignStructOps kSurfaceOps{SurfaceTo, SurfaceFrom};
+static const ForeignStructOps kPatternOps{PatternTo, PatternFrom};
+
+// setup(wrappers): the L1 module hands its JS wrapper factories ({context, surface,
+// pattern}) — each takes the `_ptr` External and returns the class instance. Stored
+// per-env (a napi_ref is env-specific) so the foreign from_func can build wrappers.
+static Napi::Value CairoSetup(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr) return env.Undefined();
+  if (!info[0].IsObject()) {
+    Napi::TypeError::New(env, "cairo setup expects a wrappers object")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  if (d->cairoWrappers != nullptr) napi_delete_reference(env, d->cairoWrappers);
+  napi_create_reference(env, info[0], 1, &d->cairoWrappers);
+  return env.Undefined();
+}
+
+void InitCairo(Napi::Env env, Napi::Object exports) {
+  // The foreign converters are static + JS-independent, so register them once at
+  // module init (before any GI call marshals a cairo type). The JS wrapper
+  // factories the from_func needs are supplied later by cairo.js's setup().
+  RegisterForeignStruct("cairo", "Context", &kContextOps);
+  RegisterForeignStruct("cairo", "Surface", &kSurfaceOps);
+  RegisterForeignStruct("cairo", "Pattern", &kPatternOps);
+
+  Napi::Object c = Napi::Object::New(env);
+  c.Set("setup", Napi::Function::New(env, CairoSetup));
+
+  // ---- constructors ----
+  c.Set("imageSurfaceCreate", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = cairo_image_surface_create(
+              static_cast<cairo_format_t>(Int(info, 0)), Int(info, 1), Int(info, 2));
+          if (!CheckStatus(env, cairo_surface_status(s), "surface")) {
+            cairo_surface_destroy(s);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, s, CairoKind::Surface);
+        }));
+  c.Set("imageSurfaceCreateFromPNG", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          std::string path = info[0].ToString().Utf8Value();
+          cairo_surface_t* s = cairo_image_surface_create_from_png(path.c_str());
+          if (!CheckStatus(env, cairo_surface_status(s), "surface")) {
+            cairo_surface_destroy(s);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, s, CairoKind::Surface);
+        }));
+  c.Set("contextCreate", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* sp = SurfaceFromExt(env, info[0]);
+          if (sp == nullptr) return env.Undefined();
+          cairo_t* cr = cairo_create(sp);
+          if (!CheckStatus(env, cairo_status(cr), "context")) {
+            cairo_destroy(cr);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, cr, CairoKind::Context);
+        }));
+  c.Set("solidPatternCreateRGB", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = cairo_pattern_create_rgb(Num(info, 0), Num(info, 1), Num(info, 2));
+          if (!CheckStatus(env, cairo_pattern_status(p), "pattern")) {
+            cairo_pattern_destroy(p);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+  c.Set("solidPatternCreateRGBA", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p =
+              cairo_pattern_create_rgba(Num(info, 0), Num(info, 1), Num(info, 2), Num(info, 3));
+          if (!CheckStatus(env, cairo_pattern_status(p), "pattern")) {
+            cairo_pattern_destroy(p);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+  // patternGetType/patternStatus back the L1 pattern from_func subclass fan-out
+  // (SolidPattern vs base Pattern), mirroring CairoPattern::from_c_ptr.
+  c.Set("patternGetType", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_pattern_get_type(p));
+        }));
+  c.Set("patternStatus", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_pattern_status(p));
+        }));
+
+  // ---- surface methods ----
+  c.Set("surfaceFlush", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          cairo_surface_flush(s);
+          CheckStatus(env, cairo_surface_status(s), "surface");
+          return env.Undefined();
+        }));
+  c.Set("surfaceFinish", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          cairo_surface_finish(s);
+          CheckStatus(env, cairo_surface_status(s), "surface");
+          return env.Undefined();
+        }));
+  c.Set("surfaceGetType", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_surface_get_type(s));
+        }));
+  c.Set("surfaceStatus", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_surface_status(s));
+        }));
+  c.Set("surfaceWriteToPNG", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          std::string path = info[1].ToString().Utf8Value();
+          cairo_status_t st = cairo_surface_write_to_png(s, path.c_str());
+          CheckStatus(env, st, "surface");
+          return env.Undefined();
+        }));
+  c.Set("imageSurfaceGetWidth", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_image_surface_get_width(s));
+        }));
+  c.Set("imageSurfaceGetHeight", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_image_surface_get_height(s));
+        }));
+  c.Set("imageSurfaceGetStride", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_image_surface_get_stride(s));
+        }));
+  c.Set("imageSurfaceGetFormat", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_image_surface_get_format(s));
+        }));
+  // getData: net-new (GJS ships no getData). flush, then COPY the ARGB32 buffer
+  // (stride*height) into a fresh Uint8Array — a copy is GC-safe (surface + array
+  // then have independent lifetimes).
+  c.Set("imageSurfaceGetData", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SfcArg(env, info);
+          if (s == nullptr) return env.Undefined();
+          cairo_surface_flush(s);
+          unsigned char* data = cairo_image_surface_get_data(s);
+          int stride = cairo_image_surface_get_stride(s);
+          int height = cairo_image_surface_get_height(s);
+          size_t len = static_cast<size_t>(stride) * static_cast<size_t>(height);
+          Napi::Uint8Array out = Napi::Uint8Array::New(env, len);
+          if (data != nullptr && len > 0) memcpy(out.Data(), data, len);
+          return out;
+        }));
+
+  // ---- context methods ----
+  c.Set("save", Napi::Function::New(env, CTX_0(cairo_save)));
+  c.Set("restore", Napi::Function::New(env, CTX_0(cairo_restore)));
+  c.Set("newPath", Napi::Function::New(env, CTX_0(cairo_new_path)));
+  c.Set("closePath", Napi::Function::New(env, CTX_0(cairo_close_path)));
+  c.Set("fill", Napi::Function::New(env, CTX_0(cairo_fill)));
+  c.Set("fillPreserve", Napi::Function::New(env, CTX_0(cairo_fill_preserve)));
+  c.Set("stroke", Napi::Function::New(env, CTX_0(cairo_stroke)));
+  c.Set("strokePreserve", Napi::Function::New(env, CTX_0(cairo_stroke_preserve)));
+  c.Set("paint", Napi::Function::New(env, CTX_0(cairo_paint)));
+  c.Set("clip", Napi::Function::New(env, CTX_0(cairo_clip)));
+  c.Set("clipPreserve", Napi::Function::New(env, CTX_0(cairo_clip_preserve)));
+
+  c.Set("setLineWidth", Napi::Function::New(env, CTX_1D(cairo_set_line_width)));
+  c.Set("paintWithAlpha", Napi::Function::New(env, CTX_1D(cairo_paint_with_alpha)));
+  c.Set("rotate", Napi::Function::New(env, CTX_1D(cairo_rotate)));
+  c.Set("setMiterLimit", Napi::Function::New(env, CTX_1D(cairo_set_miter_limit)));
+  c.Set("setTolerance", Napi::Function::New(env, CTX_1D(cairo_set_tolerance)));
+
+  c.Set("moveTo", Napi::Function::New(env, CTX_2D(cairo_move_to)));
+  c.Set("lineTo", Napi::Function::New(env, CTX_2D(cairo_line_to)));
+  c.Set("relMoveTo", Napi::Function::New(env, CTX_2D(cairo_rel_move_to)));
+  c.Set("relLineTo", Napi::Function::New(env, CTX_2D(cairo_rel_line_to)));
+  c.Set("translate", Napi::Function::New(env, CTX_2D(cairo_translate)));
+  c.Set("scale", Napi::Function::New(env, CTX_2D(cairo_scale)));
+
+  c.Set("setSourceRGB", Napi::Function::New(env, CTX_3D(cairo_set_source_rgb)));
+  c.Set("setSourceRGBA", Napi::Function::New(env, CTX_4D(cairo_set_source_rgba)));
+  c.Set("rectangle", Napi::Function::New(env, CTX_4D(cairo_rectangle)));
+  c.Set("arc", Napi::Function::New(env, CTX_5D(cairo_arc)));
+  c.Set("arcNegative", Napi::Function::New(env, CTX_5D(cairo_arc_negative)));
+  c.Set("curveTo", Napi::Function::New(env, CTX_6D(cairo_curve_to)));
+
+  c.Set("setOperator", Napi::Function::New(env, CTX_ENUM(cairo_set_operator, cairo_operator_t)));
+  c.Set("setLineCap", Napi::Function::New(env, CTX_ENUM(cairo_set_line_cap, cairo_line_cap_t)));
+  c.Set("setLineJoin", Napi::Function::New(env, CTX_ENUM(cairo_set_line_join, cairo_line_join_t)));
+  c.Set("setFillRule", Napi::Function::New(env, CTX_ENUM(cairo_set_fill_rule, cairo_fill_rule_t)));
+  c.Set("setAntialias", Napi::Function::New(env, CTX_ENUM(cairo_set_antialias, cairo_antialias_t)));
+
+  c.Set("getLineWidth", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_line_width(cr));
+        }));
+  // Deterministic state getters (font/zlib/display-independent) — mirror GJS's
+  // Context getters + drive the cross-runtime conformance program.
+  c.Set("getOperator", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_operator(cr));
+        }));
+  c.Set("getLineCap", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_line_cap(cr));
+        }));
+  c.Set("getLineJoin", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_line_join(cr));
+        }));
+  c.Set("getFillRule", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_fill_rule(cr));
+        }));
+  c.Set("getAntialias", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_antialias(cr));
+        }));
+  c.Set("getMiterLimit", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_miter_limit(cr));
+        }));
+  c.Set("getTolerance", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_tolerance(cr));
+        }));
+  c.Set("hasCurrentPoint", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Boolean::New(env, cairo_has_current_point(cr));
+        }));
+  c.Set("getCurrentPoint", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          double x = 0, y = 0;
+          cairo_get_current_point(cr, &x, &y);
+          Napi::Array a = Napi::Array::New(env, 2);
+          a.Set(0u, Napi::Number::New(env, x));
+          a.Set(1u, Napi::Number::New(env, y));
+          return a;
+        }));
+  // The 4-double extents getters (path/fill/stroke/clip) return [x1, y1, x2, y2].
+#define CTX_EXTENTS(NAME, CFN)                                              \
+  c.Set(NAME, Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value { \
+          Napi::Env env = info.Env();                                       \
+          cairo_t* cr = CtxArg(env, info);                                  \
+          if (cr == nullptr) return env.Undefined();                        \
+          double x1 = 0, y1 = 0, x2 = 0, y2 = 0;                            \
+          CFN(cr, &x1, &y1, &x2, &y2);                                      \
+          Napi::Array a = Napi::Array::New(env, 4);                         \
+          a.Set(0u, Napi::Number::New(env, x1));                            \
+          a.Set(1u, Napi::Number::New(env, y1));                            \
+          a.Set(2u, Napi::Number::New(env, x2));                            \
+          a.Set(3u, Napi::Number::New(env, y2));                            \
+          return a;                                                         \
+        }));
+  CTX_EXTENTS("pathExtents", cairo_path_extents)
+  CTX_EXTENTS("fillExtents", cairo_fill_extents)
+  CTX_EXTENTS("strokeExtents", cairo_stroke_extents)
+  CTX_EXTENTS("clipExtents", cairo_clip_extents)
+  c.Set("status", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_status(cr));
+        }));
+  c.Set("setSource", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_pattern_t* p = PatternFromExt(env, info[1]);
+          if (p == nullptr) return env.Undefined();
+          cairo_set_source(cr, p);
+          CheckStatus(env, cairo_status(cr), "context");
+          return env.Undefined();
+        }));
+  c.Set("setSourceSurface", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_surface_t* p = SurfaceFromExt(env, info[1]);
+          if (p == nullptr) return env.Undefined();
+          cairo_set_source_surface(cr, p, Num(info, 2), Num(info, 3));
+          CheckStatus(env, cairo_status(cr), "context");
+          return env.Undefined();
+        }));
+
+  // ---- $dispose (Context / Surface / Pattern) ----
+  // Eagerly destroy the underlying cairo object + mark the handle so the finalizer
+  // won't double-free and any further method call throws (a live-handle check).
+  c.Set("dispose", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          CairoHandle* h = HandleFromExternal(info[0]);
+          if (h == nullptr) return env.Undefined();
+          if (!h->disposed) {
+            DestroyCairo(h);
+            h->disposed = true;
+            h->ptr = nullptr;
+          }
+          return env.Undefined();
+        }));
+
+  exports.Set("__cairo", c);
+}
+
+}  // namespace nodegi

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -59,6 +59,12 @@ struct NodeGiEnvData {
   // undefined). Stored per-env for the same reason as errorBuilder (a napi_ref is
   // env-specific). See the Gtk.Widget composite-template scope further down.
   napi_ref templateCallbackResolver = nullptr;
+  // The cairo L1 module's JS wrapper factories ({context, surface, pattern}), set
+  // by the native cairo `setup()` when `import 'cairo'` first loads. The
+  // foreign-struct from_func calls them to wrap a returned/callback cairo pointer
+  // into the JS Context/Surface(/ImageSurface)/Pattern class instance. Per-env for
+  // the same reason as errorBuilder (a napi_ref is env-specific). See cairo.cc.
+  napi_ref cairoWrappers = nullptr;
 };
 
 void NodeGiEnvDataFinalize(napi_env env, void* data, void* hint);
@@ -99,6 +105,34 @@ bool TryGetBoxedPtr(Napi::Value v, gpointer* out);
 Napi::Value MakeGTypeHandle(Napi::Env env, GType gtype);
 GType ReadGTypeHandle(Napi::Value v);
 bool UnwrapGTypeArg(Napi::Env env, Napi::Value v, GType* out);
+
+// ---- foreign-struct seam (cairo) --------------------------------------------
+//
+// A "foreign" struct (gi_struct_info_is_foreign) is one whose layout GI does not
+// know — it delegates marshalling to a module. cairo's Context/Surface/Pattern are
+// the canonical case: a GI function taking/returning a cairo_t*/cairo_surface_t*/
+// cairo_pattern_t* (e.g. a Gtk.DrawingArea draw-func's cairo_t) round-trips through
+// the cairo module's converters, NOT the generic boxed path. Mirrors GJS's
+// gi/foreign.cpp seam (gjs_struct_foreign_register / lookup / to/from_gi_argument).
+//
+// A registered module (cairo.cc) supplies `to` (JS wrapper -> GIArgument.v_pointer)
+// and `from` (GIArgument.v_pointer -> a fresh JS wrapper). Ownership follows the
+// node-gi adopt-or-ref model (no separate release call, matching WrapBoxed).
+struct ForeignStructOps {
+  bool (*to)(Napi::Env, Napi::Value, GITransfer, GIArgument*);
+  Napi::Value (*from)(Napi::Env, gpointer, GITransfer);
+};
+void RegisterForeignStruct(const char* ns, const char* type_name, const ForeignStructOps* ops);
+const ForeignStructOps* LookupForeignStruct(const char* ns, const char* type_name);
+// The foreign ops for a struct/union GIBaseInfo, or null when it is not a
+// registered foreign type — used by the INTERFACE marshalling branches to route a
+// cairo-typed arg/return/callback-arg to the module instead of the boxed path.
+const ForeignStructOps* ForeignOpsForInfo(GIBaseInfo* iface);
+
+// cairo.cc — the native cairo binding + foreign-struct registration. Called once
+// from addon.cc's Init; sets the `__cairo` export + registers Context/Surface/
+// Pattern foreign converters.
+void InitCairo(Napi::Env env, Napi::Object exports);
 
 // ---- GJS-exact 64-bit integer marshalling helpers (shared) -------------------
 //

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -3,7 +3,38 @@
 
 #include "common.h"
 
+#include <unordered_map>
+#include <utility>
+
 namespace nodegi {
+
+// ---- foreign-struct registry (cairo seam) -----------------------------------
+//
+// Port of GJS's gi/foreign.cpp table (keyed by (namespace, type_name)). A module
+// (cairo.cc) registers converters for its foreign structs; the INTERFACE
+// marshalling branches below route a foreign-typed arg/return to them instead of
+// the generic boxed path. Populated at addon init (before any GI call marshals a
+// foreign type), then read-only — no lock needed.
+using ForeignKey = std::pair<std::string, std::string>;
+struct ForeignKeyHash {
+  size_t operator()(const ForeignKey& k) const {
+    return std::hash<std::string>()(k.first) ^ (std::hash<std::string>()(k.second) << 1);
+  }
+};
+static std::unordered_map<ForeignKey, const ForeignStructOps*, ForeignKeyHash> g_foreign_structs;
+
+void RegisterForeignStruct(const char* ns, const char* type_name, const ForeignStructOps* ops) {
+  g_foreign_structs[{ns != nullptr ? ns : "", type_name != nullptr ? type_name : ""}] = ops;
+}
+const ForeignStructOps* LookupForeignStruct(const char* ns, const char* type_name) {
+  auto it = g_foreign_structs.find({ns != nullptr ? ns : "", type_name != nullptr ? type_name : ""});
+  return it == g_foreign_structs.end() ? nullptr : it->second;
+}
+const ForeignStructOps* ForeignOpsForInfo(GIBaseInfo* iface) {
+  if (iface == nullptr || !GI_IS_STRUCT_INFO(iface)) return nullptr;
+  if (!gi_struct_info_is_foreign(reinterpret_cast<GIStructInfo*>(iface))) return nullptr;
+  return LookupForeignStruct(gi_base_info_get_namespace(iface), gi_base_info_get_name(iface));
+}
 
 // ---- value marshalling (milestone 1: primitives + strings) ----
 //
@@ -237,9 +268,18 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
           out->v_int = v.ToNumber().Int32Value();
           handled = true;
         } else if (GI_IS_STRUCT_INFO(iface) || GI_IS_UNION_INFO(iface)) {
-          // Boxed/struct IN args arrive as boxed handles; null/undefined maps to
-          // a NULL pointer (e.g. GLib.MainLoop.new(null, false)).
-          if (v.IsNull() || v.IsUndefined()) {
+          // A foreign struct (cairo Context/Surface/Pattern) marshals through its
+          // module's converter, not the boxed path.
+          const ForeignStructOps* fops = ForeignOpsForInfo(iface);
+          if (fops != nullptr) {
+            if (!fops->to(env, v, transfer, out)) {
+              gi_base_info_unref(iface);
+              return false;  // to() already threw
+            }
+            handled = true;
+          } else if (v.IsNull() || v.IsUndefined()) {
+            // Boxed/struct IN args arrive as boxed handles; null/undefined maps to
+            // a NULL pointer (e.g. GLib.MainLoop.new(null, false)).
             out->v_pointer = nullptr;
             handled = true;
           } else {
@@ -349,7 +389,11 @@ Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
       } else if (iface != nullptr && (GI_IS_ENUM_INFO(iface) || GI_IS_FLAGS_INFO(iface))) {
         result = Napi::Number::New(env, arg->v_int);
       } else if (iface != nullptr && (GI_IS_STRUCT_INFO(iface) || GI_IS_UNION_INFO(iface))) {
-        result = WrapBoxed(env, arg->v_pointer, iface, transfer);
+        // A foreign struct (cairo) returned/handed to a callback (e.g. a draw-func's
+        // cairo_t) wraps via its module's converter, not the boxed path.
+        const ForeignStructOps* fops = ForeignOpsForInfo(iface);
+        result = fops != nullptr ? fops->from(env, arg->v_pointer, transfer)
+                                 : WrapBoxed(env, arg->v_pointer, iface, transfer);
       } else {
         Napi::TypeError::New(
             env,

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -15,6 +15,7 @@ void NodeGiEnvDataFinalize(napi_env env, void* data, void* /*hint*/) {
   if (d->errorBuilder != nullptr) napi_delete_reference(env, d->errorBuilder);
   if (d->templateCallbackResolver != nullptr)
     napi_delete_reference(env, d->templateCallbackResolver);
+  if (d->cairoWrappers != nullptr) napi_delete_reference(env, d->cairoWrappers);
   delete d;
 }
 

--- a/packages/node-gi/node-gi/test/cairo-drawfunc.test.mjs
+++ b/packages/node-gi/node-gi/test/cairo-drawfunc.test.mjs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the cairo foreign-struct FROM seam via a real GTK draw-func.
+//
+// THE HEADLINE PROOF for the foreign-struct round-trip across a GI CALLBACK: a
+// Gtk.DrawingArea's `set_draw_func` hands the callback a `cairo_t*` (transfer
+// nothing). cairo is a FOREIGN struct — GI delegates its marshalling to the cairo
+// module — so the engine's foreign from_func must wrap that borrowed pointer into a
+// live `cairo.Context` the JS draw-func can draw with. This test asserts the
+// callback receives an actual `cairo.Context` (not a boxed handle) and that drawing
+// ops on it succeed, then reads the drawn pixels back off an ImageSurface-backed
+// target to confirm the paint landed.
+//
+// SELF-SKIPPING: needs a display (DISPLAY / WAYLAND_DISPLAY) + the Gtk-4.0 typelib,
+// so the fast headless `npm test` leg skips it cleanly; the dedicated `gtk-smoke`
+// CI job (Xvfb + GTK stack) is where it actually runs. Mirrors gtk-smoke.test.mjs.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+import cairo from '../cairo.js';
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let Gtk;
+let Gio;
+let GLib;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    Gtk = requireGi('Gtk', '4.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+test('Gtk.DrawingArea draw-func receives a cairo.Context (foreign FROM seam)', { skip }, () => {
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiCairoDrawFunc',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  const result = { called: false, isContext: false, drewOk: false, error: null };
+
+  app.connect('activate', () => {
+    const win = new Gtk.ApplicationWindow({ application: app });
+    win.set_default_size(40, 30);
+    const area = new Gtk.DrawingArea();
+    area.set_content_width(40);
+    area.set_content_height(30);
+
+    // The draw-func: GTK hands us (area, cr, width, height). `cr` is a cairo_t*
+    // marshalled through the foreign from_func → must be a live cairo.Context.
+    area.set_draw_func((_area, cr, width, height) => {
+      result.called = true;
+      try {
+        result.isContext = cr instanceof cairo.Context;
+        // Draw with the handed context — a broken round-trip would throw here.
+        cr.setSourceRGB(1, 0, 0);
+        cr.rectangle(0, 0, width, height);
+        cr.fill();
+        cr.setSourceRGB(0, 0, 1);
+        cr.moveTo(0, 0);
+        cr.lineTo(width, height);
+        cr.stroke();
+        result.drewOk = true;
+      } catch (err) {
+        result.error = err;
+      }
+    });
+
+    win.set_child(area);
+    win.present();
+    area.queue_draw();
+
+    // Quit shortly after — a frame renders (firing the draw-func) under Xvfb first.
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+      app.quit();
+      return GLib.SOURCE_REMOVE;
+    });
+  });
+
+  const status = app.run([]); // top-level blocking run (no async wrapper)
+
+  assert.equal(status, 0, 'app.run([]) should exit 0');
+  assert.equal(result.error, null, `draw-func threw: ${result.error && result.error.stack}`);
+  assert.equal(result.called, true, 'the draw-func should have fired');
+  assert.equal(result.isContext, true, 'the draw-func arg is a cairo.Context (foreign FROM)');
+  assert.equal(result.drewOk, true, 'drawing on the handed cairo.Context succeeded');
+});

--- a/packages/node-gi/node-gi/test/cairo.test.mjs
+++ b/packages/node-gi/node-gi/test/cairo.test.mjs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — cairo binding + foreign-struct seam, HEADLESS (no display).
+//
+// Proves the native cairo binding + the foreign-struct marshalling seam that lets
+// a GI argument of a cairo type round-trip to/from the JS cairo objects (cairo is a
+// FOREIGN struct in GObject-Introspection — GI delegates its marshalling to the
+// module). Covers:
+//  • ImageSurface + Context drawing → getData() pixel bytes (exact + checksum);
+//  • BYTE-FOR-BYTE PIXEL PARITY vs. gjs — the same scene drawn under `gjs -m`,
+//    written to PNG, decoded back, and compared pixel-for-pixel (the killer test);
+//  • SolidPattern + setSource; $dispose semantics (a disposed handle throws);
+//  • the FOREIGN-IN seam headlessly via PangoCairo.create_layout(cr) (a GI function
+//    taking a cairo_t — self-skips when the PangoCairo typelib is absent).
+// The foreign-FROM seam (a draw-func's cairo_t handed INTO JS) needs a display and
+// lives in test/cairo-drawfunc.test.mjs.
+//
+// Part of the cross-runtime conformance subset (runs on node / bun / deno).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import cairo from '../cairo.js';
+import { requireGi } from '../gi.js';
+
+// djb2 — order-sensitive checksum over the raw pixel bytes.
+function djb2(u8) {
+  let h = 5381 >>> 0;
+  for (let i = 0; i < u8.length; i++) h = (((h << 5) + h) + u8[i]) >>> 0;
+  return h;
+}
+
+// The deterministic scene, as ONE source of truth: called directly under node-gi,
+// and its own source (drawScene.toString()) is embedded into the `gjs -m` parity
+// child (native cairo) below. Takes the cairo module explicitly so the same
+// function body runs verbatim in the gjs child (which binds `cairo` to its native
+// module). Returns the flushed surface.
+function drawScene(cairo) {
+  const W = 64;
+  const H = 48;
+  const surface = new cairo.ImageSurface(cairo.Format.ARGB32, W, H);
+  const cr = new cairo.Context(surface);
+  cr.setSourceRGB(1, 1, 1);
+  cr.paint();
+  cr.setSourceRGB(0.8, 0.1, 0.1);
+  cr.rectangle(8, 8, 20, 16);
+  cr.fill();
+  cr.setLineWidth(2);
+  cr.setSourceRGB(0.1, 0.2, 0.9);
+  cr.rectangle(30, 10, 20, 20);
+  cr.stroke();
+  cr.setSourceRGBA(0.1, 0.7, 0.2, 1);
+  cr.arc(48, 36, 8, 0, 2 * Math.PI);
+  cr.fill();
+  cr.setLineWidth(1);
+  cr.setSourceRGBA(0, 0, 0, 1);
+  cr.moveTo(2, 44);
+  cr.lineTo(60, 44);
+  cr.stroke();
+  cr.$dispose();
+  surface.flush();
+  return surface;
+}
+
+test('ImageSurface geometry (ARGB32) is deterministic', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  assert.equal(s.getWidth(), 4);
+  assert.equal(s.getHeight(), 4);
+  assert.equal(s.getStride(), 16); // 4px * 4 bytes
+  assert.equal(s.getFormat(), cairo.Format.ARGB32);
+  assert.equal(s.getType(), cairo.SurfaceType.IMAGE);
+  s.$dispose();
+});
+
+test('filling a red rectangle yields the exact ARGB32 pixel bytes', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  const cr = new cairo.Context(s);
+  cr.setSourceRGB(1, 0, 0);
+  cr.rectangle(0, 0, 4, 4);
+  cr.fill();
+  cr.$dispose();
+  s.flush();
+
+  const data = s.getData();
+  assert.ok(data instanceof Uint8Array, 'getData() is a Uint8Array');
+  assert.equal(data.length, 64); // stride(16) * height(4)
+  // Opaque red on little-endian ARGB32 (premultiplied) = B,G,R,A = 0,0,255,255.
+  assert.deepEqual([...data.slice(0, 4)], [0, 0, 255, 255]);
+  let sum = 0;
+  for (const b of data) sum = (sum + b) >>> 0;
+  assert.equal(sum, 8160);
+  assert.equal(djb2(data), 3156304613);
+  s.$dispose();
+});
+
+test('a full drawing scene produces a deterministic pixel checksum', () => {
+  const s = drawScene(cairo);
+  const data = s.getData();
+  assert.equal(data.length, 12288); // stride(256) * height(48)
+  assert.equal(djb2(data), 4004317761);
+  s.$dispose();
+});
+
+test('SolidPattern.createRGB(A) + setSource', () => {
+  const p = cairo.SolidPattern.createRGBA(0.2, 0.4, 0.6, 0.8);
+  assert.ok(p instanceof cairo.SolidPattern);
+  assert.ok(p instanceof cairo.Pattern);
+  assert.equal(p.getType(), cairo.PatternType.SOLID);
+
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 8, 8);
+  const cr = new cairo.Context(s);
+  cr.setSource(p);
+  cr.paint();
+  cr.$dispose();
+  s.$dispose();
+});
+
+test('$dispose is idempotent and a disposed context throws', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  const cr = new cairo.Context(s);
+  cr.$dispose();
+  cr.$dispose(); // idempotent — no throw, no double-free
+  assert.throws(() => cr.moveTo(0, 0), /live cairo\.Context/);
+  s.$dispose();
+});
+
+test('createFromPNG round-trips writeToPNG pixels', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-cairo-'));
+  try {
+    const s = drawScene(cairo);
+    const png = join(dir, 'scene.png');
+    s.writeToPNG(png);
+    const loaded = cairo.ImageSurface.createFromPNG(png);
+    assert.equal(loaded.getWidth(), 64);
+    assert.equal(loaded.getHeight(), 48);
+    // The decoded pixels match the drawn surface exactly.
+    assert.equal(djb2(loaded.getData()), djb2(s.getData()));
+    s.$dispose();
+    loaded.$dispose();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// THE KILLER TEST: draw the identical scene under `gjs -m` (native cairo), write a
+// PNG, decode it back with node-gi, and assert the pixels are byte-for-byte equal
+// to node-gi's own rendering. Proves node-gi's cairo binding paints identically to
+// GJS. Self-skips when gjs is not on PATH (bun/deno legs, or a gjs-less box).
+const haveGjs = spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+test('pixel parity with gjs (byte-for-byte)', { skip: haveGjs ? false : 'gjs not on PATH' }, () => {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-cairo-gjs-'));
+  try {
+    const gjsPng = join(dir, 'gjs.png');
+    const gjsScript = join(dir, 'draw.js');
+    // Embed drawScene's OWN source (its .toString()) so gjs runs the identical
+    // body against its native cairo, then writes the PNG.
+    const src =
+      `import cairo from 'cairo';\n` +
+      `const drawScene = ${drawScene.toString()};\n` +
+      `const s = drawScene(cairo);\n` +
+      `s.writeToPNG(${JSON.stringify(gjsPng)});\n`;
+    writeFileSync(gjsScript, src);
+    const res = spawnSync('gjs', ['-m', gjsScript], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs draw failed: ${res.stderr}`);
+    assert.ok(existsSync(gjsPng), 'gjs produced a PNG');
+
+    // Decode gjs's PNG + node-gi's own render; compare pixels.
+    const fromGjs = cairo.ImageSurface.createFromPNG(gjsPng);
+    const own = drawScene(cairo);
+    const a = fromGjs.getData();
+    const b = own.getData();
+    assert.equal(a.length, b.length, 'same pixel-buffer length');
+    assert.deepEqual(Buffer.from(a), Buffer.from(b), 'gjs and node-gi pixels are byte-identical');
+    fromGjs.$dispose();
+    own.$dispose();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// The FOREIGN-IN seam headlessly: PangoCairo.create_layout(cr) is a GI function
+// TAKING a cairo_t — so calling it proves the foreign to_func marshals a node-gi
+// cairo.Context into a GI argument. Self-skips when the PangoCairo typelib is absent.
+let PangoCairo = null;
+try {
+  PangoCairo = requireGi('PangoCairo', '1.0');
+} catch {
+  PangoCairo = null;
+}
+test('foreign-IN seam: a cairo.Context marshals into a GI call (PangoCairo)', {
+  skip: PangoCairo ? false : 'PangoCairo typelib unavailable',
+}, () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 32, 32);
+  const cr = new cairo.Context(s);
+  const layout = PangoCairo.create_layout(cr); // foreign IN: cairo_t -> GIArgument
+  assert.ok(layout, 'create_layout returned a Pango.Layout');
+  layout.set_width(12345);
+  assert.equal(layout.get_width(), 12345);
+  PangoCairo.show_layout(cr, layout); // foreign IN again (cr + layout)
+  cr.$dispose();
+  s.$dispose();
+});

--- a/tests/e2e/node-gi-build/run.mjs
+++ b/tests/e2e/node-gi-build/run.mjs
@@ -105,6 +105,45 @@ describe('--app node gi:// → node-gi bundle E2E', { timeout: 10 * 60 * 1000 },
         );
     });
 
+    it('rewrites bare cairo to the externalised @gjsify/node-gi/cairo', () => {
+        // cairo is a GJS built-in module (the FOREIGN-struct binding). On --app node
+        // the bare `cairo` specifier routes to @gjsify/node-gi/cairo (kept EXTERNAL,
+        // like the gi:// runtime + `system`/`gettext`), so an npm `cairo` package
+        // never shadows the GI-compatible binding.
+        writeFileSync(
+            join(projectDir, 'src', 'draw.ts'),
+            [
+                "import cairo from 'cairo';",
+                'const surface = new cairo.ImageSurface(cairo.Format.ARGB32, 2, 2);',
+                'const cr = new cairo.Context(surface);',
+                'cr.setSourceRGB(1, 0, 0);',
+                'cr.paint();',
+                'console.log(surface.getWidth(), surface.getHeight());',
+                '',
+            ].join('\n'),
+        );
+
+        execFileSync('npx', ['gjsify', 'build', 'src/draw.ts', '--app', 'node', '--outfile', 'dist/draw.mjs'], {
+            cwd: projectDir,
+            stdio: 'pipe',
+            timeout: 90 * 1000,
+        });
+
+        const content = readFileSync(join(projectDir, 'dist', 'draw.mjs'), 'utf-8');
+        // The bare `cairo` import must resolve to the externalised node-gi binding,
+        // not be bundled (no ImageSurface impl inlined) and not left as bare `cairo`.
+        assert.ok(
+            content.includes('@gjsify/node-gi/cairo'),
+            'dist/draw.mjs must import @gjsify/node-gi/cairo (the externalised cairo binding)',
+        );
+        // `node --check` parses without resolving the external import.
+        execFileSync('node', ['--check', join(projectDir, 'dist', 'draw.mjs')], {
+            cwd: projectDir,
+            stdio: 'pipe',
+            timeout: 30 * 1000,
+        });
+    });
+
     it('a gated gi:// import loads on Node without @gjsify/node-gi', () => {
         // Regression guard: a gi:// import used only inside a GJS-gated branch
         // must NOT make @gjsify/node-gi a hard load-time dependency. The temp


### PR DESCRIPTION
Third **ADR-0005 graduation-gate item**: the GTK/Cairo layer. cairo is a GI *foreign struct* (`cairo_t`/`cairo_surface_t`/… aren't introspectable) — GJS ships a hand-written native binding + a foreign-struct hook so a GI function's cairo arg round-trips. This ports that to node-gi. Byte-identical pixel parity with `gjs`.

## Foreign-struct seam
Ports GJS's `gi/foreign.cpp` table into `marshal.cc`: a registry keyed by `(namespace, type_name)`; `cairo.cc` registers Context/Surface/Pattern converters. The INTERFACE marshalling branches gate on **`gi_struct_info_is_foreign()`** — only a foreign type routes to the module (a normal struct falls through the generic boxed path **unchanged**, so zero regression). Both directions: `JsToGIArgument` (IN) and `GIArgumentToJs` (FROM — used by the callback trampoline, so a draw-func's `cairo_t` is covered).

## Ported (`src/cairo.cc` + `cairo.js`)
- **Context**: save/restore, path ops (moveTo/lineTo/rel*/rectangle/arc/curveTo/close), fill/stroke/paint/clip (+Preserve), translate/scale/rotate, setSourceRGB(A)/setSource/setSourceSurface, line/antialias/operator/etc. setters+getters, extents, status, `$dispose`.
- **Surface + ImageSurface**: getData→Uint8Array, width/height/stride/format, flush/finish/writeToPNG, `create`/`createFromPNG`, `$dispose`.
- **SolidPattern**: createRGB/createRGBA.
Deferred (scoped): gradients, path/region objects, PDF/SVG/PS surfaces.

## Parity + GTK proof
- **Pixel-parity**: the same deterministic scene drawn under node-gi and `gjs -m`, both PNG'd + decoded + compared: **0 pixel diffs of 12288 bytes**. (PNG *files* differ only in zlib IDAT — node bundles its own zlib; pixels identical. The conformance program therefore checksums cairo *state*, not PNG bytes, and only calls methods GJS's native cairo exposes.)
- **GTK draw-func**: verified on a real display — `Gtk.DrawingArea.set_draw_func` received an actual `cairo.Context` (foreign FROM) and drew. Self-skips without a display; runs in the node-gi.yml gtk-smoke Xvfb job.

## L1 + L2
`cairo.js`/`cairo.d.ts` (constructors + enums ported from GJS `_cairo.js`), `package.json` `./cairo` export, `imports.cairo`. **`cairo` bare-module alias** → `@gjsify/node-gi/cairo` in `resolve-npm` `ALIASES_GJS_FOR_NODE` (the analogue of system/gettext); `gi://cairo` + bare `cairo` both resolve. e2e `node-gi-build` extended.

## Test plan
- [x] rebuild 0 warnings · `npm test` 284/0 · `test:gimarshalling` 336/0 · `test:bun`/`test:deno` 33/33 · conformance green on 4 runtimes
- [x] headless `test/cairo.test.mjs` (8 tests incl. gjs pixel-parity, foreign-IN via PangoCairo) + Xvfb `cairo-drawfunc.test.mjs`