### PR TITLE
docs(website): document @gjsify/napi (forward bridge)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -142,6 +142,7 @@ export default defineConfig({
                     items: [
                         { slug: 'projects/ts-for-gir' },
                         { slug: 'projects/node-gi' },
+                        { slug: 'projects/napi' },
                     ],
                 },
                 {

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -16,6 +16,7 @@ GJSify is organised into pillars, each implementing standard APIs on top of nati
 | Framework | app shell + tooling | [`@gjsify/adwaita-app`](/gjsify/guides/native-adwaita-app/) native app shell, [storybook](/gjsify/guides/storybook/), [devtools](/gjsify/guides/devtools/) |
 | Adwaita for browser | 3 | `@gjsify/adwaita-web`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 | Reverse bridge | 1 | [`@gjsify/node-gi`](/gjsify/projects/node-gi/) — GObject-Introspection on Node.js, Bun and Deno |
+| Forward bridge | 1 | [`@gjsify/napi`](/gjsify/projects/napi/) — load native Node.js N-API `.node` addons in GJS |
 
 93% of Node modules and 58% of web standards covered — see the [Node.js Modules](./node) and [Web APIs](./web) subpages for the full interactive breakdown.
 

--- a/website/src/content/docs/projects/napi.md
+++ b/website/src/content/docs/projects/napi.md
@@ -1,0 +1,64 @@
+---
+title: napi
+description: Load native Node.js N-API addons (.node) inside GJS — the forward bridge. The same compiled addon that runs on Node.js runs unchanged on GJS.
+---
+
+[`@gjsify/napi`](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi) is the **forward mirror** of [node-gi](/gjsify/projects/node-gi/): where node-gi carries GObject-Introspection *out* to Node.js, Bun and Deno, `@gjsify/napi` brings **native Node.js addons *into* GJS**. A compiled `.node` addon — the exact binary you would `require()` on Node — loads and runs unchanged under GJS.
+
+The point is reuse: a GJS app can pull a database driver, a hashing library or a codec straight from the native npm ecosystem, with no pure-JS reimplementation.
+
+:::note[Stability]
+`@gjsify/napi` is **experimental (tier 3)** — a new axis, released on the train but with no stability promise yet. No other GJSify package depends on it, so it can never affect a regular GJS build. See the [stability model](/gjsify/versioning/#package-tiers).
+:::
+
+## How it works
+
+Node-API (N-API) is an **engine-agnostic C ABI**: the *same* `.node` binary already runs on Node (V8), Deno and Bun (JSC). `@gjsify/napi` implements that ABI a fourth time — over GJS's SpiderMonkey engine (mozjs). The shim ships as a GObject-Introspection package (`.so` + `.gir` + `.typelib`), so GJS loads it through `imports.gi` like any other GI library. It then exposes a `loadAddon(path)` call that `dlopen`s the addon and binds its `napi_*` symbols to the shim's implementation.
+
+```ts
+import { loadAddon, hasNapi } from '@gjsify/napi';
+
+if (hasNapi()) {
+    const sqlite = loadAddon('./build/Release/better_sqlite3.node');
+    // `sqlite` is the addon's module.exports — a normal object.
+    const db = new sqlite.Database(':memory:');
+}
+```
+
+Your addon is built the normal way (node-gyp / prebuilds) — nothing about it changes. The hard part is on the shim side: SpiderMonkey has a **moving GC**, so an `napi_value` can't be a raw engine value (the shortcut Bun takes on JSC) — it is a handle into a per-environment arena of GC-traced slots. Asynchronous work (threadsafe functions, `napi_async_work`) is delivered to the addon's callbacks through a `g_idle` source on the GLib main context, so there is no separate libuv loop to run.
+
+## What runs today
+
+A golden-diff harness runs a deterministic workout of each addon on **Node (the reference)** and on **GJS-under-the-shim**, and requires **byte-identical output**:
+
+| Addon | Language / codegen | Kind | Result |
+|---|---|---|:--:|
+| [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3) | C, node-addon-api | synchronous | ✅ byte-identical |
+| [`bufferutil`](https://github.com/websockets/bufferutil) | C, node-gyp-build | synchronous | ✅ |
+| [`utf-8-validate`](https://github.com/websockets/utf-8-validate) | C++, node-gyp-build | synchronous | ✅ |
+| [`@node-rs/argon2`](https://github.com/napi-rs/node-rs) | Rust, napi-rs | synchronous | ✅ |
+| [`node-sqlite3`](https://github.com/TryGhost/node-sqlite3) | C++, node-addon-api | **asynchronous** | ✅ byte-identical |
+
+Those first four are C, C++ and Rust addons emitted by three different N-API code generators — strong evidence that an arbitrary *synchronous* addon runs unmodified. `node-sqlite3` additionally drives the async surface (`napi_async_work` + threadsafe functions), so the whole asynchronous `node-addon-api` ecosystem is reachable, not just the sync subset.
+
+### Scope
+
+The full synchronous N-API surface is implemented, plus the async / threadsafe-function group. A few Node-specific corners stay stubbed because they have no engine-agnostic meaning on GJS — most notably `napi_get_uv_event_loop` (GJS has no libuv loop; the GLib main context *is* the loop). The async model currently runs an addon's work callback inline and delivers its completion on the next main-loop turn, which is correct on GJS's single-threaded engine; true worker-thread concurrency is a possible future refinement.
+
+## Not a replacement for `gi://`
+
+`@gjsify/napi` exists to **reuse native npm addons** — not to talk to GObject libraries. On GJS the native [`gi://`](/gjsify/patterns/gobject-classes/) / `imports.gi` binding stays *the* way to use GTK, GLib and every introspected library; always prefer it. The one place the two directions meet is testing: running [`@gjsify/node-gi`](/gjsify/projects/node-gi/) *under* the shim and diffing its output against native `gi://` is a **differential oracle** that validates both sides at once — a node-gi program built `--app node` runs on the shim byte-identical to the same source under native GJS.
+
+## Getting started
+
+```bash
+gjsify install @gjsify/napi
+```
+
+Installing through the `gjsify` CLI puts the shim's typelib on `GI_TYPELIB_PATH` for you. At runtime you additionally need a built `.node` addon to load — compiled locally with a C++ toolchain, or a shipped prebuild, exactly as on Node. See the [package README](https://github.com/gjsify/gjsify/tree/main/packages/napi/napi#readme) for the full API surface and the current addon matrix.
+
+## See also
+
+- [node-gi](/gjsify/projects/node-gi/) — the reverse bridge (GObject-Introspection on Node, Bun and Deno)
+- [Runtimes](/gjsify/runtimes/) — how both bridge directions fit the target picture
+- [Versioning](/gjsify/versioning/#package-tiers) — the release train and stability model

--- a/website/src/content/docs/projects/node-gi.md
+++ b/website/src/content/docs/projects/node-gi.md
@@ -80,6 +80,7 @@ Requires a C++ toolchain (or the shipped prebuild) plus the GLib ≥ 2.80 / `gir
 
 ## See also
 
+- [napi](/gjsify/projects/napi/) — the forward bridge (native Node.js `.node` addons in GJS)
 - [Runtimes](/gjsify/runtimes/) — how the reverse bridge fits GJSify's overall target picture
 - [Versioning](/gjsify/versioning/#package-tiers) — the release train and stability model
 - [Storybook](/gjsify/guides/storybook/) — `gjsify storybook --runtime node`, the canonical consumer

--- a/website/src/content/docs/runtimes.md
+++ b/website/src/content/docs/runtimes.md
@@ -126,5 +126,6 @@ tested and released with the regular GJSify releases.
 
 - [How It Works](/gjsify/how-it-works/) — auto-aliasing, `--globals auto`, prebuilds
 - [node-gi](/gjsify/projects/node-gi/) — the reverse bridge in depth
+- [napi](/gjsify/projects/napi/) — the forward bridge: native Node.js `.node` addons in GJS
 - [Coverage](/gjsify/coverage/) — live dashboards of the implemented surface
 - [Versioning](/gjsify/versioning/) — release train and package tiers

--- a/website/src/content/docs/versioning.md
+++ b/website/src/content/docs/versioning.md
@@ -56,7 +56,8 @@ verified in CI:
   breaking change may ship with a minor version and a changelog note. The
   Adwaita design-identity packages, storybook, devtools, the native app shell,
   the published showcases and [node-gi](/gjsify/projects/node-gi/).
-- **Tier 3 — experimental.** No promise; new axes start here.
+- **Tier 3 — experimental.** No promise; new axes start here — currently
+  [`@gjsify/napi`](/gjsify/projects/napi/) (native `.node` addons in GJS).
 
 Dependencies may only point at the same or a lower tier, so an experimental
 package can never destabilize a core one. The tier model is defined in


### PR DESCRIPTION
## Document `@gjsify/napi` on the website

The N-API host in GJS (`@gjsify/napi`) is now on `main` (native `.node` addons in GJS: sync + async + tsfn, five real addons byte-identical to Node) but had no website page. This adds one, framed as the **forward mirror of node-gi** — node-gi carries GObject-Introspection *out* to Node/Bun/Deno; napi brings native Node addons *into* GJS.

Kept deliberately lean — one focused project page plus the few cross-references needed for discoverability and an accurate tier list. No rewrites of existing pages.

### New page — `projects/napi.md`

- What it is (reuse native npm addons in a GJS app) + a tier-3 stability aside.
- **How it works**: N-API is an engine-agnostic C ABI; the shim implements it a fourth time over SpiderMonkey, ships as a GI package loaded via `imports.gi`, and `loadAddon()`s the addon — with a short, honest note on the moving-GC handle model and the `g_idle` async dispatch. A minimal `loadAddon`/`hasNapi` code sample (the actual public API; the automatic `.node`-require rewrite isn't wired yet, so the example is explicit).
- **What runs today**: the byte-identical addon matrix (better-sqlite3, bufferutil, utf-8-validate, @node-rs/argon2, node-sqlite3 — C/C++/Rust across three codegens, sync + async).
- **Scope**: the honestly-stubbed corners (`napi_get_uv_event_loop` is permanent — GJS has no libuv loop) and the inline-execute async tradeoff.
- **Not a replacement for `gi://`**: on GJS, `imports.gi` stays *the* GObject path; the one meeting point is the node-gi-under-the-shim differential oracle.

### Cross-references (one line each)

- `astro.config.mjs` — the page in the Ecosystem sidebar, after node-gi.
- `versioning.md` — names `@gjsify/napi` as the current tier-3 example.
- `packages/overview.mdx` — a "Forward bridge" row mirroring the "Reverse bridge" (node-gi) row.
- `projects/node-gi.md` + `runtimes.md` — reciprocal "see also" links.

Validated with `astro build` (Starlight resolves every sidebar slug and internal link at build time).

https://claude.ai/code/session_017DWsErqLc2bQcvzo4iTvi8
