### PR TITLE
fix(node-gi): make the consumer gate show its evidence

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,20 @@ on:
   workflow_dispatch:
 
 # Cancel superseded runs on the SAME PR branch (a force-push / new commit
-# obsoletes the in-flight run). main pushes + the nightly schedule are NOT
-# cancelled — each landed commit + sweep must complete on its own.
+# obsoletes the in-flight run). main pushes + the nightly schedule are not
+# cancelled ONCE THEY HAVE STARTED — each landed commit + sweep completes on its
+# own.
+#
+# `cancel-in-progress` governs IN-PROGRESS runs only. A run still PENDING in the
+# group is evicted when a newer run joins it, whatever this expression says —
+# GitHub keeps one pending run per group. Measured 2026-08-14: the push run for
+# the #1170 merge sat pending behind a main run from 34 minutes earlier, a
+# `workflow_dispatch` on main joined the group, and the push run was cancelled 3 s
+# later with zero jobs ever started. So a LANDED COMMIT CAN END UP WITH NO RUN OF
+# ITS OWN, and the run list shows `cancelled`, which reads as noise rather than as
+# a gap. Before trusting "main is green", check that a run exists for main's
+# CURRENT sha — `gh run list --commit $(git rev-parse origin/main)` — rather than
+# reading the newest green run on the branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -7,6 +7,22 @@ name: node-gi
 # Builds the N-API addon against girepository-2.0 and runs the smoke tests on
 # Node, mirroring the Fedora 44 environment the rest of CI uses.
 
+# THE PATH FILTERS BELOW ARE NARROWER THAN WHAT THIS WORKFLOW GUARDS, and that is
+# why `schedule` and `workflow_dispatch` are here (#1173). The consumer harness
+# runs NINE OTHER packages' own test suites through the reverse bridge, so a break
+# originating anywhere in their source — or in anything they share, like
+# `packages/gjs/unit` — is invisible to a trigger naming three paths. Measured:
+# `main` went red on 2026-08-13 and stayed red with nothing reporting it, because
+# no merge after the v0.38.1 release touched a filtered path. A docs-only edit to
+# `packages/node-gi/AGENTS.md` is what eventually re-triggered it, 1 day later.
+#
+# The filters are still right for PRs: this builds an addon and runs three runtimes
+# over nine suites, which no unrelated PR should pay for. What was missing is a
+# trigger that does not depend on guessing the input set — a nightly run bounds how
+# long a break can hide at ~24 h whatever caused it, and dispatch makes it
+# answerable on demand. Same class as #1028 (an e2e guard firing only on
+# `tests/e2e/**`) and #1149 (a hook trigger naming four of 111 closure packages):
+# a guard whose trigger is narrower than its subject.
 on:
   push:
     branches: [main]
@@ -19,6 +35,11 @@ on:
       - 'packages/node-gi/**'
       - 'scripts/node-gi-consumer-harness.mjs'
       - '.github/workflows/node-gi.yml'
+  schedule:
+    # 03:17 UTC — off the hour, so this does not queue behind everything else
+    # scheduled at :00.
+    - cron: '17 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/scripts/node-gi-consumer-harness.mjs
+++ b/scripts/node-gi-consumer-harness.mjs
@@ -351,6 +351,46 @@ function collectFailures(text, max = 4) {
 /** Render a failure record the way the report stores it. */
 const formatFailure = (f) => (f.name && f.message ? `${f.name} — ${f.message}` : f.name || f.message);
 
+/**
+ * What `--require-pass` prints for ONE package that did not pass: the verdict, the
+ * counts, the bucket, and the failure SAMPLES.
+ *
+ * As a CI gate this runs on a runner whose `--out` report goes to `/tmp` and is
+ * never uploaded, so a bare `@gjsify/zlib — partial` was the entire evidence a
+ * reader got — "1 of 53375 tests failed" with nothing saying which one. Getting the
+ * name then meant building the native addon locally, which is the expensive step
+ * this replaces.
+ *
+ * Counts are printed as `passed/total` AND `failed`, because the first two alone
+ * mislead. `@gjsify/unit` bumps `countTestsFailed` without bumping
+ * `countTestsOverall` for three cases — an `it.failing` marker that started
+ * passing, an unexercised declared axis, and an assertion that fired outside any
+ * `it()` — so a run can report a SMALLER total than the same suite standalone. Read
+ * as "a test went missing", that looks like flake; it is one of those three, all of
+ * which are deterministic. Measured on zlib: 53375 through the bridge vs 53376
+ * standalone, which cost a wrong flake diagnosis before the accounting was checked.
+ *
+ * A package with no samples says so explicitly: `collectFailures` keys off a fixed
+ * marker set (`❌ ⏱ ✗ ✘`), and a reporter emitting anything else produces an empty
+ * list. Silence there means "the collector missed it", not "no failures".
+ */
+function formatGateFailure(r) {
+    const node = r.runtimes?.node;
+    const verdict = r.build?.ok ? (node?.status ?? 'no-node-run') : `build ${r.build?.reason}`;
+    const lines = [`  ${r.name} — ${verdict}`];
+    if (node && node.total !== undefined) {
+        lines.push(
+            `      ${node.passed}/${node.total} passed, ${node.failed} failed · bucket: ${node.reason ?? 'n/a'}`,
+        );
+    }
+    const samples = (node?.samples?.length ? node.samples : r.build?.samples) ?? [];
+    for (const s of samples) lines.push(`      ✖ ${s}`);
+    if (!samples.length) {
+        lines.push(`      (no failure samples captured — collectFailures matches ❌ ⏱ ✗ ✘ only)`);
+    }
+    return lines.join('\n');
+}
+
 // The failure's MESSAGE (name only as a last resort), with double-quoted spans
 // blanked so a test NAME quoted into a message cannot decide the bucket.
 const signatureOf = (f) => (f.message || f.name).replace(/"[^"\n]*"/g, '""');
@@ -651,12 +691,7 @@ function main() {
         if (notPassing.length) {
             console.error(
                 `\n✗ --require-pass: ${notPassing.length} package(s) did not PASS on node:\n` +
-                    notPassing
-                        .map(
-                            (r) =>
-                                `  ${r.name} — ${r.build?.ok ? (r.runtimes.node?.status ?? 'no-node-run') : `build ${r.build?.reason}`}`,
-                        )
-                        .join('\n'),
+                    notPassing.map(formatGateFailure).join('\n'),
             );
             process.exit(1);
         }
@@ -668,4 +703,13 @@ function main() {
 // (`tests/e2e/node-gi-consumer-harness/run.mjs` imports them).
 if (process.argv[1] && resolve(process.argv[1]).endsWith('node-gi-consumer-harness.mjs')) main();
 
-export { REASON_RULES, STAGED_ASSET_DIRS, classify, collectFailures, formatFailure, parseSummary, stageTestAssets };
+export {
+    REASON_RULES,
+    STAGED_ASSET_DIRS,
+    classify,
+    collectFailures,
+    formatFailure,
+    formatGateFailure,
+    parseSummary,
+    stageTestAssets,
+};

--- a/tests/e2e/node-gi-consumer-harness/run.mjs
+++ b/tests/e2e/node-gi-consumer-harness/run.mjs
@@ -38,8 +38,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
 const HARNESS = join(MONOREPO_ROOT, 'scripts', 'node-gi-consumer-harness.mjs');
 
-const { classify, collectFailures, formatFailure, parseSummary, stageTestAssets, REASON_RULES, STAGED_ASSET_DIRS } =
-    await import(`file://${HARNESS}`);
+const {
+    classify,
+    collectFailures,
+    formatFailure,
+    formatGateFailure,
+    parseSummary,
+    stageTestAssets,
+    REASON_RULES,
+    STAGED_ASSET_DIRS,
+} = await import(`file://${HARNESS}`);
 
 /** Bucket a raw captured run, exactly as the harness does. */
 const bucketOf = (stdout) => classify(collectFailures(stdout));
@@ -206,6 +214,61 @@ describe('node-gi consumer harness: rule precedence', () => {
 // if it were a node-gi finding — `@gjsify/fs` was recorded as a hard fail for
 // exactly this (`join(__dirname, 'test/watch.js')`, survey gap 7), so what is
 // pinned here is the SET of bridged dirs, not just that bridging happens.
+// What the CI gate PRINTS when it fails. Tested because it runs only on failure:
+// the path that carries the diagnosis is the one no green run exercises, and this
+// gate spent a day reporting `@gjsify/zlib — partial` as its entire evidence.
+describe('node-gi consumer harness: --require-pass output', () => {
+    const partial = {
+        name: '@gjsify/zlib',
+        build: { ok: true },
+        runtimes: {
+            node: {
+                status: 'partial',
+                passed: 53374,
+                total: 53375,
+                failed: 1,
+                reason: 'other',
+                samples: ['deflateSync round-trip — expected 3, got 4'],
+            },
+        },
+    };
+
+    it('names the failing test, not just the package', () => {
+        const out = formatGateFailure(partial);
+        assert.match(out, /@gjsify\/zlib — partial/);
+        assert.match(out, /deflateSync round-trip/, `the sample is the whole point: ${out}`);
+    });
+
+    it('prints failed alongside passed/total, because the two can disagree', () => {
+        // `@gjsify/unit` bumps countTestsFailed without bumping countTestsOverall for
+        // a stale `it.failing`, an unexercised axis, and a stray assertion — so a
+        // total SMALLER than the standalone run is expected in those cases and reads
+        // as flake without the failed count beside it.
+        const out = formatGateFailure(partial);
+        assert.match(out, /53374\/53375 passed, 1 failed/, out);
+    });
+
+    it('says so when the collector captured nothing, instead of printing silence', () => {
+        const noSamples = {
+            name: '@gjsify/ws',
+            build: { ok: true },
+            runtimes: { node: { status: 'partial', passed: 10, total: 12, failed: 2, reason: 'other', samples: [] } },
+        };
+        assert.match(formatGateFailure(noSamples), /no failure samples captured/);
+    });
+
+    it('falls back to the BUILD samples when the package never ran', () => {
+        const buildFail = {
+            name: '@gjsify/http2',
+            build: { ok: false, reason: 'missing-typelib', samples: ['cannot resolve gi://Soup'] },
+            runtimes: {},
+        };
+        const out = formatGateFailure(buildFail);
+        assert.match(out, /build missing-typelib/);
+        assert.match(out, /cannot resolve gi:\/\/Soup/, out);
+    });
+});
+
 describe('node-gi consumer harness: test-asset staging', () => {
     it('bridges every on-disk asset dir the suite may resolve from the bundle', () => {
         assert.ok(STAGED_ASSET_DIRS.includes('fixtures'), 'fixtures/ must stay bridged');


### PR DESCRIPTION
`--require-pass` failed on `main` with this as the complete evidence:

```
✗ --require-pass: 1 package(s) did not PASS on node:
  @gjsify/zlib — partial
```

1 of 53375 tests failed and nothing said which. The report that holds the failure samples goes to `/tmp/node-gi-consumer-survey.json` and is never uploaded, so the only route from that line to a test name was building the native addon locally.

## The gate now prints what it knows

```
✗ --require-pass: 1 package(s) did not PASS on node:
  @gjsify/zlib — partial
      53374/53375 passed, 1 failed · bucket: other
      ✖ deflateSync round-trip — expected 3, got 4
```

`failed` prints next to `passed/total` because **the two disagree by design**. `@gjsify/unit` bumps `countTestsFailed` without bumping `countTestsOverall` in three cases — a stale `it.failing` that started passing, an unexercised declared axis, and an assertion thrown outside any `it()`. A run can therefore report a SMALLER total than the same suite standalone: zlib reads 53375 through the bridge against 53376 on its own. Read as "a test went missing", that looks like flake. It is one of those three, all deterministic — and that misreading is exactly what I got wrong on #1173 before checking the accounting.

The formatter is exported and covered by four tests, because it runs **only on failure**: the path that carries the diagnosis is the one no green run exercises.

## And a trigger that does not depend on guessing the input set

`node-gi.yml` fires on three paths over a harness that runs **nine other packages'** suites through the bridge. So `main` went red on 2026-08-13 and stayed red with nothing reporting it — no merge after the v0.38.1 release touched a filtered path, and a docs-only edit to `packages/node-gi/AGENTS.md` is what eventually re-triggered it a day later.

The filters stay right for PRs (this builds an addon and runs three runtimes over nine suites; no unrelated PR should pay for it). Added instead:

- `schedule: '17 3 * * *'` — bounds how long a break can hide at ~24 h whatever caused it
- `workflow_dispatch` — makes it answerable on demand

Third instance of the class after #1028 (an e2e guard firing only on `tests/e2e/**`) and #1149 (a hook trigger naming four of 111 closure packages): **a guard whose trigger is narrower than its subject.**

## Verification

- `node --test tests/e2e/node-gi-consumer-harness/run.mjs` → 17 pass
- This PR's own `node-gi` run is the immediate use: it touches both filtered paths, so it will print the zlib failure with the test name attached.

Refs #1173