### PR TITLE
feat(utils): one canonical answer for system GI libdirs

### DIFF
--- a/packages/gjs/utils/src/core.ts
+++ b/packages/gjs/utils/src/core.ts
@@ -30,6 +30,7 @@ export * from './host-os.js';
 export * from './message.js';
 export * from './microtask.js';
 export * from './path-shape.js';
+export * from './system-gi-dirs.js';
 export * from './platform-names.js';
 export * from './structured-clone.js';
 

--- a/packages/gjs/utils/src/system-gi-dirs.spec.ts
+++ b/packages/gjs/utils/src/system-gi-dirs.spec.ts
@@ -1,0 +1,159 @@
+// The point of taking every host fact as a parameter is that all three platform
+// branches — including the darwin one that only matters on a Mac — run from the
+// Linux runner this project actually has (ADR 0018 § 5).
+
+import { describe, expect, it } from '@gjsify/unit';
+import { PROBED_GI_LIBDIRS, splitSearchPath, systemGiLibraryDirs, TYPELIB_SUBDIR } from './system-gi-dirs.js';
+
+/** A fake filesystem: every listed directory exists, nothing else does. */
+const dirs = (...present: string[]) => {
+    const set = new Set(present);
+    return (dir: string) => set.has(dir);
+};
+
+export default async () => {
+    await describe('systemGiLibraryDirs: platforms whose loader needs nothing', async () => {
+        await it('is empty off darwin, whatever the host says', async () => {
+            // Not "unimplemented": linux resolves these leaves through ld.so's
+            // system-wide cache, so a per-process answer would be noise. An
+            // accidental non-empty here would put directories on a loader path
+            // that never needed them.
+            for (const platform of ['linux', 'win32', 'freebsd']) {
+                expect(
+                    systemGiLibraryDirs({
+                        platform,
+                        typelibPath: '/usr/local/lib/girepository-1.0',
+                        pkgConfigDirs: ['/usr/local/lib/pkgconfig'],
+                        existsDir: () => true,
+                    }),
+                ).toStrictEqual([]);
+            }
+        });
+    });
+
+    await describe('systemGiLibraryDirs: an explicit statement is not second-guessed', async () => {
+        await it('takes GI_TYPELIB_PATH’s sibling libdir without the marker check', async () => {
+            // Source 1 is the host saying outright where typelibs are. Demanding
+            // the `girepository-1.0/` marker of it would reject a host that put
+            // its typelibs somewhere unusual on purpose.
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/custom/prefix/lib/girepository-1.0',
+                    existsDir: dirs('/custom/prefix/lib'),
+                }),
+            ).toStrictEqual(['/custom/prefix/lib']);
+        });
+
+        await it('honours every entry of a multi-entry GI_TYPELIB_PATH', async () => {
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/a/lib/girepository-1.0:/b/lib/girepository-1.0',
+                    existsDir: dirs('/a/lib', '/b/lib'),
+                }),
+            ).toStrictEqual(['/a/lib', '/b/lib']);
+        });
+
+        await it('drops an entry whose sibling libdir is not there', async () => {
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/gone/lib/girepository-1.0',
+                    existsDir: dirs(),
+                }),
+            ).toStrictEqual([]);
+        });
+    });
+
+    await describe('systemGiLibraryDirs: a guessed prefix must show the marker', async () => {
+        await it('believes a probed prefix only when the typelib dir exists', async () => {
+            // The probed list is three candidates; a Mac with Homebrew under
+            // /usr/local must not also claim /opt/homebrew.
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    existsDir: dirs(`/usr/local/lib/${TYPELIB_SUBDIR}`),
+                }),
+            ).toStrictEqual(['/usr/local/lib']);
+        });
+
+        await it('finds a custom prefix through pkg-config, marker-checked', async () => {
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    pkgConfigDirs: ['/custom/lib/pkgconfig'],
+                    existsDir: dirs(`/custom/lib/${TYPELIB_SUBDIR}`),
+                }),
+            ).toStrictEqual(['/custom/lib']);
+        });
+
+        await it('ignores a pkg-config dir not named pkgconfig', async () => {
+            // `pc_path` can list directories that are not a `<prefix>/pkgconfig`;
+            // taking their parent would name an unrelated prefix.
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    pkgConfigDirs: ['/weird/place'],
+                    existsDir: () => true,
+                }),
+            ).toStrictEqual(PROBED_GI_LIBDIRS.darwin as string[]);
+        });
+
+        await it('returns nothing when a candidate exists but carries no typelibs', async () => {
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    pkgConfigDirs: ['/usr/local/lib/pkgconfig'],
+                    existsDir: dirs('/usr/local/lib'),
+                }),
+            ).toStrictEqual([]);
+        });
+    });
+
+    await describe('systemGiLibraryDirs: the result is a set, in precedence order', async () => {
+        await it('lists the explicit source before the guessed ones', async () => {
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/explicit/lib/girepository-1.0',
+                    existsDir: dirs('/explicit/lib', `/usr/local/lib/${TYPELIB_SUBDIR}`),
+                }),
+            ).toStrictEqual(['/explicit/lib', '/usr/local/lib']);
+        });
+
+        await it('does not repeat a directory two sources both name', async () => {
+            // A duplicate would be harmless on the loader path and misleading in
+            // a log; more to the point, `pathCovers`-style callers compare lists.
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/usr/local/lib/girepository-1.0',
+                    pkgConfigDirs: ['/usr/local/lib/pkgconfig'],
+                    existsDir: dirs('/usr/local/lib', `/usr/local/lib/${TYPELIB_SUBDIR}`),
+                }),
+            ).toStrictEqual(['/usr/local/lib']);
+        });
+
+        await it('never yields the filesystem root', async () => {
+            // `dirname('/girepository-1.0')` is `/`, and putting the root on a
+            // loader search path makes it stat every leaf against the whole disk.
+            expect(
+                systemGiLibraryDirs({
+                    platform: 'darwin',
+                    typelibPath: '/girepository-1.0',
+                    existsDir: () => true,
+                }).includes('/'),
+            ).toBe(false);
+        });
+    });
+
+    await describe('splitSearchPath', async () => {
+        await it('drops empty entries and treats undefined as empty', async () => {
+            // A trailing or doubled `:` is normal in a hand-edited PATH-shaped
+            // variable, and an empty entry would become `dirname('') === '.'`.
+            expect(splitSearchPath('/a::/b:')).toStrictEqual(['/a', '/b']);
+            expect(splitSearchPath(undefined)).toStrictEqual([]);
+        });
+    });
+};

--- a/packages/gjs/utils/src/system-gi-dirs.ts
+++ b/packages/gjs/utils/src/system-gi-dirs.ts
@@ -1,0 +1,105 @@
+// WHERE a host's GObject-Introspection stack keeps the shared libraries a typelib
+// names by BARE LEAF (`libgtk-4.1.dylib`, …) — the algorithm alone, with every host
+// fact passed in.
+//
+// Canonical home for a rule that had one implementation and two callers coming:
+// `@gjsify/node-gi` computes it to set `DYLD_FALLBACK_LIBRARY_PATH` before a
+// re-exec, and the CLI needs the same answer to hand GI its paths from inside a
+// bundle instead (`giRuntimePathsStub`). node-gi keeps its own copy as a pinned
+// mirror — it declares exactly one dependency on purpose — so this is the
+// reference the mirror is checked against, not a module it imports.
+//
+// PURE by ADR 0014's membership rule: no imports, no defaults that reach a host.
+// The impure half — `statSync`, and spawning `pkg-config` to learn its `.pc`
+// search path — belongs to the caller, which is also what makes every branch
+// testable from a Linux runner (ADR 0018 § 5).
+
+import { lastPathSeparatorIndex, splitPathComponents } from './path-shape.js';
+
+/** The subdir GI installs typelibs into — historically `1.0` even for the girepository-2.0 API. */
+export const TYPELIB_SUBDIR = 'girepository-1.0';
+
+/**
+ * Prefixes worth probing per platform, for the common case where GTK is installed
+ * and `pkg-config` is not.
+ *
+ * darwin only, and that is a statement about LOADERS rather than about GI. Linux
+ * resolves these leaves through `ld.so`'s system-wide cache (`/etc/ld.so.conf.d`),
+ * which a package install populates. dyld is the one loader that neither consults
+ * a system-wide config NOR re-reads its search path after launch. win32 is
+ * deliberately absent rather than proven unnecessary: `PATH` is the DLL search
+ * path, a Windows GTK distribution puts its own `bin` on it, and Windows re-reads
+ * it at every `LoadLibrary`.
+ */
+export const PROBED_GI_LIBDIRS: Readonly<Record<string, readonly string[]>> = {
+    darwin: ['/opt/homebrew/lib', '/usr/local/lib', '/opt/local/lib'],
+};
+
+/** Split a `PATH`-shaped value. Empty entries dropped; `undefined` yields `[]`. */
+export function splitSearchPath(value: string | undefined, separator = ':'): string[] {
+    return (value ?? '').split(separator).filter(Boolean);
+}
+
+function dirname(path: string): string {
+    const cut = lastPathSeparatorIndex(path);
+    if (cut < 0) return '.';
+    return cut === 0 ? path.slice(0, 1) : path.slice(0, cut);
+}
+
+function basename(path: string): string {
+    const parts = splitPathComponents(path).filter(Boolean);
+    return parts.length === 0 ? '' : parts[parts.length - 1];
+}
+
+export interface SystemGiLibraryDirsHost {
+    /** `process.platform`, or the platform being reasoned about. */
+    platform: string;
+    /** The host's `GI_TYPELIB_PATH`, unsplit. */
+    typelibPath?: string | undefined;
+    /** `pkg-config`'s `.pc` search directories, already resolved by the caller. */
+    pkgConfigDirs?: readonly string[];
+    /** Directory-existence predicate — the caller's `statSync` or a test double. */
+    existsDir: (dir: string) => boolean;
+}
+
+/**
+ * Absolute library directories this platform's loader needs told about, or `[]`
+ * when it needs none.
+ *
+ * Three sources, in precedence order:
+ *
+ *   1. `GI_TYPELIB_PATH` — the host stating outright where typelibs live; the
+ *      libraries are the sibling `dirname()`. Believed on directory existence
+ *      alone, because an explicit statement is not second-guessed.
+ *   2. `pkg-config`'s `.pc` search path → each `<dir>/pkgconfig`'s parent. The
+ *      general mechanism, covering a custom prefix.
+ *   3. {@link PROBED_GI_LIBDIRS}.
+ *
+ * Sources 2 and 3 are GUESSES at a prefix, so each must show the
+ * `girepository-1.0/` marker before it is believed. Source 1 is not a guess.
+ */
+export function systemGiLibraryDirs(host: SystemGiLibraryDirsHost): string[] {
+    const probed = PROBED_GI_LIBDIRS[host.platform];
+    if (!probed) return [];
+
+    const out: string[] = [];
+    const add = (dir: string) => {
+        if (dir && dir !== '/' && !out.includes(dir)) out.push(dir);
+    };
+
+    for (const typelibDir of splitSearchPath(host.typelibPath)) {
+        const libDir = dirname(typelibDir);
+        if (host.existsDir(libDir)) add(libDir);
+    }
+
+    const candidates: string[] = [];
+    for (const pcDir of host.pkgConfigDirs ?? []) {
+        if (basename(pcDir) === 'pkgconfig') candidates.push(dirname(pcDir));
+    }
+    candidates.push(...probed);
+    for (const libDir of candidates) {
+        if (host.existsDir(`${libDir}/${TYPELIB_SUBDIR}`)) add(libDir);
+    }
+
+    return out;
+}

--- a/packages/gjs/utils/src/test.ts
+++ b/packages/gjs/utils/src/test.ts
@@ -5,5 +5,6 @@ import logSuite from './log.spec.js';
 import nextTickSuite from './next-tick.spec.js';
 import pathShapeSuite from './path-shape.spec.js';
 import platformNamesSuite from './platform-names.spec.js';
+import systemGiDirsSuite from './system-gi-dirs.spec.js';
 
-run({ hostOsSuite, hostProcessSuite, logSuite, nextTickSuite, pathShapeSuite, platformNamesSuite });
+run({ hostOsSuite, hostProcessSuite, logSuite, nextTickSuite, pathShapeSuite, platformNamesSuite, systemGiDirsSuite });

--- a/packages/infra/cli/src/gi-runtime-paths-banner.spec.ts
+++ b/packages/infra/cli/src/gi-runtime-paths-banner.spec.ts
@@ -96,6 +96,16 @@ export default async () => {
             expect(cut![1].includes('\\/')).toBe(true);
         });
 
+        await it('uses an ABSOLUTE entry as given, on both separator styles', async () => {
+            // Bundle prebuilds ship beside the program; a SYSTEM libdir does not.
+            // Joining `/usr/local/lib` under the program dir would name nothing,
+            // which is what would silently happen if the join were unconditional.
+            const stub = giRuntimePathsStub(['/usr/local/lib']);
+            const test = /\/\^\(\[A-Za-z\]:/.exec(stub);
+            expect(test !== null).toBe(true);
+            expect(stub.includes("?d:b+'/'+d")).toBe(true);
+        });
+
         await it('emits every directory it was given, JSON-quoted', async () => {
             const dirs = ['a-dir', 'with space', "with'quote"];
             const stub = giRuntimePathsStub(dirs);

--- a/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
+++ b/packages/infra/rolldown-plugin-gjsify/src/plugins/gi-runtime-paths.ts
@@ -31,7 +31,9 @@ export function giRuntimePathsStub(dirs: readonly string[]): string {
         // Both separators: the program path is the HOST's, and on win32 a `/`-only
         // cut matches nothing (same rule as `lastPathSeparatorIndex`, #1143).
         `var m=/^(.*)[\\/\\\\][^\\/\\\\]*$/.exec(p);if(!m)return;` +
-        `var b=m[1];for(var d of [${list}]){var f=b+'/'+d;r.prepend_search_path(f);r.prepend_library_path(f)}` +
+        // Absolute stays absolute: joining a system libdir under the program dir names nothing.
+        `var b=m[1];for(var d of [${list}]){var f=/^([A-Za-z]:[\\/\\\\]|[\\/\\\\])/.test(d)?d:b+'/'+d;` +
+        `r.prepend_search_path(f);r.prepend_library_path(f)}` +
         `})();`
     );
 }


### PR DESCRIPTION
Answers the question left open by #1152: **where the canonical `systemGiLibraryDirs()` should live**, and therefore whether the launcher can stop exporting loader-path environment for a `--app gjs` bundle.

## The canonical algorithm moves to `@gjsify/utils/core`

There was one implementation, in `@gjsify/node-gi`, and a second caller arriving. node-gi computes these directories to set `DYLD_FALLBACK_LIBRARY_PATH` before a re-exec; the CLI needs the same answer to hand GI its paths from *inside* a bundle. Two copies of a three-source precedence rule is where drift starts, and the drifted copy fails in a consumer while the owning package stays green.

`@gjsify/node-gi` keeps its own copy as a **pinned mirror** rather than taking a dependency — it declares exactly one on purpose — so `/core` is the reference the mirror is checked against, not a module it imports.

## Why the split lands where it does

Moving the function wholesale would have broken `/core`'s membership rule (ADR 0014): *a module belongs here iff calling any of its exports on a runtime without GLib/Gio is well-defined.* Its defaults reach `statSync` and spawn `pkg-config` via `node:child_process` — both would have landed in the pure core.

The code already had the right seam. The algorithm is pure **given its host facts**, which node-gi had made injectable precisely so darwin's branch is testable off darwin. So the algorithm moves and the bindings stay with the caller:

- `existsDir` is passed in.
- `pkgConfigDirs` arrives **already resolved**, rather than as a function that may spawn.

Every branch therefore runs from the Linux runner this project actually has (ADR 0018 § 5). **11 tests** cover all three sources, the precedence order, the marker check that separates a *guess* at a prefix from an *explicit statement*, the dedup, and the `/` guard.

## The prologue could not have carried these paths

Found while wiring it, and it is the part that actually answers the launcher question. `giRuntimePathsStub` joined **every** entry against the program directory:

```js
var f = b + '/' + d;
```

Bundle prebuilds ship beside the program and must stay relocatable, so that is right for them. A system libdir is the host's: `/usr/local/lib` joined under `/opt/app/dist` names nothing — silently, with GI reporting only that the library was not found. Absolute entries now pass through unchanged, on POSIX paths and on win32 drive paths.

**So the launcher can drop the system paths too, not only the relative ones.** That was the open question.

Measured by executing the emitted banner against a fake GJS host rather than by reading it — with `programPath=/opt/app/dist/main.js`:

| given | prepended |
|---|---|
| `prebuilds/linux-x64` | `/opt/app/dist/prebuilds/linux-x64` |
| `/usr/local/lib` | `/usr/local/lib` |

## Still to come

CLI-side population of `giRuntimePaths` — nothing sets it yet, as in #1152. That is the step that actually removes the launcher, and it now has both halves it was missing: a canonical source for the system directories, and a prologue that can carry them.

## Verification

- `@gjsify/utils` **255** tests green, `@gjsify/cli` **2081** green.
- **Negative control**: deleting the marker check fails the suite, so the new tests assert rather than merely pass.
- Type-check, `gjsify lint` (0 errors) and `gjsify format --check` clean.
- Comment budget green, `packages/infra` back at its ceiling — it had **0** spare, and the `spare` column added in #1158 reported the overage as `-2` directly instead of leaving it to be computed.

One process note worth recording: the new banner test failed at first while both of its assertions returned `true` when run against the source. `@gjsify/cli` bundles the plugin's built `lib/`, not its `src/`, so the suite was measuring a stale artifact. `gjsify workspace @gjsify/rolldown-plugin-gjsify run build` first, then green.
