### PR TITLE
fix(webgl): link the redistributable CRT on win32

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -2090,7 +2090,26 @@ jobs:
           rem to the vcvars call that establishes the rest of the toolchain env.
           rem What it is NOT: /w, /std:cNN, or any diagnostic suppression.
           set INCLUDE=%GTK_PREFIX%\include;%INCLUDE%
-          meson setup build . -Dprebuilt_vala_c=vala-c-export || exit /b 1
+          rem --buildtype=release is LOAD-BEARING ON WINDOWS, and on no other
+          rem platform. meson's default buildtype is `debug`, whose MSVC meaning
+          rem is not "keep the symbols" but `b_vscrt=mdd` — link the DEBUG CRT.
+          rem MEASURED on the win11-gjsify VM against the artifact of the green
+          rem dispatch (run 30808747504): that gwebgl.dll imports
+          rem VCRUNTIME140D.dll and ucrtbased.dll, which ship ONLY with Visual
+          rem Studio and which Microsoft's redistribution terms forbid shipping.
+          rem Every other import (epoxy-0, gdk_pixbuf-2.0-0, glib-2.0-0,
+          rem gobject-2.0-0) resolved from the batteries-included GTK bundle, so
+          rem the DLL was two files away from working and failed with a bare
+          rem "Das angegebene Modul wurde nicht gefunden" naming gwebgl.dll —
+          rem the dependency, never the dependent.
+          rem
+          rem WHY THE LOAD TEST BELOW CANNOT CATCH IT: windows-latest HAS Visual
+          rem Studio, so the debug CRT resolves there and the probe goes green on
+          rem the one artifact no user can load. That is not a gap in the probe —
+          rem it is the runner being unrepresentative in exactly the dimension the
+          rem probe cannot see, which is why the assertion after it reads the
+          rem import table instead of loading anything.
+          meson setup build . -Dprebuilt_vala_c=vala-c-export --buildtype=release || exit /b 1
           meson compile -C build || exit /b 1
 
       - name: Collect @gjsify/webgl prebuilds
@@ -2133,6 +2152,44 @@ jobs:
             exit 1
           }
           Write-Host "typelib records a .dll leaf"
+
+      # The CRT a Windows prebuild links is a REDISTRIBUTION question, and it is
+      # the one property this runner cannot answer by loading the artifact:
+      # windows-latest ships Visual Studio, so a debug-CRT DLL loads here and
+      # fails on every machine that does not. Read the import table instead —
+      # a static property of the file, identical on every host.
+      #
+      # THE INCIDENT. `meson setup` was called without `--buildtype`, meson
+      # defaults to `debug`, and MSVC's reading of `debug` is `b_vscrt=mdd`. The
+      # green dispatch (run 30808747504) therefore published a gwebgl.dll
+      # importing VCRUNTIME140D.dll + ucrtbased.dll, and it took a real Windows
+      # desktop to notice, because the load test above passed on it.
+      #
+      # The `D`/`d` suffix is the whole signal: VCRUNTIME140D / ucrtbased /
+      # MSVCP140D are the debug images, and Microsoft's terms forbid shipping
+      # them at all — so this is a licence gate as much as a portability one.
+      - name: Assert the prebuild links the REDISTRIBUTABLE CRT
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dll = "packages/framework/webgl/prebuilds/$env:PREBUILD/gwebgl.dll"
+          # vswhere locates dumpbin the way node-gi.yml's windowing bundle does,
+          # rather than hard-coding an edition or assuming a vcvars-primed shell.
+          $vs = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $dumpbin = Get-ChildItem "$vs\VC\Tools\MSVC" -Recurse -Filter dumpbin.exe -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\Hostx64\\x64\\' } | Select-Object -First 1
+          if (-not $dumpbin) { Write-Host "::error::dumpbin.exe not found under $vs"; exit 1 }
+          $imports = & $dumpbin.FullName /dependents $dll |
+            Select-String -Pattern '^\s{4}(\S+\.dll)$' | ForEach-Object { $_.Matches[0].Groups[1].Value }
+          Write-Host "imports: $($imports -join ', ')"
+          # Match the debug CRT by NAME, not by a blanket `*d.dll` — `epoxy-0.dll`
+          # and `libpng16d.dll`-shaped leaves would both trip a loose pattern.
+          $debugCrt = $imports | Where-Object { $_ -match '^(vcruntime\d+d|ucrtbased|msvcp\d+d|concrt\d+d)\.dll$' }
+          if ($debugCrt) {
+            Write-Host "::error::gwebgl.dll links the DEBUG CRT ($($debugCrt -join ', ')). Those ship only with Visual Studio and may not be redistributed, so this artifact cannot load on an end-user machine. Build with --buildtype=release (MSVC: b_vscrt=md)."
+            exit 1
+          }
+          Write-Host "CRT is redistributable"
 
       # ── THE LOAD TEST ────────────────────────────────────────────────────
       #

--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -2101,7 +2101,8 @@ jobs:
           rem gobject-2.0-0) resolved from the batteries-included GTK bundle, so
           rem the DLL was two files away from working and failed with a bare
           rem "Das angegebene Modul wurde nicht gefunden" naming gwebgl.dll —
-          rem the dependency, never the dependent.
+          rem the DEPENDENT, never the missing dependency, which is why the
+          rem message sends you looking at the one file you know is present.
           rem
           rem WHY THE LOAD TEST BELOW CANNOT CATCH IT: windows-latest HAS Visual
           rem Studio, so the debug CRT resolves there and the probe goes green on
@@ -2182,6 +2183,15 @@ jobs:
           $imports = & $dumpbin.FullName /dependents $dll |
             Select-String -Pattern '^\s{4}(\S+\.dll)$' | ForEach-Object { $_.Matches[0].Groups[1].Value }
           Write-Host "imports: $($imports -join ', ')"
+          # A parse that matched NOTHING must not read as "clean" — that is the
+          # same vacuous-pass shape as the bundle builder's ANGLE seed, which
+          # silently matched no file and let a GL-less bundle call itself
+          # windowing. gwebgl.dll links glib and the CRT at minimum, so an empty
+          # list means dumpbin's format moved, not that the DLL is dependency-free.
+          if ($imports.Count -lt 2) {
+            Write-Host "::error::parsed $($imports.Count) imports from dumpbin — expected several. The output format changed and this check is no longer reading anything; fix the parse rather than trusting the pass."
+            exit 1
+          }
           # Match the debug CRT by NAME, not by a blanket `*d.dll` — `epoxy-0.dll`
           # and `libpng16d.dll`-shaped leaves would both trip a loose pattern.
           $debugCrt = $imports | Where-Object { $_ -match '^(vcruntime\d+d|ucrtbased|msvcp\d+d|concrt\d+d)\.dll$' }

--- a/packages/node-gi/gtk-runtime-win32-x64/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/README.md
@@ -145,8 +145,9 @@ both sufficient and the simplest mechanism.
   gvsbuild GTK4 release ZIP ships none, so the bundle carries `epoxy-0.dll` —
   GL *dispatch* — and no GL *implementation*. On a host with a vendor OpenGL ICD
   that is invisible; on a GPU-less one (VM, RDP, CI) every `Gtk.GLArea` fails
-  with `No GL implementation is available`. Measured on the win11-gjsify VM; see
-  the webgl-on-win32 entry in `status/open-todos.md`. gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
+  with `No GL implementation is available`. Measured on the win11-gjsify VM;
+  tracked as #1097, with the reasoning in the webgl-on-win32 entry of
+  `status/open-todos.md`. gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
   `glib-compile-schemas`, `gtk4-update-icon-cache`, `fc-cache`) in `<prefix>/bin`.
   Each data step is defensive — a missing tree/tool WARNs and continues (the DLL +
   typelib bundle is always produced).

--- a/packages/node-gi/gtk-runtime-win32-x64/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/README.md
@@ -140,8 +140,13 @@ both sufficient and the simplest mechanism.
   ```
   The GdkWin32 backend is compiled **into** `libgtk-4-*.dll` (GTK4 builds every
   backend in), so there is no separate backend DLL — the caches (`loaders.cache`,
-  `gschemas.compiled`, `icon-theme.cache`) + the ANGLE/librsvg backers are the
-  additions. gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
+  `gschemas.compiled`, `icon-theme.cache`) + the librsvg backer are the
+  additions. The builder also seeds ANGLE (`libEGL`/`libGLESv2`), but the
+  gvsbuild GTK4 release ZIP ships none, so the bundle carries `epoxy-0.dll` —
+  GL *dispatch* — and no GL *implementation*. On a host with a vendor OpenGL ICD
+  that is invisible; on a GPU-less one (VM, RDP, CI) every `Gtk.GLArea` fails
+  with `No GL implementation is available`. Measured on the win11-gjsify VM; see
+  the webgl-on-win32 entry in `status/open-todos.md`. gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
   `glib-compile-schemas`, `gtk4-update-icon-cache`, `fc-cache`) in `<prefix>/bin`.
   Each data step is defensive — a missing tree/tool WARNs and continues (the DLL +
   typelib bundle is always produced).

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1304,7 +1304,9 @@ What is still OPEN, i.e. what a promotion owes beyond that green dispatch:
   bundle-CONTENTS decision, so it belongs with the other "what does the win32
   bundle ship" work rather than here. The positive-assertion rule the typelib
   backers already follow (`REQUIRED_NAMESPACES`) is the shape the fix wants: a
-  `--windowing` bundle that resolves no GL should FAIL its build, not warn.
+  `--windowing` bundle that resolves no GL should FAIL its build, not warn —
+  and it must fail on "the seed matched nothing", not merely on "a named file is
+  absent", or the next unmatched pattern reproduces this. Tracked as #1097.
 - **Promotion is ONE change**: the `win32-x64` token in `gjsify.platforms`, a
   generated `@gjsify/webgl-win32-x64` package (`generate-platform-packages.mjs
   --write`) whose npm name is bootstrapped via `gjsify onboard` BEFORE the

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1247,7 +1247,26 @@ in that block's header comment — do not duplicate them here.
 under cl.exe 19.51 with zero language diagnostics, `gwebgl.dll` links, the
 typelib records a `.dll` leaf, and `Gwebgl.WebGLRenderingContext` resolves
 through `@gjsify/node-gi` — so the library is really loaded, not merely found.
-What remains is a DECLARATION decision, not an engineering unknown.
+
+**"What remains is a DECLARATION decision, not an engineering unknown" — that
+sentence stood here and was WRONG, and the way it was wrong is the entry.** The
+green artifact was a DEBUG build: `meson setup` ran without `--buildtype`, meson
+defaults to `debug`, and MSVC's reading of `debug` is `b_vscrt=mdd`. Measured on
+the win11-gjsify VM against the published artifact of that very run, `gwebgl.dll`
+imports `VCRUNTIME140D.dll` and `ucrtbased.dll` — images that ship only with
+Visual Studio and that Microsoft's terms forbid redistributing. Every other
+import (`epoxy-0`, `gdk_pixbuf-2.0-0`, `glib-2.0-0`, `gobject-2.0-0`) resolved
+from the batteries-included GTK bundle, so the library was two files short of
+working and said so as `Failed to load shared library 'gwebgl.dll'` — naming the
+dependent, never the missing dependency. The load test could not see it because
+`windows-latest` HAS Visual Studio: the one artifact no user could load is
+exactly the one the runner is equipped to load. Fixed by `--buildtype=release`
+plus an import-table assertion that runs BEFORE the load test, because the
+property is about redistribution and is answered by reading the file, not by
+loading it. The general lesson is not "pass --buildtype": it is that a CI host
+provisioned as a DEVELOPER machine silently satisfies developer-only
+dependencies, so any artifact leaving that host needs at least one check that
+inspects rather than executes.
 
 What is still OPEN, i.e. what a promotion owes beyond that green dispatch:
 
@@ -1261,7 +1280,31 @@ What is still OPEN, i.e. what a promotion owes beyond that green dispatch:
 - **The load test proves `dlopen` + `…_get_type`, never RENDERING.** A
   display-less runner cannot drive a `Gtk.GLArea`, the same gap the darwin note
   in `build-prebuilds-macos-experimental` records. Pixels need a real desktop —
-  the win11-gjsify VM is the machine for it.
+  the win11-gjsify VM is the machine for it. **Now measured there, and the
+  blocker is one layer BELOW webgl: there is no GL implementation at all.**
+  `Gdk.Display.create_gl_context()` fails with `No GL implementation is
+  available`, so `three-geometry-teapot` opens a fully correct Adwaita window
+  and paints that string where the teapot belongs — a `Gtk.GLArea` failure, not
+  a `gi://Gwebgl` one. Two independent causes, and BOTH have to go:
+  (a) the VM's display adapter is QEMU/QXL with no OpenGL ICD registered under
+  `HKLM\...\OpenGLDrivers`, so Windows offers only the GDI generic OpenGL 1.1
+  that GTK4 rejects; (b) **the batteries-included win32 bundle ships no GL
+  implementation either** — its 41 DLLs include `epoxy-0.dll`, which is the GL
+  *dispatch* layer and resolves nothing on its own. The windowing builder
+  already seeds `/^libEGL.*\.dll$/i` + `/^libGLESv2.*\.dll$/i`, and those
+  patterns matched NOTHING: the gvsbuild GTK4 release ZIP carries no ANGLE. So a
+  seed that silently matches nothing is how the bundle came to promise
+  "windowing" while shipping no GL — and both places that named ANGLE as shipped
+  (the licence paragraph below, and `gtk-runtime-win32-x64/README.md`) were
+  describing the seed list rather than the artifact; both are corrected.
+  Consequence for the showcases: on a Windows host WITH a vendor ICD the GL
+  showcases should work once webgl is promoted, but on a GPU-less host (VM, RDP
+  session, CI) all three stay dark. Shipping ANGLE would fix both, since its
+  libGLESv2 targets D3D11 and D3D11 has the WARP software rasteriser — that is a
+  bundle-CONTENTS decision, so it belongs with the other "what does the win32
+  bundle ship" work rather than here. The positive-assertion rule the typelib
+  backers already follow (`REQUIRED_NAMESPACES`) is the shape the fix wants: a
+  `--windowing` bundle that resolves no GL should FAIL its build, not warn.
 - **Promotion is ONE change**: the `win32-x64` token in `gjsify.platforms`, a
   generated `@gjsify/webgl-win32-x64` package (`generate-platform-packages.mjs
   --write`) whose npm name is bootstrapped via `gjsify onboard` BEFORE the
@@ -1303,7 +1346,9 @@ have made this PR depend on that one landing first.
 
 `@gjsify/gtk-runtime-{darwin-arm64,darwin-x64,win32-x64}` each carry 37–45
 relocated LGPL/MPL/GPL libraries (GTK, GLib, Pango, cairo, freetype, fontconfig,
-harfbuzz, libadwaita, GtkSourceView, and on win32 also ANGLE, librsvg, libxml2)
+harfbuzz, libadwaita, GtkSourceView, and on win32 also librsvg, libxml2; ANGLE
+is SEEDED by the win32 builder but absent from the gvsbuild ZIP, so no shipped
+bundle contains it — see the webgl-on-win32 entry)
 and all three declare `"license": "MIT"` — the terms of their own three source
 files, not of the payload.
 


### PR DESCRIPTION
## What

The win32 `@gjsify/webgl` exploratory leg built `gwebgl.dll` against the **debug CRT**, producing an artifact that cannot load on any Windows machine without Visual Studio installed. Fixed with `--buildtype=release`, plus an assertion that keeps it fixed.

Also corrects two docs that listed ANGLE among the win32 GTK bundle's payload.

## How it was found

Measured on the `win11-gjsify` VM — a real Windows desktop, no MSVC, no Python — against the *published artifact* of the green dispatch (run 30808747504):

```
gwebgl.dll imports:
  KERNEL32.dll          in-system
  VCRUNTIME140D.dll     MISSING   <-- debug CRT
  epoxy-0.dll           in-bundle
  gdk_pixbuf-2.0-0.dll  in-bundle
  glib-2.0-0.dll        in-bundle
  gobject-2.0-0.dll     in-bundle
  ucrtbased.dll         MISSING   <-- debug CRT
```

Every GTK-side dependency resolved from the batteries-included bundle. The library was **two files short of working**, and said so as `Failed to load shared library 'gwebgl.dll'` — naming the dependent, never the missing dependency.

`meson setup` was called without `--buildtype`. meson defaults to `debug`, and MSVC's reading of `debug` is not "keep the symbols" but `b_vscrt=mdd`. `VCRUNTIME140D` / `ucrtbased` ship only with Visual Studio, and Microsoft's terms forbid redistributing them — so this is a licence gate as much as a portability one.

## Why CI was green

`windows-latest` **has** Visual Studio, so the debug CRT resolves there and the load test passes on the one artifact no user can load. That is not a gap in the probe — the runner is unrepresentative in exactly the dimension a load test cannot see.

So the new check **reads the import table** rather than loading anything: redistribution is a static property of the file, identical on every host. It runs *before* the load test, matches the debug CRT by name (`vcruntime\d+d|ucrtbased|msvcp\d+d|concrt\d+d`) rather than a loose `*d.dll` that `epoxy-0.dll` would trip, and locates `dumpbin` via `vswhere` the way `node-gi.yml` already does.

The generalisable lesson, recorded in `status/open-todos.md`: a CI host provisioned as a *developer* machine silently satisfies developer-only dependencies, so any artifact leaving it needs at least one check that **inspects** rather than **executes**.

## The ANGLE correction

While measuring the GL showcases on the same VM: the `--windowing` bundle's 41 DLLs include `epoxy-0.dll` — GL *dispatch* — and no GL *implementation*. The builder does seed `libEGL`/`libGLESv2`, but those patterns match nothing, because the gvsbuild GTK4 release ZIP carries no ANGLE. A seed that silently matches nothing is how the bundle came to promise "windowing" while shipping no GL.

Two places described that seed list as shipped payload; both are corrected. **No bundle-contents change here** — that decision belongs with the other "what does the win32 bundle ship" work.

## Verification

- `--buildtype=release` verified by dispatching `prebuilds.yml` on this branch and re-reading the resulting artifact's import table on the VM (result in a comment below).
- The three required checks are unaffected: this touches a `workflow_dispatch`-only leg plus docs.

## Not fixed here

`three-geometry-teapot` still cannot render on a GPU-less Windows host, for a reason one layer below webgl: `Gdk.Display.create_gl_context()` fails with `No GL implementation is available`. Two independent causes — the VM's QXL adapter registers no OpenGL ICD, and the bundle ships no software GL. Both are recorded in the ledger with the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
