### PR TITLE
feat(node-gi): darwin --windowing DATA (schemas/icons/gtksource)

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -962,8 +962,8 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
     steps:
-      - name: Install GTK4 + Adwaita + GtkSource + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gtksourceview5 gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
+      - name: Install GTK4 + Adwaita + GtkSource + icons + GObject-Introspection (build-time closure source)
+        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -998,6 +998,11 @@ jobs:
           echo "--- assert libgtksourceview dylib + GtkSource-5 typelib are bundled ---"
           ls packages/node-gi/gtk-runtime-darwin-arm64/gtk/lib | grep -i gtksourceview || { echo "libgtksourceview MISSING from the windowing bundle"; exit 1; }
           ls packages/node-gi/gtk-runtime-darwin-arm64/gtk/girepository-1.0 | grep -i 'GtkSource-5.typelib' || { echo "GtkSource-5.typelib MISSING from the windowing bundle"; exit 1; }
+          echo "--- assert WINDOWING DATA: compiled GSettings schemas (Gio.Settings) + GtkSource language-specs ---"
+          B=packages/node-gi/gtk-runtime-darwin-arm64/gtk
+          test -f "$B/share/glib-2.0/schemas/gschemas.compiled" || { echo "gschemas.compiled MISSING — Gio.Settings would fail on macOS"; exit 1; }
+          test -d "$B/share/gtksourceview-5/language-specs" || { echo "GtkSource-5 language-specs MISSING from the windowing bundle"; exit 1; }
+          echo "--- icon themes present (Adwaita/hicolor) ---"; ls "$B/share/icons" 2>/dev/null || echo "(no icon themes — symbolic icons may be blank)"
           echo "--- assert NO /opt/homebrew refs remain ---"
           if otool -L packages/node-gi/gtk-runtime-darwin-arm64/gtk/lib/*.dylib | grep -F /opt/homebrew; then
             echo "RELOCATION FAILED: bundled dylibs still reference /opt/homebrew"; exit 1

--- a/packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-darwin-arm64/scripts/build-gtk-runtime.mjs
@@ -195,6 +195,84 @@ if (existsSync(brewTypelibs)) {
 }
 console.log(`build-gtk-runtime: copied ${typelibCount} typelibs`);
 
+// --- 3b. WINDOWING data (schemas / icons / gtksource) ---------------------
+// The runtime DATA a REAL app needs beyond the dylibs+typelibs: compiled GSettings
+// schemas (Gio.Settings — a HARD startup blocker without them), the Adwaita/hicolor
+// icon themes, and GtkSource's language-specs/styles. These are plain files (no dylib
+// relocation), located at runtime via GSETTINGS_SCHEMA_DIR / XDG_DATA_DIRS (node-gi's
+// gtk-runtime.js maybeWireGtkWindowingEnv keys on the gschemas.compiled marker). Gated
+// on --windowing; the display-free bundle is byte-unchanged. NB the gdk-pixbuf image
+// LOADERS (needed to render SVG symbolic icons) are NOT bundled yet — they are dylibs
+// that need @loader_path relocation from a NESTED dir (unlike win32's plain DLL copy);
+// tracked follow-up, so symbolic icons may be blank until then.
+const windowing = { schemas: false, iconThemes: [], gtksource: false };
+if (WINDOWING) {
+    const brewShare = join(brewPrefix, 'share');
+    const findTool = (leaf) => {
+        const inBrew = join(brewPrefix, 'bin', leaf);
+        return existsSync(inBrew) ? inBrew : leaf; // fall back to PATH
+    };
+
+    // 3b-a. Compiled GSettings schemas + (re)compile gschemas.compiled — also the
+    // windowing-data marker node-gi's loader detects.
+    const schemasSrc = join(brewShare, 'glib-2.0', 'schemas');
+    if (existsSync(schemasSrc)) {
+        const schemasOut = join(OUT, 'share', 'glib-2.0', 'schemas');
+        mkdirSync(schemasOut, { recursive: true });
+        for (const f of readdirSync(schemasSrc)) {
+            if (f.endsWith('.xml') || f.endsWith('.gschema.override') || f === 'gschemas.compiled') {
+                copyFileSync(join(schemasSrc, f), join(schemasOut, f));
+            }
+        }
+        try {
+            execFileSync(findTool('glib-compile-schemas'), [schemasOut]);
+        } catch (err) {
+            console.warn(`build-gtk-runtime: WARNING — glib-compile-schemas failed: ${err?.message ?? err}`);
+        }
+        windowing.schemas = existsSync(join(schemasOut, 'gschemas.compiled'));
+        console.log(`build-gtk-runtime: GSettings schemas ${windowing.schemas ? 'compiled' : 'copied (no gschemas.compiled!)'}`);
+    } else {
+        console.warn(`build-gtk-runtime: WARNING — ${schemasSrc} missing; GSettings schemas NOT bundled (Gio.Settings will fail)`);
+    }
+
+    // 3b-b. Icon themes (Adwaita symbolic + hicolor) + caches, loaded from
+    // XDG_DATA_DIRS/icons/<theme>/.
+    const updateIconCache = findTool('gtk4-update-icon-cache');
+    for (const theme of ['Adwaita', 'hicolor']) {
+        const themeSrc = join(brewShare, 'icons', theme);
+        if (!existsSync(themeSrc)) continue;
+        cpSync(themeSrc, join(OUT, 'share', 'icons', theme), { recursive: true });
+        try {
+            execFileSync(updateIconCache, ['-q', '-t', '-f', join(OUT, 'share', 'icons', theme)]);
+        } catch {
+            // an existing icon-theme.cache from the copy is a usable fallback
+        }
+        windowing.iconThemes.push(theme);
+    }
+    console.log(
+        windowing.iconThemes.length
+            ? `build-gtk-runtime: icon themes ${windowing.iconThemes.join(', ')}`
+            : 'build-gtk-runtime: WARNING — no Adwaita/hicolor icon theme under share/icons',
+    );
+
+    // 3b-c. GtkSource-5 language-specs + styles (the editor's syntax highlighting).
+    const gtksourceSrc = join(brewShare, 'gtksourceview-5');
+    if (existsSync(gtksourceSrc)) {
+        let copied = 0;
+        for (const sub of ['language-specs', 'styles']) {
+            const subSrc = join(gtksourceSrc, sub);
+            if (existsSync(subSrc)) {
+                cpSync(subSrc, join(OUT, 'share', 'gtksourceview-5', sub), { recursive: true });
+                copied += readdirSync(subSrc).length;
+            }
+        }
+        windowing.gtksource = copied > 0;
+        console.log(`build-gtk-runtime: GtkSource-5 data ${windowing.gtksource ? `bundled (${copied} files)` : 'empty'}`);
+    } else {
+        console.warn(`build-gtk-runtime: WARNING — ${gtksourceSrc} missing; GtkSource-5 data NOT bundled`);
+    }
+}
+
 // --- 4. optional: relocate a copy of the node-gi addon --------------------
 // The addon (built against Homebrew) carries absolute /opt/homebrew refs. Rewrite
 // them to @rpath/<leaf> + add an rpath to the SIBLING bundle so it loads the
@@ -237,15 +315,20 @@ function dirSize(dir) {
 }
 const libBytes = dirSize(libOut);
 const typelibBytes = dirSize(typelibOut);
+const shareOut = join(OUT, 'share');
+const dataBytes = WINDOWING && existsSync(shareOut) ? dirSize(shareOut) : 0;
 const manifest = {
     platform: 'darwin-arm64',
+    windowing: WINDOWING,
     generatedFrom: brewPrefix,
     dylibs: bundledLeaves.size,
     typelibs: typelibCount,
     libBytes,
     typelibBytes,
-    totalBytes: libBytes + typelibBytes,
+    dataBytes,
+    totalBytes: libBytes + typelibBytes + dataBytes,
     dylibList: [...bundledLeaves].sort(),
+    ...(WINDOWING ? { windowingData: windowing } : {}),
 };
 writeFileSync(join(OUT, 'manifest.json'), JSON.stringify(manifest, null, 2));
 

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -158,7 +158,12 @@ export function maybePrependGtkRuntimeDllPath() {
  * @returns {void}
  */
 export function maybeWireGtkWindowingEnv() {
-    if (process.platform !== 'win32') return; // strict no-op on every non-win32 runtime
+    // win32 AND darwin ship a batteries-included --windowing bundle whose runtime
+    // DATA (gschemas / icons / loaders / gtksource / fonts) is located by these env
+    // vars — GLib/GTK read them at init, not at launch (unlike dyld's DYLD_FALLBACK),
+    // so setting them in-process works on both. The only platform difference is the
+    // XDG_DATA_DIRS separator (';' on win32, ':' on unix/darwin).
+    if (process.platform !== 'win32' && process.platform !== 'darwin') return;
     const bundle = resolveGtkRuntimeBundle();
     if (!bundle) return; // strict no-op when no bundle is present
 
@@ -166,6 +171,7 @@ export function maybeWireGtkWindowingEnv() {
     // gschemas.compiled = the windowing-data marker; absent → display-free bundle.
     if (!existsSync(join(schemaDir, 'gschemas.compiled'))) return;
 
+    const pathSep = process.platform === 'win32' ? ';' : ':';
     const setIfUnset = (name, value) => {
         if (!process.env[name]) process.env[name] = value;
     };
@@ -177,11 +183,13 @@ export function maybeWireGtkWindowingEnv() {
         setIfUnset('GDK_PIXBUF_MODULE_FILE', loaderCache);
     }
 
+    // XDG_DATA_DIRS → <bundle>/share so the icon themes (share/icons) AND GtkSource's
+    // language-specs/styles (share/gtksourceview-5) resolve.
     const shareDir = join(bundle.dir, 'share');
-    if (existsSync(join(shareDir, 'icons'))) {
+    if (existsSync(shareDir)) {
         const cur = process.env.XDG_DATA_DIRS ?? '';
-        if (!cur.split(';').filter(Boolean).includes(shareDir)) {
-            process.env.XDG_DATA_DIRS = cur ? `${shareDir};${cur}` : shareDir;
+        if (!cur.split(pathSep).filter(Boolean).includes(shareDir)) {
+            process.env.XDG_DATA_DIRS = cur ? `${shareDir}${pathSep}${cur}` : shareDir;
         }
     }
 


### PR DESCRIPTION
## What (task #66 / #72)

The darwin gtk-runtime bundle copied only **dylibs + typelibs**, no `share/` DATA — so the full **Learn6502** app can't run on macOS: `Gio.Settings` fails **hard** without compiled GSettings schemas, the editor has no GtkSource highlight data, and there's no icon theme. Add a `--windowing` DATA step (mirroring win32's, the no-relocation parts).

## How

- **`build-gtk-runtime.mjs` (darwin):** compile + bundle GSettings schemas (`gschemas.compiled` — also the windowing-data marker), copy Adwaita/hicolor icon themes (+ cache), copy GtkSource-5 `language-specs`/`styles` — under `<bundle>/share`, gated on `--windowing`. Manifest gains `windowingData` + `dataBytes`.
- **`gtk-runtime.js`:** generalize `maybeWireGtkWindowingEnv` from win32-only to **win32 + darwin** — the DATA env (`GSETTINGS_SCHEMA_DIR` / `XDG_DATA_DIRS` / `GDK_PIXBUF_*` / `FONTCONFIG_*`) is read by GLib/GTK at init on both; only the `XDG_DATA_DIRS` separator differs (`;` vs `:`). `XDG_DATA_DIRS → <bundle>/share` covers both icons **and** gtksourceview-5 data.
- **`node-gi.yml`:** the macOS windowing job `brew install`s `adwaita-icon-theme` and asserts `gschemas.compiled` + GtkSource `language-specs` land in the bundle.

## Scope note

The **gdk-pixbuf image loaders** (SVG symbolic-icon rendering) are **not** bundled yet — unlike win32's plain DLL copy, they are dylibs needing `@loader_path` relocation from a **nested** dir; tracked follow-up, so symbolic icons may be blank on macOS until then. `Gio.Settings` + GtkSource — the **hard** blockers — now work.

CI-validated (no macOS locally). Follow-on to #788 (which seeded the GtkSource dylib+typelib for darwin).

Claude-Session: https://claude.ai/code/session_01P5YTfM4iJDTP37134QcPKq