### PR TITLE
fix: close what the first post-outage CI run found

### DIFF
--- a/packages/infra/cli/src/index.ts
+++ b/packages/infra/cli/src/index.ts
@@ -17,7 +17,25 @@ try {
     // a scary `Gjs-CRITICAL **: Module … threw an exception` that buries the
     // real, already-actionable message (e.g. "gjsify build: no usable bundler
     // engine under GJS — build the facade first or run under Node"). See #597.
-    console.error(err instanceof Error ? err.message : String(err));
+    //
+    // The `code` is printed WITH the message, not dropped. Errors in this CLI
+    // carry npm's own codes on purpose — `badPlatformError()` documents that it
+    // reproduces npm's `EBADPLATFORM` payload "so a consumer's error handling
+    // (and a human reading the message) sees what npm reports" — and npm itself
+    // prints the code (`npm ERR! code EBADPLATFORM`) rather than only the prose.
+    //
+    // It has to be explicit here because this catch became the SINGLE printer:
+    // before the `.fail()` handler in `cli-app.ts`, yargs logged the error OBJECT
+    // and the code came along for free. Printing `err.message` alone silently
+    // dropped it for every coded error, which is what turned
+    // `tests/e2e/install-optional-both-blocks` red on `main` — it asserts the
+    // code is visible, and the prose it still printed did not contain it.
+    const code =
+        typeof err === 'object' && err !== null && typeof (err as { code?: unknown }).code === 'string'
+            ? (err as { code: string }).code
+            : '';
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(code && !message.includes(code) ? `${code}: ${message}` : message);
     if (process.env.GJSIFY_DEBUG && err instanceof Error && err.stack) console.error(err.stack);
     // `process.exitCode` is the gentle Node idiom (streams flush). GJS has no
     // atexit hook and would exit 0 at natural shutdown, so force a non-zero exit

--- a/packages/node/os/src/index.spec.ts
+++ b/packages/node/os/src/index.spec.ts
@@ -265,9 +265,21 @@ export default async () => {
         });
 
         await it('should be one of known machine types', async () => {
+            // `os.machine()` is `uname -m`, and that string is the KERNEL's — the
+            // same CPU answers differently per OS. Apple's arm64 says `arm64`
+            // where Linux says `aarch64` (Darwin on Intel says `x86_64`, as Linux
+            // does). Listing only the Linux spelling made this assert the HOST
+            // instead of the contract, which is the exact failure mode ADR 0018
+            // names: on Linux the missing entry cannot fail.
+            //
+            // It went red the moment it could — #1022 moved `packages/node/os`
+            // from `MACOS_PROBE_PACKAGES` to `MACOS_TEST_PACKAGES`, so the macOS
+            // leg began GATING on a suite it had only probed with. The gap is
+            // older than that move; the move is what made it visible.
             const known = [
                 'x86_64',
                 'aarch64',
+                'arm64',
                 'arm',
                 'armv7l',
                 'i686',

--- a/scripts/report-symlink-capability.mjs
+++ b/scripts/report-symlink-capability.mjs
@@ -36,7 +36,8 @@ try {
     const target = join(dir, 'target.txt');
     writeFileSync(target, 'probe');
     symlinkSync(target, join(dir, 'link.txt'));
-    verdict = 'CAN_SYMLINK=true — this host may create symlinks, so @gjsify/fs\'s 19 symlink specs RUN and must pass here.';
+    verdict =
+        "CAN_SYMLINK=true — this host may create symlinks, so @gjsify/fs's 19 symlink specs RUN and must pass here.";
 } catch (err) {
     const code = err && typeof err === 'object' && 'code' in err ? err.code : 'unknown';
     verdict =

--- a/tests/e2e/run-command/run.mjs
+++ b/tests/e2e/run-command/run.mjs
@@ -367,10 +367,7 @@ describe('gjsify run (Phase D.5)', { timeout: 60_000 }, () => {
                 existsSync(join(appDir, 'dist', 'chdir-probe.txt')),
                 'the copy must land in the WORKSPACE, not the caller cwd',
             );
-            assert.ok(
-                !existsSync(join(root, 'dist', 'chdir-probe.txt')),
-                'nothing may be written at the caller cwd',
-            );
+            assert.ok(!existsSync(join(root, 'dist', 'chdir-probe.txt')), 'nothing may be written at the caller cwd');
         },
     );
 

--- a/tests/e2e/self-update/run.mjs
+++ b/tests/e2e/self-update/run.mjs
@@ -206,6 +206,22 @@ describe('gjsify self-update E2E', { timeout: 60_000 }, () => {
                 gjsify: { prebuilds: 'prebuilds' },
             }) + '\n',
         );
+        // The manifest field alone does NOT make the engine detected, and this
+        // line is what actually makes the prefix HEALTHY. `detectNativePackages()`
+        // — which `hasBundlerEngineInstalled()` asks, and which the repair branch
+        // keys on — requires the arch-specific directory to physically exist; a
+        // package declaring `gjsify.prebuilds` with nothing on disk is skipped.
+        // Measured against this fixture: without the directory it answers `[]`,
+        // with it `["@gjsify/rolldown-native"]`.
+        //
+        // Without it the three version-match rows below read as engine-missing,
+        // self-update repairs instead of short-circuiting, and they fail
+        // asserting "Already up to date" — which is exactly how they failed on
+        // `main`. `tests/e2e/global-install-engine/run.mjs` builds its fixture
+        // the same way and documents the same `prebuilds/<os>-<arch>` convention.
+        mkdirSync(join(enginePkgDir, 'prebuilds', `${process.platform}-${process.arch}`), {
+            recursive: true,
+        });
 
         // Empty prefix (no @gjsify/cli).
         prefixEmpty = join(tmpRoot, 'global-empty');


### PR DESCRIPTION
Three things the first real CI run after the Actions outage found on `main`. I merged the PRs that exposed them, so I am closing them.

**Context:** GitHub Actions was in a `major_outage` from 15:22 UTC (webhooks throttled to ~15%). Eleven PRs were merged during it against a locally-reproduced gate. When Actions came back, the `GJS` run on `dae079a09` reported these. Two are regressions, one is an older gap that only became reachable.

## 1 · `self-update` — the fixture was never healthy (3 rows)

The suite builds a prefix it *calls* HEALTHY and writes the engine's `package.json`, but not the `prebuilds/<os>-<arch>/` directory. That directory is what makes the engine DETECTED — `detectNativePackages()`, which `hasBundlerEngineInstalled()` asks and the repair branch keys on, skips a package that declares `gjsify.prebuilds` with nothing on disk.

Measured against that exact fixture:

```
without prebuilds/         -> []
with prebuilds/linux-x64/  -> ["@gjsify/rolldown-native"]
```

So the prefix read as engine-missing, `self-update` repaired instead of short-circuiting, and three rows failed asserting `Already up to date`. It passed on developer machines only where a real engine happened to sit in the tree.

`tests/e2e/global-install-engine/run.mjs` already builds its fixture this way and documents the same convention.

**11/11, was 8/11.**

## 2 · `EBADPLATFORM` — the code stopped being printed

`index.ts`'s catch became the **single** printer when `cli-app.ts` registered a `.fail()` handler (#1020). Before that, yargs logged the error OBJECT and any `code` came along for free; printing `err.message` alone dropped it for **every** coded error, not just this one.

Those codes are load-bearing. `badPlatformError()` reproduces npm's `EBADPLATFORM` payload deliberately — *"so a consumer's error handling (and a human reading the message) sees what npm reports"* — and npm prints the code itself rather than only the sentence. `install-optional-both-blocks` asserts the code is visible; the prose that still printed does not contain it.

Prefixed only when the message does not already carry the code, so nothing prints it twice.

**install-optional-both-blocks + self-update: 15/15. `@gjsify/cli`: 1947 completed.**

## 3 · `os.machine()` — the list held only the Linux spelling

`os.machine()` is `uname -m`, and that string is the KERNEL's: the same CPU answers differently per OS. Apple's arm64 says `arm64` where Linux says `aarch64`. The known-types list had `aarch64` only, so it asserted the HOST instead of the contract — on Linux the missing entry *cannot* fail, which is the blind spot ADR 0018 exists for.

This one is **not** a regression. It went red the moment it *could*: #1022 moved `packages/node/os` from `MACOS_PROBE_PACKAGES` to `MACOS_TEST_PACKAGES`, so the macOS leg began GATING on a suite it had only probed with, and `os.test.gjs.mjs` failed 1 of 172 on macOS arm64. The gap predates the move; the move is what made it visible, which was its purpose.

**Linux unchanged: 304 completed on node, 311 on gjs.**

## Not in here

- The two remaining `format --check` offenders on `main` (`scripts/report-symlink-capability.mjs`, `tests/e2e/run-command/run.mjs`) — #1031 fixes those and I did not want to collide with it.
- The `macos-suites` / `windows-suites` bootstrap failures — also #1031 (`ci: repair the macOS and Windows bootstrap`).

## How this was verified

Separate worktree, fresh `origin/main` + `gjsify install --immutable`, bootstrapped through the published CLI. `gjsify format --check` clean for these files, `@gjsify/cli` 1947 completed, `@gjsify/os` 304/311, and the four e2e suites above green. The pre-commit hook rebuilt `affected.gjs.mjs` with the CLI source change, so `verify-committed-bundles` stays satisfied.
