### PR TITLE
fix(runtime): keep the specs out of the type build, they close a cycle

### DIFF
--- a/packages/gjs/runtime/package.json
+++ b/packages/gjs/runtime/package.json
@@ -27,7 +27,7 @@
         "check": "gjsify tsc --noEmit",
         "build": "gjsify run build:gjsify && gjsify run build:types",
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
-        "build:types": "gjsify tsc",
+        "build:types": "gjsify tsc -p tsconfig.build.json",
         "build:test": "gjsify run build:test:gjs && gjsify run build:test:node",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs",
         "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",

--- a/packages/gjs/runtime/tsconfig.build.json
+++ b/packages/gjs/runtime/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        // Declarations only, for the same reason `@gjsify/semver` gives: `build:gjsify`
+        // and `build:types` both target `lib/esm`, so whichever ran last won the JS.
+        "emitDeclarationOnly": true
+    },
+    // THE SPECS CANNOT BE IN THE TYPE BUILD, and that is a cycle rather than a
+    // preference. `@gjsify/unit`'s `src/index.ts` imports `@gjsify/runtime`, so unit
+    // cannot be type-built before runtime; runtime's SPECS import `@gjsify/unit`, so a
+    // type build that includes them cannot run before unit. `build:infra` builds both on
+    // a cold tree where nothing else has run — measured by the release dry-run, which is
+    // the only leg that bootstraps cold: `src/detect.spec.ts:8:38 - error TS2307: Cannot
+    // find module '@gjsify/unit'`. Excluding the specs cuts the edge that does not carry
+    // API: `check` (`gjsify tsc --noEmit`) still type-checks them, after the build.
+    "exclude": ["src/test.mts", "src/**/*.spec.ts", "src/**/*.spec.mts"]
+}


### PR DESCRIPTION
The release dry-run failed where nothing else could see it:

    src/detect.spec.ts:8:38 - error TS2307: Cannot find module '@gjsify/unit'
    src/index.spec.ts:9:38 - error TS2307: Cannot find module '@gjsify/unit'

and it is the other half of #1134. `@gjsify/unit`'s `src/index.ts` imports
`@gjsify/runtime`, so unit cannot be type-built before runtime; runtime's SPECS
import `@gjsify/unit`, so a type build that includes them cannot run before unit.
On a cold tree `build:infra` builds both and nothing else has run — a cycle, not an
ordering mistake, and moving the entry a second time could not have fixed it.

Cut the edge that carries no API, exactly as `@gjsify/semver`, `npm-registry`, `tar`
and `workspace` already do: a `tsconfig.build.json` that excludes specs, and
`build:types` pointed at it. Verified by A/B rather than by reading — a deliberate
type error in `detect.spec.ts` still fails `check` (`Found 1 error in
src/detect.spec.ts`, exit 1), so the specs lost their EMIT, not their type check.

Worth naming: only the release cut bootstraps a genuinely cold tree, which is why
this survived four merged PRs. `status/open-todos.md` predicted that shape ("the
warm leg cannot see the cold path") one PR before it happened.