### PR TITLE
feat(website): show each widget's Blueprint declaration

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,14 @@
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+
+// Read rather than `import … with { type: 'json' }`: the assertion syntax is
+// still version-sensitive across the Node versions this config runs under, and
+// a config that fails to parse takes the whole site with it.
+const blueprintGrammar = JSON.parse(
+    readFileSync(new URL('./src/grammars/blueprint.tmLanguage.json', import.meta.url), 'utf8'),
+);
 
 export default defineConfig({
     site: 'https://gjsify.github.io',
@@ -54,6 +62,15 @@ export default defineConfig({
         starlight({
             title: 'GJSify',
             description: 'The TypeScript framework for native Linux apps — on GJS, Node.js, Deno and Bun',
+            // Blueprint is what GTK UIs are actually WRITTEN in, so the widget
+            // gallery carries a `.blp` tab beside GJS/Web/NativeScript. Shiki
+            // bundles no grammar for it and falls back to plain text with a
+            // build warning — an unhighlighted tab between three highlighted
+            // ones reads as broken rather than deliberate. The grammar is
+            // deliberately minimal; its own header says what it does not cover.
+            expressiveCode: {
+                shiki: { langs: [blueprintGrammar] },
+            },
             head: [
                 {
                     // The @gjsify/adwaita-web skin keys its dark palette on

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -70,6 +70,14 @@ const refHref = docHref === false ? null : (docHref ?? deriveRef(title));
 // additional. Render only the slots that were actually provided.
 const IMPLS = [
     { slot: 'gjs', label: 'GJS' },
+    // Blueprint sits next to GJS because it describes the SAME native widget
+    // tree — it is how a GTK UI is usually written, with the GJS side reduced to
+    // wiring. Web and NativeScript are the ports and follow.
+    //
+    // The tab holds the DECLARATION only, deliberately: a `.blp` file is a
+    // widget tree and nothing else, and padding it with a loader would make it
+    // look like a fourth complete program rather than the thing it is.
+    { slot: 'blueprint', label: 'Blueprint' },
     { slot: 'web', label: 'Web' },
     { slot: 'nativescript', label: 'NativeScript' },
 ];

--- a/website/src/content/docs/widgets/boxed-lists.mdx
+++ b/website/src/content/docs/widgets/boxed-lists.mdx
@@ -58,6 +58,43 @@ build a full preferences page.
     group.add(new Adw.SwitchRow({ title: 'Sync over Wi-Fi only', active: true }));
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      title: _("Account");
+      description: _("Manage how this device signs in and syncs.");
+
+      header-suffix: Gtk.Button {
+        label: _("Sign out");
+
+        styles ["flat"]
+      };
+
+      Adw.EntryRow {
+        title: _("Display name");
+        text: "Grace Hopper";
+      }
+
+      Adw.SwitchRow {
+        title: _("Sync over Wi-Fi only");
+        subtitle: _("Avoid using mobile data for backups");
+        active: true;
+      }
+
+      Adw.ComboRow {
+        title: _("Region");
+        selected: 0;
+
+        model: Gtk.StringList {
+          strings [_("Europe"), _("Americas"), _("Asia"), _("Oceania")]
+        };
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -128,6 +165,30 @@ respond to a click — typically to open a detail page.
     row.activatable = true;
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.ActionRow {
+        title: _("Wi-Fi");
+        subtitle: _("Connected to Highgarden 5GHz");
+        activatable: true;
+
+        [prefix]
+        Gtk.Image {
+          icon-name: "network-wireless-symbolic";
+        }
+
+        [suffix]
+        Gtk.Image {
+          icon-name: "go-next-symbolic";
+        }
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-action-row title="Wi-Fi" subtitle="Connected to Highgarden 5GHz" activatable>
@@ -177,6 +238,20 @@ the boxed-list equivalent of a labelled on/off control.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.SwitchRow {
+        title: _("Automatic updates");
+        subtitle: _("Download and install updates without asking");
+        active: true;
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-switch-row
@@ -221,6 +296,19 @@ show an **apply button** that commits the change.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.EntryRow {
+        title: _("Display name");
+        text: "Ada Lovelace";
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-entry-row title="Display name" text="Ada Lovelace"></adw-entry-row>
@@ -256,6 +344,19 @@ them. Use it wherever a secret is edited inline in a boxed list.
         title: 'Password',
         text: 'correct-horse-battery',
     });
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.PasswordEntryRow {
+        title: _("Password");
+        text: "correct-horse-battery";
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -303,6 +404,24 @@ selection is stored as an index into the model.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.ComboRow {
+        title: _("Accent colour");
+        subtitle: _("Used to highlight selected items");
+        selected: 1;
+
+        model: Gtk.StringList {
+          strings [_("Blue"), _("Teal"), _("Green"), _("Orange"), _("Purple")]
+        };
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-combo-row
@@ -347,6 +466,25 @@ and optional decimal digits, for settings like a font size or a count.
         adjustment: new Gtk.Adjustment({ lower: 0, upper: 100, value: 16, stepIncrement: 1 }),
         digits: 0,
     });
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.SpinRow {
+        title: _("Font size");
+
+        adjustment: Gtk.Adjustment {
+          lower: 0;
+          upper: 100;
+          value: 16;
+          step-increment: 1;
+        };
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -397,6 +535,29 @@ the whole section.
     row.add_row(new Adw.SwitchRow({ title: 'Use authentication', active: false }));
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.ExpanderRow {
+        title: _("Proxy settings");
+        subtitle: _("Route traffic through a custom proxy");
+        expanded: true;
+
+        Adw.EntryRow {
+          title: _("Host");
+          text: "proxy.example.com";
+        }
+
+        Adw.SwitchRow {
+          title: _("Use authentication");
+        }
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-expander-row title="Proxy settings" subtitle="Route traffic through a custom proxy" expanded>
@@ -443,6 +604,21 @@ style class (`.suggested-action`, `.destructive-action`).
         startIconName: 'list-add-symbolic',
     });
     row.add_css_class('suggested-action');
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesGroup {
+      Adw.ButtonRow {
+        title: _("Add account");
+        start-icon-name: "list-add-symbolic";
+
+        styles ["suggested-action"]
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/content/docs/widgets/buttons.mdx
+++ b/website/src/content/docs/widgets/buttons.mdx
@@ -55,6 +55,21 @@ to give a button an icon _and_ text, and can optionally ellipsize its label
     button.add_css_class('pill');
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Gtk.Button {
+      child: Adw.ButtonContent {
+        label: _("Download");
+        icon-name: "folder-download-symbolic";
+      };
+
+      styles ["suggested-action", "pill"]
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -126,6 +141,48 @@ with any button and carry the same meaning across the toolkit.
     const flat = new Gtk.Button({ label: 'Flat' });
     flat.add_css_class('flat');
     box.append(flat);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.WrapBox {
+      child-spacing: 12;
+      line-spacing: 12;
+      halign: center;
+
+      Gtk.Button {
+        label: _("Pill");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        icon-name: "list-add-symbolic";
+
+        styles ["circular"]
+      }
+
+      Gtk.Button {
+        label: _("Suggested");
+
+        styles ["suggested-action"]
+      }
+
+      Gtk.Button {
+        label: _("Delete");
+
+        styles ["destructive-action"]
+      }
+
+      Gtk.Button {
+        label: _("Flat");
+
+        styles ["flat"]
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -201,6 +258,38 @@ too heavy.
     // button.add_css_class('flat'); // the header-bar / toolbar variant
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.SplitButton {
+      label: _("Save");
+      icon-name: "document-save-symbolic";
+
+      menu-model: menu save-menu;
+    }
+
+    menu save-menu {
+      section {
+        item {
+          label: _("Save as…");
+          action: "app.save-as";
+        }
+
+        item {
+          label: _("Export");
+          action: "app.export";
+        }
+
+        item {
+          label: _("Print");
+          action: "app.print";
+        }
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-split-button
@@ -248,6 +337,31 @@ pill-shaped appearance.
     group.add(new Adw.Toggle({ label: 'Grid', iconName: 'view-grid-symbolic' }));
     group.add(new Adw.Toggle({ label: 'Columns', iconName: 'view-columns-symbolic' }));
     group.active = 0;
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.ToggleGroup {
+      active: 0;
+
+      Adw.Toggle {
+        label: _("List");
+        icon-name: "view-list-symbolic";
+      }
+
+      Adw.Toggle {
+        label: _("Grid");
+        icon-name: "view-grid-symbolic";
+      }
+
+      Adw.Toggle {
+        label: _("Columns");
+        icon-name: "view-columns-symbolic";
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/content/docs/widgets/feedback.mdx
+++ b/website/src/content/docs/widgets/feedback.mdx
@@ -73,6 +73,21 @@ layer, which the Web and NativeScript renderers compose.
     overlay.add_toast(toast);
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    // A toast is CONSTRUCTED, not declared — `Adw.ToastOverlay` is the part a
+    // blueprint carries, and `overlay.add_toast(...)` presents one at runtime.
+    Adw.ToastOverlay overlay {
+      child: Adw.StatusPage {
+        title: _("Documents");
+        description: _("Drag files here to organise them.");
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -145,6 +160,25 @@ keys.
     dialog.set_close_response('cancel');
 
     dialog.present(parent);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.AlertDialog {
+      heading: _("Delete Project?");
+      body: _("This will permanently remove the project and all of its files. This action cannot be undone.");
+
+      responses [
+        cancel: _("Cancel"),
+        delete: _("Delete") destructive,
+      ]
+
+      default-response: "cancel";
+      close-response: "cancel";
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -223,6 +257,23 @@ metadata. It is the conventional destination of a primary-menu _About_ entry.
     });
 
     dialog.present(parent);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.AboutDialog {
+      application-name: _("Adwaita Storybook");
+      developer-name: _("A GJSify Project");
+      version: "0.11.0";
+      comments: _("A live catalogue of native GTK and Adwaita widgets, rendered under GJS.");
+      website: "https://github.com/gjsify/gjsify";
+      issue-url: "https://github.com/gjsify/gjsify/issues";
+      license-type: mit_x11;
+      copyright: "© 2026 The GJSify Project";
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -313,6 +364,52 @@ common single-page case is shown here.
     page.add(group);
     dialog.add(page);
     dialog.present(parent);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.PreferencesDialog {
+      title: _("Preferences");
+
+      Adw.PreferencesPage {
+        title: _("General");
+        icon-name: "preferences-system-symbolic";
+
+        Adw.PreferencesGroup {
+          title: _("Appearance");
+          description: _("Control how the application looks and behaves.");
+
+          Adw.SwitchRow {
+            title: _("Dark style");
+            subtitle: _("Use a dark colour scheme");
+            active: true;
+          }
+
+          Adw.ComboRow {
+            title: _("Accent colour");
+            selected: 0;
+
+            model: Gtk.StringList {
+              strings [_("Blue"), _("Teal"), _("Green"), _("Orange"), _("Purple")]
+            };
+          }
+
+          Adw.SpinRow {
+            title: _("Font size");
+
+            adjustment: Gtk.Adjustment {
+              lower: 8;
+              upper: 24;
+              value: 12;
+              step-increment: 1;
+            };
+          }
+        }
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/content/docs/widgets/layout.mdx
+++ b/website/src/content/docs/widgets/layout.mdx
@@ -66,6 +66,23 @@ without wasting space on small ones.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.Clamp {
+      maximum-size: 400;
+
+      child: Gtk.Label {
+        label: _("This content is clamped — it stops growing past the maximum size and stays centred.");
+        wrap: true;
+
+        styles ["card"]
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -127,6 +144,33 @@ navigation, menu and action buttons.
     const menuButton = new Gtk.MenuButton({ iconName: 'open-menu-symbolic', menuModel: menu });
     menuButton.add_css_class('flat');
     headerBar.pack_end(menuButton);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.HeaderBar {
+      title-widget: Adw.WindowTitle {
+        title: _("Text Editor");
+        subtitle: "notes.md";
+      };
+
+      [start]
+      Gtk.Button {
+        icon-name: "go-previous-symbolic";
+
+        styles ["flat"]
+      }
+
+      [end]
+      Gtk.MenuButton {
+        icon-name: "open-menu-symbolic";
+
+        styles ["flat"]
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -222,6 +266,59 @@ place.
     bottomBar.pack_end(shareButton);
 
     view.add_bottom_bar(bottomBar);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.ToolbarView {
+      [top]
+      Adw.HeaderBar {
+        title-widget: Adw.WindowTitle {
+          title: _("Documents");
+          subtitle: _("12 items");
+        };
+      }
+
+      content: Adw.StatusPage {
+        icon-name: "folder-symbolic";
+        title: _("Your library");
+        description: _("Content sits between the toolbars and scrolls independently of them.");
+      };
+
+      [bottom]
+      Gtk.ActionBar {
+        [start]
+        Gtk.Button {
+          icon-name: "list-add-symbolic";
+          tooltip-text: _("Add");
+
+          styles ["flat"]
+        }
+
+        [start]
+        Gtk.Button {
+          icon-name: "list-remove-symbolic";
+          tooltip-text: _("Remove");
+
+          styles ["flat"]
+        }
+
+        center-widget: Gtk.Label {
+          label: _("Selection: none");
+        };
+
+        [end]
+        Gtk.Button {
+          icon-name: "send-to-symbolic";
+          tooltip-text: _("Share");
+
+          styles ["flat"]
+        }
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -326,6 +423,65 @@ sets the gap between the lines.
         const chip = new Gtk.Button({ label: tag });
         chip.add_css_class('pill');
         wrap.append(chip);
+    }
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.WrapBox {
+      child-spacing: 8;
+      line-spacing: 8;
+
+      Gtk.Button {
+        label: _("Design");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("Adwaita");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("GNOME");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("GTK");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("Typescript");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("Storybook");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("Wrapping");
+
+        styles ["pill"]
+      }
+
+      Gtk.Button {
+        label: _("Layout");
+
+        styles ["pill"]
+      }
     }
     ```
   </Fragment>

--- a/website/src/content/docs/widgets/navigation.mdx
+++ b/website/src/content/docs/widgets/navigation.mdx
@@ -101,6 +101,84 @@ page with its own header bar.
     const view = new Adw.NavigationSplitView({ sidebar, content, showContent: true });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.NavigationSplitView {
+      sidebar: Adw.NavigationPage {
+        title: _("Mailboxes");
+
+        child: Adw.ToolbarView {
+          [top]
+          Adw.HeaderBar {}
+
+          content: Adw.PreferencesGroup {
+            Adw.ActionRow {
+              title: _("All Mail");
+              subtitle: _("128 messages");
+              activatable: true;
+
+              [prefix]
+              Gtk.Image {
+                icon-name: "mail-unread-symbolic";
+              }
+            }
+
+            Adw.ActionRow {
+              title: _("Starred");
+              subtitle: _("6 messages");
+              activatable: true;
+
+              [prefix]
+              Gtk.Image {
+                icon-name: "starred-symbolic";
+              }
+            }
+
+            Adw.ActionRow {
+              title: _("Drafts");
+              subtitle: _("2 messages");
+              activatable: true;
+
+              [prefix]
+              Gtk.Image {
+                icon-name: "document-edit-symbolic";
+              }
+            }
+
+            Adw.ActionRow {
+              title: _("Archive");
+              subtitle: _("512 messages");
+              activatable: true;
+
+              [prefix]
+              Gtk.Image {
+                icon-name: "folder-symbolic";
+              }
+            }
+          };
+        };
+      };
+
+      content: Adw.NavigationPage {
+        title: _("All Mail");
+
+        child: Adw.ToolbarView {
+          [top]
+          Adw.HeaderBar {}
+
+          content: Adw.StatusPage {
+            icon-name: "mail-unread-symbolic";
+            title: _("All Mail");
+            description: _("Select a conversation from the list to read it here.");
+          };
+        };
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -252,6 +330,76 @@ push the primary content aside on a narrow window.
     const view = new Adw.OverlaySplitView({ sidebar, content, showSidebar: true, collapsed: false });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.OverlaySplitView {
+      show-sidebar: true;
+
+      sidebar: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {}
+
+        content: Adw.PreferencesGroup {
+          Adw.ActionRow {
+            title: _("Home");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "go-home-symbolic";
+            }
+          }
+
+          Adw.ActionRow {
+            title: _("Discover");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "system-search-symbolic";
+            }
+          }
+
+          Adw.ActionRow {
+            title: _("Library");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "folder-music-symbolic";
+            }
+          }
+
+          Adw.ActionRow {
+            title: _("Settings");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "emblem-system-symbolic";
+            }
+          }
+        };
+
+        styles ["sidebar"]
+      };
+
+      content: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {}
+
+        content: Adw.StatusPage {
+          icon-name: "folder-music-symbolic";
+          title: _("Your Library");
+          description: _("Toggle the sidebar to browse sections. Collapse it to overlay the content.");
+        };
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
@@ -389,6 +537,50 @@ is interactive, so click it to see the transition and back button.
     view.add(detail);
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.NavigationView {
+      Adw.NavigationPage {
+        tag: "root";
+        title: _("Contacts");
+
+        child: Adw.ToolbarView {
+          [top]
+          Adw.HeaderBar {}
+
+          content: Gtk.Button {
+            label: _("Open contact");
+            halign: center;
+            valign: center;
+            action-name: "navigation.push";
+            action-target: "'detail'";
+
+            styles ["pill", "suggested-action"]
+          };
+        };
+      }
+
+      Adw.NavigationPage {
+        tag: "detail";
+        title: _("Ada Lovelace");
+
+        child: Adw.ToolbarView {
+          [top]
+          Adw.HeaderBar {}
+
+          content: Adw.StatusPage {
+            icon-name: "avatar-default-symbolic";
+            title: _("Ada Lovelace");
+            description: _("Mathematician and writer, the first computer programmer.");
+          };
+        };
+      }
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
@@ -505,6 +697,45 @@ wide and narrow layouts.
     box.append(sidebar);
     box.append(new Gtk.Separator({ orientation: Gtk.Orientation.VERTICAL }));
     box.append(status);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.Sidebar {
+      mode: sidebar;
+      selected: 0;
+
+      Adw.SidebarSection {
+        title: _("Mailboxes");
+
+        Adw.SidebarItem {
+          title: _("Inbox");
+          subtitle: _("3 unread");
+          icon-name: "mail-unread-symbolic";
+        }
+
+        Adw.SidebarItem {
+          title: _("Starred");
+          subtitle: _("Favourites");
+          icon-name: "starred-symbolic";
+        }
+
+        Adw.SidebarItem {
+          title: _("Sent");
+          subtitle: _("Outgoing mail");
+          icon-name: "mail-send-symbolic";
+        }
+
+        Adw.SidebarItem {
+          title: _("Archive");
+          subtitle: _("Older mail");
+          icon-name: "folder-symbolic";
+        }
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -644,6 +875,74 @@ interactive in a real window.
     }
     box.append(group);
     sheet.sheet = box;
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.BottomSheet {
+      open: true;
+      modal: true;
+      can-close: true;
+
+      content: Gtk.Button {
+        label: _("Toggle sheet");
+        halign: center;
+        valign: center;
+
+        styles ["pill", "suggested-action"]
+      };
+
+      sheet: Gtk.Box {
+        orientation: vertical;
+        spacing: 12;
+        margin-start: 18;
+        margin-end: 18;
+        margin-top: 18;
+        margin-bottom: 24;
+
+        Gtk.Label {
+          label: _("Share track");
+          xalign: 0;
+
+          styles ["title-2"]
+        }
+
+        Adw.PreferencesGroup {
+          Adw.ActionRow {
+            title: _("Copy link");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "edit-copy-symbolic";
+            }
+          }
+
+          Adw.ActionRow {
+            title: _("Send to a friend");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "mail-send-symbolic";
+            }
+          }
+
+          Adw.ActionRow {
+            title: _("Add to playlist");
+            activatable: true;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "list-add-symbolic";
+            }
+          }
+        }
+      };
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/content/docs/widgets/presentation.mdx
+++ b/website/src/content/docs/widgets/presentation.mdx
@@ -48,6 +48,19 @@ glyph up to a full profile header.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.Avatar {
+      text: "Ada Lovelace";
+      size: 96;
+      show-initials: true;
+      icon-name: "avatar-default-symbolic";
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -94,6 +107,18 @@ hides itself so it only takes space when relevant.
     container.append(banner);
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.Banner {
+      title: _("Metered connection — updates paused");
+      button-label: _("Resume");
+      revealed: true;
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-banner title="Metered connection — updates paused" button-label="Resume" revealed></adw-banner>
@@ -133,6 +158,17 @@ and scales to any **size** from an inline glyph to a page-filling placeholder.
         halign: Gtk.Align.CENTER,
         valign: Gtk.Align.CENTER,
     });
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.Spinner {
+      width-request: 48;
+      height-request: 48;
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -184,6 +220,25 @@ first document.
     });
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.StatusPage {
+      icon-name: "folder-symbolic";
+      title: _("No Documents");
+      description: _("Documents you create or open will appear here.");
+
+      child: Gtk.Button {
+        label: _("New Document");
+        halign: center;
+
+        styles ["pill", "suggested-action"]
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <adw-status-page icon="folder" title="No Documents" description="Documents you create or open will appear here.">
@@ -226,6 +281,17 @@ single-line title stays vertically centered.
         title: 'Inbox',
         subtitle: '3 unread messages',
     });
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.WindowTitle {
+      title: _("Inbox");
+      subtitle: _("3 unread messages");
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/content/docs/widgets/view-switching.mdx
+++ b/website/src/content/docs/widgets/view-switching.mdx
@@ -83,6 +83,60 @@ breakpoint.
     box.append(stack);
     ```
   </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Adw.ToolbarView {
+      [top]
+      Adw.HeaderBar {
+        title-widget: Adw.ViewSwitcher {
+          policy: wide;
+          stack: stack;
+        };
+      }
+
+      content: Adw.ViewStack stack {
+        Adw.ViewStackPage {
+          name: "inbox";
+          title: _("Inbox");
+          icon-name: "mail-unread-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "mail-unread-symbolic";
+            title: _("Inbox");
+            description: _("You have three unread conversations.");
+          };
+        }
+
+        Adw.ViewStackPage {
+          name: "starred";
+          title: _("Starred");
+          icon-name: "starred-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "starred-symbolic";
+            title: _("Starred");
+            description: _("Messages you have marked as important.");
+          };
+        }
+
+        Adw.ViewStackPage {
+          name: "archive";
+          title: _("Archive");
+          icon-name: "folder-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "folder-symbolic";
+            title: _("Archive");
+            description: _("Older conversations kept for reference.");
+          };
+        }
+      };
+    }
+    ```
+  </Fragment>
   <Fragment slot="web">
     ```html
     <!-- import '@gjsify/adwaita-web' once to register the elements -->
@@ -169,6 +223,24 @@ when only a single page remains, so a one-tab document looks chrome-free.
     const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
     box.append(tabBar);
     box.append(tabView);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Gtk.Box {
+      orientation: vertical;
+
+      Adw.TabBar {
+        view: tabs;
+      }
+
+      Adw.TabView tabs {
+        vexpand: true;
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -262,6 +334,60 @@ wide.
     const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 12 });
     box.append(switcher);
     box.append(stack);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Gtk.Box {
+      orientation: vertical;
+      spacing: 12;
+
+      Adw.InlineViewSwitcher {
+        display-mode: both;
+        stack: stack;
+        halign: center;
+      }
+
+      Adw.ViewStack stack {
+        vexpand: true;
+
+        Adw.ViewStackPage {
+          title: _("Overview");
+          icon-name: "view-grid-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "view-grid-symbolic";
+            title: _("Overview");
+            description: _("A quick summary of your project.");
+          };
+        }
+
+        Adw.ViewStackPage {
+          title: _("Activity");
+          icon-name: "document-edit-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "document-edit-symbolic";
+            title: _("Activity");
+            description: _("Recent edits and changes.");
+          };
+        }
+
+        Adw.ViewStackPage {
+          title: _("Settings");
+          icon-name: "emblem-system-symbolic";
+
+          child: Adw.StatusPage {
+            icon-name: "emblem-system-symbolic";
+            title: _("Settings");
+            description: _("Configure how things behave.");
+          };
+        }
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">
@@ -358,6 +484,43 @@ flick skip several pages.
     const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 12 });
     box.append(carousel);
     box.append(dots);
+    ```
+  </Fragment>
+  <Fragment slot="blueprint">
+    ```blueprint
+    using Gtk 4.0;
+    using Adw 1;
+
+    Gtk.Box {
+      orientation: vertical;
+      spacing: 12;
+      halign: center;
+      valign: center;
+
+      Adw.Carousel carousel {
+        Gtk.Label {
+          label: _("Welcome");
+
+          styles ["title-1", "card"]
+        }
+
+        Gtk.Label {
+          label: _("Discover");
+
+          styles ["title-1", "card"]
+        }
+
+        Gtk.Label {
+          label: _("Get started");
+
+          styles ["title-1", "card"]
+        }
+      }
+
+      Adw.CarouselIndicatorDots {
+        carousel: carousel;
+      }
+    }
     ```
   </Fragment>
   <Fragment slot="web">

--- a/website/src/grammars/blueprint.tmLanguage.json
+++ b/website/src/grammars/blueprint.tmLanguage.json
@@ -1,0 +1,99 @@
+{
+  "_comment": [
+    "A MINIMAL TextMate grammar for Blueprint (.blp), the GTK UI-definition language.",
+    "",
+    "Shiki bundles no Blueprint grammar, and a fenced ```blueprint block without one",
+    "falls back to plain text — which next to three highlighted sibling tabs reads as",
+    "a broken tab rather than a deliberate one.",
+    "",
+    "DELIBERATELY SMALL. It covers exactly the constructs the widget gallery writes:",
+    "imports, a template header, namespaced type names, property assignments, style",
+    "classes, strings (including the translatable forms), numbers and comments. It is",
+    "not a validator and not a complete grammar — blueprint-compiler is the authority",
+    "on the language, and nothing here should be read as a second definition of it.",
+    "Anything unhandled simply renders unstyled, which is the correct failure for a",
+    "highlighter.",
+    "",
+    "Reference: https://gnome.pages.gitlab.gnome.org/blueprint-compiler/"
+  ],
+  "name": "blueprint",
+  "aliases": ["blp"],
+  "displayName": "Blueprint",
+  "scopeName": "source.blueprint",
+  "patterns": [
+    { "include": "#comment" },
+    { "include": "#import" },
+    { "include": "#string" },
+    { "include": "#keyword" },
+    { "include": "#template-target" },
+    { "include": "#type" },
+    { "include": "#property" },
+    { "include": "#constant" }
+  ],
+  "repository": {
+    "comment": {
+      "patterns": [
+        { "name": "comment.line.double-slash.blueprint", "match": "//.*$" },
+        { "name": "comment.block.blueprint", "begin": "/\\*", "end": "\\*/" }
+      ]
+    },
+    "import": {
+      "comment": "`using Gtk 4.0;` — the version is a number, not a property value.",
+      "match": "\\b(using)\\s+([A-Z][A-Za-z0-9]*)\\s+([0-9]+(?:\\.[0-9]+)?)",
+      "captures": {
+        "1": { "name": "keyword.control.import.blueprint" },
+        "2": { "name": "entity.name.namespace.blueprint" },
+        "3": { "name": "constant.numeric.blueprint" }
+      }
+    },
+    "string": {
+      "patterns": [
+        {
+          "comment": "Translatable strings: _(\"…\") and C_(\"context\", \"…\").",
+          "match": "\\b(_|C_)(?=\\()",
+          "name": "entity.name.function.blueprint"
+        },
+        {
+          "name": "string.quoted.double.blueprint",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [{ "name": "constant.character.escape.blueprint", "match": "\\\\." }]
+        },
+        {
+          "name": "string.quoted.single.blueprint",
+          "begin": "'",
+          "end": "'",
+          "patterns": [{ "name": "constant.character.escape.blueprint", "match": "\\\\." }]
+        }
+      ]
+    },
+    "keyword": {
+      "name": "keyword.control.blueprint",
+      "match": "\\b(using|template|styles|menu|section|submenu|item|bind|bind-property|after|swapped|inverted|sync-create|no-sync-create|bidirectional)\\b"
+    },
+    "template-target": {
+      "comment": "`template $MainWindow: Adw.ApplicationWindow` — the app's own class.",
+      "name": "entity.name.class.blueprint",
+      "match": "\\$[A-Za-z_][A-Za-z0-9_]*"
+    },
+    "type": {
+      "comment": "`Adw.HeaderBar`, `Gtk.Box` — a namespaced widget type opening a block.",
+      "match": "\\b([A-Z][A-Za-z0-9]*)\\.([A-Z][A-Za-z0-9]*)\\b",
+      "captures": {
+        "1": { "name": "entity.name.namespace.blueprint" },
+        "2": { "name": "entity.name.type.blueprint" }
+      }
+    },
+    "property": {
+      "comment": "`title: \"…\";` — an identifier immediately before a colon.",
+      "name": "variable.other.property.blueprint",
+      "match": "\\b([a-z][A-Za-z0-9_-]*)\\s*(?=:)"
+    },
+    "constant": {
+      "patterns": [
+        { "name": "constant.language.blueprint", "match": "\\b(true|false|null)\\b" },
+        { "name": "constant.numeric.blueprint", "match": "\\b[0-9]+(?:\\.[0-9]+)?\\b" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The widget gallery showed **GJS · Web · NativeScript** — three ways to build the same tree imperatively. In practice a GTK UI is *declared*, in Blueprint, with the GJS side reduced to loading it. That was the one view missing, and it is the one closest to how these widgets are actually written.

## Scope: the declaration, nothing else

A `.blp` file **is** a widget tree. Padding each block out with a loader would make it read as a fourth complete program rather than the thing it is, so the tab carries the declaration alone.

Where a widget genuinely cannot be fully declared, the block says which part is runtime instead of pretending otherwise — a toast is constructed and handed to its overlay, so `Adw.Toast`'s blueprint carries the `AdwToastOverlay` and names the seam.

Blueprint sits directly after GJS because the two describe the same native tree; Web and NativeScript are the ports and follow.

## Highlighting had to be solved first

Shiki bundles no Blueprint grammar. A fenced ` ```blueprint ` block falls back to plain text with a build warning:

```
[WARN] [astro-expressive-code] Error while highlighting code block using language
"blueprint" … The language could not be found. Using "txt" instead.
```

An unhighlighted tab between three highlighted ones reads as broken rather than deliberate, so a grammar is registered in `astro.config.mjs`.

It is **deliberately minimal** and its own header says what it is not: imports, template headers, namespaced types, property assignments, style classes, strings (including `_()` / `C_()`), numbers and comments. It is not a validator and not a second definition of the language — blueprint-compiler is the authority. Anything unhandled renders unstyled, which is the correct failure mode for a highlighter.

## Verification

- **50 pages built, no highlighter warning** — the warning above is the regression signal if the grammar ever stops loading
- **35 Blueprint tabs** in the emitted HTML: boxed-lists 9, buttons 4, feedback 4, layout 4, navigation 5, presentation 5, view-switching 4 — one per `<AdwWidget>` block, none missed
- the rendered tab carries **six distinct token colours**, so types, properties, keywords and strings are actually distinguished
- `format --no-write` and `lint` clean repo-wide

One divergence found while writing them and fixed: the password row's blueprint omitted the `text` its GJS sibling sets. In a gallery whose whole purpose is a 1:1 comparison, that is exactly the silent drift the tabs exist to expose.