### PR TITLE
feat(conformance): require a showcase to name its runtimes

### DIFF
--- a/packages/infra/manifest-conformance/lib/rules/package-outputs.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/package-outputs.mjs
@@ -228,6 +228,59 @@ export function inspectDeclaredOutputs(ctx) {
             missing.push({ field, value, path: relative(ctx.root, abs), kind });
         }
 
+        // A package with a `gjsify.main` is launchable by `gjsify showcase`, and the CLI
+        // decides which runtimes it will accept from `gjsify.example.runtimes`. An ABSENT
+        // declaration does not mean "gjs only" — `utils/runtimes.ts` treats it as
+        // UNCONSTRAINED, so the CLI will happily try any requested runtime. That is the
+        // inverse of every other declaration in this manifest, and it makes the question
+        // "does this showcase run everywhere?" unanswerable: silence and "yes" look
+        // identical.
+        //
+        // ZERO findings today, deliberately: all nine packages declaring `gjsify.main`
+        // were surveyed, and the eight PUBLISHED ones each declare their runtimes. The
+        // ninth (`@gjsify/example-gtk-node-gi-window`) is `private` and not a CLI
+        // dependency, so `gjsify showcase` cannot resolve it by name and it has nothing
+        // to declare — which is why the private carve-out above is load-bearing here
+        // rather than merely inherited.
+        //
+        // So this is a guard, not a repair. It earns its place because the loophole is
+        // real for the published ones: add a showcase, forget the declaration, and
+        // `--runtime bun` is ACCEPTED and then dies in a bundle that was never built —
+        // the same ending as `@gjsify/example-dom-excalibur-jelly-jumper@0.23.0`, which
+        // declared four runtimes whose bundle its `build` never produced. That failure
+        // has a check (`impliedExampleNodeEntry` below); its mirror image, declaring
+        // nothing at all, did not.
+        //
+        // It lives in THIS rule rather than a new one because `gjsify.example` is already
+        // claimed here and `impliedExampleNodeEntry` already reasons about exactly this
+        // `gjsify.main` ↔ `gjsify.example` pair.
+        //
+        // In practice it fires under `verify-package-outputs.mjs --scope examples`, since
+        // the default scope excludes `@gjsify/example-*` by name and inverting that
+        // carve-out is what the examples scope exists for. Nothing else declares
+        // `gjsify.main`, so the check is inert in the other scopes rather than partial.
+        // Gated on `!private` EXPLICITLY, not inherited from the caller's
+        // `includePrivate`: the declaration is required because the CLI resolves a
+        // showcase BY NAME, which needs it published. A private workspace showcase is
+        // launched by path and has nothing to declare, so `--include-private` must not
+        // turn it into a finding — the message would then assert `gjsify showcase can
+        // launch it` about a package that it cannot.
+        if (
+            !pkg.private &&
+            typeof pkg.manifest.gjsify?.main === 'string' &&
+            !Array.isArray(pkg.manifest.gjsify?.example?.runtimes)
+        ) {
+            missing.push({
+                field: 'gjsify.example.runtimes',
+                value: '(not declared)',
+                path:
+                    `declares gjsify.main (${pkg.manifest.gjsify.main}) so \`gjsify showcase\` can launch it, but names ` +
+                    'no runtimes. An absent list reads as UNCONSTRAINED to the CLI, not as gjs-only — declare the ' +
+                    'runtimes this showcase actually ships bundles for.',
+                kind: 'declaration',
+            });
+        }
+
         // The one promise made without naming a path — see `impliedExampleNodeEntry`.
         const implied = impliedExampleNodeEntry(pkg.manifest);
         if (implied && !implied.candidates.some((c) => existsSync(resolve(pkg.dir, c)))) {

--- a/tests/e2e/package-outputs/run.mjs
+++ b/tests/e2e/package-outputs/run.mjs
@@ -103,6 +103,75 @@ describe('verify-package-outputs — declared entry points must exist (#67)', ()
         assert.match(out, /All declared entry points exist/);
     });
 
+    // A launchable showcase that declares NO runtimes. `gjsify showcase` resolves a
+    // showcase by name and reads `gjsify.example.runtimes` to decide which runtimes it
+    // will accept — and `utils/runtimes.ts` treats an ABSENT list as UNCONSTRAINED, not
+    // as gjs-only. So silence and "runs everywhere" are indistinguishable, and
+    // `--runtime bun` is accepted for a package that never built a bun bundle. That is
+    // the mirror image of the jelly-jumper@0.23.0 failure (four runtimes declared, none
+    // built), which `impliedExampleNodeEntry` already covers from the other side.
+    it('FAILS when a launchable showcase declares no runtimes at all', () => {
+        const root = makeRoot('no-runtimes');
+        addPackage(
+            root,
+            'a',
+            {
+                name: '@gjsify/example-dom-thing',
+                version: '1.0.0',
+                gjsify: { main: 'dist/gjs.js' },
+            },
+            { 'dist/gjs.js': '// bundle\n' },
+        );
+        // `--scope examples` because that is the sweep showcases are checked by: the
+        // default (core) scope excludes `@gjsify/example-*` by name, and inverting that
+        // carve-out is exactly what the examples scope is for.
+        const { status, out } = runGuard(root, ['--scope', 'examples']);
+        assert.equal(status, 1, out);
+        assert.match(out, /gjsify\.example\.runtimes/);
+        assert.match(out, /names\s+no runtimes|UNCONSTRAINED/);
+    });
+
+    it('passes once that showcase declares them', () => {
+        const root = makeRoot('has-runtimes');
+        addPackage(
+            root,
+            'a',
+            {
+                name: '@gjsify/example-dom-thing',
+                version: '1.0.0',
+                gjsify: { main: 'dist/gjs.js', example: { runtimes: ['gjs'] } },
+            },
+            { 'dist/gjs.js': '// bundle\n' },
+        );
+        const { status, out } = runGuard(root, ['--scope', 'examples']);
+        assert.equal(status, 0, out);
+    });
+
+    // A PRIVATE showcase is launched by path, never resolved by name, so it has nothing
+    // to declare — and the check is gated on `!private` explicitly rather than relying on
+    // the caller, so `--include-private` (which exists for the tarball/examples sweeps)
+    // cannot turn it into a finding whose message would claim `gjsify showcase can launch
+    // it` about a package that it cannot. `@gjsify/example-gtk-node-gi-window` is exactly
+    // this shape in the real tree.
+    it('does NOT flag a private showcase, even with --include-private', () => {
+        const root = makeRoot('private-showcase');
+        addPackage(
+            root,
+            'a',
+            {
+                name: '@gjsify/example-gtk-thing',
+                version: '1.0.0',
+                private: true,
+                gjsify: { main: 'dist/app.gjs.mjs' },
+            },
+            { 'dist/app.gjs.mjs': '// bundle\n' },
+        );
+        const bare = runGuard(root, ['--scope', 'examples']);
+        assert.equal(bare.status, 0, bare.out);
+        const withPrivate = runGuard(root, ['--scope', 'examples', '--include-private']);
+        assert.doesNotMatch(withPrivate.out, /gjsify\.example\.runtimes/);
+    });
+
     it('FAILS when the declaration tree is missing, naming the field and the path', () => {
         const root = makeRoot('no-types');
         addPackage(


### PR DESCRIPTION
`gjsify showcase` resolves a showcase **by name** and reads `gjsify.example.runtimes` to decide which runtimes it accepts. An **absent** list does not mean "gjs only" — `utils/runtimes.ts:143-147` treats it as *unconstrained*, so the CLI accepts any requested runtime. Silence and "runs everywhere" are indistinguishable, and `--runtime bun` is accepted for a package that never built a bun bundle.

That is the mirror image of a failure this rule already covers from the other side:

| | |
|---|---|
| declares runtimes, never builds their bundle | caught by `impliedExampleNodeEntry` — the `jelly-jumper@0.23.0` incident |
| declares **nothing at all** | **caught by nothing** |

## Zero findings today, deliberately

All nine packages declaring `gjsify.main` were surveyed:

```
dom-canvas2d-fireworks          gjs node bun deno
dom-excalibur-jelly-jumper      gjs node bun deno
dom-minimalist-browser          gjs
dom-three-geometry-teapot       gjs node bun deno
dom-three-postprocessing-pixel  gjs node bun deno
dom-webrtc-loopback             gjs
gtk-adwaita-storybook           gjs
gtk-node-gi-window              (none)   ← private, not a CLI dep
node-express-webserver          gjs node bun deno
```

The eight published ones each declare. The ninth is `private: true` and not a CLI dependency, so `gjsify showcase` cannot resolve it by name and it has **nothing to declare** — its silence is correct. So this is a guard, not a repair.

That is also why the `!private` gate is **explicit** rather than inherited from the caller's `includePrivate`: with that flag — which the tarball and examples sweeps accept — the check would otherwise flag a private workspace showcase with a message asserting *"`gjsify showcase` can launch it"* about a package that it cannot. Pinned by a test.

## Why here and not a new rule

`gjsify.example` is already claimed by `package-outputs`, and `impliedExampleNodeEntry` already reasons about exactly this `gjsify.main` ↔ `gjsify.example` pair. A separate rule would need a second claim on the same field, which `field-coverage` exists to make awkward.

## Tests

Three cases in `tests/e2e/package-outputs/`, all under `--scope examples` — the sweep showcases are actually checked by, since the default scope excludes `@gjsify/example-*` by name:

```
✔ FAILS when a launchable showcase declares no runtimes at all
✔ passes once that showcase declares them
✔ does NOT flag a private showcase, even with --include-private
```

**NB** five tests in that suite were already failing on this checkout *before* this change — the stale-tsbuildinfo case and the four tarball ones, for environment reasons in a partial worktree. Measured: 16 tests / 11 pass / 5 fail on a clean tree, 19 / 14 / 5 with this change. Worth a look independently of this PR.

## Context

This is step 1 of making "every showcase runs on every runtime, with no `--runtime` needed" checkable rather than hoped-for. The remaining steps — a `build:node` for the three gjs-only showcases, verified under node *and* bun *and* deno before declaring, then flipping `defaultExampleRuntime()` to follow the host — are queued separately and depend on this landing first, so the gaps are visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)