### PR TITLE
docs: add ADR 0017 for native package distribution

### DIFF
--- a/docs/adr/0017-native-package-distribution.md
+++ b/docs/adr/0017-native-package-distribution.md
@@ -1,0 +1,171 @@
+# 17. Distribution of platform-specific native builds
+
+- Status: **Accepted**
+- Date: 2026-07-31
+- Deciders: Pascal Garber
+- Related: [ADR 0003 (tiering)](0003-package-tiering.md), [ADR 0001 (install separation)](0001-install-clean-separation.md), AGENTS.md § "Prebuilds", § "New `@gjsify/*` package: first-publish + Trusted Publisher bootstrap"
+
+## Context
+
+Eleven `@gjsify/*` packages ship compiled artifacts as committed
+`prebuilds/<os>-<arch>/` directories inside **one** npm tarball, declared via
+`package.json#gjsify.platforms` and audited by `scripts/audit-runtimes.mjs`.
+
+Measured on this tree:
+
+| | |
+|---|---|
+| committed prebuild bytes | **97.3 MB** across 11 packages |
+| usable by a `linux-x64` consumer | **31.5 MB** |
+| downloaded and never loadable | **65.8 MB (68 %)** |
+
+Worst single case: `@gjsify/lightningcss-native` at 46.4 MB for six targets.
+
+The npm ecosystem solved this years ago, and we already *consume* the solution
+without *producing* it. The established pattern — esbuild, napi-rs, rolldown,
+oxc, lightningcss upstream — is:
+
+- the main package declares **no** `os`/`cpu` and lists one
+  `optionalDependencies` entry per target (`esbuild` has **26**);
+- each platform package declares `os: ["linux"], cpu: ["x64"]` and contains only
+  that binary;
+- the package manager installs the matching one and **silently skips** the
+  rest — silently, because a platform mismatch on an *optional* dependency is
+  not an error (on a required one it is `EBADPLATFORM`);
+- the main package resolves its installed sibling at runtime.
+
+The older approach — a `postinstall` script downloading a binary
+(`node-pre-gyp`, `prebuild-install`) — is in retreat because `--ignore-scripts`
+is increasingly the default in CI and in security-conscious installs. esbuild
+migrated away from it for exactly that reason. We should not adopt it.
+
+**Both halves of this are ours to fix, and they are independent:**
+
+1. *Consumer side* — honouring `os`/`cpu` when installing other people's
+   packages. `gjsify install` did not, so a linux-x64 tree carried **166
+   packages / 3563 MB / 62 % of all bytes** of foreign-platform binaries,
+   including all 26 `@esbuild/*`. Addressed by the platform-filter work
+   (`feat/install-platform-filter`); this ADR does not re-decide it.
+2. *Publisher side* — how **we** ship our own binaries. That is what this ADR is
+   about, and today we are the thing our own filter cannot help with: one
+   tarball, every platform, no `os`/`cpu` anywhere for a resolver to act on.
+
+## Decision drivers
+
+- A consumer should not download bytes their machine cannot load.
+- The bootstrap property must survive: `gjsify install --immutable` on a fresh
+  clone, no Node, driven by the committed GJS bundle.
+- Adding a published `@gjsify/*` name is **expensive and serialising**: npm
+  Trusted Publishing requires the package to already exist, so the first publish
+  is a manual maintainer action. Skipping it breaks the whole serialized
+  `npm:publish` loop — the v0.4.20 incident left 60+ packages stuck at the
+  previous version because one new name had no bootstrap.
+- The audit chain (`gjsify.platforms` → CI matrix → committed artifact →
+  loadability) is hard-won and must keep working, not be replaced by faith.
+
+## Options
+
+### A — Status quo: one tarball, all targets
+
+*Keep.* Zero migration cost, zero new names, the audit chain is unchanged.
+Costs every consumer 68 % waste, and the number grows with each new target: the
+emulated ppc64/s390x/riscv64 legs exist precisely so those platforms work, and
+each one taxes the 95 % of users who are not on them.
+
+### B — esbuild model: `optionalDependencies` per target
+
+The ecosystem standard. A consumer on linux-x64 fetches only linux-x64.
+Composes with the platform filter we just built — our own packages become
+skippable by the same rule as everyone else's.
+
+Cost, measured: **52 new npm package names** (the sum of declared targets across
+the 11 packages), each needing the manual first-publish + Trusted-Publisher
+bootstrap before the next release train, or the train stops.
+
+### C — postinstall download
+
+Rejected on the evidence above: `--ignore-scripts` breaks it, it is why esbuild
+left, and it would put a network fetch inside an install path whose
+non-destructive and hang-safety invariants (ADR 0001) we deliberately hardened.
+
+### D — Hybrid, by weight
+
+Split only where the waste is material; keep single-tarball where it is noise.
+The distribution is extremely skewed: three packages (`lightningcss-native`,
+`rolldown-native`, `oxfmt-native`) are **87.7 MB of the 97.3 MB**; the remaining
+eight together are 9.6 MB, and several are under 1 MB, where a second package
+name costs more in release-train risk than it saves in bytes.
+
+Splitting only those three: **~12 new names** instead of 52, removing the large
+majority of the waste.
+
+## Decision
+
+**Option B — the esbuild model, applied to every native package.** ~52 new
+per-target packages `@gjsify/<name>-<os>-<arch>`, each declaring `os`/`cpu`,
+referenced as `optionalDependencies` from a main package that keeps its current
+name, API and loader contract.
+
+Option D (split only the three heavy bridges) was drafted first and rejected on
+review. Its saving — 12 names instead of 52 — buys a **threshold**, and a
+threshold is a hand-maintained judgement that gets re-litigated per package and
+drifts. This repo has spent considerable effort this month replacing exactly
+that shape with derived rules. One rule for all native packages is auditable;
+"~5 MB of non-host bytes" is not.
+
+1. Split **all 11** native packages into per-target packages.
+2. `gjsify.platforms` stays the single declaration. Extend
+   `audit-runtimes.mjs` to verify, for every declared target, that a
+   corresponding `optionalDependencies` entry exists **and** that its `os`/`cpu`
+   match the target name — otherwise we trade one silent drift for another.
+3. Do the first-publish + Trusted-Publisher bootstrap for all new names in **one
+   `gjsify onboard` sweep before** the split lands, so no release train is
+   blocked on a missing name.
+4. **Sequencing (load-bearing):** the platform filter
+   (`feat/install-platform-filter`) must land and be proven **first**. After the
+   split, our own packages' installability depends on our own installer
+   honouring `optionalDependencies` + `os`/`cpu`. Shipping the split against an
+   unproven filter would make our packages fail in the hardest-to-diagnose way:
+   a main package searching for a sibling that was never installed.
+
+## Consequences
+
+**Good.** A linux-x64 consumer stops downloading ~66 MB they cannot load. Our
+own packages become subject to the same platform filtering as everyone else's,
+so the two halves of the problem get one consistent answer. Adding an exotic
+target (the emulated arches) stops taxing every other user, which lowers the
+cost of supporting more platforms — the OS axis gets cheaper to widen.
+
+**Bad.** ~52 new published names, each an irreversible npm namespace claim and a
+manual bootstrap step. The release train gains 52 more things that must already
+exist, and every future target adds one more — the `gjsify onboard` sweep is
+what keeps that from becoming a per-release chore, so it must stay working. A
+consumer whose platform package genuinely failed to install now gets a missing
+sibling rather than a missing directory: the loader must say which package it
+expected, not just "typelib not found".
+
+**Cheaper than the draft assumed.** Runtime discovery needs no new code path:
+`detectNativePackages` (`packages/infra/cli/src/utils/detect-native-packages.ts`)
+already scans *every* package in `node_modules` for a `gjsify.prebuilds` field
+and its `prebuilds/<target>/` directory, so a split package is found by exactly
+the mechanism that finds a bundled one. The loader contract is unchanged; only
+which tarball the directory arrives in changes. This removed the largest
+objection to Option B.
+
+**Neutral.** The committed-prebuild audit chain stays; only its shape per
+package changes. The bootstrap property is unaffected: the CLI's own bundle does
+not depend on the heavy bridges at install time.
+
+**Accepted cost at the small end.** `@gjsify/terminal-native` is 0.3 MB across
+six targets — a split saves a consumer ~250 KB and adds five package names,
+five registry entries and five bootstraps. Uniformity is chosen over that
+marginal loss deliberately; see the Decision.
+
+## Open question for implementation
+
+Whether the split packages should also carry `gjsify.platforms` (a one-element
+list, self-describing) or omit it and let the main package's list be
+authoritative. The former is more redundant but keeps every published tarball
+self-checking; the latter keeps one source of truth. Decide when writing the
+audit rule in step 3 — whichever choice makes a wrong declaration *impossible*
+rather than merely unlikely.


### PR DESCRIPTION
Eleven `@gjsify/*` packages ship **every** platform's binary in one tarball.
Measured on this tree:

| | |
|---|---|
| committed prebuild bytes | **97.3 MB** across 11 packages |
| usable by a `linux-x64` consumer | **31.5 MB** |
| downloaded and never loadable | **65.8 MB (68 %)** |

Worst single case: `@gjsify/lightningcss-native`, 46.4 MB for six targets.

## The ecosystem settled this; we consume the solution without producing it

`esbuild` declares **no** `os`/`cpu` itself and lists **26
`optionalDependencies`** — one per target, each declaring its own `os`/`cpu`.
The resolver installs the match and *silently* skips the rest, because a
platform mismatch on an **optional** dep is not an error (on a required one it
is `EBADPLATFORM`). napi-rs, rolldown, oxc and lightningcss upstream all ship
this way. The older `postinstall`-download approach (`node-pre-gyp`,
`prebuild-install`) is in retreat because `--ignore-scripts` keeps breaking it —
which is why esbuild left it.

Both halves are ours and they are independent: honouring `os`/`cpu` when
installing *other people's* packages (the platform-filter work — a linux-x64
tree here carries 166 foreign-platform packages / 3563 MB, including all 26
`@esbuild/*`), and how **we** publish our own. This ADR decides the second.

## Decision: Option B — the esbuild model, everywhere

~52 new per-target packages `@gjsify/<name>-<os>-<arch>`, each declaring
`os`/`cpu`, referenced as `optionalDependencies` from a main package that keeps
its name, API and loader contract.

**Option D — split only the three heavy bridges (12 names instead of 52) — was
drafted first and rejected on review.** Its saving buys a *threshold*, and a
hand-maintained threshold is re-litigated per package and drifts. That is the
exact shape this repo has spent the month replacing with derived rules; adding a
new one would be odd. One rule for all native packages is auditable.

## Two findings that shaped the decision

**Against, and load-bearing for sequencing:** after the split, our own packages'
installability depends on **our own installer** honouring `optionalDependencies`
+ `os`/`cpu`. That code is new and not yet through its gates. Shipping the split
against an unproven filter fails in the hardest-to-diagnose way — a main package
hunting a sibling that was never installed. So the platform filter lands and is
proven **first**; that is step 4 of the decision, not a footnote.

**In favour, and it removed the biggest objection:** runtime discovery needs no
new code path. `detectNativePackages` already scans *every* package in
`node_modules` for a `gjsify.prebuilds` field and its `prebuilds/<target>/`
directory, so a split package is found by exactly the mechanism that finds a
bundled one. Only which tarball the directory arrives in changes.

## Accepted costs

52 irreversible npm namespace claims, each needing the manual first-publish +
Trusted-Publisher bootstrap — done in **one `gjsify onboard` sweep before** the
split lands, or the serialized release train stops (the v0.4.20 incident left
60+ packages stuck for exactly this reason). And at the small end
`@gjsify/terminal-native` is 0.3 MB across six targets, so a split saves ~250 KB
and adds five names; uniformity is chosen over that deliberately.

Implementation is **not** in this PR — the ADR records the decision, and step 4
sequences it behind the platform filter.

https://claude.ai/code/session_01ScXtAf6EHBUhspbHy3eQxE