### PR TITLE
test(napi): gate tsfn draining on claim owners

### DIFF
--- a/packages/napi/napi/test/tsfn-addon/tsfn.c
+++ b/packages/napi/napi/test/tsfn-addon/tsfn.c
@@ -26,6 +26,14 @@ static atomic_long g_delivered = 0;  // call_js with a live env
 static atomic_long g_dropped = 0;    // call_js with env == NULL (abort drain)
 static atomic_int g_finalized = 0;   // thread finalizer ran (flood tsfn)
 static atomic_int g_spin_finalized = 0;
+// DrainWorkers whose FIRST push has RETURNED — i.e. the number of DISTINCT
+// threads the shim has credited one of holdDraining's initial claims to (it
+// attributes under its own mutex before the call can return). g_delivered
+// cannot stand in for this: it counts DELIVERIES, so N of them can come from
+// one thread that pushed N times while the other N-1 have not run once, which
+// leaves those claims unattributed and makes the teardown warn — correctly —
+// against a shape that promised silence.
+static atomic_long g_drain_pushers = 0;
 
 static napi_threadsafe_function g_spin_tsfn = NULL;
 
@@ -143,14 +151,27 @@ static napi_threadsafe_function MakeTsfn(napi_env env, napi_value cb,
   return st == napi_ok ? tsfn : NULL;
 }
 
-static void SpawnDetached(void* (*fn)(void*), napi_threadsafe_function tsfn,
+// Returns false if the worker could not be started. Callers MUST report that:
+// a thread that never runs holds its initial claim forever, which at env
+// teardown is byte-identical to a thread that has merely not been scheduled
+// yet. Discarding pthread_create's status turns a hard failure into the exact
+// intermittent teardown warning this fixture's readiness gates exist to rule
+// out, with nothing in the output to tell the two apart.
+static bool SpawnDetached(void* (*fn)(void*), napi_threadsafe_function tsfn,
                           long calls) {
   WorkerArgs* w = malloc(sizeof(WorkerArgs));
+  if (w == NULL) {
+    return false;
+  }
   w->tsfn = tsfn;
   w->calls = calls;
   pthread_t t;
-  pthread_create(&t, NULL, fn, w);
+  if (pthread_create(&t, NULL, fn, w) != 0) {
+    free(w);
+    return false;
+  }
   pthread_detach(t);
+  return true;
 }
 
 // start(cb, nThreads, callsPerThread) — nonblocking flood, unbounded queue.
@@ -167,7 +188,12 @@ static napi_value Start(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "create_threadsafe_function failed");
     return NULL;
   }
-  for (long i = 0; i < threads; i++) SpawnDetached(PushWorker, tsfn, calls);
+  for (long i = 0; i < threads; i++) {
+    if (!SpawnDetached(PushWorker, tsfn, calls)) {
+      napi_throw_error(env, NULL, "pthread_create failed");
+      return NULL;
+    }
+  }
   return NULL;
 }
 
@@ -185,8 +211,12 @@ static napi_value StartBlocking(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "create_threadsafe_function failed");
     return NULL;
   }
-  for (long i = 0; i < threads; i++)
-    SpawnDetached(BlockingWorker, tsfn, calls);
+  for (long i = 0; i < threads; i++) {
+    if (!SpawnDetached(BlockingWorker, tsfn, calls)) {
+      napi_throw_error(env, NULL, "pthread_create failed");
+      return NULL;
+    }
+  }
   return NULL;
 }
 
@@ -203,8 +233,12 @@ static napi_value StartSpin(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "create_threadsafe_function failed");
     return NULL;
   }
-  for (long i = 0; i < threads; i++)
-    SpawnDetached(SpinWorker, g_spin_tsfn, 0);
+  for (long i = 0; i < threads; i++) {
+    if (!SpawnDetached(SpinWorker, g_spin_tsfn, 0)) {
+      napi_throw_error(env, NULL, "pthread_create failed");
+      return NULL;
+    }
+  }
   return NULL;
 }
 
@@ -274,11 +308,21 @@ static void* ParkWorker(void* arg) {
 // tsfn under it — the napi_closing return consumes the claim, so it drains.
 static void* DrainWorker(void* arg) {
   WorkerArgs* w = arg;
+  int counted = 0;
   for (;;) {
     int* item = malloc(sizeof(int));
     *item = 0;
     napi_status st =
         napi_call_threadsafe_function(w->tsfn, item, napi_tsfn_nonblocking);
+    // Count this thread ONCE, on the first push to RETURN — whatever the
+    // status. The shim attributes the calling thread's claim under its own
+    // mutex before either the queue-full or the napi_closing early-return, so
+    // a returned push means this worker's initial claim is attributed;
+    // gating on napi_ok would under-count and reintroduce the race.
+    if (!counted) {
+      counted = 1;
+      atomic_fetch_add(&g_drain_pushers, 1);
+    }
     if (st != napi_ok) {
       free(item);
       if (st == napi_closing) break;
@@ -327,7 +371,10 @@ static napi_value HoldForeign(napi_env env, napi_callback_info info) {
     napi_throw_error(env, NULL, "create_threadsafe_function failed");
     return NULL;
   }
-  SpawnDetached(ParkWorker, tsfn, 0);
+  if (!SpawnDetached(ParkWorker, tsfn, 0)) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
   return NULL;
 }
 
@@ -338,21 +385,35 @@ static napi_value HoldDraining(napi_env env, napi_callback_info info) {
   napi_value argv[2];
   napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
   long threads = GetLongArg(env, argv[1]);
+  // Reset HERE, not in resetStats(): this is the one point at which no
+  // DrainWorker exists yet. Each worker counts itself exactly once and never
+  // again, so zeroing the counter under a live fan-out would strand it below
+  // `threads` forever and hang the readiness wait. A second holdDraining call
+  // in one process must keep this reset-before-spawn ordering.
+  atomic_store(&g_drain_pushers, 0);
   napi_threadsafe_function tsfn =
       MakeTsfn(env, argv[0], 0, (size_t)threads, NULL);
   if (tsfn == NULL) {
     napi_throw_error(env, NULL, "create_threadsafe_function failed");
     return NULL;
   }
-  for (long i = 0; i < threads; i++) SpawnDetached(DrainWorker, tsfn, 0);
+  for (long i = 0; i < threads; i++) {
+    if (!SpawnDetached(DrainWorker, tsfn, 0)) {
+      napi_throw_error(env, NULL, "pthread_create failed");
+      return NULL;
+    }
+  }
   return NULL;
 }
 
-// stats() → [delivered, dropped, floodFinalized, spinFinalized]
+// stats() → [delivered, dropped, floodFinalized, spinFinalized, drainPushers]
+// [4] is the only PER-THREAD figure here; [0] counts deliveries, which is not
+// the same question and must not be used as a stand-in for it (see
+// g_drain_pushers).
 static napi_value Stats(napi_env env, napi_callback_info info) {
   (void)info;
   napi_value result, v;
-  napi_create_array_with_length(env, 4, &result);
+  napi_create_array_with_length(env, 5, &result);
   napi_create_int64(env, atomic_load(&g_delivered), &v);
   napi_set_element(env, result, 0, v);
   napi_create_int64(env, atomic_load(&g_dropped), &v);
@@ -361,6 +422,8 @@ static napi_value Stats(napi_env env, napi_callback_info info) {
   napi_set_element(env, result, 2, v);
   napi_create_int64(env, atomic_load(&g_spin_finalized), &v);
   napi_set_element(env, result, 3, v);
+  napi_create_int64(env, atomic_load(&g_drain_pushers), &v);
+  napi_set_element(env, result, 4, v);
   return result;
 }
 

--- a/packages/napi/napi/test/tsfn-teardown-case.js
+++ b/packages/napi/napi/test/tsfn-teardown-case.js
@@ -89,8 +89,12 @@ switch (shape) {
         addon.resetStats();
         addon.holdDraining(cb, DRAIN_THREADS);
         // Wait until every worker has pushed at least once, so all N claims are
-        // attributed foreign when teardown starts.
-        if (!drainUntil(() => addon.stats()[0] >= DRAIN_THREADS)) throw new Error('draining: workers never got going');
+        // attributed foreign when teardown starts. Readiness must count claim
+        // OWNERS (stats()[4], distinct workers whose first push returned), NOT
+        // deliveries: stats()[0] is global, so >= N deliveries can come from
+        // fewer than N workers and leave a claim unattributed — a teardown the
+        // gate's table promises is silent then warns, correctly.
+        if (!drainUntil(() => addon.stats()[4] >= DRAIN_THREADS)) throw new Error('draining: workers never got going');
         break;
 
     default:

--- a/packages/napi/napi/test/tsfn-teardown-gate.mjs
+++ b/packages/napi/napi/test/tsfn-teardown-gate.mjs
@@ -20,6 +20,13 @@
 //   foreign     1, attributed foreign, parked   ~the 2 s deadline  warns
 //   draining    8, attributed foreign, live     fast               silent
 //
+// The "claims at teardown" column is a PRECONDITION the case establishes before
+// it returns, and for a row with more than one claim owner that means counting
+// OWNERS, not work done: `draining` waits on the addon's per-thread first-push
+// counter (stats()[4]), because the global delivery counter it used to read can
+// reach N from fewer than N workers — leaving a claim unattributed and failing
+// this gate's own `no warning` row against a runtime that is behaving correctly.
+//
 // `self` / `self-used` are the regression: a claim the JS thread will never hand
 // back cannot drain from inside a join the JS thread is blocked in, so before
 // per-claim owner attribution both burned the FULL 2 s deadline and then


### PR DESCRIPTION
The intermittent `Build & gates & conformance` red. Split out of #1033, where it appeared once and was deliberately left alone.

## The symptom

`test:gate:tsfn-teardown`'s `draining` row asserts a **silent** env teardown and sometimes warns instead:

```
  draining: teardown 6.0 / 5.2 / 4.8 ms
ok   draining: teardown does not wait (worst 6.0 ms < 500 ms)
FAIL draining: no warning
     gjsify-napi: threadsafe-function closed at env teardown with 1 of 1 outstanding
     claim(s) that nothing can hand back: 0 held by the thread running this teardown,
     1 never attributed to any thread …
```

## The runtime was right every time

`unattributed_claims` is written **once**, at creation (`src/cc/tsfn.cc:629`,
`= initial_thread_count`), and thereafter only ever decremented (`:196` in
`attribute_claim_locked`, `:245` in `retire_claim_locked`). There is no other write. It is
therefore monotonically non-increasing — so "1 never attributed" *proves* that one of the 8
DrainWorkers had not yet entered `napi_call_threadsafe_function` when teardown began. That is
deductive, not probabilistic, and no accounting error can produce it.

The `1 of 1` arithmetic that looks like a counter-argument is the confirmation. `outstanding`
is read after the join, by which point the other 7 workers have each retired their own claim
on their `napi_closing` push — hence 1, and hence a teardown that was still fast (4.8–6.0 ms,
no join timeout). With k late workers it would read `k of k`; I observed `3 of 3` and `2 of 2`
locally.

Suppressing the warning is the only runtime change that would green this row, and it would
also silence the `self` shape — which this same gate asserts *must* warn. `tsfn.cc:459` says
it outright: **"THE WARNINGS ARE NOT NOISE — DO NOT GATE OR REMOVE THEM."**

## The fixture is what was wrong

`tsfn-teardown-case.js` gated readiness on `addon.stats()[0] >= DRAIN_THREADS`, and
`stats()[0]` is `g_delivered` — a **global delivery counter** (`tsfn.c:25`, incremented in
`CallJs` at `:44`). Workers push on a 1 ms cadence, so a subset can produce 8 deliveries while
the others have not been scheduled once. The comment directly above it already claimed "every
worker has pushed at least once". The code never checked it.

So the gate was not merely flaky — on a warning run it was asserting against a shape that
never existed. I measured runs with as few as **5 of 8** workers actually holding attributed
claims.

## The fix: count claim owners, not work done

The addon tracks distinct DrainWorkers whose **first push has returned** — any status, because
the shim attributes the calling thread's claim under its own mutex *ahead of* both the
queue-full loop and the `napi_closing` early-return, so a returned push implies an attributed
claim. Gating on `napi_ok` would under-count and reintroduce the race. Exposed as `stats()[4]`.

Once all 8 are attributed, `unattributed_claims` is 0 and monotonicity means it can never rise
again: the join drains all 8, `thread_count` reaches 0, and teardown takes the silent delete
path. **By construction, not by scheduling luck.**

Also: `SpawnDetached` discarded `pthread_create`'s return. A worker that never starts leaves
its claim unattributed too, producing a byte-identical warning — silent, indistinguishable
from the race; loud, it names itself. All five call sites now report it.

## Verification

**Primary claim is the deductive one above.** The monotonicity invariant and the
attribution-before-return ordering were each read directly out of `src/cc/tsfn.cc`, not
inferred.

**Empirical corroboration** — A/B under `systemd-run --user --scope -p AllowedCPUs=0
-p CPUQuota=<q>`, the *same* `tsfn.node` in both arms with only the JS predicate differing, so
the comparison isolates exactly the change:

| quota | arm | warned |
|---|---|---|
| 15% | OLD `stats()[0]` | 1/120 |
| 15% | NEW `stats()[4]` | 0/120 |
| 8%  | OLD `stats()[0]` | 3/250 |
| 8%  | NEW `stats()[4]` | 0/250 |
| (independent earlier run, 15%) | OLD | 3/80 — incl. `delivered=8 pushers=7 → "1 of 1"`, the CI signature verbatim |
| (independent earlier run, 15%) | NEW | 0/230 |

Totals: **OLD 7/450 (~1.6%), NEW 0/600.** The old arm reproducing matters as much as the new
one passing — without it, "0 failures" would only mean the harness was insensitive.

Full gate passes all five shapes, with `foreign` still burning the 2 s deadline (the row a
"just skip the join" fix would break). `gjs test/p1-tsfn-gate.js` unaffected — `stats()`
growing 4 → 5 elements is safe; no caller checks its length.

**Both platforms confirmed in CI on this PR** (run 31154145783): `Gate — tsfn env-teardown
claim attribution` is **success on `macos-latest arm64`** — the patched addon compiles under
node-gyp on Darwin and the gate passes there — and `Build & gates & conformance (GJS /
Fedora 44)`, the job that was flaking, is green.

**What this does not establish, stated plainly:**
- The CI failure *rate* was not measured. One green run on a ~1-in-3 intermittent is weak
  evidence on its own; the claim rests on the monotonicity argument, with the local A/B as
  corroboration. The local rates come from an artificial cgroup quota on one machine and are
  **not** the Fedora-44 runner's rate — 0/600 locally cannot prove absence there. To measure
  it properly: `npm run test:gate:tsfn-teardown -- --runs=25` on the pre- and post-patch tree
  in the container (note this also multiplies the `foreign` row's deliberate 2 s burn).
- It does not prove the runtime is bug-free. It proves this row now asserts against the shape
  it names.

No timeout widened, no assertion dropped, no retry added, `src/cc/tsfn.cc` untouched.

## The diagnostic this leaves behind

If `draining` ever warns again, it is **not** this race — `stats()[4]` guarantees all 8 claims
were attributed before teardown started. Treat it as a genuine runtime regression, and
`printerr(addon.stats()[4])` in the case tells you which within one run.

## Two things found on the way, deliberately not fixed here

- The teardown warning tells the truth about the counters but **overstates the consequence**
  for the unattributed bucket: it says the control block "leaks for the process lifetime",
  while a straggler arriving just after can still free it (`tsfn.cc:678-682`). Wording only —
  but anyone fixing it must update `tsfn-teardown-gate.mjs:74` in the same commit, because the
  `self` row matches on `/nothing can hand back/`.
- `attribute_claim_locked` (`:190-195`) dedups on raw, unrefed `GThread*` pointers, and GLib
  frees a foreign thread's dummy `GRealThread` at thread exit — address reuse could in
  principle make a fresh thread look already-seen. Unreachable in `draining` (no worker exits
  before teardown) and bounded to the window where `unattributed_claims > 0`. `g_thread_ref`
  on the vector entries would close it.
