### PR TITLE
fix(node-gi): read a G_TYPE_STRV property as string[]

### DIFF
--- a/packages/node-gi/node-gi/src/object.cc
+++ b/packages/node-gi/node-gi/src/object.cc
@@ -258,7 +258,32 @@ Napi::Value GValueToJs(Napi::Env env, const GValue* v) {
       // NOT special-cased here: gjs leaves it as a GLib.Bytes boxed handle
       // (value.cpp has no GBytes case → the generic boxed branch), which is what the
       // MakeBoxedHandle below already produces (verified: a GBytes signal param →
-      // `instanceof GLib.Bytes`). A GStrv-as-array read stays a follow-up.
+      // `instanceof GLib.Bytes`).
+      //
+      // G_TYPE_STRV (a NULL-terminated gchar**, e.g. Gtk.Widget:css-classes,
+      // Gio.ThemedIcon:names, or any Vala `public string[] x { get; }` property —
+      // valac emits g_param_spec_boxed(…, G_TYPE_STRV) for those). This is the READ
+      // half of the pair JsToGValue's GStrv branch opened: without it a GStrv
+      // property fell through to MakeBoxedHandle and JS got an opaque boxed handle
+      // instead of an array — SILENTLY, because a handle is a truthy object whose
+      // `.length` is undefined, so `arr ?? []` keeps it and every index/`for` over it
+      // yields nothing (this is how @gjsify/http lost every request header on the
+      // node-gi bridge: `bridgeReq.header_pairs` became a handle and the pair loop
+      // ran zero times). Mirrors GJS gjs_value_from_g_value_internal
+      // (refs/gjs/gi/value.cpp:1082 `gtype == G_TYPE_STRV` → gjs_array_from_strv).
+      // NULL → an EMPTY ARRAY, not null: GJS explicitly excludes G_TYPE_STRV from its
+      // "pointer-valued NULL → JS null" pre-check (value.cpp:1023) and documents the
+      // choice in gjs_array_from_strv (arg.cpp:2267) — "clients would need to always
+      // check for both an empty array and null" otherwise. g_value_get_boxed BORROWS;
+      // every string is copied into JS, so nothing is owned here.
+      if (G_VALUE_HOLDS(v, G_TYPE_STRV)) {
+        const gchar* const* strv = static_cast<const gchar* const*>(g_value_get_boxed(v));
+        guint len = 0;
+        while (strv != nullptr && strv[len] != nullptr) len++;
+        Napi::Array arr = Napi::Array::New(env, len);
+        for (guint i = 0; i < len; i++) arr.Set(i, Napi::String::New(env, strv[i]));
+        return arr;
+      }
       if (G_VALUE_HOLDS(v, G_TYPE_BYTE_ARRAY)) {
         GByteArray* ba = static_cast<GByteArray*>(g_value_get_boxed(v));
         if (ba == nullptr) return env.Null();

--- a/packages/node-gi/node-gi/test/strv-read.test.mjs
+++ b/packages/node-gi/node-gi/test/strv-read.test.mjs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — reading a G_TYPE_STRV property must yield a JS string[].
+//
+// The READ half of the pair `test/strv-construct.test.mjs` opened. That file
+// fixed JsToGValue (a JS `string[]` → a GStrv construct property); GValueToJs
+// still had no G_TYPE_STRV case, so the OPPOSITE direction fell through to the
+// generic boxed branch and handed JS an opaque boxed HANDLE instead of an array.
+//
+// Why it mattered more than a wrong type: the handle is a truthy object whose
+// `.length` is `undefined`, so every idiomatic consumer degrades SILENTLY —
+// `const a = obj.strvProp ?? []` keeps the handle, `for (let i = 0; i < a.length; i++)`
+// runs zero times, `a.map(…)` throws only if reached. That is exactly how
+// `@gjsify/http` lost EVERY request header on the node-gi bridge: its Vala bridge
+// exposes `Request:header-pairs` (a Vala `public string[] { get; }` → valac emits
+// `g_param_spec_boxed(…, G_TYPE_STRV, …)`), the server read it as a handle, the
+// `[name, value, …]` pair loop ran zero times, and `req.headers` came out `{}` with
+// no error anywhere. Same class of bug for any GStrv property (Gtk.Widget:css-classes,
+// Gio.ThemedIcon:names, …).
+//
+// Reference: refs/gjs/gi/value.cpp:1082 (`gtype == G_TYPE_STRV` → gjs_array_from_strv)
+// and refs/gjs/gi/arg.cpp:2267 (a NULL strv is an EMPTY ARRAY, never null — gjs
+// deliberately excludes G_TYPE_STRV from its pointer-NULL→null pre-check at
+// value.cpp:1023 so clients never have to check for both shapes).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+const Gio = requireGi('Gio', '2.0');
+
+// Gtk only if its typelib is present (gtk-smoke job); the widget case additionally
+// needs a display. Same gating as strv-construct.test.mjs.
+let Gtk = null;
+let gtkLoadError = null;
+try {
+  Gtk = requireGi('Gtk', '4.0');
+} catch (err) {
+  gtkLoadError = err;
+}
+const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
+const widgetSkip = gtkSkip || (!haveDisplay ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)' : false);
+
+// Headless: Gio.ThemedIcon:names is a plain readable G_TYPE_STRV property on a
+// GObject that needs neither a display nor gtk_init. The value read back is the
+// property's own GValue (the names the icon was constructed with).
+test('GStrv property read: yields a real JS Array of strings', () => {
+  const icon = new Gio.ThemedIcon({ names: ['alpha', 'beta', 'gamma'] });
+  const names = icon.names;
+
+  // The regression was an opaque boxed handle here — truthy, but not an Array and
+  // with `length === undefined`. Assert the SHAPE first: that is what silently
+  // broke every consumer, not the contents.
+  assert.ok(Array.isArray(names), 'a GStrv property reads back as an Array, not a boxed handle');
+  assert.equal(names.length, 3, 'the array carries its length (a boxed handle had length === undefined)');
+  assert.deepEqual(names, ['alpha', 'beta', 'gamma']);
+  for (const n of names) assert.equal(typeof n, 'string', 'each element is a JS string');
+});
+
+// A pair-flattened GStrv is the exact shape @gjsify/http's Vala bridge uses for
+// request headers ([name, value, name, value, …]); the consumer walks it with an
+// index loop, which is the access pattern that degraded to zero iterations.
+test('GStrv property read: an index loop over the array sees every element', () => {
+  const icon = new Gio.ThemedIcon({ names: ['x-test', 'custom-value', 'host', '127.0.0.1'] });
+  const pairs = icon.names ?? [];
+  const seen = [];
+  for (let i = 0; i + 1 < pairs.length; i += 2) seen.push([pairs[i], pairs[i + 1]]);
+  assert.deepEqual(seen, [
+    ['x-test', 'custom-value'],
+    ['host', '127.0.0.1'],
+  ]);
+});
+
+// GJS parity: an unset / empty GStrv is an EMPTY ARRAY, never null. A fresh
+// Gtk.Label carries no style classes, so :css-classes is the natural empty case
+// (Gtk.Box would report its orientation class).
+test('GStrv property read: an empty GStrv is [] (not null)', { skip: widgetSkip }, () => {
+  if (typeof Gtk.init === 'function') Gtk.init();
+  const label = new Gtk.Label();
+  const classes = label.css_classes;
+  assert.ok(Array.isArray(classes), 'an empty GStrv still reads back as an Array');
+  assert.equal(classes.length, 0);
+});
+
+test('GStrv property read: Gtk widget css_classes reads back via the property', { skip: widgetSkip }, () => {
+  if (typeof Gtk.init === 'function') Gtk.init();
+  const sw = new Gtk.ScrolledWindow({ css_classes: ['foo', 'bar'] });
+  assert.deepEqual(sw.css_classes, ['foo', 'bar'], 'property read matches get_css_classes()');
+  assert.deepEqual(sw.get_css_classes(), ['foo', 'bar']);
+});

--- a/packages/node/http/src/index.spec.ts
+++ b/packages/node/http/src/index.spec.ts
@@ -801,6 +801,104 @@ export default async () => {
         });
     });
 
+    // --- Server-side request headers ---
+    //
+    // Regression guard for a SILENT header loss: the client sent its headers on the
+    // wire correctly, but the server-side `IncomingMessage` came up completely empty
+    // (`req.headers === {}`, `req.rawHeaders === []`) while method, url and body were
+    // all intact. Root cause was one layer below this package — `Request:header-pairs`
+    // on the `@gjsify/http-soup-bridge` Vala bridge is a `G_TYPE_STRV` property, and a
+    // GStrv property read marshalled to an opaque boxed HANDLE instead of a `string[]`
+    // (fixed in `@gjsify/node-gi`'s `GValueToJs`). A handle is a truthy object with
+    // `length === undefined`, so `bridgeReq.header_pairs ?? []` kept it and the
+    // `[name, value, …]` pair loop in `server.ts` ran ZERO times — no error, no
+    // warning, just no headers.
+    //
+    // The single existing `'should receive request headers'` case only echoed ONE
+    // header back through the response body, so the failure surfaced as a body
+    // mismatch inside an `'end'` listener. A throw from a stream listener is an
+    // uncaught exception (correct Node semantics — verified against real `node:http`),
+    // which kills the process before the runner can report. These cases therefore
+    // CAPTURE what the server saw, resolve, and assert AFTER the round-trip — so a
+    // regression is a reported test failure, not a dead process.
+    await describe('http server request headers', async () => {
+        interface SeenRequest {
+            headers: Record<string, string | string[] | undefined>;
+            rawHeaders: string[];
+        }
+
+        /** One round-trip; resolves with the header state the SERVER observed. */
+        const captureServerRequest = (headers: Record<string, string>): Promise<SeenRequest> =>
+            new Promise<SeenRequest>((resolve, reject) => {
+                let seen: SeenRequest | null = null;
+                const server = http.createServer((req, res) => {
+                    seen = {
+                        headers: req.headers as Record<string, string | string[] | undefined>,
+                        rawHeaders: req.rawHeaders,
+                    };
+                    res.writeHead(200);
+                    res.end('ok');
+                });
+                server.on('error', reject);
+                server.listen(0, () => {
+                    const addr = server.address() as { port: number };
+                    const req = http.request({ hostname: '127.0.0.1', port: addr.port, path: '/', headers }, (res) => {
+                        res.on('data', () => {});
+                        res.on('end', () => {
+                            server.close(() => {
+                                if (seen) resolve(seen);
+                                else reject(new Error('request handler never ran'));
+                            });
+                        });
+                    });
+                    req.on('error', reject);
+                    req.end();
+                });
+            });
+
+        await it('should deliver every client-set header to the server', async () => {
+            const seen = await captureServerRequest({
+                'X-Test': 'custom-value',
+                'X-Second': 'other-value',
+                'Content-Type': 'text/plain',
+            });
+
+            expect(seen.headers['x-test']).toBe('custom-value');
+            expect(seen.headers['x-second']).toBe('other-value');
+            expect(seen.headers['content-type']).toBe('text/plain');
+        });
+
+        await it('should always deliver the implicit Host header', async () => {
+            // Host is set by the client even when the caller passes no headers at all —
+            // so an empty `req.headers` is detectable without relying on a custom one.
+            const seen = await captureServerRequest({});
+
+            expect(typeof seen.headers.host).toBe('string');
+            expect(String(seen.headers.host)).toContain('127.0.0.1');
+        });
+
+        await it('should expose the same headers through rawHeaders', async () => {
+            const seen = await captureServerRequest({ 'X-Test': 'custom-value' });
+
+            // Flat [name, value, name, value, …] — the shape that collapsed to [].
+            expect(Array.isArray(seen.rawHeaders)).toBe(true);
+            expect(seen.rawHeaders.length).toBeGreaterThan(0);
+            expect(seen.rawHeaders.length % 2).toBe(0);
+
+            // Wire casing is not normative (Node forwards the caller's casing, the GJS
+            // client lower-cases on setHeader), so match names case-insensitively.
+            const names: string[] = [];
+            const values: string[] = [];
+            for (let i = 0; i + 1 < seen.rawHeaders.length; i += 2) {
+                names.push(seen.rawHeaders[i].toLowerCase());
+                values.push(seen.rawHeaders[i + 1]);
+            }
+            expect(names).toContain('x-test');
+            expect(names).toContain('host');
+            expect(values[names.indexOf('x-test')]).toBe('custom-value');
+        });
+    });
+
     // --- ServerResponse API ---
     await describe('ServerResponse API', async () => {
         await it('should support setHeader/getHeader/hasHeader/removeHeader', async () => {


### PR DESCRIPTION
## The defect

`@gjsify/http`'s own GJS test suite aborted under the `@gjsify/node-gi` reverse
bridge — the process died with `Expected: custom-value / Actual: no header` before
`@gjsify/unit` could print a summary (survey run: node `fail`, bun/deno `845/874`).

Isolated with a raw `node:net` client on one side and a raw `node:net` server on the
other:

| side | result |
|---|---|
| client → wire | ✅ `GET / HTTP/1.1 … x-test: custom-value` — the header IS sent |
| wire → server `IncomingMessage` | ❌ `req.rawHeaders === []`, `req.headers === {}` — **every** header gone, `Host` included |

Method, url and body were all intact. Only the header set vanished, silently.

## Root cause — a `@gjsify/node-gi` engine gap, not an `@gjsify/http` bug

`GValueToJs` (`packages/node-gi/node-gi/src/object.cc`) had no `G_TYPE_STRV` case.
Because `G_TYPE_FUNDAMENTAL(G_TYPE_STRV) == G_TYPE_BOXED`, a GStrv-typed property
read fell through to the generic boxed branch and handed JS an opaque **boxed
handle** instead of a `string[]`. This is the READ half of the pair `JsToGValue`'s
GStrv branch opened; the comment right above the fix said so: *"A GStrv-as-array
read stays a follow-up."*

The chain into `@gjsify/http`:

- `@gjsify/http-soup-bridge`'s Vala `Request` exposes
  `public string[] header_pairs { get; }` → valac emits
  `g_param_spec_boxed(…, G_TYPE_STRV, …)` and copies through `_vala_array_dup1`
  (`g_new0(gchar*, length + 1)`), so the GStrv **is** properly NULL-terminated and
  the property is well-formed — GJS reads it correctly, which is why the GJS leg was
  always green.
- `server.ts` does `const pairs = bridgeReq.header_pairs ?? []`. Under node-gi that
  was a truthy handle with `length === undefined`, so `?? []` kept it and the
  `[name, value, name, value, …]` pair loop ran **zero** times. No error, no warning.

Verified byte-for-byte against instrumentation: `get_header_pairs()` (the
length-carrying method) returned `["Host","127.0.0.1:46367","Connection","close","X-Test","custom-value"]`
at the same instant the property read returned `{}`.

Fix mirrors GJS `gjs_value_from_g_value_internal`
(`refs/gjs/gi/value.cpp:1082` → `gjs_array_from_strv`), including the NULL policy: a
NULL strv is an **empty array**, never `null` (GJS deliberately excludes
`G_TYPE_STRV` from its pointer-NULL→null pre-check at `value.cpp:1023`, documented in
`arg.cpp:2267`). `g_value_get_boxed` borrows; every string is copied into JS.

Affects any GStrv property, not just this one — `Gtk.Widget:css-classes`,
`Gio.ThemedIcon:names`, and every Vala `public string[] x { get; }` bridge property.

## Throw-in-callback fatality — correct Node semantics, deliberately NOT changed

The escaping throw is **not** a bug in `@gjsify/http` and **not** one at the node-gi
callback boundary. The failing assertion ran inside `res.on('end', …)`, and the stack
is entirely Node's own (`IncomingMessage.emit` → `endReadableNT` →
`processTicksAndRejections`) — the same stack real `node:http` produces, confirmed
with a standalone script against Node's own server/client. An uncaught throw from a
stream listener aborting the process **is** Node's contract; GJS logging it out of a
GLib source callback is the divergence, and it is GJS's, not ours. Catching it in
either package would be the blanket-swallow the brief warns against.

What was worth fixing is the **test shape** that turned a failed assertion into a
dead process. The pre-existing case echoed the header back through the response body
and asserted inside the `'end'` listener, so the only way it could fail was fatally.
The new cases capture what the server observed, resolve, and assert **after** the
round-trip — same coverage, reported instead of lethal.

## Regression coverage

`packages/node/http/src/index.spec.ts` → new `http server request headers` block
(cross-platform, `node:`-prefixed imports, green on **both** legs):

- every client-set header reaches the server (`x-test`, `x-second`, `content-type`)
- the implicit `Host` header always arrives — catches an empty header map even when
  no custom header is involved
- `rawHeaders` is a non-empty, even-length flat array whose names cover the sent
  headers (case-insensitive: Node forwards the caller's casing, the GJS client
  lower-cases in `setHeader`)

Proven to catch the bug: run in isolation against the **unfixed** engine it reports
`3 of 4 tests failed` with a clean `@gjsify/unit` summary and a non-zero exit —
`undefined`, `undefined`, `Expected 0 to be greater than 0` — instead of killing the
process.

`packages/node-gi/node-gi/test/strv-read.test.mjs` → the engine-level guard (the read
counterpart to `strv-construct.test.mjs`): array-ness + length + contents, an index
loop over a pair-flattened GStrv, empty GStrv → `[]` not `null`, and the
`Gtk.Widget:css-classes` read (Gtk/display-gated exactly like its sibling).

## Verification

| | before | after |
|---|---|---|
| `node scripts/node-gi-consumer-harness.mjs @gjsify/http --runtimes node` | ❌ `fail` — process killed, no summary | ✅ **1049/1049** |
| same, bun | 🟡 `845/874` | ✅ **1049/1049** |
| same, deno | 🟡 `845/874` | ✅ **1049/1049** |
| `gjsify workspace @gjsify/http test` (node leg) | ✅ 1040/1040 | ✅ **1051/1051** |
| `gjsify workspace @gjsify/http test` (gjs leg) | ✅ 1038/1038 | ✅ **1049/1049** |
| `node --test test/strv-read.test.mjs test/strv-construct.test.mjs` | — | ✅ 11/11 |

`gjsify lint` clean; `gjsify format --check` clean on the workspace file (the
`packages/node-gi/**` tree keeps its own 2-space style — its existing tests fail the
root `oxfmt` check too and no CI gate formats it, so the new test matches its
siblings).

Full `node --test` on node-gi: 425 pass / 5 fail — `pump.test.mjs` (2) and
`excalibur-webgl.test.mjs` — all confirmed **pre-existing**: `pump` fails identically
with the fix reverted and rebuilt (ANSI-escape mismatches in a golden string
comparison, from in-flight main-loop work in this tree), and the WebGL capstone times
out waiting for engine frames on a busy desktop.

## Note for the reviewer

The working tree this was developed in carries unrelated uncommitted work from a
concurrent session (node-gi main-loop/pump, `STATUS.md`, and the regenerated
`docs/reports/node-gi-consumer-survey.md`). This branch therefore contains **only**
the three files above. The survey report's `http` row (`node ❌ fail`, `bun/deno 🟡
845/874`) is now stale and wants a regenerated run — left to whoever owns that
in-flight report rather than committing their working copy here.
