### PR TITLE
fix(storybook): tint the preview area, not a box inside it

### DIFF
--- a/packages/framework/storybook/src/styles.ts
+++ b/packages/framework/storybook/src/styles.ts
@@ -92,30 +92,35 @@ export const STORYBOOK_CSS = `
     background-color: @window_bg_color;
 }
 
-/* The live preview's stage. It has to stay LOCATABLE even when the widget on it
-   is transparent or in an empty state (a collapsed bottom sheet, a status page,
-   a bare button) — that requirement is why a frame was here at all. A dashed
-   border met it by drawing attention to itself; two corner tints meet it by
-   giving the stage a surface, which is what the widget gallery on the website
-   does and what this mirrors.
+/* The preview AREA carries the tint, not a box inside it.
 
-   BOTH SCHEMES, WITHOUT BRANCHING. A Gtk.CssProvider string cannot ask which
-   colour scheme is active, so the tint is named rather than spelled out:
-   @accent_color is libadwaita's STANDALONE accent, defined as the accent moved
-   to a lightness that reads against the current scheme's background
-   (oklab min(l, 0.5) in light, max(l, 0.85) in dark — _colors.scss:25,88). It is
-   therefore correct in both by construction, and it follows a runtime accent, so
-   the stage is never blue while the widgets are orange. The website hardcodes
-   #3584e4 / #78aeed for the same two states, which is this name resolved by hand.
+   The requirement is unchanged — the preview must stay LOCATABLE when the widget on
+   it is transparent or in an empty state (a collapsed bottom sheet, a status page, a
+   bare button), which is why a frame was here at all. A dashed border met it by
+   drawing attention to itself; a box with a surface met it by floating in the pane
+   with no edge, which is how it read. The whole area meets it by being the surface,
+   which is what the widget gallery on the website does: there the tint is on the
+   preview panel and the stage within it is only centring.
 
-   The purple counter-tint has no named equivalent and stays a literal, as it is
-   on the website — it is decoration, not a role, and it is the same hue in both
-   schemes there too. */
-.story-stage {
-    border-radius: 12px;
-    padding: 18px;
+   BOTH SCHEMES, WITHOUT BRANCHING. A Gtk.CssProvider string cannot ask which colour
+   scheme is active, so the tint is named rather than spelled out: @accent_color is
+   libadwaita's STANDALONE accent, defined as the accent moved to a lightness that
+   reads against the current scheme's background (oklab min(l, 0.5) in light,
+   max(l, 0.85) in dark — _colors.scss:25,88). Correct in both by construction, and it
+   follows a runtime accent, so the area is never blue while the widgets are orange.
+   The website hardcodes #3584e4 / #78aeed for those two states, which is this name
+   resolved by hand.
+
+   The purple counter-tint has no named equivalent and stays a literal, as on the
+   website — decoration, not a role, and the same hue in both schemes there too. */
+.sb-preview-area {
     background-image:
         radial-gradient(circle at 0% 0%, alpha(@accent_color, 0.07), transparent 45%),
         radial-gradient(circle at 100% 100%, alpha(#926ee4, 0.06), transparent 45%);
+}
+
+/* Breathing room only. No radius and no surface: nothing here is a box any more. */
+.story-stage {
+    padding: 18px;
 }
 `;

--- a/packages/framework/storybook/src/window.ts
+++ b/packages/framework/storybook/src/window.ts
@@ -366,6 +366,10 @@ export class StorybookWindow extends Adw.ApplicationWindow implements StorybookV
         // --- Preview content + controls overlay ---
         this._content_area = new Adw.Bin({ hexpand: true, vexpand: true });
         const contentScroll = new Gtk.ScrolledWindow({ hexpand: true, vexpand: true, child: this._content_area });
+        // The preview AREA owns the tinted surface (see `.sb-preview-area`). On the
+        // scroller rather than on the Bin inside it, so the tint spans the pane and
+        // stays put while a tall story scrolls.
+        contentScroll.add_css_class('sb-preview-area');
 
         this._control_panel = new Adw.PreferencesGroup({ title: 'Controls' });
         const prefsPage = new Adw.PreferencesPage();

--- a/packages/nativescript-bridge/storybook/src/theme/storybook.css
+++ b/packages/nativescript-bridge/storybook/src/theme/storybook.css
@@ -108,8 +108,26 @@
 /* ===== Detail area (preview content + right controls overlay) ===== */
 
 .sb-controls-split,
+/* The preview AREA carries the tint, not a box inside it — the stage version floated
+ * in the pane with no edge. On the element that already owns the area's background,
+ * because an opaque background one level in covers a gradient one level out (measured
+ * on the browser target: five sample points across the pane returned the identical
+ * colour while the computed style still reported a background-image).
+ *
+ * The NS subset's two substitutions still hold: one `linear-gradient` per declaration
+ * rather than two radial corners, and the accent spelled out per scheme because there
+ * are no custom properties — so a runtime accent does NOT reach this backdrop here.
+ * Middle stops fade to a zero-alpha COPY of each tint rather than to `transparent`,
+ * which is rgba(0,0,0,0) and pulls a grey through the centre. */
 .sb-preview-scroll {
     background-color: #fafafb;
+    background-image: linear-gradient(
+        135deg,
+        rgba(28, 113, 216, 0.07) 0%,
+        rgba(28, 113, 216, 0) 45%,
+        rgba(146, 110, 228, 0) 55%,
+        rgba(146, 110, 228, 0.06) 100%
+    );
 }
 
 .sb-preview-pane {
@@ -136,41 +154,11 @@
     margin: 3 0 0 0;
 }
 
-/*
- * Centered, tinted preview stage (mirrors the browser .story-stage and the
- * native renderer's .story-stage).
- *
- * The stage must stay LOCATABLE when the widget on it is transparent or in an
- * empty state — that requirement is why it was framed at all, and two corner
- * tints meet it with a surface instead of a dashed outline.
- *
- * TWO SUBSTITUTIONS THE NS CSS SUBSET FORCES, both deliberate:
- *
- * 1. No `radial-gradient` — the parser recognises `linear-gradient` and nothing
- *    else (css/parser.js:424), and it parses ONE gradient per declaration, so
- *    the other two targets' pair of corner circles becomes a single 135deg
- *    sweep: accent in the top-left corner, purple in the bottom-right, clear
- *    through the middle where the widget sits.
- * 2. No custom properties, so the standalone accent the other two name
- *    (@accent_color / var(--accent-color)) is spelled out per scheme — the same
- *    two values adwaita-web resolves it to. A runtime accent therefore does NOT
- *    reach this backdrop on NS, unlike the other two targets.
- *
- * The middle stop fades to a ZERO-ALPHA COPY of the tint rather than to
- * `transparent`: `transparent` is rgba(0,0,0,0), and interpolating towards it
- * pulls a grey through the centre wherever the renderer does not premultiply.
- */
+/* Breathing room only. No radius and no surface: nothing here is a box any more —
+ * the tinted area is `.sb-preview-scroll` above. */
 .story-stage {
-    border-radius: 12;
     padding: 18;
     margin: 12 0 0 0;
-    background-image: linear-gradient(
-        135deg,
-        rgba(28, 113, 216, 0.07) 0%,
-        rgba(28, 113, 216, 0) 45%,
-        rgba(146, 110, 228, 0) 55%,
-        rgba(146, 110, 228, 0.06) 100%
-    );
 }
 
 /* ===== Controls panel — a RIGHT overlay (sidebar_position=END) ===== */
@@ -241,10 +229,6 @@
     color: rgba(255, 255, 255, 0.55);
 }
 
-.ns-dark .story-stage {
-    border-color: rgba(255, 255, 255, 0.28);
-}
-
 /* ===== Appearance dialog swatches =====
  * Round accent swatches. NS has no radio input and no `:checked`, so selection is a
  * class the dialog maintains and the ring is a border — `border-radius`,
@@ -276,7 +260,7 @@
     border-color: #ffffff;
 }
 
-/* The preview stage's dark tint. Only the accent end changes: it carries the
+/* The preview area's dark tint. Only the accent end changes: it carries the
  * STANDALONE accent, which libadwaita lightens for a dark background
  * (#1c71d8 → #78aeed), while the purple is decoration and is the same hue in
  * both schemes — as it is on the website. Alphas rise slightly because a tint
@@ -285,7 +269,7 @@
  * The full compound is restated rather than only the changed stops: NS sums
  * specificity FLAT (class, attribute and pseudo-class 10 each — css-selector.js
  * :205,292) and there is no per-stop cascade for a gradient anyway. */
-.ns-dark .story-stage {
+.ns-dark .sb-preview-scroll {
     background-image: linear-gradient(
         135deg,
         rgba(120, 174, 237, 0.09) 0%,

--- a/packages/web/adwaita-storybook/src/styles.ts
+++ b/packages/web/adwaita-storybook/src/styles.ts
@@ -188,12 +188,26 @@ export const STORYBOOK_WEB_CSS = `
     min-width: 0;
 }
 
+/* The tint belongs to the whole preview AREA, not to a box inside it. On the website
+   it sits on the preview panel and the stage within is only centring; on the stage it
+   drew a grey rectangle floating in the pane with no defined edge, which is how it read.
+
+   HERE and not on .sb-preview-pane, measured: this element paints an OPAQUE
+   background-color, so a gradient one level up is covered completely. Sampling five
+   points across the pane returned the identical colour while the computed style still
+   reported a background-image — true and meaningless.
+
+   A background on a scroll container is painted against its padding box, so it stays
+   put while the content scrolls, the way a wallpaper does. */
 .sb-preview-scroll {
     flex: 1 1 auto;
     min-height: 0;
     min-width: 0;
     overflow: auto;
     background-color: var(--window-bg-color);
+    background-image:
+        radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent-color) 7%, transparent), transparent 45%),
+        radial-gradient(circle at 100% 100%, color-mix(in srgb, #926ee4 6%, transparent), transparent 45%);
 }
 
 .sb-story-page {
@@ -228,19 +242,16 @@ export const STORYBOOK_WEB_CSS = `
     color: var(--window-fg-color);
 }
 
-/* Centered, tinted preview stage (mirrors the native .story-stage).
+/* Centring and breathing room only — the surface is the pane's.
 
-   The stage has to stay LOCATABLE when the widget on it is transparent or empty
-   — that is why it was framed at all. Two corner tints do that with a surface
-   instead of a dashed outline, matching the widget gallery on the website.
+   The stage carried the tint first, and against the pane's own background that read
+   as a grey rectangle floating with no edge rather than as a surface. It has no
+   border-radius for the same reason: nothing here is a box any more.
 
-   BOTH SCHEMES, WITHOUT BRANCHING: --accent-color is the STANDALONE accent
-   (#1c71d8 light, #78aeed dark — _variables.scss:55, _theme.scss:33), already
-   flipped by the same media query and .theme-dark/.theme-light classes that
-   theme everything else here, so this rule needs no scheme of its own. It also
-   follows a runtime accent. The purple counter-tint is decoration rather than a
-   role and stays a literal, as it is on the website, where it is the same hue in
-   both schemes. */
+   The requirement the tint answers is unchanged — the preview area stays locatable
+   when the widget on it is transparent or empty — it is just answered by the AREA
+   now instead of by a rectangle inside it. Scheme handling moved with it, see
+   .sb-preview-pane. */
 .story-stage {
     display: flex;
     flex-direction: column;
@@ -249,11 +260,7 @@ export const STORYBOOK_WEB_CSS = `
     gap: var(--spacing-m);
     padding: var(--spacing-l);
     margin-top: var(--spacing-s);
-    border-radius: var(--card-radius);
     min-height: 80px;
-    background-image:
-        radial-gradient(circle at 0% 0%, color-mix(in srgb, var(--accent-color) 7%, transparent), transparent 45%),
-        radial-gradient(circle at 100% 100%, color-mix(in srgb, #926ee4 6%, transparent), transparent 45%);
 }
 
 /* --- Controls panel --- */


### PR DESCRIPTION
Reported from use: the tint reads as a floating grey rectangle rather than a surface, because it does
not reach the edges of the pane it sits in — either keep a dashed outline around it, or give the whole
area the gradient.

This takes the second, which is what the website does: there the tint is on the preview **panel**
(`.adw-widget-preview`) and the stage within it is only flex-centring. My first port put it on the
stage, which is how the floating box appeared.

The requirement behind the original frame is unchanged — the preview must stay locatable when the
widget on it is transparent or in an empty state — it is answered by the **area** now instead of by a
rectangle inside it. The stage keeps its padding and loses its radius: nothing there is a box any more.

## One measurement decided where it goes, and my first attempt was wrong

Putting it on the web target's `.sb-preview-pane` reported `background-image` present in the computed
style and rendered **nothing**: `.sb-preview-scroll` inside it paints an opaque `background-color`
that covers a gradient one level out. Five sample points across the pane returned the identical
colour while the style still claimed a gradient — true and meaningless.

So each target tints the element that already **owns** its area background:

| target | element | measured (corner / centre / opposite corner) |
|---|---|---|
| browser | `.sb-preview-scroll` | dark: `(40,43,51)` / `(34,34,38)` / `(40,38,49)` |
| GTK | `.sb-preview-area` on the preview `ScrolledWindow` (new class) | dark: `(40,46,56)` / `(34,34,38)` / `(40,38,48)` |
| NativeScript | `.sb-preview-scroll` | light, on the emulator: `(237,242,249)` / `(250,250,251)` / `(245,243,250)` |

A background on a scroll container is painted against its padding box, so it stays put while a tall
story scrolls rather than sliding away with the content.

## Also removed

`.ns-dark .story-stage { border-color: … }` — dead since the dashed border went. A colour for a
border that no longer exists, which survived two changes to the same block.

## Verification

- GTK in **both** schemes via `ADW_DEBUG_COLOR_SCHEME`, screenshotted and pixel-sampled
- browser in dark and light, same
- the NativeScript app built, installed and sampled **on the Android emulator**
- the scroll-geometry browser suite stays green — the pane keeps the `min-height: 0` chain it pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)
