### PR TITLE
fix(cli): escape raw NUL in the gjs bundle

### DIFF
--- a/packages/infra/cli/src/actions/build.ts
+++ b/packages/infra/cli/src/actions/build.ts
@@ -14,11 +14,12 @@ import {
 import { pnpPlugin } from '@gjsify/rolldown-plugin-pnp';
 import { dirname, extname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { chmod, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { normalizeBundlerOptions, mergeBundlerOptions } from '../utils/normalize-bundler-options.js';
 import { inputSourceDirs, isOutdirInsideSource, libraryOutputLeakError } from '../utils/library-output.js';
 import { detectHtmlEntry, parseHtmlEntry, emitBrowserHtml, htmlOutPathFor } from '../utils/html-entry.js';
 import { assertGjsBundleLoadable } from '../utils/gjs-bundle-guard.js';
+import { escapeRawNulForGjs } from '../utils/gjs-source-escape.js';
 import { assertNodeBundleGlobalsShimmed } from '../utils/node-bundle-guard.js';
 
 const DEFAULT_GJS_SHEBANG = '#!/usr/bin/env -S gjs -m';
@@ -308,6 +309,66 @@ export class BuildAction {
         }
         await chmod(outfile, 0o755);
         if (verbose) console.debug(`[gjsify] --shebang: wrote ${line} + chmod 0o755 to ${outfile}`);
+    }
+
+    /**
+     * Post-bundle rewrite for `--app gjs`: replace raw U+0000 bytes with `\x00`.
+     *
+     * GJS hands module source to SpiderMonkey as a NUL-terminated C string, so one raw NUL
+     * truncates the file and the loader reports whatever construct was open — typically
+     * "`` literal not terminated before end of script", which names neither the NUL nor its
+     * location. The minifier produces them by inlining a `'\u0000'` constant into a template
+     * literal, so a bundle can build and run unminified and fail under the default `--minify`.
+     *
+     * Rewrites the files on disk rather than the in-memory chunks: rolldown has already
+     * written them by this point, and the same treatment has to reach every chunk of an
+     * `--outdir` build, not just a single `--outfile`.
+     */
+    private async escapeRawNul(
+        outfile: string | undefined,
+        outdir: string | undefined,
+        verbose: boolean | undefined,
+    ): Promise<void> {
+        // Deliberately NOT driven by the chunk graph: `--watch`'s BUNDLE_END carries the bundle
+        // rather than the generated output, and re-running generate() just to list chunks would
+        // double every rebuild. Reading the directory needs neither, so the same hook serves the
+        // one-shot build and the watch loop — and a watch rebuild that quietly reintroduced the
+        // raw NUL would fail exactly like the bug this exists to prevent, only intermittently.
+        const targets: string[] = [];
+        if (outfile) {
+            targets.push(outfile);
+        } else if (outdir) {
+            try {
+                for (const name of await readdir(outdir)) {
+                    if (name.endsWith('.mjs') || name.endsWith('.js')) targets.push(resolve(outdir, name));
+                }
+            } catch (err) {
+                // ENOENT alone is benign — a watch pass that failed before writing anything has
+                // no outdir yet, and there is nothing to escape. Anything ELSE (a permissions
+                // error, an I/O error, a wrong outdir) would silently skip the escape and let
+                // the build report success while emitting a bundle GJS cannot load, which is
+                // precisely the failure this hook exists to prevent.
+                if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return;
+                throw err;
+            }
+        }
+        for (const target of targets) {
+            let original: string;
+            try {
+                original = await readFile(target, 'utf-8');
+            } catch (err) {
+                // Same split: a listed-but-unwritten chunk is not this hook's problem; a real
+                // read failure must not pass for "nothing to do".
+                if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') continue;
+                throw err;
+            }
+            const { code, replaced } = escapeRawNulForGjs(original);
+            if (replaced === 0) continue; // the overwhelmingly common case — touch nothing
+            await writeFile(target, code);
+            if (verbose) {
+                console.debug(`[gjsify] escaped ${replaced} raw NUL byte(s) in ${target} so GJS can load it`);
+            }
+        }
     }
 
     /**
@@ -736,11 +797,18 @@ export class BuildAction {
         };
 
         if (opts.watch) {
-            await this.runWatchLoop(finalOpts, app, outfile, verbose);
+            await this.runWatchLoop(finalOpts, app, outfile, outdir, verbose);
             return [];
         }
 
         const writeResult = await runBundle(finalOpts);
+
+        // GJS truncates module source at a raw U+0000 (it is handed to SpiderMonkey as a
+        // NUL-terminated C string), so escape any the minifier emitted before anything else
+        // touches the file. See utils/gjs-source-escape.ts.
+        if (app === 'gjs') {
+            await this.escapeRawNul(outfile, outdir, verbose);
+        }
 
         if ((app === 'gjs' || app === 'node') && this.configData.shebang) {
             await this.applyShebang(app, outfile, verbose);
@@ -780,6 +848,7 @@ export class BuildAction {
         finalOpts: BundlerOptions,
         app: App,
         outfile: string | undefined,
+        outdir: string | undefined,
         verbose: boolean | undefined,
     ): Promise<void> {
         const watcher = await runWatch(finalOpts);
@@ -813,6 +882,12 @@ export class BuildAction {
                 case 'BUNDLE_END':
                     console.log(`[gjsify build --watch] built in ${event.duration}ms`);
                     try {
+                        // Before the shebang, which re-reads the file: a rebuild that dropped a
+                        // raw NUL back in would produce a bundle GJS cannot load, and on the
+                        // watch loop that reads as "it broke when I saved", not as a build bug.
+                        if (app === 'gjs') {
+                            await this.escapeRawNul(outfile, outdir, verbose);
+                        }
                         if ((app === 'gjs' || app === 'node') && this.configData.shebang) {
                             await this.applyShebang(app, outfile, verbose);
                         }

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -76,6 +76,7 @@ import runtimesSuite from './utils/runtimes.spec.js';
 import spawnSuite from './utils/spawn.spec.js';
 import win32CommandSuite from './utils/win32-command.spec.js';
 import gjsBundleGuardSuite from './utils/gjs-bundle-guard.spec.js';
+import gjsSourceEscapeSuite from './utils/gjs-source-escape.spec.js';
 import nodeBundleGuardSuite from './utils/node-bundle-guard.spec.js';
 import unresolvedWorkspaceImportSuite from './unresolved-workspace-import.spec.js';
 
@@ -241,6 +242,7 @@ run(
         spawnSuite,
         win32CommandSuite,
         gjsBundleGuardSuite,
+        gjsSourceEscapeSuite,
         nodeBundleGuardSuite,
         unresolvedWorkspaceImportSuite,
     },

--- a/packages/infra/cli/src/utils/gjs-source-escape.spec.ts
+++ b/packages/infra/cli/src/utils/gjs-source-escape.spec.ts
@@ -1,0 +1,77 @@
+// A raw U+0000 in a `--app gjs` bundle truncates the module: GJS hands source to SpiderMonkey
+// as a NUL-terminated C string, so the loader reports whatever construct was still open —
+// "`` literal not terminated before end of script" — naming neither the NUL nor its location.
+//
+// Every NUL below is written as an escape (String.fromCharCode(0) / '\u0000'), never as a raw
+// byte, so this spec file cannot itself become the thing it tests for.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { escapeRawNulForGjs } from './gjs-source-escape.js';
+
+const NUL = String.fromCharCode(0);
+
+export default async () => {
+    await describe('gjs-source-escape: escapeRawNulForGjs', async () => {
+        await it('leaves code without a NUL completely untouched', () => {
+            // The overwhelmingly common case — the caller skips writing the file entirely.
+            const code = 'export function f(){return`hello ${x}`}\n';
+            const result = escapeRawNulForGjs(code);
+            expect(result.replaced).toBe(0);
+            expect(result.code).toBe(code);
+        });
+
+        await it('escapes a raw NUL inside a template literal', () => {
+            // The exact shape the minifier emits when it inlines a '\u0000' constant.
+            const result = escapeRawNulForGjs('function p(e){return`' + NUL + '${e}' + NUL + '`}');
+            expect(result.replaced).toBe(2);
+            expect(result.code).toBe('function p(e){return`\\x00${e}\\x00`}');
+            expect(result.code.includes(NUL)).toBe(false);
+        });
+
+        await it('escapes a raw NUL inside a plain string', () => {
+            const result = escapeRawNulForGjs("const P='" + NUL + "'");
+            expect(result.replaced).toBe(1);
+            expect(result.code).toBe("const P='\\x00'");
+        });
+
+        await it('counts and replaces every occurrence', () => {
+            const result = escapeRawNulForGjs(NUL + 'a' + NUL + 'b' + NUL);
+            expect(result.replaced).toBe(3);
+            expect(result.code).toBe('\\x00a\\x00b\\x00');
+        });
+
+        await it('emits \\x00 rather than \\0, which a following digit would break', () => {
+            // `\0` is only NUL when NOT followed by a digit; `\01` is a legacy octal escape and a
+            // SyntaxError in a template literal and under strict mode. A digit right after the
+            // marker is exactly the shape that triggered this (`\0${index}\0` minifies with the
+            // index adjacent), so `\0` would trade one unloadable bundle for another.
+            const result = escapeRawNulForGjs(NUL + '1');
+            expect(result.code).toBe('\\x001');
+            // The dangerous output would be `\01`, which a JS parser reads as an octal escape.
+            expect(result.code.startsWith('\\0')).toBe(false);
+        });
+
+        await it('produces an escape that denotes exactly U+0000', () => {
+            // The whole point: the emitted source must still evaluate to the same character, or the
+            // marker it stands for silently changes meaning. Decoded the way a JS parser reads a
+            // `\xNN` escape — JSON.parse cannot be the oracle here, as JSON has no `\x` form.
+            const result = escapeRawNulForGjs(NUL);
+            const match = /^\\x([0-9a-fA-F]{2})$/.exec(result.code);
+            expect(match === null).toBe(false);
+            expect(String.fromCharCode(Number.parseInt(match?.[1] ?? 'ff', 16))).toBe(NUL);
+        });
+
+        await it('does not disturb other control characters', () => {
+            // Only NUL truncates a C string; tabs and newlines are legal and load fine, so
+            // rewriting them would be churn on every bundle for no reason.
+            const code = 'a\tb\nc';
+            expect(escapeRawNulForGjs(code).code).toBe(code);
+            expect(escapeRawNulForGjs(code).replaced).toBe(0);
+        });
+
+        await it('handles an empty input', () => {
+            expect(escapeRawNulForGjs('').replaced).toBe(0);
+            expect(escapeRawNulForGjs('').code).toBe('');
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/gjs-source-escape.ts
+++ b/packages/infra/cli/src/utils/gjs-source-escape.ts
@@ -1,0 +1,50 @@
+// Build-time rewrite: a `--app gjs` bundle must not contain a raw U+0000 byte.
+//
+// GJS hands module source to SpiderMonkey as a NUL-TERMINATED C string, so a raw
+// U+0000 in the emitted file truncates it at that point. Everything after is
+// silently discarded and the error names whatever construct happened to be open
+// when the text ran out:
+//
+//   SyntaxError: `` literal not terminated before end of script
+//
+// which points at the wrong place entirely and never mentions a NUL.
+//
+// This is easy to hit and hard to diagnose. `'\u0000'` in TypeScript source is an
+// ESCAPE — six harmless ASCII characters — but the minifier is free to inline the
+// constant and emit the CHARACTER:
+//
+//   const P = '\u0000'; … return `${P}${i}${P}`   // source: escaped, loads fine
+//   … return`<NUL>${e}<NUL>`                      // minified: raw byte, will not load
+//
+// so the same code builds and runs unminified and breaks under `--minify`, which is
+// the default. A real consumer hit exactly this with an IMAP literal marker — NUL
+// being the one byte that cannot occur in IMAP response text is precisely why it
+// was chosen as the marker.
+//
+// Node and browsers load a raw NUL in source without complaint (U+0000 is a legal
+// source character per the spec), so no other target notices and nothing upstream
+// is going to change. Escaping it on the way out is gjsify's job.
+//
+// The rewrite is safe as a plain text substitution: in valid JS a raw NUL can only
+// appear inside a string, a template literal, a regex or a comment, and `\x00`
+// denotes exactly U+0000 in all four — so the meaning is preserved wherever it sits.
+//
+// `\x00` and NOT `\0`: `\0` followed by a digit is a legacy octal escape, which is a
+// SyntaxError in a template literal and under strict mode. A digit right after the
+// marker is exactly the shape that triggered this (`\0${index}\0`), so `\0` would
+// trade one unloadable bundle for another.
+
+/**
+ * Replace every raw U+0000 in `code` with the `\x00` escape.
+ *
+ * Returns the rewritten code and how many were replaced, so the caller can skip
+ * writing the file (and reporting) in the overwhelmingly common zero case.
+ */
+export function escapeRawNulForGjs(code: string): { code: string; replaced: number } {
+    // split/join rather than a regex: a NUL inside a regex is exactly what oxlint's
+    // `no-control-regex` exists to flag, and the rule is right in general even though this use
+    // is deliberate. Building the needle with fromCharCode also keeps THIS file free of the raw
+    // byte it exists to remove.
+    const parts = code.split(String.fromCharCode(0));
+    return { code: parts.join('\\x00'), replaced: parts.length - 1 };
+}


### PR DESCRIPTION
GJS hands module source to SpiderMonkey as a **NUL-terminated C string**, so one raw U+0000 in the emitted file truncates it there. Everything after is silently discarded and the loader reports whatever construct was still open:

```
SyntaxError: `` literal not terminated before end of script
```

which points at the wrong place and never mentions a NUL.

### Why it is easy to hit and hard to place

It only appears in a **release** build. A `<NUL>` escape in TypeScript is six harmless ASCII characters, but the minifier may inline the constant and emit the *character*:

```js
const P = '<NUL>'; … return `${P}${i}${P}`   // source: escaped, loads fine
… return`<NUL>${e}<NUL>`                      // minified: raw byte, will not load
```

So the same code runs unminified and breaks under `--minify`, which is the default. The consumer that hit it uses NUL as an IMAP literal marker — chosen precisely because it is the one byte that cannot occur in IMAP response text.

Node and browsers load a raw NUL in source without complaint (U+0000 is a legal source character per the spec), so no other target notices and nothing upstream is going to change. Escaping on the way out belongs in gjsify, beside the other `--app gjs` post-bundle hooks, rather than in every consumer.

### The substitution

Safe as plain text: in valid JS a raw NUL can only sit inside a string, a template literal, a regex or a comment, and `\x00` denotes exactly U+0000 in all four.

**`\x00` and not `\0`** — a `\0` followed by a digit is a legacy octal escape (a SyntaxError in a template literal and under strict mode), and a digit right after the marker is exactly the shape that triggered this (`\0${index}\0`).

Implemented with `split`/`join` rather than a regex: a NUL in a regex is what oxlint's `no-control-regex` exists to flag, and the rule is right in general even though this use would be deliberate.

### Scope details

- **Runs on `--watch` too**, not only the one-shot build. It needs no chunk graph, so the same hook serves both — and a rebuild that quietly reintroduced the NUL would fail exactly like the original bug, but intermittently and on save, which is much harder to place.
- **Only ENOENT is tolerated** when listing or reading the output. A missing outdir on a failed first watch pass is benign; a permissions or I/O error must not pass for "nothing to do" and let the build report success while emitting a bundle GJS cannot load.
- **Zero cost when there is nothing to do** — a bundle with no NUL is not rewritten.

### Verification

End-to-end on the consumer's real bundle: before, GJS refuses it; after escaping, GJS loads it **and the consumer's full suite passes — 568 tests**, including every IMAP literal-placeholder case, which is exactly what the escape had to preserve.

Plus 8 unit tests here. Every NUL in them is built with `String.fromCharCode(0)` so the spec cannot become the thing it tests for.

CLI suite green on Node (1970). Repo-wide lint and format clean. The committed `dist/affected.gjs.mjs` reproduces from this source unchanged (`affected-entry` does not reach `actions/build.ts`), verified by running the same chain CI does.

---

*Split out of #1035, which also carried `@gjsify/fs` changes. Those turned out to need a deliberate redesign of fd-offset and permission semantics rather than a drive-by fix — see that PR for the two review reports. This half is self-contained and independent of it.*
