### PR TITLE
test(node-gi): prove event-bridge on node-gi

### DIFF
--- a/packages/node-gi/node-gi/.gitignore
+++ b/packages/node-gi/node-gi/.gitignore
@@ -9,3 +9,4 @@ probe-*.mjs
 conformance/dist/
 .gi-tests/
 .tmp-c2d-*/
+.tmp-eb-*/

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -736,3 +736,53 @@ mapped `Gtk.DrawingArea`'s live `GdkFrameClock` stays an active GLib source afte
 `app.quit()`, so — matching the documented lifetime divergence — a node-gi GTK
 program that must terminate exits explicitly (`process.exit(0)`), whereas `gjs -m`
 exits on module completion.
+
+### The live `@gjsify/event-bridge` dispatches DOM events on node-gi
+
+The GTK→DOM event bridge (`@gjsify/event-bridge`'s `attachEventControllers`) —
+which attaches GTK4 `EventControllerMotion`/`GestureClick`/`EventControllerScroll`/
+`EventControllerKey`/`EventControllerFocus` to a widget and dispatches W3C DOM
+events (Mouse/Pointer/Keyboard/Wheel/FocusEvent) — runs UNCHANGED on node-gi. The
+shared fixture presents a `Gtk.DrawingArea`, attaches the controllers, and drives a
+SYNTHESIZED event through each live `Gtk.EventController*` via `emit(signal, …)`
+(the same path the GJS `event-bridge.spec.ts` drives), then asserts the dispatched
+DOM event's type / coords / `getModifierState` / key / code. The `Gdk.ModifierType`
+flags and `Gdk.keyval_name`/`Gdk.keyval_to_unicode` marshalling produce
+byte-identical DOM events under node-gi and `gjs -m` — the same source builds
+`--app gjs` and `--app node` and prints the committed golden
+(`test/event-bridge.test.mjs` + `fixtures/event-bridge-app.ts`). Every golden line
+is deterministic + display-independent (coords clamp to a fixed 400x300 allocation;
+key/code/modifiers derive from the Gdk marshalling), so byte-parity is stable.
+
+**Deferred node-gi gap (does not affect the behavior):** node-gi does not wire
+`instanceof` for GObject wrapper classes yet — `new Gtk.EventControllerMotion()
+instanceof Gtk.EventControllerMotion` is `false` (even for a freshly-constructed
+wrapper), because the per-GType wrappers are not set up as real JS classes with a
+prototype chain / `Symbol.hasInstance`. So the fixture cannot use the GJS spec's
+`ctrl instanceof Gtk.EventControllerMotion` controller filter; it retrieves
+controllers by ADD ORDER off `widget.observe_controllers()` instead (wrapper
+IDENTITY *is* preserved and `emit()` resolves the signal by the live GType, so the
+bridged behavior is unaffected). Wiring `instanceof` is a core object-model change
+(per-GType JS classes or a `Symbol.hasInstance` hook) — tracked as a native-engine
+follow-up. A second minor gap the fixture routes around: boxed structs have no
+`new` constructor (`new Gdk.Rectangle()` throws `no static method 'new'`), so the
+fixture relies on the presented window's real allocation rather than a manual
+`size_allocate(rect)`.
+
+**Run it (needs a display + a built workspace + the `gjsify` CLI; self-skips
+otherwise):**
+
+```sh
+# node-gi (--app node) — the authoritative check vs the committed golden:
+export GJSIFY_BIN="$(git rev-parse --show-toplevel)/packages/infra/cli/lib/index.js"
+xvfb-run -a dbus-run-session -- \
+  env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
+      NODE_GI_NATIVE=build NODE_GI_EB_SKIP_GJS=1 GJSIFY_BIN="$GJSIFY_BIN" \
+  node --test test/event-bridge.test.mjs
+# Drop NODE_GI_EB_SKIP_GJS to additionally re-prove the golden IS gjs's own output
+# (builds + runs --app gjs; needs the workspace CLI, not the published one).
+```
+
+`GJSIFY_BIN` must point at the WORKSPACE-built `@gjsify/cli` (`packages/infra/cli/lib/index.js`),
+not the published `@gjsify/cli` — the fixture is built with current source, which
+carries this session's bundler fixes the published `0.18.0` predates.

--- a/packages/node-gi/node-gi/fixtures/event-bridge-app.ts
+++ b/packages/node-gi/node-gi/fixtures/event-bridge-app.ts
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+//
+// The @gjsify/event-bridge LIVE proof — ONE source, two runtimes.
+//
+//   gjsify build … --app gjs   → native gi:// Gtk/Gdk under GJS
+//   gjsify build … --app node  → @gjsify/node-gi under Node.js
+//
+// It imports the REAL `attachEventControllers` from `@gjsify/event-bridge` — the
+// helper that attaches GTK4 `EventControllerMotion`/`GestureClick`/
+// `EventControllerScroll`/`EventControllerKey`/`EventControllerFocus` to a widget
+// and dispatches W3C DOM events (Mouse/Pointer/Keyboard/Wheel/FocusEvent from
+// `@gjsify/dom-events`) on the associated element. This drives the exact same path
+// the `event-bridge.spec.ts` GJS spec drives — a SYNTHESIZED event pushed through
+// the LIVE `Gtk.EventController*` via `emit(signal, …)` — and asserts the resulting
+// DOM event fields (type, coords, `getModifierState`, key/code). The point: the
+// `Gdk.ModifierType` flags + `Gdk.keyval_*` marshalling must produce byte-identical
+// DOM events on node-gi as on GJS.
+//
+// Lifecycle (mirrors fixtures/canvas2d-bridge-app.ts):
+//   - a `Gtk.DrawingArea` goes into a `Gtk.ApplicationWindow`, `present()`ed under a
+//     display (Xvfb or a real session) so the widget REALIZES + ALLOCATES (400x300) — the motion
+//     handler clamps to the live allocation, so the widget must be sized;
+//   - `attachEventControllers(area, () => recorder)` wires all five controllers;
+//   - a `GLib.timeout_add` waits for the allocation, then drives:
+//       motion(12,8) motion(20,18) motion(-3,-7) | scroll(0,1) |
+//       key-pressed(KEY_a, SHIFT) key-pressed(KEY_Left, CONTROL) key-released(KEY_a) |
+//       focus enter/leave
+//     retrieving each controller off `widget.observe_controllers()` (see the index
+//     note below), asserts the dispatched DOM events, prints the fixed golden, quits.
+//
+// The controllers are retrieved by ADD ORDER. `observe_controllers()` returns them
+// in REVERSE add order (GTK LIFO), so the list is reversed to recover the order
+// `attachEventControllers` adds them in: [motion, click, scroll, key, focus]. This
+// is used INSTEAD of the spec's `ctrl instanceof Gtk.EventControllerMotion` filter
+// because node-gi does not wire `instanceof` for GObject wrapper classes yet (a
+// documented deep-engine gap — see the test file header); wrapper IDENTITY is
+// preserved and `emit()` resolves the signal by the live GType, so add-order
+// retrieval drives the real controllers correctly.
+//
+// Every printed line is DETERMINISTIC + display-independent (coords clamped to the
+// fixed 400x300 allocation; key/code/modifiers computed from Gdk marshalling), so
+// the gjs output is byte-identical to the node output AND matches the committed
+// golden. `print` is ambient under GJS and injected by `--globals auto`
+// (`@gjsify/node-gi/globals`) for the node build — NO `/register` import.
+
+import GLib from 'gi://GLib?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+import Gdk from 'gi://Gdk?version=4.0';
+import { attachEventControllers } from '@gjsify/event-bridge';
+
+const W = 400;
+const H = 300;
+
+// Minimal element stub the bridge dispatches onto; records every DOM event.
+interface RecordedEvent {
+    type: string;
+    clientX?: number;
+    clientY?: number;
+    movementX?: number;
+    movementY?: number;
+    deltaX?: number;
+    deltaY?: number;
+    key?: string;
+    code?: string;
+    shiftKey?: boolean;
+    ctrlKey?: boolean;
+    getModifierState?: (k: string) => boolean;
+}
+
+function makeRecorder() {
+    const events: RecordedEvent[] = [];
+    return {
+        events,
+        dispatchEvent(e: RecordedEvent): boolean {
+            events.push(e);
+            return true;
+        },
+    };
+}
+
+const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiEventBridge',
+    flags: Gio.ApplicationFlags.NON_UNIQUE, // no session-bus uniqueness round-trip
+});
+
+app.connect('activate', () => {
+    try {
+        print('activated');
+
+        const win = new Gtk.ApplicationWindow({ application: app });
+        win.set_default_size(W, H);
+
+        const area = new Gtk.DrawingArea();
+        area.set_content_width(W);
+        area.set_content_height(H);
+
+        const recorder = makeRecorder();
+        // The REAL helper under test — attaches all five GTK controllers.
+        attachEventControllers(area, () => recorder);
+
+        win.set_child(area);
+        win.present();
+
+        // Retrieve the controllers off the widget in ADD order (reverse of the LIFO
+        // observe_controllers list). node-gi preserves wrapper identity + resolves
+        // emit() by the live GType, so these ARE the live controllers.
+        const collectControllers = () => {
+            const list = area.observe_controllers();
+            const ctrls: Gtk.EventController[] = [];
+            for (let i = 0; i < list.get_n_items(); i++) {
+                ctrls.push(list.get_item(i) as Gtk.EventController);
+            }
+            ctrls.reverse();
+            return ctrls;
+        };
+
+        const has = (type: string) => recorder.events.some((e) => e.type === type);
+        const filter = (type: string) => recorder.events.filter((e) => e.type === type);
+
+        let ticks = 0;
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+            ticks++;
+            // Wait until the DrawingArea is realized + allocated so the motion
+            // handler's clamp reads a real 400x300 allocation (coords pass through).
+            if (area.get_allocated_width() <= 0 && ticks < 40) {
+                return GLib.SOURCE_CONTINUE;
+            }
+
+            try {
+                const ctrls = collectControllers();
+                // [motion, click, scroll, key, focus] — attachEventControllers order.
+                const [motionC, , scrollC, keyC, focusC] = ctrls;
+
+                // ---- Motion: coords, movement delta, lower-bound clamp ----
+                motionC.emit('motion', 12, 8);
+                motionC.emit('motion', 20, 18);
+                motionC.emit('motion', -3, -7); // clamps to 0,0 regardless of allocation
+
+                // ---- Scroll → WheelEvent (delta scaled ×100) ----
+                scrollC.emit('scroll', 0, 1);
+
+                // ---- Key: keyval + Gdk.ModifierType flags marshalling ----
+                keyC.emit('key-pressed', Gdk.KEY_a, 0, Gdk.ModifierType.SHIFT_MASK);
+                keyC.emit('key-pressed', Gdk.KEY_Left, 0, Gdk.ModifierType.CONTROL_MASK);
+                keyC.emit('key-released', Gdk.KEY_a, 0, 0);
+
+                // ---- Focus: enter/leave → focus/focusin, blur/focusout ----
+                focusC.emit('enter');
+                focusC.emit('leave');
+
+                // ---- Assert + print the committed golden ----
+                const pm = filter('pointermove');
+                const kd = filter('keydown');
+                const wheel = recorder.events.find((e) => e.type === 'wheel')!;
+                const keyup = recorder.events.find((e) => e.type === 'keyup')!;
+
+                print(`motion: ${pm[0].clientX},${pm[0].clientY}`);
+                print(`move: ${pm[1].movementX},${pm[1].movementY}`);
+                print(`clamp: ${pm[2].clientX},${pm[2].clientY}`);
+                print(`wheel: ${wheel.deltaX},${wheel.deltaY}`);
+                print(`keydown: ${kd[0].key} ${kd[0].code} shift=${kd[0].shiftKey} ctrl=${kd[0].ctrlKey}`);
+                print(
+                    `modstate: Shift=${kd[0].getModifierState!('Shift')} Control=${kd[0].getModifierState!('Control')}`,
+                );
+                print(`keydown: ${kd[1].key} ${kd[1].code} shift=${kd[1].shiftKey} ctrl=${kd[1].ctrlKey}`);
+                print(`keyup: ${keyup.key}`);
+                print(`focus: ${['focus', 'focusin'].filter(has).join(',')}`);
+                print(`blur: ${['blur', 'focusout'].filter(has).join(',')}`);
+                print('quit');
+            } catch (error) {
+                print(`activate-error: ${error instanceof Error ? error.message : String(error)}`);
+            }
+            app.quit();
+            return GLib.SOURCE_REMOVE;
+        });
+    } catch (error) {
+        // Surface a failure as a deterministic line so a golden mismatch points at
+        // the cause instead of hanging the loop.
+        print(`activate-error: ${error instanceof Error ? error.message : String(error)}`);
+        app.quit();
+    }
+});
+
+print('event-bridge: start');
+app.run([]); // top-level blocking run (no async wrapper — the node-gtk #442 caveat)
+print('done');
+
+// Force a clean exit(0) on BOTH runtimes. Under `gjs -m` the process exits on module
+// completion regardless; under node-gi a mapped Gtk.DrawingArea's live GdkFrameClock
+// stays an active GLib source after app.quit(), which the uv-driven auto-pump keeps
+// mirroring onto libuv — so node would otherwise NOT exit (the documented "one
+// lifetime divergence vs gjs"). A GTK program that must terminate exits explicitly.
+process.exit(0);

--- a/packages/node-gi/node-gi/test/event-bridge.test.mjs
+++ b/packages/node-gi/node-gi/test/event-bridge.test.mjs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the LIVE @gjsify/event-bridge dispatches DOM events on node-gi.
+//
+// The GTK→DOM event bridge (`@gjsify/event-bridge`) attaches GTK4
+// `EventControllerMotion`/`GestureClick`/`EventControllerScroll`/
+// `EventControllerKey`/`EventControllerFocus` to a widget and dispatches W3C DOM
+// events (Mouse/Pointer/Keyboard/Wheel/FocusEvent) on the associated element. Its
+// GJS spec (`packages/framework/event-bridge/src/event-bridge.spec.ts`) drives the
+// LIVE controllers via `emit(signal, …)` and asserts the DOM event fields. This
+// e2e proves the SAME path runs UNCHANGED on node-gi:
+//
+//   gjsify build fixtures/event-bridge-app.ts --app gjs  → gjs  -m …  (native gi://)
+//   gjsify build fixtures/event-bridge-app.ts --app node → node   …   (@gjsify/node-gi)
+//
+// The ONE shared source ([../fixtures/event-bridge-app.ts](../fixtures/event-bridge-app.ts))
+// puts a `Gtk.DrawingArea` in an `ApplicationWindow`, `present()`s it (so it
+// realizes + allocates), `attachEventControllers`, then drives a synthesized
+// event through each live `Gtk.EventController*` and asserts the resulting DOM
+// event's type / coords / `getModifierState` / key / code — the `Gdk.ModifierType`
+// flags + `Gdk.keyval_*` marshalling must match GJS. It quits from a `GLib.timeout`.
+// The AUTHORITATIVE assertion (always on): the node-gi `--app node` bundle runs +
+// exits 0 and prints the fixed committed GOLDEN. Every line is deterministic +
+// display-independent (coords clamped to the fixed 400x300 allocation; key/code/
+// modifiers computed from Gdk marshalling), so the golden is stable — the same
+// committed-golden conformance pattern node-gi uses elsewhere. A gjs gold-standard
+// gate additionally re-proves the golden IS gjs's own byte-output by building +
+// running `--app gjs` (default on; set NODE_GI_EB_SKIP_GJS=1 for a node-only run —
+// see the haveGjs note); the same gold-standard parity the `canvas2d-bridge` e2e uses.
+//
+// NODE-GI GAP the fixture routes around (documented, deferred — see README): node-gi
+// does not wire `instanceof` for GObject wrapper classes, so the fixture cannot use
+// the spec's `ctrl instanceof Gtk.EventControllerMotion` controller filter. It
+// retrieves controllers by ADD ORDER off `observe_controllers()` instead (identity
+// is preserved + `emit()` resolves by the live GType). The BEHAVIOR under test —
+// the bridge dispatching correct DOM events — is unaffected.
+//
+// This is a LOCAL/dev verification, NOT wired into CI. Running the LIVE bridge needs
+// the full gjsify workspace built with a CURRENT-source `@gjsify/cli` (the
+// register-inline for --app gjs the published CLI predates) + a display + the node-gi
+// addon — a heavyweight from-scratch rebuild too fragile to gate a minimal CI
+// container on. The node-gi event-bridge behaviour is already proven by the
+// byte-parity below (run locally), captured in the committed GOLDEN. It SELF-SKIPS in
+// the default `npm test` (no display), when `gjsify` is absent, or when
+// `@gjsify/event-bridge` is not resolvable, so it is harmless in every CI leg that
+// discovers it.
+//
+// RUN LOCALLY (from a built workspace, under a display):
+//   gjsify workspace @gjsify/event-bridge build:gjsify --with-dependencies
+//   NODE_GI_NATIVE=build node --test packages/node-gi/node-gi/test/event-bridge.test.mjs
+// Under Xvfb: prefix with `xvfb-run -a dbus-run-session -- env GSK_RENDERER=cairo
+// GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none`. Point GJSIFY_BIN at a
+// current-source CLI (`…/packages/infra/cli/lib/index.js`) if `gjsify` on PATH is
+// older. GTK needs the software-render env.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = fileURLToPath(new URL('.', import.meta.url));
+// The fixture lives OUTSIDE test/ on purpose: node --test's default glob
+// (**/test/**/*.{mjs,ts,…}) would otherwise pick it up and try to run the
+// unbundled gi:// source directly, which fails to resolve.
+const pkgRoot = join(here, '..');
+const fixture = join(pkgRoot, 'fixtures', 'event-bridge-app.ts');
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+// Locate the workspace `gjsify` CLI: an explicit override, else the nearest
+// node_modules/.bin/gjsify walking up from here, else `gjsify` on PATH.
+function findGjsify() {
+    if (process.env.GJSIFY_BIN && existsSync(process.env.GJSIFY_BIN)) return process.env.GJSIFY_BIN;
+    let dir = here;
+    for (let i = 0; i < 8; i++) {
+        const cand = join(dir, 'node_modules', '.bin', 'gjsify');
+        if (existsSync(cand)) return cand;
+        const up = dirname(dir);
+        if (up === dir) break;
+        dir = up;
+    }
+    try {
+        execFileSync('gjsify', ['--version'], { stdio: 'ignore' });
+        return 'gjsify';
+    } catch {
+        return null;
+    }
+}
+
+// Is `@gjsify/event-bridge` (with a built lib/) resolvable from the fixture? On a
+// bare node-gi tree (no workspace install/build) it is not — skip cleanly there.
+function eventBridgeResolvable() {
+    try {
+        createRequire(fixture).resolve('@gjsify/event-bridge');
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const gjsify = haveDisplay ? findGjsify() : null;
+
+const skip = !haveDisplay
+    ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+    : !gjsify
+        ? 'gjsify CLI not found (workspace not installed)'
+        : !eventBridgeResolvable()
+            ? '@gjsify/event-bridge not resolvable (workspace not built)'
+            : false;
+
+// The gjs gold-standard leg re-proves the committed GOLDEN below IS exactly gjs's
+// own byte-output. It is ON by default (a local run); set NODE_GI_EB_SKIP_GJS=1 for a
+// node-gi-only run (the node-gi assertion vs the committed golden stays the
+// authoritative check — deterministic + display-independent, so the golden is stable
+// without a `gjs -m` rebuild). Building --app gjs correctly requires the
+// register-subpath-inline bundler (AGENTS.md: `@gjsify/<pkg>/register` MUST NOT be
+// externalized for --app gjs — GJS's ESM loader can't resolve it), so run it with a
+// current-source `gjsify` (see the header).
+const haveGjs = !process.env.NODE_GI_EB_SKIP_GJS
+    && spawnSync('gjs', ['--version'], { stdio: 'ignore' }).status === 0;
+
+// The fixed sequence of lines both runtimes must print, in order — the committed
+// golden. It IS gjs's own output (asserted by the local gjs leg below).
+const GOLDEN = [
+    'event-bridge: start',
+    'activated',
+    'motion: 12,8', // pointermove clientX,clientY — coords pass through the clamp
+    'move: 8,10', // movementX,movementY across successive motions
+    'clamp: 0,0', // motion(-3,-7) → clamped to the allocation lower bound
+    'wheel: 0,100', // scroll(0,1) → WheelEvent deltaX,deltaY (ticks scaled ×100)
+    'keydown: a KeyA shift=true ctrl=false', // Gdk.KEY_a + Gdk.ModifierType.SHIFT_MASK
+    'modstate: Shift=true Control=false', // KeyboardEvent.getModifierState()
+    'keydown: ArrowLeft ArrowLeft shift=false ctrl=true', // Gdk.KEY_Left + CONTROL_MASK (special-key marshalling)
+    'keyup: a', // key-released → keyup
+    'focus: focus,focusin', // EventControllerFocus enter → focus + focusin
+    'blur: blur,focusout', // EventControllerFocus leave → blur + focusout
+    'quit',
+    'done',
+].join('\n');
+
+// Only the app's own deterministic lines are asserted — a headless GTK/dbus session
+// prints assorted portal / a11y / gvfs warnings that vary by host.
+const GOLDEN_PREFIXES = [
+    'event-bridge:',
+    'activated',
+    'motion:',
+    'move:',
+    'clamp:',
+    'wheel:',
+    'keydown:',
+    'modstate:',
+    'keyup:',
+    'focus:',
+    'blur:',
+    'quit',
+    'done',
+    'activate-error:',
+];
+
+// Software-only GTK render env for the run children. DISPLAY comes from the
+// surrounding xvfb-run / real session; these keep GTK off any GPU/Vulkan path a
+// headless Xvfb cannot provide and off the a11y bus. Merged over the inherited env
+// so a value already present (DISPLAY, NODE_GI_NATIVE) is preserved.
+const RUN_ENV = {
+    GSK_RENDERER: 'cairo',
+    GDK_BACKEND: 'x11',
+    LIBGL_ALWAYS_SOFTWARE: '1',
+    GTK_A11Y: 'none',
+    NODE_GI_NATIVE: 'build', // run the just-built addon, not a stale staged prebuild
+    ...process.env,
+};
+
+function exec(cmd, args, timeoutMs, env) {
+    try {
+        return execFileSync(cmd, args, {
+            cwd: here,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            timeout: timeoutMs,
+            encoding: 'utf-8',
+            env: env ?? process.env,
+        });
+    } catch (err) {
+        const out = (err.stdout || '').toString();
+        const e = (err.stderr || '').toString();
+        throw new Error(
+            `${cmd} ${args.join(' ')} failed (code ${err.status ?? err.code})\n--- stdout ---\n${out}\n--- stderr ---\n${e}`,
+        );
+    }
+}
+
+// Invoke the resolved gjsify CLI. A workspace CLI entry (…/infra/cli/lib/index.js)
+// is a plain .js — run it via `node` so it works regardless of the +x bit; a shell
+// shim (the workspace `.bin/gjsify`) is exec'd directly. Point GJSIFY_BIN at the
+// WORKSPACE-built CLI (current source: it carries the register-inline for --app gjs
+// that the published @gjsify/cli predates).
+function gjsifyExec(args, timeoutMs) {
+    return /\.[mc]?js$/.test(gjsify)
+        ? exec(process.execPath, [gjsify, ...args], timeoutMs)
+        : exec(gjsify, args, timeoutMs);
+}
+
+function build(app, outfile) {
+    gjsifyExec(['build', fixture, '--app', app, '--outfile', outfile], 180 * 1000);
+    assert.ok(existsSync(outfile), `${outfile} was not produced`);
+    return outfile;
+}
+
+// Keep ONLY the golden lifecycle lines (each carries a known prefix).
+function run(cmd, args) {
+    const raw = exec(cmd, args, 90 * 1000, RUN_ENV);
+    return raw
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => GOLDEN_PREFIXES.some((p) => l === p || l.startsWith(p)))
+        .join('\n');
+}
+
+test(
+    'event-bridge dispatches DOM events on node-gi (byte-identical to the golden)',
+    { skip },
+    () => {
+        // Build INSIDE the monorepo (not os tmpdir): the --app node bundle keeps
+        // `@gjsify/node-gi` external, so it must run from a tree where that package
+        // resolves (the root node_modules/@gjsify/node-gi symlink). /tmp has no such
+        // node_modules → ERR_MODULE_NOT_FOUND at run time. Kept at the package root
+        // (not under test/) so a stray dir never trips node --test's glob.
+        const dir = mkdtempSync(join(pkgRoot, '.tmp-eb-'));
+        try {
+            // --- node-gi: the real `--app node` bundle (the authoritative check) ---
+            const nodeBundle = build('node', join(dir, 'app.node.mjs'));
+            // The bridge pulls @gjsify/event-bridge + its gi:// graph, so the build
+            // MUST have rewritten gi:// → requireGi. A CLI predating that rewrite is
+            // a hard failure here, not a skip.
+            assert.ok(
+                readFileSync(nodeBundle, 'utf-8').includes('requireGi'),
+                'the --app node bundle did not rewrite gi:// → requireGi (gjsify CLI too old)',
+            );
+            const nodeOut = run('node', [nodeBundle]);
+            assert.equal(nodeOut, GOLDEN, 'node-gi output diverged from the committed golden');
+
+            // --- gjs gold-standard (LOCAL/dev gate): re-prove the golden IS gjs's ---
+            // Off with NODE_GI_EB_SKIP_GJS=1 — see the haveGjs note above.
+            if (haveGjs) {
+                const gjsBundle = build('gjs', join(dir, 'app.gjs.mjs'));
+                const gjsOut = run('gjs', ['-m', gjsBundle]);
+                assert.equal(gjsOut, GOLDEN, 'gjs gold-standard diverged from the committed golden');
+                assert.equal(gjsOut, nodeOut, 'gjs and node-gi outputs are not byte-identical');
+            }
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    },
+);


### PR DESCRIPTION
## What

Proves `@gjsify/event-bridge`'s `attachEventControllers()` — the GTK4→DOM event bridge (`EventControllerMotion`/`GestureClick`/`EventControllerScroll`/`EventControllerKey`/`EventControllerFocus` → W3C Mouse/Pointer/Keyboard/Wheel/FocusEvent) — runs **unchanged on node-gi**, mirroring the just-merged `canvas2d-bridge` proof (#763).

The shared fixture (`fixtures/event-bridge-app.ts`) presents a real `Gtk.DrawingArea`, calls `attachEventControllers`, drives a synthesized event through each **live** `Gtk.EventController*` via `emit(signal, …)` (the same path the GJS `event-bridge.spec.ts` drives), asserts the dispatched DOM event fields (type, coords, `getModifierState`, key/code), and quits from a `GLib.timeout`. The `Gdk.ModifierType` flags + `Gdk.keyval_name`/`keyval_to_unicode` marshalling produce **byte-identical** output under node-gi and `gjs -m`. Same source builds `--app gjs` and `--app node`; the committed golden is deterministic + display-independent.

Files: `test/event-bridge.test.mjs`, `fixtures/event-bridge-app.ts`, README section + `.gitignore` (`.tmp-eb-*/`).

## How verified

Under a real display (locally), current-source workspace CLI as `GJSIFY_BIN`:

- **node-gi `--app node`** — the authoritative leg, asserted against the committed golden: `tests 1 / pass 1 / fail 0`.
- **gjs `-m`** — byte-identical golden, exit 0 (proves the golden IS gjs's own output):

```
event-bridge: start
activated
motion: 12,8
move: 8,10
clamp: 0,0
wheel: 0,100
keydown: a KeyA shift=true ctrl=false
modstate: Shift=true Control=false
keydown: ArrowLeft ArrowLeft shift=false ctrl=true
keyup: a
focus: focus,focusin
blur: blur,focusout
quit
done
```

- **headless** (`build-test` leg, no display): self-skips cleanly (`skipped 1`, "no display") — no regression.

## Deferred node-gi gap (native-engine follow-up)

node-gi does **not wire `instanceof`** for GObject wrapper classes — `new Gtk.EventControllerMotion() instanceof Gtk.EventControllerMotion` is `false` (even for a freshly-constructed wrapper), because the per-GType wrappers are not real JS classes with a prototype chain / `Symbol.hasInstance`. So the fixture can't use the GJS spec's `ctrl instanceof …` controller filter — it retrieves controllers by **add-order** off `widget.observe_controllers()` instead (wrapper identity IS preserved and `emit()` resolves by the live GType, so the bridged behaviour is unaffected). Documented in the README + test header. A secondary minor gap the fixture routes around: boxed structs have no `new` constructor (`new Gdk.Rectangle()` throws), so the fixture relies on the presented window's real allocation instead of a manual `size_allocate(rect)`.

## No CI job

Kept as a **self-skipping local/dev verification** (the `canvas2d-bridge` precedent — its heavyweight CI job was dropped as too fragile). No `node-gi.yml` change; the file self-skips in every CI leg that discovers it (no display / no CLI / `@gjsify/event-bridge` not built). Run recipe lives in the README + test header.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq