### PR TITLE
feat(node-gi): implement imports.package (app bootstrap)

### DIFF
--- a/packages/node-gi/node-gi/globals.js
+++ b/packages/node-gi/node-gi/globals.js
@@ -23,6 +23,7 @@ import cairo from './cairo.js';
 // GLib.MainLoop convenience layer) — the GJS script modules many older sources use.
 import * as signalsModule from './overrides/_signals.js';
 import { createMainloop } from './overrides/mainloop.js';
+import { createPackage } from './overrides/package.js';
 
 // GJS stringifies each argument with String() and joins with a space (no
 // util.inspect object formatting) — match that for fidelity.
@@ -109,6 +110,10 @@ function makeImports() {
     gettext,
     cairo,
     signals: { addSignalMethods, _connect, _connectAfter, _disconnect, _emit, _signalHandlerIsConnected, _disconnectAll },
+    // GJS's `imports.searchPath` — `imports.package.init` unshifts the app's
+    // moduledir onto it. Inert on node-gi (ESM + gi://), but present + safe so
+    // source that reads/mutates it doesn't throw.
+    searchPath: [],
     versions: Object.create(null),
   };
   let mainloop;
@@ -116,6 +121,17 @@ function makeImports() {
     get() {
       if (mainloop === undefined) mainloop = createMainloop(requireGi('GLib', '2.0'));
       return mainloop;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  // `imports.package` — the GJS application bootstrap (pkg.init/initGettext/
+  // initFormat). Lazy like `mainloop`: a bundle that never calls it pulls no GLib.
+  let pkg;
+  Object.defineProperty(imports, 'package', {
+    get() {
+      if (pkg === undefined) pkg = createPackage({ requireGi, gettext, imports });
+      return pkg;
     },
     enumerable: true,
     configurable: true,

--- a/packages/node-gi/node-gi/overrides/package.js
+++ b/packages/node-gi/node-gi/overrides/package.js
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+// SPDX-FileCopyrightText: 2013 Giovanni Campagna <scampa.giovanni@gmail.com>
+//
+// Adapted from GJS (refs/gjs/modules/script/package.js). Copyright (c) 2013
+// Giovanni Campagna. MIT OR LGPL-2.0-or-later.
+// Modifications: the legacy `imports.package` — the GJS application bootstrap
+// (`pkg.init` / `initGettext` / `initFormat`) — ported to @gjsify/node-gi. A GNOME
+// app's entry point does `imports.package.init({ name, version, prefix, libdir })`
+// then `pkg.initGettext()` / `pkg.initFormat()`. The GJS original's heavy
+// source-tree detection + GResource registration + module-search machinery is NOT
+// load-bearing for a node-gi consumer (the app carries its own dir constants and
+// registers its own resources — see easy6502 app-gnome resources.ts), so this is
+// the minimal, honest init: set `globalThis.pkg`, wire `_`/`C_`/`N_` and
+// `String.prototype.format`, and keep `imports.searchPath` / `GLib.set_prgname`
+// calls safe. Mirrors overrides/mainloop.js's `createX(deps)` shape.
+
+/**
+ * Build the `imports.package` object bound to the L1 backend.
+ * @param {{ requireGi: Function, gettext: any, imports: Record<string, any> }} deps
+ */
+export function createPackage({ requireGi, gettext, imports }) {
+  const pkg = {
+    // Public fields GJS source may read. Populated by init().
+    name: undefined,
+    version: undefined,
+    prefix: undefined,
+    libdir: undefined,
+    datadir: undefined,
+    pkgdatadir: undefined,
+    pkglibdir: undefined,
+    moduledir: undefined,
+    localedir: undefined,
+
+    /**
+     * @param {{ name?: string, version?: string, prefix?: string, libdir?: string, datadir?: string }} params
+     */
+    init(params = {}) {
+      // The accessor GJS apps use right after: `pkg.initGettext()`.
+      globalThis.pkg = pkg;
+
+      pkg.name = params.name;
+      pkg.version = params.version;
+      pkg.prefix = params.prefix;
+      pkg.libdir = params.libdir;
+      pkg.datadir = params.datadir ?? (params.prefix ? `${params.prefix}/share` : undefined);
+
+      // Installed-layout dirs — NOT load-bearing on node-gi (apps carry their own
+      // constants + register their own resources), computed for source-compat only.
+      if (pkg.name) {
+        if (pkg.datadir) {
+          pkg.pkgdatadir = `${pkg.datadir}/${pkg.name}`;
+          pkg.moduledir = pkg.pkgdatadir;
+          pkg.localedir = `${pkg.datadir}/locale`;
+        }
+        if (pkg.libdir) pkg.pkglibdir = `${pkg.libdir}/${pkg.name}`;
+      }
+
+      // Cheap + safe: keeps ARGV[0]/app-id semantics (window-manager grouping etc.).
+      try {
+        const GLib = requireGi('GLib', '2.0');
+        if (pkg.name && typeof GLib.set_prgname === 'function') GLib.set_prgname(pkg.name);
+      } catch {
+        /* GLib not loadable in this context — skip */
+      }
+
+      // GJS unshifts moduledir onto imports.searchPath (script-import machinery).
+      // node-gi apps use ESM + gi://, so the search path is inert here — but keep
+      // the array present + the unshift safe so source that reads it doesn't throw.
+      if (!Array.isArray(imports.searchPath)) imports.searchPath = [];
+      if (pkg.moduledir) imports.searchPath.unshift(pkg.moduledir);
+    },
+
+    initGettext() {
+      if (pkg.name) {
+        try {
+          gettext.bindtextdomain?.(pkg.name, pkg.localedir ?? null);
+          gettext.textdomain?.(pkg.name);
+        } catch {
+          /* passthrough gettext — no catalog, ignore */
+        }
+      }
+      // The globals GJS apps + compiled Blueprint use pervasively.
+      globalThis._ = (msgid) => gettext.gettext(msgid);
+      globalThis.C_ = (context, msgid) => gettext.pgettext(context, msgid);
+      globalThis.N_ = (msgid) => msgid;
+    },
+
+    initFormat() {
+      // GJS sets `String.prototype.format = imports.format.format` (backed by the
+      // native `_format` vprintf). node-gi has no `imports.format`, so supply an
+      // equivalent JS vprintf here (see makeVprintf).
+      const vprintf = makeVprintf();
+      Object.defineProperty(String.prototype, 'format', {
+        configurable: true,
+        writable: true,
+        enumerable: false,
+        value: function format(...args) {
+          return vprintf(this, args);
+        },
+      });
+    },
+
+    // Script-import machinery is not ported — node-gi apps use ESM + gi://. These
+    // keep the surface present for source that references them (Learn6502 does not).
+    require() {
+      /* no-op: apps import via ESM / gi:// on node-gi */
+    },
+    requireSymbol() {
+      return true;
+    },
+    checkSymbol() {
+      return true;
+    },
+    start(params = {}) {
+      pkg.init(params);
+      if (typeof params.main === 'function') params.main(globalThis.ARGV ? ['', ...globalThis.ARGV] : []);
+    },
+    run() {
+      /* the app drives its own main() on node-gi */
+    },
+    initSubmodule() {
+      /* n/a on node-gi */
+    },
+  };
+
+  return pkg;
+}
+
+// A small vprintf covering the GJS `String.prototype.format` spec
+// (refs/gjs/modules/script/format.js): `%s %d %x %f`, `%.Nf` precision, `%Ns`/`%Nd`
+// width, `0`-padding for numerics, and `%%` → literal `%`. Positional `%N$s` is
+// supported (GJS honours it). Learn6502 only uses `%s`; the rest is fidelity.
+function makeVprintf() {
+  return function vprintf(fmt, args) {
+    let auto = 0;
+    return String(fmt).replace(
+      /%(?:(\d+)\$)?(0)?(\d+)?(?:\.(\d+))?([%sdxf])/g,
+      (match, pos, zero, width, prec, spec) => {
+        if (spec === '%') return '%';
+        const arg = pos !== undefined ? args[Number(pos) - 1] : args[auto++];
+        let str;
+        switch (spec) {
+          case 's':
+            str = String(arg);
+            break;
+          case 'd':
+            str = String(Math.trunc(Number(arg)));
+            break;
+          case 'x':
+            str = Math.trunc(Number(arg)).toString(16);
+            break;
+          case 'f':
+            str = prec !== undefined ? Number(arg).toFixed(Number(prec)) : String(Number(arg));
+            break;
+          default:
+            return match;
+        }
+        if (width !== undefined) {
+          const w = Number(width);
+          const pad = zero && spec !== 's' ? '0' : ' ';
+          while (str.length < w) str = pad + str;
+        }
+        return str;
+      },
+    );
+  };
+}

--- a/packages/node-gi/node-gi/test/imports-package.test.mjs
+++ b/packages/node-gi/node-gi/test/imports-package.test.mjs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — imports.package (the GJS application bootstrap) on node-gi.
+//
+// A real GNOME app (easy6502 packages/app-gnome) boots via:
+//   imports.package.init({ name, version, prefix, libdir });
+//   pkg.initGettext();   // wires globalThis._ / C_ / N_
+//   pkg.initFormat();    // wires String.prototype.format
+// node-gi previously exposed `imports` but not `imports.package`, so the app
+// stopped at `imports.package.init` with "Cannot read properties of undefined".
+// This proves that boot surface runs on node-gi (overrides/package.js).
+//
+// Reference: refs/gjs modules/script/{package,format}.js.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import '../globals.js';
+
+test('imports.package.init sets globalThis.pkg + the dir fields + searchPath', () => {
+  const pkg = globalThis.imports.package;
+  assert.ok(pkg, 'imports.package exists');
+  pkg.init({ name: 'eu.jumplink.Test', version: '1.2.3', prefix: '/usr', libdir: '/usr/lib' });
+  assert.equal(globalThis.pkg, pkg, 'globalThis.pkg is set to the package module');
+  assert.equal(pkg.name, 'eu.jumplink.Test');
+  assert.equal(pkg.version, '1.2.3');
+  assert.equal(pkg.datadir, '/usr/share');
+  assert.equal(pkg.moduledir, '/usr/share/eu.jumplink.Test');
+  assert.equal(pkg.localedir, '/usr/share/locale');
+  assert.ok(Array.isArray(globalThis.imports.searchPath), 'imports.searchPath is an array');
+  assert.ok(globalThis.imports.searchPath.includes('/usr/share/eu.jumplink.Test'), 'moduledir unshifted onto searchPath');
+});
+
+test('pkg.initGettext wires the _ / C_ / N_ globals (passthrough, no catalog)', () => {
+  const pkg = globalThis.imports.package;
+  pkg.init({ name: 'eu.jumplink.Test' });
+  pkg.initGettext();
+  assert.equal(typeof globalThis._, 'function');
+  assert.equal(globalThis._('Hello'), 'Hello');
+  assert.equal(globalThis.C_('some-context', 'Message'), 'Message');
+  assert.equal(globalThis.N_('untranslated'), 'untranslated');
+});
+
+test('pkg.initFormat wires String.prototype.format (JS vprintf)', () => {
+  const pkg = globalThis.imports.package;
+  pkg.initFormat();
+  assert.equal('by %s'.format('Pascal'), 'by Pascal');
+  assert.equal('%d items'.format(3), '3 items');
+  assert.equal('addr %04x'.format(0x0600), 'addr 0600'); // 0-padded hex — the Learn6502 gutter shape
+  assert.equal('%.2f'.format(3.14159), '3.14');
+  assert.equal('%5s|'.format('ab'), '   ab|'); // width, space-pad (right-align)
+  assert.equal('100%% done'.format(), '100% done'); // %% -> literal %
+  assert.equal('%s + %s'.format('a', 'b'), 'a + b'); // sequential args
+});


### PR DESCRIPTION
## What

Implements `imports.package` — the GJS application bootstrap module — on `@gjsify/node-gi`, so a real GNOME app (easy6502 `app-gnome`, the **Learn6502** port) can boot on Node/Bun/Deno.

A GNOME app's entry point does:

```js
imports.package.init({ name, version, prefix, libdir });
pkg.initGettext();   // wires globalThis._ / C_ / N_
pkg.initFormat();    // wires String.prototype.format
```

node-gi exposed `imports` but **not** `imports.package`, so the app stopped at `imports.package.init` with `Cannot read properties of undefined (reading 'init')`.

## How

New `node-gi/overrides/package.js` (`createPackage`, mirroring `overrides/mainloop.js`'s `createX(deps)` shape), wired into `globals.js` as a lazy `imports.package` getter (like `imports.mainloop` — a bundle that never calls it pulls no GLib):

- **`init()`** — set `globalThis.pkg`, store `name`/`version`/`prefix`/`libdir` + the installed-layout dirs (`datadir`/`pkgdatadir`/`moduledir`/`localedir`), `GLib.set_prgname(name)` (guarded), and unshift `moduledir` onto `imports.searchPath` (kept present + safe; inert on node-gi's ESM + `gi://` model).
- **`initGettext()`** — `gettext.bind/textdomain` (passthrough) + wire `globalThis._` / `C_` / `N_` (used pervasively, incl. compiled Blueprint).
- **`initFormat()`** — `String.prototype.format` via a JS vprintf covering the GJS `format.js` spec (`%s %d %x %f`, `%.Nf`, width, `0`-pad, `%%`, positional `%N$`).

The GJS original's source-tree detection / GResource registration / module-search machinery is **not** load-bearing on node-gi (apps carry their own dir constants and register their own resources), so this is the minimal, honest bootstrap.

## Validated

`test/imports-package.test.mjs` — 3/3 pass (init sets `pkg`/dirs/`searchPath`; `initGettext` wires `_`/`C_`/`N_`; `initFormat` vprintf incl. the `%04x` gutter shape + width/precision/`%%`).

End-to-end: with this change the Learn6502 `app-gnome` boots **past** `imports.package.init` + `initGettext` + `initFormat`, through `initResources` + `Gio.Settings` + `Adw.Application` startup into `new MainWindow` (GtkBuilder composite template) — the bootstrap surface runs on node-gi.

Adapted from GJS `refs/gjs/modules/script/package.js`. MIT OR LGPL-2.0-or-later.

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq