### PR TITLE
fix(unit): name the failing test, and record the timeouts that never were

### DIFF
--- a/packages/gjs/unit/src/failure-recap.spec.ts
+++ b/packages/gjs/unit/src/failure-recap.spec.ts
@@ -1,0 +1,119 @@
+// The failure recap — the block that NAMES what failed, above the summary that counts it.
+//
+// WHY THIS SPEC EXISTS. Before #1159 the summary line was the only failure signal and
+// it named nothing, while no marker distinguished a failing line from a passing one: a
+// grep for `✖`, `✘`, `❌`, `not ok` or `AssertionError` over a 9305-line CI log returned
+// the summary and nothing else. The reporter was the one part of this runner that
+// nothing tested, which is how it stayed that way.
+
+import { describe, expect, it, formatFailureAnnotations, formatFailureRecap } from '@gjsify/unit';
+
+/** Strip SGR codes so assertions read the text, not the colouring. */
+const plain = (lines: string[]): string[] => lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ''));
+
+const entry = (suite: string, test: string, message: string) => ({ suite, test, message });
+
+export default async () => {
+    await describe('formatFailureRecap', async () => {
+        await it('names each failure with its suite, test and reason', () => {
+            const lines = plain(
+                formatFailureRecap([entry('boxed lists', 'a row activates', 'Expected: 42\nActual: 41')], 1),
+            );
+            expect(lines.length).toBe(2);
+            expect(lines[1]!.includes('boxed lists › a row activates')).toBe(true);
+            expect(lines[1]!.includes('Expected: 42')).toBe(true);
+        });
+
+        await it('keeps only the first line of a multi-line reason', () => {
+            // The block exists to be SCANNED; the full diff is already printed above,
+            // at the failure itself. A recap that reprints diffs is the log again.
+            const lines = plain(formatFailureRecap([entry('s', 't', 'first\nsecond\nthird')], 1));
+            expect(lines[1]!.includes('first')).toBe(true);
+            expect(lines[1]!.includes('second')).toBe(false);
+        });
+
+        await it('marks every failure line with ✖, which nothing else in the output uses', () => {
+            // `grep '✖'` has to be sufficient on its own — that alone would have saved
+            // the fifteen minutes #1159 measured, with no recap being read at all.
+            // `✗` is expected failures and `❌` is the per-test line plus the summary,
+            // so neither can serve.
+            const lines = plain(formatFailureRecap([entry('a', 'one', 'x'), entry('b', 'two', 'y')], 2));
+            for (const line of lines) expect(line.includes('✖')).toBe(true);
+            expect(lines.some((l) => l.includes('✗') || l.includes('❌'))).toBe(false);
+        });
+
+        await it('reports its own blind spot when the tally exceeds the ledger', () => {
+            // The incident behind #1159 was a suite TIMEOUT: it raised the tally
+            // without recording anything, so a recap over the ledger alone would have
+            // printed an empty list under a red summary — a fix that looks like one.
+            // Both timeout paths now record; this line is what makes a future one loud.
+            const lines = plain(formatFailureRecap([entry('s', 't', 'x')], 3));
+            const last = lines[lines.length - 1]!;
+            expect(last.includes('3 failures counted but 1 named')).toBe(true);
+            expect(last.includes('INCOMPLETE')).toBe(true);
+        });
+
+        await it('stays silent about the tally when ledger and count agree', () => {
+            const lines = plain(formatFailureRecap([entry('s', 't', 'x'), entry('s', 'u', 'y')], 2));
+            expect(lines.length).toBe(3);
+            expect(lines.some((l) => l.includes('INCOMPLETE'))).toBe(false);
+        });
+
+        await it('carries the runtime tag, so a concatenated CI log stays attributable', () => {
+            // Several runtimes print into one step log; a recap that does not say which
+            // leg it belongs to sends the reader back to bisecting the log.
+            const lines = plain(formatFailureRecap([entry('s', 't', 'x')], 1, '[Node.js 24] '));
+            expect(lines[0]!.includes('[Node.js 24]')).toBe(true);
+        });
+
+        await it('singularises the heading for one failure and pluralises for more', () => {
+            expect(plain(formatFailureRecap([entry('s', 't', 'x')], 1))[0]!.includes('failed test')).toBe(true);
+            expect(
+                plain(formatFailureRecap([entry('s', 't', 'x'), entry('s', 'u', 'y')], 2))[0]!.includes('failed tests'),
+            ).toBe(true);
+        });
+    });
+
+    await describe('formatFailureAnnotations', async () => {
+        await it('emits one ::error:: command per failure, titled with suite and test', () => {
+            const lines = formatFailureAnnotations([entry('boxed lists', 'a row activates', 'Expected 42')]);
+            expect(lines.length).toBe(1);
+            expect(lines[0]!.startsWith('::error title=')).toBe(true);
+            expect(lines[0]!.includes('boxed lists › a row activates')).toBe(true);
+        });
+
+        await it('carries NO escape codes — they would print literally on the summary page', () => {
+            const lines = formatFailureAnnotations([entry('s', 't', 'x')], '[Gjs] ');
+            // eslint-disable-next-line no-control-regex
+            expect(/\x1b\[/.test(lines[0]!)).toBe(false);
+            expect(lines[0]!.includes('[Gjs]')).toBe(true);
+        });
+
+        await it('starts at column 0, or Actions does not read it as a command', () => {
+            const lines = formatFailureAnnotations([entry('s', 't', 'x')]);
+            expect(lines[0]!.startsWith(' ')).toBe(false);
+        });
+
+        await it('encodes the characters a workflow command would otherwise eat', () => {
+            const lines = formatFailureAnnotations([entry('s', 't', 'got 50% of\nthe rows')]);
+            expect(lines[0]!.includes('%25')).toBe(true);
+            // Only the first line is carried, so the newline never reaches the encoder
+            // — but a `%` in that first line must still survive.
+            expect(lines[0]!.includes('the rows')).toBe(false);
+        });
+
+        await it('caps at ten and SAYS how many it dropped', () => {
+            // Actions renders ten annotations per step, and this runner is launched once
+            // per runtime per shard. A silent cap would read as "that was all of them".
+            const many = Array.from({ length: 14 }, (_, i) => entry('s', `t${i}`, 'x'));
+            const lines = formatFailureAnnotations(many);
+            expect(lines.length).toBe(11);
+            expect(lines[10]!.includes('4 further failure(s)')).toBe(true);
+        });
+
+        await it('says nothing extra when the count is exactly the cap', () => {
+            const exactly = Array.from({ length: 10 }, (_, i) => entry('s', `t${i}`, 'x'));
+            expect(formatFailureAnnotations(exactly).length).toBe(10);
+        });
+    });
+};

--- a/packages/gjs/unit/src/failure-recap.spec.ts
+++ b/packages/gjs/unit/src/failure-recap.spec.ts
@@ -9,7 +9,9 @@
 import { describe, expect, it, formatFailureAnnotations, formatFailureRecap } from '@gjsify/unit';
 
 /** Strip SGR codes so assertions read the text, not the colouring. */
-const plain = (lines: string[]): string[] => lines.map((l) => l.replace(/\x1b\[[0-9;]*m/g, ''));
+// oxlint-disable-next-line no-control-regex -- ANSI SGR sequences are ESC-prefixed by design
+const ANSI = /\x1b\[[0-9;]*m/g;
+const plain = (lines: string[]): string[] => lines.map((l) => l.replace(ANSI, ''));
 
 const entry = (suite: string, test: string, message: string) => ({ suite, test, message });
 
@@ -84,8 +86,10 @@ export default async () => {
 
         await it('carries NO escape codes — they would print literally on the summary page', () => {
             const lines = formatFailureAnnotations([entry('s', 't', 'x')], '[Gjs] ');
-            // eslint-disable-next-line no-control-regex
-            expect(/\x1b\[/.test(lines[0]!)).toBe(false);
+            // A fresh non-global matcher: `ANSI` carries `g`, and `.test()` on a global
+            // regex advances its `lastIndex`, so sharing it here would make this
+            // assertion depend on whatever ran before it.
+            expect(lines[0]!.includes('\x1b[')).toBe(false);
             expect(lines[0]!.includes('[Gjs]')).toBe(true);
         });
 

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -1009,7 +1009,12 @@ export const describe = async function (
         await withTimeout(callback, suiteTimeoutMs, `describe: ${moduleName}`);
     } catch (e) {
         if (e instanceof TimeoutError) {
+            // Counted AND recorded. This used to raise the tally without entering the
+            // failure ledger, so the run reported "1 of N tests failed" over a ledger
+            // that named nothing — which is the whole of #1159. A recap alone would
+            // not have fixed it: there was nothing to recap.
             ++countTestsFailed;
+            testErrors.push({ suite: moduleName, test: '<suite timed out>', message: e.message });
             print(`  ${RED}⏱ Suite timed out: ${e.message}${RESET}`);
         } else {
             throw e;
@@ -1522,10 +1527,106 @@ const printResult = () => {
     }
 
     if (countTestsFailed) {
+        printFailureRecap(rtTag);
         print(`\n${RED}❌ ${rtTag}${countTestsFailed} of ${countTestsOverall} tests failed${durationStr}${RESET}`);
     } else {
         print(`\n${GREEN}✔ ${rtTag}${countTestsOverall} completed${durationStr}${RESET}`);
     }
+};
+
+/**
+ * Name every failure, right above the summary that counts them.
+ *
+ * WHY (#1159). The summary line was the only failure signal and it names nothing, and
+ * NO marker distinguished a failing line from a passing one: a grep for `✖`, `✘`,
+ * `❌`, `not ok` or `AssertionError` over a 9305-line CI log returned the summary and
+ * nothing else. Locating one test name in a red macOS run took about fifteen minutes
+ * of pure retrieval — and `macos-suites.yml` / `windows-suites.yml` run on `main` and
+ * the nightly, NOT on PRs (ADR 0018 § 5), so the least readable legs are exactly the
+ * ones nobody watches live, read by someone deciding whether their merge did it.
+ *
+ * `✖` is the marker because it appears nowhere else in this runner's output (`✗` is
+ * expected failures, `❌` is the per-test line and the summary), so `grep '✖'` alone
+ * answers "what failed" without any recap being read.
+ *
+ * IT ALSO REPORTS ITS OWN BLIND SPOT. The tally and the ledger are two counters, and
+ * they were out of step: both timeout paths raised the tally without recording
+ * anything, which is why the incident that motivated #1159 had nothing to recap in
+ * the first place. Rather than silently listing fewer failures than it counted, a
+ * mismatch is stated — a gap that announces itself cannot be mistaken for a clean
+ * list.
+ */
+const printFailureRecap = (rtTag: string): void => {
+    for (const line of formatFailureRecap(testErrors, countTestsFailed, rtTag)) print(line);
+    // On Actions, also put the names on the run's SUMMARY page. That is where the
+    // person who just merged is already looking, and until now the only annotation
+    // there was `Process completed with exit code 1`.
+    if (envVar('GITHUB_ACTIONS')) for (const line of formatFailureAnnotations(testErrors, rtTag)) print(line);
+};
+
+/**
+ * The failures as GitHub Actions `::error::` workflow commands.
+ *
+ * Separate from the human recap because the constraints differ: a command must start
+ * at column 0, carry no SGR codes (they would be printed literally in the annotation),
+ * and encode newlines as `%0A`. Emitting a coloured recap line here would put escape
+ * sequences on the summary page.
+ *
+ * Capped, because Actions renders at most ten annotations per step and this runner is
+ * launched once per runtime per shard — a 200-failure leg would spend the whole budget
+ * on one shard and push every other leg's first failure off the page. The count is
+ * stated when it truncates, so the cap can never read as "that was all of them".
+ */
+export const formatFailureAnnotations = (
+    entries: ReadonlyArray<{ suite: string; test: string; message: string }>,
+    rtTag = '',
+    max = 10,
+): string[] => {
+    const escape = (s: string): string => s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+    const lines = entries
+        .slice(0, max)
+        .map(
+            (e) =>
+                `::error title=${escape(`${rtTag}${e.suite} › ${e.test}`)}::${escape(e.message.trim().split('\n')[0]!)}`,
+        );
+    if (entries.length > max) {
+        lines.push(
+            `::error title=${escape(`${rtTag}more failures`)}::${entries.length - max} further failure(s) — see the ✖ recap in the log`,
+        );
+    }
+    return lines;
+};
+
+/**
+ * The recap's LINES, as a pure function of the ledger and the tally.
+ *
+ * Split out so a spec can drive the shipping formatter: `printFailureRecap` reads
+ * module-level state and writes to stdout, neither of which a test can reach — and a
+ * reporter nothing tests is how the gap in #1159 lasted this long. The colour codes
+ * are applied here too, so assertions see the shipped strings rather than a parallel
+ * spelling of them.
+ */
+export const formatFailureRecap = (
+    entries: ReadonlyArray<{ suite: string; test: string; message: string }>,
+    countFailed: number,
+    rtTag = '',
+): string[] => {
+    const lines = [`\n${RED}✖ ${rtTag}failed test${entries.length === 1 ? '' : 's'}${RESET}`];
+    for (const e of entries) {
+        // First line only: an assertion's message can be a multi-line diff, and this
+        // block exists to be SCANNED. The full text is already above, at the failure.
+        const reason = e.message.trim().split('\n')[0];
+        lines.push(`  ${RED}✖ ${e.suite} › ${e.test}${RESET}${GRAY} — ${reason}${RESET}`);
+    }
+
+    if (entries.length !== countFailed) {
+        lines.push(
+            `  ${RED}✖ ${countFailed} failure${countFailed === 1 ? '' : 's'} counted but ` +
+                `${entries.length} named — a failure path is raising the tally without recording ` +
+                `itself, so this list is INCOMPLETE${RESET}`,
+        );
+    }
+    return lines;
 };
 
 /**
@@ -1596,8 +1697,12 @@ export const run = async (namespaces: Namespaces, options?: RunOptions | number)
                 await withTimeout(() => runTests(namespaces), timeoutConfig.runTimeout, 'entire test run');
             } catch (e) {
                 if (e instanceof TimeoutError) {
+                    // Recorded for the same reason as the suite timeout above: a
+                    // counted failure that is absent from the ledger cannot be named
+                    // in the recap, and the recap is the only place a CI reader looks.
                     print(`\n${RED}⏱ ${e.message}${RESET}`);
                     ++countTestsFailed;
+                    testErrors.push({ suite: '<test run>', test: '<run timed out>', message: e.message });
                 } else {
                     throw e;
                 }

--- a/packages/gjs/unit/src/test.mts
+++ b/packages/gjs/unit/src/test.mts
@@ -6,6 +6,7 @@ import itFailingSuite from './it-failing.spec.js';
 import callbackAssertionSuite from './callback-assertion.spec.js';
 import capabilitiesSuite from './capabilities.spec.js';
 import axisLedgerSuite from './axis-ledger.spec.js';
+import failureRecapSuite from './failure-recap.spec.js';
 
 run(
     {
@@ -16,6 +17,7 @@ run(
         callbackAssertionSuite,
         capabilitiesSuite,
         axisLedgerSuite,
+        failureRecapSuite,
     },
     {
         // The runner's own legs are the one place this must hold end-to-end: every

--- a/tests/e2e/unit-fail-attribution/run.mjs
+++ b/tests/e2e/unit-fail-attribution/run.mjs
@@ -194,9 +194,28 @@ function runGjsBundle(outFile) {
     }
 }
 
-function runBundle(outFile) {
+/**
+ * Run the bundle with the CI-detection env PINNED rather than inherited.
+ *
+ * `GITHUB_ACTIONS` is exported into every Actions step and a spawned child inherits
+ * it, so the runner's annotation branch (#1159) fired in CI and not locally: the same
+ * input, two code paths, decided by an env var no test mentioned. That is exactly the
+ * trap `packages/infra/cli/src/affected-classifier.spec.ts` documents for
+ * `GITHUB_OUTPUT`, and it cost a red E2E here before this pin existed.
+ *
+ * `githubActions: true` opts INTO the annotation path, for the test that covers it.
+ */
+function runBundle(outFile, { githubActions = false } = {}) {
+    const env = { ...process.env };
+    if (githubActions) env.GITHUB_ACTIONS = 'true';
+    else delete env.GITHUB_ACTIONS;
     try {
-        const stdout = execFileSync('node', [outFile], { stdio: 'pipe', timeout: 60 * 1000, encoding: 'utf8' });
+        const stdout = execFileSync('node', [outFile], {
+            stdio: 'pipe',
+            timeout: 60 * 1000,
+            encoding: 'utf8',
+            env,
+        });
         return { code: 0, out: stdout };
     } catch (e) {
         return { code: e.status ?? -1, out: `${e.stdout ?? ''}${e.stderr ?? ''}` };
@@ -283,6 +302,40 @@ describe('@gjsify/unit failure attribution E2E', { timeout: 5 * 60 * 1000 }, () 
         );
 
         assert.notStrictEqual(code, 0, 'a run that destroyed its cwd must exit non-zero');
+    });
+
+    it('under GITHUB_ACTIONS the failure is also emitted as a workflow command', () => {
+        // The branch that turned this suite red before `runBundle` pinned the env: on
+        // Actions the runner also writes `::error::` lines so the names reach the run's
+        // summary page. Covered here rather than left to the machine — an output branch
+        // that only appears in CI is one nobody reads until it breaks something else.
+        const out = join(tmpDir, 'annotated-cwd.node.mjs');
+        buildEntryFromUnitSrc('__e2e_annotated_cwd.mts', DELETED_CWD_SUITE, out);
+        const { code, out: stdout } = runBundle(out, { githubActions: true });
+        const plain = stripAnsi(stdout);
+
+        const commands = plain.split('\n').filter((l) => l.startsWith('::error title='));
+        assert.strictEqual(commands.length, 1, 'exactly one annotation for the one failure');
+        assert.match(commands[0], /deleted working directory/, 'the annotation carries the reason');
+
+        // A workflow command must start at column 0 and carry no SGR bytes, or Actions
+        // prints it literally instead of rendering an annotation.
+        const raw = stdout.split('\n').find((l) => l.includes('::error title='));
+        assert.ok(raw.startsWith('::error title='), 'the command must start at column 0');
+        // A plain substring check, not a regex: `no-control-regex` flags the escape in
+        // either spelling, and the suppression would be noise for a one-character test.
+        assert.ok(!raw.includes('\u001b['), 'the command must carry no escape codes');
+
+        assert.notStrictEqual(code, 0, 'still a failing run');
+    });
+
+    it('without GITHUB_ACTIONS it emits no workflow commands', () => {
+        // The other half of the pin: the default path must stay quiet, so a developer
+        // reading the log locally never sees Actions plumbing.
+        const out = join(tmpDir, 'unannotated-cwd.node.mjs');
+        buildEntryFromUnitSrc('__e2e_unannotated_cwd.mts', DELETED_CWD_SUITE, out);
+        const { out: stdout } = runBundle(out);
+        assert.doesNotMatch(stripAnsi(stdout), /^::error/m, 'no workflow commands off Actions');
     });
 
     it('a clean suite (incl. toThrow-wrapped matcher) reports zero failures', () => {

--- a/tests/e2e/unit-fail-attribution/run.mjs
+++ b/tests/e2e/unit-fail-attribution/run.mjs
@@ -262,9 +262,25 @@ describe('@gjsify/unit failure attribution E2E', { timeout: 5 * 60 * 1000 }, () 
         // this is where the failure surfaced — in a spec that touches nothing.
         assert.match(plain, /✔ B bystander never touches the cwd/, 'the later bystander must stay green');
 
-        // Reported once, not once per remaining test.
-        const occurrences = plain.split('deleted working directory').length - 1;
-        assert.strictEqual(occurrences, 1, 'the transition is reported exactly once');
+        // Reported at the failure and once more in the recap — and NOWHERE else.
+        //
+        // The property under test is that the count does not scale with the suite: the
+        // bug this pins reported the transition once per REMAINING test. Since #1159 the
+        // runner also names every failure in a recap block above the summary, so the
+        // honest assertion is one occurrence on each side of that block's header rather
+        // than a loosened "at least one", which would stop noticing per-test repetition.
+        const parts = plain.split(/^\u2716 .*failed tests?$/m);
+        assert.strictEqual(parts.length, 2, 'expected exactly one failure-recap header');
+        assert.strictEqual(
+            parts[0].split('deleted working directory').length - 1,
+            1,
+            'the transition is reported exactly once where it happened',
+        );
+        assert.strictEqual(
+            parts[1].split('deleted working directory').length - 1,
+            1,
+            'and exactly once in the recap that names it',
+        );
 
         assert.notStrictEqual(code, 0, 'a run that destroyed its cwd must exit non-zero');
     });


### PR DESCRIPTION
Closes #1159.

## What the reader got

```
❌ [Node.js 24.18.0] 1 of 2087 tests failed  (35.28s)
```

No name, and no marker separating a failing line from a passing one: a grep for `✖`, `✘`, `❌`,
`not ok` or `AssertionError` over a 9305-line step log returned that summary and nothing else.
Attributing one red macOS run took ~20 minutes, ~15 of them purely locating the name.

It lands harder than it looks: `macos-suites.yml` / `windows-suites.yml` run on `main` and the
nightly, **not** on PRs (ADR 0018 § 5, deliberately — macOS runners bill at 10×). So the least
readable legs are exactly the ones nobody watches live, and the reader is usually someone who has
just merged and is trying to decide whether it was them.

## The recap alone would not have fixed it

This is the part that could not be seen from outside the runner: **both timeout paths raised
`countTestsFailed` without pushing to `testErrors`.** The incident behind the issue *was* a suite
timeout — so a recap over the ledger would have printed an empty list under a red summary and
looked like a fix.

I audited every `++countTestsFailed` site. Exactly two were ledger-less, both timeouts
(`describe` exceeded, and the whole-run timeout). Both now record.

A/B against the genuinely pre-change runner — `lib/` rebuilt from `HEAD`'s source, not just the
source swapped, because the probe resolves `@gjsify/unit` through the built package and my first
attempt measured the new code twice — on a probe carrying one assertion failure and one suite
timeout:

| | old | new |
|---|---|---|
| grep `✖`/`✘`/`not ok`/`AssertionError` | **nothing** | both failures named |
| what the log ended with | `❌ 2 of 2 tests failed` | recap + summary |

```
✖ [Node.js 24.15.0] failed tests
  ✖ probe assertions › an assertion that fails — Expected values to match using ===
  ✖ probe timeout › <suite timed out> — Timeout: "describe: probe timeout" exceeded 300ms
```

## Three things, per the issue

- **A recap block** above the summary: `suite › test — first line of the reason`. First line only;
  the full diff is already printed at the failure, and this block exists to be scanned.
- **A stable marker.** `✖` appears nowhere else in this runner's output (`✗` is expected failures,
  `❌` the per-test line and the summary), so `grep '✖'` is sufficient on its own — which the issue
  notes would have solved the whole incident with no recap read at all.
- **GitHub annotations per failure**, so the names reach the run's summary page. Capped at ten,
  because Actions renders ten per step and this runner is launched once per runtime per shard; a
  silent cap would read as "that was all of them", so it states what it dropped.

## It reports its own blind spot

The tally and the ledger are two counters, and they were out of step. Rather than silently listing
fewer failures than it counted, a mismatch is now stated:

```
  ✖ 3 failures counted but 1 named — a failure path is raising the tally without
    recording itself, so this list is INCOMPLETE
```

A gap that announces itself cannot be mistaken for a clean list. That line is the mechanism; the
two timeout fixes are just today's instances.

## Verification

Both formatters are pure and exported, because the reporter was the one part of this runner that
nothing tested — which is how the gap lasted. 13 tests over the **shipped** strings (SGR codes
included, so no parallel spelling can drift):

- 315 tests green on **Gjs 1.88.1, Node 24.15.0, Bun 1.3.14, Deno 2.9.4**
- annotations verified end-to-end with `GITHUB_ACTIONS=1`: column 0, no escape codes, `%`-encoded
- repo-wide `gjsify format --no-write` clean, `tsc --noEmit` clean, comment budget clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
