### PR TITLE
ci(node-gi): tolerate the release window when installing @gjsify/cli

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -474,8 +474,17 @@ jobs:
         run: |
           CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
           mkdir -p /tmp/gjsify-node-cli
+          # Prefer the version this checkout declares, but do NOT require it to be
+          # on npm yet. The release commit bumps every package.json and only THEN
+          # does release.yml publish, so between those two events this step asks
+          # npm for a version that provably does not exist — `npm error notarget
+          # No matching version found for @gjsify/cli@<v>` — and reddens main on
+          # every single release. A recurring, self-resolving red teaches people
+          # to ignore the signal. Same guard napi.yml already carries.
           ( cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1 \
-            && npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save )
+            && ( npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save 2>/dev/null \
+                 || { echo "::warning::@gjsify/cli@${CLI_VERSION} is not on npm (yet) — falling back to @latest."; \
+                      npm install "@gjsify/cli@latest" --no-audit --no-fund --no-save; } ) )
           ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
           echo "Node bundler: $(node_modules/.bin/gjsify --version)"
 
@@ -833,8 +842,17 @@ jobs:
         run: |
           CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
           mkdir -p /tmp/gjsify-node-cli
+          # Prefer the version this checkout declares, but do NOT require it to be
+          # on npm yet. The release commit bumps every package.json and only THEN
+          # does release.yml publish, so between those two events this step asks
+          # npm for a version that provably does not exist — `npm error notarget
+          # No matching version found for @gjsify/cli@<v>` — and reddens main on
+          # every single release. A recurring, self-resolving red teaches people
+          # to ignore the signal. Same guard napi.yml already carries.
           ( cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1 \
-            && npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save )
+            && ( npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save 2>/dev/null \
+                 || { echo "::warning::@gjsify/cli@${CLI_VERSION} is not on npm (yet) — falling back to @latest."; \
+                      npm install "@gjsify/cli@latest" --no-audit --no-fund --no-save; } ) )
           ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
           mkdir -p node_modules/@gjsify
           ln -sfn ../../packages/node-gi/node-gi node_modules/@gjsify/node-gi
@@ -1725,8 +1743,17 @@ jobs:
         run: |
           CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
           mkdir -p /tmp/gjsify-node-cli
+          # Prefer the version this checkout declares, but do NOT require it to be
+          # on npm yet. The release commit bumps every package.json and only THEN
+          # does release.yml publish, so between those two events this step asks
+          # npm for a version that provably does not exist — `npm error notarget
+          # No matching version found for @gjsify/cli@<v>` — and reddens main on
+          # every single release. A recurring, self-resolving red teaches people
+          # to ignore the signal. Same guard napi.yml already carries.
           ( cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1 \
-            && npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save )
+            && ( npm install "@gjsify/cli@${CLI_VERSION}" --no-audit --no-fund --no-save 2>/dev/null \
+                 || { echo "::warning::@gjsify/cli@${CLI_VERSION} is not on npm (yet) — falling back to @latest."; \
+                      npm install "@gjsify/cli@latest" --no-audit --no-fund --no-save; } ) )
           ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
           echo "Node bundler: $(node_modules/.bin/gjsify --version)"
 


### PR DESCRIPTION
Three jobs — the consumer harness, the sqlite consumer suite and the Adwaita Storybook bundle — went red on `main` immediately after the v0.25.0 cut:

```
npm error code ETARGET
npm error notarget No matching version found for @gjsify/cli@0.25.0.
```

They install the **published** `@gjsify/cli` pinned to the version this checkout declares. The release commit bumps every `package.json`, and `release.yml` publishes only *after* — so for the window between, the workspace asks npm for a version that provably does not exist. Every release reddens main, then goes green on its own once publishing finishes.

That is the worst shape a CI failure can have: recurring, attributable to nothing anyone did, and self-resolving. It teaches people that a red main is noise — which is how three genuinely broken jobs went unnoticed here earlier today behind a cache-skipped step.

`napi.yml` already solved this, comment and all: try the declared version, fall back to `@latest` with a `::warning::` naming why. Same guard, now in the workflow that lacked it, at all three install sites.

Companion to `ci/release-cut-triggers-publish`, which fixes why the publish didn't happen at all.

https://claude.ai/code/session_01ScXtAf6EHBUhspbHy3eQxE