### PR TITLE
fix(hooks): compute the affected-bundle trigger from its closure

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -138,14 +138,38 @@ rebuild_failed() {
 #
 # Both still apply to `affected.gjs.mjs`: it is built by the same `--app gjs`
 # pipeline from the same CLI source tree, so the same inputs stale it.
-AFFECTED_SRC_CHANGED="$(git diff --cached --name-only --diff-filter=ACMR -- packages/infra/cli/src/ packages/infra/cli/package.json packages/infra/resolve-npm/lib/ packages/infra/rolldown-plugin-gjsify/src/ | head -1)"
+# The trigger is COMPUTED from the bundle's own workspace-dep closure, not listed.
+# It used to name four paths over a build that inlines 111 of 201 packages, so a
+# commit touching a closure package the list did not name went out with a stale
+# bundle — measured at 5 of the last 60 commits (#1149). Widening it costs those
+# same 5 firings and buys back 5 CI round-trips; the closure walk is package.json
+# reads only, 47 ms.
+#
+# Cheap pre-filter first: nothing under packages/ staged means nothing in the
+# closure can have changed, and that is the common case.
+if [ -z "$(git diff --cached --name-only --diff-filter=ACMR -- packages/ | head -1)" ]; then
+    exit 0
+fi
+
+AFFECTED_CLOSURE_PATHS="$(node scripts/affected-bundle-closure.mjs 2>/dev/null)"
+if [ -z "$AFFECTED_CLOSURE_PATHS" ]; then
+    # Never silently skip: a closure we could not compute is unknown, not empty.
+    echo "[gjsify pre-commit] could not compute the affected-bundle closure — falling back to the four known inputs."
+    AFFECTED_CLOSURE_PATHS="packages/infra/cli/src
+packages/infra/cli/package.json
+packages/infra/resolve-npm/lib
+packages/infra/rolldown-plugin-gjsify/src"
+fi
+
+# shellcheck disable=SC2086 -- word splitting on the newline-separated path list is intended
+AFFECTED_SRC_CHANGED="$(git diff --cached --name-only --diff-filter=ACMR -- $AFFECTED_CLOSURE_PATHS | head -1)"
 
 if [ -z "$AFFECTED_SRC_CHANGED" ]; then
     exit 0
 fi
 
 echo "[gjsify pre-commit] staged changes may stale packages/infra/cli/dist/affected.gjs.mjs:"
-echo "  • packages/infra/cli/src/ (or package.json), packages/infra/resolve-npm/lib/, or packages/infra/rolldown-plugin-gjsify/src/"
+echo "  • $AFFECTED_SRC_CHANGED (in the bundle's workspace-dep closure)"
 echo "[gjsify pre-commit] rebuilding it — bypass with 'git commit --no-verify' or SKIP_GJSIFY_HOOKS=1."
 
 # `build` first: `build:affected-bundle` bundles `lib/`, which that step emits.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -151,10 +151,40 @@ if [ -z "$(git diff --cached --name-only --diff-filter=ACMR -- packages/ | head 
     exit 0
 fi
 
-AFFECTED_CLOSURE_PATHS="$(node scripts/affected-bundle-closure.mjs 2>/dev/null)"
-if [ -z "$AFFECTED_CLOSURE_PATHS" ]; then
+CLOSURE_SCRIPT="$REPO_ROOT/scripts/affected-bundle-closure.mjs"
+AFFECTED_CLOSURE_PATHS=""
+CLOSURE_FALLBACK_REASON=""
+
+# The two mundane absences are NAMED rather than run into, so the fallback below
+# can say which one happened. A silent fallback that always fires is the worse
+# bug: the closure would never run, every commit would use the four-path list,
+# and nothing would say so.
+#
+# `|| true` on the substitution is LOAD-BEARING. Under `set -e` a failing command
+# substitution in an assignment aborts the shell, so without it the fallback is
+# UNREACHABLE in exactly the case it exists for. Measured: the e2e's synthetic
+# repo has no `scripts/`, node exited 1, and the hook died at exit 1 with the
+# fallback never reached. A hook that cannot compute the closure must degrade,
+# never take the commit with it — the same rule the three guards above follow.
+#
+# stderr is NOT redirected in the third branch: node and the script are both
+# present there, so anything written is a real defect in the walk and belongs on
+# screen. The absences that would merely be noisy are the two handled above.
+if ! command -v node >/dev/null 2>&1; then
+    CLOSURE_FALLBACK_REASON="no node on PATH"
+elif [ ! -f "$CLOSURE_SCRIPT" ]; then
+    CLOSURE_FALLBACK_REASON="$CLOSURE_SCRIPT not found"
+else
+    AFFECTED_CLOSURE_PATHS="$(node "$CLOSURE_SCRIPT" --root "$REPO_ROOT" || true)"
+    if [ -z "$AFFECTED_CLOSURE_PATHS" ]; then
+        CLOSURE_FALLBACK_REASON="the closure walk produced no paths"
+    fi
+fi
+
+if [ -n "$CLOSURE_FALLBACK_REASON" ]; then
     # Never silently skip: a closure we could not compute is unknown, not empty.
-    echo "[gjsify pre-commit] could not compute the affected-bundle closure — falling back to the four known inputs."
+    echo "[gjsify pre-commit] could not compute the affected-bundle closure ($CLOSURE_FALLBACK_REASON)."
+    echo "[gjsify pre-commit] falling back to the four known inputs — a closure package outside them will not fire."
     AFFECTED_CLOSURE_PATHS="packages/infra/cli/src
 packages/infra/cli/package.json
 packages/infra/resolve-npm/lib

--- a/scripts/affected-bundle-closure.mjs
+++ b/scripts/affected-bundle-closure.mjs
@@ -69,9 +69,7 @@ for (const rel of manifests) {
     // that is present locally is present in the build.
     depsOf.set(
         pkg.name,
-        Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies }).filter((n) =>
-            n.startsWith('@gjsify/'),
-        ),
+        Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies }).filter((n) => n.startsWith('@gjsify/')),
     );
 }
 

--- a/scripts/affected-bundle-closure.mjs
+++ b/scripts/affected-bundle-closure.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// The source paths `affected.gjs.mjs` is actually built from — computed, not listed.
+//
+// WHY (#1149). The pre-commit hook decided whether to rebuild that bundle from four
+// hand-maintained paths, over a `--app gjs` build that inlines the WHOLE workspace-dep
+// closure. Its own header was honest that this is best-effort, and CI's
+// `verify-committed-bundles.mjs` is the invariant — but the gap was not free: a commit
+// touching a closure package the list did not name committed a stale bundle, and the
+// cost landed as a CI round-trip.
+//
+// MEASURED before widening it, because "the bundle inlines half the tree" sounds like a
+// trigger that would fire on everything:
+//
+//   closure of @gjsify/cli:            111 of 201 workspace packages (55%)
+//   over the last 60 commits — fired:   21 (four-path list)
+//                              would:   26 (real closure)
+//                    silently stale:     5
+//
+// So correctness costs +5 firings per 60 commits, not "most commits". The 55% is an
+// upper bound on packages, not on how often they are touched. Five wasted CI rounds
+// bought back for five local rebuilds is the trade this makes.
+//
+// Prints one path per line, for `git diff --cached -- $(…)`. Pure package.json reads:
+// no build, no install, no resolver.
+//
+// Usage: node scripts/affected-bundle-closure.mjs [--root <dir>]
+
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+
+/** The package whose `--app gjs` bundle is committed. */
+const ENTRY = '@gjsify/cli';
+
+/**
+ * Paths inlined from a BUILT directory rather than from `src/`, so a `src/` rule would
+ * miss them. `resolve-npm` is bundled from its `lib/`, which is why the old list named
+ * that path specifically — the reasoning was right, it was just not applied to the rest.
+ */
+const BUILT_INPUTS = ['packages/infra/resolve-npm/lib'];
+
+const manifests = execFileSync('git', ['ls-files', '--', 'packages/*/*/package.json'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 1 << 26,
+})
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+/** name → directory, and name → its workspace dependencies. */
+const dirOf = new Map();
+const depsOf = new Map();
+for (const rel of manifests) {
+    let pkg;
+    try {
+        pkg = JSON.parse(readFileSync(join(ROOT, rel), 'utf8'));
+    } catch {
+        continue;
+    }
+    if (!pkg.name) continue;
+    dirOf.set(pkg.name, rel.replace(/\/package\.json$/, ''));
+    // Optional deps count: the bundle inlines whatever resolves, and a platform package
+    // that is present locally is present in the build.
+    depsOf.set(
+        pkg.name,
+        Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies }).filter((n) =>
+            n.startsWith('@gjsify/'),
+        ),
+    );
+}
+
+if (!depsOf.has(ENTRY)) {
+    process.stderr.write(`affected-bundle-closure: ${ENTRY} not found among ${manifests.length} manifests.\n`);
+    process.exit(1);
+}
+
+const closure = new Set();
+const stack = [ENTRY];
+while (stack.length > 0) {
+    const name = stack.pop();
+    if (closure.has(name) || !depsOf.has(name)) continue;
+    closure.add(name);
+    for (const dep of depsOf.get(name)) stack.push(dep);
+}
+
+const paths = [];
+for (const name of closure) {
+    const dir = dirOf.get(name);
+    if (!dir) continue;
+    paths.push(`${dir}/src`);
+    paths.push(`${dir}/package.json`);
+}
+paths.push(...BUILT_INPUTS);
+
+process.stdout.write(`${paths.sort().join('\n')}\n`);

--- a/tests/e2e/git-hooks-cli-bundle-staleness/run.mjs
+++ b/tests/e2e/git-hooks-cli-bundle-staleness/run.mjs
@@ -26,6 +26,7 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
 const INSTALL_SCRIPT = join(REPO_ROOT, 'scripts', 'install-git-hooks.mjs');
+const CLOSURE_SCRIPT = join(REPO_ROOT, 'scripts', 'affected-bundle-closure.mjs');
 
 /**
  * EVERY hook `install-git-hooks.mjs` expects — READ FROM THE INSTALLER, never
@@ -68,11 +69,32 @@ const EXPECTED_HOOKS = (() => {
  *     an incomplete hooks dir)
  *   - `packages/infra/cli/src/index.ts` + `dist/affected.gjs.mjs`
  *   - `node_modules/.bin/gjsify` — synthetic stub recording its argv to a log
+ *   - `scripts/affected-bundle-closure.mjs` — THE REAL SCRIPT, plus enough
+ *     `package.json` manifests for its walk to have something to walk
  *
  * The stub is wired into PATH via `node_modules/.bin` so the hook's resolver
  * picks it up first.
+ *
+ * The manifests are what make these tests test the CLOSURE. Without them the
+ * walk finds no `@gjsify/cli`, the hook takes its four-path fallback, and every
+ * assertion here still passes — the fallback names `cli/src` too. That is not a
+ * hypothetical: the fixture had no manifests when the closure trigger landed, so
+ * the closure walk was never once exercised by this suite (#1149). Any package
+ * added below has to be REACHABLE from `@gjsify/cli`'s dependencies, or it is
+ * outside the closure and the hook is right to ignore it.
+ *
+ * `closureScript` picks which of the three states the hook must survive:
+ *   'real'    — the shipped script (the normal case)
+ *   'missing' — no `scripts/` at all, which the hook's existence guard catches
+ *   'broken'  — present but exits non-zero, which ONLY the `|| true` on the
+ *               command substitution catches, because under `set -e` a failing
+ *               substitution in an assignment aborts the shell
+ *
+ * The last two are separate states on purpose. Both guards produce the same
+ * fallback, so a single test passes with either one removed and pins neither —
+ * measured, both A/B breaks stayed green until this split.
  */
-function setupSyntheticRepo(parent) {
+function setupSyntheticRepo(parent, { closureScript = 'real' } = {}) {
     const root = mkdtempSync(join(parent, 'gh-hooks-'));
     // Init git WITHOUT global hook-path inheritance (otherwise the parent
     // workspace's core.hooksPath setting would leak in).
@@ -106,6 +128,37 @@ function setupSyntheticRepo(parent) {
     writeFileSync(join(root, 'packages', 'infra', 'cli', 'src', 'index.ts'), `export const v = 1;\n`);
     writeFileSync(join(root, 'packages', 'infra', 'cli', 'dist', 'affected.gjs.mjs'), `// initial affected bundle\n`);
 
+    // Manifests for the closure walk. `semver` is the interesting one: it is a
+    // dependency of the CLI and therefore inlined into the bundle, and it is NOT
+    // one of the four paths the hook falls back to — so a test that fires on it
+    // can only be passing through the closure.
+    const manifest = (dir, name, deps) => {
+        mkdirSync(join(root, dir, 'src'), { recursive: true });
+        writeFileSync(join(root, dir, 'package.json'), `${JSON.stringify({ name, dependencies: deps }, null, 2)}\n`);
+    };
+    manifest('packages/infra/cli', '@gjsify/cli', {
+        '@gjsify/semver': '*',
+        '@gjsify/rolldown-plugin-gjsify': '*',
+    });
+    manifest('packages/infra/semver', '@gjsify/semver', {});
+    manifest('packages/infra/rolldown-plugin-gjsify', '@gjsify/rolldown-plugin-gjsify', {});
+    // Outside the closure: nothing depends on it. Present so a trigger that fired
+    // on all of `packages/` — the failure mode of widening the list — is visible.
+    manifest('packages/web/unrelated', '@gjsify/unrelated', {});
+
+    if (closureScript !== 'missing') {
+        mkdirSync(join(root, 'scripts'), { recursive: true });
+        const dest = join(root, 'scripts', 'affected-bundle-closure.mjs');
+        if (closureScript === 'broken') {
+            // Stands in for any way the walk can fail on a real host: an unparsable
+            // manifest, a git call that errors, a rename this fixture has not caught
+            // up with. What matters is the exit code, not the reason.
+            writeFileSync(dest, `process.stderr.write('synthetic closure failure\\n');\nprocess.exit(1);\n`);
+        } else {
+            cpSync(CLOSURE_SCRIPT, dest);
+        }
+    }
+
     // The build pipeline the CLI bundle INLINES. A resolver change here is
     // silently absent from `dist/affected.gjs.mjs` until it is rebuilt, so the hook
     // treats it exactly like `cli/src/`.
@@ -138,6 +191,19 @@ exit 0
     execFileSync('git', ['-C', root, 'commit', '-q', '-m', 'initial', '--no-verify']);
 
     return { root, stubPath, logPath };
+}
+
+/**
+ * Everything the hook printed, from BOTH streams.
+ *
+ * Measured: `git commit` forwards a hook's stdout to git's own STDERR, so
+ * `result.stdout` is empty for every line the hook echoes. An assertion written
+ * against `result.stdout` therefore passes no matter what the hook said — a
+ * vacuous green. Which stream git picks is git's business and could change; the
+ * hook only promises to say the thing, so assert over the union.
+ */
+function hookOutput(result) {
+    return `${result.stdout ?? ''}${result.stderr ?? ''}`;
 }
 
 function readLog(logPath) {
@@ -178,7 +244,7 @@ describe('git pre-commit hook — affected.gjs.mjs staleness', { timeout: 2 * 60
 
         const result = runHook(root);
         assert.equal(result.status, 0, `hook failed: ${result.stderr}`);
-        assert.deepEqual(readLog(logPath), [], `hook should not have invoked gjsify, got: ${result.stdout}`);
+        assert.deepEqual(readLog(logPath), [], `hook should not have invoked gjsify, got: ${hookOutput(result)}`);
     });
 
     it('auto-rebuilds + auto-stages dist/affected.gjs.mjs when packages/infra/cli/src/ changes', () => {
@@ -281,6 +347,87 @@ describe('git pre-commit hook — affected.gjs.mjs staleness', { timeout: 2 * 60
             initialBundle,
             'affected bundle was not refreshed by the rebuild',
         );
+    });
+
+    it('fires for a closure package the four-path fallback never named', () => {
+        // The whole point of #1149. `packages/infra/semver` is inlined into the
+        // bundle because the CLI depends on it, and the old hand-listed trigger did
+        // not name it — so this commit used to go out with a stale bundle and cost a
+        // CI round-trip. If the closure walk ever silently stops working, the
+        // fallback takes over and THIS is the test that goes red; the `cli/src` ones
+        // would stay green, because the fallback names that path too.
+        const { root, logPath } = setupSyntheticRepo(parent);
+
+        const depSrc = 'packages/infra/semver/src/index.ts';
+        writeFileSync(join(root, depSrc), `export const parse = (v) => v;\n`);
+        execFileSync('git', ['-C', root, 'add', depSrc]);
+
+        const result = runHook(root);
+        assert.equal(result.status, 0, `hook failed: ${result.stderr}`);
+        assert.ok(
+            !hookOutput(result).includes('falling back'),
+            `the hook fell back instead of walking the closure: ${hookOutput(result)}`,
+        );
+        assert.deepEqual(readLog(logPath), [
+            'workspace @gjsify/cli build --with-dependencies --cached',
+            'workspace @gjsify/cli build:affected-bundle',
+        ]);
+    });
+
+    it('stays silent for a package OUTSIDE the closure', () => {
+        // The other half of the same property, and the risk in widening a trigger:
+        // firing on all of `packages/` would make every commit pay a 300 s rebuild.
+        // Nothing depends on `@gjsify/unrelated`, so it is not in the bundle.
+        const { root, logPath } = setupSyntheticRepo(parent);
+
+        const outside = 'packages/web/unrelated/src/index.ts';
+        writeFileSync(join(root, outside), `export const x = 1;\n`);
+        execFileSync('git', ['-C', root, 'add', outside]);
+
+        const result = runHook(root);
+        assert.equal(result.status, 0, `hook failed: ${result.stderr}`);
+        assert.deepEqual(readLog(logPath), [], `hook rebuilt for a non-closure package: ${hookOutput(result)}`);
+    });
+
+    it('falls back to the four known inputs — and still commits — when the closure cannot be computed', () => {
+        // The fallback was written for this case and was UNREACHABLE in it: under
+        // `set -e`, the failing command substitution aborted the hook, so a tree
+        // without the script could not commit at all. The fixture reproduces that
+        // tree by omitting the script, which is why this test exists rather than a
+        // comment claiming the branch works.
+        // The REASON is asserted per state, not just the fact of falling back. The
+        // `|| true` alone keeps the commit alive in both states, so an assertion on
+        // the announcement text is what distinguishes the named guard from the
+        // catch-all — without it, deleting the existence check changes nothing
+        // observable and the message quietly degrades to the generic one.
+        const expectedReason = { missing: 'not found', broken: 'produced no paths' };
+
+        for (const closureScript of ['missing', 'broken']) {
+            const { root, logPath } = setupSyntheticRepo(parent, { closureScript });
+
+            writeFileSync(join(root, 'packages/infra/cli/src/index.ts'), `export const v = 5;\n`);
+            execFileSync('git', ['-C', root, 'add', 'packages/infra/cli/src/index.ts']);
+
+            const result = runHook(root);
+            assert.equal(result.status, 0, `[${closureScript}] hook failed instead of falling back: ${result.stderr}`);
+            assert.ok(
+                hookOutput(result).includes('could not compute the affected-bundle closure'),
+                `[${closureScript}] the fallback did not announce itself: ${hookOutput(result)}`,
+            );
+            assert.ok(
+                hookOutput(result).includes(expectedReason[closureScript]),
+                `[${closureScript}] expected the reason to name "${expectedReason[closureScript]}": ${hookOutput(result)}`,
+            );
+            // Degraded, not disabled: the four known inputs still fire.
+            assert.deepEqual(
+                readLog(logPath),
+                [
+                    'workspace @gjsify/cli build --with-dependencies --cached',
+                    'workspace @gjsify/cli build:affected-bundle',
+                ],
+                `[${closureScript}] the fallback did not rebuild`,
+            );
+        }
     });
 
     it('skips the rebuild when SKIP_GJSIFY_HOOKS=1', () => {


### PR DESCRIPTION
Closes #1149.

The pre-commit hook decided whether to rebuild `affected.gjs.mjs` from four hand-maintained paths,
over an `--app gjs` build that inlines the bundle's whole workspace-dep closure. Its header was
already honest that this is best-effort and that CI's `verify-committed-bundles.mjs` is the invariant
— but the gap was not free.

I hit it as the **fifth measured instance** while changing `@gjsify/path` for #1146: hook silent,
build red, diagnosis a 234-byte difference at byte 6319.

## Measured before widening it

"The bundle inlines half the tree" sounds like a trigger that would fire on everything, so I checked
rather than assumed:

| | |
|---|---|
| closure of `@gjsify/cli` | **111 of 201** packages (55%) |
| last 60 commits — hook fired | 21 (four-path list) |
| last 60 commits — would fire | 26 (real closure) |
| last 60 commits — **silently stale** | **5** |

Correctness costs **+5 firings per 60 commits**, not "most commits": the 55% is an upper bound on
packages, not on how often they are touched. Five wasted CI rounds bought back for five local
rebuilds — and a CI round is ~25 minutes against a bundle rebuild's ~1.

## How

`scripts/affected-bundle-closure.mjs` walks the package.json graph from the bundle's entry package
and prints the source paths. No build, no install, no resolver — **47 ms**.

- `resolve-npm/lib` stays listed explicitly, because it is inlined from a **built** directory that a
  `src/` rule cannot see. The old list's reasoning about that one path was right; it just was not
  applied to the rest.
- A cheap pre-filter keeps the common case free: nothing under `packages/` staged means nothing in the
  closure changed, so the walk never runs.
- Failing to compute the closure falls back to the four known inputs and **says so**, rather than
  treating "could not compute" as "nothing changed".

## A/B

With `packages/node/path/src/posix.ts` staged:

```
old trigger (four paths) → matches nothing        ← the defect
new trigger (closure)    → packages/node/path/src/posix.ts
```

The header's claim is unchanged — still best-effort, CI is still the invariant. It just stops being
wrong by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
