### PR TITLE
ci: bake what the bare-fedora jobs install, and check it

### DIFF
--- a/.docker/ci-fedora.Dockerfile
+++ b/.docker/ci-fedora.Dockerfile
@@ -45,9 +45,14 @@ RUN dnf install -y \
 #
 # `glib2` (NOT just `glib2-devel`) ships the `glib-compile-resources` binary
 # that the `gjsify gresource` test hard-requires; `gettext` ships `msgfmt`
-# for the `gjsify gettext` test. This list MUST stay in lockstep with the
-# "Install GJS and GNOME development libraries" step in
-# `.github/workflows/main.yml` — that file is the source of truth.
+# for the `gjsify gettext` test.
+#
+# This list used to carry "MUST stay in lockstep with main.yml" — a convention
+# with nothing behind it, which is the shape of every drift this repo has paid
+# for. `scripts/check-ci-image-packages.mjs` now derives the answer: any job
+# running ON this image that still `dnf install`s something absent here is a
+# CI failure naming the package, and any job on a bare `fedora:<major>` must
+# appear in that script's ledger with a reason.
 RUN dnf install -y \
     gjs \
     glib2 \
@@ -80,6 +85,52 @@ RUN dnf install -y \
     gcc \
     pkgconf \
     blueprint-compiler \
+    && dnf clean all
+
+# Everything the node-gi / napi / prebuild / release jobs install for
+# themselves today. Those thirteen jobs run on a bare `fedora:<major>` and
+# `dnf install` their set at the start of EVERY run, which is what this image
+# exists to stop: during the v0.26.0 release sweep that step took 41 minutes
+# twice (its normal cost is 22 seconds) and killed the Adwaita-storybook job
+# on its 45-minute timeout, while a Docker Hub pull timeout independently
+# failed `napi`. Neither had anything to do with the code. Two of the thirteen
+# sit on the RELEASE path (release.yml's node-gi / napi prebuild jobs), so the
+# same mirror weather can strand a publish.
+#
+# Baking these does not weaken what those jobs prove. They are not minimal on
+# purpose — every one of them installs gjs and the GNOME devel set itself; the
+# thing they genuinely lack is `@gjsify/rolldown-native`, a workspace build
+# artifact no base image provides. Verified before adding: no job asserts that
+# a system library is ABSENT.
+RUN dnf install -y \
+    make \
+    gcc-c++ \
+    python3 \
+    unzip \
+    curl \
+    pkgconf-pkg-config \
+    ninja-build \
+    valgrind \
+    gjs-devel \
+    mozjs140-devel \
+    gobject-introspection \
+    libsoup3 \
+    glib-networking \
+    libnghttp2-devel \
+    gnutls-devel \
+    json-glib \
+    json-glib-devel \
+    libuv \
+    cairo \
+    cairo-devel \
+    cairo-gobject-devel \
+    pango \
+    gdk-pixbuf2 \
+    gtksourceview5-devel \
+    adwaita-icon-theme \
+    dejavu-sans-fonts \
+    dbus-daemon \
+    dbus-x11 \
     && dnf clean all
 
 # NOTE: no nodejs/npm baked in — the workflow uses actions/setup-node (Node

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -83,3 +83,14 @@ jobs:
       # storybook-core node incidents).
       - name: Check test scripts run their declared runtime legs
         run: node scripts/audit-test-scripts.mjs
+
+      # Containerised jobs vs the image they run on. Two derived questions: a
+      # job ON the baked image must not `dnf install` something the Dockerfile
+      # lacks (the "MUST stay in lockstep" comment, made real), and a job still
+      # on a bare `fedora:<major>` must say WHY in the script's ledger. This
+      # belongs here rather than in `main.yml` for the same reason as the rest
+      # of this workflow: it is pure Node over the repo's own files, needs no
+      # install and no build, and it must run on every PR — a workflow edit is
+      # exactly what silently reintroduces a per-run `dnf install`.
+      - name: Check CI container images cover their jobs
+        run: node scripts/check-ci-image-packages.mjs

--- a/scripts/check-ci-image-packages.mjs
+++ b/scripts/check-ci-image-packages.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Hold the CI container images to the jobs that use them.
+//
+// Two questions, one script, both DERIVED from the workflows rather than from
+// a list somebody remembers to update:
+//
+//   1. Does a job that runs ON the baked image install packages the image does
+//      not carry? `.docker/ci-fedora.Dockerfile` used to carry the sentence
+//      "This list MUST stay in lockstep with ... main.yml — that file is the
+//      source of truth", which is a convention with nothing behind it. This is
+//      the check that sentence was asking for.
+//
+//   2. Which jobs still run on a bare `fedora:<major>` and pay `dnf install`
+//      on every run? Each one must appear in the ledger below WITH A REASON,
+//      printed on every run. That is the `unchecked-fields.mjs` idiom: an
+//      honest "not yet" is available, a silent one is not.
+//
+// Why (2) is worth a check rather than a comment: during the v0.26.0 release
+// sweep the `dnf install` step took 41 minutes twice (normal: 22 seconds) and
+// killed the Adwaita-storybook job on its timeout, while a Docker Hub pull
+// timeout independently failed `napi`. Thirteen jobs are exposed to that, two
+// of them on the release path. The image that fixes it has existed since
+// `build-ci-image.yml` was written — these jobs simply never adopted it.
+//
+// Usage: node scripts/check-ci-image-packages.mjs [--json]
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_DIR = '.github/workflows';
+const DOCKERFILE = '.docker/ci-fedora.Dockerfile';
+const BAKED_IMAGE = 'ghcr.io/gjsify/ci-fedora';
+
+// job id -> why it is still on a bare `fedora:<major>`. Delete the entry in the
+// same change that switches the job over; an entry for a job that no longer
+// uses a bare image is a FAILURE, so this cannot rot into a stale list.
+const BARE_IMAGE_LEDGER = {
+    'node-gi.yml/build-test': 'pending switch to the baked image (packages landed, jobs not yet moved)',
+    'node-gi.yml/cross-runtime': 'pending switch to the baked image',
+    'node-gi.yml/gtk-smoke': 'pending switch to the baked image',
+    'node-gi.yml/consumer-sqlite': 'pending switch to the baked image',
+    'node-gi.yml/arm64': 'runs under QEMU on a foreign arch — needs a multi-arch image build first',
+    'node-gi.yml/consumer-suites': 'pending switch to the baked image',
+    'node-gi.yml/storybook-node-gi-bundle': 'pending switch to the baked image',
+    'napi.yml/build-test': 'pending switch to the baked image',
+    'napi.yml/consumer': 'pending switch to the baked image',
+    'napi.yml/nodegi-shim': 'pending switch to the baked image',
+    'release.yml/node-gi-prebuild-linux': 'pending switch — ON THE RELEASE PATH, do this one first',
+    'release.yml/napi-prebuild-linux': 'pending switch — ON THE RELEASE PATH, do this one first',
+    'prebuilds.yml/build-prebuilds': 'pins fedora:43 while the baked image tracks 43+44 — confirm the pin still matters',
+};
+
+/** Packages a `dnf install` line asks for, with line continuations joined. */
+function packagesIn(run) {
+    const joined = run.replace(/\\\n\s*/g, ' ');
+    const found = new Set();
+    for (const m of joined.matchAll(/dnf install ([^\n]*)/g)) {
+        for (const tok of m[1].split(/\s+/)) {
+            if (!tok || tok.startsWith('-') || tok === '&&' || tok === 'dnf' || tok === 'install') continue;
+            // `... && dnf clean all` and friends end the package list.
+            if (tok === 'clean' || tok === 'all') continue;
+            found.add(tok);
+        }
+    }
+    return found;
+}
+
+/**
+ * Containerised jobs, without a YAML parser: workflows here use `${{ }}`
+ * expressions in `container.image`, and the point is only to find each job's
+ * image and its `run:` blocks. A scanner keyed on this repo's own indentation
+ * is enough and adds no dependency.
+ */
+function scanWorkflow(file) {
+    const lines = readFileSync(join(WORKFLOW_DIR, file), 'utf8').split('\n');
+    const jobs = [];
+    let cur = null;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+        if (job) {
+            cur = { id: `${file}/${job[1]}`, image: null, run: '' };
+            jobs.push(cur);
+            continue;
+        }
+        if (!cur) continue;
+        const img = /^\s*image:\s*(\S+)/.exec(line);
+        if (img && !cur.image) cur.image = img[1];
+        if (/^\s*(- )?run:\s*\|/.test(line)) {
+            for (let j = i + 1; j < lines.length && (lines[j].trim() === '' || /^ {10}/.test(lines[j])); j++) {
+                cur.run += lines[j] + '\n';
+            }
+        }
+    }
+    return jobs;
+}
+
+const dockerfile = readFileSync(DOCKERFILE, 'utf8');
+const baked = new Set();
+for (const m of dockerfile.matchAll(/RUN dnf install -y(.*?)&& dnf clean all/gs)) {
+    for (const tok of m[1].split(/[\s\\]+/)) if (tok && !tok.startsWith('-')) baked.add(tok);
+}
+
+const problems = [];
+const bare = [];
+let bakedJobs = 0;
+
+for (const file of readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith('.yml'))) {
+    for (const job of scanWorkflow(file)) {
+        if (!job.image) continue;
+        if (job.image.startsWith(BAKED_IMAGE)) {
+            bakedJobs += 1;
+            const missing = [...packagesIn(job.run)].filter((p) => !baked.has(p)).sort();
+            if (missing.length) {
+                problems.push(
+                    `${job.id} runs on the baked image but installs ${missing.join(', ')}, ` +
+                        `which ${DOCKERFILE} does not carry — add them there instead of paying dnf every run.`,
+                );
+            }
+            continue;
+        }
+        if (!job.image.startsWith('fedora:')) continue;
+        bare.push(job.id);
+        if (!(job.id in BARE_IMAGE_LEDGER)) {
+            problems.push(
+                `${job.id} runs on a bare ${job.image} and pays dnf install on every run. ` +
+                    `Switch it to ${BAKED_IMAGE}, or add it to BARE_IMAGE_LEDGER with the reason it cannot.`,
+            );
+        }
+    }
+}
+
+for (const id of Object.keys(BARE_IMAGE_LEDGER)) {
+    if (!bare.includes(id)) {
+        problems.push(
+            `BARE_IMAGE_LEDGER lists ${id}, but no such job runs on a bare fedora image. ` +
+                `Delete the entry — it now documents a decision nobody is making.`,
+        );
+    }
+}
+
+if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({ bakedJobs, bare, problems }, null, 2));
+} else {
+    console.log(`ci-image: ${bakedJobs} job(s) on ${BAKED_IMAGE}, ${bare.length} still on a bare fedora image.`);
+    for (const id of bare.sort()) console.log(`  · ${id} — ${BARE_IMAGE_LEDGER[id] ?? 'UNDECLARED'}`);
+    for (const p of problems) console.error(`  ✗ ${p}`);
+}
+
+if (problems.length) {
+    console.error(`ci-image: ${problems.length} problem(s).`);
+    process.exit(1);
+}


### PR DESCRIPTION
Step one of two. **This PR only extends the image and adds the check; it does not switch any job yet** — `build-ci-image.yml` pushes the image only on `main`, so a PR that moved the jobs at the same time would run them against today's image and be red by construction.

### What is wrong

Thirteen containerised jobs run on a bare `fedora:<major>` and `dnf install` their package set at the start of *every* run — node-gi.yml (7), napi.yml (3), release.yml (2), prebuilds.yml (1). `main.yml` stopped doing this when `build-ci-image.yml` was written; its own header says why ("saves 3-5 minutes per matrix entry"). These thirteen never adopted it.

During the v0.26.0 release sweep it cost considerably more than five minutes:

| job | what happened |
|---|---|
| `Adwaita Storybook --app node bundle` | killed on its 45-min timeout **twice**, ~41 min of it inside `dnf install` |
| `napi` build | failed before the container started — `docker pull fedora:44` timed out against registry-1.docker.io three times |

The normal cost of that step is **22 seconds**. Neither failure involved the code; the same tree was green on the PR. **Two of the thirteen are on the release path** (`release.yml`'s node-gi/napi prebuild jobs), so the same mirror weather can strand a publish.

### Why baking is safe here

I initially assumed these jobs were minimal *on purpose* and that baking would defeat them. That was wrong, and worth stating because it is the load-bearing check: **every one of them installs `gjs` and the GNOME devel set itself.** What they genuinely lack is `@gjsify/rolldown-native`, a workspace build artifact no base image provides. Verified before adding: no job asserts that a system library is **absent** — every "absent" in those files refers to rolldown-native.

28 packages added, derived from the workflows rather than hand-listed.

### The mechanism

The Dockerfile carried *"This list MUST stay in lockstep with main.yml — that file is the source of truth"*: a convention with nothing behind it, which is the shape of every drift this repo has already paid for. `scripts/check-ci-image-packages.mjs` derives both halves instead:

- a job running **on** the baked image that installs something the Dockerfile lacks → fail, naming the package;
- a job still on a bare `fedora:<major>` → must appear in the script's ledger **with a reason**, printed every run. This is the `unchecked-fields.mjs` idiom: an honest "not yet" is available, a silent one is not. A ledger entry for a job that is no longer bare also fails, so the list cannot rot into decoration.

Wired into `audit-runtimes.yml` — pure Node over the repo's own files, no install, no build, every PR. A workflow edit is exactly what would silently reintroduce a per-run `dnf install`.

All three failure branches exercised by hand (bare job with no ledger entry; ledger entry for a job that is not bare; baked-image job installing an unbaked package). Each exits 1 and names the repair.

### Follow-up

Step two switches the thirteen jobs and empties the ledger — `release.yml`'s two first, since they are on the release path. `node-gi.yml/arm64` needs a multi-arch image build and is ledgered separately.