### PR TITLE
fix(adwaita-web): give split-view panes their libadwaita style classes

### DIFF
--- a/packages/web/adwaita-web/scss/_navigation_split_view.scss
+++ b/packages/web/adwaita-web/scss/_navigation_split_view.scss
@@ -22,12 +22,16 @@ adw-navigation-split-view {
   min-width: 0;
   flex: 1 1 auto;
 
+  // NO background here — it comes from the `.sidebar-pane` class the element
+  // applies while DOCKED (see _panes.scss). Collapsed, libadwaita builds no
+  // pane bins at all and the sidebar is an ordinary full-window navigation
+  // page; a background nailed to this private class made it sidebar-coloured
+  // at every width.
   .adw-nsv-sidebar {
     display: flex;
     flex-direction: column;
     min-height: 0;
     flex-shrink: 0;
-    background-color: var(--sidebar-bg-color);
   }
 
   // The container MINIMUM, as CSS spells it: `measure_uncollapsed`

--- a/packages/web/adwaita-web/scss/_overlay_split_view.scss
+++ b/packages/web/adwaita-web/scss/_overlay_split_view.scss
@@ -27,8 +27,12 @@ adw-overlay-split-view {
   position: relative;
   overflow: hidden;
 
+  // NO background here. The pane colour comes from the `.sidebar-pane` /
+  // `.overlay-pane` class the element toggles (see _panes.scss), because which
+  // of the two a pane is in is exactly what decides its colour — hard-coding
+  // `--sidebar-bg-color` on this private class painted a collapsed overlay,
+  // which libadwaita puts on the window background, as though it were docked.
   .adw-osv-sidebar {
-    background-color: var(--sidebar-bg-color);
     overflow-y: auto;
     flex-shrink: 0;
     z-index: 10;

--- a/packages/web/adwaita-web/scss/_panes.scss
+++ b/packages/web/adwaita-web/scss/_panes.scss
@@ -1,0 +1,57 @@
+// _panes.scss — `.sidebar-pane` / `.content-pane` / `.overlay-pane`.
+//
+// These are libadwaita STYLE CLASSES, not private markup of one widget. Both
+// split views document them as their CSS node tree
+// (adw-navigation-split-view.c:157-165, adw-overlay-split-view.c:136-152) and
+// both apply them to their pane bins, which makes them the supported hook an
+// app themes a pane through. They lived nowhere in this stylesheet, so each
+// split view hard-coded `--sidebar-bg-color` onto its own private pane div
+// instead — with two consequences.
+//
+// The first is that an app writing the documented selector styles nothing, and
+// gets no error saying so. Our own docs site is the evidence: every split-view
+// example carried `class="sidebar"` on the sidebar toolbar view, hand-written
+// by someone reaching for exactly this, matching no rule in the build.
+//
+// The second is a rendering defect, because the class is not constant — it is
+// how the widget says which of its states a pane is in. A collapsed overlay
+// sidebar is an `.overlay-pane`, on the WINDOW background, not the sidebar one
+// (adw-overlay-split-view.c:718-741); a collapsed navigation split view has no
+// pane bins at all, its pages being ordinary navigation pages. Painting the
+// sidebar colour at every width, as the private rules did, got both wrong.
+//
+// Reference: refs/libadwaita/src/stylesheet/widgets/_sidebars.scss (.sidebar-pane, .overlay-pane)
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+// Modifications: Adapted for @gjsify/adwaita-web Web Components.
+
+.sidebar-pane {
+  background-color: var(--sidebar-bg-color);
+  color: var(--sidebar-fg-color);
+}
+
+// A pane nested inside another sidebar pane defers to it rather than stacking a
+// second tint (`.sidebar-pane .sidebar-pane`, _sidebars.scss). libadwaita also
+// recolours the MIDDLE pane of a three-pane setup through
+// `--secondary-sidebar-*`; that needs a split view nested in a split view to
+// mean anything, and no such composition is rendered yet, so the tokens are
+// defined (they are public API an app may already reference) and the selector
+// is left for whoever builds the composition that can test it.
+.sidebar-pane .sidebar-pane {
+  background-color: transparent;
+  color: inherit;
+}
+
+// `.content-pane` deliberately has NO rule here. libadwaita gives it no colour
+// of its own — the window shows through — and writing `transparent` would be a
+// claim, not a copy: it would override the `--window-bg-color` the navigation
+// split view sets on its own content pane for the case where the view is not a
+// window's direct child. The class is still applied, because being able to
+// select it is the point.
+
+// Collapsed: the sidebar floats ABOVE the content as a temporary panel, and
+// libadwaita gives it the window colours rather than the sidebar ones — a panel
+// over the content is not the same surface as a pane beside it.
+.overlay-pane {
+  background-color: var(--window-bg-color);
+  color: var(--window-fg-color);
+}

--- a/packages/web/adwaita-web/scss/_sidebar.scss
+++ b/packages/web/adwaita-web/scss/_sidebar.scss
@@ -62,12 +62,19 @@ adw-sidebar {
   }
 
   // --- A single item row ---
+  //
+  // NO `width: 100%`. The list is a column flex container, so a row already
+  // stretches to it — and stretching SUBTRACTS the row's own margins, which is
+  // what puts the same 6px of air on both sides. `width: 100%` resolves against
+  // the containing block INSTEAD, which does not know about the margins, so
+  // every row came out 12px too wide: inset 6px on the left, hanging 6px past
+  // the right edge with its rounded corners cut off by the pane. Visible on any
+  // selected or hovered row, because only a filled row shows where it ends.
   .adw-sidebar-item {
     box-sizing: border-box;
     display: flex;
     align-items: center;
     gap: var(--spacing-m);
-    width: 100%;
     min-height: 36px;
     // The native row has a context menu, so padding lives on the inner box and
     // the row itself carries the menu margin + radius.

--- a/packages/web/adwaita-web/scss/_theme.scss
+++ b/packages/web/adwaita-web/scss/_theme.scss
@@ -14,6 +14,15 @@
   --headerbar-shade-color: rgba(0, 0, 6, 0.36);
   --separator-color: rgba(255, 255, 255, 0.08);
   --sidebar-bg-color: #2e2e32;
+  --sidebar-fg-color: #ffffff;
+  --sidebar-backdrop-color: #28282c;
+  --sidebar-shade-color: rgba(0, 0, 6, 0.25);
+  --sidebar-border-color: rgba(0, 0, 6, 0.36);
+  --secondary-sidebar-bg-color: #28282c;
+  --secondary-sidebar-fg-color: #ffffff;
+  --secondary-sidebar-backdrop-color: #252529;
+  --secondary-sidebar-shade-color: rgba(0, 0, 6, 0.25);
+  --secondary-sidebar-border-color: rgba(0, 0, 6, 0.36);
   --card-bg-color: rgba(255, 255, 255, 0.08);
   --card-fg-color: #ffffff;
   --card-shade-color: rgba(0, 0, 6, 0.36);

--- a/packages/web/adwaita-web/scss/_variables.scss
+++ b/packages/web/adwaita-web/scss/_variables.scss
@@ -24,8 +24,25 @@
   // draws separators, instead of a harsh near-black line on a dark surface.
   --separator-color: rgba(0, 0, 6, 0.1);
 
-  // Sidebar
+  // Sidebar / split panes. libadwaita defines the whole family, not just the
+  // background (_colors.scss:47-58), and only the background was here — so
+  // `.sidebar-pane` had no foreground to name, and an app overriding
+  // `--sidebar-fg-color` was overriding nothing.
   --sidebar-bg-color: #ebebed;
+  --sidebar-fg-color: rgba(0, 0, 6, 0.8);
+  --sidebar-backdrop-color: #f2f2f4;
+  --sidebar-shade-color: rgba(0, 0, 6, 0.07);
+  --sidebar-border-color: rgba(0, 0, 6, 0.07);
+
+  // The MIDDLE pane of a three-pane setup. Nothing renders one yet; the tokens
+  // are defined because they are public API an app may already reference, and a
+  // half-present family reads as "this one is unsupported" rather than "this
+  // composition is not built yet".
+  --secondary-sidebar-bg-color: #f3f3f5;
+  --secondary-sidebar-fg-color: rgba(0, 0, 6, 0.8);
+  --secondary-sidebar-backdrop-color: #f6f6fa;
+  --secondary-sidebar-shade-color: rgba(0, 0, 6, 0.07);
+  --secondary-sidebar-border-color: rgba(0, 0, 6, 0.07);
 
   // Cards / boxed lists
   --card-bg-color: #ffffff;

--- a/packages/web/adwaita-web/scss/adwaita-skin.scss
+++ b/packages/web/adwaita-web/scss/adwaita-skin.scss
@@ -66,6 +66,7 @@
 @use 'toast';
 @use 'toolbar_view';
 @use 'wrap_box';
+@use 'panes';
 @use 'overlay_split_view';
 @use 'navigation_split_view';
 @use 'carousel';

--- a/packages/web/adwaita-web/src/adw-sidebar.spec.ts
+++ b/packages/web/adwaita-web/src/adw-sidebar.spec.ts
@@ -329,4 +329,36 @@ export const AdwSidebarTest = async () => {
             host.remove();
         });
     });
+
+    // A row's own box, which nothing had ever measured.
+    //
+    // `.adw-sidebar-item` carried `width: 100%` ON TOP of `margin: 0 6px 2px`.
+    // The list is a column flex container, so a row already stretches to it and
+    // stretching subtracts margins; `width: 100%` resolves against the
+    // containing block instead, which does not, so every row came out 12px too
+    // wide — inset on the left, hanging past the right edge with its rounded
+    // corners clipped away. Every earlier test asked what a row CONTAINED, so
+    // all of them passed.
+    await describe('a sidebar row sits inside its list, not over its edge', async () => {
+        await it('leaves the same margin on both sides', async () => {
+            const { sidebar, host } = mountSidebar([{ items: [{ title: 'Inbox' }, { title: 'Starred' }] }], {
+                selected: '0',
+            });
+            host.setAttribute('style', 'width:220px');
+
+            const list = sidebar.querySelector('.adw-sidebar-list') as HTMLElement;
+            const listBox = list.getBoundingClientRect();
+
+            for (const row of rowsOf(sidebar)) {
+                const box = row.getBoundingClientRect();
+                const left = box.left - listBox.left;
+                const right = listBox.right - box.right;
+                // Symmetric, and INSIDE — a negative right gap is the overhang.
+                expect(Math.round(left)).toBe(Math.round(right));
+                expect(right >= 0).toBe(true);
+            }
+
+            host.remove();
+        });
+    });
 };

--- a/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
@@ -273,6 +273,16 @@ export class AdwNavigationSplitView extends HTMLElement {
             isSidebarAtVisualStart(state.sidebarPosition, this._direction),
         );
 
+        // THE PANE STYLE CLASSES, and only while docked. libadwaita builds the
+        // two `.sidebar-pane` / `.content-pane` bins in the UNCOLLAPSED branch
+        // alone (:583-608); collapsed, both pages move into one AdwNavigationView
+        // and neither bin exists (:552-568) — so a collapsed sidebar is a full
+        // window page on the WINDOW background, not a sidebar-coloured one.
+        // Painting it `--sidebar-bg-color` at every width, as this did, is the
+        // same defect the overlay view has with `.overlay-pane`.
+        this._sidebarEl?.classList.toggle('sidebar-pane', !state.collapsed);
+        this._contentEl?.classList.toggle('content-pane', !state.collapsed);
+
         // The STACK, not the two flags: `update_navigation_stack` (:342-405)
         // keeps a LONE child visible whatever `show-content` says, and with
         // `sidebar-position: end` the CONTENT is the root page — so the sidebar

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -442,6 +442,23 @@ export class AdwOverlaySplitView extends HTMLElement {
         // alone cannot get right: the divider follows where the pane is DRAWN.
         this.classList.toggle('sidebar-at-visual-start', atStart);
 
+        // THE PANE STYLE CLASSES, which libadwaita documents as part of this
+        // widget's CSS node tree (adw-overlay-split-view.c:138-152) and switches
+        // in `update_collapsed` (:718-741): docked, the panes are `.sidebar-pane`
+        // and `.content-pane`; collapsed, the sidebar becomes an `.overlay-pane`
+        // floating above a content pane that carries no class at all.
+        //
+        // They are not decoration. `.overlay-pane` is what makes a collapsed
+        // sidebar drop the sidebar background for the window one, and they are
+        // the documented hook an app themes its own panes through — so leaving
+        // them off does not merely look wrong, it makes correct app CSS a no-op.
+        // The docs site is the proof: its split-view examples carried a
+        // hand-written `class="sidebar"` that styled nothing, written by someone
+        // reaching for exactly this and finding nothing there.
+        this._sidebarEl?.classList.toggle('sidebar-pane', !state.collapsed);
+        this._sidebarEl?.classList.toggle('overlay-pane', state.collapsed);
+        this._contentEl?.classList.toggle('content-pane', !state.collapsed);
+
         // Derived, not re-decided here: the shield only exists while collapsed
         // AND revealed, and each pane is reachable by keyboard only when it is
         // the one on screen.

--- a/packages/web/adwaita-web/src/split-views.spec.ts
+++ b/packages/web/adwaita-web/src/split-views.spec.ts
@@ -890,4 +890,95 @@ export const AdwSplitViewsTest = async () => {
             host.remove();
         });
     });
+
+    // The pane STYLE CLASSES, which libadwaita documents as each split view's
+    // CSS node tree and which an app is meant to be able to select.
+    //
+    // They were absent entirely, and both views hard-coded `--sidebar-bg-color`
+    // onto their own private pane class instead. That is not the same thing
+    // twice: the class is not constant. It says which STATE a pane is in, and
+    // the colour follows from that — so a collapsed overlay sidebar, which
+    // libadwaita puts on the window background, was painted as though it were
+    // still docked beside the content.
+    //
+    // Asserting the class names and not only the colours is deliberate. The
+    // names are the app-facing contract; a rendering that happened to look right
+    // through some other selector would still have broken every app stylesheet
+    // written against the documented one.
+    await describe('split-view panes carry libadwaita pane style classes', async () => {
+        const bg = (el: Element) => getComputedStyle(el).backgroundColor;
+        const token = (name: string) => {
+            const probe = document.createElement('div');
+            probe.style.backgroundColor = `var(${name})`;
+            document.body.appendChild(probe);
+            const value = getComputedStyle(probe).backgroundColor;
+            probe.remove();
+            return value;
+        };
+
+        await it('overlay: docked panes are .sidebar-pane / .content-pane', async () => {
+            const { view, host } = mount('show-sidebar');
+            host.setAttribute('style', 'width:900px;height:300px;display:flex');
+            await settle();
+            const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            const content = view.querySelector('.adw-osv-content') as HTMLElement;
+
+            expect(sidebar.classList.contains('sidebar-pane')).toBe(true);
+            expect(sidebar.classList.contains('overlay-pane')).toBe(false);
+            expect(content.classList.contains('content-pane')).toBe(true);
+            expect(bg(sidebar)).toBe(token('--sidebar-bg-color'));
+            host.remove();
+        });
+
+        await it('overlay: collapsing turns the sidebar into an .overlay-pane on the window background', async () => {
+            const { view, host } = mount('show-sidebar');
+            host.setAttribute('style', 'width:900px;height:300px;display:flex');
+            await settle();
+            const sidebar = view.querySelector('.adw-osv-sidebar') as HTMLElement;
+            const content = view.querySelector('.adw-osv-content') as HTMLElement;
+
+            view.setAttribute('collapsed', '');
+            await settle();
+            expect(sidebar.classList.contains('overlay-pane')).toBe(true);
+            expect(sidebar.classList.contains('sidebar-pane')).toBe(false);
+            // Collapsed, libadwaita removes `.content-pane` outright — the
+            // content is no longer one pane of two, it is the whole view.
+            expect(content.classList.contains('content-pane')).toBe(false);
+            expect(bg(sidebar)).toBe(token('--window-bg-color'));
+
+            // And back: the class follows the state in BOTH directions. A
+            // one-way toggle would leave a re-expanded sidebar window-coloured.
+            view.removeAttribute('collapsed');
+            await settle();
+            expect(sidebar.classList.contains('sidebar-pane')).toBe(true);
+            expect(bg(sidebar)).toBe(token('--sidebar-bg-color'));
+            host.remove();
+        });
+
+        await it('navigation: the pane classes exist while docked and are dropped when collapsed', async () => {
+            const host = document.createElement('div');
+            host.setAttribute('style', 'width:900px;height:300px;display:flex');
+            document.body.appendChild(host);
+            host.innerHTML =
+                '<adw-navigation-split-view><div slot="sidebar">s</div><div slot="content">c</div></adw-navigation-split-view>';
+            const view = host.querySelector('adw-navigation-split-view') as AdwNavigationSplitView;
+            await settle();
+            const sidebar = view.querySelector('.adw-nsv-sidebar') as HTMLElement;
+            const content = view.querySelector('.adw-nsv-content') as HTMLElement;
+
+            expect(sidebar.classList.contains('sidebar-pane')).toBe(true);
+            expect(content.classList.contains('content-pane')).toBe(true);
+            expect(bg(sidebar)).toBe(token('--sidebar-bg-color'));
+
+            // Collapsed, libadwaita builds no pane bins at all: both pages move
+            // into one navigation view, so the sidebar is an ordinary full-width
+            // page and must stop being sidebar-coloured.
+            view.setAttribute('collapsed', '');
+            await settle();
+            expect(sidebar.classList.contains('sidebar-pane')).toBe(false);
+            expect(content.classList.contains('content-pane')).toBe(false);
+            expect(bg(sidebar)).not.toBe(token('--sidebar-bg-color'));
+            host.remove();
+        });
+    });
 };

--- a/website/src/content/docs/widgets/navigation.mdx
+++ b/website/src/content/docs/widgets/navigation.mdx
@@ -40,20 +40,14 @@ page with its own header bar.
           <adw-header-bar data-adw-slot="top">
             <adw-window-title data-adw-slot="center" title="Mailboxes"></adw-window-title>
           </adw-header-bar>
-          <adw-preferences-group>
-            <adw-action-row title="All Mail" subtitle="128 messages" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--mail-unread"></span>
-            </adw-action-row>
-            <adw-action-row title="Starred" subtitle="6 messages" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--starred"></span>
-            </adw-action-row>
-            <adw-action-row title="Drafts" subtitle="2 messages" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--document-edit"></span>
-            </adw-action-row>
-            <adw-action-row title="Archive" subtitle="512 messages" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--folder"></span>
-            </adw-action-row>
-          </adw-preferences-group>
+          <adw-sidebar mode="sidebar" selected="0">
+            <adw-sidebar-section>
+              <adw-sidebar-item title="All Mail" subtitle="128 messages" icon-name="mail-unread-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Starred" subtitle="6 messages" icon-name="starred-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Drafts" subtitle="2 messages" icon-name="document-edit-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Archive" subtitle="512 messages" icon-name="folder-symbolic"></adw-sidebar-item>
+            </adw-sidebar-section>
+          </adw-sidebar>
         </adw-toolbar-view>
         <adw-toolbar-view data-adw-slot="content">
           <adw-header-bar data-adw-slot="top">
@@ -67,23 +61,25 @@ page with its own header bar.
   <Fragment slot="gjs">
     ```ts
     import Adw from '@girs/adw-1';
-    import Gtk from '@girs/gtk-4.0';
 
-    // Sidebar: a boxed list of mailboxes inside a toolbar view.
-    const group = new Adw.PreferencesGroup();
+    // Sidebar: an Adw.Sidebar, NOT a boxed list. A boxed list is a card of
+    // settings and draws itself as one — rounded, bordered, edge to edge in a
+    // pane that gives it no margin. A navigation sidebar is a flat selectable
+    // list, and the widget that already knows how to be one is this.
+    const section = new Adw.SidebarSection();
     for (const [title, subtitle, icon] of [
         ['All Mail', '128 messages', 'mail-unread-symbolic'],
         ['Starred', '6 messages', 'starred-symbolic'],
     ] as const) {
-        const row = new Adw.ActionRow({ title, subtitle });
-        row.add_prefix(new Gtk.Image({ iconName: icon }));
-        row.activatable = true;
-        group.add(row);
+        section.append(new Adw.SidebarItem({ title, subtitle, iconName: icon }));
     }
+
+    const sidebarList = new Adw.Sidebar({ mode: Adw.SidebarMode.SIDEBAR, selected: 0 });
+    sidebarList.append(section);
 
     const sidebarToolbar = new Adw.ToolbarView();
     sidebarToolbar.add_top_bar(new Adw.HeaderBar());
-    sidebarToolbar.content = group;
+    sidebarToolbar.content = sidebarList;
     const sidebar = new Adw.NavigationPage({ title: 'Mailboxes', child: sidebarToolbar });
 
     // Content: a status page inside a toolbar view.
@@ -114,47 +110,32 @@ page with its own header bar.
           [top]
           Adw.HeaderBar {}
 
-          content: Adw.PreferencesGroup {
-            Adw.ActionRow {
-              title: _("All Mail");
-              subtitle: _("128 messages");
-              activatable: true;
+          content: Adw.Sidebar {
+            mode: sidebar;
+            selected: 0;
 
-              [prefix]
-              Gtk.Image {
+            Adw.SidebarSection {
+              Adw.SidebarItem {
+                title: _("All Mail");
+                subtitle: _("128 messages");
                 icon-name: "mail-unread-symbolic";
               }
-            }
 
-            Adw.ActionRow {
-              title: _("Starred");
-              subtitle: _("6 messages");
-              activatable: true;
-
-              [prefix]
-              Gtk.Image {
+              Adw.SidebarItem {
+                title: _("Starred");
+                subtitle: _("6 messages");
                 icon-name: "starred-symbolic";
               }
-            }
 
-            Adw.ActionRow {
-              title: _("Drafts");
-              subtitle: _("2 messages");
-              activatable: true;
-
-              [prefix]
-              Gtk.Image {
+              Adw.SidebarItem {
+                title: _("Drafts");
+                subtitle: _("2 messages");
                 icon-name: "document-edit-symbolic";
               }
-            }
 
-            Adw.ActionRow {
-              title: _("Archive");
-              subtitle: _("512 messages");
-              activatable: true;
-
-              [prefix]
-              Gtk.Image {
+              Adw.SidebarItem {
+                title: _("Archive");
+                subtitle: _("512 messages");
                 icon-name: "folder-symbolic";
               }
             }
@@ -188,20 +169,14 @@ page with its own header bar.
                 <adw-header-bar slot="top">
                     <adw-window-title slot="center" title="Mailboxes"></adw-window-title>
                 </adw-header-bar>
-                <adw-preferences-group>
-                    <adw-action-row title="All Mail" subtitle="128 messages" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--mail-unread"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Starred" subtitle="6 messages" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--starred"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Drafts" subtitle="2 messages" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--document-edit"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Archive" subtitle="512 messages" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--folder"></span>
-                    </adw-action-row>
-                </adw-preferences-group>
+                <adw-sidebar mode="sidebar" selected="0">
+                    <adw-sidebar-section>
+                        <adw-sidebar-item title="All Mail" subtitle="128 messages" icon-name="mail-unread-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Starred" subtitle="6 messages" icon-name="starred-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Drafts" subtitle="2 messages" icon-name="document-edit-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Archive" subtitle="512 messages" icon-name="folder-symbolic"></adw-sidebar-item>
+                    </adw-sidebar-section>
+                </adw-sidebar>
             </adw-toolbar-view>
             <adw-toolbar-view slot="content">
                 <adw-header-bar slot="top">
@@ -216,28 +191,25 @@ page with its own header bar.
   <Fragment slot="nativescript">
     ```ts
     import {
-        AdwActionRow,
         AdwHeaderBar,
         AdwNavigationSplitView,
-        AdwPreferencesGroup,
+        AdwSidebar,
         AdwStatusPage,
         AdwToolbarView,
     } from '@gjsify/adwaita-nativescript';
     import { mailUnreadSymbolic } from '@gjsify/adwaita-icons/status';
 
-    // Sidebar: a boxed list of mailboxes inside a toolbar view.
-    const group = new AdwPreferencesGroup();
-    for (const [title, subtitle] of [['All Mail', '128 messages'], ['Starred', '6 messages']] as const) {
-        const row = new AdwActionRow();
-        row.title = title;
-        row.subtitle = subtitle;
-        group.addRow(row);
-    }
+    // Sidebar: the navigation list, not a boxed list. The NS surface takes a
+    // flat label list (no per-item subtitle/icon slot).
+    const sidebarList = new AdwSidebar();
+    sidebarList.setItems(['All Mail', 'Starred', 'Drafts', 'Archive']);
+    sidebarList.selected = 0;
+
     const sidebarHeader = new AdwHeaderBar();
     sidebarHeader.title = 'Mailboxes';
     const sidebar = new AdwToolbarView();
     sidebar.addTopBar(sidebarHeader);
-    sidebar.setContent(group);
+    sidebar.setContent(sidebarList);
 
     // Content: a status page inside a toolbar view.
     const status = new AdwStatusPage();
@@ -270,22 +242,16 @@ push the primary content aside on a narrow window.
   <Fragment slot="preview">
     <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
       <adw-overlay-split-view show-sidebar style="flex: 1;">
-        <adw-toolbar-view data-adw-slot="sidebar" class="sidebar">
+        <adw-toolbar-view data-adw-slot="sidebar">
           <adw-header-bar data-adw-slot="top"></adw-header-bar>
-          <adw-preferences-group>
-            <adw-action-row title="Home" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--go-home"></span>
-            </adw-action-row>
-            <adw-action-row title="Discover" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--system-search"></span>
-            </adw-action-row>
-            <adw-action-row title="Library" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--folder-music"></span>
-            </adw-action-row>
-            <adw-action-row title="Settings" activatable>
-              <span data-adw-slot="prefix" class="adw-icon adw-icon--emblem-system"></span>
-            </adw-action-row>
-          </adw-preferences-group>
+          <adw-sidebar mode="sidebar" selected="0">
+            <adw-sidebar-section>
+              <adw-sidebar-item title="Home" icon-name="go-home-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Discover" icon-name="system-search-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Library" icon-name="folder-music-symbolic"></adw-sidebar-item>
+              <adw-sidebar-item title="Settings" icon-name="emblem-system-symbolic"></adw-sidebar-item>
+            </adw-sidebar-section>
+          </adw-sidebar>
         </adw-toolbar-view>
         <adw-toolbar-view data-adw-slot="content">
           <adw-header-bar data-adw-slot="top"></adw-header-bar>
@@ -297,25 +263,28 @@ push the primary content aside on a narrow window.
   <Fragment slot="gjs">
     ```ts
     import Adw from '@girs/adw-1';
-    import Gtk from '@girs/gtk-4.0';
 
-    // Sidebar: a flat, title-less toolbar view over a boxed list.
-    const group = new Adw.PreferencesGroup();
+    // Sidebar: a flat, title-less toolbar view over an Adw.Sidebar. The pane
+    // needs no style class of its own — Adw.OverlaySplitView puts `.sidebar-pane`
+    // on it while docked and `.overlay-pane` while collapsed, which is what
+    // gives it its colour. (The old `.sidebar` class libadwaita deprecates in
+    // favour of `.navigation-sidebar`; Adw.Sidebar carries that look itself.)
+    const section = new Adw.SidebarSection();
     for (const [title, icon] of [
         ['Home', 'go-home-symbolic'],
         ['Discover', 'system-search-symbolic'],
         ['Library', 'folder-music-symbolic'],
         ['Settings', 'emblem-system-symbolic'],
     ] as const) {
-        const row = new Adw.ActionRow({ title });
-        row.add_prefix(new Gtk.Image({ iconName: icon }));
-        row.activatable = true;
-        group.add(row);
+        section.append(new Adw.SidebarItem({ title, iconName: icon }));
     }
+
+    const sidebarList = new Adw.Sidebar({ mode: Adw.SidebarMode.SIDEBAR, selected: 0 });
+    sidebarList.append(section);
+
     const sidebar = new Adw.ToolbarView();
     sidebar.add_top_bar(new Adw.HeaderBar({ showTitle: false }));
-    sidebar.content = group;
-    sidebar.add_css_class('sidebar');
+    sidebar.content = sidebarList;
 
     const status = new Adw.StatusPage({
         iconName: 'folder-music-symbolic',
@@ -342,49 +311,32 @@ push the primary content aside on a narrow window.
         [top]
         Adw.HeaderBar {}
 
-        content: Adw.PreferencesGroup {
-          Adw.ActionRow {
-            title: _("Home");
-            activatable: true;
+        content: Adw.Sidebar {
+          mode: sidebar;
+          selected: 0;
 
-            [prefix]
-            Gtk.Image {
+          Adw.SidebarSection {
+            Adw.SidebarItem {
+              title: _("Home");
               icon-name: "go-home-symbolic";
             }
-          }
 
-          Adw.ActionRow {
-            title: _("Discover");
-            activatable: true;
-
-            [prefix]
-            Gtk.Image {
+            Adw.SidebarItem {
+              title: _("Discover");
               icon-name: "system-search-symbolic";
             }
-          }
 
-          Adw.ActionRow {
-            title: _("Library");
-            activatable: true;
-
-            [prefix]
-            Gtk.Image {
+            Adw.SidebarItem {
+              title: _("Library");
               icon-name: "folder-music-symbolic";
             }
-          }
 
-          Adw.ActionRow {
-            title: _("Settings");
-            activatable: true;
-
-            [prefix]
-            Gtk.Image {
+            Adw.SidebarItem {
+              title: _("Settings");
               icon-name: "emblem-system-symbolic";
             }
           }
         };
-
-        styles ["sidebar"]
       };
 
       content: Adw.ToolbarView {
@@ -404,22 +356,16 @@ push the primary content aside on a narrow window.
     ```html
     <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
         <adw-overlay-split-view show-sidebar style="flex: 1;">
-            <adw-toolbar-view slot="sidebar" class="sidebar">
+            <adw-toolbar-view slot="sidebar">
                 <adw-header-bar slot="top"></adw-header-bar>
-                <adw-preferences-group>
-                    <adw-action-row title="Home" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--go-home"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Discover" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--system-search"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Library" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--folder-music"></span>
-                    </adw-action-row>
-                    <adw-action-row title="Settings" activatable>
-                        <span slot="prefix" class="adw-icon adw-icon--emblem-system"></span>
-                    </adw-action-row>
-                </adw-preferences-group>
+                <adw-sidebar mode="sidebar" selected="0">
+                    <adw-sidebar-section>
+                        <adw-sidebar-item title="Home" icon-name="go-home-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Discover" icon-name="system-search-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Library" icon-name="folder-music-symbolic"></adw-sidebar-item>
+                        <adw-sidebar-item title="Settings" icon-name="emblem-system-symbolic"></adw-sidebar-item>
+                    </adw-sidebar-section>
+                </adw-sidebar>
             </adw-toolbar-view>
             <adw-toolbar-view slot="content">
                 <adw-header-bar slot="top"></adw-header-bar>
@@ -432,26 +378,23 @@ push the primary content aside on a narrow window.
   <Fragment slot="nativescript">
     ```ts
     import {
-        AdwActionRow,
         AdwHeaderBar,
         AdwOverlaySplitView,
-        AdwPreferencesGroup,
+        AdwSidebar,
         AdwStatusPage,
         AdwToolbarView,
     } from '@gjsify/adwaita-nativescript';
     import { folderMusicSymbolic } from '@gjsify/adwaita-icons/places';
 
-    const group = new AdwPreferencesGroup();
-    for (const title of ['Home', 'Discover', 'Library', 'Settings']) {
-        const row = new AdwActionRow();
-        row.title = title;
-        group.addRow(row);
-    }
+    const sidebarList = new AdwSidebar();
+    sidebarList.setItems(['Home', 'Discover', 'Library', 'Settings']);
+    sidebarList.selected = 0;
+
     const header = new AdwHeaderBar();
     header.flat = true;
     const sidebar = new AdwToolbarView();
     sidebar.addTopBar(header);
-    sidebar.setContent(group);
+    sidebar.setContent(sidebarList);
 
     const status = new AdwStatusPage();
     status.icon = folderMusicSymbolic;


### PR DESCRIPTION
A sidebar in the docs gallery drew its entries as a rounded card flush to the pane edges. Three separate defects behind one picture.

### 1. The pane style classes were missing entirely

libadwaita documents `.sidebar-pane` / `.content-pane` / `.overlay-pane` as each split view's CSS node tree (`adw-navigation-split-view.c:157-165`, `adw-overlay-split-view.c:136-152`) and switches them as the view collapses (`update_collapsed`, `:718-741`). Both web elements applied none, hard-coding `--sidebar-bg-color` onto their own private pane div instead.

That is not the same thing written differently — the class says which **state** a pane is in, and the colour follows from it:

- a **collapsed overlay** sidebar is an `.overlay-pane` on the **window** background, not the sidebar one;
- a **collapsed navigation split view** has no pane bins at all (`:552-568`), so its sidebar is an ordinary full-width page.

Both were painted as though still docked. And an app writing the documented selector styled nothing, with no error saying so. The docs are the evidence: every split-view example carried `class="sidebar"` on its sidebar toolbar view, matching no rule in the build — and `.sidebar` is a class libadwaita itself files under deprecated, "use `.navigation-sidebar` instead".

### 2. Only one of libadwaita's sidebar colours existed

`--sidebar-bg-color` was defined and the rest of the family was not, so `.sidebar-pane` had no foreground to name and an app overriding `--sidebar-fg-color` was overriding nothing. The `--secondary-sidebar-*` five are added too: nothing renders a three-pane setup yet, but a half-present family reads as *unsupported* rather than *unbuilt*.

### 3. Every sidebar row was 12px too wide

`.adw-sidebar-item` carried `width: 100%` on top of `margin: 0 6px 2px`. The list is a column flex container, so a row already stretches to it — and stretching **subtracts** margins, which is what puts equal air on both sides. `width: 100%` resolves against the containing block instead, which does not know about them, so rows sat inset 6px on the left and hung 6px past the right edge with their rounded corners clipped by the pane. Visible on any selected or hovered row, because only a filled row shows where it ends.

Every earlier test asked what a row *contained*; none measured its box.

### Docs

The two split-view examples stop putting a boxed list in a sidebar. A boxed list is a card of settings and draws itself as one; a navigation sidebar is a flat selectable list, and `Adw.Sidebar` already is one. All four tabs follow, so GJS, Blueprint, Web and NativeScript keep saying the same thing.

### Verification

Each fix has a test that fails without it (checked by A/B, not by assumption):

- pane classes + resulting colours, in **both** directions of collapse, for both split views — reverting the element change fails 2 tests;
- a row's margins symmetric **and** non-negative — restoring `width: 100%` fails 1 of 3847.

Browser suite green in Firefox; `format --no-write`, `lint` and `tsc` clean.