### PR TITLE
style: satisfy the format gate after #960

### DIFF
--- a/packages/napi/napi/test/addon-gate.mjs
+++ b/packages/napi/napi/test/addon-gate.mjs
@@ -96,7 +96,9 @@ if (!existsSync(NAPI_LIB)) {
 // on a fresh clone this is the normal state — name the command rather than the
 // path alone.
 if (!existsSync(PREBUILD_DIR))
-    die(`shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`);
+    die(
+        `shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`,
+    );
 stage(`addon .node: ${addonPath.replace(ADDONS_DIR + '/', '')}`);
 
 // Extra binding-module descriptors for entries that self-require the addon via

--- a/packages/napi/napi/test/consumer-gate.mjs
+++ b/packages/napi/napi/test/consumer-gate.mjs
@@ -61,7 +61,9 @@ if (!existsSync(NAPI_LIB)) {
 // on a fresh clone this is the normal state — name the command rather than the
 // path alone.
 if (!existsSync(PREBUILD_DIR))
-    die(`shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`);
+    die(
+        `shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`,
+    );
 
 const tmp = mkdtempSync(join(tmpdir(), 'gjsify-napi-consumer-'));
 const bundle = join(tmp, 'workout.gjs.mjs');

--- a/packages/napi/napi/test/nodegi-gate.mjs
+++ b/packages/napi/napi/test/nodegi-gate.mjs
@@ -48,7 +48,9 @@ if (!existsSync(CLI)) die(`gjsify Node CLI not built at ${CLI} (or set GJSIFY_CL
 // on a fresh clone this is the normal state — name the command rather than the
 // path alone.
 if (!existsSync(PREBUILD_DIR))
-    die(`shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`);
+    die(
+        `shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`,
+    );
 if (!existsSync(NODE_GI_ADDON)) {
     die(
         `node-gi addon not built at ${NODE_GI_ADDON} — run: (cd ${NODE_GI} && npm install && npm exec -- node-gyp rebuild)`,

--- a/packages/napi/napi/test/transparent-gate.mjs
+++ b/packages/napi/napi/test/transparent-gate.mjs
@@ -154,7 +154,9 @@ if (!existsSync(NAPI_LIB)) {
 // on a fresh clone this is the normal state — name the command rather than the
 // path alone.
 if (!existsSync(PREBUILD_DIR))
-    die(`shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`);
+    die(
+        `shim prebuild dir missing: ${PREBUILD_DIR} — not committed; build it: (cd ${PKG} && gjsify run build:prebuilds)`,
+    );
 
 // --- make @gjsify/napi resolvable by BARE specifier from the build graph (the
 //     `gjsify install @gjsify/napi` stand-in). The shim emits require('@gjsify/napi');

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -559,6 +559,32 @@ legs already carry, added to both release legs; deliberately not done in the cha
 that removed the committed copy, because that PR landed hours before a `minor`
 release and the release path is the one place a bad edit is unrecoverable.
 
+### A PR touching only classifier-ignored paths is never linted, and the red lands on a stranger
+
+AGENTS.md records this as a residual gap of selective CI: `check` (which runs the
+repo-wide `gjsify lint` + `oxfmt --check`) is gated on the affected classifier's
+`skip-all`, so a PR touching ONLY `packages/napi/**`, `packages/node-gi/**`,
+`website/**` or docs does not lint. What the note understates is WHERE the failure
+surfaces. It has now happened twice:
+
+- `#949` (`style: satisfy the format gate after #944`)
+- `#960` — four `packages/napi/napi/test/*-gate.mjs` files landed 3 lines over the
+  120-column width. The PR was green because `check` was skipped; the first
+  unrelated PR to run the repo-wide check (`#957`, which touches `prebuilds.yml`
+  and `tests/`) went red on someone else's diff, and `main`'s own push run went red
+  behind it.
+
+Same shape as the `[skip ci]` prebuild incident: a change lands unvalidated and its
+failure is attributed to whoever runs next. The difference is that this one is
+cheap to close — `format --check` and `lint` are repo-wide, need no build, and cost
+~0.3 s and a few seconds respectively. The blocker is that they live in the `check`
+job together with the expensive tsc gate, so un-gating the job would un-gate tsc
+too. So the fix is to split the two cheap repo-wide steps out of `check` into a job
+that always runs (or move them into `audit-runtimes.yml`, which already runs on
+every PR with no paths filter — but that job deliberately performs no install, and
+both tools are devDeps, so it would need one). Pick deliberately; either way the
+claim "lint is clean" stops depending on which paths a PR happened to touch.
+
 ### A workflow GitHub refuses to load reports the PR as GREEN
 
 When GitHub rejects a workflow file it creates a run with ZERO jobs, hence zero


### PR DESCRIPTION
## `oxfmt --check` is failing repo-wide

Four files from #960 carry a `die(...)` call 3 columns over the 120-width:

```
packages/napi/napi/test/addon-gate.mjs
packages/napi/napi/test/consumer-gate.mjs
packages/napi/napi/test/nodegi-gate.mjs
packages/napi/napi/test/transparent-gate.mjs
```

Pure reflow — `oxfmt --write`, no behaviour change, 4×3 lines.

## Why it landed green and reds someone else

`packages/napi/**` is classifier-ignored, so #960's PR skipped the `check` job —
the one that runs the **repo-wide** `gjsify lint` + `oxfmt --check`. The failure
therefore surfaced on **#957**, a PR touching `prebuilds.yml` and `tests/`, and on
`main`'s own push run behind it. Neither has anything to do with the four files.

Same shape as this morning's `f5d250b32` prebuild-bot incident: a change lands
unvalidated and its failure is attributed to whoever runs next. AGENTS.md already
records this residual gap of selective CI — what it understates is *where* the red
appears.

## The mechanism, recorded not implemented

This is the gap's **second** occurrence — `#949` (`style: satisfy the format gate
after #944`) was the first. So it now has its own `status/open-todos.md` entry
instead of remaining a clause inside a paragraph about something else, with the
concrete fix spelled out: `format --check` and `lint` are repo-wide, need no build
and cost ~0.3 s, but they live in `check` together with the expensive tsc gate, so
un-gating the job would un-gate tsc too. Splitting the two cheap steps into a job
that always runs is the fix; doing it in the same breath as a release is not.

## Verification

- `oxfmt --check packages/napi/napi/test/*.mjs` → clean (was: 4 files failing)
- `node scripts/audit-runtimes.mjs --check --strict` → exit 0
- `node scripts/generate-status.mjs` → exit 0 (`STATUS.md` gitignored, not committed)

Unblocks #957, whose only failing checks were this and the gate that aggregates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)