### PR TITLE
feat(node-gi): ship GStreamer in the batteries-included runtime bundles

### DIFF
--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1868,12 +1868,16 @@ jobs:
           # ("Doesn't match target Visual Studio version of 17") and failed with
           # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
           # same way at the next bump; vswhere already knows the answer.
+          # `--vs-ver` takes gvsbuild's own names (vs2022, vs2026), NOT the major
+          # version — 18 was rejected with "Choose from: vs2013 … vs2026".
+          # `catalog_productLineVersion` is exactly that year, so vswhere answers it
+          # directly and no table has to be kept in sync with the runner image.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
-          Write-Host "gvsbuild --vs-ver $vsMajor"
+          $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
+          Write-Host "gvsbuild --vs-ver $vsVer""
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --vs-ver $vsMajor --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1831,7 +1831,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\gtk-build\gtk\x64\release
-          key: gvsbuild-gtk4-gst-${{ env.GVSBUILD_VERSION }}-x64-v1
+          key: gvsbuild-gtk4-gst-gi-${{ env.GVSBUILD_VERSION }}-x64-v2
 
       # Build-time closure SOURCE only. Verbatim from the `windows` job.
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
@@ -1915,7 +1915,15 @@ jobs:
           # an absent libvpx simply disables the vpx plugin — which is the state we
           # want anyway. -good is still built, for the parsers and decoders the audio
           # path genuinely needs: wavparse, flac, mpg123, autodetect.
-          gvsbuild build --configuration release --vs-ver $vsVer --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          # `--enable-gi` IS THE WHOLE POINT and defaults to FALSE. gvsbuild's
+          # gstreamer projects gate introspection on it — without it they pass
+          # `-Dintrospection=disabled`, so the build succeeds and produces no
+          # .gir/.typelib at all. Measured: a complete 16-minute GStreamer build
+          # whose prefix contained zero Gst typelibs. The assertion below is what
+          # caught it, at the prefix, instead of three jobs later as "no element
+          # decodebin" — typelibs are the only reason we build this from source
+          # rather than lifting a binary.
+          gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1236,7 +1236,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
     steps:
       - name: Install GTK4 + Adwaita + GtkSource + icons + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
+        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer
 
       - name: Use Node.js 24
         uses: actions/setup-node@v4
@@ -1815,7 +1815,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\gtk-build\gtk\x64\release
-          key: gvsbuild-gtk4-${{ env.GVSBUILD_VERSION }}-x64-v1
+          key: gvsbuild-gtk4-gst-${{ env.GVSBUILD_VERSION }}-x64-v1
 
       # Build-time closure SOURCE only. Verbatim from the `windows` job.
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
@@ -1834,6 +1834,53 @@ jobs:
       # glib-compile-schemas / gtk4-update-icon-cache / fc-cache) from <prefix>/bin,
       # which link glib/gio DLLs — so <prefix>/bin must be on PATH. (The DLL closure
       # walk uses dumpbin, located via vswhere on the VS2022 image.)
+      # GSTREAMER, BUILT FROM SOURCE INTO THE SAME PREFIX.
+      #
+      # There is no prebuilt Windows GStreamer we can lift. The gvsbuild release
+      # publishes exactly two assets — GTK3_Gvsbuild and GTK4_Gvsbuild — and neither
+      # carries any of it: measured on the published @gjsify/gtk-runtime-win32-x64
+      # tarball, all 40 typelibs present and not one of them GStreamer's, which is why
+      # `new AudioContext()` threw `Failed to require Gst 1.0` on a machine whose GTK
+      # worked perfectly. gstreamer.freedesktop.org ships an installer .exe for x64,
+      # but it dropped the separate devel package, so whether it carries typelibs at
+      # all is unverified — and an installer is the wrong thing to extract in CI.
+      #
+      # gvsbuild DOES define gstreamer/orc/gst-plugins-base/-good with
+      # `-Dintrospection=enabled`, so building them is the path where the typelibs are
+      # guaranteed and the ABI matches everything already in this prefix.
+      #
+      # IT WILL REBUILD DEPENDENCIES. The extracted zip carries no gvsbuild build
+      # markers, so gvsbuild considers glib/gobject-introspection unbuilt and makes
+      # them again from source. That is the cost of not having a prebuilt binary, and
+      # it is why the cache key covers the GStreamer projects too and the timeout is
+      # generous — on a cache hit this whole step is skipped.
+      - name: Build GStreamer with gvsbuild (into the GTK prefix)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        timeout-minutes: 150
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python -m pip install --upgrade pipx
+          python -m pipx ensurepath
+          python -m pipx install "gvsbuild==$env:GVSBUILD_VERSION"
+          # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
+          # the bundle builder's single closure walk sees both.
+          gvsbuild build --configuration release --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+
+      - name: Assert GStreamer landed in the prefix (typelibs + plugins)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # The two the bundle asserts, and the plugin dir the elements come from.
+          # Fail HERE rather than three jobs later with "no element decodebin".
+          foreach ($t in @('Gst-1.0.typelib', 'GstApp-1.0.typelib')) {
+            $p = "$env:GTK_PREFIX\lib\girepository-1.0\$t"
+            if (-not (Test-Path $p)) { Write-Host "MISSING $p"; exit 1 }
+          }
+          $plugins = Get-ChildItem "$env:GTK_PREFIX\lib\gstreamer-1.0" -Filter *.dll -ErrorAction SilentlyContinue
+          if (-not $plugins) { Write-Host "no GStreamer plugins in the prefix"; exit 1 }
+          Write-Host "GStreamer: $($plugins.Count) plugin DLL(s) in the prefix"
+
       - name: Put GTK on PATH (for the bundle-data tools)
         shell: pwsh
         run: '"$env:GTK_PREFIX\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8'

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1903,7 +1903,19 @@ jobs:
           Write-Host "Visual Studio $vsMajor -> gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          # `--skip libvpx`, and it is the audio-path rule applied to the BUILD
+          # rather than only to the payload. gst-plugins-good declares exactly one
+          # dependency beyond -base, and it is libvpx: VP8/VP9, i.e. video, which
+          # gst-plugins.mjs already excludes from what ships. We were spending 15+
+          # minutes compiling a codec whose output is thrown away.
+          #
+          # It also never once succeeded. On windows-latest its configure has no
+          # `x86_64-win64-vs18` target; on windows-2022 it gets further and dies
+          # moving `x64/vpxmd.lib`. GStreamer's meson features default to `auto`, so
+          # an absent libvpx simply disables the vpx plugin — which is the state we
+          # want anyway. -good is still built, for the parsers and decoders the audio
+          # path genuinely needs: wavparse, flac, mpg123, autodetect.
+          gvsbuild build --configuration release --vs-ver $vsVer --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1863,9 +1863,17 @@ jobs:
           python -m pip install --upgrade pipx
           python -m pipx ensurepath
           python -m pipx install "gvsbuild==$env:GVSBUILD_VERSION"
+          # THE VS VERSION IS DERIVED, NOT ASSUMED. gvsbuild targets VS 17 by default
+          # and windows-latest now ships 18, so it found the toolchain, SKIPPED it
+          # ("Doesn't match target Visual Studio version of 17") and failed with
+          # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
+          # same way at the next bump; vswhere already knows the answer.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
+          Write-Host "gvsbuild --vs-ver $vsMajor"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          gvsbuild build --configuration release --vs-ver $vsMajor --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1868,13 +1868,23 @@ jobs:
           # ("Doesn't match target Visual Studio version of 17") and failed with
           # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
           # same way at the next bump; vswhere already knows the answer.
-          # `--vs-ver` takes gvsbuild's own names (vs2022, vs2026), NOT the major
-          # version — 18 was rejected with "Choose from: vs2013 … vs2026".
-          # `catalog_productLineVersion` is exactly that year, so vswhere answers it
-          # directly and no table has to be kept in sync with the runner image.
+          # `--vs-ver` takes gvsbuild's OWN names (vs2022, vs2026), not the major
+          # version: 18 was rejected with "Choose from: vs2013 … vs2026". The obvious
+          # derivation does not work either — `catalog_productLineVersion` returned
+          # "18" on this image, not "2026", so it is the major here too and `vs18` was
+          # rejected in turn.
+          #
+          # So the map is EXPLICIT, and an unknown major is a hard error rather than a
+          # guess. gvsbuild enumerates the legal names itself; a wrong guess here would
+          # only reproduce the same failure with a different number.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
-          Write-Host "gvsbuild --vs-ver $vsVer"
+          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
+          $vsVer = switch ($vsMajor) {
+            '17' { 'vs2022' }
+            '18' { 'vs2026' }
+            default { throw "unmapped Visual Studio major '$vsMajor' — add it here (gvsbuild spells these vs2022 / vs2026)" }
+          }
+          Write-Host "Visual Studio $vsMajor -> gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
           gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1874,7 +1874,7 @@ jobs:
           # directly and no table has to be kept in sync with the runner image.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
-          Write-Host "gvsbuild --vs-ver $vsVer""
+          Write-Host "gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
           gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1793,9 +1793,25 @@ jobs:
   # job (build-time closure SOURCE only, NOT shipped). Runs in parallel (does not
   # consume the addon). Uploads the bundle for the windowing proof job below.
   windows-gtk-windowing-runtime:
-    name: Windows FULL-windowing GTK runtime bundle (build / windows-latest x64)
-    runs-on: windows-latest
-    timeout-minutes: 30
+    name: Windows FULL-windowing GTK runtime bundle (build / windows-2022 x64)
+    # PINNED TO windows-2022, and not for nostalgia. Two reasons, both measured:
+    #
+    #   • gvsbuild builds GStreamer's dependency chain, and libvpx's configure has
+    #     no `x86_64-win64-vs18` target — on windows-latest (VS 18) it dies 25
+    #     minutes in with "libvpx build failed". Nothing on our side to fix; the
+    #     toolchain is simply newer than that build system.
+    #   • It is also the more correct choice. The GTK half of this prefix is the
+    #     gvsbuild RELEASE zip, built with VS 2022. Compiling GStreamer into that
+    #     same prefix with VS 18 mixes toolsets in one bundle; pinning makes the
+    #     whole prefix one.
+    #
+    # The addon that loads these DLLs is built on windows-latest and stays there —
+    # the MSVC C ABI is what makes that fine, and it is what the display-free bundle
+    # has always relied on.
+    runs-on: windows-2022
+    # Was 30, which the gvsbuild GStreamer chain blows through on a cache miss (the
+    # run that reached libvpx was already at 25 min). A cache hit skips it entirely.
+    timeout-minutes: 180
     env:
       GVSBUILD_VERSION: '2026.6.0'
       GTK_PREFIX: 'C:\gtk-build\gtk\x64\release'

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -1475,6 +1475,17 @@ jobs:
           GSK_RENDERER: cairo
         run: node --test test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs test/gtk-template-custom-child-ctor.test.mjs test/gtk-template-signals.test.mjs
 
+      # AUDIO, the counterpart to the windowing proof above. Everything else about
+      # the GStreamer payload is checkable by counting files — and counting files is
+      # what missed the defect: a bundle shipped both Gst typelibs and ZERO plugins
+      # with every gate green. This asks the registry for the elements the decode
+      # path is made of, which covers the payload AND the env wiring around it.
+      - name: Audio proof — the GStreamer elements resolve on the bundle
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+        run: node --test test/gst-elements.test.mjs
+
   # Windows proof (Phase 1 — the reverse bridge BUILDS + RUNS on windows-latest).
   # The whole team is Linux-only, so a windows-latest runner is the only way to
   # validate. Sibling of the macOS proof (its `macos` job above is the template).
@@ -2118,6 +2129,17 @@ jobs:
           NODE_GI_NATIVE: prebuild
           GSK_RENDERER: cairo
         run: node --test test/gtk-template.test.mjs test/gtk-template-callbacks.test.mjs test/gtk-template-custom-child-ctor.test.mjs test/gtk-template-signals.test.mjs
+
+      # AUDIO, the counterpart to the windowing proof above. Everything else about
+      # the GStreamer payload is checkable by counting files — and counting files is
+      # what missed the defect: a bundle shipped both Gst typelibs and ZERO plugins
+      # with every gate green. This asks the registry for the elements the decode
+      # path is made of, which covers the payload AND the env wiring around it.
+      - name: Audio proof — the GStreamer elements resolve on the bundle
+        working-directory: packages/node-gi/node-gi
+        env:
+          NODE_GI_NATIVE: prebuild
+        run: node --test test/gst-elements.test.mjs
 
   # Adwaita Storybook capstone — BUILD the `--app node` bundle. The full
   # @gjsify/storybook Libadwaita component gallery (showcases/gtk/adwaita-storybook,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -542,13 +542,23 @@ jobs:
           # ("Doesn't match target Visual Studio version of 17") and failed with
           # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
           # same way at the next bump; vswhere already knows the answer.
-          # `--vs-ver` takes gvsbuild's own names (vs2022, vs2026), NOT the major
-          # version — 18 was rejected with "Choose from: vs2013 … vs2026".
-          # `catalog_productLineVersion` is exactly that year, so vswhere answers it
-          # directly and no table has to be kept in sync with the runner image.
+          # `--vs-ver` takes gvsbuild's OWN names (vs2022, vs2026), not the major
+          # version: 18 was rejected with "Choose from: vs2013 … vs2026". The obvious
+          # derivation does not work either — `catalog_productLineVersion` returned
+          # "18" on this image, not "2026", so it is the major here too and `vs18` was
+          # rejected in turn.
+          #
+          # So the map is EXPLICIT, and an unknown major is a hard error rather than a
+          # guess. gvsbuild enumerates the legal names itself; a wrong guess here would
+          # only reproduce the same failure with a different number.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
-          Write-Host "gvsbuild --vs-ver $vsVer"
+          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
+          $vsVer = switch ($vsMajor) {
+            '17' { 'vs2022' }
+            '18' { 'vs2026' }
+            default { throw "unmapped Visual Studio major '$vsMajor' — add it here (gvsbuild spells these vs2022 / vs2026)" }
+          }
+          Write-Host "Visual Studio $vsMajor -> gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
           gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,9 +537,17 @@ jobs:
           python -m pip install --upgrade pipx
           python -m pipx ensurepath
           python -m pipx install "gvsbuild==$env:GVSBUILD_VERSION"
+          # THE VS VERSION IS DERIVED, NOT ASSUMED. gvsbuild targets VS 17 by default
+          # and windows-latest now ships 18, so it found the toolchain, SKIPPED it
+          # ("Doesn't match target Visual Studio version of 17") and failed with
+          # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
+          # same way at the next bump; vswhere already knows the answer.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
+          Write-Host "gvsbuild --vs-ver $vsMajor"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          gvsbuild build --configuration release --vs-ver $vsMajor --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,8 +450,14 @@ jobs:
     name: Publish @gjsify/gtk-runtime-win32-x64 (Windows bundle)
     needs: publish
     if: ${{ (github.event_name == 'release' || inputs.skip_publish == false) && inputs.verify_only != true }}
-    runs-on: windows-latest
-    timeout-minutes: 30
+    # windows-2022, for the reasons node-gi.yml's windows-gtk-windowing-runtime
+    # records: libvpx's configure has no VS 18 target, so the gvsbuild GStreamer
+    # chain cannot build on windows-latest — and the GTK half of this prefix is a
+    # VS 2022 release zip anyway, so one toolset per bundle is the better shape.
+    runs-on: windows-2022
+    # Was 30. gvsbuild builds GStreamer's dependency chain from source on a cache
+    # miss, which does not fit in half an hour; a hit skips straight past it.
+    timeout-minutes: 180
     permissions:
       # id-token: write = npm Trusted Publishing (OIDC), configured for this
       # workflow file (release.yml). contents: read is for checkout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -542,12 +542,16 @@ jobs:
           # ("Doesn't match target Visual Studio version of 17") and failed with
           # "Unable to find applicable Visual Studio". Hardcoding 18 would break the
           # same way at the next bump; vswhere already knows the answer.
+          # `--vs-ver` takes gvsbuild's own names (vs2022, vs2026), NOT the major
+          # version — 18 was rejected with "Choose from: vs2013 … vs2026".
+          # `catalog_productLineVersion` is exactly that year, so vswhere answers it
+          # directly and no table has to be kept in sync with the runner image.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsMajor = (& $vswhere -latest -property installationVersion).Split('.')[0]
-          Write-Host "gvsbuild --vs-ver $vsMajor"
+          $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
+          Write-Host "gvsbuild --vs-ver $vsVer""
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --vs-ver $vsMajor --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -567,7 +567,19 @@ jobs:
           Write-Host "Visual Studio $vsMajor -> gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
-          gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          # `--skip libvpx`, and it is the audio-path rule applied to the BUILD
+          # rather than only to the payload. gst-plugins-good declares exactly one
+          # dependency beyond -base, and it is libvpx: VP8/VP9, i.e. video, which
+          # gst-plugins.mjs already excludes from what ships. We were spending 15+
+          # minutes compiling a codec whose output is thrown away.
+          #
+          # It also never once succeeded. On windows-latest its configure has no
+          # `x86_64-win64-vs18` target; on windows-2022 it gets further and dies
+          # moving `x64/vpxmd.lib`. GStreamer's meson features default to `auto`, so
+          # an absent libvpx simply disables the vpx plugin — which is the state we
+          # want anyway. -good is still built, for the parsers and decoders the audio
+          # path genuinely needs: wavparse, flac, mpg123, autodetect.
+          gvsbuild build --configuration release --vs-ver $vsVer --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
       # --windowing bundle below needs — and now asserts, so a missing formula fails
       # the build instead of quietly shipping a bundle without Adwaita.
       - name: Install GTK4 + Adwaita + GtkSource + icons + GObject-Introspection (build-time closure source)
-        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config
+        run: brew install gtk4 libadwaita gtksourceview5 adwaita-icon-theme gobject-introspection cairo pango gdk-pixbuf graphene pkg-config gstreamer
 
       # Node 24 runs build-gtk-runtime-darwin.mjs (node:child_process/fs) and the publish.
       # No `registry-url` here — setting it makes actions/setup-node inject a
@@ -475,7 +475,18 @@ jobs:
 
       # Build-time closure SOURCE only — the DLLs are collected INTO the bundle, they
       # are NOT a runtime dep of the tarball.
+      # CACHED, which it was not before. Downloading the GTK zip each time was cheap;
+      # BUILDING GStreamer from source is not, and without a cache every release would
+      # pay it again. Key covers the gvsbuild version, so a bump rebuilds once.
+      - name: Cache the gvsbuild GTK4 + GStreamer prefix
+        id: cache-gtk
+        uses: actions/cache@v4
+        with:
+          path: C:\gtk-build\gtk\x64\release
+          key: gvsbuild-gtk4-gst-${{ env.GVSBUILD_VERSION }}-x64-v1
+
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -497,6 +508,53 @@ jobs:
       # gvsbuild's single prefix already carries everything the superset needs, so this
       # costs only bundle size (~36 MiB, dominated by the ANGLE GL DLLs) — and nothing
       # depends on these packages, they are installed on purpose.
+      # GSTREAMER, BUILT FROM SOURCE INTO THE SAME PREFIX.
+      #
+      # There is no prebuilt Windows GStreamer we can lift. The gvsbuild release
+      # publishes exactly two assets — GTK3_Gvsbuild and GTK4_Gvsbuild — and neither
+      # carries any of it: measured on the published @gjsify/gtk-runtime-win32-x64
+      # tarball, all 40 typelibs present and not one of them GStreamer's, which is why
+      # `new AudioContext()` threw `Failed to require Gst 1.0` on a machine whose GTK
+      # worked perfectly. gstreamer.freedesktop.org ships an installer .exe for x64,
+      # but it dropped the separate devel package, so whether it carries typelibs at
+      # all is unverified — and an installer is the wrong thing to extract in CI.
+      #
+      # gvsbuild DOES define gstreamer/orc/gst-plugins-base/-good with
+      # `-Dintrospection=enabled`, so building them is the path where the typelibs are
+      # guaranteed and the ABI matches everything already in this prefix.
+      #
+      # IT WILL REBUILD DEPENDENCIES. The extracted zip carries no gvsbuild build
+      # markers, so gvsbuild considers glib/gobject-introspection unbuilt and makes
+      # them again from source. That is the cost of not having a prebuilt binary, and
+      # it is why the cache key covers the GStreamer projects too and the timeout is
+      # generous — on a cache hit this whole step is skipped.
+      - name: Build GStreamer with gvsbuild (into the GTK prefix)
+        if: steps.cache-gtk.outputs.cache-hit != 'true'
+        shell: pwsh
+        timeout-minutes: 150
+        run: |
+          $ErrorActionPreference = 'Stop'
+          python -m pip install --upgrade pipx
+          python -m pipx ensurepath
+          python -m pipx install "gvsbuild==$env:GVSBUILD_VERSION"
+          # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
+          # the bundle builder's single closure walk sees both.
+          gvsbuild build --configuration release --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+
+      - name: Assert GStreamer landed in the prefix (typelibs + plugins)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # The two the bundle asserts, and the plugin dir the elements come from.
+          # Fail HERE rather than three jobs later with "no element decodebin".
+          foreach ($t in @('Gst-1.0.typelib', 'GstApp-1.0.typelib')) {
+            $p = "$env:GTK_PREFIX\lib\girepository-1.0\$t"
+            if (-not (Test-Path $p)) { Write-Host "MISSING $p"; exit 1 }
+          }
+          $plugins = Get-ChildItem "$env:GTK_PREFIX\lib\gstreamer-1.0" -Filter *.dll -ErrorAction SilentlyContinue
+          if (-not $plugins) { Write-Host "no GStreamer plugins in the prefix"; exit 1 }
+          Write-Host "GStreamer: $($plugins.Count) plugin DLL(s) in the prefix"
+
       - name: Build the GTK runtime bundle (--windowing superset, populate gtk/)
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,7 +548,7 @@ jobs:
           # directly and no table has to be kept in sync with the runner image.
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $vsVer = "vs$(& $vswhere -latest -property catalog_productLineVersion)"
-          Write-Host "gvsbuild --vs-ver $vsVer""
+          Write-Host "gvsbuild --vs-ver $vsVer"
           # Same prefix the zip was extracted into, so one tree carries GTK + Gst and
           # the bundle builder's single closure walk sees both.
           gvsbuild build --configuration release --vs-ver $vsVer --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,7 +489,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\gtk-build\gtk\x64\release
-          key: gvsbuild-gtk4-gst-${{ env.GVSBUILD_VERSION }}-x64-v1
+          key: gvsbuild-gtk4-gst-gi-${{ env.GVSBUILD_VERSION }}-x64-v2
 
       - name: Download + extract gvsbuild GTK4 (build-time closure source)
         if: steps.cache-gtk.outputs.cache-hit != 'true'
@@ -579,7 +579,15 @@ jobs:
           # an absent libvpx simply disables the vpx plugin — which is the state we
           # want anyway. -good is still built, for the parsers and decoders the audio
           # path genuinely needs: wavparse, flac, mpg123, autodetect.
-          gvsbuild build --configuration release --vs-ver $vsVer --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
+          # `--enable-gi` IS THE WHOLE POINT and defaults to FALSE. gvsbuild's
+          # gstreamer projects gate introspection on it — without it they pass
+          # `-Dintrospection=disabled`, so the build succeeds and produces no
+          # .gir/.typelib at all. Measured: a complete 16-minute GStreamer build
+          # whose prefix contained zero Gst typelibs. The assertion below is what
+          # caught it, at the prefix, instead of three jobs later as "no element
+          # decodebin" — typelibs are the only reason we build this from source
+          # rather than lifting a binary.
+          gvsbuild build --configuration release --vs-ver $vsVer --enable-gi --skip libvpx --build-dir C:\gtk-build gstreamer gst-plugins-base gst-plugins-good
 
       - name: Assert GStreamer landed in the prefix (typelibs + plugins)
         shell: pwsh

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -57,6 +57,7 @@ import {
     scanLicenseFiles,
     writeLicensePayload,
 } from '../../scripts/bundle-licenses.mjs';
+import { isBundledGstPlugin } from '../../scripts/gst-plugins.mjs';
 import {
     REQUIRED_NAMESPACES,
     WINDOWING_REQUIRED_NAMESPACES,
@@ -272,7 +273,9 @@ const gstPluginDir = join(PREFIX, 'lib', 'gstreamer-1.0');
 const gstPluginSeeds = [];
 if (WINDOWING && existsSync(gstPluginDir)) {
     for (const f of readdirSync(gstPluginDir)) {
-        if (f.toLowerCase().endsWith('.dll')) gstPluginSeeds.push(join(gstPluginDir, f));
+        if (f.toLowerCase().endsWith('.dll') && isBundledGstPlugin(f)) {
+            gstPluginSeeds.push(join(gstPluginDir, f));
+        }
     }
 }
 console.log(
@@ -453,6 +456,8 @@ if (WINDOWING) {
         let bytes = 0;
         for (const f of readdirSync(gstPluginDir)) {
             if (!f.toLowerCase().endsWith('.dll')) continue;
+            // The AUDIO PATH only, same rule and same reasons as darwin.
+            if (!isBundledGstPlugin(f)) continue;
             const dest = join(pluginsOut, f);
             copyFileSync(join(gstPluginDir, f), dest);
             bytes += statSync(dest).size;

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -40,7 +40,7 @@
 // back" and for "the terms of what it ships travel with it", because two copies of a
 // gate are two gates that drift.
 import { execFileSync } from 'node:child_process';
-import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -142,6 +142,15 @@ const WINDOWING_SEED_PATTERNS = [
     /^epoxy.*\.dll$/i,
     /^rsvg.*\.dll$/i,
     /^libxml2.*\.dll$/i,
+    // GStreamer, backing the Gst + GstApp typelibs `@gjsify/webaudio` imports; its
+    // PLUGINS are § 4g. TWO seeds, not one: the dumpbin walk reaches
+    // gstbase/audio/pbutils/tag/video from gstreamer-1.0-0.dll, but gstapp is a
+    // gst-plugins-base library only an appsrc/appsink user links — which is exactly
+    // what the decode pipeline is. Seeding only gstreamer would leave
+    // `GstApp-1.0.typelib` unbacked and § 3's symmetry rule would DROP it: a green
+    // build with no audio and no message.
+    /^gstreamer-1\.0-.*\.dll$/i,
+    /^gstapp-1\.0-.*\.dll$/i,
 ];
 
 // Locate an MSVC/gvsbuild tool: env override, then the gvsbuild <prefix>/bin
@@ -256,8 +265,19 @@ if (WINDOWING && existsSync(gdkPixbufLoaderDir)) {
         if (f.toLowerCase().endsWith('.dll')) loaderSeeds.push(join(gdkPixbufLoaderDir, f));
     }
 }
+
+// Same shape for the GStreamer plugins (§ 4g): they live outside bin/ and their
+// backing DLLs must still land there, so each plugin seeds the closure walk.
+const gstPluginDir = join(PREFIX, 'lib', 'gstreamer-1.0');
+const gstPluginSeeds = [];
+if (WINDOWING && existsSync(gstPluginDir)) {
+    for (const f of readdirSync(gstPluginDir)) {
+        if (f.toLowerCase().endsWith('.dll')) gstPluginSeeds.push(join(gstPluginDir, f));
+    }
+}
 console.log(
-    `build-gtk-runtime: ${seeds.length} seed DLLs${loaderSeeds.length ? ` + ${loaderSeeds.length} pixbuf loaders` : ''}`,
+    `build-gtk-runtime: ${seeds.length} seed DLLs${loaderSeeds.length ? ` + ${loaderSeeds.length} pixbuf loaders` : ''}` +
+        `${gstPluginSeeds.length ? ` + ${gstPluginSeeds.length} gst plugins` : ''}`,
 );
 
 const dumpbin = findDumpbin();
@@ -268,7 +288,7 @@ if (dumpbin) {
     console.log(`build-gtk-runtime: walking the DLL closure with ${dumpbin}`);
     // Seed with bin/ seeds (leaf names) + external loader DLLs (full paths) so THEIR
     // deps are walked into bin/ even though the loaders live outside bin/.
-    const queue = [...seeds, ...loaderSeeds];
+    const queue = [...seeds, ...loaderSeeds, ...gstPluginSeeds];
     while (queue.length) {
         const entry = queue.shift();
         const isPath = entry.includes('\\') || entry.includes('/');
@@ -365,7 +385,14 @@ if (typelibPlan.dropped.length > 0) {
 // in 0.27.1. The DATA marker node-gi keys on is gschemas.compiled; a bundle without it
 // is treated as display-free by the loader, i.e. the failure is silent, which is
 // precisely why it is asserted instead of warned about.
-const windowing = { pixbufLoaders: 0, schemas: false, iconThemes: [], fontconfig: false, gtksource: false };
+const windowing = {
+    pixbufLoaders: 0,
+    gstPlugins: 0,
+    schemas: false,
+    iconThemes: [],
+    fontconfig: false,
+    gtksource: false,
+};
 if (WINDOWING) {
     // 4a. gdk-pixbuf loaders + a bundle-relative loaders.cache. The cache maps each
     // decoder DLL to its mime/extensions; gdk-pixbuf resolves the DLL paths in it
@@ -407,6 +434,53 @@ if (WINDOWING) {
         console.warn(
             `build-gtk-runtime: WARNING — ${gdkPixbufLoaderDir} missing; no gdk-pixbuf loaders bundled ` +
                 '(§ 5b will fail this build)',
+        );
+    }
+
+    // 4g. GStreamer plugins + the plugin scanner — the ELEMENTS. `Gst.init()`
+    // succeeds against an empty registry, so a bundle shipping libgstreamer and
+    // every Gst typelib but no plugins reports itself perfectly healthy and then
+    // fails far away with "no element decodebin". The same shape 4a exists for.
+    //
+    // EVERYTHING the prefix has, not a curated element list: guessing which codecs
+    // an app will meet fails SILENTLY when the guess is wrong. The size is printed
+    // instead, so the payload is a number somebody can act on. No relocation —
+    // unlike darwin's Mach-O plugins, Windows resolves the backing DLLs by search
+    // path, and the closure walk above already put them in bin/.
+    if (existsSync(gstPluginDir)) {
+        const pluginsOut = join(OUT, 'lib', 'gstreamer-1.0');
+        mkdirSync(pluginsOut, { recursive: true });
+        let bytes = 0;
+        for (const f of readdirSync(gstPluginDir)) {
+            if (!f.toLowerCase().endsWith('.dll')) continue;
+            const dest = join(pluginsOut, f);
+            copyFileSync(join(gstPluginDir, f), dest);
+            bytes += statSync(dest).size;
+            windowing.gstPlugins++;
+        }
+        // The scanner, which GStreamer FORKS so a plugin that crashes on load cannot
+        // take the app down with it. Its compiled-in path is the build machine's, so
+        // it has to be bundled AND pointed at (`GST_PLUGIN_SCANNER`, wired in
+        // node-gi's gtk-runtime.js).
+        const scannerSrc = join(PREFIX, 'libexec', 'gstreamer-1.0', 'gst-plugin-scanner.exe');
+        if (existsSync(scannerSrc)) {
+            const scannerOut = join(OUT, 'libexec', 'gstreamer-1.0');
+            mkdirSync(scannerOut, { recursive: true });
+            copyFileSync(scannerSrc, join(scannerOut, 'gst-plugin-scanner.exe'));
+        } else {
+            console.warn(
+                `build-gtk-runtime: WARNING — ${scannerSrc} missing; GStreamer will scan plugins ` +
+                    'IN-PROCESS (works, until the first plugin that crashes on load)',
+            );
+        }
+        console.log(
+            `build-gtk-runtime: GStreamer — ${windowing.gstPlugins} plugin(s), ` +
+                `${(bytes / 1024 / 1024).toFixed(1)} MiB`,
+        );
+    } else {
+        console.warn(
+            `build-gtk-runtime: WARNING — ${gstPluginDir} missing; no GStreamer plugins bundled ` +
+                '(Gst.init() would succeed and decode nothing)',
         );
     }
 

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -478,6 +478,22 @@ if (WINDOWING) {
                     'IN-PROCESS (works, until the first plugin that crashes on load)',
             );
         }
+        // ZERO IS NEVER RIGHT, and the build shipped zero while staying green: the
+        // plugin filter stripped `^libgst`, Windows names its plugins `gstfoo.dll`
+        // without the prefix, and all 83 were skipped. Nothing noticed, because the
+        // typelib symmetry gate checks typelib against LIBRARY and knows nothing
+        // about plugins — so the bundle had libgstreamer, both Gst typelibs, and no
+        // elements at all. That is precisely the "healthy, then no element decodebin"
+        // failure this section is written against, so it is now an ERROR.
+        if (windowing.gstPlugins === 0) {
+            console.error(
+                `build-gtk-runtime: ${gstPluginDir} holds plugins but NONE matched the audio-path ` +
+                    'filter — a --windowing bundle with no GStreamer elements would report itself ' +
+                    'healthy and then fail with "no element decodebin". Check isBundledGstPlugin ' +
+                    "against this platform's plugin naming.",
+            );
+            process.exit(1);
+        }
         console.log(
             `build-gtk-runtime: GStreamer — ${windowing.gstPlugins} plugin(s), ` +
                 `${(bytes / 1024 / 1024).toFixed(1)} MiB`,

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -426,6 +426,35 @@ export function maybeWireGtkWindowingEnv() {
         setIfUnset('FONTCONFIG_PATH', join(bundle.dir, 'etc', 'fonts'));
         setIfUnset('FONTCONFIG_FILE', fontsConf);
     }
+
+    // GStreamer, which finds its plugins the way GTK finds its schemas: by env,
+    // read at init. Without this the bundle can ship every Gst typelib and still
+    // play nothing — `Gst.init()` succeeds against an EMPTY registry, so the
+    // failure surfaces far away as "no element decodebin" rather than as a missing
+    // library. That is the same shape as the 0.27.1 bundles, which carried
+    // `Adw-1.typelib` with no libadwaita behind it.
+    //
+    // SYSTEM_PATH, not GST_PLUGIN_PATH: the latter is the USER's additive override
+    // and the bundle has no business consuming it. SYSTEM_PATH also suppresses the
+    // compiled-in default, which is what we want — that default is the build
+    // machine's prefix, and on a user's box it is either absent or, worse, a
+    // foreign GStreamer whose plugins would be mixed with the bundle's.
+    const gstPlugins = join(bundle.dir, 'lib', 'gstreamer-1.0');
+    if (existsSync(gstPlugins)) {
+        setIfUnset('GST_PLUGIN_SYSTEM_PATH', gstPlugins);
+        // The scanner is a separate EXECUTABLE that GStreamer forks to inspect each
+        // plugin out-of-process, so a plugin that crashes on load cannot take the
+        // app with it. Its compiled-in path is the build machine's too, so without
+        // this GStreamer silently degrades to in-process scanning — which works,
+        // until the first bad plugin takes the process down instead of itself.
+        const scanner = join(bundle.dir, 'libexec', 'gstreamer-1.0', gstScannerLeaf());
+        if (existsSync(scanner)) setIfUnset('GST_PLUGIN_SCANNER', scanner);
+    }
+}
+
+/** The plugin scanner's leaf name — the bundles ship the same tree on both OSes. */
+function gstScannerLeaf() {
+    return process.platform === 'win32' ? 'gst-plugin-scanner.exe' : 'gst-plugin-scanner';
 }
 
 let activated = null; // memoize: the activation result (idempotent)

--- a/packages/node-gi/node-gi/test/gst-elements.test.mjs
+++ b/packages/node-gi/node-gi/test/gst-elements.test.mjs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — the GStreamer ELEMENTS resolve on a batteries-included bundle.
+//
+// The counterpart to windowing.test.mjs, for audio. Everything else about the
+// GStreamer payload is checkable by counting files, and counting files is exactly
+// what missed the defect this test exists for: a bundle shipped `libgstreamer`,
+// both Gst typelibs and ZERO plugins, and every gate stayed green — the typelib
+// symmetry check compares a typelib to its LIBRARY and knows nothing about
+// elements. `Gst.init()` then succeeds against an empty registry, and the failure
+// surfaces far away, in the application, as "no element decodebin".
+//
+// So this asks the only question that cannot be answered by inspecting the tarball:
+// does the registry actually contain the elements the audio path is made of? That
+// covers the plugin payload AND the env wiring around it
+// (`GST_PLUGIN_SYSTEM_PATH` / `GST_PLUGIN_SCANNER`, set by gtk-runtime.js) — a
+// bundle can carry every plugin and still resolve none, if the runtime is never
+// told where they are.
+//
+// NO DISPLAY NEEDED. Audio elements are constructed, not realized, so this runs on
+// any host with the bundle staged — unlike the windowing proofs beside it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireGi } from '../gi.js';
+
+let Gst = null;
+let loadError = null;
+try {
+    Gst = requireGi('Gst', '1.0');
+    Gst.init(null);
+} catch (err) {
+    loadError = err;
+}
+
+const skip = loadError ? `Gst 1.0 unavailable: ${loadError.message}` : false;
+
+// The pipeline @gjsify/webaudio is built from, element by element. Named
+// individually rather than asserted as a count, because "20 plugins loaded" is the
+// claim that was already true while the one element the decode path needs was
+// missing — and a count cannot tell you WHICH one is gone.
+const REQUIRED_ELEMENTS = [
+    ['appsrc', 'the JS → GStreamer boundary: encoded bytes are pushed in here'],
+    ['appsink', 'the GStreamer → JS boundary: decoded PCM is pulled out here'],
+    ['decodebin', 'format-agnostic decoding — the element the empty registry could not find'],
+    ['audioconvert', 'sample-format conversion into what AudioBuffer expects'],
+    ['audioresample', 'rate conversion to the context sample rate'],
+    ['typefind', 'what decodebin autoplugs from — no typefind, no format detection'],
+    ['volume', 'GainNode'],
+];
+
+test('the GStreamer registry resolves the audio-path elements', { skip }, () => {
+    const missing = [];
+    for (const [name, why] of REQUIRED_ELEMENTS) {
+        if (Gst.ElementFactory.make(name, null) === null) missing.push(`${name} (${why})`);
+    }
+    assert.deepEqual(
+        missing,
+        [],
+        `GStreamer resolved no factory for:\n  ${missing.join('\n  ')}\n\n` +
+            'The registry is populated from GST_PLUGIN_SYSTEM_PATH, which node-gi points at ' +
+            "the bundle's lib/gstreamer-1.0. An EMPTY result here means either the bundle ships " +
+            'no plugins or nothing told GStreamer where they are — both look like a healthy ' +
+            'Gst.init() and fail in the application instead.',
+    );
+});
+
+test('a decodebin pipeline actually builds', { skip }, () => {
+    // One step past "the factories exist": the elements link into the shape the
+    // decoder uses. `parse_launch` fails on a missing element OR a refused link, so
+    // this catches a registry that is populated but incoherent.
+    const pipeline = Gst.parse_launch('appsrc name=src ! decodebin ! audioconvert ! audioresample ! appsink name=sink');
+    assert.ok(pipeline, 'parse_launch returned nothing for the decode pipeline');
+    assert.ok(pipeline.get_by_name('src'), 'appsrc is not addressable in the built pipeline');
+    assert.ok(pipeline.get_by_name('sink'), 'appsink is not addressable in the built pipeline');
+    pipeline.set_state(Gst.State.NULL);
+});

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -348,7 +348,12 @@ test("the host's own typelib corpus parses, and its GTK stack is self-consistent
 test('WINDOWING_REQUIRED_NAMESPACES names what --windowing exists to add', () => {
     // Guards the floor itself: if this list were emptied, the --windowing bundles
     // could silently ship without Adwaita and every gate would still be green.
-    assert.deepEqual(WINDOWING_REQUIRED_NAMESPACES, ['Adw', 'GtkSource']);
+    //
+    // `Gst` + `GstApp` joined it when the bundles started shipping GStreamer, and
+    // BOTH are named because the failure modes differ: no `Gst` is no audio at all,
+    // while no `GstApp` is a perfectly loaded Gst whose `appsrc.push_buffer(…)` is
+    // not a function — the decode pipeline dying at its first sample.
+    assert.deepEqual(WINDOWING_REQUIRED_NAMESPACES, ['Adw', 'GtkSource', 'Gst', 'GstApp']);
     for (const ns of ['GLib', 'GObject', 'Gio', 'Gtk', 'Gdk', 'Pango', 'GdkPixbuf', 'Graphene', 'cairo']) {
         assert.ok(REQUIRED_NAMESPACES.includes(ns), `${ns} is part of the bundle's promise`);
     }

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -584,6 +584,17 @@ if (WINDOWING) {
             );
         }
 
+        // ZERO IS NEVER RIGHT — see the win32 builder's note: a plugin-naming
+        // mismatch shipped an element-free bundle there while every gate stayed
+        // green, because nothing counts plugins.
+        if (gstPluginImages.length === 0) {
+            console.error(
+                `build-gtk-runtime: ${pluginsSrc} holds plugins but NONE matched the audio-path ` +
+                    'filter — a --windowing bundle with no GStreamer elements reports itself healthy ' +
+                    'and then fails with "no element decodebin".',
+            );
+            process.exit(1);
+        }
         console.log(
             `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
                 `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins` +

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -89,6 +89,7 @@ import {
     renderThirdPartyNotice,
     writeLicensePayload,
 } from './bundle-licenses.mjs';
+import { isBundledGstPlugin } from './gst-plugins.mjs';
 import {
     REQUIRED_NAMESPACES,
     WINDOWING_REQUIRED_NAMESPACES,
@@ -498,8 +499,15 @@ if (WINDOWING) {
         mkdirSync(pluginsOut, { recursive: true });
         let bytes = 0;
         let dangling = 0;
+        let skipped = 0;
         for (const f of readdirSync(pluginsSrc)) {
             if (!f.endsWith('.dylib') && !f.endsWith('.so')) continue;
+            // The AUDIO PATH only — see gst-plugins.mjs for why "everything the
+            // prefix has" is not an option here and what the rule replaced it with.
+            if (!isBundledGstPlugin(f)) {
+                skipped++;
+                continue;
+            }
             const src = join(pluginsSrc, f);
             // A DANGLING LINK IS A PLUGIN THAT IS NOT INSTALLED. brew links every
             // plugin any formula ever provided into this one dir, and leaves the link
@@ -557,7 +565,8 @@ if (WINDOWING) {
         console.log(
             `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
                 `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins` +
-                `${dangling ? `, ${dangling} dangling brew link(s) skipped` : ''}`,
+                `, ${skipped} non-audio plugin(s) skipped` +
+                `${dangling ? `, ${dangling} dangling brew link(s)` : ''}`,
         );
     } else {
         console.warn(

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -290,8 +290,49 @@ if (seeds.length === 0) {
 }
 console.log(`build-gtk-runtime: ${seeds.length} seed libraries: ${seeds.join(', ')}`);
 
+// The GStreamer plugins § 2c ships must SEED THIS WALK, not merely be copied after
+// it. They live outside lib/, so nothing in the seed closure links them — and their
+// own dependencies (libgstaudio/tag/riff/pbutils from the gstreamer keg, plus orc
+// and libvorbis) therefore never entered it. Measured: every kept plugin came out
+// referencing `/opt/homebrew/Cellar/gstreamer/<ver>/lib/…`, and § 3 refused the
+// bundle — correctly, because those paths do not exist on a user's machine. Same
+// shape the win32 builder already had for its plugins and its pixbuf loaders.
+const gstPluginSeedPaths = [];
+const gstPluginSkips = { nonAudio: 0, dangling: 0 };
+if (WINDOWING) {
+    const dir = join(brewLib, 'gstreamer-1.0');
+    if (existsSync(dir)) {
+        for (const f of readdirSync(dir)) {
+            if (!f.endsWith('.dylib') && !f.endsWith('.so')) continue;
+            // The AUDIO PATH only — gst-plugins.mjs says why "everything the prefix
+            // has" is not an option and what the rule replaced it with.
+            if (!isBundledGstPlugin(f)) {
+                gstPluginSkips.nonAudio++;
+                continue;
+            }
+            // A DANGLING LINK IS A PLUGIN THAT IS NOT INSTALLED. brew links every
+            // plugin any formula ever provided into this one dir and leaves the link
+            // when the keg goes — `libgstnice.dylib` on the arm64 runner points at a
+            // libnice keg that is not there. `existsSync` FOLLOWS the link, so this
+            // is the check, and the skips are COUNTED rather than swallowed: a plugin
+            // quietly missing from the payload is the failure this area prevents.
+            const src = join(dir, f);
+            if (!existsSync(src)) {
+                gstPluginSkips.dangling++;
+                continue;
+            }
+            gstPluginSeedPaths.push(src);
+        }
+    }
+}
+
 const bundled = new Map(); // leaf -> real source path
 const queue = [...seeds];
+// Walk the plugins' deps into the closure WITHOUT adding the plugins themselves to
+// `bundled` — they are not flat lib/ entries, § 2c places and relocates them.
+for (const pluginPath of gstPluginSeedPaths) {
+    for (const dep of otoolDeps(pluginPath)) queue.push(basename(dep));
+}
 while (queue.length) {
     const leaf = queue.shift();
     if (bundled.has(leaf)) continue;
@@ -498,29 +539,10 @@ if (WINDOWING) {
     if (existsSync(pluginsSrc)) {
         mkdirSync(pluginsOut, { recursive: true });
         let bytes = 0;
-        let dangling = 0;
-        let skipped = 0;
-        for (const f of readdirSync(pluginsSrc)) {
-            if (!f.endsWith('.dylib') && !f.endsWith('.so')) continue;
-            // The AUDIO PATH only — see gst-plugins.mjs for why "everything the
-            // prefix has" is not an option here and what the rule replaced it with.
-            if (!isBundledGstPlugin(f)) {
-                skipped++;
-                continue;
-            }
-            const src = join(pluginsSrc, f);
-            // A DANGLING LINK IS A PLUGIN THAT IS NOT INSTALLED. brew links every
-            // plugin any formula ever provided into this one dir, and leaves the link
-            // behind when the keg goes: measured on the arm64 runner,
-            // `libgstnice.dylib` points at a libnice keg that is not there, and
-            // copyFileSync died with ENOENT on it. `existsSync` FOLLOWS the link, so
-            // this is the check — and it is counted rather than swallowed, because a
-            // plugin silently missing from the payload is the failure mode this whole
-            // section exists to prevent.
-            if (!existsSync(src)) {
-                dangling++;
-                continue;
-            }
+        // The SAME list that seeded the closure walk above — read once, so the set
+        // that was walked and the set that ships cannot disagree.
+        for (const src of gstPluginSeedPaths) {
+            const f = basename(src);
             const dest = join(pluginsOut, f);
             // Dereferencing, like § 2b: brew links plugins in from their kegs, and a
             // link into the Cellar is worthless inside a tarball.
@@ -565,8 +587,8 @@ if (WINDOWING) {
         console.log(
             `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
                 `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins` +
-                `, ${skipped} non-audio plugin(s) skipped` +
-                `${dangling ? `, ${dangling} dangling brew link(s)` : ''}`,
+                `, ${gstPluginSkips.nonAudio} non-audio plugin(s) skipped` +
+                `${gstPluginSkips.dangling ? `, ${gstPluginSkips.dangling} dangling brew link(s)` : ''}`,
         );
     } else {
         console.warn(

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -70,6 +70,7 @@ import {
     readdirSync,
     realpathSync,
     rmSync,
+    statSync,
     writeFileSync,
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
@@ -225,6 +226,17 @@ const WINDOWING_SEED_PATTERNS = [
     // trace of the missing decoder — a bundle that ships the icons but nothing to
     // rasterize them.
     /^librsvg-2\.\d+\.dylib$/,
+    // GStreamer, backing the Gst + GstApp typelibs `@gjsify/webaudio` imports. Its
+    // PLUGINS are § 2c — native modules in a nested dir, like the pixbuf loaders.
+    //
+    // TWO seeds, not one. The otool walk reaches libgstbase/audio/pbutils/tag/video
+    // from libgstreamer, but `libgstapp` is NOT among them: it is a
+    // gst-plugins-base library that only an appsrc/appsink user links, which is
+    // precisely what the decode pipeline is. Seeding libgstreamer alone would leave
+    // `GstApp-1.0.typelib` unbacked and § 4's symmetry rule would DROP it — a green
+    // build with no audio and no message, the same trace librsvg left above.
+    /^libgstreamer-1\.0\..*\.dylib$/,
+    /^libgstapp-1\.0\..*\.dylib$/,
 ];
 
 function isSystemPath(p) {
@@ -462,6 +474,85 @@ if (WINDOWING) {
     }
 }
 
+// --- 2c. WINDOWING: the GStreamer PLUGINS + scanner -------------------------
+// The elements. `Gst.init()` succeeds against an EMPTY registry, so a bundle that
+// ships libgstreamer and every Gst typelib and NO plugins reports itself perfectly
+// healthy and then fails far away with "no element decodebin". Exactly the shape
+// § 2b exists for: a complete-looking bundle missing the thing that does the work.
+//
+// EVERYTHING brew's prefix has, not a curated subset. A hand-picked element list is
+// a guess about which codecs an app will meet — and the failure mode of guessing
+// wrong is silence, not an error. The size it costs is printed below so the payload
+// is a number somebody can act on rather than a surprise in a tarball.
+//
+// Here rather than in § 4b for § 2b's reason: these are Mach-O images in a nested
+// dir, so they need the copy → relocate → re-sign pass, and § 3 then verifies them.
+// One level below lib/, hence `@loader_path/..` (the loaders sit three levels down
+// and take `../../..`).
+const gstPluginImages = []; // absolute paths in the bundle, for § 3
+const gstPluginSources = new Map(); // leaf -> keg realpath, for § 5's attribution
+if (WINDOWING) {
+    const pluginsSrc = join(brewLib, 'gstreamer-1.0');
+    const pluginsOut = join(OUT, 'lib', 'gstreamer-1.0');
+    if (existsSync(pluginsSrc)) {
+        mkdirSync(pluginsOut, { recursive: true });
+        let bytes = 0;
+        for (const f of readdirSync(pluginsSrc)) {
+            if (!f.endsWith('.dylib') && !f.endsWith('.so')) continue;
+            const src = join(pluginsSrc, f);
+            const dest = join(pluginsOut, f);
+            // Dereferencing, like § 2b: brew links plugins in from their kegs, and a
+            // link into the Cellar is worthless inside a tarball.
+            copyFileSync(src, dest);
+            bytes += statSync(dest).size;
+            gstPluginImages.push(dest);
+            try {
+                gstPluginSources.set(f, realpathSync(src));
+            } catch {
+                gstPluginSources.set(f, src);
+            }
+        }
+        for (const image of gstPluginImages) {
+            relocate(image, { id: true, depPrefix: '@loader_path/..' });
+        }
+
+        // The scanner, which GStreamer FORKS to inspect each plugin out of process so
+        // a plugin that crashes on load cannot take the app down with it. Its
+        // compiled-in path is the build machine's, so it has to be bundled AND
+        // pointed at (`GST_PLUGIN_SCANNER`, wired in node-gi's gtk-runtime.js).
+        // Two levels below the bundle root → `@loader_path/../../lib`.
+        const scannerSrc = join(brewPrefix, 'libexec', 'gstreamer-1.0', 'gst-plugin-scanner');
+        if (existsSync(scannerSrc)) {
+            const scannerOut = join(OUT, 'libexec', 'gstreamer-1.0');
+            mkdirSync(scannerOut, { recursive: true });
+            const dest = join(scannerOut, 'gst-plugin-scanner');
+            copyFileSync(scannerSrc, dest);
+            gstPluginImages.push(dest);
+            try {
+                gstPluginSources.set('gst-plugin-scanner', realpathSync(scannerSrc));
+            } catch {
+                gstPluginSources.set('gst-plugin-scanner', scannerSrc);
+            }
+            relocate(dest, { id: false, depPrefix: '@loader_path/../../lib' });
+        } else {
+            console.warn(
+                `build-gtk-runtime: WARNING — ${scannerSrc} missing; GStreamer will scan plugins ` +
+                    'IN-PROCESS (works, until the first plugin that crashes on load)',
+            );
+        }
+
+        console.log(
+            `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
+                `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins`,
+        );
+    } else {
+        console.warn(
+            `build-gtk-runtime: WARNING — ${pluginsSrc} missing; no GStreamer plugins bundled ` +
+                '(Gst.init() would succeed and decode nothing)',
+        );
+    }
+}
+
 // --- 3. verify the relocation ---------------------------------------------
 // A leftover absolute reference to a library we DID bundle is the whole failure
 // mode: the bundle looks complete, loads fine on the build host, and resolves
@@ -506,7 +597,7 @@ function verifyRelocation(paths) {
 // relocation is the harder one (a ../../.. prefix, plus an `@rpath` ref and an absolute
 // LC_ID_DYLIB on librsvg's module), so leaving them out would ship exactly the class of
 // bug this function exists to catch.
-verifyRelocation([...[...bundledLeaves].map((leaf) => join(libOut, leaf)), ...pixbufLoaderImages]);
+verifyRelocation([...[...bundledLeaves].map((leaf) => join(libOut, leaf)), ...pixbufLoaderImages, ...gstPluginImages]);
 
 // --- 4. typelibs — only the ones this bundle can actually BACK --------------
 // The brew typelib dir is shared by every installed formula, so copying it wholesale
@@ -568,6 +659,7 @@ if (typelibPlan.dropped.length > 0) {
 // every declared set that did not arrive, so a partial prefix cannot publish.
 const windowing = {
     pixbufLoaders: pixbufLoaderImages.length, // § 2b
+    gstPlugins: gstPluginImages.length, // § 2c
     schemas: false,
     iconThemes: [],
     iconFiles: 0,
@@ -743,7 +835,7 @@ const brewInfoLicense = (formula) => {
 // third-party LGPL modules too, so "the terms travel with the binaries" is only true if
 // the per-binary table names them. They attribute through the same derivation as every
 // dylib — their realpath runs through …/Cellar/{gdk-pixbuf,librsvg}/<version>/… .
-const shippedBinaries = new Map([...bundled, ...pixbufLoaderSources]);
+const shippedBinaries = new Map([...bundled, ...pixbufLoaderSources, ...gstPluginSources]);
 const { components: licenseComponents, unattributed } = describeBrewKegs({
     files: shippedBinaries,
     fallbackLicense: brewInfoLicense,

--- a/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
+++ b/packages/node-gi/scripts/build-gtk-runtime-darwin.mjs
@@ -497,9 +497,22 @@ if (WINDOWING) {
     if (existsSync(pluginsSrc)) {
         mkdirSync(pluginsOut, { recursive: true });
         let bytes = 0;
+        let dangling = 0;
         for (const f of readdirSync(pluginsSrc)) {
             if (!f.endsWith('.dylib') && !f.endsWith('.so')) continue;
             const src = join(pluginsSrc, f);
+            // A DANGLING LINK IS A PLUGIN THAT IS NOT INSTALLED. brew links every
+            // plugin any formula ever provided into this one dir, and leaves the link
+            // behind when the keg goes: measured on the arm64 runner,
+            // `libgstnice.dylib` points at a libnice keg that is not there, and
+            // copyFileSync died with ENOENT on it. `existsSync` FOLLOWS the link, so
+            // this is the check — and it is counted rather than swallowed, because a
+            // plugin silently missing from the payload is the failure mode this whole
+            // section exists to prevent.
+            if (!existsSync(src)) {
+                dangling++;
+                continue;
+            }
             const dest = join(pluginsOut, f);
             // Dereferencing, like § 2b: brew links plugins in from their kegs, and a
             // link into the Cellar is worthless inside a tarball.
@@ -543,7 +556,8 @@ if (WINDOWING) {
 
         console.log(
             `build-gtk-runtime: GStreamer — ${gstPluginImages.length} plugin(s) relocated ` +
-                `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins`,
+                `(@loader_path/..), ${(bytes / 1024 / 1024).toFixed(1)} MiB of plugins` +
+                `${dangling ? `, ${dangling} dangling brew link(s) skipped` : ''}`,
         );
     } else {
         console.warn(

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// WHICH GStreamer plugins the runtime bundles ship — one rule, both platforms.
+//
+// THE FIRST ATTEMPT WAS "everything the prefix has", on the reasoning that a
+// curated element list is a guess about which codecs an app will meet, and a wrong
+// guess fails silently. The darwin relocation gate refused it, and was right to:
+// Homebrew's `gstreamer` formula is base + good + bad + ugly + libav, so the plugin
+// dir pulls in ffmpeg, aom, dav1d, x264, x265, faac, fdk-aac, libass, little-cms2 —
+// and GTK+3, into a GTK4 runtime. Around 250 plugins whose closure is most of a
+// media distribution.
+//
+// So the rule is not "guess the codecs", it is "ship the AUDIO PATH", and the two
+// differ in a way that matters: the audio path is what `@gjsify/webaudio` is built
+// on — decodebin over appsrc, convert/resample, out through the platform sink — and
+// it is enumerable from that pipeline rather than from a hunch. Video decode,
+// encoding of any kind, streaming and capture are all out.
+//
+// It also keeps a decision out of this file that does not belong to it: x264, x265,
+// faac and fdk-aac are GPL- or patent-encumbered, and redistributing them inside a
+// runtime bundle is a licensing choice for whoever ships the product, not a
+// side effect of a build script reading a directory.
+//
+// EVERY SKIP IS LOGGED with its count by the builders. A plugin missing from the
+// payload is the failure this whole area exists to prevent, so the one thing that
+// must not happen is dropping them quietly.
+
+/**
+ * Plugin base names (no `libgst` prefix, no extension) the bundles ship.
+ *
+ * Grouped by the reason each is here, because "why is this one in the list" is the
+ * question a future reader has. Names are GStreamer's plugin names, identical on
+ * every platform — the builders add the platform's prefix/suffix.
+ */
+export const GST_AUDIO_PLUGINS = [
+    // The pipeline's skeleton. `coreelements` is queue/capsfilter/fakesink/tee;
+    // `app` is appsrc + appsink, which IS the JS boundary — @gjsify/webaudio pushes
+    // encoded bytes into one and pulls PCM out of the other.
+    'coreelements',
+    'app',
+    // What decodebin needs to work at all: typefind decides the format, playback
+    // provides decodebin/uridecodebin itself.
+    'typefindfunctions',
+    'playback',
+    // Parsers, then the decoders. Together these cover what a browser's
+    // decodeAudioData is expected to take: WAV, MP3, AAC-in-M4A, Ogg/Vorbis, Opus,
+    // FLAC. `audioparsers` supplies the mp3/aac/flac parsers decodebin autoplugs.
+    'audioparsers',
+    'wavparse',
+    'isomp4',
+    'ogg',
+    'vorbis',
+    'opus',
+    'flac',
+    'mpg123',
+    'alaw',
+    'mulaw',
+    'auparse',
+    'audioconvert',
+    'audioresample',
+    'audiorate',
+    'audiomixer',
+    'volume',
+    'audiotestsrc',
+    // Output. `autodetect` is autoaudiosink, which picks the platform sink below.
+    'autodetect',
+    'osxaudio', // darwin
+    'wasapi2', // win32 (modern); `directsound` remains as the fallback
+    'directsound',
+];
+
+/** `true` when this plugin file belongs in the bundle. */
+export function isBundledGstPlugin(fileName) {
+    const base = fileName
+        .replace(/^libgst/, '')
+        .replace(/\.(dylib|so|dll)$/i, '')
+        .toLowerCase();
+    return GST_AUDIO_PLUGINS.includes(base);
+}

--- a/packages/node-gi/scripts/gst-plugins.mjs
+++ b/packages/node-gi/scripts/gst-plugins.mjs
@@ -68,10 +68,21 @@ export const GST_AUDIO_PLUGINS = [
     'directsound',
 ];
 
-/** `true` when this plugin file belongs in the bundle. */
+/**
+ * `true` when this plugin file belongs in the bundle.
+ *
+ * The `lib` prefix is OPTIONAL, and getting that wrong shipped an empty bundle.
+ * GStreamer names a plugin `libgstcoreelements.dylib` on darwin and
+ * `gstcoreelements.dll` on Windows; a `^libgst` strip therefore left the Windows
+ * leaf as `gstcoreelements`, matched nothing, and skipped ALL 83 plugins — while
+ * the build stayed green, because the typelib symmetry gate checks typelib against
+ * LIBRARY and knows nothing about plugins. A bundle with libgstreamer, both Gst
+ * typelibs and no elements is exactly the "healthy, then no element decodebin"
+ * shape this file exists to prevent.
+ */
 export function isBundledGstPlugin(fileName) {
     const base = fileName
-        .replace(/^libgst/, '')
+        .replace(/^(lib)?gst/, '')
         .replace(/\.(dylib|so|dll)$/i, '')
         .toLowerCase();
     return GST_AUDIO_PLUGINS.includes(base);

--- a/packages/node-gi/scripts/typelib-backers.mjs
+++ b/packages/node-gi/scripts/typelib-backers.mjs
@@ -78,13 +78,24 @@ export const REQUIRED_NAMESPACES = [
 ];
 
 /**
- * What `--windowing` is FOR: libadwaita + GtkSourceView. Asserting the typelibs
- * here (and not only the dylibs, which the workflows grep for) is what makes the
- * superset's promise checkable — with the drop filter in place, a missing
+ * What `--windowing` is FOR: libadwaita + GtkSourceView + GStreamer. Asserting the
+ * typelibs here (and not only the dylibs, which the workflows grep for) is what
+ * makes the superset's promise checkable — with the drop filter in place, a missing
  * libadwaita would otherwise take `Adw-1.typelib` out of the bundle quietly and
  * leave a green build that ships no Adwaita at all.
+ *
+ * `Gst` + `GstApp` are here because `@gjsify/webaudio` imports exactly those two and
+ * neither was in ANY bundle. Measured on the published win32 tarball: 40 typelibs
+ * present, not one of them GStreamer's. So `new AudioContext()` threw `Failed to
+ * require Gst 1.0` on the batteries-included runtime and took the whole application
+ * down — fixed as a CRASH by #1089, fixed as MISSING AUDIO here.
+ *
+ * `GstApp` is not decoration. The decode pipeline is appsrc → decodebin → appsink,
+ * and `pipeline.get_by_name('src').push_buffer(…)` resolves only once the GstApp
+ * namespace is registered; without it the failure is a perfectly loaded Gst and
+ * `push_buffer is not a function` at the first sample.
  */
-export const WINDOWING_REQUIRED_NAMESPACES = ['Adw', 'GtkSource'];
+export const WINDOWING_REQUIRED_NAMESPACES = ['Adw', 'GtkSource', 'Gst', 'GstApp'];
 
 function splitList(value, separator) {
     if (!value) return [];


### PR DESCRIPTION
Closes #1092. **Draft** — neither platform can be verified from the dev machine (no macOS; no MSVC/Python on the Windows test VM), so CI is the judge here.

## The gap

Measured on the published `@gjsify/gtk-runtime-win32-x64`, listed from the Windows 11 VM: **40 typelibs, not one of them GStreamer's.** So `new AudioContext()` threw `Failed to require Gst 1.0` on a machine whose GTK worked perfectly. #1089 made that non-fatal — this makes audio actually work.

## What ships

- `Gst` + `GstApp` join `WINDOWING_REQUIRED_NAMESPACES`. That is what stops them being a *promise*: the typelib planner drops any typelib it cannot back, so without the libraries the bundle would simply have no Gst — green and silent, exactly the shape the 0.27.1 tarballs had when they carried `Adw-1.typelib` with no libadwaita.
- **Two** library seeds per platform. The closure walk reaches gstbase/audio/pbutils/tag/video from libgstreamer but **not** libgstapp — a gst-plugins-base library only an appsrc/appsink user links, which is precisely what the decode pipeline is.
- The **plugins**, which are the part that does the work, get the treatment the gdk-pixbuf loaders already get: darwin copies → relocates to `@loader_path/..` → re-signs → verifies with everything else; Windows copies and walks their backing DLLs into `bin/`.
- `gst-plugin-scanner`, plus `GST_PLUGIN_SCANNER` / `GST_PLUGIN_SYSTEM_PATH` in node-gi's loader. Without the scanner GStreamer degrades to in-process scanning — which works until the first plugin that crashes on load takes the app down instead of itself. `SYSTEM_PATH` rather than `GST_PLUGIN_PATH` (the user's own additive override) also suppresses the compiled-in default, so a foreign GStreamer on the host cannot mix its plugins with the bundle's.

**Everything the prefix has, not a curated element list.** Guessing which codecs an app will meet fails *silently* when the guess is wrong. The size is printed in the build log instead, so the payload is a number somebody can act on.

## Windows builds it from source

Nothing prebuilt exists to lift. The gvsbuild release publishes exactly `GTK3_Gvsbuild` and `GTK4_Gvsbuild`; gstreamer.freedesktop.org dropped its separate devel package, so whether its installer `.exe` carries typelibs is unverified — and an installer is the wrong thing to extract in CI.

gvsbuild defines `gstreamer` / `gst-plugins-base` / `gst-plugins-good` with `-Dintrospection=enabled`, which guarantees the typelibs and matches the ABI already in the prefix. It **will rebuild dependencies** (the extracted zip carries no build markers), so:

- the step is cached, and the key is scoped to the **one** job that builds GStreamer — sharing it with the two jobs that don't would let them save a Gst-free prefix under it and poison the windowing job;
- `release.yml` gains the prefix cache it never had, or every release would pay the build again.

macOS is one formula: brew's `gstreamer` bundles base/good/bad/ugly/libav with introspection, added to both verbatim formula lists.

## What to watch in CI

1. Does gvsbuild complete inside the timeout, and what does it drag in?
2. `Gst-1.0.typelib` + `GstApp-1.0.typelib` in the prefix — asserted right after the build, so it fails there rather than three jobs later with "no element decodebin".
3. Bundle size on both platforms.
4. The darwin relocation verification over the new plugin images.

Still missing, and I would rather add it once the above is green: a proof that actually **decodes** something on the published bundle — the audio equivalent of the windowing proof. Without it the bundle can ship every plugin and still be wired wrong.