### PR TITLE
fix(adwaita-web): hide view-switcher-bar when unrevealed

### DIFF
--- a/packages/web/adwaita-web/scss/_view_switcher_bar.scss
+++ b/packages/web/adwaita-web/scss/_view_switcher_bar.scss
@@ -11,6 +11,16 @@
 
 adw-view-switcher-bar {
     display: block;
+
+    // `revealed` drives visibility by toggling the `hidden` attribute
+    // (_applyRevealed → this.hidden). Re-assert display:none for [hidden] as an
+    // AUTHOR rule: the UA `[hidden] { display: none }` loses to this block's own
+    // author `display: block` (cascade ORIGIN beats specificity), so without this
+    // an unrevealed bar would stay visible. Author + higher specificity → wins.
+    &[hidden] {
+        display: none;
+    }
+
     box-sizing: border-box;
     // The bottom bar over a headerbar-toned surface with a top hairline (the
     // libadwaita `actionbar` inset top border), NOT a bottom border.

--- a/packages/web/adwaita-web/src/adw-view-switcher-bar.spec.ts
+++ b/packages/web/adwaita-web/src/adw-view-switcher-bar.spec.ts
@@ -1,0 +1,31 @@
+// adw-view-switcher-bar visibility regression (browser axis). Guards that the
+// `revealed` flag actually shows/hides the bar. The bar's base scss sets
+// `display: block`, an AUTHOR rule that would defeat the UA `[hidden]{display:none}`
+// the component relies on (cascade origin beats specificity) — so an unrevealed
+// bar rendered visible until scss/_view_switcher_bar.scss re-asserted
+// `&[hidden] { display: none }`. This test pins that fix.
+import { describe, expect, it } from '@gjsify/unit';
+
+export const AdwViewSwitcherBarTest = async () => {
+    await describe('adw-view-switcher-bar revealed → visibility', async () => {
+        await it('is display:none by default (not revealed) and block once revealed', async () => {
+            const bar = document.createElement('adw-view-switcher-bar');
+            document.body.appendChild(bar);
+
+            // Default: `revealed` absent → the component sets `hidden`, and the
+            // scss `[hidden]` author rule must win over the base `display: block`.
+            expect(bar.hasAttribute('revealed')).toBe(false);
+            expect(getComputedStyle(bar).display).toBe('none');
+
+            // Reveal it → shown.
+            bar.setAttribute('revealed', '');
+            expect(getComputedStyle(bar).display).toBe('block');
+
+            // Hide it again → back to none (the round-trip, not a one-way latch).
+            bar.removeAttribute('revealed');
+            expect(getComputedStyle(bar).display).toBe('none');
+
+            bar.remove();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -12,6 +12,15 @@ import { AdwDataGridTest } from './adw-data-grid.spec.js';
 import { AdwDialogTest } from './adw-dialog.spec.js';
 import { AdwDropDownTest } from './adw-drop-down.spec.js';
 import { AdwTabViewTest } from './adw-tab-view.spec.js';
+import { AdwViewSwitcherBarTest } from './adw-view-switcher-bar.spec.js';
 import { AdwStyleIsolationTest } from './style-isolation.spec.js';
 
-run({ AdwButtonRowTest, AdwDataGridTest, AdwDialogTest, AdwDropDownTest, AdwTabViewTest, AdwStyleIsolationTest });
+run({
+    AdwButtonRowTest,
+    AdwDataGridTest,
+    AdwDialogTest,
+    AdwDropDownTest,
+    AdwTabViewTest,
+    AdwViewSwitcherBarTest,
+    AdwStyleIsolationTest,
+});


### PR DESCRIPTION
## The bug

`adw-view-switcher-bar` drives its visibility off the `revealed` flag by toggling
the `hidden` attribute (`_applyRevealed()` → `this.hidden`). But the bar's base
scss sets `display: block` — an **author-origin** rule that defeats the UA
`[hidden] { display: none }`, because cascade **origin** beats specificity (an
author `display` declaration always wins over the UA sheet). So an *unrevealed*
bar stayed **visible**: `revealed` looked like a no-op, and a consumer had to hide
the bar with its own CSS instead of the widget's own contract.

## The fix

Re-assert `display: none` for `[hidden]` as an **author** rule inside the component
block:

```scss
adw-view-switcher-bar {
    display: block;
    &[hidden] { display: none; }   // author + specificity 0,1,1 > base 0,0,1
    …
}
```

Now the `revealed` ⇄ `hidden` contract actually renders. Nothing else changes —
the component logic (`_applyRevealed` still sets `this.hidden`, keeping the bar out
of the a11y tree too) is untouched.

## Test

New browser-axis regression spec `adw-view-switcher-bar.spec.ts` (registered in
`test.browser.mts`), same `getComputedStyle` pattern as `style-isolation.spec.ts`:
a default bar is `display: none`, `setAttribute('revealed','')` → `block`, remove →
`none` (asserts the round-trip, not a one-way latch).

## Verification

- `gjsify run build:scss` — compiled; `adw-view-switcher-bar[hidden]{display:none}`
  present in the generated stylesheet.
- `gjsify tsc --noEmit` (check) — clean.
- `gjsify run build:test:browser` — the browser test bundle (incl. the new spec)
  compiles. The Playwright browser leg runs it in CI.

## Context

Surfaced by the buchhaltung review UI adopting `adw-view-switcher-bar` for its phone
bottom nav (it had to work around this with a media query).

https://claude.ai/code/session_01EjNhCX22Cemx4XiBdGyEih
