### PR TITLE
ci(napi): build the CLI bundle the transparent matrix drives

### DIFF
--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -375,17 +375,26 @@ jobs:
       # went green. The bundle has to come from THIS commit's source, which
       # means building it.
       #
-      # Two steps because they answer different questions: `build` produces the
-      # CLI's own `lib/` (the bundle's entry), `build:gjs-bundle` produces the
-      # artifact. The polyfill libs and the bundler plugin they both need were
-      # built further up, and the published CLI on PATH is what drives this
-      # build — the same bootstrap `.github/actions/gjsify-setup` performs.
+      # The package's own `build:gjs-bundle` cannot be used here, and the reason
+      # is the same one that made this job attractive in the first place. It is
+      # `node lib/index.js build …`, so it needs the CLI's `lib/`, which comes
+      # from `build` = `gjsify tsc …` — and this job deliberately installs only
+      # the slice the bundler needs, so that typecheck dies on TS7016/TS7006
+      # against `@types/node` it never installed. Measured here, not guessed.
+      #
+      # So drive the SAME bundle out of the published CLI instead. That is not
+      # the substitution the comment below rules out: what matters is whose
+      # SOURCE is bundled, not who runs rolldown. The entry is this checkout's
+      # `src/index.ts`, so the artifact carries THIS commit's
+      # `napiNodeAddonPlugin` — which is the whole property the matrix needs.
+      # Using the published CLI as the DRIVER would be the broken variant, since
+      # it would execute last release's plugin.
       - name: Build the CLI's GJS bundle (untracked since ADR 0002)
+        working-directory: packages/infra/cli
         run: |
-          export PATH="$PWD/node_modules/.bin:$PATH"
-          gjsify workspace @gjsify/cli build
-          gjsify workspace @gjsify/cli build:gjs-bundle
-          ls -l packages/infra/cli/dist/cli.gjs.mjs
+          node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js \
+            build src/index.ts --app gjs --outfile dist/cli.gjs.mjs --shebang
+          ls -l dist/cli.gjs.mjs
 
       # Driven by the dist/cli.gjs.mjs BUILT ABOVE, NOT the published CLI the
       # consumer gate uses — and that distinction is the whole point.

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -316,7 +316,7 @@ jobs:
           # These jobs never use the tsc bundle, so skip building it.
           gjsify foreach build:gjsify --exclude '@gjsify/tsc'
 
-      # The committed dist/cli.gjs.mjs INLINES the build pipeline's CODE but not
+      # The CLI's `dist/cli.gjs.mjs` INLINES the build pipeline's CODE but not
       # its runtime DATA files: `resolveShim()` (rolldown-plugin-gjsify's
       # app/gjs.ts) hands rolldown FILE paths under
       # packages/infra/rolldown-plugin-gjsify/lib/shims/ (unicorn-magic,
@@ -324,14 +324,24 @@ jobs:
       # `./shims/<name>` subpath export at BUILD time and inlined into the
       # OUTPUT bundle. That `lib/` is a plain-`tsc` build output the polyfill
       # step above never produces (the package has no `build:gjsify` script), so
-      # without this step every `--app gjs` build driven by the committed bundle
-      # dies at config time with `cannot locate the "unicorn-magic" shim` — the
-      # first red of the GJS-engine transparent matrix. `--with-dependencies`
+      # without this step every `--app gjs` build driven by that bundle dies at
+      # config time with `cannot locate the "unicorn-magic" shim` — the first
+      # red of the GJS-engine transparent matrix. `--with-dependencies`
       # tsc-builds the small workspace-dep closure the plugin's own `tsc` needs
       # declarations from (console, deepkit, pnp, blueprint); deps without a
       # `build` script are skipped. Runs in BOTH jobs that save the napi-libs
       # cache so an entry always carries this output regardless of which job's
       # post-job save wins the per-key race (see the cache step above).
+      #
+      # This `lib/` is ALSO what makes the transparent matrix measure THIS
+      # commit's plugin: `napiNodeAddonPlugin` lives in THIS package, not in the
+      # CLI, and the bundle step below reaches it by resolving
+      # `@gjsify/rolldown-plugin-gjsify` through the workspace symlink. That
+      # survives a cache HIT only because the key above is exact-only with NO
+      # `restore-keys` over `packages/*/*/src/**` — all 43 of this package's
+      # sources are `.ts`, so the hash covers the whole input. Adding a
+      # `restore-keys:` fallback there would let this matrix report PASS while
+      # driving a plugin built from a DIFFERENT commit. Do not add one.
       - name: Build @gjsify/rolldown-plugin-gjsify lib (bundler shims)
         if: steps.napi-libs-cache.outputs.cache-hit != 'true'
         run: |
@@ -375,23 +385,63 @@ jobs:
       # went green. The bundle has to come from THIS commit's source, which
       # means building it.
       #
-      # The package's own `build:gjs-bundle` cannot be used here, and the reason
-      # is the same one that made this job attractive in the first place. It is
-      # `node lib/index.js build …`, so it needs the CLI's `lib/`, which comes
-      # from `build` = `gjsify tsc …` — and this job deliberately installs only
-      # the slice the bundler needs, so that typecheck dies on TS7016/TS7006
-      # against `@types/node` it never installed. Measured here, not guessed.
+      # The package's own `build:gjs-bundle` cannot be used here. It is
+      # `node lib/index.js build …`, so it needs the CLI's own `lib/`, which
+      # comes from `build` = `gjsify tsc …` — and the workspace libs this job
+      # fills in are TRANSPILE-ONLY: `build:gjsify` emits no `lib/types/*.d.ts`
+      # (the cache step above records the same fact from the other side).
+      # Measured on 8ef235413, job 92755831272: 63 errors in 26 files, 34 of
+      # them TS7016 `Could not find a declaration file for module` against
+      # @gjsify/{workspace,npm-registry,tar,semver}, the rest cascading off the
+      # resulting `any`s. NOT `@types/node` — that was installed, and every
+      # `node:` import here typechecked. Giving this job declarations means a
+      # full `gjsify foreach build` (tsc everywhere), the multi-minute build
+      # this job exists to avoid.
       #
       # So drive the SAME bundle out of the published CLI instead. That is not
       # the substitution the comment below rules out: what matters is whose
       # SOURCE is bundled, not who runs rolldown. The entry is this checkout's
-      # `src/index.ts`, so the artifact carries THIS commit's
-      # `napiNodeAddonPlugin` — which is the whole property the matrix needs.
-      # Using the published CLI as the DRIVER would be the broken variant, since
-      # it would execute last release's plugin.
-      - name: Build the CLI's GJS bundle (untracked since ADR 0002)
-        working-directory: packages/infra/cli
+      # `src/index.ts`, and `src/actions/build.ts` imports
+      # `@gjsify/rolldown-plugin-gjsify` — where `napiNodeAddonPlugin` actually
+      # lives (app/gjs.ts installs it for every `--app gjs` build) — which
+      # resolves through the workspace symlink into the `lib/` built above. The
+      # artifact therefore carries THIS commit's plugin, the whole property the
+      # matrix needs; only the transform pass is last release's.
+      #
+      # `@gjsify/create-app` is built first because it is the ONE workspace dep
+      # of this entry that neither fill step above produces: no `build:gjsify`
+      # (the polyfill foreach skips it) and not in
+      # `@gjsify/rolldown-plugin-gjsify`'s dep closure (`--with-dependencies`
+      # never reaches it), while `src/commands/create.ts` imports it and its
+      # `exports` name a gitignored `lib/`. That was 0a8e5f3d9's red:
+      # `UnresolvedWorkspaceImportError: cannot resolve the workspace package
+      # @gjsify/create-app`. It is the only such hole — the other 26 packages in
+      # this entry's `--app gjs` closure resolve. `--external` is NOT an escape
+      # (the guard says why: stock GJS's ESM loader has no node_modules walker
+      # and does not follow `package.json#exports`, so it would fail at LOAD),
+      # and aliasing it to `@gjsify/empty` would go green while making the
+      # artifact differ from the bundle that SHIPS — the matrix would quietly
+      # stop measuring what it claims to. Its own tsc closure is empty (dep:
+      # yargs; `types: ["node"]`; no `@gjsify/*` imports), so it cannot hit the
+      # .d.ts wall above, and `files: ["src/index.ts","src/create.ts"]` plus
+      # index.ts's `./prompt-template.js` import emits BOTH exported subpaths.
+      #
+      # Both commands share ONE step, and it is deliberately NOT guarded on
+      # `napi-libs-cache`. The guarded steps DEFINE what an entry under that key
+      # carries, and every live `napi-libs-v2` entry was saved by a run that
+      # never built create-app — this PR's own run took an exact hit
+      # (`Cache hit for: napi-libs-v2-104a5967…`) and skipped both of them. A
+      # guard here would be skipped on exactly the hit a workflow-only change
+      # gets and red the matrix: the v1 → v2 incident, repeated. Keeping the two
+      # commands physically together is what stops that guard being re-added by
+      # someone reading only a step name, and it keeps create-app OUT of the
+      # fill-step set the cache comment's invariant is about — so that invariant
+      # stays literally true and no key bump is needed.
+      - name: Build @gjsify/create-app, then the CLI's GJS bundle (ADR 0002 untracked it)
         run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @gjsify/create-app build
+          cd packages/infra/cli
           node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js \
             build src/index.ts --app gjs --outfile dist/cli.gjs.mjs --shebang
           ls -l dist/cli.gjs.mjs
@@ -416,13 +466,13 @@ jobs:
       # stand-in, since packages/napi is not a workspace member.
       #
       # GJSIFY_CLI_ENTRY covers only the gate's build-the-napi-L1 FALLBACK
-      # (normally a no-op — the consumer gate above already built lib/esm). It
-      # is kept pointing at the PUBLISHED entry even though the step above now
-      # builds `packages/infra/cli/lib/` too: this variable exists so the
-      # fallback has something to spawn, and pinning it to the published CLI
-      # keeps it independent of whether the in-repo build ran. The matrix BUILD
-      # itself is driven by the bundle built above (GJSIFY_GATE_ENGINE=gjs),
-      # never by this entry.
+      # (normally a no-op — the consumer gate above already built lib/esm): the
+      # in-repo Node CLI is not built in this job — the step above emits
+      # `dist/cli.gjs.mjs` and create-app's `lib/`, never
+      # `packages/infra/cli/lib/` — so without it that fallback would spawn a
+      # nonexistent packages/infra/cli/lib/index.js. The matrix BUILD itself is
+      # driven by the bundle built above (GJSIFY_GATE_ENGINE=gjs), never by this
+      # entry.
       - name: Transparent addon matrix (GJS engine, freshly built CLI bundle)
         working-directory: packages/napi/napi
         env:
@@ -582,7 +632,7 @@ jobs:
           # These jobs never use the tsc bundle, so skip building it.
           gjsify foreach build:gjsify --exclude '@gjsify/tsc'
 
-      # The committed dist/cli.gjs.mjs INLINES the build pipeline's CODE but not
+      # The CLI's `dist/cli.gjs.mjs` INLINES the build pipeline's CODE but not
       # its runtime DATA files: `resolveShim()` (rolldown-plugin-gjsify's
       # app/gjs.ts) hands rolldown FILE paths under
       # packages/infra/rolldown-plugin-gjsify/lib/shims/ (unicorn-magic,
@@ -590,9 +640,9 @@ jobs:
       # `./shims/<name>` subpath export at BUILD time and inlined into the
       # OUTPUT bundle. That `lib/` is a plain-`tsc` build output the polyfill
       # step above never produces (the package has no `build:gjsify` script), so
-      # without this step every `--app gjs` build driven by the committed bundle
-      # dies at config time with `cannot locate the "unicorn-magic" shim` — the
-      # first red of the GJS-engine transparent matrix. `--with-dependencies`
+      # without this step every `--app gjs` build driven by that bundle dies at
+      # config time with `cannot locate the "unicorn-magic" shim` — the first
+      # red of the GJS-engine transparent matrix. `--with-dependencies`
       # tsc-builds the small workspace-dep closure the plugin's own `tsc` needs
       # declarations from (console, deepkit, pnp, blueprint); deps without a
       # `build` script are skipped. Runs in BOTH jobs that save the napi-libs

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -364,13 +364,36 @@ jobs:
         working-directory: packages/napi/napi
         run: sh test/addons/setup.sh
 
-      # Driven by the COMMITTED dist/cli.gjs.mjs, NOT the published CLI the
-      # consumer gate above uses — and that distinction is the whole point.
+      # ADR 0002 untracked `dist/cli.gjs.mjs`, so the matrix below has to BUILD
+      # the bundle it drives — it used to just find it in the checkout.
+      #
+      # Substituting the published CLI here would be the easy repair and the
+      # wrong one, for the reason the next comment gives: it carries the last
+      # release's plugin, so a PR changing `napiNodeAddonPlugin` would measure
+      # nothing. Falling back to the Node driver when the file is absent would
+      # be worse still — the GJS path would stop being exercised while the job
+      # went green. The bundle has to come from THIS commit's source, which
+      # means building it.
+      #
+      # Two steps because they answer different questions: `build` produces the
+      # CLI's own `lib/` (the bundle's entry), `build:gjs-bundle` produces the
+      # artifact. The polyfill libs and the bundler plugin they both need were
+      # built further up, and the published CLI on PATH is what drives this
+      # build — the same bootstrap `.github/actions/gjsify-setup` performs.
+      - name: Build the CLI's GJS bundle (untracked since ADR 0002)
+        run: |
+          export PATH="$PWD/node_modules/.bin:$PATH"
+          gjsify workspace @gjsify/cli build
+          gjsify workspace @gjsify/cli build:gjs-bundle
+          ls -l packages/infra/cli/dist/cli.gjs.mjs
+
+      # Driven by the dist/cli.gjs.mjs BUILT ABOVE, NOT the published CLI the
+      # consumer gate uses — and that distinction is the whole point.
       # The published CLI carries the LAST RELEASE's plugin, so a PR changing
-      # `napiNodeAddonPlugin` would test nothing at all; the committed bundle
-      # carries THIS commit's plugin (the pre-commit hook rebuilds it, and
-      # main.yml's verify-committed-bundles proves it reproduces from that
-      # source). It also runs the build on `@gjsify/rolldown-native` — the
+      # `napiNodeAddonPlugin` would test nothing at all; a bundle built from
+      # this checkout carries THIS commit's plugin. (Until ADR 0002 the file was
+      # committed and the pre-commit hook kept it fresh; the step above replaces
+      # that.) It also runs the build on `@gjsify/rolldown-native` — the
       # engine where two of the six #840 defects lived (a `null` importer
       # across the JSON hook boundary, and a Rust-`regex`-incompatible filter
       # that silently disabled every interception). A Node-driven build cannot
@@ -384,12 +407,14 @@ jobs:
       # stand-in, since packages/napi is not a workspace member.
       #
       # GJSIFY_CLI_ENTRY covers only the gate's build-the-napi-L1 FALLBACK
-      # (normally a no-op — the consumer gate above already built lib/esm): the
-      # in-repo Node CLI is not built in this job, so without it that fallback
-      # would spawn a nonexistent packages/infra/cli/lib/index.js. The matrix
-      # BUILD itself is driven by the committed bundle (GJSIFY_GATE_ENGINE=gjs),
+      # (normally a no-op — the consumer gate above already built lib/esm). It
+      # is kept pointing at the PUBLISHED entry even though the step above now
+      # builds `packages/infra/cli/lib/` too: this variable exists so the
+      # fallback has something to spawn, and pinning it to the published CLI
+      # keeps it independent of whether the in-repo build ran. The matrix BUILD
+      # itself is driven by the bundle built above (GJSIFY_GATE_ENGINE=gjs),
       # never by this entry.
-      - name: Transparent addon matrix (GJS engine, committed CLI bundle)
+      - name: Transparent addon matrix (GJS engine, freshly built CLI bundle)
         working-directory: packages/napi/napi
         env:
           GJSIFY_GATE_ENGINE: gjs

--- a/packages/napi/napi/test/transparent-gate.mjs
+++ b/packages/napi/napi/test/transparent-gate.mjs
@@ -71,8 +71,9 @@ const runGjsify = (args, opts) => execFileSync(process.execPath, [CLI, ...args],
 
 /**
  * How the gate DRIVES `gjsify build`. Default is the Node CLI entry (npm
- * `rolldown`); `GJSIFY_GATE_ENGINE=gjs` drives the committed GJS bundle
- * instead, i.e. `@gjsify/rolldown-native`.
+ * `rolldown`); `GJSIFY_GATE_ENGINE=gjs` drives the in-repo
+ * `packages/infra/cli/dist/cli.gjs.mjs` instead, i.e.
+ * `@gjsify/rolldown-native`.
  *
  * The engine is not an implementation detail for this gate, it is a distinct
  * risk surface, and the interception had NO coverage on it. Two of the six
@@ -88,11 +89,17 @@ const runGjsify = (args, opts) => execFileSync(process.execPath, [CLI, ...args],
  *     WHOLE pattern rather than one branch, silently disabling every
  *     interception under GJS while npm `rolldown` keeps working.
  *
- * Using the COMMITTED bundle is deliberate: it carries the plugin code of the
- * commit under test (the pre-commit hook rebuilds it; `verify-committed-bundles`
- * proves it reproduces from that source), so no in-repo CLI build is needed —
- * which is what let this run inside the existing consumer job instead of
- * needing its own workspace build.
+ * Driving the IN-REPO bundle is deliberate: it carries the plugin code of the
+ * commit under test, which the published CLI cannot — that one ships the LAST
+ * RELEASE's `napiNodeAddonPlugin`, so a PR changing it would measure nothing.
+ *
+ * ADR 0002 untracked this file (it used to be committed, kept fresh by the
+ * pre-commit hook and proved reproducible by `verify-committed-bundles`), so
+ * producing it is now the CALLER's job — see napi.yml's "Build
+ * @gjsify/create-app, then the CLI's GJS bundle" step in the better-sqlite3
+ * consumer job. This gate does NOT build it, and deliberately does not fall
+ * back to the Node driver when it is absent: that would retire the GJS path
+ * while reporting green — the false green the six #840 defects rode in on.
  *
  * The prebuild env must be exported BEFORE the process starts: the typelib
  * lookup happens inside the GJS runtime, so the CLI cannot repair it from the
@@ -103,7 +110,13 @@ function resolveBuildDriver() {
         return { cmd: process.execPath, pre: [CLI], env: {}, label: 'node/npm-rolldown' };
     }
     const bundle = join(ROOT, 'packages', 'infra', 'cli', 'dist', 'cli.gjs.mjs');
-    if (!existsSync(bundle)) die(`GJSIFY_GATE_ENGINE=gjs but the committed CLI bundle is missing: ${bundle}`);
+    if (!existsSync(bundle))
+        die(
+            `GJSIFY_GATE_ENGINE=gjs but the CLI's GJS bundle is missing: ${bundle} — untracked since ` +
+                `ADR 0002, so the CALLER must build it (napi.yml, better-sqlite3 consumer job, ` +
+                `"Build @gjsify/create-app, then the CLI's GJS bundle"). Not falling back to the Node ` +
+                `driver on purpose: that would report green without exercising @gjsify/rolldown-native.`,
+        );
     const prebuilds = [
         join(ROOT, 'packages', 'infra', 'rolldown-native-linux-x64', 'prebuilds', 'linux-x64'),
         join(ROOT, 'node_modules', '@gjsify', 'rolldown-native', 'prebuilds', 'linux-x64'),


### PR DESCRIPTION
The third place ADR 0002 left behind, after the macOS and Windows legs #1031 just repaired.

## What is broken

`packages/napi/napi/test/transparent-gate.mjs` requires `packages/infra/cli/dist/cli.gjs.mjs` by absolute path. #1019 untracked it, so the better-sqlite3 consumer job dies on **all four** transparent addons the moment `napi.yml` triggers. This is red on `main` too (run 31142398622, job 92754830935).

```
TRANSPARENT GATE bufferutil:      FAIL — GJSIFY_GATE_ENGINE=gjs but the committed CLI bundle is missing
TRANSPARENT GATE utf-8-validate:  FAIL — …
TRANSPARENT GATE sqlite3:         FAIL — …
TRANSPARENT GATE argon2:          FAIL — …
```

The gate's own docblock names the premise that was removed:

> Using the COMMITTED bundle is deliberate: it carries the plugin code of the commit under test … **so no in-repo CLI build is needed** — which is what let this run inside the existing consumer job instead of needing its own workspace build.

That matrix is the only coverage `napiNodeAddonPlugin`'s acquisition path has. It ran in no workflow until #840, which is why six defects in it shipped at once, two of them visible only under `@gjsify/rolldown-native` on gjs.

## Three easier repairs, all wrong

- **Point at the published CLI.** Its neighbouring comment rules it out in its own words: that CLI *"carries the LAST RELEASE's plugin, so a PR changing `napiNodeAddonPlugin` would test nothing at all"*.
- **Fall back to the Node driver** when the file is absent. Worse than the red: the GJS path stops being exercised while the job reports green — the exact false green this matrix exists to catch.
- **Alias the one unresolvable dep to `@gjsify/empty`.** This goes green immediately and is the sharpest trap, because it is *nearly* harmless — the matrix never invokes `gjsify create`. But it makes the artifact under test structurally different from the bundle that ships, and the gate's whole contract is "the bundle from this commit". The same objection retires a narrower build-only entry: a bundle shape no user runs is a bundle whose future divergence from the real one is invisible to the gate meant to catch it. (It also would not work as drafted — the gate passes `build` as a positional subcommand, which the cited `affected-entry.ts` parser ignores.)

## So it builds

One step, in the job that is already warm. The published CLI is the **driver**; the **entry** is this checkout's `src/index.ts`. That distinction is the whole design: what matters is whose source is bundled, not who runs rolldown.

`packages/infra/cli/src/actions/build.ts:5` statically imports `@gjsify/rolldown-plugin-gjsify`, whose `src/app/gjs.ts:19,269` is where `napiNodeAddonPlugin` lives and gets installed for every `--app gjs` build. That specifier resolves through the workspace symlink into `packages/infra/rolldown-plugin-gjsify/lib/` — built earlier in this job, or restored from `napi-libs-v2`, which is exact-only with **no `restore-keys`** over `packages/*/*/src/**` (all 43 of that package's sources are `.ts`, so the hash covers the whole input). So the emitted bundle carries **this commit's** plugin, and the matrix then runs `gjs -m dist/cli.gjs.mjs build …` on `@gjsify/rolldown-native`. Only the transform pass is last release's.

**`@gjsify/create-app` is built first.** It is the one workspace dep of this entry that neither existing fill step produces: no `build:gjsify` (the polyfill foreach skips it) and not in `@gjsify/rolldown-plugin-gjsify`'s dep closure (`--with-dependencies` never reaches it), while `src/commands/create.ts` imports it statically and its `exports` name a gitignored `lib/`. Two independent walks of the `--app gjs` closure (~330 files, 32 `@gjsify/*` specifiers, 27 packages) agree it is the **only** one; the rest are covered by `build:gjsify`, by `--with-dependencies`, or — for `@gjsify/resolve-npm` — by having a committed `lib/`.

**Both commands share one unguarded step, on purpose.** The guarded steps define what a `napi-libs-v2` entry carries, and every live entry was saved by a run that never built create-app — this PR's own run took an exact hit (`Cache hit for: napi-libs-v2-104a5967…`) and skipped both of them. A guard here would be skipped on precisely that hit and red the matrix: the v1 → v2 incident, repeated. Folding the two commands into one step is what stops that guard being re-added by someone reading only a step name — and it keeps create-app **out** of the fill-step set the cache comment's invariant is about, so that invariant stays literally true and no key bump is needed.

## Honest correction of the earlier commits

Both previous attempts on this branch carried a wrong diagnosis, and the second failure is a direct consequence of the first.

`8ef235413` ran the CLI package's own `build` + `build:gjs-bundle` and died in `gjsify tsc`. The commit message and the in-workflow comment blamed `@types/node`, "measured here, not guessed". The log it cites says otherwise: 63 errors in 26 files, of which 34 are TS7016 `Could not find a declaration file for module` against `@gjsify/{workspace,npm-registry,tar,semver}` — this job fills `packages/*/*/lib` transpile-only, so there are no `.d.ts` — and the remainder cascade off the resulting `any`s. Zero errors mention `@types/node`, and zero touch any `node:` builtin, which is itself proof it resolved.

The same log also contained `TS2307: Cannot find module '@gjsify/create-app'`. `0a8e5f3d9` read past it, which is why the second attempt failed on the identical missing artifact by a different route.

`0a8e5f3d9` also rewrote the `GJSIFY_CLI_ENTRY` comment to say the new step "builds `packages/infra/cli/lib/` too". It does not — no step in this job does. `main`'s wording was correct and is restored.

## Also corrected

Not scope creep — these are statements this change or ADR 0002 made untrue:

- **`transparent-gate.mjs`'s docblock and `die()`** still assert the committed-bundle premise, including two guarantees that no longer exist ("the pre-commit hook rebuilds it", "`verify-committed-bundles` proves it reproduces"). That stale docblock is *why* this failure was invisible. It now names the producing step and records that the missing Node fallback is deliberate.
- **`dist/cli.gjs.mjs` described as "committed"** in the shim-build comment, in both jobs that carry that duplicated block. That comment also gains the provenance note above, so the no-`restore-keys` invariant is written down where a future edit would break it.

## Verification, stated honestly

**Not reproduced end to end.** This is a container job on `ghcr.io/gjsify/ci-fedora:44`; a locally built workspace has exactly the artifacts CI lacks, which is what made the previous attempt look proven when it was not. That trap is the reason for the checks below — each was chosen because it holds *independently* of the local tree being warm.

Run locally against this branch:

- `actionlint 1.7.12` (the pinned CI version, sha256-verified) over all workflows — clean.
- `scripts/check-workflow-inline-scripts.mjs` — 14 workflows clean; `scripts/check-ci-image-packages.mjs` — clean.
- `gjsify format --check` — 2641 files clean. `node --check transparent-gate.mjs` — parses.
- **`gjsify workspace @gjsify/create-app build` from a wiped `lib/`** — the one command here with no CI precedent.
- **`gjsify tsc --listFiles` on `@gjsify/create-app`** — the closure is 135 files and the only `packages/` entries are its own four sources. No workspace sibling, so the missing-`.d.ts` wall that killed `8ef235413` cannot reach it. This is the check that does not depend on the local tree being warm.
- `packages/infra/tsc/lib/lib*.d.ts` are **still tracked** (108 files), so `gjsify tsc`'s default libs are present in any checkout, including this job. Independently corroborated by run 31142741432, where `gjsify tsc` ran in this exact job and emitted ordinary type diagnostics rather than a missing-lib error.

The proof is the next run of `better-sqlite3 consumer gate (GJS / Fedora 44)`. It fails closed: the matrix cannot pass with the bundle missing and cannot fall back to Node.

## Not in this PR

`Build & gates & conformance (GJS / Fedora 44)` → `test:gate:tsfn-teardown` failed once here with `FAIL draining: no warning`. Not this PR: the diff is confined to the consumer job's steps, that job shares no cache with it, the same job passed on this branch's previous commit and on `main`'s tip `04773c9c1` (this PR's base — identical tree), the macOS leg of the very same run passed the same assertion, and only 1 of that job's 3 Fedora repetitions warned.

It is a fixture bug: `tsfn-teardown-case.js` waits on `stats()[0]`, a **global** delivered-callback counter, where the `draining` shape needs per-thread claim *attribution* — N deliveries from fewer than N threads satisfies it, leaving one claim unattributed, which teardown then correctly warns about. Its own PR, against `packages/napi/napi/test/{tsfn-addon/tsfn.c,tsfn-teardown-case.js}`; the runtime is not at fault, and the warning it emitted was accurate.

Note that `napi.yml` carries no required status check, so `--auto` will not wait for it. Confirm this run green by hand before merging.
