### PR TITLE
ci: close the gjs-less host coverage gap

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -50,10 +50,9 @@ cd "$REPO_ROOT"
 # bundle uses the same version the workspace declares (matters during a
 # version bump where the global gjsify on PATH may drift from
 # packages/infra/cli/package.json#version). Fall back to PATH, then to the
-# committed GJS bundle itself (works on a freshly-cloned repo with no
-# node_modules yet — but that's a near-impossible case here because we're
-# about to invoke `gjsify workspace ... build` which itself needs the
-# workspace to be installed).
+# committed GJS bundle itself. Resolving one of those says NOTHING about
+# whether this tree can BUILD — the guard below is the precondition that
+# actually matters, and the two diverge in every fresh worktree.
 
 if [ -x "$REPO_ROOT/node_modules/.bin/gjsify" ]; then
     GJSIFY="$REPO_ROOT/node_modules/.bin/gjsify"
@@ -64,6 +63,28 @@ elif command -v gjs >/dev/null 2>&1 && [ -f "$REPO_ROOT/packages/infra/cli/dist/
 else
     echo "::warning::[gjsify pre-commit] no gjsify CLI on PATH and no node_modules/.bin/gjsify;"
     echo "::warning::[gjsify pre-commit] skipping bundle freshness check. Run 'gjsify install' first."
+    exit 0
+fi
+
+# Finding a CLI is NOT the precondition — BUILDING is, and the two diverge.
+# The rebuild below runs `gjsify workspace @gjsify/cli build`, whose `build`
+# script is a plain `tsc` resolved from THIS tree's node_modules. A freshly
+# added git worktree — the standard isolated-agent flow, not the "near
+# impossible" case the comment above assumed — resolves a CLI just fine via
+# PATH or the committed bundle and has no node_modules at all. The hook then
+# sailed past the skip above and died on `tsc: command not found`, turning a
+# documented graceful skip into a hard commit failure exactly where it is
+# least recoverable: mid-commit, in a tree the author has not installed.
+#
+# Skipping is safe by design. This hook is BEST-EFFORT (its trigger list is a
+# four-path heuristic over a bundle that inlines the whole workspace-dep
+# closure); `verify-committed-bundles.mjs` in CI is the exhaustive check and
+# fails the PR with exact commands. A skip costs a red CI run; a hard failure
+# costs the commit.
+if [ ! -d "$REPO_ROOT/node_modules" ]; then
+    echo "::warning::[gjsify pre-commit] no node_modules in $REPO_ROOT — cannot rebuild the bundle(s);"
+    echo "::warning::[gjsify pre-commit] skipping bundle freshness check. Run 'gjsify install' in THIS tree first."
+    echo "::warning::[gjsify pre-commit] CI (verify-committed-bundles.mjs) remains the exhaustive check."
     exit 0
 fi
 

--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -133,6 +133,37 @@ jobs:
           # extension-less `sh` member of the trio).
           ./node_modules/.bin/gjsify --version
 
+      # `showcase` is the first thing a user runs, and the ONLY command that
+      # asks about SYSTEM dependencies. This runner has no gjs — which is
+      # exactly why the step belongs here: every Linux job has gjs installed,
+      # so "does this work without gjs" is a question they structurally cannot
+      # ask, and the environment answers it before the test can. That blind
+      # spot shipped a pre-flight demanding a gjs binary for `--runtime node`
+      # (#889) — every showcase unreachable for every Windows / plain-Node
+      # user, on the default path too.
+      #
+      # Probes a gjs-ONLY showcase so the run ends at the declaration check:
+      # no bundle, no node-gi, no GTK on the runner. WHICH error comes back is
+      # the assertion — the declaration one means the runtime was resolved
+      # first, the GJS one means it was not.
+      #
+      # This job installs the PUBLISHED CLI, so the step stays red until the
+      # fix ships. That is the signal working as designed: it turns green
+      # exactly when the fix reaches users, which is what this job measures.
+      - name: 'Showcase: --runtime node does not demand gjs'
+        id: showcase
+        continue-on-error: true
+        working-directory: gjsify-diag
+        run: |
+          set -eux
+          out="$(npx gjsify showcase webrtc-loopback --runtime node 2>&1 || true)"
+          echo "$out"
+          if echo "$out" | grep -q "Missing system dependencies"; then
+            echo "::error::showcase demanded gjs for --runtime node — the runtime gate ran too early"
+            exit 1
+          fi
+          echo "$out" | grep -q "does not support --runtime node"
+
       - name: Diagnostic summary
         run: |
           echo "## gjsify CLI on ${{ matrix.os }} (Node)" >> "$GITHUB_STEP_SUMMARY"
@@ -143,6 +174,7 @@ jobs:
           echo "| run the bundle | ${{ steps.run.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| gjsify install (backend) | ${{ steps.install.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| .bin shim created + runnable | ${{ steps.binshim.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| showcase --runtime node (no gjs) | ${{ steps.showcase.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "--- outcomes: version=${{ steps.version.outcome }} build=${{ steps.build.outcome }} run=${{ steps.run.outcome }} install=${{ steps.install.outcome }} binshim=${{ steps.binshim.outcome }}"
           # Every substantive step stays continue-on-error so ONE run still maps
           # ALL the gaps; the gate lives here, at the end.
@@ -161,6 +193,10 @@ jobs:
           if [ "${{ steps.run.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "${{ steps.install.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "${{ steps.binshim.outcome }}" != "success" ]; then FAILED=1; fi
+          # `showcase` gates like the rest. It measures the PUBLISHED CLI, so
+          # it stays red until the #889 fix ships and turns green on its own
+          # when it does — a known, self-resolving gap, not a permanent one.
+          if [ "${{ steps.showcase.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "$FAILED" = "0" ]; then
             echo "CLI PATH GREEN on ${{ matrix.os }} (toolchain + install backend)"
           else

--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -147,20 +147,44 @@ jobs:
       # the assertion — the declaration one means the runtime was resolved
       # first, the GJS one means it was not.
       #
-      # This job installs the PUBLISHED CLI, so the step stays red until the
-      # fix ships. That is the signal working as designed: it turns green
-      # exactly when the fix reaches users, which is what this job measures.
+      # This job measures the PUBLISHED CLI, which necessarily lags the fix.
+      # So the EXPECTATION is bound to the installed version rather than
+      # asserted unconditionally: below the first release carrying the fix a
+      # gjs demand is a KNOWN gap — reported, not failed; from that release on
+      # it is a regression and fails. The gate therefore arms ITSELF on the
+      # release that fixes it, with no edit here and no hand-maintained
+      # "currently skipped" list to drift.
+      #
+      # LOWEST_FIXED is a BOUND, not a prediction of the next version number:
+      # the fix merged after 0.25.1, and every later release compares >= 0.25.2
+      # in semver order (0.26.0 included).
       - name: 'Showcase: --runtime node does not demand gjs'
         id: showcase
         continue-on-error: true
         working-directory: gjsify-diag
+        env:
+          LOWEST_FIXED: '0.25.2'
         run: |
           set -eux
           out="$(npx gjsify showcase webrtc-loopback --runtime node 2>&1 || true)"
           echo "$out"
+          INSTALLED="$(node -p "require('./node_modules/@gjsify/cli/package.json').version")"
+          # Compared in node (present by definition here); `sort -V` is not
+          # portable across git-bash and BSD userland. Values travel through
+          # the environment, never through string interpolation.
+          HAS_FIX="$(INSTALLED="$INSTALLED" node -e '
+            const parse = (v) => v.split("-")[0].split(".").map(Number);
+            const [a, b] = [process.env.INSTALLED, process.env.LOWEST_FIXED].map(parse);
+            const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+            process.stdout.write(cmp >= 0 ? "1" : "0");
+          ')"
           if echo "$out" | grep -q "Missing system dependencies"; then
-            echo "::error::showcase demanded gjs for --runtime node — the runtime gate ran too early"
-            exit 1
+            if [ "$HAS_FIX" = "1" ]; then
+              echo "::error::@gjsify/cli $INSTALLED demanded gjs for --runtime node — the runtime gate ran too early"
+              exit 1
+            fi
+            echo "::warning::@gjsify/cli $INSTALLED predates the runtime-gate fix (< $LOWEST_FIXED) — known gap, not failing"
+            exit 0
           fi
           echo "$out" | grep -q "does not support --runtime node"
 
@@ -194,8 +218,9 @@ jobs:
           if [ "${{ steps.install.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "${{ steps.binshim.outcome }}" != "success" ]; then FAILED=1; fi
           # `showcase` gates like the rest. It measures the PUBLISHED CLI, so
-          # it stays red until the #889 fix ships and turns green on its own
-          # when it does — a known, self-resolving gap, not a permanent one.
+          # its EXPECTATION is version-bound (see the step): a gjs demand from
+          # a CLI predating the fix warns and passes; from the first release
+          # carrying it, the same demand fails. Nothing to remember later.
           if [ "${{ steps.showcase.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "$FAILED" = "0" ]; then
             echo "CLI PATH GREEN on ${{ matrix.os }} (toolchain + install backend)"

--- a/tests/e2e/gjs-less-host/run.mjs
+++ b/tests/e2e/gjs-less-host/run.mjs
@@ -1,0 +1,139 @@
+// E2E for the CLI on a host WITHOUT gjs.
+//
+// Why this suite exists: "is gjs on PATH" is an environment property that
+// every Linux CI job answers YES to, so "does this work without gjs" is a
+// question those jobs structurally cannot ask — the environment answers it
+// before any test can. The only runners without gjs are macOS/Windows in
+// `cli-cross-platform.yml`, which is main-only and measures the PUBLISHED
+// CLI, so nothing gated PR code on it.
+//
+// That blind spot shipped #889: `gjsify showcase --runtime node` ran a
+// system-dependency pre-flight marking `gjs` as required BEFORE resolving the
+// runtime, making every showcase unreachable for every Windows / plain-Node
+// user — on the default path too, since `defaultExampleRuntime()` falls back
+// to the host runtime on exactly those hosts.
+//
+// The fix is not a gjs-less runner: it is to stop treating "gjs exists" as a
+// host property and make it an INJECTED one. Same move the repo already makes
+// for the OS axis, where `resolvePrebuildDirName`/`libraryPathVar` are pure
+// functions of `(platform, arch, …)` so darwin/win32 branches are unit-tested
+// from Linux by injecting foreign values. Here the injected value is PATH.
+//
+// The scrub REMOVES the directories that hold a `gjs` binary and keeps
+// everything else — node stays reachable, which is what a real Windows or
+// plain-Node host looks like. An empty PATH would prove something narrower
+// and would break the launcher paths that legitimately spawn node.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, delimiter } from 'node:path';
+
+const cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+
+/** PATH with every directory containing a `gjs` binary removed. */
+function pathWithoutGjs() {
+    const names = process.platform === 'win32' ? ['gjs.exe', 'gjs.cmd', 'gjs'] : ['gjs'];
+    return (process.env.PATH ?? '')
+        .split(delimiter)
+        .filter((d) => d && !names.some((n) => existsSync(join(d, n))))
+        .join(delimiter);
+}
+
+function runCli(args, { cwd, env, timeoutMs = 60_000 } = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [cliEntry, ...args], {
+            cwd,
+            env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.setEncoding('utf-8');
+        child.stderr.setEncoding('utf-8');
+        child.stdout.on('data', (c) => (stdout += c));
+        child.stderr.on('data', (c) => (stderr += c));
+        // ChildProcess.kill with a known signal never throws — a failure to
+        // deliver just returns false (the process already exited).
+        const kill = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
+        child.on('close', (status) => {
+            clearTimeout(kill);
+            resolve({ status, stdout, stderr });
+        });
+        child.on('error', (e) => {
+            clearTimeout(kill);
+            reject(e);
+        });
+    });
+}
+
+describe('gjsify CLI on a host without gjs', { timeout: 180_000 }, () => {
+    let dir;
+    let env;
+
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-gjs-less-'));
+        env = { ...process.env, PATH: pathWithoutGjs() };
+        // `gjsify build` resolves config upward from the entry and fails with
+        // "Cannot find matching package.json" without one — the same reason
+        // `cli-cross-platform.yml` runs `npm init -y` before building.
+        writeFileSync(
+            join(dir, 'package.json'),
+            JSON.stringify({ name: 'gjsify-e2e-gjs-less', version: '0.0.0', private: true }),
+        );
+        // Only a `node:` builtin: on the node target those stay native, so the
+        // build needs no `@gjsify/*` resolution from this out-of-tree fixture.
+        writeFileSync(
+            join(dir, 'hello.ts'),
+            "import { platform } from 'node:os';\nconsole.log('GJS_LESS_OK', platform());\n",
+        );
+    });
+
+    // NEGATIVE CONTROL — without it a green suite could equally mean the scrub
+    // never took effect and gjs was reachable all along, which is the failure
+    // mode this whole suite exists to rule out. It also self-skips honestly on
+    // a host that has no gjs to begin with: there the scrub is a no-op and the
+    // remaining assertions are still exactly the ones we want.
+    it('the PATH scrub actually hides gjs', () => {
+        const before = spawnSync('gjs', ['--version'], { stdio: 'ignore' });
+        if (before.error) {
+            // No gjs installed here — the scrub is vacuous but the suite still
+            // measures the right thing.
+            return;
+        }
+        const after = spawnSync('gjs', ['--version'], { stdio: 'ignore', env });
+        assert.ok(after.error, 'gjs is still reachable after scrubbing PATH — the fixture is broken');
+    });
+
+    it('reports its version', async () => {
+        const r = await runCli(['--version'], { cwd: dir, env });
+        assert.equal(r.status, 0, r.stderr);
+        assert.doesNotMatch(r.stderr, /Missing system dependencies/);
+    });
+
+    it('builds an --app node bundle', async () => {
+        const r = await runCli(['build', 'hello.ts', '--app', 'node', '--outfile', 'hello.node.mjs'], {
+            cwd: dir,
+            env,
+        });
+        assert.doesNotMatch(r.stderr, /Missing system dependencies/);
+        assert.equal(r.status, 0, r.stderr);
+        assert.ok(existsSync(join(dir, 'hello.node.mjs')), 'no bundle emitted');
+    });
+
+    // `gjsify run <file>` decides the runtime by SNIFFING the bundle
+    // (`isLikelyGjsBundle`), so a `--app node` bundle must launch on the host
+    // runtime and never reach for gjs. This is the path that legitimately
+    // spawns `node`, which is why the scrub keeps the rest of PATH intact.
+    it('runs an --app node bundle on the host runtime', async () => {
+        const r = await runCli(['run', 'hello.node.mjs'], { cwd: dir, env });
+        assert.doesNotMatch(r.stderr, /Missing system dependencies/);
+        assert.match(r.stdout + r.stderr, /GJS_LESS_OK/);
+    });
+
+    after(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+});


### PR DESCRIPTION
Follow-up to #889. That fix was correct; this addresses **why CI let it ship**, plus one hook defect found while authoring it.

## Why #889 was invisible to CI

| | |
|---|---|
| `showcase` is exercised in | `main.yml`, `node-gi.yml` — both on Fedora **with** gjs |
| Runners **without** gjs | `cli-cross-platform.yml` (macOS + Windows) |
| What that job tested | `--version`, `build --app node`, run the bundle, `install`, bin shim |
| What it did **not** test | `showcase`, `run` — the broken path |

A job on exactly the right host that did not exercise the broken command, and jobs exercising the command on the wrong host. The bug lived in the gap.

The deeper shape: **"is gjs on PATH" is an environment property every Linux job answers YES to**, so "does this work without gjs" is a question those jobs structurally cannot ask — the environment answers it before any test can. Same failure mode already catalogued in AGENTS.md, where the whole native-bridge set stayed Linux-only while the project described itself as platform-independent, because `runtimes` says nothing about operating systems.

## 1. `test(e2e)`: a gjs-less host tier

The fix is **not** a gjs-less runner — it is to stop treating "gjs exists" as a host property and make it an *injected* one. That is the move this repo already makes on the OS axis:

> platform logic is a PURE function of `(platform, arch, declaredPlatforms, existingDirs)` so darwin/win32 branches are unit-tested from Linux by **injecting foreign values**

Here the injected value is `PATH`. The scrub removes only the directories holding a `gjs` binary and keeps the rest, so node stays reachable — the shape of a real Windows or plain-Node host. An empty PATH would prove something narrower and break the launcher paths that legitimately spawn node.

Covers `--version`, `build --app node`, and `run` on a `--app node` bundle. Runs on the existing Linux runners, ~1 s, gates PRs.

**Carries a negative control.** Without it a green suite could equally mean the scrub never took effect and gjs was reachable all along — the exact self-deception the tier exists to rule out. It self-skips honestly on a host with no gjs to begin with.

Note this tier is a *regression guard*, not a reproduction of #889: the commands it covers never demanded gjs. The reproduction lives with the showcase suite, where the classifier finds it.

## 2. `ci`: probe showcase on the gjs-less runners

`cli-cross-platform.yml` already scaffolds a project on macOS and Windows. Adding the showcase probe there tests the real thing on a genuinely gjs-less host.

Probes a gjs-**only** showcase under `--runtime node` so the run ends at the declaration check — no bundle, no node-gi, no GTK on the runner. Which error comes back is the assertion.

The job measures the *published* CLI, which necessarily lags the fix — and this workflow triggers on `pull_request` for changes to itself, so an unconditional assertion blocked the very PR introducing it (it did; that was my error, not the probe's — the detection was correct).

Excluding the step from the gate would be the hand-maintained "currently skipped" list AGENTS.md rejects. Instead the **expectation is bound to the installed version**: below the first release carrying the fix, a gjs demand warns and passes; from that release on, the same demand fails. The gate arms itself, with nothing to remember later.

`LOWEST_FIXED` is a bound, not a guess at the next version number — every release after 0.25.1 compares `>= 0.25.2` in semver order. Compared in node (`sort -V` is not portable across git-bash and BSD userland), with both values passed through the environment rather than interpolated.

## 3. `fix(githooks)`: skip when the tree cannot build

Found by hitting it. The hook resolves a CLI via `node_modules/.bin` → PATH → the committed bundle, and skips only when *none* resolves. But finding a CLI is not the precondition — **building** is: the rebuild runs `gjsify workspace @gjsify/cli build`, a plain `tsc` resolved from the tree's own `node_modules`.

A freshly added worktree resolves a CLI fine via PATH and has no `node_modules`, so the hook sailed past its skip and died on `tsc: command not found` — a documented graceful skip turned into a hard commit failure, in exactly the isolated-worktree flow agents use.

The comment above the resolution chain already predicted the case and dismissed it:

> works on a freshly-cloned repo with no node_modules yet — *but that's a near-impossible case here because we're about to invoke `gjsify workspace ... build` which itself needs the workspace to be installed*

It is not near-impossible; it is the standard flow. Corrected too, so the two no longer contradict.

Skipping is safe by design: the hook is best-effort, and `verify-committed-bundles.mjs` is the exhaustive check. A skip costs a red CI run; a hard failure costs the commit.

## Verification

- `tests/e2e/gjs-less-host` — 4/4 pass locally (run unpiped; a piped `node --test` reports the *pipe's* exit code, which is how a failing suite read as green earlier today).
- The hook fix tested behaviourally: fresh `git worktree` with no `node_modules`, staged change under `packages/infra/cli/src/`, commit → warns, skips, succeeds. Previously died on `tsc: command not found`.
- `bash -n` on the hook, YAML parse on the workflow, `oxlint` + `oxfmt --check` clean.
- Version comparison verified over `0.24.9` / `0.25.1` / `0.25.2` / `0.25.10` / `0.26.0` / `1.0.0` / `0.25.2-rc.1` — numeric, not lexicographic, and prerelease-tolerant.
