### PR TITLE
fix: gate GTK bundles from a script, not node -e

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -115,6 +115,16 @@ jobs:
       - name: Check the PR-title type list still matches commitlint
         run: node scripts/check-pr-title-types.mjs
 
+      # A multi-line inline `node -e '…'` whose body contains the quote that opened
+      # it: the shell truncates the program and the step dies before asserting
+      # anything, so the gate reports nothing about what it was gating. Belongs here
+      # for the same reason as the rest of this job, plus one more — the workflows
+      # most in need of it (`release.yml`, `cli-cross-platform.yml`) never run on a
+      # pull request, so this is the only place their inline scripts get read before
+      # a release. Incident + scope in the script header.
+      - name: Check inline workflow scripts are not self-truncating
+        run: node scripts/check-workflow-inline-scripts.mjs
+
       - name: Check for resurrected prose (advisory)
         continue-on-error: true
         env:
@@ -197,3 +207,13 @@ jobs:
 
       - name: Check the PR-title type list still matches commitlint
         run: node scripts/check-pr-title-types.mjs
+
+      # A multi-line inline `node -e '…'` whose body contains the quote that opened
+      # it: the shell truncates the program and the step dies before asserting
+      # anything, so the gate reports nothing about what it was gating. Belongs here
+      # for the same reason as the rest of this job, plus one more — the workflows
+      # most in need of it (`release.yml`, `cli-cross-platform.yml`) never run on a
+      # pull request, so this is the only place their inline scripts get read before
+      # a release. Incident + scope in the script header.
+      - name: Check inline workflow scripts are not self-truncating
+        run: node scripts/check-workflow-inline-scripts.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,33 +396,15 @@ jobs:
           echo "--- assert the third-party terms ship with the binaries ---"
           test -s "$B/THIRD-PARTY-NOTICES.md" || { echo "THIRD-PARTY-NOTICES.md MISSING or empty"; exit 1; }
           test -d "$B/licenses" || { echo "licenses/ MISSING — relocated LGPL binaries with no terms attached"; exit 1; }
-          node -e '
-            const m = require(`./packages/node-gi/gtk-runtime-${process.env.TAG}/gtk/manifest.json`);
-            const want = `darwin-${process.arch}`;
-            if (m.platform !== want) {
-              console.error(`bundle manifest says ${m.platform}, this runner is ${want}`);
-              process.exit(1);
-            }
-            // The manifest is what a consumer holding only the tarball can read, so the
-            // release gates on IT, not on the build log that produced it.
-            if (m.windowing !== true || !(m.dataBytes > 0)) {
-              console.error(`published bundle must be the windowing superset with runtime data: windowing=${m.windowing} dataBytes=${m.dataBytes}`);
-              process.exit(1);
-            }
-            if (!(m.typelibSymmetry?.backed > 0) || !(m.licenses?.texts > 0)) {
-              console.error(`manifest records no verified typelib symmetry / no license texts: ${JSON.stringify({ typelibSymmetry: m.typelibSymmetry, licenses: m.licenses })}`);
-              process.exit(1);
-            }
-            // The builder now FAILS on a missing declared data set instead of warning,
-            // and records which sets it verified; require that record, so a bundle built
-            // by an older builder (or with the gate bypassed) cannot publish.
-            const verified = m.windowingData?.verified ?? [];
-            if (!verified.length || verified.some((v) => !(v.files > 0))) {
-              console.error(`manifest records no verified windowing data sets: ${JSON.stringify(m.windowingData)}`);
-              process.exit(1);
-            }
-            console.log(`bundle target ${m.platform} matches the runner; windowing superset, ${m.typelibSymmetry.backed} backed typelibs, ${m.licenses.texts} license texts, data sets ${verified.map((v) => v.id).join('+')}`);
-          '
+          # The manifest half is a SCRIPT, shared with the win32 leg, because it was
+          # twice an inline `node -e '…'` whose last line spliced `join('+')` into a
+          # single-quoted shell string — the shell closed the body there and node died
+          # with a SyntaxError before one assertion ran, failing all three v0.28.0
+          # bundle publishes while the bundles themselves were correct. Guarded against
+          # regrowth by scripts/check-workflow-inline-scripts.mjs.
+          node packages/node-gi/scripts/verify-bundle-manifest.mjs \
+            --bundle "$B" \
+            --expect-host-target darwin
           echo "clean — bundle populated, portable, complete + license-covered"
 
       # A Node-runnable @gjsify/cli at the release-train version drives the OIDC
@@ -575,23 +557,11 @@ jobs:
           Write-Host "--- assert the third-party terms ship with the binaries ---"
           if (-not (Test-Path "$B/THIRD-PARTY-NOTICES.md")) { Write-Host "THIRD-PARTY-NOTICES.md MISSING"; exit 1 }
           if (-not (Test-Path "$B/licenses")) { Write-Host "licenses/ MISSING - LGPL DLLs with no terms attached"; exit 1 }
-          node -e '
-            const m = require("./packages/node-gi/gtk-runtime-win32-x64/gtk/manifest.json");
-            if (m.windowing !== true || !(m.dataBytes > 0)) {
-              console.error(`published bundle must be the windowing superset with runtime data: windowing=${m.windowing} dataBytes=${m.dataBytes}`);
-              process.exit(1);
-            }
-            if (!(m.typelibSymmetry?.backed > 0) || !(m.licenses?.texts > 0)) {
-              console.error(`manifest records no verified typelib symmetry / no license texts: ${JSON.stringify({ typelibSymmetry: m.typelibSymmetry, licenses: m.licenses })}`);
-              process.exit(1);
-            }
-            const verified = m.windowingData?.verified ?? [];
-            if (!verified.length || verified.some((v) => !(v.files > 0))) {
-              console.error(`manifest records no verified windowing data sets: ${JSON.stringify(m.windowingData)}`);
-              process.exit(1);
-            }
-            console.log(`windowing superset, ${m.typelibSymmetry.backed} backed typelibs, ${m.licenses.texts} license texts, data sets ${verified.map((v) => v.id).join('+')}`);
-          '
+          # Same shared script as the darwin leg — see the comment there for why the
+          # manifest half stopped being an inline `node -e`. No --expect-host-target:
+          # win32-x64 is the only Windows bundle, so there is no arch to cross-check.
+          node packages/node-gi/scripts/verify-bundle-manifest.mjs --bundle $B
+          if ($LASTEXITCODE -ne 0) { exit 1 }
           Write-Host "bundle populated, complete + license-covered"
 
       # A Node-runnable @gjsify/cli at the release-train version drives the OIDC

--- a/packages/node-gi/scripts/verify-bundle-manifest.mjs
+++ b/packages/node-gi/scripts/verify-bundle-manifest.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// Gate a GTK runtime bundle on the properties of its own manifest, before publish.
+//
+// WHY THIS IS A FILE AND NOT AN INLINE `node -e`
+//
+// It was two inline `node -e '…'` blocks — one in `release.yml`'s darwin job under
+// bash, a near-identical copy in the win32 job under pwsh — and both were DEAD ON
+// ARRIVAL. The last line of each read
+//
+//     … data sets ${verified.map((v) => v.id).join('+')}`);
+//
+// inside a SINGLE-QUOTED shell string. The shell closed the string at the quote
+// before `+`, so node received `join(+)` and died with
+// `SyntaxError: Unexpected token ')'` before evaluating a single assertion. All
+// three publish legs of v0.28.0 failed at that step (run 30932413…/jobs 920781919{09,40},
+// 92078192028) while every bundle they were gating was CORRECT — measured from the
+// manifests those same steps had already printed: darwin-arm64 `windowing: true`,
+// `dataBytes: 20247017`, 25 backed typelibs, 65 license texts; win32-x64 the same
+// shape at `dataBytes: 5628218` / 37 texts. `@gjsify/cli`, `@gjsify/node-gi` and
+// `@gjsify/napi` published at 0.28.0; the three bundles stayed at 0.27.1 — the one
+// version whose defects this gate exists to prevent shipping.
+//
+// A script file has no shell-quoting layer to get wrong, is ONE copy instead of two
+// that must agree across two different shells, and can be tested without a release.
+// `release.yml` is `on: release`/`workflow_dispatch` only, so nothing on a PR ever
+// executed either block — the same PR-coverage-parity hole AGENTS.md documents for
+// `deploy-docs` and `build-ci-image`, paid for once more. The regrow guard is
+// `scripts/check-workflow-inline-scripts.mjs`.
+//
+// WHAT IT ASSERTS, AND WHY EACH LINE IS HERE
+//
+// Every check below is a property of the ARTIFACT as a consumer holding only the
+// tarball can read it — deliberately the manifest and not the build log, because the
+// build log is not shipped. Each one names a v0.27.1 defect:
+//
+//   windowing/dataBytes  — 0.27.1 published the display-free variant (`windowing:
+//                          false`, `dataBytes: 0`, no `share/` at all), so every
+//                          GSettings-backed API and icon lookup silently misbehaved.
+//   typelibSymmetry      — the typelib copy was unfiltered while the seeds were not,
+//                          so 0.27.1 shipped `Adw-1.typelib` with NO libadwaita: 6 of
+//                          38 darwin typelibs and 3 of 37 win32 ones advertised
+//                          constructible types that died with "Failed to load shared
+//                          library 'libadwaita-1.0.dylib'" at first use.
+//   licenses             — 0.27.1 shipped 37–45 relocated LGPL/MPL/GPL libraries with
+//                          no license file of any kind.
+//   windowingData.verified — the builder records which declared data sets it verified;
+//                          requiring the RECORD means a bundle built by an older
+//                          builder, or with the gate bypassed, cannot publish.
+//
+// Usage:
+//   node packages/node-gi/scripts/verify-bundle-manifest.mjs --bundle <dir>
+//                                                            [--expect-host-target <os>]
+//
+// `--expect-host-target darwin` asserts `manifest.platform === darwin-${process.arch}`,
+// i.e. that the bundle was built for the machine now verifying it. It reads the
+// RUNNER's arch on purpose rather than the matrix value: a matrix/runner mismatch is
+// exactly the class that let the emulated prebuild legs stage x86-64 into
+// `prebuilds/linux-ppc64/` with every downstream check green.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+
+function flag(name) {
+    const i = args.indexOf(name);
+    if (i === -1) return undefined;
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+        fail(`${name} requires a value`);
+    }
+    return value;
+}
+
+function fail(message) {
+    console.error(`verify-bundle-manifest: ${message}`);
+    process.exit(1);
+}
+
+const bundle = flag('--bundle');
+if (!bundle) fail('--bundle <dir> is required');
+const expectHostTarget = flag('--expect-host-target');
+
+const manifestPath = join(bundle, 'manifest.json');
+let manifest;
+try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+} catch (error) {
+    fail(`cannot read ${manifestPath}: ${error.message}`);
+}
+
+const problems = [];
+
+if (expectHostTarget) {
+    // Both halves against the HOST, not against the caller's claim: the OS so a leg
+    // cannot verify a darwin bundle on a Linux runner, the arch so a matrix value and
+    // the machine it landed on cannot disagree. That second half is the class that let
+    // the emulated prebuild legs stage x86-64 into `prebuilds/linux-ppc64/` with every
+    // downstream check green — only reading the artifact against the machine caught it.
+    if (process.platform !== expectHostTarget) {
+        problems.push(`--expect-host-target ${expectHostTarget} but this runner is ${process.platform}`);
+    }
+    const want = `${expectHostTarget}-${process.arch}`;
+    if (manifest.platform !== want) {
+        problems.push(`bundle manifest says platform=${manifest.platform}, this runner is ${want}`);
+    }
+}
+
+if (manifest.windowing !== true || !(manifest.dataBytes > 0)) {
+    problems.push(
+        `published bundle must be the windowing superset with runtime data: ` +
+            `windowing=${manifest.windowing} dataBytes=${manifest.dataBytes}`,
+    );
+}
+
+if (!(manifest.typelibSymmetry?.backed > 0)) {
+    problems.push(`manifest records no verified typelib symmetry: ${JSON.stringify(manifest.typelibSymmetry)}`);
+}
+
+if (!(manifest.licenses?.texts > 0)) {
+    problems.push(`manifest records no license texts: ${JSON.stringify(manifest.licenses)}`);
+}
+
+const verified = manifest.windowingData?.verified ?? [];
+if (!verified.length) {
+    problems.push(`manifest records no verified windowing data sets: ${JSON.stringify(manifest.windowingData)}`);
+} else {
+    // An empty declared data set is the same missing signal as an absent one, and is
+    // what shipped in 0.27.1 — so the count, not the presence of the entry, decides.
+    const empty = verified.filter((set) => !(set.files > 0));
+    if (empty.length) {
+        problems.push(`verified windowing data sets with no files: ${JSON.stringify(empty)}`);
+    }
+}
+
+if (problems.length) {
+    console.error(`verify-bundle-manifest: ${manifestPath} FAILED ${problems.length} check(s)`);
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+}
+
+const sets = verified.map((set) => `${set.id}:${set.files}`).join(' ');
+console.log(
+    `verify-bundle-manifest: ${manifest.platform} clean — windowing superset, ` +
+        `${manifest.typelibSymmetry.backed} backed typelibs, ${manifest.licenses.texts} license texts, ` +
+        `${manifest.dataBytes} data bytes, sets ${sets}`,
+);

--- a/scripts/check-workflow-inline-scripts.mjs
+++ b/scripts/check-workflow-inline-scripts.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Refuse a workflow whose inline `node -e` / `python3 -c` body contains its own
+// shell quote character.
+//
+// THE INCIDENT
+//
+// `release.yml`'s two GTK-runtime verify steps each ended with
+//
+//     … data sets ${verified.map((v) => v.id).join('+')}`);
+//
+// inside a SINGLE-QUOTED `node -e '…'`. The shell closes the string at the quote
+// before `+`; node received `join(+)` and died with `SyntaxError: Unexpected token
+// ')'` before evaluating one assertion. All three v0.28.0 bundle publish legs failed
+// there while every bundle they gated was correct, so `@gjsify/cli`/`node-gi`/`napi`
+// went out at 0.28.0 and the three `@gjsify/gtk-runtime-*` packages stayed at 0.27.1
+// — the exact version whose defects that gate had just been written to prevent.
+//
+// It survived review twice (once per shell) because the quote is visually inert: the
+// JS reads correctly, and only the shell layer between the YAML and node disagrees.
+// And nothing ran it before the release — `release.yml` triggers on `release` /
+// `workflow_dispatch` only, so no PR ever executed either block.
+//
+// This is the same class as `assertShellSafeWorkspaceName` in the affected-classifier
+// transport, and it was settled there in the same terms: pre-quoting for unknown
+// nesting cannot work, emitting text that needs no quoting can. The primary fix is
+// therefore to move the body into a script file (`packages/node-gi/scripts/
+// verify-bundle-manifest.mjs`); this check is what stops the shape from regrowing.
+//
+// WHAT IT CHECKS — deliberately only the MULTI-LINE form
+//
+// For every `node -e|-p|--eval|--print <q>` / `python3 -c <q>` with q ∈ {', "} whose
+// body opens at END OF LINE, no line of the body may contain q. In a q-delimited
+// shell string an unescaped q cannot be body text — it IS the close — so any
+// occurrence is the defect, with no judgement call.
+//
+// Single-line invocations are deliberately NOT checked. There, q legitimately recurs
+// as part of an enclosing construct — `echo "… $(node -p "require('./p.json').v")"`
+// is correct and a counting rule flags it. A first draft of this check did exactly
+// that: 23 findings, 21 of them false, including the correct
+// `cli-cross-platform.yml:193` block. A check with false positives gets disabled, and
+// then it protects nothing.
+//
+// The body's end is the first line whose trimmed text STARTS WITH q — not one equal
+// to q. `release.yml` closed on a bare `'`, `cli-cross-platform.yml` on `')"`; the
+// stricter equality read past the real end and flagged every apostrophe in the
+// comments below it.
+//
+// It does NOT parse YAML or lex the shell. It does not need to: the defect is
+// lexical, one quote character in the wrong place.
+//
+// Usage: node scripts/check-workflow-inline-scripts.mjs [--root <dir>]
+// Exits 1 and names file:line + the offending text on any finding.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const args = process.argv.slice(2);
+const rootIndex = args.indexOf('--root');
+const root = rootIndex === -1 ? process.cwd() : args[rootIndex + 1];
+const workflowDir = join(root, '.github', 'workflows');
+
+// `node -e '`, `node --eval "`, `python3 -c '`, … — capture the quote that opens the body.
+const OPENER = /\b(node|python3?)\s+(?:-e|-p|--eval|--print|-c)\s+(['"])/g;
+
+/**
+ * Remove the spellings that legitimately place a quote inside a quoted body: the two
+ * splice idioms, and a backslash escape (valid inside a double-quoted shell string,
+ * never inside a single-quoted one — where a backslash is literal, so `\'` still ends
+ * the string and must stay counted).
+ */
+function stripSplices(text, quote) {
+    let out = text.replaceAll(`'\\''`, '').replaceAll(`'"'"'`, '');
+    if (quote === '"') out = out.replaceAll('\\"', '');
+    return out;
+}
+
+function countQuote(text, quote) {
+    return stripSplices(text, quote).split(quote).length - 1;
+}
+
+const findings = [];
+
+function checkFile(path) {
+    const lines = readFileSync(path, 'utf8').split('\n');
+    const rel = relative(root, path);
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        OPENER.lastIndex = 0;
+        let match;
+        while ((match = OPENER.exec(line)) !== null) {
+            const quote = match[2];
+            const rest = line.slice(match.index + match[0].length);
+
+            // Single-line form is out of scope — see the header. Only a body that
+            // opens at end of line is judged.
+            if (rest.trim() !== '') continue;
+
+            // The close is the first line whose trimmed text STARTS WITH the quote:
+            // a bare `'` in release.yml, `')"` where the body feeds a substitution.
+            let close = -1;
+            for (let j = i + 1; j < lines.length; j++) {
+                if (lines[j].trim().startsWith(quote)) {
+                    close = j;
+                    break;
+                }
+            }
+            if (close === -1) {
+                findings.push({
+                    file: rel,
+                    line: i + 1,
+                    detail: `inline ${match[1]} body opens with ${quote} at end of line and no line closing it was found`,
+                    text: line.trim(),
+                });
+                continue;
+            }
+            for (let j = i + 1; j < close; j++) {
+                const count = countQuote(lines[j], quote);
+                if (count > 0) {
+                    findings.push({
+                        file: rel,
+                        line: j + 1,
+                        detail: `inline ${match[1]} body (opened ${rel}:${i + 1}) contains ${quote} — the shell closes the string here`,
+                        text: lines[j].trim(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+let files;
+try {
+    files = readdirSync(workflowDir).filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'));
+} catch (error) {
+    console.error(`check-workflow-inline-scripts: cannot read ${workflowDir}: ${error.message}`);
+    process.exit(1);
+}
+
+for (const name of files.sort()) checkFile(join(workflowDir, name));
+
+if (findings.length) {
+    console.error(`check-workflow-inline-scripts: ${findings.length} broken inline script body/bodies\n`);
+    for (const finding of findings) {
+        console.error(`  ${finding.file}:${finding.line} — ${finding.detail}`);
+        console.error(`    ${finding.text.length > 140 ? `${finding.text.slice(0, 140)}…` : finding.text}\n`);
+    }
+    console.error(
+        'Fix by moving the body into a script file (no shell-quoting layer, one copy, testable),\n' +
+            'which is what packages/node-gi/scripts/verify-bundle-manifest.mjs is. Swapping the outer\n' +
+            'quote only relocates the trap to the next character of the other kind.',
+    );
+    process.exit(1);
+}
+
+console.log(`check-workflow-inline-scripts: ${files.length} workflow(s) clean.`);

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1285,3 +1285,28 @@ cover the leg that most needs them: an exploratory port is exactly where a
 renamed library or a missing sibling is most likely, and a hand-written `cp` is
 the one path that cannot notice either. Left undone here only because it would
 have made this PR depend on that one landing first.
+
+### The GTK bundles declare `license: MIT` while shipping an LGPL closure
+
+`@gjsify/gtk-runtime-{darwin-arm64,darwin-x64,win32-x64}` each carry 37–45
+relocated LGPL/MPL/GPL libraries (GTK, GLib, Pango, cairo, freetype, fontconfig,
+harfbuzz, libadwaita, GtkSourceView, and on win32 also ANGLE, librsvg, libxml2)
+and all three declare `"license": "MIT"` — the terms of their own three source
+files, not of the payload.
+
+The TEXTS are no longer missing: `packages/node-gi/scripts/bundle-licenses.mjs`
+derives `gtk/licenses/` + `gtk/THIRD-PARTY-NOTICES.md` from the source prefix,
+per-binary on darwin through each dylib's Homebrew keg (an unattributable dylib
+fails the build) and prefix-wide on win32, and `release.yml` gates on
+`m.licenses.texts > 0`. What is still wrong is the MACHINE-READABLE half: an
+automated consumer, a corporate license scanner or an SBOM generator reads the
+`license` field and never opens the notices, so the one declaration a tool can
+act on says something the tarball contradicts.
+
+Not fixed alongside the notices because the correct spelling is a judgement, not
+a mechanical edit: an SPDX expression naming the payload's real mix, versus
+`SEE LICENSE IN gtk/THIRD-PARTY-NOTICES.md`, versus splitting the package's own
+terms from the bundled ones. Whichever is chosen wants the same treatment as
+everything else here — derived from what the builder measured, so it cannot drift
+from the payload, which means `bundle-licenses.mjs` emitting the expression and a
+conformance rule comparing it to the manifest rather than a hand-edited string.

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -1,0 +1,218 @@
+// E2E test for the two halves of the GTK-runtime release gate:
+// `packages/node-gi/scripts/verify-bundle-manifest.mjs` (the gate itself) and
+// `scripts/check-workflow-inline-scripts.mjs` (the guard that keeps it a script).
+//
+// WHY THIS SUITE EXISTS
+//
+// `release.yml` triggers on `release` / `workflow_dispatch` only. Nothing on a pull
+// request has ever executed its steps, which is how the bundle gate shipped DEAD: two
+// inline `node -e '…'` blocks — one bash, one pwsh — each ending in
+//
+//     … data sets ${verified.map((v) => v.id).join('+')}`);
+//
+// inside a single-quoted shell string. The shell closed the body at the quote before
+// `+`, node received `join(+)` and died with `SyntaxError: Unexpected token ')'`
+// before evaluating one assertion. All three v0.28.0 `@gjsify/gtk-runtime-*` publish
+// legs failed there while every bundle they gated was CORRECT (darwin-arm64
+// `windowing: true`, `dataBytes: 20247017`, 25 backed typelibs, 65 license texts;
+// win32-x64 the same shape at 5628218 / 37). `cli`, `node-gi` and `napi` went out at
+// 0.28.0; the three bundles stayed at 0.27.1 — the one version whose defects that
+// gate had just been written to prevent shipping.
+//
+// So this suite IS the pre-release coverage: it is the only place either script runs
+// before a release exercises it for real. It deliberately asserts the FAILURE paths,
+// because a gate that cannot fail is what 0.27.1 shipped behind.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// tests/e2e/release-bundle-gate/ → monorepo root is 3 levels up.
+const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
+const VERIFY = join(MONOREPO_ROOT, 'packages', 'node-gi', 'scripts', 'verify-bundle-manifest.mjs');
+const GUARD = join(MONOREPO_ROOT, 'scripts', 'check-workflow-inline-scripts.mjs');
+
+/** The measured shape of a good v0.28.0 darwin-arm64 bundle manifest. */
+function goodManifest(overrides = {}) {
+    return {
+        platform: `${process.platform}-${process.arch}`,
+        windowing: true,
+        dataBytes: 20247017,
+        typelibSymmetry: { backed: 25, dropped: 6 },
+        licenses: { texts: 65 },
+        windowingData: {
+            verified: [
+                { id: 'schemas', files: 1 },
+                { id: 'icons', files: 863 },
+                { id: 'gtksource', files: 6 },
+            ],
+        },
+        ...overrides,
+    };
+}
+
+function runVerify(manifest, extraArgs = []) {
+    const dir = mkdtempSync(join(tmpdir(), 'gjsify-bundle-gate-'));
+    writeFileSync(join(dir, 'manifest.json'), JSON.stringify(manifest));
+    const result = spawnSync(process.execPath, [VERIFY, '--bundle', dir, ...extraArgs], {
+        encoding: 'utf8',
+    });
+    return { ...result, output: `${result.stdout}${result.stderr}` };
+}
+
+function runGuard(workflowFiles) {
+    const root = mkdtempSync(join(tmpdir(), 'gjsify-inline-guard-'));
+    const dir = join(root, '.github', 'workflows');
+    mkdirSync(dir, { recursive: true });
+    for (const [name, body] of Object.entries(workflowFiles)) writeFileSync(join(dir, name), body);
+    const result = spawnSync(process.execPath, [GUARD, '--root', root], { encoding: 'utf8' });
+    return { ...result, output: `${result.stdout}${result.stderr}` };
+}
+
+describe('verify-bundle-manifest: the release gate', () => {
+    it('accepts a complete windowing bundle', () => {
+        const result = runVerify(goodManifest());
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /clean — windowing superset/);
+        assert.match(result.stdout, /25 backed typelibs/);
+        assert.match(result.stdout, /65 license texts/);
+    });
+
+    it('rejects the v0.27.1 display-free bundle on every count it shipped wrong', () => {
+        // Verbatim the shape published as 0.27.1: display-free, so no runtime data, no
+        // recorded typelib symmetry (it shipped Adw-1.typelib with no libadwaita) and
+        // no license texts beside 37-45 relocated LGPL/MPL/GPL libraries.
+        const result = runVerify({ platform: `${process.platform}-${process.arch}`, windowing: false, dataBytes: 0 });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /FAILED 4 check\(s\)/);
+        assert.match(result.stderr, /windowing=false dataBytes=0/);
+        assert.match(result.stderr, /no verified typelib symmetry/);
+        assert.match(result.stderr, /no license texts/);
+        assert.match(result.stderr, /no verified windowing data sets/);
+    });
+
+    it('rejects a declared data set that holds no files', () => {
+        // A directory that exists and is empty is the same missing signal as an absent
+        // one — and is what 0.27.1's `share/` would have been had it existed at all.
+        const result = runVerify(goodManifest({ windowingData: { verified: [{ id: 'icons', files: 0 }] } }));
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /verified windowing data sets with no files/);
+        assert.match(result.stderr, /"id":"icons"/);
+    });
+
+    it('rejects a bundle built for another architecture than the host', () => {
+        const result = runVerify(goodManifest({ platform: 'darwin-ppc64' }), [
+            '--expect-host-target',
+            process.platform,
+        ]);
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /manifest says platform=darwin-ppc64/);
+    });
+
+    it('rejects verifying a foreign-OS bundle on this runner', () => {
+        const foreign = process.platform === 'win32' ? 'darwin' : 'win32';
+        const result = runVerify(goodManifest(), ['--expect-host-target', foreign]);
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, new RegExp(`--expect-host-target ${foreign} but this runner is`));
+    });
+
+    it('fails loudly on a missing manifest instead of passing vacuously', () => {
+        const result = spawnSync(process.execPath, [VERIFY, '--bundle', join(tmpdir(), 'gjsify-no-such-bundle')], {
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /cannot read/);
+    });
+
+    it('requires --bundle', () => {
+        const result = spawnSync(process.execPath, [VERIFY], { encoding: 'utf8' });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /--bundle <dir> is required/);
+    });
+});
+
+describe('check-workflow-inline-scripts: the regrow guard', () => {
+    it('rejects the exact body that failed the v0.28.0 release', () => {
+        const result = runGuard({
+            'broken.yml': [
+                'jobs:',
+                '  gate:',
+                '    steps:',
+                '      - run: |',
+                "          node -e '",
+                '            const m = require("./manifest.json");',
+                "            console.log(`sets ${m.verified.map((v) => v.id).join('+')}`);",
+                "          '",
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /1 broken inline script body/);
+        assert.match(result.stderr, /broken\.yml:7/);
+        assert.match(result.stderr, /the shell closes the string here/);
+    });
+
+    it('accepts a multi-line body that keeps the other quote inside', () => {
+        // The shape of the CORRECT cli-cross-platform.yml block: a single-quoted body
+        // using only double quotes internally, closed by `')"` rather than a bare `'`.
+        // A first draft of the guard flagged this — a check with false positives gets
+        // switched off, and then it guards nothing.
+        const result = runGuard({
+            'ok.yml': [
+                'jobs:',
+                '  probe:',
+                '    steps:',
+                '      - run: |',
+                '          OUT="$(node -e \'',
+                '            const parse = (v) => v.split("-")[0].split(".").map(Number);',
+                '            process.stdout.write(parse(process.env.V)[0] >= 1 ? "1" : "0");',
+                '          \')"',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /1 workflow\(s\) clean/);
+    });
+
+    it('leaves single-line invocations alone even when the quote recurs', () => {
+        // `echo "… $(node -p "require('./p.json').version")"` is correct: the second
+        // double quote closes the node body, the third belongs to the enclosing echo.
+        const result = runGuard({
+            'inline.yml': [
+                'jobs:',
+                '  v:',
+                '    steps:',
+                '      - run: |',
+                '          echo "cli: $(node -p "require(\'./package.json\').version")"',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 0, result.output);
+    });
+
+    it('reports an unterminated body rather than scanning to end of file', () => {
+        const result = runGuard({
+            'open.yml': [
+                'jobs:',
+                '  x:',
+                '    steps:',
+                '      - run: |',
+                "          node -e '",
+                '            1 + 1;',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /no line closing it was found/);
+    });
+
+    it("holds for this repo's own workflows", () => {
+        const result = spawnSync(process.execPath, [GUARD, '--root', MONOREPO_ROOT], { encoding: 'utf8' });
+        assert.equal(result.status, 0, result.output);
+    });
+});


### PR DESCRIPTION
v0.28.0 published `@gjsify/cli`, `@gjsify/node-gi` and `@gjsify/napi` and left all three `@gjsify/gtk-runtime-*` packages at **0.27.1** — the one version whose defects the gate that blocked them had just been written to prevent shipping.

**Neither bundle was at fault.** Both were correct, measured from the manifests the failing steps had already printed:

| | darwin-arm64 | win32-x64 |
|---|---|---|
| `windowing` | `true` | `true` |
| `dataBytes` | 20 247 017 | 5 628 218 |
| backed typelibs | 25 | 25 |
| license texts | 65 | 37 |

Every assertion would have passed.

## What actually failed

Both verify steps ended in

```js
… data sets ${verified.map((v) => v.id).join('+')}`);
```

inside a single-quoted `node -e '…'`. The shell closes the body at the quote before `+`, so node got `join(+)` and died with `SyntaxError: Unexpected token ')'` before evaluating anything. The quote is visually inert — the JS reads correctly, only the shell layer between the YAML and node disagrees — and it survived review twice because the block existed twice, once under bash and once under pwsh.

## The fix

The manifest half becomes **one script both legs call** (`packages/node-gi/scripts/verify-bundle-manifest.mjs`): no shell-quoting layer, one copy instead of two that must agree across two shells, testable without cutting a release. `--expect-host-target <os>` keeps the property the inline version had and tightens it — OS *and* arch compared against the **runner**, not the matrix value, which is the class that let the emulated prebuild legs stage x86-64 into `prebuilds/linux-ppc64/` with every downstream check green.

## Why it reached a release at all

`release.yml` triggers on `release` / `workflow_dispatch` only, so **no pull request has ever executed either block** — the PR-coverage-parity hole AGENTS.md already documents for `deploy-docs` and `build-ci-image`. Two things close it:

- **`scripts/check-workflow-inline-scripts.mjs`**, in `audit-runtimes.yml` (behind a required check, pure Node, no install): refuses a multi-line inline body containing the quote that opened it. Scoped to the multi-line form on purpose — a first draft that counted quotes on single-line invocations produced 23 findings of which **21 were false**, including the *correct* `cli-cross-platform.yml:193` block, and a check with false positives gets switched off.
- **`tests/e2e/release-bundle-gate/`** — the only place either script runs before a release does. 12 tests, asserting the failure paths incl. the exact 0.27.1 manifest shape and the exact body that broke, because a gate that cannot fail is what 0.27.1 shipped behind.

## Verification

- guard against the broken tree → exactly the 2 real findings, nothing else; against the fixed tree → 12 workflows clean
- `node --test tests/e2e/release-bundle-gate/run.mjs` → 12/12
- gate accepts the measured 0.28.0 manifest, rejects the 0.27.1 shape on all 4 counts, rejects an empty declared data set, a foreign arch, a foreign OS, a missing manifest
- `oxlint` clean, `oxfmt` applied, both workflows parse as YAML

## Follow-up

The bundles' `license: MIT` still contradicts their LGPL payload now that the texts ship — recorded in `status/open-todos.md` rather than fixed here, because the right spelling is a judgement and wants the same derived-not-hand-edited treatment as the notices.

**After merge the three bundle publish legs need re-running so 0.28.0 bundles exist on npm.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)