### PR TITLE
feat(node-gi): prove Gtk.GLArea GL context + WebGL draw on node-gi

### DIFF
--- a/docs/reports/node-gi-consumer-survey.md
+++ b/docs/reports/node-gi-consumer-survey.md
@@ -114,6 +114,15 @@ Conformance program `async-gio-await` (top-level awaits on a GLib timeout, an id
 ### P6 — GStreamer / display-bound
 `webaudio` (GStreamer AudioContext; bespoke `test.mts` with no `run()` summary), `webrtc` (also needs its Vala bridge, P5). Need GStreamer typelibs; low priority.
 
+> The **GL/display gate itself is PROVEN on node-gi**: a `Gtk.GLArea` realizes with a live, CURRENT
+> OpenGL ES 3.2 context under headless software GL (Xvfb/X11 + mesa llvmpipe, `GSK_RENDERER=cairo`
+> + `LIBGL_ALWAYS_SOFTWARE=1`), the `gwebgl` Vala bridge draws + reads pixels back through it, and
+> the FULL `@gjsify/webgl` `WebGLBridge` (TS `WebGLRenderingContext`) clears + reads back through
+> the same stack — all byte-identical to `gjs -m`. See
+> `packages/node-gi/node-gi/test/webgl-glarea.test.mjs` + the node-gi README
+> `### WebGL / Gtk.GLArea`. The remaining WebGL-on-node work is breadth
+> (shader/buffer/texture — a three.js consumer), not the GL context.
+
 ### P7 — Constructor / registerClass
 `worker_threads`: `MessagePort … Constructor cannot be called`. A node-gi native-constructor gap for the `MessagePort`/`MessageChannel` classes (compounded by P1 for the async message delivery).
 

--- a/packages/node-gi/node-gi/.gitignore
+++ b/packages/node-gi/node-gi/.gitignore
@@ -10,3 +10,4 @@ conformance/dist/
 .gi-tests/
 .tmp-c2d-*/
 .tmp-eb-*/
+.tmp-webgl-*/

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -786,3 +786,56 @@ xvfb-run -a dbus-run-session -- \
 `GJSIFY_BIN` must point at the WORKSPACE-built `@gjsify/cli` (`packages/infra/cli/lib/index.js`),
 not the published `@gjsify/cli` — the fixture is built with current source, which
 carries this session's bundler fixes the published `0.18.0` predates.
+### WebGL / `Gtk.GLArea` (the gwebgl seam)
+
+**Definitive: a `Gtk.GLArea` realizes and hands JS a LIVE, CURRENT GL context
+under node-gi on a headless software-GL display.** Verified end-to-end by
+`test/webgl-glarea.test.mjs` + the ONE dual-runtime source
+`fixtures/webgl-glarea-app.ts`: a presented `Gtk.ApplicationWindow` holding a
+`Gtk.GLArea` configured exactly like `@gjsify/webgl`'s `WebGLBridge`
+(`set_use_es(true)`, `set_required_version(3, 2)`, depth + stencil) realizes
+with `get_error() === null`, an **OpenGL ES 3.2** context
+(`Gdk.GLContext.get_current()` non-null in both `realize` and `render`), and
+the `gwebgl` Vala bridge (`new Gwebgl.WebGLRenderingContextBase()` — the native
+class `@gjsify/webgl` wraps) works through it: `getString(GL_VERSION/…)`, a
+`getParameterx` **GVariant** round-trip, and a real WebGL draw —
+`clearColor(1,0,0,1)` + `clear` + `readPixels` reading back the exact
+`255,0,0,255` pixel. The committed golden is byte-identical between `gjs -m`
+and `node` (the gjs gold-standard leg re-proves it wherever `gjs` is present;
+`NODE_GI_WEBGL_SKIP_GJS=1` skips that leg).
+
+The GL/display env the golden is pinned to (software GL, no GPU needed):
+
+```bash
+# X11 (Xvfb or a real display) + mesa llvmpipe + GTK compositing off GL:
+xvfb-run -a dbus-run-session -- \
+  env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
+    NODE_GI_NATIVE=build node --test test/webgl-glarea.test.mjs
+# GL under llvmpipe: "OpenGL ES 3.2 Mesa …" / "llvmpipe (LLVM …)".
+```
+
+**The FULL `@gjsify/webgl` `WebGLBridge` runs too** (same test file, second
+fixture `fixtures/webgl-bridge-app.ts`): the complete TS WebGL stack UNCHANGED —
+`WebGLBridge` (a `registerClass` `Gtk.GLArea` subclass), `onReady` handing out
+`HTMLCanvasElement` + `WebGLRenderingContext` (constants GHashTable, the
+`_init()` `getParameterx` GVariant reads, eager WebGL1+2 context construction),
+and browser-standard `clearColor(0,0,1,1)` + `clear` + `readPixels` reading the
+blue clear back (`bridge-pixel(0,0): 0,0,255,255`), byte-identical gjs ↔ node.
+Shader/buffer/texture breadth (a three.js triangle/teapot) is the remaining
+follow-up — the seam + context stack are proven.
+
+The tests self-skip without a display, without a `gjsify` CLI, or without the
+committed `Gwebgl-0.1` prebuild (`packages/framework/webgl/prebuilds/linux-*`,
+which the test itself puts on `GI_TYPELIB_PATH`/`LD_LIBRARY_PATH`); the bridge
+test additionally skips when `@gjsify/webgl` is not built. The fixture build
+needs a WORKSPACE-built `@gjsify/cli` (point `GJSIFY_BIN` at
+`packages/infra/cli/lib/index.js` after
+`gjsify workspace @gjsify/cli build --with-dependencies`), like
+`canvas2d-bridge`; the gjs gold-standard leg additionally needs the workspace
+register libs built (`--app gjs` force-inlines `<pkg>/register`). Two engine
+gaps this spike fixed on the way (headless regression coverage in
+`test/gerror-return.test.mjs`): GError-typed RETURNS
+(`Gtk.GLArea.get_error()` — `GI_TYPE_TAG_ERROR` → a field-readable GLib.Error
+boxed) and literal-first method-name resolution (Vala GIRs carry camelCase
+names — Gwebgl's `getString` — which the unconditional camelCase→snake_case
+alias destroyed; the engine now resolves the literal name first, alias second).

--- a/packages/node-gi/node-gi/fixtures/webgl-bridge-app.ts
+++ b/packages/node-gi/node-gi/fixtures/webgl-bridge-app.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+//
+// The FULL `@gjsify/webgl` WebGLBridge on node-gi — ONE source, two runtimes.
+//
+//   gjsify build … --app gjs   → native gi:// under GJS
+//   gjsify build … --app node  → @gjsify/node-gi under Node.js
+//
+// Where `webgl-glarea-app.ts` proves the RAW seam (Gtk.GLArea + the gwebgl
+// native class), this fixture drives the complete TS WebGL stack UNCHANGED:
+// `WebGLBridge` (a `Gtk.GLArea` subclass via `GObject.registerClass`) realizes,
+// `onReady` hands out the standard `HTMLCanvasElement` + `WebGLRenderingContext`
+// (whose construction alone exercises a broad marshalling surface —
+// `new Gwebgl.WebGLRenderingContext({})`, `get_webgl_constants()` (a GHashTable
+// return), the `_init()` `getParameterx` GVariant reads, texture-unit setup —
+// AND eagerly creates the WebGL2 context too), and the browser-standard calls
+// `gl.clearColor(0,0,1,1)` + `gl.clear(gl.COLOR_BUFFER_BIT)` +
+// `gl.readPixels(…)` read the blue clear back off the GL framebuffer:
+// `bridge-pixel(0,0): 0,0,255,255` in the committed golden, byte-identical
+// between `gjs -m` and `node`.
+//
+// Every stdout line is DETERMINISTIC; diagnostics go to stderr. `print` is
+// ambient under GJS and injected by `--globals auto` for the node build.
+//
+// Reference: packages/framework/webgl/src/ts/webgl-bridge.ts (the widget under
+// test), showcases/dom/three-* (the consumer shape this unblocks on node).
+
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import { WebGLBridge } from '@gjsify/webgl';
+
+const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiWebGLBridge',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+});
+
+let readySeen = false;
+
+app.connect('activate', () => {
+    try {
+        print('activated');
+        const win = new Gtk.ApplicationWindow({ application: app });
+        win.set_default_size(128, 96);
+
+        // The REAL bridge widget — rAF/performance globals wired like a consumer.
+        const bridge = new WebGLBridge();
+        bridge.installGlobals();
+        bridge.onReady((canvas, gl) => {
+            readySeen = true;
+            print(`ready: canvas ${canvas.width > 0 && canvas.height > 0 ? 'sized' : 'empty'}`);
+            // The browser-standard WebGL draw + read-back through the TS stack.
+            gl.clearColor(0, 0, 1, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+            const px = new Uint8Array(4);
+            gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+            print(`bridge-pixel(0,0): ${Array.from(px).join(',')}`);
+        });
+
+        win.set_child(bridge);
+        win.present();
+
+        // Quit once onReady ran (plus one extra frame); bounded safety cap.
+        let ticks = 0;
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+            ticks++;
+            bridge.queue_render();
+            if ((readySeen && ticks >= 2) || ticks >= 80) {
+                print(`ready: ${readySeen ? 'fired' : 'MISSING'}`);
+                print('quit');
+                app.quit();
+                return GLib.SOURCE_REMOVE;
+            }
+            return GLib.SOURCE_CONTINUE;
+        });
+    } catch (error) {
+        // Deterministic failure line — a golden mismatch names the cause.
+        print(`activate-error: ${error instanceof Error ? error.message : String(error)}`);
+        app.quit();
+    }
+});
+
+print('webgl-bridge: start');
+app.run([]); // top-level blocking run (no async wrapper — the node-gtk #442 caveat)
+print('done');
+
+// Force a clean exit(0) on BOTH runtimes: under node-gi the mapped GLArea's live
+// GdkFrameClock stays an active GLib source after app.quit() (the documented
+// lifetime divergence vs gjs — an active source holds the process).
+process.exit(0);

--- a/packages/node-gi/node-gi/fixtures/webgl-glarea-app.ts
+++ b/packages/node-gi/node-gi/fixtures/webgl-glarea-app.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+//
+// The @gjsify/node-gi Gtk.GLArea / WebGL spike proof — ONE source, two runtimes.
+//
+//   gjsify build … --app gjs   → native gi:// Gtk/Gwebgl under GJS
+//   gjsify build … --app node  → @gjsify/node-gi under Node.js
+//
+// THE question this answers: can a `Gtk.GLArea` be realized and hand JS a LIVE,
+// CURRENT GL context under the node-gi reverse bridge on a headless/software-GL
+// display? The GLArea is configured exactly like `@gjsify/webgl`'s `WebGLBridge`
+// (`set_use_es(true)`, `set_required_version(3, 2)`, depth + stencil), put in a
+// presented `Gtk.ApplicationWindow`, and driven through realize → render:
+//
+//   - on `realize`: `make_current()`, `get_error()` (the GError-return
+//     marshalling path), `get_context()` (ES-ness + version), and
+//     `Gdk.GLContext.get_current()` — the CURRENT-context proof;
+//   - on `render`: `Gdk.GLContext.get_current()` again (GTK made the context
+//     current for the frame), then the `gwebgl` Vala bridge — the SAME native
+//     class `@gjsify/webgl`'s `WebGLRenderingContext` wraps:
+//     `new Gwebgl.WebGLRenderingContextBase()` (a literal camelCase Vala GIR —
+//     the method-name-resolution path), `getString(GL_VERSION/RENDERER/VENDOR)`,
+//     a `getParameterx` GVariant round-trip, and a REAL WebGL draw:
+//     `clearColor(1,0,0,1)` + `clear(COLOR_BUFFER_BIT)` + `readPixels` of one
+//     pixel — asserted 255,0,0,255, the display-independent render proof;
+//   - quits from a `GLib.timeout_add` once render + the GL checks are in (a
+//     bounded safety cap otherwise), so `app.run()` returns cleanly (exit 0).
+//
+// Every stdout line is DETERMINISTIC (normalized ok/none/yes booleans + the fixed
+// clear-color pixel) so the gjs output is byte-identical to the node output — the
+// committed-golden pattern of `canvas2d-bridge`/`example-gtk`. The HOST-dependent
+// GL strings (llvmpipe/Mesa versions, texture limits) go to STDERR via `printerr`
+// as diagnostics for CI logs. `print`/`printerr` are ambient under GJS and
+// injected by `--globals auto` (`@gjsify/node-gi/globals`) for the node build.
+//
+// Reference: packages/framework/webgl/src/ts/webgl-bridge.ts (the GLArea setup
+// this mirrors), refs/gjs (g_application_run semantics).
+
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import Gdk from 'gi://Gdk?version=4.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import Gwebgl from 'gi://Gwebgl?version=0.1';
+
+// GL enums (constants only — no GL headers needed).
+const GL_VENDOR = 0x1f00;
+const GL_RENDERER = 0x1f01;
+const GL_VERSION = 0x1f02;
+const GL_SHADING_LANGUAGE_VERSION = 0x8b8c;
+const GL_MAX_TEXTURE_SIZE = 0x0d33;
+const GL_COLOR_BUFFER_BIT = 0x4000;
+const GL_RGBA = 0x1908;
+const GL_UNSIGNED_BYTE = 0x1401;
+
+const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiWebGLGLArea',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+});
+
+let renderChecked = false;
+
+app.connect('activate', () => {
+    try {
+        print('activated');
+
+        const win = new Gtk.ApplicationWindow({ application: app });
+        win.set_default_size(128, 96);
+
+        // The exact WebGLBridge GLArea configuration (webgl-bridge.ts ctor).
+        const area = new Gtk.GLArea();
+        area.set_use_es(true);
+        area.set_required_version(3, 2);
+        area.set_has_depth_buffer(true);
+        area.set_has_stencil_buffer(true);
+
+        area.connect('realize', () => {
+            area.make_current();
+            // GError-typed return: null when context creation succeeded.
+            const error = area.get_error();
+            print(`realize: error ${error === null ? 'none' : 'SET'}`);
+            const ctx = area.get_context();
+            const [major, minor] = ctx ? ctx.get_version() : [0, 0];
+            const es32 = major > 3 || (major === 3 && minor >= 2);
+            print(`realize: context ${ctx ? 'non-null' : 'NULL'} es=${ctx ? ctx.get_use_es() : false} version>=3.2 ${es32}`);
+            // THE headline probe: is the GLArea's GL context CURRENT for JS?
+            const current = Gdk.GLContext.get_current();
+            print(`realize: current ${current !== null ? 'yes' : 'NO'}`);
+        });
+
+        area.connect('render', () => {
+            if (renderChecked) return true;
+            renderChecked = true;
+            print(`render: current ${Gdk.GLContext.get_current() !== null ? 'yes' : 'NO'}`);
+
+            // The gwebgl Vala bridge — the native class @gjsify/webgl wraps.
+            const gl = new Gwebgl.WebGLRenderingContextBase();
+            const version = gl.getString(GL_VERSION);
+            const renderer = gl.getString(GL_RENDERER);
+            const vendor = gl.getString(GL_VENDOR);
+            const glsl = gl.getString(GL_SHADING_LANGUAGE_VERSION);
+            // Host-dependent — diagnostics only (stderr), normalized ok on stdout.
+            printerr(`[webgl-glarea] GL_VERSION=${version}`);
+            printerr(`[webgl-glarea] GL_RENDERER=${renderer}`);
+            printerr(`[webgl-glarea] GL_VENDOR=${vendor}`);
+            printerr(`[webgl-glarea] GLSL=${glsl}`);
+            print(`gl-strings: ${version.length > 0 && renderer.length > 0 && vendor.length > 0 && glsl.length > 0 ? 'ok' : 'EMPTY'}`);
+
+            // GVariant-returning method round-trip (the webgl-context-base.ts
+            // getParameterx path).
+            const maxTex = gl.getParameterx(GL_MAX_TEXTURE_SIZE)?.deepUnpack() as number;
+            printerr(`[webgl-glarea] MAX_TEXTURE_SIZE=${maxTex}`);
+            print(`gl-param: max-texture-size ${typeof maxTex === 'number' && maxTex > 0 ? 'positive' : 'BAD'}`);
+
+            // A REAL WebGL draw + read-back: clear to opaque red, read one pixel.
+            gl.clearColor(1, 0, 0, 1);
+            gl.clear(GL_COLOR_BUFFER_BIT);
+            const px = gl.readPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, new GLib.Variant('ay', [0, 0, 0, 0]));
+            print(`pixel(0,0): ${Array.from(px).join(',')}`);
+            return true;
+        });
+
+        win.set_child(area);
+        win.present();
+        area.queue_render();
+
+        // Quit once the render checks are in, plus one extra frame; a bounded
+        // safety cap quits regardless so run() always returns.
+        let ticks = 0;
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+            ticks++;
+            area.queue_render();
+            if ((renderChecked && ticks >= 2) || ticks >= 80) {
+                print(`render: ${renderChecked ? 'fired' : 'MISSING'}`);
+                print('quit');
+                app.quit();
+                return GLib.SOURCE_REMOVE;
+            }
+            return GLib.SOURCE_CONTINUE;
+        });
+    } catch (error) {
+        // Surface a failure as a deterministic line so a golden mismatch points
+        // at the cause instead of hanging the loop.
+        print(`activate-error: ${error instanceof Error ? error.message : String(error)}`);
+        app.quit();
+    }
+});
+
+print('webgl-glarea: start');
+app.run([]); // top-level blocking run (no async wrapper — the node-gtk #442 caveat)
+print('done');
+
+// Force a clean exit(0) on BOTH runtimes: under node-gi a mapped GLArea's live
+// GdkFrameClock stays an active GLib source after app.quit(), which the uv-driven
+// auto-pump keeps mirroring onto libuv (the documented lifetime divergence vs
+// gjs — an active GLib source holds the process, setInterval semantics).
+process.exit(0);

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -1126,7 +1126,11 @@ function wrapInstance(handle, userProto) {
       // they resolve it here from the registry, per-class). Bound to this instance.
       const promisified = resolvePromisified(handle, camelToSnake(prop));
       if (promisified !== undefined) return (...args) => promisified.apply(proxy, args);
-      return (...args) => wrapReturn(native.callMethod(handle, camelToSnake(prop), unwrapArgs(args)));
+      // Pass the LITERAL accessor name — the engine resolves it verbatim first
+      // (GJS fidelity: GIR names are exposed as-is, incl. Vala camelCase like
+      // Gwebgl's `getString`) and only falls back to the snake_case alias.
+      // Converting here would destroy a literal camelCase GI name.
+      return (...args) => wrapReturn(native.callMethod(handle, prop, unwrapArgs(args)));
     },
     set(t, prop, value) {
       if (typeof prop === 'string') {

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -1000,10 +1000,31 @@ Napi::Value CallFunction(const Napi::CallbackInfo& info) {
   return result;
 }
 
+// The JS-side camelCase → snake_case alias (gi.js camelToSnake), mirrored here so
+// method resolution can try the LITERAL introspected name first and only fall
+// back to the alias. GJS exposes GI method names VERBATIM — a Vala-generated GIR
+// carries camelCase names (Gwebgl's `getString`), which an unconditional
+// camelCase→snake conversion destroys (the webgl-glarea spike wall).
+static std::string CamelToSnake(const std::string& name) {
+  std::string out;
+  out.reserve(name.size() + 4);
+  for (char c : name) {
+    if (c >= 'A' && c <= 'Z') {
+      out += '_';
+      out += static_cast<char>(c - 'A' + 'a');
+    } else {
+      out += c;
+    }
+  }
+  return out;
+}
+
 // callMethod(handle, methodName, args?: unknown[]) -> unknown
 // Resolve an instance method by walking the instance's GIObjectInfo (own +
 // implemented-interface methods at each level, then up the parent chain), then
 // invoke it with the instance prepended. The Node twin of `obj.method(...)`.
+// The LITERAL name is resolved first (GJS fidelity — GIR names are exposed
+// verbatim, incl. Vala camelCase); the snake_case alias is the fallback.
 Napi::Value CallMethod(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 2 || !info[1].IsString()) {
@@ -1040,38 +1061,50 @@ Napi::Value CallMethod(const Napi::CallbackInfo& info) {
     return env.Null();
   }
 
-  // Search own + implemented-interface methods at each level, then the parent.
-  GIFunctionInfo* func = nullptr;
-  while (objInfo != nullptr) {
-    GIBaseInfo* declarer = nullptr;
-    func = gi_object_info_find_method_using_interfaces(objInfo, method.c_str(), &declarer);
-    if (declarer != nullptr) gi_base_info_unref(declarer);
-    if (func != nullptr) break;
-    GIObjectInfo* parent = gi_object_info_get_parent(objInfo);
-    gi_base_info_unref(objInfo);
-    objInfo = parent;
-  }
-  if (objInfo != nullptr) gi_base_info_unref(objInfo);
-
-  // The concrete GType may implement introspectable interfaces that its nearest
+  // Resolve one candidate name: own + implemented-interface methods at each
+  // level, then the parent chain; then the live GType's interface list (the
+  // concrete GType may implement introspectable interfaces its nearest
   // introspectable ANCESTOR's info does not list — e.g. a private GLocalFile
-  // (no info; ancestor = GObject) implementing GFile. Scan the live GType's
-  // interface list directly so interface methods (g_file_get_path) resolve.
-  if (func == nullptr) {
-    unsigned int n_ifaces = 0;
-    GType* ifaces = g_type_interfaces(gtype, &n_ifaces);
-    for (unsigned int i = 0; i < n_ifaces && func == nullptr; i++) {
-      GIBaseInfo* ii = gi_repository_find_by_gtype(repo, ifaces[i]);
-      if (ii != nullptr) {
-        if (GI_IS_INTERFACE_INFO(ii)) {
-          func = gi_interface_info_find_method(reinterpret_cast<GIInterfaceInfo*>(ii),
-                                               method.c_str());
-        }
-        gi_base_info_unref(ii);
-      }
+  // (no info; ancestor = GObject) implementing GFile, so g_file_get_path
+  // resolves).
+  auto resolveMethod = [&](const char* name) -> GIFunctionInfo* {
+    GIObjectInfo* walk = reinterpret_cast<GIObjectInfo*>(
+        gi_base_info_ref(reinterpret_cast<GIBaseInfo*>(objInfo)));
+    GIFunctionInfo* found = nullptr;
+    while (walk != nullptr) {
+      GIBaseInfo* declarer = nullptr;
+      found = gi_object_info_find_method_using_interfaces(walk, name, &declarer);
+      if (declarer != nullptr) gi_base_info_unref(declarer);
+      if (found != nullptr) break;
+      GIObjectInfo* parent = gi_object_info_get_parent(walk);
+      gi_base_info_unref(walk);
+      walk = parent;
     }
-    g_free(ifaces);
+    if (walk != nullptr) gi_base_info_unref(walk);
+    if (found == nullptr) {
+      unsigned int n_ifaces = 0;
+      GType* ifaces = g_type_interfaces(gtype, &n_ifaces);
+      for (unsigned int i = 0; i < n_ifaces && found == nullptr; i++) {
+        GIBaseInfo* ii = gi_repository_find_by_gtype(repo, ifaces[i]);
+        if (ii != nullptr) {
+          if (GI_IS_INTERFACE_INFO(ii)) {
+            found = gi_interface_info_find_method(reinterpret_cast<GIInterfaceInfo*>(ii), name);
+          }
+          gi_base_info_unref(ii);
+        }
+      }
+      g_free(ifaces);
+    }
+    return found;
+  };
+
+  // Literal introspected name first (GJS fidelity), snake_case alias second.
+  GIFunctionInfo* func = resolveMethod(method.c_str());
+  if (func == nullptr) {
+    const std::string snake = CamelToSnake(method);
+    if (snake != method) func = resolveMethod(snake.c_str());
   }
+  gi_base_info_unref(objInfo);
   g_object_unref(repo);
 
   if (func == nullptr) {

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -580,6 +580,26 @@ Napi::Value GIArgumentToJs(Napi::Env env, GITypeInfo* type, GIArgument* arg,
       GType gt = static_cast<GType>(arg->v_size);
       return gt != 0 ? MakeGTypeHandle(env, gt) : env.Null();
     }
+    case GI_TYPE_TAG_ERROR: {
+      // A GError-typed value (a `GLib.Error` return like Gtk.GLArea.get_error(),
+      // or a GLib.Error.new_literal construct): GJS surfaces it as a GLib.Error
+      // boxed (G_TYPE_ERROR) with `.domain`/`.code`/`.message` field access +
+      // `.matches()`/`.copy()` methods. Wrap through the GLib.Error struct info
+      // so the boxed handle resolves fields and methods; a NULL GError (the
+      // no-error case) stays null. WrapBoxed handles transfer: a transfer-none
+      // borrow is g_boxed_copy'd into an owned copy, transfer-full is adopted.
+      GError* gerr = static_cast<GError*>(arg->v_pointer);
+      if (gerr == nullptr) return env.Null();
+      GIRepository* repo = DupDefaultRepository();
+      // GLib is loaded by any namespace require; require defensively anyway so a
+      // bare engine call still resolves the struct info (idempotent, cheap).
+      gi_repository_require(repo, "GLib", "2.0", static_cast<GIRepositoryLoadFlags>(0), nullptr);
+      GIBaseInfo* errInfo = gi_repository_find_by_name(repo, "GLib", "Error");
+      Napi::Value result = WrapBoxed(env, gerr, errInfo, transfer);
+      if (errInfo != nullptr) gi_base_info_unref(errInfo);
+      g_object_unref(repo);
+      return result;
+    }
     default:
       Napi::TypeError::New(env, "Unsupported return type tag " +
                                     std::to_string(static_cast<int>(tag)) + " (milestone 1)")

--- a/packages/node-gi/node-gi/test/gerror-return.test.mjs
+++ b/packages/node-gi/node-gi/test/gerror-return.test.mjs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — GError-typed RETURNS + literal-first method-name resolution.
+//
+// Two engine gaps the webgl-glarea spike exposed (both hit before any GL call):
+//
+//  1. A **GError-typed value** (GI_TYPE_TAG_ERROR — a `GLib.Error` RETURN like
+//     `Gtk.GLArea.get_error()`) threw `Unsupported return type tag 20`. GJS
+//     surfaces it as a GLib.Error boxed with `.domain`/`.code`/`.message`
+//     fields + `.matches()`/`.copy()` methods; the engine now wraps it through
+//     the GLib.Error struct info (marshal.cc GI_TYPE_TAG_ERROR → WrapBoxed).
+//     Headless coverage via `Gio.dbus_error_new_for_dbus_error` (a namespace
+//     function with the same ERROR type-tag, transfer-full return — no display
+//     needed; `GLib.Error.new_literal` is not usable here because the L1
+//     deliberately shadows `GLib.Error` with its JS Error subclass); the
+//     null-GError path (`realize: error none`) is covered by the display-gated
+//     webgl-glarea e2e.
+//
+//  2. Instance-method resolution converted EVERY accessor camelCase→snake_case
+//     before the GI lookup, destroying literal camelCase GIR names (Vala-
+//     generated typelibs — Gwebgl's `getString` became the nonexistent
+//     `get_string`). GJS exposes GIR names VERBATIM; the engine now resolves
+//     the literal name first and falls back to the snake_case alias
+//     (calls.cc CallMethod). Covered here from both directions on an
+//     introspected instance: the literal snake name AND the camelCase alias
+//     (which now exercises the C++ fallback path). The literal-camelCase
+//     direction is covered by the webgl-glarea e2e (Gwebgl's Vala GIR).
+//
+// Reference: refs/gjs gi/arg.cpp (gjs_value_from_gi_argument ERROR branch),
+// gjs object instance method resolution (verbatim GIR names).
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+
+const Gio = requireGi('Gio', '2.0');
+
+test('GError-typed return marshals as a field-readable GLib.Error boxed', () => {
+  // Returns a GError (transfer full) — the SAME GI_TYPE_TAG_ERROR return path a
+  // `Gtk.GLArea.get_error()` non-null result takes, but headless.
+  const err = Gio.dbus_error_new_for_dbus_error('org.freedesktop.DBus.Error.Failed', 'boom');
+  assert.ok(err !== null && err !== undefined, 'a GError return must not be null');
+  assert.match(String(err.message), /boom/, 'the message FIELD must read back');
+  const domain = Gio.dbus_error_quark();
+  assert.equal(err.domain, domain, 'the domain FIELD must read back (g-dbus-error-quark)');
+  assert.equal(err.code, Gio.DBusError.FAILED, 'the code FIELD must read back (registered name → FAILED)');
+  // Boxed METHODS resolve too.
+  assert.equal(err.matches(domain, Gio.DBusError.FAILED), true);
+  assert.equal(err.matches(domain, Gio.DBusError.NO_MEMORY), false);
+  const copy = err.copy();
+  assert.match(String(copy.message), /boom/, 'copy() returns another usable GLib.Error');
+});
+
+test('instance methods resolve the literal name first, snake alias second', () => {
+  const action = new Gio.SimpleAction({ name: 'greet' });
+  // Literal introspected (snake_case) name — resolved verbatim, no conversion.
+  assert.equal(action.get_name(), 'greet');
+  // camelCase ALIAS — misses the literal lookup, resolved via the engine's
+  // snake_case fallback (the path that must keep working after literal-first).
+  assert.equal(action.getName(), 'greet');
+  // A genuinely unknown name still throws the clear method-miss error.
+  assert.throws(() => action.noSuchMethodAtAll(), /no method/);
+});

--- a/packages/node-gi/node-gi/test/webgl-glarea.test.mjs
+++ b/packages/node-gi/node-gi/test/webgl-glarea.test.mjs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Gtk.GLArea gets a LIVE, CURRENT GL context on node-gi.
+//
+// The WebGL-on-node gate: `@gjsify/webgl`'s `WebGLBridge` is a `Gtk.GLArea`
+// subclass whose whole contract is "the GLArea realizes and hands JS a current
+// GL context to drive through the gwebgl Vala bridge". This e2e proves that
+// contract holds UNCHANGED under the node-gi reverse bridge on a headless
+// software-GL display:
+//
+//   gjsify build fixtures/webgl-glarea-app.ts --app gjs  → gjs -m …  (native gi://)
+//   gjsify build fixtures/webgl-glarea-app.ts --app node → node  …   (@gjsify/node-gi)
+//
+// The ONE shared source ([../fixtures/webgl-glarea-app.ts](../fixtures/webgl-glarea-app.ts))
+// presents a `Gtk.ApplicationWindow` holding a `Gtk.GLArea` configured exactly
+// like `WebGLBridge` (ES 3.2 + depth + stencil), asserts on realize/render that
+// `Gdk.GLContext.get_current()` is non-null (THE current-context proof), drives
+// the gwebgl native class (`getString`, a `getParameterx` GVariant round-trip)
+// and performs a real WebGL draw — `clearColor(1,0,0,1)` + `clear` +
+// `readPixels` → the fixed pixel `255,0,0,255` in the committed GOLDEN. The GL
+// stack is pure software (llvmpipe via LIBGL_ALWAYS_SOFTWARE=1) so the golden is
+// display-independent; the host's GL version/renderer strings go to stderr as
+// diagnostics only. A LOCAL/dev gate additionally re-proves the golden IS gjs's
+// own byte-output by building + running `--app gjs` (skippable via
+// NODE_GI_WEBGL_SKIP_GJS, mirroring canvas2d-bridge's NODE_GI_C2D_SKIP_GJS).
+//
+// SELF-SKIPS when there is no display (the fast headless `npm test` leg), when
+// the `gjsify` CLI is absent, or when the committed Gwebgl prebuild
+// (packages/framework/webgl/prebuilds/linux-<arch>/) is missing for this arch.
+// The dedicated `webgl-glarea` CI job sets all three up (workspace-built CLI +
+// xvfb + dbus + the GTK/mesa stack) and runs it for real.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+// The fixtures live OUTSIDE test/ on purpose: node --test's default glob
+// (**/test/**/*.{mjs,ts,…}) would otherwise pick them up and try to run the
+// unbundled gi:// source directly, which fails to resolve.
+const pkgRoot = join(here, '..');
+const repoRoot = join(pkgRoot, '..', '..', '..');
+const fixture = join(pkgRoot, 'fixtures', 'webgl-glarea-app.ts');
+const bridgeFixture = join(pkgRoot, 'fixtures', 'webgl-bridge-app.ts');
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+// The committed gwebgl Vala prebuild (typelib + .so) @gjsify/webgl ships —
+// puts Gwebgl-0.1 on GI_TYPELIB_PATH/LD_LIBRARY_PATH for BOTH runtimes.
+const PREBUILD_ARCH = { x64: 'x86_64', arm64: 'aarch64' };
+const gwebglDir = join(
+    repoRoot,
+    'packages',
+    'framework',
+    'webgl',
+    'prebuilds',
+    `linux-${PREBUILD_ARCH[process.arch] ?? process.arch}`,
+);
+const haveGwebgl = existsSync(join(gwebglDir, 'Gwebgl-0.1.typelib'));
+
+// Locate the workspace `gjsify` CLI: an explicit override, else the nearest
+// node_modules/.bin/gjsify walking up from here, else `gjsify` on PATH.
+function findGjsify() {
+    if (process.env.GJSIFY_BIN && existsSync(process.env.GJSIFY_BIN)) return process.env.GJSIFY_BIN;
+    let dir = here;
+    for (let i = 0; i < 8; i++) {
+        const cand = join(dir, 'node_modules', '.bin', 'gjsify');
+        if (existsSync(cand)) return cand;
+        const up = dirname(dir);
+        if (up === dir) break;
+        dir = up;
+    }
+    try {
+        execFileSync('gjsify', ['--version'], { stdio: 'ignore' });
+        return 'gjsify';
+    } catch {
+        return null;
+    }
+}
+
+const gjsify = haveDisplay ? findGjsify() : null;
+
+const skip = !haveDisplay
+    ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+    : !haveGwebgl
+        ? `Gwebgl prebuild missing (${gwebglDir})`
+        : !gjsify
+            ? 'gjsify CLI not found (workspace not installed)'
+            : false;
+
+// The gjs gold-standard leg re-proves the committed GOLDEN below IS exactly
+// gjs's own byte-output. Skippable via NODE_GI_WEBGL_SKIP_GJS=1 (the
+// canvas2d-bridge NODE_GI_C2D_SKIP_GJS pattern) for hosts where building
+// `--app gjs` or running gjs is not set up; the node-gi assertion vs the
+// committed golden stays the authoritative check either way. It ALSO needs the
+// workspace register libs BUILT: `--app gjs` force-INLINES `<pkg>/register`
+// subpaths (the AGENTS.md invariant — GJS's loader cannot resolve them bare),
+// so an unbuilt workspace (fresh clone/worktree, no lib/esm) cannot produce a
+// loadable gjs bundle — probe one register lib the entry wrapper always pulls.
+// NB the NODE leg has no such requirement: the fixture imports only gi://.
+const workspaceBuilt = existsSync(join(repoRoot, 'packages', 'node', 'buffer', 'lib', 'esm', 'register.js'));
+const haveGjs = !process.env.NODE_GI_WEBGL_SKIP_GJS
+    && workspaceBuilt
+    && spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+// The fixed sequence of lines both runtimes must print, in order — the committed
+// golden. It IS gjs's own output (asserted by the local gjs leg below). The
+// pixel line is the WebGL draw proof: clear-color red read back off the GL
+// framebuffer via glReadPixels — software GL, so byte-stable across hosts.
+const GOLDEN = [
+    'webgl-glarea: start',
+    'activated',
+    'realize: error none',
+    'realize: context non-null es=true version>=3.2 true',
+    'realize: current yes', // THE headline: Gdk.GLContext.get_current() non-null
+    'render: current yes',
+    'gl-strings: ok',
+    'gl-param: max-texture-size positive',
+    'pixel(0,0): 255,0,0,255', // clearColor(1,0,0,1) + clear + readPixels
+    'render: fired',
+    'quit',
+    'done',
+].join('\n');
+
+// Only the apps' own deterministic lines are asserted — a headless GTK/dbus
+// session prints assorted portal / a11y / gvfs warnings that vary by host.
+// Covers BOTH fixtures (glarea + bridge).
+const GOLDEN_PREFIXES = [
+    'webgl-glarea:',
+    'webgl-bridge:',
+    'activated',
+    'realize:',
+    'render:',
+    'ready:',
+    'gl-strings:',
+    'gl-param:',
+    'pixel(',
+    'bridge-pixel(',
+    'quit',
+    'done',
+    'activate-error:',
+];
+
+// Software-only GL/GTK env for the run children. DISPLAY comes from the
+// surrounding xvfb-run / real session; LIBGL_ALWAYS_SOFTWARE forces mesa
+// llvmpipe so the GL stack needs no GPU, GSK_RENDERER=cairo keeps GTK's own
+// compositor off GL (the GLArea still creates its OWN GL context — the exact
+// headless recipe the golden is pinned to), GDK_BACKEND=x11 matches Xvfb.
+// The gwebgl prebuild dir is APPENDED to any inherited typelib/library path.
+// Merged over the inherited env so DISPLAY / NODE_GI_NATIVE are preserved.
+const RUN_ENV = {
+    GSK_RENDERER: 'cairo',
+    GDK_BACKEND: 'x11',
+    LIBGL_ALWAYS_SOFTWARE: '1',
+    GTK_A11Y: 'none',
+    NODE_GI_NATIVE: 'build', // run the just-built addon, not a stale staged prebuild
+    ...process.env,
+    GI_TYPELIB_PATH: [gwebglDir, process.env.GI_TYPELIB_PATH].filter(Boolean).join(delimiter),
+    LD_LIBRARY_PATH: [gwebglDir, process.env.LD_LIBRARY_PATH].filter(Boolean).join(delimiter),
+};
+
+function exec(cmd, args, timeoutMs, env) {
+    try {
+        return execFileSync(cmd, args, {
+            cwd: here,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: timeoutMs,
+            encoding: 'utf-8',
+            env: env ?? process.env,
+        });
+    } catch (err) {
+        const out = (err.stdout || '').toString();
+        const e = (err.stderr || '').toString();
+        throw new Error(
+            `${cmd} ${args.join(' ')} failed (code ${err.status ?? err.code})\n--- stdout ---\n${out}\n--- stderr ---\n${e}`,
+        );
+    }
+}
+
+// Invoke the resolved gjsify CLI. A workspace CLI entry (…/infra/cli/lib/index.js)
+// is a plain .js — run it via `node` so it works regardless of the +x bit; a shell
+// shim (the workspace `.bin/gjsify`) is exec'd directly. CI points GJSIFY_BIN at
+// the WORKSPACE-built CLI (current source), not the published @gjsify/cli.
+function gjsifyExec(args, timeoutMs) {
+    return /\.[mc]?js$/.test(gjsify)
+        ? exec(process.execPath, [gjsify, ...args], timeoutMs)
+        : exec(gjsify, args, timeoutMs);
+}
+
+function build(entry, app, outfile) {
+    gjsifyExec(['build', entry, '--app', app, '--outfile', outfile], 180 * 1000);
+    assert.ok(existsSync(outfile), `${outfile} was not produced`);
+    return outfile;
+}
+
+// Keep ONLY the golden lifecycle lines (each carries a known prefix).
+function run(cmd, args) {
+    const raw = exec(cmd, args, 90 * 1000, RUN_ENV);
+    return raw
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => GOLDEN_PREFIXES.some((p) => l === p || l.startsWith(p)))
+        .join('\n');
+}
+
+// Shared per-fixture flow: build --app node, assert the gi://→requireGi rewrite
+// happened, run on node vs the committed golden; then (haveGjs) build --app gjs,
+// run under gjs, and assert golden + byte-identity. Build INSIDE the monorepo
+// (not os tmpdir): the --app node bundle keeps `@gjsify/node-gi` external, so it
+// must run from a tree where that package resolves (the root
+// node_modules/@gjsify/node-gi symlink). /tmp has no such node_modules →
+// ERR_MODULE_NOT_FOUND at run time. Kept at the package root (not under test/)
+// so a stray dir never trips node --test's glob.
+function assertDualRuntimeGolden(entry, golden) {
+    const dir = mkdtempSync(join(pkgRoot, '.tmp-webgl-'));
+    try {
+        // --- node-gi: the real `--app node` bundle (the authoritative check) ---
+        const nodeBundle = build(entry, 'node', join(dir, 'app.node.mjs'));
+        // The build MUST have rewritten gi:// → requireGi (incl. gi://Gwebgl);
+        // a CLI predating that rewrite is a hard failure here, not a skip.
+        assert.ok(
+            readFileSync(nodeBundle, 'utf-8').includes('requireGi'),
+            'the --app node bundle did not rewrite gi:// → requireGi (gjsify CLI too old)',
+        );
+        const nodeOut = run('node', [nodeBundle]);
+        assert.equal(nodeOut, golden, 'node-gi output diverged from the committed golden');
+
+        // --- gjs gold-standard: re-prove the golden IS gjs's own output ---
+        // Skippable via NODE_GI_WEBGL_SKIP_GJS=1 — see the haveGjs note above.
+        if (haveGjs) {
+            const gjsBundle = build(entry, 'gjs', join(dir, 'app.gjs.mjs'));
+            const gjsOut = run('gjs', ['-m', gjsBundle]);
+            assert.equal(gjsOut, golden, 'gjs gold-standard diverged from the committed golden');
+            assert.equal(gjsOut, nodeOut, 'gjs and node-gi outputs are not byte-identical');
+        }
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+test(
+    'Gtk.GLArea realizes with a CURRENT GL context + WebGL draw on node-gi',
+    { skip },
+    () => {
+        assertDualRuntimeGolden(fixture, GOLDEN);
+    },
+);
+
+// ---- the FULL @gjsify/webgl WebGLBridge (TS WebGL stack) on node-gi ---------
+
+// Additionally needs `@gjsify/webgl` BUILT (its lib + workspace deps) — the
+// fixture bundles the whole TS WebGL stack. A bare node-gi tree (no workspace
+// build) skips cleanly; the raw-seam test above stays independent of it.
+function webglResolvable() {
+    try {
+        createRequire(bridgeFixture).resolve('@gjsify/webgl');
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const bridgeSkip = skip || (!webglResolvable() ? '@gjsify/webgl not resolvable (workspace not built)' : false);
+
+// The committed golden for the bridge fixture: the standard browser calls
+// clearColor(0,0,1,1)+clear+readPixels through the FULL TS WebGLRenderingContext
+// (constants hash, GVariant getParameterx init, WebGL1+2 context construction)
+// read the blue clear back off the GL framebuffer.
+const BRIDGE_GOLDEN = [
+    'webgl-bridge: start',
+    'activated',
+    'ready: canvas sized',
+    'bridge-pixel(0,0): 0,0,255,255',
+    'ready: fired',
+    'quit',
+    'done',
+].join('\n');
+
+test(
+    'the full @gjsify/webgl WebGLBridge draws + reads back on node-gi',
+    { skip: bridgeSkip },
+    () => {
+        assertDualRuntimeGolden(bridgeFixture, BRIDGE_GOLDEN);
+    },
+);


### PR DESCRIPTION
## The spike question — answered

**Can a `Gtk.GLArea` be realized and get a live GL context under the node-gi reverse bridge on a headless display?**

**YES — definitively.** Under software GL (mesa llvmpipe, no GPU), a `Gtk.GLArea` configured exactly like `@gjsify/webgl`'s `WebGLBridge` (`set_use_es(true)`, `set_required_version(3, 2)`, depth + stencil) realizes with `get_error() === null`, and `Gdk.GLContext.get_current()` is **non-null in both `realize` and `render`** — the context is CURRENT for JS. Captured through the live context via the gwebgl Vala bridge:

```
GL_VERSION  = OpenGL ES 3.2 Mesa 26.1.3
GL_RENDERER = llvmpipe (LLVM 22.1.7, 256 bits)
GL_VENDOR   = Mesa
GLSL        = OpenGL ES GLSL ES 3.20
```

And the bonus is in too: a **real WebGL draw** — `clearColor(1,0,0,1)` + `clear` + `readPixels` → `255,0,0,255` — plus the **FULL `@gjsify/webgl` `WebGLBridge`** (TS `WebGLRenderingContext`: constants GHashTable, GVariant `getParameterx` init reads, eager WebGL1+2 construction) clearing blue and reading back `0,0,255,255`. Both goldens are **byte-identical between `gjs -m` and `node`**.

Display/GL env the goldens are pinned to (X11/Xvfb + software GL): `GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none`, with the committed `Gwebgl-0.1` prebuild on `GI_TYPELIB_PATH`/`LD_LIBRARY_PATH` (the test wires that itself). No EGL-surfaceless fallback was needed — plain GLX/EGL-on-X11 with llvmpipe just works.

## Two engine gaps fixed on the way (root-cause, same PR)

Both were hit by the probe **before any GL call**; headless regression coverage in `test/gerror-return.test.mjs`:

1. **GError-typed RETURNS** (`GI_TYPE_TAG_ERROR`, e.g. `Gtk.GLArea.get_error()`) threw `Unsupported return type tag 20`. Now wrapped through the `GLib.Error` struct info → a field-readable boxed (`.domain`/`.code`/`.message`, `.matches()`/`.copy()`); NULL stays `null` (marshal.cc).
2. **Literal camelCase GI method names were destroyed** by the unconditional camelCase→snake_case alias — Vala GIRs carry them verbatim (Gwebgl's `getString` became the nonexistent `get_string`). `CallMethod` now resolves the **literal name first**, snake_case alias second (calls.cc), with gi.js passing the accessor through unconverted — GJS fidelity (GIR names are exposed as-is).

## Deliverables

- `fixtures/webgl-glarea-app.ts` + `fixtures/webgl-bridge-app.ts` — ONE dual-runtime source each (`--app gjs` ↔ `--app node`), deterministic stdout goldens, GL diagnostics on stderr.
- `test/webgl-glarea.test.mjs` — **self-skipping local/dev verification** (the canvas2d-bridge pattern, deliberately **no heavyweight CI job**): skips without a display / gjsify CLI / the Gwebgl prebuild; the bridge test also without a built `@gjsify/webgl`; the gjs gold-standard leg is gated on built workspace register libs (`--app gjs` force-inlines `<pkg>/register`) + `NODE_GI_WEBGL_SKIP_GJS`.
- Run recipe + findings in the node-gi README (`### WebGL / Gtk.GLArea`); the consumer-survey report's P6 section notes the GL/display gate as proven.

## Verification

- `test/webgl-glarea.test.mjs`: **2/2 pass** with BOTH legs live (node-gi golden + gjs gold-standard byte-identity), fixtures built with the **workspace (current-source) CLI** via `GJSIFY_BIN`.
- Full node-gi suite (with display, so the GTK/Adw/cairo smoke legs all ran): **389 tests, 376 pass, 0 fail, 13 env-gated skips** — no regression from the engine changes.
- Conformance (gjs × node golden-diff): **all green**; gimarshalling tier-B port: **370 pass / 0 fail / 74 documented skips**.

Remaining WebGL-on-node work is breadth (shader/buffer/texture — a three.js consumer), not the GL context: the seam + context stack are proven.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq