### PR TITLE
fix(release): give the napi prebuild leg a node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1185,6 +1185,23 @@ jobs:
           echo "gjs-1.0:   $(pkg-config --modversion gjs-1.0)"
           echo "valac:     $(valac --version)"
 
+      # `.docker/ci-fedora.Dockerfile` bakes NO nodejs/npm, deliberately and in
+      # those words — every job on that image brings its own via setup-node. The
+      # staging step below runs `node scripts/stage-prebuild.mjs`, so without
+      # this the leg dies with `node: command not found` (exit 127) AFTER a
+      # fully successful meson build. That is exactly how v0.31.0 shipped: 60
+      # packages and `@gjsify/node-gi` went out, `@gjsify/napi` did not, because
+      # this step was copied from napi.yml without the setup-node that precedes
+      # it there (napi.yml's three container jobs all carry one).
+      #
+      # Version matches `publish-napi` below rather than napi.yml's '24' — same
+      # image, same workflow, and the Dockerfile's `libatomic` note is written
+      # for setup-node >= 26.
+      - name: Setup Node.js (the baked image ships none)
+        uses: actions/setup-node@v6
+        with:
+          node-version: '26.x'
+
       - name: Checkout repository (the released tag)
         uses: actions/checkout@v4
         with:

--- a/scripts/check-ci-image-packages.mjs
+++ b/scripts/check-ci-image-packages.mjs
@@ -16,6 +16,37 @@
 //      `unchecked-fields.mjs` idiom: an honest "not yet" is available, a
 //      silent one is not.
 //
+//   3. The MIRROR of (1): does a job USE a tool the image does not carry and
+//      never installs? (1) catches installing what is already there; the
+//      symmetric mistake — reaching for what was never there — is what shipped
+//      half of v0.31.0.
+//
+// THE INCIDENT BEHIND (3)
+//
+// `release.yml`'s `napi-prebuild-linux` runs on the baked image and ends in
+// `node ../../../scripts/stage-prebuild.mjs .`. The Dockerfile carries no
+// nodejs, in those words: "no nodejs/npm baked in — the workflow uses
+// actions/setup-node". That job had no setup-node step. So on the v0.31.0
+// publish the meson build ran to completion — all 16 ninja targets, the
+// typelib generated — and the step then died on `node: command not found`,
+// exit 127. `publish-napi` needs that artifact, so it was skipped: the whole
+// 0.31.0 sweep published, `@gjsify/node-gi` published, and `@gjsify/napi`
+// alone stayed at 0.30.0.
+//
+// Two things made it invisible until a real release. The step was copied from
+// `napi.yml`, where all three container jobs DO carry a setup-node, but the
+// copy took the `run:` and not the step before it. And `release.yml` runs on
+// `release`/`workflow_dispatch` only, so no PR ever executed it — the same
+// reason `check-workflow-inline-scripts.mjs` exists, and the same failure
+// shape as the v0.28.0 gtk-runtime lag that check was written for.
+//
+// This check has no judgement call in it: on a bare or baked Fedora image
+// `node` is present only if something in the job put it there. The three other
+// container jobs that invoke node all pass because they genuinely provide it —
+// two through `./.github/actions/gjsify-setup` (which runs setup-node), one
+// through its own `dnf install … nodejs`. All three ways are recognised, so
+// the check states a fact rather than a house style.
+//
 // Why (2) is worth a check rather than a comment: during the v0.26.0 release
 // sweep the `dnf install` step took 41 minutes twice (normal: 22 seconds) and
 // killed the Adwaita-storybook job on its timeout, while a Docker Hub pull
@@ -36,13 +67,20 @@
 // linux/arm64 therefore deletes three exemptions at once, with nothing to
 // remember to update.
 //
-// Usage: node scripts/check-ci-image-packages.mjs [--json]
+// Usage: node scripts/check-ci-image-packages.mjs [--json] [--root <dir>]
+//
+// `--root` exists so the checks can be run against a FIXTURE tree — the same
+// affordance `check-workflow-inline-scripts.mjs` has, and for the same reason:
+// a guard whose failure path is never executed is the shape it was written to
+// catch. `tests/e2e/release-bundle-gate` drives it.
 
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-const WORKFLOW_DIR = '.github/workflows';
-const DOCKERFILE = '.docker/ci-fedora.Dockerfile';
+const rootIndex = process.argv.indexOf('--root');
+const ROOT = rootIndex === -1 ? '.' : process.argv[rootIndex + 1];
+const WORKFLOW_DIR = join(ROOT, '.github/workflows');
+const DOCKERFILE = join(ROOT, '.docker/ci-fedora.Dockerfile');
 const IMAGE_WORKFLOW = 'build-ci-image.yml';
 const BAKED_IMAGE = 'ghcr.io/gjsify/ci-fedora';
 
@@ -82,25 +120,87 @@ function scanWorkflow(file) {
         const line = lines[i];
         const job = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
         if (job) {
-            cur = { id: `${file}/${job[1]}`, image: null, run: '', runners: [] };
+            cur = { id: `${file}/${job[1]}`, image: null, run: '', runners: [], uses: [], commands: [] };
             jobs.push(cur);
             continue;
         }
         if (!cur) continue;
         const img = /^\s*image:\s*(\S+)/.exec(line);
         if (img && !cur.image) cur.image = img[1];
+        // `uses:` steps, for question (3): a step can PROVIDE a tool as well as
+        // install one, and a local composite action can provide it one level down.
+        const uses = /^\s*(?:- )?uses:\s*(\S+)/.exec(line);
+        if (uses) cur.uses.push(uses[1]);
+        // Single-line `run:` too, into `commands` ONLY. A one-line `run:` is a
+        // command to check for (3), but folding it into `run` would hand question
+        // (1) a package list it has never read — a behaviour change smuggled in as
+        // a refactor. Block scalars go to both; this form goes to one.
+        const inlineRun = /^\s*(?:- )?run:\s+(?![|>])(.*)$/.exec(line);
+        if (inlineRun) cur.commands.push({ line: i + 1, text: inlineRun[1] });
         // Both spellings, because the arm64 legs use the second: a literal
         // `runs-on:`, and the `runner:` values of a static matrix `include:`
         // that `runs-on: ${{ matrix.runner }}` selects from.
         const runner = /^\s*(?:- )?(?:runs-on|runner):\s*(\S+)/.exec(line);
         if (runner && !runner[1].startsWith('${{')) cur.runners.push(runner[1]);
-        if (/^\s*(- )?run:\s*\|/.test(line)) {
+        // Both block scalars. `|` alone missed every `run: >` — including
+        // `prebuilds.yml`'s only `dnf install`, so question (1) had never read that
+        // job's package list at all and question (3) would have called its perfectly
+        // good nodejs install absent.
+        //
+        // A `>` block is FOLDED as YAML folds it (lines joined by a space) rather
+        // than copied verbatim: `packagesIn` reads a `dnf install` list to end of
+        // line, and in the folded spelling the packages are on the lines after it.
+        // Doing it here keeps that parser one parser instead of two.
+        const block = /^\s*(- )?run:\s*([|>])/.exec(line);
+        if (block) {
+            const folded = block[2] === '>';
             for (let j = i + 1; j < lines.length && (lines[j].trim() === '' || /^ {10}/.test(lines[j])); j++) {
-                cur.run += lines[j] + '\n';
+                cur.run += folded ? lines[j].trim() + ' ' : lines[j] + '\n';
+                cur.commands.push({ line: j + 1, text: lines[j] });
             }
+            if (folded) cur.run += '\n';
         }
     }
     return jobs;
+}
+
+// Question (3). The tools `actions/setup-node` puts on PATH and nothing else
+// does on a Fedora image. `corepack`/`npx`/`npm` ship with Node, so a job that
+// reaches for any of them needs the same provision.
+const NODE_TOOLS = ['node', 'npx', 'npm', 'corepack'];
+// Must be a COMMAND, not a substring: `node-gi`, `node_modules`, `nodejs` and
+// `--app node` all contain the word and none of them invoke the binary. So the
+// token has to start a command — line start, or after a shell operator/`-c "` —
+// and be followed by whitespace or end.
+const NODE_CALL = new RegExp(
+    String.raw`(?:^|[;&|(]|&&|\|\||\bsudo\s|\bsu\s[^;&|]*-c\s*['"])\s*(${NODE_TOOLS.join('|')})(?=\s|$)`,
+);
+const COMMENT = /^\s*#/;
+
+/** A step that puts Node on PATH: setup-node itself, or a local composite action that does. */
+function providesNode(job, root) {
+    for (const ref of job.uses) {
+        if (ref.startsWith('actions/setup-node')) return `${ref} step`;
+        if (!ref.startsWith('./')) continue;
+        // A local composite action, one level down — `main.yml`'s jobs get Node
+        // this way and are correct. Not recursed further: this repo nests one deep,
+        // and an unbounded walk would trade a real check for a clever one.
+        for (const candidate of ['action.yml', 'action.yaml']) {
+            let body;
+            try {
+                body = readFileSync(join(root, ref.slice(2), candidate), 'utf8');
+            } catch {
+                continue;
+            }
+            if (body.includes('actions/setup-node')) return `${ref} (runs setup-node)`;
+        }
+    }
+    // Or the job installs it itself — `prebuilds.yml` does exactly this, naming
+    // `stage-prebuild.mjs` as the reason in a comment beside it. Read through the
+    // SAME parser question (1) uses, so the two can never disagree about what a
+    // job installs.
+    if (packagesIn(job.run).has('nodejs')) return 'its own nodejs install';
+    return null;
 }
 
 const dockerfile = readFileSync(DOCKERFILE, 'utf8');
@@ -133,11 +233,35 @@ const runnerArch = (label) => (/-arm$|^.*arm64.*$/.test(label) ? 'arm64' : 'amd6
 const problems = [];
 const bare = [];
 const excused = [];
+const nodeProvisioned = [];
 let bakedJobs = 0;
 
 for (const file of readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith('.yml'))) {
     for (const job of scanWorkflow(file)) {
         if (!job.image) continue;
+
+        // (3) Node is present on these images only if the job put it there.
+        // Derived, not assumed: the day the Dockerfile bakes nodejs, baked-image
+        // jobs stop needing a setup-node step and this stops asking for one.
+        const imageShipsNode = job.image.startsWith(BAKED_IMAGE) && baked.has('nodejs');
+        if ((job.image.startsWith(BAKED_IMAGE) || job.image.startsWith('fedora:')) && !imageShipsNode) {
+            const calls = job.commands.filter((c) => !COMMENT.test(c.text) && NODE_CALL.test(c.text));
+            if (calls.length) {
+                const how = providesNode(job, ROOT);
+                if (how) {
+                    nodeProvisioned.push(`${job.id} — ${calls.length} node call(s), provided by ${how}`);
+                } else {
+                    const first = calls[0];
+                    problems.push(
+                        `${job.id} runs on ${job.image}, which ships no node, and invokes it anyway ` +
+                            `(${file}:${first.line}: ${first.text.trim().slice(0, 72)}). Add an actions/setup-node ` +
+                            `step, or install nodejs in the job. This is how v0.31.0 published everything ` +
+                            `except @gjsify/napi.`,
+                    );
+                }
+            }
+        }
+
         if (job.image.startsWith(BAKED_IMAGE)) {
             bakedJobs += 1;
             const missing = [...packagesIn(job.run)].filter((p) => !baked.has(p)).sort();
@@ -189,12 +313,19 @@ for (const id of Object.keys(BARE_IMAGE_LEDGER)) {
 }
 
 if (process.argv.includes('--json')) {
-    console.log(JSON.stringify({ bakedJobs, bare, excused, ledgered: BARE_IMAGE_LEDGER, problems }, null, 2));
+    console.log(
+        JSON.stringify({ bakedJobs, bare, excused, nodeProvisioned, ledgered: BARE_IMAGE_LEDGER, problems }, null, 2),
+    );
 } else {
     console.log(
         `ci-image: ${bakedJobs} job(s) on ${BAKED_IMAGE}, ${bare.length} still on a bare fedora image ` +
-            `(${excused.length} with no image to move to, ${Object.keys(BARE_IMAGE_LEDGER).length} ledgered).`,
+            `(${excused.length} with no image to move to, ${Object.keys(BARE_IMAGE_LEDGER).length} ledgered); ` +
+            `${nodeProvisioned.length} container job(s) invoke node and provide it.`,
     );
+    // Printed like the exemptions above, and for the same reason: the interesting
+    // number is how many jobs depend on a provision step that is easy to drop when
+    // a `run:` block is copied without the step above it.
+    for (const n of nodeProvisioned.sort()) console.log(`  · ${n}`);
     // Printed every run, both kinds: the derived exemptions are the work item
     // (one `platforms:` edit retires all of them), the ledgered ones are the
     // decisions somebody owns.

--- a/tests/e2e/release-bundle-gate/run.mjs
+++ b/tests/e2e/release-bundle-gate/run.mjs
@@ -36,6 +36,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
 const VERIFY = join(MONOREPO_ROOT, 'packages', 'node-gi', 'scripts', 'verify-bundle-manifest.mjs');
 const GUARD = join(MONOREPO_ROOT, 'scripts', 'check-workflow-inline-scripts.mjs');
+const IMAGE_GUARD = join(MONOREPO_ROOT, 'scripts', 'check-ci-image-packages.mjs');
 
 /** The measured shape of a good v0.28.0 darwin-arm64 bundle manifest. */
 function goodManifest(overrides = {}) {
@@ -213,6 +214,159 @@ describe('check-workflow-inline-scripts: the regrow guard', () => {
 
     it("holds for this repo's own workflows", () => {
         const result = spawnSync(process.execPath, [GUARD, '--root', MONOREPO_ROOT], { encoding: 'utf8' });
+        assert.equal(result.status, 0, result.output);
+    });
+});
+
+// The third script that only a real release used to exercise. `release.yml`'s
+// `napi-prebuild-linux` ran `node scripts/stage-prebuild.mjs` on an image whose
+// Dockerfile says, in those words, "no nodejs/npm baked in". On the v0.31.0 publish
+// meson built all 16 targets and the step then died on `node: command not found`
+// (exit 127); `publish-napi` needs that artifact, so it was skipped and `@gjsify/napi`
+// alone stayed at 0.30.0 while the other 60 packages went out. Same suite, same
+// reason: this is where its failure path runs before a release finds it.
+describe('check-ci-image-packages: the node-availability guard', () => {
+    const dockerfileWith = (packages) =>
+        ['FROM fedora:44', 'RUN dnf install -y \\', `    ${packages} \\`, '    && dnf clean all', ''].join('\n');
+    const BAKED_DOCKERFILE = dockerfileWith('gjs meson vala');
+
+    function runImageGuard(workflowFiles, dockerfile = BAKED_DOCKERFILE) {
+        const root = mkdtempSync(join(tmpdir(), 'gjsify-image-guard-'));
+        mkdirSync(join(root, '.github', 'workflows'), { recursive: true });
+        mkdirSync(join(root, '.docker'), { recursive: true });
+        writeFileSync(join(root, '.docker', 'ci-fedora.Dockerfile'), dockerfile);
+        writeFileSync(
+            join(root, '.github', 'workflows', 'build-ci-image.yml'),
+            [
+                'jobs:',
+                '  image:',
+                '    steps:',
+                '      - uses: docker/build-push-action@v6',
+                '        with:',
+                '          platforms: linux/amd64',
+                '',
+            ].join('\n'),
+        );
+        for (const [name, body] of Object.entries(workflowFiles)) {
+            writeFileSync(join(root, '.github', 'workflows', name), body);
+        }
+        const result = spawnSync(process.execPath, [IMAGE_GUARD, '--root', root], { encoding: 'utf8' });
+        return { ...result, output: `${result.stdout}${result.stderr}` };
+    }
+
+    it('rejects the exact step that stranded @gjsify/napi at 0.30.0', () => {
+        const result = runImageGuard({
+            'release.yml': [
+                'jobs:',
+                '  napi-prebuild-linux:',
+                '    runs-on: ubuntu-latest',
+                '    container:',
+                '      image: ghcr.io/gjsify/ci-fedora:44',
+                '    steps:',
+                '      - uses: actions/checkout@v4',
+                '      - name: Build the shim + stage prebuild',
+                '        run: |',
+                '          meson setup build .',
+                '          node ../../../scripts/stage-prebuild.mjs .',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 1);
+        assert.match(result.stderr, /release\.yml\/napi-prebuild-linux/);
+        assert.match(result.stderr, /which ships no node, and invokes it anyway/);
+        assert.match(result.stderr, /release\.yml:11/);
+    });
+
+    it('accepts the same job once it provides node', () => {
+        const result = runImageGuard({
+            'release.yml': [
+                'jobs:',
+                '  napi-prebuild-linux:',
+                '    runs-on: ubuntu-latest',
+                '    container:',
+                '      image: ghcr.io/gjsify/ci-fedora:44',
+                '    steps:',
+                '      - uses: actions/setup-node@v6',
+                '        with:',
+                "          node-version: '26.x'",
+                '      - run: |',
+                '          node ../../../scripts/stage-prebuild.mjs .',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /provided by actions\/setup-node@v6 step/);
+    });
+
+    // The false positive a naive rule produces. `prebuilds.yml` installs nodejs
+    // itself, in a FOLDED (`run: >`) block whose package list is on the lines after
+    // `dnf install -y` — invisible to a scanner that reads block scalars verbatim or
+    // only handles `|`. A check that fails here gets switched off, and then it guards
+    // nothing.
+    it('accepts a job that installs nodejs itself in a folded run block', () => {
+        const result = runImageGuard({
+            'prebuilds.yml': [
+                'jobs:',
+                '  build-prebuilds:',
+                '    runs-on: ubuntu-24.04-arm',
+                '    container:',
+                '      image: fedora:43',
+                '    steps:',
+                '      - run: >',
+                '          dnf install -y',
+                '          git tar xz',
+                '          nodejs',
+                '          meson vala',
+                '      - run: node ../../../scripts/stage-prebuild.mjs . --scratch',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 0, result.output);
+        assert.match(result.stdout, /provided by its own nodejs install/);
+    });
+
+    it('does not mistake node-shaped words for an invocation', () => {
+        const result = runImageGuard({
+            'main.yml': [
+                'jobs:',
+                '  build:',
+                '    runs-on: ubuntu-latest',
+                '    container:',
+                '      image: ghcr.io/gjsify/ci-fedora:44',
+                '    steps:',
+                '      - run: |',
+                '          rm -rf node_modules',
+                '          gjsify build --app node',
+                '          gjs -m packages/node-gi/dist/test.mjs',
+                '',
+            ].join('\n'),
+        });
+        assert.equal(result.status, 0, result.output);
+    });
+
+    // The derivation, not a hardcoded fact about the image: bake nodejs in and the
+    // check stops asking for setup-node, with nothing to remember to delete.
+    it('stands down when the image itself bakes nodejs', () => {
+        const withNode = dockerfileWith('gjs meson nodejs');
+        const workflow = {
+            'release.yml': [
+                'jobs:',
+                '  napi-prebuild-linux:',
+                '    runs-on: ubuntu-latest',
+                '    container:',
+                '      image: ghcr.io/gjsify/ci-fedora:44',
+                '    steps:',
+                '      - run: |',
+                '          node ../../../scripts/stage-prebuild.mjs .',
+                '',
+            ].join('\n'),
+        };
+        assert.equal(runImageGuard(workflow).status, 1);
+        assert.equal(runImageGuard(workflow, withNode).status, 0);
+    });
+
+    it("holds for this repo's own workflows", () => {
+        const result = spawnSync(process.execPath, [IMAGE_GUARD, '--root', MONOREPO_ROOT], { encoding: 'utf8' });
         assert.equal(result.status, 0, result.output);
     });
 });


### PR DESCRIPTION
## What happened

v0.31.0 published **60 packages and `@gjsify/node-gi`** — and left `@gjsify/napi` at 0.30.0.

`release.yml`'s `napi-prebuild-linux` runs on `ghcr.io/gjsify/ci-fedora:44` and ends its build step with `node ../../../scripts/stage-prebuild.mjs .`. The Dockerfile carries no nodejs, in those words:

> `# NOTE: no nodejs/npm baked in — the workflow uses actions/setup-node (Node 26.x) …`

The job had no setup-node step. From the run ([31223987716](https://github.com/gjsify/gjsify/actions/runs/31223987716)):

```
[15/16] Linking target libgjsifynapi.so
[16/16] Generating GjsifyNapi-1.0.typelib with a custom command
/__w/_temp/….sh: line 3: node: command not found
##[error]Process completed with exit code 127.
```

meson succeeded completely; only the staging died. `publish-napi` needs that artifact, so it was **skipped**, not failed — which is why the run reported one red job and everything else green.

Two things kept it invisible. The step is copied from `napi.yml`, where all three container jobs *do* carry a setup-node — the copy took the `run:` and not the step above it. And `release.yml` triggers on `release`/`workflow_dispatch` only, so no pull request has ever executed that job. That is the same reason `check-workflow-inline-scripts.mjs` exists, and the same failure shape as the v0.28.0 gtk-runtime lag it was written for.

## The guard

Rather than a fourth workflow-lint script, this goes in as **question (3)** of `check-ci-image-packages.mjs`, which already holds these images to their jobs:

1. does a job **install** what the image already has? (existing)
2. which jobs still pay `dnf install` on a bare image? (existing)
3. does a job **use** what the image never had? (new — the mirror of 1)

On a Fedora image `node` is present only if something in the job put it there, so the rule has no judgement call in it. All three ways of putting it there are recognised — a `setup-node` step, a local composite action that runs one, an own `dnf install … nodejs` — which is why the other **15** container jobs that invoke node pass unchanged and are now listed on every run:

```
ci-image: 21 job(s) on ghcr.io/gjsify/ci-fedora, 3 still on a bare fedora image …;
          15 container job(s) invoke node and provide it.
  · main.yml/build — 7 node call(s), provided by ./.github/actions/gjsify-setup (runs setup-node)
  · napi.yml/build-test — 10 node call(s), provided by actions/setup-node@v4 step
  · prebuilds.yml/build-prebuilds — 12 node call(s), provided by its own nodejs install
  …
```

Proven in both directions, which is the only claim worth making about a guard:

```
$ node scripts/check-ci-image-packages.mjs        # unpatched release.yml
  ✗ release.yml/napi-prebuild-linux runs on ghcr.io/gjsify/ci-fedora:44, which ships no
    node, and invokes it anyway (release.yml:1219: node ../../../scripts/stage-prebuild.mjs .)
ci-image: 1 problem(s).                                                          → exit 1

$ node scripts/check-ci-image-packages.mjs        # patched
ci-image: … 15 container job(s) invoke node and provide it.                      → exit 0
```

## Two scanner defects found while proving it

Both would have made the check lie, and one of them was already making question (1) lie:

- **`run: >` was not read at all.** The scanner only captured `run: |`. `prebuilds.yml`'s only `dnf install` is a folded block, so question (1) had never read that job's package list — and question (3) would have called its perfectly good nodejs install absent. Folded blocks are now folded the way YAML folds them, so `packagesIn` stays one parser instead of two.
- **Single-line `run:` steps were invisible.** They now feed the command scan only; question (1) keeps reading exactly what it read before, so this is not a behaviour change smuggled in as a refactor.

## Tests

Six cases in `tests/e2e/release-bundle-gate` — the suite whose header says it "IS the pre-release coverage: it is the only place either script runs before a release exercises it for real". Now three scripts:

- the exact step that stranded `@gjsify/napi`
- the same job once it provides node
- the folded-install shape (`prebuilds.yml`) — the false positive a naive rule produces, and the reason a first draft of the sibling guard was rewritten
- `node_modules` / `--app node` / `node-gi` are not invocations
- the derivation itself: bake nodejs into the fixture Dockerfile and the check stands down
- the repo's own workflows

`node --test tests/e2e/release-bundle-gate/run.mjs` → **18/18**.

`--root` was added to the script for the fixture tests, the same affordance `check-workflow-inline-scripts.mjs` already has.

## Deliberately not in this PR

`napi-prebuild-darwin-arm64` has no setup-node either and passes only because macOS runners ship an ambient node; `napi.yml`'s macOS job pins one. It is the same divergence, but it is a **green** leg on the release path and this PR exists to recover a red one — pinning it is a behaviour change to make when nothing is waiting on it. The new guard does not cover it (GitHub-hosted runners genuinely ship node, so flagging them would be the false positive that gets a check switched off).

## After merge

Re-dispatch `release.yml` from `main` to publish `@gjsify/napi` at 0.31.0. The sweep is `--tolerate-republish`, so the 60 already-published packages are a no-op.
