### PR TITLE
fix(node-gi): use the shipped prebuild instead of always rebuilding

### DIFF
--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -86,10 +86,17 @@ vendored as-is — gjsify ships its own dual (GJS + Node) example/test infra.
 ## Requirements
 
 - Node.js ≥ 20
-- A C++ toolchain (`g++`/`clang`, `make`), `node-gyp`
-- GLib ≥ 2.80 development headers exposing `girepository-2.0`
-  (Fedora: `glib2-devel gobject-introspection-devel gcc-c++`;
-   Debian/Ubuntu: `libglib2.0-dev libgirepository-2.0-dev g++`)
+- **No C++ toolchain on the four prebuilt targets.** The published tarball ships
+  `prebuilds/<platform>-<arch>/node_gi.node` for `linux-x64`, `linux-arm64`,
+  `darwin-arm64` and `win32-x64` (`package.json#gjsify.platforms`), and the
+  `install` script (`scripts/install.mjs`) uses it instead of building: a source
+  build is the FALLBACK for a host with no prebuild, not the default. Force it
+  with `NODE_GI_BUILD_FROM_SOURCE=1` (or npm's `--build-from-source`); skip it
+  entirely with `NODE_GI_SKIP_NATIVE_BUILD=1`.
+- For a source build only: a C++ toolchain (`g++`/`clang`, `make`), `node-gyp`,
+  and GLib ≥ 2.80 development headers exposing `girepository-2.0` + cairo
+  (Fedora: `glib2-devel gobject-introspection-devel cairo-devel gcc-c++`;
+   Debian/Ubuntu: `libglib2.0-dev libgirepository-2.0-dev libcairo2-dev g++`)
 - At runtime, the target libraries' typelibs must be installed (same as `gi://`
   under GJS) — **except on macOS arm64**, where the optional
   [`@gjsify/gtk-runtime-darwin-arm64`](../gtk-runtime-darwin-arm64) bundle ships a
@@ -153,7 +160,7 @@ blocking loop remain Node-only (the uv co-pump).
 ## Build & test
 
 ```bash
-npm install          # builds the native addon via node-gyp (install script)
+npm install          # prebuild if one is staged, else node-gyp (scripts/install.mjs)
 npm test             # node --test (full suite, Node — authoritative)
 npm run test:gc      # node --test --expose-gc (toggle-ref GC-stress leg)
 npm run test:bun     # conformance subset on Bun   (needs `bun`)
@@ -170,7 +177,15 @@ and the bun/deno runner defaults to it — without that, a stale staged prebuild
 silently shadows your build. CI's cross-runtime job sets `NODE_GI_NATIVE=prebuild`
 to keep validating the prebuild load path with a freshly staged binary.
 `NODE_GI_NATIVE` accepts `build`, `prebuild`, or an explicit path to a
-`node_gi.node`.
+`node_gi.node`. That candidate order lives in `native-paths.js` and is shared
+with the `install` script, so the binary the guard decides not to rebuild is
+by construction the binary the loader looks for.
+
+In a checkout `prebuilds/` is gitignored, so `npm install` here always runs the
+source build — as do the `npm install --foreground-scripts` steps in
+`node-gi.yml` and the `node-gi-prebuild-*` legs in `release.yml`, which need
+`build/Release/node_gi.node` for `scripts/stage-prebuild.mjs`. Set
+`NODE_GI_BUILD_FROM_SOURCE=1` to force it regardless of a staged prebuild.
 
 Two debug-only env vars instrument the toggle-ref / teardown machinery (both
 parsed once at first use, zero cost when unset — never set them in production):

--- a/packages/node-gi/node-gi/README.md
+++ b/packages/node-gi/node-gi/README.md
@@ -98,11 +98,28 @@ vendored as-is — gjsify ships its own dual (GJS + Node) example/test infra.
   (Fedora: `glib2-devel gobject-introspection-devel cairo-devel gcc-c++`;
    Debian/Ubuntu: `libglib2.0-dev libgirepository-2.0-dev libcairo2-dev g++`)
 - At runtime, the target libraries' typelibs must be installed (same as `gi://`
-  under GJS) — **except on macOS arm64**, where the optional
-  [`@gjsify/gtk-runtime-darwin-arm64`](../gtk-runtime-darwin-arm64) bundle ships a
-  relocated GTK/GI runtime so the display-free surface works with no Homebrew GTK
-  (Phase 2). node-gi auto-detects the bundle at load and prepends its typelib dir
-  to the GIRepository search path (`gtk-runtime.js`).
+  under GJS) — **except on macOS arm64 and Windows x64**, where a
+  batteries-included, relocated GTK/GI runtime bundle ships so `gi://` works with
+  no Homebrew/gvsbuild GTK (Phase 2). node-gi auto-detects a bundle at load and
+  prepends its typelib dir to the GIRepository search path (`gtk-runtime.js`).
+- **Those bundles are a MANUAL install today.**
+  [`@gjsify/gtk-runtime-darwin-arm64`](../gtk-runtime-darwin-arm64) and
+  [`@gjsify/gtk-runtime-win32-x64`](../gtk-runtime-win32-x64) are published, and
+  node-gi finds either one the moment it is present in the tree — but **no
+  package declares them as a dependency**, so nothing installs them for you.
+  Install the one for your platform alongside node-gi:
+
+  ```bash
+  npm install @gjsify/gtk-runtime-win32-x64      # Windows x64
+  npm install @gjsify/gtk-runtime-darwin-arm64   # macOS arm64
+  ```
+
+  Both declare `os`/`cpu`, so npm/yarn/pnpm skip them off-platform. Making them
+  `optionalDependencies` of this package (which would remove the manual step
+  without any consumer-side platform branching) is pending two decisions outside
+  this package — the ADR-0003 dependency-direction rule between node-gi's tier
+  and the bundles', and `os`/`cpu` filtering in `gjsify install`'s native
+  backend, which currently places foreign-platform optional deps.
 - **Node.js ≥ 20, Bun ≥ 1.3, or Deno ≥ 2** — the addon is Node-API, so one binary
   runs on all three (see [Runtimes](#runtimes-node--bun--deno)).
 
@@ -1019,6 +1036,15 @@ Fontconfig config/cache. node-gi's loader (`gtk-runtime.js`
 marker and wires the env (`GSETTINGS_SCHEMA_DIR` / `GDK_PIXBUF_MODULE_FILE` /
 `XDG_DATA_DIRS` / `FONTCONFIG_*`); a display-free bundle carries no marker, so the
 wiring is a strict no-op and that load is byte-unchanged.
+
+The bundle is not pulled in automatically — `npm install
+@gjsify/gtk-runtime-win32-x64` alongside node-gi (see
+[Requirements](#requirements)). `resolveGtkRuntimeBundle()` finds it wherever the
+package manager placed it: an explicit `GJSIFY_GTK_RUNTIME` dir, a staged
+`prebuilds/<target>/gtk/`, the sibling monorepo checkout, or
+`require.resolve('@gjsify/gtk-runtime-<target>')` — the last of which covers a
+hoisted `node_modules/@gjsify/gtk-runtime-win32-x64`, so no loader change is
+needed if the dependency edge is ever declared.
 
 ### Adwaita widget breadth realizes + reacts + renders
 

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -11,9 +11,8 @@
 // Deno — the three runtimes that implement Node-API. Runtime-specific behaviour
 // (the libuv main-loop bridge is Node-only) is gated in gi.js off RUNTIME below.
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 import { existsSync } from 'node:fs';
+import { hostTarget, nativeCandidates, packageRoot } from './native-paths.js';
 import {
     activateBundledGtkRuntime,
     maybePrependGtkRuntimeDllPath,
@@ -46,7 +45,7 @@ maybePrependGtkRuntimeDllPath();
 maybeWireGtkWindowingEnv();
 
 const require = createRequire(import.meta.url);
-const here = dirname(fileURLToPath(import.meta.url)); // package root
+const here = packageRoot; // the package root, from the shared native-paths module
 
 /**
  * Which JS runtime we are on. The Node-API addon loads on all four: Node, Bun
@@ -71,24 +70,6 @@ export const RUNTIME =
 
 /** Whether we are on Node.js (the only runtime with the libuv main-loop bridge). */
 export const isNodeRuntime = RUNTIME === 'node';
-
-function nativeCandidates() {
-    const prebuild = join(here, 'prebuilds', `${process.platform}-${process.arch}`, 'node_gi.node');
-    const release = join(here, 'build', 'Release', 'node_gi.node');
-    const debug = join(here, 'build', 'Debug', 'node_gi.node');
-    // NODE_GI_NATIVE pins which binary loads. The package's own test scripts set
-    // `build` so local verification always exercises the JUST-BUILT addon — a stale
-    // staged prebuild would otherwise shadow build/Release and silently validate
-    // the wrong binary (the consumer-facing default below prefers the prebuild).
-    const prefer = process.env.NODE_GI_NATIVE;
-    if (prefer === 'build') return [release, debug, prebuild];
-    if (prefer === 'prebuild') return [prebuild];
-    if (prefer) return [prefer]; // an explicit path to a node_gi.node
-    // Default: prefer a shipped prebuild so a consumer needs no C toolchain and no
-    // node-gyp — the only install path Deno supports (it runs no postinstall build
-    // script). Fall back to a locally built addon (Release, then Debug).
-    return [prebuild, release, debug];
-}
 
 // GJS host mode: the addon is loaded through the @gjsify/napi shim, not
 // `require()`. The loader native is `globalThis.__gjsifyNapiLoadAddon`,
@@ -123,8 +104,8 @@ function loadNative() {
         }
     }
     throw new Error(
-        `@gjsify/node-gi: native addon not found for ${RUNTIME} on ${process.platform}-${process.arch}. ` +
-            `Expected a prebuild at prebuilds/${process.platform}-${process.arch}/node_gi.node or a local build. ` +
+        `@gjsify/node-gi: native addon not found for ${RUNTIME} on ${hostTarget()}. ` +
+            `Expected a prebuild at prebuilds/${hostTarget()}/node_gi.node or a local build. ` +
             'Run `node-gyp rebuild` in ' +
             here +
             ' (requires a C++ toolchain and the girepository-2.0 / glib-2.0 development headers), ' +

--- a/packages/node-gi/node-gi/native-paths.js
+++ b/packages/node-gi/node-gi/native-paths.js
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — WHERE the native addon lives. ONE definition, shared by the
+// two decisions that must never disagree about it:
+//
+//   1. `index.js#loadNative()` — which binary a CONSUMER loads at runtime.
+//   2. `scripts/install.mjs` — whether the `install` lifecycle script has to run
+//      a node-gyp source build at all.
+//
+// WHY THIS MODULE EXISTS: those two used to be one implementation and one
+// hard-coded string in a different file. `prebuilds/<platform>-<arch>/node_gi.node`
+// spelled twice is the setup for the two silent failures nobody sees in CI — a
+// guard that skips the build because it looked in a directory the loader does not
+// probe (install succeeds, the first `import` throws), or a guard that rebuilds on
+// every install while a perfectly good prebuild sits right beside it (the defect
+// the guard was added to remove). Sharing the probe makes both impossible by
+// construction: the target-dir spelling, the addon filename and the candidate
+// ORDER exist exactly once, here.
+//
+// NOT the same question as `resolveAddonPath()` in
+// packages/infra/rolldown-plugin-gjsify (the `@gjsify/napi` bundler seam). That
+// one replicates node-gyp-build's probe order for ARBITRARY third-party addons
+// being bundled for `--app gjs`: `build/Release` → `build/Debug` → prebuild, with
+// node-gyp-build's `<runtime>.<abi|napi>.node` tag grammar. node-gi's own default
+// is deliberately the OPPOSITE way round (prebuild FIRST — see nativeCandidates
+// below) and its artifact is a plain `node_gi.node`. Two different questions, two
+// definitions; this file is the authority for node-gi's own binary, and the third
+// copy is the one that must never be written.
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * The package root. This module sits beside `index.js`, so its own directory IS
+ * the root — the same anchor `index.js` used before the extraction.
+ */
+export const packageRoot = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The addon's file name, identical in `build/{Release,Debug}/` and in a staged
+ * `prebuilds/<target>/` (scripts/stage-prebuild.mjs copies it verbatim). NOT
+ * node-gyp-build's tag grammar — nothing in this package parses tags.
+ */
+export const ADDON_FILENAME = 'node_gi.node';
+
+/**
+ * The `<os>-<arch>` prebuild target spelling — `${process.platform}-${process.arch}`,
+ * the ONE spelling used across the whole workspace (see AGENTS.md § Runtime &
+ * platform model: it is what a running process computes about itself, so
+ * resolution needs no translation).
+ *
+ * A pure function of its arguments so the darwin/win32 branches of anything
+ * built on it stay testable from a Linux host; the host values are read only at
+ * the outermost call site, as defaults.
+ * @param {string} [platform] defaults to `process.platform`
+ * @param {string} [arch] defaults to `process.arch`
+ * @returns {string} e.g. `linux-x64`, `win32-x64`, `darwin-arm64`
+ */
+export function hostTarget(platform = process.platform, arch = process.arch) {
+    return `${platform}-${arch}`;
+}
+
+/**
+ * Absolute path of the SHIPPED prebuild for a target. This is the path
+ * `scripts/stage-prebuild.mjs` writes, `files: ["prebuilds"]` publishes,
+ * `loadNative()` prefers, and `scripts/install.mjs` tests for.
+ * @param {string} [target] defaults to the running host's target
+ * @returns {string}
+ */
+export function prebuildAddonPath(target = hostTarget()) {
+    return join(packageRoot, 'prebuilds', target, ADDON_FILENAME);
+}
+
+/**
+ * Absolute path of a LOCALLY BUILT addon — what `node-gyp rebuild` writes.
+ * @param {'Release' | 'Debug'} [flavor]
+ * @returns {string}
+ */
+export function buildAddonPath(flavor = 'Release') {
+    return join(packageRoot, 'build', flavor, ADDON_FILENAME);
+}
+
+/**
+ * The ordered list of addon paths to try, most-preferred first.
+ *
+ * `NODE_GI_NATIVE` pins which binary loads. The package's own test scripts set
+ * `build` so local verification always exercises the JUST-BUILT addon — a stale
+ * staged prebuild would otherwise shadow build/Release and silently validate the
+ * wrong binary (the consumer-facing default below prefers the prebuild).
+ *
+ * Default order: prefer a shipped prebuild so a consumer needs no C toolchain and
+ * no node-gyp — the only install path Deno supports (it runs no postinstall build
+ * script). Fall back to a locally built addon (Release, then Debug).
+ * @param {Record<string, string | undefined>} [env] defaults to `process.env`
+ * @returns {string[]}
+ */
+export function nativeCandidates(env = process.env) {
+    const prebuild = prebuildAddonPath();
+    const release = buildAddonPath('Release');
+    const debug = buildAddonPath('Debug');
+    const prefer = env.NODE_GI_NATIVE;
+    if (prefer === 'build') return [release, debug, prebuild];
+    if (prefer === 'prebuild') return [prebuild];
+    if (prefer) return [prefer]; // an explicit path to a node_gi.node
+    return [prebuild, release, debug];
+}

--- a/packages/node-gi/node-gi/package.json
+++ b/packages/node-gi/node-gi/package.json
@@ -52,9 +52,11 @@
     "gettext.d.ts",
     "cairo.js",
     "cairo.d.ts",
+    "native-paths.js",
     "overrides",
     "src",
     "binding.gyp",
+    "scripts/install.mjs",
     "scripts/win-gi-gyp-flags.mjs",
     "prebuilds"
   ],
@@ -74,7 +76,7 @@
     "tier": 2
   },
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "node scripts/install.mjs",
     "build": "node-gyp rebuild",
     "build:native": "node-gyp rebuild",
     "build:prebuild": "node-gyp rebuild && node scripts/stage-prebuild.mjs",

--- a/packages/node-gi/node-gi/scripts/conformance.mjs
+++ b/packages/node-gi/node-gi/scripts/conformance.mjs
@@ -41,6 +41,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { buildAddonPath, prebuildAddonPath } from '../native-paths.js';
 
 const pkgRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const programsDir = join(pkgRoot, 'conformance', 'programs');
@@ -119,12 +120,19 @@ const cliEntry = process.env.GJSIFY_CLI_ENTRY || join(repoRoot, 'packages', 'inf
 
 // The node-gi addon as an ABSOLUTE path (a --app gjs bundle anchors import.meta
 // at the bundle, so node-gi's package-relative probing can't find it — it must be
-// pinned via NODE_GI_NATIVE). Mirrors index.js nativeCandidates() `prefer` order.
+// pinned via NODE_GI_NATIVE).
+//
+// The three PATHS come from the package's shared `native-paths.js`, so there is
+// one spelling of `prebuilds/<target>/node_gi.node` and `build/<flavor>/…` in the
+// package. The ORDER deliberately differs from `nativeCandidates()`: an UNSET
+// `NODE_GI_NATIVE` means build-first here (this is a local dev/CI tool that must
+// validate the just-built addon), while the consumer-facing default in index.js
+// is prebuild-first. Same paths, different preference — on purpose.
 function resolveNodeGiAddon() {
     const prefer = childEnv.NODE_GI_NATIVE; // 'build' by default here
-    const release = join(pkgRoot, 'build', 'Release', 'node_gi.node');
-    const debug = join(pkgRoot, 'build', 'Debug', 'node_gi.node');
-    const prebuild = join(pkgRoot, 'prebuilds', `${process.platform}-${process.arch}`, 'node_gi.node');
+    const release = buildAddonPath('Release');
+    const debug = buildAddonPath('Debug');
+    const prebuild = prebuildAddonPath();
     let order;
     if (prefer === 'prebuild') order = [prebuild];
     else if (prefer && prefer !== 'build')
@@ -271,7 +279,11 @@ function gjsNapiTwinSrc(name, file) {
 // cache invalidates when either changes (the common edit), on top of the program
 // source. Deeper edits (an override, a polyfill) still want a `conformance/dist/`
 // wipe; the header + package.json script note that.
-const inlinedNodeGiDeps = [join(pkgRoot, 'gi.js'), join(pkgRoot, 'index.js')];
+// `native-paths.js` is in the list because index.js IMPORTS it (the shared
+// prebuild/candidate definition), so its body is inlined too — leaving it out
+// would let an edit to the addon-resolution logic validate against a cached
+// bundle carrying the previous one.
+const inlinedNodeGiDeps = [join(pkgRoot, 'gi.js'), join(pkgRoot, 'index.js'), join(pkgRoot, 'native-paths.js')];
 
 // Build (or reuse a cached) `--app gjs` bundle for the gjs-napi leg. Returns the
 // bundle path, or `{ buildError }` on a bundler failure. Cache key: the generated

--- a/packages/node-gi/node-gi/scripts/install.mjs
+++ b/packages/node-gi/node-gi/scripts/install.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the `install` lifecycle script. Use the SHIPPED PREBUILD when
+// this package carries one for the host, and run the node-gyp source build only
+// when it does not. The source build is the FALLBACK, not the default.
+//
+// THE FAILURE THIS REPLACES. Until this script existed, `package.json` declared
+// `"install": "node-gyp rebuild"`, which npm/yarn/pnpm run on EVERY install — a
+// shipped prebuild could not prevent it. Measured on a `windows-latest` runner
+// against `@gjsify/node-gi@0.26.1`, whose tarball DOES contain
+// `prebuilds/win32-x64/node_gi.node`:
+//
+//     win-gi-gyp-flags: import lib for 'girepository-2.0' not found
+//     gyp ERR! configure error
+//     → npm rolls the install back; the package is not installed at all
+//
+// So on any machine without the GTK/GObject-Introspection development toolchain
+// — i.e. every end user — `npm install @gjsify/node-gi` FAILED, prebuild or not,
+// and it failed by uninstalling the package rather than by degrading. The
+// prebuild was reachable only through `gjsify install`, which deliberately runs
+// no lifecycle scripts; that asymmetry is the whole reason
+// `gjsify showcase --runtime node` worked on Windows while a plain npm
+// dependency on the same version could not be installed.
+//
+// WHY EXISTENCE, NOT LOADABILITY, IS THE GATE. The obvious-looking alternative
+// (`node-gyp-build`) gates on its `node-gyp-build-test` bin, which `require()`s
+// the addon and falls back to a source build if the load throws. On exactly the
+// platforms whose whole point is the prebuild that is a FALSE NEGATIVE: the
+// win32/darwin addon's DLL/dylib closure is only findable after
+// `gtk-runtime.js` has wired the batteries-included GTK bundle into `PATH` /
+// `DYLD_FALLBACK_LIBRARY_PATH`, which `index.js` does at import time and a bare
+// install-time `require()` of the `.node` never does. A load-based gate would
+// therefore call a perfectly good prebuild broken and rebuild — reproducing the
+// exact failure above. Existence of the file the loader actually probes is the
+// honest question at install time; whether it LOADS is what the release
+// workflow's per-target load test answers (release.yml runs
+// `NODE_GI_NATIVE=prebuild node --test test/smoke.test.mjs` on every leg), where
+// there is a real GTK to load against.
+//
+// WHY NOT DEPEND ON `node-gyp-build` (verified, not assumed):
+//   • its skip gate is that false-negative load test (above) — the disqualifier;
+//   • its probe order is `build/` FIRST, then the prebuild, the OPPOSITE of
+//     node-gi's deliberate consumer default (see native-paths.js
+//     `nativeCandidates`), so the two would disagree about which binary matters;
+//   • it cannot produce ONE actionable diagnosis — on failure it propagates a
+//     bare node-gyp exit code, which is the status quo this change removes;
+//   • it would add a runtime `dependencies` entry to a Tier-2 package whose dep
+//     surface is otherwise just `node-addon-api`, to make a decision this
+//     package can make from its own already-shared probe.
+//   (It would, contrary to first assumption, MATCH the `node_gi.node` filename:
+//   node-gyp-build 4.8.4's `matchTags` treats a missing runtime tag as
+//   permissive — checked against the installed copy. The filename was not the
+//   blocker; the gate and the message are.)
+//
+// THE SOURCE BUILD MUST KEEP WORKING, and does. `prebuilds/` is gitignored
+// (packages/node-gi/node-gi/.gitignore), so a fresh checkout has none and this
+// script builds exactly as before — which is what the ~12 `npm install
+// --foreground-scripts` steps in node-gi.yml and the three
+// `node-gi-prebuild-*` legs in release.yml rely on to produce
+// `build/Release/node_gi.node` for `scripts/stage-prebuild.mjs`. Depending on a
+// directory being ABSENT is too implicit to be the only guarantee, so the build
+// is also forceable: `NODE_GI_BUILD_FROM_SOURCE=1` (or npm's own
+// `--build-from-source`, which sets `npm_config_build_from_source=true`) skips
+// the prebuild check entirely. `npm run build:native` / `build:prebuild` /
+// `rebuild` still invoke `node-gyp` directly and are untouched by this script.
+//
+// FAIL-SAFE DIRECTION: every uncertain branch builds. Only a positively
+// confirmed prebuild file for this exact host skips the build, so a bug here
+// degrades to the previous behaviour rather than to a package with no addon.
+import { existsSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { hostTarget, packageRoot, prebuildAddonPath } from '../native-paths.js';
+
+const target = hostTarget();
+
+/** `1`/`true` on an env var, tolerant of the shapes people actually type. */
+const isEnabled = (value) => value === '1' || value === 'true';
+
+/**
+ * Did the user explicitly ask for a source build? `NODE_GI_BUILD_FROM_SOURCE` is
+ * ours; `npm_config_build_from_source` is what npm exports for
+ * `--build-from-source` (the flag every node-gyp-build package honours), so a CI
+ * job or a maintainer can force the build without knowing node-gi's own name for
+ * it.
+ */
+const buildFromSourceRequested = () =>
+    isEnabled(process.env.NODE_GI_BUILD_FROM_SOURCE) || process.env.npm_config_build_from_source === 'true';
+
+/** The `<os>-<arch>` targets this package PROMISES a prebuild for, from its own manifest. */
+function declaredPlatforms() {
+    try {
+        const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+        const platforms = manifest?.gjsify?.platforms;
+        return Array.isArray(platforms) ? platforms : [];
+    } catch {
+        // An unreadable own manifest is not worth failing an install over — the
+        // diagnosis below just loses one line of context.
+        return [];
+    }
+}
+
+/**
+ * Run `node-gyp rebuild` in the package root, inheriting stdio so the real
+ * compiler output stays visible (it is the actual diagnosis; the framed message
+ * below only tells the reader what to DO about it).
+ *
+ * node-gyp is resolved the way node-gyp-build's own bin does: prefer node-gyp's
+ * JS entry if it happens to be resolvable, else the `node-gyp` shim that npm,
+ * yarn and pnpm all put on `PATH` for lifecycle scripts (`node-gyp.cmd` on
+ * Windows, hence `shell` there).
+ * @returns {{ status: number, error?: Error }}
+ */
+function runNodeGyp() {
+    const win32 = process.platform === 'win32';
+    let command = win32 ? 'node-gyp.cmd' : 'node-gyp';
+    let args = ['rebuild'];
+    let shell = win32;
+    try {
+        // Only succeeds when node-gyp is genuinely resolvable from here; npm's
+        // bundled copy lives in npm's own tree and is not, which is why the PATH
+        // shim above stays the normal path. `createRequire().resolve` rather than
+        // `import.meta.resolve` — the latter is only synchronous from Node 20.6,
+        // and `engines.node` is `>=20`.
+        const entry = createRequire(import.meta.url).resolve('node-gyp/bin/node-gyp.js');
+        command = process.execPath;
+        args = [entry, 'rebuild'];
+        shell = false;
+    } catch {
+        // Not resolvable — use the PATH shim.
+    }
+    const res = spawnSync(command, args, { cwd: packageRoot, stdio: 'inherit', shell, windowsHide: true });
+    return { status: res.status === null ? 1 : res.status, error: res.error };
+}
+
+/**
+ * Are we running inside a source CHECKOUT rather than an installed tarball?
+ * Keyed on two paths `files` deliberately does not publish (`test/` and the
+ * staging tool), because the distinction changes the advice: in a checkout
+ * `prebuilds/` is gitignored, so its absence is expected and the source build IS
+ * the path; in an installed copy a missing prebuild for a PROMISED target is a
+ * packaging regression the consumer should report instead of debugging.
+ */
+function isRepoCheckout() {
+    return existsSync(join(packageRoot, 'test')) || existsSync(join(packageRoot, 'scripts', 'stage-prebuild.mjs'));
+}
+
+/**
+ * ONE actionable message for "no usable prebuild AND the source build did not
+ * succeed" — the case that used to surface as nothing but a node-gyp stack. It
+ * distinguishes the three very different reasons the prebuild was missing,
+ * because the reader's next action differs each time: a checkout is SUPPOSED to
+ * build; an undeclared platform means "build it yourself or use a supported
+ * target"; and a DECLARED platform with no artifact in an installed copy is a
+ * packaging regression that should be reported, not worked around (precisely how
+ * 0.26.0 shipped `prebuilds/linux-*` only while promising four targets — and
+ * nothing told the consumer).
+ */
+function reportFailure(status, spawnError) {
+    const platforms = declaredPlatforms();
+    const promised = platforms.includes(target);
+    const checkout = isRepoCheckout();
+    const bar = '─'.repeat(78);
+    const lines = [
+        '',
+        bar,
+        `@gjsify/node-gi: could not obtain the native addon for ${target}.`,
+        '',
+        checkout
+            ? '  • This is a source checkout, where `prebuilds/` is gitignored — no staged prebuild\n' +
+              '    for this host was expected, and the source build IS the path here.'
+            : promised
+              ? `  • This package PROMISES a prebuild for ${target} (package.json#gjsify.platforms) but\n` +
+                `    the installed copy carries no prebuilds/${target}/node_gi.node. That is a packaging\n` +
+                '    bug in this release, not a problem with your machine — please report it at\n' +
+                '    https://github.com/gjsify/gjsify/issues.'
+              : `  • No prebuild ships for ${target}.` +
+                (platforms.length > 0 ? ` Prebuilds ship for: ${platforms.join(', ')}.` : ''),
+        spawnError
+            ? `  • The node-gyp source build could not even be STARTED: ${spawnError.message}\n` +
+              '    (node-gyp is normally provided on PATH by npm/yarn/pnpm for install scripts.)'
+            : `  • The node-gyp source build above exited ${status}. Its output is the actual diagnosis.`,
+        '',
+        'Building from source needs a C++ toolchain plus GLib >= 2.80 development headers',
+        'exposing girepository-2.0, and cairo:',
+        '  Fedora        dnf install gcc-c++ make python3 pkgconf-pkg-config glib2-devel \\',
+        '                    gobject-introspection-devel cairo-devel',
+        '  Debian/Ubuntu apt install g++ make python3 pkg-config libglib2.0-dev \\',
+        '                    libgirepository-2.0-dev libcairo2-dev',
+        '  macOS         brew install gobject-introspection cairo pkg-config',
+        '  Windows       gvsbuild GTK4 (MSVC ABI), then PKG_CONFIG_PATH=<prefix>\\lib\\pkgconfig',
+        '',
+        'Escape hatches:',
+        '  NODE_GI_SKIP_NATIVE_BUILD=1     install the JS without an addon (every gi:// import',
+        '                                  then throws until you point NODE_GI_NATIVE at one)',
+        '  NODE_GI_NATIVE=/abs/node_gi.node  load an addon you built or copied yourself',
+        '  NODE_GI_BUILD_FROM_SOURCE=1     build from source even when a prebuild exists',
+        bar,
+        '',
+    ];
+    console.error(lines.join('\n'));
+}
+
+function main() {
+    // Deliberately first: an explicit "do not build" wins over everything, so a
+    // consumer on an unsupported platform can complete an install and supply an
+    // addon via NODE_GI_NATIVE afterwards.
+    if (isEnabled(process.env.NODE_GI_SKIP_NATIVE_BUILD)) {
+        console.log(
+            `@gjsify/node-gi: NODE_GI_SKIP_NATIVE_BUILD is set — skipping the native addon for ${target}. ` +
+                'gi:// imports will throw until NODE_GI_NATIVE points at a node_gi.node.',
+        );
+        return 0;
+    }
+
+    const prebuild = prebuildAddonPath();
+    if (!buildFromSourceRequested() && existsSync(prebuild)) {
+        console.log(
+            `@gjsify/node-gi: using the shipped prebuild for ${target} ` +
+                `(prebuilds/${target}/node_gi.node) — no node-gyp, no C++ toolchain needed. ` +
+                'Set NODE_GI_BUILD_FROM_SOURCE=1 to build from source anyway.',
+        );
+        return 0;
+    }
+
+    const { status, error } = runNodeGyp();
+    if (status === 0 && !error) return 0;
+    reportFailure(status, error);
+    // Fail the install rather than half-install. This package IS its native
+    // addon: a zero exit here would trade a clear install-time failure for a
+    // deferred `import` failure in the consumer's own code, and npm's rollback is
+    // the honest outcome. NODE_GI_SKIP_NATIVE_BUILD is the opt-in for anyone who
+    // wants the other trade.
+    return status === 0 ? 1 : status;
+}
+
+process.exit(main());


### PR DESCRIPTION
`npm install @gjsify/node-gi` fails on every machine without a GTK/GObject-Introspection development toolchain — i.e. on every end user's machine — even though the published tarball carries a prebuild for that platform.

## The defect

`package.json` declared `"install": "node-gyp rebuild"`. npm/yarn/pnpm run that on **every** install, so a shipped prebuild could not prevent it. Measured on a `windows-latest` runner against `@gjsify/node-gi@0.26.1`, whose tarball *does* contain `prebuilds/win32-x64/node_gi.node`:

```
win-gi-gyp-flags: import lib for 'girepository-2.0' not found
gyp ERR! configure error
→ npm rolls the install back; the package is not installed at all
```

It fails by *uninstalling*, not by degrading. The prebuild was reachable only via `gjsify install`, which deliberately runs no lifecycle scripts — which is precisely why `gjsify showcase --runtime node` works on Windows while a plain npm dependency on the same version cannot be installed.

## The fix

`scripts/install.mjs` skips node-gyp iff the prebuild **the loader probes** exists for this host, and otherwise builds exactly as before.

The gate is **existence, not loadability**. The obvious alternative (`node-gyp-build`) gates on `node-gyp-build-test`, which `require()`s the addon. On win32/darwin that is a false negative: the addon's DLL/dylib closure is only findable after `gtk-runtime.js` wires the GTK bundle into `PATH` / `DYLD_FALLBACK_LIBRARY_PATH`, which `index.js` does at import time and a bare install-time `require()` never does. A load-based gate would call a good prebuild broken and rebuild — reproducing the failure above. Whether it *loads* is what `release.yml`'s per-target `NODE_GI_NATIVE=prebuild` smoke test answers, where a real GTK exists.

`native-paths.js` extracts the probe so the guard and the loader **cannot disagree** about which binary matters: the target-dir spelling, the addon filename and the candidate order now exist exactly once. A guard that skipped the build after looking in a directory the loader does not probe would install fine and throw on first `import`; that is now impossible by construction. `conformance.mjs` shares the paths but keeps its build-first order deliberately (a dev tool must validate the just-built addon), and gains `native-paths.js` in its bundle cache key — without that, an edit to addon resolution would validate against a stale cached bundle.

Fail-safe direction: only a positively confirmed prebuild skips, so a bug here degrades to the previous behaviour rather than to a package with no addon.

## Not broken by this

`prebuilds/` is gitignored, so a checkout has none and builds as before — which is what the `npm install --foreground-scripts` steps in `node-gi.yml` and the three `node-gi-prebuild-*` legs in `release.yml` rely on. Because "a directory happens to be absent" is too implicit to be the only guarantee, the build is also forceable: `NODE_GI_BUILD_FROM_SOURCE=1` or npm's own `--build-from-source`. No workflow changes.

## Second commit is docs only — the GTK bundles are still undelivered

`@gjsify/gtk-runtime-win32-x64` / `-darwin-arm64` are published and node-gi resolves either the moment it is in the tree, but **no package declares them as a dependency**, so nothing installs them. The `optionalDependencies` edge is *not* added here, blocked on two decisions outside this package:

1. **ADR 0003 forbids it.** Tier 2 must not depend on Tier 3; node-gi is `tier: 2`, both bundles are `tier: 3`, and `audit-runtimes --check` rejects the edge (verified by adding it temporarily). Promotion needs "a second real consumer" per ADR 0003, and node-gi is these bundles' only consumer *by design*. An optional peer is exempt from the rule but installs nothing.
2. **`gjsify install` does not filter `os`/`cpu`** on `main`, so the edge would place the ~36 MB Windows bundle into every Linux tree. That filter is #897.

Both are structural rather than node-gi-specific: ADR 0017 splits every native bridge into per-target artifact packages, so the tier question must be answered for that whole class. Until then the README documents the manual install instead of describing an automatic bundle nobody receives.

## Verification

`audit-runtimes --check` and `--check --strict` exit 0; `changed-packages.mjs --all` exits 0; oxfmt/oxlint clean. Probe order is byte-identical to the old inline version for all four `NODE_GI_NATIVE` states. Guard exercised in a copied fixture: skip-flag → 0; prebuild present with node-gyp unreachable on PATH → 0 (the Windows end-user case); force flag (both spellings) → builds; build failure → framed message + node-gyp's status; node-gyp missing entirely → distinct message + exit 1. `gjsify pack` and `npm pack --dry-run` produce identical 40-file sets, both containing the two new files, and the packed manifest records `install = node scripts/install.mjs`.

**Not proven here:** nothing was run on Windows or macOS. That a stock Windows/macOS `npm install` now completes is established as a *mechanism* on Linux (prebuild present + node-gyp unreachable → exit 0), not as an end-to-end result. The `node-gyp.cmd` + `shell: true` path is untested.