### PR TITLE
feat(node-gi): seed GtkSource-5 into the --windowing GTK bundles

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1475,21 +1475,18 @@ jobs:
           }
           Write-Host "--- icon themes ---"
           Get-ChildItem "$B/share/icons" -Directory -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
-          # GtkSource-5 (the Learn6502 editor's GtkSource.View backer). REPORTED, not
-          # asserted: it ships only if the gvsbuild GTK4 release ZIP includes
-          # gtksourceview5 — this surfaces whether it does. When present, the DLL is
-          # seeded (WINDOWING_SEED_PATTERNS), the typelib copied, and the
-          # language-specs/styles bundled (build step 4e). If absent here, a follow-up
-          # must build gtksourceview5 into the gvsbuild closure.
-          Write-Host "--- GtkSource-5 in the bundle? ---"
+          # GtkSource-5 (the Learn6502 editor's GtkSource.View backer). The gvsbuild
+          # GTK4 release ZIP ships gtksourceview5, so ASSERT the full closure landed:
+          # the DLL is seeded (WINDOWING_SEED_PATTERNS), the typelib copied, and the
+          # language-specs/styles bundled (build step 4e). A future gvsbuild that drops
+          # gtksourceview5 fails here loudly rather than silently shipping a bundle the
+          # editor can't load.
+          Write-Host "--- assert GtkSource-5 in the bundle ---"
           $srcDll = Get-ChildItem "$B/bin" -Filter '*gtksourceview-5*.dll' -ErrorAction SilentlyContinue
-          $srcTl  = Test-Path "$B/girepository-1.0/GtkSource-5.typelib"
-          $srcData = Test-Path "$B/share/gtksourceview-5/language-specs"
-          Write-Host ("  DLL: {0} | typelib: {1} | language-specs: {2}" -f `
-            (if ($srcDll) { $srcDll.Name } else { 'MISSING' }), $srcTl, $srcData)
-          if (-not $srcDll -or -not $srcTl) {
-            Write-Host "  NOTE: GtkSource-5 is NOT in the gvsbuild GTK4 release ZIP — the Learn6502 editor needs a follow-up to build gtksourceview5 into the Windows closure."
-          }
+          if (-not $srcDll) { Write-Host "libgtksourceview-5 DLL MISSING from the windowing bundle"; exit 1 }
+          if (-not (Test-Path "$B/girepository-1.0/GtkSource-5.typelib")) { Write-Host "GtkSource-5.typelib MISSING from the windowing bundle"; exit 1 }
+          if (-not (Test-Path "$B/share/gtksourceview-5/language-specs")) { Write-Host "GtkSource-5 language-specs MISSING from the windowing bundle"; exit 1 }
+          Write-Host ("GtkSource-5 OK: {0} + GtkSource-5.typelib + language-specs" -f $srcDll.Name)
 
       - name: Upload FULL-windowing GTK runtime bundle
         uses: actions/upload-artifact@v4

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -962,8 +962,8 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
     steps:
-      - name: Install GTK4 + Adwaita + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
+      - name: Install GTK4 + Adwaita + GtkSource + GObject-Introspection (build-time closure source)
+        run: brew install gtk4 libadwaita gtksourceview5 gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -979,7 +979,8 @@ jobs:
           name: node-gi-prebuild-darwin-arm64
           path: addon
 
-      # --windowing adds libadwaita (+ its otool deps) to the relocated closure.
+      # --windowing adds libadwaita + libgtksourceview (+ their otool deps) to the
+      # relocated closure.
       - name: Build + relocate the WINDOWING GTK runtime bundle
         run: |
           node packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs \
@@ -988,12 +989,15 @@ jobs:
             --addon "$PWD/addon/node_gi.node" \
             --stage packages/node-gi/node-gi/prebuilds/darwin-arm64
 
-      - name: Report bundle + assert libadwaita is present
+      - name: Report bundle + assert libadwaita + GtkSource are present
         run: |
           cat packages/node-gi/gtk-runtime-darwin-arm64/gtk/manifest.json
           echo "--- bundle size ---"; du -sh packages/node-gi/gtk-runtime-darwin-arm64/gtk
           echo "--- assert libadwaita relocated into the bundle ---"
           ls packages/node-gi/gtk-runtime-darwin-arm64/gtk/lib | grep -i adwaita || { echo "libadwaita MISSING from the windowing bundle"; exit 1; }
+          echo "--- assert libgtksourceview dylib + GtkSource-5 typelib are bundled ---"
+          ls packages/node-gi/gtk-runtime-darwin-arm64/gtk/lib | grep -i gtksourceview || { echo "libgtksourceview MISSING from the windowing bundle"; exit 1; }
+          ls packages/node-gi/gtk-runtime-darwin-arm64/gtk/girepository-1.0 | grep -i 'GtkSource-5.typelib' || { echo "GtkSource-5.typelib MISSING from the windowing bundle"; exit 1; }
           echo "--- assert NO /opt/homebrew refs remain ---"
           if otool -L packages/node-gi/gtk-runtime-darwin-arm64/gtk/lib/*.dylib | grep -F /opt/homebrew; then
             echo "RELOCATION FAILED: bundled dylibs still reference /opt/homebrew"; exit 1
@@ -1471,6 +1475,21 @@ jobs:
           }
           Write-Host "--- icon themes ---"
           Get-ChildItem "$B/share/icons" -Directory -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Name
+          # GtkSource-5 (the Learn6502 editor's GtkSource.View backer). REPORTED, not
+          # asserted: it ships only if the gvsbuild GTK4 release ZIP includes
+          # gtksourceview5 — this surfaces whether it does. When present, the DLL is
+          # seeded (WINDOWING_SEED_PATTERNS), the typelib copied, and the
+          # language-specs/styles bundled (build step 4e). If absent here, a follow-up
+          # must build gtksourceview5 into the gvsbuild closure.
+          Write-Host "--- GtkSource-5 in the bundle? ---"
+          $srcDll = Get-ChildItem "$B/bin" -Filter '*gtksourceview-5*.dll' -ErrorAction SilentlyContinue
+          $srcTl  = Test-Path "$B/girepository-1.0/GtkSource-5.typelib"
+          $srcData = Test-Path "$B/share/gtksourceview-5/language-specs"
+          Write-Host ("  DLL: {0} | typelib: {1} | language-specs: {2}" -f `
+            (if ($srcDll) { $srcDll.Name } else { 'MISSING' }), $srcTl, $srcData)
+          if (-not $srcDll -or -not $srcTl) {
+            Write-Host "  NOTE: GtkSource-5 is NOT in the gvsbuild GTK4 release ZIP — the Learn6502 editor needs a follow-up to build gtksourceview5 into the Windows closure."
+          }
 
       - name: Upload FULL-windowing GTK runtime bundle
         uses: actions/upload-artifact@v4

--- a/packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs
@@ -75,16 +75,21 @@ const SEED_PATTERNS = [
 ];
 
 // WINDOWING superset (opt-in via --windowing): also bundle libadwaita, whose dylib
-// backs the Adw-1 typelib. The display-free conformance closure never touches
-// Adwaita, so it is NOT a base seed — but the batteries-included bundle ships the
-// Adw-1 TYPELIB, so without libadwaita's dylib a real `new Adw.Application()` fails
-// with "Failed to load shared library 'libadwaita-1.0.dylib'" (→ Adw.Application is
-// not a constructible GObject type). This is exactly what the macOS GTK-GUI proof
-// (macos-gtk-windowing) needs; the recursive otool walk pulls libadwaita's
-// transitive deps + relocates them like any other seed. Mirrors the win32
-// --windowing superset (WINDOWING_SEED_PATTERNS there).
+// backs the Adw-1 typelib, AND libgtksourceview-5, whose dylib backs the GtkSource-5
+// typelib. The display-free conformance closure never touches Adwaita OR GtkSource,
+// so they are NOT base seeds — but the batteries-included bundle ships their TYPELIBS,
+// so without the dylibs a real `new Adw.Application()` / `new GtkSource.View()` fails
+// with "Failed to load shared library '…'" (→ the type is not a constructible
+// GObject). libgtksourceview backs the Learn6502 editor (a GtkSource.View subclass) —
+// the app-gnome node-gi port. This is exactly what the macOS GTK-GUI proof
+// (macos-gtk-windowing) needs; the recursive otool walk pulls each seed's transitive
+// deps + relocates them like any other seed. Mirrors the win32 --windowing superset
+// (WINDOWING_SEED_PATTERNS there). NB: GtkSource's runtime DATA (language-specs /
+// styles under share/gtksourceview-5) is a separate concern; the darwin bundle has no
+// share/ DATA step yet, so GtkSource CONSTRUCTS here but syntax-highlighting language
+// files are not bundled (tracked follow-up; the win32 bundle DOES ship them).
 const WINDOWING = process.argv.includes('--windowing');
-const WINDOWING_SEED_PATTERNS = [/^libadwaita-1\..*\.dylib$/];
+const WINDOWING_SEED_PATTERNS = [/^libadwaita-1\..*\.dylib$/, /^libgtksourceview-5\..*\.dylib$/];
 
 function isSystemPath(p) {
     return p.startsWith('/usr/lib/') || p.startsWith('/System/');
@@ -124,7 +129,7 @@ function resolveInBrew(leaf) {
 }
 
 // --- 1. discover the closure ----------------------------------------------
-console.log(`build-gtk-runtime: brew prefix ${brewPrefix}${WINDOWING ? ' (windowing superset — + libadwaita)' : ' (display-free)'}`);
+console.log(`build-gtk-runtime: brew prefix ${brewPrefix}${WINDOWING ? ' (windowing superset — + libadwaita + libgtksourceview)' : ' (display-free)'}`);
 const seedPatterns = WINDOWING ? [...SEED_PATTERNS, ...WINDOWING_SEED_PATTERNS] : SEED_PATTERNS;
 const seeds = readdirSync(brewLib).filter((f) => seedPatterns.some((re) => re.test(f)));
 if (seeds.length === 0) {

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -109,6 +109,7 @@ const SEED_PATTERNS = [
 // missing. (Gdk/Gsk/Gtk are all in gtk-4-*.dll, already a base seed.)
 const WINDOWING_SEED_PATTERNS = [
     /^(lib)?adwaita-1.*\.dll$/i, // gvsbuild leaf: adwaita-1-0.dll (backs the Adw-1 typelib)
+    /^(lib)?gtksourceview-5.*\.dll$/i, // gvsbuild leaf: gtksourceview-5-0.dll (backs the GtkSource-5 typelib — the Learn6502 editor)
     /^libEGL.*\.dll$/i,
     /^libGLESv2.*\.dll$/i,
     /^epoxy.*\.dll$/i,
@@ -294,7 +295,7 @@ console.log(`build-gtk-runtime: copied ${typelibCount} typelibs`);
 // partial gvsbuild layout still produces the DLL+typelib bundle. The DATA marker
 // node-gi keys on is gschemas.compiled; if that step fails the loader treats the
 // bundle as display-free (no windowing env wired).
-const windowing = { pixbufLoaders: 0, schemas: false, iconThemes: [], fontconfig: false };
+const windowing = { pixbufLoaders: 0, schemas: false, iconThemes: [], fontconfig: false, gtksource: false };
 if (WINDOWING) {
     // 4a. gdk-pixbuf loaders + a bundle-relative loaders.cache. The cache maps each
     // decoder DLL to its mime/extensions; gdk-pixbuf resolves the DLL paths in it
@@ -402,6 +403,31 @@ if (WINDOWING) {
         console.log('build-gtk-runtime: fontconfig config bundled');
     } else {
         console.log('build-gtk-runtime: no etc/fonts (pango uses the win32/DirectWrite backend) — skipping fontconfig');
+    }
+
+    // 4e. GtkSource-5 runtime DATA: the syntax-highlighting language definitions
+    // (share/gtksourceview-5/language-specs/*.lang) + style schemes
+    // (share/gtksourceview-5/styles/*.xml). GtkSource's LanguageManager /
+    // StyleSchemeManager load these from XDG_DATA_DIRS/gtksourceview-5 (node-gi
+    // prepends <bundle>/share), so without them the Learn6502 editor's GtkSource.View
+    // constructs but has no built-in languages/styles. Defensive: WARN + continue if
+    // gvsbuild's layout lacks the tree (the DLL + typelib still ship, so GtkSource
+    // itself works — only the bundled highlight data is absent).
+    const gtksourceSrc = join(PREFIX, 'share', 'gtksourceview-5');
+    if (existsSync(gtksourceSrc)) {
+        const gtksourceOut = join(OUT, 'share', 'gtksourceview-5');
+        let copied = 0;
+        for (const sub of ['language-specs', 'styles']) {
+            const subSrc = join(gtksourceSrc, sub);
+            if (existsSync(subSrc)) {
+                cpSync(subSrc, join(gtksourceOut, sub), { recursive: true });
+                copied += readdirSync(subSrc).length;
+            }
+        }
+        windowing.gtksource = copied > 0;
+        console.log(`build-gtk-runtime: GtkSource-5 data ${windowing.gtksource ? `bundled (${copied} language-specs/styles files)` : 'directory present but empty'}`);
+    } else {
+        console.warn(`build-gtk-runtime: WARNING — ${gtksourceSrc} missing; GtkSource-5 language-specs/styles NOT bundled (the editor's built-in highlighting will be unavailable)`);
     }
 }
 


### PR DESCRIPTION
## What

The batteries-included GTK-runtime bundles (`@gjsify/gtk-runtime-{darwin-arm64,win32-x64}`) seeded **libadwaita** into their `--windowing` superset but **not GtkSource-5**. macOS/Windows have no system GtkSource, so the **Learn6502** `app-gnome` node-gi port — whose editor is a `GtkSource.View` subclass — can't run there (`new GtkSource.View()` fails with *"Failed to load shared library 'libgtksourceview-5…'"*).

This is the OS-axis follow-on to the runtime work (#785/#786/#787), which got the app running clean on **Linux × {Node, Bun, Deno}**.

## Where the changes are

| File | Change |
|---|---|
| `packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs` | add `libgtksourceview-5` to `WINDOWING_SEED_PATTERNS` (dylib seed) |
| `packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs` | add `gtksourceview-5` DLL to `WINDOWING_SEED_PATTERNS` **+ new DATA step 4e** (copies `share/gtksourceview-5/{language-specs,styles}`) |
| `.github/workflows/node-gi.yml` | macOS runtime job `brew install`s `gtksourceview5` + **hard-asserts** dylib + `GtkSource-5.typelib` in the bundle; Windows job **reports** GtkSource presence |

The `GtkSource-5` typelib already rides the copy-all typelib step on both platforms; the seed pattern pulls the backing lib + its transitive deps via the recursive `otool`/`dumpbin` walk.

## Validation (CI — no local macOS/Windows)

- **macOS** hard-asserts (brew ships gtksourceview5) — validates the darwin seed.
- **Windows** reports whether the prebuilt gvsbuild GTK4 release ZIP includes gtksourceview5. If it does, the DLL + typelib + language-specs are bundled; if not, the report says so and a follow-up builds gtksourceview5 into the gvsbuild closure.

## Scope note

The **darwin** bundle has no `share/` DATA step yet (deferred follow-up), so GtkSource **constructs** on macOS but its language-specs/styles aren't bundled — highlighting data comes with the broader darwin windowing-DATA work. **win32** ships the full data (step 4e).

Independent of #785/#786/#787.

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq