### PR TITLE
feat(node-gi): unbox GValue returns like gjs

### DIFF
--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -221,6 +221,15 @@ const SKIP_GVARIANT_ARRAY =
     'phase 2.7 — arrays of GLib.Variant (boxed/variant elements) are not yet marshalled, a later PR';
 const SKIP_GVALUE_ARRAY =
     'phase 2.5 GValue — arrays of GValue elements are not yet marshalled, a later PR';
+// GValue RETURN/OUT auto-unbox is now LIVE (this PR): a GI function returning a
+// GValue is unboxed to its contained JS value, exactly as GJS does. The remaining
+// GValue skips are the adjacent capabilities the unbox direction does NOT cover:
+const SKIP_GVALUE_IN =
+    'phase 2.5 GValue IN — autoboxing a JS value INTO a GValue arg (JS 42 → a GValue ' +
+    'holding an int, with GJS type inference) is a separate direction; GValue return/OUT unbox is live';
+const SKIP_GVALUE_BOXED =
+    'GObject.Value construction — `new GObject.Value()` + .init()/.set_*() to BUILD an explicit ' +
+    'boxed GValue (to pass IN or modify) needs struct construction, a later PR; GValue return/OUT unbox is live';
 
 // Integer limits, defined without reference to GLib (because the GLib.MAXINT8
 // etc. constants are also subject to marshalling)
@@ -991,8 +1000,59 @@ describe('GHashTable', function () {
         expect(() => GIMarshallingTests.ghashtable_int_none_in(symbolDict)).not.toThrow();
     });
 });
-describeSkip('phase 2.5 GValue — GValue in/out/return, flat GValue arrays, boxed round-trips',
-    'GValue');
+// GValue RETURN/OUT auto-unboxing is now LIVE — a GI function returning (or OUT-ing)
+// a GValue is unboxed to its contained JS value (int/string/boolean/double/enum/
+// object/null), matching GJS (marshal.cc GIArgumentToJs → GValueToJs). The upstream
+// GValue block's return/OUT specs are un-skipped here; the IN direction (autoboxing a
+// JS value into a GValue arg) and explicit GObject.Value construction stay deferred.
+describe('GValue', function () {
+    // return + OUT + uninitialized-OUT are live; IN + INOUT stay deferred.
+    testSimpleMarshalling('gvalue', 42, '42', null, {
+        in: {skip: SKIP_GVALUE_IN},
+        inout: {skip: 'https://gitlab.gnome.org/GNOME/gobject-introspection/issues/192'},
+    });
+
+    it('can handle noncanonical float NaN', function () {
+        expect(GIMarshallingTests.gvalue_noncanonical_nan_float()).toBeNaN();
+    });
+
+    it('can handle noncanonical double NaN', function () {
+        expect(GIMarshallingTests.gvalue_noncanonical_nan_double()).toBeNaN();
+    });
+
+    itSkip(SKIP_GVALUE_IN, 'marshals as an int64 in parameter', function () {
+        expect(() => GIMarshallingTests.gvalue_int64_in(BigIntLimits.int64.max))
+            .not.toThrow();
+    });
+
+    itSkip(SKIP_GVALUE_IN, 'type objects can be converted from primitive-like types', function () {});
+    itSkip(SKIP_GVALUE_IN, 'can be passed into a function and modified', function () {});
+    itSkip(SKIP_GVALUE_BOXED, 'can be passed into a function as a boxed type and modified', function () {});
+    itSkip(SKIP_GVALUE_BOXED, 'enum can be passed into a function as a boxed type and packed', function () {});
+    itSkip(SKIP_GVALUE_BOXED, 'flags can be passed into a function as a boxed type and packed', function () {});
+
+    it('marshals as an int64 out parameter', function () {
+        expect(warn64(true, GIMarshallingTests.gvalue_int64_out)).toEqual(
+            Limits.int64.max);
+    });
+
+    it('marshals as a caller-allocated out parameter', function () {
+        expect(GIMarshallingTests.gvalue_out_caller_allocates()).toEqual(42);
+    });
+
+    itSkip(SKIP_GVALUE_ARRAY, 'array can be passed into a function and packed', function () {});
+    itSkip(SKIP_GVALUE_ARRAY, 'array of boxed type GValues can be passed into a function', function () {});
+    itSkip(SKIP_GVALUE_ARRAY, 'array of uninitialized boxed GValues', function () {});
+    itSkip(SKIP_GVALUE_ARRAY, 'array can be passed as an out argument and unpacked', function () {});
+    itSkip(SKIP_GVALUE_ARRAY, 'array can be passed as an out argument and unpacked when zero-terminated',
+        function () {});
+    itSkip(SKIP_GVALUE_IN, 'can have its type inferred from primitive values', function () {});
+    itSkip(SKIP_GVALUE_BOXED, 'can deal with a GValue packed in a GValue', function () {});
+    itSkip(SKIP_GVALUE_BOXED, 'separates float from double correctly', function () {});
+});
+// The IN-with-type inference breadth + flat-GValue-array round-trips stay a later PR.
+describeSkip('phase 2.5 GValue IN — gvalue_in_with_type type inference + flat-array round-trips',
+    'GValue (deferred IN breadth)');
 describeSkip('phase 2.7 callbacks — GClosure in/return + callbacks with out-params + owned boxed',
     'Callback');
 describeSkip('phase 2.4 structs — raw gpointer return round-trip',

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -744,6 +744,17 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
         a.v_pointer = blob;
         results.push_back(ReadOutOrReturn(env, callable, ti, &a, GI_TRANSFER_NOTHING, &slots));
         g_free(blob);
+      } else if (g_type_is_a(callerAllocGType[i], G_TYPE_VALUE)) {
+        // A caller-allocated GValue OUT (e.g. GIMarshallingTests.gvalue_out_caller_allocates):
+        // GJS UNBOXES the filled GValue to its contained JS value (verified: → 42, a
+        // number, not a GObject.Value box), then frees the caller-allocated storage.
+        // The blob IS the GValue (g_value_init'd + set IN PLACE by the callee). Unbox
+        // via GValueToJs (same as the return/OUT-pointer path in marshal.cc), then
+        // g_value_unset (frees any contained data, e.g. a dup'd string) + g_free the
+        // blob WE g_malloc0'd — the direct GValue release GJS uses.
+        results.push_back(GValueToJs(env, static_cast<GValue*>(blob)));
+        g_value_unset(static_cast<GValue*>(blob));
+        g_free(blob);
       } else {
         // A boxed struct/union: hand the JS side an independent boxed COPY it owns
         // (finalizer g_boxed_free's it), then free the caller-allocated blob (also

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -382,7 +382,36 @@ Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
           iface != nullptr && (GI_IS_OBJECT_INFO(iface) || GI_IS_STRUCT_INFO(iface))
               ? gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(iface))
               : G_TYPE_INVALID;
-      if (ifaceGType != G_TYPE_INVALID && g_type_is_a(ifaceGType, G_TYPE_PARAM)) {
+      if (ifaceGType != G_TYPE_INVALID && g_type_is_a(ifaceGType, G_TYPE_VALUE)) {
+        // A GValue return/OUT (GType G_TYPE_VALUE, or derived): GJS AUTO-UNBOXES it
+        // to the contained JS value (int/uint/int64/string/boolean/double/enum/
+        // object/boxed/GVariant/GParamSpec/GType/null), NOT a boxed handle. Verified
+        // against gjs 1.88: GIMarshallingTests.gvalue_return() → 42 (a number), not a
+        // GObject.Value box; gvalue_copy(<string GValue>) → "hi"; an object-holding
+        // GValue → the wrapped GObject (same identity); a NULL/unset string/object
+        // GValue → null. Unbox via GValueToJs — the SAME converter property/signal
+        // GValues use (BigInt/lossy 64-bit warning + all contained-type logic). The
+        // pointer slot holds the GValue* (a GValue return/OUT is always a pointer).
+        // Reference: refs/gjs/gi/arg.cpp gjs_value_from_gi_argument (INTERFACE branch
+        // tests `g_type_is_a(gtype, G_TYPE_VALUE)` BEFORE Struct) → value.cpp
+        // gjs_value_from_g_value. NB an EXPLICIT GObject.Value instance a user
+        // constructs stays a box — this only fires on a function's GValue return/OUT.
+        GValue* gvalue = static_cast<GValue*>(arg->v_pointer);
+        if (gvalue == nullptr) {
+          result = env.Null();
+        } else {
+          result = GValueToJs(env, gvalue);
+          // Transfer/free: GValueToJs COPIES/REFS every contained value into JS
+          // (strings are copied into V8, objects/boxeds ref'd/copied), so freeing the
+          // GValue container after the read is always safe. A transfer-EVERYTHING
+          // GValue* return (caller owns) is g_boxed_free'd — g_value_unset + free the
+          // GValue slice — exactly as GJS does (refs/gjs/gi/arg.cpp
+          // gjs_gi_argument_release G_TYPE_VALUE: pointer → g_boxed_free(gtype, …)).
+          // Transfer-NONE (the common case: gvalue_return/out, Gda.get_value_at) is a
+          // borrow → no free.
+          if (transfer == GI_TRANSFER_EVERYTHING) g_boxed_free(G_TYPE_VALUE, gvalue);
+        }
+      } else if (ifaceGType != G_TYPE_INVALID && g_type_is_a(ifaceGType, G_TYPE_PARAM)) {
         result = MakeParamSpecHandle(env, static_cast<GParamSpec*>(arg->v_pointer), transfer);
       } else if (iface != nullptr && (GI_IS_OBJECT_INFO(iface) || GI_IS_INTERFACE_INFO(iface))) {
         result = WrapGObject(env, static_cast<GObject*>(arg->v_pointer), transfer);

--- a/packages/node-gi/node-gi/test/gvalue-return.test.mjs
+++ b/packages/node-gi/node-gi/test/gvalue-return.test.mjs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// GValue return/OUT auto-unboxing for @gjsify/node-gi (marshal.cc GIArgumentToJs
+// INTERFACE branch). A GI function returning a `GValue` (GType G_TYPE_VALUE) is
+// AUTO-UNBOXED to its contained JS value — int/string/double/boolean/null — exactly
+// as GJS does, NOT handed back as an opaque GObject.Value boxed handle. Before this
+// fix such a return marshalled to `[object Object]` (a boxed handle), which is what
+// the @gjsify/sqlite consumer hit reading `Gda.DataModel.get_value_at()`.
+//
+// Source = headless libgda SQLite (the sqlite consumer's own path): a `get_value_at`
+// on a SELECT model returns a transfer-none GValue whose contained GType is pinned by
+// the column's declared type (INTEGER→int, TEXT→string, REAL→double, BOOLEAN→boolean),
+// with a NULL row for the unset→null case. Gated on libgda availability (skip cleanly
+// if absent — node/CI have it). Byte-parity is asserted against the GOLD STANDARD:
+// the SAME query body run under `gjs -m`, compared line-for-line.
+//
+// int64 + NaN-float/double GValue returns are covered by the tier-B gimarshalling
+// port (gvalue_int64_out / gvalue_noncanonical_nan_*), which has the purpose-built
+// GIMarshallingTests functions this file's headless Gda source cannot express.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { requireGi } from '../gi.js';
+
+// Load libgda; a box without the Gda-6.0 typelib skips the whole file cleanly.
+let Gda = null;
+let gdaError = '';
+try {
+  Gda = requireGi('Gda', '6.0');
+} catch (e) {
+  gdaError = String(e?.message ?? e);
+}
+const skip = Gda ? false : `libgda (Gda-6.0) unavailable: ${gdaError}`;
+
+// The SHARED probe body — runs UNCHANGED under node-gi AND gjs (see the parity test
+// below, which embeds this exact `.toString()`). Only `gi://` + plain JS, so it is
+// runtime-neutral; it returns the formatted lines and lets the caller print them.
+function probeGValues(GdaNs) {
+  const cnc = GdaNs.Connection.open_from_string(
+    'SQLite', 'DB_DIR=.;DB_NAME=:memory:', null, GdaNs.ConnectionOptions.NONE);
+  cnc.execute_non_select_command('CREATE TABLE t (i INTEGER, s TEXT, d REAL, b BOOLEAN)');
+  cnc.execute_non_select_command("INSERT INTO t VALUES (42, 'hi', 3.5, 1)");
+  cnc.execute_non_select_command('INSERT INTO t VALUES (NULL, NULL, NULL, NULL)');
+  const model = cnc.execute_select_command('SELECT i, s, d, b FROM t');
+  const labels = ['INTEGER', 'TEXT', 'REAL', 'BOOLEAN'];
+  const out = [];
+  for (let row = 0; row < model.get_n_rows(); row++) {
+    for (let col = 0; col < model.get_n_columns(); col++) {
+      const v = model.get_value_at(col, row);
+      out.push(`row${row} ${labels[col]}: ${v === null ? 'null' : v} (${typeof v})`);
+    }
+  }
+  return out;
+}
+
+test('GValue return unboxes to the contained JS primitive (Gda.DataModel.get_value_at)', { skip }, () => {
+  const cnc = Gda.Connection.open_from_string(
+    'SQLite', 'DB_DIR=.;DB_NAME=:memory:', null, Gda.ConnectionOptions.NONE);
+  cnc.execute_non_select_command('CREATE TABLE t (i INTEGER, s TEXT, d REAL, b BOOLEAN)');
+  cnc.execute_non_select_command("INSERT INTO t VALUES (42, 'hi', 3.5, 1)");
+  cnc.execute_non_select_command('INSERT INTO t VALUES (NULL, NULL, NULL, NULL)');
+  const model = cnc.execute_select_command('SELECT i, s, d, b FROM t');
+
+  // int → a JS number (NOT a boxed GObject.Value handle: typeof 'object' would be
+  // the pre-fix regression).
+  const i = model.get_value_at(0, 0);
+  assert.equal(i, 42);
+  assert.equal(typeof i, 'number');
+
+  // string → a JS string.
+  const s = model.get_value_at(1, 0);
+  assert.equal(s, 'hi');
+  assert.equal(typeof s, 'string');
+
+  // double → a JS number.
+  const d = model.get_value_at(2, 0);
+  assert.equal(d, 3.5);
+  assert.equal(typeof d, 'number');
+
+  // boolean → a JS boolean (a BOOLEAN column pins G_TYPE_BOOLEAN → true, not 1).
+  const b = model.get_value_at(3, 0);
+  assert.equal(b, true);
+  assert.equal(typeof b, 'boolean');
+
+  // NULL / unset GValue → null (every column of the second, all-NULL row).
+  for (let col = 0; col < 4; col++) {
+    assert.equal(model.get_value_at(col, 1), null, `NULL column ${col} unboxes to null`);
+  }
+});
+
+test('GValue unbox is byte-identical to gjs (gold standard)', {
+  skip: skip || (spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0 ? false : 'gjs not on PATH'),
+}, () => {
+  const ours = probeGValues(Gda).join('\n');
+
+  // Run the IDENTICAL probe body under `gjs -m` (native gi:// + GValue unbox) and
+  // compare its stdout line-for-line — the exactness oracle.
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-gvalue-gjs-'));
+  try {
+    const script = join(dir, 'probe.js');
+    const src =
+      `import Gda from 'gi://Gda?version=6.0';\n` +
+      `const probeGValues = ${probeGValues.toString()};\n` +
+      `for (const line of probeGValues(Gda)) print(line);\n`;
+    writeFileSync(script, src);
+    const res = spawnSync('gjs', ['-m', script], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs probe failed: ${res.stderr}`);
+    assert.equal(ours, res.stdout.trimEnd(), 'node-gi and gjs GValue unbox output are byte-identical');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The highest-value marshalling follow-up surfaced by the `@gjsify/sqlite` consumer (#734): node-gi wrapped a `GValue` return/OUT (`G_TYPE_VALUE`) as an opaque boxed handle (`[object Object]`); **GJS auto-unboxes it** to the contained JS value. `@gjsify/sqlite` hit this reading `Gda.DataModel.get_value_at()`. Verified byte-for-byte against `gjs`.

## gjs parity (per contained type — node-gi now matches)
int/uint/long/int64 → `number` (64-bit emits the same "cannot be safely stored" warning + rounds identically), string → `string`, boolean → `boolean`, double/float → `number` (NaN preserved), enum → `number`, object → the wrapped GObject (identity + `instanceof`), boxed → a method-routing handle, NULL/unset → `null`. **`GObject.Value` explicit construction stays a boxed instance** — the fix fires ONLY on a function's GValue return/OUT.

## Implementation (`marshal.cc` + `calls.cc` only — `GValueToJs` already existed)
- `GIArgumentToJs` INTERFACE branch: `G_TYPE_VALUE` (or derived) → unbox via `GValueToJs` (null pointer → `null`).
- caller-allocated OUT: a `G_TYPE_VALUE` blob unboxes too.
- **Transfer/free** (matches `refs/gjs/gi/arg.cpp`): transfer-everything return → `g_boxed_free(G_TYPE_VALUE,…)`; caller-alloc blob → `g_value_unset`+`g_free`; transfer-none (the common case) → borrow. `GValueToJs` copies/refs contained values in, so the post-read free is safe.

## Tests
- [x] `npm test` 286/0 · `test:gimarshalling` **343/0** (+7: GValue return/out/uninit/int64/caller-alloc/noncanonical-NaN un-skipped) · `test:conformance` 15 programs × 4 runtimes · `test:bun`/`test:deno` 34/34
- [x] `test/gvalue-return.test.mjs` (Gda unbox + byte-parity vs gjs probe) + tier-A `gvalue-return.conf.mjs`
- [x] **valgrind** 4000 iters: 0 invalid/double frees (only a one-time dlopen alloc)

Unblocks the `@gjsify/sqlite` consumer's result-reading (`convertValue` now gets unboxed primitives). Deferred (separate directions): GValue IN, explicit `GObject.Value` construction, flat GValue arrays.