### PR TITLE
ci: gate the glibc floor where a PR can see it

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -702,6 +702,25 @@ jobs:
           path: packages/infra/rolldown-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
 
+      # THE MEASUREMENT `commit-prebuilds` RUNS POST-MERGE, MOVED ONTO THE PR.
+      #
+      # `prebuilds.yml`'s base image decides which glibc the published binaries link
+      # against, so bumping it rewrites `gjsify.glibcRequires` for every consumer
+      # without touching a line of source. #897 bumped it 43 -> 44 in a hygiene sweep;
+      # glibc 2.43 re-versions the float maths lightningcss calls, the measured floor
+      # went 2.39 -> 2.43, and `main` was red for three consecutive `commit-prebuilds`
+      # runs (#924). The gate worked and named both numbers -- it just fired POST-MERGE,
+      # because `commit-prebuilds` is main-only, so the PR that caused it was green.
+      #
+      # It measures THIS LEG'S OUTPUT, not the committed copies: `stage-prebuild.mjs
+      # --scratch` wrote `<bridge>/prebuilds/<target>/`, which is empty in git, while
+      # the committed binaries live in the platform packages. Pointing plain
+      # `audit-runtimes --check` here would grade the OLD bytes -- and pass while doing
+      # it, since a missing target directory is a stat and not a failure there.
+      # `nodejs` is already installed above for `stage-prebuild.mjs`.
+      - name: Gate on the glibc floor of what this leg just built
+        run: node scripts/check-staged-prebuild-libc.mjs
+
   # ----------------------------------------------------------------
   # QEMU-emulated builds — ppc64, s390x, riscv64
   #
@@ -927,6 +946,25 @@ jobs:
           name: terminal-native-prebuilds-linux-${{ matrix.arch }}
           path: packages/node/terminal-native/prebuilds/linux-${{ matrix.arch }}/
           retention-days: 30
+
+      # THE MEASUREMENT `commit-prebuilds` RUNS POST-MERGE, MOVED ONTO THE PR.
+      #
+      # `prebuilds.yml`'s base image decides which glibc the published binaries link
+      # against, so bumping it rewrites `gjsify.glibcRequires` for every consumer
+      # without touching a line of source. #897 bumped it 43 -> 44 in a hygiene sweep;
+      # glibc 2.43 re-versions the float maths lightningcss calls, the measured floor
+      # went 2.39 -> 2.43, and `main` was red for three consecutive `commit-prebuilds`
+      # runs (#924). The gate worked and named both numbers -- it just fired POST-MERGE,
+      # because `commit-prebuilds` is main-only, so the PR that caused it was green.
+      #
+      # It measures THIS LEG'S OUTPUT, not the committed copies: `stage-prebuild.mjs
+      # --scratch` wrote `<bridge>/prebuilds/<target>/`, which is empty in git, while
+      # the committed binaries live in the platform packages. Pointing plain
+      # `audit-runtimes --check` here would grade the OLD bytes -- and pass while doing
+      # it, since a missing target directory is a stat and not a failure there.
+      # `nodejs` is already installed above for `stage-prebuild.mjs`.
+      - name: Gate on the glibc floor of what this leg just built
+        run: node scripts/check-staged-prebuild-libc.mjs
 
   # ----------------------------------------------------------------
   # macOS — prebuilds/darwin-arm64 (Apple silicon) + prebuilds/darwin-x64 (Intel)

--- a/scripts/check-staged-prebuild-libc.mjs
+++ b/scripts/check-staged-prebuild-libc.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// The glibc floor of what THIS LEG JUST BUILT, measured where it can still block a PR.
+//
+// THE INCIDENT
+//
+// `prebuilds.yml`'s base image decides which glibc our published binaries link against, so
+// bumping it rewrites `gjsify.glibcRequires` for every consumer without touching a line of
+// source. #897 bumped it 43 → 44 in a hygiene sweep; glibc 2.43 re-versions
+// `acosf`/`asinf`/`atan2f`, which lightningcss's colour conversion calls, so the measured
+// floor went 2.39 → 2.43 and `main` was red for three consecutive `commit-prebuilds` runs
+// (#924). The gate WORKED — it named both numbers and refused the artifacts — it just fired
+// POST-MERGE, because `commit-prebuilds` is main-only. The PR that caused it was green.
+//
+// That is the shape AGENTS.md § "PR coverage parity" calls dishonest: a green PR must
+// predict a green main. This runs the same measurement in the BUILD legs, which do run on
+// `pull_request`.
+//
+// WHY IT DOES NOT JUST CALL `audit-runtimes --check`
+//
+// Because that would measure the WRONG BYTES, and would do so SILENTLY.
+//
+// After ADR 0017 the committed binaries live in the per-target platform packages
+// (`packages/<pillar>/<bridge>-linux-x64/prebuilds/linux-x64/`), which is also where
+// `commit-prebuilds` downloads the artifacts to. A build leg stages into the BRIDGE's own
+// `prebuilds/<target>/` — `stage-prebuild.mjs --scratch`, deliberately: the leg commits
+// nothing. `audit-runtimes` resolves directories through the manifests, so in a build leg it
+// would walk straight past the freshly built files and grade the OLD COMMITTED ONES.
+//
+// And it would pass while doing it. `auditPrebuildLibc` treats a missing target directory as
+// a STAT, not a failure (`stats.skippedMissing++; continue;`), so a gate pointed at the wrong
+// place reports "0 targets measured" and goes green — worse than not having it.
+//
+// WHAT THIS DOES INSTEAD
+//
+// `auditPrebuildLibc` is kept as a standalone export precisely so it can be driven against
+// packages other than the ones on disk ("so an e2e suite can drive it against SYNTHETIC
+// packages in a temp directory"). Its rows carry WHERE TO MEASURE (`prebuildDir`) and WHAT TO
+// HOLD IT TO (`manifestGjsify.glibcRequires`) as separate fields. So this takes the real rows
+// — declarations and all, from the platform packages — and redirects only `prebuildDir` at
+// the freshly staged bridge directory. Same rule, same failure text, fresh bytes.
+//
+// Two properties this shape has and a path-guessing one would not:
+//
+//   1. It STRUCTURALLY cannot read a committed copy. The bridge `prebuilds/` directories are
+//      empty in git (verified across all ten bridges), so anything found under one was
+//      written by this leg's collect steps.
+//   2. The bridge ↔ platform-package mapping stays ONE derivation: `platformPackageDirName()`
+//      builds the name, and this strips exactly that suffix. A second spelling in a workflow
+//      is how the two drift.
+//
+// And the guard the silent-skip above demands: **zero staged directories is a FAILURE**, not
+// a quiet pass. In a build leg it means the collect steps did not run.
+//
+// SCOPE, stated rather than silently narrowed: this holds the libc rule — glibc floor, libc
+// flavour, musl verdict, unreadable ELF — over the freshly built artifacts. The other
+// prebuild rules (artifact existence, loader paths, `.gir` provenance) still run only in
+// `commit-prebuilds` and `audit-runtimes.yml`.
+//
+// Plain Node over the repo's own files — no install, no build. The build legs already install
+// `nodejs` for `stage-prebuild.mjs`.
+//
+// Usage: node scripts/check-staged-prebuild-libc.mjs [--root <dir>]
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    auditPrebuildLibc,
+    collectLibcPackages,
+    createContext,
+    isPlatformPackageManifest,
+} from '../packages/infra/manifest-conformance/lib/index.mjs';
+
+const args = process.argv.slice(2);
+const rootIndex = args.indexOf('--root');
+const ROOT = rootIndex === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootIndex + 1];
+
+function fail(lines) {
+    console.error(`check-staged-prebuild-libc: ${lines.join('\n  ')}`);
+    process.exit(1);
+}
+
+const ctx = createContext({ root: ROOT, discoveryRoots: ['packages'] });
+
+/**
+ * Rows whose measurement is redirected at this leg's freshly staged output.
+ *
+ * Only platform packages are considered: they are the ones that carry both a single target
+ * and the `gjsify.glibcRequires` entry for it, and they are the ones a bridge's staged
+ * directory is destined to become.
+ */
+const redirected = [];
+/** Platform packages whose bridge staged nothing — this leg did not build them. */
+const notStaged = [];
+
+for (const row of collectLibcPackages(ctx)) {
+    if (!isPlatformPackageManifest(row.manifest)) continue;
+    const target = row.declared?.length === 1 ? row.declared[0] : null;
+    if (target === null) continue;
+    if (!target.startsWith('linux-')) continue;
+
+    // The inverse of `platformPackageDirName(parentDirName, target)`, which is the ONE
+    // derivation of the forward direction. `isPlatformPackageManifest` has already
+    // established that the NAME ends in `-${target}`; the directory follows the same rule.
+    const suffix = `-${target}`;
+    if (!row.path.endsWith(suffix)) continue;
+    const bridgeRel = row.path.slice(0, -suffix.length);
+
+    const bridgePrebuilds = join(ROOT, bridgeRel, 'prebuilds');
+    if (!existsSync(join(bridgePrebuilds, target))) {
+        notStaged.push(`${row.name} → ${bridgeRel}/prebuilds/${target}/`);
+        continue;
+    }
+    // `path` follows the measurement, not the declaration, so a failure message points a
+    // reader at the bytes that actually failed. `name` stays the declaration's owner.
+    redirected.push({ ...row, path: `${bridgeRel}/prebuilds`, prebuildDir: bridgePrebuilds });
+}
+
+if (redirected.length === 0) {
+    fail([
+        'no freshly staged prebuild directory was found under any bridge package.',
+        'In a build leg that means the collect steps did not run — `stage-prebuild.mjs --scratch`',
+        'writes `<bridge>/prebuilds/<target>/`, and this check measures exactly those.',
+        'Reporting "0 targets measured" as a pass is the failure mode this check exists to remove,',
+        'so it is an error instead. Candidates that staged nothing:',
+        ...notStaged.map((n) => `  - ${n}`),
+    ]);
+}
+
+console.log(
+    `check-staged-prebuild-libc: measuring ${redirected.length} freshly staged target(s) against the ` +
+        'floors their platform packages declare:',
+);
+for (const row of redirected) console.log(`  ${row.name}  ←  ${row.path}/${row.declared[0]}/`);
+
+const { failures, notes } = auditPrebuildLibc(redirected);
+
+for (const note of notes) console.log(`  note: ${note}`);
+
+if (failures.length > 0) {
+    fail([
+        `the libc claim does not hold for what this leg just built (${failures.length} finding(s)):`,
+        ...failures.map((f) => `- ${f}`),
+        '',
+        'This is the measurement `commit-prebuilds` runs post-merge, moved onto the PR. A finding here',
+        'is the same finding that would turn `main` red — fix the declaration or the build, not this gate.',
+    ]);
+}
+
+console.log('check-staged-prebuild-libc: the freshly built artifacts match their declared libc floors.');


### PR DESCRIPTION
Closes #1004. Unblocks #924.

## The problem

`commit-prebuilds` runs `audit-runtimes --check` on the freshly downloaded artifacts and refuses them when the measured glibc floor exceeds the declaration — that is how #924 was caught. But it is **main-only**, so the PR that moved the floor was green and `main` was red for three consecutive runs.

## Two things the issue asked for turned out different

Both measured on `main` before writing anything:

**1. `nodejs` is already there.** `prebuilds.yml:382`, with the reason in the comment — it runs `stage-prebuild.mjs`. Nothing to add.

**2. The staging hazard is current, not pending.** The issue says the bridge dir "is also where the committed copy lives, so it happens to work — but *after* ADR 0017's split…". That split has landed:

| bridge | tracked in `<bridge>/prebuilds/` | in `<bridge>-linux-x64/prebuilds/` |
|---|---|---|
| `webgl` | 0 | 3 |
| `lightningcss-native` | 0 | 4 |
| `rolldown-native` | 0 | 4 |
| *(all ten)* | **0** | 3–4 |

`commit-prebuilds` confirms the direction — its `download-artifact` steps write to `packages/<pillar>/<bridge>-linux-<arch>/prebuilds/linux-<arch>/`.

So a plain `audit-runtimes --check` in a build leg would resolve through the manifests, land on the platform packages, and grade the **old committed binaries** while the fresh ones sat in the bridge scratch dir.

**And it would pass while doing it.** `auditPrebuildLibc` treats a missing target directory as a stat, not a failure:

```js
const dir = join(pkg.prebuildDir, target);
if (!existsSync(dir)) { stats.skippedMissing++; continue; }
```

A misdirected gate reports "0 targets measured" and goes green — worse than not having one.

## So the staging does not move

The issue proposes moving it. That works but touches ~20 `--scratch` calls plus their upload paths across two jobs, and changes what `commit-prebuilds` consumes.

Not needed — the rule says so itself:

> Kept as a standalone export, exactly like `auditPrebuildArtifacts`, so an e2e suite can drive it against SYNTHETIC packages in a temp directory

Its rows carry **where to measure** (`prebuildDir`) separately from **what to hold it to** (`manifestGjsify.glibcRequires`). So this takes the real rows — declarations and all, from the platform packages — and redirects only `prebuildDir` at the freshly staged bridge directory. Same rule, same failure text, fresh bytes, no change to the artifact contract.

Two properties a path-guessing version would not have:

1. **It structurally cannot read a committed copy.** Bridge `prebuilds/` is empty in git, so anything found under one was written by this leg's collect steps.
2. **One derivation of the mapping.** `platformPackageDirName()` builds the name; this strips exactly that suffix. A second spelling in workflow YAML is how the two drift.

Plus the guard the silent-skip demands: **zero staged directories is an error.** In a build leg that means the collect steps did not run.

## Verified against real artifacts, not asserted

| case | how | result |
|---|---|---|
| nothing staged | clean tree | **exit 1**, names every candidate that staged nothing |
| ten real drops staged | copied each committed `linux-x64` into its bridge dir | measured **10/10**, passed |
| declaration below the measured floor | lowered `lightningcss-native-linux-x64` to `2.14` | **exit 1**, verbatim #924: *"requires glibc ≥ 2.39 but `gjsify.glibcRequires["linux-x64"]` promises 2.14"* |

Also: YAML parses, the gate is the **last step of both** `build-prebuilds` and `build-prebuilds-qemu`, `check-workflow-inline-scripts` clean, oxlint clean.

## Scope, stated rather than narrowed

This holds the **libc** rule — floor, flavour, musl verdict, unreadable ELF — over the fresh artifacts. The other prebuild rules (artifact existence, loader paths, `.gir` provenance) still run only in `commit-prebuilds` and `audit-runtimes.yml`.

And the thing underneath is unchanged: **the floor is OBSERVED, never CHOSEN.** Even pinned to `fedora:43` it moves the day that image's glibc re-versions something else. Deciding it means building the three Rust bridges against a declared baseline (an old-glibc container, or `cargo-zigbuild --target <triple>.<glibc>`), after which `gjsify.glibcRequires` becomes an input the build satisfies rather than a number someone reads off the result. That is a policy decision — how old a distro do we support? — and wants its own change. This one only makes a PR predict its own main.
