### PR TITLE
fix(node-gi): drain deno's nextTick queue during a blocking run

### DIFF
--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -179,11 +179,32 @@ if (!isNodeRuntime && RUNTIME !== 'gjs') {
       // (Bun's own processTicksAndRejections calls it from JS).
       ({ drainMicrotasks: drain } = require('bun:jsc'));
     } else if (typeof globalThis.Deno?.internal === 'symbol') {
-      // V8: core.runMicrotasks → op_run_microtasks →
-      // Isolate::PerformMicrotaskCheckpoint (a reentrant op, explicitly
-      // safe with JS frames on the stack).
+      // V8: the checkpoint needs BOTH queues. core.runMicrotasks is only
+      // Isolate::PerformMicrotaskCheckpoint; Deno's node-compat
+      // process.nextTick queue is a SEPARATE deno_core queue
+      // (ext:deno_node/_next_tick.ts → core.queueNextTick) that only the
+      // runtime's own event loop drains — and that loop is paused for the
+      // whole lifetime of a blocking run(). node:stream delivers stream
+      // 'end' via process.nextTick (endReadableNT), so with a
+      // microtask-only drain any body consumption over a Readable
+      // (@gjsify/fetch consumeBody → XHR arrayBuffer/text) got its chunks
+      // (microtask-delivered) but never the end: every asset load hung at
+      // readyState 3 forever on Deno while the SAME bundle settled on Bun,
+      // whose nextTick rides JSC's microtask queue (bun:jsc
+      // drainMicrotasks covers it). core.runNextTicks mirrors node's
+      // task_queues.js runNextTicks: microtask checkpoint when no ticks
+      // are scheduled, full processTicksAndRejections (ticks + microtasks
+      // interleaved) when there are — one call, both queues. Regression:
+      // test/blocking-run-checkpoint.test.mjs.
       const core = globalThis.Deno[globalThis.Deno.internal]?.core;
-      if (typeof core?.runMicrotasks === 'function') drain = () => core.runMicrotasks();
+      if (typeof core?.runNextTicks === 'function') {
+        drain = () => core.runNextTicks();
+      } else if (typeof core?.runMicrotasks === 'function') {
+        // Older deno_core without runNextTicks: microtask-only drain
+        // (pre-fix behaviour — promise continuations settle, nextTick
+        // consumers like node:stream 'end' still starve).
+        drain = () => core.runMicrotasks();
+      }
     }
     if (typeof drain === 'function') native.setMicrotaskDrain(drain);
   } catch {

--- a/packages/node-gi/node-gi/scripts/cross-runtime.mjs
+++ b/packages/node-gi/node-gi/scripts/cross-runtime.mjs
@@ -52,6 +52,7 @@ const CONFORMANCE = [
   'arrays',
   'boxed-out',
   'async-error',
+  'blocking-run-checkpoint',
   'bytes',
   'cairo',
   'cairo-canvas2d',

--- a/packages/node-gi/node-gi/src/loop.cc
+++ b/packages/node-gi/node-gi/src/loop.cc
@@ -108,8 +108,14 @@ static void DrainMicrotasks() {
 //
 // Portable fix: N-API exposes no engine microtask checkpoint, but both runtimes
 // expose their OWN drain primitive to JS (Bun: `bun:jsc` drainMicrotasks —
-// JSC's VM drain, callable mid-stack by design; Deno: core.runMicrotasks →
-// Isolate::PerformMicrotaskCheckpoint via a reentrant op). index.js registers
+// JSC's VM drain, callable mid-stack by design, and Bun's process.nextTick
+// rides that same queue; Deno: core.runNextTicks — node's task_queues.js
+// runNextTicks shape, draining the node-compat process.nextTick queue AND the
+// V8 microtask checkpoint. core.runMicrotasks alone is NOT enough on Deno:
+// its nextTick queue is separate from V8's microtasks, and node:stream's
+// 'end' is nextTick-delivered (endReadableNT), so a microtask-only drain hung
+// every fetch/XHR body consumption at readyState 3 during a blocking run —
+// see test/blocking-run-checkpoint.test.mjs). index.js registers
 // it here on non-Node runtimes only; the loop-dispatched trampolines
 // (signals.cc / calls.cc / class.cc) invoke NodeGiMaybeDrainMicrotasks at their
 // OUTERMOST boundary (g_loopDispatchDepth == 0). Node never registers — its

--- a/packages/node-gi/node-gi/test/blocking-run-checkpoint.test.mjs
+++ b/packages/node-gi/node-gi/test/blocking-run-checkpoint.test.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — cross-runtime checkpoint coverage for a BLOCKING GLib run.
+//
+// Regression for the Deno XHR/fetch hang (excalibur-jelly-jumper stuck on the
+// loading screen at 0% forever): the per-runtime drain registered via
+// setMicrotaskDrain must cover BOTH continuation queues, not just the V8
+// microtask queue —
+//
+//   - microtasks (promise continuations, queueMicrotask)
+//   - the node-compat process.nextTick queue
+//
+// node:stream delivers stream 'end' via process.nextTick (endReadableNT), so a
+// Readable consumed inside a blocking GLib.MainLoop.run() gets its data chunks
+// (microtask-delivered) but never the end unless the nextTick queue drains at
+// the dispatch boundary. That is exactly how @gjsify/fetch's consumeBody — and
+// with it every XMLHttpRequest arrayBuffer()/text() — hung at readyState 3 on
+// Deno, while the SAME bundle settled on Bun (whose nextTick rides JSC's
+// microtask queue) and Node (whose napi_make_callback checkpoint runs the tick
+// queue natively). On Deno the queues are separate: core.runMicrotasks is only
+// Isolate::PerformMicrotaskCheckpoint, and the nextTick queue
+// (ext:deno_node/_next_tick.ts → core.queueNextTick) is drained by
+// core.runNextTicks — index.js must register the latter.
+//
+// The blocking run is entered from a macrotask (setTimeout), mirroring
+// Gio.Application.runAsync's deferral — entering it from the test callback's
+// own async scope would hit the documented V8 nested-checkpoint caveat (see
+// mainloop.test.mjs) and measure the wrong thing.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable } from 'node:stream';
+import { Buffer } from 'node:buffer';
+import process from 'node:process';
+import { requireGi } from '../gi.js';
+
+test('microtasks, nextTick and stream end drain during a blocking MainLoop.run()', async () => {
+    const GLib = requireGi('GLib', '2.0');
+
+    const duringRun = await new Promise((resolve, reject) => {
+        setTimeout(() => {
+            try {
+                const fired = [];
+                const loop = GLib.MainLoop.new(null, false);
+                let quitted = false;
+                const quit = () => {
+                    if (quitted) return;
+                    quitted = true;
+                    loop.quit();
+                };
+
+                // Schedule the continuations FROM a GLib dispatch inside the
+                // run — the XHR shape: fetch settles from a GLib-driven
+                // callback, then its promise chain + stream consumption must
+                // advance while the loop still owns the thread.
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 20, () => {
+                    queueMicrotask(() => fired.push('microtask'));
+                    process.nextTick(() => fired.push('nextTick'));
+                    (async () => {
+                        for await (const chunk of Readable.from(Buffer.from('jelly'))) {
+                            fired.push(`chunk:${chunk.length}`);
+                        }
+                        fired.push('end');
+                        quit();
+                    })();
+                    return false;
+                });
+
+                // Failsafe deadline: without the tick drain the stream never
+                // ends, so quit() above never runs — end the run here so the
+                // assertions below can REPORT the starvation instead of the
+                // whole test timing out.
+                GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1500, () => {
+                    quit();
+                    return false;
+                });
+
+                loop.run(); // blocks; continuations must drain in here
+                resolve([...fired]); // snapshot at the moment run() returned
+            } catch (err) {
+                reject(err);
+            }
+        }, 10);
+    });
+
+    for (const expected of ['microtask', 'nextTick', 'chunk:5', 'end']) {
+        assert.ok(
+            duringRun.includes(expected),
+            `'${expected}' must fire during the blocking run; fired: [${duringRun.join(', ')}]`,
+        );
+    }
+});


### PR DESCRIPTION
The excalibur showcase never left Excalibur's loading screen on **deno**: all 26 XHRs reached `readyState 3` in ~10 ms and then stopped forever — no 4, no `load`, no `error`, no warning. bun and node ran the identical bundle to a playable game.

The defect is in the runtime bridge, not in any XHR code.

## Root cause

After each outermost GLib→JS dispatch — the checkpoint that keeps continuations flowing while a blocking `Adw.Application.run()` owns the thread — node-gi ran deno's drain as `core.runMicrotasks()`: the V8 microtask checkpoint alone.

deno's node-compat `process.nextTick` is a **separate deno_core queue** (`ext:deno_node/_next_tick.ts` → `core.queueNextTick`), drained only by deno's own event loop — which is paused for the entire blocking run. `node:stream` delivers stream **end** via `process.nextTick` (`endReadableNT`), so `@gjsify/fetch`'s `consumeBody` (a `for await` over `Readable.from(buffer)`) got its data chunk (microtask-delivered) and never the end. `res.arrayBuffer()` never settled; the XHR froze exactly between 3 and 4.

The other runtimes hid it for different reasons: bun's `process.nextTick` rides JSC's microtask queue, which `bun:jsc` `drainMicrotasks` already covers; node's `napi_make_callback` runs the tick queue natively.

## Measurement

Blocking run entered from a macrotask, continuations scheduled from a GLib dispatch, 3 runs per runtime:

| runtime | microtask | nextTick | stream-end |
|---|---|---|---|
| node | ✓ | ✓ | ✓ |
| bun | ✓ | ✓ | ✓ |
| **deno** | ✓ | **✗** | **✗** |

## Fix

The deno drain now mirrors node's own `task_queues.js` shape via `core.runNextTicks()` — a microtask checkpoint when no ticks are pending, the full ticks-and-microtasks interleave when there are — with a fallback to `runMicrotasks()` on older deno_core.

`test/blocking-run-checkpoint.test.mjs` pins the property and **fails without the fix** on deno (2/2 runs). Wired into the bun/deno cross-runtime gate so it is checked on every runtime that must hold it.

## Evidence

- **deno reaches live gameplay** — full level, HUD, animating sprites within ~15 s, verified twice by devtools D-Bus screenshot
- cross-runtime **deno 38/38**, **bun 38/38**; node suite **444 tests, 0 fail**
- golden conformance byte-identical to gjs on all four runtimes; `gjsify lint` exit 0

## Deliberately untouched

Both XHR implementations and `@gjsify/fetch` — they were not defective, and "fixing" them would have masked the bridge-level class. Also left: `setTimeout`/`setImmediate` still starving during a blocking run on bun/deno (runtime timers; the uv co-pump is Node-only by design).

https://claude.ai/code/session_01ScXtAf6EHBUhspbHy3eQxE