### PR TITLE
feat(node-gi): prove Adwaita widget breadth on node-gi

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -275,7 +275,10 @@ jobs:
       # that a software-only Xvfb cannot provide; GTK_A11Y=none avoids the a11y bus.
       # Runs ALL the GTK smoke tests (Gtk.Application PR1 + Adw.Application PR2 +
       # Gtk.Template PR4 + Template signal callbacks & menu breadth + the GStrv
-      # construct-property cases + the GListModel interface-typed property cases,
+      # construct-property cases + the GListModel interface-typed property cases +
+      # the Adwaita widget-breadth proof (widgets.test.mjs: PreferencesPage/Group +
+      # SwitchRow/EntryRow/ComboRow/SpinRow/ExpanderRow + a Gtk.ListBox + a toast,
+      # DumpTree-typed and driven through the node-gi notify:: signal chain),
       # which need the Gtk-4.0 typelib the fast headless leg lacks) in one
       # node --test invocation so each reports even if one fails.
       - name: GTK/Adw smoke test (xvfb + dbus)
@@ -285,6 +288,7 @@ jobs:
             env GSK_RENDERER=cairo GDK_BACKEND=x11 LIBGL_ALWAYS_SOFTWARE=1 GTK_A11Y=none \
             node --test test/gtk-smoke.test.mjs test/adw-smoke.test.mjs \
               test/windowing.test.mjs test/windowing-interactive.test.mjs \
+              test/widgets.test.mjs \
               test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs \
               test/gtk-template-signals.test.mjs \
               test/strv-construct.test.mjs test/interface-props.test.mjs
@@ -1358,15 +1362,19 @@ jobs:
       # The windowing proof: a real Adw.ApplicationWindow realizes + renders a surface
       # via the GSK renderer, AND responds to input (a Gio action + a Gtk.Button::clicked
       # drive the counter — the interactive proof runs headless, no visible desktop
-      # needed, same as the render-to-texture screenshot), with the bundle as the ONLY
+      # needed, same as the render-to-texture screenshot); widgets.test.mjs adds the
+      # Adwaita widget-breadth proof on the SAME bundle (a PreferencesPage of
+      # SwitchRow/EntryRow/ComboRow/SpinRow/ExpanderRow rows + a Gtk.ListBox + a toast,
+      # constructed, DumpTree-typed, driven via notify:: and GSK-rendered), with the
+      # bundle as the ONLY
       # GTK. NODE_GI_NATIVE=prebuild loads the staged addon; the loader's PATH-prepend +
       # windowing-env wiring makes the DLLs + schemas/loaders/icons resolve from the
       # bundle. On win32 the test's display gate is IMPLICIT (no DISPLAY/WAYLAND_DISPLAY
       # needed — the GdkWin32 backend supplies it), so it runs here. GSK_RENDERER=cairo
       # forces software rendering (no GPU on the runner).
-      - name: Windowing proof — Adw window realizes, renders + reacts (no gvsbuild GTK)
+      - name: Windowing proof — Adw window realizes, renders, reacts + widget breadth (no gvsbuild GTK)
         working-directory: packages/node-gi/node-gi
         env:
           NODE_GI_NATIVE: prebuild
           GSK_RENDERER: cairo
-        run: node --test test/windowing.test.mjs test/windowing-interactive.test.mjs
+        run: node --test test/windowing.test.mjs test/windowing-interactive.test.mjs test/widgets.test.mjs

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -957,9 +957,12 @@ renderer on node-gi — the same in-process capture path `@gjsify/devtools`'
 `Gsk.Renderer.render_texture` → `Gdk.Texture.save_to_png_bytes`. A non-empty PNG
 is the unambiguous proof that a `GdkSurface` was allocated + a GSK render tree
 rasterised — not reachable by any headless program. Guarded by
-`test/windowing.test.mjs` (self-skips without a display on Linux; the win32/darwin
-GDK backend supplies its own display, so it runs there), wired into the Linux
-`gtk-smoke` + the Windows batteries-included windowing CI jobs. The
+`test/windowing.test.mjs` + `test/windowing-interactive.test.mjs` (an
+`Adw.ApplicationWindow` that RESPONDS to a `Gio.SimpleAction` + a
+`Gtk.Button::clicked` through the node-gi signal chain) + `test/widgets.test.mjs`
+(the Adwaita widget breadth below) — all self-skip without a display on Linux (the
+win32/darwin GDK backend supplies its own display, so they run there), wired into
+the Linux `gtk-smoke` + the Windows windowing CI jobs. The
 `showcases/gtk/node-gi-window` showcase runs the SAME single source on both GJS
 and Node and screenshots the live window over the `org.gjsify.Devtools` DBus
 surface.
@@ -991,6 +994,38 @@ Fontconfig config/cache. node-gi's loader (`gtk-runtime.js`
 marker and wires the env (`GSETTINGS_SCHEMA_DIR` / `GDK_PIXBUF_MODULE_FILE` /
 `XDG_DATA_DIRS` / `FONTCONFIG_*`); a display-free bundle carries no marker, so the
 wiring is a strict no-op and that load is byte-unchanged.
+
+### Adwaita widget breadth realizes + reacts + renders
+
+Beyond one window's chrome: a representative slice of the REAL Libadwaita widget
+set constructs, RENDERS and REACTS on node-gi. `test/widgets.test.mjs` builds an
+`Adw.PreferencesPage` / `Adw.PreferencesGroup` of `Adw.ActionRow`, `Adw.SwitchRow`,
+`Adw.EntryRow`, `Adw.ComboRow` (a `Gtk.StringList` model), `Adw.SpinRow` (a
+`Gtk.Adjustment`) and `Adw.ExpanderRow`, plus a `Gtk.ListBox` and a dismissible
+`Adw.Toast` via an `Adw.ToastOverlay`. Two tiers, robust on a runner whose surface
+may or may not realize:
+
+- **DumpTree** — the widget tree contains every expected type (`AdwSwitchRow`,
+  `AdwComboRow`, `AdwEntryRow`, `AdwSpinRow`, `AdwExpanderRow`, `AdwPreferencesPage`,
+  `GtkListBox`, …), read via the runtime GType (`$typeName`) the `@gjsify/devtools`
+  DumpTree uses — so each class constructs + parents correctly through node-gi.
+- **Interaction** — toggling the switch, changing the combo selection, moving the
+  spin value, expanding the expander and setting the entry text all drive
+  OBSERVABLE property changes AND fire their paired `notify::<prop>` handlers, and a
+  toast add → `dismiss()` fires `::dismissed`. This surfaces the `Gtk.StringList` /
+  `Gtk.Adjustment` model marshalling (GListModel + object construct props),
+  `notify::` property signals and the boxed-model paths — all display-independent, so
+  the interaction + DumpTree tier holds headless on Windows CI.
+- **Render** — when the surface realizes, the whole preferences surface rasterises
+  through the GSK renderer (a non-empty PNG), the strong proof the broad widget set
+  renders, not just constructs.
+
+The same widgets back the `showcases/gtk/node-gi-window` "Settings" view (an
+`Adw.ViewStack` page reachable from the bottom `Adw.ViewSwitcherBar`, beside the
+counter). No engine change and no windowing-bundle change were needed: the rows are
+core GTK4/Adwaita widgets backed by the already-bundled `gtk-4-*.dll` / `libadwaita-1`
+and the full Adwaita icon theme + compiled schemas the `--windowing` bundle already
+ships.
 
 Scoped out of the capstone fixture itself (deliberately): the Gst audio
 DECODE/playback path (`decodeAudioData`, `autoaudiosink`) — construction is

--- a/packages/node-gi/node-gi/test/widgets.test.mjs
+++ b/packages/node-gi/node-gi/test/widgets.test.mjs
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — Adwaita WIDGET-BREADTH proof (GTK-GUI-on-node-gi, increment 3).
+//
+// The step BEYOND the interactive-window proof (windowing-interactive.test.mjs): a
+// representative slice of the REAL Libadwaita widget set constructs, wires through
+// the engine and RESPONDS to interaction via node-gi — a preferences surface, a
+// GtkListBox and a dismissible toast. Two tiers, robust on a runner whose surface
+// may or may not realize:
+//
+//   MINIMUM (always asserted) — the widget tree + the interaction chain.
+//     (a) DumpTree: the tree contains every expected Adwaita type
+//         (AdwPreferencesPage / AdwPreferencesGroup / AdwActionRow / AdwSwitchRow /
+//         AdwEntryRow / AdwComboRow / AdwSpinRow / AdwExpanderRow) plus GtkListBox —
+//         proof each widget class constructs + parents correctly through node-gi.
+//     (b) STATE: interactions drive OBSERVABLE property changes through the node-gi
+//         signal chain, and the paired `notify::<prop>` handlers fire:
+//           · AdwSwitchRow.active     false -> true   (notify::active)
+//           · AdwComboRow.selected    0 -> 2          (notify::selected; the
+//                                     Gtk.StringList model reads back the string)
+//           · AdwSpinRow / Gtk.Adjustment.value  3 -> 7  (notify::value on the
+//                                     object-typed adjustment sub-model)
+//           · AdwExpanderRow.expanded false -> true   (notify::expanded)
+//           · AdwEntryRow text        '' -> 'node-gi' (Gtk.Editable set_text/get_text)
+//           · Adw.Toast add -> dismiss ('dismissed' signal via Adw.ToastOverlay)
+//         All of this is display-independent — GObject property sets + notify emit +
+//         a synchronous signal dispatch need no surface. It surfaces the
+//         Gtk.StringList / Gtk.Adjustment model marshalling (GListModel + object
+//         construct props), `notify::` property signals and the boxed-model paths.
+//
+//   STRONGER (asserted WHEN the surface realizes) — the window realizes + RENDERS
+//   the whole preferences surface through the GSK renderer (the same in-process
+//   capture @gjsify/devtools' Screenshot uses), so a non-empty PNG proves the broad
+//   widget set rasterised, not just constructed.
+//
+// PLATFORM-AWARE DISPLAY GATE (identical to windowing.test.mjs): win32/darwin have an
+// implicit display; Linux keys off DISPLAY/WAYLAND_DISPLAY (real session or Xvfb).
+// The interaction + DumpTree tier works headless on Windows CI (no visible desktop).
+//
+// run() is called at the TOP LEVEL of a synchronous test body so the node-gtk #442
+// nested-microtask-checkpoint caveat does not bite; the drive + capture + quit run
+// INSIDE the loop, from the activate handler / a GLib timeout.
+//
+// Reference: refs/gjs (g_application_run, GObject property notify), refs/libadwaita
+// (PreferencesPage / PreferencesGroup / ActionRow / SwitchRow / EntryRow / ComboRow /
+// SpinRow / ExpanderRow / ToastOverlay / Toast), @gjsify/devtools screenshot.ts.
+// Copyright (c) GNOME contributors, MIT/LGPL.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const displayless = process.platform === 'win32' || process.platform === 'darwin';
+const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let Adw;
+let Gtk;
+let Gio;
+let GLib;
+let Graphene;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    requireGi('Gdk', '4.0');
+    Gtk = requireGi('Gtk', '4.0');
+    Adw = requireGi('Adw', '1');
+    Graphene = requireGi('Graphene', '1.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 / Adw-1 / Graphene-1.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+// The @gjsify/devtools GSK capture path, inline (see windowing.test.mjs).
+function captureWidgetPng(widget) {
+  const native = widget.get_native();
+  const renderer = native ? native.get_renderer() : null;
+  if (!renderer) return null;
+  const width = widget.get_width();
+  const height = widget.get_height();
+  if (width <= 0 || height <= 0) return null;
+  const paintable = Gtk.WidgetPaintable.new(widget);
+  const snapshot = Gtk.Snapshot.new();
+  paintable.snapshot(snapshot, width, height);
+  const node = snapshot.to_node();
+  if (!node) return null;
+  const viewport = new Graphene.Rect();
+  viewport.init(0, 0, width, height);
+  const texture = renderer.render_texture(node, viewport);
+  const bytes = texture.save_to_png_bytes();
+  const data = bytes ? bytes.get_data() : null;
+  return data && data.length > 0 ? data : null;
+}
+
+// The concrete runtime GType name of a widget — the SAME seam @gjsify/devtools'
+// DumpTree uses (widget-tree.ts `widgetType`): node-gi exposes the true runtime
+// GType via `$typeName` (g_type_name(G_OBJECT_TYPE(obj))), which is authoritative
+// where `get_name()` is not — e.g. AdwPreferencesPage returns an EMPTY widget name
+// but `$typeName` is 'AdwPreferencesPage'. Falls back to the static class GType
+// name, then the widget name, so it also works on gjs.
+function widgetType(widget) {
+  if (typeof widget.$typeName === 'string' && widget.$typeName.length > 0) return widget.$typeName;
+  const ctor = widget.constructor;
+  if (ctor && ctor.$gtype && typeof ctor.$gtype.name === 'string') return ctor.$gtype.name;
+  return widget.get_name();
+}
+
+// DumpTree primitive: every widget TYPE in the tree (structural — no realized filter).
+function collectTypes(widget, out) {
+  out.push(widgetType(widget));
+  let child = widget.get_first_child();
+  while (child) {
+    collectTypes(child, out);
+    child = child.get_next_sibling();
+  }
+}
+
+test('Adwaita preferences widgets construct + react + render on node-gi', { skip }, () => {
+  const app = new Adw.Application({
+    application_id: 'eu.jumplink.NodeGiWidgets',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  let activated = false;
+  let activateError = null;
+  let pngLength = 0;
+  let allocatedWidth = 0;
+  let allocatedHeight = 0;
+
+  // OBSERVABLE state read off the WIDGETS after each interaction, plus a tally of
+  // the `notify::` property-signal firings (the signal-chain proof).
+  const state = {};
+  const notifies = { active: 0, selected: 0, value: 0, expanded: 0 };
+  const types = [];
+
+  app.connect('activate', () => {
+    try {
+      activated = true;
+
+      const win = new Adw.ApplicationWindow({ application: app });
+      win.set_default_size(480, 640);
+
+      const header = new Adw.HeaderBar();
+      header.set_title_widget(new Adw.WindowTitle({ title: 'node-gi', subtitle: 'widgets' }));
+
+      // --- The preferences surface -------------------------------------------
+      const page = new Adw.PreferencesPage();
+
+      const group = new Adw.PreferencesGroup({ title: 'Settings' });
+
+      const actionRow = new Adw.ActionRow({ title: 'Action', subtitle: 'a plain row' });
+
+      // SwitchRow — boolean `active`, notify::active.
+      const switchRow = new Adw.SwitchRow({ title: 'Enabled', active: false });
+      switchRow.connect('notify::active', () => {
+        notifies.active += 1;
+      });
+
+      // EntryRow — Gtk.Editable text.
+      const entryRow = new Adw.EntryRow({ title: 'Name' });
+
+      // ComboRow — a Gtk.StringList (GListModel) construct-typed model, notify::selected.
+      const stringList = new Gtk.StringList({ strings: ['Alpha', 'Beta', 'Gamma'] });
+      const comboRow = new Adw.ComboRow({ title: 'Choice', model: stringList });
+      comboRow.connect('notify::selected', () => {
+        notifies.selected += 1;
+      });
+
+      // SpinRow — a Gtk.Adjustment object sub-model, notify::value on the adjustment.
+      const adjustment = new Gtk.Adjustment({
+        lower: 0,
+        upper: 10,
+        step_increment: 1,
+        page_increment: 2,
+        value: 3,
+      });
+      adjustment.connect('notify::value', () => {
+        notifies.value += 1;
+      });
+      const spinRow = new Adw.SpinRow({ title: 'Amount', adjustment });
+
+      // ExpanderRow — boolean `expanded`, notify::expanded, with a nested row.
+      const expanderRow = new Adw.ExpanderRow({ title: 'More', subtitle: 'expandable' });
+      expanderRow.add_row(new Adw.ActionRow({ title: 'Nested', subtitle: 'inside the expander' }));
+      expanderRow.connect('notify::expanded', () => {
+        notifies.expanded += 1;
+      });
+
+      group.add(actionRow);
+      group.add(switchRow);
+      group.add(entryRow);
+      group.add(comboRow);
+      group.add(spinRow);
+      group.add(expanderRow);
+      page.add(group);
+
+      // --- A Gtk.ListBox with a couple of rows (boxed-list Adwaita idiom) ------
+      const listGroup = new Adw.PreferencesGroup({ title: 'List' });
+      const listBox = new Gtk.ListBox({ selection_mode: Gtk.SelectionMode.NONE });
+      listBox.add_css_class('boxed-list');
+      for (const label of ['One', 'Two']) {
+        const row = new Gtk.ListBoxRow();
+        row.set_child(new Gtk.Label({ label, halign: Gtk.Align.START, margin_top: 8, margin_bottom: 8, margin_start: 12, margin_end: 12 }));
+        listBox.append(row);
+      }
+      listGroup.add(listBox);
+      page.add(listGroup);
+
+      // --- ToastOverlay wrapping the whole content ----------------------------
+      const toolbar = new Adw.ToolbarView();
+      toolbar.add_top_bar(header);
+      toolbar.set_content(page);
+      const toastOverlay = new Adw.ToastOverlay();
+      toastOverlay.set_child(toolbar);
+      win.set_content(toastOverlay);
+
+      win.present();
+
+      // --- Drive the interactions SYNCHRONOUSLY (display-independent) ----------
+      state.initial = {
+        active: switchRow.get_active(),
+        selected: comboRow.get_selected(),
+        value: spinRow.get_value(),
+        expanded: expanderRow.get_expanded(),
+        text: entryRow.get_text(),
+      };
+
+      // (a) SwitchRow toggle -> active + notify::active.
+      switchRow.set_active(true);
+      state.switchActive = switchRow.get_active();
+
+      // (b) ComboRow selection change -> selected + the model string.
+      comboRow.set_selected(2);
+      state.comboSelected = comboRow.get_selected();
+      state.comboString = stringList.get_string(comboRow.get_selected());
+
+      // (c) SpinRow / Adjustment value change -> value + notify::value.
+      spinRow.set_value(7);
+      state.spinValue = spinRow.get_value();
+      state.adjustmentValue = adjustment.get_value();
+
+      // (d) ExpanderRow expand -> expanded + notify::expanded.
+      expanderRow.set_expanded(true);
+      state.expanderExpanded = expanderRow.get_expanded();
+
+      // (e) EntryRow text -> Gtk.Editable set/get.
+      entryRow.set_text('node-gi');
+      state.entryText = entryRow.get_text();
+
+      // (f) A dismissible Toast through the ToastOverlay + its 'dismissed' signal.
+      let toastDismissed = 0;
+      const toast = new Adw.Toast({ title: 'Saved' });
+      toast.connect('dismissed', () => {
+        toastDismissed += 1;
+      });
+      toastOverlay.add_toast(toast);
+      toast.dismiss();
+      state.toastDismissed = toastDismissed;
+
+      // DumpTree snapshot (structural — valid even if the surface never realizes).
+      collectTypes(win, types);
+
+      // Strong tier: retry the GSK capture across frames, then quit.
+      let waitedMs = 0;
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        waitedMs += 50;
+        const png = captureWidgetPng(win);
+        if (png) {
+          pngLength = png.length;
+          allocatedWidth = win.get_width();
+          allocatedHeight = win.get_height();
+          app.quit();
+          return GLib.SOURCE_REMOVE;
+        }
+        if (waitedMs >= 5000) {
+          allocatedWidth = win.get_width();
+          allocatedHeight = win.get_height();
+          app.quit();
+          return GLib.SOURCE_REMOVE;
+        }
+        return GLib.SOURCE_CONTINUE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]);
+
+  assert.equal(activateError, null, `activate threw: ${activateError && activateError.stack}`);
+  assert.ok(activated, 'the app never activated');
+  assert.equal(status, 0, `app.run() exit status was ${status}, expected 0`);
+
+  // MINIMUM 1 — DumpTree: every expected widget type constructed + parented.
+  const expectedTypes = [
+    'AdwPreferencesPage',
+    'AdwPreferencesGroup',
+    'AdwActionRow',
+    'AdwSwitchRow',
+    'AdwEntryRow',
+    'AdwComboRow',
+    'AdwSpinRow',
+    'AdwExpanderRow',
+    'AdwToastOverlay',
+    'GtkListBox',
+  ];
+  for (const type of expectedTypes) {
+    assert.ok(types.includes(type), `${type} missing from the widget tree (DumpTree: ${[...new Set(types)].join(', ')})`);
+  }
+
+  // MINIMUM 2 — the interaction chain drove OBSERVABLE state through node-gi.
+  assert.deepEqual(
+    state.initial,
+    { active: false, selected: 0, value: 3, expanded: false, text: '' },
+    'initial widget state',
+  );
+  assert.equal(state.switchActive, true, 'AdwSwitchRow.set_active(true) -> active');
+  assert.equal(state.comboSelected, 2, 'AdwComboRow.set_selected(2) -> selected');
+  assert.equal(state.comboString, 'Gamma', 'Gtk.StringList model read back the selected string');
+  assert.equal(state.spinValue, 7, 'AdwSpinRow.set_value(7) -> value');
+  assert.equal(state.adjustmentValue, 7, 'the Gtk.Adjustment sub-model tracked the value');
+  assert.equal(state.expanderExpanded, true, 'AdwExpanderRow.set_expanded(true) -> expanded');
+  assert.equal(state.entryText, 'node-gi', 'AdwEntryRow set_text/get_text (Gtk.Editable)');
+  assert.equal(state.toastDismissed, 1, 'Adw.Toast dismiss() fired the ::dismissed signal');
+
+  // MINIMUM 3 — the paired notify:: property signals fired through node-gi.
+  assert.ok(notifies.active >= 1, 'notify::active never fired on the SwitchRow');
+  assert.ok(notifies.selected >= 1, 'notify::selected never fired on the ComboRow');
+  assert.ok(notifies.value >= 1, 'notify::value never fired on the Adjustment');
+  assert.ok(notifies.expanded >= 1, 'notify::expanded never fired on the ExpanderRow');
+
+  // STRONGER (when the surface realizes): a non-empty GSK-rendered PNG.
+  if (allocatedWidth > 0 && allocatedHeight > 0) {
+    assert.ok(
+      pngLength > 0,
+      `window realized (${allocatedWidth}x${allocatedHeight}) but the GSK capture was empty`,
+    );
+    console.log(`widgets: rendered ${allocatedWidth}x${allocatedHeight} -> ${pngLength}-byte PNG (strong proof)`);
+  } else {
+    console.log('widgets: surface did not realize — interaction + DumpTree proof only');
+  }
+});

--- a/showcases/gtk/node-gi-window/README.md
+++ b/showcases/gtk/node-gi-window/README.md
@@ -1,19 +1,28 @@
 # @gjsify/example-gtk-node-gi-window
 
-An **interactive Libadwaita window** whose single `gi://` source builds and runs on
-**both GJS and Node.js** — a GTK-GUI capstone of the [`@gjsify/node-gi`](../../../packages/node-gi/node-gi)
-reverse bridge. One unchanged `Adw.Application` + `Adw.ApplicationWindow`
-(HeaderBar / WindowTitle / Clamp / PreferencesGroup / ActionRow + `Gtk.Button`s)
-realizes, renders **and responds to input** through the platform GDK backend
-(GdkWayland/GdkX11 on Linux, GdkWin32 on Windows) under Node.js exactly as under GJS.
+An **interactive Libadwaita application** whose single `gi://` source builds and runs
+on **both GJS and Node.js** — a GTK-GUI capstone of the [`@gjsify/node-gi`](../../../packages/node-gi/node-gi)
+reverse bridge. One unchanged `Adw.Application` + `Adw.ApplicationWindow` realizes,
+renders **and responds to input** through the platform GDK backend (GdkWayland/GdkX11
+on Linux, GdkWin32 on Windows) under Node.js exactly as under GJS.
 
-The window keeps a click counter. A `Gtk.Button::clicked` signal AND a
-`Gio.SimpleAction` added to the window (`win.add_action`, with `<primary>plus` /
-`<primary>r` keyboard accelerators) both dispatch into JS, mutate the counter, and
-the visible state changes — the window title, the `Adw.WindowTitle` subtitle and the
-`Adw.ActionRow` subtitle. The button and every accelerator funnel through the SAME
-action, so there is **one** state-mutation path: GTK signal/action → node-gi signal
-dispatch → JS handler → widget setter.
+Two views live in an `Adw.ViewStack`, switched by a bottom `Adw.ViewSwitcherBar`, with
+the whole content under an `Adw.ToastOverlay`:
+
+- **Counter** — a click counter. A `Gtk.Button::clicked` signal AND `Gio.SimpleAction`s
+  added to the window (`win.add_action`, with `<primary>plus` / `<primary>r` keyboard
+  accelerators) both dispatch into JS, mutate the counter, and the visible state
+  changes: the window title, the `Adw.WindowTitle` subtitle and an `Adw.ActionRow`
+  subtitle. The button and every accelerator funnel through the SAME action, so there
+  is **one** state-mutation path: GTK signal/action → node-gi signal dispatch → JS
+  handler → widget setter.
+- **Settings** — a representative slice of the REAL Libadwaita widget set proving broad
+  breadth constructs, renders and reacts via node-gi: an `Adw.PreferencesPage` /
+  `Adw.PreferencesGroup` with `Adw.ActionRow`, `Adw.SwitchRow`, `Adw.EntryRow`,
+  `Adw.ComboRow` (a `Gtk.StringList` model), `Adw.SpinRow` (a `Gtk.Adjustment`) and
+  `Adw.ExpanderRow`, plus a `Gtk.ListBox` in the boxed-list idiom. Toggling the switch
+  and a `win.toast` action both raise a dismissible `Adw.Toast` through the overlay —
+  interactions dispatched through the node-gi `notify::` signal chain.
 
 It is `private` + versioned (a dev-tooling showcase, like `adwaita-storybook`): it
 depends on `@gjsify/node-gi` via a `file:` link, so it is not published to npm.
@@ -48,13 +57,14 @@ node-gi's `instanceof` now spans the whole GObject hierarchy, so devtools resolv
 # 1. launch the Node build with devtools enabled (backgrounded)
 GJSIFY_DEVTOOLS=1 node dist/app.node.mjs &
 
-# 2. drive the window action + read the changed state over DBus
+# 2. drive a window action + read the changed state over DBus
 gdbus call --session --dest eu.jumplink.NodeGiWindow \
   --object-path /eu/jumplink/NodeGiWindow/devtools \
   --method org.gjsify.Devtools.ActivateAction win increment null
 gdbus call --session --dest eu.jumplink.NodeGiWindow \
   --object-path /eu/jumplink/NodeGiWindow/devtools \
   --method org.gjsify.Devtools.GetProperty "" title      # → "node-gi — 1 clicks"
+# (the `toast` action raises a toast the same way)
 
 # 3. screenshot it (gdbus can't save the binary `ay`, so a GJS caller does)
 gjs -m tools/shoot.js eu.jumplink.NodeGiWindow dist/window.png
@@ -66,8 +76,13 @@ The same window can be driven from an MCP client via `gjsify debug`.
 ## What it proves
 
 - `@gjsify/node-gi` dispatches the GTK signal/action/event chain into JS: a
-  `Gtk.Button::clicked` signal, a `Gio.SimpleAction::activate` on the window, and
-  `win.activate_action()` all run their JS handlers and update Adwaita widgets.
+  `Gtk.Button::clicked` signal, a `Gio.SimpleAction::activate` on the window,
+  `win.activate_action()` and `notify::<prop>` on the preferences widgets all run
+  their JS handlers and update Adwaita widgets.
+- A BROAD slice of Libadwaita constructs + renders through node-gi:
+  `Adw.PreferencesPage`/`Group`, `Adw.SwitchRow`/`EntryRow`/`ComboRow`/`SpinRow`/
+  `ExpanderRow`, `Gtk.StringList` + `Gtk.Adjustment` models, `Gtk.ListBox`,
+  `Adw.ViewStack`/`ViewSwitcherBar` and `Adw.ToastOverlay`/`Toast`.
 - `@gjsify/node-gi` marshals the full GTK4/Adwaita windowing + GSK render path
   (window realize/present, `Gtk.Snapshot.to_node()` → `Gsk.RenderNode` fundamental,
   `Gsk.Renderer.render_texture`, `Gdk.Texture.save_to_png_bytes`).
@@ -75,6 +90,7 @@ The same window can be driven from an MCP client via `gjsify debug`.
   `Screenshot` run under node-gi, not just on GJS.
 
 The self-contained, workspace-free proofs (no bundler, no `@gjsify/devtools`) live as
-`packages/node-gi/node-gi/test/windowing.test.mjs` (static render) and
+`packages/node-gi/node-gi/test/windowing.test.mjs` (static render),
 `packages/node-gi/node-gi/test/windowing-interactive.test.mjs` (the interactivity
-chain + render) — what the Linux `gtk-smoke` + Windows windowing CI jobs run.
+chain + render) and `packages/node-gi/node-gi/test/widgets.test.mjs` (the Adwaita
+widget breadth) — what the Linux `gtk-smoke` + Windows windowing CI jobs run.

--- a/showcases/gtk/node-gi-window/src/app.ts
+++ b/showcases/gtk/node-gi-window/src/app.ts
@@ -1,27 +1,36 @@
 // SPDX-License-Identifier: MIT
 //
-// GTK-GUI-on-node-gi proof — increment 2: an INTERACTIVE Libadwaita application
-// whose SINGLE source builds AND runs on both GJS and Node.js, and RESPONDS TO INPUT
-// through the full GTK signal/action/event chain via node-gi:
+// GTK-GUI-on-node-gi proof — increment 3: BROAD Libadwaita widget breadth in an
+// INTERACTIVE application whose SINGLE source builds AND runs on both GJS and
+// Node.js through the reverse bridge:
 //
 //   gjsify build src/app.ts --app gjs   → gjs  -m dist/app.gjs.mjs   (native gi://)
 //   gjsify build src/app.ts --app node  → node    dist/app.node.mjs  (@gjsify/node-gi)
 //
-// Beyond the static-render capstone (increment 1), this proves the reverse bridge
-// dispatches a REAL event chain: a `Gtk.Button::clicked` signal AND a
-// `Gio.SimpleAction` (added to the WINDOW, `<primary>plus` / `<primary>r`
-// accelerators) both route into JS, mutate a counter, and the visible state changes —
-// the window title, the `Adw.WindowTitle` subtitle and an `Adw.ActionRow` subtitle all
-// update. The button and every accelerator funnel through the SAME action so there is
-// ONE state-mutation path (GTK signal → node-gi dispatch → JS handler → widget set).
+// Two views in an `Adw.ViewStack` (switched by a bottom `Adw.ViewSwitcherBar`),
+// the whole thing wrapped in an `Adw.ToastOverlay`:
+//
+//   • "Counter" (increment 1+2, unchanged) — a click counter driven through ONE
+//     state-mutation path: a `Gtk.Button::clicked` signal AND `Gio.SimpleAction`s
+//     added to the WINDOW (`<primary>plus` / `<primary>r` accelerators) all route
+//     into JS, mutate the counter, and the window title + `Adw.WindowTitle` subtitle
+//     + an `Adw.ActionRow` subtitle update.
+//   • "Settings" (increment 3) — a representative slice of the REAL Libadwaita
+//     widget set proves it constructs + renders + reacts via node-gi: an
+//     `Adw.PreferencesPage` / `Adw.PreferencesGroup` with `Adw.ActionRow`,
+//     `Adw.SwitchRow`, `Adw.EntryRow`, `Adw.ComboRow` (a `Gtk.StringList` model),
+//     `Adw.SpinRow` (a `Gtk.Adjustment`) and `Adw.ExpanderRow`, plus a `Gtk.ListBox`
+//     in the boxed-list idiom. Interactions dispatch through the node-gi signal
+//     chain — toggling the switch and a `win.toast` action both raise a dismissible
+//     `Adw.Toast` via the overlay.
 //
 // SELF-VERIFYING over DBus. `installDevtools(app)` embeds the `@gjsify/devtools`
 // control plane (`org.gjsify.Devtools`): launch with `GJSIFY_DEVTOOLS=1` and a tool
-// can `ActivateAction("win", "increment", "null")` to drive the SAME chain over the
-// session bus, then `DumpTree`/`GetProperty`/`Screenshot` the LIVE window to assert
-// the counter changed — the interactivity proof on node-gi. `Adw.ApplicationWindow`
-// implements `Gio.ActionGroup`, so devtools resolves the `win.*` group off the active
-// window (node-gi's `instanceof` now spans the whole GObject hierarchy, matching GJS).
+// can `ActivateAction("win", "increment", "null")` (or `"toast"`) to drive the SAME
+// chains over the session bus, then `DumpTree`/`GetProperty`/`Screenshot` the LIVE
+// window to assert the state changed. `Adw.ApplicationWindow` implements
+// `Gio.ActionGroup`, so devtools resolves the `win.*` group off the active window
+// (node-gi's `instanceof` spans the whole GObject hierarchy, matching GJS).
 // `installDevtools` is a no-op unless `GJSIFY_DEVTOOLS` is truthy — prod-safe.
 //
 // runAsync — NOT sync run(). A gjsify GTK/Adwaita app MUST run via
@@ -30,9 +39,11 @@
 // triggers the reverse bridge's `@girs/*`-body resolution so `@gjsify/devtools` keeps
 // its real code under `--app node`.
 //
-// Reference: refs/gjs (g_application_run / adw_init), refs/libadwaita (ToolbarView /
-// HeaderBar / WindowTitle / Clamp / PreferencesGroup / ActionRow), refs/gjs
-// (Gio.SimpleAction / GActionMap accelerators). Copyright (c) GNOME contributors, MIT/LGPL.
+// Reference: refs/gjs (g_application_run / adw_init, Gio.SimpleAction / GActionMap
+// accelerators, GObject property notify), refs/libadwaita (ToolbarView / HeaderBar /
+// WindowTitle / ViewStack / ViewSwitcherBar / PreferencesPage / PreferencesGroup /
+// ActionRow / SwitchRow / EntryRow / ComboRow / SpinRow / ExpanderRow / ToastOverlay
+// / Toast). Copyright (c) GNOME contributors, MIT/LGPL.
 
 import Adw from 'gi://Adw?version=1';
 import Gio from 'gi://Gio?version=2.0';
@@ -52,24 +63,31 @@ app.connect('activate', () => {
     let count = 0;
 
     const win = new Adw.ApplicationWindow({ application: app });
-    win.set_default_size(480, 360);
+    win.set_default_size(480, 600);
 
     const windowTitle = new Adw.WindowTitle({ title: 'node-gi', subtitle: '0 clicks' });
     const header = new Adw.HeaderBar();
     header.set_title_widget(windowTitle);
 
-    // The single visible counter row (its subtitle is the live state).
+    // The whole content lives under a ToastOverlay so any view can raise a toast.
+    const toastOverlay = new Adw.ToastOverlay();
+
+    const showToast = (text: string) => {
+        toastOverlay.add_toast(new Adw.Toast({ title: text, timeout: 2 }));
+        print(`node-gi-window: toast → ${text}`);
+    };
+
+    // ---- View 1: the counter (increments 1+2, unchanged state path) -----------
     const countRow = new Adw.ActionRow({ title: 'Clicks', subtitle: '0' });
-    const group = new Adw.PreferencesGroup();
-    group.add(countRow);
+    const counterGroup = new Adw.PreferencesGroup();
+    counterGroup.add(countRow);
 
     const incrementButton = new Gtk.Button({ label: 'Increment', halign: Gtk.Align.CENTER });
     incrementButton.add_css_class('suggested-action');
     incrementButton.add_css_class('pill');
-
     const resetButton = new Gtk.Button({ label: 'Reset', halign: Gtk.Align.CENTER });
 
-    const box = new Gtk.Box({
+    const counterBox = new Gtk.Box({
         orientation: Gtk.Orientation.VERTICAL,
         spacing: 18,
         margin_top: 24,
@@ -77,18 +95,84 @@ app.connect('activate', () => {
         margin_start: 24,
         margin_end: 24,
     });
-    box.append(group);
-    box.append(incrementButton);
-    box.append(resetButton);
+    counterBox.append(counterGroup);
+    counterBox.append(incrementButton);
+    counterBox.append(resetButton);
+    const counterClamp = new Adw.Clamp({ maximum_size: 360, child: counterBox });
 
-    const clamp = new Adw.Clamp({ maximum_size: 360, child: box });
+    // ---- View 2: the Adwaita widget-breadth preferences surface ---------------
+    const prefsPage = new Adw.PreferencesPage();
+
+    const settingsGroup = new Adw.PreferencesGroup({ title: 'Settings' });
+    settingsGroup.add(new Adw.ActionRow({ title: 'Action', subtitle: 'a plain row' }));
+
+    const switchRow = new Adw.SwitchRow({ title: 'Enabled', active: false });
+    switchRow.connect('notify::active', () => {
+        showToast(switchRow.get_active() ? 'Enabled' : 'Disabled');
+    });
+    settingsGroup.add(switchRow);
+
+    settingsGroup.add(new Adw.EntryRow({ title: 'Name' }));
+
+    const stringList = new Gtk.StringList({ strings: ['Alpha', 'Beta', 'Gamma'] });
+    const comboRow = new Adw.ComboRow({ title: 'Choice', model: stringList });
+    settingsGroup.add(comboRow);
+
+    const adjustment = new Gtk.Adjustment({
+        lower: 0,
+        upper: 10,
+        step_increment: 1,
+        page_increment: 2,
+        value: 3,
+    });
+    settingsGroup.add(new Adw.SpinRow({ title: 'Amount', adjustment }));
+
+    const expanderRow = new Adw.ExpanderRow({ title: 'More', subtitle: 'expandable' });
+    expanderRow.add_row(new Adw.ActionRow({ title: 'Nested', subtitle: 'inside the expander' }));
+    settingsGroup.add(expanderRow);
+    prefsPage.add(settingsGroup);
+
+    const listGroup = new Adw.PreferencesGroup({ title: 'List' });
+    const listBox = new Gtk.ListBox({ selection_mode: Gtk.SelectionMode.NONE });
+    listBox.add_css_class('boxed-list');
+    for (const label of ['One', 'Two']) {
+        const row = new Gtk.ListBoxRow();
+        row.set_child(
+            new Gtk.Label({
+                label,
+                halign: Gtk.Align.START,
+                margin_top: 12,
+                margin_bottom: 12,
+                margin_start: 12,
+                margin_end: 12,
+            }),
+        );
+        listBox.append(row);
+    }
+    listGroup.add(listBox);
+
+    const toastButton = new Gtk.Button({ label: 'Show toast', halign: Gtk.Align.CENTER, margin_top: 6 });
+    toastButton.add_css_class('pill');
+    listGroup.add(toastButton);
+    prefsPage.add(listGroup);
+
+    // ---- The ViewStack + bottom switcher, under the ToastOverlay --------------
+    const viewStack = new Adw.ViewStack();
+    viewStack.add_titled_with_icon(counterClamp, 'counter', 'Counter', 'list-add-symbolic');
+    viewStack.add_titled_with_icon(prefsPage, 'settings', 'Settings', 'emblem-system-symbolic');
+
+    const switcherBar = new Adw.ViewSwitcherBar({ stack: viewStack, reveal: true });
+
     const toolbar = new Adw.ToolbarView();
     toolbar.add_top_bar(header);
-    toolbar.set_content(clamp);
-    win.set_content(toolbar);
+    toolbar.set_content(viewStack);
+    toolbar.add_bottom_bar(switcherBar);
 
-    // The ONE state-mutation path: every trigger (button, accelerator, devtools
-    // ActivateAction) funnels through these actions' `activate` handlers.
+    toastOverlay.set_child(toolbar);
+    win.set_content(toastOverlay);
+
+    // The ONE counter state-mutation path: every trigger (button, accelerator,
+    // devtools ActivateAction) funnels through these actions' `activate` handlers.
     const render = () => {
         const label = count === 1 ? '1 click' : `${count} clicks`;
         windowTitle.set_subtitle(label);
@@ -112,13 +196,19 @@ app.connect('activate', () => {
     });
     win.add_action(reset);
 
+    // A window action that raises a toast — drivable over DBus (ActivateAction) too.
+    const toastAction = new Gio.SimpleAction({ name: 'toast' });
+    toastAction.connect('activate', () => showToast('Saved'));
+    win.add_action(toastAction);
+
     // Keyboard accelerators bound to the WINDOW-scoped actions.
     app.set_accels_for_action('win.increment', ['<primary>plus', '<primary>equal', 'plus']);
     app.set_accels_for_action('win.reset', ['<primary>r']);
 
-    // GTK button `clicked` → drive the SAME window action (one state path).
+    // GTK button `clicked` → drive the SAME window actions (one state path).
     incrementButton.connect('clicked', () => win.activate_action('increment', null));
     resetButton.connect('clicked', () => win.activate_action('reset', null));
+    toastButton.connect('clicked', () => win.activate_action('toast', null));
 
     render();
     win.present();


### PR DESCRIPTION
## What

Increment 3 of the #57 GTK-GUI-on-node-gi track: prove a **BROAD slice of the real Libadwaita widget set** constructs, renders and reacts through the `@gjsify/node-gi` reverse bridge, cross-platform (Linux + Windows CI).

## Widgets exercised

A representative preferences-style surface (not a kitchen sink):
- `Adw.PreferencesPage` + `Adw.PreferencesGroup` with `Adw.ActionRow`, `Adw.SwitchRow`, `Adw.EntryRow`, `Adw.ComboRow` (a `Gtk.StringList` model), `Adw.SpinRow` (a `Gtk.Adjustment`), `Adw.ExpanderRow`
- a `Gtk.ListBox` (boxed-list idiom) with a couple of rows
- a dismissible `Adw.Toast` via an `Adw.ToastOverlay`

## Test — `test/widgets.test.mjs` (mirrors `windowing-interactive.test.mjs`, two tiers)

- **ALWAYS asserted (display-independent, holds headless):**
  - **DumpTree** — the widget tree contains every expected Adwaita type (`AdwSwitchRow`, `AdwComboRow`, `AdwEntryRow`, `AdwSpinRow`, `AdwExpanderRow`, `AdwPreferencesPage`, …) + `GtkListBox`. Read via the runtime GType (`$typeName`) the real `@gjsify/devtools` DumpTree uses — `get_name()` returns `""` for `AdwPreferencesPage`, so mirroring the authoritative `widgetType()` seam is required.
  - **Interaction** — toggling the switch, changing the combo selection, moving the spin value, expanding the expander and setting the entry text drive OBSERVABLE property changes AND fire their paired `notify::<prop>` handlers; a toast add → `dismiss()` fires `::dismissed`. Surfaces the `Gtk.StringList` / `Gtk.Adjustment` model marshalling (GListModel + object construct props), `notify::` property signals and the boxed-model paths.
- **WHEN the surface realizes:** the whole preferences surface rasterises through the GSK renderer (non-empty PNG).

**Verified locally on the Wayland display (node-gi, `--app node`):** all types present, all interactions + notify signals fired, strong tier rendered **480×640 → 26 KB PNG**.

## Showcase

`showcases/gtk/node-gi-window` gains a second **"Settings"** view — an `Adw.ViewStack` page reachable from a bottom `Adw.ViewSwitcherBar`, carrying the same widget set + a toast, with the whole content under an `Adw.ToastOverlay`. The counter view and its actions/accelerators/devtools paths are unchanged. Single `gi://` source, dual `--app gjs` / `--app node`, `runAsync`, devtools embedded. Type-checks, formats, lints, builds both targets, and runs + screenshots on node-gi over `org.gjsify.Devtools` (counter view screenshotted; symbolic switcher icons render).

## CI wiring

`test/widgets.test.mjs` added to:
- the Linux **`gtk-smoke`** job (Xvfb + dbus)
- the Windows **`windows-gtk-windowing`** job (batteries-included windowing bundle, render-to-texture, headless)

The fast headless `npm test` legs self-skip it (no `DISPLAY`), same as `windowing.test.mjs`.

## No core / bundle change needed

Audited: the rows are core GTK4/Adwaita widgets backed by the already-bundled `gtk-4-*.dll` / `libadwaita-1` and the full Adwaita icon theme + compiled schemas + pixbuf loaders the `--windowing` bundle already ships — the exact typelib+data set `windowing.test.mjs` already exercises on Windows CI. No engine gap surfaced.

macOS + display-free + prior showcase paths kept working.

https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq
