### PR TITLE
fix(rolldown-plugin-gjsify): lower CSS to GTK4 for node-gi

### DIFF
--- a/packages/infra/rolldown-plugin-gjsify/src/app/node.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/app/node.ts
@@ -287,7 +287,15 @@ export const setupForNode = async (input: NodeFactoryInput): Promise<NodeBuildCo
         // bundles. Same plugin the gjs/browser targets compose.
         blueprintPlugin() as RolldownPluginOption,
         deepkitPlugin({ reflection: input.pluginOptions.reflection }),
-        cssAsStringPlugin(),
+        // CSS-as-string. For a node-gi build (the reverse bridge runs REAL GTK on
+        // Node — `nodeGiGlobalsInject`, the same signal that keeps `@girs/*` bodies
+        // above), lower the CSS to GTK 4's subset with `firefox: 60 << 16` — exactly
+        // as `--app gjs` does — so modern authoring (nesting, `&`, …) is FLATTENED
+        // before it reaches `Gtk.CssProvider.load_from_string`. Without this GTK 4's
+        // CSS parser rejects nested rules at runtime ("Expected ';'/an identifier"
+        // theme-parser warnings, styles silently dropped — the Learn6502 app-gnome
+        // symptom). A plain-Node bundle (no node-gi) keeps the CSS pristine.
+        cssAsStringPlugin(input.pluginOptions.nodeGiGlobalsInject ? { targets: { firefox: 60 << 16 } } : {}),
         nodeModulesPathRewritePlugin({ bundleDir }),
     ];
 

--- a/tests/e2e/node-gi-build/run.mjs
+++ b/tests/e2e/node-gi-build/run.mjs
@@ -204,6 +204,37 @@ describe('--app node gi:// → node-gi bundle E2E', { timeout: 10 * 60 * 1000 },
             timeout: 30 * 1000,
         });
     });
+
+    it('lowers modern CSS (nesting) to GTK 4 subset for a node-gi build', () => {
+        // A node-gi build (the reverse bridge runs REAL GTK on Node) must FLATTEN
+        // authored CSS nesting so Gtk.CssProvider.load_from_string accepts it — GTK 4's
+        // CSS parser rejects nested rules. The lowering (lightningcss firefox60) is
+        // gated on nodeGiGlobalsInject, so the entry references a GJS ambient global
+        // (`print`) to mark it a node-gi build.
+        writeFileSync(
+            join(projectDir, 'src', 'style.css'),
+            '.card {\n  color: black;\n  &:hover { color: red; }\n  &.active { color: blue; }\n}\n',
+        );
+        writeFileSync(
+            join(projectDir, 'src', 'styled.ts'),
+            ["import css from './style.css';", 'print(css);', ''].join('\n'),
+        );
+
+        execFileSync('npx', ['gjsify', 'build', 'src/styled.ts', '--app', 'node', '--outfile', 'dist/styled.mjs'], {
+            cwd: projectDir,
+            stdio: 'pipe',
+            timeout: 90 * 1000,
+        });
+
+        const content = readFileSync(join(projectDir, 'dist', 'styled.mjs'), 'utf-8');
+        // Nesting flattened: nested selectors hoisted, the `&` combinator gone.
+        assert.ok(content.includes('.card:hover'), 'nested &:hover was not flattened to .card:hover');
+        assert.ok(content.includes('.card.active'), 'nested &.active was not flattened to .card.active');
+        assert.ok(
+            !content.includes('&:hover') && !content.includes('&.active'),
+            `raw CSS nesting (&) must not survive for a node-gi build\nContext: ${snippet(content, '&')}`,
+        );
+    });
 });
 
 /**


### PR DESCRIPTION
## What

`gjsify build --app node` composed css-as-string with **no** lightningcss targets, keeping CSS pristine. But the node-gi reverse bridge runs **real GTK** on Node, and GTK 4's CSS parser rejects modern authoring (nesting, `&`). An app that feeds `Gtk.CssProvider.load_from_string` a bundled stylesheet with nested rules gets a cascade of `Expected ';'` / `Expected an identifier` **theme-parser warnings** and silently-dropped styles — the Learn6502 `app-gnome` symptom on node-gi.

## How

Mirror `--app gjs` (`app/gjs.ts` already does this): pass `targets: { firefox: 60 << 16 }` to `cssAsStringPlugin`, so lightningcss **flattens** nesting to GTK 4's subset. Gated on `nodeGiGlobalsInject` — the same node-gi-build signal that keeps `@girs/*` bodies — so a plain-Node bundle keeps its CSS pristine.

```
- cssAsStringPlugin(),
+ cssAsStringPlugin(input.pluginOptions.nodeGiGlobalsInject ? { targets: { firefox: 60 << 16 } } : {}),
```

## Validated

- **e2e** (`tests/e2e/node-gi-build`): new case asserts a node-gi `--app node` build flattens `.card { &:hover }` → `.card:hover` (no `&` survives). Full suite **5/5**.
- **End-to-end**: the Learn6502 `app-gnome` boots on node-gi/Node with **zero** theme-parser warnings (was 10+) and zero JS errors — confirmed by rebuilding its `--app node` bundle with this fix (nesting count 1 → 0) and re-running.

This is independent of the node-gi runtime fixes (#785 / #786) — a build-tooling change.

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq