### PR TITLE
fix(cli): teach foreach to select a dependency closure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -408,6 +408,18 @@ jobs:
           # this same value; they are unaffected by the token spelling (they
           # matched the quoted form too — which is precisely why the gates kept
           # working while the build itself did nothing).
+          #
+          # `--with-dependencies` on the selective build below is what makes the
+          # restored cache safe to sit on. Without it the build rebuilt only the
+          # affected set and trusted every unchanged dependency's `lib/` — and a
+          # cache can be COMPLETE without being CURRENT, so one cancelled build
+          # on `main` left later PRs compiling against pre-merge outputs and
+          # failing with errors naming a package they never touched (#1080). The
+          # warmth probe below cannot catch that and no probe can: a stale
+          # archive is perfectly complete. It goes AFTER the excludes, so the
+          # closure does not walk out through `@gjsify/website` (which
+          # prod-depends every showcase); measured on the #1080 change set, that
+          # ordering is 5 extra packages instead of 56.
           FULL: ${{ needs.changes.outputs.global == 'true' || needs.changes.outputs.global == '' || needs.changes.outputs.include-args == '' || steps.buildwarm.outputs.warm != 'true' || needs.changes.outputs.run-e2e == 'true' || contains(needs.changes.outputs.include-args, '@gjsify/example-') }}
           INCLUDE_ARGS: ${{ needs.changes.outputs.include-args }}
         run: |
@@ -417,7 +429,7 @@ jobs:
               gjsify run build
             else
               echo \"[ci] selective build: \$INCLUDE_ARGS\"
-              gjsify foreach build \$INCLUDE_ARGS -tp --no-private --exclude \"@girs/*\" --exclude \"@gjsify/example-*\" --exclude \"@gjsify/website\"
+              gjsify foreach build \$INCLUDE_ARGS --with-dependencies -tp --no-private --exclude \"@girs/*\" --exclude \"@gjsify/example-*\" --exclude \"@gjsify/website\"
             fi
           '"
 

--- a/packages/infra/cli/src/commands/foreach.ts
+++ b/packages/infra/cli/src/commands/foreach.ts
@@ -15,6 +15,7 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { cpus } from 'node:os';
 import type { Command } from '../types/index.js';
 import {
+    affectedClosure,
     buildDependencyGraph,
     discoverWorkspaces,
     filterWorkspaces,
@@ -186,6 +187,7 @@ interface ForeachOptions {
     'topological-dev'?: boolean;
     include?: string[];
     exclude?: string[];
+    'with-dependencies'?: boolean;
     shard?: string;
     private?: boolean;
     verbose?: boolean;
@@ -243,6 +245,13 @@ export const foreachCommand: Command<unknown, ForeachOptions> = {
                 description: 'Glob pattern to exclude workspaces by name (repeatable).',
                 type: 'string',
                 array: true,
+            })
+            .option('with-dependencies', {
+                description:
+                    "Also select everything the filtered set DEPENDS ON (production deps; add --topological-dev for devDependencies). --include only filters and --topological only orders, so neither can say 'and the packages these need'. Excludes are re-applied afterwards.",
+                type: 'boolean',
+                alias: 'd',
+                default: false,
             })
             .option('private', {
                 // Yargs auto-negates `--no-private` to `private=false`, so the
@@ -341,6 +350,36 @@ export const foreachCommand: Command<unknown, ForeachOptions> = {
             exclude: args.exclude,
             noPrivate: args.private === false,
         });
+
+        // `--with-dependencies` — the third thing a selection can mean, and the
+        // one that had no spelling. `--include` FILTERS and `--topological` only
+        // ORDERS what was already selected, so "and everything these need" was
+        // inexpressible, and CI's selective build simply assumed every
+        // dependency's restored `lib/` was current. A build cache can be
+        // complete without being current: caches are branch-scoped, so ONE
+        // cancelled build on `main` left later PRs compiling against pre-merge
+        // outputs, failing with compiler errors that named a package the PR
+        // never touched (#1080). No warmth probe can see that — a stale archive
+        // is perfectly complete — so freshness has to come from the selection.
+        //
+        // AFTER the filter, not before: expanding the unfiltered set would walk
+        // out through the very packages the caller excluded (CI excludes
+        // `@gjsify/website`, which prod-depends every showcase — expanding first
+        // pulled in 56 extra packages and undid selective CI). Excludes are then
+        // re-applied, because a dependency may be something the caller took out
+        // on purpose and expansion must not smuggle it back in.
+        if (args['with-dependencies'] === true) {
+            const includeDev = args['topological-dev'] === true;
+            const forward = buildDependencyGraph(allWorkspaces, { includeDev });
+            const closure = affectedClosure(
+                forward,
+                selected.map((ws) => ws.name),
+            );
+            selected = filterWorkspaces(
+                allWorkspaces.filter((ws) => closure.has(ws.name)),
+                { exclude: args.exclude, noPrivate: args.private === false },
+            );
+        }
 
         // In script mode, only run on workspaces that actually have the
         // requested script — yarn does this too, otherwise every project

--- a/tests/e2e/foreach-command/run.mjs
+++ b/tests/e2e/foreach-command/run.mjs
@@ -260,6 +260,60 @@ describe('gjsify foreach + workspace (Phase D.4)', { timeout: 60_000 }, () => {
         assert.ok(!existsSync(join(root, 'marks', '@test-app.txt')), 'app should be excluded');
     });
 
+    // `--with-dependencies` — the third thing a selection can mean (#1080).
+    //
+    // `--include` FILTERS and `--topological` only ORDERS what was already
+    // selected, so "and everything these need" had no spelling at all. CI's
+    // selective build therefore rebuilt only the changed closure and trusted
+    // every dependency's restored `lib/` — and a build cache can be complete
+    // without being current, so one cancelled build on `main` made later PRs
+    // fail with compiler errors naming a package they never touched.
+
+    it('foreach --with-dependencies pulls in what the selection depends on', async () => {
+        rmSync(join(root, 'marks'), { recursive: true, force: true });
+        mkdirSync(join(root, 'marks'), { recursive: true });
+        // app → core → utils. Selecting app alone is exactly the case that
+        // silently trusted a stale core/lib and utils/lib.
+        const r = await runCli(
+            cliEntry,
+            ['foreach', 'mark', '--include', '@test/app', '--with-dependencies', '--topological'],
+            { cwd: root },
+        );
+        assert.equal(r.status, 0, `with-dependencies failed: ${r.stderr}`);
+        assert.ok(existsSync(join(root, 'marks', '@test-app.txt')), 'app mark missing');
+        assert.ok(existsSync(join(root, 'marks', '@test-core.txt')), 'core (direct dep) missing');
+        assert.ok(existsSync(join(root, 'marks', '@test-utils.txt')), 'utils (transitive dep) missing');
+    });
+
+    it('foreach without --with-dependencies still selects only the filter', async () => {
+        // The A/B for the test above: the flag has to be what adds them.
+        rmSync(join(root, 'marks'), { recursive: true, force: true });
+        mkdirSync(join(root, 'marks'), { recursive: true });
+        const r = await runCli(cliEntry, ['foreach', 'mark', '--include', '@test/app'], { cwd: root });
+        assert.equal(r.status, 0, `include-only failed: ${r.stderr}`);
+        assert.ok(existsSync(join(root, 'marks', '@test-app.txt')));
+        assert.ok(!existsSync(join(root, 'marks', '@test-core.txt')), 'core must NOT be selected without the flag');
+    });
+
+    it('foreach --with-dependencies re-applies --exclude', async () => {
+        // Order is the whole design. The expansion runs AFTER the filter, so it
+        // cannot walk out through a package the caller removed — and a dependency
+        // that IS excluded must not be smuggled back in by the expansion. In CI
+        // that ordering is the difference between 5 extra packages and 56:
+        // `@gjsify/website` is excluded there and prod-depends every showcase.
+        rmSync(join(root, 'marks'), { recursive: true, force: true });
+        mkdirSync(join(root, 'marks'), { recursive: true });
+        const r = await runCli(
+            cliEntry,
+            ['foreach', 'mark', '--include', '@test/app', '--with-dependencies', '--exclude', '@test/utils'],
+            { cwd: root },
+        );
+        assert.equal(r.status, 0, `with-dependencies + exclude failed: ${r.stderr}`);
+        assert.ok(existsSync(join(root, 'marks', '@test-app.txt')));
+        assert.ok(existsSync(join(root, 'marks', '@test-core.txt')));
+        assert.ok(!existsSync(join(root, 'marks', '@test-utils.txt')), 'an excluded dependency must stay excluded');
+    });
+
     it('foreach --parallel prefixes stdout with [<workspace-name>]', async () => {
         const r = await runCli(cliEntry, ['foreach', 'echo', '--parallel'], { cwd: root });
         assert.equal(r.status, 0, `parallel failed: ${r.stderr}`);


### PR DESCRIPTION
Closes #1080.

CI's selective build rebuilt only the affected closure and trusted the restored cache for every unchanged dependency. **A build cache can be COMPLETE without being CURRENT.** Caches are branch-scoped, so one cancelled build on `main` left every later selective PR compiling against pre-merge outputs:

```
[ci] selective build: --include @gjsify/adwaita-storybook --include @gjsify/adwaita-web --include @gjsify/website
[@gjsify/adwaita-web] src/elements/adw-spinner.ts:35:5 - error TS2305:
  Module '"@gjsify/adwaita-core"' has no exported member 'spinnerArc'.
… Found 24 errors in 6 files.
```

Every one of those 24 errors named an export a **merged** commit had added to `@gjsify/adwaita-core` — a package the PR never touched and the build never rebuilt. The failure names the innocent package, which is the expensive part.

No probe can catch this. A stale archive is perfectly complete, and presence is all a probe can ask — that is the third iteration of one shape, and the step's own comments record the first two, both presence checks. So freshness comes from the **selection** instead.

## `--with-dependencies`

`--include` only FILTERS and `--topological` only ORDERS what was already selected, so "and everything these need" had no spelling at all. `foreach` now takes `--with-dependencies` / `-d` — the same flag name `gjsify workspace` already uses for the same idea — and main.yml's selective build passes it.

## Order is the design

It expands **after** the filter. Expanding the unfiltered set walks out through packages the caller excluded: CI excludes `@gjsify/website`, which prod-depends every showcase. Measured on the #1080 change set:

| | packages built |
|---|---|
| expand first | 56 extra |
| filter, then expand | **5 extra** (`adwaita-core`, `adwaita-fonts`, `adwaita-icons`, `stories`, `storybook-core`) |

Excludes are re-applied after the expansion too, so a dependency the caller deliberately removed cannot be smuggled back in.

Production dependencies only, matching `--topological`; `--topological-dev` widens both together.

## Tests

Three e2e cases on the existing `app → core → utils` fixture: the closure is pulled in, it is **not** pulled in without the flag (the A/B), and an excluded dependency stays excluded. 21/21 green.

## Rejected

Requiring an exact cache-key hit for the selective path. The primary key hashes every package source, so any PR touching any source misses it — that turns every PR into a full build, which is what the selective path exists to avoid.