### PR TITLE
fix(webaudio): construct an AudioContext without GStreamer

### DIFF
--- a/packages/web/webaudio/src/audio-context.ts
+++ b/packages/web/webaudio/src/audio-context.ts
@@ -6,7 +6,7 @@
 // Reference: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext
 
 import GLib from 'gi://GLib?version=2.0';
-import { ensureGstInit } from './gst-init.js';
+import { tryEnsureGstInit } from './gst-init.js';
 import { AudioBuffer } from './audio-buffer.js';
 import { AudioNode } from './audio-node.js';
 import { AudioDestinationNode } from './audio-destination-node.js';
@@ -23,8 +23,37 @@ export class AudioContext {
 
     private _startTime: number;
 
+    /**
+     * CONSTRUCTING A CONTEXT IS NOT PLAYING AUDIO, so a missing audio backend
+     * may not be fatal here. `ensureGstInit()` threw, and it killed whole
+     * applications: on the batteries-included GTK runtime bundles (win32-x64,
+     * darwin) GStreamer is not shipped, and Excalibur's boot-time audio unlock
+     * constructs a context before the first frame — so `gjsify showcase
+     * excalibur-jelly-jumper --runtime node` on Windows died with "Failed to
+     * require Gst 1.0: Typelib file for namespace 'Gst' not found" and the game
+     * never rendered.
+     *
+     * In a browser `new AudioContext()` always succeeds; a page that cannot play
+     * sound still runs. This matches that. The rule was already written down one
+     * level below — `AudioBufferSourceNode.start()` degrades to silent rather
+     * than throw, "a single failed audio node must NEVER crash the whole app" —
+     * it just had not been applied to the constructor.
+     *
+     * Warned ONCE per context and not per sound: a game loading forty samples
+     * would otherwise bury its own output. Everything downstream already copes —
+     * `start()` degrades to silent and `decodeAudioData` rejects with an
+     * `EncodingError`, which is what the spec says a failed decode does.
+     */
     constructor() {
-        ensureGstInit();
+        const reason = tryEnsureGstInit();
+        if (reason !== null) {
+            console.warn(
+                `[webaudio] AudioContext: GStreamer is unavailable, continuing SILENT — ${reason}\n` +
+                    '  Audio needs GStreamer 1.0 with gst-plugins-base. The @gjsify/gtk-runtime-* ' +
+                    'bundles do not ship it, so install it system-wide (Fedora: gstreamer1 ' +
+                    'gstreamer1-plugins-base; Windows: an MSYS2/gvsbuild GStreamer on PATH).',
+            );
+        }
         this._startTime = GLib.get_monotonic_time();
         this.destination = new AudioDestinationNode();
     }

--- a/packages/web/webaudio/src/gst-init.ts
+++ b/packages/web/webaudio/src/gst-init.ts
@@ -34,12 +34,83 @@ function ensureGstAppLoaded(): void {
     }
 }
 
-export function ensureGstInit(): void {
-    if (!initialized) {
-        Gst.init(null);
-        ensureGstAppLoaded();
-        initialized = true;
+/** The GStreamer bring-up. A parameter so its FAILURE branch is executable. */
+export type GstInitializer = () => void;
+
+const defaultInitializer: GstInitializer = () => {
+    Gst.init(null);
+    ensureGstAppLoaded();
+};
+
+/** `null` once GStreamer is up; otherwise why it is not, memoized. */
+let outcome: 'pending' | 'ready' | { failed: string } = 'pending';
+
+/**
+ * Bring GStreamer up and REPORT the outcome instead of throwing.
+ *
+ * Returns `null` on success, or a human-readable reason. Every caller that can
+ * carry on without audio should use this one — see `AudioContext`.
+ *
+ * `initializer` is injectable for the same reason `dirLinkTarget` takes its link
+ * kind: the interesting branch here is the one where GStreamer is ABSENT, and on
+ * a developer's Linux box it never is. A branch nobody can execute is how the
+ * throwing version below shipped as the only entry point.
+ *
+ * The memo applies to the DEFAULT initializer only. A test passing its own is
+ * asking to exercise one specific outcome, and must neither be answered from the
+ * process-wide memo nor poison it.
+ */
+export function tryEnsureGstInit(initializer: GstInitializer = defaultInitializer): string | null {
+    const memoize = initializer === defaultInitializer;
+    if (memoize && outcome !== 'pending') return outcome === 'ready' ? null : outcome.failed;
+    try {
+        initializer();
+        if (memoize) {
+            outcome = 'ready';
+            initialized = true;
+        }
+        return null;
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        if (memoize) outcome = { failed: reason };
+        return reason;
     }
+}
+
+/**
+ * TEST SEAM — answer the next bring-up with `reason` (or `null` for success)
+ * without touching the real GStreamer, and `undefined` to forget again.
+ *
+ * The injectable initializer above covers `tryEnsureGstInit` itself, but not its
+ * CALLERS: `new AudioContext()` has no initializer to hand it, and "constructing
+ * a context on a host with no GStreamer does not throw" is the exact property
+ * whose absence killed the game. Priming the memo is what lets that be asserted
+ * on a developer machine, where GStreamer is always installed.
+ */
+export function primeGstOutcomeForTests(reason: string | null | undefined): void {
+    if (reason === undefined) {
+        outcome = 'pending';
+        initialized = false;
+        return;
+    }
+    outcome = reason === null ? 'ready' : { failed: reason };
+    initialized = reason === null;
+}
+
+/**
+ * Bring GStreamer up, or throw.
+ *
+ * For the callers that genuinely cannot proceed without it — decoding bytes,
+ * building a playback pipeline. Constructing an `AudioContext` is NOT one of
+ * them, and treating it as one is what killed whole applications: on the
+ * batteries-included GTK runtime bundles (win32-x64, darwin) GStreamer is not
+ * shipped at all, so `new AudioContext()` threw "Failed to require Gst 1.0"
+ * during Excalibur's boot-time audio unlock and the game never rendered a frame.
+ */
+export function ensureGstInit(): void {
+    if (initialized) return;
+    const reason = tryEnsureGstInit();
+    if (reason !== null) throw new Error(reason);
 }
 
 export { Gst };

--- a/packages/web/webaudio/src/html-audio-element.ts
+++ b/packages/web/webaudio/src/html-audio-element.ts
@@ -3,7 +3,7 @@
 //
 // Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement
 
-import { ensureGstInit, Gst } from './gst-init.js';
+import { tryEnsureGstInit, Gst } from './gst-init.js';
 import { stopPipeline, trackPipeline } from './gst-teardown.js';
 import type Gst1 from '@girs/gst-1.0';
 
@@ -41,7 +41,15 @@ export class HTMLAudioElement {
     play(): Promise<void> {
         if (!this.src) return Promise.resolve();
 
-        ensureGstInit();
+        // Same rule as AudioContext and AudioBufferSourceNode.start(): no audio
+        // backend means no sound, not a thrown error. `play()` returns a promise
+        // in the DOM, and a page that ignores it — most do — would otherwise take
+        // an unhandled rejection for a missing optional subsystem.
+        const reason = tryEnsureGstInit();
+        if (reason !== null) {
+            console.warn(`[webaudio] Audio.play: GStreamer is unavailable, staying silent — ${reason}`);
+            return Promise.resolve();
+        }
         this._cleanup();
 
         this._pipeline = Gst.ElementFactory.make('playbin', 'player');

--- a/packages/web/webaudio/src/webaudio.spec.ts
+++ b/packages/web/webaudio/src/webaudio.spec.ts
@@ -14,6 +14,7 @@ import { AudioBufferSourceNode } from './audio-buffer-source-node.js';
 import { AudioDestinationNode } from './audio-destination-node.js';
 import { HTMLAudioElement } from './html-audio-element.js';
 import { livePipelineCount, stopAllPipelines } from './gst-teardown.js';
+import { primeGstOutcomeForTests, tryEnsureGstInit } from './gst-init.js';
 
 /** Generate a minimal WAV ArrayBuffer (mono, 16-bit PCM, 440Hz sine) */
 function createTestWav(durationSec = 0.1, sampleRate = 44100): ArrayBuffer {
@@ -419,6 +420,60 @@ export default async () => {
             // (`@gjsify/unit` exits through `system.exit()`, which emits neither).
             stopAllPipelines();
             expect(livePipelineCount()).toBe(0);
+        });
+    });
+
+    // The host WITHOUT GStreamer — the one this suite could never be run on.
+    //
+    // Every test above needs GStreamer, so the whole file only ever ran where it
+    // is installed, and the branch that matters when it is NOT (the batteries-
+    // included GTK bundles ship no Gst at all) went unexecuted until a user hit
+    // it: `gjsify showcase excalibur-jelly-jumper --runtime node` on Windows 11
+    // died in `new AudioContext()` before the game rendered a frame.
+    //
+    // `tryEnsureGstInit` takes its initializer so that host is reachable from
+    // this one: a throwing initializer IS a machine without GStreamer, as far as
+    // everything downstream can tell.
+    await describe('no GStreamer on this host', async () => {
+        const absent = () => {
+            throw new Error("Failed to require Gst 1.0: Typelib file for namespace 'Gst' not found");
+        };
+
+        await it('reports the reason instead of throwing', () => {
+            const reason = tryEnsureGstInit(absent);
+            expect(typeof reason).toBe('string');
+            expect(reason).toContain('Gst 1.0');
+        });
+
+        await it('answers null when the bring-up succeeds', () => {
+            expect(tryEnsureGstInit(() => {})).toBeNull();
+        });
+
+        await it('does not poison the process-wide memo', () => {
+            // A caller passing its own initializer is asking about ONE outcome.
+            // If that answer were cached, this suite would leave every later
+            // `AudioContext` in the process convinced audio is unavailable.
+            tryEnsureGstInit(absent);
+            expect(tryEnsureGstInit()).toBeNull();
+        });
+
+        // THE REGRESSION ITSELF. `new AudioContext()` used to call the throwing
+        // bring-up, so on a host with no GStreamer it took the whole application
+        // down — Excalibur constructs one during its boot-time audio unlock, so
+        // the jelly-jumper showcase never reached its first frame on Windows.
+        await it('still constructs an AudioContext, and it is usable', () => {
+            primeGstOutcomeForTests("Failed to require Gst 1.0: Typelib file for namespace 'Gst' not found");
+            try {
+                const ctx = new AudioContext();
+                expect(ctx.destination).toBeDefined();
+                // Silent, but not broken: the graph still builds, and a source
+                // that cannot play must still settle its `onended` awaiter.
+                expect(ctx.createGain()).toBeDefined();
+                expect(ctx.createBufferSource()).toBeDefined();
+                expect(ctx.currentTime >= 0).toBe(true);
+            } finally {
+                primeGstOutcomeForTests(undefined);
+            }
         });
     });
 };


### PR DESCRIPTION
`gjsify showcase excalibur-jelly-jumper --runtime node` dies on Windows 11 with an **uncaught** exception before the game renders a frame:

```
Error: Failed to require Gst 1.0: Typelib file for namespace 'Gst', version '1.0' not found
    at ensureGstInit (…)
    at new AudioContext (…)
    at AudioContextFactory.create (…)
    at new Sound (…)
```

The batteries-included GTK runtime bundles (`@gjsify/gtk-runtime-win32-x64`, both darwin ones) ship **no GStreamer at all** — it is in none of their seed sets — and Excalibur constructs a context during its boot-time audio unlock. So a missing *optional* subsystem took the whole application down.

## The rule already existed one level below

`AudioBufferSourceNode.start()` catches a failed pipeline and continues silent, with the reason spelled out in its own comment: *"a single failed audio node must NEVER crash the whole app (Excalibur's audio-context unlock plays a 1-sample buffer at boot, so an uncaught throw here kills the game before it renders)."*

That rule had simply never been applied to the constructor. In a browser `new AudioContext()` always succeeds; a page that cannot play sound still runs.

## Changes

- `tryEnsureGstInit()` reports the reason instead of throwing. `ensureGstInit()` stays for callers that genuinely cannot proceed — decoding bytes, building a playback pipeline.
- `AudioContext` warns **once** (a game loading forty samples would otherwise bury its own output) and names both what is missing and how to install it.
- `Audio.play()` degrades the same way rather than rejecting a promise most callers ignore.
- `decodeAudioData` unchanged — it already rejects with an `EncodingError`, which is what a failed decode *is*.

## The branch is now executable

This suite could only ever run where GStreamer is installed, which is why the absent case was never tested. `tryEnsureGstInit` takes its initializer (same idiom as `dirLinkTarget`'s link kind), and `primeGstOutcomeForTests` answers the memo for callers that have no initializer to hand it — `new AudioContext()` among them.

The regression test constructs a context on a primed "no Gst" host. A/B checked: restoring the throwing constructor fails it (and takes 4 more tests with it). 70/70 pass with the fix, under GJS.

## Verified on the Windows 11 VM

Rebuilt bundle staged into the dlx cache and run: the crash is gone, the warning prints once, execution continues.

**It still does not reach a window there** — it hits `node-gi: the libgtk-4 template API could not be resolved` next, which is #1088. Two independent defects behind one broken showcase; this PR fixes the first.