### PR TITLE
fix(node-gi): copy a transfer-full boxed IN arg

### DIFF
--- a/docs/reports/node-gi-consumer-survey.md
+++ b/docs/reports/node-gi-consumer-survey.md
@@ -64,7 +64,7 @@ Legend: ✅ pass · 🟡 partial (some tests fail) · ❌ fail (non-zero exit / 
 | `tty` | ok | ✅ 29/29 | ✅ 29/29 | 🟡 40/55 | deno: assertion-mismatch |
 | `v8` | ok | 🟡 56/60 | ✅ 72/72 | ✅ 72/72 | node: other |
 | `webaudio` | ok | ▶ no-summary | ▶ no-summary | ▶ no-summary | no-unit-summary |
-| `webrtc` | ok | ❌ fail | ❌ fail | ❌ fail | node/bun: other; deno: mainloop-drain |
+| `webrtc` | ok | ▶ no-summary | ▶ no-summary | ▶ no-summary | no-unit-summary |
 | `worker_threads` | ok | ✅ 282/282 | ▶ no-summary | ▶ no-summary | bun/deno: no-unit-summary |
 | `ws` | ok | ✅ 19/19 | ✅ 19/19 | ✅ 19/19 | |
 | `zlib` | ok | ✅ 53376/53376 | ✅ 53376/53376 | 🟡 53374/53375 | deno: other |
@@ -143,18 +143,54 @@ Two distinct problems: a **fidelity bug** (a request header set by the client do
 
 **Re-measured** (`node scripts/node-gi-consumer-harness.mjs @gjsify/module --runtimes node`): the bundle now emits `import { createRequire } from "node:module"` and the `filename_from_uri` TypeError is gone. `module` still fails, with a DIFFERENT and pre-existing error — `TypeError: __name is not a function` — which reproduces identically with the guard disabled and disappears under `--minify false`: rolldown 1.1.4 emits the `output.keepNames` helper (`var __name = …`) ~9 kB into the chunk while the gi virtual module calls it at byte ~200. Tracked in STATUS.md `Open TODOs` as an upstream rolldown issue; it is not an alias-layer problem.
 
-### 6. `webrtc` — native abort in the data-channel path
+### 6. `webrtc` — native abort in the data-channel path (RESOLVED)
 
-**Affects:** `webrtc` (node, bun; deno times out in the same region).
+**Affected:** `webrtc` (node, bun; deno timed out in the same region).
 
-The suite gets through construction, SDP round-trips, ICE candidates and the deferred-API guards, then aborts inside `Loopback data channel`:
+The suite got through construction, SDP round-trips, ICE candidates and the deferred-API guards, then aborted inside `Loopback data channel`:
 
 ```
 free(): invalid pointer
    (SIGABRT, exit 134)
 ```
 
-A double-free / ownership bug on the GStreamer `webrtcbin` + data-channel path under node-gi — a native-side memory-management gap, distinct from every marshalling issue above. The Vala bridge itself loads fine (`GjsifyWebrtc` resolves via the staged prebuild path); without that env the same bundle fails earlier with `Typelib file for namespace 'GjsifyWebrtc' not found`, which is a harness-env dependency, not an engine gap.
+**Root cause — an ENGINE bug, not the Vala bridge.** `JsToGIArgument`'s boxed-handle
+branch handed the callee `h->ptr` verbatim, ignoring the argument's transfer
+annotation. A `(transfer full)` IN arg is ADOPTED by the callee, so both the callee
+and the still-owning JS boxed handle freed the same block. The trigger is
+`RTCSessionDescription.toGstDesc()`:
+
+```ts
+const [ret, sdp] = GstSdp.SDPMessage.new_from_text(this.sdp);   // OUT (transfer full) → handle owns it
+return GstWebRTC.WebRTCSessionDescription.new(type, sdp);       // IN  (transfer full) → callee adopts it
+```
+
+valgrind pins all three events on one 184-byte block: allocated in
+`gst_sdp_message_new` ← `gst_sdp_message_new_from_text` ← `gi_function_info_invoke`;
+freed by `gst_webrtc_session_description_free` ← the node-gi `BoxedHandle` finalizer;
+then freed AGAIN by `gst_sdp_message_free` ← the SDPMessage handle's own finalizer.
+The `gst_sdp_message_init` frame in the abort backtrace is `gst_sdp_message_uninit`
+walking the already-released field pointers.
+
+The same code path is safe on plain GJS (`gjsify workspace @gjsify/webrtc test`
+completes, `Loopback data channel` passes) because gjs COPIES a transferring IN arg —
+`refs/gjs/gi/wrapperutils.h` `GIWrapperBase::transfer_to_gi_argument` →
+`Instance::copy_ptr` (`g_boxed_copy`, or `g_variant_ref` for GVariant). node-gi now
+mirrors that (`TransferBoxedIn` in `packages/node-gi/node-gi/src/marshal.cc`), so the
+callee owns an independent instance and the handle keeps its own. Transfer-NOTHING is
+unchanged. Regression: `packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs`
+(GStreamer-free — `pango_attr_list_insert`, whose `attr` is `(transfer full)`; SIGSEGV
+before the fix).
+
+The Vala bridge (`@gjsify/webrtc-native`) is untouched; its prebuilt `.so`/`.typelib`
+did not need rebuilding.
+
+**Remaining:** the suite runs to completion on node, bun and deno but still scores
+`no-unit-summary` — `packages/web/webrtc/src/test.mts` awaits its spec functions
+directly instead of calling `@gjsify/unit`'s `run()`, so no summary line is emitted
+(identically on GJS). Adding `run()` would make `gjsify workspace @gjsify/webrtc test`
+exit non-zero on the suite's ~20 pre-existing functional failures, so it is tracked
+separately rather than folded into this fix.
 
 ### 7. `fs` — the harness stages only `fixtures/`, not the suite's `test/` dir
 
@@ -191,7 +227,7 @@ Prioritized by the gaps above:
 2. **bun/deno main-context pump parity** (gap 2) — unblocks the bun/deno columns of `child_process`, `dns`, `dgram`, `net`, `http` in one change.
 3. ~~**CLI alias-scoping for virtual gi modules** (gap 5)~~ — **done**; `module` now blocks on the rolldown `keepNames` helper-order bug instead (STATUS.md `Open TODOs`).
 4. **`@gjsify/http` request-header propagation + throw-in-callback fatality** (gap 4), and **`@gjsify/net`'s close/connect event ordering** (gap 3).
-5. **`webrtc` data-channel double-free** (gap 6) — a native-side ownership audit of the GStreamer webrtcbin path.
+5. ~~**`webrtc` data-channel double-free** (gap 6)~~ — RESOLVED: node-gi now copies a `(transfer full)` boxed IN arg (gap 6). Residual: give `@gjsify/webrtc`'s `test.mts` a `run()` summary so the harness can score it.
 6. **Harness fix:** stage the suite's on-disk `test/` dir alongside `fixtures/` (gap 7).
 7. **Widen the proof set:** `canvas2d-core` once its suite can run without `Gdk` (or the container carries gtk4); the GTK-stack candidates once a sibling job carries gtk4/libadwaita/webkitgtk.
 8. **Full CI matrix:** run the whole survey (not just the proof set) as a non-gating `continue-on-error` job that publishes this table, so regressions and improvements surface per PR.

--- a/packages/node-gi/node-gi/src/marshal.cc
+++ b/packages/node-gi/node-gi/src/marshal.cc
@@ -153,6 +153,43 @@ BoxedHandle* TryGetBoxedHandle(Napi::Value v) {
   return ext.Data();
 }
 
+// The pointer to hand a callee for a boxed/struct IN argument, honouring the
+// arg's TRANSFER annotation.
+//
+// A transfer-full (or -container) IN arg is ADOPTED by the callee: it will free
+// the pointer. Handing over the very block this handle still owns makes both
+// sides free it — the finalizer's g_boxed_free then hits already-released
+// memory (`free(): invalid pointer`, SIGABRT). The canonical case is
+// `GstWebRTC.WebRTCSessionDescription.new(type, sdp)`, whose `sdp` param is
+// `(transfer full)`: the fresh `GstSDPMessage` from
+// `GstSdp.SDPMessage.new_from_text()` (an OUT `(transfer full)`, so our handle
+// owns it) got freed once by `gst_webrtc_session_description_free` and again by
+// its own finalizer.
+//
+// gjs solves this by COPYING on transfer — refs/gjs/gi/wrapperutils.h
+// `GIWrapperBase::transfer_to_gi_argument` (`GI_DIRECTION_IN &&
+// transfer != GI_TRANSFER_NOTHING` → `Instance::copy_ptr`), with
+// refs/gjs/gi/struct.h `StructInstance::copy_ptr` = `g_variant_ref` for
+// GVariant else refs/gjs/gi/boxed.h `BoxedInstance::copy_ptr` = `g_boxed_copy`.
+// Mirror that: the callee owns an independent instance, the handle keeps (and
+// still owns) its own. Transfer-NOTHING is a plain borrow — unchanged.
+//
+// A handle with no copy function (a plain, non-boxed C struct — G_TYPE_INVALID,
+// or a `rawOwned` caller-allocates OUT block) cannot be duplicated. gjs throws
+// there; we instead RELINQUISH ownership so the finalizer stays out of the
+// callee's way — a leak-free hand-over is impossible either way, and not
+// double-freeing is strictly safer than the alternative.
+gpointer TransferBoxedIn(BoxedHandle* h, GITransfer transfer) {
+  if (h == nullptr) return nullptr;
+  if (transfer == GI_TRANSFER_NOTHING || h->ptr == nullptr) return h->ptr;
+  if (h->gtype == G_TYPE_VARIANT) return g_variant_ref(static_cast<GVariant*>(h->ptr));
+  if (h->gtype != G_TYPE_INVALID && G_TYPE_IS_BOXED(h->gtype))
+    return g_boxed_copy(h->gtype, h->ptr);
+  h->owns = false;
+  h->rawOwned = false;
+  return h->ptr;
+}
+
 // Read a boxed handle's pointer if `v` is one (tag-checked; no deref of ptr).
 bool TryGetBoxedPtr(Napi::Value v, gpointer* out) {
   if (!v.IsExternal()) return false;
@@ -440,7 +477,7 @@ bool JsToGIArgument(Napi::Env env, Napi::Value v, GITypeInfo* type, GIArgument* 
                     .ThrowAsJavaScriptException();
                 return false;
               }
-              out->v_pointer = h->ptr;
+              out->v_pointer = TransferBoxedIn(h, transfer);
               handled = true;
             }
           }

--- a/packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs
+++ b/packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// Boxed/struct IN-argument TRANSFER handling for @gjsify/node-gi — the
+// ownership half of the boxed marshalling contract (the OUT half lives in
+// `boxed-out.test.mjs`). Cross-runtime safe: headless, no display, no test
+// typelib (GLib + Pango only; Pango is already a CI dependency of the unit job
+// because the caller-alloc-struct-out conformance programs need it).
+//
+// Regression for a double-free: `JsToGIArgument` handed the callee the very
+// pointer the JS boxed handle still owned, ignoring the argument's
+// `(transfer full)` annotation. The callee frees it, then the handle's
+// finalizer frees it again — `free(): invalid pointer` / SIGSEGV, raised
+// asynchronously from the napi finalizer queue long after the call.
+//
+// Found via `@gjsify/webrtc` on the node-gi reverse bridge: `RTCSessionDescription
+// .toGstDesc()` does
+//
+//   const [ret, sdp] = GstSdp.SDPMessage.new_from_text(text);      // OUT (transfer full)
+//   GstWebRTC.WebRTCSessionDescription.new(type, sdp);             // IN  (transfer full)
+//
+// so `gst_webrtc_session_description_free` and the SDPMessage handle's own
+// finalizer both freed the same `GstSDPMessage`. GStreamer is not a node-gi test
+// dependency, so the same shape is reproduced here with Pango:
+// `pango_attr_size_new()` returns `(transfer full)` and `pango_attr_list_insert()`
+// takes its `attr` `(transfer full)`.
+//
+// gjs is the reference behaviour: refs/gjs/gi/wrapperutils.h
+// `GIWrapperBase::transfer_to_gi_argument` COPIES on a transferring IN arg
+// (`Instance::copy_ptr` → `g_boxed_copy`, or `g_variant_ref` for GVariant), so
+// the callee and the JS wrapper own independent instances.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { requireGi } from '../gi.js';
+
+/**
+ * Drain the napi finalizer queue: the boxed handles' finalizers run off the
+ * GC's callback queue on a later event-loop turn, so a double free only aborts
+ * after both a collection AND a turn of the loop.
+ */
+async function collect() {
+    for (let i = 0; i < 2; i++) {
+        globalThis.gc?.();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+}
+
+test('a (transfer full) boxed IN arg is copied, not surrendered: Pango.AttrList.insert', async () => {
+    const Pango = requireGi('Pango', '1.0');
+
+    // Many rounds so at least one pair of handles is collected while the test
+    // is still running (a single round would defer the abort to process exit).
+    for (let i = 0; i < 200; i++) {
+        const list = Pango.AttrList.new();
+        // (transfer full) RETURN → the handle owns this PangoAttribute.
+        const attr = Pango.AttrSize.new(12 * 1024);
+        // `attr` is (transfer full): the list ADOPTS it and destroys it with the
+        // list. Pre-fix this handed over the handle's own pointer, so the
+        // finalizer destroyed an already-destroyed attribute.
+        list.insert(attr);
+    }
+
+    await collect();
+
+    // Still usable afterwards — the copy is a real, independent attribute.
+    const list = Pango.AttrList.new();
+    list.insert(Pango.AttrSize.new(20 * 1024));
+    assert.equal(typeof list.to_string(), 'string');
+});
+
+test('a (transfer none) boxed IN arg is still a plain borrow: GLib.DateTime.difference', async () => {
+    const GLib = requireGi('GLib', '2.0');
+
+    // The unchanged side of the contract: no copy, no ownership move — the
+    // handle stays valid and keeps owning its instance across the call.
+    const a = GLib.DateTime.new_from_unix_utc(1136214245);
+    const b = a.add_hours(1);
+    for (let i = 0; i < 200; i++) assert.equal(b.difference(a), 3600000000);
+
+    await collect();
+
+    assert.equal(a.get_year(), 2006);
+    assert.equal(b.difference(a), 3600000000);
+});


### PR DESCRIPTION
## The defect

`@gjsify/webrtc`'s suite died with a **native memory error** under the `@gjsify/node-gi`
reverse bridge, inside the `Loopback data channel` suite:

```
free(): invalid pointer     → SIGABRT (exit 134)
```

Repro: `node scripts/node-gi-consumer-harness.mjs @gjsify/webrtc --runtimes node`
(recorded as gap 6 / follow-up 5 in `docs/reports/node-gi-consumer-survey.md`).

## Root cause — the engine, not the Vala bridge

The prime suspects named in the report (transfer-annotation mismatches on the
`on-message-string` / `on-message-data` payloads, or a `GstWebRTCDataChannel` ref freed
twice across the `GLib.Idle.add()` hop) were **not** it. `packages/web/webrtc-native/` is
untouched by this PR, and its committed `.so`/`.typelib` needed no rebuild.

`JsToGIArgument`'s boxed-handle branch handed the callee `h->ptr` verbatim, **ignoring the
argument's transfer annotation**. A `(transfer full)` IN arg is ADOPTED by the callee, so
the callee *and* the still-owning JS boxed handle both freed the same block. The trigger is
`RTCSessionDescription.toGstDesc()`:

```ts
const [ret, sdp] = GstSdp.SDPMessage.new_from_text(this.sdp); // OUT (transfer full) → our handle owns it
return GstWebRTC.WebRTCSessionDescription.new(type, sdp);     // IN  (transfer full) → the callee adopts it
```

Both annotations verified against the installed GIRs.

### Evidence

**gdb** — the abort is a node-gi `BoxedHandle` finalizer, not any bridge code:

```
#6  g_free ()
#7  gst_sdp_message_init ()          ← uninit walks already-released field pointers
#8  gst_sdp_message_uninit ()
#9  gst_sdp_message_free ()
#10 gst_webrtc_session_description_free ()
#11 Napi::details::FinalizeData<nodegi::BoxedHandle, nodegi::MakeBoxedHandle(...)>::Wrapper
#12 node_napi_env__::CallFinalizer<true> …
```

**valgrind** pins all three events on one 184-byte block:

```
Invalid free() …
   g_free ← gst_sdp_message_free ← nodegi::BoxedHandle finalizer          ← 2nd free (invalid)
 Address 0x24eeed00 is 0 bytes inside a block of size 184 free'd
   g_free ← gst_sdp_message_free ← gst_webrtc_session_description_free
          ← nodegi::BoxedHandle finalizer                                 ← 1st free
 Block was alloc'd at
   g_malloc0 ← gst_sdp_message_new ← gst_sdp_message_new_from_text
          ← gi_function_info_invoke ← nodegi::InvokeFunctionInfo
```

### Why plain GJS is safe

`gjsify workspace @gjsify/webrtc test` completes and `Loopback data channel` **passes** —
because gjs COPIES a transferring IN arg: `refs/gjs/gi/wrapperutils.h`
`GIWrapperBase::transfer_to_gi_argument` (`GI_DIRECTION_IN && transfer != GI_TRANSFER_NOTHING`
→ `Instance::copy_ptr`), with `refs/gjs/gi/struct.h` `g_variant_ref` for GVariant else
`refs/gjs/gi/boxed.h` `g_boxed_copy`. So the fix belongs in the bridge's marshalling, and
this mirrors gjs exactly.

## The fix

`TransferBoxedIn` in `packages/node-gi/node-gi/src/marshal.cc`. Transfer-NOTHING stays a
plain borrow. A handle with no copy function (a non-boxed C struct, or a `rawOwned`
caller-allocates OUT block) cannot be duplicated — gjs throws there, we relinquish
ownership instead, since a leak-free hand-over is impossible either way and not
double-freeing is strictly safer.

Note this was never webrtc-specific: **any** `(transfer full)` boxed IN arg was affected
(`Gst.Caps.append_structure`, `Pango.AttrList.insert`, `Json.Object.set_member`,
`Soup.CookieJar.add_cookie`, `Adw.Breakpoint.new`, …).

## Regression test

`packages/node-gi/node-gi/test/boxed-in-transfer.test.mjs` — deliberately **GStreamer-free**
so it runs in the node-gi CI container (`pango_attr_list_insert` takes its `attr`
`(transfer full)`; `pango_attr_size_new` returns one). Verified **SIGSEGV before the fix,
green after**, plus a transfer-NOTHING counter-case.

## Verification

| leg | before | after |
|---|---|---|
| harness `@gjsify/webrtc` — node | ❌ fail (SIGABRT, exit 134) | ▶ runs to completion, exit 0 |
| harness `@gjsify/webrtc` — bun | ❌ fail | ▶ runs to completion |
| harness `@gjsify/webrtc` — deno | ❌ fail (timeout in the same region) | ▶ runs to completion |
| `gjsify workspace @gjsify/webrtc test` (GJS) | 284 pass / 22 fail, exit 0 | **unchanged** — 284 pass / 22 fail, exit 0 |

The suite still scores `no-unit-summary` rather than `pass`: `packages/web/webrtc/src/test.mts`
awaits its spec functions directly instead of calling `@gjsify/unit`'s `run()`, so no summary
line is emitted — identically on GJS, and unrelated to this defect. Adding `run()` would make
`gjsify workspace @gjsify/webrtc test` exit non-zero on the ~20 pre-existing functional
failures, so it is left as a tracked residual in the survey rather than folded in here.

### No regressions

- node-gi suite (`node --test --expose-gc`): **435/439**, with exactly the same 4 pre-existing
  failures as the pre-change baseline (2 display-bound: `Canvas2DBridge`, `Excalibur.js`;
  2 child-stdout ANSI-colour mismatches in `pump.test.mjs`) — baselined by reverting
  `marshal.cc` and re-running.
- `scripts/conformance.mjs`: all green ×4 runtimes.
- Consumer proof set on node: sqlite 105/105, http2 102/102, zlib 53376/53376, tls 158/158,
  ws 19/19, crypto 626/626, string_decoder 103/103; dom-elements 441/441 on node+bun+deno.

https://claude.ai/code/session_01SeDe56GtjNzq4ehCTaF3LN
