### PR TITLE
test(node-gi): make every GTK gate state what it actually requires

### DIFF
--- a/packages/node-gi/node-gi/test/adw-smoke.test.mjs
+++ b/packages/node-gi/node-gi/test/adw-smoke.test.mjs
@@ -35,8 +35,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 // Resolve the Adw + GTK stack up front: a missing Adw-1 / Gtk-4.0 typelib (a
 // headless dev box without libadwaita-devel) must SKIP, not throw.

--- a/packages/node-gi/node-gi/test/cairo-drawfunc.test.mjs
+++ b/packages/node-gi/node-gi/test/cairo-drawfunc.test.mjs
@@ -18,8 +18,7 @@ import assert from 'node:assert/strict';
 
 import { requireGi } from '../gi.js';
 import cairo from '../cairo.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 let Gtk;
 let Gio;

--- a/packages/node-gi/node-gi/test/canvas2d-bridge.test.mjs
+++ b/packages/node-gi/node-gi/test/canvas2d-bridge.test.mjs
@@ -46,6 +46,7 @@ import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { haveDisplay } from './display-gate.mjs';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 // The fixture lives OUTSIDE test/ on purpose: node --test's default glob
@@ -53,8 +54,6 @@ const here = fileURLToPath(new URL('.', import.meta.url));
 // unbundled gi:// source directly, which fails to resolve.
 const pkgRoot = join(here, '..');
 const fixture = join(pkgRoot, 'fixtures', 'canvas2d-bridge-app.ts');
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 
 // Locate the workspace `gjsify` CLI: an explicit override, else the nearest
 // node_modules/.bin/gjsify walking up from here, else `gjsify` on PATH.

--- a/packages/node-gi/node-gi/test/display-gate.mjs
+++ b/packages/node-gi/node-gi/test/display-gate.mjs
@@ -23,11 +23,12 @@
 // A skip is invisible by design, which is exactly why the CONDITION for one may
 // not be guessed per file.
 //
-// NOT YET ADOPTED EVERYWHERE. The 14 files on the Linux-only spelling keep it for
-// now: switching a test's gate makes it START RUNNING on two more platforms, and
-// whether each is actually expected to pass there is a per-test question with a
-// real answer — not a sweep. Convert them as they are looked at, and put the
-// answer in the CI job that runs them.
+// EVERY GTK TEST ASKS THIS ONE NOW, with exactly two deliberate exceptions:
+// `webgl-glarea` and `excalibur-webgl` need a realizable GL CONTEXT, not merely a
+// display. That is a different question, so they ask it themselves and say so.
+// The point was never "one gate everywhere" — it is that a gate must state the
+// thing it actually requires. Both of those reached the right OUTCOME through the
+// wrong CLAIM, and a wrong claim keeps being right only by accident.
 
 /**
  * True where the platform backend supplies a display with no environment

--- a/packages/node-gi/node-gi/test/event-bridge.test.mjs
+++ b/packages/node-gi/node-gi/test/event-bridge.test.mjs
@@ -58,6 +58,7 @@ import { existsSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { haveDisplay } from './display-gate.mjs';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 // The fixture lives OUTSIDE test/ on purpose: node --test's default glob
@@ -65,8 +66,6 @@ const here = fileURLToPath(new URL('.', import.meta.url));
 // unbundled gi:// source directly, which fails to resolve.
 const pkgRoot = join(here, '..');
 const fixture = join(pkgRoot, 'fixtures', 'event-bridge-app.ts');
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 
 // Locate the workspace `gjsify` CLI: an explicit override, else the nearest
 // node_modules/.bin/gjsify walking up from here, else `gjsify` on PATH.

--- a/packages/node-gi/node-gi/test/excalibur-webgl.test.mjs
+++ b/packages/node-gi/node-gi/test/excalibur-webgl.test.mjs
@@ -60,7 +60,16 @@ const pkgRoot = join(here, '..');
 const repoRoot = join(pkgRoot, '..', '..', '..');
 const fixture = join(pkgRoot, 'fixtures', 'excalibur-webgl-app.ts');
 
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+// A REALIZABLE GL CONTEXT, not merely a display — a different question from the
+// one `display-gate.mjs` answers, and the reason this stays Linux-only while the
+// plain GTK tests no longer are. The Linux CI provides GL through Xvfb +
+// llvmpipe; the Windows and macOS runners have no GPU and force
+// `GSK_RENDERER=cairo` for exactly that reason, so there is nothing here to
+// realize against. Keyed on the platform EXPLICITLY: the old gate reached the
+// same outcome by testing `DISPLAY`/`WAYLAND_DISPLAY`, which GdkWin32 and
+// GdkQuartz never set — it claimed a Mac had no display, which is false, and
+// would have silently stayed "skipped" even once GL was available there.
+const haveGl = process.platform === 'linux' && (!!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY);
 
 // The committed gwebgl Vala prebuild (typelib + .so) @gjsify/webgl ships —
 // in its per-target package since ADR 0017, a SIBLING of the bridge.
@@ -99,7 +108,7 @@ function findGjsify() {
     }
 }
 
-const gjsify = haveDisplay ? findGjsify() : null;
+const gjsify = haveGl ? findGjsify() : null;
 
 // The fixture bundles excalibur + the full @gjsify/webgl TS stack — both must
 // resolve from the monorepo (a bare node-gi tree skips cleanly).
@@ -112,8 +121,8 @@ function resolvable(spec) {
     }
 }
 
-const skip = !haveDisplay
-    ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+const skip = !haveGl
+    ? 'no GL-capable display (needs Linux + DISPLAY / WAYLAND_DISPLAY)'
     : !haveGwebgl
       ? `Gwebgl prebuild missing (${gwebglDir})`
       : !gjsify

--- a/packages/node-gi/node-gi/test/gtk-smoke.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-smoke.test.mjs
@@ -28,8 +28,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
-
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+import { haveDisplay } from './display-gate.mjs';
 
 // Resolve the GTK stack up front: a missing Gtk-4.0 typelib (a headless dev box
 // with no gtk4-devel) must SKIP, not throw. The GLib/Gio deps come along too.

--- a/packages/node-gi/node-gi/test/interface-props.test.mjs
+++ b/packages/node-gi/node-gi/test/interface-props.test.mjs
@@ -31,6 +31,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
 
 const Gio = requireGi('Gio', '2.0');
 
@@ -49,7 +50,6 @@ try {
 } catch {
     // Adwaita is optional — the ComboRow repro self-skips without it.
 }
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
 const widgetSkip =
     gtkSkip ||

--- a/packages/node-gi/node-gi/test/strv-construct.test.mjs
+++ b/packages/node-gi/node-gi/test/strv-construct.test.mjs
@@ -28,6 +28,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
 
 const GLib = requireGi('GLib', '2.0');
 const Gio = requireGi('Gio', '2.0');
@@ -41,7 +42,6 @@ try {
 } catch (err) {
     gtkLoadError = err;
 }
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
 const widgetSkip = gtkSkip || (!haveDisplay ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)' : false);
 

--- a/packages/node-gi/node-gi/test/strv-read.test.mjs
+++ b/packages/node-gi/node-gi/test/strv-read.test.mjs
@@ -24,6 +24,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { requireGi } from '../gi.js';
+import { haveDisplay } from './display-gate.mjs';
 
 const Gio = requireGi('Gio', '2.0');
 
@@ -36,7 +37,6 @@ try {
 } catch (err) {
     gtkLoadError = err;
 }
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
 const gtkSkip = gtkLoadError ? `Gtk-4.0 typelib unavailable: ${gtkLoadError.message}` : false;
 const widgetSkip = gtkSkip || (!haveDisplay ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)' : false);
 

--- a/packages/node-gi/node-gi/test/webgl-glarea.test.mjs
+++ b/packages/node-gi/node-gi/test/webgl-glarea.test.mjs
@@ -45,7 +45,16 @@ const repoRoot = join(pkgRoot, '..', '..', '..');
 const fixture = join(pkgRoot, 'fixtures', 'webgl-glarea-app.ts');
 const bridgeFixture = join(pkgRoot, 'fixtures', 'webgl-bridge-app.ts');
 
-const haveDisplay = !!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY;
+// A REALIZABLE GL CONTEXT, not merely a display — a different question from the
+// one `display-gate.mjs` answers, and the reason this stays Linux-only while the
+// plain GTK tests no longer are. The Linux CI provides GL through Xvfb +
+// llvmpipe; the Windows and macOS runners have no GPU and force
+// `GSK_RENDERER=cairo` for exactly that reason, so there is nothing here to
+// realize against. Keyed on the platform EXPLICITLY: the old gate reached the
+// same outcome by testing `DISPLAY`/`WAYLAND_DISPLAY`, which GdkWin32 and
+// GdkQuartz never set — it claimed a Mac had no display, which is false, and
+// would have silently stayed "skipped" even once GL was available there.
+const haveGl = process.platform === 'linux' && (!!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY);
 
 // The committed gwebgl Vala prebuild (typelib + .so) @gjsify/webgl ships —
 // puts Gwebgl-0.1 on GI_TYPELIB_PATH/LD_LIBRARY_PATH for BOTH runtimes.
@@ -81,10 +90,10 @@ function findGjsify() {
     }
 }
 
-const gjsify = haveDisplay ? findGjsify() : null;
+const gjsify = haveGl ? findGjsify() : null;
 
-const skip = !haveDisplay
-    ? 'no display (DISPLAY / WAYLAND_DISPLAY unset)'
+const skip = !haveGl
+    ? 'no GL-capable display (needs Linux + DISPLAY / WAYLAND_DISPLAY)'
     : !haveGwebgl
       ? `Gwebgl prebuild missing (${gwebglDir})`
       : !gjsify


### PR DESCRIPTION
Follow-up to #1088, which found the class rather than just the bug.

Four `gtk-template-*` tests gated on `DISPLAY || WAYLAND_DISPLAY` — X11/Wayland variables that **GdkWin32 and GdkQuartz never set**. So they had never run off Linux, on *either* displayless platform, while node-gi shipped an `#ifdef _WIN32` template stub that made composite templates throw there. A user found that, not CI, because a skip is invisible by design.

Ten more files carried the same wrong gate.

## Eight now ask the shared question

`adw-smoke`, `gtk-smoke`, `cairo-drawfunc`, `canvas2d-bridge`, `event-bridge`, `interface-props`, `strv-read`, `strv-construct` — plain GTK/GObject tests, nothing X11-specific about any of them.

## Two deliberately do not — and that is the point

`webgl-glarea` and `excalibur-webgl` need a realizable **GL context**, not merely a display. The Linux CI provides one through Xvfb + llvmpipe; the Windows and macOS runners have no GPU and force `GSK_RENDERER=cairo` for exactly that reason.

They now key on the platform explicitly, and their skip message says `no GL-capable display` instead of claiming a Mac has no display at all. **Same outcome as before, reached by a true statement.** The old gate was right by accident, and would have stayed "skipped" even once GL became available there — which is how the template stub survived to a release.

The point was never "one gate everywhere". It is that a gate must state the thing it actually requires.

## Verification

22 tests pass locally across the eight converted files.

`canvas2d-bridge` fails on this machine with an unrelated `raf: idle` vs `raf: ticked` mismatch — **reproduced on unmodified `main`**, so it is not from this change. Flagging it rather than quietly leaving it out.