### PR TITLE
docs(status): drop the resolved squash-subject TODO

### DIFF
--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -282,25 +282,6 @@ blueprint toolchain. The shape that keeps the property is a SECOND baked image
 holding exactly this package set, built by the same workflow. Per-job judgement
 needed on which of the ten want which image.
 
-### The squash subject is what lands on main, and nothing lints it
-
-`commitlint.yml` runs `wagoid/commitlint-github-action`, which lints the PR's
-COMMITS. With squash merges, what actually lands is the PR TITLE — a string no
-check inspects. `f51fa0f57 Run the transparent addon matrix in CI (#849)` has
-no conventional prefix and is therefore absent from the generated CHANGELOG
-entirely; the work shipped in v0.26.0 with no release note. The workflow
-already triggers on `edited` (title/body changes), which only re-runs the
-commit lint today — the intent was there, the check never was.
-
-The trap when fixing it: a hand-rolled title regex is a partial reimplementation
-of commitlint (`config-conventional` also enforces `subject-case`,
-`subject-full-stop`, `header-max-length`), so it would pass titles the real
-linter rejects — the exact drift the rule exists to prevent. Running
-`@commitlint/cli` against `commitlint.config.cjs` needs `config-conventional`
-resolvable from the repo, which is precisely what the action avoids by bringing
-its own. Decide deliberately between a purpose-built title action and making
-the config self-contained; do not hand-roll the regex.
-
 ### CHANGELOG links break on `#nnn` written inside commit bodies
 
 conventional-changelog scans commit BODIES for issue references, so prose like


### PR DESCRIPTION
#908 closed this item — the TODO is now a corpse, and the repo's rule is that a resolved TODO is **deleted** (its record is the commit + CHANGELOG that closed it).

The item asked for a deliberate choice between *"a purpose-built title action"* and *"making the config self-contained"*, and warned against hand-rolling a regex. #908 took the first option and avoided the trap:

- the PR title is linted by `amannn/action-semantic-pull-request@v5` in `commitlint.yml` — no partial reimplementation of `config-conventional`;
- no second copy of the type list: the action's default **is** our `type-enum`, and `check-pr-title-types.mjs` holds that assumption, failing the moment the two diverge and telling you to make the list explicit.

Docs-only, so the affected classifier reports `skip-all`.