### PR TITLE
feat(node-gi): boot composite-template GNOME apps (Learn6502)

### DIFF
--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -255,6 +255,31 @@ function resolveTemplateCallback(handle, handlerName) {
 }
 native.setTemplateCallbackResolver(resolveTemplateCallback);
 
+// Run a registered class's JS constructor for a GObject the ENGINE instantiated
+// from C — a GtkBuilder composite-template InternalChild is the common case. node-gi's
+// JS-`new` path runs the ctor via the makeClass super-substitution; a C-created
+// instance has no such driver, so NodeGiConstructor (the overridden `constructor`
+// vfunc) calls this with the instance's canonical handle + its GType name. We set
+// `adoptHandle` and Reflect.construct the class: its `super()` reaches the makeClass
+// base ctor, which adopts the handle (no second GObject) and returns the canonical
+// wrapper, so the ctor body runs against it (`this._x = …` become expandos on the
+// one wrapper GtkBuilder-fetched children later resolve to). GJS-faithful
+// (gjs_object_constructor's native-construction branch runs the JS constructor).
+function runCtorForCObject(handle, gtypeName) {
+  const cls = classesByGType.get(gtypeName);
+  if (cls === undefined) return; // not a node-gi-registered class (shouldn't happen)
+  const prev = adoptHandle;
+  adoptHandle = handle;
+  try {
+    // No props: GtkBuilder already applied the construct properties to the C object;
+    // the ctor's `params` arg is conventionally optional for a template child.
+    Reflect.construct(cls, []);
+  } finally {
+    adoptHandle = prev;
+  }
+}
+native.setConstructCallback(runCtorForCObject);
+
 // Wrap a non-GObject GObject-fundamental (e.g. a GskRenderNode from
 // Gtk.Snapshot.to_node, a GdkEvent) as an OPAQUE, round-trippable handle. The
 // native tagged External already carries the raw pointer (its Data) + drops the
@@ -835,6 +860,18 @@ function handlerIdsForFunc(handle, fn) {
 // routing keys on the leaf so construction is correct at any depth.
 const registeredClasses = new Map();
 
+// GTypeName → registered JS class, the reverse of registeredClasses. The engine's
+// NodeGiConstructor hands runCtorForCObject (below) the C-created instance's GType
+// NAME (g_type_name), which this resolves back to the class to Reflect.construct.
+const classesByGType = new Map();
+
+// When set (by runCtorForCObject), the makeClass base ctor ADOPTS this pre-existing
+// canonical handle instead of constructing a second GObject — so a C/GtkBuilder-
+// created instance's user ctor body runs on the wrapper the engine already built.
+// A module-scoped latch is safe: it is set immediately before a synchronous
+// Reflect.construct and consumed by the base ctor before any nested construction.
+let adoptHandle;
+
 // Surface a templated type's bound children on a freshly-constructed instance
 // (GJS convention: public `this.<name>`, internal `this._<name>`, '-' → '_'). The
 // engine already ran init_template during constructType, so getTemplateChild
@@ -1295,7 +1332,17 @@ function makeClass(namespace, typeName) {
     if (nt !== undefined && nt !== proxy) {
       const reg = registeredClasses.get(nt);
       if (reg !== undefined) {
-        const handle = native.constructType(reg.typeHandle, props ? unwrapProps(props) : {});
+        let handle;
+        if (adoptHandle !== undefined) {
+          // C-created adoption (runCtorForCObject): the engine already built the
+          // GObject; use its canonical handle instead of constructing another.
+          // Consume the latch atomically so a nested `new` in the ctor body takes
+          // the normal constructType path.
+          handle = adoptHandle;
+          adoptHandle = undefined;
+        } else {
+          handle = native.constructType(reg.typeHandle, props ? unwrapProps(props) : {});
+        }
         const instance = wrapInstance(handle, nt.prototype);
         assignTemplateChildren(instance, handle, reg);
         return instance;
@@ -1963,6 +2010,9 @@ function registerClass(metaOrClass, maybeClass) {
     children: children.length > 0 ? children : undefined,
     internalChildren: internalChildren.length > 0 ? internalChildren : undefined,
   });
+  // Reverse index for runCtorForCObject: the engine identifies a C-created instance
+  // by its GType name (= gtypeName, what native.registerClass registered).
+  classesByGType.set(gtypeName, klass);
   return klass;
 }
 

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -890,6 +890,34 @@ function assignTemplateChildren(instance, handle, reg) {
   }
 }
 
+// Push construct-time GObject-property values through the class's own JS SETTERS.
+//
+// A class can declare a GObject property (`Properties: { displayWidth: ParamSpec }`,
+// often CONSTRUCT with a default) AND a matching JS accessor
+// (`get/set displayWidth` over a `_displayWidth` backing field). On GJS the property
+// set vfunc delegates to the JS setter (`JS_SetProperty`), so the CONSTRUCT default
+// reaches `_displayWidth` at construction. node-gi builds the wrapper AFTER
+// g_object_new, so at construct time there is no USER_PROTO to route through — the
+// value lands only in the engine's per-instance store, and the class's getter
+// (reading `_displayWidth`) sees `undefined` (the Learn6502 Display "DrawingArea is
+// required" wall). Once USER_PROTO is attached (here, right after construction), read
+// each such property's construct value back out (from the store, or the ParamSpec
+// default) and run it through the JS setter — the node-gi analogue of GJS applying a
+// CONSTRUCT property via the JS setter, and BEFORE the user ctor body runs (same
+// order as GJS). Only properties whose name resolves to a prototype SETTER are
+// touched, so a plain GObject property (no JS accessor) keeps the store as its single
+// backing store — unchanged.
+function flushConstructProperties(instance, handle, reg) {
+  if (reg.constructPropertyNames === undefined) return;
+  const up = instance[USER_PROTO];
+  if (up === undefined) return;
+  for (const name of reg.constructPropertyNames) {
+    const desc = findProtoDescriptor(up, name);
+    if (desc === undefined || typeof desc.set !== 'function') continue;
+    desc.set.call(instance, wrapReturn(native.getProperty(handle, name)));
+  }
+}
+
 // ---- Gio.Application.runAsync (L1, GJS-shaped) ----
 //
 // The Node twin of GJS's `Gio.Application.prototype.runAsync`
@@ -1345,6 +1373,9 @@ function makeClass(namespace, typeName) {
         }
         const instance = wrapInstance(handle, nt.prototype);
         assignTemplateChildren(instance, handle, reg);
+        // Route construct-time property values through the class's JS setters now
+        // that USER_PROTO is attached — before the user ctor body runs (GJS order).
+        flushConstructProperties(instance, handle, reg);
         return instance;
       }
       // `nt` is a subclass of this introspected GObject class but was NEVER passed to
@@ -2005,10 +2036,24 @@ function registerClass(metaOrClass, maybeClass) {
   // Record the registration so the introspected base ctor (makeClass) routes
   // `new X(args)` (where new.target === klass) to constructType(typeHandle, …) +
   // the canonical wrapper. Template children move here from the old Subclass.
+  // The names of CONSTRUCT / CONSTRUCT_ONLY properties — the ONLY ones GObject
+  // applies at construction. The flush (flushConstructProperties) must be limited to
+  // these: a plain READWRITE property is NOT set during construction, so running its
+  // JS setter early (GObject never would) fires the setter's side effects against
+  // still-uninitialised instance state (the SourceView `selectable` → `_signalHandlers`
+  // forEach crash). Matches GJS, which only runs setters for props GObject applies at
+  // construct. Flags are the ABI-stable G_PARAM_CONSTRUCT (1<<2) | CONSTRUCT_ONLY (1<<3).
+  const PARAM_CONSTRUCT_MASK = 0x4 | 0x8;
+  const constructPropertyNames = properties
+    .filter((p) => typeof p.flags === 'number' && (p.flags & PARAM_CONSTRUCT_MASK) !== 0)
+    .map((p) => p.name)
+    .filter((n) => typeof n === 'string');
   registeredClasses.set(klass, {
     typeHandle,
     children: children.length > 0 ? children : undefined,
     internalChildren: internalChildren.length > 0 ? internalChildren : undefined,
+    // CONSTRUCT-property names, for the construct-property flush (below).
+    constructPropertyNames: constructPropertyNames.length > 0 ? constructPropertyNames : undefined,
   });
   // Reverse index for runCtorForCObject: the engine identifies a C-created instance
   // by its GType name (= gtypeName, what native.registerClass registered).

--- a/packages/node-gi/node-gi/globals.js
+++ b/packages/node-gi/node-gi/globals.js
@@ -23,6 +23,7 @@ import cairo from './cairo.js';
 // GLib.MainLoop convenience layer) — the GJS script modules many older sources use.
 import * as signalsModule from './overrides/_signals.js';
 import { createMainloop } from './overrides/mainloop.js';
+import { createPackage } from './overrides/package.js';
 
 // GJS stringifies each argument with String() and joins with a space (no
 // util.inspect object formatting) — match that for fidelity.
@@ -109,6 +110,10 @@ function makeImports() {
     gettext,
     cairo,
     signals: { addSignalMethods, _connect, _connectAfter, _disconnect, _emit, _signalHandlerIsConnected, _disconnectAll },
+    // GJS's `imports.searchPath` — `imports.package.init` unshifts the app's
+    // moduledir onto it. Inert on node-gi (ESM + gi://), but present + safe so
+    // source that reads/mutates it doesn't throw.
+    searchPath: [],
     versions: Object.create(null),
   };
   let mainloop;
@@ -116,6 +121,17 @@ function makeImports() {
     get() {
       if (mainloop === undefined) mainloop = createMainloop(requireGi('GLib', '2.0'));
       return mainloop;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+  // `imports.package` — the GJS application bootstrap (pkg.init/initGettext/
+  // initFormat). Lazy like `mainloop`: a bundle that never calls it pulls no GLib.
+  let pkg;
+  Object.defineProperty(imports, 'package', {
+    get() {
+      if (pkg === undefined) pkg = createPackage({ requireGi, gettext, imports });
+      return pkg;
     },
     enumerable: true,
     configurable: true,

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -664,6 +664,16 @@ export const disconnectSignal = native.disconnectSignal;
 export const setTemplateCallbackResolver = native.setTemplateCallbackResolver;
 
 /**
+ * Register the L1 callback the engine's overridden `constructor` vfunc invokes to
+ * run a registered class's JS constructor for a GObject it instantiated from C (a
+ * GtkBuilder composite-template InternalChild). Given (instanceHandle, gtypeName)
+ * it Reflect.constructs the class in adopt mode (see gi.js runCtorForCObject).
+ * @param {(handle: unknown, gtypeName: string) => void} cb
+ * @returns {void}
+ */
+export const setConstructCallback = native.setConstructCallback;
+
+/**
  * Install (or clear, with `null`) the structured-log writer function — the
  * engine's twin of GjsPrivate.log_set_writer_func backing GLib.log_set_writer_func.
  * The writer receives (logLevel: number, fields: Record<string, Uint8Array|null>)

--- a/packages/node-gi/node-gi/overrides/package.js
+++ b/packages/node-gi/node-gi/overrides/package.js
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: MIT OR LGPL-2.0-or-later
+// SPDX-FileCopyrightText: 2013 Giovanni Campagna <scampa.giovanni@gmail.com>
+//
+// Adapted from GJS (refs/gjs/modules/script/package.js). Copyright (c) 2013
+// Giovanni Campagna. MIT OR LGPL-2.0-or-later.
+// Modifications: the legacy `imports.package` — the GJS application bootstrap
+// (`pkg.init` / `initGettext` / `initFormat`) — ported to @gjsify/node-gi. A GNOME
+// app's entry point does `imports.package.init({ name, version, prefix, libdir })`
+// then `pkg.initGettext()` / `pkg.initFormat()`. The GJS original's heavy
+// source-tree detection + GResource registration + module-search machinery is NOT
+// load-bearing for a node-gi consumer (the app carries its own dir constants and
+// registers its own resources — see easy6502 app-gnome resources.ts), so this is
+// the minimal, honest init: set `globalThis.pkg`, wire `_`/`C_`/`N_` and
+// `String.prototype.format`, and keep `imports.searchPath` / `GLib.set_prgname`
+// calls safe. Mirrors overrides/mainloop.js's `createX(deps)` shape.
+
+/**
+ * Build the `imports.package` object bound to the L1 backend.
+ * @param {{ requireGi: Function, gettext: any, imports: Record<string, any> }} deps
+ */
+export function createPackage({ requireGi, gettext, imports }) {
+  const pkg = {
+    // Public fields GJS source may read. Populated by init().
+    name: undefined,
+    version: undefined,
+    prefix: undefined,
+    libdir: undefined,
+    datadir: undefined,
+    pkgdatadir: undefined,
+    pkglibdir: undefined,
+    moduledir: undefined,
+    localedir: undefined,
+
+    /**
+     * @param {{ name?: string, version?: string, prefix?: string, libdir?: string, datadir?: string }} params
+     */
+    init(params = {}) {
+      // The accessor GJS apps use right after: `pkg.initGettext()`.
+      globalThis.pkg = pkg;
+
+      pkg.name = params.name;
+      pkg.version = params.version;
+      pkg.prefix = params.prefix;
+      pkg.libdir = params.libdir;
+      pkg.datadir = params.datadir ?? (params.prefix ? `${params.prefix}/share` : undefined);
+
+      // Installed-layout dirs — NOT load-bearing on node-gi (apps carry their own
+      // constants + register their own resources), computed for source-compat only.
+      if (pkg.name) {
+        if (pkg.datadir) {
+          pkg.pkgdatadir = `${pkg.datadir}/${pkg.name}`;
+          pkg.moduledir = pkg.pkgdatadir;
+          pkg.localedir = `${pkg.datadir}/locale`;
+        }
+        if (pkg.libdir) pkg.pkglibdir = `${pkg.libdir}/${pkg.name}`;
+      }
+
+      // Cheap + safe: keeps ARGV[0]/app-id semantics (window-manager grouping etc.).
+      try {
+        const GLib = requireGi('GLib', '2.0');
+        if (pkg.name && typeof GLib.set_prgname === 'function') GLib.set_prgname(pkg.name);
+      } catch {
+        /* GLib not loadable in this context — skip */
+      }
+
+      // GJS unshifts moduledir onto imports.searchPath (script-import machinery).
+      // node-gi apps use ESM + gi://, so the search path is inert here — but keep
+      // the array present + the unshift safe so source that reads it doesn't throw.
+      if (!Array.isArray(imports.searchPath)) imports.searchPath = [];
+      if (pkg.moduledir) imports.searchPath.unshift(pkg.moduledir);
+    },
+
+    initGettext() {
+      if (pkg.name) {
+        try {
+          gettext.bindtextdomain?.(pkg.name, pkg.localedir ?? null);
+          gettext.textdomain?.(pkg.name);
+        } catch {
+          /* passthrough gettext — no catalog, ignore */
+        }
+      }
+      // The globals GJS apps + compiled Blueprint use pervasively.
+      globalThis._ = (msgid) => gettext.gettext(msgid);
+      globalThis.C_ = (context, msgid) => gettext.pgettext(context, msgid);
+      globalThis.N_ = (msgid) => msgid;
+    },
+
+    initFormat() {
+      // GJS sets `String.prototype.format = imports.format.format` (backed by the
+      // native `_format` vprintf). node-gi has no `imports.format`, so supply an
+      // equivalent JS vprintf here (see makeVprintf).
+      const vprintf = makeVprintf();
+      Object.defineProperty(String.prototype, 'format', {
+        configurable: true,
+        writable: true,
+        enumerable: false,
+        value: function format(...args) {
+          return vprintf(this, args);
+        },
+      });
+    },
+
+    // Script-import machinery is not ported — node-gi apps use ESM + gi://. These
+    // keep the surface present for source that references them (Learn6502 does not).
+    require() {
+      /* no-op: apps import via ESM / gi:// on node-gi */
+    },
+    requireSymbol() {
+      return true;
+    },
+    checkSymbol() {
+      return true;
+    },
+    start(params = {}) {
+      pkg.init(params);
+      if (typeof params.main === 'function') params.main(globalThis.ARGV ? ['', ...globalThis.ARGV] : []);
+    },
+    run() {
+      /* the app drives its own main() on node-gi */
+    },
+    initSubmodule() {
+      /* n/a on node-gi */
+    },
+  };
+
+  return pkg;
+}
+
+// A small vprintf covering the GJS `String.prototype.format` spec
+// (refs/gjs/modules/script/format.js): `%s %d %x %f`, `%.Nf` precision, `%Ns`/`%Nd`
+// width, `0`-padding for numerics, and `%%` → literal `%`. Positional `%N$s` is
+// supported (GJS honours it). Learn6502 only uses `%s`; the rest is fidelity.
+function makeVprintf() {
+  return function vprintf(fmt, args) {
+    let auto = 0;
+    return String(fmt).replace(
+      /%(?:(\d+)\$)?(0)?(\d+)?(?:\.(\d+))?([%sdxf])/g,
+      (match, pos, zero, width, prec, spec) => {
+        if (spec === '%') return '%';
+        const arg = pos !== undefined ? args[Number(pos) - 1] : args[auto++];
+        let str;
+        switch (spec) {
+          case 's':
+            str = String(arg);
+            break;
+          case 'd':
+            str = String(Math.trunc(Number(arg)));
+            break;
+          case 'x':
+            str = Math.trunc(Number(arg)).toString(16);
+            break;
+          case 'f':
+            str = prec !== undefined ? Number(arg).toFixed(Number(prec)) : String(Number(arg));
+            break;
+          default:
+            return match;
+        }
+        if (width !== undefined) {
+          const w = Number(width);
+          const pad = zero && spec !== 's' ? '0' : ' ';
+          while (str.length < w) str = pad + str;
+        }
+        return str;
+      },
+    );
+  };
+}

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -120,6 +120,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("disconnectSignal", Napi::Function::New(env, DisconnectSignal));
   exports.Set("setTemplateCallbackResolver",
               Napi::Function::New(env, SetTemplateCallbackResolver));
+  exports.Set("setConstructCallback", Napi::Function::New(env, SetConstructCallback));
   // GjsPrivate-mirroring helpers (private.cc): the structured-log writer func +
   // the bind_property_full / BindingGroup.bind_full transform trampolines.
   exports.Set("logSetWriterFunc", Napi::Function::New(env, LogSetWriterFunc));

--- a/packages/node-gi/node-gi/src/class.cc
+++ b/packages/node-gi/node-gi/src/class.cc
@@ -383,10 +383,120 @@ static void NodeGiSetProperty(GObject* obj, guint prop_id, const GValue* value, 
   if (cd != nullptr && cd->parentSet != nullptr) cd->parentSet(obj, prop_id, value, pspec);
 }
 
+// ---- run the JS constructor for C/GtkBuilder-instantiated instances ----
+//
+// node-gi runs a registered class's JS constructor ONLY on a JS-side `new Sub()`
+// (the makeClass new.target path in gi.js routes it to constructType, and ES
+// super-substitution runs the ctor body). A GObject built from C — a GtkBuilder
+// composite-template InternalChild is the common case — never reaches that path,
+// so its ctor body (e.g. `this._x = …`) never runs. GJS solves this by overriding
+// the GObjectClass `constructor` vfunc so BOTH paths funnel through it
+// (refs/gjs/gi/gobject.cpp gjs_object_constructor). We mirror that: NodeGiConstructor
+// chains to the first non-node-gi C constructor to create the instance, then — only
+// for the C-driven path — runs the JS ctor on the canonical wrapper via the L1
+// construct callback. The JS-`new` path is unchanged (the latch NodeGiJsConstructing
+// is raised by ConstructGObject, so we return the instance and let makeClass run it).
+
+// Thread-local so a worker_threads env has its own latch (GtkBuilder construction
+// runs on the same thread as the ConstructGObject that raised it).
+static thread_local bool g_nodegiJsConstructing = false;
+bool NodeGiJsConstructing() { return g_nodegiJsConstructing; }
+void NodeGiSetJsConstructing(bool v) { g_nodegiJsConstructing = v; }
+
+static void RunJsConstructorForCObject(napi_env env, GObject* obj) {
+  // Teardown/terminate: never enter JS during GC/context teardown (GJS-faithful;
+  // same gate as the vfunc trampoline). The C object is still fully constructed.
+  if (!NodeGiJsAvailable(env)) return;
+  Napi::Env napiEnv(env);
+  Napi::HandleScope scope(napiEnv);
+  // JS dispatched from a pump-driven iteration must not inherit the in-iteration
+  // flag (mirrors the vfunc trampoline).
+  NodeGiPumpJsDispatchScope pumpWindow;
+
+  // Build this instance's OWN composite template first (a no-op unless it carries
+  // one), so the JS ctor's assignTemplateChildren sees bound children — the JS-`new`
+  // path does this in ConstructGObject before makeClass reads them.
+  MaybeInitTemplate(napiEnv, obj);
+
+  NodeGiEnvData* d = EnvData(env);
+  napi_value cb = nullptr;
+  if (d == nullptr || d->constructCallback == nullptr ||
+      napi_get_reference_value(env, d->constructCallback, &cb) != napi_ok || cb == nullptr) {
+    return;  // L1 hasn't registered the callback (nothing to run)
+  }
+  napi_value handleVal = WrapGObject(napiEnv, obj, GI_TRANSFER_NOTHING);
+  napi_value nameVal = nullptr;
+  napi_create_string_utf8(env, g_type_name(G_OBJECT_TYPE(obj)), NAPI_AUTO_LENGTH, &nameVal);
+  napi_value args[2] = {handleVal, nameVal};
+  napi_value undef = nullptr;
+  napi_get_undefined(env, &undef);
+  napi_value ret = nullptr;
+  // A plain call (not napi_make_callback): the ctor is synchronous and we must not
+  // drain the microtask queue mid-g_object_new. Matches GJS's template-callback
+  // resolver + gjs_object_constructor's JS::Construct (no checkpoint).
+  napi_status st = napi_call_function(env, undef, cb, 2, args, &ret);
+  if (st != napi_ok) {
+    // The ctor threw. Never leave a pending JS exception across the return into C
+    // (GObject/GtkBuilder can't handle it) — clear it and fold the message into a
+    // g_warning (GJS logs the uncaught exception here too).
+    napi_value ex = nullptr;
+    if (napi_get_and_clear_last_exception(env, &ex) == napi_ok && ex != nullptr) {
+      napi_value msg = nullptr;
+      std::string detail;
+      if (napi_get_named_property(env, ex, "message", &msg) == napi_ok) {
+        size_t len = 0;
+        if (napi_get_value_string_utf8(env, msg, nullptr, 0, &len) == napi_ok) {
+          detail.resize(len);
+          napi_get_value_string_utf8(env, msg, detail.data(), len + 1, &len);
+        }
+      }
+      g_warning("node-gi: JS constructor for %s threw: %s", g_type_name(G_OBJECT_TYPE(obj)),
+                detail.empty() ? "(no message)" : detail.c_str());
+    }
+  }
+}
+
+// The overridden GObjectClass `constructor` vfunc (installed on every registered
+// type in NodeGiClassInit). GJS parity: gi/gobject.cpp gjs_object_constructor.
+static GObject* NodeGiConstructor(GType type, guint n_construct_properties,
+                                  GObjectConstructParam* construct_properties) {
+  // Chain to the first non-node-gi (C) constructor UP the hierarchy, skipping our
+  // own — that actually allocates + constructs the instance (running the real C
+  // construction chain). GJS does the identical skip-walk (gobject.cpp:155).
+  GType parent = g_type_parent(type);
+  while (parent != 0) {
+    gpointer pk = g_type_class_peek(parent);
+    if (pk == nullptr || G_OBJECT_CLASS(pk)->constructor != NodeGiConstructor) break;
+    parent = g_type_parent(parent);
+  }
+  gpointer pk = parent != 0 ? g_type_class_peek(parent) : nullptr;
+  GObject* obj = (pk != nullptr && G_OBJECT_CLASS(pk)->constructor != nullptr)
+                     ? G_OBJECT_CLASS(pk)->constructor(type, n_construct_properties,
+                                                       construct_properties)
+                     : nullptr;
+  if (obj == nullptr) return nullptr;
+
+  // JS-`new` path: the makeClass super-substitution runs the user ctor after
+  // g_object_new returns — do NOT run it here (would double-run).
+  if (NodeGiJsConstructing()) return obj;
+
+  // C/GtkBuilder-driven: the user ctor has no other driver. Run it on the leaf
+  // registered class's env (correct across worker envs).
+  NodeGiClassData* cd = FindClassData(G_OBJECT_TYPE(obj));
+  if (cd != nullptr && cd->env != nullptr) RunJsConstructorForCObject(cd->env, obj);
+  return obj;
+}
+
 static void NodeGiClassInit(gpointer g_class, gpointer class_data) {
   NodeGiClassData* cd = static_cast<NodeGiClassData*>(class_data);
   GObjectClass* oc = G_OBJECT_CLASS(g_class);
   g_type_set_qdata(G_TYPE_FROM_CLASS(g_class), NodeGiClassDataQuark(), cd);
+
+  // Route construction through NodeGiConstructor so a C/GtkBuilder-instantiated
+  // instance (a composite-template InternalChild) gets its JS constructor run —
+  // GJS parity (gi/gobject.cpp). The JS-`new` path is unaffected: NodeGiConstructor
+  // returns early while the NodeGiJsConstructing() latch is raised.
+  oc->constructor = NodeGiConstructor;
 
   if (!cd->properties.empty()) {
     cd->parentGet = oc->get_property;  // capture before override (chain target)
@@ -941,6 +1051,9 @@ static Napi::Value RegisterClassImpl(Napi::Env env, const std::string& name, GTy
 
   // Parse the optional { properties, signals } and build the class metadata.
   NodeGiClassData* cd = new NodeGiClassData();
+  // Stamp the registering env so NodeGiConstructor (no user_data slot) can call
+  // into JS from this class's cd for a C/GtkBuilder-instantiated instance.
+  cd->env = env;
   cd->parentGet = nullptr;
   cd->parentSet = nullptr;
   if (optsValue.IsObject()) {
@@ -1165,6 +1278,26 @@ Napi::Value ConstructType(const Napi::CallbackInfo& info) {
   Napi::Object props = (info.Length() >= 2 && info[1].IsObject()) ? info[1].As<Napi::Object>()
                                                                  : Napi::Object::New(env);
   return ConstructGObject(env, gtype, props, std::string(g_type_name(gtype)));
+}
+
+// setConstructCallback(cb) -> void. L1 registers the callback NodeGiConstructor
+// invokes to run a registered class's JS constructor for a C/GtkBuilder-created
+// instance: (instanceHandle, gtypeName) → Reflect.construct(class) in adopt mode
+// (see gi.js runCtorForCObject). Mirrors setTemplateCallbackResolver.
+Napi::Value SetConstructCallback(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsFunction()) {
+    Napi::TypeError::New(env, "setConstructCallback(cb: function)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  NodeGiEnvData* d = EnvData(env);
+  if (d == nullptr) return env.Undefined();
+  if (d->constructCallback != nullptr) {
+    napi_delete_reference(env, d->constructCallback);
+    d->constructCallback = nullptr;
+  }
+  napi_create_reference(env, info[0], 1, &d->constructCallback);
+  return env.Undefined();
 }
 
 }  // namespace nodegi

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -82,6 +82,13 @@ struct NodeGiEnvData {
   // (napi_make_callback already runs the checkpoint there). Per-env for the same
   // reason as errorBuilder (a napi_ref is env-specific).
   napi_ref microtaskDrain = nullptr;
+  // L1 callback that runs a registered class's JS constructor body on a
+  // pre-existing canonical wrapper — invoked by NodeGiConstructor for a GObject
+  // instantiated from C (a GtkBuilder composite-template InternalChild), whose JS
+  // ctor the node-gi JS-`new` path never reaches. (handle, gtypeName) →
+  // Reflect.construct(class) in adopt mode (see gi.js runCtorForCObject). Per-env
+  // for the same reason as errorBuilder (a napi_ref is env-specific).
+  napi_ref constructCallback = nullptr;
 };
 
 void NodeGiEnvDataFinalize(napi_env env, void* data, void* hint);
@@ -457,6 +464,11 @@ struct NodeGiClassData {
   // for the class lifetime (process-permanent, like cd itself); its JS env qdata is
   // refreshed per construction so create_closure resolves handlers in the live env.
   GObject* templateScope = nullptr;
+  // The napi_env this class was registered on. NodeGiConstructor (the overridden
+  // GObjectClass `constructor` vfunc) has no user_data slot, so it reads the env to
+  // call into JS from cd — correct even across worker envs (each registers its own
+  // class, so the leaf's cd carries the right env).
+  napi_env env = nullptr;
 
   // The cold `delete cd` failure paths (a bad GParamSpec, or g_type_register_static
   // returning 0) must not leak the owned inline-template GBytes. A destructor frees
@@ -487,6 +499,14 @@ void MaybeInitTemplate(Napi::Env env, GObject* obj);
 // reuses), but NodeGiClassInit installs the scope and MaybeInitTemplate refreshes
 // its env, both above that point.
 void NodeGiInstallTemplateScopeOnClass(NodeGiClassData* cd, gpointer g_class);
+
+// A thread-local latch the node-gi JS-`new` path (ConstructGObject) raises around
+// g_object_new_with_properties. NodeGiConstructor (the overridden GObjectClass
+// `constructor` vfunc) reads it to tell a JS-driven construction — where the
+// makeClass super-substitution runs the user ctor — apart from a C/GtkBuilder-driven
+// one, where NodeGiConstructor must run the user ctor itself (see class.cc / gi.js).
+bool NodeGiJsConstructing();
+void NodeGiSetJsConstructing(bool v);
 
 // ---- N-API entry points (registered in addon.cc's Init) ----
 
@@ -546,6 +566,7 @@ Napi::Value RegisterClass(const Napi::CallbackInfo& info);
 Napi::Value RegisterClassFromGType(const Napi::CallbackInfo& info);
 Napi::Value ConstructType(const Napi::CallbackInfo& info);
 Napi::Value CallParentVfunc(const Napi::CallbackInfo& info);
+Napi::Value SetConstructCallback(const Napi::CallbackInfo& info);
 
 // template.cc
 Napi::Value GetTemplateChild(const Napi::CallbackInfo& info);

--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -595,7 +595,15 @@ Napi::Value ConstructGObject(Napi::Env env, GType gtype, Napi::Object props,
 
   GObject* obj = nullptr;
   if (ok) {
+    // Raise the JS-`new` latch across construction: this is the node-gi JS-driven
+    // path, where the makeClass super-substitution runs the user ctor AFTER this
+    // returns. NodeGiConstructor reads the latch and does NOT re-run the ctor (a
+    // C/GtkBuilder-driven g_object_new leaves it clear, so NodeGiConstructor runs
+    // the ctor there). Save/restore keeps a reentrant construct correct.
+    bool prevConstructing = NodeGiJsConstructing();
+    NodeGiSetJsConstructing(true);
     obj = g_object_new_with_properties(gtype, n, cnames.data(), values.data());
+    NodeGiSetJsConstructing(prevConstructing);
   }
   for (guint j = 0; j < initialised; j++) g_value_unset(&values[j]);
   g_type_class_unref(klass);

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -17,6 +17,7 @@ void NodeGiEnvDataFinalize(napi_env env, void* data, void* /*hint*/) {
     napi_delete_reference(env, d->templateCallbackResolver);
   if (d->cairoWrappers != nullptr) napi_delete_reference(env, d->cairoWrappers);
   if (d->microtaskDrain != nullptr) napi_delete_reference(env, d->microtaskDrain);
+  if (d->constructCallback != nullptr) napi_delete_reference(env, d->constructCallback);
   delete d;
 }
 

--- a/packages/node-gi/node-gi/test/gtk-template-custom-child-ctor.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template-custom-child-ctor.test.mjs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — a CUSTOM registerClass'd widget used as a composite-template
+// InternalChild has its JS CONSTRUCTOR run when GtkBuilder instantiates it.
+//
+// The bug this guards against (the Learn6502 app-gnome port wall): node-gi ran a
+// registered class's JS constructor ONLY on a JS-side `new Sub()` (the makeClass
+// new.target path). A GtkBuilder-built composite-template child (e.g. MainWindow's
+// `<object class="GameConsole" id="gameConsole">`) is instantiated from C via
+// g_object_new, so its ctor body never ran — `this._simulator = …` never executed,
+// and `this._gameConsole.simulator` was `undefined`, crashing MainWindow.
+//
+// The fix (GJS parity, refs/gjs/gi/gobject.cpp): node-gi overrides the GObjectClass
+// `constructor` vfunc (NodeGiConstructor). For a C/GtkBuilder-driven construction it
+// runs the child's JS ctor on the canonical wrapper via the L1 construct callback
+// (adopt mode). The JS-`new` path is unchanged (a latch skips the extra run).
+//
+// This asserts, on a real GtkBuilder template:
+//   - the custom child's JS ctor RAN (plain-JS fields it set are visible)
+//   - it ran EXACTLY ONCE (no double-run), incl. a plain `new Child()` (JS-`new`)
+//   - the child carries its user prototype (a `get`/method resolves) — the USER_PROTO
+//     that the old getTemplateChild wrapper lacked, now attached by the adopt ctor
+//
+// SELF-SKIPPING like gtk-template.test.mjs: needs a display + the Gtk-4.0 typelib,
+// so the headless `npm test` / `test:gc` legs skip it; the `gtk-smoke` CI job runs it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi, unwrap } from '../gi.js';
+import native from '../index.js';
+
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+
+let GObject;
+let Gtk;
+let Gio;
+let GLib;
+let loadError = null;
+if (haveDisplay) {
+  try {
+    GLib = requireGi('GLib', '2.0');
+    Gio = requireGi('Gio', '2.0');
+    GObject = requireGi('GObject', '2.0');
+    Gtk = requireGi('Gtk', '4.0');
+  } catch (err) {
+    loadError = err;
+  }
+}
+
+const skip = !haveDisplay
+  ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+  : loadError
+    ? `Gtk-4.0 typelib unavailable: ${loadError.message}`
+    : false;
+
+// The parent template embeds the custom child by its registered GTypeName.
+const TEMPLATE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <template class="NodeGiCtorParent" parent="GtkBox">
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="NodeGiCtorChild" id="child"/>
+    </child>
+  </template>
+</interface>`;
+
+test('a custom template child gets its JS constructor run (GtkBuilder path)', { skip }, () => {
+  // Count ctor runs to prove exactly-once (no double-run, no skip).
+  let childCtorRuns = 0;
+
+  // The custom child: its ctor body sets plain-JS state — the shape that was lost.
+  const ChildWidget = GObject.registerClass(
+    { GTypeName: 'NodeGiCtorChild' },
+    class ChildWidget extends Gtk.Box {
+      constructor(params) {
+        super(params);
+        childCtorRuns++;
+        this._marker = 'ctor-ran'; // plain-JS field set IN the constructor body
+        this._answer = 42;
+      }
+      // A user accessor + method — only reachable if the wrapper carries USER_PROTO.
+      get marker() {
+        return this._marker;
+      }
+      describe() {
+        return `${this._marker}:${this._answer}`;
+      }
+    },
+  );
+
+  const ParentBox = GObject.registerClass(
+    {
+      GTypeName: 'NodeGiCtorParent',
+      Template: new TextEncoder().encode(TEMPLATE_XML),
+      InternalChildren: ['child'],
+    },
+    class ParentBox extends Gtk.Box {},
+  );
+
+  const app = new Gtk.Application({
+    application_id: 'eu.jumplink.NodeGiCtorChild',
+    flags: Gio.ApplicationFlags.NON_UNIQUE,
+  });
+
+  const results = {};
+  let activateError = null;
+
+  app.connect('activate', () => {
+    try {
+      const parent = new ParentBox();
+
+      // The GtkBuilder-built internal child.
+      const child = parent._child;
+      results.childType = child != null ? native.getTypeName(unwrap(child)) : null;
+
+      // THE CORE ASSERTIONS: the child's JS ctor ran, so its plain-JS fields exist.
+      results.marker = child != null ? child.marker : undefined; // via get marker()
+      results.markerField = child != null ? child._marker : undefined; // the expando
+      results.answer = child != null ? child._answer : undefined;
+      results.describe = child != null ? child.describe() : undefined; // user method
+      results.isInstance = child instanceof ChildWidget;
+
+      // Ctor-run count AFTER the template child was built (GtkBuilder path).
+      results.runsAfterTemplate = childCtorRuns;
+
+      // JS-`new` path still runs the ctor EXACTLY ONCE (no double-run via the vfunc).
+      const direct = new ChildWidget();
+      results.directMarker = direct.marker;
+      results.runsAfterDirect = childCtorRuns;
+
+      const win = new Gtk.ApplicationWindow({ application: app });
+      win.set_child(parent);
+      win.present();
+
+      GLib.timeout_add(GLib.PRIORITY_DEFAULT, 50, () => {
+        app.quit();
+        return GLib.SOURCE_REMOVE;
+      });
+    } catch (err) {
+      activateError = err;
+      app.quit();
+    }
+  });
+
+  const status = app.run([]);
+
+  assert.equal(activateError, null, `activate handler threw: ${activateError && activateError.stack}`);
+  assert.equal(status, 0, 'app.run([]) should exit 0');
+
+  assert.equal(results.childType, 'NodeGiCtorChild', 'the template child is the registered custom type');
+
+  // The JS constructor ran for the GtkBuilder-created child.
+  assert.equal(results.markerField, 'ctor-ran', 'the ctor body ran: this._marker expando is set');
+  assert.equal(results.answer, 42, 'the ctor body ran: this._answer expando is set');
+  // USER_PROTO reachable: the get accessor + method resolve on the template child.
+  assert.equal(results.marker, 'ctor-ran', 'get marker() resolves (USER_PROTO attached)');
+  assert.equal(results.describe, 'ctor-ran:42', 'a user method runs against the template child');
+  assert.equal(results.isInstance, true, 'the template child is an instanceof the JS class');
+
+  // Exactly once for the template child; the JS-`new` adds exactly one more.
+  assert.equal(results.runsAfterTemplate, 1, 'the template-child ctor ran EXACTLY once (no double-run)');
+  assert.equal(results.directMarker, 'ctor-ran', 'a plain `new ChildWidget()` still runs its ctor');
+  assert.equal(results.runsAfterDirect, 2, 'JS-`new` runs the ctor once more (no double-run on that path)');
+});

--- a/packages/node-gi/node-gi/test/imports-package.test.mjs
+++ b/packages/node-gi/node-gi/test/imports-package.test.mjs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — imports.package (the GJS application bootstrap) on node-gi.
+//
+// A real GNOME app (easy6502 packages/app-gnome) boots via:
+//   imports.package.init({ name, version, prefix, libdir });
+//   pkg.initGettext();   // wires globalThis._ / C_ / N_
+//   pkg.initFormat();    // wires String.prototype.format
+// node-gi previously exposed `imports` but not `imports.package`, so the app
+// stopped at `imports.package.init` with "Cannot read properties of undefined".
+// This proves that boot surface runs on node-gi (overrides/package.js).
+//
+// Reference: refs/gjs modules/script/{package,format}.js.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import '../globals.js';
+
+test('imports.package.init sets globalThis.pkg + the dir fields + searchPath', () => {
+  const pkg = globalThis.imports.package;
+  assert.ok(pkg, 'imports.package exists');
+  pkg.init({ name: 'eu.jumplink.Test', version: '1.2.3', prefix: '/usr', libdir: '/usr/lib' });
+  assert.equal(globalThis.pkg, pkg, 'globalThis.pkg is set to the package module');
+  assert.equal(pkg.name, 'eu.jumplink.Test');
+  assert.equal(pkg.version, '1.2.3');
+  assert.equal(pkg.datadir, '/usr/share');
+  assert.equal(pkg.moduledir, '/usr/share/eu.jumplink.Test');
+  assert.equal(pkg.localedir, '/usr/share/locale');
+  assert.ok(Array.isArray(globalThis.imports.searchPath), 'imports.searchPath is an array');
+  assert.ok(globalThis.imports.searchPath.includes('/usr/share/eu.jumplink.Test'), 'moduledir unshifted onto searchPath');
+});
+
+test('pkg.initGettext wires the _ / C_ / N_ globals (passthrough, no catalog)', () => {
+  const pkg = globalThis.imports.package;
+  pkg.init({ name: 'eu.jumplink.Test' });
+  pkg.initGettext();
+  assert.equal(typeof globalThis._, 'function');
+  assert.equal(globalThis._('Hello'), 'Hello');
+  assert.equal(globalThis.C_('some-context', 'Message'), 'Message');
+  assert.equal(globalThis.N_('untranslated'), 'untranslated');
+});
+
+test('pkg.initFormat wires String.prototype.format (JS vprintf)', () => {
+  const pkg = globalThis.imports.package;
+  pkg.initFormat();
+  assert.equal('by %s'.format('Pascal'), 'by Pascal');
+  assert.equal('%d items'.format(3), '3 items');
+  assert.equal('addr %04x'.format(0x0600), 'addr 0600'); // 0-padded hex — the Learn6502 gutter shape
+  assert.equal('%.2f'.format(3.14159), '3.14');
+  assert.equal('%5s|'.format('ab'), '   ab|'); // width, space-pad (right-align)
+  assert.equal('100%% done'.format(), '100% done'); // %% -> literal %
+  assert.equal('%s + %s'.format('a', 'b'), 'a + b'); // sequential args
+});

--- a/packages/node-gi/node-gi/test/registerclass-construct-property-accessor.test.mjs
+++ b/packages/node-gi/node-gi/test/registerclass-construct-property-accessor.test.mjs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — a CONSTRUCT GObject property whose class also defines a matching
+// JS getter/setter reaches the JS backing field at construction.
+//
+// The bug this guards against (the Learn6502 Display "DrawingArea is required" wall,
+// surfaced once C-instantiated ctors ran): a class declares a GObject property
+// (`Properties: { value: ParamSpec.int(..., READWRITE|CONSTRUCT, default) }`) AND a
+// matching JS accessor (`get/set value` over a `_value` backing field). On GJS the
+// property set vfunc delegates to the JS setter, so the CONSTRUCT default reaches
+// `_value` during construction. node-gi builds the wrapper AFTER g_object_new, so the
+// CONSTRUCT value landed only in the engine's per-instance store while the class's
+// `get value()` read an unset `_value` → undefined. The construct-property flush
+// (gi.js flushConstructProperties) routes the construct value through the JS setter
+// once the user prototype is attached.
+//
+// Headless (pure GObject, no widget/display), so it runs on every `npm test` leg.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const GObject = requireGi('GObject', '2.0');
+
+const DEFAULT_VALUE = 42;
+
+// A property WITH a JS accessor (the split-brain shape) + a plain property WITHOUT
+// one (must stay store-backed, i.e. unchanged).
+const Widget = GObject.registerClass(
+  {
+    GTypeName: 'NodeGiConstructAccessor',
+    Properties: {
+      value: GObject.ParamSpec.int(
+        'value',
+        'Value',
+        'A CONSTRUCT int with a JS getter/setter over a backing field',
+        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+        0,
+        1000,
+        DEFAULT_VALUE,
+      ),
+      // No JS accessor for this one — it must keep using the engine store.
+      plain: GObject.ParamSpec.int(
+        'plain',
+        'Plain',
+        'A CONSTRUCT int with NO JS accessor',
+        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
+        0,
+        1000,
+        7,
+      ),
+      // A NON-CONSTRUCT property WITH a JS setter that has a side effect touching
+      // ctor-body-initialised state. The flush must NOT run this at construction —
+      // GObject never applies a plain READWRITE property at construct, and running
+      // the setter early crashes against uninitialised state (the Learn6502
+      // SourceView `selectable` → `_signalHandlers.forEach` regression).
+      touchy: GObject.ParamSpec.boolean(
+        'touchy',
+        'Touchy',
+        'A READWRITE (non-CONSTRUCT) bool whose setter must not fire at construct',
+        GObject.ParamFlags.READWRITE,
+        false,
+      ),
+    },
+  },
+  class Widget extends GObject.Object {
+    // Backing field with NO runtime initializer — populated only via the setter.
+    // (declare in TS; a bare field here.)
+    get value() {
+      return this._value;
+    }
+    set value(v) {
+      this._value = v;
+    }
+    get touchy() {
+      return this._touchy;
+    }
+    set touchy(v) {
+      // Side effect that only works once the ctor body has initialised _log; if the
+      // flush ran this during construction (before the ctor body), _log is undefined
+      // and this throws — exactly the SourceView `selectable` shape.
+      this._log.push(v);
+      this._touchy = v;
+    }
+    constructor(params) {
+      super(params);
+      // Runs AFTER the base ctor (where the flush lives) — proves ordering.
+      if (this._log === undefined) this._log = [];
+    }
+  },
+);
+
+test('a CONSTRUCT property default reaches the class JS backing field', () => {
+  const w = new Widget();
+  // The core assertion: the CONSTRUCT default flowed through `set value` → `_value`,
+  // so the class getter sees it (was `undefined` before the flush).
+  assert.equal(w.value, DEFAULT_VALUE, 'get value() returns the CONSTRUCT default');
+  assert.equal(w._value, DEFAULT_VALUE, 'the _value backing field is populated');
+});
+
+test('an explicitly-passed construct value reaches the JS backing field', () => {
+  const w = new Widget({ value: 123 });
+  assert.equal(w.value, 123, 'the passed construct value flowed through the JS setter');
+  assert.equal(w._value, 123, 'the _value backing field carries the passed value');
+});
+
+test('a plain CONSTRUCT property (no JS accessor) still works via the store', () => {
+  const w = new Widget();
+  // Unchanged store-backed path — the flush skips it (no prototype setter).
+  assert.equal(w.plain, 7, 'plain property returns its CONSTRUCT default from the store');
+  const w2 = new Widget({ plain: 99 });
+  assert.equal(w2.plain, 99, 'plain property carries the passed construct value');
+});
+
+test('setting the accessor property after construction round-trips', () => {
+  const w = new Widget();
+  w.value = 500; // JS setter → _value
+  assert.equal(w.value, 500, 'post-construction set/get round-trips through the accessor');
+});
+
+test('a NON-CONSTRUCT property with a JS setter is NOT flushed at construction', () => {
+  // If the flush ran `set touchy` during construction, the setter would throw on the
+  // undefined `_log` (uninitialised until the ctor body). Construction must succeed
+  // and the setter must not have fired.
+  const w = new Widget();
+  assert.deepEqual(w._log, [], 'the touchy setter did NOT run during construction');
+  // And it still works normally after construction.
+  w.touchy = true;
+  assert.equal(w.touchy, true, 'the non-construct accessor works post-construction');
+  assert.deepEqual(w._log, [true], 'the setter ran exactly once, post-construction');
+});


### PR DESCRIPTION
> **Stacked on #785** (imports.package). Two commits — the two halves of making a real GTK4/Adwaita GNOME app (**Learn6502** `app-gnome`) boot on node-gi/Node.js.

## 1. Run JS constructors for C-instantiated objects (`f7297af`)

node-gi ran a registered class's JS constructor **only** on a JS-side `new Sub()`. A GObject built from **C** — a **GtkBuilder composite-template `InternalChild`** — never reached it, so its ctor body never ran (`this._simulator = …` stayed `undefined` → crash in `MainWindow.setupMainButton`).

**Fix (GJS parity, `refs/gjs/gi/gobject.cpp`):** override the GObjectClass **`constructor` vfunc** (`NodeGiConstructor`) so both paths funnel through it. It chains to the first non-node-gi C constructor to build the instance, then — only for the C-driven path (a thread-local latch distinguishes JS-`new`) — runs the JS ctor on the canonical wrapper via a new L1 construct callback + an `adoptHandle` hook in the makeClass base ctor (which also attaches `USER_PROTO`, fixing the template-child accessor gap). The JS-`new` path is byte-unchanged.

## 2. Flush CONSTRUCT property values to JS setters (`b086a61`)

Surfaced once (1) let the ctors run: `Display.initialize()` threw `DrawingArea is required` because `this.displayWidth` was `undefined`. `displayWidth` is a `CONSTRUCT` GObject property with a default, backed by a JS getter/setter over `_displayWidth`. GJS's set vfunc delegates to the JS setter, so the default reaches the field at construct; node-gi builds the wrapper after `g_object_new`, so the value landed only in the engine store while the getter read an unset `_displayWidth`.

**Fix (pure L1, no engine change):** once `USER_PROTO` is attached — in the base ctor, before the user ctor body (GJS order) — push each **CONSTRUCT/CONSTRUCT_ONLY** property's construct value through the class's JS setter. Scoped to construct-flagged properties (a plain `READWRITE` prop is not applied at construct, so running its setter early would fire side effects against uninitialised state — the `SourceView.selectable` → `_signalHandlers.forEach` case) and to names that resolve to a prototype setter (plain GObject properties keep the store, unchanged). The hot `NodeGiGet/SetProperty` path is untouched.

## Validated — zero regressions

- node-gi suite **390/390 headless + 11/11 display, 0 fail**, with two new tests: `gtk-template-custom-child-ctor` (ctor runs on the GtkBuilder path, exactly once, USER_PROTO reachable, no double-run) and `registerclass-construct-property-accessor` (CONSTRUCT default + passed value reach the backing field; plain no-accessor prop stays store-backed; a NON-CONSTRUCT setter does **not** fire at construct; post-construct round-trip).
- *(A transient 2-test "failure" was an artifact of `FORCE_COLOR` in the dev shell colorizing a boolean in a child process's `console.log` — passes with color off; CI is unaffected.)*
- **End-to-end: the Learn6502 `app-gnome` now boots and runs on node-gi/Node** — window up, all views + editor + GameConsole initialise, survives with **zero JS errors** (only non-fatal GTK4 CSS theme-parser warnings, an app-CSS quirk).

Reference: `refs/gjs/gi/gobject.cpp`. MIT.

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq