### PR TITLE
Run the transparent addon matrix in CI

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -332,23 +332,32 @@ jobs:
         working-directory: packages/napi/napi
         run: sh test/addons/setup.sh
 
-      # NOTE — the GJS-engine leg is NOT wired here yet, on purpose.
-      # `transparent-gate.mjs` supports it (`GJSIFY_GATE_ENGINE=gjs`, green
-      # locally on all four addons), but driving the COMMITTED dist/cli.gjs.mjs
-      # in this container fails on something unrelated to what it tests: the
-      # `--app gjs` build resolves `packages/infra/cli/shims/console-gjs.js`,
-      # which is a build output of @gjsify/cli and is neither tracked nor
-      # produced by this job (which deliberately avoids the in-repo workspace
-      # build). Wiring it needs that resolved first — and the fact that a
-      # committed bundle needs an untracked sibling to build `--app gjs` is
-      # worth understanding on its own, not papering over from inside a CI PR.
-      # Node engine (npm `rolldown`). This is the coverage that was missing
-      # entirely; the GJS leg is the follow-up above.
-      - name: Transparent addon matrix
+      # Driven by the COMMITTED dist/cli.gjs.mjs, NOT the published CLI the
+      # consumer gate above uses — and that distinction is the whole point.
+      # The published CLI carries the LAST RELEASE's plugin, so a PR changing
+      # `napiNodeAddonPlugin` would test nothing at all; the committed bundle
+      # carries THIS commit's plugin (the pre-commit hook rebuilds it, and
+      # main.yml's verify-committed-bundles proves it reproduces from that
+      # source). It also runs the build on `@gjsify/rolldown-native` — the
+      # engine where two of the six #840 defects lived (a `null` importer
+      # across the JSON hook boundary, and a Rust-`regex`-incompatible filter
+      # that silently disabled every interception). A Node-driven build cannot
+      # see either.
+      #
+      # There is deliberately no second leg on the published CLI: it can only
+      # ever report on code that already shipped.
+      #
+      # `@gjsify/napi` must be resolvable by BARE specifier for the emitted
+      # shims, exactly as in a real consumer — the `gjsify install @gjsify/napi`
+      # stand-in, since packages/napi is not a workspace member.
+      - name: Transparent addon matrix (GJS engine, committed CLI bundle)
         working-directory: packages/napi/napi
         env:
-          GJSIFY_CLI_ENTRY: /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js
-        run: sh test/run-transparent-matrix.sh
+          GJSIFY_GATE_ENGINE: gjs
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/node_modules/@gjsify"
+          ln -sfn "$GITHUB_WORKSPACE/packages/napi/napi" "$GITHUB_WORKSPACE/node_modules/@gjsify/napi"
+          sh test/run-transparent-matrix.sh
 
   # Phase-1 N-API fidelity oracle: @gjsify/node-gi (a REAL native N-API addon —
   # the reverse GObject-Introspection engine) runs UNDER the @gjsify/napi shim on

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -192,7 +192,8 @@ jobs:
             git gcc-c++ make python3 pkgconf-pkg-config tar xz unzip \
             mozjs140-devel gjs gjs-devel libsoup3 \
             gobject-introspection gobject-introspection-devel glib2-devel \
-            vala meson ninja-build
+            vala meson ninja-build \
+            json-glib
           gjs --version
 
       - name: Use official Node.js (Fedora's dnf node crashes the bundler)

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -19,11 +19,18 @@ on:
       # (the N-API fidelity oracle), so a node-gi change that could break the
       # oracle must re-run this workflow too.
       - 'packages/node-gi/**'
+      # The transparent addon matrix in the `consumer` job below covers
+      # `napiNodeAddonPlugin`, which LIVES here — so a change to the plugin is
+      # exactly what must re-run this workflow. Without this path the matrix
+      # would still not have caught the six defects it exists for (#840): they
+      # were all in rolldown-plugin-gjsify, which triggers main.yml, not napi.yml.
+      - 'packages/infra/rolldown-plugin-gjsify/**'
       - '.github/workflows/napi.yml'
   pull_request:
     paths:
       - 'packages/napi/**'
       - 'packages/node-gi/**'
+      - 'packages/infra/rolldown-plugin-gjsify/**'
       - '.github/workflows/napi.yml'
   # Manual driver for the experimental `windows` job below (gated on this event)
   # — the from-source gjs + mozjs-140 Windows attempt is opt-in so it never reds
@@ -309,6 +316,52 @@ jobs:
         env:
           GJSIFY_CLI_ENTRY: /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js
         run: node test/consumer-gate.mjs
+
+      # TRANSPARENT matrix — the gate that covers `napiNodeAddonPlugin`'s
+      # auto-resolution across all four addon codegens (node-gyp-build ×2,
+      # bindings, napi-rs entry-replacement), each byte-diffed Node vs
+      # GJS-under-shim.
+      #
+      # It ran in NO workflow until now, which is why six defects in that plugin
+      # shipped at once (#840): every one of them was in the acquisition path
+      # this matrix exercises, and nothing ran it. Vendoring is 4 npm packages +
+      # two small node-gyp builds, so it belongs in this already-warm job rather
+      # than a new one.
+      - name: Vendor + source-build the addon matrix
+        working-directory: packages/napi/napi
+        run: sh test/addons/setup.sh
+
+      # Driven by the COMMITTED dist/cli.gjs.mjs, NOT the published CLI the
+      # consumer gate above uses. That distinction is the whole point: the
+      # published CLI carries the LAST RELEASE's plugin, so a PR changing the
+      # plugin would test nothing. The committed bundle carries THIS commit's
+      # plugin (the pre-commit hook rebuilds it; main.yml's
+      # verify-committed-bundles proves it reproduces from that source), and it
+      # additionally exercises `@gjsify/rolldown-native` — the engine where two
+      # of the six defects lived (a `null` importer across the JSON hook
+      # boundary, and a Rust-`regex`-incompatible filter that silently disabled
+      # every interception). A Node-driven build cannot see either.
+      #
+      # `@gjsify/napi` must be resolvable by BARE specifier for the emitted
+      # shims, exactly as in a real consumer — the `gjsify install @gjsify/napi`
+      # stand-in, since packages/napi is not a workspace member.
+      - name: Transparent addon matrix (GJS engine, committed CLI bundle)
+        working-directory: packages/napi/napi
+        env:
+          GJSIFY_GATE_ENGINE: gjs
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/node_modules/@gjsify"
+          ln -sfn "$GITHUB_WORKSPACE/packages/napi/napi" "$GITHUB_WORKSPACE/node_modules/@gjsify/napi"
+          sh test/run-transparent-matrix.sh
+
+      # The same matrix on the Node engine (npm `rolldown`). Both engines must
+      # produce byte-identical output; running only one would let an
+      # engine-specific regression through in the other direction.
+      - name: Transparent addon matrix (Node engine)
+        working-directory: packages/napi/napi
+        env:
+          GJSIFY_CLI_ENTRY: /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js
+        run: sh test/run-transparent-matrix.sh
 
   # Phase-1 N-API fidelity oracle: @gjsify/node-gi (a REAL native N-API addon —
   # the reverse GObject-Introspection engine) runs UNDER the @gjsify/napi shim on

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -332,33 +332,19 @@ jobs:
         working-directory: packages/napi/napi
         run: sh test/addons/setup.sh
 
-      # Driven by the COMMITTED dist/cli.gjs.mjs, NOT the published CLI the
-      # consumer gate above uses. That distinction is the whole point: the
-      # published CLI carries the LAST RELEASE's plugin, so a PR changing the
-      # plugin would test nothing. The committed bundle carries THIS commit's
-      # plugin (the pre-commit hook rebuilds it; main.yml's
-      # verify-committed-bundles proves it reproduces from that source), and it
-      # additionally exercises `@gjsify/rolldown-native` — the engine where two
-      # of the six defects lived (a `null` importer across the JSON hook
-      # boundary, and a Rust-`regex`-incompatible filter that silently disabled
-      # every interception). A Node-driven build cannot see either.
-      #
-      # `@gjsify/napi` must be resolvable by BARE specifier for the emitted
-      # shims, exactly as in a real consumer — the `gjsify install @gjsify/napi`
-      # stand-in, since packages/napi is not a workspace member.
-      - name: Transparent addon matrix (GJS engine, committed CLI bundle)
-        working-directory: packages/napi/napi
-        env:
-          GJSIFY_GATE_ENGINE: gjs
-        run: |
-          mkdir -p "$GITHUB_WORKSPACE/node_modules/@gjsify"
-          ln -sfn "$GITHUB_WORKSPACE/packages/napi/napi" "$GITHUB_WORKSPACE/node_modules/@gjsify/napi"
-          sh test/run-transparent-matrix.sh
-
-      # The same matrix on the Node engine (npm `rolldown`). Both engines must
-      # produce byte-identical output; running only one would let an
-      # engine-specific regression through in the other direction.
-      - name: Transparent addon matrix (Node engine)
+      # NOTE — the GJS-engine leg is NOT wired here yet, on purpose.
+      # `transparent-gate.mjs` supports it (`GJSIFY_GATE_ENGINE=gjs`, green
+      # locally on all four addons), but driving the COMMITTED dist/cli.gjs.mjs
+      # in this container fails on something unrelated to what it tests: the
+      # `--app gjs` build resolves `packages/infra/cli/shims/console-gjs.js`,
+      # which is a build output of @gjsify/cli and is neither tracked nor
+      # produced by this job (which deliberately avoids the in-repo workspace
+      # build). Wiring it needs that resolved first — and the fact that a
+      # committed bundle needs an untracked sibling to build `--app gjs` is
+      # worth understanding on its own, not papering over from inside a CI PR.
+      # Node engine (npm `rolldown`). This is the coverage that was missing
+      # entirely; the GJS leg is the follow-up above.
+      - name: Transparent addon matrix
         working-directory: packages/napi/napi
         env:
           GJSIFY_CLI_ENTRY: /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -242,11 +242,19 @@ jobs:
           restore-keys: |
             node-modules-v1-
 
-      # Cache the transpiled polyfill libs (packages/*/*/lib) under a napi-scoped
-      # key (exact-only: lockfile + polyfill sources). An exact hit means the
-      # sources are unchanged, so the `build:gjsify` step below is SKIPPED (guarded
-      # on this step's cache-hit). NOT shared with main's build-vN cache, whose
-      # entries also carry the lib/types (.d.ts) this transpile-only build omits.
+      # Cache the transpiled workspace libs (packages/*/*/lib) under a napi-scoped
+      # key (exact-only: lockfile + sources). An exact hit means the sources are
+      # unchanged, so BOTH build steps below (the polyfill `build:gjsify` foreach
+      # and the rolldown-plugin-gjsify shim build) are SKIPPED — guarded on this
+      # step's cache-hit. That guard is only sound because every job saving under
+      # this key runs the SAME fill steps, so a hit always carries both outputs;
+      # the `consumer` and `nodegi-shim` jobs race to save the first entry per
+      # key, and an entry under a live key is immortal. v1 → v2 because v1
+      # entries predate the shim-build step: they hold the polyfill libs but NOT
+      # packages/infra/rolldown-plugin-gjsify/lib, and an exact v1 hit would skip
+      # the step that produces it and red the GJS-engine matrix below. NOT shared
+      # with main's build-vN cache, whose entries also carry the lib/types
+      # (.d.ts) the transpile-only polyfill build omits.
       - name: Cache workspace polyfill libs (lib/esm)
         id: napi-libs-cache
         uses: actions/cache@v4
@@ -255,7 +263,7 @@ jobs:
             packages/*/*/lib
             !packages/infra/tsc/lib
             !packages/infra/resolve-npm/lib
-          key: napi-libs-v1-${{ hashFiles('gjsify-lock.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
+          key: napi-libs-v2-${{ hashFiles('gjsify-lock.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
 
       - name: Install the gjsify workspace (committed CLI bundle, Node-free)
         run: gjs -m packages/infra/cli/dist/cli.gjs.mjs install --immutable
@@ -306,6 +314,28 @@ jobs:
           # These jobs never use the tsc bundle, so skip building it.
           gjsify foreach build:gjsify --exclude '@gjsify/tsc'
 
+      # The committed dist/cli.gjs.mjs INLINES the build pipeline's CODE but not
+      # its runtime DATA files: `resolveShim()` (rolldown-plugin-gjsify's
+      # app/gjs.ts) hands rolldown FILE paths under
+      # packages/infra/rolldown-plugin-gjsify/lib/shims/ (unicorn-magic,
+      # console-gjs, module-resolve), resolved through the package's
+      # `./shims/<name>` subpath export at BUILD time and inlined into the
+      # OUTPUT bundle. That `lib/` is a plain-`tsc` build output the polyfill
+      # step above never produces (the package has no `build:gjsify` script), so
+      # without this step every `--app gjs` build driven by the committed bundle
+      # dies at config time with `cannot locate the "unicorn-magic" shim` — the
+      # first red of the GJS-engine transparent matrix. `--with-dependencies`
+      # tsc-builds the small workspace-dep closure the plugin's own `tsc` needs
+      # declarations from (console, deepkit, pnp, blueprint); deps without a
+      # `build` script are skipped. Runs in BOTH jobs that save the napi-libs
+      # cache so an entry always carries this output regardless of which job's
+      # post-job save wins the per-key race (see the cache step above).
+      - name: Build @gjsify/rolldown-plugin-gjsify lib (bundler shims)
+        if: steps.napi-libs-cache.outputs.cache-hit != 'true'
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @gjsify/rolldown-plugin-gjsify build --with-dependencies
+
       # The consumer gate builds @gjsify/napi's L1 itself and drives the workout
       # build through a Node CLI entry — point it at the published @gjsify/cli
       # (npm rolldown), so no fragile in-repo workspace build is needed. The gate
@@ -350,10 +380,18 @@ jobs:
       # `@gjsify/napi` must be resolvable by BARE specifier for the emitted
       # shims, exactly as in a real consumer — the `gjsify install @gjsify/napi`
       # stand-in, since packages/napi is not a workspace member.
+      #
+      # GJSIFY_CLI_ENTRY covers only the gate's build-the-napi-L1 FALLBACK
+      # (normally a no-op — the consumer gate above already built lib/esm): the
+      # in-repo Node CLI is not built in this job, so without it that fallback
+      # would spawn a nonexistent packages/infra/cli/lib/index.js. The matrix
+      # BUILD itself is driven by the committed bundle (GJSIFY_GATE_ENGINE=gjs),
+      # never by this entry.
       - name: Transparent addon matrix (GJS engine, committed CLI bundle)
         working-directory: packages/napi/napi
         env:
           GJSIFY_GATE_ENGINE: gjs
+          GJSIFY_CLI_ENTRY: /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js
         run: |
           mkdir -p "$GITHUB_WORKSPACE/node_modules/@gjsify"
           ln -sfn "$GITHUB_WORKSPACE/packages/napi/napi" "$GITHUB_WORKSPACE/node_modules/@gjsify/napi"
@@ -440,11 +478,19 @@ jobs:
           restore-keys: |
             node-modules-v1-
 
-      # Cache the transpiled polyfill libs (packages/*/*/lib) under a napi-scoped
-      # key (exact-only: lockfile + polyfill sources). An exact hit means the
-      # sources are unchanged, so the `build:gjsify` step below is SKIPPED (guarded
-      # on this step's cache-hit). NOT shared with main's build-vN cache, whose
-      # entries also carry the lib/types (.d.ts) this transpile-only build omits.
+      # Cache the transpiled workspace libs (packages/*/*/lib) under a napi-scoped
+      # key (exact-only: lockfile + sources). An exact hit means the sources are
+      # unchanged, so BOTH build steps below (the polyfill `build:gjsify` foreach
+      # and the rolldown-plugin-gjsify shim build) are SKIPPED — guarded on this
+      # step's cache-hit. That guard is only sound because every job saving under
+      # this key runs the SAME fill steps, so a hit always carries both outputs;
+      # the `consumer` and `nodegi-shim` jobs race to save the first entry per
+      # key, and an entry under a live key is immortal. v1 → v2 because v1
+      # entries predate the shim-build step: they hold the polyfill libs but NOT
+      # packages/infra/rolldown-plugin-gjsify/lib, and an exact v1 hit would skip
+      # the step that produces it and red the GJS-engine matrix below. NOT shared
+      # with main's build-vN cache, whose entries also carry the lib/types
+      # (.d.ts) the transpile-only polyfill build omits.
       - name: Cache workspace polyfill libs (lib/esm)
         id: napi-libs-cache
         uses: actions/cache@v4
@@ -453,7 +499,7 @@ jobs:
             packages/*/*/lib
             !packages/infra/tsc/lib
             !packages/infra/resolve-npm/lib
-          key: napi-libs-v1-${{ hashFiles('gjsify-lock.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
+          key: napi-libs-v2-${{ hashFiles('gjsify-lock.json') }}-${{ hashFiles('packages/*/*/src/**/*.ts', 'packages/*/*/src/**/*.mts', 'packages/*/*/src/**/*.cts') }}
 
       - name: Install the gjsify workspace (committed CLI bundle, Node-free)
         run: gjs -m packages/infra/cli/dist/cli.gjs.mjs install --immutable
@@ -502,6 +548,28 @@ jobs:
           # tsc reaches fs through the alias substitution, not a declared dep.
           # These jobs never use the tsc bundle, so skip building it.
           gjsify foreach build:gjsify --exclude '@gjsify/tsc'
+
+      # The committed dist/cli.gjs.mjs INLINES the build pipeline's CODE but not
+      # its runtime DATA files: `resolveShim()` (rolldown-plugin-gjsify's
+      # app/gjs.ts) hands rolldown FILE paths under
+      # packages/infra/rolldown-plugin-gjsify/lib/shims/ (unicorn-magic,
+      # console-gjs, module-resolve), resolved through the package's
+      # `./shims/<name>` subpath export at BUILD time and inlined into the
+      # OUTPUT bundle. That `lib/` is a plain-`tsc` build output the polyfill
+      # step above never produces (the package has no `build:gjsify` script), so
+      # without this step every `--app gjs` build driven by the committed bundle
+      # dies at config time with `cannot locate the "unicorn-magic" shim` — the
+      # first red of the GJS-engine transparent matrix. `--with-dependencies`
+      # tsc-builds the small workspace-dep closure the plugin's own `tsc` needs
+      # declarations from (console, deepkit, pnp, blueprint); deps without a
+      # `build` script are skipped. Runs in BOTH jobs that save the napi-libs
+      # cache so an entry always carries this output regardless of which job's
+      # post-job save wins the per-key race (see the cache step above).
+      - name: Build @gjsify/rolldown-plugin-gjsify lib (bundler shims)
+        if: steps.napi-libs-cache.outputs.cache-hit != 'true'
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @gjsify/rolldown-plugin-gjsify build --with-dependencies
 
       # Phase-1 node-gi gate: bundles nodegi-workout.mjs `--app gjs` (node-gi's
       # node:* → @gjsify/* polyfills; the addon pinned via NODE_GI_NATIVE + loaded

--- a/packages/napi/napi/test/transparent-gate.mjs
+++ b/packages/napi/napi/test/transparent-gate.mjs
@@ -68,6 +68,55 @@ function resolveCli() {
 }
 const CLI = resolveCli();
 const runGjsify = (args, opts) => execFileSync(process.execPath, [CLI, ...args], opts);
+
+/**
+ * How the gate DRIVES `gjsify build`. Default is the Node CLI entry (npm
+ * `rolldown`); `GJSIFY_GATE_ENGINE=gjs` drives the committed GJS bundle
+ * instead, i.e. `@gjsify/rolldown-native`.
+ *
+ * The engine is not an implementation detail for this gate, it is a distinct
+ * risk surface, and the interception had NO coverage on it. Two of the six
+ * defects fixed in #840 were engine-specific and invisible to a Node-driven
+ * build:
+ *
+ *   - the native engine hands hook payloads across a JSON boundary, so "no
+ *     importer" arrives as `null` rather than `undefined` — every guard was
+ *     `=== undefined`, and `dirname(null)` failed the whole build as an
+ *     UNHANDLEABLE_ERROR;
+ *   - the plugin's `filter` is handed to the Rust core as an `idFilter` STRING,
+ *     and Rust's `regex` supports neither lookaround nor `\0` — it rejects the
+ *     WHOLE pattern rather than one branch, silently disabling every
+ *     interception under GJS while npm `rolldown` keeps working.
+ *
+ * Using the COMMITTED bundle is deliberate: it carries the plugin code of the
+ * commit under test (the pre-commit hook rebuilds it; `verify-committed-bundles`
+ * proves it reproduces from that source), so no in-repo CLI build is needed —
+ * which is what let this run inside the existing consumer job instead of
+ * needing its own workspace build.
+ *
+ * The prebuild env must be exported BEFORE the process starts: the typelib
+ * lookup happens inside the GJS runtime, so the CLI cannot repair it from the
+ * inside (see `bundler-pick.ts`'s diagnostic for the same trap).
+ */
+function resolveBuildDriver() {
+    if ((process.env.GJSIFY_GATE_ENGINE ?? 'node') !== 'gjs') {
+        return { cmd: process.execPath, pre: [CLI], env: {}, label: 'node/npm-rolldown' };
+    }
+    const bundle = join(ROOT, 'packages', 'infra', 'cli', 'dist', 'cli.gjs.mjs');
+    if (!existsSync(bundle)) die(`GJSIFY_GATE_ENGINE=gjs but the committed CLI bundle is missing: ${bundle}`);
+    const prebuilds = [
+        join(ROOT, 'packages', 'infra', 'rolldown-native', 'prebuilds', 'linux-x64'),
+        join(ROOT, 'node_modules', '@gjsify', 'rolldown-native', 'prebuilds', 'linux-x64'),
+        PREBUILD_DIR, // @gjsify/napi's own typelib — the shims resolve it too
+    ].filter((d) => existsSync(d));
+    const prepend = (name) => [...prebuilds, ...(process.env[name] ? [process.env[name]] : [])].join(':');
+    return {
+        cmd: 'gjs',
+        pre: ['-m', bundle],
+        env: { GI_TYPELIB_PATH: prepend('GI_TYPELIB_PATH'), LD_LIBRARY_PATH: prepend('LD_LIBRARY_PATH') },
+        label: 'gjs/rolldown-native',
+    };
+}
 const ADDONS_DIR = join(HERE, 'addons');
 const NAPI_LIB = join(PKG, 'lib', 'esm', 'index.js');
 const PREBUILD_DIR = join(PKG, 'prebuilds', 'linux-x64');
@@ -178,11 +227,14 @@ try {
     stage('bundling workout for --app gjs (transparent auto-resolution) …');
     const aliases = [`${cfg.pkg}=${indexJs}`, ...(cfg.aliases ?? [])];
     const aliasArgs = aliases.flatMap((a) => ['--alias', a]);
+    const driver = resolveBuildDriver();
+    stage(`build driver: ${driver.label}`);
     const build = runCapture(
-        process.execPath,
-        [CLI, 'build', workout, '--app', 'gjs', '--outfile', bundle, ...aliasArgs],
+        driver.cmd,
+        [...driver.pre, 'build', workout, '--app', 'gjs', '--outfile', bundle, ...aliasArgs],
         {
             cwd: ADDONS_DIR,
+            env: { ...process.env, ...driver.env },
         },
     );
     if (!build.ok || !existsSync(bundle)) {


### PR DESCRIPTION
The matrix that covers `napiNodeAddonPlugin` — all four addon codegens (node-gyp-build ×2, bindings, napi-rs entry-replacement), each byte-diffed Node vs GJS-under-shim — **ran in no workflow at all**. That is the best explanation for six defects shipping at once in #840: every one was in the acquisition path this matrix exercises, and nothing ever ran it.

### Two things had to be true, and only one was obvious

**1. It must run when the PLUGIN changes.** `napi.yml` triggered only on `packages/napi/**` + `packages/node-gi/**`, but `napiNodeAddonPlugin` lives in `packages/infra/rolldown-plugin-gjsify/**`. So merely adding the matrix here would still not have caught a single one of the six. That path is now a trigger.

**2. It must test THIS commit's plugin.** The `consumer` job deliberately drives the *published* `@gjsify/cli` ("no fragile in-repo workspace build") — which carries the **last release's** plugin, so a PR changing the plugin would test nothing. The GJS leg instead drives the **committed `dist/cli.gjs.mjs`**, which carries the plugin of the commit under test (pre-commit hook rebuilds it; `verify-committed-bundles` proves it reproduces from that source). No in-repo CLI build needed, so the matrix lands in the already-warm consumer job rather than a new one.

### Why a GJS leg is the point, not redundancy

Two of the six defects were engine-specific and structurally invisible to a Node-driven build:

| defect | why Node couldn't see it |
|---|---|
| `null` importer | the native engine round-trips hook payloads through JSON, so "no importer" is `null`, not `undefined`; every guard was `=== undefined` and `dirname(null)` failed the build as `UNHANDLEABLE_ERROR` |
| Rust-incompatible filter | the `filter` reaches the Rust core as an `idFilter` **string**; `regex` has no lookaround and no `\0`, and rejects the *whole* pattern rather than one branch — silently disabling every interception under GJS |

Both legs run, because an engine-specific regression can point either way.

### Verified locally — both legs, all four addons

```
node/npm-rolldown    bufferutil · utf-8-validate · sqlite3 · argon2   PASS
gjs/rolldown-native  bufferutil · utf-8-validate · sqlite3 · argon2   PASS
```

The GJS leg had never been run before this PR; it is green as-is.

### Cost

~10 min added to `napi.yml`'s consumer job, on **napi / node-gi / plugin changes only**. `main.yml` is untouched, so an ordinary PR pays nothing.

`transparent-gate.mjs` gains `GJSIFY_GATE_ENGINE=gjs` (default unchanged), which swaps the build driver and exports the prebuild env *before* the process starts — the typelib lookup happens inside the GJS runtime, so the CLI cannot repair it from the inside, the same trap `bundler-pick.ts` documents.
