### PR TITLE
fix(os): ship real errno/signal numbers in browser

### DIFF
--- a/packages/node/os/src/browser.ts
+++ b/packages/node/os/src/browser.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Reimplemented for @gjsify browser target — inspired by CoderPuppy/os-browserify (MIT).
 //
+// NOTE: importing `./constants.js` here is deliberate — it is a pure data
+// table (plain integers, no Node/GI imports), so it costs the browser bundle
+// nothing but the numbers themselves.
+//
 // Reference: refs/node/lib/os.js (surface mirror)
 // Inspiration: os-browserify, Copyright (c) CoderPuppy. MIT.
 //
@@ -9,6 +13,8 @@
 // cpus, no mem). Mirrors what `node-stdlib-browser` exposes plus a few extras
 // (`availableParallelism`, `machine`, `version`) so npm packages probing
 // recent Node APIs don't trip.
+
+import osConstants from './constants.js';
 
 export const EOL = '\n';
 export const devNull = '/dev/null';
@@ -89,8 +95,19 @@ export const setPriority = (_pidOrPriority: number, _priority?: number): void =>
 
 export const constants = {
     UV_UDP_REUSEADDR: 4,
-    errno: {},
-    signals: {},
+    // errno + signal numbers are PLATFORM DATA, not a runtime capability —
+    // they are the same integers in a browser tab as anywhere else, and
+    // `constants-browserify` (the ecosystem's reference browser shim) ships
+    // them in full. They were `{}` here, which is why `@gjsify/constants`
+    // — whose whole job is to flatten `os.constants` — resolved `ENOENT`,
+    // `SIGINT` and friends to `undefined` in the browser build.
+    //
+    // Reuse the single source of truth in `./constants.js` rather than
+    // duplicating the tables; a second copy is a table that drifts.
+    errno: osConstants.errno,
+    signals: osConstants.signals,
+    // `dlopen` stays empty on purpose: unlike errno/signals it describes a
+    // dynamic linker, which a browser genuinely does not have.
     priority: {
         PRIORITY_LOW: 19,
         PRIORITY_BELOW_NORMAL: 10,

--- a/packages/node/os/src/index.browser.spec.ts
+++ b/packages/node/os/src/index.browser.spec.ts
@@ -147,6 +147,26 @@ export default async () => {
             expect(typeof os.constants.errno).toBe('object');
         });
 
+        // `typeof … === 'object'` above is satisfied by `{}`, which is exactly
+        // what these were: empty. `@gjsify/constants` flattens `os.constants`,
+        // so every errno/signal it re-exports resolved to `undefined` in the
+        // browser build and its suite failed the moment that bundle actually
+        // got built. Assert the VALUES, not just the shape.
+        await it('constants.errno carries the POSIX numbers, not an empty object', async () => {
+            expect(os.constants.errno.ENOENT).toBe(2);
+            expect(os.constants.errno.EACCES).toBe(13);
+            expect(os.constants.errno.EEXIST).toBe(17);
+            expect(os.constants.errno.EPERM).toBe(1);
+            expect(typeof os.constants.errno.ECONNREFUSED).toBe('number');
+        });
+
+        await it('constants.signals carries the POSIX numbers, not an empty object', async () => {
+            expect(os.constants.signals.SIGINT).toBe(2);
+            expect(os.constants.signals.SIGKILL).toBe(9);
+            expect(os.constants.signals.SIGTERM).toBe(15);
+            expect(typeof os.constants.signals.SIGHUP).toBe('number');
+        });
+
         await it('constants.UV_UDP_REUSEADDR should be a number', async () => {
             expect(typeof os.constants.UV_UDP_REUSEADDR).toBe('number');
         });


### PR DESCRIPTION
Fixes the last red job on main (`Browser (Playwright/Firefox)`), which #859 did not cover because it is a different defect.

## What is wrong

`packages/node/os/src/browser.ts` exported:

```ts
errno: {},
signals: {},
```

`@gjsify/constants` exists to **flatten `os.constants`**, so in the browser build every errno and signal it re-exports resolved to `undefined`. Its suite fails 3 of 19:

```
[constants] should contain errno constants from os:   Expected: number, Actual: undefined
[constants] should contain signal constants from os:  Expected: number, Actual: undefined
[constants] should have correct errno values:         Expected undefined to be greater than 0
```

## Why it appeared now — not a regression from #855

`@gjsify/constants` is listed in `BROWSER_KNOWN_BROKEN_BUILDS`, so its browser bundle **did not build** and its tests never ran. With the selective CI build repaired in #855 the browser bundles are genuinely built rather than cache-restored; the bundle now builds, the suite runs for the first time, and the pre-existing defect shows. Evidence: the `Browser` job was `success` on the last main before #855 (`046d9d6e6`) and `failure` on `267e26506` with these exact three assertions — identical on my #859 branch, which touches none of this. This is the blast radius I flagged on #855 landing, and it is the intended behaviour of the fix, not damage from it.

## The fix

errno and signal numbers are platform **data**, not a runtime capability — identical integers in a browser tab and on a POSIX host, and `constants-browserify` (the ecosystem's reference shim) ships them in full. The complete tables already live in `./constants.ts`, so `browser.ts` now reuses that single source instead of keeping a second, emptier copy. Importing it costs the bundle only the integers: it is a pure data module with no Node/GI imports.

`dlopen` deliberately stays `{}` — unlike errno/signals it describes a dynamic linker, which a browser genuinely has not got.

## Test gap this also closes

The existing browser spec asserted only `typeof os.constants.errno === 'object'` — which `{}` satisfies. That is why an empty table sat there unnoticed. Added cases asserting the **values** (ENOENT=2, EACCES=13, EEXIST=17, EPERM=1, SIGINT=2, SIGKILL=9, SIGTERM=15), so it cannot silently empty out again.

## Verification

- `@gjsify/os` suite: **276 passed under Node and 276 under GJS**, `check` clean.
- Built browser shim: `errno.ENOENT = 2`, `signals.SIGINT = 2`, 79 errno keys, 33 signal keys, `dlopen` 0.
- `@gjsify/constants` browser test bundle now **builds** (63 KB) and inlines `ENOENT:2` / `SIGINT:2`, with no `errno:{}` left in it.
- `gjsify lint` 0 errors.

Follow-up for a maintainer, not done here: `@gjsify/constants` can probably come **off** `BROWSER_KNOWN_BROKEN_BUILDS` now that its bundle builds — worth confirming on a green run first.