### PR TITLE
docs(adr): record ts-for-gir's library shape

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -133,6 +133,14 @@ jobs:
       - name: Check every e2e suite runs or says why not
         run: node scripts/check-e2e-suite-coverage.mjs
 
+      # ADR 0017 sat on disk, load-bearing and ABSENT from the index table, because
+      # nothing compared the directory to it. The mirror-image cost landed the same day:
+      # an agent reading a pre-fix checkout filed an issue asserting 0018 did not exist,
+      # hours after it had. The Status column is a second copy of each ADR's own line, so
+      # this compares those too — promoting Proposed → Accepted touches two files.
+      - name: Check the ADR index lists every ADR
+        run: node scripts/check-adr-index.mjs
+
       # A lockfile whose FORMAT lags the installer is silent: `--immutable` accepts old
       # versions on purpose, so every install still succeeds — just without the platform
       # fields the filter reads. That is how this repo installed every platform's
@@ -294,6 +302,14 @@ jobs:
       # globbing, correctly; what was missing is a record of which omissions are meant.
       - name: Check every e2e suite runs or says why not
         run: node scripts/check-e2e-suite-coverage.mjs
+
+      # ADR 0017 sat on disk, load-bearing and ABSENT from the index table, because
+      # nothing compared the directory to it. The mirror-image cost landed the same day:
+      # an agent reading a pre-fix checkout filed an issue asserting 0018 did not exist,
+      # hours after it had. The Status column is a second copy of each ADR's own line, so
+      # this compares those too — promoting Proposed → Accepted touches two files.
+      - name: Check the ADR index lists every ADR
+        run: node scripts/check-adr-index.mjs
 
       # A lockfile whose FORMAT lags the installer is silent: `--immutable` accepts old
       # versions on purpose, so every install still succeeds — just without the platform

--- a/docs/adr/0019-ts-for-gir-as-library.md
+++ b/docs/adr/0019-ts-for-gir-as-library.md
@@ -1,0 +1,173 @@
+# ADR 0019 — ts-for-gir as a library; the `.gir` travels with the runtime package
+
+- **Status:** Proposed (2026-08-05)
+- **Scope:** `@ts-for-gir/lib` (programmatic entry, no build step), `@gjsify/gtk-runtime-*` (`gjsify.prebuilds` + `.gir`), `@girs/*` `libraryVersion`, the six bridges' `build:gir-types` recipes
+
+## Context
+
+`@girs/*` types are generated ahead of time from **one** upstream version and then
+loaded against whatever library the host actually has. **GIRepository cannot
+notice the difference** — it matches only the API version, so a `Gtk-4.0.typelib`
+from GTK 4.12 and one from 4.23 both satisfy `gi://Gtk?version=4.0`.
+
+Measured on the maintainer workstation, 2026-08-04. Host GTK **4.22.4**,
+`@girs/gtk-4.0@4.1.0` generated from **4.23.0**, and `Gtk.RestoreReason.RECOVER`
+is `@since 4.24`:
+
+| | |
+|---|---|
+| `gjsify tsc --noEmit` | **exit 0**, no diagnostic |
+| the same line at runtime | `TypeError: Gtk.RestoreReason is undefined` |
+| `gjsify system-check` | `✓ GTK4 (4.22.4)` — silent |
+
+Two routes close it, and they are **not equivalent**:
+
+- **(a) make `libraryVersion` honest.** Helps every consumer at once, but only
+  where the GIR carries a `<package version>`. Measured over the 32 installed
+  packages: **12 real, 17 degenerate, 3 absent** — `@girs/gdk-4.0` states
+  `4.0.0` because GDK ships *inside* GTK and declares no version of its own, a
+  string shaped exactly like a release that corresponds to none.
+- **(b) ship the `.gir` next to the artifact.** Types generated from the exact
+  GIR the binary was built against cannot drift at all.
+
+Route (b) is what requires a **library**. The pipeline pieces already live in
+`@ts-for-gir/lib` (`gir-module.ts`, `generators/`, `transformation/`), but the
+**orchestration** lives in `@ts-for-gir/cli` (`generation-handler.ts`,
+`module-loader.ts`, `config.ts`), so a consumer can only shell out to a
+subprocess.
+
+Two facts make this a small step rather than a new mechanism:
+
+- The pattern **already exists** via subprocess. Six gjsify bridges
+  (`http2-native`, `tls-native`, `sab-native`, `terminal-native`,
+  `http-soup-bridge`, `lightningcss-native`) run
+  `ts-for-gir generate --girDirectories=<the prebuild dir>` in `build:gir-types`.
+- The **`prebuild-artifacts` invariant already mandates the `.gir`** for every
+  package declaring `gjsify.prebuilds`, with this reasoning in its header.
+
+The gap is exactly where the drift was measured: `@gjsify/gtk-runtime-*`
+declares only `gjsify.runtimes` and `gjsify.tier` — **no `gjsify.prebuilds`** —
+so it sits outside that invariant and carries no `.gir`. GTK is the namespace
+the failure above was measured on.
+
+## Decision
+
+### 1. ts-for-gir stays build-step-free; gjsify bundles it
+
+Every `@ts-for-gir/*` package exports `src/index.ts` directly (`AGENTS.md`:
+*"TS runs directly, no build step"*); `@ts-for-gir/lib`'s `exports` is literally
+`{".": "./src/index.ts"}`. The library entry adds no `dist/`.
+
+Bundling is **gjsify's** job, and it already ships: ts-for-gir#426 builds the
+Node CLI with `gjsify build --app node`.
+
+**Rejected: a `dist/` build in ts-for-gir.** It would place a second copy of
+every generator under a freshness gate — the exact tax ADR 0002 is currently
+removing from this repo, where 43 of the 250 commits on `cli.gjs.mjs` are
+`chore: release` and a version bump restales every open PR's bundle.
+
+### 2. The `.gir` travels with the RUNTIME package, never with the type package
+
+`@gjsify/gtk-runtime-*` declares `gjsify.prebuilds` and thereby comes under the
+`prebuild-artifacts` invariant, which already requires the `.gir`.
+
+**Rejected: shipping `.gir` inside `@girs/*`.** It duplicates the generator's
+input across ~700 packages, and — decisively — a `.gir` in a type package proves
+nothing about the library the host will load. That is the entire failure being
+fixed. Next to the binary it is one copy, and it is provenance.
+
+### 3. `libraryVersion` states only what the library states
+
+ts-for-gir#436. `LibraryVersion` records whether the library itself declared
+`MAJOR_VERSION`/`MINOR_VERSION`/`MICRO_VERSION`, and the package template omits
+the field when it did not; `PACKAGE_DESC` stops making the claim too.
+**Absence becomes a fact a consumer can act on.**
+
+**Rejected: a consumer-side allowlist of which packages to believe.**
+`@gjsify/cli` carried exactly that. A value that must be second-guessed per
+package is worse than no value.
+
+## Rejected — one `@gjsify/gtk-runtime` meta name
+
+ADR 0017's shape is per-target packages behind an `optionalDependencies` bridge,
+so **npm installs the matching target automatically**. For the GTK runtime
+bundles that was implemented (#910) and reverted (#920). Measured, parent vs.
+merge commit, same job, same runner image:
+
+```
+b607be808 (parent)  npm install → "added 1 package"   boxed-out PASS
+da9ca4001 (merge)   npm install → "added 2 packages"  boxed-out FAIL
+```
+
+The second package is `@gjsify/gtk-runtime-darwin-arm64`, 31.5 MB. An installed
+bundle satisfies **candidate 4** of `resolveGtkRuntimeBundle()`
+(`require.resolve`), so the process re-execs onto the **bundle's** typelibs while
+the addon's native code is linked against Homebrew GTK 4.22.4. Method lookups
+then land on the wrong entries — `no method 'match' on GObject-weak-notifies`,
+`no method 'get_identifier' on GIRepository` — after which the runner produced no
+output for **29 minutes** and the job hit its timeout.
+
+**The bundle must not override a GTK the addon was actually built against.** The
+install edge is the forbidden part, and a meta name is precisely an install edge.
+
+It also buys nothing on the resolution side:
+
+- resolution already works **by name** — `resolveGtkRuntimeBundle()` probes
+  `require.resolve('@gjsify/gtk-runtime-<target>')` as candidate 4;
+- npm's platform filter would already select correctly — the packages declare
+  `os: ["darwin"]`, `cpu: ["arm64"]`;
+- `@gjsify/node-gi` declares **no `optionalDependencies` at all** today. That is
+  the revert, held.
+
+Reconsider only once the mismatch is **visible rather than a timeout**: the
+bundle's `manifest.json` records its build prefix and dylib set, and the addon's
+`otool -L`/`LC_RPATH` records what it linked against, so a load-time check could
+refuse the combination outright. Until then the bundles stay manual installs.
+Tracked in `status/open-todos.md` § "The GTK-runtime bundle precedence question
+is still open".
+
+Decision 2 is **independent** of this: declaring `gjsify.prebuilds` adds a `.gir`
+to the tarball, not a dependency edge.
+
+## Consequences
+
+- `@ts-for-gir/lib` gains a public programmatic surface, so it acquires a
+  compatibility contract it does not have today — the orchestration is currently
+  free to change because only the CLI calls it.
+- A library consumer must be able to run TypeScript. gjsify can; an arbitrary
+  npm consumer cannot. That is deliberate — the consumer **is** gjsify.
+- The six bridges' subprocess recipes may stay as they are. Nothing forces a
+  migration; the library path is what enables the gtk-runtime case, which has no
+  CLI equivalent because those bundles ship no `.gir` at all.
+- The GTK bundles grow by their `.gir` set. Size is not a counter-argument here:
+  the darwin bundle is already 31.5 MB of relocated dylibs.
+- `@girs/*` consumers will see **fewer** `libraryVersion` values, not more. That
+  is the intended direction — 17 of 32 currently state something untrue.
+
+## Implementation
+
+1. **ts-for-gir#437 → #435 → #436.** The order is forced, not preference:
+   #436's own description names #435 as its prerequisite (`build:types` runs
+   through `bin/ts-for-gir-dev`, which discarded its child's exit code, so the
+   step that generates ~700 `@girs/*` packages could not fail), and both are red
+   on `check` until #437's CLI bump lands.
+2. Lift the generation orchestration from `@ts-for-gir/cli` into
+   `@ts-for-gir/lib`; the CLI becomes an argv adapter over it. **No new npm name
+   is required** — `@ts-for-gir/lib` exists and is published, which avoids the
+   manual first-publish + Trusted Publisher bootstrap.
+3. Add `gjsify.prebuilds` + the `.gir` set to `@gjsify/gtk-runtime-*`, and let
+   `prebuild-artifacts` hold the claim.
+4. Generate the GTK `@girs/*` from the bundle's own `.gir` on the platforms where
+   a bundle is what actually runs.
+
+## Do not
+
+- **Do not make a GTK runtime bundle an install-time dependency, under any
+  name.** See Rejected — the cost was measured at 29 minutes of silence on the
+  macOS leg, and the mechanism is unchanged.
+- **Do not ship a `.gir` inside a `@girs/*` package to "fix" the drift.** A
+  `.gir` with no binary beside it carries no provenance, which is the whole
+  property being bought.
+- **Do not reintroduce a padded `libraryVersion`.** A namespace version widened
+  to three components is indistinguishable from a release by inspection, which
+  is what forced a per-package allowlist onto the consumer.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ the TODO records the *what's left*.
 | [0016](0016-status-as-data.md) | Status as data — authored status data (`status/`) + derived facts, gated by the `status-data` conformance rule; the rendered STATUS.md is generated, not committed (amended) | Accepted |
 | [0017](0017-native-package-distribution.md) | Distribution of platform-specific native builds — per-target packages behind an `optionalDependencies` bridge | Accepted |
 | [0018](0018-os-axis-declaration.md) | The OS axis is a declared, checked claim; Linux + macOS + Windows are the target | Proposed |
+| [0019](0019-ts-for-gir-as-library.md) | ts-for-gir as a library; the `.gir` travels with the runtime package | Proposed |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)
 (condensed findings + prioritized backlog).

--- a/scripts/check-adr-index.mjs
+++ b/scripts/check-adr-index.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// Every ADR on disk is in the index, and every index row describes it correctly.
+//
+// THE INCIDENT
+//
+// `0017-native-package-distribution.md` sat on disk, load-bearing — it is the per-target
+// platform-package split that `generate-platform-packages.mjs`, the `platform-packages`
+// conformance rule and `commit-prebuilds` all implement — and it was ABSENT from the index
+// table in docs/adr/README.md. A reader who trusted the index did not know it existed.
+// Nothing compared the two, so the gap was found by a human reading the directory.
+//
+// The same session produced the mirror-image cost: a fresh agent read a checkout from
+// before the fix and filed an issue asserting that 0018 did not exist and that #996 cited
+// a non-existent ADR. Both had landed hours earlier. An index nobody checks is wrong in
+// both directions — it omits what exists and it is trusted anyway.
+//
+// WHAT IT CHECKS, four directions
+//
+//   1. an ADR file on disk with no index row              → FAIL (the incident)
+//   2. an index row whose file does not exist             → FAIL (stale row)
+//   3. a row whose Status disagrees with the file's own   → FAIL (second copy drifting)
+//   4. a Status outside the vocabulary README declares    → FAIL
+//
+// (3) is the one that pays off repeatedly: the index Status column is a copy of the
+// `- **Status:**` line inside each ADR, and a copy nothing compares is a copy that drifts.
+// Promoting an ADR from Proposed to Accepted touches two files, and forgetting the second
+// is silent today.
+//
+// Plain Node over the repo's own files — no install, no build — so it runs in
+// `audit-runtimes.yml` next to the other repo-scoped guards.
+//
+// Usage: node scripts/check-adr-index.mjs [--root <dir>]
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootIndex = args.indexOf('--root');
+const ROOT = rootIndex === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootIndex + 1];
+
+const ADR_DIR = join(ROOT, 'docs', 'adr');
+const INDEX = join(ADR_DIR, 'README.md');
+
+/** The statuses docs/adr/README.md § Format declares. `Superseded by NNNN` carries a number. */
+const STATUS_PATTERN = /^(Proposed|Accepted|Rejected|Superseded by \d{4})$/;
+
+function fail(lines) {
+    console.error(`check-adr-index: ${lines.join('\n  ')}`);
+    process.exit(1);
+}
+
+let indexText;
+try {
+    indexText = readFileSync(INDEX, 'utf8');
+} catch (error) {
+    fail([`cannot read ${INDEX}: ${error.message}`]);
+}
+
+/** ADR files on disk: NNNN-<slug>.md, excluding README.md. */
+let onDisk;
+try {
+    onDisk = readdirSync(ADR_DIR)
+        .filter((name) => /^\d{4}-.+\.md$/.test(name))
+        .sort();
+} catch (error) {
+    fail([`cannot read ${ADR_DIR}: ${error.message}`]);
+}
+if (onDisk.length === 0) fail([`no ADR files under ${ADR_DIR} — the check is measuring nothing.`]);
+
+/** Index rows: | [NNNN](file.md) | Title | Status | */
+const rows = new Map();
+for (const line of indexText.split('\n')) {
+    const match = line.match(/^\|\s*\[(\d{4})\]\(([^)]+)\)\s*\|(.+)\|([^|]+)\|\s*$/);
+    if (match) rows.set(match[1], { file: match[2].trim(), status: match[4].trim() });
+}
+if (rows.size === 0) fail([`no ADR rows parsed from ${INDEX} — the table shape changed, so this check is blind.`]);
+
+/**
+ * The status an ADR declares about ITSELF.
+ *
+ * Three header shapes exist in the tree and all three are legitimate MADR — the oldest
+ * ADRs use a `## Status` section, the middle ones a `- Status:` bullet, the newest a
+ * `- **Status:**` bullet with the date inline. This check compares the CLAIM, not the
+ * formatting, so it reads all three rather than failing settled documents over layout.
+ */
+function declaredStatus(file) {
+    const text = readFileSync(join(ADR_DIR, file), 'utf8');
+    const bullet = text.match(/^-\s*(?:\*\*)?Status:?(?:\*\*)?:?\s*(.+)$/m);
+    const section = text.match(/^##\s*Status\s*$\n+(.+)$/m);
+    const raw = bullet?.[1] ?? section?.[1];
+    if (raw === undefined) return null;
+    // The status is the LEADING token; several ADRs qualify it in the same line with a
+    // date, an amendment pointer or a graduation note. Those are prose about the
+    // decision, not a different status, so the comparable claim is the token itself.
+    const leading = raw
+        .replace(/\*\*/g, '')
+        .trim()
+        .match(/^(Proposed|Accepted|Rejected|Superseded by \d{4})/);
+    return leading ? leading[1] : raw.replace(/\*\*/g, '').trim();
+}
+
+const problems = [];
+
+// 1. On disk, no row.
+for (const file of onDisk) {
+    const number = file.slice(0, 4);
+    if (!rows.has(number)) {
+        problems.push(
+            `docs/adr/${file} has no row in docs/adr/README.md. Add it — an ADR missing from the ` +
+                'index is invisible to every reader who trusts the index, which is how 0017 was lost.',
+        );
+    }
+}
+
+for (const [number, row] of [...rows].sort()) {
+    // 2. Row, no file.
+    if (!existsSync(join(ADR_DIR, row.file))) {
+        problems.push(
+            `docs/adr/README.md links ADR ${number} to "${row.file}", which does not exist. ` +
+                'Fix the link or delete the row.',
+        );
+        continue;
+    }
+    if (!row.file.startsWith(number)) {
+        problems.push(`docs/adr/README.md row ${number} links to "${row.file}", whose number differs.`);
+    }
+    // 4. Status vocabulary.
+    if (!STATUS_PATTERN.test(row.status)) {
+        problems.push(
+            `docs/adr/README.md row ${number} has status "${row.status}", which is not one of ` +
+                'Proposed / Accepted / Rejected / "Superseded by NNNN" (§ Format).',
+        );
+    }
+    // 3. Row status vs the ADR's own.
+    const own = declaredStatus(row.file);
+    if (own === null) {
+        problems.push(`docs/adr/${row.file} has no "- **Status:**" line, so the index row cannot be verified.`);
+    } else if (own !== row.status) {
+        problems.push(
+            `ADR ${number}: docs/adr/README.md says "${row.status}", docs/adr/${row.file} says "${own}". ` +
+                "The index Status is a copy of the ADR's own line — update both, or the copy drifts.",
+        );
+    }
+}
+
+if (problems.length > 0) fail(problems);
+
+console.log(`check-adr-index: ${onDisk.length} ADR(s) indexed, statuses agree.`);


### PR DESCRIPTION
Closes the writable half of #998 A, and the mechanism half of #1003.

## ADR 0019 — and why it has three decisions, not four

The decisions were settled in an earlier session; only their **reasoning** was missing, which is what blocked #998 A. Rather than restate four bullets without a why — the failure mode that ADR names itself — each one is grounded in an artefact that still exists:

| decision | what grounds it |
|---|---|
| ts-for-gir stays build-step-free; **gjsify bundles it** | already shipped — ts-for-gir#426 builds the Node CLI with `gjsify build --app node`; `@ts-for-gir/lib`'s `exports` is literally `{".": "./src/index.ts"}` |
| the `.gir` travels with the **runtime** package | the `prebuild-artifacts` invariant already mandates it for every `gjsify.prebuilds` package — and `@gjsify/gtk-runtime-*` declares only `runtimes` + `tier`, so it sits outside, carrying no `.gir`, in exactly the namespace the drift was measured on |
| `libraryVersion` states only what the library states | ts-for-gir#436, and the 12 real / 17 degenerate / 3 absent split across 32 installed packages |

The problem underneath, measured 2026-08-04: host GTK **4.22.4**, `@girs/gtk-4.0@4.1.0` generated from **4.23.0**, `Gtk.RestoreReason.RECOVER` is `@since 4.24` → `gjsify tsc --noEmit` **exit 0**, `TypeError` at runtime, `gjsify system-check` printed `✓ GTK4 (4.22.4)`. GIRepository cannot see it: it matches the API version only.

### The fourth is recorded as REJECTED, with the incident

A single `@gjsify/gtk-runtime` meta name means ADR 0017's `optionalDependencies` bridge, which means **npm installs the bundle automatically**. That was implemented (#910) and reverted (#920):

```
b607be808 (parent)  npm install → "added 1 package"   boxed-out PASS
da9ca4001 (merge)   npm install → "added 2 packages"  boxed-out FAIL
```

An installed 31.5 MB bundle satisfies candidate 4 of `resolveGtkRuntimeBundle()`, so the process re-execs onto the **bundle's** typelibs while the addon is linked against Homebrew GTK 4.22.4 — wrong method entries, then 29 minutes of silence and a timeout.

It buys nothing else either: resolution already works **by name** (candidate 4 is `require.resolve('@gjsify/gtk-runtime-<target>')`), and npm's platform filter would already select correctly (`os: ["darwin"]`, `cpu: ["arm64"]`). Verified on `main` today: `@gjsify/node-gi` declares **no `optionalDependencies` at all**. The install edge is the forbidden part, and a meta name is exactly an install edge.

Decision 2 is independent of it — `gjsify.prebuilds` adds a `.gir` to the tarball, not a dependency edge.

## The check, because an unchecked index is how 0017 was lost

`scripts/check-adr-index.mjs`, four directions, **each negative-tested against a scratch copy** rather than asserted:

1. ADR on disk with no row → the 0017 incident
2. row whose file does not exist
3. row whose number disagrees with its link
4. Status outside the vocabulary README § Format declares

Plus the one that will keep paying: the index Status column is a **second copy** of each ADR's own `Status` line. Promoting Proposed → Accepted touches two files and forgetting the second was silent until now.

The parser reads all three header shapes present in the tree (`## Status` section, `- Status:` bullet, `- **Status:**` with the date inline) and compares the **leading status token**. That is deliberate: this checks the claim, not the layout. Normalising 19 settled ADRs would be churn, and several qualify their status in the same line with an amendment or graduation note — prose about the decision, not a different status.

Wired into **both** jobs of `audit-runtimes.yml`, next to the sibling repo-scoped guards. Plain Node, no install, no build.

## Verification

- `node scripts/check-adr-index.mjs` → `19 ADR(s) indexed, statuses agree.`
- each of the four failure directions reproduced on a scratch copy, exit 1 with the naming message
- `check-workflow-inline-scripts` → `12 workflow(s) clean`
- `oxlint` clean, `oxfmt` applied

## Not in this PR

The implementation itself — lifting the generation orchestration out of `@ts-for-gir/cli` into `@ts-for-gir/lib`, and adding `gjsify.prebuilds` + the `.gir` set to the GTK bundles. The ADR's Implementation section names the forced order, which starts in the other repo: **ts-for-gir#437 → #435 → #436**.

Worth flagging from reading those: **#437's remaining red is not json-glib.** Its log says `@gjsify/rolldown-native` **is NOT INSTALLED**, and `npm view @gjsify/cli@0.29.0` confirms it is an *optional* peerDependency, which npm does not install. The json-glib fix in that PR is correct but addresses a different failure than the one now showing.
