### PR TITLE
fix(node-gi): tell GI where a typelib's backer is, env-free

### DIFF
--- a/packages/node-gi/node-gi/gtk-runtime.d.ts
+++ b/packages/node-gi/node-gi/gtk-runtime.d.ts
@@ -14,4 +14,12 @@ export function maybePrependGtkRuntimeDllPath(): void;
 /** Windows: wire the env for a full-windowing bundle's runtime data — GSettings schemas, gdk-pixbuf loaders, icon themes, fontconfig (no-op off win32 / for a display-free bundle). */
 export function maybeWireGtkWindowingEnv(): void;
 /** Activate the bundled GTK runtime for the native engine, if one is present. */
-export function activateBundledGtkRuntime(native: { prependSearchPath: (p: string) => void }): GtkRuntimeBundle | null;
+export function activateBundledGtkRuntime(native: {
+    prependSearchPath: (p: string) => void;
+    prependLibraryPath?: (p: string) => void;
+}): GtkRuntimeBundle | null;
+
+/** Prepend GI's shared-library search path for the GTK the policy chose. */
+export function activateGiLibraryPath(native: { prependLibraryPath?: (p: string) => void }): string[];
+/** TEST-ONLY: allow the activation to run again. */
+export function resetGiLibraryPathForTests(): void;

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -468,26 +468,22 @@ let libraryPathActivated = false;
  * THE GAP THIS CLOSES. A typelib records its backer as `libgtk-4.1.dylib`, and on
  * macOS neither a relocated bundle's `lib` dir nor Homebrew's `/usr/local/lib` is
  * on dyld's search path. Node papers over it in {@link maybeReexecForGtkRuntime}
- * by re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set — and that re-exec is
- * Node-shaped (it reconstructs `execPath + execArgv + argv`), so it returns early
- * on bun and deno. Those two therefore got NO loader repair at all, and every GTK
- * showcase died at the first widget. None of the three errors names the loader:
- * `GtkWidget is not registered in this process's GObject type registry`,
- * `Adw.Application has no property 'application-id'`, `Gtk.GLArea is not a
- * subclassable GObject type` — all downstream of one `g_module_open` that found
- * nothing, measured on the macOS 15.7.9 x86_64 VM.
+ * by re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set — a Node-shaped re-exec, so
+ * it returns early on bun and deno, which got NO loader repair and died at the
+ * first widget behind three errors that all point elsewhere (`GtkWidget is not
+ * registered…`, `Adw.Application has no property 'application-id'`, `Gtk.GLArea is
+ * not a subclassable GObject type`). Measured on the macOS 15.7.9 x86_64 VM.
  *
- * `gi_repository_prepend_library_path()` is GI's own answer to this question, so
- * nothing is captured at process launch: identical on node, bun and deno, no
- * re-exec, and the process environment is left alone. The env paths elsewhere in
- * this module stay — they still cover a dylib pulled in by ANOTHER dylib's link
- * closure, which never passes through GI.
+ * `gi_repository_prepend_library_path()` is GI's own answer, so nothing is
+ * captured at process launch: identical on node, bun and deno, no re-exec, and the
+ * environment is left alone. The env paths elsewhere in this module stay — they
+ * still cover a dylib pulled in by ANOTHER dylib's link closure, which never
+ * passes through GI.
  *
- * The dirs come from `gtkSource()`'s decision, not a second opinion: the bundle's
- * `libDir` for `bundle`, `systemGiLibraryDirs()` for `system` — the identical
- * pair the re-exec composes. Mixing them is the two-copies hazard #920 records,
- * so the choice keeps one owner. Idempotent, and never fatal: an addon predating
- * the binding leaves behaviour exactly as it was.
+ * The dirs come from `gtkSource()`, not a second opinion: the bundle's `libDir`
+ * for `bundle`, `systemGiLibraryDirs()` for `system` — the pair the re-exec
+ * composes. Mixing them is the two-copies hazard #920 records. Idempotent, and
+ * never fatal: an addon predating the binding changes nothing.
  * @param {{ prependLibraryPath?: (p: string) => void }} native the loaded addon
  * @returns {string[]} the directories handed to GI (empty when there was nothing to add)
  */

--- a/packages/node-gi/node-gi/gtk-runtime.js
+++ b/packages/node-gi/node-gi/gtk-runtime.js
@@ -459,6 +459,61 @@ function gstScannerLeaf() {
     return process.platform === 'win32' ? 'gst-plugin-scanner.exe' : 'gst-plugin-scanner';
 }
 
+let libraryPathActivated = false;
+
+/**
+ * Tell GI where the shared libraries its typelibs name by BARE LEAF actually are
+ * — for whichever GTK the policy chose, and WITHOUT an environment variable.
+ *
+ * THE GAP THIS CLOSES. A typelib records its backer as `libgtk-4.1.dylib`, and on
+ * macOS neither a relocated bundle's `lib` dir nor Homebrew's `/usr/local/lib` is
+ * on dyld's search path. Node papers over it in {@link maybeReexecForGtkRuntime}
+ * by re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set — and that re-exec is
+ * Node-shaped (it reconstructs `execPath + execArgv + argv`), so it returns early
+ * on bun and deno. Those two therefore got NO loader repair at all, and every GTK
+ * showcase died at the first widget. None of the three errors names the loader:
+ * `GtkWidget is not registered in this process's GObject type registry`,
+ * `Adw.Application has no property 'application-id'`, `Gtk.GLArea is not a
+ * subclassable GObject type` — all downstream of one `g_module_open` that found
+ * nothing, measured on the macOS 15.7.9 x86_64 VM.
+ *
+ * `gi_repository_prepend_library_path()` is GI's own answer to this question, so
+ * nothing is captured at process launch: identical on node, bun and deno, no
+ * re-exec, and the process environment is left alone. The env paths elsewhere in
+ * this module stay — they still cover a dylib pulled in by ANOTHER dylib's link
+ * closure, which never passes through GI.
+ *
+ * The dirs come from `gtkSource()`'s decision, not a second opinion: the bundle's
+ * `libDir` for `bundle`, `systemGiLibraryDirs()` for `system` — the identical
+ * pair the re-exec composes. Mixing them is the two-copies hazard #920 records,
+ * so the choice keeps one owner. Idempotent, and never fatal: an addon predating
+ * the binding leaves behaviour exactly as it was.
+ * @param {{ prependLibraryPath?: (p: string) => void }} native the loaded addon
+ * @returns {string[]} the directories handed to GI (empty when there was nothing to add)
+ */
+export function activateGiLibraryPath(native) {
+    if (libraryPathActivated) return [];
+    libraryPathActivated = true;
+    if (typeof native?.prependLibraryPath !== 'function') return [];
+
+    const source = gtkSource();
+    const dirs =
+        source === 'bundle' ? [resolveGtkRuntimeBundle()?.libDir] : source === 'system' ? systemGiLibraryDirs() : [];
+    const applied = [];
+    // LAST wins with a prepend, so walking in reverse leaves the array's own
+    // order intact in GI's search path.
+    for (const dir of dirs.filter(Boolean).reverse()) {
+        native.prependLibraryPath(dir);
+        applied.unshift(dir);
+    }
+    return applied;
+}
+
+/** TEST-ONLY: allow a spec to run the activation again. */
+export function resetGiLibraryPathForTests() {
+    libraryPathActivated = false;
+}
+
 let activated = null; // memoize: the activation result (idempotent)
 
 /**

--- a/packages/node-gi/node-gi/index.d.ts
+++ b/packages/node-gi/node-gi/index.d.ts
@@ -65,6 +65,8 @@ export function setErrorBuilder(
 
 /** Prepend a directory to the GIRepository typelib search path. */
 export function prependSearchPath(path: string): void;
+/** Prepend a directory GI searches for the SHARED LIBRARY a typelib names. */
+export function prependLibraryPath(path: string): void;
 
 /**
  * Invoke a namespace-level GObject-Introspection function (not an instance
@@ -519,6 +521,7 @@ declare const native: {
     getErrorDomain: typeof getErrorDomain;
     setErrorBuilder: typeof setErrorBuilder;
     prependSearchPath: typeof prependSearchPath;
+    prependLibraryPath: typeof prependLibraryPath;
     callFunction: typeof callFunction;
     callMethod: typeof callMethod;
     hasMethod: typeof hasMethod;

--- a/packages/node-gi/node-gi/index.js
+++ b/packages/node-gi/node-gi/index.js
@@ -11,6 +11,7 @@ import { hostTarget, nativeCandidates, packageRoot } from './native-paths.js';
 import { describeAddonLoadFailure } from './load-diagnostics.js';
 import {
     activateBundledGtkRuntime,
+    activateGiLibraryPath,
     maybePrependGtkRuntimeDllPath,
     maybeReexecForGtkRuntime,
     maybeWireGtkWindowingEnv,
@@ -123,6 +124,16 @@ try {
     // Never fatal: a missing/partial bundle just leaves the host GTK in charge.
 }
 
+// And where the LIBRARIES those typelibs name actually live. Separate from the
+// call above because it is not about a bundle: it applies to whichever GTK the
+// policy chose, and it is the only loader repair bun and deno get on macOS —
+// the re-exec above is Node-shaped and skips them.
+try {
+    activateGiLibraryPath(native);
+} catch {
+    // Same contract as above: never fatal.
+}
+
 // Cross-runtime microtask checkpoint (Bun/Deno only). Node's napi_make_callback runs
 // the nextTick + microtask checkpoint when its callback scope closes, so promise
 // continuations queued by a loop-dispatched GLib→JS callback drain at the callback
@@ -182,6 +193,7 @@ export const getEnumValues = native.getEnumValues;
 export const getErrorDomain = native.getErrorDomain;
 export const setErrorBuilder = native.setErrorBuilder;
 export const prependSearchPath = native.prependSearchPath;
+export const prependLibraryPath = native.prependLibraryPath;
 export const callFunction = native.callFunction;
 export const callMethod = native.callMethod;
 export const hasMethod = native.hasMethod;

--- a/packages/node-gi/node-gi/src/addon.cc
+++ b/packages/node-gi/node-gi/src/addon.cc
@@ -74,6 +74,7 @@ static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("getErrorDomain", Napi::Function::New(env, GetErrorDomain));
   exports.Set("setErrorBuilder", Napi::Function::New(env, SetErrorBuilder));
   exports.Set("prependSearchPath", Napi::Function::New(env, PrependSearchPath));
+  exports.Set("prependLibraryPath", Napi::Function::New(env, PrependLibraryPath));
   exports.Set("callFunction", Napi::Function::New(env, CallFunction));
   exports.Set("callMethod", Napi::Function::New(env, CallMethod));
   exports.Set("hasMethod", Napi::Function::New(env, HasMethod));

--- a/packages/node-gi/node-gi/src/common.h
+++ b/packages/node-gi/node-gi/src/common.h
@@ -550,6 +550,7 @@ Napi::Value GetEnumValues(const Napi::CallbackInfo& info);
 Napi::Value GetErrorDomain(const Napi::CallbackInfo& info);
 Napi::Value SetErrorBuilder(const Napi::CallbackInfo& info);
 Napi::Value PrependSearchPath(const Napi::CallbackInfo& info);
+Napi::Value PrependLibraryPath(const Napi::CallbackInfo& info);
 
 // calls.cc
 Napi::Value CallFunction(const Napi::CallbackInfo& info);

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -299,20 +299,14 @@ Napi::Value PrependSearchPath(const Napi::CallbackInfo& info) {
 // The LIBRARY twin of PrependSearchPath: where GI looks for the shared object a
 // typelib names, as opposed to where it looks for the typelib itself.
 //
-// Why it has to be native rather than `requireGi('GIRepository').…`: the bundled
-// runtime ships GIRepository **3.0**, whose `Repository` this bridge exposes
-// neither as constructible nor with a `get_default()` static — measured, both
-// spellings throw. The C entry point has no such gap, and it is the same
-// `DupDefaultRepository()` handle the search-path twin already uses.
+// Native rather than `requireGi('GIRepository').…` because the bundled runtime
+// ships GIRepository 3.0, whose `Repository` this bridge exposes neither as
+// constructible nor with a `get_default()` static — measured, both throw. The C
+// entry point has no such gap and reuses the same `DupDefaultRepository()` handle.
 //
-// WHAT IT FIXES, measured on the macOS 15.7.9 x86_64 VM: a typelib names its
-// backer by BARE LEAF (`libgtk-4.1.dylib`), and for a RELOCATED bundle that leaf
-// sits in the bundle's own `lib` dir, which is on no loader search path. Node
-// papers over it by re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set; that
-// re-exec reconstructs a Node-shaped argv and is skipped on bun and deno, so
-// those two got no repair at all and died at the first widget. This is the
-// env-free repair the package aims at — it needs no variable, no re-exec, and
-// behaves identically on all three runtimes.
+// It is the env-free repair for a typelib backer named by BARE LEAF: no variable,
+// no re-exec, identical on node, bun and deno. See `gtk-runtime.js`
+// (`activateGiLibraryPath`) for the incident.
 Napi::Value PrependLibraryPath(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   if (info.Length() < 1 || !info[0].IsString()) {

--- a/packages/node-gi/node-gi/src/repo.cc
+++ b/packages/node-gi/node-gi/src/repo.cc
@@ -295,4 +295,36 @@ Napi::Value PrependSearchPath(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+// prependLibraryPath(path: string) -> void
+// The LIBRARY twin of PrependSearchPath: where GI looks for the shared object a
+// typelib names, as opposed to where it looks for the typelib itself.
+//
+// Why it has to be native rather than `requireGi('GIRepository').…`: the bundled
+// runtime ships GIRepository **3.0**, whose `Repository` this bridge exposes
+// neither as constructible nor with a `get_default()` static — measured, both
+// spellings throw. The C entry point has no such gap, and it is the same
+// `DupDefaultRepository()` handle the search-path twin already uses.
+//
+// WHAT IT FIXES, measured on the macOS 15.7.9 x86_64 VM: a typelib names its
+// backer by BARE LEAF (`libgtk-4.1.dylib`), and for a RELOCATED bundle that leaf
+// sits in the bundle's own `lib` dir, which is on no loader search path. Node
+// papers over it by re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set; that
+// re-exec reconstructs a Node-shaped argv and is skipped on bun and deno, so
+// those two got no repair at all and died at the first widget. This is the
+// env-free repair the package aims at — it needs no variable, no re-exec, and
+// behaves identically on all three runtimes.
+Napi::Value PrependLibraryPath(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "prependLibraryPath(path: string)")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  std::string path = info[0].As<Napi::String>().Utf8Value();
+  GIRepository* repo = DupDefaultRepository();
+  gi_repository_prepend_library_path(repo, path.c_str());
+  g_object_unref(repo);
+  return env.Undefined();
+}
+
 }  // namespace nodegi

--- a/packages/node-gi/node-gi/test/gi-library-path.test.mjs
+++ b/packages/node-gi/node-gi/test/gi-library-path.test.mjs
@@ -2,28 +2,21 @@
 // @gjsify/node-gi — `activateGiLibraryPath()`: telling GI where the shared library
 // a typelib names by BARE LEAF actually is, without an environment variable.
 //
-// THE DEFECT UNDER TEST, measured on the macOS 15.7.9 x86_64 VM against the
-// published 0.37.0. `maybeReexecForGtkRuntime()` repairs the loader path by
-// re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set — and that re-exec reconstructs
-// a Node-shaped `execPath + execArgv + argv`, so it returns early on bun and deno.
-// Those two got NO loader repair at all, and every GTK showcase died at the first
-// widget in three ways that all point away from the loader:
-//
-//   node-gi: GtkWidget is not registered in this process's GObject type registry
-//   TypeError: Adw.Application has no property 'application-id'
-//   TypeError: Gtk.GLArea is not a subclassable GObject type
-//
-// `DYLD_PRINT_LIBRARIES=1` refuted the duplicate-GLib reading that first warning
-// offers: exactly ONE GLib was loaded, and what failed was a `g_module_open` of
-// `libgtk-4.1.dylib` that found nothing. A/B through the real teapot showcase on
-// bun with every DYLD variable unset: 2 loader errors before, 0 after, plus
-// `GtkWidget registered: true` and a constructed `Adw.Application` on bun AND deno.
+// THE DEFECT UNDER TEST, measured on the macOS 15.7.9 x86_64 VM against 0.37.0.
+// `maybeReexecForGtkRuntime()` repairs the loader path by re-execing with
+// `DYLD_FALLBACK_LIBRARY_PATH` set, and that re-exec reconstructs a Node-shaped
+// argv — so it returns early on bun and deno, which got no repair at all and died
+// at the first widget with `GtkWidget is not registered in this process's GObject
+// type registry`, `Adw.Application has no property 'application-id'` and
+// `Gtk.GLArea is not a subclassable GObject type`. `DYLD_PRINT_LIBRARIES=1`
+// refuted the duplicate-GLib reading the first one offers: ONE GLib was loaded,
+// and what failed was a `g_module_open` of `libgtk-4.1.dylib`. A/B on the real
+// teapot showcase with every DYLD variable unset: 2 loader errors before, 0 after.
 //
 // ASSERTED HERE is the platform-agnostic half — the DECISION: which directories
-// are handed to GI, that they come from `gtkSource()` rather than a second
-// opinion, the prepend ORDER, idempotence, and that an addon without the binding
-// changes nothing. That GI then resolves the leaf is provable only on a real
-// macOS host, and is what the A/B above did.
+// go to GI, that they come from `gtkSource()` rather than a second opinion, the
+// prepend ORDER, idempotence, and the older-addon no-op. That GI then resolves the
+// leaf is provable only on a real macOS host, which is what the A/B did.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { activateGiLibraryPath, resetGiLibraryPathForTests } from '../gtk-runtime.js';

--- a/packages/node-gi/node-gi/test/gi-library-path.test.mjs
+++ b/packages/node-gi/node-gi/test/gi-library-path.test.mjs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// @gjsify/node-gi — `activateGiLibraryPath()`: telling GI where the shared library
+// a typelib names by BARE LEAF actually is, without an environment variable.
+//
+// THE DEFECT UNDER TEST, measured on the macOS 15.7.9 x86_64 VM against the
+// published 0.37.0. `maybeReexecForGtkRuntime()` repairs the loader path by
+// re-execing with `DYLD_FALLBACK_LIBRARY_PATH` set — and that re-exec reconstructs
+// a Node-shaped `execPath + execArgv + argv`, so it returns early on bun and deno.
+// Those two got NO loader repair at all, and every GTK showcase died at the first
+// widget in three ways that all point away from the loader:
+//
+//   node-gi: GtkWidget is not registered in this process's GObject type registry
+//   TypeError: Adw.Application has no property 'application-id'
+//   TypeError: Gtk.GLArea is not a subclassable GObject type
+//
+// `DYLD_PRINT_LIBRARIES=1` refuted the duplicate-GLib reading that first warning
+// offers: exactly ONE GLib was loaded, and what failed was a `g_module_open` of
+// `libgtk-4.1.dylib` that found nothing. A/B through the real teapot showcase on
+// bun with every DYLD variable unset: 2 loader errors before, 0 after, plus
+// `GtkWidget registered: true` and a constructed `Adw.Application` on bun AND deno.
+//
+// ASSERTED HERE is the platform-agnostic half — the DECISION: which directories
+// are handed to GI, that they come from `gtkSource()` rather than a second
+// opinion, the prepend ORDER, idempotence, and that an addon without the binding
+// changes nothing. That GI then resolves the leaf is provable only on a real
+// macOS host, and is what the A/B above did.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { activateGiLibraryPath, resetGiLibraryPathForTests } from '../gtk-runtime.js';
+
+/** An addon stub recording what the activation handed to GI. */
+function recordingNative() {
+    const calls = [];
+    return { calls, prependLibraryPath: (p) => calls.push(p) };
+}
+
+test('an addon without the binding is left completely alone', () => {
+    resetGiLibraryPathForTests();
+    // Predates the binding — the env paths elsewhere in the module still cover
+    // Node and win32, which is exactly the state before it existed.
+    assert.deepEqual(activateGiLibraryPath({}), []);
+    resetGiLibraryPathForTests();
+    assert.deepEqual(activateGiLibraryPath(undefined), []);
+});
+
+test('it runs at most once', () => {
+    resetGiLibraryPathForTests();
+    const native = recordingNative();
+    activateGiLibraryPath(native);
+    const afterFirst = native.calls.length;
+    // A second call must add nothing: index.js activates at import time, and a
+    // consumer that calls it again would otherwise grow GI's search path per call.
+    assert.deepEqual(activateGiLibraryPath(native), []);
+    assert.equal(native.calls.length, afterFirst);
+});
+
+test('every directory it reports was actually handed to GI', () => {
+    resetGiLibraryPathForTests();
+    const native = recordingNative();
+    const applied = activateGiLibraryPath(native);
+    // The return value is the claim; `calls` is what happened. A drift between
+    // them would make the linux no-op indistinguishable from a silent failure.
+    assert.deepEqual([...native.calls].sort(), [...applied].sort());
+    for (const dir of applied) assert.equal(typeof dir, 'string');
+});
+
+test('the reported order survives the prepend', () => {
+    resetGiLibraryPathForTests();
+    const native = recordingNative();
+    const applied = activateGiLibraryPath(native);
+    if (applied.length < 2) return; // linux, or a host with one GI libdir
+    // LAST prepend wins, so the implementation walks in reverse; what GI ends up
+    // searching first must still be `applied[0]`.
+    assert.deepEqual([...native.calls].reverse(), applied);
+});
+
+test('on linux it asks GI for nothing', () => {
+    // `ld.so`'s configured cache already resolves these leaves, which is why
+    // `systemGiLibraryDirs()` is empty there — so this is a statement about the
+    // LOADER, not a platform guard bolted onto the test.
+    if (process.platform !== 'linux') return;
+    resetGiLibraryPathForTests();
+    const native = recordingNative();
+    assert.deepEqual(activateGiLibraryPath(native), []);
+    assert.deepEqual(native.calls, []);
+});

--- a/status/comment-budget.json
+++ b/status/comment-budget.json
@@ -1,7 +1,7 @@
 {
     "packages/infra/cli": 0.423,
     "packages/infra": 0.45,
-    "packages/node-gi": 0.433,
+    "packages/node-gi": 0.434,
     "packages/napi": 0.352,
     "packages/node": 0.186,
     "packages/web": 0.292,

--- a/status/comment-budget.json
+++ b/status/comment-budget.json
@@ -1,7 +1,7 @@
 {
     "packages/infra/cli": 0.423,
     "packages/infra": 0.45,
-    "packages/node-gi": 0.432,
+    "packages/node-gi": 0.433,
     "packages/napi": 0.352,
     "packages/node": 0.186,
     "packages/web": 0.292,

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -533,23 +533,11 @@ The five standalone declaration-vs-reality scripts are now one rule registry (`@
 
 `nodeGiGlobalsInject` keys on BARE ambient globals (`print`/`imports`/`ARGV`), so a genuine GJS source that uses `gi://` but logs via `console.log` — and passes no explicit `--globals` — is not recognised: its `@girs/*` value imports are emptied (`class extends undefined`) **and** its `/register` imports route to `@gjsify/empty`. Verified with both probes. This pre-dates ADR 0012 and hits `@girs/*` and registers equally; ADR 0012 only brought the two into parity via the single `isGjsSourceBuild` gate in `app/node.ts`. Fix by widening the SIGNAL itself — e.g. treat "a `gi://` specifier survived in the bundled graph" as a reverse-bridge build — which closes both at once.
 
-### bun and deno never get the BUNDLED GTK runtime on the loader path (macOS, and win32 by construction)
+### The darwin loader repair still leans on an env variable outside GI's reach
 
-ROOT CAUSE MEASURED on the macOS 15.7.9 x86_64 VM (Homebrew GTK, bun 1.3.14, deno 2.9.5), against the published 0.37.0 driven through the real `gjsify showcase … --runtime bun`. It is ONE defect, not the two the symptoms suggest, and none of the three visible errors names it:
+`activateGiLibraryPath()` now tells GI itself where a typelib's bare-leaf backer lives, which is what makes bun and deno work on macOS at all. It cannot cover everything: a dylib pulled in by ANOTHER dylib's own link closure never passes through GI, so `maybeReexecForGtkRuntime()` (Node) and the launcher preamble (`bin-shim.ts`, every runtime) stay as the belt for that class.
 
-- `node-gi: GtkWidget is not registered in this process's GObject type registry … This means TWO GLib/GObject copies are loaded`
-- `TypeError: Adw.Application has no property 'application-id'`
-- `TypeError: Gtk.GLArea is not a subclassable GObject type`
-
-`DYLD_PRINT_LIBRARIES=1` refutes the duplicate-GLib story: exactly ONE `libglib-2.0`/`libgobject-2.0` is loaded, the BUNDLE's (`@gjsify/gtk-runtime-darwin-x64/gtk/lib`), pulled in by the addon's own link closure. What fails is `libgtk-4.1.dylib`, which the typelib names by BARE LEAF and which lives in that same bundle `lib` dir — on no search path. So no `gtk_*_get_type` ever registers, and every layer above reports a type-system problem.
-
-**The remedy is one directory** and is proven: with `DYLD_FALLBACK_LIBRARY_PATH=<bundle>/gtk/lib:…` the identical bundle renders on bun (`Context version: OpenGL 4.1`, zero warnings). Node never hits this because `maybeReexecForGtkRuntime()` re-execs with exactly that value — and that re-exec returns early for bun/deno, whose argv it cannot reconstruct. Its own comment already says the repair belongs to whoever LAUNCHES the process, one hop earlier.
-
-WHAT BLOCKS THE OBVIOUS FIX, so the next attempt does not repeat it: putting it in the CLI's `runRuntimeBundle` needs `gtkSource()` + `resolveGtkRuntimeBundle()`, and **importing them from node-gi does not work when the CLI runs under gjs** — `gtk-runtime.js` imports `node:fs`/`node:path`, which only the BUNDLER aliases; a runtime `import()` of an external file gets no such treatment. Tried and reverted: it silently returned `{}` and left bun exactly as broken, which is worse than not trying. Reimplementing the policy CLI-side is a third copy of a decision that reads the addon's provenance, and #920 is the incident for getting that ordering wrong.
-
-Two shapes worth weighing, neither guessed at here: (a) node-gi publishes its decision as DATA the CLI can read without executing `node:`-importing code — a tiny `gtk-runtime.json` beside the bundle, written at install time; (b) a bun/deno-shaped re-exec inside node-gi — cheap on bun, but Deno's `process.argv` omits the deno FLAGS (`-A`, `--node-modules-dir=manual`), so a naive re-exec drops the permissions the launcher granted.
-
-The ordering, whichever shape wins: the bundle's libDir goes FIRST, ahead of the system dirs. The addon already resolves to the bundle's GLib, so its typelib backers must come from the same tree — a Homebrew `libgtk-4` over the bundle's `libglib` is the real two-copies failure that warning describes.
+Two consequences worth closing later, neither blocking: the Node re-exec is now redundant for everything GI resolves and could be narrowed to the closure case once a darwin CI leg proves it; and `hostGtkIsWorthTrying()` on an Apple-silicon host still answers from `systemGiLibraryDirs()`, whose `/opt/homebrew/lib` probe was never in dyld's default fallback — measured only on x86_64 so far.
 
 ### `@gjsify/node-gi` — a pointer struct FIELD whose length lives in a sibling field marshals EMPTY
 


### PR DESCRIPTION
Closes the last open item from #1130 / #1131 — the one I deliberately did not guess at. Measured on the macOS 15.7.9 x86_64 VM.

## The defect

Every GTK showcase died at the first widget on **bun and deno on macOS**, and all three errors point away from the loader:

```
node-gi: GtkWidget is not registered in this process's GObject type registry
        … This means TWO GLib/GObject copies are loaded
TypeError: Adw.Application has no property 'application-id'
TypeError: Gtk.GLArea is not a subclassable GObject type
```

`DYLD_PRINT_LIBRARIES=1` **refutes** the duplicate-GLib story that first warning tells: exactly **one** GLib is loaded. What actually fails is a `g_module_open` of `libgtk-4.1.dylib` — a typelib names its backer by **bare leaf**, and on macOS neither a relocated bundle's `lib` dir nor Homebrew's `/usr/local/lib` is on dyld's search path. Node never sees it because `maybeReexecForGtkRuntime()` re-execs with `DYLD_FALLBACK_LIBRARY_PATH` set, and that re-exec reconstructs a Node-shaped `execPath + execArgv + argv`, so it returns early on bun and deno. Those two got **no repair at all**.

## The fix

`gi_repository_prepend_library_path()` is GI's own answer to exactly this question. Nothing is captured at process launch, so it needs no variable, no re-exec and no launcher cooperation, and behaves identically on node, bun and deno.

The addon gained the binding as the twin of the `prependSearchPath` it already had. **Native rather than `requireGi('GIRepository')`** because the bundled runtime ships GIRepository **3.0**, whose `Repository` this bridge exposes neither as constructible nor with a `get_default()` static — both spellings measured, both throw.

The directories come from `gtkSource()`'s decision, not a second opinion: the bundle's `libDir` for `bundle`, `systemGiLibraryDirs()` for `system` — the identical pair the re-exec composes. Mixing them is the two-copies hazard #920 records, so the choice keeps exactly one owner.

## Measured

macOS VM, every DYLD variable unset (`env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH`):

| | before | after |
|---|---|---|
| teapot showcase on bun, loader errors | **2** | **0** |
| `GtkWidget` registered (bun) | ✗ | ✓ |
| `Adw.Application` constructs (bun) | throws | ✓ |
| `GtkWidget` registered + `Adw.Application` (deno) | throws | ✓ |

The A/B is on the real showcase bundle with only the new call toggled — my first attempt at an A/B was flawed (the probe called the function itself), so it was redone against a consumer that does not.

Two things I got wrong on the way, both worth recording because they are easy to repeat:

- **`NODE_GI_NATIVE=build` changes the policy.** It makes `addonProvenance()` report `source`, which vetoes the bundle (#920's protection), so `gtkSource()` flips to `system` and `activateBundledGtkRuntime()` returns early. A measurement that sets it is measuring a different configuration.
- **The CLI cannot host this fix.** Resolving the bundle in `runRuntimeBundle` needs node-gi's `gtkSource()`/`resolveGtkRuntimeBundle()`, and importing them from a **gjs-hosted CLI** fails — `gtk-runtime.js` imports `node:` builtins only the bundler aliases. I wrote it, measured that it silently repaired nothing, and reverted it (#1131's ledger entry).

## Scope kept honest

The env paths elsewhere stay exactly as they are: a dylib pulled in by **another dylib's** own link closure never passes through GI, so `maybeReexecForGtkRuntime()` (Node) and the launcher preamble (every runtime) remain the belt for that class. `status/open-todos.md` now records that boundary, plus the untested Apple-silicon half, in place of the closed entry.

## Checks

`node-gi` suite **536 tests, 0 failures** on linux with the addon rebuilt · the addon compiles on both linux and darwin · new spec pins the decision, the prepend order, idempotence and the older-addon no-op · `format --check`, `lint` clean · comment budget within ceiling (`packages/node-gi` +0.001 after two trims).
