### PR TITLE
fix(ci): re-emit README when exemption clears

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -2577,19 +2577,26 @@ jobs:
       - name: Clear platform exemptions the downloads satisfied
         run: |
           set -euo pipefail
-          # stdout is the list of manifests it changed, so the next step stages
+          # stdout is the list of every FILE it wrote, so the next step stages
           # exactly those (a `packages/*/*/package.json` glob in a job that
           # pushes to `main` would sweep in whatever else happened to be dirty).
-          node scripts/clear-committed-platform-exemptions.mjs > cleared-manifests.txt
-          cat cleared-manifests.txt
+          #
+          # More than the manifest, because `gjsify.platformsUncommitted` is an
+          # input to TWO generated files of a platform package: the manifest block
+          # and a deferred-artifact paragraph in the generated `README.md`. Writing
+          # only the manifest left a README the generator disagreed with, and the
+          # gate below then failed on a byte comparison — that is what kept this
+          # job red from 2026-08-01 with every build leg green.
+          node scripts/clear-committed-platform-exemptions.mjs > regenerated-files.txt
+          cat regenerated-files.txt
 
       - name: Stage prebuilds
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          xargs -r git add < cleared-manifests.txt
-          rm -f cleared-manifests.txt
+          xargs -r git add < regenerated-files.txt
+          rm -f regenerated-files.txt
           # A GLOB, not a hand-written list, and that is now the only shape that
           # can be right. ADR 0017 moved every prebuild out of its bridge and
           # into a per-target package, so the ten paths this used to name stopped
@@ -2611,6 +2618,21 @@ jobs:
           # — it already matches on `*prebuilds/*`.
           git add packages/*/*/prebuilds/
           git diff --cached --stat | cat
+
+          # Nothing this job wrote may stay UNSTAGED. The gate two steps below
+          # audits the working tree, but what gets pushed is the INDEX — so an
+          # unstaged write means the gate blessed a tree that is not the one that
+          # lands. That gap is how a half-written generated package shipped: the
+          # clear step rewrote a manifest and left its generated README behind,
+          # and nothing noticed until the gate compared bytes. Now it is the clear
+          # step's job to report every file it wrote, and this asserts it did.
+          unstaged="$(git status --porcelain -uall | grep -v '^[ACDMRT] ' || true)"
+          if [ -n "$unstaged" ]; then
+            echo "::error::this job changed files it did not stage — the gate below would audit a tree that is not the one being pushed:"
+            printf '::error::  %s\n' $unstaged
+            exit 1
+          fi
+          echo "no unstaged change left behind."
 
       # THE guard. A package this run skipped contributed no artifact, so its
       # committed prebuild must come through untouched — and "untouched" has to

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1562,6 +1562,14 @@ async function main() {
         const portableScripts = byId.get('portable-scripts');
         const coverage = byId.get('field-coverage');
         const statusData = byId.get('status-data');
+        // `platform-packages` is selected by CHECK_RULES, so its failures set the
+        // exit code — but it was never fetched here, in EITHER branch, so its
+        // findings were structurally unprintable and its summary printed on no
+        // run. That is what made the 2026-08-01 `commit-prebuilds` outage cost six
+        // main runs and ~41 hours: the gate said `DRIFT DETECTED.` and named
+        // nothing, because the only rule that could fail was the one rule with no
+        // print block. See the accountant at the end of this branch.
+        const platformPackages = byId.get('platform-packages');
         const reach = reachability.reach;
 
         if (run.ok) {
@@ -1575,6 +1583,7 @@ async function main() {
             console.log(portableScripts.summary);
             console.log(coverage.summary);
             console.log(statusData.summary);
+            console.log(platformPackages.summary);
             for (const note of coverage.notes ?? []) console.log(`  · ${note}`);
             renderReachabilityNotes(reach);
             process.exit(0);
@@ -1754,8 +1763,71 @@ async function main() {
             );
             console.error('');
         }
+        if ((platformPackages.failures ?? []).length > 0) {
+            console.error(`PLATFORM-PACKAGE FAILURES on ${platformPackages.failures.length} finding(s):`);
+            for (const line of platformPackages.failures) {
+                console.error(`  - ${line}`);
+            }
+            console.error('');
+            console.error(
+                'The per-target packages (ADR 0017) are GENERATED — both their `package.json` AND their ' +
+                    '`README.md`. Re-emit with `node scripts/generate-platform-packages.mjs --write` and commit ' +
+                    'the result; never hand-edit one. If the difference is a `libc` / `gjsify.glibcRequires` ' +
+                    'field, a rebuild MEASURED a different floor: that is a declaration change and belongs in a ' +
+                    'reviewed commit, not in a job that pushes under `[skip ci]`.',
+            );
+            console.error('');
+        }
         for (const note of coverage.notes ?? []) console.error(`  · ${note}`);
         renderReachabilityNotes(reach);
+
+        // THE ACCOUNTANT — a verdict may not be emitted without the findings that
+        // caused it.
+        //
+        // Everything above is a HAND-WRITTEN list of rule ids while the verdict
+        // comes from the AGGREGATE (`run.failures`, over every selected rule). A
+        // rule missing from the list therefore fails in total silence, and one
+        // was: `platform-packages`. Six main runs were spent on `DRIFT DETECTED.`
+        // followed by nothing but informational notes.
+        //
+        // This closes the class rather than the instance: the set below is what
+        // has a print block, and anything selected but absent from it gets dumped
+        // verbatim. It can only ADD output to a run that is already failing, so it
+        // can never turn a green run red. (Deriving the whole report from
+        // `run.results` — which removes this list entirely — is the follow-up;
+        // until then, adding an id here without a print block is a deliberate lie.)
+        const REPORTED_RULE_IDS = new Set([
+            'runtimes-drift',
+            'tier',
+            'platforms-ci',
+            'prebuild-artifacts',
+            'prebuild-libc',
+            'runtimes-reachability',
+            'curated-alias-routing',
+            'headless',
+            'portable-scripts',
+            'field-coverage',
+            'status-data',
+            'platform-packages',
+        ]);
+        const unreported = run.results.filter(
+            ({ rule, result }) => (result.failures ?? []).length > 0 && !REPORTED_RULE_IDS.has(rule.id),
+        );
+        if (unreported.length > 0) {
+            console.error('');
+            console.error('UNREPORTED FINDING(S) — this is a REPORTER bug, not a new drift:');
+            for (const { rule, result } of unreported) {
+                for (const line of result.failures) console.error(`  - [${rule.id}] ${line}`);
+            }
+            console.error('');
+            console.error(
+                'A rule was selected by CHECK_RULES but has no print block in scripts/audit-runtimes.mjs, so ' +
+                    'it set the exit code without naming anything. Add its block next to the others — and add ' +
+                    'its id to REPORTED_RULE_IDS only together with that block.',
+            );
+            console.error('');
+        }
+
         console.error(
             "Either update the package's source-code signals (the GJS-binding shape changed) or update its package.json#gjsify.runtimes to match the new reality. See AGENTS.md `## Strategic direction — cross-runtime portability` for the slot model. For tier-contract failures see docs/adr/0003-package-tiering.md + docs/adr/0005-node-gi-scope.md. For reachability failures see docs/adr/0014-utils-core-subpath-and-platform-entry-routing.md. For headless-contract failures see docs/adr/0015-headless-package-contract.md.",
         );

--- a/scripts/clear-committed-platform-exemptions.mjs
+++ b/scripts/clear-committed-platform-exemptions.mjs
@@ -21,15 +21,50 @@
 // which is the whole point: it still describes reality.
 //
 // Usage: node scripts/clear-committed-platform-exemptions.mjs [--dry-run] [--root <dir>]
-//   STDOUT is the machine-readable half: one repo-relative manifest path per
-//   changed file, so the caller stages exactly those and nothing else (a
-//   `git add packages/*/*/package.json` in a job that pushes to `main` would
-//   sweep in whatever else happened to be dirty). Commentary goes to stderr.
-//   Exits 0 with empty stdout when there is nothing to clear — the common case.
+//   STDOUT is the machine-readable half: one repo-relative path per file
+//   WRITTEN — the manifest whose exemption was cleared, plus every other
+//   generated file re-derived from that change — so the caller stages exactly
+//   those and nothing else (a `git add packages/*/*/package.json` in a job that
+//   pushes to `main` would sweep in whatever else happened to be dirty).
+//   Commentary goes to stderr. Exits 0 with empty stdout when there is nothing
+//   to clear — the common case.
+//
+// WHY THIS WRITES MORE THAN THE MANIFEST
+//
+// `gjsify.platformsUncommitted` is an input to TWO generated files of a platform
+// package, not one: the manifest block itself, and a nine-line "No artifact in
+// this tarball yet" paragraph in the generated `README.md` that
+// `generate-platform-packages.mjs` emits only while `planned.state ===
+// 'uncommitted'`. `auditPlatformPackages` byte-compares BOTH. So deleting the
+// exemption and writing only the manifest leaves a README the generator no
+// longer agrees with, and the gate two steps later in `commit-prebuilds` fails
+// with `README.md is not what the generator emits now` — once per cleared
+// package. That is what kept `commit-prebuilds` red from 2026-08-01 onward, with
+// every build leg green and no prebuild landing on `main` for 41 hours.
+//
+// WHY IT STILL WRITES THE MANIFEST ITSELF RATHER THAN ASKING THE GENERATOR
+//
+// The generator's `write()` is parent-scoped: it re-emits every target of a
+// touched parent, and `expectedFiles` derives `gjsify.glibcRequires` by MEASURING
+// the binary on disk. The eight parents this script clears own 36 sibling `plan`
+// children, 26 of them carrying a measured glibc floor. Calling `write()` here
+// would let a job that pushes under `[skip ci]` silently raise a floor that the
+// `prebuild-libc` gate compares against two steps later — verbatim the failure
+// that gate exists to catch, and which has already fired for real (#927). So the
+// surgical delete stays, and the generator is used as an ORACLE: its manifest
+// must equal ours, or this script refuses. A floor is a promise to consumers; a
+// human declares it.
 
-import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import {
+    expectedFiles,
+    firstDifference,
+    generatorContext,
+    planPlatformPackages,
+} from './generate-platform-packages.mjs';
 
 const argv = process.argv.slice(2);
 const dryRun = argv.includes('--dry-run');
@@ -60,12 +95,14 @@ function packageManifests(root) {
 /**
  * Clear satisfied exemptions.
  *
- * @returns `{ cleared, manifests }` — the `<pkg> <target>` pairs for the log,
- *   and the repo-relative manifest paths the caller must stage.
+ * @returns `{ cleared, paths }` — the `<pkg> <target>` pairs for the log, and
+ *   the repo-relative paths of every file written, which the caller must stage.
  */
 export function clearSatisfiedExemptions(root, { dryRun: dry = false } = {}) {
     const cleared = [];
-    const manifests = [];
+    const paths = [];
+    /** Built lazily and at most once — it walks every package. */
+    let plan = null;
     for (const manifest of packageManifests(root)) {
         const raw = readFileSync(manifest, 'utf8');
         const data = JSON.parse(raw);
@@ -88,17 +125,70 @@ export function clearSatisfiedExemptions(root, { dryRun: dry = false } = {}) {
         if (!changed) continue;
         if (Object.keys(exemptions).length === 0) delete gjsify.platformsUncommitted;
         // Match the tree's manifest style: 4-space indent, trailing newline.
-        if (!dry) writeFileSync(manifest, `${JSON.stringify(data, null, 4)}\n`);
-        manifests.push(manifest.slice(root.length + 1));
+        const surgical = `${JSON.stringify(data, null, 4)}\n`;
+
+        // Which OTHER generated files does this package have, and what should
+        // they look like now that the exemption is gone? Matched by NAME:
+        // `platformPackageName()` is the one truth for the parent→child mapping,
+        // and a path comparison would break the first time a root sits behind a
+        // symlink (macOS `/var` vs `/private/var`).
+        plan ??= planPlatformPackages(generatorContext(root));
+        let parent = null;
+        let planned = null;
+        for (const candidate of plan.parents) {
+            const hit = candidate.targets.find((t) => t.name === data.name);
+            if (hit) {
+                parent = candidate;
+                planned = hit;
+                break;
+            }
+        }
+
+        const written = [manifest];
+        if (planned) {
+            // `why` goes with the exemption; `state` flips `uncommitted` → `plan`,
+            // which is exactly what the generator keys the README block on.
+            const want = expectedFiles(parent, { ...planned, state: 'plan', why: undefined });
+
+            // The generator is an ORACLE here, never the writer. If its manifest
+            // disagrees with the surgical delete, the difference is MEASURED from
+            // the artifact that just landed (`libc` / `gjsify.glibcRequires`) —
+            // numbers a delete cannot invent and this job must not declare.
+            if (want['package.json'] !== surgical) {
+                throw new Error(
+                    `clear-committed-platform-exemptions: refusing to write ${data.name}.\n` +
+                        `The generator's manifest differs from clearing the exemption, which means it would\n` +
+                        `also change a MEASURED declaration (libc / gjsify.glibcRequires). A floor is a\n` +
+                        `promise to consumers — declare it in a reviewed commit, not from a [skip ci] job.\n` +
+                        firstDifference(surgical, want['package.json']),
+                );
+            }
+
+            // Every OTHER generated entry, derived rather than hard-coded: a third
+            // generated file added to `expectedFiles` later is covered for free.
+            for (const [name, contents] of Object.entries(want)) {
+                if (name === 'package.json') continue;
+                const target = join(dirname(manifest), name);
+                if (existsSync(target) && readFileSync(target, 'utf8') === contents) continue;
+                if (!dry) writeFileSync(target, contents);
+                written.push(target);
+            }
+        }
+
+        // The `!dry` guard is load-bearing, not cosmetic: the e2e suite calls this
+        // function on the REAL monorepo root with `dryRun: true`, so unguarded
+        // re-emission would rewrite live package READMEs on every test run.
+        if (!dry) writeFileSync(manifest, surgical);
+        for (const path of written) paths.push(relative(root, path).replaceAll('\\', '/'));
     }
-    return { cleared, manifests };
+    return { cleared, paths };
 }
 
 // Only act when executed directly — the e2e suite imports the function.
 if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
-    const { cleared, manifests } = clearSatisfiedExemptions(ROOT, { dryRun });
+    const { cleared, paths } = clearSatisfiedExemptions(ROOT, { dryRun });
     for (const entry of cleared) {
         console.error(`[platform-exemptions] cleared ${entry} — its prebuild directory is now committed`);
     }
-    for (const path of manifests) console.log(path);
+    for (const path of paths) console.log(path);
 }

--- a/scripts/generate-platform-packages.mjs
+++ b/scripts/generate-platform-packages.mjs
@@ -193,7 +193,12 @@ export function platformManifest(parent, target, measured, exemption = null) {
     if (!osCpu) throw new Error(`generate-platform-packages: ${parent.name} declares an invalid target \`${target}\``);
     const name = platformPackageName(parent.name, target);
     const dirName = platformPackageDirName(basename(parent.dir), target);
-    const repoDir = `${relative(ROOT, dirname(parent.dir)).replaceAll('\\', '/')}/${dirName}`;
+    // Relative to the CONTEXT's root, not the module-level one: the emitters are
+    // also driven against a temp-root fixture (see
+    // tests/e2e/platform-exemption-clearing), where closing over `ROOT` computes
+    // a `../../../tmp/…` traversal. An equality-only test would then compare
+    // garbage to garbage and notice nothing.
+    const repoDir = `${relative(parent.root ?? ROOT, dirname(parent.dir)).replaceAll('\\', '/')}/${dirName}`;
 
     /** @type {Record<string, unknown>} */
     const manifest = {
@@ -589,6 +594,9 @@ export function planPlatformPackages(ctx) {
             name: row.name,
             path: row.path,
             dir: pkg.dir,
+            // The root this plan was built against, so every emitter derives
+            // repo-relative paths from it rather than from the module-level ROOT.
+            root: ctx.root ?? ROOT,
             version: pkg.manifest.version,
             tier: row.tier,
             manifest: pkg.manifest,
@@ -657,6 +665,7 @@ export function expectedFiles(parent, planned) {
                     name: parent.name,
                     version: parent.version,
                     dir: parent.dir,
+                    root: parent.root,
                     tier: parent.tier,
                 },
                 planned.target,
@@ -886,7 +895,7 @@ export function auditPlatformPackages(ctx) {
 }
 
 /** The first differing line of two strings, so a mismatch names itself. */
-function firstDifference(have, want) {
+export function firstDifference(have, want) {
     const a = have.split('\n');
     const b = want.split('\n');
     for (let i = 0; i < Math.max(a.length, b.length); i++) {

--- a/tests/e2e/platform-exemption-clearing/run.mjs
+++ b/tests/e2e/platform-exemption-clearing/run.mjs
@@ -19,7 +19,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -28,8 +28,68 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // tests/e2e/platform-exemption-clearing/ → monorepo root is 3 levels up.
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
 const SCRIPT = join(MONOREPO_ROOT, 'scripts', 'clear-committed-platform-exemptions.mjs');
+const GENERATOR = join(MONOREPO_ROOT, 'scripts', 'generate-platform-packages.mjs');
 
 const { clearSatisfiedExemptions } = await import(`file://${SCRIPT}`);
+const { auditPlatformPackages, generatorContext } = await import(`file://${GENERATOR}`);
+
+/**
+ * A realistic POST-SPLIT pair, copied out of the real tree so the fixture IS
+ * generator output rather than a hand-written approximation.
+ *
+ * That distinction is the whole reason the defect survived: the synthetic
+ * `@gjsify/thing` fixture above has no generated `README.md`, so a suite that
+ * ran on every PR shard could not see that clearing an exemption invalidates
+ * one. A fixture that cannot reach the bug is not coverage.
+ */
+function splitPairFixture() {
+    const root = mkdtempSync(join(tmpdir(), 'gjsify-split-pair-'));
+    // `planPlatformPackages` derives each child's semver `range` from
+    // `isWorkspaceMember`; without the root manifest the copied `workspace:*`
+    // entry mismatches and the plan describes something else entirely.
+    writeFileSync(
+        join(root, 'package.json'),
+        `${JSON.stringify({ name: 'root', workspaces: ['packages/*/*'] }, null, 4)}\n`,
+    );
+    // `collectNativePackages` only considers a package native when it has
+    // `meson.build`, `binding.gyp` or a string `gjsify.prebuilds` — and a
+    // post-split bridge has NONE of those in its manifest, so without this the
+    // plan finds zero parents and the whole fixture silently proves nothing
+    // (measured: `parents found: 0`). Only `existsSync` is consulted, so an
+    // empty file is faithful. No `binding.gyp`, so the parent classifies as
+    // meson → `prebuildOwnership` 'split' rather than a 'committed-here' failure.
+    for (const rel of [
+        join('packages', 'node', 'tls-native', 'package.json'),
+        join('packages', 'node', 'tls-native-darwin-x64', 'package.json'),
+        join('packages', 'node', 'tls-native-darwin-x64', 'README.md'),
+    ]) {
+        mkdirSync(join(root, dirname(rel)), { recursive: true });
+        copyFileSync(join(MONOREPO_ROOT, rel), join(root, rel));
+    }
+    writeFileSync(join(root, 'packages', 'node', 'tls-native', 'meson.build'), '# fixture\n');
+    // Narrow the parent to the ONE target under test. `tls-native` really
+    // declares seven, and `platform-packages` requires a child package per
+    // declared target — copying one child out of seven makes the audit report the
+    // six missing siblings, which would drown the assertion this test is for.
+    // Narrowing keeps the pair internally consistent instead of faking six
+    // packages whose committed Linux artifacts also carry measured glibc floors.
+    const parentManifest = join(root, 'packages', 'node', 'tls-native', 'package.json');
+    const parent = JSON.parse(readFileSync(parentManifest, 'utf8'));
+    parent.gjsify.platforms = ['darwin-x64'];
+    parent.optionalDependencies = Object.fromEntries(
+        Object.entries(parent.optionalDependencies ?? {}).filter(([name]) => name.endsWith('-darwin-x64')),
+    );
+    writeFileSync(parentManifest, `${JSON.stringify(parent, null, 4)}\n`);
+    // The landing: an EMPTY directory is enough, because `expectedFiles` is
+    // artifact-independent for a darwin target (`measureLibcFields`
+    // short-circuits off linux to the same shape as the no-directory fallback).
+    mkdirSync(join(root, 'packages', 'node', 'tls-native-darwin-x64', 'prebuilds', 'darwin-x64'), { recursive: true });
+    return {
+        root,
+        childDir: join(root, 'packages', 'node', 'tls-native-darwin-x64'),
+        cleanup: () => rmSync(root, { recursive: true, force: true }),
+    };
+}
 
 /**
  * A synthetic workspace root holding one package.
@@ -72,9 +132,9 @@ describe('clear-committed-platform-exemptions', () => {
             presentDirs: ['linux-x64', 'darwin-x64'],
         });
         try {
-            const { cleared, manifests } = clearSatisfiedExemptions(f.root);
+            const { cleared, paths } = clearSatisfiedExemptions(f.root);
             assert.deepEqual(cleared, ['@gjsify/thing darwin-x64']);
-            assert.deepEqual(manifests, ['packages/node/thing/package.json']);
+            assert.deepEqual(paths, ['packages/node/thing/package.json']);
             const g = readGjsify(f.manifest);
             // The object goes away with its last entry — an empty
             // `platformsUncommitted` would be a declaration promising nothing.
@@ -95,9 +155,9 @@ describe('clear-committed-platform-exemptions', () => {
             presentDirs: ['linux-x64'],
         });
         try {
-            const { cleared, manifests } = clearSatisfiedExemptions(f.root);
+            const { cleared, paths } = clearSatisfiedExemptions(f.root);
             assert.deepEqual(cleared, []);
-            assert.deepEqual(manifests, []);
+            assert.deepEqual(paths, []);
             assert.deepEqual(readGjsify(f.manifest).platformsUncommitted, {
                 'darwin-x64': 'CI builds it; not committed here yet',
             });
@@ -150,5 +210,51 @@ describe('clear-committed-platform-exemptions', () => {
         // Every exemption currently in the tree is genuinely unsatisfied; if
         // this ever fires, an artifact landed without its marker being cleared.
         assert.deepEqual(clearSatisfiedExemptions(MONOREPO_ROOT, { dryRun: true }).cleared, []);
+    });
+
+    it('leaves a tree the generator agrees with', () => {
+        // THE MECHANISM, and the assertion whose absence cost 41 hours.
+        //
+        // The cases above pin the FIELD that gets removed. None of them pinned
+        // the STATE the removal leaves behind — and that is where the defect
+        // lived: `gjsify.platformsUncommitted` is an input to the generated
+        // `README.md` as well as to the manifest, so clearing it in the manifest
+        // alone leaves a README the generator no longer agrees with, and
+        // `commit-prebuilds`' gate fails two steps later on a byte comparison.
+        //
+        // Deliberately invariant-shaped rather than case-shaped: it names no
+        // filename, so whatever `expectedFiles` emits next is covered without
+        // touching this test. And it runs on every PR with no artifact, no macOS
+        // leg and no write access — which is what makes the class visible off
+        // `main`, where `commit-prebuilds` cannot run at all.
+        const f = splitPairFixture();
+        try {
+            const { cleared, paths } = clearSatisfiedExemptions(f.root);
+            assert.deepEqual(cleared, ['@gjsify/tls-native-darwin-x64 darwin-x64']);
+            // Both generated files, not just the manifest.
+            assert.deepEqual(paths.sort(), [
+                'packages/node/tls-native-darwin-x64/README.md',
+                'packages/node/tls-native-darwin-x64/package.json',
+            ]);
+            assert.deepEqual(auditPlatformPackages(generatorContext(f.root)).failures, []);
+        } finally {
+            f.cleanup();
+        }
+    });
+
+    it('does not touch the generated README on a dry run', () => {
+        // The guard on the `dryRun: true` call above, which runs against the REAL
+        // monorepo root: unguarded re-emission would rewrite live package READMEs
+        // every time this suite runs.
+        const f = splitPairFixture();
+        try {
+            const before = readFileSync(join(f.childDir, 'README.md'), 'utf8');
+            const { cleared } = clearSatisfiedExemptions(f.root, { dryRun: true });
+            assert.deepEqual(cleared, ['@gjsify/tls-native-darwin-x64 darwin-x64']);
+            assert.equal(readFileSync(join(f.childDir, 'README.md'), 'utf8'), before);
+            assert.match(readFileSync(join(f.childDir, 'package.json'), 'utf8'), /platformsUncommitted/);
+        } finally {
+            f.cleanup();
+        }
     });
 });


### PR DESCRIPTION
Unblocks `commit-prebuilds`. **No prebuild has landed on `main` since `eb34d95ac` — 2026-08-01 09:59, 79 commits ago.** The job has failed on every run since 2026-08-01 23:12, six consecutive runs, with every build leg green each time.

## One defect, one missing write

`clear-committed-platform-exemptions.mjs` had a single `writeFileSync`, on the manifest. But `gjsify.platformsUncommitted` is an input to **two** generated files of a platform package:

| file | where |
|---|---|
| `package.json` — the block itself | `generate-platform-packages.mjs:228` |
| `README.md` — a 9-line *"No artifact in this tarball yet"* paragraph, emitted only while `planned.state === 'uncommitted'` | `:192-204` |

`expectedFiles()` emits both, `auditPlatformPackages()` byte-compares both, and the state flips from `uncommitted` to `plan` the moment the exemption is deleted. So the job landed a darwin payload, deleted the exemption, left the README stale, and the gate two steps later correctly reported `README.md is not what the generator emits now` — once per cleared package.

**Reproduced twice, independently**: once by fabricating darwin payloads in an isolated worktree (the exact CI symptom: exit 1, `DRIFT DETECTED.`, zero findings; then `--write` → 6 READMEs → exit 0), and once read-only across **all nine** declaring packages by driving the repo's own emitters — for all nine, the surgical delete matches `generator(plan)` exactly while the on-disk README does not.

## Why the obvious repair is rejected

Calling the generator's `write()` would have been one line. It is **measured** to be dangerous: `write()`'s filter is parent-scoped and re-emits **every** target of a touched parent, deriving `gjsify.glibcRequires` by *measuring the binary on disk*. The eight parents this job clears own **36 sibling `plan` children, 26 of them carrying a measured glibc floor** (all five `lightningcss-native-linux-*` at `2.39`).

That would let a job pushing under `[skip ci]` silently raise the floor that `prebuild-libc` compares against two steps later — verbatim the failure that gate exists to catch, and which has already fired for real: the 01.08 23:12 run, fixed by #927.

So the surgical delete stays and **the generator becomes an oracle**: its manifest must equal ours or the script *refuses*, naming the first differing line. A floor is a promise to consumers; a human declares it. Every other generated entry is then written from `expectedFiles` — derived, not hard-coded, so a third generated file added later is covered without touching this script.

## Mechanism

The existing e2e pinned the **field** that gets removed, never the **state** the removal leaves behind — and its synthetic fixture had no generated README, so a suite running on every PR shard could not reach the bug. *A fixture that cannot reach the bug is not coverage.*

The new case builds a realistic post-split pair from real generator output and asserts `auditPlatformPackages(...).failures` is empty — invariant-shaped, naming no filename, so whatever `expectedFiles` emits next is covered. It needs no artifact, no macOS leg and no write access, so it runs on **every PR** — which is what makes this class visible off `main`, where `commit-prebuilds` cannot run at all.

**Tested the test:** neutralising only the re-emission turns that case red; restoring it turns it green. A guard nobody has seen fail is a guard nobody knows works.

## Second commit: the gate now names what failed

The verdict came from the aggregate (`registry.mjs:191`) while the printer came from a hand-written list — eleven `byId.get(...)` reads out of twelve selected rules, with no aggregate fallback. `platform-packages` was the missing one, in **both** branches: its findings set the exit code and printed nothing, and its summary appeared on no run. Since every other selected rule had a print block, *"exit 1 with zero findings" was only producible by that one rule*.

Adds its block and its summary, then closes the class with an **accountant**: any selected rule whose findings were not printed gets dumped verbatim under `UNREPORTED FINDING(S) — this is a REPORTER bug, not a new drift`. It can only add output to an already-failing run, so it can never turn green red.

Verified both directions — a hand-edited generated README now fails like this, where before it produced the silent verdict:

```
PLATFORM-PACKAGE FAILURES on 1 finding(s):
  - @gjsify/tls-native-darwin-x64: `README.md` is not what the generator emits now. …
    line 36: have "hand-edited line that the generator would never emit"
    line 36: want null
```

and a clean run prints `platform packages (ADR 0017): OK. …` — a line that appeared on no run before.

## Verification

| | |
|---|---|
| `audit-runtimes --check --strict` (required check) | exit 0 |
| `generate-platform-packages --check` | exit 0, tree untouched — the emitter change is a no-op |
| `clear-committed-platform-exemptions --dry-run` on the real tree | exit 0, empty stdout, tree untouched |
| `tests/e2e/platform-exemption-clearing` | 8/8, incl. the new mechanism + a dry-run README guard |
| `oxfmt --check` | clean — run *before* committing |
| `prebuilds.yml` | parses (PyYAML), 8 jobs |

Touches **no** `packages/infra/cli/src`, so no committed GJS bundle goes stale and no ~20-minute rebuild is needed.

## Deliberately out of scope, with reasons

- **The rebase (`git pull --rebase`, `:2670`).** Will recur — `.gitattributes` declares the binaries `binary` with no merge driver, so a concurrent change to the same path is unresolvable with no human present (run `cedd7f2eb`). Worse, it runs *after* the gate, so whenever main moved the pushed tree was never audited. Not what breaks the next run though: measured, 0 prebuild/darwin files changed between `3a2ae0ff9` and `HEAD`. Wants its own PR with a tested `scripts/commit-prebuilds.mjs`.
- **`release.yml`'s napi path.** It stages the darwin-arm64 artifact into `packages/napi/napi-darwin-arm64` and publishes with the exemption *and* the deferred README intact — so the published tarball contains the artifact while its README says it does not. Consumer-visible; a one-step follow-up.
- **The full derived reporter.** Deleting the hand-written list entirely is the sustainable end state; the accountant is what makes this interim safe rather than merely smaller.
- **The two red musl legs** (`linux-x64-musl` at `Build @gjsify/sab-native against musl`, `linux-arm64-musl` at `Checkout repository`). Not in `commit-prebuilds`' `needs`, so they never blocked the commit — but they colour the workflow red and hid the real blocker.

## How it lands

`prebuilds.yml` is a shared input, so **merging this triggers a full 10-bridge rebuild on main — that run is the one that lands the payloads and exercises the fixed tail.** No dispatch to remember. Two honest caveats: the landing run re-measures every declared floor (if a rebuild has outgrown one, the gate fails *correctly* — the #927 class), and no genuine darwin-x64 binary has been audited yet, only fabricated ones. `prebuild-artifacts` has its own print block, so unlike before, such a failure will name itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)