### PR TITLE
docs(website): command tabs, GJSify spelling, layout fixes

### DIFF
--- a/website/src/components/CommandTabs.astro
+++ b/website/src/components/CommandTabs.astro
@@ -1,0 +1,105 @@
+---
+// CommandTabs — one command block, one tab per way of invoking the toolchain
+// (GJSify's own Node-free CLI, npm, Bun, Deno). Built on our own
+// <adw-inline-view-switcher> from @gjsify/adwaita-web, so the tabs look and
+// behave like a native Adwaita toggle group. The tab contents are ordinary
+// fenced code blocks passed via named slots, so Expressive Code keeps its
+// syntax highlighting and copy button.
+//
+// The selected runtime is remembered (localStorage) and synchronized across
+// every CommandTabs instance on the site: pick "Deno" once and all command
+// blocks follow.
+//
+// Usage (MDX):
+//   <CommandTabs>
+//     <Fragment slot="gjsify">```bash …```</Fragment>
+//     <Fragment slot="npm">```bash …```</Fragment>
+//     <Fragment slot="bun">```bash …```</Fragment>
+//     <Fragment slot="deno">```bash …```</Fragment>
+//   </CommandTabs>
+const RUNTIMES = [
+    { slot: 'gjsify', label: 'GJSify' },
+    { slot: 'npm', label: 'npm' },
+    { slot: 'bun', label: 'Bun' },
+    { slot: 'deno', label: 'Deno' },
+];
+// Astro slots can't be referenced with a dynamic `name` in the template —
+// render the provided ones to HTML up front instead.
+const present = [];
+for (const r of RUNTIMES) {
+    if (Astro.slots.has(r.slot)) {
+        present.push({ ...r, html: await Astro.slots.render(r.slot) });
+    }
+}
+const runtimesAttr = present.map((r) => r.slot).join(',');
+---
+
+<adw-inline-view-switcher class="command-tabs" display-mode="labels" round data-command-tabs data-runtimes={runtimesAttr}>
+    {present.map((r) => <adw-view-stack-page title={r.label} set:html={r.html} />)}
+</adw-inline-view-switcher>
+
+<script>
+    import '@gjsify/adwaita-web';
+
+    const KEY = 'gjsify-preferred-runtime';
+
+    const applyPreference = (runtime: string | null, skip?: Element) => {
+        if (!runtime) return;
+        for (const el of document.querySelectorAll<HTMLElement>('[data-command-tabs]')) {
+            if (el === skip) continue;
+            const runtimes = (el.dataset.runtimes ?? '').split(',');
+            const index = runtimes.indexOf(runtime);
+            if (index >= 0) el.setAttribute('active', String(index));
+        }
+    };
+
+    // Follow user selection: persist + mirror to every other instance.
+    document.addEventListener('notify::active', (event) => {
+        const target = event.target as HTMLElement;
+        if (!target?.matches?.('[data-command-tabs]')) return;
+        const runtimes = (target.dataset.runtimes ?? '').split(',');
+        const runtime = runtimes[(event as CustomEvent).detail?.active ?? 0];
+        if (!runtime) return;
+        try {
+            localStorage.setItem(KEY, runtime);
+        } catch {
+            // Private mode — selection just won't persist.
+        }
+        applyPreference(runtime, target);
+    });
+
+    // Initial: restore the remembered runtime once the element is defined.
+    customElements.whenDefined('adw-inline-view-switcher').then(() => {
+        try {
+            applyPreference(localStorage.getItem(KEY));
+        } catch {
+            // ignore
+        }
+    });
+</script>
+
+<style is:global>
+    /* Before the custom element hydrates, show only the first page so the
+       server-rendered HTML doesn't stack every tab's code block. */
+    adw-inline-view-switcher.command-tabs:not(:defined) > adw-view-stack-page {
+        display: none;
+    }
+    adw-inline-view-switcher.command-tabs:not(:defined) > adw-view-stack-page:first-of-type {
+        display: block;
+    }
+
+    .command-tabs {
+        display: block;
+        margin-top: 1rem;
+    }
+
+    .command-tabs .adw-inline-view-switcher-group {
+        margin-bottom: 0.75rem;
+    }
+
+    /* The page panel holds a regular Expressive Code block — let it keep its
+       own margins collapsed against the switcher bar. */
+    .command-tabs .adw-inline-view-switcher-page > :first-child {
+        margin-top: 0;
+    }
+</style>

--- a/website/src/components/ThreeWorldsFusion.astro
+++ b/website/src/components/ThreeWorldsFusion.astro
@@ -9,11 +9,11 @@
 
 <section class="fusion">
   <div class="fusion-inner">
-    <p class="fusion-eyebrow">What makes gjsify different</p>
+    <p class="fusion-eyebrow">What makes GJSify different</p>
     <h2 class="fusion-title">Three worlds, one runtime</h2>
     <p class="fusion-lead">
       GNOME, Node.js, and the Web have lived in separate runtimes for a
-      decade. gjsify dissolves the boundary — every API lands inside one
+      decade. GJSify dissolves the boundary — every API lands inside one
       SpiderMonkey process and shares the same memory, the same event
       loop, the same GTK main context.
     </p>
@@ -54,19 +54,19 @@
           <li><code>Canvas 2D</code> · WebGL · WebGPU bridge</li>
           <li>WebRTC · WebAudio · Gamepad</li>
           <li><code>FormData</code> · Streams · Crypto</li>
-          <li>DOM events, Mutation/Resize observers</li>
+          <li>DOM events, Mutation / Resize observers</li>
         </ul>
       </div>
 
       <div class="fusion-arrow" aria-hidden="true">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M5 12h14M13 6l6 6-6 6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M12 5v14M6 13l6 6 6-6" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </div>
 
       <div class="fusion-output">
         <div class="fusion-output-head">
-          <span class="fusion-output-tag">gjsify</span>
+          <span class="fusion-output-tag">GJSify</span>
         </div>
         <p class="fusion-output-text">
           One SpiderMonkey process. One TypeScript codebase. Zero glue
@@ -81,7 +81,7 @@
         Ship a browser game engine — without shipping a browser.
       </p>
       <p class="fusion-callout-body">
-        <a href="https://excaliburjs.com/" target="_blank" rel="noopener">Excalibur.js</a> renders directly into a <code>Gtk.GLArea</code> through gjsify's WebGL bridge.
+        <a href="https://excaliburjs.com/" target="_blank" rel="noopener">Excalibur.js</a> renders directly into a <code>Gtk.GLArea</code> through GJSify's WebGL bridge.
         Pointer, keyboard, and gamepad input flows through GTK4 event controllers, dispatched as W3C DOM events.
         Audio runs on GStreamer through the Web Audio API. The whole game lives in one process — the same
         one that draws the Adwaita window around it. No <code>WebKit.WebView</code>, no IPC bridge, no
@@ -93,7 +93,7 @@
           <span class="fusion-vs-value fusion-vs-bad">~150 MB Chromium runtime · separate renderer process · webContents bridge · X11/Wayland double-buffered</span>
         </div>
         <div class="fusion-vs-row">
-          <span class="fusion-vs-label">gjsify app</span>
+          <span class="fusion-vs-label">GJSify app</span>
           <span class="fusion-vs-value fusion-vs-good">Stock GJS · single process · native GTK4 widgets · uses the GNOME runtime the user already has installed</span>
         </div>
       </div>
@@ -107,6 +107,9 @@
     max-width: 1200px;
     margin-inline: auto;
     padding-inline: 1.5rem;
+    /* The pillar grid adapts to the actual content column (which varies with
+       the two sidebars), not the viewport. */
+    container-type: inline-size;
   }
 
   .fusion-inner {
@@ -143,10 +146,13 @@
     line-height: 1.6;
   }
 
-  /* --- Pillar layout --- */
+  /* --- Pillar layout ---
+     Three pillars side by side, then a downward arrow, then the GJSify
+     output card across the full width — each element gets room to breathe
+     instead of squeezing five columns into one row. */
   .fusion-stack {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr)) auto minmax(0, 1.2fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
     width: 100%;
     align-items: stretch;
@@ -206,12 +212,15 @@
   .fusion-pillar-list code {
     font-size: 0.85em;
     padding: 1px 5px;
+    white-space: nowrap; /* chips wrap between items, never inside a name */
   }
 
   .fusion-arrow {
-    align-self: center;
+    grid-column: 1 / -1;
+    justify-self: center;
     color: var(--sl-color-gray-4);
     display: flex;
+    padding-block: 0.25rem;
   }
 
   .fusion-arrow svg {
@@ -220,6 +229,13 @@
   }
 
   .fusion-output {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+    text-align: center;
     border-color: var(--sl-color-accent);
     box-shadow: 0 0 0 1px var(--sl-color-accent-low), 0 8px 24px rgba(53, 132, 228, 0.18);
     background: linear-gradient(180deg, var(--sl-color-accent-low) 0%, var(--sl-color-bg-nav) 80%);
@@ -227,7 +243,7 @@
 
   .fusion-output-text {
     margin: 0;
-    font-size: 1rem;
+    font-size: 1.05rem;
     color: var(--sl-color-white);
     line-height: 1.55;
   }
@@ -311,15 +327,17 @@
   .fusion-vs-bad  { color: var(--sl-color-gray-3); }
   .fusion-vs-good { color: var(--sl-color-gray-2); }
 
-  /* --- Responsive --- */
-  @media (max-width: 980px) {
+  /* --- Responsive ---
+     Starlight's content column caps at 45rem (720px), so the pillars sit
+     three-across inside it on desktop; only genuinely narrow layouts stack. */
+  @container (max-width: 640px) {
     .fusion-stack {
       grid-template-columns: 1fr;
     }
 
-    .fusion-arrow {
-      transform: rotate(90deg);
-      justify-self: center;
+    .fusion-output {
+      flex-direction: column;
+      gap: 0.75rem;
     }
   }
 

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: All gjsify subcommands, flags and typical usage
+description: All GJSify subcommands, flags and typical usage
 ---
 
 The `@gjsify/cli` package ships the `gjsify` binary. Run it via `npx @gjsify/cli <command>` or add it as a dev dependency.
@@ -80,7 +80,7 @@ The `gjsify` field in `package.json` (or `.gjsifyrc.js` / `gjsify.config.mjs`) c
 
 `bundler` is a `RolldownOptions` subset. The orchestrator applies platform-specific defaults on top.
 
-> **`define` placement:** `define` belongs under `bundler.transform.define`, **not** at the top level of `bundler`. If you write `bundler.define` (a common mistake when flat-renaming the old `esbuild` key), gjsify auto-maps it to `bundler.transform.define` and emits a build-time warning. To suppress the warning, move it:
+> **`define` placement:** `define` belongs under `bundler.transform.define`, **not** at the top level of `bundler`. If you write `bundler.define` (a common mistake when flat-renaming the old `esbuild` key), GJSify auto-maps it to `bundler.transform.define` and emits a build-time warning. To suppress the warning, move it:
 >
 > ```jsonc
 > // ❌ silently wrong without the alias — now warned + auto-fixed
@@ -702,7 +702,7 @@ Configure defaults in `package.json#gjsify.storybook` (`applicationId`, `title`,
 
 ## `gjsify debug`
 
-Launch an **MCP↔devtools bridge** for a running, devtools-enabled gjsify app (its `org.gjsify.Devtools` DBus control plane). An MCP client (e.g. Claude Code) uses this as its server command; the bridge speaks JSON-RPC on stdio and translates each tool call to the app's DBus interface. Provided by [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp).
+Launch an **MCP↔devtools bridge** for a running, devtools-enabled GJSify app (its `org.gjsify.Devtools` DBus control plane). An MCP client (e.g. Claude Code) uses this as its server command; the bridge speaks JSON-RPC on stdio and translates each tool call to the app's DBus interface. Provided by [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp).
 
 ```bash
 # Point an MCP client at it (.mcp.json):
@@ -1046,7 +1046,7 @@ Only works for CLIs installed under `~/.local/share/gjsify/global/` (the `instal
 
 ## `gjsify generate-installer`
 
-Scaffold an `install.mjs` for your own GJS-runnable npm package — your users get the same `curl ... | gjs -m -` install story as gjsify itself.
+Scaffold an `install.mjs` for your own GJS-runnable npm package — your users get the same `curl ... | gjs -m -` install story as GJSify itself.
 
 ```bash
 cd my-gjs-app
@@ -1061,13 +1061,13 @@ gjsify generate-installer \
   --output bin/install.mjs --force
 ```
 
-The generated `install.mjs` is a verbatim copy of gjsify's own root `install.mjs` with three constants substituted (`DEFAULT_TARGET`, `DEFAULT_BIN_NAME`, `DEFAULT_BOOTSTRAP_URL`). See the [Distributing GJS apps guide](/guides/distributing-gjs-apps/) for the full publication workflow.
+The generated `install.mjs` is a verbatim copy of GJSify's own root `install.mjs` with three constants substituted (`DEFAULT_TARGET`, `DEFAULT_BIN_NAME`, `DEFAULT_BOOTSTRAP_URL`). See the [Distributing GJS apps guide](/guides/distributing-gjs-apps/) for the full publication workflow.
 
 | Option | Default | Description |
 |---|---|---|
 | `[target]` (positional) | `package.json#name` | npm package to install. |
 | `--bin-name <name>` | first key of `gjsify.bin` or `bin` | Bin name produced by the installer. |
-| `--bootstrap-url <url>` | gjsify GH `releases/latest/download/cli.gjs.mjs` | Override the bootstrap bundle source. |
+| `--bootstrap-url <url>` | GJSify GH `releases/latest/download/cli.gjs.mjs` | Override the bootstrap bundle source. |
 | `--output <file>` | `install.mjs` | Where to write the installer. |
 | `--force` | `false` | Overwrite an existing file. |
 
@@ -1178,8 +1178,8 @@ gjsify onboard --yes                 # non-interactive: fail clearly if a login/
 
 Format JS/TS source files via [oxfmt](https://oxc.rs/docs/guide/usage/formatter) (oxc's formatter). Dual-engine:
 
-- **Under GJS** (the `gjs -m cli.gjs.mjs` bundle), gjsify prefers the `@gjsify/oxfmt-native` GI bridge — the full oxfmt CLI runs in-process, **Node-free** (config resolution, ignore handling, file walking, `--write`/`--check`/`--list-different` all included). Override with `GJSIFY_OXFMT=npm` (force the Node launcher) or `GJSIFY_OXFMT=native` (error instead of falling back when the prebuild is unavailable).
-- **On Node** (or when the native prebuild is missing), gjsify resolves oxfmt's npm package Node launcher from `node_modules/oxfmt/bin/oxfmt` and spawns it with the current Node executable. The per-platform native code ships as the `@oxfmt/binding-<target>` napi optionalDependency.
+- **Under GJS** (the `gjs -m cli.gjs.mjs` bundle), GJSify prefers the `@gjsify/oxfmt-native` GI bridge — the full oxfmt CLI runs in-process, **Node-free** (config resolution, ignore handling, file walking, `--write`/`--check`/`--list-different` all included). Override with `GJSIFY_OXFMT=npm` (force the Node launcher) or `GJSIFY_OXFMT=native` (error instead of falling back when the prebuild is unavailable).
+- **On Node** (or when the native prebuild is missing), GJSify resolves oxfmt's npm package Node launcher from `node_modules/oxfmt/bin/oxfmt` and spawns it with the current Node executable. The per-platform native code ships as the `@oxfmt/binding-<target>` napi optionalDependency.
 
 > **CSS/JSON formatting is not supported.** oxfmt formats JS/TS (+TOML) only. The previous Biome toolchain formatted CSS and JSON too; that is intentionally dropped in the oxc migration and not replaced by another formatter.
 
@@ -1202,7 +1202,7 @@ gjsify format src/               # report drift without writing (list-different)
 
 With no `--write`/`--check`, `gjsify format` reports drift via oxfmt's `--list-different` without modifying files.
 
-**Workspace-aware resolution** — when run from inside a sub-workspace, gjsify walks up to the workspace root to find `node_modules/oxfmt/bin/oxfmt`. A single `.oxfmtrc.json` at the workspace root applies everywhere oxfmt discovers it.
+**Workspace-aware resolution** — when run from inside a sub-workspace, GJSify walks up to the workspace root to find `node_modules/oxfmt/bin/oxfmt`. A single `.oxfmtrc.json` at the workspace root applies everywhere oxfmt discovers it.
 
 **Standalone projects** — same shape, single `.oxfmtrc.json` at the project root.
 
@@ -1211,7 +1211,7 @@ With no `--write`/`--check`, `gjsify format` reports drift via oxfmt's `--list-d
 `gjsify format --init` writes two config files tuned for GJS/GNOME projects:
 
 `.oxfmtrc.json` (formatter):
-- 4-space indent (spaces, not tabs), single quotes, semicolons-always, trailing commas `all`, arrow parens `always`, printWidth 120, bracket spacing on (matches the gjsify codebase + GNOME Shell style guide).
+- 4-space indent (spaces, not tabs), single quotes, semicolons-always, trailing commas `all`, arrow parens `always`, printWidth 120, bracket spacing on (matches the GJSify codebase + GNOME Shell style guide).
 - Excludes generated artifacts (`dist`, `lib`, `cli.gjs.mjs`, `test.{gjs,node}.mjs`), Flatpak build dirs, `refs/` submodules, prebuilds, compiled `.metainfo.xml`.
 
 `.oxlintrc.json` (linter):
@@ -1227,7 +1227,7 @@ With no `--write`/`--check`, `gjsify format` reports drift via oxfmt's `--list-d
 
 ## `gjsify lint`
 
-Run [oxlint](https://oxc.rs/docs/guide/usage/linter) diagnostics. Default reports findings (exit non-zero); `--fix` applies safe fixes in place. oxlint is spawned via its Node launcher (`node_modules/oxlint/bin/oxlint`) so its JS-plugin host — including gjsify's internal `gjsify/register-class-order` rule — is available.
+Run [oxlint](https://oxc.rs/docs/guide/usage/linter) diagnostics. Default reports findings (exit non-zero); `--fix` applies safe fixes in place. oxlint is spawned via its Node launcher (`node_modules/oxlint/bin/oxlint`) so its JS-plugin host — including GJSify's internal `gjsify/register-class-order` rule — is available.
 
 ```bash
 gjsify lint              # lint all
@@ -1246,7 +1246,7 @@ Use `gjsify fix` for the combined format + safe-lint-fix pass.
 
 ### Internal lint rule: `gjsify/register-class-order`
 
-gjsify ships an internal oxlint JS plugin (`@gjsify/oxlint-plugin-gjsify`, not published to npm) with one rule, wired into the workspace `.oxlintrc.json` via `jsPlugins`. It flags `static` GObject metadata fields (`GTypeName`, `Properties`, `InternalChildren`, `Signals`, `Template`, `CssName`, …) declared **after** a `static { GObject.registerClass(…) }` block — where `registerClass` runs before the field is assigned, so the metadata is silently ignored — and autofixes by hoisting those fields above the static block. (GNOME/gjs#704, gjsify/ts-for-gir#410.)
+GJSify ships an internal oxlint JS plugin (`@gjsify/oxlint-plugin-gjsify`, not published to npm) with one rule, wired into the workspace `.oxlintrc.json` via `jsPlugins`. It flags `static` GObject metadata fields (`GTypeName`, `Properties`, `InternalChildren`, `Signals`, `Template`, `CssName`, …) declared **after** a `static { GObject.registerClass(…) }` block — where `registerClass` runs before the field is assigned, so the metadata is silently ignored — and autofixes by hoisting those fields above the static block. (GNOME/gjs#704, gjsify/ts-for-gir#410.)
 
 ## `gjsify fix`
 

--- a/website/src/content/docs/contributing/development-setup.md
+++ b/website/src/content/docs/contributing/development-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Development Setup
-description: Clone the gjsify monorepo and build it locally
+description: Clone the GJSify monorepo and build it locally
 ---
 
 This page is for **contributors** working on the GJSify monorepo itself. If you just want to use GJSify in your own project, head to [Getting Started](/gjsify/getting-started/) instead.

--- a/website/src/content/docs/coverage.mdx
+++ b/website/src/content/docs/coverage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Coverage
-description: How complete gjsify is — pillar entries, Node.js modules and W3C/WHATWG web standards, rendered live from STATUS.md.
+description: How complete GJSify is — pillar entries, Node.js modules and W3C/WHATWG web standards, rendered live from STATUS.md.
 ---
 
 import PillarCoverage from '../../components/PillarCoverage.astro';
@@ -8,7 +8,7 @@ import NodeApiCoverage from '../../components/NodeApiCoverage.astro';
 import WebStandardsCoverage from '../../components/WebStandardsCoverage.astro';
 import IntegrationTests from '../../components/IntegrationTests.astro';
 
-gjsify's progress is tracked in [`STATUS.md`](https://github.com/gjsify/gjsify/blob/main/STATUS.md) and regenerated into these dashboards on every build, so the bars never lag behind reality.
+GJSify's progress is tracked in [`STATUS.md`](https://github.com/gjsify/gjsify/blob/main/STATUS.md) and regenerated into these dashboards on every build, so the bars never lag behind reality.
 
 The dashboards below cover the primary direction — Node.js, Web and DOM APIs implemented on GJS. For what is validated on the *other* runtimes (Node.js, Bun, Deno, the browser), see [Runtimes](/gjsify/runtimes/).
 

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -3,29 +3,49 @@ title: Getting Started
 description: Scaffold, build and run your first GJSify project
 ---
 
+import CommandTabs from '../../components/CommandTabs.astro';
+
 ## Quick Start
 
-**Node-free (recommended)** — install `@gjsify/cli` with one curl line:
+Pick your toolchain — GJSify's own **Node-free** CLI (recommended), or the
+same CLI through npm, Bun or Deno:
 
-```bash
-curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs \
-  -o /tmp/g.mjs && gjs -m /tmp/g.mjs && rm /tmp/g.mjs
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs \
+      -o /tmp/g.mjs && gjs -m /tmp/g.mjs && rm /tmp/g.mjs
 
-gjsify create my-app
-cd my-app
-gjsify install
-gjsify run dev
-```
+    gjsify create my-app
+    cd my-app
+    gjsify install
+    gjsify run dev
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npx @gjsify/cli create my-app
+    cd my-app && npm install
+    npm run dev
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bunx @gjsify/cli create my-app
+    cd my-app && bun install
+    bun run dev
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno run -A npm:@gjsify/cli create my-app
+    cd my-app && deno install
+    deno task dev
+    ```
+  </Fragment>
+</CommandTabs>
 
-Or if you already have Node.js installed:
-
-```bash
-npx @gjsify/cli create my-app
-cd my-app && npm install
-npm run dev
-```
-
-Either way: a GTK 4 window running your TypeScript, natively on Linux. See the [Install guide](/gjsify/guides/install/) for `~/.local/bin` PATH setup, [`gjsify self-update`](/gjsify/cli-reference/#gjsify-self-update), and [`gjsify uninstall`](/gjsify/cli-reference/#gjsify-uninstall).
+Whichever you pick: a GTK 4 window running your TypeScript, natively on Linux. See the [Install guide](/gjsify/guides/install/) for `~/.local/bin` PATH setup, [`gjsify self-update`](/gjsify/cli-reference/#gjsify-self-update), and [`gjsify uninstall`](/gjsify/cli-reference/#gjsify-uninstall).
 
 > **Tip:** Run `gjsify --help` (or `npx @gjsify/cli --help`) to see all available subcommands.
 
@@ -36,7 +56,7 @@ You need a few system packages:
 - **GJS** 1.86+ — the GNOME JavaScript runtime (SpiderMonkey 140)
 - **GTK 4** — the UI toolkit
 - **libsoup3** — HTTP, WebSocket and `fetch` at runtime
-- **Node.js** 24+ — *optional*, only needed if you prefer `npm install` / `npx` over the Node-free bootstrap above
+- **Node.js 24+, Bun or Deno** — *optional*, only needed if you prefer a package-manager workflow over the Node-free bootstrap above
 
 <details>
 <summary>Install commands</summary>
@@ -57,9 +77,28 @@ sudo apt install gjs libgtk-4-1 libsoup-3.0-0
 
 Not sure if everything is in place?
 
-```bash
-npx @gjsify/cli check
-```
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify system-check
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npx @gjsify/cli system-check
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bunx @gjsify/cli system-check
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno run -A npm:@gjsify/cli system-check
+    ```
+  </Fragment>
+</CommandTabs>
 
 ## What gets scaffolded
 
@@ -86,11 +125,38 @@ The build script uses `--globals auto` by default — no manual list to maintain
 
 ## Build and run
 
-```bash
-npm run build   # gjsify build src/index.ts --outfile dist/index.js
-npm start       # gjsify run dist/index.js
-npm run dev     # build + run in one step
-```
+The scaffolded scripts run with whichever toolchain you picked:
+
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify run build   # gjsify build src/index.ts --outfile dist/index.js
+    gjsify run start   # gjsify run dist/index.js
+    gjsify run dev     # build + run in one step
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm run build   # gjsify build src/index.ts --outfile dist/index.js
+    npm start       # gjsify run dist/index.js
+    npm run dev     # build + run in one step
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun run build   # gjsify build src/index.ts --outfile dist/index.js
+    bun run start   # gjsify run dist/index.js
+    bun run dev     # build + run in one step
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno task build   # gjsify build src/index.ts --outfile dist/index.js
+    deno task start   # gjsify run dist/index.js
+    deno task dev     # build + run in one step
+    ```
+  </Fragment>
+</CommandTabs>
 
 `gjsify run` automatically sets `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH` for any native prebuilds (e.g. `@gjsify/webgl`).
 

--- a/website/src/content/docs/guides/devtools.md
+++ b/website/src/content/docs/guides/devtools.md
@@ -1,15 +1,15 @@
 ---
 title: Devtools & MCP
-description: Inspect, screenshot and drive a running gjsify app — by hand with gdbus or from an AI agent over MCP — for GTK and web apps alike
+description: Inspect, screenshot and drive a running GJSify app — by hand with gdbus or from an AI agent over MCP — for GTK and web apps alike
 ---
 
-gjsify ships a **devtools control plane**: opt your app in with one call and it exposes a stable `org.gjsify.Devtools` interface you can drive three ways —
+GJSify ships a **devtools control plane**: opt your app in with one call and it exposes a stable `org.gjsify.Devtools` interface you can drive three ways —
 
 - **By hand** with `gdbus` / d-feet / GNOME Builder — no AI, no dev server.
 - **From an AI agent** (Claude Code, the MCP Inspector, …) over **MCP**, via `gjsify debug`.
 - **Headless in CI** — the same calls make a no-AI end-to-end UI test harness.
 
-It works for **GTK apps** (DBus is the idiomatic GNOME transport) and, through the bundled Adwaita web browser, for **web apps you build with gjsify** too. The contract — *commands + state + introspection* — is the same across both.
+It works for **GTK apps** (DBus is the idiomatic GNOME transport) and, through the bundled Adwaita web browser, for **web apps you build with GJSify** too. The contract — *commands + state + introspection* — is the same across both.
 
 ## The packages
 
@@ -18,7 +18,7 @@ It works for **GTK apps** (DBus is the idiomatic GNOME transport) and, through t
 | [`@gjsify/devtools-protocol`](https://www.npmjs.com/package/@gjsify/devtools-protocol) | The transport-agnostic contract (pure TS): methods, pause classification, envelope, interface name. |
 | [`@gjsify/devtools`](https://www.npmjs.com/package/@gjsify/devtools) | The in-app **DBus** adapter for GTK/GJS. `installDevtools(app, …)`. |
 | [`@gjsify/devtools-mcp`](https://www.npmjs.com/package/@gjsify/devtools-mcp) | The **MCP bridge** an agent talks to. Powers `gjsify debug`. |
-| [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser) | The minimalist Adwaita **web browser** for debugging gjsify web apps. Powers `gjsify browse`. |
+| [`@gjsify/devtools-browser`](https://www.npmjs.com/package/@gjsify/devtools-browser) | The minimalist Adwaita **web browser** for debugging GJSify web apps. Powers `gjsify browse`. |
 
 Two CLI commands tie it together: [`gjsify debug`](../../cli-reference/#gjsify-debug) (the MCP bridge) and [`gjsify browse`](../../cli-reference/#gjsify-browse) (the web browser). The GTK [`gjsify storybook`](../../cli-reference/#gjsify-storybook) is debuggable through the same plane.
 
@@ -105,7 +105,7 @@ The bridge auto-detects a **tool profile** from your `package.json` dependencies
 
 ## 4. Debug web apps — `gjsify browse`
 
-Because the apps you debug are **themselves built with gjsify**, you can render them in the bundled Adwaita web browser and drive *its* devtools plane. Launch with `--devtools`:
+Because the apps you debug are **themselves built with GJSify**, you can render them in the bundled Adwaita web browser and drive *its* devtools plane. Launch with `--devtools`:
 
 ```bash
 gjsify browse https://localhost:8080 --devtools
@@ -136,7 +136,7 @@ The browser profile adds web-debugging tools on top of the generics:
 | `get_accessibility` | An approximate accessibility tree (role + name + aria-*). |
 | `open_inspector` / `close_inspector` | Toggle the WebKit Web Inspector panel. |
 
-This is purpose-built for the gjsify web-app workflow: a developer (or an agent) opens the app, screenshots the real rendered output, evaluates assertions in-page, and inspects layout/network/a11y — without a separate browser-automation stack.
+This is purpose-built for the GJSify web-app workflow: a developer (or an agent) opens the app, screenshots the real rendered output, evaluates assertions in-page, and inspects layout/network/a11y — without a separate browser-automation stack.
 
 ## 5. Storybook
 

--- a/website/src/content/docs/guides/distributing-gjs-apps.md
+++ b/website/src/content/docs/guides/distributing-gjs-apps.md
@@ -1,6 +1,6 @@
 ---
 title: Distribute your GJS app
-description: Ship a one-line installer for your gjsify-based npm package.
+description: Ship a one-line installer for your GJSify-based npm package.
 ---
 
 The same Node-free bootstrap that installs `@gjsify/cli` also installs
@@ -8,7 +8,7 @@ The same Node-free bootstrap that installs `@gjsify/cli` also installs
 
 ## Generate an installer for your package
 
-From the root of your gjsify app:
+From the root of your GJSify app:
 
 ```bash
 gjsify generate-installer
@@ -16,7 +16,7 @@ gjsify generate-installer
 
 This writes `install.mjs` to the current directory, with three constants
 substituted for your package: the npm name (from `package.json#name`),
-the bin name (the first key of `gjsify.bin` or `bin`), and the gjsify
+the bin name (the first key of `gjsify.bin` or `bin`), and the GJSify
 bootstrap URL (defaults to
 `https://github.com/gjsify/gjsify/releases/latest/download/cli.gjs.mjs`).
 
@@ -36,7 +36,7 @@ curl -fsSL https://github.com/<you>/<repo>/raw/main/install.mjs \
 
 ## What it does for your users
 
-1. Downloads the pinned `cli.gjs.mjs` bootstrap bundle from the gjsify
+1. Downloads the pinned `cli.gjs.mjs` bootstrap bundle from the GJSify
    GitHub release, verifies SHA-256.
 2. Spawns `gjs -m <bundle> install -g <your-package>` — `@gjsify/cli`'s
    install backend resolves your package's transitive dependencies
@@ -61,7 +61,7 @@ gjsify generate-installer \
 |---|---|
 | `[target]` (positional) | `package.json#name` |
 | `--bin-name <name>` | first key of `gjsify.bin` or `bin` |
-| `--bootstrap-url <url>` | gjsify GitHub `releases/latest/download/cli.gjs.mjs` |
+| `--bootstrap-url <url>` | GJSify GitHub `releases/latest/download/cli.gjs.mjs` |
 | `--output <file>` | `install.mjs` (in cwd) |
 | `--force` | overwrite existing |
 

--- a/website/src/content/docs/guides/flatpak-cli-tool.md
+++ b/website/src/content/docs/guides/flatpak-cli-tool.md
@@ -175,7 +175,7 @@ gjsify flatpak deps --lockfile yarn.lock --out flatpak-node-sources.json
 
 The output is the JSON file you reference from your manifest's `sources:` array.
 
-> **Long-term goal:** the gjsify ecosystem aims for a Node-free build chain. When `gjsify install` (a future Yarn replacement) and a GJS-native `gjsify build` exist, the Node SDK extension and `flatpak-node-generator` step both drop out. Tracked in [STATUS.md → Node-free build chain](https://github.com/gjsify/gjsify/blob/main/STATUS.md). For now, Node 24 + flatpak-node-generator are part of the build-time (not runtime) story.
+> **Long-term goal:** the GJSify ecosystem aims for a Node-free build chain. When `gjsify install` (a future Yarn replacement) and a GJS-native `gjsify build` exist, the Node SDK extension and `flatpak-node-generator` step both drop out. Tracked in [STATUS.md → Node-free build chain](https://github.com/gjsify/gjsify/blob/main/STATUS.md). For now, Node 24 + flatpak-node-generator are part of the build-time (not runtime) story.
 
 ## 5. Build the bundle
 

--- a/website/src/content/docs/guides/native-adwaita-app.md
+++ b/website/src/content/docs/guides/native-adwaita-app.md
@@ -3,7 +3,7 @@ title: Native Adwaita Apps
 description: Assemble a native GNOME/Adwaita GJS app from the reusable shell in @gjsify/adwaita-app — runAsync lifecycle, a NavigationSplitView nav shell, async view mounting, and dialog/toast/file helpers
 ---
 
-Every native Adwaita app on gjsify repeats the same shell: an `Adw.Application`
+Every native Adwaita app on GJSify repeats the same shell: an `Adw.Application`
 run with `runAsync`, a startup CSS bootstrap, the [devtools](./devtools/) control
 plane, standard quit/about actions, an `Adw.NavigationSplitView` with a sidebar
 and a content stack, and a way to mount views that may load asynchronously.

--- a/website/src/content/docs/guides/self-executing-package.md
+++ b/website/src/content/docs/guides/self-executing-package.md
@@ -267,7 +267,7 @@ Wire as a yargs command:
 .command("self-update", "update to the latest release", {}, selfUpdate)
 ```
 
-This works because gjsify bundles the modern `fetch` + `node:fs` polyfills automatically.
+This works because GJSify bundles the modern `fetch` + `node:fs` polyfills automatically.
 
 ## 7. Optional — also publish on npm
 

--- a/website/src/content/docs/guides/storybook.md
+++ b/website/src/content/docs/guides/storybook.md
@@ -1,9 +1,9 @@
 ---
 title: Storybook
-description: Build a live component browser for your GTK/Adwaita widgets with gjsify — write a *.story.ts, run `gjsify storybook`, and get a sidebar of interactive, control-driven previews
+description: Build a live component browser for your GTK/Adwaita widgets with GJSify — write a *.story.ts, run `gjsify storybook`, and get a sidebar of interactive, control-driven previews
 ---
 
-gjsify ships a **storybook**: a live component browser for your widgets, the GTK/Adwaita analogue of [Storybook](https://storybook.js.org/). Write a `*.story.ts` per widget, run `gjsify storybook`, and get a categorized sidebar of interactive previews whose properties are driven by a live controls panel — no per-project storybook *app* to maintain.
+GJSify ships a **storybook**: a live component browser for your widgets, the GTK/Adwaita analogue of [Storybook](https://storybook.js.org/). Write a `*.story.ts` per widget, run `gjsify storybook`, and get a categorized sidebar of interactive previews whose properties are driven by a live controls panel — no per-project storybook *app* to maintain.
 
 It is the idiomatic way to **develop, document, and visually verify** custom widgets. Pair it with [devtools](./devtools/) to drive/screenshot the running storybook headlessly.
 

--- a/website/src/content/docs/how-it-works.mdx
+++ b/website/src/content/docs/how-it-works.mdx
@@ -3,6 +3,8 @@ title: How It Works
 description: Auto-aliasing, automatic globals detection and the GJS build pipeline
 ---
 
+import CommandTabs from '../../components/CommandTabs.astro';
+
 GJSify lets you write code against familiar Node.js and Web APIs while running natively on GJS. This page explains the three pieces that make that possible: **automatic module aliasing** at build time, **automatic globals detection via `--globals auto`**, and **automatic native library loading** at runtime.
 
 The same pipeline works for every build target — `gjsify build --app gjs|node|browser` swaps the alias layer, and for `--app node` it even runs in reverse: `gi://` imports resolve through the [node-gi bridge](/gjsify/projects/node-gi/) so GObject code runs on Node.js, Bun and Deno. See [Runtimes](/gjsify/runtimes/) for the target overview; the rest of this page walks through the GJS direction.
@@ -44,10 +46,32 @@ Every `@gjsify/*` package that provides a Node or Web global exposes one or more
 
 The CLI's default `--globals auto` discovers which registers your project needs by analysing the bundled output:
 
-```bash
-gjsify build src/index.ts --outfile dist/index.js
-# (--globals auto is the default — no flag needed)
-```
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify build src/index.ts --outfile dist/index.js
+    # (--globals auto is the default — no flag needed)
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npx @gjsify/cli build src/index.ts --outfile dist/index.js
+    # (--globals auto is the default — no flag needed)
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bunx @gjsify/cli build src/index.ts --outfile dist/index.js
+    # (--globals auto is the default — no flag needed)
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno run -A npm:@gjsify/cli build src/index.ts --outfile dist/index.js
+    # (--globals auto is the default — no flag needed)
+    ```
+  </Fragment>
+</CommandTabs>
 
 ### How auto detection works
 
@@ -122,7 +146,7 @@ Scaffolded projects rely on the default `auto` mode and don't pass `--globals` a
 }
 ```
 
-`yarn install && yarn build` is enough — no global lists to maintain, no `ReferenceError`s to chase down.
+`gjsify install && gjsify run build` is enough — no global lists to maintain, no `ReferenceError`s to chase down.
 
 ### Troubleshooting: `ReferenceError: X is not defined`
 
@@ -140,16 +164,57 @@ Some GJSify packages need native code. For example, `@gjsify/webgl` ships a Vala
 
 `gjsify run` scans your `node_modules` for these packages, prepends the right directories to `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH`, and then spawns `gjs -m <bundle>`:
 
-```bash
-npx @gjsify/cli run dist/index.js
-```
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify run dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npx @gjsify/cli run dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bunx @gjsify/cli run dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno run -A npm:@gjsify/cli run dist/index.js
+    ```
+  </Fragment>
+</CommandTabs>
 
 If you want to run `gjs` directly (for example from a systemd unit or a packaged Flatpak), you can ask the CLI to print the environment for you:
 
-```bash
-eval $(npx @gjsify/cli info --export)
-gjs -m dist/index.js
-```
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    eval $(gjsify info --export)
+    gjs -m dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    eval $(npx @gjsify/cli info --export)
+    gjs -m dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    eval $(bunx @gjsify/cli info --export)
+    gjs -m dist/index.js
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    eval $(deno run -A npm:@gjsify/cli info --export)
+    gjs -m dist/index.js
+    ```
+  </Fragment>
+</CommandTabs>
 
 Use `gjsify info` without `--export` for a human-readable report of every detected native package and the exact env vars needed.
 
@@ -159,7 +224,7 @@ Node.js servers (`http.Server.listen()`, `net.Server.listen()`, `dgram.Socket.bi
 
 ## Vite-plugin track (browser / web-content targets)
 
-gjsify's build plugins are Rollup-shaped, which means they run under both Rolldown (via the `gjsify build` CLI) and Vite (for HMR-enabled dev servers). For web-content targets — browser extensions, GJS-WebKit hybrid apps, or games running in a WebView — you can use Vite during development for fast module reloads, then switch to `gjsify build --app browser` for the production bundle.
+GJSify's build plugins are Rollup-shaped, which means they run under both Rolldown (via the `gjsify build` CLI) and Vite (for HMR-enabled dev servers). For web-content targets — browser extensions, GJS-WebKit hybrid apps, or games running in a WebView — you can use Vite during development for fast module reloads, then switch to `gjsify build --app browser` for the production bundle.
 
 Two plugins that always work under Vite are already published:
 
@@ -172,7 +237,7 @@ The same plugins are composed by `gjsify build` under the hood — there is no d
 
 ## Location-independent published bundles
 
-GJS bundles built with gjsify resolve their bundled dependencies' data files at runtime from the bundle's actual on-disk location. A dep that loads its own `package.json`, i18n files, or templates via `import.meta.url` continues to work after the bundle is installed globally — even if the bundle ends up at a different `node_modules` depth than where it was built. This is handled transparently by `@gjsify/module`'s PnP-aware `createRequire`; no special configuration is required.
+GJS bundles built with GJSify resolve their bundled dependencies' data files at runtime from the bundle's actual on-disk location. A dep that loads its own `package.json`, i18n files, or templates via `import.meta.url` continues to work after the bundle is installed globally — even if the bundle ends up at a different `node_modules` depth than where it was built. This is handled transparently by `@gjsify/module`'s PnP-aware `createRequire`; no special configuration is required.
 
 ## Where to go next
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -10,7 +10,7 @@ import QuickStartCta from '../../components/QuickStartCta.astro';
 
 {/* The home page stays deliberately minimal: the hero + showcase slideshow
     (rendered by the custom Hero override) already tell the story, followed by a
-    single "get started" call-to-action. The deeper material — what makes gjsify
+    single "get started" call-to-action. The deeper material — what makes GJSify
     different, the coverage dashboards, the bridge widgets — lives in the
     documentation subpages (Overview, Coverage, Patterns/Bridges). */}
 

--- a/website/src/content/docs/overview.mdx
+++ b/website/src/content/docs/overview.mdx
@@ -1,26 +1,26 @@
 ---
 title: Overview
-description: What gjsify is — a TypeScript framework for native Linux apps that unifies GNOME, Node.js and the Web across runtimes.
+description: What GJSify is — a TypeScript framework for native Linux apps that unifies GNOME, Node.js and the Web across runtimes.
 ---
 
 import ThreeWorldsFusion from '../../components/ThreeWorldsFusion.astro';
 
-**gjsify is a TypeScript framework for native Linux apps.** You build
+**GJSify is a TypeScript framework for native Linux apps.** You build
 GTK 4 / Adwaita applications, games and CLI tools against the APIs you already
-know — Node.js modules, Web standards, the DOM — and gjsify maps them onto the
+know — Node.js modules, Web standards, the DOM — and GJSify maps them onto the
 GNOME platform.
 
 The runtime is a build-time decision, not an architecture decision:
 
-- On **GJS**, GNOME's JavaScript runtime, gjsify implements the Node.js and
+- On **GJS**, GNOME's JavaScript runtime, GJSify implements the Node.js and
   Web APIs on top of Gio, libsoup, Cairo and friends.
-- On **Node.js, Bun and Deno**, gjsify implements the GJS side — `gi://`
+- On **Node.js, Bun and Deno**, GJSify implements the GJS side — `gi://`
   imports and the GObject type system — through the
   [node-gi](/gjsify/projects/node-gi/) reverse bridge.
 - In the **browser**, the same source runs as a web app, with the Adwaita
   design system [carried over as Web Components](/gjsify/packages/web/).
 
-This also makes gjsify a bridge between the web and the native desktop in both
+This also makes GJSify a bridge between the web and the native desktop in both
 directions: web code runs inside native GTK windows, and the native look and
 feel travels to the web. See [Runtimes](/gjsify/runtimes/) for the full
 picture of what runs where.

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -4,6 +4,7 @@ description: Summary of all GJSify packages
 ---
 
 import BridgesGrid from '../../../components/BridgesGrid.astro';
+import CommandTabs from '../../../components/CommandTabs.astro';
 
 GJSify is organised into pillars, each implementing standard APIs on top of native GNOME libraries — plus a framework layer that glues them to GTK.
 
@@ -24,10 +25,27 @@ GJSify is organised into pillars, each implementing standard APIs on top of nati
 
 All packages are published to npm under the `@gjsify` scope:
 
-```bash
-npm install @gjsify/fs @gjsify/http @gjsify/fetch
-# or, in a Node-free gjsify project:
-gjsify install @gjsify/fs @gjsify/http @gjsify/fetch
-```
+<CommandTabs>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/fs @gjsify/http @gjsify/fetch
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm install @gjsify/fs @gjsify/http @gjsify/fetch
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun add @gjsify/fs @gjsify/http @gjsify/fetch
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno add npm:@gjsify/fs npm:@gjsify/http npm:@gjsify/fetch
+    ```
+  </Fragment>
+</CommandTabs>
 
 In most cases, you don't install packages directly — `gjsify build` automatically aliases Node.js and Web API imports to the right implementation for the chosen [target](/gjsify/runtimes/): `@gjsify/*` polyfills on GJS, the native platform on Node.js and in the browser.

--- a/website/src/content/docs/packages/web.mdx
+++ b/website/src/content/docs/packages/web.mdx
@@ -48,7 +48,7 @@ import WebStandardsCoverage from '../../../components/WebStandardsCoverage.astro
 
 ## Usage
 
-Web APIs are available as bare specifiers in gjsify builds — on GJS they resolve to these GNOME-backed implementations, in the browser the native platform takes over, and 12 of these packages are additionally validated against real Firefox via Playwright (see [Runtimes](/gjsify/runtimes/)). The build handles the aliasing automatically:
+Web APIs are available as bare specifiers in GJSify builds — on GJS they resolve to these GNOME-backed implementations, in the browser the native platform takes over, and 12 of these packages are additionally validated against real Firefox via Playwright (see [Runtimes](/gjsify/runtimes/)). The build handles the aliasing automatically:
 
 ```typescript
 // This works in GJS — Soup.Session under the hood

--- a/website/src/content/docs/projects/node-gi.md
+++ b/website/src/content/docs/projects/node-gi.md
@@ -3,7 +3,7 @@ title: node-gi
 description: Run unchanged GJS / GObject-Introspection code on Node.js, Bun and Deno — the reverse bridge. One source builds and runs on GJS and every Node-API runtime.
 ---
 
-[`@gjsify/node-gi`](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi) is the **reverse** of the rest of gjsify: instead of bringing Node/Web APIs to GJS, it brings **GObject-Introspection to Node.js, Bun and Deno**. The same unchanged `gi://` source builds and runs natively under GJS *and* on every Node-API runtime — no code changes.
+[`@gjsify/node-gi`](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi) is the **reverse** of the rest of GJSify: instead of bringing Node/Web APIs to GJS, it brings **GObject-Introspection to Node.js, Bun and Deno**. The same unchanged `gi://` source builds and runs natively under GJS *and* on every Node-API runtime — no code changes.
 
 :::note[Product — Tier 2]
 node-gi **graduated to Tier 2** on 2026-07-14 ([ADR 0005](https://github.com/gjsify/gjsify/blob/main/docs/adr/0005-node-gi-scope.md)) once its four gate items landed: the toggle-ref/multi-env teardown crash fixed, vfunc OUT/INOUT chain-up, the GTK/Cairo layer, and a second real consumer (`@gjsify/sqlite`'s test suite runs on node-gi). Tier 2 is **best-effort**: tested and released on the train, but breaking changes may ship with a minor + a changelog note. One invariant is kept from Tier 3: no Tier-1/2 `@gjsify/*` package may take a **hard** dependency on `@gjsify/node-gi` — the sanctioned seams stay a `devDependency` and the conditional `--app node` build injection (the reverse bridge would otherwise double the runtime test matrix).
@@ -70,6 +70,6 @@ Requires a C++ toolchain plus the GLib ≥ 2.80 / `girepository-2.0` development
 
 ## See also
 
-- [Runtimes](/gjsify/runtimes/) — how the reverse bridge fits gjsify's overall target picture
+- [Runtimes](/gjsify/runtimes/) — how the reverse bridge fits GJSify's overall target picture
 - [Versioning](/gjsify/versioning/#package-tiers) — what the Tier-2 contract means
 - [Storybook](/gjsify/guides/storybook/) — `gjsify storybook --runtime node`, the canonical consumer

--- a/website/src/content/docs/projects/ts-for-gir.md
+++ b/website/src/content/docs/projects/ts-for-gir.md
@@ -3,14 +3,14 @@ title: ts-for-gir
 description: TypeScript type definition generator for GObject Introspection — strong typing, IDE jump-to-definition, autocompletion across the whole GNOME stack.
 ---
 
-[ts-for-gir](https://github.com/gjsify/ts-for-gir) is the TypeScript type-definition generator that powers IDE autocomplete + type-checking for every gjsify project (and many non-gjsify GJS projects). It reads GObject Introspection (`.gir` XML) files and emits `.d.ts` declarations covering GLib, GIO, GTK, GStreamer, libadwaita, WebKit, and ~700 other GNOME-stack modules.
+[ts-for-gir](https://github.com/gjsify/ts-for-gir) is the TypeScript type-definition generator that powers IDE autocomplete + type-checking for every GJSify project (and many non-gjsify GJS projects). It reads GObject Introspection (`.gir` XML) files and emits `.d.ts` declarations covering GLib, GIO, GTK, GStreamer, libadwaita, WebKit, and ~700 other GNOME-stack modules.
 
 ## What you get
 
 - **Compile-time type safety** for every `import Gtk from 'gi://Gtk?version=4.0'`.
 - **IDE jump-to-definition** into `@girs/*` declarations: hover a `Gtk.Button` to see its constructor, methods, signals.
 - **Pre-generated npm packages** at [gjsify/types](https://github.com/gjsify/types) — `npm i @girs/gtk-4.0` instead of running the generator yourself.
-- **First-class gjsify integration**: the [`types-gjsify`](https://github.com/gjsify/ts-for-gir/tree/main/templates/types-gjsify) starter template wires `ts-for-gir generate` into `gjsify install`, `gjsify build`, and `gjsify run` so a fresh project compiles in seconds.
+- **First-class GJSify integration**: the [`types-gjsify`](https://github.com/gjsify/ts-for-gir/tree/main/templates/types-gjsify) starter template wires `ts-for-gir generate` into `gjsify install`, `gjsify build`, and `gjsify run` so a fresh project compiles in seconds.
 
 ## Install
 
@@ -29,7 +29,7 @@ gjsify dlx @ts-for-gir/cli generate Gtk-4.0
 
 `gjsify dlx` fetches the package into a content-addressed cache (`~/.cache/gjsify/dlx`), runs its GJS bundle, and reuses the cache on subsequent invocations of the same spec. Pass `--cache-max-age 0` to force a refresh.
 
-**Global install via the gjsify CLI:**
+**Global install via the GJSify CLI:**
 
 ```bash
 gjsify install -g @ts-for-gir/cli
@@ -67,7 +67,7 @@ npx @ts-for-gir/cli create my-app
 
 | Template | Best for |
 |---|---|
-| `types-gjsify` | Node-free GJS app — all dev scripts (install, build, run, format) routed through gjsify |
+| `types-gjsify` | Node-free GJS app — all dev scripts (install, build, run, format) routed through GJSify |
 | `types-npm` | Single-package, types from `@girs/*` npm, esbuild + node |
 | `types-locally` | Generate types into `./@types/` (no `@girs/*` dep) |
 | `types-workspace` | npm workspace with `@girs/*` as locally-generated workspace packages |
@@ -122,11 +122,11 @@ The [Patterns](../../patterns/) section of this site documents the idioms that s
 - [**GObject classes**](../../patterns/gobject-classes/) — `GObject.registerClass()` forms, the static-block pattern, init-order rules behind [GNOME/gjs#704](https://gitlab.gnome.org/GNOME/gjs/-/work_items/704), and the `static override $gtype: GObject.GType<Foo>` declaration that narrows the statically-inherited `$gtype` from the base class.
 - [**Bridge widgets**](../../patterns/bridges/) — how `Canvas2DBridge` / `WebGLBridge` / `IFrameBridge` / `VideoBridge` pair a polyfill DOM element with a real GTK widget so browser-shaped code drives the GTK surface directly.
 
-## gjsify dogfoods its own bundler
+## GJSify dogfoods its own bundler
 
-`@ts-for-gir/cli` is built with `gjsify build --app node` — a real-world Node CLI that bundles the TypeScript compiler, TypeDoc, shiki, yargs, ejs, and ~100 transitive npm dependencies into a single executable with `--shebang` (emitting `#!/usr/bin/env node`). This makes ts-for-gir a concrete proof point that gjsify can bundle and distribute production-grade Node.js CLIs:
+`@ts-for-gir/cli` is built with `gjsify build --app node` — a real-world Node CLI that bundles the TypeScript compiler, TypeDoc, shiki, yargs, ejs, and ~100 transitive npm dependencies into a single executable with `--shebang` (emitting `#!/usr/bin/env node`). This makes ts-for-gir a concrete proof point that GJSify can bundle and distribute production-grade Node.js CLIs:
 
-- Bundled deps that read their own data files at runtime (`typedoc` loading its theme assets, ejs loading templates) work correctly after install at any `node_modules` depth, because gjsify resolves those paths from the bundle's actual runtime location rather than a path baked at build time.
+- Bundled deps that read their own data files at runtime (`typedoc` loading its theme assets, ejs loading templates) work correctly after install at any `node_modules` depth, because GJSify resolves those paths from the bundle's actual runtime location rather than a path baked at build time.
 - Yarn PnP-resident zip packages (the ~100 Yarn-cached deps) are resolved transparently by `@gjsify/module`'s PnP-aware `createRequire`.
 - The produced Node bundle is directly executable (`chmod +x`) and published to npm — no separate build wrapper script needed.
 

--- a/website/src/content/docs/runtimes.md
+++ b/website/src/content/docs/runtimes.md
@@ -1,14 +1,14 @@
 ---
 title: Runtimes
-description: One TypeScript codebase on GJS, Node.js, Deno and Bun — how gjsify makes the runtime a build-time decision.
+description: One TypeScript codebase on GJS, Node.js, Deno and Bun — how GJSify makes the runtime a build-time decision.
 ---
 
-gjsify started as "Node.js & Web APIs on GJS". Today the bridge runs in **both
-directions**, and the runtime has become a build-time decision:
+GJSify's bridge runs in **both directions**, so the runtime is a build-time
+decision, not an architecture decision:
 
-- **On GJS**, gjsify implements the Node.js and Web APIs on top of the GNOME
+- **On GJS**, GJSify implements the Node.js and Web APIs on top of the GNOME
   platform — `node:fs` is backed by Gio, `fetch` by libsoup, Canvas by Cairo.
-- **On Node.js, Bun and Deno**, gjsify implements the GJS side: `gi://` imports,
+- **On Node.js, Bun and Deno**, GJSify implements the GJS side: `gi://` imports,
   GObject classes, signals and the GLib main loop, through the
   [`@gjsify/node-gi`](/gjsify/projects/node-gi/) native bridge.
 
@@ -20,7 +20,7 @@ for `gjs`, `node` and `browser`.
 
 ### Node.js & Web APIs on GJS — `--app gjs`
 
-The classic direction and still the primary target. The build rewrites
+The primary target. The build rewrites
 `node:*` imports and Web globals to their `@gjsify/*` implementations, each
 backed by a GNOME library. Your app runs as a single native process — GTK 4
 widgets, Adwaita styling, and the npm ecosystem in one SpiderMonkey runtime.

--- a/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
+++ b/website/src/content/docs/showcases/excalibur-jelly-jumper.mdx
@@ -47,7 +47,7 @@ The asset loader fetches tilemaps + spritesheets from `@gjsify/example-dom-excal
 
 ## Why this showcase is load-bearing
 
-Excalibur is the canonical real-world consumer of the full WebGL + Canvas + WebAudio + XHR + DOMParser stack. Every time we promote a `@gjsify/*` package from Partial → Full, this showcase is one of the first regression checks — if Excalibur's "FillContainer" mode reflows correctly, if its asset loader resolves binary blobs without truncation, if its WebAudio mixer plays a multi-channel sound effect without artifacts, then the gjsify port of the underlying API is genuinely production-grade.
+Excalibur is the canonical real-world consumer of the full WebGL + Canvas + WebAudio + XHR + DOMParser stack. Every time we promote a `@gjsify/*` package from Partial → Full, this showcase is one of the first regression checks — if Excalibur's "FillContainer" mode reflows correctly, if its asset loader resolves binary blobs without truncation, if its WebAudio mixer plays a multi-channel sound effect without artifacts, then the GJSify port of the underlying API is genuinely production-grade.
 
 ## Related
 

--- a/website/src/content/docs/showcases/express-webserver.mdx
+++ b/website/src/content/docs/showcases/express-webserver.mdx
@@ -3,7 +3,7 @@ title: "Express Web Server"
 description: Unmodified Express 5 running on GJS through @gjsify/http — proves the http.Server / IncomingMessage / ServerResponse surface holds for the most-deployed Node web framework.
 ---
 
-A small Express 5 blog app — JSON API (`/api/posts`, `/api/posts/:slug`, `/api/runtime`), server-rendered article pages, and a static HTML/CSS/JS frontend — running on GJS through [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http). Express imports unmodified from npm; gjsify's Node compat layer serves every `http.Server` / `IncomingMessage` / `ServerResponse` API call Express reaches for.
+A small Express 5 blog app — JSON API (`/api/posts`, `/api/posts/:slug`, `/api/runtime`), server-rendered article pages, and a static HTML/CSS/JS frontend — running on GJS through [`@gjsify/http`](https://github.com/gjsify/gjsify/tree/main/packages/node/http). Express imports unmodified from npm; GJSify's Node compat layer serves every `http.Server` / `IncomingMessage` / `ServerResponse` API call Express reaches for.
 
 ## What it exercises
 
@@ -53,7 +53,7 @@ The package ships both `start` (GJS) and `start:node` scripts; same `src/index.t
 
 ## Why Express specifically
 
-Express is the most-deployed Node web framework on the planet. If gjsify's `http` package can carry Express 5 unmodified — including middleware composition, error handling, route matching — then arbitrary npm web apps targeting Node tend to "just work" on GJS too. This showcase is the canary.
+Express is the most-deployed Node web framework on the planet. If GJSify's `http` package can carry Express 5 unmodified — including middleware composition, error handling, route matching — then arbitrary npm web apps targeting Node tend to "just work" on GJS too. This showcase is the canary.
 
 Integration coverage for the broader npm web ecosystem (Socket.IO, axios, WebTorrent, …) lives under [`tests/integration/`](https://github.com/gjsify/gjsify/tree/main/tests/integration) — they all dovetail with the same `@gjsify/http` + `@gjsify/stream` surface.
 

--- a/website/src/content/docs/showcases/index.mdx
+++ b/website/src/content/docs/showcases/index.mdx
@@ -8,7 +8,7 @@ The **showcases** are end-to-end runnable applications that double as proof of t
 - **In a GTK4 window** via `gjsify showcase <name>` — Cairo / WebGL / WebKit / GStreamer backing the standard DOM APIs the showcase code reaches for.
 - **In a regular browser** via `import { mount } from '@gjsify/example-dom-<name>/browser'` — same module, native browser implementations.
 
-If something runs on GJS through gjsify, it also runs in the browser unmodified (and vice versa). That cross-platform contract is the point.
+If something runs on GJS through GJSify, it also runs in the browser unmodified (and vice versa). That cross-platform contract is the point.
 
 ## Browse the catalog
 
@@ -44,7 +44,7 @@ const container = document.getElementById('app')!;
 mount(container);
 ```
 
-The website's `<ShowcaseEmbed>` component handles the loading and lifecycle for the live demos linked above. Source for each showcase lives under [`showcases/`](https://github.com/gjsify/gjsify/tree/main/showcases) in the gjsify repo — see the per-showcase pages for the deep dive on how each one exercises the pillar set.
+The website's `<ShowcaseEmbed>` component handles the loading and lifecycle for the live demos linked above. Source for each showcase lives under [`showcases/`](https://github.com/gjsify/gjsify/tree/main/showcases) in the GJSify repo — see the per-showcase pages for the deep dive on how each one exercises the pillar set.
 
 ## Why two targets matter
 


### PR DESCRIPTION
Follow-up to #748, addressing review feedback.

## CommandTabs — one block, every toolchain

New `CommandTabs.astro` component built on **our own `<adw-inline-view-switcher>`** from `@gjsify/adwaita-web` (the website resolves it from workspace source, so it always uses the latest in-repo implementation — no version bump needed). Each command appears once, with **GJSify / npm / Bun / Deno** tabs rendered as a native-looking Adwaita toggle group. Fenced code blocks stay ordinary Expressive Code (highlighting + copy button preserved). The selected runtime is stored in `localStorage` and synchronized across every instance and page — pick Deno once, all blocks follow.

Applied on:
- **getting-started** — quick start (previously two separate blocks), system-check, build & run (`getting-started.md` → `.mdx`, slug unchanged)
- **how-it-works** — the build / run / `info --export` invocations (→ `.mdx`)
- **packages/overview** — the install snippet

Drive-by fix: getting-started still recommended `npx @gjsify/cli check` as the dependency check — `check` is the tsc orchestrator now; corrected to `system-check`.

## Layout: Three worlds, one runtime

The 5-track row (3 pillars + arrow + output) read cramped — `worker_threads` broke mid-word. Now: three pillars side by side → downward arrow → the GJSify card **full-width** below. Code chips are `nowrap`, and the grid adapts via a **container query** to the actual content column (Starlight caps it at 45rem, so a viewport-based breakpoint was the wrong signal).

## Wording

- **Runtimes page** no longer opens with the historical "GJSify started as…" — current state only.
- Brand spelling normalized to **GJSify** in all prose (the GJS in the name is the runtime and stays uppercase); commands, `@gjsify/*` package names, URLs and file paths stay lowercase.

## Verification

- `astro build` green (39 pages)
- Playwright against `astro preview`: tabs render as Adwaita toggle group, clicking **Deno** switches all instances on the page, the choice persists across navigation (verified on how-it-works); fusion section verified at 1600px (3 columns) and 880px (stacked).