### PR TITLE
feat(adwaita-web): TabBar-integrated command tabs

### DIFF
--- a/packages/web/adwaita-web/scss/_tab_view.scss
+++ b/packages/web/adwaita-web/scss/_tab_view.scss
@@ -154,6 +154,25 @@ adw-tab-view {
     }
   }
 
+  // Adw.TabBar `expand-tabs` — tabs stretch to fill the bar evenly.
+  &[expand-tabs] {
+    .adw-tab-box {
+      flex: 1 1 auto;
+    }
+
+    .adw-tab {
+      flex: 1 1 0;
+      max-width: none;
+      justify-content: center;
+    }
+  }
+
+  // Web-specific escape hatch: static tab sets (e.g. documentation command
+  // tabs) render no close affordance.
+  &[no-close] .adw-tab-close {
+    display: none;
+  }
+
   // Single-tab bars dim the close affordance (libadwaita keeps a lone tab
   // non-interactive-looking).
   .adw-tab-bar.single-tab .adw-tab {

--- a/packages/web/adwaita-web/src/adw-tab-view.spec.ts
+++ b/packages/web/adwaita-web/src/adw-tab-view.spec.ts
@@ -1,0 +1,98 @@
+// DOM-level behaviour tests for <adw-tab-view>. Runs in a real browser via the
+// @gjsify/adwaita-web browser test axis (the entry self-applies the compiled
+// stylesheet, so computed-style assertions are valid). Asserts page building,
+// selected↔click sync, notify/close events, and the expand-tabs / no-close
+// attributes.
+import { describe, expect, it } from '@gjsify/unit';
+
+import type { AdwTabView } from './elements/adw-tab-view.js';
+
+function makeTabView(attrs = ''): AdwTabView {
+    const host = document.createElement('div');
+    host.innerHTML = `<adw-tab-view ${attrs}>
+        <adw-tab-page title="One"><p>first</p></adw-tab-page>
+        <adw-tab-page title="Two"><p>second</p></adw-tab-page>
+        <adw-tab-page title="Three"><p>third</p></adw-tab-page>
+    </adw-tab-view>`;
+    document.body.appendChild(host);
+    return host.querySelector('adw-tab-view') as AdwTabView;
+}
+
+export const AdwTabViewTest = async () => {
+    await describe('adw-tab-view pages', async () => {
+        await it('builds one tab per page and shows the first page', async () => {
+            const view = makeTabView();
+            expect(view.querySelectorAll('.adw-tab').length).toBe(3);
+            expect(view.selected).toBe(0);
+            const pages = view.querySelectorAll('.adw-tab-page');
+            expect((pages[0] as HTMLElement).hidden).toBe(false);
+            expect((pages[1] as HTMLElement).hidden).toBe(true);
+            view.parentElement?.remove();
+        });
+
+        await it('clicking a tab selects its page and notifies', async () => {
+            const view = makeTabView();
+            let notified = -1;
+            view.addEventListener('notify::selected-page', (event) => {
+                notified = (event as CustomEvent).detail.selected;
+            });
+            (view.querySelectorAll('.adw-tab')[2] as HTMLButtonElement).click();
+            expect(view.selected).toBe(2);
+            expect(notified).toBe(2);
+            expect((view.querySelectorAll('.adw-tab-page')[2] as HTMLElement).hidden).toBe(false);
+            view.parentElement?.remove();
+        });
+
+        await it('setting the selected attribute switches pages', async () => {
+            const view = makeTabView();
+            view.setAttribute('selected', '1');
+            expect((view.querySelectorAll('.adw-tab-page')[1] as HTMLElement).hidden).toBe(false);
+            expect((view.querySelectorAll('.adw-tab-page')[0] as HTMLElement).hidden).toBe(true);
+            view.parentElement?.remove();
+        });
+
+        await it('emits close-page from the close affordance', async () => {
+            const view = makeTabView();
+            let closed = -1;
+            view.addEventListener('close-page', (event) => {
+                closed = (event as CustomEvent).detail.index;
+            });
+            (view.querySelectorAll('.adw-tab-close')[1] as HTMLButtonElement).click();
+            expect(closed).toBe(1);
+            // Closing must not also select the tab.
+            expect(view.selected).toBe(0);
+            view.parentElement?.remove();
+        });
+    });
+
+    await describe('adw-tab-view expand-tabs / no-close', async () => {
+        await it('no-close hides every close affordance', async () => {
+            const view = makeTabView('no-close');
+            expect(view.noClose).toBe(true);
+            for (const close of view.querySelectorAll('.adw-tab-close')) {
+                expect(getComputedStyle(close).display).toBe('none');
+            }
+            view.parentElement?.remove();
+        });
+
+        await it('expand-tabs stretches tabs evenly across the bar', async () => {
+            const view = makeTabView('expand-tabs');
+            expect(view.expandTabs).toBe(true);
+            for (const tab of view.querySelectorAll('.adw-tab')) {
+                expect(getComputedStyle(tab).flexGrow).toBe('1');
+            }
+            view.parentElement?.remove();
+        });
+
+        await it('properties reflect to attributes', async () => {
+            const view = makeTabView();
+            view.noClose = true;
+            view.expandTabs = true;
+            expect(view.hasAttribute('no-close')).toBe(true);
+            expect(view.hasAttribute('expand-tabs')).toBe(true);
+            view.noClose = false;
+            expect(view.hasAttribute('no-close')).toBe(false);
+            view.parentElement?.remove();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -9,6 +9,10 @@
 //   selected (zero-based index of the visible page, default 0)
 //   autohide (boolean — hide the tab bar when only one page remains, mirroring
 //     the Adw.TabBar `autohide` property)
+//   expand-tabs (boolean — tabs stretch to fill the bar evenly, mirroring the
+//     Adw.TabBar `expand-tabs` property)
+//   no-close (boolean — render no close affordance; web-specific escape hatch
+//     for static tab sets such as documentation command tabs)
 // Events:
 //   `notify::selected-page` (CustomEvent, bubbles, `detail = { selected }`) when
 //     the visible page changes — mirrors the Adw.TabView `selected-page` property.
@@ -37,7 +41,7 @@ export class AdwTabView extends HTMLElement {
     private _initialized = false;
 
     static get observedAttributes() {
-        return ['selected', 'autohide'];
+        return ['selected', 'autohide', 'expand-tabs', 'no-close'];
     }
 
     /** Zero-based index of the visible page. */
@@ -57,6 +61,26 @@ export class AdwTabView extends HTMLElement {
     set autohide(value: boolean) {
         if (value) this.setAttribute('autohide', '');
         else this.removeAttribute('autohide');
+    }
+
+    /** Whether tabs stretch to fill the bar evenly (Adw.TabBar `expand-tabs`). */
+    get expandTabs(): boolean {
+        return this.hasAttribute('expand-tabs');
+    }
+
+    set expandTabs(value: boolean) {
+        if (value) this.setAttribute('expand-tabs', '');
+        else this.removeAttribute('expand-tabs');
+    }
+
+    /** Whether the close affordance is omitted (static tab sets). */
+    get noClose(): boolean {
+        return this.hasAttribute('no-close');
+    }
+
+    set noClose(value: boolean) {
+        if (value) this.setAttribute('no-close', '');
+        else this.removeAttribute('no-close');
     }
 
     connectedCallback() {

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -10,5 +10,6 @@ import '@gjsify/adwaita-web';
 import { AdwDataGridTest } from './adw-data-grid.spec.js';
 import { AdwDialogTest } from './adw-dialog.spec.js';
 import { AdwDropDownTest } from './adw-drop-down.spec.js';
+import { AdwTabViewTest } from './adw-tab-view.spec.js';
 
-run({ AdwDataGridTest, AdwDialogTest, AdwDropDownTest });
+run({ AdwDataGridTest, AdwDialogTest, AdwDropDownTest, AdwTabViewTest });

--- a/website/src/components/CommandTabs.astro
+++ b/website/src/components/CommandTabs.astro
@@ -1,10 +1,12 @@
 ---
-// CommandTabs — one command block, one tab per way of invoking the toolchain
-// (GJSify's own Node-free CLI, npm, Bun, Deno). Built on our own
-// <adw-inline-view-switcher> from @gjsify/adwaita-web, so the tabs look and
-// behave like a native Adwaita toggle group. The tab contents are ordinary
-// fenced code blocks passed via named slots, so Expressive Code keeps its
-// syntax highlighting and copy button.
+// CommandTabs — one command window, one tab per way of invoking the toolchain
+// (GJSify's own Node-free CLI, npm, Bun, Deno). Built on <adw-tab-view> from
+// @gjsify/adwaita-web (the Adw.TabView/TabBar counterpart), so the tabs sit in
+// the window chrome exactly the way the Adwaita design system draws them —
+// with `expand-tabs` + `no-close` for a static tab set. Each page holds an
+// ordinary fenced code block: Expressive Code keeps its syntax highlighting,
+// and the per-block Adwaita window frame is flattened so the tab view is the
+// one window (the copy button floats over the code, EC-style).
 //
 // The selected runtime is remembered (localStorage) and synchronized across
 // every CommandTabs instance on the site: pick "Deno" once and all command
@@ -34,9 +36,9 @@ for (const r of RUNTIMES) {
 const runtimesAttr = present.map((r) => r.slot).join(',');
 ---
 
-<adw-inline-view-switcher class="command-tabs" display-mode="labels" round data-command-tabs data-runtimes={runtimesAttr}>
-    {present.map((r) => <adw-view-stack-page title={r.label} set:html={r.html} />)}
-</adw-inline-view-switcher>
+<adw-tab-view class="command-tabs" no-close expand-tabs data-command-tabs data-runtimes={runtimesAttr}>
+    {present.map((r) => <adw-tab-page title={r.label} set:html={r.html} />)}
+</adw-tab-view>
 
 <script>
     import '@gjsify/adwaita-web';
@@ -49,16 +51,16 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
             if (el === skip) continue;
             const runtimes = (el.dataset.runtimes ?? '').split(',');
             const index = runtimes.indexOf(runtime);
-            if (index >= 0) el.setAttribute('active', String(index));
+            if (index >= 0) el.setAttribute('selected', String(index));
         }
     };
 
     // Follow user selection: persist + mirror to every other instance.
-    document.addEventListener('notify::active', (event) => {
+    document.addEventListener('notify::selected-page', (event) => {
         const target = event.target as HTMLElement;
         if (!target?.matches?.('[data-command-tabs]')) return;
         const runtimes = (target.dataset.runtimes ?? '').split(',');
-        const runtime = runtimes[(event as CustomEvent).detail?.active ?? 0];
+        const runtime = runtimes[(event as CustomEvent).detail?.selected ?? 0];
         if (!runtime) return;
         try {
             localStorage.setItem(KEY, runtime);
@@ -69,7 +71,7 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
     });
 
     // Initial: restore the remembered runtime once the element is defined.
-    customElements.whenDefined('adw-inline-view-switcher').then(() => {
+    customElements.whenDefined('adw-tab-view').then(() => {
         try {
             applyPreference(localStorage.getItem(KEY));
         } catch {
@@ -81,25 +83,90 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 <style is:global>
     /* Before the custom element hydrates, show only the first page so the
        server-rendered HTML doesn't stack every tab's code block. */
-    adw-inline-view-switcher.command-tabs:not(:defined) > adw-view-stack-page {
+    adw-tab-view.command-tabs:not(:defined) > adw-tab-page {
         display: none;
     }
-    adw-inline-view-switcher.command-tabs:not(:defined) > adw-view-stack-page:first-of-type {
+    adw-tab-view.command-tabs:not(:defined) > adw-tab-page:first-of-type {
         display: block;
     }
 
+    /* The tab view is the window — same chrome as the EC adw-code-window it
+       replaces (radius + shadow mirror .quick-start-window / custom.css). */
     .command-tabs {
-        display: block;
         margin-top: 1rem;
+        border-radius: 12px;
+        box-shadow:
+            0 0 14px 5px rgb(0 0 0 / 15%),
+            0 0 5px 2px rgb(0 0 0 / 10%),
+            0 0 0 1px rgb(0 0 0 / 5%);
+        outline: 1px solid rgb(255 255 255 / 7%);
+        outline-offset: -1px;
     }
 
-    .command-tabs .adw-inline-view-switcher-group {
-        margin-bottom: 0.75rem;
+    :root:not([data-theme='dark']) .command-tabs {
+        outline-color: rgb(0 0 6 / 8%);
     }
 
-    /* The page panel holds a regular Expressive Code block — let it keep its
-       own margins collapsed against the switcher bar. */
-    .command-tabs .adw-inline-view-switcher-page > :first-child {
-        margin-top: 0;
+    /* The adwaita-web skin keys on prefers-color-scheme; the site theme keys
+       on Starlight's data-theme. Re-map the tab-view's skin variables to the
+       site's theme-aware --adw-* tokens so the bar follows the theme toggle.
+       --view-bg-color is the surface the active tab is raised onto — the code
+       background (#fff light / #222226 dark, see custom.css --code-background). */
+    .command-tabs {
+        --headerbar-bg-color: var(--adw-headerbar-bg);
+        --headerbar-fg-color: var(--adw-window-fg);
+        --headerbar-shade-color: var(--adw-headerbar-shade);
+        --view-bg-color: var(--adw-view-bg);
+        --view-fg-color: var(--adw-window-fg);
+        --window-bg-color: var(--adw-view-bg);
+        --button-hover-color: rgba(128, 128, 128, 0.12);
+        --button-active-color: rgba(128, 128, 128, 0.22);
+        --button-radius: var(--adw-button-radius);
+    }
+
+    :root[data-theme='dark'] .command-tabs {
+        --view-bg-color: var(--adw-window-bg);
+        --window-bg-color: var(--adw-window-bg);
+    }
+
+    /* Flatten the per-block Adwaita EC window inside the pages — the tab view
+       provides the one window frame. */
+    .command-tabs .expressive-code {
+        margin: 0;
+    }
+
+    .command-tabs .expressive-code .frame.adw-code-window {
+        position: relative;
+        border-radius: 0;
+        box-shadow: none;
+        outline: none;
+    }
+
+    .command-tabs .expressive-code .frame.adw-code-window pre {
+        border: none;
+        border-radius: 0;
+        margin: 0;
+    }
+
+    /* Collapse the block's own headerbar: no second chrome row under the tab
+       bar — the copy button floats over the code's top-right corner instead.
+       !important mirrors custom.css's own !important on these rules. */
+    .command-tabs .expressive-code .frame .adw-code-headerbar {
+        display: contents !important;
+    }
+
+    .command-tabs .expressive-code .frame .adw-code-headerbar-start,
+    .command-tabs .expressive-code .frame .adw-code-headerbar-title {
+        display: none !important;
+    }
+
+    .command-tabs .expressive-code .frame .adw-code-headerbar-end {
+        position: absolute !important;
+        inset: 6px 6px auto auto !important;
+        z-index: 5;
+        /* Long code lines run under the floating button — back it with the
+           code surface so the icon stays legible. */
+        background: var(--code-background);
+        border-radius: 9px;
     }
 </style>


### PR DESCRIPTION
Follow-up to #750: the runtime tabs move **into the code window's chrome**, the way [Adw.TabBar](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.TabBar.html) draws them — instead of a detached pill toggle floating above the block.

## Core first — `@gjsify/adwaita-web`

`<adw-tab-view>` (our Adw.TabView/TabBar counterpart) already existed; two attributes were missing for static tab sets and are added at the core:

- **`expand-tabs`** — tabs stretch to fill the bar evenly (mirrors `Adw.TabBar:expand-tabs`)
- **`no-close`** — no close affordance (web-specific escape hatch; a static tab set has nothing to close)

Styling-only attribute selectors in `_tab_view.scss` + reflecting property accessors, covered by a new `adw-tab-view.spec.ts` on the browser test axis (page building, selection/notify, close-page, both attributes — **all 9 browser suites green** under Playwright Firefox locally).

## Website

`CommandTabs` now renders an `<adw-tab-view expand-tabs no-close>` as **the** window: headerbar-colored tab strip on top, active tab raised onto the code surface, Expressive Code block directly below. The per-block `adw-code-window` frame is flattened (one window, not two), its headerbar collapses, and the copy button floats over the code's top-right on a code-surface chip. The adwaita-web skin keys on `prefers-color-scheme` while the site keys on Starlight's `data-theme` — the skin variables are re-mapped to the site's theme-aware `--adw-*` tokens in the component scope, so the tabs follow the theme toggle.

Selection sync/persistence is unchanged (localStorage; all instances + pages follow), verified via Playwright in dark **and** light theme.