### PR TITLE
feat(node-gi): marshal JS functions as GClosures

### DIFF
--- a/packages/node-gi/node-gi/binding.gyp
+++ b/packages/node-gi/node-gi/binding.gyp
@@ -10,6 +10,7 @@
         "src/loop.cc",
         "src/marshal.cc",
         "src/object.cc",
+        "src/private.cc",
         "src/repo.cc",
         "src/signals.cc",
         "src/template.cc",

--- a/packages/node-gi/node-gi/conformance/golden/gclosure-in-args.txt
+++ b/packages/node-gi/node-gi/conformance/golden/gclosure-in-args.txt
@@ -1,0 +1,7 @@
+id is number: true
+handler saw: [[true,"enabled"]]
+after disconnect: [[true,"enabled"]]
+transform-to result: "true"
+false-return keeps target: "unchanged"
+bidirectional to: "n:5"
+bidirectional from: 42

--- a/packages/node-gi/node-gi/conformance/programs/gclosure-in-args.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/gclosure-in-args.conf.mjs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// JS function → GClosure IN-argument parity (base typelibs, deterministic output).
+// A JS function passed for a GObject.Closure IN-arg is marshalled as a real
+// GClosure whose marshal converts the invocation's GValue params to JS, calls the
+// function, and marshals the JS return back. gjs is the gold standard — node / bun
+// / deno must print byte-identical output.
+//
+// Covered here (all on base GLib/GObject/Gio, no test typelib, no addresses/timers):
+//   • GObject.signal_connect_closure — a JS fn as a GClosure signal handler
+//   • GObject.Object.prototype.bind_property_full — the JS transform actually
+//     transforms (to + bidirectional from), and [false, …] leaves it unchanged.
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+// ---- signal_connect_closure ------------------------------------------------
+const action = new Gio.SimpleAction({ name: 'x', enabled: true });
+const seen = [];
+const id = GObject.signal_connect_closure(
+  action,
+  'notify::enabled',
+  (obj, pspec) => {
+    seen.push([obj === action, pspec.name]);
+  },
+  false,
+);
+print('id is number:', typeof id === 'number' && id > 0);
+action.set_enabled(false);
+print('handler saw:', JSON.stringify(seen));
+GObject.signal_handler_disconnect(action, id);
+action.set_enabled(true);
+print('after disconnect:', JSON.stringify(seen));
+
+// ---- bind_property_full ----------------------------------------------------
+const T = GObject.registerClass(
+  {
+    GTypeName: 'NodeGiConfBindFull',
+    Properties: {
+      bool: GObject.ParamSpec.boolean('bool', 'Bool', 'B', GObject.ParamFlags.READWRITE, true),
+      num: GObject.ParamSpec.int('num', 'Num', 'N', GObject.ParamFlags.READWRITE, -1000, 1000, 0),
+      string: GObject.ParamSpec.string('string', 'String', 'S', GObject.ParamFlags.READWRITE, ''),
+    },
+  },
+  class NodeGiConfBindFull extends GObject.Object {},
+);
+
+const a = new T();
+const b = new T();
+a.bind_property_full(
+  'bool',
+  b,
+  'string',
+  GObject.BindingFlags.NONE,
+  (_binding, source) => [true, `${source}`],
+  null,
+);
+a.bool = true;
+print('transform-to result:', JSON.stringify(b.string));
+
+const c = new T();
+const d = new T();
+d.string = 'unchanged';
+c.bind_property_full('num', d, 'string', GObject.BindingFlags.NONE, () => [false, 'nope'], null);
+c.num = 7;
+print('false-return keeps target:', JSON.stringify(d.string));
+
+const e = new T();
+const f = new T();
+e.bind_property_full(
+  'num',
+  f,
+  'string',
+  GObject.BindingFlags.BIDIRECTIONAL,
+  (_binding, src) => [true, `n:${src}`],
+  (_binding, src) => [true, parseInt(String(src).replace('n:', ''), 10) + 1],
+);
+e.num = 5;
+print('bidirectional to:', JSON.stringify(f.string));
+f.string = 'n:41';
+print('bidirectional from:', e.num);

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -50,10 +50,34 @@ function toKebab(name) {
   return name.replace(/([A-Z])/g, '-$1').replace(/_/g, '-').toLowerCase();
 }
 
+// Per-user-function shim cache so repeated passes of the same callback marshal to
+// the SAME native-facing function (stable identity, one ffi/GClosure wrapper per
+// user fn per call site pattern).
+const callbackShims = new WeakMap();
+
+// A JS function crossing INTO the engine (a GI callback arg, or a JS fn
+// marshalled as a GClosure IN-arg) is wrapped so that when C invokes it:
+//   • each native arg is marshalled through wrapReturn — a GObject handle becomes
+//    the cached chainable instance, a GVariant a GLib.Variant wrapper, a GParamSpec
+//    a ParamSpec wrapper — matching what GJS hands a callback;
+//   • the JS return is unwrapped back to its native handle (a GLib.Variant
+//     wrapper returned from e.g. a DBus get-property closure must reach the
+//     engine as the raw variant handle).
+// Primitives and plain objects pass through both directions untouched.
+function wrapCallbackFn(fn) {
+  let shim = callbackShims.get(fn);
+  if (shim === undefined) {
+    shim = (...args) => unwrapArg(fn(...args.map(wrapReturn)));
+    callbackShims.set(fn, shim);
+  }
+  return shim;
+}
+
 function unwrapArg(value) {
   if (value !== null && typeof value === 'object' && value[HANDLE] !== undefined) {
     return value[HANDLE];
   }
+  if (typeof value === 'function') return wrapCallbackFn(value);
   return value;
 }
 
@@ -550,23 +574,22 @@ const valueClass = makeValueClass();
 // every other member resolving from introspection. (Additive, like the GObject
 // overlay; the introspected struct-based `GLib.Variant` is replaced by the
 // ergonomic wrapper class so `new GLib.Variant(...)` + `.deepUnpack()` work.)
-// GLib.log_set_writer_func(fn) requires a JS GLogWriterFunc marshalled as a
-// GClosure/callback IN-argument (the introspected engine passes NULL for it → a
-// GLib-CRITICAL no-op), the same L0 gap that blocks bind_property_full. gjs itself
-// routes around it via GjsPrivate.log_set_writer_func; on node-gi it is a clear
-// kept-throw until the engine can marshal a JS function as a callback IN-argument.
-const LOG_SET_WRITER_FUNC_MSG =
-  'GLib.log_set_writer_func(fn) is not supported on @gjsify/node-gi yet: a JS GLogWriterFunc must ' +
-  'be marshalled as a GClosure/callback IN-argument, which the native engine cannot yet do. Use ' +
-  'GLib.log_structured or console for structured logging.';
-
 // The GLib names the L1 overlay adds/replaces on top of introspection.
+// log_set_writer_func / log_set_writer_default mirror gjs's GLib.js overrides:
+// gjs routes them through GjsPrivate (a C wrapper) because a GLogWriterFunc can
+// fire on any thread and its GLogField array is not generically introspectable —
+// node-gi's engine ships the same wrapper natively (logSetWriterFunc /
+// logSetWriterDefault, src/private.cc). The JS writer receives
+// (logLevel, fields) where fields is a plain object whose values are Uint8Arrays
+// of the field bytes (or null for empty fields) — byte-for-byte the shape gjs's
+// `{...stringFields.recursiveUnpack()}` produces (verified vs gjs 1.88).
 const GLIB_OVERLAY_NAMES = new Set([
   'log_structured',
   'idle_add_once',
   'timeout_add_once',
   'timeout_add_seconds_once',
   'log_set_writer_func',
+  'log_set_writer_default',
 ]);
 
 // GLib.log_structured(domain, level, fields): pack `fields` into an `a{sv}` and hand
@@ -620,9 +643,17 @@ function decorateGLibNamespace(baseNs) {
           return baseNs.SOURCE_REMOVE;
         });
     } else if (prop === 'log_set_writer_func') {
-      value = () => {
-        throw new Error(LOG_SET_WRITER_FUNC_MSG);
+      // The gjs GLib.js shape: a non-function clears the JS writer (logs fall
+      // back to the default writer); a function becomes the structured-log
+      // writer. NOTE (GLib contract, identical under gjs): the underlying
+      // g_log_set_writer_func may only ever be installed ONCE per process — a
+      // second install aborts inside GLib itself.
+      value = (writerFunc) => {
+        if (typeof writerFunc !== 'function') native.logSetWriterFunc(null);
+        else native.logSetWriterFunc(writerFunc);
       };
+    } else if (prop === 'log_set_writer_default') {
+      value = () => native.logSetWriterDefault();
     }
     cache.set(prop, value);
     return value;
@@ -907,23 +938,31 @@ export function stopMainContextPump() {
   }
 }
 
-// bind_property_full needs the transform-to/transform-from callbacks marshalled as
-// GClosure IN-arguments, which the native engine cannot yet do (the same L0 gap that
-// blocks GLib.log_set_writer_func and a GDBus method-export closure). gjs itself
-// avoids the introspected version via GjsPrivate.g_object_bind_property_full; on
-// node-gi there is no such shim, so this is a clear kept-throw until the engine can
-// marshal a JS function as a GClosure/callback IN-argument.
-const BIND_PROPERTY_FULL_MSG =
-  'GObject.Object.prototype.bind_property_full is not supported on @gjsify/node-gi yet: it needs ' +
-  'the JS transform-to/from closures marshalled as GClosure IN-arguments, which the native engine ' +
-  'cannot yet do. Use bind_property (no transforms), or convert the value in a notify:: handler.';
+// bind_property_full / BindingGroup.bind_full: the transform functions are driven
+// by the native GjsPrivate-mirror (src/private.cc) — the same architecture gjs
+// uses (GjsPrivate.g_object_bind_property_full / g_binding_group_bind_full),
+// because the transform's `to_value` is a write-back GValue no marshaled GClosure
+// can reach. The JS contract matches gjs byte-for-byte (verified vs gjs 1.88):
+//   (binding, sourceValue) => [ok: boolean, targetValue]
+// — sourceValue arrives unpacked, [false, …] leaves the target unchanged, a
+// non-Array return is reported and treated as no-transform. This wrapper wraps
+// the incoming binding/source into chainable L1 values and unwraps the returned
+// target value back to a native handle (object/variant-valued properties).
+function wrapBindingTransform(fn) {
+  if (typeof fn !== 'function') return null;
+  return (binding, value) => {
+    const result = fn(wrapReturn(binding), wrapReturn(value));
+    if (!Array.isArray(result)) return result; // native reports + treats as FALSE
+    return [result[0], unwrap(result[1])];
+  };
+}
 
-// gjs's GObject.Object.prototype signal-convenience methods + the bind_property_full
-// kept-throw, resolved by JS-accessor name (snake_case or camelCase). Returns a
-// `(handle, args) => result` applier, or undefined for a name we do not shim.
-// block/unblock route through the introspected single-handler g_signal_handler_*
-// functions (verified to marshal a node-gi GObject IN-arg); stop_emission_by_name
-// through g_signal_stop_emission_by_name.
+// gjs's GObject.Object.prototype signal-convenience methods + bind_property_full
+// (and BindingGroup.bind_full), resolved by JS-accessor name (snake_case or
+// camelCase). Returns a `(handle, args) => result` applier, or undefined for a
+// name we do not shim. block/unblock route through the introspected
+// single-handler g_signal_handler_* functions (verified to marshal a node-gi
+// GObject IN-arg); stop_emission_by_name through g_signal_stop_emission_by_name.
 function objectPrototypeShim(prop) {
   switch (prop) {
     case 'block_signal_handler':
@@ -940,8 +979,40 @@ function objectPrototypeShim(prop) {
         wrapReturn(native.callFunction('GObject', 'signal_stop_emission_by_name', [handle, args[0]]));
     case 'bind_property_full':
     case 'bindPropertyFull':
-      return () => {
-        throw new Error(BIND_PROPERTY_FULL_MSG);
+      return (handle, args) =>
+        wrapReturn(
+          native.bindPropertyFull(
+            handle,
+            args[0],
+            unwrap(args[1]),
+            args[2],
+            args[3],
+            wrapBindingTransform(args[4]),
+            wrapBindingTransform(args[5]),
+          ),
+        );
+    case 'bind_full':
+    case 'bindFull':
+      // GObject.BindingGroup.bind_full (gjs: GjsPrivate.g_binding_group_bind_full).
+      // Gated per instance: on any OTHER class a genuine `bind_full` method keeps
+      // resolving through the normal GI route. NOTE: without this shim the
+      // introspected name would resolve to bind_with_closures (its GIR shadow),
+      // whose write-back GValue contract a marshaled GClosure cannot satisfy.
+      return (handle, args) => {
+        if (!native.isInstanceOf(handle, 'GObject', 'BindingGroup')) {
+          return wrapReturn(native.callMethod(handle, 'bind_full', unwrapArgs(args)));
+        }
+        return wrapReturn(
+          native.bindingGroupBindFull(
+            handle,
+            args[0],
+            unwrap(args[1]),
+            args[2],
+            args[3],
+            wrapBindingTransform(args[4]),
+            wrapBindingTransform(args[5]),
+          ),
+        );
       };
     default:
       return undefined;
@@ -1024,8 +1095,8 @@ function wrapInstance(handle, userProto) {
         return () => applicationRunAsync(handle);
       }
       // gjs's GObject.Object.prototype signal conveniences (block_signal_handler /
-      // unblock_signal_handler / stop_emission_by_name) + the bind_property_full
-      // kept-throw (refs/gjs GObject.js). These are NOT introspected instance
+      // unblock_signal_handler / stop_emission_by_name) + bind_property_full and
+      // BindingGroup.bind_full (refs/gjs GObject.js). These are NOT introspected instance
       // methods — they are gjs shims over the namespace-level g_signal_* functions —
       // so route them explicitly before property / GI-method resolution.
       const shim = objectPrototypeShim(prop);
@@ -2051,7 +2122,12 @@ export function requireGi(namespace, version) {
  * @returns {unknown}
  */
 export function unwrap(value) {
-  return unwrapArg(value);
+  // NOT unwrapArg: the public unwrap only extracts handles — it must never
+  // replace a function with the engine-facing callback shim.
+  if (value !== null && typeof value === 'object' && value[HANDLE] !== undefined) {
+    return value[HANDLE];
+  }
+  return value;
 }
 
 export default requireGi;

--- a/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
+++ b/packages/node-gi/node-gi/gimarshalling/testGIMarshalling.port.mjs
@@ -1084,8 +1084,17 @@ describe('GValue', function () {
 // The IN-with-type inference breadth + flat-GValue-array round-trips stay a later PR.
 describeSkip('phase 2.5 GValue IN — gvalue_in_with_type type inference + flat-array round-trips',
     'GValue (deferred IN breadth)');
-describeSkip('phase 2.7 callbacks — GClosure in/return + callbacks with out-params + owned boxed',
-    'Callback');
+// GClosure IN-parameter: a JS function marshalled as a real GClosure (the
+// GClosure-arg primitive). The rest of the Callback suite (callback OUT-params,
+// gclosure_return) stays skipped — those need callback OUT-param marshalling /
+// invokable GObject.Closure returns, separate features.
+describe('Callback', function () {
+    describe('GClosure', function () {
+        testInParameter('gclosure', () => 42);
+    });
+});
+describeSkip('phase 2.7 callbacks — callback out-params + gclosure_return + owned boxed',
+    'Callback (deferred: callback OUT-params)');
 describeSkip('phase 2.4 structs — raw gpointer return round-trip',
     'Raw pointers');
 

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -420,6 +420,49 @@ export function setTemplateCallbackResolver(
   ) => ((...args: unknown[]) => unknown) | undefined,
 ): void;
 
+/**
+ * Install (or clear, with `null`) the structured-log writer function backing
+ * GLib.log_set_writer_func. The writer receives (logLevel, fields) where each
+ * field value is a Uint8Array of the field bytes (or null for an empty field),
+ * and returns a GLib.LogWriterOutput. NOTE: GLib permits at most ONE install per
+ * process (a second aborts in GLib).
+ */
+export function logSetWriterFunc(
+  writer: ((logLevel: number, fields: Record<string, Uint8Array | null>) => number) | null,
+): void;
+
+/** Route structured logs back to the default writer (GLib.log_set_writer_default). */
+export function logSetWriterDefault(): void;
+
+/**
+ * g_object_bind_property_full with JS transform functions (backs
+ * GObject.Object.prototype.bind_property_full). Each transform is
+ * `(binding, sourceValue) => [ok: boolean, targetValue]`. Returns the GBinding handle.
+ */
+export function bindPropertyFull(
+  source: GObjectHandle,
+  sourceProperty: string,
+  target: GObjectHandle,
+  targetProperty: string,
+  flags: number,
+  transformTo: ((...args: unknown[]) => unknown) | null,
+  transformFrom: ((...args: unknown[]) => unknown) | null,
+): GObjectHandle;
+
+/**
+ * g_binding_group_bind_full with JS transform functions (backs
+ * GObject.BindingGroup.bind_full). Same transform contract as {@link bindPropertyFull}.
+ */
+export function bindingGroupBindFull(
+  group: GObjectHandle,
+  sourceProperty: string,
+  target: GObjectHandle,
+  targetProperty: string,
+  flags: number,
+  transformTo: ((...args: unknown[]) => unknown) | null,
+  transformFrom: ((...args: unknown[]) => unknown) | null,
+): void;
+
 declare const native: {
   requireNamespace: typeof requireNamespace;
   listInfoNames: typeof listInfoNames;
@@ -461,5 +504,9 @@ declare const native: {
   emitSignal: typeof emitSignal;
   disconnectSignal: typeof disconnectSignal;
   setTemplateCallbackResolver: typeof setTemplateCallbackResolver;
+  logSetWriterFunc: typeof logSetWriterFunc;
+  logSetWriterDefault: typeof logSetWriterDefault;
+  bindPropertyFull: typeof bindPropertyFull;
+  bindingGroupBindFull: typeof bindingGroupBindFull;
 };
 export default native;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -515,4 +515,32 @@ export const disconnectSignal = native.disconnectSignal;
  */
 export const setTemplateCallbackResolver = native.setTemplateCallbackResolver;
 
+/**
+ * Install (or clear, with `null`) the structured-log writer function — the
+ * engine's twin of GjsPrivate.log_set_writer_func backing GLib.log_set_writer_func.
+ * The writer receives (logLevel: number, fields: Record<string, Uint8Array|null>)
+ * and returns a GLib.LogWriterOutput. NOTE: GLib allows at most ONE
+ * g_log_set_writer_func install per process (a second install aborts in GLib).
+ */
+export const logSetWriterFunc = native.logSetWriterFunc;
+
+/**
+ * Route structured logs back to the default writer (the engine's twin of
+ * GjsPrivate.log_set_writer_default backing GLib.log_set_writer_default).
+ */
+export const logSetWriterDefault = native.logSetWriterDefault;
+
+/**
+ * g_object_bind_property_full with JS transform functions — the engine's twin of
+ * GjsPrivate.g_object_bind_property_full backing
+ * GObject.Object.prototype.bind_property_full.
+ */
+export const bindPropertyFull = native.bindPropertyFull;
+
+/**
+ * g_binding_group_bind_full with JS transform functions — the engine's twin of
+ * GjsPrivate.g_binding_group_bind_full backing GObject.BindingGroup.bind_full.
+ */
+export const bindingGroupBindFull = native.bindingGroupBindFull;
+
 export default native;

--- a/packages/node-gi/node-gi/overrides/gio-dbus.js
+++ b/packages/node-gi/node-gi/overrides/gio-dbus.js
@@ -21,12 +21,11 @@
 //     GBusAcquiredCallback/GBusNameAppearedCallback that g_bus_own_name/watch_name
 //     take, so those namespace functions are re-implemented in JS here.
 //
-// DEFERRED — object export (Gio.DBusExportedObject.wrapJSObject): GJS builds it on
-// GjsPrivate.DBusImplementation (a C type absent on a plain Node/GI host); the
-// introspectable alternative g_dbus_connection_register_object_with_closures needs
-// GClosure IN-arguments the node-gi engine cannot yet marshal, and the plain
-// register_object takes a non-introspectable vtable. wrapJSObject therefore throws
-// a clear, actionable error (never crashes).
+// Object export (Gio.DBusExportedObject.wrapJSObject): GJS builds it on
+// GjsPrivate.DBusImplementation (a C type absent on a plain Node/GI host); node-gi
+// drives the INTROSPECTABLE g_dbus_connection_register_object_with_closures2
+// instead — three GClosures (method call / get property / set property) the engine
+// now marshals from JS functions. See wrapJSObject at the bottom of this module.
 import { addSignalMethods, _connect, _disconnect, _emit } from './_signals.js';
 
 // The `_signals` mixin's error paths (a throwing handler / a method-name clash)
@@ -506,18 +505,209 @@ export function createGioDBus(ctx) {
     },
   });
 
-  // ---- Gio.DBusExportedObject (export side — DEFERRED, clear error) ----
-  function wrapJSObject() {
-    throw new Error(
-      '@gjsify/node-gi: Gio.DBusExportedObject.wrapJSObject (exporting a JS object as a DBus ' +
-        'service) is not yet supported. GJS builds it on GjsPrivate.DBusImplementation (a ' +
-        'GJS-internal C type, absent on a plain Node/GI host); the introspectable alternative ' +
-        'g_dbus_connection_register_object_with_closures needs GClosure IN-arguments the node-gi ' +
-        'engine cannot yet marshal, and g_dbus_connection_register_object takes a non-introspectable ' +
-        'vtable. The DBus CLIENT half (Gio.DBusProxy.makeProxyWrapper) and name owning/watching ' +
-        '(Gio.DBus.own_name / watch_name) ARE supported.',
+  // ---- Gio.DBusExportedObject (export side) ---------------------------------
+  //
+  // Ported from refs/gjs Gio.js (_wrapJSObject + _handleMethodCall /
+  // _handlePropertyGet / _handlePropertySet). GJS builds this on the C type
+  // GjsPrivate.DBusImplementation (a GObject with handle-method-call /
+  // handle-property-get / handle-property-set signals); node-gi has no such type,
+  // so it instead drives the INTROSPECTABLE
+  // g_dbus_connection_register_object_with_closures2 — three GClosures whose
+  // marshal the engine now supports. The closure param shapes match glib's
+  // register_with_closures_on_* trampolines (gio/gdbusconnection.c):
+  //   method_call: (conn, sender, path, iface, method, params:Variant, invocation)
+  //   get_property: (conn, sender, path, iface, prop) -> Variant|null
+  //   set_property: (conn, sender, path, iface, prop, value:Variant) -> boolean
+  // Ownership: register_object_data_new refs+sinks its own copy of each closure
+  // and frees them on unregister_object, so the JS handler (and everything it
+  // captures) lives exactly as long as the registration. The closures2 variant
+  // does NOT transfer the invocation ref to the closure — the engine's
+  // transfer-full-instance handling refs the invocation before a return_* call,
+  // matching gjs's introspection-annotation-driven behaviour.
+
+  function _makeOutSignature(args) {
+    let ret = '(';
+    for (let i = 0; i < args.length; i++) ret += args[i].signature;
+    return `${ret})`;
+  }
+
+  function _handleDBusReply(invocation, ret) {
+    if (ret === undefined) ret = new GLib.Variant('()', []);
+    try {
+      if (!(ret instanceof GLib.Variant)) {
+        const outArgs = invocation.get_method_info().out_args;
+        const outSignature = _makeOutSignature(outArgs);
+        if (outArgs.length === 1) ret = [ret];
+        ret = new GLib.Variant(outSignature, ret);
+      }
+      invocation.return_value(ret);
+    } catch (e) {
+      logError(e, `Exception in method call: ${invocation.get_method_name()}`);
+      invocation.return_dbus_error(
+        'org.gnome.gjs.JSError.ValueError',
+        'Service implementation returned an incorrect value type',
+      );
+    }
+  }
+
+  function _handleDBusError(invocation, e) {
+    if (e instanceof GLib.Error) {
+      invocation.return_gerror(e);
+      return;
+    }
+    let name = e && e.name ? e.name : 'Error';
+    if (!name.includes('.')) name = `org.gnome.gjs.JSError.${name}`;
+    logError(e, `Exception in method call: ${invocation.get_method_name()}`);
+    invocation.return_dbus_error(name, e && e.message ? e.message : String(e));
+  }
+
+  function _handleMethodCall(jsObj, methodName, parameters, invocation) {
+    const method = jsObj[methodName];
+    if (typeof method === 'function') {
+      let retval;
+      try {
+        const args = parameters.deepUnpack();
+        retval = method.apply(jsObj, args);
+      } catch (e) {
+        _handleDBusError(invocation, e);
+        return;
+      }
+      // A Promise-returning (async) method resolves to the reply.
+      if (retval && typeof retval.then === 'function') {
+        retval.then(
+          (r) => _handleDBusReply(invocation, r),
+          (e) => _handleDBusError(invocation, e),
+        );
+        return;
+      }
+      _handleDBusReply(invocation, retval);
+      return;
+    }
+
+    const asyncMethod = jsObj[`${methodName}Async`];
+    if (typeof asyncMethod === 'function') {
+      let ret;
+      try {
+        ret = asyncMethod.call(jsObj, parameters.deepUnpack(), invocation);
+      } catch (e) {
+        _handleDBusError(invocation, e);
+        return;
+      }
+      if (ret && typeof ret.catch === 'function') ret.catch((e) => _handleDBusError(invocation, e));
+      return;
+    }
+
+    logError(new Error(), `Missing handler for DBus method ${methodName}`);
+    invocation.return_dbus_error(
+      'org.freedesktop.DBus.Error.UnknownMethod',
+      `Method ${methodName} is not implemented`,
     );
   }
+
+  function _handlePropertyGet(jsObj, info, propertyName) {
+    const propInfo = info.lookup_property(propertyName);
+    const jsval = jsObj[propertyName];
+    if (jsval === undefined || jsval === null) return null;
+    if (jsval instanceof GLib.Variant) return jsval;
+    return new GLib.Variant(propInfo.signature, jsval);
+  }
+
+  function _handlePropertySet(jsObj, propertyName, newValue) {
+    jsObj[propertyName] = newValue.deepUnpack();
+    return true;
+  }
+
+  function wrapJSObject(interfaceInfo, jsObj) {
+    let info;
+    if (isGioInstance(interfaceInfo, 'DBusInterfaceInfo')) info = interfaceInfo;
+    else info = _newInterfaceInfo(interfaceInfo);
+    // cache_build is required so lookup_property/method work off the info.
+    info.cache_build();
+    const ifaceName = info.name;
+
+    // Every connection this object is exported on: { connection, registrationId }.
+    const registrations = [];
+
+    const impl = {
+      get_info: () => info,
+      get_object_path: () => impl._objectPath,
+      get_connection: () => impl._connection,
+      _objectPath: null,
+      _connection: null,
+
+      export(connection, path) {
+        // register_object_with_closures2 (since 2.84): closures for method call /
+        // get property / set property. Passing JS functions marshals each to a
+        // real GClosure (the engine's GClosure IN-arg support). Returns the
+        // registration id (throws on error).
+        const id = connection.register_object_with_closures2(
+          path,
+          info,
+          (_conn, _sender, _path, _iface, method, params, invocation) =>
+            _handleMethodCall(jsObj, method, params, invocation),
+          (_conn, _sender, _path, _iface, prop) => _handlePropertyGet(jsObj, info, prop),
+          (_conn, _sender, _path, _iface, prop, value) => _handlePropertySet(jsObj, prop, value),
+        );
+        registrations.push({ connection, id });
+        impl._connection = connection;
+        impl._objectPath = path;
+        return id;
+      },
+
+      unexport() {
+        for (const { connection, id } of registrations.splice(0)) {
+          connection.unregister_object(id);
+        }
+        impl._connection = null;
+      },
+
+      unexport_from_connection(connection) {
+        const handle = unwrap(connection);
+        for (let i = registrations.length - 1; i >= 0; i--) {
+          if (unwrap(registrations[i].connection) === handle) {
+            registrations[i].connection.unregister_object(registrations[i].id);
+            registrations.splice(i, 1);
+          }
+        }
+        if (registrations.length === 0) impl._connection = null;
+      },
+
+      emit_signal(name, parameters = null) {
+        for (const { connection } of registrations) {
+          connection.emit_signal(null, impl._objectPath, ifaceName, name, parameters);
+        }
+      },
+
+      emit_property_changed(name, value) {
+        const changed = {};
+        changed[name] = value;
+        const params = new GLib.Variant('(sa{sv}as)', [ifaceName, changed, []]);
+        for (const { connection } of registrations) {
+          connection.emit_signal(
+            null,
+            impl._objectPath,
+            'org.freedesktop.DBus.Properties',
+            'PropertiesChanged',
+            params,
+          );
+        }
+      },
+
+      flush() {
+        for (const { connection } of registrations) connection.flush(null);
+      },
+    };
+    // camelCase aliases (GJS's DBusImplementation exposes snake_case; keep both
+    // so either spelling works, matching the rest of the node-gi surface).
+    impl.getInfo = impl.get_info;
+    impl.getObjectPath = impl.get_object_path;
+    impl.getConnection = impl.get_connection;
+    impl.unexportFromConnection = impl.unexport_from_connection;
+    impl.emitSignal = impl.emit_signal;
+    impl.emitPropertyChanged = impl.emit_property_changed;
+    return impl;
+  }
+
   const DBusExportedObject = { wrapJSObject };
 
   return { DBus, DBusProxy, DBusExportedObject };

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -45,6 +45,7 @@ const CONFORMANCE = [
   'closure-exception',
   'construct-camelcase',
   'enums-constants',
+  'gclosure-in-args',
   'gettext',
   'gi',
   'globals',

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -111,6 +111,12 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("disconnectSignal", Napi::Function::New(env, DisconnectSignal));
   exports.Set("setTemplateCallbackResolver",
               Napi::Function::New(env, SetTemplateCallbackResolver));
+  // GjsPrivate-mirroring helpers (private.cc): the structured-log writer func +
+  // the bind_property_full / BindingGroup.bind_full transform trampolines.
+  exports.Set("logSetWriterFunc", Napi::Function::New(env, LogSetWriterFunc));
+  exports.Set("logSetWriterDefault", Napi::Function::New(env, LogSetWriterDefault));
+  exports.Set("bindPropertyFull", Napi::Function::New(env, BindPropertyFull));
+  exports.Set("bindingGroupBindFull", Napi::Function::New(env, BindingGroupBindFull));
   // The native cairo binding + foreign-struct registration (the `__cairo` export).
   InitCairo(env, exports);
   return exports;

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -404,7 +404,28 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   // is handed to the C callee). Sized once to n_args so the addresses never move.
   std::vector<GIArgument> slots(n_args);
   std::vector<std::string> held(n_args);
-  if (isMethod) in_args[0].v_pointer = instance;
+  bool instanceRefTaken = false;  // the transfer-full-instance ref below, undone on early bail
+  if (isMethod) {
+    in_args[0].v_pointer = instance;
+    // A transfer-full INSTANCE parameter (rare but load-bearing:
+    // g_dbus_method_invocation_return_value/_return_error/… — "this method will
+    // take ownership of @invocation") CONSUMES one ref of the instance. Our JS
+    // wrapper keeps its own ref for the handle's lifetime (its finalizer unrefs),
+    // so hand the callee a ref of its own — exactly what gjs's arg-cache does for
+    // the instance argument — otherwise the wrapper's later unref double-frees.
+    // Only a GObject instance can be safely ref'd here; the transfer-full-instance
+    // methods in the base typelibs are all GObject methods (a boxed instance
+    // method reaching this path keeps the previous behaviour).
+    if (gi_callable_info_get_instance_ownership_transfer(callable) == GI_TRANSFER_EVERYTHING) {
+      // gi_base_info_get_container returns a borrowed ref — no unref.
+      GIBaseInfo* container = gi_base_info_get_container(reinterpret_cast<GIBaseInfo*>(func));
+      if (container != nullptr && GI_IS_OBJECT_INFO(container) &&
+          G_IS_OBJECT(static_cast<GObject*>(instance))) {
+        g_object_ref(static_cast<GObject*>(instance));
+        instanceRefTaken = true;
+      }
+    }
+  }
 
   // Pre-scan: the user_data + destroy-notify slots associated with a callback
   // arg are filled from the callback, not consumed from the JS argument list.
@@ -470,6 +491,11 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   std::vector<gpointer> ownedInStrings;
   std::vector<NodeGiCallback*> created;    // all callbacks made this call
   std::vector<NodeGiCallback*> callScope;  // scope=call → freed after the invoke
+  // JS functions marshalled as GClosure IN-args this call (see common.h). Each
+  // carries one ref taken at marshal time (gjs's ref+sink): transfer-none refs are
+  // dropped after the invoke, transfer-full refs belong to the callee (dropped
+  // only when the callee never ran).
+  CreatedClosures createdClosures;
   bool ok = true;
   size_t jsCursor = 0;
   for (unsigned int i = 0; i < n_args && ok; i++) {
@@ -714,7 +740,8 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
         }
       } else {
         GITransfer tr = gi_arg_info_get_ownership_transfer(ai);
-        ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i], tr, &ownedInStrings);
+        ok = JsToGIArgument(env, v, ti, &in_args[inPos[i]], &held[i], tr, &ownedInStrings,
+                            &createdClosures);
       }
     }
 
@@ -725,6 +752,12 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   if (!ok) {
     for (NodeGiCallback* cb : created) NodeGiCallbackFree(cb);
     for (const InContainer& c : inContainers) FreeInContainer(c);
+    // The callee never ran, so NO closure ref was adopted — release every created
+    // closure (refcount 1 → 0 → finalize drops the JS-function ref).
+    for (GClosure* c : createdClosures.transferNone) g_closure_unref(c);
+    for (GClosure* c : createdClosures.transferFull) g_closure_unref(c);
+    // Likewise the transfer-full-instance ref: the callee never consumed it.
+    if (instanceRefTaken) g_object_unref(static_cast<GObject*>(instance));
     for (gpointer s : ownedInStrings) g_free(s);  // never reached the callee (#658)
     // Caller-allocated blobs never reached the callee (or it was never called) —
     // they are zeroed g_malloc0 storage, so a plain g_free is correct here.
@@ -740,6 +773,14 @@ static Napi::Value InvokeFunctionInfo(Napi::Env env, GIFunctionInfo* func, gpoin
   // Call-scope closures are only valid for the duration of the invoke; free them
   // now (notified/async closures are owned by the callee / self-freeing).
   for (NodeGiCallback* cb : callScope) NodeGiCallbackFree(cb);
+  // Transfer-none GClosure IN-args: drop the ref taken at marshal time (gjs
+  // BoxedInTransferNone::release, which runs on success AND error paths). A
+  // callee that stored the closure (signal connect, source_set_closure, a DBus
+  // registration) holds its own ref+sink, so the closure lives on; a callee that
+  // only invoked it synchronously lets this unref finalize it (dropping the JS
+  // ref). Transfer-full closures were adopted by the callee — no release (gjs
+  // GClosureIn::release skips).
+  for (GClosure* c : createdClosures.transferNone) g_closure_unref(c);
   if (!success) {
     for (const InContainer& c : inContainers) FreeInContainer(c);
     // A failed invoke did not adopt the transfer-full IN/INOUT strings we g_strdup'd

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -229,14 +229,40 @@ inline void WarnIfUnsafeUint64(uint64_t v) {
               std::to_string(v).c_str());
 }
 
+// ---- JS function -> GClosure IN-args ----------------------------------------
+//
+// A JS function passed for a `GObject.Closure`-typed IN parameter (e.g.
+// g_signal_connect_closure, g_source_set_closure, GIMarshallingTests.gclosure_in,
+// g_dbus_connection_register_object_with_closures2) is marshalled as a REAL
+// GClosure whose marshal converts the invocation's GValue params to JS, calls the
+// function, and writes the JS return into the return GValue — mirroring GJS's
+// Gjs::Closure::create_marshaled "boxed" closures (refs/gjs/gi/arg-cache.cpp
+// GClosureInTransferNone::in + gi/closure.cpp). Lifetime follows gjs exactly:
+// the closure is ref'd + sunk at marshal time; a transfer-none arg drops that ref
+// after the invoke (the callee keeps its own if it stored the closure), a
+// transfer-full arg leaves it with the callee. Closures created during an invoke
+// are recorded here so calls.cc can release them on the right path.
+struct CreatedClosures {
+  std::vector<GClosure*> transferNone;  // unref after the invoke (gjs BoxedInTransferNone::release)
+  std::vector<GClosure*> transferFull;  // callee adopts; unref only when the callee never ran
+};
+
+// Build the (floating) marshaled GClosure for a JS function (signals.cc — shares
+// the battle-tested JsClosure marshal/finalize machinery with `.connect()`).
+GClosure* NodeGiMakeGenericJsClosure(Napi::Env env, Napi::Value fn);
+
 // `ownedStrings` (optional): when a transfer-full string IN/INOUT arg is g_strdup'd
 // here, the freshly-allocated pointer is appended so the caller can g_free it if the
 // invoke never adopts it (an arg-marshal error before the call, or a failed invoke).
 // nullptr (the default) → no tracking, for the vfunc-return / signal-arg callers.
+// `closures` (optional): enables the JS-function→GClosure IN-arg marshalling above;
+// nullptr (the default) keeps the previous behaviour (function → TypeError) on
+// paths that cannot release a created closure.
 bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* out,
                     std::string* heldString,
                     GITransfer transfer = GI_TRANSFER_NOTHING,
-                    std::vector<gpointer>* ownedStrings = nullptr);
+                    std::vector<gpointer>* ownedStrings = nullptr,
+                    CreatedClosures* closures = nullptr);
 
 // ---- IN container building -----------------------------------------
 //
@@ -471,6 +497,18 @@ Napi::Value ConnectSignal(const Napi::CallbackInfo& info);
 Napi::Value EmitSignal(const Napi::CallbackInfo& info);
 Napi::Value DisconnectSignal(const Napi::CallbackInfo& info);
 Napi::Value SetTemplateCallbackResolver(const Napi::CallbackInfo& info);
+
+// private.cc — GjsPrivate-mirroring helpers (refs/gjs/libgjs-private/gjs-util.c).
+// The structured-log writer func + the bind_property_full/bind_full transform
+// trampolines, which need a C wrapper for the same reasons GJS uses GjsPrivate:
+// the GLogWriterFunc can fire on ANY thread (JS only runs on the registration
+// thread; other threads fall back to the default writer) and the GLogField array
+// is not generically introspectable; the binding transform's `to_value` is a
+// write-back OUT GValue no marshaled GClosure can reach.
+Napi::Value LogSetWriterFunc(const Napi::CallbackInfo& info);
+Napi::Value LogSetWriterDefault(const Napi::CallbackInfo& info);
+Napi::Value BindPropertyFull(const Napi::CallbackInfo& info);
+Napi::Value BindingGroupBindFull(const Napi::CallbackInfo& info);
 
 // loop.cc
 Napi::Value StartMainLoop(const Napi::CallbackInfo& info);

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -231,7 +231,8 @@ bool UnwrapGTypeArg(Napi::Env env, Napi::Value v, GType* out) {
 bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* out,
                     std::string* heldString,
                     GITransfer transfer,
-                    std::vector<gpointer>* ownedStrings) {
+                    std::vector<gpointer>* ownedStrings,
+                    CreatedClosures* closures) {
   if (v.IsEmpty()) {
     // Residue of a swallowed napi failure (a fallible Get()/coercion upstream
     // failed on a terminating env, or a throwing getter left the exception
@@ -308,6 +309,25 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
               gi_base_info_unref(iface);
               return false;  // to() already threw
             }
+            handled = true;
+          } else if (v.IsFunction() && closures != nullptr &&
+                     gi_registered_type_info_get_g_type(
+                         reinterpret_cast<GIRegisteredTypeInfo*>(iface)) == G_TYPE_CLOSURE) {
+            // A JS function for a `GObject.Closure` IN-arg → a real marshaled
+            // GClosure, exactly as gjs (refs/gjs/gi/arg-cache.cpp
+            // GClosureInTransferNone::in: create_marshaled + g_closure_ref +
+            // g_closure_sink). The ref taken here is released by calls.cc after
+            // the invoke for transfer-none (gjs BoxedInTransferNone::release —
+            // the callee keeps its own ref if it stored the closure), and left
+            // with the callee for transfer-full (gjs GClosureIn::release skips).
+            // An existing GObject.Closure boxed handle still routes through the
+            // boxed-handle branch below.
+            GClosure* closure = NodeGiMakeGenericJsClosure(env, v);
+            g_closure_ref(closure);
+            g_closure_sink(closure);
+            out->v_pointer = closure;
+            if (transfer == GI_TRANSFER_NOTHING) closures->transferNone.push_back(closure);
+            else closures->transferFull.push_back(closure);
             handled = true;
           } else if (v.IsNull() || v.IsUndefined()) {
             // Boxed/struct IN args arrive as boxed handles; null/undefined maps to

--- a/packages/node-gi/node-gi/src/private.cc
+++ b/packages/node-gi/node-gi/src/private.cc
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: MIT
+// GjsPrivate-mirroring helpers: the structured-log writer func + the
+// bind_property_full / BindingGroup.bind_full transform trampolines.
+//
+// Reference: refs/gjs/libgjs-private/gjs-util.c (gjs_log_set_writer_func /
+// gjs_log_writer_func_wrapper / gjs_log_set_writer_default /
+// gjs_g_object_bind_property_full / gjs_g_binding_group_bind_full). GJS routes
+// these APIs through a private C library instead of introspection because:
+//   • a GLogWriterFunc can fire on ANY thread, but JS only runs on the thread
+//     that registered the writer — off-thread logs must fall back to the default
+//     writer in C, before any JS is entered;
+//   • the GLogField array (key + length-or-NUL-terminated value) is not
+//     generically introspectable — the C wrapper converts it field-by-field;
+//   • the binding transform's `to_value` is a WRITE-BACK GValue pre-initialised
+//     to the target property's type; a marshaled GClosure (which unboxes GValue
+//     params, per gjs's own closure marshal) cannot reach it, so gjs — and we —
+//     use plain C transform callbacks with g_object_bind_property_full.
+// node-gi mirrors that architecture 1:1 so the JS-visible contract matches gjs
+// byte-for-byte (verified: scratch gold runs vs gjs 1.88 — see the test file).
+
+#include <cstring>
+
+#include "common.h"
+
+namespace nodegi {
+
+// ---- GLib.log_set_writer_func ----------------------------------------------
+//
+// Process-global writer state, mirroring gjs-util.c's statics. GLib enforces at
+// most ONE g_log_set_writer_func call per process (a second call is a fatal
+// g_error — gjs behaves identically), so a single static slot is faithful.
+static bool g_logWriterCleared = false;
+static napi_env g_logWriterEnv = nullptr;
+static napi_ref g_logWriterFn = nullptr;
+static GThread* g_logWriterThread = nullptr;
+
+// Env teardown with the writer still installed: logs after this point must go to
+// the default writer, and the napi_ref must not be touched on a dead env.
+static void LogWriterEnvCleanup(void* arg) {
+  if (g_logWriterEnv != static_cast<napi_env>(arg)) return;
+  g_logWriterCleared = true;
+  // Deleting the ref during env cleanup is safe (the env is still tearing down,
+  // not freed); afterwards the wrapper never dereferences it again.
+  if (g_logWriterFn != nullptr) {
+    napi_delete_reference(g_logWriterEnv, g_logWriterFn);
+    g_logWriterFn = nullptr;
+  }
+  g_logWriterEnv = nullptr;
+}
+
+// The C writer installed into GLib — the twin of gjs_log_writer_func_wrapper.
+// Converts the GLogField array to a plain JS object whose values match gjs's
+// `{...stringFields.recursiveUnpack()}` shape exactly (verified vs gjs 1.88):
+//   length < 0 (NUL-terminated) → Uint8Array of strlen bytes
+//   length > 0 (binary)         → Uint8Array of length bytes
+//   length == 0                 → null (gjs packs a maybe-nothing → null)
+// and calls the JS writer as (logLevel: number, fields: object) expecting a
+// GLib.LogWriterOutput number back; UNHANDLED (or a throw, or an off-thread /
+// cleared / teardown call) falls back to g_log_writer_default.
+static GLogWriterOutput NodeGiLogWriterWrapper(GLogLevelFlags log_level, const GLogField* fields,
+                                               gsize n_fields, gpointer /*user_data*/) {
+  if (g_logWriterCleared || g_thread_self() != g_logWriterThread || g_logWriterFn == nullptr ||
+      g_logWriterEnv == nullptr) {
+    return g_log_writer_default(log_level, fields, n_fields, nullptr);
+  }
+  napi_env env = g_logWriterEnv;
+  if (!NodeGiJsAvailable(env)) {
+    return g_log_writer_default(log_level, fields, n_fields, nullptr);
+  }
+  Napi::Env napiEnv(env);
+  Napi::HandleScope scope(napiEnv);
+
+  // Field values are plain Uint8Arrays (NOT Node Buffers): gjs's recursiveUnpack
+  // of the maybe-bytestring fields yields Uint8Array — and e.g. JSON.stringify of
+  // the two differs, so the distinction is observable byte-for-byte.
+  auto bytesValue = [&](const void* data, size_t len) -> Napi::Value {
+    Napi::Uint8Array arr = Napi::Uint8Array::New(env, len);
+    if (len > 0) memcpy(arr.Data(), data, len);
+    return arr;
+  };
+  Napi::Object obj = Napi::Object::New(napiEnv);
+  for (gsize i = 0; i < n_fields; i++) {
+    const GLogField* field = &fields[i];
+    if (field->key == nullptr) continue;
+    Napi::Value value;
+    if (field->length < 0) {
+      const char* s = static_cast<const char*>(field->value);
+      value = bytesValue(s, s != nullptr ? strlen(s) : 0);
+    } else if (field->length > 0) {
+      value = bytesValue(field->value, static_cast<size_t>(field->length));
+    } else {
+      value = napiEnv.Null();
+    }
+    obj.Set(field->key, value);
+  }
+
+  napi_value fn = nullptr;
+  if (napi_get_reference_value(env, g_logWriterFn, &fn) != napi_ok || fn == nullptr) {
+    return g_log_writer_default(log_level, fields, n_fields, nullptr);
+  }
+  napi_value global = nullptr;
+  napi_get_global(env, &global);
+  napi_value args[2] = {Napi::Number::New(napiEnv, static_cast<double>(log_level)), obj};
+  napi_value ret = nullptr;
+  napi_status st = napi_make_callback(env, nullptr, global, fn, 2, args, &ret);
+  if (st != napi_ok || napiEnv.IsExceptionPending()) {
+    // A throwing writer must never wedge the logging path (nor leave a pending
+    // exception across the C boundary): surface + clear, then default-write.
+    SurfacePendingException(env, "GLib log writer func");
+    return g_log_writer_default(log_level, fields, n_fields, nullptr);
+  }
+  GLogWriterOutput output =
+      static_cast<GLogWriterOutput>(NodeGiToInt32(Napi::Value(env, ret)));
+  if (output == G_LOG_WRITER_UNHANDLED) {
+    return g_log_writer_default(log_level, fields, n_fields, nullptr);
+  }
+  return output;
+}
+
+// logSetWriterFunc(fn | null) -> void. Installs the wrapper into GLib (a second
+// call aborts inside GLib itself — "g_log_set_writer_func() called multiple
+// times" — exactly as under gjs). fn == null re-arms the default fallback.
+Napi::Value LogSetWriterFunc(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::Value fn = info.Length() >= 1 ? info[0] : env.Null();
+
+  // Replace any previous JS-side state (the GLib-side wrapper can only ever be
+  // installed once; the JS fn/env slots are ours to swap).
+  if (g_logWriterFn != nullptr && g_logWriterEnv != nullptr) {
+    napi_delete_reference(g_logWriterEnv, g_logWriterFn);
+    g_logWriterFn = nullptr;
+  }
+  g_logWriterEnv = env;
+  g_logWriterThread = g_thread_self();
+  g_logWriterCleared = false;
+  if (fn.IsFunction()) {
+    napi_create_reference(env, fn, 1, &g_logWriterFn);
+  }
+  // The cleanup hook is registered once (adding an identical fn+arg pair twice is
+  // an N-API fatal). GLib itself enforces at most one g_log_set_writer_func call
+  // per process, so a single hook covers every reachable state.
+  static bool hookAdded = false;
+  if (!hookAdded) {
+    napi_add_env_cleanup_hook(env, LogWriterEnvCleanup, env);
+    hookAdded = true;
+  }
+  g_log_set_writer_func(NodeGiLogWriterWrapper, nullptr, nullptr);
+  return env.Undefined();
+}
+
+// logSetWriterDefault() -> void. The twin of gjs_log_set_writer_default: the
+// GLib-side writer stays installed (it can never be swapped back), but every
+// subsequent log is routed to g_log_writer_default by the cleared flag.
+Napi::Value LogSetWriterDefault(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (g_logWriterFn != nullptr && g_logWriterEnv != nullptr) {
+    napi_delete_reference(g_logWriterEnv, g_logWriterFn);
+    g_logWriterFn = nullptr;
+  }
+  g_logWriterEnv = nullptr;
+  g_logWriterThread = g_thread_self();
+  g_logWriterCleared = true;
+  return env.Undefined();
+}
+
+// ---- bind_property_full / BindingGroup.bind_full ---------------------------
+//
+// The twin of gjs_g_object_bind_property_full: the JS transform functions are
+// held per binding and driven by plain C GBindingTransformFunc trampolines. The
+// JS contract (gjs gold standard, verified vs gjs 1.88):
+//   (binding, sourceValue) => [ok: boolean, targetValue]
+// — sourceValue arrives UNPACKED, a truthy ok writes targetValue into the
+// pre-initialised target GValue, [false, …] leaves the target unchanged, and a
+// non-Array return is reported (gjs logs "returned unexpected value, expecting
+// an Array") and treated as no-transform.
+struct NodeGiBindingTransforms {
+  napi_env env;
+  napi_ref toFn;    // nullptr when no transform-to
+  napi_ref fromFn;  // nullptr when no transform-from
+};
+
+static gboolean NodeGiBindingTransformInvoke(GBinding* binding, const GValue* from_value,
+                                             GValue* to_value, NodeGiBindingTransforms* data,
+                                             napi_ref fnRef) {
+  if (data == nullptr || fnRef == nullptr) return FALSE;
+  napi_env env = data->env;
+  // A binding transform fired at env teardown (a dispose cascade) must not enter
+  // JS — treat as no-transform, like the signal/callback teardown gates.
+  if (!NodeGiJsAvailable(env)) return FALSE;
+  Napi::Env napiEnv(env);
+  Napi::HandleScope scope(napiEnv);
+
+  napi_value fn = nullptr;
+  if (napi_get_reference_value(env, fnRef, &fn) != napi_ok || fn == nullptr) return FALSE;
+
+  napi_value args[2] = {WrapGObject(napiEnv, G_OBJECT(binding), GI_TRANSFER_NOTHING),
+                        GValueToJs(napiEnv, from_value)};
+  if (napiEnv.IsExceptionPending()) {
+    SurfacePendingException(env, "property binding transform");
+    return FALSE;
+  }
+  napi_value global = nullptr;
+  napi_get_global(env, &global);
+  napi_value ret = nullptr;
+  napi_status st = napi_make_callback(env, nullptr, global, fn, 2, args, &ret);
+  if (st != napi_ok || napiEnv.IsExceptionPending()) {
+    SurfacePendingException(env, "property binding transform");
+    return FALSE;
+  }
+  Napi::Value retVal(env, ret);
+  if (!retVal.IsArray()) {
+    // gjs: "Call to unnamed function (GjsPrivate.BindingTransformFunc) returned
+    // unexpected value, expecting an Array" — logged, transform treated as FALSE.
+    g_printerr("\n(node-gi) property binding transform returned unexpected value, "
+               "expecting an Array [ok, value]\n");
+    return FALSE;
+  }
+  Napi::Array arr = retVal.As<Napi::Array>();
+  if (!NodeGiToBool(arr.Get(uint32_t{0}))) return FALSE;
+  if (!JsToGValue(napiEnv, arr.Get(uint32_t{1}), to_value)) {
+    SurfacePendingException(env, "property binding transform");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+static gboolean NodeGiBindingTransformTo(GBinding* binding, const GValue* from_value,
+                                         GValue* to_value, gpointer user_data) {
+  NodeGiBindingTransforms* data = static_cast<NodeGiBindingTransforms*>(user_data);
+  return NodeGiBindingTransformInvoke(binding, from_value, to_value, data,
+                                      data != nullptr ? data->toFn : nullptr);
+}
+
+static gboolean NodeGiBindingTransformFrom(GBinding* binding, const GValue* from_value,
+                                           GValue* to_value, gpointer user_data) {
+  NodeGiBindingTransforms* data = static_cast<NodeGiBindingTransforms*>(user_data);
+  return NodeGiBindingTransformInvoke(binding, from_value, to_value, data,
+                                      data != nullptr ? data->fromFn : nullptr);
+}
+
+// GDestroyNotify for the transforms — runs when the binding is destroyed
+// (unbind / source finalized). Deleting a napi_ref needs a live env; at real env
+// teardown the refs are reclaimed with the env, so skipping is leak-free.
+static void NodeGiBindingTransformsFree(gpointer user_data) {
+  NodeGiBindingTransforms* data = static_cast<NodeGiBindingTransforms*>(user_data);
+  if (data == nullptr) return;
+  if (NodeGiJsAvailable(data->env)) {
+    if (data->toFn != nullptr) napi_delete_reference(data->env, data->toFn);
+    if (data->fromFn != nullptr) napi_delete_reference(data->env, data->fromFn);
+  }
+  delete data;
+}
+
+// Shared arg parsing + invocation for bindPropertyFull / bindingGroupBindFull.
+// info: (sourceHandle|groupHandle, sourceProperty, targetHandle, targetProperty,
+//        flags, toFn|null, fromFn|null)
+static bool ParseBindFullArgs(const Napi::CallbackInfo& info, GObject** instance,
+                              std::string* sourceProp, GObject** target, std::string* targetProp,
+                              GBindingFlags* flags, NodeGiBindingTransforms** outData) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 5 || !info[1].IsString() || !info[3].IsString()) {
+    Napi::TypeError::New(env,
+                         "bindPropertyFull(handle, sourceProperty: string, targetHandle, "
+                         "targetProperty: string, flags: number, transformTo?, transformFrom?)")
+        .ThrowAsJavaScriptException();
+    return false;
+  }
+  *instance = UnwrapGObject(env, info[0]);
+  if (*instance == nullptr) return false;
+  *sourceProp = info[1].As<Napi::String>().Utf8Value();
+  *target = UnwrapGObject(env, info[2]);
+  if (*target == nullptr) return false;
+  *targetProp = info[3].As<Napi::String>().Utf8Value();
+  *flags = static_cast<GBindingFlags>(NodeGiToInt32(info[4]));
+
+  Napi::Value toFn = info.Length() >= 6 ? info[5] : env.Null();
+  Napi::Value fromFn = info.Length() >= 7 ? info[6] : env.Null();
+  bool hasTo = toFn.IsFunction();
+  bool hasFrom = fromFn.IsFunction();
+  NodeGiBindingTransforms* data = nullptr;
+  if (hasTo || hasFrom) {
+    data = new NodeGiBindingTransforms();
+    data->env = env;
+    data->toFn = nullptr;
+    data->fromFn = nullptr;
+    if (hasTo) napi_create_reference(env, toFn, 1, &data->toFn);
+    if (hasFrom) napi_create_reference(env, fromFn, 1, &data->fromFn);
+  }
+  *outData = data;
+  return true;
+}
+
+// bindPropertyFull(sourceHandle, sourceProperty, targetHandle, targetProperty,
+//                  flags, transformTo|null, transformFrom|null) -> Binding handle
+Napi::Value BindPropertyFull(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GObject* source = nullptr;
+  GObject* target = nullptr;
+  std::string sourceProp, targetProp;
+  GBindingFlags flags = G_BINDING_DEFAULT;
+  NodeGiBindingTransforms* data = nullptr;
+  if (!ParseBindFullArgs(info, &source, &sourceProp, &target, &targetProp, &flags, &data)) {
+    return env.Null();
+  }
+  GBinding* binding = g_object_bind_property_full(
+      source, sourceProp.c_str(), target, targetProp.c_str(), flags,
+      data != nullptr && data->toFn != nullptr ? NodeGiBindingTransformTo : nullptr,
+      data != nullptr && data->fromFn != nullptr ? NodeGiBindingTransformFrom : nullptr, data,
+      data != nullptr ? NodeGiBindingTransformsFree : nullptr);
+  if (binding == nullptr) {
+    // g_object_bind_property_full already freed `data` via the destroy notify on
+    // its g_return_val_if_fail paths? It does NOT (precondition failures return
+    // before adopting user_data) — free it here so a bad property name doesn't
+    // leak the refs.
+    NodeGiBindingTransformsFree(data);
+    Napi::Error::New(env, "bind_property_full failed (unknown property?)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+  // The binding return is (transfer none) — WrapGObject takes its own ref.
+  return WrapGObject(env, G_OBJECT(binding), GI_TRANSFER_NOTHING);
+}
+
+// bindingGroupBindFull(groupHandle, sourceProperty, targetHandle, targetProperty,
+//                      flags, transformTo|null, transformFrom|null) -> undefined
+// The twin of gjs_g_binding_group_bind_full (GObject.BindingGroup.bind_full).
+Napi::Value BindingGroupBindFull(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  GObject* group = nullptr;
+  GObject* target = nullptr;
+  std::string sourceProp, targetProp;
+  GBindingFlags flags = G_BINDING_DEFAULT;
+  NodeGiBindingTransforms* data = nullptr;
+  if (!ParseBindFullArgs(info, &group, &sourceProp, &target, &targetProp, &flags, &data)) {
+    return env.Undefined();
+  }
+  if (!G_IS_BINDING_GROUP(group)) {
+    NodeGiBindingTransformsFree(data);
+    Napi::TypeError::New(env, "bind_full: expected a GObject.BindingGroup instance")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  g_binding_group_bind_full(
+      G_BINDING_GROUP(group), sourceProp.c_str(), target, targetProp.c_str(), flags,
+      data != nullptr && data->toFn != nullptr ? NodeGiBindingTransformTo : nullptr,
+      data != nullptr && data->fromFn != nullptr ? NodeGiBindingTransformFrom : nullptr, data,
+      data != nullptr ? NodeGiBindingTransformsFree : nullptr);
+  return env.Undefined();
+}
+
+}  // namespace nodegi

--- a/packages/node-gi/node-gi/src/signals.cc
+++ b/packages/node-gi/node-gi/src/signals.cc
@@ -36,9 +36,8 @@ static void JsClosureFinalize(gpointer data, GClosure* /*closure*/) {
   g_free(jc);
 }
 
-static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_param_values,
-                             const GValue* param_values, gpointer /*invocation_hint*/,
-                             gpointer /*marshal_data*/) {
+static void JsClosureMarshalImpl(GClosure* closure, GValue* return_value, guint n_param_values,
+                                 const GValue* param_values, bool unboxNestedValues) {
   JsClosureData* jc = static_cast<JsClosureData*>(closure->data);
   if (jc == nullptr || jc->callback == nullptr) return;
   // ENV-TEARDOWN GATE: a signal emitted by a dispose cascade at env teardown (or
@@ -73,7 +72,20 @@ static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_pa
   std::vector<napi_value> args;
   args.reserve(n_param_values);
   for (guint i = 0; i < n_param_values; i++) {
-    Napi::Value v = GValueToJs(env, &param_values[i]);
+    // Generic (IN-arg) closures mirror gjs's closure marshal (refs/gjs/gi/
+    // value.cpp gjs_value_from_g_value): a G_TYPE_VALUE-boxed param is UNBOXED to
+    // the contained value (recursively), so e.g. GIMarshallingTests-style
+    // `g_closure_invoke` consumers hand the JS function plain values, exactly as
+    // GJS does. Signal closures keep the existing param conversion untouched.
+    const GValue* pv = &param_values[i];
+    if (unboxNestedValues) {
+      while (G_VALUE_HOLDS(pv, G_TYPE_VALUE)) {
+        const GValue* inner = static_cast<const GValue*>(g_value_get_boxed(pv));
+        if (inner == nullptr) break;
+        pv = inner;
+      }
+    }
+    Napi::Value v = GValueToJs(env, pv);
     if (env.IsExceptionPending()) {
       // An arg-marshal failure: propagate to a synchronous emit() caller, or
       // surface + clear when dispatched from the loop (see g_syncEmitDepth).
@@ -106,7 +118,47 @@ static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_pa
 
   if (return_value != nullptr && (G_VALUE_TYPE(return_value) != G_TYPE_INVALID)) {
     JsToGValue(env, Napi::Value(jc->env, result), return_value);
+    // The return marshal must never leave a pending JS exception across the
+    // C boundary of a loop-dispatched invocation (same contract as the arg/call
+    // paths above): surface + clear it so the GLib/libuv pump stays alive.
+    if (env.IsExceptionPending() && g_syncEmitDepth == 0) {
+      SurfacePendingException(jc->env, "signal handler");
+    }
   }
+}
+
+// Signal-closure marshal (`.connect()`, template callbacks): params as-is.
+static void JsClosureMarshal(GClosure* closure, GValue* return_value, guint n_param_values,
+                             const GValue* param_values, gpointer /*invocation_hint*/,
+                             gpointer /*marshal_data*/) {
+  JsClosureMarshalImpl(closure, return_value, n_param_values, param_values, false);
+}
+
+// Generic-closure marshal (a JS fn marshalled as a GClosure IN-arg, invoked by
+// arbitrary C via g_closure_invoke): identical to the signal marshal except that
+// G_TYPE_VALUE-boxed params are unboxed to their contained value, mirroring gjs's
+// gjs_value_from_g_value (see JsClosureMarshalImpl).
+static void JsGenericClosureMarshal(GClosure* closure, GValue* return_value, guint n_param_values,
+                                    const GValue* param_values, gpointer /*invocation_hint*/,
+                                    gpointer /*marshal_data*/) {
+  JsClosureMarshalImpl(closure, return_value, n_param_values, param_values, true);
+}
+
+// JS function → a floating marshaled GClosure (the engine's twin of GJS's
+// Gjs::Closure::create_marshaled for "boxed" closure args — refs/gjs/gi/
+// arg-cache.cpp GClosureInTransferNone::in). The closure holds a strong ref to
+// the function; JsClosureFinalize drops it when the closure is invalidated /
+// finalized (the callee released its last ref, or the invoke-site released the
+// only ref because the callee never kept one). Ref/sink + release policy lives at
+// the marshalling site (marshal.cc / calls.cc CreatedClosures).
+GClosure* NodeGiMakeGenericJsClosure(Napi::Env env, Napi::Value fn) {
+  JsClosureData* jc = g_new0(JsClosureData, 1);
+  jc->env = env;
+  napi_create_reference(env, fn, 1, &jc->callback);
+  GClosure* closure = g_closure_new_simple(sizeof(GClosure), jc);
+  g_closure_set_marshal(closure, JsGenericClosureMarshal);
+  g_closure_add_finalize_notifier(closure, jc, JsClosureFinalize);
+  return closure;
 }
 
 // connectSignal(handle, signalName, callback, after?) -> handlerId

--- a/packages/node-gi/node-gi/test/dbus.test.mjs
+++ b/packages/node-gi/node-gi/test/dbus.test.mjs
@@ -108,11 +108,103 @@ test('makeProxyWrapper.newAsync builds an inited proxy', { skip: busSkip }, asyn
   assert.match(id, HEX32);
 });
 
-test('Gio.DBusExportedObject.wrapJSObject throws a clear "not supported" error (export deferred)', () => {
-  // No bus needed — this asserts the deferred export side fails loudly, not silently.
-  const gio = requireGi('Gio', '2.0');
-  assert.throws(
-    () => gio.DBusExportedObject.wrapJSObject('<node/>', {}),
-    /not yet supported/,
+// Object export (wrapJSObject) — a JS object exported over DBus via the GClosure
+// vtable (register_object_with_closures2). Full round-trip: a proxy calls an
+// exported method, gets/sets an exported property, and receives an emitted signal.
+// Async proxy + async calls throughout (a sync self-call would deadlock the single
+// main loop that must also service the incoming request). Needs a session bus.
+test('Gio.DBusExportedObject.wrapJSObject export round-trip', { skip: busSkip }, async () => {
+  const IFACE = 'org.gjsify.NodeGiExportTest';
+  const OBJ = '/org/gjsify/NodeGiExportTest';
+  const XML = `<node><interface name="${IFACE}">
+<method name="Echo"><arg type="s" direction="in"/><arg type="s" direction="out"/></method>
+<method name="Boom"><arg type="s" direction="out"/></method>
+<property name="Level" type="i" access="readwrite"/>
+<signal name="Pinged"><arg type="s"/></signal>
+</interface></node>`;
+
+  const conn = Gio.bus_get_sync(Gio.BusType.SESSION, null);
+  const service = {
+    Level: 7,
+    Echo(s) {
+      return `echo:${s}`;
+    },
+    Boom() {
+      throw new Error('kaboom');
+    },
+  };
+  const impl = Gio.DBusExportedObject.wrapJSObject(XML, service);
+  impl.export(conn, OBJ);
+  assert.equal(impl.get_object_path(), OBJ);
+
+  const loop = GLib.MainLoop.new(null, false);
+  const result = {};
+  const ownId = Gio.DBus.own_name(
+    Gio.BusType.SESSION,
+    IFACE,
+    Gio.BusNameOwnerFlags.NONE,
+    () => {},
+    () => {
+      const PW = Gio.DBusProxy.makeProxyWrapper(XML);
+      PW(conn, IFACE, OBJ, (proxy, err) => {
+        if (err) {
+          result.error = String(err);
+          loop.quit();
+          return;
+        }
+        let signal = null;
+        proxy.connectSignal('Pinged', (_p, _s, args) => {
+          signal = args[0];
+        });
+        proxy.EchoRemote('hi', ([echoed]) => {
+          result.echo = echoed;
+          // property get + set via org.freedesktop.DBus.Properties (async, no deadlock)
+          conn.call(
+            IFACE, OBJ, 'org.freedesktop.DBus.Properties', 'Get',
+            new GLib.Variant('(ss)', [IFACE, 'Level']),
+            new GLib.VariantType('(v)'), Gio.DBusCallFlags.NONE, -1, null,
+            (_s1, res1) => {
+              result.levelBefore = conn.call_finish(res1).deepUnpack()[0].deepUnpack();
+              conn.call(
+                IFACE, OBJ, 'org.freedesktop.DBus.Properties', 'Set',
+                new GLib.Variant('(ssv)', [IFACE, 'Level', new GLib.Variant('i', 99)]),
+                null, Gio.DBusCallFlags.NONE, -1, null,
+                (_s2, res2) => {
+                  conn.call_finish(res2);
+                  result.levelAfter = service.Level;
+                  // error-return path: Boom throws → DBus error → proxy err
+                  proxy.BoomRemote(([_v], boomErr) => {
+                    result.boomErr = Boolean(boomErr);
+                    impl.emit_signal('Pinged', new GLib.Variant('(s)', ['ping!']));
+                    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
+                      result.signal = signal;
+                      loop.quit();
+                      return false;
+                    });
+                  });
+                },
+              );
+            },
+          );
+        });
+      });
+    },
+    () => {},
   );
+  GLib.timeout_add(GLib.PRIORITY_DEFAULT, 8000, () => {
+    result.timedOut = true;
+    loop.quit();
+    return false;
+  });
+  loop.run();
+  Gio.DBus.unown_name(ownId);
+  impl.unexport();
+
+  assert.equal(result.timedOut, undefined, 'round-trip must complete before the safety timeout');
+  assert.equal(result.error, undefined);
+  assert.equal(result.echo, 'echo:hi', 'exported method reply');
+  assert.equal(result.levelBefore, 7, 'get-property closure');
+  assert.equal(result.levelAfter, 99, 'set-property closure wrote through');
+  assert.equal(result.boomErr, true, 'a throwing method returns a DBus error');
+  assert.equal(result.signal, 'ping!', 'emit_signal reaches the proxy');
 });

--- a/packages/node-gi/node-gi/test/gclosure-in-args.test.mjs
+++ b/packages/node-gi/node-gi/test/gclosure-in-args.test.mjs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — JS function → GClosure / GCallback IN-argument marshalling.
+//
+// Covers the L0 primitive (a JS function passed for a GObject.Closure IN-arg is
+// marshalled as a real GClosure whose marshal calls the function) and its three L1
+// consumers, all verified against gjs (`/usr/bin/gjs`) as the gold standard:
+//   1. GLib.log_set_writer_func(fn)  — a plain GLogWriterFunc; fn receives a real log
+//   2. GObject.Object.prototype.bind_property_full — a transform actually transforms
+//   3. Gio.DBusExportedObject.wrapJSObject — an exported method round-trips (in dbus.test.mjs)
+//   +  GObject.signal_connect_closure / GObject.source_set_closure — the raw primitive
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const GLib = requireGi('GLib', '2.0');
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+
+// ---- 1. GLib.log_set_writer_func -------------------------------------------
+//
+// Installs the JS writer, emits a structured log, and asserts the writer received
+// it. GLib allows only ONE g_log_set_writer_func per process (a second is a fatal
+// g_error — same as gjs), so this is the single install for the whole test file;
+// log_set_writer_default() below re-arms the default fallback but keeps the
+// GLib-side wrapper in place.
+test('GLib.log_set_writer_func: the JS writer receives a real structured log', () => {
+  const seen = [];
+  GLib.log_set_writer_func((level, fields) => {
+    seen.push({ level, fields });
+    return GLib.LogWriterOutput.HANDLED;
+  });
+
+  GLib.log_structured('node-gi-writer-test', GLib.LogLevelFlags.LEVEL_MESSAGE, {
+    MESSAGE: 'hello writer',
+    MY_FIELD: 'custom',
+  });
+
+  const rec = seen.find((r) => {
+    const m = r.fields.MESSAGE;
+    return m && Buffer.from(m).toString('utf8') === 'hello writer';
+  });
+  assert.ok(rec, 'the writer saw the emitted MESSAGE');
+  assert.equal(rec.level, GLib.LogLevelFlags.LEVEL_MESSAGE);
+  // Field values are Uint8Arrays of the field bytes (gjs recursiveUnpack shape).
+  assert.ok(rec.fields.MESSAGE instanceof Uint8Array, 'field value is a Uint8Array');
+  assert.equal(Buffer.from(rec.fields.MY_FIELD).toString('utf8'), 'custom');
+  assert.equal(Buffer.from(rec.fields.GLIB_DOMAIN).toString('utf8'), 'node-gi-writer-test');
+
+  // Re-arm the default writer (route further logs to g_log_writer_default).
+  GLib.log_set_writer_default();
+});
+
+// ---- 2. GObject.Object.prototype.bind_property_full ------------------------
+
+const PropObj = GObject.registerClass(
+  {
+    GTypeName: 'NodeGiBindFullTestObj',
+    Properties: {
+      string: GObject.ParamSpec.string('string', 'String', 'S', GObject.ParamFlags.READWRITE, ''),
+      bool: GObject.ParamSpec.boolean('bool', 'Bool', 'B', GObject.ParamFlags.READWRITE, true),
+      num: GObject.ParamSpec.int('num', 'Num', 'N', GObject.ParamFlags.READWRITE, -1000, 1000, 0),
+    },
+  },
+  class NodeGiBindFullTestObj extends GObject.Object {},
+);
+
+test('bind_property_full: a transform-to actually transforms a bound value', () => {
+  const a = new PropObj();
+  const b = new PropObj();
+  let sawSource;
+  a.bind_property_full(
+    'bool',
+    b,
+    'string',
+    GObject.BindingFlags.NONE,
+    (_binding, source) => {
+      sawSource = source;
+      return [true, `${source}`];
+    },
+    null,
+  );
+  a.bool = true;
+  assert.equal(b.string, 'true', 'the transform wrote the converted value to the target');
+  assert.equal(sawSource, true, 'the transform received the unpacked source value');
+});
+
+test('bind_property_full: [false, …] leaves the target unchanged', () => {
+  const a = new PropObj();
+  const b = new PropObj();
+  b.string = 'unchanged';
+  a.bind_property_full('num', b, 'string', GObject.BindingFlags.NONE, () => [false, 'nope'], null);
+  a.num = 7;
+  assert.equal(b.string, 'unchanged');
+});
+
+test('bind_property_full: bidirectional transform-from converts back', () => {
+  const e = new PropObj();
+  const f = new PropObj();
+  e.bind_property_full(
+    'num',
+    f,
+    'string',
+    GObject.BindingFlags.BIDIRECTIONAL,
+    (_binding, src) => [true, `n:${src}`],
+    (_binding, src) => [true, parseInt(String(src).replace('n:', ''), 10) + 1],
+  );
+  e.num = 5;
+  assert.equal(f.string, 'n:5', 'forward transform');
+  f.string = 'n:41';
+  assert.equal(e.num, 42, 'reverse transform');
+});
+
+test('bind_property_full: null transforms = a plain copy binding', () => {
+  const g = new PropObj();
+  const h = new PropObj();
+  g.bind_property_full('string', h, 'string', GObject.BindingFlags.NONE, null, null);
+  g.string = 'plain';
+  assert.equal(h.string, 'plain');
+});
+
+// ---- 3. Raw primitive: signal_connect_closure / source_set_closure ---------
+
+test('GObject.signal_connect_closure: a JS fn as a GClosure signal handler fires', () => {
+  const action = new Gio.SimpleAction({ name: 'x', enabled: true });
+  const seen = [];
+  const id = GObject.signal_connect_closure(
+    action,
+    'notify::enabled',
+    (obj, pspec) => {
+      seen.push([obj === action, pspec.name]);
+    },
+    false,
+  );
+  assert.equal(typeof id, 'number');
+  assert.ok(id > 0);
+  action.set_enabled(false);
+  assert.deepEqual(seen, [[true, 'enabled']]);
+  // After disconnect the closure no longer fires (and its JS ref can be released).
+  GObject.signal_handler_disconnect(action, id);
+  action.set_enabled(true);
+  assert.deepEqual(seen, [[true, 'enabled']], 'no dispatch after disconnect');
+});
+
+test('GObject.source_set_closure: a JS fn drives a timeout source', () => {
+  const loop = GLib.MainLoop.new(null, false);
+  let ticks = 0;
+  const source = GLib.timeout_source_new(5);
+  GObject.source_set_closure(source, () => {
+    ticks++;
+    if (ticks >= 2) {
+      loop.quit();
+      return false;
+    }
+    return true;
+  });
+  source.attach(null);
+  loop.run();
+  assert.equal(ticks, 2);
+});
+
+test('a throwing GClosure handler is surfaced, not propagated (loop-dispatched)', () => {
+  const action = new Gio.SimpleAction({ name: 'y', enabled: true });
+  GObject.signal_connect_closure(
+    action,
+    'notify::enabled',
+    () => {
+      throw new Error('boom-closure');
+    },
+    false,
+  );
+  // gjs logs an uncaught handler exception rather than propagating it to the
+  // trigger site — set_enabled must return normally.
+  assert.doesNotThrow(() => action.set_enabled(false));
+});

--- a/packages/node-gi/node-gi/test/glib-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/glib-overrides.test.mjs
@@ -4,9 +4,9 @@
 // Covers the GLib conveniences gjs adds over introspection
 // (refs/gjs/modules/core/overrides/GLib.js): GLib.log_structured (pack fields into
 // an a{sv} + hand to g_log_variant), the one-shot idle/timeout helpers
-// (idle_add_once / timeout_add_once / timeout_add_seconds_once), and the
-// GLib.log_set_writer_func kept-throw (the JS-callback-as-GLogWriterFunc GClosure
-// IN-arg gap). log_structured's stderr output is checked byte-for-byte against the
+// (idle_add_once / timeout_add_once / timeout_add_seconds_once), and
+// GLib.log_set_writer_func (a JS callback marshalled as a GLogWriterFunc via the
+// native GjsPrivate-mirror). log_structured's stderr output is checked byte-for-byte against the
 // GOLD STANDARD by running the SAME log call under both node-gi and `gjs -m` and
 // asserting the writer emits the identical MESSAGE + domain.
 //
@@ -119,10 +119,25 @@ test('timeout_add_once fires exactly once (auto-removed)', () => {
   assert.equal(n, 1, 'did not re-fire (source removed)');
 });
 
-// ---- log_set_writer_func kept-throw ---------------------------------------
+// ---- log_set_writer_func (works: JS fn → GLogWriterFunc) ------------------
 
-test('log_set_writer_func is a clear kept-throw (GLogWriterFunc IN-arg gap)', () => {
-  assert.throws(() => GLib.log_set_writer_func(() => GLib.LogWriterOutput.HANDLED), /GLogWriterFunc/);
+test('log_set_writer_func installs a JS writer that receives a real log', () => {
+  // GLib allows only ONE g_log_set_writer_func per process (a second is a fatal
+  // g_error, same as gjs) — this file's single install; log_set_writer_default()
+  // re-arms the default fallback afterwards. Full coverage: gclosure-in-args.test.mjs.
+  const seen = [];
+  GLib.log_set_writer_func((_level, fields) => {
+    seen.push(fields);
+    return GLib.LogWriterOutput.HANDLED;
+  });
+  GLib.log_structured('node-gi-glib-overrides', GLib.LogLevelFlags.LEVEL_MESSAGE, {
+    MESSAGE: 'writer-func-works',
+  });
+  const rec = seen.find(
+    (f) => f.MESSAGE && Buffer.from(f.MESSAGE).toString('utf8') === 'writer-func-works',
+  );
+  assert.ok(rec, 'the installed writer received the emitted MESSAGE');
+  GLib.log_set_writer_default();
 });
 
 test('the LogLevelFlags / LogWriterOutput surface is present', () => {

--- a/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
+++ b/packages/node-gi/node-gi/test/gobject-overrides.test.mjs
@@ -213,7 +213,7 @@ test('GObject.Object.new_with_properties zips names + values', () => {
   );
 });
 
-// ---- bind_property (works) + bind_property_full (kept-throw) ---------------
+// ---- bind_property + bind_property_full (both work) ------------------------
 
 test('bind_property (no transform) is introspected and syncs', () => {
   const src = new Gio.SimpleAction({ name: 's', enabled: true });
@@ -224,13 +224,28 @@ test('bind_property (no transform) is introspected and syncs', () => {
   assert.equal(dst.enabled, false, 'a later source change propagates');
 });
 
-test('bind_property_full is a clear kept-throw (GClosure IN-arg gap)', () => {
+test('bind_property_full runs the JS transform (GClosure IN-arg)', () => {
+  // The transform closures are driven natively (GjsPrivate-mirror); the JS
+  // transform-to must actually convert the source value into the target. Full
+  // coverage lives in test/gclosure-in-args.test.mjs — this is the override-layer
+  // smoke test that the prototype method is wired to the native path (no throw).
   const src = new Gio.SimpleAction({ name: 's2', enabled: true });
   const dst = new Gio.SimpleAction({ name: 'd2', enabled: false });
-  assert.throws(
-    () => src.bind_property_full('enabled', dst, 'enabled', GObject.BindingFlags.DEFAULT, () => {}, null),
-    /GClosure IN-arguments/,
+  let sawSource;
+  src.bind_property_full(
+    'enabled',
+    dst,
+    'enabled',
+    GObject.BindingFlags.DEFAULT,
+    (_binding, source) => {
+      sawSource = source;
+      return [true, !source];
+    },
+    null,
   );
+  src.enabled = false;
+  assert.equal(sawSource, false, 'the transform received the source value');
+  assert.equal(dst.enabled, true, 'the inverted transform result reached the target');
 });
 
 // ---- ParamFlags / SignalFlags / AccumulatorType / TYPE_* ------------------


### PR DESCRIPTION
Implements the **JS-function → GClosure/GCallback IN-argument** primitive — the single L0 gap that blocked three L1 features (each previously a clear kept-throw). All three now land, verified byte-for-byte against `gjs`.

## The primitive (both shapes)
- **GClosure IN-args** (`marshal.cc` + `signals.cc`): `JsToGIArgument`'s INTERFACE branch recognizes a JS fn for a `G_TYPE_CLOSURE` param and builds a real marshaled `GClosure` (`NodeGiMakeGenericJsClosure`, reusing the `JsClosure` marshal/finalize machinery); the marshal unboxes `G_TYPE_VALUE`-boxed params like gjs.
- **Plain GCallback IN-args** (new `src/private.cc`, following gjs's `GjsPrivate` architecture): the `GLogWriterFunc` wrapper + `GBindingTransformFunc` trampolines — needed because the writer fires on any thread and the transform's write-back GValue isn't reachable via a marshaled GClosure.

## Consumers unblocked (all gjs byte-identical)
1. **`GLib.log_set_writer_func(fn)`** — JS writer gets a real structured log, its `LogWriterOutput` drives handled/unhandled fallback (+ `log_set_writer_default`).
2. **`GObject.bind_property_full` / `BindingGroup.bind_full`** — transform-to/from convert bound values, `[false,…]` leaves target unchanged, null transforms = plain copy.
3. **`Gio.DBusExportedObject.wrapJSObject`** (the hardest — DBus object export) — via `register_object_with_closures`: full round-trip under `dbus-run-session` (proxy calls a method, get/set property, a throwing method returns a DBus error, `emit_signal` reaches the proxy).

## Lifetime / ownership
Closure holds a strong `napi_ref`; the callee ref+sinks its own copy so the fn lives exactly as long as the registration, released on finalize (disconnect/unbind/unregister). transfer-none vs transfer-full handled on success + error paths; the `g_dbus_method_invocation` ownership-transfer double-free avoided. **valgrind** (connect/disconnect + bind/drop loops): 0 lost, 0 invalid read/write, no closure-path frames in any leak record.

## Test plan
- [x] rebuild 0 warnings · `npm test` **340/0** · `test:gimarshalling` **369/0** (+1 `gclosure_in`) · `test:dbus` 5/5 (incl. export round-trip) · `test:conformance` + `test:bun`/`test:deno` 34/34
- [x] new `test/gclosure-in-args.test.mjs` (8) + conformance program; 3 stale kept-throw assertions replaced with real behavior tests
- [x] exit-clean (`require + bind_property_full + exit`, `require Gio/Gda + exit`) + no sqlite regression

Deferred (separate features): callback-OUT params, `gclosure_return`.