### PR TITLE
fix(install): make the macOS bootstrap find libsoup

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -20,8 +20,69 @@
 
 import GLib from 'gi://GLib';
 import Gio from 'gi://Gio';
-import Soup from 'gi://Soup?version=3.0';
 import system, { exit } from 'system';
+
+/**
+ * Soup, loaded late and — on a macOS that cannot find it — through one re-exec.
+ *
+ * WHY THIS IS NOT A PLAIN IMPORT. GI resolves a typelib's shared library with a
+ * bare-leaf `dlopen("libsoup-3.0.0.dylib")`. Homebrew installs that dylib in
+ * `/usr/local/lib` (Intel) or `/opt/homebrew/lib` (arm64), and `gjs` carries an
+ * rpath only for glib's own directory, so on a stock Homebrew macOS dyld never
+ * looks where the library actually is. Measured 2026-08-13 on macOS 15.7.9:
+ *
+ *     $ curl -fsSL .../install.mjs -o /tmp/g.mjs && gjs -m /tmp/g.mjs
+ *     Failed to load shared library 'libsoup-3.0.0.dylib' referenced by the typelib
+ *     JS ERROR: Error: Unsupported type void, deriving from fundamental void
+ *
+ * That is the DOCUMENTED install path for a platform this project advertises,
+ * and it fails before the first byte is downloaded — the bootstrap's own fetcher
+ * is Soup. `DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib` fixes it, but nothing can
+ * export that on the user's behalf from inside this process: the variable is
+ * read by dyld at image load, long before any JS runs. Hence a re-exec.
+ *
+ * Repaired ONLY when the load actually fails, so a healthy host (arm64 Homebrew,
+ * a distro-packaged gjs, anything with a working rpath) re-execs never.
+ *
+ * Note the probe touches `Session` rather than just importing the namespace:
+ * `imports.gi.Soup` SUCCEEDS on a broken host — the library is resolved lazily,
+ * when a type is first needed. A namespace-only check reports a healthy
+ * environment and is the reason this looked like a network bug for so long.
+ */
+const DYLD_REEXEC_MARKER = 'GJSIFY_INSTALL_DYLD_REEXEC';
+
+/** dyld's documented default fallback list, plus both Homebrew prefixes. */
+function dyldFallbackDirs() {
+    const home = GLib.get_home_dir();
+    return [`${home}/lib`, '/usr/local/lib', '/opt/homebrew/lib', '/lib', '/usr/lib'].join(':');
+}
+
+async function loadSoup() {
+    const mod = await import('gi://Soup?version=3.0');
+    void mod.default.Session; // forces the dlopen; see above
+    return mod.default;
+}
+
+let Soup;
+try {
+    Soup = await loadSoup();
+} catch (error) {
+    const onMacos = GLib.file_test('/usr/lib/dyld', GLib.FileTest.EXISTS);
+    if (!onMacos || GLib.getenv(DYLD_REEXEC_MARKER)) throw error;
+
+    const self = GLib.filename_from_uri(import.meta.url)[0];
+    const gjs = GLib.find_program_in_path('gjs');
+    if (!gjs) throw error;
+
+    // SIP strips an INHERITED DYLD_* when a protected binary is exec'd, but a
+    // value this process sets itself survives into Homebrew's unprotected `gjs`.
+    const launcher = new Gio.SubprocessLauncher({ flags: Gio.SubprocessFlags.NONE });
+    launcher.setenv('DYLD_FALLBACK_LIBRARY_PATH', dyldFallbackDirs(), true);
+    launcher.setenv(DYLD_REEXEC_MARKER, '1', true);
+    const child = launcher.spawnv([gjs, '-m', self, ...(system?.programArgs ?? [])]);
+    child.wait(null);
+    exit(child.get_exit_status() === 0 ? 0 : 1);
+}
 
 Gio._promisify(Soup.Session.prototype, 'send_and_read_async');
 Gio._promisify(Gio.Subprocess.prototype, 'wait_check_async');


### PR DESCRIPTION
## What broke

The **documented** Node-free install is dead on a stock Homebrew macOS, and it
dies before the first byte is downloaded — the bootstrap's own fetcher is Soup.
Measured on macOS 15.7.9 (Intel, Homebrew `gjs` 1.88.1), against
`releases/latest`:

```
$ curl -fsSL .../install.mjs -o /tmp/g.mjs && gjs -m /tmp/g.mjs
GLib-GIRepository-WARNING: Failed to load shared library 'libsoup-3.0.0.dylib'
  referenced by the typelib: dlopen(libsoup-3.0.0.dylib, 0x0009): tried:
  'libsoup-3.0.0.dylib' (no such file),
  '/usr/local/Cellar/gjs/1.88.1/bin/../../../../opt/glib/lib/libsoup-3.0.0.dylib' (no such file),
  '/usr/lib/libsoup-3.0.0.dylib' (no such file, not in dyld cache)
Gjs-CRITICAL: JS ERROR: Error: Unsupported type void, deriving from fundamental void
```

The library is installed — `/usr/local/lib/libsoup-3.0.0.dylib` exists. GI
resolves a typelib's library with a **bare-leaf `dlopen`**, and `gjs` carries an
rpath only for glib's own directory, so dyld never looks in the Homebrew libdir.
The tried-paths list in the warning is the whole proof: glib's rpath and
`/usr/lib`, nothing else.

This is the first command on the Getting Started page, for a platform the home
page advertises in its own description.

## Why it cannot be fixed with an export

`DYLD_FALLBACK_LIBRARY_PATH` is read by dyld at **image load**, long before any
JS runs, so nothing inside this process can set it for itself. Hence: load Soup
late, and on failure re-exec **once** with dyld's documented default list plus
both Homebrew prefixes.

A healthy host never re-execs — the repair sits on the catch path, not the happy
path. So arm64 Homebrew, a distro-packaged `gjs`, and anything with a working
rpath are untouched.

## The probe touches a type on purpose

`imports.gi.Soup` **succeeds** on a broken host: GI resolves the shared library
lazily, when a type is first needed. So a namespace-only check reports a healthy
environment on the exact machine where the install is broken. That false green is
why this read as a network fault (`request to registry.npmjs.org failed`) for so
long — and it is why the probe touches `Soup.Session`.

## Verification

| | unpatched | patched |
|---|---|---|
| macOS 15.7.9, clean env | dies on the Soup import | re-execs, fetches + verifies the bundle, prints the cached path |
| Linux x64 | works | works (`--help`, `--fetch-only`) — no re-exec |

`packages/infra/cli/src/templates/install.mjs.tmpl` is a committed **symlink** to
this file, so `gjsify generate-installer` emits the fix for end-user apps with no
second edit.

`tests/e2e/install-script` fails 4 assertions **identically** with and without
this change on this checkout (a `0.0.99-test` fixture version it cannot resolve),
so the suite is unaffected — control run included.

## Found by

A full sweep of the home page's advertised commands on Linux · Windows · macOS
against published 0.38.0. Two further macOS/Windows defects came out of the same
run and are reported separately; they need a policy decision rather than a
one-line fix.
