### PR TITLE
fix(website): lay widget previews out by the widget stylesheet alone

### DIFF
--- a/packages/web/adwaita-web/scss/_overlay_split_view.scss
+++ b/packages/web/adwaita-web/scss/_overlay_split_view.scss
@@ -110,6 +110,62 @@ adw-overlay-split-view {
     box-shadow: 0 0 12px rgb(0 0 0 / 25%);
   }
 
+  // THE TWO RESTING STATES ARE CSS. Everything BETWEEN them is JS.
+  //
+  // Dropping these is what shipped the docs-site regression. The offset is
+  // driven per frame from `layoutOverlaySplitView` — but a view that has never
+  // been measured drives nothing, and an absolutely-positioned pane with no
+  // `left` resolves to `left: 0` at full opacity. So a HIDDEN sidebar was
+  // painted over the content at the wrong edge, on a page whose slideshow
+  // builds each slide inside `display: none` and moves it in, so the first
+  // measurement never arrived and this fallback was the whole rendering.
+  //
+  // Not a second copy of the arithmetic: 0% and 100% ARE the two ends the JS
+  // interpolates between, and neither of them needs a pixel to say. The element
+  // clears its inline placement whenever it has no measurement, which is what
+  // hands control back to these rules instead of stranding a stale offset.
+  &.collapsed {
+    // Revealed: flush against the edge the pane is drawn on.
+    &.sidebar-at-visual-start .adw-osv-sidebar {
+      left: 0;
+      right: auto;
+    }
+
+    &:not(.sidebar-at-visual-start) .adw-osv-sidebar {
+      left: auto;
+      right: 0;
+    }
+
+    // Hidden: entirely off that same edge, and untouchable while it is there.
+    &:not(.show-sidebar) {
+      .adw-osv-sidebar {
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      &.sidebar-at-visual-start .adw-osv-sidebar {
+        left: auto;
+        right: 100%;
+      }
+
+      &:not(.sidebar-at-visual-start) .adw-osv-sidebar {
+        left: 100%;
+        right: auto;
+      }
+    }
+  }
+
+  // Docked and hidden — the pane takes no room in the row. The JS expresses
+  // this as a negative margin so it can animate; unmeasured, the end state is
+  // simply a pane of no width.
+  &:not(.collapsed):not(.show-sidebar) .adw-osv-sidebar {
+    width: 0;
+    min-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+
   // Backdrop — the click-outside shield. `hidden` is the element's, off
   // `shieldVisible`; the OPACITY is the shadow-helper progress, so it fades with
   // the reveal instead of appearing whole.

--- a/packages/web/adwaita-web/src/elements/adw-action-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-action-row.ts
@@ -84,7 +84,17 @@ export class AdwActionRow extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document. `disconnectedCallback` drops the
+            // sensitivity observer, and returning here without rebuilding it
+            // left a MOVED row permanently blind to its activatable widget
+            // becoming insensitive — the same shape that broke the overlay
+            // split view's ResizeObserver and both view switchers' page
+            // observers. Anything torn down on the way out has to be rebuilt
+            // on the way back in.
+            this._observeSensitivity(this._state.activatableWidget);
+            return;
+        }
         this._initialized = true;
 
         const prefixChildren = Array.from(this.querySelectorAll(':scope > [slot="prefix"]'));

--- a/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-inline-view-switcher.ts
@@ -170,7 +170,13 @@ export class AdwInlineViewSwitcher extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document — same reason as `adw-view-switcher.ts`:
+            // the page observer is dropped on disconnect, so it has to be
+            // rebuilt here or a moved switcher goes deaf permanently.
+            this._watchPages();
+            return;
+        }
 
         // `:scope >` rather than a subtree scan — `<adw-view-stack>` uses the
         // same tag for its pages, so an unscoped query adopted a nested stack's.

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -168,6 +168,17 @@ export class AdwOverlaySplitView extends HTMLElement {
     }
 
     connectedCallback() {
+        this._buildOnce();
+        // EVERY connect, not only the first — see `_bindToDocument`.
+        this._bindToDocument();
+        this._reflectShowSidebar();
+        this._syncClasses();
+        this._syncSidebarWidth();
+        this._syncBreakpoint();
+    }
+
+    /** The DOM surgery and the state, which happen once per element lifetime. */
+    private _buildOnce() {
         if (this._initialized) return;
         this._initialized = true;
 
@@ -222,9 +233,37 @@ export class AdwOverlaySplitView extends HTMLElement {
             this._syncClasses();
         });
 
+        // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) — absent from
+        // BOTH ports, which made `OverlaySplitViewState.escape()` dead code.
+        // Bound on the element, so it only fires while focus is inside the view
+        // and still propagates when the state declines to consume it.
+        //
+        // Bound ONCE, here, and never removed: a listener on the element itself
+        // survives detaching and is collected with the element, so there is
+        // nothing to leak — while re-adding it per connect would stack a second
+        // handler on every move. Only the two bindings that reach OUTSIDE the
+        // element (the observer below and the breakpoint's media query) need a
+        // teardown, and they are re-established on every connect.
+        this.addEventListener('keydown', this._onKeyDown);
+        this._bindSwipe();
+    }
+
+    /**
+     * Everything that must be re-established every time the element enters a
+     * document — NOT once per lifetime.
+     *
+     * `connectedCallback` returns early on the second connect (the DOM is
+     * already built), so anything torn down in `disconnectedCallback` used to be
+     * gone for good: moving the view between parents — which is what a slideshow
+     * or a client-side route change does — killed the ResizeObserver and left
+     * `_measuredWidth` frozen at whatever it last saw, or at 0 if the view had
+     * never been visible. That is the other half of the docs-site regression.
+     */
+    private _bindToDocument() {
         // The view's own box is the size source, the same one the breakpoints
         // use: the sidebar width is a FRACTION of it and has to be recomputed
         // when it changes, which a one-shot read at connect could not do.
+        this._resizeObserver?.disconnect();
         this._resizeObserver = new ResizeObserver((entries) => {
             const entry = entries[entries.length - 1];
             if (!entry) return;
@@ -234,18 +273,12 @@ export class AdwOverlaySplitView extends HTMLElement {
             this._syncClasses();
         });
         this._resizeObserver.observe(this);
-
-        // `escape_shortcut_cb` (adw-overlay-split-view.c:705-716) — absent from
-        // BOTH ports, which made `OverlaySplitViewState.escape()` dead code.
-        // Bound on the element, so it only fires while focus is inside the view
-        // and still propagates when the state declines to consume it.
-        this.addEventListener('keydown', this._onKeyDown);
-        this._bindSwipe();
-
-        this._reflectShowSidebar();
-        this._syncClasses();
-        this._syncSidebarWidth();
-        this._syncBreakpoint();
+        // Seed synchronously so the FIRST paint after a connect is already
+        // placed. The observer's initial callback is a frame away, and on a
+        // re-connect there may be no size change at all for it to report.
+        // Zero is the honest answer while the view is in a `display: none`
+        // subtree, and `_syncGeometry` knows what to do with it.
+        this._measuredWidth = this.offsetWidth;
     }
 
     disconnectedCallback() {
@@ -253,7 +286,6 @@ export class AdwOverlaySplitView extends HTMLElement {
         this._disposeBreakpoint = undefined;
         this._resizeObserver?.disconnect();
         this._resizeObserver = undefined;
-        this.removeEventListener('keydown', this._onKeyDown);
     }
 
     /** `escape_shortcut_cb` — only a COLLAPSED view with a revealed sidebar consumes it. */
@@ -432,7 +464,31 @@ export class AdwOverlaySplitView extends HTMLElement {
      */
     private _syncGeometry() {
         const sidebar = this._sidebarEl;
-        if (!sidebar || this._measuredWidth <= 0) return;
+        if (!sidebar) return;
+        // NOTHING MEASURED YET — HAND THE PLACEMENT BACK TO THE STYLESHEET.
+        //
+        // This used to `return` and leave the inline styles alone, which is the
+        // one thing it must not do. The stylesheet no longer carries a
+        // `transform: translateX(±100%)` for the hidden end state (that is the
+        // point of driving the offset per frame), so an absolutely-positioned
+        // pane with no `left` resolves to `left: 0` at full opacity: a HIDDEN
+        // sidebar painted over the content at the wrong edge. Shipped that way
+        // in v0.32.0's `feat(adwaita)` commit and visible on the docs site,
+        // whose slideshow builds each slide hidden and moves it in — so the
+        // first measurement never arrived and the fallback was all there was.
+        //
+        // Clearing rather than skipping matters just as much: a STALE inline
+        // `left` from an earlier measurement outranks the resting rule (an
+        // absolutely-positioned box with `left` + `width` ignores `right`), so
+        // leaving the old value behind would defeat the stylesheet exactly when
+        // it is needed. `_resting.scss` carries the four end states.
+        if (this._measuredWidth <= 0) {
+            for (const prop of ['left', 'marginLeft', 'marginRight', 'width', 'minWidth', 'maxWidth', 'opacity', 'pointerEvents'] as const) {
+                sidebar.style[prop] = '';
+            }
+            if (this._backdropEl) this._backdropEl.style.opacity = '';
+            return;
+        }
         const state = this._state;
         const measured = this._sidebarWidth;
         const layout = layoutOverlaySplitView({

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -483,7 +483,16 @@ export class AdwOverlaySplitView extends HTMLElement {
         // leaving the old value behind would defeat the stylesheet exactly when
         // it is needed. `_resting.scss` carries the four end states.
         if (this._measuredWidth <= 0) {
-            for (const prop of ['left', 'marginLeft', 'marginRight', 'width', 'minWidth', 'maxWidth', 'opacity', 'pointerEvents'] as const) {
+            for (const prop of [
+                'left',
+                'marginLeft',
+                'marginRight',
+                'width',
+                'minWidth',
+                'maxWidth',
+                'opacity',
+                'pointerEvents',
+            ] as const) {
                 sidebar.style[prop] = '';
             }
             if (this._backdropEl) this._backdropEl.style.opacity = '';

--- a/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
+++ b/packages/web/adwaita-web/src/elements/adw-view-switcher.ts
@@ -185,7 +185,15 @@ export class AdwViewSwitcher extends HTMLElement {
     }
 
     connectedCallback() {
-        if (this._initialized) return;
+        if (this._initialized) {
+            // Re-entering a document. `disconnectedCallback` drops the page
+            // observer on the way out, and this early return used to skip
+            // rebuilding it — so a switcher that had merely been MOVED (a
+            // slideshow slide, a client-side route change) stopped noticing
+            // page attribute changes for good, and did it silently.
+            this._watchPages();
+            return;
+        }
 
         // `:scope >` rather than a subtree scan: an unscoped query let an outer
         // switcher adopt the pages of a nested one, since both use the same tag.

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -802,4 +802,92 @@ export const AdwSplitViewsTest = async () => {
             end.host.remove();
         });
     });
+
+    // A VIEW THAT WAS NEVER MEASURED, AND A VIEW THAT WAS MOVED.
+    //
+    // Both shipped broken in v0.32.0 and were visible on the docs site: its
+    // slideshow builds each slide inside `display: none` and moves it in, so the
+    // controls pane had no measurement when it first rendered and no live
+    // observer afterwards. A hidden sidebar was painted over the content at the
+    // wrong edge — the state was right the whole time, only the geometry never
+    // reached the DOM.
+    //
+    // These are placement assertions on purpose. Every other test here reads the
+    // state or a class, and every one of them PASSED while the widget was
+    // visibly wrong: nothing in the suite looked at where the pane actually
+    // ended up. That is the gap, not the individual bug.
+    await describe('AdwOverlaySplitView — geometry survives being unmeasured and moved', async () => {
+        /** Does the pane cover the view's own box? */
+        const covers = (view: AdwOverlaySplitView): boolean => {
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            const a = view.getBoundingClientRect();
+            const b = pane.getBoundingClientRect();
+            return b.width > 0 && b.right > a.left + 1 && b.left < a.right - 1;
+        };
+
+        await it('keeps a hidden sidebar off-screen when it is first laid out inside display:none', async () => {
+            const slide = document.createElement('div');
+            slide.style.display = 'none';
+            document.body.appendChild(slide);
+            slide.innerHTML =
+                '<div style="width:900px;height:300px;display:flex">' +
+                '<adw-overlay-split-view collapsed show-sidebar="false" sidebar-position="end">' +
+                '<div slot="content">c</div><div slot="sidebar">s</div>' +
+                '</adw-overlay-split-view></div>';
+            const view = slide.querySelector('adw-overlay-split-view') as AdwOverlaySplitView;
+            await settle();
+
+            // The slide becomes the visible one.
+            slide.style.display = '';
+            await settle();
+            expect(view.showSidebar).toBe(false);
+            expect(covers(view)).toBe(false);
+            slide.remove();
+        });
+
+        await it('re-measures after being moved to another parent', async () => {
+            const from = document.createElement('div');
+            from.style.display = 'none';
+            const to = document.createElement('div');
+            to.setAttribute('style', 'width:900px;height:300px;display:flex');
+            document.body.append(from, to);
+            from.innerHTML =
+                '<adw-overlay-split-view collapsed show-sidebar="false" sidebar-position="end">' +
+                '<div slot="content">c</div><div slot="sidebar">s</div>' +
+                '</adw-overlay-split-view>';
+            const view = from.querySelector('adw-overlay-split-view') as AdwOverlaySplitView;
+            await settle();
+
+            // Moving a node is a disconnect followed by a connect. The observer
+            // torn down by the first has to be rebuilt by the second.
+            to.appendChild(view);
+            await settle();
+            expect(covers(view)).toBe(false);
+
+            // And it must keep tracking: a resize after the move has to land.
+            to.style.width = '600px';
+            await settle();
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(pane.style.left).toBe('600px');
+            from.remove();
+            to.remove();
+        });
+
+        await it('hands placement back to the stylesheet rather than stranding a stale offset', async () => {
+            const { view, host } = mount('collapsed show-sidebar="false" sidebar-position="end"');
+            host.setAttribute('style', 'width:900px;height:300px;display:flex');
+            await settle();
+            const pane = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            expect(pane.style.left).toBe('900px');
+
+            // Unmeasurable again: the inline offset must be CLEARED, because an
+            // absolutely-positioned box with `left` + `width` ignores `right`,
+            // so a leftover value would outrank the resting rule it falls back
+            // to and pin the pane wherever it last happened to be.
+            host.style.display = 'none';
+            await settle();
+            expect(pane.style.left).toBe('');
+            host.remove();
+        });
+    });
 };

--- a/packages/web/adwaita-web/src/view-switcher.spec.ts
+++ b/packages/web/adwaita-web/src/view-switcher.spec.ts
@@ -626,4 +626,40 @@ export const AdwViewSwitcherTest = async () => {
             host.remove();
         });
     });
+
+    // MOVING A SWITCHER MUST NOT MAKE IT DEAF.
+    //
+    // `disconnectedCallback` drops the page observer, and `connectedCallback`
+    // returned early once the element was built — so a switcher that had merely
+    // been moved between parents (a slideshow slide, a client-side route change)
+    // stopped tracking its pages permanently, and silently. Same shape as the
+    // overlay split view's ResizeObserver, and found with it.
+    await describe('adw-view-switcher — a moved switcher keeps watching its pages', async () => {
+        await it('still notices a page attribute change after being re-parented', async () => {
+            const from = document.createElement('div');
+            const to = document.createElement('div');
+            document.body.append(from, to);
+
+            const element = document.createElement('adw-view-switcher') as AdwViewSwitcher;
+            const page = declarePage('adw-view-switcher-page', {
+                name: 'one',
+                title: 'One',
+                iconName: 'go-next-symbolic',
+                visible: true,
+            } as ViewSwitcherVectorPage);
+            element.appendChild(page);
+            from.appendChild(element);
+
+            // Appending elsewhere is a disconnect followed by a connect.
+            to.appendChild(element);
+            page.setAttribute('title', 'Renamed');
+            // The observer delivers on a microtask; GTK's notify is synchronous.
+            await Promise.resolve();
+
+            const label = element.querySelector('.adw-view-switcher-label') as HTMLElement;
+            expect(label.textContent).toBe('Renamed');
+            from.remove();
+            to.remove();
+        });
+    });
 };

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -87,19 +87,6 @@ const hasPreview = Astro.slots.has('preview');
 <div class="adw-widget">
     {
         hasPreview && (
-            {/* `not-content` for the same reason CommandTabs.astro states it,
-                and it was missing HERE while the tabs below already carried it.
-                Starlight gives every content element that FOLLOWS a sibling a
-                `margin-top: 1rem` and exempts only `:where(.not-content *)`.
-                Inside a preview that lands on the widgets themselves: measured
-                on the deployed page, the second button of a wrap box and every
-                one after it took `margin-top: 16px` while the first took none —
-                and in a flex line the first then STRETCHED by exactly that much,
-                50px tall against its siblings' 34px. The same rule pushed a
-                header bar's trailing button below its own title and set the two
-                panes of a split view onto different baselines.
-                A preview is a rendering of a widget, not prose: it has to be
-                laid out by the widget's own stylesheet alone. */}
             <div
                 class:list={[
                     'adw-widget-preview',
@@ -108,6 +95,20 @@ const hasPreview = Astro.slots.has('preview');
                     { 'is-scroll': scroll },
                 ]}
             >
+                {/* `not-content` for the same reason CommandTabs.astro states it,
+                    and it was missing HERE while the tabs below already carried
+                    it. Starlight gives every content element that FOLLOWS a
+                    sibling a `margin-top: 1rem`, exempting only
+                    `:where(.not-content *)`. Inside a preview that lands on the
+                    widgets: measured on the deployed page, the second button of
+                    a wrap box and every one after it took `margin-top: 16px`
+                    while the first took none — and in a flex line the first then
+                    STRETCHED by exactly that much, 50px against its siblings'
+                    34px. The same rule pushed a header bar's trailing button
+                    below its own title and set the two panes of a split view
+                    onto baselines 16px apart, which clipped the sidebar's last
+                    row. A preview is a rendering of a widget, not prose: it has
+                    to be laid out by the widget's own stylesheet alone. */}
                 {/* The preview is cloned into the stage at runtime (see <script>),
                     not server-rendered directly, for two reasons:
                     1. adwaita-web custom elements upgrade as the page is parsed;

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -87,9 +87,23 @@ const hasPreview = Astro.slots.has('preview');
 <div class="adw-widget">
     {
         hasPreview && (
+            {/* `not-content` for the same reason CommandTabs.astro states it,
+                and it was missing HERE while the tabs below already carried it.
+                Starlight gives every content element that FOLLOWS a sibling a
+                `margin-top: 1rem` and exempts only `:where(.not-content *)`.
+                Inside a preview that lands on the widgets themselves: measured
+                on the deployed page, the second button of a wrap box and every
+                one after it took `margin-top: 16px` while the first took none —
+                and in a flex line the first then STRETCHED by exactly that much,
+                50px tall against its siblings' 34px. The same rule pushed a
+                header bar's trailing button below its own title and set the two
+                panes of a split view onto different baselines.
+                A preview is a rendering of a widget, not prose: it has to be
+                laid out by the widget's own stylesheet alone. */}
             <div
                 class:list={[
                     'adw-widget-preview',
+                    'not-content',
                     `is-${padding}`,
                     { 'is-scroll': scroll },
                 ]}


### PR DESCRIPTION
Reported against the deployed docs: several Adwaita widget examples render wrong. Five of the six reports turned out to be **one rule**.

## The rule

Starlight gives every content element that FOLLOWS a sibling a `margin-top: 1rem`, exempting only `:where(.not-content *)`. The preview wrapper never opted out — while the code tabs directly below it already did, with a comment in `CommandTabs.astro` stating exactly why.

So the rule applied to the widgets. Measured on the deployed page:

| | height | margin-top |
|---|---|---|
| first pill | **50px** | 0px |
| every other pill | 34px | **16px** |

Both halves are visible damage, and the second one is the counter-intuitive part: the siblings get pushed down 16px, and in a flex line the first item then **stretches** by exactly that much. A row of eight identical `<adw-button pill>` renders with the first one bigger — which is what the report described.

## What that one rule accounted for

- a wrap box whose **first pill is larger** than the other seven
- a button row whose **first button sits higher** than the rest
- a header bar whose **trailing button sits below its own title**
- a split view whose two panes are on baselines **16px apart**, which pushed the sidebar's fourth row out of the frame and clipped both header bars
- the same clipping on the gallery index cards

## Verified

By adding the class on the live page and re-measuring, before the change was written:

```
pills   BEFORE  Design h=50 m=0px | Adwaita h=34 m=16px | GNOME h=34 m=16px | GTK h=34 m=16px
        AFTER   all four h=34, margin-top 0px

split   BEFORE  header bar tops 1059 / 1075     (16px apart)
        AFTER   header bar tops 1043 / 1043     (aligned, all four rows inside the frame)
```

The same markup rendered outside the docs was correct all along — buttons at identical tops and heights, header-bar parts sharing one centre line — which is what pointed at the environment rather than at the widgets.

## Not in this PR

The About Dialog preview renders empty. That one is **not** this rule and not the environment: the same markup collapses to zero height standalone too. Its sheet is `position: fixed` with no definite height, and every element under it is `flex: 1 1 auto; min-height: 0`, so the chain resolves circularly to 0 while the header bar inside genuinely measures 47px. That is a widget bug in `@gjsify/adwaita-web` and gets its own fix.