### PR TITLE
fix(cli): read the CLI's own version from one resolver

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -121,6 +121,17 @@ jobs:
       - name: Check the PR-title type list still matches commitlint
         run: node scripts/check-pr-title-types.mjs
 
+      # Same shape as the two above: a rule that only prose enforced, broken by a
+      # copy that grew next to the resolver whose comment forbids it. `@gjsify/cli`
+      # is dual-entry, so a fixed-depth read of its own manifest is right from
+      # `lib/` and wrong from `dist/cli.gjs.mjs` — the entry a globally installed
+      # `gjsify` runs. It fails silently (the read is inside a `try`), and the
+      # version it fails to produce is what `showcase` pins its dlx spec to, so
+      # 0.38.0 served a cached 0.37.0 showcase that crashed on a bug 0.38.0 had
+      # fixed. Invisible to every CI leg, all of which use the `lib/` entry.
+      - name: Check the CLI reads its own version through one resolver
+        run: node scripts/check-cli-own-version-read.mjs
+
       # Comment volume has no natural limit, so nothing failed while `cli-fail.ts` grew
       # a 47-line yargs research diary above a 3-line function (ratio 9.3), while
       # `rolldown-plugin-gjsify` reached one comment line per code line, or while

--- a/docs/code-anti-patterns.md
+++ b/docs/code-anti-patterns.md
@@ -123,3 +123,39 @@ for the raw call. A guard watching another mechanism is the smell the governance
 rules name, and the cost of this one would be a grep over the tree that cannot
 tell a display string (where the host separator is arguably right) from a value
 about to be split.
+
+## A dual-entry package reading its own manifest at a fixed depth
+
+**Rule: `@gjsify/cli` learns its own version from `cliVersion()`
+(`utils/publish-headers.ts`) and nowhere else. A
+`new URL('../../package.json', import.meta.url)` read is wrong by construction
+in this package — machine-checked by
+[`scripts/check-cli-own-version-read.mjs`](../scripts/check-cli-own-version-read.mjs).**
+
+The CLI ships TWO entries from one package: `npm install` runs the tsc output
+under `lib/`, a globally installed `gjsify` runs the bundle at
+`dist/cli.gjs.mjs`. A relative manifest read is depth-dependent, so one spelling
+cannot be right for both — `../../package.json` resolves correctly from
+`lib/commands/` and lands one directory ABOVE the package from `dist/`, where no
+manifest exists.
+
+It fails silently. The read sits in a `try`, so the miss is not an error; it is
+the answer "no version".
+
+Measured 2026-08-13, against published 0.38.0. `showcase` PINS the showcase
+package to the CLI's own version, and a version it cannot read leaves the spec as
+a bare package name — at which point `dlx` serves whatever it cached for that
+name once. `gjsify showcase adwaita-storybook`, the first tab of the project's
+own home page, ran a cached **0.37.0** bundle and died with
+`ImportError: Unsupported URI scheme for importing: node`: that release's
+`dist/gjs.js` was byte-identical to its `gjs.node.mjs`. 0.38.0 had already fixed
+it. The banner told the whole story and nobody was reading it — `npx`/`bunx`
+printed `[gjsify 0.38.0]`, the gjs entry printed no version at all.
+
+**Why no CI leg saw it:** every runtime the test matrix exercises invokes the
+`lib/` entry, where the fixed depth happens to be correct. The broken entry is
+the one a user installs.
+
+The resolver's own doc comment already said "deliberately NOT a fixed
+`../../package.json` read", and a fourth copy grew beside it regardless. Prose
+does not fail a PR; the check does.

--- a/packages/infra/cli/src/commands/showcase.ts
+++ b/packages/infra/cli/src/commands/showcase.ts
@@ -8,6 +8,7 @@ import { ensurePkgDir } from './dlx.js';
 import { fetchPackument, type Packument } from '@gjsify/npm-registry';
 import { loadNpmrc } from '../utils/load-npmrc.js';
 import { parseSpec } from '../utils/parse-spec.js';
+import { cliVersion } from '../utils/publish-headers.js';
 import { resolveNodeEntry } from '../utils/resolve-gjs-entry.js';
 import { runRuntimeBundle } from '../utils/run-node.js';
 import {
@@ -20,14 +21,15 @@ import {
     type ExampleRuntime,
 } from '../utils/runtimes.js';
 
+/**
+ * This CLI's own version, or `undefined` when it genuinely cannot be told.
+ *
+ * The shared resolver, never a local fixed-depth manifest read — that misses from
+ * `dist/`, unpinning `dlxSpec`. Incident: `docs/code-anti-patterns.md`.
+ */
 function readCliVersion(): string | undefined {
-    try {
-        const pkgUrl = new URL('../../package.json', import.meta.url);
-        const pkg = JSON.parse(readFileSync(pkgUrl, 'utf8')) as { version?: unknown };
-        return typeof pkg.version === 'string' ? pkg.version : undefined;
-    } catch {
-        return undefined;
-    }
+    const version = cliVersion();
+    return version === 'unknown' ? undefined : version;
 }
 
 /**

--- a/packages/infra/cli/src/utils/publish-headers.spec.ts
+++ b/packages/infra/cli/src/utils/publish-headers.spec.ts
@@ -12,7 +12,7 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 import type { NpmrcConfig } from '@gjsify/npm-registry';
-import { buildPublishHeaders, escapePackageName } from './publish-headers.js';
+import { buildPublishHeaders, cliVersion, escapePackageName } from './publish-headers.js';
 
 function npmrcWithToken(token: string): NpmrcConfig {
     return {
@@ -138,6 +138,15 @@ export default async () => {
 
             const h = buildPublishHeaders(URL, { npmrc: npmrcWithToken('tok') });
             expect(h['user-agent']?.startsWith(`gjsify-publish/${declared} `)).toBe(true);
+        });
+
+        await it('answers a real version from a dist-shaped bundle, for callers that PIN to it', async () => {
+            // Meaningful because THIS SPEC RUNS AS A BUNDLE IN `dist/`: the layout
+            // where the fixed-depth read `showcase.ts` used to carry answers nothing,
+            // unpinning its dlx spec (`docs/code-anti-patterns.md`).
+            const version = cliVersion();
+            expect(version).not.toBe('unknown');
+            expect(/^\d+\.\d+\.\d+/.test(version)).toBe(true);
         });
 
         await it('honours an explicit userAgent override', async () => {

--- a/packages/infra/cli/src/utils/publish-headers.ts
+++ b/packages/infra/cli/src/utils/publish-headers.ts
@@ -115,9 +115,14 @@ export function buildPublishHeaders(url: string, opts: PublishHeaderOptions): Re
  *    `lib/`, `dist/` and an installed `node_modules/@gjsify/cli/**` alike.
  *
  * `GJSIFY_CLI_PACKAGE_JSON` overrides both, matching `self-update.ts`.
+ *
+ * Exported because `showcase` needs the SAME answer rather than a fourth
+ * resolver: it PINS the showcase package to this version, so a version it cannot
+ * read is a showcase left unpinned and `dlx` serves a stale cached one
+ * (`docs/code-anti-patterns.md`). Returns `'unknown'`, never `undefined`.
  */
 let cachedCliVersion: string | undefined;
-function cliVersion(): string {
+export function cliVersion(): string {
     if (cachedCliVersion !== undefined) return cachedCliVersion;
     cachedCliVersion =
         (typeof __PACKAGE_VERSION__ === 'string' ? __PACKAGE_VERSION__ : '') || walkForCliVersion() || 'unknown';

--- a/scripts/check-cli-own-version-read.mjs
+++ b/scripts/check-cli-own-version-read.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// The CLI must read its OWN version through one resolver, never at a fixed depth.
+//
+// WHAT THIS PROTECTS
+//
+// `@gjsify/cli` is a DUAL-ENTRY package: `npm install` runs the tsc output under
+// `lib/`, while a globally installed `gjsify` runs the bundle at
+// `dist/cli.gjs.mjs`. A relative manifest read is therefore depth-dependent —
+// `new URL('../../package.json', import.meta.url)` resolves correctly from
+// `lib/commands/` and lands one directory ABOVE the package from `dist/`, where
+// there is no manifest at all. The read is inside a `try`, so it does not throw;
+// it quietly answers "no version".
+//
+// That is not cosmetic, because the version is load-bearing. `showcase` PINS the
+// showcase package to the CLI's own version; unpinned, the spec degrades to the
+// bare package name and `dlx` serves whatever it cached for that name once.
+// Measured on 2026-08-13 with 0.38.0 installed: `gjsify showcase
+// adwaita-storybook` — the first tab of the project's own home page — ran a
+// cached 0.37.0 bundle and died on `ImportError: Unsupported URI scheme for
+// importing: node`, a defect 0.38.0 had already fixed. The same commit under
+// `npx`/`bunx` printed `[gjsify 0.38.0]` and worked, which is precisely why no
+// CI leg saw it: every runtime CI exercises uses the `lib/` entry, and the one
+// entry that is broken is the one a user installs.
+//
+// `cliVersion()` in `utils/publish-headers.ts` is the resolver: a compile-time
+// define for the bundle, an upward manifest walk for `lib/`. It is depth-
+// independent, so it cannot acquire this bug. Its own doc comment already said
+// "deliberately NOT a fixed `../../package.json` read" — and a fourth copy grew
+// beside it anyway. Prose does not fail a PR.
+//
+// FAILURE POLICY: hard. This reads first-party source that is always present;
+// if the scan finds nothing to scan, that is itself an error, because a check
+// that cannot find what it checks has stopped checking.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CLI_SRC = join(REPO_ROOT, 'packages/infra/cli/src');
+const RESOLVER = 'utils/publish-headers.ts';
+
+// `new URL(<anything ending in package.json>, import.meta.url)` — the shape that
+// hard-codes a directory distance to the package root. Matched irrespective of
+// how many `../` it walks, since the count is the part that is wrong.
+const FIXED_DEPTH_READ = /new URL\(\s*(['"`])[^'"`]*package\.json\1\s*,\s*import\.meta\.url\s*\)/;
+
+function walk(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) out.push(...walk(full));
+        else if (entry.endsWith('.ts') && !entry.endsWith('.spec.ts')) out.push(full);
+    }
+    return out;
+}
+
+let files;
+try {
+    files = walk(CLI_SRC);
+} catch (err) {
+    console.error(`check-cli-own-version-read: cannot scan ${CLI_SRC}: ${err.message}`);
+    process.exit(1);
+}
+
+if (files.length === 0) {
+    console.error(`check-cli-own-version-read: no sources under ${CLI_SRC} — the scan found nothing to check.`);
+    process.exit(1);
+}
+
+// Blank out comment bodies while preserving line numbering: the rule this check
+// enforces is precisely the kind a comment needs to QUOTE in order to explain
+// itself, and a guard that fires on its own rationale trains people to delete
+// the rationale.
+function stripComments(text) {
+    return text
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+        .replace(/(^|[^:])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+}
+
+const offenders = [];
+for (const file of files) {
+    const rel = relative(CLI_SRC, file);
+    if (rel === RESOLVER) continue; // the resolver is the one allowed to know about layouts
+    const text = stripComments(readFileSync(file, 'utf8'));
+    text.split('\n').forEach((line, i) => {
+        if (FIXED_DEPTH_READ.test(line)) {
+            offenders.push(`packages/infra/cli/src/${rel}:${i + 1}: ${line.trim()}`);
+        }
+    });
+}
+
+if (offenders.length > 0) {
+    console.error('check-cli-own-version-read: fixed-depth manifest read(s) in @gjsify/cli source:\n');
+    for (const o of offenders) console.error(`  ${o}`);
+    console.error(
+        '\nThis resolves from `lib/` and misses from `dist/cli.gjs.mjs`, so a globally\n' +
+            'installed gjsify reads no version — and `showcase` then leaves its dlx spec\n' +
+            'unpinned, serving a cached older showcase.\n\n' +
+            'Use the shared resolver instead:\n' +
+            "  import { cliVersion } from '../utils/publish-headers.js';\n",
+    );
+    process.exit(1);
+}
+
+console.log(`check-cli-own-version-read: OK — ${files.length} CLI sources, no fixed-depth manifest reads.`);


### PR DESCRIPTION
## What broke

`gjsify showcase adwaita-storybook` — the first tab of the project's own home
page — fails against **published 0.38.0** on a machine that has run gjsify before:

```
$ gjsify --version
0.38.0
$ gjsify showcase adwaita-storybook
Gjs-WARNING: JS ERROR: ImportError: Unsupported URI scheme for importing: node
gjs exited with code 1
```

It ran a cached **0.37.0** bundle, whose `dist/gjs.js` was byte-identical to its
`dist/gjs.node.mjs` (`md5 492063d6…` for both) and therefore carried
`node:module`. 0.38.0 had already fixed that — its two bundles differ and the gjs
one has no `node:` specifier.

## Why it ran the wrong version

`showcase` PINS the showcase package to the CLI's own version, and read that
version with a fixed-depth manifest read:

```ts
const pkgUrl = new URL('../../package.json', import.meta.url);
```

`@gjsify/cli` is dual-entry. From `lib/commands/` that depth is right; from
`dist/cli.gjs.mjs` — the entry a **globally installed `gjsify` runs** — it lands
one directory above the package, where no manifest exists. The read is inside a
`try`, so it does not throw. It answers "no version", `dlxSpec` degrades to the
bare package name, and `dlx` serves whatever it resolved for that name once.

The banner said so the whole time, on the same commit and the same machine:

| tab | banner |
|---|---|
| `npx @gjsify/cli@latest` | `Running showcase: … [gjsify 0.38.0] on node` |
| `bunx @gjsify/cli@latest` | `Running showcase: … [gjsify 0.38.0] on bun` |
| **`gjsify`** | `Running showcase: … (via gjsify dlx @gjsify/example-…)` — **no version** |

Clearing the dlx cache makes 0.38.0 resolve and the showcase render, which is
what confirms it is resolution and not a bad release.

## Why no CI leg caught it

Every runtime the test matrix exercises invokes the `lib/` entry, where the fixed
depth happens to be correct. The one entry that is broken is the one a user
installs.

## The fix

`cliVersion()` in `utils/publish-headers.ts` is already the depth-independent
resolver — a compile-time define for the bundle, an upward manifest walk for
`lib/` — and its own doc comment already said *"deliberately NOT a fixed
`../../package.json` read"*. A fourth copy grew next to it anyway. It is now
exported and used.

## Mechanism, because prose did not hold the line

- **`scripts/check-cli-own-version-read.mjs`** fails any first-party CLI source
  that re-introduces the fixed-depth read, wired into `audit-runtimes.yml`
  beside the other one-rule-one-spelling guards. Verified both ways: green on
  this branch, red on the parent commit, pointing at `showcase.ts:25`.
- **`publish-headers.spec`** asserts a real version — this spec runs as a bundle
  in `dist/`, the exact layout where the old spelling silently answered nothing.
- **`docs/code-anti-patterns.md`** carries the incident, so the rule keeps its
  reason.

## Verification

Measured against published packages on Linux x64, all 6 homepage showcases ×
their declared runtimes plus `create my-app` on all four tabs: green, including
`adwaita-storybook` on gjs once the stale cache is gone (window verified via
`GJSIFY_DEVTOOLS` screenshot, not just exit code).

Not a defect, recorded so it is not re-diagnosed: `deno run -A
npm:@gjsify/cli@latest` resolves the previous release for the first 24 h after a
publish — deno's `--min-dep-age` default, visible as `[gjsify 0.37.0]` on the
deno tab. `--reload --min-dep-age 0` gets 0.38.0, which is what
`showcase`'s own pinned-invocation hint already tells users.
