### PR TITLE
fix(fs): drop POSIX-only assumptions from the specs

### DIFF
--- a/packages/node/fs/src/dir.spec.ts
+++ b/packages/node/fs/src/dir.spec.ts
@@ -161,7 +161,7 @@ export default async () => {
         await it('throws if callback is not a function', async () => {
             let threw = false;
             try {
-                (opendir as any)('/tmp');
+                (opendir as any)(tmpdir());
             } catch (_e: unknown) {
                 threw = true;
             }

--- a/packages/node/fs/src/errors.spec.ts
+++ b/packages/node/fs/src/errors.spec.ts
@@ -245,7 +245,7 @@ export default async () => {
             expect(fs.existsSync('/')).toBe(true);
         });
         await it('should return true for /tmp', async () => {
-            expect(fs.existsSync('/tmp')).toBe(true);
+            expect(fs.existsSync(tmpdir())).toBe(true);
         });
         await it('should return true for tmpdir()', async () => {
             expect(fs.existsSync(tmpdir())).toBe(true);
@@ -258,7 +258,7 @@ export default async () => {
     // ===================== readdir with options =====================
     await describe('fs.readdirSync options', async () => {
         await it('should return string array by default', async () => {
-            const entries = fs.readdirSync('/tmp');
+            const entries = fs.readdirSync(tmpdir());
             expect(Array.isArray(entries)).toBe(true);
             if (entries.length > 0) {
                 expect(typeof entries[0]).toBe('string');
@@ -266,7 +266,7 @@ export default async () => {
         });
 
         await it('should return Dirent array with withFileTypes', async () => {
-            const entries = fs.readdirSync('/tmp', { withFileTypes: true });
+            const entries = fs.readdirSync(tmpdir(), { withFileTypes: true });
             expect(Array.isArray(entries)).toBe(true);
             if (entries.length > 0) {
                 const d = entries[0];
@@ -278,7 +278,7 @@ export default async () => {
         });
 
         await it('should return string with utf8 encoding', async () => {
-            const entries = fs.readdirSync('/tmp', { encoding: 'utf8' });
+            const entries = fs.readdirSync(tmpdir(), { encoding: 'utf8' });
             expect(Array.isArray(entries)).toBe(true);
             if (entries.length > 0) {
                 expect(typeof entries[0]).toBe('string');

--- a/packages/node/fs/src/extended.spec.ts
+++ b/packages/node/fs/src/extended.spec.ts
@@ -28,7 +28,7 @@ import {
     writeFile,
 } from 'node:fs';
 import * as promises from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
 
@@ -44,15 +44,17 @@ export default async () => {
             const resolved = realpathSync(filePath);
             expect(typeof resolved).toBe('string');
             expect(resolved.length).toBeGreaterThan(0);
-            // Should be an absolute path
-            expect(resolved.startsWith('/')).toBeTruthy();
+            // Should be an absolute path. `isAbsolute`, not `startsWith('/')`:
+            // the resolved value is correct on Windows too, it just begins with
+            // a drive letter, so the POSIX SHAPE check was the only thing wrong.
+            expect(isAbsolute(resolved)).toBeTruthy();
 
             rmSync(filePath);
             rmdirSync(dir);
         });
 
         await it('should resolve /tmp to its real path', async () => {
-            const resolved = realpathSync('/tmp');
+            const resolved = realpathSync(tmpdir());
             expect(typeof resolved).toBe('string');
             expect(resolved.length).toBeGreaterThan(0);
         });
@@ -77,7 +79,7 @@ export default async () => {
                 });
             });
             expect(typeof resolved).toBe('string');
-            expect(resolved.startsWith('/')).toBeTruthy();
+            expect(isAbsolute(resolved)).toBeTruthy();
 
             rmSync(filePath);
             rmdirSync(dir);
@@ -112,7 +114,7 @@ export default async () => {
         });
 
         await it('should return stats for directory', async () => {
-            const stats = await promises.stat('/tmp');
+            const stats = await promises.stat(tmpdir());
             expect(stats.isDirectory()).toBeTruthy();
             expect(stats.isFile()).toBeFalsy();
         });
@@ -519,7 +521,7 @@ export default async () => {
 
             const resolved = await promises.realpath(filePath);
             expect(typeof resolved).toBe('string');
-            expect(resolved.startsWith('/')).toBeTruthy();
+            expect(isAbsolute(resolved)).toBeTruthy();
 
             rmSync(filePath);
             rmdirSync(dir);

--- a/packages/node/fs/src/glob.spec.ts
+++ b/packages/node/fs/src/glob.spec.ts
@@ -5,12 +5,21 @@
 
 import { describe, it, expect } from '@gjsify/unit';
 import { globSync, glob, promises, mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
 function makeTmp(): string {
     return mkdtempSync(join(tmpdir(), 'gjsify-glob-'));
 }
+
+// Measured against NATIVE Node on win32-x64: `globSync` ACCEPTS a POSIX pattern
+// (`sub/*.ts` matches) but RETURNS platform-native separators
+// (`sub\\nested.ts`). Patterns therefore stay POSIX below — that is Node's
+// documented contract and reads the same everywhere — while every expected
+// RESULT goes through `r()`, which is the only part that has to vary by OS.
+// Hardcoding `'sub/nested.ts'` as an expectation was the bug: it asserted the
+// pattern dialect against the result dialect.
+const r = (posix: string) => posix.split('/').join(sep);
 
 export default async () => {
     await describe('fs.globSync', async () => {
@@ -33,7 +42,7 @@ export default async () => {
             writeFileSync(join(tmp, 'sub', 'other.txt'), '');
 
             const results = globSync('**/*.ts', { cwd: tmp });
-            expect(results.sort()).toStrictEqual(['root.ts', 'sub/nested.ts']);
+            expect(results.sort()).toStrictEqual(['root.ts', r('sub/nested.ts')]);
             rmSync(tmp, { recursive: true, force: true });
         });
 
@@ -45,7 +54,7 @@ export default async () => {
             writeFileSync(join(tmp, 'index.ts'), '');
 
             const results = globSync('src/*.ts', { cwd: tmp });
-            expect(results.sort()).toStrictEqual(['src/index.ts', 'src/util.ts']);
+            expect(results.sort()).toStrictEqual([r('src/index.ts'), r('src/util.ts')]);
             rmSync(tmp, { recursive: true, force: true });
         });
 
@@ -69,7 +78,7 @@ export default async () => {
             const results = globSync('**', { cwd: tmp });
             // Should include '.', 'a.ts', 'sub', 'sub/b.ts'
             expect(results.includes('a.ts')).toBe(true);
-            expect(results.includes('sub/b.ts')).toBe(true);
+            expect(results.includes(r('sub/b.ts'))).toBe(true);
             rmSync(tmp, { recursive: true, force: true });
         });
 
@@ -81,7 +90,7 @@ export default async () => {
 
             const results = globSync('sub/**', { cwd: tmp });
             expect(results.includes('sub')).toBe(true);
-            expect(results.includes('sub/x.ts')).toBe(true);
+            expect(results.includes(r('sub/x.ts'))).toBe(true);
             expect(results.includes('root.ts')).toBe(false);
             rmSync(tmp, { recursive: true, force: true });
         });
@@ -187,7 +196,7 @@ export default async () => {
                 results.push(match);
             }
 
-            expect(results.sort()).toStrictEqual(['index.ts', 'lib/helper.ts']);
+            expect(results.sort()).toStrictEqual(['index.ts', r('lib/helper.ts')]);
             rmSync(tmp, { recursive: true, force: true });
         });
     });

--- a/packages/node/fs/src/promises.spec.ts
+++ b/packages/node/fs/src/promises.spec.ts
@@ -17,9 +17,16 @@ import {
     stat,
     unlink,
 } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
+
+// Node on win32 returns the first created directory in EXTENDED-LENGTH form
+// (`\\?\C:\…`) from a recursive mkdir, while `join()` yields the plain form.
+// Same directory, different spelling — measured against native Node, which
+// returns the plain form on Linux. So the comparison, not the value, was the
+// POSIX-only part here.
+const plainPath = (p: string | undefined) => p?.replace(/^\\\\\?\\/, '');
 
 export default async () => {
     await describe('fs/promises', async () => {
@@ -614,7 +621,7 @@ export default async () => {
             await writeFile(file, 'data');
             const resolved = await promises.realpath(file);
             // Should be an absolute path
-            expect(resolved.startsWith('/')).toBe(true);
+            expect(isAbsolute(resolved)).toBe(true);
             // Should end with the file name
             expect(resolved.endsWith('real.txt')).toBe(true);
             await rm(file);
@@ -672,7 +679,11 @@ export default async () => {
 
     await describe('fs.promises return types', async () => {
         await it('readFile should return a Promise', async () => {
-            const p = promises.readFile('/etc/hosts');
+            // Spec-created file rather than `/etc/hosts`, which is POSIX-only.
+            const dir = await mkdtemp(join(tmpdir(), 'fs-pret-rf-'));
+            const file = join(dir, 'read.txt');
+            await promises.writeFile(file, 'data');
+            const p = promises.readFile(file);
             expect(p instanceof Promise).toBe(true);
             await p; // consume
         });
@@ -688,7 +699,7 @@ export default async () => {
         });
 
         await it('stat should return a Promise', async () => {
-            const p = stat('/tmp');
+            const p = stat(tmpdir());
             expect(p instanceof Promise).toBe(true);
             await p;
         });
@@ -702,7 +713,7 @@ export default async () => {
         });
 
         await it('access should return a Promise', async () => {
-            const p = access('/tmp', fsConstants.F_OK);
+            const p = access(tmpdir(), fsConstants.F_OK);
             expect(p instanceof Promise).toBe(true);
             await p;
         });
@@ -725,7 +736,7 @@ export default async () => {
             const result = await mkdir(nested, { recursive: true });
             // Should return the first directory created (x)
             expect(typeof result).toBe('string');
-            expect(result).toBe(join(dir, 'x'));
+            expect(plainPath(result)).toBe(join(dir, 'x'));
             expect(existsSync(nested)).toBe(true);
             await promises.rm(dir, { recursive: true });
         });

--- a/packages/node/fs/src/sync.spec.ts
+++ b/packages/node/fs/src/sync.spec.ts
@@ -24,9 +24,22 @@ import {
 import { Buffer } from 'node:buffer';
 import { tmpdir } from 'node:os';
 
+// Node on win32 returns the first created directory in EXTENDED-LENGTH form
+// (`\\?\C:\…`) from a recursive mkdir, while `join()` yields the plain form.
+// Same directory, different spelling — measured against native Node, which
+// returns the plain form on Linux. So the comparison, not the value, was the
+// POSIX-only part here.
+const plainPath = (p: string | undefined) => p?.replace(/^\\\\\?\\/, '');
+
 export default async () => {
     await describe('fs.existsSync', async () => {
-        const existingFiles = ['/tmp', '/etc/hosts'];
+        // A spec-created file, not a system one: `/etc/hosts` does not exist on
+        // Windows (it lives under %SystemRoot%\\System32\\drivers\\etc), and the
+        // test only needs "a path that exists".
+        const existingDir = mkdtempSync(join(tmpdir(), 'fs-exists-'));
+        const existingFile = join(existingDir, 'present.txt');
+        writeFileSync(existingFile, 'x');
+        const existingFiles = [tmpdir(), existingFile];
         const nonExistingFiles = ['asdasd', '/asdasd', ''];
 
         await it('should return true for existing files', () => {
@@ -119,8 +132,13 @@ export default async () => {
 
     await describe('fs.readFileSync', async () => {
         await it('should return a Buffer if no encoding was specified', () => {
-            const bufferData = readFileSync('/etc/hosts');
+            // Spec-created file rather than `/etc/hosts`, which is POSIX-only.
+            const dir = mkdtempSync(join(tmpdir(), 'fs-rfs-buf-'));
+            const filePath = join(dir, 'bytes.bin');
+            writeFileSync(filePath, 'payload');
+            const bufferData = readFileSync(filePath);
             expect(bufferData instanceof Buffer).toBeTruthy();
+            rmSync(dir, { recursive: true, force: true });
         });
 
         await it('should return a string when encoding is utf-8', () => {
@@ -254,7 +272,7 @@ export default async () => {
             const result = mkdirSync(nested, { recursive: true });
             // The first created directory should be 'a' (the top-level new dir)
             expect(typeof result).toBe('string');
-            expect(result).toBe(join(dir, 'a'));
+            expect(plainPath(result)).toBe(join(dir, 'a'));
             expect(existsSync(nested)).toBe(true);
             rmSync(dir, { recursive: true });
         });

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -34,45 +34,42 @@ only its specs have been.
 **Note for anyone re-measuring:** a hand-created `C:\tmp` makes the module-load
 failure vanish without fixing anything (one existed on the test VM for several
 hours and hid exactly this). It has been removed there. Do not re-create it.
-### `@gjsify/fs` on Windows — 24 failures that only became visible once the runner stopped dying
+### `@gjsify/fs` on Windows — 10 assertions win32 cannot satisfy
 
-Making `@gjsify/unit` report an assertion thrown from a host callback turned the
-`@gjsify/fs` Node suite on `win32-x64` from "144 lines, dead process, no summary,
-1 of 19 spec modules reached" into "611 tests, 24 failures, exit 1". None of the
-24 is new; all 24 were unreachable behind the crash.
+Everything mechanical here is FIXED. What remains is one honest residue: ten
+assertions that encode a concept Windows does not have, so no spec edit can make
+them pass.
 
-**All 24 are SPEC bugs, not impl gaps, and that is structural rather than a
-guess:** `@gjsify/fs` declares `runtimes.node: "none"`, so `test:node` does not
-alias `node:fs` to our polyfill — the specs run against NATIVE Node fs. Per the
-testing rules, a `test:node` failure means the TEST is wrong; native Node's
-`realpathSync` and `chmod` are not in question. So the work is correcting POSIX
-assumptions, with Node's own behaviour on Windows as the oracle. Do NOT go
-looking for an impl bug here — an earlier version of this entry guessed
-"`realpath` looks like a genuine impl gap" and was simply wrong: the assertion is
-`expect(resolved.startsWith('/')).toBeTruthy()`.
+History worth keeping, because both numbers were wrong once. Making
+`@gjsify/unit` report an assertion thrown from a host callback turned this suite
+from "144 lines, dead process, no summary, 1 of 19 spec modules reached" into a
+full run — first measured at 24 failures, which was itself understated: a
+hand-created `C:\tmp` on the test VM was masking 8 more. **32 is the clean-host
+baseline**; 22 of those were spec bugs and are gone (see the `fix(fs)` commit for
+the five classes).
 
-Measured on the win11-gjsify test VM (Node 24.18.1), and they fall into five
-classes, not 24 problems:
+That the surviving 10 are not impl gaps is structural, not a judgement:
+`@gjsify/fs` declares `runtimes.node: "none"`, so `test:node` never aliases
+`node:fs` to our polyfill — those specs run against NATIVE Node fs, and per the
+testing rules a failure there means the TEST is wrong. Measured on the
+win11-gjsify VM (Node 24.18.1):
 
-- **POSIX mode bits (7)** — `chmod`/`chmodSync`/`fchmodSync`/`promises.chmod`
-  specs assert `0o644`/`0o600`/`0o640` and read back `0o666`. NTFS carries no
-  POSIX permission bits; Node reports `0o666` (`0o444` read-only). The specs, not
-  the impl, encode the POSIX assumption.
-- **POSIX absolute-path shape asserted (5)** — `realpathSync`, `realpath` and
-  `promises.realpath` specs assert `resolved.startsWith('/')`, which no Windows
-  path satisfies. The values returned are correct; the shape check is what is
-  POSIX-only. `isAbsolute()` from `node:path` is the portable spelling.
-- **POSIX absolute paths hardcoded in specs (3)** — `/etc/hosts` and `/dev/null`
-  resolve to `C:\etc\hosts` / `C:\dev\null` and `ENOENT`. Same class the
-  `@gjsify/child_process` specs hit with `realpathSync('/tmp')`.
-- **glob separators (5)** — specs expect `sub/nested.ts`, Node's `fs.glob`
-  yields `sub\nested.ts`. Decide deliberately whether the contract is POSIX-
-  normalised or platform-native, then fix one side.
-- **remainder (4)** — `existsSync` on an existing file, `statSync().size` zero,
-  `mkdirSync`/`promises.mkdir` recursive return value, missing mode constants.
+- **POSIX mode bits (6)** — `chmod`/`chmodSync`/`fchmodSync`/`promises.chmod`
+  assert `0o644`/`0o600`/`0o640` and read back `0o666`. NTFS carries no POSIX
+  permission bits; Node reports `0o666` (`0o444` read-only).
+- **a stat-able character device (1)** — `statSync('/dev/null').isCharacterDevice()`.
+  Windows has no path that stats as one.
+- **directory `size > 0` (2)** — `statSync(dir).size` is 0 on Windows.
+- **`S_IRUSR`-style mode constants (1)** — absent from `fs.constants` on Windows.
 
-A shared path-form helper covers classes 2, 3 and 4 — they are all one question
-(POSIX shape vs `node:path`). Classes 1 and 5 are per-assertion work.
+The sanctioned tool for declaring these is `it.failing`'s `when` option, so each
+keeps RUNNING, is tolerated only on win32, and fails the run the day it starts
+passing — rather than being guarded away and forgotten. NOT a platform `if`, and
+NOT a warning: both give up the self-retiring half.
+
+**Note for anyone re-measuring:** do not create `C:\tmp` to make things pass. It
+masks a real defect (that is how the 8 stayed hidden), and it has been removed
+from the VM.
 
 ### Bun DID hard-crash in the N-API teardown class — the first one, and the note that predicted it asked to be told
 


### PR DESCRIPTION
## What this fixes

`@gjsify/fs` declares `runtimes.node: "none"`, so `test:node` runs these specs against **native Node** — a failure there means the *test* is wrong, structurally, not the impl. On `win32-x64` 32 of them were, in five mechanical ways:

| Class | Was | Is |
|---|---|---|
| absolute-path **shape** | `expect(resolved.startsWith('/'))` | `isAbsolute(resolved)` |
| glob separators | `'sub/nested.ts'` | `r('sub/nested.ts')` |
| literal `/tmp` | resolves to a nonexistent `C:\tmp` | `os.tmpdir()` |
| `/etc/hosts` as "a file that exists" | a POSIX system file | a spec-created temp file |
| recursive `mkdir` return | compared to `join()` | `plainPath()` strips `\\?\` |

Two of these came from *measuring* native Node rather than assuming:

- **glob** accepts a POSIX *pattern* (`sub/*.ts` matches) but returns **platform-native separators**. The specs were asserting the pattern dialect against the result dialect. Patterns stay POSIX — that's Node's contract and reads the same everywhere — and only expected *results* go through the helper.
- **recursive `mkdir`** returns the first created directory in **extended-length** form (`\\?\C:\…`) on win32, plain on Linux. Same directory, different spelling. I had this filed as "unexplained, needs its own look"; it turned out mechanical.

## Measured

On the `win11-gjsify` VM (Node 24.18.1), no hand-made `C:\tmp`:

| | before | after |
|---|---|---|
| failures | **32** | **10** |
| assertions run | 603 | 622 |

**Linux unchanged and green: 668 completed, exit 0.** `tsc`, `lint`, `format --check`, `audit-runtimes --check --strict` all clean.

## A number I got wrong twice

My first measurement said 24 failures. That was taken while a hand-created `C:\tmp` on the test VM masked 8 more — **32 is the clean-host baseline**, and the 22 fixed here are against that. The directory has been removed and `open-todos.md` now says not to re-create it, because it makes real defects disappear.

## The 10 left, deliberately

They encode concepts Windows does not have, so no spec edit can make them pass: POSIX mode bits (6 — `chmod` reads back `0o666`), a stat-able character device (1), directory `size > 0` (2), `S_IRUSR`-style constants (1).

They stay **failing and visible** rather than guarded away. The tool for declaring them is `it.failing`'s `when` option — a follow-up — so each keeps running, is tolerated only on win32, and fails the run the day it starts passing. A platform `if` or a warning would both give up that second half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
