### PR TITLE
feat(storybook): the overview leads, the stage is tinted, and two NS gestures measured

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -244,6 +244,15 @@ jobs:
       - name: Check every storybook story exists on all three targets
         run: node scripts/check-storybook-story-parity.mjs
 
+      # Story-set parity says the same stories EXIST; it cannot say the reader meets
+      # them in the same order. That order was a by-product of enumeration — a path
+      # glob on two targets, a hand-written list on the third — and a comment claiming
+      # the two mirrored each other was the only thing holding it. They did not:
+      # `Overview` led one sidebar and sat fifth, below the fold, on another, which
+      # reads as the overview being missing rather than as an ordering difference.
+      - name: Check every storybook category is placed by the declaration
+        run: node scripts/check-storybook-category-order.mjs
+
       # A NativeScript widget's className and the theme's selector are two halves of
       # one decision that nothing compares. Renaming the shortcut-label keycap class
       # from `keycap` to `adw-keycap` was measured: 3221 tests stayed GREEN while
@@ -537,6 +546,15 @@ jobs:
       # others is the one state where no comparison is possible at all.
       - name: Check every storybook story exists on all three targets
         run: node scripts/check-storybook-story-parity.mjs
+
+      # Story-set parity says the same stories EXIST; it cannot say the reader meets
+      # them in the same order. That order was a by-product of enumeration — a path
+      # glob on two targets, a hand-written list on the third — and a comment claiming
+      # the two mirrored each other was the only thing holding it. They did not:
+      # `Overview` led one sidebar and sat fifth, below the fold, on another, which
+      # reads as the overview being missing rather than as an ordering difference.
+      - name: Check every storybook category is placed by the declaration
+        run: node scripts/check-storybook-category-order.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of
       # one decision that nothing compares. Renaming the shortcut-label keycap class

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -258,6 +258,14 @@ jobs:
       # from `keycap` to `adw-keycap` was measured: 3221 tests stayed GREEN while
       # every keycap lost its fill, radius, padding and minimum width. The renderer
       # spec cannot see it — it reads the same constant the widget writes.
+      # AdwExpanderRow extends GridLayout, so no off-device spec can construct one —
+      # which is how its entire expand affordance stayed a 16-unit chevron on the port
+      # whose targets are fingers (#1155). Measured on the emulator: a NativeScript tap
+      # does NOT stop at the child that handles it, so toggling from the row's own tap
+      # would collapse the row whenever a user touched anything nested inside it.
+      - name: Check disclosure toggles are wired to the header, not the whole row
+        run: node scripts/check-nativescript-disclosure-toggles.mjs
+
       - name: Check the NativeScript theme styles every class its widgets emit
         run: node scripts/check-nativescript-theme-classes.mjs
 
@@ -561,6 +569,14 @@ jobs:
       # from `keycap` to `adw-keycap` was measured: 3221 tests stayed GREEN while
       # every keycap lost its fill, radius, padding and minimum width. The renderer
       # spec cannot see it — it reads the same constant the widget writes.
+      # AdwExpanderRow extends GridLayout, so no off-device spec can construct one —
+      # which is how its entire expand affordance stayed a 16-unit chevron on the port
+      # whose targets are fingers (#1155). Measured on the emulator: a NativeScript tap
+      # does NOT stop at the child that handles it, so toggling from the row's own tap
+      # would collapse the row whenever a user touched anything nested inside it.
+      - name: Check disclosure toggles are wired to the header, not the whole row
+        run: node scripts/check-nativescript-disclosure-toggles.mjs
+
       - name: Check the NativeScript theme styles every class its widgets emit
         run: node scripts/check-nativescript-theme-classes.mjs
 

--- a/packages/framework/storybook-core/src/category-order.spec.ts
+++ b/packages/framework/storybook-core/src/category-order.spec.ts
@@ -1,0 +1,65 @@
+// @gjsify/storybook-core — sidebar category order tests.
+// Runs on GJS + Node + browser (pure TS, no platform imports).
+
+import { describe, expect, it } from '@gjsify/unit';
+import { STORYBOOK_CATEGORY_ORDER, orderCategories } from './category-order.js';
+
+export default async () => {
+    await describe('orderCategories', async () => {
+        await it('sorts listed categories into the declared order', () => {
+            // Deliberately handed in REVERSED, because the defect this replaces
+            // was the input order leaking through untouched.
+            const input = [...STORYBOOK_CATEGORY_ORDER].reverse();
+            expect(orderCategories(input)).toStrictEqual([...STORYBOOK_CATEGORY_ORDER]);
+        });
+
+        await it('leads with Overview, whatever position it arrived in', () => {
+            // The reported symptom: a glob put Overview fifth, which reads as the
+            // gallery being absent rather than as an ordering difference.
+            const globOrder = ['Buttons', 'Feedback', 'Layout', 'Navigation', 'Overview', 'Presentation'];
+            expect(orderCategories(globOrder)[0]).toBe('Overview');
+        });
+
+        await it('keeps a subset in declared order without inventing absent categories', () => {
+            expect(orderCategories(['Feedback', 'Buttons', 'Overview'])).toStrictEqual([
+                'Overview',
+                'Buttons',
+                'Feedback',
+            ]);
+        });
+
+        await it('appends unlisted categories after every listed one', () => {
+            expect(orderCategories(['Chrome', 'Buttons', 'Rows'])).toStrictEqual(['Buttons', 'Chrome', 'Rows']);
+        });
+
+        await it('keeps unlisted categories in arrival order', () => {
+            // Partitioning, not sorting: an unrecognised prefix must not be
+            // reordered against its peers just because it is unrecognised.
+            expect(orderCategories(['Rows', 'Chrome'])).toStrictEqual(['Rows', 'Chrome']);
+            expect(orderCategories(['Chrome', 'Rows'])).toStrictEqual(['Chrome', 'Rows']);
+        });
+
+        await it('drops nothing and duplicates nothing', () => {
+            const input = ['Feedback', 'Zebra', 'Overview', 'Aardvark', 'Layout'];
+            const out = orderCategories(input);
+            expect(out.length).toBe(input.length);
+            expect([...out].sort()).toStrictEqual([...input].sort());
+        });
+
+        await it('does not mutate its argument', () => {
+            const input = ['Feedback', 'Overview'];
+            orderCategories(input);
+            expect(input).toStrictEqual(['Feedback', 'Overview']);
+        });
+
+        await it('returns an empty list unchanged', () => {
+            expect(orderCategories([])).toStrictEqual([]);
+        });
+    });
+
+    await describe('STORYBOOK_CATEGORY_ORDER', async () => {
+        await it('names each category once', () => {
+            expect(new Set(STORYBOOK_CATEGORY_ORDER).size).toBe(STORYBOOK_CATEGORY_ORDER.length);
+        });
+    });
+};

--- a/packages/framework/storybook-core/src/category-order.ts
+++ b/packages/framework/storybook-core/src/category-order.ts
@@ -1,0 +1,57 @@
+// The sidebar's category order — declared once, for every renderer.
+//
+// WHY THIS EXISTS. The order used to be a by-product of how each target happened
+// to ENUMERATE its stories, and the three targets enumerate differently: the GTK
+// and NativeScript storybooks take a path glob (so the order was alphabetical by
+// `<category-dir>/<file>`), while the browser target has a hand-written import
+// list. Nothing reconciled the two, so the reader met a different first screen
+// per target — `Overview` led the browser sidebar and sat FIFTH, below the fold,
+// on the GTK one, which reads as "the overview is missing" rather than as an
+// ordering difference. That is exactly how it was reported.
+//
+// A comment in the browser's list asserted the two "mirror" each other while they
+// measurably did not, which is the second half of the same defect: the only thing
+// holding an invariant across three files was a sentence, and the sentence was
+// wrong. So the order moves HERE, where all three renderers already share a
+// `StorybookController`, and `scripts/check-storybook-category-order.mjs` holds
+// the declaration against the categories the stories actually carry.
+//
+// The order itself is editorial, not mechanical: the gallery first, then the
+// plain presentational widgets, then rows, then the structural widgets that need
+// a page around them to make sense. Alphabetical would put Feedback and Layout
+// ahead of the boxed lists that make up most of the set.
+
+/**
+ * The category order every storybook renders its sidebar in.
+ *
+ * A category NOT listed here still renders — it sorts after every listed one,
+ * keeping discovery order among its peers — because a storybook that drops a
+ * story on an unrecognised prefix would hide work rather than surface it. The
+ * build gate is what makes the omission visible.
+ */
+export const STORYBOOK_CATEGORY_ORDER: readonly string[] = [
+    'Overview',
+    'Presentation',
+    'Boxed Lists',
+    'Buttons',
+    'Layout',
+    'View Switching',
+    'Navigation',
+    'Feedback',
+];
+
+/**
+ * Order `categories` by {@link STORYBOOK_CATEGORY_ORDER}, appending unlisted ones
+ * in the order they arrived.
+ *
+ * Stable by construction: it partitions rather than sorts, so two unlisted
+ * categories keep their discovery order instead of depending on a comparator's
+ * tie-breaking.
+ */
+export function orderCategories(categories: readonly string[]): string[] {
+    const rank = new Map(STORYBOOK_CATEGORY_ORDER.map((name, index) => [name, index]));
+    const listed = [...categories].filter((name) => rank.has(name));
+    listed.sort((a, b) => rank.get(a)! - rank.get(b)!);
+    const unlisted = categories.filter((name) => !rank.has(name));
+    return [...listed, ...unlisted];
+}

--- a/packages/framework/storybook-core/src/controller.spec.ts
+++ b/packages/framework/storybook-core/src/controller.spec.ts
@@ -102,6 +102,24 @@ export default async () => {
             expect(view.shown).not.toBeNull();
         });
 
+        await it('lands on the story the sidebar leads with, not the one found first', () => {
+            // The two were the same list until categories gained a declared
+            // order. Discovery hands `Buttons` over first here while the sidebar
+            // has to lead with `Overview`; reading the landing story off the
+            // registry instead opens a story the sidebar does not show at the
+            // top, which is what the reordering first shipped.
+            const view = new MockView();
+            const controller = new StorybookController<MockStory>(view, () => []);
+            controller.mount([
+                makeModule({ title: 'Buttons/Button Content', controls: [] }),
+                makeModule({ title: 'Overview/Widgets', controls: [] }),
+            ]);
+
+            expect(view.sidebar.map((g) => g.category)).toStrictEqual(['Overview', 'Buttons']);
+            expect(view.selectedTitle).toBe('Overview/Widgets');
+            expect(view.previewTitle).toBe('Overview/Widgets — Default');
+        });
+
         await it('honours openFirst=false', () => {
             const view = new MockView();
             const controller = new StorybookController<MockStory>(view, () => []);

--- a/packages/framework/storybook-core/src/controller.ts
+++ b/packages/framework/storybook-core/src/controller.ts
@@ -5,6 +5,7 @@
 // {@link StorybookView} (render seams) plus a `buildControls` builder.
 
 import type { StoryArgs, StoryArgValue, StoryControl } from '@gjsify/stories';
+import { orderCategories } from './category-order.js';
 import type { ControlRow } from './controls.js';
 import { StoryRegistry, type StoryModuleLike } from './registry.js';
 
@@ -75,15 +76,21 @@ export class StorybookController<TInstance extends StoryInstanceLike> {
 
     /**
      * Register + instantiate `modules`, render the sidebar, and (when
-     * `openFirst`) select the first story.
+     * `openFirst`) select the story the sidebar lists first.
      */
     mount(modules: StoryModuleLike<TInstance, new () => TInstance>[], openFirst = true): void {
         this._registry.registerStories(modules);
         const instantiated = this._registry.createStoryInstances();
-        this._view.renderSidebar(this._groupByCategory(instantiated), (instance) => this.select(instance));
+        const groups = this._groupByCategory(instantiated);
+        this._view.renderSidebar(groups, (instance) => this.select(instance));
 
         if (openFirst) {
-            const first = this._firstStory();
+            // The landing story is read off the SIDEBAR, not the registry.
+            // Those were the same list until the categories gained a declared
+            // order; taking it from the registry again would open a story the
+            // sidebar does not lead with, which is a stranger first impression
+            // than either order on its own.
+            const first = groups[0]?.stories[0]?.instance ?? null;
             if (first) this.select(first);
         }
     }
@@ -128,7 +135,14 @@ export class StorybookController<TInstance extends StoryInstanceLike> {
                 byCategory.get(category)!.push({ instance, name: name || 'Unnamed' });
             }
         }
-        return [...byCategory].map(([category, stories]) => ({ category, stories }));
+        // Categories follow the DECLARED order, not the order the modules were
+        // enumerated in — a path glob on two targets and a hand-written list on
+        // the third, which is how one story set grew three different first
+        // screens. Stories WITHIN a category keep discovery order.
+        return orderCategories([...byCategory.keys()]).map((category) => ({
+            category,
+            stories: byCategory.get(category)!,
+        }));
     }
 
     // --- MCP / devtools control surface (mirrors all three apps) ---
@@ -181,11 +195,4 @@ export class StorybookController<TInstance extends StoryInstanceLike> {
         return null;
     }
 
-    private _firstStory(): TInstance | null {
-        for (const module of this._registry.getStories()) {
-            const first = (module.instances ?? [])[0];
-            if (first) return first;
-        }
-        return null;
-    }
 }

--- a/packages/framework/storybook-core/src/controller.ts
+++ b/packages/framework/storybook-core/src/controller.ts
@@ -194,5 +194,4 @@ export class StorybookController<TInstance extends StoryInstanceLike> {
         }
         return null;
     }
-
 }

--- a/packages/framework/storybook-core/src/index.ts
+++ b/packages/framework/storybook-core/src/index.ts
@@ -10,6 +10,7 @@ export * from './story-view-base.js';
 export * from './registry.js';
 export * from './controls.js';
 export * from './controller.js';
+export * from './category-order.js';
 export * from './discover.js';
 export * from './devtools.js';
 export * from './settings.js';

--- a/packages/framework/storybook-core/src/test.browser.mts
+++ b/packages/framework/storybook-core/src/test.browser.mts
@@ -9,6 +9,7 @@ import storyViewBaseTestSuite from './story-view-base.spec.js';
 import registryTestSuite from './registry.spec.js';
 import controlsTestSuite from './controls.spec.js';
 import controllerTestSuite from './controller.spec.js';
+import categoryOrderTestSuite from './category-order.spec.js';
 import discoverTestSuite from './discover.spec.js';
 
 run({
@@ -16,5 +17,6 @@ run({
     registryTestSuite,
     controlsTestSuite,
     controllerTestSuite,
+    categoryOrderTestSuite,
     discoverTestSuite,
 });

--- a/packages/framework/storybook-core/src/test.mts
+++ b/packages/framework/storybook-core/src/test.mts
@@ -4,6 +4,7 @@ import storyViewBaseTestSuite from './story-view-base.spec.js';
 import registryTestSuite from './registry.spec.js';
 import controlsTestSuite from './controls.spec.js';
 import controllerTestSuite from './controller.spec.js';
+import categoryOrderTestSuite from './category-order.spec.js';
 import discoverTestSuite from './discover.spec.js';
 import settingsTestSuite from './settings.spec.js';
 
@@ -12,6 +13,7 @@ run({
     registryTestSuite,
     controlsTestSuite,
     controllerTestSuite,
+    categoryOrderTestSuite,
     discoverTestSuite,
     settingsTestSuite,
 });

--- a/packages/framework/storybook/src/story-widget.ts
+++ b/packages/framework/storybook/src/story-widget.ts
@@ -42,8 +42,8 @@ function buildGtkChrome(bin: Adw.Bin): StoryChrome<Gtk.Widget> {
         spacing: 12,
         hexpand: true,
     });
-    // Subtle dashed frame so the preview's bounds are visible even when the
-    // widget itself is transparent or in an empty state (see `.story-stage`).
+    // Tinted stage so the preview's bounds are visible even when the widget
+    // itself is transparent or in an empty state (see `.story-stage`).
     content.add_css_class('story-stage');
 
     group.add(content);

--- a/packages/framework/storybook/src/styles.ts
+++ b/packages/framework/storybook/src/styles.ts
@@ -92,13 +92,30 @@ export const STORYBOOK_CSS = `
     background-color: @window_bg_color;
 }
 
-/* Subtle dashed frame around the live preview so the widget's bounds stay
-   locatable even when it is transparent or in an empty state (e.g. a collapsed
-   bottom sheet, a status page, a bare button). @window_fg_color flips with the
-   theme (alpha(currentColor, …) does not resolve in a Gtk.CssProvider). */
+/* The live preview's stage. It has to stay LOCATABLE even when the widget on it
+   is transparent or in an empty state (a collapsed bottom sheet, a status page,
+   a bare button) — that requirement is why a frame was here at all. A dashed
+   border met it by drawing attention to itself; two corner tints meet it by
+   giving the stage a surface, which is what the widget gallery on the website
+   does and what this mirrors.
+
+   BOTH SCHEMES, WITHOUT BRANCHING. A Gtk.CssProvider string cannot ask which
+   colour scheme is active, so the tint is named rather than spelled out:
+   @accent_color is libadwaita's STANDALONE accent, defined as the accent moved
+   to a lightness that reads against the current scheme's background
+   (oklab min(l, 0.5) in light, max(l, 0.85) in dark — _colors.scss:25,88). It is
+   therefore correct in both by construction, and it follows a runtime accent, so
+   the stage is never blue while the widgets are orange. The website hardcodes
+   #3584e4 / #78aeed for the same two states, which is this name resolved by hand.
+
+   The purple counter-tint has no named equivalent and stays a literal, as it is
+   on the website — it is decoration, not a role, and it is the same hue in both
+   schemes there too. */
 .story-stage {
-    border: 1px dashed alpha(@window_fg_color, 0.28);
     border-radius: 12px;
     padding: 18px;
+    background-image:
+        radial-gradient(circle at 0% 0%, alpha(@accent_color, 0.07), transparent 45%),
+        radial-gradient(circle at 100% 100%, alpha(#926ee4, 0.06), transparent 45%);
 }
 `;

--- a/packages/nativescript-bridge/adwaita/src/accent-theme.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/accent-theme.spec.ts
@@ -16,10 +16,14 @@ export default async () => {
             await it(`${vector.name} fills with the palette colour and shades with the derivation`, () => {
                 expect(adwaitaNsAccentColor(vector.name, 'fill')).toBe(vector.background);
                 // The shade is `min(l, 0.5)` — libadwaita's "this colour, darker".
-                // It is NOT the dark-scheme standalone: both shade sites in the theme
-                // are already scheme-specific through their own selector.
+                // It is NOT the dark-scheme standalone: every shade site in the theme
+                // is already scheme-specific through its own selector.
                 expect(adwaitaNsAccentColor(vector.name, 'shade')).toBe(vector.standaloneLight);
                 expect(adwaitaNsAccentColor(vector.name, 'shade')).not.toBe(vector.standaloneDark);
+                // And the third role is that other branch, `max(l, 0.85)`: accent TEXT
+                // on a dark page has to go LIGHTER, the opposite of a press fill.
+                // Collapsing the two is what left four dark rules unreachable (#1154).
+                expect(adwaitaNsAccentColor(vector.name, 'standalone-dark')).toBe(vector.standaloneDark);
             });
         }
     });
@@ -46,9 +50,12 @@ export default async () => {
             expect(css.includes(adwaitaAccentBgColor('green'))).toBe(true);
             expect(css.includes(adwaitaAccentColor('green', false))).toBe(true);
             // The literals the theme hardcodes must be gone, or the override is a
-            // no-op that looks like a change.
+            // no-op that looks like a change. `#78aeed` is here because it was the
+            // one that WAS a no-op: unclassified, so four dark accent-text rules kept
+            // painting blue under every accent (#1154).
             expect(css.includes('#3584e4')).toBe(false);
             expect(css.includes('#1c71d8')).toBe(false);
+            expect(css.includes('#78aeed')).toBe(false);
         });
 
         await it('keeps the dark-scheme selectors scoped', () => {
@@ -60,9 +67,22 @@ export default async () => {
             for (const rule of dark) expect(css.includes(`${rule.selector} {`)).toBe(true);
         });
 
-        await it('covers both roles, so neither shade site is left behind', () => {
+        await it('uses every role, so no site is left behind', () => {
             const roles = new Set(ADWAITA_NS_ACCENT_RULES.map((rule) => rule.role));
-            expect([...roles].sort()).toStrictEqual(['fill', 'shade']);
+            expect([...roles].sort()).toStrictEqual(['fill', 'shade', 'standalone-dark']);
+        });
+
+        await it('gives the three roles three DIFFERENT colours', () => {
+            // A role that resolves to the same colour as another is a role in name
+            // only: it would look covered in the table and repaint nothing new. Worth
+            // asserting because `shade` and `standalone-dark` are the two branches of
+            // one derivation, and passing the wrong boolean silently merges them.
+            for (const accent of ['blue', 'orange', 'slate'] as const) {
+                const colours = (['fill', 'shade', 'standalone-dark'] as const).map((role) =>
+                    adwaitaNsAccentColor(accent, role),
+                );
+                expect(new Set(colours).size).toBe(3);
+            }
         });
     });
 };

--- a/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
+++ b/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
@@ -1582,9 +1582,9 @@ Page.ns-dark.adw-window {
  *
  * It carries the SHADE role, the same one the light press uses — `.ns-dark
  * .adw-avatar` already spells a shade under a dark selector, and the role is
- * scheme-independent by construction (accent-theme.ts). The dark button press
- * two sections down instead hand-picks `#2c75d6`, which is a THIRD literal no
- * accent override can reach (#1154); this rule does not add a fourth. */
+ * scheme-independent by construction (accent-theme.ts). The dark button press two
+ * sections down used to hand-pick its own literal instead; #1154 made it carry
+ * this same role, so the two dark presses now agree. */
 .ns-dark .adw-image-button.adw-entry-apply:highlighted {
     background-color: #1c71d8;
 }
@@ -1688,8 +1688,16 @@ Page.ns-dark.adw-window {
     background-color: rgba(255, 255, 255, 0.22);
 }
 
+/* The SHADE, not a lighter press. libadwaita presses an opaque button — which is
+ * what `.suggested-action` extends — with `background-image: image(RGB(0 0 6 /
+ * 20%))`, a darkening overlay that is identical in both schemes
+ * (_buttons.scss:165-167). The lighter press two rules up belongs to the plain
+ * button, whose fill is itself an overlay; an accent button has no lighter state
+ * in either scheme. This used to hand-pick `#2c75d6`, a third literal the accent
+ * override could not reach, so the button turned orange and its pressed state
+ * flashed blue (#1154). */
 .ns-dark .adw-button.suggested-action:highlighted {
-    background-color: #2c75d6;
+    background-color: #1c71d8;
 }
 
 .ns-dark .adw-button.destructive-action:highlighted {

--- a/packages/nativescript-bridge/adwaita/src/widgets/accent-theme.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/accent-theme.ts
@@ -6,29 +6,46 @@
 // reassign. Changing the accent at runtime therefore means generating rules that
 // override those exact selectors and handing them to `Application.addCss`.
 //
-// TWO ROLES, NOT TWO CONSTANTS. The theme uses `#3584e4` for the accent fill and
-// `#1c71d8` for a DARKER variant (the pressed suggested-action, the dark-mode
-// avatar). `#1c71d8` is not the standalone colour — libadwaita derives `#0461be`
-// for blue — it is adwaita-web's legacy shade, so treating it as "standalone"
-// would put a text colour on a button. Both roles come from
-// `@gjsify/adwaita-core`: the fill from the palette, the darker one from the
-// `min(l, 0.5)` derivation, which is exactly "this accent, darkened".
+// ROLES, NOT CONSTANTS. The theme uses `#3584e4` for the accent fill and `#1c71d8`
+// for a DARKER variant (the pressed suggested-action, the dark-mode avatar).
+// `#1c71d8` is not the standalone colour — libadwaita derives `#0461be` for blue —
+// it is adwaita-web's legacy shade, so treating it as "standalone" would put a text
+// colour on a button. Both come from `@gjsify/adwaita-core`: the fill from the
+// palette, the darker one from the `min(l, 0.5)` derivation, which is exactly
+// "this accent, darkened".
+//
+// THE THIRD ROLE, and why it was missing (#1154). Four dark rules paint accent TEXT
+// (`.ns-dark` switch, view-switcher label, button-row title, active carousel dot)
+// with `#78aeed` — adwaita-web's dark `--accent-color`. The gate recognised two
+// literals, so this one was not a mismatch, it was INVISIBLE: under
+// `applyAdwaitaNsAccent('orange')` every one of those stayed blue. It is a real
+// role rather than drift, because a standalone accent on a dark background has to
+// be LIGHTENED to stay legible (libadwaita: oklab `max(l, 0.85)`), which is the
+// opposite of what `shade` does.
+//
+// The dark press shade that #1154 opened on, `#2c75d6`, was NOT a role: libadwaita
+// presses an opaque button with `background-image: image(RGB(0 0 6 / 20%))` — a
+// DARKENING overlay, the same in both schemes (_buttons.scss:165-167, via
+// `%opaque_button`). There is no lighter dark press for an accent button; the
+// lighter one belongs to the plain button. So it carries `shade`, like the light
+// press and like `.adw-entry-apply` already did.
 //
 // Free of `@nativescript/core` value imports so the spec suite exercises the
 // shipping generator; the applier that calls `Application.addCss` cannot be
 // imported off-device.
 //
 // The table below is kept honest by `scripts/check-nativescript-accent-rules.mjs`,
-// which fails the build when the theme declares an accent the table does not
-// cover. A hand-listed selector set with nothing checking it is how the theme and
-// its override drift apart.
+// which fails the build when the theme declares an accent the table does not cover
+// — and, since #1154, when the theme carries a colour the gate cannot CLASSIFY at
+// all, which is how `#78aeed` and `#2c75d6` stayed hidden. A hand-listed selector
+// set with nothing checking it is how the theme and its override drift apart.
 //
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
 import { adwaitaAccentBgColor, adwaitaAccentColor, type AdwAccentColorName } from '@gjsify/adwaita-core';
 
-/** Which of the two accent shades a declaration carries. */
-export type AccentRole = 'fill' | 'shade';
+/** Which accent shade a declaration carries. */
+export type AccentRole = 'fill' | 'shade' | 'standalone-dark';
 
 /** One accent-carrying declaration in `theme/adwaita.css`. */
 export interface AccentRule {
@@ -67,16 +84,39 @@ export const ADWAITA_NS_ACCENT_RULES: ReadonlyArray<AccentRule> = [
     { selector: '.adw-image-button.adw-entry-apply', property: 'background-color', role: 'fill' },
     { selector: '.adw-image-button.adw-entry-apply:highlighted', property: 'background-color', role: 'shade' },
     { selector: '.ns-dark .adw-button.suggested-action', property: 'background-color', role: 'fill' },
+    { selector: '.ns-dark .adw-button.suggested-action:highlighted', property: 'background-color', role: 'shade' },
     { selector: '.ns-dark .adw-avatar', property: 'background-color', role: 'shade' },
     { selector: '.ns-dark .adw-image-button.adw-entry-apply:highlighted', property: 'background-color', role: 'shade' },
+    // Accent TEXT on a dark page — the standalone role, lightened rather than
+    // darkened. These four were the invisible half of #1154.
+    { selector: '.ns-dark .adw-switch', property: 'color', role: 'standalone-dark' },
+    {
+        selector: '.ns-dark .adw-viewswitcherbar-button.active .adw-viewswitcherbar-button-label',
+        property: 'color',
+        role: 'standalone-dark',
+    },
+    // One entry, because the theme groups these two into one rule and the generated
+    // override has to reproduce the selector VERBATIM to win on source order.
+    {
+        selector: '.ns-dark .adw-button-row-title, .ns-dark .adw-button-row-start-icon',
+        property: 'color',
+        role: 'standalone-dark',
+    },
+    { selector: '.ns-dark .adw-carousel-dot.active', property: 'color', role: 'standalone-dark' },
 ];
 
 /** The colour for one role of `accent`. */
 export function adwaitaNsAccentColor(accent: AdwAccentColorName, role: AccentRole): string {
     // 'shade' is the `min(l, 0.5)` derivation — libadwaita's own "darker version of
-    // this colour", which is what the two shade sites want. It is NOT scheme
-    // dependent here: both sites are already scheme specific through their selector.
-    return role === 'fill' ? adwaitaAccentBgColor(accent) : adwaitaAccentColor(accent, false);
+    // this colour", which is what the shade sites want. It is not scheme dependent
+    // here: every one of them is already scheme specific through its selector.
+    //
+    // 'standalone-dark' is the SAME derivation with the dark branch, `max(l, 0.85)`.
+    // The two are not interchangeable and the difference is the point: a press fill
+    // must go darker than the accent, accent text on a dark page must go lighter.
+    // Sharing one role between them is what left four rules unreachable.
+    if (role === 'fill') return adwaitaAccentBgColor(accent);
+    return adwaitaAccentColor(accent, role === 'standalone-dark');
 }
 
 /**

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-expander-row.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-expander-row.ts
@@ -1,11 +1,12 @@
 // AdwExpanderRow — a Libadwaita-style expander row for NativeScript.
 //
 // Extends {@link AdwActionRow}: the inherited title/subtitle stack is the always-
-// visible header, a `[+]/[−]` disclosure `Button` sits in the suffix slot, and a
-// second grid row (spanning both columns) holds a `StackLayout` of child rows that
-// is revealed/collapsed by toggling its `visibility`. Mirrors `Adw.ExpanderRow`:
+// visible header, a chevron sits in the suffix slot, and a second grid row
+// (spanning both columns) holds a `StackLayout` of child rows that is
+// revealed/collapsed by toggling its `visibility`. Mirrors `Adw.ExpanderRow`:
 // `addRow(child)` appends to the disclosure, `expanded` get/set drives the reveal
-// and emits `notify::expanded`.
+// and emits `notify::expanded`. Tapping the HEADER toggles it — see the
+// constructor for which views carry that and the device measurement behind it.
 //
 // The disclosure STATE MACHINE (the expanded/collapsed toggle + notify-on-change)
 // is HEADLESS and lives in `@gjsify/adwaita-core` (ADR 0004) as {@link ExpanderState};
@@ -81,8 +82,7 @@ export class AdwExpanderRow extends AdwActionRow {
         this.setSuffix(toggle);
         this._toggle = toggle;
 
-        // The core state drives the reveal + chevron + notify; the chevron tap
-        // flips it.
+        // The core state drives the reveal + chevron + notify.
         this._state.subscribe((expanded) => {
             this._disclosure.visibility = expanded ? 'visible' : 'collapse';
             this._toggle.icon = expanded ? panUpSymbolic : panDownSymbolic;
@@ -93,9 +93,41 @@ export class AdwExpanderRow extends AdwActionRow {
             };
             this.notify(data);
         });
-        toggle.addEventListener('tap', () => {
+
+        // WHAT TOGGLES THE ROW, and why it is wired exactly here (#1155).
+        //
+        // libadwaita expands from the HEADER, and says why in the template:
+        // "The header row must be activatable to toggle expansion by clicking it"
+        // (adw-expander-row.ui:24-26 → activate_cb → adw-expander-row.c:94-98). It
+        // sets `activatable=False` on the expander itself and True on the inner
+        // header, so the REVEALED rows cannot toggle their own parent.
+        //
+        // This port has no inner header widget — it IS an AdwActionRow — so the
+        // targets are the header's own children: the title/subtitle stack, which
+        // fills the flexible column and therefore most of the header, plus the
+        // chevron. Both sit in grid row 0; the disclosure is row 1.
+        //
+        // MEASURED ON DEVICE, because the answer decides the shape and no
+        // off-device spec can reach it (`extends GridLayout` cannot be imported):
+        // a NativeScript `tap` does NOT stop at a child that handles it. A tap on a
+        // plain Label inside the disclosure fires its own listener AND the row's;
+        // so does a tap on a nested switch row. (A nested entry row fires neither —
+        // the native EditText consumes it.) So the tempting version, toggling from
+        // the row's own `tap` or from `activate()`, would collapse the row whenever
+        // a user touched anything inside it.
+        //
+        // For the same reason the chevron's listener is the ONLY one on the chevron:
+        // if the row itself also toggled, a chevron tap would toggle twice and read
+        // as dead. Siblings do not receive each other's taps, which is what makes
+        // two header-scoped listeners safe.
+        //
+        // The affordance was previously the chevron alone — a 16-unit square, on the
+        // port whose targets are fingers.
+        const toggleOnTap = () => {
             this._state.toggle();
-        });
+        };
+        this._textStack.addEventListener('tap', toggleOnTap);
+        toggle.addEventListener('tap', toggleOnTap);
     }
 
     /** Append a child row (or any view) to the disclosure container. */

--- a/packages/nativescript-bridge/storybook/src/story-view.ts
+++ b/packages/nativescript-bridge/storybook/src/story-view.ts
@@ -27,8 +27,8 @@ export type StoryArgsListener = (args: StoryArgs) => void;
  * Base class for NativeScript story views.
  *
  * Provides default chrome — a clamped boxed group (`AdwClamp` +
- * `AdwPreferencesGroup`) with a title + description above a centered,
- * dashed-framed preview "stage" — built programmatically with the
+ * `AdwPreferencesGroup`) with a title + description above a centered, tinted
+ * preview "stage" — built programmatically with the
  * `@gjsify/adwaita-nativescript` widgets + the Adwaita CSS classes. Simple
  * stories compose their preview by calling {@link addContent}; a subclass that
  * needs a bespoke layout passes its own root view to the constructor (then
@@ -102,9 +102,9 @@ export class StoryView extends StoryViewBase<View> {
         descLabel.textWrap = true;
         let hasDesc = false;
 
-        // Subtle dashed-frame stage so the preview's bounds stay locatable even
-        // when the widget is transparent or empty (mirrors the browser
-        // `.story-stage` and the native renderer's `.story-stage`).
+        // Tinted stage so the preview's bounds stay locatable even when the
+        // widget is transparent or empty (mirrors the browser `.story-stage`
+        // and the native renderer's `.story-stage`).
         const stage = new StackLayout();
         stage.orientation = 'vertical';
         stage.className = 'story-stage';

--- a/packages/nativescript-bridge/storybook/src/theme/storybook.css
+++ b/packages/nativescript-bridge/storybook/src/theme/storybook.css
@@ -137,16 +137,40 @@
 }
 
 /*
- * Centered, dashed-framed preview stage (mirrors the browser .story-stage and
- * the native renderer's .story-stage). NS supports a dashed border style.
+ * Centered, tinted preview stage (mirrors the browser .story-stage and the
+ * native renderer's .story-stage).
+ *
+ * The stage must stay LOCATABLE when the widget on it is transparent or in an
+ * empty state — that requirement is why it was framed at all, and two corner
+ * tints meet it with a surface instead of a dashed outline.
+ *
+ * TWO SUBSTITUTIONS THE NS CSS SUBSET FORCES, both deliberate:
+ *
+ * 1. No `radial-gradient` — the parser recognises `linear-gradient` and nothing
+ *    else (css/parser.js:424), and it parses ONE gradient per declaration, so
+ *    the other two targets' pair of corner circles becomes a single 135deg
+ *    sweep: accent in the top-left corner, purple in the bottom-right, clear
+ *    through the middle where the widget sits.
+ * 2. No custom properties, so the standalone accent the other two name
+ *    (@accent_color / var(--accent-color)) is spelled out per scheme — the same
+ *    two values adwaita-web resolves it to. A runtime accent therefore does NOT
+ *    reach this backdrop on NS, unlike the other two targets.
+ *
+ * The middle stop fades to a ZERO-ALPHA COPY of the tint rather than to
+ * `transparent`: `transparent` is rgba(0,0,0,0), and interpolating towards it
+ * pulls a grey through the centre wherever the renderer does not premultiply.
  */
 .story-stage {
-    border-width: 1;
-    border-color: rgba(0, 0, 0, 0.28);
-    border-style: dashed;
     border-radius: 12;
     padding: 18;
     margin: 12 0 0 0;
+    background-image: linear-gradient(
+        135deg,
+        rgba(28, 113, 216, 0.07) 0%,
+        rgba(28, 113, 216, 0) 45%,
+        rgba(146, 110, 228, 0) 55%,
+        rgba(146, 110, 228, 0.06) 100%
+    );
 }
 
 /* ===== Controls panel — a RIGHT overlay (sidebar_position=END) ===== */
@@ -250,4 +274,23 @@
 
 .ns-dark .sb-swatch.selected {
     border-color: #ffffff;
+}
+
+/* The preview stage's dark tint. Only the accent end changes: it carries the
+ * STANDALONE accent, which libadwaita lightens for a dark background
+ * (#1c71d8 → #78aeed), while the purple is decoration and is the same hue in
+ * both schemes — as it is on the website. Alphas rise slightly because a tint
+ * over #1d1d20 reads weaker than the same tint over white.
+ *
+ * The full compound is restated rather than only the changed stops: NS sums
+ * specificity FLAT (class, attribute and pseudo-class 10 each — css-selector.js
+ * :205,292) and there is no per-stop cascade for a gradient anyway. */
+.ns-dark .story-stage {
+    background-image: linear-gradient(
+        135deg,
+        rgba(120, 174, 237, 0.09) 0%,
+        rgba(120, 174, 237, 0) 45%,
+        rgba(146, 110, 228, 0) 55%,
+        rgba(146, 110, 228, 0.08) 100%
+    );
 }

--- a/packages/web/adwaita-storybook/src/story-element.ts
+++ b/packages/web/adwaita-storybook/src/story-element.ts
@@ -15,7 +15,7 @@ export type StoryArgsListener = (args: StoryArgs) => void;
  * Base class for browser story elements.
  *
  * Provides default chrome — a clamped boxed group with a title + description above a
- * centered, dashed-framed preview stage. Simple stories compose their preview by
+ * centered, tinted preview stage. Simple stories compose their preview by
  * calling {@link addContent}; a subclass needing a bespoke layout passes its own root
  * element to the constructor, and {@link addContent} is then a no-op.
  */

--- a/packages/web/adwaita-storybook/src/styles.ts
+++ b/packages/web/adwaita-storybook/src/styles.ts
@@ -203,7 +203,19 @@ export const STORYBOOK_WEB_CSS = `
     color: var(--window-fg-color);
 }
 
-/* Centered, dashed-framed preview stage (mirrors the native .story-stage). */
+/* Centered, tinted preview stage (mirrors the native .story-stage).
+
+   The stage has to stay LOCATABLE when the widget on it is transparent or empty
+   — that is why it was framed at all. Two corner tints do that with a surface
+   instead of a dashed outline, matching the widget gallery on the website.
+
+   BOTH SCHEMES, WITHOUT BRANCHING: --accent-color is the STANDALONE accent
+   (#1c71d8 light, #78aeed dark — _variables.scss:55, _theme.scss:33), already
+   flipped by the same media query and .theme-dark/.theme-light classes that
+   theme everything else here, so this rule needs no scheme of its own. It also
+   follows a runtime accent. The purple counter-tint is decoration rather than a
+   role and stays a literal, as it is on the website, where it is the same hue in
+   both schemes. */
 .story-stage {
     display: flex;
     flex-direction: column;
@@ -212,9 +224,11 @@ export const STORYBOOK_WEB_CSS = `
     gap: var(--spacing-m);
     padding: var(--spacing-l);
     margin-top: var(--spacing-s);
-    border: 1px dashed rgba(127, 127, 127, 0.28);
     border-radius: var(--card-radius);
     min-height: 80px;
+    background-image:
+        radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent-color) 7%, transparent), transparent 45%),
+        radial-gradient(circle at 100% 100%, color-mix(in srgb, #926ee4 6%, transparent), transparent 45%);
 }
 
 /* --- Controls panel --- */

--- a/scripts/check-nativescript-accent-rules.mjs
+++ b/scripts/check-nativescript-accent-rules.mjs
@@ -27,8 +27,37 @@ const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..
 const THEME = join(ROOT, 'packages/nativescript-bridge/adwaita/src/theme/adwaita.css');
 const TABLE = join(ROOT, 'packages/nativescript-bridge/adwaita/src/widgets/accent-theme.ts');
 
-/** The two literals the theme uses for the accent, and the role each stands for. */
-const ACCENT_LITERALS = { '#3584e4': 'fill', '#1c71d8': 'shade' };
+/** The literals the theme uses for the accent, and the role each stands for. */
+const ACCENT_LITERALS = { '#3584e4': 'fill', '#1c71d8': 'shade', '#78aeed': 'standalone-dark' };
+
+/**
+ * Every OTHER opaque colour the theme is allowed to contain, with the reason.
+ *
+ * WHY A CLOSED LIST. The scan used to classify two literals and IGNORE the rest, so
+ * an accent-derived colour that was not one of those two was not a mismatch — it was
+ * invisible. That is how `#2c75d6` (a hand-picked dark press) and `#78aeed` (accent
+ * TEXT on dark, four rules) survived: the gate reported counts, never coverage. Now
+ * a colour is either an accent role or listed here, and a new one fails until
+ * someone says which it is.
+ *
+ * Alpha colours are deliberately out of scope: `rgba(255,255,255,.1)` and friends are
+ * overlays over whatever is behind them, so they cannot encode an accent.
+ */
+const NON_ACCENT_LITERALS = {
+    '#ffffff': 'plain white — accent foregrounds, dark-mode text',
+    '#fafafb': 'light $window_bg',
+    '#ebebed': 'light $view/$card shade',
+    '#e6e6e9': 'light pressed row',
+    '#222226': 'dark $window_bg',
+    '#2e2e32': 'dark $sidebar_bg',
+    '#2a2a2e': 'dark $view_bg',
+    '#303034': 'dark elevated surface',
+    '#34343a': 'dark $card_bg',
+    '#3a3a40': 'dark banner strip — neutral by design, not an accent',
+    '#45454c': 'dark separator/border',
+    '#c01c28': 'libadwaita $destructive_bg (red_4)',
+    '#ff7b80': 'libadwaita destructive foreground on dark',
+};
 
 /** Every accent declaration in the stylesheet, as `selector|property|role`. */
 function themeDeclarations(css) {
@@ -62,8 +91,30 @@ function tableEntries(source) {
     return found;
 }
 
-const declarations = themeDeclarations(readFileSync(THEME, 'utf8'));
+/**
+ * Every opaque colour literal in the theme that is neither an accent nor listed.
+ *
+ * Comments are blanked first, newlines kept, so line numbers stay true while a
+ * colour NAMED in prose — explaining what a rule replaced, say — does not read as a
+ * declaration the gate has to classify.
+ */
+function unclassifiedLiterals(css) {
+    const found = new Map(); // literal -> first line it appears on
+    const lines = css.replace(/\/\*[\s\S]*?\*\//g, (block) => block.replace(/[^\n]/g, ' ')).split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        for (const [literal] of lines[i].matchAll(/#[0-9a-fA-F]{6}/g)) {
+            const key = literal.toLowerCase();
+            if (key in ACCENT_LITERALS || key in NON_ACCENT_LITERALS) continue;
+            if (!found.has(key)) found.set(key, i + 1);
+        }
+    }
+    return found;
+}
+
+const css = readFileSync(THEME, 'utf8');
+const declarations = themeDeclarations(css);
 const entries = tableEntries(readFileSync(TABLE, 'utf8'));
+const unclassified = unclassifiedLiterals(css);
 
 if (declarations.length === 0) {
     console.error('check-nativescript-accent-rules: found no accent declarations in the theme — the scan is broken.');
@@ -82,10 +133,17 @@ for (const item of tabled) {
     if (!declared.has(item))
         failures.push(`the table covers ${item.split('|').join('  ')} — the theme no longer declares it`);
 }
+for (const [literal, line] of unclassified) {
+    failures.push(
+        `${literal} (${relative(ROOT, THEME)}:${line}) is neither an accent role nor a listed ` +
+            'non-accent — an accent the gate cannot classify is not a mismatch, it is invisible',
+    );
+}
 
 console.log(
     `check-nativescript-accent-rules: ${declared.size} accent declaration(s) in the theme, ` +
-        `${tabled.size} in the override table.`,
+        `${tabled.size} in the override table; ` +
+        `${Object.keys(NON_ACCENT_LITERALS).length} non-accent colours accounted for.`,
 );
 
 if (failures.length > 0) {

--- a/scripts/check-nativescript-disclosure-toggles.mjs
+++ b/scripts/check-nativescript-disclosure-toggles.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// A disclosure's toggle is wired to the HEADER, never to the whole row.
+//
+// WHY A SOURCE SCAN AND NOT A TEST
+//
+// `AdwExpanderRow extends AdwActionRow extends GridLayout`, so the class evaluates
+// the bare `@nativescript/core` specifier at module load and cannot be imported
+// off-device. No spec in the renderer suite can construct one, which is precisely
+// how the defect in #1155 survived: the whole affordance for expanding a row was
+// the 16-unit chevron, on the port whose targets are fingers, and 3000+ green
+// tests could not see it.
+//
+// WHAT THE DEVICE SAID, and why it decides the shape (measured on the Android
+// emulator, 2026-08-14, storybook Expander Row story):
+//
+//   tap target                      child listener   the ROW's own `tap`
+//   plain Label in the disclosure    fires            FIRES
+//   nested switch row                fires            FIRES
+//   nested entry row                 –                – (native EditText eats it)
+//   the header                       –                fires
+//   the 16x16 chevron                fires            FIRES
+//
+// A NativeScript `tap` does NOT stop at a child that handles it. So toggling from
+// the row's own `tap` — or from `activate()`, which that listener calls — collapses
+// the row whenever a user touches anything inside it. libadwaita avoids the same
+// trap structurally: `activatable=False` on the expander, True on the inner header
+// row (adw-expander-row.ui:24-26), so revealed rows cannot toggle their parent.
+//
+// Siblings do NOT receive each other's taps, which is what makes header-scoped
+// listeners safe and is the whole reason the wiring must stay header-scoped.
+//
+// WHAT IT CHECKS
+//
+// In each listed widget, the disclosure-toggling listener may only be attached to a
+// header-scoped view. Attaching it to `this` (the row, an ancestor of the
+// disclosure) or to the disclosure container fails — those are the two spellings
+// that put the toggle in the path of every nested tap.
+//
+// Plain Node over the repo's own files — no install, no build, no device.
+//
+// Usage: node scripts/check-nativescript-disclosure-toggles.mjs [--root <dir>]
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+
+const NS_WIDGETS = join(ROOT, 'packages/nativescript-bridge/adwaita/src/widgets');
+
+/**
+ * Widgets that reveal nested content, and the receiver their toggle must NOT be on.
+ *
+ * `state.toggle()` is the call that flips a disclosure; the scan looks at which
+ * object the listener carrying it was registered on.
+ */
+const GUARDED = [
+    {
+        file: 'adw-expander-row.ts',
+        /** The call that flips the disclosure. */
+        toggle: '_state.toggle()',
+        /** Receivers that are ancestors of the revealed content. */
+        forbidden: ['this.addEventListener', 'disclosure.addEventListener', 'this._disclosure.addEventListener'],
+    },
+];
+
+const failures = [];
+let checked = 0;
+
+for (const widget of GUARDED) {
+    const path = join(NS_WIDGETS, widget.file);
+    let source;
+    try {
+        source = readFileSync(path, 'utf8');
+    } catch {
+        failures.push(`${widget.file} is listed here but does not exist — the scan is stale, not the widget.`);
+        continue;
+    }
+
+    if (!source.includes(widget.toggle)) {
+        failures.push(
+            `${widget.file} no longer calls \`${widget.toggle}\`, so this scan is watching a call that moved. ` +
+                'Point it at the new one rather than deleting the guard.',
+        );
+        continue;
+    }
+
+    // The listener bodies that toggle, and what each was registered on. A body is
+    // the arrow function passed to addEventListener, or a named handler assigned
+    // once and attached by reference.
+    const togglingHandlers = new Set();
+    for (const match of source.matchAll(/const\s+(\w+)\s*=\s*\(\)\s*=>\s*\{([^}]*)\}/g)) {
+        if (match[2].includes(widget.toggle)) togglingHandlers.add(match[1]);
+    }
+
+    for (const receiver of widget.forbidden) {
+        // Inline form: `<receiver>('tap', () => { … state.toggle() … })`.
+        //
+        // The gap is `[\s\S]{0,300}?`, NOT `[^)]*?`: an arrow function's own `()`
+        // ends a negated-paren run immediately, so the tighter-looking pattern
+        // matched nothing and the gate passed the very defect it exists for. Found by
+        // A/B-ing both spellings rather than only the one written first.
+        const inline = new RegExp(
+            `${receiver.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\(\\s*'tap'\\s*,[\\s\\S]{0,300}?${widget.toggle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+            's',
+        );
+        if (inline.test(source)) {
+            failures.push(
+                `${widget.file}: \`${receiver}('tap', …)\` toggles the disclosure. That receiver is an ANCESTOR of ` +
+                    'the revealed content, and a NativeScript tap does not stop at the child that handles it — ' +
+                    'so every tap inside the row would collapse it.',
+            );
+        }
+        // By-reference form: `<receiver>('tap', toggleOnTap)`
+        for (const handler of togglingHandlers) {
+            if (source.includes(`${receiver}('tap', ${handler})`)) {
+                failures.push(
+                    `${widget.file}: \`${receiver}('tap', ${handler})\` puts the disclosure toggle on an ancestor ` +
+                        'of the revealed content; a tap on any nested child would collapse the row.',
+                );
+            }
+        }
+    }
+    checked++;
+}
+
+if (failures.length > 0) {
+    console.error(`check-nativescript-disclosure-toggles: ${failures.length} problem(s):\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(
+        `\nAttach the toggle to a HEADER-scoped view instead (the title stack, the chevron). Siblings do not\n` +
+            `receive each other's taps, which is what makes that safe — measured on device, see this file's header.\n` +
+            `  widgets: ${relative(ROOT, NS_WIDGETS)}`,
+    );
+    process.exit(1);
+}
+
+console.log(`check-nativescript-disclosure-toggles: ${checked} disclosure widget(s), all toggling from the header.`);

--- a/scripts/check-storybook-category-order.mjs
+++ b/scripts/check-storybook-category-order.mjs
@@ -73,7 +73,9 @@ const declared = [];
     const source = readFileSync(ORDER_SRC, 'utf8');
     const block = source.match(/STORYBOOK_CATEGORY_ORDER[^=]*=\s*\[([^\]]*)\]/);
     if (!block) {
-        console.error(`check-storybook-category-order: no STORYBOOK_CATEGORY_ORDER array in ${relative(ROOT, ORDER_SRC)}.`);
+        console.error(
+            `check-storybook-category-order: no STORYBOOK_CATEGORY_ORDER array in ${relative(ROOT, ORDER_SRC)}.`,
+        );
         process.exit(1);
     }
     for (const match of block[1].matchAll(/'([^']+)'/g)) declared.push(match[1]);

--- a/scripts/check-storybook-category-order.mjs
+++ b/scripts/check-storybook-category-order.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Every storybook category is placed by the declaration, not by an enumeration.
+//
+// WHAT THIS REPLACES
+//
+// The sidebar's category order used to be whatever order each target happened to
+// enumerate its stories in, and the three targets enumerate differently: the GTK
+// and NativeScript storybooks take a path glob (alphabetical by
+// `<category-dir>/<file>`), the browser target a hand-written import list. The
+// only thing holding them together was a sentence in the browser list saying it
+// "mirrors the native sidebar's category order" — which it did not. `Overview`
+// led the browser sidebar and sat FIFTH, below the fold, on the native one, and
+// that reads as the overview being MISSING rather than as an ordering
+// difference. That is how it was reported.
+//
+// STORYBOOK_CATEGORY_ORDER now owns the order for all three (they share a
+// StorybookController). A declaration is only worth more than the comment it
+// replaces if something checks it, so:
+//
+// WHAT IT CHECKS
+//
+//   1. Every category a story actually carries is named in the declaration.
+//      An unlisted category still renders — it sorts after the listed ones —
+//      so without this check a new category would silently land at the end.
+//   2. The declaration names no category that no story carries, so a renamed
+//      or deleted category cannot leave a stale entry behind that looks like
+//      it is doing something.
+//   3. The declaration has no duplicates (a second entry can never be reached).
+//
+// It reads the categories out of the `title:` of each renderer-agnostic
+// `*.meta.ts` — the same single source the three renderings share — rather than
+// out of any one target's list, because a per-target list is precisely what
+// stopped being authoritative.
+//
+// Plain Node over the repo's own files — no install, no build — so it runs in
+// `audit-runtimes.yml` next to the other repo-scoped guards.
+//
+// Usage: node scripts/check-storybook-category-order.mjs [--root <dir>]
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+
+/** The GTK showcase owns the renderer-agnostic metas all three targets import. */
+const GTK_SRC = join(ROOT, 'showcases/gtk/adwaita-storybook/src');
+/** Where the order is declared. */
+const ORDER_SRC = join(ROOT, 'packages/framework/storybook-core/src/category-order.ts');
+
+/** Absolute paths of every `*.meta.ts` under `dir`. */
+function metaFiles(dir) {
+    const found = [];
+    const walk = (current) => {
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            const path = join(current, entry.name);
+            if (entry.isDirectory()) walk(path);
+            else if (entry.name.endsWith('.meta.ts')) found.push(path);
+        }
+    };
+    walk(dir);
+    return found;
+}
+
+// A story's category is the part of its title before the first `/` — the same
+// split StorybookController._groupByCategory makes.
+const TITLE_RE = /^\s*title:\s*'([^']+)'/m;
+
+const declared = [];
+{
+    const source = readFileSync(ORDER_SRC, 'utf8');
+    const block = source.match(/STORYBOOK_CATEGORY_ORDER[^=]*=\s*\[([^\]]*)\]/);
+    if (!block) {
+        console.error(`check-storybook-category-order: no STORYBOOK_CATEGORY_ORDER array in ${relative(ROOT, ORDER_SRC)}.`);
+        process.exit(1);
+    }
+    for (const match of block[1].matchAll(/'([^']+)'/g)) declared.push(match[1]);
+}
+
+const used = new Map(); // category -> the meta file that first carried it
+for (const file of metaFiles(GTK_SRC)) {
+    const title = readFileSync(file, 'utf8').match(TITLE_RE);
+    if (!title) continue;
+    const category = title[1].split('/')[0];
+    if (!used.has(category)) used.set(category, file);
+}
+
+if (used.size === 0) {
+    console.error('check-storybook-category-order: found no story titles — the scan is broken, not the showcases.');
+    process.exit(1);
+}
+if (declared.length === 0) {
+    console.error('check-storybook-category-order: the declaration is empty — every category would sort as unlisted.');
+    process.exit(1);
+}
+
+const failures = [];
+
+const unlisted = [...used.keys()].filter((name) => !declared.includes(name)).sort();
+for (const name of unlisted) {
+    failures.push(
+        `"${name}" is carried by ${relative(ROOT, used.get(name))} but is not in STORYBOOK_CATEGORY_ORDER — ` +
+            'it would render last on every target, in whatever order discovery happened to hand it over.',
+    );
+}
+
+const stale = declared.filter((name) => !used.has(name)).sort();
+for (const name of stale) {
+    failures.push(`"${name}" is declared but no story carries it — a stale entry that looks like it places something.`);
+}
+
+const seen = new Set();
+for (const name of declared) {
+    if (seen.has(name)) failures.push(`"${name}" is declared twice; the second entry can never be reached.`);
+    seen.add(name);
+}
+
+if (failures.length > 0) {
+    console.error(`check-storybook-category-order: ${failures.length} problem(s):\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(
+        `\nThe order is what a reader meets first, and it used to differ per target while a comment said\n` +
+            `it did not. Declare the category in ${relative(ROOT, ORDER_SRC)} rather than letting\n` +
+            `enumeration decide where it lands.`,
+    );
+    process.exit(1);
+}
+
+console.log(
+    `check-storybook-category-order: ${declared.length} categories declared, ` +
+        `all ${used.size} in use placed — leading with "${declared[0]}".`,
+);

--- a/showcases/dom/adwaita-storybook-nativescript/src/overview/widgets.ns.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/overview/widgets.ns.ts
@@ -20,7 +20,10 @@ import {
 import {
     OVERVIEW_ACCENT_OPTIONS,
     OVERVIEW_ADVANCED_ROWS,
+    OVERVIEW_DEVICES,
+    OVERVIEW_GROUP_TITLES,
     OVERVIEW_SHORTCUTS,
+    OVERVIEW_TEXT,
     overviewWidgetsMeta,
 } from '@gjsify/example-gtk-adwaita-storybook/metas';
 
@@ -39,8 +42,8 @@ export class OverviewWidgetsNsStory extends StoryView {
         const host = new StackLayout();
 
         this._banner = new AdwBanner();
-        this._banner.title = 'You have unsaved changes';
-        this._banner.buttonLabel = 'Save';
+        this._banner.title = OVERVIEW_TEXT.bannerTitle;
+        this._banner.buttonLabel = OVERVIEW_TEXT.bannerButton;
         this._syncBanner();
         host.addChild(this._banner);
 
@@ -50,22 +53,22 @@ export class OverviewWidgetsNsStory extends StoryView {
         // in its chrome, and wiring these to it would give one setting two controls
         // that disagree.
         const appearance = new AdwPreferencesGroup();
-        appearance.title = 'APPEARANCE';
+        appearance.title = OVERVIEW_GROUP_TITLES.appearance;
 
         const dark = new AdwSwitchRow();
-        dark.title = 'Dark mode';
-        dark.subtitle = 'Use the dark Adwaita palette';
+        dark.title = OVERVIEW_TEXT.darkMode;
+        dark.subtitle = OVERVIEW_TEXT.darkModeSubtitle;
         dark.active = false;
         appearance.addRow(dark);
 
         const notifications = new AdwSwitchRow();
-        notifications.title = 'Notifications';
-        notifications.subtitle = 'Show toasts for events';
+        notifications.title = OVERVIEW_TEXT.notifications;
+        notifications.subtitle = OVERVIEW_TEXT.notificationsSubtitle;
         notifications.active = true;
         appearance.addRow(notifications);
 
         const accent = new AdwComboRow();
-        accent.title = 'Accent color';
+        accent.title = OVERVIEW_TEXT.accentColor;
         accent.options = OVERVIEW_ACCENT_OPTIONS.map((label) => ({ label, value: label.toLowerCase() }));
         accent.selectedIndex = 0;
         appearance.addRow(accent);
@@ -74,29 +77,29 @@ export class OverviewWidgetsNsStory extends StoryView {
 
         // --- Account ---
         const account = new AdwPreferencesGroup();
-        account.title = 'ACCOUNT';
+        account.title = OVERVIEW_GROUP_TITLES.account;
 
         const name = new AdwEntryRow();
-        name.title = 'Name';
-        name.text = 'Ada Lovelace';
+        name.title = OVERVIEW_TEXT.name;
+        name.text = OVERVIEW_TEXT.nameValue;
         account.addRow(name);
 
         const email = new AdwEntryRow();
-        email.title = 'Email';
-        email.text = 'ada@example.com';
+        email.title = OVERVIEW_TEXT.email;
+        email.text = OVERVIEW_TEXT.emailValue;
         account.addRow(email);
 
         const devices = new AdwSpinRow();
-        devices.title = 'Devices';
-        devices.min = 1;
-        devices.max = 10;
-        devices.step = 1;
-        devices.value = 3;
+        devices.title = OVERVIEW_TEXT.devices;
+        devices.min = OVERVIEW_DEVICES.lower;
+        devices.max = OVERVIEW_DEVICES.upper;
+        devices.step = OVERVIEW_DEVICES.step;
+        devices.value = OVERVIEW_DEVICES.value;
         account.addRow(devices);
 
         const advanced = new AdwExpanderRow();
-        advanced.title = 'Advanced';
-        advanced.subtitle = 'More options';
+        advanced.title = OVERVIEW_TEXT.advanced;
+        advanced.subtitle = OVERVIEW_TEXT.advancedSubtitle;
         for (const row of OVERVIEW_ADVANCED_ROWS) {
             if (row.kind === 'switch') {
                 const child = new AdwSwitchRow();
@@ -116,7 +119,7 @@ export class OverviewWidgetsNsStory extends StoryView {
 
         // --- Shortcuts: the newest widget, in context ---
         const shortcuts = new AdwPreferencesGroup();
-        shortcuts.title = 'SHORTCUTS';
+        shortcuts.title = OVERVIEW_GROUP_TITLES.shortcuts;
         for (const shortcut of OVERVIEW_SHORTCUTS) {
             const row = new AdwActionRow();
             row.title = shortcut.title;
@@ -129,18 +132,18 @@ export class OverviewWidgetsNsStory extends StoryView {
 
         // --- Actions ---
         const actions = new AdwPreferencesGroup();
-        actions.title = 'ACTIONS';
+        actions.title = OVERVIEW_GROUP_TITLES.actions;
         const buttons = new StackLayout();
         buttons.orientation = 'horizontal';
         buttons.className = 'adw-action-buttons';
 
         const save = new AdwButton();
-        save.text = 'Save changes';
+        save.text = OVERVIEW_TEXT.save;
         save.variant = 'suggested-action';
         buttons.addChild(save);
 
         const remove = new AdwButton();
-        remove.text = 'Delete account';
+        remove.text = OVERVIEW_TEXT.delete;
         remove.variant = 'destructive-action';
         buttons.addChild(remove);
 

--- a/showcases/dom/adwaita-storybook-nativescript/src/stories.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/stories.ts
@@ -3,9 +3,12 @@
 // asserted against the @gjsify/adwaita-core/conformance vectors — nothing compares the rendering
 // (#1052).
 //
-// The array order must stay as it is: the GTK storybook discovers `*.story.ts` by path glob, making
-// its sidebar order alphabetical by `<category-dir>/<story-file>`, and this list reproduces that so
-// the NS sidebar matches.
+// THE ORDER OF THIS ARRAY NO LONGER DECIDES THE SIDEBAR. It used to have to reproduce the GTK
+// storybook's path glob (alphabetical by `<category-dir>/<story-file>`) so the two sidebars agreed —
+// a rule kept by hand in a comment, which the browser target's own list broke without anything
+// noticing. Categories now come from STORYBOOK_CATEGORY_ORDER in @gjsify/storybook-core, applied by
+// the controller all three targets share, so this list only decides which stories exist and how they
+// sit WITHIN their category.
 
 import type { NsStoryModule } from '@gjsify/storybook-nativescript';
 // Buttons

--- a/showcases/gtk/adwaita-storybook/src/browser/overview/widgets.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/overview/widgets.web.ts
@@ -5,7 +5,10 @@ import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } fro
 import {
     OVERVIEW_ACCENT_OPTIONS,
     OVERVIEW_ADVANCED_ROWS,
+    OVERVIEW_DEVICES,
+    OVERVIEW_GROUP_TITLES,
     OVERVIEW_SHORTCUTS,
+    OVERVIEW_TEXT,
     overviewWidgetsMeta,
 } from '../../overview/widgets.meta.js';
 
@@ -33,7 +36,7 @@ export class OverviewWidgetsWebStory extends StoryElement {
         host.style.flexDirection = 'column';
         host.style.width = '100%';
 
-        this._banner = el('adw-banner', { title: 'You have unsaved changes', 'button-label': 'Save' });
+        this._banner = el('adw-banner', { title: OVERVIEW_TEXT.bannerTitle, 'button-label': OVERVIEW_TEXT.bannerButton });
         this._syncBanner();
         host.append(this._banner);
 
@@ -42,12 +45,12 @@ export class OverviewWidgetsWebStory extends StoryElement {
         // --- Appearance: a widget demo only. The storybook's OWN appearance is in
         // the chrome, and wiring these to it would give one setting two controls
         // that disagree.
-        const appearance = el('adw-preferences-group', { title: 'Appearance' });
+        const appearance = el('adw-preferences-group', { title: OVERVIEW_GROUP_TITLES.appearance });
         appearance.append(
-            el('adw-switch-row', { title: 'Dark mode', subtitle: 'Use the dark Adwaita palette' }),
-            el('adw-switch-row', { title: 'Notifications', subtitle: 'Show toasts for events', active: '' }),
+            el('adw-switch-row', { title: OVERVIEW_TEXT.darkMode, subtitle: OVERVIEW_TEXT.darkModeSubtitle }),
+            el('adw-switch-row', { title: OVERVIEW_TEXT.notifications, subtitle: OVERVIEW_TEXT.notificationsSubtitle, active: '' }),
             el('adw-combo-row', {
-                title: 'Accent color',
+                title: OVERVIEW_TEXT.accentColor,
                 // `items` is JSON, not a comma list — the element parses it.
                 items: JSON.stringify([...OVERVIEW_ACCENT_OPTIONS]),
                 selected: '0',
@@ -56,14 +59,20 @@ export class OverviewWidgetsWebStory extends StoryElement {
         page.append(appearance);
 
         // --- Account ---
-        const account = el('adw-preferences-group', { title: 'Account' });
+        const account = el('adw-preferences-group', { title: OVERVIEW_GROUP_TITLES.account });
         account.append(
-            el('adw-entry-row', { title: 'Name', text: 'Ada Lovelace' }),
-            el('adw-entry-row', { title: 'Email', text: 'ada@example.com' }),
-            el('adw-spin-row', { title: 'Devices', min: '1', max: '10', step: '1', value: '3' }),
+            el('adw-entry-row', { title: OVERVIEW_TEXT.name, text: OVERVIEW_TEXT.nameValue }),
+            el('adw-entry-row', { title: OVERVIEW_TEXT.email, text: OVERVIEW_TEXT.emailValue }),
+            el('adw-spin-row', {
+                title: OVERVIEW_TEXT.devices,
+                min: String(OVERVIEW_DEVICES.lower),
+                max: String(OVERVIEW_DEVICES.upper),
+                step: String(OVERVIEW_DEVICES.step),
+                value: String(OVERVIEW_DEVICES.value),
+            }),
         );
 
-        const advanced = el('adw-expander-row', { title: 'Advanced', subtitle: 'More options' });
+        const advanced = el('adw-expander-row', { title: OVERVIEW_TEXT.advanced, subtitle: OVERVIEW_TEXT.advancedSubtitle });
         advanced.toggleAttribute('expanded', true);
         for (const row of OVERVIEW_ADVANCED_ROWS) {
             advanced.append(
@@ -76,7 +85,7 @@ export class OverviewWidgetsWebStory extends StoryElement {
         page.append(account);
 
         // --- Shortcuts: the newest widget, in context ---
-        const shortcuts = el('adw-preferences-group', { title: 'Shortcuts' });
+        const shortcuts = el('adw-preferences-group', { title: OVERVIEW_GROUP_TITLES.shortcuts });
         for (const shortcut of OVERVIEW_SHORTCUTS) {
             const row = el('adw-action-row', { title: shortcut.title });
             const label = el('adw-shortcut-label', { accelerator: shortcut.accelerator, slot: 'suffix' });
@@ -86,7 +95,7 @@ export class OverviewWidgetsWebStory extends StoryElement {
         page.append(shortcuts);
 
         // --- Actions ---
-        const actions = el('adw-preferences-group', { title: 'Actions' });
+        const actions = el('adw-preferences-group', { title: OVERVIEW_GROUP_TITLES.actions });
         const buttons = document.createElement('div');
         buttons.style.display = 'flex';
         buttons.style.gap = '12px';
@@ -94,10 +103,10 @@ export class OverviewWidgetsWebStory extends StoryElement {
 
         const save = document.createElement('button');
         save.className = 'adw-button suggested-action';
-        save.textContent = 'Save changes';
+        save.textContent = OVERVIEW_TEXT.save;
         const remove = document.createElement('button');
         remove.className = 'adw-button destructive-action';
-        remove.textContent = 'Delete account';
+        remove.textContent = OVERVIEW_TEXT.delete;
         buttons.append(save, remove);
         actions.append(buttons);
         page.append(actions);

--- a/showcases/gtk/adwaita-storybook/src/browser/overview/widgets.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/overview/widgets.web.ts
@@ -36,7 +36,10 @@ export class OverviewWidgetsWebStory extends StoryElement {
         host.style.flexDirection = 'column';
         host.style.width = '100%';
 
-        this._banner = el('adw-banner', { title: OVERVIEW_TEXT.bannerTitle, 'button-label': OVERVIEW_TEXT.bannerButton });
+        this._banner = el('adw-banner', {
+            title: OVERVIEW_TEXT.bannerTitle,
+            'button-label': OVERVIEW_TEXT.bannerButton,
+        });
         this._syncBanner();
         host.append(this._banner);
 
@@ -48,7 +51,11 @@ export class OverviewWidgetsWebStory extends StoryElement {
         const appearance = el('adw-preferences-group', { title: OVERVIEW_GROUP_TITLES.appearance });
         appearance.append(
             el('adw-switch-row', { title: OVERVIEW_TEXT.darkMode, subtitle: OVERVIEW_TEXT.darkModeSubtitle }),
-            el('adw-switch-row', { title: OVERVIEW_TEXT.notifications, subtitle: OVERVIEW_TEXT.notificationsSubtitle, active: '' }),
+            el('adw-switch-row', {
+                title: OVERVIEW_TEXT.notifications,
+                subtitle: OVERVIEW_TEXT.notificationsSubtitle,
+                active: '',
+            }),
             el('adw-combo-row', {
                 title: OVERVIEW_TEXT.accentColor,
                 // `items` is JSON, not a comma list — the element parses it.
@@ -72,7 +79,10 @@ export class OverviewWidgetsWebStory extends StoryElement {
             }),
         );
 
-        const advanced = el('adw-expander-row', { title: OVERVIEW_TEXT.advanced, subtitle: OVERVIEW_TEXT.advancedSubtitle });
+        const advanced = el('adw-expander-row', {
+            title: OVERVIEW_TEXT.advanced,
+            subtitle: OVERVIEW_TEXT.advancedSubtitle,
+        });
         advanced.toggleAttribute('expanded', true);
         for (const row of OVERVIEW_ADVANCED_ROWS) {
             advanced.append(

--- a/showcases/gtk/adwaita-storybook/src/browser/stories.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/stories.ts
@@ -3,8 +3,17 @@
 // embeddable `mount(container)` (`embed.ts`, used by the gjsify website) draw
 // from this single list so the two stay in lockstep.
 //
-// Order mirrors the native sidebar's category order (Presentation, Boxed
-// Lists, Buttons, …).
+// THE ORDER OF THIS ARRAY NO LONGER DECIDES THE SIDEBAR. Categories are ordered
+// by STORYBOOK_CATEGORY_ORDER in @gjsify/storybook-core, which every target's
+// controller applies, so this list only decides which stories exist and how they
+// sit WITHIN their category.
+//
+// It used to claim it mirrored the native sidebar's order. It measurably did not:
+// the GTK and NativeScript storybooks took their order from a path glob
+// (alphabetical by directory), so `Overview` led here and sat fifth there. One
+// sentence was the only thing holding an invariant across three files, and the
+// sentence was wrong — which is why the order moved somewhere a build gate can
+// check it.
 
 import type { WebStoryModule } from '@gjsify/adwaita-storybook';
 import { OverviewWidgetsWebStories } from './overview/widgets.web.js';

--- a/showcases/gtk/adwaita-storybook/src/overview/widgets.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/overview/widgets.meta.ts
@@ -33,6 +33,54 @@ export const OVERVIEW_ADVANCED_ROWS: ReadonlyArray<OverviewExpanderRow> = [
 /** The accent names the gallery's combo row offers — a plain widget demo, not the real setting. */
 export const OVERVIEW_ACCENT_OPTIONS: readonly string[] = ['Blue', 'Teal', 'Green', 'Orange'];
 
+/**
+ * The gallery's preference-group headings.
+ *
+ * Shared for the same reason the rows are: they were literals repeated in all
+ * three renderings, and the NativeScript copy had drifted to UPPERCASE
+ * (`APPEARANCE`) while GTK and the browser used title case. It was the only file
+ * in that showcase spelling group titles that way, so it read as a house style
+ * without being one — `Adw.PreferencesGroup:title` is rendered as given on every
+ * target, and libadwaita does not upper-case it.
+ */
+export const OVERVIEW_GROUP_TITLES = {
+    appearance: 'Appearance',
+    account: 'Account',
+    shortcuts: 'Shortcuts',
+    actions: 'Actions',
+} as const;
+
+/**
+ * Every remaining string the gallery puts on screen.
+ *
+ * The rows, shortcuts and accent names were already shared; the labels around
+ * them were not, and that is where the uppercase drift got in. Sharing only the
+ * headings would fix the one instance and leave the class — a literal repeated in
+ * three renderings, with nothing comparing them — so the whole content of the
+ * gallery lives here and each target only decides how to BUILD it.
+ */
+export const OVERVIEW_TEXT = {
+    bannerTitle: 'You have unsaved changes',
+    bannerButton: 'Save',
+    darkMode: 'Dark mode',
+    darkModeSubtitle: 'Use the dark Adwaita palette',
+    notifications: 'Notifications',
+    notificationsSubtitle: 'Show toasts for events',
+    accentColor: 'Accent color',
+    name: 'Name',
+    nameValue: 'Ada Lovelace',
+    email: 'Email',
+    emailValue: 'ada@example.com',
+    devices: 'Devices',
+    advanced: 'Advanced',
+    advancedSubtitle: 'More options',
+    save: 'Save changes',
+    delete: 'Delete account',
+} as const;
+
+/** The spin row's range and starting value, shared so the three agree on it too. */
+export const OVERVIEW_DEVICES = { value: 3, lower: 1, upper: 10, step: 1 } as const;
+
 /** The shortcut rows, so the newest widget appears in context and not only alone. */
 export const OVERVIEW_SHORTCUTS: ReadonlyArray<{ title: string; accelerator: string }> = [
     { title: 'Copy', accelerator: '<Control>C' },

--- a/showcases/gtk/adwaita-storybook/src/overview/widgets.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/overview/widgets.story.ts
@@ -8,7 +8,10 @@ import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@
 import {
     OVERVIEW_ACCENT_OPTIONS,
     OVERVIEW_ADVANCED_ROWS,
+    OVERVIEW_DEVICES,
+    OVERVIEW_GROUP_TITLES,
     OVERVIEW_SHORTCUTS,
+    OVERVIEW_TEXT,
     overviewWidgetsMeta,
 } from './widgets.meta.js';
 
@@ -32,8 +35,8 @@ export class OverviewWidgetsStory extends StoryWidget {
         const box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, hexpand: true });
 
         this._banner = new Adw.Banner({
-            title: 'You have unsaved changes',
-            button_label: 'Save',
+            title: OVERVIEW_TEXT.bannerTitle,
+            button_label: OVERVIEW_TEXT.bannerButton,
             revealed: this.args.revealed as boolean,
         });
         box.append(this._banner);
@@ -43,14 +46,14 @@ export class OverviewWidgetsStory extends StoryWidget {
         // --- Appearance: switches and a combo. A widget demo only — the
         // storybook's OWN appearance lives in the header bar's dialog, and wiring
         // these to it would give one setting two controls that disagree.
-        const appearance = new Adw.PreferencesGroup({ title: 'Appearance' });
+        const appearance = new Adw.PreferencesGroup({ title: OVERVIEW_GROUP_TITLES.appearance });
         appearance.add(
-            new Adw.SwitchRow({ title: 'Dark mode', subtitle: 'Use the dark Adwaita palette', active: false }),
+            new Adw.SwitchRow({ title: OVERVIEW_TEXT.darkMode, subtitle: OVERVIEW_TEXT.darkModeSubtitle, active: false }),
         );
-        appearance.add(new Adw.SwitchRow({ title: 'Notifications', subtitle: 'Show toasts for events', active: true }));
+        appearance.add(new Adw.SwitchRow({ title: OVERVIEW_TEXT.notifications, subtitle: OVERVIEW_TEXT.notificationsSubtitle, active: true }));
         appearance.add(
             new Adw.ComboRow({
-                title: 'Accent color',
+                title: OVERVIEW_TEXT.accentColor,
                 model: Gtk.StringList.new([...OVERVIEW_ACCENT_OPTIONS]),
                 selected: 0,
             }),
@@ -58,26 +61,30 @@ export class OverviewWidgetsStory extends StoryWidget {
         page.add(appearance);
 
         // --- Account: entries, a spin row, and a nested expander ---
-        const account = new Adw.PreferencesGroup({ title: 'Account' });
+        const account = new Adw.PreferencesGroup({ title: OVERVIEW_GROUP_TITLES.account });
 
-        const name = new Adw.EntryRow({ title: 'Name' });
-        name.set_text('Ada Lovelace');
+        const name = new Adw.EntryRow({ title: OVERVIEW_TEXT.name });
+        name.set_text(OVERVIEW_TEXT.nameValue);
         account.add(name);
 
-        const email = new Adw.EntryRow({ title: 'Email' });
-        email.set_text('ada@example.com');
+        const email = new Adw.EntryRow({ title: OVERVIEW_TEXT.email });
+        email.set_text(OVERVIEW_TEXT.emailValue);
         account.add(email);
 
         const devices = new Adw.SpinRow({
-            title: 'Devices',
-            adjustment: new Gtk.Adjustment({ value: 3, lower: 1, upper: 10, step_increment: 1, page_increment: 1 }),
+            title: OVERVIEW_TEXT.devices,
+            adjustment: new Gtk.Adjustment({ value: OVERVIEW_DEVICES.value,
+                lower: OVERVIEW_DEVICES.lower,
+                upper: OVERVIEW_DEVICES.upper,
+                step_increment: OVERVIEW_DEVICES.step,
+                page_increment: OVERVIEW_DEVICES.step }),
         });
         // The displayed value does not always follow the adjustment through
         // property-init ordering, so it is set explicitly.
-        devices.set_value(3);
+        devices.set_value(OVERVIEW_DEVICES.value);
         account.add(devices);
 
-        const advanced = new Adw.ExpanderRow({ title: 'Advanced', subtitle: 'More options', expanded: true });
+        const advanced = new Adw.ExpanderRow({ title: OVERVIEW_TEXT.advanced, subtitle: OVERVIEW_TEXT.advancedSubtitle, expanded: true });
         for (const row of OVERVIEW_ADVANCED_ROWS) {
             advanced.add_row(
                 row.kind === 'switch'
@@ -89,7 +96,7 @@ export class OverviewWidgetsStory extends StoryWidget {
         page.add(account);
 
         // --- Shortcuts: the newest widget, in context ---
-        const shortcuts = new Adw.PreferencesGroup({ title: 'Shortcuts' });
+        const shortcuts = new Adw.PreferencesGroup({ title: OVERVIEW_GROUP_TITLES.shortcuts });
         for (const shortcut of OVERVIEW_SHORTCUTS) {
             const row = new Adw.ActionRow({ title: shortcut.title });
             row.add_suffix(new Adw.ShortcutLabel({ accelerator: shortcut.accelerator, valign: Gtk.Align.CENTER }));
@@ -98,7 +105,7 @@ export class OverviewWidgetsStory extends StoryWidget {
         page.add(shortcuts);
 
         // --- Actions: the two button styles side by side ---
-        const actions = new Adw.PreferencesGroup({ title: 'Actions' });
+        const actions = new Adw.PreferencesGroup({ title: OVERVIEW_GROUP_TITLES.actions });
         const buttons = new Gtk.Box({
             orientation: Gtk.Orientation.HORIZONTAL,
             spacing: 12,
@@ -106,10 +113,10 @@ export class OverviewWidgetsStory extends StoryWidget {
             margin_top: 6,
             margin_bottom: 6,
         });
-        const save = new Gtk.Button({ label: 'Save changes' });
+        const save = new Gtk.Button({ label: OVERVIEW_TEXT.save });
         save.add_css_class('suggested-action');
         buttons.append(save);
-        const remove = new Gtk.Button({ label: 'Delete account' });
+        const remove = new Gtk.Button({ label: OVERVIEW_TEXT.delete });
         remove.add_css_class('destructive-action');
         buttons.append(remove);
         actions.add(buttons);

--- a/showcases/gtk/adwaita-storybook/src/overview/widgets.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/overview/widgets.story.ts
@@ -48,9 +48,19 @@ export class OverviewWidgetsStory extends StoryWidget {
         // these to it would give one setting two controls that disagree.
         const appearance = new Adw.PreferencesGroup({ title: OVERVIEW_GROUP_TITLES.appearance });
         appearance.add(
-            new Adw.SwitchRow({ title: OVERVIEW_TEXT.darkMode, subtitle: OVERVIEW_TEXT.darkModeSubtitle, active: false }),
+            new Adw.SwitchRow({
+                title: OVERVIEW_TEXT.darkMode,
+                subtitle: OVERVIEW_TEXT.darkModeSubtitle,
+                active: false,
+            }),
         );
-        appearance.add(new Adw.SwitchRow({ title: OVERVIEW_TEXT.notifications, subtitle: OVERVIEW_TEXT.notificationsSubtitle, active: true }));
+        appearance.add(
+            new Adw.SwitchRow({
+                title: OVERVIEW_TEXT.notifications,
+                subtitle: OVERVIEW_TEXT.notificationsSubtitle,
+                active: true,
+            }),
+        );
         appearance.add(
             new Adw.ComboRow({
                 title: OVERVIEW_TEXT.accentColor,
@@ -73,18 +83,24 @@ export class OverviewWidgetsStory extends StoryWidget {
 
         const devices = new Adw.SpinRow({
             title: OVERVIEW_TEXT.devices,
-            adjustment: new Gtk.Adjustment({ value: OVERVIEW_DEVICES.value,
+            adjustment: new Gtk.Adjustment({
+                value: OVERVIEW_DEVICES.value,
                 lower: OVERVIEW_DEVICES.lower,
                 upper: OVERVIEW_DEVICES.upper,
                 step_increment: OVERVIEW_DEVICES.step,
-                page_increment: OVERVIEW_DEVICES.step }),
+                page_increment: OVERVIEW_DEVICES.step,
+            }),
         });
         // The displayed value does not always follow the adjustment through
         // property-init ordering, so it is set explicitly.
         devices.set_value(OVERVIEW_DEVICES.value);
         account.add(devices);
 
-        const advanced = new Adw.ExpanderRow({ title: OVERVIEW_TEXT.advanced, subtitle: OVERVIEW_TEXT.advancedSubtitle, expanded: true });
+        const advanced = new Adw.ExpanderRow({
+            title: OVERVIEW_TEXT.advanced,
+            subtitle: OVERVIEW_TEXT.advancedSubtitle,
+            expanded: true,
+        });
         for (const row of OVERVIEW_ADVANCED_ROWS) {
             advanced.add_row(
                 row.kind === 'switch'


### PR DESCRIPTION
Five Adwaita items in one pass. Each commit stands alone; the first three came out of
reading the storybook side by side with the website, the last two close open issues.

## The reported symptom, and what it actually was

> the web storybook has a Widgets overview, the native one is missing it

The story exists on all three targets and renders correctly on every one. What differed
is the ORDER: the sidebar's category order was a by-product of how each target
*enumerates* its stories, and the three enumerate differently — a path glob on GTK and
NativeScript (alphabetical by `<category-dir>/<file>`), a hand-written import list on the
browser. So `Overview` led the browser sidebar and sat **fifth, below the fold**, on the
native one. That does not read as an ordering difference; it reads as the overview being
absent.

The only thing holding the invariant across three files was a sentence in the browser
list claiming it "mirrors the native sidebar's category order". It measurably did not.

`STORYBOOK_CATEGORY_ORDER` now owns it in `@gjsify/storybook-core` — all three renderers
already share a `StorybookController`, so it is one declaration instead of three lists.
The landing story also moved from the registry to the sidebar: those were the same list
until the order was declared.

## Commits

| | |
|---|---|
| `feat(storybook)` | one declared sidebar order + `check-storybook-category-order.mjs` |
| `feat(storybook)` | the preview stage on the gallery's gradient, both schemes |
| `refactor(storybook)` | the Widgets gallery's content shared through its meta |
| `fix(adwaita-nativescript)` | #1154 — the accent literals the gate could not see |
| `fix(adwaita-nativescript)` | #1155 — expand from the header, not a 16px chevron |

Closes #1154. Closes #1155.

## The dashed frame → a tinted stage

The requirement behind the frame is real: the preview must stay locatable when the widget
on it is transparent or empty. Two corner tints meet it with a surface instead, matching
the website's widget gallery.

Both schemes without branching on the two targets that can: the tint carries libadwaita's
**standalone** accent (`@accent_color` / `var(--accent-color)`), defined as the accent moved
to a lightness that reads against the current background — oklab `min(l, 0.5)` light,
`max(l, 0.85)` dark. Correct in both by construction, and it follows a runtime accent. The
website hardcodes `#3584e4` / `#78aeed` for those two states, which is this name resolved by
hand. Measured on GTK in light and dark.

NativeScript forces two substitutions, both written down rather than left silent: its parser
knows `linear-gradient` only, one gradient per declaration, so the corner circles become one
135° sweep; and with no custom properties the accent is spelled out per `.ns-dark`, so a
runtime accent does **not** reach that backdrop there.

## #1154 — and the bigger half the issue asked about

The press shade was drift, and the C settles it rather than taste: libadwaita presses an
opaque button (`.suggested-action` extends it) with `background-image: image(RGB(0 0 6 / 20%))`
— a darkening overlay identical in both schemes. There is no lighter dark press for an accent
button. So `#2c75d6` becomes the registered `shade`.

The issue asked whether any other literal was an unregistered accent. **Yes:** `#78aeed`,
four times, painting accent *text* on dark. Under `applyAdwaitaNsAccent('orange')` every one
of those stayed blue. It is a real role, not drift — a standalone accent on a dark background
must be *lightened* — so it becomes a third role, `standalone-dark`, the branch
`ACCENT_COLOR_VECTORS.standaloneDark` already modelled and nothing consumed.

Both hid the same way, so the mechanism matters more than either fix: the gate classified two
literals and **ignored every other colour**, so it could report *"18 accent declarations, 18 in
the override table"* over a theme carrying two unreachable accents. A/B-measured — the old gate
exits 0 on the exact #1154 defect. Every opaque colour is now either an accent role or listed
as a non-accent with its reason.

## #1155 — decided on device, and the issue's first option is refuted

`AdwExpanderRow extends GridLayout`, so no off-device spec can construct one; 3306 green tests
could not see that the entire expand affordance was a 16-unit square. Measured on the emulator:

| tap target | child listener | the row's own `tap` |
|---|---|---|
| plain Label in the disclosure | fires | **fires** |
| nested switch row | fires | **fires** |
| nested entry row | – | – (native EditText consumes) |
| the header | – | fires |
| the 16×16 chevron | fires | **fires** |

A NativeScript `tap` does **not** stop at the child that handles it, so "toggle from
`ACTIVATED` and drop the chevron listener" would collapse the row whenever a user touched
anything nested inside it. Siblings do not receive each other's taps — which is what makes
header-scoped listeners safe, and why the toggle now sits on the title stack plus the chevron
(both grid row 0; the disclosure is row 1). libadwaita reaches the same separation
structurally.

Verified after the fix: header collapses and re-expands, chevron alternates, and a tap on the
nested switch row flips the switch and leaves the row open.

`check-nativescript-disclosure-toggles.mjs` fails when a disclosure toggle is attached to the
row or the disclosure, in either spelling. Worth noting: its first inline pattern used
`[^)]*?`, which an arrow function's own `()` terminates — so it **passed the very defect it
exists for**, and only trying both spellings found that.

## Verification

- `storybook-core` 132 tests, GJS + Node (9 new for the order, 1 for the landing story)
- `adwaita-nativescript` 3306 tests, GJS + Node
- all seven Adwaita/storybook gates green; each new one A/B-measured against a deliberate break
- GTK storybook screenshotted in light and dark; NativeScript app built, installed and driven
  on the Android emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
