### PR TITLE
ci(webgl): explore a win32-x64 prebuild

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1682,15 +1682,22 @@ jobs:
   #
   # ── THE ONE GENUINE UNKNOWN — ANSWERED: YES, MSVC COMPILES IT ─────────────
   #
-  # MEASURED on the first dispatch (run 30808356641, cl.exe 19.51.36252, VS
-  # 2026): of the four generated `.c` files, MSVC compiled `handle-types.c` and
-  # `webgl-rendering-context.c` CLEANLY and reported ZERO language diagnostics on
-  # any of them. The two that failed did so with `C1083: Cannot open include
-  # file: 'epoxy/gl.h'` — a missing include DIRECTORY on a header that was
-  # present on disk (see the `INCLUDE` line in the build step for the mechanism
-  # and the fix). So the question this job was created to answer is settled:
-  # Vala-generated C is MSVC-compatible, and nothing about the generated code
-  # needed changing.
+  # MEASURED END TO END, and the leg is GREEN (run 30808747504, cl.exe
+  # 19.51.36252 / VS 2026, valac 0.56.19, gvsbuild 2026.6.0 = GLib 2.88.1 /
+  # GTK 4.22.4 / epoxy 1.5.10):
+  #   • all four generated `.c` files compiled, `gwebgl.dll` linked (189440 B),
+  #     `Gwebgl-0.1.typelib` generated (41744 B — the Linux one is 41752 B, and
+  #     the 8-byte delta is the recorded leaf string, `gwebgl.dll` vs
+  #     `libgwebgl.so`);
+  #   • ZERO language diagnostics on any file, so nothing about the generated
+  #     code needed changing;
+  #   • `Gwebgl.WebGLRenderingContext` resolved through node-gi, i.e. GI called
+  #     `…_get_type` and the DLL was really loaded.
+  # The FIRST dispatch (run 30808356641) is worth knowing about because it is
+  # what located the one real obstacle: it compiled 2 of the 4 files and failed
+  # the other two on `C1083: Cannot open include file: 'epoxy/gl.h'` — a header
+  # present on disk that no `.pc` file names. See the `INCLUDE` line in the build
+  # step; the mechanism is now printed by the diagnostics step every run.
   #
   # The pre-dispatch source scan that predicted this is kept because it explains
   # WHY, and because it is the thing to re-run if a valac bump ever breaks it —

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1618,6 +1618,462 @@ jobs:
           packages/web/webrtc-native|GjsifyWebrtc|WebrtcbinBridge
           EOF
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # win32-x64 exploratory — @gjsify/webgl, SPLIT ACROSS TWO JOBS
+  #
+  # MANUAL DISPATCH ONLY (both halves), absent from `commit-prebuilds`, and NO
+  # `win32-x64` token is added to any `gjsify.platforms` — the same posture the
+  # macOS and musl exploratory legs take, for the same reason: the
+  # declared-vs-built invariant is SYMMETRIC, so the leg proves itself first and
+  # the declaration follows. `parseCiPlatforms()` EXCLUDES jobs gated on
+  # `github.event_name == 'workflow_dispatch'`, so while these are unproven they
+  # contribute nothing to the audit in either direction. Both `if:` lines below
+  # are what that parser matches CHARACTER FOR CHARACTER — an equivalent
+  # rewriting would credit `@gjsify/webgl` with a `win32-x64` it does not
+  # declare and fail the audit for a package nobody touched.
+  #
+  # ── WHY IT IS TWO JOBS: valac MUST NOT RUN ON WINDOWS ─────────────────────
+  #
+  # This is the whole shape of the thing, and it is a researched conclusion
+  # rather than a preference:
+  #   • There is no standalone MSVC valac. `supercamel/ValaOnWindows` ships no
+  #     compiler of its own (it points at Ooblerg or MSYS2 pacman), builds with
+  #     MinGW-w64 gcc, and explicitly does not cover shared libraries or
+  #     GIR/typelib generation — i.e. it omits both artifacts this bridge IS.
+  #   • gvsbuild has no `vala` project at all. Its project list (checked against
+  #     `repos/wingtk/gvsbuild/contents/gvsbuild/projects`) carries libepoxy,
+  #     gtk, glib, gobject_introspection, libsoup, nghttp2, libnice and
+  #     gstreamer — and no Vala compiler.
+  #   • Reaching for MinGW anyway is an ABI HAZARD, not a shortcut. gvsbuild's
+  #     GTK4 is MSVC-ABI, and this job's load test goes through
+  #     `@gjsify/node-gi`, whose Windows stack loads girepository out of that
+  #     same bundle. A MinGW-built DLL against MSVC-ABI GLib mixes CRTs, and
+  #     GLib routinely allocates what the consumer frees. `napi.yml`'s `windows`
+  #     job records the identical wall for the identical reason — read its
+  #     header before proposing MinGW here.
+  #
+  # So: a host that HAS valac emits the C sources AND the GIR (valac produces
+  # both; `vala_gir:` in the package's meson.build is what asks for the GIR),
+  # and the Windows half compiles that C with MSVC and runs gvsbuild's
+  # `g-ir-compiler` on that GIR.
+  #
+  # ── WHY THE C IS AN ARTIFACT AND NEVER A COMMIT ───────────────────────────
+  #
+  # Generation and consumption are two jobs of ONE RUN: same commit, same valac,
+  # so drift between them is structurally impossible rather than merely
+  # unlikely. A committed copy would be a build input nothing regenerates and
+  # nothing byte-checks — precisely the stale-artifact class AGENTS.md
+  # § Committed-artifact freshness exists to keep out, and the one committed
+  # artifact family that still has no byte-check is `prebuilds/**` itself. The
+  # package's `.gitignore` entry for `vala-c-export/` is the mechanism; the
+  # option's comment is only the explanation.
+  #
+  # ── WHY ONE meson.build AND NOT A SECOND ──────────────────────────────────
+  #
+  # The Windows path lives in `packages/framework/webgl/meson.build` behind
+  # `-Dprebuilt_vala_c=<dir>`, not in a parallel build file. A second
+  # description is only ever exercised by the platform that uses it, so it
+  # drifts from the one Linux CI reads on every PR and nobody finds out until
+  # somebody dispatches this. The branch is "somebody else ran valac", NOT "this
+  # is MSVC" — which is why a Linux host can and does exercise it (measured
+  # locally before this landed: the prebuilt-C branch under GCC produces a
+  # `Gwebgl-0.1.typelib` BYTE-IDENTICAL to the valac branch's, and both load
+  # `Gwebgl.WebGLRenderingContext` under stock gjs).
+  #
+  # ── THE ONE GENUINE UNKNOWN THIS EXISTS TO ANSWER ─────────────────────────
+  #
+  # DOES MSVC COMPILE VALA-GENERATED C? docs.vala.dev states Vala targets the
+  # same C ABI and GObject stack on Windows as elsewhere, and a source scan of
+  # the emitted C (10266 lines across 4 `.c` + `gwebgl.h`) found no construct
+  # MSVC rejects:
+  #   • ZERO statement expressions, `typeof`, `__extension__`, `__builtin_*`,
+  #     nested functions, VLAs or `long long`.
+  #   • The single `__attribute__` in the whole set sits inside valac's OWN
+  #     `#if defined(_MSC_VER)` ladder in `gwebgl.h`, whose MSVC arm is
+  #     `#define VALA_EXTERN __declspec(dllexport) extern`. Vala therefore
+  #     already handles Windows symbol export itself — no `.def` file, unlike
+  #     the napi shim. And because that ladder is a PREPROCESSOR decision, C
+  #     generated on Linux still takes the MSVC arm when MSVC compiles it, which
+  #     is the property that makes this split work at all.
+  #   • The only remaining GCC-isms are 3 `#pragma GCC/clang diagnostic` lines,
+  #     which MSVC ignores as unknown pragmas (C4068).
+  # That is strong evidence, NOT proof — nobody here has run cl.exe over it. The
+  # first dispatch is the experiment. If MSVC rejects something, RECORD WHAT IT
+  # REJECTED: do not reach for flags that hide a real incompatibility, and do
+  # not fall back to MinGW (see the ABI hazard above). Selecting a C STANDARD
+  # (`-Dc_std=…`) is a legitimate answer to a standards diagnostic; `/w` is not.
+  # `c_std` is deliberately NOT preset here — MSVC's default C mode is its most
+  # permissive, so the first run should be asked the plainest possible question.
+  #
+  # ── WHAT PROMOTION WOULD STILL OWE, beyond a green run ────────────────────
+  #
+  # Recorded because "it built and loaded" is NOT the whole bill:
+  #   • `gwebgl.dll` imports `epoxy-0.dll`. On Linux libepoxy is a distro
+  #     package; Windows has no system libepoxy, so a shipped win32 prebuild is
+  #     NOT self-contained the way the Linux ones are — it needs node-gi's
+  #     batteries-included GTK bundle (which carries epoxy because GTK4 does).
+  #     Whose tarball ships what is a promotion decision, not a build detail.
+  #   • The load test proves `dlopen` + `…_get_type`, never RENDERING. A
+  #     display-less runner cannot drive a `Gtk.GLArea`, exactly as the macOS
+  #     note above says. Pixels need a real desktop.
+  #   • Promotion is one change: the `win32-x64` token in `gjsify.platforms`, a
+  #     generated `@gjsify/webgl-win32-x64` package (`generate-platform-packages
+  #     .mjs --write`) with its npm name bootstrapped via `gjsify onboard`, both
+  #     `if:` gates dropped, and the matching download + `git add` in
+  #     `commit-prebuilds`.
+  # ════════════════════════════════════════════════════════════════════════════
+  webgl-vala-c-win32:
+    name: Emit Vala C + GIR for the win32 experiment (fedora)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 20
+    container:
+      # fedora:43 for the VALAC VERSION, not for its glibc. Everything this job
+      # emits is text — C sources and an XML GIR — so the elaborate glibc-floor
+      # argument on `build-prebuilds`' identical image does not apply here and
+      # this line is not a distribution decision. What it does buy is that ONE
+      # valac produces the C for every target: the same compiler that builds the
+      # committed Linux prebuilds emits what MSVC will compile, so the two halves
+      # cannot disagree about generated code.
+      image: fedora:43
+    steps:
+      # No `changes` gate anywhere in either job, deliberately. A dispatch has no
+      # previous state to diff against, so the `changes` job classifies
+      # everything as built and `skip` is always `[]` — an
+      # `!contains(needs.changes.outputs.skip, '"webgl"')` here would be a
+      # condition that cannot be false, reading as a decision while being dead
+      # weight.
+      - name: Install prerequisites
+        # No Rust, no gstreamer, no soup/nghttp2/gnutls: this job compiles ONE
+        # Vala bridge. gtk4/gdk-pixbuf2/libepoxy are what its `dependency()`
+        # calls resolve; gobject-introspection-devel supplies g-ir-compiler for
+        # the Linux-side typelib (built but not shipped — see below).
+        run: >
+          dnf install -y
+          git tar xz findutils
+          meson vala gcc pkgconf
+          glib2-devel gobject-introspection-devel
+          gtk4-devel gdk-pixbuf2-devel
+          libepoxy-devel
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Record the generator's provenance
+        # The C is an opaque artifact downstream, so say which compiler made it.
+        # A "MSVC rejects this" finding is only actionable next to a valac
+        # version.
+        run: |
+          valac --version
+          meson --version
+          pkg-config --modversion glib-2.0 gtk4 epoxy gdk-pixbuf-2.0
+
+      # The ORDINARY Linux build — no options, the same two commands every other
+      # Linux leg runs. Meson drives valac as part of it and leaves the emitted
+      # `.c` in its private object dir; running the full compile (rather than
+      # just the codegen rule) also proves on the cheapest possible host that the
+      # C compiles at all, so a Windows failure is unambiguously about MSVC.
+      - name: Build @gjsify/webgl Vala library (generates the C + GIR)
+        working-directory: packages/framework/webgl
+        run: |
+          meson setup build .
+          meson compile -C build
+
+      # Meson has no declared output for the Vala→C step, so the export reads its
+      # private object dir. That path is derived the same way this workflow's
+      # other Linux steps derive `build/libgwebgl.so` — and every assumption in
+      # it is ASSERTED rather than trusted, because a silent partial export would
+      # surface on Windows as an undefined symbol at link time, a long way from
+      # its cause.
+      #
+      # The `.vala` list is read off DISK and each file's `.c` is required to
+      # exist. That also catches a `src/vala/*.vala` the package's `meson.build`
+      # does not list — a file the Linux build silently ignores today.
+      - name: Export the generated C + GIR
+        working-directory: packages/framework/webgl
+        run: |
+          set -euo pipefail
+          PRIV=build/libgwebgl.so.p
+          OUT=vala-c-export
+          if [ ! -d "$PRIV" ]; then
+            echo "::error::$PRIV is missing. Meson keeps the Vala-generated C in <builddir>/<library-file>.p/; either that layout changed or the library target was renamed. Fix this path, do not glob for it — picking the wrong private dir exports the TEST APP's subset and fails on Windows at link time."
+            exit 1
+          fi
+          mkdir -p "$OUT/src/vala"
+          rc=0
+          for vala in src/vala/*.vala; do
+            rel="src/vala/$(basename "$vala" .vala).c"
+            if [ -f "$PRIV/$rel" ]; then
+              cp "$PRIV/$rel" "$OUT/$rel"
+            else
+              echo "::error file=$vala::valac emitted no $rel — this .vala is not in meson.build's \`vala_sources\`, so the Linux build is ignoring it too."
+              rc=1
+            fi
+          done
+          # `gwebgl.h` is what every generated `.c` `#include`s; the GIR is the
+          # g-ir-compiler input. Both are meson-declared outputs of the library
+          # target, so these two paths are not layout guesses.
+          cp build/gwebgl.h "$OUT/gwebgl.h"
+          cp build/Gwebgl-0.1.gir "$OUT/Gwebgl-0.1.gir"
+          echo "--- exported ---"
+          find "$OUT" -type f | sort
+          echo "--- the leaf THIS host's typelib recorded (for contrast, not shipped) ---"
+          grep -m1 -o 'shared-library="[^"]*"' build/Gwebgl-0.1.gir || true
+          exit $rc
+
+      - name: Upload the Vala C + GIR
+        uses: actions/upload-artifact@v7
+        with:
+          name: webgl-vala-c-win32
+          path: packages/framework/webgl/vala-c-export/
+          if-no-files-found: error
+          # Short on purpose: this is an intermediate consumed by the next job of
+          # the SAME run. Nothing should ever reach for an old one — that would
+          # be the committed-generated-C failure wearing a different hat.
+          retention-days: 1
+
+  build-prebuilds-win32-experimental:
+    name: Build prebuilds (win32-x64) [experimental — webgl via MSVC]
+    needs: [webgl-vala-c-win32]
+    runs-on: windows-latest
+    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
+    env:
+      PREBUILD: win32-x64
+      # gvsbuild setup is REUSED VERBATIM from node-gi.yml's `windows` job,
+      # down to the cache key, so the two share one warm cache and there is
+      # exactly one place that knows how a Windows GTK/GI toolchain is acquired
+      # in this repository. Do not hand-roll a second copy; if this needs to
+      # move, move it there.
+      GVSBUILD_VERSION: '2026.6.0'
+      GTK_PREFIX: 'C:\gtk-build\gtk\x64\release'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Node 24 builds `@gjsify/node-gi` (node-gyp) and runs the load test — the
+      # same version node-gi.yml's Windows jobs pin.
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Cache gvsbuild GTK4 bundle
+        id: cache-gtk
+        uses: actions/cache@v4
+        with:
+          path: C:\gtk-build\gtk\x64\release
+          key: gvsbuild-gtk4-${{ env.GVSBUILD_VERSION }}-x64-v1
+
+      - name: Download + extract gvsbuild GTK4 (MSVC-ABI, girepository-2.0)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://github.com/wingtk/gvsbuild/releases/download/$env:GVSBUILD_VERSION/GTK4_Gvsbuild_${env:GVSBUILD_VERSION}_x64.zip"
+          Write-Host "Downloading $url"
+          curl.exe -L --fail --retry 3 -o gtk4.zip $url
+          New-Item -ItemType Directory -Force -Path $env:GTK_PREFIX | Out-Null
+          tar.exe -xf gtk4.zip -C $env:GTK_PREFIX
+          Remove-Item gtk4.zip
+
+      - name: Put GTK on PATH + set GI/PKG env
+        shell: pwsh
+        run: |
+          "$env:GTK_PREFIX\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          "PKG_CONFIG_PATH=$env:GTK_PREFIX\lib\pkgconfig" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # The typelib DIRECTORY is historically named girepository-1.0 even for
+          # the girepository-2.0 API.
+          "GI_TYPELIB_PATH=$env:GTK_PREFIX\lib\girepository-1.0" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "GSETTINGS_SCHEMA_DIR=$env:GTK_PREFIX\share\glib-2.0\schemas" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Install meson + ninja
+        run: python -m pip install --disable-pip-version-check meson ninja
+
+      # THE EVIDENCE THIS JOB EXISTS TO PRODUCE, printed before anything can
+      # fail on it — the same posture `build-prebuilds-macos-experimental` takes
+      # with its "Report what pkg-config actually resolved" step. Two open
+      # questions live here:
+      #   • does the gvsbuild GTK4 bundle export `epoxy.pc`? GTK4 links libepoxy
+      #     on Windows and gvsbuild has a libepoxy project, but the release ZIP's
+      #     dev files are what decide it, and this bridge's C
+      #     `#include <epoxy/gl.h>`.
+      #   • is the typelib compiler still called `g-ir-compiler.exe`? GLib ≥ 2.80
+      #     moved girepository in-tree and ships `gi-compile-repository`; the
+      #     package's meson.build asks `find_program('g-ir-compiler')`, so an
+      #     absent alias fails at `meson setup` with a message that does not
+      #     explain itself. Naming both here turns that into a diagnosis. If it
+      #     IS missing, teaching meson.build to accept either name is the fix —
+      #     and it touches Linux and macOS too, so make it deliberately.
+      - name: Report what the Windows toolchain actually resolved
+        shell: pwsh
+        run: |
+          Write-Host "pkg-config: $((Get-Command pkg-config -ErrorAction SilentlyContinue).Source)"
+          foreach ($pc in @('glib-2.0','gobject-2.0','gdk-pixbuf-2.0','gtk4','epoxy','girepository-2.0')) {
+            $v = & pkg-config --define-prefix --modversion $pc 2>$null
+            if ($LASTEXITCODE -ne 0) { $v = 'MISSING' }
+            Write-Host ("{0,-20} {1}" -f $pc, $v)
+          }
+          Write-Host "--- typelib compilers on PATH ---"
+          foreach ($exe in @('g-ir-compiler','gi-compile-repository')) {
+            $c = Get-Command "$exe" -ErrorAction SilentlyContinue
+            Write-Host ("{0,-24} {1}" -f $exe, $(if ($c) { $c.Source } else { 'MISSING' }))
+          }
+          Write-Host "--- epoxy header ---"
+          Write-Host $(if (Test-Path "$env:GTK_PREFIX\include\epoxy\gl.h") { 'epoxy/gl.h present' } else { 'epoxy/gl.h MISSING' })
+
+      - name: Download the Vala C + GIR
+        uses: actions/download-artifact@v8
+        with:
+          name: webgl-vala-c-win32
+          # The meson option takes a path RELATIVE to the package, because
+          # meson's source sandbox refuses a `files()` outside the tree. Landing
+          # the download here is what makes `-Dprebuilt_vala_c=vala-c-export`
+          # resolvable, and `vala-c-export/` is gitignored so it can never be
+          # committed by accident.
+          path: packages/framework/webgl/vala-c-export
+
+      - name: Show what arrived
+        shell: pwsh
+        run: Get-ChildItem packages/framework/webgl/vala-c-export -Recurse -File | ForEach-Object { $_.FullName }
+
+      # ONE `cmd` step, because vcvars64.bat exports its environment into the
+      # shell it runs in and meson needs `cl.exe` on PATH. Deliberately NOT a
+      # third-party "setup MSVC" action and NOT a vcvars→$GITHUB_ENV dump:
+      # GitHub ignores PATH written through $GITHUB_ENV (it wants $GITHUB_PATH),
+      # so that dump silently loses the one variable that matters. vswhere is how
+      # this repo already locates the VS install (node-gi.yml's windowing bundle
+      # finds dumpbin the same way) rather than hard-coding an edition.
+      #
+      # `meson compile` runs BOTH halves of the Windows build: cl.exe over the
+      # imported C into `gwebgl.dll`, then g-ir-compiler over the imported GIR
+      # into `Gwebgl-0.1.typelib` — recording whatever leaf name meson chose,
+      # which is the point of `fs.name(libGwebgl.full_path())` in meson.build
+      # (`gwebgl.dll` under MSVC, `libgwebgl.dll` under MinGW; no
+      # `host_machine.system()` branch can be right for both).
+      - name: Build @gjsify/webgl with MSVC from the imported C
+        working-directory: packages/framework/webgl
+        shell: cmd
+        run: |
+          for /f "usebackq delims=" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath`) do set VSPATH=%%i
+          if not defined VSPATH ( echo ::error::vswhere found no Visual Studio installation & exit /b 1 )
+          call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+          cl 2>&1 | findstr /C:"Version"
+          meson setup build . -Dprebuilt_vala_c=vala-c-export || exit /b 1
+          meson compile -C build || exit /b 1
+
+      - name: Collect @gjsify/webgl prebuilds
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = "packages/framework/webgl/prebuilds/$env:PREBUILD"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          Copy-Item packages/framework/webgl/build/gwebgl.dll -Destination $dest
+          Copy-Item packages/framework/webgl/build/Gwebgl-0.1.typelib -Destination $dest
+          # The GIR comes from the ARTIFACT, not from build/: on the
+          # prebuilt-C branch meson never re-emits it (valac did, one job ago),
+          # so `build/` legitimately has none. Staging it keeps this directory
+          # the same shape the darwin legs produce, which is what lets the leaf
+          # assertion below be the same assertion.
+          Copy-Item packages/framework/webgl/vala-c-export/Gwebgl-0.1.gir -Destination $dest
+          Get-ChildItem $dest | Select-Object Name, Length
+
+      # A typelib whose recorded leaf is wrong is FOUND via GI_TYPELIB_PATH and
+      # then never loads — the silent failure `fs.name()` replaced an OS-branch
+      # chain to prevent. Assert it before the load test so a mismatch is named
+      # here rather than diagnosed from a GI error.
+      - name: Verify the typelib records a .dll leaf
+        shell: pwsh
+        run: |
+          $gir = "packages/framework/webgl/prebuilds/$env:PREBUILD/Gwebgl-0.1.gir"
+          $leaf = (Select-String -Path $gir -Pattern 'shared-library="([^"]*)"' | Select-Object -First 1).Matches[0].Groups[1].Value
+          Write-Host "$gir -> shared-library=$leaf"
+          # The GIR is the LINUX-generated one, so its recorded leaf is still
+          # `libgwebgl.so`; what matters is the TYPELIB, which meson rebuilt here
+          # with `--shared-library` set from the target meson actually produced.
+          # Read the string out of the compiled typelib rather than trusting the
+          # command line that made it.
+          $bytes = [System.IO.File]::ReadAllBytes("packages/framework/webgl/prebuilds/$env:PREBUILD/Gwebgl-0.1.typelib")
+          $text = [System.Text.Encoding]::ASCII.GetString($bytes)
+          if ($text -notmatch 'gwebgl\.dll') {
+            Write-Host "::error::the compiled typelib does not record a .dll leaf. Strings found: $(($text -split "`0" | Where-Object { $_ -match 'gwebgl' }) -join ', ')"
+            exit 1
+          }
+          Write-Host "typelib records a .dll leaf"
+
+      # ── THE LOAD TEST ────────────────────────────────────────────────────
+      #
+      # "A prebuild never LOADED in CI is a prebuild nobody tested", and this one
+      # cannot use gjs: there is no libgjs for Windows (napi.yml's `windows` job
+      # documents that open wall in detail). On Windows this project's runtime IS
+      # Node, and GObject comes from `@gjsify/node-gi` — so going through node-gi
+      # is not a workaround, it is the platform's actual GObject path, which is
+      # what makes a pass here mean something to a real user.
+      #
+      # node-gi is built FROM SOURCE against the same gvsbuild bundle rather than
+      # installed from npm, so the test cannot silently pass against a published
+      # binary that has nothing to do with this run.
+      - name: Supply libffi headers (gvsbuild omits ffi.h)
+        # Verbatim from node-gi.yml's `windows` job, which explains why: gvsbuild
+        # installs ffi.lib but not ffi.h/ffitarget.h, while GLib's girffi.h
+        # (which it DOES install) includes ffi.h — so the addon will not compile
+        # (C1083) without them. libffi's public ABI is frozen across 3.x.
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libffi:x64-windows
+          $inc = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\include"
+          Copy-Item "$inc\ffi.h","$inc\ffitarget.h" -Destination "$env:GTK_PREFIX\include" -Force
+
+      - name: Build @gjsify/node-gi (node-gyp / MSVC)
+        working-directory: packages/node-gi/node-gi
+        run: npm install --no-audit --no-fund --foreground-scripts
+
+      # Resolving a CLASS is the trigger, not a formality: `getGType` is what
+      # forces GI to call the type's `…_get_type`, and THAT is what LoadLibrary's
+      # the leaf the typelib records. A typelib merely FOUND resolves the
+      # namespace and then returns null here — which is why the check below is on
+      # the GType and not on `requireNamespace` succeeding.
+      #
+      # `node --input-type=module -e` from inside the node-gi package rather than
+      # a written probe file: `-e`'s module base is the cwd, so `./index.js`
+      # resolves with nothing to clean up afterwards. The array-join is not style
+      # — a PowerShell here-string has to start at column 0, which terminates the
+      # YAML block scalar the step is written in.
+      - name: Load-test the win32-x64 prebuild through node-gi
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $abs = (Resolve-Path "packages/framework/webgl/prebuilds/$env:PREBUILD").Path
+          # PATH is the DLL search path on Windows — the analogue of
+          # LD_LIBRARY_PATH/DYLD_LIBRARY_PATH in the Linux/darwin load tests, and
+          # what `buildNativeEnv()` exports for win32.
+          $env:PATH = "$abs;$env:PATH"
+          $env:GI_TYPELIB_PATH = "$abs;$env:GI_TYPELIB_PATH"
+          $env:NODE_GI_NATIVE = 'build'
+          $probe = @(
+            "import { requireNamespace, getGType } from './index.js';",
+            "requireNamespace('Gwebgl', '0.1');",
+            "const g = getGType('Gwebgl', 'WebGLRenderingContext');",
+            "if (g == null) throw new Error('getGType returned null - the typelib was found but gwebgl.dll never loaded');",
+            "console.log('Gwebgl.WebGLRenderingContext resolved via node-gi - gwebgl.dll loaded, GType', g);"
+          ) -join "`n"
+          Push-Location packages/node-gi/node-gi
+          try { node --input-type=module -e $probe } finally { Pop-Location }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload @gjsify/webgl win32-x64 prebuilds artifact
+        # Uploaded so a dispatch can be inspected and diffed. NOT downloaded by
+        # `commit-prebuilds` — committing it is the promotion step, together with
+        # the declaration and the per-target package (see this block's header).
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: webgl-prebuilds-win32-x64
+          path: packages/framework/webgl/prebuilds/win32-x64/
+          if-no-files-found: warn
+          retention-days: 30
+
   # ----------------------------------------------------------------
   # Alpine / musl — prebuilds/linux-{x64,arm64}-musl
   #
@@ -2736,6 +3192,8 @@ jobs:
       - build-prebuilds-qemu
       - build-prebuilds-macos
       - build-prebuilds-macos-experimental
+      - webgl-vala-c-win32
+      - build-prebuilds-win32-experimental
       - build-prebuilds-musl
       - commit-prebuilds
     if: always()
@@ -2800,10 +3258,11 @@ jobs:
               echo 'skipped leg that matters is `build-prebuilds-macos` — every Linux target in'
               echo '`package.json#gjsify.platforms` is built, neither `darwin-arm64` nor'
               echo '`darwin-x64` is (both are legs of that one matrixed job). Label the PR'
-              echo '`ci:macos` to add them. (`build-prebuilds-macos-experimental` and'
-              echo '`build-prebuilds-musl` are dispatch-only by design — the musl leg builds targets'
-              echo 'no package declares yet, so it proves itself before the declaration exists —'
-              echo 'and `commit-prebuilds` is main-only by design.)'
+              echo '`ci:macos` to add them. (`build-prebuilds-macos-experimental`,'
+              echo '`build-prebuilds-musl` and the win32 pair `webgl-vala-c-win32` +'
+              echo '`build-prebuilds-win32-experimental` are dispatch-only by design — each builds'
+              echo 'targets no package declares yet, so they prove themselves before the'
+              echo 'declaration exists — and `commit-prebuilds` is main-only by design.)'
             else
               echo '**Every prebuild leg in this workflow ran.**'
             fi

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1745,14 +1745,26 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
     container:
-      # fedora:43 for the VALAC VERSION, not for its glibc. Everything this job
-      # emits is text — C sources and an XML GIR — so the elaborate glibc-floor
-      # argument on `build-prebuilds`' identical image does not apply here and
-      # this line is not a distribution decision. What it does buy is that ONE
-      # valac produces the C for every target: the same compiler that builds the
-      # committed Linux prebuilds emits what MSVC will compile, so the two halves
-      # cannot disagree about generated code.
-      image: fedora:43
+      # THE BAKED IMAGE, not a bare `fedora:43` — required, and machine-checked
+      # by `scripts/check-ci-image-packages.mjs`: an amd64 containerised job that
+      # COULD run on this image and does not must be ledgered with a reason, and
+      # that ledger is deliberately empty. (It caught this job on its first run.
+      # The three jobs still on a bare image are all `ubuntu-24.04-arm`, which
+      # the check DERIVES as excused because `build-ci-image.yml` publishes
+      # linux/amd64 only.) It also removes the `dnf install` this job used to
+      # carry: the image already bakes meson, vala, gcc, pkgconf, glib2-devel,
+      # gobject-introspection-devel, gtk4-devel, gdk-pixbuf2-devel and
+      # libepoxy-devel, which is exactly this job's set.
+      #
+      # TAG 43, NOT 44, and for the VALAC VERSION rather than for glibc:
+      # `ci-fedora:43` is `FROM fedora:43`, the image `build-prebuilds` pins, so
+      # ONE valac produces the C for every target — the same compiler that builds
+      # the committed Linux prebuilds emits what MSVC will compile, and the two
+      # halves cannot disagree about generated code. The elaborate glibc-floor
+      # argument on `build-prebuilds`' image does NOT apply here: everything this
+      # job emits is text (C sources and an XML GIR), so this line is not a
+      # distribution decision.
+      image: ghcr.io/gjsify/ci-fedora:43
     steps:
       # No `changes` gate anywhere in either job, deliberately. A dispatch has no
       # previous state to diff against, so the `changes` job classifies
@@ -1760,27 +1772,19 @@ jobs:
       # `!contains(needs.changes.outputs.skip, '"webgl"')` here would be a
       # condition that cannot be false, reading as a decision while being dead
       # weight.
-      - name: Install prerequisites
-        # No Rust, no gstreamer, no soup/nghttp2/gnutls: this job compiles ONE
-        # Vala bridge. gtk4/gdk-pixbuf2/libepoxy are what its `dependency()`
-        # calls resolve; gobject-introspection-devel supplies g-ir-compiler for
-        # the Linux-side typelib (built but not shipped — see below).
-        run: >
-          dnf install -y
-          git tar xz findutils
-          meson vala gcc pkgconf
-          glib2-devel gobject-introspection-devel
-          gtk4-devel gdk-pixbuf2-devel
-          libepoxy-devel
-
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Record the generator's provenance
-        # The C is an opaque artifact downstream, so say which compiler made it.
-        # A "MSVC rejects this" finding is only actionable next to a valac
-        # version.
+      - name: Verify the baked toolchain + record the generator's provenance
+        # TWO jobs, one step, because they print the same three facts. Verifying
+        # is the convention every job on this image follows — assert the tools
+        # are there rather than assume the pull was the image you meant, so a
+        # bare `fedora:43` fails HERE naming the cause instead of inside `meson
+        # setup`. Recording is what makes the C downstream actionable: it is an
+        # opaque artifact by the time MSVC sees it, and a "MSVC rejects this"
+        # finding is only useful next to a valac version.
         run: |
+          echo "ci-fedora image major: $(cat /etc/gjsify-ci-fedora-version)"
           valac --version
           meson --version
           pkg-config --modversion glib-2.0 gtk4 epoxy gdk-pixbuf-2.0

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -1680,11 +1680,21 @@ jobs:
   # `Gwebgl-0.1.typelib` BYTE-IDENTICAL to the valac branch's, and both load
   # `Gwebgl.WebGLRenderingContext` under stock gjs).
   #
-  # ── THE ONE GENUINE UNKNOWN THIS EXISTS TO ANSWER ─────────────────────────
+  # ── THE ONE GENUINE UNKNOWN — ANSWERED: YES, MSVC COMPILES IT ─────────────
   #
-  # DOES MSVC COMPILE VALA-GENERATED C? docs.vala.dev states Vala targets the
-  # same C ABI and GObject stack on Windows as elsewhere, and a source scan of
-  # the emitted C (10266 lines across 4 `.c` + `gwebgl.h`) found no construct
+  # MEASURED on the first dispatch (run 30808356641, cl.exe 19.51.36252, VS
+  # 2026): of the four generated `.c` files, MSVC compiled `handle-types.c` and
+  # `webgl-rendering-context.c` CLEANLY and reported ZERO language diagnostics on
+  # any of them. The two that failed did so with `C1083: Cannot open include
+  # file: 'epoxy/gl.h'` — a missing include DIRECTORY on a header that was
+  # present on disk (see the `INCLUDE` line in the build step for the mechanism
+  # and the fix). So the question this job was created to answer is settled:
+  # Vala-generated C is MSVC-compatible, and nothing about the generated code
+  # needed changing.
+  #
+  # The pre-dispatch source scan that predicted this is kept because it explains
+  # WHY, and because it is the thing to re-run if a valac bump ever breaks it —
+  # across 10266 lines of emitted C (4 `.c` + `gwebgl.h`) there is no construct
   # MSVC rejects:
   #   • ZERO statement expressions, `typeof`, `__extension__`, `__builtin_*`,
   #     nested functions, VLAs or `long long`.
@@ -1697,13 +1707,13 @@ jobs:
   #     is the property that makes this split work at all.
   #   • The only remaining GCC-isms are 3 `#pragma GCC/clang diagnostic` lines,
   #     which MSVC ignores as unknown pragmas (C4068).
-  # That is strong evidence, NOT proof — nobody here has run cl.exe over it. The
-  # first dispatch is the experiment. If MSVC rejects something, RECORD WHAT IT
-  # REJECTED: do not reach for flags that hide a real incompatibility, and do
-  # not fall back to MinGW (see the ABI hazard above). Selecting a C STANDARD
-  # (`-Dc_std=…`) is a legitimate answer to a standards diagnostic; `/w` is not.
-  # `c_std` is deliberately NOT preset here — MSVC's default C mode is its most
-  # permissive, so the first run should be asked the plainest possible question.
+  # `c_std` is deliberately NOT preset — MSVC's default C mode is its most
+  # permissive, and the first run confirmed nothing stricter is needed. THE RULE
+  # THAT GOT THIS ANSWER, kept for whoever hits the next wall: record what the
+  # compiler actually rejected. Do not reach for flags that hide a real
+  # incompatibility, and do not fall back to MinGW (see the ABI hazard above).
+  # Selecting a C STANDARD or supplying a missing include DIRECTORY answers a
+  # real question about the platform; `/w` answers none.
   #
   # ── WHAT PROMOTION WOULD STILL OWE, beyond a green run ────────────────────
   #
@@ -1921,6 +1931,18 @@ jobs:
           }
           Write-Host "--- epoxy header ---"
           Write-Host $(if (Test-Path "$env:GTK_PREFIX\include\epoxy\gl.h") { 'epoxy/gl.h present' } else { 'epoxy/gl.h MISSING' })
+          # MEASURED, not inferred: the first dispatch failed C1083 on
+          # `epoxy/gl.h` while the header was present and `epoxy.pc` resolved,
+          # because `epoxy.pc` emits NO -I at all. On a POSIX prefix
+          # `<prefix>/include` is a default compiler search path so a .pc has
+          # nothing to add; MSVC has no such default, so the header is present
+          # and unreachable. Print the cflags each dependency contributes so
+          # that mechanism stays visible in the log instead of living only in a
+          # comment — glib is the contrast case, it names its own subdirectory.
+          Write-Host "--- cflags each dependency contributes ---"
+          foreach ($pc in @('epoxy','glib-2.0','gtk4')) {
+            Write-Host ("{0,-12} {1}" -f $pc, (& pkg-config --define-prefix --cflags-only-I $pc 2>&1))
+          }
 
       - name: Download the Vala C + GIR
         uses: actions/download-artifact@v8
@@ -1959,6 +1981,26 @@ jobs:
           if not defined VSPATH ( echo ::error::vswhere found no Visual Studio installation & exit /b 1 )
           call "%VSPATH%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
           cl 2>&1 | findstr /C:"Version"
+          rem Supply the include ROOT of the gvsbuild prefix, which no .pc file
+          rem names. MEASURED on the first dispatch (run 30808356641): MSVC
+          rem compiled 2 of the 4 generated .c files and failed the other two
+          rem with C1083 on `epoxy/gl.h` — a header that WAS present at
+          rem %GTK_PREFIX%\include\epoxy\gl.h while `pkg-config epoxy` resolved
+          rem 1.5.10 and contributed no -I whatsoever. `epoxy.pc` installs its
+          rem headers straight into <prefix>/include, which on a POSIX prefix is
+          rem already a default compiler search path, so the .pc has nothing to
+          rem add; MSVC has no equivalent default. (glib is the contrast: it
+          rem names include/glib-2.0, so its -I is explicit and it compiled.)
+          rem
+          rem This is SUPPLYING A PLATFORM DEFAULT, not hiding an
+          rem incompatibility — the same class as this job's vcpkg ffi.h step
+          rem and node-gi.yml's, which exists because gvsbuild omits ffi.h
+          rem outright. It is deliberately NOT a `-Dc_args=` in meson.build:
+          rem meson.build must stay free of Windows specifics, and `INCLUDE` is
+          rem the variable MSVC itself defines for exactly this, set right next
+          rem to the vcvars call that establishes the rest of the toolchain env.
+          rem What it is NOT: /w, /std:cNN, or any diagnostic suppression.
+          set INCLUDE=%GTK_PREFIX%\include;%INCLUDE%
           meson setup build . -Dprebuilt_vala_c=vala-c-export || exit /b 1
           meson compile -C build || exit /b 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,15 @@ repo/
 # `check-refs-pin.mjs` pins the refs/ half. See each package's README.
 packages/infra/*/src/rust/target/
 
+# Vala-generated C + GIR handed from a valac host to a host that has no valac
+# (today: the win32 webgl experiment in prebuilds.yml, via the package's
+# `prebuilt_vala_c` meson option). Generation and consumption happen in the SAME
+# workflow run, so these must NEVER be committed: a tracked copy would be a
+# build input nothing regenerates and nothing byte-checks — the stale-artifact
+# class AGENTS.md § Committed-artifact freshness exists to keep out. The ignore
+# is the mechanism; the option's comment is only the explanation.
+vala-c-export/
+
 *.tsbuildinfo
 
 node_modules/

--- a/packages/framework/webgl/meson.build
+++ b/packages/framework/webgl/meson.build
@@ -1,26 +1,79 @@
-project('Gwebgl', ['c', 'vala'], version: '0.1')
+# `vala` is added CONDITIONALLY below rather than declared here, because declaring
+# a language makes meson require its compiler at `meson setup` time — and the
+# whole point of the `prebuilt_vala_c` option is a host that has no valac. Adding
+# it via `add_languages()` on the branch that needs it is the only difference from
+# `project('Gwebgl', ['c', 'vala'], …)`; the Vala path below is otherwise
+# unchanged.
+project('Gwebgl', ['c'], version: '0.1')
 
 root_dir = meson.current_source_dir()
 
 vapi_dir = root_dir / 'src/vapi'
 
-add_project_arguments(
-    [
-        '--vapidir', vapi_dir,
-    ],
-    language: 'vala'
-)
+gir_name = meson.project_name() + '-0.1.gir'
+
+# ONE source list, TWO consumers: valac compiles these entries on a host that has
+# it, and the prebuilt-C branch derives its `.c` file names from the very same
+# entries. A second hand-written list of `.c` names is how the two halves would
+# drift — the file that got added to one and not the other fails at LINK time
+# with an undefined symbol, a long way from the list that caused it.
+vala_sources = [
+    'src/vala/handle-types.vala',
+    'src/vala/webgl-rendering-context-base.vala',
+    'src/vala/webgl-rendering-context.vala',
+    'src/vala/webgl2-rendering-context.vala',
+]
 
 dependencies = [ dependency('glib-2.0'), dependency('gobject-2.0'), dependency('gdk-pixbuf-2.0'), dependency('gtk4'), dependency('epoxy')]
 
-sources = files('src/vala/handle-types.vala', 'src/vala/webgl-rendering-context-base.vala', 'src/vala/webgl-rendering-context.vala', 'src/vala/webgl2-rendering-context.vala')
+prebuilt_vala_c = get_option('prebuilt_vala_c')
 
-libGwebgl = library('gwebgl', sources,
-    dependencies: dependencies,
-    vala_gir:  meson.project_name() + '-0.1.gir',
-    install: true,
-    install_dir: [true, true, true, true]
-)
+if prebuilt_vala_c == ''
+    add_languages('vala', native: false)
+
+    add_project_arguments(
+        [
+            '--vapidir', vapi_dir,
+        ],
+        language: 'vala'
+    )
+
+    sources = files(vala_sources)
+
+    libGwebgl = library('gwebgl', sources,
+        dependencies: dependencies,
+        vala_gir:  gir_name,
+        install: true,
+        install_dir: [true, true, true, true]
+    )
+
+    gir_path = meson.current_build_dir() / gir_name
+
+    # Test app — Vala-only by construction, so it lives on this branch. It is not
+    # part of the shipped prebuild and the Windows experiment does not need it.
+    test_sources = files('src/vala/handle-types.vala', 'src/vala/webgl-rendering-context-base.vala', 'src/vala/webgl-rendering-context.vala', 'src/test/app.vala')
+    executable('gwebgl_vala_app', test_sources, dependencies: dependencies)
+else
+    # The C valac already emitted, compiled by whatever C compiler this host has.
+    # Nothing here is Windows-specific: the branch is "somebody else ran valac",
+    # not "this is MSVC", which is why a Linux host can exercise it too — and
+    # should, because a branch only Windows takes is a branch nobody reviews.
+    prebuilt_c = []
+    foreach vala_source : vala_sources
+        prebuilt_c += prebuilt_vala_c / vala_source.replace('.vala', '.c')
+    endforeach
+
+    libGwebgl = library('gwebgl', files(prebuilt_c),
+        dependencies: dependencies,
+        # The generated `.c` files do `#include "gwebgl.h"`, which sits at the
+        # ROOT of the artifact while they sit under `src/vala/` — so the quoted
+        # include does not find it next to the includer and needs this -I.
+        include_directories: include_directories(prebuilt_vala_c),
+        install: true
+    )
+
+    gir_path = root_dir / prebuilt_vala_c / gir_name
+endif
 
 # ----------------------------------------------------------------------------
 # The shared-library leaf name the typelib records — ASKED, not predicted.
@@ -46,14 +99,9 @@ g_ir_compiler = find_program('g-ir-compiler')
 
 
 # TODO not working if gwebgl-0.1.gir not exists
-custom_target(meson.project_name() + '-0.1.typelib', command: [g_ir_compiler, '--shared-library', shared_lib_name, '--output', '@OUTPUT@', meson.current_build_dir() / meson.project_name() + '-0.1.gir'],
-              #input: meson.current_build_dir() / meson.project_name() + '-0.1.gir',
+custom_target(meson.project_name() + '-0.1.typelib', command: [g_ir_compiler, '--shared-library', shared_lib_name, '--output', '@OUTPUT@', gir_path],
+              #input: gir_path,
               output: meson.project_name() +'-0.1.typelib',
               depends: libGwebgl,
               install: true,
               install_dir: get_option('libdir') / 'girepository-1.0')
-
-
-# Test app
-test_sources = files('src/vala/handle-types.vala', 'src/vala/webgl-rendering-context-base.vala', 'src/vala/webgl-rendering-context.vala', 'src/test/app.vala')
-executable('gwebgl_vala_app', test_sources, dependencies: dependencies)

--- a/packages/framework/webgl/meson_options.txt
+++ b/packages/framework/webgl/meson_options.txt
@@ -1,0 +1,35 @@
+# valac does not run on Windows, so a win32 build of this bridge has to be split
+# across two hosts: one that HAS valac emits the C sources and the GIR, and the
+# Windows half compiles those with MSVC. This option is how the second half is
+# told where the first half's output is.
+#
+# EMPTY (the default) IS THE ORDINARY BUILD. valac runs, meson drives it exactly
+# as before, and this file changes nothing — every Linux/macOS leg keeps the code
+# path it already had.
+#
+# Set it to a directory RELATIVE TO THIS PACKAGE (meson's source sandbox refuses
+# a `files()` outside the tree, and an artifact unpacked into the package dir is
+# also the only shape a CI download can produce without a copy step), holding:
+#
+#   <dir>/gwebgl.h              the generated public header (`#include "gwebgl.h"`)
+#   <dir>/Gwebgl-0.1.gir        valac's GIR — the g-ir-compiler input
+#   <dir>/src/vala/<name>.c     one .c per .vala, MIRRORING the source path,
+#                               which is what valac does with `--directory`
+#
+# WHY AN OPTION AND NOT A SECOND meson.build: a second build description is only
+# ever exercised by the platform that uses it, so it drifts from the one Linux CI
+# runs on every PR and nobody finds out until somebody dispatches the Windows
+# leg. One description with a branch keeps both halves inside the file that every
+# green Linux build already reads.
+#
+# WHY THE C IS NEVER COMMITTED: generation and consumption happen in the SAME
+# workflow run, from the same commit and the same valac, so the two cannot drift.
+# A committed copy would recreate the stale-artifact class this repo keeps paying
+# for (AGENTS.md § Committed-artifact freshness) — with no guard, because nothing
+# would rebuild it.
+option(
+    'prebuilt_vala_c',
+    type: 'string',
+    value: '',
+    description: 'Directory with pre-generated Vala C sources + GIR; skips valac (see comment in meson_options.txt)',
+)

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -738,16 +738,23 @@ repository has the same "valac does not run on Windows" problem, and
 Lifting it is premature until a second bridge wants it — but the second one is
 where the helper gets lifted, not the third.
 
-The win32 leg deliberately hand-copies its artifacts instead of going through
-`scripts/stage-prebuild.mjs`, and the reason is worth stating because the shared
-stager is normally the rule: since ADR 0017 `resolveStageDir()` requires a
-sibling per-target package for any bridge that declares no `gjsify.prebuilds`,
-and creating `@gjsify/webgl-win32-x64` IS the declaration this leg exists to earn
-first. That is not hypothetical — `build-prebuilds-musl` walks straight into it
-today and both its legs fail on it (`sab-native-linux-x64-musl/ does not exist …
-Generate the platform packages first`), so the musl exploration is currently
-blocked on the same ordering problem rather than on anything about musl. Either
-`--allow-undeclared` grows a "stage into the bridge as scratch" mode for exactly
-this pre-declaration state, or every exploratory leg keeps its own `cp` and the
-stager's safety guarantees do not cover the legs that most need them. Pick one
-deliberately.
+The win32 leg hand-copies its artifacts instead of going through
+`scripts/stage-prebuild.mjs`, and that is now the ONLY thing keeping a second
+copy of staging logic alive. The reason it started that way: since ADR 0017
+`resolveStageDir()` requires a sibling per-target package for any bridge that
+declares no `gjsify.prebuilds`, and creating `@gjsify/webgl-win32-x64` IS the
+declaration this leg exists to earn first — so there was no destination to stage
+into. `build-prebuilds-musl` hit the identical wall (`sab-native-linux-x64-musl/
+does not exist … Generate the platform packages first`), which is what made this
+an ordering problem rather than anything about win32 or musl.
+
+That question is ANSWERED, not open: the stager grew a NAMED scratch destination
+(`--dest <dir>`, only valid together with `--allow-undeclared` — a relaxed
+default would have been the wrong shape, since a destination outside the package
+tree is only meaningful for a target the package does not promise), and
+`musl-build.sh` uses it. **The remaining work is to delete this leg's `cp` and
+call the stager the same way**, so the extension-matching and loader-path checks
+cover the leg that most needs them: an exploratory port is exactly where a
+renamed library or a missing sibling is most likely, and a hand-written `cp` is
+the one path that cannot notice either. Left undone here only because it would
+have made this PR depend on that one landing first.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -691,3 +691,44 @@ still unusable on a whole libc's worth of hosts, and because the reflex fix —
 teaching the musl check to verify GStreamer elements — would be an accepted gap
 from day one. Revisit when Alpine's libnice reaches 0.1.23; the right check then
 is a real element probe, which would go green rather than being born red.
+
+### `@gjsify/webgl` on win32-x64 — the exploratory leg exists; the declaration does not
+
+`prebuilds.yml` carries a dispatch-only PAIR — `webgl-vala-c-win32` (Linux, emits
+the Vala C + GIR) and `build-prebuilds-win32-experimental` (windows-latest,
+compiles that C with MSVC against gvsbuild and load-tests through
+`@gjsify/node-gi`) — behind the package's `prebuilt_vala_c` meson option. No
+`win32-x64` token is in `gjsify.platforms`, deliberately: the declared-vs-built
+invariant is symmetric, so the leg proves itself first. Full rationale, the
+researched rejection of valac-on-Windows/MinGW, and the pre-dispatch source scan
+of the generated C live in that block's header comment — do not duplicate them
+here.
+
+What is still OPEN, i.e. what a promotion owes beyond a green dispatch:
+
+- **`gwebgl.dll` imports `epoxy-0.dll`, and Windows has no system libepoxy.** On
+  Linux and macOS libepoxy is a distro/Homebrew package, so the committed
+  prebuild is a single library plus a typelib. On win32 the loadable unit is
+  bigger than the artifact: it needs node-gi's batteries-included GTK bundle
+  (which carries epoxy because GTK4 does). Which tarball ships what is a
+  packaging decision nobody has taken — and it is the first case in this repo
+  where a prebuild's runtime closure is not satisfiable from the host.
+- **The load test proves `dlopen` + `…_get_type`, never RENDERING.** A
+  display-less runner cannot drive a `Gtk.GLArea`, the same gap the darwin note
+  in `build-prebuilds-macos-experimental` records. Pixels need a real desktop —
+  the win11-gjsify VM is the machine for it.
+- **Promotion is ONE change**: the `win32-x64` token in `gjsify.platforms`, a
+  generated `@gjsify/webgl-win32-x64` package (`generate-platform-packages.mjs
+  --write`) whose npm name is bootstrapped via `gjsify onboard` BEFORE the
+  release that ships it, both `if: github.event_name == 'workflow_dispatch'`
+  gates dropped, and the matching download + `git add` in `commit-prebuilds`.
+- **It would close the concrete failure the `needsWebgl` entry above records** —
+  `gjsify showcase three-geometry-teapot` dying at `gi://Gwebgl` on win32 — so
+  the two are worth reading together, and a win32 prebuild changes which of that
+  entry's two resolutions is the honest one.
+
+The split itself generalises past webgl: every other Vala bridge in this
+repository has the same "valac does not run on Windows" problem, and
+`prebuilt_vala_c` is a per-package option today rather than a shared mechanism.
+Lifting it is premature until a second bridge wants it — but the second one is
+where the helper gets lifted, not the third.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -732,3 +732,17 @@ repository has the same "valac does not run on Windows" problem, and
 `prebuilt_vala_c` is a per-package option today rather than a shared mechanism.
 Lifting it is premature until a second bridge wants it — but the second one is
 where the helper gets lifted, not the third.
+
+The win32 leg deliberately hand-copies its artifacts instead of going through
+`scripts/stage-prebuild.mjs`, and the reason is worth stating because the shared
+stager is normally the rule: since ADR 0017 `resolveStageDir()` requires a
+sibling per-target package for any bridge that declares no `gjsify.prebuilds`,
+and creating `@gjsify/webgl-win32-x64` IS the declaration this leg exists to earn
+first. That is not hypothetical — `build-prebuilds-musl` walks straight into it
+today and both its legs fail on it (`sab-native-linux-x64-musl/ does not exist …
+Generate the platform packages first`), so the musl exploration is currently
+blocked on the same ordering problem rather than on anything about musl. Either
+`--allow-undeclared` grows a "stage into the bridge as scratch" mode for exactly
+this pre-declaration state, or every exploratory leg keeps its own `cp` and the
+stager's safety guarantees do not cover the legs that most need them. Pick one
+deliberately.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -700,11 +700,16 @@ compiles that C with MSVC against gvsbuild and load-tests through
 `@gjsify/node-gi`) — behind the package's `prebuilt_vala_c` meson option. No
 `win32-x64` token is in `gjsify.platforms`, deliberately: the declared-vs-built
 invariant is symmetric, so the leg proves itself first. Full rationale, the
-researched rejection of valac-on-Windows/MinGW, and the pre-dispatch source scan
-of the generated C live in that block's header comment — do not duplicate them
-here.
+researched rejection of valac-on-Windows/MinGW, and the measured MSVC result live
+in that block's header comment — do not duplicate them here.
 
-What is still OPEN, i.e. what a promotion owes beyond a green dispatch:
+**The leg is GREEN** (run 30808747504): all four generated `.c` files compile
+under cl.exe 19.51 with zero language diagnostics, `gwebgl.dll` links, the
+typelib records a `.dll` leaf, and `Gwebgl.WebGLRenderingContext` resolves
+through `@gjsify/node-gi` — so the library is really loaded, not merely found.
+What remains is a DECLARATION decision, not an engineering unknown.
+
+What is still OPEN, i.e. what a promotion owes beyond that green dispatch:
 
 - **`gwebgl.dll` imports `epoxy-0.dll`, and Windows has no system libepoxy.** On
   Linux and macOS libepoxy is a distro/Homebrew package, so the committed

--- a/tests/e2e/prebuild-change-gate/run.mjs
+++ b/tests/e2e/prebuild-change-gate/run.mjs
@@ -392,21 +392,49 @@ describe('prebuild change gate — fail open', () => {
         // `download-artifact` throws `Artifact '<name>' not found` and has no
         // `if-no-artifact-found` input — so upload and download must turn on and
         // off together, per package, everywhere.
+        //
+        // SCOPED TO THE AUTOMATIC LEGS, because the decision it enforces only
+        // exists there. A `workflow_dispatch`-only job is not in `needs: [changes]`
+        // — `needs.changes.outputs.skip` is not in scope inside it, so requiring
+        // the gate string would buy a dead `if:` that READS like a live decision,
+        // which is worse than none. It is also unnecessary: an exploratory leg
+        // uploads for a human to inspect, `commit-prebuilds` never downloads it,
+        // and an artifact nothing consumes cannot desync from anything.
+        //
+        // Pairs are matched by JOB SCOPE rather than by artifact name on purpose:
+        // uploads are matrix-parameterised (`…-prebuilds-linux-${{ matrix.arch }}`)
+        // while the downloads spell each arch out, so a name-level set comparison
+        // reports every automatic leg as unpaired — measured, and it is a property
+        // of the spelling, not of the workflow.
         const text = readFileSync(workflow, 'utf8');
-        const steps = text.split(/^ {6}- (?=name:|uses:|run:)/m).slice(1);
+        // Two-space-indented `<name>:` on its own line = a job. `on:`'s children
+        // match too and contribute no artifact steps, which is harmless.
+        const jobs = text.split(/^ {2}(?=[a-z0-9-]+:\s*$)/m).slice(1);
         let checked = 0;
-        for (const step of steps) {
-            if (!/actions\/(up|down)load-artifact/.test(step)) continue;
-            const artifact = /\n\s*name:\s*([\w-]+)-prebuilds-/.exec(step);
-            if (!artifact) continue;
-            const key = artifact[1];
-            checked++;
-            assert.ok(
-                step.includes(`'"${key}"'`),
-                `an artifact step for "${key}" is not gated on its own package:\n${step.slice(0, 200)}`,
-            );
+        let exempt = 0;
+        for (const job of jobs) {
+            const jobIf = /^ {4}if:\s*(.+)$/m.exec(job);
+            const dispatchOnly = jobIf?.[1].trim() === "github.event_name == 'workflow_dispatch'";
+            for (const step of job.split(/^ {6}- (?=name:|uses:|run:)/m).slice(1)) {
+                if (!/actions\/(up|down)load-artifact/.test(step)) continue;
+                const artifact = /\n\s*name:\s*([\w-]+)-prebuilds-/.exec(step);
+                if (!artifact) continue;
+                if (dispatchOnly) {
+                    exempt++;
+                    continue;
+                }
+                const key = artifact[1];
+                checked++;
+                assert.ok(
+                    step.includes(`'"${key}"'`),
+                    `an artifact step for "${key}" is not gated on its own package:\n${step.slice(0, 200)}`,
+                );
+            }
         }
-        assert.ok(checked >= 60, `expected every artifact step to be checked, saw ${checked}`);
+        // The exemption must stay a carve-out, not become the rule: the automatic
+        // legs are ~60 steps and every one of them is still held to the gate.
+        assert.ok(checked >= 60, `expected every automatic artifact step to be checked, saw ${checked}`);
+        assert.ok(exempt < checked / 4, `too many artifact steps exempted as dispatch-only (${exempt})`);
     });
 });
 


### PR DESCRIPTION
**#956 has landed; this is now rebased directly on `main`** (5 commits). It needed
that PR's `refactor(webgl): ask meson for the typelib's library leaf` —
`meson.build` derives the typelib's recorded library leaf via
`fs.name(libGwebgl.full_path())` instead of an `if host_machine.system()` chain.
That matters here specifically: the same `library('gwebgl', …)` is `gwebgl.dll`
under MSVC and `libgwebgl.dll` under MinGW, so **no OS branch can be right for
both**, and asking meson removes the one thing this port would otherwise have had
to guess. Since #956 was squash-merged, its two original commits were dropped from
this branch (`git rebase --onto main`) rather than re-applied on top of their own
squash.

## What this adds

A **`workflow_dispatch`-only pair** of jobs in `prebuilds.yml` that builds
`@gjsify/webgl` for `win32-x64`, plus the meson option that lets the Windows half
exist at all.

| job | runner | does |
|---|---|---|
| `webgl-vala-c-win32` | `fedora:43` on ubuntu | runs the ORDINARY `meson setup && meson compile`, exports the Vala-generated `.c` + `gwebgl.h` + `Gwebgl-0.1.gir` as a workflow artifact |
| `build-prebuilds-win32-experimental` | `windows-latest` | downloads that artifact, compiles the C with **MSVC** against gvsbuild, runs gvsbuild's `g-ir-compiler` on the GIR, load-tests through `@gjsify/node-gi` |

**Nothing is declared.** No `win32-x64` in `gjsify.platforms`, no per-target
package, no `commit-prebuilds` wiring. A declaration is a promise that CI
reproduces *and commits* the artifact; this is exploration, so the leg proves
itself first and the declaration follows — the same posture
`build-prebuilds-macos-experimental` and `build-prebuilds-musl` already take.
Both `if:` lines are the verbatim string `parseCiPlatforms()` matches to exclude
a manual job, so the audit stays green: `platform audit: OK. 74 native package(s)
… committed prebuilds and CI-produced targets agree with every declaration.`

## Why two jobs — valac must not run on Windows

Researched and rejected, not assumed:

- **No standalone MSVC valac exists.** `supercamel/ValaOnWindows` ships no
  compiler of its own (it points at Ooblerg or MSYS2 pacman), builds with
  MinGW-w64 gcc, and explicitly does not cover shared libraries or GIR/typelib
  generation — the two artifacts this bridge *is*.
- **gvsbuild has no `vala` project.** Checked
  `gh api repos/wingtk/gvsbuild/contents/gvsbuild/projects`: libepoxy, gtk, glib,
  gobject_introspection, libsoup, nghttp2, libnice, gstreamer — no Vala compiler.
- **MinGW anyway is an ABI hazard, not a shortcut.** gvsbuild's GTK4 is MSVC-ABI
  and the load test loads girepository out of that same bundle; a MinGW DLL
  against MSVC-ABI GLib mixes CRTs where GLib routinely allocates what the
  consumer frees. `napi.yml`'s `windows` job records the identical wall for the
  identical reason.

So a host that *has* valac emits the C **and** the GIR (`vala_gir:` is what asks
for the GIR), and the Windows half compiles that C and compiles that GIR into a
typelib. The gvsbuild acquisition is reused **verbatim** from `node-gi.yml`'s
`windows` job — same `GVSBUILD_VERSION: '2026.6.0'`, same cache key, same
PATH/`PKG_CONFIG_PATH`/`GI_TYPELIB_PATH` step, same vcpkg `ffi.h` workaround — so
one place knows how a Windows GI toolchain is acquired.

## The three constraints, and how each is held

- **The generated C is never committed.** Both halves are jobs of one run: same
  commit, same valac, so drift is structurally impossible rather than merely
  unlikely. A committed copy would be a build input nothing regenerates and
  nothing byte-checks — the stale-artifact class AGENTS.md § Committed-artifact
  freshness exists to keep out. `.gitignore` gains `vala-c-export/`, so this is
  *enforced*, not documented.
- **One build description, not two.** The Windows path is a branch in the
  package's own `meson.build` behind `-Dprebuilt_vala_c=<dir>`. A second build
  file is only ever exercised by the platform that uses it, so it drifts from the
  one Linux CI reads on every PR. The branch is *"somebody else ran valac"*, not
  *"this is MSVC"* — so a Linux host can exercise it, and did (below).
- **The GIR travels too**, not only the `.c`. It is the `g-ir-compiler` input, and
  on the prebuilt-C branch meson never re-emits it, so the collect step takes it
  from the artifact rather than from `build/`.

`vala` moves from `project()` to a conditional `add_languages()` because
declaring a language makes meson demand its compiler at setup time — precisely
what the option's host does not have. The Vala path is otherwise unchanged.

## The one genuine unknown — ANSWERED: yes, MSVC compiles it

**The leg is green.** [Run 30808747504](https://github.com/gjsify/gjsify/actions/runs/30808747504)
— cl.exe 19.51.36252 (VS 2026), valac 0.56.19, gvsbuild 2026.6.0 (GLib 2.88.1 /
GTK 4.22.4 / epoxy 1.5.10):

```
[1/6] Compiling C object gwebgl.dll.p/vala-c-export_src_vala_handle-types.c.obj
[2/6] Compiling C object gwebgl.dll.p/vala-c-export_src_vala_webgl-rendering-context.c.obj
[3/6] Compiling C object gwebgl.dll.p/vala-c-export_src_vala_webgl2-rendering-context.c.obj
[4/6] Compiling C object gwebgl.dll.p/vala-c-export_src_vala_webgl-rendering-context-base.c.obj
[5/6] Linking target gwebgl.dll
[6/6] Generating Gwebgl-0.1.typelib with a custom command
```

- **Zero language diagnostics** on any of the four files — nothing about the
  generated code needed changing.
- Staged artifact: `gwebgl.dll` 189440 B, `Gwebgl-0.1.typelib` 41744 B. The Linux
  typelib is 41752 B and the 8-byte delta is exactly the recorded leaf string
  (`gwebgl.dll` vs `libgwebgl.so`).
- The `.dll`-leaf assertion reads the **typelib bytes**, not the command line that
  made it: `typelib records a .dll leaf`. (The staged *GIR* still says
  `libgwebgl.so` — it is the Linux-generated one, which is why the check is on the
  typelib.)
- Load test through node-gi:
  `Gwebgl.WebGLRenderingContext resolved via node-gi - gwebgl.dll loaded, GType [External: 22ea0013710]`

### The one real obstacle, and how the first dispatch found it

The **first** dispatch ([run 30808356641](https://github.com/gjsify/gjsify/actions/runs/30808356641))
compiled 2 of the 4 files and failed the other two with `C1083: Cannot open
include file: 'epoxy/gl.h'` — while the header **was present** at
`%GTK_PREFIX%\include\epoxy\gl.h` and `pkg-config epoxy` resolved 1.5.10.

The mechanism is now *printed* by the diagnostics step rather than inferred:

```
--- cflags each dependency contributes ---
epoxy
glib-2.0     -I…/include/glib-2.0 -I…/lib/glib-2.0/include
gtk4         -I…/include/gtk-4.0 -I…/include/pango-1.0 …
```

`epoxy.pc` contributes **no `-I` at all**, because it installs its headers
straight into `<prefix>/include` — already a default compiler search path on a
POSIX prefix, so the `.pc` has nothing to add. MSVC has no equivalent default, so
the header is present and unreachable. glib is the contrast: it names
`include/glib-2.0`, so its `-I` is explicit, and its files compiled.

Fixed by `set INCLUDE=%GTK_PREFIX%\include;%INCLUDE%` beside the vcvars call that
establishes the rest of the toolchain env. That is **supplying a platform
default** — the same class as this job's vcpkg `ffi.h` step, which exists because
gvsbuild omits `ffi.h` outright — not a diagnostic suppression. No `/w`, no
`/std:cNN`. It is deliberately not a `-Dc_args=` in `meson.build`, which must stay
free of Windows specifics.

`c_std` is left unset: MSVC's default C mode is its most permissive and the run
confirmed nothing stricter is needed.

### Why it was always likely to work

Kept in the header comment because it explains *why*, and because it is what to
re-run if a valac bump ever breaks this. Across 10266 lines of emitted C:

- **Zero** statement expressions, `typeof`, `__extension__`, `__asm__`,
  `__builtin_*`, nested functions, VLAs or `long long`.
- The **single `__attribute__`** sits inside valac's *own* `#if defined(_MSC_VER)`
  ladder in `gwebgl.h`, whose MSVC arm is
  `#define VALA_EXTERN __declspec(dllexport) extern`. So Vala already handles
  Windows symbol export itself (**no `.def` file**, unlike the napi shim), and
  because that ladder is a *preprocessor* decision, C generated on Linux still
  takes the MSVC arm when MSVC compiles it. **That is the property the whole split
  rests on.**
- The only remaining GCC-isms are 3 `#pragma GCC/clang diagnostic` lines, which
  MSVC ignores as unknown pragmas (C4068).

## Measured locally before this landed

The prebuilt-C branch is not theoretical — it was exercised end to end on Linux
(valac 0.56.19, meson 1.11.2, GCC):

- default (valac) path: builds, typelib records `libgwebgl.so`,
  `Gwebgl.WebGLRenderingContext` resolves under stock gjs.
- `-Dprebuilt_vala_c=…` path: builds from the exported C **with no valac
  involved**, and its `Gwebgl-0.1.typelib` is **byte-identical** to the valac
  path's (`cmp` clean). Same class resolves under gjs.

So the only thing the Windows dispatch tests that Linux cannot is MSVC itself.

## The load test cannot use gjs

There is no libgjs for Windows — `napi.yml` documents that open wall. On Windows
this project's runtime **is** Node and GObject comes from `@gjsify/node-gi`, so
going through node-gi is the platform's actual GObject path rather than a
workaround. node-gi is built **from source** against the same gvsbuild bundle, so
the test cannot pass against an unrelated published binary. It resolves a
**class** via `getGType('Gwebgl', 'WebGLRenderingContext')`, because that is what
forces `…_get_type` and therefore the `LoadLibrary` — a typelib merely *found*
resolves the namespace and returns null.

## What promotion still owes (recorded in `status/open-todos.md`)

- **`gwebgl.dll` imports `epoxy-0.dll`, and Windows has no system libepoxy.** On
  Linux/macOS libepoxy is a distro/Homebrew package, so the prebuild is one
  library plus a typelib. On win32 the loadable unit is *bigger than the
  artifact* — it needs node-gi's batteries-included GTK bundle. First case in
  this repo where a prebuild's runtime closure is not satisfiable from the host,
  and a packaging decision nobody has taken.
- **The load test proves `dlopen` + `…_get_type`, never rendering.** A
  display-less runner cannot drive a `Gtk.GLArea` — same gap the darwin note
  records. Pixels need a real desktop (win11-gjsify).
- **Promotion is one change**: the token, a generated
  `@gjsify/webgl-win32-x64` (`generate-platform-packages.mjs --write`) with its
  npm name bootstrapped via `gjsify onboard` *before* the release that ships it,
  both `if:` gates dropped, and the `commit-prebuilds` download + `git add`.
- It would close the concrete failure the existing `needsWebgl` TODO records —
  `gjsify showcase three-geometry-teapot` dying at `gi://Gwebgl` on win32 — and
  changes which of that entry's two resolutions is the honest one.

## Deliberately left open

- **`prebuilt_vala_c` is per-package, not a shared mechanism.** Every other Vala
  bridge here has the same "valac does not run on Windows" problem. Lifting it is
  premature until a *second* bridge wants it — the second one is where the helper
  gets lifted, not the third.
- **Is `g-ir-compiler.exe` still the name?** GLib ≥ 2.80 moved girepository
  in-tree and ships `gi-compile-repository`; `meson.build` asks
  `find_program('g-ir-compiler')`. The Windows job's diagnostics step reports
  both names *before* the build so an absent alias is a diagnosis rather than a
  raw `meson setup` failure. Teaching `meson.build` to accept either would touch
  Linux and macOS too, so it is not done speculatively.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/prebuilds.yml'))"` — parses.
- `node scripts/audit-runtimes.mjs --check --strict` — exit 0, platform audit OK.
- No JS/TS touched, so `oxfmt` is not involved.
- **No regression on the ordinary paths**: in run 30808356641 the `x64`, `arm64`
  and `darwin-arm64` legs all built + collected `@gjsify/webgl` successfully with
  the restructured `meson.build`.
- **On a `pull_request` event both new jobs correctly SKIP** (dispatch-only) and
  `Coverage summary` succeeds — verified in run 30808458006.
- The two `linux-*-musl` failures in those runs are **pre-existing and unrelated**
  — see the staging-ordering note added to `status/open-todos.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

