### PR TITLE
style: satisfy the format gate after #944

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -195,11 +195,7 @@ function readBytesOrNull(path) {
  * can never be warm" for "the cache grows forever".
  */
 function pruneCache(dir, keepBasename) {
-    const children = Gio.File.new_for_path(dir).enumerate_children(
-        'standard::name',
-        Gio.FileQueryInfoFlags.NONE,
-        null,
-    );
+    const children = Gio.File.new_for_path(dir).enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null);
     for (;;) {
         const info_ = children.next_file(null);
         if (info_ === null) break;
@@ -252,7 +248,9 @@ async function resolveBootstrap(session, bootstrapUrl, sha256Url) {
     }
 
     const dir = cacheDir();
-    const basename = expected ? `${CACHE_PREFIX}${expected}${CACHE_SUFFIX}` : `${CACHE_PREFIX}unverified${CACHE_SUFFIX}`;
+    const basename = expected
+        ? `${CACHE_PREFIX}${expected}${CACHE_SUFFIX}`
+        : `${CACHE_PREFIX}unverified${CACHE_SUFFIX}`;
     const bundlePath = GLib.build_filenamev([dir, basename]);
 
     if (expected) {

--- a/tests/e2e/self-host/run.mjs
+++ b/tests/e2e/self-host/run.mjs
@@ -27,7 +27,16 @@
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
`main` is red on `Format (oxfmt --check)`. Fixing my own mess: #944's `Check Fedora 44` was failing at that step, and the PR merged at 18:51 before the verdict landed, so the violation is on `main`.

Both hunks are pure line-length consequences of #944's edits — no behaviour change:

- `tests/e2e/self-host/run.mjs`: adding `readFileSync` pushed the `node:fs` import past 120 columns, so oxfmt expands it to one-per-line.
- `install.mjs`: the `basename` ternary exceeded 120 and gets split; with that done oxfmt also collapses the `enumerate_children(...)` call back onto one line, since it now fits.

`node_modules/oxfmt/bin/oxfmt --check install.mjs tests/e2e/self-host/run.mjs` → *All matched files use the correct format.*

## Why it slipped through, and the part worth acting on

Two independent things had to line up:

1. **I did not run the formatter before committing.** Entirely on me — `Format (oxfmt --check)` is a documented CI step and I should have run it locally. I have since verified #946's TypeScript files the same way, before pushing, and they were clean.
2. **`Check Fedora 44` is not a required check**, and the merge happened while `CI gate (GJS)` had not yet reported (E2E was still running). The `main branch` ruleset lists `OrganizationAdmin` with `bypass_mode: always`, so the merge was permitted with the gate still pending.

Point 2 is not a complaint about the merge — it is the observation that for an org admin the three required checks are advisory, so "wait for green" is discipline rather than a mechanism. If that is not the intent, the cheap fix is to keep the bypass (it is needed for release tooling) but stop relying on it by habit; if it *is* the intent, then a red `Format` step reaching `main` is the accepted cost and this PR is simply the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)