### PR TITLE
docs(showcases): align every showcase README

### DIFF
--- a/showcases/dom/adwaita-storybook-nativescript/README.md
+++ b/showcases/dom/adwaita-storybook-nativescript/README.md
@@ -1,15 +1,53 @@
 # @gjsify/example-dom-adwaita-storybook-nativescript
 
-The full **Adwaita storybook** as a real **NativeScript-Android** app — the same
-component browser as the native **GTK** (`@gjsify/storybook`) and **browser**
-(`@gjsify/adwaita-storybook`) targets, rendered with **real native**
-`@gjsify/adwaita-nativescript` widgets (NOT a webview) via
-`@gjsify/storybook-nativescript`.
+The full **Adwaita storybook** as a real **NativeScript-Android** app — the same component browser as the native **GTK** (`@gjsify/storybook`) and **browser** (`@gjsify/adwaita-storybook`) targets, rendered with **real native** `@gjsify/adwaita-nativescript` widgets (NOT a webview) via `@gjsify/storybook-nativescript`.
 
-All three targets share the renderer-agnostic `*.meta.ts` metadata: this app
-imports it from the GTK showcase's `@gjsify/example-gtk-adwaita-storybook/metas`
-barrel, so every story exposes identical controls and the three targets can be
-compared **1:1** by screenshot.
+All three targets share the renderer-agnostic `*.meta.ts` metadata: this app imports it from the GTK showcase's `@gjsify/example-gtk-adwaita-storybook/metas` barrel, so every story exposes identical controls and the three targets can be compared **1:1** by screenshot.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Renderer | Showcase |
+|---|---|---|
+| **Android (NativeScript)** | `@gjsify/storybook-nativescript` + `@gjsify/adwaita-nativescript` | this one |
+| GTK 4 / GJS · Node · Bun · Deno | `@gjsify/storybook` (native `Adw.*`) | [`adwaita-storybook`](../../gtk/adwaita-storybook) |
+| Browser | `@gjsify/adwaita-storybook` (`@gjsify/adwaita-web` components) | [`adwaita-storybook`](../../gtk/adwaita-storybook) (`build:web`) |
+
+One story contract, three renderers: `@gjsify/storybook-core` holds the renderer-free logic (registry, control binding, controller) and each target is a thin adapter over it.
+
+## Prerequisites
+
+The Android SDK, an emulator or device, and the NativeScript CLI prerequisites — see the [NativeScript setup docs](https://docs.nativescript.org/setup/).
+
+This project is excluded from the root `workspaces` glob (its NativeScript toolchain must not be pulled into every `gjsify install`), but its `@gjsify/*` deps are resolved from the **hoisted workspace** `node_modules` (caret ranges), so the NativeScript CLI must NOT run its own `npm install` — every script passes `--disable-npm-install`.
+
+## Run
+
+```bash
+emulator -avd Medium_Phone_API_36 -gpu host   # boot a device first
+cd showcases/dom/adwaita-storybook-nativescript
+npm run run:android        # or: npm run debug:android  (serves the V8 CDP inspector)
+```
+
+`sync:theme` (run by every script) copies the current `adwaita.css` + `storybook.css` out of the bridge packages, so the app never ships a drifted theme copy.
+
+## What it demonstrates
+
+- A complete component browser — 35 stories, sidebar navigation, live two-way controls — running as a **real native Android app**
+- The SAME stories on three renderers from ONE renderer-agnostic `*.meta.ts` source, imported across package boundaries via the GTK showcase's `./metas` export — so a control added once shows up on all three
+- Native Adwaita widgets on NativeScript (`@gjsify/adwaita-nativescript`), styled with the Adwaita CSS theme + Adwaita Sans, with no webview anywhere
+- The narrow-width shell: a collapsed `AdwNavigationSplitView` (story list ↔ detail + back button), matching the GTK `NavigationSplitView` at phone width
+- The storybook control plane over a third transport — `installStorybookDevtools` exposes `ListStories` / `OpenStory` / `SetStoryArg` plus `DumpTree` / `Screenshot` to an MCP agent over the V8 CDP inspector, the same surface the GTK target serves over DBus
+- 1:1 screenshot comparability between the GTK, browser and Android renderings
+
+## MCP / devtools
+
+`storybook-page.ts` installs the in-app devtools agent + the storybook control surface (`installStorybookDevtools`), so an MCP agent attached over the V8 CDP inspector (`nativescript debug android`) can `ListStories` / `OpenStory` / `SetStoryArg`, `DumpTree` the native Adwaita view tree, and `Screenshot` it — the same control plane as the GTK (`@gjsify/devtools`) and browser targets.
+
+```bash
+gjsify debug --profile nativescript   # bridges the V8 inspector → MCP tools
+```
 
 ## Layout
 
@@ -27,27 +65,19 @@ src/
   stories.ts                aggregated NsStoryModule[] (category order)
 ```
 
-## Run on an Android emulator
+> This showcase is a NativeScript project (it owns `App_Resources/`, `nativescript.config.ts`)
+> and declares no `build`/`check`/`test` scripts, so `gjsify foreach` skips it — it is built and
+> run via the NativeScript CLI.
 
-The `@gjsify/*` deps are resolved from the **hoisted workspace** `node_modules`
-(caret ranges), so the NativeScript CLI must NOT run its own `npm install` —
-every script passes `--disable-npm-install`:
+## Related
 
-```bash
-emulator -avd Medium_Phone_API_36 -gpu host   # boot a device first
-cd showcases/dom/adwaita-storybook-nativescript
-npm run run:android        # or: npm run debug:android  (serves the V8 CDP inspector)
-```
+- [`@gjsify/storybook-nativescript`](../../../packages/nativescript-bridge/storybook) — the NativeScript story renderer
+- [`@gjsify/adwaita-nativescript`](../../../packages/nativescript-bridge/adwaita) — the native Adwaita widget set
+- [`@gjsify/storybook-core`](../../../packages/framework/storybook-core) — the renderer-free storybook logic all three targets share
+- [`@gjsify/stories`](../../../packages/framework/stories) — the pure-TS story contract
+- [`adwaita-storybook`](../../gtk/adwaita-storybook) — the GTK + browser targets and the shared `*.meta.ts` source
+- [`adwaita-widgets-nativescript`](../adwaita-widgets-nativescript) — the smaller de-risking spike for the same widget set
 
-## MCP / devtools
+## License
 
-`storybook-page.ts` installs the in-app devtools agent + the storybook control
-surface (`installStorybookDevtools`), so an MCP agent attached over the V8 CDP
-inspector (`nativescript debug android`) can `ListStories` / `OpenStory` /
-`SetStoryArg`, `DumpTree` the native Adwaita view tree, and `Screenshot` it — the
-same control plane as the GTK (`@gjsify/devtools`) and browser targets.
-
-> This showcase is a NativeScript project (it owns `App_Resources/`,
-> `nativescript.config.ts`); it is a workspace member only for dependency
-> hoisting and declares no `build`/`check`/`test` scripts, so `gjsify foreach`
-> skips it (built/run via the NativeScript CLI).
+MIT

--- a/showcases/dom/adwaita-widgets-nativescript/README.md
+++ b/showcases/dom/adwaita-widgets-nativescript/README.md
@@ -1,31 +1,33 @@
 # @gjsify/example-dom-adwaita-widgets-nativescript
 
-Native **Adwaita widgets on NativeScript-Android** — a real NativeScript app that
-renders Libadwaita-styled components as **real native views** (no webview), and is
-**MCP-drivable** by an LLM agent over the V8 CDP inspector.
+Native **Adwaita widgets on NativeScript-Android** — a real NativeScript app that renders Libadwaita-styled components as **real native views** (no webview), and is **MCP-drivable** by an LLM agent over the V8 CDP inspector.
 
-It is the de-risking spike for bringing GNOME/Adwaita apps to Android (and later
-iOS) via NativeScript, the true-native path:
+It is the de-risking spike for bringing GNOME/Adwaita apps to Android (and later iOS) via NativeScript, the true-native path.
 
-- **`@gjsify/adwaita-nativescript`** — `AdwPreferencesGroup` / `AdwActionRow` /
-  `AdwSwitchRow` built on native NS `StackLayout` / `GridLayout` / `Switch` /
-  `Label`, styled with the Adwaita CSS theme + Adwaita Sans font. The agent's
-  introspection sees the actual Adwaita widget tree (`AdwSwitchRow`), not a DOM.
-- **`@gjsify/devtools-nativescript`** — an in-app agent (`globalThis.__adwDevtools`)
-  reusing the transport-agnostic `@gjsify/devtools-protocol` method registry; the
-  host-side `@gjsify/devtools-mcp` `nativescriptProfile` reaches it over the V8
-  CDP inspector (`Runtime.evaluate`) to `dump_tree` / `screenshot` / `get_property`.
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
-The widget tree is built **programmatically** in `app/home/home-page.ts` (the spike
-validates native rendering + native-tree introspection without the XML
-`registerElement` path).
+## Targets
+
+| Target | Renderer | Showcase |
+|---|---|---|
+| **Android (NativeScript)** | `@gjsify/adwaita-nativescript` — real native NS views | this one |
+| GTK 4 / GJS | native `Adw.*` widgets | [`adwaita-storybook`](../../gtk/adwaita-storybook) |
+| Browser | `@gjsify/adwaita-web` web components | [`adwaita-storybook`](../../gtk/adwaita-storybook) (`build:web`) |
+
+The stack it exercises:
+
+- **`@gjsify/adwaita-nativescript`** — `AdwPreferencesGroup` / `AdwActionRow` / `AdwSwitchRow` built on native NS `StackLayout` / `GridLayout` / `Switch` / `Label`, styled with the Adwaita CSS theme + Adwaita Sans font. The agent's introspection sees the actual Adwaita widget tree (`AdwSwitchRow`), not a DOM.
+- **`@gjsify/devtools-nativescript`** — an in-app agent (`globalThis.__adwDevtools`) reusing the transport-agnostic `@gjsify/devtools-protocol` method registry; the host-side `@gjsify/devtools-mcp` `nativescriptProfile` reaches it over the V8 CDP inspector (`Runtime.evaluate`) to `dump_tree` / `screenshot` / `get_property`.
+
+The widget tree is built **programmatically** in `app/home/home-page.ts` (the spike validates native rendering + native-tree introspection without the XML `registerElement` path).
 
 ## Version line
 
-Targets the **`@nativescript/vite` 8.x** line (Vite 8 / Rolldown / HMR) with the
-NS **9.1.0-alpha** runtime — `@gjsify/nativescript-vite` auto-detects the major and
-skips its Vite-8 compatibility patches (upstream handles Vite 8 / Rolldown
-natively on 8.x). Falls back cleanly to the 9.0.x / `@nativescript/vite@2` line.
+Targets the **`@nativescript/vite` 8.x** line (Vite 8 / Rolldown / HMR) with the NS **9.1.0-alpha** runtime — `@gjsify/nativescript-vite` auto-detects the major and skips its Vite-8 compatibility patches (upstream handles Vite 8 / Rolldown natively on 8.x). Falls back cleanly to the 9.0.x / `@nativescript/vite@2` line.
+
+## Prerequisites
+
+The Android SDK, an emulator or device, and the NativeScript CLI prerequisites — see the [NativeScript setup docs](https://docs.nativescript.org/setup/). This project is excluded from the root `workspaces` glob (its NativeScript toolchain must not be pulled into every `gjsify install`); the `@gjsify/*` packages resolve from the hoisted workspace `node_modules`.
 
 ## Run
 
@@ -37,10 +39,46 @@ nativescript debug android          # same + serve the V8 CDP inspector for the 
 
 ## Drive it with an agent
 
-With `nativescript debug android` running (the in-app devtools agent is
-force-enabled in `app/app.ts`), point the gjsify MCP bridge at the inspector:
+With `nativescript debug android` running (the in-app devtools agent is force-enabled in `app/app.ts`), point the gjsify MCP bridge at the inspector:
 
 ```bash
 gjsify debug --profile nativescript   # bridges the V8 inspector → MCP tools
 # agent tools: get_status · list_toplevels · dump_tree · get_property · screenshot
 ```
+
+## What it demonstrates
+
+- Libadwaita-styled widgets rendering as **real native Android views** — the same design language as GTK/Adwaita, no webview and no DOM
+- One shared widget vocabulary across renderers: an `AdwSwitchRow` on NativeScript is the same contract as the GTK and web ones
+- The Adwaita CSS theme + Adwaita Sans fonts applied to native NS views
+- The gjsify devtools protocol reaching a **third** transport: DBus on GJS, the V8 CDP inspector on NativeScript — one `@gjsify/devtools-protocol` method registry behind both
+- An LLM agent inspecting and screenshotting a running Android app over MCP (`dump_tree` sees `AdwSwitchRow`, not a view-hierarchy dump)
+- `@gjsify/nativescript-vite` building an NS app on the Vite 8 / Rolldown line, with version auto-detection across the 8.x and 9.0.x lines
+
+## Layout
+
+```
+app/
+  app.ts               entry — Application.run({ moduleName: 'app-root' }) + devtools agent
+  app-root.xml         <Frame defaultPage="home/home-page" />
+  home/home-page.*     the Adwaita widget tree, built programmatically
+  app.css              @nativescript/theme + adwaita.css + fonts
+  adwaita.css          widget theme (from @gjsify/adwaita-nativescript)
+  fonts/               Adwaita Sans TTFs
+App_Resources/         Android + iOS platform resources
+nativescript.config.ts bundler: 'vite'
+vite.config.ts         @gjsify/nativescript-vite defineNativescriptConfig()
+```
+
+## Related
+
+- [`@gjsify/adwaita-nativescript`](../../../packages/nativescript-bridge/adwaita) — the native Adwaita widget set
+- [`@gjsify/devtools-nativescript`](../../../packages/nativescript-bridge/devtools) — the in-app devtools agent
+- [`@gjsify/devtools-protocol`](../../../packages/framework/devtools-protocol) — the transport-agnostic method registry both bridges share
+- [`@gjsify/nativescript-vite`](../../../packages/infra/nativescript-vite) — the Vite 8 / Rolldown NativeScript build
+- [`adwaita-storybook-nativescript`](../adwaita-storybook-nativescript) — the full 35-story storybook on this widget set
+- [`three-geometry-teapot-nativescript`](../three-geometry-teapot-nativescript) — the WebGL/three.js NativeScript target
+
+## License
+
+MIT

--- a/showcases/dom/canvas2d-fireworks/README.md
+++ b/showcases/dom/canvas2d-fireworks/README.md
@@ -1,18 +1,35 @@
 # @gjsify/example-dom-canvas2d-fireworks
 
-A polished Canvas 2D fireworks animation running on both GJS/GTK (via `@gjsify/canvas2d`'s `Canvas2DBridge` over Cairo) and in the browser — from the same shared source. Adapted from [juliangarnier's fireworks pen](https://codepen.io/juliangarnier/pen/gmOwJX). The GJS variant renders inside a native Adwaita window with GTK controls; the browser variant uses the same animation code with `@gjsify/adwaita-web` components.
+A polished Canvas 2D fireworks animation running on GJS/GTK (via `@gjsify/canvas2d`'s `Canvas2DBridge` over Cairo) and in the browser — from a shared `start(canvas)` entry point. Adapted from [juliangarnier's fireworks pen](https://codepen.io/juliangarnier/pen/gmOwJX). The GJS variant renders inside a native Adwaita window with GTK controls; the browser variant runs the same animation code behind `@gjsify/adwaita-web` components.
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/canvas2d` `Canvas2DBridge` → Cairo + PangoCairo |
+| Node · Bun · Deno | `dist/gjs.node.mjs` (`--app node`) | the same GTK window through the `@gjsify/node-gi` reverse bridge |
+| Browser | `dist/browser.js` (`--app browser`) | a real `<canvas>` + `@gjsify/adwaita-web` |
+
+Every target enters the same `start(canvas)` seam in `src/fireworks.ts` — only the shell around the canvas differs.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4. `gjsify system-check` reports what is missing.
 
 ## Run
 
 ```bash
-# Build first
+# Build first (gjs + node + browser bundles and the assets)
 gjsify run build
 
 # GJS / GTK4 native window
 gjsify showcase canvas2d-fireworks
 # or: gjsify run start
+
+# The same --app node bundle on Node.js / Bun / Deno
+gjsify showcase canvas2d-fireworks --runtime node   # or: bun | deno
 
 # Browser (serves dist/ on localhost:8080)
 gjsify run start:browser
@@ -20,10 +37,28 @@ gjsify run start:browser
 
 ## What it demonstrates
 
-- Canvas 2D rendering on GJS via `@gjsify/canvas2d` (Cairo + PangoCairo backend)
-- Shared animation logic between GJS and browser targets
-- Adwaita design language in both variants (`@gjsify/adwaita-web` for browser, native Adw widgets for GJS)
-- `gjsify build --app gjs` and `--app browser` dual-target build
+- Canvas 2D rendering on GJS via `@gjsify/canvas2d` (Cairo + PangoCairo backend) — gradients, composite operations and per-particle fills at animation rates
+- `requestAnimationFrame` + pointer events on GJS, identical to the browser code path
+- Shared `start(canvas)` pattern — identical entry for GJS, Node and browser
+- Adwaita design language in both variants (`@gjsify/adwaita-web` for browser, native `Adw.*` widgets for GJS)
+- Live two-way controls over the running animation: particle count, auto-fire interval, maximum burst radius, auto-fireworks toggle
+- `gjsify build --app gjs`, `--app node` and `--app browser` from one source tree
+
+## Layout
+
+```
+src/
+  fireworks.ts         shared start(canvas) — the whole animation, platform-agnostic
+  gjs/                 Adw.Application + fireworks-window.blp (Blueprint UI)
+  browser/             adwaita-web shell + index.html + canvas2d.css
+```
+
+## Related
+
+- [`@gjsify/canvas2d`](../../../packages/framework/canvas2d) — the `Canvas2DBridge` implementation this exercises
+- [`@gjsify/canvas2d-core`](../../../packages/dom/canvas2d-core) — the toolkit-free Canvas 2D core behind it
+- [`@gjsify/adwaita-web`](../../../packages/web/adwaita-web) — the Adwaita web components of the browser variant
+- [`excalibur-jelly-jumper`](../excalibur-jelly-jumper) — a game engine on the same bridges, with a WebGL2 → Canvas 2D fallback
 
 ## License
 

--- a/showcases/dom/excalibur-jelly-jumper/README.md
+++ b/showcases/dom/excalibur-jelly-jumper/README.md
@@ -1,27 +1,42 @@
-# Jelly Jumper — Excalibur.js Showcase
+# @gjsify/example-dom-excalibur-jelly-jumper
 
-2D platformer showcase using [Excalibur.js](https://excaliburjs.com/) 0.32.0 with Tiled tilemaps, running natively on GJS/GTK4 and in the browser via gjsify.
+A full 2D platformer — [Excalibur.js](https://excaliburjs.com/) 0.32.0 with Tiled tilemaps — running natively on GJS/GTK4 and in the browser from one shared game source. The GJS variant renders inside a native Adwaita window (WebGL2 via `@gjsify/webgl`, with a Cairo `Canvas2DBridge` fallback); the browser variant runs the same `startGame(canvas)` entry on a real `<canvas>`.
 
-Physics settings inspired by Super Mario World.
+Based on the original [sample-jelly-jumper](https://github.com/excaliburjs/sample-jelly-jumper) by the Excalibur.js team; physics settings inspired by Super Mario World.
 
-Based on the original [sample-jelly-jumper](https://github.com/excaliburjs/sample-jelly-jumper) by the Excalibur.js team.
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
-<img width="1573" height="989" alt="grafik" src="https://github.com/user-attachments/assets/4a18214c-5944-43b4-be48-571141b502ce" />
+<img width="1573" height="989" alt="Jelly Jumper running in a native Adwaita window" src="https://github.com/user-attachments/assets/4a18214c-5944-43b4-be48-571141b502ce" />
 
-## Setup
+## Targets
 
-```bash
-gjsify install
-gjsify run build
-```
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/webgl` `WebGLBridge` → `Gtk.GLArea`, falling back to `@gjsify/canvas2d` `Canvas2DBridge` (Cairo) |
+| Node · Bun · Deno | `dist/gjs.node.mjs` (`--app node`) | the same GTK window through the `@gjsify/node-gi` reverse bridge |
+| Browser | `dist/browser.js` (`--app browser`) | a real `<canvas>` + `@gjsify/adwaita-web` |
+
+Every target enters the same `startGame(canvas, options)` seam in `src/game.ts` — only the shell around the canvas differs. Both bridge widgets expose the identical `onReady` / `onResize` / `installGlobals` surface, so the fallback path differs from the WebGL path only in the constructor.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4 and a GL/GLES driver for the WebGL2 renderer (without one the window starts on the Cairo fallback). `gjsify system-check` reports what is missing.
 
 ## Run
 
 ```bash
-# GJS/GTK4 native
-gjsify run start
+# Build first (gjs + node + browser bundles and the assets)
+gjsify install
+gjsify run build
 
-# Browser
+# GJS / GTK4 native window
+gjsify showcase excalibur-jelly-jumper
+# or: gjsify run start
+
+# The same --app node bundle on Node.js / Bun / Deno
+gjsify showcase excalibur-jelly-jumper --runtime node   # or: bun | deno
+
+# Browser (serves dist/ on localhost:8080)
 gjsify run start:browser
 ```
 
@@ -32,6 +47,41 @@ gjsify run start:browser
 | Move   | Arrow keys | Left stick |
 | Run    | S | B button |
 | Jump   | A | A button |
+| Perf HUD | F1 | — |
+
+The header bar adds pause/resume and mute/unmute buttons in the GJS variant.
+
+## What it demonstrates
+
+- A complete third-party game engine (Excalibur 0.32, WebGL2-only renderer) running **unmodified** on GJS
+- WebGL2 rendering via `@gjsify/webgl` with a runtime fallback to Canvas 2D over Cairo (`@gjsify/canvas2d`) when no GL2 context is available — mirroring the browser's own fallback path
+- The DOM/Web API surface a real game needs on GJS: `requestAnimationFrame`, keyboard/pointer events, `fetch` + `XMLHttpRequest` asset loading, `Audio`/`AudioContext`, gamepad events
+- Tiled map loading through `@excaliburjs/plugin-tiled`, with `/res/...` paths rewritten via the `assetBase` option so the same resource table serves both targets
+- Shared `startGame(canvas, options)` seam — identical entry for GJS, Node and browser, with per-platform tuning (`pixelRatio`, `fixedUpdateFps`, `enablePerf`) instead of forked code
+- Audio degraded gracefully: a sound the host cannot decode or play is tolerated rather than failing scene init
+- The opt-in `@gjsify/devtools` control plane (`GJSIFY_DEVTOOLS=1`), so the running game is screenshot- and MCP-debuggable via `gjsify debug`
+- `gjsify build --app gjs`, `--app node` and `--app browser` from one source tree
+
+## Layout
+
+```
+src/
+  game.ts              shared startGame(canvas, options) seam
+  main.ts              scene/engine wiring
+  resources.ts         asset table (assetBase rewrite, audio failure tolerance)
+  actors/ scenes/ physics/ components/ classes/ state/ ui/ perf/ util/
+  gjs/                 Adw.Application + jelly-jumper-window.blp (Blueprint UI)
+  browser/             adwaita-web shell + index.html
+  assets/              images, tilemaps, music, sfx, fonts
+scripts/perf-compare.mjs   frame-time comparison between targets
+```
+
+## Related
+
+- [`@gjsify/webgl`](../../../packages/framework/webgl) — the WebGL2 bridge over `Gtk.GLArea`
+- [`@gjsify/canvas2d`](../../../packages/framework/canvas2d) — the Cairo fallback renderer
+- [`@gjsify/devtools`](../../../packages/framework/devtools) — the DBus + MCP control plane used by `gjsify debug`
+- [`canvas2d-fireworks`](../canvas2d-fireworks) — the same Canvas 2D bridge without a game engine on top
 
 ## Credits
 

--- a/showcases/dom/minimalist-browser/README.md
+++ b/showcases/dom/minimalist-browser/README.md
@@ -1,10 +1,54 @@
 # @gjsify/example-dom-minimalist-browser
 
-Minimalist browser showcase — URL bar + Back/Forward/Reload buttons + iframe content area. Runs in both a real browser (using a native `<iframe>`) and natively under GJS (using `@gjsify/iframe`'s `IFrameBridge` over `WebKit.WebView`). The same shared core (`src/browser-demo.ts`) drives both variants — only the platform-specific UI shell differs.
+A minimalist web browser — URL bar, back/forward/reload navigation and an iframe content area — running in a real browser (native `<iframe>`) and natively under GJS (`@gjsify/iframe`'s `IFrameBridge` over `WebKit.WebView`) from one shared core. An Epiphany-style Adwaita header bar looks identical in both variants; only the platform UI shell differs.
 
 Purpose: stress-test `@gjsify/iframe`'s feature-completeness against a non-trivial application. Any gap surfaces here and lands in the same workstream.
 
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/iframe` `IFrameBridge` → `WebKit.WebView` + native `Adw.*` widgets |
+| Browser | `dist/browser-main.js` (`--app browser`) | a real `<iframe>` + `@gjsify/adwaita-web` |
+
+Both targets drive the same `BrowserCore` in `src/browser-demo.ts`. GJS-only by design (`gjsify.example.runtimes: ["gjs"]`) — the content area is a WebKit view, so there is no `--app node` bundle.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4 and WebKitGTK 6.0. `gjsify system-check` reports what is missing.
+
+## Run
+
+```bash
+# Build first (gjs + browser bundles and the assets)
+gjsify run build
+
+# GJS / GTK4 native window
+gjsify showcase minimalist-browser
+# or: gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
+
+Both variants:
+
+1. Open with `page:welcome` loaded
+2. Quick-nav strip lists built-in pages: `page:welcome`, `page:about`, `page:postmessage`, `page:adwaita`
+3. URL bar accepts both the `page:<name>` scheme (loads from the in-memory page library via `srcdoc` / `loadHtml`) and real URLs like `https://example.com` (GJS variant: loads via WebKit; browser variant: loaded by the browser's iframe)
+4. Each built-in page sends a `{type: 'page-loaded', title, url}` postMessage on `DOMContentLoaded`; the parent's status line displays it
+
 ## What it demonstrates
+
+- A W3C `HTMLIFrameElement` surface on GJS, backed by `WebKit.WebView` — `src`, `srcdoc`, `contentWindow`, navigation
+- Bidirectional `postMessage` across the frame boundary on GJS, through WebKit's script-message-handler and `@gjsify/message-channel`'s `MessageEvent`
+- One unchanged application core (`src/browser-demo.ts`) driving both a real `<iframe>` and `IFrameBridge` — duck-typed on an `IFrameHandle`
+- Adwaita design language in both variants (`Adw.ApplicationWindow` / `Adw.HeaderBar` / `Adw.ToolbarView` on GJS, `@gjsify/adwaita-web` in the browser)
+- `gjsify build --app gjs` and `--app browser` dual-target build
+
+### Feature-by-feature
 
 | Feature | Browser variant | GJS variant |
 |---|---|---|
@@ -16,21 +60,6 @@ Purpose: stress-test `@gjsify/iframe`'s feature-completeness against a non-trivi
 | Adwaita design language | `@gjsify/adwaita-web` web components | Native Adw widgets (`Adw.ApplicationWindow`, `Adw.HeaderBar` with flat nav buttons + a `Gtk.Entry` URL title-widget + home button, `Adw.ToolbarView` bottom status bar) |
 
 The application-side history stack keeps both variants symmetric — browsers won't allow cross-origin `iframe.contentWindow.history.go(-1)` programmatically, so both variants pop the parent-tracked stack and re-load the URL the same way. (`IFrameBridge` also exposes WebKit's internal `goBack` / `goForward` / `reload` / `canGoBack` / `canGoForward` for apps that prefer the WebKit-side back/forward list — see the API table below.)
-
-## Run
-
-```bash
-yarn build
-yarn start           # GJS / GTK4 native window
-yarn start:browser   # http-server dist; open localhost:8080
-```
-
-Both variants:
-
-1. Open with `page:welcome` loaded
-2. Quick-nav strip lists built-in pages: `page:welcome`, `page:about`, `page:postmessage`, `page:adwaita`
-3. URL bar accepts both the `page:<name>` scheme (loads from in-memory page library via `srcdoc` / `loadHtml`) and real URLs like `https://example.com` (GJS variant: loads via WebKit; browser variant: loaded by the browser's iframe)
-4. Each built-in page sends a `{type: 'page-loaded', title, url}` postMessage on `DOMContentLoaded`; the parent's status line displays it
 
 ## Built-in pages
 
@@ -46,7 +75,7 @@ Defined in `src/browser-demo.ts` as srcdoc templates. Each carries an inline `<s
 ## API surface exercised
 
 - `@gjsify/iframe` exports:
-  - `IFrameBridge` — `WebKit.WebView` subclass with the iframe-element wrapper, message bridge, ready callbacks, `.loadUri()` / `.loadHtml()` / `.postMessage()`, plus new `.goBack()` / `.goForward()` / `.canGoBack` / `.canGoForward` (this PR) — and `.reload()` inherited from `WebKit.WebView` natively
+  - `IFrameBridge` — `WebKit.WebView` subclass with the iframe-element wrapper, message bridge, ready callbacks, `.loadUri()` / `.loadHtml()` / `.postMessage()`, `.goBack()` / `.goForward()` / `.canGoBack` / `.canGoForward` — and `.reload()` inherited from `WebKit.WebView` natively
   - `HTMLIFrameElement` — `.src`, `.srcdoc`, `.contentWindow`, `.contentDocument` (stub)
   - `IFrameWindowProxy` — `.postMessage()` + `addEventListener('message')`
   - `MessageBridge` — bidirectional postMessage transport via WebKit's script-message-handler
@@ -55,14 +84,28 @@ Defined in `src/browser-demo.ts` as srcdoc templates. Each carries an inline `<s
   - `iframe.contentWindow.addEventListener('message', handler)`
   - `iframe.src = url` / `iframe.srcdoc = html`
 
+## Layout
+
+```
+src/
+  browser-demo.ts      shared BrowserCore + the built-in srcdoc page library
+  gjs/                 Adw.Application shell (header bar, URL entry, status bar)
+  browser/             adwaita-web shell + index.html
+```
+
 ## Architecture note
 
-The cross-variant goal is that the same `browser-demo.ts` runs unchanged in both targets. `BrowserCore` operates on an `IFrameHandle` duck-typed against `HTMLIFrameElement` — real `<iframe>` and `IFrameBridge.iframeElement` both satisfy it (because `IFrameBridge.iframeElement` IS an `HTMLIFrameElement`).
+The cross-variant goal is that the same `browser-demo.ts` runs unchanged in both targets. `BrowserCore` operates on an `IFrameHandle` duck-typed against `HTMLIFrameElement` — a real `<iframe>` and `IFrameBridge.iframeElement` both satisfy it (because `IFrameBridge.iframeElement` IS an `HTMLIFrameElement`).
 
 The one platform-specific concern: in the GJS variant, `IFrameWindowProxy` is lazy — `contentWindow` is null until the first navigation produces a `LoadEvent.FINISHED`. The GJS bootstrap re-attaches the BrowserCore listener via `iframeWidget.onReady(() => core.reattachListener())` after every load. The browser variant doesn't need this — a real `<iframe>` keeps `contentWindow` across navigations.
 
 ## Related
 
-- [`examples/dom/iframe-basic/`](../../../examples/dom/iframe-basic/) — minimal bidirectional postMessage example (167 LOC, single file). The minimalist-browser showcase is a more substantive build on the same primitives.
-- [`@gjsify/iframe`](../../../packages/framework/iframe/) — the IFrameBridge implementation.
-- [`@gjsify/message-channel`](../../../packages/web/message-channel/) — the W3C MessageChannel + MessagePort surface backing the postMessage transport (PR #196 / #198).
+- [`@gjsify/iframe`](../../../packages/framework/iframe) — the `IFrameBridge` implementation this stress-tests
+- [`@gjsify/message-channel`](../../../packages/web/message-channel) — the W3C MessageChannel + MessagePort surface backing the postMessage transport
+- [`@gjsify/adwaita-web`](../../../packages/web/adwaita-web) — the Adwaita web components of the browser variant
+- [`examples/dom/iframe-basic/`](../../../examples/dom/iframe-basic/) — the minimal bidirectional postMessage example on the same primitives
+
+## License
+
+MIT

--- a/showcases/dom/three-geometry-teapot-nativescript/README.md
+++ b/showcases/dom/three-geometry-teapot-nativescript/README.md
@@ -1,8 +1,20 @@
-# Three.js Utah teapot on NativeScript
+# @gjsify/example-dom-three-geometry-teapot-nativescript
 
-The [`three-geometry-teapot`](../three-geometry-teapot) showcase runs the same Utah teapot on GNOME (GJS) and the browser from one shared `start(canvas)` seam. This is the **NativeScript-Android** target of that teapot — the same three.js rendering logic, on a phone.
+The three.js Utah teapot on **NativeScript-Android** — the same shared `start(canvas)` seam as the GNOME and browser teapot, on a phone. `@nativescript/canvas` provides the native WebGL surface, `@nativescript/canvas-polyfill` supplies the DOM shims three.js expects, and the shared demo logic renders unchanged.
 
-It is built with **[`@gjsify/nativescript-vite`](../../../packages/infra/nativescript-vite)** on **Vite 8 / Rolldown**: `@nativescript/canvas` provides the native WebGL surface, `@nativescript/canvas-polyfill` supplies the DOM shims three.js expects, and the shared `app/three-demo.ts` (a copy of the canonical teapot logic) renders unchanged.
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+The [`three-geometry-teapot`](../three-geometry-teapot) showcase runs the same teapot on GNOME (GJS) and in the browser from one shared `start(canvas)` seam. This is the NativeScript-Android target of that teapot:
+
+| Target | Shared seam | Platform glue |
+|---|---|---|
+| GNOME (GJS / GTK 4) | `start(canvas)` | `@gjsify/webgl` → `Gtk.GLArea` |
+| Browser | `start(canvas)` | a real `<canvas>` |
+| **NativeScript (Android)** | `start(canvas)` | `@nativescript/canvas` (native GL) + `@nativescript/canvas-polyfill` |
+
+`app/three-demo.ts` is copied (not referenced) so this project is self-contained. `app/home/home-page.ts` feeds the native canvas + a `file://` asset base into `start(canvas)`; everything else is identical three.js.
 
 ## Standalone by design
 
@@ -13,27 +25,53 @@ cd showcases/dom/three-geometry-teapot-nativescript
 npm install
 ```
 
-## Build & run
+## Prerequisites
 
-Requires the Android SDK + an emulator/device and the NativeScript CLI prerequisites (see the [NativeScript setup docs](https://docs.nativescript.org/setup/)).
+The Android SDK, an emulator or device, and the NativeScript CLI prerequisites — see the [NativeScript setup docs](https://docs.nativescript.org/setup/).
+
+## Run
 
 ```bash
 npm run prepare:android   # bundle only (vite → bundle.mjs baked into the project)
 npm run run:android       # build the APK, install + launch on an emulator/device
 ```
 
-`nativescript.config.ts` selects `bundler: 'vite'`; `vite.config.ts` is `@gjsify/nativescript-vite`'s `defineNativescriptConfig()`, which makes `@nativescript/vite` build under Vite 8 / Rolldown and layers gjsify's NativeScript transforms.
+`nativescript.config.ts` selects `bundler: 'vite'`; `vite.config.ts` is `@gjsify/nativescript-vite`'s `defineNativescriptConfig()`, which makes `@nativescript/vite` build under Vite 8 / Rolldown and layers gjsify's NativeScript transforms. This showcase targets the 9.0.x / `@nativescript/vite@2` line.
 
-## How it maps to the shared teapot
+## What it demonstrates
 
-| | shared seam | platform glue |
-|---|---|---|
-| GNOME | `start(canvas)` | `@gjsify/webgl` → `Gtk.GLArea` |
-| Browser | `start(canvas)` | a real `<canvas>` |
-| **NativeScript** | `start(canvas)` | `@nativescript/canvas` (native GL) + `@nativescript/canvas-polyfill` |
+- Unmodified three.js (`THREE.WebGLRenderer`, `TeapotGeometry`, `OrbitControls`) rendering on a **native Android GL surface**
+- The `start(canvas)` seam holding across a *third* platform: one demo module, three canvas providers (GTK `Gtk.GLArea`, the browser's `<canvas>`, `@nativescript/canvas`)
+- `@nativescript/canvas-polyfill` supplying the DOM globals three.js reaches for, in place of gjsify's own DOM layer
+- `@gjsify/nativescript-vite` building a NativeScript app with Vite 8 / Rolldown, auto-detecting the `@nativescript/vite` major
+- Asset loading from a `file://` base — the same cube map and texture files as the GNOME/browser teapot
+- A NativeScript showcase kept out of the workspace install so its toolchain cost is opt-in
 
-`app/three-demo.ts` is copied (not referenced) so this project is self-contained. `app/home/home-page.ts` feeds the native canvas + a `file://` asset base into `start(canvas)`; everything else is identical three.js.
+## Layout
+
+```
+app/
+  app.ts               entry — Application.run({ moduleName: 'app-root' })
+  app-root.xml         <Frame defaultPage="home/home-page" />
+  home/home-page.*     native canvas + file:// asset base → start(canvas)
+  three-demo.ts        copy of the canonical teapot logic (self-contained)
+  assets/              uv_grid_opengl.jpg + pisa/ cube map
+App_Resources/         Android + iOS platform resources
+nativescript.config.ts bundler: 'vite'
+vite.config.ts         @gjsify/nativescript-vite defineNativescriptConfig()
+```
 
 ## Note
 
 `@nativescript/canvas-polyfill` `require()`s `@nativescript/audio-context` / `@nativescript/canvas-media` inside a try/catch; this WebGL-only app never executes them, so `vite.config.ts` marks them `external`.
+
+## Related
+
+- [`three-geometry-teapot`](../three-geometry-teapot) — the GNOME + browser teapot and the canonical `start(canvas)` logic
+- [`@gjsify/nativescript-vite`](../../../packages/infra/nativescript-vite) — the Vite 8 / Rolldown NativeScript build
+- [`adwaita-widgets-nativescript`](../adwaita-widgets-nativescript) — the native Adwaita widget path on NativeScript
+- [`adwaita-storybook-nativescript`](../adwaita-storybook-nativescript) — the full Adwaita storybook on NativeScript
+
+## License
+
+MIT

--- a/showcases/dom/three-geometry-teapot/README.md
+++ b/showcases/dom/three-geometry-teapot/README.md
@@ -4,15 +4,34 @@ A three.js Utah Teapot showcase running on GJS/GTK (via `@gjsify/webgl`'s `WebGL
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/webgl` `WebGLBridge` → `Gtk.GLArea` + libepoxy |
+| Node · Bun · Deno | `dist/gjs.node.mjs` (`--app node`) | the same GTK window through the `@gjsify/node-gi` reverse bridge |
+| Browser | `dist/browser.js` (`--app browser`) | a real `<canvas>` + `@gjsify/adwaita-web` |
+| Android | [`three-geometry-teapot-nativescript`](../three-geometry-teapot-nativescript) | `@nativescript/canvas` (native GL) |
+
+Every target enters the same `start(canvas)` seam in `src/three-demo.ts` — only the shell around the canvas differs.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4 and a working GL/GLES driver. `gjsify system-check` reports what is missing.
+
 ## Run
 
 ```bash
-# Build first
+# Build first (gjs + node + browser bundles and the assets)
 gjsify run build
 
 # GJS / GTK4 native window (WebGL via Gtk.GLArea)
 gjsify showcase three-geometry-teapot
 # or: gjsify run start
+
+# The same --app node bundle on Node.js / Bun / Deno
+gjsify showcase three-geometry-teapot --runtime node   # or: bun | deno
+# or: gjsify run start:node
 
 # Browser (serves dist/ on localhost:8080)
 gjsify run start:browser
@@ -21,10 +40,28 @@ gjsify run start:browser
 ## What it demonstrates
 
 - WebGL rendering on GJS via `@gjsify/webgl` (Vala bridge over `Gtk.GLArea` + libepoxy)
-- three.js (`THREE.WebGLRenderer`) running unmodified on GJS
-- Shared `start(canvas)` pattern — identical entry for GJS and browser
-- Adwaita design language in both variants
-- `gjsify build --app gjs` and `--app browser` dual-target build
+- three.js (`THREE.WebGLRenderer`) running unmodified on GJS — `TeapotGeometry`, `OrbitControls` and a pisa cube-map environment straight from `three/addons`
+- Shared `start(canvas)` pattern — identical entry for GJS, Node and browser
+- Adwaita design language in both variants (native `Adw.*` widgets on GJS, `@gjsify/adwaita-web` in the browser)
+- Live two-way controls over the running scene: tessellation level, lid/body/bottom visibility, snug lid, shading and material — `Adw.ComboRow` / `Adw.SwitchRow` in a sidebar on GJS, the same set as web components in the browser
+- `gjsify build --app gjs`, `--app node` and `--app browser` from one source tree
+
+## Layout
+
+```
+src/
+  three-demo.ts        shared start(canvas) — the whole demo, platform-agnostic
+  gjs/                 Adw.Application + teapot-window.blp (Blueprint UI)
+  browser/             adwaita-web shell + index.html + webgl.css
+  assets/              uv_grid_opengl.jpg + pisa/ cube map
+```
+
+## Related
+
+- [`@gjsify/webgl`](../../../packages/framework/webgl) — the `WebGLBridge` implementation this exercises
+- [`@gjsify/adwaita-web`](../../../packages/web/adwaita-web) — the Adwaita web components of the browser variant
+- [`three-postprocessing-pixel`](../three-postprocessing-pixel) — the same seam driving a three.js `EffectComposer` chain
+- [`three-geometry-teapot-nativescript`](../three-geometry-teapot-nativescript) — the Android/NativeScript target of this teapot
 
 ## License
 

--- a/showcases/dom/three-postprocessing-pixel/README.md
+++ b/showcases/dom/three-postprocessing-pixel/README.md
@@ -1,18 +1,36 @@
 # @gjsify/example-dom-three-postprocessing-pixel
 
-A three.js pixel post-processing showcase running on GJS/GTK (via `@gjsify/webgl`'s `WebGLBridge` over `Gtk.GLArea`) and in the browser — from a shared `start(canvas)` entry point. Ported from [`three/examples/webgl_postprocessing_pixel`](https://threejs.org/examples/#webgl_postprocessing_pixel). Demonstrates three.js `EffectComposer` with a custom pixel/posterize shader running on native GJS WebGL.
+A three.js pixel post-processing showcase running on GJS/GTK (via `@gjsify/webgl`'s `WebGLBridge` over `Gtk.GLArea`) and in the browser — from a shared `start(canvas)` entry point. Ported from [`three/examples/webgl_postprocessing_pixel`](https://threejs.org/examples/#webgl_postprocessing_pixel). Demonstrates a three.js `EffectComposer` chain (`RenderPixelatedPass` + `OutputPass`) running on native GJS WebGL.
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/webgl` `WebGLBridge` → `Gtk.GLArea` + libepoxy |
+| Node · Bun · Deno | `dist/gjs.node.mjs` (`--app node`) | the same GTK window through the `@gjsify/node-gi` reverse bridge |
+| Browser | `dist/browser.js` (`--app browser`) | a real `<canvas>` + `@gjsify/adwaita-web` |
+
+Every target enters the same `start(canvas)` seam in `src/three-demo.ts` — only the shell around the canvas differs.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4 and a working GL/GLES driver. `gjsify system-check` reports what is missing.
 
 ## Run
 
 ```bash
-# Build first
+# Build first (gjs + node + browser bundles and the assets)
 gjsify run build
 
 # GJS / GTK4 native window (WebGL via Gtk.GLArea)
 gjsify showcase three-postprocessing-pixel
 # or: gjsify run start
+
+# The same --app node bundle on Node.js / Bun / Deno
+gjsify showcase three-postprocessing-pixel --runtime node   # or: bun | deno
+# or: gjsify run start:node
 
 # Browser (serves dist/ on localhost:8080)
 gjsify run start:browser
@@ -20,11 +38,28 @@ gjsify run start:browser
 
 ## What it demonstrates
 
-- three.js post-processing (`EffectComposer` + pixel shader) on GJS
+- three.js post-processing on GJS: `EffectComposer` with `RenderPixelatedPass` + `OutputPass`, rendering to and resolving from off-screen render targets
 - WebGL rendering via `@gjsify/webgl` (Vala bridge over `Gtk.GLArea` + libepoxy)
-- Shared `start(canvas)` pattern — identical entry for GJS and browser
-- Adwaita design language in both variants
-- `gjsify build --app gjs` and `--app browser` dual-target build
+- Shared `start(canvas)` pattern — identical entry for GJS, Node and browser
+- Adwaita design language in both variants (native `Adw.*` widgets on GJS, `@gjsify/adwaita-web` in the browser)
+- Live two-way controls over the running scene: pixel size, normal-edge and depth-edge strength, pixel-aligned panning
+- `gjsify build --app gjs`, `--app node` and `--app browser` from one source tree
+
+## Layout
+
+```
+src/
+  three-demo.ts        shared start(canvas) — the whole demo, platform-agnostic
+  gjs/                 Adw.Application + pixel-window.blp (Blueprint UI)
+  browser/             adwaita-web shell + index.html + webgl.css
+  assets/              checker.png
+```
+
+## Related
+
+- [`@gjsify/webgl`](../../../packages/framework/webgl) — the `WebGLBridge` implementation this exercises
+- [`@gjsify/adwaita-web`](../../../packages/web/adwaita-web) — the Adwaita web components of the browser variant
+- [`three-geometry-teapot`](../three-geometry-teapot) — the same seam without a post-processing chain
 
 ## License
 

--- a/showcases/dom/webrtc-loopback/README.md
+++ b/showcases/dom/webrtc-loopback/README.md
@@ -1,17 +1,23 @@
-# webrtc-loopback — WebRTC Data Channel loopback demo
+# @gjsify/example-dom-webrtc-loopback
 
-Two `RTCPeerConnection` instances in a single GJS process perform the full
-WebRTC handshake (offer/answer + ICE trickle) and exchange string and binary
-payloads over a data channel.
+A WebRTC data-channel loopback demo: two `RTCPeerConnection` instances in a single process perform the full WebRTC handshake (offer/answer + trickle ICE) and exchange string and binary payloads over a data channel. Runs on GJS (`@gjsify/webrtc` over GStreamer `webrtcbin`) and in the browser (native WebRTC) — from one shared `runLoopback(log)` entry point.
 
-This is the smoke-test example for [@gjsify/webrtc](../../../packages/web/webrtc),
-backed by the [@gjsify/webrtc-native](../../../packages/web/webrtc-native)
-Vala bridge that marshals webrtcbin's streaming-thread signals and
-`Gst.Promise` callbacks onto the GLib main context.
+This is the smoke-test showcase for [`@gjsify/webrtc`](../../../packages/web/webrtc), backed by the [`@gjsify/webrtc-native`](../../../packages/web/webrtc-native) Vala bridge that marshals webrtcbin's streaming-thread signals and `Gst.Promise` callbacks onto the GLib main context.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/webrtc` → `@gjsify/webrtc-native` → GStreamer `webrtcbin` + libnice |
+| Browser | `dist/browser-main.js` (`--app browser`) | the browser's own WebRTC stack |
+
+Both targets run the same `runLoopback(log)` in `src/loopback-demo.ts` and differ only in where the log lines are printed. GJS-only on the native side (`gjsify.example.runtimes: ["gjs"]`) — the bridge is a GStreamer/GLib typelib, so there is no `--app node` bundle.
 
 ## Prerequisites
 
-GStreamer ≥ 1.20 with both the WebRTC plugin and libnice:
+GJS ≥ 1.86 and GStreamer ≥ 1.20 with both the WebRTC plugin and libnice:
 
 | Distro          | Install                                                                   |
 |-----------------|---------------------------------------------------------------------------|
@@ -23,13 +29,39 @@ Verify:
 ```bash
 gst-inspect-1.0 webrtcbin    # must print the webrtcbin plugin
 gst-inspect-1.0 nicesrc      # must print the nice plugin
+gjsify system-check          # reports GJS + the optional GStreamer deps
 ```
 
 ## Run
 
 ```bash
-yarn build
-yarn start
+# Build first (gjs + browser bundles and the assets)
+gjsify run build
+
+# GJS
+gjsify showcase webrtc-loopback
+# or: gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
+
+## What it demonstrates
+
+- The W3C WebRTC peer-connection surface on GJS: `RTCPeerConnection`, `createOffer` / `createAnswer` / `setLocalDescription` / `setRemoteDescription`, trickle `addIceCandidate`
+- The full state machine observable from JS — `signalingState`, `iceConnectionState`, `connectionState` transitions on both peers
+- `RTCDataChannel` end to end: `createDataChannel`, `ondatachannel`, `onopen`, `onmessage` with both string and `ArrayBuffer` payloads
+- Streaming-thread safety: webrtcbin's signals and `Gst.Promise` callbacks arrive on GStreamer threads and are marshalled onto the GLib main context by `@gjsify/webrtc-native`, so JS handlers run on the main loop
+- One shared demo module driving GJS and the browser — the same code path proves API parity
+- `gjsify build --app gjs` and `--app browser` dual-target build
+
+## Layout
+
+```
+src/
+  loopback-demo.ts     shared runLoopback(log) — the whole handshake + echo round-trip
+  gjs/                 GJS entry (prints the trace to stdout)
+  browser/             browser entry + index.html (prints the trace into the page)
 ```
 
 ## Expected output
@@ -53,3 +85,13 @@ yarn start
 [A] received ArrayBuffer(4): [4, 3, 2, 1]
 [main] demo complete — closing peer connections
 ```
+
+## Related
+
+- [`@gjsify/webrtc`](../../../packages/web/webrtc) — the W3C WebRTC implementation this smoke-tests
+- [`@gjsify/webrtc-native`](../../../packages/web/webrtc-native) — the Vala bridge over GStreamer `webrtcbin`
+- [`webrtc-video`](../webrtc-video) — the media side of the same stack (`getUserMedia` + a GTK video sink)
+
+## License
+
+MIT

--- a/showcases/dom/webrtc-video/README.md
+++ b/showcases/dom/webrtc-video/README.md
@@ -1,6 +1,40 @@
-# WebRTC Video — Webcam Preview
+# @gjsify/example-dom-webrtc-video
 
-Demonstrates `getUserMedia()` video capture rendered in a GTK4 window via `VideoBridge`.
+A webcam preview showcase: `navigator.mediaDevices.getUserMedia()` video capture rendered in a native GTK4 window via `@gjsify/video`'s `VideoBridge` (`Gtk.Picture` + GStreamer `gtk4paintablesink`) and in the browser in a real `<video>` element — from one shared entry point.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/webrtc` `getUserMedia` + `@gjsify/video` `VideoBridge` → `Gtk.Picture` / `gtk4paintablesink` |
+| Browser | `dist/browser-main.js` (`--app browser`) | the browser's own `getUserMedia` + a real `<video>` element |
+
+Both targets run the same demo in `src/video-demo.ts` and differ only in the shell around the video surface.
+
+This showcase is `private` (not published to npm) and not part of the `gjsify showcase` manifest — it runs from a checkout via its own scripts.
+
+## Prerequisites
+
+- GJS ≥ 1.86 with GTK 4
+- GStreamer with `gtk4paintablesink` from gst-plugins-rs — `dnf install gstreamer1-plugin-gtk4` (Fedora) / `apt install gstreamer1.0-gtk4` (Ubuntu/Debian); verify with `gst-inspect-1.0 gtk4paintablesink`
+- A webcam or a virtual video device, and PipeWire or PulseAudio for capture
+
+`gjsify system-check` reports GJS plus the optional GStreamer dependencies.
+
+## Run
+
+```bash
+# Build first (gjs + browser bundles and the assets)
+gjsify run build
+
+# GJS / GTK4 native window (Adwaita)
+gjsify run start
+
+# Browser (serves dist/ on localhost:8080)
+gjsify run start:browser
+```
 
 ## What it does
 
@@ -11,21 +45,29 @@ Demonstrates `getUserMedia()` video capture rendered in a GTK4 window via `Video
 
 ## What it demonstrates
 
-- `navigator.mediaDevices.getUserMedia()` with video constraints
-- `MediaStream` and `MediaStreamTrack` APIs
-- `HTMLVideoElement.srcObject` assignment
-- `@gjsify/video` `VideoBridge` — bridges the DOM `<video>` element to a GTK4 widget
-- GStreamer source chain: `pipewiresrc` → `pulsesrc` → `v4l2src` fallback
-- Adwaita application window with `HeaderBar` + `ToolbarView`
+- `navigator.mediaDevices.getUserMedia()` with video constraints on GJS
+- `MediaStream` and `MediaStreamTrack` APIs backed by a GStreamer pipeline
+- `HTMLVideoElement.srcObject` assignment — the W3C spelling, on a GTK widget
+- `@gjsify/video`'s `VideoBridge` — bridges the DOM `<video>` element to a GTK4 widget
+- GStreamer source-chain negotiation with fallbacks: `pipewiresrc` → `pulsesrc` → `v4l2src`
+- Adwaita application window with `Adw.HeaderBar` + `Adw.ToolbarView`
+- `gjsify build --app gjs` and `--app browser` dual-target build
 
-## Prerequisites
+## Layout
 
-- Webcam (or virtual video device)
-- PipeWire or PulseAudio for video capture
-
-## Run
-
-```bash
-yarn build && yarn start        # GJS (Adwaita window)
-yarn build:browser && yarn start:browser  # Browser
 ```
+src/
+  video-demo.ts        shared demo — getUserMedia + srcObject wiring
+  gjs/                 Adw.Application shell around the VideoBridge widget
+  browser/             browser shell + index.html
+```
+
+## Related
+
+- [`@gjsify/video`](../../../packages/framework/video) — the `VideoBridge` implementation this exercises
+- [`@gjsify/webrtc`](../../../packages/web/webrtc) — `getUserMedia` / `MediaStream` and the peer-connection surface
+- [`webrtc-loopback`](../webrtc-loopback) — the data-channel side of the same stack
+
+## License
+
+MIT

--- a/showcases/gtk/adwaita-storybook/README.md
+++ b/showcases/gtk/adwaita-storybook/README.md
@@ -1,9 +1,11 @@
-# Adwaita Storybook
+# @gjsify/example-gtk-adwaita-storybook
 
 An interactive **component browser for [Libadwaita](https://gnome.pages.gitlab.gnome.org/libadwaita/)**
 widgets — the GNOME equivalent of a web "storybook". Each widget is rendered live, in
 isolation, with a two-way-bound **Controls** panel so you can poke at its properties and
-watch it update.
+watch it update. 35 stories across 7 categories.
+
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
 It is a showcase for three pieces of gjsify tooling working together:
 
@@ -15,12 +17,33 @@ It is a showcase for three pieces of gjsify tooling working together:
 
 ![Avatar story](docs/avatar.png)
 
+## Targets
+
+| Target | Bundle | Renderer |
+|---|---|---|
+| GJS / GTK 4 | `dist/gjs.js` (`--app gjs`) | `@gjsify/storybook` — native `Adw.*` widgets |
+| Node · Bun · Deno | `dist/gjs.node.mjs` (`--app node`) | the same GTK renderer through the `@gjsify/node-gi` reverse bridge |
+| Browser | `dist/browser-main.js` (`--app browser`) | `@gjsify/adwaita-storybook` — `@gjsify/adwaita-web` components |
+| Android (NativeScript) | [`adwaita-storybook-nativescript`](../../dom/adwaita-storybook-nativescript) | `@gjsify/storybook-nativescript` — real native NS views |
+
+Every target renders the SAME stories: the renderer-free `*.meta.ts` metadata is exported from
+this package's `./metas` barrel and the shared logic lives in
+[`@gjsify/storybook-core`](../../../packages/framework/storybook-core), so each renderer is a
+thin adapter and the four renderings are comparable 1:1 by screenshot.
+
+## Prerequisites
+
+GJS ≥ 1.86 with GTK 4 and Libadwaita 1.x. `gjsify system-check` reports what is missing.
+
 ## Run it
 
 ```bash
 # from this directory
 gjsify storybook            # discover every *.story.ts, build (--app gjs), launch the browser
 gjsify storybook --watch    # rebuild + relaunch on change
+
+# without a checkout
+gjsify showcase adwaita-storybook
 ```
 
 `gjsify storybook` reads the `gjsify.storybook` block in [`package.json`](package.json)
@@ -46,6 +69,17 @@ GTK renderer reached over a different bridge; what a runtime has to prove is tha
 holds. All three open the window and claim `org.gjsify.AdwaitaStorybook` on the session bus,
 which is exactly what the DBus harness below drives — so "it works there" is a checkable
 claim, not a build that merely completed.
+
+### In the browser
+
+The web renderer builds the same stories as `@gjsify/adwaita-web` components:
+
+```bash
+gjsify run build:web        # build:browser + build:assets
+gjsify run start:browser    # http-server dist; open localhost:8080
+```
+
+The `./browser` export is the embeddable entry the project website uses.
 
 ## Debug / drive it over DBus + MCP
 
@@ -76,6 +110,32 @@ showcase:
 ```bash
 GJSIFY_DEVTOOLS=1 gjsify storybook &                       # launch
 gjs -m tools/shoot-stories.js org.gjsify.AdwaitaStorybook ./shots   # capture all stories
+```
+
+## What it demonstrates
+
+- A real Libadwaita component browser built from `*.story.ts` files alone — no per-project
+  storybook application, the renderer and the CLI command are the shared parts
+- Two-way-bound live controls over native GObject properties: editing a control writes the
+  widget property, and a `notify::` on the widget updates the control
+- ONE renderer-free story contract driving four renderings (GTK, Node/Bun/Deno over node-gi,
+  browser, NativeScript) — the same `*.meta.ts` metadata, shared across package boundaries
+- The `@gjsify/devtools` DBus + MCP control plane: an agent can list and open stories, set
+  story args, dump the widget tree and screenshot the window headlessly
+- Breadth of the Libadwaita widget set working under gjsify — rows, navigation, view
+  switching, dialogs and toasts (see the table below)
+- `gjsify storybook` as a first-class workflow: discovery, build, launch, `--watch`, `--runtime`
+
+## Layout
+
+```
+src/
+  <category>/<name>.meta.ts   renderer-free story metadata (title + controls) — shared by ALL targets
+  <category>/<name>.story.ts  the GTK story (StoryWidget subclass)
+  metas.ts                    the ./metas barrel the other renderers import
+  browser/<category>/<name>.web.ts   the adwaita-web story for the same meta
+  browser/{main,embed,stories}.ts + index.html   the browser shell and ./browser export
+tools/shoot-stories.js        open + screenshot every story over the devtools DBus surface
 ```
 
 ## Stories
@@ -134,6 +194,15 @@ export const MyStories: StoryModule = { stories: [MyStory] };
 Rules of thumb: globally-unique `GTypeName` (prefix `AdwStorybook…`), wrap `Adw.*Row`s in an
 `Adw.PreferencesGroup`, give space-filling widgets a `widthRequest`/`heightRequest`, and
 present dialogs from a button rather than embedding them.
+
+## Related
+
+- [`@gjsify/storybook`](../../../packages/framework/storybook) — the GTK story renderer
+- [`@gjsify/storybook-core`](../../../packages/framework/storybook-core) — the renderer-free logic all targets share
+- [`@gjsify/adwaita-storybook`](../../../packages/web/adwaita-storybook) — the browser renderer
+- [`@gjsify/devtools`](../../../packages/framework/devtools) — the DBus + MCP control plane
+- [`@gjsify/node-gi`](../../../packages/node-gi/node-gi) — the reverse bridge behind the Node/Bun/Deno target
+- [`adwaita-storybook-nativescript`](../../dom/adwaita-storybook-nativescript) — the same stories as a native Android app
 
 ## License
 

--- a/showcases/gtk/node-gi-window/README.md
+++ b/showcases/gtk/node-gi-window/README.md
@@ -6,6 +6,22 @@ reverse bridge. One unchanged `Adw.Application` + `Adw.ApplicationWindow` realiz
 renders **and responds to input** through the platform GDK backend (GdkWayland/GdkX11
 on Linux, GdkWin32 on Windows) under Node.js exactly as under GJS.
 
+Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS | `dist/app.gjs.mjs` (`--app gjs`) | GJS's own `gi://` imports |
+| Node.js | `dist/app.node.mjs` (`--app node`) | `@gjsify/node-gi` — `gi://` → `requireGi` over GObject-Introspection |
+
+Same source, same window, both directions of the bridge. It is `private` + versioned (a
+dev-tooling showcase, like [`adwaita-storybook`](../adwaita-storybook)): it depends on
+`@gjsify/node-gi` via a `file:` link, so it is not published to npm and not part of the
+`gjsify showcase` manifest — it runs from a checkout via its own scripts.
+
+## The app
+
 Two views live in an `Adw.ViewStack`, switched by a bottom `Adw.ViewSwitcherBar`, with
 the whole content under an `Adw.ToastOverlay`:
 
@@ -24,10 +40,13 @@ the whole content under an `Adw.ToastOverlay`:
   and a `win.toast` action both raise a dismissible `Adw.Toast` through the overlay —
   interactions dispatched through the node-gi `notify::` signal chain.
 
-It is `private` + versioned (a dev-tooling showcase, like `adwaita-storybook`): it
-depends on `@gjsify/node-gi` via a `file:` link, so it is not published to npm.
+## Prerequisites
 
-## Build + run
+GJS ≥ 1.86 (for the GJS target), Node.js ≥ 20 (what `@gjsify/node-gi` declares, for
+the Node target), GTK 4 and Libadwaita 1.x with their typelibs. `gjsify system-check`
+reports what is missing.
+
+## Run
 
 ```bash
 # GJS (native gi://)
@@ -50,7 +69,7 @@ control plane via `installDevtools(app)` (a no-op unless `GJSIFY_DEVTOOLS` is
 truthy). With it enabled, the LIVE window is drivable, inspectable and screenshottable
 over the session bus (`org.gjsify.Devtools`) — so the interactivity is provable
 without a human clicking. `Adw.ApplicationWindow` implements `Gio.ActionGroup`, and
-node-gi's `instanceof` now spans the whole GObject hierarchy, so devtools resolves the
+node-gi's `instanceof` spans the whole GObject hierarchy, so devtools resolves the
 `win.*` action group off the active window:
 
 ```bash
@@ -73,7 +92,7 @@ gjs -m tools/shoot.js eu.jumplink.NodeGiWindow dist/window.png
 `tools/shoot.js` calls `GetStatus` → `DumpTree` → `Screenshot` and writes the PNG.
 The same window can be driven from an MCP client via `gjsify debug`.
 
-## What it proves
+## What it demonstrates
 
 - `@gjsify/node-gi` dispatches the GTK signal/action/event chain into JS: a
   `Gtk.Button::clicked` signal, a `Gio.SimpleAction::activate` on the window,
@@ -88,9 +107,30 @@ The same window can be driven from an MCP client via `gjsify debug`.
   `Gsk.Renderer.render_texture`, `Gdk.Texture.save_to_png_bytes`).
 - `@gjsify/devtools`' live DBus `ActivateAction` / `GetProperty` / `DumpTree` /
   `Screenshot` run under node-gi, not just on GJS.
+- One `gi://` source tree building for `--app gjs` and `--app node` — the reverse
+  direction of the usual gjsify story (Node APIs on GJS), and the same window either way.
+
+## Layout
+
+```
+src/
+  app.ts               the whole app — Adw.Application, both views, installDevtools()
+  globals.d.ts         the GJS ambient globals the app references
+tools/shoot.js         GetStatus → DumpTree → Screenshot → PNG (GJS caller)
+```
+
+## Related
+
+- [`@gjsify/node-gi`](../../../packages/node-gi/node-gi) — the reverse bridge this is the GUI capstone of
+- [`@gjsify/devtools`](../../../packages/framework/devtools) — the DBus + MCP control plane used to self-verify
+- [`adwaita-storybook`](../adwaita-storybook) — the storybook, which also runs on Node/Bun/Deno over node-gi
 
 The self-contained, workspace-free proofs (no bundler, no `@gjsify/devtools`) live as
 `packages/node-gi/node-gi/test/windowing.test.mjs` (static render),
 `packages/node-gi/node-gi/test/windowing-interactive.test.mjs` (the interactivity
 chain + render) and `packages/node-gi/node-gi/test/widgets.test.mjs` (the Adwaita
 widget breadth) — what the Linux `gtk-smoke` + Windows windowing CI jobs run.
+
+## License
+
+MIT

--- a/showcases/node/express-webserver/README.md
+++ b/showcases/node/express-webserver/README.md
@@ -1,31 +1,72 @@
 # @gjsify/example-node-express-webserver
 
-An Express 5 blog showcase — JSON API + static frontend — running on GJS using gjsify's Node.js polyfills (`@gjsify/http`, etc.). The same source also builds for Node.js, demonstrating that a real Express web application runs unmodified on GJS via the `@gjsify/*` Node API layer.
+An Express 5 blog showcase — JSON API + static frontend — running on GJS using gjsify's Node.js polyfills (`@gjsify/http` over libsoup 3). The same source also builds for Node.js, Bun and Deno, demonstrating that a real Express web application runs unmodified on GJS via the `@gjsify/*` Node API layer.
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
+
+## Targets
+
+| Target | Bundle | Platform glue |
+|---|---|---|
+| GJS | `dist/index.gjs.js` (`--app gjs`) | `@gjsify/http` + `@gjsify/http-soup-bridge` → libsoup 3 |
+| Node · Bun · Deno | `dist/index.node.mjs` (`--app node`) | the runtime's own `node:http` |
+
+One unchanged Express app, both bundles — no server-side forks. Declared portable across Linux, macOS and Windows (`gjsify.os`).
+
+## Prerequisites
+
+GJS ≥ 1.86 with libsoup 3. `gjsify system-check` reports what is missing.
 
 ## Run
 
 ```bash
-# Build first
+# Build first (gjs + node bundles and the static frontend)
 gjsify run build
 
 # GJS (Express over GJS + Soup HTTP)
 gjsify showcase express-webserver
 # or: gjsify run start
 
-# Node.js (for comparison)
-gjsify run start:node
+# Node.js / Bun / Deno (for comparison)
+gjsify showcase express-webserver --runtime node   # or: bun | deno
+# or: gjsify run start:node
 ```
 
 Then open `http://localhost:3000` in a browser.
 
+## Routes
+
+| Route | Serves |
+|---|---|
+| `GET /` | the static frontend from `src/public/` |
+| `GET /api/posts` | the post list as JSON |
+| `GET /api/posts/:slug` | a single post as JSON |
+| `GET /api/runtime` | which runtime is serving the request |
+| `GET /posts/:slug` | server-rendered post page |
+
 ## What it demonstrates
 
-- Express 5 running on GJS with gjsify's `@gjsify/http` (Soup 3.0 backend)
+- Express 5 running **unmodified** on GJS with gjsify's `@gjsify/http` (libsoup 3 backend)
+- The Node HTTP server surface Express builds on — `http.createServer`, request/response streams, headers, status codes — implemented over GNOME libraries
+- Express middleware and routing on GJS: `express.json()`, custom middleware, route params, `express.static()`
 - JSON REST API + static file serving from a single Express app
-- Same source building for both `--app gjs` and `--app node` targets
-- Node.js polyfill layer compatibility with an unmodified npm package
+- The same source building for `--app gjs` and `--app node`, and ONE `--app node` bundle serving Node, Bun and Deno (Node-API is their common ABI)
+- Node.js polyfill-layer compatibility with an unmodified npm package — the showcase is a compatibility probe, so any gap surfaces here and is fixed in the package, not worked around here
+
+## Layout
+
+```
+src/
+  index.ts             the Express app (routes, middleware, listen)
+  data/posts.ts        the in-memory post data
+  public/              static frontend (index.html, app.js, style.css)
+```
+
+## Related
+
+- [`@gjsify/http`](../../../packages/node/http) — the `node:http` implementation this exercises
+- [`@gjsify/http-soup-bridge`](../../../packages/node/http-soup-bridge) — the libsoup 3 transport behind it
+- [`minimalist-browser`](../../dom/minimalist-browser) — the browser-side counterpart (WebKit content area on GJS)
 
 ## License
 


### PR DESCRIPTION
## What

The `three-geometry-teapot` and `three-postprocessing-pixel` READMEs carried a **What it demonstrates** section — a short list of what the showcase actually proves. The other eleven did not, and each had drifted into its own shape. This gives all thirteen one skeleton and fills in the missing information.

Skeleton (sections dropped only where meaningless): package name → one-paragraph lead → the "Part of the gjsify project" line → **Targets** → **Prerequisites** → **Run** → **What it demonstrates** → **Layout** → **Related** → **License**.

Every showcase keeps its own material: the storybook's story table + authoring guide, the minimalist browser's API-surface and built-in-page tables, jelly-jumper's controls and credits, the loopback's expected trace, the NativeScript standalone/version notes, node-gi-window's DBus self-verification walkthrough.

| | targets | prereq | run | demonstrates | layout | related |
|---|---|---|---|---|---|---|
| all 13 | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

## Corrections found while writing them

- **`yarn build` / `yarn start`** (minimalist-browser, webrtc-loopback, webrtc-video) → `gjsify run <script>`. The repo has been yarn-free since the ADR 0002 bootstrap; those commands do not work.
- **Undocumented targets.** `webrtc-loopback` ships a browser bundle its README never mentioned; `adwaita-storybook` additionally runs on Node/Bun/Deno *and* in the browser. Each README now lists exactly the targets its own `package.json` + `gjsify.example.runtimes` declare, with the `gjsify showcase <name> --runtime …` line where the declaration allows it.
- **`three-postprocessing-pixel`** claimed "a custom pixel/posterize shader" — it uses three's stock `RenderPixelatedPass` + `OutputPass`.
- **`adwaita-storybook-nativescript`** claimed to be a workspace member. It is excluded from the `workspaces` glob (its NS toolchain must stay out of `gjsify install`); the `@gjsify/*` deps resolve from the hoisted root `node_modules` by directory walk, which is *why* `--disable-npm-install` is load-bearing. Documented as such.
- **`webrtc-video`** pointed at gst-plugins-bad for `gtk4paintablesink`; it ships in gst-plugins-rs (`gstreamer1-plugin-gtk4` / `gstreamer1.0-gtk4`) — the package name `@gjsify/video`'s own error message prints.
- **`minimalist-browser`** advertised `goBack`/`goForward` "(this PR)" and a PR number as if unmerged.
- **`node-gi-window`** claimed Node ≥ 22 where `@gjsify/node-gi` declares `>= 20`.

## Verification

- Every relative link in all thirteen files resolves (checked programmatically against the tree).
- Every run command, script name, bundle path, declared runtime, tier and `private` flag was read out of the package's `package.json` on this branch, not from memory.
- Story counts (35 stories / 35 `*.meta.ts` / 35 `*.web.ts` / 35 `*.ns.ts`), route lists and control names were read from the sources.
- Docs-only: no source, no bundle, no manifest touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)