### PR TITLE
node-gi: GClosure consumer parity — coverage, fd-list fix, un-stale docs

### DIFF
--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -471,9 +471,18 @@ Also present: `GObject.ParamFlags` / `SignalFlags` (full introspected bitfields)
 the fundamental `GObject.TYPE_*` GTypes, `GObject.AccumulatorType`, and
 `GObject.signal_connect` / `signal_connect_after` / `signal_emit_by_name`.
 
-**Kept-throw** (a clear, actionable error, not a crash): `bind_property_full` needs
-the JS transform-to/from closures marshalled as **GClosure IN-arguments**, which the
-engine cannot yet do — plain `bind_property` (no transforms) works. `ParamSpec.enum`
+`bind_property_full` / `BindingGroup.bind_full` work with **real JS transform
+functions** (the engine marshals them as C `GBindingTransformFunc` trampolines,
+the same architecture gjs uses via GjsPrivate — see `src/private.cc`): a
+transform-to converts the bound value, returning `[false, …]` leaves the target
+unchanged, a bidirectional transform-from converts back, and `null` transforms
+give a plain copy binding. Verified byte-identical to gjs by the
+`gclosure-in-args` conformance program. The related raw primitives
+`GObject.signal_connect_closure` / `GObject.source_set_closure` accept a plain
+JS function wherever a `GObject.Closure` IN-argument is expected (the engine
+marshals it as a real GClosure).
+
+**Kept-throw** (a clear, actionable error, not a crash): `ParamSpec.enum`
 / `flags` / `char` / `uchar` / `long` / `ulong` / `param` are not yet buildable (the
 native param-spec builder covers int/uint/int64/uint64/double/float/string/boolean/
 object/boxed).
@@ -484,21 +493,36 @@ object/boxed).
 string / `Uint8Array` / `GLib.Variant` fields into an `a{sv}` and hands it to
 `g_log_variant`) and the one-shot source helpers `idle_add_once` /
 `timeout_add_once` / `timeout_add_seconds_once` (the callback runs once, then the
-source is auto-removed). **Kept-throw:** `GLib.log_set_writer_func(fn)` — a JS
-`GLogWriterFunc` is a **GClosure/callback IN-argument** the engine cannot yet
-marshal (the same gap as `bind_property_full` + DBus object export); use
-`GLib.log_structured` or `console` for structured logging.
+source is auto-removed).
 
-#### `Gio.DBus` (client proxy + name owning)
+`GLib.log_set_writer_func(fn)` installs a **JS `GLogWriterFunc`** as the
+process structured-log writer, with gjs semantics (node-gi ships the same
+thread-guarded C wrapper gjs routes through GjsPrivate — `src/private.cc`): the
+writer receives `(logLevel, fields)` where `fields` is a plain object whose
+values are `Uint8Array`s of the field bytes (`null` for empty fields) —
+byte-for-byte the shape gjs's `{...stringFields.recursiveUnpack()}` produces —
+and its returned `GLib.LogWriterOutput` drives the handled/unhandled fallback.
+`GLib.log_set_writer_default()` detaches the JS writer (later logs fall back to
+`g_log_writer_default`). Verified byte-identical to gjs by the `log-writer`
+conformance program. Two contracts, identical under gjs: the underlying
+`g_log_set_writer_func` may only ever be called ONCE per process — a second
+`GLib.log_set_writer_func(fn)` call aborts inside GLib itself (install one
+writer per process; `log_set_writer_default()` detaches the JS side but cannot
+re-arm a new install) — and an off-thread log falls back to the default writer
+in C (JS is never entered from a foreign thread).
 
-`requireGi('Gio')` carries the GJS DBus surface. The **client** half is complete:
-`Gio.DBusProxy.makeProxyWrapper(interfaceXml)` parses the interface XML and returns
-a proxy constructor whose instances expose each method as `NameSync` (sync),
+#### `Gio.DBus` (client proxy, name owning + object export)
+
+`requireGi('Gio')` carries the GJS DBus surface — both halves. The **client**
+half: `Gio.DBusProxy.makeProxyWrapper(interfaceXml)` parses the interface XML and
+returns a proxy constructor whose instances expose each method as `NameSync` (sync),
 `NameRemote` (raw async callback) and `NameAsync` (Promise), each property as a
 getter/setter, and each signal via `connectSignal` / `disconnectSignal` (the same
 pure-JS `_signals` mixin GJS uses). `Gio.DBus.session` / `Gio.DBus.system` are the
 bus getters; `Gio.DBus.own_name` / `unown_name` / `watch_name` / `unwatch_name`
-own and watch bus names.
+own and watch bus names. The **export** half
+(`Gio.DBusExportedObject.wrapJSObject` — exporting a JS object AS a DBus
+service) is described below the example.
 
 ```js
 const Gio = requireGi('Gio', '2.0');
@@ -521,17 +545,50 @@ const id = Gio.DBus.own_name(Gio.BusType.SESSION, 'org.example.App',
 ```
 
 A blocking `GLib.MainLoop.run()` drives the async replies / signals / name
-callbacks (they fire from the loop, as under GJS). Two DBus divergences to know:
-(1) a `NameAsync` **Promise** `.then` does not drain *while* a node-gi loop blocks
+callbacks (they fire from the loop, as under GJS). One DBus divergence to know:
+a `NameAsync` **Promise** `.then` does not drain *while* a node-gi loop blocks
 (node-gtk #442/#121) — the reply still fires and settles the Promise, so it
 resolves once `run()` returns; drive an async method inside the loop through the
-raw `NameRemote` callback. (2) **Object export** (`Gio.DBusExportedObject.wrapJSObject`
-— exporting a JS object AS a DBus service) is **not yet supported**: GJS builds it
-on `GjsPrivate.DBusImplementation` (a GJS-internal C type, absent on a plain Node/GI
-host), the introspectable `register_object_with_closures` needs GClosure
-IN-arguments the engine cannot yet marshal, and `register_object` takes a
-non-introspectable vtable — so `wrapJSObject` throws a clear, actionable error
-rather than crashing.
+raw `NameRemote` callback.
+
+**Object export** (`Gio.DBusExportedObject.wrapJSObject` — exporting a JS
+object AS a DBus service) works with GJS semantics. GJS builds it on
+`GjsPrivate.DBusImplementation` (a GJS-internal C type, absent on a plain
+Node/GI host); node-gi instead drives the **introspectable**
+`g_dbus_connection_register_object_with_closures2` (GLib ≥ 2.84) — the
+method-call / get-property / set-property vtable slots are plain JS functions
+the engine marshals as real **GClosure IN-arguments**:
+
+```js
+const service = {
+  Level: 7,                                  // property (read via the interface XML signature)
+  Echo(s) { return `echo:${s}`; },           // method (an Async variant + Promise return also work)
+  Boom() { throw new Error('kaboom'); },     // a throw becomes a DBus error (org.gnome.gjs.JSError.*)
+};
+const impl = Gio.DBusExportedObject.wrapJSObject(interfaceXml, service);
+impl.export(Gio.DBus.session, '/org/example/App');
+impl.emit_signal('Pinged', new GLib.Variant('(s)', ['ping!']));
+impl.emit_property_changed('Level', new GLib.Variant('i', 8)); // updates proxy caches
+impl.unexport();                              // releases the registration + its closures
+```
+
+The impl surface matches GJS (`export` / `unexport` / `unexport_from_connection`
+/ `emit_signal` / `emit_property_changed` / `flush` / `get_object_path`, plus
+node-gi's usual camelCase aliases). The full round-trip — exported method,
+property get/set through `org.freedesktop.DBus.Properties`, a throwing method
+returning a DBus error, `emit_signal`, `emit_property_changed` updating a
+proxy's cached property, and unexport — runs byte-identical to gjs
+(`dbus/export-scenario.mjs`, cross-checked against `gjs -m` under
+`dbus-run-session` by `npm run test:dbus`). Lifetime: the registration ref+sinks
+its closures, so the service object lives exactly as long as the registration
+(surviving GC with no JS references) and becomes collectable after
+`unexport()` — guarded by the `--expose-gc` leg of the dbus suite. A method
+handler receives the GJS-appended trailing `Gio.UnixFDList` argument (`null`
+when the call carries no fds — verified against gjs; an actual fd-carrying
+call arrives as a wrapped `UnixFDList` but deeper fd extraction is untested).
+As under GJS, a **sync** self-call from the exporting process deadlocks the
+shared main loop that must also service the incoming request — use the async
+`NameRemote` forms.
 
 ### GJS ambient globals (`@gjsify/node-gi/globals`)
 

--- a/packages/node-gi/node-gi/conformance/golden/log-writer.txt
+++ b/packages/node-gi/node-gi/conformance/golden/log-writer.txt
@@ -1,0 +1,11 @@
+records: 1
+level is MESSAGE: true
+keys: GLIB_DOMAIN,MESSAGE,MY_FIELD,PRIORITY
+all bytes: true
+MESSAGE: hello writer
+MY_FIELD: custom-value
+PRIORITY: 5
+second level is INFO: true
+RAW: raw-bytes
+WRAPPED: variant-string
+after default: 2

--- a/packages/node-gi/node-gi/conformance/programs/log-writer.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/log-writer.conf.mjs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// GLib.log_set_writer_func parity — a JS GLogWriterFunc installed as the
+// process structured-log writer receives real logs: the level flags plus the
+// GLogField array as a plain object whose values are Uint8Arrays of the field
+// bytes (gjs packs each field as a maybe-bytestring and hands the writer
+// `{...stringFields.recursiveUnpack()}` — refs/gjs/libgjs-private/gjs-util.c
+// gjs_log_writer_func_wrapper). HANDLED stops the default writer;
+// log_set_writer_default() detaches the JS writer so later logs fall back.
+// gjs is the gold standard — node / bun / deno must print byte-identical output.
+//
+// Determinism notes: the writer only records logs from its own domain (anything
+// else is UNHANDLED → default writer → stderr, which the runner ignores), the
+// key list is printed sorted, and the post-detach probe logs at LEVEL_MESSAGE
+// (the default writer sends non-info/debug levels to stderr unconditionally, so
+// stdout stays clean regardless of G_MESSAGES_DEBUG).
+import GLib from 'gi://GLib?version=2.0';
+
+const DOMAIN = 'node-gi-conf-writer';
+const dec = new TextDecoder();
+const records = [];
+
+GLib.log_set_writer_func((level, fields) => {
+    const domain = fields.GLIB_DOMAIN ? dec.decode(fields.GLIB_DOMAIN) : '';
+    if (domain !== DOMAIN) return GLib.LogWriterOutput.UNHANDLED;
+    records.push({ level, fields });
+    return GLib.LogWriterOutput.HANDLED;
+});
+
+GLib.log_structured(DOMAIN, GLib.LogLevelFlags.LEVEL_MESSAGE, {
+    MESSAGE: 'hello writer',
+    MY_FIELD: 'custom-value',
+});
+
+print('records:', records.length);
+const rec = records[0];
+print('level is MESSAGE:', rec.level === GLib.LogLevelFlags.LEVEL_MESSAGE);
+print('keys:', Object.keys(rec.fields).sort().join(','));
+print('all bytes:', Object.values(rec.fields).every((v) => v instanceof Uint8Array));
+print('MESSAGE:', dec.decode(rec.fields.MESSAGE));
+print('MY_FIELD:', dec.decode(rec.fields.MY_FIELD));
+print('PRIORITY:', dec.decode(rec.fields.PRIORITY));
+
+// Field packing flavours: a Uint8Array field and a GLib.Variant field also
+// round-trip through log_structured → the writer.
+GLib.log_structured(DOMAIN, GLib.LogLevelFlags.LEVEL_INFO, {
+    MESSAGE: 'second',
+    RAW: new TextEncoder().encode('raw-bytes'),
+    WRAPPED: new GLib.Variant('s', 'variant-string'),
+});
+const rec2 = records[1];
+print('second level is INFO:', rec2.level === GLib.LogLevelFlags.LEVEL_INFO);
+print('RAW:', dec.decode(rec2.fields.RAW));
+print('WRAPPED:', dec.decode(rec2.fields.WRAPPED));
+
+// log_set_writer_default(): the JS writer is detached — the record count must
+// not grow (the probe log goes to the default writer's stderr instead).
+GLib.log_set_writer_default();
+GLib.log_structured(DOMAIN, GLib.LogLevelFlags.LEVEL_MESSAGE, { MESSAGE: 'unseen' });
+print('after default:', records.length);

--- a/packages/node-gi/node-gi/dbus/export-scenario.mjs
+++ b/packages/node-gi/node-gi/dbus/export-scenario.mjs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Shared DBus OBJECT-EXPORT scenario for @gjsify/node-gi, parameterized by the
+// Gio + GLib namespaces so the SAME source runs on gjs (`gi://` via
+// ./gjs-harness.js) and node-gi (`requireGi` via ../test/dbus.test.mjs) — gjs is
+// the gold standard, the two results must compare byte-for-byte.
+//
+// It exercises the EXPORT half of the DBus surface
+// (Gio.DBusExportedObject.wrapJSObject — a JS object exported AS a DBus
+// service; gjs builds it on GjsPrivate.DBusImplementation, node-gi on the
+// introspectable g_dbus_connection_register_object_with_closures2):
+//   • the common impl surface (export/unexport/unexport_from_connection/
+//     emit_signal/emit_property_changed/flush/get_object_path),
+//   • a proxy (async init — a SYNC self-call would deadlock the one main loop
+//     that must also service the incoming request) calls an exported method,
+//   • property GET + SET via org.freedesktop.DBus.Properties (the get-property /
+//     set-property closures; Set writes through to the JS object),
+//   • a throwing method surfaces as a DBus error (org.gnome.gjs.JSError.Error),
+//   • emit_signal reaches the proxy's connectSignal handler,
+//   • emit_property_changed updates the proxy's cached property,
+//   • after unexport() the object is gone (a further call errors).
+//
+// All calls are driven through RAW async callbacks (never Promise `.then` — a
+// Promise continuation does not drain under a blocking node-gi GLib loop,
+// node-gtk #442/#121). The proxy targets the connection's own UNIQUE name, so
+// no bus-name owning/timing is involved; nothing nondeterministic is recorded.
+
+export const EXPORT_EXPECTED = {
+    implSurface: {
+        export: 'function',
+        unexport: 'function',
+        unexport_from_connection: 'function',
+        emit_signal: 'function',
+        emit_property_changed: 'function',
+        flush: 'function',
+        get_object_path: 'function',
+    },
+    objectPath: '/org/gjsify/NodeGiExportScenario',
+    echo: 'echo:hi',
+    // GJS appends the message's Gio.UnixFDList as a trailing method argument —
+    // null when the call carries no fds; node-gi mirrors the shape.
+    echoFdArg: 'null',
+    levelBefore: 7,
+    levelAfterSet: 99,
+    boomErrHasName: true,
+    boomErrHasMessage: true,
+    signal: 'ping!',
+    propAfterChanged: 99,
+    afterUnexportErrors: true,
+};
+
+const IFACE = 'org.gjsify.NodeGiExportScenario';
+const OBJ_PATH = '/org/gjsify/NodeGiExportScenario';
+const XML = `<node><interface name="${IFACE}">
+<method name="Echo"><arg type="s" direction="in"/><arg type="s" direction="out"/></method>
+<method name="Boom"><arg type="s" direction="out"/></method>
+<property name="Level" type="i" access="readwrite"/>
+<signal name="Pinged"><arg type="s"/></signal>
+</interface></node>`;
+
+/**
+ * Run the object-export round-trip and return the normalized result object
+ * (matches EXPORT_EXPECTED on a working runtime). Blocks on a GLib main loop
+ * until the round-trip completes (bounded by a safety timeout).
+ * @param {{ Gio: any, GLib: any }} ns
+ * @returns {object}
+ */
+export function runExportScenario({ Gio, GLib }) {
+    const conn = Gio.bus_get_sync(Gio.BusType.SESSION, null);
+    let echoFdArg = 'unset';
+    const service = {
+        Level: 7,
+        Echo(s, fdList) {
+            echoFdArg = fdList === null ? 'null' : typeof fdList;
+            return `echo:${s}`;
+        },
+        Boom() {
+            throw new Error('kaboom');
+        },
+    };
+
+    const result = {
+        implSurface: {},
+        objectPath: null,
+        echo: null,
+        echoFdArg: null,
+        levelBefore: null,
+        levelAfterSet: null,
+        boomErrHasName: null,
+        boomErrHasMessage: null,
+        signal: null,
+        propAfterChanged: null,
+        afterUnexportErrors: null,
+    };
+
+    const impl = Gio.DBusExportedObject.wrapJSObject(XML, service);
+    for (const k of Object.keys(EXPORT_EXPECTED.implSurface)) result.implSurface[k] = typeof impl[k];
+
+    impl.export(conn, OBJ_PATH);
+    result.objectPath = impl.get_object_path();
+
+    const loop = GLib.MainLoop.new(null, false);
+    const finish = () => loop.quit();
+
+    // The proxy targets our OWN connection's unique name — always resolvable,
+    // never racing a name-ownership handshake; never recorded (it is per-run).
+    const dest = conn.get_unique_name();
+    const ProxyClass = Gio.DBusProxy.makeProxyWrapper(XML);
+    new ProxyClass(conn, dest, OBJ_PATH, (proxy, initErr) => {
+        if (initErr) {
+            result.initError = String(initErr);
+            finish();
+            return;
+        }
+        let signalSeen = null;
+        proxy.connectSignal('Pinged', (_p, _sender, args) => {
+            signalSeen = args[0];
+        });
+        proxy.EchoRemote('hi', ([echoed]) => {
+            result.echo = echoed;
+            result.echoFdArg = echoFdArg;
+            // Property GET via org.freedesktop.DBus.Properties (async — the
+            // get-property closure runs on this same loop).
+            conn.call(
+                dest, OBJ_PATH, 'org.freedesktop.DBus.Properties', 'Get',
+                new GLib.Variant('(ss)', [IFACE, 'Level']),
+                new GLib.VariantType('(v)'), Gio.DBusCallFlags.NONE, -1, null,
+                (_s1, res1) => {
+                    result.levelBefore = conn.call_finish(res1).deepUnpack()[0].deepUnpack();
+                    // Property SET: the set-property closure writes through to
+                    // the JS object.
+                    conn.call(
+                        dest, OBJ_PATH, 'org.freedesktop.DBus.Properties', 'Set',
+                        new GLib.Variant('(ssv)', [IFACE, 'Level', new GLib.Variant('i', 99)]),
+                        null, Gio.DBusCallFlags.NONE, -1, null,
+                        (_s2, res2) => {
+                            conn.call_finish(res2);
+                            result.levelAfterSet = service.Level;
+                            // A throwing method returns a DBus error carrying the
+                            // gjs-style error name + the thrown message.
+                            proxy.BoomRemote((_v, boomErr) => {
+                                const msg = boomErr && boomErr.message ? boomErr.message : '';
+                                result.boomErrHasName = msg.includes('org.gnome.gjs.JSError.Error');
+                                result.boomErrHasMessage = msg.includes('kaboom');
+                                // emit_signal + emit_property_changed, then give
+                                // the bus a settle window before reading back.
+                                impl.emit_signal('Pinged', new GLib.Variant('(s)', ['ping!']));
+                                impl.emit_property_changed('Level', new GLib.Variant('i', 99));
+                                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 250, () => {
+                                    result.signal = signalSeen;
+                                    // The PropertiesChanged emission updated the
+                                    // proxy's cached property.
+                                    result.propAfterChanged = proxy.Level;
+                                    impl.unexport();
+                                    proxy.EchoRemote('again', (_r, err) => {
+                                        result.afterUnexportErrors = Boolean(err);
+                                        finish();
+                                    });
+                                    return false; // G_SOURCE_REMOVE
+                                });
+                            });
+                        },
+                    );
+                },
+            );
+        });
+    });
+
+    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 10000, () => {
+        result.timedOut = true;
+        finish();
+        return false;
+    });
+    loop.run();
+    return result;
+}

--- a/packages/node-gi/node-gi/dbus/gjs-harness.js
+++ b/packages/node-gi/node-gi/dbus/gjs-harness.js
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: MIT
-// Gold-standard harness: runs the shared DBus scenario under gjs (`gjs -m`) and
-// prints `RESULT=<json>`. dbus.test.mjs spawns this under a private session bus
-// and asserts the normalized result equals the node-gi run's — the byte-for-byte
-// gjs cross-check. Kept a plain `.js` run via `gjs -m` (ESM).
+// Gold-standard harness: runs the shared DBus scenarios under gjs (`gjs -m`) and
+// prints `RESULT=<json>` (client half) + `EXPORT_RESULT=<json>` (object-export
+// half). dbus.test.mjs spawns this under a private session bus and asserts each
+// normalized result equals the node-gi run's — the byte-for-byte gjs
+// cross-check. Kept a plain `.js` run via `gjs -m` (ESM).
 import Gio from 'gi://Gio?version=2.0';
 import GLib from 'gi://GLib?version=2.0';
 import { runScenario } from './scenario.mjs';
+import { runExportScenario } from './export-scenario.mjs';
 
 const result = runScenario({ Gio, GLib });
 print(`RESULT=${JSON.stringify(result)}`);
+
+const exportResult = runExportScenario({ Gio, GLib });
+print(`EXPORT_RESULT=${JSON.stringify(exportResult)}`);

--- a/packages/node-gi/node-gi/overrides/gio-dbus.js
+++ b/packages/node-gi/node-gi/overrides/gio-dbus.js
@@ -562,11 +562,16 @@ export function createGioDBus(ctx) {
   }
 
   function _handleMethodCall(jsObj, methodName, parameters, invocation) {
+    // GJS appends the message's Gio.UnixFDList as a trailing argument (null when
+    // the call carries no fds) — mirror it so fd-aware services see the same
+    // shape (refs/gjs Gio.js _handleMethodCall).
+    const fdList = invocation.get_message().get_unix_fd_list();
     const method = jsObj[methodName];
     if (typeof method === 'function') {
       let retval;
       try {
         const args = parameters.deepUnpack();
+        args.push(fdList);
         retval = method.apply(jsObj, args);
       } catch (e) {
         _handleDBusError(invocation, e);
@@ -588,7 +593,7 @@ export function createGioDBus(ctx) {
     if (typeof asyncMethod === 'function') {
       let ret;
       try {
-        ret = asyncMethod.call(jsObj, parameters.deepUnpack(), invocation);
+        ret = asyncMethod.call(jsObj, parameters.deepUnpack(), invocation, fdList);
       } catch (e) {
         _handleDBusError(invocation, e);
         return;

--- a/packages/node-gi/node-gi/overrides/mainloop.js
+++ b/packages/node-gi/node-gi/overrides/mainloop.js
@@ -5,9 +5,10 @@
 // Giovanni Campagna. MIT OR LGPL-2.0-or-later.
 // Modifications: the legacy `imports.mainloop` — a thin convenience layer over
 // GLib.MainLoop — ported to @gjsify/node-gi. GJS builds the idle/timeout sources
-// via GObject.source_set_closure (a GClosure the node-gi engine cannot yet
-// marshal); this port routes through GLib.idle_add / GLib.timeout_add directly
-// (which the engine DOES marshal), keeping the same `imports.mainloop.*` surface.
+// via GObject.source_set_closure; this port routes through GLib.idle_add /
+// GLib.timeout_add directly instead (equivalent behavior, one less indirection —
+// the engine marshals JS functions both as GI callbacks and as GClosures, see
+// test/gclosure-in-args.test.mjs), keeping the same `imports.mainloop.*` surface.
 
 const DEFAULT_IDLE_PRIORITY = 200; // GLib.PRIORITY_DEFAULT_IDLE
 

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -70,7 +70,7 @@
     "test": "NODE_GI_NATIVE=build node --test",
     "test:node": "NODE_GI_NATIVE=build node --test",
     "test:gc": "NODE_GI_NATIVE=build node --test --expose-gc",
-    "test:dbus": "dbus-run-session -- env NODE_GI_NATIVE=build node --test test/dbus.test.mjs",
+    "test:dbus": "dbus-run-session -- env NODE_GI_NATIVE=build node --test --expose-gc test/dbus.test.mjs",
     "test:bun": "node scripts/cross-runtime.mjs bun",
     "test:conformance": "node scripts/conformance.mjs",
     "test:gimarshalling": "node scripts/gimarshalling.mjs",

--- a/packages/node-gi/node-gi/test/dbus.test.mjs
+++ b/packages/node-gi/node-gi/test/dbus.test.mjs
@@ -1,18 +1,23 @@
 // SPDX-License-Identifier: MIT
-// @gjsify/node-gi — Gio.DBus client round-trip on a private session bus.
+// @gjsify/node-gi — Gio.DBus client + object-export round-trips on a private
+// session bus.
 //
-// Runs the SHARED scenario (../dbus/scenario.mjs) on node-gi and asserts it equals
-// the golden result AND the output of the SAME scenario under `gjs -m`
+// Runs the SHARED scenarios (../dbus/scenario.mjs client half,
+// ../dbus/export-scenario.mjs export half) on node-gi and asserts each equals
+// its golden result AND the output of the SAME scenario under `gjs -m`
 // (../dbus/gjs-harness.js) — the byte-for-byte gjs cross-check. Requires a session
 // bus; wrap the invocation in `dbus-run-session` for isolation:
-//   dbus-run-session -- node --test test/dbus.test.mjs   (npm run test:dbus)
+//   dbus-run-session -- node --test --expose-gc test/dbus.test.mjs   (npm run test:dbus)
 // When no session bus is reachable (the default `npm test` in a headless CI
 // container), every case self-skips — it never fails for lack of a bus.
 //
 // Coverage: makeProxyWrapper (sync + async-raw + Promise methods, the proxy
 // surface, a live NameOwnerChanged signal), Gio.DBus.session, name owning
-// (own_name → onNameAcquired), and the DEFERRED export side (wrapJSObject throws a
-// clear error, never crashes).
+// (own_name → onNameAcquired), object export (Gio.DBusExportedObject.wrapJSObject
+// over the GClosure vtable — method call / property get+set / error / signal /
+// PropertiesChanged / unexport), and the export registration's GC lifetime
+// (closures rooted while exported, released after unregister — the --expose-gc
+// leg).
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
@@ -21,6 +26,7 @@ import { dirname, join } from 'node:path';
 
 import { requireGi } from '../gi.js';
 import { runScenario, EXPECTED } from '../dbus/scenario.mjs';
+import { runExportScenario, EXPORT_EXPECTED } from '../dbus/export-scenario.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const HARNESS = join(HERE, '..', 'dbus', 'gjs-harness.js');
@@ -85,6 +91,13 @@ test('the same round-trip under `gjs -m` is byte-identical (gold standard)', { s
   assert.ok(line, `no RESULT= line in gjs output:\n${r.stdout}\n${r.stderr}`);
   const gjsResult = JSON.parse(line.slice('RESULT='.length));
   assert.deepEqual(gjsResult, EXPECTED, 'gjs golden result diverged from EXPECTED');
+  // The export half rides the same harness run: gjs's native wrapJSObject
+  // (GjsPrivate.DBusImplementation) must produce the SAME normalized result as
+  // node-gi's GClosure-vtable port (asserted against EXPORT_EXPECTED below).
+  const exportLine = (r.stdout || '').split('\n').find((l) => l.startsWith('EXPORT_RESULT='));
+  assert.ok(exportLine, `no EXPORT_RESULT= line in gjs output:\n${r.stdout}\n${r.stderr}`);
+  const gjsExportResult = JSON.parse(exportLine.slice('EXPORT_RESULT='.length));
+  assert.deepEqual(gjsExportResult, EXPORT_EXPECTED, 'gjs export result diverged from EXPORT_EXPECTED');
 });
 
 test('proxy method Promise variant (FooAsync) resolves', { skip: busSkip }, async () => {
@@ -109,102 +122,114 @@ test('makeProxyWrapper.newAsync builds an inited proxy', { skip: busSkip }, asyn
 });
 
 // Object export (wrapJSObject) — a JS object exported over DBus via the GClosure
-// vtable (register_object_with_closures2). Full round-trip: a proxy calls an
-// exported method, gets/sets an exported property, and receives an emitted signal.
-// Async proxy + async calls throughout (a sync self-call would deadlock the single
-// main loop that must also service the incoming request). Needs a session bus.
-test('Gio.DBusExportedObject.wrapJSObject export round-trip', { skip: busSkip }, async () => {
-  const IFACE = 'org.gjsify.NodeGiExportTest';
-  const OBJ = '/org/gjsify/NodeGiExportTest';
+// vtable (register_object_with_closures2). The SHARED scenario covers the full
+// round-trip: impl surface, exported method, property get+set, throwing method →
+// DBus error, emit_signal, emit_property_changed → proxy cache, and unexport →
+// further calls error. The gjs harness runs the SAME source (gold standard test
+// above). Async proxy + async calls throughout (a sync self-call would deadlock
+// the single main loop that must also service the incoming request).
+test('Gio.DBusExportedObject.wrapJSObject export round-trip (shared scenario)', { skip: busSkip }, () => {
+  const result = runExportScenario({ Gio, GLib });
+  assert.deepEqual(result, EXPORT_EXPECTED);
+});
+
+// node-gi-specific export surface not part of the shared scenario: the camelCase
+// aliases the L1 layer adds (GJS's C skeleton has snake_case only).
+test('wrapJSObject camelCase aliases mirror the snake_case surface', { skip: busSkip }, () => {
+  const impl = Gio.DBusExportedObject.wrapJSObject(
+    '<node><interface name="org.gjsify.NodeGiAliasTest"><method name="Noop"/></interface></node>',
+    { Noop() {} },
+  );
+  assert.equal(impl.getInfo, impl.get_info);
+  assert.equal(impl.getObjectPath, impl.get_object_path);
+  assert.equal(impl.getConnection, impl.get_connection);
+  assert.equal(impl.unexportFromConnection, impl.unexport_from_connection);
+  assert.equal(impl.emitSignal, impl.emit_signal);
+  assert.equal(impl.emitPropertyChanged, impl.emit_property_changed);
+});
+
+// GC/lifetime (the --expose-gc leg; self-skips otherwise): the method/property
+// GClosures — and the service object they capture — must be rooted by NOTHING
+// but the native registration (JsClosureData's strong napi_ref, ref+sunk by
+// register_object_data), surviving a full GC with every JS reference dropped;
+// and unregistering must release them (closure invalidate → JsClosureFinalize →
+// napi_delete_reference) so the service becomes collectable — not a process-
+// lifetime leak. This is the adversarial rooting test for a long-lived DBus
+// registration outliving the call that created it.
+const gcSkip =
+  busSkip || (typeof globalThis.gc !== 'function' ? 'needs --expose-gc (npm run test:dbus)' : false);
+test('export registration roots its closures across GC; unregister releases them', { skip: gcSkip }, async () => {
+  const IFACE = 'org.gjsify.NodeGiExportGcTest';
+  const OBJ = '/org/gjsify/NodeGiExportGcTest';
   const XML = `<node><interface name="${IFACE}">
 <method name="Echo"><arg type="s" direction="in"/><arg type="s" direction="out"/></method>
-<method name="Boom"><arg type="s" direction="out"/></method>
-<property name="Level" type="i" access="readwrite"/>
-<signal name="Pinged"><arg type="s"/></signal>
 </interface></node>`;
 
   const conn = Gio.bus_get_sync(Gio.BusType.SESSION, null);
-  const service = {
-    Level: 7,
-    Echo(s) {
-      return `echo:${s}`;
-    },
-    Boom() {
-      throw new Error('kaboom');
-    },
-  };
-  const impl = Gio.DBusExportedObject.wrapJSObject(XML, service);
-  impl.export(conn, OBJ);
-  assert.equal(impl.get_object_path(), OBJ);
+  let collected = false;
+  const registry = new FinalizationRegistry(() => {
+    collected = true;
+  });
 
+  // Register, then drop EVERY JS reference — impl's own methods close over the
+  // service, so impl must go too. Creation happens inside a helper so no live
+  // frame slot can pin the service; only the registration id survives.
+  const setupExport = () => {
+    const service = {
+      Echo(s) {
+        return `gc:${s}`;
+      },
+    };
+    registry.register(service, 'service');
+    const impl = Gio.DBusExportedObject.wrapJSObject(XML, service);
+    return impl.export(conn, OBJ);
+  };
+  const registrationId = setupExport();
+
+  globalThis.gc();
+  globalThis.gc();
+  await new Promise((resolve) => setImmediate(resolve));
+  globalThis.gc();
+  assert.equal(collected, false, 'the exported service must NOT be collected while registered');
+
+  // The handler still works after the GC barrage — a use-after-free here would
+  // crash or mis-reply.
+  const dest = conn.get_unique_name();
   const loop = GLib.MainLoop.new(null, false);
   const result = {};
-  const ownId = Gio.DBus.own_name(
-    Gio.BusType.SESSION,
-    IFACE,
-    Gio.BusNameOwnerFlags.NONE,
-    () => {},
-    () => {
-      const PW = Gio.DBusProxy.makeProxyWrapper(XML);
-      PW(conn, IFACE, OBJ, (proxy, err) => {
-        if (err) {
-          result.error = String(err);
-          loop.quit();
-          return;
-        }
-        let signal = null;
-        proxy.connectSignal('Pinged', (_p, _s, args) => {
-          signal = args[0];
-        });
-        proxy.EchoRemote('hi', ([echoed]) => {
-          result.echo = echoed;
-          // property get + set via org.freedesktop.DBus.Properties (async, no deadlock)
-          conn.call(
-            IFACE, OBJ, 'org.freedesktop.DBus.Properties', 'Get',
-            new GLib.Variant('(ss)', [IFACE, 'Level']),
-            new GLib.VariantType('(v)'), Gio.DBusCallFlags.NONE, -1, null,
-            (_s1, res1) => {
-              result.levelBefore = conn.call_finish(res1).deepUnpack()[0].deepUnpack();
-              conn.call(
-                IFACE, OBJ, 'org.freedesktop.DBus.Properties', 'Set',
-                new GLib.Variant('(ssv)', [IFACE, 'Level', new GLib.Variant('i', 99)]),
-                null, Gio.DBusCallFlags.NONE, -1, null,
-                (_s2, res2) => {
-                  conn.call_finish(res2);
-                  result.levelAfter = service.Level;
-                  // error-return path: Boom throws → DBus error → proxy err
-                  proxy.BoomRemote(([_v], boomErr) => {
-                    result.boomErr = Boolean(boomErr);
-                    impl.emit_signal('Pinged', new GLib.Variant('(s)', ['ping!']));
-                    GLib.timeout_add(GLib.PRIORITY_DEFAULT, 150, () => {
-                      result.signal = signal;
-                      loop.quit();
-                      return false;
-                    });
-                  });
-                },
-              );
-            },
-          );
-        });
-      });
-    },
-    () => {},
-  );
+  const PW = Gio.DBusProxy.makeProxyWrapper(XML);
+  new PW(conn, dest, OBJ, (proxy, err) => {
+    if (err) {
+      result.error = String(err);
+      loop.quit();
+      return;
+    }
+    proxy.EchoRemote('alive', (r, callErr) => {
+      result.callErr = Boolean(callErr);
+      result.echo = callErr ? null : r[0];
+      loop.quit();
+    });
+  });
   GLib.timeout_add(GLib.PRIORITY_DEFAULT, 8000, () => {
     result.timedOut = true;
     loop.quit();
     return false;
   });
   loop.run();
-  Gio.DBus.unown_name(ownId);
-  impl.unexport();
-
-  assert.equal(result.timedOut, undefined, 'round-trip must complete before the safety timeout');
+  assert.equal(result.timedOut, undefined, 'call must complete before the safety timeout');
   assert.equal(result.error, undefined);
-  assert.equal(result.echo, 'echo:hi', 'exported method reply');
-  assert.equal(result.levelBefore, 7, 'get-property closure');
-  assert.equal(result.levelAfter, 99, 'set-property closure wrote through');
-  assert.equal(result.boomErr, true, 'a throwing method returns a DBus error');
-  assert.equal(result.signal, 'ping!', 'emit_signal reaches the proxy');
+  assert.equal(result.callErr, false);
+  assert.equal(result.echo, 'gc:alive', 'the closure-rooted handler still replies after GC');
+
+  // Unregister: the registration drops its closure refs → finalize → the JS
+  // service becomes collectable. GDBus may defer the release to the main
+  // context, so pump the loop between GC passes; a service that NEVER becomes
+  // collectable is a leak and fails here.
+  assert.equal(conn.unregister_object(registrationId), true);
+  for (let i = 0; i < 100 && !collected; i++) {
+    globalThis.gc();
+    pumpFor(10);
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(collected, true, 'the service must be collectable after unregister_object');
 });

--- a/packages/node-gi/node-gi/test/gclosure-in-args.test.mjs
+++ b/packages/node-gi/node-gi/test/gclosure-in-args.test.mjs
@@ -158,6 +158,65 @@ test('GObject.source_set_closure: a JS fn drives a timeout source', () => {
   assert.equal(ticks, 2);
 });
 
+// ---- 4. GC/lifetime: the closure's strong napi_ref is the ONLY root ---------
+//
+// A JS fn handed to signal_connect_closure is rooted by nothing but the
+// marshaled GClosure's JsClosureData napi_ref (ref+sunk by the connection):
+// with every JS reference dropped it must survive a full GC while connected
+// (an under-rooted weak ref would collect it → the emit would be a
+// use-after-free), and disconnecting must release it (closure invalidate →
+// JsClosureFinalize → napi_delete_reference) so the fn becomes collectable —
+// not a process-lifetime leak. Node --expose-gc leg only (bun/deno run this
+// file in the cross-runtime subset without an exposed deterministic gc).
+const isNodeGc =
+  typeof process !== 'undefined' &&
+  Boolean(process.versions?.node) &&
+  !process.versions?.bun &&
+  typeof globalThis.Deno === 'undefined' &&
+  typeof globalThis.gc === 'function';
+test(
+  'GC: a connected closure survives gc; disconnect releases the fn',
+  { skip: !isNodeGc && 'needs node --test --expose-gc (npm run test:gc)' },
+  async () => {
+    // Bun's node:test shim ignores the `skip` option and runs the body anyway —
+    // bail imperatively on any runtime without Node's exposed deterministic gc.
+    if (!isNodeGc) return;
+    const action = new Gio.SimpleAction({ name: 'gc-root', enabled: true });
+    let collected = false;
+    const registry = new FinalizationRegistry(() => {
+      collected = true;
+    });
+    const state = { seen: 0 };
+    // Connect inside a helper so no live frame slot can pin the handler; only
+    // the handler id escapes.
+    const connectHandler = () => {
+      const fn = () => {
+        state.seen++;
+      };
+      registry.register(fn, 'handler');
+      return GObject.signal_connect_closure(action, 'notify::enabled', fn, false);
+    };
+    const id = connectHandler();
+
+    globalThis.gc();
+    globalThis.gc();
+    await new Promise((resolve) => setImmediate(resolve));
+    globalThis.gc();
+    assert.equal(collected, false, 'the handler must NOT be collected while connected');
+    action.set_enabled(false);
+    assert.equal(state.seen, 1, 'the closure-rooted handler still fires after GC');
+
+    GObject.signal_handler_disconnect(action, id);
+    for (let i = 0; i < 100 && !collected; i++) {
+      globalThis.gc();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    assert.equal(collected, true, 'the handler must be collectable after disconnect');
+    action.set_enabled(true);
+    assert.equal(state.seen, 1, 'no dispatch after disconnect');
+  },
+);
+
 test('a throwing GClosure handler is surfaced, not propagated (loop-dispatched)', () => {
   const action = new Gio.SimpleAction({ name: 'y', enabled: true });
   GObject.signal_connect_closure(


### PR DESCRIPTION
## What

#742 landed the GClosure IN-argument primitive **and all three of its L1 consumers** (`GLib.log_set_writer_func`, `bind_property_full`, `Gio.DBusExportedObject.wrapJSObject`) — but the README still called all three *kept-throw*, the DBus **export** half had no gjs byte-parity harness (only the client half was scenario-shared), the log writer had no conformance program, and nothing adversarially exercised the GC lifetime of closures held by long-lived registrations. This PR closes those gaps, plus one real behavior divergence it surfaced.

### `fix(node-gi): append unix-fd-list to dbus handlers`
GJS appends the invocation message's `Gio.UnixFDList` as a trailing argument to every exported DBus method handler (`null` when no fds) and as the 3rd arg of the `*Async` form — node-gi's `wrapJSObject` port dropped it. Now mirrored exactly (refs/gjs `Gio.js` `_handleMethodCall`); the `null` no-fd shape is byte-verified against gjs by the shared export scenario. Deeper fd extraction from a real fd-carrying call stays untested (documented).

### `test(node-gi): gclosure parity + gc lifetime`
- **`conformance/programs/log-writer.conf.mjs` (+ golden)** — a JS `GLogWriterFunc` receives real structured logs (level flags; fields as Uint8Array bytes incl. `GLIB_DOMAIN`/`PRIORITY`; string/Uint8Array/Variant packing), `HANDLED` stops the default writer, `log_set_writer_default()` detaches. **Byte-identical on gjs × node × bun × deno.**
- **`dbus/export-scenario.mjs`** — the object-export half as a SHARED scenario (impl surface, exported method incl. the trailing fd-list arg, property get/set via `org.freedesktop.DBus.Properties`, throwing method → `org.gnome.gjs.JSError.Error`, `emit_signal`, `emit_property_changed` → proxy cache, unexport → further calls error). The gjs harness runs the SAME source; both results must equal `EXPORT_EXPECTED` — the byte-for-byte gjs cross-check the export side lacked.
- **GC/lifetime (adversarial, `--expose-gc`)** — a connected signal closure and a DBus export registration root their JS function/service via NOTHING but the marshaled closure's strong `napi_ref`: they survive a full GC with every JS reference dropped and still dispatch; `signal_handler_disconnect` / `unregister_object` release them (closure invalidate → `JsClosureFinalize` → `napi_delete_reference`), observed via `FinalizationRegistry` — a leak fails the test. `test:dbus` now runs with `--expose-gc`. (Bun's `node:test` shim ignores `skip`, so the GC test also bails imperatively off Node.)

### `docs(node-gi): un-stale gclosure kept-throw claims`
README rewritten to the true post-#742 state for all three consumers (the only remaining kept-throw in that section is the ParamSpec builder gap: `enum`/`flags`/`char`/`uchar`/`long`/`ulong`/`param` — re-verified still accurate); stale “engine cannot yet marshal a GClosure” note in `overrides/mainloop.js` and the “DEFERRED export” dbus-test header dropped. STATUS.md needs no edit — these items were never in the node-gi deferred-limitations list (the staleness lived in the README).

## Verification (local, Fedora, GLib 2.88 / gjs on PATH)

- `npm test` → **358 pass / 0 fail** (`test:gc` leg: 358/358, 0 skipped — live session bus, so the dbus + GC legs really ran)
- `npm run test:dbus` → **7/7**, incl. the gjs harness asserting BOTH `RESULT` and the new `EXPORT_RESULT` equal the shared goldens
- `npm run test:conformance` → **17 programs × gjs/node/bun/deno all green** (incl. new `log-writer`)
- `npm run test:bun` / `test:deno` → **34/34** each
- `npm run test:gimarshalling` → **369 pass / 0 fail**

## Residuals (honest)

- fd-carrying DBus calls: the trailing `UnixFDList` arrives wrapped, deeper fd extraction untested.
- `g_log_set_writer_func` is once-per-process (a 2nd install aborts inside GLib — identical under gjs; documented).
- Pre-existing README drift outside this scope (e.g. the milestone-1 intro's vfunc-chain-up note, the multi-level-subclass caveat vs `multilevel-subclass.test.mjs`) left untouched.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq