### PR TITLE
ci(napi): don't bundle @gjsify/tsc while building the polyfill libs

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -286,7 +286,17 @@ jobs:
         if: steps.napi-libs-cache.outputs.cache-hit != 'true'
         run: |
           export PATH="$PWD/node_modules/.bin:$PATH"
-          gjsify foreach build:gjsify
+          # `--exclude @gjsify/tsc`: this step exists to transpile the POLYFILL
+          # lib/esm trees, and every polyfill's `build:gjsify` is a self-contained
+          # `gjsify build --library`. `@gjsify/tsc`'s is not — it BUNDLES typescript
+          # `--app gjs`, which resolves `node:fs` → `@gjsify/fs` and therefore needs
+          # the very lib/esm trees this loop is still producing. `foreach` is
+          # unordered by default (`--topological` is opt-in) and discovery puts
+          # packages/infra/tsc before packages/node/fs, so it died with
+          # `cannot resolve @gjsify/fs`. Topological order would not help either:
+          # tsc reaches fs through the alias substitution, not a declared dep.
+          # These jobs never use the tsc bundle, so skip building it.
+          gjsify foreach build:gjsify --exclude '@gjsify/tsc'
 
       # The consumer gate builds @gjsify/napi's L1 itself and drives the workout
       # build through a Node CLI entry — point it at the published @gjsify/cli
@@ -432,7 +442,17 @@ jobs:
         if: steps.napi-libs-cache.outputs.cache-hit != 'true'
         run: |
           export PATH="$PWD/node_modules/.bin:$PATH"
-          gjsify foreach build:gjsify
+          # `--exclude @gjsify/tsc`: this step exists to transpile the POLYFILL
+          # lib/esm trees, and every polyfill's `build:gjsify` is a self-contained
+          # `gjsify build --library`. `@gjsify/tsc`'s is not — it BUNDLES typescript
+          # `--app gjs`, which resolves `node:fs` → `@gjsify/fs` and therefore needs
+          # the very lib/esm trees this loop is still producing. `foreach` is
+          # unordered by default (`--topological` is opt-in) and discovery puts
+          # packages/infra/tsc before packages/node/fs, so it died with
+          # `cannot resolve @gjsify/fs`. Topological order would not help either:
+          # tsc reaches fs through the alias substitution, not a declared dep.
+          # These jobs never use the tsc bundle, so skip building it.
+          gjsify foreach build:gjsify --exclude '@gjsify/tsc'
 
       # Phase-1 node-gi gate: bundles nodegi-workout.mjs `--app gjs` (node-gi's
       # node:* → @gjsify/* polyfills; the addon pinned via NODE_GI_NATIVE + loaded


### PR DESCRIPTION
Both Fedora gates in `napi.yml` — `node-gi N-API fidelity under shim` and `better-sqlite3 consumer gate` — are **red on `main` right now**, independently of any PR. Confirmed by dispatching the workflow on unmodified `main`: same two failures.

```
UnresolvedWorkspaceImportError: gjsify build --app gjs:
cannot resolve `@gjsify/fs`, the `--app gjs` substitution for `fs`, `node:fs`.
[@gjsify/tsc] build failed (exit 1)
```

## Cause

The step exists to transpile the POLYFILL `lib/esm` trees the bundler needs, and every polyfill's `build:gjsify` is a self-contained `gjsify build --library`. `@gjsify/tsc`'s is the one exception — it BUNDLES typescript `--app gjs`, so it resolves `node:fs` → `@gjsify/fs` and needs the very trees this loop is still producing.

`foreach` is unordered by default (`--topological` is opt-in), and discovery visits `packages/infra/tsc` before `packages/node/fs`. So tsc bundles against a `@gjsify/fs` with no `lib/` yet.

**`--topological` would not fix it**: tsc reaches fs through the alias substitution, not a declared dependency, so no dependency order can know about the edge. These jobs never consume `dist/tsc.gjs.mjs`, so the fix is to not build it here.

## Why it surfaced now

The step is skipped on an exact `napi-libs` cache hit, and that key hashes every package source — so it has been skipped for as long as sources were unchanged. The first PR to touch a package (#869) made it actually run, on a workflow whose last real execution predates whatever changed underneath it.

That is the part worth noting beyond this fix: a cache-skipped step is a step nobody is running, and its breakage surfaces attributed to whoever happens to change a source file next.

https://claude.ai/code/session_01ScXtAf6EHBUhspbHy3eQxE