### PR TITLE
feat(rolldown-plugin-gjsify): hand GI its paths from inside the bundle

### DIFF
--- a/packages/infra/cli/src/gi-runtime-paths-banner.spec.ts
+++ b/packages/infra/cli/src/gi-runtime-paths-banner.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+// The GI runtime-path prologue — the banner that lets a `--app gjs` bundle run under a
+// bare `gjs -m bundle.mjs` with NO `GI_TYPELIB_PATH` and no loader-path environment,
+// and therefore with no launcher.
+//
+// Asserted as a STRING, deliberately: same rationale as `process-stub-banner.spec.ts`
+// — no bundle build, and it fails on the mistake itself rather than on a downstream
+// symptom. The behaviour behind it is measured, not assumed (macOS 15.7.9 x86_64 VM +
+// linux, gjs 1.88.1, `env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH -u
+// GI_TYPELIB_PATH`): without the prepend `imports.gi.Gtk` dies with `Failed to load
+// shared library 'libgtk-4.1.dylib'`, with it `Gtk.Widget.$gtype.name` answers.
+//
+// Tested from @gjsify/cli's harness because the plugin package has no `test:node`
+// script of its own — the same placement rationale as `process-stub-banner.spec.ts`
+// and the twelve other bundler specs here.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { giRuntimePathsStub } from '@gjsify/rolldown-plugin-gjsify';
+
+/** GJS ambient globals a bundled module could plausibly shadow at top level. */
+const AMBIENT_GLOBALS = ['imports', 'print', 'printerr', 'log', 'logError', 'ARGV'];
+
+export default async () => {
+    await describe('giRuntimePathsStub: nothing to say, nothing emitted', async () => {
+        await it('emits an empty string for an empty list', async () => {
+            // A no-op prologue in every bundle is a guard that can never fire, and a
+            // banner that is not there cannot drift.
+            expect(giRuntimePathsStub([])).toBe('');
+        });
+    });
+
+    await describe('giRuntimePathsStub: the byte-1 rules', async () => {
+        await it('reaches every ambient global through globalThis.', async () => {
+            // THE incident this pins, from `process-stub-banner.spec.ts`: a BARE
+            // `imports` at byte 1 binds to any top-level `const imports` a bundled
+            // module declares — `@girs/gjs`'s generated shim declares exactly that —
+            // and at byte 1 that binding is still in its temporal dead zone, so the
+            // bundle dies at load with `ReferenceError: can't access lexical
+            // declaration 'imports' before initialization`.
+            const stub = giRuntimePathsStub(['node_modules/@gjsify/webgl-linux-x64/prebuilds/linux-x64']);
+            for (const name of AMBIENT_GLOBALS) {
+                const bare = new RegExp(`(^|[^.\\w"'])${name}\\b`);
+                const offending = bare.exec(stub.replace(/globalThis\./g, 'globalThis_'));
+                expect(offending === null || /globalThis_/.test(offending[0])).toBe(true);
+            }
+            expect(stub.includes('globalThis.imports')).toBe(true);
+        });
+
+        await it('stays on ONE line', async () => {
+            // The banner runs before any source-map-aware machinery, so a newline
+            // shifts every bundle line number by one.
+            expect(giRuntimePathsStub(['a', 'b']).includes('\n')).toBe(false);
+        });
+    });
+
+    await describe('giRuntimePathsStub: both prepends, because both are load-bearing', async () => {
+        await it('calls prepend_search_path AND prepend_library_path', async () => {
+            // Measured on linux: prepending only the SEARCH path finds the typelib and
+            // then fails with `Failed to load shared library 'libgwebgl.so' referenced
+            // by the typelib`. Dropping either call is a silent half-fix.
+            const stub = giRuntimePathsStub(['prebuilds/linux-x64']);
+            expect(stub.includes('prepend_search_path')).toBe(true);
+            expect(stub.includes('prepend_library_path')).toBe(true);
+        });
+
+        await it('degrades to a no-op where GIRepository is not introspectable', async () => {
+            // Guarded probes and not try/catch: none of these calls has a throw path
+            // (no `throws` in the GIR), so a catch would have nothing to catch and
+            // would hide a real absence. What is genuinely optional is the API.
+            const stub = giRuntimePathsStub(['x']);
+            expect(stub.includes('dup_default')).toBe(true);
+            for (const guard of ['!i||!i.gi', '!R||!R.Repository', '!r.prepend_search_path']) {
+                expect(stub.includes(guard)).toBe(true);
+            }
+            expect(/\bcatch\b/.test(stub)).toBe(false);
+        });
+    });
+
+    await describe('giRuntimePathsStub: paths are relative to the PROGRAM', async () => {
+        await it('joins against the program dir rather than baking an absolute path', async () => {
+            // A baked absolute path is the BUILD machine's, so a shipped app would
+            // carry directories that do not exist on the user's disk.
+            const stub = giRuntimePathsStub(['prebuilds/linux-x64']);
+            expect(stub.includes('programPath')).toBe(true);
+            expect(stub.includes('programInvocationName')).toBe(true);
+        });
+
+        await it('cuts the program dir on EITHER separator', async () => {
+            // The program path is the HOST's: on win32 it is `C:\…\main.js`, where a
+            // `/`-only cut matches nothing and the join would silently yield a relative
+            // path. Same rule as `@gjsify/utils/core`'s `lastPathSeparatorIndex` (#1143).
+            const stub = giRuntimePathsStub(['x']);
+            const cut = /\/\^\(\.\*\)\[([^\]]*)\]/.exec(stub);
+            expect(cut !== null).toBe(true);
+            expect(cut![1].includes('\\\\')).toBe(true);
+            expect(cut![1].includes('\\/')).toBe(true);
+        });
+
+        await it('emits every directory it was given, JSON-quoted', async () => {
+            const dirs = ['a-dir', 'with space', "with'quote"];
+            const stub = giRuntimePathsStub(dirs);
+            for (const d of dirs) expect(stub.includes(JSON.stringify(d))).toBe(true);
+        });
+    });
+};

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 import bundlerPickSuite from './bundler-pick.spec.js';
 import cliFailSuite from './cli-fail.spec.js';
 import installProjectEngineSuite from './commands/install-project-engine.spec.js';
+import giRuntimePathsBannerSuite from './gi-runtime-paths-banner.spec.js';
 import processStubBannerSuite from './process-stub-banner.spec.js';
 import barrelsGenerateSuite from './barrels-generate.spec.js';
 import npmOidcSuite from './npm-oidc.spec.js';
@@ -183,6 +184,7 @@ run(
         bundlerPickSuite,
         cliFailSuite,
         installProjectEngineSuite,
+        giRuntimePathsBannerSuite,
         processStubBannerSuite,
         barrelsGenerateSuite,
         npmOidcSuite,

--- a/packages/infra/rolldown-plugin-gjsify/src/index.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/index.ts
@@ -16,6 +16,7 @@ export {
 export type { NodeModulesPathRewriteOptions, RewriteResult } from './plugins/rewrite-node-modules-paths.js';
 
 export { processStubPlugin, GJS_PROCESS_STUB, composeBanner } from './plugins/process-stub.js';
+export { giRuntimePathsStub } from './plugins/gi-runtime-paths.js';
 export type { ProcessStubPluginOptions } from './plugins/process-stub.js';
 export { cssAsStringPlugin } from './plugins/css-as-string.js';
 export { textLoaderPlugin } from './plugins/text-loader.js';

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
@@ -1,78 +1,35 @@
 // Tell GI where a bundle's own typelibs and their backing libraries are — from
 // INSIDE the process, so a `--app gjs` bundle needs no launcher and no environment.
-//
-// WHAT THIS REPLACES
-//
-// `@gjsify/cli`'s launcher preamble globs `node_modules/**/prebuilds/<target>/` in
-// SHELL and exports `GI_TYPELIB_PATH` + `LD_LIBRARY_PATH`/`DYLD_FALLBACK_LIBRARY_PATH`
-// for the child. That works and costs a launcher: a bundle handed to a bare
-// `gjs -m bundle.mjs` gets none of it, and on macOS dies at the first widget because
-// gjs's own rpath points into glib's keg alone.
-//
-// MEASURED, not assumed (macOS 15.7.9 x86_64 VM + linux, gjs 1.88.1), under
-// `env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH -u GI_TYPELIB_PATH`:
-//
-//   no prepend                    → Failed to load shared library 'libgtk-4.1.dylib'
-//   prepend_search_path only      → typelib found, then the SAME dlopen failure
-//   both prepends                 → OK gtype: GtkWidget
-//
-// So both calls are load-bearing and neither is redundant. This is the same repair
-// `activateGiLibraryPath()` (#1132) makes in C for node-gi — `dup_default()` is its
-// `DupDefaultRepository()` — reached from JS instead. Details + the remaining gap in
-// `status/open-todos.md` § "A globally installed GJS launcher still cannot load a
-// system GTK on macOS".
-//
-// WHAT IT DOES NOT COVER
-//
-// A library pulled in through ANOTHER library's link closure (`LC_LOAD_DYLIB` /
-// `NEEDED`). The loader resolves those and GI never sees them, so only
-// `@rpath`/`$ORIGIN` in the binaries reaches them (ADR 0023 § 4).
-//
-// WHY RELATIVE PATHS, RESOLVED AT RUNTIME
-//
-// A baked absolute path is the build machine's, so a shipped app would carry
-// directories that do not exist on the user's disk. The dirs are therefore emitted
-// relative to the PROGRAM, and joined against `system.programPath`'s directory when
-// the bundle starts.
+// Why it exists, what it does NOT cover (a dylib reached through another dylib's
+// link closure never passes through GI, so only `@rpath`/`$ORIGIN` reaches it) and
+// the macOS measurements behind it: `status/open-todos.md` § "A globally installed
+// GJS launcher still cannot load a system GTK on macOS", ADR 0023 § 4.
 
 /**
  * The byte-1 prologue that prepends `dirs` to the default repository's typelib
- * search path and library path.
- *
- * Returns `''` for an empty list: emitting a no-op prologue would put a guard in
- * every bundle that can never do anything, and a banner that is not there cannot
+ * search path and library path. Empty list → `''`: a no-op prologue in every
+ * bundle is a guard that can never fire, and a banner that is not there cannot
  * drift.
  *
- * @param dirs directories RELATIVE to the program's own directory, `/`-separated
+ * @param dirs directories RELATIVE to the program's own directory, `/`-separated —
+ *   an absolute path baked at build time is the BUILD machine's
  */
 export function giRuntimePathsStub(dirs: readonly string[]): string {
     if (dirs.length === 0) return '';
     const list = dirs.map((d) => JSON.stringify(d)).join(',');
-    // Every ambient global goes through `globalThis.` — a BARE `imports` at byte 1
-    // binds to any top-level `const imports` a bundled module declares, which is
-    // still in its temporal dead zone there, and the bundle dies at load with
-    // `ReferenceError: can't access lexical declaration 'imports'`. The generated
-    // `@girs/gjs` shim declares exactly that, so this is not hypothetical —
-    // `process-stub-banner.spec.ts` pins the same rule for the process stub.
-    //
-    // Guarded probes rather than try/catch: none of these calls has a throw path
-    // (no `throws` in the GIR), so a catch here would have nothing to catch and
-    // would hide a real absence instead. What IS genuinely optional is the API
-    // itself — `Repository.dup_default` + the two prepends need GIRepository to be
-    // introspectable, and a host without it must degrade to a no-op rather than
-    // fail to start.
-    //
-    // Single line: the banner runs before any source-map-aware machinery, so a
-    // newline here shifts every bundle line number by one.
+    // Four rules, each pinned with its incident by `gi-runtime-paths-banner.spec.ts`:
+    // every ambient global through `globalThis.` (a bare `imports` at byte 1 binds to
+    // a bundled module's own top-level `const imports`, still in its TDZ); guarded
+    // probes, not try/catch (no call here has a throw path, so a catch would hide a
+    // real absence); one line (the banner precedes source-map-aware machinery); both
+    // prepends (search path alone finds the typelib, then fails the dlopen).
     return (
         `(function(){var i=globalThis.imports;if(!i||!i.gi||!i.system)return;` +
         `var R=i.gi.GIRepository;if(!R||!R.Repository||!R.Repository.dup_default)return;` +
         `var r=R.Repository.dup_default();if(!r||!r.prepend_search_path||!r.prepend_library_path)return;` +
         `var p=i.system.programPath||i.system.programInvocationName||'';` +
-        // Both separators, because the program path is the HOST's: on win32 it is
-        // `C:\…\main.js`, where a `/`-only cut yields nothing and the join below
-        // would silently produce a relative path. Same rule as
-        // `@gjsify/utils/core`'s `lastPathSeparatorIndex` (#1143).
+        // Both separators: the program path is the HOST's, and on win32 a `/`-only
+        // cut matches nothing (same rule as `lastPathSeparatorIndex`, #1143).
         `var m=/^(.*)[\\/\\\\][^\\/\\\\]*$/.exec(p);if(!m)return;` +
         `var b=m[1];for(var d of [${list}]){var f=b+'/'+d;r.prepend_search_path(f);r.prepend_library_path(f)}` +
         `})();`

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
@@ -1,0 +1,80 @@
+// Tell GI where a bundle's own typelibs and their backing libraries are — from
+// INSIDE the process, so a `--app gjs` bundle needs no launcher and no environment.
+//
+// WHAT THIS REPLACES
+//
+// `@gjsify/cli`'s launcher preamble globs `node_modules/**/prebuilds/<target>/` in
+// SHELL and exports `GI_TYPELIB_PATH` + `LD_LIBRARY_PATH`/`DYLD_FALLBACK_LIBRARY_PATH`
+// for the child. That works and costs a launcher: a bundle handed to a bare
+// `gjs -m bundle.mjs` gets none of it, and on macOS dies at the first widget because
+// gjs's own rpath points into glib's keg alone.
+//
+// MEASURED, not assumed (macOS 15.7.9 x86_64 VM + linux, gjs 1.88.1), under
+// `env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH -u GI_TYPELIB_PATH`:
+//
+//   no prepend                    → Failed to load shared library 'libgtk-4.1.dylib'
+//   prepend_search_path only      → typelib found, then the SAME dlopen failure
+//   both prepends                 → OK gtype: GtkWidget
+//
+// So both calls are load-bearing and neither is redundant. This is the same repair
+// `activateGiLibraryPath()` (#1132) makes in C for node-gi — `dup_default()` is its
+// `DupDefaultRepository()` — reached from JS instead. Details + the remaining gap in
+// `status/open-todos.md` § "A globally installed GJS launcher still cannot load a
+// system GTK on macOS".
+//
+// WHAT IT DOES NOT COVER
+//
+// A library pulled in through ANOTHER library's link closure (`LC_LOAD_DYLIB` /
+// `NEEDED`). The loader resolves those and GI never sees them, so only
+// `@rpath`/`$ORIGIN` in the binaries reaches them (ADR 0023 § 4).
+//
+// WHY RELATIVE PATHS, RESOLVED AT RUNTIME
+//
+// A baked absolute path is the build machine's, so a shipped app would carry
+// directories that do not exist on the user's disk. The dirs are therefore emitted
+// relative to the PROGRAM, and joined against `system.programPath`'s directory when
+// the bundle starts.
+
+/**
+ * The byte-1 prologue that prepends `dirs` to the default repository's typelib
+ * search path and library path.
+ *
+ * Returns `''` for an empty list: emitting a no-op prologue would put a guard in
+ * every bundle that can never do anything, and a banner that is not there cannot
+ * drift.
+ *
+ * @param dirs directories RELATIVE to the program's own directory, `/`-separated
+ */
+export function giRuntimePathsStub(dirs: readonly string[]): string {
+    if (dirs.length === 0) return '';
+    const list = dirs.map((d) => JSON.stringify(d)).join(',');
+    // Every ambient global goes through `globalThis.` — a BARE `imports` at byte 1
+    // binds to any top-level `const imports` a bundled module declares, which is
+    // still in its temporal dead zone there, and the bundle dies at load with
+    // `ReferenceError: can't access lexical declaration 'imports'`. The generated
+    // `@girs/gjs` shim declares exactly that, so this is not hypothetical —
+    // `process-stub-banner.spec.ts` pins the same rule for the process stub.
+    //
+    // Guarded probes rather than try/catch: none of these calls has a throw path
+    // (no `throws` in the GIR), so a catch here would have nothing to catch and
+    // would hide a real absence instead. What IS genuinely optional is the API
+    // itself — `Repository.dup_default` + the two prepends need GIRepository to be
+    // introspectable, and a host without it must degrade to a no-op rather than
+    // fail to start.
+    //
+    // Single line: the banner runs before any source-map-aware machinery, so a
+    // newline here shifts every bundle line number by one.
+    return (
+        `(function(){var i=globalThis.imports;if(!i||!i.gi||!i.system)return;` +
+        `var R=i.gi.GIRepository;if(!R||!R.Repository||!R.Repository.dup_default)return;` +
+        `var r=R.Repository.dup_default();if(!r||!r.prepend_search_path||!r.prepend_library_path)return;` +
+        `var p=i.system.programPath||i.system.programInvocationName||'';` +
+        // Both separators, because the program path is the HOST's: on win32 it is
+        // `C:\…\main.js`, where a `/`-only cut yields nothing and the join below
+        // would silently produce a relative path. Same rule as
+        // `@gjsify/utils/core`'s `lastPathSeparatorIndex` (#1143).
+        `var m=/^(.*)[\\/\\\\][^\\/\\\\]*$/.exec(p);if(!m)return;` +
+        `var b=m[1];for(var d of [${list}]){var f=b+'/'+d;r.prepend_search_path(f);r.prepend_library_path(f)}` +
+        `})();`
+    );
+}

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
@@ -12,8 +12,7 @@
 // later via `--globals auto` (which injects @gjsify/node-globals/register/process).
 //
 // Kept as a single line: the banner runs before any source-map-aware
-// machinery, so newlines here would shift every line number by one. Single
-// line = zero source-map drift for the actual bundle code below.
+// machinery, so newlines here would shift every line number by one.
 import type { Plugin } from 'rolldown';
 
 import { BUNDLE_URL_BANNER } from './bundle-url-banner.js';
@@ -27,30 +26,23 @@ import { giRuntimePathsStub } from './gi-runtime-paths.js';
 // in its temporal dead zone: `ReferenceError: can't access lexical declaration
 // 'imports' before initialization`, thrown at load, before a single line of
 // program code runs. `@girs/gjs`'s `gjs.js` declares exactly that
-// (`const imports = globalThis.imports || {}`), so the failure is real and
-// arrives whenever tree-shaking happens to retain that module. It was found
-// via `@gjsify/web-streams`, whose GJS test leg died the moment `@gjsify/utils`
-// became more shakeable — but nothing about it is specific to either package.
+// (`const imports = globalThis.imports || {}`), so the failure arrives whenever
+// tree-shaking happens to retain that module.
 export const GJS_PROCESS_STUB =
     'if(typeof globalThis.process==="undefined"){' +
     'const _s=globalThis.imports.system,_G=globalThis.imports.gi.GLib;' +
-    // process.hrtime needs a `.bigint` property attached to the function
-    // itself (Node API shape: `process.hrtime.bigint()` — used by execa,
-    // perf-tracking libs, …). Build it as a named local so we can
-    // attach the property before stashing it on the stub object.
+    // `process.hrtime.bigint()` is the shape execa and perf-tracking libs reach
+    // for, so `.bigint` has to hang off the function itself.
     'const _h=t=>t?[0,0]:[0,0];_h.bigint=()=>0n;' +
-    // `platform`/`arch`, answered LAZILY by the same `uname -sm` probe
-    // `@gjsify/process` uses (`packages/node/process/src/internal/uname.ts`),
-    // with `@gjsify/utils`' `platform-names.ts` mapping tables inlined minimally
-    // — a banner runs before the module system exists and cannot import the
-    // canonical ones. Those two are the source of truth; keep this in step or a
-    // bundle answers differently depending on whether it pulled
-    // `@gjsify/process` in. These used to be the literals `"linux"`/`"x64"`,
-    // which is a WRONG answer on two of three OSes rather than a missing one.
-    // Lazy, so the cost falls only on a bundle that reads the field AND never
-    // loads `@gjsify/process` (whose register replaces this object): nothing is
-    // spawned at load. Windows is answered from the environment — `uname` is not
-    // on a native Windows PATH, and the env answer is exact.
+    // `platform`/`arch` from the same `uname -sm` probe `@gjsify/process` uses
+    // (`packages/node/process/src/internal/uname.ts`) plus `@gjsify/utils`'
+    // `platform-names.ts` tables, inlined minimally because a banner runs before
+    // the module system exists. Those two are the source of truth; keep this in
+    // step or a bundle answers differently depending on whether it pulled
+    // `@gjsify/process` in. These used to be the literals `"linux"`/`"x64"` — a
+    // WRONG answer on two of three OSes rather than a missing one. Lazy, so
+    // nothing is spawned at load. Windows is answered from the environment:
+    // `uname` is not on a native Windows PATH, and the env answer is exact.
     'let _pc;const _p=()=>{if(_pc)return _pc;_pc={platform:"linux",arch:"x64"};' +
     'try{' +
     'if(_G.getenv("OS")==="Windows_NT"||_G.getenv("SystemRoot")){' +
@@ -87,17 +79,10 @@ export const GJS_PROCESS_STUB =
     '}';
 
 /**
- * Compose the GJS process stub with the user-supplied banner so the result
- * is valid syntax for `gjs -m`. A leading `#!shebang` line in the user
- * banner is hoisted to byte 0 of the output. Any `#` character that appears
- * anywhere except byte 0 is a fatal SyntaxError under SpiderMonkey 128+ —
- * putting our process stub before the user's shebang would break the bundle.
- *
- * Output shape:
- *   [#!shebang\n][<process-stub>\n<rest-of-user-banner>]
- *
- * Either side of the bracket may be empty; the result is always concatenated
- * without leading whitespace.
+ * Compose the GJS process stub with the user-supplied banner so the result is
+ * valid syntax for `gjs -m`, hoisting a leading `#!shebang` to byte 0: a `#`
+ * anywhere except byte 0 is a fatal SyntaxError under SpiderMonkey 128+, so
+ * putting the stub before the user's shebang would break the bundle.
  */
 export function composeBanner(stub: string, userBanner: string): string {
     if (!userBanner) return stub;
@@ -110,13 +95,6 @@ export function composeBanner(stub: string, userBanner: string): string {
     return shebang + stub + (rest ? '\n' + rest : '');
 }
 
-/**
- * Build a Rolldown plugin that injects the GJS process stub as a chunk
- * banner. Runs with `enforce: 'post'`-equivalent ordering so the stub
- * lands *after* any user `output.banner` value, except when the user
- * banner starts with a `#!shebang` line — which is hoisted to byte 0
- * by `composeBanner`.
- */
 export interface ProcessStubPluginOptions {
     /** User-supplied banner string. May contain a leading `#!shebang`. */
     userBanner?: string;
@@ -135,15 +113,13 @@ export interface ProcessStubPluginOptions {
     giRuntimePaths?: readonly string[];
 }
 
+/** Inject the byte-1 banner as a chunk banner, after any user `output.banner`. */
 export function processStubPlugin(options: ProcessStubPluginOptions = {}): Plugin {
-    // The anchor capture must precede the process stub so it runs at the very
-    // top of the chunk (where `import.meta.url` is the bundle's own URL). The
-    // well-known-symbols polyfill must also run before any module init, so it
-    // joins the byte-1 banner. All three pieces are single-line (no source-map
-    // drift) and idempotent.
-    // The GI path prologue goes LAST of the three: it reads `imports.system`, which
-    // the process stub does not provide and does not disturb, and it must still run
-    // before any module init so the first `gi://` import already sees the paths.
+    // Order is load-bearing: the anchor capture first, because `import.meta.url`
+    // is the bundle's own URL only at the very top of the chunk; the GI path
+    // prologue last, because it reads `imports.system`, which the process stub
+    // neither provides nor disturbs. Everything here runs before module init and
+    // is single-line and idempotent.
     const stub =
         (options.captureBundleUrl ? BUNDLE_URL_BANNER : '') +
         GJS_WELLKNOWN_SYMBOLS_STUB +

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/process-stub.ts
@@ -18,6 +18,7 @@ import type { Plugin } from 'rolldown';
 
 import { BUNDLE_URL_BANNER } from './bundle-url-banner.js';
 import { GJS_WELLKNOWN_SYMBOLS_STUB } from './wellknown-symbols-banner.js';
+import { giRuntimePathsStub } from './gi-runtime-paths.js';
 
 // Every GJS ambient global is reached through `globalThis.` — NEVER as a bare
 // identifier. The banner shares the module's top-level scope with the bundled
@@ -124,6 +125,14 @@ export interface ProcessStubPluginOptions {
      * ESM-only — set by the orchestrator when `format === 'esm'`.
      */
     captureBundleUrl?: boolean;
+    /**
+     * Directories, RELATIVE to the program's own directory, holding typelibs and
+     * their backing libraries. Emitted as a byte-1 prologue that hands them to GI at
+     * runtime, so the bundle needs no `GI_TYPELIB_PATH` / loader-path environment and
+     * therefore no launcher (see `gi-runtime-paths.ts` for the measurement).
+     * Empty or unset emits nothing.
+     */
+    giRuntimePaths?: readonly string[];
 }
 
 export function processStubPlugin(options: ProcessStubPluginOptions = {}): Plugin {
@@ -132,7 +141,14 @@ export function processStubPlugin(options: ProcessStubPluginOptions = {}): Plugi
     // well-known-symbols polyfill must also run before any module init, so it
     // joins the byte-1 banner. All three pieces are single-line (no source-map
     // drift) and idempotent.
-    const stub = (options.captureBundleUrl ? BUNDLE_URL_BANNER : '') + GJS_WELLKNOWN_SYMBOLS_STUB + GJS_PROCESS_STUB;
+    // The GI path prologue goes LAST of the three: it reads `imports.system`, which
+    // the process stub does not provide and does not disturb, and it must still run
+    // before any module init so the first `gi://` import already sees the paths.
+    const stub =
+        (options.captureBundleUrl ? BUNDLE_URL_BANNER : '') +
+        GJS_WELLKNOWN_SYMBOLS_STUB +
+        GJS_PROCESS_STUB +
+        giRuntimePathsStub(options.giRuntimePaths ?? []);
     const banner = composeBanner(stub, options.userBanner ?? '');
     return {
         name: 'gjsify-process-stub',

--- a/scripts/check-comment-budget.mjs
+++ b/scripts/check-comment-budget.mjs
@@ -120,6 +120,25 @@ function measure() {
 /** @param {{code: number, comment: number}} t */
 const ratio = (t) => (t.code === 0 ? 0 : t.comment / t.code);
 
+// One part in 2000, absorbing the rounding in the committed ceiling so a
+// re-baselined tree does not fail its own value.
+const TOLERANCE = 0.0005;
+
+/**
+ * The most comment lines a tree may hold and still pass — the ONE number both the
+ * verdict and the advice are read off, so they cannot disagree.
+ *
+ * They did: the gate compared the ratio against `ceiling + TOLERANCE` while the
+ * advice reported against `ceiling * code`, so the message asked for a cut the gate
+ * did not require, by a margin that scaled with the tree — 6 lines on
+ * `packages/infra`, 44 on `packages/node`. The message directly below names what
+ * has to survive a trim (the incident behind a rule, GI quirks, error text); an
+ * inflated number is spent on exactly that material.
+ *
+ * @param {number} ceiling @param {number} code
+ */
+const allowedComments = (ceiling, code) => Math.floor((ceiling + TOLERANCE) * code);
+
 const mode = process.argv.includes('--check') ? 'check' : process.argv.includes('--update') ? 'update' : 'print';
 
 const totals = measure();
@@ -151,11 +170,12 @@ for (const area of AREAS) {
     if (t.files === 0) continue;
     const have = ratio(t);
     const ceiling = budget[area];
-    // Tolerance of one part in 2000 absorbs the rounding in the committed value,
-    // so a re-baselined tree does not fail its own ceiling.
-    const over = ceiling !== undefined && have > ceiling + 0.0005;
+    // Compared in LINES, not in ratios, so the verdict and the "cut N lines" advice
+    // are the same statement. Exactly equivalent to `have > ceiling + TOLERANCE`.
+    const allowed = ceiling === undefined ? Number.POSITIVE_INFINITY : allowedComments(ceiling, t.code);
+    const over = t.comment > allowed;
     rows.push({ area, ...t, have, ceiling, over });
-    if (over) failures.push({ area, have, ceiling, comment: t.comment, code: t.code });
+    if (over) failures.push({ area, have, ceiling, comment: t.comment, allowed });
 }
 
 const pad = (s, n) => String(s).padEnd(n);
@@ -192,11 +212,10 @@ for (const area of unbudgeted) {
 if (mode !== 'check') process.exit(stale.length + unbudgeted.length > 0 ? 1 : 0);
 
 for (const f of failures) {
-    const allowed = Math.floor(f.ceiling * f.code);
     process.stderr.write(
         `\ncheck-comment-budget: ${f.area} is at ${f.have.toFixed(3)} comment lines per code line, ` +
-            `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines against ` +
-            `${f.code} code lines, about ${f.comment - allowed} more than the ceiling allows.\n` +
+            `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines, ` +
+            `${f.comment - f.allowed} more than the ${f.allowed} this tree's ceiling allows.\n` +
             '  Comment WHY, not WHAT: a comment that restates the code is a second copy that drifts.\n' +
             '  What usually has to go: restatement, narrative history ("previously we…", "ported from…"),\n' +
             '  upstream source coordinates a reader cannot act on, and change-log entries git already has.\n' +

--- a/scripts/check-comment-budget.mjs
+++ b/scripts/check-comment-budget.mjs
@@ -175,7 +175,7 @@ for (const area of AREAS) {
     const allowed = ceiling === undefined ? Number.POSITIVE_INFINITY : allowedComments(ceiling, t.code);
     const over = t.comment > allowed;
     rows.push({ area, ...t, have, ceiling, over });
-    if (over) failures.push({ area, have, ceiling, comment: t.comment, allowed });
+    if (over) failures.push({ area, have, ceiling, comment: t.comment, code: t.code, allowed });
 }
 
 const pad = (s, n) => String(s).padEnd(n);
@@ -214,8 +214,9 @@ if (mode !== 'check') process.exit(stale.length + unbudgeted.length > 0 ? 1 : 0)
 for (const f of failures) {
     process.stderr.write(
         `\ncheck-comment-budget: ${f.area} is at ${f.have.toFixed(3)} comment lines per code line, ` +
-            `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines, ` +
-            `${f.comment - f.allowed} more than the ${f.allowed} this tree's ceiling allows.\n` +
+            `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines against ` +
+            `${f.code} code lines, ${f.comment - f.allowed} more than the ${f.allowed} that ceiling allows. ` +
+            `Cutting ${f.comment - f.allowed} passes; cutting more than that is spending headroom you do not owe.\n` +
             '  Comment WHY, not WHAT: a comment that restates the code is a second copy that drifts.\n' +
             '  What usually has to go: restatement, narrative history ("previously we…", "ported from…"),\n' +
             '  upstream source coordinates a reader cannot act on, and change-log entries git already has.\n' +


### PR DESCRIPTION
Follow-up to #1151, which measured this. **The seam, with tests — not yet the finished
feature** (see *Deliberately unfinished* below).

## The problem

A `--app gjs` bundle learns where its typelibs and their backing libraries are from the
**environment**, exported by the CLI launcher after globbing
`node_modules/**/prebuilds/<target>/` in shell. Handed to a bare `gjs -m bundle.mjs` it learns
nothing — and on macOS dies at the first widget, because gjs's own rpath points into glib's keg
alone.

## The change

`giRuntimePathsStub()` emits a byte-1 prologue that tells GI at **runtime**:
`Repository.dup_default()` + `prepend_search_path` + `prepend_library_path`. Same repair
`activateGiLibraryPath()` (#1132) makes in C for node-gi — `dup_default()` *is* its
`DupDefaultRepository()` — reached from JS.

## Measured, not assumed

macOS 15.7.9 x86_64 VM **and** linux, gjs 1.88.1, under
`env -u DYLD_FALLBACK_LIBRARY_PATH -u DYLD_LIBRARY_PATH -u GI_TYPELIB_PATH`:

| | |
|---|---|
| no prepend | `Failed to load shared library 'libgtk-4.1.dylib'` |
| `prepend_search_path` only | typelib found, then the **same** dlopen failure |
| both prepends | **`OK gtype: GtkWidget`** |

The middle row is the control that makes `prepend_library_path` load-bearing rather than
decoration — and it is why the spec asserts both calls.

## The two byte-1 rules it obeys, and why

- **Every ambient global through `globalThis.`** A bare `imports` at byte 1 binds to the
  generated `@girs/gjs` shim's top-level `const imports`, still in its temporal dead zone, and
  the bundle dies at load. `process-stub-banner.spec.ts` already pins this for the process stub;
  this spec pins it for the prologue.
- **One line.** The banner precedes any source-map-aware machinery.

Plus: paths are emitted **relative to the program** and joined at startup (a baked absolute path
is the *build machine's*), and the program dir is cut on **either** separator, because that path
is the host's and on win32 a `/`-only cut matches nothing (#1143). Guarded probes, no
`try`/`catch` — none of these calls has a throw path, so a catch would have nothing to catch and
would hide a real absence. An empty list emits **nothing**, rather than a prologue that can never
act.

## Verification, including the negative control

`@gjsify/cli` 2079 tests pass (up from 2055). Both checks that make that number mean something:

1. **Did the suite run?** The first green run did **not** include it — `test:node` fires a
   prebuilt bundle, so 2055 passed while the new file was never executed. Exactly the shape #1044
   describes. With a rebuild: 2079, suite visible.
2. **Does it catch the incident?** Reverting the prologue to a bare `imports` fails **exactly one
   of 2073** tests — this one. The test pins the incident, not itself.

## Deliberately unfinished, and why it is stated here

`giRuntimePaths` is an option **nothing populates yet**, so this ships the mechanism, not the
behaviour change. Two follow-ups, both recorded in `status/open-todos.md` under the launcher
entry:

- **CLI-side population** from the native packages it already detects. Two of the three path
  sources (gjsify's own `prebuilds/<target>`, a chosen GTK bundle's `libDir`) are relative to the
  app tree and need nothing new.
- **The system dirs** need `systemGiLibraryDirs()`, which lives in `@gjsify/node-gi` — a package
  with exactly **one** dependency (`node-addon-api`) and not a workspace member. Importing it from
  a bundle, or giving it a `@gjsify/utils` dependency, both change a posture that looks
  deliberate, so that stays an explicit decision rather than a drive-by.

**What this does not fix:** a library pulled in through another library's link closure. The
loader resolves those and GI never sees them — only `@rpath`/`$ORIGIN` reaches them
([ADR 0023 § 4](docs/adr/0023-gtk-source-precedence.md)), which is why #1144 is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added after review of the first CI run

The first run went red on `Detect runtime-triplet drift` — `check-comment-budget --check`, `packages/infra` at 0.456 against a ceiling of 0.450. Three commits followed, and the second and third are a defect the first one uncovered.

**`docs(rolldown-plugin-gjsify): cut restatement`.** The check was right. `gi-runtime-paths.ts` arrived with 66 comment lines above 13 code lines — ratio 5.1, the exact shape the budget exists to stop. Measurement that shaped the response: the tree was at **exactly** 0.450 before this branch, because `--update` re-baselines to the measured value, so every tree it has cleaned carries zero headroom and the next comment-adding commit pays. Raising the ceiling would have spent a reviewed allowance on prose, so the allowance is earned back instead — the launcher narrative and the macOS measurement table were already the subject of `status/open-todos.md` and ADR 0023 §4, and the file now points at them. Every incident survives; both emitted banners are byte-identical to the previous commit (478 and 1944 bytes), so the eight banner specs cannot have changed meaning.

**`fix: one number for the budget verdict and advice`.** Following the red check surfaced a defect in the check itself: it decided in ratios and advised in lines, and the two formulas were not the same one. The gate compares `have > ceiling + 0.0005`; the advice computed `floor(ceiling * code)` and dropped the tolerance. The gap is `0.0005 * code`, so it scales with the tree — 6 lines on `packages/infra`, 14 on `packages/infra/cli`, **44 on `packages/node`**. Measured here: the gate needed 67 lines cut, the message asked for 73.

That matters because of what sits directly under the number — a list of what must survive a trim (the incident behind a rule, GI/GNOME quirks, spec links, error text). Anyone trimming to the printed figure over-cuts by up to 44 lines, and the surplus comes out of exactly the material the check protects.

Fixed by removing the second formula rather than syncing it: `allowedComments()` returns the most comment lines a tree may hold, the verdict becomes `comment > allowed`, the advice reports `comment - allowed`. Comparing in **lines** rather than ratios is what makes them one statement — a shared constant would only have made them agree today. Provably equivalent to the old predicate; verified against the true threshold (the largest comment count that still passes) at three ceilings on `packages/infra`: 0.400 → 4927, 0.300 → 3697, 0.440 → 5419, exact in all three.

**`fix: say what a passing trim looks like`.** The message now prints the target alongside the overage and states that cutting past it is not required.

### Verification

`gjsify format --check` clean, `gjsify workspace @gjsify/rolldown-plugin-gjsify run check` exit 0, comment budget green. `gjsify lint` exits 1 in this working tree, entirely from an **untracked** `showcases/dom/adwaita-widgets-nativescript/.ns-vite-build/` (2899 findings in generated vendor bundles) belonging to unrelated in-progress work; **0 findings outside it**. That directory is in neither `.gitignore` nor `.oxlintrc.json` and will turn the lint step red for everyone once the showcase lands — flagged to the session that owns it, not fixed here.

### Also filed

A second facet on #1149, measured on this branch: the `docs` commit above was comment-only and could not change the bundle, yet the pre-commit hook spent **over five minutes** rebuilding `affected.gjs.mjs` to produce a zero-byte diff. The trigger is wrong in both directions — too narrow (real staleness slips through, the original report) and too wide (rebuilds that cannot matter) — because it asks which paths were staged instead of whether the artifact still matches its inputs.
