### PR TITLE
fix(os): read internal off the loopback flag, not the address

### DIFF
--- a/packages/node/os/src/linux.ts
+++ b/packages/node/os/src/linux.ts
@@ -27,6 +27,20 @@ const getIPv6Subnet = createSubnet(128, 16, 16, ':');
 function parseInterfaces(info) {
     info = info.trim();
     if (info.length < 1) return;
+    // Node derives `internal` from the interface's IFF_LOOPBACK flag, not from
+    // the address. `darwin.ts` already reads it that way and carries the
+    // reasoning; off `ip addr` the same flag sits in the block's first line
+    // (`lo: <LOOPBACK,UP,LOWER_UP> …`), because `networkInterfaces()` splits the
+    // output on `^\d+:\s+`.
+    //
+    // The address test this replaces — `ip[0] === '127.0.0.1'` — answered NO for
+    // `::1`, so loopback's IPv6 address came back EXTERNAL while its IPv4 came
+    // back internal, on the same interface. Two specs in `index.spec.ts` have
+    // asserted otherwise all along. They pass in CI only because the image
+    // ships no `iproute`: `cli('ip addr')` throws there and the procfs fallback
+    // answers instead, and that fallback reads the flag correctly. On any host
+    // that HAS `ip` — every developer machine — this path runs and they fail.
+    const internal = /<[^>]*\bLOOPBACK\b[^>]*>/.test(info.split(EOL)[0] ?? '');
     let iface = [],
         mac;
     for (let line, lines = info.split(EOL), i = 0; i < lines.length; i++) {
@@ -43,7 +57,7 @@ function parseInterfaces(info) {
                     netmask: (v === '4' ? getIPv4Subnet : getIPv6Subnet)(ip[1]),
                     family: 'IPv' + v,
                     mac: mac,
-                    internal: ip[0] === '127.0.0.1',
+                    internal,
                 });
                 break;
         }


### PR DESCRIPTION
`os.networkInterfaces()` reports loopback's IPv6 address as EXTERNAL while reporting its IPv4 address on the same interface as internal. Two specs in `packages/node/os/src/index.spec.ts` have asserted otherwise since they were written, and both fail on any host that has `ip`.

## The defect

`parseInterfaces()` derived the flag from the ADDRESS:

```js
internal: ip[0] === '127.0.0.1',
```

Node derives it from the interface's `IFF_LOOPBACK` flag. The address test answers NO for `::1`, and NO for every `127.x.x.x` that is not exactly `127.0.0.1`.

`darwin.ts` already reads the flag rather than the address, and states the reason at the line (`Node derives 'internal' from the interface's IFF_LOOPBACK flag, not from the address`). `readNetworkInterfacesFromProc()` — the fallback in this same file — also gets it right (`internal: devName === 'lo'`). Only the primary `ip addr` path was wrong, so the file disagreed with itself in two places.

`ip addr` carries the flag in each block's first line, and `networkInterfaces()` already splits on `^\d+:\s+`, so the block starts at `lo: <LOOPBACK,UP,LOWER_UP> …`. Reading it costs one regex and matches what `darwin.ts` does.

## Measured, on this host

Against real `ip addr` output, comparing the old rule with the new one for every address the parser produces:

| interface | family | address | before | after |
|---|---|---|---|---|
| `lo` | IPv4 | `127.0.0.1` | `true` | `true` |
| `lo` | IPv6 | `::1` | **`false`** | **`true`** |
| `wlo1` | IPv4 | `192.168.178.161` | `false` | `false` |
| `wlo1` | IPv6 | `fe80::…` | `false` | `false` |
| `virbr0` | IPv4 | `192.168.122.1` | `false` | `false` |
| `enp0s20f0u7` | IPv6 | `fe80::…` | `false` | `false` |

Exactly one verdict changes, and it is the one the specs were already asserting:

```
❌ flags loopback addresses as internal            Expected: true    Actual: false
❌ agrees on internal across an interface's address families
                                                   Expected: lo:true Actual: lo:false
```

## Why CI never saw it — the part worth more than the fix

**The `ip addr` path does not execute in CI at all.** `.docker/ci-fedora.Dockerfile` installs `git`, `tar`, `xz`, `findutils`, `libatomic` and the GJS/GNOME devel libs — no `iproute`, so no `ip`(8). `cli('ip addr')` therefore throws on every CI run and the `catch` hands the whole question to `readNetworkInterfacesFromProc()`, which is correct.

So the primary implementation of `networkInterfaces()` is dead code in CI, and the fallback is what every green run has been measuring. The specs are not weak — they are right, and they were structurally unable to fail where they run. That is the same shape as ADR 0018's finding for the OS axis: an assertion that cannot fail in the one environment that runs it proves nothing about the code it names.

Two ways to close it, deliberately NOT bundled into this fix:

1. **Add `iproute` to the CI image** — one line, and it makes the primary path the one CI exercises. It also changes what every other `os` spec measures, which is a bigger blast radius than a bug fix should carry.
2. **A fixture-driven spec for `parseInterfaces`** — feed it a captured `ip addr` block and assert the parse, with no dependency on the host having `ip`. Stronger, because it holds on every runner rather than on the ones that happen to ship `iproute`; it needs the function exported, which is a small refactor.

(2) is the better mechanism and should follow. Naming them here rather than doing them silently, or not at all.

## Verification status — stated plainly

The parse semantics above were verified against this host's real `ip addr` output. The package suite was **not** run for this branch: GitHub Actions has been in a major outage since 15:22 UTC (`Internal Server Error occurred while resolving "actions/checkout@v6"`), and the local workspace was in use by other work at the time. The change is one expression whose before/after verdicts are tabulated above; anything beyond that is unverified until CI returns.
