### PR TITLE
Drop the platform exemptions the artifacts outgrew

### DIFF
--- a/packages/framework/webgl/package.json
+++ b/packages/framework/webgl/package.json
@@ -30,11 +30,6 @@
             "linux-s390x",
             "linux-riscv64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/infra/lightningcss-native/package.json
+++ b/packages/infra/lightningcss-native/package.json
@@ -28,11 +28,6 @@
             "linux-riscv64",
             "darwin-arm64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "tier": 1
     },

--- a/packages/node/http-soup-bridge/package.json
+++ b/packages/node/http-soup-bridge/package.json
@@ -27,11 +27,6 @@
             "linux-riscv64",
             "darwin-arm64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/node/http2-native/package.json
+++ b/packages/node/http2-native/package.json
@@ -27,11 +27,6 @@
             "linux-riscv64",
             "darwin-arm64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/node/sab-native/package.json
+++ b/packages/node/sab-native/package.json
@@ -26,11 +26,6 @@
             "linux-s390x",
             "linux-riscv64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/node/terminal-native/package.json
+++ b/packages/node/terminal-native/package.json
@@ -27,11 +27,6 @@
             "linux-riscv64",
             "darwin-arm64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/node/tls-native/package.json
+++ b/packages/node/tls-native/package.json
@@ -27,11 +27,6 @@
             "linux-riscv64",
             "darwin-arm64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",

--- a/packages/web/webrtc-native/package.json
+++ b/packages/web/webrtc-native/package.json
@@ -26,11 +26,6 @@
             "linux-s390x",
             "linux-riscv64"
         ],
-        "platformsUncommitted": {
-            "linux-ppc64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-s390x": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed",
-            "linux-riscv64": "no CI leg can currently produce it: under real emulation the QEMU prebuild job cannot install its build dependencies (dnf segfaults on s390x, the RPM transaction fails on ppc64). The artifact previously committed here was a host x86-64 build and was removed"
-        },
         "prebuilds": "prebuilds",
         "runtimes": {
             "gjs": "polyfill",


### PR DESCRIPTION
main is red: the artifact invariant from #838 refuses to let an escape hatch outlive its reason.

`gjsify.platformsUncommitted` exempted `linux-ppc64`/`s390x`/`riscv64` on all eight native bridges, with the reason *"no CI leg can currently produce it"*. #838 pinned the emulator, the legs now build for real, and `commit-prebuilds` (1ec2f6742) landed all 24 directories — so the reason expired and the check said so on 24 targets.

Removing the exemptions puts those artifacts back under the full existence + loadability contract.

Verified the machine type rather than the directory name:

```
webgl/prebuilds/linux-s390x/libgwebgl.so
  → ELF 64-bit MSB shared object, IBM S/390
```

Genuinely big-endian — the first such artifact this repo ships.

`node scripts/audit-runtimes.mjs --check` → exit 0 (captured directly, not through a pipe).