### PR TITLE
fix(cli): --version through the one resolver

### DIFF
--- a/packages/infra/cli/src/cli-app.ts
+++ b/packages/infra/cli/src/cli-app.ts
@@ -15,12 +15,10 @@
 // This module MUST NOT execute anything at load time (no top-level
 // `parseAsync`) — `run.ts` imports it, and a top-level run would re-dispatch
 // the original argv on import.
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import yargs from 'yargs';
 
 import { classifyCliFailure } from './cli-fail.js';
+import { cliVersion } from './utils/publish-headers.js';
 
 import {
     buildCommand as build,
@@ -92,24 +90,6 @@ function runtimeLabel(): string {
     return 'unknown runtime';
 }
 
-// Read the version from package.json adjacent to the bundle. yargs's
-// auto-version-discovery (its `pkg-up`-driven default) doesn't reach
-// through the bundled `dist/cli.gjs.mjs` path on GJS — falls back to
-// "unknown". Both layouts are covered:
-//   - dev (tsx, `yarn workspace`):  src/index.ts → ../package.json
-//   - bundled (install -g):         dist/cli.gjs.mjs → ../package.json
-function readBundleVersion(): string {
-    try {
-        const here = dirname(fileURLToPath(import.meta.url));
-        const pkg = JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8')) as {
-            version?: unknown;
-        };
-        return typeof pkg.version === 'string' ? pkg.version : 'unknown';
-    } catch {
-        return 'unknown';
-    }
-}
-
 /**
  * Build + run the gjsify yargs command surface for the given argv (already
  * stripped of the `node`/`gjs` + script prefix — i.e. what `hideBin` returns).
@@ -128,7 +108,7 @@ export async function runCli(argv: readonly string[]): Promise<void> {
     const cli = yargs(argv as string[]);
     await cli
         .scriptName(APP_NAME)
-        .version(readBundleVersion())
+        .version(cliVersion())
         .strict()
         // Sits beside `.strict()` because that is what produces most of what it
         // classifies. See `cli-fail.ts` for the four yargs measurements this

--- a/scripts/check-changelog-references.mjs
+++ b/scripts/check-changelog-references.mjs
@@ -1,43 +1,38 @@
 #!/usr/bin/env node
 // Every reference link in CHANGELOG.md must name the thing its href points at.
 //
-// THE FAILURE (measured on the 0.27.1 cut, and public in its release notes):
-// the generated changelog carried links to issues that do not exist and to
-// repositories that do not exist —
+// THE FAILURE (measured on the 0.27.1 cut, public in its release notes): the
+// generated changelog linked to issues and REPOSITORIES that do not exist —
 //
 //   closes [#version](https://github.com/gjsify/gjsify/issues/version)
 //          [pre-#955](https://github.com/gjsify/pre-/issues/955)
-//          [Post-#955](https://github.com/gjsify/Post-/issues/955)
 //          [442/#121](https://github.com/442/gjsify/issues/121)
 //          [@import](https://github.com/import)
 //
 // TWO INDEPENDENT PRODUCERS, both inside `@release-it/conventional-changelog`'s
 // preset, both structurally unable to tell a reference from a token:
 //
-//  1. `conventional-commits-parser`'s reference regex is
-//     `(?:.*?)??\s*([\w-\.\/]*?)??(#)([\w-]+)(?=\s|$|[,;)\]])`. The issue group
-//     is `[\w-]+`, NOT digits — so `#version`, `#ifdef`, `#ffffff` and
-//     `package.json#exports` all parse as issues. The group before it is a free
+//  1. `conventional-commits-parser`'s reference regex,
+//     `(?:.*?)??\s*([\w-\.\/]*?)??(#)([\w-]+)(?=\s|$|[,;)\]])`. The issue group is
+//     `[\w-]+`, NOT digits, so `#version`, `#ifdef`, `#ffffff` and
+//     `package.json#exports` all parse as issues; the group before it is a free
 //     `owner/repo` prefix, so `pre-#955` yields repository `pre-` and `#442/#121`
-//     yields owner `442`. The writer then fills the missing half from the repo
-//     context and emits a URL for a repository nobody ever named.
-//  2. the preset's writer `transform` re-links the SUBJECT with
-//     `(#)([a-z0-9]+)` and mentions with `\B@([a-z0-9](?:-?[a-z0-9/]){0,38})`.
-//     That is the same path that renders the load-bearing `(#970)` squash-merge
-//     suffix into a link, and the one that turned the CSS at-rule `@import` and
-//     the npm scope `@girs` into user pages.
+//     owner `442`. The writer fills the missing half from the repo context and emits
+//     a URL for a repository nobody named.
+//  2. the preset's writer `transform`, re-linking the SUBJECT with `(#)([a-z0-9]+)`
+//     and mentions with `\B@([a-z0-9](?:-?[a-z0-9/]){0,38})` — the same path that
+//     renders the load-bearing `(#970)` squash suffix as a link, and that turned the
+//     CSS at-rule `@import` and the npm scope `@girs` into user pages.
 //
-// WHY A POST-GENERATION GATE AND NOT PRESET CONFIG. Producer 1 CAN be narrowed:
-// `parserOpts.issuePrefixes` accepts a RegExp (`joinOr` inlines `.source` for a
-// non-string), and `[/(?<=(?:^|[\s(\[])(?:[A-Za-z\d][\w.-]*\/[A-Za-z\d][\w.-]*)?)#(?=\d+(?:[\s,;:)\].]|$))/]`
-// was measured to reject every artefact shape above while still accepting `#971`
-// and `GNOME/gjs#704`. It is not enough, for two reasons: a RegExp cannot be
-// written in `.release-it.json` (the config would have to become JS), and
-// producer 2 reads the PRESET's own `issuePrefixes: ['#']` to build a regex that
-// is baked into the preset's `transform` closure — narrowing it there either
-// breaks the `(#970)` subject links this changelog depends on or means replacing
-// the preset's `transform` wholesale. A gate over the emitted file covers both
-// producers with one rule and cannot be outflanked by a third.
+// WHY A POST-GENERATION GATE AND NOT PRESET CONFIG. Producer 1 CAN be narrowed —
+// `parserOpts.issuePrefixes` accepts a RegExp, and one was measured that rejects
+// every shape above while still accepting `#971` and `GNOME/gjs#704`. Not enough,
+// twice over: a RegExp cannot live in `.release-it.json` (the config would have to
+// become JS), and producer 2 reads the PRESET's own `issuePrefixes: ['#']` into a
+// regex baked into its `transform` closure, so narrowing there either breaks the
+// `(#970)` subject links this changelog depends on or replaces `transform`
+// wholesale. A gate over the emitted file covers both with one rule, and cannot be
+// outflanked by a third producer.
 //
 // IT ASSERTS POSITIVE FACTS, it does not merely exit 0. Before looking at the
 // file it runs its own detector over a fixture matrix of the seventeen artefact
@@ -48,16 +43,14 @@
 // as a clean one. The same matrix covers the section slicer, because the release
 // body is a slice and a mis-slice publishes the wrong release's notes.
 //
-// `--write` REPAIRS, then re-asserts. Same shape as `after:bump`'s
-// `generate-platform-packages --write` → `audit-runtimes --check --strict`: fix
-// what is derivable, then refuse to commit what is not. Repair is deliberately
-// LOSSY-BUT-HONEST — an invalid entry in a `, closes …` list is DROPPED and an
-// invalid link anywhere else is UNLINKED to its literal text. It never re-points
-// a fabricated link, because the token's real target is not derivable: `PKCS#7`,
-// `gjs#44` and `node-gtk #442/#121` name a standard, a GitLab project and
-// another repository's issues, so mechanically re-pointing them at this repo
-// would replace a broken link with a confidently wrong one. The token itself
-// survives verbatim in the commit body, which every entry links to by hash.
+// `--write` REPAIRS, then re-asserts — the shape of `after:bump`'s
+// `generate-platform-packages --write` → `audit-runtimes --check --strict`. Repair is
+// deliberately LOSSY-BUT-HONEST: an invalid entry in a `, closes …` list is DROPPED,
+// an invalid link elsewhere is UNLINKED to its literal text, and nothing is ever
+// re-pointed, because the token's real target is not derivable — `PKCS#7`, `gjs#44`
+// and `node-gtk #442/#121` name a standard, a GitLab project and another repo's
+// issues, so re-pointing them here would trade a broken link for a confidently wrong
+// one. The token survives verbatim in the commit body every entry links to by hash.
 //
 // THE FILE IS NOT THE PUBLISHED ARTEFACT — `--release-notes` is why this script
 // also emits. Repairing CHANGELOG.md does NOT repair the GitHub release body:

--- a/scripts/check-cli-own-version-read.mjs
+++ b/scripts/check-cli-own-version-read.mjs
@@ -29,6 +29,29 @@
 // "deliberately NOT a fixed `../../package.json` read" — and a fourth copy grew
 // beside it anyway. Prose does not fail a PR.
 //
+// THE GATE ITSELF MISSED ONE, which is why it now keys on data flow rather than on
+// a spelling. Its first version tested only
+// `new URL('…package.json', import.meta.url)`, while `cli-app.ts` spelled the same
+// defect as
+//
+//     const here = dirname(fileURLToPath(import.meta.url));
+//     JSON.parse(readFileSync(join(here, '..', 'package.json'), 'utf8'))
+//
+// — no `new URL`, so this scan reported OK while `gjsify --version` answered
+// `unknown` from every relocated bundle, the documented `GJSIFY_BOOTSTRAP` cache
+// included (#1177). A guard that recognises one way of writing a defect certifies
+// every other way.
+//
+// The rule is therefore: a manifest path built from the module's own location AND a
+// LITERAL parent hop, however spelled. "Derived from `import.meta.url`" is NOT the
+// rule and was measured to be wrong — `install.ts` binds `dir` from
+// `import.meta.url` too and then CLIMBS until it finds a `@gjsify/cli` manifest,
+// which is the depth-independent pattern this check wants people to use. What
+// separates the defect from the cure is the fixed `'..'`, not the starting point.
+// Flagging the derivation produced three false alarms on correct code, and a check
+// with false alarms is worse than none — it gets deleted, and takes the real rule
+// with it.
+//
 // FAILURE POLICY: hard. This reads first-party source that is always present;
 // if the scan finds nothing to scan, that is itself an error, because a check
 // that cannot find what it checks has stopped checking.
@@ -45,6 +68,27 @@ const RESOLVER = 'utils/publish-headers.ts';
 // hard-codes a directory distance to the package root. Matched irrespective of
 // how many `../` it walks, since the count is the part that is wrong.
 const FIXED_DEPTH_READ = /new URL\(\s*(['"`])[^'"`]*package\.json\1\s*,\s*import\.meta\.url\s*\)/;
+
+/** Anything that mentions a `package.json` path literal. */
+const MANIFEST_LITERAL = /(['"`])[^'"`]*package\.json\1/;
+
+/**
+ * A LITERAL parent hop: `'..'` as its own path segment, or leading `../` inside a
+ * path literal. This is the "counting directories" part — the half that breaks when
+ * the same code ships from `lib/` and from `dist/`.
+ */
+const LITERAL_PARENT_HOP = /(['"`])\.\.\1|(['"`])(?:\.\.\/)+[^'"`]*\2/;
+
+/**
+ * `<decl> <name> = …import.meta.url…` — a binding carrying this module's own
+ * location. Tracked within a short WINDOW above the read, not file-wide: names like
+ * `dir` are reused across functions, and a file-wide set made three correct
+ * upward-walk reads look like offenders.
+ */
+const BINDS_OWN_LOCATION = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=[^\n]*import\.meta\.url/;
+
+/** How far above a manifest read a location binding still counts as feeding it. */
+const BINDING_WINDOW = 4;
 
 function walk(dir) {
     const out = [];
@@ -84,9 +128,36 @@ for (const file of files) {
     const rel = relative(CLI_SRC, file);
     if (rel === RESOLVER) continue; // the resolver is the one allowed to know about layouts
     const text = stripComments(readFileSync(file, 'utf8'));
-    text.split('\n').forEach((line, i) => {
+    const lines = text.split('\n');
+
+    /** Does a location binding sit within `BINDING_WINDOW` lines above `i`? */
+    const boundNearby = (i) => {
+        const names = [];
+        for (let j = Math.max(0, i - BINDING_WINDOW); j < i; j++) {
+            const bound = lines[j].match(BINDS_OWN_LOCATION);
+            if (bound) names.push(bound[1]);
+        }
+        return names;
+    };
+
+    lines.forEach((line, i) => {
+        if (!MANIFEST_LITERAL.test(line) && !FIXED_DEPTH_READ.test(line)) return;
+        const at = `packages/infra/cli/src/${rel}:${i + 1}: ${line.trim()}`;
+
+        // One statement, the original spelling: `new URL('…package.json',
+        // import.meta.url)`. Fixed-depth even with zero `..` — a sibling read is a
+        // distance too.
         if (FIXED_DEPTH_READ.test(line)) {
-            offenders.push(`packages/infra/cli/src/${rel}:${i + 1}: ${line.trim()}`);
+            offenders.push(at);
+            return;
+        }
+
+        // Own location + a literal parent hop, in one statement or across two. The
+        // hop is what makes it fixed; without it the code is climbing, which is the
+        // pattern this check recommends.
+        if (!LITERAL_PARENT_HOP.test(line)) return;
+        if (/import\.meta\.url/.test(line) || boundNearby(i).some((n) => new RegExp(`\\b${n}\\b`).test(line))) {
+            offenders.push(at);
         }
     });
 }

--- a/scripts/generate-platform-packages.mjs
+++ b/scripts/generate-platform-packages.mjs
@@ -2,73 +2,58 @@
 /**
  * Generate the per-target platform packages of every native bridge — ADR 0017.
  *
- * WHAT AND WHY
+ * A native bridge used to ship every `<os>-<arch>` prebuild it promises in ONE
+ * tarball. Measured here: 97.3 MB of committed binaries, of which a `linux-x64`
+ * consumer could load 31.5 MB — 68 % downloaded and never loadable, growing with
+ * every emulated architecture and taxing the 95 % of users not on it.
  *
- * A native bridge used to ship every `<os>-<arch>` prebuild it promises inside
- * ONE tarball. Measured on this tree: 97.3 MB of committed binaries, of which a
- * `linux-x64` consumer could load 31.5 MB. 68 % of the bytes were downloaded and
- * never loadable, and the number grows with every emulated architecture the
- * project adds — each new target taxing the 95 % of users who are not on it.
+ * ADR 0017 adopts the ecosystem answer (esbuild ships 26 of these; napi-rs,
+ * rolldown, oxc, lightningcss the same): the bridge keeps its name, API and loader
+ * contract and declares one `optionalDependencies` entry per target, each holding
+ * that target's binary behind `os`/`cpu`. A package manager installs the one that
+ * fits and SILENTLY skips the rest — silently, because a platform mismatch on an
+ * OPTIONAL dependency is not an error (on a required one it is `EBADPLATFORM`).
  *
- * ADR 0017 adopts the ecosystem answer (esbuild has 26 of these, napi-rs,
- * rolldown, oxc and lightningcss upstream all do the same): the bridge keeps its
- * name, API and loader contract, declares one `optionalDependencies` entry per
- * target, and each target's binary lives in a package that declares `os`/`cpu`.
- * A package manager installs the one that fits and SILENTLY skips the rest —
- * silently, because a platform mismatch on an OPTIONAL dependency is not an
- * error (on a required one it is `EBADPLATFORM`).
+ * GENERATED, NOT WRITTEN. 51 manifests × 12 fields is not a review surface a human
+ * holds correct, and every field is DERIVABLE (name from parent + token, `os`/`cpu`
+ * from the token, version and tier from the parent, glibc floor from the ELF). A
+ * hand-written set would drift on the first release bump and on every new target,
+ * in the worst shape: a bridge searching at runtime for a sibling that was never
+ * published, reporting "typelib not found". So one function emits the set and
+ * `--check` re-emits and compares. `audit-runtimes.mjs --check` runs that as the
+ * `platform-packages` rule, which also holds ADR 0017 step 2 — every declared
+ * target has a package AND an `optionalDependencies` entry whose `os`/`cpu` match
+ * the token, "otherwise we trade one silent drift for another".
  *
- * WHY THE MANIFESTS ARE GENERATED RATHER THAN WRITTEN
+ * WHAT A GENERATED PACKAGE DELIBERATELY LACKS
  *
- * 51 manifests × 12 fields is not a review surface a human can hold correct, and
- * every field in them is DERIVABLE: the name from the parent plus the token, the
- * `os`/`cpu` from the token, the version from the parent, the tier from the
- * parent, the glibc floor from the ELF. A hand-written set would drift on the
- * first release bump and on every new target, and the drift would be silent in
- * the worst possible shape — a bridge searching at runtime for a sibling package
- * that was never published, reporting "typelib not found".
+ *   · No `main`/`types`/`module`/`exports`. These are DATA packages; the loader
+ *     (`detectNativePackages()`) finds them by scanning node_modules for
+ *     `gjsify.prebuilds` + `prebuilds/<target>/` — the same mechanism that found
+ *     the bundled directory before the split, which is why ADR 0017 needs no new
+ *     runtime code path. A declared-but-absent entry point would (correctly) fail
+ *     the `package-outputs` rule.
+ *   · No `gjsify.runtimes`: that quadruplet describes an API's cross-runtime reach
+ *     and a package with no JavaScript has none. `runtimes-drift` skips them on the
+ *     same signal the generator writes — see `isPlatformPackageManifest()`.
+ *   · No sources, build or tests. The four lifecycle scripts are no-ops so
+ *     `gjsify foreach {build,check,clear,test}` — which derives its set from the
+ *     workspace, not a list — walks them without special-casing.
  *
- * So the set is emitted from one function, and `--check` re-emits it and compares.
- * `audit-runtimes.mjs --check` runs that comparison as the `platform-packages`
- * rule, which additionally holds ADR 0017 step 2: every declared target has a
- * platform package AND an `optionalDependencies` entry whose `os`/`cpu` match the
- * token — "otherwise we trade one silent drift for another".
+ * THE LIBC AXIS IS MEASURED. `libc` and `gjsify.glibcRequires` are read out of the
+ * ELF by the `prebuild-libc` rule's OWN reader (`measurePrebuildLibc`), never a copy
+ * living here — {@link measureLibcFields} holds the incident. A guessed
+ * `libc: ["glibc"]` would make every package manager refuse the install on musl
+ * hosts where six of these bridges provably load, so the field is written only where
+ * a glibc dynamic loader is actually recorded.
  *
- * WHAT A GENERATED PACKAGE DELIBERATELY DOES NOT HAVE
- *
- *   · No `main`, `types`, `module` or `exports`. These are DATA packages; the
- *     loader (`detectNativePackages()`) finds them by scanning node_modules for
- *     `gjsify.prebuilds` + `prebuilds/<target>/`, exactly the mechanism that
- *     found the bundled directory before the split — which is why ADR 0017 needs
- *     no new runtime code path at all. Declaring an entry point that does not
- *     exist would (correctly) fail the `package-outputs` rule.
- *   · No `gjsify.runtimes`. That quadruplet describes the cross-runtime reach of
- *     an API; a package with no JavaScript has none. `runtimes-drift` skips these
- *     packages on the same signal the generator writes them with — see
- *     `isPlatformPackageManifest()`.
- *   · No sources, no build, no tests. The four lifecycle scripts are no-ops so
- *     that `gjsify foreach {build,check,clear,test}` — which derives its package
- *     set from the workspace rather than from a list — walks them without
- *     special-casing.
- *
- * THE LIBC AXIS IS MEASURED, NOT GUESSED
- *
- * A generated manifest also carries the npm `libc` filter and
- * `gjsify.glibcRequires`, both read out of the ELF by the `prebuild-libc` rule's
- * OWN reader (`measurePrebuildLibc`), never by a copy of it living here — see
- * {@link measureLibcFields} for the incident that rule exists to prevent. A
- * guessed `libc: ["glibc"]` would make every package manager refuse the install
- * on musl hosts where six of these bridges provably load, so the field is
- * written only where a glibc dynamic loader is actually recorded.
- *
- * A GENUINE IMPROVEMENT THE SPLIT BUYS ON THAT AXIS: npm's `libc` is ONE
- * package-level filter while the requirement is per TARGET —
- * `@gjsify/tls-native` records no libc soname on x64/arm64/ppc64/s390x and DOES
- * record the glibc interpreter on riscv64, because Fedora's riscv64 toolchain
- * links it explicitly. One tarball could not state that; per-target packages
- * can, and do: only `@gjsify/tls-native-linux-riscv64` declares the restriction.
- * The same holds for the floor — `gjsify.glibcRequires` becomes a one-entry map
- * per package instead of a whole-tree maximum every consumer inherits.
+ * The split IMPROVES that axis: npm's `libc` is one package-level filter while the
+ * requirement is per TARGET. `@gjsify/tls-native` records no libc soname on
+ * x64/arm64/ppc64/s390x and DOES record the glibc interpreter on riscv64, because
+ * Fedora's riscv64 toolchain links it explicitly — one tarball cannot state that,
+ * and only `@gjsify/tls-native-linux-riscv64` declares the restriction. Same for the
+ * floor: a one-entry map per package instead of a whole-tree maximum every consumer
+ * inherits.
  *
  * Usage:
  *   node scripts/generate-platform-packages.mjs            # --check (default)
@@ -111,34 +96,28 @@ const stringifyManifest = (obj) => `${JSON.stringify(obj, null, 4)}\n`;
  * The npm `libc` + `gjsify.glibcRequires` values MEASURED from the committed
  * artifacts of one target.
  *
- * Both are properties of the BINARY, so both are read out of the binary — the
- * same reason `prebuild-artifacts` reads the machine out of `e_machine` instead
- * of trusting the directory name. A hand-maintained fact about a committed
- * binary is a fact that has already drifted; you just do not know when.
+ * Both describe the BINARY, so both are read out of it — the same reason
+ * `prebuild-artifacts` reads `e_machine` instead of trusting a directory name.
  *
- * The measurement itself is NOT reimplemented here. `measurePrebuildLibc()` is
- * the `prebuild-libc` rule's own reader, and the generator calls it because the
- * two must agree by construction: the rule GRADES the field this function
- * WRITES, so a second opinion about the same bytes can only ever be a way for
- * `--write` to emit a manifest that `--check` then rejects. That is not
- * hypothetical — it is what a hand-rolled copy of the loader predicate did here
- * on its first real run. It tested `/^ld-linux[\w.-]*\.so(\.\d+)?$/`, which is
- * the loader's name on x86-64, arm64 and riscv64 but NOT on ppc64le or s390x,
- * where glibc calls it `ld64.so.2` / `ld64.so.1`. So the generator wrote no
- * `libc` for exactly those two targets of `@gjsify/lightningcss-native` and the
- * rule failed them for the omission — two tools reading one ELF and disagreeing.
- * `libcFlavourOfNeeded`/`muslVerdictOfNeeded` match all five spellings.
+ * The measurement is NOT reimplemented here: `measurePrebuildLibc()` is the
+ * `prebuild-libc` rule's own reader, and the rule GRADES the field this function
+ * WRITES, so a second opinion about the same bytes can only make `--write` emit a
+ * manifest `--check` rejects. Not hypothetical — a hand-rolled copy of the loader
+ * predicate did exactly that on its first run. It tested
+ * `/^ld-linux[\w.-]*\.so(\.\d+)?$/`, the loader's name on x86-64, arm64 and riscv64
+ * but NOT on ppc64le or s390x, where glibc calls it `ld64.so.2` / `ld64.so.1`: the
+ * generator wrote no `libc` for those two targets of `@gjsify/lightningcss-native`
+ * and the rule failed them for the omission. `libcFlavourOfNeeded` /
+ * `muslVerdictOfNeeded` match all five spellings.
  *
- * What the generator still decides is the POLICY, and only where it is a direct
- * read rather than an inference: `musl: 'incompatible'` — a recorded glibc
- * dynamic loader — means the image cannot load under musl's loader at all, so
- * the filter is required. An `'undetermined'` verdict is NOT the opposite: musl
- * treats a `DT_NEEDED` of `libc.so.6` as a request for itself and loads such an
- * image happily, which a container probe on `alpine:3.24.1` confirmed for six of
- * this repo's bridges. Declaring `libc: ["glibc"]` there would refuse the
- * install on exactly the platform the axis exists to support, so nothing is
- * declared and the three-tier judgement stays with the rule, which is where it
- * belongs.
+ * The generator decides only the POLICY, and only where it is a direct read:
+ * `musl: 'incompatible'` — a recorded glibc dynamic loader — means the image cannot
+ * load under musl's loader, so the filter is required. `'undetermined'` is NOT the
+ * opposite: musl treats a `DT_NEEDED` of `libc.so.6` as a request for itself and
+ * loads such an image happily, confirmed on `alpine:3.24.1` for six of this repo's
+ * bridges. Declaring `libc: ["glibc"]` there would refuse the install on exactly the
+ * platform the axis exists to support, so nothing is declared and the three-tier
+ * judgement stays with the rule.
  *
  * @param {string} dir absolute path to the target's prebuild directory
  * @param {string} target the `<os>-<arch>` token
@@ -338,31 +317,25 @@ License: MIT
  *      declared target — correctly, since the directory really is gone.
  *   2. `prebuilds` is dropped from `files`. This is the byte saving; without it
  *      the tarball is unchanged and the whole exercise buys nothing.
- *   3. The npm `libc` filter and `gjsify.glibcRequires` are REMOVED, because
- *      both are properties of a BINARY and this tarball no longer holds one.
- *      Leaving `libc` behind is not cosmetic — it is an install-time
- *      REGRESSION the split would otherwise introduce. npm, yarn and pnpm all
- *      honour the field, so `@gjsify/lightningcss-native`'s inherited
- *      `libc: ["glibc"]` would refuse to install the pure-TypeScript half on
- *      every musl host, where it runs fine (the bridge degrades gracefully when
- *      no native engine loads, and on Alpine that is exactly what should
- *      happen). Before the split one filter had to cover the whole tarball;
- *      now the constraint belongs to the one package that carries the
- *      constrained bytes, which is the per-target precision ADR 0017 buys —
- *      only `@gjsify/tls-native-linux-riscv64` declares `libc`, not all five
- *      of that bridge's Linux targets. `gjsify.glibcRequires` moves for the
- *      same reason plus a second one: as a parent-level map it is a fact about
- *      directories the parent cannot see any more, so nothing could keep it
- *      true. Each child measures its own floor out of its own ELF.
- *   4. `optionalDependencies` gains one entry per split target. The RANGE is
- *      `workspace:*` for a workspace member — the repository's convention (283
- *      of 285 sibling runtime edges use the workspace protocol) and it resolves
- *      to the EXACT sibling version at pack time, which is the pin the esbuild
- *      model needs and which no release bump can forget. `@gjsify/napi` and
- *      `@gjsify/node-gi` are deliberately NOT workspace members (their own CI,
- *      their own carve-outs), and `gjsify pack` throws on a `workspace:` range
- *      it cannot resolve, so those get the literal version — kept honest by the
- *      audit rule rather than by memory.
+ *   3. The npm `libc` filter and `gjsify.glibcRequires` are REMOVED: both describe
+ *      a BINARY this tarball no longer holds. Leaving `libc` is not cosmetic but
+ *      an install-time REGRESSION — npm, yarn and pnpm all honour it, so
+ *      `@gjsify/lightningcss-native`'s inherited `libc: ["glibc"]` would refuse the
+ *      pure-TypeScript half on every musl host, where it runs fine (the bridge
+ *      degrades when no native engine loads, which on Alpine is the right
+ *      outcome). The constraint now belongs to the package carrying the
+ *      constrained bytes — only `@gjsify/tls-native-linux-riscv64` declares
+ *      `libc`, not all five of that bridge's Linux targets. `glibcRequires` moves
+ *      for that reason plus one more: as a parent-level map it describes
+ *      directories the parent can no longer see, so nothing could keep it true.
+ *   4. `optionalDependencies` gains one entry per split target, ranged
+ *      `workspace:*` for a workspace member — the repo convention (283 of 285
+ *      sibling runtime edges) which resolves to the EXACT sibling version at pack
+ *      time, the pin the esbuild model needs and no release bump can forget.
+ *      `@gjsify/napi` and `@gjsify/node-gi` are deliberately NOT members (own CI,
+ *      own carve-outs) and `gjsify pack` throws on a `workspace:` range it cannot
+ *      resolve, so those get the literal version — held by the audit rule rather
+ *      than by memory.
  *
  * `gjsify.platforms` is untouched: ADR 0017 step 2 keeps it as the single
  * declaration, and every child's one-element list is derived from it.

--- a/scripts/relocate-macho.mjs
+++ b/scripts/relocate-macho.mjs
@@ -2,47 +2,45 @@
 /**
  * Relocate a staged darwin prebuild off the BUILD HOST's Homebrew prefix.
  *
- * A Mach-O records the FULL INSTALL PATH of every dependency where an ELF records
- * a bare SONAME, so every darwin prebuild this repo published named its GLib under
- * the DEFAULT Homebrew prefix of whichever machine linked it (`/usr/local` Intel,
- * `/opt/homebrew` Apple silicon) — unloadable without Homebrew, with a non-default
+ * A Mach-O records each dependency's FULL INSTALL PATH where an ELF records a bare
+ * SONAME, so every darwin prebuild this repo published named its GLib under the
+ * default Homebrew prefix of whichever machine linked it (`/usr/local` Intel,
+ * `/opt/homebrew` Apple silicon) — unloadable without Homebrew, under a custom
  * `HOMEBREW_PREFIX`, on MacPorts, or without those formulae (#1102, all 12 darwin
- * packages, both arches). Fix: rewrite each such load command to `@rpath/<leaf>`
- * and give the image an `LC_RPATH` list that resolves it.
+ * packages, both arches). Fix: rewrite those load commands to `@rpath/<leaf>` and
+ * give the image an `LC_RPATH` list that resolves them.
  *
- * Separate from `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs`, which
- * does the same to its own payload, because `packages/node-gi/**` is both the
- * affected classifier's IGNORE list and `node-gi.yml`'s `paths:` trigger — an
- * import either way leaves one of the two building without its CI. Only the binary
- * READER is shared (`readLibrary()`, the repo's ONE parser), so the code rewriting
- * a load command and the code later failing the build over one see the same bytes.
+ * Separate from `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs`, which does
+ * the same to its own payload: `packages/node-gi/**` is both the affected
+ * classifier's IGNORE list and `node-gi.yml`'s `paths:` trigger, so an import
+ * either way leaves one of the two building without its CI. Only the binary READER
+ * is shared (`readLibrary()`, the repo's ONE parser), so rewriting a load command
+ * and later failing the build over one see the same bytes.
  *
- * dyld tries `LC_RPATH` entries in order, so this list IS the precedence policy:
+ * dyld tries `LC_RPATH` in order, so the list IS the precedence policy:
  *
- *   1. `@loader_path` — a dependency staged INTO the prebuild dir wins. Nothing
+ *   1. `@loader_path` — a dependency staged into the prebuild dir wins. Nothing
  *      does that today; one load command reserves the option.
  *   2. `@loader_path/../../../gtk-runtime-darwin-<arch>/gtk/lib` — the
- *      batteries-included bundle as an npm SIBLING of the platform package
- *      (`prebuilds/<target>/` climbs three to `@gjsify/`). The "no Homebrew" path.
+ *      batteries-included bundle as an npm SIBLING (`prebuilds/<target>/` climbs
+ *      three to `@gjsify/`). The "no Homebrew" path.
  *   3. `<homebrew prefix>/lib` — the system stack, LAST.
  *
- * Bundle before system is ADR 0023's per-OS policy (`decideGtkSource()`), and a
- * prebuild resolving its GLib differently from the process that loaded it is the
- * two-GTKs-in-one-process failure #910 paid for. The list CANNOT honour
- * `GJSIFY_GTK_PREFER` — `LC_RPATH` is fixed at link time and dyld consults no
- * environment expanding `@rpath` — so the artifact encodes the default and the
- * override stays a node-gi concern; the two look interchangeable and are not.
+ * Bundle before system is ADR 0023's darwin policy (`decideGtkSource()`); a prebuild
+ * resolving GLib differently from the process that loaded it is the two-GTKs failure
+ * #910 paid for. The list cannot honour `GJSIFY_GTK_PREFER` — `LC_RPATH` is fixed at
+ * link time and no environment expands `@rpath` — so the artifact encodes the
+ * default and the override stays a node-gi concern. The two look interchangeable.
  *
- * Entry 3 keeps an absolute build-host path ON PURPOSE, so `checkPrebuildDir()`
- * REPORTS an absolute `LC_RPATH` where it FAILS an absolute `LC_LOAD_DYLIB`: a
- * missing hard dependency aborts the load, a missing search path is skipped.
- * Dropping it would stop the artifact loading on the Homebrew-only GJS host that
- * works today.
+ * Entry 3 stays an absolute build-host path ON PURPOSE: `checkPrebuildDir()` REPORTS
+ * an absolute `LC_RPATH` where it FAILS an absolute `LC_LOAD_DYLIB`, because a
+ * missing hard dependency aborts the load while a missing search path is skipped.
+ * Dropping it would stop the artifact loading on today's Homebrew-only GJS host.
  *
- * The incoming version-PINNED rpaths (`…/Cellar/glib/2.88.2/lib`) meson bakes in
- * are replaced, not extended: they die at the build host's next `brew upgrade`, and
- * naming a formula VERSION makes two CI runs of one commit produce different bytes.
- * Homebrew symlinks every keg into `<prefix>/lib`, so one entry replaces all.
+ * Version-PINNED incoming rpaths (`…/Cellar/glib/2.88.2/lib`, baked in by meson) are
+ * replaced rather than extended: they die at the next `brew upgrade`, and naming a
+ * formula VERSION makes two CI runs of one commit produce different bytes. Homebrew
+ * symlinks every keg into `<prefix>/lib`, so one entry replaces all.
  *
  * Usage: node scripts/relocate-macho.mjs <prebuild-dir> --target darwin-<arch>
  */
@@ -54,13 +52,11 @@ import { basename, join, resolve } from 'node:path';
 import { isBuildHostAbsolutePath, readLibrary } from '../packages/infra/manifest-conformance/lib/binary.mjs';
 
 /**
- * Homebrew's documented default prefix, keyed by the TARGET arch.
- *
- * Not `brew --prefix`: this module also repairs an ALREADY-COMMITTED prebuild,
- * so an Intel Mac editing the `darwin-arm64` image must write `/opt/homebrew` —
- * the prefix of the machine that will RUN it — not its own `/usr/local`.
- * A custom `HOMEBREW_PREFIX` is likewise not consulted; the entry is a FALLBACK
- * for consumers, so the only useful value is the one most consumers have.
+ * Homebrew's default prefix, keyed by the TARGET arch — not `brew --prefix`. This
+ * also repairs an ALREADY-COMMITTED prebuild, so an Intel Mac editing the
+ * `darwin-arm64` image must write `/opt/homebrew`: the prefix of the machine that
+ * will RUN it. A custom `HOMEBREW_PREFIX` is likewise not consulted — the entry is a
+ * consumer FALLBACK, so the only useful value is the one most consumers have.
  */
 const HOMEBREW_DEFAULT_PREFIX = {
     x64: '/usr/local',
@@ -93,12 +89,10 @@ const run = (argv) => execFileSync(argv[0], argv.slice(1), { stdio: ['ignore', '
  * Run one `install_name_tool` edit, translating its ONE expected failure into
  * something actionable.
  *
- * A Mach-O's load commands live in a fixed-size header pad decided at LINK time,
- * so growing them can simply not fit. Cargo leaves no spare pad on x86-64 (the
- * arm64 twins happen to have room, which is what makes this look like a flake).
- * Nothing is asked to grow today, but when something hits the wall the fix is a
- * LINK FLAG (`-Wl,-headerpad_max_install_names`) in that package's `meson.build`,
- * and a raw `execFileSync` stack trace does not say so.
+ * Load commands live in a header pad fixed at LINK time, so growing them can simply
+ * not fit. Cargo leaves no spare pad on x86-64 while the arm64 twins happen to have
+ * room, which is what makes it look like a flake. The fix is a LINK FLAG
+ * (`-Wl,-headerpad_max_install_names`), and a raw stack trace does not say so.
  *
  * @param {string[]} argv
  * @param {string} file
@@ -154,27 +148,23 @@ export function relocateImage(file, rpaths) {
         changed.push(`${dep} → ${to}`);
     }
 
-    // ONLY an image that has something to resolve gets a search path.
-    //
-    // `@rpath` in an image's OWN id is not a dependency — it is a template the
-    // CONSUMER expands against its own rpaths — so a library recording an id of
-    // `@rpath/<leaf>` and no `@rpath/` dependency needs no `LC_RPATH`. Both Rust
-    // cdylibs are that shape, and three rpaths would be dead weight that also
-    // does not fit in cargo's header pad. Deriving the need from the dependencies
-    // makes both arches produce the same bytes, which a blanket rule did not.
+    // ONLY an image with something to resolve gets a search path. `@rpath` in an
+    // image's OWN id is not a dependency but a template the CONSUMER expands, so an
+    // id of `@rpath/<leaf>` with no `@rpath/` dependency needs no `LC_RPATH`. Both
+    // Rust cdylibs are that shape, where three rpaths would be dead weight that also
+    // does not fit cargo's header pad. Deriving the need from the dependencies makes
+    // both arches produce the same bytes, which a blanket rule did not.
     const needsRpath = rewritten.length > 0 || info.needed.some((d) => d.startsWith('@rpath/'));
     if (needsRpath) {
-        // Replace the search-path list AND ITS ORDER: delete EVERY existing entry,
-        // including one already in the wanted list, then add the wanted ones in
-        // sequence. Deleting only the unwanted ones is wrong invisibly —
-        // `-add_rpath` APPENDS, so a kept entry holds its original position and
-        // additions land behind it, making precedence a property of whatever the
-        // linker baked in. A freshly-linked `libgwebgl.dylib` carries `<brew>/lib`
-        // from the Homebrew link line, so keeping it put the SYSTEM prefix ahead of
-        // the bundle: the inversion of ADR 0023's darwin policy and #910's
-        // two-GLibs hazard on any host with both. The committed artifacts hid it,
-        // their version-pinned Cellar rpaths all being deleted anyway. Deleting and
-        // re-adding the same string costs zero header bytes.
+        // Replace the list AND ITS ORDER: delete EVERY existing entry, including one
+        // already wanted, then add the wanted ones in sequence. Keeping the wanted
+        // ones is wrong INVISIBLY — `-add_rpath` APPENDS, so a kept entry holds its
+        // position and additions land behind it, making precedence a property of
+        // whatever the linker baked in. A freshly-linked `libgwebgl.dylib` carries
+        // `<brew>/lib` from the Homebrew link line, so keeping it put the SYSTEM
+        // prefix ahead of the bundle — ADR 0023 inverted, and #910's two-GLibs hazard
+        // on any host with both. The committed artifacts hid it, their version-pinned
+        // Cellar rpaths all being deleted anyway. Re-adding costs zero header bytes.
         for (const existing of info.searchPaths) {
             edit(['install_name_tool', '-delete_rpath', existing, file], file);
             changed.push(`-rpath ${existing}`);
@@ -185,19 +175,19 @@ export function relocateImage(file, rpaths) {
         }
     }
 
-    // Re-sign what was signed, and ONLY that. `install_name_tool` invalidates an
-    // existing signature and Apple-silicon dyld refuses a mis-signed dylib, so an
-    // image that HAD one needs a fresh one. An image that had none must not get
-    // one: the signature lands on a fresh page-aligned `__LINKEDIT` tail, so
-    // signing an unsigned 20,288-byte `libgjsifylightningcss.dylib` produced 38,720
-    // bytes — ~18 KB × 9 x64 artifacts of growth in COMMITTED files that every
-    // `commit-prebuilds` run rewrites (Mach-O output is not byte-reproducible).
+    // Re-sign what was signed, and ONLY that. `install_name_tool` invalidates a
+    // signature and Apple-silicon dyld refuses a mis-signed dylib. An image that had
+    // NONE must not get one: the signature lands on a fresh page-aligned
+    // `__LINKEDIT` tail, so signing an unsigned 20,288-byte
+    // `libgjsifylightningcss.dylib` produced 38,720 — ~18 KB × 9 x64 artifacts of
+    // growth in COMMITTED files that every `commit-prebuilds` run rewrites (Mach-O
+    // output is not byte-reproducible).
     //
-    // Derived from the image, not the arch: the two agree today (all 18 committed
-    // artifacts — arm64 `adhoc,linker-signed`, x64 unsigned, ld64 requiring a
-    // signature on arm64 macOS only) and a toolchain that starts signing x64 needs
-    // no edit here. `build-gtk-runtime-darwin.mjs` signs unconditionally — correct
-    // THERE, where the output is a fresh tarball payload, not committed.
+    // Derived from the image, not the arch: the two agree today (arm64
+    // `adhoc,linker-signed`, x64 unsigned, ld64 requiring a signature on arm64 only)
+    // and a toolchain that starts signing x64 needs no edit here.
+    // `build-gtk-runtime-darwin.mjs` signs unconditionally — correct THERE, where the
+    // output is a fresh tarball payload rather than a committed file.
     if (changed.length > 0 && info.signed) {
         run(['codesign', '--force', '--sign', '-', file]);
         changed.push('re-signed (ad-hoc)');

--- a/status/comment-budget.json
+++ b/status/comment-budget.json
@@ -10,7 +10,7 @@
     "packages/nativescript-bridge": 0.495,
     "packages/gjs": 0.399,
     "tests": 0.239,
-    "scripts": 0.583,
+    "scripts": 0.586,
     "examples": 0.182,
     "showcases": 0.158,
     "website": 0.17


### PR DESCRIPTION
`gjsify --version` answers `unknown` from any bundle that is not sitting exactly one directory below its own `package.json` — the documented `GJSIFY_BOOTSTRAP` cache included. Closes #1177.

Measured on the **published** `@gjsify/cli@0.38.1` tarball under GJS 1.88.1:

```
cd package && gjs -m dist/cli.gjs.mjs --version   → 0.38.1
cp dist/cli.gjs.mjs elsewhere/ && … --version     → unknown
```

Same on real arm64 hardware (OnePlus 6T, postmarketOS, gjs 1.88.1), which is where it surfaced — probing the published artifact ahead of a release rather than the checkout.

## One resolver, one straggler

#1139 consolidated the CLI's version reads under `cliVersion()`. This call site was not converted: `cli-app.ts` kept its own `readBundleVersion()`, a fixed-depth `join(here, '..', 'package.json')` inside a `try` that answers `'unknown'` rather than throwing.

The correct value was in the same process the whole time — the build define bakes it into the bundle, so `cliVersion()` returns `0.38.1` while `--version` printed `unknown`:

```
(){return zP===void 0&&(zP=`0.38.1`),zP}
```

Not cosmetic, because `--version` is used as an **oracle**: `cli-cross-platform.yml` asserts it, `release-cut.yml`'s pre-flight compares `DECLARED` against `REPORTED`, and `showcase` PINS its dlx spec to it — a version it cannot read is a showcase left unpinned, serving a cached older bundle. That is #1139's own incident, reachable again through a different door.

## The gate for this missed it

`check-cli-own-version-read.mjs` exists for exactly this defect and matched one spelling:

```js
/new URL\(\s*(['"`])[^'"`]*package\.json\1\s*,\s*import\.meta\.url\s*\)/
```

`cli-app.ts` wrote the same defect with `join()`, so the scan reported OK for a month while the bug shipped. **A guard that recognises one way of writing a defect certifies every other way.**

It now keys on the property that is actually wrong: a manifest path built from the module's own location **and a literal parent hop**, in either spelling.

"Derived from `import.meta.url`" is *not* the rule, and I measured that before settling on it — `install.ts` and `build-cache.ts` bind from `import.meta.url` too and then **climb** until they find a `@gjsify/cli` manifest, which is the depth-independent pattern this check recommends. Keying on the derivation flagged three correct reads, and a check with false alarms is worse than none: it gets deleted, and takes the real rule with it.

A/B, both spellings against both gate versions:

| defect | old gate | new gate |
|---|---|---|
| `join(here, '..', 'package.json')` | **exit 0 — missed** | exit 1 |
| `new URL('../package.json', import.meta.url)` | exit 1 | exit 1 |

## What this does NOT add

A runtime guard. Asserting the version out of a *relocated* bundle needs a real `dist/cli.gjs.mjs`, and no e2e has one — `bootstrap-cold-tree` drives `resolveGjsifySpawn` against a stand-in file, never a built bundle. Building one for a version string costs ~300 s, so the cause is gated at the source and the artifact is covered by the published-release probe that found this.

Closes #1177