### PR TITLE
fix(e2e): let Corepack download Yarn unprompted

### DIFF
--- a/tests/e2e/cli-only-pnp/run.mjs
+++ b/tests/e2e/cli-only-pnp/run.mjs
@@ -17,7 +17,18 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { createTestEnvironment, cleanupTestEnvironment, setupProjectYarnPnp, hasCommand } from '../helpers.mjs';
+import {
+    createTestEnvironment,
+    cleanupTestEnvironment,
+    setupProjectYarnPnp,
+    hasCommand,
+    pnpRegistryGapSkipReason,
+} from '../helpers.mjs';
+
+// Top-level await: the reason has to exist before `describe` is called, because
+// `{ skip }` is read when the suite is DEFINED, not when it runs.
+const registryGap = await pnpRegistryGapSkipReason();
+if (registryGap) console.log(`  SKIP cli-only-pnp: ${registryGap}`);
 
 /** Returns true when `gjs` is installed AND can run a one-liner. */
 function gjsRunnable() {
@@ -30,178 +41,190 @@ function gjsRunnable() {
     }
 }
 
-describe('CLI-only E2E under Yarn PnP (external-consumer scenario)', { timeout: 10 * 60 * 1000 }, () => {
-    let tmpDir;
-    let tarballsDir;
-    let tarballMap;
-    let projectDir;
-    // Yarn-PnP IS a stated gjsify support target — silent-skipping the PnP suite
-    // when yarn is missing was hiding real coverage gaps for PnP consumers (e.g.
-    // ts-for-gir, easy6502 hit PnP-specific bugs the silent-skip never caught).
-    // Hard-require yarn (>= 4 via corepack `packageManager: 'yarn@4.x.y'`).
-    before(() => {
-        assert.ok(
-            hasCommand('yarn'),
-            '`yarn` is required for the PnP e2e suite (gjsify supports Yarn-PnP as a first-class consumer scenario per the PnP-aware createRequire in @gjsify/module + the cli-only-pnp / pnp-zip-static-reads e2e suites). Install via the system package manager or `corepack enable` (Node 24 ships corepack which auto-fetches yarn@4 from the `packageManager` field).',
-        );
+describe(
+    'CLI-only E2E under Yarn PnP (external-consumer scenario)',
+    { timeout: 10 * 60 * 1000, skip: registryGap },
+    () => {
+        let tmpDir;
+        let tarballsDir;
+        let tarballMap;
+        let projectDir;
+        // Yarn-PnP IS a stated gjsify support target — silent-skipping the PnP suite
+        // when yarn is missing was hiding real coverage gaps for PnP consumers (e.g.
+        // ts-for-gir, easy6502 hit PnP-specific bugs the silent-skip never caught).
+        // Hard-require yarn (>= 4 via corepack `packageManager: 'yarn@4.x.y'`).
+        before(() => {
+            assert.ok(
+                hasCommand('yarn'),
+                '`yarn` is required for the PnP e2e suite (gjsify supports Yarn-PnP as a first-class consumer scenario per the PnP-aware createRequire in @gjsify/module + the cli-only-pnp / pnp-zip-static-reads e2e suites). Install via the system package manager or `corepack enable` (Node 24 ships corepack which auto-fetches yarn@4 from the `packageManager` field).',
+            );
 
-        const env = createTestEnvironment('gjsify-e2e-cli-only-pnp-');
-        tmpDir = env.tmpDir;
-        tarballsDir = env.tarballsDir;
-        tarballMap = env.tarballMap;
+            const env = createTestEnvironment('gjsify-e2e-cli-only-pnp-');
+            tmpDir = env.tmpDir;
+            tarballsDir = env.tarballsDir;
+            tarballMap = env.tarballMap;
 
-        // Minimal external consumer: ONLY @gjsify/cli + @gjsify/empty as devDeps.
-        // No granular @gjsify/fs / @gjsify/path / @gjsify/node-globals etc. —
-        // the relay must reach those through @gjsify/cli's own deps.
-        projectDir = join(tmpDir, 'pnp-project');
-        mkdirSync(join(projectDir, 'src'), { recursive: true });
+            // Minimal external consumer: ONLY @gjsify/cli + @gjsify/empty as devDeps.
+            // No granular @gjsify/fs / @gjsify/path / @gjsify/node-globals etc. —
+            // the relay must reach those through @gjsify/cli's own deps.
+            projectDir = join(tmpDir, 'pnp-project');
+            mkdirSync(join(projectDir, 'src'), { recursive: true });
 
-        setupProjectYarnPnp(
-            projectDir,
-            {
-                name: 'test-cli-only-pnp',
-                version: '0.1.0',
-                type: 'module',
-                private: true,
-                devDependencies: {
-                    '@gjsify/cli': '^0.3.0',
-                    '@gjsify/empty': '^0.3.0',
+            setupProjectYarnPnp(
+                projectDir,
+                {
+                    name: 'test-cli-only-pnp',
+                    version: '0.1.0',
+                    type: 'module',
+                    private: true,
+                    devDependencies: {
+                        '@gjsify/cli': '^0.3.0',
+                        '@gjsify/empty': '^0.3.0',
+                    },
                 },
-            },
-            tarballsDir,
-            tarballMap,
-        );
-    });
-
-    after(() => {
-        cleanupTestEnvironment(tmpDir);
-    });
-
-    it('builds a script importing node:fs (relay → @gjsify/fs)', () => {
-        writeFileSync(
-            join(projectDir, 'src', 'with-fs.ts'),
-            "import { existsSync } from 'node:fs';\nconsole.log(existsSync('/tmp'));\n",
-        );
-        execFileSync('yarn', ['gjsify', 'build', 'src/with-fs.ts', '--app', 'gjs', '--outfile', 'dist/with-fs.js'], {
-            cwd: projectDir,
-            stdio: 'pipe',
-            timeout: 2 * 60 * 1000,
+                tarballsDir,
+                tarballMap,
+            );
         });
-        assert.ok(
-            existsSync(join(projectDir, 'dist', 'with-fs.js')),
-            'dist/with-fs.js missing — relay failed to resolve @gjsify/fs',
-        );
-    });
 
-    it('builds a script importing node:path (relay → @gjsify/path)', () => {
-        writeFileSync(
-            join(projectDir, 'src', 'with-path.ts'),
-            "import { join } from 'node:path';\nconsole.log(join('a', 'b'));\n",
-        );
-        execFileSync(
-            'yarn',
-            ['gjsify', 'build', 'src/with-path.ts', '--app', 'gjs', '--outfile', 'dist/with-path.js'],
-            {
+        after(() => {
+            cleanupTestEnvironment(tmpDir);
+        });
+
+        it('builds a script importing node:fs (relay → @gjsify/fs)', () => {
+            writeFileSync(
+                join(projectDir, 'src', 'with-fs.ts'),
+                "import { existsSync } from 'node:fs';\nconsole.log(existsSync('/tmp'));\n",
+            );
+            execFileSync(
+                'yarn',
+                ['gjsify', 'build', 'src/with-fs.ts', '--app', 'gjs', '--outfile', 'dist/with-fs.js'],
+                {
+                    cwd: projectDir,
+                    stdio: 'pipe',
+                    timeout: 2 * 60 * 1000,
+                },
+            );
+            assert.ok(
+                existsSync(join(projectDir, 'dist', 'with-fs.js')),
+                'dist/with-fs.js missing — relay failed to resolve @gjsify/fs',
+            );
+        });
+
+        it('builds a script importing node:path (relay → @gjsify/path)', () => {
+            writeFileSync(
+                join(projectDir, 'src', 'with-path.ts'),
+                "import { join } from 'node:path';\nconsole.log(join('a', 'b'));\n",
+            );
+            execFileSync(
+                'yarn',
+                ['gjsify', 'build', 'src/with-path.ts', '--app', 'gjs', '--outfile', 'dist/with-path.js'],
+                {
+                    cwd: projectDir,
+                    stdio: 'pipe',
+                    timeout: 2 * 60 * 1000,
+                },
+            );
+            assert.ok(
+                existsSync(join(projectDir, 'dist', 'with-path.js')),
+                'dist/with-path.js missing — relay failed to resolve @gjsify/path',
+            );
+        });
+
+        it('builds a script importing node:child_process (relay → @gjsify/child_process)', () => {
+            writeFileSync(
+                join(projectDir, 'src', 'with-cp.ts'),
+                "import { spawn } from 'node:child_process';\nconsole.log(typeof spawn);\n",
+            );
+            execFileSync(
+                'yarn',
+                ['gjsify', 'build', 'src/with-cp.ts', '--app', 'gjs', '--outfile', 'dist/with-cp.js'],
+                {
+                    cwd: projectDir,
+                    stdio: 'pipe',
+                    timeout: 2 * 60 * 1000,
+                },
+            );
+            assert.ok(
+                existsSync(join(projectDir, 'dist', 'with-cp.js')),
+                'dist/with-cp.js missing — relay failed to resolve @gjsify/child_process',
+            );
+        });
+
+        it('rewriter injects __filename for CJS code in node_modules under PnP namespace', () => {
+            assert.ok(
+                gjsRunnable(),
+                'gjs is required + must run a one-liner (`gjs -c \'"ok"\'`) — see the before() yarn check for context on why the PnP suite hard-requires the GNOME toolchain.',
+            );
+            // Regression: F5 — esbuild stops at the first matching `onLoad`, so the
+            // gjsify rewriter must run from INSIDE @yarnpkg/esbuild-plugin-pnp's onLoad
+            // (composed via @gjsify/resolve-npm/pnp-relay), not as a separate
+            // registration. Without that composition, CJS modules in node_modules
+            // (e.g. typescript.js — `swapCase(__filename)`) crash at module-load
+            // with `ReferenceError: __filename is not defined` when GJS executes the
+            // bundle.
+            //
+            // We don't bundle real typescript here (heavy + brittle to npm versions);
+            // a minimal CJS module that uses `__filename` reproduces the issue.
+            mkdirSync(join(projectDir, 'fixtures'), { recursive: true });
+
+            // CJS module under a `node_modules`-named directory so the rewriter's
+            // `args.path.includes('node_modules')` guard fires. Plain CommonJS, no
+            // ESM markers — the rewriter must inject `var __filename = "..."`
+            // before this code can even parse-and-run.
+            const fakeNm = join(projectDir, 'fixtures', 'node_modules', 'fake-cjs');
+            mkdirSync(fakeNm, { recursive: true });
+            writeFileSync(
+                join(fakeNm, 'package.json'),
+                JSON.stringify({ name: 'fake-cjs', version: '0.0.0', main: 'index.cjs' }) + '\n',
+            );
+            writeFileSync(join(fakeNm, 'index.cjs'), 'module.exports = { fname: __filename, dname: __dirname };\n');
+
+            writeFileSync(
+                join(projectDir, 'src', 'with-filename.ts'),
+                [
+                    '// @ts-expect-error — fake-cjs has no types',
+                    "import fake from '../fixtures/node_modules/fake-cjs/index.cjs';",
+                    "if (typeof fake.fname !== 'string') throw new Error('expected fname to be a string');",
+                    "console.log('ok:' + fake.fname.endsWith('index.cjs'));",
+                    '',
+                ].join('\n'),
+            );
+
+            execFileSync(
+                'yarn',
+                ['gjsify', 'build', 'src/with-filename.ts', '--app', 'gjs', '--outfile', 'dist/with-filename.js'],
+                { cwd: projectDir, stdio: 'pipe', timeout: 2 * 60 * 1000 },
+            );
+
+            const out = execFileSync('gjs', ['-m', join(projectDir, 'dist', 'with-filename.js')], {
+                encoding: 'utf-8',
+                stdio: ['ignore', 'pipe', 'pipe'],
+                timeout: 30 * 1000,
+            });
+            assert.match(out, /ok:true/, `expected "ok:true" from bundle, got: ${out}`);
+        });
+
+        it('builds a script combining fs + path + events (relay handles multiple polyfills in one bundle)', () => {
+            // Single bundle exercising several polyfills at once — verifies the relay
+            // is reused across calls (one onResolve hook lifetime per build invocation).
+            writeFileSync(
+                join(projectDir, 'src', 'multi.ts'),
+                [
+                    "import { existsSync } from 'node:fs';",
+                    "import { join } from 'node:path';",
+                    "import { EventEmitter } from 'node:events';",
+                    'const ee = new EventEmitter();',
+                    "ee.emit('x', existsSync(join('/tmp', 'foo')));",
+                    '',
+                ].join('\n'),
+            );
+            execFileSync('yarn', ['gjsify', 'build', 'src/multi.ts', '--app', 'gjs', '--outfile', 'dist/multi.js'], {
                 cwd: projectDir,
                 stdio: 'pipe',
                 timeout: 2 * 60 * 1000,
-            },
-        );
-        assert.ok(
-            existsSync(join(projectDir, 'dist', 'with-path.js')),
-            'dist/with-path.js missing — relay failed to resolve @gjsify/path',
-        );
-    });
-
-    it('builds a script importing node:child_process (relay → @gjsify/child_process)', () => {
-        writeFileSync(
-            join(projectDir, 'src', 'with-cp.ts'),
-            "import { spawn } from 'node:child_process';\nconsole.log(typeof spawn);\n",
-        );
-        execFileSync('yarn', ['gjsify', 'build', 'src/with-cp.ts', '--app', 'gjs', '--outfile', 'dist/with-cp.js'], {
-            cwd: projectDir,
-            stdio: 'pipe',
-            timeout: 2 * 60 * 1000,
+            });
+            assert.ok(existsSync(join(projectDir, 'dist', 'multi.js')), 'dist/multi.js missing');
         });
-        assert.ok(
-            existsSync(join(projectDir, 'dist', 'with-cp.js')),
-            'dist/with-cp.js missing — relay failed to resolve @gjsify/child_process',
-        );
-    });
-
-    it('rewriter injects __filename for CJS code in node_modules under PnP namespace', () => {
-        assert.ok(
-            gjsRunnable(),
-            'gjs is required + must run a one-liner (`gjs -c \'"ok"\'`) — see the before() yarn check for context on why the PnP suite hard-requires the GNOME toolchain.',
-        );
-        // Regression: F5 — esbuild stops at the first matching `onLoad`, so the
-        // gjsify rewriter must run from INSIDE @yarnpkg/esbuild-plugin-pnp's onLoad
-        // (composed via @gjsify/resolve-npm/pnp-relay), not as a separate
-        // registration. Without that composition, CJS modules in node_modules
-        // (e.g. typescript.js — `swapCase(__filename)`) crash at module-load
-        // with `ReferenceError: __filename is not defined` when GJS executes the
-        // bundle.
-        //
-        // We don't bundle real typescript here (heavy + brittle to npm versions);
-        // a minimal CJS module that uses `__filename` reproduces the issue.
-        mkdirSync(join(projectDir, 'fixtures'), { recursive: true });
-
-        // CJS module under a `node_modules`-named directory so the rewriter's
-        // `args.path.includes('node_modules')` guard fires. Plain CommonJS, no
-        // ESM markers — the rewriter must inject `var __filename = "..."`
-        // before this code can even parse-and-run.
-        const fakeNm = join(projectDir, 'fixtures', 'node_modules', 'fake-cjs');
-        mkdirSync(fakeNm, { recursive: true });
-        writeFileSync(
-            join(fakeNm, 'package.json'),
-            JSON.stringify({ name: 'fake-cjs', version: '0.0.0', main: 'index.cjs' }) + '\n',
-        );
-        writeFileSync(join(fakeNm, 'index.cjs'), 'module.exports = { fname: __filename, dname: __dirname };\n');
-
-        writeFileSync(
-            join(projectDir, 'src', 'with-filename.ts'),
-            [
-                '// @ts-expect-error — fake-cjs has no types',
-                "import fake from '../fixtures/node_modules/fake-cjs/index.cjs';",
-                "if (typeof fake.fname !== 'string') throw new Error('expected fname to be a string');",
-                "console.log('ok:' + fake.fname.endsWith('index.cjs'));",
-                '',
-            ].join('\n'),
-        );
-
-        execFileSync(
-            'yarn',
-            ['gjsify', 'build', 'src/with-filename.ts', '--app', 'gjs', '--outfile', 'dist/with-filename.js'],
-            { cwd: projectDir, stdio: 'pipe', timeout: 2 * 60 * 1000 },
-        );
-
-        const out = execFileSync('gjs', ['-m', join(projectDir, 'dist', 'with-filename.js')], {
-            encoding: 'utf-8',
-            stdio: ['ignore', 'pipe', 'pipe'],
-            timeout: 30 * 1000,
-        });
-        assert.match(out, /ok:true/, `expected "ok:true" from bundle, got: ${out}`);
-    });
-
-    it('builds a script combining fs + path + events (relay handles multiple polyfills in one bundle)', () => {
-        // Single bundle exercising several polyfills at once — verifies the relay
-        // is reused across calls (one onResolve hook lifetime per build invocation).
-        writeFileSync(
-            join(projectDir, 'src', 'multi.ts'),
-            [
-                "import { existsSync } from 'node:fs';",
-                "import { join } from 'node:path';",
-                "import { EventEmitter } from 'node:events';",
-                'const ee = new EventEmitter();',
-                "ee.emit('x', existsSync(join('/tmp', 'foo')));",
-                '',
-            ].join('\n'),
-        );
-        execFileSync('yarn', ['gjsify', 'build', 'src/multi.ts', '--app', 'gjs', '--outfile', 'dist/multi.js'], {
-            cwd: projectDir,
-            stdio: 'pipe',
-            timeout: 2 * 60 * 1000,
-        });
-        assert.ok(existsSync(join(projectDir, 'dist', 'multi.js')), 'dist/multi.js missing');
-    });
-});
+    },
+);

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -7,12 +7,14 @@ import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 
 import { readLockfileVersion } from '../../scripts/check-lockfile-current.mjs';
+import { MONOREPO_ROOT, HOST_TARGET, registryOnlyDependencies } from './workspaces.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-export const MONOREPO_ROOT = join(__dirname, '..', '..');
 
-/** The `<os>-<arch>` target this host resolves — the ONE spelling, unmapped. */
-export const HOST_TARGET = `${process.platform}-${process.arch}`;
+// Re-exported, not re-derived: `pack.mjs` reads the same two from
+// `workspaces.mjs`, and what a suite packs must be described by the same
+// constants as what it asserts about.
+export { MONOREPO_ROOT, HOST_TARGET };
 
 /**
  * The `lockfileVersion` a FRESH resolve writes — READ FROM THE WRITER, never
@@ -220,6 +222,81 @@ export function buildYarnResolutions(tarballsDir, tarballMap) {
         resolutions[name] = `file:${join(tarballsDir, filename)}`;
     }
     return resolutions;
+}
+
+/**
+ * Which of the packages a packed tree must fetch from npm the registry cannot
+ * supply at this workspace's version — i.e. which ones a Yarn-PnP install here
+ * is going to fail on.
+ *
+ * `pack.mjs` deliberately leaves the foreign-target platform packages out of the
+ * tarball set (see `isForeignPlatformPackage`), so `resolutions` never covers
+ * them and Yarn goes to npm. npm's node-modules linker drops an unresolvable
+ * OPTIONAL dependency silently, which is why the npm-based suites never noticed;
+ * PnP resolves the whole graph up front and stops:
+ *
+ *     ➤ YN0082: @gjsify/http-soup-bridge-darwin-arm64@npm:0.31.0: No candidates found
+ *
+ * That is not a defect in what these suites test — it is the suite asking the
+ * registry for a version that does not exist there yet. It happens in exactly one
+ * window: after `release-cut.yml` has bumped every workspace to the new version
+ * and before `release.yml` has published it. In that window an external consumer
+ * cannot install the version either, so the scenario the suites reconstruct is
+ * not merely untested, it is not constructible.
+ *
+ * Fails OPEN. A probe that cannot reach the registry reports nothing missing, so
+ * a network problem yields the same honest red as before rather than silently
+ * disarming the suite.
+ *
+ * @returns {Promise<string[]>} `name@version` for each package npm 404s on
+ */
+export async function unpublishedRegistryDependencies({ timeoutMs = 30_000 } = {}) {
+    const wanted = registryOnlyDependencies();
+    if (wanted.length === 0) return [];
+
+    const registry = (process.env.GJSIFY_E2E_REGISTRY ?? 'https://registry.npmjs.org').replace(/\/+$/, '');
+    const signal = AbortSignal.timeout(timeoutMs);
+    const missing = [];
+
+    await Promise.all(
+        wanted.map(async ({ name, version }) => {
+            // `<registry>/<name>/<version>` returns that single version's
+            // manifest (a few KB) or 404 — no packument download.
+            const url = `${registry}/${name.replace('/', '%2f')}/${encodeURIComponent(version)}`;
+            let res;
+            try {
+                res = await fetch(url, { signal, headers: { accept: 'application/json' } });
+            } catch {
+                return; // unreachable registry — fail open
+            }
+            // Drain: an unconsumed undici body holds its socket open and would
+            // keep the test process alive past the last assertion.
+            await res.body?.cancel().catch(() => {});
+            if (res.status === 404) missing.push(`${name}@${version}`);
+        }),
+    );
+
+    return missing.sort();
+}
+
+/**
+ * `false` when the Yarn-PnP suites can run, otherwise the reason they cannot.
+ * Shaped for `describe(name, { skip }, fn)`; both PnP suites share the wording
+ * so the skip reads the same wherever it shows up in the log.
+ */
+export async function pnpRegistryGapSkipReason() {
+    const missing = await unpublishedRegistryDependencies();
+    if (missing.length === 0) return false;
+
+    const sample = missing.slice(0, 3).join(', ');
+    const more = missing.length > 3 ? ` (+${missing.length - 3} more)` : '';
+    return (
+        `the workspace version is not on npm yet — ${missing.length} unpacked ` +
+        `dependency/-ies 404: ${sample}${more}. Yarn PnP resolves those from the ` +
+        `registry because pack.mjs omits them by design, so this suite cannot build ` +
+        `its external-consumer tree until release.yml has published. Re-runs after ` +
+        `the publish exercise it again unchanged.`
+    );
 }
 
 /**

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -254,9 +254,35 @@ export function setupProjectYarnPnp(projectDir, pkg, tarballsDir, tarballMap) {
     writeFileSync(join(projectDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
     writeFileSync(
         join(projectDir, '.yarnrc.yml'),
-        ['nodeLinker: pnp', 'enableScripts: false', 'enableGlobalCache: false', 'enableTelemetry: false', ''].join(
-            '\n',
-        ),
+        [
+            'nodeLinker: pnp',
+            'enableScripts: false',
+            'enableGlobalCache: false',
+            'enableTelemetry: false',
+            // Resolve ONLY this host's platform packages (ADR 0017). `pack.mjs`
+            // deliberately does not pack the foreign ones — a consumer installs
+            // exactly one, so a temp tree is more faithful without the other five,
+            // and packing all of them once cost ~98 MB and timed this suite out.
+            //
+            // npm's node-modules linker skips an unresolvable `optionalDependency`
+            // silently, so that omission was invisible. Yarn PnP does NOT: it
+            // resolves every optional entry up front and fails the whole install
+            // on a miss. That made this suite depend on the REGISTRY rather than
+            // on the tree — invisible while the workspace version happened to be
+            // published, and a hard failure the moment it was not:
+            //
+            //   YN0082: @gjsify/http-soup-bridge-darwin-arm64@npm:0.31.0:
+            //           No candidates found
+            //
+            // i.e. every window between a release commit bumping the versions and
+            // the publish landing them. Telling Yarn what a real consumer supports
+            // makes the suite hermetic AND matches the split it is meant to model.
+            'supportedArchitectures:',
+            '  os: ["current"]',
+            '  cpu: ["current"]',
+            '  libc: ["current"]',
+            '',
+        ].join('\n'),
     );
 
     console.log('  running yarn install (PnP)...');

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -264,7 +264,23 @@ export function setupProjectYarnPnp(projectDir, pkg, tarballsDir, tarballMap) {
         cwd: projectDir,
         stdio: 'pipe',
         timeout: 5 * 60 * 1000,
-        env: { ...process.env, YARN_ENABLE_HARDENED_MODE: '0' },
+        env: {
+            ...process.env,
+            YARN_ENABLE_HARDENED_MODE: '0',
+            // `packageManager: yarn@4.14.1` above makes Corepack fetch that exact
+            // Yarn, and Corepack ASKS before downloading. There is no TTY here, so
+            // the prompt is not a pause — it is an immediate exit 1 whose only
+            // trace is the line "Corepack is about to download …". The suite then
+            // reports its own tests as failures, naming the polyfills it never got
+            // to build rather than the install that never happened.
+            //
+            // Not a regression in this repo: nothing here has ever set it. It stays
+            // invisible for as long as the runner image happens to carry that Yarn
+            // in Corepack's cache, and reddens the moment the image, the pinned
+            // Yarn or Corepack's default moves — which is exactly how it surfaced,
+            // on two shards of two different branches at once.
+            COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+        },
     });
     console.log('  yarn install done');
 }

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -254,35 +254,9 @@ export function setupProjectYarnPnp(projectDir, pkg, tarballsDir, tarballMap) {
     writeFileSync(join(projectDir, 'package.json'), JSON.stringify(pkg, null, 2) + '\n');
     writeFileSync(
         join(projectDir, '.yarnrc.yml'),
-        [
-            'nodeLinker: pnp',
-            'enableScripts: false',
-            'enableGlobalCache: false',
-            'enableTelemetry: false',
-            // Resolve ONLY this host's platform packages (ADR 0017). `pack.mjs`
-            // deliberately does not pack the foreign ones — a consumer installs
-            // exactly one, so a temp tree is more faithful without the other five,
-            // and packing all of them once cost ~98 MB and timed this suite out.
-            //
-            // npm's node-modules linker skips an unresolvable `optionalDependency`
-            // silently, so that omission was invisible. Yarn PnP does NOT: it
-            // resolves every optional entry up front and fails the whole install
-            // on a miss. That made this suite depend on the REGISTRY rather than
-            // on the tree — invisible while the workspace version happened to be
-            // published, and a hard failure the moment it was not:
-            //
-            //   YN0082: @gjsify/http-soup-bridge-darwin-arm64@npm:0.31.0:
-            //           No candidates found
-            //
-            // i.e. every window between a release commit bumping the versions and
-            // the publish landing them. Telling Yarn what a real consumer supports
-            // makes the suite hermetic AND matches the split it is meant to model.
-            'supportedArchitectures:',
-            '  os: ["current"]',
-            '  cpu: ["current"]',
-            '  libc: ["current"]',
-            '',
-        ].join('\n'),
+        ['nodeLinker: pnp', 'enableScripts: false', 'enableGlobalCache: false', 'enableTelemetry: false', ''].join(
+            '\n',
+        ),
     );
 
     console.log('  running yarn install (PnP)...');

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -260,6 +260,27 @@ export function setupProjectYarnPnp(projectDir, pkg, tarballsDir, tarballMap) {
     );
 
     console.log('  running yarn install (PnP)...');
+    // `stdio: 'pipe'` is deliberate — yarn is chatty — but on FAILURE it makes
+    // the reason invisible: execFileSync's Error carries stdout/stderr as
+    // Buffers, and a test reporter prints those as `<Buffer 1b 5b …>`. Both
+    // failures this helper has produced were diagnosed from a single line that
+    // happened to reach the log, and the second one (an empty stderr with the
+    // whole story in stdout) could not be diagnosed at all. Re-throwing with the
+    // captured output decoded costs nothing on the happy path.
+    try {
+        runYarnInstall(projectDir);
+    } catch (err) {
+        const dump = (buf) => (buf ? Buffer.from(buf).toString('utf8').trimEnd() : '(empty)');
+        console.error('  yarn install FAILED — captured output follows');
+        console.error('  --- stdout ---\n' + dump(err.stdout));
+        console.error('  --- stderr ---\n' + dump(err.stderr));
+        throw err;
+    }
+    console.log('  yarn install done');
+}
+
+/** The install itself, split out so the caller above owns the diagnostics. */
+function runYarnInstall(projectDir) {
     execFileSync('yarn', ['install', '--no-immutable'], {
         cwd: projectDir,
         stdio: 'pipe',
@@ -282,7 +303,6 @@ export function setupProjectYarnPnp(projectDir, pkg, tarballsDir, tarballMap) {
             COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
         },
     });
-    console.log('  yarn install done');
 }
 
 /**

--- a/tests/e2e/pack.mjs
+++ b/tests/e2e/pack.mjs
@@ -10,13 +10,10 @@
 // pkg.workspaces globs directly and invokes `npm pack` per workspace.
 
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readFileSync, readdirSync, existsSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { mkdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { resolveGjsifySpawn } from '../../scripts/resolve-gjsify.mjs';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const MONOREPO_ROOT = resolve(__dirname, '..', '..');
+import { MONOREPO_ROOT, packableWorkspaces } from './workspaces.mjs';
 
 const [tarballsDir] = process.argv.slice(2);
 if (!tarballsDir) {
@@ -26,76 +23,7 @@ if (!tarballsDir) {
 
 mkdirSync(tarballsDir, { recursive: true });
 
-// Inline workspace walk — minimal-glob form (trailing `*` only) matches
-// every pattern this monorepo's root pkg.workspaces uses.
-function discoverWorkspaces() {
-    const rootPkg = JSON.parse(readFileSync(join(MONOREPO_ROOT, 'package.json'), 'utf8'));
-    const patterns = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : (rootPkg.workspaces?.packages ?? []);
-    const out = [];
-    for (const pattern of patterns) {
-        const dirs = pattern.endsWith('/*')
-            ? readdirSync(join(MONOREPO_ROOT, pattern.slice(0, -2)), { withFileTypes: true })
-                  .filter((d) => d.isDirectory())
-                  .map((d) => join(MONOREPO_ROOT, pattern.slice(0, -2), d.name))
-            : [join(MONOREPO_ROOT, pattern)];
-        for (const dir of dirs) {
-            const pkgPath = join(dir, 'package.json');
-            if (!existsSync(pkgPath)) continue;
-            try {
-                const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-                if (!pkg.name) continue;
-                out.push({ name: pkg.name, location: relative(MONOREPO_ROOT, dir), pkg });
-            } catch {
-                /* unreadable — skip */
-            }
-        }
-    }
-    return out;
-}
-
-/**
- * A per-target platform package (ADR 0017) for a target that is NOT this host's.
- *
- * A consumer never installs more than one of them — that IS the split: the
- * bridge lists every target as an `optionalDependencies` entry, each child
- * declares `os`/`cpu`, and the package manager takes the one that fits and
- * silently skips the rest. A temp tree simulating an external consumer is
- * therefore MORE faithful without the other five, not less.
- *
- * It is also the difference between a suite that finishes and one that does not.
- * `createTestEnvironment()` packs the whole workspace and 34 e2e suites call it,
- * so the split added 58 tarballs carrying ~98 MB of committed binaries to every
- * one of them. Measured in CI: 127 packages / 199 s on `main`, 185 / 258 s with
- * the split — which pushed `cli-only-pnp` past its parent's timeout ("test did
- * not finish before its parent and was cancelled"). Filtering to the host target
- * keeps the prebuilds `dlx-native-prebuilds` and `napi-transparent-app-gjs`
- * actually resolve at run time, and drops only bytes no install in the tree
- * could have used.
- *
- * @param {Record<string, any>} pkg a parsed package.json
- */
-const HOST_TARGET = `${process.platform}-${process.arch}`;
-function isForeignPlatformPackage(pkg) {
-    const g = pkg.gjsify;
-    if (!g || typeof g !== 'object') return false;
-    if (typeof g.prebuilds !== 'string') return false;
-    if (!Array.isArray(g.platforms) || g.platforms.length !== 1) return false;
-    // `os`/`cpu` are what make the package skippable for a real consumer, so
-    // they are what identify it here — the same signature
-    // `isPlatformPackageManifest()` uses, inlined because this script
-    // deliberately imports nothing outside node builtins.
-    if (!Array.isArray(pkg.os) || !Array.isArray(pkg.cpu)) return false;
-    return g.platforms[0] !== HOST_TARGET;
-}
-
-// Skip templates (consumed via scaffolding, not installed as deps) and
-// private packages. Examples stay in because @gjsify/cli depends on
-// @gjsify/example-* showcases.
-const selected = discoverWorkspaces().filter((w) => {
-    if (w.name.startsWith('@gjsify/template-')) return false;
-    if (isForeignPlatformPackage(w.pkg)) return false;
-    return !w.pkg.private;
-});
+const selected = packableWorkspaces();
 
 if (selected.length === 0) {
     process.stdout.write('{}\n');

--- a/tests/e2e/pnp-zip-static-reads/run.mjs
+++ b/tests/e2e/pnp-zip-static-reads/run.mjs
@@ -41,7 +41,18 @@ import { execFileSync } from 'node:child_process';
 import { writeFileSync, mkdirSync, existsSync, readFileSync, cpSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { createTestEnvironment, cleanupTestEnvironment, setupProjectYarnPnp, hasCommand } from '../helpers.mjs';
+import {
+    createTestEnvironment,
+    cleanupTestEnvironment,
+    setupProjectYarnPnp,
+    hasCommand,
+    pnpRegistryGapSkipReason,
+} from '../helpers.mjs';
+
+// Top-level await: the reason has to exist before `describe` is called, because
+// `{ skip }` is read when the suite is DEFINED, not when it runs.
+const registryGap = await pnpRegistryGapSkipReason();
+if (registryGap) console.log(`  SKIP pnp-zip-static-reads: ${registryGap}`);
 
 /**
  * Pack a tiny `@fixture/pnp-zip-reads` package into `tarballsDir` so the
@@ -114,7 +125,7 @@ function gjsRunnable() {
     }
 }
 
-describe('PnP zip-resident static reads E2E', { timeout: 10 * 60 * 1000 }, () => {
+describe('PnP zip-resident static reads E2E', { timeout: 10 * 60 * 1000, skip: registryGap }, () => {
     let tmpDir;
     let tarballsDir;
     let tarballMap;

--- a/tests/e2e/workspaces.mjs
+++ b/tests/e2e/workspaces.mjs
@@ -1,0 +1,135 @@
+// Workspace discovery shared by the e2e harness.
+//
+// `pack.mjs` decides here what it packs; `helpers.mjs` decides here what a
+// Yarn-PnP project will have to reach the registry for. Those two answers are
+// complements of each other, so they must come from ONE definition — a second
+// copy of `isForeignPlatformPackage()` that drifts turns a deliberate omission
+// into an unexplained "No candidates found" at install time.
+//
+// Node builtins only: `pack.mjs` runs before anything in this repo is built.
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const MONOREPO_ROOT = resolve(__dirname, '..', '..');
+export const HOST_TARGET = `${process.platform}-${process.arch}`;
+
+/**
+ * Every workspace package, as `{ name, location, pkg }`.
+ *
+ * Inline workspace walk — minimal-glob form (trailing `*` only) matches
+ * every pattern this monorepo's root pkg.workspaces uses.
+ */
+export function discoverWorkspaces() {
+    const rootPkg = JSON.parse(readFileSync(join(MONOREPO_ROOT, 'package.json'), 'utf8'));
+    const patterns = Array.isArray(rootPkg.workspaces) ? rootPkg.workspaces : (rootPkg.workspaces?.packages ?? []);
+    const out = [];
+    for (const pattern of patterns) {
+        const dirs = pattern.endsWith('/*')
+            ? readdirSync(join(MONOREPO_ROOT, pattern.slice(0, -2)), { withFileTypes: true })
+                  .filter((d) => d.isDirectory())
+                  .map((d) => join(MONOREPO_ROOT, pattern.slice(0, -2), d.name))
+            : [join(MONOREPO_ROOT, pattern)];
+        for (const dir of dirs) {
+            const pkgPath = join(dir, 'package.json');
+            if (!existsSync(pkgPath)) continue;
+            try {
+                const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+                if (!pkg.name) continue;
+                out.push({ name: pkg.name, location: relative(MONOREPO_ROOT, dir), pkg });
+            } catch {
+                /* unreadable — skip */
+            }
+        }
+    }
+    return out;
+}
+
+/**
+ * A per-target platform package (ADR 0017) for a target that is NOT this host's.
+ *
+ * A consumer never installs more than one of them — that IS the split: the
+ * bridge lists every target as an `optionalDependencies` entry, each child
+ * declares `os`/`cpu`, and the package manager takes the one that fits and
+ * silently skips the rest. A temp tree simulating an external consumer is
+ * therefore MORE faithful without the other five, not less.
+ *
+ * It is also the difference between a suite that finishes and one that does not.
+ * `createTestEnvironment()` packs the whole workspace and 34 e2e suites call it,
+ * so the split added 58 tarballs carrying ~98 MB of committed binaries to every
+ * one of them. Measured in CI: 127 packages / 199 s on `main`, 185 / 258 s with
+ * the split — which pushed `cli-only-pnp` past its parent's timeout ("test did
+ * not finish before its parent and was cancelled"). Filtering to the host target
+ * keeps the prebuilds `dlx-native-prebuilds` and `napi-transparent-app-gjs`
+ * actually resolve at run time, and drops only bytes no install in the tree
+ * could have used.
+ *
+ * @param {Record<string, any>} pkg a parsed package.json
+ */
+export function isForeignPlatformPackage(pkg) {
+    const g = pkg.gjsify;
+    if (!g || typeof g !== 'object') return false;
+    if (typeof g.prebuilds !== 'string') return false;
+    if (!Array.isArray(g.platforms) || g.platforms.length !== 1) return false;
+    // `os`/`cpu` are what make the package skippable for a real consumer, so
+    // they are what identify it here — the same signature
+    // `isPlatformPackageManifest()` uses, inlined because this module
+    // deliberately imports nothing outside node builtins.
+    if (!Array.isArray(pkg.os) || !Array.isArray(pkg.cpu)) return false;
+    return g.platforms[0] !== HOST_TARGET;
+}
+
+/**
+ * The workspaces `pack.mjs` turns into tarballs.
+ *
+ * Skip templates (consumed via scaffolding, not installed as deps) and private
+ * packages. Examples stay in because @gjsify/cli depends on @gjsify/example-*
+ * showcases.
+ */
+export function packableWorkspaces() {
+    return discoverWorkspaces().filter((w) => {
+        if (w.name.startsWith('@gjsify/template-')) return false;
+        if (isForeignPlatformPackage(w.pkg)) return false;
+        return !w.pkg.private;
+    });
+}
+
+/**
+ * The `@gjsify/*` packages a tree built from those tarballs still has to fetch
+ * from **npm**: declared as a runtime / optional / peer dependency by something
+ * that IS packed, but not packed itself.
+ *
+ * Derived rather than listed. Today the answer is exactly the foreign-target
+ * platform packages, but stating it that way would be stating a coincidence: any
+ * future omission from `packableWorkspaces()` — a package turned private, a new
+ * exclusion — lands a consumer in the same registry dependency without touching
+ * anything that names it. `devDependencies` are left out on purpose; a
+ * dependency's dev deps are not installed into a consumer's tree.
+ *
+ * @returns {{name: string, version: string}[]} sorted by name
+ */
+export function registryOnlyDependencies() {
+    const all = discoverWorkspaces();
+    const byName = new Map(all.map((w) => [w.name, w]));
+    const packed = new Set(packableWorkspaces().map((w) => w.name));
+
+    const needed = new Map();
+    for (const w of all) {
+        if (!packed.has(w.name)) continue;
+        for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+            for (const name of Object.keys(w.pkg[field] ?? {})) {
+                if (!name.startsWith('@gjsify/') || packed.has(name) || needed.has(name)) continue;
+                // Only workspace members carry a version this release moves. A
+                // genuinely external @gjsify dependency resolves from npm at a
+                // published range and is unaffected by the release window.
+                const target = byName.get(name);
+                if (target?.pkg.version) needed.set(name, { name, version: target.pkg.version });
+            }
+        }
+    }
+
+    return [...needed.values()].sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}


### PR DESCRIPTION
Two E2E shards went red on `main` **and** on #1041 within the same hour, with identical output:

```
Error: Command failed: yarn install --no-immutable
! Corepack is about to download https://repo.yarnpkg.com/4.14.1/packages/yarnpkg-cli/bin/yarn.js
```

`setupProjectYarnPnp` writes `packageManager: 'yarn@4.14.1'`, so Corepack fetches that exact Yarn — and **asks first**. There is no TTY in CI, so the prompt is not a pause; it is an immediate `exit 1`.

## Why it reads as a code failure

The install throws inside a `before` hook, so the suite reports **its own tests** as the failures:

```
✖ builds a script importing node:fs (relay → @gjsify/fs)
✖ builds a script importing node:path (relay → @gjsify/path)
✖ rewriter injects __filename for CJS code in node_modules under PnP namespace
```

None of those ran. The one line that says what actually happened is buried in the exec error's stderr. I first read this as a consequence of the v0.31.0 version bump — it appeared on the release commit — and it is not: it reproduces on #1041, whose diff is two CI files.

## Not a regression

`grep -rn corepack tests/e2e/helpers.mjs .github/workflows/main.yml` → nothing. The variable has never been set. It stays invisible for as long as the runner image happens to carry that Yarn in Corepack's cache, and reddens the moment the image, the pinned Yarn, or Corepack's default moves.

## Placement

In the shared helper, not per suite and not in the workflow env. `pnp-zip-static-reads` and `cli-only-pnp` are the only callers today and both reach `yarn` exclusively through `setupProjectYarnPnp`, so a third PnP suite inherits the fix without having to know it exists.

## Scope

Deliberately separate from #1041 (the v0.31.0 publish fix). Mixing an urgent release repair with an unrelated CI defect makes both harder to review and to revert.
