### PR TITLE
fix(release): bump the standalone apps' ranges, and name what fails

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -188,23 +188,36 @@ jobs:
       #
       #   1. bump-docs-version.mjs           — docs follow the version
       #   2. generate-platform-packages --write — RE-DERIVE what the bumper cannot
-      #   3. audit-runtimes --check --strict  — REFUSE to commit an inconsistent tree
-      #   4. verify-committed-bundles --rebuild — bundles reproduce at the new version
+      #   3. bump-release-train-ranges.mjs   — the same, for workspace-EXCLUDED apps
+      #   4. audit-runtimes --check --strict  — REFUSE to commit an inconsistent tree
+      #   5. verify-committed-bundles --rebuild — bundles reproduce at the new version
       #
-      # Step 2 exists because `@release-it/bumper` rewrites ONLY the `version`
-      # field. That is enough for a workspace member, whose siblings are pinned
-      # `workspace:^` and resolved at pack time — but `@gjsify/napi` is NOT a
-      # workspace member (its own CI, its own carve-out), so its
-      # `optionalDependencies` on `@gjsify/napi-{linux-x64,darwin-arm64}` carry
-      # LITERAL versions that nothing rewrote. v0.27.0 was cut with the parent at
-      # 0.27.0 and both children pinned 0.26.1; `main` went red on
-      # `platform-packages` and the tag would have published a bridge pinned to
-      # the previous release's binaries. Measured: simulating the bumper's
-      # version-only rewrite reproduces exactly those two findings, and
-      # `--write` clears them.
+      # Steps 2 AND 3 exist for one reason: `@release-it/bumper` rewrites ONLY the
+      # `version` field. Never a dependency RANGE. That is enough for a workspace
+      # member, whose siblings are pinned `workspace:^` and resolved at pack time
+      # — and it has now cost a release twice, in the two places that are not
+      # workspace members.
       #
-      # Step 3 is the mechanism, not a belt-and-braces repeat: step 2 fixes what
-      # is DERIVABLE, and anything it cannot fix must stop the cut rather than
+      # Step 2: `@gjsify/napi` is NOT a workspace member (its own CI, its own
+      # carve-out), so its `optionalDependencies` on
+      # `@gjsify/napi-{linux-x64,darwin-arm64}` carry LITERAL versions that
+      # nothing rewrote. v0.27.0 was cut with the parent at 0.27.0 and both
+      # children pinned 0.26.1; `main` went red on `platform-packages` and the tag
+      # would have published a bridge pinned to the previous release's binaries.
+      # Measured: simulating the bumper's version-only rewrite reproduces exactly
+      # those two findings, and `--write` clears them.
+      #
+      # Step 3: the NativeScript apps under `showcases/` are excluded from
+      # `workspaces` too, so their `@gjsify/*` deps are ordinary npm ranges. The
+      # `release-train` rule (ADR 0008) requires them to name the CURRENT version
+      # — which, between the bump and step 4, they never did: the rule was
+      # unsatisfiable inside a cut from the day it landed, and the v0.32.0 attempt
+      # (the first cut since) died on 11 findings across three apps. The rewriter
+      # shares its edge selection with the rule it satisfies, so the two cannot
+      # drift apart.
+      #
+      # Step 4 is the mechanism, not a belt-and-braces repeat: steps 2-3 fix what
+      # is DERIVABLE, and anything they cannot fix must stop the cut rather than
       # ride a tag out to npm. The audit already runs on every PR — it just never
       # ran on the tree the bump creates, which exists for only these few seconds.
       #

--- a/.release-it.json
+++ b/.release-it.json
@@ -16,7 +16,7 @@
     "publish": false
   },
   "hooks": {
-    "after:bump": "node scripts/bump-docs-version.mjs ${latestVersion} ${version} && node scripts/generate-platform-packages.mjs --write && node scripts/audit-runtimes.mjs --check --strict && node scripts/verify-committed-bundles.mjs --rebuild",
+    "after:bump": "node scripts/bump-docs-version.mjs ${latestVersion} ${version} && node scripts/generate-platform-packages.mjs --write && node scripts/bump-release-train-ranges.mjs ${latestVersion} ${version} && node scripts/audit-runtimes.mjs --check --strict && node scripts/verify-committed-bundles.mjs --rebuild",
     "before:git:beforeRelease": "node scripts/check-changelog-references.mjs --write"
   },
   "plugins": {

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1681,6 +1681,9 @@ async function main() {
         const headless = byId.get('headless');
         const portableScripts = byId.get('portable-scripts');
         const osAxis = byId.get('os-axis');
+        const storybook = byId.get('storybook');
+        const nativescriptPlatforms = byId.get('nativescript-platforms');
+        const releaseTrain = byId.get('release-train');
         const coverage = byId.get('field-coverage');
         const statusData = byId.get('status-data');
         // `platform-packages` is selected by CHECK_RULES, so its failures set the
@@ -1703,6 +1706,9 @@ async function main() {
             console.log(headless.summary);
             console.log(portableScripts.summary);
             console.log(osAxis.summary);
+            console.log(storybook.summary);
+            console.log(nativescriptPlatforms.summary);
+            console.log(releaseTrain.summary);
             console.log(coverage.summary);
             console.log(statusData.summary);
             console.log(platformPackages.summary);
@@ -1880,6 +1886,55 @@ async function main() {
             );
             console.error('');
         }
+        if ((storybook.failures ?? []).length > 0) {
+            console.error(`STORYBOOK-DECLARATION FAILURES on ${storybook.failures.length} package(s):`);
+            for (const line of storybook.failures) {
+                console.error(`  - ${line.split('\n').join('\n    ')}`);
+            }
+            console.error('');
+            console.error(
+                '`gjsify.storybook.stories` is the directory `gjsify storybook` globs for `*.story.{ts,js,mts,mjs}` ' +
+                    '(default `src`). A path that does not exist, or holds no story, produces an empty storybook at ' +
+                    'RUN time — and nothing in CI runs the command reliably (the only job that does is path-filtered, ' +
+                    'so it is advisory). Fix by pointing `stories` at the directory that actually holds them, or by ' +
+                    'dropping the declaration if the package no longer ships stories.',
+            );
+            console.error('');
+        }
+        if ((nativescriptPlatforms.failures ?? []).length > 0) {
+            console.error(
+                `NATIVESCRIPT-PLATFORM FAILURES on ${nativescriptPlatforms.failures.length} declaration(s)/module(s):`,
+            );
+            for (const line of nativescriptPlatforms.failures) {
+                console.error(`  - ${line.split('\n').join('\n    ')}`);
+            }
+            console.error('');
+            console.error(
+                'A `gjsify.nativescriptPlatforms` entry promises that every platform-resolved module has a variant for ' +
+                    'that platform. There is no iOS CI anywhere in this repo, so "does the declared platform have an ' +
+                    'implementation at all" is the only half any machine here can hold — and it is the half that fails ' +
+                    'SILENTLY: the NS build resolves `foo.<platform>.ts` before `foo.ts`, so a missing variant falls ' +
+                    'back to the base module and renders nothing, with no crash and no warning (icons.ios.ts, for the ' +
+                    'whole life of the declaration). Fix by adding the variant, or by narrowing the declared list.',
+            );
+            console.error('');
+        }
+        if ((releaseTrain.failures ?? []).length > 0) {
+            console.error(`RELEASE-TRAIN FAILURES (ADR 0008) on ${releaseTrain.failures.length} dependency range(s):`);
+            for (const line of releaseTrain.failures) {
+                console.error(`  - ${line.split('\n').join('\n    ')}`);
+            }
+            console.error('');
+            console.error(
+                'The apps EXCLUDED from `workspaces` (the NativeScript ones under `showcases/`) resolve their ' +
+                    '`@gjsify/*` deps through npm, not through the workspace, so their ranges are the one place a ' +
+                    'stale version survives unnoticed — nothing installs them in CI and `gjsify upgrade --check` ' +
+                    'never sees them. Fix by naming the current workspace version in every range; during a RELEASE ' +
+                    'that is done for you by `scripts/bump-release-train-ranges.mjs` in the `after:bump` hook, so a ' +
+                    'finding here on a bumped tree means that hook did not run or did not reach these files.',
+            );
+            console.error('');
+        }
         if ((coverage.failures ?? []).length > 0) {
             console.error(`MANIFEST FIELD-COVERAGE FAILURES on ${coverage.failures.length} declaration kind(s):`);
             for (const line of coverage.failures) {
@@ -1951,6 +2006,15 @@ async function main() {
             'headless',
             'portable-scripts',
             'os-axis',
+            // All three were selected by CHECK_RULES with no print block, so all
+            // three could set the exit code while naming nothing — the same
+            // defect as `platform-packages` above, times three. `release-train`
+            // is the one that was actually hit: it fired inside the v0.32.0
+            // `after:bump` hook and the accountant below is the only reason its
+            // 11 findings were visible at all.
+            'storybook',
+            'nativescript-platforms',
+            'release-train',
             'field-coverage',
             'status-data',
             'platform-packages',

--- a/scripts/bump-release-train-ranges.mjs
+++ b/scripts/bump-release-train-ranges.mjs
@@ -1,0 +1,235 @@
+#!/usr/bin/env node
+// Pull the workspace-EXCLUDED apps onto the release train being cut.
+//
+// Invoked from `.release-it.json` as:
+//   node scripts/bump-release-train-ranges.mjs ${latestVersion} ${version}
+//
+// WHY IT EXISTS. `@release-it/bumper` globs `showcases/*/*/package.json` and
+// `examples/*/*/package.json`, but it rewrites exactly one thing in each: the
+// `version` field. Dependency RANGES it never touches — and three apps under
+// `showcases/` are `!`-negated out of the root `workspaces` globs
+// (`adwaita-storybook-nativescript`, `adwaita-widgets-nativescript`,
+// `three-geometry-teapot-nativescript`: they carry their own `node_modules` and
+// their own NS toolchain), so their `@gjsify/*` deps are ordinary npm ranges
+// that resolve through the registry. Nothing kept those current, so the instant
+// release-it bumped the workspace to the next version they all named the
+// previous one, and the `release-train` conformance rule failed inside the same
+// `after:bump` hook. That rule was therefore unsatisfiable DURING a cut from the
+// day it landed; the v0.32.0 attempt was the first cut since, and it died there
+// with 11 findings. This script is the half that was missing.
+//
+// WHY NOT `workspace:^` IN THOSE THREE MANIFESTS, which would hand the problem
+// to machinery that already exists (`gjsify pack` substitutes `workspace:`
+// ranges). Because nothing ever packs them — they are apps, not packages. That
+// substitution happens in the TARBALL and leaves the source at `workspace:^`;
+// here the COMMITTED manifest is what `npm install` reads in a user's clone, so
+// it has to carry a concrete version. `findWorkspaceRoot()` is also deliberately
+// strict about members, and these three are non-members on purpose.
+//
+// WHY NOT REUSE `rewriteWorkspaceDeps` FROM `commands/pack.ts`. Its contract is
+// adopted here verbatim (see below); its code cannot be. It is module-private
+// (pack.ts exports only `packCommand`/`packWorkspace`/`collectPackedFiles`/
+// `collectTypeDeclarationRefs`); its input domain is the `workspace:` protocol,
+// which is precisely the set `release-train` EXCLUDES, so pointed at these
+// manifests it would return them unchanged; it resolves versions from
+// `discoverWorkspaces()`, i.e. workspace MEMBERS, and these apps are negated out;
+// and it lives in TypeScript compiled to `packages/infra/cli/lib`, a BUILD
+// OUTPUT, whereas every other `after:bump` hook script is pure Node with no
+// dependency beyond builtins. Generalising a private packer function from
+// `workspace:` ranges to arbitrary ones, exporting it, and making a release hook
+// depend on the CLI's build output is a risky refactor of the code path that
+// produces every tarball, in service of a different problem.
+//
+// WHAT IS REUSED IS THE RULE. `pack`'s contract — "a `workspace:` range is
+// either substituted correctly or the pack FAILS; it is never silently
+// published" — is the whole point, because the failure this rule exists to
+// prevent is a manifest that LOOKS authoritative and is not. So this script
+// never skips-and-continues. It collects every problem, writes NOTHING, and
+// exits 1 on: a manifest that does not parse, a governed range that is not the
+// version being replaced, a `@gjsify/*` dependency that names no package in this
+// monorepo, or one whose own manifest was not bumped. The write pass runs only
+// once every edge has been proven substitutable, so a failure leaves the tree
+// untouched instead of half-rewritten.
+//
+// WHY "a governed range that is not `^${latestVersion}`" IS A FAILURE rather
+// than something to repair. `main` is branch-protected and the audit that runs
+// `release-train` is a required check, so on the pre-bump tree EVERY governed
+// range has already been proven to equal `^${latestVersion}` — it is the only
+// value that passes. A different one means the bump ran on a tree that never
+// passed that gate, and quietly rewriting it would publish a release whose
+// provenance nobody checked. `^${nextVersion}` is the one exception: that is a
+// re-run of the hook, and it is a no-op.
+//
+// WHY IT TAKES THE VERSION AS AN ARGUMENT, in the shape
+// `bump-docs-version.mjs` already uses. At `after:bump` time the root
+// package.json has been rewritten, so the target version could be read from
+// disk — but a release hook that infers what it is releasing is a hook that
+// breaks the first time the inference is wrong, silently and inside the few
+// seconds the bumped tree exists. release-it knows both numbers; it passes both.
+//
+// WHY IT SHARES ITS SELECTION WITH THE RULE rather than restating it. The rule
+// deliberately does NOT govern `workspace:`/`file:`/`link:` (already pinned to
+// this checkout) nor `*`/`latest` (loose about the future, never stale about the
+// past — `examples/*` uses that on purpose for dev-only tooling). A rewriter
+// with its own copy of that list would eventually "fix" an edge the rule allows,
+// or skip one it does not, and the disagreement would only ever surface as a
+// failed release. So the set comes from `trainEdges()` in the rule module: ONE
+// definition, two consumers.
+//
+// WHAT IT DOES NOT DO: verify itself. `audit-runtimes --check --strict` runs
+// immediately after in the same hook and is the gate; a second check here would
+// be a guard watching a guard.
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { collectStandaloneApps, trainEdges, trainRange } from './manifest-conformance/rules/release-train.mjs';
+
+const [, , latestVersion, nextVersion] = process.argv;
+
+if (!latestVersion || !nextVersion) {
+    console.error('usage: bump-release-train-ranges.mjs <latestVersion> <nextVersion>');
+    process.exit(1);
+}
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..');
+const wanted = trainRange(nextVersion);
+const previous = trainRange(latestVersion);
+
+/** Directory groups that hold this monorepo's `<group>/<x>/<y>` packages. */
+const PACKAGE_GROUPS = ['packages', 'showcases', 'examples'];
+
+/**
+ * `@gjsify/<name>` → the manifest that DEFINES it, so a range can be checked
+ * against a package that provably exists here rather than assumed.
+ *
+ * This is the half `release-train` cannot see: the rule proves a range names the
+ * current version, this proves the thing it names is a real member of the train
+ * whose own manifest the bumper reached. A name that resolves to nothing would
+ * get `^${nextVersion}` written against a package that is never published under
+ * it — the ETARGET failure again, arrived at from the other side.
+ *
+ * @returns {Map<string, {rel: string, version: unknown}>}
+ */
+function indexMonorepoPackages() {
+    const index = new Map();
+    for (const group of PACKAGE_GROUPS) {
+        const groupDir = join(repoRoot, group);
+        if (!existsSync(groupDir)) continue;
+        for (const pillar of readdirSync(groupDir, { withFileTypes: true })) {
+            if (!pillar.isDirectory()) continue;
+            for (const pkg of readdirSync(join(groupDir, pillar.name), { withFileTypes: true })) {
+                if (!pkg.isDirectory()) continue;
+                const rel = `${group}/${pillar.name}/${pkg.name}`;
+                const path = join(repoRoot, rel, 'package.json');
+                if (!existsSync(path)) continue;
+                let manifest;
+                try {
+                    manifest = JSON.parse(readFileSync(path, 'utf8'));
+                } catch {
+                    // Reported by the `unreadable` pass below, which sees the
+                    // same file — failing here would report it twice.
+                    continue;
+                }
+                if (typeof manifest.name === 'string') index.set(manifest.name, { rel, version: manifest.version });
+            }
+        }
+    }
+    return index;
+}
+
+/**
+ * The manifest's own indentation, so a rewrite is a value change and not a
+ * reformat of the whole file. `@release-it/bumper` writes these files the same
+ * way (detected indent, `JSON.stringify`), which is why the round trip is
+ * lossless here — measured across all 76 standalone-app manifests under
+ * `showcases` and `examples`, none of which re-serialises differently.
+ *
+ * @param {string} raw
+ * @returns {string}
+ */
+function detectIndent(raw) {
+    const match = /\n([ \t]+)"/.exec(raw);
+    return match ? match[1] : '  ';
+}
+
+const { apps, unreadable } = collectStandaloneApps(repoRoot);
+const index = indexMonorepoPackages();
+
+/** Everything that stops the cut. Collected in full — one run, one verdict. */
+const failures = unreadable.map(
+    (rel) =>
+        `${rel}/package.json does not parse, so its \`@gjsify/*\` ranges can be neither read nor rewritten. ` +
+        `A manifest that cannot be parsed is invisible to \`release-train\` too, which is the exact shape ` +
+        `this hook exists to prevent: a file that looks authoritative and is not.`,
+);
+/** Proven-substitutable edits, applied only once nothing failed. */
+const planned = [];
+
+for (const { rel, manifest } of apps) {
+    const edits = [];
+    for (const { block, name, range } of trainEdges(manifest)) {
+        if (range === wanted) continue;
+        if (range !== previous) {
+            failures.push(
+                `${rel}/package.json: \`${block}.${name}\` is \`${range}\`, which is neither the version being ` +
+                    `replaced (\`${previous}\`) nor the one being cut (\`${wanted}\`). \`main\` is gated by the same ` +
+                    `\`release-train\` rule as a required check, so every governed range on the pre-bump tree has ` +
+                    `already been proven to equal \`${previous}\`. Rewriting this one anyway would put a release ` +
+                    `behind a manifest nothing verified.`,
+            );
+            continue;
+        }
+        const target = index.get(name);
+        if (!target) {
+            failures.push(
+                `${rel}/package.json: \`${block}.${name}\` names no package in this monorepo, so \`${wanted}\` ` +
+                    `cannot be substituted for it — the range would promise a publish that will never happen. ` +
+                    `This is how \`adwaita-storybook-nativescript\` came to request a version that was never ` +
+                    `published, failing every install there with ETARGET and nothing to notice it.`,
+            );
+            continue;
+        }
+        if (target.version !== nextVersion) {
+            failures.push(
+                `${rel}/package.json: \`${block}.${name}\` resolves to ${target.rel}, whose own \`version\` is ` +
+                    `\`${String(target.version)}\` and not \`${nextVersion}\`. \`@release-it/bumper\` did not reach ` +
+                    `that manifest, so \`${wanted}\` would name a version this release never publishes — the shape ` +
+                    `that cut v0.27.0 with \`@gjsify/napi\`'s children pinned a release behind.`,
+            );
+            continue;
+        }
+        edits.push({ block, name });
+    }
+    if (edits.length > 0) planned.push({ rel, edits });
+}
+
+if (failures.length > 0) {
+    console.error(`[bump-release-train-ranges] REFUSING to rewrite — ${failures.length} unsubstitutable range(s):`);
+    for (const line of failures) console.error(`  - ${line}`);
+    console.error('');
+    console.error(
+        'Nothing was written: the release train (ADR 0008) guarantees compatibility only WITHIN a release, and an ' +
+            'app outside the workspace gets that guarantee only if every range it names is a package this cut ' +
+            'actually publishes. Fix the manifest on `main` and re-dispatch the cut.',
+    );
+    process.exit(1);
+}
+
+let changedRanges = 0;
+for (const { rel, edits } of planned) {
+    const path = join(repoRoot, rel, 'package.json');
+    const raw = readFileSync(path, 'utf8');
+    const manifest = JSON.parse(raw);
+    for (const { block, name } of edits) manifest[block][name] = wanted;
+    writeFileSync(path, `${JSON.stringify(manifest, null, detectIndent(raw))}\n`);
+    changedRanges += edits.length;
+    console.log(`[bump-release-train-ranges] ${rel}/package.json: ${edits.length} range(s) ${previous} -> ${wanted}`);
+}
+
+console.log(
+    changedRanges === 0
+        ? `[bump-release-train-ranges] every standalone app already names ${wanted}`
+        : `[bump-release-train-ranges] updated ${changedRanges} range(s) across ${planned.length} app(s) to ${wanted}`,
+);

--- a/scripts/manifest-conformance/rules/release-train.mjs
+++ b/scripts/manifest-conformance/rules/release-train.mjs
@@ -19,6 +19,20 @@
  * installable, but mixing releases across exactly the boundary ADR 0008 says
  * carries no compatibility promise.
  *
+ * WHO KEEPS IT TRUE ACROSS A RELEASE. `@release-it/bumper` globs these same
+ * manifests, but it rewrites only their `version` field — never a dependency
+ * RANGE. So the moment release-it bumped the workspace to the next version,
+ * every range here named the PREVIOUS one and this rule failed inside the
+ * `after:bump` hook: unsatisfiable during a cut from the day it was added, and
+ * the v0.32.0 attempt was the first cut since, which is where it surfaced (11
+ * findings across the three NativeScript apps). The missing half is
+ * `scripts/bump-release-train-ranges.mjs`, which runs earlier in that same hook
+ * and rewrites the edges `trainEdges()` selects — the SAME selection this rule
+ * grades, shared rather than reimplemented, for the reason on that generator.
+ * That script is fail-closed on `gjsify pack`'s contract (substitute correctly
+ * or refuse; never write a range nothing verified), so a finding here on a
+ * bumped tree means the hook did not run, not that it gave up quietly.
+ *
  * Why repo-scoped: it compares against THIS repo's own version and reads only
  * `@gjsify/*` edges in paths this repo lays out. In a consumer's tree it would
  * be meaningless.
@@ -51,11 +65,19 @@ function readManifest(path) {
  * `package.json` — the workspace-excluded apps among them are what this rule is
  * for, and including the rest costs nothing because they resolve identically.
  *
+ * A manifest that EXISTS but does not parse is returned separately rather than
+ * dropped. Dropping it is the failure this rule is about, one level up: an
+ * unreadable file has no ranges, so it passes every check by having nothing to
+ * check — a manifest that looks authoritative and is not. An ABSENT
+ * `package.json` is ordinary (most directories under a pillar are not apps) and
+ * is simply skipped.
+ *
  * @param {string} root
- * @returns {Array<{rel: string, manifest: Record<string, unknown>}>}
+ * @returns {{apps: Array<{rel: string, manifest: Record<string, unknown>}>, unreadable: string[]}}
  */
 export function collectStandaloneApps(root) {
-    const found = [];
+    const apps = [];
+    const unreadable = [];
     for (const group of ['showcases', 'examples']) {
         const groupDir = join(root, group);
         if (!existsSync(groupDir)) continue;
@@ -65,12 +87,53 @@ export function collectStandaloneApps(root) {
             for (const app of readdirSync(pillarDir, { withFileTypes: true })) {
                 if (!app.isDirectory()) continue;
                 const rel = `${group}/${pillar.name}/${app.name}`;
-                const manifest = readManifest(join(pillarDir, app.name, 'package.json'));
-                if (manifest) found.push({ rel, manifest });
+                const path = join(pillarDir, app.name, 'package.json');
+                if (!existsSync(path)) continue;
+                const manifest = readManifest(path);
+                if (manifest) apps.push({ rel, manifest });
+                else unreadable.push(rel);
             }
         }
     }
-    return found;
+    return { apps, unreadable };
+}
+
+/** The range every governed edge has to name, for a given workspace version. */
+export function trainRange(version) {
+    return `^${version}`;
+}
+
+/**
+ * THE ONE definition of "which dependency edges ride the release train".
+ *
+ * It is a generator rather than an inlined loop because a SECOND consumer needs
+ * exactly this set: `scripts/bump-release-train-ranges.mjs`, the release hook
+ * that rewrites these ranges to the version being cut. A rewriter with its own
+ * copy of the skip list would "fix" an edge this rule deliberately allows (or
+ * miss one it does not), and the two would disagree — inside the few seconds of
+ * a bumped tree, where the only symptom is a failed cut.
+ *
+ * @param {Record<string, unknown>} manifest
+ * @returns {Generator<{block: string, name: string, range: string}>}
+ */
+export function* trainEdges(manifest) {
+    for (const block of DEP_BLOCKS) {
+        const deps = manifest[block];
+        if (!deps || typeof deps !== 'object') continue;
+        for (const [name, range] of Object.entries(deps)) {
+            if (!name.startsWith('@gjsify/')) continue;
+            // A workspace protocol or a local path is already pinned to this
+            // checkout — it cannot drift, so it is not this rule's business.
+            if (typeof range !== 'string') continue;
+            if (range.startsWith('workspace:') || range.startsWith('file:') || range.startsWith('link:')) continue;
+            // `*` / `latest` cannot LAG — they always resolve to the newest
+            // publish, which is the failure mode this rule exists for. They
+            // are loose about the future rather than stale about the past,
+            // and `examples/*` uses that deliberately for dev-only tooling.
+            if (range === '*' || range === 'latest') continue;
+            yield { block, name, range };
+        }
+    }
 }
 
 /**
@@ -80,34 +143,20 @@ export function collectStandaloneApps(root) {
  */
 export function auditReleaseTrain(apps, version) {
     const failures = [];
-    const wanted = `^${version}`;
+    const wanted = trainRange(version);
     let ranges = 0;
 
     for (const { rel, manifest } of apps) {
-        for (const block of DEP_BLOCKS) {
-            const deps = manifest[block];
-            if (!deps || typeof deps !== 'object') continue;
-            for (const [name, range] of Object.entries(deps)) {
-                if (!name.startsWith('@gjsify/')) continue;
-                // A workspace protocol or a local path is already pinned to this
-                // checkout — it cannot drift, so it is not this rule's business.
-                if (typeof range !== 'string') continue;
-                if (range.startsWith('workspace:') || range.startsWith('file:') || range.startsWith('link:')) continue;
-                // `*` / `latest` cannot LAG — they always resolve to the newest
-                // publish, which is the failure mode this rule exists for. They
-                // are loose about the future rather than stale about the past,
-                // and `examples/*` uses that deliberately for dev-only tooling.
-                if (range === '*' || range === 'latest') continue;
-                ranges++;
-                if (range === wanted) continue;
-                failures.push(
-                    `${rel}/package.json: \`${block}.${name}\` is \`${range}\`, not \`${wanted}\`. ` +
-                        `\`@gjsify/*\` ships as one release train (ADR 0008) and guarantees compatibility only ` +
-                        `WITHIN a release, so an app that is not a workspace member has to name the current one. ` +
-                        `This is how ${'`'}adwaita-storybook-nativescript${'`'} came to request a version that was ` +
-                        `never published, failing every install there with ETARGET and nothing to notice it.`,
-                );
-            }
+        for (const { block, name, range } of trainEdges(manifest)) {
+            ranges++;
+            if (range === wanted) continue;
+            failures.push(
+                `${rel}/package.json: \`${block}.${name}\` is \`${range}\`, not \`${wanted}\`. ` +
+                    `\`@gjsify/*\` ships as one release train (ADR 0008) and guarantees compatibility only ` +
+                    `WITHIN a release, so an app that is not a workspace member has to name the current one. ` +
+                    `This is how ${'`'}adwaita-storybook-nativescript${'`'} came to request a version that was ` +
+                    `never published, failing every install there with ETARGET and nothing to notice it.`,
+            );
         }
     }
     return { failures, checked: apps.length, ranges };
@@ -123,11 +172,17 @@ export const releaseTrainRule = defineRule({
         if (typeof version !== 'string') {
             return { failures: ['root package.json has no `version`, so the release train has no value to check.'] };
         }
-        const apps = collectStandaloneApps(ctx.root);
+        const { apps, unreadable } = collectStandaloneApps(ctx.root);
         const { failures, checked, ranges } = auditReleaseTrain(apps, version);
+        for (const rel of unreadable) {
+            failures.push(
+                `${rel}/package.json exists but does not parse, so nothing can read its \`@gjsify/*\` ranges — ` +
+                    `it passes this rule by having nothing to check. Fix the JSON.`,
+            );
+        }
         return {
             failures,
-            stats: { apps: checked, ranges },
+            stats: { apps: checked, ranges, unreadable: unreadable.length },
             summary: `release-train: ${ranges} \`@gjsify/*\` range(s) across ${checked} standalone app(s) name ^${version}`,
         };
     },


### PR DESCRIPTION
The `v0.32.0` cut failed inside `after:bump`, on the `release-train` rule added in #1058. **Nothing half-landed** — no tag, no release, `main` untouched — but the rule was unsatisfiable during a cut from the day it landed, and `v0.32.0` was the first cut since.

## The blocker

`@release-it/bumper` globs `showcases/*/*/package.json`, but it rewrites exactly one key: `version`. Never a dependency range.

Three apps under `showcases/` are `!`-negated out of the root `workspaces` globs — they carry their own `node_modules` and their own NativeScript toolchain — so their `@gjsify/*` deps are ordinary npm ranges that nothing keeps current. The moment `release-it` bumped the workspace, all eleven named the previous version:

```
[release-train] showcases/dom/adwaita-storybook-nativescript/package.json:
  `dependencies.@gjsify/adwaita-nativescript` is `^0.31.0`, not `^0.32.0`.
```

The fix makes the release **satisfy** the rule rather than weakening it. The rule exists because `adwaita-storybook-nativescript` once asked for a version that had never been published — every `npm install` there failed with ETARGET and nothing noticed, because those apps are outside the workspace so `gjsify upgrade --check` never sees them. Rewriting the ranges at bump time is what makes them actually installable after a release, which is the whole point.

## Why not `workspace:^`

Worth writing down, because the machinery exists and looks applicable. `gjsify pack` already substitutes `workspace:^` / `~` / `*` before packing, and `tests/e2e/pack-workspace-protocol` pins the contract: *substituted correctly or the pack FAILS, never silently published.* The sibling repo `ts-for-gir` uses the protocol throughout and releases through it.

It does not transfer to these three:

- its input domain is the `workspace:` protocol, which is precisely the set `release-train` **excludes** — pointed at these manifests it returns them unchanged;
- it resolves versions through workspace **membership**, and `findWorkspaceRoot()` is deliberately strict about that; these apps are negated out on purpose;
- they are never packed. An app installed from the registry is read from its **committed** manifest, not from a tarball, so the range must be concrete.

Its **contract** is adopted, though. The rewriter collects every problem, writes nothing, and exits 1 on: a manifest that does not parse; a governed range that is not the version being replaced; a `@gjsify/*` dep naming no package in this monorepo; or a dep whose own manifest the bumper never reached. The write pass runs only once every edge is proven substitutable, so a refusal leaves the tree untouched rather than half-rewritten.

`trainEdges()` and `trainRange()` now have one definition, shared by the rule and the rewriter, so the two cannot drift into disagreeing about which edges ride the train.

## The reporter bug the same run surfaced

```
UNREPORTED FINDING(S) — this is a REPORTER bug, not a new drift
A rule was selected by CHECK_RULES but has no print block in scripts/audit-runtimes.mjs,
so it set the exit code without naming anything.
```

Three rules, not one: `release-train`, `nativescript-platforms` and **`storybook`**. Each could fail the build while naming nothing, and each ran invisibly on a green run too. All three now print in both directions. The accountant that caught them was built for exactly this and should not have had to.

Also: `collectStandaloneApps` no longer treats a manifest that **exists but does not parse** the same as an absent one. That was the rule's own failure mode one level up — a file passing by having nothing to check.

## Verification

The full `after:bump` chain simulated against a bumped tree (271 manifests → 0.32.0):

| step | result |
|---|---|
| audit **before** the rewriter | exit **1** |
| `bump-release-train-ranges 0.31.0 0.32.0` | `updated 11 range(s) across 3 app(s)` |
| `generate-platform-packages --write` | 1 change |
| `audit-runtimes --check --strict` | exit **0**, `release-train: 11 range(s) across 76 standalone app(s) name ^0.32.0` |

All four refusal paths fire with exit 1 and an untouched tree. Each of the three reporting fixes was counter-tested by introducing a violation: the check exits 1 and prints a named finding, with an `UNREPORTED FINDING` count of 0.

Re-running the rewriter at the same version is a correct no-op (`every standalone app already names ^0.31.0`).

## Not verified

`release-it` itself was not run — it requires a clean tree, `main`, and a tag push. The chain is proven by simulating the bumper's `out` globs exactly; the untested residue is release-it's own argument interpolation, which is identical in shape to the adjacent `bump-docs-version.mjs` call. There is no e2e suite covering the audit's reporting or this hook; adding one requires listing it in `test:e2e` (`check-e2e-suite-coverage` enforces that) and was left out of a release-blocking fix.