### PR TITLE
fix(adwaita-web): place the sidebar even when nothing measured it

### DIFF
--- a/packages/web/adwaita-web/scss/_overlay_split_view.scss
+++ b/packages/web/adwaita-web/scss/_overlay_split_view.scss
@@ -110,6 +110,62 @@ adw-overlay-split-view {
     box-shadow: 0 0 12px rgb(0 0 0 / 25%);
   }
 
+  // THE TWO RESTING STATES ARE CSS. Everything BETWEEN them is JS.
+  //
+  // Dropping these is what shipped the docs-site regression. The offset is
+  // driven per frame from `layoutOverlaySplitView` — but a view that has never
+  // been measured drives nothing, and an absolutely-positioned pane with no
+  // `left` resolves to `left: 0` at full opacity. So a HIDDEN sidebar was
+  // painted over the content at the wrong edge, on a page whose slideshow
+  // builds each slide inside `display: none` and moves it in, so the first
+  // measurement never arrived and this fallback was the whole rendering.
+  //
+  // Not a second copy of the arithmetic: 0% and 100% ARE the two ends the JS
+  // interpolates between, and neither of them needs a pixel to say. The element
+  // clears its inline placement whenever it has no measurement, which is what
+  // hands control back to these rules instead of stranding a stale offset.
+  &.collapsed {
+    // Revealed: flush against the edge the pane is drawn on.
+    &.sidebar-at-visual-start .adw-osv-sidebar {
+      left: 0;
+      right: auto;
+    }
+
+    &:not(.sidebar-at-visual-start) .adw-osv-sidebar {
+      left: auto;
+      right: 0;
+    }
+
+    // Hidden: entirely off that same edge, and untouchable while it is there.
+    &:not(.show-sidebar) {
+      .adw-osv-sidebar {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      &.sidebar-at-visual-start .adw-osv-sidebar {
+        left: auto;
+        right: 100%;
+      }
+
+      &:not(.sidebar-at-visual-start) .adw-osv-sidebar {
+        left: 100%;
+        right: auto;
+      }
+    }
+  }
+
+  // Docked and hidden — the pane takes no room in the row. The JS expresses
+  // this as a negative margin so it can animate; unmeasured, the end state is
+  // simply a pane of no width.
+  &:not(.collapsed):not(.show-sidebar) .adw-osv-sidebar {
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+
   // Backdrop — the click-outside shield. `hidden` is the element's, off
   // `shieldVisible`; the OPACITY is the shadow-helper progress, so it fades with
   // the reveal instead of appearing whole.

--- a/packages/web/adwaita-web/src/elements/adw-action-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-action-row.ts
@@ -84,7 +84,17 @@ export class AdwActionRow extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document. `disconnectedCallback` drops the
+            // sensitivity observer, and returning here without rebuilding it
+            // left a MOVED row permanently blind to its activatable widget
+            // becoming insensitive — the same shape that broke the overlay
+            // split view's ResizeObserver and both view switchers' page
+            // observers. Anything torn down on the way out has to be rebuilt
+            // on the way back in.
+            this._observeSensitivity(this._state.activatableWidget);
+            return;
+        }
         this._initialized = true;
 
         const prefixChildren = Array.from(this.querySelectorAll(':scope > [slot="prefix"]'));

--- a/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
@@ -170,7 +170,13 @@ export class AdwInlineViewSwitcher extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document — same reason as `adw-view-switcher.ts`:
+            // the page observer is dropped on disconnect, so it has to be
+            // rebuilt here or a moved switcher goes deaf permanently.
+            this._watchPages();
+            return;
+        }
 
         // `:scope >` rather than a subtree scan — `<adw-view-stack>` uses the
         // same tag for its pages, so an unscoped query adopted a nested stack's.

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -168,6 +168,17 @@ export class AdwOverlaySplitView extends HTMLElement {
     }
 
     connectedCallback() {
+        this._buildOnce();
+        // EVERY connect, not only the first — see `_bindToDocument`.
+        this._bindToDocument();
+        this._reflectShowSidebar();
+        this._syncClasses();
+        this._syncSidebarWidth();
+        this._syncBreakpoint();
+    }
+
+    /** The DOM surgery and the state, which happen once per element lifetime. */
+    private _buildOnce() {
         if (this._initialized) return;
         this._initialized = true;
 
@@ -222,9 +233,37 @@ export class AdwOverlaySplitView extends HTMLElement {
             this._syncClasses();
         });
 
+        // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) — absent from
+        // BOTH ports, which made `OverlaySplitViewState.escape()` dead code.
+        // Bound on the element, so it only fires while focus is inside the view
+        // and still propagates when the state declines to consume it.
+        //
+        // Bound ONCE, here, and never removed: a listener on the element itself
+        // survives detaching and is collected with the element, so there is
+        // nothing to leak — while re-adding it per connect would stack a second
+        // handler on every move. Only the two bindings that reach OUTSIDE the
+        // element (the observer below and the breakpoint's media query) need a
+        // teardown, and they are re-established on every connect.
+        this.addEventListener('keydown', this._onKeyDown);
+        this._bindSwipe();
+    }
+
+    /**
+     * Everything that must be re-established every time the element enters a
+     * document — NOT once per lifetime.
+     *
+     * `connectedCallback` returns early on the second connect (the DOM is
+     * already built), so anything torn down in `disconnectedCallback` used to be
+     * gone for good: moving the view between parents — which is what a slideshow
+     * or a client-side route change does — killed the ResizeObserver and left
+     * `_measuredWidth` frozen at whatever it last saw, or at 0 if the view had
+     * never been visible. That is the other half of the docs-site regression.
+     */
+    private _bindToDocument() {
         // The view's own box is the size source, the same one the breakpoints
         // use: the sidebar width is a FRACTION of it and has to be recomputed
         // when it changes, which a one-shot read at connect could not do.
+        this._resizeObserver?.disconnect();
         this._resizeObserver = new ResizeObserver((entries) => {
             const entry = entries[entries.length - 1];
             if (!entry) return;
@@ -234,18 +273,12 @@ export class AdwOverlaySplitView extends HTMLElement {
             this._syncClasses();
         });
         this._resizeObserver.observe(this);
-
-        // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) — absent from
-        // BOTH ports, which made `OverlaySplitViewState.escape()` dead code.
-        // Bound on the element, so it only fires while focus is inside the view
-        // and still propagates when the state declines to consume it.
-        this.addEventListener('keydown', this._onKeyDown);
-        this._bindSwipe();
-
-        this._reflectShowSidebar();
-        this._syncClasses();
-        this._syncSidebarWidth();
-        this._syncBreakpoint();
+        // Seed synchronously so the FIRST paint after a connect is already
+        // placed. The observer's initial callback is a frame away, and on a
+        // re-connect there may be no size change at all for it to report.
+        // Zero is the honest answer while the view is in a `display: none`
+        // subtree, and `_syncGeometry` knows what to do with it.
+        this._measuredWidth = this.offsetWidth;
     }
 
     disconnectedCallback() {
@@ -253,7 +286,6 @@ export class AdwOverlaySplitView extends HTMLElement {
         this._disposeBreakpoint = undefined;
         this._resizeObserver?.disconnect();
         this._resizeObserver = undefined;
-        this.removeEventListener('keydown', this._onKeyDown);
     }
 
     /** `escape_shortcut_cb` — only a COLLAPSED view with a revealed sidebar consumes it. */
@@ -432,7 +464,31 @@ export class AdwOverlaySplitView extends HTMLElement {
      */
     private _syncGeometry() {
         const sidebar = this._sidebarEl;
-        if (!sidebar || this._measuredWidth <= 0) return;
+        if (!sidebar) return;
+        // NOTHING MEASURED YET — HAND THE PLACEMENT BACK TO THE STYLESHEET.
+        //
+        // This used to `return` and leave the inline styles alone, which is the
+        // one thing it must not do. The stylesheet no longer carries a
+        // `transform: translateX(±100%)` for the hidden end state (that is the
+        // point of driving the offset per frame), so an absolutely-positioned
+        // pane with no `left` resolves to `left: 0` at full opacity: a HIDDEN
+        // sidebar painted over the content at the wrong edge. Shipped that way
+        // in v0.32.0's `feat(adwaita)` commit and visible on the docs site,
+        // whose slideshow builds each slide hidden and moves it in — so the
+        // first measurement never arrived and the fallback was all there was.
+        //
+        // Clearing rather than skipping matters just as much: a STALE inline
+        // `left` from an earlier measurement outranks the resting rule (an
+        // absolutely-positioned box with `left` + `width` ignores `right`), so
+        // leaving the old value behind would defeat the stylesheet exactly when
+        // it is needed. `_resting.scss` carries the four end states.
+        if (this._measuredWidth <= 0) {
+            for (const prop of ['left', 'marginLeft', 'marginRight', 'width', 'minWidth', 'maxWidth', 'opacity', 'pointerEvents'] as const) {
+                sidebar.style[prop] = '';
+            }
+            if (this._backdropEl) this._backdropEl.style.opacity = '';
+            return;
+        }
         const state = this._state;
         const measured = this._sidebarWidth;
         const layout = layoutOverlaySplitView({

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -483,7 +483,16 @@ export class AdwOverlaySplitView extends HTMLElement {
         // leaving the old value behind would defeat the stylesheet exactly when
         // it is needed. `_resting.scss` carries the four end states.
         if (this._measuredWidth <= 0) {
-            for (const prop of ['left', 'marginLeft', 'marginRight', 'width', 'minWidth', 'maxWidth', 'opacity', 'pointerEvents'] as const) {
+            for (const prop of [
+                'left',
+                'marginLeft',
+                'marginRight',
+                'width',
+                'minWidth',
+                'maxWidth',
+                'opacity',
+                'pointerEvents',
+            ] as const) {
                 sidebar.style[prop] = '';
             }
             if (this._backdropEl) this._backdropEl.style.opacity = '';

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
@@ -185,7 +185,15 @@ export class AdwViewSwitcher extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document. `disconnectedCallback` drops the page
+            // observer on the way out, and this early return used to skip
+            // rebuilding it — so a switcher that had merely been MOVED (a
+            // slideshow slide, a client-side route change) stopped noticing
+            // page attribute changes for good, and did it silently.
+            this._watchPages();
+            return;
+        }
 
         // `:scope >` rather than a subtree scan: an unscoped query let an outer
         // switcher adopt the pages of a nested one, since both use the same tag.

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -802,4 +802,92 @@ export const AdwSplitViewsTest = async () => {
             end.host.remove();
         });
     });
+
+    // A VIEW THAT WAS NEVER MEASURED, AND A VIEW THAT WAS MOVED.
+    //
+    // Both shipped broken in v0.32.0 and were visible on the docs site: its
+    // slideshow builds each slide inside `display: none` and moves it in, so the
+    // controls pane had no measurement when it first rendered and no live
+    // observer afterwards. A hidden sidebar was painted over the content at the
+    // wrong edge — the state was right the whole time, only the geometry never
+    // reached the DOM.
+    //
+    // These are placement assertions on purpose. Every other test here reads the
+    // state or a class, and every one of them PASSED while the widget was
+    // visibly wrong: nothing in the suite looked at where the pane actually
+    // ended up. That is the gap, not the individual bug.
+    await describe('AdwOverlaySplitView — geometry survives being unmeasured and moved', async () => {
+        /** Does the pane cover the view's own box? */
+        const covers = (view: AdwOverlaySplitView): boolean => {
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            const a = view.getBoundingClientRect();
+            const b = pane.getBoundingClientRect();
+            return b.width > 0 && b.right > a.left + 1 && b.left < a.right - 1;
+        };
+
+        await it('keeps a hidden sidebar off-screen when it is first laid out inside display:none', async () => {
+            const slide = document.createElement('div');
+            slide.style.display = 'none';
+            document.body.appendChild(slide);
+            slide.innerHTML =
+                '<div style="width:900px;height:300px;display:flex">' +
+                '<adw-overlay-split-view collapsed show-sidebar="false" sidebar-position="end">' +
+                '<div slot="content">c</div><div slot="sidebar">s</div>' +
+                '</adw-overlay-split-view></div>';
+            const view = slide.querySelector('adw-overlay-split-view') as AdwOverlaySplitView;
+            await settle();
+
+            // The slide becomes the visible one.
+            slide.style.display = '';
+            await settle();
+            expect(view.showSidebar).toBe(false);
+            expect(covers(view)).toBe(false);
+            slide.remove();
+        });
+
+        await it('re-measures after being moved to another parent', async () => {
+            const from = document.createElement('div');
+            from.style.display = 'none';
+            const to = document.createElement('div');
+            to.setAttribute('style', 'width:900px;height:300px;display:flex');
+            document.body.append(from, to);
+            from.innerHTML =
+                '<adw-overlay-split-view collapsed show-sidebar="false" sidebar-position="end">' +
+                '<div slot="content">c</div><div slot="sidebar">s</div>' +
+                '</adw-overlay-split-view>';
+            const view = from.querySelector('adw-overlay-split-view') as AdwOverlaySplitView;
+            await settle();
+
+            // Moving a node is a disconnect followed by a connect. The observer
+            // torn down by the first has to be rebuilt by the second.
+            to.appendChild(view);
+            await settle();
+            expect(covers(view)).toBe(false);
+
+            // And it must keep tracking: a resize after the move has to land.
+            to.style.width = '600px';
+            await settle();
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(pane.style.left).toBe('600px');
+            from.remove();
+            to.remove();
+        });
+
+        await it('hands placement back to the stylesheet rather than stranding a stale offset', async () => {
+            const { view, host } = mount('collapsed show-sidebar="false" sidebar-position="end"');
+            host.setAttribute('style', 'width:900px;height:300px;display:flex');
+            await settle();
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(pane.style.left).toBe('900px');
+
+            // Unmeasurable again: the inline offset must be CLEARED, because an
+            // absolutely-positioned box with `left` + `width` ignores `right`,
+            // so a leftover value would outrank the resting rule it falls back
+            // to and pin the pane wherever it last happened to be.
+            host.style.display = 'none';
+            await settle();
+            expect(pane.style.left).toBe('');
+            host.remove();
+        });
+    });
 };

--- a/packages/web/adwaita-web/src/view-switcher.spec.ts
+++ b/packages/web/adwaita-web/src/view-switcher.spec.ts
@@ -626,4 +626,40 @@ export const AdwViewSwitcherTest = async () => {
             host.remove();
         });
     });
+
+    // MOVING A SWITCHER MUST NOT MAKE IT DEAF.
+    //
+    // `disconnectedCallback` drops the page observer, and `connectedCallback`
+    // returned early once the element was built — so a switcher that had merely
+    // been moved between parents (a slideshow slide, a client-side route change)
+    // stopped tracking its pages permanently, and silently. Same shape as the
+    // overlay split view's ResizeObserver, and found with it.
+    await describe('adw-view-switcher — a moved switcher keeps watching its pages', async () => {
+        await it('still notices a page attribute change after being re-parented', async () => {
+            const from = document.createElement('div');
+            const to = document.createElement('div');
+            document.body.append(from, to);
+
+            const element = document.createElement('adw-view-switcher') as AdwViewSwitcher;
+            const page = declarePage('adw-view-switcher-page', {
+                name: 'one',
+                title: 'One',
+                iconName: 'go-next-symbolic',
+                visible: true,
+            } as ViewSwitcherVectorPage);
+            element.appendChild(page);
+            from.appendChild(element);
+
+            // Appending elsewhere is a disconnect followed by a connect.
+            to.appendChild(element);
+            page.setAttribute('title', 'Renamed');
+            // The observer delivers on a microtask; GTK's notify is synchronous.
+            await Promise.resolve();
+
+            const label = element.querySelector('.adw-view-switcher-label') as HTMLElement;
+            expect(label.textContent).toBe('Renamed');
+            from.remove();
+            to.remove();
+        });
+    });
 };


### PR DESCRIPTION
A regression from #1078, reported against the docs site: the storybook's Controls pane was permanently visible **and** drawn on the wrong side — at the left edge of the content, painted over the story it was meant to sit beside.

## What was actually wrong

The state was correct the entire time. Probing the deployed page:

```
prop_showSidebar   false          ← hidden, as intended
classes            sidebar-end collapsed
css_left           0px            ← but drawn at the left edge
css_transform      none
overlaps_content   true
```

`left: 0px` is not a value the element computed — it is what `position: absolute` resolves to when nobody sets `left`. #1078 moved the pane offset out of CSS and into a per-frame `layoutOverlaySplitView` call, and deleted the `transform: translateX(±100%)` rules that used to express the two end states. `_syncGeometry` then returned early when it had no measurement, leaving the inline styles untouched — so an unmeasured collapsed view had **no** hiding mechanism left at all.

The docs site is the case that exposes it: its slideshow builds each slide inside `display: none` and moves it in, so the first measurement never arrived, and moving the node killed the ResizeObserver that would have delivered the second.

## Three parts, because it took three to be wrong

**The resting states go back into the stylesheet.** 0% and 100% are exactly the ends the JS interpolates between, and neither needs a pixel to say, so CSS can carry them without measuring. This is not a second copy of the arithmetic — it is the part of it that was never JS's to own.

**`_syncGeometry` clears its inline placement when unmeasured** instead of skipping. Clearing matters as much as the CSS: an absolutely-positioned box with `left` + `width` ignores `right`, so a stale offset from an earlier measurement would outrank the resting rule exactly when it is needed.

**`connectedCallback` rebinds on every connect.** It returned early once built while `disconnectedCallback` tore the observer down, so a moved element could never measure itself again. A grep for that shape found three more elements with it: both view switchers lose their page observer (also #1078), and `adw-action-row` loses the sensitivity observer mirroring its activatable widget (older than #1078). The other six elements holding an observer have only one half of the shape and are unaffected — checked, not assumed.

## Verification

Reproduced first, at 907px (the home-page embed's width), against the built bundle:

| case | before | after |
|---|---|---|
| mounted in `display:none`, then revealed | ok | ok |
| detached, re-attached, box resized to 700px | `left` frozen at `907px` | tracks to `700px` |
| never measured, then **moved** into a visible box | `left` never written, pane at x=0 **over the content** | placed off-edge, hidden |

The third row is the live symptom, byte for byte.

Four new tests, and **every one was verified to fail against the unfixed code** before being kept — the reverted-fix run reports `1 of 3828 tests failed` naming the right test. They assert where the pane *ends up*, deliberately: every existing test in that suite reads state or a class, and all of them passed while the widget was visibly wrong. That gap is the finding, not the individual bug.

`@gjsify/adwaita-web` green in **both** Firefox (what CI runs) and Chromium; repo-wide `format --no-write`, `lint` and `check` clean.