### PR TITLE
ci: catch what silently reaches main — resurrected prose and unlinted PR titles

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -109,6 +109,12 @@ jobs:
       #
       # Needs history, and this checkout is shallow — deepen just for this step
       # rather than making every other check in this job pay for a full clone.
+      # The PR-title linter inherits its type list from the action default
+      # instead of carrying a second copy of `type-enum`. That is only sound
+      # while the two agree — this is what says so out loud.
+      - name: Check the PR-title type list still matches commitlint
+        run: node scripts/check-pr-title-types.mjs
+
       - name: Check for resurrected prose (advisory)
         continue-on-error: true
         env:

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -94,3 +94,25 @@ jobs:
       # exactly what silently reintroduces a per-run `dnf install`.
       - name: Check CI container images cover their jobs
         run: node scripts/check-ci-image-packages.mjs
+
+      # Prose that a change resurrects after the base branch deleted it. Git
+      # merges that WITHOUT a conflict — the merge base has neither wording, so
+      # "replace these paragraphs with those" is an ordinary edit — which is how
+      # #886 put back five paragraphs #885 had consolidated, and how #892 carried
+      # the whole pre-#885 AGENTS.md. Nothing else can see it: prose has no test,
+      # no type, no conformance rule.
+      #
+      # WARNS by design and never gates: a deliberate revert has the identical
+      # signature, and a hard gate on an ambiguous signal is one people learn to
+      # route around. `continue-on-error` keeps it advisory; a `Revert-Of:`
+      # trailer marks the intent explicitly.
+      #
+      # Needs history, and this checkout is shallow — deepen just for this step
+      # rather than making every other check in this job pay for a full clone.
+      - name: Check for resurrected prose (advisory)
+        continue-on-error: true
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          git fetch --no-tags --quiet --deepen=200 origin "$BASE_REF" 2>/dev/null || true
+          node scripts/check-doc-revert.mjs --base "origin/$BASE_REF"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -23,3 +23,20 @@ jobs:
       # with EUNSUPPORTEDPROTOCOL).
       - name: Lint PR commits
         uses: wagoid/commitlint-github-action@v6
+
+      # The step above lints the PR's COMMITS. With squash merges what actually
+      # lands on main is the PR TITLE — the one string nothing looked at. #849
+      # merged as "Run the transparent addon matrix in CI (#849)" with no
+      # conventional prefix and is absent from the v0.26.1 CHANGELOG entirely:
+      # the work shipped with no release note. This workflow already triggers on
+      # `edited`, so the intent was there; only the check was missing.
+      #
+      # Deliberately NO `types:` input. Our `type-enum` is exactly this action's
+      # default, so passing one would put a second copy of the list in a
+      # workflow file, where it drifts silently. `check-pr-title-types.mjs`
+      # holds that assumption: the moment the two diverge it fails and tells you
+      # to make the list explicit here.
+      - name: Lint the PR title (it becomes the squash subject)
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/check-doc-revert.mjs
+++ b/scripts/check-doc-revert.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Catch a change that silently resurrects prose the base branch deleted.
+//
+// THE FAILURE, twice in one day. A doc commit gets written against a copy of a
+// file that predates a rewrite already on the base branch, and puts the old
+// wording back. Git merges it WITHOUT A CONFLICT — "replace these paragraphs
+// with those paragraphs" is an ordinary edit — and the rewrite is silently
+// undone. `AGENTS.md` on #886: the governance block #885 had consolidated came
+// back as five duplicated paragraphs. Again on #892: the whole pre-#885 file.
+// Nothing could see it — prose has no test, no type, no conformance rule, and
+// by construction no conflict.
+//
+// THE SIGNATURE IS NOT "removes what the base added". Both incidents had the
+// new wording in their own merge base and replaced it anyway, so nothing was
+// removed that the base gained later. What actually distinguishes them is the
+// other direction: **the change ADDS lines the base branch had DELETED.** That
+// is content coming back from the dead, which is what writing against a stale
+// copy produces and what an ordinary edit does not.
+//
+// It WARNS and offers an acknowledgement rather than gating: a deliberate
+// revert has the identical signature, and a hard gate on an ambiguous signal
+// trains people to route around it. Acknowledge with a `Revert-Of:` trailer.
+//
+// Usage: node scripts/check-doc-revert.mjs [--base <ref>] [--head <ref>]
+//                                          [--depth N] [--all] [--json] [--strict]
+//   --depth   how far back on the base branch to look for deletions (default 80)
+//   --all     every changed file, not just *.md — prose is the default because
+//             a source regression of this shape gets caught by tsc/lint/tests
+//   --strict  exit 1 on an unacknowledged hit
+
+import { execFileSync } from 'node:child_process';
+
+const argv = process.argv.slice(2);
+const flag = (name, fallback) => {
+    const i = argv.indexOf(name);
+    return i === -1 ? fallback : argv[i + 1];
+};
+const has = (name) => argv.includes(name);
+
+const BASE = flag('--base', 'origin/main');
+const HEAD = flag('--head', 'HEAD');
+const DEPTH = Number(flag('--depth', '80'));
+const JSON_OUT = has('--json');
+const STRICT = has('--strict');
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 512 * 1024 * 1024 });
+
+/**
+ * A line worth comparing. Structural noise (blank lines, fences, lone brackets,
+ * short fragments) collides across unrelated revisions and would bury a real
+ * hit; a length floor is the cheapest filter that keeps prose and drops it.
+ */
+const significant = (line) => {
+    const t = line.trim();
+    return t.length >= 40 && !/^[-=*_`|#>\s]+$/.test(t);
+};
+
+let mergeBase;
+try {
+    // stderr silenced for the same reason as the `git show` below: "no merge
+    // base" / "not a valid object name" is an EXPECTED answer here, and a
+    // leaked `fatal:` line reads like a failure in a CI log when the check is
+    // in fact skipping cleanly.
+    mergeBase = execFileSync('git', ['merge-base', BASE, HEAD], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+} catch {
+    // A shallow clone has no common ancestor to find. Say so instead of
+    // printing "nothing resurrected", which would read as a clean bill of
+    // health from a check that never ran — the exact shape this repo keeps
+    // paying for. The caller is expected to deepen first.
+    console.log(
+        `doc-revert: SKIPPED — no merge base between ${BASE} and ${HEAD} (shallow clone?).\n` +
+            `  Deepen first, e.g. \`git fetch --deepen=200 origin <base>\`.`,
+    );
+    process.exit(0);
+}
+
+const filter = has('--all') ? [] : ['*.md'];
+const files = git('diff', '--name-only', `${mergeBase}...${HEAD}`, '--', ...filter)
+    .split('\n')
+    .filter(Boolean);
+
+const findings = [];
+for (const file of files) {
+    const added = new Set(
+        git('diff', '--unified=0', `${mergeBase}...${HEAD}`, '--', file)
+            .split('\n')
+            .filter((l) => l.startsWith('+') && !l.startsWith('+++'))
+            .map((l) => l.slice(1))
+            .filter(significant),
+    );
+    if (!added.size) continue;
+
+    // Every line the base branch has DELETED from this file recently. One git
+    // call per file — a `log -S` per candidate line would be the same answer at
+    // hundreds of times the cost.
+    const deleted = new Set(
+        git('log', '-p', '--format=', `-n${DEPTH}`, BASE, '--', file)
+            .split('\n')
+            .filter((l) => l.startsWith('-') && !l.startsWith('---'))
+            .map((l) => l.slice(1))
+            .filter(significant),
+    );
+
+    // A line that STILL EXISTS on the base in a slightly different form was not
+    // resurrected — it churned. The canonical case is the header carrying the
+    // workspace version, deleted and rewritten by every release, which would
+    // otherwise fire on every branch that predates a release and train everyone
+    // to ignore this check. Keyed on a prefix so a reworded tail still matches.
+    const key = (l) => l.trim().slice(0, 40);
+    let baseText = '';
+    try {
+        // stderr is silenced deliberately: "path does not exist in <ref>" is an
+        // EXPECTED answer here, and execFileSync would otherwise leak git's
+        // message to the caller's stderr as if something had gone wrong.
+        baseText = execFileSync('git', ['show', `${BASE}:${file}`], {
+            encoding: 'utf8',
+            maxBuffer: 512 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+    } catch {
+        // The file does not exist on the base branch — this change creates it,
+        // so nothing of it is "still live there" and every match stands.
+        // `git show <ref>:<path>` is the only way to ask, and it exits non-zero
+        // rather than returning empty.
+    }
+    const liveOnBase = new Set(baseText.split('\n').filter(significant).map(key));
+
+    const resurrected = [...added].filter((l) => deleted.has(l) && !liveOnBase.has(key(l)));
+    if (resurrected.length) findings.push({ file, count: resurrected.length, sample: resurrected[0] });
+}
+
+const trailers = git('log', '--format=%B', `${mergeBase}..${HEAD}`);
+const acknowledged = /^Revert-Of:/m.test(trailers);
+
+if (JSON_OUT) {
+    console.log(JSON.stringify({ mergeBase, findings, acknowledged }, null, 2));
+} else if (!findings.length) {
+    console.log(`doc-revert: nothing resurrected — no added line was previously deleted from ${BASE}.`);
+} else {
+    const total = findings.reduce((n, f) => n + f.count, 0);
+    console.log(`doc-revert: ${total} line(s) this change ADDS were previously DELETED from ${BASE}.`);
+    for (const f of findings) console.log(`  · ${f.file}: ${f.count}`);
+    console.log(`  first: ${findings[0].sample.slice(0, 110)}`);
+    console.log(
+        acknowledged
+            ? '  Acknowledged by a `Revert-Of:` trailer — treated as deliberate.'
+            : '  Usually this means the file was edited against a stale copy: take the base version\n' +
+                  '  and re-apply your change on top of it. If the revert IS the intent, say so with a\n' +
+                  '  `Revert-Of: <what>` trailer.',
+    );
+}
+
+if (STRICT && findings.length && !acknowledged) process.exit(1);

--- a/scripts/check-pr-title-types.mjs
+++ b/scripts/check-pr-title-types.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Hold the PR-title linter's implicit type list to the one commitlint enforces.
+//
+// WHY A CHECK RATHER THAN A SECOND LIST. With squash merges, what lands on
+// `main` is the PR TITLE, not the commits — and `commitlint.yml` lints the
+// COMMITS. So the string that becomes history is the one string nothing looks
+// at: #849 merged as "Run the transparent addon matrix in CI (#849)" with no
+// conventional prefix and is therefore absent from the v0.26.1 CHANGELOG
+// entirely. The work shipped with no release note.
+//
+// The title step fixes that, and it needs a type list. Passing one would put a
+// SECOND copy of `type-enum` in a workflow file, where it drifts silently — the
+// failure mode this repo keeps paying for. It happens that our list is exactly
+// the conventional-commit default, so the step passes NO `types` input and
+// inherits it. That is only safe while the two agree, which is what this
+// asserts: add a type to commitlint.config.cjs and this fails, telling you to
+// make the workflow's list explicit instead of letting the two diverge unseen.
+//
+// Usage: node scripts/check-pr-title-types.mjs
+
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+
+// The default of `amannn/action-semantic-pull-request`, which takes it from
+// `conventional-commit-types`. Mirrored here ON PURPOSE: this constant IS the
+// claim being checked, not a duplicate of our own configuration.
+const ACTION_DEFAULT_TYPES = [
+    'feat',
+    'fix',
+    'docs',
+    'style',
+    'refactor',
+    'perf',
+    'test',
+    'build',
+    'ci',
+    'chore',
+    'revert',
+];
+
+const WORKFLOW = '.github/workflows/commitlint.yml';
+
+const rule = require('../commitlint.config.cjs').rules?.['type-enum'];
+const ours = rule?.[2];
+if (!Array.isArray(ours)) {
+    console.error('::error::commitlint.config.cjs declares no `type-enum` list — nothing to compare.');
+    process.exit(1);
+}
+
+const workflow = readFileSync(WORKFLOW, 'utf8');
+const stepDeclaresTypes = /^\s*types:\s*\|/m.test(workflow);
+
+const norm = (xs) => [...xs].sort().join(',');
+const agree = norm(ours) === norm(ACTION_DEFAULT_TYPES);
+
+if (agree) {
+    console.log(`pr-title-types: commitlint's ${ours.length} types match the action default — no second list needed.`);
+    if (stepDeclaresTypes) {
+        console.error(
+            `::error::${WORKFLOW} passes an explicit \`types:\` while the lists agree. ` +
+                `Drop it — a second copy only exists to drift.`,
+        );
+        process.exit(1);
+    }
+    process.exit(0);
+}
+
+const onlyOurs = ours.filter((t) => !ACTION_DEFAULT_TYPES.includes(t));
+const onlyDefault = ACTION_DEFAULT_TYPES.filter((t) => !ours.includes(t));
+
+if (stepDeclaresTypes) {
+    console.log(`pr-title-types: lists differ and ${WORKFLOW} declares its own — consistent.`);
+    process.exit(0);
+}
+
+console.error('::error::commitlint.config.cjs no longer matches the PR-title action default.');
+if (onlyOurs.length) console.error(`::error::  only in commitlint.config.cjs: ${onlyOurs.join(', ')}`);
+if (onlyDefault.length) console.error(`::error::  only in the action default: ${onlyDefault.join(', ')}`);
+console.error(
+    `::error::The title step inherits the default, so a title using one of ours would be ` +
+        `rejected (or one of theirs accepted). Pass an explicit \`types:\` in ${WORKFLOW}.`,
+);
+process.exit(1);


### PR DESCRIPTION
Twice in one day a doc change was written against a copy of a file that predated a rewrite already on `main`, and put the old wording back. Git merged it **without a conflict** — the merge base has neither version, so *"replace these paragraphs with those"* is an ordinary edit. #886 restored five paragraphs #885 had consolidated; #892 carried the entire pre-#885 `AGENTS.md`. Nothing could see either: prose has no test, no type and no conformance rule.

### The signature is not the obvious one

My first attempt looked for *"removes lines the base added"*. **It does not fire on either incident** — both had the new wording in their own merge base and replaced it anyway, so nothing was removed that the base gained later.

What distinguishes them is the other direction: **the change ADDS lines the base branch had DELETED.** Content coming back from the dead is what writing against a stale copy produces, and what an ordinary edit does not.

### It covers one half of the class, and the other half needs nothing

| shape | merge behaviour | covered by |
|---|---|---|
| branch holds the new version and replaces it (#886) | merges **silently** | this check |
| branch predates the rewrite (#892) | git **conflicts** | git itself |

#892 never added those lines, so there is nothing to detect — and the merge conflicted, which is how I found it. Only the #886 shape is invisible.

### Warns, never gates

A deliberate revert has the identical signature, and a hard gate on an ambiguous signal is one people learn to route around. `continue-on-error: true`; a `Revert-Of:` trailer marks intent explicitly; `--strict` exists for a caller that wants the gate.

### Two things keep it from becoming noise

- **A churn filter.** A line that still exists on the base in a slightly different form was not resurrected. Without it, the `AGENTS.md` header carrying the workspace version — deleted and rewritten by *every release* — fired on every branch spanning a release. That is precisely how a check earns being ignored.
- **A shallow clone reports `SKIPPED`, not "nothing found".** A check that cannot run must not read as a clean bill of health. The step deepens 200 commits first, and only for this step, so the rest of the job keeps its fast checkout.

### Verification — against the real commits, not fixtures

| case | result |
|---|---|
| the #886 incident | fires, **6 lines**, exit 1 under `--strict` |
| the commit that fixed it | silent |
| this branch | silent, exit 0 |
| no merge base available | `SKIPPED`, exit 0 |