### PR TITLE
fix(cli): make gjsify tsc fail when it fails

### DIFF
--- a/packages/infra/cli/src/commands/install.ts
+++ b/packages/infra/cli/src/commands/install.ts
@@ -32,7 +32,7 @@ import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, rmSync, syml
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { gjsExit } from '@gjsify/rolldown-plugin-gjsify/runtime';
+import { forceExit } from '../utils/force-exit.js';
 import { discoverWorkspaces } from '@gjsify/workspace';
 import type { Command } from '../types/index.js';
 import { buildInstallCommand, detectPackageManager, runMinimalChecks } from '../utils/check-system-deps.js';
@@ -406,21 +406,6 @@ function isAbortedFromOverallTimeout(err: unknown): boolean {
     // the overall budget but typically the symptom the overall timer reports.
     if (name === 'RegistryTimeoutError') return true;
     return false;
-}
-
-/**
- * Force a non-zero process exit that is honored on BOTH runtimes.
- *
- * Node exits at natural shutdown once `process.exitCode` is set, but GJS has
- * no atexit hook, so `imports.system.exit` is called directly there —
- * SpiderMonkey raises its uncatchable exit exception from any context,
- * including the `setTimeout` continuation the backstop timer runs in. Mirrors
- * the entry wrapper (`index.ts`) and `setOxcExitCode` (`oxc-resolve.ts`).
- */
-function forceExit(code: number): void {
-    process.exitCode = code;
-    if (gjsExit(code)) return;
-    process.exit(code);
 }
 
 const CLI_PACKAGE_NAME = '@gjsify/cli';

--- a/packages/infra/cli/src/commands/tsc.ts
+++ b/packages/infra/cli/src/commands/tsc.ts
@@ -24,6 +24,7 @@ import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { Command } from '../types/index.js';
 import { detectNativePackages, buildNativeEnv } from '../utils/detect-native-packages.js';
+import { forceExit } from '../utils/force-exit.js';
 import { nodeBinary } from '../utils/run-node.js';
 import { findWorkspaceRoot } from '../utils/workspace-root.js';
 
@@ -115,9 +116,12 @@ export const tscCommand: Command<unknown, TscOptions> = {
         if (!bundlePath && !nodeTscPath) {
             console.error('gjsify tsc: neither @gjsify/tsc (GJS bundle) nor npm `typescript` (Node) is installed.');
             console.error('  Install with: gjsify install --save-dev @gjsify/tsc   (or add `typescript`).');
-            // `return` — a bare `process.exit()` is deferred under GJS and the
-            // handler would try to spawn a compiler that is not there.
-            return process.exit(1);
+            // `return` — the handler must not fall through and try to spawn a
+            // compiler that is not there. `forceExit` and not `process.exit`
+            // because the latter is idle-scheduled under GJS, and NOTHING here
+            // armed a main loop to deliver it: the process would reach natural
+            // shutdown and report 0 while printing the message above.
+            return forceExit(1);
         }
 
         // Mirror `gjsify run`'s native-env composition so any future
@@ -148,7 +152,7 @@ export const tscCommand: Command<unknown, TscOptions> = {
         // this CLI already routes through it.
         const runNodeTsc = (): void => {
             const child = spawn(nodeBinary(), [nodeTscPath as string, ...tscArgs], { env, stdio: 'inherit' });
-            child.on('close', (code) => process.exit(code ?? 1));
+            child.on('close', (code) => forceExit(code ?? 1));
             child.on('error', (err: NodeJS.ErrnoException) => {
                 if (err.code === 'ENOENT') {
                     console.error(
@@ -159,7 +163,7 @@ export const tscCommand: Command<unknown, TscOptions> = {
                 } else {
                     console.error(`gjsify tsc (node typescript): ${err.message}`);
                 }
-                process.exit(1);
+                forceExit(1);
             });
         };
 
@@ -179,7 +183,7 @@ export const tscCommand: Command<unknown, TscOptions> = {
             await new Promise<void>((resolvePromise) => {
                 child.on('close', (code) => {
                     if (gjsSpawnFailed) return;
-                    process.exit(code ?? 1);
+                    forceExit(code ?? 1);
                 });
                 child.on('error', (err: NodeJS.ErrnoException) => {
                     gjsSpawnFailed = true;
@@ -189,10 +193,10 @@ export const tscCommand: Command<unknown, TscOptions> = {
                     } else if (err.code === 'ENOENT') {
                         console.error('gjsify tsc: `gjs` not found on PATH and no npm `typescript` fallback.');
                         console.error('  Install GJS (e.g. `dnf install gjs`), or add `typescript` to the project.');
-                        process.exit(1);
+                        forceExit(1);
                     } else {
                         console.error(`gjsify tsc: ${err.message}`);
-                        process.exit(1);
+                        forceExit(1);
                     }
                 });
                 // Never resolves naturally — process.exit() above terminates the

--- a/packages/infra/cli/src/commands/tsc.ts
+++ b/packages/infra/cli/src/commands/tsc.ts
@@ -24,6 +24,8 @@ import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { Command } from '../types/index.js';
 import { detectNativePackages, buildNativeEnv } from '../utils/detect-native-packages.js';
+import { isOnPath } from '../utils/check-system-deps.js';
+import { existsSync } from 'node:fs';
 import { forceExit } from '../utils/force-exit.js';
 import { nodeBinary } from '../utils/run-node.js';
 import { findWorkspaceRoot } from '../utils/workspace-root.js';
@@ -151,7 +153,30 @@ export const tscCommand: Command<unknown, TscOptions> = {
         // `run-node.ts` owns the one correct answer; every other spawn site in
         // this CLI already routes through it.
         const runNodeTsc = (): void => {
-            const child = spawn(nodeBinary(), [nodeTscPath as string, ...tscArgs], { env, stdio: 'inherit' });
+            const nodeBin = nodeBinary();
+            // PRE-FLIGHT, deliberately NOT the spawn's `'error'` event.
+            //
+            // Under the GJS bundle that event is not delivered when the program
+            // is missing: the handler below never runs, the command returns
+            // normally, and `gjsify tsc` exits **0 in total silence** having
+            // compiled nothing. Measured in CI by `tests/e2e/tsc-node-fallback`'s
+            // "FAILS LOUDLY …" case, whose assertion printed an EMPTY captured
+            // output — no stderr at all, so nothing had reported anything.
+            //
+            // Deciding it here, synchronously, is what makes the failure
+            // reportable: the exit happens on the caller's own stack rather than
+            // in a continuation that may never be scheduled.
+            const runnable = nodeBin.includes('/') || nodeBin.includes('\\') ? existsSync(nodeBin) : isOnPath(nodeBin);
+            if (!runnable) {
+                console.error(
+                    `gjsify tsc: the @gjsify/tsc GJS bundle is unavailable and \`${nodeBin}\` cannot be run, ` +
+                        'so upstream `typescript` cannot run either.',
+                );
+                console.error('  Build the bundle with: gjsify workspace @gjsify/tsc build');
+                console.error('  …or install Node.js so the upstream `typescript` fallback can be spawned.');
+                return forceExit(1);
+            }
+            const child = spawn(nodeBin, [nodeTscPath as string, ...tscArgs], { env, stdio: 'inherit' });
             child.on('close', (code) => forceExit(code ?? 1));
             child.on('error', (err: NodeJS.ErrnoException) => {
                 if (err.code === 'ENOENT') {

--- a/packages/infra/cli/src/utils/check-system-deps.ts
+++ b/packages/infra/cli/src/utils/check-system-deps.ts
@@ -62,7 +62,7 @@ function tryExecFile(binary: string, args: string[]): string | null {
  * reason. It stays a second copy on purpose: it is `.mjs` under `tests/` and
  * cannot be imported from the shipped CLI.
  */
-function isOnPath(cmd: string): boolean {
+export function isOnPath(cmd: string): boolean {
     const pathVar = process.env.PATH;
     if (!pathVar) return false;
     const sep = process.platform === 'win32' ? ';' : ':';

--- a/packages/infra/cli/src/utils/force-exit.ts
+++ b/packages/infra/cli/src/utils/force-exit.ts
@@ -1,0 +1,44 @@
+// The one way to end the CLI with a chosen exit code on BOTH runtimes.
+//
+// Node exits at natural shutdown once `process.exitCode` is set. GJS does not:
+// it has no atexit hook, and `process.exit()` there is not immediate — its
+// `exitProcess` IDLE-SCHEDULES `quitMainLoop()` + `imports.system.exit()` (see
+// `utils/spawn.ts` for the main-loop machinery this rides on). From inside an
+// asynchronous continuation — a `child.on('close'|'error')` handler, a
+// `setTimeout`, a promise callback — that idle can lose the race with the
+// module's own shutdown, and gjs then exits **0** no matter what code was
+// requested. `imports.system.exit` has no such gap: SpiderMonkey raises its
+// uncatchable exit exception from any context.
+//
+// This is not theoretical. `gjsify tsc` spawned the compiler and ended both its
+// `close` and `error` handlers with a bare `process.exit(…)`. Under the GJS
+// bundle every one of those exits was dropped, so the command reported SUCCESS
+// whatever the compiler did — a type error exited 0, and so did "no compiler
+// could be spawned at all". A release-cut on a cold tree then ran
+// `node scripts/process-template.mjs && gjsify tsc && node scripts/set-bin-mode.mjs`
+// to completion and died in `set-bin-mode.mjs` on a `lib/index.js` that `tsc`
+// had never written — pointing the blame two steps past the actual failure.
+//
+// Two copies of this logic already existed (`commands/install.ts`'s local
+// `forceExit`, `utils/oxc-resolve.ts`'s `setOxcExitCode`) and a third call site
+// simply did without. One exported helper is the point: a new async exit path
+// gets it right by importing it rather than by remembering the rule.
+
+import { gjsExit } from '@gjsify/rolldown-plugin-gjsify/runtime';
+
+/**
+ * Exit the process with `code`, honoured on Node and GJS alike.
+ *
+ * Safe to call from any context, including an async callback where a bare
+ * `process.exit()` would be dropped under GJS. Does not return.
+ *
+ * `process.exitCode` is set FIRST so that a host which somehow reaches natural
+ * shutdown anyway still reports the right code.
+ */
+export function forceExit(code: number): never {
+    process.exitCode = code;
+    // Under GJS this does not return — `imports.system.exit` unwinds via
+    // SpiderMonkey's uncatchable exit exception.
+    if (gjsExit(code)) return undefined as never;
+    return process.exit(code);
+}

--- a/tests/e2e/tsc-node-fallback/run.mjs
+++ b/tests/e2e/tsc-node-fallback/run.mjs
@@ -195,7 +195,7 @@ describe('gjsify tsc — Node fallback under a GJS-hosted CLI', { skip: SKIP, ti
         );
         assert.match(
             output,
-            /not on PATH|cannot run|not found/i,
+            /not on PATH|cannot (be )?run|not found/i,
             `expected a diagnosis naming the missing interpreter, got:\n${output}`,
         );
     });

--- a/tests/e2e/tsc-node-fallback/run.mjs
+++ b/tests/e2e/tsc-node-fallback/run.mjs
@@ -73,11 +73,12 @@ describe('gjsify tsc — Node fallback under a GJS-hosted CLI', { skip: SKIP, ti
     let bundleCopy;
 
     /** Run the GJS-hosted CLI: `gjs -m <copied bundle> tsc <args…>` in projectDir. */
-    function runGjsifyTsc(args) {
+    function runGjsifyTsc(args, env) {
         const r = spawnSync('gjs', ['-m', bundleCopy, 'tsc', ...args], {
             cwd: projectDir,
             encoding: 'utf-8',
             stdio: ['ignore', 'pipe', 'pipe'],
+            ...(env ? { env } : {}),
         });
         return { code: r.status, output: `${r.stdout ?? ''}${r.stderr ?? ''}` };
     }
@@ -164,5 +165,38 @@ describe('gjsify tsc — Node fallback under a GJS-hosted CLI', { skip: SKIP, ti
         // Bare code, not `error TS2322`: tsc inserts ANSI escapes between the
         // two when it detects colour support (see tests/e2e/self-host-tsc).
         assert.match(output, /TS2322/, `expected TS2322, got:\n${output}`);
+    });
+
+    // The path NOTHING covered before, and the one that shipped broken.
+    //
+    // The two cases above exercise `child.on('close')` — the child RAN, so the
+    // async spawn armed the GLib main loop and the idle-scheduled
+    // `process.exit()` was delivered. When the spawn itself FAILS there is no
+    // child and no armed loop, so that idle never runs: the CLI printed its
+    // diagnosis and then exited **0**.
+    //
+    // That is not a cosmetic exit code. `@gjsify/create-app`'s build is
+    // `node scripts/process-template.mjs && gjsify tsc && node scripts/set-bin-mode.mjs`,
+    // so a 0 here runs `set-bin-mode.mjs` against a `lib/index.js` tsc never
+    // wrote — which is how a release-cut on a cold tree failed pointing two
+    // steps past the real fault. `ci-fedora` ships no node, and the Node
+    // fallback is the NORMAL path on a cold tree, so this is reachable in CI.
+    it('FAILS LOUDLY when the compiler cannot be spawned at all (no node on PATH)', () => {
+        writeFileSync(join(projectDir, 'src', 'index.ts'), 'export const answer: number = 42;\n');
+        // A PATH that still resolves `gjs` (the host we are launching) but not
+        // `node` (the interpreter the fallback needs), so the spawn raises
+        // ENOENT instead of the child failing.
+        const gjsDir = dirname(spawnSync('sh', ['-c', 'command -v gjs'], { encoding: 'utf-8' }).stdout.trim());
+        const { code, output } = runGjsifyTsc(['-p', 'tsconfig.json'], { ...process.env, PATH: gjsDir });
+        assert.notEqual(
+            code,
+            0,
+            `gjsify tsc reported SUCCESS while producing nothing — the deferred exit was dropped:\n${output}`,
+        );
+        assert.match(
+            output,
+            /not on PATH|cannot run|not found/i,
+            `expected a diagnosis naming the missing interpreter, got:\n${output}`,
+        );
     });
 });


### PR DESCRIPTION
Found while diagnosing why the **v0.31.0 release-cut dry run failed**.

## What breaks

`gjsify tsc` ends all six of its exit paths with a bare `process.exit()`. Under GJS that is **idle-scheduled** — `exitProcess` queues `quitMainLoop()` + `imports.system.exit()` — so from a `child.on('close'|'error')` handler it can lose the race with the module's own shutdown and the process reports **0** whatever was asked for.

## Why the release-cut died two steps past the fault

`@gjsify/create-app`'s build is an `&&` chain:

```
node scripts/process-template.mjs && gjsify tsc && node scripts/set-bin-mode.mjs
```

In [the failed run](https://github.com/gjsify/gjsify/actions/runs/31177657929) `gjsify tsc` printed `spawn … ENOENT` five times **and `set-bin-mode.mjs` still ran** — which in an `&&` chain is only possible if tsc exited 0. It then died on a `lib/index.js` that tsc had never written, so the error named `set-bin-mode.mjs` while the fault was one link earlier.

This path is reachable in CI by construction: `ghcr.io/gjsify/ci-fedora:44` ships **no node** (verified by running the image), and `tsc.ts`'s own comment calls the Node fallback "the NORMAL path" on a cold tree, since `@gjsify/tsc`'s bundle is a build output that `build:infra` produces only later.

Related, and why it went unnoticed until now: the cold-tree bootstrap step in `release-cut.yml` arrived with #1019 (ADR 0002) on 2026-08-06, while v0.30.0 was cut on 2026-08-05. **No release has ever gone through it.**

## The fix

The repo already had the rule and two copies of it — `utils/spawn.ts` documents the main-loop machinery, `gjsExit()` exists for precisely this ("GJS has no atexit hook and would exit 0 at natural shutdown, so a non-zero `process.exitCode` alone does not stick"), and both `install.ts::forceExit` and `oxc-resolve.ts::setOxcExitCode` implement it locally. `tsc.ts` had none of it.

Hoisted into `utils/force-exit.ts` and used at all six sites, so the next async exit path gets it right by importing rather than by remembering. `install.ts` delegates instead of carrying copy three; `setOxcExitCode` is left alone (different contract — it deliberately does not exit on Node).

## The test gap this closes

`tests/e2e/tsc-node-fallback` already asserted a non-zero exit for a type error — and passes. It only ever exercised `child.on('close')`: the child RAN, so the async spawn had armed the main loop and the deferred exit was delivered. **Nothing covered a spawn that FAILS**, where there is no child and no armed loop. Added that case, with a PATH that resolves `gjs` but not `node`.

## What is proven, and what is not

**Proven:**
- tsc exited 0 in CI while reporting failure — the `&&` chain reaching `set-bin-mode.mjs` cannot happen otherwise.
- `ci-fedora:44` has no node (`command -v node` → empty in the image).
- `isGjs()` is NOT the culprit: measured inside that image, `imports.gi` is present and `isGjs()` returns `true` (gjs 1.88.1, same as the host).
- The existing e2e's coverage boundary, read from its own assertions.

**Not proven:** I could not reproduce the silent exit locally. Runs against the unmodified v0.30.0 bundle with `node` off PATH and no `@gjsify/tsc` bundle present still compiled and exited 0 *successfully*, so some path I have not yet identified served the compile. The fix rests on the documented GJS exit semantics and the CI evidence, not on a local before/after.

**The verification that settles it** is a re-run of the release-cut dry run once this lands: either it gets past `@gjsify/create-app`, or it now fails AT tsc with a diagnosis instead of at `chmod`. Both outcomes are progress; the second is the one this PR promises.

Not fixed here, and worth its own change: `@gjsify/child_process`'s spawn error does not carry `err.code`, so `tsc.ts`'s dedicated ENOENT branch ("`node` is not on PATH") never fires and the vaguer `else` message is printed instead. That is why the CI log named the bootstrap bundle rather than the missing interpreter.
