### PR TITLE
test(ci): make the exemption fixture hermetic

### DIFF
--- a/tests/e2e/platform-exemption-clearing/run.mjs
+++ b/tests/e2e/platform-exemption-clearing/run.mjs
@@ -31,7 +31,12 @@ const SCRIPT = join(MONOREPO_ROOT, 'scripts', 'clear-committed-platform-exemptio
 const GENERATOR = join(MONOREPO_ROOT, 'scripts', 'generate-platform-packages.mjs');
 
 const { clearSatisfiedExemptions } = await import(`file://${SCRIPT}`);
-const { auditPlatformPackages, generatorContext } = await import(`file://${GENERATOR}`);
+const { auditPlatformPackages, expectedFiles, generatorContext, planPlatformPackages } = await import(
+    `file://${GENERATOR}`
+);
+
+/** The deferral reason the fixture declares. Any non-empty string works. */
+const FIXTURE_WHY = 'a fixture reason — the deferral text is not what this suite is about';
 
 /**
  * A realistic POST-SPLIT pair, copied out of the real tree so the fixture IS
@@ -41,6 +46,26 @@ const { auditPlatformPackages, generatorContext } = await import(`file://${GENER
  * `@gjsify/thing` fixture above has no generated `README.md`, so a suite that
  * ran on every PR shard could not see that clearing an exemption invalidates
  * one. A fixture that cannot reach the bug is not coverage.
+ *
+ * The pair is copied for SHAPE and then re-emitted into the state under test —
+ * it does not INHERIT that state. The distinction is the second half of this
+ * suite's own lesson, and it cost `main`:
+ *
+ *   `commit-prebuilds` pushes under `[skip ci]`, so nothing runs on the commit
+ *   it makes. On 2026-08-03 that commit landed the darwin-x64 artifacts and —
+ *   exactly as designed — cleared `platformsUncommitted` from the live
+ *   `tls-native-darwin-x64` manifest. This fixture used to copy that field in,
+ *   so the moment the mechanism under test worked in production, the test for it
+ *   lost its precondition: `cleared` went to `[]` on every subsequent PR, with a
+ *   bare deepEqual diff naming nothing about the cause. `main` was red for every
+ *   PR and the commit that broke it had no CI at all.
+ *
+ * So the exemption is DECLARED here, via the generator, in the `uncommitted`
+ * state. `state`/`why` are the same two fields the script under test overrides
+ * in the other direction. Seeding both generated files matters: the script only
+ * reports a path it actually had to write, so a README already in cleared shape
+ * would silently shrink `paths` to the manifest alone and the assertion below
+ * would pass while proving half of what it claims.
  */
 function splitPairFixture() {
     const root = mkdtempSync(join(tmpdir(), 'gjsify-split-pair-'));
@@ -80,13 +105,45 @@ function splitPairFixture() {
         Object.entries(parent.optionalDependencies ?? {}).filter(([name]) => name.endsWith('-darwin-x64')),
     );
     writeFileSync(parentManifest, `${JSON.stringify(parent, null, 4)}\n`);
+
+    // Put the child INTO the state under test, from the generator, so the
+    // fixture owns its own precondition. Done before the artifact directory
+    // exists: `expectedFiles` measures a binary when one is there, and the
+    // point here is the no-artifact shape.
+    const childDir = join(root, 'packages', 'node', 'tls-native-darwin-x64');
+    const childName = JSON.parse(readFileSync(join(childDir, 'package.json'), 'utf8')).name;
+    const plan = planPlatformPackages(generatorContext(root));
+    // Matched by NAME, like the script under test: `platformPackageName()` is the
+    // one truth for the parent→child mapping, and a path comparison breaks the
+    // first time a root sits behind a symlink (macOS `/var` vs `/private/var`).
+    let plannedParent = null;
+    let planned = null;
+    for (const candidate of plan.parents) {
+        const hit = candidate.targets.find((t) => t.name === childName);
+        if (hit) {
+            plannedParent = candidate;
+            planned = hit;
+            break;
+        }
+    }
+    // A fixture that silently proves nothing is the failure mode this whole
+    // comment block is about, so say so instead of asserting on the aftermath.
+    assert.ok(planned, `fixture is not a pair: the plan found no target named ${childName}`);
+    for (const [name, contents] of Object.entries(
+        expectedFiles(plannedParent, { ...planned, state: 'uncommitted', why: FIXTURE_WHY }),
+    )) {
+        writeFileSync(join(childDir, name), contents);
+    }
+
     // The landing: an EMPTY directory is enough, because `expectedFiles` is
     // artifact-independent for a darwin target (`measureLibcFields`
     // short-circuits off linux to the same shape as the no-directory fallback).
-    mkdirSync(join(root, 'packages', 'node', 'tls-native-darwin-x64', 'prebuilds', 'darwin-x64'), { recursive: true });
+    mkdirSync(join(childDir, 'prebuilds', 'darwin-x64'), { recursive: true });
     return {
         root,
-        childDir: join(root, 'packages', 'node', 'tls-native-darwin-x64'),
+        childDir,
+        childName,
+        target: planned.target,
         cleanup: () => rmSync(root, { recursive: true, force: true }),
     };
 }
@@ -230,7 +287,7 @@ describe('clear-committed-platform-exemptions', () => {
         const f = splitPairFixture();
         try {
             const { cleared, paths } = clearSatisfiedExemptions(f.root);
-            assert.deepEqual(cleared, ['@gjsify/tls-native-darwin-x64 darwin-x64']);
+            assert.deepEqual(cleared, [`${f.childName} ${f.target}`]);
             // Both generated files, not just the manifest.
             assert.deepEqual(paths.sort(), [
                 'packages/node/tls-native-darwin-x64/README.md',
@@ -250,7 +307,7 @@ describe('clear-committed-platform-exemptions', () => {
         try {
             const before = readFileSync(join(f.childDir, 'README.md'), 'utf8');
             const { cleared } = clearSatisfiedExemptions(f.root, { dryRun: true });
-            assert.deepEqual(cleared, ['@gjsify/tls-native-darwin-x64 darwin-x64']);
+            assert.deepEqual(cleared, [`${f.childName} ${f.target}`]);
             assert.equal(readFileSync(join(f.childDir, 'README.md'), 'utf8'), before);
             assert.match(readFileSync(join(f.childDir, 'package.json'), 'utf8'), /platformsUncommitted/);
         } finally {


### PR DESCRIPTION
## `main` is red for every open PR, and no PR caused it

`tests/e2e/platform-exemption-clearing/run.mjs` fails two assertions on
every pull request:

```
actual   []
expected [ '@gjsify/tls-native-darwin-x64 darwin-x64' ]
```

Reproduced on a **clean checkout of `main` (f5d250b32) with no PR content
involved** — which is what places the defect here rather than in #955, #956
or #957, all three of which were reported red for exactly this.

## What happened

`splitPairFixture()` seeded itself by **copying the live**
`packages/node/tls-native-darwin-x64/package.json` and relying on that
manifest still declaring an unsatisfied `gjsify.platformsUncommitted` entry
to clear.

`commit-prebuilds` pushes with GitHub's CI-skip directive in the commit
message, so **nothing runs on the commit it makes**. On 2026-08-03 `f5d250b32 chore: update native prebuilds` (carrying that directive)
landed the darwin artifacts and — exactly as designed, and exactly as #951
built it to — cleared `platformsUncommitted` from that same live manifest:

```diff
-        "platformsUncommitted": {
-            "darwin-x64": "prebuilds.yml's `build-prebuilds-macos` Intel leg builds, …"
-        },
```

So the mechanism *working in production* removed the test's precondition.
`cleared` became `[]`, and the failure surfaced on unrelated PRs as a bare
`deepEqual` diff naming nothing about the cause.

## The fix

The fixture now **declares** the state under test instead of inheriting it.
It plans itself, finds its own child by name, and re-emits both generated
files through the generator:

```js
expectedFiles(plannedParent, { ...planned, state: 'uncommitted', why: FIXTURE_WHY })
```

`state`/`why` are the same two fields the script under test overrides in the
other direction, so this is the sanctioned shape rather than a new one.

**Seeding both files is load-bearing, not thorough.** `clearSatisfiedExemptions`
only reports a path it actually had to write:

```js
if (existsSync(target) && readFileSync(target, 'utf8') === contents) continue;
```

A README already in cleared shape would silently shrink `paths` to the
manifest alone — the assertion would still pass while proving half of what it
claims. Injecting the manifest field alone would have been the version of this
fix that quietly re-opens #951.

`cleared` is now derived from the fixture (`${f.childName} ${f.target}`)
rather than spelling out a live package name, and the fixture asserts its own
pairing, so a fixture that proves nothing says so instead of failing on the
aftermath — the `parents found: 0` failure mode its own comment block already
warns about.

## Verification

- **8/8 pass** locally.
- **Still catches the defect it was written for.** Re-injecting #951 (skip the
  README re-emission in `clear-committed-platform-exemptions.mjs`) fails
  `leaves a tree the generator agrees with` — 7 pass / 1 fail. The fixture is
  hermetic without being neutered, which is the one thing a change like this
  can get wrong invisibly.
- A full run leaves the real tree untouched (`git status` clean apart from the
  test itself) — the `dryRun` guard the suite header calls load-bearing.
- `oxfmt --check` clean.

## The class, and what is still open

The instance is fixed. The class is not: **`commit-prebuilds` pushes to `main`
with the CI-skip directive, so any check that reads the files that job writes
is validated by nothing.** A sweep for the smallest honest guard — running the
checks the job's own mutation can invalidate *before* it pushes, so the job
that breaks `main` fails instead of a stranger's PR — is in flight, and lands
either as a follow-up commit here or as its own PR. Flagging it explicitly so
this PR is not mistaken for closing the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Footnote: this PR could not run its own CI at first

The first push of this branch reported **zero checks** and sat `BLOCKED` with
nothing red to explain it. Cause: the commit message spelled the skip directive
out literally while explaining it, and GitHub honoured it — the commit
documenting the hazard was skipped by the hazard. Both the message and this
description are now written without the token, which matters twice over: a
**squash merge turns the description into the commit message**, so leaving it
here would have skipped CI on `main` itself.
