### PR TITLE
feat(node-gi): make the GTK window interactive

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -284,7 +284,7 @@ jobs:
           xvfb-run -a dbus-run-session -- \
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs \
-              test/windowing.test.mjs \
+              test/windowing.test.mjs test/windowing-interactive.test.mjs \
               test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs \
               test/gtk-template-signals.test.mjs \
               test/strv-construct.test.mjs test/interface-props.test.mjs
@@ -1356,15 +1356,17 @@ jobs:
           Test-Path packages/node-gi/node-gi/prebuilds/win32-x64/gtk/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
 
       # The windowing proof: a real Adw.ApplicationWindow realizes + renders a surface
-      # via the GSK renderer, with the bundle as the ONLY GTK. NODE_GI_NATIVE=prebuild
-      # loads the staged addon; the loader's PATH-prepend + windowing-env wiring makes
-      # the DLLs + schemas/loaders/icons resolve from the bundle. On win32 the test's
-      # display gate is IMPLICIT (no DISPLAY/WAYLAND_DISPLAY needed — the GdkWin32
-      # backend supplies it), so it runs here. GSK_RENDERER=cairo forces software
-      # rendering (no GPU on the runner).
-      - name: Windowing proof — Adw window realizes + renders (no gvsbuild GTK)
+      # via the GSK renderer, AND responds to input (a Gio action + a Gtk.Button::clicked
+      # drive the counter — the interactive proof runs headless, no visible desktop
+      # needed, same as the render-to-texture screenshot), with the bundle as the ONLY
+      # GTK. NODE_GI_NATIVE=prebuild loads the staged addon; the loader's PATH-prepend +
+      # windowing-env wiring makes the DLLs + schemas/loaders/icons resolve from the
+      # bundle. On win32 the test's display gate is IMPLICIT (no DISPLAY/WAYLAND_DISPLAY
+      # needed — the GdkWin32 backend supplies it), so it runs here. GSK_RENDERER=cairo
+      # forces software rendering (no GPU on the runner).
+      - name: Windowing proof — Adw window realizes, renders + reacts (no gvsbuild GTK)
         working-directory: packages/node-gi/node-gi
         env:
           NODE_GI_NATIVE: prebuild
           GSK_RENDERER: cairo
-        run: node --test test/windowing.test.mjs
+        run: node --test test/windowing.test.mjs test/windowing-interactive.test.mjs

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -484,7 +484,8 @@ classes (`class extends Gio.SimpleAction { … }`).
 
 Caveats (this is the no-toggle-ref object model): the user class's JS constructor
 body is not run — GObject-idiomatic init belongs in `vfunc_constructed`;
-instances are Proxies over a native handle (not real `instanceof` instances);
+instances are Proxies over a native handle (but `instanceof` still works — it is
+resolved through the GObject type system, see the `instanceof` note below);
 **plain (non-GObject-property) JS instance fields do NOT cross the
 vfunc↔instance boundary** — inside a vfunc, `this` is a distinct wrapper over the
 same GObject (the native engine mints a fresh handle per call, so there is no
@@ -777,17 +778,20 @@ byte-identical DOM events under node-gi and `gjs -m` — the same source builds
 is deterministic + display-independent (coords clamp to a fixed 400x300 allocation;
 key/code/modifiers derive from the Gdk marshalling), so byte-parity is stable.
 
-**Deferred node-gi gap (does not affect the behavior):** node-gi does not wire
-`instanceof` for GObject wrapper classes yet — `new Gtk.EventControllerMotion()
-instanceof Gtk.EventControllerMotion` is `false` (even for a freshly-constructed
-wrapper), because the per-GType wrappers are not set up as real JS classes with a
-prototype chain / `Symbol.hasInstance`. So the fixture cannot use the GJS spec's
-`ctrl instanceof Gtk.EventControllerMotion` controller filter; it retrieves
-controllers by ADD ORDER off `widget.observe_controllers()` instead (wrapper
-IDENTITY *is* preserved and `emit()` resolves the signal by the live GType, so the
-bridged behavior is unaffected). Wiring `instanceof` is a core object-model change
-(per-GType JS classes or a `Symbol.hasInstance` hook) — tracked as a native-engine
-follow-up. (A second gap the fixture originally routed around — `new
+**`instanceof` across the GObject hierarchy (GJS parity):** `instanceof` for GObject
+wrapper classes is wired through the GObject type system — each per-GType wrapper
+carries a `Symbol.hasInstance` that resolves via `g_type_is_a` (native
+`isInstanceOf`), so `new Gtk.EventControllerMotion() instanceof
+Gtk.EventControllerMotion` is `true`, and so is a base class (`… instanceof
+Gtk.EventController`), an implemented interface (`simpleAction instanceof Gio.Action`)
+and a `registerClass` subclass against its leaf / base / interface — while a sibling
+type, an unrelated class, a boxed/`Variant` handle, `null` or a plain object stay
+`false`. `test/instanceof.test.mjs` + the cross-runtime golden
+`conformance/programs/instanceof-hierarchy.conf.mjs` (gjs/node/bun/deno byte-identical)
+guard it. The event-bridge fixture retrieves controllers by ADD ORDER off
+`widget.observe_controllers()` as a stylistic choice (identity is preserved and
+`emit()` resolves the signal by the live GType) — no longer forced by a gap.
+(A second gap the fixture originally routed around — `new
 Gdk.Rectangle()` threw `no static method 'new'` — is FIXED: `new <BoxedStruct>()`
 now zero-allocates with GJS `gi/boxed.cpp` semantics when the struct has no `new`
 constructor (`Graphene.Rect`/`Point`, `Gdk.Rectangle`, `Gdk.RGBA` — the

--- a/packages/node-gi/node-gi/conformance/golden/instanceof-hierarchy.txt
+++ b/packages/node-gi/node-gi/conformance/golden/instanceof-hierarchy.txt
@@ -1,0 +1,19 @@
+action instanceof SimpleAction: true
+action instanceof GObject.Object: true
+action instanceof Gio.Action (iface): true
+group instanceof SimpleActionGroup: true
+group instanceof GObject.Object: true
+group instanceof Gio.ActionGroup (iface): true
+group instanceof Gio.ActionMap (iface): true
+action instanceof Cancellable: false
+action instanceof SimpleActionGroup: false
+cancellable instanceof Gio.Action: false
+plain {} instanceof SimpleAction: false
+null instanceof SimpleAction: false
+boxed Variant instanceof SimpleAction: false
+sub instanceof MyAction (leaf): true
+sub instanceof SimpleAction (base): true
+sub instanceof GObject.Object: true
+sub instanceof Gio.Action (iface): true
+sub instanceof OtherAction (sibling): false
+plain SimpleAction instanceof MyAction: false

--- a/packages/node-gi/node-gi/conformance/programs/instanceof-hierarchy.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/instanceof-hierarchy.conf.mjs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// `instanceof` across the GObject hierarchy (phase 3.x) — GJS parity for the WHOLE
+// class chain + implemented interfaces, not just the leaf class. Headless
+// Gio/GObject (no display / test typelib). An introspected instance is a Proxy over
+// a bare handle with no live JS prototype chain, so the default instanceof reported
+// `false` for base classes and interfaces; node-gi now resolves it through the
+// GObject type system (g_type_is_a) exactly like GJS. The golden is the gjs output;
+// node/bun/deno must match it byte-for-byte. Deterministic — no addresses/timestamps.
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+const action = new Gio.SimpleAction({ name: 'x', enabled: true });
+const group = new Gio.SimpleActionGroup();
+const cancellable = new Gio.Cancellable();
+
+// ---- introspected instance: exact class, base classes, implemented interfaces ----
+print('action instanceof SimpleAction:', action instanceof Gio.SimpleAction);
+print('action instanceof GObject.Object:', action instanceof GObject.Object);
+print('action instanceof Gio.Action (iface):', action instanceof Gio.Action);
+print('group instanceof SimpleActionGroup:', group instanceof Gio.SimpleActionGroup);
+print('group instanceof GObject.Object:', group instanceof GObject.Object);
+print('group instanceof Gio.ActionGroup (iface):', group instanceof Gio.ActionGroup);
+print('group instanceof Gio.ActionMap (iface):', group instanceof Gio.ActionMap);
+
+// ---- negatives: unrelated class, un-implemented interface, non-GObject values ----
+print('action instanceof Cancellable:', action instanceof Gio.Cancellable);
+print('action instanceof SimpleActionGroup:', action instanceof Gio.SimpleActionGroup);
+print('cancellable instanceof Gio.Action:', cancellable instanceof Gio.Action);
+print('plain {} instanceof SimpleAction:', {} instanceof Gio.SimpleAction);
+print('null instanceof SimpleAction:', null instanceof Gio.SimpleAction);
+print('boxed Variant instanceof SimpleAction:', new GObject.Value() instanceof Gio.SimpleAction);
+
+// ---- registered subclass: leaf, introspected base, GObject.Object, interface ----
+const MyAction = GObject.registerClass(
+  { GTypeName: 'NodeGiInstanceofAction' },
+  class MyAction extends Gio.SimpleAction {},
+);
+const OtherAction = GObject.registerClass(
+  { GTypeName: 'NodeGiInstanceofOther' },
+  class OtherAction extends Gio.SimpleAction {},
+);
+const sub = new MyAction({ name: 'sub', enabled: true });
+print('sub instanceof MyAction (leaf):', sub instanceof MyAction);
+print('sub instanceof SimpleAction (base):', sub instanceof Gio.SimpleAction);
+print('sub instanceof GObject.Object:', sub instanceof GObject.Object);
+print('sub instanceof Gio.Action (iface):', sub instanceof Gio.Action);
+print('sub instanceof OtherAction (sibling):', sub instanceof OtherAction);
+print('plain SimpleAction instanceof MyAction:', action instanceof MyAction);

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -1326,6 +1326,42 @@ function makeClass(namespace, typeName) {
     enumerable: false,
     configurable: true,
   });
+  // `inst instanceof Ns.Class` — GJS parity for the WHOLE GObject hierarchy, not
+  // just the leaf class. An instance is a Proxy over a bare `{[HANDLE]}` (no live JS
+  // prototype chain linking Adw.ApplicationWindow → Gtk.ApplicationWindow → …), so
+  // the default instanceof (a prototype-chain walk) reported `false` for every base
+  // class. Resolve it by the GObject type system instead: `native.isInstanceOf`
+  // (g_type_is_a) recognises subclasses AND implemented interfaces, exactly like GJS.
+  // Guarded by `isGObjectHandle` first — a bare/boxed/variant handle (or any non-node-gi
+  // value) is NOT a GObject, so it must be `false`, never reach `isInstanceOf` (which
+  // throws on a non-GObject handle). The makeClass Proxy `get` trap forwards this
+  // symbol to the target (`typeof prop !== 'string'` → `t[prop]`), so `instanceof`
+  // finds it on the proxy. Overlay-built classes (GLib.Variant / GObject.Value /
+  // GObject.ParamSpec) bypass makeClass and keep their own dedicated hasInstance.
+  Object.defineProperty(ctor, Symbol.hasInstance, {
+    configurable: true,
+    value(instance) {
+      if (instance === null || typeof instance !== 'object') return false;
+      const handle = instance[HANDLE];
+      if (handle === undefined || !native.isGObjectHandle(handle)) return false;
+      // The introspected class ITSELF → resolve by name: g_type_is_a recognises every
+      // subclass AND implemented interface, matching GJS exactly.
+      if (this === proxy) return native.isInstanceOf(handle, namespace, typeName);
+      // A registerClass'd subclass INHERITS this method (it `extends` the proxy) but
+      // must match ITS OWN registered GType, not the shared introspected base — else a
+      // sibling subclass or a bare-base instance would wrongly test true. Resolve the
+      // instance's runtime GType against the subclass's own `$gtype` through the GObject
+      // type system (a live JS prototype chain the subclass instance lacks — the L1
+      // wrapper carries the user prototype as a symbol, not as [[Prototype]]).
+      const subGType = this.$gtype;
+      if (subGType !== undefined && subGType !== null) {
+        const G = requireGi('GObject', '2.0');
+        return G.type_is_a(G.type_from_name(native.getTypeName(handle)), subGType);
+      }
+      // A raw (unregistered) subclass / unrelated ctor: ordinary prototype-chain.
+      return Function.prototype[Symbol.hasInstance].call(this, instance);
+    },
+  });
   // Expose constructor/static methods lazily: Ns.Class.new(...) /
   // Ns.Class.new_for_path(...) (and the camelCase aliases). `new Ns.Class({...})`
   // still goes through the target's [[Construct]] (the default Proxy behaviour).

--- a/packages/node-gi/node-gi/test/event-bridge.test.mjs
+++ b/packages/node-gi/node-gi/test/event-bridge.test.mjs
@@ -27,12 +27,12 @@
 // running `--app gjs` (default on; set NODE_GI_EB_SKIP_GJS=1 for a node-only run —
 // see the haveGjs note); the same gold-standard parity the `canvas2d-bridge` e2e uses.
 //
-// NODE-GI GAP the fixture routes around (documented, deferred — see README): node-gi
-// does not wire `instanceof` for GObject wrapper classes, so the fixture cannot use
-// the spec's `ctrl instanceof Gtk.EventControllerMotion` controller filter. It
-// retrieves controllers by ADD ORDER off `observe_controllers()` instead (identity
-// is preserved + `emit()` resolves by the live GType). The BEHAVIOR under test —
-// the bridge dispatching correct DOM events — is unaffected.
+// The fixture retrieves controllers by ADD ORDER off `observe_controllers()` (identity
+// is preserved + `emit()` resolves by the live GType) rather than by the spec's
+// `ctrl instanceof Gtk.EventControllerMotion` filter. `instanceof` across the GObject
+// hierarchy IS wired now (see test/instanceof.test.mjs + conformance/programs/
+// instanceof-hierarchy.conf.mjs), so this is a stylistic choice, not a routed-around
+// gap. The BEHAVIOR under test — the bridge dispatching correct DOM events — is the same.
 //
 // This is a LOCAL/dev verification, NOT wired into CI. Running the LIVE bridge needs
 // the full gjsify workspace built with a CURRENT-source `@gjsify/cli` (the

--- a/packages/node-gi/node-gi/test/instanceof.test.mjs
+++ b/packages/node-gi/node-gi/test/instanceof.test.mjs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — `instanceof` across the GObject hierarchy (GJS parity).
+//
+// An introspected instance is a Proxy over a bare handle with NO live JS prototype
+// chain linking a leaf class to its bases/interfaces, so the default instanceof (a
+// prototype-chain walk) reported `false` for every base class + interface. node-gi
+// now resolves membership through the GObject type system (g_type_is_a), exactly as
+// GJS does — recognising base classes, implemented interfaces, and registerClass
+// subclasses, while a non-GObject value / boxed handle / sibling type stays `false`.
+//
+// Headless: Gio/GObject only (no display / test typelib), so it runs in the fast
+// `npm test` leg. The cross-runtime golden-diff of the same behaviour lives in
+// conformance/programs/instanceof-hierarchy.conf.mjs (gjs/node/bun/deno byte-identical).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const GObject = requireGi('GObject', '2.0');
+const Gio = requireGi('Gio', '2.0');
+const GLib = requireGi('GLib', '2.0');
+
+test('introspected instance is-a its exact class, base classes + interfaces', () => {
+  const action = new Gio.SimpleAction({ name: 'x', enabled: true });
+  assert.ok(action instanceof Gio.SimpleAction, 'exact class');
+  assert.ok(action instanceof GObject.Object, 'cross-namespace base GObject.Object');
+  assert.ok(action instanceof Gio.Action, 'implemented interface Gio.Action');
+
+  const group = new Gio.SimpleActionGroup();
+  assert.ok(group instanceof Gio.SimpleActionGroup, 'exact class');
+  assert.ok(group instanceof GObject.Object, 'base');
+  assert.ok(group instanceof Gio.ActionGroup, 'interface Gio.ActionGroup');
+  assert.ok(group instanceof Gio.ActionMap, 'interface Gio.ActionMap');
+});
+
+test('unrelated classes, interfaces + non-GObject values are NOT instanceof', () => {
+  const action = new Gio.SimpleAction({ name: 'x' });
+  const cancellable = new Gio.Cancellable();
+  assert.ok(!(action instanceof Gio.Cancellable), 'unrelated class');
+  assert.ok(!(action instanceof Gio.SimpleActionGroup), 'unrelated class');
+  assert.ok(!(cancellable instanceof Gio.Action), 'un-implemented interface');
+  assert.ok(!({} instanceof Gio.SimpleAction), 'plain object');
+  assert.ok(!(null instanceof Gio.SimpleAction), 'null');
+  assert.ok(!(new GLib.Variant('s', 'x') instanceof Gio.SimpleAction), 'boxed Variant handle');
+  assert.ok(!(new GObject.Value() instanceof Gio.SimpleAction), 'boxed GValue handle');
+});
+
+test('registerClass subclass: leaf, base, interface true; sibling + bare-base false', () => {
+  const MyAction = GObject.registerClass(
+    { GTypeName: 'NodeGiInstanceofTestAction' },
+    class MyAction extends Gio.SimpleAction {},
+  );
+  const OtherAction = GObject.registerClass(
+    { GTypeName: 'NodeGiInstanceofTestOther' },
+    class OtherAction extends Gio.SimpleAction {},
+  );
+  const sub = new MyAction({ name: 'sub', enabled: true });
+
+  assert.ok(sub instanceof MyAction, 'leaf registered class');
+  assert.ok(sub instanceof Gio.SimpleAction, 'introspected base');
+  assert.ok(sub instanceof GObject.Object, 'root base');
+  assert.ok(sub instanceof Gio.Action, 'inherited interface');
+  assert.ok(!(sub instanceof OtherAction), 'sibling registered class');
+
+  // A plain introspected instance is NOT an instance of a registered subclass.
+  const plain = new Gio.SimpleAction({ name: 'plain' });
+  assert.ok(!(plain instanceof MyAction), 'bare base is not the subclass');
+});

--- a/packages/node-gi/node-gi/test/windowing-interactive.test.mjs
+++ b/packages/node-gi/node-gi/test/windowing-interactive.test.mjs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — INTERACTIVE-window proof (GTK-GUI-on-node-gi, increment 2).
+//
+// The step BEYOND the static construct+render proof (windowing.test.mjs): a real
+// Adw.ApplicationWindow RESPONDS TO INPUT through the full GTK signal/action/event
+// chain via node-gi. Two tiers, robust on a runner whose surface may or may not
+// realize:
+//
+//   MINIMUM (always asserted) — the interactivity chain. A `Gio.SimpleAction` added
+//   to the WINDOW (`win.add_action`) and a `Gtk.Button::clicked` signal both dispatch
+//   into JS, mutate a counter, and the OBSERVABLE widget state changes: the window
+//   title, the `Adw.WindowTitle` subtitle and an `Adw.ActionRow` subtitle. This holds
+//   even if the platform surface never realizes — GAction activation + a synchronous
+//   `emit('clicked')` are display-independent. It exercises the exact path the
+//   `@gjsify/devtools` `ActivateAction` DBus method drives (`win.activate_action`):
+//   GTK signal/action → node-gi signal dispatch → JS handler → widget setter.
+//
+//   STRONGER (asserted WHEN the surface realizes) — the window realizes + RENDERS a
+//   surface through the GSK renderer (the same in-process capture @gjsify/devtools'
+//   Screenshot uses), so a non-empty PNG proves the interactive UI rasterised.
+//
+// PLATFORM-AWARE DISPLAY GATE (identical to windowing.test.mjs): win32/darwin have an
+// implicit display; Linux keys off DISPLAY/WAYLAND_DISPLAY (real session or Xvfb).
+// On Windows CI the action-activate + state-assert path works headless (no visible
+// desktop needed) — same as the render-to-texture screenshot.
+//
+// run() is called at the TOP LEVEL of a synchronous test body so the node-gtk #442
+// nested-microtask-checkpoint caveat does not bite; the drive + capture + quit run
+// INSIDE the loop, from the activate handler / a GLib timeout.
+//
+// Reference: refs/gjs (g_application_run, Gio.SimpleAction / GActionMap), refs/
+// libadwaita (ToolbarView / HeaderBar / WindowTitle / PreferencesGroup / ActionRow),
+// @gjsify/devtools screenshot.ts. Copyright (c) GNOME contributors, MIT/LGPL.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const displayless = process.platform === 'win32' || process.platform === 'darwin';
+const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let Adw;
+let Gtk;
+let Gdk;
+let Gio;
+let GLib;
+let Graphene;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    Gdk = requireGi('Gdk', '4.0');
+    Gtk = requireGi('Gtk', '4.0');
+    Adw = requireGi('Adw', '1');
+    Graphene = requireGi('Graphene', '1.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 / Adw-1 / Graphene-1.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+// The @gjsify/devtools GSK capture path, inline (see windowing.test.mjs).
+function captureWidgetPng(widget) {
+  const native = widget.get_native();
+  const renderer = native ? native.get_renderer() : null;
+  if (!renderer) return null;
+  const width = widget.get_width();
+  const height = widget.get_height();
+  if (width <= 0 || height <= 0) return null;
+  const paintable = Gtk.WidgetPaintable.new(widget);
+  const snapshot = Gtk.Snapshot.new();
+  paintable.snapshot(snapshot, width, height);
+  const node = snapshot.to_node();
+  if (!node) return null;
+  const viewport = new Graphene.Rect();
+  viewport.init(0, 0, width, height);
+  const texture = renderer.render_texture(node, viewport);
+  const bytes = texture.save_to_png_bytes();
+  const data = bytes ? bytes.get_data() : null;
+  return data && data.length > 0 ? data : null;
+}
+
+// DumpTree primitive: every widget TYPE in the tree (structural — no realized filter).
+function collectTypes(widget, out) {
+  out.push(widget.get_name());
+  let child = widget.get_first_child();
+  while (child) {
+    collectTypes(child, out);
+    child = child.get_next_sibling();
+  }
+}
+
+test('Adw window responds to a Gio action + a Gtk.Button::clicked on node-gi', { skip }, () => {
+  const app = new Adw.Application({
+    application_id: 'eu.jumplink.NodeGiInteractive',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  let activated = false;
+  let activateError = null;
+  let pngLength = 0;
+  let allocatedWidth = 0;
+  let allocatedHeight = 0;
+
+  // OBSERVABLE state snapshots (read from the WIDGETS, not the JS counter) after each
+  // trigger — the GetProperty tier. Each is `<title>|<windowTitle subtitle>|<row subtitle>`.
+  const states = {};
+  const chrome = { windowTitle: false, actionRow: false, button: false, toolbarView: false };
+
+  app.connect('activate', () => {
+    try {
+      activated = true;
+
+      let count = 0;
+      const win = new Adw.ApplicationWindow({ application: app });
+      win.set_default_size(480, 360);
+
+      const windowTitle = new Adw.WindowTitle({ title: 'node-gi', subtitle: '0 clicks' });
+      const header = new Adw.HeaderBar();
+      header.set_title_widget(windowTitle);
+
+      const countRow = new Adw.ActionRow({ title: 'Clicks', subtitle: '0' });
+      const group = new Adw.PreferencesGroup();
+      group.add(countRow);
+
+      const incrementButton = new Gtk.Button({ label: 'Increment' });
+      const resetButton = new Gtk.Button({ label: 'Reset' });
+
+      const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 18 });
+      box.append(group);
+      box.append(incrementButton);
+      box.append(resetButton);
+
+      const toolbar = new Adw.ToolbarView();
+      toolbar.add_top_bar(header);
+      toolbar.set_content(box);
+      win.set_content(toolbar);
+
+      // ONE state-mutation path; every trigger funnels through the action handlers.
+      const render = () => {
+        const label = count === 1 ? '1 click' : `${count} clicks`;
+        windowTitle.set_subtitle(label);
+        countRow.set_subtitle(String(count));
+        win.set_title(`node-gi — ${label}`);
+      };
+      const increment = new Gio.SimpleAction({ name: 'increment' });
+      increment.connect('activate', () => {
+        count += 1;
+        render();
+      });
+      win.add_action(increment);
+      const reset = new Gio.SimpleAction({ name: 'reset' });
+      reset.connect('activate', () => {
+        count = 0;
+        render();
+      });
+      win.add_action(reset);
+      incrementButton.connect('clicked', () => win.activate_action('increment', null));
+      resetButton.connect('clicked', () => win.activate_action('reset', null));
+
+      render();
+      win.present();
+
+      // Read the OBSERVABLE state off the widgets.
+      const snapshot = () =>
+        `${win.get_title()}|${windowTitle.get_subtitle()}|${countRow.get_subtitle()}`;
+
+      // Drive the chain SYNCHRONOUSLY (GAction activate + button clicked are synchronous
+      // dispatch — no main loop / surface needed).
+      states.initial = snapshot(); // 0
+
+      // (a) the Gio.SimpleAction on the window — the devtools ActivateAction path.
+      win.activate_action('increment', null);
+      win.activate_action('increment', null);
+      states.afterTwoActions = snapshot(); // 2
+
+      // (b) the Gtk.Button::clicked signal → JS → win.activate_action('increment').
+      incrementButton.emit('clicked');
+      states.afterButton = snapshot(); // 3
+
+      // (c) a second action resets the state.
+      win.activate_action('reset', null);
+      states.afterReset = snapshot(); // 0
+
+      // Structural chrome proof (DumpTree).
+      const types = [];
+      collectTypes(win, types);
+      chrome.windowTitle = types.includes('AdwWindowTitle');
+      chrome.actionRow = types.includes('AdwActionRow');
+      chrome.button = types.includes('GtkButton');
+      chrome.toolbarView = types.includes('AdwToolbarView');
+
+      // Strong tier: retry the GSK capture across frames, then quit.
+      let waitedMs = 0;
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        waitedMs += 50;
+        const png = captureWidgetPng(win);
+        if (png) {
+          pngLength = png.length;
+          allocatedWidth = win.get_width();
+          allocatedHeight = win.get_height();
+          app.quit();
+          return GLib.SOURCE_REMOVE;
+        }
+        if (waitedMs >= 5000) {
+          allocatedWidth = win.get_width();
+          allocatedHeight = win.get_height();
+          app.quit();
+          return GLib.SOURCE_REMOVE;
+        }
+        return GLib.SOURCE_CONTINUE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]);
+
+  assert.equal(activateError, null, `activate threw: ${activateError && activateError.stack}`);
+  assert.ok(activated, 'the app never activated');
+  assert.equal(status, 0, `app.run() exit status was ${status}, expected 0`);
+
+  // MINIMUM (always): the interactivity chain drove the OBSERVABLE widget state.
+  assert.equal(states.initial, 'node-gi — 0 clicks|0 clicks|0', 'initial widget state');
+  assert.equal(
+    states.afterTwoActions,
+    'node-gi — 2 clicks|2 clicks|2',
+    'Gio.SimpleAction activate → ::activate handler → widgets (2×)',
+  );
+  assert.equal(
+    states.afterButton,
+    'node-gi — 3 clicks|3 clicks|3',
+    'Gtk.Button::clicked → JS → win.activate_action → widgets',
+  );
+  assert.equal(states.afterReset, 'node-gi — 0 clicks|0 clicks|0', 'reset action → widgets');
+
+  // Structural chrome (DumpTree) — valid even if the surface never realizes.
+  assert.ok(chrome.toolbarView, 'AdwToolbarView missing from the widget tree');
+  assert.ok(chrome.windowTitle, 'AdwWindowTitle missing from the widget tree');
+  assert.ok(chrome.actionRow, 'AdwActionRow missing from the widget tree');
+  assert.ok(chrome.button, 'GtkButton missing from the widget tree');
+
+  // STRONGER (when the surface realizes): a non-empty GSK-rendered PNG.
+  if (allocatedWidth > 0 && allocatedHeight > 0) {
+    assert.ok(
+      pngLength > 0,
+      `window realized (${allocatedWidth}x${allocatedHeight}) but the GSK capture was empty`,
+    );
+    console.log(`interactive: rendered ${allocatedWidth}x${allocatedHeight} → ${pngLength}-byte PNG (strong proof)`);
+  } else {
+    console.log('interactive: surface did not realize — interactivity + DumpTree proof only');
+  }
+});

--- a/showcases/gtk/node-gi-window/README.md
+++ b/showcases/gtk/node-gi-window/README.md
@@ -1,11 +1,19 @@
 # @gjsify/example-gtk-node-gi-window
 
-A **minimal Libadwaita window** whose single `gi://` source builds and runs on
-**both GJS and Node.js** — the GTK-GUI capstone of the [`@gjsify/node-gi`](../../../packages/node-gi/node-gi)
+An **interactive Libadwaita window** whose single `gi://` source builds and runs on
+**both GJS and Node.js** — a GTK-GUI capstone of the [`@gjsify/node-gi`](../../../packages/node-gi/node-gi)
 reverse bridge. One unchanged `Adw.Application` + `Adw.ApplicationWindow`
-(HeaderBar / WindowTitle / StatusPage) realizes and renders a real top-level window
-through the platform GDK backend (GdkWayland/GdkX11 on Linux, GdkWin32 on Windows)
-under Node.js exactly as under GJS — beyond the display-free conformance.
+(HeaderBar / WindowTitle / Clamp / PreferencesGroup / ActionRow + `Gtk.Button`s)
+realizes, renders **and responds to input** through the platform GDK backend
+(GdkWayland/GdkX11 on Linux, GdkWin32 on Windows) under Node.js exactly as under GJS.
+
+The window keeps a click counter. A `Gtk.Button::clicked` signal AND a
+`Gio.SimpleAction` added to the window (`win.add_action`, with `<primary>plus` /
+`<primary>r` keyboard accelerators) both dispatch into JS, mutate the counter, and
+the visible state changes — the window title, the `Adw.WindowTitle` subtitle and the
+`Adw.ActionRow` subtitle. The button and every accelerator funnel through the SAME
+action, so there is **one** state-mutation path: GTK signal/action → node-gi signal
+dispatch → JS handler → widget setter.
 
 It is `private` + versioned (a dev-tooling showcase, like `adwaita-storybook`): it
 depends on `@gjsify/node-gi` via a `file:` link, so it is not published to npm.
@@ -20,26 +28,35 @@ gjsify run build:gjs && gjsify run start:gjs
 gjsify run build:node && gjsify run start:node
 ```
 
-Both builds produce the same window. `src/app.ts` runs the app via
+Both builds produce the same interactive window. `src/app.ts` runs the app via
 `Adw.Application.runAsync()` (NOT sync `run()` — sync view loads hang on their
 spinner under node-gi/gjsify) and references the GJS ambient `print` global, which
 triggers the reverse bridge's `@girs/*`-body resolution so `@gjsify/devtools` keeps
 its real code under `--app node`.
 
-## Self-verify over DBus (screenshot)
+## Self-verify the event chain over DBus
 
 `src/app.ts` embeds the [`@gjsify/devtools`](../../../packages/framework/devtools)
 control plane via `installDevtools(app)` (a no-op unless `GJSIFY_DEVTOOLS` is
-truthy). With it enabled, the LIVE window is inspectable and screenshottable over
-the session bus (`org.gjsify.Devtools`) — proving devtools' in-process GSK-renderer
-capture (`Gtk.WidgetPaintable` → `Gsk.Renderer.render_texture` → `Gdk.Texture` PNG)
-works on node-gi against a real toplevel:
+truthy). With it enabled, the LIVE window is drivable, inspectable and screenshottable
+over the session bus (`org.gjsify.Devtools`) — so the interactivity is provable
+without a human clicking. `Adw.ApplicationWindow` implements `Gio.ActionGroup`, and
+node-gi's `instanceof` now spans the whole GObject hierarchy, so devtools resolves the
+`win.*` action group off the active window:
 
 ```bash
 # 1. launch the Node build with devtools enabled (backgrounded)
 GJSIFY_DEVTOOLS=1 node dist/app.node.mjs &
 
-# 2. screenshot it over DBus (gdbus can't save the binary `ay`, so a GJS caller does)
+# 2. drive the window action + read the changed state over DBus
+gdbus call --session --dest eu.jumplink.NodeGiWindow \
+  --object-path /eu/jumplink/NodeGiWindow/devtools \
+  --method org.gjsify.Devtools.ActivateAction win increment null
+gdbus call --session --dest eu.jumplink.NodeGiWindow \
+  --object-path /eu/jumplink/NodeGiWindow/devtools \
+  --method org.gjsify.Devtools.GetProperty "" title      # → "node-gi — 1 clicks"
+
+# 3. screenshot it (gdbus can't save the binary `ay`, so a GJS caller does)
 gjs -m tools/shoot.js eu.jumplink.NodeGiWindow dist/window.png
 ```
 
@@ -48,12 +65,16 @@ The same window can be driven from an MCP client via `gjsify debug`.
 
 ## What it proves
 
+- `@gjsify/node-gi` dispatches the GTK signal/action/event chain into JS: a
+  `Gtk.Button::clicked` signal, a `Gio.SimpleAction::activate` on the window, and
+  `win.activate_action()` all run their JS handlers and update Adwaita widgets.
 - `@gjsify/node-gi` marshals the full GTK4/Adwaita windowing + GSK render path
   (window realize/present, `Gtk.Snapshot.to_node()` → `Gsk.RenderNode` fundamental,
   `Gsk.Renderer.render_texture`, `Gdk.Texture.save_to_png_bytes`).
-- `@gjsify/devtools`' live DBus `Screenshot`/`DumpTree` run under node-gi, not just
-  on GJS.
+- `@gjsify/devtools`' live DBus `ActivateAction` / `GetProperty` / `DumpTree` /
+  `Screenshot` run under node-gi, not just on GJS.
 
-The self-contained, workspace-free windowing smoke (no bundler, no `@gjsify/devtools`)
-lives as `packages/node-gi/node-gi/test/windowing.test.mjs` and is what the Linux
-`gtk-smoke` + Windows batteries-included CI jobs run.
+The self-contained, workspace-free proofs (no bundler, no `@gjsify/devtools`) live as
+`packages/node-gi/node-gi/test/windowing.test.mjs` (static render) and
+`packages/node-gi/node-gi/test/windowing-interactive.test.mjs` (the interactivity
+chain + render) — what the Linux `gtk-smoke` + Windows windowing CI jobs run.

--- a/showcases/gtk/node-gi-window/src/app.ts
+++ b/showcases/gtk/node-gi-window/src/app.ts
@@ -1,37 +1,42 @@
 // SPDX-License-Identifier: MIT
 //
-// GTK-GUI-on-node-gi proof — a MINIMAL Libadwaita application whose SINGLE source
-// builds AND runs on both GJS and Node.js, rendering a REAL top-level window:
+// GTK-GUI-on-node-gi proof — increment 2: an INTERACTIVE Libadwaita application
+// whose SINGLE source builds AND runs on both GJS and Node.js, and RESPONDS TO INPUT
+// through the full GTK signal/action/event chain via node-gi:
 //
 //   gjsify build src/app.ts --app gjs   → gjs  -m dist/app.gjs.mjs   (native gi://)
 //   gjsify build src/app.ts --app node  → node    dist/app.node.mjs  (@gjsify/node-gi)
 //
-// It is the GUI capstone of the node-gi reverse bridge: an UNCHANGED
-// `Adw.Application` + `Adw.ApplicationWindow` (HeaderBar / WindowTitle / StatusPage)
-// realizes + renders through the GdkWayland/GdkX11 (or GdkWin32) backend under
-// Node.js exactly as under GJS — beyond the display-free conformance.
+// Beyond the static-render capstone (increment 1), this proves the reverse bridge
+// dispatches a REAL event chain: a `Gtk.Button::clicked` signal AND a
+// `Gio.SimpleAction` (added to the WINDOW, `<primary>plus` / `<primary>r`
+// accelerators) both route into JS, mutate a counter, and the visible state changes —
+// the window title, the `Adw.WindowTitle` subtitle and an `Adw.ActionRow` subtitle all
+// update. The button and every accelerator funnel through the SAME action so there is
+// ONE state-mutation path (GTK signal → node-gi dispatch → JS handler → widget set).
 //
 // SELF-VERIFYING over DBus. `installDevtools(app)` embeds the `@gjsify/devtools`
 // control plane (`org.gjsify.Devtools`): launch with `GJSIFY_DEVTOOLS=1` and a tool
-// (e.g. `tools/shoot.js`, `gjsify debug`) can `Screenshot`/`DumpTree` the LIVE
-// window over the session bus — proving @gjsify/devtools' in-process GSK-renderer
-// capture (Gtk.WidgetPaintable → Gsk.Renderer.render_texture → Gdk.Texture PNG)
-// works on node-gi against a real toplevel. `installDevtools` is a no-op unless
-// `GJSIFY_DEVTOOLS` is truthy, so it is safe to leave wired in.
+// can `ActivateAction("win", "increment", "null")` to drive the SAME chain over the
+// session bus, then `DumpTree`/`GetProperty`/`Screenshot` the LIVE window to assert
+// the counter changed — the interactivity proof on node-gi. `Adw.ApplicationWindow`
+// implements `Gio.ActionGroup`, so devtools resolves the `win.*` group off the active
+// window (node-gi's `instanceof` now spans the whole GObject hierarchy, matching GJS).
+// `installDevtools` is a no-op unless `GJSIFY_DEVTOOLS` is truthy — prod-safe.
 //
 // runAsync — NOT sync run(). A gjsify GTK/Adwaita app MUST run via
-// `Adw.Application.runAsync()`: sync `run()` hangs synchronous view loads on their
-// spinner under node-gi/gjsify (the promise-job-queue class). node-gi provides the
-// GJS-shaped `runAsync` override (defers the blocking run() to a macrotask). The
-// `print` global (ambient under GJS, injected by `--globals auto` via the
-// `@gjsify/node-gi/globals` shim for the node build) triggers the reverse bridge's
-// `@girs/*`-body resolution so `@gjsify/devtools` keeps its real code under
-// `--app node`.
+// `Adw.Application.runAsync()`. The `print` global (ambient under GJS, injected by
+// `--globals auto` via the `@gjsify/node-gi/globals` shim for the node build) also
+// triggers the reverse bridge's `@girs/*`-body resolution so `@gjsify/devtools` keeps
+// its real code under `--app node`.
 //
-// Reference: refs/gjs (g_application_run / adw_init), refs/libadwaita
-// (ToolbarView / HeaderBar / StatusPage). Copyright (c) GNOME contributors, MIT/LGPL.
+// Reference: refs/gjs (g_application_run / adw_init), refs/libadwaita (ToolbarView /
+// HeaderBar / WindowTitle / Clamp / PreferencesGroup / ActionRow), refs/gjs
+// (Gio.SimpleAction / GActionMap accelerators). Copyright (c) GNOME contributors, MIT/LGPL.
 
 import Adw from 'gi://Adw?version=1';
+import Gio from 'gi://Gio?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
 import { installDevtools } from '@gjsify/devtools';
 
 const app = new Adw.Application({ application_id: 'eu.jumplink.NodeGiWindow' });
@@ -44,23 +49,78 @@ app.connect('startup', () => {
 });
 
 app.connect('activate', () => {
+    let count = 0;
+
     const win = new Adw.ApplicationWindow({ application: app });
-    win.set_default_size(480, 320);
+    win.set_default_size(480, 360);
 
+    const windowTitle = new Adw.WindowTitle({ title: 'node-gi', subtitle: '0 clicks' });
     const header = new Adw.HeaderBar();
-    header.set_title_widget(new Adw.WindowTitle({ title: 'node-gi', subtitle: 'Adwaita on Node.js' }));
+    header.set_title_widget(windowTitle);
 
-    const status = new Adw.StatusPage({
-        icon_name: 'application-x-executable-symbolic',
-        title: 'Hello from node-gi',
-        description: 'A real Adw.ApplicationWindow rendered by @gjsify/node-gi',
+    // The single visible counter row (its subtitle is the live state).
+    const countRow = new Adw.ActionRow({ title: 'Clicks', subtitle: '0' });
+    const group = new Adw.PreferencesGroup();
+    group.add(countRow);
+
+    const incrementButton = new Gtk.Button({ label: 'Increment', halign: Gtk.Align.CENTER });
+    incrementButton.add_css_class('suggested-action');
+    incrementButton.add_css_class('pill');
+
+    const resetButton = new Gtk.Button({ label: 'Reset', halign: Gtk.Align.CENTER });
+
+    const box = new Gtk.Box({
+        orientation: Gtk.Orientation.VERTICAL,
+        spacing: 18,
+        margin_top: 24,
+        margin_bottom: 24,
+        margin_start: 24,
+        margin_end: 24,
     });
+    box.append(group);
+    box.append(incrementButton);
+    box.append(resetButton);
 
+    const clamp = new Adw.Clamp({ maximum_size: 360, child: box });
     const toolbar = new Adw.ToolbarView();
     toolbar.add_top_bar(header);
-    toolbar.set_content(status);
+    toolbar.set_content(clamp);
     win.set_content(toolbar);
 
+    // The ONE state-mutation path: every trigger (button, accelerator, devtools
+    // ActivateAction) funnels through these actions' `activate` handlers.
+    const render = () => {
+        const label = count === 1 ? '1 click' : `${count} clicks`;
+        windowTitle.set_subtitle(label);
+        countRow.set_subtitle(String(count));
+        win.set_title(`node-gi — ${label}`);
+    };
+
+    const increment = new Gio.SimpleAction({ name: 'increment' });
+    increment.connect('activate', () => {
+        count += 1;
+        render();
+        print(`node-gi-window: increment → ${count}`);
+    });
+    win.add_action(increment);
+
+    const reset = new Gio.SimpleAction({ name: 'reset' });
+    reset.connect('activate', () => {
+        count = 0;
+        render();
+        print('node-gi-window: reset → 0');
+    });
+    win.add_action(reset);
+
+    // Keyboard accelerators bound to the WINDOW-scoped actions.
+    app.set_accels_for_action('win.increment', ['<primary>plus', '<primary>equal', 'plus']);
+    app.set_accels_for_action('win.reset', ['<primary>r']);
+
+    // GTK button `clicked` → drive the SAME window action (one state path).
+    incrementButton.connect('clicked', () => win.activate_action('increment', null));
+    resetButton.connect('clicked', () => win.activate_action('reset', null));
+
+    render();
     win.present();
     print('node-gi-window: presented');
 });


### PR DESCRIPTION
Increment 2 of the GTK-GUI-on-node-gi track (#774 was the static-render increment 1): prove a real Adwaita window **responds to input** via node-gi — the GTK signal/action/event chain, not just a static render.

## What's new

**Interactive showcase** (`showcases/gtk/node-gi-window`). The window keeps a click counter. A `Gtk.Button::clicked` signal AND a `Gio.SimpleAction` added to the window (`win.add_action`, `<primary>plus` / `<primary>r` accelerators) both dispatch into JS, mutate the counter, and the visible state changes — window title, `Adw.WindowTitle` subtitle and an `Adw.ActionRow` subtitle. Button + accelerators funnel through the SAME action → one state path: GTK signal/action → node-gi dispatch → JS handler → widget setter. Single `gi://` source, builds `--app gjs` AND `--app node`, `runAsync`, `@gjsify/devtools` embedded.

**Core fix — `instanceof` across the GObject hierarchy.** Surfaced while wiring devtools: an introspected instance is a Proxy over a bare handle with no live JS prototype chain, so `adwWindow instanceof Gtk.ApplicationWindow` was `false` on node-gi but `true` on GJS — which broke `@gjsify/devtools` resolving the `win.*` action group off an `Adw.ApplicationWindow`. `makeClass` now installs a `Symbol.hasInstance` that resolves via `g_type_is_a` (native `isInstanceOf`), recognising base classes AND implemented interfaces, with correct handling of registerClass subclasses (match own `$gtype`, not the shared base) and non-GObject values (`false`). Pure-JS, no addon rebuild.

## Event-chain proof (node-gi)

Drove `org.gjsify.Devtools.ActivateAction("win","increment")` over DBus and read the changed title via `GetProperty`: `node-gi — 0 clicks` → `node-gi — 3 clicks` → (reset) `node-gi — 0 clicks`, plus a GSK-rendered screenshot. `--app gjs` behaves identically.

## Tests + CI

- `test/windowing-interactive.test.mjs` — two tiers mirroring `windowing.test.mjs`: drives the Gio action + `emit('clicked')` and asserts the observable widget state changed (DumpTree/GetProperty tier, always: `0→2→3→0`); asserts a non-empty GSK PNG when the surface realizes. Wired into the Linux `gtk-smoke` job AND the Windows `windows-gtk-windowing` job (headless-capable — no visible desktop needed).
- `test/instanceof.test.mjs` (fast headless leg) + `conformance/programs/instanceof-hierarchy.conf.mjs` (gjs/node/bun/deno byte-identical golden) cover exact class / base / interface / negatives / registerClass leaf-base-interface-sibling.

Local verification: full conformance 21/21 green (gjs+node); display GTK set (windowing + windowing-interactive + adw-smoke) 3/3 with strong render tiers; headless suite regression-free (the 2 pre-existing `pump.test.mjs` ANSI-color flakes are sandbox artifacts, identical on `main`). macOS untouched; display-free + static-window paths unchanged.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq