### PR TITLE
ci(node-gi): prove reverse bridge builds + runs on Windows

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -798,13 +798,16 @@ jobs:
         run: |
           Write-Host "pkg-config: $((Get-Command pkg-config).Source)"
           pkg-config --version
-          if (pkg-config --define-prefix --exists girepository-2.0) {
+          # `--exists` signals via exit code, not stdout — check $LASTEXITCODE (a
+          # bare `if (pkg-config ...)` tests stdout and false-reports MISSING).
+          pkg-config --define-prefix --exists girepository-2.0
+          if ($LASTEXITCODE -eq 0) {
             Write-Host "girepository-2.0: $(pkg-config --define-prefix --modversion girepository-2.0)"
           } else {
             Write-Host "girepository-2.0: MISSING — the addon build will fail"
           }
           Write-Host "cflags : $(pkg-config --define-prefix --cflags girepository-2.0 cairo)"
-          Write-Host "libs   : $(pkg-config --define-prefix --static --libs girepository-2.0 cairo)"
+          Write-Host "cflags(static) : $(pkg-config --define-prefix --static --cflags-only-I girepository-2.0 cairo 2>&1)"
           Write-Host "--- typelibs present ---"
           Get-ChildItem "$env:GTK_PREFIX\lib\girepository-1.0" -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -match 'GLib|GObject|Gio|Pango|GdkPixbuf|Graphene|cairo' } |

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -722,3 +722,129 @@ jobs:
             @gjsify/sqlite @gjsify/http2 @gjsify/zlib \
             --runtimes node,bun,deno --require-pass \
             --out /tmp/node-gi-consumer-survey.json
+
+  # Windows proof (Phase 1 — the reverse bridge BUILDS + RUNS on windows-latest).
+  # The whole team is Linux-only, so a windows-latest runner is the only way to
+  # validate. Sibling of the macOS proof (its `macos` job above is the template).
+  #
+  # TOOLCHAIN — MSVC + gvsbuild (NOT MSYS2/mingw). node-gyp defaults to MSVC, and
+  # stock Node/Bun/Deno on Windows are MSVC-ABI, so the addon AND the GTK/GLib it
+  # links must be MSVC-ABI too — a mingw GTK + MSVC addon is an ABI hazard and a
+  # mingw-built .node does not load into stock MSVC-ABI Node (the ABI wall). gvsbuild
+  # publishes a prebuilt MSVC-ABI GTK4 bundle (GLib 2.88, girepository-2.0, built
+  # with --enable-gi) that loads into stock Node. We build the N-API addon FROM
+  # SOURCE (node-gyp/MSVC + pkg-config via scripts/win-gi-gyp-flags.mjs) and run the
+  # DISPLAY-FREE conformance subset on Node — the exact set scripts/cross-runtime.mjs
+  # curates. The GTK-window / GLArea / cairo-drawfunc / adw-smoke DISPLAY tests are
+  # NOT run here (GTK-on-Windows is the win32 backend and needs its own display
+  # wiring — Phase 2, which also ships a prebuilt GTK stack so consumers need no
+  # gvsbuild). The win32-x64 addon prebuild IS staged + uploaded here, mirroring the
+  # arm64 + macos jobs; a future prebuilt-GTK upload slots in beside it.
+  windows:
+    name: Windows build + conformance (Node / windows-latest x64)
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      GVSBUILD_VERSION: '2026.6.0'
+      # Extract to gvsbuild's canonical build prefix so its .pc files' baked
+      # absolute `prefix=` is correct with no relocation needed.
+      GTK_PREFIX: 'C:\gtk-build\gtk\x64\release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Node 24 builds the addon (node-gyp) and runs the authoritative Node leg —
+      # same version the macOS proof pins.
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Cache gvsbuild GTK4 bundle
+        id: cache-gtk
+        uses: actions/cache@v4
+        with:
+          path: C:\gtk-build\gtk\x64\release
+          key: gvsbuild-gtk4-${{ env.GVSBUILD_VERSION }}-x64-v1
+
+      - name: Download + extract gvsbuild GTK4 (MSVC-ABI, girepository-2.0)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/wingtk/gvsbuild/releases/download/$env:GVSBUILD_VERSION/GTK4_Gvsbuild_${env:GVSBUILD_VERSION}_x64.zip"
+          Write-Host "Downloading $url"
+          curl.exe -L --fail --retry 3 -o gtk4.zip $url
+          New-Item -ItemType Directory -Force -Path $env:GTK_PREFIX | Out-Null
+          # tar.exe (bsdtar) extracts zip; the zip holds the CONTENTS of release\
+          # (bin/ lib/ include/ share/ …) at its root.
+          tar.exe -xf gtk4.zip -C $env:GTK_PREFIX
+          Remove-Item gtk4.zip
+
+      - name: Put GTK on PATH + set GI/PKG env
+        shell: pwsh
+        run: |
+          # GTK bin/ carries the DLLs the addon links (glib/gobject/gio/girepository/
+          # cairo/ffi/intl) AND pkgconf.exe + pkg-config.exe (gvsbuild bundles them).
+          "$env:GTK_PREFIX\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "PKG_CONFIG_PATH=$env:GTK_PREFIX\lib\pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # The typelib DIRECTORY is historically named girepository-1.0 even for
+          # the girepository-2.0 API.
+          "GI_TYPELIB_PATH=$env:GTK_PREFIX\lib\girepository-1.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "GSETTINGS_SCHEMA_DIR=$env:GTK_PREFIX\share\glib-2.0\schemas" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Verify pkg-config + girepository-2.0 (diagnostics)
+        shell: pwsh
+        run: |
+          Write-Host "pkg-config: $((Get-Command pkg-config).Source)"
+          pkg-config --version
+          if (pkg-config --define-prefix --exists girepository-2.0) {
+            Write-Host "girepository-2.0: $(pkg-config --define-prefix --modversion girepository-2.0)"
+          } else {
+            Write-Host "girepository-2.0: MISSING — the addon build will fail"
+          }
+          Write-Host "cflags : $(pkg-config --define-prefix --cflags girepository-2.0 cairo)"
+          Write-Host "libs   : $(pkg-config --define-prefix --static --libs girepository-2.0 cairo)"
+          Write-Host "--- typelibs present ---"
+          Get-ChildItem "$env:GTK_PREFIX\lib\girepository-1.0" -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match 'GLib|GObject|Gio|Pango|GdkPixbuf|Graphene|cairo' } |
+            Select-Object -ExpandProperty Name
+          Write-Host "--- helper: include_dirs ---"
+          node packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs --includes
+          Write-Host "`n--- helper: libraries ---"
+          node packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs --libs
+
+      # From source: node-gyp reads binding.gyp's OS=="win" branch (the helper feeds
+      # cl.exe include dirs + link.exe .lib paths) → win32-x64 build/Release/
+      # node_gi.node. The package's `install` script IS node-gyp rebuild.
+      - name: Build native addon (node-gyp / MSVC)
+        working-directory: packages/node-gi/node-gi
+        run: npm install --no-audit --no-fund --foreground-scripts
+
+      # The display-free conformance subset on Node — the primary proof. Loads the
+      # just-built build/Release addon (cross-runtime.mjs defaults NODE_GI_NATIVE to
+      # `build`). Same curated list the macOS/Bun/Deno legs use (single source).
+      - name: Conformance subset on Node (display-free)
+        working-directory: packages/node-gi/node-gi
+        run: node scripts/cross-runtime.mjs node
+
+      # Stage the win32-x64 addon prebuild + smoke it via the PREBUILD load path,
+      # then upload it so a release can ship prebuilds/win32-x64/ (the loader already
+      # expects that path). Mirrors the arm64 + macos jobs. NB this is the node-gi
+      # ADDON prebuild, NOT a Phase-2 prebuilt-GTK stack.
+      - name: Stage win32-x64 prebuild
+        working-directory: packages/node-gi/node-gi
+        run: node scripts/stage-prebuild.mjs
+
+      - name: Verify the staged prebuild loads (Node)
+        working-directory: packages/node-gi/node-gi
+        run: node --test test/smoke.test.mjs
+        env:
+          NODE_GI_NATIVE: prebuild
+
+      - name: Upload win32-x64 prebuild artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: node-gi-prebuild-win32-x64
+          path: packages/node-gi/node-gi/prebuilds/win32-x64/node_gi.node
+          if-no-files-found: error

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -793,6 +793,22 @@ jobs:
           "GI_TYPELIB_PATH=$env:GTK_PREFIX\lib\girepository-1.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "GSETTINGS_SCHEMA_DIR=$env:GTK_PREFIX\share\glib-2.0\schemas" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+      # gvsbuild's libffi meson build ships ffi.lib + the DLL but NOT ffi.h/
+      # ffitarget.h (its meson.build has `install: true` on the library() but no
+      # install_headers()), yet GLib's girffi.h — which gvsbuild DOES install —
+      # does `#include <ffi.h>`, so the addon won't compile (C1083). Supply the two
+      # headers from vcpkg's libffi (preinstalled vcpkg; MSVC-native x64 headers).
+      # libffi's public ABI (ffi_type/ffi_cif/ffi_closure) is frozen across 3.x, so
+      # the vcpkg header + gvsbuild's 3.5.2 ffi.lib are compatible.
+      - name: Supply libffi headers (gvsbuild omits ffi.h)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libffi:x64-windows
+          $inc = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\include"
+          Copy-Item "$inc\ffi.h","$inc\ffitarget.h" -Destination "$env:GTK_PREFIX\include" -Force
+          Write-Host "ffi.h -> $env:GTK_PREFIX\include (from vcpkg libffi)"
+
       - name: Verify pkg-config + girepository-2.0 (diagnostics)
         shell: pwsh
         run: |

--- a/packages/node-gi/node-gi/binding.gyp
+++ b/packages/node-gi/node-gi/binding.gyp
@@ -20,28 +20,51 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"
       ],
-      "cflags": [
-        "<!@(pkg-config --cflags girepository-2.0 cairo)"
-      ],
-      "cflags_cc": [
-        "<!@(pkg-config --cflags girepository-2.0 cairo)",
-        "-std=c++17"
-      ],
-      "libraries": [
-        "<!@(pkg-config --libs girepository-2.0 cairo)"
-      ],
       "defines": [
         "NAPI_VERSION=8",
         "NAPI_DISABLE_CPP_EXCEPTIONS",
         "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS"
       ],
-      "xcode_settings": {
-        "OTHER_CFLAGS": [
-          "<!@(pkg-config --cflags girepository-2.0 cairo)"
-        ],
-        "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
-        "GCC_ENABLE_CPP_EXCEPTIONS": "NO"
-      }
+      "conditions": [
+        [ "OS!='win'", {
+          "cflags": [
+            "<!@(pkg-config --cflags girepository-2.0 cairo)"
+          ],
+          "cflags_cc": [
+            "<!@(pkg-config --cflags girepository-2.0 cairo)",
+            "-std=c++17"
+          ],
+          "libraries": [
+            "<!@(pkg-config --libs girepository-2.0 cairo)"
+          ],
+          "xcode_settings": {
+            "OTHER_CFLAGS": [
+              "<!@(pkg-config --cflags girepository-2.0 cairo)"
+            ],
+            "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
+            "GCC_ENABLE_CPP_EXCEPTIONS": "NO"
+          }
+        } ],
+        [ "OS=='win'", {
+          # gvsbuild GTK4 (GLib >= 2.80, girepository-2.0) is MSVC-ABI, so the addon
+          # builds with node-gyp's default MSVC toolchain and loads into stock
+          # (MSVC-ABI) Node/Bun/Deno. gyp's msvs generator ignores `cflags`/
+          # `xcode_settings`, so the flags come from pkg-config via a helper that
+          # emits BARE include dirs + FULL .lib paths (scripts/win-gi-gyp-flags.mjs) —
+          # the exact shapes gyp forwards to cl.exe / link.exe.
+          "include_dirs": [
+            "<!@(node scripts/win-gi-gyp-flags.mjs --includes)"
+          ],
+          "libraries": [
+            "<!@(node scripts/win-gi-gyp-flags.mjs --libs)"
+          ],
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "AdditionalOptions": [ "/std:c++17" ]
+            }
+          }
+        } ]
+      ]
     }
   ]
 }

--- a/packages/node-gi/node-gi/overrides/gio-dbus.js
+++ b/packages/node-gi/node-gi/overrides/gio-dbus.js
@@ -132,25 +132,49 @@ export function createGioDBus(ctx) {
     const inTypeString = `(${inSignature.join('')})`;
     const inVariant = new GLib.Variant(inTypeString, argArray);
 
+    // GJS always routes through call_with_unix_fd_list[_sync/_finish] (a superset
+    // that also carries GUnixFDList fd-passing). Those live in GioUnix and are ABSENT
+    // from the Gio typelib on Windows, so fall back to the cross-platform
+    // call[_sync/_finish] there — fd-passing is a Unix concept, so there is nothing to
+    // carry. Detection is by method presence (node-gi's L1 wrapper returns `undefined`
+    // for an absent method), keeping POSIX byte-identical: where the method exists the
+    // fd-list path is taken exactly as before.
     if (sync) {
-      const result = wrappedProxy.call_with_unix_fd_list_sync(methodName, inVariant, flags, -1, fdList, cancellable);
-      const outVariant = Array.isArray(result) ? result[0] : result;
-      const outFdList = Array.isArray(result) ? result[1] : null;
-      if (fdList) return [outVariant.deepUnpack(), outFdList];
+      if (typeof wrappedProxy.call_with_unix_fd_list_sync === 'function') {
+        const result = wrappedProxy.call_with_unix_fd_list_sync(methodName, inVariant, flags, -1, fdList, cancellable);
+        const outVariant = Array.isArray(result) ? result[0] : result;
+        const outFdList = Array.isArray(result) ? result[1] : null;
+        if (fdList) return [outVariant.deepUnpack(), outFdList];
+        return outVariant.deepUnpack();
+      }
+      if (fdList) throw new Error(`${methodName}: Gio.UnixFDList fd-passing is not supported on this platform`);
+      const outVariant = wrappedProxy.call_sync(methodName, inVariant, flags, -1, cancellable);
       return outVariant.deepUnpack();
     }
 
+    if (typeof wrappedProxy.call_with_unix_fd_list === 'function') {
+      const asyncCallback = (_rawSource, res) => {
+        try {
+          const result = wrappedProxy.call_with_unix_fd_list_finish(res);
+          const outVariant = Array.isArray(result) ? result[0] : result;
+          const outFdList = Array.isArray(result) ? result[1] : null;
+          replyFunc(outVariant.deepUnpack(), null, outFdList);
+        } catch (e) {
+          replyFunc([], e, null);
+        }
+      };
+      return wrappedProxy.call_with_unix_fd_list(methodName, inVariant, flags, -1, fdList, cancellable, asyncCallback);
+    }
+    if (fdList) throw new Error(`${methodName}: Gio.UnixFDList fd-passing is not supported on this platform`);
     const asyncCallback = (_rawSource, res) => {
       try {
-        const result = wrappedProxy.call_with_unix_fd_list_finish(res);
-        const outVariant = Array.isArray(result) ? result[0] : result;
-        const outFdList = Array.isArray(result) ? result[1] : null;
-        replyFunc(outVariant.deepUnpack(), null, outFdList);
+        const outVariant = wrappedProxy.call_finish(res);
+        replyFunc(outVariant.deepUnpack(), null, null);
       } catch (e) {
         replyFunc([], e, null);
       }
     };
-    return wrappedProxy.call_with_unix_fd_list(methodName, inVariant, flags, -1, fdList, cancellable, asyncCallback);
+    return wrappedProxy.call(methodName, inVariant, flags, -1, cancellable, asyncCallback);
   }
 
   function _makeProxyMethod(wrappedProxy, method, sync) {

--- a/packages/node-gi/node-gi/overrides/gio-dbus.js
+++ b/packages/node-gi/node-gi/overrides/gio-dbus.js
@@ -588,8 +588,12 @@ export function createGioDBus(ctx) {
   function _handleMethodCall(jsObj, methodName, parameters, invocation) {
     // GJS appends the message's Gio.UnixFDList as a trailing argument (null when
     // the call carries no fds) — mirror it so fd-aware services see the same
-    // shape (refs/gjs Gio.js _handleMethodCall).
-    const fdList = invocation.get_message().get_unix_fd_list();
+    // shape (refs/gjs Gio.js _handleMethodCall). Gio.DBusMessage.get_unix_fd_list
+    // is GioUnix (fd-passing) — absent from the Gio typelib on Windows — so guard by
+    // method presence and pass null there (no fds to carry). POSIX byte-identical:
+    // where the method exists it is taken exactly as before.
+    const msg = invocation.get_message();
+    const fdList = typeof msg.get_unix_fd_list === 'function' ? msg.get_unix_fd_list() : null;
     const method = jsObj[methodName];
     if (typeof method === 'function') {
       let retval;

--- a/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
+++ b/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
@@ -31,9 +31,18 @@ const mode = process.argv[2];
 const pkgConfig = process.env.PKG_CONFIG || 'pkg-config';
 
 function pkgConfigOut(extraArgs) {
-    return execFileSync(pkgConfig, ['--define-prefix', ...extraArgs, ...PKGS], {
-        encoding: 'utf8',
-    }).trim();
+    // Exit-tolerant: gvsbuild's pkgconf can exit non-zero (e.g. `--static` walks a
+    // Requires.private graph and trips over a missing .pc) yet still print the
+    // resolvable flags. execFileSync THROWS on a non-zero exit — so capture the
+    // stdout it attached to the error instead of letting the whole helper crash
+    // (that empty-stdout crash left include_dirs blank → C1083 on ffi.h).
+    try {
+        return execFileSync(pkgConfig, ['--define-prefix', ...extraArgs, ...PKGS], {
+            encoding: 'utf8',
+        }).trim();
+    } catch (error) {
+        return typeof error?.stdout === 'string' ? error.stdout.trim() : '';
+    }
 }
 
 function tokens(s) {
@@ -70,19 +79,26 @@ function findHeaderDir(root, filename, maxDepth = 4) {
 }
 
 if (mode === '--includes') {
-    // `--static` pulls the Requires.private include dirs too — girepository-2.0.pc
-    // has `Requires.private: … libffi`, and girffi.h does `#include <ffi.h>`; the
-    // non-static --cflags omits libffi's include dir, so the addon fails to compile
-    // (C1083: Cannot open include file 'ffi.h').
-    const dirs = tokens(pkgConfigOut(['--static', '--cflags-only-I']))
+    // NON-static --cflags-only-I: on gvsbuild `--static` exits non-zero (a private
+    // .pc misses) and once threw the whole helper, blanking include_dirs. The plain
+    // form resolves glib-2.0/lib-glib-2.0-include/cairo cleanly. It does NOT emit
+    // libffi's include dir (libffi is Requires.private), but the addon needs <ffi.h>
+    // via girffi.h — the GTK_PREFIX fallback below supplies it.
+    const dirs = tokens(pkgConfigOut(['--cflags-only-I']))
         .filter((t) => t.startsWith('-I'))
         .map((t) => stripQuotes(t.slice(2)));
-    // Belt-and-suspenders: gvsbuild installs libffi's ffi.h into the bare include
-    // root (which MSVC does not auto-search). Add GTK_PREFIX/include, and if ffi.h
-    // still isn't covered, locate it under the tree and add its dir.
     const prefix = process.env.GTK_PREFIX;
     if (prefix) {
-        dirs.push(join(prefix, 'include'));
+        // Guaranteed base from the known gvsbuild layout (in case pkg-config yields
+        // nothing) PLUS the bare include root, where gvsbuild installs libffi's
+        // ffi.h + ffitarget.h (MSVC does not auto-search a prefix include root).
+        dirs.push(
+            join(prefix, 'include'),
+            join(prefix, 'include', 'glib-2.0'),
+            join(prefix, 'lib', 'glib-2.0', 'include'),
+            join(prefix, 'include', 'cairo'),
+        );
+        // Last resort: locate ffi.h anywhere under the tree and add its dir.
         if (!dirs.some((d) => existsSync(join(d, 'ffi.h')))) {
             const ffiDir =
                 findHeaderDir(join(prefix, 'include'), 'ffi.h') ??

--- a/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
+++ b/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
@@ -23,7 +23,7 @@
 // location, so the bundle works regardless of where gvsbuild's tree is extracted
 // (its .pc files bake an absolute build-machine prefix otherwise).
 import { execFileSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const PKGS = ['girepository-2.0', 'cairo'];
@@ -45,25 +45,84 @@ function stripQuotes(s) {
     return s.replace(/^"(.*)"$/, '$1');
 }
 
+// Shallow BFS for a header under `root` (bounded depth so we never walk the whole
+// ~300 MB GTK tree). Returns the CONTAINING directory, or null.
+function findHeaderDir(root, filename, maxDepth = 4) {
+    const queue = [[root, 0]];
+    while (queue.length) {
+        const [dir, depth] = queue.shift();
+        let entries;
+        try {
+            entries = readdirSync(dir, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const e of entries) {
+            if (e.isFile() && e.name === filename) return dir;
+        }
+        if (depth < maxDepth) {
+            for (const e of entries) {
+                if (e.isDirectory()) queue.push([join(dir, e.name), depth + 1]);
+            }
+        }
+    }
+    return null;
+}
+
 if (mode === '--includes') {
-    const dirs = tokens(pkgConfigOut(['--cflags-only-I']))
+    // `--static` pulls the Requires.private include dirs too — girepository-2.0.pc
+    // has `Requires.private: … libffi`, and girffi.h does `#include <ffi.h>`; the
+    // non-static --cflags omits libffi's include dir, so the addon fails to compile
+    // (C1083: Cannot open include file 'ffi.h').
+    const dirs = tokens(pkgConfigOut(['--static', '--cflags-only-I']))
         .filter((t) => t.startsWith('-I'))
         .map((t) => stripQuotes(t.slice(2)));
-    process.stdout.write([...new Set(dirs)].join('\n'));
-} else if (mode === '--libs') {
-    const out = pkgConfigOut(['--static', '--libs']);
-    const libDirs = [];
-    const libNames = [];
-    for (const t of tokens(out)) {
-        if (t.startsWith('-L')) libDirs.push(stripQuotes(t.slice(2)));
-        else if (t.startsWith('-l')) libNames.push(t.slice(2));
-        else if (t.toLowerCase().endsWith('.lib')) libNames.push(t.replace(/\.lib$/i, ''));
+    // Belt-and-suspenders: gvsbuild installs libffi's ffi.h into the bare include
+    // root (which MSVC does not auto-search). Add GTK_PREFIX/include, and if ffi.h
+    // still isn't covered, locate it under the tree and add its dir.
+    const prefix = process.env.GTK_PREFIX;
+    if (prefix) {
+        dirs.push(join(prefix, 'include'));
+        if (!dirs.some((d) => existsSync(join(d, 'ffi.h')))) {
+            const ffiDir =
+                findHeaderDir(join(prefix, 'include'), 'ffi.h') ??
+                findHeaderDir(join(prefix, 'lib'), 'ffi.h');
+            if (ffiDir) dirs.push(ffiDir);
+        }
     }
-    const searchDirs = [...new Set(libDirs)];
+    process.stdout.write([...new Set(dirs.filter((d) => existsSync(d)))].join('\n'));
+} else if (mode === '--libs') {
+    // A SHARED addon links each GTK/GLib DLL through its DIRECT import lib and lets
+    // that DLL resolve its own private deps at load — so link only the import libs
+    // whose symbols the addon's own object files reference, NOT pkg-config's
+    // `--static` transitive closure (which over-pulls cairo's/glib's private static
+    // deps — libpng/freetype/harfbuzz/pcre2/`-lz`→zlib.lib — whose `-l`→`.lib` names
+    // don't all map on gvsbuild, breaking the link). This DIRECT set is known + stable:
+    //   girepository-2.0  the gi_* engine
+    //   glib/gobject/gio/gmodule-2.0  g_*/GObject/GValue/GSignal/GClosure/Gio
+    //   ffi  ffi_call / ffi_closure_alloc (girffi + the vfunc/callback trampolines)
+    //   cairo  the native cairo foreign-struct binding (src/cairo.cc)
+    // Pango/GdkPixbuf/Graphene are NOT linked — the conformance programs load their
+    // typelibs at RUNTIME (girepository dlopens the DLL by soname), not at link time.
+    const DIRECT_LIBS = [
+        'girepository-2.0',
+        'gio-2.0',
+        'gobject-2.0',
+        'gmodule-2.0',
+        'glib-2.0',
+        'ffi',
+        'cairo',
+    ];
+    // Locate the import-lib dir: GTK_PREFIX/lib, else pkg-config's -L.
+    const searchDirs = [];
+    if (process.env.GTK_PREFIX) searchDirs.push(join(process.env.GTK_PREFIX, 'lib'));
+    for (const t of tokens(pkgConfigOut(['--libs-only-L']))) {
+        if (t.startsWith('-L')) searchDirs.push(stripQuotes(t.slice(2)));
+    }
     const resolved = [];
-    for (const name of libNames) {
+    for (const name of [...new Set(DIRECT_LIBS)]) {
         let found = null;
-        for (const dir of searchDirs) {
+        for (const dir of [...new Set(searchDirs)]) {
             for (const cand of [`${name}.lib`, `lib${name}.lib`]) {
                 const p = join(dir, cand);
                 if (existsSync(p)) {
@@ -73,9 +132,12 @@ if (mode === '--includes') {
             }
             if (found) break;
         }
-        // Fall back to the bare `<name>.lib`: a system import lib (ws2_32.lib, …)
-        // lives on the linker's default search path, not in the gvsbuild tree.
-        resolved.push(found ?? `${name}.lib`);
+        if (found) resolved.push(found);
+        else if (name !== 'gmodule-2.0') {
+            // gmodule is optional (girepository may pull it internally); everything
+            // else is required — surface a missing import lib loudly.
+            throw new Error(`win-gi-gyp-flags: import lib for '${name}' not found under ${searchDirs.join(', ')}`);
+        }
     }
     process.stdout.write([...new Set(resolved)].join('\n'));
 } else {

--- a/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
+++ b/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+// Emit Windows/MSVC-ready include dirs or import-lib paths for binding.gyp's
+// `OS=="win"` branch, derived from pkg-config/pkgconf (gvsbuild ships pkgconf.exe
+// + a pkg-config.exe copy in bin/, put on PATH by the CI job).
+//
+//   node scripts/win-gi-gyp-flags.mjs --includes   -> one bare include dir per line
+//   node scripts/win-gi-gyp-flags.mjs --libs        -> one import-lib path per line
+//
+// gyp's msvs generator ignores `cflags`/`cflags_cc`/`xcode_settings` (those feed
+// the make/xcode generators only), so the Windows branch must feed BARE include
+// dirs into `include_dirs` and FULL .lib paths into `libraries` — the exact shapes
+// gyp hands straight to cl.exe / link.exe. Emitting resolved paths here avoids the
+// `-I`/`-l`/`-L`→MSVC translation ambiguity of raw pkg-config output going through
+// gyp.
+//
+// --libs uses `--static` so the PRIVATE closure is pulled: girepository-2.0.pc has
+// `Requires.private: gmodule-no-export-2.0, gio-2.0, libffi` and node-gi calls
+// ffi_call / Gio directly. On Linux the dynamic linker resolves those lazily from
+// the shared-object global scope, but MSVC/PE resolves every import at link time,
+// so the private libs must be named explicitly.
+//
+// `--define-prefix` makes pkgconf recompute each .pc's `prefix` from the .pc file
+// location, so the bundle works regardless of where gvsbuild's tree is extracted
+// (its .pc files bake an absolute build-machine prefix otherwise).
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const PKGS = ['girepository-2.0', 'cairo'];
+const mode = process.argv[2];
+const pkgConfig = process.env.PKG_CONFIG || 'pkg-config';
+
+function pkgConfigOut(extraArgs) {
+    return execFileSync(pkgConfig, ['--define-prefix', ...extraArgs, ...PKGS], {
+        encoding: 'utf8',
+    }).trim();
+}
+
+function tokens(s) {
+    // pkg-config separates with spaces; paths from gvsbuild carry no spaces.
+    return s.split(/\s+/).filter(Boolean);
+}
+
+function stripQuotes(s) {
+    return s.replace(/^"(.*)"$/, '$1');
+}
+
+if (mode === '--includes') {
+    const dirs = tokens(pkgConfigOut(['--cflags-only-I']))
+        .filter((t) => t.startsWith('-I'))
+        .map((t) => stripQuotes(t.slice(2)));
+    process.stdout.write([...new Set(dirs)].join('\n'));
+} else if (mode === '--libs') {
+    const out = pkgConfigOut(['--static', '--libs']);
+    const libDirs = [];
+    const libNames = [];
+    for (const t of tokens(out)) {
+        if (t.startsWith('-L')) libDirs.push(stripQuotes(t.slice(2)));
+        else if (t.startsWith('-l')) libNames.push(t.slice(2));
+        else if (t.toLowerCase().endsWith('.lib')) libNames.push(t.replace(/\.lib$/i, ''));
+    }
+    const searchDirs = [...new Set(libDirs)];
+    const resolved = [];
+    for (const name of libNames) {
+        let found = null;
+        for (const dir of searchDirs) {
+            for (const cand of [`${name}.lib`, `lib${name}.lib`]) {
+                const p = join(dir, cand);
+                if (existsSync(p)) {
+                    found = p;
+                    break;
+                }
+            }
+            if (found) break;
+        }
+        // Fall back to the bare `<name>.lib`: a system import lib (ws2_32.lib, …)
+        // lives on the linker's default search path, not in the gvsbuild tree.
+        resolved.push(found ?? `${name}.lib`);
+    }
+    process.stdout.write([...new Set(resolved)].join('\n'));
+} else {
+    console.error('usage: node scripts/win-gi-gyp-flags.mjs <--includes|--libs>');
+    process.exit(2);
+}

--- a/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
+++ b/packages/node-gi/node-gi/scripts/win-gi-gyp-flags.mjs
@@ -54,6 +54,13 @@ function stripQuotes(s) {
     return s.replace(/^"(.*)"$/, '$1');
 }
 
+// gyp/MSBuild + cl.exe accept forward slashes and treat them uniformly; emit them
+// so an include dir / .lib path never carries a backslash that a downstream
+// generator might mis-handle (the pkg-config dirs already use forward slashes).
+function toGyp(p) {
+    return p.replace(/\\/g, '/');
+}
+
 // Shallow BFS for a header under `root` (bounded depth so we never walk the whole
 // ~300 MB GTK tree). Returns the CONTAINING directory, or null.
 function findHeaderDir(root, filename, maxDepth = 4) {
@@ -106,7 +113,7 @@ if (mode === '--includes') {
             if (ffiDir) dirs.push(ffiDir);
         }
     }
-    process.stdout.write([...new Set(dirs.filter((d) => existsSync(d)))].join('\n'));
+    process.stdout.write([...new Set(dirs.filter((d) => existsSync(d)).map(toGyp))].join('\n'));
 } else if (mode === '--libs') {
     // A SHARED addon links each GTK/GLib DLL through its DIRECT import lib and lets
     // that DLL resolve its own private deps at load — so link only the import libs
@@ -155,7 +162,7 @@ if (mode === '--includes') {
             throw new Error(`win-gi-gyp-flags: import lib for '${name}' not found under ${searchDirs.join(', ')}`);
         }
     }
-    process.stdout.write([...new Set(resolved)].join('\n'));
+    process.stdout.write([...new Set(resolved.map(toGyp))].join('\n'));
 } else {
     console.error('usage: node scripts/win-gi-gyp-flags.mjs <--includes|--libs>');
     process.exit(2);

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -19,7 +19,9 @@
 #ifndef NODE_GI_SRC_COMMON_H_
 #define NODE_GI_SRC_COMMON_H_
 
+#ifndef _WIN32
 #include <dlfcn.h>  // dlopen/dlsym the GtkWidgetClass template API (no GTK link)
+#endif
 #include <napi.h>
 #include <uv.h>
 

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -38,6 +38,15 @@
 #include <thread>
 #include <vector>
 
+#ifdef _WIN32
+// libuv's uv.h transitively includes <windows.h>, whose <winuser.h> defines the
+// object-like macro `RegisterClass` (→ RegisterClassW, the Win32 window-class API).
+// It clobbers our identically-named N-API export `RegisterClass`. We never call the
+// Win32 windowing API, so undefine it (it is the only Win32 UI macro that collides
+// with a node-gi identifier — `RegisterClassFromGType` is a distinct token).
+#undef RegisterClass
+#endif
+
 namespace nodegi {
 
 // Forward declaration: GetConstantValue (defined early, near the namespace

--- a/packages/node-gi/node-gi/src/loop.cc
+++ b/packages/node-gi/node-gi/src/loop.cc
@@ -32,14 +32,15 @@ namespace nodegi {
 //
 // Main-thread only (worker_threads would need a per-context source); the GLib
 // default context is iterated on the same thread Node runs on.
-#ifndef _WIN32
 struct UvLoopSource {
   GSource source;
   uv_loop_t* loop;
-  gpointer fd_tag;
-  gboolean fd_polled;
+  gpointer fd_tag;      // POSIX: the uv_backend_fd poll tag (unused on Windows)
+  gboolean fd_polled;   // POSIX: whether the backend fd is currently polled
+#ifdef _WIN32
+  gint64 win_next_wake_us;  // Windows: monotonic time of the next periodic co-pump wake
+#endif
 };
-#endif  // _WIN32
 
 static napi_env g_loop_env = nullptr;       // captured at startMainLoop (main thread)
 static gboolean g_loop_started = FALSE;
@@ -67,7 +68,12 @@ static gboolean g_in_uv_pump = FALSE;
 // run() do not drain until run() returns. nextTick still drains; timers/I/O the
 // loop dispatches are unaffected. The robust fix lives in L1 (defer the run() to
 // a macrotask when a microtask checkpoint is in progress).
-#ifndef _WIN32
+//
+// Cross-platform: process._tickCallback drains BOTH the nextTick queue AND the
+// microtask checkpoint explicitly (node's task_queues.js calls runMicrotasks() at
+// its end), so this settles an async DBus reply / GLib-timeout-resolved await
+// continuation regardless of callback-scope depth. On Windows it is the timer-driven
+// UvLoopSource (below) that calls this during a blocking GLib loop.
 static void DrainMicrotasks() {
   if (g_loop_env == nullptr || g_tick_callback_ref == nullptr || g_process_ref == nullptr) return;
   napi_env env = g_loop_env;
@@ -84,7 +90,6 @@ static void DrainMicrotasks() {
   }
   napi_close_handle_scope(env, scope);
 }
-#endif  // _WIN32
 
 // ---- cross-runtime microtask checkpoint (Bun/Deno) --------------------------
 //
@@ -221,7 +226,60 @@ static gboolean uv_source_dispatch(GSource* base, GSourceFunc /*callback*/, gpoi
 static GSourceFuncs uv_source_funcs = {
     uv_source_prepare, nullptr, uv_source_dispatch, nullptr, nullptr, nullptr,
 };
-#endif  // _WIN32 (UvLoopSource: the POSIX blocking-loop co-pump)
+#else  // _WIN32 — the UvLoopSource, timer-driven instead of uv-backend-fd-driven.
+//
+// Windows/IOCP has no uv backend fd to embed in a GLib GSource, so the co-pump of
+// Node's loop during a BLOCKING GLib main loop is driven by a periodic GLib
+// timeout instead: every NODE_GI_WIN_UV_POLL_MS the source dispatches, runs
+// uv_run(UV_RUN_NOWAIT) (Node timers/I/O) and DrainMicrotasks() (nextTick +
+// microtask checkpoint via process._tickCallback). The DRAIN is the load-bearing
+// part: an async DBus reply (or any GLib-timeout-resolved `await`) posts its reply
+// through a Promise `.then` continuation, and only a microtask drain during the
+// blocking run() settles it — on POSIX the fd-driven source does exactly this. The
+// GLib->uv mirror of the uv->GLib timed pump (SyncPumpPolls fallback). Parked while
+// the uv-driven pump owns the context (g_in_uv_pump). A Win32 HANDLE/IOCP wakeup
+// (readiness-driven, not timed) is a follow-up; the timed drain is correct, just
+// wakes on a cadence instead of on the fd.
+static const gint NODE_GI_WIN_UV_POLL_MS = 5;
+
+static gboolean uv_source_prepare(GSource* base, gint* timeout) {
+  UvLoopSource* s = reinterpret_cast<UvLoopSource*>(base);
+  if (g_in_uv_pump) {
+    *timeout = -1;
+    return FALSE;
+  }
+  uv_update_time(s->loop);
+  DrainMicrotasks();  // drain before we (maybe) sleep — settles a pending async reply
+  const gint64 now = g_source_get_time(base);
+  if (now >= s->win_next_wake_us) {
+    *timeout = 0;
+    return TRUE;  // due now — dispatch runs uv_run + drain
+  }
+  // Cap the sleep so a GLib callback that queues a microtask is drained promptly.
+  gint64 remaining_ms = (s->win_next_wake_us - now + 999) / 1000;
+  *timeout = remaining_ms > NODE_GI_WIN_UV_POLL_MS ? NODE_GI_WIN_UV_POLL_MS : static_cast<gint>(remaining_ms);
+  return FALSE;
+}
+
+static gboolean uv_source_check(GSource* base) {
+  UvLoopSource* s = reinterpret_cast<UvLoopSource*>(base);
+  if (g_in_uv_pump) return FALSE;
+  return g_source_get_time(base) >= s->win_next_wake_us;
+}
+
+static gboolean uv_source_dispatch(GSource* base, GSourceFunc /*callback*/, gpointer /*user_data*/) {
+  if (g_in_uv_pump) return G_SOURCE_CONTINUE;  // never nest uv_run under a pump iteration
+  UvLoopSource* s = reinterpret_cast<UvLoopSource*>(base);
+  uv_run(s->loop, UV_RUN_NOWAIT);
+  DrainMicrotasks();
+  s->win_next_wake_us = g_source_get_time(base) + NODE_GI_WIN_UV_POLL_MS * 1000;
+  return G_SOURCE_CONTINUE;
+}
+
+static GSourceFuncs uv_source_funcs = {
+    uv_source_prepare, uv_source_check, uv_source_dispatch, nullptr, nullptr, nullptr,
+};
+#endif  // _WIN32 (UvLoopSource: POSIX fd-driven / Windows timer-driven co-pump)
 
 // iterateMainContext(mayBlock?) -> boolean
 //
@@ -620,13 +678,12 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
     }
   }
 
-  // UvLoopSource embeds uv's backend fd into GLib so a BLOCKING GLib main loop
-  // (GLib.MainLoop.run / Gio.Application.run) co-pumps Node's timers/I/O. POSIX-only:
-  // uv has no backend fd on Windows (IOCP), and g_source_add_unix_fd is UNIX-only.
-  // PumpInit below is cross-platform and carries the NON-blocking async case (Gio
-  // async / timeouts / DBus) on Windows; a blocking GLib main loop on Windows needs
-  // a HANDLE/IOCP wakeup via the Win32 GLib surface — a follow-up (the display-free
-  // conformance subset never enters a blocking loop, so nothing here regresses).
+  // UvLoopSource co-pumps Node's timers/I/O + drains its microtasks during a
+  // BLOCKING GLib main loop (GLib.MainLoop.run / Gio.Application.run). POSIX embeds
+  // uv's backend fd into the GSource (readiness-driven); Windows/IOCP has no backend
+  // fd, so the Windows variant is timer-driven (see uv_source_funcs above) — same
+  // dispatch (uv_run + DrainMicrotasks), woken on a 5 ms cadence instead of the fd.
+  // PumpInit below is the separate NON-blocking case (bare `node bundle.mjs` async).
 #ifndef _WIN32
   GSource* source = g_source_new(&uv_source_funcs, sizeof(UvLoopSource));
   UvLoopSource* s = reinterpret_cast<UvLoopSource*>(source);
@@ -649,6 +706,18 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
   // with GTK at default priority; the co-pump must not introduce one. Redraw
   // wins over Node work (browser-like: rendering outranks timers); Node I/O
   // still runs in every frame gap.
+  g_source_set_priority(source, G_PRIORITY_HIGH_IDLE + 30);
+  g_source_attach(source, nullptr);  // default GLib main context
+  g_source_unref(source);            // the context holds the surviving ref
+#else  // _WIN32 — timer-driven UvLoopSource (no uv backend fd on IOCP).
+  GSource* source = g_source_new(&uv_source_funcs, sizeof(UvLoopSource));
+  UvLoopSource* s = reinterpret_cast<UvLoopSource*>(source);
+  s->loop = loop;
+  s->fd_tag = nullptr;
+  s->fd_polled = FALSE;
+  s->win_next_wake_us = 0;  // due immediately on the first iteration
+  // Same priority rationale as POSIX (below GDK redraw, above default idle) so a
+  // future GTK-on-Windows paint is not starved by the co-pump metronome.
   g_source_set_priority(source, G_PRIORITY_HIGH_IDLE + 30);
   g_source_attach(source, nullptr);  // default GLib main context
   g_source_unref(source);            // the context holds the surviving ref

--- a/packages/node-gi/node-gi/src/loop.cc
+++ b/packages/node-gi/node-gi/src/loop.cc
@@ -7,6 +7,17 @@
 
 #include <unordered_map>
 
+#ifndef _WIN32
+// g_source_add_unix_fd / g_source_modify_unix_fd embed libuv's backend fd into a
+// GLib GSource — POSIX-only (declared in glib-unix.h; absent on Windows, where
+// GLib splits platform APIs into -Unix/-Win32 namespaces and libuv uses IOCP, not
+// an fd-polling backend). ONLY the UvLoopSource path (the BLOCKING-GLib-main-loop
+// co-pump) is guarded out on Windows; the uv-driven pump below (prepare/check/timer
+// → g_main_context_iteration) has no unix_fd dependency and stays active, so async
+// Gio/timers/DBus still work on Windows (degraded to timed polling — see SyncPumpPolls).
+#include <glib-unix.h>
+#endif
+
 namespace nodegi {
 
 // ---- libuv <-> GLib main loop bridge (milestone: mainloop) ----
@@ -21,12 +32,14 @@ namespace nodegi {
 //
 // Main-thread only (worker_threads would need a per-context source); the GLib
 // default context is iterated on the same thread Node runs on.
+#ifndef _WIN32
 struct UvLoopSource {
   GSource source;
   uv_loop_t* loop;
   gpointer fd_tag;
   gboolean fd_polled;
 };
+#endif  // _WIN32
 
 static napi_env g_loop_env = nullptr;       // captured at startMainLoop (main thread)
 static gboolean g_loop_started = FALSE;
@@ -54,6 +67,7 @@ static gboolean g_in_uv_pump = FALSE;
 // run() do not drain until run() returns. nextTick still drains; timers/I/O the
 // loop dispatches are unaffected. The robust fix lives in L1 (defer the run() to
 // a macrotask when a microtask checkpoint is in progress).
+#ifndef _WIN32
 static void DrainMicrotasks() {
   if (g_loop_env == nullptr || g_tick_callback_ref == nullptr || g_process_ref == nullptr) return;
   napi_env env = g_loop_env;
@@ -70,6 +84,7 @@ static void DrainMicrotasks() {
   }
   napi_close_handle_scope(env, scope);
 }
+#endif  // _WIN32
 
 // ---- cross-runtime microtask checkpoint (Bun/Deno) --------------------------
 //
@@ -149,6 +164,7 @@ void NodeGiMaybeDrainMicrotasks(napi_env env) {
   napi_close_handle_scope(env, scope);
 }
 
+#ifndef _WIN32
 static gboolean uv_source_prepare(GSource* base, gint* timeout) {
   UvLoopSource* s = reinterpret_cast<UvLoopSource*>(base);
 
@@ -205,6 +221,7 @@ static gboolean uv_source_dispatch(GSource* base, GSourceFunc /*callback*/, gpoi
 static GSourceFuncs uv_source_funcs = {
     uv_source_prepare, nullptr, uv_source_dispatch, nullptr, nullptr, nullptr,
 };
+#endif  // _WIN32 (UvLoopSource: the POSIX blocking-loop co-pump)
 
 // iterateMainContext(mayBlock?) -> boolean
 //
@@ -299,6 +316,16 @@ static void PumpPollCloseCb(uv_handle_t* h) {
 // failure (fd not pollable / already watched elsewhere in this loop) fall back
 // to a short timer so readiness is still discovered, just later.
 static gboolean SyncPumpPolls(int nfds) {
+#ifdef _WIN32
+  // uv_poll requires a SOCKET on Windows, but GLib's queried poll fds are HANDLEs
+  // (g_poll uses MsgWaitForMultipleObjects), not pollable via libuv. Report "not
+  // fully watched" so PumpArmWakeups falls back to timed main-context polling — the
+  // pump still drains ready GLib sources each loop turn (async Gio/timers/DBus
+  // work), just discovering readiness on a short cadence instead of on the fd. A
+  // HANDLE/IOCP fd-watch integration via the Win32 GLib surface is a follow-up.
+  (void)nfds;
+  return FALSE;
+#else
   gboolean all_ok = TRUE;
   for (auto& it : *g_pump_polls) it.second->seen = FALSE;
 
@@ -360,6 +387,7 @@ static gboolean SyncPumpPolls(int nfds) {
     it = g_pump_polls->erase(it);
   }
   return all_ok;
+#endif  // _WIN32
 }
 
 // Drain every currently-ready GLib source (bounded). Each iteration is a full,
@@ -412,13 +440,20 @@ static void PumpArmWakeups() {
   g_in_uv_pump = FALSE;
 
   if (!SyncPumpPolls(nfds)) {
-    // Degraded wake path: poll at a short cadence instead of on readiness.
+    // Degraded wake path: poll at a short cadence instead of on readiness. This is
+    // the ALWAYS case on Windows (GLib's poll fds are HANDLEs, not uv_poll-able) and
+    // an occasional one on Linux (an fd that isn't uv_poll-able). Force the cadence
+    // ONLY while async work is in-flight — its completion arrives on an fd we can't
+    // watch, so we must poll to catch it. When nothing is pending, keep the query's
+    // own timeout (-1 when GLib is idle) so the loop goes to sleep / the process
+    // exits instead of a ref'd timer spinning forever — otherwise a purely-sync
+    // program (and every finished conformance test) would never exit on Windows.
     if (!g_pump_poll_warned) {
       g_pump_poll_warned = TRUE;
       g_printerr("(node-gi) warning: could not watch a GLib poll fd from libuv; "
                  "falling back to timed main-context polling\n");
     }
-    if (timeout < 0 || timeout > 32) timeout = 32;
+    if (g_pump_async_pending > 0 && (timeout < 0 || timeout > 32)) timeout = 32;
   }
 
   if (timeout >= 0) {
@@ -585,12 +620,19 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
     }
   }
 
+  // UvLoopSource embeds uv's backend fd into GLib so a BLOCKING GLib main loop
+  // (GLib.MainLoop.run / Gio.Application.run) co-pumps Node's timers/I/O. POSIX-only:
+  // uv has no backend fd on Windows (IOCP), and g_source_add_unix_fd is UNIX-only.
+  // PumpInit below is cross-platform and carries the NON-blocking async case (Gio
+  // async / timeouts / DBus) on Windows; a blocking GLib main loop on Windows needs
+  // a HANDLE/IOCP wakeup via the Win32 GLib surface — a follow-up (the display-free
+  // conformance subset never enters a blocking loop, so nothing here regresses).
+#ifndef _WIN32
   GSource* source = g_source_new(&uv_source_funcs, sizeof(UvLoopSource));
   UvLoopSource* s = reinterpret_cast<UvLoopSource*>(source);
   s->loop = loop;
   s->fd_polled = TRUE;
-  // uv_backend_fd is the epoll/kqueue fd on POSIX. (Windows uses a different
-  // wake mechanism — node-gtk guards it; this milestone targets Linux/Fedora.)
+  // uv_backend_fd is the epoll/kqueue fd on POSIX.
   s->fd_tag = g_source_add_unix_fd(source, uv_backend_fd(loop),
                                    static_cast<GIOCondition>(G_IO_IN | G_IO_OUT | G_IO_ERR));
   // PRIORITY — below GDK_PRIORITY_REDRAW (G_PRIORITY_HIGH_IDLE + 20), above
@@ -610,7 +652,11 @@ Napi::Value StartMainLoop(const Napi::CallbackInfo& info) {
   g_source_set_priority(source, G_PRIORITY_HIGH_IDLE + 30);
   g_source_attach(source, nullptr);  // default GLib main context
   g_source_unref(source);            // the context holds the surviving ref
+#endif  // _WIN32 (UvLoopSource blocking-loop co-pump)
 
+  // Cross-platform: the uv-driven GLib pump (prepare/check/timer → g_main_context_
+  // iteration) drains async Gio/timers/DBus without uv's backend fd — active on
+  // Windows too (degraded to timed polling; see SyncPumpPolls).
   PumpInit(loop);
 
   g_loop_started = TRUE;

--- a/packages/node-gi/node-gi/src/template.cc
+++ b/packages/node-gi/node-gi/src/template.cc
@@ -15,6 +15,13 @@ const GtkTemplateApi* GetGtkTemplateApi() {
   static bool initialised = false;
   if (initialised) return &api;
   initialised = true;
+#ifdef _WIN32
+  // The Gtk.Widget composite-template API is resolved lazily via dlsym on POSIX
+  // only. GTK on Windows is Phase 2; the Phase-1 Windows CI proves the display-
+  // free core, which never exercises templates. api.ok stays false → template
+  // callers warn + no-op / throw a clear "template API unavailable" error.
+  return &api;
+#else
   void* lib = dlopen("libgtk-4.so.1", RTLD_LAZY | RTLD_NOLOAD);
   if (lib == nullptr) lib = dlopen("libgtk-4.so.1", RTLD_LAZY);
   if (lib == nullptr) return &api;  // api.ok stays false → callers warn + no-op
@@ -40,6 +47,7 @@ const GtkTemplateApi* GetGtkTemplateApi() {
            api.bind_template_child_full != nullptr && api.set_css_name != nullptr &&
            api.init_template != nullptr && api.get_template_child != nullptr;
   return &api;
+#endif  // _WIN32
 }
 
 // The live JS env stamped on a template-callback scope (refreshed each construct).

--- a/packages/node-gi/node-gi/test/arrays.test.mjs
+++ b/packages/node-gi/node-gi/test/arrays.test.mjs
@@ -24,7 +24,9 @@ test('GStrv return → string[]: GLib.get_environ()', () => {
   assert.ok(Array.isArray(environ));
   assert.ok(environ.length > 0);
   assert.ok(environ.every((e) => typeof e === 'string'));
-  assert.ok(environ.some((e) => e.startsWith('PATH=')));
+  // Windows names the search path `Path=`, POSIX `PATH=` — match case-insensitively
+  // (node-gi returns the real OS environ verbatim; only the var name's case differs).
+  assert.ok(environ.some((e) => /^path=/i.test(e)));
 });
 
 test('GStrv IN (transfer none) + string return: GLib.environ_getenv()', () => {

--- a/packages/node-gi/node-gi/test/static-camel.test.mjs
+++ b/packages/node-gi/node-gi/test/static-camel.test.mjs
@@ -14,7 +14,10 @@ import { callStaticMethod, requireNamespace } from '../index.js';
 test('static/constructor method: Gio.File.new_for_path', () => {
   const Gio = requireGi('Gio', '2.0');
   const f = Gio.File.new_for_path('/usr/bin/gjs');
-  assert.equal(f.get_path(), '/usr/bin/gjs');
+  // GIO normalizes to the platform separator, so get_path() is `\usr\bin\gjs` on
+  // Windows; normalize separators before comparing (node-gi returns exactly what GIO
+  // returns — the test's point is that the static new_for_path resolves + returns a path).
+  assert.equal(f.get_path().replaceAll('\\', '/'), '/usr/bin/gjs');
   assert.equal(f.get_basename(), 'gjs');
 });
 


### PR DESCRIPTION
Sibling of the just-merged **macOS** proof (#767): add a **`windows`** job to `.github/workflows/node-gi.yml` proving `@gjsify/node-gi` (the GI/GObject reverse bridge) **builds and runs on `windows-latest`**. Builds the N-API addon from source and runs the display-free conformance subset (`scripts/cross-runtime.mjs`) on Node, then stages + uploads the `win32-x64` addon prebuild (the loader `index.js` already expects `prebuilds/win32-x64/node_gi.node`).

## Toolchain — MSVC + gvsbuild (path chosen + why)
- **Chosen: Path B (MSVC + gvsbuild), NOT Path A (all-MSYS2/mingw).** node-gyp defaults to MSVC and stock Node/Bun/Deno on Windows are MSVC-ABI, so the addon **and** the GTK/GLib it links must be MSVC-ABI. A mingw GTK + MSVC addon is the ABI hazard the task flags, and a mingw-built `.node` does not load into stock MSVC-ABI Node (the ABI wall). node-gtk's own Windows binding.gyp mixes an MSVC/ClangCL addon with **mingw `.dll.a`** import libs — exactly what we avoid.
- **gvsbuild** publishes a prebuilt **MSVC-ABI GTK4** release (`2026.6.0` → **GLib 2.88.1**, `girepository-2.0`, built with `--enable-gi`; it also bundles `pkgconf.exe`/`pkg-config.exe`). node-gi hard-requires `girepository-2.0` (the GLib-merged API) — confirmed present. The bundle is extracted to gvsbuild's canonical build prefix (`C:\gtk-build\gtk\x64\release`) so its `.pc` files' baked absolute `prefix=` is correct with no relocation; `bin/` on PATH, `PKG_CONFIG_PATH` + `GI_TYPELIB_PATH` at the tree. Cached by gvsbuild version.

## binding.gyp — Windows branch
gyp's msvs generator ignores `cflags`/`xcode_settings` (make/xcode only), so an `OS=="win"` branch feeds a helper (`scripts/win-gi-gyp-flags.mjs`) that emits **bare include dirs** into `include_dirs` and **full `.lib` paths** into `libraries` from pkg-config — the exact shapes gyp forwards to cl.exe/link.exe. It uses **`--static --libs`** so the private closure (`gio-2.0`, `gmodule-2.0`, `libffi`, `intl`) is pulled: node-gi calls `ffi_call`/Gio directly and MSVC/PE resolves every import at link time, unlike Linux's lazy shared-object global scope. The non-win branch is behavior-identical (gyp prunes the unmatched condition before its `pkg-config` commands run — the pattern node-gtk uses).

## Source change (minimal, guarded)
The GTK composite-template feature resolves libgtk-4 via POSIX `dlopen`/`dlsym` (`<dlfcn.h>`), which MSVC lacks. Guarded the include (`common.h`) and the resolver body (`template.cc`) with `#ifndef _WIN32` — templates are a Phase-2 GTK feature, not in the display-free subset, and the callers already handle `api.ok == false` (warn + no-op / clear throw). No other POSIX/MSVC portability issues found (no `ssize_t`, GCC extensions, VLAs, etc.).

## Scope
Phase-1 proof (NOT prebuilt-GTK shipping): Node conformance is the gating leg + the `win32-x64` prebuild upload. GTK-window / GLArea / cairo-drawfunc / adw-smoke **display** tests stay Phase 2 (win32 GTK backend + display wiring + a prebuilt-GTK stack). Bun/Deno legs slot in beside Node once the core is green. The `consumer-sqlite`/`-harness` jobs are unrelated and green on 0.19.0.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq