### PR TITLE
fix(ci): push the release cut as the deploy key

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -71,12 +71,42 @@ jobs:
       # Full history + tags: the conventional-changelog plugin walks commits
       # since the last tag, and release-it derives the next version from the
       # tags. A shallow clone silently produces an empty changelog.
+      # SSH via the repository DEPLOY KEY, not the workflow token — and that is
+      # forced rather than preferred, for the same reason `commit-prebuilds` in
+      # prebuilds.yml uses it.
+      #
+      # `main` is protected by the `main` ruleset, whose `required_status_checks`
+      # rule applies to DIRECT PUSHES and not only to pull requests. The release
+      # commit is created BY this job, so the three required checks cannot
+      # possibly have run on it — the push is rejected with
+      #
+      #   GH013: Repository rule violations found for refs/heads/main.
+      #     - 3 of 3 required status checks are expected.
+      #
+      # which is not a condition any amount of waiting satisfies. The ruleset
+      # already grants `DeployKey` an `always` bypass precisely for this class of
+      # push (alongside org/repo admins); the workflow token's
+      # `github-actions[bot]` is deliberately NOT a bypass actor, because that
+      # would exempt EVERY workflow holding `contents: write` rather than the two
+      # bot paths that need it. So the fix is to push as the actor the repo has
+      # already sanctioned, NOT to widen the ruleset.
+      #
+      # Measured: the ruleset was created 2026-08-02, one day after v0.26.1, so
+      # the v0.27.0 attempt was the first cut to meet it — it failed AFTER
+      # `verify-committed-bundles` had passed and left nothing behind, because
+      # release-it rolled the remote tag back on the failed push.
+      #
+      # This is not an unverified push: the job installs, builds and runs
+      # `scripts/verify-committed-bundles.mjs` before release-it commits, and the
+      # tree it cuts from is a `main` commit that already went green.
       - name: Checkout main (full history + tags)
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          # Persist the token so the release commit + tag can be pushed back.
+          # Handing the key to checkout is what makes the later `git push` use
+          # SSH as the deploy key rather than HTTPS as the workflow token.
+          ssh-key: ${{ secrets.PREBUILDS_DEPLOY_KEY }}
           persist-credentials: true
 
       - name: Setup Node.js


### PR DESCRIPTION
**The v0.27.0 cut failed on this.** Nothing was left behind — no tag, no GitHub release, no npm version, no release commit on `main` — because release-it rolled the remote tag back when the push was declined. Verified all four after the fact.

## What happened

`release-cut` pushed the release commit with the **workflow token**:

```
GH013: Repository rule violations found for refs/heads/main.
  - 3 of 3 required status checks are expected.
! [remote rejected]     main -> main (push declined due to repository rule violations)
```

The `main` ruleset's `required_status_checks` rule applies to **direct pushes**, not only to pull requests. The release commit is created *by this job*, so `CI gate (GJS)`, `Detect runtime-triplet drift` and `Lint commit messages` cannot possibly have run on it. This is not a wait-and-retry condition — the push is structurally impossible for that actor.

**Why nobody hit it before:** the ruleset was created **2026-08-02**, one day after v0.26.1 shipped. v0.27.0 is the first cut to meet it. It got as far as `Git commit` ✔ and `Git tag` ✔ and died on `Git push`, i.e. *after* `verify-committed-bundles` had already confirmed every committed bundle reproduces byte-identically.

## The fix

Push as the actor the repository has **already sanctioned**. `gh api repos/gjsify/gjsify/rulesets/20230871`:

```json
"bypass_actors": [
  { "actor_type": "DeployKey",         "bypass_mode": "always" },
  { "actor_type": "OrganizationAdmin", "bypass_mode": "always" },
  { "actor_type": "RepositoryRole", "actor_id": 5, "bypass_mode": "always" }
]
```

`DeployKey` is there precisely for this class of push — it is how `commit-prebuilds` in `prebuilds.yml` has been pushing to `main` all day (`7f4e81291`, `bf4ac60a1`, …). So the checkout now takes `ssh-key: ${{ secrets.PREBUILDS_DEPLOY_KEY }}`, exactly as that job does, and `git push` goes over SSH as the deploy key instead of HTTPS as `github-actions[bot]`.

**One line of behaviour, plus the comment recording why.** The ruleset is untouched.

### The repair I deliberately did NOT make

Adding `github-actions[bot]` as a bypass actor. That would exempt **every** workflow holding `contents: write` from the required checks, rather than the two bot paths that actually need it — strictly weaker protection for the same outcome.

### Is a bypassing push honest here?

Yes, and it is worth stating rather than assuming. The job installs, builds, and runs `scripts/verify-committed-bundles.mjs` **before** release-it commits, and it cuts from a `main` commit that already went green. The release commit is a version bump over a verified tree; requiring the checks to have run on it first is a condition nothing can satisfy, which is why the bypass exists.

## Naming, flagged not fixed

The secret is called `PREBUILDS_DEPLOY_KEY` and now also cuts releases. Functionally identical — one repo-scoped write deploy key, and a second key would add no isolation — but the name is narrower than its use. Renaming needs a maintainer action (new secret + key rotation), so it is not bundled into a release-path fix.

## Verification

- `python3 yaml.safe_load` on `release-cut.yml` → parses; the checkout step's `with:` carries `ref`, `fetch-depth`, `ssh-key`, `persist-credentials`
- `node scripts/audit-runtimes.mjs --check --strict` → exit 0
- `node scripts/check-ci-image-packages.mjs` → exit 0

**Not verifiable before merge:** that the push now succeeds. It only runs on `workflow_dispatch` against `main`, so the proof is the next cut. The evidence it will work is that the same key + same `ssh-key:` spelling is what `commit-prebuilds` used for every prebuild commit that landed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)