### PR TITLE
docs(website): descriptive command-window titles

### DIFF
--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -10,7 +10,7 @@ import CommandTabs from '../../components/CommandTabs.astro';
 Pick your toolchain — GJSify's own **Node-free** CLI (recommended), or the
 same CLI through npm, Bun or Deno:
 
-<CommandTabs>
+<CommandTabs title="Create my-app">
   <Fragment slot="gjsify">
     ```bash
     curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs \
@@ -77,7 +77,7 @@ sudo apt install gjs libgtk-4-1 libsoup-3.0-0
 
 Not sure if everything is in place?
 
-<CommandTabs>
+<CommandTabs title="System check">
   <Fragment slot="gjsify">
     ```bash
     gjsify system-check
@@ -127,7 +127,7 @@ The build script uses `--globals auto` by default — no manual list to maintain
 
 The scaffolded scripts run with whichever toolchain you picked:
 
-<CommandTabs>
+<CommandTabs title="Build & run">
   <Fragment slot="gjsify">
     ```bash
     gjsify run build   # gjsify build src/index.ts --outfile dist/index.js

--- a/website/src/content/docs/how-it-works.mdx
+++ b/website/src/content/docs/how-it-works.mdx
@@ -46,7 +46,7 @@ Every `@gjsify/*` package that provides a Node or Web global exposes one or more
 
 The CLI's default `--globals auto` discovers which registers your project needs by analysing the bundled output:
 
-<CommandTabs>
+<CommandTabs title="Build the bundle">
   <Fragment slot="gjsify">
     ```bash
     gjsify build src/index.ts --outfile dist/index.js
@@ -164,7 +164,7 @@ Some GJSify packages need native code. For example, `@gjsify/webgl` ships a Vala
 
 `gjsify run` scans your `node_modules` for these packages, prepends the right directories to `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH`, and then spawns `gjs -m <bundle>`:
 
-<CommandTabs>
+<CommandTabs title="Run the bundle">
   <Fragment slot="gjsify">
     ```bash
     gjsify run dist/index.js
@@ -189,7 +189,7 @@ Some GJSify packages need native code. For example, `@gjsify/webgl` ships a Vala
 
 If you want to run `gjs` directly (for example from a systemd unit or a packaged Flatpak), you can ask the CLI to print the environment for you:
 
-<CommandTabs>
+<CommandTabs title="Export the environment">
   <Fragment slot="gjsify">
     ```bash
     eval $(gjsify info --export)

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -25,7 +25,7 @@ GJSify is organised into pillars, each implementing standard APIs on top of nati
 
 All packages are published to npm under the `@gjsify` scope:
 
-<CommandTabs>
+<CommandTabs title="Install packages">
   <Fragment slot="gjsify">
     ```bash
     gjsify install @gjsify/fs @gjsify/http @gjsify/fetch


### PR DESCRIPTION
Follow-up to #752: each command window now carries a title describing what the block does, instead of the generic "Terminal" — Create my-app / System check / Build & run (getting-started), Build the bundle / Run the bundle / Export the environment (how-it-works), Install packages (packages overview). Verified against astro preview.