### PR TITLE
ci(release): dispatch the publish without gh

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -161,16 +161,59 @@ jobs:
       # `workflow_ref` would name THIS file instead and the OIDC exchange would
       # be rejected. A dispatch keeps release.yml a top-level run, so the claim
       # still matches what npmjs.com is configured to trust.
+      # THE LOAD-BEARING STEP. A `release: published` event created with the
+      # workflow's own GITHUB_TOKEN does NOT trigger other workflows (GitHub's
+      # recursion guard), so `release.yml` only ever runs because of this
+      # dispatch. If it does not fire, the release is committed, tagged and
+      # visible on GitHub while NOTHING reaches npm — and the job goes red only
+      # AFTER all of that is already written, which reads like "the cut failed"
+      # when in fact only publishing did.
+      #
+      # It used to call `gh`, which exists on a bare runner image but NOT in
+      # this job's container (ghcr.io/gjsify/ci-fedora:44). The v0.26.0 cut is
+      # where that surfaced: `gh: command not found`, release cut, npm empty,
+      # recovered by dispatching by hand. So dispatch through `node`, which this
+      # job provably has (setup-node ran, and release-it above went through
+      # npx) rather than through a CLI the image is not required to carry.
       - name: Dispatch the npm publish
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           TAG="$(git describe --tags --abbrev=0)"
           echo "dispatching release.yml for $TAG"
-          gh workflow run release.yml --ref main \
-            -f release_tag="$TAG" -f skip_publish=false -f verify_only=false
           echo "PUBLISH_TAG=$TAG" >> "$GITHUB_ENV"
+          TAG="$TAG" node --input-type=module -e '
+            const { GITHUB_TOKEN, REPO, TAG } = process.env;
+            const url = `https://api.github.com/repos/${REPO}/actions/workflows/release.yml/dispatches`;
+            const res = await fetch(url, {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${GITHUB_TOKEN}`,
+                    accept: "application/vnd.github+json",
+                    "x-github-api-version": "2022-11-28",
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    ref: "main",
+                    inputs: { release_tag: TAG, skip_publish: "false", verify_only: "false" },
+                }),
+            });
+            // 204 is the documented success. Anything else means the release is
+            // already cut but unpublished, so say exactly how to finish it by
+            // hand instead of leaving the operator to reconstruct the call.
+            if (res.status !== 204) {
+                console.error(`::error::dispatch failed: HTTP ${res.status} ${await res.text()}`);
+                console.error(
+                    `::error::${TAG} is cut and tagged but NOT on npm. Recover with: ` +
+                        `gh workflow run release.yml --ref main -f release_tag=${TAG} ` +
+                        `-f skip_publish=false -f verify_only=false`,
+                );
+                process.exit(1);
+            }
+            console.log(`dispatched release.yml for ${TAG} (HTTP 204)`);
+          '
 
       - name: Summary
         if: always()

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -267,3 +267,66 @@ explicit acknowledgement path (a `Revert-Of:` trailer, or a label), never a hard
 gate. Cheapest home: a step in the `check` job over `git diff --merge-base`,
 scoped to `*.md` first, since prose is where the class actually bites — source
 regressions of this shape are usually caught by tsc, lint or a test.
+
+### node-gi + napi jobs still `dnf install` from Docker Hub every run
+
+Ten jobs — seven in `node-gi.yml`, three in `napi.yml` — run `container:
+image: fedora:44` and then `dnf install` their package set on every run.
+`main.yml` stopped doing that long ago: `build-ci-image.yml` bakes the packages
+into `ghcr.io/gjsify/ci-fedora:<major>`, and its own header says why ("saves
+3-5 minutes per matrix entry"). These ten never adopted it.
+
+During the v0.26.0 release sweep the cost was not three minutes. `napi` failed
+outright when `docker pull fedora:44` timed out against registry-1.docker.io
+three times before the container existed, and the storybook bundle job was
+killed by its 45-minute timeout TWICE with ~41 of those minutes inside a single
+`dnf install` — a step that takes 22 seconds on a good day. Neither failure had
+anything to do with the code; the same commit was green on the PR.
+
+Not a one-line switch to `ci-fedora`, which is why this is a TODO and not a
+drive-by: several of these jobs are minimal ON PURPOSE (the Node-free install
+proof, "no system GTK" conformance), and `ci-fedora` carries gjs, GTK and the
+blueprint toolchain. The shape that keeps the property is a SECOND baked image
+holding exactly this package set, built by the same workflow. Per-job judgement
+needed on which of the ten want which image.
+
+### The squash subject is what lands on main, and nothing lints it
+
+`commitlint.yml` runs `wagoid/commitlint-github-action`, which lints the PR's
+COMMITS. With squash merges, what actually lands is the PR TITLE — a string no
+check inspects. `f51fa0f57 Run the transparent addon matrix in CI (#849)` has
+no conventional prefix and is therefore absent from the generated CHANGELOG
+entirely; the work shipped in v0.26.0 with no release note. The workflow
+already triggers on `edited` (title/body changes), which only re-runs the
+commit lint today — the intent was there, the check never was.
+
+The trap when fixing it: a hand-rolled title regex is a partial reimplementation
+of commitlint (`config-conventional` also enforces `subject-case`,
+`subject-full-stop`, `header-max-length`), so it would pass titles the real
+linter rejects — the exact drift the rule exists to prevent. Running
+`@commitlint/cli` against `commitlint.config.cjs` needs `config-conventional`
+resolvable from the repo, which is precisely what the action avoids by bringing
+its own. Decide deliberately between a purpose-built title action and making
+the config self-contained; do not hand-roll the regex.
+
+### CHANGELOG links break on `#nnn` written inside commit bodies
+
+conventional-changelog scans commit BODIES for issue references, so prose like
+"pre-#885" or "#870/#873" becomes a link to `github.com/gjsify/pre-/issues/885`
+and `github.com/870/gjsify/issues/873`. Both are in the published v0.26.0
+changelog. Either stop writing bare `#nnn` mid-sentence in commit bodies (a
+convention nothing enforces, so it will regress), or configure the parser's
+`issuePrefixes`/reference handling so only trailer-style references count.
+
+### Nothing byte-compares a committed prebuild, and macOS re-commits noise
+
+AGENTS.md already records that committed `prebuilds/**` binaries are unguarded
+(provenance proves the inputs; nothing compares the bytes). The v0.26.0 sweep
+showed the other half of that gap: `commit-prebuilds` pushed six darwin-arm64
+dylibs whose sizes were IDENTICAL to their predecessors (37144 -> 37144, and so
+on) but whose bytes differed — non-reproducible Mach-O output (timestamps,
+UUIDs). So every macOS prebuild run commits binary churn with no semantic
+change, and that push moved `main` out from under an already-verified sweep
+mid-release. Worth fixing at the source (reproducible flags) rather than by
+suppressing the commit, since byte-reproducibility is what would let a future
+check compare a committed prebuild against a CI-built one at all.


### PR DESCRIPTION
The v0.26.0 cut went red on its last step with `gh: command not found`.

`release-cut.yml` runs inside `ghcr.io/gjsify/ci-fedora:44`, which does not carry the GitHub CLI; the step was written against a bare runner image, where it is preinstalled. It was the first real (non-dry-run) pass through this workflow, so nothing had exercised it.

**Why it was expensive rather than cosmetic.** A `release: published` event created with the workflow's own `GITHUB_TOKEN` does not trigger other workflows — GitHub's recursion guard — so `release.yml` runs *only* because of this dispatch (that is why #874 added it). When it dies, the release is already committed, tagged and public while nothing reaches npm, and the job reports failure *after* all of that is written, which reads like the cut failed when only publishing did. v0.26.0 was recovered by dispatching by hand.

**The fix.** Dispatch through `node`, which this job provably has (setup-node ran, and release-it went through npx), rather than through a CLI the image is not required to carry. Plain `fetch` against the workflow-dispatch endpoint; inputs travel via `env:` and are read from `process.env`, nothing interpolated into the script body. On any status other than the documented 204 it prints the exact `gh workflow run` recovery line, so the operator does not reconstruct the call from workflow source while a half-finished release sits on main.

**Verification** — both branches, against the real API:

| case | result |
|---|---|
| deliberately invalid token | HTTP 401, recovery message printed, exit 1 |
| identical request, harmless inputs (`skip_publish`/`verify_only` true, empty tag) | HTTP 204, exit 0 |

The 204 case is the one that proves the input *names* and their string typing — a 401 fails before the payload is ever validated, so the failure test alone could not have caught a typo there.

Also records four gaps the same release sweep exposed in `status/open-todos.md`, each with the incident that revealed it: the ten node-gi/napi jobs still `dnf install`ing from Docker Hub (which cost two 45-minute timeouts and one hard failure this sweep), the unlinted squash subject (#849 shipped in v0.26.0 with no changelog entry), broken changelog links from `#nnn` in commit bodies, and non-reproducible macOS prebuilds re-committing byte noise that moved `main` mid-release.