### PR TITLE
fix(adwaita-app): stop hardwiring Enter to confirm

### DIFF
--- a/packages/framework/adwaita-app/README.md
+++ b/packages/framework/adwaita-app/README.md
@@ -87,7 +87,11 @@ promise-job queue under `run()`).
 
 ### Interaction helpers
 
-- `confirmDialog(parent, { heading, body?, confirmLabel?, cancelLabel?, destructive? }): Promise<boolean>`
+- `confirmDialog(parent, { heading, body?, confirmLabel?, cancelLabel?, destructive?, defaultResponse? }): Promise<boolean>`
+  — `defaultResponse` (`'confirm' | 'cancel'`, default `'confirm'`) picks the
+  response Enter activates. A destructive question wants both: `destructive: true`
+  for the red button and `defaultResponse: 'cancel'` so the reflex keystroke
+  escapes instead of deleting. An id that is neither throws a `TypeError`.
 - `errorDialog(parent, heading, body?): Promise<void>`
 - `registerToastOverlay(overlay)` + `showToast(title, timeout?)`
 - `pickFile(parent, { title?, filters? }): Promise<string | null>` /

--- a/packages/framework/adwaita-app/src/dialog-model.spec.ts
+++ b/packages/framework/adwaita-app/src/dialog-model.spec.ts
@@ -1,0 +1,27 @@
+// @gjsify/adwaita-app — confirm-dialog model tests.
+// Runs on GJS + Node (pure helper, no platform imports).
+
+import { describe, expect, it } from '@gjsify/unit';
+import { resolveDefaultResponse } from './dialog-model.js';
+
+export default async () => {
+    await describe('resolveDefaultResponse', async () => {
+        await it('keeps confirm as the default when unset', () => {
+            expect(resolveDefaultResponse()).toBe('confirm');
+            expect(resolveDefaultResponse(undefined)).toBe('confirm');
+        });
+
+        await it('makes the requested response the default', () => {
+            expect(resolveDefaultResponse('cancel')).toBe('cancel');
+            expect(resolveDefaultResponse('confirm')).toBe('confirm');
+        });
+
+        await it('rejects a response the dialog does not have', () => {
+            // Adw would take 'delete' and silently leave the dialog without a
+            // default widget, so an unknown id has to fail loudly here instead.
+            expect(() => resolveDefaultResponse('delete')).toThrow(TypeError);
+            expect(() => resolveDefaultResponse('delete')).toThrow('delete');
+            expect(() => resolveDefaultResponse('')).toThrow(TypeError);
+        });
+    });
+};

--- a/packages/framework/adwaita-app/src/dialog-model.ts
+++ b/packages/framework/adwaita-app/src/dialog-model.ts
@@ -1,0 +1,32 @@
+// @gjsify/adwaita-app — pure confirm-dialog model.
+// No @girs imports: unit-tested on Node + GJS, unlike the Adw wrapper it serves.
+
+import type { ConfirmResponse } from './types.js';
+
+function isConfirmResponse(value: string): value is ConfirmResponse {
+    return value === 'confirm' || value === 'cancel';
+}
+
+/**
+ * Resolve which response a confirm dialog opens focused on — the one Enter picks.
+ *
+ * Falls back to `confirm`, which is what every caller of the option-less API
+ * already gets; changing that default would change published behaviour under
+ * consumers who never asked for it.
+ *
+ * The id is checked at RUNTIME, not just by the union: the type is erased, and
+ * `adw_alert_dialog_set_default_response()` takes any string — an id matching no
+ * response stores the quark and never touches the default widget, so a typo
+ * ships as a dialog where Enter quietly does nothing.
+ *
+ * @throws TypeError for an id the dialog has no response for.
+ */
+export function resolveDefaultResponse(requested?: string): ConfirmResponse {
+    if (requested === undefined) return 'confirm';
+    if (!isConfirmResponse(requested)) {
+        throw new TypeError(
+            `@gjsify/adwaita-app: confirmDialog defaultResponse must be 'confirm' or 'cancel', got ${JSON.stringify(requested)}`,
+        );
+    }
+    return requested;
+}

--- a/packages/framework/adwaita-app/src/dialogs.ts
+++ b/packages/framework/adwaita-app/src/dialogs.ts
@@ -5,6 +5,9 @@
 import Adw from '@girs/adw-1';
 import type Gtk from '@girs/gtk-4.0';
 
+import { resolveDefaultResponse } from './dialog-model.js';
+import type { ConfirmResponse } from './types.js';
+
 /** Options for {@link confirmDialog}. */
 export interface ConfirmOptions {
     /** Dialog heading. */
@@ -17,6 +20,14 @@ export interface ConfirmOptions {
     cancelLabel?: string;
     /** Style the confirm button as destructive (red) instead of suggested. */
     destructive?: boolean;
+    /**
+     * Response the dialog opens focused on, so Enter activates it. Default `confirm`.
+     *
+     * Pair `cancel` with `destructive`: what makes a "really delete this?" dialog
+     * worth showing is the accidental gesture, and a `confirm` default hands the
+     * reflex of dismissing a dialog with Enter the deletion instead of the escape.
+     */
+    defaultResponse?: ConfirmResponse;
 }
 
 /**
@@ -24,6 +35,10 @@ export interface ConfirmOptions {
  * on cancel/dismiss. `parent` anchors the dialog (typically the window).
  */
 export function confirmDialog(parent: Gtk.Widget, options: ConfirmOptions): Promise<boolean> {
+    // An invalid option is a caller bug, not a dialog outcome: validated outside
+    // the executor so it throws at the call site instead of arriving as a
+    // rejection on the channel that reports the user's answer.
+    const defaultResponse = resolveDefaultResponse(options.defaultResponse);
     return new Promise((resolve) => {
         const dialog = new Adw.AlertDialog({ heading: options.heading, body: options.body ?? '' });
         dialog.add_response('cancel', options.cancelLabel ?? 'Cancel');
@@ -32,7 +47,7 @@ export function confirmDialog(parent: Gtk.Widget, options: ConfirmOptions): Prom
             'confirm',
             options.destructive ? Adw.ResponseAppearance.DESTRUCTIVE : Adw.ResponseAppearance.SUGGESTED,
         );
-        dialog.set_default_response('confirm');
+        dialog.set_default_response(defaultResponse);
         dialog.set_close_response('cancel');
         dialog.connect('response', (_dialog, response) => resolve(response === 'confirm'));
         dialog.present(parent);

--- a/packages/framework/adwaita-app/src/index.ts
+++ b/packages/framework/adwaita-app/src/index.ts
@@ -26,4 +26,4 @@ export { readAppDevHooks } from './dev-hooks.js';
 export type { AppDevHooks, ReadAppDevHooksOptions } from './dev-hooks.js';
 
 export { findNavItem, resolveInitialNavIndex } from './nav-model.js';
-export type { AboutInfo, NavItem } from './types.js';
+export type { AboutInfo, ConfirmResponse, NavItem } from './types.js';

--- a/packages/framework/adwaita-app/src/test.mts
+++ b/packages/framework/adwaita-app/src/test.mts
@@ -5,11 +5,13 @@
 import { run } from '@gjsify/unit';
 
 import devHooksSuite from './dev-hooks.spec.js';
+import dialogModelSuite from './dialog-model.spec.js';
 import navModelSuite from './nav-model.spec.js';
 import viewLoaderSuite from './view-loader.spec.js';
 
 run({
     devHooksSuite,
+    dialogModelSuite,
     navModelSuite,
     viewLoaderSuite,
 });

--- a/packages/framework/adwaita-app/src/types.ts
+++ b/packages/framework/adwaita-app/src/types.ts
@@ -2,6 +2,9 @@
 // Pure types only (no @girs value imports) so the pure-logic modules that
 // consume them stay Node + GJS testable.
 
+/** The two response ids a `confirmDialog` adds to its `Adw.AlertDialog`. */
+export type ConfirmResponse = 'confirm' | 'cancel';
+
 /** A single entry in the navigation sidebar / view stack. */
 export interface NavItem {
     /** Stable id used as the `Gtk.Stack` child name and for `selectById`. */


### PR DESCRIPTION
## The defect

`confirmDialog` set `set_default_response('confirm')` unconditionally, and `ConfirmOptions` had no
way to change it. For a confirming dialog that is harmless. For a **destructive** one it is
dangerous: a "really delete this wall?" dialog opened with the delete button focused, so the reflex
of dismissing a dialog with Enter performed the deletion instead of escaping it.

That is the most common reason to ask a question at all, which made the helper unusable for it — a
real consumer, `JumpLink/bauplaner`, still hand-rolls a deprecated `Adw.MessageDialog` with
`set_default_response('cancel')` rather than call the library. The gap surfaced while working on
that consumer, so per the root-cause rule it is fixed here, not worked around there.

## What changed

- **`ConfirmOptions.defaultResponse?: ConfirmResponse`** (`'confirm' | 'cancel'`). Named after
  `adw_alert_dialog_set_default_response`, typed as the two response ids the helper actually adds —
  the same camelCase-mirroring-the-Adw-property shape as the options next to it.
- **`resolveDefaultResponse()` in a new pure `dialog-model.ts`**, the split the package already uses
  for `nav-model.ts` vs `nav-shell.ts`: the decision has no `@girs` value import, so it is unit-tested
  on Node **and** GJS while `dialogs.ts` keeps its `Adw` import.
- **An unknown id throws a `TypeError` instead of being ignored.** `adw_alert_dialog_set_default_response`
  takes any string: `find_response()` returning NULL is not an error there, it stores the quark and
  never touches the default widget. A typo would therefore have shipped as "Enter quietly does
  nothing" rather than as a failure.

The destructive **appearance** was already available (`destructive?: boolean` →
`Adw.ResponseAppearance.DESTRUCTIVE`), so only the missing half needed adding.

## Not changed, on purpose

The default is still `confirm`. This is published API and existing consumers rely on the current
behaviour, so the option is opt-in and an option-less call is byte-identical to before.

**Observation for a later PR:** the safe default is the other one. Anything passing
`destructive: true` almost certainly also wants `defaultResponse: 'cancel'` — the two are one
decision — so either coupling them (destructive implies a `cancel` default unless overridden) or
flipping the global default would remove the footgun instead of documenting it. Both change
behaviour under existing callers, so they belong in their own PR with their own release note, not
smuggled in here.

## Tests

`dialog-model.spec.ts`, Node + GJS (35 assertions in the package suite, both runtimes green):

- unset → still `confirm` (the pre-option behaviour is pinned, not just described)
- `'cancel'` / `'confirm'` → becomes the default
- an id the dialog has no response for → `TypeError` naming the offending value

## Migration for a consumer

```ts
await confirmDialog(window, {
    heading: 'Wand löschen?',
    body: '…',
    confirmLabel: 'Trotzdem löschen',
    cancelLabel: 'Abbrechen',
    destructive: true,
    defaultResponse: 'cancel', // ← Enter cancels, as the hand-rolled dialog did
});
```

Nothing to do for callers that do not pass the option.
