### PR TITLE
ci(release): bootstrap a cold tree under Node

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -139,6 +139,21 @@ jobs:
       # mechanism napi.yml already uses for the same reason, down to the shared
       # `install-published-cli.sh` (which retries through the window where a release
       # has bumped every package.json but npm does not serve the version yet).
+      #
+      # TEMPORARY, AND MEANT TO BE REVERTED. The project's direction is to run as
+      # much as possible ON gjsify rather than on Node — CI included — because
+      # running the toolchain on itself is what makes its defects observable at
+      # all. This one step is the exception only because it cannot repair itself.
+      # Revert it to `gjs -m "$GJSIFY_BOOTSTRAP" run build:infra` once BOTH hold:
+      #   1. a RELEASED @gjsify/cli carries the fixes this step trips over
+      #      (gjsify#1038: `gjsify tsc` exiting 0 when it can spawn no compiler),
+      #      so `releases/latest` is no longer the broken one; and
+      #   2. a NON-BLOCKING job exercises the GJS-hosted bootstrap, so the next
+      #      regression there is a signal rather than a deadlocked release.
+      # Without (2) a revert only re-arms the trap for the next CLI bug.
+      # Note: every step AFTER this one already runs the repo's own CLI
+      # (`PATH="$PWD/node_modules/.bin:$PATH" gjsify …`), so what is on Node here
+      # is the cold start, not the release.
       - name: Bootstrap the build toolchain (cold trees only)
         run: |
           if [ -f packages/infra/cli/lib/index.js ]; then

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -149,6 +149,13 @@ jobs:
             cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1
             "${GITHUB_WORKSPACE}/.github/scripts/install-published-cli.sh" "${CLI_VERSION}"
             cd - >/dev/null
+            # Point the workspace shim at the published CLI too. `build:infra`
+            # runs PACKAGE SCRIPTS, and those call bare `gjsify`, which resolves
+            # through `node_modules/.bin/gjsify` — a workspace symlink to the
+            # very `packages/infra/cli/lib/index.js` this step exists to create.
+            # Without this the child dies on MODULE_NOT_FOUND for that path.
+            ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
+            echo "Node bootstrap CLI: $(node_modules/.bin/gjsify --version)"
             node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js run build:infra
           fi
 

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -123,12 +123,33 @@ jobs:
           gjs -m "$B" install --immutable
           echo "GJSIFY_BOOTSTRAP=$B" >> "$GITHUB_ENV"
 
+      # Bootstrap under NODE, not under the GJS bootstrap bundle.
+      #
+      # `$GJSIFY_BOOTSTRAP` is downloaded from `releases/latest/download/cli.gjs.mjs`,
+      # so it is ALWAYS THE PREVIOUS RELEASE'S CLI. That makes this step unfixable
+      # from the CLI source: a bug reached here can only be repaired by a release,
+      # and this step is what a release runs. v0.31.0's first cut hit exactly that —
+      # `gjsify tsc` inside `@gjsify/create-app`'s build spawned the bootstrap bundle
+      # instead of `node`, wrote no `lib/index.js`, and the `&&` chain then died in
+      # `set-bin-mode.mjs` on the missing file, naming a step past the fault.
+      #
+      # A published @gjsify/cli run under Node has none of that surface: `isNode()`
+      # is genuinely true so `nodeBinary()` resolves the real interpreter, and
+      # `process.exit()` is immediate rather than idle-scheduled. It is the same
+      # mechanism napi.yml already uses for the same reason, down to the shared
+      # `install-published-cli.sh` (which retries through the window where a release
+      # has bumped every package.json but npm does not serve the version yet).
       - name: Bootstrap the build toolchain (cold trees only)
         run: |
           if [ -f packages/infra/cli/lib/index.js ]; then
             echo "Node CLI entry present — the .bin shim is usable, skipping build:infra."
           else
-            gjs -m "$GJSIFY_BOOTSTRAP" run build:infra
+            CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
+            mkdir -p /tmp/gjsify-node-cli
+            cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1
+            "${GITHUB_WORKSPACE}/.github/scripts/install-published-cli.sh" "${CLI_VERSION}"
+            cd - >/dev/null
+            node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js run build:infra
           fi
 
       # `verify-committed-bundles.mjs` (the after:bump hook) resolves each

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -172,6 +172,20 @@ jobs:
             ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
             echo "Node bootstrap CLI: $(node_modules/.bin/gjsify --version)"
             node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js run build:infra
+            # …and HAND THE SHIM BACK the moment the tree can drive itself. The
+            # published CLI is a jump-start, not the release's toolchain: every
+            # later step resolves `gjsify` through this shim, so leaving it
+            # pointed at 0.30.0 would build, verify and CUT with a stale CLI
+            # instead of the one this commit ships.
+            #
+            # Measured, not hypothetical: with the shim left dangling,
+            # `verify-committed-bundles` rebuilt `affected.gjs.mjs` 157 bytes
+            # SHORTER than the committed file and reported it STALE — while the
+            # same rebuild driven by the freshly built CLI reproduces it
+            # byte-identically. The check was right; it was being handed the
+            # wrong compiler.
+            ln -sf "$PWD/packages/infra/cli/lib/index.js" node_modules/.bin/gjsify
+            echo "Handed back to the freshly built CLI: $(node_modules/.bin/gjsify --version)"
           fi
 
       # `verify-committed-bundles.mjs` (the after:bump hook) resolves each


### PR DESCRIPTION
**v0.31.0 cannot be cut without this.** Two dry runs have died in the same step, and #1038 — a real CLI fix, merged — provably could not help.

## The trap

```yaml
gjs -m "$GJSIFY_BOOTSTRAP" run build:infra
```

`$GJSIFY_BOOTSTRAP` is downloaded from `releases/latest/download/cli.gjs.mjs`. It is **always the previous release's CLI**. So this step cannot be fixed from the CLI source: a bug that reaches here is only repairable by a release, and this step is what a release runs.

That is not theory. #1038 fixed the exact defect this step trips over, landed on `main`, and the very next dry run ([31188521136](https://github.com/gjsify/gjsify/actions/runs/31188521136)) failed **byte-identically** to the one before it — because the bootstrap is still 0.30.0 and will be until a release ships, which is the thing being blocked.

## What actually breaks

`build:infra` reaches `@gjsify/create-app`, whose build is an `&&` chain:

```
node scripts/process-template.mjs && gjsify tsc && node scripts/set-bin-mode.mjs
```

`gjsify tsc` prints `spawn <bootstrap-bundle> ENOENT` five times — it resolved the compiler to the bootstrap bundle rather than `node` — writes no `lib/index.js`, **and exits 0**. `set-bin-mode.mjs` therefore runs and dies on the missing file, so the error names a step past the fault. (The exit-0 half is what #1038 fixes; it will matter for the release *after* this one, when the bootstrap becomes 0.31.0.)

Worth stating: this step arrived with #1019 (ADR 0002) on 2026-08-06 and v0.30.0 was cut on 2026-08-05, so **no release has ever gone through it**. Its first real run was its first failure.

## The change

Drive the same build from a published `@gjsify/cli` **run under Node**. None of the failing surface exists there: `isNode()` is genuinely true so `nodeBinary()` resolves the real interpreter, and `process.exit()` is immediate rather than idle-scheduled through a GLib main loop.

This is not a new mechanism — `napi.yml` already does exactly this, for exactly this reason, and this reuses its `install-published-cli.sh` rather than re-implementing the retry window it documents (a release bumps every `package.json` before npm serves that version).

`Setup Node.js` (26.x) already runs two steps earlier, so nothing new is asked of the image — which ships no `node` of its own, and that is precisely why the GJS-hosted fallback had nothing to spawn.

The warm-tree branch is untouched: a tree that already has `packages/infra/cli/lib/index.js` still skips this entirely.

## Verification

A dry run on this branch is the test, and it is a real one — the two prior dry runs both failed here, so a pass is not a vacuous green. I will report the result on this PR before merging.
