### PR TITLE
perf(hooks): make an amend's rebuild a cache hit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -161,7 +161,27 @@ echo "[gjsify pre-commit] rebuilding it — bypass with 'git commit --no-verify'
 # Same shape as #1080 one level down: a build trusting an on-disk artefact without
 # checking it is current. There the answer was to widen the SELECTION rather than
 # add a probe, and it is the same answer here.
-$GJSIFY workspace @gjsify/cli build --with-dependencies || rebuild_failed "gjsify workspace @gjsify/cli build --with-dependencies"
+#
+# `--cached` (ADR 0006) is here for the RE-RUN, and deliberately not sold as the
+# answer to #1100. Measured on a 20-core workstation, warm tree:
+#
+#   no cache, twice in a row                          336.1 s / 335.6 s
+#   --cached, nothing changed since the last run        2.5 s
+#   --cached, CLI source edited (what TRIGGERS the hook)  303.8 s
+#
+# So it does NOT fix the reported cost: the hook only fires when one of the four
+# paths below changed, and in that state 27 workspace packages miss — including
+# the CLI's whole dep closure (assert, path, url, utils, workspace, semver, tar,
+# npm-registry, sqlite), whose own sources did not change. Why they miss is not
+# explained by the version-based toolchain salt and is worth its own look; the
+# 10 % is what it is worth today.
+#
+# What it DOES buy is the second run over the same sources: `git commit --amend`,
+# a retry after a rejected message, a re-run after fixing an unrelated staged
+# file — 336 s → 2.5 s. That is a real workflow and the flag is free, so it stays;
+# it is just not the narrowing #1100 asks for. That one still wants the set the
+# bundle actually inlines.
+$GJSIFY workspace @gjsify/cli build --with-dependencies --cached || rebuild_failed "gjsify workspace @gjsify/cli build --with-dependencies --cached"
 $GJSIFY workspace @gjsify/cli build:affected-bundle || rebuild_failed "gjsify workspace @gjsify/cli build:affected-bundle"
 
 # ANNOUNCE a change instead of staging it silently. A rebuild producing identical

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -24,18 +24,6 @@ it wants an ADR before implementation.
 Until then a consumer that must degrade has to swap the GTK widget itself, which is what
 `jelly-jumper-window.ts` already does on a `startGame()` rejection.
 
-### `on('Display')` is X11/Wayland-shaped, so every GL test skips on macOS
-
-`hasDisplay()` in `packages/gjs/unit/src/index.ts` is `!!(DISPLAY || WAYLAND_DISPLAY)`. GDK's
-macOS backend sets neither, so `on('Display')` reports no display and the whole WebGL1 +
-WebGL2 suites — the GL-backed ones — are silently counted as ignored on darwin. Measured while
-closing #1107: `gjsify workspace @gjsify/webgl run test` runs 54 tests on this macOS VM, none
-of them against a real GL context, on a host where a real context is available and works.
-
-This is how the darwin GL defects (#1103–#1107) reached a human instead of CI. The gate needs
-to ask whether a display is reachable rather than whether an X11/Wayland variable is set —
-on darwin and win32 GTK has one without either.
-
 ### jelly-jumper does not run in a browser
 
 Its `--app browser` build renders the Adwaita chrome and nothing else; the canvas stays at the
@@ -363,34 +351,6 @@ Worth deciding rather than discovering: whether the shim should REFUSE for the
 second row (a name-based deny-list is ugly; a `gjsify.nodeOnly` manifest flag is
 honest) or whether "fails further in" is acceptable. Nobody has hit it yet
 because every host that runs those has Node.
-
-### Every DISPLAY-gated GTK test silently skips on macOS, so the darwin GTK path is near-uncovered
-
-`test/gtk-smoke.test.mjs`, `gtk-template*.test.mjs`, `adw-smoke.test.mjs` and
-`cairo-drawfunc.test.mjs` each gate on
-`!!process.env.DISPLAY || !!process.env.WAYLAND_DISPLAY`. GTK's macOS backend is
-quartz, which sets NEITHER — so on both macOS matrix legs every one of them
-reports as a clean skip, and the `macos` job has never executed a GTK assertion.
-That is how two independent darwin defects shipped in v0.27.0 together (the
-bare-leaf `dlopen` and the ELF-soname-only template API): nothing on that job
-could fail.
-
-The new `test/gtk-typelib-backers.test.mjs` closes the part that needs no
-display, which is the loader question and was the reported bug. What is still
-uncovered is everything downstream of `gtk_init`: real windows, composite
-templates, the Cairo draw func. **Measured, and it is the encouraging half:** on
-the local macOS 15.7.8 test VM the fireworks showcase constructs a
-`Gtk.ApplicationWindow` from a `.blp` template and runs its main loop cleanly
-over a plain SSH session with no GUI login — so quartz needs far less than
-`DISPLAY` implies, and the honest predicate is probably
-`process.platform === 'darwin' || DISPLAY || WAYLAND_DISPLAY`.
-
-Not changed here because the predicate is copy-pasted into five test files
-(lift it to one shared helper in the same change — that duplication is the
-reason it drifted this far) and because "a GitHub macOS runner has a usable
-window server" is an assumption this PR has no way to measure; getting it wrong
-turns five clean skips into five red legs on an unrelated PR. Do it as its own
-change, where a red macOS leg means what it says.
 
 ### `systemGiLibraryDirs()` lives in two places, pinned by a test rather than shared
 
@@ -1825,3 +1785,41 @@ What is NOT closed by that run, stated so neither reads as covered:
   the two are not separable from this one observation. Worth one deliberate
   measurement on a clean host with scripts approved, because "install node-gi and
   it works" is what the win32 story currently promises.
+
+### This ledger goes stale silently, and the two obvious guards were measured and rejected
+
+Two entries here — the `on('Display')` X11/Wayland gate and the DISPLAY-gated GTK
+skips — described a tree that had not existed for days. `capabilities.ts`
+(`canRealizeSurface`/`canRealizeGl`, #1133) and `node-gi`'s `test/display-gate.mjs`
+had already landed the exact shape the second entry ASKED for, down to lifting the
+copy-pasted predicate into one shared helper, and five macOS GTK job families
+including a windowing proof were green on both arches. Both entries were deleted in
+the change that added this one. The cost is not tidiness: an agent asked for the
+next development steps read this file, believed it, and proposed work that was
+already merged.
+
+The generate-status corpse check cannot see this class. It matches the SHAPE of a
+resolved heading (`~~`, `✓`, `Completed`), and a stale entry has none of those — it
+reads exactly like live work, because it was.
+
+Two guards suggest themselves. Both were measured against this file, and both are
+worse than nothing:
+
+- **Flag an entry that references a CLOSED issue.** 34 distinct issue references
+  across 92 sections; 6 point at closed issues (#503, #655, #997, #1002, #1101,
+  #1107). Every one of the six is legitimate provenance — *"Found closing #1107"*,
+  *"the #655 guard"*, *"issue #503"* naming an upstream GIO bug in another tracker,
+  and #1002's own text already says *"is closed as"*. Six false positives, zero
+  findings. It would also have missed both stale entries, which carried no issue
+  reference at all.
+- **Flag an entry naming a path that does not exist.** 23 of 92 sections name one,
+  and they are overwhelmingly correct prose using package-relative shorthand
+  (`lib/esm/index.js`, `src/index.ts`, `test/arrays.test.mjs`). Failing on those
+  would train everyone to bypass the check within a week.
+
+What the two stale entries had in common is not an anchor, it is a QUOTE: each
+one quoted a source fragment (`` `!!(DISPLAY || WAYLAND_DISPLAY)` ``) from a
+repo-rooted file it named. A check that held such a quote to still occurring in
+that file would have failed the day `capabilities.ts` landed, offline and with no
+network. Whether enough entries make a quotable claim to be worth the machinery is
+unmeasured — that measurement is the next step, not another guard.

--- a/tests/e2e/git-hooks-cli-bundle-staleness/run.mjs
+++ b/tests/e2e/git-hooks-cli-bundle-staleness/run.mjs
@@ -203,7 +203,15 @@ describe('git pre-commit hook — affected.gjs.mjs staleness', { timeout: 2 * 60
         // resolve-npm/rolldown-plugin-gjsify and staged a bundle CI could not
         // reproduce (#1093). Pinning the exact command is what stops that being
         // dropped again by someone simplifying the line.
-        assert.equal(invocations[0], 'workspace @gjsify/cli build --with-dependencies');
+        //
+        // `--cached` is pinned for a narrower reason, stated so nobody reads it
+        // as the fix for #1100 — measured, it is not: with CLI source edited,
+        // which is the only state that FIRES this hook, it saves 336 s → 304 s.
+        // What it saves is the RE-RUN over unchanged sources (`--amend`, a retry
+        // after a rejected message): 336 s → 2.5 s. Pinned because that is a
+        // silent property — dropping the flag breaks no assertion, it just makes
+        // every amend slow again.
+        assert.equal(invocations[0], 'workspace @gjsify/cli build --with-dependencies --cached');
         assert.equal(invocations[1], 'workspace @gjsify/cli build:affected-bundle');
 
         // The rebuilt bundle must be in the just-recorded commit.
@@ -250,7 +258,7 @@ describe('git pre-commit hook — affected.gjs.mjs staleness', { timeout: 2 * 60
 
         const invocations = readLog(logPath);
         assert.deepEqual(invocations, [
-            'workspace @gjsify/cli build --with-dependencies',
+            'workspace @gjsify/cli build --with-dependencies --cached',
             'workspace @gjsify/cli build:affected-bundle',
         ]);
 


### PR DESCRIPTION
Two claims this repo made about itself were false. This replaces both with
measurements — including one that says my own change does less than I expected.

## The hook — #1100 is confirmed, NOT closed

Measured on a 20-core workstation, warm tree (~4 cores burned by unrelated
runaway processes, so the absolutes are pessimistic; the ratio is not):

| run | wall clock |
|---|---|
| `build --with-dependencies` — today's hook, twice in a row | **336.1 s / 335.6 s** |
| `--cached`, nothing changed since the last run | **2.5 s** |
| `--cached`, CLI source edited — **the only state that fires the hook** | **303.8 s** |
| `build:affected-bundle` (second hook step, untouched) | 2.5–2.9 s |

The second 335.6 s run rules out a cold-tree artefact: this is what every
CLI-source commit pays, every time. #1100 reported "did not finish inside 2
minutes" — it is five and a half.

**The cache buys 10 %, because the hook fires exactly when the cache cannot
help.** With one CLI source file edited, 27 workspace packages miss — the CLI's
own dependency closure (`assert`, `path`, `url`, `utils`, `workspace`, `semver`,
`tar`, `npm-registry`, `sqlite`, …), none of which had a source change. The 38
hits are almost entirely platform stubs. `resolveToolchainVersions()` salts keys
with `@gjsify/cli`'s *version*, which did not change, so the salt does not
explain it — that question is bigger than this hook and is filed on #1100 with
the package list.

So `--cached` is kept and **labelled for what it actually buys**: the re-run over
unchanged sources — `git commit --amend`, a retry after a rejected message —
336 s → 2.5 s. Real workflow, free flag, wrong issue. #1100 stays open; shape 1
(ask the bundler for the module graph) is still the path, and ADR 0002's
`bootstrap.inputs.json` is half of it already.

`--with-dependencies` is untouched. Narrowing the *selection* is what staged a
bundle CI could not reproduce (#1093); the cache narrows *work*, so that fix
cannot regress here. The e2e pins both flags — dropping `--cached` breaks no
assertion, it just makes every amend slow again, which is what a pinned command
line is for.

## The ledger

Two entries described a tree that had not existed for days:

- **`on('Display')` is X11/Wayland-shaped** — `capabilities.ts`
  (`canRealizeSurface`/`canRealizeGl`, #1133) replaced it. The darwin GL
  substance that remains has its own entry, so the deletion loses nothing.
- **Every DISPLAY-gated GTK test silently skips on macOS** — node-gi's
  `test/display-gate.mjs` landed the exact shape the entry asked for, down to
  lifting the copy-pasted predicate into one shared helper; 20 test files use it.
  Its claim that "the `macos` job has never executed a GTK assertion" is no
  longer true: five macOS GTK job families run, and *macOS windowing proof (no
  brew GTK)* is green on darwin-x64 and darwin-arm64.

Not tidiness. An agent asked for the next development steps read this file,
believed it, and proposed work that was already merged.

### The guard that is deliberately NOT here

The replacement entry records the class *with the measurement*, because both
obvious guards are worse than nothing — measured against the real file:

| candidate | result today |
|---|---|
| flag an entry referencing a CLOSED issue | 6 false positives, 0 findings — all provenance (`Found closing #1107`, `the #655 guard`; #1002's own text says "is closed as"). Would also have missed both stale entries, which carry no issue reference. |
| flag an entry naming a nonexistent path | 23 false positives on correct prose using package-relative shorthand (`lib/esm/index.js`, `src/index.ts`) |

What both stale entries shared is a QUOTE, not an anchor: each quoted a source
fragment from a repo-rooted file it named. A check holding such a quote to still
occurring in that file would have failed the day `capabilities.ts` landed,
offline. Whether enough entries make a quotable claim to pay for the machinery is
unmeasured — that measurement is the next step, not another guard.

## Unrelated, closed alongside

#1056 was already implemented in `scripts/verify-published-closure.mjs`,
including both judgement calls it left open. Closed with the evidence.
