### PR TITLE
fix(vite-plugin-blueprint): find the compiler, or say how

### DIFF
--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -141,6 +141,7 @@
         "@gjsify/npm-registry": "workspace:^",
         "@gjsify/resolve-npm": "workspace:^",
         "@gjsify/rolldown-plugin-gjsify": "workspace:^",
+        "@gjsify/vite-plugin-blueprint": "workspace:^",
         "@gjsify/rolldown-plugin-pnp": "workspace:^",
         "@gjsify/semver": "workspace:^",
         "@gjsify/tar": "workspace:^",

--- a/packages/infra/cli/src/utils/check-system-deps.spec.ts
+++ b/packages/infra/cli/src/utils/check-system-deps.spec.ts
@@ -13,8 +13,10 @@
 
 import { describe, it, expect } from '@gjsify/unit';
 import type { DepCheck } from './check-system-deps.js';
+import { resolveBlueprintCompiler } from '@gjsify/vite-plugin-blueprint/resolve';
 import {
     buildInstallCommand,
+    checkBlueprintCompiler,
     checkTypeSkew,
     missingSystemDepsFor,
     OPTIONAL_DEPS,
@@ -106,6 +108,49 @@ export default async () => {
                 .map((d) => d.id)
                 .filter((id) => !declared.has(id));
             expect(undeclared.join(', ')).toBe('');
+        });
+
+        await it('every package manager can spell blueprint-compiler', async () => {
+            // A `.blp` build that cannot find the compiler used to rethrow execa's
+            // error, which names the command that failed and nothing to install.
+            // Measured on the win11-gjsify VM 2026-08-10, that was read as
+            // "blueprint-compiler is a GNOME Python tool, so it is unavailable on
+            // Windows" — a wrong conclusion that reached a docs file. It is pure
+            // Python and MSYS2 ships it prebuilt; only PyGObject (no Windows
+            // wheel) makes plain pip impossible.
+            const missing: DepCheck[] = [
+                { id: 'blueprint-compiler', name: 'blueprint-compiler', found: false, severity: 'optional' },
+            ];
+            const silent: string[] = [];
+            for (const pm of ['apt', 'dnf', 'pacman', 'zypper', 'apk', 'brew'] as const) {
+                if (!buildInstallCommand(pm, missing)) silent.push(pm);
+            }
+            expect(silent.join(', ')).toBe('');
+        });
+
+        await it('the win32 blueprint hint is MSYS2, never a winget package', async () => {
+            // winget has no blueprint-compiler and cannot usefully get one, so the
+            // hint must not be `winget install`-shaped. This asserts the standalone
+            // branch instead of the PM_PACKAGES table — putting it in the table
+            // would print a line that looks right and installs nothing.
+            if (process.platform !== 'win32') return;
+            const missing: DepCheck[] = [
+                { id: 'blueprint-compiler', name: 'blueprint-compiler', found: false, severity: 'optional' },
+            ];
+            const hint = buildInstallCommand('winget', missing) ?? '';
+            expect(hint.includes('mingw-w64-ucrt-x86_64-blueprint-compiler')).toBe(true);
+            expect(hint.includes('winget install')).toBe(false);
+        });
+
+        await it('the blueprint check agrees with the resolver the BUILD uses', async () => {
+            // The two must not be able to disagree. On win32 the compiler is
+            // normally an MSYS2 script deliberately kept OFF PATH, so a PATH-only
+            // check would report "missing" on a host where every `.blp` builds —
+            // a check failing for the wrong reason.
+            const check = checkBlueprintCompiler(['@gjsify/vite-plugin-blueprint']);
+            expect(check.id).toBe('blueprint-compiler');
+            expect(check.severity).toBe('optional');
+            expect(check.found).toBe(resolveBlueprintCompiler() !== null);
         });
     });
 

--- a/packages/infra/cli/src/utils/check-system-deps.ts
+++ b/packages/infra/cli/src/utils/check-system-deps.ts
@@ -16,6 +16,9 @@ import { dirname, join, resolve } from 'node:path';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
+// The zero-dependency subpath, deliberately: importing the plugin root would
+// pull vite/execa/minify-xml into a system CHECK.
+import { resolveBlueprintCompiler } from '@gjsify/vite-plugin-blueprint/resolve';
 
 export type DepSeverity = 'required' | 'optional';
 
@@ -469,6 +472,33 @@ export function runMinimalChecks(): DepCheck[] {
     return results;
 }
 
+/**
+ * Is a blueprint-compiler reachable, by the SAME rule the build uses?
+ *
+ * Delegates to `@gjsify/vite-plugin-blueprint/resolve` rather than probing PATH
+ * here, because the two answers must not be able to disagree: on win32 the
+ * compiler is normally an MSYS2 script that is deliberately NOT on PATH, so a
+ * PATH-only check would report "missing" on a host where every `.blp` builds
+ * fine — a check failing for the wrong reason, which is the failure mode this
+ * file's own history is made of.
+ *
+ * `--version` is not run. MSYS2 ships blueprint-compiler as a shebang script
+ * with no `.exe`, so `checkBinary` cannot execute it on Windows; presence of the
+ * resolved pair is the honest answer, and the `source` is worth reporting
+ * because "found via msys2" explains an install PATH does not show.
+ */
+export function checkBlueprintCompiler(requiredBy?: string[]): DepCheck {
+    const resolved = resolveBlueprintCompiler();
+    return {
+        id: 'blueprint-compiler',
+        name: 'blueprint-compiler (.blp templates)',
+        found: resolved !== null,
+        version: resolved ? `found via ${resolved.source}` : undefined,
+        severity: 'optional',
+        requiredBy,
+    };
+}
+
 /** Check gwebgl npm package (project first, CLI fallback). Optional — only needed by @gjsify/webgl users. */
 export function checkGwebgl(cwd: string): DepCheck {
     return checkNpmPackage('gwebgl', 'gwebgl (@gjsify/webgl)', '@gjsify/webgl', cwd, 'optional', ['@gjsify/webgl']);
@@ -541,7 +571,14 @@ function runNativeBuildToolchainChecks(): DepCheck[] {
     // crate by Cargo path-dependency need a Rust toolchain.
     const rustBridges = ['@gjsify/lightningcss-native', '@gjsify/oxfmt-native', '@gjsify/rolldown-native'];
 
+    // Every showcase/app whose window comes from a `.blp` template. NOT a Vala
+    // bridge and nothing to do with meson — it is a BUILD-time toolchain in the
+    // same sense, and it belongs here so `gjsify system-check` names it before a
+    // build does.
+    const blueprintConsumers = ['@gjsify/vite-plugin-blueprint'];
+
     return [
+        checkBlueprintCompiler(blueprintConsumers),
         checkBinary('ninja', 'Ninja', 'ninja', ['--version'], 'optional', undefined, valaBridges),
         checkBinary(
             'vala',
@@ -808,10 +845,25 @@ export function buildInstallCommand(pm: PackageManager, missing: DepCheck[]): st
     const pkgMap = PM_PACKAGES[pm];
     const pkgs: string[] = [];
     const npmDeps: string[] = [];
+    const standalone: string[] = [];
 
     for (const dep of missing) {
         if (dep.id === 'gwebgl') {
             npmDeps.push('@gjsify/webgl');
+            continue;
+        }
+        // blueprint-compiler on Windows is the one dep whose install command is
+        // not this host's package manager. winget has no package for it, and it
+        // cannot get one that works: the tool needs PyGObject, which publishes
+        // no Windows wheel, so MSYS2 — which ships Python, PyGObject and the
+        // typelibs already fitted together — is the only source. Its command is
+        // not `winget install`-shaped, so it cannot live in PM_PACKAGES without
+        // producing a line that looks right and fails.
+        if (dep.id === 'blueprint-compiler' && process.platform === 'win32') {
+            standalone.push(
+                'pacman -S mingw-w64-ucrt-x86_64-blueprint-compiler mingw-w64-ucrt-x86_64-gtk4 ' +
+                    'mingw-w64-ucrt-x86_64-libadwaita   # inside MSYS2; found automatically afterwards',
+            );
             continue;
         }
         if (dep.id === 'nodejs') continue; // can't be missing if we're running
@@ -826,6 +878,7 @@ export function buildInstallCommand(pm: PackageManager, missing: DepCheck[]): st
     if (npmDeps.length > 0) {
         lines.push(`npm install ${npmDeps.join(' ')}`);
     }
+    lines.push(...standalone);
 
     return lines.length > 0 ? lines.join('\n  ') : null;
 }

--- a/packages/infra/vite-plugin-blueprint/package.json
+++ b/packages/infra/vite-plugin-blueprint/package.json
@@ -11,6 +11,10 @@
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"
         },
+        "./resolve": {
+            "types": "./lib/resolve-compiler.d.ts",
+            "default": "./lib/resolve-compiler.js"
+        },
         "./types": {
             "types": "./types/blueprint.d.ts"
         }

--- a/packages/infra/vite-plugin-blueprint/package.json
+++ b/packages/infra/vite-plugin-blueprint/package.json
@@ -68,6 +68,11 @@
         "vite": "^8.1.3"
     },
     "gjsify": {
-        "tier": 1
+        "tier": 1,
+        "os": {
+            "linux": "supported",
+            "darwin": "supported",
+            "win32": "supported"
+        }
     }
 }

--- a/packages/infra/vite-plugin-blueprint/src/index.ts
+++ b/packages/infra/vite-plugin-blueprint/src/index.ts
@@ -1,11 +1,14 @@
 import { type Plugin } from 'vite';
 import { execa } from 'execa';
 import minifyXML from 'minify-xml';
+import { formatMissingBlueprintCompiler, resolveBlueprintCompiler } from './resolve-compiler.js';
 
 export interface BlueprintPluginOptions {
     minify?: boolean;
     verbose?: boolean;
 }
+
+export { resolveBlueprintCompiler, formatMissingBlueprintCompiler } from './resolve-compiler.js';
 
 export default function blueprintPlugin(options: BlueprintPluginOptions = {}): Plugin {
     const { minify = false, verbose = false } = options;
@@ -15,10 +18,22 @@ export default function blueprintPlugin(options: BlueprintPluginOptions = {}): P
 
         async load(id) {
             if (id.endsWith('.blp')) {
+                // Resolved per load rather than once at plugin construction, so a
+                // compiler installed mid-watch is picked up without a restart —
+                // and so the "missing" diagnostic names the .blp that wanted it.
+                const compiler = resolveBlueprintCompiler();
+                if (!compiler) {
+                    throw new Error(`${id}: ${formatMissingBlueprintCompiler()}`);
+                }
+
                 try {
                     // Compile .blp file and get XML output directly
-                    const { stdout } = await execa('blueprint-compiler', ['compile', id]);
-                    if (verbose) console.log(`Compiled ${id}`);
+                    const { stdout } = await execa(compiler.file, [...compiler.prefixArgs, 'compile', id], {
+                        // Only ever an overlay (an MSYS2 PATH prepend); undefined
+                        // inherits the environment unchanged.
+                        env: compiler.env,
+                    });
+                    if (verbose) console.log(`Compiled ${id} (blueprint-compiler via ${compiler.source})`);
 
                     let xmlContent = stdout;
 
@@ -31,8 +46,13 @@ export default function blueprintPlugin(options: BlueprintPluginOptions = {}): P
                     // Return the XML content as a string
                     return `export default ${JSON.stringify(xmlContent)};`;
                 } catch (error) {
-                    console.error(`Error processing ${id}:`, error);
-                    throw error;
+                    // The compiler EXISTS and refused the file, so this is a
+                    // blueprint syntax/type error and its own stderr is the
+                    // useful part — surface that, not an install hint the reader
+                    // has already satisfied.
+                    const detail =
+                        error instanceof Error ? (error as { stderr?: string }).stderr || error.message : String(error);
+                    throw new Error(`${id}: blueprint-compiler failed (${compiler.file})\n${detail}`);
                 }
             }
         },

--- a/packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts
+++ b/packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts
@@ -1,0 +1,160 @@
+// Where is `blueprint-compiler`, and what do we say when it is nowhere?
+//
+// Split out of the plugin so it is answerable in a test without a compiler
+// installed, and because the answer is genuinely platform-shaped on Windows.
+//
+// The failure this replaces: the plugin called `execa('blueprint-compiler', …)`
+// and rethrew whatever came back, so a host without it got an ExecaError stack
+// naming the COMMAND THAT FAILED and nothing about what to install. Measured on
+// the win11-gjsify VM, that error was read as "blueprint-compiler is a GNOME
+// Python tool, so it is unavailable on Windows" — a conclusion that reached a
+// docs file and stopped anyone building a `.blp` showcase there for a day. It is
+// available; nothing said how to get it.
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** A spawnable blueprint-compiler, plus how it was found (for `verbose`). */
+export interface ResolvedBlueprintCompiler {
+    /** The executable to spawn. */
+    file: string;
+    /** Arguments that must precede blueprint-compiler's own (e.g. the script path). */
+    prefixArgs: string[];
+    /** Environment overlay to spawn with, or undefined to inherit unchanged. */
+    env?: Record<string, string>;
+    source: 'env' | 'path' | 'msys2';
+}
+
+/**
+ * MSYS2 install roots to probe on win32, in order.
+ *
+ * MSYS2 is the ONLY way to get blueprint-compiler onto Windows today, and not
+ * for the reason the tool's Python-ness suggests: it is pure Python (PyPI ships
+ * a `py3-none-any` wheel), but `blueprintcompiler/gir.py` reads TYPELIBS through
+ * `GIRepository`, so it needs PyGObject — which publishes no Windows wheel, so
+ * `pip install blueprint-compiler` dies building it from source. MSYS2 is where
+ * Python, PyGObject and the typelibs arrive already fitted together.
+ *
+ * `C:\msys64` is the installer default; the `$USERPROFILE` entries cover the
+ * extracted-archive install, which is what a host without admin rights gets;
+ * `C:\tools\msys64` is Chocolatey's.
+ */
+const MSYS2_ROOTS = [
+    process.env.MSYS2_ROOT,
+    'C:\\msys64',
+    process.env.USERPROFILE && join(process.env.USERPROFILE, 'msys64'),
+    process.env.USERPROFILE && join(process.env.USERPROFILE, 'Tools', 'msys64'),
+    'C:\\tools\\msys64',
+].filter((root): root is string => typeof root === 'string' && root.length > 0);
+
+/**
+ * MSYS2 environments, most-preferred first. `ucrt64` is MSYS2's own default for
+ * new installs and links the modern Universal CRT; the others are probed so an
+ * existing install is not rejected for being older.
+ */
+const MSYS2_ENVS = ['ucrt64', 'mingw64', 'clang64'];
+
+/** Executable suffixes to try for a bare command name. Windows needs them; POSIX does not. */
+const EXE_SUFFIXES = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+
+/** First existing `<dir>/<cmd><suffix>`, or null. */
+function findOnPath(cmd: string): string | null {
+    const pathVar = process.env.PATH;
+    if (!pathVar) return null;
+    const sep = process.platform === 'win32' ? ';' : ':';
+    for (const dir of pathVar.split(sep)) {
+        if (!dir) continue;
+        for (const suffix of EXE_SUFFIXES) {
+            const candidate = join(dir, cmd + suffix);
+            try {
+                if (existsSync(candidate)) return candidate;
+            } catch {
+                // An unreadable PATH entry is not an answer about `cmd`.
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * Find an MSYS2-provided blueprint-compiler.
+ *
+ * MSYS2 installs it as a SHEBANG SCRIPT with no `.exe` beside it, which Windows
+ * cannot execute — so this returns MSYS2's own `python.exe` with the script as
+ * its first argument, rather than the script alone. `<env>/bin` is prepended to
+ * PATH because the script imports PyGObject, which loads MSYS2's libglib and its
+ * typelibs from there.
+ *
+ * Deliberately does NOT set `GI_TYPELIB_PATH` at the gjsify GTK runtime bundle:
+ * those typelibs are gvsbuild's and name `glib-2.0-0.dll` in their
+ * `shared_library` field while MSYS2 ships `libglib-2.0-0.dll`. Measured — it
+ * fails with "Failed to load shared library", and the obvious repair (put both
+ * on PATH) would load two GLib builds into one process, which is a worse problem
+ * than the one it solves.
+ */
+function findInMsys2(): ResolvedBlueprintCompiler | null {
+    if (process.platform !== 'win32') return null;
+    for (const root of MSYS2_ROOTS) {
+        for (const env of MSYS2_ENVS) {
+            const bin = join(root, env, 'bin');
+            const script = join(bin, 'blueprint-compiler');
+            const python = join(bin, 'python.exe');
+            try {
+                if (!existsSync(script) || !existsSync(python)) continue;
+            } catch {
+                continue;
+            }
+            return {
+                file: python,
+                prefixArgs: [script],
+                env: { PATH: `${bin};${process.env.PATH ?? ''}` },
+                source: 'msys2',
+            };
+        }
+    }
+    return null;
+}
+
+/**
+ * Locate a usable blueprint-compiler, or null when there is none.
+ *
+ * Order: `BLUEPRINT_COMPILER` (an explicit answer always wins, and is the escape
+ * hatch for an install none of the probes below know about) → `PATH` → an MSYS2
+ * install on win32.
+ */
+export function resolveBlueprintCompiler(): ResolvedBlueprintCompiler | null {
+    const override = process.env.BLUEPRINT_COMPILER;
+    if (override) {
+        return { file: override, prefixArgs: [], source: 'env' };
+    }
+    const onPath = findOnPath('blueprint-compiler');
+    if (onPath) {
+        return { file: onPath, prefixArgs: [], source: 'path' };
+    }
+    return findInMsys2();
+}
+
+/**
+ * What to tell someone who has no blueprint-compiler.
+ *
+ * Names the install command for THIS platform rather than listing every one:
+ * the reader is on one host and the other two lines are noise they have to
+ * filter. `BLUEPRINT_COMPILER` is mentioned everywhere because it is the answer
+ * for any install the probes miss.
+ */
+export function formatMissingBlueprintCompiler(): string {
+    const install =
+        process.platform === 'win32'
+            ? 'MSYS2 packages it prebuilt (it needs PyGObject, which has no Windows wheel, so pip cannot):\n' +
+              '    pacman -S mingw-w64-ucrt-x86_64-blueprint-compiler mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-libadwaita\n' +
+              '  An MSYS2 install under C:\\msys64, %USERPROFILE%\\msys64, %USERPROFILE%\\Tools\\msys64 or\n' +
+              '  C:\\tools\\msys64 is found automatically — it does NOT need to be on PATH.'
+            : process.platform === 'darwin'
+              ? 'brew install blueprint-compiler'
+              : 'sudo dnf install blueprint-compiler   (Debian/Ubuntu: sudo apt install blueprint-compiler)';
+    return (
+        'blueprint-compiler was not found, so a .blp template cannot be compiled.\n' +
+        `  ${install}\n` +
+        '  Or set BLUEPRINT_COMPILER to its full path.'
+    );
+}


### PR DESCRIPTION
## What

A `.blp` build on a host without blueprint-compiler rethrew execa's error — which names the command that failed and **nothing to install**. Measured on the win11-gjsify VM: that message was read as *"blueprint-compiler is a GNOME Python tool, so it is unavailable on Windows"*, a conclusion that reached a docs file and stopped anyone building a `.blp` showcase there for a day.

**It is available.** It's pure Python (PyPI ships a `py3-none-any` wheel) and MSYS2 packages it prebuilt. What genuinely blocks plain CPython is **PyGObject**, which publishes no Windows wheel and which the tool needs for real — `blueprintcompiler/gir.py` reads *typelibs* through `GIRepository`, not GIR XML. So the Python has to arrive with a GI stack attached, and MSYS2 is that.

## Two changes

**1. The failure names the fix.** Per-platform install command plus `BLUEPRINT_COMPILER` for an install the probes miss. A compiler that *exists* and rejects the file keeps reporting its own stderr — that reader has already satisfied the install hint, and repeating it would bury the syntax error.

**2. The compiler is DISCOVERED, not just looked up on PATH.** MSYS2 installs it as a shebang script with no `.exe`, which Windows cannot execute and no bare-name spawn can reach — so a win32 host needed a hand-written `.cmd` shim. `resolveBlueprintCompiler()` probes the known MSYS2 roots (`%MSYS2_ROOT%`, `C:\msys64`, `%USERPROFILE%\msys64`, `%USERPROFILE%\Tools\msys64`, `C:\tools\msys64` × `ucrt64`/`mingw64`/`clang64`) and spawns `python.exe <script>` with `<env>/bin` prepended to the **child's** PATH.

New `./resolve` subpath export, deliberately zero-dependency: importing the plugin root would pull `vite`/`execa`/`minify-xml` into a system *check*.

## Deliberately not done

It does **not** point MSYS2's PyGObject at the typelibs in `@gjsify/gtk-runtime-win32-x64`. Those are gvsbuild's and name `glib-2.0-0.dll` in their `shared_library` field while MSYS2 ships `libglib-2.0-0.dll` — measured, it fails to load, and the obvious repair (put both on PATH) would pull two GLib builds into one process.

## system-check

`gjsify system-check` reports it through the **same resolver**, not a PATH probe of its own — the two answers must not be able to disagree. On win32 the compiler is normally an MSYS2 script deliberately kept off PATH, so a PATH-only check would report "missing" on a host where every `.blp` builds: a check failing for the wrong reason, which is what this file's own history is made of.

The win32 hint is the MSYS2 `pacman` line via the standalone branch, **not** a `winget install` — winget has no such package and cannot usefully have one, so putting it in `PM_PACKAGES` would print a line that looks right and installs nothing.

## Verified

- On the win11-gjsify VM with blueprint-compiler **entirely off PATH**: `three-postprocessing-pixel` builds. The `.cmd` shim is deleted.
- Full `@gjsify/cli` suite green (1997 tests), including 3 new ones — one asserting the check agrees with the resolver, one asserting every package manager can spell it, one asserting the win32 hint is never winget-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)