### PR TITLE
fix(cli): check before acting, and report only what happened

### DIFF
--- a/.github/workflows/cli-cross-platform.yml
+++ b/.github/workflows/cli-cross-platform.yml
@@ -173,15 +173,21 @@ jobs:
       # release that fixes it, with no edit here and no hand-maintained
       # "currently skipped" list to drift.
       #
-      # LOWEST_FIXED is a BOUND, not a prediction of the next version number:
-      # the fix merged after 0.25.1, and every later release compares >= 0.25.2
-      # in semver order (0.26.0 included).
+      # TWO bounds, because this step now gates TWO fixes that shipped in
+      # DIFFERENT releases — the node-gi step below learned the same lesson the
+      # hard way ("one bound served both and therefore lied about one of them").
+      # Each is a BOUND, not a prediction of the next version number:
+      #   * LOWEST_FIXED — the runtime gate must not demand gjs for
+      #     `--runtime node`. Merged after 0.25.1, so >= 0.25.2 (#889).
+      #   * LOWEST_PREFLIGHT_FIXED — the declaration check must run BEFORE the
+      #     install, not after it. Merged after 0.31.0, so >= 0.31.1 (#1069).
       - name: 'Showcase: --runtime node does not demand gjs'
         id: showcase
         continue-on-error: true
         working-directory: gjsify-diag
         env:
           LOWEST_FIXED: '0.25.2'
+          LOWEST_PREFLIGHT_FIXED: '0.31.1'
         run: |
           set -eux
           out="$(npx gjsify showcase webrtc-loopback --runtime node 2>&1 || true)"
@@ -190,12 +196,19 @@ jobs:
           # Compared in node (present by definition here); `sort -V` is not
           # portable across git-bash and BSD userland. Values travel through
           # the environment, never through string interpolation.
-          HAS_FIX="$(INSTALLED="$INSTALLED" node -e '
-            const parse = (v) => v.split("-")[0].split(".").map(Number);
-            const [a, b] = [process.env.INSTALLED, process.env.LOWEST_FIXED].map(parse);
-            const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
-            process.stdout.write(cmp >= 0 ? "1" : "0");
-          ')"
+          #
+          # One comparison, two call sites — a shell function for the same reason
+          # the node-gi step below uses one: two inline copies serving two
+          # different bounds is how the wrong fix got demanded of a release.
+          has_fix() {
+            INSTALLED="$1" BOUND="$2" node -e '
+              const parse = (v) => v.split("-")[0].split(".").map(Number);
+              const [a, b] = [process.env.INSTALLED, process.env.BOUND].map(parse);
+              const cmp = a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+              process.stdout.write(cmp >= 0 ? "1" : "0");
+            '
+          }
+          HAS_FIX="$(has_fix "$INSTALLED" "$LOWEST_FIXED")"
           if echo "$out" | grep -q "Missing system dependencies"; then
             if [ "$HAS_FIX" = "1" ]; then
               echo "::error::@gjsify/cli $INSTALLED demanded gjs for --runtime node — the runtime gate ran too early"
@@ -205,6 +218,24 @@ jobs:
             exit 0
           fi
           echo "$out" | grep -q "does not support --runtime node"
+
+          # The error being RIGHT is not the whole property (#1069). It used to be
+          # produced only AFTER a full resolve + download of the showcase tree and
+          # the pinned native `@gjsify/node-gi` bridge — the bridge fetched
+          # BECAUSE `--runtime node` was requested, to support a runtime the
+          # package was about to refuse. The declaration is in the registry
+          # packument, so it must be answered with one metadata GET and no
+          # install. Asserting the ABSENCE of the install lines is what turns
+          # "the error is right" into "the error is right and nothing was
+          # downloaded to produce it" — the part that actually regressed.
+          if [ "$(has_fix "$INSTALLED" "$LOWEST_PREFLIGHT_FIXED")" = "1" ]; then
+            if echo "$out" | grep -q "gjsify install:"; then
+              echo "::error::@gjsify/cli $INSTALLED installed the showcase tree before the declaration check rejected the run"
+              exit 1
+            fi
+          elif echo "$out" | grep -q "gjsify install:"; then
+            echo "::warning::@gjsify/cli $INSTALLED predates the showcase pre-flight (< $LOWEST_PREFLIGHT_FIXED) — known gap, not failing"
+          fi
 
       # The PUBLISH-side question no other gate asks. `audit-runtimes --check` holds
       # "a declared target is produced by a CI job", and `node-gi.yml` genuinely

--- a/packages/infra/cli/src/commands/self-update.ts
+++ b/packages/infra/cli/src/commands/self-update.ts
@@ -30,6 +30,7 @@ import type { Command } from '../types/index.js';
 import { installPackages, makeProgressReporter } from '../utils/install-backend.js';
 import {
     defaultGlobalLayout,
+    globalLayoutIsDefault,
     hasBundlerEngineInstalled,
     installGjsEnginePackages,
     linkGlobalBins,
@@ -209,17 +210,24 @@ export const selfUpdateCommand: Command<unknown, SelfUpdateOptions> = {
 
         // Did the update change what `gjsify` RUNS? Everything above only proves
         // we wrote the prefix. See the #1064 note at the top of this file.
-        const verdict = verifyPathResolution({
-            binName: BIN_NAME,
-            binDir: layout.binDir,
-            resolvedBin: resolveBinOnPath(BIN_NAME),
-            runningVersion: currentVersion,
-            targetVersion: target,
-        });
-        if (!verdict.ok) {
-            console.error(`\nInstalled ${PACKAGE_NAME} v${target} at ${layout.prefix}`);
-            console.error(verdict.message);
-            return process.exit(1);
+        //
+        // Only for the user's OWN layout: a caller that redirected the install
+        // with GJSIFY_GLOBAL_PREFIX/_BIN_DIR manages placement itself, and
+        // telling a harness that installed into a temp prefix "your PATH still
+        // points elsewhere" is true and useless.
+        if (globalLayoutIsDefault()) {
+            const verdict = verifyPathResolution({
+                binName: BIN_NAME,
+                binDir: layout.binDir,
+                resolvedBin: resolveBinOnPath(BIN_NAME),
+                runningVersion: currentVersion,
+                targetVersion: target,
+            });
+            if (!verdict.ok) {
+                console.error(`\nInstalled ${PACKAGE_NAME} v${target} at ${layout.prefix}`);
+                console.error(verdict.message);
+                return process.exit(1);
+            }
         }
 
         console.log(`\nUpdated ${PACKAGE_NAME} to v${target}.`);

--- a/packages/infra/cli/src/commands/self-update.ts
+++ b/packages/infra/cli/src/commands/self-update.ts
@@ -11,9 +11,18 @@
 // `defaultGlobalLayout().prefix` (i.e. via `gjsify install -g` or via the
 // `install.mjs` bootstrap). Installs from `npm install -g @gjsify/cli` land
 // elsewhere and we don't try to chase them — we print a warning and exit.
+//
+// AND THE WARNING IS NOT ENOUGH ON ITS OWN (#1064). This command's whole job is
+// to change which binary the user's next `gjsify` runs, so success has to be
+// measured on PATH, not on the prefix it wrote. Reported from a Windows host:
+// the pre-install warning fired, the install succeeded, `Updated @gjsify/cli to
+// v0.31.0` printed — and the shell kept resolving a v0.26.0 npm-global install,
+// so the very next command re-hit the `dlx` EPERM fixed three releases earlier.
+// A silent no-op that reports success is worse than a clean failure, so the
+// post-link verification below is fatal.
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, posix, resolve, win32 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { fetchPackument, type Packument } from '@gjsify/npm-registry';
 import type { Argv } from 'yargs';
@@ -24,6 +33,7 @@ import {
     hasBundlerEngineInstalled,
     installGjsEnginePackages,
     linkGlobalBins,
+    resolveBinOnPath,
 } from '../utils/install-global.js';
 
 interface SelfUpdateOptions {
@@ -196,6 +206,22 @@ export const selfUpdateCommand: Command<unknown, SelfUpdateOptions> = {
                 console.log(`  • ${bin.link}  →  ${bin.target}`);
             }
         }
+
+        // Did the update change what `gjsify` RUNS? Everything above only proves
+        // we wrote the prefix. See the #1064 note at the top of this file.
+        const verdict = verifyPathResolution({
+            binName: BIN_NAME,
+            binDir: layout.binDir,
+            resolvedBin: resolveBinOnPath(BIN_NAME),
+            runningVersion: currentVersion,
+            targetVersion: target,
+        });
+        if (!verdict.ok) {
+            console.error(`\nInstalled ${PACKAGE_NAME} v${target} at ${layout.prefix}`);
+            console.error(verdict.message);
+            return process.exit(1);
+        }
+
         console.log(`\nUpdated ${PACKAGE_NAME} to v${target}.`);
         if (pullDeps) {
             console.log('Runtime dependencies were resolved alongside the bundle.');
@@ -204,6 +230,68 @@ export const selfUpdateCommand: Command<unknown, SelfUpdateOptions> = {
         }
     },
 };
+
+/** The bin `@gjsify/cli` installs, and the name a user types. */
+const BIN_NAME = 'gjsify';
+
+/** Verdict of the post-install "did this change what runs?" check. */
+export type PathVerdict = { ok: true } | { ok: false; message: string };
+
+/**
+ * Compare where PATH sends `binName` against the `binDir` we just linked into.
+ *
+ * Pure so the three outcomes are unit-testable off-host — the interesting two
+ * are exactly the ones a developer's own machine never produces, since a working
+ * install resolves to its own `binDir` by definition.
+ *
+ * Path comparison is case-INSENSITIVE on win32: `C:\Users\X\.local\bin` and
+ * `c:\users\x\.local\bin` are one directory there, and a case-sensitive compare
+ * would report a correct install as shadowed.
+ */
+export function verifyPathResolution(opts: {
+    binName: string;
+    binDir: string;
+    resolvedBin: string | null;
+    /** `null` is what `readCurrentVersion()` returns when it cannot tell. */
+    runningVersion: string | null | undefined;
+    targetVersion: string;
+    platform?: NodeJS.Platform;
+}): PathVerdict {
+    const platform = opts.platform ?? process.platform;
+    // The TARGET platform's path module, never the host's — see `pathFor` in
+    // `utils/install-global.ts` for why (`resolve('C:\\x')` on posix is wrong).
+    const p = platform === 'win32' ? win32 : posix;
+    const norm = (v: string) => (platform === 'win32' ? p.resolve(v).toLowerCase() : p.resolve(v));
+
+    if (opts.resolvedBin === null) {
+        return {
+            ok: false,
+            message:
+                `BUT nothing named \`${opts.binName}\` is on PATH, so the update cannot take effect.\n\n` +
+                `  Add the bin dir to PATH:\n    ${opts.binDir}`,
+        };
+    }
+
+    if (norm(p.dirname(opts.resolvedBin)) === norm(opts.binDir)) return { ok: true };
+
+    // Deliberately NOT split into "a rival install" vs "a transient runner"
+    // (npx/dlx, whose temp bin wins PATH for the length of the run). Both are the
+    // same fact — `gjsify` does not currently mean the tree we just wrote — and
+    // guessing which one it is would be a heuristic that can only be wrong. So
+    // the finding is stated and both remedies are offered.
+    const running = opts.runningVersion ? ` (v${opts.runningVersion})` : '';
+    return {
+        ok: false,
+        message:
+            `BUT \`${opts.binName}\` on PATH resolves to\n    ${opts.resolvedBin}${running}\n` +
+            `which is NOT the install that was just updated, so the next \`${opts.binName}\`\n` +
+            `you run will not be v${opts.targetVersion}.\n\n` +
+            `  If that is another install, remove it (e.g. \`npm uninstall -g ${PACKAGE_NAME}\`)\n` +
+            `  or put ${opts.binDir} ahead of it on PATH.\n` +
+            `  If you ran this through npx/dlx, that temporary copy owns the name only for\n` +
+            `  this run — open a new shell and check \`${opts.binName} --version\`.`,
+    };
+}
 
 /**
  * Resolve the CLI's own `package.json#version`. Walks up from

--- a/packages/infra/cli/src/commands/showcase-preflight.spec.ts
+++ b/packages/infra/cli/src/commands/showcase-preflight.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+// Unit coverage for the showcase runtime pre-flight (#1069).
+//
+// The pre-flight exists to stop `showcase <gjs-only> --runtime node` from
+// downloading the whole dlx tree — plus the pinned native `@gjsify/node-gi`
+// bridge, fetched BECAUSE `--runtime node` was requested — before reading the
+// declaration that rejects the run.
+//
+// Every test here is about ONE contract: the pre-flight may only ever turn a run
+// that WOULD have failed into a faster failure. It must never fail a run that
+// would have worked. That property is entirely a question of which branches
+// answer `undefined` ("cannot say" → install, then let the on-disk check decide),
+// so those are the cases worth pinning.
+
+import { describe, expect, it } from '@gjsify/unit';
+import type { Packument } from '@gjsify/npm-registry';
+
+import { declaredRuntimesFromPackument } from './showcase.js';
+
+/** A packument carrying `versions` + `dist-tags`, shaped like the registry's. */
+function packument(versions: Record<string, unknown>, latest?: string): Packument {
+    return {
+        name: '@gjsify/example-gtk-adwaita-storybook',
+        'dist-tags': latest ? { latest } : {},
+        versions,
+    } as unknown as Packument;
+}
+
+const gjsOnly = { gjsify: { example: { runtimes: ['gjs'] } } };
+
+export default async () => {
+    await describe('showcase pre-flight: declaredRuntimesFromPackument', async () => {
+        await it('reads the declaration of the PINNED version', async () => {
+            // The real shape, verified against the live registry:
+            // `.versions["0.31.0"].gjsify.example.runtimes === ["gjs"]`.
+            const doc = packument({ '0.31.0': gjsOnly }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, '0.31.0')).toStrictEqual(['gjs']);
+        });
+
+        await it('does NOT let another version answer for the pinned one', async () => {
+            // 0.31.0 says gjs-only; 0.30.0 claims node. Asking about 0.30.0 must
+            // not return 0.31.0's answer, or the pre-flight would reject a run
+            // the installed showcase actually supports.
+            const doc = packument(
+                { '0.30.0': { gjsify: { example: { runtimes: ['gjs', 'node'] } } }, '0.31.0': gjsOnly },
+                '0.31.0',
+            );
+            expect(declaredRuntimesFromPackument(doc, '0.30.0')).toStrictEqual(['gjs', 'node']);
+        });
+
+        await it('says "cannot say" for a pinned version that is not published', async () => {
+            // A dev / pre-release CLI is the normal way here. Falling back to
+            // `latest` would answer a DIFFERENT question, so it must not.
+            const doc = packument({ '0.31.0': gjsOnly }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, '0.32.0-dev.1')).toBe(undefined);
+        });
+
+        await it('falls back to dist-tags.latest only when nothing is pinned', async () => {
+            const doc = packument({ '0.31.0': gjsOnly }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, undefined)).toStrictEqual(['gjs']);
+        });
+
+        await it('says "cannot say" with no pin and no latest tag', async () => {
+            const doc = packument({ '0.31.0': gjsOnly });
+            expect(declaredRuntimesFromPackument(doc, undefined)).toBe(undefined);
+        });
+
+        await it('is PERMISSIVE for a version that declares nothing', async () => {
+            // `null` is "unconstrained", which `checkRuntimeSupported` accepts —
+            // distinct from `undefined` ("could not determine"). Both let the run
+            // proceed; conflating them would be harmless today and wrong the
+            // moment either side grows a behaviour.
+            const doc = packument({ '0.31.0': { name: 'x' } }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, '0.31.0')).toBe(null);
+        });
+
+        await it('is permissive for a malformed declaration rather than guessing', async () => {
+            const doc = packument({ '0.31.0': { gjsify: { example: { runtimes: 'gjs' } } } }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, '0.31.0')).toBe(null);
+        });
+
+        await it('drops an unknown runtime name instead of hard-failing an older CLI', async () => {
+            const doc = packument({ '0.31.0': { gjsify: { example: { runtimes: ['gjs', 'wasmtime'] } } } }, '0.31.0');
+            expect(declaredRuntimesFromPackument(doc, '0.31.0')).toStrictEqual(['gjs']);
+        });
+
+        await it('says "cannot say" for a document with no versions map', async () => {
+            const doc = { name: 'x', 'dist-tags': { latest: '1.0.0' } } as unknown as Packument;
+            expect(declaredRuntimesFromPackument(doc, undefined)).toBe(undefined);
+        });
+    });
+};

--- a/packages/infra/cli/src/commands/showcase.ts
+++ b/packages/infra/cli/src/commands/showcase.ts
@@ -5,6 +5,8 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { ensurePkgDir } from './dlx.js';
+import { fetchPackument, type Packument } from '@gjsify/npm-registry';
+import { loadNpmrc } from '../utils/load-npmrc.js';
 import { parseSpec } from '../utils/parse-spec.js';
 import { resolveNodeEntry } from '../utils/resolve-gjs-entry.js';
 import { runRuntimeBundle } from '../utils/run-node.js';
@@ -251,13 +253,8 @@ async function resolveShowcaseDir(
     extraSpecs: readonly string[] = [],
 ): Promise<string> {
     // Local-first: a workspace showcase resolves via its own package name.
-    try {
-        const req = createRequire(import.meta.url);
-        const localPkgJson = req.resolve(`${showcase.packageName}/package.json`);
-        if (existsSync(localPkgJson)) return dirname(localPkgJson);
-    } catch {
-        // Not resolvable locally — fall through to dlx install.
-    }
+    const local = resolveLocalShowcaseDir(showcase);
+    if (local) return local;
 
     const spec = cliVersion ? `${showcase.packageName}@${cliVersion}` : showcase.packageName;
     const { pkgDir } = await ensurePkgDir(parseSpec(spec), {
@@ -267,6 +264,94 @@ async function resolveShowcaseDir(
         extraSpecs,
     });
     return pkgDir;
+}
+
+/**
+ * The LOCAL (workspace / node_modules) directory of a showcase, or `null`.
+ *
+ * Factored out because two callers need the same question answered: the resolver
+ * below, and the pre-flight, which must know whether an install is even going to
+ * happen before deciding to spend a registry request avoiding it.
+ */
+function resolveLocalShowcaseDir(showcase: ShowcaseInfo): string | null {
+    try {
+        const req = createRequire(import.meta.url);
+        const localPkgJson = req.resolve(`${showcase.packageName}/package.json`);
+        if (existsSync(localPkgJson)) return dirname(localPkgJson);
+    } catch {
+        // Not resolvable locally — the caller falls back to a dlx install.
+    }
+    return null;
+}
+
+/**
+ * Read a showcase's declared runtimes from the REGISTRY, with no install (#1069).
+ *
+ * WHY. `--runtime node` on a gjs-only showcase used to resolve and download the
+ * whole dlx tree — plus the pinned native `@gjsify/node-gi` bridge, added
+ * BECAUSE `--runtime node` was requested — and only then read the declaration
+ * that rejects the run. Measured for `adwaita-storybook`: a 310 KB showcase with
+ * no runtime deps, and 3.77 MB of `node-gi` fetched to support a runtime the
+ * package was about to refuse. The full packument carries
+ * `gjsify.example.runtimes` verbatim, so one metadata GET answers it.
+ *
+ * NOT solved by putting `runtimes` in `showcases.json`: that is a second copy of
+ * a declaration the package already owns, maintained by hand. See the
+ * `needsWebgl` post-mortem in `utils/discover-showcases.ts` — "a field nobody
+ * reads is a field nobody maintains", proven by a showcase that shipped
+ * `"needsWebgl": false` while its engine was WebGL2-only.
+ *
+ * FAIL-SAFE DIRECTION, and it is the whole contract: this may only ever turn a
+ * run that WOULD have failed into a faster failure. It must never fail a run
+ * that would have worked, so every uncertain branch — offline, unpublished
+ * version, missing field, malformed document — returns `undefined` and lets the
+ * install proceed to the authoritative on-disk check.
+ *
+ * @returns the declared list, `null` for a package that declares none
+ *   (unconstrained), or `undefined` when the question could not be answered.
+ */
+async function preflightDeclaredRuntimes(
+    showcase: ShowcaseInfo,
+    cliVersion: string | undefined,
+): Promise<ExampleRuntime[] | null | undefined> {
+    try {
+        // `fullMetadata` is REQUIRED: the abbreviated (corgi) document omits
+        // custom fields, so `gjsify.example` is simply absent there — the same
+        // shape as the `libc` note in `@gjsify/npm-registry`'s PackumentVersion.
+        const packument = await fetchPackument(showcase.packageName, {
+            npmrc: await loadNpmrc(process.cwd()),
+            fullMetadata: true,
+        });
+        return declaredRuntimesFromPackument(packument, cliVersion);
+    } catch {
+        // Offline, private registry, auth failure, 404 — all "cannot say".
+        return undefined;
+    }
+}
+
+/**
+ * The pure half of {@link preflightDeclaredRuntimes}: pick the version whose
+ * declaration decides, and read it.
+ *
+ * Separate from the fetch so the fail-safe direction is unit-testable — that
+ * contract ("never fail a run that would have worked") is the only thing that
+ * makes a pre-install check safe, and it lives entirely in which branches return
+ * `undefined`.
+ *
+ * @param cliVersion the CLI's own version; `showcase` pins the showcase to it.
+ */
+export function declaredRuntimesFromPackument(
+    packument: Packument,
+    cliVersion: string | undefined,
+): ExampleRuntime[] | null | undefined {
+    // A pinned version that is NOT published is "cannot say", never "ask latest":
+    // a different version's declaration is a different answer, and a wrong
+    // "unsupported" is precisely the failure this must not introduce. (A dev or
+    // pre-release CLI is the normal way to reach this.)
+    const version = cliVersion ?? packument['dist-tags']?.latest;
+    const entry = version ? packument.versions?.[version] : undefined;
+    if (!entry) return undefined;
+    return readDeclaredRuntimes(entry as { gjsify?: { example?: { runtimes?: unknown } } });
 }
 
 /**
@@ -280,6 +365,20 @@ async function runShowcaseOnRuntime(
     runtime: Exclude<ExampleRuntime, 'gjs'>,
     cliVersion: string | undefined,
 ): Promise<void> {
+    // PRE-FLIGHT, before anything is downloaded. Only for the dlx path: a local
+    // showcase resolves with no network and no install, so there is nothing to
+    // pre-empt there and the on-disk check below is already free.
+    if (resolveLocalShowcaseDir(showcase) === null) {
+        const preflight = await preflightDeclaredRuntimes(showcase, cliVersion);
+        if (preflight !== undefined) {
+            const support = checkRuntimeSupported(runtime, preflight, showcase.name);
+            if (!support.ok) {
+                console.error(support.message);
+                return process.exit(1);
+            }
+        }
+    }
+
     let pkgDir: string;
     try {
         // `@gjsify/node-gi` is the `gi://` bridge the `--app node` bundle

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -20,6 +20,7 @@ import installBackendParseSpecSuite from './install-backend-parse-spec.spec.js';
 import installTarballCacheSuite from './utils/install-tarball-cache.spec.js';
 import installPackumentCacheSuite from './utils/install-packument-cache.spec.js';
 import dirLinkSuite from './utils/dir-link.spec.js';
+import showcasePreflightSuite from './commands/showcase-preflight.spec.js';
 import checkSystemDepsSuite from './utils/check-system-deps.spec.js';
 import dlxCacheSuite from './utils/dlx-cache.spec.js';
 import installCacheFsSuite from './utils/install-cache-fs.spec.js';
@@ -193,6 +194,7 @@ run(
         authNpmrcSuite,
         promptKeySuite,
         dirLinkSuite,
+        showcasePreflightSuite,
         checkSystemDepsSuite,
         dlxCacheSuite,
         installCacheFsSuite,

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -20,6 +20,7 @@ import installBackendParseSpecSuite from './install-backend-parse-spec.spec.js';
 import installTarballCacheSuite from './utils/install-tarball-cache.spec.js';
 import installPackumentCacheSuite from './utils/install-packument-cache.spec.js';
 import dirLinkSuite from './utils/dir-link.spec.js';
+import resolveBinOnPathSuite from './utils/resolve-bin-on-path.spec.js';
 import showcasePreflightSuite from './commands/showcase-preflight.spec.js';
 import checkSystemDepsSuite from './utils/check-system-deps.spec.js';
 import dlxCacheSuite from './utils/dlx-cache.spec.js';
@@ -194,6 +195,7 @@ run(
         authNpmrcSuite,
         promptKeySuite,
         dirLinkSuite,
+        resolveBinOnPathSuite,
         showcasePreflightSuite,
         checkSystemDepsSuite,
         dlxCacheSuite,

--- a/packages/infra/cli/src/utils/install-global.ts
+++ b/packages/infra/cli/src/utils/install-global.ts
@@ -350,12 +350,101 @@ function readJson(file: string): Record<string, unknown> {
     return JSON.parse(fs.readFileSync(file, 'utf-8')) as Record<string, unknown>;
 }
 
+/**
+ * The path module for a TARGET platform, not for the host.
+ *
+ * Load-bearing for every function below that takes a `platform`. `path.resolve`
+ * is host-bound: on Linux `path.resolve('C:\\tools')` returns
+ * `<cwd>/C:\tools`, because posix has no notion of a drive letter. So a function
+ * that accepts `platform` and then calls the host's `path` is only pretending to
+ * be portable — it silently mangles Windows input everywhere except Windows,
+ * which is exactly the class of bug an injected platform is supposed to expose.
+ * Caught by `resolve-bin-on-path.spec.ts`, which asserts real `C:\…` semantics
+ * from Linux.
+ */
+function pathFor(platform: NodeJS.Platform): typeof path.win32 {
+    return platform === 'win32' ? path.win32 : path.posix;
+}
+
+/** PATH split into resolved directory entries, in search order. */
+function searchPathEntries(pathValue: string, platform: NodeJS.Platform): string[] {
+    const p = pathFor(platform);
+    const sep = platform === 'win32' ? ';' : ':';
+    return pathValue
+        .split(sep)
+        .filter(Boolean)
+        .map((entry) => p.resolve(entry));
+}
+
 /** Returns `true` if `binDir` is on the user's PATH. */
 export function binDirOnPath(binDir: string): boolean {
-    const PATH = process.env.PATH ?? '';
-    const sep = process.platform === 'win32' ? ';' : ':';
-    const want = path.resolve(binDir);
-    return PATH.split(sep).some((entry) => entry && path.resolve(entry) === want);
+    const want = pathFor(process.platform).resolve(binDir);
+    return searchPathEntries(process.env.PATH ?? '', process.platform).includes(want);
+}
+
+/** Injection points for {@link resolveBinOnPath} — see its `platform` note. */
+export interface ResolveBinOnPathOptions {
+    /** PATH to search. Defaults to `process.env.PATH`. */
+    pathValue?: string;
+    /** PATHEXT to honour on win32. Defaults to `process.env.PATHEXT` or cmd.exe's set. */
+    pathExt?: string;
+    /** Host platform. Defaults to `process.platform`. */
+    platform?: NodeJS.Platform;
+    /** File-existence probe. Defaults to a real `fs.existsSync`. */
+    exists?: (file: string) => boolean;
+}
+
+/** cmd.exe's default when PATHEXT is unset. `.CMD` is the one npm-style shims need. */
+const DEFAULT_PATHEXT = '.COM;.EXE;.BAT;.CMD;.VBS;.JS;.WS;.MSC';
+
+/**
+ * Resolve `binName` the way the user's shell will: the FIRST hit in PATH order.
+ *
+ * WHY THIS IS NOT `binDirOnPath`. That answers "is our dir on PATH", which is
+ * necessary but not sufficient for anything that CHANGES which binary runs:
+ * `~/.local/bin` can be on PATH and still lose to an npm-global `gjsify` earlier
+ * in it. `self-update` reported "Updated to v0.31.0" on exactly that host while
+ * the shell kept resolving a v0.26.0 install five releases behind — and the user
+ * then re-hit a bug fixed three releases earlier and reported it as new (#1064).
+ * "Which one wins" is the question, so this returns the winning PATH.
+ *
+ * WINDOWS. An extension-less name is not executable there; cmd.exe and pwsh
+ * append each `PATHEXT` entry, which is how the `.cmd` shim `bin-shim.ts` writes
+ * gets found. The bare name is probed LAST so a git-bash/MSYS `sh` shim is still
+ * reported rather than missed. `platform`/`pathExt`/`exists` are injectable for
+ * the same reason `dirLinkTarget` takes `linkType`: nothing in CI resolves a bin
+ * on a Windows host, so an injected `'win32'` is the ONLY way that branch is ever
+ * EXECUTED — and an unexecutable Windows branch is exactly how the `'dir'` bug in
+ * `dir-link.ts` shipped.
+ *
+ * @returns the absolute path of the winning candidate, or `null` when PATH holds none.
+ */
+export function resolveBinOnPath(binName: string, opts: ResolveBinOnPathOptions = {}): string | null {
+    const platform = opts.platform ?? process.platform;
+    const pathValue = opts.pathValue ?? process.env.PATH ?? '';
+    const exists = opts.exists ?? fs.existsSync;
+
+    // On win32 the extensions come FIRST (what cmd.exe/pwsh actually launch) and
+    // the bare name last (git-bash). Elsewhere there is only the bare name.
+    const suffixes =
+        platform === 'win32'
+            ? [
+                  ...(opts.pathExt ?? process.env.PATHEXT ?? DEFAULT_PATHEXT)
+                      .split(';')
+                      .filter(Boolean)
+                      .map((ext) => (ext.startsWith('.') ? ext : `.${ext}`)),
+                  '',
+              ]
+            : [''];
+
+    const p = pathFor(platform);
+    for (const dir of searchPathEntries(pathValue, platform)) {
+        for (const suffix of suffixes) {
+            const candidate = p.join(dir, `${binName}${suffix}`);
+            if (exists(candidate)) return candidate;
+        }
+    }
+    return null;
 }
 
 /**

--- a/packages/infra/cli/src/utils/install-global.ts
+++ b/packages/infra/cli/src/utils/install-global.ts
@@ -351,6 +351,24 @@ function readJson(file: string): Record<string, unknown> {
 }
 
 /**
+ * Is the global layout the user's own, or has a caller redirected it?
+ *
+ * `GJSIFY_GLOBAL_PREFIX` / `GJSIFY_GLOBAL_BIN_DIR` are the escape hatches
+ * {@link defaultGlobalLayout} documents for tests, and a caller that sets them
+ * has taken over placement — so "which `gjsify` will PATH resolve next" stops
+ * being a question about THEIR intent. `self-update` gates its fatal PATH check
+ * on this: without it, every harness installing into a temp prefix it never put
+ * on PATH is told its update did not take effect, which is true and useless.
+ * Caught by `tests/e2e/global-install-engine`.
+ *
+ * @param env injectable so both answers are testable without mutating the real
+ *   environment mid-suite.
+ */
+export function globalLayoutIsDefault(env: NodeJS.ProcessEnv = process.env): boolean {
+    return !env.GJSIFY_GLOBAL_PREFIX && !env.GJSIFY_GLOBAL_BIN_DIR;
+}
+
+/**
  * The path module for a TARGET platform, not for the host.
  *
  * Load-bearing for every function below that takes a `platform`. `path.resolve`

--- a/packages/infra/cli/src/utils/resolve-bin-on-path.spec.ts
+++ b/packages/infra/cli/src/utils/resolve-bin-on-path.spec.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+// Unit tests for "which binary does PATH actually pick?".
+//
+// The whole point of this file, and the same argument as `dir-link.spec.ts`: the
+// WINDOWS branch is exercised HERE, on Linux, by injecting the platform. Nothing
+// in CI resolves a bin on a Windows host, so an injected `'win32'` is the ONLY
+// way the PATHEXT branch is ever EXECUTED — and an unexecutable Windows branch is
+// exactly how the `'dir'` bug in `dir-link.ts` shipped.
+//
+// The `verifyPathResolution` cases matter for the same reason from the other
+// direction: a developer's own machine only ever produces the HAPPY one, because
+// a working install resolves to its own binDir by definition. The two failing
+// shapes — shadowed, and absent — are the ones #1064 was reported from, and they
+// are unreachable without injection.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { posix, win32 } from 'node:path';
+
+import { resolveBinOnPath } from './install-global.js';
+import { verifyPathResolution } from '../commands/self-update.js';
+
+export default async () => {
+    await describe('resolveBinOnPath', async () => {
+        await it('returns the FIRST hit in PATH order, not merely any hit', async () => {
+            // The bug being guarded: `~/.local/bin` is on PATH but loses to an
+            // npm-global dir earlier in it. "Is our dir on PATH" answers yes here
+            // and is the wrong question.
+            const present = new Set([posix.resolve('/opt/npm/bin/gjsify'), posix.resolve('/home/u/.local/bin/gjsify')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'linux',
+                pathValue: '/opt/npm/bin:/home/u/.local/bin',
+                exists: (f) => present.has(f),
+            });
+            expect(found).toBe(posix.resolve('/opt/npm/bin/gjsify'));
+        });
+
+        await it('returns null when PATH holds no candidate', async () => {
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'linux',
+                pathValue: '/usr/bin:/bin',
+                exists: () => false,
+            });
+            expect(found).toBe(null);
+        });
+
+        await it('skips PATH entries that do not carry the bin', async () => {
+            const present = new Set([posix.resolve('/second/gjsify')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'linux',
+                pathValue: '/first:/second',
+                exists: (f) => present.has(f),
+            });
+            expect(found).toBe(posix.resolve('/second/gjsify'));
+        });
+
+        await it('ignores empty PATH segments', async () => {
+            const present = new Set([posix.resolve('/only/gjsify')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'linux',
+                pathValue: ':/only:',
+                exists: (f) => present.has(f),
+            });
+            expect(found).toBe(posix.resolve('/only/gjsify'));
+        });
+
+        // --- win32: the branch that cannot run on this host ------------------
+
+        // Windows' filesystem is CASE-INSENSITIVE, and the two sides disagree on
+        // case by convention: `PATHEXT` is spelled `.CMD` while `bin-shim.ts`
+        // writes `gjsify.cmd`. A case-sensitive stub would therefore report a
+        // correct install as missing — the stub, not the resolver, is what has to
+        // model the host here.
+        const winExists = (present: string[]) => {
+            const set = new Set(present.map((f) => f.toLowerCase()));
+            return (f: string) => set.has(f.toLowerCase());
+        };
+
+        // For the same reason, the resolver returns the candidate it BUILT, whose
+        // extension carries PATHEXT's casing (`gjsify.CMD`) rather than the file's
+        // (`gjsify.cmd`). On Windows both name one file, so the assertion compares
+        // up to the case the platform does not distinguish.
+        const sameWinPath = (a: string | null, b: string) => (a ?? '').toLowerCase() === b.toLowerCase();
+
+        await it('finds the .cmd shim on win32, which is what cmd.exe launches', async () => {
+            // `bin-shim.ts` writes the sh/.cmd/.ps1 triple. An extension-less
+            // name is not executable on Windows, so a resolver that only probed
+            // the bare name would report "not installed" for a correct install.
+            const exists = winExists([win32.resolve('C:\\tools\\gjsify.cmd')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'win32',
+                pathValue: 'C:\\tools',
+                pathExt: '.COM;.EXE;.BAT;.CMD',
+                exists,
+            });
+            expect(sameWinPath(found, win32.resolve('C:\\tools\\gjsify.cmd'))).toBe(true);
+        });
+
+        await it('prefers an earlier PATHEXT entry over a later one', async () => {
+            const exists = winExists([win32.resolve('C:\\tools\\gjsify.exe'), win32.resolve('C:\\tools\\gjsify.cmd')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'win32',
+                pathValue: 'C:\\tools',
+                pathExt: '.EXE;.CMD',
+                exists,
+            });
+            expect(sameWinPath(found, win32.resolve('C:\\tools\\gjsify.exe'))).toBe(true);
+        });
+
+        await it('still reports a bare sh shim on win32 (git-bash), as the last resort', async () => {
+            const exists = winExists([win32.resolve('C:\\tools\\gjsify')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'win32',
+                pathValue: 'C:\\tools',
+                pathExt: '.CMD',
+                exists,
+            });
+            expect(sameWinPath(found, win32.resolve('C:\\tools\\gjsify'))).toBe(true);
+        });
+
+        await it('splits win32 PATH on `;`, not `:` — a drive letter is not a separator', async () => {
+            const exists = winExists([win32.resolve('C:\\second\\gjsify.cmd')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'win32',
+                pathValue: 'C:\\first;C:\\second',
+                pathExt: '.CMD',
+                exists,
+            });
+            expect(sameWinPath(found, win32.resolve('C:\\second\\gjsify.cmd'))).toBe(true);
+        });
+
+        await it('normalises a PATHEXT entry given without its leading dot', async () => {
+            const exists = winExists([win32.resolve('C:\\tools\\gjsify.cmd')]);
+            const found = resolveBinOnPath('gjsify', {
+                platform: 'win32',
+                pathValue: 'C:\\tools',
+                pathExt: 'CMD',
+                exists,
+            });
+            expect(sameWinPath(found, win32.resolve('C:\\tools\\gjsify.cmd'))).toBe(true);
+        });
+    });
+
+    await describe('verifyPathResolution', async () => {
+        const binDir = posix.join('/home/u/.local/bin');
+
+        await it('is ok when PATH resolves into the dir we linked', async () => {
+            const verdict = verifyPathResolution({
+                binName: 'gjsify',
+                binDir,
+                resolvedBin: posix.join(binDir, 'gjsify'),
+                runningVersion: '0.31.0',
+                targetVersion: '0.31.0',
+                platform: 'linux',
+            });
+            expect(verdict.ok).toBe(true);
+        });
+
+        await it('FAILS when another install shadows the name — the #1064 report', async () => {
+            const verdict = verifyPathResolution({
+                binName: 'gjsify',
+                binDir,
+                resolvedBin: '/opt/npm/bin/gjsify',
+                runningVersion: '0.26.0',
+                targetVersion: '0.31.0',
+                platform: 'linux',
+            });
+            expect(verdict.ok).toBe(false);
+            // The message must name BOTH sides: the version the user believes
+            // they got, and the path that will actually run instead.
+            const message = verdict.ok ? '' : verdict.message;
+            expect(message.includes('/opt/npm/bin/gjsify')).toBe(true);
+            expect(message.includes('0.26.0')).toBe(true);
+            expect(message.includes('0.31.0')).toBe(true);
+            expect(message.includes(binDir)).toBe(true);
+        });
+
+        await it('FAILS when nothing named gjsify is on PATH at all', async () => {
+            const verdict = verifyPathResolution({
+                binName: 'gjsify',
+                binDir,
+                resolvedBin: null,
+                runningVersion: undefined,
+                targetVersion: '0.31.0',
+                platform: 'linux',
+            });
+            expect(verdict.ok).toBe(false);
+            const message = verdict.ok ? '' : verdict.message;
+            expect(message.includes(binDir)).toBe(true);
+        });
+
+        await it('treats win32 paths case-insensitively, so a correct install is not called shadowed', async () => {
+            // `C:\Users\X\.local\bin` and `c:\users\x\.local\bin` are ONE
+            // directory on Windows. A case-sensitive compare fails a good install.
+            const verdict = verifyPathResolution({
+                binName: 'gjsify',
+                binDir: 'C:\\Users\\X\\.local\\bin',
+                resolvedBin: 'c:\\users\\x\\.local\\bin\\gjsify.cmd',
+                runningVersion: '0.31.0',
+                targetVersion: '0.31.0',
+                platform: 'win32',
+            });
+            expect(verdict.ok).toBe(true);
+        });
+
+        await it('keeps the same paths DISTINCT on linux, where case matters', async () => {
+            const verdict = verifyPathResolution({
+                binName: 'gjsify',
+                binDir: '/home/U/.local/bin',
+                resolvedBin: '/home/u/.local/bin/gjsify',
+                runningVersion: '0.26.0',
+                targetVersion: '0.31.0',
+                platform: 'linux',
+            });
+            expect(verdict.ok).toBe(false);
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/resolve-bin-on-path.spec.ts
+++ b/packages/infra/cli/src/utils/resolve-bin-on-path.spec.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect } from '@gjsify/unit';
 import { posix, win32 } from 'node:path';
 
-import { resolveBinOnPath } from './install-global.js';
+import { globalLayoutIsDefault, resolveBinOnPath } from './install-global.js';
 import { verifyPathResolution } from '../commands/self-update.js';
 
 export default async () => {
@@ -212,6 +212,28 @@ export default async () => {
                 platform: 'linux',
             });
             expect(verdict.ok).toBe(false);
+        });
+    });
+    await describe('globalLayoutIsDefault', async () => {
+        // The gate that keeps the PATH verdict from firing where it is useless.
+        // `tests/e2e/global-install-engine` installs into a temp prefix it never
+        // puts on PATH, and the first version of this change failed it — the
+        // verdict was TRUE ("PATH does not point here") and worthless, because
+        // the caller chose that location. CI caught it; this pins the rule.
+        await it('is true for the untouched user layout', async () => {
+            expect(globalLayoutIsDefault({})).toBe(true);
+        });
+
+        await it('is false once the prefix is redirected', async () => {
+            expect(globalLayoutIsDefault({ GJSIFY_GLOBAL_PREFIX: '/tmp/harness' })).toBe(false);
+        });
+
+        await it('is false once the bin dir is redirected', async () => {
+            expect(globalLayoutIsDefault({ GJSIFY_GLOBAL_BIN_DIR: '/tmp/harness/bin' })).toBe(false);
+        });
+
+        await it('ignores unrelated environment', async () => {
+            expect(globalLayoutIsDefault({ PATH: '/usr/bin', XDG_DATA_HOME: '/x' })).toBe(true);
         });
     });
 };


### PR DESCRIPTION
Two commands that reported the wrong thing, both found while testing 0.31.0 on a fresh Windows VM and a Mac. One theme: **do the cheap check before the expensive work, and never report success you did not achieve.**

## `showcase` downloaded the tree before the check that rejects the run (#1069)

```
$ npx @gjsify/cli@latest showcase adwaita-storybook --runtime node
gjsify install: resolving done
gjsify install: downloading done
"adwaita-storybook" does not support --runtime node.
```

The error was already correct — the two lines above it were the bug. `runShowcaseOnRuntime` installed first and read the declaration second, and the sharp edge was `extraSpecs`: `@gjsify/node-gi` is added **because** `--runtime node` was requested, so the CLI fetched the native `gi://` bridge to support a runtime the showcase was about to refuse. Measured: a 310 KB showcase with `"dependencies": {}`, plus 3.77 MB of node-gi.

The full packument carries the declaration verbatim, so one metadata GET answers it:

```console
$ curl -s https://registry.npmjs.org/@gjsify/example-gtk-adwaita-storybook \
  | jq '.versions["0.31.0"].gjsify.example'
{ "runtimes": [ "gjs" ] }
```

Pre-flight runs on the dlx path only — a local showcase resolves with no network, so there is nothing to pre-empt there and the on-disk check is already free.

**Deliberately not fixed by adding `runtimes` to `showcases.json`.** That is a second copy of a declaration the package owns, maintained by hand, and `utils/discover-showcases.ts` already records where that goes: `needsWebgl` was deleted rather than wired up because "a field nobody reads is a field nobody maintains", proven by `excalibur-jelly-jumper` shipping `"needsWebgl": false` while Excalibur 0.32 is WebGL2-only.

**The fail-safe direction is the whole contract**, so it is split into a pure function and pinned by tests: the pre-flight may only ever turn a run that *would* have failed into a faster failure. Every uncertain branch — offline, unpublished pinned version, missing field, malformed document — answers "cannot say" and lets the install proceed to the authoritative on-disk check. In particular a pinned version that is not published does **not** fall back to `latest`, because a different version's declaration is a different answer.

## `self-update` reported success while PATH kept the old binary (#1064)

```
> gjsify self-update
Current @gjsify/cli: v0.26.0
Warning: no @gjsify/cli install found under C:\Users\JumpLink\.local\share\gjsify\global.
...
Updated @gjsify/cli to v0.31.0.

> gjsify showcase excalibur-jelly-jumper
Could not resolve showcase "...": EPERM: operation not permitted, symlink '...'
```

That EPERM is the bug `utils/dir-link.ts` exists to kill — absent from v0.26.0, present from v0.28.0. So the command that ran was v0.26.0, five releases behind what `self-update` had just called installed, and the user re-hit a fixed bug and reported it as new. (I filed and withdrew a dlx issue over it; `cli-cross-platform.yml`'s Windows journey leg exercises dlx on 0.31.0 and is green, which independently rules out a live regression.)

It already held both halves of the mismatch — `readCurrentVersion()` → v0.26.0, and `existsSync` on the target prefix → false, which it even warned about — and still printed unconditional success. Now the post-link check is fatal and names both paths and both versions.

`binDirOnPath` (which `install -g` already uses, and `self-update` did not) answers "is our dir on PATH". Necessary but not sufficient: the dir can be on PATH and still lose to an earlier entry. `resolveBinOnPath` answers the question that matters, honouring `PATHEXT` so the `.cmd` shim `bin-shim.ts` writes is found where an extension-less name is not executable.

### One thing the tests caught that I had wrong

Both new functions take `platform` as an argument — and therefore need the *target* platform's path module, not the host's. `path.resolve('C:\\tools')` on posix returns `<cwd>/C:\tools`, so a function that accepts a `platform` and then calls the host's `path` only pretends to be portable; it silently mangles Windows input everywhere except Windows. My first version did exactly that and the win32 specs failed on it, which is the argument for writing them: nothing in CI resolves a bin on a Windows host, so an injected `'win32'` is the only way that branch is ever *executed* — the same reasoning `dir-link.spec.ts` gives, and an unexecutable Windows branch is how the `'dir'` bug shipped in the first place.

## Mechanism

The CI step `Showcase: --runtime node does not demand gjs` asserted only that the message appears, which the wasteful behaviour satisfied. It now also asserts the **absence** of the `gjsify install:` lines, turning "the error is right" into "the error is right and nothing was downloaded to produce it" — the property that actually regressed.

That needed a second version bound, and the node-gi step below already learned why one bound cannot serve two fixes ("one bound served both and therefore lied about one of them"), so the comparison became a shared shell function with `LOWEST_FIXED` (#889) and `LOWEST_PREFLIGHT_FIXED` (this change) as separate values. Both arm themselves on the next release with no edit here.

## Verification

- `npm run check` (tsc --noEmit) clean
- `npm run test:node` — **1998 pass**, up from 1970: 19 new for the PATH resolver and verdict, 9 for the pre-flight
- `gjsify lint` clean on all touched files
- workflow YAML parses

## Not in this PR

**#1063** (every `gi://` showcase dies on a clean Windows host) is **blocked on a decision, not effort** — and my proposed fix in that issue was wrong. `docs/node-gi-platform-notes.md` states in bold that *"a bundle must NEVER be a dependency of `@gjsify/node-gi`"*, backed by a measurement: #910 did exactly that and produced wrong method entries and a 29-minute timeout, #920 reverted it. I corrected the issue and left the real open question — precedence between a bundle and the GTK the addon was linked against — for an explicit decision rather than a drive-by reversal of an incident-backed rule. #1065 (a Windows CI leg that actually loads the addon) is independent and still worth landing.
