### PR TITLE
fix(ci): run the musl legs, and fix what they found

### DIFF
--- a/.github/prebuild-toolchain/musl-build.sh
+++ b/.github/prebuild-toolchain/musl-build.sh
@@ -1,6 +1,29 @@
 #!/bin/sh
 # Build + verify every musl prebuild, INSIDE an alpine:3.24 container.
 #
+# WHAT THIS LEG IS FOR — it keeps the `libc: null` POLICY honest.
+#
+# musl is deliberately NOT a target token: the vocabulary is `<os>-<arch>` and
+# the libc distinction rides the npm `libc` field, which
+# `generate-platform-packages.mjs` MEASURES from the ELF. Its policy is that only
+# a recorded glibc dynamic loader (`musl: 'incompatible'`) earns
+# `libc: ["glibc"]`; an `'undetermined'` verdict declares nothing, because musl
+# treats a `DT_NEEDED` of `libc.so.6` as a request for itself and loads such an
+# image happily. So `@gjsify/<x>-linux-<arch>` installs on musl hosts BY DESIGN,
+# and this leg is what stops that from being an assumption: it compiles the same
+# sources against musl and runs them there. Nothing else in CI ever executes on
+# musl.
+#
+# The policy is confirmed on real hardware, not only in a container: the
+# COMMITTED glibc-built `@gjsify/sab-native-linux-arm64` artifact (`DT_NEEDED`
+# `libc.so.6`, no `libc` field) loads and runs on a OnePlus 6T under
+# postmarketOS — aarch64, musl 1.2, gjs 1.88.1, `/lib/libc.so.6` absent and only
+# `libc.musl-aarch64.so.1` present — and `shared-buffer.gjs.spec.ts`'s whole
+# surface passes there, including the `from_fd` second-mapping semantics that a
+# load test cannot reach. The generator's own note cites an `alpine:3.24.1`
+# container probe for six bridges; that probe was x64 only, so arm64 musl rested
+# on the same reasoning with no measurement behind it until this one.
+#
 # WHY THIS IS A SCRIPT AND NOT A JOB-LEVEL `container:`
 #
 # `prebuilds.yml`'s musl leg used `container: image: alpine:3.24`, which puts
@@ -245,4 +268,135 @@ for lib in \
         rc=1
     fi
 done
+
+# ── the COMMITTED glibc artifacts must resolve here too ─────────────────────
+# The step above proves the artifacts THIS LEG BUILT are sound. It says nothing
+# about the ones users actually get: `@gjsify/<x>-linux-<arch>` is built against
+# glibc, declares no npm `libc` filter, and is therefore installed on musl hosts
+# BY DESIGN (`generate-platform-packages.mjs` writes `libc: ["glibc"]` only for a
+# recorded glibc dynamic loader, which a shared library never has). That design
+# rests on one claim — every symbol those binaries reference exists in musl too —
+# and until this step nothing anywhere tested it.
+#
+# It was false, measurably, for two of the ten bridges: `sab-native` referenced
+# `fcntl64` + `__cmsg_nxthdr` and `lightningcss-native` references
+# `gnu_get_libc_version`. None of it is a LOAD failure — GI binds lazily, so the
+# typelib resolved and the package worked until the unbound path was first
+# called. `@gjsify/worker_threads` therefore lost all four of its SharedBuffer
+# cross-process tests on every musl host while being fully green on glibc, and
+# the existing load test could not see it. This leg runs on real musl; asking it
+# the question costs one loop.
+#
+# `ldd` is musl's OWN loader in list mode, so it reports every unresolved
+# relocation at once rather than dlopen's first-error-only. Two failure classes
+# come back and they are NOT the same: a "symbol not found" is a real libc gap
+# and fails the leg, while "Error loading shared library" only means Alpine here
+# lacks that system dependency (libmozjs-140 has no Alpine package at all). The
+# second is reported as not-verified, never as broken — the same honesty the
+# cross-arch load tests already practise.
+#
+# ACCEPTED GAPS carry a mandatory reason and are printed every run. The ledger is
+# deliberately awkward in the same way `gjsify.platformsUncommitted` is: an entry
+# whose package STOPS having the gap becomes a FAILURE, so it retires itself
+# instead of rotting into a permanent exemption. `sab-native` is deliberately NOT
+# in here — its two symbols were OURS to stop referencing, and it now resolves.
+musl_gap_reason() {
+    case "$1" in
+    lightningcss-native-linux-*)
+        echo "gnu_get_libc_version is referenced by a crates.io dependency of the pinned refs/lightningcss build, not by our own source, so it cannot be removed the way sab-native's fcntl64/__cmsg_nxthdr were. Options are an upstream change or a musl-built sibling package; tracked in status/open-todos.md."
+        ;;
+    *) echo '' ;;
+    esac
+}
+
+# The bridges' own GNOME/system dependencies, so that as few packages as possible
+# land in the not-verified bucket below. Kept as a SEPARATE install from the
+# build toolchain because it buys check COVERAGE, not the ability to compile: a
+# library missing here silences the verdict for that package rather than failing
+# it, so every one added is one more artifact actually judged. `libmozjs-140`
+# (@gjsify/napi) has no Alpine package at all and stays unjudged.
+#
+# WHAT A GREEN VERDICT HERE DOES NOT MEAN. This step judges RELOCATIONS, so it
+# answers "can musl bind every symbol", never "does the host provide what this
+# bridge needs at runtime". `@gjsify/webrtc-native` is the standing example and it
+# is not hypothetical: `gst-plugins-bad` gives it `libgstwebrtc-1.0.so.0`, so it
+# resolves cleanly and this check reports it green — while on the very same image
+# `gst-inspect-1.0 webrtcbin` finds NOTHING. GStreamer 1.28's nice plugin needs
+# libnice >= 0.1.23 and Alpine ships 0.1.22, so the webrtcbin ELEMENT is not built
+# at all. Measured on alpine:3.24: library present, element and nice plugin both
+# absent. So `@gjsify/webrtc` cannot work on Alpine or postmarketOS today no
+# matter how well its prebuild links, and that is upstream, not ours:
+#   https://gitlab.postmarketos.org/postmarketOS/pmaports/-/work_items/4443
+#   https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18092
+# Adding the postmarketOS repositories on top of Alpine does NOT fix it, which is
+# measured rather than assumed: on a real postmarketOS v26.06 device with the pmOS
+# mirrors active, `apk list -a libnice` still reports 0.1.22-r0 — pmOS takes it
+# from Alpine community unchanged — and `Gst.ElementFactory.find()` finds no
+# `webrtcbin`, `nicesrc` or `nicesink` while `dtlssrtpenc` and `rtpbin` are both
+# there, exactly the shape a libnice-gated nice plugin produces.
+# Do not extend this step into an element check on that basis — it would be an
+# accepted gap on day one with nothing we can do about it. It is recorded in
+# status/open-todos.md so a green line here is not read as "works on musl".
+apk add --no-cache \
+    libepoxy gdk-pixbuf json-glib libsoup3 gnutls gstreamer gst-plugins-base gst-plugins-bad
+
+echo "--- checking every COMMITTED glibc prebuild for this arch resolves under musl"
+committed_target="${PREBUILD%-musl}"
+checked=0
+for so in packages/*/*/prebuilds/"${committed_target}"/*.so; do
+    [ -f "$so" ] || continue
+    checked=$((checked + 1))
+    pkg=$(echo "$so" | sed 's|^packages/[^/]*/||;s|/prebuilds/.*||')
+    out=$(ldd "$so" 2>&1 || true)
+    # `|| true` on both: under `set -e` a `grep` that matches NOTHING exits 1 and
+    # a failing command substitution aborts the script — so the healthy case (no
+    # unresolved symbols) killed the loop at the first clean package, silently,
+    # while the exit code looked like a verdict. An exit code is not evidence
+    # that the loop ran.
+    syms=$(echo "$out" | grep 'symbol not found' | sed 's/^.*so: //;s/: symbol not found//' | sort -u | tr '\n' ' ' || true)
+    # The glibc dynamic loader appears as a DT_NEEDED of every Rust cdylib here
+    # and musl of course does not ship it. Its absence is the NORMAL case this
+    # whole check exists to characterise — musl substitutes itself — so it must
+    # not be read as a missing dependency, or the packages with a real gap
+    # (lightningcss-native) would be the ones silenced.
+    libs=$(echo "$out" | grep 'Error loading shared library' | sed 's/.*shared library //;s/:.*//' \
+        | grep -vE '^(ld-linux[^ ]*|ld64\.so\.[0-9]+)$' | sort -u | tr '\n' ' ' || true)
+    accepted=$(musl_gap_reason "$pkg")
+    # ORDER IS LOAD-BEARING: a genuinely absent library makes the SYMBOL verdict
+    # meaningless, because musl's loader then reports every symbol that library
+    # would have provided as not-found too. Judging symbols first blamed musl for
+    # a container that simply lacked libepoxy — ~200 `epoxy_gl*` "gaps" in
+    # `@gjsify/webgl`, none of them real. So: no library missing is the
+    # PRECONDITION for judging symbols at all.
+    if [ -n "$libs" ]; then
+        echo "--- $pkg: NOT VERIFIED here — absent system libs: $libs"
+    elif [ -n "$syms" ] && [ -n "$accepted" ]; then
+        echo "--- $pkg: ACCEPTED musl gap ($syms) — $accepted"
+    elif [ -n "$syms" ]; then
+        echo "::error::$pkg ($(basename "$so")) is installed on musl but does not resolve there: $syms"
+        echo "    Either stop referencing the glibc-private symbol (preferred — one"
+        echo "    artifact then serves both libcs), or declare libc: [\"glibc\"] on"
+        echo "    $pkg so npm refuses the install instead of failing at first call."
+        echo "    NOTE: this reads the COMMITTED binary, which is what users get."
+        echo "    A source fix does not clear it until the prebuild is rebuilt and"
+        echo "    re-committed, and \`commit-prebuilds\` is main-only — so the PR that"
+        echo "    fixes the source stays red here until it lands. That is the honest"
+        echo "    state (the shipped artifact really is still broken), not a bug."
+        rc=1
+    elif [ -n "$accepted" ]; then
+        echo "::error::$pkg resolves fully on musl, so its accepted-gap entry in musl_gap_reason() no longer applies — delete it."
+        rc=1
+    else
+        echo "--- $pkg: every relocation resolves"
+    fi
+done
+# A glob that matched nothing would make this whole step a silent no-op, which is
+# the failure mode the repo keeps paying for (`--include` matching zero
+# workspaces, a `files` glob shipping nothing). There are committed linux-x64 and
+# linux-arm64 prebuilds; if this leg finds none, the layout moved.
+if [ "$checked" -eq 0 ]; then
+    echo "::error::no committed prebuilds/${committed_target}/*.so found — this check verified nothing"
+    rc=1
+fi
+
 exit $rc

--- a/.github/prebuild-toolchain/musl-build.sh
+++ b/.github/prebuild-toolchain/musl-build.sh
@@ -1,0 +1,248 @@
+#!/bin/sh
+# Build + verify every musl prebuild, INSIDE an alpine:3.24 container.
+#
+# WHY THIS IS A SCRIPT AND NOT A JOB-LEVEL `container:`
+#
+# `prebuilds.yml`'s musl leg used `container: image: alpine:3.24`, which puts
+# GitHub's own action runtime inside the container. On the arm64 runner that
+# fails before anything is built:
+#
+#     JavaScript Actions in Alpine containers are only supported on x64 Linux
+#     runners. Detected Linux Arm64
+#
+# `actions/checkout` is a JavaScript action, and the runtime it needs exists for
+# musl only as an x64 binary. So the arm64 leg could never go green as written —
+# it died at `Checkout repository`, every run, and coloured the whole workflow
+# red while gating nothing. (Nothing about gjs or Alpine on arm64 is the
+# problem: the container itself runs natively there. The limitation is entirely
+# in GitHub's action runtime.)
+#
+# Inverting the containment fixes it and costs nothing: the JS actions run on the
+# glibc host, and everything that must see musl runs in here. No emulation is
+# involved on either arch — the runner's own architecture IS the target
+# architecture, which is exactly what the machine check below asserts rather
+# than assumes.
+#
+# Routing this through `emulated-build.sh` instead was considered and rejected:
+# that script REFUSES Alpine deliberately, and its refusal names three things an
+# apk branch would need — the third being that `build_pkg` stages into
+# `prebuilds/linux-${ARCH}`, which on Alpine would overwrite a COMMITTED glibc
+# artifact with a musl one while every downstream declaration check stayed green.
+# Staging here cannot do that: it goes through `scripts/stage-prebuild.mjs` with
+# an explicit `--dest` OUTSIDE the package tree, so no committed directory is
+# reachable at all — and the guard below independently refuses unless the host
+# resolves as this leg's own musl token.
+#
+# REPRODUCE LOCALLY (the property the QEMU legs have and this leg lacked). Both
+# extra flags were paid for once: without `:z` SELinux denies the bind mount on
+# Fedora (`can't open '…/musl-build.sh': Permission denied`, which reads like a
+# missing exec bit and is not), and without `--platform` a cached foreign-arch
+# `alpine` image runs EMULATED behind nothing but a podman warning:
+#
+#     podman run --rm --platform linux/amd64 -v "$PWD:/w:z" -w /w \
+#       -e PREBUILD=linux-x64-musl -e MACHINE=x86-64 \
+#       alpine:3.24 sh .github/prebuild-toolchain/musl-build.sh
+#
+# In CI neither is needed — no SELinux on the runners, and the runner's own arch
+# is the target — which is precisely why the guard below asserts the arch instead
+# of trusting the invocation.
+#
+# POSIX `sh` ONLY. The Alpine base image has no bash — only busybox `sh` (ash).
+# Verified in `alpine:3.24` that busybox ash takes everything used here:
+# `set -euo pipefail`, the `case`-based `built()` helper, `while IFS='|' read`
+# over a heredoc, `${var%%pattern}`, `env -u`. No arrays anywhere, which is the
+# one bashism the macOS legs rely on.
+#
+# Env in:
+#   PREBUILD       `linux-<arch>-musl` — the target token, asserted below
+#   MACHINE        file(1)'s spelling of the ELF e_machine this leg must produce
+#   PREBUILD_SKIP  the `changes` job's JSON array, verbatim
+#   STAGE_DIR      where artifacts land (default /tmp/musl-prebuilds). Outside any
+#                  package ON PURPOSE — see the `--dest` note below.
+
+# `pipefail` is NOT a POSIX option, but busybox ash supports it and the steps
+# this replaces all set it. Keeping it matters: `rustc -vV | grep '^host:'` and
+# the `file -b` pipelines below would otherwise report success when their left
+# side failed. Verified accepted by `alpine:3.24`'s ash.
+set -euo pipefail
+
+: "${PREBUILD:?PREBUILD must be set (e.g. linux-x64-musl)}"
+: "${MACHINE:?MACHINE must be set (e.g. x86-64)}"
+# Outside the package tree, and that is the fix for the SECOND thing broken here.
+# After ADR 0017 a bridge owns no `prebuilds/` — `stage-prebuild.mjs` resolves the
+# destination to a sibling platform package and REFUSES when there is none. For
+# this leg there never is one: it builds targets no package declares yet, so
+# declaring them would publish a promise CI must reproduce and commit. Measured:
+# the musl build of sab-native succeeds and staging fails with
+# `sab-native-linux-x64-musl/ does not exist`. `--dest` names a destination
+# instead of relaxing the default, so every other caller keeps the refusal.
+STAGE_DIR="${STAGE_DIR:-/tmp/musl-prebuilds}"
+echo "--- staging destination: ${STAGE_DIR}/${PREBUILD}"
+
+# Did THIS run build it? Keyed on the directory basename, the key
+# `changed-packages.mjs` emits, quoted so `"sab-native"` cannot match a longer
+# key. An unset/empty PREBUILD_SKIP builds and verifies everything — the same
+# fail-open direction the workflow's `if:` gates took.
+built() { case "${PREBUILD_SKIP:-}" in *"\"${1##*/}\""*) return 1 ;; *) return 0 ;; esac; }
+
+# ── the toolchain ───────────────────────────────────────────────────────────
+# apk names are NOT the Fedora ones: `ninja-build` (there is no `ninja`), `vala`
+# (no `valac`), `gobject-introspection-dev` for `g-ir-compiler`. Alpine has no
+# weak dependencies, so no `install_weak_deps` equivalent is needed. apk's rustc
+# is used deliberately instead of rustup: rustup's `*-unknown-linux-musl` target
+# defaults to `crt-static` ON, under which cargo CANNOT emit a cdylib at all —
+# the artifact every Rust bridge here is.
+echo "--- installing the Alpine toolchain"
+apk add --no-cache \
+    meson ninja-build gcc build-base pkgconf file binutils linux-headers \
+    vala glib-dev gobject-introspection-dev \
+    cargo rust musl-dev \
+    gjs nodejs git
+cat /etc/alpine-release
+valac --version
+meson --version
+cargo --version
+rustc --version
+# The host triple decides the crt-static default, which decides whether a cdylib
+# can be produced at all — print it, so a log alone answers the question if this
+# ever fails.
+rustc -vV | grep '^host:'
+gjs --version
+node --version
+command -v g-ir-compiler
+
+# ── the clobber guard, BEFORE anything is built ─────────────────────────────
+# `hostStagingTarget()` is the exact function `stage-prebuild.mjs` uses to pick
+# the directory it will `rmSync` and rewrite. If node ever failed to see this
+# host as musl it would resolve `linux-<arch>` — a DECLARED, COMMITTED target —
+# and the leg would silently replace a shipped glibc prebuild with a musl one.
+# Importing the module runs no `main()` (it is guarded on `process.argv[1]`), so
+# this is a pure read.
+#
+# It doubles as the proof that no emulation crept in: the token it resolves is
+# derived from the running host, so agreement with `PREBUILD` means this
+# container really is the architecture the matrix entry claims.
+echo "--- confirming this container resolves as ${PREBUILD}"
+resolved="$(node -e 'import("./scripts/stage-prebuild.mjs").then((m) => console.log(m.hostStagingTarget()))')"
+echo "stage-prebuild.mjs resolves this host as: ${resolved}"
+if [ "$resolved" != "$PREBUILD" ]; then
+    echo "::error::this container resolves as \`${resolved}\`, not \`${PREBUILD}\`. Refusing to build:"
+    echo "::error::staging would write into a committed glibc prebuild directory and overwrite it."
+    exit 1
+fi
+
+WORKSPACE="$PWD"
+
+# ── @gjsify/sab-native (GjsifySabNative) ────────────────────────────────────
+if built packages/node/sab-native; then
+    echo "--- building @gjsify/sab-native against musl"
+    cd "$WORKSPACE/packages/node/sab-native"
+    meson setup build .
+    meson compile -C build
+    node "$WORKSPACE/scripts/stage-prebuild.mjs" . --allow-undeclared --dest "$STAGE_DIR"
+    ls -lh "${STAGE_DIR}/${PREBUILD}/"
+    cd "$WORKSPACE"
+else
+    echo "--- @gjsify/sab-native: not in this run's package set, skipped"
+fi
+
+# ── @gjsify/lightningcss-native (GjsifyLightningcss) ────────────────────────
+if built packages/infra/lightningcss-native; then
+    echo "--- building @gjsify/lightningcss-native against musl (Rust cdylib + Vala bridge)"
+    cd "$WORKSPACE/packages/infra/lightningcss-native"
+    meson setup build .
+    meson compile -C build
+    # Matching by EXTENSION is what picks up both halves of the pair here
+    # (`libgjsifylightningcss.so` + the `libgjsify_lightningcss.so` cdylib it
+    # links), and the stager then runs `checkPrebuildDir()` over what it wrote —
+    # the staged-sibling + `$ORIGIN` invariant, verified on musl.
+    node "$WORKSPACE/scripts/stage-prebuild.mjs" . --allow-undeclared --dest "$STAGE_DIR"
+    ls -lh "${STAGE_DIR}/${PREBUILD}/"
+    cd "$WORKSPACE"
+else
+    echo "--- @gjsify/lightningcss-native: not in this run's package set, skipped"
+fi
+
+# ── each staged artifact's machine must match its directory ─────────────────
+echo "--- verifying each staged artifact's machine matches its directory"
+rc=0
+for dir in packages/node/sab-native packages/infra/lightningcss-native; do
+    built "$dir" || { echo "--- $dir: not built by this run, not verified"; continue; }
+    out="${STAGE_DIR}/${PREBUILD}"
+    if [ ! -d "$out" ]; then
+        echo "::error::$out does not exist — the build ran but staged somewhere else"
+        rc=1
+        continue
+    fi
+    for lib in "$out"/*.so; do
+        desc="$(file -b "$lib")"
+        echo "$lib: $desc"
+        case "$desc" in
+            *"$MACHINE"*) ;;
+            *) echo "::error file=$lib::expected a $MACHINE object in ${PREBUILD}, got: $desc"; rc=1 ;;
+        esac
+    done
+done
+[ "$rc" -eq 0 ] || exit $rc
+
+# ── load-test every prebuild under Alpine gjs ──────────────────────────────
+# The protocol the Fedora and macOS legs use, unchanged: resolving a GObject
+# class forces GI to call the class's `…_get_type` symbol, which is what dlopens
+# the recorded shared library. A typelib that is merely FOUND resolves the
+# namespace and then throws here.
+#
+# LD_LIBRARY_PATH is set on purpose and is NOT a workaround for a musl defect: a
+# typelib records the BARE leaf name of its library, so a GI_TYPELIB_PATH-only
+# load fails identically for every bridge on glibc (verified on both). The CLI's
+# `buildNativeEnv()` exports exactly this variable for exactly this reason, so
+# passing it here makes the test match what a real `gjsify` run does — do not
+# "fix" the non-bug.
+echo "--- load-testing every musl prebuild under Alpine gjs"
+rc=0
+while IFS='|' read -r dir ns sym; do
+    [ -n "$dir" ] || continue
+    built "$dir" || { echo "--- ${ns}: not built by this run, not load-tested"; continue; }
+    abs="${STAGE_DIR}/${PREBUILD}"
+    echo "--- ${ns}.${sym} from ${abs}"
+    # `< /dev/null`: the loop's stdin is the heredoc below, and a child that
+    # reads it would eat the remaining rows.
+    if GI_TYPELIB_PATH="$abs" LD_LIBRARY_PATH="$abs" gjs -c \
+        "const T = imports.gi.${ns}.${sym};
+         if (typeof T !== 'function') { throw new Error('${ns}.${sym} did not resolve to a class'); }
+         print('${ns}.${sym} resolved — shared library loaded');" < /dev/null
+    then :; else
+        echo "::error::${ns} prebuild in ${abs} does not load under gjs"
+        rc=1
+    fi
+done <<'EOF'
+packages/node/sab-native|GjsifySabNative|SharedBuffer
+packages/infra/lightningcss-native|GjsifyLightningcss|Engine
+EOF
+[ "$rc" -eq 0 ] || exit $rc
+
+# ── every relocation must resolve with no library-path variable ─────────────
+# The stricter half, and the one that makes this leg worth running: GI opens a
+# library with G_MODULE_BIND_LAZY, so the gjs step above binds only what it
+# touches — and a missing symbol is precisely why both packages in this leg need
+# a musl build in the first place (`fcntl64`, `__cmsg_nxthdr`,
+# `gnu_get_libc_version`). RTLD_NOW binds everything. With LD_LIBRARY_PATH
+# unset, the only way the Vala half of lightningcss-native can find its sibling
+# cdylib is its own `$ORIGIN` RUNPATH — the dynamic twin of
+# `check-prebuild-loader-path.mjs`.
+echo "--- proving every relocation resolves with no library-path variable"
+# No `-ldl`: musl has no separate libdl.
+cc -o /tmp/dlopen-rtld-now .github/prebuild-toolchain/dlopen-rtld-now.c
+rc=0
+for lib in \
+    "packages/node/sab-native|${STAGE_DIR}/${PREBUILD}/libgjsifysabnative.so" \
+    "packages/infra/lightningcss-native|${STAGE_DIR}/${PREBUILD}/libgjsifylightningcss.so"; do
+    pkg="${lib%%|*}"
+    lib="${lib#*|}"
+    built "$pkg" || { echo "--- $pkg: not built by this run, not dlopened"; continue; }
+    echo "--- dlopen(RTLD_NOW) $lib with LD_LIBRARY_PATH unset"
+    if env -u LD_LIBRARY_PATH /tmp/dlopen-rtld-now "$lib"; then :; else
+        echo "::error::$lib does not fully resolve on musl"
+        rc=1
+    fi
+done
+exit $rc

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1825,21 +1825,41 @@ jobs:
     needs: [changes]
     runs-on: ${{ matrix.runner }}
     if: github.event_name == 'workflow_dispatch'
-    container:
-      image: alpine:3.24
     timeout-minutes: 60
 
-    defaults:
-      run:
-        # THE ALPINE BASE IMAGE HAS NO BASH — only busybox `sh` (ash). GitHub's
-        # default is `bash -e {0}` with a documented fallback to `sh`, but an
-        # implicit fallback is not something to build a leg on: say `sh` and
-        # keep every script below POSIX. Verified in `alpine:3.24` that busybox
-        # ash takes everything these steps use — `set -euo pipefail`, the
-        # `case`-based `built()` helper, `while IFS='|' read` over a heredoc,
-        # `${var%%pattern}`, `env -u`. No arrays anywhere, which is the one
-        # bashism the macOS legs above rely on.
-        shell: sh
+    # NO job-level `container:`, and that is the fix rather than a preference.
+    #
+    # This leg used `container: image: alpine:3.24`, which puts GitHub's own
+    # action runtime inside the container. On the arm64 runner that fails before
+    # anything is built:
+    #
+    #     JavaScript Actions in Alpine containers are only supported on x64
+    #     Linux runners. Detected Linux Arm64
+    #
+    # `actions/checkout` is a JavaScript action and its runtime ships for musl
+    # only as an x64 binary, so the arm64 leg could never go green as written —
+    # it died at `Checkout repository` on every run. Nothing about gjs or Alpine
+    # on arm64 is at fault: the container runs natively there, and the
+    # limitation is entirely in the action runtime.
+    #
+    # Inverting the containment costs nothing and buys a property this leg
+    # lacked: the JS actions run on the glibc host, everything that must see
+    # musl runs inside `alpine:3.24` via one script, and that script is
+    # reproducible by hand (see its header). Both arches stay NATIVE — no
+    # emulation, no binfmt pin — and the script asserts that rather than
+    # assuming it, by requiring `stage-prebuild.mjs` to resolve the host as the
+    # matrix entry's own token before it builds anything.
+    #
+    # `continue-on-error` because this leg is a CANARY, not a gate: it is
+    # dispatch-only, it appears in no `needs:` (see `commit-prebuilds`), and its
+    # artifacts are NEVER committed — it builds targets no package declares yet,
+    # so it proves itself before the declaration exists. What it must not do is
+    # colour the run red, because that is how it spent 2026-08-01..03 hiding the
+    # real blocker: `commit-prebuilds` was failing at its gate for 41 hours with
+    # every build leg green, and two permanently-red musl legs sat next to it
+    # making the workflow look broken for a reason nobody was chasing. A
+    # canary's failure has to be visible and harmless, in that order.
+    continue-on-error: true
 
     strategy:
       fail-fast: false
@@ -1886,168 +1906,37 @@ jobs:
       PREBUILD_SKIP: ${{ needs.changes.outputs.skip }}
 
     steps:
-      - name: Install the Alpine toolchain
-        run: |
-          set -eux
-          apk add --no-cache \
-            meson ninja-build gcc build-base pkgconf file binutils linux-headers \
-            vala glib-dev gobject-introspection-dev \
-            cargo rust musl-dev \
-            gjs nodejs git
-          cat /etc/alpine-release
-          valac --version
-          meson --version
-          cargo --version
-          rustc --version
-          # The host triple decides the crt-static default, which decides
-          # whether a cdylib can be produced at all — print it, so a log alone
-          # answers the question if this ever fails.
-          rustc -vV | grep '^host:'
-          gjs --version
-          node --version
-          command -v g-ir-compiler
-
+      # Checkout runs on the GLIBC HOST — that is the entire point of dropping
+      # `container:` (see the job comment). It also means it can come first:
+      # under the old shape `apk add … git` had to run before it, because the
+      # Alpine base image has no git.
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Confirm this container resolves as a musl target
-        # The clobber guard, run BEFORE anything is built. `hostStagingTarget()`
-        # is the exact function `stage-prebuild.mjs` uses to pick the directory
-        # it will `rmSync` and rewrite; if node ever failed to see this host as
-        # musl it would resolve `linux-<arch>` — a DECLARED, COMMITTED target —
-        # and the leg would silently replace a shipped glibc prebuild with a
-        # musl one. Importing the module runs no `main()` (it is guarded on
-        # `process.argv[1]`), so this is a pure read.
+      # One step, one container, one script — and the script is the same one a
+      # human runs by hand (its header carries the command). Everything that
+      # must observe musl lives in there; nothing that needs GitHub's action
+      # runtime does.
+      #
+      # No `--platform`: the runner's own architecture IS the target, so pulling
+      # `alpine:3.24` natively is both correct and fastest. Getting that wrong
+      # would silently emulate, which is why the script REFUSES unless
+      # `stage-prebuild.mjs` resolves the host as this entry's own token — and
+      # why the per-artifact `file(1)` machine check is inside it too. (Measured
+      # locally: without a forced platform, a cached foreign-arch image runs
+      # emulated and podman warns rather than fails — an assertion is the only
+      # thing that catches that in CI.)
+      - name: Build and verify every musl prebuild inside alpine:3.24
         run: |
           set -euo pipefail
-          resolved="$(node -e 'import("./scripts/stage-prebuild.mjs").then((m) => console.log(m.hostStagingTarget()))')"
-          echo "stage-prebuild.mjs resolves this host as: ${resolved}"
-          if [ "$resolved" != "$PREBUILD" ]; then
-            echo "::error::this container resolves as \`${resolved}\`, not \`${PREBUILD}\`. Refusing to build:"
-            echo "::error::staging would write into a committed glibc prebuild directory and overwrite it."
-            exit 1
-          fi
+          docker run --rm \
+            -v "$PWD:/workspace" -w /workspace \
+            -e PREBUILD -e MACHINE -e PREBUILD_SKIP \
+            alpine:3.24 sh .github/prebuild-toolchain/musl-build.sh
 
-      # -------- @gjsify/sab-native (GjsifySabNative) --------
-      - name: Build @gjsify/sab-native against musl
-        if: ${{ !contains(needs.changes.outputs.skip, '"sab-native"') }}
-        working-directory: packages/node/sab-native
-        run: |
-          set -euo pipefail
-          meson setup build .
-          meson compile -C build
-          node "$GITHUB_WORKSPACE/scripts/stage-prebuild.mjs" . --allow-undeclared
-          ls -lh "prebuilds/${PREBUILD}/"
-
-      # -------- @gjsify/lightningcss-native (GjsifyLightningcss) --------
-      - name: Build @gjsify/lightningcss-native against musl (Rust cdylib + Vala bridge)
-        if: ${{ !contains(needs.changes.outputs.skip, '"lightningcss-native"') }}
-        working-directory: packages/infra/lightningcss-native
-        run: |
-          set -euo pipefail
-          meson setup build .
-          meson compile -C build
-          # Matching by EXTENSION is what picks up both halves of the pair here
-          # (`libgjsifylightningcss.so` + the `libgjsify_lightningcss.so` cdylib
-          # it links), and the stager then runs `checkPrebuildDir()` over what it
-          # wrote — the staged-sibling + `$ORIGIN` invariant, verified on musl.
-          node "$GITHUB_WORKSPACE/scripts/stage-prebuild.mjs" . --allow-undeclared
-          ls -lh "prebuilds/${PREBUILD}/"
-
-      - name: Verify each staged artifact's machine matches its directory
-        run: |
-          set -euo pipefail
-          # Did THIS run build it? Keyed on the directory basename, the key
-          # `changed-packages.mjs` emits, quoted so `"sab-native"` cannot match
-          # a longer key. An unset/empty PREBUILD_SKIP verifies everything —
-          # the same fail-open direction the `if:` gates take.
-          built() { case "${PREBUILD_SKIP:-}" in *"\"${1##*/}\""*) return 1 ;; *) return 0 ;; esac; }
-          rc=0
-          for dir in packages/node/sab-native packages/infra/lightningcss-native; do
-            built "$dir" || { echo "--- $dir: not built by this run, not verified"; continue; }
-            out="$dir/prebuilds/${PREBUILD}"
-            if [ ! -d "$out" ]; then
-              echo "::error::$out does not exist — the build ran but staged somewhere else"
-              rc=1
-              continue
-            fi
-            for lib in "$out"/*.so; do
-              desc="$(file -b "$lib")"
-              echo "$lib: $desc"
-              case "$desc" in
-                *"$MACHINE"*) ;;
-                *) echo "::error file=$lib::expected a $MACHINE object in ${PREBUILD}, got: $desc"; rc=1 ;;
-              esac
-            done
-          done
-          exit $rc
-
-      - name: Load-test every musl prebuild under Alpine gjs
-        # The protocol the Fedora and macOS legs use, unchanged: resolving a
-        # GObject class forces GI to call the class's `…_get_type` symbol, which
-        # is what dlopens the recorded shared library. A typelib that is merely
-        # FOUND resolves the namespace and then throws here.
-        #
-        # LD_LIBRARY_PATH is set on purpose and is NOT a workaround for a musl
-        # defect: a typelib records the BARE leaf name of its library, so a
-        # GI_TYPELIB_PATH-only load fails identically for every bridge on glibc
-        # (verified on both). The CLI's `buildNativeEnv()` exports exactly this
-        # variable for exactly this reason, so passing it here makes the test
-        # match what a real `gjsify` run does — do not "fix" the non-bug.
-        run: |
-          set -euo pipefail
-          built() { case "${PREBUILD_SKIP:-}" in *"\"${1##*/}\""*) return 1 ;; *) return 0 ;; esac; }
-          rc=0
-          while IFS='|' read -r dir ns sym; do
-            [ -n "$dir" ] || continue
-            built "$dir" || { echo "--- ${ns}: not built by this run, not load-tested"; continue; }
-            abs="$PWD/${dir}/prebuilds/${PREBUILD}"
-            echo "--- ${ns}.${sym} from ${abs}"
-            # `< /dev/null`: the loop's stdin is the heredoc below, and a child
-            # that reads it would eat the remaining rows.
-            if GI_TYPELIB_PATH="$abs" LD_LIBRARY_PATH="$abs" gjs -c \
-                 "const T = imports.gi.${ns}.${sym};
-                  if (typeof T !== 'function') { throw new Error('${ns}.${sym} did not resolve to a class'); }
-                  print('${ns}.${sym} resolved — shared library loaded');" < /dev/null
-            then :; else
-              echo "::error::${ns} prebuild in ${abs} does not load under gjs"
-              rc=1
-            fi
-          done <<'EOF'
-          packages/node/sab-native|GjsifySabNative|SharedBuffer
-          packages/infra/lightningcss-native|GjsifyLightningcss|Engine
-          EOF
-          exit $rc
-
-      - name: Prove every relocation resolves with no library-path variable
-        # The stricter half, and the one that makes this leg worth running: GI
-        # opens a library with G_MODULE_BIND_LAZY, so the gjs step above binds
-        # only what it touches — and a missing symbol is precisely why both
-        # packages in this leg need a musl build in the first place
-        # (`fcntl64`, `__cmsg_nxthdr`, `gnu_get_libc_version`). RTLD_NOW binds
-        # everything. With LD_LIBRARY_PATH unset, the only way the Vala half of
-        # lightningcss-native can find its sibling cdylib is its own `$ORIGIN`
-        # RUNPATH — the dynamic twin of `check-prebuild-loader-path.mjs`.
-        run: |
-          set -euo pipefail
-          built() { case "${PREBUILD_SKIP:-}" in *"\"${1##*/}\""*) return 1 ;; *) return 0 ;; esac; }
-          # No `-ldl`: musl has no separate libdl.
-          cc -o /tmp/dlopen-rtld-now .github/prebuild-toolchain/dlopen-rtld-now.c
-          rc=0
-          for lib in \
-            "packages/node/sab-native/prebuilds/${PREBUILD}/libgjsifysabnative.so" \
-            "packages/infra/lightningcss-native/prebuilds/${PREBUILD}/libgjsifylightningcss.so"
-          do
-            pkg="${lib%%/prebuilds/*}"
-            built "$pkg" || { echo "--- $pkg: not built by this run, not dlopened"; continue; }
-            echo "--- dlopen(RTLD_NOW) $lib with LD_LIBRARY_PATH unset"
-            if env -u LD_LIBRARY_PATH /tmp/dlopen-rtld-now "$PWD/$lib"; then :; else
-              echo "::error::$lib does not fully resolve on musl"
-              rc=1
-            fi
-          done
-          exit $rc
-
+      # The uploads stay on the host: their paths are in the bind-mounted
+      # workspace, and `upload-artifact` is a JS action that must not be asked to
+      # run inside Alpine.
       - name: Upload @gjsify/sab-native musl prebuilds artifact
         if: ${{ !contains(needs.changes.outputs.skip, '"sab-native"') }}
         uses: actions/upload-artifact@v7
@@ -2065,6 +1954,7 @@ jobs:
           path: packages/infra/lightningcss-native/prebuilds/linux-${{ matrix.arch }}-musl/
           if-no-files-found: error
           retention-days: 30
+
 
   # ----------------------------------------------------------------
   # Commit all prebuilds back to the repo — main only, and never from a PR

--- a/packages/node/sab-native/src/vala/sab-helpers.c
+++ b/packages/node/sab-native/src/vala/sab-helpers.c
@@ -3,6 +3,34 @@
  *
  * Linux-only. Compile with -D_GNU_SOURCE so memfd_create, MFD_CLOEXEC,
  * and the FUTEX_*_PRIVATE constants are visible.
+ *
+ * ONE ARTIFACT MUST SERVE BOTH LIBCS — no glibc-private symbols.
+ *
+ * This translation unit is compiled against glibc and the resulting
+ * `@gjsify/sab-native-linux-<arch>` declares no npm `libc` filter, so npm
+ * installs it on musl hosts too. That is deliberate (musl binds a `DT_NEEDED`
+ * of `libc.so.6` to itself), but it only holds while every symbol we reference
+ * exists in BOTH libcs — and two glibc conveniences quietly broke it:
+ *
+ *   - `fcntl()` is redirected to `fcntl64()` by glibc >= 2.28 for large-file
+ *     support. musl exports no `fcntl64`.
+ *   - `CMSG_NXTHDR()` expands to a call to `__cmsg_nxthdr()`, a glibc-internal
+ *     function musl does not have.
+ *
+ * GI opens the library with G_MODULE_BIND_LAZY, so neither is a load failure:
+ * the typelib resolved, `SharedBuffer.create()` worked, and the two unbound
+ * relocations surfaced only when their code path was first called. Measured on
+ * alpine:3.24 (x86-64) and on a OnePlus 6T under postmarketOS (aarch64): the
+ * package's own suite lost exactly its two fd-passing tests, and
+ * `@gjsify/worker_threads` lost all four SharedBuffer cross-process tests
+ * (timeout, not error) while both suites were fully green on glibc. So the
+ * `transferList` SharedBuffer path was broken on every musl host and no check
+ * could see it.
+ *
+ * Hence: reach the kernel directly (the same reason `memfd_create` below is a
+ * raw syscall) and do the cmsg arithmetic here, out of pure macros both libcs
+ * define identically. `ldd` under musl must report no unresolved symbol — that
+ * is what `.github/prebuild-toolchain/musl-build.sh` asserts with RTLD_NOW.
  */
 
 #include "sab-helpers.h"
@@ -32,6 +60,41 @@ static int
 gjsify_memfd_create (const char *name, unsigned int flags)
 {
   return (int) syscall (SYS_memfd_create, name, flags);
+}
+
+/* `fcntl()` compiles to `fcntl64()` on glibc >= 2.28 (LFS redirect) and musl
+ * exports no such symbol — see the libc note in the file header. Every target
+ * in `gjsify.platforms` is LP64, where `SYS_fcntl` already takes 64-bit
+ * offsets, so there is no `SYS_fcntl64` case to pick between. */
+static int
+gjsify_dup_cloexec (int fd)
+{
+  return (int) syscall (SYS_fcntl, fd, F_DUPFD_CLOEXEC, 0);
+}
+
+/* musl defines CMSG_ALIGN under _GNU_SOURCE, as does glibc; the fallback is
+ * here so a libc that omits it cannot turn into a silent miscompile. */
+#ifndef CMSG_ALIGN
+#  define CMSG_ALIGN(len) (((len) + sizeof (size_t) - 1) & (size_t) ~(sizeof (size_t) - 1))
+#endif
+
+/* `CMSG_NXTHDR()` is a call to glibc-private `__cmsg_nxthdr()` — see the file
+ * header. This is that function's own logic, and BOTH of its bounds checks are
+ * kept: room for the next header, and room for that header's aligned payload.
+ * Dropping either would read past `msg_control` on a truncated control buffer,
+ * which is attacker-influenced data on a socket. */
+static struct cmsghdr *
+gjsify_cmsg_nxthdr (const struct msghdr *msg, struct cmsghdr *cmsg)
+{
+  if (cmsg->cmsg_len < sizeof (struct cmsghdr)) return NULL;
+
+  unsigned char *end  = (unsigned char *) msg->msg_control + msg->msg_controllen;
+  unsigned char *next = (unsigned char *) cmsg + CMSG_ALIGN (cmsg->cmsg_len);
+
+  if (next + sizeof (struct cmsghdr) > end) return NULL;
+  if (next + CMSG_ALIGN (((struct cmsghdr *) next)->cmsg_len) > end) return NULL;
+
+  return (struct cmsghdr *) next;
 }
 
 /* ────────────────────────────────────────────────────────────────────── *
@@ -108,7 +171,7 @@ gjsify_sab_region_new_from_fd (gint fd, gsize size)
   if (fd < 0 || size == 0) { errno = EINVAL; return NULL; }
 
   /* dup so the caller can close their copy without unmapping ours. */
-  int dup_fd = fcntl (fd, F_DUPFD_CLOEXEC, 0);
+  int dup_fd = gjsify_dup_cloexec (fd);
   if (dup_fd < 0) return NULL;
 
   void *ptr = mmap (NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, dup_fd, 0);
@@ -435,7 +498,7 @@ gjsify_sab_recv_fd (gint socket_fd, guint32 *tag)
   *tag = GUINT32_FROM_BE (tag_be);
 
   /* Extract the fd from the control message. */
-  for (struct cmsghdr *cm = CMSG_FIRSTHDR (&msg); cm != NULL; cm = CMSG_NXTHDR (&msg, cm)) {
+  for (struct cmsghdr *cm = CMSG_FIRSTHDR (&msg); cm != NULL; cm = gjsify_cmsg_nxthdr (&msg, cm)) {
     if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
       int fd;
       memcpy (&fd, CMSG_DATA (cm), sizeof (int));

--- a/scripts/stage-prebuild.mjs
+++ b/scripts/stage-prebuild.mjs
@@ -180,7 +180,14 @@ function main() {
     const args = process.argv.slice(2);
     const buildFlag = args.indexOf('--build-dir');
     const buildDirName = buildFlag >= 0 ? args[buildFlag + 1] : 'build';
-    const pkgDir = resolve(args.find((a) => !a.startsWith('--') && a !== buildDirName) ?? process.cwd());
+    const destFlag = args.indexOf('--dest');
+    const destArg = destFlag >= 0 ? args[destFlag + 1] : null;
+    // Excluded from the positional scan for the same reason `buildDirName` is: a
+    // flag VALUE does not start with `--`, so without this it would be taken for
+    // the package directory.
+    const pkgDir = resolve(
+        args.find((a) => !a.startsWith('--') && a !== buildDirName && a !== destArg) ?? process.cwd(),
+    );
 
     const pkgJsonPath = join(pkgDir, 'package.json');
     if (!existsSync(pkgJsonPath)) {
@@ -263,12 +270,49 @@ function main() {
         process.exit(1);
     }
 
-    const staged = resolveStageDir(pkgDir, pkg, target);
-    if ('error' in staged) {
-        console.error(`[stage-prebuild] ${staged.error}`);
-        process.exit(1);
+    let outDir;
+    if (destArg !== null) {
+        // AN EXPLICIT DESTINATION OUTSIDE ANY PACKAGE, for a target that is
+        // undeclared BY DESIGN.
+        //
+        // `resolveStageDir` refuses when a bridge has no `gjsify.prebuilds` and no
+        // sibling platform package, and that refusal is correct — staging into the
+        // bridge would create a directory `files` does not ship and no conformance
+        // rule can see. But it makes `prebuilds.yml`'s musl leg unstageable, and
+        // not by oversight: that leg exists to build targets NO package declares
+        // yet ("it proves itself before the declaration exists"), so by
+        // construction there is no platform package to stage into, and generating
+        // one would publish a promise CI must then reproduce and commit.
+        //
+        // Measured: after ADR 0017 that leg's `stage-prebuild . --allow-undeclared`
+        // fails with `sab-native-linux-x64-musl/ does not exist` — the musl build
+        // itself succeeds. Reproduced locally in `alpine:3.24`.
+        //
+        // So the escape is a NAMED destination rather than a relaxed default, and
+        // it requires `--allow-undeclared` as well: the two together say "this
+        // host is not a promised target AND these bytes are not going into a
+        // package". Everything after this point — the replace-not-merge, the
+        // extension match, `checkPrebuildDir()` — runs unchanged, which is the
+        // whole point of routing a CI leg through this script instead of a `cp`.
+        if (!allowUndeclared) {
+            console.error(
+                '[stage-prebuild] `--dest` requires `--allow-undeclared`.\n' +
+                    '  A destination outside the package tree is only meaningful for a target this\n' +
+                    '  package does not promise. For a DECLARED target the destination is resolved,\n' +
+                    '  never chosen: that is what keeps a shipped artifact in the one directory\n' +
+                    '  `files` ships and the conformance rules can see.',
+            );
+            process.exit(1);
+        }
+        outDir = join(resolve(destArg), target);
+    } else {
+        const staged = resolveStageDir(pkgDir, pkg, target);
+        if ('error' in staged) {
+            console.error(`[stage-prebuild] ${staged.error}`);
+            process.exit(1);
+        }
+        outDir = staged.dir;
     }
-    const outDir = staged.dir;
     // Replace rather than merge: a stale artifact from a previous build (a
     // renamed library, a dropped typelib) must not survive into the shipped set.
     rmSync(outDir, { recursive: true, force: true });

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -592,3 +592,57 @@ state:
   worth having while win32/darwin are active port targets. Needs the fix to
   `excalibur-jelly-jumper` in the same change, and a check so the next entry
   cannot be wrong for free.
+
+### `@gjsify/lightningcss-native` references `gnu_get_libc_version`, which musl lacks
+
+The committed glibc build declares no npm `libc` filter, so npm installs it on
+musl hosts, where `ldd` reports `gnu_get_libc_version: symbol not found` on both
+of its libraries. GI binds lazily, so this is not a load failure — it is an
+unbound relocation that crashes if and when that path is called, the same shape
+that hid `sab-native`'s `fcntl64`/`__cmsg_nxthdr` until the musl leg started
+checking committed artifacts.
+
+Unlike `sab-native`, the reference is not ours to remove: it comes from a
+crates.io dependency of the pinned `refs/lightningcss` build. So the fix is
+either an upstream/dependency change, or a musl-built sibling package with
+`libc: ["musl"]` beside a `libc: ["glibc"]` parent — which needs the target
+vocabulary to carry a libc component it deliberately does not have today, plus
+two new published npm names. Until then it is an ACCEPTED gap in
+`musl_gap_reason()` in `.github/prebuild-toolchain/musl-build.sh`, printed on
+every musl run, and that entry FAILS the leg the day the symbol stops appearing —
+so it cannot outlive the problem.
+
+### `@gjsify/webrtc` cannot work on Alpine / postmarketOS — no `webrtcbin` element
+
+Separate from the libc axis and easy to mistake for it. The musl leg's
+committed-prebuild check reports `webrtc-native` as fully resolving, which is true
+and misleading: `gst-plugins-bad` provides `libgstwebrtc-1.0.so.0`, so every
+relocation binds, while `gst-inspect-1.0 webrtcbin` on the same image finds
+nothing. GStreamer 1.28's nice plugin requires libnice >= 0.1.23 and Alpine ships
+0.1.22, so the `webrtcbin` element and the `nice` plugin are not built at all.
+Measured on `alpine:3.24`: library present, element absent, nice plugin absent.
+Installing `libnice` does not help and that is measured too — with
+`libnice-0.1.22-r0` genuinely installed from community, `/usr/lib/gstreamer-1.0/`
+still contains no nice plugin at all, so `nicesrc`/`nicesink`/`webrtcbin` remain
+missing. Alpine's libnice package simply does not build the GStreamer plugin, and
+the phone does not even have libnice installed.
+
+`@gjsify/webrtc` is built entirely on `webrtcbin`, so it is non-functional on
+Alpine and on postmarketOS regardless of the prebuild. Layering the postmarketOS
+repositories on top of Alpine does not help, and that is measured, not assumed:
+on a real postmarketOS v26.06 device with the pmOS mirrors active, `libnice` is
+still 0.1.22-r0 (taken from Alpine community unchanged) and
+`Gst.ElementFactory.find()` finds no `webrtcbin`, `nicesrc` or `nicesink`, while
+`dtlssrtpenc` and `rtpbin` are both present — exactly the shape a libnice-gated
+nice plugin produces. Nothing to fix here; the blocker is a distro package
+version, and the upstream threads say a maintainer MR bumping libnice plus a
+`gst-plugins-bad` rebuild is all it takes:
+
+- https://gitlab.postmarketos.org/postmarketOS/pmaports/-/work_items/4443
+- https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18092
+
+Worth tracking because it is the one bridge whose prebuild can be perfect and
+still unusable on a whole libc's worth of hosts, and because the reflex fix —
+teaching the musl check to verify GStreamer elements — would be an accepted gap
+from day one. Revisit when Alpine's libnice reaches 0.1.23; the right check then
+is a real element probe, which would go green rather than being born red.

--- a/tests/e2e/prebuild-change-gate/run.mjs
+++ b/tests/e2e/prebuild-change-gate/run.mjs
@@ -21,6 +21,7 @@ import {
     rmSync,
     symlinkSync,
     writeFileSync,
+    statSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -30,6 +31,7 @@ const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
 const script = fileURLToPath(new URL('../../../.github/prebuild-toolchain/changed-packages.mjs', import.meta.url));
 const workflow = fileURLToPath(new URL('../../../.github/workflows/prebuilds.yml', import.meta.url));
 const emulated = fileURLToPath(new URL('../../../.github/prebuild-toolchain/emulated-build.sh', import.meta.url));
+const muslScript = fileURLToPath(new URL('../../../.github/prebuild-toolchain/musl-build.sh', import.meta.url));
 
 // A scratch dir this suite owns, for the per-run GITHUB_OUTPUT files below.
 const scratch = mkdtempSync(join(tmpdir(), 'prebuild-gate-out-'));
@@ -442,5 +444,18 @@ done`;
     it('is a real, executable file the workflow mounts', () => {
         assert.ok(existsSync(emulated));
         assert.equal(spawnSync('bash', ['-n', emulated]).status, 0, 'emulated-build.sh must parse');
+    });
+
+    it('the musl leg\u2019s script parses under POSIX sh and is executable', () => {
+        // Checked with `sh -n`, not `bash -n`: it runs in `alpine:3.24`, whose
+        // only shell is busybox ash. A bashism would pass a bash check and then
+        // fail in the container, which is the one place this leg cannot be
+        // debugged cheaply — it is dispatch-only and main-only in effect.
+        assert.ok(existsSync(muslScript));
+        assert.equal(spawnSync('sh', ['-n', muslScript]).status, 0, 'musl-build.sh must parse under POSIX sh');
+        // Mounted and invoked as `sh <script>`, so the bit is not strictly
+        // required — but its sibling has it, and a script a human is told to run
+        // by hand (see its header) should be runnable.
+        assert.ok(statSync(muslScript).mode & 0o111, 'musl-build.sh must be executable');
     });
 });

--- a/tests/e2e/stage-prebuild/run.mjs
+++ b/tests/e2e/stage-prebuild/run.mjs
@@ -62,8 +62,17 @@ function fixture(platforms, files) {
     return dir;
 }
 
-function runStager(dir) {
-    return execFileSync(process.execPath, [STAGER, dir], { encoding: 'utf8' });
+function runStager(dir, ...extra) {
+    return execFileSync(process.execPath, [STAGER, dir, ...extra], { encoding: 'utf8' });
+}
+
+/** A POST-SPLIT bridge: declares platforms, owns no `prebuilds/` (ADR 0017). */
+function splitBridgeFixture(platforms, files) {
+    const dir = mkdtempSync(join(tmpdir(), 'gjsify-stage-split-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@gjsify/fixture-bridge', gjsify: { platforms } }));
+    mkdirSync(join(dir, 'build'), { recursive: true });
+    for (const f of files) writeFileSync(join(dir, 'build', f), f);
+    return dir;
 }
 
 describe('stage-prebuild: target selection', () => {
@@ -193,6 +202,48 @@ describe('stage-prebuild: staging', () => {
             assert.deepEqual(staged, ['libnew.so'], 'the renamed-away library must not survive');
         } finally {
             rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('--dest stages OUTSIDE the package for a target undeclared by design', () => {
+        // `prebuilds.yml`'s musl leg. After ADR 0017 a bridge owns no
+        // `prebuilds/`, so `resolveStageDir` resolves to a sibling platform
+        // package and REFUSES when there is none — and for this leg there never
+        // is one, because it builds targets no package declares yet. Measured in
+        // `alpine:3.24`: the musl build succeeds and staging failed with
+        // `sab-native-linux-x64-musl/ does not exist`.
+        //
+        // The escape is a NAMED destination, not a relaxed default: everything
+        // after it — replace-not-merge, the extension match, `checkPrebuildDir()`
+        // — still runs, which is why the leg routes through this script at all
+        // instead of a `cp`.
+        const other = process.platform === 'linux' ? 'darwin-arm64' : 'linux-x64';
+        const dir = splitBridgeFixture([other], ['libfoo.so', 'Foo-1.0.typelib']);
+        const dest = mkdtempSync(join(tmpdir(), 'gjsify-stage-dest-'));
+        try {
+            runStager(dir, '--allow-undeclared', '--dest', dest);
+            assert.deepEqual(readdirSync(join(dest, HOST_TARGET)).sort(), ['Foo-1.0.typelib', 'libfoo.so']);
+            // And nothing inside the package — the directory `files` does not
+            // ship and no conformance rule can see is exactly what must not appear.
+            assert.ok(!readdirSync(dir).includes('prebuilds'), 'must not stage into the bridge');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+            rmSync(dest, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses --dest without --allow-undeclared', () => {
+        // The two together mean "not a promised target AND not going into a
+        // package". Allowing `--dest` alone would let a DECLARED target's shipped
+        // artifact be redirected out of the one directory `files` ships, which is
+        // the quiet failure `resolveStageDir` was written to remove.
+        const dir = splitBridgeFixture([HOST_TARGET], ['libfoo.so']);
+        const dest = mkdtempSync(join(tmpdir(), 'gjsify-stage-dest-'));
+        try {
+            assert.throws(() => runStager(dir, '--dest', dest), /requires .--allow-undeclared./);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+            rmSync(dest, { recursive: true, force: true });
         }
     });
 


### PR DESCRIPTION
## What this is

The musl legs of `prebuilds.yml` had never produced a green run, so nothing in CI
had ever executed on musl. Making them able to run at all turned out to be the
cheap part — once they ran, they found a shipping defect.

Three commits, in the order they must land:

### 1. `fix(ci)`: make the musl canary able to run at all

Two independent breakages:

- The job used `container: image: alpine:3.24`, which puts GitHub's own action
  runtime inside the container. On the arm64 runner `actions/checkout` cannot
  start there — *"JavaScript Actions in Alpine containers are only supported on
  x64 Linux runners"* — so the arm64 leg died at checkout on every run and
  coloured the workflow red while gating nothing. Inverting the containment (JS
  actions on the glibc host, everything that must see musl inside a `docker run`)
  costs nothing and needs no emulation: the runner's own arch *is* the target,
  which the script now asserts rather than assumes.
- Staging refused: after ADR 0017 a bridge owns no `prebuilds/`, and
  `stage-prebuild.mjs` resolves the destination to a sibling platform package.
  For this leg there is never one — it builds targets no package declares. So it
  gets an explicit `--dest` (gated behind `--allow-undeclared`) pointing outside
  the package tree; every other caller keeps the refusal.

The script is POSIX `sh` (Alpine has no bash) and documents how to reproduce each
leg locally, which is the property the QEMU legs had and this one lacked.

### 2. `fix(sab-native)`: drop glibc-private symbols

**This is the find.** `@gjsify/sab-native-linux-<arch>` is built against glibc and
declares no npm `libc` filter, so npm installs it on musl hosts *by design* —
musl binds a `DT_NEEDED` of `libc.so.6` to itself. That design holds only while
every symbol the binary references exists in both libcs, and two did not:

- `fcntl()` is redirected to `fcntl64()` by glibc ≥ 2.28; musl exports no `fcntl64`.
- `CMSG_NXTHDR()` expands to a call to glibc-internal `__cmsg_nxthdr()`.

Neither is a load failure. GI opens with `G_MODULE_BIND_LAZY`, so the typelib
resolved and `SharedBuffer.create()` worked — the unbound relocations surfaced
only when their code path was first called, which is the fd-passing half.

| suite | glibc x86-64 | musl x86-64 | musl aarch64 (real hardware) |
|---|---|---|---|
| `sab-native` before | 76 ✓ | **2 failed** | **2 failed** |
| `worker_threads` before | 288 ✓ | **4 failed** | — |
| `sab-native` after | 76 ✓ | 76 ✓ | 76 ✓ |
| `worker_threads` after | 288 ✓ | 288 ✓ | 288 ✓ |

So `@gjsify/worker_threads`' `transferList` SharedBuffer path (memfd + SCM_RIGHTS
over fd 3) was broken on **every musl host**, and no check could see it. The
aarch64 column is a OnePlus 6T under postmarketOS (musl 1.2, gjs 1.88.1) — real
hardware, not emulation; CI's own arm64 musl leg is a container.

Fix: reach the kernel directly for the dup (the same reason `memfd_create` beside
it is already a raw syscall; every declared target is LP64, so `SYS_fcntl` needs
no `SYS_fcntl64` alternative), and do the cmsg walk locally out of pure macros
both libcs define identically — keeping **both** of glibc's bounds checks,
because `msg_control` holds attacker-influenced data.

Side effect worth noting: the glibc floor drops from **2.28 to 2.14** (x64) /
**2.17** (arm64), since `fcntl64@GLIBC_2.28` was the only thing forcing 2.28.
`gjsify.glibcRequires` is measured from the artifact, so it follows on the next
prebuild rebuild.

### 3. `ci`: verify committed prebuilds under musl

The mechanism, so this class stays visible. The leg already runs on real musl; it
now also `ldd`s **the committed glibc artifacts** — the ones users actually get —
which is a direct, heuristic-free test of exactly the claim `libc: null` makes.

`ldd` on Alpine is musl's own loader in list mode, so it reports every unresolved
relocation at once. Two failure classes are kept strictly apart, and the ORDER is
load-bearing: a genuinely absent system library makes the *symbol* verdict
meaningless (the loader reports everything that library would have provided as
not-found too). Judging symbols first blamed musl for a container that merely
lacked libepoxy — ~200 phantom `epoxy_gl*` "gaps" in `@gjsify/webgl`. So "no
library missing" is now the precondition for judging symbols at all, and the
glibc dynamic loader is filtered out of that precondition because its absence is
the normal case this check exists to characterise.

Current output on `linux-x64-musl`:

```
--- webgl-linux-x64: every relocation resolves
--- lightningcss-native-linux-x64: ACCEPTED musl gap (gnu_get_libc_version) — …
--- oxfmt-native-linux-x64: every relocation resolves
--- rolldown-native-linux-x64: every relocation resolves
--- napi-linux-x64: NOT VERIFIED here — absent system libs: libmozjs-140.so.0
--- http-soup-bridge-linux-x64: every relocation resolves
--- http2-native-linux-x64: every relocation resolves
::error::sab-native-linux-x64 … does not resolve there: __cmsg_nxthdr fcntl64
--- terminal-native-linux-x64: every relocation resolves
--- tls-native-linux-x64: every relocation resolves
--- webrtc-native-linux-x64: every relocation resolves
```

`lightningcss-native`'s `gnu_get_libc_version` comes from a crates.io dependency
of the pinned `refs/lightningcss` build, not from our source, so it cannot be
removed the way `sab-native`'s two were. It is an **accepted gap** with a
mandatory printed reason, in a ledger deliberately awkward like
`gjsify.platformsUncommitted`: the entry **fails the leg the day the package
starts resolving**, so it retires itself instead of becoming a permanent
exemption. `status/open-todos.md` records what closing it would take.

## Expect this leg to stay red until it merges

The check reads the **committed** binary. A source fix does not clear it until the
prebuild is rebuilt and re-committed, and `commit-prebuilds` is main-only — so
this PR's own `sab-native` error is the honest state (the shipped artifact really
is still broken), not a bug. The check says so in its own output. The legs are
`continue-on-error`, so it reports without blocking.

## Verification

Everything above was measured, not reasoned:

- the emulated musl build, both suites and the `ldd` sweep, in `alpine:3.24`
  containers (x64 native on the dev box);
- the arm64 half on a OnePlus 6T under postmarketOS over ssh — the shipped
  glibc artifact, then the fixed one, running the packages' own suites;
- the new check step exercised end-to-end against this branch's tree with the
  builds skipped, including its exit code (an earlier iteration aborted silently
  at the first clean package, because under `set -e` a `grep` that matches
  nothing kills a command substitution — fixed, and commented at the site).

## One thing a green line here does NOT mean

Added while writing this: the check judges *relocations*, so it answers "can musl
bind every symbol", never "does the host provide what this bridge needs at
runtime". `@gjsify/webrtc-native` is the standing example. `gst-plugins-bad` gives
it `libgstwebrtc-1.0.so.0`, so it resolves cleanly and the check reports it green —
while on the very same image `gst-inspect-1.0 webrtcbin` finds nothing, because
GStreamer 1.28's nice plugin needs libnice ≥ 0.1.23 and Alpine ships 0.1.22.
Measured on `alpine:3.24`: library present, element and `nice` plugin both absent.

So `@gjsify/webrtc` is non-functional on Alpine and postmarketOS no matter how
well its prebuild links, and that is upstream
([pmaports#4443](https://gitlab.postmarketos.org/postmarketOS/pmaports/-/work_items/4443),
[aports#18092](https://gitlab.alpinelinux.org/alpine/aports/-/work_items/18092)).
Recorded in `status/open-todos.md`, and the script says it at the site, so nobody
reads the green line as "works on musl". Deliberately NOT turned into an element
check: that would be an accepted gap on day one.
