### PR TITLE
docs(adr): state that a process has ONE GObject registry

### DIFF
--- a/docs/adr/0023-gtk-source-precedence.md
+++ b/docs/adr/0023-gtk-source-precedence.md
@@ -3,6 +3,11 @@
 - Status: **Accepted**
 - Date: 2026-08-08
 - Deciders: Pascal Garber
+- **Amended 2026-08-13 (§ 4).** The per-OS preference table below is unchanged and
+  confirmed. What it did not state is the invariant ABOVE it: preference names which
+  GTK wins, and nothing said the loser must not be loaded as well. Two measured
+  instances now say it has to be stated and checked — #1120 (already in Consequences)
+  and #1144 (macOS + deno). See § *4. Exactly one GObject type registry per process*.
 - Related: [ADR 0017 (native distribution)](0017-native-package-distribution.md), [ADR 0018 (OS-axis declaration)](0018-os-axis-declaration.md), `docs/node-gi-platform-notes.md` § batteries-included GTK bundles
 
 ## Context
@@ -85,6 +90,93 @@ actually loads.
 `GJSIFY_GTK_PREFER=bundle` can lift the veto. Building against a bundle on
 purpose is legitimate, and an explicitly-set variable is consent; what #910 was is
 an accident nobody chose. Only the *default* has to refuse it.
+
+### 4. Exactly one GObject type registry per process
+
+*Added 2026-08-13.*
+
+**The invariant: a process has exactly ONE GObject type registry.** Sections 2 and
+3 answer *which* GTK wins. They do not forbid the other one being loaded too, and
+that is a separate failure with its own signature — not a preference that came out
+wrong, but two answers coexisting:
+
+```
+objc[…]: Class GtkMacosContentView is implemented in both …/homebrew/…/libgtk-4.1.dylib
+         and …/@gjsify/gtk-runtime-darwin-x64/…/libgtk-4.1.dylib
+GtkWidget is not registered in this process's GObject type registry
+TypeError: Adw.Application has no property 'application-id'
+```
+
+The registry, not the file count, is what the invariant is about: two copies of
+`libgtk` that never met would be wasteful; two that both register types make every
+`g_object_class_find_property` ask a registry that does not have the caller's type,
+and the symptom is a MISSING PROPERTY on a widget that plainly exists.
+
+**Why preference cannot deliver this, measured twice.** The Consequences section
+already records #1120 and drew the general lesson: *a preference expressed in
+environment variables cannot override a Mach-O load command that resolves.* There
+the resolving load command was in our own addon (an absolute
+`/usr/local/opt/glib/…`, fixed by relocating to `@rpath`). #1144 is the same class
+one layer out — `gjs`, `node` and `bun` on the same machine, same bundle, are
+green; only `deno` ends up with both — so the load command that resolves is no
+longer ours, and an env variable will not reach it either.
+
+Therefore: **preference is a choice, the invariant is a CHECK.** They live at
+different levels and the check has to read what is actually LOADED, not what was
+preferred. Anything asserted from `GJSIFY_GTK_PREFER`, `DYLD_*` or
+`decideGtkSource()`'s return value is a restatement of the preference and cannot
+observe its own failure.
+
+**Detection is portable; enforcement is per-OS.** Deliberately split, because they
+have different evidence requirements:
+
+- *Detection* — "how many distinct libraries back the GObject types this process
+  has" — is answerable on every platform and is a pure function of the loaded-image
+  list, so it is testable from the Linux runner this project actually has, which is
+  the standing constraint (ADR 0018 § 5).
+- *Enforcement* — preventing the second load — depends on the loader, and the loader
+  is per-OS. For #1144 there is a documented CANDIDATE mechanism (below), not yet a
+  confirmed one.
+
+**The candidate mechanism for #1144, from this module's own comment.** The repair
+that exists — `activateGiLibraryPath()`, added in #1132 — was written for exactly
+these three errors and is `export`ed *and called* (`index.js`) in v0.38.0, the
+version #1144 was measured against. So the repair ran and the collision happened
+anyway. Its own doc says why it might not be enough:
+
+> The env paths elsewhere in this module stay — they still cover a dylib pulled in
+> by ANOTHER dylib's link closure, which never passes through GI.
+
+Those env paths are set by `maybeReexecForGtkRuntime()`, which is Node-shaped and
+returns early on bun and deno. `activateGiLibraryPath()` covers what GI resolves by
+bare leaf; nothing covers a dylib pulled in through another dylib's link closure. On
+deno that gap has no cover at all — which would produce one Homebrew copy arriving
+through a link closure beside the bundle's, i.e. precisely the observed collision.
+
+If that is confirmed, the fix is **not** a new preference and not an env variable —
+#1120's lesson forbids both. It is to make the bundle's dylibs need no search path:
+relocate them to `@rpath` the way `scripts/relocate-macho.mjs` already does for
+every other darwin prebuild, and the way #1120's own fix relocated the addon. That
+removes the gap on every runtime at once, with no env and no re-exec.
+
+This section deliberately does not RATIFY that mechanism — it has to be measured on
+the macOS host first (does the loaded addon expose `prependLibraryPath`; does
+`activateGiLibraryPath()` return a non-empty list under deno; what does
+`DYLD_PRINT_LIBRARIES=1` list). Naming the invariant is the decision here; #1120's
+lesson is that guessing the mechanism from the preference layer is how a release
+ships broken.
+
+**Linux is in scope for the invariant even though it is system-first.** The
+preference table keeps Linux on the distribution's stack, and the reasoning for
+that is stronger than "GTK is native there": the distro ships GTK *and* the
+matching typelibs as a tested pair, and the theme, icon theme, input methods,
+AT-SPI and portals all come from the same system — a bundle would satisfy none of
+that contract, which is also why Flatpak's `org.gnome.Platform` (not a
+gjsify-specific Linux bundle) is the right answer to "ship a GTK" on Linux. But
+"system wins" is not "only one exists": a Flatpak runtime beside a host stack is
+the same double-load hazard, and § 2's fallback clause means Linux CAN reach a
+bundle. The invariant is therefore platform-independent even where the preference
+is not — and that is precisely what makes it checkable on Linux.
 
 ## Consequences
 


### PR DESCRIPTION
Amends [ADR 0023](docs/adr/0023-gtk-source-precedence.md) with § 4. Decision requested and
taken by @JumpLink; no code changes.

## What was missing

§ 2's per-OS table answers **which** GTK wins. Nothing said the loser must not be loaded as
well — and that is a different failure with its own signature: not a preference that came out
wrong, but two answers coexisting. Every `g_object_class_find_property` then asks a registry
that does not have the caller's type, so the symptom is a **missing property on a widget that
plainly exists**.

Measured twice: #1120 (already recorded in Consequences) and #1144.

## The preference table is unchanged, Linux included

Confirmed rather than revisited. Linux stays **system-first**, and the reason is stronger than
"GTK is native there": the distribution ships GTK *and* the matching typelibs as a tested
pair, and the theme, icon theme, input methods, AT-SPI and portals come from that same
system — a bundle satisfies none of it. Which is also why Flatpak's `org.gnome.Platform`,
not a gjsify-specific Linux bundle, is the answer to "ship a GTK" on Linux.

But *system wins* is not *only one exists*: a Flatpak runtime beside a host stack is the same
hazard, and § 2's fallback clause means Linux **can** reach a bundle. So the invariant is
platform-independent even where the preference is not — which is exactly what makes it
checkable from the Linux runner this project has (ADR 0018 § 5).

## It records a candidate mechanism, not a policy, for #1144

While writing this I found the answer is probably not policy at all. The repair for those
exact three errors — `activateGiLibraryPath()`, #1132 — was **wired and reachable in
v0.38.0**, the version #1144 was measured against:

```
git show v0.38.0:…/index.js | grep activateGiLibraryPath → 14: import · 132: call
```

So it ran, and the collision happened anyway. The same function's comment names the
uncovered route:

> The env paths elsewhere in this module stay — they still cover a dylib pulled in by
> ANOTHER dylib's link closure, **which never passes through GI**.

Those env paths come from `maybeReexecForGtkRuntime()`, which is Node-shaped and returns
early on bun and deno. If that is the route, the fix is relocating the **bundle's** dylibs to
`@rpath` — as #1120's fix did for the addon — and not a new preference or env variable, per
this ADR's own recorded lesson: *a preference expressed in environment variables cannot
override a Mach-O load command that resolves.*

The ADR deliberately does **not** ratify that mechanism. It has to be measured on the macOS
host first; the four steps are listed in #1144.

## Verification

`check-adr-index` passes (23 ADRs, statuses agree). Docs-only, so no package behaviour
changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)