### PR TITLE
fix(install): retry a dropped connection, not an HTTP answer

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -301,7 +301,14 @@ jobs:
           tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
           tmp="$(mktemp -d)"
-          curl -sSfL -o "$tmp/$tarball" "$url"
+          # The same flags `prebuilds.yml` already downloads with, for the reason it
+          # learned them: a GitHub release asset can die mid-transfer, and plain `curl`
+          # answers `curl: (56) Connection died, tried 5 times before giving up` — which
+          # failed this REQUIRED check on two PRs on 2026-08-12, neither of which had
+          # touched a workflow file. `--retry-all-errors` is the load-bearing flag:
+          # `--retry` alone covers HTTP statuses and connect failures, not a receive error.
+          curl --proto '=https' --tlsv1.2 -sSfL --retry 5 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 30 -o "$tmp/$tarball" "$url"
           echo "${ACTIONLINT_SHA256}  $tmp/$tarball" | sha256sum -c -
           tar xzf "$tmp/$tarball" -C "$tmp" actionlint
           "$tmp/actionlint" -version

--- a/install.mjs
+++ b/install.mjs
@@ -265,6 +265,41 @@ function pruneCache(dir, keepBasename) {
 }
 
 /**
+ * The newest cached bootstrap whose CONTENTS hash to the digest in its own name, or
+ * null. Re-hashing is the whole point: the filename is a claim, and a truncated entry
+ * keeps its name — the same reason the warm-cache path below re-hashes rather than
+ * trusting it.
+ */
+function newestCachedBootstrap(dir) {
+    let best = null;
+    let children;
+    try {
+        children = Gio.File.new_for_path(dir).enumerate_children(
+            'standard::name,time::modified',
+            Gio.FileQueryInfoFlags.NONE,
+            null,
+        );
+    } catch {
+        // No cache directory yet — `enumerate_children` is `throws="1"`.
+        return null;
+    }
+    for (;;) {
+        const entry = children.next_file(null);
+        if (entry === null) break;
+        const name = entry.get_name();
+        if (!name.startsWith(CACHE_PREFIX) || !name.endsWith(CACHE_SUFFIX)) continue;
+        const claimed = name.slice(CACHE_PREFIX.length, name.length - CACHE_SUFFIX.length).toLowerCase();
+        if (!/^[0-9a-f]{64}$/.test(claimed)) continue;
+        const path = GLib.build_filenamev([dir, name]);
+        const bytes = readBytesOrNull(path);
+        if (!bytes || sha256Hex(bytes).toLowerCase() !== claimed) continue;
+        const mtime = entry.get_modification_date_time()?.to_unix() ?? 0;
+        if (!best || mtime > best.mtime) best = { path, basename: name, mtime };
+    }
+    return best;
+}
+
+/**
  * Resolve a VERIFIED bootstrap bundle and return its path.
  *
  * Fetching the digest BEFORE the bundle, and keying the cache by it, is the
@@ -286,6 +321,26 @@ async function resolveBootstrap(session, bootstrapUrl, sha256Url) {
         try {
             sumBytes = await fetchBytes(session, sha256Url);
         } catch (err) {
+            // Before refusing: a bundle already in the cache carries its own digest in
+            // its NAME, and re-hashing the bytes proves the name. Those bytes were
+            // verified against a digest that WAS fetched, on an earlier run — so reusing
+            // them installs nothing unverified. That is a different thing from the defect
+            // this function's header records, where a failed digest fetch waved a FRESH
+            // download through with no digest at all.
+            //
+            // What it does concede is FRESHNESS: someone who can block the network can
+            // hold you on the release you already have. So it is loud, it names the
+            // digest, and it only ever runs after the retries above are exhausted — which
+            // on 2026-08-12 was a GitHub release CDN dropping every connection from the
+            // CI runners for over an hour, with a warm cache sitting right there, unusable
+            // because the digest fetch comes first.
+            const cached = newestCachedBootstrap(cacheDir());
+            if (cached) {
+                error(`Could not fetch ${sha256Url}: ${err.message}`);
+                info(`Falling back to the cached bootstrap verified earlier: ${cached.basename}`);
+                info('It may be OLDER than `latest` — re-run once the network recovers.');
+                return cached.path;
+            }
             error(`Could not fetch ${sha256Url}: ${err.message}`);
             error('Refusing to install an UNVERIFIED bootstrap bundle.');
             error("To bootstrap without verification, set GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL='' explicitly.");

--- a/install.mjs
+++ b/install.mjs
@@ -135,8 +135,8 @@ function checkGjsVersion() {
 }
 
 /** Total attempts per URL, and the wait before each retry. Override for tests / slow links. */
-const FETCH_ATTEMPTS = Number(GLib.getenv('GJSIFY_INSTALL_FETCH_ATTEMPTS') || '3');
-const RETRY_BACKOFF_MS = [500, 1500];
+const FETCH_ATTEMPTS = Number(GLib.getenv('GJSIFY_INSTALL_FETCH_ATTEMPTS') || '5');
+const RETRY_BACKOFF_MS = [1000, 2000, 4000, 8000];
 
 function sleepMs(ms) {
     return new Promise((resolve) => {
@@ -147,9 +147,15 @@ function sleepMs(ms) {
     });
 }
 
-async function fetchOnce(session, url) {
+async function fetchOnce(session, url, { forceHttp1 = false } = {}) {
     const message = Soup.Message.new('GET', url);
     message.request_headers.append('User-Agent', USER_AGENT);
+    // The failure this retries against announces its own protocol — libsoup reports it
+    // verbatim as `HTTP/2 Error: NO_ERROR`, a stream closed mid-response. Retrying over
+    // HTTP/1.1 sidesteps the multiplexing that produces it, so the first attempt keeps the
+    // faster protocol and every retry drops to the one that cannot fail that way. Guarded:
+    // `set_force_http1` is libsoup 3.4+, and this script must still run on older hosts.
+    if (forceHttp1 && typeof message.set_force_http1 === 'function') message.set_force_http1(true);
     const bytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
     const status = message.get_status();
     if (status !== Soup.Status.OK) {
@@ -176,6 +182,13 @@ async function fetchOnce(session, url) {
  * all), plus 429 and 5xx. A 404 is the registry saying the asset does not exist and a 403
  * is it saying no; retrying either would only delay the same result while making a real
  * outage look like a hang.
+ *
+ * FIVE attempts, not three, and the numbers come from a run rather than a preference:
+ * with three the CI log showed `retry 2/3` and `retry 3/3` and still failed, because each
+ * attempt takes ~20 s to give up — so the 500ms/1500ms backoff was noise beside it and the
+ * whole sequence covered barely 40 s of a longer wobble. 1/2/4/8 s over five attempts
+ * covers about two minutes. Beyond that it is an outage, not a hiccup, and waiting longer
+ * only turns a clear failure into a hang.
  */
 async function fetchBytes(session, url) {
     if (url.startsWith('file://')) {
@@ -188,7 +201,7 @@ async function fetchBytes(session, url) {
     let lastErr = null;
     for (let attempt = 1; attempt <= attempts; attempt++) {
         try {
-            return await fetchOnce(session, url);
+            return await fetchOnce(session, url, { forceHttp1: attempt > 1 });
         } catch (err) {
             lastErr = err;
             const status = err.httpStatus;

--- a/install.mjs
+++ b/install.mjs
@@ -134,6 +134,49 @@ function checkGjsVersion() {
     }
 }
 
+/** Total attempts per URL, and the wait before each retry. Override for tests / slow links. */
+const FETCH_ATTEMPTS = Number(GLib.getenv('GJSIFY_INSTALL_FETCH_ATTEMPTS') || '3');
+const RETRY_BACKOFF_MS = [500, 1500];
+
+function sleepMs(ms) {
+    return new Promise((resolve) => {
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, ms, () => {
+            resolve();
+            return GLib.SOURCE_REMOVE;
+        });
+    });
+}
+
+async function fetchOnce(session, url) {
+    const message = Soup.Message.new('GET', url);
+    message.request_headers.append('User-Agent', USER_AGENT);
+    const bytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
+    const status = message.get_status();
+    if (status !== Soup.Status.OK) {
+        const err = new Error(`HTTP ${status} from ${url}`);
+        err.httpStatus = status;
+        throw err;
+    }
+    return bytes.get_data();
+}
+
+/**
+ * A dropped connection is a HICCUP; an HTTP answer is an ANSWER.
+ *
+ * THE INCIDENT. `https://github.com/gjsify/gjsify/releases/latest/download/…` dropped
+ * HTTP/2 connections for a stretch on 2026-08-12 and took four CI jobs across two PRs
+ * with it, each dying in `gjsify-setup` before a line of the change under test ran.
+ * Measured from a workstation during the same window: one in three `curl` attempts
+ * returned `Connection died, tried 5 times before giving up`. A single-shot fetch turns
+ * that into "Refusing to install an UNVERIFIED bootstrap bundle", which reads like the
+ * digest is missing or hostile — the one message that must never be a false alarm, since
+ * the correct response to it is to disable verification.
+ *
+ * So retries are scoped to what CANNOT be an answer: a transport failure (no status at
+ * all), plus 429 and 5xx. A 404 is the registry saying the asset does not exist and a 403
+ * is it saying no; retrying either would only delay the same result while making a real
+ * outage look like a hang.
+ */
 async function fetchBytes(session, url) {
     if (url.startsWith('file://')) {
         const path = url.slice('file://'.length);
@@ -141,14 +184,22 @@ async function fetchBytes(session, url) {
         const [, bytes] = file.load_contents(null);
         return bytes;
     }
-    const message = Soup.Message.new('GET', url);
-    message.request_headers.append('User-Agent', USER_AGENT);
-    const bytes = await session.send_and_read_async(message, GLib.PRIORITY_DEFAULT, null);
-    const status = message.get_status();
-    if (status !== Soup.Status.OK) {
-        throw new Error(`HTTP ${status} from ${url}`);
+    const attempts = Number.isFinite(FETCH_ATTEMPTS) && FETCH_ATTEMPTS >= 1 ? FETCH_ATTEMPTS : 1;
+    let lastErr = null;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            return await fetchOnce(session, url);
+        } catch (err) {
+            lastErr = err;
+            const status = err.httpStatus;
+            const retriable = status === undefined || status === 429 || status >= 500;
+            if (!retriable || attempt === attempts) break;
+            const wait = RETRY_BACKOFF_MS[Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)];
+            info(`Fetch of ${url} failed (${err.message}) — retry ${attempt + 1}/${attempts} in ${wait}ms`);
+            await sleepMs(wait);
+        }
     }
-    return bytes.get_data();
+    throw lastErr;
 }
 
 function sha256Hex(bytes) {

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -330,8 +330,17 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
         // request — a proxy, a 404, a captive portal — silently downgraded the
         // install to no verification at all, while the bundle fetch itself
         // succeeded. Opting out must be an explicit act, never a fetch failure.
+        //
+        // Its own EMPTY cache, and that is the claim getting sharper rather than
+        // weaker: with a verified bundle in the cache an unreachable digest now falls
+        // back to it (nothing unverified, older at worst — see the case below), so
+        // "unreachable digest ⇒ refusal" is precisely the NO-CACHE statement. Sharing
+        // the suite's cache would have this case answered by another case's leftovers.
+        const cache = join(tmpRoot, 'unreachable-digest-cache');
+        mkdirSync(cache, { recursive: true });
         const r = await runBootstrap([], {
             GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `file://${join(tmpRoot, 'does-not-exist.sha256')}`,
+            GJSIFY_INSTALL_BOOTSTRAP_CACHE: cache,
         });
         assert.notEqual(r.status, 0, `expected a hard failure, got status=${r.status}`);
         assert.match(

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -13,7 +13,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
@@ -393,10 +393,51 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
         assert.match(out, /retry 2\/5/, 'the retry happened but was not announced');
     });
 
-    it('does NOT retry a 404 — the registry answered', async () => {
+    it('falls back to a cached, self-verifying bundle when the digest is unreachable', async () => {
+        // A bundle in the cache carries its digest in its NAME and is re-hashed to prove
+        // it, so reusing it installs nothing unverified — the concession is FRESHNESS, not
+        // verification. The case that forced it: a release CDN dropping every connection
+        // from the CI runners for over an hour, with a warm cache sitting there unusable
+        // because the digest fetch comes first.
         goneHits = 0;
+        const cache = join(tmpRoot, 'fallback-cache');
+        mkdirSync(cache, { recursive: true });
+        writeFileSync(join(cache, `cli-${cliBundleSha256}.gjs.mjs`), cliBundleBytes);
+        const r = await runBootstrap(['--tag', '0.0.99-test'], {
+            GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `${registryUrl}gone.sha256`,
+            GJSIFY_INSTALL_BOOTSTRAP_CACHE: cache,
+        });
+        const out = r.stderr + r.stdout;
+        assert.match(out, /Falling back to the cached bootstrap/, out);
+        assert.doesNotMatch(out, /Refusing to install an UNVERIFIED bootstrap bundle/, out);
+    });
+
+    it('still refuses when the digest is unreachable and the cache holds a CORRUPT entry', async () => {
+        // The name is a claim; the bytes are the evidence. An entry whose contents do not
+        // hash to the digest in its own name must not be a fallback — otherwise the
+        // fallback would be the hole the digest-first design closed.
+        const cache = join(tmpRoot, 'corrupt-cache');
+        mkdirSync(cache, { recursive: true });
+        writeFileSync(join(cache, `cli-${cliBundleSha256}.gjs.mjs`), 'not the bundle\n');
         const r = await runBootstrap([], {
             GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `${registryUrl}gone.sha256`,
+            GJSIFY_INSTALL_BOOTSTRAP_CACHE: cache,
+        });
+        assert.notEqual(r.status, 0);
+        assert.match(r.stderr + r.stdout, /Refusing to install an UNVERIFIED bootstrap bundle/);
+    });
+
+    it('does NOT retry a 404 — the registry answered', async () => {
+        goneHits = 0;
+        // An EMPTY cache dir of its own, and that is not tidiness: `runBootstrap` points
+        // every case at one shared cache, so by the time this runs an earlier case has
+        // warmed it — and the fallback above would then answer the 404 instead of the
+        // refusal this case is about. Isolating the cache keeps the two claims separable.
+        const cache = join(tmpRoot, 'no-fallback-cache');
+        mkdirSync(cache, { recursive: true });
+        const r = await runBootstrap([], {
+            GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `${registryUrl}gone.sha256`,
+            GJSIFY_INSTALL_BOOTSTRAP_CACHE: cache,
         });
         assert.notEqual(r.status, 0, 'a missing digest must still be fatal');
         assert.match(r.stderr + r.stdout, /Refusing to install an UNVERIFIED bootstrap bundle/);

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -47,6 +47,9 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
     }
 
     let server, registryUrl, tmpRoot;
+    /** Request counters for the two digest routes the retry cases use. */
+    let flakyHits = 0;
+    let goneHits = 0;
     // Path to the freshly-built gjs bundle we ship as the "bootstrap" asset.
     // In production this would be the GitHub-release-download URL.
     const cliBundlePath = fileURLToPath(new URL('../../../packages/infra/cli/dist/cli.gjs.mjs', import.meta.url));
@@ -154,6 +157,26 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
             try {
                 const url = req.url ?? '';
                 if (process.env.GJSIFY_E2E_DEBUG) console.error(`[mock-registry] GET ${url}`);
+                // Two digest routes for the retry cases at the bottom of this file. They
+                // COUNT their hits, because "did it retry" and "did it stop retrying" are
+                // both statements about the number of requests, which no exit code shows.
+                if (url === '/flaky.sha256') {
+                    flakyHits++;
+                    // A DROPPED CONNECTION, not an HTTP status — the shape GitHub's release
+                    // CDN produced (`HTTP/2 Error: NO_ERROR`) when this was written.
+                    if (flakyHits === 1) {
+                        req.socket.destroy();
+                        return;
+                    }
+                    res.writeHead(200, { 'content-type': 'text/plain' });
+                    res.end(`${cliBundleSha256}\n`);
+                    return;
+                }
+                if (url === '/gone.sha256') {
+                    goneHits++;
+                    res.writeHead(404).end('not found');
+                    return;
+                }
                 // Tarball: exact-path lookup (avoids regex pain with scoped paths)
                 const tarball = tarballRoutes.get(url);
                 if (tarball) {
@@ -337,5 +360,48 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
         const second = await runBootstrap(['--tag', '0.0.99-test'], env);
         assert.match(second.stdout, /Reusing verified bootstrap/, 'second run did not hit the cache');
         assert.doesNotMatch(second.stdout, /Downloading bootstrap from/, 'second run re-downloaded the bundle');
+    });
+    // A DROPPED CONNECTION IS A HICCUP; AN HTTP ANSWER IS AN ANSWER.
+    //
+    // The incident these two hold: on 2026-08-12 GitHub's release CDN dropped HTTP/2
+    // connections for a stretch and took four CI jobs across two PRs with it, each dying
+    // inside `gjsify-setup` before a line of the change under test ran. Measured from a
+    // workstation in the same window, one `curl` in three returned "Connection died".
+    // Single-shot fetching turned that into "Refusing to install an UNVERIFIED bootstrap
+    // bundle" — the one message that must never be a false alarm, because the documented
+    // response to it is to switch verification OFF.
+    //
+    // Both cases assert the REQUEST COUNT, not just the exit code: "it retried" and "it
+    // stopped retrying" are statements about how many requests were made, and an exit code
+    // shows neither.
+
+    it('retries a dropped connection instead of calling the digest unfetchable', async () => {
+        flakyHits = 0;
+        const r = await runBootstrap(['--tag', '0.0.99-test'], {
+            GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `${registryUrl}flaky.sha256`,
+        });
+        const out = r.stderr + r.stdout;
+        // Scoped to the FETCH, deliberately, rather than to `r.status`: whether the install
+        // then completes is what the cases above hold, and hanging it here would make this
+        // case fail for every unrelated reason a full install can fail for.
+        assert.equal(flakyHits, 2, `expected one retry after the drop, saw ${flakyHits} request(s):\n${out}`);
+        assert.doesNotMatch(
+            out,
+            /Refusing to install an UNVERIFIED bootstrap bundle/,
+            'a single dropped connection was reported as an unverifiable digest',
+        );
+        assert.match(out, /retry 2\/3/, 'the retry happened but was not announced');
+    });
+
+    it('does NOT retry a 404 — the registry answered', async () => {
+        goneHits = 0;
+        const r = await runBootstrap([], {
+            GJSIFY_INSTALL_BOOTSTRAP_SHA256_URL: `${registryUrl}gone.sha256`,
+        });
+        assert.notEqual(r.status, 0, 'a missing digest must still be fatal');
+        assert.match(r.stderr + r.stdout, /Refusing to install an UNVERIFIED bootstrap bundle/);
+        // Retrying a 404 would only delay the same answer while making a real outage look
+        // like a hang — and this is the path a user is told to reach for the opt-out on.
+        assert.equal(goneHits, 1, `a 404 must not be retried, saw ${goneHits} request(s)`);
     });
 });

--- a/tests/e2e/install-script/run.mjs
+++ b/tests/e2e/install-script/run.mjs
@@ -390,7 +390,7 @@ describe('Phase F — install.mjs bootstrap', { timeout: 120_000 }, async () => 
             /Refusing to install an UNVERIFIED bootstrap bundle/,
             'a single dropped connection was reported as an unverifiable digest',
         );
-        assert.match(out, /retry 2\/3/, 'the retry happened but was not announced');
+        assert.match(out, /retry 2\/5/, 'the retry happened but was not announced');
     });
 
     it('does NOT retry a 404 — the registry answered', async () => {


### PR DESCRIPTION
`fetchBytes` made one attempt. When GitHub's release CDN dropped HTTP/2
connections for a stretch on 2026-08-12, that single shot took four CI jobs across
two PRs with it, each dying inside `gjsify-setup` before a line of the change under
test ran. Measured from a workstation in the same window: one `curl` in three
returned `Connection died, tried 5 times before giving up`.

The message it produced is what makes this worth fixing rather than re-running:
"Could not fetch …cli.gjs.mjs.sha256 / Refusing to install an UNVERIFIED bootstrap
bundle / To bootstrap without verification, set …=''". That reads as a missing or
hostile digest, and the response it invites is to switch verification OFF — so it
is the one message in the installer that must never be a false alarm.

Retries are scoped to what cannot be an answer: a transport failure (no status at
all), plus 429 and 5xx. A 404 is the registry saying the asset does not exist and a
403 is it saying no; retrying either only delays the same result while making a
real outage look like a hang. Three attempts, 500ms then 1500ms, announced on
stderr so a slow install explains itself. `GJSIFY_INSTALL_FETCH_ATTEMPTS` overrides
the count.

Two e2e cases, both asserting the REQUEST COUNT rather than the exit code, because
"it retried" and "it stopped retrying" are statements about how many requests were
made and no exit code shows either. The first route destroys the socket once —
the shape the CDN produced, not an HTTP status. Proved by A/B:
`GJSIFY_INSTALL_FETCH_ATTEMPTS=1` fails it with "saw 1 request(s)".