### PR TITLE
fix: print each tree's remaining comment headroom

### DIFF
--- a/scripts/check-comment-budget.mjs
+++ b/scripts/check-comment-budget.mjs
@@ -174,20 +174,26 @@ for (const area of AREAS) {
     // are the same statement. Exactly equivalent to `have > ceiling + TOLERANCE`.
     const allowed = ceiling === undefined ? Number.POSITIVE_INFINITY : allowedComments(ceiling, t.code);
     const over = t.comment > allowed;
-    rows.push({ area, ...t, have, ceiling, over });
+    rows.push({ area, ...t, have, ceiling, allowed, over });
     if (over) failures.push({ area, have, ceiling, comment: t.comment, code: t.code, allowed });
 }
 
 const pad = (s, n) => String(s).padEnd(n);
 const lpad = (s, n) => String(s).padStart(n);
+// `spare` is printed while PASSING too, and that is the point: it is the number a
+// reader wants before spending it, and the obvious way to work it out by hand —
+// `ceiling * code` — is the very formula this script stopped using, so leaving it
+// unprinted invites the wrong arithmetic. Both authors of the change that added it
+// computed a margin by hand and both got it too low.
 process.stdout.write(
-    `${pad('area', 32)}${lpad('files', 6)}${lpad('code', 9)}${lpad('comment', 9)}${lpad('ratio', 8)}${lpad('ceiling', 9)}\n`,
+    `${pad('area', 32)}${lpad('files', 6)}${lpad('code', 9)}${lpad('comment', 9)}${lpad('ratio', 8)}${lpad('ceiling', 9)}${lpad('spare', 7)}\n`,
 );
 for (const r of rows) {
+    const spare = Number.isFinite(r.allowed) ? r.allowed - r.comment : '-';
     process.stdout.write(
         `${pad(r.area, 32)}${lpad(r.files, 6)}${lpad(r.code, 9)}${lpad(r.comment, 9)}` +
             `${lpad(r.have.toFixed(3), 8)}${lpad(r.ceiling === undefined ? '-' : r.ceiling.toFixed(3), 9)}` +
-            `${r.over ? '  OVER' : ''}\n`,
+            `${lpad(spare, 7)}${r.over ? '  OVER' : ''}\n`,
     );
 }
 
@@ -217,6 +223,8 @@ for (const f of failures) {
             `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines against ` +
             `${f.code} code lines, ${f.comment - f.allowed} more than the ${f.allowed} that ceiling allows. ` +
             `Cutting ${f.comment - f.allowed} passes; cutting more than that is spending headroom you do not owe.\n` +
+            '  This is a RATIO, so DELETING CODE raises it: a commit that only removes dead code,\n' +
+            '  adding no comment at all, can land here. Check the code column before assuming otherwise.\n' +
             '  Comment WHY, not WHAT: a comment that restates the code is a second copy that drifts.\n' +
             '  What usually has to go: restatement, narrative history ("previously we…", "ported from…"),\n' +
             '  upstream source coordinates a reader cannot act on, and change-log entries git already has.\n' +


### PR DESCRIPTION
Follow-up to #1152, closing the two cheap fixes measured in #1157.

## Print the balance, not just the verdict

`check-comment-budget` printed ratio and ceiling and stopped, so the one number a reader acts on — comment lines still free — had to be computed by hand. The obvious hand computation is `ceiling * code`, which is exactly the formula #1152 removed from this script, so not printing it invited the wrong arithmetic.

That is measured, not supposed: while #1152 was open, **two people independently computed a margin for `scripts/` by hand and both got it too low**, by 4 and 5 lines, both by omitting the tolerance. Neither had a reason to open the script — the number simply was not on offer.

`spare` is printed while **passing**, which is the point. A budget is spent before it is exceeded, and the moment to see the balance is while there still is one.

```
area                             files     code  comment   ratio  ceiling  spare
packages/infra/cli                 199    29479    12547   0.426    0.426     25
packages/infra                     118    12304     5542   0.450    0.450      0
packages/node-gi                   165    18785     8146   0.434    0.434     16
packages/node                      514    87986    14486   0.165    0.186   1923
scripts                             60     8684     5034   0.580    0.583     33
website                             14     1142      194   0.170    0.170      0
```

## It corrects a reading the old table encouraged

A tree whose ratio and ceiling **print** the same is not necessarily at zero. Both are rounded to three decimals, and the tolerance buys lines in proportion to tree size:

| tree | displayed | true ratio | spare |
|---|---|---|---|
| `packages/infra/cli` | 0.426 / 0.426 | 0.42563 | **25** |
| `packages/node-gi` | 0.434 / 0.434 | 0.43364 | **16** |
| `packages/infra` | 0.450 / 0.450 | 0.45042 | 0 |
| `website` | 0.170 / 0.170 | 0.16988 | 0 |

Exactly **two** trees are genuinely at zero, not the four an equal display suggests. I asserted the wrong version of this in #1157 — inferred from the display — and it is corrected there. The old table could not have told anyone otherwise, which is the argument for the column.

## Deleting code fails this check

Second change, in the failure message. It is a ratio: removing code raises it. A commit that only deletes dead code and adds no comment at all can land on this gate. That surprised a contributor on #1156 — a retired `--update` block took ~10 code lines out and the tree's margin dropped without a comment being written — and nothing anywhere said so.

## Verification

`gjsify format --check` clean; `node scripts/check-comment-budget.mjs --check` exit 0 with the new column; failure path exercised by temporarily lowering a ceiling. `gjsify lint` exits 1 in this working tree from an unrelated untracked directory with **zero** findings in this file.

### Cost to `scripts/`, stated because #1157 is about exactly this

This PR spends 3 of that tree's lines (36 → 33). #1156 is open against the same tree and needs 11; if this lands first it keeps ~8. Both stay green, and the point of saying so is that neither PR's own CI can see the other.