### PR TITLE
fix(webgl): inject a #version a core profile accepts

### DIFF
--- a/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
+++ b/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
@@ -253,7 +253,13 @@ const shaderLifecycleMethods: ShaderLifecycleMethods & ThisType<WebGLContextBase
                 const glArea = this.canvas.getGlArea();
                 const es = glArea.get_use_es();
                 const usesGlsl1Syntax = /\b(attribute|varying)\b/.test(source);
-                const version = usesGlsl1Syntax ? (es ? '100' : '120') : this._getGlslVersion(es);
+                // A GLSL1-shaped source must stay GLSL1 even on a WebGL2 context,
+                // which is why this does NOT go through `_getGlslVersion` — that
+                // one is overridden to answer `300 es` there. It used to inline
+                // `'120'`, and desktop GLSL 1.20 is a COMPATIBILITY dialect a core
+                // profile rejects outright; `_getGlsl1Version` knows the measured
+                // answer for both kinds of desktop context.
+                const version = usesGlsl1Syntax ? this._getGlsl1Version(es) : this._getGlslVersion(es);
                 if (version) {
                     source = '#version ' + version + '\n' + preamble + source;
                 } else if (preamble) {

--- a/packages/framework/webgl/src/ts/webgl-context-base.ts
+++ b/packages/framework/webgl/src/ts/webgl-context-base.ts
@@ -297,7 +297,72 @@ export abstract class WebGLContextBase {
     }
 
     _getGlslVersion(es: boolean): string {
-        return es ? '100' : '120';
+        return this._getGlsl1Version(es);
+    }
+
+    /**
+     * The `#version` a GLSL ES 1.00-SHAPED shader must carry — the dialect with
+     * `attribute`, `varying` and `gl_FragColor`. Deliberately NOT overridden by
+     * the WebGL2 context: such a source stays GLSL1 wherever it appears.
+     *
+     * On a desktop context the answer used to be an unconditional `'120'`, and
+     * desktop GLSL 1.20 is a COMPATIBILITY-profile dialect. A core profile
+     * rejects the directive outright — `version '120' is not supported`, then
+     * `#version required and missing`, then a syntax error on the first
+     * `varying` — so every versionless shader died on macOS, which is the one
+     * platform that gets a core profile. Measured on the
+     * `three-postprocessing-pixel` showcase: its fourteen GLSL ES 3.00 shaders
+     * compiled and its two versionless ones did not, leaving the scene black
+     * behind a fully-drawn Adwaita window.
+     *
+     * `'100'` is the right answer rather than a workaround: it is the dialect
+     * the source is actually written in, and `ARB_ES2_compatibility` — CORE FROM
+     * GL 4.1 — is precisely the extension that makes a desktop compiler accept
+     * it. Measured on macOS 15.7.9 / GL 4.1 core, GLSL1-shaped body:
+     * `100` OK, `110` FAIL, `120` FAIL.
+     *
+     * The version gate keeps the old answer where nothing better exists: below
+     * GL 4.1 there is no `ARB_ES2_compatibility`, and such a context can only be
+     * a compatibility profile anyway — which is exactly where `120` works.
+     */
+    _getGlsl1Version(es: boolean): string {
+        return es ? '100' : this._atLeastGlVersion(4, 1) ? '100' : '120';
+    }
+
+    /**
+     * The `#version` token of the context's OWN desktop GLSL — `'410'` for
+     * GLSL 4.10 — for a versionless shader written in the MODERN dialect
+     * (`in`/`out`, no `gl_FragColor`).
+     *
+     * Derived rather than a hand-picked floor, because the driver's own version
+     * is by construction one it accepts, and on any context that can be a core
+     * profile it is ≥ 1.40 — which is the whole requirement. Falls back to
+     * `'130'` where no version can be read, the pre-core case the previous
+     * hardcoded literal was right about.
+     */
+    protected _desktopGlslVersion(): string {
+        const glsl = this._gl.getString(0x8b8c /* GL_SHADING_LANGUAGE_VERSION */);
+        if (!glsl || glsl.startsWith('OpenGL ES ')) return '130';
+        const [major, minor] = glsl.split('.', 2).map((part) => Number.parseInt(part, 10));
+        if (!Number.isFinite(major) || !Number.isFinite(minor)) return '130';
+        // "4.10" spells the minor as 10, "4.6" as 6 — `#version` wants two digits.
+        return String(major * 100 + (minor >= 10 ? minor : minor * 10));
+    }
+
+    /**
+     * Is the RAW GL version at least `major.minor`, on a DESKTOP context?
+     *
+     * False for GLES, whose versions answer a different question entirely.
+     * Read off `glGetString(GL_VERSION)` rather than `getParameter(VERSION)`,
+     * which this class answers with the WebGL spelling (`"WebGL 1.0 …"`) and so
+     * cannot be parsed for a driver version.
+     */
+    protected _atLeastGlVersion(major: number, minor: number): boolean {
+        const version = this._gl.getString(0x1f02 /* GL_VERSION */);
+        if (!version || version.startsWith('OpenGL ES ')) return false;
+        const [haveMajor, haveMinor] = version.split('.', 2).map((part) => Number.parseInt(part, 10));
+        if (!Number.isFinite(haveMajor) || !Number.isFinite(haveMinor)) return false;
+        return haveMajor > major || (haveMajor === major && haveMinor >= minor);
     }
 
     // ─── Foundational helpers used across multiple split modules ──────────

--- a/packages/framework/webgl/src/ts/webgl2-rendering-context.ts
+++ b/packages/framework/webgl/src/ts/webgl2-rendering-context.ts
@@ -53,8 +53,22 @@ export class WebGL2RenderingContext extends WebGLContextBase implements WebGL2Re
         this._init();
     }
 
+    /**
+     * `'130'` here was the same defect as the base class's `'120'`, and equally
+     * unmeasured: measured on macOS 15.7.9 / GL 4.1 core with a modern (`out`)
+     * body, `#version 130` FAILS while `140`, `150` and `410 core` compile — a
+     * core profile supports 1.40 upwards and nothing below. So a versionless
+     * modern shader was uncompilable there for exactly the reason a versionless
+     * GLSL1 one was.
+     *
+     * The context's OWN GLSL version is the answer, not a floor picked by hand:
+     * it is by construction the highest the compiler accepts, and on any context
+     * that can be core it is ≥ 1.40. `_desktopGlslVersion()` falls back to `130`
+     * only where it cannot read one, which is the pre-core case the old literal
+     * was right about.
+     */
     override _getGlslVersion(es: boolean): string {
-        return es ? '300 es' : '130';
+        return es ? '300 es' : this._desktopGlslVersion();
     }
 
     // ─── WebGL2 overrides for WebGL1 validation that's too strict ─────────

--- a/packages/framework/webgl/src/ts/webgl2.spec.ts
+++ b/packages/framework/webgl/src/ts/webgl2.spec.ts
@@ -155,6 +155,36 @@ export default async () => {
                 gl2.deleteShader(sh);
             });
 
+            await it('compiles a VERSIONLESS GLSL1 shader — the injected #version must suit the profile', async () => {
+                // A shader with no `#version` gets one from `_wrapShader`, and the
+                // desktop answer used to be a hardcoded `120`. Desktop GLSL 1.20
+                // is a COMPATIBILITY dialect: measured on macOS 15.7.9 / GL 4.1
+                // core, `#version 100` compiles and `110`/`120` do not, so every
+                // versionless shader was uncompilable on the one platform that
+                // gets a core profile. `three-postprocessing-pixel` rendered a
+                // black scene behind a complete Adwaita window because of exactly
+                // these two shaders.
+                //
+                // Asserted through compilation rather than by reading the injected
+                // line back: what matters is that the driver accepts it, and the
+                // right token differs per context (100 on GLES and on desktop
+                // >= 4.1, 120 below it).
+                const src = [
+                    'attribute vec4 aPos;',
+                    'varying vec2 vUv;',
+                    'void main(){ vUv = aPos.xy; gl_Position = aPos; }',
+                ].join('\n');
+                const sh = gl2.createShader(gl2.VERTEX_SHADER)!;
+                gl2.shaderSource(sh, src);
+                gl2.compileShader(sh);
+                if (!gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)) {
+                    console.error('versionless GLSL1 log:', gl2.getShaderInfoLog(sh));
+                    console.error('injected source:', gl2.getShaderSource(sh)?.split('\n')[0]);
+                }
+                expect(gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)).toBeTruthy();
+                gl2.deleteShader(sh);
+            });
+
             await it('never rewrites a WebGL1 #version 100 shader', async () => {
                 // The non-regression that matters most. `#version 100` compiles on
                 // macOS through `ARB_ES2_compatibility` (core from GL 4.1) and is


### PR DESCRIPTION
Found by running the showcases on the macOS VM after #1104 landed. `three-postprocessing-pixel` drew a **fully correct Adwaita window with a black scene inside it** — the shape the ledger had called the "black window".

## What it was

A shader with no `#version` gets one from `_wrapShader`, and the desktop answer was hardcoded — `120` in the base class, `130` in the WebGL2 override. Both are dialects a **core profile rejects outright**, and macOS is the one platform that gets a core profile.

Measured on macOS 15.7.9 / GL 4.1 core, one body per directive:

```
GLSL1 body (varying / gl_FragColor)   100 OK     110 FAIL   120 FAIL
modern body (out)                     130 FAIL   140 OK     410 core OK
```

Neither literal had ever been exercised: a GLES context — every Linux CI host — takes the `es` arm and never reaches them.

## How it surfaced

Instrumenting `shaderSource` showed the split exactly:

```
[shaderSource] in=#version 300 es  out=#version 410 core  target=410   × 14   ← #1104's rewrite, fine
[shaderSource] in=#version 120     out=#version 120       target=410   × 2    ← ours, uncompilable
```

Fourteen shaders arrive with an explicit version and compile through the dialect rewrite; the two versionless ones were injected with `120` by this code and failed with `version '120' is not supported` → `#version required and missing` → a syntax error on the first `varying`.

## The fix

`100` rather than `120`, and it is the right answer rather than a workaround: it is the dialect the source is actually written in, and `ARB_ES2_compatibility` — **core from GL 4.1** — is exactly the extension that makes a desktop compiler accept it. The version gate keeps `120` for a context that cannot do better, which can only be a compatibility profile, which is precisely where `120` works.

The modern arm takes the context's **own** GLSL version, derived rather than a hand-picked floor: it is by construction one the driver accepts, and on anything that can be core it is ≥ 1.40.

The GLSL1 decision moves into `_getGlsl1Version`, which the WebGL2 context deliberately does **not** override — a GLSL1-shaped source stays GLSL1 wherever it appears, and inlining the literal at the call site is what kept that one path from ever learning about profiles.

## Result

`three-postprocessing-pixel` renders the scene — cubes, icosahedron, checkered floor, shadows and the pixelation pass — at 100% non-black where it was 32% (the sidebar alone). `three-geometry-teapot` is unchanged, verified as a regression check.

The new test asserts through **compilation**, not by reading the injected line back: what matters is that the driver accepts it, and the correct token differs per context.

## Not in scope

`excalibur-jelly-jumper` was tested in the same pass. Its GL layer is fine — all twelve Excalibur shaders translate and compile — but it fails earlier, loading `/res/tilemaps/level1.tmx` (`Error loading resources` → `Error during scene initialization`), with the asset present in `dist/res`. That is a resource-loading question, not a graphics one, and it reproduces from the showcase's own directory, so it is not an invocation artefact. Filed separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)