### PR TITLE
fix: close three silent bootstrap-chain holes

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -26,8 +26,11 @@
  * Test hooks (set by tests/e2e/install-script/run.mjs):
  *   GJSIFY_INSTALL_BOOTSTRAP_URL  override the cli.gjs.mjs download origin
  *                                 (accepts file:// for offline tests)
- *   GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL  override the .sha256 companion URL
- *                                 (set to empty string to skip SHA-256)
+ *   GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL  override the .sha256 companion URL.
+ *                                 An EMPTY string is the only way to install
+ *                                 without verification, and it warns loudly; a
+ *                                 digest URL that is set but unreachable is a
+ *                                 hard failure, never a silent downgrade.
  *   GJSIFY_GLOBAL_PREFIX          override install prefix (forwarded to cli)
  *   GJSIFY_GLOBAL_BIN_DIR         override bin dir (forwarded to cli)
  *   GJSIFY_INSTALL_REGISTRY       override npm registry (forwarded as npm_config_registry)
@@ -49,6 +52,11 @@ const DEFAULT_BOOTSTRAP_URL = 'https://github.com/gjsify/gjsify/releases/latest/
 const DEFAULT_BOOTSTRAP_SHA256_URL = `${DEFAULT_BOOTSTRAP_URL}.sha256`;
 
 const USER_AGENT = 'gjsify-installer/1.0';
+
+// The bootstrap cache is CONTENT-ADDRESSED: `cli-<sha256>.gjs.mjs`. See
+// `resolveBootstrap()` for why the digest, not a fixed name, keys it.
+const CACHE_PREFIX = 'cli-';
+const CACHE_SUFFIX = '.gjs.mjs';
 
 function info(msg) {
     print(`[gjsify] ${msg}`);
@@ -168,35 +176,120 @@ function writeBytes(path, bytes) {
     Gio.File.new_for_path(path).replace_contents(bytes, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
 }
 
-async function downloadBootstrap(session, bootstrapUrl, sha256Url) {
-    info(`Downloading bootstrap from ${bootstrapUrl} ...`);
-    const bundleBytes = await fetchBytes(session, bootstrapUrl);
-    if (sha256Url && sha256Url !== '') {
-        info('Verifying SHA-256 ...');
-        let sumExpected;
+function readBytesOrNull(path) {
+    try {
+        const [, bytes] = Gio.File.new_for_path(path).load_contents(null);
+        return bytes;
+    } catch {
+        // An absent — or unreadable, e.g. truncated by a killed earlier run —
+        // cache entry is a MISS, not an error. `load_contents` is a real
+        // `throws="1"` GIR call, so this catch has a genuine throw path.
+        return null;
+    }
+}
+
+/**
+ * Drop every other cached bootstrap so the content-addressed cache stays
+ * bounded. Each entry is a ~6.6 MB bundle and the digest changes with every
+ * release — without this, keying the cache by content would trade "the cache
+ * can never be warm" for "the cache grows forever".
+ */
+function pruneCache(dir, keepBasename) {
+    const children = Gio.File.new_for_path(dir).enumerate_children(
+        'standard::name',
+        Gio.FileQueryInfoFlags.NONE,
+        null,
+    );
+    for (;;) {
+        const info_ = children.next_file(null);
+        if (info_ === null) break;
+        const name = info_.get_name();
+        if (name === keepBasename || !name.startsWith(CACHE_PREFIX) || !name.endsWith(CACHE_SUFFIX)) continue;
+        Gio.File.new_for_path(GLib.build_filenamev([dir, name])).delete(null);
+    }
+}
+
+/**
+ * Resolve a VERIFIED bootstrap bundle and return its path.
+ *
+ * The digest is fetched BEFORE the bundle, and the cache is keyed by it. That
+ * ordering is the mechanism, not an optimisation — it fixes two independent
+ * defects that both came from doing it the other way round:
+ *
+ *   1. Verification was skippable by anyone who could break ONE request. The
+ *      bundle was downloaded first and verified after, and a failed `.sha256`
+ *      fetch merely logged "skipping verification" and carried on — so a proxy,
+ *      a 404, or a captive portal silently downgraded the install to no
+ *      verification at all. Fetching the digest first makes that impossible:
+ *      no digest, no install.
+ *   2. The cache could never be warm. It wrote a fixed `cli.gjs.mjs` and never
+ *      read it back, so every run re-downloaded ~6.6 MB. A content-addressed
+ *      name lets a matching entry short-circuit the download entirely.
+ *
+ * Skipping verification is still possible, but only as an EXPLICIT act
+ * (`GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL=''`), and it says so on stderr.
+ */
+async function resolveBootstrap(session, bootstrapUrl, sha256Url) {
+    let expected = null;
+    if (sha256Url) {
+        info(`Fetching published SHA-256 from ${sha256Url} ...`);
+        let sumBytes;
         try {
-            const sumBytes = await fetchBytes(session, sha256Url);
-            sumExpected = new TextDecoder().decode(sumBytes).trim().split(/\s+/)[0];
+            sumBytes = await fetchBytes(session, sha256Url);
         } catch (err) {
-            error(`Could not fetch ${sha256Url} — skipping verification: ${err.message}`);
+            error(`Could not fetch ${sha256Url}: ${err.message}`);
+            error('Refusing to install an UNVERIFIED bootstrap bundle.');
+            error("To bootstrap without verification, set GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL='' explicitly.");
+            exit(1);
         }
-        if (sumExpected) {
-            const sumActual = sha256Hex(bundleBytes);
-            if (sumExpected.toLowerCase() !== sumActual.toLowerCase()) {
-                error(`SHA-256 mismatch: expected ${sumExpected}, got ${sumActual}`);
-                exit(1);
-            }
+        expected = (new TextDecoder().decode(sumBytes).trim().split(/\s+/)[0] ?? '').toLowerCase();
+        if (!/^[0-9a-f]{64}$/.test(expected)) {
+            error(`${sha256Url} did not contain a SHA-256 digest (read ${JSON.stringify(expected.slice(0, 80))}).`);
+            exit(1);
+        }
+    } else {
+        error("SHA-256 verification is DISABLED (GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL='') — the bundle is unverified.");
+    }
+
+    const dir = cacheDir();
+    const basename = expected ? `${CACHE_PREFIX}${expected}${CACHE_SUFFIX}` : `${CACHE_PREFIX}unverified${CACHE_SUFFIX}`;
+    const bundlePath = GLib.build_filenamev([dir, basename]);
+
+    if (expected) {
+        // Re-hash rather than trusting the filename: the name is only a CLAIM
+        // about the contents, and a truncated entry keeps its name.
+        const cached = readBytesOrNull(bundlePath);
+        if (cached && sha256Hex(cached).toLowerCase() === expected) {
+            info(`Reusing verified bootstrap ${bundlePath} (${cached.length} bytes)`);
+            return bundlePath;
         }
     }
-    const dir = cacheDir();
+
+    info(`Downloading bootstrap from ${bootstrapUrl} ...`);
+    const bundleBytes = await fetchBytes(session, bootstrapUrl);
+    if (expected) {
+        const actual = sha256Hex(bundleBytes).toLowerCase();
+        if (actual !== expected) {
+            error(`SHA-256 mismatch: expected ${expected}, got ${actual}`);
+            exit(1);
+        }
+        info('SHA-256 verified.');
+    }
+
     try {
         ensureDir(dir);
     } catch {
         /* exists */
     }
-    const bundlePath = GLib.build_filenamev([dir, 'cli.gjs.mjs']);
     writeBytes(bundlePath, bundleBytes);
     info(`Bootstrap cached at ${bundlePath} (${bundleBytes.length} bytes)`);
+    try {
+        pruneCache(dir, basename);
+    } catch (err) {
+        // Housekeeping only: a read-only or concurrently-modified cache dir
+        // must never fail an install.
+        info(`Could not prune the bootstrap cache: ${err.message}`);
+    }
     return bundlePath;
 }
 
@@ -232,7 +325,7 @@ async function main() {
     const session = new Soup.Session();
     let bundlePath;
     try {
-        bundlePath = await downloadBootstrap(session, opts.bootstrapUrl, opts.bootstrapSha256Url);
+        bundlePath = await resolveBootstrap(session, opts.bootstrapUrl, opts.bootstrapSha256Url);
     } catch (err) {
         error(`Bootstrap download failed: ${err.message}`);
         exit(1);

--- a/scripts/install-git-hooks.mjs
+++ b/scripts/install-git-hooks.mjs
@@ -102,13 +102,22 @@ if (!existsSync(PRE_COMMIT_PATH)) {
     process.exit(1);
 }
 
+// Apply each config key on its own and KEEP GOING.
+//
+// This used to `process.exit(0)` right here when `core.hooksPath` already
+// matched, which made everything below unreachable on exactly the clones that
+// need it most: an existing clone has the key set, so any git config the
+// project adds after this point would only ever land on FRESH clones, and the
+// difference is invisible — the script prints "nothing to do" and exits 0 in
+// both cases. Idempotency is a property of each individual write, not a licence
+// to abandon the rest of the script.
 const current = gitConfig(['--get', 'core.hooksPath']);
 if (current === HOOKS_DIR_RELATIVE) {
-    log(`core.hooksPath already set to ${HOOKS_DIR_RELATIVE} — nothing to do.`);
-    process.exit(0);
+    log(`core.hooksPath already set to ${HOOKS_DIR_RELATIVE}.`);
+} else {
+    execFileSync('git', ['config', 'core.hooksPath', HOOKS_DIR_RELATIVE], { cwd: ROOT });
+    log(`core.hooksPath = ${HOOKS_DIR_RELATIVE} (was ${current ?? 'unset / .git/hooks'})`);
 }
 
-execFileSync('git', ['config', 'core.hooksPath', HOOKS_DIR_RELATIVE], { cwd: ROOT });
-log(`core.hooksPath = ${HOOKS_DIR_RELATIVE} (was ${current ?? 'unset / .git/hooks'})`);
 log(`active hooks: pre-commit`);
 log(`bypass with: 'git commit --no-verify' or SKIP_GJSIFY_HOOKS=1`);

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -13,7 +13,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
@@ -249,8 +249,14 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
     it('downloads bootstrap bundle and runs it (default target = @gjsify/cli)', async () => {
         const r = await runBootstrap(['--tag', '0.0.99-test']);
         assert.equal(r.status, 0, `bootstrap failed:\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
-        // Bundle cached in our override path.
-        assert.ok(existsSync(join(r.cache, 'cli.gjs.mjs')), 'bundle not cached');
+        // Bundle cached in our override path, under its CONTENT-ADDRESSED name.
+        // The digest in the filename is what makes the cache reachable at all —
+        // the old fixed `cli.gjs.mjs` was written and never read back, so every
+        // run re-downloaded the bundle (see `resolveBootstrap` in install.mjs).
+        assert.ok(
+            existsSync(join(r.cache, `cli-${cliBundleSha256}.gjs.mjs`)),
+            `bundle not cached under its digest; cache holds: ${readdirSync(r.cache).join(', ')}`,
+        );
         // Package laid out at user prefix.
         assert.ok(
             existsSync(join(r.prefix, 'node_modules', '@gjsify', 'cli', 'package.json')),
@@ -268,5 +274,43 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
         });
         assert.notEqual(r.status, 0, `expected SHA-256 mismatch failure, got status=${r.status}`);
         assert.match(r.stderr + r.stdout, /SHA-256 mismatch/, 'expected error message about SHA-256 mismatch');
+    });
+
+    it('refuses to install when the digest URL is unreachable (no silent downgrade)', async () => {
+        // The hole this closes: a failed `.sha256` fetch used to log
+        // "skipping verification" and CARRY ON, so anyone able to break that one
+        // request — a proxy, a 404, a captive portal — silently downgraded the
+        // install to no verification at all, while the bundle fetch itself
+        // succeeded. Opting out must be an explicit act, never a fetch failure.
+        const r = await runBootstrap([], {
+            GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `file://${join(tmpRoot, 'does-not-exist.sha256')}`,
+        });
+        assert.notEqual(r.status, 0, `expected a hard failure, got status=${r.status}`);
+        assert.match(
+            r.stderr + r.stdout,
+            /Refusing to install an UNVERIFIED bootstrap bundle/,
+            'expected a refusal naming the unverified bundle',
+        );
+    });
+
+    it('reuses the cached bundle on a second run instead of re-downloading', async () => {
+        // `runBootstrap` points every invocation at the same cache dir, so the
+        // first run populates it and the second must short-circuit. Guards the
+        // property the old fixed-name cache could never have: being warm.
+        //
+        // Deliberately asserts ONLY on the bootstrap stage's own output and does
+        // not require the spawned `install -g` to succeed. Caching is decided
+        // before the CLI is ever spawned, so coupling this to the mock-registry
+        // half would make it fail for reasons that have nothing to do with the
+        // cache — which is exactly what the sibling test above does today.
+        // Its OWN cache dir: the sibling tests share `runBootstrap`'s default
+        // one and have already populated it, so a shared dir would make this
+        // test's "first" run warm and assert nothing.
+        const env = { GJSIFY_INSTALL_BOOTSTRAP_CACHE: join(tmpRoot, 'cache-warm') };
+        const first = await runBootstrap(['--tag', '0.0.99-test'], env);
+        assert.match(first.stdout, /Downloading bootstrap from/, 'first run did not download');
+        const second = await runBootstrap(['--tag', '0.0.99-test'], env);
+        assert.match(second.stdout, /Reusing verified bootstrap/, 'second run did not hit the cache');
+        assert.doesNotMatch(second.stdout, /Downloading bootstrap from/, 'second run re-downloaded the bundle');
     });
 });

--- a/tests/e2e/self-host/run.mjs
+++ b/tests/e2e/self-host/run.mjs
@@ -14,7 +14,7 @@
 //      green (exits 0, last line includes `52 completed`).
 //
 // Notes:
-//   - We invoke the GJS-CLI directly via `gjs -m dist/cli.gjs.mjs ...`
+//   - We invoke the GJS-CLI directly via `gjs -m dist/cli.selfhost.gjs.mjs ...`
 //     rather than going through `gjsify run` because we want the
 //     environment under test to mirror what `gjsify dlx` etc. will
 //     eventually need (no Node-side helper).
@@ -27,7 +27,7 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -36,11 +36,49 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // tests/e2e/self-host/run.mjs → ../../..
 const MONOREPO_ROOT = resolvePath(__dirname, '..', '..', '..');
 const NODE_CLI = join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'lib', 'index.js');
-const GJS_CLI_BUNDLE = join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'dist', 'cli.gjs.mjs');
+const CLI_PKG_JSON = join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'package.json');
+const CLI_VERSION = JSON.parse(readFileSync(CLI_PKG_JSON, 'utf-8')).version;
 const FIXTURES_DIR = join(__dirname, 'fixtures');
 const SIMPLE_FIXTURE = join(FIXTURES_DIR, 'simple', 'main.mjs');
 const YARGS_FIXTURE = join(MONOREPO_ROOT, 'tests', 'integration', 'yargs', 'src', 'test.mts');
 const OUT_DIR = join(__dirname, 'out');
+// The GJS-CLI under test — a SIBLING of the tracked bundle, never the tracked
+// bundle itself. Untracked: `.gitignore` re-includes exactly `cli.gjs.mjs` and
+// `affected.gjs.mjs` out of the ignored `dist/`, so any other name here is
+// ignored by construction.
+//
+// This used to BE `dist/cli.gjs.mjs`, which made running this suite a
+// destructive act on the working tree: the `before()` build passes no
+// `--shebang`, and that flag is what "prepend a shebang and mark it executable
+// (chmod 755)" means (`commands/build.ts`), so each run replaced a `100755`
+// blob starting `#!/usr/bin/env -S gjs -m` with a shebang-less one and never
+// restored it. Nothing here reverted it and nothing downstream noticed:
+// `.bin/gjsify` and the flatpak launcher both `exec gjs -m <path>`, so the
+// missing `#!` only surfaces where the file is exec'd DIRECTLY — which falls
+// through to `/bin/sh` (the hazard `utils/bin-shim.ts` documents at
+// `writeBinEntry`).
+//
+// It has to stay EXACTLY ONE DIRECTORY BELOW `packages/infra/cli/` rather than
+// moving to OUT_DIR, and that is not cosmetic: `--version` is answered by
+// `readBundleVersion()` (cli-app.ts), which reads `<bundle dir>/../package.json`
+// and returns `'unknown'` from a swallowing catch when that read fails. So
+// `dist/<anything>.gjs.mjs` resolves `packages/infra/cli/package.json` while
+// OUT_DIR resolves the absent `tests/e2e/self-host/package.json`. Measured both
+// ways: the identical build reports `0.26.1` from `cli/dist/` and `unknown` from
+// anywhere else.
+//
+// NB it is neither the `__PACKAGE_VERSION__` define nor `resolveCliVersion()`
+// (utils/publish-headers.ts) that answers `--version` — that pair drives the npm
+// user-agent / publish headers, and it DOES honour the define (verified: a
+// `--define` build folds `typeof __PACKAGE_VERSION__` away and inlines the
+// value). `readBundleVersion()` has never consulted either, which is also why it
+// is the fragile twin of `readOwnCliVersion()` in utils/build-cache.ts — that one
+// walks up to four levels and checks `pkg.name === '@gjsify/cli'`, and its own
+// comment says it "mirrors cli-app's readBundleVersion but tolerates both
+// directory depths". Making `--version` use the robust one would remove this
+// positional coupling altogether; it touches `cli/src` (and so the committed
+// bundle), so it is not part of this change.
+const GJS_CLI_BUNDLE = join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'dist', 'cli.selfhost.gjs.mjs');
 
 function collectPrebuildDirs() {
     // The bundled GJS-CLI uses `@gjsify/rolldown-native` at runtime; its
@@ -91,10 +129,12 @@ function gjs(args, opts = {}) {
 
 describe('CLI self-host loop', { timeout: 5 * 60 * 1000 }, () => {
     before(() => {
-        // Step 1 — bootstrap: Node-CLI builds the GJS-CLI bundle.
-        // This step is intentionally Node-side; once the bundle exists
-        // every subsequent step runs only via gjs(1).
+        // Step 1 — bootstrap: Node-CLI builds the GJS-CLI bundle to the
+        // untracked sibling path (never over the tracked `dist/cli.gjs.mjs` —
+        // see GJS_CLI_BUNDLE). This step is intentionally Node-side; once the
+        // bundle exists every subsequent step runs only via gjs(1).
         rmSync(OUT_DIR, { recursive: true, force: true });
+        rmSync(GJS_CLI_BUNDLE, { force: true });
         mkdirSync(OUT_DIR, { recursive: true });
         execFileSync(
             'node',
@@ -109,13 +149,18 @@ describe('CLI self-host loop', { timeout: 5 * 60 * 1000 }, () => {
             ],
             { cwd: MONOREPO_ROOT, stdio: 'pipe' },
         );
-        assert.ok(existsSync(GJS_CLI_BUNDLE), 'Node-CLI did not produce dist/cli.gjs.mjs');
+        assert.ok(existsSync(GJS_CLI_BUNDLE), `Node-CLI did not produce ${GJS_CLI_BUNDLE}`);
     });
 
     it('GJS-CLI prints --version', () => {
         const r = gjs(['-m', GJS_CLI_BUNDLE, '--version']);
         assert.equal(r.status, 0, `--version exited ${r.status}: ${r.stderr}`);
-        assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+/, `unexpected version output: ${r.stdout}`);
+        // The EXACT version, not merely a version-shaped string. `--version` is
+        // answered by the position-dependent `readBundleVersion()` (see
+        // GJS_CLI_BUNDLE), whose failure mode is a swallowed catch returning
+        // `'unknown'` — so this is the assertion that fails loudly if the bundle
+        // is ever moved out of the package again.
+        assert.equal(r.stdout.trim(), CLI_VERSION, `unexpected version output: ${JSON.stringify(r.stdout)}`);
     });
 
     it('GJS-CLI prints --help with yargs subcommands registered', () => {
@@ -162,8 +207,8 @@ describe('CLI self-host loop', { timeout: 5 * 60 * 1000 }, () => {
     });
 
     it('GJS-CLI rebuilds ITSELF under gjs + native rolldown (Node-free self-host; bridge bugs A+B)', () => {
-        // The committed GJS-CLI rebuilds its OWN entry — the "previous gjsify
-        // builds next gjsify" milestone. This is the only build that hits BOTH
+        // The GJS-CLI rebuilds its OWN entry — the "previous gjsify builds next
+        // gjsify" milestone. This is the only build that hits BOTH
         // native-bridge edge cases that broke the self-build before:
         //   A) `transform` on rolldown's virtual `\0rolldown/empty.js` (the
         //      externalized typescript/lib stub, code "") — the C glue returned


### PR DESCRIPTION
Three independent defects in the Node-free bootstrap path, each of which fails by staying quiet. Groundwork for ADR 0002 (#945), but every fix stands on its own.

**Deliberately touches no source that the committed GJS bundles inline**, so no bundle is staled and no rebuild is needed. The two remaining preflight fixes (`bundler-pick.ts` candidate iteration, `bin-shim.ts` cold-tree existence check) do live under `packages/infra/cli/src/` and are held back for their own PR for exactly that reason.

### 1. `tests/e2e/self-host` overwrote a TRACKED artifact

Its `before()` hook built the CLI straight into `packages/infra/cli/dist/cli.gjs.mjs` and passed no `--shebang` — the flag that means *"prepend a shebang and mark it executable (chmod 755)"*. Every run replaced a `100755` blob starting `#!/usr/bin/env -S gjs -m` with a shebang-less one and never restored it. Nothing reverted it and nothing downstream noticed: `.bin/gjsify` and the flatpak launcher both `exec gjs -m <path>`, so a missing `#!` only bites where the file is exec'd **directly**, which falls through to `/bin/sh` (the hazard `utils/bin-shim.ts` documents at `writeBinEntry`).

Now builds to the untracked sibling `dist/cli.selfhost.gjs.mjs`.

It has to stay **exactly one directory below** `packages/infra/cli/` rather than moving to the suite's own `OUT_DIR`, and that is not cosmetic: `--version` is answered by `readBundleVersion()` (`cli-app.ts`), which reads `<bundle dir>/../package.json` and returns `'unknown'` from a swallowing catch when that read fails. `dist/<anything>.gjs.mjs` resolves `packages/infra/cli/package.json`; `OUT_DIR` resolves the absent `tests/e2e/self-host/package.json`. Measured both ways: the identical build reports `0.26.1` from `cli/dist/` and `unknown` from anywhere else. The `--version` assertion is tightened from "version-shaped" to the exact workspace version, so moving the bundle out of the package again fails loudly instead of silently falling back.

### 2. `install.mjs` downgraded itself to no verification on a fetch failure

It downloaded the bundle first and verified after, and a failed `.sha256` fetch only logged `skipping verification` and **carried on**. Anyone able to break that one request — a proxy, a 404, a captive portal — silently got an unverified bundle while the bundle fetch itself succeeded.

Fixed by **order, not by a policy check**: the digest is fetched first and the cache is keyed by it, so no code path can install without one. Opting out stays possible but must be explicit (`GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL=''`) and says so on stderr.

The same reordering fixes a second defect for free: the cache wrote a fixed `cli.gjs.mjs` and never read it back, so it could never be warm and every run re-downloaded ~6.6 MB. Content-addressed entries short-circuit the download; `pruneCache` keeps the directory bounded, because otherwise keying by content would trade *never warm* for *grows forever*. A cached entry is re-hashed rather than trusted by name — a truncated file keeps its name.

### 3. `scripts/install-git-hooks.mjs` made its own tail unreachable

It `process.exit(0)`'d as soon as `core.hooksPath` already matched, so any git config the project adds below that point would only ever land on **fresh** clones — invisibly, since the script prints "nothing to do" and exits 0 either way. Idempotency is a property of each individual write, not a licence to abandon the rest of the script.

## Verification

- `tests/e2e/self-host`: suite run locally — the tracked bundle's SHA-256 and `100755` mode are unchanged afterwards, and `git status` no longer lists it. `--version` from the new path measured as `0.26.1`.
- `tests/e2e/install-script`: two new cases green (unreachable digest URL is fatal; a second run reuses the cache without downloading). The pre-existing `downloads bootstrap bundle and runs it` case fails **identically on unmodified HEAD** on this machine — a local-environment artifact, not a regression: `~/.npmrc` sets a scoped `@gjsify:registry`, while the test only overrides the default `npm_config_registry`, so the mock registry is bypassed for exactly the scope under test. It passes in CI. Worth fixing separately by neutralising scoped registry config in that suite.

## Side finding, not fixed here

`readBundleVersion()` is the fragile twin of `readOwnCliVersion()` in `utils/build-cache.ts`, which walks up to four levels and checks `pkg.name === '@gjsify/cli'` — its own comment says it *"mirrors cli-app's readBundleVersion but tolerates both directory depths"*. The duplicated-and-drifted copy is the one on the user-facing `--version`, and its `catch` turns "I am not where I think I am" into a plausible-looking `unknown`. Pointing `--version` at the robust resolver would remove the positional coupling this PR has to work around; it touches `cli/src` (and therefore the committed bundle), so it belongs with the next preflight PR.

An earlier revision of this description claimed `--define __PACKAGE_VERSION__=…` does not reach `resolveCliVersion()`. That was wrong: it does — a `--define` build folds `typeof __PACKAGE_VERSION__` away and inlines the value. `--version` simply never consulted that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

