### PR TITLE
ci(prebuilds): gate the tree the bot pushes

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -2729,21 +2729,96 @@ jobs:
       # so this needs no install and no build. It runs on the STAGED tree — after
       # every download, before the commit — which is the only moment the new
       # binaries and the old declarations exist side by side.
+      #
+      # This step is the FAST FAIL. It is deliberately kept even though the gate
+      # below subsumes it: failing before a commit exists is a clearer log than
+      # failing after a commit and a rebase.
       - name: Gate on the measured glibc floor + libc flavour
         run: |
           set -euo pipefail
           node scripts/audit-runtimes.mjs --check
 
       - name: Commit prebuilds
+        id: commit
         run: |
           set -euo pipefail
           if git diff --cached --quiet; then
             echo "No prebuild changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: update native prebuilds [skip ci]"
+            # Rebase, but DO NOT push yet — the gate below has to see the tree
+            # that will actually land, and this is the line that changes it.
             git pull --rebase origin main
-            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # THE THIRD guard, and the one that closes the hole the first two share:
+      # they check a tree nobody pushes.
+      #
+      # Two separate defects, both measured, both fixed by putting one step here:
+      #
+      # 1. ORDERING. The gate above ran before `git pull --rebase origin main`,
+      #    so the audited tree was provably not the pushed tree. A PR that edits a
+      #    bridge's `gjsify.platforms`, drops a per-target package or bumps a
+      #    version can merge while this job sits between the two steps; the rebase
+      #    replays the prebuild commit onto it cleanly, because the hunks do not
+      #    overlap, and the combination nobody audited is what lands.
+      #
+      # 2. SCOPE. The push carries `[skip ci]`, which suppresses BOTH required
+      #    checks on the resulting commit — `CI gate (GJS)` and `Detect runtime-
+      #    triplet drift` — and the step above substitutes exactly one of
+      #    audit-runtimes.yml's steps. Everything else that reads what this job
+      #    writes ran nowhere. That is not hypothetical: on 2026-08-03 f5d250b32
+      #    cleared `gjsify.platformsUncommitted` from the darwin manifests (its own
+      #    step, 90 lines up) and broke `tests/e2e/platform-exemption-clearing`,
+      #    whose fixture had seeded itself from one of them. `main` was red for
+      #    every open PR for hours, each one blaming its own diff, and the commit
+      #    that caused it had no CI to blame. The fixture is hermetic now — but
+      #    hermetic fixtures are not the general answer, because several of these
+      #    suites measure the REAL committed artifact on purpose:
+      #    `prebuild-loader-path` asserts exact glibc floors, exact DT_NEEDED sets
+      #    and a `=== null`; `prebuild-declaration-invariant` hard-codes measured
+      #    floors. Those are properties of bytes THIS JOB REWRITES.
+      #
+      # So: the checks that read this job's output now run on the exact tree this
+      # job is about to push, and a bot that would break `main` fails instead —
+      # `main` stays green and the next PR author is never handed someone else's
+      # failure.
+      #
+      # `--strict` and not plain `--check`, because audit-runtimes.yml already runs
+      # `--check --strict` on this very runner (plain `ubuntu-latest`). Leaving the
+      # bot's command weaker than the branch's is a standing exemption for every
+      # future strict-only rule.
+      #
+      # The suite list is explicit rather than a glob: it is exactly the set whose
+      # fixtures read the state this job mutates. A glob would drag in suites that
+      # need a built workspace or a GJS runtime, which this runner has not got.
+      # Every entry imports nothing but `node:*` and repo-local paths, so this
+      # needs no install and no container — measured on main: 110 tests, seconds.
+      #
+      # WHAT THIS DOES NOT COVER, so a green verdict is not misread: the two
+      # assertions that actually LOAD a committed prebuild live in main.yml's
+      # `test` job under GJS and are unreachable from here, and
+      # `prebuild-artifacts`' dlopen probe degrades to a note on a runner without
+      # libsoup/GStreamer/GTK4/libepoxy. This gate proves declarations and file
+      # shape, not that every artifact loads.
+      - name: Gate the tree being pushed
+        if: steps.commit.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          node scripts/audit-runtimes.mjs --check --strict
+          node scripts/audit-test-scripts.mjs
+          node --test --test-concurrency=4 \
+            tests/e2e/platform-exemption-clearing/run.mjs \
+            tests/e2e/prebuild-declaration-invariant/run.mjs \
+            tests/e2e/prebuild-loader-path/run.mjs \
+            tests/e2e/prebuild-change-gate/run.mjs \
+            tests/e2e/stage-prebuild/run.mjs
+
+      - name: Push
+        if: steps.commit.outputs.changed == 'true'
+        run: git push
 
   # ----------------------------------------------------------------
   # Coverage summary — what this run actually built, and what it did not

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -492,6 +492,54 @@ mid-release. Worth fixing at the source (reproducible flags) rather than by
 suppressing the commit, since byte-reproducibility is what would let a future
 check compare a committed prebuild against a CI-built one at all.
 
+### What still writes to `main` unverified, after the bot push got a gate
+
+`commit-prebuilds` now runs the checks that read its own output on the tree it is
+about to push (`Gate the tree being pushed`), which closed the incident where
+f5d250b32 cleared `gjsify.platformsUncommitted` under a CI-skip directive and left
+`tests/e2e/platform-exemption-clearing` red on every open PR for hours. A sweep
+done while fixing it found five more holes in the same write path. All five are
+verified reads, none is fixed:
+
+- **`packages/napi/napi-*/prebuilds/**` is committed but written by no job.**
+  `napi.yml` rebuilds it, overwrites the checked-out copy and throws the result
+  away; `prebuilds.yml` has no napi download step. So any change to
+  `packages/napi/napi/src/` leaves the committed bytes at their old commit while
+  every declaration check stays green.
+- **`download-artifact` MERGES and nothing prunes.** Each step extracts into an
+  existing `prebuilds/<target>/` without clearing it, `git add` only adds, and
+  `Refuse to delete a committed prebuild` forbids removal — so a `meson.build`
+  change that renames a library or drops a `.gir` leaves the stale file beside the
+  new one, and `files: ["prebuilds"]` publishes both.
+- **The committed `.gir` files are validated by nothing on Linux.**
+  `prebuild-artifacts` looks at `LIB_EXT[os]` and `.typelib`; `prebuild-libc` reads
+  ELF. No rule enumerates expected files, only "at least one lib + at least one
+  typelib", so a leg that stops emitting a `.gir` is silent.
+- **`prebuild-artifacts`' dlopen probe degrades to a NOTE on `ubuntu-latest`,**
+  which is the runner that gates the push: no libsoup3 / GStreamer / GTK4 /
+  libepoxy, so the linux-x64 artifacts of http-soup-bridge, http2-native, webgl and
+  webrtc-native are never actually loaded there. The gate proves declarations and
+  file shape, not that an artifact loads.
+- **Two `commit-prebuilds` jobs can race.** Non-PR runs get a concurrency group
+  keyed by `run_id` with `cancel-in-progress: false`, deliberately — so a
+  `workflow_dispatch` run overlapping a `push` run means one `git push` is rejected
+  non-fast-forward, the step fails, and every binary that run downloaded is
+  discarded with no retry.
+
+Adjacent, same cause, different workflow: `commitlint.yml` triggers on
+`pull_request` only, so neither bot path to `main` — the prebuild push nor
+`chore: release v${version}` — is ever linted, while
+`@release-it/conventional-changelog` walks exactly those commits to build the
+CHANGELOG.
+
+The one lever not pulled is **dropping the CI-skip directive from the prebuild
+push**. Checked: it cannot loop (`prebuilds.yml`'s own `push` paths list sources,
+meson files and scripts — not `packages/*/*/prebuilds/**`), and it would buy the
+only coverage the new gate structurally cannot reach: the two specs that genuinely
+LOAD a committed prebuild under GJS in `main.yml`'s `test` job. It costs one full
+`main.yml` run per landing, which is rare. It detects rather than prevents, so it
+is a complement to the gate, not a replacement — decide it deliberately.
+
 ### A workflow GitHub refuses to load reports the PR as GREEN
 
 When GitHub rejects a workflow file it creates a run with ZERO jobs, hence zero


### PR DESCRIPTION
**Depends on #958**, which fixes the instance. This is the mechanism.

## `commit-prebuilds` verified a tree nobody pushes

Two separate defects, both measured, both closed by one step placed correctly.

### 1. Ordering

`audit-runtimes.mjs --check` ran **before** `git pull --rebase origin main`:

| line | step |
|---|---|
| 2735 | `node scripts/audit-runtimes.mjs --check` |
| 2743 | `git commit` |
| 2744 | `git pull --rebase origin main` |
| 2745 | `git push` |

So the audited tree was provably not the pushed tree. A PR that edits a bridge's
`gjsify.platforms`, drops a per-target package or bumps a version can merge while
this job sits between those steps; the rebase replays the prebuild commit onto it
cleanly, because the hunks do not overlap, and the combination nobody audited is
what lands.

### 2. Scope

The push carries GitHub's CI-skip directive, which suppresses **both** required
checks on the resulting commit — `CI gate (GJS)` (main.yml, `push: [main]`, no
paths filter) and `Detect runtime-triplet drift` (audit-runtimes.yml, no paths
filter) — while that one step substituted exactly **one** of audit-runtimes.yml's
steps. Everything else that reads what this job writes ran nowhere.

That is not hypothetical. On 2026-08-03 `f5d250b32` cleared
`gjsify.platformsUncommitted` from the darwin manifests — **its own step, 90 lines
above the gate** — and broke `tests/e2e/platform-exemption-clearing`, whose fixture
had seeded itself from one of those manifests. `main` was red for every open PR,
each one blaming its own diff, and the commit that caused it had no CI to blame.

## What this changes

`Commit prebuilds` commits and rebases but no longer pushes. A new
`Gate the tree being pushed` step runs between the rebase and the push:

```yaml
node scripts/audit-runtimes.mjs --check --strict
node scripts/audit-test-scripts.mjs
node --test --test-concurrency=4 \
  tests/e2e/platform-exemption-clearing/run.mjs \
  tests/e2e/prebuild-declaration-invariant/run.mjs \
  tests/e2e/prebuild-loader-path/run.mjs \
  tests/e2e/prebuild-change-gate/run.mjs \
  tests/e2e/stage-prebuild/run.mjs
```

Three deliberate choices:

- **`--check --strict`, not `--check`.** `audit-runtimes.yml` already runs
  `--check --strict` on plain `ubuntu-latest`, so the strict probes are proven on
  this runner. Keeping the bot's command weaker than the branch's is a standing
  exemption for every future strict-only rule.
- **The suite list is explicit, not globbed.** It is exactly the set whose fixtures
  read the state this job mutates. A glob would drag in suites needing a built
  workspace or a GJS runtime this runner has not got.
- **The pre-commit gate stays.** It is now subsumed, but failing before a commit
  exists is a clearer log than failing after a commit and a rebase.

## Why hermetic fixtures are not the general answer

#958 made the one broken fixture hermetic. That fixes the instance and **not** the
class, which is why both ship. Several of these suites measure the real committed
artifact *on purpose*: `prebuild-loader-path` asserts exact glibc floors, exact
`DT_NEEDED` sets and a `=== null`; `prebuild-declaration-invariant` hard-codes
measured floors. Those are properties of bytes **this job rewrites**. Making them
hermetic would delete the coverage.

## Verification

Measured, not asserted:

- **The gate passes on the fixed tree**: `110 tests, 110 pass, 5.1 s wall` on
  `main` + #958. Zero deps beyond `node:*` — every entry's import lines checked —
  so no install, no build, no container.
- **The gate catches the incident**: the same command on `main` *without* #958 —
  i.e. exactly the state `f5d250b32` created — exits **1** with `108/110`, failing
  `leaves a tree the generator agrees with` and `does not touch the generated
  README on a dry run`. **Had this step existed, the bot job would have failed and
  `main` would never have gone red.**
- `--check --strict` → exit 0 on main; `audit-test-scripts.mjs` → exit 0.
- `prebuilds.yml` parses (PyYAML); step wiring confirmed —
  `Commit prebuilds` has `id: commit`, and both `Gate the tree being pushed` and
  `Push` carry `if: steps.commit.outputs.changed == 'true'`.
- `generate-status.mjs` regenerates cleanly after the `open-todos.md` edit
  (`STATUS.md` is gitignored, and stayed untracked).

## What a green verdict here does NOT mean

Stated in the step comment so it cannot be misread later: the two assertions that
genuinely **load** a committed prebuild live in `main.yml`'s `test` job under GJS
and are unreachable from this runner, and `prebuild-artifacts`' dlopen probe
degrades to a *note* on a runner without libsoup3 / GStreamer / GTK4 / libepoxy —
which is the runner that gates the push. This gate proves declarations and file
shape, not that every artifact loads.

## Recorded, not fixed

The sweep that found the ordering defect found five more holes in the same write
path. All are verified reads; none is fixed here. They are in
`status/open-todos.md` under **"What still writes to `main` unverified, after the
bot push got a gate"**: napi's committed prebuilds are written by no job;
`download-artifact` merges and nothing prunes; the committed `.gir` files are
validated by nothing on Linux; the dlopen degradation above; and two
`commit-prebuilds` jobs can race, discarding one run's binaries with no retry.
Plus the adjacent finding that `commitlint.yml` is `pull_request`-only, so neither
bot path to `main` is ever linted while release-it walks those same commits for the
CHANGELOG.

The one lever not pulled is **dropping the skip directive from the prebuild push**.
Checked rather than assumed: it cannot loop, because `prebuilds.yml`'s own `push`
paths list sources, meson files and scripts — not `packages/*/*/prebuilds/**`. It
would buy the only coverage this gate structurally cannot reach. It detects rather
than prevents, so it is a complement, not a replacement — worth deciding
deliberately, not as a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
