### PR TITLE
docs: put AGENTS.md back under its byte ceiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ are in [docs/code-anti-patterns.md](docs/code-anti-patterns.md) — read them be
 
 |**try/catch around a call that cannot throw** — for GI calls read the GIR, only `throws="1"` raises. A kept catch must STATE ITS REASON; `eslint/no-empty` is `error`
 |**paranoid probes for what the workspace guarantees** — redundant `x?.m?.()` on our own classes hides real bugs as silent no-calls. Only the documented probes are sanctioned
-|**comments that restate the code** — comment WHY; a restating comment is a second copy that drifts. Cut restatement, narrative history, upstream source coordinates; keep the incident, GI quirks, spec links, error text. A LIVE COUNT is restatement too, and drifts unseen (`224 packages` → 232, `~110` → 199): write what the number establishes, not the number. Per-tree volume REPORTED against MEASURED ceilings by `scripts/check-comment-budget.mjs` (`--warn` in CI, `--check` locally — a score, so it advises rather than blocks)
+|**comments that restate the code** — comment WHY; a restating comment is a second copy that drifts. Cut restatement, narrative history, upstream source coordinates; keep the incident, GI quirks, spec links, error text. A LIVE COUNT is restatement too, and drifts unseen (`224 packages` → 232, `~110` → 199): write what the number establishes, not the number. `scripts/check-comment-budget.mjs` reports per-tree volume — a score, so it advises
 |**duplication instead of a helper** — the SECOND copy is where you lift; the drifted copy fails in a CONSUMER while the owning package stays green
 |**scattered lifecycle** — cleanup beside creation, ownership in ONE place, wired to the exit the host actually has
 |**shelling out where an API exists** — pass an argv array (`Gio.Subprocess`), never an interpolated command line


### PR DESCRIPTION
`main` is red and every open PR inherits it:

```
check-agent-context-size: AGENTS.md grew to 20986 bytes, over its committed
ceiling of 20909 (+77). This file is loaded on every agent turn.
```

Mine, from #1166: the sentence describing the comment budget as a report was longer than the one it
replaced. Rewritten to the shorter form that says the same thing — **20901 bytes**.

## How it got through, which is the part worth recording

I verified `node scripts/check-agent-context-size.mjs` and read exit 0. CI runs it with `--check`.
Bare is a **report**, `--check` is the **gate**.

That is the third time today the same shape cost a red build:

| check | what I ran | what CI runs |
|---|---|---|
| formatter | `gjsify format` on the sibling branch | `gjsify format --check`, repo-wide |
| comment budget | `check-comment-budget.mjs` (report, exit 0) | `--check` (gate, exit 1) |
| agent context size | `check-agent-context-size.mjs` (report, exit 0) | `--check` (gate, exit 1) |

The rule that would have caught all three: **copy the invocation out of the workflow**, never infer it
from the script name. `grep -n '<script>' .github/workflows/*.yml` costs ten seconds.

Unblocks #1167, #1168, #1169, #1170, whose `Audit runtimes` failures are all this one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
