### PR TITLE
feat(webgl): compile WebGL2 shaders on desktop GL 4.1

### DIFF
--- a/packages/framework/webgl/README.md
+++ b/packages/framework/webgl/README.md
@@ -132,10 +132,10 @@ consumer installs only the artifact that fits its platform.
 | `linux-x64` | ✅ `libgwebgl.so` + `Gwebgl-0.1.typelib` | native runner |
 | `linux-arm64` | ✅ | native runner |
 | `linux-ppc64`, `linux-s390x`, `linux-riscv64` | ✅ | QEMU emulation |
-| `darwin-arm64` / `darwin-x64` | ✅ `libgwebgl.dylib` + `Gwebgl-0.1.typelib` | native runner — **WebGL1 only, see below** |
+| `darwin-arm64` / `darwin-x64` | ✅ `libgwebgl.dylib` + `Gwebgl-0.1.typelib` | native runner — **WebGL2 via a shader-dialect rewrite, see below** |
 | Windows | ❌ | — no Vala/GI bridge in this repo targets Windows |
 
-**macOS renders — WebGL1 only.** Measured on macOS 15.7.8 / x86_64 with gtk 4.22 and
+**macOS renders, WebGL1 and WebGL2.** Measured on macOS 15.7.8 / x86_64 with gtk 4.22 and
 libepoxy 1.5.10: `Gtk.GLArea` realizes a `GdkMacosGLContext`, and this bridge draws real
 pixels through it. That describes the GL stack once GTK is loaded — reaching it needed
 `DYLD_LIBRARY_PATH=/usr/local/lib` exported by hand, because the `Gtk-4.0` typelib names a
@@ -150,7 +150,22 @@ platform, not from the bridge:
   GL 4.1 on macOS.
 - Desktop GL 4.1 has **no GLSL ES 3.00 compiler** (that needs `ARB_ES3_compatibility`, GL 4.3),
   so `#version 300 es` shaders — i.e. all WebGL2 content, including three.js ≥ r163 and
-  Excalibur 0.32 — do not compile. `#version 100` (WebGL1) does, via `ARB_ES2_compatibility`.
+  Excalibur 0.32 — do not compile as written. `#version 100` (WebGL1) does, via
+  `ARB_ES2_compatibility`, which is core from 4.1; that one-version gap between the two
+  extensions is the entire reason WebGL1 worked here first.
+
+  **`shaderSource()` now closes it by rewriting the dialect**, and only where it must: on a
+  desktop context that lacks `ARB_ES3_compatibility`, `#version 300 es` becomes
+  `#version <the context's GLSL> core` (4.10 on macOS). Nothing else in the source changes,
+  which is a measured claim rather than a hopeful one — a three.js-shaped GLES 3.00 pair
+  (`layout(location=)` on attributes and fragment outputs, a `layout(std140)` block,
+  `texture()`, `isampler2D` + `texelFetch`, `textureLod`, MRT, precision statements) and
+  eleven separately probed edge constructs all compile on GLSL 4.10 with just that
+  substitution. Measured end to end on macOS 15.7.9 / GL 4.1 core: compiles, links, draws,
+  and `readPixels` returns the shader's colour. `#version 100` is left byte-for-byte alone,
+  and a context that already speaks GLSL ES 3.00 — Mesa's `4.6 (Compatibility Profile)` on
+  win32, GLES anywhere — is not rewritten at all.
+
   Of the 219 GL entry points the library references, exactly two are absent from Apple's
   `OpenGL.framework` (`glInvalidateFramebuffer`, `glInvalidateSubFramebuffer`, both GL 4.3);
   they are gated on `epoxy_gl_version() >= 43` because libepoxy aborts rather than returning

--- a/packages/framework/webgl/src/ts/webgl2.spec.ts
+++ b/packages/framework/webgl/src/ts/webgl2.spec.ts
@@ -130,6 +130,44 @@ export default async () => {
                 gl2.deleteShader(sh);
             });
 
+            await it('leaves the source alone on a context that speaks GLSL ES 3.00', async () => {
+                // The three tests around this one assert the OUTCOME (it compiles,
+                // it links, it draws). This one asserts the MECHANISM, because the
+                // outcome is identical whether the dialect was rewritten or never
+                // needed rewriting — and those are opposite states to be in.
+                //
+                // `getShaderSource` reports what GL was actually handed, so the
+                // round-trip is the only way to see which of the two happened.
+                // On GLES (every Linux CI host) and on a desktop context with
+                // `ARB_ES3_compatibility` the source must survive byte-for-byte:
+                // rewriting there would be changing a consumer's shader for no
+                // reason. On macOS's GL 4.1, which has no such extension, the
+                // version line must come back as desktop GLSL.
+                const sh = gl2.createShader(gl2.VERTEX_SHADER)!;
+                gl2.shaderSource(sh, VS300);
+                const stored = gl2.getShaderSource(sh) ?? '';
+                const version = stored.split('\n')[0].trim();
+                const rest = stored.split('\n').slice(1).join('\n');
+
+                expect(version === '#version 300 es' || /^#version \d{3} core$/.test(version)).toBeTruthy();
+                // Whatever happened to line 1, NOTHING else may change.
+                expect(rest).toBe(VS300.split('\n').slice(1).join('\n'));
+                gl2.deleteShader(sh);
+            });
+
+            await it('never rewrites a WebGL1 #version 100 shader', async () => {
+                // The non-regression that matters most. `#version 100` compiles on
+                // macOS through `ARB_ES2_compatibility` (core from GL 4.1) and is
+                // the reason WebGL1 worked on darwin before WebGL2 did. A rewrite
+                // that reached it would break the case that already worked, on the
+                // one platform the rewrite exists for.
+                const src = ['#version 100', 'attribute vec4 aPos;', 'void main(){ gl_Position = aPos; }'].join('\n');
+                const sh = gl2.createShader(gl2.VERTEX_SHADER)!;
+                gl2.shaderSource(sh, src);
+                expect(gl2.getShaderSource(sh)).toBe(src);
+                gl2.deleteShader(sh);
+            });
+
             await it('#version 300 es program links and renders green', async () => {
                 // makeProgram works with WebGL2 context too — cast to WebGLRenderingContext
                 const prog = makeProgram(gl2 as unknown as WebGLRenderingContext, VS300, FS300);

--- a/packages/framework/webgl/src/vala/webgl-rendering-context-base.vala
+++ b/packages/framework/webgl/src/vala/webgl-rendering-context-base.vala
@@ -55,6 +55,12 @@ namespace Gwebgl {
         protected int lastError = GL_NO_ERROR;
 
         /**
+         * The `#version` token to rewrite a GLSL ES 3.00 shader to, or 0 when
+         * this context needs no rewrite. See {@link translateShaderDialect}.
+         */
+        protected int shader_dialect_target = 0;
+
+        /**
          * The vertex-array object that STANDS IN for WebGL's object 0.
          *
          * 0 means "this context does not need one" — which is every context but
@@ -89,6 +95,12 @@ namespace Gwebgl {
             // platform it fixes. It stays PUBLIC so it is callable and inspectable
             // once those types catch up, and it is idempotent.
             ensureDefaultVertexArray();
+            // Decided ONCE, here, for the same reason and at the same moment as
+            // the stand-in VAO above: the context is current, and the answer
+            // cannot change for its lifetime. Doing it per `shaderSource()` call
+            // would put two `glGetString`s and an extension walk on the path a
+            // renderer takes for every shader it compiles.
+            shader_dialect_target = detectShaderDialectTarget();
 
             this.webgl_constants.insert("UNPACK_FLIP_Y_WEBGL", UNPACK_FLIP_Y_WEBGL);
             this.webgl_constants.insert("UNPACK_PREMULTIPLY_ALPHA_WEBGL", UNPACK_PREMULTIPLY_ALPHA_WEBGL);
@@ -1573,9 +1585,118 @@ namespace Gwebgl {
             glScissor(x, y, width, height);
         }
 
+        /**
+         * The `#version` token a GLSL ES 3.00 shader must be rewritten to on this
+         * context, or 0 when it must be left exactly as the consumer wrote it.
+         *
+         * WHY A REWRITE IS NEEDED AT ALL, and only here. `#version 300 es` is
+         * accepted by a desktop GL compiler through `ARB_ES3_compatibility`,
+         * which is CORE FROM GL 4.3. macOS caps CGL at 4.1 and therefore does not
+         * have it — measured, `version '300' is not supported` — while it DOES
+         * have `ARB_ES2_compatibility` (core from 4.1), which is exactly why
+         * WebGL1's `#version 100` compiles there today and must not be touched.
+         * The one-version gap between those two extensions is the whole reason
+         * WebGL1 works on macOS and WebGL2 does not.
+         *
+         * So the predicate is the EXTENSION, not the OS and not the version
+         * alone: Mesa on win32 reports `4.6 (Compatibility Profile)` and has
+         * `ARB_ES3_compatibility`, so it compiles the consumer's own dialect and
+         * a rewrite there would be gratuitous — changing source we were not asked
+         * to change, on a context that never needed it.
+         *
+         * Returns 0 for a GLES context (the dialect IS native there), for a
+         * desktop context that already speaks GLSL ES 3.00, and for a desktop
+         * GLSL below 3.30 — below that there are no `layout` qualifiers, so the
+         * rewrite could not produce a compilable shader and failing at
+         * `#version` is the more honest error.
+         */
+        private int detectShaderDialectTarget() {
+            unowned string? version = glGetString(GL_VERSION);
+            if (version == null || version.has_prefix("OpenGL ES ")) {
+                return 0;
+            }
+            if (versionAtLeast(version, 4, 3)) {
+                return 0;
+            }
+            foreach (unowned string ext in getSupportedExtensions()) {
+                if (ext == "GL_ARB_ES3_compatibility") {
+                    return 0;
+                }
+            }
+            unowned string? glsl = glGetString(GL_SHADING_LANGUAGE_VERSION);
+            if (glsl == null) {
+                return 0;
+            }
+            string[] parts = glsl.split(".", 3);
+            if (parts.length < 2) {
+                return 0;
+            }
+            int major = int.parse(parts[0]);
+            int minor = int.parse(parts[1]);
+            // "4.10" spells the minor as 10, "4.6" as 6 — both mean 4.60/4.10 in
+            // `#version` terms, which is a two-digit minor.
+            int token = major * 100 + (minor >= 10 ? minor : minor * 10);
+            return token >= 330 ? token : 0;
+        }
+
+        /**
+         * Rewrite a GLSL ES 3.00 shader into the desktop dialect this context
+         * compiles. Returns `source` unchanged whenever nothing is needed.
+         *
+         * ONLY THE `#version` LINE CHANGES, and that is a measured scope rather
+         * than a hopeful one. On macOS 15.7.9 / GL 4.1 core / GLSL 4.10, a
+         * three.js-shaped GLES 3.00 pair — `layout(location=)` on attributes AND
+         * fragment outputs, a `layout(std140)` uniform block, `texture()`,
+         * `isampler2D` + `texelFetch`, `textureLod`, MRT, precision statements —
+         * compiles clean with only this substitution, as do `invariant
+         * gl_Position`, a fragment shader with no precision statement at all,
+         * `gl_FragDepth`, `sampler2DShadow`, `uint`/bitfield ops, `gl_VertexID`,
+         * `textureGrad`/`textureOffset`, `mediump` on a struct member and a
+         * dynamically-indexed sampler array. GLSL ES 3.00 and GLSL 4.10 simply
+         * agree on everything a WebGL2 consumer emits.
+         *
+         * `#extension … : require` is deliberately NOT rewritten. three.js 0.185
+         * emits exactly two (`GL_ANGLE_clip_cull_distance`,
+         * `GL_ANGLE_multi_draw`) and emits them only when the context advertises
+         * those extensions, which a desktop GL context does not — so the case
+         * this would guard against cannot arise from the consumer that motivated
+         * the work, and silently downgrading a `require` to `enable` would turn a
+         * shader's stated hard requirement into a warning behind its back.
+         */
+        private string translateShaderDialect(string source) {
+            if (shader_dialect_target == 0 || !source.contains("#version")) {
+                return source;
+            }
+            var translated = new StringBuilder.sized(source.length + 8);
+            bool rewritten = false;
+            string[] lines = source.split("\n");
+            for (int i = 0; i < lines.length; i++) {
+                // The directive must be the first thing in the shader bar
+                // comments and blank lines, so the FIRST `#version` is the only
+                // one that can be real — a later match is inside a string or a
+                // comment and rewriting it would corrupt the source.
+                if (!rewritten && lines[i].strip().has_prefix("#version")) {
+                    rewritten = true;
+                    if (lines[i].contains("300") && lines[i].contains("es")) {
+                        translated.append_printf("#version %d core", shader_dialect_target);
+                        if (i < lines.length - 1) {
+                            translated.append_c('\n');
+                        }
+                        continue;
+                    }
+                }
+                translated.append(lines[i]);
+                if (i < lines.length - 1) {
+                    translated.append_c('\n');
+                }
+            }
+            return translated.str;
+        }
+
         public void shaderSource(/*WebGLShader*/ uint shader, string source) {
-            string[] sources = new string[]{ source };
-            int[] length = new int[1]{ source.length };
+            string translated = translateShaderDialect(source);
+            string[] sources = new string[]{ translated };
+            int[] length = new int[1]{ translated.length };
             glShaderSource(shader, 1, sources, length);
         }
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -558,14 +558,28 @@ What is still open:
   GL backend is a version line. That the route EXISTS was never in doubt: Safari and Chrome both
   ship WebGL2 on macOS, on a stack capped at the same 4.1. **Decision: (b)** — rewrite the dialect
   in the Vala layer at `shaderSource()` time for a desktop-GL context, NOT (a) declaring darwin
-  WebGL1-only and not (c) shipping ANGLE. Still to be done and NOT yet claimed: the rewrite itself
-  (`#version`, plus `: require` → `: enable` for GLES-only extension names), and the API-level GLES
-  3.0 features desktop GL 4.1 spells differently — `GL_PRIMITIVE_RESTART_FIXED_INDEX` (4.3 on
-  desktop; 4.1 has `glPrimitiveRestartIndex` + `GL_PRIMITIVE_RESTART`, which is what ANGLE emulates
-  with) and the mandatory ETC2/EAC formats (absent on desktop, unused by three.js/Excalibur).
-  Until the rewrite lands, "webgl works on darwin" still means **WebGL1-only**, and the OS-axis
-  declaration in `packages/framework/webgl/package.json` promises a loadable prebuild, NOT a
-  WebGL2-capable one.
+  WebGL1-only and not (c) shipping ANGLE. **DONE**, and measured end to end on macOS 15.7.9 /
+  GL 4.1 core through the real library: an unmodified `#version 300 es` pair compiles, links,
+  draws, and `readPixels` returns the shader's colour — the first WebGL2 CONTENT this repo has
+  drawn on darwin. `#version 100` comes back byte-for-byte unchanged in the same run.
+  **The predicate is the EXTENSION, not the OS**: `ARB_ES3_compatibility` (core from GL 4.3) is
+  what makes a desktop compiler accept the ES dialect, so Mesa's `4.6 (Compatibility Profile)` on
+  win32 has it and is deliberately NOT rewritten — rewriting a context that never needed it would
+  be changing a consumer's shader for nothing. The mirror of that extension is why WebGL1 worked
+  here first: `ARB_ES2_compatibility` is core from 4.1, and the ONE version between the two is the
+  whole of what separated WebGL1 from WebGL2 on this platform.
+  Deliberately NOT done, with the reason rather than a shrug: `: require` → `: enable` is not
+  rewritten, because three.js 0.185 emits exactly two `require` directives
+  (`GL_ANGLE_clip_cull_distance`, `GL_ANGLE_multi_draw`) and only when the context ADVERTISES
+  those extensions, which a desktop GL context does not — so the case cannot arise from the
+  consumer that motivated the work, and silently downgrading a shader's stated hard requirement
+  to a warning behind its back is worse than the failure it would hide.
+  Still open: the API-level GLES 3.0 features desktop GL 4.1 spells differently —
+  `GL_PRIMITIVE_RESTART_FIXED_INDEX` (4.3 on desktop; 4.1 has `glPrimitiveRestartIndex` +
+  `GL_PRIMITIVE_RESTART`, which is what ANGLE emulates with) and the mandatory ETC2/EAC formats
+  (absent on desktop, unused by three.js/Excalibur). Neither is reached by the showcases, so
+  neither is claimed as working; both are shader-independent and would surface as a draw-time
+  error, not a compile failure.
 - ~~**`getSupportedExtensions()` trips a GLib assertion on every desktop-GL context.**~~ **CLOSED**
   (#1101). A core profile makes `glGetString(GL_EXTENSIONS)` return NULL, and the split
   dereferenced it — `g_strsplit: assertion 'string != NULL' failed` here, a silent process death on


### PR DESCRIPTION
Follow-up to #1103, which decided this route. macOS caps CGL at GL 4.1, so `#version 300 es` — every WebGL2 shader, including all of three.js ≥ r163 and Excalibur 0.32 — did not compile there and the WebGL2 showcases drew nothing.

## The blocker was never the API

GL 4.1 core is a superset of GLES 3.0: VAOs, UBOs, instancing, transform feedback, sampler objects, MRT, array textures are all ≤ 4.1. Only the shader **dialect** is refused, because accepting it needs `ARB_ES3_compatibility` — **core from GL 4.3**.

Its mirror is why WebGL1 worked here first. `ARB_ES2_compatibility` is **core from GL 4.1**, so `#version 100` compiles on the very same context. Measured, one context, three sources:

```
4.1core  GL_VERSION=4.1  GLSL=4.10  profile_mask=0x1 (CORE)
    no #version, attribute/varying    FAIL  "#version required and missing."
    #version 100 explicit             OK
    #version 300 es                   FAIL  "version '300' is not supported"
```

That one version between the two extensions is the whole of what separated WebGL1 from WebGL2 on this platform — and it is why the rewrite must not touch `#version 100`.

## What changed

`shaderSource()` rewrites `#version 300 es` to the context's own desktop GLSL (`#version 410 core` on macOS) and changes nothing else. **The scope is measured, not hopeful.** A three.js-shaped GLES 3.00 pair — `layout(location=)` on attributes *and* fragment outputs, a `layout(std140)` block, `texture()`, `isampler2D` + `texelFetch`, `textureLod`, MRT, precision statements — compiles on GLSL 4.10 with only that substitution, as do eleven constructs probed separately for being the likely breakers:

```
invariant gl_Position                  OK      uint / uvec4 / bitfield ops        OK
no precision statement at all          OK      gl_VertexID / gl_InstanceID        OK
gl_FragDepth                           OK      textureGrad + textureOffset        OK
sampler2DShadow + texture(vec3)        OK      mediump in a struct member         OK
#extension GL_OES_standard_derivatives OK      array of samplers, dynamic index   OK
#extension GL_EXT_shader_texture_lod   OK
```

**The predicate is the extension, not the OS and not the version alone.** Mesa on win32 reports `4.6 (Compatibility Profile)` and *has* `ARB_ES3_compatibility`, so it compiles the consumer's own dialect and is deliberately left alone — rewriting a context that never needed it would be changing a shader we were not asked to change. GLES contexts are untouched for the same reason, which is every Linux CI host, so this PR cannot move Linux behaviour.

## Deliberately not done

`: require` → `: enable` is **not** rewritten. three.js 0.185 emits exactly two `require` directives (`GL_ANGLE_clip_cull_distance`, `GL_ANGLE_multi_draw`) and only when the context advertises those extensions, which a desktop GL context does not. So the case cannot arise from the consumer that motivated this, and silently downgrading a shader's stated hard requirement to a warning behind its back is worse than the failure it would hide.

Still open and not claimed: `GL_PRIMITIVE_RESTART_FIXED_INDEX` (4.3 on desktop) and the mandatory ETC2/EAC formats. Both are shader-independent and would surface as a draw-time error, not a compile failure; neither is reached by the showcases.

## Verification

End to end on macOS 15.7.9 / GL 4.1 core, through the real built library:

```
context: OpenGL 4.1
  GLSL ES 3.00 vertex      COMPILES  first line now: "#version 410 core"
  GLSL ES 3.00 fragment    COMPILES  first line now: "#version 410 core"
  GLSL ES 1.00 (WebGL1)    COMPILES  first line now: "#version 100"
  program                  LINKS
  draw                     error 0x0
  pixel at (0,0)           [0, 255, 0, 255]
```

The pixel is the point: that is WebGL2 **content** rendering on darwin, which nothing in this repo had done before.

Construction still queues no GL error (`0x0` after both context constructions and after a second `getSupportedExtensions()`) — the detection added here runs in the same constructor and must not reintroduce what #1101 removed.

Two new tests assert the **mechanism** rather than the outcome, because a rewritten context and a never-needed-rewriting context are indistinguishable by outcome and are opposite states to be in: a `getShaderSource` round-trip pins that only line 1 may differ, and a second pins that a WebGL1 shader is never touched at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)