### PR TITLE
docs(status): a third shape for the macOS launcher gap, measured

### DIFF
--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -438,6 +438,58 @@ launcher defer to the CLI rather than re-derive; that is a launcher-shape change
 and belongs in its own PR, ideally the one that lifts `system-gi` to a shared
 package (above).
 
+**A THIRD SHAPE EXISTS, and it needs no launcher at all — measured 2026-08-13 on
+the macOS 15.7.9 x86_64 VM.** Neither of the two shapes above is the only option,
+because the repair does not have to reach the process from OUTSIDE. GI takes it at
+runtime, from inside the process, in three lines:
+
+```js
+const repo = imports.gi.GIRepository.Repository.dup_default();
+repo.prepend_search_path(dir);   // replaces GI_TYPELIB_PATH
+repo.prepend_library_path(dir);  // replaces DYLD_/LD_LIBRARY_PATH
+```
+
+Measured, plain `gjs`, under `env -u DYLD_FALLBACK_LIBRARY_PATH -u
+DYLD_LIBRARY_PATH -u GI_TYPELIB_PATH`:
+
+| | |
+|---|---|
+| no prepend | `Failed to load shared library 'libgtk-4.1.dylib'` — dlopen tried only gjs's own rpath, `…/Cellar/gjs/1.88.1/bin/../../../../opt/glib/lib`, i.e. **glib's keg alone**, confirming the mechanism this entry describes |
+| with prepend | **`OK gtype: GtkWidget`** |
+
+`Repository.dup_default()`, `prepend_search_path` and `prepend_library_path` are
+all present under gjs 1.88.1 (checked on darwin AND linux). The linux control that
+isolates which call does what: prepending only the SEARCH path finds the typelib
+and then fails with `Failed to load shared library 'libgwebgl.so' referenced by the
+typelib`, so `prepend_library_path` is load-bearing and not redundant.
+
+This is the same call `activateGiLibraryPath()` (#1132) makes in C for node-gi —
+`dup_default()` is node-gi's `DupDefaultRepository()`. What is new is that a GJS
+BUNDLE can make it too, which removes the launcher from this path entirely rather
+than making it smarter.
+
+**It has no snapshot problem** (it runs at app start, so `systemGiLibraryDirs()` is
+evaluated then) and **no shell copy** (same TypeScript, type-checked). Both
+objections above dissolve.
+
+**What it does NOT cover, so the launcher does not disappear wholesale:** a library
+pulled in through ANOTHER library's link closure (`LC_LOAD_DYLIB` / `NEEDED`). The
+loader resolves those and GI never sees them, so only `@rpath`/`$ORIGIN` in the
+binaries reaches them — the same distinction ADR 0023 § 4 draws, and the reason
+#1144 is not fixed by this.
+
+**The one open decision before implementing.** The dirs have to come from
+somewhere the bundle can import. Two of the three sources are relative to the app
+tree (gjsify's own `prebuilds/<target>` dirs, a chosen GTK bundle's `libDir`) and
+need nothing new. The SYSTEM dirs need `systemGiLibraryDirs()`, which lives in
+`@gjsify/node-gi` — a package with exactly ONE dependency (`node-addon-api`) and
+not a workspace member, so importing it from a bundle, or giving it a
+`@gjsify/utils` dependency, both change a posture that looks deliberate. Lifting
+the canonical copy to `@gjsify/utils/core` (pure, already the home for this kind
+of helper) and keeping node-gi's as the pinned mirror it already is would leave the
+copy count unchanged and make it importable — but that is node-gi's dependency
+posture, so it wants a deliberate call rather than a drive-by.
+
 ### Bun DID hard-crash in the N-API teardown class — the first one, and the note that predicted it asked to be told
 
 **Cross-reference (added 2026-08-06): #925 files the same `test/arrays.test.mjs` occurrences as a TEST FLAKE, while this entry files them as an N-API teardown crash class (`free(): invalid pointer`, a glibc abort). Same file, two theories. Whichever is right, the next occurrence should be read from the RAW job log for a `----- Native stack trace -----` block, which is what tells the two apart.**


### PR DESCRIPTION
Measured on the macOS 15.7.9 x86_64 VM. Docs-only; no behaviour changes.

## The parked entry

`status/open-todos.md` → *"A globally installed GJS launcher still cannot load a system GTK on
macOS"* was deliberately left alone because **neither available shape was right**: baking
`systemGiLibraryDirs()` into a launcher at write time is a snapshot (launchers get written
before `brew install gtk4`), and re-deriving it in shell is a third copy of a two-copy rule,
in the one language nothing here type-checks.

Both objections share an assumption: that the repair has to reach the process from **outside**.

## It does not

GI takes it at runtime, from inside the process:

```js
const repo = imports.gi.GIRepository.Repository.dup_default();
repo.prepend_search_path(dir);   // replaces GI_TYPELIB_PATH
repo.prepend_library_path(dir);  // replaces DYLD_/LD_LIBRARY_PATH
```

Plain `gjs`, under `env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH -u GI_TYPELIB_PATH`:

| | |
|---|---|
| no prepend | `Failed to load shared library 'libgtk-4.1.dylib'` — dlopen tried only gjs's own rpath, `…/Cellar/gjs/1.88.1/bin/../../../../opt/glib/lib`, i.e. **glib's keg alone**, which is exactly the mechanism that entry describes |
| with prepend | **`OK gtype: GtkWidget`** |

This is the same call `activateGiLibraryPath()` (#1132) makes in C for node-gi —
`dup_default()` *is* its `DupDefaultRepository()`. What is new is that a **GJS bundle** can make
it too, so the launcher leaves this path rather than getting smarter. No snapshot (evaluated at
app start), no shell copy (same TypeScript, type-checked).

**Isolating control, on linux:** prepending only the *search* path finds the typelib and then
fails with `Failed to load shared library 'libgwebgl.so' referenced by the typelib` — so
`prepend_library_path` is load-bearing, not redundant. `dup_default` and both methods are
present under gjs 1.88.1 on darwin *and* linux.

## What it does not cover, recorded with it

A library pulled in through **another library's link closure** (`LC_LOAD_DYLIB` / `NEEDED`).
The loader resolves those and GI never sees them, so only `@rpath`/`$ORIGIN` in the binaries
reaches them — the distinction [ADR 0023 § 4](docs/adr/0023-gtk-source-precedence.md) draws,
and the reason this does **not** fix #1144.

## Why this stops at docs

The implementation needs the dirs to come from somewhere a bundle can import. Two of the three
sources are relative to the app tree and need nothing new; the **system** dirs need
`systemGiLibraryDirs()`, which lives in `@gjsify/node-gi` — a package with exactly **one**
dependency (`node-addon-api`) and not a workspace member. Importing it from a bundle, or giving
it a `@gjsify/utils` dependency, both change a posture that looks deliberate, so that call is
recorded as the one open decision rather than made in passing.

> **Correction (after merge).** This PR's body originally claimed
> `packages/infra/rolldown-plugin-gjsify` "has no test harness at all". **That is wrong** — I
> looked inside the package directory instead of searching. Its plugins are covered by **14
> specs** in `@gjsify/cli`'s harness, with the placement rationale stated in each
> (`unresolved-workspace-import.spec.ts`: *"Tested from @gjsify/cli's harness because the plugin
> package has no `test:node` script of its own"*), and one of them —
> `process-stub-banner.spec.ts` — already pins the very banner a GI-paths prologue would extend,
> including the rule that the banner must reach ambient globals through `globalThis.` or a
> bundled module's top-level `const imports` kills it at byte 1 from its TDZ.
>
> So there is **no missing harness and no test blocker**. The remaining blocker is the one
> below (where the canonical `systemGiLibraryDirs()` lives), and it only affects the *system*
> dirs — the other two path sources are relative to the app tree and need nothing new.

## Also from this session

#1144's step-4 hypothesis (bundle dylibs never relocated) is **refuted** and corrected in the
issue: install-names are `@loader_path/…` and `otool -L` shows no absolute closure entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
