### PR TITLE
fix(ci): stop the prebuild image from moving the glibc floor

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -56,7 +56,7 @@ name: Build Native Prebuilds
 # while checking out the PR's head code — precisely the combination that must
 # not exist in a workflow that contains a job which pushes commits. Plain
 # `pull_request` runs with a token GitHub forces to read-only for fork PRs, and
-# the build legs need nothing more: they pull the PUBLIC `fedora:44` image, so
+# the build legs need nothing more: they pull the PUBLIC `fedora:43` image, so
 # unlike main.yml's private `ghcr.io/gjsify/ci-fedora` they also work on a fork
 # PR. Least privilege backs that up rather than relying on it — see
 # `permissions` below.
@@ -320,7 +320,41 @@ jobs:
     needs: [changes]
     runs-on: ${{ matrix.runner }}
     container:
-      image: fedora:44
+      # ══════════════════════════════════════════════════════════════════
+      # THIS IMAGE IS A DISTRIBUTION DECISION, NOT A TEST HOST. DO NOT BUMP
+      # IT TO MATCH THE OTHER WORKFLOWS.
+      #
+      # Every other `fedora:<n>` in this repository picks a machine to RUN
+      # tests on; a newer one is strictly better and bumping them together
+      # is the obvious hygiene. This one picks the glibc our published
+      # binaries are LINKED AGAINST, and that number is a promise to every
+      # consumer — the toolchain's own `gjsify.glibcRequires` floor, which
+      # `lightningcss-native` alone pushes to the highest value in the tree.
+      #
+      # #897 bumped it 43 → 44 as part of exactly that hygiene sweep, with
+      # no functional need, and it took main red for three consecutive
+      # `commit-prebuilds` runs. Measured:
+      #
+      #   fedora:43 → glibc 2.42, floor stays 2.39 (`pidfd_spawnp`, from
+      #               Rust std) — the value every package declares today
+      #   fedora:44 → glibc 2.43, floor jumps to 2.43, because 2.43
+      #               RE-VERSIONS three float-math symbols
+      #               (`acosf`/`asinf`/`atan2f`) that lightningcss's colour
+      #               conversion calls. The linker binds the newest default
+      #               version available, so merely BUILDING there rewrites
+      #               the requirement — no source change, no review.
+      #
+      # The old symbol versions still exist in glibc 2.43 and behave the
+      # way lightningcss needs, so nothing is gained by the newer ones. What
+      # is LOST is every consumer below 2.43: at 2.39 this toolchain runs on
+      # Ubuntu 24.04 and Debian 13; at 2.43 it runs on essentially nothing
+      # shipping today.
+      #
+      # If this must move, the floor moves with it — so decide the floor
+      # first (see `status/open-todos.md` → "the prebuild glibc floor is an
+      # accident of the build image"), do not inherit it from a tag.
+      # ══════════════════════════════════════════════════════════════════
+      image: fedora:43
 
     strategy:
       fail-fast: false
@@ -697,9 +731,9 @@ jobs:
   # emulation, registered at a PINNED version (see the step below) and driven
   # by a plain `docker run --platform`.
   #
-  # ppc64 + s390x: fedora:44 has official images for both → same dnf
+  # ppc64 + s390x: fedora:43 has official images for both → same dnf
   #   package names as the native job above.
-  # riscv64: fedora:44 has no riscv64 image → ubuntu:26.04 is used
+  # riscv64: fedora:43 has no riscv64 image → ubuntu:26.04 is used
   #   instead (package names differ; auto-detected via command -v dnf).
   #
   # Node.js process.arch values used as the prebuilds/ dir suffix:
@@ -738,12 +772,16 @@ jobs:
           # IBM POWER9/10 workstations and servers (e.g. Raptor Computing Talos II)
           - arch: ppc64
             platform: linux/ppc64le
-            base_image: fedora:44
+            # Same image as the native leg, and pinned to it for the same
+            # reason: these artifacts are published too, so the emulated
+            # legs' glibc sets their floor exactly as it does for x64/arm64.
+            # See the block on `build-prebuilds`' own `container:`.
+            base_image: fedora:43
 
           # IBM Z mainframes — enterprise Linux servers
           - arch: s390x
             platform: linux/s390x
-            base_image: fedora:44
+            base_image: fedora:43
 
           # RISC-V boards (StarFive VisionFive 2, Milk-V Pioneer, SiFive HiFive, …)
           # ubuntu:26.04 because Fedora publishes no riscv64 image.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,6 +4,48 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
+### Bun DID hard-crash in the N-API teardown class — the first one, and the note that predicted it asked to be told
+
+`scripts/cross-runtime.mjs` carves Deno out of exit-code gating for the
+post-pass teardown abort (#47) and deliberately does NOT carve out Bun, on
+measured grounds: *"~7000 Bun runs (arrays + the GObject/boxed-heavy files …,
+full 37-file suite ×40, a probe holding 30k live boxed handles to process exit,
+random `--smol` GC pressure) produced 0 crashes / 0 cores"*, and it closes with
+an instruction — **"if Bun ever hard-crashes here, re-confirm with a gdb
+backtrace (the Deno determination's bar) first."**
+
+It has now happened, twice, on PR #923's CI (`ci-fedora:44`, bun 1.3.14,
+`NODE_GI_NATIVE=prebuild`):
+
+```
+test/arrays.test.mjs:
+  (pass) GStrv return → string[] … 8/8 assertions pass
+free(): invalid pointer
+  ✗ arrays
+```
+
+Note the marker: `free(): invalid pointer` is a **glibc heap abort**, not the
+`SIGSEGV` inside `g_boxed_free` that the Deno determination is built on, and not
+Bun's own `panic(main thread)`. Same family (a corrupt pointer reaching the
+allocator at teardown, after every assertion has passed), different
+manifestation — so the mechanism argument for Bun (deferred finalizers, run
+single-threaded on the JS thread under `DeferGCForAWhile`, `napi_internal_remove_finalizer`
+dedup) does not obviously cover it and should be re-checked rather than assumed.
+
+Nondeterministic, and independent of that PR's contents: attempt 1 failed on
+bun, attempt 2 on **deno**, attempt 3 passed, all on one commit; the job runs
+`npm install` + node-gyp inside `packages/node-gi/node-gi` (sole dependency
+`node-addon-api`), so nothing in that PR is reachable from it; the CI images
+either side of the first failure are package-identical (797 packages, empty
+`diff`, same `glibc-2.43-6`); 10 local `--only arrays` runs on unmodified `main`
+were green.
+
+Next step is the one the note names, not a carve-out: reproduce under gdb (the
+Deno case took ~8 cores on a loop of the boxed-heavy files) and get a backtrace.
+Until then Bun stays on exit-code gating — a `pass>0 && fail===0 && <crash
+marker>` carve-out added now would mask exactly the real Bun teardown bug this
+might be.
+
 ### The prebuild glibc floor is an accident of the build image, and the gate that says so only runs post-merge
 
 Two halves, and the first one is now paid for. `prebuilds.yml`'s base image

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,6 +4,45 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
+### The prebuild glibc floor is an accident of the build image, and the gate that says so only runs post-merge
+
+Two halves, and the first one is now paid for. `prebuilds.yml`'s base image
+decides which glibc our published binaries link against, so bumping it rewrites
+`gjsify.glibcRequires` for every consumer without touching a line of source.
+#897 bumped it 43 → 44 as part of a hygiene sweep across the workflows' images,
+and glibc 2.43 re-versions `acosf`/`asinf`/`atan2f` — which lightningcss's colour
+conversion calls — so the measured floor went 2.39 → 2.43 and main was red for
+three consecutive `commit-prebuilds` runs. Reverted, with the reason written at
+the `container:` line so the next hygiene sweep cannot repeat it.
+
+**The gate worked; it just fired late.** `commit-prebuilds` runs
+`audit-runtimes --check` on the freshly downloaded artifacts and refused them,
+naming both numbers — exactly what the step's own comment predicted a base-image
+bump would do. But `commit-prebuilds` is main-only, so the PR that caused it was
+green. That is the shape AGENTS.md § "PR coverage parity" calls dishonest: a
+green PR must predict a green main.
+
+Closing it means running the same measurement in the BUILD legs, which do run on
+`pull_request`. Two prerequisites, neither large:
+- the legs need `nodejs` in their `dnf install` line (`audit-runtimes.mjs` is
+  pure Node with no dependencies, which is why `audit-runtimes.yml` can run it
+  with no install);
+- the measurement must read the FRESHLY BUILT files, so the legs have to stage
+  into the directory the artifact is actually published from. Today they stage
+  into the bridge's own `prebuilds/`, which is also where the committed copy
+  lives, so it happens to work — but after ADR 0017's split that is scratch
+  space and the audit would silently measure the old committed binaries instead.
+  Move the staging with the gate, in the same change.
+
+**Still open underneath both:** the floor is OBSERVED, never CHOSEN. Even pinned
+to `fedora:43` it moves the day that image's glibc re-versions something else.
+Deciding it would mean building the three Rust bridges against a declared
+baseline — an old-glibc container (manylinux/RHEL-derived) or
+`cargo-zigbuild --target <triple>.<glibc>` — and then `gjsify.glibcRequires`
+becomes an input the build satisfies rather than a number someone reads off the
+result. That is a policy decision (how old a distro do we support?) and wants its
+own change.
+
 ### `cli.gjs.mjs` byte-reproducibility is not closed — main shipped a non-reproducing bundle again
 
 #906 merged a committed `packages/infra/cli/dist/cli.gjs.mjs` that does not


### PR DESCRIPTION
`main`'s `Build Native Prebuilds` has been red since 2026-08-01 20:05 — three
consecutive `commit-prebuilds` runs, so no new prebuild has landed since.

## What broke

`prebuilds.yml`'s base image decides which glibc every published binary is
**linked against**. #897 bumped it `fedora:43` → `fedora:44` as part of a hygiene
sweep across the workflows' images. That sweep is right for every *other*
`fedora:<n>` in the repo — those pick a machine to run tests on, and newer is
strictly better. This one picks an ABI promise.

Measured, on this machine:

| image | glibc | resulting floor |
|---|---|---|
| `fedora:43` | 2.42 | **2.39** — `pidfd_spawnp`/`pidfd_getpid`, from Rust std. The value every package declares today. |
| `fedora:44` | 2.43 | **2.43** — glibc 2.43 RE-VERSIONS `acosf`, `asinf` and `atan2f`, which lightningcss's colour conversion calls. |

From the artifact the failing run actually uploaded:

```
$ readelf --dyn-syms -W libgjsify_lightningcss.so | grep GLIBC_2.43
  32: … UND atan2f@GLIBC_2.43 (11)
  33: … UND asinf@GLIBC_2.43  (11)
  37: … UND acosf@GLIBC_2.43  (11)
```

The linker binds the newest *default* version available, so merely building
there rewrites the requirement — no source change, no review, nothing to
attribute it to. The old symbol versions still exist in 2.43 and behave the way
lightningcss needs, so the new ones buy nothing. What they cost is every consumer
below 2.43: at 2.39 this toolchain runs on Ubuntu 24.04 and Debian 13; at 2.43,
on essentially nothing shipping today.

## The fix

Revert the five image references (native container + the two emulated
`base_image`s + two comments), and put the reason **at the `container:` line**.
The failure mode is that the next person doing image hygiene sees a
stale-looking tag; a commit message will not be in front of them.

No declaration changes: the committed artifacts already measure 2.39, which is
what every package declares. Raising the declaration to 2.43 was the other way
out and is rejected on the numbers above.

## The gate did its job

Nothing about `prebuild-libc` needs changing. `commit-prebuilds` measured the
freshly downloaded artifacts, refused them and named both numbers — exactly what
that step's own comment predicted a base-image bump would do:

> a base-image bump (fedora:43 → 44 → …) is exactly the change that moves that
> number without touching one line of source

It fired **late**, though: `commit-prebuilds` is main-only, so the PR that caused
it was green. That is the shape AGENTS.md § "PR coverage parity" calls dishonest.
Closing it means running the same measurement in the build legs, which do run on
`pull_request` — recorded in `status/open-todos.md` with both prerequisites
(`nodejs` in the legs' `dnf` line; the legs must stage where the artifact is
published from, which ADR 0017's split changes, so the two want to move
together).

Also recorded there: underneath all of this the floor is **observed, never
chosen**. Even pinned to `fedora:43` it moves the day that image's glibc
re-versions something else. Choosing it means building the three Rust bridges
against a declared baseline (old-glibc container or `cargo-zigbuild --target
<triple>.<glibc>`) — a policy decision about how old a distro we support, and its
own change.

## Verified

- `node scripts/audit-runtimes.mjs --check --strict` → OK
- `changed-packages.mjs` still parses the workflow and gates correctly (its
  package table is derived from these very files)
- both glibc numbers measured under `podman run --platform linux/amd64`
