### PR TITLE
ci(node-gi): also ship the linux-arm64 prebuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,20 +452,30 @@ jobs:
   # once for this repo + release.yml (a maintainer runs `gjsify trust`, exactly like
   # the gtk-runtime bootstrap) — OIDC cannot self-bootstrap its own trust.
   #
-  # Build the linux-x64 node-gi prebuild so the published tarball SHIPS it. node-gi's
-  # `files` includes `prebuilds`, `index.js` prefers a prebuild, and Deno (which runs
-  # NO install script) can only load a prebuild — but nothing staged one, so 0.20/0.21
-  # shipped none: node/bun consumers had to `node-gyp rebuild` at install time and a
-  # `gjsify install` consumer (which does not run the `install` script) or Deno got no
-  # binary at all. Built in the SAME Fedora container node-gi.yml uses (proven GLib/GI
-  # ABI) via `npm install` (runs node-gi's `install` = node-gyp rebuild) + stage-prebuild,
-  # then handed to publish-node-gi as an artifact staged into prebuilds/ before publish.
+  # Build the linux node-gi prebuilds (x64 + arm64) so the published tarball SHIPS
+  # them. node-gi's `files` includes `prebuilds`, `index.js` prefers a prebuild, and
+  # Deno (which runs NO install script) can only load a prebuild — but nothing staged
+  # one, so 0.20/0.21 shipped none: node/bun consumers had to `node-gyp rebuild` at
+  # install time and a `gjsify install` consumer (which does not run the `install`
+  # script) or Deno got no binary at all. Built in the SAME Fedora container node-gi.yml
+  # uses (proven GLib/GI ABI) via `npm install` (runs node-gi's `install` = node-gyp
+  # rebuild) + stage-prebuild, on a native runner per arch (x64 = ubuntu-latest, arm64 =
+  # ubuntu-24.04-arm — no QEMU), then handed to publish-node-gi as artifacts staged into
+  # prebuilds/ before publish.
   node-gi-prebuild-linux:
-    name: Build @gjsify/node-gi linux-x64 prebuild
+    name: Build @gjsify/node-gi linux-${{ matrix.arch }} prebuild
     needs: publish
     if: ${{ (github.event_name == 'release' || inputs.skip_publish == false) && inputs.verify_only != true }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     container:
       image: fedora:44
     steps:
@@ -483,8 +493,9 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
       # `npm install --foreground-scripts` runs node-gi's `install` (node-gyp rebuild)
-      # → build/Release/node_gi.node; stage-prebuild copies it to prebuilds/linux-x64.
-      - name: Build + stage the linux-x64 prebuild
+      # → build/Release/node_gi.node; stage-prebuild copies it to prebuilds/linux-<arch>
+      # (process.arch = x64 | arm64 on the native runner).
+      - name: Build + stage the linux-${{ matrix.arch }} prebuild
         working-directory: packages/node-gi/node-gi
         run: |
           npm install --no-audit --no-fund --foreground-scripts
@@ -493,7 +504,7 @@ jobs:
       - name: Upload the prebuild artifact
         uses: actions/upload-artifact@v4
         with:
-          name: node-gi-prebuild-linux-x64
+          name: node-gi-prebuild-linux-${{ matrix.arch }}
           path: packages/node-gi/node-gi/prebuilds/
           if-no-files-found: error
 
@@ -514,15 +525,17 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
 
-      # Stage the linux-x64 prebuild (from node-gi-prebuild-linux) into the package's
-      # prebuilds/ dir BEFORE publish, so the tarball ships it (prebuilds is in node-gi's
-      # `files`). Downloads into prebuilds/linux-x64/node_gi.node.
-      - name: Download + stage the linux-x64 prebuild
+      # Stage the linux prebuilds (x64 + arm64, from the node-gi-prebuild-linux matrix)
+      # into the package's prebuilds/ dir BEFORE publish, so the tarball ships them
+      # (prebuilds is in node-gi's `files`). merge-multiple flattens both artifacts into
+      # prebuilds/{linux-x64,linux-arm64}/node_gi.node.
+      - name: Download + stage the linux prebuilds (x64 + arm64)
         uses: actions/download-artifact@v4
         with:
-          name: node-gi-prebuild-linux-x64
+          pattern: node-gi-prebuild-linux-*
+          merge-multiple: true
           path: packages/node-gi/node-gi/prebuilds/
-      - name: Confirm the prebuild is staged
+      - name: Confirm the prebuilds are staged
         run: ls -la packages/node-gi/node-gi/prebuilds/*/node_gi.node
 
       # No `registry-url` (it would inject a placeholder NODE_AUTH_TOKEN and defeat


### PR DESCRIPTION
## What (task #71)

PR #792 shipped the **linux-x64** node-gi prebuild in the release. This adds **linux-arm64** so 0.22.0+ ships both — no `node-gyp` build on either arch (and Deno, which can't build, works on both).

## How

- `node-gi-prebuild-linux` becomes a per-arch matrix: **x64** on `ubuntu-latest`, **arm64** on **`ubuntu-24.04-arm`** (native GitHub arm64 runner — no QEMU). Each builds in the Fedora container (`npm install --foreground-scripts` → node-gyp rebuild + `stage-prebuild.mjs`) and uploads `node-gi-prebuild-linux-<arch>`.
- `publish-node-gi` downloads both via `pattern: node-gi-prebuild-linux-*` + `merge-multiple`, staging `prebuilds/{linux-x64,linux-arm64}/node_gi.node` before `gjsify publish`.

## Validation

CI-validated on the **next release** (release-workflow, not PR-triggered). The build step is unchanged from #792 (proven); only the arch matrix + the download pattern are new.

Follow-on to #792 / the node-gi 0.21.0 prebuild gap.

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq