### PR TITLE
ci(prebuilds): retry the network fetches the emulated legs depend on

### DIFF
--- a/.github/prebuild-toolchain/emulated-build.sh
+++ b/.github/prebuild-toolchain/emulated-build.sh
@@ -139,8 +139,24 @@ command -v g-ir-compiler > /dev/null 2>&1 || {
 
 # rustup (lightningcss-native, below). The distro cargo is usually older than
 # the rustc >= 1.85 that indexmap@2.14's edition2024 needs.
+#
+# RETRIED, because one transient fetch discards a whole emulated build. By the
+# time this line runs the leg has installed a few hundred packages under QEMU,
+# and a bare `curl -sSf` turns any blip into a red `main`: on 2026-08-02 it was
+# `curl: (35) Send failure: Connection reset by peer` on s390x, one run after a
+# `502 Bad Gateway` from Docker Hub killed ppc64 the same way. Neither said
+# anything about this repository's code, and each threw away minutes of
+# emulated work — plus every other package that leg had already built.
+#
+# `--retry-all-errors` is the load-bearing flag: plain `--retry` covers
+# transient HTTP codes and timeouts but NOT a connection reset, which is
+# precisely what happened. Curl's own retry rather than a shell loop, because
+# the download is piped straight into `sh` — re-running the pipeline would
+# re-run the installer, not just the fetch.
 if needs_rust; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |
+    curl --proto '=https' --tlsv1.2 -sSf \
+        --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 \
+        https://sh.rustup.rs |
         sh -s -- -y --default-toolchain stable --profile minimal
     export PATH="$HOME/.cargo/bin:$PATH"
 else

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -403,7 +403,8 @@ jobs:
         # which requires `edition2024` (rustc ≥ 1.85). Install rustup
         # directly for a current toolchain.
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+          curl --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 \
+            https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Checkout repository
@@ -853,6 +854,24 @@ jobs:
           PREBUILD_SKIP: ${{ needs.changes.outputs.skip }}
         run: |
           set -euo pipefail
+          # PULL FIRST, AND RETRY IT. `docker run` would pull implicitly, which
+          # conflates two failures that deserve different treatment: a registry
+          # blip and a broken build. On 2026-08-02 the ppc64 leg died on
+          #   Head ".../library/fedora/manifests/43": 502 Bad Gateway
+          # with exit 125 — Docker's "could not even start the container" — and
+          # took a green run down with it. Docker Hub is unauthenticated here
+          # (deliberately: it is what lets these legs work on a fork PR), so it
+          # is both rate-limited and occasionally flaky, and every retry is
+          # cheap next to the ~3 min of emulation behind it.
+          for attempt in 1 2 3 4 5; do
+            if docker pull --platform "$PLATFORM" "$BASE_IMAGE"; then break; fi
+            if [ "$attempt" = 5 ]; then
+              echo "::error::could not pull $BASE_IMAGE for $PLATFORM after 5 attempts"
+              exit 1
+            fi
+            echo "pull failed (attempt $attempt/5) — retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker run --rm --platform "$PLATFORM" \
             -v "$PWD:/workspace" -w /workspace \
             -e ARCH="$ARCH" \
@@ -1077,7 +1096,8 @@ jobs:
             rustup toolchain install stable --profile minimal
             rustup default stable
           else
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+            curl --proto '=https' --tlsv1.2 -sSf --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 \
+            https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
             echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
           fi
 


### PR DESCRIPTION
Two consecutive `main` runs died on transient network failures, in two different
places, neither about this repository's code:

| leg | failure |
|---|---|
| ppc64 | `docker: Head ".../library/fedora/manifests/43": 502 Bad Gateway` → exit 125 |
| s390x | `curl: (35) Send failure: Connection reset by peer` (rustup installer) |

Each threw away a leg that had already spent minutes emulating — and because
`commit-prebuilds` `needs` all of them, each one also discarded the artifacts
the **other seven legs produced successfully**. The blast radius of one blip is
the entire run, which is why these read as real breakage when they are not.

## What changes

- **The image is pulled explicitly**, five attempts with linear backoff, instead
  of implicitly by `docker run`. That also separates two failures worth telling
  apart — a registry blip and a broken build — which `docker run` reports
  identically as exit 125. Docker Hub is unauthenticated here *on purpose* (it is
  what lets these legs work on a fork PR), so it is both rate-limited and
  occasionally flaky.
- **All three `sh.rustup.rs` fetches** (emulated, native Fedora, macOS) get
  `--retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30`.

`--retry-all-errors` is the load-bearing flag: plain `--retry` covers transient
HTTP codes and timeouts but **not** a connection reset, which is exactly what
s390x hit. Curl's own retry rather than a shell loop, because the download pipes
straight into `sh` — retrying the pipeline would re-run the installer, not just
the fetch.

## Verified

`prebuilds.yml` parses, `emulated-build.sh` passes `bash -n`,
`changed-packages.mjs` still derives its table from the workflow, and
`audit-runtimes --check --strict` is green.