### PR TITLE
fix(cli): chdir before the in-process dispatch

### DIFF
--- a/packages/infra/cli/src/commands/run.ts
+++ b/packages/infra/cli/src/commands/run.ts
@@ -378,6 +378,21 @@ async function runScript(script: string, extraArgs: readonly string[], cwd: stri
         process.env.npm_package_name = env.npm_package_name;
         process.env.npm_package_version = env.npm_package_version;
         if (env.FORCE_COLOR !== undefined) process.env.FORCE_COLOR = env.FORCE_COLOR;
+        // …and the working directory, for the same reason. The spawn path below
+        // passes `cwd` to `spawn()`; this path used to pass it nowhere, so a
+        // `gjsify run -w <ws> <script>` resolved the WORKSPACE and then ran the
+        // command in the CALLER's directory. Every relative path in the script
+        // — `src/app/main.ts`, `dist/…`, `tests/test.mts` — then resolved
+        // against the monorepo root.
+        //
+        // Only this branch was affected, which is why it survived: the fast path
+        // fires exactly when the script is a SINGLE `gjsify <subcommand>`, so a
+        // compound script (`a && b`) took the shell path and worked. Measured on
+        // the two consumers: bauplaner's cli scripts are all single commands and
+        // it documents the gap in its AGENTS.md, sidestepping it with
+        // `cd cli && …`; buchhaltung's one `-w` use is `build:meson`, a compound
+        // command, and it works.
+        if (cwd !== process.cwd()) process.chdir(cwd);
         // Track the failure LOCALLY rather than through `process.exitCode`.
         // Under GJS `process.exit()` is deferred (see the note below), so the
         // `process.exit(1)` that used to live in the catch returned instead of

--- a/tests/e2e/run-command/run.mjs
+++ b/tests/e2e/run-command/run.mjs
@@ -12,7 +12,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, chmodSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
@@ -327,6 +327,52 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
         assert.equal(byPath.status, 0, `by-path failed: ${byPath.stderr}`);
         assert.match(byPath.stdout, /hello-from-script/);
     });
+
+    // The regression this suite could not see. Both `-w` rows above go through
+    // `runCli`, which spawns `process.execPath` — i.e. NODE — so they only ever
+    // exercise the SHELL path, and the shell path always passed `cwd` to
+    // `spawn()`. The in-process fast path (GJS only, single `gjsify <subcommand>`
+    // scripts) resolved the workspace and then ran the command in the CALLER's
+    // directory, so every relative path in the script resolved against the
+    // monorepo root.
+    //
+    // Asserts on WHERE the artifact landed, not just on the exit code: a chdir
+    // bug that happens to find a same-named file at the root would otherwise
+    // pass. The entry exists ONLY inside the workspace, so pre-fix this fails to
+    // resolve it at all and post-fix it writes `<ws>/dist/chdir-probe.js`.
+    it(
+        'runs the in-process -w dispatch INSIDE the workspace (GJS)',
+        { skip: hasGjs() ? false : 'gjs not on PATH' },
+        async () => {
+            const bundle = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
+            const appDir = join(root, 'packages', 'app');
+            const pkgPath = join(appDir, 'package.json');
+            const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+            // A SINGLE `gjsify <subcommand>` — that is what selects the fast path.
+            // Relative in and out, which is the whole point.
+            // `copy`, not `build`: it is a single `gjsify <subcommand>` (so it
+            // takes the fast path), it reads and writes RELATIVE paths (so a
+            // wrong cwd is visible), and it needs no bundler engine — `runGjs`
+            // invokes `gjs -m dist/cli.gjs.mjs` directly, bypassing the launcher
+            // that exports GI_TYPELIB_PATH/LD_LIBRARY_PATH for the prebuilds, so
+            // anything needing the engine fails here for an unrelated reason.
+            pkg.scripts.chdirprobe = 'gjsify copy src/chdir-asset.txt dist/chdir-probe.txt';
+            writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+            mkdirSync(join(appDir, 'src'), { recursive: true });
+            writeFileSync(join(appDir, 'src', 'chdir-asset.txt'), 'in-workspace\n');
+
+            const r = await runGjs(bundle, ['run', 'chdirprobe', '-w', '@test/app'], { cwd: root, timeoutMs: 120_000 });
+            assert.equal(r.status, 0, `-w dispatch failed:\n${r.stdout}\n${r.stderr}`);
+            assert.ok(
+                existsSync(join(appDir, 'dist', 'chdir-probe.txt')),
+                'the copy must land in the WORKSPACE, not the caller cwd',
+            );
+            assert.ok(
+                !existsSync(join(root, 'dist', 'chdir-probe.txt')),
+                'nothing may be written at the caller cwd',
+            );
+        },
+    );
 
     it('errors clearly for an unknown -w workspace', async () => {
         const r = await runCli(cliEntry, ['run', 'hello', '-w', 'does-not-exist'], { cwd: root });


### PR DESCRIPTION
`gjsify run -w <ws> <script>` resolved the workspace and then ran the command in the **caller's** directory, so every relative path in the script — `src/app/main.ts`, `dist/…`, `tests/test.mts` — resolved against the monorepo root.

## Why only one path, and why it looked like it worked

Only the **in-process fast path** was affected. The shell path (`spawn`) has always passed `cwd`. The fast path fires exactly when the script is a SINGLE `gjsify <subcommand>`, mutated `process.env` to match the spawn path's env — and then never changed directory.

Measured on the two consumers, which is what makes the split visible:

| consumer | shape | outcome |
|---|---|---|
| bauplaner | all `cli` scripts are single commands → fast path | broken; documents the gap in its `AGENTS.md` and sidesteps it with `cd cli &&` |
| buchhaltung | its one `-w` use is `build:meson`, compound → shell path | fine |

## The test is the other half

Both existing `-w` rows drive `runCli`, which spawns `process.execPath` — **Node** — so they could only ever exercise the shell path. That is why a chdir bug lived in the GJS-only branch untested.

The new row runs the real GJS bundle and asserts **where the artifact landed**, not just the exit code: a chdir bug that happened to find a same-named file at the root would pass otherwise.

**Verified it actually catches the defect** by stashing the fix: 16/16 with it, exit 1 without.

It dispatches `gjsify copy`, not `gjsify build`, deliberately — the suite's `runGjs` invokes `gjs -m dist/cli.gjs.mjs` directly, bypassing the launcher that exports `GI_TYPELIB_PATH`/`LD_LIBRARY_PATH`, so anything needing the bundler engine fails there for an unrelated reason. I found that by hitting it, and the failure was reported correctly by the engine diagnosis added in #1020. That launcher dependency is itself being removed on a separate branch.

## CI

GitHub Actions is not dispatching reliably right now (jobs queued for hours, then cancelled; `Build` killed at 15 min with no failing step). Verified locally instead: `gjsify workspace @gjsify/cli run check`, `tests/e2e/run-command` 16/16, `gjsify format && gjsify lint`.

**Pre-existing and unrelated:** `scripts/verify-committed-bundles.mjs` is already red on `main` — `@gjsify/create-app`'s build fails with `Unbekanntes Argument: …/typescript/lib/tsc.js`, a self-re-exec shape. Confirmed pre-existing by stashing these changes and re-running.