### PR TITLE
ci(release): one cold-tree bootstrap, not two

### DIFF
--- a/.github/scripts/bootstrap-cold-tree.sh
+++ b/.github/scripts/bootstrap-cold-tree.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Make a COLD checkout able to build itself, then hand it its own toolchain.
+#
+# A fresh CI tree has no `packages/infra/cli/lib/index.js` — it is a build
+# output. Without it `node_modules/.bin/gjsify` dangles, and the GJS bootstrap
+# bundle cannot fill the gap either: under GJS the only bundler engine is
+# `@gjsify/rolldown-native`, whose JS facade is itself a build output, so it
+# would have to bundle its own bundler.
+#
+# `$GJSIFY_BOOTSTRAP` is no way out: it is downloaded from
+# `releases/latest/download/cli.gjs.mjs`, i.e. ALWAYS THE PREVIOUS RELEASE'S
+# CLI. A bug that reaches this step can therefore only be repaired by a
+# release — and this step is what a release runs. Measured twice: v0.24.1 lost
+# @gjsify/napi to it, and v0.31.0's cut and publish both died on it.
+#
+# So: jump-start with a PUBLISHED @gjsify/cli under NODE, where `isNode()` is
+# genuinely true and `process.exit()` is immediate rather than idle-scheduled
+# through a GLib main loop — then HAND THE SHIM BACK, because everything after
+# this resolves `gjsify` through it and the release must be built, verified and
+# cut by the CLI this commit ships, not by the last one.
+#
+# TEMPORARY BY INTENT. The project's direction is to run as much as possible ON
+# gjsify — CI included — because running the toolchain on itself is what makes
+# its defects observable at all. Revert this to
+# `gjs -m "$GJSIFY_BOOTSTRAP" run build:infra` once BOTH hold:
+#   1. a RELEASED @gjsify/cli carries the fixes this step trips over (#1038:
+#      `gjsify tsc` exiting 0 when it can spawn no compiler); and
+#   2. a NON-BLOCKING job exercises the GJS-hosted bootstrap, so the next
+#      regression there is a signal rather than a deadlocked release.
+# Without (2) a revert only re-arms the trap for the next CLI bug.
+#
+# ONE script, called by every workflow that needs it. The duplicate copy in
+# release.yml is exactly why v0.31.0's publish still failed after the cut was
+# fixed: the fix went to one of the two.
+set -euo pipefail
+
+if [ -f packages/infra/cli/lib/index.js ]; then
+    echo "Node CLI entry present — the .bin shim is usable, skipping build:infra."
+    exit 0
+fi
+
+CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
+mkdir -p /tmp/gjsify-node-cli
+(cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1)
+# Retries through the window where a release has bumped every package.json but
+# npm does not yet serve that version — see the script's own comment.
+(cd /tmp/gjsify-node-cli && "${GITHUB_WORKSPACE}/.github/scripts/install-published-cli.sh" "${CLI_VERSION}")
+
+# `build:infra` runs PACKAGE SCRIPTS, and those call bare `gjsify`, which
+# resolves through this shim — a workspace symlink to the very file this step
+# exists to create. Without repointing it the child dies on MODULE_NOT_FOUND.
+ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
+echo "Node bootstrap CLI: $(node_modules/.bin/gjsify --version)"
+
+node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js run build:infra
+
+# Hand it back. Left dangling, `verify-committed-bundles` rebuilt
+# affected.gjs.mjs 157 bytes short and reported it STALE — the check was right,
+# it was being handed the wrong compiler.
+ln -sf "$PWD/packages/infra/cli/lib/index.js" node_modules/.bin/gjsify
+echo "Handed back to the freshly built CLI: $(node_modules/.bin/gjsify --version)"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -155,38 +155,7 @@ jobs:
       # (`PATH="$PWD/node_modules/.bin:$PATH" gjsify …`), so what is on Node here
       # is the cold start, not the release.
       - name: Bootstrap the build toolchain (cold trees only)
-        run: |
-          if [ -f packages/infra/cli/lib/index.js ]; then
-            echo "Node CLI entry present — the .bin shim is usable, skipping build:infra."
-          else
-            CLI_VERSION="$(node -p "require('./packages/infra/cli/package.json').version")"
-            mkdir -p /tmp/gjsify-node-cli
-            cd /tmp/gjsify-node-cli && npm init -y >/dev/null 2>&1
-            "${GITHUB_WORKSPACE}/.github/scripts/install-published-cli.sh" "${CLI_VERSION}"
-            cd - >/dev/null
-            # Point the workspace shim at the published CLI too. `build:infra`
-            # runs PACKAGE SCRIPTS, and those call bare `gjsify`, which resolves
-            # through `node_modules/.bin/gjsify` — a workspace symlink to the
-            # very `packages/infra/cli/lib/index.js` this step exists to create.
-            # Without this the child dies on MODULE_NOT_FOUND for that path.
-            ln -sf /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js node_modules/.bin/gjsify
-            echo "Node bootstrap CLI: $(node_modules/.bin/gjsify --version)"
-            node /tmp/gjsify-node-cli/node_modules/@gjsify/cli/lib/index.js run build:infra
-            # …and HAND THE SHIM BACK the moment the tree can drive itself. The
-            # published CLI is a jump-start, not the release's toolchain: every
-            # later step resolves `gjsify` through this shim, so leaving it
-            # pointed at 0.30.0 would build, verify and CUT with a stale CLI
-            # instead of the one this commit ships.
-            #
-            # Measured, not hypothetical: with the shim left dangling,
-            # `verify-committed-bundles` rebuilt `affected.gjs.mjs` 157 bytes
-            # SHORTER than the committed file and reported it STALE — while the
-            # same rebuild driven by the freshly built CLI reproduces it
-            # byte-identically. The check was right; it was being handed the
-            # wrong compiler.
-            ln -sf "$PWD/packages/infra/cli/lib/index.js" node_modules/.bin/gjsify
-            echo "Handed back to the freshly built CLI: $(node_modules/.bin/gjsify --version)"
-          fi
+        run: .github/scripts/bootstrap-cold-tree.sh
 
       # `verify-committed-bundles.mjs` (the after:bump hook) resolves each
       # workspace dep's `lib/esm` — it must run AFTER a workspace build, which is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,7 @@ jobs:
           echo "GJSIFY_BOOTSTRAP=$B" >> "$GITHUB_ENV"
 
       - name: Bootstrap the build toolchain (cold trees only)
-        run: |
-          if [ -f packages/infra/cli/lib/index.js ]; then
-            echo "Node CLI entry present — the .bin shim is usable, skipping build:infra."
-          else
-            gjs -m "$GJSIFY_BOOTSTRAP" run build:infra
-          fi
+        run: .github/scripts/bootstrap-cold-tree.sh
 
       - name: Build packages
         run: PATH="$PWD/node_modules/.bin:$PATH" gjsify run build


### PR DESCRIPTION
**v0.31.0 is stopped halfway.** The cut ([31202492287](https://github.com/gjsify/gjsify/actions/runs/31202492287)) passed all 15 steps — tag, GitHub release, assets, dispatch. The **publish** ([31203920532](https://github.com/gjsify/gjsify/actions/runs/31203920532)) then failed on the same cold-tree bootstrap #1040 had just fixed, because `release.yml` carries **its own copy** of that step and #1040 fixed only `release-cut.yml`.

## Nothing reached npm

Verified against the registry, not assumed:

```
@gjsify/cli@0.31.0                         NOT published
@gjsify/fs@0.31.0                          NOT published
@gjsify/webkit-native@0.31.0               NOT published
@gjsify/webkit-native-darwin-arm64@0.31.0  NOT published
@gjsify/iframe@0.31.0                      NOT published
latest: @gjsify/cli 0.30.0 · @gjsify/iframe 0.30.0
```

The job died before the first `npm publish`, which is the best available failure: `publishing.md` warns that a PARTIAL publish is worse than none, and this is not one. Recovery is a plain re-run once this lands — `--tolerate-republish` no-ops what already exists, and here nothing does.

## The duplication IS the defect

So this does not add a second fix. It extracts the logic into `.github/scripts/bootstrap-cold-tree.sh` and points both workflows at it, so a third copy cannot drift away from it.

The script keeps what #1040 established and states each reason in place:

- jump-start with a **published** `@gjsify/cli` under Node — `$GJSIFY_BOOTSTRAP` is downloaded from `releases/latest`, i.e. always the PREVIOUS release's CLI, so a bug reaching this step is otherwise only repairable by a release, and this step is what a release runs;
- repoint `node_modules/.bin/gjsify` **before** `build:infra`, or its package scripts die on MODULE_NOT_FOUND for the very file being created;
- hand the shim **back** afterwards, or the release is built, verified and cut by 0.30.0 rather than by the CLI it ships (this one produced a false STALE verdict on `affected.gjs.mjs`, 157 bytes short);
- and the two conditions for reverting the whole thing to a GJS-hosted bootstrap.

## Third time for this shape

`release.yml`'s own comment records the first: *"This job's tree is COLD by design … which is what broke the v0.24.1 release: … `@gjsify/napi` was the one package that missed the train."* Then v0.31.0's cut. Then v0.31.0's publish, an hour after the cut was fixed.

Each time the repair went to the site that failed rather than to the shape. That is what this PR changes.

## After merging

Re-dispatch `release.yml` for the existing `v0.31.0` tag. The cut does not need repeating — the tag, the commit, the GitHub release and the uploaded bootstrap bundle are all in place and correct.
