### PR TITLE
ci: close the release-asset 404 window and gate unloadable workflows

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -141,6 +141,57 @@ jobs:
       - name: Check the tracked lockfile carries current platform data
         run: node scripts/check-lockfile-current.mjs
 
+      # A workflow file GitHub REFUSES TO LOAD reports the pull request as GREEN.
+      #
+      # GitHub creates a run with zero jobs for it, hence zero check runs, so there
+      # is nothing red to see — the only visible trace is a run oddly named after
+      # the file path instead of the workflow name. MEASURED: moving nine jobs onto
+      # the baked CI image deleted a single-line `run:` and left a step carrying
+      # only a `name:`. GitHub rejected the whole file, six node-gi jobs silently
+      # did not run, and the PR reported 24 GREEN CHECKS. It was caught by a human
+      # asking why the expected job names were missing, not by any signal.
+      #
+      # This job is the right home for the same reason the checks above are: it
+      # runs on every pull request with no install and no build, so it can see
+      # what the broken workflow cannot report about itself.
+      #
+      # WHY actionlint AND NOT OUR OWN CHECKER. A hand-rolled YAML outline scanner
+      # was written for exactly this and produced 17 FALSE POSITIVES on
+      # `prebuilds.yml` and `release.yml`, both of which GitHub loads fine — and a
+      # check that cries wolf is worse than no check. Node ships no YAML parser, so
+      # the alternatives were a real parser plus schema logic of our own (the same
+      # drift risk, better hidden) or the purpose-built tool. actionlint validates
+      # the workflow schema, `needs:` references, runner labels and `${{ }}`
+      # expressions — a superset of the load-blocking class.
+      #
+      # Pinned + checksummed: this downloads a binary into a job that reads this
+      # repository's workflows, so "latest" is not acceptable and neither is an
+      # unverified tarball. Bump both values together.
+      #
+      # `-shellcheck=` and `-pyflakes=` are DELIBERATELY empty. Both are
+      # preinstalled on the ubuntu image, both answer a different question (shell
+      # and Python style inside `run:` bodies), and the volume they would add here
+      # is UNMEASURED — turning them on is how this step would acquire the false
+      # positives that killed its predecessor. With them off the whole repository
+      # is clean at 0 findings, which is why this gates rather than warns.
+      # Widening to shellcheck is a separate, measured change.
+      - name: Check GitHub can load every workflow file
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          tmp="$(mktemp -d)"
+          curl -sSfL -o "$tmp/$tarball" "$url"
+          echo "${ACTIONLINT_SHA256}  $tmp/$tarball" | sha256sum -c -
+          tar xzf "$tmp/$tarball" -C "$tmp" actionlint
+          "$tmp/actionlint" -version
+          # No file arguments: actionlint discovers `.github/workflows/**` itself,
+          # so a newly added workflow is covered without editing this step.
+          "$tmp/actionlint" -shellcheck= -pyflakes=
+
       - name: Check for resurrected prose (advisory)
         continue-on-error: true
         env:
@@ -181,9 +232,11 @@ jobs:
   # which silently detaches any branch-protection rule that requires the current
   # name. A second job adds the signal without touching the required one.
   #
-  # WHAT IT DELIBERATELY OMITS: the resurrected-prose step. It is advisory, it
-  # needs a deepened fetch and POSIX shell syntax, and running an
-  # OS-independent text diff twice buys nothing.
+  # WHAT IT DELIBERATELY OMITS: the resurrected-prose step and the actionlint
+  # workflow-load gate. The first is advisory, needs a deepened fetch and POSIX
+  # shell syntax, and running an OS-independent text diff twice buys nothing. The
+  # second is the same argument plus a concrete one — actionlint reads YAML, its
+  # verdict cannot depend on the host, and the pinned tarball is `linux_amd64`.
   check-windows:
     name: Manifest checks (Windows)
     runs-on: windows-latest

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -242,6 +242,95 @@ jobs:
           echo "release-it $*"
           PATH="$PWD/node_modules/.bin:$PATH" npx release-it "$@"
 
+      # THE ASSETS SHIP HERE, NOT IN release.yml — and the ordering is the whole
+      # point.
+      #
+      # release-it above creates the GitHub release as PUBLISHED
+      # (`github.release: true`, `preRelease: false`), and `releases/latest`
+      # starts pointing at it immediately. `release.yml` used to be the only
+      # uploader, in its Phase F, AFTER the ~130-package serial npm publish. So
+      # between those two moments there was a live release with zero assets that
+      # `releases/latest/download/...` already resolved to. MEASURED on the
+      # v0.29.0 cut: over TWO HOURS, `install.mjs` and `cli.gjs.mjs` both HTTP
+      # 404 the whole time.
+      #
+      # That URL is not incidental — it is THE documented Node-free install path
+      # (README.md, website/src/content/docs/guides/install.md), and every job in
+      # `gjsify/ts-for-gir`'s CI bootstraps through it. So for the length of each
+      # publish, a fresh consumer install and that repo's entire CI failed with
+      # `curl: (22) 404`. It cost an investigation once already: a container probe
+      # bootstrapping that way failed, and the failure first read as a
+      # GJS-version problem.
+      #
+      # This job is the only one that HAS the bytes before anything is public.
+      # Both are same-commit artifacts of the release commit itself:
+      # `install.mjs` is tracked at the root, and `dist/cli.gjs.mjs` was rebuilt
+      # AT THE NEW VERSION by the `after:bump` hook — `--rebuild` implies
+      # `--keep`, so what is on disk here is what the tag carries. Uploading from
+      # release.yml could only ever re-derive that.
+      - name: Generate cli.gjs.mjs.sha256
+        if: ${{ !inputs.dry_run }}
+        id: assets
+        run: |
+          set -euo pipefail
+          cd packages/infra/cli/dist
+          sha256sum cli.gjs.mjs | awk '{print $1}' > cli.gjs.mjs.sha256
+          cat cli.gjs.mjs.sha256
+          cd - >/dev/null
+          # The tag release-it just created. The dispatch step below re-derives
+          # this the same way; both read the tag rather than recomputing a
+          # version, so neither can disagree with what was actually pushed.
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload installer + bootstrap bundle to the release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@v3
+        with:
+          # Same invocation shape as release.yml's Phase F (tag_name + files, no
+          # `body`): targeting an EXISTING release uploads the assets onto it and
+          # leaves the release notes release-it computed alone.
+          tag_name: ${{ steps.assets.outputs.tag }}
+          files: |
+            install.mjs
+            packages/infra/cli/dist/cli.gjs.mjs
+            packages/infra/cli/dist/cli.gjs.mjs.sha256
+
+      # A check that cannot fail is decoration, so this one gates — and it gates
+      # BEFORE the publish dispatch on purpose. The two failure modes are not
+      # symmetric: stopping here leaves a cut release with npm not yet published,
+      # which the dispatch comment below already describes as recoverable by
+      # hand; letting it through would publish into exactly the 404 window this
+      # step exists to close. Retried because the object store needs a moment to
+      # serve a just-uploaded asset, and a redirect-following HEAD on a cold CDN
+      # path is the one part of this that can be slow without being wrong.
+      - name: Assert the documented install URLs resolve
+        if: ${{ !inputs.dry_run }}
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.assets.outputs.tag }}
+        run: |
+          set -euo pipefail
+          base="https://github.com/$REPO/releases"
+          fail=0
+          for url in "$base/latest/download/install.mjs" \
+                     "$base/latest/download/cli.gjs.mjs" \
+                     "$base/download/$TAG/install.mjs" \
+                     "$base/download/$TAG/cli.gjs.mjs"; do
+            code=""
+            for attempt in 1 2 3 4 5 6; do
+              code="$(curl -sILo /dev/null -w '%{http_code}' "$url" || echo 000)"
+              [ "$code" = "200" ] && break
+              sleep 10
+            done
+            if [ "$code" = "200" ]; then
+              echo "ok   $code  $url"
+            else
+              echo "::error::$url returned $code — the documented install path is broken for this release."
+              fail=1
+            fi
+          done
+          [ "$fail" = "0" ]
+
       # The cut creates a GitHub release, and release.yml listens for
       # `release: [published]` — but a release created by a workflow using the
       # repository's GITHUB_TOKEN does NOT trigger other workflows. That is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,11 +161,22 @@ jobs:
       # `curl ... | gjs -m -` line, no npm/Node required. The bundle was
       # rebuilt above by `gjsify run build` (executes build:gjs-bundle).
       #
-      # Asset upload fires on the original `release` event and on manual
-      # reruns that target a specific tag — the second path is the fix for
-      # the v0.4.15 incident (release-event run failed, the manual reruns
-      # that followed silently skipped the upload because the original
-      # gate was hard-pinned to `event_name == 'release'`).
+      # THIS IS NO LONGER THE PRIMARY UPLOAD — `release-cut.yml` now ships these
+      # three files immediately after it creates the release, and asserts the
+      # documented URLs resolve before it dispatches this workflow. It has to:
+      # this phase runs after the ~130-package serial npm publish, and the gap
+      # between "release published" and "assets present" was a MEASURED two-hour
+      # window in which `releases/latest/download/install.mjs` 404'd — breaking
+      # the documented install path and all of ts-for-gir's CI. See the comment
+      # at that step for the full incident.
+      #
+      # It stays because it is the RECOVERY path, and re-uploading identical
+      # bytes is a no-op: asset upload fires on the original `release` event and
+      # on manual reruns that target a specific tag — the second path is the fix
+      # for the v0.4.15 incident (release-event run failed, the manual reruns
+      # that followed silently skipped the upload because the original gate was
+      # hard-pinned to `event_name == 'release'`). A cut that dies between
+      # creating the release and uploading still has one way to land the assets.
       - name: Generate cli.gjs.mjs.sha256
         if: ${{ (github.event_name == 'release' || inputs.release_tag != '') && inputs.verify_only != true }}
         run: |

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -341,6 +341,22 @@ What is MEASURED, and what is not:
   stayed quiet would read as "all clear". **This entry therefore stays open**:
   the standing repair is still to take CI's `rebuilt-bundles` bytes and re-run
   the triple. The hook only removes the part where nobody knew to.
+- **2026-08-05 — a RELEASE restales every open PR's bundle, and the mismatch it
+  produces looks nothing like the drift above.** PR #994 was red on the verify
+  step with the two files at the SAME size (6612297 B) and differing in exactly
+  **one byte**: the committed bundle read `gjsify-install/0.28.0` where the
+  rebuild emits `0.29.0`. `buildHeaders()` (`utils/publish-headers.ts`) bakes the
+  CLI version into the install backend's `user-agent`, the branch's bundle was
+  built before `chore: release v0.29.0`, and the branch then sat on top of it.
+  Nothing about that PR touched the baked value. So this cause is neither
+  non-determinism nor a stale closure — it is the release train, it fires on
+  EVERY open PR whose bundle predates a cut, and the author sees an unexplained
+  byte mismatch in a file they did not meaningfully change. The one-byte,
+  same-size signature is worth recognising on sight: check the baked version
+  before reaching for the `$N` explanation. It is also the sharpest argument for
+  the second direction below — ADR 0002 measures 43 of the 250 commits on this
+  artifact as `chore: release`, and an untracked bundle cannot be restaled by a
+  version bump at all.
 
 AGENTS.md § Committed-artifact freshness already says `--with-dependencies` pins
 the INPUTS so that "a mismatch means staleness"; the run above is that sentence
@@ -1115,40 +1131,6 @@ that always runs (or move them into `audit-runtimes.yml`, which already runs on
 every PR with no paths filter — but that job deliberately performs no install, and
 both tools are devDeps, so it would need one). Pick deliberately; either way the
 claim "lint is clean" stops depending on which paths a PR happened to touch.
-
-### A workflow GitHub refuses to load reports the PR as GREEN
-
-When GitHub rejects a workflow file it creates a run with ZERO jobs, hence zero
-check runs — so the pull request shows green while the workflow never ran. The
-only visible trace is a run oddly named after the file path instead of the
-workflow name.
-
-Measured: moving nine jobs onto the baked CI image deleted a single-line `run:`
-and left a step carrying only a `name:`. GitHub refused the whole file, six
-node-gi jobs silently did not run, and the PR reported **24 green checks**. It
-was caught by asking why the expected job names were missing, not by any signal.
-
-Measured AGAIN on 2026-08-04, with a different cause and the same silence:
-`PREBUILD_SNAPSHOT: ${{ runner.temp }}/…` in `jobs.commit-prebuilds.env` — the
-`runner` context does not exist outside steps. GitHub refused the file and raised
-run 30890615702 as a `push`-event run on a topic branch that `prebuilds.yml`'s
-`push` trigger does not even cover (a file it cannot parse never gets its triggers
-evaluated), while `gh pr checks` reported only passes. So the class has now cost
-two incidents, and the second one was a CONTEXT error rather than a shape error —
-whatever gate is chosen must evaluate expression scope, not just outline shape.
-`tests/e2e/prebuild-change-gate` now fails a `runner`/`steps` reference in any
-job-level `env:` block, which covers that one mistake in that one file; it is a
-point fix, not the general gate this entry is about.
-
-Another workflow CAN see what the broken one cannot report — `audit-runtimes.yml`
-already runs pure-Node repo checks on every PR with no install — so the gate has
-an obvious home. The trap is the checker itself: a hand-rolled YAML outline
-scanner written for this produced 17 false positives on `prebuilds.yml` and
-`release.yml`, both of which GitHub loads fine, and a check that cries wolf is
-worse than none. Node ships no YAML parser, so the real options are `actionlint`
-(purpose-built, one Go binary, catches far more) or python3 + PyYAML, which the
-ubuntu runners already have and which gave the correct answer — exactly one
-offending step — when used ad hoc. Pick one deliberately; do not hand-roll.
 
 ### `needsWebgl` in `showcases.json` is declared, parsed, and read by nobody
 


### PR DESCRIPTION
Two CI-honesty fixes. Neither touches a committed bundle.

## 1. Release assets ship from the cut job (closes #995)

`release-cut.yml` publishes the GitHub release immediately; the assets were uploaded by `release.yml`'s Phase F, *after* the ~130-package serial npm publish. In between, `releases/latest` resolves to a release with zero assets.

Measured on v0.29.0: **over two hours** during which `releases/latest/download/install.mjs` returned 404 — the documented Node-free install path, and the URL every `gjsify/ts-for-gir` CI job bootstraps through.

The cut job is the only one holding those bytes before anything is public, and both are same-commit artifacts of the release commit (`install.mjs` tracked at root; `dist/cli.gjs.mjs` rebuilt at the new version by `after:bump`, where `--rebuild` implies `--keep`). Upload moves there, ahead of the publish dispatch, followed by a gating assertion that the documented URLs return 200.

The assertion gates *before* the dispatch on purpose: stopping there leaves a cut release with npm unpublished — recoverable by hand, as the dispatch step already documents — whereas letting it through publishes into the window this closes.

Phase F stays as the recovery path for a cut that dies mid-upload (the v0.4.15 shape); re-uploading identical bytes is a no-op.

## 2. actionlint gate in `audit-runtimes.yml`

A workflow GitHub refuses to load creates a run with zero jobs, so the PR shows green while it never ran. Two incidents so far — a step with only a `name:` (24 green checks, six node-gi jobs silent) and `runner.temp` in a job-level `env:`.

actionlint rather than our own checker: the TODO entry records that a hand-rolled outline scanner gave 17 false positives on workflows GitHub loads fine, and demanded the gate evaluate expression *scope* after incident 2. Both shapes were reproduced against actionlint 1.7.12 before wiring it up — `[syntax-check]` and `[expression]` respectively.

Pinned by version + sha256. `-shellcheck=`/`-pyflakes=` deliberately empty: unmeasured volume is how this step would acquire its predecessor's false positives. With them off the repo is clean at 0 findings, which is why it gates.

## Status data

- Deletes the resolved workflow-load TODO entry.
- Adds a third measured cause to the `cli.gjs.mjs` byte-reproducibility entry: a release bump restales every open PR's bundle through the baked `user-agent` version — a one-byte, same-size mismatch unlike the `$N` drift. Found on #994 during this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)