### PR TITLE
fix(child_process): take TMP_DIR from os.tmpdir()

### DIFF
--- a/packages/node/child_process/src/index.spec.ts
+++ b/packages/node/child_process/src/index.spec.ts
@@ -2,14 +2,21 @@ import { describe, it, expect, on } from '@gjsify/unit';
 // Testing the child_process module API — all commands are hardcoded safe literals
 import { execSync, execFileSync, spawnSync, exec, execFile, spawn } from 'node:child_process';
 import { realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 // A process's working directory is the RESOLVED path, so `pwd` in a child
 // spawned with `cwd: TMP_DIR` prints the symlink target, not the string that
-// was passed in. On macOS `/tmp` is a symlink to `/private/tmp`, so asserting
-// the literal fails there while passing on Linux; Node reports the resolved
-// path on both. Comparing against the resolved value keeps ONE assertion
-// correct on every OS (on Linux `realpathSync('/tmp')` is `/tmp`).
-const TMP_DIR = '/tmp';
+// was passed in. On macOS the temp dir sits under `/var`, a symlink to
+// `/private/var`, so asserting the literal fails there while passing on Linux;
+// Node reports the resolved path on both. Comparing against the resolved value
+// keeps ONE assertion correct on every OS.
+//
+// `tmpdir()`, never the literal `/tmp`: on Windows that resolves against the
+// current drive to `C:\tmp`, which does not exist, and `realpathSync` throws at
+// MODULE EVALUATION — so the whole spec module fails to load and not one of its
+// tests runs. A hand-created `C:\tmp` makes the symptom disappear without fixing
+// anything, which is how this stayed hidden.
+const TMP_DIR = tmpdir();
 const TMP_DIR_RESOLVED = realpathSync(TMP_DIR);
 
 // Ported from refs/node/test/parallel/test-child-process-exec*.js

--- a/packages/node/child_process/src/parity.spec.ts
+++ b/packages/node/child_process/src/parity.spec.ts
@@ -16,12 +16,14 @@ import { describe, it, expect } from '@gjsify/unit';
 import { execSync, execFileSync, spawnSync, exec, execFile, spawn } from 'node:child_process';
 import { Buffer } from 'node:buffer';
 import { realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
-// See the note in `index.spec.ts`: a child's reported cwd is the RESOLVED
-// path, which differs from the literal wherever the directory is a symlink
-// (macOS `/tmp` → `/private/tmp`).
-const TMP_DIR = '/tmp';
+// See the note in `index.spec.ts`: a child's reported cwd is the RESOLVED path,
+// which differs from the literal wherever the directory is a symlink, and
+// `tmpdir()` rather than a literal `/tmp` because that throws here at module
+// evaluation on Windows and takes the entire module's tests with it.
+const TMP_DIR = tmpdir();
 const TMP_DIR_RESOLVED = realpathSync(TMP_DIR);
 
 export default async () => {

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -18,12 +18,18 @@ Measured on the win11-gjsify VM (Node 24.18.1), with no `C:\tmp` present:
 | tests run | **0** | **145** |
 | failures | — (module never loaded) | 86 |
 
-The 86 are pre-existing POSIX assumptions in the specs, not regressions, and they
-are the bulk of what a Windows port of this package has to work through: shell
-built-ins assumed to exist (`echo`/`pwd`/`cat` under `cmd.exe`), POSIX absolute
-paths, exit-code and signal semantics, and `/bin/sh`-shaped `shell:` options.
-Triage before editing — some of these are the IMPL being wrong on Windows, not
-the spec, and the two need separating.
+The 86 are pre-existing POSIX assumptions in the SPECS, not regressions and not
+impl gaps — which is structural, not a judgement call: `@gjsify/child_process`
+declares `runtimes.node: "none"`, so `test:node` never aliases
+`node:child_process` to our polyfill and those specs run against NATIVE Node. Per
+the testing rules a failure there means the TEST is wrong. What they encode:
+shell built-ins assumed to exist (`echo`/`pwd`/`cat` under `cmd.exe`), POSIX
+absolute paths, exit-code and signal semantics, and `/bin/sh`-shaped `shell:`
+options. Node's own behaviour on Windows is the oracle for each.
+
+The GJS run is the one that measures our impl, and it cannot run on Windows at
+all (no `gjs` there) — so this package's Windows impl story is still unmeasured;
+only its specs have been.
 
 **Note for anyone re-measuring:** a hand-created `C:\tmp` makes the module-load
 failure vanish without fixing anything (one existed on the test VM for several

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,6 +4,31 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
+### `@gjsify/child_process` on Windows — 86 of 145 specs fail once the module can load at all
+
+The specs took `TMP_DIR` from a literal `/tmp` and `realpathSync`'d it at MODULE
+EVALUATION. On `win32-x64` that resolves against the current drive to `C:\tmp`,
+which does not exist, so the module threw before defining a single test.
+
+Measured on the win11-gjsify VM (Node 24.18.1), with no `C:\tmp` present:
+
+| | before | after `tmpdir()` |
+|---|---|---|
+| output | 23 lines, `ENOENT: lstat 'C:\tmp'` | full run |
+| tests run | **0** | **145** |
+| failures | — (module never loaded) | 86 |
+
+The 86 are pre-existing POSIX assumptions in the specs, not regressions, and they
+are the bulk of what a Windows port of this package has to work through: shell
+built-ins assumed to exist (`echo`/`pwd`/`cat` under `cmd.exe`), POSIX absolute
+paths, exit-code and signal semantics, and `/bin/sh`-shaped `shell:` options.
+Triage before editing — some of these are the IMPL being wrong on Windows, not
+the spec, and the two need separating.
+
+**Note for anyone re-measuring:** a hand-created `C:\tmp` makes the module-load
+failure vanish without fixing anything (one existed on the test VM for several
+hours and hid exactly this). It has been removed there. Do not re-create it.
+
 ### Bun DID hard-crash in the N-API teardown class — the first one, and the note that predicted it asked to be told
 
 `scripts/cross-runtime.mjs` carves Deno out of exit-code gating for the


### PR DESCRIPTION
## The defect

Both `@gjsify/child_process` spec modules did this at **module scope**:

```ts
const TMP_DIR = '/tmp';
const TMP_DIR_RESOLVED = realpathSync(TMP_DIR);
```

On `win32-x64`, `/tmp` resolves against the current drive to `C:\tmp`, which does not exist. `realpathSync` throws during module evaluation — and a module-level throw takes **every test in the file** with it.

## Measured

On the `win11-gjsify` test VM (Node 24.18.1), with no `C:\tmp` present:

| | before | after |
|---|---|---|
| output | 23 lines, `ENOENT: lstat 'C:\tmp'` | full run |
| tests run | **0** of 145 | **145** of 145 |
| failures reported | — (module never loaded) | 86 |

## The 86 failures are not regressions

They are pre-existing POSIX assumptions in these specs — shell built-ins assumed to exist under `cmd.exe`, POSIX absolute paths, exit-code and signal semantics, `/bin/sh`-shaped `shell:` options — that were simply unreachable. They are classified in `status/open-todos.md` rather than fixed here, with an explicit warning: **some are the impl being wrong on Windows, not the spec**, and that has to be separated before anyone starts editing assertions.

## Why `tmpdir()` and not just a Windows branch

`tmpdir()` preserves the reason the `realpathSync` was there: a child's reported cwd is the *resolved* path, and on macOS the temp dir sits under `/var`, a symlink to `/private/var`. Resolving keeps one assertion correct on every OS — only the *source* of the path changes. No platform branch, no weakened assertion.

## The part worth remembering

This failure mode hides itself. A hand-created `C:\tmp` makes it vanish with nothing fixed — one existed on the test VM for several hours, which is exactly why the module looked healthy there while being broken on any clean Windows host and in CI. It has been removed, and the TODO says not to re-create it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
