### PR TITLE
fix(adwaita-web): let a navigation view report a content height

### DIFF
--- a/packages/web/adwaita-web/scss/_navigation_view.scss
+++ b/packages/web/adwaita-web/scss/_navigation_view.scss
@@ -16,9 +16,13 @@ adw-navigation-view {
   background-color: var(--window-bg-color);
   color: var(--window-fg-color);
 
-  // The page stack — fills the view; positioned so pages can stack.
+  // The page stack — fills the view when it is given a height, and MEASURES the
+  // visible page when it is not. A flex column rather than a positioning
+  // context: the page is an in-flow item, so its content reaches the view.
   .adw-navigation-view-pages {
     flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
     position: relative;
     box-sizing: border-box;
     min-height: 0;
@@ -26,11 +30,31 @@ adw-navigation-view {
   }
 
   // A single navigation page — the visible one fills the view, the rest are
-  // hidden. Positioned absolutely so a transition can overlap two pages.
+  // `display: none`.
+  //
+  // IN FLOW, not absolute. It was `position: absolute; inset: 0` under a comment
+  // saying it had to be "so a transition can overlap two pages" — but two pages
+  // never overlap here: `adw-navigation-view.ts` marks every page but the
+  // visible one `[hidden]`, which is `display: none` below, and the push
+  // animation runs on `.visible-page` alone. So the absolute positioning bought
+  // an overlap that does not happen, and what it cost was the HEIGHT: an
+  // absolutely-positioned child contributes nothing to its parent, so the page
+  // stack measured 0, the view above it measured 0, and the page — `inset: 0` of
+  // a zero-height parent — measured 0 in turn. A closed circle.
+  //
+  // Inside a window that never showed, because a definite height arrived from
+  // outside. `<adw-about-dialog>` is the case where none does: its sheet is
+  // `position: fixed` with a width and no height, exactly as
+  // `adw-about-dialog.ui` declares it (`content-width` 360, no content-height —
+  // libadwaita takes the height from the content). The whole dialog rendered
+  // invisible, with a header bar inside it genuinely measuring 47px.
+  //
+  // `flex: 1 1 auto` keeps the fill: given a height the page still grows into
+  // it; without one it reports its content.
   .adw-navigation-page {
     box-sizing: border-box;
-    position: absolute;
-    inset: 0;
+    position: relative;
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     overflow: auto;

--- a/packages/web/adwaita-web/src/adw-about-dialog.spec.ts
+++ b/packages/web/adwaita-web/src/adw-about-dialog.spec.ts
@@ -347,4 +347,40 @@ export const AdwAboutDialogTest = async () => {
             mounted.dispose();
         });
     });
+
+    // AN OPENED DIALOG HAS TO OCCUPY SPACE.
+    //
+    // Every other test in this file reads the built DOM, and all of them passed
+    // while the dialog rendered INVISIBLE — its sheet measured 360×0. The suite
+    // could not see that, because none of it looks at geometry.
+    //
+    // The sheet is `position: fixed` with a width and no height, which is what
+    // `adw-about-dialog.ui:7` declares: `content-width` 360 and no
+    // content-height, libadwaita taking the height from the content. The content
+    // could not supply one — the navigation pages were absolutely positioned, so
+    // they contributed nothing to the page stack, which contributed nothing to
+    // the view, which left the sheet at zero; and the pages, being `inset: 0` of
+    // a zero-height parent, were zero in turn.
+    await describe('adw-about-dialog — an opened dialog is actually on screen', async () => {
+        await it('gives its sheet a height derived from its content', () => {
+            const mounted = mount({ 'application-name': 'Adwaita Storybook', version: '0.11.0' });
+            mounted.dialog.setAttribute('open', '');
+
+            const sheet = mounted.dialog.querySelector('.adw-about-dialog-sheet') as HTMLElement;
+            const rect = sheet.getBoundingClientRect();
+            // HEIGHT only. The width was never the defect, and pinning it here
+            // needs `calc(100vw - 48px)` restated in JS — where `100vw` and
+            // `innerWidth` disagree by the scrollbar (360 against a measured
+            // 342), so the assertion would report the harness rather than the
+            // widget. A test should assert the rule the bug broke.
+            expect(rect.height > 0).toBe(true);
+            // And not merely the header: the sheet has to be taller than the one
+            // child that had a size of its own all along, which is what made the
+            // collapse invisible to every other test in this file.
+            const header = sheet.querySelector('adw-header-bar') as HTMLElement;
+            expect(rect.height > header.getBoundingClientRect().height).toBe(true);
+
+            mounted.dispose();
+        });
+    });
 };


### PR DESCRIPTION
Closes #1083.

`<adw-about-dialog open>` rendered **nothing**. The element upgraded, took `open`, built its whole DOM — and its sheet measured **360×0**.

## The circle

The sheet is `position: fixed` with a width and no height, which is exactly what `adw-about-dialog.ui:7` declares: `content-width` 360 and **no** content-height, libadwaita taking the height from the content. The content could not supply one:

```
.adw-about-dialog-sheet             h=0
  adw-navigation-view               h=0
    .adw-navigation-view-pages      h=0
      .adw-navigation-page          h=0   position: absolute; inset: 0
        .adw-about-dialog-toolbar-view  h=0
          adw-header-bar            h=47  ← the only thing with a real height
```

An absolutely-positioned child contributes nothing to its parent, so the page stack was 0, the view above it was 0, the sheet above that was 0 — and the pages, being `inset: 0` of a zero-height parent, were 0 in turn. Inside a window it never showed, because a definite height arrives from outside.

## The comment did not match the code

```scss
// Positioned absolutely so a transition can overlap two pages.
.adw-navigation-page { position: absolute; inset: 0; }
```

Two pages never overlap. `adw-navigation-view.ts` marks every page but the visible one `[hidden]`, which is `display: none`, and the push animation runs on `.visible-page` alone. The absolute positioning was paying for an overlap that does not happen, and the height is what it cost. That is why this is a fix and not a trade-off: nothing is given up.

## The change

The page stack becomes a flex column and the page goes back in flow as `position: relative; flex: 1 1 auto`. Given a height the page still fills it; without one it reports its content. The dialog now measures 360×299 — the declared width, and a height that came from what is inside it.

## Verification

- `@gjsify/adwaita-web` green in **both** Firefox (what CI runs) and Chromium; `format --no-write` and `lint` clean repo-wide
- the new test was verified to **fail** against the unfixed stylesheet before being kept
- the dialog rendered and screenshotted: app name, developer, version pill, Details and Legal rows, all present

The test asserts **height**, deliberately. The width was never the defect, and restating `max-width: calc(100vw - 48px)` in JS makes the assertion report the harness rather than the widget — `100vw` and `innerWidth` disagree by the scrollbar, 360 against a measured 342. Two runs were spent learning that; the note is in the test so the next person does not repeat it.

Not a regression: the dialog shipped this way in v0.32.0. Same class as #1079 — the suite was fully green while the widget was invisible, because nothing asserted rendered geometry.