### PR TITLE
feat(node-gi): inout containers + byte-array fixes

### DIFF
--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -255,9 +255,15 @@ function wrapBoxed(handle) {
         return () => wrapReturn(native.callBoxedMethod(handle, 'get_data', []));
       }
       const snake = camelToSnake(prop);
-      if (native.boxedMemberKind(handle, snake) === 2) {
-        return wrapReturn(native.getBoxedField(handle, snake));
-      }
+      // boxedMemberKind: 0 = not a member (type info resolved) → `undefined`, so
+      // `typeof boxed.noSuchName === 'undefined'` matches gjs (a fabricated
+      // dispatcher would read `'function'` and break JS duck-typing such as
+      // `if (typeof value.toArray === 'function')`); 1 = method; 2 = field; 3 =
+      // undecidable (unregistered struct, no static info) → keep the dispatcher
+      // fallback so a genuine method still resolves + throws a clear error at call.
+      const kind = native.boxedMemberKind(handle, snake);
+      if (kind === 2) return wrapReturn(native.getBoxedField(handle, snake));
+      if (kind === 0) return undefined;
       return methodDispatch(prop);
     },
     set(t, prop, value) {

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -195,12 +195,17 @@ function testContainerMarshalling(root, value, inoutValue, defaultValue, options
 }
 
 // ---- phase-2.2/2.3/2.4 skip reasons (scoped OUT of this container/compound-OUT
-// PR; each cites the roadmap item that will land it). INOUT containers (2.5),
-// struct FIELD access (2.6) and GLib.Variant/GParamSpec element marshalling (2.7)
-// are the deferred pieces the sections below route their sub-specs through. ----
-const SKIP_INOUT_CONTAINER =
-    'phase 2.5 INOUT containers — read-modify-write of a caller-built container ' +
-    '(GArray/GList/GHashTable/array inout) is a later PR; pure IN + compound OUT are live';
+// PR; each cites the roadmap item that will land it). INOUT containers (2.5) are
+// now LIVE (read-modify-write of a caller-built container round-trips like gjs;
+// only the gjs-quirky transfer-full (#192) / transfer-container (#44) / 64-bit
+// (#271) variants stay skipped, exactly as gjs skips them). struct FIELD access
+// (2.6) and GLib.Variant/GParamSpec element marshalling (2.7) remain the deferred
+// pieces the sections below route their sub-specs through. ----
+// gjs pends this exact test with gjs#106 (a transfer-full caller-allocated GArray
+// out the callee reallocates is unsupported upstream), so node-gi matches by skip.
+const SKIP_GARRAY_CALLER_ALLOC =
+    'https://gitlab.gnome.org/GNOME/gjs/issues/106 — transfer-full caller-allocated ' +
+    'GArray out (the callee reallocates a caller-provided GArray); gjs pends it too';
 // Struct FIELD get/set on a RETURNED struct/union is now LIVE (phase 2.6). The
 // remaining struct skips are the adjacent capabilities field access does NOT cover:
 const SKIP_STRUCT_CONSTRUCT =
@@ -519,9 +524,27 @@ describe('UTF-8 string', function () {
     });
 });
 
-// INOUT array (a caller-owned array the callee reallocates) is the phase-2.5
-// read-modify-write container case — deferred.
-describeSkip(SKIP_INOUT_CONTAINER, 'In-out array in the style of gtk_init()');
+// INOUT array in the style of gtk_init(): a caller-owned strv the callee
+// reads + reallocates (transfer full, modified in place). Now LIVE (INOUT
+// containers). Verified byte-for-byte against gjs 1.88.
+describe('In-out array in the style of gtk_init()', function () {
+    it('marshals null', function () {
+        const [, newArray] = GIMarshallingTests.init_function(null);
+        expect(newArray).toEqual([]);
+    });
+
+    it('marshals an inout empty array', function () {
+        const [ret, newArray] = GIMarshallingTests.init_function([]);
+        expect(ret).toBeTrue();
+        expect(newArray).toEqual([]);
+    });
+
+    it('marshals an inout array', function () {
+        const [ret, newArray] = GIMarshallingTests.init_function(['--foo', '--bar']);
+        expect(ret).toBeTrue();
+        expect(newArray).toEqual(['--foo']);
+    });
+});
 
 describe('Fixed-size C array', function () {
     describe('of ints', function () {
@@ -530,7 +553,7 @@ describe('Fixed-size C array', function () {
         testOutParameter('array_fixed', [-1, 0, 1, 2]);
         testUninitializedOutParameter('array_fixed', null);
         testOutParameter('array_fixed_caller_allocated', [-1, 0, 1, 2]);
-        testInoutParameter('array_fixed', [-1, 0, 1, 2], [2, 1, 0, -1], {skip: SKIP_INOUT_CONTAINER});
+        testInoutParameter('array_fixed', [-1, 0, 1, 2], [2, 1, 0, -1]);
     });
 
     describe('of shorts', function () {
@@ -572,9 +595,7 @@ describe('Fixed-size C array', function () {
 });
 
 describe('C array with length', function () {
-    testSimpleMarshalling('array', [-1, 0, 1, 2], [-2, -1, 0, 1, 2], [], {
-        inout: {skip: SKIP_INOUT_CONTAINER},
-    });
+    testSimpleMarshalling('array', [-1, 0, 1, 2], [-2, -1, 0, 1, 2], []);
 
     it('can be returned along with other arguments', function () {
         let [array, sum] = GIMarshallingTests.array_return_etc(9, 5);
@@ -673,7 +694,7 @@ describe('C array with length', function () {
         expect(() => GIMarshallingTests.array_in_guint8_len([-1, 0, 1, 2])).not.toThrow();
     });
 
-    itSkip(SKIP_INOUT_CONTAINER, 'can be an in-out argument', function () {
+    it('can be an in-out argument', function () {
         const array = GIMarshallingTests.array_inout([-1, 0, 1, 2]);
         expect(array).toEqual([-2, -1, 0, 1, 2]);
     });
@@ -684,7 +705,7 @@ describe('C array with length', function () {
         expect(array).toEqual([9, 0, 1, 5]);
     });
 
-    itSkip(SKIP_INOUT_CONTAINER, 'can be an in-out argument along with other arguments', function () {
+    it('can be an in-out argument along with other arguments', function () {
         let [array, sum] = GIMarshallingTests.array_inout_etc(9, [-1, 0, 1, 2], 5);
         expect(sum).toEqual(14);
         expect(array).toEqual([9, -1, 0, 1, 5]);
@@ -703,7 +724,7 @@ describe('C array with length', function () {
         });
     }
 
-    itSkip(SKIP_INOUT_CONTAINER, 'supports optional inout array with length', function () {
+    it('supports optional inout array with length', function () {
         expect(GIMarshallingTests.length_array_utf8_optional_inout(['🅰', 'β', 'c', 'd']))
             .toEqual(['a', 'b', '¢', '🔠']);
     });
@@ -712,7 +733,7 @@ describe('C array with length', function () {
 describe('Zero-terminated C array', function () {
     describe('of strings', function () {
         testSimpleMarshalling('array_zero_terminated', ['0', '1', '2'],
-            ['-1', '0', '1', '2'], null, {inout: {skip: SKIP_INOUT_CONTAINER}});
+            ['-1', '0', '1', '2'], null);
     });
 
     it('marshals null as a zero-terminated array return value', function () {
@@ -761,7 +782,11 @@ describe('Exhaustive test of UTF-8 sequences', function () {
             });
 
             it(`${arrayKind} inout transfer ${transfer}`, function () {
-                pending(SKIP_INOUT_CONTAINER);
+                const func = testFunction('inout');
+                if (transfer === 'container')
+                    pending('https://gitlab.gnome.org/GNOME/gjs/-/issues/44');
+
+                expect(func(['🅰', 'β', 'c', 'd'])).toEqual(['a', 'b', '¢', '🔠']);
             });
         }));
 });
@@ -782,15 +807,12 @@ describe('GArray', function () {
     });
 
     describe('of strings', function () {
-        testContainerMarshalling('garray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null, {
-            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
-        });
+        testContainerMarshalling('garray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null);
 
-        // caller-allocated GArray out (gjs#106/#344) — the callee reallocates a
-        // caller-provided GArray; that INOUT-shaped case is out of scope here.
-        itSkip(SKIP_INOUT_CONTAINER, 'marshals as a transfer-full caller-allocated out parameter', function () {
+        // caller-allocated GArray out: gjs ITSELF pends this with gjs#106 (the
+        // callee reallocates a caller-provided GArray — unsupported upstream), so
+        // node-gi keeps it skipped for the SAME reason (not an INOUT-container gap).
+        itSkip(SKIP_GARRAY_CALLER_ALLOC, 'marshals as a transfer-full caller-allocated out parameter', function () {
             expect(GIMarshallingTests.garray_utf8_full_out_caller_allocated())
                 .toEqual(['0', '1', '2']);
         });
@@ -815,11 +837,7 @@ describe('GArray', function () {
 
 describe('GPtrArray', function () {
     describe('of strings', function () {
-        testContainerMarshalling('gptrarray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null, {
-            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
-        });
+        testContainerMarshalling('gptrarray_utf8', ['0', '1', '2'], ['-2', '-1', '0', '1'], null);
     });
 
     describe('of structs', function () {
@@ -836,8 +854,7 @@ describe('GByteArray', function () {
 
     testReturnValue('bytearray_full', refByteArray);
     testOutParameter('bytearray_full', refByteArray);
-    testInoutParameter('bytearray_full', refByteArray, Uint8Array.from([104, 101, 108, 0, 0xFF]),
-        {skip: SKIP_INOUT_CONTAINER});
+    testInoutParameter('bytearray_full', refByteArray, Uint8Array.from([104, 101, 108, 0, 0xFF]));
 
     it('can be passed in with transfer none', function () {
         expect(() => GIMarshallingTests.bytearray_none_in(refByteArray)).not.toThrow();
@@ -887,8 +904,7 @@ describe('GBytes', function () {
 });
 
 describe('GStrv', function () {
-    testSimpleMarshalling('gstrv', ['0', '1', '2'], ['-1', '0', '1', '2'], null,
-        {inout: {skip: SKIP_INOUT_CONTAINER}});
+    testSimpleMarshalling('gstrv', ['0', '1', '2'], ['-1', '0', '1', '2'], null);
 });
 
 // Arrays whose ELEMENTS are themselves GStrv (nested container elements) are a
@@ -914,11 +930,7 @@ describeSkip('phase 2.2 arrays — length-annotated arrays of GStrv (nested cont
 
         describe('of strings', function () {
             testContainerMarshalling(`${list}_utf8`, ['0', '1', '2'],
-                ['-2', '-1', '0', '1'], [], {
-                    none: {inout: {skip: SKIP_INOUT_CONTAINER}},
-                    full: {inout: {skip: SKIP_INOUT_CONTAINER}},
-                    container: {inout: {skip: SKIP_INOUT_CONTAINER}},
-                });
+                ['-2', '-1', '0', '1'], []);
         });
     });
 });
@@ -954,11 +966,7 @@ describe('GHashTable', function () {
             0: '0',
             1: '1',
         };
-        testContainerMarshalling('ghashtable_utf8', stringDict, stringDictOut, null, {
-            none: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            full: {inout: {skip: SKIP_INOUT_CONTAINER}},
-            container: {inout: {skip: SKIP_INOUT_CONTAINER}},
-        });
+        testContainerMarshalling('ghashtable_utf8', stringDict, stringDictOut, null);
     });
 
     describe('with double values', function () {
@@ -1256,7 +1264,7 @@ describe('GObject', function () {
             expect(o.method_array_out()).toEqual([-1, 0, 1, 2]);
         });
 
-        itSkip(SKIP_INOUT_CONTAINER, 'marshals an int array as an inout parameter', function () {
+        it('marshals an int array as an inout parameter', function () {
             expect(o.method_array_inout([-1, 0, 1, 2])).toEqual([-2, -1, 0, 1, 2]);
         });
 

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -480,6 +480,11 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
       // closure/destroy slots (always IN) are filled by the callback handler.
       if (isLenArg[i] && (dirs[i] == GI_DIRECTION_OUT || dirs[i] == GI_DIRECTION_INOUT))
         out_args[outPos[i]].v_pointer = &slots[i];
+      // An INOUT length arg is a single `gint*` the callee reads (the in-count) AND
+      // writes (the out-count): the in_arg is a POINTER to the same stable slot. The
+      // in-count is written into slots[i] when the INOUT array is marshalled below.
+      if (isLenArg[i] && dirs[i] == GI_DIRECTION_INOUT)
+        in_args[inPos[i]].v_pointer = &slots[i];
       continue;
     }
     GIArgInfo* ai = gi_callable_info_get_arg(callable, i);
@@ -553,13 +558,61 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
         GITypeTag tg = gi_type_info_get_tag(ti);
         if (tg == GI_TYPE_TAG_ARRAY || tg == GI_TYPE_TAG_GLIST || tg == GI_TYPE_TAG_GSLIST ||
             tg == GI_TYPE_TAG_GHASH) {
-          // INOUT containers (read-modify-write a caller-built container) are the
-          // rare, ownership-tricky case — defer cleanly. Pure-OUT containers fall
-          // through to the slot-wiring branch below.
-          Napi::TypeError::New(
-              env, displayName + ": INOUT container parameters are not yet supported")
-              .ThrowAsJavaScriptException();
-          ok = false;
+          // INOUT container (read-modify-write a caller-built container). The ABI is
+          // a single `container**` the callee reads (the in-container) and reassigns
+          // (the out-container). We stash the in-container pointer in the stable slot
+          // and point BOTH in_args + out_args at &slots[i]; the callee overwrites
+          // slots[i].v_pointer with the out-container, which the read-back loop below
+          // marshals via ReadOutOrReturn (OUT transfer). OWNERSHIP: JsToInContainer
+          // records the ORIGINAL in-container in `inContainers`, so FreeInContainer
+          // (after the reads) releases it per the IN transfer — NONE → we free the
+          // in-container we built; EVERYTHING/CONTAINER → the callee adopted it, we
+          // don't. The out-container is freed (or borrowed) by ReadOutOrReturn per the
+          // SAME (OUT) transfer. Verified vs gjs 1.88 (GIMarshallingTests.array_inout,
+          // garray/glist/gslist/gptrarray/ghashtable_utf8_none_inout, bytearray_full_inout).
+          Napi::Value v = jsCursor < args.Length() ? args.Get(jsCursor) : env.Undefined();
+          jsCursor++;
+          if (!IsSupportedContainerType(ti, &why)) {
+            Napi::TypeError::New(env, displayName + ": INOUT " + why +
+                                          " parameters are not yet supported")
+                .ThrowAsJavaScriptException();
+            ok = false;
+          } else {
+            GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
+            gpointer cptr = nullptr;
+            long ccount = 0;
+            // A nullable INOUT container passed null/undefined → a NULL in-container
+            // (count 0), matching gjs (e.g. length_array_utf8_optional_inout(null)
+            // → []). A non-nullable arg falls through to JsToInContainer, which
+            // throws for a non-array, exactly as before.
+            if ((v.IsNull() || v.IsUndefined()) && gi_arg_info_may_be_null(ai)) {
+              ok = true;
+            } else {
+              ok = JsToInContainer(env, v, ti, tr, &cptr, &ccount, &inContainers);
+            }
+            if (ok) {
+              slots[i].v_pointer = cptr;
+              in_args[inPos[i]].v_pointer = &slots[i];
+              out_args[outPos[i]].v_pointer = &slots[i];
+              // The length arg carries the in-count. An INOUT length gets it in ITS
+              // slot (the callee reads+writes that slot); a plain IN length gets the
+              // value directly in its in_arg.
+              if (tg == GI_TYPE_TAG_ARRAY) {
+                unsigned int L = 0;
+                if (gi_type_info_get_array_length_index(ti, &L) && L < n_args) {
+                  GIArgInfo* la = gi_callable_info_get_arg(callable, L);
+                  GITypeInfo* lt = gi_arg_info_get_type_info(la);
+                  if (dirs[L] == GI_DIRECTION_INOUT) {
+                    WriteLengthValue(lt, &slots[L], ccount);
+                  } else if (dirs[L] == GI_DIRECTION_IN && inPos[L] >= 0) {
+                    WriteLengthValue(lt, &in_args[inPos[L]], ccount);
+                  }
+                  gi_base_info_unref(lt);
+                  gi_base_info_unref(la);
+                }
+              }
+            }
+          }
         } else {
           // INOUT scalar: marshal the JS input into the slot (like IN); the
           // invoker hands the slot's address to the callee, which reads + writes.

--- a/packages/node-gi/node-gi/src/class.cc
+++ b/packages/node-gi/node-gi/src/class.cc
@@ -52,6 +52,16 @@ static GType TypeNameToGType(const std::string& t) {
   if (t == "float") return G_TYPE_FLOAT;
   if (t == "object") return G_TYPE_OBJECT;
   if (t == "void" || t == "none") return G_TYPE_NONE;
+  // The GByteArray boxed type (a byte-array signal param / property). Named
+  // explicitly (not just via g_type_from_name) so referencing G_TYPE_BYTE_ARRAY
+  // also REGISTERS it — g_type_from_name returns 0 for a type never yet touched.
+  if (t == "GByteArray" || t == "bytearray") return G_TYPE_BYTE_ARRAY;
+  // General fallback: any already-registered GType by its canonical name (e.g.
+  // "GBytes", "GdkRGBA", an enum/boxed/object type). Keeps the fast-path names
+  // above (they're the common shorthands) while letting a fully-qualified GType
+  // name resolve — matching gjs, which accepts a GType for a signal param type.
+  GType named = g_type_from_name(t.c_str());
+  if (named != G_TYPE_INVALID) return named;
   return G_TYPE_INVALID;
 }
 
@@ -684,13 +694,48 @@ Napi::Value CallParentVfunc(const Napi::CallbackInfo& info) {
       } else if (dir == GI_DIRECTION_INOUT &&
                  (tg == GI_TYPE_TAG_ARRAY || tg == GI_TYPE_TAG_GLIST ||
                   tg == GI_TYPE_TAG_GSLIST || tg == GI_TYPE_TAG_GHASH)) {
-        // INOUT containers (read-modify-write a caller-built container) are the rare,
-        // ownership-tricky case — defer cleanly (as the function path does). Pure-OUT
-        // containers fall through to the slot-wiring branch below.
-        Napi::TypeError::New(env, "super." + vname +
-                                      ": INOUT container parameters are not yet supported")
-            .ThrowAsJavaScriptException();
-        ok = false;
+        // INOUT container: same read-modify-write model as the function path. The ffi
+        // param is a single `container**` the parent reads (in) then reassigns (out);
+        // we stash the in-container in slots[i] and point giArgs[1+i] at &slots[i].
+        // OWNERSHIP: JsToInContainer records the ORIGINAL in-container in inContainers,
+        // so FreeInContainer (after the reads) releases it per the IN transfer; the
+        // out-container the parent wrote into slots[i] is read + freed per the OUT
+        // transfer by ReadOutOrReturn below.
+        Napi::Value v = jsCursor < args.Length() ? args.Get(jsCursor) : env.Undefined();
+        jsCursor++;
+        if (!IsSupportedContainerType(ti, &why)) {
+          Napi::TypeError::New(env, "super." + vname + ": INOUT " + why +
+                                        " parameters are not yet supported")
+              .ThrowAsJavaScriptException();
+          ok = false;
+        } else {
+          GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
+          gpointer cptr = nullptr;
+          long ccount = 0;
+          if ((v.IsNull() || v.IsUndefined()) && gi_arg_info_may_be_null(ai)) {
+            ok = true;  // nullable INOUT container → NULL in-container (count 0)
+          } else {
+            ok = JsToInContainer(env, v, ti, tr, &cptr, &ccount, &inContainers);
+          }
+          if (ok) {
+            slots[i].v_pointer = cptr;
+            giArgs[1 + i].v_pointer = &slots[i];
+            if (tg == GI_TYPE_TAG_ARRAY) {
+              unsigned int L = 0;
+              if (gi_type_info_get_array_length_index(ti, &L) && L < nDeclared) {
+                GIArgInfo* la = gi_callable_info_get_arg(ci, L);
+                GITypeInfo* lt = gi_arg_info_get_type_info(la);
+                // An INOUT length's slot is what the parent reads+writes (giArgs[1+L]
+                // already points at &slots[L] via the skip-branch); a plain IN length
+                // takes the value directly in its ffi slot.
+                if (dirs[L] == GI_DIRECTION_INOUT) WriteLengthValue(lt, &slots[L], ccount);
+                else if (dirs[L] == GI_DIRECTION_IN) WriteLengthValue(lt, &giArgs[1 + L], ccount);
+                gi_base_info_unref(lt);
+                gi_base_info_unref(la);
+              }
+            }
+          }
+        }
       } else if (dir == GI_DIRECTION_INOUT) {
         // INOUT scalar: marshal the JS input into the slot (like IN); the parent
         // reads + writes it through &slots[i].

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -925,22 +925,33 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
   *outCount = 0;
 
   // Raw bytes from a TypedArray / Buffer (Uint8Array round-trips, etc.).
+  // `hasRawBytes` (NOT `rawBytes != nullptr`) marks a TypedArray/Buffer SOURCE: an
+  // EMPTY Uint8Array/Buffer has a NULL backing-store pointer (V8 hands out nullptr
+  // for a zero-length ArrayBuffer), yet it is still a valid 0-length byte source.
+  // gjs marshals `new Uint8Array([])` to an empty C container (count 0); it must
+  // NOT fall through to the `!v.IsArray()` throw below (a TypedArray isn't a JS
+  // Array). Verified vs gjs 1.88: GLib.base64_encode(new Uint8Array([])) === ''.
   const uint8_t* rawBytes = nullptr;
   size_t rawLen = 0;
+  bool hasRawBytes = false;
   if (v.IsBuffer()) {
     Napi::Buffer<uint8_t> b = v.As<Napi::Buffer<uint8_t>>();
     rawBytes = b.Data();
     rawLen = b.Length();
+    hasRawBytes = true;
   } else if (v.IsTypedArray()) {
     Napi::TypedArray ta = v.As<Napi::TypedArray>();
     rawBytes = static_cast<const uint8_t*>(ta.ArrayBuffer().Data()) + ta.ByteOffset();
     rawLen = ta.ByteLength();
+    hasRawBytes = true;
   }
 
   if (at == GI_ARRAY_TYPE_BYTE_ARRAY) {
     GByteArray* ba = g_byte_array_new();
-    if (rawBytes != nullptr) {
-      g_byte_array_append(ba, rawBytes, static_cast<guint>(rawLen));
+    if (hasRawBytes) {
+      // append is a no-op for len 0; guard so a NULL data ptr (empty typed array)
+      // is never handed to g_byte_array_append's memcpy.
+      if (rawLen > 0) g_byte_array_append(ba, rawBytes, static_cast<guint>(rawLen));
       *outCount = static_cast<long>(rawLen);
     } else if (v.IsArray()) {
       Napi::Array arr = v.As<Napi::Array>();
@@ -966,10 +977,14 @@ static bool JsToCArray(Napi::Env env, Napi::Value v, GITypeInfo* type, gpointer*
   // string → bytes) are C-array-only ergonomics (a GArray/GPtrArray of bytes is
   // not something GJS accepts a TypedArray for), so gate them on the C kind.
 
-  // Byte C array from a TypedArray / Buffer.
-  if (at == GI_ARRAY_TYPE_C && isByte && rawBytes != nullptr) {
+  // Byte C array from a TypedArray / Buffer. `hasRawBytes` (not `rawBytes !=
+  // nullptr`) so an empty typed array (NULL data, len 0) still lands here: it
+  // allocates a 0-length buffer (g_malloc0(0) → NULL, i.e. an empty C array,
+  // count 0 — the same shape an empty JS array `[]` already produced) instead of
+  // falling through to the `!v.IsArray()` throw. memcpy is guarded on rawLen>0.
+  if (at == GI_ARRAY_TYPE_C && isByte && hasRawBytes) {
     void* buf = g_malloc0(elemSize * (rawLen + (zt ? 1 : 0)));
-    memcpy(buf, rawBytes, rawLen);
+    if (rawLen > 0) memcpy(buf, rawBytes, rawLen);
     *outPtr = buf;
     *outCount = static_cast<long>(rawLen);
     gi_base_info_unref(elem);
@@ -1376,9 +1391,16 @@ static BoxedHandle* UnwrapBoxedArg(const Napi::CallbackInfo& info) {
   return bh;
 }
 
-// boxedMemberKind(handle, name) → 0 (neither) | 1 (method) | 2 (field). Methods
-// take priority (gjs find_unique_js_field_name renames a colliding field to
-// `_name`), so L1 wrapBoxed checks this to route method-dispatch vs field access.
+// boxedMemberKind(handle, name) → 0 (neither) | 1 (method) | 2 (field) | 3 (type
+// info unavailable — membership undecidable). Methods take priority (gjs
+// find_unique_js_field_name renames a colliding field to `_name`), so L1 wrapBoxed
+// checks this to route method-dispatch vs field access. The 3 case only arises for
+// a boxed handle whose GType is unregistered AND carries no static info (neither
+// gtype nor stored info resolves a struct/union): L1 keeps its method-dispatch
+// fallback there. When info IS resolvable, 0 is AUTHORITATIVE ("not a member"), so
+// L1 returns `undefined` for it — matching gjs, where `typeof boxed.noSuchName` is
+// `'undefined'` (a fabricated dispatcher would make it `'function'`, breaking JS
+// duck-typing like `typeof x.toArray === 'function'`).
 Napi::Value BoxedMemberKind(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 2 || !info[1].IsString()) {
@@ -1390,8 +1412,9 @@ Napi::Value BoxedMemberKind(const Napi::CallbackInfo& info) {
   if (bh == nullptr) return env.Null();
   std::string name = info[1].As<Napi::String>().Utf8Value();
   GIBaseInfo* ti = DupBoxedTypeInfo(bh);
-  int kind = 0;
+  int kind = 3;  // no resolvable type info → membership undecidable (L1 keeps its fallback)
   if (ti != nullptr) {
+    kind = 0;  // info resolvable → 0 is authoritative ("not a member")
     if (BoxedHasMethod(ti, name.c_str())) {
       kind = 1;
     } else {

--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -170,9 +170,21 @@ Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
       // The wrapped boxed handle carries its GType, so L1 wrapBoxed routes
       // `.dup_string()` etc. through CallBoxedMethod (gi_repository_find_by_gtype →
       // GLib.VariantType struct methods). (GVariant is fundamental, handled by its
-      // own G_TYPE_VARIANT case above; GStrv/GByteArray-as-array reads — a GJS
-      // niceness, refs/gjs/gi/value.cpp:1020/1029 — stay a follow-up: they land here
-      // as a boxed handle rather than a string/byte array, but no longer throw.)
+      // own G_TYPE_VARIANT case above.)
+      //
+      // G_TYPE_BYTE_ARRAY (a GByteArray) is special-cased to a Node Buffer (Uint8Array)
+      // — NOT a boxed handle — matching gjs (refs/gjs/gi/value.cpp:1091
+      // gjs_byte_array_from_byte_array). Verified vs gjs 1.88 (a GByteArray signal
+      // param → a Uint8Array in the handler). GBytes (G_TYPE_BYTES) is deliberately
+      // NOT special-cased here: gjs leaves it as a GLib.Bytes boxed handle
+      // (value.cpp has no GBytes case → the generic boxed branch), which is what the
+      // MakeBoxedHandle below already produces (verified: a GBytes signal param →
+      // `instanceof GLib.Bytes`). A GStrv-as-array read stays a follow-up.
+      if (G_VALUE_HOLDS(v, G_TYPE_BYTE_ARRAY)) {
+        GByteArray* ba = static_cast<GByteArray*>(g_value_get_boxed(v));
+        if (ba == nullptr) return env.Null();
+        return Napi::Buffer<uint8_t>::Copy(env, ba->data, ba->len);
+      }
       gpointer boxed = g_value_get_boxed(v);
       if (boxed == nullptr) return env.Null();
       GType bt = G_VALUE_TYPE(v);
@@ -208,6 +220,43 @@ bool JsToGValue(Napi::Env env, Napi::Value js, GValue* v) {
     if (!UnwrapGTypeArg(env, js, &gt)) return false;
     g_value_set_gtype(v, gt);
     return true;
+  }
+  // G_TYPE_BYTE_ARRAY (a GByteArray boxed value, e.g. a byte-array signal param or
+  // property). G_TYPE_FUNDAMENTAL == G_TYPE_BOXED, so the switch below would route a
+  // Uint8Array to the boxed-HANDLE case and reject it. Special-case it FIRST — a JS
+  // Uint8Array/Buffer → a freshly-allocated GByteArray, matching gjs
+  // (refs/gjs/gi/value.cpp:783 gjs_byte_array_get_byte_array, gated on
+  // JS_IsUint8Array). A non-Uint8Array value falls through to the generic boxed
+  // handling below (so a real GByteArray boxed handle still works), exactly as gjs
+  // does. g_value_take_boxed makes the GValue OWN the GByteArray; g_value_unset frees
+  // it. null/undefined → NULL. Verified vs gjs 1.88 (Uint8Array → GByteArray signal
+  // param round-trips to a Uint8Array in the handler).
+  if (G_VALUE_HOLDS(v, G_TYPE_BYTE_ARRAY)) {
+    if (js.IsNull() || js.IsUndefined()) {
+      g_value_set_boxed(v, nullptr);
+      return true;
+    }
+    const uint8_t* bytes = nullptr;
+    size_t len = 0;
+    bool isU8 = false;
+    if (js.IsBuffer()) {
+      Napi::Buffer<uint8_t> b = js.As<Napi::Buffer<uint8_t>>();
+      bytes = b.Data();
+      len = b.Length();
+      isU8 = true;
+    } else if (js.IsTypedArray() && js.As<Napi::TypedArray>().TypedArrayType() == napi_uint8_array) {
+      Napi::TypedArray ta = js.As<Napi::TypedArray>();
+      bytes = static_cast<const uint8_t*>(ta.ArrayBuffer().Data()) + ta.ByteOffset();
+      len = ta.ByteLength();
+      isU8 = true;
+    }
+    if (isU8) {
+      GByteArray* ba = g_byte_array_new();
+      if (len > 0) g_byte_array_append(ba, bytes, static_cast<guint>(len));
+      g_value_take_boxed(v, ba);
+      return true;
+    }
+    // else: fall through to the generic G_TYPE_BOXED handling (a boxed handle).
   }
   // G_TYPE_STRV (a GStrv / NULL-terminated char** boxed property, e.g.
   // Gtk.Widget:css-classes). G_TYPE_FUNDAMENTAL(G_TYPE_STRV) == G_TYPE_BOXED, so

--- a/packages/node-gi/node-gi/test/arrays.test.mjs
+++ b/packages/node-gi/node-gi/test/arrays.test.mjs
@@ -11,7 +11,7 @@
 //  * plain C utf8 array return (transfer full)      (g_uri_list_extract_uris)
 //  * GHashTable<utf8,utf8> return → object          (GLib.Uri.parse_params)
 //  * GList<utf8> return → string[]                  (g_content_types_get_registered)
-//  * deferred INOUT container throws clearly        (g_base64_decode_inplace)
+//  * INOUT byte-array container is handled           (g_base64_decode_inplace)
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -100,11 +100,18 @@ test('GList<utf8> return → string[]: Gio.content_types_get_registered()', () =
   assert.ok(types.every((t) => typeof t === 'string'));
 });
 
-test('deferred INOUT container throws a clear error: GLib.base64_decode_inplace()', () => {
-  // The text arg is an INOUT byte array — the rare read-modify-write container
-  // case is deferred. It must throw "not yet supported", never mis-handle it.
-  assert.throws(
-    () => callFunction('GLib', 'base64_decode_inplace', [Uint8Array.from([65, 65]), 2]),
-    /not yet supported/,
+test('INOUT byte-array container is handled, not deferred: GLib.base64_decode_inplace()', () => {
+  // The `text` arg is an INOUT byte array (decoded in place). INOUT containers now
+  // marshal (round-tripped byte-for-byte vs gjs in the gimarshalling port +
+  // marshalling-close.test.mjs), so this no longer throws the old "not yet supported"
+  // deferral. base64_decode_inplace ITSELF is a known-quirky in-place case: its
+  // return-array aliases the freed in-place `text` buffer, so the decoded bytes are
+  // implementation-defined AND NON-DETERMINISTIC on GJS too (verified: gjs returns a
+  // different garbage byte each run) — hence only the absence of the deferral throw is
+  // asserted here, never specific bytes. Well-defined INOUT arrays/lists/hashes are
+  // covered exhaustively (with exact values) by the tier-B gimarshalling port.
+  requireNamespace('GLib', '2.0');
+  assert.doesNotThrow(
+    () => callFunction('GLib', 'base64_decode_inplace', [Uint8Array.from([97, 71, 107, 61])]),
   );
 });

--- a/packages/node-gi/node-gi/test/marshalling-close.test.mjs
+++ b/packages/node-gi/node-gi/test/marshalling-close.test.mjs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+// Marshalling-correctness close-out for @gjsify/node-gi — display-free, headless.
+// Three gaps, each asserted against the gjs GOLD STANDARD (the SAME probe body run
+// under `gjs -m`, compared line-for-line — the exactness oracle):
+//
+//   Gap 1  empty Uint8Array / empty array as an IN byte container (marshal.cc
+//          JsToCArray): an EMPTY typed array has a NULL backing-store pointer, which
+//          used to defeat the byte fast-path and throw "expected an array"; now it
+//          marshals to an empty C container (count 0) like gjs.
+//   Gap 2  GValue byte-array marshalling + the boxed-handle Proxy (object.cc
+//          GValueToJs/JsToGValue + gi.js wrapBoxed): a GByteArray GValue round-trips
+//          a Uint8Array (gjs value.cpp:1091/783), and a boxed handle's Proxy returns
+//          `undefined` for a name that is neither a method nor a field (so
+//          `typeof x.toArray` is `'undefined'`, not `'function'` — the divergence
+//          that broke the @gjsify/sqlite BLOB round-trip via its
+//          `typeof value.toArray === 'function'` duck-type). Gda checks gate on libgda.
+//   Gap 3  INOUT containers are covered by the tier-B gimarshalling port
+//          (array_inout / *_utf8_none_inout / init_function / ...) and by the INOUT
+//          strv chain-up in vfunc-chainup.test.mjs.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+const GObject = requireGi('GObject', '2.0');
+
+const gjsAvailable = spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+// Run a self-contained probe body (only `gi://` + plain JS) under `gjs -m` and
+// return its stdout — the gold-standard oracle. `imports` maps a local name to its
+// `gi://` specifier; the body is `.toString()`-inlined + called via `callExpr`.
+function goldStandard(imports, bodyFn, callExpr) {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-marshal-gjs-'));
+  try {
+    const script = join(dir, 'probe.js');
+    const importLines = Object.entries(imports)
+      .map(([name, spec]) => `import ${name} from '${spec}';`)
+      .join('\n');
+    const src = `${importLines}\nconst probe = ${bodyFn.toString()};\nfor (const line of ${callExpr}) print(line);\n`;
+    writeFileSync(script, src);
+    const res = spawnSync('gjs', ['-m', script], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs probe failed: ${res.stderr}`);
+    return res.stdout.trimEnd();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- Gap 1 - empty Uint8Array / empty array as an IN byte container ----------
+
+function probeEmptyByteIn(GLib) {
+  const out = [];
+  out.push(`base64(new Uint8Array([])) = ${JSON.stringify(GLib.base64_encode(new Uint8Array([])))}`);
+  out.push(`base64([]) = ${JSON.stringify(GLib.base64_encode([]))}`);
+  out.push(`base64(new Uint8Array([104,105])) = ${JSON.stringify(GLib.base64_encode(new Uint8Array([104, 105])))}`);
+  out.push(`md5(new Uint8Array([])) = ${GLib.compute_checksum_for_data(GLib.ChecksumType.MD5, new Uint8Array([]))}`);
+  out.push(`md5([]) = ${GLib.compute_checksum_for_data(GLib.ChecksumType.MD5, [])}`);
+  out.push(`md5([97,98,99]) = ${GLib.compute_checksum_for_data(GLib.ChecksumType.MD5, [97, 98, 99])}`);
+  return out;
+}
+
+test('Gap 1: an empty Uint8Array / array marshals as an empty byte container (no throw)', () => {
+  // The regression: an empty typed array used to throw "expected an array".
+  assert.equal(GLib.base64_encode(new Uint8Array([])), '');
+  assert.equal(GLib.base64_encode([]), '');
+  assert.equal(GLib.base64_encode(new Uint8Array([104, 105])), 'aGk=');
+  // MD5 of the empty string - proves an empty typed array reached C as a 0-length buffer.
+  assert.equal(GLib.compute_checksum_for_data(GLib.ChecksumType.MD5, new Uint8Array([])),
+    'd41d8cd98f00b204e9800998ecf8427e');
+});
+
+test('Gap 1: empty-byte-container IN is byte-identical to gjs', { skip: gjsAvailable ? false : 'gjs not on PATH' }, () => {
+  const ours = probeEmptyByteIn(GLib).join('\n');
+  const gold = goldStandard({ GLib: 'gi://GLib?version=2.0' }, probeEmptyByteIn, 'probe(GLib)');
+  assert.equal(ours, gold, 'node-gi and gjs empty-byte-container IN output are byte-identical');
+});
+
+// ---- Gap 2 - GByteArray GValue round-trips a Uint8Array (object.cc) ----------
+
+test('Gap 2: a GByteArray GValue round-trips a Uint8Array (signal param)', () => {
+  // A byte-array signal param exercises BOTH directions: emit marshals the JS
+  // Uint8Array INTO a G_TYPE_BYTE_ARRAY GValue (JsToGValue), the handler receives it
+  // back OUT (GValueToJs). gjs gold standard (verified): a Uint8Array in the handler.
+  const Klass = GObject.registerClass(
+    { GTypeName: 'NodeGiByteArrayGValueSig', Signals: { 'sig-ba': { param_types: ['GByteArray'] } } },
+    class extends GObject.Object {},
+  );
+  const o = new Klass();
+  let got;
+  o.connect('sig-ba', (_o, v) => { got = v; });
+  o.emit('sig-ba', new Uint8Array([10, 20, 30]));
+  assert.ok(got instanceof Uint8Array, 'a GByteArray GValue unboxes to a Uint8Array, not a boxed handle');
+  assert.deepEqual([...got], [10, 20, 30]);
+});
+
+// ---- Gap 2 - the boxed-handle Proxy + the Gda BLOB round-trip (libgda) -------
+
+let Gda = null;
+let gdaError = '';
+try {
+  Gda = requireGi('Gda', '6.0');
+} catch (e) {
+  gdaError = String(e?.message ?? e);
+}
+const gdaSkip = Gda ? false : `libgda (Gda-6.0) unavailable: ${gdaError}`;
+
+// The SHARED probe body - a BLOB read returns a boxed GdaBinary handle on BOTH
+// node-gi and gjs (NOT a Uint8Array - verified). What must match is the JS shape of
+// that handle: a name that is not a real member reads `undefined` (`typeof
+// v.toArray`), `'x' in v` is false, and a REAL method (`get_size`) is a callable
+// returning the byte count. The constructor NAME (Gda_Binary vs a generic proxy) is
+// intentionally NOT compared - that wrapper-shape difference is orthogonal here.
+function probeBlobHandle(Gda) {
+  const cnc = Gda.Connection.open_from_string(
+    'SQLite', 'DB_DIR=.;DB_NAME=:memory:', null, Gda.ConnectionOptions.NONE);
+  cnc.execute_non_select_command('CREATE TABLE t (b BLOB)');
+  cnc.execute_non_select_command("INSERT INTO t VALUES (x'68656c6c6f')");
+  const model = cnc.execute_select_command('SELECT b FROM t');
+  const v = model.get_value_at(0, 0);
+  const out = [];
+  out.push(`isUint8Array: ${v instanceof Uint8Array}`);
+  out.push(`typeof toArray: ${typeof v.toArray}`);
+  out.push(`toArray in v: ${'toArray' in v}`);
+  out.push(`typeof nope123: ${typeof v.nope123}`);
+  out.push(`typeof get_size: ${typeof v.get_size}`);
+  out.push(`get_size(): ${v.get_size()}`);
+  return out;
+}
+
+test('Gap 2: a BLOB get_value_at() boxed handle exposes no phantom members', { skip: gdaSkip }, () => {
+  const cnc = Gda.Connection.open_from_string(
+    'SQLite', 'DB_DIR=.;DB_NAME=:memory:', null, Gda.ConnectionOptions.NONE);
+  cnc.execute_non_select_command('CREATE TABLE t (b BLOB)');
+  cnc.execute_non_select_command("INSERT INTO t VALUES (x'68656c6c6f')");
+  const v = cnc.execute_select_command('SELECT b FROM t').get_value_at(0, 0);
+  // The gi.js Proxy fix: a non-member reads `undefined` (was a fabricated function),
+  // matching gjs - this is what let the sqlite reader's `typeof value.toArray ===
+  // 'function'` duck-type stop falsely matching + throwing on a non-existent call.
+  assert.equal(typeof v.toArray, 'undefined', 'a non-member is undefined, not a phantom function');
+  assert.equal(typeof v.nope123, 'undefined');
+  assert.equal('toArray' in v, false);
+  // A REAL introspected method is still callable + returns the byte count.
+  assert.equal(typeof v.get_size, 'function');
+  assert.equal(v.get_size(), 5);
+});
+
+test('Gap 2: the BLOB boxed-handle shape is byte-identical to gjs', {
+  skip: gdaSkip || (gjsAvailable ? false : 'gjs not on PATH'),
+}, () => {
+  const ours = probeBlobHandle(Gda).join('\n');
+  const gold = goldStandard({ Gda: 'gi://Gda?version=6.0' }, probeBlobHandle, 'probe(Gda)');
+  assert.equal(ours, gold, 'node-gi and gjs BLOB boxed-handle JS shape are byte-identical');
+});

--- a/packages/node-gi/node-gi/test/vfunc-chainup.test.mjs
+++ b/packages/node-gi/node-gi/test/vfunc-chainup.test.mjs
@@ -297,14 +297,17 @@ test('super.vfunc_get_value() returns the OUT-carried byte array (L1)', () => {
   assert.deepEqual(Array.from(result), [1, 2, 3]);
 });
 
-// ---- INOUT container chain-up stays DEFERRED (a clean throw, not a crash) ----
+// ---- INOUT container chain-up (read-modify-write a caller-built container) ----
 //
 // GApplication.local_command_line has an INOUT `arguments` (a strv) + an OUT
-// `exit_status`. The OUT scalar is now handled, but INOUT CONTAINERS remain the
-// rare, ownership-tricky case the function-invoke path also defers. The guard
-// must turn that into a clear, CATCHABLE throw BEFORE the ffi_call (never a crash).
+// `exit_status` + a boolean return. Chaining up to the parent marshals the JS
+// array IN as the strv, passes it INOUT, and reads the (possibly modified) strv +
+// the OUT exit_status back. Verified against gjs 1.88: for a no-op command line,
+// super.vfunc_local_command_line(['myapp']) → [true, ['myapp'], 0] (return, the
+// round-tripped INOUT argv, the OUT exit_status). Was DEFERRED with a clean throw
+// before INOUT containers landed; now it round-trips like gjs.
 
-test('chain-up of a vfunc with an INOUT container throws, does not crash (native)', () => {
+test('chain-up of a vfunc with an INOUT container round-trips (native)', () => {
   requireNamespace('Gio', '2.0');
   const Type = registerClass('NodeGiChainInoutGuard', 'Gio', 'Application', {
     vfuncs: {
@@ -314,26 +317,23 @@ test('chain-up of a vfunc with an INOUT container throws, does not crash (native
     },
   });
   const app = constructType(Type, { 'application-id': 'eu.gjsify.ChainInoutGuard' });
-  assert.throws(
-    () => callParentVfunc(app, 'local_command_line', [['myapp']]),
-    /INOUT container parameters are not yet supported/,
-  );
+  assert.deepEqual(callParentVfunc(app, 'local_command_line', [['myapp']]), [true, ['myapp'], 0]);
 });
 
-test('chain-up of a vfunc with an INOUT container throws via L1 super', () => {
+test('chain-up of a vfunc with an INOUT container round-trips via L1 super', () => {
   const GObject = requireGi('GObject', '2.0');
   const Gio = requireGi('Gio', '2.0');
+  let received;
   const Klass = GObject.registerClass(
     { GTypeName: 'NodeGiL1ChainInoutGuard' },
     class extends Gio.Application {
       vfunc_local_command_line(argv) {
+        received = argv;
         return super.vfunc_local_command_line(argv);
       }
     },
   );
   const app = new Klass({ 'application-id': 'eu.gjsify.L1ChainInoutGuard' });
-  assert.throws(
-    () => app.vfunc_local_command_line(['myapp']),
-    /INOUT container parameters are not yet supported/,
-  );
+  assert.deepEqual(app.vfunc_local_command_line(['myapp']), [true, ['myapp'], 0]);
+  assert.deepEqual(received, ['myapp']);
 });

--- a/packages/node/sqlite/src/test.node-gi.mts
+++ b/packages/node/sqlite/src/test.node-gi.mts
@@ -22,10 +22,10 @@
 // `open`/`execute` are blocking), so — unlike an async-Gio consumer — it needs
 // NO GLib main-loop pumping and the WHOLE suite runs under node-gi. It reuses
 // the package's existing spec suites VERBATIM — same assertions as `test:gjs`.
-// Result of the 52 tests: 51 pass (connection lifecycle, prepare, param
-// binding, SQL/parser validation, error handling, option validation AND
-// scalar result-row reading via `Gda.DataModel.get_value_at()`, whose GValue
-// returns node-gi unboxes to JS primitives since gjsify PR #735).
+// Result: ALL 52 tests pass (connection lifecycle, prepare, param binding,
+// SQL/parser validation, error handling, option validation, scalar result-row
+// reading via `Gda.DataModel.get_value_at()` whose GValue returns node-gi
+// unboxes since gjsify PR #735, AND the BLOB round-trip — see below).
 import { run } from '@gjsify/unit';
 
 import testSuiteDatabaseSync from './database-sync.spec.js';
@@ -36,24 +36,17 @@ import testSuiteDataTypes from './data-types.spec.js';
 // the auto-injected `@gjsify/node-gi/globals` shim.
 print('sqlite suite on @gjsify/node-gi (Gda SQLite on Node)');
 
-// ── node-gi gap: BLOB (byte-array) ↔ GValue marshalling ───────────────────────
-// The ONE remaining failure. This test round-trips a `Uint8Array` BLOB: it binds
-// one as a statement parameter (`Gda.Holder.set_value(u8)`) and reads a BLOB
-// column back (`Gda.DataModel.get_value_at()`). node-gi doesn't marshal a JS
-// byte array to/from a `GValue` holding a GLib byte array the way GJS auto-does:
-// a bound `Uint8Array` doesn't round-trip (the inserted BLOB row isn't found on
-// read), and a BLOB `get_value_at()` return comes back as a RAW boxed node-gi
-// handle rather than a `Uint8Array` (confirmed by a direct Gda probe). This is
-// DISTINCT from the scalar GValue-return unboxing gjsify PR #735 already fixed
-// (int/real/text now round-trip — that turned 13 of the original 14 failures
-// green). It's a native-engine follow-up (byte-array GValue boxing/unboxing in
-// src/marshal.cc), not a @gjsify/sqlite bug and not fixable at the JS/L1 layer,
-// so this one test is skipped WITH a reason (never silently). All other reads —
-// INTEGER/REAL/TEXT/NULL, get()/all()/run(), BigInt toggles, array rows — pass.
-const NODE_GI_BLOB_GVALUE =
-    'node-gi does not marshal a Uint8Array BLOB to/from a GValue byte array: a bound Uint8Array param does not round-trip and a BLOB get_value_at() return is a raw boxed handle, not a Uint8Array (byte-array GValue boxing/unboxing gap in marshal.cc; distinct from the scalar GValue-return fix in PR #735)';
-const skip: Record<string, string> = {
-    'supports INTEGER, REAL, TEXT, BLOB, and NULL': NODE_GI_BLOB_GVALUE,
-};
-
-run({ testSuiteDatabaseSync, testSuiteStatementSync, testSuiteDataTypes }, { skip });
+// ── BLOB (byte-array) round-trip — now GREEN ─────────────────────────────────
+// The 'supports INTEGER, REAL, TEXT, BLOB, and NULL' test round-trips a
+// `Uint8Array` BLOB (inserted inline as an `X'…'` literal, read back through
+// `Gda.DataModel.get_value_at()`). It failed under node-gi because the read
+// returns a boxed `GdaBinary` handle (exactly as GJS does — verified), and the
+// reader's `if (typeof value.toArray === 'function')` duck-type check falsely
+// matched: node-gi's boxed-handle Proxy used to fabricate a method for ANY name,
+// so `typeof handle.toArray === 'function'` was true (it is `'undefined'` on
+// GJS), and calling the non-existent `toArray()` threw → `get()` swallowed it →
+// the row read as `undefined`. Fixed in @gjsify/node-gi's boxed Proxy (gi.js):
+// a name that is neither a method nor a field now yields `undefined`, matching
+// GJS. The distinct byte-array GValue marshalling (GByteArray ↔ Uint8Array) was
+// also brought to GJS parity in the same change. No @gjsify/sqlite change needed.
+run({ testSuiteDatabaseSync, testSuiteStatementSync, testSuiteDataTypes });


### PR DESCRIPTION
Closes the last three marshalling-correctness gaps, each verified byte-for-byte against `gjs 1.88`. **`@gjsify/sqlite`'s node-gi suite reaches 52/52.**

## Gap 1 — empty Uint8Array as an IN byte container (`marshal.cc`)
An empty `Uint8Array` threw `expected an array` (empty `[]` already worked) — an empty typed array has a NULL backing pointer that defeated the byte fast-path. Now tracks `hasRawBytes` (a TypedArray *source* is valid at length 0) and guards the copy on `rawLen>0`. gjs: `GLib.base64_encode(new Uint8Array([]))` → `""` — matched.

## Gap 2 — byte-array GValue / Gda BLOB (the premise was wrong; verified vs gjs)
A Gda BLOB `get_value_at()` returns a boxed **`Gda_Binary`** handle on **both** gjs and node-gi (NOT a Uint8Array), and `holder.set_value(bareUint8Array)` **throws** on gjs too — so the marshaller already matched gjs. The real sqlite failure was the **L1 boxed-handle Proxy** (`gi.js`) fabricating phantom methods (`typeof handle.toArray === 'function'` where gjs gives `undefined`), so the sqlite reader called a nonexistent method and the row read as `undefined`. Fix: `BoxedMemberKind` returns `3` (unresolvable type info → keep the dispatcher) vs `0` (authoritative non-member → the trap returns `undefined`), matching gjs. Also brought `G_TYPE_BYTE_ARRAY` GValue ↔ Buffer/Uint8Array to gjs parity (`object.cc`); `G_TYPE_BYTES` stays a GLib.Bytes handle (as gjs).

## Gap 3 — INOUT containers (`calls.cc` + `class.cc`, Phase 2.5)
Implemented for function-invoke **and** `super.vfunc` chain-up (array / GList / GSList / GPtrArray / GHashTable / GByteArray), read-modify-write with correct per-transfer ownership + INOUT length wiring + nullable INOUT. gjs-verified: `array_inout` → `[-2,-1,0,1,2]`, `init_function(['--foo','--bar'])` → `[true,['--foo']]`, `bytearray_full_inout`, garray/glist/gslist/gptrarray/ghashtable inout, etc.

## Specs & tests
- gimarshalling **343 → 366 pass** (+23 INOUT specs un-skipped); kept-skipped exactly as gjs skips them (gi#192, gjs#44/#271/#106) with precise reasons; two obsolete "INOUT deferred" tests rewritten to assert the now-working behavior.
- `@gjsify/sqlite` node-gi suite **52/52** — removed the one BLOB skip in `test.node-gi.mts` (only consumer change).
- New `test/marshalling-close.test.mjs` (gjs byte-parity, libgda-gated BLOB oracle). No Gda conformance program (base CI lacks libgda).

## Test plan
- [x] rebuild 0 warnings · `npm test` 291/0 · `test:gimarshalling` 366/0/77 · `test:conformance` 14 programs × 4 runtimes · `test:bun`/`test:deno` 33/33 · sqlite node-gi suite green
- [x] **valgrind** 400-iter INOUT/GByteArray loop: no leaks in the new paths

Deviation: Gap 2's real fix landed in `gi.js` + `class.cc` (the boxed-Proxy divergence), not just `object.cc` — because the marshaller already matched gjs.