### PR TITLE
fix(webrtc): tell missing from not-packaged for webrtcbin

### DIFF
--- a/packages/web/webrtc/src/gst-init.ts
+++ b/packages/web/webrtc/src/gst-init.ts
@@ -22,10 +22,27 @@ export function ensureWebrtcbinAvailable(): void {
     ensureGstInit();
     const webrtcFactory = Gst.ElementFactory.find('webrtcbin');
     if (!webrtcFactory) {
+        // Distinguish "gst-plugins-bad is not installed" from "it is installed
+        // but this distro does not build its webrtc plugin" — the advice differs
+        // and only one of them is actionable. `dtlsenc`/`sctpenc` are siblings
+        // from the SAME source package, so their presence settles it without
+        // guessing at file paths. Measured on postmarketOS v26.06 / Alpine v3.24
+        // aarch64: gst-plugins-bad 1.28.3 installed, libgstdtls/sctp/srtp all
+        // present, `libgstwebrtc.so` absent from the package (it is still there
+        // in Alpine v3.23) — and the old message told the user to install a
+        // package they already had.
+        const badInstalled = Gst.ElementFactory.find('dtlsenc') !== null || Gst.ElementFactory.find('sctpenc') !== null;
         throwNotSupported(
-            'GStreamer element "webrtcbin" not available. Install gst-plugins-bad:\n' +
-                '  Fedora:        dnf install gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-extras\n' +
-                '  Ubuntu/Debian: apt install gstreamer1.0-plugins-bad',
+            badInstalled
+                ? 'GStreamer element "webrtcbin" not available, but gst-plugins-bad IS installed\n' +
+                      '(its dtls/sctp elements are registered). This distro does not ship the\n' +
+                      'plugin — verify with: ls /usr/lib/gstreamer-1.0/libgstwebrtc.so\n' +
+                      '  Alpine/postmarketOS: absent since Alpine v3.24; no package provides it.\n' +
+                      '  Otherwise: install the plugin from source, or use a distro that ships it.'
+                : 'GStreamer element "webrtcbin" not available. Install gst-plugins-bad:\n' +
+                      '  Fedora:              dnf install gstreamer1-plugins-bad-free gstreamer1-plugins-bad-free-extras\n' +
+                      '  Ubuntu/Debian:       apt install gstreamer1.0-plugins-bad\n' +
+                      '  Alpine/postmarketOS: apk add gst-plugins-bad',
         );
     }
     // webrtcbin requires libnice's GStreamer plugin for ICE transport —


### PR DESCRIPTION
## What

The `webrtcbin` unavailability error told every host to install `gst-plugins-bad`. On the OnePlus test device — postmarketOS v26.06 / Alpine v3.24, aarch64 — that package **is** installed (1.28.3, with `libgstdtls.so`, `libgstsctp.so` and `libgstsrtp.so` all present) and simply does not contain `libgstwebrtc.so`. Alpine v3.23 still shipped it; v3.24 does not, on either aarch64 or x86_64, and no other package provides it.

So the advice was "install a package you already have", it succeeded, and nothing changed — the next run printed the same line.

## The fix

Probe a sibling element from the same source package (`dtlsenc` / `sctpenc`) before choosing the message. Their presence settles "is gst-plugins-bad installed" without guessing at file paths:

* **not installed** → the install commands, now with `apk add gst-plugins-bad` alongside Fedora and Debian.
* **installed** → say so, name the file to check (`ls /usr/lib/gstreamer-1.0/libgstwebrtc.so`), and state plainly that this distro does not ship the plugin.

## Verification

On the device, the second branch is what it prints:

```
[ERROR] GStreamer element "webrtcbin" not available, but gst-plugins-bad IS installed
(its dtls/sctp elements are registered). This distro does not ship the
plugin — verify with: ls /usr/lib/gstreamer-1.0/libgstwebrtc.so
  Alpine/postmarketOS: absent since Alpine v3.24; no package provides it.
  Otherwise: install the plugin from source, or use a distro that ships it.
```

The `webrtc-loopback` showcase remains unrunnable there — that is a distro gap, not a gjsify one, and the message now says which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)