### PR TITLE
fix(example-dom-three-postprocessing-pixel): build a valid URI

### DIFF
--- a/packages/node-gi/gtk-runtime-win32-x64/README.md
+++ b/packages/node-gi/gtk-runtime-win32-x64/README.md
@@ -141,13 +141,36 @@ both sufficient and the simplest mechanism.
   The GdkWin32 backend is compiled **into** `libgtk-4-*.dll` (GTK4 builds every
   backend in), so there is no separate backend DLL — the caches (`loaders.cache`,
   `gschemas.compiled`, `icon-theme.cache`) + the librsvg backer are the
-  additions. The builder also seeds ANGLE (`libEGL`/`libGLESv2`), but the
-  gvsbuild GTK4 release ZIP ships none, so the bundle carries `epoxy-0.dll` —
-  GL *dispatch* — and no GL *implementation*. On a host with a vendor OpenGL ICD
-  that is invisible; on a GPU-less one (VM, RDP, CI) every `Gtk.GLArea` fails
-  with `No GL implementation is available`. Measured on the win11-gjsify VM;
-  tracked as #1097, with the reasoning in the webgl-on-win32 entry of
-  `status/open-todos.md`. gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
+  additions. The bundle carries `epoxy-0.dll` — GL *dispatch* — and **no GL
+  *implementation***; the builder probes for one and records the answer as
+  `manifest.glImplementation` (`--require-gl` makes an empty result fatal, for the
+  promotion that ships one). On a host with a vendor OpenGL ICD that is invisible;
+  on a GPU-less one (VM, RDP, CI) every `Gtk.GLArea` fails with `No GL
+  implementation is available`. Measured on the win11-gjsify VM; tracked as #1097,
+  with the reasoning in the webgl-on-win32 entry of `status/open-todos.md`.
+
+  **Neither obvious way of closing it works as-is**, which is why the bundle still
+  ships none — both measured on 0.34.0:
+  - *ANGLE* (`libEGL`/`libGLESv2`) is what #1097 proposed, and gvsbuild ships none.
+    But adding it would not have helped: this `epoxy-0.dll` is built with **no EGL
+    support at all** (no `epoxy_has_egl` export, no `egl*` entry point), so
+    `gdk_win32_display_get_egl_display()` can never engage. That needs libepoxy
+    rebuilt with `-Degl=enabled` first.
+  - *A desktop ICD in `bin/`* (Mesa's `opengl32.dll` + `libgallium_wgl.dll`) is
+    inert by PLACEMENT: epoxy loads desktop GL with a bare
+    `LoadLibraryA("OPENGL32")`, which Windows answers from the **application
+    directory** and then **System32** — never from `PATH`, the only search the
+    loader's bundle wiring controls. System32's inbox GL 1.1 wins and GTK4 rejects
+    it. Reaching a bundled ICD needs the addon to opt the process into
+    `SetDefaultDllDirectories` + `AddDllDirectory(<bundle>/bin)`.
+
+  **The host-side answer works today** and needs no bundle change: register Mesa as
+  a system OpenGL ICD (`mesa-dist-win`'s `systemwidedeploy.cmd 1` writes
+  `HKLM\…\OpenGLDrivers\MSOGL` → `mesadrv.dll` and leaves the inbox `opengl32.dll`
+  in place as the loader). Measured on the win11-gjsify VM: GDK then reports
+  **OpenGL 4.6, non-legacy**, and `three-geometry-teapot` renders.
+
+  gvsbuild ships the tools this step runs (`gdk-pixbuf-query-loaders`,
   `glib-compile-schemas`, `gtk4-update-icon-cache`, `fc-cache`) in `<prefix>/bin`.
   Each data step is defensive — a missing tree/tool WARNs and continues (the DLL +
   typelib bundle is always produced).

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -355,7 +355,10 @@ console.log(`build-gtk-runtime: copied ${binDlls.size} DLLs -> ${binOut}`);
 // the interesting one and it is stated positively — which patterns were tried and
 // that NONE matched — because the failure this closes was a seed that silently
 // matched nothing while the bundle went on advertising `windowing: true`.
-const glImplementation = describeGlImplementation({ dlls: [...binDlls.values()].map(basename) });
+// `.map((f) => basename(f))`, NOT `.map(basename)`: map passes the INDEX as the
+// second argument and basename reads that as its `suffix`, which throws on the
+// first element. Same shape as `dllList` below.
+const glImplementation = describeGlImplementation({ dlls: [...binDlls.values()].map((f) => basename(f)) });
 if (WINDOWING && glImplementation.matched.length === 0) {
     const message = formatMissingGlImplementation({ gl: glImplementation, prefixBin: gtkBin });
     if (REQUIRE_GL) {

--- a/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
+++ b/packages/node-gi/gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs
@@ -57,6 +57,11 @@ import {
     scanLicenseFiles,
     writeLicensePayload,
 } from '../../scripts/bundle-licenses.mjs';
+import {
+    GL_IMPLEMENTATION_PATTERNS,
+    describeGlImplementation,
+    formatMissingGlImplementation,
+} from '../../scripts/gl-implementation.mjs';
 import { isBundledGstPlugin } from '../../scripts/gst-plugins.mjs';
 import {
     REQUIRED_NAMESPACES,
@@ -84,6 +89,13 @@ const OUT = argValue('--out') ?? join(pkgRoot, 'gtk');
 const PREFIX = argValue('--prefix') ?? process.env.GTK_PREFIX;
 // The full-windowing SUPERSET: also collect the runtime data a real GTK window needs.
 const WINDOWING = process.argv.includes('--windowing');
+// Make "this windowing bundle resolves no GL implementation" FATAL rather than a
+// warning. Off by default because no gvsbuild prefix has ever satisfied it (see
+// GL_IMPLEMENTATION_PATTERNS): turning it on today would fail every win32 bundle
+// build for a gap the bundle cannot currently close. It exists so the promotion
+// that DOES ship a GL implementation can lock the property in the same change,
+// instead of re-deriving it — and so the check is exercised, not just written.
+const REQUIRE_GL = process.argv.includes('--require-gl');
 
 if (process.platform !== 'win32' || process.arch !== 'x64') {
     console.error(`build-gtk-runtime: only supported on win32/x64, not ${process.platform}/${process.arch}`);
@@ -129,17 +141,17 @@ const SEED_PATTERNS = [
 
 // Extra seeds for the WINDOWING superset: libadwaita (the Adw-1 typelib's backing
 // DLL — a real Adw.Application/ApplicationWindow needs it; the display-free
-// conformance never touches Adwaita, so it is NOT in the base seeds), the GL backing
-// a GSK GL renderer picks (ANGLE libEGL/libGLESv2 + epoxy — the cairo renderer needs
-// none, but a real window may negotiate GL), and librsvg (the SVG gdk-pixbuf loader
-// that renders the Adwaita symbolic icons). Most GL/rsvg deps are pulled transitively
-// by the loaders below; naming them keeps the closure complete even if a loader is
-// missing. (Gdk/Gsk/Gtk are all in gtk-4-*.dll, already a base seed.)
+// conformance never touches Adwaita, so it is NOT in the base seeds), the GL
+// dispatch layer epoxy (which GTK links; the cairo renderer needs no GL at all, but
+// a real window may negotiate it), any GL IMPLEMENTATION the prefix happens to carry
+// (see above — none has yet), and librsvg (the SVG gdk-pixbuf loader that renders the
+// Adwaita symbolic icons). Most rsvg deps are pulled transitively by the loaders
+// below; naming them keeps the closure complete even if a loader is missing.
+// (Gdk/Gsk/Gtk are all in gtk-4-*.dll, already a base seed.)
 const WINDOWING_SEED_PATTERNS = [
     /^(lib)?adwaita-1.*\.dll$/i, // gvsbuild leaf: adwaita-1-0.dll (backs the Adw-1 typelib)
     /^(lib)?gtksourceview-5.*\.dll$/i, // gvsbuild leaf: gtksourceview-5-0.dll (backs the GtkSource-5 typelib — the Learn6502 editor)
-    /^libEGL.*\.dll$/i,
-    /^libGLESv2.*\.dll$/i,
+    ...GL_IMPLEMENTATION_PATTERNS,
     /^epoxy.*\.dll$/i,
     /^rsvg.*\.dll$/i,
     /^libxml2.*\.dll$/i,
@@ -336,6 +348,24 @@ for (const src of binDlls.values()) {
     copyFileSync(join(gtkBin, src), join(binOut, src));
 }
 console.log(`build-gtk-runtime: copied ${binDlls.size} DLLs -> ${binOut}`);
+
+// --- 2b. does this bundle carry a GL IMPLEMENTATION? ----------------------
+// Asked of the FINISHED bin/, not of the seed list, so the answer describes the
+// artifact a user installs rather than the intent of the recipe. The negative is
+// the interesting one and it is stated positively — which patterns were tried and
+// that NONE matched — because the failure this closes was a seed that silently
+// matched nothing while the bundle went on advertising `windowing: true`.
+const glImplementation = describeGlImplementation({ dlls: [...binDlls.values()].map(basename) });
+if (WINDOWING && glImplementation.matched.length === 0) {
+    const message = formatMissingGlImplementation({ gl: glImplementation, prefixBin: gtkBin });
+    if (REQUIRE_GL) {
+        console.error(`build-gtk-runtime: ${message}`);
+        process.exit(1);
+    }
+    console.warn(`build-gtk-runtime: WARNING — ${message}`);
+} else if (WINDOWING) {
+    console.log(`build-gtk-runtime: GL implementation in bundle: ${glImplementation.matched.join(', ')}`);
+}
 
 // --- 3. typelibs — only the ones this bundle can actually BACK -------------
 // gvsbuild's typelib dir covers its whole build, not our closure, so copying it
@@ -770,6 +800,9 @@ const manifest = {
         dropped: typelibPlan.dropped.map((t) => ({ namespace: t.key, missing: t.missing })),
         requiredNamespaces,
     },
+    // Windowing-only: a display-free bundle is not expected to rasterise anything,
+    // so the absence of GL there is by design and recording it would read as a gap.
+    ...(WINDOWING ? { glImplementation } : {}),
     licenses: {
         notice: 'THIRD-PARTY-NOTICES.md',
         dir: 'licenses',

--- a/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
+++ b/packages/node-gi/node-gi/test/gtk-runtime-bundle-gates.test.mjs
@@ -58,6 +58,11 @@ import {
     renderThirdPartyNotice,
     scanLicenseFiles,
 } from '../../scripts/bundle-licenses.mjs';
+import {
+    GL_IMPLEMENTATION_PATTERNS,
+    describeGlImplementation,
+    formatMissingGlImplementation,
+} from '../../scripts/gl-implementation.mjs';
 
 // --- a synthetic typelib ----------------------------------------------------
 // girepository's Header, built by hand so the parser is tested against the FORMAT
@@ -771,6 +776,51 @@ test('WINDOWING_DATA_SETS keys every set to a namespace the floor guarantees', a
     assert.ok(
         WINDOWING_DATA_SETS.some((set) => set.id === 'pixbuf-loaders'),
         'the pixbuf loaders are shipped by both builders and belong in the shared list',
+    );
+});
+
+// --- GL implementation vs. GL dispatch (#1097) -----------------------------
+// The shipped 0.34.0 win32 bundle: 41 DLLs, epoxy among them, no rasteriser. It
+// advertised `windowing: true` and every Gtk.GLArea failed with "No GL
+// implementation is available" on a host without a vendor ICD.
+const BUNDLE_0_34_0 = ['gtk-4-1.dll', 'epoxy-0.dll', 'cairo-2.dll', 'glib-2.0-0.dll', 'adwaita-1-0.dll'];
+
+test('epoxy alone is NOT a GL implementation — the bundle that shipped for four releases', () => {
+    const gl = describeGlImplementation({ dlls: BUNDLE_0_34_0 });
+    assert.deepEqual(gl.matched, [], 'epoxy is dispatch; counting it is exactly the misreading #1097 records');
+    assert.deepEqual(gl.dispatch, ['epoxy-0.dll'], 'dispatch is reported, in its own field, so it cannot be misread');
+});
+
+test('a desktop-GL ICD and ANGLE each count, case-insensitively', () => {
+    // Mesa's win32 pair, as `mesa-dist-win` lays it out beside an executable.
+    // Sorted with localeCompare, which orders case-insensitively — `libgallium`
+    // before `OPENGL32`, not after it as a byte sort would put them.
+    const wgl = describeGlImplementation({ dlls: [...BUNDLE_0_34_0, 'OPENGL32.DLL', 'libgallium_wgl.dll'] });
+    assert.deepEqual(wgl.matched, ['libgallium_wgl.dll', 'OPENGL32.DLL']);
+    // ANGLE, which is what #1097 originally proposed shipping.
+    const egl = describeGlImplementation({ dlls: [...BUNDLE_0_34_0, 'libEGL.dll', 'libGLESv2.dll'] });
+    assert.deepEqual(egl.matched, ['libEGL.dll', 'libGLESv2.dll']);
+});
+
+test('the failure names every pattern it tried, not one absent file', () => {
+    // The regression guard: #1097 happened because an unmatched seed was
+    // indistinguishable from a matched one. A message naming a single missing file
+    // would let the NEXT unmatched pattern reproduce it just as quietly.
+    const gl = describeGlImplementation({ dlls: BUNDLE_0_34_0 });
+    const message = formatMissingGlImplementation({ gl, prefixBin: 'C:\\gtk-build\\gtk\\x64\\release\\bin' });
+    for (const pattern of GL_IMPLEMENTATION_PATTERNS) {
+        assert.ok(message.includes(String(pattern)), `the message must state that ${pattern} was tried`);
+    }
+    assert.ok(message.includes('epoxy-0.dll'), 'and that what IS present is dispatch');
+    assert.ok(message.includes('#1097'), 'and where the reasoning lives');
+});
+
+test('the patterns are recorded in the result, so a manifest proves the negative was checked', () => {
+    const gl = describeGlImplementation({ dlls: [] });
+    assert.deepEqual(gl.patterns, GL_IMPLEMENTATION_PATTERNS.map(String));
+    assert.ok(
+        !gl.patterns.some((p) => /epoxy/i.test(p)),
+        'epoxy must never enter the implementation patterns — that is the whole defect',
     );
 });
 

--- a/packages/node-gi/scripts/gl-implementation.mjs
+++ b/packages/node-gi/scripts/gl-implementation.mjs
@@ -1,0 +1,87 @@
+// Does a GTK runtime bundle carry a GL IMPLEMENTATION — the thing that actually
+// rasterises — or only the dispatch layer that promises one?
+//
+// Split out of `gtk-runtime-win32-x64/scripts/build-gtk-runtime.mjs` so the
+// question is answerable in a test without a gvsbuild prefix, a Windows runner or
+// dumpbin. The builder asks it of the FINISHED `bin/`, so the answer describes the
+// artifact a user installs rather than the intent of the recipe.
+//
+// The defect this exists to close (#1097): the win32 windowing builder seeded ANGLE
+// (`libEGL`/`libGLESv2`), those patterns matched NOTHING in the gvsbuild ZIP, and
+// the build stayed green — so four releases shipped a bundle advertising
+// `windowing: true` whose every `Gtk.GLArea` failed with `No GL implementation is
+// available` on any host without a vendor OpenGL ICD. A seed that silently matches
+// nothing is indistinguishable from a seed that matched.
+
+/**
+ * Filenames that ARE a GL implementation, matched case-insensitively against a
+ * bundle's DLL leaf names.
+ *
+ * Two families, either of which would satisfy GDK:
+ *
+ * - `opengl32` / `libgallium_wgl` / `mesadrv` — a desktop-GL ICD reached over WGL.
+ *   Mesa's win32 build ships the first two; `mesadrv.dll` is the name
+ *   `mesa-dist-win` installs a system-wide ICD under.
+ * - `libEGL` / `libGLESv2` — ANGLE, reached over EGL.
+ *
+ * Deliberately NOT here: `epoxy`. libepoxy is the GL *dispatch* layer — it resolves
+ * entry points from whatever implementation the OS provides and supplies none
+ * itself. Counting it is precisely the misreading that made the bundle look
+ * GL-capable, so {@link describeGlImplementation} reports it in its own field.
+ */
+export const GL_IMPLEMENTATION_PATTERNS = [
+    /^opengl32\.dll$/i,
+    /^libgallium_wgl\.dll$/i,
+    /^mesadrv\.dll$/i,
+    /^libEGL.*\.dll$/i,
+    /^libGLESv2.*\.dll$/i,
+];
+
+/** Filenames that are GL DISPATCH only — present, necessary, and not an implementation. */
+export const GL_DISPATCH_PATTERNS = [/^epoxy.*\.dll$/i];
+
+/**
+ * Classify a bundle's DLL leaf names into GL implementation vs. GL dispatch.
+ *
+ * @param {object} options
+ * @param {string[]} options.dlls Leaf filenames present in the bundle's `bin/`.
+ * @returns {{matched: string[], dispatch: string[], patterns: string[]}} `matched`
+ *   and `dispatch` are sorted for a stable manifest; `patterns` records what was
+ *   asked, so a consumer holding only the manifest can see that the negative was
+ *   checked rather than merely unstated.
+ */
+export function describeGlImplementation({ dlls }) {
+    const sorted = (xs) => [...xs].sort((a, b) => a.localeCompare(b));
+    return {
+        matched: sorted(dlls.filter((f) => GL_IMPLEMENTATION_PATTERNS.some((re) => re.test(f)))),
+        dispatch: sorted(dlls.filter((f) => GL_DISPATCH_PATTERNS.some((re) => re.test(f)))),
+        patterns: GL_IMPLEMENTATION_PATTERNS.map(String),
+    };
+}
+
+/**
+ * The message for a windowing bundle that resolves no GL implementation.
+ *
+ * States which patterns were tried and that none matched — the "the seed matched
+ * nothing" form — rather than naming one absent file, because the next unmatched
+ * pattern must not be able to reproduce #1097 quietly. Also names the two reasons
+ * the obvious fixes do not work as-is, so the reader does not re-derive them:
+ * gvsbuild's libepoxy carries no EGL, and a bare `LoadLibraryA("OPENGL32")` is
+ * answered from the application directory and System32, never from `PATH`.
+ *
+ * @param {object} options
+ * @param {ReturnType<typeof describeGlImplementation>} options.gl
+ * @param {string} options.prefixBin The `<prefix>/bin` the closure was drawn from.
+ */
+export function formatMissingGlImplementation({ gl, prefixBin }) {
+    const dispatch = gl.dispatch.join(' + ') || 'epoxy';
+    return (
+        `no GL implementation in this bundle — none of ${gl.patterns.join(', ')} matched anything under ` +
+        `${prefixBin}, and ${dispatch} is GL DISPATCH, which resolves nothing on its own. Every Gtk.GLArea will ` +
+        'fail with "No GL implementation is available" on a host with no vendor OpenGL ICD (VM, RDP session, CI). ' +
+        'Hosts WITH a vendor driver, or with Mesa registered as a system ICD, are unaffected — the implementation ' +
+        'comes from the system there. Note that simply bundling one does not close this: gvsbuild libepoxy is built ' +
+        'without EGL (so ANGLE cannot be reached), and epoxy loads desktop GL by bare name, which Windows answers ' +
+        'from the application directory and System32 but never from PATH. See #1097.'
+    );
+}

--- a/showcases/dom/three-postprocessing-pixel/src/gjs/pixel-window.ts
+++ b/showcases/dom/three-postprocessing-pixel/src/gjs/pixel-window.ts
@@ -4,7 +4,6 @@
 // Original: MIT license, three.js authors (https://threejs.org)
 
 import GObject from 'gi://GObject?version=2.0';
-import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 import Adw from 'gi://Adw?version=1';
 import { WebGLBridge } from '@gjsify/webgl';
@@ -104,8 +103,15 @@ export class PixelWindow extends Adw.ApplicationWindow {
             // itself. The writes this replaces were silent no-ops whose comment
             // claimed they were what made the resize check work.
 
-            const bundleDir = GLib.path_get_dirname(GLib.filename_from_uri(import.meta.url)[0]);
-            const assetBase = `file://${bundleDir}/`;
+            // Derived in URI SPACE, never by pasting `file://` onto a native path.
+            // `GLib.filename_from_uri()` hands back a PLATFORM path, which on win32
+            // is `C:\…\dist` — and `file://${that}/` makes `C:` the URI HOSTNAME, so
+            // GdkPixbuf rejects every texture with "The hostname of the URI … is
+            // invalid" and the scene loads nothing. It only looked right on Linux and
+            // macOS, where an absolute path already starts with the `/` that
+            // `file://` needs. `new URL('./', …)` keeps the value a URL end to end, so
+            // no separator or drive letter is ever handled by hand.
+            const assetBase = new URL('./', import.meta.url).href;
 
             this._demo = start(canvas, { assetBase });
             this.connectControls(this._demo);

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1402,14 +1402,52 @@ What is still OPEN, i.e. what a promotion owes beyond that green dispatch:
   describing the seed list rather than the artifact; both are corrected.
   Consequence for the showcases: on a Windows host WITH a vendor ICD the GL
   showcases should work once webgl is promoted, but on a GPU-less host (VM, RDP
-  session, CI) all three stay dark. Shipping ANGLE would fix both, since its
-  libGLESv2 targets D3D11 and D3D11 has the WARP software rasteriser — that is a
-  bundle-CONTENTS decision, so it belongs with the other "what does the win32
-  bundle ship" work rather than here. The positive-assertion rule the typelib
-  backers already follow (`REQUIRED_NAMESPACES`) is the shape the fix wants: a
-  `--windowing` bundle that resolves no GL should FAIL its build, not warn —
-  and it must fail on "the seed matched nothing", not merely on "a named file is
-  absent", or the next unmatched pattern reproduces this. Tracked as #1097.
+  session, CI) all three stay dark.
+
+  **(a) is CLOSED, and it closes the user-visible symptom on its own.** Mesa 26.1.6
+  registered as a system OpenGL ICD (`mesa-dist-win`'s `systemwidedeploy.cmd 1`:
+  `HKLM\…\OpenGLDrivers\MSOGL` → `mesadrv.dll`, the inbox `opengl32.dll` kept as the
+  loader — no System32 binary replaced, uninstall is option `10`) gives the
+  win11-gjsify VM **OpenGL 4.6, non-legacy**, and `three-geometry-teapot` RENDERS —
+  the first WebGL content this repo has drawn on Windows. `excalibur-jelly-jumper`
+  paints its Excalibur loader instead of the GL error. **The `4.6 (Compatibility
+  Profile)` this file predicted for Mesa/win32 is not what apps get**: GDK asks for
+  a CORE profile, so `is_legacy` is false and the `ensureDefaultVertexArray()` /
+  `ARB_ES3_compatibility` reasoning in the WebGL entries applies on win32 exactly as
+  it does on darwin, not the compatibility-profile branch.
+
+  **(b) survives, and the proposed fix for it was wrong.** Shipping ANGLE would NOT
+  have fixed a GPU-less host: the gvsbuild `epoxy-0.dll` is built with **no EGL
+  support at all** — measured on the shipped 0.34.0 bundle, it exports no
+  `epoxy_has_egl` and contains no `egl*` entry point — so
+  `gdk_win32_display_get_egl_display()` can never engage no matter what `libEGL.dll`
+  is present. That path needs libepoxy rebuilt with `-Degl=enabled` FIRST, which is
+  a gvsbuild-side change. And the other family is inert for a second, independent
+  reason: epoxy resolves desktop GL with a bare `LoadLibraryA("OPENGL32")`, which
+  Windows answers from the **application directory** then **System32** — never from
+  `PATH`, which is the only search the loader's bundle wiring controls (`opengl32`
+  is NOT in `KnownDLLs`, so the app-directory slot is genuinely open). An
+  `opengl32.dll` placed in the bundle's `bin/` is therefore never consulted.
+  Measured three ways on the VM: bundle-local `libEGL`+`libGLESv2`+`libgallium_wgl`
+  → still `No GL implementation is available`; bundle-local `opengl32.dll` preloaded
+  by absolute path via `process.dlopen` → still none (Node *unloads* a DLL that
+  fails to self-register, so the base-name-match trick needs the addon, not JS);
+  the same `opengl32.dll` beside a copied `node.exe` → **GL 4.6, works**, which is
+  what proves the mechanism is placement and nothing else. So a bundled ICD requires
+  the ADDON to opt the process into `SetDefaultDllDirectories(…)` +
+  `AddDllDirectory(<bundle>/bin)` — process-wide DLL-resolution surgery that would
+  also stop other native modules resolving their deps from `PATH`, so it is a
+  decision, not a detail.
+
+  The positive-assertion rule the typelib backers already follow
+  (`REQUIRED_NAMESPACES`) is the shape the fix wants, and **that half is now DONE**:
+  the windowing builder probes the FINISHED `bin/` for a GL implementation, records
+  the answer as `manifest.glImplementation` (with `dispatch` listed separately so
+  epoxy's presence can never be misread as GL), and warns naming every pattern that
+  matched nothing. `--require-gl` makes it fatal; it is off by default only because
+  no gvsbuild prefix satisfies it yet, so turning it on today would fail every win32
+  bundle build for a gap the bundle cannot currently close — the promotion that
+  ships a GL implementation flips it in the same change. Tracked as #1097.
 - **Promotion is ONE change**: the `win32-x64` token in `gjsify.platforms`, a
   generated `@gjsify/webgl-win32-x64` package (`generate-platform-packages.mjs
   --write`) whose npm name is bootstrapped via `gjsify onboard` BEFORE the


### PR DESCRIPTION
## What

`three-postprocessing-pixel` loaded **no textures on win32**. `GLib.filename_from_uri()` returns a *platform* path, so `assetBase` came out as:

```
file://C:\src\...\dist/
```

which makes `C:` the URI **hostname**. GdkPixbuf refused every asset with *"The hostname of the URI … is invalid"*, thrown out of the `src` setter inside a signal handler — so it surfaced as an unhandled exception rather than an image `error` event.

It only ever looked right on Linux and macOS, where an absolute path already begins with the `/` that `file://` needs. Pasting a scheme onto a native path is the bug; the platform hid it.

```diff
-const bundleDir = GLib.path_get_dirname(GLib.filename_from_uri(import.meta.url)[0]);
-const assetBase = `file://${bundleDir}/`;
+const assetBase = new URL('./', import.meta.url).href;
```

`new URL('./', import.meta.url).href` keeps the value a URL from end to end, so no separator and no drive letter is ever handled by hand. `GLib` is no longer needed in this file.

## Measured

On the win11-gjsify VM (Mesa 26.1.6 as a system ICD, GDK reporting OpenGL 4.6), against the published `@gjsify/example-dom-three-postprocessing-pixel@0.34.0` bundle patched at the same expression — the showcase carries a `.blp`, and that VM has no blueprint-compiler, so the built bundle is the only thing runnable there:

- **before** — `GLib.Error: The hostname of the URI "file://C:\...\node-gi/assets/checker.png" is invalid`, no assets.
- **after** — URI error gone, textures load, window and controls correct.

**This fix is not what makes the canvas paint.** What the window then shows is the separate, already-addressed shader-dialect gap: the `OutputShader` fails to link with ``illegal use of reserved word `precision` ``, which #1108 and the `#version` injection landed after v0.34.0 cover. On that published bundle the canvas therefore stays black either way.

## Deliberately not changed

The same `'file://' + path` shape exists in `html-image-element.spec.ts` and `register.spec.ts`. Left alone: those specs run under GJS, and there is no GJS on Windows, so it is latent there rather than live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)