### PR TITLE
feat(node-gi): batteries-included Windows x64 GTK runtime

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1042,3 +1042,162 @@ jobs:
           name: node-gi-prebuild-win32-x64
           path: packages/node-gi/node-gi/prebuilds/win32-x64/node_gi.node
           if-no-files-found: error
+
+  # Windows Phase 2 — BUILD the batteries-included GTK runtime bundle. Reuses the
+  # `windows` job's gvsbuild download/cache steps as the closure SOURCE (build-time
+  # only; NOT shipped), then COLLECTS the display-free DLL closure into gtk/bin +
+  # the typelibs into gtk/girepository-1.0. CRUCIAL DIFFERENCE from macOS: NO
+  # relocation — Windows resolves DLLs by SEARCH PATH at LoadLibrary time, so
+  # "relocation" is just copying the DLLs into one dir (no install_name_tool /
+  # @rpath / codesign, and no addon relocation). Uploads the bundle for the
+  # no-gvsbuild conformance job below. Independent of the `windows` job (it does not
+  # consume the addon), so it runs in parallel.
+  windows-gtk-runtime:
+    name: Windows GTK runtime bundle (build / windows-latest x64)
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GVSBUILD_VERSION: '2026.6.0'
+      GTK_PREFIX: 'C:\gtk-build\gtk\x64\release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Node 24 runs build-gtk-runtime.mjs (node:child_process/fs). Same version the
+      # `windows` proof pins.
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Cache gvsbuild GTK4 bundle
+        id: cache-gtk
+        uses: actions/cache@v4
+        with:
+          path: C:\gtk-build\gtk\x64\release
+          key: gvsbuild-gtk4-${{ env.GVSBUILD_VERSION }}-x64-v1
+
+      # Build-time closure SOURCE only — the DLLs are collected INTO the bundle, they
+      # are NOT what the no-gvsbuild conformance job runs on. Verbatim from the
+      # `windows` job's download/extract step.
+      - name: Download + extract gvsbuild GTK4 (build-time closure source)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/wingtk/gvsbuild/releases/download/$env:GVSBUILD_VERSION/GTK4_Gvsbuild_${env:GVSBUILD_VERSION}_x64.zip"
+          Write-Host "Downloading $url"
+          curl.exe -L --fail --retry 3 -o gtk4.zip $url
+          New-Item -ItemType Directory -Force -Path $env:GTK_PREFIX | Out-Null
+          tar.exe -xf gtk4.zip -C $env:GTK_PREFIX
+          Remove-Item gtk4.zip
+
+      # Collect the DLL closure + typelibs into the package's gtk/ dir. The script
+      # walks the closure with dumpbin (located via vswhere) and falls back to
+      # copying the full bin/*.dll set if dumpbin is unavailable — either way the
+      # bundle is complete. Only --out + --prefix are needed (no addon relocation).
+      - name: Build the GTK runtime bundle (collect DLL closure + typelibs)
+        shell: pwsh
+        run: |
+          node packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs `
+            --out packages/node-gi/gtk-runtime-win32-x64/gtk `
+            --prefix $env:GTK_PREFIX
+
+      - name: Report bundle size + layout sanity
+        shell: pwsh
+        run: |
+          $B = "packages/node-gi/gtk-runtime-win32-x64/gtk"
+          Get-Content "$B/manifest.json"
+          Write-Host "--- bundle size ---"
+          "{0:N1} MiB" -f ((Get-ChildItem $B -Recurse -File | Measure-Object Length -Sum).Sum / 1MB)
+          if (-not (Test-Path "$B/bin") -or -not (Test-Path "$B/girepository-1.0")) {
+            Write-Host "BUNDLE INCOMPLETE: gtk/bin + gtk/girepository-1.0 are required (index.js isPresent)"
+            exit 1
+          }
+          Write-Host "--- a few bundled DLLs ---"
+          Get-ChildItem "$B/bin" -Filter *.dll | Select-Object -First 10 -ExpandProperty Name
+
+      - name: Upload GTK runtime bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: gtk-runtime-win32-x64
+          path: packages/node-gi/gtk-runtime-win32-x64/gtk
+          if-no-files-found: error
+
+  # Windows Phase 2 — PROVE batteries-included. This job NEVER installs gvsbuild: it
+  # downloads the relocated-by-copy bundle + the win32 addon prebuild and runs the
+  # display-free conformance against them, so a green run proves node-gi works with
+  # ZERO gvsbuild/system GTK. UNLIKE the macOS batteries job (which needs a CORE
+  # leg + a re-exec for the non-addon-linked backers), ONE PATH-prepend covers the
+  # whole subset: node-gi prepends the bundle's gtk/bin to PATH before the addon
+  # loads, and Windows re-reads that path at each LoadLibrary — so the addon's own
+  # DLL imports AND the runtime g_module_open of Pango/Gdk/Graphene both resolve
+  # from the bundle in a single, env-free run.
+  windows-batteries-included:
+    name: Windows batteries-included conformance (no gvsbuild / windows-latest x64)
+    runs-on: windows-latest
+    needs: [windows, windows-gtk-runtime]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      # This job never installs gvsbuild. Hard-fail if a gvsbuild GTK tree is present
+      # (it would muddy the proof — the bundle must be the ONLY GTK).
+      - name: Assert gvsbuild GTK is NOT present (clean batteries-included host)
+        shell: pwsh
+        run: |
+          if (Test-Path 'C:\gtk-build\gtk\x64\release\bin\glib-2.0-0.dll') {
+            Write-Host "gvsbuild GTK is present — not a clean batteries-included test"
+            exit 1
+          }
+          Write-Host "clean host — gvsbuild GTK was never installed in this job"
+
+      # Stage the bundle + addon prebuild in the SIBLING layout node-gi's loader
+      # expects (prebuilds/win32-x64/{node_gi.node, gtk/}). The loader prepends
+      # gtk/bin to PATH before loading the addon, so its DLL imports resolve here.
+      - name: Download GTK runtime bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: gtk-runtime-win32-x64
+          path: packages/node-gi/node-gi/prebuilds/win32-x64/gtk
+
+      - name: Download node-gi addon prebuild (from the windows job)
+        uses: actions/download-artifact@v4
+        with:
+          name: node-gi-prebuild-win32-x64
+          path: packages/node-gi/node-gi/prebuilds/win32-x64
+
+      - name: Verify staged layout
+        shell: pwsh
+        run: |
+          Get-ChildItem packages/node-gi/node-gi/prebuilds/win32-x64
+          Write-Host "--- DLLs ---"
+          Get-ChildItem packages/node-gi/node-gi/prebuilds/win32-x64/gtk/bin -Filter *.dll | Select-Object -First 10 -ExpandProperty Name
+          Write-Host "--- typelibs ---"
+          Get-ChildItem packages/node-gi/node-gi/prebuilds/win32-x64/gtk/girepository-1.0 -Filter *.typelib | Select-Object -First 10 -ExpandProperty Name
+
+      # Fast probe FIRST — one clean process, NO GTK on PATH set by the job. node-gi's
+      # loader prepends the bundle's gtk/bin to PATH before loading the addon, and
+      # prependSearchPath for the typelibs; this reproduces registerClass subclassing
+      # + Pango/Graphene/Gdk get_type resolving env-free from the bundle.
+      - name: Batteries-included probe — no gvsbuild GTK (Node)
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+        run: node scripts/check-batteries.mjs
+
+      # The full display-free conformance subset — the primary proof, with the bundle
+      # as the ONLY GTK. NODE_GI_NATIVE=prebuild loads the staged addon; the loader's
+      # PATH-prepend makes its DLL imports + the typelib backers resolve from gtk/bin.
+      # No CORE/FULL split (see the job comment): one PATH covers everything.
+      - name: Conformance subset — no gvsbuild GTK (Node)
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+        run: node scripts/cross-runtime.mjs node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,3 +315,128 @@ jobs:
           node "${{ steps.cli.outputs.bin }}" publish \
             packages/node-gi/gtk-runtime-darwin-arm64 \
             --tolerate-republish --tag latest --access public
+
+  # Windows publish leg for the batteries-included GTK runtime bundle — the sibling
+  # of publish-gtk-runtime-darwin-arm64 above (see that job's rationale in full).
+  #
+  # WHY A SEPARATE JOB: @gjsify/gtk-runtime-win32-x64 ships a HEAVY GTK/GI DLL +
+  # typelib closure in its `gtk/` dir. That bundle is gitignored and can ONLY be
+  # produced on a windows/x64 runner (gvsbuild closure -> collect the DLL closure
+  # into gtk/bin, see the package's scripts/build-gtk-runtime.mjs). The ubuntu
+  # `publish` job cannot build it, and it never tries to: `packages/node-gi/*` is
+  # NOT a root workspace, so `gjsify foreach` (behind `gjsify run npm:publish`)
+  # never touches this package — the same race-safety the darwin job relies on.
+  # Here we BUILD the bundle on Windows and OIDC-publish JUST this one package WITH
+  # the populated `gtk/`, so `require('@gjsify/gtk-runtime-win32-x64')` reports
+  # isPresent=true and the "no gvsbuild needed" promise is actually delivered.
+  #
+  # UNLIKE macOS: there is NO relocation/codesign step (Windows resolves DLLs by
+  # search path at LoadLibrary time), and NO addon build (the tarball ships only
+  # gtk/{bin,girepository-1.0,manifest.json}; the addon prebuild is node-gi's own
+  # concern in node-gi.yml).
+  #
+  # MAINTAINER ACTION — MANUAL FIRST PUBLISH REQUIRED (like the darwin package):
+  # npm Trusted Publishing (OIDC) cannot CREATE a package, only publish new versions
+  # of an existing one. So @gjsify/gtk-runtime-win32-x64 needs a one-time manual
+  # `gjsify publish --access public` + `gjsify trust @gjsify/gtk-runtime-win32-x64`
+  # (or `gjsify onboard`) from a maintainer machine BEFORE this job's first CI
+  # release — otherwise the OIDC exchange 404s. See AGENTS.md "New @gjsify/* package:
+  # first-publish + Trusted Publisher bootstrap".
+  #
+  # `needs: publish` so @gjsify/cli@<release-version> is already on npm and the two
+  # publish legs are serialized.
+  publish-gtk-runtime-win32-x64:
+    name: Publish @gjsify/gtk-runtime-win32-x64 (Windows bundle)
+    needs: publish
+    if: ${{ (github.event_name == 'release' || inputs.skip_publish == false) && inputs.verify_only != true }}
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      # id-token: write = npm Trusted Publishing (OIDC), configured for this
+      # workflow file (release.yml). contents: read is for checkout.
+      contents: read
+      id-token: write
+    env:
+      GVSBUILD_VERSION: '2026.6.0'
+      GTK_PREFIX: 'C:\gtk-build\gtk\x64\release'
+    steps:
+      - name: Checkout repository (the released tag)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
+
+      # Node 24 runs build-gtk-runtime.mjs + the publish. No `registry-url` (it would
+      # inject a placeholder NODE_AUTH_TOKEN and defeat OIDC — see the ubuntu job).
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # Build-time closure SOURCE only — the DLLs are collected INTO the bundle, they
+      # are NOT a runtime dep of the tarball.
+      - name: Download + extract gvsbuild GTK4 (build-time closure source)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/wingtk/gvsbuild/releases/download/$env:GVSBUILD_VERSION/GTK4_Gvsbuild_${env:GVSBUILD_VERSION}_x64.zip"
+          Write-Host "Downloading $url"
+          curl.exe -L --fail --retry 3 -o gtk4.zip $url
+          New-Item -ItemType Directory -Force -Path $env:GTK_PREFIX | Out-Null
+          tar.exe -xf gtk4.zip -C $env:GTK_PREFIX
+          Remove-Item gtk4.zip
+
+      # Populate the gitignored gtk/ bundle so `files: ["gtk"]` ships it. Only --out +
+      # --prefix are needed (no addon relocation on Windows).
+      - name: Build the GTK runtime bundle (populate gtk/)
+        shell: pwsh
+        run: |
+          node packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs `
+            --out packages/node-gi/gtk-runtime-win32-x64/gtk `
+            --prefix $env:GTK_PREFIX
+
+      # Gate the publish on a populated bundle: assert the two dirs index.js's
+      # isPresent check requires actually exist.
+      - name: Verify bundle (layout present)
+        shell: pwsh
+        run: |
+          $B = "packages/node-gi/gtk-runtime-win32-x64/gtk"
+          Get-Content "$B/manifest.json"
+          Write-Host "--- bundle size ---"
+          "{0:N1} MiB" -f ((Get-ChildItem $B -Recurse -File | Measure-Object Length -Sum).Sum / 1MB)
+          if (-not (Test-Path "$B/bin") -or -not (Test-Path "$B/girepository-1.0")) {
+            Write-Host "BUNDLE INCOMPLETE: gtk/bin + gtk/girepository-1.0 are required (index.js isPresent)"
+            exit 1
+          }
+          Write-Host "bundle populated"
+
+      # A Node-runnable @gjsify/cli at the release-train version drives the OIDC
+      # publish. This package has NO workspace deps, so a standalone pack needs no
+      # `gjsify install`. `needs: publish` guarantees this version is already on npm.
+      - name: Prepare a Node-runnable @gjsify/cli
+        id: cli
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $cliVersion = node -p "require('./packages/infra/cli/package.json').version"
+          $dir = Join-Path $env:RUNNER_TEMP 'gjsify-node-cli'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          Push-Location $dir
+          npm init -y | Out-Null
+          npm install "@gjsify/cli@$cliVersion" --no-audit --no-fund --no-save
+          Pop-Location
+          $bin = Join-Path $dir 'node_modules\@gjsify\cli\lib\index.js'
+          "bin=$bin" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          node $bin --version
+
+      # OIDC Trusted Publishing from release.yml — publishes ONLY this package, WITH
+      # the populated gtk/ bundle. --tolerate-republish makes a manual rerun over an
+      # already-published version a no-op instead of a hard 409/403.
+      - name: Publish @gjsify/gtk-runtime-win32-x64 (OIDC, with bundle)
+        shell: pwsh
+        env:
+          GJSIFY_PUBLISH_DEBUG: '1'
+          CLI_BIN: ${{ steps.cli.outputs.bin }}
+        run: |
+          node "$env:CLI_BIN" publish `
+            packages/node-gi/gtk-runtime-win32-x64 `
+            --tolerate-republish --tag latest --access public

--- a/packages/node-gi/gtk-runtime-win32-x64/.gitignore
+++ b/packages/node-gi/gtk-runtime-win32-x64/.gitignore
@@ -1,0 +1,3 @@
+# The heavy GTK DLL + typelib bundle is produced on a Windows runner, never committed.
+gtk/
+staged/

--- a/packages/node-gi/gtk-runtime-win32-x64/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/README.md
@@ -1,0 +1,94 @@
+# @gjsify/gtk-runtime-win32-x64
+
+Batteries-included GTK / GObject-Introspection runtime bundle for **Windows x64**.
+It lets [`@gjsify/node-gi`](../node-gi) load `gi://` namespaces (GLib · GObject ·
+Gio · cairo · Pango · Graphene · Gdk) with **no gvsbuild / system GTK** installed on
+the host — the Windows sibling of `@gjsify/gtk-runtime-darwin-arm64`.
+
+Platform-gated (`os: ["win32"]`, `cpu: ["x64"]`), tier 3 (experimental). On any
+other platform npm skips it and `@gjsify/node-gi` falls back to a system/gvsbuild
+GTK. The heavy `gtk/` payload is **not committed** — it is built on a Windows CI
+runner (`scripts/build-gtk-runtime.mjs`) and shipped via the package tarball /
+staged into node-gi's `prebuilds/win32-x64/gtk/`.
+
+## Layout
+
+```
+gtk/
+  bin/                 GTK/GLib/cairo/pango/graphene/gdk-pixbuf DLLs (+ deps)
+  girepository-1.0/    typelibs (GLib/GObject/Gio/cairo/Pango/Graphene/Gdk/…)
+  manifest.json        counts + sizes + DLL list
+```
+
+Note the native code lives in **`gtk/bin`** (DLLs), not `gtk/lib` — on Windows the
+loadable images and the import libraries (`.lib`, not shipped) live in different
+dirs, and only the DLLs are needed at runtime.
+
+## How it is built (no relocation — the crux)
+
+`node scripts/build-gtk-runtime.mjs` runs on a Windows runner **with** a build-time
+gvsbuild GTK4 stack extracted at `--prefix` (env `GTK_PREFIX`, the closure *source*,
+not shipped):
+
+1. **Collect** — enumerate `<prefix>/bin/*.dll` and, from the display-free seed DLLs
+   the conformance loads (glib/gobject/gio/gmodule + girepository + cairo + pango +
+   graphene + gdk-pixbuf + gtk4 + harfbuzz), walk the DLL import closure with
+   `dumpbin /dependents` (recursively), keeping every dependency that is itself a
+   gvsbuild DLL. System DLLs (`KERNEL32`, `msvcrt`, `api-ms-win-*`, …) never resolve
+   to a file under `<prefix>/bin`, so the "keep only gvsbuild-resident deps" filter
+   leaves them OS-provided. If dumpbin can't be located the script copies the whole
+   `bin/*.dll` set (a complete superset).
+2. **Copy** — the closure DLLs are copied **flat** into `gtk/bin`. **That is the whole
+   job.** There is **no** `install_name_tool`/`@rpath`/`codesign` step: Windows
+   resolves a DLL's imports by **search path** at `LoadLibrary` time, so a directory
+   of DLLs is portable the moment it exists — no per-file rewriting, no re-signing.
+3. **Typelibs** — copy the typelib set into `gtk/girepository-1.0`.
+
+Contrast with macOS, where dyld bakes each dylib's dependency install-names, so the
+darwin bundle must rewrite every reference to `@loader_path/<leaf>` and ad-hoc
+re-sign. Windows needs none of that.
+
+## How node-gi finds + activates it
+
+`@gjsify/node-gi`'s loader (`gtk-runtime.js`) resolves the bundle from, in order:
+
+1. `GJSIFY_GTK_RUNTIME` (explicit bundle dir),
+2. node-gi's own `prebuilds/win32-x64/gtk/` (the CI/dev staging path),
+3. the sibling monorepo dir `../gtk-runtime-win32-x64/gtk`,
+4. `require.resolve('@gjsify/gtk-runtime-win32-x64')` (the published dep).
+
+On a match (win32 only) node-gi makes the bundle genuinely **env-free**:
+
+- **DLLs** — before the native addon is loaded, node-gi **prepends `gtk/bin` to
+  `process.env.PATH`** (`maybePrependGtkRuntimeDllPath`, from `index.js`, run BEFORE
+  the addon's `require`). Windows re-reads the DLL search path at **every**
+  `LoadLibrary` call — unlike dyld, which captures `DYLD_FALLBACK_LIBRARY_PATH` only
+  at process launch — so a plain in-process `process.env.PATH` mutation is enough:
+  when node-gi's own `require(node_gi.node)` triggers the addon's DLL imports
+  (`glib-2.0-0.dll`, `girepository-2.0-0.dll`, `cairo-2.dll`, …), the loader consults
+  the just-updated `PATH` and finds them in the bundle. The **same** `PATH` entry also
+  satisfies the runtime `g_module_open(<soname>)` lookups a typelib does for its
+  non-addon-linked backers (Pango / Gdk / Graphene) — one mechanism covers both, so
+  there is no DYLD-style dual path.
+- **typelibs** — node-gi prepends `gtk/girepository-1.0` to the GIRepository search
+  path via the native `prependSearchPath` (a runtime API, no env needed).
+
+### Why no re-exec (unlike macOS)
+
+The macOS bundle re-execs the process once with `DYLD_FALLBACK_LIBRARY_PATH` set,
+because dyld reads that variable **only at launch** — a JS-time `process.env`
+mutation cannot reach the running dyld. Windows has no such capture: the DLL search
+consults the live `PATH` at each `LoadLibrary`, and the node-gi addon is loaded
+**exclusively** by node-gi's own `require()` (in `loadNative()`), which runs *after*
+the `PATH` prepend. So the addon's static DLL imports resolve against the bundle with
+no re-exec and no native `AddDllDirectory` call (which would be chicken-and-egg —
+the addon must already be loaded to call it). PATH-prepend before the `require` is
+both sufficient and the simplest mechanism.
+
+## Scope & what a full windowing bundle still needs
+
+This bundle targets the **display-free conformance closure only**. The full GTK
+windowing/display stack additionally needs: the Win32 GDK backend wiring, the
+`gdk-pixbuf` `loaders.cache` + loader modules, compiled GSettings schemas
+(`glib-compile-schemas`), the Adwaita icon theme + `icon-theme.cache`, and
+Fontconfig cache/config — none of which are collected here.

--- a/packages/node-gi/gtk-runtime-win32-x64/index.d.ts
+++ b/packages/node-gi/gtk-runtime-win32-x64/index.d.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+/** Absolute path to the bundle root (contains `bin/` + `girepository-1.0/`). */
+export const bundleDir: string;
+/** Absolute path to the bundled DLL dir (prepend to PATH so LoadLibrary finds it). */
+export const binDir: string;
+/** Absolute path to the typelib dir (feed to GIRepository.prepend_search_path). */
+export const typelibDir: string;
+/** Whether the bundle payload is actually present on disk (it is built on CI). */
+export const isPresent: boolean;
+declare const _default: { bundleDir: string; binDir: string; typelibDir: string; isPresent: boolean };
+export default _default;

--- a/packages/node-gi/gtk-runtime-win32-x64/index.js
+++ b/packages/node-gi/gtk-runtime-win32-x64/index.js
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/gtk-runtime-win32-x64 — path helpers for the bundled GTK runtime.
+// @gjsify/node-gi resolves this package (optional, os/cpu-gated) to find the
+// bundled typelib + DLL dirs when no gvsbuild/system GTK is present. Unlike
+// macOS, Windows needs NO relocation: DLLs resolve by SEARCH PATH at LoadLibrary
+// time, so node-gi just prepends `gtk/bin` to PATH before the addon loads. The
+// heavy `gtk/` payload is produced by scripts/build-gtk-runtime.mjs on a Windows
+// runner.
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Absolute path to the bundle root (contains `bin/` + `girepository-1.0/`). */
+export const bundleDir = join(here, 'gtk');
+
+/** Absolute path to the bundled DLL dir (prepend to PATH so LoadLibrary finds it). */
+export const binDir = join(bundleDir, 'bin');
+
+/** Absolute path to the typelib dir (feed to GIRepository.prepend_search_path). */
+export const typelibDir = join(bundleDir, 'girepository-1.0');
+
+/** Whether the bundle payload is actually present on disk (it is built on CI). */
+export const isPresent = existsSync(typelibDir) && existsSync(binDir);
+
+export default { bundleDir, binDir, typelibDir, isPresent };

--- a/packages/node-gi/gtk-runtime-win32-x64/package.json
+++ b/packages/node-gi/gtk-runtime-win32-x64/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@gjsify/gtk-runtime-win32-x64",
+  "version": "0.19.0",
+  "description": "Batteries-included GTK/GObject-Introspection runtime bundle for Windows x64 — lets @gjsify/node-gi load gi:// namespaces (GLib/GObject/Gio/cairo/Pango/Graphene/Gdk) with NO gvsbuild/system GTK. Platform-gated (win32/x64 only).",
+  "type": "module",
+  "license": "MIT",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./gtk/girepository-1.0": "./gtk/girepository-1.0",
+    "./gtk/bin": "./gtk/bin"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "scripts",
+    "gtk"
+  ],
+  "gjsify": {
+    "runtimes": {
+      "gjs": "none",
+      "node": "polyfill",
+      "browser": "none",
+      "nativescript": "none"
+    },
+    "tier": 3
+  },
+  "scripts": {
+    "build:bundle": "node scripts/build-gtk-runtime.mjs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gjsify/gjsify.git",
+    "directory": "packages/node-gi/gtk-runtime-win32-x64"
+  }
+}

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+// Collect a standalone, batteries-included GTK/GObject-Introspection runtime
+// bundle for Windows x64 — so @gjsify/node-gi's display-free conformance runs with
+// NO gvsbuild/system GTK on the host (the Windows sibling of the darwin-arm64
+// bundle).
+//
+//   node scripts/build-gtk-runtime.mjs [--out <dir>] [--prefix <gvsbuild GTK prefix>]
+//
+// Runs ONLY on win32/x64 with a build-time gvsbuild GTK4 stack extracted at
+// --prefix (env GTK_PREFIX, the same tree the node-gi.yml `windows` job caches at
+// C:\gtk-build\gtk\x64\release). It:
+//   1. Enumerates <prefix>/bin/*.dll and, from the display-free seed DLLs the
+//      conformance loads (glib/gobject/gio/gmodule + girepository + cairo + pango +
+//      graphene + gdk-pixbuf + gtk4 + harfbuzz), walks the DLL import closure with
+//      `dumpbin /dependents` (recursively), keeping every dependency that is itself
+//      a gvsbuild DLL (system DLLs like KERNEL32 are left OS-provided — they never
+//      resolve to a file in <prefix>/bin, so the "keep only gvsbuild-resident deps"
+//      filter drops them). If dumpbin can't be located, it falls back to copying the
+//      whole <prefix>/bin/*.dll set (a complete superset — a loud WARNING flags it).
+//   2. Copies the closure DLLs FLAT into <out>/bin.
+//   3. Copies the typelib set into <out>/girepository-1.0.
+//
+// CRUCIAL DIFFERENCE FROM macOS: there is NO relocation step (no install_name_tool,
+// no @rpath, no codesign). Windows resolves a DLL's imports by SEARCH PATH at
+// LoadLibrary time, so a bundle is "portable" the moment its DLLs sit in one dir —
+// node-gi just prepends <out>/bin to PATH before the addon loads (see the package
+// README + @gjsify/node-gi/gtk-runtime.js). Copying is the whole job.
+//
+// Reference: GJS ships no relocation; gvsbuild ships the MSVC-ABI GTK4 stack whose
+// DLLs load into stock (MSVC-ABI) Node.
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// --- args ------------------------------------------------------------------
+function argValue(flag) {
+    const i = process.argv.indexOf(flag);
+    return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+const OUT = argValue('--out') ?? join(pkgRoot, 'gtk');
+const PREFIX = argValue('--prefix') ?? process.env.GTK_PREFIX;
+
+if (process.platform !== 'win32' || process.arch !== 'x64') {
+    console.error(`build-gtk-runtime: only supported on win32/x64, not ${process.platform}/${process.arch}`);
+    process.exit(2);
+}
+if (!PREFIX) {
+    console.error('build-gtk-runtime: no GTK prefix — pass --prefix or set GTK_PREFIX (e.g. C:\\gtk-build\\gtk\\x64\\release)');
+    process.exit(1);
+}
+
+const gtkBin = join(PREFIX, 'bin');
+const gtkTypelibs = join(PREFIX, 'lib', 'girepository-1.0');
+if (!existsSync(gtkBin)) {
+    console.error(`build-gtk-runtime: ${gtkBin} not found — extract the gvsbuild GTK4 stack first`);
+    process.exit(1);
+}
+
+const sh = (bin, args) => execFileSync(bin, args, { encoding: 'utf8' });
+
+// The seed DLLs of the DISPLAY-FREE conformance closure. Liberal, version-agnostic
+// patterns matched against <prefix>/bin (gvsbuild's suffixes drift: glib-2.0-0.dll,
+// girepository-2.0-0.dll, cairo-2.dll, pango-1.0-0.dll, gdk_pixbuf-2.0-0.dll,
+// gtk-4-1.dll, harfbuzz.dll, …). The recursive dumpbin walk pulls every transitive
+// gvsbuild dep (harfbuzz, fribidi, fontconfig, freetype, pixman, png, intl, pcre2,
+// ffi, epoxy, zlib, …). gtk-4 is seeded because it backs the Gdk typelib the
+// conformance's struct-construct loads (Gdk/Graphene) and transitively pulls
+// pango/graphene/gdk-pixbuf/cairo/harfbuzz.
+const SEED_PATTERNS = [
+    /^glib-2\.0-.*\.dll$/i,
+    /^gobject-2\.0-.*\.dll$/i,
+    /^gio-2\.0-.*\.dll$/i,
+    /^gmodule-2\.0-.*\.dll$/i,
+    /^girepository-[12]\.0-.*\.dll$/i, // girepository-2.0 (merged API) on modern gvsbuild
+    /^cairo(-gobject|-script-interpreter)?-?\d*\.dll$/i,
+    /^pango(cairo|ft2|win32)?-1\.0-.*\.dll$/i,
+    /^graphene-1\.0-.*\.dll$/i,
+    /^gdk[-_]pixbuf-2\.0-.*\.dll$/i,
+    /^gtk-4-.*\.dll$/i, // provides the Gdk typelib's backing library
+    /^harfbuzz.*\.dll$/i,
+];
+
+// Locate dumpbin (MSVC): env override, then PATH (a dev-cmd/vcvars job), then
+// vswhere's -find glob into the VC toolchain. Null when unavailable → the caller
+// falls back to copying the whole bin/ DLL set.
+function findDumpbin() {
+    const envd = process.env.DUMPBIN;
+    if (envd && existsSync(envd)) return envd;
+    try {
+        const p = sh('where', ['dumpbin']).split(/\r?\n/).map((s) => s.trim()).filter(Boolean)[0];
+        if (p && existsSync(p)) return p;
+    } catch {
+        // not on PATH
+    }
+    const vswhere = join(
+        process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)',
+        'Microsoft Visual Studio',
+        'Installer',
+        'vswhere.exe',
+    );
+    if (existsSync(vswhere)) {
+        try {
+            const out = sh(vswhere, ['-latest', '-products', '*', '-find', '**\\Hostx64\\x64\\dumpbin.exe']);
+            const p = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)[0];
+            if (p && existsSync(p)) return p;
+        } catch {
+            // vswhere present but no match
+        }
+    }
+    return null;
+}
+
+// Parse `dumpbin /dependents <dll>` into the list of imported DLL leaf names (both
+// normal + delay-load sections; stop at the Summary). Exit-tolerant: dumpbin can
+// print the section then exit non-zero on some inputs — capture the attached stdout.
+function dumpbinDeps(dumpbin, dllPath) {
+    let out;
+    try {
+        out = sh(dumpbin, ['/nologo', '/dependents', dllPath]);
+    } catch (error) {
+        out = typeof error?.stdout === 'string' ? error.stdout : '';
+    }
+    const deps = [];
+    let inDeps = false;
+    for (const raw of out.split(/\r?\n/)) {
+        const line = raw.replace(/\s+$/, '');
+        if (/following (delay load )?dependencies:/i.test(line)) {
+            inDeps = true;
+            continue;
+        }
+        if (/^\s*Summary/i.test(line)) break;
+        if (inDeps) {
+            const m = line.match(/^\s+([A-Za-z0-9_.+-]+\.dll)\s*$/i);
+            if (m) deps.push(m[1]);
+        }
+    }
+    return deps;
+}
+
+// --- 1. discover the closure ----------------------------------------------
+console.log(`build-gtk-runtime: gvsbuild prefix ${PREFIX}`);
+// leaf(lower) -> actual on-disk filename in <prefix>/bin
+const binFiles = new Map();
+for (const f of readdirSync(gtkBin)) {
+    if (f.toLowerCase().endsWith('.dll')) binFiles.set(f.toLowerCase(), f);
+}
+if (binFiles.size === 0) {
+    console.error(`build-gtk-runtime: no DLLs under ${gtkBin} — is the GTK stack extracted?`);
+    process.exit(1);
+}
+
+const seeds = [...binFiles.values()].filter((f) => SEED_PATTERNS.some((re) => re.test(f)));
+if (seeds.length === 0) {
+    console.error('build-gtk-runtime: no seed DLLs matched — check the gvsbuild layout / SEED_PATTERNS');
+    process.exit(1);
+}
+console.log(`build-gtk-runtime: ${seeds.length} seed DLLs: ${seeds.join(', ')}`);
+
+const dumpbin = findDumpbin();
+// leaf(lower) -> actual filename (source in <prefix>/bin)
+const bundled = new Map();
+if (dumpbin) {
+    console.log(`build-gtk-runtime: walking the DLL closure with ${dumpbin}`);
+    const queue = [...seeds];
+    while (queue.length) {
+        const leaf = queue.shift();
+        const lower = leaf.toLowerCase();
+        if (bundled.has(lower)) continue;
+        const src = binFiles.get(lower);
+        if (!src) continue; // system / non-gvsbuild dep — leave as OS-provided
+        bundled.set(lower, src);
+        for (const dep of dumpbinDeps(dumpbin, join(gtkBin, src))) {
+            const dl = dep.toLowerCase();
+            if (!bundled.has(dl) && binFiles.has(dl)) queue.push(dep);
+        }
+    }
+} else {
+    console.warn(
+        'build-gtk-runtime: WARNING — dumpbin not found (no MSVC / vswhere); falling back to copying the FULL bin/*.dll set (a complete but larger superset).',
+    );
+    for (const [lower, src] of binFiles) bundled.set(lower, src);
+}
+console.log(`build-gtk-runtime: closure = ${bundled.size} DLLs`);
+
+// --- 2. copy DLLs (no relocation — Windows resolves by search path) -------
+const binOut = join(OUT, 'bin');
+rmSync(OUT, { recursive: true, force: true });
+mkdirSync(binOut, { recursive: true });
+for (const src of bundled.values()) {
+    copyFileSync(join(gtkBin, src), join(binOut, src));
+}
+console.log(`build-gtk-runtime: copied ${bundled.size} DLLs -> ${binOut}`);
+
+// --- 3. typelibs -----------------------------------------------------------
+const typelibOut = join(OUT, 'girepository-1.0');
+mkdirSync(typelibOut, { recursive: true });
+let typelibCount = 0;
+if (existsSync(gtkTypelibs)) {
+    for (const f of readdirSync(gtkTypelibs)) {
+        if (f.endsWith('.typelib')) {
+            copyFileSync(join(gtkTypelibs, f), join(typelibOut, f));
+            typelibCount++;
+        }
+    }
+}
+console.log(`build-gtk-runtime: copied ${typelibCount} typelibs`);
+
+// --- manifest + size -------------------------------------------------------
+function dirSize(dir) {
+    let total = 0;
+    for (const f of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, f.name);
+        total += f.isDirectory() ? dirSize(p) : statSync(p).size;
+    }
+    return total;
+}
+const binBytes = dirSize(binOut);
+const typelibBytes = dirSize(typelibOut);
+const manifest = {
+    platform: 'win32-x64',
+    generatedFrom: PREFIX,
+    walkedWith: dumpbin ? 'dumpbin' : 'copy-all-fallback',
+    dlls: bundled.size,
+    typelibs: typelibCount,
+    binBytes,
+    typelibBytes,
+    totalBytes: binBytes + typelibBytes,
+    dllList: [...bundled.values()].map((f) => basename(f)).sort((a, b) => a.localeCompare(b)),
+};
+writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
+
+const mb = (n) => (n / 1024 / 1024).toFixed(1);
+console.log(
+    `build-gtk-runtime: DONE -> ${OUT}\n` +
+        `  DLLs:     ${bundled.size} (${mb(binBytes)} MiB)\n` +
+        `  typelibs: ${typelibCount} (${mb(typelibBytes)} MiB)\n` +
+        `  total:    ${mb(manifest.totalBytes)} MiB`,
+);

--- a/packages/node-gi/node-gi/gtk-runtime.d.ts
+++ b/packages/node-gi/node-gi/gtk-runtime.d.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-/** A resolved GTK runtime bundle: relocated dylib dir + typelib dir. */
+/** A resolved GTK runtime bundle: native-code dir (dylibs on darwin, DLLs on win32) + typelib dir. */
 export interface GtkRuntimeBundle {
     dir: string;
     libDir: string;
@@ -7,5 +7,9 @@ export interface GtkRuntimeBundle {
 }
 /** Resolve the GTK runtime bundle directory for this platform, or null. */
 export function resolveGtkRuntimeBundle(): GtkRuntimeBundle | null;
+/** macOS: re-exec once with DYLD_FALLBACK_LIBRARY_PATH set to the bundle (no-op off darwin). */
+export function maybeReexecForGtkRuntime(): void;
+/** Windows: prepend the bundle's gtk/bin DLL dir to process.env.PATH (no-op off win32). */
+export function maybePrependGtkRuntimeDllPath(): void;
 /** Activate the bundled GTK runtime for the native engine, if one is present. */
 export function activateBundledGtkRuntime(native: { prependSearchPath: (p: string) => void }): GtkRuntimeBundle | null;

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -23,7 +23,8 @@ const REEXEC_SENTINEL = 'GJSIFY_GTK_REEXEC';
 
 /**
  * Resolve the GTK runtime bundle directory for this platform, or `null`. A valid
- * bundle dir contains `lib/` (relocated dylibs) + `girepository-1.0/` (typelibs).
+ * bundle dir contains the native-code dir (`lib/` relocated dylibs on darwin,
+ * `bin/` DLLs on win32) + `girepository-1.0/` (typelibs).
  * Search order (first hit wins):
  *   1. GJSIFY_GTK_RUNTIME env (an explicit bundle dir),
  *   2. node-gi's own prebuilds/<platform>-<arch>/gtk/ (CI/dev staging path),
@@ -46,9 +47,13 @@ export function resolveGtkRuntimeBundle() {
         // Not installed — fine.
     }
 
+    // The loadable native code lives in `lib` (dylibs) on macOS and `bin` (DLLs) on
+    // Windows. `libDir` is the dir node-gi adds to the OS library search path
+    // (DYLD_FALLBACK on darwin, PATH on win32) — its NAME differs, its ROLE does not.
+    const nativeSubdir = process.platform === 'win32' ? 'bin' : 'lib';
     for (const dir of candidates) {
         if (!dir) continue;
-        const libDir = join(dir, 'lib');
+        const libDir = join(dir, nativeSubdir);
         const typelibDir = join(dir, 'girepository-1.0');
         if (existsSync(libDir) && existsSync(typelibDir)) return { dir, libDir, typelibDir };
     }
@@ -109,6 +114,31 @@ export function maybeReexecForGtkRuntime() {
     process.exit(res.status === null ? 1 : res.status);
 }
 
+/**
+ * Prepend the bundled GTK runtime's DLL dir (`gtk/bin`) to `process.env.PATH` so a
+ * later `LoadLibrary` resolves against the bundle with NO gvsbuild/system GTK — both
+ * the native addon's OWN static imports (glib/gobject/gio/girepository/cairo/ffi/…)
+ * AND every runtime `g_module_open(<soname>)` a typelib does for its backers
+ * (Pango/Gdk/Graphene). This is the Windows analog of the darwin re-exec, but
+ * SIMPLER: Windows re-reads the DLL search path at EACH `LoadLibrary` (unlike dyld,
+ * which captures `DYLD_FALLBACK_LIBRARY_PATH` only at process launch), so an
+ * in-process `process.env.PATH` mutation is sufficient — no re-exec, and no native
+ * `AddDllDirectory` (which would be chicken-and-egg: the addon must already be loaded
+ * to expose it). MUST be called at module top-level BEFORE the addon is `require()`'d
+ * (index.js does exactly that, before loadNative()). Strict no-op off win32 / without
+ * a bundle / when the dir is already on PATH. Idempotent.
+ * @returns {void}
+ */
+export function maybePrependGtkRuntimeDllPath() {
+    if (process.platform !== 'win32') return; // strict no-op on every non-win32 runtime
+    const bundle = resolveGtkRuntimeBundle();
+    if (!bundle) return; // strict no-op when no bundle is present
+    const binDir = bundle.libDir; // on win32 the native-code dir is gtk/bin (the DLLs)
+    const cur = process.env.PATH ?? '';
+    if (cur.split(';').filter(Boolean).includes(binDir)) return; // already on PATH
+    process.env.PATH = cur ? `${binDir};${cur}` : binDir;
+}
+
 let activated = null; // memoize: the activation result (idempotent)
 
 /**
@@ -116,21 +146,25 @@ let activated = null; // memoize: the activation result (idempotent)
  *   • typelibs — prepend the bundle's girepository-1.0 dir to the GIRepository
  *     search path (env-free, via the native prependSearchPath); this alone lets
  *     node-gi FIND the bundled typelibs without GI_TYPELIB_PATH.
- *   • dylibs — prepend the bundle's lib dir to process.env.DYLD_FALLBACK_LIBRARY_PATH.
- *     NB dyld captures that variable at LAUNCH, so setting it here only helps
- *     child processes / a re-exec; a bundle whose dylibs a namespace loads by
- *     leaf name still needs the value present in the launching environment (see
- *     the package README's env-free caveat). Namespaces whose dylib is already
- *     in-process via the addon's link closure (GLib/GObject/Gio/cairo) resolve
- *     regardless.
- * Currently scoped to darwin (the only platform shipping a relocated bundle).
+ *   • native code — darwin: prepend the bundle's lib dir to
+ *     process.env.DYLD_FALLBACK_LIBRARY_PATH. NB dyld captures that variable at
+ *     LAUNCH, so setting it here only helps child processes / a re-exec; a bundle
+ *     whose dylibs a namespace loads by leaf name still needs the value present in
+ *     the launching environment (see the package README's env-free caveat).
+ *     Namespaces whose dylib is already in-process via the addon's link closure
+ *     (GLib/GObject/Gio/cairo) resolve regardless. win32: prepend the bundle's bin
+ *     dir to process.env.PATH — already done by maybePrependGtkRuntimeDllPath before
+ *     the addon loaded; re-asserted here for child processes + the runtime
+ *     g_module_open of typelib backers. Windows re-reads PATH per LoadLibrary, so no
+ *     launch-time capture applies (see the package README).
+ * Scoped to darwin + win32 (the platforms shipping a batteries-included bundle).
  * @param {{ prependSearchPath: (p: string) => void }} native the loaded addon
  * @returns {{ dir: string, libDir: string, typelibDir: string } | null}
  */
 export function activateBundledGtkRuntime(native) {
     if (activated !== null) return activated || null;
     activated = false;
-    if (process.platform !== 'darwin') return null;
+    if (process.platform !== 'darwin' && process.platform !== 'win32') return null;
 
     const bundle = resolveGtkRuntimeBundle();
     if (!bundle) return null;
@@ -141,9 +175,16 @@ export function activateBundledGtkRuntime(native) {
         // A stubbed/old addon without prependSearchPath — non-fatal.
     }
 
-    const existing = process.env.DYLD_FALLBACK_LIBRARY_PATH;
-    if (!existing || !existing.split(':').includes(bundle.libDir)) {
-        process.env.DYLD_FALLBACK_LIBRARY_PATH = existing ? `${bundle.libDir}:${existing}` : `${bundle.libDir}:/usr/lib`;
+    if (process.platform === 'win32') {
+        const existing = process.env.PATH ?? '';
+        if (!existing.split(';').filter(Boolean).includes(bundle.libDir)) {
+            process.env.PATH = existing ? `${bundle.libDir};${existing}` : bundle.libDir;
+        }
+    } else {
+        const existing = process.env.DYLD_FALLBACK_LIBRARY_PATH;
+        if (!existing || !existing.split(':').includes(bundle.libDir)) {
+            process.env.DYLD_FALLBACK_LIBRARY_PATH = existing ? `${bundle.libDir}:${existing}` : `${bundle.libDir}:/usr/lib`;
+        }
     }
 
     activated = bundle;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -14,7 +14,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { activateBundledGtkRuntime, maybeReexecForGtkRuntime } from './gtk-runtime.js';
+import { activateBundledGtkRuntime, maybePrependGtkRuntimeDllPath, maybeReexecForGtkRuntime } from './gtk-runtime.js';
 
 // macOS batteries-included GTK: if a relocated bundle ships for this platform,
 // re-exec ONCE with DYLD_FALLBACK_LIBRARY_PATH pointed at it BEFORE the addon (and
@@ -23,6 +23,14 @@ import { activateBundledGtkRuntime, maybeReexecForGtkRuntime } from './gtk-runti
 // Gdk / Graphene) by leaf soname. No-op off darwin, without a bundle, or once the
 // fallback already covers the bundle (the re-exec'd child). Never returns on re-exec.
 maybeReexecForGtkRuntime();
+
+// Windows batteries-included GTK: if a bundle ships for this platform, prepend its
+// gtk/bin DLL dir to process.env.PATH BEFORE the addon is require()'d below. Windows
+// re-reads the DLL search path at each LoadLibrary (unlike dyld's launch-time
+// capture), so this in-process PATH mutation is enough for the addon's static DLL
+// imports AND the runtime g_module_open of typelib backers — no re-exec needed.
+// No-op off win32 / without a bundle.
+maybePrependGtkRuntimeDllPath();
 
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url)); // package root

--- a/packages/node-gi/node-gi/scripts/check-batteries.mjs
+++ b/packages/node-gi/node-gi/scripts/check-batteries.mjs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
-// Fast single-process probe for the batteries-included (no-Homebrew) GTK runtime
-// on macOS. Reproduces the two paths that need a leaf-soname g_module_open to
-// resolve against the bundled dylibs — which only works once node-gi has made the
-// runtime env-free (the DYLD_FALLBACK re-exec in gtk-runtime.js):
+// Fast single-process probe for the batteries-included GTK runtime (no Homebrew on
+// macOS / no gvsbuild on Windows). Reproduces the two paths that need a leaf-soname
+// g_module_open to resolve against the bundled native code — which only works once
+// node-gi has made the runtime env-free (the DYLD_FALLBACK re-exec on macOS, the
+// gtk/bin PATH-prepend on Windows — both in gtk-runtime.js):
 //   1. registerClass subclassing — gi_registered_type_info_get_g_type() must call
 //      the parent type's get_type() (e.g. g_simple_action_get_type in libgio), the
 //      exact path that failed with "… is not a subclassable GObject type".
@@ -33,4 +34,4 @@ for (const [ns, type] of [
     if (g == null) throw new Error(`${ns}.${type}: getGType returned null — leaf g_module_open failed env-free`);
 }
 
-console.log('batteries-included probe OK: registerClass(Gio.SimpleAction) + Pango/Graphene/Gdk get_type resolved with no Homebrew GTK');
+console.log('batteries-included probe OK: registerClass(Gio.SimpleAction) + Pango/Graphene/Gdk get_type resolved with no system/Homebrew/gvsbuild GTK');

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -122,19 +122,21 @@ const argsFor = (file) =>
       : ['test', '-A', '--node-modules-dir=auto', file];
 const runtimeBin = runtime === 'node' ? process.execPath : runtime;
 
-// Deno's N-API env teardown on macOS can abort a test FILE with a non-zero exit
-// AFTER every assertion in it has already passed — no test summary is printed, the
-// process just exits non-zero once the last subtest reported `ok` (the #47 teardown
-// class; the graphene/Gdk boxed g_boxed_free churn is one trigger, but it is
-// NONDETERMINISTIC and lands on a DIFFERENT file run-to-run — struct-construct one
-// run, out-params the next). That is not a reverse-bridge capability gap, so on
-// deno+darwin ONLY we gate on the per-subtest RESULTS parsed from Deno's own output
+// Deno's N-API env teardown can abort a test FILE with a non-zero exit AFTER every
+// assertion in it has already passed — no test summary is printed, the process just
+// exits non-zero once the last subtest reported `ok` (the #47 teardown class; the
+// graphene/Gdk boxed g_boxed_free churn is one trigger). It is NONDETERMINISTIC in
+// two ways: it lands on a DIFFERENT file run-to-run (struct-construct one run,
+// out-params the next, gobject the next) AND on a DIFFERENT platform run-to-run
+// (macos-arm64 one run, linux-aarch64 the next) — it is an N-API-env-teardown quirk,
+// not a darwin-specific one. That is not a reverse-bridge capability gap, so on DENO
+// (all platforms) we gate on the per-subtest RESULTS parsed from Deno's own output
 // instead of the process exit code: if every test the run announced actually ran and
 // none reported FAILED, a non-zero exit is the known teardown artifact (non-gating).
 // A real assertion failure (a FAILED line) OR a truncated run (fewer results than the
 // "running N tests" header promised — i.e. a genuine mid-test crash) still HARD-gates.
-// node / bun / linux keep exit-code gating unchanged. See #47.
-const denoDarwinTeardownCarveout = runtime === 'deno' && process.platform === 'darwin';
+// node / bun keep exit-code gating unchanged. See #47.
+const denoTeardownCarveout = runtime === 'deno';
 
 // Parse Deno's test output into { expected, ran, failed } by counting its per-subtest
 // result lines ("<name> ... ok|FAILED|ignored (<dur>)") and the "running N tests from"
@@ -168,7 +170,7 @@ for (const base of files) {
     encoding: 'utf8',
     env: { ...process.env, NODE_GI_NATIVE: nativePref },
   });
-  const teardown = denoDarwinTeardownCarveout && res.status !== 0
+  const teardown = denoTeardownCarveout && res.status !== 0
     ? classifyDenoOutput((res.stdout || '') + '\n' + (res.stderr || ''))
     : null;
   if (res.status === 0) {
@@ -176,7 +178,7 @@ for (const base of files) {
   } else if (teardown?.teardownArtifact) {
     softFailed++;
     console.log(
-      `  ⚠ ${base} (known non-gating: deno/darwin teardown-exit after ${teardown.ran}/${teardown.expected} tests passed, 0 failed — see #47)`,
+      `  ⚠ ${base} (known non-gating: deno teardown-exit after ${teardown.ran}/${teardown.expected} tests passed, 0 failed — see #47)`,
     );
   } else {
     failed++;


### PR DESCRIPTION
Build the **Windows batteries-included** sibling of the macOS `@gjsify/gtk-runtime-darwin-arm64` package (#768) so `@gjsify/node-gi` runs on Windows with **NO gvsbuild install on the host**. Mirrors the darwin package (#768) + its release publish leg (#770).

## What's in it

1. **Package `@gjsify/gtk-runtime-win32-x64`** (`packages/node-gi/gtk-runtime-win32-x64/`) — mirror of darwin-arm64 with `os:["win32"]`, `cpu:["x64"]`, tier 3. `index.js` path helpers point at the Windows layout (`gtk/bin` DLLs + `gtk/girepository-1.0` typelibs). Committed `.gitignore` for `gtk/`; `files:["gtk"]` ships it recursively.
2. **Bundle build** `scripts/build-gtk-runtime.mjs` — on a windows-latest runner with gvsbuild GTK4 present, walks the display-free DLL closure from the seed set with `dumpbin /dependents` (located via `vswhere`), keeping only gvsbuild-resident deps, into `gtk/bin`; copies typelibs into `gtk/girepository-1.0`; emits `manifest.json`. Falls back to copying the whole `bin/*.dll` set if dumpbin is unavailable (complete superset). **No relocation** — Windows resolves DLLs by search path, so copying is the whole job.
3. **Loader integration** (`packages/node-gi/node-gi/gtk-runtime.js` + `index.js`) — new `maybePrependGtkRuntimeDllPath()` prepends the bundle's `gtk/bin` to `process.env.PATH` **before** the addon is `require()`'d. `resolveGtkRuntimeBundle` is now platform-aware (`bin` on win32, `lib` on darwin); `activateBundledGtkRuntime` extended to win32. **macOS behavior is byte-identical** (verified by simulation).
4. **CI** (`node-gi.yml`) — `windows-gtk-runtime` (build + upload the bundle) + `windows-batteries-included` (download bundle + addon prebuild, assert gvsbuild absent, run the display-free conformance with the bundle as the ONLY GTK).
5. **Release** (`release.yml`) — `publish-gtk-runtime-win32-x64` mirroring #770: build the bundle → OIDC-publish only this package.

## Loader mechanism: PATH-prepend, no re-exec (and why)

Windows re-reads the DLL search path at **every** `LoadLibrary` call — unlike dyld, which captures `DYLD_FALLBACK_LIBRARY_PATH` only at process launch (the reason macOS needs a one-shot re-exec). The node-gi addon is loaded **exclusively** by node-gi's own `require()` in `loadNative()`, which runs *after* the PATH prepend, so the addon's static DLL imports resolve against the bundle with no re-exec. `AddDllDirectory` would be chicken-and-egg (the addon must already be loaded to expose it). The **same** `gtk/bin` PATH entry also satisfies the runtime `g_module_open(<soname>)` lookups for the non-addon-linked backers (Pango/Gdk/Graphene) — so, unlike the macOS batteries job (CORE + FULL legs), one PATH-prepend covers everything in a single env-free run.

## Verified statically vs needs Windows CI

**Verified locally (Linux):** all JS/MJS `node --check`; both workflows are valid YAML with the new jobs present; the seed-pattern + `dumpbin` parser logic against realistic gvsbuild inputs (system DLLs correctly dropped); the loader path resolution + PATH-prepend for win32 (idempotent) **and** byte-identical darwin behavior, via `process.platform` simulation; the bundle layout matches `index.js`'s `isPresent` check; `packages/node-gi/*` stays out of the root workspaces (race-safe publish, same as darwin).

**Only Windows CI can confirm:** that a `process.env.PATH` mutation reaches `LoadLibraryEx`'s search on Node 24/Windows (the core assumption); that the collected DLL closure is complete for every conformance file; and that the gvsbuild-linked addon loads its imports from the bundle. These are exactly what the two new CI jobs prove.

## ⚠️ Maintainer action — manual first publish required

Like the darwin package, `@gjsify/gtk-runtime-win32-x64` needs a **one-time manual** `gjsify publish --access public` + `gjsify trust @gjsify/gtk-runtime-win32-x64` (or `gjsify onboard`) from a maintainer machine **before** the first CI release — npm Trusted Publishing (OIDC) can publish new versions but cannot *create* a package, so an unbootstrapped first `publish-gtk-runtime-win32-x64` run would 404.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq