### PR TITLE
test(fs): declare the ten win32 gaps as expected failures

### DIFF
--- a/packages/node/fs/src/callback.spec.ts
+++ b/packages/node/fs/src/callback.spec.ts
@@ -23,8 +23,15 @@ import {
 } from 'node:fs';
 import { constants } from 'node:fs';
 import { Buffer } from 'node:buffer';
+import { platform } from 'node:process';
 
 const TEST_DIR = './test-callback-' + Date.now();
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     await describe('fs callback API', async () => {
@@ -286,23 +293,28 @@ export default async () => {
 
         // ==================== chmod ====================
         await describe('chmod', async () => {
-            await it('should change file mode', async () => {
-                const path = TEST_DIR + '-chmod.txt';
-                await new Promise<void>((resolve, reject) => {
-                    writeFile(path, 'chmod test', (err) => {
-                        if (err) return reject(err);
-                        chmod(path, 0o644, (err2) => {
-                            if (err2) return reject(err2);
-                            stat(path, (err3, stats) => {
-                                if (err3) return reject(err3);
-                                // Check that mode includes the permission bits
-                                expect(stats.mode & 0o777).toBe(0o644);
-                                rm(path, () => resolve());
+            await it.failing(
+                'should change file mode',
+                async () => {
+                    const path = TEST_DIR + '-chmod.txt';
+                    await new Promise<void>((resolve, reject) => {
+                        writeFile(path, 'chmod test', (err) => {
+                            if (err) return reject(err);
+                            chmod(path, 0o644, (err2) => {
+                                if (err2) return reject(err2);
+                                stat(path, (err3, stats) => {
+                                    if (err3) return reject(err3);
+                                    // Check that mode includes the permission bits
+                                    expect(stats.mode & 0o777).toBe(0o644);
+                                    rm(path, () => resolve());
+                                });
                             });
                         });
                     });
-                });
-            });
+                },
+                'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+                { when: IS_WIN32 },
+            );
         });
     });
 };

--- a/packages/node/fs/src/extended.spec.ts
+++ b/packages/node/fs/src/extended.spec.ts
@@ -31,6 +31,13 @@ import * as promises from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Buffer } from 'node:buffer';
+import { platform } from 'node:process';
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     // ==================== realpathSync ====================
@@ -242,19 +249,24 @@ export default async () => {
     await describe('fs.chmodSync (paths with spaces)', async () => {
         // Same shell-out bug class as linkSync — chmod/chown used to route
         // through an unquoted shell command line too. Now native Gio attributes.
-        await it('should chmod a path containing a space and metacharacters', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod meta-');
-            const filePath = join(dir, 'mode $(x) file.txt');
-            writeFileSync(filePath, 'x');
+        await it.failing(
+            'should chmod a path containing a space and metacharacters',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod meta-');
+                const filePath = join(dir, 'mode $(x) file.txt');
+                writeFileSync(filePath, 'x');
 
-            chmodSync(filePath, 0o600);
-            expect(statSync(filePath).mode & 0o777).toBe(0o600);
-            chmodSync(filePath, 0o644);
-            expect(statSync(filePath).mode & 0o777).toBe(0o644);
+                chmodSync(filePath, 0o600);
+                expect(statSync(filePath).mode & 0o777).toBe(0o600);
+                chmodSync(filePath, 0o644);
+                expect(statSync(filePath).mode & 0o777).toBe(0o644);
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+            { when: IS_WIN32 },
+        );
     });
 
     await describe('fs.link (callback)', async () => {
@@ -329,60 +341,75 @@ export default async () => {
     // ==================== chmodSync / chmod ====================
 
     await describe('fs.chmodSync', async () => {
-        await it('should change file permissions', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod-');
-            const filePath = join(dir, 'file.txt');
-            writeFileSync(filePath, 'data');
+        await it.failing(
+            'should change file permissions',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod-');
+                const filePath = join(dir, 'file.txt');
+                writeFileSync(filePath, 'data');
 
-            chmodSync(filePath, 0o644);
-            const stats = statSync(filePath);
-            // Check permission bits (mask out file type bits)
-            expect(stats.mode & 0o777).toBe(0o644);
+                chmodSync(filePath, 0o644);
+                const stats = statSync(filePath);
+                // Check permission bits (mask out file type bits)
+                expect(stats.mode & 0o777).toBe(0o644);
 
-            chmodSync(filePath, 0o755);
-            const stats2 = statSync(filePath);
-            expect(stats2.mode & 0o777).toBe(0o755);
+                chmodSync(filePath, 0o755);
+                const stats2 = statSync(filePath);
+                expect(stats2.mode & 0o777).toBe(0o755);
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+            { when: IS_WIN32 },
+        );
     });
 
     await describe('fs.chmod (callback)', async () => {
-        await it('should change file permissions asynchronously', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod-cb-');
-            const filePath = join(dir, 'file.txt');
-            writeFileSync(filePath, 'data');
+        await it.failing(
+            'should change file permissions asynchronously',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'chmod-cb-');
+                const filePath = join(dir, 'file.txt');
+                writeFileSync(filePath, 'data');
 
-            await new Promise<void>((resolve, reject) => {
-                chmod(filePath, 0o600, (err) => {
-                    if (err) reject(err);
-                    else resolve();
+                await new Promise<void>((resolve, reject) => {
+                    chmod(filePath, 0o600, (err) => {
+                        if (err) reject(err);
+                        else resolve();
+                    });
                 });
-            });
-            const stats = statSync(filePath);
-            expect(stats.mode & 0o777).toBe(0o600);
+                const stats = statSync(filePath);
+                expect(stats.mode & 0o777).toBe(0o600);
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+            { when: IS_WIN32 },
+        );
     });
 
     // ==================== promises.chmod ====================
 
     await describe('fs.promises.chmod', async () => {
-        await it('should change file permissions', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'pchmod-');
-            const filePath = join(dir, 'file.txt');
-            writeFileSync(filePath, 'data');
+        await it.failing(
+            'should change file permissions',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'pchmod-');
+                const filePath = join(dir, 'file.txt');
+                writeFileSync(filePath, 'data');
 
-            await promises.chmod(filePath, 0o640);
-            const stats = statSync(filePath);
-            expect(stats.mode & 0o777).toBe(0o640);
+                await promises.chmod(filePath, 0o640);
+                const stats = statSync(filePath);
+                expect(stats.mode & 0o777).toBe(0o640);
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+            { when: IS_WIN32 },
+        );
     });
 
     // ==================== promises.writeFile / readFile ====================

--- a/packages/node/fs/src/fd-ops.spec.ts
+++ b/packages/node/fs/src/fd-ops.spec.ts
@@ -26,6 +26,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { platform } from 'node:process';
 
 const TMP = tmpdir();
 
@@ -34,6 +35,12 @@ function tmpFile(name: string, content = 'hello world'): string {
     writeFileSync(p, content);
     return p;
 }
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     await describe('fs fd-based operations', async () => {
@@ -115,18 +122,23 @@ export default async () => {
             }
         });
 
-        await it('fchmodSync changes file permissions', async () => {
-            const f = tmpFile('fchmod', 'x');
-            const fd = openSync(f, 'r');
-            try {
-                fchmodSync(fd, 0o600);
-                const st = fstatSync(fd);
-                expect(st.mode & 0o777).toBe(0o600);
-            } finally {
-                closeSync(fd);
-                unlinkSync(f);
-            }
-        });
+        await it.failing(
+            'fchmodSync changes file permissions',
+            async () => {
+                const f = tmpFile('fchmod', 'x');
+                const fd = openSync(f, 'r');
+                try {
+                    fchmodSync(fd, 0o600);
+                    const st = fstatSync(fd);
+                    expect(st.mode & 0o777).toBe(0o600);
+                } finally {
+                    closeSync(fd);
+                    unlinkSync(f);
+                }
+            },
+            'NTFS carries no POSIX permission bits, so Node reports 0o666 (0o444 when the read-only attribute is set) whatever mode was requested. The read-only case DOES work and is asserted unmarked elsewhere; the rest cannot be represented on win32.',
+            { when: IS_WIN32 },
+        );
 
         await it('closeSync closes the fd', async () => {
             const f = tmpFile('close', 'c');

--- a/packages/node/fs/src/new-apis.spec.ts
+++ b/packages/node/fs/src/new-apis.spec.ts
@@ -30,6 +30,13 @@ import {
 import * as promises from 'node:fs/promises';
 import { Buffer } from 'node:buffer';
 import { join } from 'node:path';
+import { platform } from 'node:process';
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     // ==================== constants ====================
@@ -52,11 +59,16 @@ export default async () => {
             expect(constants.S_IFDIR).toBeDefined();
         });
 
-        await it('should export file mode constants', async () => {
-            expect(constants.S_IRUSR).toBeDefined();
-            expect(constants.S_IWUSR).toBeDefined();
-            expect(constants.S_IXUSR).toBeDefined();
-        });
+        await it.failing(
+            'should export file mode constants',
+            async () => {
+                expect(constants.S_IRUSR).toBeDefined();
+                expect(constants.S_IWUSR).toBeDefined();
+                expect(constants.S_IXUSR).toBeDefined();
+            },
+            'The S_IRUSR/S_IWUSR/S_IXUSR family is absent from fs.constants on win32, because the permission model it describes does not exist there.',
+            { when: IS_WIN32 },
+        );
     });
 
     // ==================== renameSync ====================

--- a/packages/node/fs/src/stat.spec.ts
+++ b/packages/node/fs/src/stat.spec.ts
@@ -3,83 +3,100 @@ import { statSync, mkdtempSync, writeFileSync, rmSync, rmdirSync } from 'node:fs
 import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { platform } from 'node:process';
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     await describe('fs.statSync', async () => {
-        await it('Should return the file stat', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-stat-'));
-            const filePath = join(dir, 'test.txt');
-            writeFileSync(filePath, 'stat test data');
+        await it.failing(
+            'Should return the file stat',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-stat-'));
+                const filePath = join(dir, 'test.txt');
+                writeFileSync(filePath, 'stat test data');
 
-            const s = statSync(filePath);
+                const s = statSync(filePath);
 
-            expect(s.atime instanceof Date).toBeTruthy();
-            expect(s.atimeMs).toBeGreaterThan(0);
-            expect(s.birthtime instanceof Date).toBeTruthy();
-            expect(s.birthtimeMs).toBeGreaterThan(0);
-            expect(s.blksize).toBeGreaterThan(0);
-            expect(s.blocks).toBeGreaterThan(0);
-            expect(s.ctime instanceof Date).toBeTruthy();
-            expect(s.ctimeMs).toBeGreaterThan(0);
-            expect(s.dev).toBeGreaterThan(0);
-            expect(s.gid).toBeGreaterThan(-1);
-            expect(s.ino).toBeGreaterThan(0);
-            expect(s.mode).toBeGreaterThan(0);
-            expect(s.mtime instanceof Date).toBeTruthy();
-            expect(s.mtimeMs).toBeGreaterThan(0);
-            expect(s.nlink).toBeGreaterThan(0);
-            expect(s.rdev).toBeGreaterThan(-1);
-            expect(s.size).toBeGreaterThan(0);
-            expect(s.uid).toBeGreaterThan(-1);
-            expect(s.isBlockDevice()).toBeFalsy();
-            expect(s.isCharacterDevice()).toBeFalsy();
-            expect(s.isDirectory()).toBeFalsy();
-            expect(s.isFIFO()).toBeFalsy();
-            expect(s.isFile()).toBeTruthy();
-            expect(s.isSocket()).toBeFalsy();
-            expect(s.isSymbolicLink()).toBeFalsy();
+                expect(s.atime instanceof Date).toBeTruthy();
+                expect(s.atimeMs).toBeGreaterThan(0);
+                expect(s.birthtime instanceof Date).toBeTruthy();
+                expect(s.birthtimeMs).toBeGreaterThan(0);
+                expect(s.blksize).toBeGreaterThan(0);
+                expect(s.blocks).toBeGreaterThan(0);
+                expect(s.ctime instanceof Date).toBeTruthy();
+                expect(s.ctimeMs).toBeGreaterThan(0);
+                expect(s.dev).toBeGreaterThan(0);
+                expect(s.gid).toBeGreaterThan(-1);
+                expect(s.ino).toBeGreaterThan(0);
+                expect(s.mode).toBeGreaterThan(0);
+                expect(s.mtime instanceof Date).toBeTruthy();
+                expect(s.mtimeMs).toBeGreaterThan(0);
+                expect(s.nlink).toBeGreaterThan(0);
+                expect(s.rdev).toBeGreaterThan(-1);
+                expect(s.size).toBeGreaterThan(0);
+                expect(s.uid).toBeGreaterThan(-1);
+                expect(s.isBlockDevice()).toBeFalsy();
+                expect(s.isCharacterDevice()).toBeFalsy();
+                expect(s.isDirectory()).toBeFalsy();
+                expect(s.isFIFO()).toBeFalsy();
+                expect(s.isFile()).toBeTruthy();
+                expect(s.isSocket()).toBeFalsy();
+                expect(s.isSymbolicLink()).toBeFalsy();
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            '`stat.blocks` is 0 on win32 — Windows does not report an allocated block count (measured: 8 on Linux, 0 on win32 for the same file).',
+            { when: IS_WIN32 },
+        );
     });
 
     await describe('fs.stat (promise)', async () => {
-        await it('Should return the file stat', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-pstat-'));
-            const filePath = join(dir, 'test.txt');
-            writeFileSync(filePath, 'stat test data');
+        await it.failing(
+            'Should return the file stat',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-pstat-'));
+                const filePath = join(dir, 'test.txt');
+                writeFileSync(filePath, 'stat test data');
 
-            const s = await stat(filePath);
+                const s = await stat(filePath);
 
-            expect(s.atime instanceof Date).toBeTruthy();
-            expect(s.atimeMs).toBeGreaterThan(0);
-            expect(s.birthtime instanceof Date).toBeTruthy();
-            expect(s.birthtimeMs).toBeGreaterThan(0);
-            expect(s.blksize).toBeGreaterThan(0);
-            expect(s.blocks).toBeGreaterThan(0);
-            expect(s.ctime instanceof Date).toBeTruthy();
-            expect(s.ctimeMs).toBeGreaterThan(0);
-            expect(s.dev).toBeGreaterThan(0);
-            expect(s.gid).toBeGreaterThan(-1);
-            expect(s.ino).toBeGreaterThan(0);
-            expect(s.mode).toBeGreaterThan(0);
-            expect(s.mtime instanceof Date).toBeTruthy();
-            expect(s.mtimeMs).toBeGreaterThan(0);
-            expect(s.nlink).toBeGreaterThan(0);
-            expect(s.rdev).toBeGreaterThan(-1);
-            expect(s.size).toBeGreaterThan(0);
-            expect(s.uid).toBeGreaterThan(-1);
-            expect(s.isBlockDevice()).toBeFalsy();
-            expect(s.isCharacterDevice()).toBeFalsy();
-            expect(s.isDirectory()).toBeFalsy();
-            expect(s.isFIFO()).toBeFalsy();
-            expect(s.isFile()).toBeTruthy();
-            expect(s.isSocket()).toBeFalsy();
-            expect(s.isSymbolicLink()).toBeFalsy();
+                expect(s.atime instanceof Date).toBeTruthy();
+                expect(s.atimeMs).toBeGreaterThan(0);
+                expect(s.birthtime instanceof Date).toBeTruthy();
+                expect(s.birthtimeMs).toBeGreaterThan(0);
+                expect(s.blksize).toBeGreaterThan(0);
+                expect(s.blocks).toBeGreaterThan(0);
+                expect(s.ctime instanceof Date).toBeTruthy();
+                expect(s.ctimeMs).toBeGreaterThan(0);
+                expect(s.dev).toBeGreaterThan(0);
+                expect(s.gid).toBeGreaterThan(-1);
+                expect(s.ino).toBeGreaterThan(0);
+                expect(s.mode).toBeGreaterThan(0);
+                expect(s.mtime instanceof Date).toBeTruthy();
+                expect(s.mtimeMs).toBeGreaterThan(0);
+                expect(s.nlink).toBeGreaterThan(0);
+                expect(s.rdev).toBeGreaterThan(-1);
+                expect(s.size).toBeGreaterThan(0);
+                expect(s.uid).toBeGreaterThan(-1);
+                expect(s.isBlockDevice()).toBeFalsy();
+                expect(s.isCharacterDevice()).toBeFalsy();
+                expect(s.isDirectory()).toBeFalsy();
+                expect(s.isFIFO()).toBeFalsy();
+                expect(s.isFile()).toBeTruthy();
+                expect(s.isSocket()).toBeFalsy();
+                expect(s.isSymbolicLink()).toBeFalsy();
 
-            rmSync(filePath);
-            rmdirSync(dir);
-        });
+                rmSync(filePath);
+                rmdirSync(dir);
+            },
+            '`stat.blocks` is 0 on win32 — Windows does not report an allocated block count (measured: 8 on Linux, 0 on win32 for the same file).',
+            { when: IS_WIN32 },
+        );
     });
 };

--- a/packages/node/fs/src/sync.spec.ts
+++ b/packages/node/fs/src/sync.spec.ts
@@ -23,6 +23,7 @@ import {
 } from 'node:fs';
 import { Buffer } from 'node:buffer';
 import { tmpdir } from 'node:os';
+import { platform } from 'node:process';
 
 // Node on win32 returns the first created directory in EXTENDED-LENGTH form
 // (`\\?\C:\…`) from a recursive mkdir, while `join()` yields the plain form.
@@ -30,6 +31,12 @@ import { tmpdir } from 'node:os';
 // returns the plain form on Linux. So the comparison, not the value, was the
 // POSIX-only part here.
 const plainPath = (p: string | undefined) => p?.replace(/^\\\\\?\\/, '');
+
+// Assertions below marked `it.failing(..., { when: IS_WIN32 })` describe POSIX
+// concepts win32 does not have. The marker keeps them RUNNING and keeps the
+// assertion unweakened; it tolerates the failure only here, and fails the run the
+// day it starts passing — unlike a platform guard, which would hide it forever.
+const IS_WIN32 = platform === 'win32';
 
 export default async () => {
     await describe('fs.existsSync', async () => {
@@ -423,15 +430,20 @@ export default async () => {
             rmdirSync(dir);
         });
 
-        await it('statSync should detect isCharacterDevice for /dev/null', () => {
-            const s = statSync('/dev/null');
-            expect(s.isCharacterDevice()).toBe(true);
-            expect(s.isFile()).toBe(false);
-            expect(s.isDirectory()).toBe(false);
-            expect(s.isSocket()).toBe(false);
-            expect(s.isFIFO()).toBe(false);
-            expect(s.isBlockDevice()).toBe(false);
-        });
+        await it.failing(
+            'statSync should detect isCharacterDevice for /dev/null',
+            () => {
+                const s = statSync('/dev/null');
+                expect(s.isCharacterDevice()).toBe(true);
+                expect(s.isFile()).toBe(false);
+                expect(s.isDirectory()).toBe(false);
+                expect(s.isSocket()).toBe(false);
+                expect(s.isFIFO()).toBe(false);
+                expect(s.isBlockDevice()).toBe(false);
+            },
+            "win32 has no path that stats as a character device — there is no /dev/null, and \\\\.\\NUL does not report S_IFCHR through Node's stat.",
+            { when: IS_WIN32 },
+        );
     });
 
     await describe('fs.FSWatcher ref/unref', async () => {

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -34,43 +34,6 @@ only its specs have been.
 **Note for anyone re-measuring:** a hand-created `C:\tmp` makes the module-load
 failure vanish without fixing anything (one existed on the test VM for several
 hours and hid exactly this). It has been removed there. Do not re-create it.
-### `@gjsify/fs` on Windows — 10 assertions win32 cannot satisfy
-
-Everything mechanical here is FIXED. What remains is one honest residue: ten
-assertions that encode a concept Windows does not have, so no spec edit can make
-them pass.
-
-History worth keeping, because both numbers were wrong once. Making
-`@gjsify/unit` report an assertion thrown from a host callback turned this suite
-from "144 lines, dead process, no summary, 1 of 19 spec modules reached" into a
-full run — first measured at 24 failures, which was itself understated: a
-hand-created `C:\tmp` on the test VM was masking 8 more. **32 is the clean-host
-baseline**; 22 of those were spec bugs and are gone (see the `fix(fs)` commit for
-the five classes).
-
-That the surviving 10 are not impl gaps is structural, not a judgement:
-`@gjsify/fs` declares `runtimes.node: "none"`, so `test:node` never aliases
-`node:fs` to our polyfill — those specs run against NATIVE Node fs, and per the
-testing rules a failure there means the TEST is wrong. Measured on the
-win11-gjsify VM (Node 24.18.1):
-
-- **POSIX mode bits (6)** — `chmod`/`chmodSync`/`fchmodSync`/`promises.chmod`
-  assert `0o644`/`0o600`/`0o640` and read back `0o666`. NTFS carries no POSIX
-  permission bits; Node reports `0o666` (`0o444` read-only).
-- **a stat-able character device (1)** — `statSync('/dev/null').isCharacterDevice()`.
-  Windows has no path that stats as one.
-- **directory `size > 0` (2)** — `statSync(dir).size` is 0 on Windows.
-- **`S_IRUSR`-style mode constants (1)** — absent from `fs.constants` on Windows.
-
-The sanctioned tool for declaring these is `it.failing`'s `when` option, so each
-keeps RUNNING, is tolerated only on win32, and fails the run the day it starts
-passing — rather than being guarded away and forgotten. NOT a platform `if`, and
-NOT a warning: both give up the self-retiring half.
-
-**Note for anyone re-measuring:** do not create `C:\tmp` to make things pass. It
-masks a real defect (that is how the 8 stayed hidden), and it has been removed
-from the VM.
-
 ### Bun DID hard-crash in the N-API teardown class — the first one, and the note that predicted it asked to be told
 
 `scripts/cross-runtime.mjs` carves Deno out of exit-code gating for the


### PR DESCRIPTION
## The `@gjsify/fs` suite is green on Windows

```
win32:  622 completed, 10 expected failures, exit 0
linux:  668 completed,  0 expected failures, exit 0
```

Without weakening a single assertion.

#952 fixed everything mechanical (32 → 10). The ten left are neither spec bugs nor impl gaps: each asserts a POSIX concept Windows does not have, so no edit can make them pass. They are now **declared** with `it.failing(..., { when: IS_WIN32 })` (#953), which keeps them running, tolerates the failure only on win32, and **fails the run the day it starts passing**.

**The Linux line is the half that matters most.** With `when: false` each marker is an ordinary `it()`, so all ten still run and must pass there. A platform guard would have deleted that coverage on both platforms; a skip would have hidden it.

## What each group is — measured, not assumed

| group | why win32 cannot satisfy it |
|---|---|
| POSIX mode bits (6) | NTFS carries no permission bits; Node reports `0o666` whatever was requested |
| `stat.blocks` (2) | 0 on win32 — Windows reports no allocated block count (probed: **8** on Linux, **0** on win32, same file) |
| character device (1) | no path stats as `S_IFCHR`; there is no `/dev/null` |
| `S_IRUSR` family (1) | absent from `fs.constants` on win32 |

Two corrections came out of measuring rather than pattern-matching:

- **One chmod test is deliberately NOT marked.** `promises.spec.ts` asserts `0o444` and **passes** on Windows — the read-only attribute is the one POSIX bit NTFS can represent. The marker set is as narrow as the platform actually forces, not as wide as the category suggests.
- **`stat.blocks`, not "directory size".** I had two of these filed as `size > 0`. Probing the stat fields showed `size` is fine and `blocks` is the zero. The reason strings say the measured thing.

## The marker set is self-checking

This is how I know it is exactly right: had I marked a test that actually passes, `it.failing` would have failed the run with **"passed unexpectedly"**. It did not, on either platform. That property is what made a ten-marker change across six files safe to do mechanically.

## `open-todos.md`

The fs win32 entry is **deleted**, per the file's own delete-on-resolve rule — the record is the commit. Safe here for a reason specific to `it.failing`: the markers are self-retiring, so if win32 ever gains one of these capabilities the suite fails and names the marker to remove. That is a better tracker than a TODO entry nobody re-reads.

## Verified

`audit-runtimes --check --strict`, `tsc`, `lint`, `format --check` all green; suite re-run on both platforms after formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
