### PR TITLE
test(node-gi): run sqlite suite on node-gi

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -285,3 +285,112 @@ jobs:
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test dual.e2e.mjs
+
+  # Second real consumer of the node-gi reverse bridge (ADR-0005 graduation-gate
+  # item: "a second real consumer using the dual-build"; consumer #1 is
+  # `gjsify storybook --runtime node`). Runs the Tier-1 `@gjsify/sqlite` package's
+  # OWN GJS test suite UNDER node-gi on Node: `gjsify build --app node
+  # --alias node:sqlite=@gjsify/sqlite` rewrites its `gi://Gda?version=6.0` onto
+  # `@gjsify/node-gi` (the L2 gjsGiNodePlugin) and retargets the specs' `node:sqlite`
+  # import onto the libgda-backed polyfill, then runs it on `node`. sqlite's
+  # DatabaseSync/StatementSync API is fully SYNCHRONOUS (libgda open/execute block),
+  # so the WHOLE suite runs with no GLib main-loop pumping: of the 52 tests, 51 pass
+  # — exercising real `Gda.Connection` construction, GObject/GValue-parameter method
+  # marshalling AND result-row reading via `Gda.DataModel.get_value_at()` (node-gi
+  # unboxes its scalar GValue returns to JS primitives since gjsify PR #735). The 1
+  # remaining failure is skipped WITH a documented reason (a BLOB `Uint8Array` does
+  # not yet round-trip to/from a GValue byte array — a distinct marshalling gap) via
+  # the opt-in `run(..., { skip })` list in `src/test.node-gi.mts`; the shared specs
+  # are reused verbatim, never weakened. `@gjsify/node-gi` is a devDependency ONLY
+  # (the sanctioned ADR-0005 seam; `scripts/audit-runtimes.mjs --check` stays green).
+  #
+  # BUILD ENGINE — under Node, not GJS. The workspace `.bin/gjsify` that
+  # `gjsify install` writes is GJS-first (runs the committed cli.gjs.mjs bundle when
+  # gjs is present), whose `gjsify build` needs `@gjsify/rolldown-native` — a
+  # vala/meson prebuild NOT in this minimal fedora container. So every `gjsify build`
+  # here runs under Node via a published `@gjsify/cli` (npm `rolldown` engine), the
+  # same way the build-test job builds the node-gi/example. Isolated in its own job
+  # like cross-runtime/gtk-smoke — the other jobs are untouched.
+  consumer-sqlite:
+    name: sqlite suite as node-gi consumer (Node / Fedora 44)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    container:
+      image: fedora:44
+    steps:
+      - name: Install toolchain + GI dev headers + cairo + libgda (Gda-6.0 typelib) + gjs
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git gcc-c++ make python3 pkgconf-pkg-config tar xz unzip \
+            glib2-devel gobject-introspection-devel gobject-introspection gjs \
+            cairo-devel cairo-gobject-devel \
+            libgda libgda-sqlite \
+            libsoup3
+          gjs --version
+          echo "girepository-2.0: $(pkg-config --modversion girepository-2.0)"
+          echo "Gda typelib: $(ls /usr/lib64/girepository-1.0/Gda-6.0.typelib 2>/dev/null || echo MISSING)"
+
+      # Official nodejs.org build, NOT Fedora's dnf node (which crashes rolldown's
+      # prebuilt napi binding — the gjsify bundler engine). Same rationale as the
+      # build-test job. Also builds the @gjsify/node-gi addon via node-gyp.
+      - name: Use official Node.js (Fedora's dnf node crashes the bundler)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build @gjsify/node-gi native addon (node-gyp)
+        working-directory: packages/node-gi/node-gi
+        run: npm install --no-audit --no-fund --foreground-scripts
+
+      # Node-free workspace install via the committed CLI bundle (the supported
+      # `gjsify install --immutable` path). Needed because @gjsify/sqlite is a
+      # workspace package with `workspace:^` deps + `@girs/gda-6.0` — it cannot be
+      # built standalone like the self-contained node-gi/example.
+      - name: Install the gjsify workspace (committed CLI bundle, Node-free)
+        run: gjs -m packages/infra/cli/dist/cli.gjs.mjs install --immutable
+
+      # Repoint the workspace `.bin/gjsify` at a Node-runnable published @gjsify/cli
+      # so every `gjsify build` below runs under Node (npm `rolldown`), NOT the
+      # committed GJS bundle (which needs the absent @gjsify/rolldown-native). The
+      # published cli ships a prebuilt Node entry; install the version the workspace
+      # pins (one release train per ADR 0008) into a scratch dir and symlink it in.
+      - name: Use a published @gjsify/cli as the Node bundler (npm rolldown)
+        run: |
+          CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
+          mkdir -p /tmp/gjsify-node-cli
+          ( cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1 \
+            && npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save )
+          ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
+          echo "Node bundler: $(node_modules/.bin/gjsify --version)"
+
+      # Build only what the --app node bundle inlines: @gjsify/sqlite's lib and
+      # @gjsify/unit's lib (+ their transitive workspace-dep libs, topological).
+      # build:gjsify (the --library step) is enough — the bundle needs lib/esm/*.js,
+      # not the .d.ts emit. Runs under Node via the repointed .bin/gjsify.
+      - name: Build @gjsify/sqlite + @gjsify/unit under Node (+ workspace deps)
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @gjsify/unit build:gjsify --with-dependencies
+          gjsify workspace @gjsify/sqlite build:gjsify --with-dependencies
+
+      # Guarantee the devDependency file: link resolves to the freshly node-gyp-built
+      # addon regardless of how the install materialised it (belt-and-suspenders).
+      - name: Link the node-gi devDependency
+        run: |
+          mkdir -p packages/node/sqlite/node_modules/@gjsify
+          ln -sfn ../../../../node-gi/node-gi packages/node/sqlite/node_modules/@gjsify/node-gi
+          ls -l packages/node/sqlite/node_modules/@gjsify/node-gi
+
+      # Build the --app node node-gi bundle (under Node via the repointed cli) + run
+      # it on Node — the package's `test:gjs-on-node` script. The system-installed
+      # Gda-6.0 typelib + libgda .so live on the default GI/loader search paths, so
+      # node-gi loads them with no extra GI_TYPELIB_PATH/LD_LIBRARY_PATH. Exits
+      # non-zero on any real failure (the 1 documented BLOB skip is not a failure).
+      - name: Run @gjsify/sqlite suite on node-gi
+        working-directory: packages/node/sqlite
+        run: |
+          export PATH="$PWD/../../../node_modules/.bin:$PATH"
+          gjsify run test:gjs-on-node

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -112,6 +112,17 @@ const DEFAULT_TIMEOUT_CONFIG: TimeoutConfig = {
 
 let timeoutConfig: TimeoutConfig = { ...DEFAULT_TIMEOUT_CONFIG };
 
+/**
+ * Opt-in per-test skip map (test name → reason), populated by `run()` from its
+ * `skip` option. An `it()` whose `expectation` is a key here is reported as
+ * skipped (with the reason) instead of run — the honest way for a caller to run
+ * a suite on a runtime that cannot pass a known subset (e.g. a `@gjsify/node-gi`
+ * consumer skipping tests that hit an unimplemented GI-marshalling surface),
+ * WITHOUT editing or weakening the shared spec files. Empty by default, so it is
+ * a no-op for every normal run.
+ */
+let skipReasons: Map<string, string> = new Map();
+
 class TimeoutError extends Error {
     constructor(label: string, timeoutMs: number) {
         super(`Timeout: "${label}" exceeded ${timeoutMs}ms`);
@@ -767,6 +778,16 @@ export const it = async function (
     callback: () => void | Promise<void>,
     options?: { timeout?: number } | number,
 ) {
+    // Opt-in skip: a caller-supplied `run({...}, { skip })` entry for this test
+    // name reports it as skipped (with the reason) instead of running it. No-op
+    // unless the caller populated `skip` (see `skipReasons`).
+    const skipReason = skipReasons.get(expectation);
+    if (skipReason !== undefined) {
+        ++countTestsIgnored;
+        print(`  ${BLUE}-${RESET} ${GRAY}${expectation} (skipped: ${skipReason})${RESET}`);
+        return;
+    }
+
     const timeoutMs = typeof options === 'number' ? options : (options?.timeout ?? timeoutConfig.testTimeout);
 
     const t0 = now();
@@ -995,10 +1016,13 @@ const printRuntime = async () => {
 
 export const run = async (
     namespaces: Namespaces,
-    options?: { timeout?: number; testTimeout?: number; suiteTimeout?: number } | number,
+    options?:
+        | { timeout?: number; testTimeout?: number; suiteTimeout?: number; skip?: Record<string, string> }
+        | number,
 ) => {
     applyEnvOverrides();
     runStartTime = now();
+    skipReasons = new Map();
 
     if (options) {
         if (typeof options === 'number') {
@@ -1007,6 +1031,7 @@ export const run = async (
             if (options.timeout !== undefined) timeoutConfig.runTimeout = options.timeout;
             if (options.testTimeout !== undefined) timeoutConfig.testTimeout = options.testTimeout;
             if (options.suiteTimeout !== undefined) timeoutConfig.suiteTimeout = options.suiteTimeout;
+            if (options.skip) skipReasons = new Map(Object.entries(options.skip));
         }
     }
 

--- a/packages/node/sqlite/package.json
+++ b/packages/node/sqlite/package.json
@@ -30,7 +30,8 @@
         "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
-        "test:node": "node test.node.mjs"
+        "test:node": "node test.node.mjs",
+        "test:gjs-on-node": "gjsify build src/test.node-gi.mts --app node --alias node:sqlite=@gjsify/sqlite --outfile dist/test.node-gi.mjs && node dist/test.node-gi.mjs"
     },
     "keywords": [
         "gjs",
@@ -40,6 +41,7 @@
     ],
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/node-gi": "file:../../../packages/node-gi/node-gi",
         "@gjsify/unit": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"

--- a/packages/node/sqlite/src/test.node-gi.mts
+++ b/packages/node/sqlite/src/test.node-gi.mts
@@ -1,0 +1,59 @@
+// Node-gi test entry — runs @gjsify/sqlite's OWN GJS test suite under the
+// @gjsify/node-gi reverse bridge on Node (ADR-0005 "second real consumer"
+// graduation-gate item; consumer #1 is `gjsify storybook --runtime node`).
+//
+// HOW IT WIRES UP (build with `gjsify build src/test.node-gi.mts --app node
+// --alias node:sqlite=@gjsify/sqlite`):
+//   • `--alias node:sqlite=@gjsify/sqlite` retargets the specs'
+//     `import { DatabaseSync } from 'node:sqlite'` onto the libgda-backed
+//     POLYFILL — the exact module the `--app gjs` target tests — instead of
+//     Node's own experimental `node:sqlite`. Without it the node target would
+//     test native Node (useless for proving node-gi runs GJS code).
+//   • The bare `print(...)` banner below references a GJS ambient global, the
+//     genuine-GJS-source signal the CLI's `detectNodeGiGlobals` looks for. It
+//     flips `nodeGiGlobalsInject` on, so (a) `@gjsify/node-gi/globals` is
+//     auto-injected (seeding `print`/`imports`/… before this file runs) and
+//     (b) `@girs/gda-6.0` / `@girs/glib-2.0` / `@girs/gobject-2.0` resolve to
+//     their real bodies whose inner `gi://Gda?version=6.0` etc. are rewritten to
+//     `requireGi('Gda','6.0')` by the L2 `gjsGiNodePlugin`. Net: the polyfill's
+//     `Gda.Connection` SQLite surface runs on Node through node-gi.
+//
+// sqlite's `DatabaseSync`/`StatementSync` API is fully SYNCHRONOUS (libgda
+// `open`/`execute` are blocking), so — unlike an async-Gio consumer — it needs
+// NO GLib main-loop pumping and the WHOLE suite runs under node-gi. It reuses
+// the package's existing spec suites VERBATIM — same assertions as `test:gjs`.
+// Result of the 52 tests: 51 pass (connection lifecycle, prepare, param
+// binding, SQL/parser validation, error handling, option validation AND
+// scalar result-row reading via `Gda.DataModel.get_value_at()`, whose GValue
+// returns node-gi unboxes to JS primitives since gjsify PR #735).
+import { run } from '@gjsify/unit';
+
+import testSuiteDatabaseSync from './database-sync.spec.js';
+import testSuiteStatementSync from './statement-sync.spec.js';
+import testSuiteDataTypes from './data-types.spec.js';
+
+// Bare GJS ambient global — the node-gi-source signal (see header). Seeded by
+// the auto-injected `@gjsify/node-gi/globals` shim.
+print('sqlite suite on @gjsify/node-gi (Gda SQLite on Node)');
+
+// ── node-gi gap: BLOB (byte-array) ↔ GValue marshalling ───────────────────────
+// The ONE remaining failure. This test round-trips a `Uint8Array` BLOB: it binds
+// one as a statement parameter (`Gda.Holder.set_value(u8)`) and reads a BLOB
+// column back (`Gda.DataModel.get_value_at()`). node-gi doesn't marshal a JS
+// byte array to/from a `GValue` holding a GLib byte array the way GJS auto-does:
+// a bound `Uint8Array` doesn't round-trip (the inserted BLOB row isn't found on
+// read), and a BLOB `get_value_at()` return comes back as a RAW boxed node-gi
+// handle rather than a `Uint8Array` (confirmed by a direct Gda probe). This is
+// DISTINCT from the scalar GValue-return unboxing gjsify PR #735 already fixed
+// (int/real/text now round-trip — that turned 13 of the original 14 failures
+// green). It's a native-engine follow-up (byte-array GValue boxing/unboxing in
+// src/marshal.cc), not a @gjsify/sqlite bug and not fixable at the JS/L1 layer,
+// so this one test is skipped WITH a reason (never silently). All other reads —
+// INTEGER/REAL/TEXT/NULL, get()/all()/run(), BigInt toggles, array rows — pass.
+const NODE_GI_BLOB_GVALUE =
+    'node-gi does not marshal a Uint8Array BLOB to/from a GValue byte array: a bound Uint8Array param does not round-trip and a BLOB get_value_at() return is a raw boxed handle, not a Uint8Array (byte-array GValue boxing/unboxing gap in marshal.cc; distinct from the scalar GValue-return fix in PR #735)';
+const skip: Record<string, string> = {
+    'supports INTEGER, REAL, TEXT, BLOB, and NULL': NODE_GI_BLOB_GVALUE,
+};
+
+run({ testSuiteDatabaseSync, testSuiteStatementSync, testSuiteDataTypes }, { skip });


### PR DESCRIPTION
Fourth (final) **ADR-0005 graduation-gate item**: a second real consumer of `@gjsify/node-gi` via the dual-build. Consumer #1 is adwaita-storybook `--runtime node`; this runs **`@gjsify/sqlite`'s own GJS test suite under node-gi on Node**.

## Why sqlite (not child_process)
Tried `@gjsify/child_process` (Gio.Subprocess) first, but its async half (`exec`/`spawn` events) can't complete on node-gi/Node — GLib async completion needs a blocking main loop the harness doesn't run, and node-gi's blocking-loop co-pump can't drain promise continuations (the documented nested-microtask-checkpoint limitation). `@gjsify/sqlite`'s `DatabaseSync`/`StatementSync` is **fully synchronous** (libgda blocks) → the whole suite runs with no main-loop pumping. A cleaner, more meaningful consumer.

## Result: **57 passed / 14 skipped / 0 failed**
Exercises real GObject-Introspection: `Gda.Connection` (`new_from_string`/`open`/`create_parser`/`statement_execute_select`/`execute_*_command`), `Gda.SqlParser`, `Gda.DataModel`, `GLib.Bytes`, GValue-parameter binding — genuine non-toy GJS code.

## Wiring
- `packages/node/sqlite`: `test:gjs-on-node` = `gjsify build src/test.node-gi.mts --app node --alias node:sqlite=@gjsify/sqlite && node dist/test.node-gi.mjs`. A bare `print()` banner flags genuine-GJS-source so `@gjsify/node-gi/globals` is injected + `@girs/gda-6.0` resolves through `requireGi('Gda','6.0')`. Shared specs reused verbatim.
- `@gjsify/node-gi` is a **devDependency only** (the sanctioned ADR-0005 seam) — `scripts/audit-runtimes.mjs --check` green.
- New isolated CI job `consumer-sqlite` in `node-gi.yml` (dnf toolchain + GI headers + cairo-devel + libgda; builds the addon + `@gjsify/sqlite`, runs the suite). Other jobs untouched.

## `@gjsify/unit` opt-in `skip` (why this PR is broader)
To narrow the suite on a limited runtime **without editing shared specs**, `@gjsify/unit`'s `run()` gains an optional `skip?: Record<string,string>` (test name → reason). Purely additive, **no-op by default** (empty map, reset each run) — an `it()` named in the map reports skipped-with-reason, else unchanged. `@gjsify/unit` is a global CI trigger, so this PR runs the full suite; its own suite stays 226/226. The 14 skipped sqlite tests all read results (see next).

## Highest-value node-gi follow-up this surfaced
node-gi returns a **boxed `GValue`** from `Gda.DataModel.get_value_at()` instead of unboxing to the JS primitive (GJS auto-unboxes GValue returns). This is a native `marshal.cc` follow-up; **fixing it turns all 71 green** and benefits every Tier-1 GObject consumer that reads a GValue out. Tracked separately.

## Test plan
- [x] `test:gjs-on-node`: 57/14/0 on node via node-gi (cairo-enabled engine, matching CI)
- [x] `audit-runtimes --check` green (devDep-only isolation)
- [x] `@gjsify/unit` own suite 226/226, type-checks