### PR TITLE
fix: close what the macOS leg found, and unbreak the leg

### DIFF
--- a/.github/workflows/macos-suites.yml
+++ b/.github/workflows/macos-suites.yml
@@ -179,11 +179,20 @@ jobs:
       # Cold tree: ADR 0002 untracked both bundles, so `node_modules/.bin/gjsify`
       # dispatches to build outputs that do not exist yet. The published CLI is
       # the only CLI this tree has — the same bootstrap a user performs.
-      - name: Bootstrap the toolchain from the published CLI
-        run: npx --yes @gjsify/cli@latest run build:infra
+      #
+      # INSTALL BEFORE BUILD, and that order is the whole point of these two
+      # steps being separate. `build:infra` compiles `@gjsify/vite-plugin-blueprint`
+      # first, whose `gjsify tsc` needs `@types/node` — a dependency, not a build
+      # output. Building first on a tree with no `node_modules` therefore dies
+      # with `TS2688: Cannot find type definition file for 'node'`, which is what
+      # this leg did on BOTH architectures on its first real run. It is also the
+      # order `.github/actions/gjsify-setup` has always used (`install --immutable`,
+      # then build) and the one ADR 0002 documents.
+      - name: Install the workspace with the published CLI
+        run: npx --yes @gjsify/cli@latest install --immutable
 
-      - name: Install the workspace
-        run: node packages/infra/cli/lib/index.js install --immutable
+      - name: Bootstrap this repo's own toolchain
+        run: npx --yes @gjsify/cli@latest run build:infra
 
       # `test:node` and `test:gjs` both only RUN a bundle; the bundle has to
       # exist first, and a package's own build needs its workspace dependencies

--- a/.github/workflows/windows-suites.yml
+++ b/.github/workflows/windows-suites.yml
@@ -122,22 +122,39 @@ jobs:
           "PATH=$($kept -join ';')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "dropped $((($env:PATH -split ';') | Where-Object { $_ -match '\\Git\\' }).Count) \Git\ entr(y|ies) from PATH"
 
+      # `where X && exit 1 || echo …` reads correctly and does not WORK: cmd's
+      # internal `echo` does not reliably clear the ERRORLEVEL that a failed
+      # `where` left behind, so the step exited 1 while printing "no sh on PATH
+      # - good" — semantically passing, mechanically red. Measured on main:
+      # both utilities were absent, COMSPEC printed, exit code 1. An explicit
+      # failure branch plus a terminal `exit /b 0` leaves nothing to infer.
       - name: Prove the POSIX utilities are gone
         run: |
-          where sh && exit 1 || echo "no sh on PATH - good"
-          where rm && exit 1 || echo "no rm on PATH - good"
+          where sh >nul 2>&1 && (echo ERROR: sh is still on PATH & exit /b 1)
+          where rm >nul 2>&1 && (echo ERROR: rm is still on PATH & exit /b 1)
+          echo no sh and no rm on PATH - good
           echo COMSPEC=%COMSPEC%
+          exit /b 0
 
       # Cold tree: `node_modules/.bin/gjsify` dispatches to build outputs that do
       # not exist yet (ADR 0002 untracked both bundles), and the Linux route
       # through `gjs -m dist/cli.gjs.mjs` is unavailable here by construction.
       # The published CLI is the only CLI this tree has, which is the same
       # bootstrap `cli-cross-platform.yml` exercises from a user's side.
-      - name: Bootstrap the toolchain from the published CLI
-        run: npx --yes @gjsify/cli@latest run build:infra
+      #
+      # INSTALL BEFORE BUILD. `build:infra` compiles
+      # `@gjsify/vite-plugin-blueprint` first, whose `gjsify tsc` needs
+      # `@types/node` — a dependency, not a build output — so building on a tree
+      # with no `node_modules` dies with `TS2688: Cannot find type definition
+      # file for 'node'`. `macos-suites.yml` inherited this order from here and
+      # went red on both architectures with exactly that error; this leg had not
+      # yet reached the step to show it. `.github/actions/gjsify-setup` has
+      # always installed first, and ADR 0002 documents that order.
+      - name: Install the workspace with the published CLI
+        run: npx --yes @gjsify/cli@latest install --immutable
 
-      - name: Install the workspace
-        run: node packages\infra\cli\lib\index.js install --immutable
+      - name: Bootstrap this repo's own toolchain
+        run: npx --yes @gjsify/cli@latest run build:infra
 
       # `test:node` is only `node test.node.mjs` — it BUILDS nothing. The
       # bundle has to exist first, and a package's own build needs its

--- a/packages/infra/cli/src/run-node-resolve.spec.ts
+++ b/packages/infra/cli/src/run-node-resolve.spec.ts
@@ -20,6 +20,7 @@ import { describe, expect, it } from '@gjsify/unit';
 import { resolveNodeGi, resolveNodeGiForBundle } from './utils/run-node.js';
 import { computeNativeEnvForBundle } from './utils/run-gjs.js';
 import { libraryPathVar } from './utils/detect-native-packages.js';
+import { systemGiLibraryDirs } from './utils/system-gi.js';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -108,10 +109,23 @@ export default async () => {
         // there and invisible on Linux.
         const libVar = libraryPathVar(process.platform).name;
 
-        await it('is EMPTY when no native package was detected', () => {
-            // Two directories with no node_modules at all: nothing to prepend,
-            // so `buildNativeEnv` hands the inherited values straight back and
-            // the CLI has changed nothing to report.
+        await it('reports NOTHING BUT what the CLI actually changed', () => {
+            // Two directories with no node_modules at all, so no prebuild dir
+            // is prepended to anything.
+            //
+            // "Nothing to prepend" is NOT the same as "nothing to report", and
+            // spelling it that way was a Linux answer wearing a universal
+            // one's clothes. `buildNativeEnv` also repairs the HOST's own GI
+            // libdirs on darwin — deliberately, and deliberately even when the
+            // package set is empty, because that gap is in dyld and not in a
+            // gjsify prebuild. So on a Mac with a system GTK the echo has one
+            // legitimate entry, and asserting an empty string there fails a
+            // launcher that is doing exactly what it documents.
+            //
+            // Keyed on the CAPABILITY, never on `process.platform`: a Mac with
+            // no GI stack installed produces an empty prefix and must still
+            // pass, and if `systemGiLibraryDirs()` ever answers on another OS
+            // this row follows without being edited.
             const a = mkdtempSync(join(tmpdir(), 'gjsify-env-echo-a-'));
             const b = mkdtempSync(join(tmpdir(), 'gjsify-env-echo-b-'));
             const bundle = makeBundle(a, 'dist');
@@ -121,7 +135,42 @@ export default async () => {
                 GI_TYPELIB_PATH: '/usr/lib/girepository-1.0',
             };
             const { envPrefix } = computeNativeEnvForBundle(bundle, b, inherited);
-            expect(envPrefix).toBe('');
+
+            const systemDirs = systemGiLibraryDirs({ env: inherited });
+            if (systemDirs.length === 0) {
+                expect(envPrefix).toBe('');
+                rmSync(a, { recursive: true, force: true });
+                rmSync(b, { recursive: true, force: true });
+                return;
+            }
+
+            // Asserted as PROPERTIES rather than as a literal, so this row
+            // states the contract instead of restating the implementation —
+            // a spec that recomputes `buildNativeEnv`'s join order passes for
+            // whatever that function does, including for a bug.
+            const assignments = envPrefix.trim().split(/\s+/).filter(Boolean);
+            expect(assignments.length).toBe(1);
+
+            const [name, value] = [
+                assignments[0].slice(0, assignments[0].indexOf('=')),
+                assignments[0].slice(assignments[0].indexOf('=') + 1),
+            ];
+            // The FALLBACK variable, never the override one: pointing the
+            // override at a whole system libdir replaces libraries the host
+            // already resolved correctly. `buildNativeEnv` documents why.
+            expect(name).toBe('DYLD_FALLBACK_LIBRARY_PATH');
+
+            const entries = value.split(':');
+            // Every probed libdir is there, `/usr/lib` still terminates the
+            // search (setting the variable REPLACES dyld's own default list),
+            // and nothing appears twice.
+            for (const dir of systemDirs) expect(entries.includes(dir)).toBe(true);
+            expect(entries.includes('/usr/lib')).toBe(true);
+            expect(entries.length).toBe(new Set(entries).size);
+            // The "and nothing else" half: the inherited loader variable must
+            // not come back, which is the win32 symptom the next row pins from
+            // the other side.
+            expect(envPrefix.includes('C:\\Windows')).toBe(false);
 
             rmSync(a, { recursive: true, force: true });
             rmSync(b, { recursive: true, force: true });

--- a/packages/infra/cli/src/utils/detect-native-packages.ts
+++ b/packages/infra/cli/src/utils/detect-native-packages.ts
@@ -762,7 +762,18 @@ export function buildNativeEnv(
     const systemDirs = (opts.systemGiDirs ?? systemGiLibraryDirs)({ platform, env });
     if (systemDirs.length > 0) {
         const inherited = splitSearchPath(env[DYLD_FALLBACK_VAR]);
-        out[DYLD_FALLBACK_VAR] = [...systemDirs, ...(inherited.length > 0 ? inherited : ['/usr/lib'])].join(':');
+        // Deduplicated, and not for tidiness: `systemGiLibraryDirs()` accepts a
+        // libdir stated outright through `GI_TYPELIB_PATH` on directory
+        // existence alone, so a host that names `/usr/lib/girepository-1.0`
+        // there puts `/usr/lib` in `systemDirs` — and the `/usr/lib` tail below
+        // then repeated it. A search path that lists the same directory twice
+        // asks the loader to stat it twice for every miss, and it makes the
+        // value the `$ …` echo prints read as though the CLI had composed
+        // something it did not. First occurrence wins in every loader, so
+        // dropping later repeats is behaviour-preserving.
+        out[DYLD_FALLBACK_VAR] = [
+            ...new Set([...systemDirs, ...(inherited.length > 0 ? inherited : ['/usr/lib'])]),
+        ].join(':');
     }
     return out;
 }

--- a/packages/node/dns/src/index.spec.ts
+++ b/packages/node/dns/src/index.spec.ts
@@ -32,6 +32,24 @@ import dns, {
     CANCELLED,
 } from 'node:dns';
 
+/**
+ * Is this a NATIVE Node older than the release that made `lookup('')` throw?
+ *
+ * Node validated an empty hostname with `ERR_INVALID_ARG_VALUE` only from v25;
+ * before that it warned `DEP0118` and called back with `err: null`. This
+ * package declares `runtimes.node: "none"`, so `test:node` runs against native
+ * Node — which means the two rows below assert the HOST's behaviour there, and
+ * on a Node 24 runner the host is right to disagree. Measured on
+ * darwin-x64 / Node 24.18.1: `dns.lookup('', cb)` → `DEP0118`, `err: null`.
+ *
+ * The gjs check comes first and is not redundant: `@gjsify/process` reports
+ * `versions.node = '20.0.0'` deliberately, for npm packages that gate on it, so
+ * a bare major comparison would classify GJS as an old Node and tolerate a
+ * failure there — where our own implementation DOES throw and must keep doing so.
+ */
+const isPreV25NativeNode =
+    typeof process.versions?.gjs !== 'string' && Number(process.versions.node.split('.')[0]) < 25;
+
 export default async () => {
     await describe('dns', async () => {
         // --- Constants ---
@@ -186,28 +204,38 @@ export default async () => {
                 });
             });
 
-            await it('should throw ERR_INVALID_ARG_VALUE for empty hostname', async () => {
-                // Node (>=25) and @gjsify/dns both reject an empty hostname
-                // synchronously with ERR_INVALID_ARG_VALUE — older Node called
-                // back with a null address; tightened under Node 26 (see #601).
-                let code: string | undefined;
-                try {
-                    lookup('', () => {});
-                } catch (e) {
-                    code = (e as any).code;
-                }
-                expect(code).toBe('ERR_INVALID_ARG_VALUE');
-            });
+            await it.failing(
+                'should throw ERR_INVALID_ARG_VALUE for empty hostname',
+                async () => {
+                    // Node (>=25) and @gjsify/dns both reject an empty hostname
+                    // synchronously with ERR_INVALID_ARG_VALUE — older Node called
+                    // back with a null address; tightened under Node 26 (see #601).
+                    let code: string | undefined;
+                    try {
+                        lookup('', () => {});
+                    } catch (e) {
+                        code = (e as any).code;
+                    }
+                    expect(code).toBe('ERR_INVALID_ARG_VALUE');
+                },
+                'Node rejected an empty hostname only from v25 — before that it warned DEP0118 and called back with err: null. `@gjsify/dns` declares runtimes.node: "none", so this leg runs NATIVE Node and the assertion is about the host, not about us; our own implementation throws and the gjs leg proves it. Retires itself when the runner Node reaches 25.',
+                { when: isPreV25NativeNode },
+            );
 
-            await it('should throw ERR_INVALID_ARG_VALUE for empty hostname with family 6', async () => {
-                let code: string | undefined;
-                try {
-                    lookup('', { family: 6 }, () => {});
-                } catch (e) {
-                    code = (e as any).code;
-                }
-                expect(code).toBe('ERR_INVALID_ARG_VALUE');
-            });
+            await it.failing(
+                'should throw ERR_INVALID_ARG_VALUE for empty hostname with family 6',
+                async () => {
+                    let code: string | undefined;
+                    try {
+                        lookup('', { family: 6 }, () => {});
+                    } catch (e) {
+                        code = (e as any).code;
+                    }
+                    expect(code).toBe('ERR_INVALID_ARG_VALUE');
+                },
+                'Node rejected an empty hostname only from v25 — before that it warned DEP0118 and called back with err: null. `@gjsify/dns` declares runtimes.node: "none", so this leg runs NATIVE Node and the assertion is about the host, not about us; our own implementation throws and the gjs leg proves it. Retires itself when the runner Node reaches 25.',
+                { when: isPreV25NativeNode },
+            );
 
             await it('should return all addresses with all: true', async () => {
                 await new Promise<void>((resolve) => {

--- a/packages/node/fs/src/extended.spec.ts
+++ b/packages/node/fs/src/extended.spec.ts
@@ -748,26 +748,28 @@ export default async () => {
     // ==================== symlink creation ====================
 
     await describe('fs.symlinkSync (creation)', async () => {
-        await it.failing('should create and read a symlink', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'sym-');
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'symlink.txt');
-            writeFileSync(target, 'symlink content');
+        await it.failing(
+            'should create and read a symlink',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'sym-');
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'symlink.txt');
+                writeFileSync(target, 'symlink content');
 
-            symlinkSync(target, link);
-            expect(existsSync(link)).toBeTruthy();
+                symlinkSync(target, link);
+                expect(existsSync(link)).toBeTruthy();
 
-            // lstatSync should show it as a symlink
-            const stats = lstatSync(link);
-            expect(stats.isSymbolicLink()).toBeTruthy();
+                // lstatSync should show it as a symlink
+                const stats = lstatSync(link);
+                expect(stats.isSymbolicLink()).toBeTruthy();
 
-            // Reading through the symlink should give original content
-            expect(readFileSync(link, 'utf8')).toBe('symlink content');
+                // Reading through the symlink should give original content
+                expect(readFileSync(link, 'utf8')).toBe('symlink content');
 
-            unlinkSync(link);
-            rmSync(target);
-            rmdirSync(dir);
-        },
+                unlinkSync(link);
+                rmSync(target);
+                rmdirSync(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
@@ -776,22 +778,24 @@ export default async () => {
     // ==================== promises.symlink ====================
 
     await describe('fs.promises.symlink', async () => {
-        await it.failing('should create a symlink', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'psym-');
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            writeFileSync(target, 'data');
+        await it.failing(
+            'should create a symlink',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-') + 'psym-');
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                writeFileSync(target, 'data');
 
-            await promises.symlink(target, link);
-            expect(existsSync(link)).toBeTruthy();
+                await promises.symlink(target, link);
+                expect(existsSync(link)).toBeTruthy();
 
-            const stats = await promises.lstat(link);
-            expect(stats.isSymbolicLink()).toBeTruthy();
+                const stats = await promises.lstat(link);
+                expect(stats.isSymbolicLink()).toBeTruthy();
 
-            unlinkSync(link);
-            rmSync(target);
-            rmdirSync(dir);
-        },
+                unlinkSync(link);
+                rmSync(target);
+                rmdirSync(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );

--- a/packages/node/fs/src/new-apis.spec.ts
+++ b/packages/node/fs/src/new-apis.spec.ts
@@ -313,20 +313,22 @@ export default async () => {
     // ==================== readlinkSync ====================
 
     await describe('fs.readlinkSync', async () => {
-        await it.failing('should read symlink target', async () => {
-            const dir = mkdtempSync('fs-test-');
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            writeFileSync(target, 'data');
-            symlinkSync(target, link);
+        await it.failing(
+            'should read symlink target',
+            async () => {
+                const dir = mkdtempSync('fs-test-');
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                writeFileSync(target, 'data');
+                symlinkSync(target, link);
 
-            const result = readlinkSync(link);
-            expect(String(result)).toBe(target);
+                const result = readlinkSync(link);
+                expect(String(result)).toBe(target);
 
-            unlinkSync(link);
-            rmSync(target);
-            rmdirSync(dir);
-        },
+                unlinkSync(link);
+                rmSync(target);
+                rmdirSync(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );

--- a/packages/node/fs/src/rm-symlink.spec.ts
+++ b/packages/node/fs/src/rm-symlink.spec.ts
@@ -23,48 +23,52 @@ import { CAN_SYMLINK, NO_SYMLINK_REASON } from './capabilities.spec.js';
 
 export default async () => {
     await describe('fs.rmSync — symlinks must not leak into target tree', async () => {
-        await it.failing('removes the symlink, leaves the target directory + contents intact', async () => {
-            const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-sync-'));
-            const target = join(tmp, 'workspace');
-            const link = join(tmp, 'link-to-workspace');
+        await it.failing(
+            'removes the symlink, leaves the target directory + contents intact',
+            async () => {
+                const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-sync-'));
+                const target = join(tmp, 'workspace');
+                const link = join(tmp, 'link-to-workspace');
 
-            mkdirSync(join(target, 'src'), { recursive: true });
-            writeFileSync(join(target, 'src', 'index.ts'), 'export const ok = 1;\n');
-            writeFileSync(join(target, 'package.json'), '{"name":"workspace"}\n');
-            symlinkSync(target, link);
+                mkdirSync(join(target, 'src'), { recursive: true });
+                writeFileSync(join(target, 'src', 'index.ts'), 'export const ok = 1;\n');
+                writeFileSync(join(target, 'package.json'), '{"name":"workspace"}\n');
+                symlinkSync(target, link);
 
-            rmSync(link, { recursive: true, force: true });
+                rmSync(link, { recursive: true, force: true });
 
-            // The symlink itself is gone.
-            expect(existsSync(link)).toBe(false);
-            // The TARGET directory and its contents survive.
-            expect(existsSync(target)).toBe(true);
-            expect(existsSync(join(target, 'src', 'index.ts'))).toBe(true);
-            expect(readFileSync(join(target, 'src', 'index.ts'), 'utf8')).toBe('export const ok = 1;\n');
-            expect(readdirSync(join(target, 'src'))).toStrictEqual(['index.ts']);
+                // The symlink itself is gone.
+                expect(existsSync(link)).toBe(false);
+                // The TARGET directory and its contents survive.
+                expect(existsSync(target)).toBe(true);
+                expect(existsSync(join(target, 'src', 'index.ts'))).toBe(true);
+                expect(readFileSync(join(target, 'src', 'index.ts'), 'utf8')).toBe('export const ok = 1;\n');
+                expect(readdirSync(join(target, 'src'))).toStrictEqual(['index.ts']);
 
-            rmSync(tmp, { recursive: true, force: true });
-        },
+                rmSync(tmp, { recursive: true, force: true });
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
 
-        await it.failing('removes the symlink without --recursive, target untouched', async () => {
-            const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-sync-no-recursive-'));
-            const target = join(tmp, 'workspace');
-            const link = join(tmp, 'link');
-            mkdirSync(target, { recursive: true });
-            writeFileSync(join(target, 'file.txt'), 'survive');
-            symlinkSync(target, link);
+        await it.failing(
+            'removes the symlink without --recursive, target untouched',
+            async () => {
+                const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-sync-no-recursive-'));
+                const target = join(tmp, 'workspace');
+                const link = join(tmp, 'link');
+                mkdirSync(target, { recursive: true });
+                writeFileSync(join(target, 'file.txt'), 'survive');
+                symlinkSync(target, link);
 
-            rmSync(link, { force: true });
+                rmSync(link, { force: true });
 
-            expect(existsSync(link)).toBe(false);
-            expect(existsSync(target)).toBe(true);
-            expect(existsSync(join(target, 'file.txt'))).toBe(true);
+                expect(existsSync(link)).toBe(false);
+                expect(existsSync(target)).toBe(true);
+                expect(existsSync(join(target, 'file.txt'))).toBe(true);
 
-            rmSync(tmp, { recursive: true, force: true });
-        },
+                rmSync(tmp, { recursive: true, force: true });
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
@@ -84,44 +88,48 @@ export default async () => {
             rmSync(tmp, { recursive: true, force: true });
         });
 
-        await it.failing('removes a symlink to a single file without affecting the file', async () => {
-            const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-file-'));
-            const target = join(tmp, 'real.txt');
-            const link = join(tmp, 'link.txt');
-            writeFileSync(target, 'keep me');
-            symlinkSync(target, link);
+        await it.failing(
+            'removes a symlink to a single file without affecting the file',
+            async () => {
+                const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-file-'));
+                const target = join(tmp, 'real.txt');
+                const link = join(tmp, 'link.txt');
+                writeFileSync(target, 'keep me');
+                symlinkSync(target, link);
 
-            rmSync(link, { force: true });
+                rmSync(link, { force: true });
 
-            expect(existsSync(link)).toBe(false);
-            expect(existsSync(target)).toBe(true);
-            expect(readFileSync(target, 'utf8')).toBe('keep me');
+                expect(existsSync(link)).toBe(false);
+                expect(existsSync(target)).toBe(true);
+                expect(readFileSync(target, 'utf8')).toBe('keep me');
 
-            rmSync(tmp, { recursive: true, force: true });
-        },
+                rmSync(tmp, { recursive: true, force: true });
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
     });
 
     await describe('fs.promises.rm — symlinks must not leak into target tree', async () => {
-        await it.failing('removes the symlink, leaves the target intact', async () => {
-            const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-promise-'));
-            const target = join(tmp, 'workspace');
-            const link = join(tmp, 'link');
+        await it.failing(
+            'removes the symlink, leaves the target intact',
+            async () => {
+                const tmp = mkdtempSync(join(tmpdir(), 'rm-symlink-promise-'));
+                const target = join(tmp, 'workspace');
+                const link = join(tmp, 'link');
 
-            mkdirSync(join(target, 'src'), { recursive: true });
-            writeFileSync(join(target, 'src', 'index.ts'), 'export const ok = 1;\n');
-            symlinkSync(target, link);
+                mkdirSync(join(target, 'src'), { recursive: true });
+                writeFileSync(join(target, 'src', 'index.ts'), 'export const ok = 1;\n');
+                symlinkSync(target, link);
 
-            await rm(link, { recursive: true, force: true });
+                await rm(link, { recursive: true, force: true });
 
-            expect(existsSync(link)).toBe(false);
-            expect(existsSync(target)).toBe(true);
-            expect(existsSync(join(target, 'src', 'index.ts'))).toBe(true);
+                expect(existsSync(link)).toBe(false);
+                expect(existsSync(target)).toBe(true);
+                expect(existsSync(join(target, 'src', 'index.ts'))).toBe(true);
 
-            rmSync(tmp, { recursive: true, force: true });
-        },
+                rmSync(tmp, { recursive: true, force: true });
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );

--- a/packages/node/fs/src/symlink.spec.ts
+++ b/packages/node/fs/src/symlink.spec.ts
@@ -27,129 +27,141 @@ export default async () => {
             }).toThrow(Error);
         });
 
-        await it.failing('should create a symlink pointing to a file', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-sym-cb-'));
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            writeFileSync(target, 'symlink target');
+        await it.failing(
+            'should create a symlink pointing to a file',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-sym-cb-'));
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                writeFileSync(target, 'symlink target');
 
-            await new Promise<void>((resolve, reject) => {
-                symlinkCb(target, link, (err) => {
-                    if (err) return reject(err);
-                    try {
-                        const s = lstatSync(link);
-                        expect(s.isSymbolicLink()).toBe(true);
-                        resolve();
-                    } catch (e) {
-                        reject(e);
-                    }
+                await new Promise<void>((resolve, reject) => {
+                    symlinkCb(target, link, (err) => {
+                        if (err) return reject(err);
+                        try {
+                            const s = lstatSync(link);
+                            expect(s.isSymbolicLink()).toBe(true);
+                            resolve();
+                        } catch (e) {
+                            reject(e);
+                        }
+                    });
                 });
-            });
 
-            unlinkSync(link);
-            unlinkSync(target);
-            rmdirSync(dir);
-        },
+                unlinkSync(link);
+                unlinkSync(target);
+                rmdirSync(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
     });
 
     await describe('fs.symlink (promise)', async () => {
-        await it.failing('should create a symlink pointing to a file', async () => {
-            const dir = await mkdtemp(join(tmpdir(), 'fs-sym-p-'));
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            await writeFile(target, 'symlink target content');
+        await it.failing(
+            'should create a symlink pointing to a file',
+            async () => {
+                const dir = await mkdtemp(join(tmpdir(), 'fs-sym-p-'));
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                await writeFile(target, 'symlink target content');
 
-            await symlink(target, link);
-
-            const s = lstatSync(link);
-            expect(s.isSymbolicLink()).toBe(true);
-
-            await unlink(link);
-            await unlink(target);
-            await rmdir(dir);
-        },
-            NO_SYMLINK_REASON,
-            { when: !CAN_SYMLINK },
-        );
-
-        await it.failing('should throw ENOENT when symlinking to non-existent target', async () => {
-            const dir = await mkdtemp(join(tmpdir(), 'fs-sym-err-'));
-            const link = join(dir, 'link.txt');
-            // Creating a dangling symlink — target doesn't exist
-            await symlink('/nonexistent/path/12345abc', link);
-            const s = await lstat(link);
-            expect(s.isSymbolicLink()).toBe(true);
-            await unlink(link);
-            await rmdir(dir);
-        },
-            NO_SYMLINK_REASON,
-            { when: !CAN_SYMLINK },
-        );
-
-        await it.failing('should throw EEXIST when symlink already exists', async () => {
-            const dir = await mkdtemp(join(tmpdir(), 'fs-sym-exist-'));
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            await writeFile(target, 'data');
-            await symlink(target, link);
-
-            let threw = false;
-            try {
                 await symlink(target, link);
-            } catch (e: unknown) {
-                threw = true;
-                expect((e as NodeJS.ErrnoException).code).toBe('EEXIST');
-            }
-            expect(threw).toBe(true);
 
-            await unlink(link);
-            await unlink(target);
-            await rmdir(dir);
-        },
+                const s = lstatSync(link);
+                expect(s.isSymbolicLink()).toBe(true);
+
+                await unlink(link);
+                await unlink(target);
+                await rmdir(dir);
+            },
+            NO_SYMLINK_REASON,
+            { when: !CAN_SYMLINK },
+        );
+
+        await it.failing(
+            'should throw ENOENT when symlinking to non-existent target',
+            async () => {
+                const dir = await mkdtemp(join(tmpdir(), 'fs-sym-err-'));
+                const link = join(dir, 'link.txt');
+                // Creating a dangling symlink — target doesn't exist
+                await symlink('/nonexistent/path/12345abc', link);
+                const s = await lstat(link);
+                expect(s.isSymbolicLink()).toBe(true);
+                await unlink(link);
+                await rmdir(dir);
+            },
+            NO_SYMLINK_REASON,
+            { when: !CAN_SYMLINK },
+        );
+
+        await it.failing(
+            'should throw EEXIST when symlink already exists',
+            async () => {
+                const dir = await mkdtemp(join(tmpdir(), 'fs-sym-exist-'));
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                await writeFile(target, 'data');
+                await symlink(target, link);
+
+                let threw = false;
+                try {
+                    await symlink(target, link);
+                } catch (e: unknown) {
+                    threw = true;
+                    expect((e as NodeJS.ErrnoException).code).toBe('EEXIST');
+                }
+                expect(threw).toBe(true);
+
+                await unlink(link);
+                await unlink(target);
+                await rmdir(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
     });
 
     await describe('fs.readlink', async () => {
-        await it.failing('should read the symlink target synchronously', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-rl-'));
-            const target = join(dir, 'target.txt');
-            const link2 = join(dir, 'link2.txt');
-            writeFileSync(target, 'data');
+        await it.failing(
+            'should read the symlink target synchronously',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-rl-'));
+                const target = join(dir, 'target.txt');
+                const link2 = join(dir, 'link2.txt');
+                writeFileSync(target, 'data');
 
-            await new Promise<void>((resolve) => {
-                symlinkCb(target, link2, () => {
-                    const dest = readlinkSync(link2);
-                    expect(dest).toBe(target);
-                    unlinkSync(link2);
-                    unlinkSync(target);
-                    rmdirSync(dir);
-                    resolve();
+                await new Promise<void>((resolve) => {
+                    symlinkCb(target, link2, () => {
+                        const dest = readlinkSync(link2);
+                        expect(dest).toBe(target);
+                        unlinkSync(link2);
+                        unlinkSync(target);
+                        rmdirSync(dir);
+                        resolve();
+                    });
                 });
-            });
-        },
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
 
-        await it.failing('should read the symlink target via promise', async () => {
-            const dir = await mkdtemp(join(tmpdir(), 'fs-rl-p-'));
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            await writeFile(target, 'data');
-            await symlink(target, link);
+        await it.failing(
+            'should read the symlink target via promise',
+            async () => {
+                const dir = await mkdtemp(join(tmpdir(), 'fs-rl-p-'));
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                await writeFile(target, 'data');
+                await symlink(target, link);
 
-            const dest = await readlink(link);
-            expect(dest).toBe(target);
+                const dest = await readlink(link);
+                expect(dest).toBe(target);
 
-            await unlink(link);
-            await unlink(target);
-            await rmdir(dir);
-        },
+                await unlink(link);
+                await unlink(target);
+                await rmdir(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
@@ -167,80 +179,86 @@ export default async () => {
     });
 
     await describe('fs.realpath', async () => {
-        await it.failing('should resolve a symlink to real path (sync)', async () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-rp-'));
-            const target = join(dir, 'realfile.txt');
-            const link = join(dir, 'link.txt');
-            writeFileSync(target, 'realpath test');
+        await it.failing(
+            'should resolve a symlink to real path (sync)',
+            async () => {
+                const dir = mkdtempSync(join(tmpdir(), 'fs-rp-'));
+                const target = join(dir, 'realfile.txt');
+                const link = join(dir, 'link.txt');
+                writeFileSync(target, 'realpath test');
 
-            await new Promise<void>((resolve) => {
-                symlinkCb(target, link, () => {
-                    const real = realpathSync(link);
-                    // realpath resolves symlinks to actual path
-                    expect(typeof real).toBe('string');
-                    expect(real.length).toBeGreaterThan(0);
-                    unlinkSync(link);
-                    resolve();
+                await new Promise<void>((resolve) => {
+                    symlinkCb(target, link, () => {
+                        const real = realpathSync(link);
+                        // realpath resolves symlinks to actual path
+                        expect(typeof real).toBe('string');
+                        expect(real.length).toBeGreaterThan(0);
+                        unlinkSync(link);
+                        resolve();
+                    });
                 });
-            });
 
-            unlinkSync(target);
-            rmdirSync(dir);
-        },
+                unlinkSync(target);
+                rmdirSync(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
 
-        await it.failing('should resolve a symlink to real path (promise)', async () => {
-            const dir = await mkdtemp(join(tmpdir(), 'fs-rp-p-'));
-            const target = join(dir, 'realfile.txt');
-            const link = join(dir, 'link.txt');
-            await writeFile(target, 'realpath test');
-            await symlink(target, link);
+        await it.failing(
+            'should resolve a symlink to real path (promise)',
+            async () => {
+                const dir = await mkdtemp(join(tmpdir(), 'fs-rp-p-'));
+                const target = join(dir, 'realfile.txt');
+                const link = join(dir, 'link.txt');
+                await writeFile(target, 'realpath test');
+                await symlink(target, link);
 
-            const real = await realpath(link);
-            expect(typeof real).toBe('string');
-            expect(real.length).toBeGreaterThan(0);
+                const real = await realpath(link);
+                expect(typeof real).toBe('string');
+                expect(real.length).toBeGreaterThan(0);
 
-            await unlink(link);
-            await unlink(target);
-            await rmdir(dir);
-        },
+                await unlink(link);
+                await unlink(target);
+                await rmdir(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
 
-        await it.failing('resolves a symlinked ANCESTOR, not just a trailing symlink', async () => {
-            // The gap the two cases above could not see, twice over: they assert
-            // only `typeof real === 'string'` plus a non-zero length, and they
-            // only ever put the symlink LAST. `realpathSync` used to query the
-            // full path once and return it unchanged when the leaf was a real
-            // file, so a symlink anywhere ABOVE the leaf survived into the result.
-            //
-            // Invisible on Linux CI (`/tmp` is a real directory, so identity is
-            // also correct) and wrong on macOS, where `/var` symlinks to
-            // `private/var` — six `@gjsify/child_process` cwd tests failed on
-            // main's macOS leg because `realpathSync(os.tmpdir())` disagreed with
-            // the cwd a spawned process reports. This asserts the VALUE, so it
-            // fails on the defect instead of on a symptom somewhere downstream.
-            const dir = mkdtempSync(join(tmpdir(), 'fs-rp-anc-'));
-            const realDir = join(dir, 'real');
-            const linkDir = join(dir, 'link');
-            mkdirSync(join(realDir, 'leaf'), { recursive: true });
-            await symlink(realDir, linkDir);
+        await it.failing(
+            'resolves a symlinked ANCESTOR, not just a trailing symlink',
+            async () => {
+                // The gap the two cases above could not see, twice over: they assert
+                // only `typeof real === 'string'` plus a non-zero length, and they
+                // only ever put the symlink LAST. `realpathSync` used to query the
+                // full path once and return it unchanged when the leaf was a real
+                // file, so a symlink anywhere ABOVE the leaf survived into the result.
+                //
+                // Invisible on Linux CI (`/tmp` is a real directory, so identity is
+                // also correct) and wrong on macOS, where `/var` symlinks to
+                // `private/var` — six `@gjsify/child_process` cwd tests failed on
+                // main's macOS leg because `realpathSync(os.tmpdir())` disagreed with
+                // the cwd a spawned process reports. This asserts the VALUE, so it
+                // fails on the defect instead of on a symptom somewhere downstream.
+                const dir = mkdtempSync(join(tmpdir(), 'fs-rp-anc-'));
+                const realDir = join(dir, 'real');
+                const linkDir = join(dir, 'link');
+                mkdirSync(join(realDir, 'leaf'), { recursive: true });
+                await symlink(realDir, linkDir);
 
-            // `dir` itself may sit behind a symlink (it does on macOS), so the
-            // expectation is anchored on the resolved parent rather than on `dir`.
-            const resolvedDir = realpathSync(dir);
-            expect(realpathSync(join(linkDir, 'leaf'))).toBe(join(resolvedDir, 'real', 'leaf'));
-            // The leaf-symlink case must keep working — with its value checked.
-            expect(realpathSync(linkDir)).toBe(join(resolvedDir, 'real'));
+                // `dir` itself may sit behind a symlink (it does on macOS), so the
+                // expectation is anchored on the resolved parent rather than on `dir`.
+                const resolvedDir = realpathSync(dir);
+                expect(realpathSync(join(linkDir, 'leaf'))).toBe(join(resolvedDir, 'real', 'leaf'));
+                // The leaf-symlink case must keep working — with its value checked.
+                expect(realpathSync(linkDir)).toBe(join(resolvedDir, 'real'));
 
-            await unlink(linkDir);
-            await rmdir(join(realDir, 'leaf'));
-            await rmdir(realDir);
-            await rmdir(dir);
-        },
+                await unlink(linkDir);
+                await rmdir(join(realDir, 'leaf'));
+                await rmdir(realDir);
+                await rmdir(dir);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );

--- a/packages/node/fs/src/sync.spec.ts
+++ b/packages/node/fs/src/sync.spec.ts
@@ -251,17 +251,17 @@ export default async () => {
         await it.failing(
             'should return the real and absolute path',
             () => {
-            const dir = mkdtempSync(join(tmpdir(), 'fs-rp-'));
-            const target = join(dir, 'target.txt');
-            const link = join(dir, 'link.txt');
-            writeFileSync(target, 'data');
-            symlinkSync(target, link);
+                const dir = mkdtempSync(join(tmpdir(), 'fs-rp-'));
+                const target = join(dir, 'target.txt');
+                const link = join(dir, 'link.txt');
+                writeFileSync(target, 'data');
+                symlinkSync(target, link);
 
-            const realPath = realpathSync(target);
-            const realSymLinkPath = realpathSync(link);
+                const realPath = realpathSync(target);
+                const realSymLinkPath = realpathSync(link);
 
-            // Should point to the real file, not the symlink
-            expect(realSymLinkPath).toBe(realPath);
+                // Should point to the real file, not the symlink
+                expect(realSymLinkPath).toBe(realPath);
 
                 unlinkSync(link);
                 rmSync(target);

--- a/packages/node/fs/src/utimes.spec.ts
+++ b/packages/node/fs/src/utimes.spec.ts
@@ -62,19 +62,21 @@ export default async () => {
             unlinkSync(f);
         });
 
-        await it.failing('lutimesSync does not throw on a symlink', async () => {
-            const target = tmpFile('lutime-target');
-            const link = join(TMP, `gjsify-lutime-link-${process.pid}`);
-            // force:true is the non-throwing spelling of "remove a leftover
-            // from a previous run" — a real failure (EACCES) still surfaces.
-            rmSync(link, { force: true });
-            symlinkSync(target, link);
-            const mtime = new Date('2017-05-20T00:00:00Z');
-            // Just verify the call completes without throwing
-            expect(() => lutimesSync(link, mtime, mtime)).not.toThrow();
-            unlinkSync(link);
-            unlinkSync(target);
-        },
+        await it.failing(
+            'lutimesSync does not throw on a symlink',
+            async () => {
+                const target = tmpFile('lutime-target');
+                const link = join(TMP, `gjsify-lutime-link-${process.pid}`);
+                // force:true is the non-throwing spelling of "remove a leftover
+                // from a previous run" — a real failure (EACCES) still surfaces.
+                rmSync(link, { force: true });
+                symlinkSync(target, link);
+                const mtime = new Date('2017-05-20T00:00:00Z');
+                // Just verify the call completes without throwing
+                expect(() => lutimesSync(link, mtime, mtime)).not.toThrow();
+                unlinkSync(link);
+                unlinkSync(target);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );
@@ -92,22 +94,24 @@ export default async () => {
             unlinkSync(f);
         });
 
-        await it.failing('lchownSync does not throw (may need root to actually change)', async () => {
-            const f = tmpFile('lchown');
-            const link = join(TMP, `gjsify-lchown-link-${process.pid}`);
-            // force:true is the non-throwing spelling of "remove a leftover
-            // from a previous run" — a real failure (EACCES) still surfaces.
-            rmSync(link, { force: true });
-            symlinkSync(f, link);
-            // This will only actually change owner if running as root; just verify no throw
-            try {
-                lchownSync(link, process.getuid ? process.getuid() : 0, process.getgid ? process.getgid() : 0);
-            } catch {
-                // acceptable if kernel denies (EPERM) — just must not crash the process
-            }
-            unlinkSync(link);
-            unlinkSync(f);
-        },
+        await it.failing(
+            'lchownSync does not throw (may need root to actually change)',
+            async () => {
+                const f = tmpFile('lchown');
+                const link = join(TMP, `gjsify-lchown-link-${process.pid}`);
+                // force:true is the non-throwing spelling of "remove a leftover
+                // from a previous run" — a real failure (EACCES) still surfaces.
+                rmSync(link, { force: true });
+                symlinkSync(f, link);
+                // This will only actually change owner if running as root; just verify no throw
+                try {
+                    lchownSync(link, process.getuid ? process.getuid() : 0, process.getgid ? process.getgid() : 0);
+                } catch {
+                    // acceptable if kernel denies (EPERM) — just must not crash the process
+                }
+                unlinkSync(link);
+                unlinkSync(f);
+            },
             NO_SYMLINK_REASON,
             { when: !CAN_SYMLINK },
         );

--- a/packages/node/fs/src/watch.spec.ts
+++ b/packages/node/fs/src/watch.spec.ts
@@ -12,6 +12,40 @@ function makeTmp(): string {
     return mkdtempSync(join(tmpdir(), 'gjsify-watch-'));
 }
 
+/**
+ * Timers a test armed and must not leave running past its own temp directory.
+ *
+ * Every test here writes into its temp dir from a timer and then removes that
+ * dir when it ends, and the abort RACES the timeout by design — so "it will
+ * have fired by then" is not a property any of them can rely on. A timer that
+ * outlives its test writes into a path that no longer exists, and the ENOENT
+ * surfaces against whichever test happens to be running when it fires: on
+ * darwin a `tracked.txt` write armed by `filename in event is a string or null`
+ * failed `stops cleanly when AbortController is aborted during iteration`.
+ *
+ * Four timers were armed and never cancelled. Rather than four clears, the
+ * timer and the directory it writes into get ONE owner — {@link scheduleWrite}
+ * arms, {@link cleanup} cancels and removes, and a test cannot do the second
+ * without the first.
+ */
+const pendingWrites = new Set<ReturnType<typeof setTimeout>>();
+
+/** Schedule `write` once, `ms` from now, and remember it until it fires. */
+function scheduleWrite(write: () => void, ms: number): void {
+    const id = setTimeout(() => {
+        pendingWrites.delete(id);
+        write();
+    }, ms);
+    pendingWrites.add(id);
+}
+
+/** Cancel anything still armed, THEN remove the directory it would write into. */
+function cleanup(tmp: string): void {
+    for (const id of pendingWrites) clearTimeout(id);
+    pendingWrites.clear();
+    rmSync(tmp, { recursive: true, force: true });
+}
+
 export default async () => {
     await describe('fs.promises.watch', async () => {
         await it('yields rename event when a file is created in a directory', async () => {
@@ -20,7 +54,7 @@ export default async () => {
             let received = false;
 
             // Write the file shortly after the iterator starts waiting
-            setTimeout(() => {
+            scheduleWrite(() => {
                 writeFileSync(join(tmp, 'new-file.txt'), 'hello');
             }, 30);
 
@@ -37,7 +71,7 @@ export default async () => {
             }
 
             expect(received).toBe(true);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
 
         await it('yields change event when a watched file is modified', async () => {
@@ -48,7 +82,7 @@ export default async () => {
             const ac = new AbortController();
             let received = false;
 
-            setTimeout(() => {
+            scheduleWrite(() => {
                 writeFileSync(file, 'modified');
             }, 30);
 
@@ -64,7 +98,7 @@ export default async () => {
             }
 
             expect(received).toBe(true);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
 
         await it('filename in event is a string or null', async () => {
@@ -72,7 +106,7 @@ export default async () => {
             const ac = new AbortController();
             let filename: string | null | undefined = undefined;
 
-            setTimeout(() => {
+            scheduleWrite(() => {
                 writeFileSync(join(tmp, 'tracked.txt'), 'x');
             }, 30);
 
@@ -88,7 +122,7 @@ export default async () => {
             // filename is a string basename or null (GJS writeFileSync uses atomic writes
             // via GLib.file_set_contents which may report a temp filename — any string is valid)
             expect(typeof filename === 'string' || filename === null).toBe(true);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
 
         await it('stops iterating immediately when signal is pre-aborted', async () => {
@@ -106,7 +140,7 @@ export default async () => {
             }
 
             expect(count).toBe(0);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
 
         await it('stops cleanly when AbortController is aborted during iteration', async () => {
@@ -135,7 +169,7 @@ export default async () => {
             }
 
             expect(eventCount).toBeGreaterThan(0);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
 
         await it('multiple events can be collected before abort', async () => {
@@ -143,7 +177,7 @@ export default async () => {
             const ac = new AbortController();
             const events: string[] = [];
 
-            setTimeout(() => {
+            scheduleWrite(() => {
                 writeFileSync(join(tmp, 'a.txt'), '1');
                 writeFileSync(join(tmp, 'b.txt'), '2');
             }, 30);
@@ -160,7 +194,7 @@ export default async () => {
             }
 
             expect(events.length).toBeGreaterThan(0);
-            rmSync(tmp, { recursive: true, force: true });
+            cleanup(tmp);
         });
     });
 };

--- a/packages/node/http2/src/server/response/respond-with-file.ts
+++ b/packages/node/http2/src/server/response/respond-with-file.ts
@@ -6,13 +6,13 @@
 // implementations onto the prototype.
 //
 // Houses `respondWithFD()` / `respondWithFile()` plus the file-streaming
-// helper `_respondFromFD()` and the `_fdPath()` lookup. Exported helpers
+// helper `_respondFromFD()`. Exported helpers
 // stay module-local (no public surface change).
 // Reference: refs/node/lib/internal/http2/core.js
 // (Http2Stream.respondWithFD / respondWithFile).
 // Original: see server/response.ts pre-split.
 
-import { read as fsRead, statSync, openSync, closeSync, type Stats } from 'node:fs';
+import { read as fsRead, fstatSync, openSync, closeSync, type Stats } from 'node:fs';
 import { Buffer } from 'node:buffer';
 import type { OutgoingHttpHeaders } from 'node:http';
 import type { Http2ServerResponse } from '../response.js';
@@ -107,7 +107,7 @@ const respondWithFileMethods: RespondWithFileMethods & ThisType<Http2ServerRespo
  * _respondFromFD — common implementation behind respondWithFD / respondWithFile.
  *
  * Flow:
- *  1) statSync on the FD so the user-supplied `statCheck()` callback can
+ *  1) fstatSync on the FD so the user-supplied `statCheck()` callback can
  *     mutate headers based on size / mtime / ino (Node parity).
  *  2) flushHeaders via writeHead — kicks the Soup chunked-write path.
  *  3) Read the FD in 64 KiB chunks via fs.read; pipe each chunk through
@@ -144,7 +144,14 @@ function _respondFromFD(
     // on stat results without hand-writing fstat boilerplate.
     if (options.statCheck) {
         try {
-            const stat = statSync(_fdPath(fd) ?? '/proc/self/fd/' + fd);
+            // `fstatSync(fd)`, not a stat of `/proc/self/fd/<fd>`. procfs is a
+            // LINUX filesystem, so the path form resolved nothing on macOS,
+            // `statSync` threw, and the catch below swallowed it — `statCheck`
+            // silently never ran and the response went out without the headers
+            // the application meant to set. Measured on darwin-x64 / gjs
+            // 1.88.1: `statSeen` stayed null. `fstat(2)` is what Node itself
+            // uses here and needs no path at all.
+            const stat = fstatSync(fd);
             // `finalHeaders` is the http2-style outgoing-headers shape
             // (`Record<string, string | string[] | number>`) which is the same
             // record-shape as `OutgoingHttpHeaders`; the explicit cast bridges
@@ -161,8 +168,11 @@ function _respondFromFD(
                 if (closeFd) closeSync(fd);
                 return;
             }
-            // Continue without statCheck — Node's behaviour is to skip silently
-            // when fstat fails (the FD will fail later in the read loop anyway).
+            // Continue without statCheck — Node skips silently when fstat
+            // fails, and the FD will fail again in the read loop below, so the
+            // error is not lost. Kept narrow ON PURPOSE: this catch used to
+            // absorb a platform defect (a Linux-only path that could not
+            // resolve on macOS) and report it as "the file had no stat".
         }
     }
 
@@ -248,18 +258,6 @@ function _respondFromFD(
     // Mark that we used the fd-streaming path so listeners know the body
     // is being delivered out-of-band of the regular write() machinery.
     void bytesSent;
-}
-
-/**
- * _fdPath — best-effort fd → path lookup via `/proc/self/fd/<fd>`.
- *
- * Used only for statCheck; `fs.statSync` accepts that path on Linux to
- * stat the open FD. Returns null on non-Linux (caller falls back to
- * `/proc/self/fd/N` regardless — `statSync` will fail cleanly).
- */
-function _fdPath(fd: number): string | null {
-    if (typeof fd !== 'number' || fd < 0) return null;
-    return '/proc/self/fd/' + fd;
 }
 
 /** Install respondWithFD + respondWithFile on Http2ServerResponse.prototype. */

--- a/packages/node/sqlite/src/database-sync.spec.ts
+++ b/packages/node/sqlite/src/database-sync.spec.ts
@@ -5,11 +5,22 @@
 import { describe, it, expect } from '@gjsify/unit';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, realpathSync } from 'node:fs';
 import { DatabaseSync } from 'node:sqlite';
 
 let cnt = 0;
-const testDir = join(tmpdir(), 'gjsify-sqlite-test-' + Date.now());
+// `realpathSync`, not a bare `tmpdir()`. `location()` answers with the path
+// SQLite RESOLVED, and on macOS `/var` is a symlink to `private/var`, so
+// `tmpdir()` hands out `/var/folders/…` while the open database reports
+// `/private/var/folders/…`. Comparing the two is a test of the host's symlink
+// layout, not of `location()` — and it cannot fail on a typical Linux box,
+// where `/tmp` is a real directory and the identity answer happens to be right.
+//
+// The same trap already cost this repo six `@gjsify/child_process` cwd failures
+// and a fix to `@gjsify/fs`'s `realpathSync`, which documents it at length. This
+// is that defect in a second place: resolving ONCE, here, keeps every path this
+// suite compares in the same form.
+const testDir = join(realpathSync(tmpdir()), 'gjsify-sqlite-test-' + Date.now());
 
 function setup() {
     // recursive:true already makes an existing dir a no-op — any other

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -634,6 +634,29 @@ installs, documented in node-gi's README.
 
 `@gjsify/net`'s `server.spec.ts` still reports 1-2 of 381 failing under NATIVE Node on darwin (`read ECONNRESET`), against 381 green under GJS on the same host. It was 2-4 before `withServer` took ownership of the accepted sockets and the affected specs learned to tolerate exactly `ECONNRESET`, so what is left is narrower, not closed. The mechanism is the kernel's: BSD resets a connection that is closed while unread data is buffered where Linux delivers a FIN, and an `'error'` event with no listener is re-thrown. The remaining failures wander between `close event after end` and `localPort after connect`, which is the signature of a socket outliving the spec that made it — the next thing to try is owning the CLIENT sockets' lifecycle the way the server's now is. Per this repo's testing rules a native-Node failure is a statement about the TEST, and our implementation is the one that is green.
 
+### `@gjsify/sqlite`'s GJS suite ABORTS the process, and the trigger is a GC window
+
+Not a failing assertion — `SIGABRT`. Measured on darwin-x64 / gjs 1.88.1 / libgda 6.0, running `database-sync.spec.ts` alone under the real harness:
+
+```
+DatabaseSync.prototype.close()
+GLib-GObject:ERROR:../gobject/gobject.c:6103:_weak_ref_set:
+  assertion failed: (weak_ref_data_list_find (new_wrdata, weak_ref) < 0)
+Bail out!   gjs exited with code null
+```
+
+It stayed invisible until the `/var` vs `/private/var` fix landed, because the node leg failed first and the `&&` chain never reached the gjs one.
+
+**Ruled out, each by measurement rather than by reading:** bare libgda (`Gda.Connection.new_from_string` + `open()` + `close()`, nothing of ours in the process) does not abort · leaked connections plus an explicit `system.gc()` do not abort · the same operations driven through the real `DatabaseSync` API outside the harness do not abort · a specific test is not responsible, and neither is a leaked connection from the constructor block — the constructor validates (`parsePath`, `validateOptions`) BEFORE it opens, so a throwing construction never creates one.
+
+**What the bisect says.** Keeping the first N `it()` rows of the constructor block and rebuilding: N=0 ok, **N=1 CRASH**, N=2 ok, N=3 ok, **N=11 CRASH**. Non-monotonic — the number of preceding rows perturbs *when* the collector runs relative to the libgda objects' lifetimes, and nothing more. That is the signature of a GC window in the interaction between GJS's object-wrapper machinery (toggle refs / `GWeakRef`) and libgda's objects, not of a condition in our code. It is therefore NOT fixable by editing a spec, and a fix that appeared to work by adding or removing a test row would be luck.
+
+Next step is instrumentation, not more bisecting: run under `GJS_DEBUG_ALL`/`G_DEBUG=fatal-warnings` with a breakpoint on `_weak_ref_set` to see which object is being re-registered, and whether the second registration comes from GJS's wrapper or from libgda. If it is GJS's, this joins the libgda row already in `upstream-patch-candidates.md`; if it is ours, the owner is `DatabaseSync`'s lifecycle. Until then there is no workaround to maintain, which is why this is here and not in that table.
+
+### Two packages have no darwin target at all, and their specs say so by failing
+
+`@gjsify/webrtc` dies at `Requiring GjsifyWebrtc … Typelib file for namespace 'GjsifyWebrtc' not found` and `@gjsify/sab-native`'s positive control `hasNativeSab() returns true when prebuild is loaded` cannot pass, because no `webrtc-native-darwin-*` package exists and `@gjsify/sab-native`'s `gjsify.platforms` declares `linux-*` only. Both are honest failures of a promise nobody made — the declarations are correct and the artifacts genuinely do not exist. Recorded so a macOS run's red is READ correctly: it is a missing target, not a broken port. Closing either means adding the darwin legs to `prebuilds.yml` and the targets to the manifests, at which point the same specs become the check. The sibling bridges (`http2-native`, `tls-native`, `terminal-native`, `http-soup-bridge`, `webgl`, `lightningcss-native`, `oxfmt-native`, `rolldown-native`) all already ship `*-darwin-{x64,arm64}`, so the pattern is proven — these two were simply never extended.
+
 ### `@gjsify/rolldown-native` macOS prebuild — the last step to a Node-free toolchain on macOS
 
 The Rust blocker is GONE (eventfd descriptors → portable anonymous pipes in `src/rust/src/wakeup.rs`; `cargo check --target aarch64-apple-darwin` green) and `meson.build` is darwin-ready — but no NATIVE macOS build has been promoted: run the manual-dispatch `build-prebuilds-macos-experimental` job, promote the package into the REQUIRED `build-prebuilds-macos` job, add `darwin-arm64` to `package.json#gjsify.platforms`, and commit the prebuild. Until that leg is green the docs must keep describing the Node-free toolchain as Linux-only. The CLI-side loading follow-ups are DONE (`detectNativePackages()` resolves `<os>-<arch>` for the running host; `buildNativeEnv()` emits the loader variable the host actually reads). Only the artifact itself is missing. (See also the CI coverage item above — the darwin leg is proven, not promoted.)


### PR DESCRIPTION
#1022 added a leg that runs the Node pillar on macOS. **This is what it found once it existed** — including the reason the leg itself was red on `main`, which had nothing to do with the code it was added to measure.

**7 commits, 7 defects closed. A full local sweep goes from 8 red packages to 5, and every one of the 5 is either structurally impossible on macOS or ledgered with a diagnosis.**

Measured on the darwin-x64 VM (macOS 15.7.8 / gjs 1.88.1 / Node 24.18.1). The sweep is every published workspace package, one at a time, both `test:node` and `test:gjs`, failures tolerated — the local stand-in for CI's `test` job while Actions was down.

## The urgent one: both new OS legs are red on `main`, for reasons of their own

| leg | failing step | why |
|---|---|---|
| macOS ×2 arch | `Bootstrap the toolchain from the published CLI` | it built **before** it installed |
| Windows | `Prove the POSIX utilities are gone` | passed semantically, exited 1 |

`build:infra` compiles `@gjsify/vite-plugin-blueprint` first, whose `gjsify tsc` needs `@types/node` — a dependency, not a build output. On a cold tree that dies with `TS2688: Cannot find type definition file for 'node'` and the leg never reaches a single suite. `.github/actions/gjsify-setup` has always installed first and ADR 0002 documents that order; the two steps were simply the wrong way round. **`windows-suites.yml` has the same inversion** — `macos-suites.yml` inherited it from there and it had not yet reached the step to show it, so both are corrected together.

The Windows step is a cmd trap: `where X && exit 1 || echo …` leaves the ERRORLEVEL that the failed `where` set, because cmd's internal `echo` does not reliably clear it. Measured on main: both utilities absent, "no sh on PATH - good" printed, COMSPEC printed, **exit code 1**. Replaced with an explicit failure branch and a terminal `exit /b 0`, so nothing is inferred from a chain's residue.

## The defects the leg was built to find

### `fix(cli)` — the dyld fallback repeated `/usr/lib`, and its spec assumed Linux

```
is EMPTY when no native package was detected
  Expected:
  Actual:   DYLD_FALLBACK_LIBRARY_PATH=/usr/lib:/usr/local/lib:/usr/lib
```

Two defects, one symptom. "Nothing to prepend" is not "nothing to report" — `buildNativeEnv` also repairs the HOST's own GI libdirs on darwin, deliberately even with an empty package set, because that gap is in dyld and not in a gjsify prebuild. And `/usr/lib` was genuinely listed twice: `systemGiLibraryDirs()` accepts a libdir the host names through `GI_TYPELIB_PATH` on existence alone, and the `/usr/lib` tail then repeated it.

The row now asserts **properties**, not a literal — exactly one assignment, the *fallback* variable rather than the override one, every probed libdir present, `/usr/lib` still terminating the search, no duplicate entry, the inherited loader variable not handed back. A spec that recomputes the implementation's join order passes for whatever that function does, including for a bug. Keyed on the CAPABILITY, never on `process.platform`, so a Mac with no GI stack still expects an empty prefix.

### `fix(http2)` — `statCheck` stat'ed a procfs path, and the catch hid it

`respondWithFile`'s `statCheck` callback never ran on macOS, and nothing said so. The implementation stat'ed `/proc/self/fd/<fd>`; procfs is a **Linux** filesystem, so the path resolved nothing, `statSync` threw, and the catch below absorbed it as "the file had no stat". The response then went out without the headers the application meant to set — a silent wrong answer, not an error.

`fstatSync(fd)` needs no path at all, is what Node itself uses here, and was already in `@gjsify/fs`. The `_fdPath()` helper existed only to build that procfs path and goes with it.

### `test(fs)` — four timers with no owner

Four tests armed a bare `setTimeout` to write into their temp directory and never cancelled it, then removed that directory when they ended. The abort **races** the timeout by design, so "it will have fired by then" is not a property any of them can rely on. The ENOENT then surfaces against whichever test is RUNNING when it fires — which is why the failure appeared to wander between three tests.

Not four clears: the timer and the directory it writes into get **one** owner. `scheduleWrite()` arms and remembers, `cleanup()` cancels and then removes, and a test cannot do the second without the first.

### `test(sqlite)` — compare paths in one resolved form

`location()` answers with the path SQLite **resolved**; the suite built its expectation from `os.tmpdir()`, and `/var` is a symlink to `private/var` on macOS. This repo has already paid for that trap once — six `@gjsify/child_process` cwd failures and the rewrite of `@gjsify/fs`'s `realpathSync`, which documents the incident at length. This is the same defect in a spec rather than an implementation.

### `test(dns)` — the empty-hostname throw is a Node 25 fact

`@gjsify/dns` declares `runtimes.node: "none"`, so `test:node` runs **native** Node, and these rows assert that `lookup('')` throws `ERR_INVALID_ARG_VALUE` — which Node only started doing in v25. On a Node 24 runner the host is right to disagree (`DEP0118`, `err: null`). Same shape as a POSIX literal in an OS-conditional spec, one axis over, so it becomes `it.failing(…, { when })` and retires itself when the runner's Node makes it pass.

The predicate checks for GJS **first**, and that is not redundant: `@gjsify/process` reports `versions.node = '20.0.0'` on purpose, so a bare major comparison would classify GJS as an old Node and tolerate a failure there — where our implementation *does* throw and the gjs leg is what proves it.

## Verification (darwin-x64)

```
@gjsify/cli      1953 node                was 1 of 1944
@gjsify/fs        671 node   677 gjs      was 1 of 671, intermittent — 4 consecutive runs green
@gjsify/http2     102 node   231 gjs      was 1 of 229; the count rises because two
                                          assertions behind `statSeen` had never executed
@gjsify/dns       118 node   118 gjs      was 2 of 118 (+2 declared it.failing)
@gjsify/sqlite    105 node                was 1 of 105

full sweep        155 packages, 5 failing — was 8

audit-runtimes --check      OK    audit-test-scripts        OK
verify-committed-bundles    OK    commitlint                clean
oxfmt --check               clean (739 files)
```

## The 5 that remain, and why none is unexplained

| package | class |
|---|---|
| `@gjsify/iframe` | **structural** — WebKitGTK is Linux-only upstream. ADR + measurements in #1028 |
| `@gjsify/webrtc` | **structural** — no `webrtc-native-darwin-*` package exists |
| `@gjsify/sab-native` | **structural** — `gjsify.platforms` declares `linux-*` only |
| `@gjsify/net` | ledgered in #1022 — a pre-existing loopback teardown race on the **native-Node** leg only (gjs is green); narrowed from 2–4 to 1–2 there |
| `@gjsify/sqlite` (gjs) | **ledgered with a diagnosis**, below |

### The one that is not closed, and what is actually known about it

`@gjsify/sqlite`'s GJS suite **aborts the process** — `SIGABRT` in GLib's weak-ref machinery, not a failing assertion. It was invisible until the `/var` fix landed, because the node leg failed first and the `&&` chain never reached it.

```
DatabaseSync.prototype.close()
GLib-GObject:ERROR:../gobject/gobject.c:6103:_weak_ref_set:
  assertion failed: (weak_ref_data_list_find (new_wrdata, weak_ref) < 0)
Bail out!   gjs exited with code null
```

Four hypotheses ruled out **by measurement**: bare libgda (`new_from_string` + `open()` + `close()`, nothing of ours in the process) does not abort · leaked connections plus an explicit `system.gc()` do not abort · the same operations through the real `DatabaseSync` API outside the harness do not abort · the constructor does not leak, because it validates *before* it opens.

The bisect is the finding. Keeping the first N `it()` rows of the constructor block: **N=0 ok, N=1 CRASH, N=2 ok, N=3 ok, N=11 CRASH**. Non-monotonic — the row count only perturbs *when* the collector runs relative to the libgda objects' lifetimes. That is a GC window between GJS's wrapper machinery and libgda, not a condition in our code, so no spec edit can fix it and a fix that appeared to work by moving a test would be luck. The next step is naming the object being re-registered, not more bisecting. Ledgered with all of the above; deliberately **not** in `upstream-patch-candidates.md`, which is for workarounds we maintain — there is no workaround here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
