### PR TITLE
Tab the package managers in the Vite plugin docs

### DIFF
--- a/website/src/components/CommandTabs.astro
+++ b/website/src/components/CommandTabs.astro
@@ -35,18 +35,45 @@ import { Code } from '@astrojs/starlight/components';
 interface Props {
     /** Window title shown centered in the headerbar. */
     title?: string;
-    /** Programmatic tabs (alternative to MDX slots) — one command per runtime. */
-    commands?: { runtime: 'gjsify' | 'npm' | 'bun' | 'deno'; code: string }[];
+    /**
+     * Which set of tabs this window offers, and which preference it shares.
+     *
+     *   `runtime` (default) — WHICH RUNTIME executes the command.
+     *   `pm`               — WHICH PACKAGE MANAGER installs it.
+     *
+     * They are deliberately separate groups rather than one list. The two
+     * questions are independent (a Node project may install with pnpm), and the
+     * selection is persisted + mirrored across the site — so mixing them would
+     * mean picking "Deno" in one window silently hunting for a nonexistent
+     * "deno" tab in a package-manager window, and picking "pnpm" dragging every
+     * runtime window somewhere arbitrary. Each group keeps its own
+     * localStorage key and only syncs with its own kind.
+     */
+    group?: 'runtime' | 'pm';
+    /** Programmatic tabs (alternative to MDX slots) — one command per tab. */
+    commands?: { runtime: 'gjsify' | 'npm' | 'bun' | 'deno' | 'yarn' | 'pnpm'; code: string }[];
 }
 
-const { title = 'Terminal', commands } = Astro.props;
+const { title = 'Terminal', group = 'runtime', commands } = Astro.props;
 
-const RUNTIMES = [
-    { slot: 'gjsify', label: 'GJS' },
-    { slot: 'npm', label: 'Node' },
-    { slot: 'bun', label: 'Bun' },
-    { slot: 'deno', label: 'Deno' },
-];
+const TAB_SETS: Record<string, { slot: string; label: string }[]> = {
+    runtime: [
+        { slot: 'gjsify', label: 'GJS' },
+        { slot: 'npm', label: 'Node' },
+        { slot: 'bun', label: 'Bun' },
+        { slot: 'deno', label: 'Deno' },
+    ],
+    // npm first: it is what a reader lands on with no stored preference, and
+    // the one every ecosystem tool documents. `gjsify` last — it is ours, and
+    // putting it first would read as steering.
+    pm: [
+        { slot: 'npm', label: 'npm' },
+        { slot: 'yarn', label: 'Yarn' },
+        { slot: 'pnpm', label: 'pnpm' },
+        { slot: 'gjsify', label: 'GJSify' },
+    ],
+};
+const RUNTIMES = TAB_SETS[group] ?? TAB_SETS.runtime;
 const LABELS: Record<string, string> = Object.fromEntries(RUNTIMES.map((r) => [r.slot, r.label]));
 
 // A present tab either carries pre-rendered slot `html` OR raw `code` to feed
@@ -70,7 +97,7 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 {/* `not-content` opts the window chrome out of Starlight's content-flow
     spacing — its `* + *` rule otherwise puts a 1rem margin-top on the
     <adw-tab-view> (a visible gap between headerbar and tab bar). */}
-<div class="command-tabs not-content" data-command-tabs data-runtimes={runtimesAttr}>
+<div class="command-tabs not-content" data-command-tabs data-tab-group={group} data-runtimes={runtimesAttr}>
     <div class="command-tabs-headerbar">
         <span class="command-tabs-headerbar-start"></span>
         <span class="command-tabs-headerbar-title">{title}</span>
@@ -96,11 +123,19 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 <script>
     import '@gjsify/adwaita-web';
 
-    const KEY = 'gjsify-preferred-runtime';
+    // One key per tab GROUP. `runtime` keeps the original key so an existing
+    // visitor's stored choice survives; other groups get their own namespace.
+    // A shared key would be actively wrong, not just untidy — the groups have
+    // disjoint tab ids, so one group's stored value never matches the other's
+    // tabs, and cross-applying it would move windows arbitrarily.
+    const keyFor = (group: string) =>
+        group === 'runtime' ? 'gjsify-preferred-runtime' : `gjsify-preferred-${group}`;
+    const groupOf = (el: HTMLElement) => el.dataset.tabGroup ?? 'runtime';
 
-    const applyPreference = (runtime: string | null, skip?: Element) => {
+    const applyPreference = (group: string, runtime: string | null, skip?: Element) => {
         if (!runtime) return;
         for (const el of document.querySelectorAll<HTMLElement>('[data-command-tabs]')) {
+            if (groupOf(el) !== group) continue;
             const view = el.querySelector('adw-tab-view');
             if (!view || view === skip) continue;
             const runtimes = (el.dataset.runtimes ?? '').split(',');
@@ -117,12 +152,13 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
         const runtimes = (host.dataset.runtimes ?? '').split(',');
         const runtime = runtimes[(event as CustomEvent).detail?.selected ?? 0];
         if (!runtime) return;
+        const group = groupOf(host);
         try {
-            localStorage.setItem(KEY, runtime);
+            localStorage.setItem(keyFor(group), runtime);
         } catch {
             // Private mode — selection just won't persist.
         }
-        applyPreference(runtime, view);
+        applyPreference(group, runtime, view);
     });
 
     // Headerbar copy button → forward to the ACTIVE page's hidden Expressive
@@ -142,10 +178,16 @@ const runtimesAttr = present.map((r) => r.slot).join(',');
 
     // Initial: restore the remembered runtime once the element is defined.
     customElements.whenDefined('adw-tab-view').then(() => {
-        try {
-            applyPreference(localStorage.getItem(KEY));
-        } catch {
-            // ignore
+        // Restore each group independently — a page can hold both kinds.
+        const groups = new Set(
+            [...document.querySelectorAll<HTMLElement>('[data-command-tabs]')].map(groupOf),
+        );
+        for (const group of groups) {
+            try {
+                applyPreference(group, localStorage.getItem(keyFor(group)));
+            } catch {
+                // ignore
+            }
         }
     });
 </script>

--- a/website/src/content/docs/guides/vite-plugin.mdx
+++ b/website/src/content/docs/guides/vite-plugin.mdx
@@ -3,16 +3,36 @@ title: Vite Plugin
 description: Use GJSify's browser and NativeScript transforms directly in a Vite config — with or without the gjsify CLI — so a dual-target app develops under Vite exactly as it builds for production
 ---
 
+import CommandTabs from '../../../components/CommandTabs.astro';
+
 `@gjsify/vite-plugin-gjsify` brings GJSify's build transforms to **Vite**. It exists because a dual-target app has two build paths that must agree: it ships for production via `gjsify build --app browser`, but it *develops* under Vite (dev server, HMR). The preset is what makes the two produce the same thing.
 
 **You do not need the `gjsify` CLI to use it.** The plugin is an ordinary npm package with `vite` as its only peer dependency. Install it with npm/yarn/pnpm, spread it into `vite.config.ts`, and run plain `vite` / `vite build`. This is covered by an end-to-end test whose fixture project depends on the plugin and *not* on `@gjsify/cli`.
 
 ## Install
 
-```bash
-npm install -D @gjsify/vite-plugin-gjsify vite
-# or: yarn add -D … / pnpm add -D … / gjsify install @gjsify/vite-plugin-gjsify
-```
+<CommandTabs title="Install" group="pm">
+  <Fragment slot="npm">
+    ```bash
+    npm install -D @gjsify/vite-plugin-gjsify vite
+    ```
+  </Fragment>
+  <Fragment slot="yarn">
+    ```bash
+    yarn add -D @gjsify/vite-plugin-gjsify vite
+    ```
+  </Fragment>
+  <Fragment slot="pnpm">
+    ```bash
+    pnpm add -D @gjsify/vite-plugin-gjsify vite
+    ```
+  </Fragment>
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/vite-plugin-gjsify vite
+    ```
+  </Fragment>
+</CommandTabs>
 
 ## Browser target
 
@@ -76,23 +96,6 @@ This is the low-level form. For a NativeScript app, prefer the one-file composer
 // vite.config.ts
 import { defineNativescriptConfig } from '@gjsify/nativescript-vite';
 export default defineNativescriptConfig();
-```
-
-## Version alignment — track Vite, not "latest"
-
-GJSify's build chain is derived from Vite's, and staying compatible with Vite means matching **what Vite pins**, which is not the same as the newest release on npm:
-
-| Package | What Vite 8.1.5 pins |
-|---|---|
-| `rolldown` | `~1.1.5` |
-| `lightningcss` | `^1.32.0` |
-
-Upgrading `rolldown` to its newest release (1.2.x) moves *away* from Vite, not with it — Vite 8.1.x will still resolve its own `~1.1.5`, so you end up running two bundler versions and lose the parity the preset exists to provide. When you bump, bump to the version in the table above.
-
-Check what your installed Vite actually pins rather than trusting this page:
-
-```bash
-npm view vite@$(npm view vite version) dependencies
 ```
 
 ## When you still want the CLI


### PR DESCRIPTION
The Vite-plugin install listed its alternatives in a code **comment** (`# or: yarn add -D … / pnpm add -D … / gjsify install …`), while the site already answers exactly this kind of "pick your flavour" question with tabs. Now it uses the same window.

### Why a new tab *group* rather than more tabs

The existing tabs answer a different question:

| group | question | tabs |
|---|---|---|
| `runtime` (existing, default) | which runtime **executes** this | GJS · Node · Bun · Deno |
| `pm` (new) | which package manager **installs** it | npm · Yarn · pnpm · GJSify |

They are independent — a Node project may install with pnpm — so one longer list would be wrong.

Keeping them separate is **load-bearing, not tidiness**: the selection is persisted and mirrored across every window on the site, and the two sets have disjoint tab ids. A shared key would mean choosing "Deno" once and then every package-manager window hunting for a `deno` tab it does not have, and choosing "pnpm" dragging every runtime window somewhere arbitrary. Each group therefore keeps its own `localStorage` key and only syncs with its own kind. `runtime` keeps the original key, so an existing visitor's stored choice survives.

The doc becomes `.mdx` — Starlight renders components only there.

### Also: drops the "Version alignment" section

It pinned concrete numbers (`rolldown ~1.1.5`, `lightningcss ^1.32.0`) that age with every Vite release, and closed by telling the reader to check their installed Vite *"rather than trusting this page"*. A section that concedes it cannot be relied on is better removed than maintained. The underlying rule — gjsify tracks what Vite pins, not npm `latest` — stays true; it just does not belong in a table on a docs page.

### Verification

`astro build` green; `/guides/vite-plugin/` renders npm / Yarn / pnpm / GJSify. No regression in the existing windows: `getting-started` and `packages/overview` still emit `group="runtime"` with GJS/Node/Bun/Deno.
