### PR TITLE
feat(node-gi): add Gio.DBus proxy + signals mixin

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -39,9 +39,11 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git gcc-c++ make python3 pkgconf-pkg-config tar xz unzip \
-            glib2-devel gobject-introspection-devel gobject-introspection gjs cairo-devel
+            glib2-devel gobject-introspection-devel gobject-introspection gjs cairo-devel \
+            dbus-daemon
           gjs --version
           echo "girepository-2.0: $(pkg-config --modversion girepository-2.0)"
+          echo "dbus-run-session: $(command -v dbus-run-session)"
 
       # Use the official nodejs.org build, NOT Fedora's `dnf nodejs`: the Fedora
       # package segfaults rolldown's prebuilt napi binding (the gjsify bundler
@@ -82,6 +84,17 @@ jobs:
       - name: Smoke test (node --test)
         working-directory: packages/node-gi/node-gi
         run: npm test
+
+      # DBus leg: the Gio.DBus client surface (makeProxyWrapper + name owning +
+      # a live signal round-trip) needs a session bus — no display required, so it
+      # runs here under a throwaway private bus (dbus-run-session, from the
+      # dbus-daemon package added above). The test also spawns `gjs -m` against its
+      # OWN private bus and asserts the normalized round-trip is byte-identical
+      # (gjs is the gold standard). The default `npm test` above self-skips these
+      # cases when no bus is reachable, so this is the leg that exercises them.
+      - name: DBus test (dbus-run-session)
+        working-directory: packages/node-gi/node-gi
+        run: npm run test:dbus
 
       # GC-stress leg: the toggle-ref instance bridge (wrapper identity,
       # collectability, toggle-up rooting, resurrection, signal-cycle, soak) only

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -56,7 +56,17 @@ interface _CountedError {
     __testFailureCounted?: boolean;
 }
 
-const mainloop: GLib.MainLoop | undefined = runtimeGlobals().imports?.mainloop;
+// Decide the run/exit strategy by the ACTUAL runtime, NOT by `imports.mainloop`
+// presence. GJS drives async tests by blocking on `imports.mainloop.run()` and
+// quitting from a callback; Node/Bun/Deno instead exit via `process.exit()` after
+// the (promise-based) run settles. `@gjsify/node-gi` now legitimately provides
+// `imports.mainloop` on Node too (a GJS-compat feature), so keying on its presence
+// would wrongly send node-gi consumers down the GJS path — a blocking mainloop
+// whose quit (queued as a promise continuation) never drains under the blocking
+// loop, so the process hangs forever. Gate on `process.versions.gjs` (the same
+// signal getRuntime() uses) so only real GJS runs the blocking mainloop.
+const mainloop: GLib.MainLoop | undefined =
+    typeof runtimeGlobals().process?.versions?.gjs === 'string' ? runtimeGlobals().imports?.mainloop : undefined;
 
 let countTestsOverall = 0;
 let countTestsFailed = 0;

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -437,6 +437,50 @@ a JS↔GObject reference cycle on a custom instance leaks (the same cycle-leak
 caveat the signal/vfunc layer carries); and multi-level registered subclass
 chains (registering a subclass of a registered subclass) are not yet supported.
 
+#### `Gio.DBus` (client proxy + name owning)
+
+`requireGi('Gio')` carries the GJS DBus surface. The **client** half is complete:
+`Gio.DBusProxy.makeProxyWrapper(interfaceXml)` parses the interface XML and returns
+a proxy constructor whose instances expose each method as `NameSync` (sync),
+`NameRemote` (raw async callback) and `NameAsync` (Promise), each property as a
+getter/setter, and each signal via `connectSignal` / `disconnectSignal` (the same
+pure-JS `_signals` mixin GJS uses). `Gio.DBus.session` / `Gio.DBus.system` are the
+bus getters; `Gio.DBus.own_name` / `unown_name` / `watch_name` / `unwatch_name`
+own and watch bus names.
+
+```js
+const Gio = requireGi('Gio', '2.0');
+
+const Proxy = Gio.DBusProxy.makeProxyWrapper(`<node>
+  <interface name="org.freedesktop.DBus">
+    <method name="GetId"><arg type="s" direction="out"/></method>
+    <signal name="NameOwnerChanged"><arg type="s"/><arg type="s"/><arg type="s"/></signal>
+  </interface>
+</node>`);
+
+const proxy = new Proxy(Gio.DBus.session, 'org.freedesktop.DBus', '/org/freedesktop/DBus');
+const [busId] = proxy.GetIdSync();                 // synchronous method
+proxy.GetIdRemote((result, error) => { /* … */ }); // async, raw callback
+const [id2] = await proxy.GetIdAsync();            // async, Promise (drains after run())
+proxy.connectSignal('NameOwnerChanged', (p, sender, [name, oldOwner, newOwner]) => { /* … */ });
+
+const id = Gio.DBus.own_name(Gio.BusType.SESSION, 'org.example.App',
+  Gio.BusNameOwnerFlags.NONE, null, (conn, name) => { /* acquired */ }, null);
+```
+
+A blocking `GLib.MainLoop.run()` drives the async replies / signals / name
+callbacks (they fire from the loop, as under GJS). Two DBus divergences to know:
+(1) a `NameAsync` **Promise** `.then` does not drain *while* a node-gi loop blocks
+(node-gtk #442/#121) — the reply still fires and settles the Promise, so it
+resolves once `run()` returns; drive an async method inside the loop through the
+raw `NameRemote` callback. (2) **Object export** (`Gio.DBusExportedObject.wrapJSObject`
+— exporting a JS object AS a DBus service) is **not yet supported**: GJS builds it
+on `GjsPrivate.DBusImplementation` (a GJS-internal C type, absent on a plain Node/GI
+host), the introspectable `register_object_with_closures` needs GClosure
+IN-arguments the engine cannot yet marshal, and `register_object` takes a
+non-introspectable vtable — so `wrapJSObject` throws a clear, actionable error
+rather than crashing.
+
 ### GJS ambient globals (`@gjsify/node-gi/globals`)
 
 GJS source relies on globals that exist implicitly under `gjs` — `print`,
@@ -451,6 +495,13 @@ print('hello', 1, true);                 // → stdout, GJS String()-join
 const GLib = imports.gi.GLib;            // legacy imports.gi (honours .versions)
 imports.gi.versions.Gtk = '4.0';
 console.log(imports.gettext.gettext('x')); // no-translation passthrough
+
+// Legacy script modules many older GJS sources use:
+const emitter = {};
+imports.signals.addSignalMethods(emitter);      // the pure-JS Signals mixin
+emitter.connect('ready', () => imports.mainloop.quit());
+imports.mainloop.timeout_add(50, () => { emitter.emit('ready'); return false; });
+imports.mainloop.run();                          // thin GLib.MainLoop wrapper
 ```
 
 A follow-up `--app node` build step will inject this automatically for any

--- a/packages/node-gi/node-gi/dbus/gjs-harness.js
+++ b/packages/node-gi/node-gi/dbus/gjs-harness.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// Gold-standard harness: runs the shared DBus scenario under gjs (`gjs -m`) and
+// prints `RESULT=<json>`. dbus.test.mjs spawns this under a private session bus
+// and asserts the normalized result equals the node-gi run's — the byte-for-byte
+// gjs cross-check. Kept a plain `.js` run via `gjs -m` (ESM).
+import Gio from 'gi://Gio?version=2.0';
+import GLib from 'gi://GLib?version=2.0';
+import { runScenario } from './scenario.mjs';
+
+const result = runScenario({ Gio, GLib });
+print(`RESULT=${JSON.stringify(result)}`);

--- a/packages/node-gi/node-gi/dbus/scenario.mjs
+++ b/packages/node-gi/node-gi/dbus/scenario.mjs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+// Shared DBus round-trip scenario for @gjsify/node-gi, parameterized by the Gio +
+// GLib namespaces so the SAME source runs on gjs (`gi://` via ./gjs-harness.js)
+// and node-gi (`requireGi` via ../test/dbus.test.mjs). It lives OUTSIDE test/ so
+// `node --test` (which globs every file under test/) never tries to evaluate the
+// gi://-importing harness. The result is normalized to a
+// deterministic shape (no bus UUID / no unique connection name) so the two
+// runtimes compare byte-for-byte — gjs is the gold standard.
+//
+// It exercises the CLIENT half of the DBus surface against the always-present
+// org.freedesktop.DBus service (no object export needed):
+//   • makeProxyWrapper → sync method (GetIdSync), async method via the raw remote
+//     callback (GetIdRemote), array-returning method (ListNamesSync),
+//   • name owning (Gio.DBus.own_name → onNameAcquired fires),
+//   • a live signal round-trip (connectSignal('NameOwnerChanged') fires when we
+//     own the name),
+//   • NameHasOwner before/after owning.
+//
+// The async method is driven through the RAW remote callback (GetIdRemote), NOT
+// the Promise variant (GetIdAsync): a Promise `.then` continuation does not drain
+// under a blocking node-gi GLib loop (node-gtk #442/#121), so a cross-runtime,
+// loop-driven scenario must use the callback form. GetIdAsync's Promise variant is
+// covered separately in dbus.test.mjs.
+
+export const EXPECTED = {
+  surface: {
+    GetIdSync: 'function',
+    GetIdRemote: 'function',
+    GetIdAsync: 'function',
+    NameHasOwnerSync: 'function',
+    ListNamesSync: 'function',
+    connectSignal: 'function',
+    disconnectSignal: 'function',
+  },
+  getIdSyncHex: true,
+  hasOwnerBefore: false,
+  hasOwnerAfter: true,
+  getIdRemoteHex: true,
+  listNamesHasDBus: true,
+  signalReceived: [true, true],
+  acquiredFired: true,
+};
+
+const DBUS_XML = `<node>
+<interface name="org.freedesktop.DBus">
+  <method name="GetId"><arg type="s" direction="out"/></method>
+  <method name="NameHasOwner"><arg type="s" direction="in"/><arg type="b" direction="out"/></method>
+  <method name="ListNames"><arg type="as" direction="out"/></method>
+  <signal name="NameOwnerChanged"><arg type="s"/><arg type="s"/><arg type="s"/></signal>
+</interface>
+</node>`;
+
+const HEX32 = /^[0-9a-f]{32}$/;
+
+/**
+ * Run the DBus client round-trip and return the normalized result object (matches
+ * EXPECTED on a working runtime). Blocks on a GLib main loop until the round-trip
+ * completes. A unique bus name (per process) keeps concurrent runs isolated; it is
+ * normalized out of the result.
+ * @param {{ Gio: any, GLib: any }} ns
+ * @returns {object}
+ */
+export function runScenario({ Gio, GLib }) {
+  const uniqueName = `org.gjsify.nodegi.DBusTest.p${(typeof process !== 'undefined' && process.pid) || 0}n${Math.floor(Math.random() * 1e6)}`;
+
+  const ProxyClass = Gio.DBusProxy.makeProxyWrapper(DBUS_XML);
+  const proxy = new ProxyClass(Gio.DBus.session, 'org.freedesktop.DBus', '/org/freedesktop/DBus');
+
+  const result = {
+    surface: {},
+    getIdSyncHex: null,
+    hasOwnerBefore: null,
+    hasOwnerAfter: null,
+    getIdRemoteHex: null,
+    listNamesHasDBus: null,
+    signalReceived: null,
+    acquiredFired: false,
+  };
+  for (const k of ['GetIdSync', 'GetIdRemote', 'GetIdAsync', 'NameHasOwnerSync', 'ListNamesSync', 'connectSignal', 'disconnectSignal']) {
+    result.surface[k] = typeof proxy[k];
+  }
+
+  const [id] = proxy.GetIdSync();
+  result.getIdSyncHex = HEX32.test(id);
+  result.hasOwnerBefore = proxy.NameHasOwnerSync(uniqueName)[0];
+
+  const loop = GLib.MainLoop.new(null, false);
+
+  const handlerId = proxy.connectSignal('NameOwnerChanged', (_proxy, _senderName, args) => {
+    if (args[0] === uniqueName) {
+      // [old owner was empty, new owner is non-empty] → we just acquired it.
+      result.signalReceived = [args[1] === '', args[2] !== ''];
+    }
+  });
+
+  Gio.DBus.own_name(
+    Gio.BusType.SESSION,
+    uniqueName,
+    Gio.BusNameOwnerFlags.NONE,
+    null,
+    () => {
+      result.acquiredFired = true;
+    },
+    null,
+  );
+
+  // Give the async name acquisition + signal delivery a moment, then finish the
+  // round-trip with an array method + a raw-callback async method, and quit.
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 600, () => {
+    result.hasOwnerAfter = proxy.NameHasOwnerSync(uniqueName)[0];
+    const names = proxy.ListNamesSync()[0];
+    result.listNamesHasDBus = Array.isArray(names) && names.includes('org.freedesktop.DBus');
+    proxy.GetIdRemote((res, err) => {
+      result.getIdRemoteHex = !err && HEX32.test(res[0]);
+      proxy.disconnectSignal(handlerId);
+      loop.quit();
+    });
+    return false; // G_SOURCE_REMOVE
+  });
+
+  loop.run();
+  return result;
+}

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -20,6 +20,9 @@ import * as native from './index.js';
 // node:timers import; Bun/Node re-export it there too), so import it for the
 // macrotask-deferred runAsync to work on all three runtimes.
 import { setImmediate } from 'node:timers';
+// The GJS Gio DBus surface (Gio.DBus.session/system, own_name/watch_name,
+// Gio.DBusProxy.makeProxyWrapper, Gio.DBusExportedObject) — ported to the L1 model.
+import { createGioDBus } from './overrides/gio-dbus.js';
 
 // Symbol carrying the raw native GObject handle on a wrapped instance, so it can
 // be unwrapped again when passed back into the engine as a GI argument.
@@ -460,16 +463,37 @@ function decorateGLibNamespace(baseNs) {
 }
 
 // Overlay the GJS Gio runtime statics on the introspected Gio namespace —
-// additively. `_promisify` is the genuinely-new helper (refs/gjs Gio.js); every
-// other member keeps resolving from introspection.
+// additively. `_promisify` is the genuinely-new helper (refs/gjs Gio.js); the
+// DBus surface (Gio.DBus, Gio.DBusProxy.makeProxyWrapper, Gio.DBusExportedObject)
+// is built by createGioDBus (overrides/gio-dbus.js) over the introspected Gio +
+// the ergonomic GLib. Every other member keeps resolving from introspection.
 function decorateGioNamespace(baseNs) {
+  // Lazily construct the DBus surface: it needs the ergonomic GLib (`new
+  // GLib.Variant`), and building it only on first `Gio.DBus*` access keeps a plain
+  // `import Gio` (no DBus) from pulling GLib in.
+  let dbus;
+  const getDBus = () => {
+    if (dbus === undefined) {
+      dbus = createGioDBus({ Gio: baseNs, GLib: requireGi('GLib', '2.0'), unwrap: unwrapArg, native });
+    }
+    return dbus;
+  };
   return new Proxy(baseNs, {
     get(t, prop) {
       if (prop === '_promisify') return promisify;
+      if (prop === 'DBus') return getDBus().DBus;
+      if (prop === 'DBusProxy') return getDBus().DBusProxy;
+      if (prop === 'DBusExportedObject') return getDBus().DBusExportedObject;
       return t[prop];
     },
     has(t, prop) {
-      return prop === '_promisify' || prop in t;
+      return (
+        prop === '_promisify' ||
+        prop === 'DBus' ||
+        prop === 'DBusProxy' ||
+        prop === 'DBusExportedObject' ||
+        prop in t
+      );
     },
   });
 }

--- a/packages/node-gi/node-gi/globals.js
+++ b/packages/node-gi/node-gi/globals.js
@@ -19,6 +19,10 @@ import { requireGi } from './gi.js';
 import system from './system.js';
 import gettext from './gettext.js';
 import cairo from './cairo.js';
+// Legacy `imports.signals` (the pure-JS Signals mixin) + `imports.mainloop` (the
+// GLib.MainLoop convenience layer) — the GJS script modules many older sources use.
+import * as signalsModule from './overrides/_signals.js';
+import { createMainloop } from './overrides/mainloop.js';
 
 // GJS stringifies each argument with String() and joins with a space (no
 // util.inspect object formatting) — match that for fidelity.
@@ -91,7 +95,32 @@ function makeImports() {
   // module objects (`./system.js` / `./gettext.js` / `./cairo.js`) — the single
   // source of truth for those surfaces, shared with the bare `system` / `gettext` /
   // `cairo` specifiers on Node.
-  return { gi, system, gettext, cairo, versions: Object.create(null) };
+  //
+  // `imports.signals` is the pure-JS Signals mixin (`addSignalMethods` + the
+  // `_connect`/`_disconnect`/`_emit`/… primitives), the SAME module the DBus proxy
+  // surface uses. `imports.mainloop` (a lazy getter — it needs GLib, and a source
+  // that never touches the main loop should not pull GLib in) is the thin
+  // GLib.MainLoop convenience layer.
+  const { addSignalMethods, _connect, _connectAfter, _disconnect, _emit, _signalHandlerIsConnected, _disconnectAll } =
+    signalsModule;
+  const imports = {
+    gi,
+    system,
+    gettext,
+    cairo,
+    signals: { addSignalMethods, _connect, _connectAfter, _disconnect, _emit, _signalHandlerIsConnected, _disconnectAll },
+    versions: Object.create(null),
+  };
+  let mainloop;
+  Object.defineProperty(imports, 'mainloop', {
+    get() {
+      if (mainloop === undefined) mainloop = createMainloop(requireGi('GLib', '2.0'));
+      return mainloop;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  return imports;
 }
 
 // Side effect on import: seed the globals.

--- a/packages/node-gi/node-gi/overrides/_signals.js
+++ b/packages/node-gi/node-gi/overrides/_signals.js
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+// SPDX-FileCopyrightText: 2008 litl, LLC
+// SPDX-FileCopyrightText: 2022 Canonical Ltd.
+//
+// Adapted from GJS (refs/gjs/modules/core/_signals.js). Copyright (c) 2008
+// litl, LLC; 2022 Canonical Ltd. MIT OR LGPL-2.0-or-later.
+// Modifications: ported near-verbatim as an ESM module for @gjsify/node-gi; the
+// individual `_connect`/`_disconnect`/`_emit`/… functions are named-exported so
+// both the DBus proxy surface (overrides/gio-dbus.js) and the legacy
+// `imports.signals` (globals.js) reuse the SAME mixin, exactly as GJS does.
+//
+// A couple principals of this simple signal system:
+// 1) should look just like our GObject signal binding
+// 2) memory and safety matter more than speed of connect/disconnect/emit
+// 3) the expectation is that a given object will have a very small number of
+//    connections, but they may be to different signal names
+
+function _connectFull(name, callback, after) {
+  // be paranoid about callback arg since we'd start to throw from emit()
+  // if it was messed up
+  if (typeof callback !== 'function')
+    throw new Error('When connecting signal must give a callback that is a function');
+
+  // we instantiate the "signal machinery" only on-demand if anything
+  // gets connected.
+  if (this._signalConnections === undefined) {
+    this._signalConnections = Object.create(null);
+    this._signalConnectionsByName = Object.create(null);
+    this._nextConnectionId = 1;
+  }
+
+  const id = this._nextConnectionId;
+  this._nextConnectionId += 1;
+
+  this._signalConnections[id] = {
+    name,
+    callback,
+    after,
+  };
+
+  const connectionsByName = this._signalConnectionsByName[name] ?? [];
+
+  if (!connectionsByName.length)
+    this._signalConnectionsByName[name] = connectionsByName;
+  connectionsByName.push(id);
+
+  return id;
+}
+
+export function _connect(name, callback) {
+  return _connectFull.call(this, name, callback, false);
+}
+
+export function _connectAfter(name, callback) {
+  return _connectFull.call(this, name, callback, true);
+}
+
+export function _disconnect(id) {
+  const connection = this._signalConnections?.[id];
+
+  if (!connection)
+    throw new Error(`No signal connection ${id} found`);
+
+  if (connection.disconnected)
+    throw new Error(`Signal handler id ${id} already disconnected`);
+
+  connection.disconnected = true;
+  delete this._signalConnections[id];
+
+  const ids = this._signalConnectionsByName[connection.name];
+  if (!ids)
+    return;
+
+  const indexOfId = ids.indexOf(id);
+  if (indexOfId !== -1)
+    ids.splice(indexOfId, 1);
+
+  if (ids.length === 0)
+    delete this._signalConnectionsByName[connection.name];
+}
+
+export function _signalHandlerIsConnected(id) {
+  const connection = this._signalConnections?.[id];
+  return !!connection && !connection.disconnected;
+}
+
+export function _disconnectAll() {
+  Object.values(this._signalConnections ?? {}).forEach(c => (c.disconnected = true));
+  delete this._signalConnections;
+  delete this._signalConnectionsByName;
+}
+
+export function _emit(name, ...args) {
+  const connections = this._signalConnectionsByName?.[name];
+
+  // may not be any signal handlers at all, if not then return
+  if (!connections)
+    return;
+
+  // To deal with re-entrancy (removal/addition while
+  // emitting), we copy out a list of what was connected
+  // at emission start; and just before invoking each
+  // handler we check its disconnected flag.
+  const handlers = connections.map(id => this._signalConnections[id]);
+
+  // create arg array which is emitter + everything passed in except
+  // signal name. Would be more convenient not to pass emitter to
+  // the callback, but trying to be 100% consistent with GObject
+  // which does pass it in. Also if we pass in the emitter here,
+  // people don't create closures with the emitter in them,
+  // which would be a cycle.
+  const argArray = [this, ...args];
+
+  const afterHandlers = [];
+  const beforeHandlers = handlers.filter(c => {
+    if (!c.after)
+      return true;
+
+    afterHandlers.push(c);
+    return false;
+  });
+
+  if (!_callHandlers(beforeHandlers, argArray))
+    _callHandlers(afterHandlers, argArray);
+}
+
+function _callHandlers(handlers, argArray) {
+  for (const handler of handlers) {
+    if (handler.disconnected)
+      continue;
+
+    try {
+      // since we pass "null" for this, the global object will be used.
+      const ret = handler.callback.apply(null, argArray);
+
+      // if the callback returns true, we don't call the next
+      // signal handlers
+      if (ret === true)
+        return true;
+    } catch (e) {
+      // just log any exceptions so that callbacks can't disrupt
+      // signal emission
+      logError(e, `Exception in callback for signal: ${handler.name}`);
+    }
+  }
+
+  return false;
+}
+
+function _addSignalMethod(proto, functionName, func) {
+  if (proto[functionName] && proto[functionName] !== func)
+    log(`WARNING: addSignalMethods is replacing existing ${proto} ${functionName} method`);
+
+  proto[functionName] = func;
+}
+
+export function addSignalMethods(proto) {
+  _addSignalMethod(proto, 'connect', _connect);
+  _addSignalMethod(proto, 'connectAfter', _connectAfter);
+  _addSignalMethod(proto, 'disconnect', _disconnect);
+  _addSignalMethod(proto, 'emit', _emit);
+  _addSignalMethod(proto, 'signalHandlerIsConnected', _signalHandlerIsConnected);
+  // this one is not in GObject, but useful
+  _addSignalMethod(proto, 'disconnectAll', _disconnectAll);
+}
+
+export default { addSignalMethods, _connect, _connectAfter, _disconnect, _emit, _signalHandlerIsConnected, _disconnectAll };

--- a/packages/node-gi/node-gi/overrides/gio-dbus.js
+++ b/packages/node-gi/node-gi/overrides/gio-dbus.js
@@ -1,0 +1,526 @@
+// SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+// SPDX-FileCopyrightText: 2011 Giovanni Campagna
+//
+// Adapted from GJS (refs/gjs/modules/core/overrides/Gio.js). Copyright (c) 2011
+// Giovanni Campagna and GJS contributors. MIT OR LGPL-2.0-or-later.
+// Modifications: the DBus surface (Gio.DBus.session/system, own_name/watch_name,
+// Gio.DBusProxy.makeProxyWrapper) ported to the @gjsify/node-gi L1 model.
+//
+// The upstream override patches `Gio.DBusProxy.prototype` and returns a class
+// extending Gio.DBusProxy. node-gi instances are Proxies over a native GObject
+// handle (no live prototype to patch, and an unknown property READ returns a GI
+// method thunk rather than `undefined`), so this port instead:
+//   • builds each proxy's convenience methods/properties as own expandos on the
+//     instance (node-gi's set trap stores them; the get trap surfaces them),
+//   • hosts the `_signals` mixin on a DEDICATED plain emitter object per proxy
+//     (the mixin's `this._signalConnections === undefined` bootstrap can't run on
+//     an instance wrapper — see above), exposed as `connectSignal`/`disconnectSignal`,
+//   • drives name owning via org.freedesktop.DBus RequestName/ReleaseName and name
+//     watching via NameOwnerChanged `signal_subscribe` — the node-gi engine can
+//     marshal a GDBusSignalCallback and a GSourceFunc (idle), but NOT the
+//     GBusAcquiredCallback/GBusNameAppearedCallback that g_bus_own_name/watch_name
+//     take, so those namespace functions are re-implemented in JS here.
+//
+// DEFERRED — object export (Gio.DBusExportedObject.wrapJSObject): GJS builds it on
+// GjsPrivate.DBusImplementation (a C type absent on a plain Node/GI host); the
+// introspectable alternative g_dbus_connection_register_object_with_closures needs
+// GClosure IN-arguments the node-gi engine cannot yet marshal, and the plain
+// register_object takes a non-introspectable vtable. wrapJSObject therefore throws
+// a clear, actionable error (never crashes).
+import { addSignalMethods, _connect, _disconnect, _emit } from './_signals.js';
+
+// The `_signals` mixin's error paths (a throwing handler / a method-name clash)
+// reference the GJS ambient `log`/`logError`. Under a bare `@gjsify/node-gi/gi`
+// consumer (no globals.js) those may be absent — install minimal fallbacks so the
+// mixin never ReferenceErrors. Idempotent; globals.js's richer versions win if
+// already present.
+function ensureAmbientLog() {
+  const g = globalThis;
+  if (typeof g.log === 'undefined') g.log = (...args) => console.error(args.map((a) => String(a)).join(' '));
+  if (typeof g.logError === 'undefined') {
+    g.logError = (error, prefix) => {
+      const head = prefix ? `${prefix}: ` : '';
+      console.error(head + (error && error.stack ? error.stack : String(error)));
+    };
+  }
+}
+
+/**
+ * Build the L1 DBus surface bound to a set of node-gi primitives.
+ * @param {object} ctx
+ * @param {Record<string, unknown>} ctx.Gio the INTROSPECTED Gio namespace (constructible classes + namespace functions)
+ * @param {Record<string, unknown>} ctx.GLib the ergonomic GLib namespace (`new GLib.Variant(...)`, idle_add)
+ * @param {(fn: Function, ...args: unknown[]) => void} ctx.unwrap gi.js's `unwrap` (wrapped instance → native handle)
+ * @param {typeof import('../index.js')} ctx.native the native engine (isInstanceOf)
+ * @returns {{ DBus: object, DBusProxy: object, DBusExportedObject: object }}
+ */
+export function createGioDBus(ctx) {
+  const { Gio, GLib, unwrap, native } = ctx;
+  // Scoped to actual DBus usage (first Gio.DBus* access), so a plain non-DBus
+  // `import { requireGi }` adds no global side effects.
+  ensureAmbientLog();
+
+  // DBus RequestName reply codes (org.freedesktop.DBus).
+  const REQUEST_NAME_PRIMARY_OWNER = 1;
+  const REQUEST_NAME_ALREADY_OWNER = 4;
+  const DBUS_NAME = 'org.freedesktop.DBus';
+  const DBUS_PATH = '/org/freedesktop/DBus';
+
+  function safeCallback(fn, ...args) {
+    try {
+      fn(...args);
+    } catch (e) {
+      logError(e, 'Exception in DBus name callback');
+    }
+  }
+
+  // Is `value` a wrapped node-gi instance of Gio.<typeName>? Used to classify the
+  // trailing flags/Cancellable/UnixFDList args a proxy method call may carry.
+  function isGioInstance(value, typeName) {
+    if (value === null || typeof value !== 'object') return false;
+    const handle = unwrap(value);
+    if (handle === value) return false; // not a wrapped instance
+    try {
+      return native.isInstanceOf(handle, 'Gio', typeName);
+    } catch {
+      return false;
+    }
+  }
+
+  function _logReply(result, exc) {
+    if (exc !== null && exc !== undefined) log(`Ignored exception from dbus method: ${exc}`);
+  }
+
+  // Ported from refs/gjs Gio.js `_proxyInvoker`. `wrappedProxy` is captured (GJS
+  // uses `this`) because node-gi delivers a RAW source handle to the async ready
+  // callback, so the wrapper must come from the closure to reach the L1 finish.
+  function _proxyInvoker(wrappedProxy, methodName, sync, inSignature, args) {
+    let replyFunc = _logReply;
+    let flags = 0;
+    let cancellable = null;
+    let fdList = null;
+    const argArray = Array.prototype.slice.call(args);
+
+    const signatureLength = inSignature.length;
+    const minNumberArgs = signatureLength;
+    const maxNumberArgs = signatureLength + 4;
+    if (argArray.length < minNumberArgs) {
+      throw new Error(
+        `Not enough arguments passed for method: ${methodName}. Expected ${minNumberArgs}, got ${argArray.length}`,
+      );
+    } else if (argArray.length > maxNumberArgs) {
+      throw new Error(
+        `Too many arguments passed for method ${methodName}. Maximum is ${maxNumberArgs} ` +
+          'including one callback, Gio.Cancellable, Gio.UnixFDList, and/or flags',
+      );
+    }
+
+    while (argArray.length > signatureLength) {
+      const argNum = argArray.length - 1;
+      const arg = argArray.pop();
+      if (typeof arg === 'function' && !sync) replyFunc = arg;
+      else if (typeof arg === 'number') flags = arg;
+      else if (isGioInstance(arg, 'Cancellable')) cancellable = arg;
+      else if (isGioInstance(arg, 'UnixFDList')) fdList = arg;
+      else {
+        throw new Error(
+          `Argument ${argNum} of method ${methodName} is ${typeof arg}. It should be a callback, ` +
+            'flags, Gio.UnixFDList, or a Gio.Cancellable',
+        );
+      }
+    }
+
+    const inTypeString = `(${inSignature.join('')})`;
+    const inVariant = new GLib.Variant(inTypeString, argArray);
+
+    if (sync) {
+      const result = wrappedProxy.call_with_unix_fd_list_sync(methodName, inVariant, flags, -1, fdList, cancellable);
+      const outVariant = Array.isArray(result) ? result[0] : result;
+      const outFdList = Array.isArray(result) ? result[1] : null;
+      if (fdList) return [outVariant.deepUnpack(), outFdList];
+      return outVariant.deepUnpack();
+    }
+
+    const asyncCallback = (_rawSource, res) => {
+      try {
+        const result = wrappedProxy.call_with_unix_fd_list_finish(res);
+        const outVariant = Array.isArray(result) ? result[0] : result;
+        const outFdList = Array.isArray(result) ? result[1] : null;
+        replyFunc(outVariant.deepUnpack(), null, outFdList);
+      } catch (e) {
+        replyFunc([], e, null);
+      }
+    };
+    return wrappedProxy.call_with_unix_fd_list(methodName, inVariant, flags, -1, fdList, cancellable, asyncCallback);
+  }
+
+  function _makeProxyMethod(wrappedProxy, method, sync) {
+    const name = method.name;
+    const inArgs = method.in_args;
+    const inSignature = [];
+    for (let i = 0; i < inArgs.length; i++) inSignature.push(inArgs[i].signature);
+    return function proxyMethod(...args) {
+      return _proxyInvoker(wrappedProxy, name, sync, inSignature, args);
+    };
+  }
+
+  function _propertyGetter(wrappedProxy, name) {
+    const value = wrappedProxy.get_cached_property(name);
+    return value ? value.deepUnpack() : null;
+  }
+
+  function _propertySetter(wrappedProxy, name, signature, value) {
+    const variant = new GLib.Variant(signature, value);
+    wrappedProxy.set_cached_property(name, variant);
+    wrappedProxy.call(
+      'org.freedesktop.DBus.Properties.Set',
+      new GLib.Variant('(ssv)', [wrappedProxy.g_interface_name, name, variant]),
+      Gio.DBusCallFlags.NONE,
+      -1,
+      null,
+      (_rawSource, res) => {
+        try {
+          wrappedProxy.call_finish(res);
+        } catch (e) {
+          log(`Could not set property ${name} on remote object ${wrappedProxy.g_object_path}: ${e.message}`);
+        }
+      },
+    );
+  }
+
+  // Attach the method/property/signal convenience to a freshly-inited DBusProxy
+  // instance wrapper. Ported from refs/gjs Gio.js `_addDBusConvenience`.
+  function _addDBusConvenience(wrappedProxy, info) {
+    // The `_signals` mixin bookkeeping lives on a dedicated plain emitter (see the
+    // module header): connectSignal/disconnectSignal delegate to it.
+    const emitter = {};
+    addSignalMethods(emitter);
+    wrappedProxy.connectSignal = (name, callback) => _connect.call(emitter, name, callback);
+    wrappedProxy.disconnectSignal = (id) => _disconnect.call(emitter, id);
+
+    const signals = info.signals;
+    if (signals && signals.length > 0) {
+      wrappedProxy.connect('g-signal', (_proxy, senderName, signalName, parameters) => {
+        _emit.call(emitter, signalName, senderName, parameters.deepUnpack());
+      });
+    }
+
+    const methods = info.methods;
+    for (let i = 0; i < methods.length; i++) {
+      const method = methods[i];
+      const name = method.name;
+      const remoteMethod = _makeProxyMethod(wrappedProxy, method, false);
+      wrappedProxy[`${name}Remote`] = remoteMethod;
+      wrappedProxy[`${name}Sync`] = _makeProxyMethod(wrappedProxy, method, true);
+      wrappedProxy[`${name}Async`] = function proxyAsyncMethod(...args) {
+        return new Promise((resolve, reject) => {
+          args.push((result, error, fdList) => {
+            if (error) reject(error);
+            else if (fdList) resolve([result, fdList]);
+            else resolve(result);
+          });
+          remoteMethod(...args);
+        });
+      };
+    }
+
+    const properties = info.properties;
+    for (let i = 0; i < properties.length; i++) {
+      const propInfo = properties[i];
+      const name = propInfo.name;
+      const signature = propInfo.signature;
+      const propFlags = propInfo.flags;
+      let getter = () => {
+        throw new Error(`Property ${name} is not readable`);
+      };
+      let setter = () => {
+        throw new Error(`Property ${name} is not writable`);
+      };
+      if (propFlags & Gio.DBusPropertyInfoFlags.READABLE) getter = () => _propertyGetter(wrappedProxy, name);
+      if (propFlags & Gio.DBusPropertyInfoFlags.WRITABLE) {
+        setter = (value) => _propertySetter(wrappedProxy, name, signature, value);
+      }
+      Object.defineProperty(wrappedProxy, name, {
+        get: getter,
+        set: setter,
+        configurable: false,
+        enumerable: true,
+      });
+    }
+  }
+
+  function _newInterfaceInfo(xml) {
+    const nodeInfo = Gio.DBusNodeInfo.new_for_xml(xml);
+    return nodeInfo.interfaces[0];
+  }
+
+  // Gio.DBusProxy.makeProxyWrapper(interfaceXml). Returns a constructor:
+  //   new ProxyClass(bus, name, objectPath[, asyncCallback[, cancellable[, flags]]])
+  // and a static `ProxyClass.newAsync(bus, name, objectPath[, cancellable[, flags]])`.
+  function makeProxyWrapper(interfaceXml) {
+    const info = _newInterfaceInfo(interfaceXml);
+    const iname = info.name;
+
+    function ProxyClass(bus, name, object, asyncCallback, cancellable = null, flags = Gio.DBusProxyFlags.NONE) {
+      const obj = new Gio.DBusProxy({
+        g_connection: bus,
+        g_interface_name: iname,
+        g_interface_info: info,
+        g_name: name,
+        g_flags: flags,
+        g_object_path: object,
+      });
+
+      if (asyncCallback) {
+        obj.init_async(GLib.PRIORITY_DEFAULT, cancellable, (_rawSource, res) => {
+          try {
+            obj.init_finish(res);
+            _addDBusConvenience(obj, info);
+            asyncCallback(obj, null);
+          } catch (e) {
+            asyncCallback(null, e);
+          }
+        });
+      } else {
+        obj.init(cancellable);
+        _addDBusConvenience(obj, info);
+      }
+      return obj;
+    }
+
+    ProxyClass.newAsync = function newAsync(bus, name, object, cancellable = null, flags = Gio.DBusProxyFlags.NONE) {
+      const obj = new Gio.DBusProxy({
+        g_connection: bus,
+        g_interface_name: info.name,
+        g_interface_info: info,
+        g_name: name,
+        g_flags: flags,
+        g_object_path: object,
+      });
+      return new Promise((resolve, reject) => {
+        obj.init_async(GLib.PRIORITY_DEFAULT, cancellable, (_rawSource, res) => {
+          try {
+            obj.init_finish(res);
+            _addDBusConvenience(obj, info);
+            resolve(obj);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    };
+
+    return ProxyClass;
+  }
+
+  // ---- name owning ----
+  const ownedNames = new Map();
+  const watchedNames = new Map();
+  let nextToken = 1;
+
+  function busConnection(busType) {
+    return Gio.bus_get_sync(busType, null);
+  }
+
+  function requestName(connection, name, flags) {
+    const reply = connection.call_sync(
+      DBUS_NAME,
+      DBUS_PATH,
+      DBUS_NAME,
+      'RequestName',
+      new GLib.Variant('(su)', [name, flags >>> 0]),
+      null,
+      Gio.DBusCallFlags.NONE,
+      -1,
+      null,
+    );
+    return reply.deepUnpack()[0];
+  }
+
+  function ownNameCore(connection, name, flags, onBusAcquired, onNameAcquired, onNameLost) {
+    const token = nextToken++;
+    ownedNames.set(token, { connection, name });
+    let code;
+    try {
+      code = requestName(connection, name, flags);
+    } catch (e) {
+      ownedNames.delete(token);
+      throw e;
+    }
+    // GJS fires the acquired/lost callbacks from the main loop, never synchronously.
+    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      if (typeof onBusAcquired === 'function') safeCallback(onBusAcquired, connection, name);
+      const acquired = code === REQUEST_NAME_PRIMARY_OWNER || code === REQUEST_NAME_ALREADY_OWNER;
+      if (acquired) {
+        if (typeof onNameAcquired === 'function') safeCallback(onNameAcquired, connection, name);
+      } else if (typeof onNameLost === 'function') {
+        safeCallback(onNameLost, connection, name);
+      }
+      return false; // G_SOURCE_REMOVE
+    });
+    return token;
+  }
+
+  function own_name(busType, name, flags, onBusAcquired, onNameAcquired, onNameLost) {
+    return ownNameCore(busConnection(busType), name, flags, onBusAcquired, onNameAcquired, onNameLost);
+  }
+
+  function own_name_on_connection(connection, name, flags, onNameAcquired, onNameLost) {
+    return ownNameCore(connection, name, flags, undefined, onNameAcquired, onNameLost);
+  }
+
+  function unown_name(token) {
+    const entry = ownedNames.get(token);
+    if (!entry) return;
+    ownedNames.delete(token);
+    try {
+      entry.connection.call_sync(
+        DBUS_NAME,
+        DBUS_PATH,
+        DBUS_NAME,
+        'ReleaseName',
+        new GLib.Variant('(s)', [entry.name]),
+        null,
+        Gio.DBusCallFlags.NONE,
+        -1,
+        null,
+      );
+    } catch {
+      /* connection already gone — nothing to release */
+    }
+  }
+
+  // ---- name watching (NameOwnerChanged subscription + GetNameOwner probe) ----
+  function getNameOwner(connection, name) {
+    try {
+      const reply = connection.call_sync(
+        DBUS_NAME,
+        DBUS_PATH,
+        DBUS_NAME,
+        'GetNameOwner',
+        new GLib.Variant('(s)', [name]),
+        null,
+        Gio.DBusCallFlags.NONE,
+        -1,
+        null,
+      );
+      return reply.deepUnpack()[0];
+    } catch {
+      return null; // NameHasNoOwner
+    }
+  }
+
+  function watchNameCore(connection, name, onNameAppeared, onNameVanished) {
+    const token = nextToken++;
+    let lastOwner = null;
+
+    const dispatch = () => {
+      const owner = getNameOwner(connection, name);
+      if (owner && owner.length > 0) {
+        if (owner !== lastOwner && typeof onNameAppeared === 'function') safeCallback(onNameAppeared, connection, name, owner);
+        lastOwner = owner;
+      } else {
+        if (lastOwner !== null && typeof onNameVanished === 'function') safeCallback(onNameVanished, connection, name);
+        lastOwner = null;
+      }
+    };
+
+    // arg0-filtered subscription: NameOwnerChanged whose first arg is `name`.
+    const subId = connection.signal_subscribe(
+      DBUS_NAME,
+      DBUS_NAME,
+      'NameOwnerChanged',
+      DBUS_PATH,
+      name,
+      Gio.DBusSignalFlags.NONE,
+      () => dispatch(),
+    );
+    watchedNames.set(token, { connection, subId });
+
+    // Initial state, delivered from the loop like g_bus_watch_name's GetNameOwner.
+    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      const owner = getNameOwner(connection, name);
+      if (owner && owner.length > 0) {
+        lastOwner = owner;
+        if (typeof onNameAppeared === 'function') safeCallback(onNameAppeared, connection, name, owner);
+      } else if (typeof onNameVanished === 'function') {
+        safeCallback(onNameVanished, connection, name);
+      }
+      return false; // G_SOURCE_REMOVE
+    });
+    return token;
+  }
+
+  function watch_name(busType, name, _flags, onNameAppeared, onNameVanished) {
+    return watchNameCore(busConnection(busType), name, onNameAppeared, onNameVanished);
+  }
+
+  function watch_name_on_connection(connection, name, _flags, onNameAppeared, onNameVanished) {
+    return watchNameCore(connection, name, onNameAppeared, onNameVanished);
+  }
+
+  function unwatch_name(token) {
+    const entry = watchedNames.get(token);
+    if (!entry) return;
+    watchedNames.delete(token);
+    try {
+      entry.connection.signal_unsubscribe(entry.subId);
+    } catch {
+      /* connection already gone */
+    }
+  }
+
+  // ---- Gio.DBus namespace ----
+  const DBus = {
+    get: Gio.bus_get,
+    get_finish: Gio.bus_get_finish,
+    get_sync: Gio.bus_get_sync,
+    own_name,
+    own_name_on_connection,
+    unown_name,
+    watch_name,
+    watch_name_on_connection,
+    unwatch_name,
+  };
+  Object.defineProperty(DBus, 'session', {
+    get() {
+      return Gio.bus_get_sync(Gio.BusType.SESSION, null);
+    },
+    enumerable: false,
+  });
+  Object.defineProperty(DBus, 'system', {
+    get() {
+      return Gio.bus_get_sync(Gio.BusType.SYSTEM, null);
+    },
+    enumerable: false,
+  });
+
+  // ---- Gio.DBusProxy (adds the static makeProxyWrapper to the introspected class) ----
+  const DBusProxy = new Proxy(Gio.DBusProxy, {
+    get(target, prop) {
+      if (prop === 'makeProxyWrapper') return makeProxyWrapper;
+      return target[prop];
+    },
+    has(target, prop) {
+      return prop === 'makeProxyWrapper' || prop in target;
+    },
+  });
+
+  // ---- Gio.DBusExportedObject (export side — DEFERRED, clear error) ----
+  function wrapJSObject() {
+    throw new Error(
+      '@gjsify/node-gi: Gio.DBusExportedObject.wrapJSObject (exporting a JS object as a DBus ' +
+        'service) is not yet supported. GJS builds it on GjsPrivate.DBusImplementation (a ' +
+        'GJS-internal C type, absent on a plain Node/GI host); the introspectable alternative ' +
+        'g_dbus_connection_register_object_with_closures needs GClosure IN-arguments the node-gi ' +
+        'engine cannot yet marshal, and g_dbus_connection_register_object takes a non-introspectable ' +
+        'vtable. The DBus CLIENT half (Gio.DBusProxy.makeProxyWrapper) and name owning/watching ' +
+        '(Gio.DBus.own_name / watch_name) ARE supported.',
+    );
+  }
+  const DBusExportedObject = { wrapJSObject };
+
+  return { DBus, DBusProxy, DBusExportedObject };
+}
+
+export default createGioDBus;

--- a/packages/node-gi/node-gi/overrides/mainloop.js
+++ b/packages/node-gi/node-gi/overrides/mainloop.js
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+// SPDX-FileCopyrightText: 2012 Giovanni Campagna <scampa.giovanni@gmail.com>
+//
+// Adapted from GJS (refs/gjs/modules/script/mainloop.js). Copyright (c) 2012
+// Giovanni Campagna. MIT OR LGPL-2.0-or-later.
+// Modifications: the legacy `imports.mainloop` — a thin convenience layer over
+// GLib.MainLoop — ported to @gjsify/node-gi. GJS builds the idle/timeout sources
+// via GObject.source_set_closure (a GClosure the node-gi engine cannot yet
+// marshal); this port routes through GLib.idle_add / GLib.timeout_add directly
+// (which the engine DOES marshal), keeping the same `imports.mainloop.*` surface.
+
+const DEFAULT_IDLE_PRIORITY = 200; // GLib.PRIORITY_DEFAULT_IDLE
+
+/**
+ * Build the `imports.mainloop` object bound to the L1 GLib namespace.
+ * @param {Record<string, any>} GLib
+ * @returns {{ run(name?: string): void, quit(name?: string): void, idle_add: Function, timeout_add: Function, timeout_add_seconds: Function, source_remove: Function }}
+ */
+export function createMainloop(GLib) {
+  const _mainLoops = Object.create(null);
+
+  function run(name = '') {
+    if (!_mainLoops[name]) _mainLoops[name] = GLib.MainLoop.new(null, false);
+    _mainLoops[name].run();
+  }
+
+  function quit(name = '') {
+    if (!_mainLoops[name]) throw new Error('No main loop with this id');
+
+    const loop = _mainLoops[name];
+    _mainLoops[name] = null;
+
+    if (!loop.is_running()) throw new Error('Main loop was stopped already');
+
+    loop.quit();
+  }
+
+  // GJS signature is `idle_add(handler, priority)` — handler first — whereas the
+  // introspected GLib.idle_add is `(priority, handler)`; bridge the argument order.
+  function idle_add(handler, priority = DEFAULT_IDLE_PRIORITY) {
+    return GLib.idle_add(priority, handler);
+  }
+
+  function timeout_add(timeout, handler, priority = GLib.PRIORITY_DEFAULT) {
+    return GLib.timeout_add(priority, timeout, handler);
+  }
+
+  function timeout_add_seconds(timeout, handler, priority = GLib.PRIORITY_DEFAULT) {
+    return GLib.timeout_add_seconds(priority, timeout, handler);
+  }
+
+  function source_remove(id) {
+    return GLib.source_remove(id);
+  }
+
+  return { run, quit, idle_add, timeout_add, timeout_add_seconds, source_remove };
+}
+
+export default createMainloop;

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -46,6 +46,7 @@
     "gettext.d.ts",
     "cairo.js",
     "cairo.d.ts",
+    "overrides",
     "src",
     "binding.gyp",
     "prebuilds"
@@ -69,6 +70,7 @@
     "test": "NODE_GI_NATIVE=build node --test",
     "test:node": "NODE_GI_NATIVE=build node --test",
     "test:gc": "NODE_GI_NATIVE=build node --test --expose-gc",
+    "test:dbus": "dbus-run-session -- env NODE_GI_NATIVE=build node --test test/dbus.test.mjs",
     "test:bun": "node scripts/cross-runtime.mjs bun",
     "test:conformance": "node scripts/conformance.mjs",
     "test:gimarshalling": "node scripts/gimarshalling.mjs",

--- a/packages/node-gi/node-gi/test/dbus.test.mjs
+++ b/packages/node-gi/node-gi/test/dbus.test.mjs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gio.DBus client round-trip on a private session bus.
+//
+// Runs the SHARED scenario (../dbus/scenario.mjs) on node-gi and asserts it equals
+// the golden result AND the output of the SAME scenario under `gjs -m`
+// (../dbus/gjs-harness.js) — the byte-for-byte gjs cross-check. Requires a session
+// bus; wrap the invocation in `dbus-run-session` for isolation:
+//   dbus-run-session -- node --test test/dbus.test.mjs   (npm run test:dbus)
+// When no session bus is reachable (the default `npm test` in a headless CI
+// container), every case self-skips — it never fails for lack of a bus.
+//
+// Coverage: makeProxyWrapper (sync + async-raw + Promise methods, the proxy
+// surface, a live NameOwnerChanged signal), Gio.DBus.session, name owning
+// (own_name → onNameAcquired), and the DEFERRED export side (wrapJSObject throws a
+// clear error, never crashes).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { requireGi } from '../gi.js';
+import { runScenario, EXPECTED } from '../dbus/scenario.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HARNESS = join(HERE, '..', 'dbus', 'gjs-harness.js');
+const HEX32 = /^[0-9a-f]{32}$/;
+
+const PROXY_XML = `<node><interface name="org.freedesktop.DBus">
+<method name="GetId"><arg type="s" direction="out"/></method>
+</interface></node>`;
+
+// Detect a reachable session bus once. bus_get_sync throws fast (no hang) when the
+// address is unset and autolaunch is unavailable — the headless-CI default.
+let Gio;
+let GLib;
+let busSkip = false;
+try {
+  Gio = requireGi('Gio', '2.0');
+  GLib = requireGi('GLib', '2.0');
+  Gio.bus_get_sync(Gio.BusType.SESSION, null);
+} catch (e) {
+  busSkip = `no session bus (${e.message}) — run under dbus-run-session (npm run test:dbus)`;
+}
+
+function haveCommand(cmd) {
+  const r = spawnSync(cmd, ['--version'], { encoding: 'utf8' });
+  return !r.error;
+}
+
+const gjsSkip = busSkip
+  ? busSkip
+  : !haveCommand('gjs')
+    ? 'gjs not on PATH'
+    : !haveCommand('dbus-run-session')
+      ? 'dbus-run-session not on PATH'
+      : false;
+
+// Block the default GLib main context for `ms` so pending GIO async replies fire
+// (their GI callbacks settle any awaited Promise). node-gtk #442/#121: a Promise
+// `.then` does not drain WHILE the loop blocks, but the reply DOES fire, so the
+// Promise is settled by the time run() returns and a subsequent `await` resolves.
+function pumpFor(ms) {
+  const loop = GLib.MainLoop.new(null, false);
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, ms, () => {
+    loop.quit();
+    return false;
+  });
+  loop.run();
+}
+
+test('DBus client round-trip matches the golden result', { skip: busSkip }, () => {
+  const result = runScenario({ Gio, GLib });
+  assert.deepEqual(result, EXPECTED);
+});
+
+test('the same round-trip under `gjs -m` is byte-identical (gold standard)', { skip: gjsSkip }, () => {
+  // Give gjs its own private bus so it never races the node run's names.
+  const r = spawnSync('dbus-run-session', ['--', 'gjs', '-m', HARNESS], {
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  assert.equal(r.status, 0, `gjs harness failed: ${r.stderr || r.error}`);
+  const line = (r.stdout || '').split('\n').find((l) => l.startsWith('RESULT='));
+  assert.ok(line, `no RESULT= line in gjs output:\n${r.stdout}\n${r.stderr}`);
+  const gjsResult = JSON.parse(line.slice('RESULT='.length));
+  assert.deepEqual(gjsResult, EXPECTED, 'gjs golden result diverged from EXPECTED');
+});
+
+test('proxy method Promise variant (FooAsync) resolves', { skip: busSkip }, async () => {
+  const ProxyClass = Gio.DBusProxy.makeProxyWrapper(PROXY_XML);
+  const proxy = new ProxyClass(Gio.DBus.session, 'org.freedesktop.DBus', '/org/freedesktop/DBus');
+  const promise = proxy.GetIdAsync();
+  // Pump the loop so the DBus reply fires + settles the Promise, then await it
+  // (the reply's GI callback runs during the pump; the `.then`/await drains after).
+  pumpFor(400);
+  const [id] = await promise;
+  assert.match(id, HEX32);
+});
+
+test('makeProxyWrapper.newAsync builds an inited proxy', { skip: busSkip }, async () => {
+  const ProxyClass = Gio.DBusProxy.makeProxyWrapper(PROXY_XML);
+  const promise = ProxyClass.newAsync(Gio.DBus.session, 'org.freedesktop.DBus', '/org/freedesktop/DBus');
+  pumpFor(400);
+  const proxy = await promise;
+  assert.equal(typeof proxy.GetIdSync, 'function');
+  const [id] = proxy.GetIdSync();
+  assert.match(id, HEX32);
+});
+
+test('Gio.DBusExportedObject.wrapJSObject throws a clear "not supported" error (export deferred)', () => {
+  // No bus needed — this asserts the deferred export side fails loudly, not silently.
+  const gio = requireGi('Gio', '2.0');
+  assert.throws(
+    () => gio.DBusExportedObject.wrapJSObject('<node/>', {}),
+    /not yet supported/,
+  );
+});

--- a/packages/node-gi/node-gi/test/signals-mixin.test.mjs
+++ b/packages/node-gi/node-gi/test/signals-mixin.test.mjs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the pure-JS `_signals` mixin (addSignalMethods) + the legacy
+// `imports.signals` / `imports.mainloop` script modules. No GObject / no bus: the
+// mixin is plain JS (it also backs the DBus proxy signal surface), and the mainloop
+// wrapper drives a GLib main loop (headless, no display).
+//
+// Importing ../globals.js installs the GJS ambient globals (print/log/logError +
+// the `imports` object) on this per-file test process — the entry point a real
+// `--app node` GJS source gets. `imports.signals` IS the mixin module.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import '../globals.js';
+
+const { addSignalMethods } = globalThis.imports.signals;
+
+test('addSignalMethods installs the GObject-shaped signal API', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  for (const m of ['connect', 'connectAfter', 'disconnect', 'emit', 'signalHandlerIsConnected', 'disconnectAll']) {
+    assert.equal(typeof obj[m], 'function', `missing ${m}`);
+  }
+});
+
+test('emit passes the emitter as the first handler arg (GObject parity), then the payload', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  let seenEmitter;
+  let seenArgs;
+  obj.connect('changed', (emitter, ...args) => {
+    seenEmitter = emitter;
+    seenArgs = args;
+  });
+  obj.emit('changed', 'a', 42);
+  assert.equal(seenEmitter, obj, 'first arg is the emitter');
+  assert.deepEqual(seenArgs, ['a', 42]);
+});
+
+test('connect returns a rising id; disconnect stops the handler', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  let count = 0;
+  const id = obj.connect('ping', () => {
+    count++;
+  });
+  assert.equal(typeof id, 'number');
+  obj.emit('ping');
+  obj.emit('ping');
+  assert.equal(count, 2);
+  obj.disconnect(id);
+  obj.emit('ping');
+  assert.equal(count, 2);
+  assert.equal(obj.signalHandlerIsConnected(id), false);
+});
+
+test('connectAfter handlers run after the before handlers', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  const order = [];
+  obj.connectAfter('go', () => order.push('after'));
+  obj.connect('go', () => order.push('before'));
+  obj.emit('go');
+  assert.deepEqual(order, ['before', 'after']);
+});
+
+test('a before handler returning true stops the emission (later before AND after handlers)', () => {
+  // The mixin's `_emit` is `if (!_callHandlers(before)) _callHandlers(after)`, so a
+  // true-returning before handler short-circuits the whole emission.
+  const obj = {};
+  addSignalMethods(obj);
+  const order = [];
+  obj.connect('go', () => {
+    order.push('first');
+    return true;
+  });
+  obj.connect('go', () => order.push('second-should-not-run'));
+  obj.connectAfter('go', () => order.push('after-should-not-run'));
+  obj.emit('go');
+  assert.deepEqual(order, ['first']);
+});
+
+test('a throwing handler is caught (logged) and does not disrupt emission', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  let reached = false;
+  obj.connect('go', () => {
+    throw new Error('boom');
+  });
+  obj.connect('go', () => {
+    reached = true;
+  });
+  // Must not throw out of emit; the second handler still runs.
+  obj.emit('go');
+  assert.equal(reached, true);
+});
+
+test('disconnectAll drops every handler', () => {
+  const obj = {};
+  addSignalMethods(obj);
+  let count = 0;
+  obj.connect('a', () => count++);
+  obj.connect('b', () => count++);
+  obj.disconnectAll();
+  obj.emit('a');
+  obj.emit('b');
+  assert.equal(count, 0);
+});
+
+test('imports.signals exposes the private primitives too', () => {
+  const s = globalThis.imports.signals;
+  for (const k of ['_connect', '_connectAfter', '_disconnect', '_emit', '_signalHandlerIsConnected', '_disconnectAll']) {
+    assert.equal(typeof s[k], 'function', `missing ${k}`);
+  }
+});
+
+test('imports.mainloop: timeout_add fires under run(), quit() stops the loop', () => {
+  const mainloop = globalThis.imports.mainloop;
+  let fired = false;
+  mainloop.timeout_add(10, () => {
+    fired = true;
+    mainloop.quit();
+    return false; // G_SOURCE_REMOVE
+  });
+  mainloop.run(); // blocks until quit()
+  assert.equal(fired, true);
+});
+
+test('imports.mainloop: idle_add fires, source_remove cancels a pending timeout', () => {
+  const mainloop = globalThis.imports.mainloop;
+  let idleFired = false;
+  let cancelledFired = false;
+  const cancelledId = mainloop.timeout_add(5, () => {
+    cancelledFired = true;
+    return false;
+  });
+  mainloop.source_remove(cancelledId);
+  mainloop.idle_add(() => {
+    idleFired = true;
+    // Give the (removed) timeout a chance to have NOT fired, then stop.
+    mainloop.timeout_add(30, () => {
+      mainloop.quit();
+      return false;
+    });
+    return false;
+  });
+  mainloop.run();
+  assert.equal(idleFired, true);
+  assert.equal(cancelledFired, false, 'source_remove cancelled the timeout');
+});


### PR DESCRIPTION
Phase 3.1 + 3.4: the Gio.DBus surface, the `_signals` mixin, and legacy `imports.signals`/`imports.mainloop`. Every behavior matched byte-for-byte against `gjs`.

## Landed
- **`_signals` mixin** (`overrides/_signals.js`) — near-verbatim port of GJS's `_signals.js` (`addSignalMethods`), reused by DBus proxies and `imports.signals`.
- **DBus client `makeProxyWrapper`** (full): `NameSync` / `NameRemote` (async callback) / `NameAsync` (Promise) / property get-set / signals (`connectSignal`/`disconnectSignal`) / `makeProxyWrapper.newAsync`; `Gio.DBus.session`/`system`.
- **Name owning/watching**: `own_name`/`unown_name` (over `org.freedesktop.DBus` RequestName/ReleaseName) + `watch_name`/`unwatch_name` (over a `NameOwnerChanged` subscribe + GetNameOwner probe) — the engine can't marshal the `GBus*Callback`s `g_bus_own_name` takes, so re-implemented via the bus with callbacks fired from the loop.
- **Legacy `imports.signals` + `imports.mainloop`** (`globals.js` + `overrides/mainloop.js`).

## Deferred (clear throw, never a crash)
- **Object export `DBusExportedObject.wrapJSObject`** — empirically impossible in the current engine: `register_object_with_closures` needs GClosure IN-args node-gi can't marshal yet (same wall as `g_bus_own_name` callbacks), and `register_object`'s vtable is non-introspectable. Needs an L0 GClosure-IN-arg marshalling (or a native DBusImplementation) — tracked follow-up.

## gjs parity
The full round-trip (proxy surface, sync `GetId`, `NameHasOwner` before/after own, async `GetIdRemote`, `ListNames`, two signal deliveries, name-acquired) is **byte-identical on gjs and node-gi**, and works on **bun and deno** (the blocking GLib loop dispatches idle/timeout/signal there too).

## CI
`dbus-daemon` added to the build-test dnf line (provides `dbus-run-session`); a new "DBus test" step runs `dbus-run-session -- node --test test/dbus.test.mjs`. Default `npm test` self-skips DBus when no bus is reachable.

## Test plan
- [x] `npm test` **306/0** (11 pre-existing --expose-gc skips) · `test:conformance` 4 runtimes green · `test:bun`/`test:deno` 33/33
- [x] `test/dbus.test.mjs` (5, incl. gjs cross-check) + `test/signals-mixin.test.mjs` (10) under `dbus-run-session`

Remaining DBus gaps (follow-ups): object export (needs GClosure IN-arg marshalling), UnixFDList/`h`-type FD passing, async-Promise-during-blocking-loop (node-gtk #442, use `NameRemote`), best-effort name-owning callbacks.