### PR TITLE
fix(node-gi): implement the GTK template API on Windows

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1459,6 +1459,22 @@ jobs:
           GSK_RENDERER: cairo
         run: node --test test/windowing.test.mjs test/windowing-interactive.test.mjs test/widgets.test.mjs
 
+      # Composite templates — the proof that was missing on BOTH displayless
+      # platforms. All four gtk-template tests gated on DISPLAY/WAYLAND_DISPLAY,
+      # variables GdkWin32 and GdkQuartz never set, so they had never run off
+      # Linux. Windows meanwhile shipped `GetGtkTemplateApi()` as an
+      # `#ifdef _WIN32` stub, and a user found it before CI did: `gjsify showcase
+      # three-geometry-teapot --runtime node` on Windows 11 died with "the
+      # libgtk-4 template API is unavailable" on a machine with working GTK 4.
+      # Running them here is what turns "templates work on this platform" from a
+      # claim into a check.
+      - name: Template proof — composite templates resolve, install and bind children
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+          GSK_RENDERER: cairo
+        run: node --test test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs test/gtk-template-custom-child-ctor.test.mjs test/gtk-template-signals.test.mjs
+
   # Windows proof (Phase 1 — the reverse bridge BUILDS + RUNS on windows-latest).
   # The whole team is Linux-only, so a windows-latest runner is the only way to
   # validate. Sibling of the macOS proof (its `macos` job above is the template).
@@ -1981,6 +1997,22 @@ jobs:
           NODE_GI_NATIVE: prebuild
           GSK_RENDERER: cairo
         run: node --test test/windowing.test.mjs test/windowing-interactive.test.mjs test/widgets.test.mjs
+
+      # Composite templates — the proof that was missing on BOTH displayless
+      # platforms. All four gtk-template tests gated on DISPLAY/WAYLAND_DISPLAY,
+      # variables GdkWin32 and GdkQuartz never set, so they had never run off
+      # Linux. Windows meanwhile shipped `GetGtkTemplateApi()` as an
+      # `#ifdef _WIN32` stub, and a user found it before CI did: `gjsify showcase
+      # three-geometry-teapot --runtime node` on Windows 11 died with "the
+      # libgtk-4 template API is unavailable" on a machine with working GTK 4.
+      # Running them here is what turns "templates work on this platform" from a
+      # claim into a check.
+      - name: Template proof — composite templates resolve, install and bind children
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+          GSK_RENDERER: cairo
+        run: node --test test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs test/gtk-template-custom-child-ctor.test.mjs test/gtk-template-signals.test.mjs
 
   # Adwaita Storybook capstone — BUILD the `--app node` bundle. The full
   # @gjsify/storybook Libadwaita component gallery (showcases/gtk/adwaita-storybook,

--- a/packages/node-gi/node-gi/src/template.cc
+++ b/packages/node-gi/node-gi/src/template.cc
@@ -5,67 +5,102 @@
 
 namespace nodegi {
 
+namespace {
+
+// The GTK 4 shared library, opened by leaf name. THREE things vary per OS and
+// nothing else does, so only those three are spelled per-OS — the symbol table in
+// the function below is written once and both sides run it.
+//
+// The LEAF NAME is what has bitten, twice. Hardcoding the ELF soname made the
+// whole composite-template API unavailable on macOS: `libgtk-4.so.1` does not
+// exist there, so every `registerClass({ Template })` widget failed with "the
+// libgtk-4 template API is unavailable" on a host with GTK 4 correctly installed.
+// Invisible until v0.27.0 shipped the first darwin-x64 addon.
+#if defined(_WIN32)
+// gvsbuild's leaf — what @gjsify/gtk-runtime-win32-x64 ships — then MSYS2's
+// `lib`-prefixed spelling.
+constexpr const char* kGtkLeaves[] = {"gtk-4-1.dll", "libgtk-4-1.dll"};
+using LibHandle = HMODULE;
+
+// The counterpart of RTLD_NOLOAD, and it is load-bearing rather than an
+// optimisation: `requireGi('Gtk','4.0')` has already loaded the DLL through the
+// typelib's shared_library field, and asking for a handle to THAT copy is what
+// keeps this from pulling a second GTK off PATH.
+inline LibHandle OpenAlreadyLoaded(const char* leaf) { return GetModuleHandleA(leaf); }
+inline LibHandle OpenLibrary(const char* leaf) { return LoadLibraryA(leaf); }
+inline void* FindSymbol(LibHandle lib, const char* name) {
+  return reinterpret_cast<void*>(GetProcAddress(lib, name));
+}
+#else
+#if defined(__APPLE__)
+constexpr const char* kGtkLeaves[] = {"libgtk-4.1.dylib", "libgtk-4.dylib"};
+#else
+constexpr const char* kGtkLeaves[] = {"libgtk-4.so.1", "libgtk-4.so"};
+#endif
+using LibHandle = void*;
+
+// RTLD_NOLOAD first — requireGi('Gtk','4.0') already dlopened libgtk-4 via the
+// typelib, so this only bumps the refcount; the plain dlopen behind it serves a
+// caller that never required Gtk through the typelib.
+inline LibHandle OpenAlreadyLoaded(const char* leaf) {
+  return dlopen(leaf, RTLD_LAZY | RTLD_NOLOAD);
+}
+inline LibHandle OpenLibrary(const char* leaf) { return dlopen(leaf, RTLD_LAZY); }
+inline void* FindSymbol(LibHandle lib, const char* name) { return dlsym(lib, name); }
+#endif
+
+}  // namespace
+
 // Resolve the GTK template API once (C++11 function-local static init is
-// thread-safe; node-gi calls these only on the main thread). How the library
-// handle is obtained — and why the leaf name has to be per-OS — is documented at
-// the dlopen below.
+// thread-safe; node-gi calls these only on the main thread).
+//
+// WINDOWS USED TO BE A STUB HERE — an `#ifdef _WIN32 → return &api` leaving
+// `api.ok` false, on the reasoning that "GTK on Windows is Phase 2". The
+// reasoning went stale without the stub noticing: the `--windowing` runtime
+// bundle now ships GTK and libadwaita for win32-x64 and CI renders the whole
+// Libadwaita gallery on it, while `gjsify showcase three-geometry-teapot
+// --runtime node` still died on Windows with "the libgtk-4 template API is
+// unavailable" — on a machine where GTK 4 was present and working. Nothing was
+// missing but these nine symbols.
+//
+// Same lesson as the macOS soname bug, from the other side: a per-OS branch that
+// cannot be EXECUTED anywhere is not a conservative default, it is an untested
+// claim. So this function has no OS branch left — only a per-OS loader above it.
 const GtkTemplateApi* GetGtkTemplateApi() {
   static GtkTemplateApi api = {};
   static bool initialised = false;
   if (initialised) return &api;
   initialised = true;
-#ifdef _WIN32
-  // The Gtk.Widget composite-template API is resolved lazily via dlsym on POSIX
-  // only. GTK on Windows is Phase 2; the Phase-1 Windows CI proves the display-
-  // free core, which never exercises templates. api.ok stays false → template
-  // callers warn + no-op / throw a clear "template API unavailable" error.
-  return &api;
-#else
-  // The library's LEAF NAME IS PER-OS, and hardcoding the ELF soname made the
-  // whole composite-template API unavailable on macOS: `libgtk-4.so.1` does not
-  // exist there, so every `registerClass({ Template })` widget failed with
-  // "the libgtk-4 template API is unavailable" on a host with GTK 4 correctly
-  // installed. Invisible until v0.27.0 shipped the first darwin-x64 addon.
-  //
-  // Candidates are the leaf names GTK 4 actually installs, newest ABI first.
-#ifdef __APPLE__
-  static const char* const kGtkLeaves[] = {"libgtk-4.1.dylib", "libgtk-4.dylib"};
-#else
-  static const char* const kGtkLeaves[] = {"libgtk-4.so.1", "libgtk-4.so"};
-#endif
-  void* lib = nullptr;
+
+  LibHandle lib = nullptr;
   for (const char* leaf : kGtkLeaves) {
-    // RTLD_NOLOAD first — requireGi('Gtk','4.0') already dlopened libgtk-4 via the
-    // typelib, so this only bumps the refcount; the plain dlopen behind it serves a
-    // caller that never required Gtk through the typelib.
-    lib = dlopen(leaf, RTLD_LAZY | RTLD_NOLOAD);
-    if (lib == nullptr) lib = dlopen(leaf, RTLD_LAZY);
+    lib = OpenAlreadyLoaded(leaf);
+    if (lib == nullptr) lib = OpenLibrary(leaf);
     if (lib != nullptr) break;
   }
   if (lib == nullptr) return &api;  // api.ok stays false → callers warn + no-op
   api.set_template = reinterpret_cast<decltype(api.set_template)>(
-      dlsym(lib, "gtk_widget_class_set_template"));
+      FindSymbol(lib, "gtk_widget_class_set_template"));
   api.set_template_from_resource = reinterpret_cast<decltype(api.set_template_from_resource)>(
-      dlsym(lib, "gtk_widget_class_set_template_from_resource"));
+      FindSymbol(lib, "gtk_widget_class_set_template_from_resource"));
   api.bind_template_child_full = reinterpret_cast<decltype(api.bind_template_child_full)>(
-      dlsym(lib, "gtk_widget_class_bind_template_child_full"));
-  api.set_css_name =
-      reinterpret_cast<decltype(api.set_css_name)>(dlsym(lib, "gtk_widget_class_set_css_name"));
+      FindSymbol(lib, "gtk_widget_class_bind_template_child_full"));
+  api.set_css_name = reinterpret_cast<decltype(api.set_css_name)>(
+      FindSymbol(lib, "gtk_widget_class_set_css_name"));
   api.init_template =
-      reinterpret_cast<decltype(api.init_template)>(dlsym(lib, "gtk_widget_init_template"));
+      reinterpret_cast<decltype(api.init_template)>(FindSymbol(lib, "gtk_widget_init_template"));
   api.get_template_child = reinterpret_cast<decltype(api.get_template_child)>(
-      dlsym(lib, "gtk_widget_get_template_child"));
+      FindSymbol(lib, "gtk_widget_get_template_child"));
   api.set_template_scope = reinterpret_cast<decltype(api.set_template_scope)>(
-      dlsym(lib, "gtk_widget_class_set_template_scope"));
+      FindSymbol(lib, "gtk_widget_class_set_template_scope"));
   api.builder_get_current_object = reinterpret_cast<decltype(api.builder_get_current_object)>(
-      dlsym(lib, "gtk_builder_get_current_object"));
+      FindSymbol(lib, "gtk_builder_get_current_object"));
   api.builder_scope_get_type = reinterpret_cast<decltype(api.builder_scope_get_type)>(
-      dlsym(lib, "gtk_builder_scope_get_type"));
+      FindSymbol(lib, "gtk_builder_scope_get_type"));
   api.ok = api.set_template != nullptr && api.set_template_from_resource != nullptr &&
            api.bind_template_child_full != nullptr && api.set_css_name != nullptr &&
            api.init_template != nullptr && api.get_template_child != nullptr;
   return &api;
-#endif  // _WIN32
 }
 
 // The live JS env stamped on a template-callback scope (refreshed each construct).

--- a/packages/node-gi/node-gi/test/display-gate.mjs
+++ b/packages/node-gi/node-gi/test/display-gate.mjs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// "Can this host open a window?" — one answer, shared by every GTK test.
+//
+// The gate was copy-pasted into 18 test files, in TWO spellings that disagree:
+//
+//     const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;   // 14 files
+//     const displayless = process.platform === 'win32' || process.platform === 'darwin';
+//     const haveDisplay = displayless || !!DISPLAY || !!WAYLAND_DISPLAY;            // 4 files
+//
+// Only the second is true. `DISPLAY`/`WAYLAND_DISPLAY` are X11/Wayland variables;
+// GdkWin32 and GdkQuartz supply the display themselves and set neither. So the
+// first spelling does not read "no display available" off Linux — it reads
+// "skipped", permanently and silently, on every non-Linux host.
+//
+// That is not hypothetical. Every `gtk-template-*` test carried the Linux-only
+// gate, so all four skipped on Windows for as long as they existed, and node-gi's
+// `GetGtkTemplateApi()` shipped an `#ifdef _WIN32` stub that made composite
+// templates throw there. A user found it, not CI: `gjsify showcase
+// three-geometry-teapot --runtime node` on Windows 11 died with "the libgtk-4
+// template API is unavailable". The suite that was supposed to catch it was green
+// because it had not run.
+//
+// A skip is invisible by design, which is exactly why the CONDITION for one may
+// not be guessed per file.
+//
+// NOT YET ADOPTED EVERYWHERE. The 14 files on the Linux-only spelling keep it for
+// now: switching a test's gate makes it START RUNNING on two more platforms, and
+// whether each is actually expected to pass there is a per-test question with a
+// real answer — not a sweep. Convert them as they are looked at, and put the
+// answer in the CI job that runs them.
+
+/**
+ * True where the platform backend supplies a display with no environment
+ * variable to advertise it: GdkWin32 on Windows, GdkQuartz on macOS.
+ */
+export const displayless = process.platform === 'win32' || process.platform === 'darwin';
+
+/** True when this host can realize a GTK surface. */
+export const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;

--- a/packages/node-gi/node-gi/test/gtk-template-callbacks.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template-callbacks.test.mjs
@@ -27,8 +27,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi, unwrap } from '../gi.js';
 import native from '../index.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let GObject;
 let Gtk;

--- a/packages/node-gi/node-gi/test/gtk-template-custom-child-ctor.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template-custom-child-ctor.test.mjs
@@ -26,8 +26,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi, unwrap } from '../gi.js';
 import native from '../index.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let GObject;
 let Gtk;

--- a/packages/node-gi/node-gi/test/gtk-template-signals.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template-signals.test.mjs
@@ -36,8 +36,7 @@ import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 // gjs is the reference. Probe it once; a missing gjs skips ONLY the parity leg (the
 // node-gi golden-value assertions still run).

--- a/packages/node-gi/node-gi/test/gtk-template.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-template.test.mjs
@@ -33,8 +33,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi, unwrap } from '../gi.js';
 import native from '../index.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let GObject;
 let Gtk;

--- a/packages/node-gi/node-gi/test/gtksource-smoke.test.mjs
+++ b/packages/node-gi/node-gi/test/gtksource-smoke.test.mjs
@@ -55,9 +55,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
-
-const displayless = process.platform === 'win32' || process.platform === 'darwin';
-const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let GObject;
 let GLib;

--- a/packages/node-gi/node-gi/test/widgets.test.mjs
+++ b/packages/node-gi/node-gi/test/widgets.test.mjs
@@ -47,9 +47,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
-
-const displayless = process.platform === 'win32' || process.platform === 'darwin';
-const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let Adw;
 let Gtk;

--- a/packages/node-gi/node-gi/test/windowing-interactive.test.mjs
+++ b/packages/node-gi/node-gi/test/windowing-interactive.test.mjs
@@ -34,9 +34,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
-
-const displayless = process.platform === 'win32' || process.platform === 'darwin';
-const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let Adw;
 let Gtk;

--- a/packages/node-gi/node-gi/test/windowing.test.mjs
+++ b/packages/node-gi/node-gi/test/windowing.test.mjs
@@ -37,11 +37,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
 
 // On win32/darwin the platform backend supplies the display; only Linux keys off
 // the X11/Wayland env vars.
-const displayless = process.platform === 'win32' || process.platform === 'darwin';
-const haveDisplay = displayless || !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 
 // Resolve the full GTK/Adw/Graphene stack up front: a missing typelib (a headless
 // dev box without gtk4-devel/libadwaita-devel) SKIPS, not throws.


### PR DESCRIPTION
`gjsify showcase three-geometry-teapot --runtime node` dies on Windows 11 with:

```
node-gi: a Gtk.Widget Template was requested but the libgtk-4 template API could not be resolved (is GTK 4 installed?)
Error: node-gi: the libgtk-4 template API is unavailable
```

…on a machine where GTK 4 is present and working. Reproduced on the Windows 11 test VM with gjsify 0.33.0.

## The cause

`GetGtkTemplateApi()` carried an `#ifdef _WIN32 → return &api`, leaving `api.ok` false, on the reasoning that *"GTK on Windows is Phase 2; the Phase-1 Windows CI proves the display-free core, which never exercises templates."*

That reasoning went stale without the stub noticing. The `--windowing` runtime bundle ships GTK **and libadwaita** for win32-x64, `release.yml` publishes that superset, and `windows-gtk-storybook` renders the entire Libadwaita gallery on it. Only composite templates were still refused — which is most real apps, since every `.blp` goes through `gtk_widget_class_set_template`.

Nothing was missing but nine symbols.

## The fix

The function has **no OS branch left**. Exactly three things vary per OS — the library's leaf name, how an already-loaded handle is obtained, and how a symbol is looked up — so those are spelled per-OS above it and the symbol table is written once:

- `gtk-4-1.dll` (gvsbuild's leaf, what the bundle ships), then MSYS2's `libgtk-4-1.dll`
- `GetModuleHandleA` as the `RTLD_NOLOAD` counterpart — load-bearing, not an optimisation: `requireGi('Gtk','4.0')` already loaded the DLL through the typelib, and asking for a handle to *that* copy is what stops a stray GTK on `PATH` from winning
- `GetProcAddress` for the nine lookups

Same shape as the macOS soname bug this file already documents (`libgtk-4.so.1` does not exist on darwin), from the other side.

## Why CI did not catch it

All four `gtk-template-*` tests gated on `DISPLAY || WAYLAND_DISPLAY` — X11/Wayland variables that GdkWin32 and GdkQuartz **never set**. So they had never run off Linux, on *either* displayless platform. Four other GTK tests already used the platform-aware spelling; the two disagreed and nothing reconciled them.

- the gate is now one shared module (`test/display-gate.mjs`) that states which spelling is true and why, adopted by all eight files that had the platform-aware question
- the template tests now run in **both** the Windows and macOS windowing jobs

The remaining 14 files keep the Linux-only gate on purpose: switching one makes a test *start running* on two more platforms, which is a per-test question with a real answer, not a sweep. The module says so.

## Verification

- Windows failure reproduced on the VM at 0.33.0 (before).
- All eight touched tests pass locally on Linux/Wayland against the published 0.33.0 addon — the POSIX path is behaviour-identical after the refactor.
- The Windows claim itself is CI's to prove: no MSVC/Python on the test VM, so the addon cannot be built there. The new step in `windows-gtk-windowing` is the check.