### PR TITLE
docs(node-gi): record bun teardown not deno-class

### DIFF
--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -155,6 +155,29 @@ const runtimeBin = runtime === 'node' ? process.execPath : runtime;
 // crash) still HARD-gates. node / bun keep exit-code gating unchanged. See #47.
 const denoTeardownCarveout = runtime === 'deno';
 
+// BUN was investigated for the SAME teardown class (#58) and is deliberately NOT
+// carved out — it stays on plain exit-code gating (above). The Deno root cause does
+// not transfer to Bun's N-API teardown, confirmed both by mechanism and empirically:
+//   • Mechanism: for a non-EXPERIMENTAL module (node-addon-api) Bun DEFERS the boxed-
+//     handle External finalizer — NapiExternal's destructor enqueues a NapiFinalizerTask
+//     onto the JS/main-thread event loop instead of running it inline
+//     (napi.h mustDeferFinalizers()/napi_internal_enqueue_finalizer). At env teardown
+//     the finalizers run single-threaded on the JS thread, under DeferGCForAWhile, with
+//     napi_internal_remove_finalizer dedup — so FreeBoxedHandleRecord always receives
+//     node-gi's OWN valid BoxedHandle* (its gtype is intact), never a stale finalize_data
+//     handed over by a concurrent runtime-worker weak callback. That concurrency — V8
+//     firing the second-pass weak callback on the isolate-owning tokio thread over
+//     Reference state Deno is freeing — IS the Deno crash, and Bun has no equivalent
+//     (its own crash marker even reads `panic(main thread)`).
+//   • Empirically: ~7000 Bun runs (arrays + the GObject/boxed-heavy files incl. `methods`,
+//     full 37-file suite ×40, a probe holding 30k live boxed handles to process exit,
+//     random --smol GC pressure) produced 0 crashes / 0 cores. The SAME box + harness
+//     reproduces the Deno crash readily (8 SIGSEGV/SIGABRT cores; gdb: SIGSEGV inside
+//     libgobject-2.0.so.0 on a runtime-worker thread, main thread idle in epoll_wait).
+// So a `pass>0 && fail===0 && <crash marker>` Bun carve-out would only MASK a real
+// node-gi/Bun teardown bug if one ever appears. Do NOT add one on inference: if Bun ever
+// hard-crashes here, re-confirm with a gdb backtrace (the Deno determination's bar) first.
+
 // Parse Deno's test output into { expected, ran, failed } by counting its per-subtest
 // result lines ("<name> ... ok|FAILED|ignored (<dur>)") and the "running N tests from"
 // headers. ANSI colour codes are stripped first. `teardownArtifact` is true iff every


### PR DESCRIPTION
## Summary

Task #58 asked whether Bun (JavaScriptCore) shares the #47 **Deno** teardown
SIGSEGV class (non-zero exit *after* every subtest passes, from the boxed-handle
External finalizer). This is the rigor result: **it does not** — Bun is
deliberately kept on plain exit-code gating, with the investigation recorded in
`scripts/cross-runtime.mjs` (mirroring the Deno "record as not-fixable" note in
#773). **Comment-only, +23 lines. No carve-out added.**

## gdb finding (the deliverable)

- **Deno (positive control, CONFIRMED):** on this box the Deno crash reproduces
  readily — 8 SIGSEGV/SIGABRT cores across a session. gdb on a core:
  **frame #0 is inside `libgobject-2.0.so.0` (glib2-2.88.1), on a runtime-worker
  thread**, while the process **main thread sits idle in `epoll_wait`** — the
  jump is through a garbage pointer (`n/a + 0x0`), matching the documented
  `FreeBoxedHandleRecord → g_boxed_free` with a stale/garbage GType at isolate
  disposal.
- **Bun: no crash, no core** across **~7000 runs** on the SAME box + harness that
  catches Deno: `arrays` + the GObject/boxed-heavy files (incl. `methods`, the
  file Deno crashes on most), the full 37-file suite ×40, a probe holding **30k
  live boxed handles to process exit** (forcing `g_boxed_free` at teardown), and
  random `--smol` GC pressure. 0 crashes / 0 cores.

## Why the mechanism does not transfer (refs/bun N-API)

For a non-EXPERIMENTAL module (node-addon-api) Bun **defers** the boxed-handle
External finalizer: `NapiExternal`'s destructor enqueues a `NapiFinalizerTask`
onto the JS/main-thread event loop instead of running it inline
(`napi.h` `mustDeferFinalizers()` / `napi_internal_enqueue_finalizer`). At env
teardown the finalizers run **single-threaded on the JS thread**, under
`DeferGCForAWhile`, with `napi_internal_remove_finalizer` dedup — so
`FreeBoxedHandleRecord` always gets node-gi's **own valid `BoxedHandle*`**
(gtype intact), never a stale `finalize_data` handed over by a concurrent
runtime-worker weak callback. That concurrency (V8 firing the second-pass weak
callback on the isolate-owning tokio thread over Reference state Deno is freeing)
**is** the Deno crash; Bun has no equivalent — its crash marker even reads
`panic(main thread)`.

## Decision

A `pass>0 && fail===0 && <crash marker>` Bun carve-out would only **mask** a real
node-gi/Bun teardown bug if one ever appeared. Per the task's rigor bar, the gate
is **not** widened on inference. Verified the safety property still holds: a
forced Bun non-zero exit still **hard-gates** (runner exit 1, reports `✗`, no
soft-pass). The Deno path is unchanged; the Bun leg stays 37/37 green.

If Bun ever hard-crashes here, re-confirm with a gdb backtrace (the Deno
determination's bar) before treating.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq