### PR TITLE
feat(node-gi): bind cairo canvas2d surface

### DIFF
--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -691,10 +691,21 @@ const layout = PangoCairo.create_layout(new cairo.Context(surface));
 //   area.set_draw_func((_area, ctx, w, h) => { ctx.setSourceRGB(1, 0, 0); … });
 ```
 
-Ported this slice: `cairo.Context` (drawing + transform ops, state getters,
-`$dispose`), `cairo.Surface` + `cairo.ImageSurface` (`getData`/`getWidth`/
-`getHeight`/`getStride`/`getFormat`/`flush`/`writeToPNG`/`createFromPNG`),
-`cairo.SolidPattern`, and the enums (`Format`, `Operator`, `Content`, …). The
-native binding paints **byte-for-byte identically to GJS** (verified pixel-for-pixel
-against `gjs -m`). Deferred: gradients, path/region objects, and the PDF/SVG/PS
-surfaces.
+Ported this slice: `cairo.Context` (drawing + transform ops incl.
+`identityMatrix` and the `userToDevice[Distance]` / `deviceToUser[Distance]`
+point transforms, state getters, `setDash`/`getDashCount` (+ a net-new
+`getDash`), `inFill`/`inStroke`, `newSubPath`, `copyPath`/`copyPathFlat`/
+`appendPath` (owned `cairo.Path` handles), `getSource` with concrete-subclass
+fan-out, `$dispose`), `cairo.Surface` + `cairo.ImageSurface` (`getData`/
+`getWidth`/`getHeight`/`getStride`/`getFormat`/`flush`/`writeToPNG`/
+`createFromPNG`), the patterns — `cairo.SolidPattern`,
+`cairo.LinearGradient`/`cairo.RadialGradient` (`addColorStopRGB[A]` via the
+shared `cairo.Gradient` base), `cairo.SurfacePattern`
+(`setExtend`/`getExtend`/`setFilter`/`getFilter`) — the opaque `cairo.Path`,
+and the enums (`Format`, `Operator`, `Content`, `Extend`, `Filter`, …). This is
+the full surface `@gjsify/canvas2d-core` draws through (headless Canvas 2D).
+The native binding paints **byte-for-byte identically to GJS** (verified
+pixel-for-pixel against `gjs -m`, incl. gradients / repeating surface patterns /
+dashed strokes / path round-trips — `test/cairo-canvas2d.test.mjs`). Deferred:
+region objects, the PDF/SVG/PS surfaces, and the text/font ops
+(`showText`/`selectFontFace` — canvas2d text rides PangoCairo instead).

--- a/packages/node-gi/node-gi/cairo.d.ts
+++ b/packages/node-gi/node-gi/cairo.d.ts
@@ -47,6 +47,36 @@ export class Context {
   setSourceRGBA(red: number, green: number, blue: number, alpha: number): void;
   setSource(pattern: Pattern): void;
   setSourceSurface(surface: Surface, x: number, y: number): void;
+  /** The context's current source pattern (own reference; concrete subclass). */
+  getSource(): Pattern;
+  identityMatrix(): void;
+  newSubPath(): void;
+  /** User → device coordinates as `[x, y]` (GJS return shape). */
+  userToDevice(x: number, y: number): [number, number];
+  /** User → device distance (ignores translation) as `[dx, dy]`. */
+  userToDeviceDistance(dx: number, dy: number): [number, number];
+  /** Device → user coordinates as `[x, y]`. */
+  deviceToUser(x: number, y: number): [number, number];
+  /** Device → user distance (ignores translation) as `[dx, dy]`. */
+  deviceToUserDistance(dx: number, dy: number): [number, number];
+  /** Copy the current path into an owned {@link Path} handle. */
+  copyPath(): Path;
+  /** Like {@link copyPath} but with curves flattened to line segments. */
+  copyPathFlat(): Path;
+  appendPath(path: Path): void;
+  /**
+   * Set the stroke dash pattern. GJS semantics: holes/undefined entries are
+   * skipped, a non-positive value throws, an empty array disables dashing.
+   */
+  setDash(dashes: number[], offset: number): void;
+  getDashCount(): number;
+  /**
+   * The current dash pattern as `[dashes, offset]`.
+   * Note: GJS ships only `getDashCount`; this is a node-gi convenience.
+   */
+  getDash(): [number[], number];
+  inFill(x: number, y: number): boolean;
+  inStroke(x: number, y: number): boolean;
   setLineWidth(width: number): void;
   getLineWidth(): number;
   setLineCap(lineCap: number): void;
@@ -96,6 +126,37 @@ export class SolidPattern extends Pattern {
   static createRGBA(red: number, green: number, blue: number, alpha: number): SolidPattern;
 }
 
+/** gradient base class — shared color-stop API. */
+export class Gradient extends Pattern {
+  addColorStopRGB(offset: number, red: number, green: number, blue: number): void;
+  addColorStopRGBA(offset: number, red: number, green: number, blue: number, alpha: number): void;
+}
+
+/** linear gradient (`cairo_pattern_create_linear`). */
+export class LinearGradient extends Gradient {
+  constructor(x0: number, y0: number, x1: number, y1: number);
+}
+
+/** radial gradient (`cairo_pattern_create_radial`). */
+export class RadialGradient extends Gradient {
+  constructor(cx0: number, cy0: number, radius0: number, cx1: number, cy1: number, radius1: number);
+}
+
+/** surface-backed pattern (`cairo_pattern_create_for_surface`). */
+export class SurfacePattern extends Pattern {
+  constructor(surface: Surface);
+  setExtend(extend: number): void;
+  getExtend(): number;
+  setFilter(filter: number): void;
+  getFilter(): number;
+}
+
+/**
+ * Opaque copied path (`cairo_path_t`, from `Context.copyPath[Flat]()`).
+ * Method-less in GJS too — round-trips through `appendPath` / GI calls.
+ */
+export class Path {}
+
 /** The GJS `cairo` module object (`import cairo from 'cairo'`). */
 declare const cairo: {
   Antialias: CairoEnum;
@@ -116,6 +177,11 @@ declare const cairo: {
   ImageSurface: typeof ImageSurface;
   Pattern: typeof Pattern;
   SolidPattern: typeof SolidPattern;
+  Gradient: typeof Gradient;
+  LinearGradient: typeof LinearGradient;
+  RadialGradient: typeof RadialGradient;
+  SurfacePattern: typeof SurfacePattern;
+  Path: typeof Path;
 };
 
 export default cairo;

--- a/packages/node-gi/node-gi/cairo.js
+++ b/packages/node-gi/node-gi/cairo.js
@@ -216,6 +216,62 @@ export class Context {
   rotate(angle) {
     c.rotate(this[H], angle);
   }
+  identityMatrix() {
+    c.identityMatrix(this[H]);
+  }
+  newSubPath() {
+    c.newSubPath(this[H]);
+  }
+  /** User → device coordinates as `[x, y]` (GJS return shape). */
+  userToDevice(x, y) {
+    return c.userToDevice(this[H], x, y);
+  }
+  /** User → device distance (ignores translation) as `[dx, dy]`. */
+  userToDeviceDistance(dx, dy) {
+    return c.userToDeviceDistance(this[H], dx, dy);
+  }
+  /** Device → user coordinates as `[x, y]`. */
+  deviceToUser(x, y) {
+    return c.deviceToUser(this[H], x, y);
+  }
+  /** Device → user distance (ignores translation) as `[dx, dy]`. */
+  deviceToUserDistance(dx, dy) {
+    return c.deviceToUserDistance(this[H], dx, dy);
+  }
+  /** Copy the current path into an owned {@link Path} handle. */
+  copyPath() {
+    return wrapRaw(Path, c.copyPath(this[H]));
+  }
+  /** Like {@link copyPath} but with curves flattened to line segments. */
+  copyPathFlat() {
+    return wrapRaw(Path, c.copyPathFlat(this[H]));
+  }
+  appendPath(path) {
+    c.appendPath(this[H], handleOf(path, 'cairo.Path'));
+  }
+  /**
+   * Set the stroke dash pattern. GJS semantics: holes/undefined entries are
+   * skipped, a non-positive value throws, an empty array disables dashing.
+   */
+  setDash(dashes, offset) {
+    c.setDash(this[H], dashes, offset);
+  }
+  getDashCount() {
+    return c.getDashCount(this[H]);
+  }
+  /**
+   * The current dash pattern as `[dashes, offset]`.
+   * Note: GJS ships only `getDashCount`; this is a node-gi convenience.
+   */
+  getDash() {
+    return c.getDash(this[H]);
+  }
+  inFill(x, y) {
+    return c.inFill(this[H], x, y);
+  }
+  inStroke(x, y) {
+    return c.inStroke(this[H], x, y);
+  }
 
   setSourceRGB(red, green, blue) {
     c.setSourceRGB(this[H], red, green, blue);
@@ -228,6 +284,10 @@ export class Context {
   }
   setSourceSurface(surface, x, y) {
     c.setSourceSurface(this[H], handleOf(surface, 'cairo.Surface'), x, y);
+  }
+  /** The context's current source pattern (a ref of its own — safe to keep). */
+  getSource() {
+    return wrapPatternHandle(c.getSource(this[H]));
   }
 
   setLineWidth(width) {
@@ -395,16 +455,88 @@ export class SolidPattern extends Pattern {
   }
 }
 
+/** Gradient base class — the shared color-stop API (GJS `CairoGradient`). */
+export class Gradient extends Pattern {
+  addColorStopRGB(offset, red, green, blue) {
+    c.patternAddColorStopRGB(this[H], offset, red, green, blue);
+  }
+  addColorStopRGBA(offset, red, green, blue, alpha) {
+    c.patternAddColorStopRGBA(this[H], offset, red, green, blue, alpha);
+  }
+}
+
+/** A linear gradient (`cairo_pattern_create_linear`). */
+export class LinearGradient extends Gradient {
+  constructor(x0, y0, x1, y1) {
+    super();
+    setHandle(this, c.linearGradientCreate(x0, y0, x1, y1));
+  }
+}
+
+/** A radial gradient (`cairo_pattern_create_radial`). */
+export class RadialGradient extends Gradient {
+  constructor(cx0, cy0, radius0, cx1, cy1, radius1) {
+    super();
+    setHandle(this, c.radialGradientCreate(cx0, cy0, radius0, cx1, cy1, radius1));
+  }
+}
+
+/** A surface-backed pattern (`cairo_pattern_create_for_surface`). */
+export class SurfacePattern extends Pattern {
+  constructor(surface) {
+    super();
+    setHandle(this, c.surfacePatternCreate(handleOf(surface, 'cairo.Surface')));
+  }
+
+  setExtend(extend) {
+    c.patternSetExtend(this[H], extend);
+  }
+  getExtend() {
+    return c.patternGetExtend(this[H]);
+  }
+  setFilter(filter) {
+    c.patternSetFilter(this[H], filter);
+  }
+  getFilter() {
+    return c.patternGetFilter(this[H]);
+  }
+}
+
+/**
+ * An opaque copied path (`cairo_path_t`, from `Context.copyPath[Flat]()`).
+ * Method-less in GJS too — it only round-trips through `appendPath` / GI calls.
+ * The underlying path is destroyed on GC (`cairo_path_destroy`).
+ */
+export class Path {}
+
+// Fan a pattern handle out to the concrete subclass by cairo runtime type —
+// mirrors gjs_cairo_pattern_from_pattern (MESH/RASTER_SOURCE fall back to the
+// base Pattern; gjs throws for those, but they are unreachable from this module).
+function wrapPatternHandle(handle) {
+  const t = c.patternGetType(handle);
+  const Klass =
+    t === PatternType.SOLID
+      ? SolidPattern
+      : t === PatternType.SURFACE
+        ? SurfacePattern
+        : t === PatternType.LINEAR
+          ? LinearGradient
+          : t === PatternType.RADIAL
+            ? RadialGradient
+            : Pattern;
+  return wrapRaw(Klass, handle);
+}
+
 // Register the wrapper factories so the engine's foreign-struct from_func can turn
 // a returned/callback cairo pointer into the right JS instance. Surface + Pattern
 // fan out to the concrete subclass by cairo runtime type (mirrors
-// CairoSurface::from_c_ptr / CairoPattern::from_c_ptr).
+// CairoSurface::from_c_ptr / gjs_cairo_pattern_from_pattern).
 c.setup({
   context: (handle) => wrapRaw(Context, handle),
   surface: (handle) =>
     wrapRaw(c.surfaceGetType(handle) === SurfaceType.IMAGE ? ImageSurface : Surface, handle),
-  pattern: (handle) =>
-    wrapRaw(c.patternGetType(handle) === PatternType.SOLID ? SolidPattern : Pattern, handle),
+  pattern: (handle) => wrapPatternHandle(handle),
+  path: (handle) => wrapRaw(Path, handle),
 });
 
 // The default export mirrors GJS's ESM `cairo` object (enums + constructors), the
@@ -428,6 +560,11 @@ const cairo = {
   ImageSurface,
   Pattern,
   SolidPattern,
+  Gradient,
+  LinearGradient,
+  RadialGradient,
+  SurfacePattern,
+  Path,
 };
 
 export default cairo;

--- a/packages/node-gi/node-gi/conformance/golden/cairo.txt
+++ b/packages/node-gi/node-gi/conformance/golden/cairo.txt
@@ -16,4 +16,28 @@ inside save lineWidth: 7 lineCap: 2
 after restore lineWidth: 2 lineCap: 0
 pattern type: 0
 setSource ok
+linear type: 2
+radial type: 3
+surface-pattern type: 1
+extend default: 0 filter default: 1
+extend set: 1 filter set: 3
+source type linear: 2
+source type surface: 1 filter: 3
+dash count initial: 0
+dash count: 4
+dash count skip-undefined: 2
+dash error: Dash value must be positive
+dash count off: 0
+userToDevice: [12,23]
+userToDeviceDistance: [2,3]
+deviceToUser: [1,1]
+deviceToUserDistance: [1,1]
+identity userToDevice: [5,6]
+inFill: true false
+inStroke: true false
+current point after newSubPath: false
+extents before: [1,2,11,9]
+extents cleared: [0,0,0,0]
+extents round-trip: [1,2,11,9]
+extents flattened: [1,2,11,9]
 done

--- a/packages/node-gi/node-gi/conformance/programs/cairo.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/cairo.conf.mjs
@@ -81,6 +81,89 @@ cr2.setSource(pattern);
 cr2.paint();
 print('setSource ok');
 
+// ---- the canvas2d slice: gradients, surface patterns, dash, paths, matrix ----
+// (only methods GJS's native cairo exposes — gjs, the reference, runs unchanged)
+
+// Gradients: color stops + pattern types.
+const lin = new cairo.LinearGradient(0, 0, 0, H);
+lin.addColorStopRGB(0, 1, 1, 1);
+lin.addColorStopRGBA(1, 0.2, 0.25, 0.5, 1);
+print('linear type:', lin.getType());
+const rad = new cairo.RadialGradient(10, 10, 2, 10, 10, 9);
+rad.addColorStopRGBA(0, 1, 0.9, 0.2, 1);
+rad.addColorStopRGBA(1, 0.8, 0.2, 0.1, 0);
+print('radial type:', rad.getType());
+
+// SurfacePattern: extend + filter get/set (defaults come from cairo itself).
+const tile = new cairo.ImageSurface(cairo.Format.ARGB32, 8, 8);
+const sp = new cairo.SurfacePattern(tile);
+print('surface-pattern type:', sp.getType());
+print('extend default:', sp.getExtend(), 'filter default:', sp.getFilter());
+sp.setExtend(cairo.Extend.REPEAT);
+sp.setFilter(cairo.Filter.NEAREST);
+print('extend set:', sp.getExtend(), 'filter set:', sp.getFilter());
+
+// getSource fans out to the concrete pattern subclass (SurfacePattern exposes
+// getFilter) — the canvas2d imageSmoothing path.
+const cr3 = new cairo.Context(surface);
+cr3.setSource(lin);
+print('source type linear:', cr3.getSource().getType());
+cr3.setSource(sp);
+print('source type surface:', cr3.getSource().getType(), 'filter:', cr3.getSource().getFilter());
+
+// Dash: count + GJS validation semantics (skip undefined, throw on <= 0).
+print('dash count initial:', cr3.getDashCount());
+cr3.setDash([6, 3, 2, 3], 1);
+print('dash count:', cr3.getDashCount());
+cr3.setDash([1, undefined, 2], 0);
+print('dash count skip-undefined:', cr3.getDashCount());
+try {
+  cr3.setDash([1, -1], 0);
+} catch (e) {
+  print('dash error:', e.message);
+}
+cr3.setDash([], 0);
+print('dash count off:', cr3.getDashCount());
+
+// Matrix point/distance transforms + identityMatrix.
+cr3.translate(10, 20);
+cr3.scale(2, 3);
+print('userToDevice:', JSON.stringify(cr3.userToDevice(1, 1)));
+print('userToDeviceDistance:', JSON.stringify(cr3.userToDeviceDistance(1, 1)));
+print('deviceToUser:', JSON.stringify(cr3.deviceToUser(12, 23)));
+print('deviceToUserDistance:', JSON.stringify(cr3.deviceToUserDistance(2, 3)));
+cr3.identityMatrix();
+print('identity userToDevice:', JSON.stringify(cr3.userToDevice(5, 6)));
+
+// inFill / inStroke + newSubPath current-point semantics.
+cr3.newPath();
+cr3.rectangle(2, 2, 10, 8);
+print('inFill:', cr3.inFill(5, 5), cr3.inFill(30, 25));
+cr3.setLineWidth(4);
+print('inStroke:', cr3.inStroke(2, 5), cr3.inStroke(7, 6));
+cr3.newPath();
+cr3.moveTo(3, 3);
+cr3.newSubPath();
+print('current point after newSubPath:', cr3.hasCurrentPoint());
+
+// Path copy/append round-trip (copyPath + copyPathFlat) via extents.
+cr3.newPath();
+cr3.moveTo(1, 2);
+cr3.lineTo(11, 2);
+cr3.curveTo(11, 5, 11, 7, 11, 9);
+cr3.closePath();
+print('extents before:', JSON.stringify(cr3.pathExtents()));
+const copied = cr3.copyPath();
+const flattened = cr3.copyPathFlat();
+cr3.newPath();
+print('extents cleared:', JSON.stringify(cr3.pathExtents()));
+cr3.appendPath(copied);
+print('extents round-trip:', JSON.stringify(cr3.pathExtents()));
+cr3.newPath();
+cr3.appendPath(flattened);
+print('extents flattened:', JSON.stringify(cr3.pathExtents()));
+
 cr.$dispose();
 cr2.$dispose();
+cr3.$dispose();
 print('done');

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -76,6 +76,7 @@
     "test:gimarshalling": "node scripts/gimarshalling.mjs",
     "test:deno": "node scripts/cross-runtime.mjs deno",
     "test:cairo": "NODE_GI_NATIVE=build node --test test/cairo.test.mjs",
+    "test:cairo-canvas2d": "NODE_GI_NATIVE=build node --test test/cairo-canvas2d.test.mjs",
     "test:gtk": "NODE_GI_NATIVE=build node --test test/gtk-smoke.test.mjs",
     "test:gtk-cairo": "NODE_GI_NATIVE=build node --test test/cairo-drawfunc.test.mjs",
     "test:adw": "NODE_GI_NATIVE=build node --test test/adw-smoke.test.mjs",

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -41,6 +41,7 @@ const CONFORMANCE = [
   'async-error',
   'bytes',
   'cairo',
+  'cairo-canvas2d',
   'call-function',
   'callbacks',
   'closure-exception',

--- a/packages/node-gi/node-gi/src/cairo.cc
+++ b/packages/node-gi/node-gi/src/cairo.cc
@@ -10,11 +10,17 @@
 // that binding + registration.
 //
 // Reference: refs/gjs/modules/cairo-*.cpp (Context/Surface/ImageSurface/Pattern/
-// SolidPattern) + refs/gjs/gi/foreign.cpp (the foreign seam). Copyright (c) 2010
+// SolidPattern/Gradient/LinearGradient/RadialGradient/SurfacePattern/Path) +
+// refs/gjs/gi/foreign.cpp (the foreign seam). Copyright (c) 2010
 // litl, LLC / GJS contributors, MIT OR LGPL-2.0-or-later. Retargeted to N-API +
 // the node-gi ownership model (adopt-or-ref, no separate release call — matching
-// WrapBoxed). Slice: Context (drawing ops), Surface + ImageSurface (headless
-// pixels), SolidPattern. Deferred: gradients, path, region, PDF/SVG/PS surfaces.
+// WrapBoxed; cairo_path_t is NOT ref-counted, so a borrowed path is COPIED via
+// the gjs CairoPath::copy_ptr dummy-context trick instead of ref'd). Slice:
+// Context (drawing ops, path copy/append, dash, matrix point transforms,
+// in-fill/in-stroke, getSource), Surface + ImageSurface (headless pixels),
+// SolidPattern, LinearGradient/RadialGradient (color stops), SurfacePattern
+// (extend/filter), Path handles. Deferred: region, PDF/SVG/PS surfaces,
+// text/font ops (showText/selectFontFace — canvas2d text rides PangoCairo).
 //
 // The JS wrapper classes live in the L1 module (cairo.js); each instance holds
 // this binding's pointer as a type-tagged External under `_ptr`. The foreign
@@ -27,11 +33,13 @@
 #include <cairo.h>
 #include <string.h>  // memcpy
 
+#include <vector>
+
 namespace nodegi {
 
 // The pointer kind carried by a cairo handle, so the finalizer/dispose picks the
 // matching cairo_*_destroy and the marshaller can typecheck a foreign IN arg.
-enum class CairoKind : uint8_t { Context, Surface, Pattern };
+enum class CairoKind : uint8_t { Context, Surface, Pattern, Path };
 
 // A cairo object handle: the ref-counted cairo pointer + its kind. `owns` is true
 // for every handle this binding creates (constructors own their fresh ref;
@@ -57,6 +65,7 @@ static void DestroyCairo(CairoHandle* h) {
     case CairoKind::Context: cairo_destroy(static_cast<cairo_t*>(h->ptr)); break;
     case CairoKind::Surface: cairo_surface_destroy(static_cast<cairo_surface_t*>(h->ptr)); break;
     case CairoKind::Pattern: cairo_pattern_destroy(static_cast<cairo_pattern_t*>(h->ptr)); break;
+    case CairoKind::Path: cairo_path_destroy(static_cast<cairo_path_t*>(h->ptr)); break;
   }
 }
 
@@ -137,6 +146,27 @@ static cairo_pattern_t* PatternFromExt(Napi::Env env, Napi::Value v) {
     return nullptr;
   }
   return static_cast<cairo_pattern_t*>(h->ptr);
+}
+static cairo_path_t* PathFromExt(Napi::Env env, Napi::Value v) {
+  CairoHandle* h = HandleFromExternal(v);
+  if (h == nullptr || h->kind != CairoKind::Path || h->disposed || h->ptr == nullptr) {
+    Napi::TypeError::New(env, "expected a live cairo.Path").ThrowAsJavaScriptException();
+    return nullptr;
+  }
+  return static_cast<cairo_path_t*>(h->ptr);
+}
+
+// Copy a cairo_path_t (not ref-counted): replay it onto a dummy 0x0 image-surface
+// context and copy it back out. Mirrors gjs CairoPath::copy_ptr (adapted from
+// PyGObject cairo code).
+static cairo_path_t* CopyCairoPath(cairo_path_t* path) {
+  cairo_surface_t* surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 0, 0);
+  cairo_t* cr = cairo_create(surface);
+  cairo_append_path(cr, path);
+  cairo_path_t* copy = cairo_copy_path(cr);
+  cairo_destroy(cr);
+  cairo_surface_destroy(surface);
+  return copy;
 }
 
 static double Num(const Napi::CallbackInfo& info, size_t i) {
@@ -296,13 +326,37 @@ static Napi::Value PatternFrom(Napi::Env env, gpointer ptr, GITransfer transfer)
   return CallWrapper(env, "pattern", MakeCairoHandle(env, ptr, CairoKind::Pattern));
 }
 
+// cairo_path_t is not ref-counted: a borrowed path (transfer-nothing FROM, or a
+// transfer-everything IN where the callee takes ownership) is COPIED instead of
+// ref'd — same semantics as gjs's path_to/from_gi_argument + CairoPath::copy_ptr.
+static bool PathTo(Napi::Env env, Napi::Value v, GITransfer transfer, GIArgument* arg) {
+  if (v.IsNull() || v.IsUndefined()) { arg->v_pointer = nullptr; return true; }
+  void* p = PtrFromWrapper(v, CairoKind::Path);
+  if (p == nullptr) {
+    Napi::TypeError::New(env, "expected a cairo.Path").ThrowAsJavaScriptException();
+    return false;
+  }
+  if (transfer == GI_TRANSFER_EVERYTHING) p = CopyCairoPath(static_cast<cairo_path_t*>(p));
+  arg->v_pointer = p;
+  return true;
+}
+static Napi::Value PathFrom(Napi::Env env, gpointer ptr, GITransfer transfer) {
+  if (ptr == nullptr) return env.Null();
+  cairo_path_t* owned = (transfer == GI_TRANSFER_EVERYTHING)
+                            ? static_cast<cairo_path_t*>(ptr)
+                            : CopyCairoPath(static_cast<cairo_path_t*>(ptr));
+  return CallWrapper(env, "path", MakeCairoHandle(env, owned, CairoKind::Path));
+}
+
 static const ForeignStructOps kContextOps{ContextTo, ContextFrom};
 static const ForeignStructOps kSurfaceOps{SurfaceTo, SurfaceFrom};
 static const ForeignStructOps kPatternOps{PatternTo, PatternFrom};
+static const ForeignStructOps kPathOps{PathTo, PathFrom};
 
 // setup(wrappers): the L1 module hands its JS wrapper factories ({context, surface,
-// pattern}) — each takes the `_ptr` External and returns the class instance. Stored
-// per-env (a napi_ref is env-specific) so the foreign from_func can build wrappers.
+// pattern, path}) — each takes the `_ptr` External and returns the class instance.
+// Stored per-env (a napi_ref is env-specific) so the foreign from_func can build
+// wrappers.
 static Napi::Value CairoSetup(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   NodeGiEnvData* d = EnvData(env);
@@ -324,6 +378,7 @@ void InitCairo(Napi::Env env, Napi::Object exports) {
   RegisterForeignStruct("cairo", "Context", &kContextOps);
   RegisterForeignStruct("cairo", "Surface", &kSurfaceOps);
   RegisterForeignStruct("cairo", "Pattern", &kPatternOps);
+  RegisterForeignStruct("cairo", "Path", &kPathOps);
 
   Napi::Object c = Napi::Object::New(env);
   c.Set("setup", Napi::Function::New(env, CairoSetup));
@@ -378,6 +433,86 @@ void InitCairo(Napi::Env env, Napi::Object exports) {
             return env.Undefined();
           }
           return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+  c.Set("linearGradientCreate", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p =
+              cairo_pattern_create_linear(Num(info, 0), Num(info, 1), Num(info, 2), Num(info, 3));
+          if (!CheckStatus(env, cairo_pattern_status(p), "pattern")) {
+            cairo_pattern_destroy(p);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+  c.Set("radialGradientCreate", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = cairo_pattern_create_radial(Num(info, 0), Num(info, 1), Num(info, 2),
+                                                           Num(info, 3), Num(info, 4), Num(info, 5));
+          if (!CheckStatus(env, cairo_pattern_status(p), "pattern")) {
+            cairo_pattern_destroy(p);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+  c.Set("surfacePatternCreate", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_surface_t* s = SurfaceFromExt(env, info[0]);
+          if (s == nullptr) return env.Undefined();
+          cairo_pattern_t* p = cairo_pattern_create_for_surface(s);
+          if (!CheckStatus(env, cairo_pattern_status(p), "pattern")) {
+            cairo_pattern_destroy(p);
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+
+  // ---- pattern methods (the pattern handle External is info[0]) ----
+  // Gradient color stops (Gradient in gjs terms — Linear/RadialGradient).
+  c.Set("patternAddColorStopRGB", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          cairo_pattern_add_color_stop_rgb(p, Num(info, 1), Num(info, 2), Num(info, 3), Num(info, 4));
+          CheckStatus(env, cairo_pattern_status(p), "pattern");
+          return env.Undefined();
+        }));
+  c.Set("patternAddColorStopRGBA", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          cairo_pattern_add_color_stop_rgba(p, Num(info, 1), Num(info, 2), Num(info, 3), Num(info, 4),
+                                            Num(info, 5));
+          CheckStatus(env, cairo_pattern_status(p), "pattern");
+          return env.Undefined();
+        }));
+  // Extend/filter (SurfacePattern methods in gjs — cairo accepts them on any pattern).
+  c.Set("patternSetExtend", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          cairo_pattern_set_extend(p, static_cast<cairo_extend_t>(Int(info, 1)));
+          CheckStatus(env, cairo_pattern_status(p), "pattern");
+          return env.Undefined();
+        }));
+  c.Set("patternGetExtend", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_pattern_get_extend(p));
+        }));
+  c.Set("patternSetFilter", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          cairo_pattern_set_filter(p, static_cast<cairo_filter_t>(Int(info, 1)));
+          CheckStatus(env, cairo_pattern_status(p), "pattern");
+          return env.Undefined();
+        }));
+  c.Set("patternGetFilter", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_pattern_t* p = PatternFromExt(env, info[0]);
+          if (p == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_pattern_get_filter(p));
         }));
   // patternGetType/patternStatus back the L1 pattern from_func subclass fan-out
   // (SolidPattern vs base Pattern), mirroring CairoPattern::from_c_ptr.
@@ -625,7 +760,152 @@ void InitCairo(Napi::Env env, Napi::Object exports) {
           return env.Undefined();
         }));
 
-  // ---- $dispose (Context / Surface / Pattern) ----
+  c.Set("identityMatrix", Napi::Function::New(env, CTX_0(cairo_identity_matrix)));
+  c.Set("newSubPath", Napi::Function::New(env, CTX_0(cairo_new_sub_path)));
+
+  // Point/distance transforms: (x, y) IN-OUT doubles, returned as a 2-array —
+  // the GJS FUNC2FFAFF return shape ([x, y]).
+#define CTX_2FFAFF(NAME, CFN)                                                                 \
+  c.Set(NAME, Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {  \
+          Napi::Env env = info.Env();                                                        \
+          cairo_t* cr = CtxArg(env, info);                                                   \
+          if (cr == nullptr) return env.Undefined();                                         \
+          double x = Num(info, 1), y = Num(info, 2);                                         \
+          CFN(cr, &x, &y);                                                                   \
+          if (!CheckStatus(env, cairo_status(cr), "context")) return env.Undefined();        \
+          Napi::Array a = Napi::Array::New(env, 2);                                          \
+          a.Set(0u, Napi::Number::New(env, x));                                              \
+          a.Set(1u, Napi::Number::New(env, y));                                              \
+          return a;                                                                          \
+        }));
+  CTX_2FFAFF("userToDevice", cairo_user_to_device)
+  CTX_2FFAFF("userToDeviceDistance", cairo_user_to_device_distance)
+  CTX_2FFAFF("deviceToUser", cairo_device_to_user)
+  CTX_2FFAFF("deviceToUserDistance", cairo_device_to_user_distance)
+
+  c.Set("inFill", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_bool_t ret = cairo_in_fill(cr, Num(info, 1), Num(info, 2));
+          if (!CheckStatus(env, cairo_status(cr), "context")) return env.Undefined();
+          return Napi::Boolean::New(env, ret);
+        }));
+  c.Set("inStroke", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_bool_t ret = cairo_in_stroke(cr, Num(info, 1), Num(info, 2));
+          if (!CheckStatus(env, cairo_status(cr), "context")) return env.Undefined();
+          return Napi::Boolean::New(env, ret);
+        }));
+
+  // Path copy/append — a copied path is an OWNED cairo_path_t handle (destroyed
+  // on GC / $dispose via cairo_path_destroy).
+  c.Set("copyPath", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_path_t* path = cairo_copy_path(cr);
+          if (path->status != CAIRO_STATUS_SUCCESS) {
+            cairo_status_t st = path->status;
+            cairo_path_destroy(path);
+            CheckStatus(env, st, "context");
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, path, CairoKind::Path);
+        }));
+  c.Set("copyPathFlat", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_path_t* path = cairo_copy_path_flat(cr);
+          if (path->status != CAIRO_STATUS_SUCCESS) {
+            cairo_status_t st = path->status;
+            cairo_path_destroy(path);
+            CheckStatus(env, st, "context");
+            return env.Undefined();
+          }
+          return MakeCairoHandle(env, path, CairoKind::Path);
+        }));
+  c.Set("appendPath", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_path_t* path = PathFromExt(env, info[1]);
+          if (path == nullptr) return env.Undefined();
+          cairo_append_path(cr, path);
+          CheckStatus(env, cairo_status(cr), "context");
+          return env.Undefined();
+        }));
+
+  // setDash mirrors gjs's setDash_func: holes/undefined entries are skipped, a
+  // non-positive dash throws, an empty array disables dashing.
+  c.Set("setDash", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          if (!info[1].IsArray()) {
+            Napi::TypeError::New(env, "dashes must be an array").ThrowAsJavaScriptException();
+            return env.Undefined();
+          }
+          Napi::Array dashes = info[1].As<Napi::Array>();
+          double offset = Num(info, 2);
+          uint32_t len = dashes.Length();
+          std::vector<double> dashes_c;
+          dashes_c.reserve(len);
+          for (uint32_t i = 0; i < len; ++i) {
+            Napi::Value elem = dashes.Get(i);
+            if (elem.IsUndefined()) continue;
+            double b = elem.ToNumber().DoubleValue();
+            if (b <= 0) {
+              Napi::Error::New(env, "Dash value must be positive").ThrowAsJavaScriptException();
+              return env.Undefined();
+            }
+            dashes_c.push_back(b);
+          }
+          cairo_set_dash(cr, dashes_c.data(), static_cast<int>(dashes_c.size()), offset);
+          CheckStatus(env, cairo_status(cr), "context");
+          return env.Undefined();
+        }));
+  c.Set("getDashCount", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          return Napi::Number::New(env, cairo_get_dash_count(cr));
+        }));
+  // getDash: net-new (GJS ships only getDashCount). Returns [dashes[], offset].
+  c.Set("getDash", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          int count = cairo_get_dash_count(cr);
+          std::vector<double> dashes_c(static_cast<size_t>(count > 0 ? count : 0));
+          double offset = 0;
+          cairo_get_dash(cr, dashes_c.data(), &offset);
+          Napi::Array dashes = Napi::Array::New(env, dashes_c.size());
+          for (size_t i = 0; i < dashes_c.size(); ++i) {
+            dashes.Set(static_cast<uint32_t>(i), Napi::Number::New(env, dashes_c[i]));
+          }
+          Napi::Array out = Napi::Array::New(env, 2);
+          out.Set(0u, dashes);
+          out.Set(1u, Napi::Number::New(env, offset));
+          return out;
+        }));
+
+  // getSource: the pattern belongs to the context — take our own ref so the JS
+  // wrapper owns one (mirrors gjs_cairo_pattern_from_pattern's kept reference).
+  c.Set("getSource", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {
+          Napi::Env env = info.Env();
+          cairo_t* cr = CtxArg(env, info);
+          if (cr == nullptr) return env.Undefined();
+          cairo_pattern_t* p = cairo_get_source(cr);
+          if (!CheckStatus(env, cairo_status(cr), "context")) return env.Undefined();
+          cairo_pattern_reference(p);
+          return MakeCairoHandle(env, p, CairoKind::Pattern);
+        }));
+
+  // ---- $dispose (Context / Surface / Pattern / Path) ----
   // Eagerly destroy the underlying cairo object + mark the handle so the finalizer
   // won't double-free and any further method call throws (a live-handle check).
   c.Set("dispose", Napi::Function::New(env, +[](const Napi::CallbackInfo& info) -> Napi::Value {

--- a/packages/node-gi/node-gi/test/cairo-canvas2d.test.mjs
+++ b/packages/node-gi/node-gi/test/cairo-canvas2d.test.mjs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the cairo canvas2d slice, HEADLESS (no display).
+//
+// Covers the APIs @gjsify/canvas2d-core drives beyond the base drawing slice:
+//  • LinearGradient / RadialGradient (+ addColorStopRGB[A]) as Context sources;
+//  • SurfacePattern (+ setExtend/getExtend/setFilter/getFilter);
+//  • Context: copyPath/copyPathFlat/appendPath (cairo_path_t handles),
+//    identityMatrix, userToDevice/userToDeviceDistance/deviceToUser/
+//    deviceToUserDistance, setDash/getDashCount (+ the net-new getDash),
+//    getSource (concrete-subclass fan-out), inFill/inStroke, newSubPath.
+//
+// gjs is the gold standard, verified two ways:
+//  • BYTE-FOR-BYTE PIXEL PARITY — the same scene (gradients, repeating surface
+//    pattern, dashed stroke, path copy/append round-trip) drawn under `gjs -m`,
+//    written to PNG, decoded back and compared pixel-for-pixel;
+//  • STATE PARITY — a deterministic probe of every new getter/transform runs on
+//    both runtimes and the JSON results must be deeply equal.
+// Both self-skip when gjs is not on PATH (bun/deno legs, or a gjs-less box);
+// runtime-independent invariants are asserted unconditionally.
+//
+// Part of the cross-runtime conformance subset (runs on node / bun / deno).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import cairo from '../cairo.js';
+
+// The deterministic scene, as ONE source of truth: called directly under node-gi,
+// and its own source (drawScene.toString()) is embedded into the `gjs -m` parity
+// child (native cairo) below — so the identical body runs on both.
+function drawScene(cairo) {
+  const W = 96;
+  const H = 72;
+  const surface = new cairo.ImageSurface(cairo.Format.ARGB32, W, H);
+  const cr = new cairo.Context(surface);
+
+  // Linear-gradient background.
+  const lin = new cairo.LinearGradient(0, 0, 0, H);
+  lin.addColorStopRGB(0, 0.95, 0.95, 1);
+  lin.addColorStopRGBA(1, 0.2, 0.25, 0.5, 1);
+  cr.setSource(lin);
+  cr.paint();
+
+  // Radial-gradient disc.
+  const rad = new cairo.RadialGradient(28, 24, 2, 28, 24, 16);
+  rad.addColorStopRGBA(0, 1, 0.9, 0.2, 1);
+  rad.addColorStopRGBA(1, 0.8, 0.2, 0.1, 0);
+  cr.setSource(rad);
+  cr.arc(28, 24, 16, 0, 2 * Math.PI);
+  cr.fill();
+
+  // 8x8 checker tile -> repeating SurfacePattern with NEAREST filter, painted
+  // through a clip (the canvas2d createPattern('repeat') shape).
+  const tile = new cairo.ImageSurface(cairo.Format.ARGB32, 8, 8);
+  const tcr = new cairo.Context(tile);
+  tcr.setSourceRGB(1, 1, 1);
+  tcr.paint();
+  tcr.setSourceRGB(0.1, 0.1, 0.1);
+  tcr.rectangle(0, 0, 4, 4);
+  tcr.fill();
+  tcr.rectangle(4, 4, 4, 4);
+  tcr.fill();
+  tcr.$dispose();
+  tile.flush();
+  const pat = new cairo.SurfacePattern(tile);
+  pat.setExtend(cairo.Extend.REPEAT);
+  pat.setFilter(cairo.Filter.NEAREST);
+  cr.save();
+  cr.rectangle(52, 8, 36, 28);
+  cr.clip();
+  cr.setSource(pat);
+  cr.paint();
+  cr.restore();
+
+  // Dashed stroke (setDash), then dashing disabled again by the empty array.
+  cr.setLineWidth(2);
+  cr.setSourceRGB(0.05, 0.4, 0.1);
+  cr.setDash([6, 3, 2, 3], 1);
+  cr.moveTo(4, 46);
+  cr.lineTo(92, 46);
+  cr.stroke();
+  cr.setDash([], 0);
+
+  // Path copy/append round-trip: build a triangle, copy it, clear, re-append.
+  cr.newPath();
+  cr.moveTo(8, 54);
+  cr.lineTo(28, 54);
+  cr.lineTo(18, 68);
+  cr.closePath();
+  const saved = cr.copyPath();
+  cr.newPath();
+  cr.appendPath(saved);
+  cr.setSourceRGBA(0.2, 0.2, 0.8, 0.9);
+  cr.fill();
+
+  // A flattened curve copied under a transform, appended after identityMatrix
+  // (exercises copyPathFlat + the user-space copy semantics).
+  cr.save();
+  cr.translate(40, 50);
+  cr.scale(1.5, 1);
+  cr.newPath();
+  cr.moveTo(0, 8);
+  cr.curveTo(6, -4, 18, 20, 24, 8);
+  const flat = cr.copyPathFlat();
+  cr.restore();
+  cr.identityMatrix();
+  cr.newPath();
+  cr.appendPath(flat);
+  cr.setSourceRGB(0, 0, 0);
+  cr.setLineWidth(1);
+  cr.stroke();
+
+  // newSubPath: two disjoint circles in ONE path (no connecting segment).
+  cr.newPath();
+  cr.newSubPath();
+  cr.arc(70, 58, 6, 0, 2 * Math.PI);
+  cr.newSubPath();
+  cr.arc(84, 58, 4, 0, 2 * Math.PI);
+  cr.setSourceRGBA(0.6, 0.1, 0.5, 1);
+  cr.fill();
+
+  cr.$dispose();
+  surface.flush();
+  return surface;
+}
+
+// Deterministic state probe — every value is computed by cairo itself
+// (font/zlib/display-independent), so gjs and node-gi must agree exactly.
+// Uses ONLY methods GJS's native cairo exposes (no getDash here — see below).
+function probeState(cairo) {
+  const out = {};
+  const surface = new cairo.ImageSurface(cairo.Format.ARGB32, 40, 30);
+  const cr = new cairo.Context(surface);
+
+  // Matrix point/distance transforms under translate+scale.
+  cr.translate(10, 20);
+  cr.scale(2, 3);
+  out.userToDevice = cr.userToDevice(1, 1);
+  out.userToDeviceDistance = cr.userToDeviceDistance(1, 1);
+  out.deviceToUser = cr.deviceToUser(12, 23);
+  out.deviceToUserDistance = cr.deviceToUserDistance(2, 3);
+  cr.identityMatrix();
+  out.identityUserToDevice = cr.userToDevice(5, 6);
+
+  // inFill / inStroke against a rectangle path.
+  cr.newPath();
+  cr.rectangle(2, 2, 10, 8);
+  out.inFillInside = cr.inFill(5, 5);
+  out.inFillOutside = cr.inFill(30, 25);
+  cr.setLineWidth(4);
+  out.inStrokeOnEdge = cr.inStroke(2, 5);
+  out.inStrokeCenter = cr.inStroke(7, 6);
+
+  // Dash state machine, incl. the GJS setDash validation semantics.
+  out.dashCountInitial = cr.getDashCount();
+  cr.setDash([4, 2], 0.5);
+  out.dashCount = cr.getDashCount();
+  let dashErr = '';
+  try {
+    cr.setDash([1, -1], 0);
+  } catch (e) {
+    dashErr = String(e.message);
+  }
+  out.dashErr = dashErr;
+  cr.setDash([1, undefined, 2], 0); // undefined entries are skipped (GJS)
+  out.dashCountSkip = cr.getDashCount();
+  cr.setDash([], 0); // empty array disables dashing
+  out.dashCountOff = cr.getDashCount();
+
+  // Gradients + surface pattern types, extend/filter get/set.
+  const lin = new cairo.LinearGradient(0, 0, 10, 0);
+  lin.addColorStopRGB(0, 1, 0, 0);
+  lin.addColorStopRGBA(1, 0, 0, 1, 0.5);
+  out.linType = lin.getType();
+  const rad = new cairo.RadialGradient(0, 0, 1, 5, 5, 10);
+  rad.addColorStopRGBA(0, 0, 1, 0, 1);
+  out.radType = rad.getType();
+  const tile = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  const sp = new cairo.SurfacePattern(tile);
+  out.spType = sp.getType();
+  out.spExtendDefault = sp.getExtend();
+  sp.setExtend(cairo.Extend.REFLECT);
+  out.spExtend = sp.getExtend();
+  out.spFilterDefault = sp.getFilter();
+  sp.setFilter(cairo.Filter.NEAREST);
+  out.spFilter = sp.getFilter();
+
+  // getSource fans out to the concrete pattern class on both runtimes: the
+  // surface-pattern source must expose getFilter() (SurfacePattern in gjs).
+  cr.setSource(lin);
+  out.sourceTypeLinear = cr.getSource().getType();
+  cr.setSource(sp);
+  out.sourceTypeSurface = cr.getSource().getType();
+  out.sourceFilter = cr.getSource().getFilter();
+  cr.setSourceRGB(1, 0, 0);
+  out.sourceTypeSolid = cr.getSource().getType();
+
+  // Path copy/append round-trip via extents.
+  cr.newPath();
+  cr.moveTo(1, 2);
+  cr.lineTo(11, 2);
+  cr.lineTo(11, 9);
+  cr.closePath();
+  const before = cr.pathExtents();
+  const copied = cr.copyPath();
+  cr.newPath();
+  out.emptyExtents = cr.pathExtents();
+  cr.appendPath(copied);
+  out.roundTripExtents = cr.pathExtents();
+  out.extentsEqual = JSON.stringify(before) === JSON.stringify(out.roundTripExtents);
+  const flat = cr.copyPathFlat();
+  cr.newPath();
+  cr.appendPath(flat);
+  out.flatExtents = cr.pathExtents();
+
+  // newSubPath clears the current point (the roundRect/arc idiom).
+  cr.newPath();
+  cr.moveTo(3, 3);
+  out.hasPointBeforeNewSub = cr.hasCurrentPoint();
+  cr.newSubPath();
+  out.hasPointAfterNewSub = cr.hasCurrentPoint();
+
+  cr.$dispose();
+  return out;
+}
+
+const haveGjs = spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+test('gradient/pattern classes: hierarchy + handle wiring', () => {
+  const lin = new cairo.LinearGradient(0, 0, 10, 10);
+  assert.ok(lin instanceof cairo.LinearGradient);
+  assert.ok(lin instanceof cairo.Gradient);
+  assert.ok(lin instanceof cairo.Pattern);
+  assert.equal(lin.getType(), cairo.PatternType.LINEAR);
+
+  const rad = new cairo.RadialGradient(0, 0, 1, 5, 5, 10);
+  assert.ok(rad instanceof cairo.Gradient);
+  assert.equal(rad.getType(), cairo.PatternType.RADIAL);
+
+  const tile = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  const sp = new cairo.SurfacePattern(tile);
+  assert.ok(sp instanceof cairo.SurfacePattern);
+  assert.ok(sp instanceof cairo.Pattern);
+  assert.equal(sp.getType(), cairo.PatternType.SURFACE);
+
+  lin.$dispose();
+  rad.$dispose();
+  sp.$dispose();
+  tile.$dispose();
+});
+
+test('getSource returns the concrete pattern subclass', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 8, 8);
+  const cr = new cairo.Context(s);
+
+  cr.setSourceRGB(1, 0, 0);
+  assert.ok(cr.getSource() instanceof cairo.SolidPattern);
+
+  const lin = new cairo.LinearGradient(0, 0, 8, 0);
+  cr.setSource(lin);
+  assert.ok(cr.getSource() instanceof cairo.LinearGradient);
+
+  const rad = new cairo.RadialGradient(0, 0, 1, 4, 4, 8);
+  cr.setSource(rad);
+  assert.ok(cr.getSource() instanceof cairo.RadialGradient);
+
+  const tile = new cairo.ImageSurface(cairo.Format.ARGB32, 2, 2);
+  const sp = new cairo.SurfacePattern(tile);
+  cr.setSource(sp);
+  const src = cr.getSource();
+  assert.ok(src instanceof cairo.SurfacePattern);
+  // The returned wrapper owns its own ref — usable after the original goes away.
+  sp.$dispose();
+  assert.equal(src.getType(), cairo.PatternType.SURFACE);
+  assert.equal(src.getExtend(), cairo.Extend.NONE);
+
+  cr.$dispose();
+  s.$dispose();
+});
+
+test('setDash/getDash/getDashCount round-trip (getDash is net-new)', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 4, 4);
+  const cr = new cairo.Context(s);
+  assert.equal(cr.getDashCount(), 0);
+  cr.setDash([4, 2], 0.5);
+  assert.equal(cr.getDashCount(), 2);
+  assert.deepEqual(cr.getDash(), [[4, 2], 0.5]);
+  assert.throws(() => cr.setDash([0], 0), /Dash value must be positive/);
+  assert.throws(() => cr.setDash([1, -2], 0), /Dash value must be positive/);
+  cr.setDash([], 0);
+  assert.deepEqual(cr.getDash(), [[], 0]);
+  cr.$dispose();
+  s.$dispose();
+});
+
+test('copyPath handles are live cairo.Path objects; appendPath typechecks', () => {
+  const s = new cairo.ImageSurface(cairo.Format.ARGB32, 8, 8);
+  const cr = new cairo.Context(s);
+  cr.rectangle(1, 1, 4, 4);
+  const p = cr.copyPath();
+  assert.ok(p instanceof cairo.Path);
+  const pf = cr.copyPathFlat();
+  assert.ok(pf instanceof cairo.Path);
+  assert.throws(() => cr.appendPath({}), /expected a cairo\.Path/);
+  // A wrong-kind handle (a Surface) is rejected by the native typecheck.
+  assert.throws(() => cr.appendPath(s), /expected a live cairo\.Path/);
+  cr.newPath();
+  cr.appendPath(p);
+  assert.deepEqual(cr.pathExtents(), [1, 1, 5, 5]);
+  cr.$dispose();
+  s.$dispose();
+});
+
+test('scene invariants: repeated tile + dash gap pixels (AA-independent)', () => {
+  const s = drawScene(cairo);
+  const data = s.getData();
+  const stride = s.getStride();
+  const px = (x, y) => [...data.slice(y * stride + x * 4, y * stride + x * 4 + 4)];
+  // Checker tile (pattern origin = surface origin; dark squares at tile-mod
+  // (0..3,0..3)+(4..7,4..7)): dark interior is exactly rgb(0.1,0.1,0.1) -> 25
+  // per channel; the light one pure white. (58,10) ≡ (2,2) dark, (54,10) ≡
+  // (6,2) light, (66,18) ≡ (2,2) one repeat period later.
+  assert.deepEqual(px(58, 10), [25, 25, 25, 255], 'dark checker square (B,G,R,A)');
+  assert.deepEqual(px(54, 10), [255, 255, 255, 255], 'light checker square');
+  assert.deepEqual(px(66, 18), [25, 25, 25, 255], 'repeat period dark square');
+  s.$dispose();
+});
+
+// BYTE-FOR-BYTE pixel parity vs gjs: identical scene, drawn by gjs's native cairo,
+// written to PNG, decoded back with node-gi, compared to node-gi's own render.
+test('pixel parity with gjs (byte-for-byte)', { skip: haveGjs ? false : 'gjs not on PATH' }, () => {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-cairo-c2d-gjs-'));
+  try {
+    const gjsPng = join(dir, 'gjs.png');
+    const gjsScript = join(dir, 'draw.js');
+    const src =
+      `import cairo from 'cairo';\n` +
+      `const drawScene = ${drawScene.toString()};\n` +
+      `const s = drawScene(cairo);\n` +
+      `s.writeToPNG(${JSON.stringify(gjsPng)});\n`;
+    writeFileSync(gjsScript, src);
+    const res = spawnSync('gjs', ['-m', gjsScript], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs draw failed: ${res.stderr}`);
+    assert.ok(existsSync(gjsPng), 'gjs produced a PNG');
+
+    const fromGjs = cairo.ImageSurface.createFromPNG(gjsPng);
+    const own = drawScene(cairo);
+    const a = fromGjs.getData();
+    const b = own.getData();
+    assert.equal(a.length, b.length, 'same pixel-buffer length');
+    assert.deepEqual(Buffer.from(a), Buffer.from(b), 'gjs and node-gi pixels are byte-identical');
+    fromGjs.$dispose();
+    own.$dispose();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// STATE parity vs gjs: the probe runs on both runtimes; results must deep-equal.
+test('state parity with gjs (transforms, dash, patterns, paths)', {
+  skip: haveGjs ? false : 'gjs not on PATH',
+}, () => {
+  const dir = mkdtempSync(join(tmpdir(), 'nodegi-cairo-c2d-probe-'));
+  try {
+    const gjsScript = join(dir, 'probe.js');
+    const src =
+      `import cairo from 'cairo';\n` +
+      `const probeState = ${probeState.toString()};\n` +
+      `print(JSON.stringify(probeState(cairo)));\n`;
+    writeFileSync(gjsScript, src);
+    const res = spawnSync('gjs', ['-m', gjsScript], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `gjs probe failed: ${res.stderr}`);
+    const fromGjs = JSON.parse(res.stdout.trim());
+    const own = JSON.parse(JSON.stringify(probeState(cairo)));
+    assert.deepEqual(own, fromGjs, 'gjs and node-gi state probes are identical');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Bind the Cairo surface `@gjsify/canvas2d-core` (headless Canvas 2D) draws through, in the node-gi foreign-struct cairo binding — closing the `this._ctx.copyPath is not a function` / missing-gradient class of failures on the Axis-5 reverse bridge.

## What's bound (`src/cairo.cc` + `cairo.js` + `cairo.d.ts`)

- **Gradients** — `LinearGradient` (`cairo_pattern_create_linear`) + `RadialGradient` (`cairo_pattern_create_radial`), both with `addColorStopRGB`/`addColorStopRGBA` on a shared `Gradient` base (the gjs class shape), usable via `Context.setSource`.
- **`SurfacePattern`** (`cairo_pattern_create_for_surface`) with `setExtend`/`getExtend`/`setFilter`/`getFilter` (as in gjs, these live on `SurfacePattern`).
- **`Context`** — `copyPath`/`copyPathFlat`/`appendPath` over a new owned `cairo_path_t` handle kind (freed via `cairo_path_destroy`; borrowed paths are **copied** with the gjs `CairoPath::copy_ptr` dummy-context trick since `cairo_path_t` is not ref-counted), `identityMatrix`, `newSubPath`, `userToDevice`/`userToDeviceDistance`/`deviceToUser`/`deviceToUserDistance` (gjs `[x, y]` return shape), `setDash` (gjs validation semantics: skip `undefined` entries, throw `Dash value must be positive`, empty array disables) + `getDashCount` + a **net-new `getDash`** (documented — gjs ships only `getDashCount`), `inFill`/`inStroke`, and `getSource` with concrete-subclass fan-out (mirrors `gjs_cairo_pattern_from_pattern`).
- **Foreign seam** — `cairo.Path` registered as a foreign struct (copy-on-borrow to/from), matching `gjs_cairo_path_init`.

## Verification (headless, gjs = gold standard)

- `test/cairo-canvas2d.test.mjs` (7 tests): a scene using linear+radial gradients, a repeating NEAREST-filtered surface pattern, dashed strokes, path copy/append round-trips, `copyPathFlat` under a transform + `identityMatrix`, and `newSubPath` renders **byte-for-byte identical to `gjs -m`** (PNG round-trip decode + full-buffer compare); a deterministic state probe over every new getter/transform (matrix transforms, dash counts + error message, extend/filter defaults+set, `getSource` types, path-extents round-trips) **deep-equals gjs's output** on the identical source.
- Conformance program `cairo.conf.mjs` extended with the same coverage; golden regenerated from gjs — **green on gjs / node / bun / deno**.
- The new test file joins the bun/deno cross-runtime subset (verified per-file green on both).

## Consumer signal (not the gate)

`scripts/node-gi-consumer-harness.mjs @gjsify/canvas2d-core --runtimes node`: **before 134/193 (59 failed; the copyPath TypeError aborted whole suites), after 529/543 (14 failed; 350 more tests even run now)**. The residual 14 are engine marshalling gaps, not cairo-binding gaps: 11× `PangoLayout.get_pixel_extents: caller-allocates OUT parameter type is not yet supported` (text metrics) + 3× `Unsupported interface IN argument` (the putImageData Uint8Array→GBytes class) — both queued as separate follow-ups (PR 2).

## No regressions

- `npm test` 375 tests / 0 fail (13 pre-existing display-dependent skips, identical on origin/main), `test:gc` 0 fail.
- `test:conformance` full matrix all green (18 programs × gjs/node/bun/deno, only the 2 committed LEDGERED entries).
- `test:bun` 35/35, `test:deno` 35/35.

Still deferred in the cairo binding (unchanged, documented in README): region objects, PDF/SVG/PS surfaces, text/font ops (`showText`/`selectFontFace` — canvas2d text rides PangoCairo instead).

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq
