### PR TITLE
feat(create-app): modernise what the templates scaffold

### DIFF
--- a/packages/gjs/runtime/package.json
+++ b/packages/gjs/runtime/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@gjsify/runtime",
     "version": "0.30.0",
-    "description": "Platform-independent runtime detection for GJS and Node.js",
+    "description": "Platform-independent runtime detection for GJS, Node.js, Bun and Deno",
     "keywords": [
         "gjs",
         "node",
@@ -23,14 +23,24 @@
         }
     },
     "scripts": {
-        "clear": "gjsify clear lib tsconfig.tsbuildinfo",
+        "clear": "gjsify clear lib tsconfig.tsbuildinfo test.gjs.mjs test.node.mjs",
         "check": "gjsify tsc --noEmit",
         "build": "gjsify run build:gjsify && gjsify run build:types",
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
-        "build:types": "gjsify tsc"
+        "build:types": "gjsify tsc",
+        "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
+        "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:node && gjsify run test:gjs",
+        "test:gjs": "gjsify run test.gjs.mjs",
+        "test:node": "node test.node.mjs",
+        "test:bun": "bun test.node.mjs",
+        "test:deno": "deno run -A --no-lock --node-modules-dir=none test.node.mjs",
+        "test:cross-runtime": "gjsify run build:test:node && gjsify run test:node && gjsify run test:bun && gjsify run test:deno"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
     },

--- a/packages/gjs/runtime/src/index.spec.ts
+++ b/packages/gjs/runtime/src/index.spec.ts
@@ -1,0 +1,62 @@
+// Runtime detection must name the runtime it is ACTUALLY on.
+//
+// The bug this pins: `process.versions.node` is set on three of the four
+// runtimes (Bun and Deno fake it for npm compatibility, GJS's `@gjsify/process`
+// shim sets it), so a `versions.node` check that runs before the Bun/Deno
+// probes answers `'Node.js'` on Bun and on Deno. Silently wrong, never
+// `'Unknown'` — and surfaced straight to users, since the `cli`,
+// `web-server-hono` and `web-server-express` scaffolding templates all print
+// `runtimeName` as the answer to "which runtime is serving this?".
+//
+// A detector can only be checked against the host running it, so the coverage
+// that matters is running this file on all four: `test:node`, `test:gjs`,
+// `test:bun`, `test:deno` (`test:cross-runtime` chains the non-GJS three).
+// What each run asserts is INTERNAL CONSISTENCY plus the one cross-cutting
+// invariant — the flags are mutually exclusive — which is exactly the property
+// the old ordering violated.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { isBun, isDeno, isGJS, isNode, runtimeName, runtimeTarget, runtimeVersion } from './index.js';
+
+const NAME_FOR = { gjs: 'GJS', node: 'Node.js', bun: 'Bun', deno: 'Deno' } as const;
+
+export default async (): Promise<void> => {
+    await describe('@gjsify/runtime detection', async () => {
+        await it('identifies exactly one runtime', async () => {
+            // The whole defect in one assertion: on Bun the old implementation
+            // had BOTH isBun-equivalent truth and isNode true, and isNode won.
+            const flags = [isGJS, isNode, isBun, isDeno].filter(Boolean);
+            expect(flags.length).toBe(1);
+        });
+
+        await it('names a runtime, never "Unknown", on a supported host', async () => {
+            expect(['GJS', 'Node.js', 'Bun', 'Deno']).toContain(runtimeName);
+        });
+
+        await it('agrees with itself across name, target and flags', async () => {
+            expect(runtimeTarget).toBeDefined();
+            const target = runtimeTarget as keyof typeof NAME_FOR;
+            expect(runtimeName).toBe(NAME_FOR[target]);
+            expect({ gjs: isGJS, node: isNode, bun: isBun, deno: isDeno }[target]).toBe(true);
+        });
+
+        await it('emits a target the CLI vocabulary accepts', async () => {
+            // `runtimeTarget` is the value that may be handed back to
+            // `gjsify run --runtime`; `runtimeName` is prose and must not be.
+            expect(['gjs', 'node', 'bun', 'deno']).toContain(runtimeTarget);
+        });
+
+        await it('reports the version of THIS runtime', async () => {
+            expect(typeof runtimeVersion).toBe('string');
+            expect((runtimeVersion as string).length > 0).toBeTruthy();
+            // Bun and Deno report a real Node version through
+            // `process.versions.node`; reading it there would be a plausible
+            // number about a runtime we are not on.
+            if (isBun || isDeno) {
+                expect(runtimeVersion).not.toBe(
+                    (globalThis as { process?: { versions?: { node?: string } } }).process?.versions?.node,
+                );
+            }
+        });
+    });
+};

--- a/packages/gjs/runtime/src/index.ts
+++ b/packages/gjs/runtime/src/index.ts
@@ -1,29 +1,85 @@
-// Runtime detection for GJS and Node.js — original implementation
-// Works on both platforms without any @gjsify/* dependencies.
-// On GJS: relies on process.versions.gjs being set by @gjsify/process (via @gjsify/node-globals).
-// On Node.js: uses native process.versions.node.
+// Runtime detection for the four runtimes gjsify targets — original
+// implementation, no `@gjsify/*` dependencies, so it stays importable from
+// anywhere including a bare template.
+//
+// PROBE ORDER IS LOAD-BEARING: Bun and Deno both set `process.versions.node`
+// for npm compatibility, and GJS's `@gjsify/process` shim sets it too, so
+// reading `process.versions.node` FIRST is a false Node positive on three of
+// the four runtimes. Probe the distinguishing global (`Bun`, `Deno`) before
+// falling back to the version table — the same order, and for the same reason,
+// as `hostRuntime()` in `@gjsify/rolldown-plugin-gjsify/runtime`, which is the
+// single source of truth for host-derived build/launch defaults.
+//
+// Measured before this order existed: `runtimeName` returned `'Node.js'` under
+// both Bun and Deno, never `'Unknown'` — a silently wrong answer rather than an
+// absent one. The scaffolding templates that print it (`cli`,
+// `web-server-hono`, `web-server-express`) therefore told a Bun user they were
+// on Node.js, on the very screen whose job is to show which runtime is serving.
+
+const proc = typeof process !== 'undefined' ? process : undefined;
+
+/** `true` when running on Bun. */
+export const isBun: boolean = typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+
+/** `true` when running on Deno. */
+export const isDeno: boolean = typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined';
 
 /**
  * `true` when running on GJS (GNOME JavaScript).
+ *
+ * Checks the ambient GJS host (`imports.gi`) as well as `process.versions.gjs`:
+ * the latter is set by `@gjsify/process` via `@gjsify/node-globals`, so a bare
+ * GJS program that does not pull the Node globals in has no `process` at all
+ * and used to report `'Unknown'` about itself.
  */
-export const isGJS: boolean = typeof process !== 'undefined' && typeof process.versions?.gjs === 'string';
+export const isGJS: boolean =
+    typeof (globalThis as { imports?: { gi?: unknown } }).imports?.gi !== 'undefined' ||
+    (!isBun && !isDeno && typeof proc?.versions?.gjs === 'string');
+
+/** `true` when running on Node.js — and NOT on Bun, Deno or GJS. */
+export const isNode: boolean = !isBun && !isDeno && !isGJS && typeof proc?.versions?.node === 'string';
 
 /**
- * `true` when running on Node.js.
+ * Human-readable runtime name: `'GJS'`, `'Node.js'`, `'Bun'`, `'Deno'`, or
+ * `'Unknown'`.
+ *
+ * For the lowercase token `gjsify run --runtime` accepts, use
+ * {@link runtimeTarget}.
  */
-export const isNode: boolean = typeof process !== 'undefined' && typeof process.versions?.node === 'string';
+export const runtimeName: string = isBun ? 'Bun' : isDeno ? 'Deno' : isGJS ? 'GJS' : isNode ? 'Node.js' : 'Unknown';
 
 /**
- * Human-readable runtime name: `'GJS'`, `'Node.js'`, or `'Unknown'`.
+ * The runtime as the CLI spells it — `'gjs' | 'node' | 'bun' | 'deno'`, the
+ * vocabulary of `--runtime` and of `gjsify.example.runtimes`. `undefined` on an
+ * unrecognised host.
+ *
+ * Kept distinct from {@link runtimeName}, which is prose for a user interface:
+ * one of these two is safe to pass back to the tooling and the other is not.
  */
-export const runtimeName: string = isGJS ? 'GJS' : isNode ? 'Node.js' : 'Unknown';
+export const runtimeTarget: 'gjs' | 'node' | 'bun' | 'deno' | undefined = isBun
+    ? 'bun'
+    : isDeno
+      ? 'deno'
+      : isGJS
+        ? 'gjs'
+        : isNode
+          ? 'node'
+          : undefined;
 
 /**
- * Runtime version string, e.g. `'1.86.0'` (GJS) or `'24.1.0'` (Node.js).
- * `undefined` if the runtime cannot be detected.
+ * Runtime version string, e.g. `'1.86.0'` (GJS), `'24.1.0'` (Node.js),
+ * `'1.2.0'` (Bun), `'2.1.0'` (Deno). `undefined` if it cannot be determined.
+ *
+ * Bun and Deno are read from their own globals rather than
+ * `process.versions.node`, which on both reports the Node version they emulate
+ * — a real number, about a runtime you are not on.
  */
-export const runtimeVersion: string | undefined = isGJS
-    ? process.versions.gjs
-    : isNode
-      ? process.versions.node
-      : undefined;
+export const runtimeVersion: string | undefined = isBun
+    ? (globalThis as { Bun?: { version?: string } }).Bun?.version
+    : isDeno
+      ? (globalThis as { Deno?: { version?: { deno?: string } } }).Deno?.version?.deno
+      : isGJS
+        ? proc?.versions?.gjs
+        : isNode
+          ? proc?.versions?.node
+          : undefined;

--- a/packages/gjs/runtime/src/test.mts
+++ b/packages/gjs/runtime/src/test.mts
@@ -1,0 +1,4 @@
+import { run } from '@gjsify/unit';
+import indexTestSuite from './index.spec.js';
+
+run({ indexTestSuite });

--- a/packages/infra/create-gjsify/README.md
+++ b/packages/infra/create-gjsify/README.md
@@ -2,17 +2,55 @@
 
 Scaffolding tool for creating new Gjsify projects.
 
-Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js, Web and
+DOM APIs for GJS (GNOME JavaScript), plus Node.js, Bun and Deno.
 
 ## Usage
 
 ```bash
 gjsify create my-app
 
-# npm or yarn create also work:
+# npm, yarn and pnpm create also work:
 npm create @gjsify/app my-app
 yarn create @gjsify/app my-app
+pnpm create @gjsify/app my-app
 ```
+
+### Options
+
+| | |
+|---|---|
+| `-t, --template <name>` | Template to scaffold from. Required when stdin is not a TTY; otherwise prompted for. |
+| `-f, --force` | Scaffold into a non-empty directory. |
+| `--install` | Install dependencies after scaffolding. |
+| `-p, --package-manager <pm>` | `npm` (default), `yarn`, `pnpm` or `gjsify`. Used for `--install` and for the commands printed in the next steps. |
+
+`gjsify` is gjsify's own installer and the only one of the four that works on a
+host with no Node.js at all.
+
+## Templates
+
+| Template | Runtimes | |
+|---|---|---|
+| `gtk-minimal` | GJS | `Gtk.Window` + `Gtk.Label`; no Adwaita, no Blueprint. |
+| `adw-canvas2d` | GJS | Adwaita app rendering through the HTML Canvas 2D API (Blueprint UI). |
+| `adw-webgl` | GJS | Adwaita app rendering through WebGL + three.js (Blueprint UI). |
+| `adw-game` | GJS | Adwaita game shell on Excalibur.js; WebGL with a Canvas 2D fallback. |
+| `cli` | GJS · Node · Bun · Deno | Command-line tool using yargs. |
+| `web-server-hono` | GJS · Node · Bun · Deno | HTTP server using Hono (Web-standard fetch-style API). |
+| `web-server-express` | GJS · Node · Bun · Deno | HTTP server using Express. |
+
+The GTK/Adwaita templates drive libadwaita through `gi://`, so GJS is where they
+belong. The other three ship two bundles — `--app gjs` and `--app node`, the
+latter shared by Node, Bun and Deno, whose common ABI is Node-API. Each template
+declares its own reach in `package.json` as `gjsify.example.runtimes`, and every
+build names its `--app` target explicitly rather than inheriting whichever
+runtime happens to invoke it.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows (ADR 0018). What a scaffolded project
+can do on each depends on the GNOME libraries installed there, not on gjsify.
 
 ## License
 

--- a/packages/infra/create-gjsify/scripts/process-template.mjs
+++ b/packages/infra/create-gjsify/scripts/process-template.mjs
@@ -121,6 +121,14 @@ function processTemplate(name, versionMap) {
     const templatePkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
     // Overwrite the workspace name with the sentinel; createProject() replaces it with the user's project name.
     templatePkg.name = 'new-gjsify-app';
+    // …and the version, for the same reason the name is overwritten: the
+    // template's own field belongs to the template, not to the project
+    // scaffolded from it. It is a private workspace member whose version nobody
+    // publishes and nobody bumps deliberately, so whatever it happens to say
+    // became the starting version of every new user project — measured at
+    // `0.1.10`, a number with no meaning to the person who just ran
+    // `npm create @gjsify/app`.
+    templatePkg.version = '0.1.0';
     for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
         templatePkg[field] = resolveWorkspaceDeps(templatePkg[field], versionMap, name);
     }

--- a/packages/infra/create-gjsify/src/create.ts
+++ b/packages/infra/create-gjsify/src/create.ts
@@ -6,14 +6,36 @@ import { discoverTemplates, findTemplate, type TemplateInfo } from './discover-t
 export { discoverTemplates, findTemplate } from './discover-templates.js';
 export type { TemplateInfo } from './discover-templates.js';
 
+/**
+ * Package managers a scaffolded project can be installed with. All four work:
+ * the templates declare every dependency they need explicitly — including
+ * `@gjsify/rolldown-native`, which npm/yarn/pnpm would otherwise skip as an
+ * optional peer of `@gjsify/cli`.
+ *
+ * `gjsify` is gjsify's own installer and the only one of the four that works on
+ * a host with no Node.js at all.
+ */
+export const PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm', 'gjsify'] as const;
+export type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+
+/** The `install` argv for each package manager. */
+const INSTALL_ARGV: Record<PackageManager, string[]> = {
+    npm: ['install', '--no-audit', '--no-fund'],
+    yarn: ['install'],
+    pnpm: ['install'],
+    gjsify: ['install'],
+};
+
 export interface CreateProjectOptions {
     projectName: string;
     /** Template short name, e.g. "gtk-minimal". If omitted, the caller is responsible for providing one via prompt. */
     template: string;
     /** Allow scaffolding into an existing non-empty directory. */
     force?: boolean;
-    /** Run `npm install` in the scaffolded directory after writing files. */
+    /** Install dependencies in the scaffolded directory after writing files. */
     install?: boolean;
+    /** Which package manager to install with, and to name in the printed next steps. */
+    packageManager?: PackageManager;
 }
 
 /** Sentinel replaced by the user's project name in every text file under the template. */
@@ -57,7 +79,7 @@ function isDirEmpty(path: string): boolean {
 
 export async function createProject(options: CreateProjectOptions): Promise<void> {
     const projectName = sanitizeProjectName(options.projectName);
-    const { template, force = false, install = false } = options;
+    const { template, force = false, install = false, packageManager = 'npm' } = options;
 
     const info = findTemplate(template);
     if (!info) {
@@ -87,7 +109,8 @@ export async function createProject(options: CreateProjectOptions): Promise<void
     substituteProjectName(targetDir, projectName);
 
     if (install) {
-        console.log('Running npm install...');
+        const argv = INSTALL_ARGV[packageManager];
+        console.log(`Running ${packageManager} ${argv[0]}...`);
         // `shell: true` is what makes this work on Windows, where `npm` is
         // `npm.cmd`: `CreateProcess` appends only `.exe` when it searches PATH
         // for a bare name, so `spawnSync('npm', …)` is ENOENT there — and
@@ -95,23 +118,24 @@ export async function createProject(options: CreateProjectOptions): Promise<void
         // below fired and told the user npm had failed. `npm create gjsify
         // my-app` therefore scaffolded a project, never installed anything, and
         // blamed npm for it. `shell: true` is the exemption the invariant in
-        // `@gjsify/cli`'s `utils/spawn.ts` sanctions for exactly this case.
-        const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
+        // `@gjsify/cli`'s `utils/spawn.ts` sanctions for exactly this case. It
+        // applies to all four managers, which all ship as `.cmd` shims there.
+        const result = spawnSync(packageManager, argv, {
             cwd: targetDir,
             stdio: 'inherit',
             shell: true,
         });
         // Report the spawn error itself when there is one. Without it a failure
-        // to START npm and a failure OF npm read identically, which is how the
-        // Windows case stayed invisible.
+        // to START the package manager and a failure OF it read identically,
+        // which is how the Windows case stayed invisible.
         if (result.error) {
-            console.warn(`npm install could not start (${result.error.message}); re-run it manually.`);
+            console.warn(`${packageManager} install could not start (${result.error.message}); re-run it manually.`);
         } else if (result.status !== 0) {
-            console.warn('npm install failed; re-run it manually in the project directory.');
+            console.warn(`${packageManager} install failed; re-run it manually in the project directory.`);
         }
     }
 
-    printNextSteps(projectName, info, install);
+    printNextSteps(projectName, info, install, packageManager);
 }
 
 /**
@@ -140,13 +164,50 @@ function substituteProjectName(rootDir: string, projectName: string): void {
     }
 }
 
-function printNextSteps(projectName: string, template: TemplateInfo, installed: boolean): void {
+function printNextSteps(
+    projectName: string,
+    template: TemplateInfo,
+    installed: boolean,
+    packageManager: PackageManager,
+): void {
+    // `npm run <script>` / `yarn <script>` / `pnpm <script>` / `gjsify run
+    // <script>` — the same script, four spellings. Printing the one that
+    // matches the manager the user actually chose is the whole point of
+    // threading it this far.
+    const run = packageManager === 'npm' ? 'npm run' : packageManager === 'gjsify' ? 'gjsify run' : packageManager;
+
     console.log('');
     console.log(`Project created from template "${template.name}".`);
     console.log('');
     console.log('Next steps:');
     console.log(`  cd ${projectName}`);
-    if (!installed) console.log('  npm install');
-    console.log('  npm run dev');
+    if (!installed) console.log(`  ${packageManager} install`);
+    console.log(`  ${run} dev`);
     console.log('');
+    // The runtimes the template DECLARES, not a fixed list: a GJS-only template
+    // must not advertise `start:node`, and a portable one must not hide it.
+    const runtimes = declaredRuntimes(template);
+    if (runtimes.length > 1) {
+        console.log(`Runs on ${runtimes.join(', ')}:`);
+        console.log(`  ${run} build`);
+        for (const runtime of runtimes) {
+            console.log(`  ${run} ${runtime === 'gjs' ? 'start' : `start:${runtime}`}`);
+        }
+        console.log('');
+    }
+}
+
+/** `gjsify.example.runtimes` from the template's manifest; `[]` when unstated. */
+function declaredRuntimes(template: TemplateInfo): string[] {
+    try {
+        const pkg = JSON.parse(readFileSync(join(template.path, 'package.json'), 'utf-8')) as {
+            gjsify?: { example?: { runtimes?: unknown } };
+        };
+        const runtimes = pkg.gjsify?.example?.runtimes;
+        return Array.isArray(runtimes) ? runtimes.filter((r): r is string => typeof r === 'string') : [];
+    } catch {
+        // A template with no readable manifest cannot be scaffolded at all —
+        // `createProject` already failed by here. Nothing to advertise.
+        return [];
+    }
 }

--- a/packages/infra/create-gjsify/src/index.ts
+++ b/packages/infra/create-gjsify/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import { createProject } from './create.js';
+import { createProject, PACKAGE_MANAGERS, type PackageManager } from './create.js';
 import { discoverTemplates } from './discover-templates.js';
 import { promptTemplate } from './prompt-template.js';
 
@@ -33,9 +33,17 @@ void yargs(hideBin(process.argv))
                     default: false,
                 })
                 .option('install', {
-                    describe: 'Run npm install after scaffolding',
+                    describe: 'Install dependencies after scaffolding',
                     type: 'boolean',
                     default: false,
+                })
+                .option('package-manager', {
+                    alias: 'p',
+                    describe:
+                        'Package manager to install with, and to name in the printed next steps. `gjsify` is the only one that works on a host with no Node.js.',
+                    type: 'string',
+                    choices: PACKAGE_MANAGERS,
+                    default: 'npm' as PackageManager,
                 });
         },
         async (argv) => {
@@ -61,10 +69,17 @@ void yargs(hideBin(process.argv))
                 template,
                 force: argv['force'] as boolean,
                 install: argv['install'] as boolean,
+                packageManager: argv['package-manager'] as PackageManager,
             });
         },
     )
     .help().argv;
 
-export { createProject, sanitizeProjectName, type CreateProjectOptions } from './create.js';
+export {
+    createProject,
+    sanitizeProjectName,
+    PACKAGE_MANAGERS,
+    type CreateProjectOptions,
+    type PackageManager,
+} from './create.js';
 export { discoverTemplates, findTemplate, type TemplateInfo } from './discover-templates.js';

--- a/templates/adw-canvas2d/README.md
+++ b/templates/adw-canvas2d/README.md
@@ -1,25 +1,57 @@
 # new-gjsify-app
 
-An Adwaita app with HTML Canvas 2D rendering (Blueprint UI), scaffolded from the gjsify `adw-canvas2d` template.
+An Adwaita app rendering with the HTML Canvas 2D API (Blueprint UI), scaffolded from the gjsify `adw-canvas2d` template.
+
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
 
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
 npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
+npm run build     # bundle for GJS  → dist/index.gjs.js
+npm start         # run the built bundle on GJS
 npm run check     # type-check
+npm run clear     # remove build output
 ```
+
+## Runtimes
+
+This template targets **GJS**. It drives GTK/libadwaita through `gi://`, so GJS
+is where it belongs — `package.json` declares that as
+`gjsify.example.runtimes: ["gjs"]`, and the build passes `--app gjs` explicitly
+so the target does not silently follow whichever runtime happens to invoke it.
+
+gjsify itself also targets Node.js, Bun and Deno; the `cli`, `web-server-hono`
+and `web-server-express` templates are the ones that ship bundles for all four.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/adw-canvas2d/package.json
+++ b/templates/adw-canvas2d/package.json
@@ -5,10 +5,11 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js --globals auto,dom",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js --globals auto,dom && gjsify run dist/index.js"
+        "build": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js --globals auto,dom",
+        "start": "gjsify run dist/index.gjs.js",
+        "dev": "gjsify run build && gjsify run start"
     },
     "devDependencies": {
         "@girs/adw-1": "^4.1.0",
@@ -17,11 +18,20 @@
         "@girs/gobject-2.0": "^4.1.0",
         "@girs/gtk-4.0": "^4.1.0",
         "@gjsify/cli": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/vite-plugin-blueprint": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
     },
     "dependencies": {
         "@gjsify/canvas2d": "workspace:^"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs"
+            ]
+        }
     }
 }

--- a/templates/adw-game/README.md
+++ b/templates/adw-game/README.md
@@ -1,25 +1,57 @@
 # new-gjsify-app
 
-An Adwaita game shell using Excalibur.js with WebGL → Canvas2D fallback, scaffolded from the gjsify `adw-game` template.
+An Adwaita game shell built on Excalibur.js, WebGL with a Canvas 2D fallback, scaffolded from the gjsify `adw-game` template.
+
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
 
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
 npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
+npm run build     # bundle for GJS  → dist/index.gjs.js
+npm start         # run the built bundle on GJS
 npm run check     # type-check
+npm run clear     # remove build output
 ```
+
+## Runtimes
+
+This template targets **GJS**. It drives GTK/libadwaita through `gi://`, so GJS
+is where it belongs — `package.json` declares that as
+`gjsify.example.runtimes: ["gjs"]`, and the build passes `--app gjs` explicitly
+so the target does not silently follow whichever runtime happens to invoke it.
+
+gjsify itself also targets Node.js, Bun and Deno; the `cli`, `web-server-hono`
+and `web-server-express` templates are the ones that ship bundles for all four.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/adw-game/package.json
+++ b/templates/adw-game/package.json
@@ -1,14 +1,15 @@
 {
     "name": "@gjsify/template-adw-game",
-    "description": "Adwaita game shell using Excalibur.js, WebGL → Canvas2D fallback.",
+    "description": "Adwaita game shell using Excalibur.js, WebGL \u2192 Canvas2D fallback.",
     "version": "0.1.10",
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js --globals auto,dom",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js --globals auto,dom && gjsify run dist/index.js"
+        "build": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js --globals auto,dom",
+        "start": "gjsify run dist/index.gjs.js",
+        "dev": "gjsify run build && gjsify run start"
     },
     "devDependencies": {
         "@girs/adw-1": "^4.1.0",
@@ -18,6 +19,7 @@
         "@girs/gtk-4.0": "^4.1.0",
         "@gjsify/canvas2d": "workspace:^",
         "@gjsify/cli": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/vite-plugin-blueprint": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
@@ -25,5 +27,13 @@
     "dependencies": {
         "@gjsify/webgl": "workspace:^",
         "excalibur": "0.32.0"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs"
+            ]
+        }
     }
 }

--- a/templates/adw-webgl/README.md
+++ b/templates/adw-webgl/README.md
@@ -1,25 +1,57 @@
 # new-gjsify-app
 
-An Adwaita app with WebGL + three.js (Blueprint UI), scaffolded from the gjsify `adw-webgl` template.
+An Adwaita app rendering with WebGL and three.js (Blueprint UI), scaffolded from the gjsify `adw-webgl` template.
+
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
 
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
 npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
+npm run build     # bundle for GJS  → dist/index.gjs.js
+npm start         # run the built bundle on GJS
 npm run check     # type-check
+npm run clear     # remove build output
 ```
+
+## Runtimes
+
+This template targets **GJS**. It drives GTK/libadwaita through `gi://`, so GJS
+is where it belongs — `package.json` declares that as
+`gjsify.example.runtimes: ["gjs"]`, and the build passes `--app gjs` explicitly
+so the target does not silently follow whichever runtime happens to invoke it.
+
+gjsify itself also targets Node.js, Bun and Deno; the `cli`, `web-server-hono`
+and `web-server-express` templates are the ones that ship bundles for all four.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/adw-webgl/package.json
+++ b/templates/adw-webgl/package.json
@@ -5,10 +5,11 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+        "build": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
+        "start": "gjsify run dist/index.gjs.js",
+        "dev": "gjsify run build && gjsify run start"
     },
     "devDependencies": {
         "@girs/adw-1": "^4.1.0",
@@ -17,6 +18,7 @@
         "@girs/gobject-2.0": "^4.1.0",
         "@girs/gtk-4.0": "^4.1.0",
         "@gjsify/cli": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/vite-plugin-blueprint": "workspace:^",
         "@types/node": "^25.9.2",
         "@types/three": "^0.185.0",
@@ -25,5 +27,13 @@
     "dependencies": {
         "@gjsify/webgl": "workspace:^",
         "three": "0.185.1"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs"
+            ]
+        }
     }
 }

--- a/templates/cli/README.md
+++ b/templates/cli/README.md
@@ -1,25 +1,61 @@
 # new-gjsify-app
 
-A command-line tool using yargs, runnable on GJS, scaffolded from the gjsify `cli` template.
+A command-line tool using yargs, scaffolded from the gjsify `cli` template.
+
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
 
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
-npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
-npm run check     # type-check
+npm run dev            # build for GJS + run
+npm run build          # bundle for every runtime (dist/index.gjs.js + dist/index.node.mjs)
+npm start              # run on GJS
+npm run start:node     # run on Node.js
+npm run start:bun      # run on Bun
+npm run start:deno     # run on Deno
+npm run check          # type-check
+npm run clear          # remove build output
 ```
+
+## Runtimes
+
+This template runs on **GJS, Node.js, Bun and Deno**, declared in `package.json`
+as `gjsify.example.runtimes`. Two bundles cover all four: `--app gjs` produces
+`dist/index.gjs.js`, and `--app node` produces `dist/index.node.mjs`, which
+Node, Bun and Deno all consume (Node-API is their common ABI).
+
+The build names its target explicitly. Without `--app`, `gjsify build` follows
+the runtime that happens to be invoking it, so the same `npm run build` would
+produce a different artifact on a contributor's machine than in CI.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/cli/package.json
+++ b/templates/cli/package.json
@@ -5,14 +5,21 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+        "build": "gjsify run build:gjs && gjsify run build:node",
+        "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
+        "build:node": "gjsify build src/index.ts --app node --outfile dist/index.node.mjs",
+        "start": "gjsify run dist/index.gjs.js",
+        "start:node": "gjsify run dist/index.node.mjs --runtime node",
+        "start:bun": "gjsify run dist/index.node.mjs --runtime bun",
+        "start:deno": "gjsify run dist/index.node.mjs --runtime deno",
+        "dev": "gjsify run build:gjs && gjsify run start"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
         "@gjsify/node-globals": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/runtime": "workspace:^",
         "@types/node": "^25.9.2",
         "@types/yargs": "^17.0.35",
@@ -20,5 +27,17 @@
     },
     "dependencies": {
         "yargs": "^18.0.0"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs",
+                "node",
+                "bun",
+                "deno"
+            ],
+            "node": "dist/index.node.mjs"
+        }
     }
 }

--- a/templates/gtk-minimal/README.md
+++ b/templates/gtk-minimal/README.md
@@ -2,24 +2,56 @@
 
 A minimal GTK 4 app — `Gtk.Window` + `Gtk.Label`, no Adwaita, no Blueprint — scaffolded from the gjsify `gtk-minimal` template.
 
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
+
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
 npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
+npm run build     # bundle for GJS  → dist/index.gjs.js
+npm start         # run the built bundle on GJS
 npm run check     # type-check
+npm run clear     # remove build output
 ```
+
+## Runtimes
+
+This template targets **GJS**. It drives GTK/libadwaita through `gi://`, so GJS
+is where it belongs — `package.json` declares that as
+`gjsify.example.runtimes: ["gjs"]`, and the build passes `--app gjs` explicitly
+so the target does not silently follow whichever runtime happens to invoke it.
+
+gjsify itself also targets Node.js, Bun and Deno; the `cli`, `web-server-hono`
+and `web-server-express` templates are the ones that ship bundles for all four.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/gtk-minimal/package.json
+++ b/templates/gtk-minimal/package.json
@@ -1,17 +1,19 @@
 {
     "name": "@gjsify/template-gtk-minimal",
-    "description": "Minimal GTK4 app — Gtk.Window + Gtk.Label (no Adwaita, no Blueprint).",
+    "description": "Minimal GTK4 app \u2014 Gtk.Window + Gtk.Label (no Adwaita, no Blueprint).",
     "version": "0.1.10",
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+        "build": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
+        "start": "gjsify run dist/index.gjs.js",
+        "dev": "gjsify run build && gjsify run start"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
     },
@@ -19,5 +21,13 @@
         "@girs/gio-2.0": "^4.1.0",
         "@girs/glib-2.0": "^4.1.0",
         "@girs/gtk-4.0": "^4.1.0"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs"
+            ]
+        }
     }
 }

--- a/templates/web-server-express/README.md
+++ b/templates/web-server-express/README.md
@@ -1,25 +1,61 @@
 # new-gjsify-app
 
-An HTTP server using Express (familiar Node.js stack), scaffolded from the gjsify `web-server-express` template.
+An HTTP server using Express (the familiar Node.js stack), scaffolded from the gjsify `web-server-express` template.
+
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
 
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
-npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
-npm run check     # type-check
+npm run dev            # build for GJS + run
+npm run build          # bundle for every runtime (dist/index.gjs.js + dist/index.node.mjs)
+npm start              # run on GJS
+npm run start:node     # run on Node.js
+npm run start:bun      # run on Bun
+npm run start:deno     # run on Deno
+npm run check          # type-check
+npm run clear          # remove build output
 ```
+
+## Runtimes
+
+This template runs on **GJS, Node.js, Bun and Deno**, declared in `package.json`
+as `gjsify.example.runtimes`. Two bundles cover all four: `--app gjs` produces
+`dist/index.gjs.js`, and `--app node` produces `dist/index.node.mjs`, which
+Node, Bun and Deno all consume (Node-API is their common ABI).
+
+The build names its target explicitly. Without `--app`, `gjsify build` follows
+the runtime that happens to be invoking it, so the same `npm run build` would
+produce a different artifact on a contributor's machine than in CI.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/web-server-express/package.json
+++ b/templates/web-server-express/package.json
@@ -5,14 +5,21 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+        "build": "gjsify run build:gjs && gjsify run build:node",
+        "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
+        "build:node": "gjsify build src/index.ts --app node --outfile dist/index.node.mjs",
+        "start": "gjsify run dist/index.gjs.js",
+        "start:node": "gjsify run dist/index.node.mjs --runtime node",
+        "start:bun": "gjsify run dist/index.node.mjs --runtime bun",
+        "start:deno": "gjsify run dist/index.node.mjs --runtime deno",
+        "dev": "gjsify run build:gjs && gjsify run start"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
         "@gjsify/node-globals": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/runtime": "workspace:^",
         "@types/express": "^5.0.6",
         "@types/node": "^25.9.2",
@@ -20,5 +27,17 @@
     },
     "dependencies": {
         "express": "^5.2.1"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs",
+                "node",
+                "bun",
+                "deno"
+            ],
+            "node": "dist/index.node.mjs"
+        }
     }
 }

--- a/templates/web-server-hono/README.md
+++ b/templates/web-server-hono/README.md
@@ -2,24 +2,60 @@
 
 An HTTP server using Hono (Web-standard fetch-style API), scaffolded from the gjsify `web-server-hono` template.
 
+## Install
+
+```bash
+npm install          # or: yarn / pnpm install, or `gjsify install`
+```
+
+Any of the four works. `gjsify install` is gjsify's own installer and the only
+one that works on a host with no Node.js at all; npm, yarn and pnpm are fine
+everywhere else. Whichever you use, `@gjsify/rolldown-native` — the bundler
+engine the build needs when it runs under GJS — is listed explicitly in
+`devDependencies` so it is installed either way.
+
 ## Commands
 
 ```bash
-npm install       # or: gjsify install
-npm run dev       # build + run
-npm run build     # bundle for GJS
-npm start         # run the built bundle
-npm run check     # type-check
+npm run dev            # build for GJS + run
+npm run build          # bundle for every runtime (dist/index.gjs.js + dist/index.node.mjs)
+npm start              # run on GJS
+npm run start:node     # run on Node.js
+npm run start:bun      # run on Bun
+npm run start:deno     # run on Deno
+npm run check          # type-check
+npm run clear          # remove build output
 ```
+
+## Runtimes
+
+This template runs on **GJS, Node.js, Bun and Deno**, declared in `package.json`
+as `gjsify.example.runtimes`. Two bundles cover all four: `--app gjs` produces
+`dist/index.gjs.js`, and `--app node` produces `dist/index.node.mjs`, which
+Node, Bun and Deno all consume (Node-API is their common ABI).
+
+The build names its target explicitly. Without `--app`, `gjsify build` follows
+the runtime that happens to be invoking it, so the same `npm run build` would
+produce a different artifact on a contributor's machine than in CI.
+
+## Operating systems
+
+gjsify targets Linux, macOS and Windows. What this project can actually do on
+each depends on the GNOME libraries you have installed, not on gjsify — GTK and
+libadwaita are packaged for all three, but Linux is where they are best
+supported and best tested. See
+[Platform support](https://gjsify.github.io/gjsify/platform-support/).
 
 ## Versioning & compatibility
 
 All `@gjsify/*` packages ship as one release train — compatibility between them
-is guaranteed only within the same release version. Upgrade them together
-instead of bumping individual packages:
+is guaranteed only within the same release version, so upgrade them together
+rather than bumping individual packages:
 
 ```bash
-gjsify upgrade --latest --filter @gjsify   # bump all @gjsify/* deps to the same train
+gjsify upgrade --latest --filter @gjsify   # bump every @gjsify/* dep to the newest train
+gjsify upgrade --align                     # repair drift back onto one train
+gjsify upgrade --check                     # fail if the deps straddle two trains
 ```
 
 See [Versioning & Compatibility](https://gjsify.github.io/gjsify/versioning/)

--- a/templates/web-server-hono/package.json
+++ b/templates/web-server-hono/package.json
@@ -5,14 +5,21 @@
     "type": "module",
     "private": true,
     "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify build src/index.ts --outfile dist/index.js",
-        "start": "gjsify run dist/index.js",
-        "dev": "gjsify build src/index.ts --outfile dist/index.js && gjsify run dist/index.js"
+        "build": "gjsify run build:gjs && gjsify run build:node",
+        "build:gjs": "gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js",
+        "build:node": "gjsify build src/index.ts --app node --outfile dist/index.node.mjs",
+        "start": "gjsify run dist/index.gjs.js",
+        "start:node": "gjsify run dist/index.node.mjs --runtime node",
+        "start:bun": "gjsify run dist/index.node.mjs --runtime bun",
+        "start:deno": "gjsify run dist/index.node.mjs --runtime deno",
+        "dev": "gjsify run build:gjs && gjsify run start"
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
         "@gjsify/node-globals": "workspace:^",
+        "@gjsify/rolldown-native": "workspace:^",
         "@gjsify/runtime": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3"
@@ -20,5 +27,17 @@
     "dependencies": {
         "@hono/node-server": "^2.0.8",
         "hono": "^4.12.27"
+    },
+    "gjsify": {
+        "main": "dist/index.gjs.js",
+        "example": {
+            "runtimes": [
+                "gjs",
+                "node",
+                "bun",
+                "deno"
+            ],
+            "node": "dist/index.node.mjs"
+        }
     }
 }

--- a/tests/e2e/create-app/run.mjs
+++ b/tests/e2e/create-app/run.mjs
@@ -57,6 +57,22 @@ function scaffold(cwd, projectName, template) {
 }
 
 /**
+ * The build artifacts a scaffolded project DECLARES: `gjsify.main` (the
+ * `--app gjs` bundle) plus `gjsify.example.node` (the `--app node` one, shared
+ * by node/bun/deno).
+ *
+ * Asserting against the manifest instead of a hardcoded `dist/index.js` is what
+ * makes this suite track the template rather than one historical filename: a
+ * template that claims a runtime and emits no bundle for it now fails here,
+ * and a rename of the output cannot quietly turn the assertion into a tautology
+ * against a file nothing produces any more.
+ */
+function declaredArtifacts(projectDir) {
+    const pkg = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8'));
+    return [pkg.gjsify?.main, pkg.gjsify?.example?.node].filter((p) => typeof p === 'string' && p.length > 0);
+}
+
+/**
  * Patch the scaffolded package.json:
  * - Drop @girs/* (types-only; gi:// imports are externalized by esbuild).
  * - Remap @gjsify/* deps/devDeps to local tarballs.
@@ -145,7 +161,7 @@ describe('create-app E2E', { timeout: 60 * 60 * 1000 }, () => {
                 assert.ok(existsSync(join(projectDir, 'node_modules', '.package-lock.json')), 'lockfile missing');
             });
 
-            it('npm run build produces dist/index.js', (t) => {
+            it('npm run build produces every declared artifact', (t) => {
                 if (skipReason) return t.skip(skipReason);
                 console.log(`  [${template}] npm run build…`);
                 execSync('npm run build', {
@@ -153,14 +169,41 @@ describe('create-app E2E', { timeout: 60 * 60 * 1000 }, () => {
                     stdio: 'pipe',
                     timeout: 5 * 60 * 1000,
                 });
-                assert.ok(existsSync(join(projectDir, 'dist', 'index.js')), 'dist/index.js missing after build');
+                const artifacts = declaredArtifacts(projectDir);
+                assert.ok(artifacts.length > 0, 'template declares no build artifact');
+                for (const rel of artifacts) {
+                    assert.ok(existsSync(join(projectDir, rel)), `${rel} missing after build`);
+                }
+            });
+
+            it('every declared runtime has a bundle behind it', (t) => {
+                if (skipReason) return t.skip(skipReason);
+                const pkg = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf8'));
+                const runtimes = pkg.gjsify?.example?.runtimes;
+                assert.ok(Array.isArray(runtimes) && runtimes.length > 0, 'gjsify.example.runtimes not declared');
+                // node/bun/deno all consume the one `--app node` bundle, so a
+                // template claiming any of them owes exactly one extra entry.
+                if (runtimes.some((r) => r !== 'gjs')) {
+                    assert.ok(
+                        pkg.gjsify?.example?.node,
+                        'claims a non-gjs runtime but declares no gjsify.example.node',
+                    );
+                }
+                if (runtimes.includes('gjs')) {
+                    assert.ok(pkg.gjsify?.main, 'claims gjs but declares no gjsify.main');
+                }
             });
 
             it('build output is valid JavaScript', (t) => {
                 if (skipReason) return t.skip(skipReason);
-                const outFile = join(projectDir, 'dist', 'index.js');
-                if (!existsSync(outFile)) return t.skip('build output missing');
-                execFileSync('node', ['--check', outFile], { stdio: 'pipe' });
+                let checked = 0;
+                for (const rel of declaredArtifacts(projectDir)) {
+                    const outFile = join(projectDir, rel);
+                    if (!existsSync(outFile)) continue;
+                    execFileSync('node', ['--check', outFile], { stdio: 'pipe' });
+                    checked++;
+                }
+                if (checked === 0) return t.skip('build output missing');
             });
         });
     }


### PR DESCRIPTION
## Status

Follow-up to #1027, which fixed the *build* of `@gjsify/create-app`. This one
fixes what it *scaffolds*. Everything below is measured on this tree.

## The scaffolded project did not work

Measured on a plain Linux box with node and gjs installed — the three commands
the template README itself prints:

```
$ npm create @gjsify/app my-app -- --template gtk-minimal
$ cd my-app && npm install && npm run build && npm start

Error: Cannot run this bundle on node: it uses gi:// via `@gjsify/node-gi`,
which is not installed.
```

Two independent defects, both of them things the templates did **not** say.

### 1. No `--app`, so the build target followed whoever ran it

`gjsify build` defaults to *the target of the host runtime* — documented in
`commands/build.ts`: *"Defaults to the target of the HOST runtime running the
CLI: gjs when run under gjs, node when run under node/bun/deno."* No template
passed `--app`. So `npm run build` under Node compiled a **GTK app for Node**,
which reaches GTK through `@gjsify/node-gi` — a package no template declares.
The same command on a gjs-hosted CLI produced a GJS bundle and worked. One
script, two artifacts, decided by the machine.

### 2. No bundler engine

`@gjsify/rolldown-native` is an **optional peer** of `@gjsify/cli`. npm, yarn and
pnpm all skip optional peers; `ensureProjectGjsEngine()` (#1005) tops it up only
from a release that carries it, and the published CLI a scaffold installs today
is 0.30.0, which predates it. Measured on a fresh scaffold after both
`npm install` *and* `gjsify install`:

```
$ ./node_modules/.bin/gjsify run build
gjsify build: no usable bundler engine under GJS — `@gjsify/rolldown-native`
is not loadable […]
`@gjsify/rolldown-native` is NOT INSTALLED
```

Declaring it explicitly is what both real standalone consumers already do
(`buchhaltung/app`, `bauplaner/cli`, each an exact pin in `devDependencies`), and
it is the only form that survives all four package managers regardless of which
CLI release the user has. ADR 0020 would retire the policy; until it lands, the
declaration is the durable answer.

## What changed

**Every template names its target and declares its reach**, following
`showcases/node/express-webserver` exactly rather than inventing a shape:

| Template | `gjsify.example.runtimes` | Bundles |
|---|---|---|
| `gtk-minimal`, `adw-canvas2d`, `adw-webgl`, `adw-game` | `["gjs"]` | `dist/index.gjs.js` |
| `cli`, `web-server-hono`, `web-server-express` | `["gjs","node","bun","deno"]` | `+ dist/index.node.mjs` |

The GTK/Adwaita four drive libadwaita through `gi://`, so GJS is where they
belong and `--app gjs` says so. The other three ship both bundles; one
`--app node` bundle serves Node, Bun and Deno, Node-API being their common ABI.
Output is named `.gjs.js` / `.node.mjs` so `isLikelyGjsBundle`'s fast path works.
Plus `@gjsify/rolldown-native`, and `clear`, which every showcase has and no
template had.

**The scaffolder is no longer npm-only.** New `-p, --package-manager
<npm|yarn|pnpm|gjsify>` selects both the install argv and the spelling of the
printed commands. `gjsify` is the only one of the four that works on a host with
no Node.js. Next steps are runtime-aware — read from the template's own
declaration, so a GJS-only template does not advertise `start:node`:

```
Next steps:
  cd app-web-server-hono
  npm install
  npm run dev

Runs on gjs, node, bun, deno:
  npm run build
  npm run start
  npm run start:node
  npm run start:bun
  npm run start:deno
```

**`version` no longer leaks.** `process-template.mjs` overwrote `name` but not
`version`, so the template's own field — a private workspace member nobody
publishes and nobody bumps deliberately — became the starting version of every
new user project. It read `0.1.10`. Now `0.1.0`.

**READMEs rewritten.** They said `npm run build # bundle for GJS` (false under
Node, per defect 1), offered `npm install # or: gjsify install` (misleading —
`gjsify` is not on PATH before the first install unless installed globally),
under-claimed the `cli` template as "runnable on GJS", and omitted `gjsify
upgrade --align` / `--check`, which ADR 0008 §3 names *this very file* as the
place to document. Each now states its runtimes and the OS position.

## A core bug the modernisation exposed

Three templates print `runtimeName` from `@gjsify/runtime` as the answer to
"which runtime is serving this?". That function read `process.versions.node`
first — and **three of the four runtimes set it** (Bun and Deno fake it for npm
compatibility; GJS's `@gjsify/process` shim sets it). So Bun and Deno both
reported `'Node.js'`: silently wrong, never `'Unknown'`.

Visible in the verification matrix below — the express rows on bun and deno say
`"runtime":"Node.js"`, because a scaffolded project installs the **published**
`@gjsify/runtime@0.30.0`. Declaring bun/deno support is what put that wrong
answer on the user's screen, so it is fixed at the core in this PR
(`fix(runtime): name Bun and Deno, not Node.js`) rather than worked around in a
template: probe the distinguishing global first, same order and same reason as
`hostRuntime()`. `runtimeVersion` now reports Bun's/Deno's own version instead of
the Node version they emulate, and a new `runtimeTarget` gives the lowercase
token the CLI vocabulary actually accepts (`runtimeName` is prose for a UI and
must not be fed back to the tooling). Those rows will read `Bun` / `Deno` from
0.31.0.

This is also the package's first test suite, run on all four runtimes.

## Verification

Every template scaffolded fresh, `npm install`, `npm run build`, then run on
**every runtime it claims**.

```
════ --install --package-manager gjsify, then the GJS-hosted project bin ════
Running gjsify install...
Detected 6 @gjsify/* package(s) with native prebuilds:
  • @gjsify/rolldown-native-linux-x64          ← was absent before; the defect-2 fix
$ ./node_modules/.bin/gjsify run build        → exit 0
  dist/index.gjs.js  362865   dist/index.node.mjs  41493

════ scaffold + npm install + npm run build ════
gtk-minimal          BUILD OK   dist/index.gjs.js    133349
adw-canvas2d         BUILD OK   dist/index.gjs.js    216327
adw-webgl            BUILD OK   dist/index.gjs.js    866852
adw-game             BUILD OK   dist/index.gjs.js    932192
cli                  BUILD OK   dist/index.gjs.js    394685  dist/index.node.mjs  125255
web-server-hono      BUILD OK   dist/index.gjs.js    362886  dist/index.node.mjs   41462
web-server-express   BUILD OK   dist/index.gjs.js   1017985  dist/index.node.mjs  599078

════ cli — every declared runtime ════
npm run start        → app-cli — a gjsify CLI starter  (gjs 1.88.1)
npm run start:node   → app-cli — a gjsify CLI starter  (node 24.15.0)
npm run start:bun    → app-cli — a gjsify CLI starter  (bun 1.3.14)
npm run start:deno   → app-cli — a gjsify CLI starter  (deno 2.9.4)

════ servers — every declared runtime, curl GET /api/ping ════
web-server-hono    / start       → OK  {"ok":true,"time":"2026-08-06T22:05:27.339Z"}
web-server-hono    / start:node  → OK  {"ok":true,"time":"2026-08-06T22:05:29.393Z"}
web-server-hono    / start:bun   → OK  {"ok":true,"time":"2026-08-06T22:05:31.454Z"}
web-server-hono    / start:deno  → OK  {"ok":true,"time":"2026-08-06T22:05:33.510Z"}
web-server-express / start       → OK  {"ok":true,"runtime":"GJS","time":"…"}
web-server-express / start:node  → OK  {"ok":true,"runtime":"Node.js","time":"…"}
web-server-express / start:bun   → OK  {"ok":true,"runtime":"Node.js","time":"…"}   ← the core bug, fixed here, ships in 0.31.0
web-server-express / start:deno  → OK  {"ok":true,"runtime":"Node.js","time":"…"}   ← ditto
```

| | |
|---|---|
| 7/7 templates scaffold + install + build | ✅ |
| 8/8 declared runtime × template combinations run | ✅ |
| `@gjsify/runtime` tests on gjs / node / bun / deno | ✅ all four |
| `node scripts/audit-runtimes.mjs --check --strict` | ✅ exit 0 |
| `node scripts/check-adr-index.mjs` | ✅ exit 0 |
| `gjsify lint` | ✅ exit 0 |
| `gjsify format --check` (changed areas) | ✅ clean |
| `gjsify workspace @gjsify/{create-app,runtime} check` | ✅ exit 0 |
| `tests/e2e/create-app` | ✅ 42/42 pass, exit 0 (with the stricter declaration-driven assertions) |
| `--package-manager` for all four spellings | ✅ correct install argv + printed commands |
| `--install --package-manager gjsify`, then a GJS-hosted build | ✅ engine installed, `dist/index.gjs.js` + `dist/index.node.mjs` produced |

**Not verified:** Linux/x64/glibc only. No macOS or Windows claim here is
measured — including the READMEs' OS section, which deliberately says what
gjsify *targets* and that the answer depends on the GNOME libraries installed,
rather than promising behaviour on hosts nobody ran.

## No ADR

The brief flagged "new template variants per runtime" as ADR-sized. That is not
what this is: no template was added or split. Three existing templates adopt the
declaration shape `showcases/node/express-webserver` already uses
(`gjsify.example.runtimes` + `gjsify.main` + `gjsify.example.node`), which
`readDeclaredRuntimes()` has consumed since it was written. Conforming to a
documented convention is not a new decision. `check-adr-index.mjs` passes; 0021
stays free.

Deliberately **not** declared: `gjsify.os`. ADR 0018 derives the candidate set
from OS-branching code and exempts private packages — *"a declaration is a
promise to a CONSUMER, and examples and templates have none"* — so authoring it
would restate a derivable fact the conformance rules forbid.

Deliberately **not** bumped: `typescript` (^6.0.3, upstream 7.0.2) and
`@types/node` (^25.9.2, upstream 26.1.2). Both match the workspace pin, and the
root AGENTS.md makes the TypeScript version a workspace-wide invariant — moving
it is one PR that touches every `package.json`, not a template edit.

## CI

Actions is not dispatching; `gh run list` for this branch returns `[]`. Local
verification is the standard per the repo owner. The table above is what was
actually run.


## A note on the `tests/e2e/create-app` result

It fails on a tree that has only had `build:infra` — the packed workspace
tarballs are then missing their `lib/`, and every template dies on
`UnresolvedWorkspaceImportError`. That is the prerequisite its own header states
(*"Requires: yarn build (monorepo must be built first)"*), and it is what was
seen while #1027 was in flight. After a full `gjsify run build` it is 42/42
green, which settles that reading.
