### PR TITLE
feat(node-gi): gobject/glib override parity

### DIFF
--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -437,6 +437,58 @@ a JS↔GObject reference cycle on a custom instance leaks (the same cycle-leak
 caveat the signal/vfunc layer carries); and multi-level registered subclass
 chains (registering a subclass of a registered subclass) are not yet supported.
 
+#### `GObject` conveniences (signals, `GObject.Value`, `Object.new`)
+
+`requireGi('GObject')` carries the GJS `GObject.js` convenience surface on top of
+introspection:
+
+```js
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+// By-function signal ops — node-gi connects through private closures, so the
+// (function → handler id) mapping is recorded at connect() time.
+const action = new Gio.SimpleAction({ name: 'a', enabled: true });
+const onChange = () => { /* … */ };
+action.connect('notify::enabled', onChange);
+GObject.signal_handlers_block_by_func(action, onChange);   // → count blocked
+GObject.signal_handlers_unblock_by_func(action, onChange); // → count unblocked
+GObject.signal_handlers_disconnect_by_func(action, onChange); // → count disconnected
+action.block_signal_handler(id); action.unblock_signal_handler(id); // by id
+action.stop_emission_by_name('notify::enabled');           // from within a handler
+
+// GObject.Value — an explicit GValue you can build, set, read, copy and pass IN.
+const v = new GObject.Value();
+v.init(GObject.TYPE_INT); v.set_int(42); v.get_int();      // → 42
+const s = new GObject.Value(GObject.TYPE_STRING, 'hi');    // 2-arg convenience
+v instanceof GObject.Value;                                // → true
+
+// Construct a GObject from a runtime GType.
+const made = GObject.Object.new(Gio.SimpleAction.$gtype, { name: 'made' });
+```
+
+Also present: `GObject.ParamFlags` / `SignalFlags` (full introspected bitfields),
+the fundamental `GObject.TYPE_*` GTypes, `GObject.AccumulatorType`, and
+`GObject.signal_connect` / `signal_connect_after` / `signal_emit_by_name`.
+
+**Kept-throw** (a clear, actionable error, not a crash): `bind_property_full` needs
+the JS transform-to/from closures marshalled as **GClosure IN-arguments**, which the
+engine cannot yet do — plain `bind_property` (no transforms) works. `ParamSpec.enum`
+/ `flags` / `char` / `uchar` / `long` / `ulong` / `param` are not yet buildable (the
+native param-spec builder covers int/uint/int64/uint64/double/float/string/boolean/
+object/boxed).
+
+#### `GLib` conveniences (`log_structured`, one-shot idle/timeout)
+
+`requireGi('GLib')` carries `GLib.log_structured(domain, level, fields)` (packs
+string / `Uint8Array` / `GLib.Variant` fields into an `a{sv}` and hands it to
+`g_log_variant`) and the one-shot source helpers `idle_add_once` /
+`timeout_add_once` / `timeout_add_seconds_once` (the callback runs once, then the
+source is auto-removed). **Kept-throw:** `GLib.log_set_writer_func(fn)` — a JS
+`GLogWriterFunc` is a **GClosure/callback IN-argument** the engine cannot yet
+marshal (the same gap as `bind_property_full` + DBus object export); use
+`GLib.log_structured` or `console` for structured logging.
+
 #### `Gio.DBus` (client proxy + name owning)
 
 `requireGi('Gio')` carries the GJS DBus surface. The **client** half is complete:

--- a/packages/node-gi/node-gi/conformance/golden/gobject-overrides.txt
+++ b/packages/node-gi/node-gi/conformance/golden/gobject-overrides.txt
@@ -1,0 +1,19 @@
+after1: 2
+blocked: 2
+after2: 2
+unblocked: 2
+after3: 4
+disconnected: 2
+after4: 4
+blockmethod: 0
+unblockmethod: 1
+value int: 42
+value string: hi
+value bool: true
+value double: 3.5
+value copy: 42
+value instanceof: true
+type_compatible: true
+object.new name: made
+object.new get_name(): made
+accumulator NONE/FIRST_WINS/TRUE_HANDLED: 0 1 2

--- a/packages/node-gi/node-gi/conformance/programs/gobject-overrides.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/gobject-overrides.conf.mjs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+// GObject.js override parity (phase 3.2) via headless Gio/GObject (no test typelib
+// needed): the by-function signal-handler ops, GObject.Value construction +
+// set_*/get_*/copy + the 2-arg convenience + instanceof + a static, GObject.Object.new
+// by GType, and the AccumulatorType fake enum. The golden is the gjs output;
+// node/bun/deno must match it byte-for-byte. Deterministic — no addresses/timestamps.
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+// ---- signal_handlers_{block,unblock,disconnect}_by_func -------------------
+const a = new Gio.SimpleAction({ name: 'x', enabled: true });
+let count = 0;
+const handler = () => {
+  count++;
+};
+a.connect('notify::enabled', handler);
+a.connect('notify::enabled', handler);
+a.connect('notify::enabled', () => {});
+a.set_enabled(false);
+print('after1:', count);
+print('blocked:', GObject.signal_handlers_block_by_func(a, handler));
+a.set_enabled(true);
+print('after2:', count);
+print('unblocked:', GObject.signal_handlers_unblock_by_func(a, handler));
+a.set_enabled(false);
+print('after3:', count);
+print('disconnected:', GObject.signal_handlers_disconnect_by_func(a, handler));
+a.set_enabled(true);
+print('after4:', count);
+
+// block_signal_handler / unblock_signal_handler (prototype methods)
+let c2 = 0;
+const b = new Gio.SimpleAction({ name: 'y', enabled: true });
+const idb = b.connect('notify::enabled', () => {
+  c2++;
+});
+b.block_signal_handler(idb);
+b.set_enabled(false);
+print('blockmethod:', c2);
+b.unblock_signal_handler(idb);
+b.set_enabled(true);
+print('unblockmethod:', c2);
+
+// ---- GObject.Value --------------------------------------------------------
+const v = new GObject.Value();
+v.init(GObject.TYPE_INT);
+v.set_int(42);
+print('value int:', v.get_int());
+print('value string:', new GObject.Value(GObject.TYPE_STRING, 'hi').get_string());
+print('value bool:', new GObject.Value(GObject.TYPE_BOOLEAN, true).get_boolean());
+print('value double:', new GObject.Value(GObject.TYPE_DOUBLE, 3.5).get_double());
+const copyTarget = new GObject.Value();
+copyTarget.init(GObject.TYPE_INT);
+v.copy(copyTarget);
+print('value copy:', copyTarget.get_int());
+print('value instanceof:', v instanceof GObject.Value);
+print('type_compatible:', GObject.Value.type_compatible(GObject.TYPE_INT, GObject.TYPE_INT));
+
+// ---- GObject.Object.new ---------------------------------------------------
+const made = GObject.Object.new(Gio.SimpleAction.$gtype, { name: 'made', enabled: false });
+print('object.new name:', made.name);
+print('object.new get_name():', made.get_name());
+
+// ---- AccumulatorType ------------------------------------------------------
+print('accumulator NONE/FIRST_WINS/TRUE_HANDLED:', GObject.AccumulatorType.NONE, GObject.AccumulatorType.FIRST_WINS, GObject.AccumulatorType.TRUE_HANDLED);

--- a/packages/node-gi/node-gi/gi.d.ts
+++ b/packages/node-gi/node-gi/gi.d.ts
@@ -107,6 +107,27 @@ export interface GObjectNamespace extends GiNamespace {
   };
   /** The FULL introspected `GSignalFlags` bitfield (RUN_FIRST/RUN_LAST/RUN_CLEANUP/NO_RECURSE/DETAILED/ACTION/NO_HOOKS/MUST_COLLECT/DEPRECATED/…). */
   SignalFlags: { RUN_FIRST: number; RUN_LAST: number; RUN_CLEANUP: number; [member: string]: number };
+  /**
+   * `GObject.Value` — `new GObject.Value()` / `new GObject.Value(gtype, value)`
+   * build a GValue; the boxed instance exposes `.init(gtype)`/`.set_*`/`.get_*`/
+   * `.copy`/`.unset`; static `type_compatible`/`type_transformable` route to the
+   * engine. `value instanceof GObject.Value` recognises a wrapped GValue.
+   */
+  Value: { new (): unknown; new (gtype: unknown, value: unknown): unknown; [staticMethod: string]: unknown };
+  /** gjs's fake enum for signal accumulators. */
+  AccumulatorType: { NONE: number; FIRST_WINS: number; TRUE_HANDLED: number };
+  /** Block every handler on `instance` connected with `fn`; returns the count matched. */
+  signal_handlers_block_by_func(instance: unknown, fn: Function): number;
+  /** Unblock every handler on `instance` connected with `fn`; returns the count matched. */
+  signal_handlers_unblock_by_func(instance: unknown, fn: Function): number;
+  /** Disconnect every handler on `instance` connected with `fn`; returns the count matched. */
+  signal_handlers_disconnect_by_func(instance: unknown, fn: Function): number;
+  /** Connect `handler` to `object`'s `name` signal via the instance's own `.connect`. */
+  signal_connect(object: unknown, name: string, handler: Function): number;
+  /** Connect `handler` in the after-phase via the instance's own `.connect_after`. */
+  signal_connect_after(object: unknown, name: string, handler: Function): number;
+  /** Emit `name` on `object` via the instance's own `.emit`. */
+  signal_emit_by_name(object: unknown, ...nameAndArgs: unknown[]): unknown;
 }
 
 /**
@@ -149,6 +170,17 @@ export interface VariantConstructor {
  */
 export interface GLibNamespace extends GiNamespace {
   Variant: VariantConstructor;
+  /**
+   * Pack `fields` (string / Uint8Array / {@link Variant} values) into an `a{sv}` and
+   * hand it to `g_log_variant` — gjs's `GLib.log_structured`.
+   */
+  log_structured(logDomain: string, logLevel: number, fields: Record<string, unknown>): void;
+  /** One-shot `idle_add` — the callback runs once, then the source is removed. */
+  idle_add_once(priority: number, callback: () => void): number;
+  /** One-shot `timeout_add` — the callback runs once, then the source is removed. */
+  timeout_add_once(priority: number, interval: number, callback: () => void): number;
+  /** One-shot `timeout_add_seconds` — the callback runs once, then the source is removed. */
+  timeout_add_seconds_once(priority: number, interval: number, callback: () => void): number;
 }
 
 /**

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -442,11 +442,191 @@ function makeVariantClass() {
 
 const variantClass = makeVariantClass();
 
+// ---- GObject.Value ergonomics (the GJS GObject.Value override, L1) ----
+//
+// gjs exposes `new GObject.Value()` (an empty GValue) + the convenience
+// `new GObject.Value(gtype, value)` (init + a set_* chosen by the value's type),
+// over the introspected GValue struct methods (.init/.set_*/.get_*/.copy/.reset/
+// .unset) + the static type_compatible/type_transformable —
+// refs/gjs/modules/core/overrides/GObject.js gValueConstructorFunc over the real
+// GValue class. node-gi has no g_value_new(), so construction goes through
+// native.newGValue (a zeroed G_TYPE_VALUE boxed handle) and the method surface then
+// routes through wrapBoxed's boxed-method dispatch (verified: init/set_int/get_int
+// resolve as GValue methods).
+
+// Fundamental GType name → GValue setter, for the `new GObject.Value(gtype, value)`
+// convenience. Non-primitive types (enum/flags/boxed/object/param/variant) are
+// matched by g_type_is_a below, exactly like gjs's default switch branch.
+const GVALUE_PRIMITIVE_SETTERS = {
+  gboolean: 'set_boolean',
+  gchar: 'set_schar',
+  guchar: 'set_uchar',
+  gint: 'set_int',
+  guint: 'set_uint',
+  glong: 'set_long',
+  gulong: 'set_ulong',
+  gint64: 'set_int64',
+  guint64: 'set_uint64',
+  gfloat: 'set_float',
+  gdouble: 'set_double',
+  gchararray: 'set_string',
+  GType: 'set_gtype',
+  GVariant: 'set_variant',
+  GParam: 'set_param',
+};
+
+// Pick the GValue setter for a (resolved) GType handle, mirroring gjs's constructor
+// switch: an exact fundamental → its setter, else g_type_is_a → flags/enum/boxed/…
+// (introspected GObject.type_name / type_is_a — both verified on node-gi).
+function gvalueSetterFor(gt) {
+  const G = requireGi('GObject', '2.0');
+  const prim = GVALUE_PRIMITIVE_SETTERS[G.type_name(gt)];
+  if (prim !== undefined) return prim;
+  if (G.type_is_a(gt, G.TYPE_FLAGS)) return 'set_flags';
+  if (G.type_is_a(gt, G.TYPE_ENUM)) return 'set_enum';
+  if (G.type_is_a(gt, G.TYPE_VARIANT)) return 'set_variant';
+  if (G.type_is_a(gt, G.TYPE_PARAM)) return 'set_param';
+  if (G.type_is_a(gt, G.TYPE_BOXED)) return 'set_boxed';
+  if (G.type_is_a(gt, G.TYPE_OBJECT)) return 'set_object';
+  throw new TypeError(`Invalid type argument '${G.type_name(gt)}' to the GObject.Value constructor`);
+}
+
+// Build the empty/convenience GValue: a zeroed GValue boxed handle wrapped with the
+// GValue struct methods; the 2-arg form inits it to `gtype` (a class ctor's $gtype
+// or a GType handle) and sets `value` via the matching setter.
+function buildValue(args) {
+  const v = wrapBoxed(native.newGValue());
+  if (args.length >= 2) {
+    const gt = resolveGTypeArg(args[0]);
+    // Resolve the setter BEFORE init so an unsupported type throws a clean JS
+    // TypeError rather than driving g_value_init with a value-table-less type (a
+    // GLib-CRITICAL that would abort under G_DEBUG=fatal-criticals) — same net
+    // result as gjs's constructor, minus the noisy failed init.
+    const setter = gvalueSetterFor(gt);
+    v.init(gt);
+    v[setter](args[1]);
+  }
+  return v;
+}
+
+// `GObject.Value` as a class-like object: `new GObject.Value()` /
+// `new GObject.Value(gtype, value)` construct via buildValue, static methods
+// (type_compatible / type_transformable + camelCase) route through the engine, and
+// `value instanceof GObject.Value` recognises any wrapper over a GValue boxed handle.
+function makeValueClass() {
+  const ctor = function Value(...args) {
+    return buildValue(args);
+  };
+  Object.defineProperty(ctor, 'name', { value: 'Value', configurable: true });
+  ctor.$gtypeName = 'GObject.Value';
+  Object.defineProperty(ctor, Symbol.hasInstance, {
+    value(instance) {
+      if (instance === null || typeof instance !== 'object') return false;
+      const handle = instance[HANDLE];
+      return (
+        handle !== undefined &&
+        native.isBoxedHandle(handle) &&
+        native.boxedTypeName(handle) === 'GValue'
+      );
+    },
+    configurable: true,
+  });
+  return new Proxy(ctor, {
+    get(t, prop) {
+      if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
+      const giName = camelToSnake(prop);
+      return (...args) =>
+        wrapReturn(native.callStaticMethod('GObject', 'Value', giName, unwrapArgs(args)));
+    },
+    construct(_t, args) {
+      return buildValue(args);
+    },
+  });
+}
+
+const valueClass = makeValueClass();
+
 // Overlay the GJS Variant ergonomics on the introspected GLib namespace, leaving
 // every other member resolving from introspection. (Additive, like the GObject
 // overlay; the introspected struct-based `GLib.Variant` is replaced by the
 // ergonomic wrapper class so `new GLib.Variant(...)` + `.deepUnpack()` work.)
+// GLib.log_set_writer_func(fn) requires a JS GLogWriterFunc marshalled as a
+// GClosure/callback IN-argument (the introspected engine passes NULL for it → a
+// GLib-CRITICAL no-op), the same L0 gap that blocks bind_property_full. gjs itself
+// routes around it via GjsPrivate.log_set_writer_func; on node-gi it is a clear
+// kept-throw until the engine can marshal a JS function as a callback IN-argument.
+const LOG_SET_WRITER_FUNC_MSG =
+  'GLib.log_set_writer_func(fn) is not supported on @gjsify/node-gi yet: a JS GLogWriterFunc must ' +
+  'be marshalled as a GClosure/callback IN-argument, which the native engine cannot yet do. Use ' +
+  'GLib.log_structured or console for structured logging.';
+
+// The GLib names the L1 overlay adds/replaces on top of introspection.
+const GLIB_OVERLAY_NAMES = new Set([
+  'log_structured',
+  'idle_add_once',
+  'timeout_add_once',
+  'timeout_add_seconds_once',
+  'log_set_writer_func',
+]);
+
+// GLib.log_structured(domain, level, fields): pack `fields` into an `a{sv}` and hand
+// it to the introspected GLib.log_variant — refs/gjs/modules/core/overrides/GLib.js
+// log_structured. Each field value is `ay` (Uint8Array), `s` (string) or a Variant
+// passed through; anything else is a TypeError, matching gjs.
+function makeLogStructured(baseNs) {
+  return (logDomain, logLevel, fields) => {
+    const variantFields = {};
+    for (const key of Object.keys(fields)) {
+      const field = fields[key];
+      if (field instanceof Uint8Array) variantFields[key] = variantClass('ay', field);
+      else if (typeof field === 'string') variantFields[key] = variantClass('s', field);
+      else if (field instanceof variantClass) variantFields[key] = field;
+      else {
+        throw new TypeError(
+          `Unsupported value ${field}, log_structured supports GLib.Variant, Uint8Array, and string values.`,
+        );
+      }
+    }
+    baseNs.log_variant(logDomain, logLevel, variantClass('a{sv}', variantFields));
+  };
+}
+
 function decorateGLibNamespace(baseNs) {
+  // Per-namespace cache of the overlay functions that need the introspected baseNs
+  // (log_structured → log_variant; the *_once helpers → idle_add/timeout_add).
+  const cache = new Map();
+  const overlay = (prop) => {
+    if (cache.has(prop)) return cache.get(prop);
+    let value;
+    if (prop === 'log_structured') value = makeLogStructured(baseNs);
+    // The one-shot idle/timeout conveniences (gjs GLib.js): auto-remove the source
+    // after the callback runs, so the callback needs no `return SOURCE_REMOVE`.
+    else if (prop === 'idle_add_once') {
+      value = (priority, callback) =>
+        baseNs.idle_add(priority, () => {
+          callback();
+          return baseNs.SOURCE_REMOVE;
+        });
+    } else if (prop === 'timeout_add_once') {
+      value = (priority, interval, callback) =>
+        baseNs.timeout_add(priority, interval, () => {
+          callback();
+          return baseNs.SOURCE_REMOVE;
+        });
+    } else if (prop === 'timeout_add_seconds_once') {
+      value = (priority, interval, callback) =>
+        baseNs.timeout_add_seconds(priority, interval, () => {
+          callback();
+          return baseNs.SOURCE_REMOVE;
+        });
+    } else if (prop === 'log_set_writer_func') {
+      value = () => {
+        throw new Error(LOG_SET_WRITER_FUNC_MSG);
+      };
+    }
+    cache.set(prop, value);
+    return value;
+  };
   return new Proxy(baseNs, {
     get(t, prop) {
       if (prop === 'Variant') return variantClass;
@@ -454,10 +634,16 @@ function decorateGLibNamespace(baseNs) {
       // and `new GLib.Error(domain, code, message)` constructs one), shadowing the
       // introspected boxed type so `instanceof GLib.Error` + `.matches()` work.
       if (prop === 'Error') return GLibError;
+      if (typeof prop === 'string' && GLIB_OVERLAY_NAMES.has(prop)) return overlay(prop);
       return t[prop];
     },
     has(t, prop) {
-      return prop === 'Variant' || prop === 'Error' || prop in t;
+      return (
+        prop === 'Variant' ||
+        prop === 'Error' ||
+        (typeof prop === 'string' && GLIB_OVERLAY_NAMES.has(prop)) ||
+        prop in t
+      );
     },
   });
 }
@@ -530,6 +716,54 @@ function isProtoSameOrDescendantOf(proto, maybeAncestor) {
 // External is kept alive by the toggle-up root while C owns the object, which in
 // turn keeps this WeakMap entry — and the proxy + its fields — alive).
 const instanceCache = new WeakMap();
+
+// ---- signal-handler bookkeeping (JS function → connected handler ids) ----
+//
+// node-gi connects signals through PRIVATE GClosures (a JS callback wrapped in a C
+// closure — see signals.cc), so the GObject cannot map a JS function back to its
+// handler ids the way gjs's signal_handler_find can. gjs reaches this via its own
+// per-instance private-closure registry (Gi.signals_{block,unblock,disconnect}_
+// symbol, refs/gjs/modules/core/overrides/GObject.js); we keep the equivalent map
+// here, populated at connect() time, so GObject.signal_handlers_{block,unblock,
+// disconnect}_by_func can resolve a function to its ids. Keyed by the canonical
+// native handle (a WeakMap, so it is collected with the object). Divergence
+// (documented): disconnecting a handler by a route OTHER than the L1 `.disconnect(id)`
+// / a by-func disconnect (e.g. the introspected GObject.signal_handler_disconnect)
+// leaves a stale id here; a following block/unblock/disconnect-by-func would then act
+// on a dead id (native.disconnectSignal already guards is_connected; block/unblock
+// would g_warning). Normal connect→block/unblock/disconnect flows are exact.
+const signalHandlerIds = new WeakMap(); // handle → Map<jsFunc, Set<handlerId>>
+
+function recordSignalHandler(handle, fn, id) {
+  let byFn = signalHandlerIds.get(handle);
+  if (byFn === undefined) {
+    byFn = new Map();
+    signalHandlerIds.set(handle, byFn);
+  }
+  let ids = byFn.get(fn);
+  if (ids === undefined) {
+    ids = new Set();
+    byFn.set(fn, ids);
+  }
+  ids.add(id);
+}
+
+// Drop a handler id from the per-instance registry (on disconnect), pruning an
+// emptied function entry so a later by-func lookup reports zero matches.
+function forgetSignalHandlerId(handle, id) {
+  const byFn = signalHandlerIds.get(handle);
+  if (byFn === undefined) return;
+  for (const [fn, ids] of byFn) {
+    if (ids.delete(id) && ids.size === 0) byFn.delete(fn);
+  }
+}
+
+// The connected handler ids for a given JS function on an instance (a fresh array;
+// empty when the function was never connected on this instance).
+function handlerIdsForFunc(handle, fn) {
+  const ids = signalHandlerIds.get(handle)?.get(fn);
+  return ids === undefined ? [] : [...ids];
+}
 
 // ---- G3 mutate-in-place registry ----
 //
@@ -673,6 +907,47 @@ export function stopMainContextPump() {
   }
 }
 
+// bind_property_full needs the transform-to/transform-from callbacks marshalled as
+// GClosure IN-arguments, which the native engine cannot yet do (the same L0 gap that
+// blocks GLib.log_set_writer_func and a GDBus method-export closure). gjs itself
+// avoids the introspected version via GjsPrivate.g_object_bind_property_full; on
+// node-gi there is no such shim, so this is a clear kept-throw until the engine can
+// marshal a JS function as a GClosure/callback IN-argument.
+const BIND_PROPERTY_FULL_MSG =
+  'GObject.Object.prototype.bind_property_full is not supported on @gjsify/node-gi yet: it needs ' +
+  'the JS transform-to/from closures marshalled as GClosure IN-arguments, which the native engine ' +
+  'cannot yet do. Use bind_property (no transforms), or convert the value in a notify:: handler.';
+
+// gjs's GObject.Object.prototype signal-convenience methods + the bind_property_full
+// kept-throw, resolved by JS-accessor name (snake_case or camelCase). Returns a
+// `(handle, args) => result` applier, or undefined for a name we do not shim.
+// block/unblock route through the introspected single-handler g_signal_handler_*
+// functions (verified to marshal a node-gi GObject IN-arg); stop_emission_by_name
+// through g_signal_stop_emission_by_name.
+function objectPrototypeShim(prop) {
+  switch (prop) {
+    case 'block_signal_handler':
+    case 'blockSignalHandler':
+      return (handle, args) =>
+        wrapReturn(native.callFunction('GObject', 'signal_handler_block', [handle, args[0]]));
+    case 'unblock_signal_handler':
+    case 'unblockSignalHandler':
+      return (handle, args) =>
+        wrapReturn(native.callFunction('GObject', 'signal_handler_unblock', [handle, args[0]]));
+    case 'stop_emission_by_name':
+    case 'stopEmissionByName':
+      return (handle, args) =>
+        wrapReturn(native.callFunction('GObject', 'signal_stop_emission_by_name', [handle, args[0]]));
+    case 'bind_property_full':
+    case 'bindPropertyFull':
+      return () => {
+        throw new Error(BIND_PROPERTY_FULL_MSG);
+      };
+    default:
+      return undefined;
+  }
+}
+
 // Wrap a live GObject handle as a GJS-shaped instance. When `userProto` is given
 // (a registerClass subclass's prototype) the wrapper resolves the user class's
 // own prototype members FIRST — so `inst.myMethod()` runs the JS method with the
@@ -706,14 +981,27 @@ function wrapInstance(handle, userProto) {
       if (typeof prop !== 'string' || RESERVED.has(prop)) return t[prop];
       switch (prop) {
         case 'connect':
-          return (signal, cb) => native.connectSignal(handle, signal, wrapSignalCallback(cb), false);
+          // Record the (user fn → id) mapping so signal_handlers_*_by_func can
+          // resolve the private-closure handler back to its ids (see the registry).
+          return (signal, cb) => {
+            const id = native.connectSignal(handle, signal, wrapSignalCallback(cb), false);
+            recordSignalHandler(handle, cb, id);
+            return id;
+          };
         case 'connect_after':
-          return (signal, cb) => native.connectSignal(handle, signal, wrapSignalCallback(cb), true);
+          return (signal, cb) => {
+            const id = native.connectSignal(handle, signal, wrapSignalCallback(cb), true);
+            recordSignalHandler(handle, cb, id);
+            return id;
+          };
         case 'emit':
           return (signal, ...args) =>
             wrapReturn(native.emitSignal(handle, signal, unwrapArgs(args)));
         case 'disconnect':
-          return (id) => native.disconnectSignal(handle, id);
+          return (id) => {
+            forgetSignalHandlerId(handle, id);
+            return native.disconnectSignal(handle, id);
+          };
         default:
           break;
       }
@@ -735,6 +1023,13 @@ function wrapInstance(handle, userProto) {
       if (prop === 'runAsync' && native.isInstanceOf(handle, 'Gio', 'Application')) {
         return () => applicationRunAsync(handle);
       }
+      // gjs's GObject.Object.prototype signal conveniences (block_signal_handler /
+      // unblock_signal_handler / stop_emission_by_name) + the bind_property_full
+      // kept-throw (refs/gjs GObject.js). These are NOT introspected instance
+      // methods — they are gjs shims over the namespace-level g_signal_* functions —
+      // so route them explicitly before property / GI-method resolution.
+      const shim = objectPrototypeShim(prop);
+      if (shim !== undefined) return (...args) => shim(handle, args);
       const propName = toKebab(prop);
       if (native.hasProperty(handle, propName)) {
         return wrapReturn(native.getProperty(handle, propName));
@@ -907,12 +1202,47 @@ function makeClass(namespace, typeName) {
       // introspected class itself (receiver === proxy) resolves the real lazy GType.
       if (prop === '$gtype' && receiver !== proxy) return undefined;
       if (typeof prop !== 'string' || prop in t || RESERVED.has(prop)) return t[prop];
+      // GObject.Object.new(gtype, props) / .new_with_properties(gtype, names,
+      // values): gjs's GObject.js statics that construct a GObject from a runtime
+      // GType. Not introspected (g_object_new is variadic), so route them to the
+      // by-GType constructor (native.constructType accepts any GType handle).
+      if (namespace === 'GObject' && typeName === 'Object' &&
+          (prop === 'new' || prop === 'new_with_properties' || prop === 'newWithProperties')) {
+        return objectStaticConstructor(prop);
+      }
       const giName = camelToSnake(prop);
       return (...args) =>
         wrapReturn(native.callStaticMethod(namespace, typeName, giName, unwrapArgs(args)));
     },
   });
   return proxy;
+}
+
+// The GObject.Object.new / new_with_properties statics (gjs GObject.js). `new`
+// resolves the GType (a class ctor's $gtype or a GType handle) and constructs it via
+// constructType (which accepts an arbitrary GType, returning the canonical wrapper —
+// the same routing `new Ns.Class({...})` uses); `new_with_properties` zips the two
+// arrays into a prop dict and delegates. Mirrors GJS's `GObject.Object.new`, which
+// looks up the constructor for `gtype` and `new`s it with the prop dict.
+function objectStaticConstructor(prop) {
+  const objectNew = (gtype, props = {}) => {
+    const gt = resolveGTypeArg(gtype);
+    if (gt === undefined || gt === null) {
+      throw new TypeError('GObject.Object.new: a GType (class or Class.$gtype) is required');
+    }
+    return wrapInstance(native.constructType(gt, props ? unwrapProps(props) : {}));
+  };
+  if (prop === 'new') return objectNew;
+  return (gtype, names, values) => {
+    if (!Array.isArray(names) || !Array.isArray(values) || names.length !== values.length) {
+      throw new Error(
+        'GObject.Object.new_with_properties takes two equal-length arrays (names, values)',
+      );
+    }
+    const props = {};
+    for (let i = 0; i < names.length; i++) props[names[i]] = values[i];
+    return objectNew(gtype, props);
+  };
 }
 
 // Surface a boxed/struct type (e.g. GLib.MainLoop) as a class-like object whose
@@ -1471,15 +1801,85 @@ function mergeFlags(introspected, convenience) {
   return Object.freeze({ ...convenience, ...introspected });
 }
 
+// GObject.AccumulatorType — gjs's fake enum for signal accumulators (GObject.js,
+// "keep in sync with gi/object.c"). Not introspected; a pure convenience table.
+const AccumulatorType = Object.freeze({ NONE: 0, FIRST_WINS: 1, TRUE_HANDLED: 2 });
+
+// GObject.signal_handlers_{block,unblock,disconnect}_by_func(instance, fn) — gjs's
+// GObject.js by-function handler ops. node-gi connects via PRIVATE closures, so the
+// function is resolved to its recorded handler ids (signalHandlerIds), then each is
+// blocked/unblocked via the introspected single-handler g_signal_handler_{block,
+// unblock} (verified to marshal a node-gi GObject IN-arg) or disconnected via
+// native.disconnectSignal. Returns the count of handlers matched, exactly as gjs's
+// g_signal_handlers_*_matched-based helpers do.
+function signalHandlersBlockByFunc(instance, fn) {
+  const handle = unwrapArg(instance);
+  const ids = handlerIdsForFunc(handle, fn);
+  for (const id of ids) native.callFunction('GObject', 'signal_handler_block', [handle, id]);
+  return ids.length;
+}
+function signalHandlersUnblockByFunc(instance, fn) {
+  const handle = unwrapArg(instance);
+  const ids = handlerIdsForFunc(handle, fn);
+  for (const id of ids) native.callFunction('GObject', 'signal_handler_unblock', [handle, id]);
+  return ids.length;
+}
+function signalHandlersDisconnectByFunc(instance, fn) {
+  const handle = unwrapArg(instance);
+  const ids = handlerIdsForFunc(handle, fn);
+  for (const id of ids) {
+    native.disconnectSignal(handle, id);
+    forgetSignalHandlerId(handle, id);
+  }
+  return ids.length;
+}
+// Matches gjs's non-introspectable guard (GObject.js) — there is no func→data map.
+function signalHandlersDisconnectByData() {
+  throw new Error(
+    'GObject.signal_handlers_disconnect_by_data() is not introspectable. Use ' +
+      'GObject.signal_handlers_disconnect_by_func() instead.',
+  );
+}
+
+// GObject.signal_connect / signal_connect_after / signal_emit_by_name — gjs's
+// GObject.js shims that call the instance's OWN connect/connect_after/emit (a
+// workaround for classes that shadow those names with their own methods). The
+// instance is the L1 wrapper, whose .connect records the id in the by-func registry.
+function signalConnect(object, name, handler) {
+  return object.connect(name, handler);
+}
+function signalConnectAfter(object, name, handler) {
+  return object.connect_after(name, handler);
+}
+function signalEmitByName(object, ...nameAndArgs) {
+  return object.emit(...nameAndArgs);
+}
+
 // Overlay the GJS `GObject` runtime statics on top of the introspected GObject
-// namespace proxy — ADDITIVELY, never shadowing. `registerClass` + `ParamSpec`
-// are genuinely new. `ParamFlags` / `SignalFlags` are FULL introspected
-// bitfields: returning a hardcoded 5-member table would make every other member
-// read `undefined` (→ coerces to 0 in `FLAGS | GObject.ParamFlags.X`, silently
-// dropping the bit), so they resolve to the introspected enum (convenience names
-// merged underneath as a fallback). `GObject.Object` etc. keep resolving from
-// introspection. Merged enums are cached so identity is stable.
-const OVERLAY_NAMES = new Set(['registerClass', 'ParamSpec', 'ParamFlags', 'SignalFlags']);
+// namespace proxy — ADDITIVELY. `registerClass` + `ParamSpec` + the signal-by-func
+// helpers + `Value` + `AccumulatorType` are genuinely new (or shadow a broken
+// introspected member — `Value`, whose struct has no `new()`). `ParamFlags` /
+// `SignalFlags` are FULL introspected bitfields: returning a hardcoded 5-member
+// table would make every other member read `undefined` (→ coerces to 0 in `FLAGS |
+// GObject.ParamFlags.X`, silently dropping the bit), so they resolve to the
+// introspected enum (convenience names merged underneath as a fallback).
+// `GObject.Object` etc. keep resolving from introspection (with .new added in
+// makeClass). Merged enums are cached so identity is stable.
+const OVERLAY_NAMES = new Set([
+  'registerClass',
+  'ParamSpec',
+  'ParamFlags',
+  'SignalFlags',
+  'Value',
+  'AccumulatorType',
+  'signal_handlers_block_by_func',
+  'signal_handlers_unblock_by_func',
+  'signal_handlers_disconnect_by_func',
+  'signal_handlers_disconnect_by_data',
+  'signal_connect',
+  'signal_connect_after',
+  'signal_emit_by_name',
+]);
 
 // The fundamental GObject.TYPE_* constants. GJS defines these in its GObject
 // override by looking each name up in libgobject AT RUNTIME (not hardcoding the
@@ -1536,6 +1936,15 @@ function decorateGObjectNamespace(baseNs) {
     else if (prop === 'ParamSpec') value = ParamSpec;
     else if (prop === 'ParamFlags') value = mergeFlags(baseNs.ParamFlags, ParamFlags);
     else if (prop === 'SignalFlags') value = mergeFlags(baseNs.SignalFlags, SignalFlags);
+    else if (prop === 'Value') value = valueClass;
+    else if (prop === 'AccumulatorType') value = AccumulatorType;
+    else if (prop === 'signal_handlers_block_by_func') value = signalHandlersBlockByFunc;
+    else if (prop === 'signal_handlers_unblock_by_func') value = signalHandlersUnblockByFunc;
+    else if (prop === 'signal_handlers_disconnect_by_func') value = signalHandlersDisconnectByFunc;
+    else if (prop === 'signal_handlers_disconnect_by_data') value = signalHandlersDisconnectByData;
+    else if (prop === 'signal_connect') value = signalConnect;
+    else if (prop === 'signal_connect_after') value = signalConnectAfter;
+    else if (prop === 'signal_emit_by_name') value = signalEmitByName;
     else if (Object.prototype.hasOwnProperty.call(GTYPE_CONSTANT_NAMES, prop)) {
       // Resolve the real GType from libgobject via the introspected type_from_name
       // (0 / unregistered → null, matching object.cc's GType marshalling).

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -232,9 +232,17 @@ const SKIP_GVALUE_ARRAY =
 const SKIP_GVALUE_IN =
     'phase 2.5 GValue IN — autoboxing a JS value INTO a GValue arg (JS 42 → a GValue ' +
     'holding an int, with GJS type inference) is a separate direction; GValue return/OUT unbox is live';
-const SKIP_GVALUE_BOXED =
-    'GObject.Value construction — `new GObject.Value()` + .init()/.set_*() to BUILD an explicit ' +
-    'boxed GValue (to pass IN or modify) needs struct construction, a later PR; GValue return/OUT unbox is live';
+// GObject.Value construction + int/enum boxed-GValue IN are now LIVE (phase 3.2):
+// `new GObject.Value()` + .init()/.set_*() build an explicit boxed GValue that can
+// be passed IN and modified in place (the two specs below un-skipped). The remaining
+// boxed-GValue skips need a capability node-gi does not have yet:
+const SKIP_GVALUE_CTOR_GTYPE =
+    'node-gi does not stamp `$gtype` on JS built-in constructors / enum objects, so ' +
+    '`value.init(Number)` / `value.init(GIMarshallingTests.Flags)` cannot resolve a GType — a later ' +
+    'PR; GObject.Value construction + int/enum boxed-GValue IN are live';
+const SKIP_GVALUE_FLOAT =
+    'GIMarshallingTests.gvalue_float rejects a boxed GValue as its interface IN-argument (distinct ' +
+    'from the working gvalue_in_with_modification path) — a GValue-IN marshalling quirk, a later PR';
 
 // Integer limits, defined without reference to GLib (because the GLib.MAXINT8
 // etc. constants are also subject to marshalling)
@@ -1035,9 +1043,24 @@ describe('GValue', function () {
 
     itSkip(SKIP_GVALUE_IN, 'type objects can be converted from primitive-like types', function () {});
     itSkip(SKIP_GVALUE_IN, 'can be passed into a function and modified', function () {});
-    itSkip(SKIP_GVALUE_BOXED, 'can be passed into a function as a boxed type and modified', function () {});
-    itSkip(SKIP_GVALUE_BOXED, 'enum can be passed into a function as a boxed type and packed', function () {});
-    itSkip(SKIP_GVALUE_BOXED, 'flags can be passed into a function as a boxed type and packed', function () {});
+    // node-gi phase 3.2: a constructed boxed GObject.Value is passed IN and the C side
+    // modifies it in place (get_int → 24) — verified vs gjs's identical body.
+    it('can be passed into a function as a boxed type and modified', function () {
+        const value = new GObject.Value();
+        value.init(GObject.TYPE_INT);
+        value.set_int(42);
+
+        expect(() => GIMarshallingTests.gvalue_in_with_modification(value)).not.toThrow();
+        expect(value.get_int()).toBe(24);
+    });
+    it('enum can be passed into a function as a boxed type and packed', function () {
+        const value = new GObject.Value();
+        // GIMarshallingTests.Enum is a native enum; pack it via the abstract G_TYPE_ENUM.
+        value.init(GObject.TYPE_ENUM);
+        value.set_enum(GIMarshallingTests.Enum.VALUE3);
+        expect(() => GIMarshallingTests.gvalue_in_enum(value)).not.toThrow();
+    });
+    itSkip(SKIP_GVALUE_CTOR_GTYPE, 'flags can be passed into a function as a boxed type and packed', function () {});
 
     it('marshals as an int64 out parameter', function () {
         expect(warn64(true, GIMarshallingTests.gvalue_int64_out)).toEqual(
@@ -1055,8 +1078,8 @@ describe('GValue', function () {
     itSkip(SKIP_GVALUE_ARRAY, 'array can be passed as an out argument and unpacked when zero-terminated',
         function () {});
     itSkip(SKIP_GVALUE_IN, 'can have its type inferred from primitive values', function () {});
-    itSkip(SKIP_GVALUE_BOXED, 'can deal with a GValue packed in a GValue', function () {});
-    itSkip(SKIP_GVALUE_BOXED, 'separates float from double correctly', function () {});
+    itSkip(SKIP_GVALUE_CTOR_GTYPE, 'can deal with a GValue packed in a GValue', function () {});
+    itSkip(SKIP_GVALUE_FLOAT, 'separates float from double correctly', function () {});
 });
 // The IN-with-type inference breadth + flat-GValue-array round-trips stay a later PR.
 describeSkip('phase 2.5 GValue IN — gvalue_in_with_type type inference + flat-array round-trips',

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -283,6 +283,15 @@ export function isGObjectHandle(value: unknown): boolean;
 export type BoxedHandle = { readonly __nodeGiBoxed: unique symbol };
 
 /**
+ * Allocate a fresh, zero-initialised GValue and return it as a boxed handle (GType
+ * `G_TYPE_VALUE`, owned → freed on GC). GObject.Value has no `g_value_new()`, so the
+ * L1 layer (gi.js `makeValueClass`) uses this to build a `new GObject.Value()` and
+ * then drives `.init(gtype)` / `.set_*` / `.get_*` / `.copy` / `.unset` through the
+ * boxed-method path.
+ */
+export function newGValue(): BoxedHandle;
+
+/**
  * Invoke an instance method on a boxed/struct handle (e.g. `mainLoop.run()` /
  * `mainLoop.quit()`). The method is resolved against the boxed GType's
  * introspection info and invoked with the boxed pointer as the instance.
@@ -434,6 +443,7 @@ declare const native: {
   getGType: typeof getGType;
   isInstanceOf: typeof isInstanceOf;
   isGObjectHandle: typeof isGObjectHandle;
+  newGValue: typeof newGValue;
   callBoxedMethod: typeof callBoxedMethod;
   isBoxedHandle: typeof isBoxedHandle;
   boxedMemberKind: typeof boxedMemberKind;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -329,6 +329,16 @@ export const isInstanceOf = native.isInstanceOf;
 export const isGObjectHandle = native.isGObjectHandle;
 
 /**
+ * Allocate a fresh, zero-initialised GValue and return it as a node-gi boxed
+ * handle (GType G_TYPE_VALUE, owned → freed on GC). GObject.Value has no
+ * `g_value_new()`, so the L1 layer (gi.js `makeValueClass`) uses this to build a
+ * `new GObject.Value()` and then drives `.init(gtype)` / `.set_*` / `.get_*` /
+ * `.copy` / `.unset` through the boxed-method path.
+ * @returns {unknown} opaque GObject.Value boxed handle
+ */
+export const newGValue = native.newGValue;
+
+/**
  * Invoke an instance method on a boxed/struct handle (e.g. `mainLoop.run()` /
  * `mainLoop.quit()`). The method is resolved against the boxed GType's
  * introspection info and invoked with the boxed pointer as the instance.

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -86,6 +86,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getGType", Napi::Function::New(env, GetGType));
   exports.Set("isInstanceOf", Napi::Function::New(env, IsInstanceOf));
   exports.Set("isGObjectHandle", Napi::Function::New(env, IsGObjectHandle));
+  exports.Set("newGValue", Napi::Function::New(env, NewGValue));
   // Test-only (cross-thread GC stress) — see StressRefUnrefOffThread.
   exports.Set("__stressRefUnrefOffThread", Napi::Function::New(env, StressRefUnrefOffThread));
   exports.Set("__stressRefUnrefRunning", Napi::Function::New(env, StressRefUnrefRunning));

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -397,6 +397,7 @@ Napi::Value GetTypeName(const Napi::CallbackInfo& info);
 Napi::Value GetGType(const Napi::CallbackInfo& info);
 Napi::Value IsInstanceOf(const Napi::CallbackInfo& info);
 Napi::Value IsGObjectHandle(const Napi::CallbackInfo& info);
+Napi::Value NewGValue(const Napi::CallbackInfo& info);
 
 // class.cc
 Napi::Value RegisterClass(const Napi::CallbackInfo& info);

--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -660,4 +660,24 @@ Napi::Value IsGObjectHandle(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, is);
 }
 
+// newGValue() -> a fresh, zero-initialised GObject.Value boxed handle.
+//
+// GObject.Value has no g_value_new(): a GValue is a plain struct the caller owns,
+// so GJS's `new GObject.Value()` allocates one specially (refs/gjs gi/value.cpp).
+// Allocate a zeroed GValue THROUGH the G_TYPE_VALUE boxed system —
+// g_boxed_copy(G_TYPE_VALUE, &zero) slice-dups an all-zero G_VALUE_INIT struct into
+// a fresh GValue (G_IS_VALUE(&zero) is false, so value_copy just dups the zeroed
+// bytes) — so the handle's finalizer g_boxed_free(G_TYPE_VALUE, ...) frees it via
+// the MATCHING allocator (value_free: g_value_unset + slice-free). The L1 layer
+// (gi.js makeValueClass) wraps it with the GObject.Value ergonomics
+// (.init/.set_*/.get_*/.copy/.unset via the boxed-method path). The Node twin of
+// GJS's `new GObject.Value()` (refs/gjs/modules/core/overrides/GObject.js
+// gValueConstructorFunc over realGValueClass).
+Napi::Value NewGValue(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GValue zero = G_VALUE_INIT;
+  GValue* v = static_cast<GValue*>(g_boxed_copy(G_TYPE_VALUE, &zero));
+  return MakeBoxedHandle(env, v, G_TYPE_VALUE, true);
+}
+
 }  // namespace nodegi

--- a/packages/node-gi/node-gi/test/glib-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/glib-overrides.test.mjs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+// GLib.js override-parity tests for @gjsify/node-gi (Phase 3.3).
+//
+// Covers the GLib conveniences gjs adds over introspection
+// (refs/gjs/modules/core/overrides/GLib.js): GLib.log_structured (pack fields into
+// an a{sv} + hand to g_log_variant), the one-shot idle/timeout helpers
+// (idle_add_once / timeout_add_once / timeout_add_seconds_once), and the
+// GLib.log_set_writer_func kept-throw (the JS-callback-as-GLogWriterFunc GClosure
+// IN-arg gap). log_structured's stderr output is checked byte-for-byte against the
+// GOLD STANDARD by running the SAME log call under both node-gi and `gjs -m` and
+// asserting the writer emits the identical MESSAGE + domain.
+//
+// Reference: refs/gjs/modules/core/overrides/GLib.js; verified vs gjs 1.88.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as native from '../index.js';
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const hasGjs = spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+// ---- GLib.log_structured --------------------------------------------------
+
+test('log_structured accepts string / Uint8Array / GLib.Variant fields', () => {
+  // No throw for the three supported value kinds (writes to the GLib log/stderr).
+  assert.doesNotThrow(() =>
+    GLib.log_structured('nodegi-test', GLib.LogLevelFlags.LEVEL_DEBUG, {
+      MESSAGE: 'a string field',
+      RAW: Uint8Array.of(1, 2, 3),
+      EXTRA: new GLib.Variant('s', 'a variant field'),
+    }),
+  );
+});
+
+test('log_structured rejects an unsupported field value (gjs TypeError)', () => {
+  assert.throws(
+    () => GLib.log_structured('nodegi-test', GLib.LogLevelFlags.LEVEL_DEBUG, { N: 5 }),
+    /Unsupported value .*log_structured supports GLib.Variant, Uint8Array, and string/,
+  );
+});
+
+// The log line reaches GLib's default writer on stderr — capture it from a child so
+// the C-level fd-2 write is visible. A LEVEL_MESSAGE log is emitted unconditionally
+// (no G_MESSAGES_DEBUG gate needed), so the domain + message text are deterministic.
+function logStderr(runtime) {
+  const dir = mkdtempSync(join(tmpdir(), `nodegi-log-${runtime}-`));
+  try {
+    const script = join(dir, 'probe.mjs');
+    if (runtime === 'gjs') {
+      writeFileSync(
+        script,
+        `import GLib from 'gi://GLib';\n` +
+          `GLib.log_structured('nodegi-parity', GLib.LogLevelFlags.LEVEL_MESSAGE, { MESSAGE: 'structured-gold' });\n`,
+      );
+      const res = spawnSync('gjs', ['-m', script], { encoding: 'utf8' });
+      return res.stderr;
+    }
+    writeFileSync(
+      script,
+      `import { requireGi } from ${JSON.stringify(join(pkgRoot, 'gi.js'))};\n` +
+        `const GLib = requireGi('GLib', '2.0');\n` +
+        `GLib.log_structured('nodegi-parity', GLib.LogLevelFlags.LEVEL_MESSAGE, { MESSAGE: 'structured-gold' });\n`,
+    );
+    const res = spawnSync(process.execPath, [script], {
+      encoding: 'utf8',
+      env: { ...process.env, NODE_GI_NATIVE: 'build' },
+    });
+    return res.stderr;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('log_structured emits the message + domain to the GLib writer', () => {
+  const err = logStderr('node');
+  assert.match(err, /structured-gold/, 'the MESSAGE reaches stderr');
+  assert.match(err, /nodegi-parity/, 'the log domain reaches stderr');
+});
+
+test('log_structured writer output matches gjs (gold standard)', { skip: hasGjs ? false : 'gjs not on PATH' }, () => {
+  // GLib's default writer format is identical on both; the timestamp differs, so
+  // compare the stable tail (domain-Message: <hh:mm:ss.ms>: <message>) by shape.
+  const strip = (s) => s.replace(/\d\d:\d\d:\d\d\.\d+/g, 'TIME').trim();
+  const ours = strip(logStderr('node'));
+  const theirs = strip(logStderr('gjs'));
+  assert.equal(ours, theirs, 'node-gi and gjs produce the identical structured-log line');
+});
+
+// ---- one-shot idle/timeout conveniences -----------------------------------
+
+test('idle_add_once fires exactly once (auto-removed)', () => {
+  let n = 0;
+  GLib.idle_add_once(GLib.PRIORITY_DEFAULT_IDLE, () => {
+    n++;
+  });
+  for (let i = 0; i < 8 && n === 0; i++) native.iterateMainContext(true);
+  assert.equal(n, 1, 'fired once');
+  // Drain any further ready sources — a *_once helper returned SOURCE_REMOVE, so it
+  // must not fire again.
+  for (let i = 0; i < 5; i++) native.iterateMainContext(false);
+  assert.equal(n, 1, 'did not re-fire (source removed)');
+});
+
+test('timeout_add_once fires exactly once (auto-removed)', () => {
+  let n = 0;
+  GLib.timeout_add_once(GLib.PRIORITY_DEFAULT, 0, () => {
+    n++;
+  });
+  for (let i = 0; i < 20 && n === 0; i++) native.iterateMainContext(true);
+  assert.equal(n, 1, 'fired once');
+  for (let i = 0; i < 5; i++) native.iterateMainContext(false);
+  assert.equal(n, 1, 'did not re-fire (source removed)');
+});
+
+// ---- log_set_writer_func kept-throw ---------------------------------------
+
+test('log_set_writer_func is a clear kept-throw (GLogWriterFunc IN-arg gap)', () => {
+  assert.throws(() => GLib.log_set_writer_func(() => GLib.LogWriterOutput.HANDLED), /GLogWriterFunc/);
+});
+
+test('the LogLevelFlags / LogWriterOutput surface is present', () => {
+  assert.equal(typeof GLib.LogLevelFlags.LEVEL_MESSAGE, 'number');
+  assert.equal(typeof GLib.LogWriterOutput.HANDLED, 'number');
+});

--- a/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+// GObject.js override-parity tests for @gjsify/node-gi (Phase 3.2).
+//
+// Covers the convenience surface gjs adds over introspected GObject
+// (refs/gjs/modules/core/overrides/GObject.js): the by-function signal-handler ops
+// (signal_handlers_{block,unblock,disconnect}_by_func) + their prototype-method
+// twins (block_signal_handler / unblock_signal_handler / stop_emission_by_name),
+// GObject.Value construction + set_*/get_*/copy/unset + the 2-arg convenience,
+// GObject.Object.new(gtype, props), and the AccumulatorType fake enum. Every
+// numeric behaviour is asserted against a base-typelib GObject (Gio.SimpleAction,
+// a headless GObject with a boolean `enabled` property whose set fires notify::)
+// and — for the load-bearing signal counts + GValue round-trips — checked
+// byte-for-byte against the GOLD STANDARD (the SAME probe body run under `gjs -m`).
+//
+// Reference: refs/gjs/modules/core/overrides/GObject.js; verified vs gjs 1.88.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as native from '../index.js';
+import { requireGi } from '../gi.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+const hasGjs = spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+// Run a stringifiable probe body under `gjs -m` (native gi://) with the given
+// import + call prelude, returning its stdout lines. The exactness oracle: the
+// SAME `fn` body runs on node-gi and on gjs; both print the formatted lines.
+function gjsProbeLines(fn, prelude) {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-gobj-gjs-'));
+  try {
+    const script = join(dir, 'probe.js');
+    writeFileSync(script, `${prelude}\nconst __probe = ${fn.toString()};\nfor (const l of __probe(...__args)) print(l);\n`);
+    const res = spawnSync('gjs', ['-m', script], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs probe failed: ${res.stderr}`);
+    return res.stdout.trimEnd().split('\n');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---- signal_handlers_{block,unblock,disconnect}_by_func -------------------
+
+// The shared body: connect the SAME handler twice + a third throwaway, then
+// block/unblock/disconnect BY FUNC around notify::enabled emissions, reporting the
+// hit-count and the running callback count at each step.
+function signalsByFuncProbe(GObjectNs, GioNs) {
+  const out = [];
+  const a = new GioNs.SimpleAction({ name: 'x', enabled: true });
+  let count = 0;
+  const handler = () => {
+    count++;
+  };
+  a.connect('notify::enabled', handler);
+  a.connect('notify::enabled', handler);
+  a.connect('notify::enabled', () => {});
+  a.set_enabled(false);
+  out.push(`after1 ${count}`);
+  out.push(`blocked ${GObjectNs.signal_handlers_block_by_func(a, handler)}`);
+  a.set_enabled(true);
+  out.push(`after2 ${count}`);
+  out.push(`unblocked ${GObjectNs.signal_handlers_unblock_by_func(a, handler)}`);
+  a.set_enabled(false);
+  out.push(`after3 ${count}`);
+  out.push(`disconnected ${GObjectNs.signal_handlers_disconnect_by_func(a, handler)}`);
+  a.set_enabled(true);
+  out.push(`after4 ${count}`);
+  out.push(`disc-unknown ${GObjectNs.signal_handlers_disconnect_by_func(a, () => {})}`);
+  return out;
+}
+
+test('signal_handlers_{block,unblock,disconnect}_by_func track private closures', () => {
+  const lines = signalsByFuncProbe(GObject, Gio);
+  assert.deepEqual(lines, [
+    'after1 2', // both handler connections fire (throwaway too, but count is handler-only)
+    'blocked 2', // two ids matched the function
+    'after2 2', // blocked → no increment
+    'unblocked 2', // two ids matched
+    'after3 4', // unblocked → +2
+    'disconnected 2', // two ids matched + removed
+    'after4 4', // disconnected → no increment
+    'disc-unknown 0', // an unconnected function matches nothing
+  ]);
+});
+
+test('signal by-func ops are byte-identical to gjs (gold standard)', { skip: hasGjs ? false : 'gjs not on PATH' }, () => {
+  const ours = signalsByFuncProbe(GObject, Gio).join('\n');
+  const theirs = gjsProbeLines(signalsByFuncProbe, `import GObject from 'gi://GObject';\nimport Gio from 'gi://Gio';\nconst __args = [GObject, Gio];`).join('\n');
+  assert.equal(ours, theirs, 'node-gi and gjs by-func signal ops agree line-for-line');
+});
+
+// ---- prototype-method signal conveniences ---------------------------------
+
+test('block_signal_handler / unblock_signal_handler gate a single handler by id', () => {
+  const a = new Gio.SimpleAction({ name: 'y', enabled: true });
+  let c = 0;
+  const id = a.connect('notify::enabled', () => {
+    c++;
+  });
+  a.block_signal_handler(id);
+  a.set_enabled(false);
+  assert.equal(c, 0, 'blocked handler does not fire');
+  a.unblock_signal_handler(id);
+  a.set_enabled(true);
+  assert.equal(c, 1, 'unblocked handler fires again');
+});
+
+test('stop_emission_by_name halts a signal from a handler', () => {
+  const a = new Gio.SimpleAction({ name: 'z', enabled: true });
+  let first = 0;
+  let second = 0;
+  a.connect('notify::enabled', () => {
+    first++;
+    a.stop_emission_by_name('notify::enabled');
+  });
+  a.connect('notify::enabled', () => {
+    second++;
+  });
+  a.set_enabled(false);
+  assert.equal(first, 1, 'the first handler ran');
+  assert.equal(second, 0, 'stop_emission_by_name prevented the second handler');
+});
+
+test('GObject.signal_connect / signal_emit_by_name route through the instance', () => {
+  const a = new Gio.SimpleAction({ name: 'c', enabled: true });
+  let n = 0;
+  const handler = () => {
+    n++;
+  };
+  GObject.signal_connect(a, 'notify::enabled', handler);
+  a.set_enabled(false);
+  assert.equal(n, 1);
+  // A signal_connect-registered handler is in the by-func registry too.
+  assert.equal(GObject.signal_handlers_block_by_func(a, handler), 1);
+  a.set_enabled(true);
+  assert.equal(n, 1, 'still blocked');
+});
+
+test('signal_handlers_disconnect_by_data throws the gjs not-introspectable error', () => {
+  assert.throws(() => GObject.signal_handlers_disconnect_by_data(), /not introspectable/);
+});
+
+// ---- GObject.Value --------------------------------------------------------
+
+// The shared body: build empty + typed GValues, round-trip set_*/get_*, copy, and
+// the 2-arg convenience across the fundamental types base typelibs expose.
+function valueProbe(GObjectNs) {
+  const out = [];
+  const v = new GObjectNs.Value();
+  v.init(GObjectNs.TYPE_INT);
+  v.set_int(42);
+  out.push(`int ${v.get_int()}`);
+  out.push(`string ${new GObjectNs.Value(GObjectNs.TYPE_STRING, 'hi').get_string()}`);
+  out.push(`bool ${new GObjectNs.Value(GObjectNs.TYPE_BOOLEAN, true).get_boolean()}`);
+  out.push(`double ${new GObjectNs.Value(GObjectNs.TYPE_DOUBLE, 3.5).get_double()}`);
+  out.push(`uint ${new GObjectNs.Value(GObjectNs.TYPE_UINT, 7).get_uint()}`);
+  const other = new GObjectNs.Value();
+  other.init(GObjectNs.TYPE_INT);
+  v.copy(other);
+  out.push(`copy ${other.get_int()}`);
+  out.push(`compatible ${GObjectNs.Value.type_compatible(GObjectNs.TYPE_INT, GObjectNs.TYPE_INT)}`);
+  return out;
+}
+
+test('GObject.Value: new/init/set_*/get_*/copy + the 2-arg convenience', () => {
+  const lines = valueProbe(GObject);
+  assert.deepEqual(lines, ['int 42', 'string hi', 'bool true', 'double 3.5', 'uint 7', 'copy 42', 'compatible true']);
+  // get_int returns a JS number, not a boxed handle.
+  const v = new GObject.Value();
+  v.init(GObject.TYPE_INT);
+  v.set_int(5);
+  assert.equal(typeof v.get_int(), 'number');
+  // instanceof recognises a wrapped GValue (boxed GType GValue).
+  assert.ok(v instanceof GObject.Value);
+  assert.ok(!(new Gio.SimpleAction({ name: 'q' }) instanceof GObject.Value));
+});
+
+test('GObject.Value is byte-identical to gjs (gold standard)', { skip: hasGjs ? false : 'gjs not on PATH' }, () => {
+  const ours = valueProbe(GObject).join('\n');
+  const theirs = gjsProbeLines(valueProbe, `import GObject from 'gi://GObject';\nconst __args = [GObject];`).join('\n');
+  assert.equal(ours, theirs, 'node-gi and gjs GObject.Value agree line-for-line');
+});
+
+test('GObject.Value 2-arg convenience rejects an unsupported type', () => {
+  // TYPE_NONE (void) has no setter — gjs throws a TypeError from the constructor.
+  assert.throws(() => new GObject.Value(GObject.TYPE_NONE, 1), /Invalid type argument/);
+});
+
+// ---- GObject.Object.new ---------------------------------------------------
+
+test('GObject.Object.new(gtype, props) constructs the right runtime type', () => {
+  const o = GObject.Object.new(Gio.SimpleAction.$gtype, { name: 'made', enabled: false });
+  assert.equal(o.name, 'made');
+  assert.equal(o.enabled, false);
+  assert.equal(o.get_name(), 'made'); // a real GSimpleAction instance method works
+  // A class ctor (carrying $gtype) is accepted for the gtype arg too.
+  const o2 = GObject.Object.new(Gio.SimpleAction, { name: 'ctor' });
+  assert.equal(o2.name, 'ctor');
+});
+
+test('GObject.Object.new_with_properties zips names + values', () => {
+  const o = GObject.Object.new_with_properties(Gio.SimpleAction.$gtype, ['name', 'enabled'], ['zip', false]);
+  assert.equal(o.name, 'zip');
+  assert.equal(o.enabled, false);
+  assert.throws(
+    () => GObject.Object.new_with_properties(Gio.SimpleAction.$gtype, ['name'], ['a', 'b']),
+    /equal-length arrays/,
+  );
+});
+
+// ---- bind_property (works) + bind_property_full (kept-throw) ---------------
+
+test('bind_property (no transform) is introspected and syncs', () => {
+  const src = new Gio.SimpleAction({ name: 's', enabled: true });
+  const dst = new Gio.SimpleAction({ name: 'd', enabled: false });
+  src.bind_property('enabled', dst, 'enabled', GObject.BindingFlags.SYNC_CREATE);
+  assert.equal(dst.enabled, true, 'SYNC_CREATE copied the source value');
+  src.enabled = false;
+  assert.equal(dst.enabled, false, 'a later source change propagates');
+});
+
+test('bind_property_full is a clear kept-throw (GClosure IN-arg gap)', () => {
+  const src = new Gio.SimpleAction({ name: 's2', enabled: true });
+  const dst = new Gio.SimpleAction({ name: 'd2', enabled: false });
+  assert.throws(
+    () => src.bind_property_full('enabled', dst, 'enabled', GObject.BindingFlags.DEFAULT, () => {}, null),
+    /GClosure IN-arguments/,
+  );
+});
+
+// ---- ParamFlags / SignalFlags / AccumulatorType / TYPE_* ------------------
+
+test('ParamFlags keeps every introspected bit (not just the convenience 5)', () => {
+  // READWRITE is the convenience combo; CONSTRUCT_ONLY a real bit that a hardcoded
+  // 5-member table might have dropped to undefined (→ 0). Both must be real numbers.
+  assert.equal(GObject.ParamFlags.READWRITE, 3);
+  assert.equal(typeof GObject.ParamFlags.CONSTRUCT_ONLY, 'number');
+  assert.equal(typeof GObject.ParamFlags.EXPLICIT_NOTIFY, 'number');
+});
+
+test('AccumulatorType is the gjs fake enum', () => {
+  assert.deepEqual({ ...GObject.AccumulatorType }, { NONE: 0, FIRST_WINS: 1, TRUE_HANDLED: 2 });
+});
+
+test('the fundamental GObject.TYPE_* are real process GTypes', () => {
+  // Opaque GType handles (like gjs's GType objects), resolvable by type_name.
+  assert.equal(native.getTypeName ? GObject.type_name(GObject.TYPE_INT) : 'gint', 'gint');
+  assert.equal(GObject.type_name(GObject.TYPE_STRING), 'gchararray');
+  assert.equal(GObject.type_name(GObject.TYPE_BOOLEAN), 'gboolean');
+  assert.ok(GObject.type_is_a(GObject.TYPE_INT, GObject.TYPE_INT));
+});


### PR DESCRIPTION
Phase 3.2 + 3.3: the GObject.js + GLib.js convenience override surface, verified byte-for-byte against `gjs`.

## GObject
- **`signal_handlers_{block,unblock,disconnect}_by_func`** (+ `block_signal_handler`/`unblock_signal_handler`/`stop_emission_by_name`/`signal_handlers_disconnect_by_data`): node-gi connects through private GClosures, so a per-instance `WeakMap<handle, Map<fn, Set<id>>>` populated at `connect()` maps a JS fn back to its handler ids (what gjs gets from `signals_*_symbol`). block/unblock route through introspected `g_signal_handler_{block,unblock}`. Counts matched gjs (2/2/2).
- **`GObject.Value`** — was **broken** (routed to a non-existent `Value.new`). New native `newGValue()` (allocates a zeroed GValue via the `G_TYPE_VALUE` boxed system); L1 drives init/set/get/copy/unset. `new Value()/init/set_int/get_int/copy/instanceof` matched gjs byte-for-byte.
- **`GObject.Object.new` / `new_with_properties`** via `constructType`.

## GLib
- **`log_structured`** (packs `a{sv}` → `g_log_variant`; stderr matched gjs), one-shot **`idle_add_once`/`timeout_add_once`/`timeout_add_seconds_once`**. `LogLevelFlags`/`LogWriterOutput`, spawn/env helpers already introspected.

## Kept-throw (clear messages) — all block on ONE L0 gap
`bind_property_full`, `GLib.log_set_writer_func`, and the DBus object-export path all need **a JS function marshalled as a GClosure/callback IN-argument** — a known L0 capability node-gi doesn't have yet. Each is now an actionable throw naming the gap (the highest-value follow-up: implementing GClosure-IN-arg marshalling unblocks all three).

## Test plan
- [x] rebuild 0 warnings · `npm test` **330/0** · `test:gimarshalling` **368/0** (+2 GValue-boxed specs) · `test:conformance` 15 programs × 4 runtimes · `test:bun`/`test:deno` 33/33
- [x] new `test/gobject-overrides.test.mjs` (16) + `test/glib-overrides.test.mjs` (8) with gjs parity + tier-A `gobject-overrides.conf.mjs`
- [x] process-exits-cleanly check (no eager mainloop/source/log-writer at load)

Native changes confined to `object.cc`/`common.h`/`addon.cc` (avoided calls/class/toggle per the concurrent worker.terminate effort).