### PR TITLE
test(e2e): let the harness run on Windows

### DIFF
--- a/tests/e2e/build-cache/run.mjs
+++ b/tests/e2e/build-cache/run.mjs
@@ -32,6 +32,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 function runCli(cliEntry, args, { cwd, env, timeoutMs = 60_000 } = {}) {
     return new Promise((resolve, reject) => {
@@ -86,7 +87,7 @@ describe('gjsify build cache (--cached, ADR 0006 phase 1)', { timeout: 300_000 }
 
     before(() => {
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-build-cache-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         writeFileSync(
             join(root, 'package.json'),
@@ -289,7 +290,7 @@ describe('gjsify build cache — the dual emit must not clobber itself', { timeo
 
     before(() => {
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-dual-emit-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         writeFileSync(
             join(root, 'package.json'),
             JSON.stringify(

--- a/tests/e2e/deterministic-library-build/run.mjs
+++ b/tests/e2e/deterministic-library-build/run.mjs
@@ -37,8 +37,9 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const CLI_ENTRY = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+const CLI_ENTRY = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
 /** sha256 over the sorted (path, content) sequence of a directory tree. */
 function hashTree(dir) {

--- a/tests/e2e/dlx-version-pin/run.mjs
+++ b/tests/e2e/dlx-version-pin/run.mjs
@@ -32,7 +32,7 @@ import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
+import { pathToFileURL, fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
 // Tar helpers — assemble a ustar archive with multiple files.
@@ -263,7 +263,7 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
         // Run the CLI from the workspace build output. `XDG_CACHE_HOME=<tmp>`
         // makes `dlxCacheRoot()` return `<tmp>/gjsify/dlx`. Forcing the native
         // backend keeps the test independent of npm being on PATH.
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             XDG_CACHE_HOME: cacheRoot,

--- a/tests/e2e/foreach-command/run.mjs
+++ b/tests/e2e/foreach-command/run.mjs
@@ -12,6 +12,7 @@ import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, readFileSync
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 function runCli(cliEntry, args, { cwd, env, timeoutMs = 30_000 } = {}) {
     return new Promise((resolve, reject) => {
@@ -51,7 +52,7 @@ describe('gjsify foreach + workspace (Phase D.4)', { timeout: 60_000 }, () => {
 
     before(() => {
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-foreach-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         // Root manifest declaring 3 packages/*.
         writeFileSync(

--- a/tests/e2e/gjs-less-host/run.mjs
+++ b/tests/e2e/gjs-less-host/run.mjs
@@ -30,8 +30,9 @@ import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+const cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
 /** PATH with every directory containing a `gjs` binary removed. */
 function pathWithoutGjs() {

--- a/tests/e2e/homepage-run-variations/run.mjs
+++ b/tests/e2e/homepage-run-variations/run.mjs
@@ -38,9 +38,10 @@ import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const LIB_ENTRY = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
-const GJS_BUNDLE = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
+const LIB_ENTRY = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
+const GJS_BUNDLE = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
 
 // How each host launches the local CLI entry (+ the substring its banner
 // reports so we can prove the CLI booted under THAT runtime). node is the host

--- a/tests/e2e/install-concurrent/run.mjs
+++ b/tests/e2e/install-concurrent/run.mjs
@@ -36,6 +36,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0, same pattern as install-workspace-source-safety) -----
 const BLOCK = 512;
@@ -220,7 +221,7 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
         server = makeRegistry();
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         fixtureRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-concurrent-'));
         const sharedXdgCache = join(fixtureRoot, 'xdg-cache');

--- a/tests/e2e/install-conflict-warning/run.mjs
+++ b/tests/e2e/install-conflict-warning/run.mjs
@@ -27,6 +27,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0, same pattern as install-version-conflict) -----
 const BLOCK = 512;
@@ -177,7 +178,7 @@ describe('gjsify install — version-conflict warning (ADR 0001 step 3)', { time
         server = makeRegistry();
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-conflict-warn-'));
         const homeDir = join(root, 'home');

--- a/tests/e2e/install-extract-stall/run.mjs
+++ b/tests/e2e/install-extract-stall/run.mjs
@@ -24,6 +24,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // Minimal ustar tar archive containing a single `package/package.json`.
 function buildPackageTar(pkgJson) {
@@ -128,7 +129,7 @@ describe('gjsify install — per-extract stall guard', { timeout: 60_000 }, () =
         });
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
     });
 
     after(() => {

--- a/tests/e2e/install-immutable/run.mjs
+++ b/tests/e2e/install-immutable/run.mjs
@@ -24,6 +24,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0 with a single package.json entry) -----
 const BLOCK = 512;
@@ -161,7 +162,7 @@ describe('gjsify install --immutable (Phase D.6)', { timeout: 90_000 }, () => {
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/install-incremental-extract/run.mjs
+++ b/tests/e2e/install-incremental-extract/run.mjs
@@ -31,6 +31,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0, a single package.json entry) -----
 const BLOCK = 512;
@@ -170,7 +171,7 @@ describe('gjsify install — incremental extraction (skip already-extracted)', {
         // Per-run cache root so a developer's warm ~/.cache doesn't change the
         // network behaviour, and so the suite stays parallel-safe.
         cacheDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-incremental-cache-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/install-lock-preserve/run.mjs
+++ b/tests/e2e/install-lock-preserve/run.mjs
@@ -26,6 +26,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0) -----
 const BLOCK = 512;
@@ -167,7 +168,7 @@ describe('gjsify install — lockfile preservation', { timeout: 90_000 }, () => 
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-preserve-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = { ...process.env, GJSIFY_INSTALL_BACKEND: 'native', npm_config_registry: registryUrl };
 
         writeFileSync(

--- a/tests/e2e/install-non-destructive/run.mjs
+++ b/tests/e2e/install-non-destructive/run.mjs
@@ -32,6 +32,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn, execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const BLOCK = 512;
 
@@ -223,7 +224,7 @@ describe('gjsify install — non-destructive (ADR 0001)', { timeout: 120_000 }, 
         server = makeRegistry();
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
     });
 
     after(() => {

--- a/tests/e2e/install-platform-filter/run.mjs
+++ b/tests/e2e/install-platform-filter/run.mjs
@@ -38,6 +38,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0) — same shape as install-lock-preserve/run.mjs ---
 const BLOCK = 512;
@@ -224,7 +225,7 @@ describe('gjsify install — os/cpu/libc filtering', { timeout: 180_000 }, () =>
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-platform-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         baseEnv = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -20,6 +20,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0 with a package.json + bundle file) -----
 const BLOCK = 512;
@@ -90,8 +91,8 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
     let server, registryUrl, tmpRoot;
     // Path to the freshly-built gjs bundle we ship as the "bootstrap" asset.
     // In production this would be the GitHub-release-download URL.
-    const cliBundlePath = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
-    const installerPath = new URL('../../../install.mjs', import.meta.url).pathname;
+    const cliBundlePath = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
+    const installerPath = fileURLToPath(new URL('../../../install.mjs', import.meta.url));
 
     const cliBundleBytes = existsSync(cliBundlePath) ? readFileSync(cliBundlePath) : null;
     const cliBundleSha256 = cliBundleBytes ? sha256Hex(cliBundleBytes) : null;

--- a/tests/e2e/install-timeout/run.mjs
+++ b/tests/e2e/install-timeout/run.mjs
@@ -20,6 +20,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 function runCli(cliEntry, args, { cwd, env, timeoutMs = 30_000 } = {}) {
     return new Promise((resolve, reject) => {
@@ -75,7 +76,7 @@ describe('gjsify install --timeout — slow-registry safety net', { timeout: 60_
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/install-version-conflict/run.mjs
+++ b/tests/e2e/install-version-conflict/run.mjs
@@ -28,6 +28,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0 with arbitrary file entries) -----
 const BLOCK = 512;
@@ -240,7 +241,7 @@ describe('gjsify install — nested-node_modules version conflict (Phase D.7b)',
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-conflict-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/install-version-skew/run.mjs
+++ b/tests/e2e/install-version-skew/run.mjs
@@ -15,6 +15,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 function runCli(cliEntry, args, { cwd, env, timeoutMs = 30_000 } = {}) {
     return new Promise((resolve, reject) => {
@@ -60,7 +61,7 @@ describe('gjsify install — CLI/workspace version-skew warning', { timeout: 60_
     let cliEntry, runningVersion;
 
     before(() => {
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         runningVersion = JSON.parse(
             readFileSync(new URL('../../../packages/infra/cli/package.json', import.meta.url), 'utf-8'),
         ).version;

--- a/tests/e2e/install-workspace-source-safety/run.mjs
+++ b/tests/e2e/install-workspace-source-safety/run.mjs
@@ -51,6 +51,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const BLOCK = 512;
 
@@ -302,7 +303,7 @@ describe('gjsify install — never fetch/extract over workspace sources', { time
         server = makeRegistry();
         await new Promise((r) => server.listen(0, '127.0.0.1', r));
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         // Fixture-local caches: the `fetch: @fixture/app` assertions below
         // require the tarball to actually come off the network — a shared
         // user-level XDG cache from a previous local run turns the fetch into

--- a/tests/e2e/native-install-project/run.mjs
+++ b/tests/e2e/native-install-project/run.mjs
@@ -16,6 +16,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // ----- tar helpers (ustar v0 with a single package.json entry) -----
 const BLOCK = 512;
@@ -160,7 +161,7 @@ describe('gjsify install <pkg> — project-local native (Phase D.1)', { timeout:
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-install-project-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             // Native backend is the default; force it here to make the test

--- a/tests/e2e/native-install/run.mjs
+++ b/tests/e2e/native-install/run.mjs
@@ -15,6 +15,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // Build a minimal ustar tar archive in memory containing a single
 // `package/package.json` whose contents are `pkgJson` (object).
@@ -225,8 +226,8 @@ describe('native install backend (in-process registry)', { timeout: 60_000 }, ()
         // Drop the harness inside the workspace root so the spawned `node`
         // resolves workspace packages via the gjsify-installed node_modules tree
         // (Phase D.7d dropped yarn from CI; we no longer have PnP available).
-        const harnessFile = new URL('./harness.tmp.mjs', import.meta.url).pathname;
-        const workspaceRoot = new URL('../../../', import.meta.url).pathname;
+        const harnessFile = fileURLToPath(new URL('./harness.tmp.mjs', import.meta.url));
+        const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url));
         writeFileSync(harnessFile, harness);
         try {
             const out = await runHarness('node', ['--no-warnings', harnessFile], workspaceRoot);
@@ -289,8 +290,8 @@ describe('native install backend (in-process registry)', { timeout: 60_000 }, ()
       });
       console.log('OK');
     `;
-        const harnessFile = new URL('./harness-conflict.tmp.mjs', import.meta.url).pathname;
-        const workspaceRoot = new URL('../../../', import.meta.url).pathname;
+        const harnessFile = fileURLToPath(new URL('./harness-conflict.tmp.mjs', import.meta.url));
+        const workspaceRoot = fileURLToPath(new URL('../../../', import.meta.url));
         writeFileSync(harnessFile, harness);
         try {
             const out = await runHarness('node', ['--no-warnings', harnessFile], workspaceRoot);

--- a/tests/e2e/pack-gitignored-files/run.mjs
+++ b/tests/e2e/pack-gitignored-files/run.mjs
@@ -69,7 +69,7 @@ describe('gjsify pack — files allowlist overrides .gitignore', () => {
         const tgz = readdirSync(dir).find((f) => f.endsWith('.tgz'));
         assert.ok(tgz, 'pack produced a .tgz');
         const entries = execFileSync('tar', ['tzf', join(dir, tgz)], { encoding: 'utf-8' })
-            .split('\n')
+            .split(/\r?\n/)
             .filter(Boolean)
             .map((e) => e.replace(/^package\//, ''));
 

--- a/tests/e2e/pack-lifecycle-scripts/run.mjs
+++ b/tests/e2e/pack-lifecycle-scripts/run.mjs
@@ -57,7 +57,7 @@ function listTarball(cwd, filename) {
     const stdout = execFileSync('tar', ['-tzf', join(cwd, filename)], {
         encoding: 'utf8',
     });
-    return stdout.split('\n').filter(Boolean);
+    return stdout.split(/\r?\n/).filter(Boolean);
 }
 
 describe('gjsify pack — lifecycle scripts', () => {

--- a/tests/e2e/pack.mjs
+++ b/tests/e2e/pack.mjs
@@ -13,6 +13,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, readdirSync, existsSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveGjsifySpawn } from '../../scripts/resolve-gjsify.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MONOREPO_ROOT = resolve(__dirname, '..', '..');
@@ -107,11 +108,23 @@ for (const w of selected) {
     // `gjsify-buffer-0.4.0.tgz`) into the cwd by default. `--pack-destination`
     // redirects it to <tarballsDir> directly. Match the same --json shape as
     // npm pack: an array of {filename, …} entries.
-    const stdout = execFileSync('gjsify', ['pack', '--pack-destination', resolve(tarballsDir), '--json'], {
+    //
+    // Resolved rather than spawned by bare name. On Windows `gjsify` on PATH is
+    // a `.cmd` shim and `CreateProcess` appends only `.exe` when it searches for
+    // a bare name, so this was `spawnSync gjsify ENOENT` — in the ONE helper
+    // that `createTestEnvironment` / `packWorkspaces` funnel through. 34 e2e
+    // suites died here, before reaching their first assertion.
+    const spec = resolveGjsifySpawn(MONOREPO_ROOT, ['pack', '--pack-destination', resolve(tarballsDir), '--json']);
+    if (!spec) {
+        console.error('pack.mjs: no gjsify CLI found (node_modules/.bin, PATH, or the committed bundle).');
+        process.exit(1);
+    }
+    const stdout = execFileSync(spec.cmd, spec.args, {
         cwd: join(MONOREPO_ROOT, w.location),
         stdio: ['pipe', 'pipe', 'inherit'],
         encoding: 'utf8',
         maxBuffer: 50 * 1024 * 1024,
+        windowsVerbatimArguments: spec.windowsVerbatimArguments,
     });
     const result = JSON.parse(stdout);
     const filename = result[0]?.filename;

--- a/tests/e2e/publish-files-glob/run.mjs
+++ b/tests/e2e/publish-files-glob/run.mjs
@@ -68,7 +68,7 @@ describe('gjsify pack — files glob expansion', () => {
         const tgz = readdirSync(dir).find((f) => f.endsWith('.tgz'));
         assert.ok(tgz, 'pack produced a .tgz');
         const entries = execFileSync('tar', ['tzf', join(dir, tgz)], { encoding: 'utf-8' })
-            .split('\n')
+            .split(/\r?\n/)
             .filter(Boolean)
             .map((e) => e.replace(/^package\//, ''));
 

--- a/tests/e2e/publish-types-shipped/run.mjs
+++ b/tests/e2e/publish-types-shipped/run.mjs
@@ -40,7 +40,7 @@ function tarEntries(dir) {
     const tgz = readdirSync(dir).find((f) => f.endsWith('.tgz'));
     assert.ok(tgz, `pack produced a .tgz in ${dir}`);
     return execFileSync('tar', ['tzf', join(dir, tgz)], { encoding: 'utf-8' })
-        .split('\n')
+        .split(/\r?\n/)
         .filter(Boolean)
         .map((e) => e.replace(/^package\//, ''));
 }

--- a/tests/e2e/run-command/run.mjs
+++ b/tests/e2e/run-command/run.mjs
@@ -16,6 +16,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, chmodSync 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 // The GJS-only in-process fast path in `run.ts` only activates under `gjs`,
 // not Node — so the double-execution regression can only be exercised by
@@ -91,7 +92,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
 
     before(() => {
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-run-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         // Build a tiny monorepo so we can test:
         //   - script lookup in a workspace package
@@ -238,7 +239,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
         'does not double-execute an in-process gjsify subcommand script (GJS)',
         { skip: hasGjs() ? false : 'gjs not on PATH' },
         async () => {
-            const bundle = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
+            const bundle = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
             const pkgPath = join(wsDir, 'package.json');
             const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
             // `gjsify --version` is a single gjsify subcommand → in-process path.
@@ -269,7 +270,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
         'propagates a non-zero gjs bundle exit through an in-process run script (GJS)',
         { skip: hasGjs() ? false : 'gjs not on PATH' },
         async () => {
-            const bundle = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
+            const bundle = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
             writeFileSync(join(wsDir, 'fail-bundle.js'), 'imports.system.exit(3);\n');
             const pkgPath = join(wsDir, 'package.json');
             const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
@@ -301,7 +302,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
         'propagates a THROWING in-process gjsify subcommand through run (GJS)',
         { skip: hasGjs() ? false : 'gjs not on PATH' },
         async () => {
-            const bundle = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
+            const bundle = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
             const pkgPath = join(wsDir, 'package.json');
             const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
             // Single `gjsify <subcommand>` → in-process fast path.
@@ -345,7 +346,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
         'exits cleanly (no core dump) when the script is missing (GJS)',
         { skip: hasGjs() ? false : 'gjs not on PATH' },
         async () => {
-            const bundle = new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url).pathname;
+            const bundle = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
             const r = await runGjs(bundle, ['run', 'no-such-script-xyz'], { cwd: wsDir });
             assert.equal(
                 r.status,

--- a/tests/e2e/showcase-runtime/run.mjs
+++ b/tests/e2e/showcase-runtime/run.mjs
@@ -18,8 +18,9 @@ import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+const cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
 function onPath(cmd) {
     try {

--- a/tests/e2e/uninstall-global/run.mjs
+++ b/tests/e2e/uninstall-global/run.mjs
@@ -18,6 +18,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const BLOCK = 512;
 function tarHeader(name, size, type = '0') {
@@ -163,7 +164,7 @@ describe('Phase F.8 — gjsify uninstall -g', { timeout: 60_000 }, () => {
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-uninstall-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_GLOBAL_PREFIX: join(tmpRoot, 'global'),

--- a/tests/e2e/workspace-install/run.mjs
+++ b/tests/e2e/workspace-install/run.mjs
@@ -27,6 +27,7 @@ import { createServer } from 'node:http';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 const BLOCK = 512;
 
@@ -170,7 +171,7 @@ describe('gjsify install — workspace-aware (Phase D.3)', { timeout: 60_000 }, 
         registryUrl = `http://127.0.0.1:${server.address().port}/`;
 
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-ws-install-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',

--- a/tests/e2e/workspace-with-dependencies/run.mjs
+++ b/tests/e2e/workspace-with-dependencies/run.mjs
@@ -27,6 +27,7 @@ import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, statSync } f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 function runCli(cliEntry, args, { cwd, env, timeoutMs = 30_000 } = {}) {
     return new Promise((resolve, reject) => {
@@ -66,7 +67,7 @@ describe('gjsify workspace <name> <script> --with-dependencies', { timeout: 120_
 
     before(() => {
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-wsd-'));
-        cliEntry = new URL('../../../packages/infra/cli/lib/index.js', import.meta.url).pathname;
+        cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         writeFileSync(
             join(root, 'package.json'),

--- a/tests/integration/mcp-inspector-cli/src/helpers.ts
+++ b/tests/integration/mcp-inspector-cli/src/helpers.ts
@@ -62,7 +62,8 @@ export async function startServer(
     // LD_LIBRARY_PATH / GI_TYPELIB_PATH get auto-injected from every
     // workspace `@gjsify/*` package's `gjsify.prebuilds` field. Without
     // this the example fails to load the @gjsify/http-soup-bridge typelib.
-    const cmd = target === 'gjs' ? new URL('../../../../node_modules/.bin/gjsify', import.meta.url).pathname : 'node';
+    const cmd =
+        target === 'gjs' ? fileURLToPath(new URL('../../../../node_modules/.bin/gjsify', import.meta.url)) : 'node';
     const args = target === 'gjs' ? ['run', bundle] : [bundle];
 
     const proc = spawn(cmd, args, {


### PR DESCRIPTION
test(e2e): let the harness run on Windows

Three harness defects, none of them in anything under test, between them
gating most of the e2e suite on Windows. Measured before: of 86
Node-only suites, 61 were runnable enough to try and 38 failed — 34 of
them before their first assertion.

1. `pack.mjs` spawned `gjsify` by BARE NAME. On Windows that is a `.cmd`
   shim and `CreateProcess` appends only `.exe`, so it was `spawnSync
   gjsify ENOENT` — inside the one helper `createTestEnvironment` and
   `packWorkspaces` funnel through. 34 suites died there. Routed through
   the resolver added for the same defect in `scripts/`.

2. `new URL(rel, import.meta.url).pathname` in 37 places. `.pathname` is
   the URL path, not a filesystem path: on Windows it is `/C:/src/…`,
   with a leading slash before the drive letter, which `spawn` then
   resolves against the cwd's drive as `C:\C:\src\…` →
   `Cannot find module`. 24 suites failed on exactly this signature.
   `fileURLToPath()` is the answer the URL API already provides.

3. `.split('\n')` on `tar tzf` output in the four suites that read a
   tarball listing. Windows' bundled bsdtar terminates lines with CRLF,
   so every entry kept a trailing `\r` and no `includes()` could match.
   That also made the NEGATIVE assertions pass VACUOUSLY — nothing can
   equal a name with `\r` glued on, so "excludes X" was true for every X,
   on every platform's reading of that output.

Verified on win32 through cmd.exe with the POSIX-tool directories
stripped from PATH: pack-gitignored-files, publish-files-glob,
pack-lifecycle-scripts, publish-types-shipped, showcase-runtime,
gjs-less-host, deterministic-library-build, install-timeout,
uninstall-global and homepage-run-variations all exit 0 — every one of
them red before. run-command, foreach-command and
workspace-with-dependencies now REACH their assertions and fail there on
residual, unrelated causes; those are follow-ups, not regressions.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
