### PR TITLE
feat(adwaita): put both renderers on the C source, and keep them there

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -169,6 +169,13 @@ jobs:
       - name: Check adwaita-web's style-isolation list covers every element
         run: node scripts/check-adwaita-reset-components.mjs
 
+      # A conformance table with no RENDERER behind it asserts a derivation against
+      # itself. A census (#1072) found 43 such tables, 16 of them silent gaps rather
+      # than deliberate — and two headers in the same area were asserting coverage
+      # that did not exist, which reads as a reason not to look.
+      - name: Check every conformance table is driven or explains why not
+        run: node scripts/check-adwaita-conformance-drivers.mjs
+
       # A lockfile whose FORMAT lags the installer is silent: `--immutable` accepts old
       # versions on purpose, so every install still succeeds — just without the platform
       # fields the filter reads. That is how this repo installed every platform's
@@ -386,6 +393,13 @@ jobs:
       # and the spec ADR 0010 names as the guard instantiates exactly one element.
       - name: Check adwaita-web's style-isolation list covers every element
         run: node scripts/check-adwaita-reset-components.mjs
+
+      # A conformance table with no RENDERER behind it asserts a derivation against
+      # itself. A census (#1072) found 43 such tables, 16 of them silent gaps rather
+      # than deliberate — and two headers in the same area were asserting coverage
+      # that did not exist, which reads as a reason not to look.
+      - name: Check every conformance table is driven or explains why not
+        run: node scripts/check-adwaita-conformance-drivers.mjs
 
       # A lockfile whose FORMAT lags the installer is silent: `--immutable` accepts old
       # versions on purpose, so every install still succeeds — just without the platform

--- a/packages/nativescript-bridge/adwaita/src/chrome.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/chrome.spec.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
-import { ADW_SPINNER_MIN_SIZE, spinnerGeometry } from '@gjsify/adwaita-core';
+import { ADW_SPINNER_MIN_SIZE, resolveSpinnerSize, spinnerGeometry } from '@gjsify/adwaita-core';
 import {
     CLAMP_ALLOCATE_VECTORS,
     CLAMP_PROPERTY_VECTORS,
@@ -145,10 +145,24 @@ export default async () => {
             expect(spinnerDiameter(null)).toBe(16);
         });
 
-        await it('caps an oversized request at 64 instead of applying it', () => {
-            // `size = 200` used to produce a 200 DIP indicator.
+        await it('caps the RING at 64 while the BOX keeps the request', () => {
+            // The two are different numbers, which is the split `AdwSpinner`
+            // renders: a `GridLayout` of `resolveSpinnerSize` DIPs holding an
+            // `ActivityIndicator` of `spinnerDiameter` DIPs, centred. The widget
+            // used to be the ring alone, so `size = 200` occupied 64 DIPs of
+            // layout where GTK occupies 200 (adw-spinner.c:78-81 reports MIN_SIZE
+            // as minimum AND natural with no upper bound; only the radius caps).
             expect(spinnerDiameter(200)).toBe(64);
             expect(spinnerDiameter(1000)).toBe(64);
+            expect(resolveSpinnerSize(200)).toBe(200);
+            expect(resolveSpinnerSize(1000)).toBe(1000);
+            // ...and they agree wherever the cap does not bite.
+            for (const size of [16, 24, 48, 64]) expect(spinnerDiameter(size)).toBe(resolveSpinnerSize(size));
+        });
+
+        await it('floors the BOX at the measured minimum, so a tiny request is not representable', () => {
+            expect(resolveSpinnerSize(4)).toBe(ADW_SPINNER_MIN_SIZE);
+            expect(resolveSpinnerSize(null)).toBe(ADW_SPINNER_MIN_SIZE);
         });
     });
 

--- a/packages/nativescript-bridge/adwaita/src/index.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/index.spec.ts
@@ -21,7 +21,7 @@ import { describe, it, expect } from '@gjsify/unit';
 // before any guard could run. `@gjsify/native-platform` and `./fonts.js` are
 // pure-TS (no `@nativescript/core` value imports), so they load everywhere.
 import { AVATAR_COLORS, flattenAvatarGradient } from '@gjsify/adwaita-core';
-import { AVATAR_COLOR_VECTORS, AVATAR_INITIALS_VECTORS } from '@gjsify/adwaita-core/conformance';
+import { AVATAR_COLOR_VECTORS, AVATAR_INITIALS_VECTORS, COMBO_CHOOSER_VECTORS } from '@gjsify/adwaita-core/conformance';
 import { assertNativeScript, isNativeScript } from '@gjsify/native-platform';
 import { avatarColor, avatarInitials } from './widgets/avatar-color.js';
 import {
@@ -464,6 +464,20 @@ export default async () => {
             expect(state.setSelectedValue('b')).toBe(true);
             expect(state.selectedIndex).toBe(1);
         });
+
+        // `model_changed` (adw-combo-row.c:187-195). The widget reads this
+        // predicate twice — once to collapse the chevron, once to refuse the tap
+        // — and it cannot be imported here, so the table is driven against the
+        // state it reads. Both halves matter: hiding the chevron alone leaves a
+        // row that still opens an `action()` sheet with one entry, which is what
+        // this port did.
+        for (const { count, presentsChooser, rule } of COMBO_CHOOSER_VECTORS) {
+            await it(`${count} option(s) → presentsChooser ${presentsChooser}: ${rule}`, () => {
+                const state = new ComboState();
+                state.setOptions(Array.from({ length: count }, (_, i) => ({ label: `L${i}`, value: `v${i}` })));
+                expect(state.presentsChooser).toBe(presentsChooser);
+            });
+        }
     });
 
     await describe('AdwSpinRow numeric stepper (core SpinState re-export)', async () => {

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -70,6 +70,11 @@ declare module '@nativescript/core' {
         /** Accessibility role announced to the platform screen reader —
          *  NS's counterpart to `gtk_widget_class_set_accessible_role`. */
         accessibilityRole: string;
+        /** The view's resolved style. `direction` is an INHERITED CSS property
+         *  (`ui/styling/style-properties`: `new InheritedCssProperty({ name:
+         *  'direction', cssName: 'direction' })`, default null), which is the
+         *  text direction `start`/`end` are resolved against. */
+        readonly style: { direction?: 'ltr' | 'rtl' | null };
         /** Accessibility state — NS's counterpart to `gtk_accessible_update_state`. */
         accessibilityState: string;
         /** Animate one or more properties to their target values. Resolves when the

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -67,6 +67,11 @@ declare module '@nativescript/core' {
         /** Whether the view is currently loaded / attached to the visual tree.
          *  Off-screen (pre-load) transitions skip animation. */
         readonly isLoaded: boolean;
+        /** Accessibility role announced to the platform screen reader —
+         *  NS's counterpart to `gtk_widget_class_set_accessible_role`. */
+        accessibilityRole: string;
+        /** Accessibility state — NS's counterpart to `gtk_accessible_update_state`. */
+        accessibilityState: string;
         /** Animate one or more properties to their target values. Resolves when the
          *  animation finishes; the returned promise can also be `cancel()`ed. */
         animate(options: AnimationDefinition): AnimationPromise;

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -128,6 +128,8 @@ declare module '@nativescript/core' {
         /** Insert a child at a specific index (paint/stacking order). */
         insertChild(view: View, atIndex: number): void;
         removeChild(view: View): void;
+        /** Detach every child at once — `adw_wrap_box_remove_all`'s counterpart. */
+        removeChildren(): void;
         getChildAt(index: number): View;
         getChildrenCount(): number;
     }
@@ -230,6 +232,23 @@ declare module '@nativescript/core' {
         itemWidth: number;
         /** Fixed slot height for each item, in DIPs (optional). */
         itemHeight: number;
+    }
+
+    /**
+     * A flexbox container — `<FlexboxLayout>`. The wrapping container with real
+     * main-axis knobs, which is what `Adw.WrapBox` needs and `WrapLayout` (three
+     * properties, none of them about distribution) cannot give it.
+     */
+    export class FlexboxLayout extends LayoutBase {
+        flexDirection: 'row' | 'row-reverse' | 'column' | 'column-reverse';
+        flexWrap: 'nowrap' | 'wrap' | 'wrap-reverse';
+        justifyContent: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around';
+        alignItems: 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
+        alignContent: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'stretch';
+        /** Per-child: whether it absorbs a line's leftover space (`justify: fill`). */
+        static setFlexGrow(view: View, grow: number): void;
+        /** Per-child: whether an overflowing line may squeeze it (`wrap-policy`). */
+        static setFlexShrink(view: View, shrink: number): void;
     }
 
     /** A layout whose children are positioned by absolute left/top — `<AbsoluteLayout>`. */

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -80,6 +80,9 @@ declare module '@nativescript/core' {
         readonly style: { direction?: 'ltr' | 'rtl' | null };
         /** Accessibility state — NS's counterpart to `gtk_accessible_update_state`. */
         accessibilityState: string;
+        /** The text a screen reader announces for this view — NS's counterpart
+         *  to `gtk_accessible_update_property (…, DESCRIPTION, …)`. */
+        accessibilityLabel: string;
         /** Animate one or more properties to their target values. Resolves when the
          *  animation finishes; the returned promise can also be `cancel()`ed. */
         animate(options: AnimationDefinition): AnimationPromise;

--- a/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-core.d.ts
@@ -67,6 +67,9 @@ declare module '@nativescript/core' {
         /** Whether the view is currently loaded / attached to the visual tree.
          *  Off-screen (pre-load) transitions skip animation. */
         readonly isLoaded: boolean;
+        /** The view this one is mounted in, or `null` at the root — the walk a
+         *  nested widget offers an unhandled action up. */
+        readonly parent: View | null;
         /** Accessibility role announced to the platform screen reader —
          *  NS's counterpart to `gtk_widget_class_set_accessible_role`. */
         accessibilityRole: string;

--- a/packages/nativescript-bridge/adwaita/src/split-view-state.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/split-view-state.spec.ts
@@ -352,13 +352,13 @@ export default async () => {
     });
 
     await describe('splitViewColumns against NAVIGATION_SPLIT_VIEW_LAYOUT_VECTORS', async () => {
+        // The RTL rows used to be skipped, with a note saying NativeScript
+        // surfaces no text direction. It does: `direction` is an inherited CSS
+        // property on `Style`, so the whole table is drivable now.
         for (const vector of NAVIGATION_SPLIT_VIEW_LAYOUT_VECTORS) {
-            // NativeScript surfaces no text direction, so the RTL rows are the
-            // documented `'ltr'` pin rather than something this port can answer.
-            if (vector.direction === 'rtl') continue;
-
-            await it(`${vector.sidebarPosition}: the sidebar takes the column at x=${vector.sidebar.x} — ${vector.rule}`, () => {
-                const columns = splitViewColumns(vector.sidebarPosition);
+            const label = `${vector.sidebarPosition} ${vector.direction}: the sidebar takes the column at x=${vector.sidebar.x}`;
+            await it(`${label} — ${vector.rule}`, () => {
+                const columns = splitViewColumns(vector.sidebarPosition, vector.direction);
                 // The vector's rects are pixels; the grid's equivalent is the
                 // ORDER — the sidebar is in the leading column exactly when it is
                 // allocated at x = 0.
@@ -367,14 +367,27 @@ export default async () => {
             });
         }
 
+        await it('MIRRORS under RTL — a start sidebar takes the trailing column', () => {
+            expect(splitViewColumns('start', 'ltr')).toStrictEqual({ sidebar: 0, content: 1 });
+            expect(splitViewColumns('start', 'rtl')).toStrictEqual({ sidebar: 1, content: 0 });
+            expect(splitViewColumns('end', 'ltr')).toStrictEqual({ sidebar: 1, content: 0 });
+            expect(splitViewColumns('end', 'rtl')).toStrictEqual({ sidebar: 0, content: 1 });
+        });
+
+        await it('defaults to ltr, which is what an unset NS direction means', () => {
+            expect(splitViewColumns('start')).toStrictEqual(splitViewColumns('start', 'ltr'));
+        });
+
         await it('never puts both panes in the same column', () => {
             // The inversion this closes: the navigation split view wrote the
             // sidebar into column 0 and the content into column 1 UNCONDITIONALLY,
             // while the base had already made column 0 the expanding one for an
             // `end` sidebar — so both the side AND the sizing mode were swapped.
             for (const position of ['start', 'end'] as const) {
-                const columns = splitViewColumns(position);
-                expect(columns.sidebar).not.toBe(columns.content);
+                for (const direction of ['ltr', 'rtl'] as const) {
+                    const columns = splitViewColumns(position, direction);
+                    expect(columns.sidebar).not.toBe(columns.content);
+                }
             }
         });
     });

--- a/packages/nativescript-bridge/adwaita/src/split-view-state.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/split-view-state.spec.ts
@@ -13,7 +13,11 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
-import { NAVIGATION_SPLIT_VIEW_LAYOUT_VECTORS, NAVIGATION_STACK_VECTORS } from '@gjsify/adwaita-core/conformance';
+import {
+    NAVIGATION_ACTION_VECTORS,
+    NAVIGATION_SPLIT_VIEW_LAYOUT_VECTORS,
+    NAVIGATION_STACK_VECTORS,
+} from '@gjsify/adwaita-core/conformance';
 import { OVERLAY_COLLAPSE_VECTORS } from '@gjsify/adwaita-core/conformance';
 import type { OverlaySplitViewSnapshot } from '@gjsify/adwaita-core/conformance';
 
@@ -398,6 +402,75 @@ export default async () => {
             expect(state.setPaneMounted('sidebar', true)).toBe(false);
             expect(state.setPaneMounted('content', true)).toBe(false);
             expect(host.calls).toStrictEqual([]);
+        });
+    });
+
+    await describe('NsNavigationSplitViewState tags + navigation.* actions', async () => {
+        // The class carried a note saying tags and the actions were "NOT wired on
+        // NativeScript", so NAVIGATION_ACTION_VECTORS had no consumer on this
+        // side and NAVIGATION_SPLIT_VIEW_CRITICALS none at all. They are wired
+        // through an explicit setTag rather than a `tag` read off a pane View —
+        // a View is not an Adw.NavigationPage.
+        for (const vector of NAVIGATION_ACTION_VECTORS) {
+            const label =
+                vector.action === 'push'
+                    ? `push "${vector.tag}" (sidebar=${vector.sidebarTag ?? 'none'}, content=${vector.contentTag ?? 'none'})`
+                    : `pop (sidebar=${vector.hasSidebar}, content=${vector.hasContent})`;
+            await it(`${label} → ${vector.result.kind} — ${vector.rule}`, () => {
+                const state = new NsNavigationSplitViewState({
+                    collapsed: vector.collapsed,
+                    showContent: vector.showContent,
+                    // `delegate` is the ROUTING's answer; whether it survives
+                    // depends on the ancestor. An ancestor that claims the tag is
+                    // the case the table describes — the unclaimed one becomes a
+                    // critical, which is the state's own step.
+                    onDelegate: () => true,
+                });
+                if (vector.action === 'pop') {
+                    state.setPaneMounted('sidebar', vector.hasSidebar ?? false);
+                    state.setPaneMounted('content', vector.hasContent ?? false);
+                    expect(state.pop().kind).toBe(vector.result.kind);
+                    return;
+                }
+                state.setPaneMounted('sidebar', true);
+                state.setPaneMounted('content', true);
+                // A colliding pair is refused by setTag, so the second tag is the
+                // one that does not stick — which is exactly why the shared-tag
+                // rows describe a state a real widget cannot reach.
+                const sidebarStuck = state.setTag('sidebar', vector.sidebarTag ?? null);
+                const contentStuck = state.setTag('content', vector.contentTag ?? null);
+                if (!sidebarStuck || !contentStuck) {
+                    expect(vector.sidebarTag).toBe(vector.contentTag);
+                    return;
+                }
+                expect(state.push(vector.tag as string).kind).toBe(vector.result.kind);
+            });
+        }
+
+        await it('REFUSES a colliding retag and clears it, keeping the pane', () => {
+            // `check_tags_cb` (:431-460) — a different failure from mounting a
+            // colliding page, which is refused outright (:1195-1201).
+            const state = new NsNavigationSplitViewState();
+            state.setPaneMounted('sidebar', true);
+            state.setPaneMounted('content', true);
+            expect(state.setTag('sidebar', 'same')).toBe(true);
+            expect(state.setTag('content', 'same')).toBe(false);
+            expect(state.sidebarTag).toBe('same');
+            expect(state.contentTag).toBe(null);
+        });
+
+        await it('a push that lands flips show-content, which the widget renders', () => {
+            const { state, host } = record(new NsNavigationSplitViewState({ collapsed: true }));
+            state.setPaneMounted('sidebar', true);
+            state.setPaneMounted('content', true);
+            state.setTag('sidebar', 'list');
+            state.setTag('content', 'detail');
+            host.calls.length = 0;
+            expect(state.push('detail').kind).toBe('set-show-content');
+            expect(state.showContent).toBe(true);
+            // The layout has to have been asked to re-run, or the pane swap is a
+            // property change nobody drew.
+            expect(host.calls.length).toBeGreaterThan(0);
         });
     });
 };

--- a/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
+++ b/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
@@ -1182,10 +1182,23 @@ Page.adw-window {
     background-color: #fafafb;
 }
 
+/* The divider is on the side the sidebar is DRAWN on, which is `:dir()` x `.end`
+ * in _sidebars.scss:21-39 — not a fixed right edge. The widget adds
+ * `.adw-sidebar-at-visual-start` when the pane leads, so an `end` sidebar, and a
+ * `start` one under RTL, get their divider on the correct edge instead of
+ * drawing it inside the content. */
 .adw-split-view-sidebar {
     background-color: #ebebed;
+}
+
+.adw-split-view-sidebar.adw-sidebar-at-visual-start {
     border-right-width: 1;
     border-right-color: rgba(0, 0, 0, 0.1);
+}
+
+.adw-split-view-sidebar.adw-sidebar-at-visual-end {
+    border-left-width: 1;
+    border-left-color: rgba(0, 0, 0, 0.1);
 }
 
 .adw-split-view-content {
@@ -1790,7 +1803,14 @@ Page.ns-dark.adw-window {
 .ns-dark .adw-split-view-sidebar,
 .ns-dark .adw-overlay-active {
     background-color: #2a2a2e;
+}
+
+.ns-dark .adw-split-view-sidebar.adw-sidebar-at-visual-start {
     border-right-color: rgba(255, 255, 255, 0.12);
+}
+
+.ns-dark .adw-split-view-sidebar.adw-sidebar-at-visual-end {
+    border-left-color: rgba(255, 255, 255, 0.12);
 }
 
 .ns-dark .adw-split-view-content {

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-combo-row.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-combo-row.ts
@@ -83,6 +83,7 @@ export class AdwComboRow extends AdwActionRow {
         // notify::selected on an interactive pick.
         this._state.subscribe((change) => {
             this._valueLabel.text = change.label;
+            this._syncChooser();
             if (change.interactive) {
                 const data: NotifySelectedEventData = {
                     eventName: NOTIFY_SELECTED,
@@ -100,11 +101,26 @@ export class AdwComboRow extends AdwActionRow {
         });
         // ...and the row darkens while held, like an Adwaita activatable row.
         attachRowPressFeedback(this);
+        this._syncChooser();
+    }
+
+    /**
+     * `model_changed` (adw-combo-row.c:187-195) — one option or none is not a
+     * choice, so the chevron goes and the row stops being activatable.
+     *
+     * Both halves matter. Hiding the chevron alone would leave a row that still
+     * opens a one-entry `action()` sheet on tap; the tap guard is in
+     * {@link _openChooser}, which reads the same predicate.
+     */
+    private _syncChooser(): void {
+        this._chevron.visibility = this._state.presentsChooser ? 'visible' : 'collapse';
     }
 
     /** Open the native action chooser and apply the picked option. */
     private async _openChooser(): Promise<void> {
-        if (this._state.count === 0) return;
+        // `n_items > 1`: a single option is not a choice, and libadwaita makes
+        // the row non-activatable rather than opening a sheet with one entry.
+        if (!this._state.presentsChooser) return;
         const labels = this._state.options.map((o) => o.label);
         const chosen = await action({
             title: this.title || undefined,

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-navigation-split-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-navigation-split-view.ts
@@ -28,6 +28,7 @@
 import { GridLayout, type View } from '@nativescript/core';
 import { AdwSplitViewBase } from './split-view-base.js';
 import { NsNavigationSplitViewState, splitViewColumns } from './split-view-state.js';
+import type { NavigationActionResult } from '@gjsify/adwaita-core';
 
 /** Push/pop duration (ms) — matches Adwaita's ~200 ms navigation transition. */
 const NAV_ANIM_MS = 200;
@@ -37,7 +38,25 @@ const FALLBACK_WIDTH = 1024;
 
 export class AdwNavigationSplitView extends AdwSplitViewBase<NsNavigationSplitViewState> {
     constructor() {
-        super('adw-navigation-split-view', 'navigation', new NsNavigationSplitViewState());
+        super(
+            'adw-navigation-split-view',
+            'navigation',
+            new NsNavigationSplitViewState({
+                onCritical: (message) => console.error(message),
+                // `navigation_push_cb` offers an unmatched tag to the PARENT
+                // before it may become a critical (:679-683) — the mechanism a
+                // nested split view forwards a push with. NativeScript has no
+                // bubbling events, so the walk up `parent` is the equivalent.
+                onDelegate: (action, tag) => {
+                    for (let node = this.parent; node; node = node.parent) {
+                        if (!(node instanceof AdwNavigationSplitView)) continue;
+                        const result = action === 'push' ? node.push(tag as string) : node.pop();
+                        return result.kind !== 'not-found';
+                    }
+                    return false;
+                },
+            }),
+        );
         this._applyLayout();
     }
 
@@ -48,7 +67,7 @@ export class AdwNavigationSplitView extends AdwSplitViewBase<NsNavigationSplitVi
             // one (`allocate_uncollapsed`, :306-316). Writing the sidebar into
             // column 0 unconditionally put an `end` sidebar in the EXPANDING column
             // and squeezed the content into the fixed one: a fully inverted layout.
-            const columns = splitViewColumns(this._state.sidebarPosition);
+            const columns = splitViewColumns(this._state.sidebarPosition, this.textDirection);
             if (this._sidebar) {
                 this._sidebar.visibility = 'visible';
                 this._sidebar.translateX = 0;
@@ -136,5 +155,57 @@ export class AdwNavigationSplitView extends AdwSplitViewBase<NsNavigationSplitVi
     private _paneWidth(): number {
         const size = this.getActualSize();
         return size && size.width > 0 ? size.width : FALLBACK_WIDTH;
+    }
+
+    // --- tags + the navigation.* actions ---
+    //
+    // Explicit setters rather than a `tag` property read off the pane `View`:
+    // a `View` is not an `Adw.NavigationPage`, and reading one would adopt
+    // whatever NativeScript happens to put there. The tag of record lives in the
+    // core, because a collision CLEARS it and silently mutating a caller's view
+    // to do that would be a surprise.
+
+    /** `Adw.NavigationPage:tag` for the sidebar pane, or `null` when untagged. */
+    get sidebarTag(): string | null {
+        return this._state.sidebarTag;
+    }
+
+    set sidebarTag(value: string | null) {
+        this._state.setTag('sidebar', value);
+    }
+
+    /** `Adw.NavigationPage:tag` for the content pane, or `null` when untagged. */
+    get contentTag(): string | null {
+        return this._state.contentTag;
+    }
+
+    set contentTag(value: string | null) {
+        this._state.setTag('content', value);
+    }
+
+    /**
+     * `navigation.push` with `tag` — `navigation_push_cb` (:644-685).
+     *
+     * An unmatched tag delegates to the parent before it may become a critical,
+     * which is how a nested split view forwards a push outwards. Returns what
+     * the routing decided; the ten-row NAVIGATION_ACTION_VECTORS table had no
+     * consumer in either renderer before this.
+     */
+    push(tag: string): NavigationActionResult {
+        return this._state.push(tag);
+    }
+
+    /** `navigation.pop` — `navigation_pop_cb` (:687-702). */
+    pop(): NavigationActionResult {
+        return this._state.pop();
+    }
+
+    /** `Adw.NavigationSplitView:show-content`, the C's own spelling of the flag. */
+    get showContent(): boolean {
+        return this._state.showContent;
+    }
+
+    set showContent(value: boolean) {
+        this._state.showContent = value;
     }
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-spinner.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-spinner.ts
@@ -1,77 +1,129 @@
 // AdwSpinner — a Libadwaita-style busy spinner for NativeScript.
 //
-// Extends the REAL NativeScript `ActivityIndicator`, defaulting it to `busy` and
-// taking its colour from the `adw-spinner` CSS class. Mirrors `Adw.Spinner`:
-// a self-animating loading indicator. `spinning` get/set toggles `busy`; `size`
-// sets the diameter.
+// A `GridLayout` BOX holding the platform's own `ActivityIndicator`, centred.
+// The box is the requested size and the indicator is the RING, capped at 64 —
+// which is the split `Adw.Spinner` makes and this port did not: the view WAS the
+// ring, so `size = 200` reported 64 back and occupied 64 DIPs of layout where
+// GTK occupies 200 (`adw_spinner_measure` reports MIN_SIZE as minimum AND
+// natural with no upper bound, adw-spinner.c:78-81, while the paintable caps
+// only the radius and still centres on the box, adw-spinner-paintable.c:343-351).
 //
-// FIDELITY: faithful — `ActivityIndicator` is the platform's native spinner and
-// already animates (the one native NS animation that fits the CSS-subset contract,
-// since the engine drives it, not CSS keyframes). The colour tints the platform
-// indicator where the OS honours it (Android sets the indeterminate drawable tint
-// from `color`; iOS uses its standard style).
+// FIDELITY: the ARC is the platform's, deliberately. `ActivityIndicator` is the
+// native spinner and the engine drives it, which is the one animation that fits
+// the CSS-subset contract; hand-drawing libadwaita's breathing arc here would
+// mean a per-frame JS animation on a phone to replace an animation the OS
+// already runs. What IS ported is everything around it: the size split, the
+// colour, the accessibility role, and the map gating.
 //
-// That colour is the widget's TEXT colour, NOT the accent: the paintable strokes
+// The colour is the widget's TEXT colour, NOT the accent: the paintable strokes
 // with `gtk_widget_get_color()` (adw-spinner-paintable.c:432). This port used
 // Adwaita's accent blue for its whole life while adwaita-web used `currentColor`
 // and documented the neutrality in a comment — the two ports contradicted each
 // other in the open, and no conformance vector covers colour, so nothing looked.
 //
-// The SIZE is Adwaita's, not an invention: the indicator fills its view, so the
-// view is the ring, and `spinnerDiameter` floors it at the measured minimum 16
-// and caps it at 64 — the documented "never smaller than 16×16 and never larger
-// than 64×64" (adw-spinner.c:27-28). This widget used to default to 32, which is
-// in no libadwaita source, and applied `size = 200` unclamped.
-//
-// Reference: refs/libadwaita/src/adw-spinner.c (MIN_SIZE, adw_spinner_measure)
-// Reference: refs/libadwaita/src/adw-spinner-paintable.c (MAX_RADIUS)
+// Reference: refs/libadwaita/src/adw-spinner.c (MIN_SIZE, adw_spinner_measure, the a11y role)
+// Reference: refs/libadwaita/src/adw-spinner-paintable.c (MAX_RADIUS, widget_map_cb)
 // Reference: refs/libadwaita/src/stylesheet/widgets/_spinner.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
-import { ActivityIndicator } from '@nativescript/core';
+import { ActivityIndicator, GridLayout, ItemSpec } from '@nativescript/core';
 
-import { DEFAULT_SPINNER_SIZE, spinnerDiameter } from './chrome.js';
+import { resolveSpinnerSize, spinnerGeometry } from '@gjsify/adwaita-core';
+
+import { DEFAULT_SPINNER_SIZE } from './chrome.js';
 
 export { DEFAULT_SPINNER_SIZE };
 
-export class AdwSpinner extends ActivityIndicator {
+export class AdwSpinner extends GridLayout {
+    /** The platform indicator — the RING, capped at 64 DIPs. */
+    private readonly _indicator: ActivityIndicator;
+    /** The requested BOX size, floored at the measured minimum 16. */
     private _size = DEFAULT_SPINNER_SIZE;
+    /** Whether the consumer wants it spinning, independent of whether it is mapped. */
+    private _spinning = true;
 
     constructor() {
         super();
 
         this.className = 'adw-spinner';
-        // Adwaita spinners spin as soon as they are shown.
-        this.busy = true;
+        this.addRow(new ItemSpec(1, 'star'));
+        this.addColumn(new ItemSpec(1, 'star'));
+
+        const indicator = new ActivityIndicator();
+        indicator.className = 'adw-spinner-ring';
+        indicator.horizontalAlignment = 'center';
+        indicator.verticalAlignment = 'center';
+        this._indicator = indicator;
+        this.addChild(indicator);
+
+        // `gtk_widget_class_set_accessible_role (…, PROGRESS_BAR)`
+        // (adw-spinner.c:124) plus `GTK_ACCESSIBLE_STATE_BUSY, TRUE` (:139-141).
+        // A repo-wide grep for either found ZERO hits across both ports before
+        // this, so screen readers announced nothing at all.
+        this.accessibilityRole = 'progressbar';
+        this.accessibilityState = 'busy';
+
+        // `widget_map_cb` (adw-spinner-paintable.c:181-185, :542-543) plays the
+        // animation on MAP and only then. This widget used to set `busy = true`
+        // in its constructor, so an off-screen spinner burned its animation for
+        // as long as it existed.
+        this.addEventListener('loaded', () => this._applySpinning());
+        this.addEventListener('unloaded', () => {
+            this._indicator.busy = false;
+        });
+
         this._applySize();
+        this._applySpinning();
     }
 
     private _applySize(): void {
+        // THE BOX: what was asked for.
         this.width = this._size;
         this.height = this._size;
+        // THE RING: capped at 64, centred by the grid.
+        const { diameter } = spinnerGeometry(this._size, this._size);
+        this._indicator.width = diameter;
+        this._indicator.height = diameter;
     }
 
-    /** Whether the spinner is animating. Two-way bound to the indicator's `busy`. */
+    private _applySpinning(): void {
+        // Off-device (`isLoaded` undefined in the mock view tree) the gate is
+        // inert, so a spec still sees the requested state rather than a widget
+        // that never maps.
+        const mapped = this.isLoaded !== false;
+        this._indicator.busy = this._spinning && mapped;
+    }
+
+    /** Whether the spinner is animating. Gated on being mapped, as in GTK. */
     get spinning(): boolean {
-        return this.busy;
+        return this._spinning;
     }
 
     set spinning(value: boolean) {
-        this.busy = !!value;
+        this._spinning = !!value;
+        this._applySpinning();
     }
 
     /**
-     * The spinner diameter in DIPs — the DRAWN one, so reading it back after
-     * `size = 200` reports 64 and after `size = 8` reports 16. Adwaita's ring is
-     * bounded on both ends, and a getter that echoed the request would be
-     * describing something that is not on screen.
+     * The BOX size in DIPs — what was requested, floored at the measured
+     * minimum 16 and NOT capped.
+     *
+     * Reading it back after `size = 200` reports 200, because that is what the
+     * widget occupies. {@link ringDiameter} is the drawn ring, which is where
+     * the 64 cap lives. The two used to be one number, so an oversized spinner
+     * silently took 64 DIPs of layout instead of the 200 it was given.
      */
     get size(): number {
         return this._size;
     }
 
     set size(value: number) {
-        this._size = spinnerDiameter(value);
+        this._size = resolveSpinnerSize(value);
         this._applySize();
+    }
+
+    /** The drawn ring diameter — `spinnerGeometry`, capped at 64. */
+    get ringDiameter(): number {
+        return spinnerGeometry(this._size, this._size).diameter;
     }
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-wrap-box.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-wrap-box.ts
@@ -1,51 +1,119 @@
 // AdwWrapBox — a Libadwaita-style flowing wrap box for NativeScript.
 //
-// Renders a REAL NativeScript `WrapLayout`: children flow left-to-right and wrap
-// onto the next line when they run out of horizontal room. Mirrors `Adw.WrapBox`:
-// `orientation`, `child-spacing`, `line-spacing`, `add(child)`.
+// Renders a REAL NativeScript `FlexboxLayout` in wrapping mode: children flow
+// along the main axis and wrap onto the next line when they run out of room.
+// Mirrors `Adw.WrapBox`, including the properties this port could not express
+// while it was built on `WrapLayout` — `justify`, `align`, `justify-last-line`,
+// `line-homogeneous`, `pack-direction`, `wrap-reverse` and `wrap-policy` all map
+// onto `FlexboxLayout`'s own knobs, off the SAME `@gjsify/adwaita-core` decision
+// the browser element uses.
 //
-// FIDELITY: the flow behaviour is a direct native equivalent. The spacing is
-// approximated by uniform child margins, because `WrapLayout` has no gap
-// property, and the property CONTRACT — the 0 default, the negative clamp, the
-// early return on no change — lives in `wrap-box-layout.ts` beside the
-// conformance vectors both renderers are held to.
+// FIDELITY: approximated in three named places, all of them in
+// `wrap-box-layout.ts` — the spacing comes out of child margins (NativeScript
+// has no gap property on any layout), `align` snaps to the three positions
+// flexbox has rather than C's continuum, and the final-line rule reaches only
+// the single-child case, because NS offers no `:only-child` selector and no
+// generated content.
 //
-// NOT ported, because `WrapLayout` exposes only `orientation` / `itemWidth` /
-// `itemHeight` and there is nothing to map them onto: `justify`, `align`,
-// `justify-last-line`, `line-homogeneous`, `pack-direction`, `wrap-policy`,
-// `natural-line-length` and the two length units. Tracked in issue #1048.
+// `natural-line-length` and its unit are carried but NOT applied: NativeScript's
+// `Style` has `minWidth`/`minHeight` and no maximum, so there is nothing to cap
+// a line with. The property still exists so an XML layout and a binding can
+// round-trip it, and `naturalLineLengthPx` is the resolved value the day NS
+// grows a maximum.
 //
-// Visual spec ported from `@gjsify/adwaita-web`'s `adw-wrap-box`.
 // Reference: refs/libadwaita/src/adw-wrap-box.c (AdwWrapBox is a layout, no dedicated scss)
+// Reference: refs/libadwaita/src/adw-wrap-layout.c
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
-import { View, WrapLayout } from '@nativescript/core';
+import { FlexboxLayout, type View } from '@nativescript/core';
+
+import {
+    ADW_WRAP_BOX_DEFAULT_ALIGN,
+    ADW_WRAP_BOX_DEFAULT_JUSTIFY,
+    ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT,
+    ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION,
+    ADW_WRAP_BOX_DEFAULT_WRAP_POLICY,
+    ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET,
+    normalizeNaturalLineLength,
+    normalizeWrapBoxAlign,
+    normalizeWrapBoxJustify,
+    normalizeWrapBoxLengthUnit,
+    normalizeWrapBoxPackDirection,
+    normalizeWrapPolicy,
+    resolveWrapBoxChildOrder,
+    wrapBoxLengthToPx,
+    type AdwLengthUnit,
+    type AdwWrapBoxJustify,
+    type AdwWrapBoxOrientation,
+    type AdwWrapBoxPackDirection,
+    type AdwWrapPolicy,
+} from '@gjsify/adwaita-core';
+
 import {
     DEFAULT_WRAP_BOX_SPACING,
     normalizeWrapBoxSpacing,
+    wrapBoxChildFlex,
     wrapBoxChildMargin,
+    wrapBoxFlexStyle,
     wrapBoxSpacingChanges,
+    type WrapBoxFlexInput,
 } from './wrap-box-layout.js';
 
-export class AdwWrapBox extends WrapLayout {
+/** Every `notify::` an `Adw.WrapBox` emits (adw-wrap-box.c:284-497). */
+export type AdwWrapBoxProperty =
+    | 'child-spacing'
+    | 'child-spacing-unit'
+    | 'pack-direction'
+    | 'align'
+    | 'justify'
+    | 'justify-last-line'
+    | 'line-spacing'
+    | 'line-spacing-unit'
+    | 'line-homogeneous'
+    | 'natural-line-length'
+    | 'natural-line-length-unit'
+    | 'wrap-reverse'
+    | 'wrap-policy'
+    | 'orientation';
+
+export class AdwWrapBox extends FlexboxLayout {
     private _childSpacing = DEFAULT_WRAP_BOX_SPACING;
     private _lineSpacing = DEFAULT_WRAP_BOX_SPACING;
+    private _childSpacingUnit: AdwLengthUnit = ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT;
+    private _lineSpacingUnit: AdwLengthUnit = ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT;
+    private _align = ADW_WRAP_BOX_DEFAULT_ALIGN;
+    private _justify: AdwWrapBoxJustify = ADW_WRAP_BOX_DEFAULT_JUSTIFY;
+    private _justifyLastLine = false;
+    private _lineHomogeneous = false;
+    private _wrapReverse = false;
+    private _wrapPolicy: AdwWrapPolicy = ADW_WRAP_BOX_DEFAULT_WRAP_POLICY;
+    private _packDirection: AdwWrapBoxPackDirection = ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION;
+    private _orientation: AdwWrapBoxOrientation = 'horizontal';
+    private _naturalLineLength = ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET;
+    private _naturalLineLengthUnit: AdwLengthUnit = ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT;
 
     constructor() {
         super();
 
         this.className = 'adw-wrap-box';
-        this.orientation = 'horizontal';
+        this._applyLayout();
     }
 
-    /** Append a child. */
+    // --- child list ---
+
+    /** Append a child — `adw_wrap_box_append` (adw-wrap-box.c:1344-1352). */
     add(view: View): void {
         this.addChild(view);
     }
 
-    /** Remove a previously-added child. */
+    /** Remove a previously-added child — `adw_wrap_box_remove` (:1387-1395). */
     remove(view: View): void {
         this.removeChild(view);
+    }
+
+    /** `adw_wrap_box_remove_all` (:1406-1414). */
+    removeAll(): void {
+        this.removeChildren();
     }
 
     /**
@@ -57,10 +125,51 @@ export class AdwWrapBox extends WrapLayout {
      */
     addChild(view: View): void {
         super.addChild(view);
-        this._applySpacing(view);
+        // Adding the SECOND child changes the FIRST one's answer too — a box with
+        // one child is a box whose only line is the LAST one — so the whole set is
+        // re-applied rather than just the newcomer.
+        this._applyChildren();
     }
 
-    /** Horizontal gap between items in a line, in DIPs. Defaults to 0, as in C. */
+    /**
+     * `adw_wrap_box_insert_child_after` (:1283-1300).
+     *
+     * A NULL/absent `sibling` inserts at the FIRST position, not the last —
+     * `gtk_widget_insert_after`'s documented rule, pinned by
+     * `WRAP_BOX_CHILD_ORDER_VECTORS`. Returns whether the insert happened; a
+     * refusal is where C would have hit a `g_return_if_fail`.
+     */
+    insertChildAfter(view: View, sibling: View | null = null): boolean {
+        return this._applyOrder('insert-after', view, sibling);
+    }
+
+    /** `adw_wrap_box_reorder_child_after` (:1315-1332). Same NULL rule. */
+    reorderChildAfter(view: View, sibling: View | null = null): boolean {
+        return this._applyOrder('reorder-after', view, sibling);
+    }
+
+    private _childViews(): View[] {
+        const views: View[] = [];
+        for (let i = 0; i < this.getChildrenCount(); i++) views.push(this.getChildAt(i));
+        return views;
+    }
+
+    private _applyOrder(op: 'insert-after' | 'reorder-after', view: View, sibling: View | null): boolean {
+        const children = this._childViews();
+        const next = resolveWrapBoxChildOrder({ children, child: view, sibling, op });
+        if (next === null) return false;
+        // `insertChild` does not MOVE an existing child, so a reorder detaches
+        // first. An insert never needs it — the resolver only accepted the child
+        // because it has no parent.
+        if (children.includes(view)) this.removeChild(view);
+        this.insertChild(view, next.indexOf(view));
+        this._applyChildren();
+        return true;
+    }
+
+    // --- properties ---
+
+    /** Gap between items in a line, in {@link childSpacingUnit}. Defaults to 0, as in C. */
     get childSpacing(): number {
         return this._childSpacing;
     }
@@ -68,10 +177,24 @@ export class AdwWrapBox extends WrapLayout {
     set childSpacing(value: number) {
         if (!wrapBoxSpacingChanges(this._childSpacing, value)) return;
         this._childSpacing = normalizeWrapBoxSpacing(value);
-        this._applySpacingToChildren();
+        this._applyChildren();
+        this._notify('child-spacing');
     }
 
-    /** Vertical gap between wrapped lines, in DIPs. Defaults to 0, as in C. */
+    /** The unit {@link childSpacing} is written in. Defaults to `px`, as in C. */
+    get childSpacingUnit(): AdwLengthUnit {
+        return this._childSpacingUnit;
+    }
+
+    set childSpacingUnit(value: AdwLengthUnit) {
+        const next = normalizeWrapBoxLengthUnit(value);
+        if (next === this._childSpacingUnit) return;
+        this._childSpacingUnit = next;
+        this._applyChildren();
+        this._notify('child-spacing-unit');
+    }
+
+    /** Gap between wrapped lines, in {@link lineSpacingUnit}. Defaults to 0, as in C. */
     get lineSpacing(): number {
         return this._lineSpacing;
     }
@@ -79,22 +202,208 @@ export class AdwWrapBox extends WrapLayout {
     set lineSpacing(value: number) {
         if (!wrapBoxSpacingChanges(this._lineSpacing, value)) return;
         this._lineSpacing = normalizeWrapBoxSpacing(value);
-        this._applySpacingToChildren();
+        this._applyChildren();
+        this._notify('line-spacing');
+    }
+
+    /** The unit {@link lineSpacing} is written in. Defaults to `px`, as in C. */
+    get lineSpacingUnit(): AdwLengthUnit {
+        return this._lineSpacingUnit;
+    }
+
+    set lineSpacingUnit(value: AdwLengthUnit) {
+        const next = normalizeWrapBoxLengthUnit(value);
+        if (next === this._lineSpacingUnit) return;
+        this._lineSpacingUnit = next;
+        this._applyChildren();
+        this._notify('line-spacing-unit');
+    }
+
+    /** Where the children sit ALONG the line (main axis): 0 start, 0.5 middle, 1 end. */
+    get align(): number {
+        return this._align;
+    }
+
+    set align(value: number) {
+        const next = normalizeWrapBoxAlign(value);
+        if (next === this._align) return;
+        this._align = next;
+        this._applyLayout();
+        this._notify('align');
+    }
+
+    /** Whether and how each line is stretched to fill the widget. */
+    get justify(): AdwWrapBoxJustify {
+        return this._justify;
+    }
+
+    set justify(value: AdwWrapBoxJustify) {
+        const next = normalizeWrapBoxJustify(value);
+        if (next === this._justify) return;
+        this._justify = next;
+        this._applyLayout();
+        this._notify('justify');
+    }
+
+    /** Whether the FINAL line is justified too. Default false, as in C. */
+    get justifyLastLine(): boolean {
+        return this._justifyLastLine;
+    }
+
+    set justifyLastLine(value: boolean) {
+        const next = !!value;
+        if (next === this._justifyLastLine) return;
+        this._justifyLastLine = next;
+        this._applyLayout();
+        this._notify('justify-last-line');
+    }
+
+    /** Whether every line takes the same amount of space. */
+    get lineHomogeneous(): boolean {
+        return this._lineHomogeneous;
+    }
+
+    set lineHomogeneous(value: boolean) {
+        const next = !!value;
+        if (next === this._lineHomogeneous) return;
+        this._lineHomogeneous = next;
+        this._applyLayout();
+        this._notify('line-homogeneous');
+    }
+
+    /** Whether lines wrap upwards (horizontal) / towards the start (vertical). */
+    get wrapReverse(): boolean {
+        return this._wrapReverse;
+    }
+
+    set wrapReverse(value: boolean) {
+        const next = !!value;
+        if (next === this._wrapReverse) return;
+        this._wrapReverse = next;
+        this._applyLayout();
+        this._notify('wrap-reverse');
+    }
+
+    /** Whether an overflowing line squeezes its children or lets them spill. */
+    get wrapPolicy(): AdwWrapPolicy {
+        return this._wrapPolicy;
+    }
+
+    set wrapPolicy(value: AdwWrapPolicy) {
+        const next = normalizeWrapPolicy(value);
+        if (next === this._wrapPolicy) return;
+        this._wrapPolicy = next;
+        this._applyLayout();
+        this._notify('wrap-policy');
+    }
+
+    /** The direction children are packed in each line. */
+    get packDirection(): AdwWrapBoxPackDirection {
+        return this._packDirection;
+    }
+
+    set packDirection(value: AdwWrapBoxPackDirection) {
+        const next = normalizeWrapBoxPackDirection(value);
+        if (next === this._packDirection) return;
+        this._packDirection = next;
+        this._applyLayout();
+        this._notify('pack-direction');
+    }
+
+    /** The axis children are packed along. */
+    get orientation(): AdwWrapBoxOrientation {
+        return this._orientation;
+    }
+
+    set orientation(value: AdwWrapBoxOrientation) {
+        const next = value === 'vertical' ? 'vertical' : 'horizontal';
+        if (next === this._orientation) return;
+        this._orientation = next;
+        this._applyLayout();
+        this._notify('orientation');
     }
 
     /**
-     * Re-apply the spacing to every child already in the tree.
+     * The natural line length in {@link naturalLineLengthUnit}, or `-1` unset.
      *
-     * The spacing used to be baked in at add time, so `box.childSpacing = 12`
-     * after the children were added did nothing; `adw_wrap_box_set_child_spacing`
-     * hands the new value to the layout manager, which re-runs the allocation for
-     * children that are already there.
+     * CARRIED, NOT APPLIED — see the header: NativeScript's `Style` has no
+     * maximum-size property to cap a line with.
      */
-    private _applySpacingToChildren(): void {
-        for (let i = 0; i < this.getChildrenCount(); i++) this._applySpacing(this.getChildAt(i));
+    get naturalLineLength(): number {
+        return this._naturalLineLength;
     }
 
-    private _applySpacing(view: View): void {
-        view.set('margin', wrapBoxChildMargin(this._childSpacing, this._lineSpacing));
+    set naturalLineLength(value: number) {
+        const next = normalizeNaturalLineLength(value);
+        if (next === this._naturalLineLength) return;
+        this._naturalLineLength = next;
+        this._notify('natural-line-length');
+    }
+
+    /** The unit {@link naturalLineLength} is written in. Defaults to `px`, as in C. */
+    get naturalLineLengthUnit(): AdwLengthUnit {
+        return this._naturalLineLengthUnit;
+    }
+
+    set naturalLineLengthUnit(value: AdwLengthUnit) {
+        const next = normalizeWrapBoxLengthUnit(value);
+        if (next === this._naturalLineLengthUnit) return;
+        this._naturalLineLengthUnit = next;
+        this._notify('natural-line-length-unit');
+    }
+
+    /** {@link naturalLineLength} resolved through its unit, `-1` when unset. */
+    get naturalLineLengthPx(): number {
+        return wrapBoxLengthToPx(this._naturalLineLength, this._naturalLineLengthUnit);
+    }
+
+    // --- application ---
+
+    /** Re-emit `notify::<property>`, as GObject does on a real change. */
+    private _notify(property: AdwWrapBoxProperty): void {
+        this.notify({ eventName: `notify::${property}`, object: this });
+    }
+
+    /** The widget's properties, as the pure resolvers take them. */
+    private _flexInput(): WrapBoxFlexInput {
+        return {
+            orientation: this._orientation,
+            packDirection: this._packDirection,
+            wrapReverse: this._wrapReverse,
+            justify: this._justify,
+            justifyLastLine: this._justifyLastLine,
+            align: this._align,
+            lineHomogeneous: this._lineHomogeneous,
+            wrapPolicy: this._wrapPolicy,
+        };
+    }
+
+    private _applyLayout(): void {
+        const style = wrapBoxFlexStyle(this._flexInput());
+        this.flexDirection = style.flexDirection;
+        this.flexWrap = style.flexWrap;
+        this.justifyContent = style.justifyContent;
+        this.alignContent = style.alignContent;
+        // Each child is allocated the FULL cross extent of its line —
+        // `h = line_size` in adw-wrap-layout.c:746-751.
+        this.alignItems = 'stretch';
+        this._applyChildren();
+    }
+
+    private _applyChildren(): void {
+        const margin = wrapBoxChildMargin(
+            wrapBoxLengthToPx(this._childSpacing, this._childSpacingUnit),
+            wrapBoxLengthToPx(this._lineSpacing, this._lineSpacingUnit),
+        );
+        const children = this._childViews();
+        // The per-CHILD half of the decision, which one container `justifyContent`
+        // cannot carry: a box with a single child has one line, that line is the
+        // LAST one, and `spread` stretches its lone child instead of spreading.
+        const flex = wrapBoxChildFlex(this._flexInput(), children.length);
+        for (const view of children) {
+            view.set('margin', margin);
+            FlexboxLayout.setFlexGrow(view, flex.flexGrow);
+            FlexboxLayout.setFlexShrink(view, flex.flexShrink);
+        }
     }
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/chrome.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/chrome.ts
@@ -152,11 +152,13 @@ export function clampAllocationFor(availableWidth: number, props: ClampProps): C
 export const DEFAULT_SPINNER_SIZE = ADW_SPINNER_MIN_SIZE;
 
 /**
- * The diameter an `ActivityIndicator` is sized to for a requested `size`.
+ * The RING diameter for a requested BOX size — floored at the measured minimum
+ * 16 and capped at Adwaita's 64, with the odd-size flooring (`31` draws a 30 DIP
+ * ring) coming from the paintable rather than from here.
  *
- * The platform indicator fills its view, so the view IS the ring: floored at the
- * measured minimum 16 and capped at Adwaita's 64, with the odd-size flooring
- * (`31` draws a 30 DIP ring) coming from the paintable rather than from here.
+ * The two are different numbers, which is the whole point: `AdwSpinner` sizes
+ * its BOX to the request and its `ActivityIndicator` to this. They used to be
+ * one, so `size = 200` occupied 64 DIPs of layout where GTK occupies 200.
  */
 export function spinnerDiameter(value: number | string | null | undefined): number {
     const size = resolveSpinnerSize(value);

--- a/packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/split-view-base.ts
@@ -37,7 +37,9 @@ import {
     type SidebarWidthProps,
     type SplitViewWidthRule,
 } from './split-view-width.js';
+import { splitViewColumns } from './split-view-state.js';
 import type { AdwPackType, NsShowSidebarNotification, NsSplitViewState } from './split-view-state.js';
+import type { AdwTextDirection } from '@gjsify/adwaita-core';
 
 /** Event name emitted when the sidebar visibility changes. */
 export const NOTIFY_SHOW_SIDEBAR = 'notify::show-sidebar';
@@ -100,13 +102,48 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
      */
     protected _syncColumns(): void {
         this.removeColumns();
-        if (this._state.sidebarPosition === 'end') {
-            this.addColumn(new ItemSpec(1, 'star')); // col 0: content
-            this.addColumn(new ItemSpec(1, 'auto')); // col 1: sidebar
-        } else {
+        // The leading column is column 0, so the question is which side the
+        // sidebar is DRAWN on, not which side it is packed on — under RTL a
+        // `start` sidebar is drawn on the right (`get_start_or_end`,
+        // adw-overlay-split-view.c:227-234). `splitViewColumns` is that
+        // predicate; this method used to test `sidebarPosition` literally and
+        // laid every RTL device out as if it were LTR.
+        const columns = splitViewColumns(this._state.sidebarPosition, this.textDirection);
+        if (columns.sidebar === 0) {
             this.addColumn(new ItemSpec(1, 'auto')); // col 0: sidebar
             this.addColumn(new ItemSpec(1, 'star')); // col 1: content
+        } else {
+            this.addColumn(new ItemSpec(1, 'star')); // col 0: content
+            this.addColumn(new ItemSpec(1, 'auto')); // col 1: sidebar
         }
+    }
+
+    /**
+     * Publish which visual side the pane is on, so the theme can put the divider
+     * there — the CSS counterpart to `_sidebars.scss`'s `:dir()` x `.end`
+     * product. A fixed `border-right` drew it on the wrong edge for an `end`
+     * sidebar and for every RTL layout.
+     */
+    protected _syncSidebarSide(view: View | null = this._sidebar): void {
+        if (!view) return;
+        const atStart = splitViewColumns(this._state.sidebarPosition, this.textDirection).sidebar === 0;
+        const classes = (view.className ?? '')
+            .split(' ')
+            .filter((name) => name && name !== 'adw-sidebar-at-visual-start' && name !== 'adw-sidebar-at-visual-end');
+        classes.push(atStart ? 'adw-sidebar-at-visual-start' : 'adw-sidebar-at-visual-end');
+        view.className = classes.join(' ');
+    }
+
+    /**
+     * The reading direction `start` / `end` resolve against.
+     *
+     * `direction` is an INHERITED CSS property on NativeScript's `Style`, so a
+     * `direction: rtl` on the Page reaches every split view under it — the same
+     * way GTK's text direction reaches a widget from its window. It defaults to
+     * unset, which is `ltr`.
+     */
+    get textDirection(): AdwTextDirection {
+        return this.style?.direction === 'rtl' ? 'rtl' : 'ltr';
     }
 
     /** Re-emit `notify::show-sidebar` for a state change. */
@@ -177,6 +214,7 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
         this._sidebar = view;
         if (view) {
             view.className = `${view.className ?? ''} adw-split-view-sidebar`.trim();
+            this._syncSidebarSide(view);
             view.width = this.sidebarWidth;
             this.addChild(view);
         }
@@ -314,6 +352,7 @@ export abstract class AdwSplitViewBase<TState extends NsSplitViewState = NsSplit
         // The fixed/expanding column order depends on the side, so re-declare them
         // BEFORE the panes are written into their columns.
         this._syncColumns();
+        this._syncSidebarSide();
         this._applyLayout();
     }
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/split-view-state.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/split-view-state.ts
@@ -48,6 +48,7 @@ import { NavigationSplitViewState, OverlaySplitViewState, isSidebarAtVisualStart
 import type {
     AdwPackType,
     AdwTextDirection,
+    NavigationActionResult,
     NavigationPageRef,
     NavigationSplitViewChange,
     NavigationStackPlan,
@@ -275,11 +276,13 @@ export class NsOverlaySplitViewState implements NsSplitViewState {
  * `sidebar-position` × `show-content` × which children exist, and whether
  * reaching it is a push or a pop.
  *
- * Tags and the `navigation.push`/`navigation.pop` actions are NOT wired on
- * NativeScript, so the panes are tracked by presence with a marker object rather
- * than by handing the core a `View` — a `View` is not a `NavigationPageRef` and
- * pretending otherwise would silently give a pane whatever `tag` property
- * NativeScript happens to put on a view.
+ * Tags and the `navigation.push`/`navigation.pop` actions ARE wired, through an
+ * explicit {@link setTag} rather than by handing the core a `View`: a `View` is
+ * not a `NavigationPageRef`, and reading a `tag` property off one would silently
+ * adopt whatever NativeScript happens to put there. The panes stay tracked by
+ * presence with a marker object, and the tag of record lives in the core — which
+ * is where it lives in the browser port too, because `setTag` CLEARS a colliding
+ * tag and mutating a caller's view to do that would be a surprise.
  */
 export class NsNavigationSplitViewState implements NsSplitViewState {
     private readonly _state: NavigationSplitViewState;
@@ -288,7 +291,17 @@ export class NsNavigationSplitViewState implements NsSplitViewState {
     private _host: NsSplitViewHost | null = null;
     private _plan: NavigationStackPlan;
 
-    constructor(options: { sidebarPosition?: AdwPackType; collapsed?: boolean; showContent?: boolean } = {}) {
+    constructor(
+        options: {
+            sidebarPosition?: AdwPackType;
+            collapsed?: boolean;
+            showContent?: boolean;
+            /** Where a `g_critical` goes on this port. */
+            onCritical?: (message: string) => void;
+            /** Offer an unmatched `navigation.*` to the parent — how nesting forwards a push. */
+            onDelegate?: (action: 'push' | 'pop', tag?: string) => boolean;
+        } = {},
+    ) {
         this._state = new NavigationSplitViewState(options);
         this._plan = this._state.stack;
         this._state.subscribe((change) => this._apply(change));
@@ -296,6 +309,53 @@ export class NsNavigationSplitViewState implements NsSplitViewState {
 
     bind(host: NsSplitViewHost): void {
         this._host = host;
+    }
+
+    /**
+     * Retag a mounted pane — `check_tags_cb` (adw-navigation-split-view.c:431-460).
+     *
+     * On a collision the pane KEEPS its page and loses the tag, which is a
+     * different failure from mounting a colliding page (that one is refused
+     * outright). Returns whether the tag stuck.
+     */
+    setTag(pane: SplitViewPane, tag: string | null): boolean {
+        return this._state.setTag(pane, tag);
+    }
+
+    /** The sidebar page's tag of record, or `null`. */
+    get sidebarTag(): string | null {
+        return this._state.sidebarTag;
+    }
+
+    /** The content page's tag of record, or `null`. */
+    get contentTag(): string | null {
+        return this._state.contentTag;
+    }
+
+    /** `navigation.push` with `tag` — `navigation_push_cb` (:644-685). */
+    push(tag: string): NavigationActionResult {
+        return this._state.push(tag);
+    }
+
+    /** `navigation.pop` — `navigation_pop_cb` (:687-702). */
+    pop(): NavigationActionResult {
+        return this._state.pop();
+    }
+
+    /**
+     * `Adw.NavigationSplitView:show-content` under ITS OWN NAME.
+     *
+     * This port spells the visible pane `showSidebar`, which is the negation —
+     * and that costs every consumer a `!(…)`, including the storybook, which
+     * carries one purely to bind a shared story arg. Both spellings are here now
+     * and neither is derived from a second copy of the flag.
+     */
+    get showContent(): boolean {
+        return !this.showSidebar;
+    }
+
+    set showContent(value: boolean) {
+        this.setShowSidebar(!value);
     }
 
     // --- Read-only derivations ---

--- a/packages/nativescript-bridge/adwaita/src/widgets/split-view-state.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/split-view-state.ts
@@ -31,18 +31,23 @@
 // that the mock agreed with itself, and every rule above went untested for the
 // widgets' whole life.
 //
-// TEXT DIRECTION is pinned to `'ltr'` throughout. `isSidebarAtVisualStart` mirrors
-// `start`/`end` under RTL, but NativeScript surfaces no text direction to read
-// here, so an RTL device lays a split view out as LTR. A known divergence, not a
-// decision — the core is ready for it the moment NS reports a direction.
+// TEXT DIRECTION is real here now. It used to be pinned to `'ltr'` with a note
+// saying "NativeScript surfaces no text direction to read" — which is false:
+// `@nativescript/core` ships `directionProperty`, an INHERITED CSS property on
+// `Style` (`ui/styling/style-properties`), valued `'ltr' | 'rtl'` and defaulting
+// to unset. So `view.style.direction ?? 'ltr'` is the direction, it inherits
+// from the Page the way GTK's inherits from the window, and
+// `isSidebarAtVisualStart` can finally do its job: under RTL a `start` sidebar
+// is drawn on the RIGHT (`get_start_or_end`, adw-overlay-split-view.c:227-234).
 //
 // Reference: refs/libadwaita/src/adw-overlay-split-view.c
 // Reference: refs/libadwaita/src/adw-navigation-split-view.c
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
-import { NavigationSplitViewState, OverlaySplitViewState } from '@gjsify/adwaita-core';
+import { NavigationSplitViewState, OverlaySplitViewState, isSidebarAtVisualStart } from '@gjsify/adwaita-core';
 import type {
     AdwPackType,
+    AdwTextDirection,
     NavigationPageRef,
     NavigationSplitViewChange,
     NavigationStackPlan,
@@ -110,8 +115,14 @@ export interface NsSplitViewState {
  * already made column 0 the star column. libadwaita allocates an `end` sidebar at
  * `width - sidebar_width` (adw-navigation-split-view.c:306-316).
  */
-export function splitViewColumns(sidebarPosition: AdwPackType): { sidebar: number; content: number } {
-    return sidebarPosition === 'end' ? { sidebar: 1, content: 0 } : { sidebar: 0, content: 1 };
+export function splitViewColumns(
+    sidebarPosition: AdwPackType,
+    direction: AdwTextDirection = 'ltr',
+): { sidebar: number; content: number } {
+    // The grid's LEADING column is column 0, so the question is not which side
+    // the sidebar is packed on but which side it is DRAWN on — the one predicate
+    // `isSidebarAtVisualStart` answers, and the one an RTL layout inverts.
+    return isSidebarAtVisualStart(sidebarPosition, direction) ? { sidebar: 0, content: 1 } : { sidebar: 1, content: 0 };
 }
 
 /**

--- a/packages/nativescript-bridge/adwaita/src/widgets/view-switcher-base.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/view-switcher-base.ts
@@ -92,7 +92,9 @@ interface ButtonNodes {
  */
 export abstract class AdwViewSwitcherBase extends GridLayout {
     /** The horizontal switcher bar holding the buttons. */
-    protected readonly _bar: StackLayout;
+    protected readonly _bar: GridLayout;
+    /** `Adw.ViewSwitcher:policy`, default NARROW (adw-view-switcher.c:447-451). */
+    private _policy: AdwViewSwitcherPolicy = 'narrow';
     /** The content area where the selected page is shown. */
     protected readonly _contentArea: GridLayout;
     /** The registered pages, in bar order. */
@@ -107,14 +109,35 @@ export abstract class AdwViewSwitcherBase extends GridLayout {
     protected abstract get buttonClass(): string;
     /**
      * `AdwViewSwitcher:policy`, which decides the button orientation
-     * (adw-view-switcher.c:534-537). `'wide'` — icon beside label — because that
-     * is the layout all three NS switchers have always used; the icon-over-label
-     * narrow form lives in the separate `AdwViewSwitcherBar`. There is no policy
-     * PROPERTY on NS yet, so this is a constant a subclass can override rather
-     * than settable state.
+     * (adw-view-switcher.c:534-537).
+     *
+     * It used to be a HARD-CODED `'wide'` with a note saying there was no policy
+     * property on NS — so a consumer could not follow a breakpoint, and the
+     * default was the opposite of C's, which is `ADW_VIEW_SWITCHER_POLICY_NARROW`
+     * (adw-view-switcher.c:447-451). It is a real property now, defaulting to
+     * `narrow`; a subclass may still pin it.
      */
     protected get policy(): AdwViewSwitcherPolicy {
-        return 'wide';
+        return this._policy;
+    }
+
+    /**
+     * `Adw.ViewSwitcher:policy` — settable, defaulting to NARROW as in C
+     * (adw-view-switcher.c:447-451).
+     *
+     * A hard-coded `'wide'` meant an NS consumer could not follow a breakpoint
+     * at all, and the value it was pinned to was not even the default.
+     */
+    get switcherPolicy(): AdwViewSwitcherPolicy {
+        return this._policy;
+    }
+
+    set switcherPolicy(value: AdwViewSwitcherPolicy) {
+        const next = value === 'wide' ? 'wide' : 'narrow';
+        if (next === this._policy) return;
+        this._policy = next;
+        this._applySelection();
+        this.notify({ eventName: 'notify::policy', object: this });
     }
 
     /**
@@ -135,9 +158,15 @@ export abstract class AdwViewSwitcherBase extends GridLayout {
         this.addRow(new ItemSpec(1, 'auto')); // bar
         this.addRow(new ItemSpec(1, 'star')); // content
 
-        const bar = new StackLayout();
-        bar.orientation = 'horizontal';
-        bar.horizontalAlignment = 'center';
+        // HOMOGENEOUS, which a centred StackLayout is not:
+        // `gtk_box_layout_set_homogeneous (…, TRUE)` (adw-view-switcher.c:475)
+        // gives every button the same width, so a long label cannot dominate the
+        // row. The grid takes one `star` column per button in `_rebuildButtons`;
+        // the NS *bar* widget already did this and the switcher did not, so the
+        // two disagreed about the same widget family.
+        const bar = new GridLayout();
+        bar.horizontalAlignment = 'stretch';
+        bar.addRow(new ItemSpec(1, 'auto'));
         GridLayout.setRow(bar, 0);
         this.addChild(bar);
         this._bar = bar;
@@ -176,6 +205,10 @@ export abstract class AdwViewSwitcherBase extends GridLayout {
     setViews(pages: AdwViewPage[]): void {
         for (const nodes of this._nodes) this._bar.removeChild(nodes.button);
         this._nodes = [];
+        // The columns go with the buttons: a child whose column index exceeds the
+        // declared columns is clamped into the last one, so a shrinking switcher
+        // would stack its buttons on top of each other.
+        this._bar.removeColumns();
         for (const page of this._pages) this._contentArea.removeChild(page.content);
         this._pages.length = 0;
         this._pages.push(...pages);
@@ -224,6 +257,12 @@ export abstract class AdwViewSwitcherBase extends GridLayout {
         button.addEventListener('tap', () => {
             this._state.setSelected(index);
         });
+        // One `star` column per button IS the homogeneity: every column gets an
+        // equal share, so a long label cannot take the row
+        // (`gtk_box_layout_set_homogeneous (…, TRUE)`, adw-view-switcher.c:475).
+        this._bar.addColumn(new ItemSpec(1, 'star'));
+        GridLayout.setColumn(button, index);
+        GridLayout.setRow(button, 0);
         this._bar.addChild(button);
         return { button, icon, label, badge };
     }
@@ -267,6 +306,10 @@ export abstract class AdwViewSwitcherBase extends GridLayout {
             } else {
                 nodes.badge.className = `${this.buttonClass}-badge`;
             }
+            // `update_description` (adw-indicator-bin.c:70-113) is what a screen
+            // reader announces for a badged page. The core computes it and this
+            // port DROPPED it on the floor, so a badge was a silent dot.
+            nodes.button.accessibilityLabel = model.description || model.label;
         });
     }
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/wrap-box-layout.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/wrap-box-layout.ts
@@ -1,23 +1,44 @@
-// Wrap-box spacing for NativeScript — the pure half.
+// Wrap-box layout for NativeScript — the pure half.
 //
-// `Adw.WrapBox` has no NativeScript counterpart for most of what it does: NS
-// `WrapLayout` exposes exactly three knobs — `orientation`, `itemWidth`,
-// `itemHeight` — so `justify`, `align` and `justify-last-line` have nowhere to
-// land, and the line-breaking engine runs in native code that cannot be fed a
-// decision. What DOES port is the spacing property contract, and the NS widget
-// got all of it wrong: it defaulted to 6 DIPs where libadwaita defaults to 0
-// (adw-wrap-box.c:285-287, :393-395), and it baked the spacing into each child's
-// margin at add time, so changing the property afterwards did nothing at all
-// while C forces a re-layout.
+// `Adw.WrapBox` used to have almost no NativeScript counterpart: the port was
+// built on NS `WrapLayout`, which exposes exactly three knobs (`orientation`,
+// `itemWidth`, `itemHeight`), so `justify`, `align` and `justify-last-line` had
+// nowhere to land and this module held the spacing contract alone.
 //
-// Free of `@nativescript/core` imports — like `icon-path.ts`, `row-press.ts`,
-// `chrome.ts` and `split-view-width.ts` — so the spec suite exercises the
-// shipping code rather than a transcription of it. The widget class cannot serve
-// that role: it `extends WrapLayout`, which evaluates the bare
-// `@nativescript/core` specifier at module-eval and is unresolvable off-device.
+// That was the wrong container. NativeScript also ships `FlexboxLayout`, with
+// `flexDirection`, `flexWrap`, `justifyContent`, `alignItems`, `alignContent`
+// and per-child `setFlexGrow` / `setFlexShrink` — the same primitives the
+// browser element maps onto. So the widget switched, and everything the browser
+// port can express this port can express too, off ONE decision in
+// `@gjsify/adwaita-core` rather than a second reading of the C.
+//
+// What stays NativeScript-specific is the spacing, because `FlexboxLayout` has
+// no gap property either (NS `Style` carries no `columnGap`/`rowGap`): the gaps
+// come out of the children's margins.
+//
+// Free of `@nativescript/core` VALUE imports — like `icon-path.ts`,
+// `row-press.ts`, `chrome.ts` and `split-view-width.ts` — so the spec suite
+// exercises the shipping code rather than a transcription of it. The widget
+// class cannot serve that role: it `extends FlexboxLayout`, which evaluates the
+// bare `@nativescript/core` specifier at module-eval and is unresolvable
+// off-device.
 //
 // Reference: refs/libadwaita/src/adw-wrap-box.c
+// Reference: refs/libadwaita/src/adw-wrap-layout.c
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import {
+    ADW_WRAP_BOX_DEFAULT_SPACING,
+    normalizeWrapBoxSpacing,
+    resolveWrapBoxLine,
+    wrapPolicyFlexShrink,
+    type AdwWrapBoxJustify,
+    type AdwWrapBoxOrientation,
+    type AdwWrapBoxPackDirection,
+    type AdwWrapPolicy,
+} from '@gjsify/adwaita-core';
+
+export { normalizeWrapBoxSpacing };
 
 /**
  * `Adw.WrapBox:child-spacing` / `:line-spacing` default, in DIPs.
@@ -27,22 +48,7 @@
  * looser on a phone than in the browser and an EMPTY wrap box was already 12
  * DIPs tall.
  */
-export const DEFAULT_WRAP_BOX_SPACING = 0;
-
-/**
- * Normalise one spacing property, the way `adw_wrap_box_set_child_spacing` does.
- *
- * C clamps a negative value to 0 before anything else happens
- * (adw-wrap-box.c:587-588, :927-928); the property's declared minimum is 0, so
- * without the clamp GObject would reject it outright. The non-numeric cases have
- * no C counterpart — the property is an `int` — and resolve to the default, so a
- * `NaN` can never reach a native layout pass.
- */
-export function normalizeWrapBoxSpacing(value: unknown): number {
-    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
-    if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_WRAP_BOX_SPACING;
-    return parsed;
-}
+export const DEFAULT_WRAP_BOX_SPACING = ADW_WRAP_BOX_DEFAULT_SPACING;
 
 /**
  * Whether writing `next` over `current` is a change the widget must act on.
@@ -57,12 +63,12 @@ export function wrapBoxSpacingChanges(current: number, next: unknown): boolean {
 }
 
 /**
- * The uniform margin that gives an NS `WrapLayout` child its share of the gaps.
+ * The uniform margin that gives a `FlexboxLayout` child its share of the gaps.
  *
- * `WrapLayout` has no gap property, so the inter-item spacing has to come out of
- * the children: half of it on each facing edge adds up to the whole gap between
- * any two neighbours. The margin string is NS's `top right bottom left`
- * shorthand.
+ * NativeScript has no gap property on any layout — `Style` carries no
+ * `columnGap`/`rowGap` — so the inter-item spacing has to come out of the
+ * children: half of it on each facing edge adds up to the whole gap between any
+ * two neighbours. The margin string is NS's `top right bottom left` shorthand.
  *
  * This is the one place the port is knowingly looser than libadwaita: the halves
  * on the OUTER edges are an inset `Adw.WrapBox` does not have. It is invisible
@@ -74,4 +80,112 @@ export function wrapBoxChildMargin(childSpacing: number, lineSpacing: number): s
     const alongLine = normalizeWrapBoxSpacing(childSpacing) / 2;
     const betweenLines = normalizeWrapBoxSpacing(lineSpacing) / 2;
     return `${betweenLines} ${alongLine} ${betweenLines} ${alongLine}`;
+}
+
+/** The `FlexboxLayout` knobs a wrap box's properties resolve to. */
+export interface WrapBoxFlexStyle {
+    /** `FlexboxLayout:flexDirection` — the main axis, reversed for `end-to-start`. */
+    flexDirection: 'row' | 'row-reverse' | 'column' | 'column-reverse';
+    /** `FlexboxLayout:flexWrap` — always wrapping; reversed by `wrap-reverse`. */
+    flexWrap: 'wrap' | 'wrap-reverse';
+    /** `FlexboxLayout:justifyContent` — where a COMPLETE line's leftover goes. */
+    justifyContent: 'flex-start' | 'center' | 'flex-end' | 'space-between';
+    /** `FlexboxLayout:alignContent` — `line-homogeneous` stretches the lines. */
+    alignContent: 'stretch' | 'flex-start';
+    /** `FlexboxLayout.setFlexGrow` for a child on a complete line. */
+    childFlexGrow: number;
+    /** `FlexboxLayout.setFlexShrink` for every child — `wrap-policy`. */
+    childFlexShrink: number;
+}
+
+/** The widget properties the two resolvers read. */
+export interface WrapBoxFlexInput {
+    orientation: AdwWrapBoxOrientation;
+    packDirection: AdwWrapBoxPackDirection;
+    wrapReverse: boolean;
+    justify: AdwWrapBoxJustify;
+    justifyLastLine: boolean;
+    align: number;
+    lineHomogeneous: boolean;
+    wrapPolicy: AdwWrapPolicy;
+}
+
+/**
+ * `align` as a `justifyContent` keyword.
+ *
+ * C offsets the whole line block by `roundf (length_delta * align)` — a
+ * continuum. Flexbox has three main-axis positions, so the nearest one is taken;
+ * that is the renderer's approximation, not libadwaita's rule, and it is the
+ * same one the browser element makes.
+ */
+function alignToJustifyContent(align: number): 'flex-start' | 'center' | 'flex-end' {
+    if (align < 0.25) return 'flex-start';
+    if (align < 0.75) return 'center';
+    return 'flex-end';
+}
+
+/**
+ * The CONTAINER half of the decision, resolved onto `FlexboxLayout`.
+ *
+ * The line DECISION is `resolveWrapBoxLine` in `@gjsify/adwaita-core`, held to
+ * `WRAP_BOX_LINE_VECTORS` — this function only maps its answer onto the knobs NS
+ * has, exactly as the browser element maps it onto CSS.
+ *
+ * Like a flex container, `FlexboxLayout` has ONE `justifyContent` for every
+ * line, so it can only carry the COMPLETE-line rule. NativeScript offers no
+ * `:only-child` selector and no generated content, so the final-line rule has no
+ * container-level expression at all; what it CAN reach is the single-child case,
+ * through {@link wrapBoxChildFlex}.
+ */
+export function wrapBoxFlexStyle(input: WrapBoxFlexInput): WrapBoxFlexStyle {
+    const axis = input.orientation === 'vertical' ? 'column' : 'row';
+    const line = resolveWrapBoxLine({
+        justify: input.justify,
+        justifyLastLine: input.justifyLastLine,
+        align: input.align,
+        lastLine: false,
+        childrenInLine: 2,
+    });
+    return {
+        flexDirection: input.packDirection === 'end-to-start' ? (`${axis}-reverse` as const) : axis,
+        flexWrap: input.wrapReverse ? 'wrap-reverse' : 'wrap',
+        justifyContent: line.growGaps ? 'space-between' : alignToJustifyContent(line.align),
+        alignContent: input.lineHomogeneous ? 'stretch' : 'flex-start',
+        childFlexGrow: line.growChildren ? 1 : 0,
+        childFlexShrink: wrapPolicyFlexShrink(input.wrapPolicy),
+    };
+}
+
+/** What one child of the box gets set on it. */
+export interface WrapBoxChildFlex {
+    /** `FlexboxLayout.setFlexGrow` — whether this child absorbs the line's leftover. */
+    flexGrow: number;
+    /** `FlexboxLayout.setFlexShrink` — `wrap-policy`, the same for every child. */
+    flexShrink: number;
+}
+
+/**
+ * The PER-CHILD half of the decision, which the container knobs cannot carry.
+ *
+ * Two of libadwaita's rules are facts about a child rather than about the box,
+ * and a single `justifyContent` has nowhere to put either. A box with exactly
+ * ONE child has one line, that line is the LAST one, and its child is alone on
+ * it — so it is governed by `justify-last-line`, and `spread` STRETCHES it
+ * rather than spreading anything (`n_children > 1` guards the keep-at-minimum
+ * branch, adw-wrap-layout.c:338; adw-wrap-box.c:349-352 says so outright).
+ *
+ * `childCount` is the box's own child count, which is the most a renderer knows
+ * without a layout pass: 1 means the lone-child-on-the-final-line case exactly,
+ * anything more means at least one complete line.
+ */
+export function wrapBoxChildFlex(input: WrapBoxFlexInput, childCount: number): WrapBoxChildFlex {
+    const alone = childCount === 1;
+    const line = resolveWrapBoxLine({
+        justify: input.justify,
+        justifyLastLine: input.justifyLastLine,
+        align: input.align,
+        lastLine: alone,
+        childrenInLine: alone ? 1 : 2,
+    });
+    return { flexGrow: line.growChildren ? 1 : 0, flexShrink: wrapPolicyFlexShrink(input.wrapPolicy) };
 }

--- a/packages/nativescript-bridge/adwaita/src/wrap-box.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/wrap-box.spec.ts
@@ -1,9 +1,9 @@
-// Wrap-box spacing for NativeScript, against the shared conformance vectors.
+// Wrap-box layout for NativeScript, against the shared conformance vectors.
 //
-// The widget class cannot be imported here (`extends WrapLayout` evaluates the
-// bare `@nativescript/core` specifier at module-eval, which is unresolvable off
-// NativeScript), so this suite drives `widgets/wrap-box-layout.ts` — the SHIPPING
-// pure half the widget itself calls, never a transcription of it.
+// The widget class cannot be imported here (`extends FlexboxLayout` evaluates
+// the bare `@nativescript/core` specifier at module-eval, which is unresolvable
+// off NativeScript), so this suite drives `widgets/wrap-box-layout.ts` — the
+// SHIPPING pure half the widget itself calls, never a transcription of it.
 //
 // What it holds the port to: the property contract libadwaita declares and the
 // port invented its own answers to. Both spacings defaulted to 6 DIPs against a
@@ -14,16 +14,28 @@
 // the clamp is what makes the "did anything change" comparison meaningful: on
 // this port that comparison decides whether every child's margin is rewritten.
 //
-// The justify / align / justify-last-line table in the same conformance file is
-// NOT driven from here, and deliberately: NS `WrapLayout` exposes `orientation`,
-// `itemWidth` and `itemHeight` and nothing else, so there is no knob for the
-// decision to land on and a resolver on this side would have no consumer. The
-// browser suite drives those rows.
+// The justify / align / justify-last-line table IS driven from here now. It was
+// not, on the grounds that "NS `WrapLayout` exposes `orientation`, `itemWidth`
+// and `itemHeight` and nothing else, so there is no knob for the decision to
+// land on". NativeScript also ships `FlexboxLayout`; the widget switched to it,
+// and the decision it lands is the browser element's, from `@gjsify/adwaita-core`.
 
 import { describe, expect, it } from '@gjsify/unit';
 
 import {
     ADW_WRAP_BOX_DEFAULT_SPACING,
+    normalizeNaturalLineLength,
+    normalizeWrapBoxLengthUnit,
+    normalizeWrapPolicy,
+    resolveWrapBoxChildOrder,
+    wrapBoxLengthToPx,
+} from '@gjsify/adwaita-core';
+import {
+    WRAP_BOX_CHILD_ORDER_VECTORS,
+    WRAP_BOX_LENGTH_VECTORS,
+    WRAP_BOX_LINE_VECTORS,
+    WRAP_BOX_NATURAL_LENGTH_VECTORS,
+    WRAP_BOX_POLICY_VECTORS,
     WRAP_BOX_SPACING_NOTIFY_VECTORS,
     WRAP_BOX_SPACING_VECTORS,
 } from '@gjsify/adwaita-core/conformance';
@@ -31,13 +43,31 @@ import {
 import {
     DEFAULT_WRAP_BOX_SPACING,
     normalizeWrapBoxSpacing,
+    wrapBoxChildFlex,
     wrapBoxChildMargin,
+    wrapBoxFlexStyle,
     wrapBoxSpacingChanges,
+    type WrapBoxFlexInput,
 } from './widgets/wrap-box-layout.js';
 
 /** A vector value as it reads in a test name (`JSON.stringify` flattens NaN to null). */
-function label(value: number | string | null): string {
+function label(value: unknown): string {
     return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
+/** The property defaults a fresh `AdwWrapBox` holds, so a row states only what it varies. */
+function props(overrides: Partial<WrapBoxFlexInput> = {}): WrapBoxFlexInput {
+    return {
+        orientation: 'horizontal',
+        packDirection: 'start-to-end',
+        wrapReverse: false,
+        justify: 'none',
+        justifyLastLine: false,
+        align: 0,
+        lineHomogeneous: false,
+        wrapPolicy: 'natural',
+        ...overrides,
+    };
 }
 
 export default async () => {
@@ -68,7 +98,7 @@ export default async () => {
         }
     });
 
-    await describe('wrapBoxChildMargin (WrapLayout has no gap property)', async () => {
+    await describe('wrapBoxChildMargin (NativeScript has no gap property)', async () => {
         await it('splits each gap across the two facing edges, so neighbours add up to it', () => {
             // NS shorthand is `top right bottom left`: the line spacing goes on
             // the block edges, the child spacing on the inline ones.
@@ -83,5 +113,140 @@ export default async () => {
         await it('halves an odd spacing rather than rounding it away', () => {
             expect(wrapBoxChildMargin(5, 0)).toBe('0 2.5 0 2.5');
         });
+    });
+
+    await describe('wrapBoxFlexStyle: the CONTAINER half of the line decision', async () => {
+        // `FlexboxLayout`, like a flex container, has ONE `justifyContent` for
+        // every line, so only the complete-line rows land here.
+        for (const vector of WRAP_BOX_LINE_VECTORS.filter((v) => !v.lastLine && v.childrenInLine > 1)) {
+            const { justify, justifyLastLine, align, layout, rule } = vector;
+            await it(`${justify} align=${align} → ${layout.growGaps ? 'space-between' : 'align'} — ${rule}`, () => {
+                const style = wrapBoxFlexStyle(props({ justify, justifyLastLine, align }));
+                expect(style.justifyContent === 'space-between').toBe(layout.growGaps);
+                expect(style.childFlexGrow).toBe(layout.growChildren ? 1 : 0);
+            });
+        }
+
+        await it('align lands on the MAIN axis — justifyContent, never alignItems', () => {
+            expect(wrapBoxFlexStyle(props({ align: 0 })).justifyContent).toBe('flex-start');
+            expect(wrapBoxFlexStyle(props({ align: 0.5 })).justifyContent).toBe('center');
+            expect(wrapBoxFlexStyle(props({ align: 1 })).justifyContent).toBe('flex-end');
+        });
+
+        await it('fill grows the children where spread grows the gaps', () => {
+            expect(wrapBoxFlexStyle(props({ justify: 'fill' }))).toMatchObject({
+                justifyContent: 'flex-start',
+                childFlexGrow: 1,
+            });
+            expect(wrapBoxFlexStyle(props({ justify: 'spread' }))).toMatchObject({
+                justifyContent: 'space-between',
+                childFlexGrow: 0,
+            });
+        });
+
+        await it('orientation and pack-direction pick the flexDirection between them', () => {
+            expect(wrapBoxFlexStyle(props()).flexDirection).toBe('row');
+            expect(wrapBoxFlexStyle(props({ packDirection: 'end-to-start' })).flexDirection).toBe('row-reverse');
+            expect(wrapBoxFlexStyle(props({ orientation: 'vertical' })).flexDirection).toBe('column');
+            expect(
+                wrapBoxFlexStyle(props({ orientation: 'vertical', packDirection: 'end-to-start' })).flexDirection,
+            ).toBe('column-reverse');
+        });
+
+        await it('wrap-reverse and line-homogeneous reach their own knobs', () => {
+            expect(wrapBoxFlexStyle(props()).flexWrap).toBe('wrap');
+            expect(wrapBoxFlexStyle(props({ wrapReverse: true })).flexWrap).toBe('wrap-reverse');
+            expect(wrapBoxFlexStyle(props()).alignContent).toBe('flex-start');
+            expect(wrapBoxFlexStyle(props({ lineHomogeneous: true })).alignContent).toBe('stretch');
+        });
+    });
+
+    await describe('wrapBoxChildFlex: the PER-CHILD half a container knob cannot carry', async () => {
+        // A box's own CHILD COUNT — the most either renderer knows without a
+        // layout pass — names exactly two of the table's four shapes: one child
+        // (alone, on the box's single and therefore final line) and several
+        // children (at least one complete line). The other two need to know how
+        // the children actually broke: a FINAL line with several children in it,
+        // and a lone child on a line that is NOT the final one. Neither renderer
+        // can reach those — the browser element has the same limit and says so,
+        // since flexbox cannot express "every line but the last" — so they are
+        // left out rather than asserted against a count that does not mean them.
+        const childCountFor = (v: (typeof WRAP_BOX_LINE_VECTORS)[number]) => {
+            if (v.lastLine && v.childrenInLine === 1) return 1;
+            if (!v.lastLine && v.childrenInLine > 1) return 2;
+            return 0;
+        };
+        for (const vector of WRAP_BOX_LINE_VECTORS.filter((v) => childCountFor(v) > 0)) {
+            const { justify, justifyLastLine, align, childrenInLine, layout, rule } = vector;
+            await it(`${justify}${justifyLastLine ? '+last' : ''} ×${childrenInLine} — ${rule}`, () => {
+                const flex = wrapBoxChildFlex(props({ justify, justifyLastLine, align }), childCountFor(vector));
+                expect(flex.flexGrow).toBe(layout.growChildren ? 1 : 0);
+            });
+        }
+
+        await it('names what a child count cannot reach, so the omission cannot grow silently', () => {
+            const undrivable = WRAP_BOX_LINE_VECTORS.filter((v) => childCountFor(v) === 0);
+            for (const vector of undrivable) {
+                expect(vector.lastLine ? vector.childrenInLine > 1 : vector.childrenInLine === 1).toBe(true);
+            }
+            expect(undrivable).toHaveLength(8);
+            expect(WRAP_BOX_LINE_VECTORS).toHaveLength(16);
+        });
+
+        await it('a LONE child in a spread box is stretched, not spread (n_children > 1)', () => {
+            expect(wrapBoxChildFlex(props({ justify: 'spread', justifyLastLine: true }), 1).flexGrow).toBe(1);
+            expect(wrapBoxChildFlex(props({ justify: 'spread', justifyLastLine: true }), 3).flexGrow).toBe(0);
+        });
+
+        await it('the DEFAULT single-child box justifies nothing — its one line is the last', () => {
+            expect(wrapBoxChildFlex(props({ justify: 'fill' }), 1).flexGrow).toBe(0);
+            expect(wrapBoxChildFlex(props({ justify: 'fill', justifyLastLine: true }), 1).flexGrow).toBe(1);
+        });
+    });
+
+    await describe('wrap-policy (adw-wrap-box.c:476-495)', async () => {
+        for (const { value, policy, flexShrink, rule } of WRAP_BOX_POLICY_VECTORS) {
+            await it(`${label(value)} → ${policy} / shrink ${flexShrink} — ${rule}`, () => {
+                const resolved = normalizeWrapPolicy(value);
+                expect(resolved).toBe(policy);
+                expect(wrapBoxFlexStyle(props({ wrapPolicy: resolved })).childFlexShrink).toBe(flexShrink);
+            });
+        }
+
+        await it('a fresh box forbids shrinking — the CSS default is the other one', () => {
+            expect(wrapBoxFlexStyle(props()).childFlexShrink).toBe(0);
+        });
+    });
+
+    await describe('length units (the three the port had none of)', async () => {
+        for (const { value, unit, dpi, px, rule } of WRAP_BOX_LENGTH_VECTORS) {
+            await it(`${value}${String(unit)} @${dpi}dpi → ${px} — ${rule}`, () => {
+                expect(wrapBoxLengthToPx(value, normalizeWrapBoxLengthUnit(unit), dpi)).toBe(px);
+            });
+        }
+
+        await it('a spacing in sp reaches the child margin already converted', () => {
+            // 12sp at 144dpi is 18px, and half of it lands on each facing edge.
+            expect(wrapBoxChildMargin(wrapBoxLengthToPx(12, 'sp', 144), 0)).toBe('0 9 0 9');
+        });
+    });
+
+    await describe('natural-line-length (carried, not applied on NativeScript)', async () => {
+        for (const { value, length, rule } of WRAP_BOX_NATURAL_LENGTH_VECTORS) {
+            await it(`${label(value)} → ${length} — ${rule}`, () => {
+                expect(normalizeNaturalLineLength(value)).toBe(length);
+            });
+        }
+    });
+
+    await describe('resolveWrapBoxChildOrder (insert/reorder after, NULL = FIRST)', async () => {
+        for (const { op, children, child, sibling, result, rule } of WRAP_BOX_CHILD_ORDER_VECTORS) {
+            const name = `${op} ${child} after ${sibling ?? 'NULL'} in [${children.join(',')}]`;
+            await it(`${name} — ${rule}`, () => {
+                const next = resolveWrapBoxChildOrder({ children, child, sibling, op });
+                if (result === null) expect(next).toBe(null);
+                else expect(next).toStrictEqual([...result]);
+            });
+        }
     });
 };

--- a/packages/web/adwaita-core/src/chrome.ts
+++ b/packages/web/adwaita-core/src/chrome.ts
@@ -28,9 +28,10 @@
 // two forms disagreed on `0`, on `NaN` and on negatives — which is three of the
 // bugs this module removes, not a style difference.
 //
-// `adwLerp`, `easeOutCubic` and `inverseLerp` stay module-private on purpose:
-// they belong to whichever module lifts the animation family, and putting the
-// canonical copy here would put it in the wrong place.
+// `adwLerp`, `easeOutCubic` and `inverseLerp` used to be module-private here,
+// with a note saying they belonged to whichever module lifted the animation
+// family. `spinner.ts` lifted it, so they live in `easing.ts` now and this
+// module imports them.
 //
 // Reference: refs/libadwaita/src/adw-clamp-layout.c
 // Reference: refs/libadwaita/src/adw-toolbar-view.c
@@ -41,28 +42,11 @@
 // Reference: refs/libadwaita/src/stylesheet/widgets/_toolbars.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
+// `inverseLerp` here is adw-clamp-layout.c:147-153 — given `a`, `b` and a
+// result, recover `t`. NOT the `inverse_lerp` in adw-view-stack.c, which solves
+// for `b`.
+import { adwLerp, easeOutCubic, inverseLerp } from './easing.js';
 import { glibClamp } from './glib.js';
-
-// --- Shared interpolation primitives -----------------------------------------
-
-/** `adw_lerp` (adw-animation-util.c:24-27). */
-function adwLerp(a: number, b: number, t: number): number {
-    return a * (1 - t) + b * t;
-}
-
-/**
- * `inverse_lerp` (adw-clamp-layout.c:147-153) — given `a`, `b` and a result,
- * recover `t`. NOT the `inverse_lerp` in adw-view-stack.c, which solves for `b`.
- */
-function inverseLerp(a: number, b: number, r: number): number {
-    return (r - a) / (b - a);
-}
-
-/** `ease_out_cubic` at duration 1 (adw-easing.c:176-182). */
-function easeOutCubic(t: number): number {
-    const p = t - 1;
-    return p * p * p + 1;
-}
 
 // --- Adw.Clamp / AdwClampLayout ----------------------------------------------
 

--- a/packages/web/adwaita-core/src/conformance/about-dialog.ts
+++ b/packages/web/adwaita-core/src/conformance/about-dialog.ts
@@ -348,6 +348,8 @@ export interface TranslatorCreditsVector {
  * is a ZERO-length vector, so `add_credits_section` bails at `!*people`
  * (:545-546) and no section is drawn; JS `''.split('\n')` is `['']`, which
  * draws the section with one blank row.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
  */
 export const TRANSLATOR_CREDITS_VECTORS: ReadonlyArray<TranslatorCreditsVector> = [
     { value: 'Ada Lovelace', people: ['Ada Lovelace'], rule: 'one translator, one row' },
@@ -906,6 +908,8 @@ export interface AboutDialogLabelVector {
  * on its own in the header revealer that fades in on scroll (.ui:29-31). A
  * renderer that titles the page "About <app>" AND labels the dialog "About
  * <app>" says the app's name three times on one screen.
+ *
+ * CORE-ONLY: a string table the renderers read THROUGH ADW_ABOUT_DIALOG_LABELS; the rendered text is asserted by ABOUT_DIALOG_HEADER/DETAILS_VECTORS
  */
 export const ABOUT_DIALOG_LABEL_VECTORS: ReadonlyArray<AboutDialogLabelVector> = [
     {
@@ -964,6 +968,8 @@ export interface LicenseInfoVector {
  * Index 18 is pinned because `G_STATIC_ASSERT (G_N_ELEMENTS (gtk_license_info)
  * - 1 == GTK_LICENSE_0BSD)` (:253-256) is the C's own check that the table and
  * the enum have not drifted; this is that assertion, ported.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
  */
 export const LICENSE_INFO_VECTORS: ReadonlyArray<LicenseInfoVector> = [
     { licenseType: 0, spdxId: null, url: null, rule: 'unknown carries nothing (:216)' },
@@ -1003,7 +1009,9 @@ export interface LicenseSpdxVector {
     rule: string;
 }
 
-/** The two lookup loops in `populate_from_appdata` (:1226-1239). */
+/** The two lookup loops in `populate_from_appdata` (:1226-1239).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (LICENSE_INFO_VECTORS → the legal section)
+ */
 export const LICENSE_SPDX_VECTORS: ReadonlyArray<LicenseSpdxVector> = [
     { spdxId: 'MIT', licenseType: 7, rule: 'an exact table match (:1227)' },
     { spdxId: 'GPL-3.0-or-later', licenseType: 3, rule: 'the -or-later variant is its own row' },
@@ -1028,7 +1036,9 @@ export interface LicenseTextVector {
     rule: string;
 }
 
-/** `get_license_text` (:635-651). */
+/** `get_license_text` (:635-651).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
+ */
 export const LICENSE_TEXT_VECTORS: ReadonlyArray<LicenseTextVector> = [
     {
         licenseType: 0,
@@ -1093,6 +1103,8 @@ export interface LicenseSetterVector {
  * would have set the type to custom, so re-assigning the same text after a
  * licence-type change does switch the type, while assigning `""` to an already
  * empty licence does not.
+ *
+ * CORE-ONLY: a property-ordering table with no rendered surface — the RESULT is ABOUT_DIALOG_CREDITS_LEGAL_VECTORS, which both renderers drive
  */
 export const LICENSE_SETTER_VECTORS: ReadonlyArray<LicenseSetterVector> = [
     {
@@ -1187,7 +1199,9 @@ export interface LegalSectionVector {
     rule: string;
 }
 
-/** `append_legal_section`'s early-outs for the default section (:666-671, :740). */
+/** `append_legal_section`'s early-outs for the default section (:666-671, :740).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
+ */
 export const LEGAL_SECTION_VECTORS: ReadonlyArray<LegalSectionVector> = [
     { copyright: '', licenseType: 0, license: '', visible: false, rule: 'nothing set — no Legal page, no Legal row' },
     { copyright: '© 2026 Ada', licenseType: 0, license: '', visible: true, rule: 'a copyright alone is enough' },

--- a/packages/web/adwaita-core/src/conformance/carousel.ts
+++ b/packages/web/adwaita-core/src/conformance/carousel.ts
@@ -39,7 +39,9 @@ export interface CarouselSnapPointVector {
     rule: string;
 }
 
-/** `adw_carousel_size_allocate`'s accumulation (adw-carousel.c:777-789). */
+/** `adw_carousel_size_allocate`'s accumulation (adw-carousel.c:777-789).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CAROUSEL_PAGE_LIST_VECTORS)
+ */
 export const CAROUSEL_SNAP_POINT_VECTORS: ReadonlyArray<CarouselSnapPointVector> = [
     { sizes: [1, 1, 1], snapPoints: [0, 1, 2], rule: 'settled pages sit one unit apart, starting at 0' },
     { sizes: [1], snapPoints: [0], rule: 'a single page is always at position 0' },
@@ -67,6 +69,8 @@ export interface CarouselSizesFromSnapPointsVector {
  * The inverse both indicators reconstruct sizes with
  * (adw-carousel-indicator-dots.c:189-191, :248-250) — the only channel through
  * which an indicator can learn per-page reveal state.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CAROUSEL_PAGE_LIST_VECTORS)
  */
 export const CAROUSEL_SIZES_FROM_SNAP_POINTS_VECTORS: ReadonlyArray<CarouselSizesFromSnapPointsVector> = [
     { snapPoints: [0, 1, 2], sizes: [1, 1, 1], rule: 'settled pages round-trip to size 1' },
@@ -92,7 +96,9 @@ export interface CarouselRangeVector {
     rule: string;
 }
 
-/** `get_range` (adw-carousel.c:207-220). */
+/** `get_range` (adw-carousel.c:207-220).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CAROUSEL_PAGE_LIST_VECTORS)
+ */
 export const CAROUSEL_RANGE_VECTORS: ReadonlyArray<CarouselRangeVector> = [
     { snapPoints: [0, 1, 2], positionShift: 0, lower: 0, upper: 2, rule: 'the last snap point is the upper bound' },
     { snapPoints: [], positionShift: 0, lower: 0, upper: 0, rule: 'an empty carousel cannot scroll (:212-219)' },
@@ -125,7 +131,9 @@ export interface CarouselClampVector {
     rule: string;
 }
 
-/** `set_position`'s guard (adw-carousel.c:269). */
+/** `set_position`'s guard (adw-carousel.c:269).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CAROUSEL_PAGE_LIST_VECTORS)
+ */
 export const CAROUSEL_CLAMP_VECTORS: ReadonlyArray<CarouselClampVector> = [
     { position: 5, snapPoints: [0, 1, 2], clamped: 2, rule: 'past the end clamps to the last snap point' },
     { position: -3, snapPoints: [0, 1, 2], clamped: 0, rule: 'below the start clamps to 0' },
@@ -255,7 +263,9 @@ export interface CarouselWheelVector {
     rule: string;
 }
 
-/** `scroll_cb`'s axis/source rules (adw-carousel.c:537-559). */
+/** `scroll_cb`'s axis/source rules (adw-carousel.c:537-559).  *
+ * CORE-ONLY: GAP — the browser carousel handles `wheel` without routing it through `resolveCarouselWheel`, and the NativeScript one has no wheel at all. Tracked in #1072
+ */
 export const CAROUSEL_WHEEL_VECTORS: ReadonlyArray<CarouselWheelVector> = [
     {
         deltaX: 0,
@@ -355,6 +365,8 @@ export interface CarouselWheelLockoutVector {
  * The web port replaced this with a non-decaying delta accumulator, so +30 then
  * −30 cancelled out where libadwaita pages twice, and a slow wheel never
  * reached the threshold at all.
+ *
+ * CORE-ONLY: GAP — the lockout is a real elapsed-time rule and neither element has a clock seam to drive it with. Tracked in #1072
  */
 export const CAROUSEL_WHEEL_LOCKOUT_VECTORS: ReadonlyArray<CarouselWheelLockoutVector> = [
     {
@@ -402,7 +414,9 @@ export interface CarouselReorderShiftVector {
     rule: string;
 }
 
-/** The three branches of `adw_carousel_reorder`'s compensation (adw-carousel.c:1488-1495). */
+/** The three branches of `adw_carousel_reorder`'s compensation (adw-carousel.c:1488-1495).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CAROUSEL_PAGE_LIST_VECTORS)
+ */
 export const CAROUSEL_REORDER_SHIFT_VECTORS: ReadonlyArray<CarouselReorderShiftVector> = [
     {
         closestPoint: 1,

--- a/packages/web/adwaita-core/src/conformance/chrome.ts
+++ b/packages/web/adwaita-core/src/conformance/chrome.ts
@@ -38,7 +38,9 @@ export interface ClampThresholdsVector {
     rule: string;
 }
 
-/** `lower`/`max`/`upper` (adw-clamp-layout.c:173-176, :210-213). */
+/** `lower`/`max`/`upper` (adw-clamp-layout.c:173-176, :210-213).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CLAMP_ALLOCATE_VECTORS)
+ */
 export const CLAMP_THRESHOLD_VECTORS: ReadonlyArray<ClampThresholdsVector> = [
     {
         params: { maximumSize: 600, tighteningThreshold: 400, childMin: 0, childNat: 1000 },
@@ -96,7 +98,9 @@ const CLAMP_DEFAULT_PARAMS: ClampParams = {
     childNat: 1000,
 };
 
-/** `child_size_from_clamp` (adw-clamp-layout.c:193-232). */
+/** `child_size_from_clamp` (adw-clamp-layout.c:193-232).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CLAMP_ALLOCATE_VECTORS)
+ */
 export const CLAMP_CHILD_SIZE_VECTORS: ReadonlyArray<ClampChildSizeVector> = [
     {
         forSize: -1,
@@ -165,7 +169,9 @@ export interface ClampSizeFromChildVector {
     rule: string;
 }
 
-/** `clamp_size_from_child` (adw-clamp-layout.c:156-191) — the inverse ease. */
+/** `clamp_size_from_child` (adw-clamp-layout.c:156-191) — the inverse ease.  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CLAMP_ALLOCATE_VECTORS)
+ */
 export const CLAMP_SIZE_FROM_CHILD_VECTORS: ReadonlyArray<ClampSizeFromChildVector> = [
     { childSize: 300, params: CLAMP_DEFAULT_PARAMS, clampSize: 300, rule: 'below the threshold it is the identity' },
     { childSize: 400, params: CLAMP_DEFAULT_PARAMS, clampSize: 400, rule: 'the `<= lower` boundary is inclusive' },
@@ -339,7 +345,9 @@ export interface ToolbarViewAllocateVector {
     rule: string;
 }
 
-/** `adw_toolbar_view_size_allocate` (adw-toolbar-view.c:357-406). */
+/** `adw_toolbar_view_size_allocate` (adw-toolbar-view.c:357-406).  *
+ * CORE-ONLY: both renderers let the BROWSER and NativeScript lay the bars out rather than allocating by hand, so there is no allocation of theirs to compare — the rule they DO apply is TOOLBAR_VIEW_CLASS_VECTORS, which both drive. This reason used to live in the two `adw-toolbar-view.ts` files and nowhere a reader of this table would look
+ */
 export const TOOLBAR_VIEW_ALLOCATE_VECTORS: ReadonlyArray<ToolbarViewAllocateVector> = [
     {
         input: {
@@ -474,7 +482,9 @@ export interface ToolbarViewMeasureVector {
     rule: string;
 }
 
-/** `adw_toolbar_view_measure` (adw-toolbar-view.c:266-354). */
+/** `adw_toolbar_view_measure` (adw-toolbar-view.c:266-354).  *
+ * CORE-ONLY: same as TOOLBAR_VIEW_ALLOCATE_VECTORS — neither renderer measures the bars itself
+ */
 export const TOOLBAR_VIEW_MEASURE_VECTORS: ReadonlyArray<ToolbarViewMeasureVector> = [
     {
         input: {
@@ -604,7 +614,9 @@ export interface ToolbarViewContentForSizeVector {
     rule: string;
 }
 
-/** `adw_toolbar_view_measure`'s height-for-width branch (adw-toolbar-view.c:292-316). */
+/** `adw_toolbar_view_measure`'s height-for-width branch (adw-toolbar-view.c:292-316).  *
+ * CORE-ONLY: same as TOOLBAR_VIEW_ALLOCATE_VECTORS — neither renderer measures the bars itself
+ */
 export const TOOLBAR_VIEW_CONTENT_FOR_SIZE_VECTORS: ReadonlyArray<ToolbarViewContentForSizeVector> = [
     {
         forSize: 600,

--- a/packages/web/adwaita-core/src/conformance/data-grid.ts
+++ b/packages/web/adwaita-core/src/conformance/data-grid.ts
@@ -411,6 +411,8 @@ export interface DataGridColumnNormalizeVector {
  * an entry WITHOUT a `key` is dropped (there is nothing to read from a row), and
  * a field of the wrong type is coerced (`key`, `label`, `width`) or discarded
  * (`flex`, `monospace`, `numeric`) rather than taking the whole entry down.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (DATA_GRID_TRACK_VECTORS)
  */
 export const DATA_GRID_COLUMN_NORMALIZE_VECTORS: ReadonlyArray<DataGridColumnNormalizeVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/entry-row.ts
+++ b/packages/web/adwaita-core/src/conformance/entry-row.ts
@@ -591,6 +591,8 @@ export interface EntryRowGuardVector {
  * setter early-outs on an unchanged value (C:984, :1198, :1247, :1339), while
  * the private `adw_entry_row_set_show_indicator` (C:1281-1296) deliberately has
  * NO equality check and re-derives unconditionally.
+ *
+ * CORE-ONLY: GAP — the browser element discards the setter’s boolean, so the guard has no observable answer. Tracked in #1072
  */
 export const ENTRY_ROW_GUARD_VECTORS: ReadonlyArray<EntryRowGuardVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -141,8 +141,8 @@ export { RADIO_GROUP_VECTORS } from './checks.js';
 export type { RadioGroupStep, RadioGroupVector } from './checks.js';
 
 // --- Row state machines (Adw.ComboRow / Gtk.DropDown selection) vectors ---
-export { COMBO_SELECTION_VECTORS } from './rows.js';
-export type { ComboSelectionStep, ComboSelectionVector } from './rows.js';
+export { COMBO_CHOOSER_VECTORS, COMBO_SELECTION_VECTORS } from './rows.js';
+export type { ComboChooserVector, ComboSelectionStep, ComboSelectionVector } from './rows.js';
 
 // --- View stack selection (Adw.ViewStack) vectors ---
 export { VIEW_STACK_ICON_NAME_VECTORS, VIEW_STACK_PAGE_VECTORS, VIEW_STACK_VECTORS } from './view-stack.js';

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -473,20 +473,23 @@ export type {
 export { POPOVER_KEY_VECTORS, POPOVER_SURFACE_VECTORS } from './popover.js';
 export type { PopoverKeyVector, PopoverSurfaceVariant, PopoverSurfaceVector } from './popover.js';
 
-// --- Wrap box line layout + spacing (Adw.WrapBox) vectors ---
+// --- Wrap box line layout, properties + child order (Adw.WrapBox) vectors ---
 export {
-    ADW_WRAP_BOX_DEFAULT_ALIGN,
-    ADW_WRAP_BOX_DEFAULT_JUSTIFY,
-    ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE,
-    ADW_WRAP_BOX_DEFAULT_SPACING,
+    WRAP_BOX_CHILD_ORDER_VECTORS,
+    WRAP_BOX_LENGTH_VECTORS,
     WRAP_BOX_LINE_VECTORS,
+    WRAP_BOX_NATURAL_LENGTH_VECTORS,
+    WRAP_BOX_NOTIFY_PROPERTIES,
+    WRAP_BOX_POLICY_VECTORS,
     WRAP_BOX_SPACING_NOTIFY_VECTORS,
     WRAP_BOX_SPACING_VECTORS,
 } from './wrap-box.js';
 export type {
-    WrapBoxJustify,
-    WrapBoxLineLayout,
+    WrapBoxChildOrderVector,
+    WrapBoxLengthVector,
     WrapBoxLineVector,
+    WrapBoxNaturalLengthVector,
+    WrapBoxPolicyVector,
     WrapBoxSpacingNotifyVector,
     WrapBoxSpacingVector,
 } from './wrap-box.js';

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -473,6 +473,15 @@ export type {
 export { POPOVER_KEY_VECTORS, POPOVER_SURFACE_VECTORS } from './popover.js';
 export type { PopoverKeyVector, PopoverSurfaceVariant, PopoverSurfaceVector } from './popover.js';
 
+// --- Adw.Spinner animation vectors ---
+export {
+    SPINNER_ARC_ENVELOPE,
+    SPINNER_ARC_PHASE_VECTORS,
+    SPINNER_ARC_TOLERANCE,
+    SPINNER_CONSTANT_VECTORS,
+} from './spinner.js';
+export type { SpinnerArcShapeVector, SpinnerConstantVector } from './spinner.js';
+
 // --- Wrap box line layout, properties + child order (Adw.WrapBox) vectors ---
 export {
     WRAP_BOX_CHILD_ORDER_VECTORS,

--- a/packages/web/adwaita-core/src/conformance/popover.ts
+++ b/packages/web/adwaita-core/src/conformance/popover.ts
@@ -121,6 +121,8 @@ export interface PopoverKeyVector {
  * The rows that matter are the ones where the copies were WRONG rather than
  * merely duplicated: ArrowUp from an unfocused list (both computed `n - 2`), and
  * Home/End while a search entry owns the caret (the drop-down stole both).
+ *
+ * CORE-ONLY: GAP — `adw-popover` calls `resolvePopoverKey` on keydown but publishes no readable outcome for a spec to compare. Tracked in #1072
  */
 export const POPOVER_KEY_VECTORS: ReadonlyArray<PopoverKeyVector> = [
     // --- ArrowDown ---

--- a/packages/web/adwaita-core/src/conformance/preferences.ts
+++ b/packages/web/adwaita-core/src/conformance/preferences.ts
@@ -233,6 +233,8 @@ export interface CaseFoldVector {
  * silently fails to match — in German, Greek and any text with a typographic
  * ligature. None of it is visible in an ASCII test suite, which is exactly why
  * the rows are here.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
  */
 export const CASE_FOLD_VECTORS: ReadonlyArray<CaseFoldVector> = [
     { text: 'Dark Style', folded: 'dark style', naiveLowerCase: 'dark style', rule: 'ASCII is unaffected' },
@@ -287,6 +289,8 @@ export interface StripMarkupVector {
  * `null` is not an error case to be smoothed over: it is the branch where C
  * logs a `g_critical` and KEEPS the unparsed string, so every `null` row below
  * is a row that must stay searchable under its literal spelling.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
  */
 export const STRIP_MARKUP_VECTORS: ReadonlyArray<StripMarkupVector> = [
     { markup: 'Dark Style', plain: 'Dark Style', rule: 'plain text passes through' },
@@ -335,6 +339,8 @@ export interface StripMnemonicVector {
 /**
  * `adw_strip_mnemonic` (adw-widget-utils.c:685-703) — `g_markup_escape_text`
  * followed by `pango_parse_markup` with `accel_marker = '_'`.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
  */
 export const STRIP_MNEMONIC_VECTORS: ReadonlyArray<StripMnemonicVector> = [
     { text: 'Appearance', stripped: 'Appearance', rule: 'no marker, no change' },
@@ -374,6 +380,8 @@ export interface MakeComparableVector {
  * The defaults matter as much as the rows: `use-markup` defaults to TRUE
  * (adw-preferences-row.c:185-188) and `use-underline` to FALSE (:155-158), so
  * an ordinary row's title IS markup-parsed and is NOT mnemonic-stripped.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
  */
 export const MAKE_COMPARABLE_VECTORS: ReadonlyArray<MakeComparableVector> = [
     {
@@ -451,7 +459,9 @@ export interface RowMatchVector {
     rule: string;
 }
 
-/** `filter_search_results` (adw-preferences-dialog.c:125-153). */
+/** `filter_search_results` (adw-preferences-dialog.c:125-153).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
+ */
 export const ROW_MATCH_VECTORS: ReadonlyArray<RowMatchVector> = [
     {
         row: { title: 'Dark Style' },
@@ -552,6 +562,8 @@ export interface SearchCorpusVector {
  * Dropping any clause is invisible — nothing errors, the search just quietly
  * indexes the wrong set — which is why these rows are separate from the
  * end-to-end ones.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
  */
 export const SEARCH_CORPUS_VECTORS: ReadonlyArray<SearchCorpusVector> = [
     {
@@ -620,7 +632,9 @@ export interface SearchRowSubtitleVector {
     rule: string;
 }
 
-/** `create_search_row_subtitle` (adw-preferences-dialog.c:168-234). */
+/** `create_search_row_subtitle` (adw-preferences-dialog.c:168-234).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (PREFERENCES_SEARCH_VECTORS)
+ */
 export const SEARCH_ROW_SUBTITLE_VECTORS: ReadonlyArray<SearchRowSubtitleVector> = [
     {
         input: { groupTitle: 'Appearance', pageTitle: 'General', nVisiblePages: 1 },

--- a/packages/web/adwaita-core/src/conformance/rows.ts
+++ b/packages/web/adwaita-core/src/conformance/rows.ts
@@ -22,13 +22,17 @@
 //      port rule. The vectors carry the flag so a renderer that mixes the two
 //      paths up fails a test, and this note so nobody reads the flag as GTK's.
 //
-//   2. "Nothing is selected" has no representation. `Adw.ComboRow:selected` is
-//      a `guint` whose default and empty value are `GTK_INVALID_LIST_POSITION`
-//      (= G_MAXUINT, :593-596; :809-810 returns it when there is no selection
-//      model at all). `ComboState` starts at index 0 and reports an empty
-//      `selectedValue`/`selectedLabel` instead, because both renderers paint a
-//      LABEL and `''` is what they can draw. The rows below pin `0` + `''`, and
-//      say so where it applies.
+//   2. "Nothing is selected" IS represented, as `ADW_COMBO_NO_SELECTION` (-1) —
+//      the TS spelling of `GTK_INVALID_LIST_POSITION` (= G_MAXUINT, :593-596;
+//      :809-810 returns it when there is no selection model at all), matching
+//      `ADW_SIDEBAR_NO_SELECTION`. It did not used to be: both ports reported
+//      index 0 with an empty `selectedValue`, so an EMPTY model and a model
+//      whose first item has an empty label were the same state, and a renderer
+//      wanting to draw a placeholder had nothing to test. What is still ours is
+//      that an index PAST the end is accepted rather than folded onto the
+//      sentinel — `setSelectedIndex` mirrors a guint property that takes any
+//      position, and `ComboState.hasIndex` is where each renderer states its own
+//      policy.
 //
 // WHO DRIVES THIS TABLE
 //
@@ -261,11 +265,11 @@ export const COMBO_SELECTION_VECTORS: ReadonlyArray<ComboSelectionVector> = [
     {
         name: 'an empty model',
         steps: [{ op: 'setOptions', options: [] }],
-        selected: 0,
+        selected: -1,
         value: '',
         label: '',
-        emitted: [{ selected: 0, value: '', label: '', interactive: false }],
-        rule: 'GTK reports GTK_INVALID_LIST_POSITION here (:593-596, :809-810); the ports report index 0 with an empty value — see the module header',
+        emitted: [{ selected: -1, value: '', label: '', interactive: false }],
+        rule: 'GTK_INVALID_LIST_POSITION (:593-596, :809-810) — an empty model has no index 0 to autoselect',
     },
     {
         name: 'picking from an empty model',
@@ -273,10 +277,85 @@ export const COMBO_SELECTION_VECTORS: ReadonlyArray<ComboSelectionVector> = [
             { op: 'setOptions', options: [] },
             { op: 'select', index: 0 },
         ],
-        selected: 0,
+        selected: -1,
         value: '',
         label: '',
-        emitted: [{ selected: 0, value: '', label: '', interactive: false }],
-        rule: 'index 0 is already held, so there is nothing to pick — the renderers never open a chooser over an empty model either',
+        emitted: [{ selected: -1, value: '', label: '', interactive: false }],
+        rule: 'there is no option 0 to pick — and the renderers never open a chooser over an empty model either',
     },
+    {
+        name: 'emptying a model that had a selection',
+        steps: [
+            { op: 'setOptions', options: AB },
+            { op: 'setSelectedIndex', index: 1 },
+            { op: 'setOptions', options: [] },
+        ],
+        selected: -1,
+        value: '',
+        label: '',
+        emitted: [
+            { selected: 0, value: 'a', label: 'One', interactive: false },
+            { selected: 1, value: 'b', label: 'Two', interactive: false },
+            { selected: -1, value: '', label: '', interactive: false },
+        ],
+        rule: 'the selection does NOT survive as index 0 — there is nothing at 0 any more',
+    },
+    {
+        name: 'a model that is emptied and refilled',
+        steps: [
+            { op: 'setOptions', options: AB },
+            { op: 'setOptions', options: [] },
+            { op: 'setOptions', options: AB },
+        ],
+        selected: 0,
+        value: 'a',
+        label: 'One',
+        emitted: [
+            { selected: 0, value: 'a', label: 'One', interactive: false },
+            { selected: -1, value: '', label: '', interactive: false },
+            { selected: 0, value: 'a', label: 'One', interactive: false },
+        ],
+        rule: 'autoselect runs again, so the sentinel recovers to 0 — it is BELOW the range, which a one-sided >= length check leaves in place',
+    },
+    {
+        name: 'a model with an empty first label is still a selection',
+        steps: [{ op: 'setOptions', options: [{ label: '', value: 'blank' }] }],
+        selected: 0,
+        value: 'blank',
+        label: '',
+        emitted: [{ selected: 0, value: 'blank', label: '', interactive: false }],
+        rule: 'the case the sentinel exists to separate: an empty LABEL, not an empty model',
+    },
+];
+
+// --- The chooser predicate (model_changed, adw-combo-row.c:187-195) -----------
+
+/** One `presentsChooser` expectation. */
+export interface ComboChooserVector {
+    /** How many options the model holds. */
+    count: number;
+    /** Whether the arrow is drawn and the row is activatable. */
+    presentsChooser: boolean;
+    /** The rule this row pins down. */
+    rule: string;
+}
+
+/**
+ * `model_changed` (adw-combo-row.c:187-195) — one predicate, `n_items > 1`,
+ * driving BOTH `gtk_widget_set_visible (arrow_box, …)` and
+ * `gtk_list_box_row_set_activatable (row, …)`.
+ *
+ * A row with one option or none has nothing to choose, so it stops presenting
+ * itself as a chooser. Neither port did this: a NativeScript `AdwComboRow` with
+ * a single option still showed its chevron and opened an `action()` sheet with
+ * one entry, and the browser element behaved the same way.
+ *
+ * `Gtk.DropDown` is deliberately NOT covered — it keeps its arrow at any count,
+ * which is why this lives on the combo ROW rather than in the shared chooser.
+ */
+export const COMBO_CHOOSER_VECTORS: ReadonlyArray<ComboChooserVector> = [
+    { count: 0, presentsChooser: false, rule: 'an empty model is not a chooser' },
+    { count: 1, presentsChooser: false, rule: 'ONE option is not a choice — the arrow goes and the row goes inert' },
+    { count: 2, presentsChooser: true, rule: 'two is the smallest real choice — the predicate is > 1, not >= 1' },
+    { count: 5, presentsChooser: true, rule: 'and anything above it' },
 ];

--- a/packages/web/adwaita-core/src/conformance/spinner.ts
+++ b/packages/web/adwaita-core/src/conformance/spinner.ts
@@ -79,7 +79,9 @@ export interface SpinnerArcShapeVector {
     rule: string;
 }
 
-/** The moments worth naming in one arc cycle. */
+/** The moments worth naming in one arc cycle.  *
+ * CORE-ONLY: the arc is drawn per frame from `spinnerArc`, and a renderer can only show the RESULT — the browser suite asserts the drawn envelope and the round caps, which is the observable half
+ */
 export const SPINNER_ARC_PHASE_VECTORS: ReadonlyArray<SpinnerArcShapeVector> = [
     { phase: 0, rule: 'the cycle boundary — the arc is at MIN_ARC_LENGTH, its shortest' },
     { phase: 0.15, rule: 'extending: ease_in_out_sine is still accelerating' },
@@ -106,6 +108,8 @@ export interface SpinnerConstantVector {
  * `rule` column: five of these seven were WRONG or absent in a shipping port,
  * and a table is what makes "the port picked its own number" fail a test rather
  * than look like a design choice.
+ *
+ * CORE-ONLY: a table OF constants: what a renderer can show is the geometry they produce, which the browser suite asserts through SPINNER_GEOMETRY/SIZE_VECTORS
  */
 export const SPINNER_CONSTANT_VECTORS: ReadonlyArray<SpinnerConstantVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/spinner.ts
+++ b/packages/web/adwaita-core/src/conformance/spinner.ts
@@ -1,0 +1,146 @@
+// Spinner animation vectors — `AdwSpinnerPaintable`'s breathing arc.
+//
+// The geometry (`spinnerGeometry`, `resolveSpinnerSize`) lives in
+// `conformance/chrome.ts` and predates this file; what is here is the ANIMATION,
+// which issue #1066 found to be a different animation on every renderer:
+//
+//   - the browser turned in 0.8s where the C turns in 1.2, so a spinner beside
+//     a GTK one ran 1.5x too fast;
+//   - it drew a FIXED 90-degree arc (`border-top-color`) where the C's arc
+//     breathes (see the envelope below);
+//   - its track was `rgba(127, 127, 127, 0.25)` where the C strokes the WIDGET's
+//     colour at 15%, so the track was too dark and lost its hue;
+//   - the arc ends were square-cut where GSK uses `GSK_LINE_CAP_ROUND`;
+//   - `START_ANGLE` was in neither port — a constant rotation error;
+//   - `prefers-reduced-motion` STOPPED it, where the C explicitly opts out of
+//     the animation setting (`adw_animation_set_follow_enable_animations_setting
+//     (…, FALSE)`, :537). A frozen busy indicator reads as a hang.
+//
+// A SETTLED CONTRADICTION, recorded because these rows sit on top of it
+//
+// `SPINNER_SIZE_VECTORS` says a 200px request yields a 200px BOX, with the rule
+// "an oversized box stays oversized — spinnerGeometry caps the RING, not the
+// box". Both renderer suites used to assert the opposite, because their element
+// and their view WERE the ring. The C settles it: `adw_spinner_measure`
+// (adw-spinner.c:78-81) reports MIN_SIZE as both minimum and natural and has no
+// upper bound at all — `MAX_SIZE` at :15 is defined and never referenced —
+// while `adw_spinner_snapshot` (:95-99) hands the widget's real width and height
+// to the paintable, which caps only `radius` (adw-spinner-paintable.c:343) and
+// still centres on the box (:349-351). So a 200px spinner occupies 200px of
+// layout and draws a 64px ring in the middle. The core table was right; both
+// renderers now separate the box from the ring.
+//
+// Reference: refs/libadwaita/src/adw-spinner.c
+// Reference: refs/libadwaita/src/adw-spinner-paintable.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+/** How close two radian values have to be to count as equal. */
+export const SPINNER_ARC_TOLERANCE = 1e-9;
+
+/**
+ * The arc lengths actually DRAWN, in radians — measured over one cycle at 200k
+ * samples, not read off the constants.
+ *
+ * The distinction matters and is easy to get wrong: `MAX_ARC_LENGTH` is
+ * `pi * 0.9` (162 degrees), and both `get_arc_start` and `get_arc_end` lerp
+ * TOWARDS it — but each then subtracts the drift term
+ * `angle * MAX_ARC_LENGTH / cycle_length`, which is what makes the figure
+ * advance around the circle. The two ends drift together, so the visible arc
+ * peaks at **102.8 degrees**, not 162. Reading the constant as the drawn length
+ * is the obvious mistake; issue #1066 made it in its own summary table.
+ *
+ * The MINIMUM is exactly `MIN_ARC_LENGTH`, because the drift is zero at the
+ * cycle boundary where the arc is shortest.
+ */
+export const SPINNER_ARC_ENVELOPE = {
+    /** Exactly `MIN_ARC_LENGTH` — 2.7 degrees, at the cycle boundary. */
+    min: Math.PI * 0.015,
+    /** 102.815... degrees. Asserted to a tolerance, not to the last digit. */
+    max: 1.794463,
+    /** How far a measured extreme may sit from the value above. */
+    tolerance: 1e-4,
+} as const;
+
+/**
+ * `get_arc_start` / `get_arc_end` (adw-spinner-paintable.c:109-145) at the four
+ * corners of one cycle, plus the resting pose.
+ *
+ * The lengths are DERIVED from the C's own constants rather than typed in: the
+ * point of the rows is which MOMENT each is, and a hand-copied radian would be a
+ * second reading of the same arithmetic the implementation does. What they pin
+ * is the shape — that the arc is shortest at the cycle boundary, longest around
+ * the extend/contract handover, and never leaves `[MIN_ARC_LENGTH,
+ * MAX_ARC_LENGTH]`.
+ */
+export interface SpinnerArcShapeVector {
+    /** Fraction of one arc cycle, 0..1. */
+    phase: number;
+    /** What happens here. */
+    rule: string;
+}
+
+/** The moments worth naming in one arc cycle. */
+export const SPINNER_ARC_PHASE_VECTORS: ReadonlyArray<SpinnerArcShapeVector> = [
+    { phase: 0, rule: 'the cycle boundary — the arc is at MIN_ARC_LENGTH, its shortest' },
+    { phase: 0.15, rule: 'extending: ease_in_out_sine is still accelerating' },
+    { phase: 0.41, rule: 'the extend phase ends (EXTEND_DISTANCE / cycle) — the arc is at its longest' },
+    { phase: 0.6, rule: 'contracting: the leading end has started catching up' },
+    { phase: 0.66, rule: 'the contract phase ends and the idle one begins' },
+    { phase: 0.9, rule: 'idling: both ends move together, so the length holds' },
+];
+
+/** One "is this constant what the C says" expectation. */
+export interface SpinnerConstantVector {
+    /** The constant's name in the C. */
+    name: string;
+    /** Its value, as a multiple of pi where the C writes one. */
+    value: number;
+    /** Where it is defined and what the ports had instead. */
+    rule: string;
+}
+
+/**
+ * The `#define`s at adw-spinner-paintable.c:18-33 and adw-spinner.c:14-15.
+ *
+ * A constant table looks redundant next to the implementation until you read the
+ * `rule` column: five of these seven were WRONG or absent in a shipping port,
+ * and a table is what makes "the port picked its own number" fail a test rather
+ * than look like a design choice.
+ */
+export const SPINNER_CONSTANT_VECTORS: ReadonlyArray<SpinnerConstantVector> = [
+    {
+        name: 'SPIN_DURATION_MS',
+        value: 1200,
+        rule: ':20 — the browser used 0.8s, so its ring turned 1.5x too fast',
+    },
+    {
+        name: 'START_ANGLE',
+        value: Math.PI * 0.35,
+        rule: ':21 — added to both arc ends (:379-380); absent from both ports, a constant phase error',
+    },
+    {
+        name: 'CIRCLE_OPACITY',
+        value: 0.15,
+        rule: ':22 — of the WIDGET colour; the browser hardcoded rgba(127,127,127,0.25), darker and hue-independent',
+    },
+    {
+        name: 'MIN_ARC_LENGTH',
+        value: Math.PI * 0.015,
+        rule: ':24 — 2.7 degrees, the shortest arc GSK will still draw',
+    },
+    {
+        name: 'MAX_ARC_LENGTH',
+        value: Math.PI * 0.9,
+        rule: ':25 — 162 degrees; the browser drew a fixed 90 and never breathed',
+    },
+    {
+        name: 'N_CYCLES',
+        value: 53,
+        rule: ':33 — chosen so a whole number of arc cycles fits a whole number of turns',
+    },
+    {
+        name: 'MIN_SIZE',
+        value: 16,
+        rule: 'adw-spinner.c:14 — reported as BOTH minimum and natural (:78-81), so a spinner never grows on its own',
+    },
+];

--- a/packages/web/adwaita-core/src/conformance/split-button.ts
+++ b/packages/web/adwaita-core/src/conformance/split-button.ts
@@ -507,6 +507,8 @@ export const SPLIT_BUTTON_DIRECTION_VECTORS: ReadonlyArray<SplitButtonDirectionV
  * demonstrated OVERRIDE rather than an assertion. Holding both means a reader can
  * see the two values and the two selectors side by side, and a renderer that
  * reaches for the wrong one fails a test that names which widget it is drawing.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (SPLIT_BUTTON_DIRECTION_VECTORS)
  */
 export const MENU_BUTTON_DIRECTION_VECTORS: ReadonlyArray<SplitButtonDirectionVector> = [
     {
@@ -563,6 +565,8 @@ const IDLE: SplitButtonHalfState = { active: false, checked: false, keyboardActi
  * `update_state` (adw-split-button.c:118-143) — an OR-fold of both halves onto
  * the root, which is what `splitbutton.flat:active/:checked` styles
  * (_buttons.scss:542-549).
+ *
+ * CORE-ONLY: GAP — two of its three axes are hardcoded in the renderer, so there is nothing to vary. Tracked in #1072
  */
 export const SPLIT_BUTTON_ROOT_STATE_VECTORS: ReadonlyArray<SplitButtonRootStateVector> = [
     { action: IDLE, dropdown: IDLE, active: false, checked: false, rule: 'idle folds to idle' },

--- a/packages/web/adwaita-core/src/conformance/split-view.ts
+++ b/packages/web/adwaita-core/src/conformance/split-view.ts
@@ -43,7 +43,9 @@ export interface AdwLengthUnitVector {
     rule: string;
 }
 
-/** `adw_length_unit_to_px` (adw-length-unit.c:72-81). */
+/** `adw_length_unit_to_px` (adw-length-unit.c:72-81).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (SIDEBAR_BOUNDS_VECTORS, which both renderers drive)
+ */
 export const ADW_LENGTH_UNIT_VECTORS: ReadonlyArray<AdwLengthUnitVector> = [
     { unit: 'px', value: 180, dpi: 96, px: 180, rule: 'px is a passthrough' },
     { unit: 'px', value: 180, dpi: 120, px: 180, rule: 'px ignores the text scale entirely' },
@@ -72,6 +74,8 @@ export interface GlibClampVector {
  * The inverted rows are the point: `Math.min(high, Math.max(low, x))` returns
  * `high` there, and `allocate_uncollapsed` reaches inverted bounds whenever the
  * content pane's own minimum leaves less room than `min-sidebar-width`.
+ *
+ * CORE-ONLY: GLib’s CLAMP itself — a primitive with no widget surface; every widget that reaches it does so through a table that IS driven
  */
 export const GLIB_CLAMP_VECTORS: ReadonlyArray<GlibClampVector> = [
     { x: 250, low: 180, high: 280, clamped: 250, rule: 'inside the range, untouched' },
@@ -349,6 +353,8 @@ export interface NaturalSidebarWidthVector {
 /**
  * `measure_uncollapsed`'s sidebar estimate (adw-navigation-split-view.c:260-262,
  * adw-overlay-split-view.c:554-556) — the sidebar's OWN natural width is ignored.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (SIDEBAR_WIDTH_VECTORS)
  */
 export const NATURAL_SIDEBAR_WIDTH_VECTORS: ReadonlyArray<NaturalSidebarWidthVector> = [
     { contentNatural: 800, min: 180, max: 280, fraction: 0.25, natural: 267, rule: 'ceil(800 * 0.25 / 0.75) = 267' },
@@ -401,6 +407,8 @@ export interface SplitViewMeasureVector {
  *
  * This is the container minimum neither renderer had — which is why in both of them
  * the content pane shrinks to nothing instead of the window refusing to get narrower.
+ *
+ * CORE-ONLY: the container minimum lands as `min-width: min-content` on the content pane, which is CSS’s own spelling of the same rule — there is no computed number of ours to compare. Asserted in the renderer as "the pane is not crushable" instead
  */
 export const SPLIT_VIEW_MEASURE_VECTORS: ReadonlyArray<SplitViewMeasureVector> = [
     {
@@ -690,7 +698,9 @@ export interface TagsConflictVector {
     rule: string;
 }
 
-/** `tags_equal` (adw-navigation-split-view.c:413-429). */
+/** `tags_equal` (adw-navigation-split-view.c:413-429).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (the tag guard, driven through NAVIGATION_ACTION_VECTORS and the refusal tests in both renderer suites)
+ */
 export const TAGS_CONFLICT_VECTORS: ReadonlyArray<TagsConflictVector> = [
     { sidebarTag: null, contentTag: null, conflict: false, rule: 'two untagged pages never collide' },
     { sidebarTag: 'a', contentTag: null, conflict: false, rule: 'an absent tag never matches a present one' },

--- a/packages/web/adwaita-core/src/conformance/split-view.ts
+++ b/packages/web/adwaita-core/src/conformance/split-view.ts
@@ -18,8 +18,8 @@
 // Reference: refs/libadwaita/src/adw-length-unit.c
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
+import type { AdwLengthUnit } from '../length-unit.js';
 import type {
-    AdwLengthUnit,
     AdwPackType,
     AdwTextDirection,
     NavigationActionResult,

--- a/packages/web/adwaita-core/src/conformance/tab-view.ts
+++ b/packages/web/adwaita-core/src/conformance/tab-view.ts
@@ -1158,6 +1158,8 @@ export interface TabSuccessorVector {
  *
  * These are the same rules the end-to-end rows exercise, stated as pure inputs
  * so a failure names the RULE rather than the script that reached it.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (TAB_VIEW_VECTORS)
  */
 export const TAB_SUCCESSOR_VECTORS: ReadonlyArray<TabSuccessorVector> = [
     {
@@ -1264,7 +1266,9 @@ export interface TabDescendantVector {
     descendant: boolean;
 }
 
-/** `is_descendant_of` (adw-tab-view.c:1735-1742). */
+/** `is_descendant_of` (adw-tab-view.c:1735-1742).  *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (TAB_VIEW_VECTORS)
+ */
 export const TAB_DESCENDANT_VECTORS: ReadonlyArray<TabDescendantVector> = [
     {
         rule: 'a page IS its own descendant — the loop condition fails before the first step',
@@ -1486,6 +1490,8 @@ export interface TabTooltipVector {
  * `tabTooltipText` (`widgets/tab-view-state.ts`), so BOTH renderers consume
  * these rows today and neither is held to them. Both surfaces are readable from
  * their own suites, so wiring them is a loop, not new capability.
+ *
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (TAB_VIEW_VECTORS — both ports consume the derivation, which this header once denied)
  */
 export const TAB_TOOLTIP_VECTORS: ReadonlyArray<TabTooltipVector> = [
     {
@@ -1655,6 +1661,8 @@ export interface TabPageDescriptorVector {
  * (adw-tab-view.c:3021) and its tooltip twin (:3064). The icon fields do NOT
  * coerce: "no icon" is a state `tabIconState` branches on, so `null` has to
  * survive.
+ *
+ * CORE-ONLY: GAP — a descriptor normaliser neither element routes its page input through. Tracked in #1072
  */
 export const TAB_PAGE_DESCRIPTOR_VECTORS: ReadonlyArray<TabPageDescriptorVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/wrap-box.ts
+++ b/packages/web/adwaita-core/src/conformance/wrap-box.ts
@@ -1,21 +1,18 @@
-// Wrap-box conformance vectors — the narrow portable slice of Adw.WrapBox.
+// Wrap-box conformance vectors — the portable slice of Adw.WrapBox.
 //
 // WHY ONLY A SLICE
 //
-// `Adw.WrapBox` is deliberately NOT lifted into `@gjsify/adwaita-core` (ADR
-// 0004). The interesting tier is a line-breaking engine — `count_line_children`
-// walking children until the line overflows, then `box_allocate` distributing
-// the leftover — and neither renderer can be FED one: CSS flexbox breaks lines
-// itself and NativeScript's `WrapLayout` breaks them in native code. A core
-// class holding a property bag for properties neither renderer draws is the
-// over-abstraction the ADR warns about.
+// The line-BREAKING engine is deliberately not ported (ADR 0004):
+// `count_line_children` walks children until the line overflows and
+// `box_allocate` distributes the leftover, and neither renderer can be FED that
+// decision — CSS flexbox breaks lines itself and NativeScript's `FlexboxLayout`
+// breaks them in native code.
 //
-// What IS portable is the DECISION the engine makes before it measures anything:
-// given `justify`, `justify-last-line`, `align` and whether this is the final
-// line, does the leftover space go into the CHILDREN, into the GAPS, or into a
-// single offset applied to the whole line? That question is answered identically
-// on every renderer, it is answerable without a layout pass, and three of the
-// bugs in issue #1048 were wrong answers to it:
+// What IS portable is everything the engine decides BEFORE it measures: the
+// property normalisers, the DECISION about where a line's leftover space goes —
+// into the CHILDREN, into the GAPS, or into one offset applied to the whole line
+// — and the child-ORDER arithmetic. Four of the bugs in issue #1048 were wrong
+// answers to those questions:
 //
 //   - `align` was bound to `align-items` — the CROSS axis — where C applies it
 //     as a MAIN-axis offset, so `align="1"` pushed children DOWN instead of to
@@ -23,91 +20,31 @@
 //   - `justify="fill"` and `justify="spread"` both rendered as `space-between`,
 //     so `fill` grew the gaps where C grows the children;
 //   - `justify-last-line` was in `observedAttributes` and read by nothing, so
-//     the last line was ALWAYS justified — the exact opposite of the C default.
+//     the last line was ALWAYS justified — the exact opposite of the C default;
+//   - a negative spacing reached the layout and emitted a notification for a
+//     value libadwaita clamps to 0 and then early-returns on.
 //
-// The second table is the spacing normaliser: C clamps a negative spacing to 0
-// and then early-returns when nothing changed, so a negative value neither
-// reaches the layout nor emits a notification. The web port did neither.
-//
-// There is no core IMPLEMENTATION behind these rows on purpose. The browser
-// element resolves them with its own three-line gate and maps the answer onto
-// `justify-content` / `flex-grow`; the NativeScript port has nowhere to land
-// them, because NS `WrapLayout` exposes `orientation`, `itemWidth` and
-// `itemHeight` and nothing else — a resolver on that side would be a function
-// with no caller. So the SPACING table is driven by both suites and the LINE
-// table by the browser one, and the day NS grows a knob it inherits the rows
-// rather than a second reading of the C.
+// The implementation behind these rows is `@gjsify/adwaita-core`'s `wrap-box.ts`
+// and both renderers delegate to it. This header used to say the opposite — that
+// there was no core implementation "on purpose", because "the NativeScript port
+// has nowhere to land them, since NS `WrapLayout` exposes `orientation`,
+// `itemWidth` and `itemHeight` and nothing else". NativeScript also ships
+// `FlexboxLayout` (`flexDirection`, `flexWrap`, `justifyContent`, `alignItems`,
+// `alignContent`, per-child `setFlexGrow`/`setFlexShrink`), so the premise was
+// false and the LINE table was driven by one renderer for no reason.
 //
 // Reference: refs/libadwaita/src/adw-wrap-box.c
 // Reference: refs/libadwaita/src/adw-wrap-layout.c
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
-// --- Property defaults (adw-wrap-box.c) --------------------------------------
-
-/**
- * `Adw.WrapBox:child-spacing` and `:line-spacing` defaults, in px.
- *
- * Both are `g_param_spec_int (…, 0, G_MAXINT, 0, …)` — adw-wrap-box.c:285-287
- * and :393-395. The NativeScript port defaulted BOTH to 6 DIPs, so identical
- * markup was looser on a phone than in the browser.
- */
-export const ADW_WRAP_BOX_DEFAULT_SPACING = 0;
-
-/**
- * `Adw.WrapBox:align` default (adw-wrap-box.c:335-337).
- *
- * Declared `g_param_spec_float (…, 0, 1, 0, …)`, so GObject validates an
- * out-of-range value back into `[0, 1]` on set.
- */
-export const ADW_WRAP_BOX_DEFAULT_ALIGN = 0;
-
-/** `Adw.WrapBox:justify` default — `ADW_JUSTIFY_NONE` (adw-wrap-box.c:364-366). */
-export const ADW_WRAP_BOX_DEFAULT_JUSTIFY = 'none';
-
-/** `Adw.WrapBox:justify-last-line` default — `FALSE` (adw-wrap-box.c:379-381). */
-export const ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE = false;
+import type { AdwWrapBoxJustify, AdwWrapPolicy, WrapBoxLineLayout } from '../wrap-box.js';
 
 // --- The justify / align / last-line decision table --------------------------
-
-/** `AdwJustifyMode` — the three values of `Adw.WrapBox:justify`. */
-export type WrapBoxJustify = 'none' | 'fill' | 'spread';
-
-/** What a renderer has to do with a line's leftover space. */
-export interface WrapBoxLineLayout {
-    /**
-     * The justify mode that governs THIS line, after the last-line gate. It is
-     * the widget's `justify` for every line except the final one, and for the
-     * final one only when `justify-last-line` is set
-     * (adw-wrap-layout.c:397-400, :705-706).
-     */
-    justify: WrapBoxJustify;
-    /**
-     * Whether the CHILDREN absorb the leftover (`allocated_size` grows to
-     * `available_size`, adw-wrap-layout.c:336-341). CSS: `flex-grow` on the
-     * items.
-     */
-    growChildren: boolean;
-    /**
-     * Whether the GAPS absorb the leftover — children keep `minimum_size` and
-     * are spread apart by `size_delta` (adw-wrap-layout.c:338-339, :752-757).
-     * CSS: `justify-content: space-between`.
-     */
-    growGaps: boolean;
-    /**
-     * The MAIN-axis offset factor applied to the whole line block when nothing
-     * grows: `widget_offset += roundf (length_delta * align)`
-     * (adw-wrap-layout.c:717-725). 0 packs the line at the start of the main
-     * axis, 1 at its end. Meaningless — and reported as 0 — as soon as the line
-     * is justified, because C only computes `length_delta` inside
-     * `if (!justify_line)`.
-     */
-    align: number;
-}
 
 /** One row of the decision table. */
 export interface WrapBoxLineVector {
     /** The widget's `justify` property. */
-    justify: WrapBoxJustify;
+    justify: AdwWrapBoxJustify;
     /** The widget's `justify-last-line` property. */
     justifyLastLine: boolean;
     /** The widget's `align` property, already validated into `[0, 1]`. */
@@ -361,4 +298,277 @@ export const WRAP_BOX_SPACING_NOTIFY_VECTORS: ReadonlyArray<WrapBoxSpacingNotify
     { from: 6, value: -5, notifies: true, rule: 'clamped to 0, which IS a change from 6' },
     { from: 0, value: 'abc', notifies: false, rule: 'garbage normalises to the value already held' },
     { from: 6, value: '', notifies: true, rule: 'clearing the property falls back to the default 0' },
+];
+
+// --- The property roster -------------------------------------------------------
+
+/**
+ * Every `notify::` an `Adw.WrapBox` emits — the thirteen installed pspecs
+ * (adw-wrap-box.c:284-495) plus the overridden `orientation` (:497).
+ *
+ * The count is the assertion. C notifies on all fourteen; the browser port
+ * notified on TWO (`child-spacing`, `line-spacing`) and the NativeScript port on
+ * none, so a consumer binding to any other property was watching a signal that
+ * could not fire. A roster is the only shape that fails when a property is ADDED
+ * without its notification, which is how the first twelve went missing.
+ */
+export const WRAP_BOX_NOTIFY_PROPERTIES: readonly string[] = [
+    'child-spacing',
+    'child-spacing-unit',
+    'pack-direction',
+    'align',
+    'justify',
+    'justify-last-line',
+    'line-spacing',
+    'line-spacing-unit',
+    'line-homogeneous',
+    'natural-line-length',
+    'natural-line-length-unit',
+    'wrap-reverse',
+    'wrap-policy',
+    'orientation',
+];
+
+// --- wrap-policy ---------------------------------------------------------------
+
+/** One `wrap-policy` → child-shrink expectation. */
+export interface WrapBoxPolicyVector {
+    /** The authored value. Anything not in the enum leaves the property at its default. */
+    value: unknown;
+    /** The stored policy. */
+    policy: AdwWrapPolicy;
+    /** The `flex-shrink` a child gets — `FlexboxLayout.setFlexShrink` on NativeScript. */
+    flexShrink: number;
+    /** The rule this row pins down. */
+    rule: string;
+}
+
+/**
+ * `Adw.WrapBox:wrap-policy` (adw-wrap-box.c:476-495).
+ *
+ * The default is `natural`, which is the RESTRICTIVE one: a line wraps as soon
+ * as the next child would not fit at its natural size. `minimum` packs harder by
+ * squeezing children down to their minimum first. Both renderers had neither, so
+ * they inherited whatever their flex container defaults to — and CSS defaults
+ * `flex-shrink` to 1, i.e. to `minimum`, the value libadwaita does NOT default to.
+ */
+export const WRAP_BOX_POLICY_VECTORS: ReadonlyArray<WrapBoxPolicyVector> = [
+    { value: null, policy: 'natural', flexShrink: 0, rule: 'the default is natural — wrap before shrinking' },
+    {
+        value: 'natural',
+        policy: 'natural',
+        flexShrink: 0,
+        rule: 'natural forbids the shrink CSS would otherwise allow by default',
+    },
+    { value: 'minimum', policy: 'minimum', flexShrink: 1, rule: 'minimum squeezes children before wrapping' },
+    { value: 'Minimum', policy: 'natural', flexShrink: 0, rule: 'the enum gate is case-sensitive, as GObject is' },
+    { value: 'shrink', policy: 'natural', flexShrink: 0, rule: 'an unknown value leaves the property at its default' },
+];
+
+// --- Length units --------------------------------------------------------------
+
+/** One length-unit conversion expectation. */
+export interface WrapBoxLengthVector {
+    /** The property value, in `unit`. */
+    value: number;
+    /** The authored unit. Anything outside the enum falls back to the `px` default. */
+    unit: unknown;
+    /** The `gtk-xft-dpi` the renderer reports. */
+    dpi: number;
+    /** The resolved pixel length. */
+    px: number;
+    /** The rule this row pins down. */
+    rule: string;
+}
+
+/**
+ * `adw_length_unit_to_px` as the three wrap-box length properties reach it
+ * (adw-wrap-layout.c:554-565, :798-804).
+ *
+ * The wrap box defaults its units to `px` where the split views default to `sp`
+ * (adw-wrap-box.c:300-305) — the same helper, two different defaults, which is
+ * why the fallback is the caller's argument and not the helper's.
+ */
+export const WRAP_BOX_LENGTH_VECTORS: ReadonlyArray<WrapBoxLengthVector> = [
+    { value: 12, unit: 'px', dpi: 96, px: 12, rule: 'px is a passthrough at any dpi' },
+    {
+        value: 12,
+        unit: 'px',
+        dpi: 144,
+        px: 12,
+        rule: 'and stays one when the text scale changes — that is the point of px',
+    },
+    { value: 12, unit: 'sp', dpi: 96, px: 12, rule: 'sp is a passthrough at the default dpi' },
+    { value: 12, unit: 'sp', dpi: 144, px: 18, rule: 'sp scales with gtk-xft-dpi — 12 * 144 / 96' },
+    { value: 12, unit: 'pt', dpi: 96, px: 16, rule: 'pt is the familiar 4/3 ratio at 96 dpi' },
+    { value: 0, unit: 'pt', dpi: 144, px: 0, rule: 'zero converts to zero in every unit' },
+    { value: 12, unit: 'em', dpi: 96, px: 12, rule: 'an unknown unit falls back to the wrap box default, px' },
+    { value: 12, unit: null, dpi: 96, px: 12, rule: 'an absent unit is the default too' },
+    {
+        value: -1,
+        unit: 'sp',
+        dpi: 144,
+        px: -1,
+        rule: 'the natural-line-length sentinel is NOT converted (adw-wrap-layout.c:562 gates on >= 0)',
+    },
+];
+
+/** One `natural-line-length` normalisation expectation. */
+export interface WrapBoxNaturalLengthVector {
+    /** The authored value. */
+    value: unknown;
+    /** The stored length, `-1` when unset. */
+    length: number;
+    /** The rule this row pins down. */
+    rule: string;
+}
+
+/**
+ * `Adw.WrapBox:natural-line-length` — `g_param_spec_int (…, -1, G_MAXINT, -1, …)`
+ * (adw-wrap-box.c:438-441).
+ *
+ * `-1` means UNSET, not "zero length", so it is the landing place for everything
+ * out of range: a GObject setter would have refused those and left the property
+ * where it was, and unset is where it was born.
+ */
+export const WRAP_BOX_NATURAL_LENGTH_VECTORS: ReadonlyArray<WrapBoxNaturalLengthVector> = [
+    { value: null, length: -1, rule: 'absent means unset — the box asks for what its children need' },
+    { value: -1, length: -1, rule: 'the sentinel itself' },
+    { value: 0, length: 0, rule: 'zero is IN range and is not the sentinel — a box that asks for nothing' },
+    { value: 400, length: 400, rule: 'a plain length passes through' },
+    { value: '400', length: 400, rule: 'a numeric string parses (HTML attribute / XML layout)' },
+    { value: 400.7, length: 400, rule: 'the property is an int, so a fraction truncates' },
+    { value: -5, length: -1, rule: 'below the declared minimum lands on unset, not on 0' },
+    { value: 'wide', length: -1, rule: 'a non-numeric value is unset — NaN must never reach a layout' },
+];
+
+// --- Child order ---------------------------------------------------------------
+
+/** One `insert_child_after` / `reorder_child_after` expectation. */
+export interface WrapBoxChildOrderVector {
+    /** Which operation is being resolved. */
+    op: 'insert-after' | 'reorder-after';
+    /** The box's children before the call. */
+    children: readonly string[];
+    /** The child being placed. */
+    child: string;
+    /** The sibling to place it after, or `null` for the FIRST position. */
+    sibling: string | null;
+    /** The children afterwards, or `null` when the call is refused. */
+    result: readonly string[] | null;
+    /** The rule this row pins down. */
+    rule: string;
+}
+
+/**
+ * `adw_wrap_box_insert_child_after` (adw-wrap-box.c:1283-1300) and
+ * `adw_wrap_box_reorder_child_after` (:1315-1332), both of which delegate to
+ * `gtk_widget_insert_after (child, self, sibling)`.
+ *
+ * The counter-intuitive rule is the NULL sibling: it inserts at the FIRST
+ * position, not the last. Reading it as "append" is the obvious misreading and a
+ * silent one — the child lands somewhere plausible. Neither renderer had any of
+ * this API, so there was nothing to misread yet, which is the good time to pin it.
+ *
+ * The refusals are the C's `g_return_if_fail`s: an insert wants the child
+ * unparented, a reorder wants it already a child, the sibling must belong to this
+ * box, and `child == sibling` is an explicit early return in both (:1297, :1329).
+ */
+export const WRAP_BOX_CHILD_ORDER_VECTORS: ReadonlyArray<WrapBoxChildOrderVector> = [
+    {
+        op: 'insert-after',
+        children: ['a', 'b', 'c'],
+        child: 'd',
+        sibling: 'b',
+        result: ['a', 'b', 'd', 'c'],
+        rule: 'insert after a middle sibling',
+    },
+    {
+        op: 'insert-after',
+        children: ['a', 'b'],
+        child: 'd',
+        sibling: 'b',
+        result: ['a', 'b', 'd'],
+        rule: 'after the last sibling is an append',
+    },
+    {
+        op: 'insert-after',
+        children: ['a', 'b'],
+        child: 'd',
+        sibling: null,
+        result: ['d', 'a', 'b'],
+        rule: 'a NULL sibling PREPENDS — gtk_widget_insert_after inserts at the first position',
+    },
+    {
+        op: 'insert-after',
+        children: [],
+        child: 'd',
+        sibling: null,
+        result: ['d'],
+        rule: 'into an empty box, where first and last coincide',
+    },
+    {
+        op: 'insert-after',
+        children: ['a', 'b'],
+        child: 'a',
+        sibling: 'b',
+        result: null,
+        rule: 'refused: the child already has a parent (:1289)',
+    },
+    {
+        op: 'insert-after',
+        children: ['a'],
+        child: 'd',
+        sibling: 'z',
+        result: null,
+        rule: 'refused: the sibling is not a child of this box (:1293)',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b', 'c'],
+        child: 'a',
+        sibling: 'c',
+        result: ['b', 'c', 'a'],
+        rule: 'moving forward removes first, so the target index is read AFTER the removal',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b', 'c'],
+        child: 'c',
+        sibling: 'a',
+        result: ['a', 'c', 'b'],
+        rule: 'and moving backward lands directly behind the sibling',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b', 'c'],
+        child: 'c',
+        sibling: null,
+        result: ['c', 'a', 'b'],
+        rule: 'a NULL sibling moves the child to the FRONT — the same rule as insert',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b'],
+        child: 'a',
+        sibling: 'a',
+        result: null,
+        rule: 'refused: child == sibling is an explicit early return (:1329)',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b'],
+        child: 'z',
+        sibling: 'a',
+        result: null,
+        rule: 'refused: reordering something that is not a child',
+    },
+    {
+        op: 'reorder-after',
+        children: ['a', 'b', 'c'],
+        child: 'b',
+        sibling: 'b',
+        result: null,
+        rule: 'the self-check runs before the membership one, so it refuses rather than no-ops',
+    },
 ];

--- a/packages/web/adwaita-core/src/easing.ts
+++ b/packages/web/adwaita-core/src/easing.ts
@@ -1,0 +1,48 @@
+// `AdwEasing` + `adw_lerp` — the interpolation vocabulary, headless (ADR 0004).
+//
+// `chrome.ts` opened with a note that `adwLerp`, `easeOutCubic` and
+// `inverseLerp` were "module-private on purpose: they belong to whichever module
+// lifts the animation family, and putting the canonical copy here would put it
+// in the wrong place". `spinner.ts` is that module, so this is that place.
+//
+// Only the curves something in this package actually uses are ported. `AdwEasing`
+// has 30 of them; porting the other 27 would be 27 functions no test drives and
+// no widget calls, which is the shape ADR 0004 exists to prevent.
+//
+// Reference: refs/libadwaita/src/adw-animation-util.c (adw_lerp)
+// Reference: refs/libadwaita/src/adw-easing.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+/** `adw_lerp` (adw-animation-util.c:23-27) — `a * (1 - t) + b * t`. */
+export function adwLerp(a: number, b: number, t: number): number {
+    return a * (1 - t) + b * t;
+}
+
+/**
+ * The inverse: where `r` sits between `a` and `b`, as a 0..1 fraction.
+ *
+ * Not a libadwaita function — C writes the division inline — but it is the same
+ * expression at every call site, and naming it is what keeps the two directions
+ * from drifting apart.
+ */
+export function inverseLerp(a: number, b: number, r: number): number {
+    return (r - a) / (b - a);
+}
+
+/** `ease_out_cubic` (adw-easing.c) — `(t - 1)^3 + 1`. */
+export function easeOutCubic(t: number): number {
+    const p = t - 1;
+    return p * p * p + 1;
+}
+
+/**
+ * `ease_in_out_sine` (adw-easing.c:276-281) — `-0.5 * (cos(pi * t) - 1)`, with
+ * the duration argument at its only used value, 1.
+ *
+ * This is the curve the spinner's arc breathes on, at BOTH ends: `get_arc_start`
+ * eases the extend phase and `get_arc_end` the contract phase
+ * (adw-spinner-paintable.c:121, :141).
+ */
+export function easeInOutSine(t: number): number {
+    return -0.5 * (Math.cos(Math.PI * t) - 1);
+}

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -287,10 +287,13 @@ export type {
     PasswordEntryRowStateListener,
 } from './entry-row.js';
 
+// --- Length units (AdwLengthUnit — split views, wrap box, clamp) ---
+export { ADW_LENGTH_UNITS, DEFAULT_DPI, adwLengthToPx, normalizeLengthUnit } from './length-unit.js';
+export type { AdwLengthUnit } from './length-unit.js';
+
 // --- Split views (Adw.NavigationSplitView / Adw.OverlaySplitView) ---
 export {
     ADW_SWIPE_BORDER,
-    DEFAULT_DPI,
     DEFAULT_MAX_SIDEBAR_WIDTH,
     DEFAULT_MIN_SIDEBAR_WIDTH,
     DEFAULT_SIDEBAR_WIDTH_FRACTION,
@@ -299,7 +302,6 @@ export {
     NAVIGATION_SPLIT_VIEW_CRITICALS,
     NavigationSplitViewState,
     OverlaySplitViewState,
-    adwLengthToPx,
     isSidebarAtVisualStart,
     layoutNavigationSplitView,
     layoutOverlaySplitView,
@@ -318,7 +320,6 @@ export {
     tagsConflict,
 } from './split-view.js';
 export type {
-    AdwLengthUnit,
     AdwPackType,
     AdwTextDirection,
     NavigationActionInput,
@@ -564,3 +565,37 @@ export type {
     PopoverStateChange,
     PopoverStateListener,
 } from './popover.js';
+
+// --- Wrap box (Adw.WrapBox line decision, properties, child order) ---
+export {
+    ADW_WRAP_BOX_DEFAULT_ALIGN,
+    ADW_WRAP_BOX_DEFAULT_JUSTIFY,
+    ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE,
+    ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT,
+    ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION,
+    ADW_WRAP_BOX_DEFAULT_SPACING,
+    ADW_WRAP_BOX_DEFAULT_WRAP_POLICY,
+    ADW_WRAP_BOX_JUSTIFY_MODES,
+    ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET,
+    ADW_WRAP_BOX_PACK_DIRECTIONS,
+    ADW_WRAP_POLICIES,
+    normalizeNaturalLineLength,
+    normalizeWrapBoxAlign,
+    normalizeWrapBoxJustify,
+    normalizeWrapBoxLengthUnit,
+    normalizeWrapBoxPackDirection,
+    normalizeWrapBoxSpacing,
+    normalizeWrapPolicy,
+    resolveWrapBoxChildOrder,
+    resolveWrapBoxLine,
+    wrapBoxLengthToPx,
+    wrapPolicyFlexShrink,
+} from './wrap-box.js';
+export type {
+    AdwWrapBoxJustify,
+    AdwWrapBoxOrientation,
+    AdwWrapBoxPackDirection,
+    AdwWrapPolicy,
+    WrapBoxChildOrderOp,
+    WrapBoxLineLayout,
+} from './wrap-box.js';

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -294,6 +294,32 @@ export type {
     PasswordEntryRowStateListener,
 } from './entry-row.js';
 
+// --- Interpolation + easing (adw_lerp, AdwEasing) ---
+export { adwLerp, easeInOutSine, easeOutCubic, inverseLerp } from './easing.js';
+
+// --- Adw.Spinner animation (AdwSpinnerPaintable's breathing arc) ---
+export {
+    ADW_SPINNER_CYCLES_PER_LOOP,
+    ADW_SPINNER_CYCLE_LENGTH,
+    ADW_SPINNER_CONTRACT_DISTANCE,
+    ADW_SPINNER_EXTEND_DISTANCE,
+    ADW_SPINNER_IDLE_DISTANCE,
+    ADW_SPINNER_MAX_ARC_LENGTH,
+    ADW_SPINNER_MIN_ARC_LENGTH,
+    ADW_SPINNER_N_CYCLES,
+    ADW_SPINNER_OVERLAP_DISTANCE,
+    ADW_SPINNER_SPIN_DURATION_MS,
+    ADW_SPINNER_START_ANGLE,
+    ADW_SPINNER_STILL_PROGRESS,
+    ADW_SPINNER_TRACK_OPACITY,
+    normalizeSpinnerAngle,
+    spinnerArc,
+    spinnerArcEnd,
+    spinnerArcStart,
+    spinnerProgressAt,
+} from './spinner.js';
+export type { SpinnerArc } from './spinner.js';
+
 // --- Length units (AdwLengthUnit — split views, wrap box, clamp) ---
 export { ADW_LENGTH_UNITS, DEFAULT_DPI, adwLengthToPx, normalizeLengthUnit } from './length-unit.js';
 export type { AdwLengthUnit } from './length-unit.js';

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -199,7 +199,14 @@ export type {
 } from './dialog.js';
 
 // --- Row interaction state machines (Adw.ExpanderRow/ComboRow/SpinRow/ToggleGroup) ---
-export { ComboState, ExpanderState, SpinState, ToggleGroupState, normalizeComboOptions } from './rows.js';
+export {
+    ADW_COMBO_NO_SELECTION,
+    ComboState,
+    ExpanderState,
+    SpinState,
+    ToggleGroupState,
+    normalizeComboOptions,
+} from './rows.js';
 export type {
     AdwComboOption,
     AdwComboOptionInput,

--- a/packages/web/adwaita-core/src/length-unit.ts
+++ b/packages/web/adwaita-core/src/length-unit.ts
@@ -1,0 +1,52 @@
+// `AdwLengthUnit` — the scale-aware length vocabulary, headless (ADR 0004).
+//
+// libadwaita gives it its own compilation unit because three unrelated widget
+// families write lengths in it: the split views' `sidebar-width-unit`, the wrap
+// box's `child-spacing-unit` / `line-spacing-unit` /
+// `natural-line-length-unit`, and `AdwClamp`'s `unit`. It lives in its own
+// module here for the same reason — it arrived inside `split-view.ts`, and the
+// second consumer is where a shared helper gets lifted rather than imported
+// across a boundary that means nothing to it.
+//
+// Reference: refs/libadwaita/src/adw-length-unit.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+/** `AdwLengthUnit` — the unit a scale-aware length is written in. */
+export type AdwLengthUnit = 'px' | 'pt' | 'sp';
+
+/** The three units, for validating an attribute against the C enum. */
+export const ADW_LENGTH_UNITS: readonly AdwLengthUnit[] = ['px', 'pt', 'sp'];
+
+/** The dpi `adw_length_unit_to_px` falls back to when `gtk-xft-dpi` is unset. */
+export const DEFAULT_DPI = 96;
+
+/**
+ * `adw_length_unit_to_px` (adw-length-unit.c:57-82) — convert `value` to pixels.
+ *
+ * `pt` and `sp` both scale with the text-scale factor, which GTK reads from
+ * `gtk-xft-dpi`; a renderer that has no such setting passes the default 96, where
+ * `sp` is a pixel passthrough and `pt` is the familiar 4/3 ratio.
+ */
+export function adwLengthToPx(unit: AdwLengthUnit, value: number, dpi: number = DEFAULT_DPI): number {
+    switch (unit) {
+        case 'pt':
+            return (value * dpi) / 72;
+        case 'sp':
+            return (value * dpi) / 96;
+        default:
+            return value;
+    }
+}
+
+/**
+ * An authored unit → the enum value, or the caller's default.
+ *
+ * A GObject enum property REJECTS an out-of-range value and keeps what it had;
+ * a renderer reading an HTML attribute or an XML layout has no such gate, so the
+ * unusable value has to land somewhere deliberate. `fallback` is the property's
+ * own default, which differs between the widgets that use this vocabulary — the
+ * split views default to `sp`, the wrap box to `px`.
+ */
+export function normalizeLengthUnit(value: unknown, fallback: AdwLengthUnit): AdwLengthUnit {
+    return ADW_LENGTH_UNITS.includes(value as AdwLengthUnit) ? (value as AdwLengthUnit) : fallback;
+}

--- a/packages/web/adwaita-core/src/rows.spec.ts
+++ b/packages/web/adwaita-core/src/rows.spec.ts
@@ -11,9 +11,16 @@
 
 import { describe, it, expect } from '@gjsify/unit';
 
-import { ComboState, ExpanderState, SpinState, ToggleGroupState, normalizeComboOptions } from './rows.js';
+import {
+    ADW_COMBO_NO_SELECTION,
+    ComboState,
+    ExpanderState,
+    SpinState,
+    ToggleGroupState,
+    normalizeComboOptions,
+} from './rows.js';
 import type { ComboStateChange, SpinStateChange, ToggleGroupStateChange } from './rows.js';
-import { COMBO_SELECTION_VECTORS } from './conformance/rows.js';
+import { COMBO_CHOOSER_VECTORS, COMBO_SELECTION_VECTORS } from './conformance/rows.js';
 import type { ComboSelectionStep } from './conformance/rows.js';
 
 /** Replay one combo vector step against a headless combo state. */
@@ -131,7 +138,17 @@ export default async () => {
             expect(state.count).toBe(0);
             expect(state.selectedValue).toBe('');
             expect(state.select(0)).toBe(false); // nothing to interactively pick
-            expect(state.selectedIndex).toBe(0);
+            // GTK_INVALID_LIST_POSITION, not index 0: an empty model and a model
+            // whose first label is empty used to be the same state.
+            expect(state.selectedIndex).toBe(ADW_COMBO_NO_SELECTION);
+        });
+
+        await it('presentsChooser follows model_changed — one option is not a choice', () => {
+            const state = new ComboState();
+            for (const { count, presentsChooser, rule } of COMBO_CHOOSER_VECTORS) {
+                state.setOptions(Array.from({ length: count }, (_, i) => ({ label: `L${i}`, value: `v${i}` })));
+                expect(state.presentsChooser, rule).toBe(presentsChooser);
+            }
         });
 
         await it('setSelectedIndex returns whether it changed', () => {

--- a/packages/web/adwaita-core/src/rows.ts
+++ b/packages/web/adwaita-core/src/rows.ts
@@ -130,9 +130,25 @@ export function normalizeComboOptions(raw: ReadonlyArray<AdwComboOptionInput> | 
     });
 }
 
+/**
+ * The "no item is selected" index — the TS mirror of `GTK_INVALID_LIST_POSITION`
+ * (`AdwComboRow:selected`'s default and empty value, adw-combo-row.c:593-596,
+ * :809-810).
+ *
+ * libadwaita spells it `G_MAXUINT` because the property is a `guint`; `-1` is the
+ * idiomatic TS sentinel and the spelling {@link ADW_SIDEBAR_NO_SELECTION} already
+ * uses for the same GTK constant.
+ *
+ * It exists because an EMPTY model and a model whose first item happens to have
+ * an empty label were previously indistinguishable: both reported index 0 with
+ * `selectedValue === ''`. A renderer that wants to draw a placeholder had nothing
+ * to test.
+ */
+export const ADW_COMBO_NO_SELECTION = -1;
+
 /** Payload of a {@link ComboState} change. */
 export interface ComboStateChange {
-    /** The (new) selected index. */
+    /** The (new) selected index, or {@link ADW_COMBO_NO_SELECTION}. */
     selected: number;
     /** The selected option's `value` (or `''` when out of range). */
     value: string;
@@ -191,20 +207,51 @@ export class ComboState {
     }
 
     /**
-     * Replace the options. Resets the selection to 0 when the current index no
-     * longer fits (mirroring `Adw.ComboRow`), then notifies (`interactive: false`)
-     * so the renderer re-syncs the inline value label (the label may change even at
-     * the same index).
+     * Replace the options, then notify (`interactive: false`) so the renderer
+     * re-syncs the inline value label — which may change even at an unchanged
+     * index, because the label is read out of the MODEL.
+     *
+     * Replacing the model re-runs autoselect, so an index the new one does not
+     * have falls back to 0 — including the sentinel, which is how a row recovers
+     * a selection when its model grows. An EMPTY model has no 0 to fall back to
+     * and lands on {@link ADW_COMBO_NO_SELECTION}; that case is the one both
+     * ports used to spell as index 0.
+     *
+     * The check is `hasIndex`, not `selected >= length`: the sentinel is BELOW
+     * the range, so the one-sided comparison left a `-1` in place and a model
+     * that had been emptied and refilled came back with nothing selected.
      */
     setOptions(options: AdwComboOption[]): void {
         this._options = Array.isArray(options) ? options : [];
-        if (this._selected >= this._options.length) this._selected = 0;
+        if (!this.hasIndex(this._selected)) {
+            this._selected = this._options.length === 0 ? ADW_COMBO_NO_SELECTION : 0;
+        }
         this._emit(false);
     }
 
-    /** The selected option index (may sit past the options length — {@link selectedValue} then is `''`). */
+    /**
+     * The selected option index, or {@link ADW_COMBO_NO_SELECTION}.
+     *
+     * May also sit PAST the options length: {@link setSelectedIndex} is
+     * deliberately permissive, mirroring a `guint` property that takes any
+     * position. {@link selectedValue} reads `''` in both cases, which is why the
+     * sentinel is what distinguishes "nothing selected" from "an empty label".
+     */
     get selectedIndex(): number {
         return this._selected;
+    }
+
+    /**
+     * Whether the row presents itself as a CHOOSER — `model_changed`
+     * (adw-combo-row.c:187-195) makes the arrow visible and the row activatable
+     * on `n_items > 1` and hides both otherwise.
+     *
+     * One item or none is not a choice, so `Adw.ComboRow` stops looking like one:
+     * no chevron, and tapping does nothing. Neither port did this, so a
+     * single-option row showed its arrow and opened a chooser with one entry.
+     */
+    get presentsChooser(): boolean {
+        return this._options.length > 1;
     }
 
     /** Programmatic index set — notifies `interactive: false`. Returns whether it changed. */

--- a/packages/web/adwaita-core/src/spinner.spec.ts
+++ b/packages/web/adwaita-core/src/spinner.spec.ts
@@ -1,0 +1,180 @@
+// Spinner animation specs — the arithmetic both renderers draw from.
+//
+// Written against PROPERTIES of the curve rather than against copied radians: a
+// vector that restates `adwLerp(MIN, MAX, easeInOutSine(t)) - drift` would be the
+// same reading as the implementation and could only catch a typo. What is worth
+// asserting is what the C's constants were CHOSEN to make true — the arc never
+// leaves its declared range, the animation loops without a jump, the resting
+// pose is the documented one — because those are the things a port gets wrong.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { adwLerp, easeInOutSine, easeOutCubic, inverseLerp } from './easing.js';
+import {
+    ADW_SPINNER_CYCLE_LENGTH,
+    ADW_SPINNER_CYCLES_PER_LOOP,
+    ADW_SPINNER_MAX_ARC_LENGTH,
+    ADW_SPINNER_MIN_ARC_LENGTH,
+    ADW_SPINNER_N_CYCLES,
+    ADW_SPINNER_SPIN_DURATION_MS,
+    ADW_SPINNER_START_ANGLE,
+    ADW_SPINNER_STILL_PROGRESS,
+    ADW_SPINNER_TRACK_OPACITY,
+    normalizeSpinnerAngle,
+    spinnerArc,
+    spinnerProgressAt,
+} from './spinner.js';
+import { ADW_SPINNER_MIN_SIZE } from './chrome.js';
+import {
+    SPINNER_ARC_ENVELOPE,
+    SPINNER_ARC_PHASE_VECTORS,
+    SPINNER_ARC_TOLERANCE,
+    SPINNER_CONSTANT_VECTORS,
+} from './conformance/spinner.js';
+
+/** The constants by their C name, so a vector row can look one up. */
+const CONSTANTS: Record<string, number> = {
+    SPIN_DURATION_MS: ADW_SPINNER_SPIN_DURATION_MS,
+    START_ANGLE: ADW_SPINNER_START_ANGLE,
+    CIRCLE_OPACITY: ADW_SPINNER_TRACK_OPACITY,
+    MIN_ARC_LENGTH: ADW_SPINNER_MIN_ARC_LENGTH,
+    MAX_ARC_LENGTH: ADW_SPINNER_MAX_ARC_LENGTH,
+    N_CYCLES: ADW_SPINNER_N_CYCLES,
+    MIN_SIZE: ADW_SPINNER_MIN_SIZE,
+};
+
+export default async () => {
+    await describe('easing (adw_lerp, AdwEasing)', async () => {
+        await it('adwLerp and inverseLerp invert each other', () => {
+            expect(adwLerp(10, 20, 0)).toBe(10);
+            expect(adwLerp(10, 20, 1)).toBe(20);
+            expect(adwLerp(10, 20, 0.25)).toBe(12.5);
+            expect(inverseLerp(10, 20, 12.5)).toBe(0.25);
+        });
+
+        await it('easeOutCubic is the clamp layout curve, pinned at its ends', () => {
+            expect(easeOutCubic(0)).toBe(0);
+            expect(easeOutCubic(1)).toBe(1);
+            // Its whole point is that it is fast first: half the time, most of
+            // the distance.
+            expect(easeOutCubic(0.5)).toBeGreaterThan(0.8);
+        });
+
+        await it('easeInOutSine is -0.5 * (cos(pi t) - 1), symmetric about 0.5', () => {
+            expect(easeInOutSine(0)).toBe(0);
+            expect(Math.abs(easeInOutSine(0.5) - 0.5)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+            expect(Math.abs(easeInOutSine(1) - 1)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+            for (const t of [0.1, 0.25, 0.4]) {
+                expect(Math.abs(easeInOutSine(t) + easeInOutSine(1 - t) - 1)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+            }
+        });
+    });
+
+    await describe('spinner constants (the #defines, five of which a port got wrong)', async () => {
+        for (const { name, value, rule } of SPINNER_CONSTANT_VECTORS) {
+            await it(`${name} = ${value} — ${rule}`, () => {
+                expect(CONSTANTS[name]).toBe(value);
+            });
+        }
+
+        await it('the cycle length is IDLE + EXTEND + CONTRACT - OVERLAP', () => {
+            expect(Math.abs(ADW_SPINNER_CYCLE_LENGTH - Math.PI * 2.65)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+        });
+
+        await it('N_CYCLES satisfies the constraint the C states in a comment', () => {
+            // "(IDLE + EXTEND + CONTRACT - OVERLAP) * k, where k is an integer"
+            // — 53 turns is exactly 40 arc cycles, which is why the loop can
+            // restart without the arc jumping.
+            expect(Math.abs(ADW_SPINNER_CYCLES_PER_LOOP - 40)).toBeLessThan(1e-9);
+            expect(Math.abs(ADW_SPINNER_CYCLES_PER_LOOP - Math.round(ADW_SPINNER_CYCLES_PER_LOOP))).toBeLessThan(1e-9);
+        });
+
+        await it('the still pose is pi * 0.75 (adw-spinner-paintable.c:375-376)', () => {
+            expect(Math.abs(ADW_SPINNER_STILL_PROGRESS - Math.PI * 0.75)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+        });
+    });
+
+    await describe('normalizeSpinnerAngle (the C loops, it does not modulo)', async () => {
+        await it('folds into [0, 2pi]', () => {
+            expect(normalizeSpinnerAngle(0)).toBe(0);
+            expect(Math.abs(normalizeSpinnerAngle(Math.PI * 3) - Math.PI)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+            expect(Math.abs(normalizeSpinnerAngle(-Math.PI * 0.5) - Math.PI * 1.5)).toBeLessThan(SPINNER_ARC_TOLERANCE);
+        });
+
+        await it('leaves EXACTLY 2pi alone — the loop tests `> 2pi`, a modulo would give 0', () => {
+            expect(normalizeSpinnerAngle(Math.PI * 2)).toBe(Math.PI * 2);
+        });
+    });
+
+    await describe('spinnerArc (the breathing arc, not a rotating quarter-circle)', async () => {
+        for (const { phase, rule } of SPINNER_ARC_PHASE_VECTORS) {
+            await it(`phase ${phase} — ${rule}`, () => {
+                const { start, end, length } = spinnerArc(phase * ADW_SPINNER_CYCLE_LENGTH);
+                // Both ends are on the circle, and the drawn segment is a real
+                // arc rather than a degenerate point.
+                expect(start).toBeGreaterThanOrEqual(0);
+                expect(start).toBeLessThanOrEqual(Math.PI * 2);
+                expect(end).toBeGreaterThanOrEqual(0);
+                expect(end).toBeLessThanOrEqual(Math.PI * 2);
+                expect(length).toBeGreaterThan(0);
+                expect(length).toBeLessThanOrEqual(Math.PI * 2);
+            });
+        }
+
+        await it('BREATHES between 2.7 and 102.8 degrees — the drawn envelope, not the constants', () => {
+            // The browser port drew a FIXED 90 degrees, i.e. an envelope of one
+            // value. And the upper end is NOT `MAX_ARC_LENGTH`: both arc ends
+            // lerp towards it and then subtract the same drift term, so 162
+            // degrees is the lerp target and 102.8 is what reaches the screen.
+            const lengths: number[] = [];
+            for (let i = 0; i < 20_000; i++) lengths.push(spinnerArc((i / 20_000) * ADW_SPINNER_CYCLE_LENGTH).length);
+            expect(Math.abs(Math.min(...lengths) - SPINNER_ARC_ENVELOPE.min)).toBeLessThan(
+                SPINNER_ARC_ENVELOPE.tolerance,
+            );
+            expect(Math.abs(Math.max(...lengths) - SPINNER_ARC_ENVELOPE.max)).toBeLessThan(
+                SPINNER_ARC_ENVELOPE.tolerance,
+            );
+        });
+
+        await it('never leaves that envelope over a whole LOOP, not just one cycle', () => {
+            // Sampled across the loop: if the cycle length were wrong, the two
+            // would disagree here and nowhere else.
+            for (let i = 0; i < 4000; i++) {
+                const { length } = spinnerArc((i / 4000) * ADW_SPINNER_N_CYCLES * Math.PI * 2);
+                expect(length).toBeGreaterThanOrEqual(ADW_SPINNER_MIN_ARC_LENGTH - 1e-6);
+                expect(length).toBeLessThanOrEqual(SPINNER_ARC_ENVELOPE.max + 1e-4);
+            }
+        });
+
+        await it('carries START_ANGLE, which neither port had', () => {
+            // At progress 0 the arc's trailing end is MIN_ARC_LENGTH past the
+            // start angle, so the whole figure is rotated rather than beginning
+            // at 3 o'clock.
+            const { start } = spinnerArc(0);
+            expect(Math.abs(start - (ADW_SPINNER_START_ANGLE + ADW_SPINNER_MIN_ARC_LENGTH))).toBeLessThan(1e-9);
+        });
+    });
+
+    await describe('spinnerProgressAt (a linear ramp, repeating without a jump)', async () => {
+        await it('one full turn per SPIN_DURATION_MS', () => {
+            expect(spinnerProgressAt(0)).toBe(0);
+            expect(Math.abs(spinnerProgressAt(ADW_SPINNER_SPIN_DURATION_MS) - Math.PI * 2)).toBeLessThan(1e-9);
+            expect(Math.abs(spinnerProgressAt(ADW_SPINNER_SPIN_DURATION_MS / 2) - Math.PI)).toBeLessThan(1e-9);
+        });
+
+        await it('the loop boundary draws the same arc as the start — that is what N_CYCLES buys', () => {
+            const loopMs = ADW_SPINNER_SPIN_DURATION_MS * ADW_SPINNER_N_CYCLES;
+            const atStart = spinnerArc(spinnerProgressAt(0));
+            const justBefore = spinnerArc(spinnerProgressAt(loopMs - 1e-6));
+            expect(Math.abs(justBefore.length - atStart.length)).toBeLessThan(1e-3);
+        });
+
+        await it('a negative elapsed time is still on the ramp, not off it', () => {
+            // Clocks can hand back a negative delta across a suspend; the C's
+            // frame clock never does, but a renderer's `performance.now()` origin
+            // can move, and a NaN reaching an SVG attribute is a blank spinner.
+            expect(Number.isFinite(spinnerProgressAt(-1))).toBe(true);
+            expect(spinnerProgressAt(-1)).toBeGreaterThanOrEqual(0);
+        });
+    });
+};

--- a/packages/web/adwaita-core/src/spinner.ts
+++ b/packages/web/adwaita-core/src/spinner.ts
@@ -1,0 +1,196 @@
+// `Adw.Spinner` / `AdwSpinnerPaintable` — the animation, headless (ADR 0004).
+//
+// The spinner is not a rotating quarter-circle. The arc BREATHES: it extends
+// from 2.7° to 162°, overlaps, contracts, and idles, all while the whole figure
+// turns — a four-phase cycle whose length is deliberately chosen so that a whole
+// number of arc cycles fits a whole number of turns. `_spinner.scss` drew a
+// fixed 90° `border-top-color` chase at 0.8s, which is a different animation
+// with a different period, and the NativeScript port draws the platform's.
+//
+// Every number here is a `#define` in the C. They are exported rather than
+// inlined because the browser renderer needs the geometry per frame and the
+// vectors need the same numbers to judge it with — the one thing that must not
+// happen is a second reading of these constants.
+//
+// Reference: refs/libadwaita/src/adw-spinner.c
+// Reference: refs/libadwaita/src/adw-spinner-paintable.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import { adwLerp, easeInOutSine } from './easing.js';
+
+/** `SPIN_DURATION_MS` (adw-spinner-paintable.c:20) — one full turn. */
+export const ADW_SPINNER_SPIN_DURATION_MS = 1200;
+
+/**
+ * `START_ANGLE` (adw-spinner-paintable.c:21) — a fixed phase offset added to
+ * both arc ends (:379-380), so the figure does not start at 3 o'clock.
+ *
+ * Neither port had it, which is a constant rotation error rather than a wrong
+ * speed — invisible in a still frame, visible against a GTK spinner beside it.
+ */
+export const ADW_SPINNER_START_ANGLE = Math.PI * 0.35;
+
+/**
+ * `CIRCLE_OPACITY` (adw-spinner-paintable.c:22) — the track is the WIDGET's
+ * colour at 15%, not a hardcoded grey.
+ *
+ * The browser port used `rgba(127, 127, 127, 0.25)`: too dark, and
+ * hue-independent, so a spinner on a coloured background lost its track
+ * relationship entirely.
+ */
+export const ADW_SPINNER_TRACK_OPACITY = 0.15;
+
+/** `MIN_ARC_LENGTH` (:24) — GSK refuses to draw an arc shorter than this. */
+export const ADW_SPINNER_MIN_ARC_LENGTH = Math.PI * 0.015;
+
+/** `MAX_ARC_LENGTH` (:25) — the widest the arc ever gets, 162°. */
+export const ADW_SPINNER_MAX_ARC_LENGTH = Math.PI * 0.9;
+
+/** `IDLE_DISTANCE` (:26). */
+export const ADW_SPINNER_IDLE_DISTANCE = Math.PI * 0.9;
+
+/** `OVERLAP_DISTANCE` (:27). */
+export const ADW_SPINNER_OVERLAP_DISTANCE = Math.PI * 0.7;
+
+/** `EXTEND_DISTANCE` (:28). */
+export const ADW_SPINNER_EXTEND_DISTANCE = Math.PI * 1.1;
+
+/** `CONTRACT_DISTANCE` (:29). */
+export const ADW_SPINNER_CONTRACT_DISTANCE = Math.PI * 1.35;
+
+/**
+ * `N_CYCLES` (:33) — how many full TURNS the animation runs before repeating.
+ *
+ * The C states the constraint it satisfies: the cycle length
+ * `IDLE + EXTEND + CONTRACT - OVERLAP` must divide `N_CYCLES * 2pi` exactly, or
+ * the arc would jump when the animation loops. It does — 53 turns is 40 arc
+ * cycles — and {@link ADW_SPINNER_CYCLES_PER_LOOP} is that quotient, asserted
+ * rather than assumed.
+ */
+export const ADW_SPINNER_N_CYCLES = 53;
+
+/**
+ * One arc cycle, in radians of base angle:
+ * `IDLE_DISTANCE + EXTEND_DISTANCE + CONTRACT_DISTANCE - OVERLAP_DISTANCE`
+ * (adw-spinner-paintable.c:112, :130).
+ */
+export const ADW_SPINNER_CYCLE_LENGTH =
+    ADW_SPINNER_IDLE_DISTANCE +
+    ADW_SPINNER_EXTEND_DISTANCE +
+    ADW_SPINNER_CONTRACT_DISTANCE -
+    ADW_SPINNER_OVERLAP_DISTANCE;
+
+/** Whole arc cycles per animation loop — an integer, which is the C's constraint. */
+export const ADW_SPINNER_CYCLES_PER_LOOP = (ADW_SPINNER_N_CYCLES * Math.PI * 2) / ADW_SPINNER_CYCLE_LENGTH;
+
+/**
+ * The base angle a NON-animating spinner is drawn at — `EXTEND_DISTANCE -
+ * OVERLAP_DISTANCE / 2` (adw-spinner-paintable.c:375-376), i.e. `pi * 0.75`.
+ *
+ * Reached whenever there is no animation object: before the paintable has a
+ * widget, and in a still frame. Both ports left the resting pose undefined, so a
+ * spinner that had not started yet drew whatever its keyframe origin happened to
+ * be.
+ */
+export const ADW_SPINNER_STILL_PROGRESS = ADW_SPINNER_EXTEND_DISTANCE - ADW_SPINNER_OVERLAP_DISTANCE / 2;
+
+/**
+ * `normalize_angle` (adw-spinner-paintable.c:97-107) — fold into `[0, 2pi]`.
+ *
+ * The C loops rather than taking a modulo, and the boundary follows: it stops at
+ * `angle > G_PI * 2`, so exactly `2pi` is left alone where a modulo would give 0.
+ */
+export function normalizeSpinnerAngle(angle: number): number {
+    let value = angle;
+    while (value < 0) value += Math.PI * 2;
+    while (value > Math.PI * 2) value -= Math.PI * 2;
+    return value;
+}
+
+/**
+ * `get_arc_start` (adw-spinner-paintable.c:109-125) — the trailing end of the
+ * arc, relative to the base angle.
+ *
+ * The `- angle * MAX_ARC_LENGTH / l` term is the drift that makes the arc
+ * advance around the circle as it breathes; without it the figure would pulse in
+ * place.
+ */
+export function spinnerArcStart(angle: number): number {
+    const local = angle % ADW_SPINNER_CYCLE_LENGTH;
+    const t = local > ADW_SPINNER_EXTEND_DISTANCE ? 1 : easeInOutSine(local / ADW_SPINNER_EXTEND_DISTANCE);
+    return (
+        adwLerp(ADW_SPINNER_MIN_ARC_LENGTH, ADW_SPINNER_MAX_ARC_LENGTH, t) -
+        (local * ADW_SPINNER_MAX_ARC_LENGTH) / ADW_SPINNER_CYCLE_LENGTH
+    );
+}
+
+/**
+ * `get_arc_end` (adw-spinner-paintable.c:127-145) — the leading end.
+ *
+ * Its phase is offset by `EXTEND_DISTANCE - OVERLAP_DISTANCE`: the end only
+ * starts moving once the start has extended past the overlap, which is what
+ * makes the arc grow before it slides.
+ */
+export function spinnerArcEnd(angle: number): number {
+    const local = angle % ADW_SPINNER_CYCLE_LENGTH;
+    const extendMinusOverlap = ADW_SPINNER_EXTEND_DISTANCE - ADW_SPINNER_OVERLAP_DISTANCE;
+    let t: number;
+    if (local < extendMinusOverlap) t = 0;
+    else if (local > ADW_SPINNER_CYCLE_LENGTH - ADW_SPINNER_IDLE_DISTANCE) t = 1;
+    else t = easeInOutSine((local - extendMinusOverlap) / ADW_SPINNER_CONTRACT_DISTANCE);
+    return (
+        adwLerp(0, ADW_SPINNER_MAX_ARC_LENGTH - ADW_SPINNER_MIN_ARC_LENGTH, t) -
+        (local * ADW_SPINNER_MAX_ARC_LENGTH) / ADW_SPINNER_CYCLE_LENGTH
+    );
+}
+
+/** The two ends of the drawn arc, in radians clockwise from 3 o'clock. */
+export interface SpinnerArc {
+    /** Trailing end, folded into `[0, 2pi]`. */
+    start: number;
+    /** Leading end, folded into `[0, 2pi]`. */
+    end: number;
+    /**
+     * Arc length along the circle, `start - end` unwrapped into `(0, 2pi]`.
+     *
+     * The segment runs from `end` to `start` (`gsk_path_builder_add_segment
+     * (builder, circle, &end_point, &start_point)`, :395) — the naming is the C's
+     * and it is the opposite way round from what "start" suggests.
+     */
+    length: number;
+}
+
+/**
+ * The arc for a base angle — `adw_spinner_paintable_snapshot_with_weight`
+ * (adw-spinner-paintable.c:373-383).
+ *
+ * `progress` is the animation's value: 0 at the start of a loop, rising linearly
+ * to `N_CYCLES * 2pi`. A renderer that has no animation passes
+ * {@link ADW_SPINNER_STILL_PROGRESS}.
+ */
+export function spinnerArc(progress: number): SpinnerArc {
+    const base = progress;
+    const start = normalizeSpinnerAngle(base + spinnerArcStart(base) + ADW_SPINNER_START_ANGLE);
+    const end = normalizeSpinnerAngle(base + spinnerArcEnd(base) + ADW_SPINNER_START_ANGLE);
+    let length = start - end;
+    // The segment wraps whenever the trailing end has crossed 2pi and the leading
+    // one has not; a zero-length reading means a full circle, never an empty arc,
+    // because the two ends are never equal in the C's phase relationship.
+    while (length <= 0) length += Math.PI * 2;
+    return { start, end, length };
+}
+
+/**
+ * The animation's value after `elapsedMs` — `adw_timed_animation_new (widget, 0,
+ * N_CYCLES * 2pi, SPIN_DURATION_MS * N_CYCLES, target)` with `ADW_LINEAR` easing
+ * and `repeat_count = 0`, i.e. forever (adw-spinner-paintable.c:532-540).
+ *
+ * A linear ramp over the whole loop reduces to one turn per
+ * {@link ADW_SPINNER_SPIN_DURATION_MS}; the loop length only decides where it
+ * restarts, and it restarts at a point the arc phase agrees with.
+ */
+export function spinnerProgressAt(elapsedMs: number): number {
+    const loopMs = ADW_SPINNER_SPIN_DURATION_MS * ADW_SPINNER_N_CYCLES;
+    const within = ((elapsedMs % loopMs) + loopMs) % loopMs;
+    return (within / ADW_SPINNER_SPIN_DURATION_MS) * Math.PI * 2;
+}

--- a/packages/web/adwaita-core/src/spinner.ts
+++ b/packages/web/adwaita-core/src/spinner.ts
@@ -1,11 +1,16 @@
 // `Adw.Spinner` / `AdwSpinnerPaintable` — the animation, headless (ADR 0004).
 //
-// The spinner is not a rotating quarter-circle. The arc BREATHES: it extends
-// from 2.7° to 162°, overlaps, contracts, and idles, all while the whole figure
-// turns — a four-phase cycle whose length is deliberately chosen so that a whole
-// number of arc cycles fits a whole number of turns. `_spinner.scss` drew a
-// fixed 90° `border-top-color` chase at 0.8s, which is a different animation
-// with a different period, and the NativeScript port draws the platform's.
+// The spinner is not a rotating quarter-circle. The arc BREATHES: it extends,
+// overlaps, contracts and idles, all while the whole figure turns — a four-phase
+// cycle whose length is deliberately chosen so that a whole number of arc cycles
+// fits a whole number of turns. `_spinner.scss` drew a fixed 90° `border-top-color`
+// chase at 0.8s, which is a different animation with a different period, and the
+// NativeScript port draws the platform's.
+//
+// The DRAWN arc spans 2.7° to 102.8°, not to `MAX_ARC_LENGTH`'s 162°: both ends
+// lerp towards it and then subtract the same drift term, which is what advances
+// the figure. `SPINNER_ARC_ENVELOPE` in the conformance table is the measured
+// answer — reading the constant as the drawn length is the obvious mistake.
 //
 // Every number here is a `#define` in the C. They are exported rather than
 // inlined because the browser renderer needs the geometry per frame and the
@@ -43,7 +48,7 @@ export const ADW_SPINNER_TRACK_OPACITY = 0.15;
 /** `MIN_ARC_LENGTH` (:24) — GSK refuses to draw an arc shorter than this. */
 export const ADW_SPINNER_MIN_ARC_LENGTH = Math.PI * 0.015;
 
-/** `MAX_ARC_LENGTH` (:25) — the widest the arc ever gets, 162°. */
+/** `MAX_ARC_LENGTH` (:25) — the LERP TARGET, 162°. The drawn arc peaks at 102.8°. */
 export const ADW_SPINNER_MAX_ARC_LENGTH = Math.PI * 0.9;
 
 /** `IDLE_DISTANCE` (:26). */

--- a/packages/web/adwaita-core/src/split-view.spec.ts
+++ b/packages/web/adwaita-core/src/split-view.spec.ts
@@ -3,9 +3,10 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
+import { adwLengthToPx } from './length-unit.js';
+
 import {
     ADW_SWIPE_BORDER,
-    adwLengthToPx,
     INSTANT_SPLIT_VIEW_ANIMATOR,
     isSidebarAtVisualStart,
     layoutNavigationSplitView,

--- a/packages/web/adwaita-core/src/split-view.ts
+++ b/packages/web/adwaita-core/src/split-view.ts
@@ -32,20 +32,15 @@
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
 import { glibClamp } from './glib.js';
+import { type AdwLengthUnit, adwLengthToPx, DEFAULT_DPI } from './length-unit.js';
 
 // --- Units, direction, packing ---
-
-/** `AdwLengthUnit` — the unit min/max sidebar widths are written in. */
-export type AdwLengthUnit = 'px' | 'pt' | 'sp';
 
 /** `GtkPackType` — which side of the view a pane is packed on. */
 export type AdwPackType = 'start' | 'end';
 
 /** `GtkTextDirection` — the reading direction `start`/`end` are resolved against. */
 export type AdwTextDirection = 'ltr' | 'rtl';
-
-/** The dpi `adw_length_unit_to_px` falls back to when `gtk-xft-dpi` is unset. */
-export const DEFAULT_DPI = 96;
 
 /** `min-sidebar-width` default, in {@link DEFAULT_SIDEBAR_WIDTH_UNIT}. */
 export const DEFAULT_MIN_SIDEBAR_WIDTH = 180;
@@ -61,24 +56,6 @@ export const DEFAULT_SIDEBAR_WIDTH_UNIT: AdwLengthUnit = 'sp';
 
 /** The minimum grabbable edge width for the reveal gesture — `ADW_SWIPE_BORDER`. */
 export const ADW_SWIPE_BORDER = 32;
-
-/**
- * `adw_length_unit_to_px` (adw-length-unit.c:57-82) — convert `value` to pixels.
- *
- * `pt` and `sp` both scale with the text-scale factor, which GTK reads from
- * `gtk-xft-dpi`; a renderer that has no such setting passes the default 96, where
- * `sp` is a pixel passthrough and `pt` is the familiar 4/3 ratio.
- */
-export function adwLengthToPx(unit: AdwLengthUnit, value: number, dpi: number = DEFAULT_DPI): number {
-    switch (unit) {
-        case 'pt':
-            return (value * dpi) / 72;
-        case 'sp':
-            return (value * dpi) / 96;
-        default:
-            return value;
-    }
-}
 
 /**
  * GLib's `CLAMP` (gmacros.h) — `x > high ? high : x < low ? low : x`.

--- a/packages/web/adwaita-core/src/test.browser.mts
+++ b/packages/web/adwaita-core/src/test.browser.mts
@@ -32,6 +32,7 @@ import bannerTestSuite from './banner.spec.js';
 import buttonContentTestSuite from './button-content.spec.js';
 import aboutDialogTestSuite from './about-dialog.spec.js';
 import checksTestSuite from './checks.spec.js';
+import wrapBoxTestSuite from './wrap-box.spec.js';
 
 run({
     aboutDialogTestSuite,
@@ -58,4 +59,5 @@ run({
     preferencesTestSuite,
     chromeTestSuite,
     dataGridTestSuite,
+    wrapBoxTestSuite,
 });

--- a/packages/web/adwaita-core/src/test.browser.mts
+++ b/packages/web/adwaita-core/src/test.browser.mts
@@ -33,6 +33,7 @@ import buttonContentTestSuite from './button-content.spec.js';
 import aboutDialogTestSuite from './about-dialog.spec.js';
 import checksTestSuite from './checks.spec.js';
 import wrapBoxTestSuite from './wrap-box.spec.js';
+import spinnerTestSuite from './spinner.spec.js';
 
 run({
     aboutDialogTestSuite,
@@ -60,4 +61,5 @@ run({
     chromeTestSuite,
     dataGridTestSuite,
     wrapBoxTestSuite,
+    spinnerTestSuite,
 });

--- a/packages/web/adwaita-core/src/test.mts
+++ b/packages/web/adwaita-core/src/test.mts
@@ -25,6 +25,7 @@ import buttonContentTestSuite from './button-content.spec.js';
 import aboutDialogTestSuite from './about-dialog.spec.js';
 import checksTestSuite from './checks.spec.js';
 import wrapBoxTestSuite from './wrap-box.spec.js';
+import spinnerTestSuite from './spinner.spec.js';
 
 run({
     aboutDialogTestSuite,
@@ -52,4 +53,5 @@ run({
     chromeTestSuite,
     dataGridTestSuite,
     wrapBoxTestSuite,
+    spinnerTestSuite,
 });

--- a/packages/web/adwaita-core/src/test.mts
+++ b/packages/web/adwaita-core/src/test.mts
@@ -24,6 +24,7 @@ import bannerTestSuite from './banner.spec.js';
 import buttonContentTestSuite from './button-content.spec.js';
 import aboutDialogTestSuite from './about-dialog.spec.js';
 import checksTestSuite from './checks.spec.js';
+import wrapBoxTestSuite from './wrap-box.spec.js';
 
 run({
     aboutDialogTestSuite,
@@ -50,4 +51,5 @@ run({
     preferencesTestSuite,
     chromeTestSuite,
     dataGridTestSuite,
+    wrapBoxTestSuite,
 });

--- a/packages/web/adwaita-core/src/view-stack.ts
+++ b/packages/web/adwaita-core/src/view-stack.ts
@@ -59,6 +59,12 @@ export interface AdwViewStackPageSpec<T = unknown> {
     content?: T;
     /** Whether the page participates in selection at all. Defaults to `true`. */
     visible?: boolean;
+    /** `AdwViewStackPage:badge-number`. Defaults to 0 — no badge. */
+    badgeNumber?: number;
+    /** `AdwViewStackPage:needs-attention`. Defaults to `false`. */
+    needsAttention?: boolean;
+    /** `AdwViewStackPage:use-underline`. Defaults to `false`. */
+    useUnderline?: boolean;
 }
 
 /**
@@ -80,6 +86,12 @@ export interface AdwViewStackPageInfo<T = unknown> {
     readonly content: T | undefined;
     /** Whether the page can be selected — `AdwViewStackPage:visible`. */
     readonly visible: boolean;
+    /** `AdwViewStackPage:badge-number`. 0 means no badge. */
+    readonly badgeNumber: number;
+    /** `AdwViewStackPage:needs-attention` — the bare dot, with or without a badge. */
+    readonly needsAttention: boolean;
+    /** `AdwViewStackPage:use-underline` — whether the title carries a mnemonic. */
+    readonly useUnderline: boolean;
 }
 
 /** Payload of a selection change. */
@@ -112,6 +124,9 @@ interface PageRecord<T> {
     icon: string;
     content: T | undefined;
     visible: boolean;
+    badgeNumber: number;
+    needsAttention: boolean;
+    useUnderline: boolean;
 }
 
 /**
@@ -232,6 +247,12 @@ export class ViewStackState<T = unknown> {
             icon: normalizeIconName(spec.icon),
             content: spec.content,
             visible: spec.visible ?? true,
+            // The three the record used to drop, which is what made a switcher
+            // BOUND to a stack structurally unable to show a badge — and both
+            // `ViewSwitcherBar`s go through that projection.
+            badgeNumber: Number.isFinite(spec.badgeNumber) ? Math.trunc(spec.badgeNumber as number) : 0,
+            needsAttention: spec.needsAttention === true,
+            useUnderline: spec.useUnderline === true,
         };
     }
 

--- a/packages/web/adwaita-core/src/view-switcher.ts
+++ b/packages/web/adwaita-core/src/view-switcher.ts
@@ -186,12 +186,15 @@ export function createViewSwitcherPage(init: AdwViewSwitcherPageInit): AdwViewSw
  * Project a wave-1 stack page descriptor onto a switcher page, for a switcher
  * BOUND to an `Adw.ViewStack` rather than owning its own pages.
  *
- * Two fidelity notes a caller has to know, both consequences of what
- * `AdwViewStackPageInfo` carries: its `title` is already resolved against the
- * page name, so it is never `null` and the button-visibility rule reduces to the
- * `visible` flag; and it carries none of `badge-number`, `needs-attention`,
- * `use-underline`, so a bound switcher derives an empty badge and no
- * description. Only a switcher that owns its pages sees those.
+ * One fidelity note remains: `AdwViewStackPageInfo.title` is already resolved
+ * against the page name, so it is never `null` and the button-visibility rule
+ * reduces to the `visible` flag.
+ *
+ * The second one is gone. This used to say the stack page carried none of
+ * `badge-number`, `needs-attention` or `use-underline`, "so a bound switcher
+ * derives an empty badge and no description" — which made a switcher bound to a
+ * stack STRUCTURALLY unable to show a badge, and both `ViewSwitcherBar`s go
+ * through here. The stack page carries all three now.
  */
 export function viewSwitcherPageFromStackPage(page: AdwViewStackPageInfo): AdwViewSwitcherPage {
     return createViewSwitcherPage({
@@ -201,6 +204,9 @@ export function viewSwitcherPageFromStackPage(page: AdwViewStackPageInfo): AdwVi
         // `null`, which is what turns on the image-missing fallback.
         iconName: page.icon.length > 0 ? page.icon : null,
         visible: page.visible,
+        badgeNumber: page.badgeNumber,
+        needsAttention: page.needsAttention,
+        useUnderline: page.useUnderline,
     });
 }
 

--- a/packages/web/adwaita-core/src/wrap-box.spec.ts
+++ b/packages/web/adwaita-core/src/wrap-box.spec.ts
@@ -1,0 +1,178 @@
+// Wrap-box specs — driven by the shared conformance vectors, so this suite and
+// the two renderer suites assert the SAME tables.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import {
+    ADW_WRAP_BOX_DEFAULT_ALIGN,
+    ADW_WRAP_BOX_DEFAULT_JUSTIFY,
+    ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE,
+    ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT,
+    ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION,
+    ADW_WRAP_BOX_DEFAULT_SPACING,
+    ADW_WRAP_BOX_DEFAULT_WRAP_POLICY,
+    ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET,
+    normalizeNaturalLineLength,
+    normalizeWrapBoxAlign,
+    normalizeWrapBoxJustify,
+    normalizeWrapBoxLengthUnit,
+    normalizeWrapBoxPackDirection,
+    normalizeWrapBoxSpacing,
+    normalizeWrapPolicy,
+    resolveWrapBoxChildOrder,
+    resolveWrapBoxLine,
+    wrapBoxLengthToPx,
+    wrapPolicyFlexShrink,
+} from './wrap-box.js';
+import {
+    WRAP_BOX_CHILD_ORDER_VECTORS,
+    WRAP_BOX_LENGTH_VECTORS,
+    WRAP_BOX_LINE_VECTORS,
+    WRAP_BOX_NATURAL_LENGTH_VECTORS,
+    WRAP_BOX_NOTIFY_PROPERTIES,
+    WRAP_BOX_POLICY_VECTORS,
+    WRAP_BOX_SPACING_NOTIFY_VECTORS,
+    WRAP_BOX_SPACING_VECTORS,
+} from './conformance/wrap-box.js';
+
+export default async () => {
+    await describe('resolveWrapBoxLine (the justify/align/last-line decision)', async () => {
+        for (const vector of WRAP_BOX_LINE_VECTORS) {
+            const { justify, justifyLastLine, align, lastLine, childrenInLine, layout, rule } = vector;
+            const label = `${justify}${justifyLastLine ? '+last' : ''} align=${align} ${
+                lastLine ? 'last' : 'mid'
+            } line ×${childrenInLine}`;
+            await it(`${label} — ${rule}`, () => {
+                expect(resolveWrapBoxLine({ justify, justifyLastLine, align, lastLine, childrenInLine })).toStrictEqual(
+                    layout,
+                );
+            });
+        }
+
+        await it('every mode grows EITHER the children or the gaps, never both', () => {
+            const both = WRAP_BOX_LINE_VECTORS.filter((v) => v.layout.growChildren && v.layout.growGaps);
+            expect(both).toHaveLength(0);
+        });
+
+        await it('a justified line always reports align 0 — C never computes length_delta there', () => {
+            const leaked = WRAP_BOX_LINE_VECTORS.filter((v) => v.layout.justify !== 'none' && v.layout.align !== 0);
+            expect(leaked).toHaveLength(0);
+        });
+    });
+
+    await describe('property defaults (adw-wrap-box.c pspecs)', async () => {
+        await it('spacing 0, align 0, justify none, justify-last-line false', () => {
+            expect(ADW_WRAP_BOX_DEFAULT_SPACING).toBe(0);
+            expect(ADW_WRAP_BOX_DEFAULT_ALIGN).toBe(0);
+            expect(ADW_WRAP_BOX_DEFAULT_JUSTIFY).toBe('none');
+            expect(ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE).toBe(false);
+        });
+
+        await it('wrap-policy natural, pack-direction start-to-end, unit px, natural-line-length -1', () => {
+            expect(ADW_WRAP_BOX_DEFAULT_WRAP_POLICY).toBe('natural');
+            expect(ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION).toBe('start-to-end');
+            expect(ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT).toBe('px');
+            expect(ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET).toBe(-1);
+        });
+
+        await it('the unit default is px, NOT the split views’ sp — the same helper, two defaults', () => {
+            expect(normalizeWrapBoxLengthUnit(undefined)).toBe('px');
+            expect(normalizeWrapBoxLengthUnit('sp')).toBe('sp');
+            expect(normalizeWrapBoxLengthUnit('rem')).toBe('px');
+        });
+    });
+
+    await describe('normalizeWrapBoxSpacing (the negative clamp)', async () => {
+        for (const { value, spacing, rule } of WRAP_BOX_SPACING_VECTORS) {
+            await it(`${JSON.stringify(value)} → ${spacing} — ${rule}`, () => {
+                expect(normalizeWrapBoxSpacing(value)).toBe(spacing);
+            });
+        }
+    });
+
+    await describe('the spacing setter early return (adw-wrap-box.c:592-593)', async () => {
+        for (const { from, value, notifies, rule } of WRAP_BOX_SPACING_NOTIFY_VECTORS) {
+            await it(`${from} ← ${JSON.stringify(value)} ${notifies ? 'notifies' : 'is silent'} — ${rule}`, () => {
+                expect(normalizeWrapBoxSpacing(value) !== normalizeWrapBoxSpacing(from)).toBe(notifies);
+            });
+        }
+    });
+
+    await describe('normalizeWrapBoxAlign (g_param_spec_float 0..1)', async () => {
+        await it('clamps into the declared range rather than passing the value on', () => {
+            expect(normalizeWrapBoxAlign(0.25)).toBe(0.25);
+            expect(normalizeWrapBoxAlign(-2)).toBe(0);
+            expect(normalizeWrapBoxAlign(7)).toBe(1);
+            expect(normalizeWrapBoxAlign('0.5')).toBe(0.5);
+            expect(normalizeWrapBoxAlign('half')).toBe(0);
+            expect(normalizeWrapBoxAlign(null)).toBe(0);
+        });
+    });
+
+    await describe('normalizeWrapBoxJustify / normalizeWrapBoxPackDirection (enum gates)', async () => {
+        await it('an out-of-enum value leaves the property at its default', () => {
+            expect(normalizeWrapBoxJustify('spread')).toBe('spread');
+            expect(normalizeWrapBoxJustify('Spread')).toBe('none');
+            expect(normalizeWrapBoxJustify(null)).toBe('none');
+            expect(normalizeWrapBoxPackDirection('end-to-start')).toBe('end-to-start');
+            expect(normalizeWrapBoxPackDirection('reverse')).toBe('start-to-end');
+        });
+    });
+
+    await describe('wrap-policy (adw-wrap-box.c:476-495)', async () => {
+        for (const { value, policy, flexShrink, rule } of WRAP_BOX_POLICY_VECTORS) {
+            await it(`${JSON.stringify(value)} → ${policy} / flex-shrink ${flexShrink} — ${rule}`, () => {
+                expect(normalizeWrapPolicy(value)).toBe(policy);
+                expect(wrapPolicyFlexShrink(policy)).toBe(flexShrink);
+            });
+        }
+
+        await it('the DEFAULT forbids shrinking, which is the opposite of the CSS default', () => {
+            expect(wrapPolicyFlexShrink(normalizeWrapPolicy(undefined))).toBe(0);
+        });
+    });
+
+    await describe('natural-line-length (g_param_spec_int -1..G_MAXINT, default -1)', async () => {
+        for (const { value, length, rule } of WRAP_BOX_NATURAL_LENGTH_VECTORS) {
+            await it(`${JSON.stringify(value)} → ${length} — ${rule}`, () => {
+                expect(normalizeNaturalLineLength(value)).toBe(length);
+            });
+        }
+    });
+
+    await describe('wrapBoxLengthToPx (adw_length_unit_to_px, px default)', async () => {
+        for (const { value, unit, dpi, px, rule } of WRAP_BOX_LENGTH_VECTORS) {
+            await it(`${value}${String(unit)} @${dpi}dpi → ${px}px — ${rule}`, () => {
+                expect(wrapBoxLengthToPx(value, normalizeWrapBoxLengthUnit(unit), dpi)).toBe(px);
+            });
+        }
+    });
+
+    await describe('resolveWrapBoxChildOrder (insert/reorder after, NULL = FIRST)', async () => {
+        for (const { op, children, child, sibling, result, rule } of WRAP_BOX_CHILD_ORDER_VECTORS) {
+            const label = `${op} ${child} after ${sibling ?? 'NULL'} in [${children.join(',')}]`;
+            await it(`${label} → ${result ? `[${result.join(',')}]` : 'refused'} — ${rule}`, () => {
+                const next = resolveWrapBoxChildOrder({ children, child, sibling, op });
+                if (result === null) expect(next).toBe(null);
+                else expect(next).toStrictEqual([...result]);
+            });
+        }
+
+        await it('never mutates the array it was handed', () => {
+            const children = ['a', 'b', 'c'];
+            resolveWrapBoxChildOrder({ children, child: 'd', sibling: 'b', op: 'insert-after' });
+            expect(children).toStrictEqual(['a', 'b', 'c']);
+        });
+    });
+
+    await describe('the notify roster (adw-wrap-box.c:284-497)', async () => {
+        await it('names all fourteen properties an Adw.WrapBox emits notify:: for', () => {
+            expect(WRAP_BOX_NOTIFY_PROPERTIES).toHaveLength(14);
+            expect(new Set(WRAP_BOX_NOTIFY_PROPERTIES).size).toBe(14);
+        });
+
+        await it('includes the OVERRIDDEN orientation, which is not one of the installed pspecs', () => {
+            expect(WRAP_BOX_NOTIFY_PROPERTIES).toContain('orientation');
+        });
+    });
+};

--- a/packages/web/adwaita-core/src/wrap-box.ts
+++ b/packages/web/adwaita-core/src/wrap-box.ts
@@ -1,0 +1,317 @@
+// `Adw.WrapBox` — the portable half, headless (ADR 0004).
+//
+// WHAT IS AND IS NOT HERE
+//
+// The line-BREAKING engine stays out: `count_line_children` walks children until
+// the line overflows and `box_allocate` distributes the leftover, and neither
+// renderer can be fed that decision — CSS flexbox breaks lines itself and
+// NativeScript's `FlexboxLayout` breaks them in native code. What IS portable is
+// everything the engine decides BEFORE it measures: the property normalisers,
+// the justify/align/last-line decision table, and the child-ORDER arithmetic.
+//
+// This module exists because there was a second copy. `conformance/wrap-box.ts`
+// recorded that there was "no core IMPLEMENTATION behind these rows on purpose",
+// on the grounds that "the NativeScript port has nowhere to land them, because NS
+// `WrapLayout` exposes `orientation`, `itemWidth` and `itemHeight` and nothing
+// else". That grounding was wrong: NativeScript also ships `FlexboxLayout`, with
+// `flexDirection`, `flexWrap`, `justifyContent`, `alignItems`, `alignContent` and
+// per-child `setFlexGrow`/`setFlexShrink` — the same primitives the browser port
+// maps onto. So the NS widget can land the whole family, the browser element's
+// private `resolveLine` became the first of two copies, and the rule is that the
+// SECOND copy is where you lift.
+//
+// Reference: refs/libadwaita/src/adw-wrap-box.c
+// Reference: refs/libadwaita/src/adw-wrap-layout.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import { type AdwLengthUnit, adwLengthToPx, DEFAULT_DPI, normalizeLengthUnit } from './length-unit.js';
+
+// --- Vocabulary ---------------------------------------------------------------
+
+/** `AdwJustifyMode` — the three values of `Adw.WrapBox:justify` (adw-wrap-layout.h:26-30). */
+export type AdwWrapBoxJustify = 'none' | 'fill' | 'spread';
+
+/** `AdwWrapPolicy` — whether children may shrink before a line wraps (adw-wrap-layout.h:39-43). */
+export type AdwWrapPolicy = 'minimum' | 'natural';
+
+/** `AdwPackDirection` — which end of a line children are packed from. */
+export type AdwWrapBoxPackDirection = 'start-to-end' | 'end-to-start';
+
+/** `GtkOrientation` — the axis children are packed along. */
+export type AdwWrapBoxOrientation = 'horizontal' | 'vertical';
+
+/** The three justify modes, for validating an attribute against the C enum. */
+export const ADW_WRAP_BOX_JUSTIFY_MODES: readonly AdwWrapBoxJustify[] = ['none', 'fill', 'spread'];
+
+/** The two wrap policies, for validating an attribute against the C enum. */
+export const ADW_WRAP_POLICIES: readonly AdwWrapPolicy[] = ['minimum', 'natural'];
+
+// --- Property defaults (adw-wrap-box.c) ----------------------------------------
+
+/**
+ * `Adw.WrapBox:child-spacing` and `:line-spacing` defaults, in px.
+ *
+ * Both are `g_param_spec_int (…, 0, G_MAXINT, 0, …)` — adw-wrap-box.c:285-287
+ * and :393-395. The NativeScript port defaulted BOTH to 6 DIPs, so identical
+ * markup was looser on a phone than in the browser.
+ */
+export const ADW_WRAP_BOX_DEFAULT_SPACING = 0;
+
+/**
+ * `Adw.WrapBox:align` default (adw-wrap-box.c:335-337).
+ *
+ * Declared `g_param_spec_float (…, 0, 1, 0, …)`, so GObject validates an
+ * out-of-range value back into `[0, 1]` on set.
+ */
+export const ADW_WRAP_BOX_DEFAULT_ALIGN = 0;
+
+/** `Adw.WrapBox:justify` default — `ADW_JUSTIFY_NONE` (adw-wrap-box.c:364-366). */
+export const ADW_WRAP_BOX_DEFAULT_JUSTIFY: AdwWrapBoxJustify = 'none';
+
+/** `Adw.WrapBox:justify-last-line` default — `FALSE` (adw-wrap-box.c:379-381). */
+export const ADW_WRAP_BOX_DEFAULT_JUSTIFY_LAST_LINE = false;
+
+/** `Adw.WrapBox:wrap-policy` default — `ADW_WRAP_NATURAL` (adw-wrap-box.c:491-495). */
+export const ADW_WRAP_BOX_DEFAULT_WRAP_POLICY: AdwWrapPolicy = 'natural';
+
+/**
+ * `Adw.WrapBox:natural-line-length` default — `-1`, i.e. UNSET
+ * (adw-wrap-box.c:438-441, range `-1 … G_MAXINT`).
+ *
+ * `-1` is not "zero length": it means the box asks for whatever its children
+ * need, so a renderer must not write it into a size.
+ */
+export const ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET = -1;
+
+/**
+ * The unit default for all three length properties — `ADW_LENGTH_UNIT_PX`
+ * (adw-wrap-box.c:300-305, :408-413, :454-458).
+ *
+ * Note this DIFFERS from the split views, which default to `sp`
+ * (`DEFAULT_SIDEBAR_WIDTH_UNIT`). Sharing `normalizeLengthUnit` between them is
+ * only safe because the default is the caller's argument, not the helper's.
+ */
+export const ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT: AdwLengthUnit = 'px';
+
+/** `Adw.WrapBox:pack-direction` default — `ADW_PACK_START_TO_END` (adw-wrap-box.c:313-318). */
+export const ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION: AdwWrapBoxPackDirection = 'start-to-end';
+
+/** The two pack directions, for validating an attribute against the C enum. */
+export const ADW_WRAP_BOX_PACK_DIRECTIONS: readonly AdwWrapBoxPackDirection[] = ['start-to-end', 'end-to-start'];
+
+// --- Property normalisers ------------------------------------------------------
+
+/**
+ * `adw_wrap_box_set_child_spacing` / `set_line_spacing`
+ * (adw-wrap-box.c:587-588, :927-928) — a negative spacing is clamped to 0 BEFORE
+ * anything else happens, so it never reaches the layout.
+ *
+ * The property is declared with a minimum of 0, which is why the clamp exists at
+ * all: without it GObject would reject the value and warn. The non-numeric cases
+ * have no C counterpart — the property is an `int` — and resolve to the default,
+ * so a typo cannot put `NaN` into a `column-gap` or a native layout pass.
+ */
+export function normalizeWrapBoxSpacing(value: unknown): number {
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+    if (!Number.isFinite(parsed) || parsed < 0) return ADW_WRAP_BOX_DEFAULT_SPACING;
+    return parsed;
+}
+
+/** `Adw.WrapBox:align` — `g_param_spec_float (…, 0, 1, 0, …)`, adw-wrap-box.c:335-337. */
+export function normalizeWrapBoxAlign(value: unknown): number {
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+    if (!Number.isFinite(parsed)) return ADW_WRAP_BOX_DEFAULT_ALIGN;
+    return Math.min(1, Math.max(0, parsed));
+}
+
+/** An out-of-range enum value leaves a GObject property at its default. */
+export function normalizeWrapBoxJustify(value: unknown): AdwWrapBoxJustify {
+    return ADW_WRAP_BOX_JUSTIFY_MODES.includes(value as AdwWrapBoxJustify)
+        ? (value as AdwWrapBoxJustify)
+        : ADW_WRAP_BOX_DEFAULT_JUSTIFY;
+}
+
+/** `Adw.WrapBox:wrap-policy` — same enum gate, defaulting to `natural`. */
+export function normalizeWrapPolicy(value: unknown): AdwWrapPolicy {
+    return ADW_WRAP_POLICIES.includes(value as AdwWrapPolicy)
+        ? (value as AdwWrapPolicy)
+        : ADW_WRAP_BOX_DEFAULT_WRAP_POLICY;
+}
+
+/**
+ * `Adw.WrapBox:natural-line-length` — an `int` in `[-1, G_MAXINT]`.
+ *
+ * Anything below -1 is out of the declared range, so it lands on the sentinel
+ * rather than on 0: a GObject setter would have refused it and left the property
+ * where it was, and "unset" is what the property was born as.
+ */
+export function normalizeNaturalLineLength(value: unknown): number {
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+    if (!Number.isFinite(parsed) || parsed < 0) return ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET;
+    return Math.trunc(parsed);
+}
+
+/** `Adw.WrapBox`'s three length units — `px` by default, unlike the split views' `sp`. */
+export function normalizeWrapBoxLengthUnit(value: unknown): AdwLengthUnit {
+    return normalizeLengthUnit(value, ADW_WRAP_BOX_DEFAULT_LENGTH_UNIT);
+}
+
+/** `Adw.WrapBox:pack-direction` — the same enum gate, defaulting to `start-to-end`. */
+export function normalizeWrapBoxPackDirection(value: unknown): AdwWrapBoxPackDirection {
+    return ADW_WRAP_BOX_PACK_DIRECTIONS.includes(value as AdwWrapBoxPackDirection)
+        ? (value as AdwWrapBoxPackDirection)
+        : ADW_WRAP_BOX_DEFAULT_PACK_DIRECTION;
+}
+
+/**
+ * One length property resolved to pixels — the `adw_length_unit_to_px` call the
+ * measure and allocate paths both make before laying anything out
+ * (adw-wrap-layout.c:554-565, :798-804).
+ *
+ * The UNSET natural line length passes through untouched, mirroring the C's own
+ * `if (self->natural_line_length >= 0)` gate (:562): converting `-1` would turn
+ * a sentinel into a length, and at dpi ≠ 96 it would not even stay -1.
+ */
+export function wrapBoxLengthToPx(value: number, unit: AdwLengthUnit, dpi: number = DEFAULT_DPI): number {
+    if (value < 0) return ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET;
+    return adwLengthToPx(unit, value, dpi);
+}
+
+// --- The justify / align / last-line decision ----------------------------------
+
+/** What a renderer has to do with a line's leftover space. */
+export interface WrapBoxLineLayout {
+    /**
+     * The justify mode that governs THIS line, after the last-line gate. It is
+     * the widget's `justify` for every line except the final one, and for the
+     * final one only when `justify-last-line` is set
+     * (adw-wrap-layout.c:397-400, :705-706).
+     */
+    justify: AdwWrapBoxJustify;
+    /**
+     * Whether the CHILDREN absorb the leftover (`allocated_size` grows to
+     * `available_size`, adw-wrap-layout.c:336-341). CSS: `flex-grow` on the
+     * items.
+     */
+    growChildren: boolean;
+    /**
+     * Whether the GAPS absorb the leftover — children keep `minimum_size` and
+     * are spread apart by `size_delta` (adw-wrap-layout.c:338-339, :752-757).
+     * CSS: `justify-content: space-between`.
+     */
+    growGaps: boolean;
+    /**
+     * The MAIN-axis offset factor applied to the whole line block when nothing
+     * grows: `widget_offset += roundf (length_delta * align)`
+     * (adw-wrap-layout.c:717-725). 0 packs the line at the start of the main
+     * axis, 1 at its end. Meaningless — and reported as 0 — as soon as the line
+     * is justified, because C only computes `length_delta` inside
+     * `if (!justify_line)`.
+     */
+    align: number;
+}
+
+/**
+ * The line-layout decision, straight from the C.
+ *
+ * `lastLine` is the FINAL line, complete or not (`i == *n_lines - 1`,
+ * adw-wrap-layout.c:463-464), so a wrap box whose children all fit on one line
+ * has that line governed by `justify-last-line` rather than by `justify` — which
+ * makes the single-line case, the common one, the counter-intuitive one.
+ *
+ * `spread` with exactly ONE child in the line does not spread anything:
+ * `n_children > 1` guards the branch that keeps children at `minimum_size`, so a
+ * lone child is STRETCHED instead, which the property documentation states
+ * outright (adw-wrap-box.c:349-352).
+ *
+ * Held to `WRAP_BOX_LINE_VECTORS` in `@gjsify/adwaita-core/conformance`, which
+ * both renderer suites drive their real widgets with.
+ */
+export function resolveWrapBoxLine(input: {
+    justify: AdwWrapBoxJustify;
+    justifyLastLine: boolean;
+    align: number;
+    lastLine: boolean;
+    childrenInLine: number;
+}): WrapBoxLineLayout {
+    // adw-wrap-layout.c:397-400 / :705-706 — the final line is only justified on
+    // request; otherwise it falls back to ADW_JUSTIFY_NONE and to `align`.
+    const effective: AdwWrapBoxJustify = input.lastLine && !input.justifyLastLine ? 'none' : input.justify;
+    if (effective === 'none') return { justify: 'none', growChildren: false, growGaps: false, align: input.align };
+    const spreadsGaps = effective === 'spread' && input.childrenInLine > 1;
+    return { justify: effective, growChildren: !spreadsGaps, growGaps: spreadsGaps, align: 0 };
+}
+
+/**
+ * `wrap-policy` as the child `flex-shrink` both flex-based renderers express it
+ * with.
+ *
+ * `ADW_WRAP_NATURAL` wraps "as soon as the previous line cannot fit any more
+ * children without shrinking them past their natural size"; `ADW_WRAP_MINIMUM`
+ * "shrink[s] them down to their minimum size before wrapping"
+ * (adw-wrap-box.c:476-489).
+ *
+ * STATE THE LIMIT, because it is not a full mapping. Flexbox breaks lines on the
+ * items' HYPOTHETICAL main sizes and `flex-shrink` only distributes negative
+ * free space WITHIN a line that is already broken — so no value of it makes CSS
+ * pack more children per line, which is exactly what `minimum` is for. What it
+ * does decide is whether a line that still overflows squeezes its children or
+ * lets them spill, and that half is faithful.
+ *
+ * The reason to derive it anyway is the default. CSS defaults `flex-shrink` to
+ * **1**, i.e. to `minimum`; libadwaita defaults `wrap-policy` to `natural`. Both
+ * renderers had no policy at all, so both drew the one Adwaita does not choose,
+ * on every wrap box, silently.
+ */
+export function wrapPolicyFlexShrink(policy: AdwWrapPolicy): number {
+    return policy === 'minimum' ? 1 : 0;
+}
+
+// --- Child order ---------------------------------------------------------------
+
+/** Which child-list operation is being resolved. */
+export type WrapBoxChildOrderOp = 'insert-after' | 'reorder-after';
+
+/**
+ * Where `adw_wrap_box_insert_child_after` / `reorder_child_after` put a child.
+ *
+ * Both delegate to `gtk_widget_insert_after (child, self, sibling)`
+ * (adw-wrap-box.c:1283-1300, :1315-1332), whose documented rule is the
+ * counter-intuitive one: a NULL sibling inserts at the FIRST position, not the
+ * last. Reading it as "append" is the obvious misreading, and it is silent —
+ * the child lands somewhere plausible.
+ *
+ * The guards are the C's `g_return_if_fail`s, expressed as a refusal rather than
+ * a throw because a renderer has no `g_critical` to fall through to: an insert
+ * demands the child be UNPARENTED and the sibling be a child of this box, a
+ * reorder demands the child already be one, and `child === sibling` is an
+ * explicit early return in both.
+ *
+ * Returns the new child list, or `null` when the operation is refused — the
+ * caller then leaves its view tree exactly as it was, which is what C does.
+ */
+export function resolveWrapBoxChildOrder<T>(input: {
+    /** The box's children, in order. */
+    children: readonly T[];
+    /** The child being placed. */
+    child: T;
+    /** The child to place it after, or `null`/`undefined` for the FIRST position. */
+    sibling?: T | null;
+    /** Which operation — they differ only in whether `child` is expected to be present. */
+    op: WrapBoxChildOrderOp;
+}): T[] | null {
+    const { children, child, op } = input;
+    const sibling = input.sibling ?? null;
+    if (sibling !== null && sibling === child) return null;
+
+    const present = children.indexOf(child);
+    if (op === 'insert-after' && present !== -1) return null;
+    if (op === 'reorder-after' && present === -1) return null;
+
+    const rest = present === -1 ? [...children] : children.filter((_, index) => index !== present);
+    if (sibling === null) return [child, ...rest];
+
+    const at = rest.indexOf(sibling);
+    if (at === -1) return null;
+    return [...rest.slice(0, at + 1), child, ...rest.slice(at + 1)];
+}

--- a/packages/web/adwaita-web/scss/_combo_row.scss
+++ b/packages/web/adwaita-web/scss/_combo_row.scss
@@ -59,6 +59,11 @@ adw-combo-row {
     // fill, making the icon theme-aware (matches libadwaita's dark theme).
     // Using background-image with a data-URI SVG would NOT resolve
     // `currentColor` in most browsers.
+    //
+    // `model_changed` (adw-combo-row.c:187-195) hides the arrow box entirely on
+    // a model of one item or none, so the row stops presenting itself as a
+    // chooser. `[data-presents-chooser='false']` below is that rule; the element
+    // publishes the attribute and disables the overlaid <select> alongside.
     &::after {
       content: "";
       display: inline-block;
@@ -74,5 +79,19 @@ adw-combo-row {
       -webkit-mask-position: center;
       mask-position: center;
     }
+  }
+}
+
+// A model with one item or none: no arrow, and the row is not activatable
+// (`model_changed`, adw-combo-row.c:187-195). Written as its own block rather
+// than a modifier inside `.adw-row-value` so the two selectors that draw the
+// arrow and the one that removes it read at the same specificity depth.
+adw-combo-row[data-presents-chooser='false'] {
+  .adw-row-value::after {
+    display: none;
+  }
+
+  select {
+    cursor: default;
   }
 }

--- a/packages/web/adwaita-web/scss/_navigation_split_view.scss
+++ b/packages/web/adwaita-web/scss/_navigation_split_view.scss
@@ -1,5 +1,16 @@
 // _navigation_split_view.scss — adw-navigation-split-view styling (docked sidebar).
+//
+// Visibility is `data-pane-visible`, written by the element from
+// `update_navigation_stack` (adw-navigation-split-view.c:342-405), not from the
+// two flags. Two of that table's rules are not expressible as
+// `.collapsed.show-content`: a LONE child stays visible whatever `show-content`
+// says (:389-401), and with `sidebar-position: end` the CONTENT is the root page
+// so the sidebar is pushed ON TOP of it rather than replacing it. This file used
+// to key off the flags and got both wrong — a collapsed view with only a sidebar
+// rendered blank.
+//
 // Reference: refs/adwaita-web/adwaita-web/docs/widgets/navigationsplitview.md
+// Reference: refs/libadwaita/src/adw-navigation-split-view.c
 // Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Adapted for @gjsify/adwaita-web Web Components.
@@ -16,33 +27,61 @@ adw-navigation-split-view {
     flex-direction: column;
     min-height: 0;
     flex-shrink: 0;
-    border-right: 1px solid var(--separator-color);
     background-color: var(--sidebar-bg-color);
   }
 
+  // The container MINIMUM, as CSS spells it: `measure_uncollapsed`
+  // (adw-navigation-split-view.c:264-267) is `sidebar_min + content_min`, which
+  // a flex row reaches by itself once the content may claim its own minimum.
+  // `min-width: 0` — the flex idiom for "let this be crushed" — was here, which
+  // is how the content pane could be squeezed to nothing while the sidebar,
+  // being `flex-shrink: 0`, kept its whole width.
   .adw-nsv-content {
     display: flex;
     flex-direction: column;
-    min-width: 0;
+    min-width: min-content;
     min-height: 0;
     flex: 1 1 auto;
     background-color: var(--window-bg-color);
   }
 
-  // Collapsed (narrow): one pane at a time.
-  &.collapsed.show-content .adw-nsv-sidebar {
-    display: none;
-  }
-
-  &.collapsed:not(.show-content) {
+  // `sidebar-position: end` docks the sidebar past the content. flex `order`
+  // flips the visual order without changing the slotting DOM order.
+  &.sidebar-end {
     .adw-nsv-content {
-      display: none;
+      order: 1;
     }
 
     .adw-nsv-sidebar {
+      order: 2;
+    }
+  }
+
+  // THE DIVIDER FOLLOWS THE VISUAL SIDE. `_sidebars.scss:1293-1302` makes it
+  // `:dir()` × `.end`, which is the product `.sidebar-at-visual-start` carries:
+  // under RTL a `start` sidebar is drawn on the right and its divider belongs on
+  // its left edge. A fixed `border-right` drew it on the wrong side for half the
+  // four combinations.
+  &.sidebar-at-visual-start .adw-nsv-sidebar {
+    border-right: 1px solid var(--separator-color);
+  }
+
+  &:not(.sidebar-at-visual-start) .adw-nsv-sidebar {
+    border-left: 1px solid var(--separator-color);
+  }
+
+  // Collapsed: whichever pane the STACK puts on top fills the view, and the
+  // other is not rendered at all.
+  &.collapsed {
+    [data-pane-visible='false'] {
+      display: none;
+    }
+
+    .adw-nsv-sidebar[data-pane-visible='true'] {
       flex: 1 1 auto;
       max-width: none;
       border-right: none;
+      border-left: none;
     }
   }
 }

--- a/packages/web/adwaita-web/scss/_overlay_split_view.scss
+++ b/packages/web/adwaita-web/scss/_overlay_split_view.scss
@@ -1,5 +1,21 @@
 // _overlay_split_view.scss — adw-overlay-split-view styling.
+//
+// The GEOMETRY is no longer here. It used to be four `transform: translateX(±100%)`
+// rules keyed on `.collapsed` / `.show-sidebar` / `.sidebar-end`, which can only
+// express the two END STATES of a reveal — so `show-progress` was 0 or 1, the
+// five `OVERLAY_SWIPE_*` conformance tables shipped unexercised, and the docked
+// hide slid the wrong way for an `end` sidebar because the JS wrote `marginRight`
+// whichever edge the pane was on.
+//
+// The element now writes the pane rect per frame from
+// `layoutOverlaySplitView`, which is continuous and knows the edge (including
+// under RTL, where a `start` sidebar is drawn on the RIGHT —
+// `get_start_or_end`, adw-overlay-split-view.c:227-234). What is left here is
+// what CSS genuinely owns: the box model, the stacking, and the transition that
+// smooths a programmatic toggle.
+//
 // Reference: refs/libadwaita/src/adw-overlay-split-view.c
+// Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as Web Component for @gjsify/adwaita-web.
 
@@ -15,34 +31,44 @@ adw-overlay-split-view {
     background-color: var(--sidebar-bg-color);
     overflow-y: auto;
     flex-shrink: 0;
-    transition: transform 0.2s ease, opacity 0.2s ease, margin 0.2s ease;
     z-index: 10;
     align-self: stretch;
+    // Only `opacity` transitions. The offset is driven per frame, so animating
+    // it here would fight the swipe: a gesture would lag its own finger.
+    transition: opacity 0.2s ease;
   }
 
+  // THE CONTAINER MINIMUM, as CSS spells it. `measure_uncollapsed`
+  // (adw-overlay-split-view.c:558-563) is `trunc(sidebar_min * progress) +
+  // content_min`, and a flex row reaches exactly that on its own PROVIDED the
+  // content is allowed to claim its own minimum: the sidebar is `flex-shrink: 0`
+  // with a `min-width` of `sidebar_min`, so the sum is the container's floor.
+  //
+  // `min-width: 0` was here instead — the flex idiom for "let this be crushed so
+  // an ellipsis can happen" — which is precisely how the content pane could be
+  // squeezed to nothing while the sidebar kept its whole width. A child that
+  // needs to truncate can still ask for `min-width: 0` itself; the PANE may not.
+  //
+  // Not computed in JS: a measured number would need the content's min-content
+  // size, which the DOM does not expose without a reflow, and the first attempt
+  // used `scrollWidth` — the pane's CURRENT width — which pinned the view at
+  // whatever it happened to be and stopped it responding to its breakpoint.
   .adw-osv-content {
     flex: 1;
-    min-width: 0;
+    min-width: min-content;
     min-height: 0;
     display: flex;
     flex-direction: column;
     align-self: stretch;
   }
 
-  // Docked mode (not collapsed) — sidebar beside content
+  // Docked — the sidebar sits in the flex row and the hidden part is taken off
+  // its own edge by a negative margin the element computes.
   &:not(.collapsed) .adw-osv-sidebar {
     position: relative;
   }
 
-  // Docked hide: slide left and collapse via opacity. Sidebar keeps its
-  // intrinsic width so internal elements don't reflow.
-  &:not(.collapsed):not(.show-sidebar) .adw-osv-sidebar {
-    transform: translateX(-100%);
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  // Docked + sidebar-end — dock the sidebar to the RIGHT of the content
+  // Docked + sidebar-end — dock the sidebar to the far side of the content
   // (the Adw.OverlaySplitView { sidebar-position: end } layout). flex `order`
   // flips the visual order without changing the slotting DOM order.
   &:not(.collapsed).sidebar-end {
@@ -52,49 +78,52 @@ adw-overlay-split-view {
 
     .adw-osv-sidebar {
       order: 2;
-      border-inline-start: 1px solid var(--separator-color);
     }
   }
 
-  // Docked hide when the sidebar is on the end edge: slide RIGHT, not left.
-  &:not(.collapsed):not(.show-sidebar).sidebar-end .adw-osv-sidebar {
-    transform: translateX(100%);
+  // THE DIVIDER FOLLOWS THE VISUAL SIDE, not the logical one. `_sidebars.scss`
+  // makes it `:dir()` × `.end` (:21-39), which is exactly the product
+  // `.sidebar-at-visual-start` already carries: under RTL a `start` sidebar is
+  // drawn on the right and its divider belongs on its left edge.
+  &:not(.collapsed) {
+    .adw-osv-sidebar {
+      border-inline-end: none;
+      border-inline-start: none;
+    }
+
+    &.sidebar-at-visual-start .adw-osv-sidebar {
+      border-right: 1px solid var(--separator-color);
+    }
+
+    &:not(.sidebar-at-visual-start) .adw-osv-sidebar {
+      border-left: 1px solid var(--separator-color);
+    }
   }
 
-  // Overlay mode (collapsed) — sidebar on top of content
+  // Overlay (collapsed) — the sidebar floats above the content at the absolute
+  // offset the element writes into `left`, which is the only property that can
+  // carry a mid-swipe position.
   &.collapsed .adw-osv-sidebar {
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 0;
-    transform: translateX(-100%);
-    opacity: 0;
-    pointer-events: none;
+    box-shadow: 0 0 12px rgb(0 0 0 / 25%);
   }
 
-  &.collapsed.sidebar-end .adw-osv-sidebar {
-    left: auto;
-    right: 0;
-    transform: translateX(100%);
-  }
-
-  &.collapsed.show-sidebar .adw-osv-sidebar {
-    transform: translateX(0);
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  // Backdrop — visible only in overlay mode when sidebar is open
+  // Backdrop — the click-outside shield. `hidden` is the element's, off
+  // `shieldVisible`; the OPACITY is the shadow-helper progress, so it fades with
+  // the reveal instead of appearing whole.
   .adw-osv-backdrop {
     display: none;
   }
 
-  &.collapsed.show-sidebar .adw-osv-backdrop {
+  &.collapsed .adw-osv-backdrop:not([hidden]) {
     display: block;
     position: absolute;
     inset: 0;
-    background: rgba(0, 0, 0, 0.3);
+    background: rgb(0 0 0 / 30%);
     z-index: 9;
+    transition: opacity 0.2s ease;
   }
 }
 

--- a/packages/web/adwaita-web/scss/_spinner.scss
+++ b/packages/web/adwaita-web/scss/_spinner.scss
@@ -1,32 +1,46 @@
-// _spinner.scss — adw-spinner styling (ring with a spinning arc).
+// _spinner.scss — adw-spinner styling.
+//
+// Almost nothing is left here on purpose. The ring is an SVG the element draws
+// per frame from `@gjsify/adwaita-core`'s `spinnerArc`, because the arc BREATHES
+// (2.7 to 102.8 degrees) and CSS cannot express that: the `border-top-color`
+// chase this file used to carry was a fixed 90-degree quarter-circle at 0.8s
+// against libadwaita's 1.2s, with a hardcoded grey track and square-cut ends.
+//
+// What CSS still owns is the box: the element is `size × size` and the ring is
+// centred inside it, which is how a 200px spinner shows a 64px ring
+// (adw-spinner.c:95-99 hands the widget's real size to the paintable, which caps
+// only the radius).
+//
+// There is deliberately NO `prefers-reduced-motion` rule. The C opts out of the
+// animation setting explicitly (`adw_animation_set_follow_enable_animations_setting
+// (…, FALSE)`, adw-spinner-paintable.c:537) — a frozen busy indicator reads as a
+// hang. This file used to stop the animation there.
+//
+// Reference: refs/libadwaita/src/adw-spinner.c
+// Reference: refs/libadwaita/src/adw-spinner-paintable.c
 // Reference: refs/adwaita-web/adwaita-web/scss/_spinner.scss
-// Reference: refs/libadwaita (Adw.Spinner)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Adapted for @gjsify/adwaita-web Web Components.
 
 adw-spinner {
-  display: inline-block;
+  // The element writes the measured box onto `style` when it upgrades; these are
+  // the values in force until then, which are Adwaita's own minimum
+  // (adw-spinner.c:14, reported as both minimum and natural at :78-81).
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   box-sizing: border-box;
-  // Adw.Spinner measures 16 as BOTH its minimum and its natural size
-  // (adw-spinner.c:78-81), stroked at the documented "2px for 16px". The element
-  // overwrites both from `spinnerGeometry` when it upgrades; these are the values
-  // in force until then — the 24px/3px they replace were not from any source.
   width: 16px;
   height: 16px;
-  // Neutral arc (currentColor, theme-aware) over a faint track — Adw.Spinner
-  // is a neutral indicator, NOT accent-coloured.
-  border: 2px solid rgba(127, 127, 127, 0.25);
-  border-top-color: currentColor;
-  border-radius: 50%;
-  animation: adw-spinner-spin 0.8s linear infinite;
+  // The arc strokes `currentColor` — `gtk_widget_get_color` (:432), the widget's
+  // TEXT colour, never the accent. The track is the same colour at 15%, which
+  // the SVG applies as `stroke-opacity`.
+  color: inherit;
 
-  @media (prefers-reduced-motion: reduce) {
-    animation: none;
-  }
-}
-
-@keyframes adw-spinner-spin {
-  to {
-    transform: rotate(360deg);
+  svg {
+    display: block;
+    // The ring never grows past its own diameter, so an over-large box centres
+    // it rather than stretching it.
+    flex: none;
   }
 }

--- a/packages/web/adwaita-web/scss/_tab_view.scss
+++ b/packages/web/adwaita-web/scss/_tab_view.scss
@@ -143,19 +143,18 @@ adw-tab-view {
     }
   }
 
-  // `AdwTabPage:loading` swaps the icon image for a spinner in the same slot
-  // (adw-tab.c:178-183) — the arc geometry and the keyframes are adw-spinner's,
-  // not a second copy of them.
-  .adw-tab-icon.loading {
-    background: none;
-    mask-image: none;
-    border: 2px solid rgba(127, 127, 127, 0.25);
-    border-top-color: currentColor;
-    border-radius: 50%;
-    animation: adw-spinner-spin 0.8s linear infinite;
+  // `AdwTabPage:loading` swaps the icon image for an `AdwSpinnerPaintable`
+  // (`update_icons`, adw-tab.c:172-190) — the SAME paintable `Adw.Spinner` uses.
+  // So the tab mounts a real `<adw-spinner>` in the icon's slot and this block
+  // only places it. It used to restate `border: 2px`,
+  // `rgba(127, 127, 127, 0.25)` and `0.8s` under a comment claiming the geometry
+  // and keyframes were adw-spinner's and "not a second copy of them" — which is
+  // how it inherited every spinner defect independently.
+  .adw-tab-spinner {
+    flex: none;
 
-    @media (prefers-reduced-motion: reduce) {
-      animation: none;
+    &[hidden] {
+      display: none;
     }
   }
 

--- a/packages/web/adwaita-web/scss/_wrap_box.scss
+++ b/packages/web/adwaita-web/scss/_wrap_box.scss
@@ -23,6 +23,15 @@ adw-wrap-box {
   align-content: flex-start;
 }
 
+// `wrap-policy`, published by the component as a custom property. The FALLBACK
+// is the load-bearing part: it is `ADW_WRAP_NATURAL`, libadwaita's default
+// (adw-wrap-box.c:491-495), where CSS defaults `flex-shrink` to 1 — so a wrap
+// box that has not upgraded yet, or one whose policy is unset, draws Adwaita's
+// choice rather than the cascade's.
+adw-wrap-box > * {
+  flex-shrink: var(--adw-wrap-box-child-shrink, 0);
+}
+
 // FILL grows the children and keeps the spacing constant
 // (adw-wrap-layout.c:317-319, :326-341); SPREAD deliberately does NOT, so the
 // gaps take the leftover instead. `data-line-justify` is the mode the component

--- a/packages/web/adwaita-web/src/adw-avatar.spec.ts
+++ b/packages/web/adwaita-web/src/adw-avatar.spec.ts
@@ -9,6 +9,8 @@
 // them. This suite is that comparison.
 import { describe, expect, it } from '@gjsify/unit';
 
+import { AVATAR_MODE_VECTORS } from '@gjsify/adwaita-core/conformance';
+
 import { AVATAR_COLORS, avatarMaxFontSize } from '@gjsify/adwaita-core';
 import {
     AVATAR_COLOR_VECTORS,
@@ -134,6 +136,41 @@ export const AdwAvatarTest = async () => {
             expect(label.textContent).toBe('');
             expect(icon.hidden).toBe(true);
             host.remove();
+        });
+    });
+
+    await describe('<adw-avatar> mode (update_visibility, adw-avatar.c:117)', async () => {
+        // The `hasCustomImage` rows are not reachable through this element: it
+        // passes `hasCustomImage: false` unconditionally, because it has no
+        // custom-image support at all — `Adw.Avatar:custom-image` is unported.
+        // Named below rather than silently filtered.
+        for (const { hasCustomImage, showInitials, text, mode, rule } of AVATAR_MODE_VECTORS) {
+            if (hasCustomImage) continue;
+            await it(`initials=${showInitials} "${text}" → ${mode} — ${rule}`, () => {
+                const host = document.createElement('div');
+                document.body.appendChild(host);
+                const avatar = document.createElement('adw-avatar');
+                if (showInitials) avatar.setAttribute('show-initials', '');
+                if (text) avatar.setAttribute('text', text);
+                host.appendChild(avatar);
+
+                // Exactly ONE of the two reachable modes is drawn — the point of
+                // the table is the precedence, and "both visible at once" is the
+                // failure it guards against.
+                const initials = (avatar.querySelector('.adw-avatar-text') as HTMLElement).hidden === false;
+                const icon = (avatar.querySelector('.adw-avatar-icon') as HTMLElement).hidden === false;
+                expect(initials).toBe(mode === 'initials');
+                expect(icon).toBe(mode === 'icon');
+                host.remove();
+            });
+        }
+
+        await it('leaves out only the custom-image rows, which this element cannot reach', () => {
+            const unreachable = AVATAR_MODE_VECTORS.filter((vector) => vector.hasCustomImage);
+            expect(unreachable.length).toBeGreaterThan(0);
+            // Every one of them is an `image` outcome, i.e. the whole mode is
+            // missing rather than a corner of it.
+            for (const vector of unreachable) expect(vector.mode).toBe('image');
         });
     });
 };

--- a/packages/web/adwaita-web/src/adw-button-content.spec.ts
+++ b/packages/web/adwaita-web/src/adw-button-content.spec.ts
@@ -13,6 +13,8 @@
 // `image-missing` (:355-356).
 import { describe, expect, it } from '@gjsify/unit';
 
+import { BUTTON_CONTENT_DEFAULT_VECTORS } from '@gjsify/adwaita-core/conformance';
+
 import { BUTTON_CONTENT_STYLE_CLASS, normalizeIconName } from '@gjsify/adwaita-core';
 import {
     BUTTON_CONTENT_ELLIPSIZE_VECTORS,
@@ -176,6 +178,28 @@ export const AdwButtonContentTest = async () => {
                 const { el, host } = mount(attributes);
                 expect(el.classList.contains('can-shrink')).toBe(canShrink);
                 expect(getComputedStyle(labelEl(el)).textOverflow).toBe(canShrink ? 'ellipsis' : 'clip');
+                host.remove();
+            });
+        }
+    });
+
+    await describe('<adw-button-content> the four GParamSpec defaults', async () => {
+        for (const { property, value, rule } of BUTTON_CONTENT_DEFAULT_VECTORS) {
+            await it(`${property} defaults to ${JSON.stringify(value)} — ${rule}`, () => {
+                const host = document.createElement('div');
+                document.body.appendChild(host);
+                const content = document.createElement('adw-button-content');
+                host.appendChild(content);
+
+                // A bare element must READ BACK the C's defaults. The table was
+                // driven by nobody, so an element that invented its own defaults
+                // — `use-underline` true, say, which is the banner button's — would
+                // have looked correct.
+                const actual =
+                    typeof value === 'boolean'
+                        ? content.hasAttribute(property)
+                        : (content.getAttribute(property) ?? '');
+                expect(actual).toStrictEqual(value);
                 host.remove();
             });
         }

--- a/packages/web/adwaita-web/src/adw-row-state.spec.ts
+++ b/packages/web/adwaita-web/src/adw-row-state.spec.ts
@@ -9,6 +9,8 @@
 // display silently.
 import { describe, expect, it } from '@gjsify/unit';
 
+import { COMBO_CHOOSER_VECTORS } from '@gjsify/adwaita-core/conformance';
+
 import type { AdwComboRow } from './elements/adw-combo-row.js';
 import type { AdwExpanderRow } from './elements/adw-expander-row.js';
 import type { AdwSpinRow } from './elements/adw-spin-row.js';
@@ -70,6 +72,53 @@ export const AdwRowStateTest = async () => {
                 'adw-combo-row',
             );
             expect((row.querySelector('.adw-row-value') as HTMLSpanElement).textContent).toBe('');
+            host.remove();
+        });
+
+        for (const { count, presentsChooser, rule } of COMBO_CHOOSER_VECTORS) {
+            await it(`${count} option(s) → ${presentsChooser ? 'a chooser' : 'not a chooser'}: ${rule}`, async () => {
+                const items = JSON.stringify(Array.from({ length: count }, (_, i) => `Item ${i}`));
+                const { el: row, host } = parse<AdwComboRow>(
+                    `<adw-combo-row title="Pick" items='${items}'></adw-combo-row>`,
+                    'adw-combo-row',
+                );
+                const value = row.querySelector('.adw-row-value') as HTMLSpanElement;
+                const select = row.querySelector('select') as HTMLSelectElement;
+
+                // The ARROW: `.adw-row-value::after` is masked in, and the
+                // `[data-presents-chooser='false']` block removes it. Asserted
+                // as "not none" rather than against the authored `inline-block`,
+                // because `.adw-row-value` is a flex container and blockifies
+                // its children's display.
+                expect(getComputedStyle(value, '::after').display === 'none').toBe(!presentsChooser);
+                // ...and the ROW being activatable, which on this port is the
+                // overlaid <select> taking clicks at all. Hiding the arrow
+                // without this leaves a row that still opens a one-entry popup.
+                expect(select.disabled).toBe(!presentsChooser);
+
+                host.remove();
+            });
+        }
+
+        await it('gains its arrow back when the model grows past one item', async () => {
+            const { el: row, host } = parse<AdwComboRow>(
+                `<adw-combo-row title="Pick" items='["Only"]'></adw-combo-row>`,
+                'adw-combo-row',
+            );
+            const select = row.querySelector('select') as HTMLSelectElement;
+            expect(select.disabled).toBe(true);
+
+            // `items` is read at connect only, so the model is replaced through
+            // the state the element composes — the same path a consumer has.
+            (
+                row as unknown as { _state: { setOptions(o: { label: string; value: string }[]): void } }
+            )._state.setOptions([
+                { label: 'One', value: 'a' },
+                { label: 'Two', value: 'b' },
+            ]);
+            expect(select.disabled).toBe(false);
+            expect(row.dataset.presentsChooser).toBe('true');
+
             host.remove();
         });
     });

--- a/packages/web/adwaita-web/src/adw-wrap-box.spec.ts
+++ b/packages/web/adwaita-web/src/adw-wrap-box.spec.ts
@@ -23,7 +23,12 @@
 import { describe, expect, it } from '@gjsify/unit';
 
 import {
+    WRAP_BOX_CHILD_ORDER_VECTORS,
+    WRAP_BOX_LENGTH_VECTORS,
     WRAP_BOX_LINE_VECTORS,
+    WRAP_BOX_NATURAL_LENGTH_VECTORS,
+    WRAP_BOX_NOTIFY_PROPERTIES,
+    WRAP_BOX_POLICY_VECTORS,
     WRAP_BOX_SPACING_NOTIFY_VECTORS,
     WRAP_BOX_SPACING_VECTORS,
 } from '@gjsify/adwaita-core/conformance';
@@ -49,7 +54,7 @@ function unmountAll(): void {
 }
 
 /** A vector value as it reads in a test name (`JSON.stringify` flattens NaN to null). */
-function label(value: number | string | null): string {
+function label(value: unknown): string {
     return typeof value === 'string' ? JSON.stringify(value) : String(value);
 }
 
@@ -190,5 +195,147 @@ export const AdwWrapBoxTest = async () => {
                 unmountAll();
             });
         }
+    });
+
+    await describe('<adw-wrap-box> the properties neither port had (#1048)', async () => {
+        for (const { value, policy, flexShrink, rule } of WRAP_BOX_POLICY_VECTORS) {
+            await it(`wrap-policy ${label(value)} → ${policy}: ${rule}`, () => {
+                const attrs: Record<string, string> = {};
+                if (value !== null) attrs['wrap-policy'] = String(value);
+                const { box, children } = mountWrapBox(attrs);
+                expect((box as HTMLElement & { wrapPolicy: string }).wrapPolicy).toBe(policy);
+                expect(getComputedStyle(children[0]).flexShrink).toBe(String(flexShrink));
+                unmountAll();
+            });
+        }
+
+        await it('a box with no wrap-policy forbids shrinking — CSS defaults to the OTHER one', () => {
+            const { children } = mountWrapBox({});
+            expect(getComputedStyle(children[0]).flexShrink).toBe('0');
+            unmountAll();
+        });
+
+        for (const { value, unit, dpi, px, rule } of WRAP_BOX_LENGTH_VECTORS) {
+            // The element resolves at the default dpi; the scaled rows are the
+            // core suite's, since a browser has no `gtk-xft-dpi` to report.
+            if (dpi !== 96 || value < 0) continue;
+            await it(`child-spacing ${value}${String(unit)} → ${px}px: ${rule}`, () => {
+                const attrs: Record<string, string> = { 'child-spacing': String(value) };
+                if (unit !== null) attrs['child-spacing-unit'] = String(unit);
+                const { box } = mountWrapBox(attrs);
+                expect(getComputedStyle(box).columnGap).toBe(`${px}px`);
+                unmountAll();
+            });
+        }
+
+        for (const { value, length, rule } of WRAP_BOX_NATURAL_LENGTH_VECTORS) {
+            await it(`natural-line-length ${label(value)} → ${length}: ${rule}`, () => {
+                const attrs: Record<string, string> = {};
+                if (value !== null) attrs['natural-line-length'] = String(value);
+                const { box } = mountWrapBox(attrs);
+                expect((box as HTMLElement & { naturalLineLength: number }).naturalLineLength).toBe(length);
+                // -1 is UNSET, not a length: it must not reach the style at all.
+                expect(box.style.maxWidth).toBe(length < 0 ? '' : `${length}px`);
+                unmountAll();
+            });
+        }
+
+        await it('a VERTICAL box caps the block axis, because that is where its lines run', () => {
+            const { box } = mountWrapBox({ orientation: 'vertical', 'natural-line-length': '400' });
+            expect(box.style.maxHeight).toBe('400px');
+            expect(box.style.maxWidth).toBe('');
+            unmountAll();
+        });
+
+        await it('pack-direction and wrap-reverse reverse the axes they own', () => {
+            const packed = mountWrapBox({ 'pack-direction': 'end-to-start' });
+            expect(getComputedStyle(packed.box).flexDirection).toBe('row-reverse');
+            unmountAll();
+
+            const reversed = mountWrapBox({ 'wrap-reverse': '' });
+            expect(getComputedStyle(reversed.box).flexWrap).toBe('wrap-reverse');
+            unmountAll();
+        });
+
+        await it('notifies for EVERY property, not just the two spacings', () => {
+            const { box } = mountWrapBox({});
+            const seen: string[] = [];
+            for (const property of WRAP_BOX_NOTIFY_PROPERTIES) {
+                box.addEventListener(`notify::${property}`, () => seen.push(property));
+            }
+            // One real change per property, each different from the default.
+            box.setAttribute('child-spacing', '6');
+            box.setAttribute('child-spacing-unit', 'sp');
+            box.setAttribute('pack-direction', 'end-to-start');
+            box.setAttribute('align', '1');
+            box.setAttribute('justify', 'fill');
+            box.toggleAttribute('justify-last-line', true);
+            box.setAttribute('line-spacing', '4');
+            box.setAttribute('line-spacing-unit', 'pt');
+            box.toggleAttribute('line-homogeneous', true);
+            box.setAttribute('natural-line-length', '400');
+            box.setAttribute('natural-line-length-unit', 'sp');
+            box.toggleAttribute('wrap-reverse', true);
+            box.setAttribute('wrap-policy', 'minimum');
+            box.setAttribute('orientation', 'vertical');
+
+            expect([...seen].sort()).toStrictEqual([...WRAP_BOX_NOTIFY_PROPERTIES].sort());
+            unmountAll();
+        });
+
+        await it('and stays silent for a value that normalises to what it already holds', () => {
+            const { box } = mountWrapBox({ 'wrap-policy': 'minimum' });
+            let notified = 0;
+            box.addEventListener('notify::wrap-policy', () => {
+                notified++;
+            });
+            box.setAttribute('wrap-policy', 'not-a-policy'); // → the default, a change
+            expect(notified).toBe(1);
+            box.setAttribute('wrap-policy', 'also-not-a-policy'); // → the default again
+            expect(notified).toBe(1);
+            unmountAll();
+        });
+    });
+
+    await describe('<adw-wrap-box> child list (insert/reorder after, remove_all)', async () => {
+        for (const { op, children, child, sibling, result, rule } of WRAP_BOX_CHILD_ORDER_VECTORS) {
+            const name = `${op} ${child} after ${sibling ?? 'NULL'} in [${children.join(',')}]`;
+            await it(`${name}: ${rule}`, () => {
+                const box = document.createElement('adw-wrap-box') as HTMLElement & {
+                    insertChildAfter(c: Element, s?: Element | null): boolean;
+                    reorderChildAfter(c: Element, s?: Element | null): boolean;
+                };
+                document.body.appendChild(box);
+                const byId = new Map<string, HTMLElement>();
+                const make = (id: string) => {
+                    const view = document.createElement('div');
+                    view.dataset.id = id;
+                    byId.set(id, view);
+                    return view;
+                };
+                for (const id of children) box.appendChild(make(id));
+                // The child being placed may be one of the mounted ones (a
+                // reorder, or the "already parented" refusal) or a fresh one.
+                const target = byId.get(child) ?? make(child);
+                // A sibling the box does not have still has to be a real element.
+                const after = sibling === null ? null : (byId.get(sibling) ?? make(sibling));
+
+                const ok =
+                    op === 'insert-after' ? box.insertChildAfter(target, after) : box.reorderChildAfter(target, after);
+                expect(ok).toBe(result !== null);
+                const order = [...box.children].map((view) => (view as HTMLElement).dataset.id);
+                expect(order).toStrictEqual(result === null ? [...children] : [...result]);
+                unmountAll();
+            });
+        }
+
+        await it('removeAll empties the box, leaving the box itself mounted', () => {
+            const { box } = mountWrapBox({}, 4);
+            expect(box.children.length).toBe(4);
+            (box as HTMLElement & { removeAll(): void }).removeAll();
+            expect(box.children.length).toBe(0);
+            expect(box.isConnected).toBe(true);
+            unmountAll();
+        });
     });
 };

--- a/packages/web/adwaita-web/src/chrome.spec.ts
+++ b/packages/web/adwaita-web/src/chrome.spec.ts
@@ -14,7 +14,7 @@
 // faking one.
 import { describe, expect, it } from '@gjsify/unit';
 
-import { ADW_SPINNER_MIN_SIZE, spinnerGeometry } from '@gjsify/adwaita-core';
+import { ADW_SPINNER_MIN_SIZE, ADW_SPINNER_TRACK_OPACITY, spinnerGeometry } from '@gjsify/adwaita-core';
 import {
     CLAMP_ALLOCATE_VECTORS,
     CLAMP_PROPERTY_VECTORS,
@@ -201,57 +201,156 @@ export const AdwChromeTest = async () => {
     });
 
     await describe('adw-spinner geometry (AdwSpinnerPaintable conformance vectors)', async () => {
+        /** The `<svg>` the element draws its ring into. */
+        const ringOf = (spinner: HTMLElement) => spinner.querySelector('svg') as SVGSVGElement;
+
         for (const { width, height, diameter, lineWidth, rule } of SPINNER_GEOMETRY_VECTORS) {
-            // The element is the ring itself, so only the square, allocatable
-            // boxes describe what a `size` attribute can produce.
+            // Only square, allocatable boxes describe what a `size` attribute
+            // can produce; the rectangular rows exercise the paintable directly.
             if (width !== height || width < ADW_SPINNER_MIN_SIZE) continue;
 
             await it(`size ${width} draws a ${diameter}px ring stroked ${lineWidth}px — ${rule}`, () => {
-                const { host } = mountSized(200);
+                const { host } = mountSized(400);
                 const spinner = document.createElement('adw-spinner');
                 spinner.setAttribute('size', String(width));
                 host.appendChild(spinner);
 
-                expect(spinner.offsetWidth).toBe(diameter);
-                expect(spinner.offsetHeight).toBe(diameter);
-                expect(Number.parseFloat(spinner.style.borderWidth)).toBe(lineWidth);
+                const svg = ringOf(spinner);
+                expect(svg.getAttribute('width')).toBe(String(diameter));
+                expect(svg.getAttribute('height')).toBe(String(diameter));
+                const arc = svg.querySelectorAll('circle')[1] as SVGCircleElement;
+                expect(Number(arc.getAttribute('stroke-width'))).toBe(lineWidth);
                 host.remove();
             });
         }
 
         await it('strokes 3px at 24 and 6px at 48, where it used to stroke 2 and 4', () => {
-            const { host } = mountSized(200);
+            const { host } = mountSized(400);
             const spinner = document.createElement('adw-spinner');
             host.appendChild(spinner);
             const strokeAt = (size: number) => {
                 spinner.setAttribute('size', String(size));
-                return Number.parseFloat(spinner.style.borderWidth);
+                return Number(ringOf(spinner).querySelector('circle')?.getAttribute('stroke-width'));
             };
             expect(strokeAt(24)).toBe(3);
             expect(strokeAt(48)).toBe(6);
             expect(strokeAt(64)).toBe(8);
             host.remove();
         });
+
+        await it('rounds its arc ends — GSK_LINE_CAP_ROUND, square-cut before', () => {
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner');
+            spinner.setAttribute('size', '64');
+            host.appendChild(spinner);
+            const [track, arc] = [...ringOf(spinner).querySelectorAll('circle')];
+            expect(arc.getAttribute('stroke-linecap')).toBe('round');
+            // The TRACK is the widget colour at CIRCLE_OPACITY, not a grey.
+            expect(track.getAttribute('stroke')).toBe('currentColor');
+            expect(Number(track.getAttribute('stroke-opacity'))).toBe(ADW_SPINNER_TRACK_OPACITY);
+            host.remove();
+        });
     });
 
-    await describe('adw-spinner sizing (adw_spinner_measure minimum = natural)', async () => {
+    await describe('adw-spinner sizing — the BOX and the RING are different things', async () => {
         for (const { value, size, rule } of SPINNER_SIZE_VECTORS) {
-            await it(`size ${JSON.stringify(value ?? null)} → a ${spinnerGeometry(size, size).diameter}px ring — ${rule}`, () => {
+            await it(`size ${JSON.stringify(value ?? null)} → a ${size}px box — ${rule}`, () => {
                 const { host } = mountSized(400);
                 const spinner = document.createElement('adw-spinner');
                 if (value !== null && value !== undefined) spinner.setAttribute('size', String(value));
                 host.appendChild(spinner);
 
-                expect(spinner.offsetWidth).toBe(spinnerGeometry(size, size).diameter);
+                // THE BOX takes the whole request — this suite used to assert the
+                // ring's diameter here, contradicting the core table it drives.
+                expect(spinner.offsetWidth).toBe(size);
+                expect(spinner.offsetHeight).toBe(size);
+                // THE RING is capped and centred inside it.
+                const svg = spinner.querySelector('svg') as SVGSVGElement;
+                expect(Number(svg.getAttribute('width'))).toBe(spinnerGeometry(size, size).diameter);
                 host.remove();
             });
         }
+
+        await it('a 200px spinner occupies 200px and draws a 64px ring', () => {
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner');
+            spinner.setAttribute('size', '200');
+            host.appendChild(spinner);
+            expect(spinner.offsetWidth).toBe(200);
+            expect(Number((spinner.querySelector('svg') as SVGSVGElement).getAttribute('width'))).toBe(64);
+            host.remove();
+        });
 
         await it('defaults to the measured 16, not the invented 24', () => {
             const { host } = mountSized(400);
             const spinner = document.createElement('adw-spinner');
             host.appendChild(spinner);
             expect(spinner.offsetWidth).toBe(ADW_SPINNER_MIN_SIZE);
+            host.remove();
+        });
+    });
+
+    await describe('adw-spinner animation + accessibility (#1066)', async () => {
+        await it('announces itself — role progressbar, aria-busy (zero hits before)', () => {
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner');
+            host.appendChild(spinner);
+            expect(spinner.getAttribute('role')).toBe('progressbar');
+            expect(spinner.getAttribute('aria-busy')).toBe('true');
+            host.remove();
+        });
+
+        await it('BREATHES — the drawn arc length changes across a turn', () => {
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner') as HTMLElement & { drawAt(now: number): void };
+            spinner.setAttribute('size', '64');
+            host.appendChild(spinner);
+            const arc = spinner.querySelectorAll('circle')[1] as SVGCircleElement;
+
+            const drawnAt = (ms: number) => {
+                spinner.drawAt(ms);
+                return Number.parseFloat((arc.getAttribute('stroke-dasharray') ?? '0').split(' ')[0]);
+            };
+            // `drawAt` takes the FIRST call as the origin, so these are offsets
+            // into one animation, sampled across a cycle.
+            const lengths = [0, 200, 500, 900, 1300, 1900].map(drawnAt);
+            const spread = Math.max(...lengths) - Math.min(...lengths);
+            // A fixed 90-degree border chase — what this element used to draw —
+            // has a spread of exactly zero.
+            expect(spread).toBeGreaterThan(0);
+            host.remove();
+        });
+
+        await it('KEEPS SPINNING under reduced motion — a frozen busy indicator reads as a hang', () => {
+            // libadwaita opts the spinner out of the animation setting on purpose
+            // (adw-spinner-paintable.c:537). The old stylesheet had
+            // `@media (prefers-reduced-motion: reduce) { animation: none }`, so
+            // this asserts the ABSENCE of any CSS animation to switch off: the
+            // arc is driven per frame from JS and cannot be disabled by a query.
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner');
+            host.appendChild(spinner);
+            expect(getComputedStyle(spinner).animationName).toBe('none');
+            host.remove();
+        });
+
+        await it('advances while mapped and stops when it is not', () => {
+            const { host } = mountSized(400);
+            const spinner = document.createElement('adw-spinner') as HTMLElement & { drawAt(now: number): void };
+            host.appendChild(spinner);
+            const arc = spinner.querySelectorAll('circle')[1] as SVGCircleElement;
+            spinner.drawAt(0);
+            const first = arc.getAttribute('stroke-dashoffset');
+            spinner.drawAt(400);
+            expect(arc.getAttribute('stroke-dashoffset')).not.toBe(first);
+
+            // Unmapping removes it from the shared ticker — `widget_map_cb`
+            // (adw-spinner-paintable.c:181-185) is what plays the animation, so
+            // an off-screen spinner burns nothing.
+            spinner.remove();
+            const parked = arc.getAttribute('stroke-dashoffset');
+            spinner.drawAt(800); // only reachable directly; the ticker has dropped it
+            expect(arc.getAttribute('stroke-dashoffset')).not.toBe(parked);
             host.remove();
         });
     });

--- a/packages/web/adwaita-web/src/elements/adw-combo-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-combo-row.ts
@@ -85,6 +85,7 @@ export class AdwComboRow extends HTMLElement {
         this._state.subscribe((change) => {
             this._valueEl.textContent = change.label;
             if (this._select.selectedIndex !== change.selected) this._select.selectedIndex = change.selected;
+            this._syncChooser();
             if (!change.interactive) return;
             this.setAttribute('selected', String(change.selected));
             this.dispatchEvent(
@@ -101,6 +102,7 @@ export class AdwComboRow extends HTMLElement {
             this._state.select(this._select.selectedIndex);
         });
 
+        this._syncChooser();
         this._renderText();
     }
 
@@ -113,6 +115,21 @@ export class AdwComboRow extends HTMLElement {
         } else {
             this._renderText();
         }
+    }
+
+    /**
+     * `model_changed` (adw-combo-row.c:187-195) — one option or none is not a
+     * choice, so the arrow goes and the row stops being activatable.
+     *
+     * Both halves have to be expressed: `data-presents-chooser` gates the
+     * `.adw-row-value::after` mask in the stylesheet, and DISABLING the overlaid
+     * `<select>` is what makes the row inert — hiding the arrow alone would leave
+     * a row that still opens a one-entry popup on click.
+     */
+    private _syncChooser() {
+        const presents = this._state.presentsChooser;
+        this.dataset.presentsChooser = presents ? 'true' : 'false';
+        this._select.disabled = !presents;
     }
 
     private _renderText() {

--- a/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
@@ -108,7 +108,7 @@ export class AdwInlineViewSwitcher extends HTMLElement {
     private _pageObserver: MutationObserver | undefined;
 
     static get observedAttributes() {
-        return ['active', 'display-mode', 'flat', 'round'];
+        return ['active', 'display-mode', 'flat', 'round', 'osd'];
     }
 
     constructor() {
@@ -383,8 +383,16 @@ export class AdwInlineViewSwitcher extends HTMLElement {
     }
 
     private _applyStyleClasses(): void {
-        this.classList.toggle('flat', this.hasAttribute('flat'));
-        this.classList.toggle('round', this.hasAttribute('round'));
+        // `css_classes_changed_cb` (adw-inline-view-switcher.c:528-545) forwards
+        // THREE classes onto the toggle group, not two: `flat`, `round` and
+        // `osd`. This element carried the first two and only onto the host, so an
+        // `osd` inline switcher — the one in a floating overlay, where the class
+        // exists to make it legible — styled nothing at all.
+        for (const name of ['flat', 'round', 'osd'] as const) {
+            const present = this.hasAttribute(name);
+            this.classList.toggle(name, present);
+            this._groupEl?.classList.toggle(name, present);
+        }
         // The group carries the display-mode class, mirroring libadwaita's
         // inline-view-switcher > toggle-group.{labels,icons,both} (:826-850).
         for (const mode of INLINE_VIEW_SWITCHER_DISPLAY_MODES) {

--- a/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
@@ -53,6 +53,7 @@ import {
     isInlineViewSwitcherDisplayMode,
     toggleIndexForPage,
 } from '@gjsify/adwaita-core';
+import type { ViewSwitcherScheduler } from '@gjsify/adwaita-core';
 import type {
     AdwInlineViewSwitcherDisplayMode,
     AdwViewSwitcherPage,
@@ -75,13 +76,36 @@ export class AdwViewStackPage extends HTMLElement {
 }
 
 export class AdwInlineViewSwitcher extends HTMLElement {
-    private readonly _state = new ViewSwitcherState({ scheduler: domViewSwitcherScheduler });
+    /**
+     * The dwell timer, injectable.
+     *
+     * It used to be `new ViewSwitcherState({ scheduler: domViewSwitcherScheduler })`
+     * inline, which left NOWHERE to hand a clock in — so
+     * `VIEW_SWITCHER_DRAG_VECTORS` was driven by the core suite alone, and the
+     * conformance header claimed all three suites drove it. `scheduler` is a
+     * property so a test can replace it before the element connects; the DOM one
+     * is the default, exactly as before.
+     */
+    scheduler: ViewSwitcherScheduler = domViewSwitcherScheduler;
+    private _stateInstance: ViewSwitcherState | null = null;
+
+    /** Built on first access, so a `scheduler` set before connect is the one used. */
+    private get _state(): ViewSwitcherState {
+        if (!this._stateInstance) {
+            this._stateInstance = new ViewSwitcherState({ scheduler: this.scheduler });
+            this._stateInstance.subscribe((change) => this._onStateChange(change));
+        }
+        return this._stateInstance;
+    }
     private _groupEl!: HTMLDivElement;
     private _pagesEl!: HTMLDivElement;
     private _panels: HTMLDivElement[] = [];
     private _toggles: HTMLButtonElement[] = [];
     private _displayMode: AdwInlineViewSwitcherDisplayMode = 'labels';
     private _initialized = false;
+    /** The page ELEMENTS, kept because this element detaches them from the tree. */
+    private _declared: HTMLElement[] = [];
+    private _pageObserver: MutationObserver | undefined;
 
     static get observedAttributes() {
         return ['active', 'display-mode', 'flat', 'round'];
@@ -89,7 +113,6 @@ export class AdwInlineViewSwitcher extends HTMLElement {
 
     constructor() {
         super();
-        this._state.subscribe((change) => this._onStateChange(change));
     }
 
     /** Zero-based index of the visible PAGE, `-1` when nothing is selected. */
@@ -176,6 +199,8 @@ export class AdwInlineViewSwitcher extends HTMLElement {
         this._displayMode = this._readDisplayModeAttr();
         this._initialized = true;
 
+        this._declared = declared;
+        this._watchPages();
         this._state.setPages(declared.map((pageEl) => readSwitcherPage(pageEl)));
         if (declaredActive !== null) {
             const index = Number.parseInt(declaredActive, 10);
@@ -186,6 +211,37 @@ export class AdwInlineViewSwitcher extends HTMLElement {
 
     disconnectedCallback() {
         this._state.cancelDrag();
+        this._pageObserver?.disconnect();
+        this._pageObserver = undefined;
+    }
+
+    /**
+     * Re-read every declared page and push it into the state.
+     *
+     * Driven by {@link _watchPages}, which is what makes a runtime
+     * `badge-number` or `icon-name` change reach the toggle — C rebinds on every
+     * page `notify` (adw-view-switcher.c:184-193) and this element did not.
+     */
+    refreshPages(): void {
+        if (!this._initialized) return;
+        this._state.setPages(this._declared.map((pageEl) => readSwitcherPage(pageEl)));
+        this._rebuildToggles();
+    }
+
+    /**
+     * Watch the declared pages for attribute changes — the DOM's `notify::` on
+     * `AdwViewStackPage`, which C binds per page (adw-view-switcher.c:184-193).
+     *
+     * A `MutationObserver` rather than an `attributeChangedCallback`: this
+     * element consumes the page elements at connect and `replaceChildren`s them
+     * out of the tree, so a detached page cannot find its owner. It delivers on
+     * a MICROTASK where GTK's notify is synchronous — invisible to a user, and
+     * nothing here reads the toggle back inside the setter.
+     */
+    private _watchPages(): void {
+        this._pageObserver?.disconnect();
+        this._pageObserver = new MutationObserver(() => this.refreshPages());
+        for (const pageEl of this._declared) this._pageObserver.observe(pageEl, { attributes: true });
     }
 
     attributeChangedCallback(name: string) {
@@ -265,8 +321,21 @@ export class AdwInlineViewSwitcher extends HTMLElement {
             toggle.addEventListener('click', () => {
                 this._state.setSelected(model.pageIndex);
             });
-            toggle.addEventListener('dragenter', () => this._state.dragEnter(model.pageIndex));
-            toggle.addEventListener('dragleave', () => this._state.dragLeave(model.pageIndex));
+            // The `relatedTarget` test is load-bearing: a toggle holds an icon,
+            // a label and an indicator, and the DOM fires `dragleave` +
+            // `dragenter` when the pointer crosses BETWEEN them — which cleared
+            // the dwell timer and re-armed a fresh 500ms, so a drag that merely
+            // slid across the toggle never switched the page. C has one
+            // `GtkDropControllerMotion` per BUTTON widget
+            // (adw-view-switcher-button.c:79-96), which has no internal edges.
+            toggle.addEventListener('dragenter', (event) => {
+                if (toggle.contains((event as DragEvent).relatedTarget as Node | null)) return;
+                this._state.dragEnter(model.pageIndex);
+            });
+            toggle.addEventListener('dragleave', (event) => {
+                if (toggle.contains((event as DragEvent).relatedTarget as Node | null)) return;
+                this._state.dragLeave(model.pageIndex);
+            });
 
             this._groupEl.appendChild(toggle);
             return toggle;

--- a/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
@@ -2,31 +2,74 @@
 // visible when expanded; when `collapsed` it shows one pane at a time
 // (`show-content` decides which), mirroring Adw.NavigationSplitView's
 // push-navigation on narrow widths.
-// Attributes: collapsed, show-content, min-sidebar-width, max-sidebar-width,
-//   breakpoint (an Adwaita condition, e.g. "max-width: 720px", that collapses
-//   the view by itself — the counterpart to an Adw.Breakpoint add_setter()).
+//
+// Attributes: collapsed, show-content, sidebar-position, min-sidebar-width,
+//   max-sidebar-width, breakpoint (an Adwaita condition, e.g. "max-width: 720px",
+//   that collapses the view by itself — the counterpart to an Adw.Breakpoint
+//   add_setter()). A slotted pane may carry `tag`, which is
+//   `Adw.NavigationPage:tag`.
 // Slots: slot="sidebar", slot="content".
+//
+// The element used to toggle two CSS classes and nothing else, so THREE rules
+// from the C had no expression here at all: the navigation-stack ordering table
+// (a LONE child stays visible whatever `show-content` says; with
+// `sidebar-position: end` the CONTENT is the root page), the duplicate-tag
+// guard, and the `navigation.push` / `navigation.pop` routing that lets a nested
+// split view forward a push outwards. All three are `NavigationSplitViewState`
+// in `@gjsify/adwaita-core`, held to NAVIGATION_STACK_VECTORS,
+// NAVIGATION_SPLIT_VIEW_CRITICALS and NAVIGATION_ACTION_VECTORS — the last of
+// which had no consumer at all before this.
+//
 // Reference: refs/adwaita-web/adwaita-web/docs/widgets/navigationsplitview.md
+// Reference: refs/libadwaita/src/adw-navigation-split-view.c
 // Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
-import { DEFAULT_MAX_SIDEBAR_WIDTH, DEFAULT_MIN_SIDEBAR_WIDTH, resolveSidebarBounds } from '@gjsify/adwaita-core';
+import {
+    DEFAULT_MAX_SIDEBAR_WIDTH,
+    DEFAULT_MIN_SIDEBAR_WIDTH,
+    NavigationSplitViewState,
+    isSidebarAtVisualStart,
+    resolveSidebarBounds,
+    type AdwPackType,
+    type AdwTextDirection,
+    type NavigationActionResult,
+} from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+
+/** Detail of the `navigation-push` / `navigation-pop` delegation event. */
+export interface NavigationDelegateDetail {
+    /** The tag a `push` names; absent for a `pop`. */
+    tag?: string;
+    /** Set by an ancestor that handled it — the `return TRUE` of the C's routing. */
+    handled: boolean;
+}
 
 export class AdwNavigationSplitView extends HTMLElement {
     private _sidebarEl!: HTMLDivElement;
     private _contentEl!: HTMLDivElement;
     private _initialized = false;
     private _disposeBreakpoint: (() => void) | undefined;
+    /** The ordering table, the tag guard and the action routing (ADR 0004). */
+    private _state = new NavigationSplitViewState();
+    /** Re-entrancy guard for the `show-content` reflection. */
+    private _reflecting = false;
 
     static get observedAttributes() {
-        return ['collapsed', 'show-content', 'min-sidebar-width', 'max-sidebar-width', 'breakpoint'];
+        return [
+            'collapsed',
+            'show-content',
+            'sidebar-position',
+            'min-sidebar-width',
+            'max-sidebar-width',
+            'breakpoint',
+        ];
     }
 
     get collapsed(): boolean {
-        return this.hasAttribute('collapsed');
+        return this._initialized ? this._state.collapsed : this.hasAttribute('collapsed');
     }
 
     set collapsed(v: boolean) {
@@ -35,11 +78,47 @@ export class AdwNavigationSplitView extends HTMLElement {
 
     /** When collapsed, whether the content pane (true) or sidebar (false) shows. */
     get showContent(): boolean {
-        return this.hasAttribute('show-content');
+        return this._initialized ? this._state.showContent : this.hasAttribute('show-content');
     }
 
     set showContent(v: boolean) {
         this.toggleAttribute('show-content', v);
+    }
+
+    /** Which side the sidebar is packed on — `start` (default) or `end`. */
+    get sidebarPosition(): AdwPackType {
+        return this.getAttribute('sidebar-position') === 'end' ? 'end' : 'start';
+    }
+
+    set sidebarPosition(value: AdwPackType) {
+        this.setAttribute('sidebar-position', value);
+    }
+
+    /** The sidebar page's tag of record, or `null`. */
+    get sidebarTag(): string | null {
+        return this._state.sidebarTag;
+    }
+
+    /** The content page's tag of record, or `null`. */
+    get contentTag(): string | null {
+        return this._state.contentTag;
+    }
+
+    /**
+     * `navigation.push` with `tag` — `navigation_push_cb` (:644-685).
+     *
+     * An unmatched tag DELEGATES to the parent before it may become a critical,
+     * which is how nested split views forward a push outwards; on this port that
+     * is a bubbling `navigation-push` event whose `detail.handled` an ancestor
+     * sets. Returns what the routing decided.
+     */
+    push(tag: string): NavigationActionResult {
+        return this._state.push(tag);
+    }
+
+    /** `navigation.pop` — `navigation_pop_cb` (:687-702). */
+    pop(): NavigationActionResult {
+        return this._state.pop();
     }
 
     connectedCallback() {
@@ -58,9 +137,66 @@ export class AdwNavigationSplitView extends HTMLElement {
         for (const child of contentChildren) this._contentEl.appendChild(child);
 
         this.replaceChildren(this._sidebarEl, this._contentEl);
+
+        // Parse-time attributes are the CONSTRUCTION properties, for the same
+        // reason the overlay view treats them so: applying them as sequential
+        // setters would emit a transition for a state the markup simply declared.
+        this._state = new NavigationSplitViewState({
+            sidebarPosition: this.sidebarPosition,
+            collapsed: this.hasAttribute('collapsed'),
+            showContent: this.hasAttribute('show-content'),
+            // `g_critical` has no browser counterpart that a consumer can see;
+            // `console.error` is the one a developer reads, and the TEXT is the
+            // C's verbatim so a GTK bug report and a browser one say the same.
+            onCritical: (message) => console.error(message),
+            onDelegate: (action, tag) => {
+                const detail: NavigationDelegateDetail = { tag, handled: false };
+                this.dispatchEvent(new CustomEvent(`navigation-${action}`, { bubbles: true, detail }));
+                return detail.handled;
+            },
+        });
+        // Which children EXIST decides the stack, so the panes are mounted into
+        // the state, not merely into the DOM — a lone child stays visible
+        // whatever `show-content` says (:389-401), which two CSS classes cannot
+        // express.
+        this._state.setSidebar(sidebarChildren.length > 0 ? { tag: this._tagOf(sidebarChildren) } : null);
+        this._state.setContent(contentChildren.length > 0 ? { tag: this._tagOf(contentChildren) } : null);
+        this._state.subscribe(() => {
+            this._reflectShowContent();
+            this._syncClasses();
+        });
+
         this._syncWidth();
         this._syncClasses();
         this._syncBreakpoint();
+    }
+
+    /** `Adw.NavigationPage:tag` off the slotted pane, or `null` when untagged. */
+    private _tagOf(children: readonly Element[]): string | null {
+        for (const child of children) {
+            const tag = child.getAttribute('tag');
+            if (tag !== null) return tag;
+        }
+        return null;
+    }
+
+    /**
+     * Mirror the state's `showContent` onto the attribute, so the DOM keeps
+     * telling the truth after a `navigation.push` moved it.
+     *
+     * Guarded the way the overlay view's reflection is: writing the attribute
+     * re-enters `attributeChangedCallback`, which without the flag is a loop.
+     */
+    private _reflectShowContent() {
+        if (this._reflecting) return;
+        const wanted = this._state.showContent;
+        if (this.hasAttribute('show-content') === wanted) return;
+        this._reflecting = true;
+        try {
+            this.toggleAttribute('show-content', wanted);
+        } finally {
+            this._reflecting = false;
+        }
     }
 
     disconnectedCallback() {
@@ -70,13 +206,20 @@ export class AdwNavigationSplitView extends HTMLElement {
 
     attributeChangedCallback(name: string) {
         if (!this._initialized) return;
-        if (name === 'breakpoint') this._syncBreakpoint();
-        else if (name === 'min-sidebar-width' || name === 'max-sidebar-width') this._syncWidth();
-        else {
-            this._syncClasses();
-            // Collapsing flips whether the sidebar is width-capped, so re-apply.
-            this._syncWidth();
+        if (name === 'breakpoint') {
+            this._syncBreakpoint();
+            return;
         }
+        if (name === 'min-sidebar-width' || name === 'max-sidebar-width') {
+            this._syncWidth();
+            return;
+        }
+        if (name === 'collapsed') this._state.setCollapsed(this.hasAttribute('collapsed'));
+        if (name === 'show-content') this._state.setShowContent(this.hasAttribute('show-content'));
+        if (name === 'sidebar-position') this._state.setSidebarPosition(this.sidebarPosition);
+        this._syncClasses();
+        // Collapsing flips whether the sidebar is width-capped, so re-apply.
+        this._syncWidth();
     }
 
     private _syncWidth() {
@@ -113,9 +256,31 @@ export class AdwNavigationSplitView extends HTMLElement {
         return Number.isFinite(value) ? value : fallback;
     }
 
+    /** The reading direction `start` / `end` resolve against (`get_start_or_end`, :220-227). */
+    private get _direction(): AdwTextDirection {
+        return getComputedStyle(this).direction === 'rtl' ? 'rtl' : 'ltr';
+    }
+
     private _syncClasses() {
-        this.classList.toggle('collapsed', this.collapsed);
-        this.classList.toggle('show-content', this.showContent);
+        const state = this._state;
+        this.classList.toggle('collapsed', state.collapsed);
+        this.classList.toggle('show-content', state.showContent);
+        this.classList.toggle('sidebar-end', state.sidebarPosition === 'end');
+        // The VISUAL side, which under RTL is the opposite of the logical one —
+        // it decides where the pane is drawn AND which edge its divider is on.
+        this.classList.toggle(
+            'sidebar-at-visual-start',
+            isSidebarAtVisualStart(state.sidebarPosition, this._direction),
+        );
+
+        // The STACK, not the two flags: `update_navigation_stack` (:342-405)
+        // keeps a LONE child visible whatever `show-content` says, and with
+        // `sidebar-position: end` the CONTENT is the root page — so the sidebar
+        // is PUSHED ON TOP of it rather than replacing it.
+        const { stack } = state.stack;
+        const visible = stack[stack.length - 1] ?? null;
+        if (this._sidebarEl) this._sidebarEl.dataset.paneVisible = String(!state.collapsed || visible === 'sidebar');
+        if (this._contentEl) this._contentEl.dataset.paneVisible = String(!state.collapsed || visible === 'content');
     }
 
     /** (Re)bind the `breakpoint` condition to `collapsed`. */

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -539,7 +539,18 @@ export class AdwOverlaySplitView extends HTMLElement {
                     return;
                 }
                 state.beginSwipe();
-                this.setPointerCapture(event.pointerId);
+                // Capture keeps the move/up events coming once the pointer
+                // leaves the element — an optimisation, not a precondition. It
+                // THROWS for a pointer id the browser has no active pointer for,
+                // which Firefox does strictly and Chromium tolerates: a synthetic
+                // event, or one whose pointer was already released, aborted the
+                // whole gesture before the progress was ever written. The swipe
+                // still works without it, so the failure is swallowed on purpose.
+                try {
+                    this.setPointerCapture(event.pointerId);
+                } catch {
+                    /* no active pointer for this id — the gesture does not need capture */
+                }
             }
             state.setShowProgress(this._swipeOrigin.progress + travel);
         });
@@ -549,6 +560,8 @@ export class AdwOverlaySplitView extends HTMLElement {
             this._swipePointer = null;
             const state = this._state;
             if (!state.swipeActive) return;
+            // Same asymmetry on the way out: `hasPointerCapture` is false when the
+            // capture above was refused, so the release is already conditional.
             if (this.hasPointerCapture(event.pointerId)) this.releasePointerCapture(event.pointerId);
             // A cancelled gesture snaps back to where it came from
             // (`get_cancel_progress`, :1253-1258); a released one settles on the

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -12,11 +12,63 @@ import {
     DEFAULT_MIN_SIDEBAR_WIDTH,
     DEFAULT_SIDEBAR_WIDTH_FRACTION,
     OverlaySplitViewState,
+    isSidebarAtVisualStart,
+    layoutOverlaySplitView,
+    resolveOverlaySidebarWidth,
     resolveSidebarBounds,
+    resolveSwipeArea,
+    resolveSwipeSnapPoints,
+    resolveSwipeStart,
+    swipeCancelProgress,
     type AdwPackType,
+    type AdwTextDirection,
+    type SplitViewAnimator,
 } from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+
+/**
+ * The reveal spring, as a CSS-timed animator.
+ *
+ * libadwaita animates with a spring `(1, 0.5, 500)`
+ * (adw-overlay-split-view.c:1163-1165). A browser cannot be handed spring
+ * parameters, so this drives the progress from `requestAnimationFrame` on a
+ * critically-damped approximation and lets the element write the resulting
+ * geometry — which is the same seam the NativeScript port fills with
+ * `View.animate()`, and the same one a test fills with an instant fake.
+ */
+const CSS_SPLIT_VIEW_ANIMATOR: SplitViewAnimator = {
+    animate(request) {
+        let handle = 0;
+        let cancelled = false;
+        // 250ms is the visible settle time of libadwaita's spring at these
+        // parameters; the CURVE is an approximation and says so, the ENDPOINTS
+        // are exact because `onDone` writes `to`.
+        const duration = 250;
+        const start = performance.now();
+        const step = (now: number) => {
+            if (cancelled) return;
+            const t = Math.min((now - start) / duration, 1);
+            // ease-out: fast first, settling — the visible signature of a spring
+            // with no overshoot, which is what `clamp` asks for anyway.
+            const eased = 1 - (1 - t) * (1 - t);
+            request.onValue(request.from + (request.to - request.from) * eased);
+            if (t < 1) {
+                handle = requestAnimationFrame(step);
+                return;
+            }
+            request.onValue(request.to);
+            request.onDone();
+        };
+        handle = requestAnimationFrame(step);
+        return {
+            cancel() {
+                cancelled = true;
+                if (handle) cancelAnimationFrame(handle);
+            },
+        };
+    },
+};
 
 /**
  * Read a boolean attribute the way a GTK property with a TRUE default has to be
@@ -48,6 +100,13 @@ export class AdwOverlaySplitView extends HTMLElement {
     private _state = new OverlaySplitViewState();
     /** Re-entrancy guard for {@link _reflectShowSidebar}. */
     private _reflecting = false;
+    /** The view's own width in CSS px — the size the sidebar fraction is OF. */
+    private _measuredWidth = 0;
+    private _resizeObserver: ResizeObserver | undefined;
+    /** The pointer currently panning the sidebar, if any. */
+    private _swipePointer: number | null = null;
+    /** Where the pan started, and the progress it started from. */
+    private _swipeOrigin = { x: 0, progress: 0 };
 
     /**
      * Every attribute {@link _readAttribute} handles must be listed here — an
@@ -65,6 +124,8 @@ export class AdwOverlaySplitView extends HTMLElement {
             'min-sidebar-width',
             'max-sidebar-width',
             'sidebar-width-fraction',
+            'enable-show-gesture',
+            'enable-hide-gesture',
             'breakpoint',
         ];
     }
@@ -150,7 +211,37 @@ export class AdwOverlaySplitView extends HTMLElement {
             showSidebar: readTriStateAttr(this, 'show-sidebar', true),
             pinSidebar: this.hasAttribute('pin-sidebar'),
             sidebarPosition: this.getAttribute('sidebar-position') === 'end' ? 'end' : ('start' as AdwPackType),
+            enableShowGesture: readTriStateAttr(this, 'enable-show-gesture', true),
+            enableHideGesture: readTriStateAttr(this, 'enable-hide-gesture', true),
+            animator: CSS_SPLIT_VIEW_ANIMATOR,
         });
+        // Every progress step repaints — the reveal is a CONTINUUM now, not two
+        // end states, which is what the five OVERLAY_SWIPE_* tables describe.
+        this._state.subscribe(() => {
+            this._reflectShowSidebar();
+            this._syncClasses();
+        });
+
+        // The view's own box is the size source, the same one the breakpoints
+        // use: the sidebar width is a FRACTION of it and has to be recomputed
+        // when it changes, which a one-shot read at connect could not do.
+        this._resizeObserver = new ResizeObserver((entries) => {
+            const entry = entries[entries.length - 1];
+            if (!entry) return;
+            const box = entry.borderBoxSize?.[0];
+            this._measuredWidth = box ? box.inlineSize : entry.contentRect.width;
+            this._syncSidebarWidth();
+            this._syncClasses();
+        });
+        this._resizeObserver.observe(this);
+
+        // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) — absent from
+        // BOTH ports, which made `OverlaySplitViewState.escape()` dead code.
+        // Bound on the element, so it only fires while focus is inside the view
+        // and still propagates when the state declines to consume it.
+        this.addEventListener('keydown', this._onKeyDown);
+        this._bindSwipe();
+
         this._reflectShowSidebar();
         this._syncClasses();
         this._syncSidebarWidth();
@@ -160,7 +251,18 @@ export class AdwOverlaySplitView extends HTMLElement {
     disconnectedCallback() {
         this._disposeBreakpoint?.();
         this._disposeBreakpoint = undefined;
+        this._resizeObserver?.disconnect();
+        this._resizeObserver = undefined;
+        this.removeEventListener('keydown', this._onKeyDown);
     }
+
+    /** `escape_shortcut_cb` — only a COLLAPSED view with a revealed sidebar consumes it. */
+    private readonly _onKeyDown = (event: KeyboardEvent) => {
+        if (event.key !== 'Escape' || event.defaultPrevented) return;
+        // The state decides: an uncollapsed view lets Escape through so an
+        // enclosing dialog still closes.
+        if (this._state.escape()) event.preventDefault();
+    };
 
     attributeChangedCallback(_name: string, _old: string | null, _val: string | null) {
         if (!this._initialized) return;
@@ -169,10 +271,20 @@ export class AdwOverlaySplitView extends HTMLElement {
             return;
         }
         this._readAttribute(_name);
-        this._syncClasses();
-        if (_name === 'min-sidebar-width' || _name === 'max-sidebar-width' || _name === 'sidebar-width-fraction') {
+        // `collapsed` is in the list because `get_sidebar_width` IGNORES the
+        // fraction while collapsed and clamps the VIEW width instead
+        // (adw-overlay-split-view.c:462-463) — a collapsed sidebar is a
+        // different number, not the same one drawn differently. Leaving it out
+        // is the frame-late bug the NativeScript port paid for.
+        if (
+            _name === 'min-sidebar-width' ||
+            _name === 'max-sidebar-width' ||
+            _name === 'sidebar-width-fraction' ||
+            _name === 'collapsed'
+        ) {
             this._syncSidebarWidth();
         }
+        this._syncClasses();
     }
 
     /**
@@ -196,6 +308,14 @@ export class AdwOverlaySplitView extends HTMLElement {
         }
         if (name === 'show-sidebar') {
             state.setShowSidebar(readTriStateAttr(this, 'show-sidebar', true));
+        }
+        // Both default TRUE (adw-overlay-split-view.c:1178-1210), so they read
+        // through the tri-state helper for the same reason `show-sidebar` does.
+        if (name === 'enable-show-gesture') {
+            state.setEnableShowGesture(readTriStateAttr(this, 'enable-show-gesture', true));
+        }
+        if (name === 'enable-hide-gesture') {
+            state.setEnableHideGesture(readTriStateAttr(this, 'enable-hide-gesture', true));
         }
         // Last: it can change `show-sidebar`, so it must not be overwritten after.
         if (name === 'collapsed') state.setCollapsed(this.hasAttribute('collapsed'));
@@ -248,12 +368,47 @@ export class AdwOverlaySplitView extends HTMLElement {
         );
     }
 
+    /**
+     * The reading direction `start` / `end` are resolved against.
+     *
+     * `get_start_or_end` (adw-overlay-split-view.c:227-234) returns
+     * `GTK_PACK_END` under RTL, so a `start` sidebar is drawn on the RIGHT.
+     * Neither renderer mirrored any of it; the browser has the direction for
+     * free and only had to read it.
+     */
+    private get _direction(): AdwTextDirection {
+        return getComputedStyle(this).direction === 'rtl' ? 'rtl' : 'ltr';
+    }
+
+    /** The sizing properties as the core takes them. */
+    private get _widthSpec() {
+        return {
+            minSidebarWidth: this.minSidebarWidth,
+            maxSidebarWidth: this.maxSidebarWidth,
+            sidebarWidthFraction: this.sidebarWidthFraction,
+        };
+    }
+
+    /** The sidebar's allocated width in px — `get_sidebar_width` (:441-466). */
+    private get _sidebarWidth(): number {
+        return resolveOverlaySidebarWidth({
+            ...this._widthSpec,
+            totalWidth: this._measuredWidth,
+            collapsed: this._state.collapsed,
+        });
+    }
+
     private _syncClasses() {
         const state = this._state;
         this.classList.toggle('collapsed', state.collapsed);
         this.classList.toggle('show-sidebar', state.showSidebar);
+        const atStart = isSidebarAtVisualStart(state.sidebarPosition, this._direction);
         this.classList.toggle('sidebar-start', state.sidebarPosition === 'start');
         this.classList.toggle('sidebar-end', state.sidebarPosition === 'end');
+        // The VISUAL side, which under RTL is the opposite of the logical one.
+        // The stylesheet needs it for the divider edge, which `border-inline-*`
+        // alone cannot get right: the divider follows where the pane is DRAWN.
+        this.classList.toggle('sidebar-at-visual-start', atStart);
 
         // Derived, not re-decided here: the shield only exists while collapsed
         // AND revealed, and each pane is reachable by keyboard only when it is
@@ -262,16 +417,57 @@ export class AdwOverlaySplitView extends HTMLElement {
         this._sidebarEl?.setAttribute('aria-hidden', String(!state.sidebarFocusable));
         this._contentEl?.setAttribute('aria-hidden', String(!state.contentFocusable));
 
-        // In docked mode, use negative margin to collapse sidebar space
-        // while keeping the sidebar's intrinsic width (slide animation).
-        if (this._sidebarEl && !this.collapsed) {
-            if (!this.showSidebar) {
-                const w = this._sidebarEl.offsetWidth;
-                this._sidebarEl.style.marginRight = `-${w}px`;
-            } else {
-                this._sidebarEl.style.marginRight = '';
-            }
+        this._syncGeometry();
+    }
+
+    /**
+     * Place the sidebar for the current progress — `allocate_uncollapsed`
+     * (:572-610) and `allocate_collapsed` (:653-703), through the core.
+     *
+     * The slide used to be `marginRight: -offsetWidth` REGARDLESS of which edge
+     * the sidebar is on, so an `end` sidebar slid the wrong way; and it was only
+     * two states, so a swipe had nothing to drive. `layoutOverlaySplitView`
+     * returns the pane rect for any progress including the overshoot, which is
+     * what makes a continuous gesture expressible at all.
+     */
+    private _syncGeometry() {
+        const sidebar = this._sidebarEl;
+        if (!sidebar || this._measuredWidth <= 0) return;
+        const state = this._state;
+        const measured = this._sidebarWidth;
+        const layout = layoutOverlaySplitView({
+            totalWidth: this._measuredWidth,
+            sidebarWidth: measured,
+            showProgress: state.showProgress,
+            collapsed: state.collapsed,
+            sidebarPosition: state.sidebarPosition,
+            direction: this._direction,
+        });
+        const atStart = isSidebarAtVisualStart(state.sidebarPosition, this._direction);
+
+        sidebar.style.width = `${layout.sidebar.width}px`;
+        if (state.collapsed) {
+            // Floating above the content: absolutely placed at the rect the core
+            // returned, so an overshoot widens the pane instead of detaching it.
+            sidebar.style.marginLeft = '';
+            sidebar.style.marginRight = '';
+            sidebar.style.insetInlineStart = '';
+            sidebar.style.left = `${layout.sidebar.x}px`;
+        } else {
+            // Docked: the pane keeps its place in the flex row and the hidden
+            // part is taken off the edge it is ON — the left one at visual
+            // start, the right one at visual end.
+            sidebar.style.left = '';
+            const hidden = measured - Math.trunc(measured * Math.min(state.showProgress, 1));
+            sidebar.style.marginLeft = atStart ? `${-hidden}px` : '';
+            sidebar.style.marginRight = atStart ? '' : `${-hidden}px`;
         }
+        sidebar.style.opacity = state.showProgress <= 0 ? '0' : '1';
+        // `sidebarPainted` is the snapshot gate (:757): below zero progress there
+        // is nothing on screen, and a pane that is not painted must not take
+        // pointer events either.
+        sidebar.style.pointerEvents = state.sidebarPainted ? '' : 'none';
+        if (this._backdropEl) this._backdropEl.style.opacity = String(1 - layout.shadowProgress);
     }
 
     private _syncSidebarWidth() {
@@ -280,14 +476,98 @@ export class AdwOverlaySplitView extends HTMLElement {
         // libadwaita never lets `max` fall below `min`, and CSS resolves that
         // conflict the other way round (min-width wins over max-width), so an
         // inverted pair would render differently here than in GTK.
-        const bounds = resolveSidebarBounds(
-            { minSidebarWidth: this.minSidebarWidth, maxSidebarWidth: this.maxSidebarWidth },
-            0,
-            { ceil: true },
-        );
+        const bounds = resolveSidebarBounds(this._widthSpec, 0, { ceil: true });
         this._sidebarEl.style.minWidth = `${bounds.min}px`;
         this._sidebarEl.style.maxWidth = `${bounds.max}px`;
-        this._sidebarEl.style.width = `${this.sidebarWidthFraction * 100}%`;
+        // NOT a CSS percentage. `(int)` truncates toward zero, and a percentage
+        // is fractional — core's own header forbids it in as many words, and
+        // this element carried one for its whole life.
+        this._syncGeometry();
+    }
+
+    // --- swipe (Adw.Swipeable) ---
+
+    /**
+     * The pan gesture the five `OVERLAY_SWIPE_*` tables describe.
+     *
+     * There was no gesture code in either renderer — grep for `pan` in both
+     * split views returned zero — so `showProgress` was only ever 0 or 1 and the
+     * tables shipped unexercised. Pointer events give the browser the whole
+     * gesture in three handlers; every DECISION in them is core's.
+     */
+    private _bindSwipe() {
+        this.addEventListener('pointerdown', (event) => {
+            if (this._swipePointer !== null || event.button !== 0) return;
+            const state = this._state;
+            const rect = this.getBoundingClientRect();
+            const area = resolveSwipeArea({
+                isDrag: true,
+                sidebarWidth: this._sidebarWidth,
+                showProgress: state.showProgress,
+                totalWidth: rect.width,
+                totalHeight: rect.height,
+                sidebarPosition: state.sidebarPosition,
+                direction: this._direction,
+            });
+            const x = event.clientX - rect.left;
+            const y = event.clientY - rect.top;
+            if (x < area.x || x > area.x + area.width || y < area.y || y > area.y + area.height) return;
+            this._swipePointer = event.pointerId;
+            this._swipeOrigin = { x: event.clientX, progress: state.showProgress };
+        });
+
+        this.addEventListener('pointermove', (event) => {
+            if (event.pointerId !== this._swipePointer) return;
+            const state = this._state;
+            const width = this._sidebarWidth || 1;
+            const atStart = isSidebarAtVisualStart(state.sidebarPosition, this._direction);
+            // Dragging AWAY from the sidebar's edge opens it, so the sign of the
+            // travel depends on which edge that is — the same `atStart` predicate
+            // the layout uses.
+            const travel = ((event.clientX - this._swipeOrigin.x) / width) * (atStart ? 1 : -1);
+            if (!state.swipeActive) {
+                if (
+                    !resolveSwipeStart({
+                        showProgress: state.showProgress,
+                        collapsed: state.collapsed,
+                        direction: travel >= 0 ? 'forward' : 'back',
+                        enableShowGesture: state.enableShowGesture,
+                        enableHideGesture: state.enableHideGesture,
+                    })
+                ) {
+                    this._swipePointer = null;
+                    return;
+                }
+                state.beginSwipe();
+                this.setPointerCapture(event.pointerId);
+            }
+            state.setShowProgress(this._swipeOrigin.progress + travel);
+        });
+
+        const release = (event: PointerEvent, cancelled: boolean) => {
+            if (event.pointerId !== this._swipePointer) return;
+            this._swipePointer = null;
+            const state = this._state;
+            if (!state.swipeActive) return;
+            if (this.hasPointerCapture(event.pointerId)) this.releasePointerCapture(event.pointerId);
+            // A cancelled gesture snaps back to where it came from
+            // (`get_cancel_progress`, :1253-1258); a released one settles on the
+            // NEAREST allowed snap point.
+            const points = resolveSwipeSnapPoints({
+                showProgress: state.showProgress,
+                enableShowGesture: state.enableShowGesture,
+                enableHideGesture: state.enableHideGesture,
+                swipeActive: true,
+            });
+            const target = cancelled
+                ? swipeCancelProgress(state.showProgress)
+                : points.reduce((best, point) =>
+                      Math.abs(point - state.showProgress) < Math.abs(best - state.showProgress) ? point : best,
+                  );
+            state.endSwipe(target);
+        };
+        this.addEventListener('pointerup', (event) => release(event, false));
+        this.addEventListener('pointercancel', (event) => release(event, true));
     }
 }
 

--- a/packages/web/adwaita-web/src/elements/adw-spinner.ts
+++ b/packages/web/adwaita-web/src/elements/adw-spinner.ts
@@ -1,45 +1,189 @@
 // <adw-spinner> — A continuously-spinning loading indicator.
-// Attributes: size (px; the measured minimum, 16, when absent or unusable).
+// Attributes: size (px; the BOX, floored at the measured minimum 16).
 //
-// The ring geometry is `Adw.Spinner`'s, not a guess: the diameter and the stroke
-// come from `@gjsify/adwaita-core`'s `spinnerGeometry`, which is
-// `AdwSpinnerPaintable`'s `radius = min(floor(min(w, h) / 2), 32)` with
-// `lineWidth = diameter / 8`. This element used to default to 24px and stroke
-// `max(2, round(size / 12))`, which draws 2px where Adwaita draws 3px at 24, 4px
-// against 6px at 48 and 5px against 8px at 64 — the ring was visibly thinner than
-// GTK's at every size above the minimum.
+// THE BOX AND THE RING ARE DIFFERENT THINGS. `adw_spinner_measure`
+// (adw-spinner.c:78-81) reports MIN_SIZE as both minimum and natural and has no
+// upper bound — `MAX_SIZE` at :15 is defined and never referenced — while
+// `adw_spinner_snapshot` (:95-99) hands the widget's real width and height to
+// the paintable, which caps only `radius` (adw-spinner-paintable.c:343) and
+// still centres on the box (:349-351). So `size="200"` occupies 200px of layout
+// and draws a 64px ring in the middle. This element used to BE the ring, which
+// is why its suite asserted the opposite of the core's `SPINNER_SIZE_VECTORS`.
 //
-// Reference: refs/libadwaita/src/adw-spinner.c (MIN_SIZE, adw_spinner_measure)
-// Reference: refs/libadwaita/src/adw-spinner-paintable.c (MAX_RADIUS, calculate_line_width)
-// Reference: refs/adwaita-web/adwaita-web/scss/_spinner.scss
+// THE ARC IS NOT A ROTATING QUARTER-CIRCLE. It extends, overlaps, contracts and
+// idles on an ease-in-out-sine while the figure turns; the arithmetic is
+// `@gjsify/adwaita-core`'s `spinnerArc`, shared with the vectors that judge it.
+// Expressing that needs a per-frame value, so this element draws an SVG arc and
+// advances it from one module-level ticker — not one timer per spinner. CSS
+// keyframes cannot express it: a `border-top-color` chase is a fixed 90 degrees,
+// which is what this element drew for its whole life.
+//
+// IT KEEPS SPINNING UNDER REDUCED MOTION. `adw_spinner_paintable_set_widget`
+// calls `adw_animation_set_follow_enable_animations_setting (…, FALSE)` (:537)
+// — deliberately, because a frozen busy indicator reads as a hang. The old
+// `@media (prefers-reduced-motion: reduce) { animation: none }` did exactly that.
+//
+// Reference: refs/libadwaita/src/adw-spinner.c (MIN_SIZE, adw_spinner_measure, the a11y role)
+// Reference: refs/libadwaita/src/adw-spinner-paintable.c (the animation + geometry)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
-import { resolveSpinnerSize, spinnerGeometry } from '@gjsify/adwaita-core';
+import {
+    ADW_SPINNER_STILL_PROGRESS,
+    ADW_SPINNER_TRACK_OPACITY,
+    resolveSpinnerSize,
+    spinnerArc,
+    spinnerGeometry,
+    spinnerProgressAt,
+} from '@gjsify/adwaita-core';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+/**
+ * Every mapped spinner, driven by ONE `requestAnimationFrame` loop.
+ *
+ * The C animates per widget off the frame clock, which costs nothing extra
+ * because the clock is already ticking. A browser has no such clock, so the
+ * equivalent is one shared rAF: N spinners on a page must not mean N loops, and
+ * the loop must not exist at all while none are mapped.
+ */
+const mapped = new Set<AdwSpinner>();
+let frameHandle = 0;
+
+function tick(now: number): void {
+    for (const spinner of mapped) spinner.drawAt(now);
+    frameHandle = mapped.size > 0 ? requestAnimationFrame(tick) : 0;
+}
+
+function startTicking(): void {
+    if (frameHandle === 0 && mapped.size > 0) frameHandle = requestAnimationFrame(tick);
+}
 
 export class AdwSpinner extends HTMLElement {
     static get observedAttributes() {
         return ['size'];
     }
 
+    private _svg: SVGSVGElement | null = null;
+    private _track: SVGCircleElement | null = null;
+    private _arc: SVGCircleElement | null = null;
+    /** Path length of the ring, so the dash arithmetic is done once per resize. */
+    private _circumference = 0;
+    /** Ring radius in px — the dash lengths are arc-length, i.e. radians × r. */
+    private _radius = 0;
+    /** The timestamp this spinner was mapped at, so its progress starts at 0. */
+    private _origin: number | null = null;
+
     connectedCallback() {
-        this._sync();
+        this._build();
+        // `widget_map_cb` (adw-spinner-paintable.c:181-185) plays the animation
+        // on MAP, not on construction: an off-screen spinner burns nothing.
+        mapped.add(this);
+        this._origin = null;
+        startTicking();
+    }
+
+    disconnectedCallback() {
+        mapped.delete(this);
     }
 
     attributeChangedCallback() {
         this._sync();
     }
 
-    private _sync() {
-        // The element IS the ring, so it takes the DRAWN diameter rather than the
-        // requested box: a request below 16 is not representable (GTK never
-        // allocates below a widget's minimum) and one above 64 draws a 64px ring,
-        // which is Adwaita's documented "never larger than 64×64".
+    /**
+     * Draw the frame for `now`, in `requestAnimationFrame` timebase.
+     *
+     * Public because the shared ticker is a module-level function rather than a
+     * method — and because a test needs to place the spinner at a known moment
+     * without waiting for real frames.
+     */
+    drawAt(now: number): void {
+        if (this._origin === null) this._origin = now;
+        this._paint(spinnerProgressAt(now - this._origin));
+    }
+
+    private _build(): void {
+        if (this._svg) return;
+        const svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('fill', 'none');
+        // The ring is decorative; the ROLE is on the host, per adw-spinner.c:124.
+        svg.setAttribute('aria-hidden', 'true');
+
+        const track = document.createElementNS(SVG_NS, 'circle');
+        track.setAttribute('stroke', 'currentColor');
+        // `CIRCLE_OPACITY` of the WIDGET's colour (adw-spinner-paintable.c:367-369),
+        // not a hardcoded grey — so the track follows the text colour everywhere.
+        track.setAttribute('stroke-opacity', String(ADW_SPINNER_TRACK_OPACITY));
+
+        const arc = document.createElementNS(SVG_NS, 'circle');
+        arc.setAttribute('stroke', 'currentColor');
+        // `GSK_LINE_CAP_ROUND` (adw-spinner-paintable.c:354). The port's
+        // `border-top-color` ends were square-cut, visible from 48px up.
+        arc.setAttribute('stroke-linecap', 'round');
+
+        svg.append(track, arc);
+        this._svg = svg;
+        this._track = track;
+        this._arc = arc;
+        this.replaceChildren(svg);
+
+        // `gtk_widget_class_set_accessible_role (…, PROGRESS_BAR)` (adw-spinner.c:124)
+        // and `GTK_ACCESSIBLE_STATE_BUSY, TRUE` (:139-141). A repo-wide grep for
+        // either found ZERO hits before this: screen readers announced nothing.
+        this.setAttribute('role', 'progressbar');
+        this.setAttribute('aria-busy', 'true');
+
+        this._sync();
+    }
+
+    /** Re-derive the box, the ring and the stroke from the `size` attribute. */
+    private _sync(): void {
+        const svg = this._svg;
+        const track = this._track;
+        const arc = this._arc;
+        if (!svg || !track || !arc) return;
+
         const size = resolveSpinnerSize(this.getAttribute('size'));
         const { diameter, lineWidth } = spinnerGeometry(size, size);
-        this.style.width = `${diameter}px`;
-        this.style.height = `${diameter}px`;
-        this.style.borderWidth = `${lineWidth}px`;
+        // THE BOX: whatever was asked for, floored at the measured minimum.
+        this.style.width = `${size}px`;
+        this.style.height = `${size}px`;
+        // THE RING: capped at 64, centred by the host's flex box.
+        svg.setAttribute('width', String(diameter));
+        svg.setAttribute('height', String(diameter));
+        svg.setAttribute('viewBox', `0 0 ${diameter} ${diameter}`);
+
+        // The stroke is centred on the path, so the circle sits half a stroke in
+        // — `radius - line_width / 2` (adw-spinner-paintable.c:364).
+        const radius = (diameter - lineWidth) / 2;
+        this._radius = radius;
+        this._circumference = 2 * Math.PI * radius;
+        for (const circle of [track, arc]) {
+            circle.setAttribute('cx', String(diameter / 2));
+            circle.setAttribute('cy', String(diameter / 2));
+            circle.setAttribute('r', String(radius));
+            circle.setAttribute('stroke-width', String(lineWidth));
+        }
+        // A resize while unmapped still has to leave a drawable frame behind:
+        // the resting pose, which is what a paintable without an animation draws.
+        this._paint(this._origin === null ? ADW_SPINNER_STILL_PROGRESS : this._lastProgress);
+    }
+
+    /** The progress the last painted frame used, so a resize can repaint it. */
+    private _lastProgress = ADW_SPINNER_STILL_PROGRESS;
+
+    private _paint(progress: number): void {
+        const arc = this._arc;
+        if (!arc || this._radius <= 0) return;
+        this._lastProgress = progress;
+        const { end, length } = spinnerArc(progress);
+        const drawn = length * this._radius;
+        arc.setAttribute('stroke-dasharray', `${drawn} ${Math.max(this._circumference - drawn, 0)}`);
+        // An SVG circle's path starts at 3 o'clock and runs clockwise, which is
+        // the same origin and direction the C's angles use — so a radian is a
+        // path distance and the dash only has to be shifted to `end`.
+        arc.setAttribute('stroke-dashoffset', String(-end * this._radius));
     }
 }
 

--- a/packages/web/adwaita-web/src/elements/adw-tab-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-tab-view.ts
@@ -513,6 +513,19 @@ export class AdwTabView extends HTMLElement {
         const icon = createAdwIcon(null, 'adw-tab-icon');
         tab.appendChild(icon);
 
+        // `AdwTabPage:loading` swaps the icon image for an `AdwSpinnerPaintable`
+        // — the SAME paintable `Adw.Spinner` uses (`update_icons`,
+        // adw-tab.c:172-190). So this is a real `<adw-spinner>` in the icon's
+        // slot, not a ring drawn again in CSS: the stylesheet used to restate
+        // the border, the grey and the 0.8s under a comment claiming it was
+        // "not a second copy of them", and it inherited every spinner defect
+        // independently.
+        const spinner = document.createElement('adw-spinner');
+        spinner.className = 'adw-tab-spinner';
+        spinner.setAttribute('size', '16');
+        spinner.hidden = true;
+        tab.appendChild(spinner);
+
         const label = document.createElement('span');
         label.className = 'adw-tab-title';
         tab.appendChild(label);
@@ -588,9 +601,14 @@ export class AdwTabView extends HTMLElement {
         const icon = tab.querySelector('.adw-tab-icon') as AdwIcon | null;
         if (icon) {
             icon.iconName = icons.icon;
-            icon.classList.toggle('loading', icons.spinner);
-            icon.hidden = !icons.iconVisible;
+            // The two occupy the same slot and are never both visible: C
+            // REPLACES the image's contents rather than stacking a second node.
+            icon.hidden = !icons.iconVisible || icons.spinner;
         }
+        const spinner = tab.querySelector('.adw-tab-spinner') as HTMLElement | null;
+        // The spinner is mounted only while it spins, so an idle tab holds no
+        // element in the shared rAF ticker.
+        if (spinner) spinner.hidden = !(icons.spinner && icons.iconVisible);
         const indicator = tab.querySelector('.adw-tab-indicator') as AdwIcon | null;
         if (indicator) {
             indicator.iconName = page.indicatorIcon;

--- a/packages/web/adwaita-web/src/elements/adw-view-stack.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-stack.ts
@@ -168,6 +168,7 @@ export class AdwViewStack extends HTMLElement {
         this.appendChild(content);
         this._applyVisibility();
         this._reflectName();
+        this._emitItemsChanged();
         return page;
     }
 
@@ -188,6 +189,7 @@ export class AdwViewStack extends HTMLElement {
         content?.remove();
         this._applyVisibility();
         this._reflectName();
+        this._emitItemsChanged();
         return true;
     }
 
@@ -200,7 +202,26 @@ export class AdwViewStack extends HTMLElement {
     setPageVisible(name: string, visible: boolean): boolean {
         const moved = this._state.setPageVisible(name, visible);
         this._applyVisibility();
+        // A visibility flip changes what the pages MODEL reports, which is what
+        // `update_bar_revealed` counts (adw-view-switcher-bar.c:340) — hiding
+        // the second-to-last visible page must retract the bar.
+        this._emitItemsChanged();
         return moved;
+    }
+
+    /**
+     * The pages model's `items-changed`, which the DOM stack had no counterpart
+     * for at all.
+     *
+     * `AdwViewSwitcherBar` re-runs `update_bar_revealed` on it
+     * (adw-view-switcher-bar.c:340) and `AdwViewSwitcher` rebinds its buttons
+     * (adw-view-switcher.c:258-263). Both ports listened only on
+     * `notify::visible-child`, so adding a page or hiding a non-selected one
+     * left `revealed` — and the button row — stale, with a manual `refresh()`
+     * as the documented workaround.
+     */
+    private _emitItemsChanged(): void {
+        this.dispatchEvent(new CustomEvent('items-changed', { bubbles: true, detail: { count: this.pages.length } }));
     }
 
     private _onStateChange(change: ViewStackStateChange<HTMLElement>): void {

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher-bar.ts
@@ -147,11 +147,13 @@ export class AdwViewSwitcherBar extends HTMLElement {
     }
 
     /**
-     * Rebuild the buttons — needed after pages were added to the bound stack
-     * WITHOUT changing its selection. A page add that does move the selection
-     * (the first one) notifies and rebuilds on its own. libadwaita rebuilds on
-     * the pages model's `items-changed` (adw-view-switcher.c:258-263), which the
-     * DOM stack has no counterpart for yet.
+     * Rebuild the buttons by hand.
+     *
+     * Kept as public API — a consumer that mutates a page in place still has a
+     * way to say so — but no longer the ONLY way: the stack emits
+     * `items-changed` now and this bar binds it, which is the mechanism
+     * libadwaita uses (adw-view-switcher-bar.c:340,
+     * adw-view-switcher.c:258-263).
      */
     refresh(): void {
         this._rebuild();
@@ -163,10 +165,16 @@ export class AdwViewSwitcherBar extends HTMLElement {
 
     private _bindStack(): void {
         this._stack?.addEventListener('notify::visible-child', this._onStackNotify);
+        // `update_bar_revealed` runs on the pages model's `items-changed` too
+        // (adw-view-switcher-bar.c:340), which is the half that was missing: a
+        // page added without moving the selection, or a non-selected page
+        // hidden, changes the COUNT the reveal is decided from.
+        this._stack?.addEventListener('items-changed', this._onStackNotify);
     }
 
     private _unbindStack(): void {
         this._stack?.removeEventListener('notify::visible-child', this._onStackNotify);
+        this._stack?.removeEventListener('items-changed', this._onStackNotify);
     }
 
     private _resolveStack(value: AdwViewStack | string | null): AdwViewStack | null {

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
@@ -56,6 +56,7 @@ import {
     buildViewSwitcherButtons,
     isViewSwitcherPolicy,
 } from '@gjsify/adwaita-core';
+import type { ViewSwitcherScheduler } from '@gjsify/adwaita-core';
 // Aliased because `AdwViewSwitcherPage` is already this module's page ELEMENT —
 // the custom element the package has always exported under that name.
 import type {
@@ -82,18 +83,50 @@ interface PageNodes {
     body: HTMLDivElement;
 }
 
-/** A single page. Children of <adw-view-switcher>; consumed at connect time. */
-export class AdwViewSwitcherPage extends HTMLElement {
-    static get observedAttributes() {
-        return ['name', 'title', 'icon-name', 'badge-number', 'needs-attention', 'use-underline'];
-    }
-}
+/**
+ * A single page. Children of `<adw-view-switcher>`; consumed at connect time.
+ *
+ * Deliberately carries NO `observedAttributes`. It used to declare six of them
+ * and no `attributeChangedCallback`, which is a dead declaration — the browser
+ * computes the list and has nowhere to deliver to — so changing `badge-number`,
+ * `title`, `icon-name` or `needs-attention` after connect did nothing at all,
+ * where C rebinds on every page `notify` (adw-view-switcher.c:184-193, :223).
+ *
+ * A callback could not fix it either: the switcher consumes these elements at
+ * connect and `replaceChildren`s them away, so a detached page has no `closest`
+ * to reach its owner through. The switcher watches them with a `MutationObserver`
+ * instead, which keeps working after the detach and needs nothing from this class.
+ */
+export class AdwViewSwitcherPage extends HTMLElement {}
 
 export class AdwViewSwitcher extends HTMLElement {
-    private readonly _state = new ViewSwitcherState({ scheduler: domViewSwitcherScheduler });
+    /**
+     * The dwell timer, injectable.
+     *
+     * It used to be `new ViewSwitcherState({ scheduler: domViewSwitcherScheduler })`
+     * inline, which left NOWHERE to hand a clock in — so
+     * `VIEW_SWITCHER_DRAG_VECTORS` was driven by the core suite alone, and the
+     * conformance header claimed all three suites drove it. `scheduler` is a
+     * property so a test can replace it before the element connects; the DOM one
+     * is the default, exactly as before.
+     */
+    scheduler: ViewSwitcherScheduler = domViewSwitcherScheduler;
+    private _stateInstance: ViewSwitcherState | null = null;
+
+    /** Built on first access, so a `scheduler` set before connect is the one used. */
+    private get _state(): ViewSwitcherState {
+        if (!this._stateInstance) {
+            this._stateInstance = new ViewSwitcherState({ scheduler: this.scheduler });
+            this._stateInstance.subscribe((change) => this._onStateChange(change));
+        }
+        return this._stateInstance;
+    }
     private _barEl!: HTMLDivElement;
     private _contentEl!: HTMLDivElement;
     private _nodes: PageNodes[] = [];
+    /** The page ELEMENTS, kept because the switcher detaches them from the tree. */
+    private _declared: HTMLElement[] = [];
+    private _pageObserver: MutationObserver | undefined;
     private _policy: AdwViewSwitcherPolicy = 'narrow';
     private _initialized = false;
 
@@ -105,7 +138,6 @@ export class AdwViewSwitcher extends HTMLElement {
         super();
         // Subscribing touches no attributes and no children, so it is legal in a
         // custom element constructor — unlike anything DOM-shaped.
-        this._state.subscribe((change) => this._onStateChange(change));
     }
 
     /** The policy controlling the button layout ('wide' | 'narrow'). */
@@ -172,6 +204,8 @@ export class AdwViewSwitcher extends HTMLElement {
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-view-switcher-content';
 
+        this._declared = declared;
+        this._watchPages();
         this._nodes = declared.map((pageEl, index) => this._buildPage(pageEl, index));
         this._barEl.append(...this._nodes.map((nodes) => nodes.button));
         this._contentEl.append(...this._nodes.map((nodes) => nodes.body));
@@ -193,6 +227,41 @@ export class AdwViewSwitcher extends HTMLElement {
         // A drag that leaves with the element would otherwise switch pages after
         // the widget is gone; C drops the source in dispose the same way.
         this._state.cancelDrag();
+        this._pageObserver?.disconnect();
+        this._pageObserver = undefined;
+    }
+
+    /**
+     * Re-read every declared page and push it into the state.
+     *
+     * Called by `AdwViewSwitcherPage.attributeChangedCallback`, which is what
+     * makes a runtime `badge-number` change reach the button. `setPages` keeps
+     * the selection where it can, so this is a repaint and not a reset.
+     */
+    refreshPages(): void {
+        if (!this._initialized) return;
+        this._state.setPages(this._declared.map((pageEl) => readSwitcherPage(pageEl)));
+        this._render();
+    }
+
+    /**
+     * Watch the declared pages for attribute changes.
+     *
+     * A `MutationObserver` rather than an `attributeChangedCallback` on the page:
+     * the switcher consumes those elements at connect and `replaceChildren`s them
+     * out of the tree, so a detached page cannot find its owner — but an observer
+     * bound to it keeps firing. This is the DOM's `notify::` on
+     * `AdwViewStackPage`, which the C's `update_button` handler binds per page
+     * (adw-view-switcher.c:184-193).
+     *
+     * It delivers on a MICROTASK where GTK's notify is synchronous. That is the
+     * DOM's contract for watching a node, it is invisible to a user, and nothing
+     * in this element reads the button back inside the setter.
+     */
+    private _watchPages(): void {
+        this._pageObserver?.disconnect();
+        this._pageObserver = new MutationObserver(() => this.refreshPages());
+        for (const pageEl of this._declared) this._pageObserver.observe(pageEl, { attributes: true });
     }
 
     attributeChangedCallback(name: string) {
@@ -239,8 +308,23 @@ export class AdwViewSwitcher extends HTMLElement {
             this._state.setSelected(index);
         });
         // GtkDropControllerMotion's enter/leave, which drive TIMEOUT_EXPAND.
-        button.addEventListener('dragenter', () => this._state.dragEnter(index));
-        button.addEventListener('dragleave', () => this._state.dragLeave(index));
+        //
+        // The `relatedTarget` test is the whole point: this button contains an
+        // icon and a label, and the DOM fires `dragleave` + `dragenter` when the
+        // pointer crosses BETWEEN them. `ViewSwitcherDragSwitch.leave` clears the
+        // dwell timer and `enter` re-arms a fresh 500ms, so a drag that merely
+        // slid from the icon to the label restarted the countdown and the page
+        // never switched. C has one `GtkDropControllerMotion` per BUTTON
+        // (adw-view-switcher-button.c:79-96), which has no such internal edges —
+        // `relatedTarget` containment is that same "did we really leave" test.
+        button.addEventListener('dragenter', (event) => {
+            if (button.contains((event as DragEvent).relatedTarget as Node | null)) return;
+            this._state.dragEnter(index);
+        });
+        button.addEventListener('dragleave', (event) => {
+            if (button.contains((event as DragEvent).relatedTarget as Node | null)) return;
+            this._state.dragLeave(index);
+        });
 
         const body = document.createElement('div');
         body.className = 'adw-view-switcher-page';

--- a/packages/web/adwaita-web/src/elements/adw-wrap-box.ts
+++ b/packages/web/adwaita-web/src/elements/adw-wrap-box.ts
@@ -1,103 +1,75 @@
 // <adw-wrap-box> — A box-like container that lays its children out in a line and
-// wraps them onto new lines when they run out of room (the web analog of
-// flexbox `flex-wrap: wrap` with a gap). Mirrors Adw.WrapBox.
-// Attributes:
-//   child-spacing   (px, default 0) — spacing between children on the same line
-//                                      → CSS column-gap
-//   line-spacing    (px, default 0) — spacing between lines → CSS row-gap
-//   orientation     ("horizontal" | "vertical", default "horizontal") — the main
-//                                      axis children are packed along
-//   align           (0..1, default 0) — where the children sit ALONG the line
-//                                      (main axis); 0 = start, 0.5 = middle, 1 = end
-//   justify         ("none" | "fill" | "spread", default "none") — whether/how
-//                                      each line is stretched to fill the widget
-//   justify-last-line (boolean) — also justify the last (final) line
-//   line-homogeneous  (boolean) — make every line take the same amount of space
-//   pack-direction  ("start-to-end" | "end-to-start", default "start-to-end") —
-//                                      direction children are packed within a line
-//   wrap-reverse    (boolean) — reverse the wrap direction (lines wrap upwards)
-// Events: notify::child-spacing, notify::line-spacing (CustomEvent, bubbles —
-//   mirrors GObject signal naming, including its "only on a real change" rule).
+// wraps them onto new lines when they run out of room (the web analog of flexbox
+// `flex-wrap: wrap` with a gap). Mirrors Adw.WrapBox.
+//
+// Attributes — all fourteen of the widget's properties, each with a
+// `notify::<property>` (adw-wrap-box.c:284-497). The element used to carry nine
+// attributes and notify for two, so a consumer binding to any of the other
+// twelve was listening to a signal that could not fire.
+//
+//   child-spacing / line-spacing        (int >= 0, default 0) -> column-gap / row-gap
+//   child-spacing-unit / line-spacing-unit ("px" | "pt" | "sp", default "px")
+//   orientation      ("horizontal" | "vertical", default "horizontal")
+//   pack-direction   ("start-to-end" | "end-to-start", default "start-to-end")
+//   align            (0..1, default 0) — MAIN-axis offset of the whole line block
+//   justify          ("none" | "fill" | "spread", default "none")
+//   justify-last-line (boolean)
+//   line-homogeneous  (boolean)
+//   wrap-reverse      (boolean)
+//   wrap-policy      ("minimum" | "natural", default "natural")
+//   natural-line-length (int >= -1, default -1 = unset) + -unit
+//
+// The property CONTRACT — the normalisers and the justify/align/last-line
+// decision — is `@gjsify/adwaita-core`'s `wrap-box.ts`, held to
+// `WRAP_BOX_LINE_VECTORS` and friends, which the NativeScript suite drives too.
+// This element used to carry its own copy of all of it.
+//
 // Reference: refs/libadwaita/src/adw-wrap-box.c / adw-wrap-layout.c (Adw.WrapBox)
 // Reference: refs/adwaita-web/adwaita-web/scss/_wrap_box.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
-/** `AdwJustifyMode` (adw-wrap-layout.c:74-83). */
-type JustifyMode = 'none' | 'fill' | 'spread';
-
-/** The three modes, for validating the attribute against the C enum. */
-const JUSTIFY_MODES: readonly JustifyMode[] = ['none', 'fill', 'spread'];
-
-/** What one line does with the space its children do not use. */
-interface LineLayout {
-    /** The mode governing this line, after the last-line gate. */
-    justify: JustifyMode;
-    /** Whether the CHILDREN absorb the leftover (adw-wrap-layout.c:336-341). */
-    growChildren: boolean;
-    /** Whether the GAPS absorb it (adw-wrap-layout.c:338-339, :752-757). */
-    growGaps: boolean;
-    /** The main-axis offset factor for an un-justified line (adw-wrap-layout.c:717-725). */
-    align: number;
-}
+import {
+    ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET,
+    normalizeNaturalLineLength,
+    normalizeWrapBoxAlign,
+    normalizeWrapBoxJustify,
+    normalizeWrapBoxLengthUnit,
+    normalizeWrapBoxPackDirection,
+    normalizeWrapBoxSpacing,
+    normalizeWrapPolicy,
+    resolveWrapBoxChildOrder,
+    resolveWrapBoxLine,
+    wrapBoxLengthToPx,
+    wrapPolicyFlexShrink,
+    type AdwLengthUnit,
+} from '@gjsify/adwaita-core';
 
 /**
- * The line-layout decision, straight from the C.
+ * The attributes that carry a property, in the order the C installs them.
  *
- * `lastLine` is the FINAL line, complete or not (`i == *n_lines - 1`,
- * adw-wrap-layout.c:463-464), so a wrap box whose children all fit on one line
- * has that line governed by `justify-last-line` rather than by `justify`.
- *
- * The conformance table this must agree with is
- * `@gjsify/adwaita-core/conformance` → `WRAP_BOX_LINE_VECTORS`; the same rows
- * are asserted against the NativeScript port, so the two cannot drift apart
- * without a test naming the input.
+ * Doubles as the `notify::` roster: every entry gets an event on a real change,
+ * so adding an attribute without its notification is not expressible here.
  */
-function resolveLine(
-    justify: JustifyMode,
-    justifyLastLine: boolean,
-    align: number,
-    lastLine: boolean,
-    childrenInLine: number,
-): LineLayout {
-    // adw-wrap-layout.c:397-400 / :705-706 — the final line is only justified on
-    // request; otherwise it falls back to ADW_JUSTIFY_NONE and to `align`.
-    const effective: JustifyMode = lastLine && !justifyLastLine ? 'none' : justify;
-    if (effective === 'none') return { justify: 'none', growChildren: false, growGaps: false, align };
-    // adw-wrap-layout.c:338 — SPREAD keeps children at their minimum size and
-    // widens the gaps, but the branch is guarded by `n_children > 1`: a lone
-    // child has nothing to spread against and is stretched instead, which the
-    // property documentation states outright (adw-wrap-box.c:349-352).
-    const spreadsGaps = effective === 'spread' && childrenInLine > 1;
-    return { justify: effective, growChildren: !spreadsGaps, growGaps: spreadsGaps, align: 0 };
-}
+const PROPERTY_ATTRIBUTES = [
+    'child-spacing',
+    'child-spacing-unit',
+    'pack-direction',
+    'align',
+    'justify',
+    'justify-last-line',
+    'line-spacing',
+    'line-spacing-unit',
+    'line-homogeneous',
+    'natural-line-length',
+    'natural-line-length-unit',
+    'wrap-reverse',
+    'wrap-policy',
+    'orientation',
+] as const;
 
-/**
- * `Adw.WrapBox:child-spacing` / `:line-spacing` normalisation.
- *
- * C clamps a negative value to 0 before it reaches the layout
- * (adw-wrap-box.c:587-588, :927-928) — the property is declared with a minimum
- * of 0, so without the clamp GObject would reject it. The non-numeric cases have
- * no C counterpart (the property is an `int`); they resolve to the default so a
- * typo cannot put `NaN` into a `column-gap`.
- */
-function normalizeSpacing(raw: string | null): number {
-    const value = Number.parseFloat(raw ?? '');
-    if (!Number.isFinite(value) || value < 0) return 0;
-    return value;
-}
-
-/** `Adw.WrapBox:align` — `g_param_spec_float (…, 0, 1, 0, …)`, adw-wrap-box.c:335-337. */
-function normalizeAlign(raw: string | null): number {
-    const value = Number.parseFloat(raw ?? '');
-    if (!Number.isFinite(value)) return 0;
-    return Math.min(1, Math.max(0, value));
-}
-
-/** An out-of-range enum value leaves a GObject property at its default. */
-function normalizeJustify(raw: string | null): JustifyMode {
-    return JUSTIFY_MODES.includes(raw as JustifyMode) ? (raw as JustifyMode) : 'none';
-}
+/** One attribute's normalised value, for the "did it really change" comparison. */
+type PropertyValue = string | number | boolean;
 
 /**
  * `align` as a `justify-content` keyword.
@@ -117,36 +89,185 @@ export class AdwWrapBox extends HTMLElement {
     private _initialized = false;
 
     static get observedAttributes() {
-        return [
-            'child-spacing',
-            'line-spacing',
-            'orientation',
-            'align',
-            'justify',
-            'justify-last-line',
-            'line-homogeneous',
-            'pack-direction',
-            'wrap-reverse',
-        ];
+        return [...PROPERTY_ATTRIBUTES];
     }
 
-    /** Spacing between children on the same line, in px (CSS column-gap). */
+    // --- properties ---
+
+    /** Spacing between children on the same line, in `child-spacing-unit`. */
     get childSpacing(): number {
-        return normalizeSpacing(this.getAttribute('child-spacing'));
+        return normalizeWrapBoxSpacing(this.getAttribute('child-spacing'));
     }
 
     set childSpacing(value: number) {
         this.setAttribute('child-spacing', String(value));
     }
 
-    /** Spacing between lines, in px (CSS row-gap). */
+    /** The unit `child-spacing` is written in. Defaults to `px`, as in C. */
+    get childSpacingUnit(): AdwLengthUnit {
+        return normalizeWrapBoxLengthUnit(this.getAttribute('child-spacing-unit'));
+    }
+
+    set childSpacingUnit(value: AdwLengthUnit) {
+        this.setAttribute('child-spacing-unit', value);
+    }
+
+    /** Spacing between lines, in `line-spacing-unit`. */
     get lineSpacing(): number {
-        return normalizeSpacing(this.getAttribute('line-spacing'));
+        return normalizeWrapBoxSpacing(this.getAttribute('line-spacing'));
     }
 
     set lineSpacing(value: number) {
         this.setAttribute('line-spacing', String(value));
     }
+
+    /** The unit `line-spacing` is written in. Defaults to `px`, as in C. */
+    get lineSpacingUnit(): AdwLengthUnit {
+        return normalizeWrapBoxLengthUnit(this.getAttribute('line-spacing-unit'));
+    }
+
+    set lineSpacingUnit(value: AdwLengthUnit) {
+        this.setAttribute('line-spacing-unit', value);
+    }
+
+    /** Where the children sit ALONG the line (main axis): 0 start, 0.5 middle, 1 end. */
+    get align(): number {
+        return normalizeWrapBoxAlign(this.getAttribute('align'));
+    }
+
+    set align(value: number) {
+        this.setAttribute('align', String(value));
+    }
+
+    /** Whether and how each line is stretched to fill the widget. */
+    get justify(): 'none' | 'fill' | 'spread' {
+        return normalizeWrapBoxJustify(this.getAttribute('justify'));
+    }
+
+    set justify(value: 'none' | 'fill' | 'spread') {
+        this.setAttribute('justify', value);
+    }
+
+    /** Whether the FINAL line is justified too. Default false, as in C. */
+    get justifyLastLine(): boolean {
+        return this.hasAttribute('justify-last-line');
+    }
+
+    set justifyLastLine(value: boolean) {
+        this.toggleAttribute('justify-last-line', !!value);
+    }
+
+    /** Whether an overflowing line squeezes its children or lets them spill. */
+    get wrapPolicy(): 'minimum' | 'natural' {
+        return normalizeWrapPolicy(this.getAttribute('wrap-policy'));
+    }
+
+    set wrapPolicy(value: 'minimum' | 'natural') {
+        this.setAttribute('wrap-policy', value);
+    }
+
+    /** The direction children are packed in each line. */
+    get packDirection(): 'start-to-end' | 'end-to-start' {
+        return normalizeWrapBoxPackDirection(this.getAttribute('pack-direction'));
+    }
+
+    set packDirection(value: 'start-to-end' | 'end-to-start') {
+        this.setAttribute('pack-direction', value);
+    }
+
+    /** Whether lines wrap upwards (horizontal) / towards the start (vertical). */
+    get wrapReverse(): boolean {
+        return this.hasAttribute('wrap-reverse');
+    }
+
+    set wrapReverse(value: boolean) {
+        this.toggleAttribute('wrap-reverse', !!value);
+    }
+
+    /** Whether every line takes the same amount of space. */
+    get lineHomogeneous(): boolean {
+        return this.hasAttribute('line-homogeneous');
+    }
+
+    set lineHomogeneous(value: boolean) {
+        this.toggleAttribute('line-homogeneous', !!value);
+    }
+
+    /** The natural line length in `natural-line-length-unit`, or `-1` when unset. */
+    get naturalLineLength(): number {
+        return normalizeNaturalLineLength(this.getAttribute('natural-line-length'));
+    }
+
+    set naturalLineLength(value: number) {
+        this.setAttribute('natural-line-length', String(value));
+    }
+
+    /** The unit `natural-line-length` is written in. Defaults to `px`, as in C. */
+    get naturalLineLengthUnit(): AdwLengthUnit {
+        return normalizeWrapBoxLengthUnit(this.getAttribute('natural-line-length-unit'));
+    }
+
+    set naturalLineLengthUnit(value: AdwLengthUnit) {
+        this.setAttribute('natural-line-length-unit', value);
+    }
+
+    /** The axis children are packed along. */
+    get orientation(): 'horizontal' | 'vertical' {
+        return this.getAttribute('orientation') === 'vertical' ? 'vertical' : 'horizontal';
+    }
+
+    set orientation(value: 'horizontal' | 'vertical') {
+        this.setAttribute('orientation', value);
+    }
+
+    // --- child list (adw_wrap_box_insert_child_after / reorder / remove_all) ---
+    //
+    // `adw_wrap_box_append`, `_prepend` and `_remove` are deliberately NOT
+    // redeclared: `ParentNode.append` / `.prepend` and `Node.removeChild` are
+    // those three, with the same semantics, and shadowing them would give this
+    // element two spellings of one operation. Only the three the DOM has no
+    // counterpart for are added.
+
+    /** The element children, which are what the layout actually lays out. */
+    private get _children(): Element[] {
+        return [...this.children];
+    }
+
+    /**
+     * `adw_wrap_box_insert_child_after` (adw-wrap-box.c:1283-1300).
+     *
+     * A NULL/absent `sibling` inserts at the FIRST position, not the last —
+     * `gtk_widget_insert_after`'s documented rule, pinned by
+     * `WRAP_BOX_CHILD_ORDER_VECTORS`. Returns whether the insert happened; a
+     * refusal is where C would have hit a `g_return_if_fail`.
+     */
+    insertChildAfter(child: Element, sibling: Element | null = null): boolean {
+        return this._applyOrder('insert-after', child, sibling);
+    }
+
+    /** `adw_wrap_box_reorder_child_after` (adw-wrap-box.c:1315-1332). Same NULL rule. */
+    reorderChildAfter(child: Element, sibling: Element | null = null): boolean {
+        return this._applyOrder('reorder-after', child, sibling);
+    }
+
+    /** `adw_wrap_box_remove_all` (adw-wrap-box.c:1406-1414). */
+    removeAll(): void {
+        for (const child of this._children) this.removeChild(child);
+    }
+
+    private _applyOrder(op: 'insert-after' | 'reorder-after', child: Element, sibling: Element | null): boolean {
+        const next = resolveWrapBoxChildOrder({ children: this._children, child, sibling, op });
+        if (next === null) return false;
+        // Move exactly the one node: `insertBefore` relocates a node already in
+        // the tree, and a null reference node appends. Re-appending the whole
+        // resolved list would reach the same order while detaching and
+        // re-attaching every sibling, which resets focus and any element state.
+        const at = next.indexOf(child);
+        this.insertBefore(child, next[at + 1] ?? null);
+        return true;
+    }
+
+    // --- lifecycle ---
 
     connectedCallback() {
         if (this._initialized) return;
@@ -159,40 +280,56 @@ export class AdwWrapBox extends HTMLElement {
         this._sync();
         // C compares AFTER normalising and returns early when nothing changed
         // (adw-wrap-box.c:592-593), so `child-spacing="-5"` on a box already at 0
-        // notifies nobody.
-        if (name === 'child-spacing') {
-            const next = normalizeSpacing(value);
-            if (next === normalizeSpacing(old)) return;
-            this.dispatchEvent(
-                new CustomEvent('notify::child-spacing', { bubbles: true, detail: { childSpacing: next } }),
-            );
-        } else if (name === 'line-spacing') {
-            const next = normalizeSpacing(value);
-            if (next === normalizeSpacing(old)) return;
-            this.dispatchEvent(
-                new CustomEvent('notify::line-spacing', { bubbles: true, detail: { lineSpacing: next } }),
-            );
+        // notifies nobody. The same gate applies to every property, not just the
+        // two spacings this element used to special-case.
+        const next = this._normalized(name, value);
+        if (next === this._normalized(name, old)) return;
+        this.dispatchEvent(new CustomEvent(`notify::${name}`, { bubbles: true, detail: { [name]: next } }));
+    }
+
+    /** One attribute's value as the widget stores it — the notify comparison key. */
+    private _normalized(name: string, raw: string | null): PropertyValue {
+        switch (name) {
+            case 'child-spacing':
+            case 'line-spacing':
+                return normalizeWrapBoxSpacing(raw);
+            case 'child-spacing-unit':
+            case 'line-spacing-unit':
+            case 'natural-line-length-unit':
+                return normalizeWrapBoxLengthUnit(raw);
+            case 'align':
+                return normalizeWrapBoxAlign(raw);
+            case 'justify':
+                return normalizeWrapBoxJustify(raw);
+            case 'wrap-policy':
+                return normalizeWrapPolicy(raw);
+            case 'pack-direction':
+                return normalizeWrapBoxPackDirection(raw);
+            case 'natural-line-length':
+                return normalizeNaturalLineLength(raw);
+            case 'orientation':
+                return raw === 'vertical' ? 'vertical' : 'horizontal';
+            default:
+                // The three booleans: a present attribute is true whatever it says.
+                return raw !== null;
         }
     }
 
     private _sync() {
         const style = this.style;
-        const vertical = this.getAttribute('orientation') === 'vertical';
-        const reverseWrap = this.hasAttribute('wrap-reverse');
-        const packEndToStart = this.getAttribute('pack-direction') === 'end-to-start';
+        const vertical = this.orientation === 'vertical';
 
         // Main axis is the packing direction; lines wrap along the cross axis.
         const direction = vertical ? 'column' : 'row';
-        const reversed = packEndToStart ? `${direction}-reverse` : direction;
-        style.flexDirection = reversed;
-        style.flexWrap = reverseWrap ? 'wrap-reverse' : 'wrap';
+        style.flexDirection = this.packDirection === 'end-to-start' ? `${direction}-reverse` : direction;
+        style.flexWrap = this.wrapReverse ? 'wrap-reverse' : 'wrap';
 
         // child-spacing is along the line (main axis), line-spacing is between
         // lines (cross axis). For a horizontal box that maps to column-gap /
-        // row-gap respectively; the mapping flips for a vertical box.
-        const childSpacing = this.childSpacing;
-        const childGap = `${childSpacing}px`;
-        const lineGap = `${this.lineSpacing}px`;
+        // row-gap respectively; the mapping flips for a vertical box. Both are
+        // resolved through their OWN unit first, which is why they can disagree.
+        const childGap = `${wrapBoxLengthToPx(this.childSpacing, this.childSpacingUnit)}px`;
+        const lineGap = `${wrapBoxLengthToPx(this.lineSpacing, this.lineSpacingUnit)}px`;
         if (vertical) {
             style.rowGap = childGap;
             style.columnGap = lineGap;
@@ -204,9 +341,9 @@ export class AdwWrapBox extends HTMLElement {
         // main-axis gap so it can never push a full line into a new one.
         style.setProperty('--adw-wrap-box-child-spacing', childGap);
 
-        const justify = normalizeJustify(this.getAttribute('justify'));
-        const justifyLastLine = this.hasAttribute('justify-last-line');
-        const align = normalizeAlign(this.getAttribute('align'));
+        const justify = this.justify;
+        const justifyLastLine = this.justifyLastLine;
+        const align = this.align;
 
         // A flex container has ONE `justify-content` and applies it to every
         // line, so it carries the COMPLETE-line rule; the final-line rule is
@@ -216,8 +353,8 @@ export class AdwWrapBox extends HTMLElement {
         // The pair is deliberately never collapsed into one attribute: flexbox
         // cannot express "every line but the last", and pretending otherwise is
         // what made `justify-last-line` a no-op in the first place.
-        const line = resolveLine(justify, justifyLastLine, align, false, 2);
-        const lastLine = resolveLine(justify, justifyLastLine, align, true, 2);
+        const line = resolveWrapBoxLine({ justify, justifyLastLine, align, lastLine: false, childrenInLine: 2 });
+        const lastLine = resolveWrapBoxLine({ justify, justifyLastLine, align, lastLine: true, childrenInLine: 2 });
         this.dataset.lineJustify = line.justify;
         this.dataset.lastLineJustify = lastLine.justify;
 
@@ -228,7 +365,25 @@ export class AdwWrapBox extends HTMLElement {
 
         // line-homogeneous makes every line take the same amount of space, which
         // flexbox approximates by stretching the lines across the cross axis.
-        style.alignContent = this.hasAttribute('line-homogeneous') ? 'stretch' : 'flex-start';
+        style.alignContent = this.lineHomogeneous ? 'stretch' : 'flex-start';
+
+        // `wrap-policy` decides whether an overflowing line squeezes its children
+        // or lets them spill. CSS defaults `flex-shrink` to 1, i.e. to
+        // ADW_WRAP_MINIMUM — the value libadwaita does NOT default to, so an
+        // unset policy has been drawing the wrong one on every wrap box. What
+        // flexbox cannot do either way is pack MORE children onto a line, since
+        // line breaking runs on hypothetical sizes; see `wrapPolicyFlexShrink`.
+        style.setProperty('--adw-wrap-box-child-shrink', String(wrapPolicyFlexShrink(this.wrapPolicy)));
+
+        // DELIBERATE DEVIATION: libadwaita's `natural-line-length` caps the box's
+        // NATURAL size request, leaving a larger allocation free to happen; CSS
+        // has no property that caps only the intrinsic contribution, so this is a
+        // max-size on the main axis and therefore caps the allocation too. It is
+        // the intended use (limiting line length inside a popover) either way.
+        const natural = wrapBoxLengthToPx(this.naturalLineLength, this.naturalLineLengthUnit);
+        const cap = natural === ADW_WRAP_BOX_NATURAL_LINE_LENGTH_UNSET ? '' : `${natural}px`;
+        style.maxWidth = vertical ? '' : cap;
+        style.maxHeight = vertical ? cap : '';
     }
 }
 

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -20,6 +20,7 @@ import {
     OVERLAY_SWIPE_SNAP_POINT_VECTORS,
     OVERLAY_SWIPE_START_VECTORS,
     NAVIGATION_ACTION_VECTORS,
+    OVERLAY_SPLIT_VIEW_LAYOUT_VECTORS,
     NAVIGATION_STACK_VECTORS,
     SIDEBAR_BOUNDS_VECTORS,
 } from '@gjsify/adwaita-core/conformance';
@@ -567,6 +568,35 @@ export const AdwSplitViewsTest = async () => {
             expect(getComputedStyle(content).minWidth).not.toBe('0px');
             host.remove();
         });
+
+        for (const vector of OVERLAY_SPLIT_VIEW_LAYOUT_VECTORS) {
+            // Its exact analogue NAVIGATION_SPLIT_VIEW_LAYOUT_VECTORS was driven
+            // from the NativeScript suite while this one was driven by nobody —
+            // two sibling tables in the same file, with no reason for the
+            // difference. The element writes the pane rect from
+            // `layoutOverlaySplitView` now, so the rects are readable.
+            const label = `${vector.collapsed ? 'collapsed' : 'docked'} ${vector.sidebarPosition}/${vector.direction} @${vector.showProgress}`;
+            await it(`${label} — ${vector.rule}`, async () => {
+                const attrs =
+                    (vector.collapsed ? 'collapsed ' : '') +
+                    (vector.sidebarPosition === 'end' ? 'sidebar-position="end" ' : '') +
+                    'pin-sidebar';
+                const { view, host } = mountSizedView(vector.totalWidth, attrs);
+                if (vector.direction === 'rtl') host.style.direction = 'rtl';
+                await settle();
+                const state = stateOf(view);
+                state.setShowProgress(vector.showProgress);
+
+                // The SHIELD and the paint gate are the element's to publish;
+                // the pixel rects depend on the measured sidebar width, which a
+                // real layout decides, so the shared half is what is compared.
+                const backdrop = view.querySelector('.adw-osv-backdrop') as HTMLElement;
+                expect(backdrop.hidden).toBe(!vector.layout.shieldVisible);
+                const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+                expect(sidebar.style.pointerEvents === 'none').toBe(!vector.layout.sidebarPainted);
+                host.remove();
+            });
+        }
 
         await it('names the cancel rows the core owns, so this suite is not read as covering them', () => {
             // `swipeCancelProgress`'s half-away-from-zero rounding is arithmetic

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -19,6 +19,8 @@ import {
     OVERLAY_SWIPE_RELEASE_VECTORS,
     OVERLAY_SWIPE_SNAP_POINT_VECTORS,
     OVERLAY_SWIPE_START_VECTORS,
+    NAVIGATION_ACTION_VECTORS,
+    NAVIGATION_STACK_VECTORS,
     SIDEBAR_BOUNDS_VECTORS,
 } from '@gjsify/adwaita-core/conformance';
 
@@ -572,6 +574,190 @@ export const AdwSplitViewsTest = async () => {
             // OUTCOME, not the rule. The core suite drives every row.
             expect(OVERLAY_SWIPE_CANCEL_VECTORS.length).toBeGreaterThan(0);
             expect(OVERLAY_SWIPE_START_VECTORS.length).toBeGreaterThan(0);
+        });
+    });
+
+    await describe('<adw-navigation-split-view> stack, tags and navigation.* actions', async () => {
+        /** Mount a navigation split view with the given panes and attributes. */
+        function mountNav(attrs = '', panes = { sidebar: true, content: true, sidebarTag: '', contentTag: '' }) {
+            const host = document.createElement('div');
+            host.style.width = '800px';
+            host.style.height = '400px';
+            document.body.appendChild(host);
+            const sidebar = panes.sidebar
+                ? `<div slot="sidebar"${panes.sidebarTag ? ` tag="${panes.sidebarTag}"` : ''}>s</div>`
+                : '';
+            const content = panes.content
+                ? `<div slot="content"${panes.contentTag ? ` tag="${panes.contentTag}"` : ''}>c</div>`
+                : '';
+            host.innerHTML = `<adw-navigation-split-view ${attrs}>${sidebar}${content}</adw-navigation-split-view>`;
+            return {
+                view: host.querySelector('adw-navigation-split-view') as AdwNavigationSplitView,
+                host,
+            };
+        }
+
+        /** Which pane the element says is on top, read off the DOM. */
+        const visiblePane = (view: AdwNavigationSplitView) => {
+            const sidebar = view.querySelector('.adw-nsv-sidebar') as HTMLElement;
+            const content = view.querySelector('.adw-nsv-content') as HTMLElement;
+            return {
+                sidebar: sidebar?.dataset.paneVisible === 'true',
+                content: content?.dataset.paneVisible === 'true',
+            };
+        };
+
+        for (const vector of NAVIGATION_STACK_VECTORS) {
+            // Only the STATIC rows: the animated branch reaches the same stack by
+            // a push or a pop, and a DOM renderer that has no transition cannot
+            // tell them apart. The core suite drives the direction.
+            if (vector.changingPage) continue;
+            const label =
+                `${vector.hasSidebar ? 'sidebar' : '-'}/${vector.hasContent ? 'content' : '-'} ` +
+                `${vector.sidebarPosition} show-content=${vector.showContent}`;
+            await it(`${label} → [${vector.plan.stack.join(', ')}] — ${vector.rule}`, async () => {
+                const attrs =
+                    'collapsed ' +
+                    (vector.showContent ? 'show-content ' : '') +
+                    (vector.sidebarPosition === 'end' ? 'sidebar-position="end"' : '');
+                const { view, host } = mountNav(attrs, {
+                    sidebar: vector.hasSidebar,
+                    content: vector.hasContent,
+                    sidebarTag: '',
+                    contentTag: '',
+                });
+                await settle();
+                const top = vector.plan.stack[vector.plan.stack.length - 1] ?? null;
+                const panes = visiblePane(view);
+                // A LONE child stays visible whatever `show-content` says — the
+                // rule two CSS classes could not express, and the reason a
+                // collapsed sidebar-only view used to render blank.
+                if (vector.hasSidebar) expect(panes.sidebar).toBe(top === 'sidebar');
+                if (vector.hasContent) expect(panes.content).toBe(top === 'content');
+                host.remove();
+            });
+        }
+
+        for (const vector of NAVIGATION_ACTION_VECTORS) {
+            const label =
+                vector.action === 'push'
+                    ? `push "${vector.tag}" (sidebar=${vector.sidebarTag ?? 'none'}, content=${vector.contentTag ?? 'none'})`
+                    : `pop (sidebar=${vector.hasSidebar}, content=${vector.hasContent})`;
+            // A row whose two panes carry the SAME tag describes a state the
+            // duplicate-tag guard makes unreachable through a real widget: the
+            // second assignment is refused (:1195-1201), so the element can never
+            // hold both. Asserted below instead of driven here.
+            const collides =
+                vector.action === 'push' && vector.sidebarTag != null && vector.sidebarTag === vector.contentTag;
+            if (collides) continue;
+
+            await it(`${label} → ${vector.result.kind} — ${vector.rule}`, async () => {
+                const attrs = (vector.collapsed ? 'collapsed ' : '') + (vector.showContent ? 'show-content' : '');
+                const { view, host } = mountNav(attrs, {
+                    sidebar: vector.action === 'pop' ? (vector.hasSidebar ?? false) : true,
+                    content: vector.action === 'pop' ? (vector.hasContent ?? false) : true,
+                    sidebarTag: vector.sidebarTag ?? '',
+                    contentTag: vector.contentTag ?? '',
+                });
+                // `delegate` is the ROUTING's answer; whether it survives depends
+                // on the ancestor. An ancestor that claims the tag is the case the
+                // table describes — the unclaimed one becomes a critical, which
+                // is the state's own step and has its own test below.
+                host.addEventListener('navigation-push', (event) => {
+                    (event as CustomEvent<{ handled: boolean }>).detail.handled = true;
+                });
+                host.addEventListener('navigation-pop', (event) => {
+                    (event as CustomEvent<{ handled: boolean }>).detail.handled = true;
+                });
+                await settle();
+                const result = vector.action === 'push' ? view.push(vector.tag as string) : view.pop();
+                expect(result.kind).toBe(vector.result.kind);
+                if (result.kind === 'set-show-content' && vector.result.kind === 'set-show-content') {
+                    expect(view.showContent).toBe(vector.result.showContent);
+                    // The DOM has to agree, or a consumer reading the attribute
+                    // back after a push sees the pre-push answer.
+                    expect(view.hasAttribute('show-content')).toBe(vector.result.showContent);
+                }
+                host.remove();
+            });
+        }
+
+        await it('leaves out only the rows the tag guard makes unreachable', () => {
+            const collidingRows = NAVIGATION_ACTION_VECTORS.filter(
+                (v) => v.action === 'push' && v.sidebarTag != null && v.sidebarTag === v.contentTag,
+            );
+            // Exactly the shared-tag pushes. Their `rule` even says so — the C's
+            // routing tests the content tag first, which only matters in a
+            // collision the setters refuse to create.
+            expect(collidingRows.length).toBeGreaterThan(0);
+            for (const row of collidingRows) expect(row.contentTag).toBe(row.sidebarTag);
+        });
+
+        await it('an UNCLAIMED push becomes a critical, not a silent no-op', async () => {
+            // `navigation_push_cb` :683 — the parent gets first refusal, and only
+            // then is it an error. A pop walks off the end silently instead.
+            const { view, host } = mountNav('collapsed', {
+                sidebar: true,
+                content: true,
+                sidebarTag: 'list',
+                contentTag: 'detail',
+            });
+            await settle();
+            const pushed = view.push('nowhere');
+            expect(pushed.kind).toBe('not-found');
+            expect(view.showContent).toBe(false);
+            host.remove();
+        });
+
+        await it('delegates an unmatched push to an ancestor, which is how nesting forwards it', async () => {
+            const { view, host } = mountNav('collapsed', {
+                sidebar: true,
+                content: true,
+                sidebarTag: 'list',
+                contentTag: 'detail',
+            });
+            await settle();
+            const seen: string[] = [];
+            host.addEventListener('navigation-push', (event) => {
+                const detail = (event as CustomEvent<{ tag?: string; handled: boolean }>).detail;
+                seen.push(detail.tag ?? '');
+                // An ancestor that OWNS the tag says so, and the critical is
+                // never reached — `return TRUE` in the C's routing.
+                detail.handled = true;
+            });
+            const result = view.push('somewhere-else');
+            expect(seen).toStrictEqual(['somewhere-else']);
+            expect(result.kind).toBe('delegate');
+            host.remove();
+        });
+
+        await it('REFUSES a pane whose tag the other one already carries', async () => {
+            // `adw_navigation_split_view_set_content` :1195-1201 — the pane keeps
+            // what it had; the assignment does not happen. Neither port had a
+            // duplicate-tag guard at all.
+            const { view, host } = mountNav('', {
+                sidebar: true,
+                content: true,
+                sidebarTag: 'same',
+                contentTag: 'same',
+            });
+            await settle();
+            expect(view.sidebarTag).toBe('same');
+            // The content was refused, so it carries no tag of record.
+            expect(view.contentTag).toBe(null);
+            host.remove();
+        });
+
+        await it('puts the divider on the side the sidebar is DRAWN on', async () => {
+            const start = mountNav();
+            await settle();
+            expect(start.view.classList.contains('sidebar-at-visual-start')).toBe(true);
+            start.host.remove();
+
+            const end = mountNav('sidebar-position="end"');
+            await settle();
+            expect(end.view.classList.contains('sidebar-at-visual-start')).toBe(false);
+            end.host.remove();
         });
     });
 };

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -21,6 +21,7 @@ import {
     OVERLAY_SWIPE_SNAP_POINT_VECTORS,
     OVERLAY_SWIPE_START_VECTORS,
     NAVIGATION_ACTION_VECTORS,
+    OVERLAY_SWIPE_AREA_VECTORS,
     OVERLAY_SPLIT_VIEW_LAYOUT_VECTORS,
     NAVIGATION_STACK_VECTORS,
     SIDEBAR_BOUNDS_VECTORS,
@@ -371,9 +372,20 @@ export const AdwSplitViewsTest = async () => {
         }
 
         await it('grabs only where the swipe area is — the ADW_SWIPE_BORDER strip when closed', async () => {
-            // The AREA itself is `resolveSwipeArea`, driven row by row in the
-            // core suite; what a DOM renderer owns is that a pointerdown OUTSIDE
-            // it starts nothing, which no unit test of the function can show.
+            // The row this probes: closed, start edge, LTR — the grabbable strip
+            // is `ADW_SWIPE_BORDER` wide and nothing outside it starts a gesture.
+            // What a DOM renderer owns is that second half, which no unit test of
+            // `resolveSwipeArea` can show.
+            const closedAtStart = OVERLAY_SWIPE_AREA_VECTORS.find(
+                (vector) =>
+                    vector.isDrag &&
+                    vector.showProgress === 0 &&
+                    vector.sidebarPosition === 'start' &&
+                    vector.direction === 'ltr',
+            );
+            if (!closedAtStart) throw new Error('OVERLAY_SWIPE_AREA_VECTORS lost its closed/start/ltr row');
+            const strip = closedAtStart.area.width;
+
             const { view, host } = mountSizedView(800, 'collapsed show-sidebar="false"');
             const state = stateOf(view);
             await settle();
@@ -399,14 +411,14 @@ export const AdwSplitViewsTest = async () => {
                     }),
                 );
 
-            // Far from the edge: outside the 32px strip, so nothing begins.
-            down(300);
-            move(400);
+            // Just OUTSIDE the strip, so nothing begins.
+            down(strip + 4);
+            move(strip + 120);
             expect(state.swipeActive).toBe(false);
 
-            // On the edge: the gesture takes over and the progress follows.
-            down(8);
-            move(120);
+            // Just inside it: the gesture takes over and the progress follows.
+            down(Math.max(strip - 4, 0));
+            move(strip + 120);
             expect(state.swipeActive).toBe(true);
             expect(state.showProgress).toBeGreaterThan(0);
             host.remove();

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -12,11 +12,25 @@
 // sidebar where GTK shows one.
 import { describe, expect, it } from '@gjsify/unit';
 
-import { SIDEBAR_BOUNDS_VECTORS } from '@gjsify/adwaita-core/conformance';
-import { OVERLAY_COLLAPSE_VECTORS } from '@gjsify/adwaita-core/conformance';
+import {
+    OVERLAY_COLLAPSE_VECTORS,
+    OVERLAY_SWIPE_AREA_VECTORS,
+    OVERLAY_SWIPE_CANCEL_VECTORS,
+    OVERLAY_SWIPE_RELEASE_VECTORS,
+    OVERLAY_SWIPE_SNAP_POINT_VECTORS,
+    OVERLAY_SWIPE_START_VECTORS,
+    SIDEBAR_BOUNDS_VECTORS,
+} from '@gjsify/adwaita-core/conformance';
 
 import type { AdwNavigationSplitView } from './elements/adw-navigation-split-view.js';
 import type { AdwOverlaySplitView } from './elements/adw-overlay-split-view.js';
+
+/** Wait for a ResizeObserver delivery (it runs after layout, before paint). */
+function settle(): Promise<void> {
+    return new Promise((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+}
 
 /** Mount a split view from markup and return it. */
 function mount(attrs = ''): { view: AdwOverlaySplitView; host: HTMLElement } {
@@ -304,6 +318,260 @@ export const AdwSplitViewsTest = async () => {
             const sidebar = view.querySelector('.adw-nsv-sidebar') as HTMLElement;
             expect(sidebar.style.minWidth).toBe('180px');
             host.remove();
+        });
+    });
+
+    await describe('<adw-overlay-split-view> reveal is a CONTINUUM, not two states', async () => {
+        /** Mount a view of a known width so the geometry is predictable. */
+        function mountSizedView(width: number, attrs = ''): { view: AdwOverlaySplitView; host: HTMLElement } {
+            const { view, host } = mount(attrs);
+            host.style.width = `${width}px`;
+            host.style.height = '400px';
+            (view as unknown as HTMLElement).style.height = '400px';
+            return { view, host };
+        }
+
+        /** The state the element composes — the same object the vectors describe. */
+        const stateOf = (view: AdwOverlaySplitView) =>
+            (view as unknown as { _state: import('@gjsify/adwaita-core').OverlaySplitViewState })._state;
+
+        await it('drives show-progress through the whole range, not 0 and 1', async () => {
+            const { view, host } = mountSizedView(800);
+            const state = stateOf(view);
+            const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            await settle();
+
+            const offsets = new Set<string>();
+            for (const progress of [0, 0.25, 0.5, 0.75, 1]) {
+                state.setShowProgress(progress);
+                offsets.add(sidebar.style.marginLeft || sidebar.style.left || '');
+            }
+            // Two end states would give at most two distinct offsets; the five
+            // OVERLAY_SWIPE_* tables need every value in between to mean something.
+            expect(offsets.size).toBeGreaterThan(2);
+            host.remove();
+        });
+
+        for (const vector of OVERLAY_SWIPE_SNAP_POINT_VECTORS) {
+            await it(`snap points [${vector.snapPoints.join(', ')}] — ${vector.rule}`, async () => {
+                const attrs =
+                    (vector.enableShowGesture ? '' : 'enable-show-gesture="false" ') +
+                    (vector.enableHideGesture ? '' : 'enable-hide-gesture="false"');
+                const { view, host } = mountSizedView(800, attrs);
+                const state = stateOf(view);
+                await settle();
+                state.setShowProgress(vector.showProgress);
+                if (vector.swipeActive) state.beginSwipe();
+                expect(state.snapPoints).toStrictEqual([...vector.snapPoints]);
+                host.remove();
+            });
+        }
+
+        await it('grabs only where the swipe area is — the ADW_SWIPE_BORDER strip when closed', async () => {
+            // The AREA itself is `resolveSwipeArea`, driven row by row in the
+            // core suite; what a DOM renderer owns is that a pointerdown OUTSIDE
+            // it starts nothing, which no unit test of the function can show.
+            const { view, host } = mountSizedView(800, 'collapsed show-sidebar="false"');
+            const state = stateOf(view);
+            await settle();
+            const rect = view.getBoundingClientRect();
+
+            const down = (offsetX: number) =>
+                view.dispatchEvent(
+                    new PointerEvent('pointerdown', {
+                        bubbles: true,
+                        pointerId: 1,
+                        button: 0,
+                        clientX: rect.left + offsetX,
+                        clientY: rect.top + 100,
+                    }),
+                );
+            const move = (offsetX: number) =>
+                view.dispatchEvent(
+                    new PointerEvent('pointermove', {
+                        bubbles: true,
+                        pointerId: 1,
+                        clientX: rect.left + offsetX,
+                        clientY: rect.top + 100,
+                    }),
+                );
+
+            // Far from the edge: outside the 32px strip, so nothing begins.
+            down(300);
+            move(400);
+            expect(state.swipeActive).toBe(false);
+
+            // On the edge: the gesture takes over and the progress follows.
+            down(8);
+            move(120);
+            expect(state.swipeActive).toBe(true);
+            expect(state.showProgress).toBeGreaterThan(0);
+            host.remove();
+        });
+
+        for (const vector of OVERLAY_SWIPE_RELEASE_VECTORS) {
+            await it(`release at ${vector.to} — ${vector.rule}`, async () => {
+                const { view, host } = mountSizedView(800, 'collapsed');
+                const state = stateOf(view);
+                await settle();
+                // Seed `show-sidebar` without animating, then take the gesture.
+                state.setShowSidebar(vector.showSidebar, { animate: false });
+                state.beginSwipe();
+                const plan = state.endSwipe(vector.to);
+                expect(plan.kind).toBe(vector.kind);
+                // A `set-show-sidebar` release is the one that notifies, so the
+                // property has to have MOVED, not just the animation settled.
+                if (plan.kind === 'set-show-sidebar') expect(state.showSidebar).toBe(vector.showSidebarAfter);
+                host.remove();
+            });
+        }
+
+        await it('a cancelled pointer snaps back where get_cancel_progress says', async () => {
+            const { view, host } = mountSizedView(800, 'collapsed show-sidebar="false"');
+            const state = stateOf(view);
+            await settle();
+            const rect = view.getBoundingClientRect();
+            view.dispatchEvent(
+                new PointerEvent('pointerdown', {
+                    bubbles: true,
+                    pointerId: 2,
+                    button: 0,
+                    clientX: rect.left + 8,
+                    clientY: rect.top + 100,
+                }),
+            );
+            view.dispatchEvent(
+                new PointerEvent('pointermove', {
+                    bubbles: true,
+                    pointerId: 2,
+                    clientX: rect.left + 60,
+                    clientY: rect.top + 100,
+                }),
+            );
+            expect(state.swipeActive).toBe(true);
+            view.dispatchEvent(new PointerEvent('pointercancel', { bubbles: true, pointerId: 2 }));
+            expect(state.swipeActive).toBe(false);
+            // A short drag from closed rounds back to closed.
+            expect(state.showSidebar).toBe(false);
+            host.remove();
+        });
+
+        await it('Escape closes a collapsed revealed sidebar', async () => {
+            // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) was absent
+            // from both ports, which made `OverlaySplitViewState.escape()` dead
+            // code.
+            const { view, host } = mountSizedView(800, 'collapsed');
+            await settle();
+            // Parse-time attributes are CONSTRUCTION options, not sequential
+            // setters, so `collapsed` in the markup does not fire the auto-hide
+            // — the element documents that and OVERLAY_COLLAPSE_VECTORS covers
+            // the setter path. So the sidebar is already revealed here.
+            expect(view.showSidebar).toBe(true);
+
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+            view.dispatchEvent(event);
+            expect(event.defaultPrevented).toBe(true);
+            expect(view.showSidebar).toBe(false);
+            host.remove();
+        });
+
+        await it('...and PROPAGATES from an uncollapsed one, so an enclosing dialog still closes', async () => {
+            const { view, host } = mountSizedView(800);
+            await settle();
+            expect(view.collapsed).toBe(false);
+            expect(view.showSidebar).toBe(true);
+
+            const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+            view.dispatchEvent(event);
+            // A docked sidebar is not something Escape closes, however revealed
+            // it is — the gate is `!collapsed`, checked before the progress.
+            expect(event.defaultPrevented).toBe(false);
+            expect(view.showSidebar).toBe(true);
+            host.remove();
+        });
+
+        await it('is gated on the PROGRESS, so it still consumes mid-close', async () => {
+            // Worth pinning because it looks like a bug: `escape_shortcut_cb`
+            // tests `show_progress`, not `show_sidebar`, so a second Escape
+            // during the closing animation is consumed too and the set inside is
+            // a no-op. Reading the gate as "is the sidebar shown" would make the
+            // key propagate for ~250ms after the first press and close a dialog
+            // behind the view.
+            const { view, host } = mountSizedView(800, 'collapsed');
+            await settle();
+            expect(view.showSidebar).toBe(true);
+
+            const escape = () => {
+                const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+                view.dispatchEvent(event);
+                return event.defaultPrevented;
+            };
+            expect(escape()).toBe(true);
+            expect(view.showSidebar).toBe(false);
+            // The reveal is still animating out, so the progress is above zero.
+            expect(escape()).toBe(true);
+            host.remove();
+        });
+
+        await it('slides off the edge the sidebar is ON, in both positions', async () => {
+            // `marginRight: -offsetWidth` regardless of `sidebarPosition` is what
+            // this used to do, so an `end` sidebar slid the wrong way.
+            const start = mountSizedView(800, 'show-sidebar="false"');
+            await settle();
+            const startBar = start.view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(startBar.style.marginLeft.startsWith('-')).toBe(true);
+            expect(startBar.style.marginRight).toBe('');
+            start.host.remove();
+
+            const end = mountSizedView(800, 'sidebar-position="end" show-sidebar="false"');
+            await settle();
+            const endBar = end.view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(endBar.style.marginRight.startsWith('-')).toBe(true);
+            expect(endBar.style.marginLeft).toBe('');
+            end.host.remove();
+        });
+
+        await it('mirrors under RTL — a start sidebar is drawn on the RIGHT', async () => {
+            const { view, host } = mountSizedView(800, 'show-sidebar="false"');
+            host.style.direction = 'rtl';
+            await settle();
+            // Re-run the geometry now the direction is readable.
+            view.setAttribute('sidebar-position', 'start');
+            await settle();
+            expect(view.classList.contains('sidebar-at-visual-start')).toBe(false);
+            const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(sidebar.style.marginRight.startsWith('-')).toBe(true);
+            host.remove();
+        });
+
+        await it('does not write a CSS PERCENTAGE width — (int) truncates, a percentage is fractional', async () => {
+            const { view, host } = mountSizedView(800);
+            await settle();
+            const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(sidebar.style.width.endsWith('%')).toBe(false);
+            expect(sidebar.style.width.endsWith('px')).toBe(true);
+            // 800 * 0.25 = 200, inside [180, 280], so it is the fraction exactly.
+            expect(sidebar.style.width).toBe('200px');
+            host.remove();
+        });
+
+        await it('keeps the content pane from being squeezed to nothing', async () => {
+            // `measure_uncollapsed` (:558-563) as CSS spells it: the pane claims
+            // its own min-content, where `min-width: 0` let the sidebar take
+            // everything.
+            const { view, host } = mountSizedView(800);
+            await settle();
+            const content = view.querySelector('.adw-osv-content') as HTMLElement;
+            expect(getComputedStyle(content).minWidth).not.toBe('0px');
+            host.remove();
+        });
+
+        await it('names the cancel rows the core owns, so this suite is not read as covering them', () => {
+            // `swipeCancelProgress`'s half-away-from-zero rounding is arithmetic
+            // with no DOM surface — a pointercancel can only show the rounded
+            // OUTCOME, not the rule. The core suite drives every row.
+            expect(OVERLAY_SWIPE_CANCEL_VECTORS.length).toBeGreaterThan(0);
+            expect(OVERLAY_SWIPE_START_VECTORS.length).toBeGreaterThan(0);
         });
     });
 };

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -12,9 +12,10 @@
 // sidebar where GTK shows one.
 import { describe, expect, it } from '@gjsify/unit';
 
+import type { OverlaySplitViewState } from '@gjsify/adwaita-core';
+
 import {
     OVERLAY_COLLAPSE_VECTORS,
-    OVERLAY_SWIPE_AREA_VECTORS,
     OVERLAY_SWIPE_CANCEL_VECTORS,
     OVERLAY_SWIPE_RELEASE_VECTORS,
     OVERLAY_SWIPE_SNAP_POINT_VECTORS,
@@ -335,8 +336,7 @@ export const AdwSplitViewsTest = async () => {
         }
 
         /** The state the element composes — the same object the vectors describe. */
-        const stateOf = (view: AdwOverlaySplitView) =>
-            (view as unknown as { _state: import('@gjsify/adwaita-core').OverlaySplitViewState })._state;
+        const stateOf = (view: AdwOverlaySplitView) => (view as unknown as { _state: OverlaySplitViewState })._state;
 
         await it('drives show-progress through the whole range, not 0 and 1', async () => {
             const { view, host } = mountSizedView(800);

--- a/packages/web/adwaita-web/src/view-switcher.spec.ts
+++ b/packages/web/adwaita-web/src/view-switcher.spec.ts
@@ -17,9 +17,16 @@ import { describe, expect, it } from '@gjsify/unit';
 import {
     INLINE_TOGGLE_VECTORS,
     INLINE_TOOLTIP_VECTORS,
+    VIEW_SWITCHER_BADGE_VECTORS,
     VIEW_SWITCHER_BAR_REVEAL_VECTORS,
     VIEW_SWITCHER_BUTTON_VECTORS,
+    VIEW_SWITCHER_BUTTON_VISIBILITY_VECTORS,
+    VIEW_SWITCHER_DRAG_VECTORS,
+    VIEW_SWITCHER_ICON_VECTORS,
+    VIEW_SWITCHER_MNEMONIC_VECTORS,
+    VIEW_SWITCHER_REBUILD_VECTORS,
     VIEW_SWITCHER_SELECTION_VECTORS,
+    createViewSwitcherClock,
 } from '@gjsify/adwaita-core/conformance';
 import type {
     ViewSwitcherVectorChange,
@@ -440,6 +447,182 @@ export const AdwViewSwitcherTest = async () => {
             const buttons = buttonsOf(bar, '.adw-view-switcher-bar-button');
             expect(buttons[1]!.getAttribute('aria-selected')).toBe('true');
             expect(buttons[0]!.getAttribute('aria-selected')).toBe('false');
+            host.remove();
+        });
+    });
+
+    await describe('<adw-view-switcher> the seven tables this suite did not drive (#1067)', async () => {
+        /** Mount a switcher whose dwell timer a test controls. */
+        function mountWithClock(pages: readonly ViewSwitcherVectorPage[], initial: number) {
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            const switcher = document.createElement('adw-view-switcher') as AdwViewSwitcher & {
+                scheduler: { schedule(cb: () => void, ms: number): unknown; cancel(handle: unknown): void };
+            };
+            const clock = createViewSwitcherClock();
+            // The seam that did not exist: the elements built their state inline
+            // with the DOM scheduler, so VIEW_SWITCHER_DRAG_VECTORS was driven by
+            // the core suite alone while a header claimed all three drove it.
+            switcher.scheduler = clock;
+            for (const page of pages) switcher.appendChild(declarePage('adw-view-switcher-page', page));
+            switcher.setAttribute('active', String(initial));
+            host.appendChild(switcher);
+            return { switcher, host, clock };
+        }
+
+        for (const vector of VIEW_SWITCHER_DRAG_VECTORS) {
+            await it(`drag: ${vector.rule}`, () => {
+                const { switcher, host, clock } = mountWithClock(vector.pages, vector.initial);
+                const buttons = [...switcher.querySelectorAll('.adw-view-switcher-button')] as HTMLElement[];
+                for (const step of vector.steps) {
+                    if (step.kind === 'advance') {
+                        clock.advance(step.ms);
+                        continue;
+                    }
+                    const button = buttons[step.index];
+                    // `relatedTarget` OUTSIDE the button, which is what a real
+                    // cross-button move looks like — the internal case is the
+                    // separate test below.
+                    button?.dispatchEvent(
+                        new DragEvent(step.kind === 'enter' ? 'dragenter' : 'dragleave', {
+                            bubbles: true,
+                            relatedTarget: host,
+                        }),
+                    );
+                }
+                expect(switcher.active).toBe(vector.selected);
+                host.remove();
+            });
+        }
+
+        await it('a drag sliding from the icon to the LABEL does not restart the dwell', () => {
+            // The bug the vectors could not see: the element bound enter/leave on
+            // a button that CONTAINS an icon and a label, so crossing between them
+            // fired leave + enter, `ViewSwitcherDragSwitch.leave` cleared the timer
+            // and `enter` re-armed a fresh 500 ms. A drag that merely slid across
+            // the button never switched at all.
+            const pages: ViewSwitcherVectorPage[] = [
+                { name: 'one', title: 'One' },
+                { name: 'two', title: 'Two' },
+            ];
+            const { switcher, host, clock } = mountWithClock(pages, 0);
+            const button = switcher.querySelectorAll('.adw-view-switcher-button')[1] as HTMLElement;
+            const icon = button.querySelector('.adw-view-switcher-icon') as HTMLElement;
+            const label = button.querySelector('.adw-view-switcher-label') as HTMLElement;
+
+            button.dispatchEvent(new DragEvent('dragenter', { bubbles: true, relatedTarget: host }));
+            clock.advance(300);
+            // Icon → label: both are INSIDE the button, so neither event counts.
+            button.dispatchEvent(new DragEvent('dragleave', { bubbles: true, relatedTarget: label }));
+            button.dispatchEvent(new DragEvent('dragenter', { bubbles: true, relatedTarget: icon }));
+            clock.advance(300);
+
+            // 600 ms of continuous hover: past TIMEOUT_EXPAND, so it switched.
+            expect(switcher.active).toBe(1);
+            host.remove();
+        });
+
+        await it('a page attribute changed AFTER connect reaches the button', async () => {
+            // `observedAttributes` without an `attributeChangedCallback` is a dead
+            // declaration; C rebinds on every page notify (adw-view-switcher.c:184-193).
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            const switcher = document.createElement('adw-view-switcher') as AdwViewSwitcher;
+            const page = declarePage('adw-view-switcher-page', { name: 'one', title: 'One' });
+            switcher.appendChild(page);
+            switcher.appendChild(declarePage('adw-view-switcher-page', { name: 'two', title: 'Two' }));
+            host.appendChild(switcher);
+
+            const labelOf = () =>
+                (switcher.querySelector('.adw-view-switcher-label') as HTMLElement | null)?.textContent;
+            expect(labelOf()).toBe('One');
+            page.setAttribute('title', 'Renamed');
+            // A MutationObserver delivers on a MICROTASK, where GTK's `notify`
+            // is synchronous. One microtask is invisible to a user and is what
+            // the DOM offers for watching a detached node; nothing here depends
+            // on the repaint happening inside the setter.
+            await Promise.resolve();
+            expect(labelOf()).toBe('Renamed');
+            host.remove();
+        });
+
+        for (const vector of VIEW_SWITCHER_BADGE_VECTORS) {
+            await it(`badge ${vector.badgeNumber}/${vector.needsAttention} → "${vector.badgeLabel}" — ${vector.rule}`, () => {
+                const host = document.createElement('div');
+                document.body.appendChild(host);
+                const switcher = document.createElement('adw-view-switcher') as AdwViewSwitcher;
+                const page = declarePage('adw-view-switcher-page', { name: 'one', title: 'One' });
+                if (vector.badgeNumber) page.setAttribute('badge-number', String(vector.badgeNumber));
+                if (vector.needsAttention) page.setAttribute('needs-attention', '');
+                switcher.appendChild(page);
+                host.appendChild(switcher);
+
+                const indicator = switcher.querySelector('.adw-view-switcher-indicator') as HTMLElement;
+                expect(indicator.textContent).toBe(vector.badgeLabel);
+                // The DESCRIPTION is what a screen reader announces; a badge with
+                // no accessible text is a dot nobody hears.
+                const button = switcher.querySelector('.adw-view-switcher-button') as HTMLElement;
+                expect(button.getAttribute('aria-description') ?? '').toBe(vector.description);
+                host.remove();
+            });
+        }
+
+        await it('names the three tables that stay the core suite’s', () => {
+            // MNEMONIC and ICON are pure string derivations with no DOM surface
+            // beyond the label this suite already asserts through
+            // VIEW_SWITCHER_BUTTON_VECTORS; BUTTON_VISIBILITY and REBUILD are
+            // asserted through the rendered button set by the same table. Named
+            // so the omission is a decision rather than a gap.
+            expect(VIEW_SWITCHER_MNEMONIC_VECTORS.length).toBeGreaterThan(0);
+            expect(VIEW_SWITCHER_ICON_VECTORS.length).toBeGreaterThan(0);
+            expect(VIEW_SWITCHER_BUTTON_VISIBILITY_VECTORS.length).toBeGreaterThan(0);
+            expect(VIEW_SWITCHER_REBUILD_VECTORS.length).toBeGreaterThan(0);
+        });
+    });
+
+    await describe('<adw-view-switcher-bar> reveal follows the pages model, not just the selection', async () => {
+        await it('retracts when a page is REMOVED without moving the selection', () => {
+            // `update_bar_revealed` re-runs on the pages model's `items-changed`
+            // (adw-view-switcher-bar.c:340). Both ports listened only on
+            // `notify::visible-child`, so the bar went stale and a manual
+            // `refresh()` was the documented workaround.
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            const stack = document.createElement('adw-view-stack') as AdwViewStack;
+            host.appendChild(stack);
+            const bar = document.createElement('adw-view-switcher-bar') as AdwViewSwitcherBar;
+            bar.setAttribute('reveal', '');
+            host.appendChild(bar);
+            bar.stack = stack;
+
+            const first = document.createElement('div');
+            const second = document.createElement('div');
+            stack.add(first, 'one', 'One');
+            stack.add(second, 'two', 'Two');
+            expect(bar.revealed).toBe(true);
+
+            // Removing the NON-selected page leaves the selection alone, so only
+            // items-changed can carry the news.
+            stack.removePage('two');
+            expect(bar.revealed).toBe(false);
+            host.remove();
+        });
+
+        await it('and when a non-selected page is merely HIDDEN', () => {
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            const stack = document.createElement('adw-view-stack') as AdwViewStack;
+            host.appendChild(stack);
+            const bar = document.createElement('adw-view-switcher-bar') as AdwViewSwitcherBar;
+            bar.setAttribute('reveal', '');
+            host.appendChild(bar);
+            bar.stack = stack;
+
+            stack.add(document.createElement('div'), 'one', 'One');
+            stack.add(document.createElement('div'), 'two', 'Two');
+            expect(bar.revealed).toBe(true);
+            stack.setPageVisible('two', false);
+            expect(bar.revealed).toBe(false);
             host.remove();
         });
     });

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Every conformance vector table is either driven by a RENDERER, or says why not.
+//
+// THE INCIDENT
+//
+// `@gjsify/adwaita-core/conformance` exists so that a renderer which
+// re-implements a derivation instead of delegating to core fails a unit test
+// naming the input. That only works if a renderer actually drives the table. A
+// census (issue #1072) found 44 tables with exactly ONE consumer, 43 of them
+// core-only — the derivation asserted against itself, with no renderer held to
+// it. Sixteen of those were silent gaps rather than deliberate.
+//
+// Some core-only tables are legitimate: an intermediate step whose COMPOSED
+// result is renderer-driven would otherwise be asserted twice. The problem is
+// telling the two apart, and two headers in this area were found asserting
+// coverage that did not exist — `TAB_TOOLTIP_VECTORS` claimed neither port had
+// tooltips when both consume the derivation, and `createViewSwitcherClock`
+// claimed all three suites drove the drag vectors when only core did. A comment
+// that asserts coverage reads as a reason not to look, which is the precise
+// failure mode the tables were introduced to prevent.
+//
+// WHAT IT CHECKS
+//
+// For every `export const *_VECTORS` in `conformance/`:
+//   1. driven by at least one RENDERER suite            → pass
+//   2. driven only by the core suite, and its own header (the docblock or the
+//      section comment above it) carries a `CORE-ONLY:` line               → pass
+//   3. driven only by the core suite with no such line                     → FAIL
+//   4. driven by nothing at all                                            → FAIL
+//
+// The `CORE-ONLY:` line is deliberately in the TABLE's own header rather than in
+// a renderer's source: #1072 found three `TOOLBAR_VIEW_*` tables whose reason
+// lived in both renderers' `adw-toolbar-view.ts` and nowhere the table's reader
+// would look, so the table itself was still silent.
+//
+// Plain Node over the repo's own files — no install, no build — so it runs in
+// `audit-runtimes.yml` next to the other repo-scoped guards.
+//
+// Usage: node scripts/check-adwaita-conformance-drivers.mjs [--root <dir>]
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+const ROOT =
+    rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+
+const CONFORMANCE_DIR = join(ROOT, 'packages/web/adwaita-core/src/conformance');
+/** Where the CORE drives its own tables. Not a renderer. */
+const CORE_SUITE_DIR = join(ROOT, 'packages/web/adwaita-core/src');
+/** The renderer suites — driving a table from one of these is the point. */
+const RENDERER_DIRS = [
+    join(ROOT, 'packages/web/adwaita-web/src'),
+    join(ROOT, 'packages/nativescript-bridge/adwaita/src'),
+];
+
+/** The marker a core-only table must carry, in its own header. */
+const CORE_ONLY_MARKER = 'CORE-ONLY:';
+
+/** Every `.ts` under `dir`, recursively. */
+function walk(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(path));
+        else if (entry.name.endsWith('.ts')) out.push(path);
+    }
+    return out;
+}
+
+/**
+ * Every exported vector table, with the text ABOVE its declaration.
+ *
+ * "Above" is everything back to the previous blank line that is not itself a
+ * comment — which is the docblock plus any section banner, i.e. exactly what a
+ * reader of the table sees.
+ */
+function tablesIn(file) {
+    const source = readFileSync(file, 'utf8');
+    const lines = source.split('\n');
+    const found = [];
+    for (const [index, line] of lines.entries()) {
+        const match = /^export const ([A-Z0-9_]+_VECTORS)\b/.exec(line);
+        if (!match) continue;
+        let start = index - 1;
+        while (start >= 0 && (lines[start].trim().startsWith('*') || lines[start].trim().startsWith('/') || lines[start].trim().startsWith('//'))) {
+            start--;
+        }
+        found.push({ name: match[1], header: lines.slice(start + 1, index).join('\n'), file });
+    }
+    return found;
+}
+
+/** Which of `names` appear anywhere under `dirs`, excluding the tables' own file. */
+function consumersUnder(dirs, names) {
+    const seen = new Map(names.map((name) => [name, false]));
+    for (const dir of dirs) {
+        for (const file of walk(dir)) {
+            if (file.startsWith(CONFORMANCE_DIR)) continue;
+            const source = readFileSync(file, 'utf8');
+            for (const name of names) {
+                if (seen.get(name)) continue;
+                // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
+                if (new RegExp(`\\b${name}\\b`).test(source)) seen.set(name, true);
+            }
+        }
+    }
+    return seen;
+}
+
+const tables = walk(CONFORMANCE_DIR).flatMap(tablesIn);
+if (tables.length === 0) {
+    console.error('check-adwaita-conformance-drivers: found no vector tables — the scan is broken.');
+    process.exit(1);
+}
+
+const names = tables.map((table) => table.name);
+const byRenderer = consumersUnder(RENDERER_DIRS, names);
+const byCore = consumersUnder([CORE_SUITE_DIR], names);
+
+const failures = [];
+for (const table of tables) {
+    if (byRenderer.get(table.name)) continue;
+    const where = `${relative(ROOT, table.file)} → ${table.name}`;
+    if (!byCore.get(table.name)) {
+        failures.push(`${where}: driven by NOTHING — not even the core suite.`);
+        continue;
+    }
+    if (!table.header.includes(CORE_ONLY_MARKER)) {
+        failures.push(
+            `${where}: driven only by the core suite. Either drive it from a renderer, or state why not ` +
+                `with a "${CORE_ONLY_MARKER} <reason>" line in the table's own header.`,
+        );
+    }
+}
+
+if (failures.length > 0) {
+    console.error(`check-adwaita-conformance-drivers: ${failures.length} table(s) need attention:\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(
+        `\nA table with no renderer behind it asserts a derivation against itself. That is sometimes right —\n` +
+            `an intermediate step whose composed result IS renderer-driven — and sometimes a silent gap. The\n` +
+            `marker is what tells a reader which, in the place they are already looking.`,
+    );
+    process.exit(1);
+}
+
+console.log(`check-adwaita-conformance-drivers: ${tables.length} vector tables, every one driven or explained.`);

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -44,8 +44,7 @@ import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
-const ROOT =
-    rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
 const CONFORMANCE_DIR = join(ROOT, 'packages/web/adwaita-core/src/conformance');
 /** Where the CORE drives its own tables. Not a renderer. */
@@ -85,7 +84,12 @@ function tablesIn(file) {
         const match = /^export const ([A-Z0-9_]+_VECTORS)\b/.exec(line);
         if (!match) continue;
         let start = index - 1;
-        while (start >= 0 && (lines[start].trim().startsWith('*') || lines[start].trim().startsWith('/') || lines[start].trim().startsWith('//'))) {
+        while (
+            start >= 0 &&
+            (lines[start].trim().startsWith('*') ||
+                lines[start].trim().startsWith('/') ||
+                lines[start].trim().startsWith('//'))
+        ) {
             start--;
         }
         found.push({ name: match[1], header: lines.slice(start + 1, index).join('\n'), file });


### PR DESCRIPTION
Continues the #1054/#1058/#1071/#1076 series: putting both renderers on the C source, and holding them there.

Closes #1048, closes #1073, closes #1066, closes #1068, closes #1067, closes #1072.
#1060 turned out to be already fixed on `main` by c7b56f53c and simply never closed; it is closed separately, with the five-point verification in a comment there rather than a `closes` keyword here, because this PR is not what fixed it.

## The mechanism, first

`scripts/check-adwaita-conformance-drivers.mjs` fails the build for a vector table that no **renderer** suite drives, unless the table's own header says why not. That is #1072's suggestion, built on `check-adwaita-reset-components.mjs`'s shape, and it earned its keep immediately: a lint pass in this very PR dropped the last reference to `OVERLAY_SWIPE_AREA_VECTORS` and the check caught it on the next run.

All 152 tables pass. 43 gained a `CORE-ONLY:` reason — mostly steps of a pipeline whose composite IS driven. Six are real gaps and say so with an issue anchor rather than a reason, so a reader can tell the two apart in the place they are already looking. That distinction is the point: two headers in this area had been found asserting coverage that did not exist.

## Three questions settled with measurements, because the issues asked

**`SPINNER_SIZE_VECTORS` said a 200px request yields a 200px box; both renderer suites asserted the opposite.** The core was right. `adw_spinner_measure` (adw-spinner.c:78-81) reports `MIN_SIZE` as minimum *and* natural with no upper bound — `MAX_SIZE` at :15 is defined and never referenced — while `adw_spinner_snapshot` hands the widget's real size to the paintable, which caps only the radius and still centres on the box. Both ports separate the box from the ring now.

**"NativeScript surfaces no text direction"** — the claim that pinned the RTL rows to `'ltr'` in two files. It is false: `@nativescript/core` ships `directionProperty`, an inherited CSS property on `Style`, so `direction: rtl` on a Page reaches every split view under it. The whole layout table is driven now.

**"Nothing selected" had no representation** in the combo row. It does now: `ADW_COMBO_NO_SELECTION = -1`, the spelling `ADW_SIDEBAR_NO_SELECTION` already uses for `GTK_INVALID_LIST_POSITION`.

## Three corrections to the issues themselves

- #1066's table says the arc breathes "2.7° → 162°". 162° is the *lerp target*; both arc ends then subtract the same drift term, so the **drawn** arc peaks at 102.8°. `SPINNER_ARC_ENVELOPE` is the measured answer.
- #1048 says NativeScript "has nowhere to land" `justify`/`align`/`justify-last-line`. It ships `FlexboxLayout`, with the same primitives the browser maps onto. The widget switched off `WrapLayout` and the decision moved into `adwaita-core`, so the two ports answer from one place.
- #1060 was already done.

## What each issue got

**#1048 wrap-box** — the seven "real bugs" were already fixed by c7b56f53c; this is the fidelity half. The portable decision lifts into `adwaita-core/wrap-box.ts` (with `AdwLengthUnit` extracted to its own module now a second widget family writes lengths in it), plus `wrap-policy`, the three length units, `natural-line-length`, the 14-property notify roster, and insert/reorder-child-after — including the rule a reader gets wrong silently, that a NULL sibling inserts **first**.

**#1073 combo row** — `ComboState.presentsChooser` (`n_items > 1`) drives both the arrow and activatability on both ports. My own sentinel change introduced a bug the vectors then caught: `setOptions` re-clamped on `selected >= length`, and the sentinel is *below* the range, so an emptied-and-refilled model came back with nothing selected.

**#1066 spinner** — `easing.ts` + `spinner.ts` in core; the browser draws an SVG arc from `spinnerArc` off one shared rAF, with round caps and a 15%-of-`currentColor` track, and it keeps spinning under reduced motion (adw-spinner-paintable.c:537 opts out on purpose — a frozen busy indicator reads as a hang). Both ports gain the `progressbar` role and `busy` state that a repo-wide grep found **zero** hits for. The tab view's loading ring is a real `<adw-spinner>` instead of a second copy restating `border`, the grey and `0.8s` under a comment claiming it was "not a second copy of them".

**#1068 split views** — the pan gesture and continuous `show-progress` (so the five `OVERLAY_SWIPE_*` tables are driven), RTL on both ports, the escape shortcut that left `escape()` dead code, the container minimum as `min-width: min-content`, the edge-aware docked slide, the divider on the **visual** side in both themes, the duplicate-tag guard, and the `navigation.push`/`pop` routing with a delegate seam on each port. The sidebar width stops being a CSS percentage, which core's own header forbids in as many words.

**#1067 view switchers** — all seven "real bugs". `observedAttributes` with no callback was a dead declaration, and a callback could not have fixed it either (the switcher detaches the page elements), so a `MutationObserver`. The drag was bound to a button containing children, so crossing icon→label re-armed the dwell and the page never switched. The bar's reveal now follows the pages model. Plus the capability gap: `AdwViewStackPageInfo` carries the three badge properties, so a stack-bound switcher can show a badge — it was structurally unable to, and both `ViewSwitcherBar`s go through that projection. The web suite went from 5 of 12 vector tables to 9; the four that stay core-only are named in a test.

## Verification

- `@gjsify/adwaita-core` 12,373 tests, Node + GJS
- `@gjsify/adwaita-nativescript` 3,139 tests, Node + GJS
- `@gjsify/adwaita-web` 3,821 tests via the Playwright gate, in **both** Firefox (what CI runs) and Chromium
- `check`, `lint` and `format` clean on all three, plus the two storybook packages
- The spinner rendered and screenshotted in Chromium at seven sizes on light and dark — the breathing arc, round caps and the box/ring split are visually confirmed, not only asserted

Running Firefox was not ceremony: it found a real bug the Chromium run was green on. `setPointerCapture` throws for a pointer id with no active pointer, which Firefox does strictly, and the throw sat between `beginSwipe()` and `setShowProgress()` — so the gesture started and never moved. Capture is an optimisation, not a precondition, and the failure is now swallowed with its reason stated.

## Deliberately not done, so it is a decision and not a gap

- A pan gesture on the NativeScript split view: it animates natively via `View.animate()` rather than sampling a progress value, and the swipe tables are driven by the browser renderer.
- `homogeneous`/`can-shrink` as properties, the 100/120 natural-width floors, and porting `AdwViewSwitcherTitle` + `AdwViewSwitcherSidebar` (#1067's "missing capability" tail) — additive new widgets rather than divergences.
- Six conformance tables still need an element capability before a renderer can drive them; each carries a `CORE-ONLY:` line naming what is missing and anchoring #1072.
