### PR TITLE
ci: deploy docs on adwaita-web changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'website/**'
+      # The site embeds @gjsify/adwaita-web (resolved from workspace source,
+      # compiled during the site build) — its changes alter the rendered docs.
+      - 'packages/web/adwaita-web/**'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
Follow-up to #754: the docs deploy only watched `website/**`, but the site embeds `@gjsify/adwaita-web` from workspace source — #754's tab-bar restyle merged without a deploy (I dispatched one manually). Adding `packages/web/adwaita-web/**` to the trigger paths closes the gap.