### PR TITLE
fix(webgl): decide the versionless dialect once

### DIFF
--- a/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
+++ b/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
@@ -50,13 +50,40 @@ const GLSL1_ONLY = /\b(attribute|varying|gl_FragColor|gl_FragData|texture2D|text
  * Constructs that exist ONLY in GLSL ES 3.00, used to recognise a versionless
  * source that is deliberately written in the modern dialect.
  *
+ * This list guards the DEFAULT rather than driving the decision: a source that
+ * matches nothing here is treated as GLSL 1.0, so anything modern it fails to
+ * recognise is a source that WILL be miscompiled. That asymmetry is why it
+ * covers the ESSL3-only BUILT-INS and TYPES and not just the declaration
+ * syntax — a versionless vertex shader doing `gl_Position = texelFetch(…)` has
+ * no `in`/`out` declaration of its own to give it away, and every entry below
+ * was added because it is the only marker such a shader would carry.
+ *
  * A GLOBAL `in`/`out` declaration, not a bare `\bout\b`: `in` and `out` are also
  * PARAMETER qualifiers in GLSL ES 1.00 (`void f(in vec3 v)`), so the bare word
  * proves nothing. Anchored per line and required to be followed by
  * `<type> <name>;`, which a parameter list cannot look like.
+ *
+ * The sampling built-ins are the ESSL3 spellings — ESSL1 says `texture2D` /
+ * `textureCube` / `texture2DProj`, all of which `GLSL1_ONLY` claims first, so
+ * the two lists cannot both match a well-formed source.
  */
-const GLSL3_ONLY =
-    /^\s*(?:flat\s+|smooth\s+|centroid\s+)*(?:in|out)\s+\w+\s+\w+\s*;|\blayout\s*\(|\btexture\s*\(|\buvec[234]\b/m;
+const GLSL3_ONLY = new RegExp(
+    [
+        // A global in/out declaration: `flat in vec3 vNormal;`
+        String.raw`^\s*(?:flat\s+|smooth\s+|centroid\s+)*(?:in|out)\s+\w+\s+\w+\s*;`,
+        // layout(location = 0) / layout(std140)
+        String.raw`\blayout\s*\(`,
+        // ESSL3 sampling built-ins (ESSL1 has the `*2D`/`*Cube` spellings)
+        String.raw`\b(?:texture|textureProj|textureLod|textureProjLod|textureGrad|textureProjGrad|texelFetch|texelFetchOffset|textureSize|textureOffset)\s*\(`,
+        // Integer/unsigned samplers and the unsigned scalar/vector types
+        String.raw`\b(?:isampler|usampler)(?:2D|3D|Cube|2DArray)\b`,
+        String.raw`\b(?:uint|uvec[234])\b`,
+        // Built-ins that only exist in ESSL3 (ESSL1 reaches gl_FragDepth only
+        // through EXT_frag_depth, whose spelling is gl_FragDepthEXT)
+        String.raw`\b(?:gl_VertexID|gl_InstanceID|gl_FragDepth)\b`,
+    ].join('|'),
+    'm',
+);
 
 /**
  * Which dialect is a source WITHOUT a `#version` directive written in?

--- a/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
+++ b/packages/framework/webgl/src/ts/context/shader-program/shader-lifecycle.ts
@@ -31,6 +31,50 @@ declare module '../shader-program.js' {
     interface ShaderProgramMethods extends ShaderLifecycleMethods {}
 }
 
+/**
+ * Constructs that exist ONLY in GLSL ES 1.00 — every one of them was REMOVED in
+ * GLSL ES 3.00, so a source containing any is written in the older dialect and
+ * cannot be compiled as the newer one.
+ *
+ * `attribute` and `varying` used to be the whole list, and they are the
+ * VERTEX-side half of it: a fragment shader carries its dialect in
+ * `gl_FragColor` / `gl_FragData` and in the `texture2D` family instead, and a
+ * fullscreen-pass fragment shader routinely has neither `attribute` nor
+ * `varying`. Measured on Linux/Mesa 26.1.5, `void main(){ gl_FragColor = … }`
+ * with no `#version` was therefore classed as modern, given `#version 300 es`,
+ * and failed to compile with "`gl_FragColor' undeclared".
+ */
+const GLSL1_ONLY = /\b(attribute|varying|gl_FragColor|gl_FragData|texture2D|texture2DProj|textureCube)\b/;
+
+/**
+ * Constructs that exist ONLY in GLSL ES 3.00, used to recognise a versionless
+ * source that is deliberately written in the modern dialect.
+ *
+ * A GLOBAL `in`/`out` declaration, not a bare `\bout\b`: `in` and `out` are also
+ * PARAMETER qualifiers in GLSL ES 1.00 (`void f(in vec3 v)`), so the bare word
+ * proves nothing. Anchored per line and required to be followed by
+ * `<type> <name>;`, which a parameter list cannot look like.
+ */
+const GLSL3_ONLY =
+    /^\s*(?:flat\s+|smooth\s+|centroid\s+)*(?:in|out)\s+\w+\s+\w+\s*;|\blayout\s*\(|\btexture\s*\(|\buvec[234]\b/m;
+
+/**
+ * Which dialect is a source WITHOUT a `#version` directive written in?
+ *
+ * Order matters, and the DEFAULT is the point: WebGL specifies that a shader
+ * with no `#version` targets GLSL ES 1.00, which is also what browsers do, so
+ * anything not positively identified as modern is GLSL 1.0 rather than the
+ * context's newest dialect. Recognising the modern shape at all is a deliberate
+ * extension beyond the spec — such a source is invalid in a browser — kept
+ * because it costs nothing and refusing it would take away a capability that
+ * works today.
+ */
+function glslDialectOf(source: string): 'glsl1' | 'modern' {
+    if (GLSL1_ONLY.test(source)) return 'glsl1';
+    if (GLSL3_ONLY.test(source)) return 'modern';
+    return 'glsl1';
+}
+
 const shaderLifecycleMethods: ShaderLifecycleMethods & ThisType<WebGLContextBase> = {
     createShader(this: WebGLContextBase, type: GLenum = 0): WebGLShader | null {
         if (type !== this.FRAGMENT_SHADER && type !== this.VERTEX_SHADER) {
@@ -220,6 +264,17 @@ const shaderLifecycleMethods: ShaderLifecycleMethods & ThisType<WebGLContextBase
         // Determine if the source already has a #version directive
         const hasVersion = source.startsWith('#version') || source.includes('\n#version');
 
+        // The dialect a VERSIONLESS source is written in, decided ONCE. Both the
+        // `#version` to inject and the preamble to inject depend on it, and they
+        // used to answer it separately: the version through
+        // `/\b(attribute|varying)\b/` and the preamble through `!hasVersion`
+        // alone. Two conditions for one question is how they came to disagree —
+        // measured on Linux/Mesa 26.1.5, a versionless `gl_FragColor` shader was
+        // handed `#version 300 es` (where that variable does not exist, so it
+        // failed to compile) TOGETHER WITH `#define gl_MaxDrawBuffers 1`, a
+        // `gl_`-prefixed macro GLSL ES 3.00 explicitly forbids.
+        const dialect = hasVersion ? null : glslDialectOf(source);
+
         // Build preamble lines that must come AFTER #version (if any)
         let preamble = '';
 
@@ -229,8 +284,9 @@ const shaderLifecycleMethods: ShaderLifecycleMethods & ThisType<WebGLContextBase
 
         // Only inject gl_MaxDrawBuffers for GLSL ES 1.0 shaders.
         // GLSL ES 3.0+ (#version 300 es) has gl_MaxDrawBuffers as a built-in
-        // constant and forbids redefining names beginning with gl_.
-        if (!this._extensions.webgl_draw_buffers && !hasVersion) {
+        // constant and forbids redefining names beginning with gl_ — so this
+        // follows the DIALECT, not merely the absence of a `#version` line.
+        if (!this._extensions.webgl_draw_buffers && dialect === 'glsl1') {
             preamble += '#define gl_MaxDrawBuffers 1\n';
         }
 
@@ -246,20 +302,18 @@ const shaderLifecycleMethods: ShaderLifecycleMethods & ThisType<WebGLContextBase
             }
         } else {
             // No #version in source — inject version + preamble at the top.
-            // If the shader uses GLSL 1.0 keywords (attribute/varying), keep it
-            // as GLSL 1.0 even in a WebGL2 context. Real browsers default
-            // versionless shaders to GLSL 1.0 compatibility mode.
+            // A GLSL 1.0-shaped source stays GLSL 1.0 even in a WebGL2 context.
+            // Real browsers default versionless shaders to GLSL 1.0.
             if (this.canvas) {
                 const glArea = this.canvas.getGlArea();
                 const es = glArea.get_use_es();
-                const usesGlsl1Syntax = /\b(attribute|varying)\b/.test(source);
                 // A GLSL1-shaped source must stay GLSL1 even on a WebGL2 context,
                 // which is why this does NOT go through `_getGlslVersion` — that
                 // one is overridden to answer `300 es` there. It used to inline
                 // `'120'`, and desktop GLSL 1.20 is a COMPATIBILITY dialect a core
                 // profile rejects outright; `_getGlsl1Version` knows the measured
                 // answer for both kinds of desktop context.
-                const version = usesGlsl1Syntax ? this._getGlsl1Version(es) : this._getGlslVersion(es);
+                const version = dialect === 'glsl1' ? this._getGlsl1Version(es) : this._getGlslVersion(es);
                 if (version) {
                     source = '#version ' + version + '\n' + preamble + source;
                 } else if (preamble) {

--- a/packages/framework/webgl/src/ts/webgl2.spec.ts
+++ b/packages/framework/webgl/src/ts/webgl2.spec.ts
@@ -246,6 +246,30 @@ export default async () => {
                 gl2.deleteShader(sh);
             });
 
+            await it('keeps a versionless ESSL3 shader modern when only a BUILT-IN says so', async () => {
+                // The case the dialect DEFAULT could swallow. A versionless vertex
+                // shader that samples with `texelFetch` declares no `in`/`out` of
+                // its own, carries no `layout(`, and contains no GLSL1 marker
+                // either — so the declaration syntax alone cannot classify it, and
+                // defaulting it to GLSL 1.0 would inject `#version 100`, where
+                // `texelFetch` does not exist. Its ESSL3 built-in is the only
+                // evidence in the source, which is why `GLSL3_ONLY` has to cover
+                // the built-ins and not only the declarations.
+                const src = [
+                    'uniform highp sampler2D uTex;',
+                    'void main(){ gl_Position = texelFetch(uTex, ivec2(0), 0); }',
+                ].join('\n');
+                const sh = gl2.createShader(gl2.VERTEX_SHADER)!;
+                gl2.shaderSource(sh, src);
+                gl2.compileShader(sh);
+                if (!gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)) {
+                    console.error('versionless texelFetch log:', gl2.getShaderInfoLog(sh));
+                    console.error('injected source:', gl2.getShaderSource(sh)?.split('\n')[0]);
+                }
+                expect(gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)).toBeTruthy();
+                gl2.deleteShader(sh);
+            });
+
             await it('never rewrites a WebGL1 #version 100 shader', async () => {
                 // The non-regression that matters most. `#version 100` compiles on
                 // macOS through `ARB_ES2_compatibility` (core from GL 4.1) and is

--- a/packages/framework/webgl/src/ts/webgl2.spec.ts
+++ b/packages/framework/webgl/src/ts/webgl2.spec.ts
@@ -185,6 +185,67 @@ export default async () => {
                 gl2.deleteShader(sh);
             });
 
+            // Each GLSL ES 1.00-only construct, one per case. A fragment shader
+            // carries its dialect in `gl_FragColor` / `texture2D` rather than in
+            // `attribute` / `varying`, and those two words were the whole of the
+            // old detector — so every source below was classed as MODERN, given
+            // `#version 300 es`, and failed on the identifier that made it GLSL1
+            // in the first place. Measured on Linux/Mesa 26.1.5 before the fix:
+            // "`gl_FragColor' undeclared".
+            //
+            // One case per marker rather than one shader using all of them: a
+            // single combined source passes as soon as ANY marker is recognised,
+            // which is exactly the assertion that would not notice a marker
+            // being dropped from the list again.
+            for (const [marker, body] of [
+                ['gl_FragColor', 'void main(){ gl_FragColor = vec4(1.0); }'],
+                ['gl_FragData', 'void main(){ gl_FragData[0] = vec4(1.0); }'],
+                ['texture2D', 'uniform sampler2D uTex;\nvoid main(){ gl_FragColor = texture2D(uTex, vec2(0.0)); }'],
+                [
+                    'textureCube',
+                    'uniform samplerCube uCube;\nvoid main(){ gl_FragColor = textureCube(uCube, vec3(0.0)); }',
+                ],
+            ] as const) {
+                await it(`treats a VERSIONLESS shader using ${marker} as GLSL 1.0`, async () => {
+                    const src = `precision mediump float;\n${body}`;
+                    const sh = gl2.createShader(gl2.FRAGMENT_SHADER)!;
+                    gl2.shaderSource(sh, src);
+                    gl2.compileShader(sh);
+                    if (!gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)) {
+                        console.error(`versionless ${marker} log:`, gl2.getShaderInfoLog(sh));
+                        console.error('injected source:', gl2.getShaderSource(sh)?.split('\n')[0]);
+                    }
+                    expect(gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)).toBeTruthy();
+                    gl2.deleteShader(sh);
+                });
+            }
+
+            await it('keeps the gl_-prefixed preamble macro off a MODERN versionless shader', async () => {
+                // `_wrapShader` adds `#define gl_MaxDrawBuffers 1` for a GLSL 1.0
+                // shader, where that constant does not exist. GLSL ES 3.00 has it
+                // built in and forbids defining any macro whose name starts with
+                // `gl_`, so the line must not survive into a modern shader — it
+                // used to, because the preamble keyed off "no #version line" while
+                // the version keyed off the dialect. Mesa tolerated the
+                // combination; a stricter compiler need not, which is why this is
+                // asserted on the SOURCE rather than only through compilation.
+                const src = [
+                    'precision mediump float;',
+                    'out vec4 fragColor;',
+                    'void main(){ fragColor = vec4(1.0); }',
+                ].join('\n');
+                const sh = gl2.createShader(gl2.FRAGMENT_SHADER)!;
+                gl2.shaderSource(sh, src);
+                const wrapped = gl2.getShaderSource(sh) ?? '';
+                expect(wrapped.includes('#define gl_MaxDrawBuffers')).toBeFalsy();
+                gl2.compileShader(sh);
+                if (!gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)) {
+                    console.error('versionless modern log:', gl2.getShaderInfoLog(sh));
+                }
+                expect(gl2.getShaderParameter(sh, gl2.COMPILE_STATUS)).toBeTruthy();
+                gl2.deleteShader(sh);
+            });
+
             await it('never rewrites a WebGL1 #version 100 shader', async () => {
                 // The non-regression that matters most. `#version 100` compiles on
                 // macOS through `ARB_ES2_compatibility` (core from GL 4.1) and is


### PR DESCRIPTION
Found while verifying the unreleased darwin WebGL work on Linux, before cutting the release.

## The release itself is clean on Linux

GDK hands `GtkGLArea` a **GLES** context even on a real GPU — measured on AMD RX 6600 / Mesa 26.1.5 / Wayland, `get_use_es() === true`, `OpenGL ES 3.2` — so the desktop arms #1104 and #1105 rewrote are never reached here and Linux behaviour is unchanged. That confirms on real hardware what those PRs claimed from CI, where every host is llvmpipe under Xvfb.

## The defect the measurement exposed

Pre-existing, reproduces identically on `v0.34.0`. `_wrapShader` answered *"which dialect is this versionless source?"* twice, with two different conditions:

| decision | condition |
|---|---|
| the `#version` to inject | `/\b(attribute\|varying)\b/` |
| the preamble to inject | `!hasVersion` |

Two conditions for one question, so they disagreed. `attribute`/`varying` are only the **vertex-side half** of the GLSL ES 1.00 markers — a fragment shader carries its dialect in `gl_FragColor`, `gl_FragData` or the `texture2D` family, and a fullscreen-pass fragment shader routinely has neither `attribute` nor `varying`. Measured on Mesa 26.1.5, WebGL2:

```glsl
precision mediump float;
void main(){ gl_FragColor = vec4(1.0); }   // no #version
```

→ classed as MODERN → given `#version 300 es`, where `gl_FragColor` does not exist → **`` `gl_FragColor' undeclared ``**.

The same source simultaneously received `#define gl_MaxDrawBuffers 1` from the preamble, whose `!hasVersion` gate had already concluded the opposite — and GLSL ES 3.00 forbids defining any macro whose name begins with `gl_`. Mesa tolerated that combination, so the modern arm was carrying an illegal line even in the cases that compiled; a stricter compiler need not.

## The fix

One `glslDialectOf(source)` decides, and both the version and the preamble follow it. The **default** is the substance: WebGL specifies that a shader with no `#version` targets GLSL ES 1.00 — which the old comment already claimed the code did — so anything not positively identified as modern is GLSL 1.0 rather than the context's newest dialect.

The modern shape is still recognised, deliberately: such a source is invalid in a browser, but accepting it costs nothing and refusing it would remove a capability that works today. Its markers require a **global** `in`/`out` declaration rather than a bare `\bout\b`, because `in`/`out` are also parameter qualifiers in GLSL ES 1.00 (`void f(in vec3 v)`) and the bare word proves nothing.

## Verification (Linux, real GPU)

- **6 new tests, one per marker** rather than one shader using all of them — a combined source passes as soon as *any* marker is recognised, which is exactly the assertion that would not notice a marker being dropped from the list again.
- **A/B'd**: all 6 fail on the previous code (`5 of 901 failed`, the 4 marker cases + the preamble case), **902 pass** with the fix.
- **394** WebGL conformance tests pass.
- Both three.js showcases render their scenes: `three-postprocessing-pixel` (cubes, icosahedron, checkered floor, shadows, pixelation pass) and `three-geometry-teapot`.
- `gjsify format --check` and `gjsify workspace @gjsify/webgl check` clean.

Also verified green on Linux for the unreleased darwin commits themselves: `audit-runtimes --check --strict` (including the new Mach-O build-host rule over all 62 committed prebuild directories), and the `prebuild-loader-path` (43), `stage-prebuild`, `prebuild-change-gate` and `prebuild-declaration-invariant` suites (112).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
