### PR TITLE
docs(website): plain-language node-gi stability note

### DIFF
--- a/website/src/content/docs/projects/node-gi.md
+++ b/website/src/content/docs/projects/node-gi.md
@@ -5,8 +5,8 @@ description: Run unchanged GJS / GObject-Introspection code on Node.js, Bun and 
 
 [`@gjsify/node-gi`](https://github.com/gjsify/gjsify/tree/main/packages/node-gi/node-gi) is the **reverse** of the rest of GJSify: instead of bringing Node/Web APIs to GJS, it brings **GObject-Introspection to Node.js, Bun and Deno**. The same unchanged `gi://` source builds and runs natively under GJS *and* on every Node-API runtime — no code changes.
 
-:::note[Product — Tier 2]
-node-gi **graduated to Tier 2** on 2026-07-14 ([ADR 0005](https://github.com/gjsify/gjsify/blob/main/docs/adr/0005-node-gi-scope.md)) once its four gate items landed: the toggle-ref/multi-env teardown crash fixed, vfunc OUT/INOUT chain-up, the GTK/Cairo layer, and a second real consumer (`@gjsify/sqlite`'s test suite runs on node-gi). Tier 2 is **best-effort**: tested and released on the train, but breaking changes may ship with a minor + a changelog note. One invariant is kept from Tier 3: no Tier-1/2 `@gjsify/*` package may take a **hard** dependency on `@gjsify/node-gi` — the sanctioned seams stay a `devDependency` and the conditional `--app node` build injection (the reverse bridge would otherwise double the runtime test matrix).
+:::note[Stability]
+node-gi is tested and released together with every GJSify release, and real consumers exercise it — `@gjsify/sqlite`'s own test suite runs on it. It is still a **younger part of the framework** than the GJS side, so a breaking change may occasionally ship in a minor release (always with a changelog note). Regular GJS apps are unaffected either way: no GJSify package depends on node-gi at runtime. Details in the [stability model](/gjsify/versioning/#package-tiers).
 :::
 
 ## One source, every runtime
@@ -71,5 +71,5 @@ Requires a C++ toolchain plus the GLib ≥ 2.80 / `girepository-2.0` development
 ## See also
 
 - [Runtimes](/gjsify/runtimes/) — how the reverse bridge fits GJSify's overall target picture
-- [Versioning](/gjsify/versioning/#package-tiers) — what the Tier-2 contract means
+- [Versioning](/gjsify/versioning/#package-tiers) — the release train and stability model
 - [Storybook](/gjsify/guides/storybook/) — `gjsify storybook --runtime node`, the canonical consumer

--- a/website/src/content/docs/runtimes.md
+++ b/website/src/content/docs/runtimes.md
@@ -70,10 +70,11 @@ GIMarshallingTests currently pass 343 cases on all four runtimes.
 - **Use Node.js, Bun or Deno where GJS isn't available** — dev tooling, CI,
   benchmarks, or editor integrations. `gjsify storybook --runtime node` is the
   canonical example: the same GTK storybook, running on Node.js.
-- **`@gjsify/node-gi` is a Tier-2 package** — best effort, released on the
-  train. Framework packages never hard-depend on it, so the reverse bridge can
-  never destabilize a GJS build. See
-  [Versioning](/gjsify/versioning/) for the tier model.
+- **node-gi is newer than the GJS side.** It is tested and released with
+  every GJSify release, but a breaking change may still ship in a minor
+  version. No GJSify package depends on it at runtime, so the reverse bridge
+  can never destabilize a GJS build — see
+  [Versioning](/gjsify/versioning/) for the stability model.
 
 ## Mobile: NativeScript (experimental)
 
@@ -81,8 +82,8 @@ A fifth direction is taking shape: the Adwaita widget set, storybook renderer
 and devtools agent exist as **native NativeScript components** for Android and
 iOS (`@gjsify/adwaita-nativescript` — real views, not a WebView), and
 `gjsify build --app nativescript` produces bundles for the NativeScript
-toolchain. The runtime slot itself is still experimental; the widget packages
-ship as Tier 2.
+toolchain. The runtime target itself is still experimental; the widget packages are
+tested and released with the regular GJSify releases.
 
 ## Related
 


### PR DESCRIPTION
The "Product — Tier 2" info block on the node-gi page read like an internal changelog — Tier, ADR, gate items, toggle-ref teardown, devDep-only seams mean nothing to a site visitor. It is now a short **Stability** note in plain terms:

> node-gi is tested and released together with every GJSify release, and real consumers exercise it — `@gjsify/sqlite`'s own test suite runs on it. It is still a younger part of the framework than the GJS side, so a breaking change may occasionally ship in a minor release (always with a changelog note). Regular GJS apps are unaffected either way: no GJSify package depends on node-gi at runtime.

The two "Tier" mentions on the Runtimes page get the same treatment. The [versioning page](https://gjsify.github.io/gjsify/versioning/#package-tiers) remains the one place that introduces and defines the tier vocabulary.