### PR TITLE
feat(adwaita-web): isolate widgets from host CSS

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -942,6 +942,15 @@ gjsify trust @gjsify/adwaita-core             # configure Trusted Publisher
 
 Then strike this entry (precedent: the resolved `@gjsify/oxfmt-native` / `@gjsify/nativescript-vite` / `@gjsify/vite-plugin-gjsify` blockers below).
 
+### Follow-up — adwaita-web style isolation (ADR 0010)
+
+The style-isolation boundary reset (`scss/_reset.scss`, PR #789) landed the fix — a host page's inherited typography no longer leaks into embedded light-DOM widgets. Remaining:
+
+- Document the `--adw-*` / `--*` token set as the public theming contract on the website (it is now the sanctioned external-override API — the counterpart to the isolation).
+- If a second light-DOM Adwaita renderer ever appears, lift the boundary reset into `@gjsify/adwaita-core` (headless) so both share it, instead of duplicating.
+- Keep `$adw-components` in `_reset.scss` in sync with `src/elements/*` (`customElements.define('adw-…')`); guarded by `style-isolation.spec.ts`.
+- Shadow DOM stays a documented FUTURE option (ADR 0010), not adopted — revisit only if embedding into hostile third-party pages becomes a hard requirement (open roots + `adoptedStyleSheets` + `::part` + Declarative Shadow DOM).
+
 ### Follow-up — adopt `@gjsify/adwaita-app` in the shell consumers (ADR 0009)
 
 The package ships the native Adwaita app shell (runAsync lifecycle + devtools/CSS bootstrap, `createNavShell`, `loadIntoStack`/`LoadToken`, dialog/toast/file helpers, `readAppDevHooks`). Adoption is opportunistic, not a rewrite — wire each consumer onto it on its next shell touch, after the package is released:

--- a/docs/adr/0010-adwaita-web-style-isolation.md
+++ b/docs/adr/0010-adwaita-web-style-isolation.md
@@ -1,0 +1,92 @@
+# ADR 0010 — adwaita-web style isolation: light-DOM boundary reset + token contract
+
+- **Status:** Accepted (2026-07-24)
+- **Scope:** `@gjsify/adwaita-web` (Web pillar, published). Binds its consumers — the gjsify website docs, the browser storybook (`@gjsify/adwaita-storybook`), `easy6502` `app-web`, and the DOM showcases.
+
+## Context
+
+`@gjsify/adwaita-web` renders the Adwaita widget set as **light-DOM Custom Elements**
+styled by one global SCSS stylesheet (design-identity axis 4: carry Libadwaita into
+the browser so it *composes* with the page and stays themeable via the `--adw-*` /
+`--*` design tokens). Light DOM was a deliberate choice — it keeps the widgets
+overridable and trivially server-renderable (Astro docs/showcases paint them fully
+styled from server HTML, no FOUC).
+
+The open question (raised 2026-07): should the components move to **Shadow DOM** so
+they don't break visually when embedded in a host page with conflicting CSS? Shadow
+DOM would isolate them — but the isolation is symmetric: a shadow boundary blocks the
+host's CSS from leaking *in* **and** from *overriding* in. So naive Shadow DOM buys
+"don't break" at the cost of "can't override from outside", which is the exact
+friction we want to avoid. A shadow migration is also a real re-architecture
+(adopted stylesheets, a `::part`/token API to freeze, Declarative Shadow DOM for SSR,
+forms/ARIA-across-boundary care) and would regress the SSR-simplicity the consumers
+rely on.
+
+**Evidence (measured, not theoretical).** Dropping the real widgets into a
+deliberately hostile host theme (Georgia serif, purple text, `line-height: 2.3`,
+`letter-spacing`, generic `button`/`input` rules, a `* { box-sizing: content-box }`
+reset) showed the actual exposure: the components' *class-scoped* rules already win
+the box/border/background battles against realistic element-level host CSS; what
+leaks is **inherited typography** (`font-family`, `color`, `line-height`,
+`letter-spacing`, …) into text and elements the components don't explicitly pin, plus
+a `*`-reset reaching internal `box-sizing`. That is a narrow, fixable surface — it
+does not require Shadow DOM.
+
+A note on `@layer`: cascade layers are an *override-ergonomics* tool, not an isolation
+tool. Layered styles LOSE to un-layered styles regardless of specificity, so putting
+adwaita in a layer makes it *more* vulnerable to a host's un-layered resets — the
+wrong direction for "don't break". Layers are therefore explicitly not used here.
+
+## Decision
+
+Keep adwaita-web **light-DOM** and harden it, rather than migrate to Shadow DOM.
+
+1. **Style-isolation boundary reset** (`scss/_reset.scss`, `@use`d before the
+   component partials): every component's custom-element tag re-establishes the
+   Adwaita typographic + box-model context (`font-*`, `color`, `line-height`,
+   `letter-spacing`, `word-spacing`, `text-align/-indent/-transform/-shadow`,
+   `box-sizing`), so a host page's inherited typography stops at each widget
+   boundary. A descendant `box-sizing: border-box` pins the box model against a host
+   `* {}` reset. It is a FLOOR only — emitted first, so each component's own rules
+   override it, and no `!important` is used.
+
+2. **The `--adw-*` / `--*` design tokens are the public theming contract.** Consumers
+   re-theme through tokens (which cross any future shadow boundary unchanged) and
+   ordinary higher-specificity rules — light DOM keeps full overridability, the thing
+   Shadow DOM would take away.
+
+3. **Shadow DOM is the documented future option, not adopted now.** If embedding into
+   genuinely hostile third-party pages ever becomes a hard requirement, the path is:
+   **open** shadow roots + one shared constructable stylesheet via `adoptedStyleSheets`
+   + a deliberate `--adw-*` + `::part()` override API + Declarative Shadow DOM for SSR
+   + native `<slot>` (which would also retire the current querySelector slot
+   emulation). That is a separate ADR when/if triggered.
+
+4. **No dual-mode.** We do not ship a per-component light/shadow toggle — two styling
+   models would double the surface and the bugs.
+
+## Consequences
+
+- **Pro:** widgets survive a hostile host's typography without losing overridability;
+  SSR stays trivial (no shadow, no FOUC, no DSD plumbing); a small, low-risk,
+  additive change (one partial); no published-API break — only stronger defaults.
+- **Con:** not bulletproof against an *adversarial* host (`!important` on inherited
+  properties, or rules deliberately targeting `adw-*` internals with high
+  specificity) — that is the price of light DOM, and the escape hatch is the Shadow
+  DOM path above.
+- **Maintenance:** `$adw-components` in `_reset.scss` lists every custom-element tag
+  and must stay in sync with `src/elements/*` (the `customElements.define('adw-…')`
+  calls). Guarded by the style-isolation browser spec.
+- The `--adw-*` token set is now an intentional, documented public contract, not an
+  incidental implementation detail.
+
+## Implementation
+
+- `packages/web/adwaita-web/scss/_reset.scss` + `@use 'reset';` in `adwaita-skin.scss`.
+- Regression test: `src/style-isolation.spec.ts` (browser axis) embeds a widget in a
+  hostile-typography container and asserts its computed `font-family` stays Adwaita.
+- Validated on the real widgets: normal rendering unchanged; the hostile-host
+  typography leak is blocked (before/after captured during review).
+- Follow-ups (STATUS.md `## Open TODOs`): document the `--adw-*` token contract on the
+  website; consider lifting the boundary reset into `@gjsify/adwaita-core` if a second
+  light-DOM renderer ever needs it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ the TODO records the *what's left*.
 | [0007](0007-web-pillar-common-ui.md) | Web targets implement the shared controller/view layer (experiment) | Accepted |
 | [0008](0008-release-versioning-policy.md) | Release-train versioning policy for `@gjsify/*` | Accepted |
 | [0009](0009-native-adwaita-app-shell.md) | Native Adwaita app shell — extract the GTK application shell | Accepted |
+| [0010](0010-adwaita-web-style-isolation.md) | adwaita-web style isolation — light-DOM boundary reset + token contract | Accepted |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)
 (condensed findings + prioritized backlog).

--- a/packages/web/adwaita-web/scss/_reset.scss
+++ b/packages/web/adwaita-web/scss/_reset.scss
@@ -1,0 +1,69 @@
+// _reset.scss — style-isolation boundary for embedding in arbitrary host pages.
+//
+// adwaita-web renders as LIGHT-DOM custom elements (by design: the widgets
+// compose with the page and stay overridable via the `--adw-*` / `--*` design
+// tokens). The trade-off of light DOM is that a host page's *inherited*
+// typography — `font-family`, `color`, `line-height`, `letter-spacing`, … — and
+// generic element resets can leak into the widgets.
+//
+// This partial establishes an Adwaita typographic + box-model context at EVERY
+// component boundary, so inheritance from the host stops at the widget. It sets
+// only a FLOOR: it is `@use`d before the component partials, so each component's
+// own rules override it, and consumers keep full control through the tokens and
+// ordinary higher-specificity rules (isolation without giving up overriding).
+//
+// The box battles (borders, backgrounds) are already won by the components'
+// class-scoped rules against realistic element-level host CSS; the real leak is
+// inherited typography + a host `* {}` box-sizing reset, which is what this
+// neutralises.
+
+// Every custom element adwaita-web defines. Keep in sync with
+// `src/elements/*` (the `customElements.define('adw-…')` calls).
+$adw-components:
+  adw-about-dialog, adw-action-row, adw-alert-dialog, adw-alert-response,
+  adw-avatar, adw-banner, adw-bottom-sheet, adw-bottom-sheet-content,
+  adw-bottom-sheet-sheet, adw-button, adw-button-content, adw-button-row,
+  adw-card, adw-carousel, adw-carousel-indicator-dots,
+  adw-carousel-indicator-lines, adw-clamp, adw-combo-row, adw-data-grid,
+  adw-dialog, adw-drop-down, adw-entry, adw-entry-row, adw-expander-row,
+  adw-header-bar, adw-inline-view-switcher, adw-menu-button, adw-navigation-page,
+  adw-navigation-split-view, adw-navigation-view, adw-overlay-split-view,
+  adw-password-entry-row, adw-preferences-dialog, adw-preferences-group,
+  adw-preferences-page, adw-sidebar, adw-sidebar-item, adw-sidebar-section,
+  adw-spinner, adw-spin-row, adw-split-button, adw-status-page, adw-switch-row,
+  adw-tab-page, adw-tab-view, adw-toast-overlay, adw-toggle, adw-toggle-group,
+  adw-toolbar-view, adw-view-stack, adw-view-stack-page, adw-view-switcher,
+  adw-view-switcher-bar, adw-view-switcher-page, adw-window, adw-window-title,
+  adw-wrap-box;
+
+// Roots: re-root the inherited typographic properties (and the box model) so a
+// host page's font / colour / spacing cannot flow into the widget. Every value
+// is the Adwaita default; a component that wants something else overrides it on
+// its own element (this rule is emitted first).
+#{$adw-components} {
+  box-sizing: border-box;
+  color: var(--window-fg-color);
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  font-weight: 400;
+  font-style: normal;
+  font-variant: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  word-spacing: normal;
+  text-align: start;
+  text-indent: 0;
+  text-transform: none;
+  text-shadow: none;
+}
+
+// Descendants: `box-sizing` does not inherit, so a host `*, *::before {
+// box-sizing: content-box }` reset would still reach internal elements. Pin it
+// to `border-box` (adwaita's model throughout) inside every component.
+@each $c in $adw-components {
+  #{$c} *,
+  #{$c} *::before,
+  #{$c} *::after {
+    box-sizing: border-box;
+  }
+}

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -10,6 +10,9 @@
 @use 'variables';
 @use 'theme';
 @use 'root';
+// Style-isolation boundary — emitted before the components so their own rules
+// override this typographic/box-model floor (see _reset.scss).
+@use 'reset';
 @use 'window';
 @use 'headerbar';
 @use 'window_title';

--- a/packages/web/adwaita-web/src/style-isolation.spec.ts
+++ b/packages/web/adwaita-web/src/style-isolation.spec.ts
@@ -1,0 +1,36 @@
+// Style-isolation regression test (browser axis). Guards the boundary reset
+// (scss/_reset.scss, ADR 0010): a host page's inherited typography must not leak
+// into an adwaita-web widget. It also guards that the widget's tag is listed in
+// the reset's `$adw-components` — if it weren't, the reset wouldn't apply and
+// these assertions would fail.
+import { describe, expect, it } from '@gjsify/unit';
+
+export const AdwStyleIsolationTest = async () => {
+    await describe('style isolation (boundary reset)', async () => {
+        await it('re-roots typography so a host font does not inherit into a widget', async () => {
+            // A container styled like a hostile host theme.
+            const host = document.createElement('div');
+            host.style.fontFamily = 'Georgia, "Times New Roman", serif';
+            host.style.color = 'rgb(255, 0, 255)';
+            host.style.lineHeight = '2.4';
+            host.style.letterSpacing = '3px';
+            host.style.textTransform = 'uppercase';
+            document.body.appendChild(host);
+
+            const row = document.createElement('adw-switch-row');
+            row.setAttribute('title', 'Wi-Fi');
+            host.appendChild(row);
+
+            const cs = getComputedStyle(row);
+            // The boundary reset re-roots the inherited typography to Adwaita's,
+            // so the host's serif / magenta / spacing / casing do not leak in.
+            expect(cs.fontFamily.includes('Adwaita Sans')).toBe(true);
+            expect(cs.fontFamily.includes('Georgia')).toBe(false);
+            expect(cs.letterSpacing).toBe('normal');
+            expect(cs.textTransform).toBe('none');
+            expect(cs.color === 'rgb(255, 0, 255)').toBe(false);
+
+            host.remove();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -12,5 +12,6 @@ import { AdwDataGridTest } from './adw-data-grid.spec.js';
 import { AdwDialogTest } from './adw-dialog.spec.js';
 import { AdwDropDownTest } from './adw-drop-down.spec.js';
 import { AdwTabViewTest } from './adw-tab-view.spec.js';
+import { AdwStyleIsolationTest } from './style-isolation.spec.js';
 
-run({ AdwButtonRowTest, AdwDataGridTest, AdwDialogTest, AdwDropDownTest, AdwTabViewTest });
+run({ AdwButtonRowTest, AdwDataGridTest, AdwDialogTest, AdwDropDownTest, AdwTabViewTest, AdwStyleIsolationTest });


### PR DESCRIPTION
## What

Harden `@gjsify/adwaita-web` against a host page's CSS when its light-DOM widgets are embedded elsewhere, **without** giving up external overridability.

- New **style-isolation boundary reset** (`scss/_reset.scss`, `@use`d before the component partials): every component's custom-element tag re-roots the Adwaita typographic + box-model context (`font-*`, `color`, `line-height`, `letter-spacing`, `word-spacing`, `text-*`, `box-sizing`), so a host page's *inherited* typography stops at each widget boundary. Floor only — no `!important`, components override it, consumers keep full control via the `--adw-*` tokens.
- **ADR 0010** records the decision: light-DOM-hardened + token contract; **not** Shadow DOM (its isolation also blocks external overriding, regresses SSR, and is a full re-architecture — documented as the future option if hostile third-party embedding ever becomes a hard requirement); **not** `@layer` (layered styles lose to un-layered host CSS — the wrong direction for isolation).
- **Browser regression spec** (`src/style-isolation.spec.ts`) asserts a host font does not inherit into a widget.

## Evidence

Measured on the real widgets in a deliberately hostile host theme (Georgia serif, purple text, `line-height: 2.3`, `letter-spacing`, generic `button`/`input`, `* { box-sizing: content-box }`):

- **Before:** widget text rendered in the host's serif/purple with the host's spacing; the box/border/background survived (adwaita's class rules already win those).
- **After:** typography snaps back to Adwaita Sans / correct colour / correct spacing; **normal (non-hostile) rendering is unchanged.**

## Notes

- `$adw-components` in `_reset.scss` lists every `adw-*` tag and must stay in sync with `src/elements/*`; the new spec guards this for a representative widget.
- Scope kept to the code + ADR + test. The ADR's follow-ups (document the `--adw-*` token contract on the website; consider lifting the reset into `@gjsify/adwaita-core` if a second light-DOM renderer appears) should be added to `STATUS.md` `## Open TODOs` — left out here to avoid churn on that file.

https://claude.ai/code/session_01UrWi3dWmz4Gy61TkuMifJx