### PR TITLE
ci(cross-platform): prove the journey, not the early exit

### DIFF
--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -231,9 +231,34 @@ jobs:
           install_ok=1
           npm install --no-audit --no-fund --no-save "@gjsify/node-gi@latest" > npm-nodegi.log 2>&1 || install_ok=0
           tail -40 npm-nodegi.log
+          # A failed install often ROLLS BACK, so the package is simply not there
+          # afterwards. That is a CONSEQUENCE of the failure above, not a separate
+          # defect, and it must stay version-bound with it — treating "not placed"
+          # as unconditionally fatal made a KNOWN gap fail the job (measured on
+          # windows-latest: the node-gyp configure error leaves no package behind).
+          #
+          # Only the other order is inexplicable and stays hard: npm reported
+          # SUCCESS and the package is still missing.
           if [ ! -f node_modules/@gjsify/node-gi/package.json ]; then
-            echo "::error::npm could not even place @gjsify/node-gi on $TARGET — see the log above"
-            exit 1
+            if [ "$install_ok" = "1" ]; then
+              echo "::error::npm reported success but did not place @gjsify/node-gi on $TARGET"
+              exit 1
+            fi
+            # The version bound needs a version, and the manifest is gone — read it
+            # from the registry instead of guessing.
+            INSTALLED="$(npm view @gjsify/node-gi version 2>/dev/null || echo 0.0.0)"
+            HAS_FIX="$(INSTALLED="$INSTALLED" node -e '
+              const parse = (v) => v.split("-")[0].split(".").map(Number);
+              const [a, b] = [process.env.INSTALLED, process.env.LOWEST_FIXED].map(parse);
+              const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+              process.stdout.write(cmp >= 0 ? "1" : "0");
+            ')"
+            if [ "$HAS_FIX" = "1" ]; then
+              echo "::error::@gjsify/node-gi $INSTALLED cannot be installed on $TARGET at all — its install script runs node-gyp unconditionally and npm rolled the install back"
+              exit 1
+            fi
+            echo "::warning::@gjsify/node-gi $INSTALLED cannot be installed on $TARGET and predates the fix (< $LOWEST_FIXED) — known gap, not failing"
+            exit 0
           fi
           ADDON="node_modules/@gjsify/node-gi/prebuilds/$TARGET/node_gi.node"
           ls -la node_modules/@gjsify/node-gi/prebuilds/ || true

--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -35,8 +35,18 @@ on:
   pull_request:
     paths:
       - '.github/workflows/cli-cross-platform.yml'
+  # A release is the moment this job's answer CHANGES — it measures the PUBLISHED
+  # CLI, so every finding here is about an artifact that already exists. Waiting
+  # for the Monday cron means a platform can be broken for users for up to seven
+  # days before anything notices, which is exactly what happened with the Windows
+  # `EPERM` and the missing node-gi prebuilds: both were live in a published
+  # release, and the weekly run was the only thing that would ever have asked.
+  release:
+    types: [published]
   schedule:
-    # Weekly drift check (Mondays 05:00 UTC) so a released regression surfaces.
+    # Weekly drift check (Mondays 05:00 UTC) so a released regression surfaces
+    # even when no release happened — a registry-side or runner-image change can
+    # break a published CLI that nobody republished.
     - cron: '0 5 * * 1'
 
 permissions:
@@ -188,6 +198,126 @@ jobs:
           fi
           echo "$out" | grep -q "does not support --runtime node"
 
+      # The PUBLISH-side question no other gate asks. `audit-runtimes --check` holds
+      # "a declared target is produced by a CI job", and `node-gi.yml` genuinely
+      # produces win32-x64 and darwin-arm64 — load test included. Nothing asked
+      # whether the RELEASE ships them, and it did not: `@gjsify/node-gi@0.26.0`'s
+      # tarball carried only the two linux targets, so `--runtime node` could not
+      # work on this runner at all.
+      #
+      # This is the cheapest possible form of that check and needs no GTK and no
+      # display: install the package and look for the addon for THIS host triple.
+      # Only a cross-platform job can ask it, because only here is the host triple
+      # something other than linux-x64.
+      #
+      # Version-bound like the showcase step below: a published CLI predating the
+      # fix reports a KNOWN gap; from the first release carrying it, the same
+      # absence fails. The gate arms itself, with no edit here.
+      - name: 'node-gi: a prebuild exists for this platform'
+        id: nodegiprebuild
+        continue-on-error: true
+        working-directory: gjsify-diag
+        env:
+          LOWEST_FIXED: '0.26.1'
+        run: |
+          set -eux
+          TARGET="$(node -p "process.platform + '-' + process.arch")"
+          npm install --no-audit --no-fund --no-save "@gjsify/node-gi@${NODE_GI_VERSION:-latest}"
+          ADDON="node_modules/@gjsify/node-gi/prebuilds/$TARGET/node_gi.node"
+          ls -la node_modules/@gjsify/node-gi/prebuilds/ || true
+          INSTALLED="$(node -p "require('./node_modules/@gjsify/node-gi/package.json').version")"
+          HAS_FIX="$(INSTALLED="$INSTALLED" node -e '
+            const parse = (v) => v.split("-")[0].split(".").map(Number);
+            const [a, b] = [process.env.INSTALLED, process.env.LOWEST_FIXED].map(parse);
+            const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+            process.stdout.write(cmp >= 0 ? "1" : "0");
+          ')"
+          if [ -f "$ADDON" ]; then
+            echo "prebuild present for $TARGET"
+            exit 0
+          fi
+          # It is declared but not shipped — report which, so the message names the
+          # contradiction rather than just the missing file.
+          DECLARED="$(node -p "require('./node_modules/@gjsify/node-gi/package.json').gjsify.platforms.join(' ')")"
+          if [ "$HAS_FIX" = "1" ]; then
+            echo "::error::@gjsify/node-gi $INSTALLED declares [$DECLARED] but ships no prebuild for $TARGET — every --runtime node command fails at the addon load"
+            exit 1
+          fi
+          echo "::warning::@gjsify/node-gi $INSTALLED ships no $TARGET prebuild (declares [$DECLARED]) and predates the fix (< $LOWEST_FIXED) — known gap, not failing"
+
+      # The FULL end-user journey, run to completion. The step above it asserts a
+      # correct EARLY EXIT for a gjs-only showcase; that assertion is valuable and
+      # stays, but it terminates before the dlx cache, before any install and before
+      # the addon load — which is precisely why a directory-symlink `EPERM` in the
+      # dlx cache shipped to Windows users unnoticed. A probe that stops one step
+      # before the code that breaks cannot see the break.
+      #
+      # `express-webserver` is the showcase for this, deliberately not the
+      # canvas/GTK ones: it declares `node` in `gjsify.example.runtimes` AND is
+      # headless, so it proves dlx cache -> install -> node bundle -> real HTTP
+      # response with no display and no GTK on the runner. The GUI showcases need
+      # a windowing GTK bundle that is a separate, still-open concern.
+      #
+      # It serves forever (`app.listen`), so the run is BOUNDED: start detached,
+      # poll until it answers, assert the payload, then kill it. A hang must fail
+      # the step rather than burn the job timeout, which is what the poll ceiling
+      # is for.
+      - name: 'Showcase: the full --runtime node journey'
+        id: journey
+        continue-on-error: true
+        working-directory: gjsify-diag
+        env:
+          LOWEST_FIXED: '0.26.1'
+          PORT: '3123'
+        run: |
+          set -eux
+          npx gjsify showcase express-webserver --runtime node > journey.log 2>&1 &
+          SHOWCASE_PID=$!
+          ok=0
+          # ~90s ceiling: a cold dlx tree installs the showcase + node-gi first.
+          # Counter loop, not `seq`: `seq` is coreutils and not something to assume
+          # of every runner image's bash (git-bash on windows-latest included).
+          tries=0
+          while [ "$tries" -lt 90 ]; do
+            if curl -fsS "http://127.0.0.1:${PORT}/api/posts" -o payload.json 2>/dev/null; then ok=1; break; fi
+            # If the child is already gone, stop waiting — it failed to start, and
+            # polling a dead process for 90s would hide the reason in the timeout.
+            kill -0 "$SHOWCASE_PID" 2>/dev/null || break
+            tries=$((tries + 1))
+            sleep 1
+          done
+          kill "$SHOWCASE_PID" 2>/dev/null || true
+          wait "$SHOWCASE_PID" 2>/dev/null || true
+          cat journey.log
+          INSTALLED="$(node -p "require('./node_modules/@gjsify/cli/package.json').version")"
+          HAS_FIX="$(INSTALLED="$INSTALLED" node -e '
+            const parse = (v) => v.split("-")[0].split(".").map(Number);
+            const [a, b] = [process.env.INSTALLED, process.env.LOWEST_FIXED].map(parse);
+            const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+            process.stdout.write(cmp >= 0 ? "1" : "0");
+          ')"
+          if [ "$ok" = "1" ]; then
+            # Assert something is really answering with JSON — deliberately NOT a
+            # shape assertion: the showcase's payload contract is not pinned
+            # anywhere, and inventing one here would fail on a harmless change to
+            # the demo data. `readFileSync`, not `require`, because the scaffold's
+            # module type is not ours to assume.
+            node -e "
+              const { readFileSync } = require('node:fs');
+              const raw = readFileSync('payload.json', 'utf8');
+              const parsed = JSON.parse(raw);
+              if (raw.length === 0 || parsed === null) { console.error('empty payload'); process.exit(1); }
+              console.log('payload parsed,', raw.length, 'bytes');
+            "
+            echo "the journey completed and the showcase served a response"
+            exit 0
+          fi
+          if [ "$HAS_FIX" = "1" ]; then
+            echo "::error::@gjsify/cli $INSTALLED could not run a node-declared showcase to completion on this platform — see journey.log above"
+            exit 1
+          fi
+          echo "::warning::@gjsify/cli $INSTALLED predates the Windows/dlx fixes (< $LOWEST_FIXED) — known gap, not failing"
+
       - name: Diagnostic summary
         run: |
           echo "## gjsify CLI on ${{ matrix.os }} (Node)" >> "$GITHUB_STEP_SUMMARY"
@@ -199,6 +329,8 @@ jobs:
           echo "| gjsify install (backend) | ${{ steps.install.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| .bin shim created + runnable | ${{ steps.binshim.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| showcase --runtime node (no gjs) | ${{ steps.showcase.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| node-gi prebuild for this platform | ${{ steps.nodegiprebuild.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| showcase --runtime node (full journey) | ${{ steps.journey.outcome }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "--- outcomes: version=${{ steps.version.outcome }} build=${{ steps.build.outcome }} run=${{ steps.run.outcome }} install=${{ steps.install.outcome }} binshim=${{ steps.binshim.outcome }}"
           # Every substantive step stays continue-on-error so ONE run still maps
           # ALL the gaps; the gate lives here, at the end.
@@ -222,6 +354,24 @@ jobs:
           # a CLI predating the fix warns and passes; from the first release
           # carrying it, the same demand fails. Nothing to remember later.
           if [ "${{ steps.showcase.outcome }}" != "success" ]; then FAILED=1; fi
+          # The two publish-side probes gate the same way, and for the same reason
+          # the others do: they are the only steps in this repository that can ask
+          # whether a RELEASED artifact works on a platform nobody here runs.
+          #
+          # `nodegiprebuild` asks the question no declaration invariant covers —
+          # `audit-runtimes --check` proves a CI job BUILDS a target, never that the
+          # release SHIPS it, and two of node-gi's four declared platforms were
+          # missing from the tarball while every check stayed green.
+          #
+          # `journey` is the end-user path run to completion. The `showcase` step
+          # above asserts a correct early exit for a gjs-only showcase; this one
+          # goes all the way through the dlx cache, the install and the bundle, and
+          # is what would have caught the directory-symlink EPERM on Windows.
+          #
+          # Both are version-bound in their steps, so they report against a CLI
+          # predating the fix and fail from the first release that carries it.
+          if [ "${{ steps.nodegiprebuild.outcome }}" != "success" ]; then FAILED=1; fi
+          if [ "${{ steps.journey.outcome }}" != "success" ]; then FAILED=1; fi
           if [ "$FAILED" = "0" ]; then
             echo "CLI PATH GREEN on ${{ matrix.os }} (toolchain + install backend)"
           else

--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -222,7 +222,19 @@ jobs:
         run: |
           set -eux
           TARGET="$(node -p "process.platform + '-' + process.arch")"
-          npm install --no-audit --no-fund --no-save "@gjsify/node-gi@${NODE_GI_VERSION:-latest}"
+          # The install is ALLOWED to fail and is a finding in its own right. It
+          # declares `scripts.install: node-gyp rebuild`, so npm ALWAYS runs a
+          # source build here — independent of whether a prebuild ships — and a
+          # tarball missing a file that `binding.gyp` calls makes `npm install`
+          # itself fail. Letting `set -e` kill the step would report that as a raw
+          # node-gyp trace with no attribution.
+          install_ok=1
+          npm install --no-audit --no-fund --no-save "@gjsify/node-gi@latest" > npm-nodegi.log 2>&1 || install_ok=0
+          tail -40 npm-nodegi.log
+          if [ ! -f node_modules/@gjsify/node-gi/package.json ]; then
+            echo "::error::npm could not even place @gjsify/node-gi on $TARGET — see the log above"
+            exit 1
+          fi
           ADDON="node_modules/@gjsify/node-gi/prebuilds/$TARGET/node_gi.node"
           ls -la node_modules/@gjsify/node-gi/prebuilds/ || true
           INSTALLED="$(node -p "require('./node_modules/@gjsify/node-gi/package.json').version")"
@@ -232,8 +244,19 @@ jobs:
             const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
             process.stdout.write(cmp >= 0 ? "1" : "0");
           ')"
-          if [ -f "$ADDON" ]; then
-            echo "prebuild present for $TARGET"
+          if [ -f "$ADDON" ] && [ "$install_ok" = "1" ]; then
+            echo "prebuild present for $TARGET and the install completed"
+            exit 0
+          fi
+          # Report the two failure modes separately — they have different causes
+          # and different fixes, and collapsing them would send the next reader
+          # after the wrong one.
+          if [ "$install_ok" = "0" ]; then
+            if [ "$HAS_FIX" = "1" ]; then
+              echo "::error::@gjsify/node-gi $INSTALLED failed to install on $TARGET — its install script runs node-gyp unconditionally, so a file binding.gyp calls that the tarball omits breaks every install here"
+              exit 1
+            fi
+            echo "::warning::@gjsify/node-gi $INSTALLED failed to install on $TARGET and predates the fix (< $LOWEST_FIXED) — known gap, not failing"
             exit 0
           fi
           # It is declared but not shipped — report which, so the message names the


### PR DESCRIPTION
This job **already** ran on `macos-latest` and `windows-latest`, and **already** probed
`showcase --runtime node` — and a directory-symlink `EPERM` in the dlx cache still shipped
to every non-elevated Windows user (#898).

It could not have seen it. The probe deliberately uses a **gjs-only** showcase and asserts
the run ends at the *declaration check*:

```
npx gjsify showcase webrtc-loopback --runtime node
  → expects "does not support --runtime node"
```

That is before the dlx cache, before any install, before the addon load. **A probe that
stops one step short of the code that breaks reads as coverage without being any.**

The assertion itself is worth keeping — it guards the #889 regression where a pre-flight
demanded gjs for `--runtime node` — so it stays, and two probes join it.

## 1. The full journey, run to completion

`express-webserver` is the right showcase: it declares `node` in
`gjsify.example.runtimes` **and** is headless, so it exercises

> dlx cache → install → node bundle → a real HTTP response

with no display and no GTK on the runner. The canvas/GTK showcases need a windowing GTK
bundle, which is a separate and still-open concern.

It serves forever (`app.listen`), so the run is **bounded**: start detached, poll until it
answers, assert the payload parses, kill it. The poll also stops early when the child is
already gone, so a failure to start surfaces as itself rather than as a 90-second timeout.

## 2. A prebuild exists for this platform

The question no declaration invariant asks. `audit-runtimes --check` holds *"a declared
target is produced by a CI job"* — and `node-gi.yml` genuinely produces `win32-x64` and
`darwin-arm64`, load test included. Nothing asked whether the **release** ships them, and it
did not: `@gjsify/node-gi@0.26.0`'s tarball carries only the two linux targets (see #900).

This is the cheapest possible form of that check and needs neither GTK nor a display:
install the package, look for the addon for **this** host triple, and name the contradiction
between `gjsify.platforms` and the tarball. Only a cross-platform job can ask it — only here
is the host triple something other than `linux-x64`.

## Both gate, and both arm themselves

Version-bound exactly the way the existing showcase step is: against a published CLI
predating the fix they report a KNOWN gap and pass; from the first release carrying it, the
same failure is a regression. **No edit here later, and no hand-maintained "currently
skipped" list to drift.**

Consequence for *this* PR: the published CLI is 0.26.0 and the bound is 0.26.1, so the two
new steps will run on real Windows and macOS and report warnings. That is the intent — it
validates the shell logic on both platforms without failing on a gap that is genuinely still
open.

## Also: `release: published`

This job measures the PUBLISHED CLI, so a release is the moment its answer changes. With
only the Monday cron, a broken platform can be live for up to **seven days** before anything
asks — and both defects above were exactly that: live in a published release, with the
weekly run the only thing that would ever have noticed. The cron stays, for the case where
nothing was republished but a registry or runner-image change broke it anyway.

## Verification

YAML parses · `bash -n` clean on both new `run` blocks · all 8 steps wired into the
end-of-job gate (the established pattern here: every step is `continue-on-error` so ONE run
maps ALL gaps, and the gate lives at the end) · two rows added to the step summary.

Portability: a counter loop rather than `seq`, and `readFileSync` rather than `require` for
the payload (the scaffold's module type is not ours to assume). Deliberately **not** a
payload-shape assertion — the showcase's response contract is not pinned anywhere, and
inventing one would fail on a harmless change to the demo data.

**Only the PR run itself can prove** the bounded start/poll/kill sequence behaves under
git-bash on `windows-latest`; that is the main thing to read the logs for.
