### PR TITLE
fix(showcases): ship the src the exports declare

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -425,6 +425,20 @@ jobs:
       - name: Verify declared entry points are in the tarball
         run: su testuser -c 'node scripts/verify-tarball-outputs.mjs'
 
+      # The SHOWCASES, as a separate scope. Held back until now for one honest
+      # reason recorded in `status/open-todos.md`: it red-lined on a real finding
+      # — 13 declared entry points across 6 of the 8 published showcases, every
+      # one present on disk and absent from the tarball because `files` was
+      # `["dist"]` while the export names `./src/…`. Wiring it while it failed
+      # would only have blocked main; the finding is fixed now (those six ship
+      # `src`, matching what `adwaita-storybook` already did), so the scope can
+      # hold the line instead of documenting a hole. It matters beyond cosmetics:
+      # AGENTS.md documents `require.resolve('@gjsify/example-dom-<name>/assets/
+      # <file>')` as the RUNTIME asset path, and the website imports `./browser`
+      # from every one of them — published, each was a dangling pointer.
+      - name: Verify declared entry points are in the tarball (showcases)
+        run: su testuser -c 'node scripts/verify-tarball-outputs.mjs --scope examples'
+
       # THE build-output cache's only writer. `gjsify-setup` deliberately only
       # RESTORES, because `actions/cache`'s automatic post-job save fires in
       # every job that uses the action — and `deploy-docs.yml`, which builds the

--- a/showcases/dom/canvas2d-fireworks/package.json
+++ b/showcases/dom/canvas2d-fireworks/package.json
@@ -5,7 +5,8 @@
   "main": "dist/gjs.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     "./browser": "./src/browser/browser.ts",

--- a/showcases/dom/excalibur-jelly-jumper/package.json
+++ b/showcases/dom/excalibur-jelly-jumper/package.json
@@ -5,7 +5,8 @@
     "main": "dist/gjs.js",
     "type": "module",
     "files": [
-        "dist"
+        "dist",
+        "src"
     ],
     "exports": {
         "./browser": "./src/browser/browser.ts",

--- a/showcases/dom/minimalist-browser/package.json
+++ b/showcases/dom/minimalist-browser/package.json
@@ -5,7 +5,8 @@
   "main": "dist/gjs.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     "./browser": "./src/browser/browser.ts",

--- a/showcases/dom/three-geometry-teapot/package.json
+++ b/showcases/dom/three-geometry-teapot/package.json
@@ -5,7 +5,8 @@
   "main": "dist/gjs.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     "./browser": "./src/browser/browser.ts",

--- a/showcases/dom/three-postprocessing-pixel/package.json
+++ b/showcases/dom/three-postprocessing-pixel/package.json
@@ -5,7 +5,8 @@
   "main": "dist/gjs.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     "./browser": "./src/browser/browser.ts",

--- a/showcases/dom/webrtc-loopback/package.json
+++ b/showcases/dom/webrtc-loopback/package.json
@@ -5,7 +5,8 @@
   "main": "dist/gjs.js",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     "./browser": "./src/browser/browser.ts",

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -122,38 +122,6 @@ launcher defer to the CLI rather than re-derive; that is a launcher-shape change
 and belongs in its own PR, ideally the one that lifts `system-gi` to a shared
 package (above).
 
-### Six published showcases declare `exports` subpaths their tarball does not contain
-
-Found by `scripts/verify-tarball-outputs.mjs` on its first run — `--scope
-examples`, 13 declared entry points across 6 of the 8 published showcases, every
-one present on disk and absent from the tarball because `files` is `["dist"]`
-while the export names `./src/…`:
-
-- `example-dom-canvas2d-fireworks` — `./browser`
-- `example-dom-excalibur-jelly-jumper` — `./browser`, `./assets/*`
-- `example-dom-minimalist-browser` — `./browser`, `./browser-demo`
-- `example-dom-three-geometry-teapot` — `./browser`, `./three-demo`, `./assets/*`
-- `example-dom-three-postprocessing-pixel` — `./browser`, `./three-demo`, `./assets/*`
-- `example-dom-webrtc-loopback` — `./browser`, `./loopback-demo`
-
-Invisible until now for the same reason the cold-clone finding was misread: the
-website resolves `@gjsify/example-dom-<name>/browser` through the workspace
-symlink, where `src/` is on disk. Published, each is a dangling pointer — and
-`./assets/*` is worse than cosmetic, because AGENTS.md documents
-`require.resolve('@gjsify/example-dom-<name>/assets/<file>')` as the RUNTIME
-asset path.
-
-Deliberately NOT fixed in the PR that found it, because both repairs are
-publishing-policy decisions rather than drive-bys. (a) Add `src` to `files`:
-makes the declaration true, and costs up to 3.9 MB per tarball
-(`excalibur-jelly-jumper`'s `src/`; `three-geometry-teapot/src/assets` alone is
-1.3 MB) to ship TypeScript no published consumer compiles. (b) Delete the
-subpaths: cheaper, but it also removes them inside the workspace — an `exports`
-map gates subpath access, so the website's imports break with them. Pick (a) for
-`./assets/*` at minimum. `--scope examples` is what closes it: the core scope is
-wired into `main.yml` and green, the examples scope is not wired precisely
-because it would red-line `main` on this finding.
-
 ### `@gjsify/child_process` on Windows — 86 of 145 specs fail once the module can load at all
 
 The specs took `TMP_DIR` from a literal `/tmp` and `realpathSync`'d it at MODULE


### PR DESCRIPTION
## The defect

Six published showcases declared `exports` subpaths their tarball did not contain — **13 entry points**, every one present on disk and absent from the tarball because `files` was `["dist"]` while the export names `./src/…`.

Invisible in the workspace, where the symlink puts `src/` on disk. **Published, each was a dangling pointer** — and `./assets/*` is the worst of them, because AGENTS.md documents `require.resolve('@gjsify/example-dom-<name>/assets/<file>')` as the **runtime** asset path.

## Why it was held, and why both halves of that reasoning were wrong

`status/open-todos.md` filed this as a publishing-policy choice between **(a)** add `src` to `files` and **(b)** delete the subpaths. Two measurements settled it, and each contradicted how the choice had been written down:

**(b) was never available.** The website imports `./browser` from *every one* of the six (grepped `website/src`), plus `example-dom-excalibur-jelly-jumper/assets/*`. An `exports` map gates subpath access, so deleting any of them breaks the site. None of these paths is vestigial.

**(a)'s cost was mis-stated** as "up to 3.9 MB … to ship TypeScript no published consumer compiles". Measured per package, `src` minus `assets`:

| package | `src` − assets | assets |
|---|---|---|
| canvas2d-fireworks | 60 KB | — |
| minimalist-browser | 56 KB | — |
| webrtc-loopback | 36 KB | — |
| three-postprocessing-pixel | 64 KB | 8 KB |
| three-geometry-teapot | 64 KB | 1328 KB |
| excalibur-jelly-jumper | 360 KB | 3628 KB |

The 3.9 MB is almost entirely `src/assets` — i.e. the very files `./assets/*` declares and the website consumes. **The TypeScript is the cheap part, and the expensive part is not optional.**

Nor is (a) a new policy: `example-gtk-adwaita-storybook` already shipped `["dist", "src"]`, and `example-dom-webrtc-video` carries no `files` field at all (so it ships everything). These six manifests were the outlier, not the fix.

## The mechanism

`--scope examples` now runs in `main.yml`, right after the core scope. It was held back for an honest reason — it red-lined on this exact finding — which no longer applies, so the scope can hold the line instead of documenting a hole.

## Verification

```
$ node scripts/verify-tarball-outputs.mjs --scope examples
Declared-in-tarball check [scope: examples]: 8 workspace package(s) (non-private)
Every declared entry point is in its tarball.
exit 0
```

The diff is one added line per manifest, in each file's own indentation — the multi-line spelling `adwaita-storybook` already uses, so nothing but the new entry moves.