### PR TITLE
fix(website): no flow margin between headerbar and tab bar

### DIFF
--- a/website/src/components/CommandTabs.astro
+++ b/website/src/components/CommandTabs.astro
@@ -46,7 +46,10 @@ for (const r of RUNTIMES) {
 const runtimesAttr = present.map((r) => r.slot).join(',');
 ---
 
-<div class="command-tabs" data-command-tabs data-runtimes={runtimesAttr}>
+{/* `not-content` opts the window chrome out of Starlight's content-flow
+    spacing — its `* + *` rule otherwise puts a 1rem margin-top on the
+    <adw-tab-view> (a visible gap between headerbar and tab bar). */}
+<div class="command-tabs not-content" data-command-tabs data-runtimes={runtimesAttr}>
     <div class="command-tabs-headerbar">
         <span class="command-tabs-headerbar-start"></span>
         <span class="command-tabs-headerbar-title">{title}</span>
@@ -143,6 +146,11 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 
     :root:not([data-theme='dark']) .command-tabs {
         outline-color: rgb(0 0 6 / 8%);
+    }
+
+    /* Belt and braces to `not-content`: the chrome rows must sit flush. */
+    .command-tabs > adw-tab-view {
+        margin: 0;
     }
 
     /* The adwaita-web skin keys on prefers-color-scheme; the site theme keys


### PR DESCRIPTION
Fixes the visible gap inside the command-window chrome (spotted via dev tools: a 16px margin-top on `<adw-tab-view>`): Starlight's content-flow rule (`* + *` → `margin-top: 1rem`) applied to the tab view because it follows the headerbar. The wrapper now carries Starlight's `not-content` class (descendants exempt from flow spacing) plus an explicit margin reset.

Verified against the live site via computed styles (16px → 0px) and visual check in dark mode — headerbar and tab bar now sit flush, exactly like the Adw.TabBar reference. No element inside the window carries a stray flow margin anymore.