### PR TITLE
fix(adwaita-storybook): let the web preview scroll again

### DIFF
--- a/packages/web/adwaita-storybook/package.json
+++ b/packages/web/adwaita-storybook/package.json
@@ -19,7 +19,8 @@
         "clear": "gjsify clear lib tsconfig.tsbuildinfo",
         "check": "gjsify tsc --noEmit",
         "build": "gjsify run build:types",
-        "build:types": "gjsify tsc"
+        "build:types": "gjsify tsc",
+        "build:test:browser": "gjsify build src/test.browser.mts --app browser --outfile dist/test.browser.mjs"
     },
     "keywords": [
         "storybook",

--- a/packages/web/adwaita-storybook/src/preview-scroll.spec.ts
+++ b/packages/web/adwaita-storybook/src/preview-scroll.spec.ts
@@ -1,0 +1,127 @@
+// Where the preview area's scroll BOUND actually lands.
+//
+// WHY THIS IS THE FIRST TEST IN THIS PACKAGE. The web preview stopped scrolling
+// entirely: a tall story ended mid-page and nothing below was reachable. Every
+// layer's CSS was individually valid — the overlay split view held itself to the
+// window height, the scroller declared overflow: auto and min-height: 0 — but the
+// slotted pane between them had no rule in this target, so it grew to the content's
+// height and handed the scroller a bound equal to its own content. clientHeight ===
+// scrollHeight, nothing to scroll, remainder clipped by an overflow: hidden further
+// up.
+//
+// Nothing could have caught that by reading state or class names, which is all the
+// sibling suites do. The rule this encodes: a layout has to be asserted by WHERE
+// things land — measure the box, not the declaration.
+//
+// Runs in the tests/browser Playwright harness, which drives FIREFOX in CI, not just
+// Chromium.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+// Registers the custom elements the storybook chrome is built from, and injects the
+// adwaita-web stylesheet. Without it the panes are unstyled inline boxes and every
+// measurement below would be meaningless rather than wrong.
+import '@gjsify/adwaita-web';
+
+import type { StoryMeta } from '@gjsify/stories';
+import { StoryElement } from './story-element.js';
+import { mountStorybook } from './app.js';
+import type { WebStoryModule } from './types.js';
+
+/** A story deliberately taller than any host we mount it in. */
+class TallStory extends StoryElement {
+    constructor() {
+        super(TallStory.getMetadata(), 'Default');
+    }
+
+    /** Part of the authoring contract the registry instantiates through. */
+    static getMetadata(): StoryMeta {
+        return { title: 'Probe/Tall', description: 'taller than its host on purpose', controls: [] };
+    }
+
+    initialize(): void {
+        const filler = document.createElement('div');
+        filler.style.height = '1600px';
+        filler.style.width = '100%';
+        this.addContent(filler);
+    }
+}
+
+const HOST_HEIGHT = 600;
+
+/** Mount the storybook in a fixed-height host and hand back its preview scroller. */
+function mountTall(): { host: HTMLElement; scroller: HTMLElement } {
+    const host = document.createElement('div');
+    // A definite height, because that is the whole question: the real page gives the
+    // window one and the chain has to carry it down.
+    host.style.height = `${HOST_HEIGHT}px`;
+    host.style.width = '900px';
+    document.body.append(host);
+
+    const module: WebStoryModule = { stories: [TallStory] };
+    mountStorybook(host, { stories: [module], title: 'Probe' });
+
+    const scroller = host.querySelector('.sb-preview-scroll') as HTMLElement | null;
+    if (!scroller) throw new Error('no .sb-preview-scroll after mount — the chrome changed shape');
+    return { host, scroller };
+}
+
+export const AdwStorybookPreviewScrollTest = async () => {
+    await describe('storybook preview scrolling', async () => {
+        await it('bounds the scroller by its host rather than by its content', () => {
+            const { host, scroller } = mountTall();
+            try {
+                // The defect in one assertion: the scroller was 1008px tall inside a
+                // 697px bound because the pane above it ignored the bound.
+                expect(scroller.clientHeight).toBeLessThan(HOST_HEIGHT);
+                expect(scroller.clientHeight).toBeGreaterThan(0);
+            } finally {
+                host.remove();
+            }
+        });
+
+        await it('can actually scroll when the story is taller than the host', () => {
+            const { host, scroller } = mountTall();
+            try {
+                expect(scroller.scrollHeight).toBeGreaterThan(scroller.clientHeight);
+            } finally {
+                host.remove();
+            }
+        });
+
+        await it('reaches the bottom of the story', () => {
+            // Being scrollable is not the same as being able to READ the end: an
+            // ancestor clipping at the fold satisfies the two assertions above while
+            // the last rows stay unreachable.
+            const { host, scroller } = mountTall();
+            try {
+                scroller.scrollTop = scroller.scrollHeight;
+                expect(scroller.scrollTop).toBeGreaterThan(0);
+                const reached = scroller.scrollTop + scroller.clientHeight;
+                expect(reached).toBeGreaterThan(scroller.scrollHeight - 2);
+            } finally {
+                host.remove();
+            }
+        });
+
+        await it('keeps every layer between the bound and the scroller collapsible', () => {
+            // The named cause, so a future regression says WHICH layer broke instead of
+            // only that scrolling stopped. min-height: auto on any of them re-creates
+            // the defect exactly.
+            const { host, scroller } = mountTall();
+            try {
+                let el: HTMLElement | null = scroller;
+                const offenders: string[] = [];
+                while (el && el !== host) {
+                    const style = getComputedStyle(el);
+                    if (style.minHeight !== '0px' && style.minHeight !== '0')
+                        offenders.push(`${el.tagName.toLowerCase()}.${String(el.className || '-').split(' ')[0]}`);
+                    el = el.parentElement;
+                }
+                expect(offenders).toStrictEqual([]);
+            } finally {
+                host.remove();
+            }
+        });
+    });
+};

--- a/packages/web/adwaita-storybook/src/styles.ts
+++ b/packages/web/adwaita-storybook/src/styles.ts
@@ -163,6 +163,31 @@ export const STORYBOOK_WEB_CSS = `
 }
 
 /* --- Preview area --- */
+
+/* The slotted content pane has to PASS ITS BOUND DOWN, or the scroller below it has
+   nothing to scroll against.
+
+   Measured before this rule existed: .adw-osv-content bounded itself correctly at
+   697px while its content wanted 1008px, but this div — display: block,
+   min-height: auto, flex: 0 1 auto — ignored that and grew to 1008. So
+   .sb-preview-scroll inherited clientHeight === scrollHeight, had nothing to scroll,
+   and everything past the fold was clipped by the toolbar view's overflow: hidden:
+   a tall story just ended mid-page.
+
+   The sidebar never had this. Its scroller sits directly inside the toolbar view's own
+   flex content wrapper, so nothing breaks the chain there; this pane is the one place
+   a plain div sits between the bound and the scroller.
+
+   NOTE: no backticks in this file's comments — the whole stylesheet is a JS template
+   literal, so a backtick ends it and the parse error lands nine lines away. */
+.sb-preview-pane {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    min-width: 0;
+}
+
 .sb-preview-scroll {
     flex: 1 1 auto;
     min-height: 0;

--- a/packages/web/adwaita-storybook/src/test.browser.mts
+++ b/packages/web/adwaita-storybook/src/test.browser.mts
@@ -1,0 +1,12 @@
+// Browser test entry for @gjsify/adwaita-storybook. Discovered and run by the
+// tests/browser Playwright harness (see AGENTS.md → Browser tests), which drives
+// Firefox in CI.
+//
+// This package had no test entry at all until the preview stopped scrolling — its
+// output is layout, and layout is the one thing a state-and-class-names assertion
+// cannot see.
+import { run } from '@gjsify/unit';
+
+import { AdwStorybookPreviewScrollTest } from './preview-scroll.spec.js';
+
+run({ AdwStorybookPreviewScrollTest });

--- a/packages/web/adwaita-storybook/tsconfig.json
+++ b/packages/web/adwaita-storybook/tsconfig.json
@@ -2,7 +2,11 @@
     "compilerOptions": {
         "module": "ESNext",
         "target": "ESNext",
-        "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        "lib": [
+            "ESNext",
+            "DOM",
+            "DOM.Iterable"
+        ],
         "rootDir": "src",
         "outDir": "lib",
         "declarationDir": "lib/types",
@@ -10,8 +14,11 @@
         "moduleResolution": "bundler",
         "allowImportingTsExtensions": true,
         "emitDeclarationOnly": true,
+        "skipLibCheck": true,
         "strict": true,
         "types": []
     },
-    "include": ["src/**/*.ts"]
+    "include": [
+        "src/**/*.ts"
+    ]
 }


### PR DESCRIPTION
Reported from use: in the browser storybook the main area does not scroll. The Widgets gallery
ends somewhere inside Account and nothing below it is reachable.

## Measured, not guessed

Chromium against the built bundle, walking the chain from the scroller upwards:

| element | clientHeight | scrollHeight | overflow-y | min-height | display |
|---|---|---|---|---|---|
| `.sb-preview-scroll` | 1008 | 1008 | auto | 0 | block |
| **`.sb-preview-pane`** | **1008** | **1008** | visible | **auto** | **block** |
| `.adw-osv-content` | 697 | 1008 | visible | 0 | flex |

The bound was already there — `.adw-osv-content` correctly held itself to 697px while its content
wanted 1008. The slotted pane between it and the scroller had **no rule at all in this target**, so
as a `display: block` box with `min-height: auto` it ignored the bound and grew to the content's
height. The scroller then inherited `clientHeight === scrollHeight`, had nothing to scroll, and the
remainder was clipped by the toolbar view's `overflow: hidden`.

Every layer was individually valid. The composition was unusable.

The sidebar never had this: its scroller sits directly inside the toolbar view's own flex content
wrapper, so nothing breaks that chain. This pane is the one place a plain div sits between the bound
and the scroller — and the NativeScript theme has always styled its equivalent.

After, same measurement: `client=697 scroll=1008`, scrollable, and scrolled to the bottom Devices,
the Advanced expander, Shortcuts and Actions are all reachable.

## The mechanism, because this class is invisible to the existing suites

`packages/web/adwaita-storybook` had **no test entry at all**. Its output is layout, and reading
state and class names — what the sibling suites do — cannot see a composition defect. Four
assertions now run in the Playwright harness (Firefox in CI):

- the scroller is bounded by its **host**, not by its content
- it can scroll when the story is taller than the host
- `scrollTop` actually reaches the end — *scrollable is not the same as readable*: an ancestor
  clipping at the fold satisfies the first two assertions while the last rows stay unreachable
- every layer between the bound and the scroller stays collapsible, so a regression reports **which
  layer** grew a `min-height` rather than only that scrolling stopped

A/B-measured by deleting the new rule and rebuilding — all four fail, legibly:

```
Expected 1745 to be less than 600
Expected 1745 to be greater than 1745      ← clientHeight === scrollHeight
Expected 0 to be greater than 0
```

No CI wiring: the Playwright leg discovers `packages/*/*/dist/test.browser.mjs`, so the new
`build:test:browser` script suffices.

## Two notes left for the next reader

- **No backticks in that stylesheet's comments.** It is a JS template literal, so a backtick ends it
  and the parse error surfaces nine lines from the cause — which is how the first version of the
  comment failed to build.
- `tsconfig` gains `skipLibCheck`, matching the sibling `adwaita-web`: `@gjsify/unit`'s own `.d.ts`
  references `node:assert`. Skipping a dependency's check is narrower than `types: ["node"]`, which
  would pull Node globals into a browser package's type space and stop a stray Node import from
  being an error.

Verified: lint, repo-wide `format --check`, `tsc --noEmit`, comment budget `--check`, and the new
browser suite green under Firefox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
