### PR TITLE
fix(adwaita-storybook): render Columns toggle icon

### DIFF
--- a/showcases/gtk/adwaita-storybook/src/browser/buttons/toggle-group.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/buttons/toggle-group.web.ts
@@ -7,12 +7,14 @@ import { toggleGroupMeta } from '../../buttons/toggle-group.meta.js';
 
 const STYLE_CLASSES = ['flat', 'round'] as const;
 
-// The three toggles, mirroring the native demo. (`view-dual` stands in for the
-// native `view-columns-symbolic` — the closest icon in @gjsify/adwaita-icons.)
+// The three toggles, mirroring the native demo. `view-columns` matches the
+// native `view-columns-symbolic`; @gjsify/adwaita-web supplies that glyph (it is
+// not in the vendored icon theme, so build-scss adds it). The previous
+// `view-dual` name had no `.adw-icon--*` rule and rendered blank.
 const TOGGLES: ReadonlyArray<{ label: string; icon: string }> = [
     { label: 'List', icon: 'view-list' },
     { label: 'Grid', icon: 'view-grid' },
-    { label: 'Columns', icon: 'view-dual' },
+    { label: 'Columns', icon: 'view-columns' },
 ];
 
 export class ToggleGroupWebStory extends StoryElement {


### PR DESCRIPTION
The browser **Toggle Group** story set the Columns toggle's icon to `view-dual`, which has no `.adw-icon--*` rule in `@gjsify/adwaita-web` and rendered **blank**. Switch to `view-columns` — adwaita-web already supplies that glyph (build-scss hand-adds it, since it is not in the vendored icon theme) and it matches the native `view-columns-symbolic` the GTK story uses.

Verified: `view-columns` renders in the browser (it is the icon the website's widget gallery already uses for this toggle).

Note (follow-up, not in this PR): `view-columns-symbolic` still isn't in `@gjsify/adwaita-icons` (generated from the theme), so the NativeScript story falls back to `view-paged`. Lifting the glyph into a manual-icons provision in adwaita-icons would let all three renderers unify on `view-columns` and drop the build-scss workaround.

https://claude.ai/code/session_01UrWi3dWmz4Gy61TkuMifJx