### PR TITLE
[verification, do not merge] one Vala bridge only

### DIFF
--- a/packages/node/terminal-native/src/vala/terminal.vala
+++ b/packages/node/terminal-native/src/vala/terminal.vala
@@ -1,6 +1,9 @@
 /*
  * GjsifyTerminal — POSIX terminal primitives for GJS.
  *
+ * (VERIFICATION-ONLY comment for PR #843's per-package prebuild gate — this
+ * branch touches nothing but this file. Do not merge.)
+ *
  * Exposes POSIX syscalls that have no GLib equivalent:
  *   • Posix.isatty()      — reliable TTY detection
  *   • ioctl(TIOCGWINSZ)   — actual terminal dimensions


### PR DESCRIPTION
Verification run for #843. Base is #843's branch, so the workflow change itself is NOT in the diff — the only changed file is `packages/node/terminal-native/src/vala/terminal.vala`.

Expected: `terminal-native` builds on every leg; the other nine packages — including `lightningcss-native`, which is 77-83% of every emulated leg — are skipped, and the emulated legs skip the rustup install too.

Close after the wall-clock is recorded. Do not merge.