### PR TITLE
[verification, do not merge] lightningcss-native only

### DIFF
--- a/packages/infra/lightningcss-native/src/rust/src/lib.rs
+++ b/packages/infra/lightningcss-native/src/rust/src/lib.rs
@@ -1,5 +1,8 @@
 //! gjsify_lightningcss — single-call Rust→C FFI for lightningcss.
 //!
+//! (VERIFICATION-ONLY comment for PR #843's per-package prebuild gate — this
+//! branch touches nothing but this file. Do not merge.)
+//!
 //! Adapted from refs/lightningcss/c/src/lib.rs (lightningcss_c_bindings,
 //! Devon Govett, MIT). The upstream C bindings expose a 3-step pipeline
 //! (parse → transform → to_css) plus separate Targets/PseudoClasses/etc


### PR DESCRIPTION
Verification run for #843. Base is #843's branch, so the workflow change itself is NOT in the diff — the only changed file is `packages/infra/lightningcss-native/src/rust/src/lib.rs`.

Expected: `lightningcss-native` builds on every leg (the expensive one, on purpose); the other nine packages are skipped.

Close after the wall-clock is recorded. Do not merge.