### PR TITLE
fix: leave no slack behind a required check

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -182,6 +182,15 @@ jobs:
       # warning, so the end of an oversized file is not read at all. Per-file ceilings
       # are MEASURED for the same reason as above: two files are over the 20 KB target
       # AGENTS.md sets itself, and a flat gate would have been waived on arrival.
+      #
+      # The ceilings are EXACT, so a file BELOW its ceiling fails here too and the fix is
+      # `--update` plus the ledger in the same commit. That is not pedantry: a required
+      # check reads `main` plus ONE branch and `strict_required_status_checks_policy` is
+      # false, so any slack a committed number carries can be spent in full by two
+      # branches at once. Probe-merged in #1157 — a 48-byte window left by an
+      # un-re-baselined cleanup took `main` to 979 over a ceiling of 955 with both PRs
+      # green. At zero slack the two spenders collide in the ledger and git stops them.
+      # Reasoning + the residual: docs/governance.md § Concurrent PRs.
       - name: Check agent context file sizes
         run: node scripts/check-agent-context-size.mjs --check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,8 +163,11 @@ axis 6 bundled toolchains → [docs/bundled-toolchains.md](docs/bundled-toolchai
 Every AGENTS.md ≤ 20 KB, nothing over 32 KiB: that is `project_doc_max_bytes`, where Codex
 silently truncates the tail with no warning. This file reached 277 KB before it was split, one
 defensible paragraph at a time. Held by `scripts/check-agent-context-size.mjs --check`: the 32 KiB
-cap plus a MEASURED per-file ceiling that only tightens. This file and `packages/framework/AGENTS.md`
-are over the 20 KB target, so the gate catches REGROWTH instead of claiming the target is met.
+cap plus an EXACT per-file ceiling. This file and `packages/framework/AGENTS.md` are over the
+20 KB target, so the gate catches REGROWTH instead of claiming the target is met. Exact means
+BELOW fails too: touch a context file, `--update`, commit `status/agent-context-budget.json` with
+it. Slack is what two concurrent PRs each spend in full, and that ledger line is what makes them
+collide in git rather than on `main` ([docs/governance.md](docs/governance.md) § Concurrent PRs).
 
 **Where content goes.** True repo-wide → this file. Scoped to one subtree → that subtree's
 AGENTS.md, authoritative there. The INCIDENT behind a rule, a lookup table, a rare procedure →

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -130,3 +130,81 @@ That second cost is what ADR 0002 removes: with the bundle untracked, a CLI PR
 becomes a source-only diff and re-merging is a normal text merge rather than a
 20-minute rebuild. The "prefer few large PRs" conclusion survives on the
 25-minutes-per-pass arithmetic alone.
+
+## Concurrent PRs and checks that score a shared number
+
+> Root [AGENTS.md](../AGENTS.md) § Writing agent context files carries the rule this
+> section is the reasoning for. Issue #1157 is the thread.
+
+A required check reads exactly one tree: `main` plus **one** branch's diff. It never sees
+the other open branches, and `main`'s ruleset sets
+`strict_required_status_checks_policy: false`, so a branch is not required to be up to
+date before merging and nothing re-measures at merge time. For a check that asserts a
+FACT about a diff — this declaration matches that file, this workflow block is valid
+shell — that is harmless: the fact stays true however the merge orders.
+
+For a check that scores a **shared number**, it is not. Any slack the number carries can
+be spent in full by two branches at once, and the second merge lands a state neither CI
+run measured. Both PRs are green, the merge is clean, and `main` is red for a reason that
+appears in neither diff. Per the incident in #906, every open PR then fails on `main`'s
+reason while looking like its own diff is broken.
+
+**Two checks in `Detect runtime-triplet drift` carried such a number. Nothing else does**
+— audited script by script; every other check in that job fails per item, on a fact, and
+is immune by construction. They were resolved differently, on purpose.
+
+### `check-comment-budget` — de-gated (#1166)
+
+A comment-to-code ratio over a whole tree is the worst case: ~500 unrelated files feed one
+counter, so any two PRs touching the same pillar contend. Probe-merged in #1157: `main` at
+5014/8678 = 0.578, `main` + #1152 + #1156 at 5060/8671 = 0.584, over a 0.583 ceiling. Two
+further facts came out of that probe and neither was guessable from the PRs' own deltas —
+#1156 lost 27 lines of headroom by **deleting ~10 code lines** and adding no comment at
+all (it is a ratio, so removing code raises it), and a third open PR removed comment lines
+net, so the set that overflowed was not the set that landed.
+
+The fix was not to give the counter slack. It was to notice that the check scores a
+**proxy** rather than a fact — moving a full-line comment to the end of a code line drops
+the comment count and leaves the code count untouched, and ~1670 trailing comments are
+already invisible to it — and that blocking power over unrelated work is more than a proxy
+earns. CI runs `--warn`: the table plus one annotation per over-ceiling tree, exit 0. The
+ledger's own integrity still fails, because a stale or missing ceiling is a fact.
+
+Adding a margin to the ceilings was considered and rejected: it weakens the ratchet by
+exactly its own size, and it is a second, weaker fix for a problem de-gating already
+closed.
+
+### `check-agent-context-size` — exact ledger, still gated
+
+This one stays a gate: it asserts a fact with a real cost behind it (past 32 KiB Codex
+truncates the tail with no warning), so de-gating was not on offer. Per-file byte ceilings
+look immune — different files never contend — but the shape is the same, and it was
+reproduced rather than argued. Ceiling 955; a cleanup takes the file to 907 and does not
+re-baseline; two PRs then add 35 bytes each in different paragraphs. Both green, merge
+clean, `main` at 979 over 955.
+
+The window is always **the slack itself**, and the fix is to have none: a file BELOW its
+ceiling now fails, with `--update` named in the message. At zero slack every size change
+must edit that path's line in `status/agent-context-budget.json`, so two concurrent
+changes to the same context file collide there and **git** refuses the merge — the ledger
+becomes the interlock, and the check no longer has to see a branch it was never run on.
+Measured both ways: +35 B and +41 B conflict in the ledger and are blocked.
+
+**Residual, stated because it is real.** Two PRs that change one file by the *identical*
+number of bytes write the identical ledger line, which merges clean and lands over the
+ceiling. Byte-exact collisions are narrow, not impossible, and `main`'s own run is what
+catches them. Closing that too needs `strict_required_status_checks_policy: true` or a
+merge queue — both were weighed and both lose to the arithmetic in § PR size above: a full
+pass is ~25 minutes, and every merge into `main` would force a re-run of every open PR.
+
+**The cost, stated because it is paid by everyone.** Changing an agent context file by one
+byte fails CI until `--update` runs and the ledger is committed alongside. That friction is
+the mechanism, not a side effect.
+
+### The rule this generalises to
+
+Before putting a number behind a required check, ask whether two branches can each spend
+its slack in full. If they can, either the check should not gate, or its ledger must be
+exact enough that concurrent spenders collide in git first. A whole-tree or whole-repo
+aggregate is structurally blind to concurrent PRs; only per-item exactness gives the merge
+something to trip over.

--- a/scripts/check-agent-context-size.mjs
+++ b/scripts/check-agent-context-size.mjs
@@ -15,12 +15,20 @@
 //         was when last reviewed. Two files are over the 20 KB target AGENTS.md sets
 //         for itself, so a flat 20 KB gate would have failed on arrival and been
 //         waived; a per-file ratchet fails only on REGROWTH, which is the thing worth
-//         catching. `--update` after a cleanup lowers a ceiling; raising one is a
-//         reviewed line in the same commit as the prose that needed it.
+//         catching.
+//
+// The SOFT ceiling is EXACT: a file BELOW its ceiling fails too, and `--update` is the
+// one-command fix named in the message. Slack is the defect — a required check reads
+// `main` plus ONE branch and `strict_required_status_checks_policy` is false, so two
+// branches can each spend the same slack in full and land a state neither run measured
+// (#1157, probe-merged: a 48-byte window took `main` to 979 over a ceiling of 955 with
+// both PRs green). At zero slack every size change must edit this path's ledger line,
+// so concurrent changes to one file collide in git rather than on `main`. Reasoning,
+// both reproductions and the residual: docs/governance.md § Concurrent PRs.
 //
 //   node scripts/check-agent-context-size.mjs            # print the table
 //   node scripts/check-agent-context-size.mjs --check    # gate (CI)
-//   node scripts/check-agent-context-size.mjs --update   # re-baseline
+//   node scripts/check-agent-context-size.mjs --update   # re-baseline (both directions)
 //
 // A `CLAUDE.md` that is a real file rather than a symlink to `AGENTS.md` is also an
 // error: both get loaded, so the tax doubles and the second copy drifts.
@@ -68,13 +76,18 @@ for (const r of rows) {
     const ceiling = budget[r.file];
     const overHard = r.bytes > HARD_CAP;
     const overSoft = ceiling !== undefined && r.bytes > ceiling;
+    // Slack is the whole defect, so it is a failure rather than a courtesy. A ceiling
+    // above the file is also simply a false statement about the tree — the same kind of
+    // thing as the stale and unbudgeted entries below, not a judgement about size.
+    const slack = ceiling !== undefined && r.bytes < ceiling;
     process.stdout.write(
         `${pad(r.file, 52)}${lpad(r.bytes, 8)}${lpad(ceiling === undefined ? '-' : ceiling, 9)}` +
-            `${overHard ? '  OVER 32 KiB' : overSoft ? '  OVER' : ''}\n`,
+            `${overHard ? '  OVER 32 KiB' : overSoft ? '  OVER' : slack ? `  STALE -${ceiling - r.bytes}` : ''}\n`,
     );
     if (overHard) failures.push({ ...r, ceiling, kind: 'hard' });
     else if (overSoft) failures.push({ ...r, ceiling, kind: 'soft' });
     else if (ceiling === undefined) failures.push({ ...r, ceiling, kind: 'unbudgeted' });
+    else if (slack) failures.push({ ...r, ceiling, kind: 'slack' });
 }
 
 // A ceiling for a file that no longer exists is a claim nothing checks.
@@ -114,12 +127,22 @@ for (const f of failures) {
                 `${f.ceiling} (+${f.bytes - f.ceiling}). This file is loaded on every agent turn.\n` +
                 '  Move the DETAIL into `docs/` and keep the rule plus one link — never delete the incident\n' +
                 '  behind a rule, which is what makes the rule survive a future "simplification".\n' +
-                `  If the growth is genuinely warranted, raise the ceiling in ${BUDGET_FILE} in the same\n` +
-                '  commit, so the increase is reviewed rather than accumulated.\n',
+                '  If the growth is genuinely warranted: node scripts/check-agent-context-size.mjs --update\n' +
+                `  and commit ${BUDGET_FILE} with it, so the increase is one reviewed line rather than\n` +
+                '  something that accumulated. That line is also the interlock — a concurrent PR growing the\n' +
+                '  same file writes the same line, so git stops the pair instead of CI stopping `main`.\n',
         );
     } else if (f.kind === 'unbudgeted') {
         process.stderr.write(
             `\ncheck-agent-context-size: ${f.file} has no ceiling in ${BUDGET_FILE}. Run --update to baseline it.\n`,
+        );
+    } else if (f.kind === 'slack') {
+        process.stderr.write(
+            `\ncheck-agent-context-size: ${f.file} is ${f.bytes} bytes but its ceiling says ${f.ceiling} ` +
+                `(${f.ceiling - f.bytes} bytes of slack). Shrinking is the point, so this is not a complaint ` +
+                'about the file — the LEDGER is out of date, and unclaimed slack is what two concurrent PRs ' +
+                'can each spend in full while both stay green (#1157).\n' +
+                '  Fix: node scripts/check-agent-context-size.mjs --update — then commit the ledger with it.\n',
         );
     }
 }

--- a/scripts/check-comment-budget.mjs
+++ b/scripts/check-comment-budget.mjs
@@ -163,6 +163,16 @@ const TOLERANCE = 0.0005;
  */
 const allowedComments = (ceiling, code) => Math.floor((ceiling + TOLERANCE) * code);
 
+/**
+ * The other side of the same ratio: the code total at which today's comments fit. Printed
+ * next to the cut because a message that only ever says "cut N" teaches that deletion is
+ * the safe direction, and it is not — #1156 lost 27 lines of headroom by removing ~10
+ * code lines and adding no comment at all. Read by both surfaces, so they cannot drift
+ * into advising half of a two-sided quantity.
+ * @param {number} comment @param {number} ceiling
+ */
+const codeToFit = (comment, ceiling) => Math.ceil(comment / (ceiling + TOLERANCE));
+
 const mode = process.argv.includes('--check')
     ? 'check'
     : process.argv.includes('--update')
@@ -175,13 +185,26 @@ const totals = measure();
 
 if (mode === 'update') {
     /** @type {Record<string, number>} */
+    const previous = existsSync(BUDGET_FILE) ? JSON.parse(readFileSync(BUDGET_FILE, 'utf8')) : {};
+    /** @type {Record<string, number>} */
     const out = {};
+    const moved = [];
     for (const area of AREAS) {
         const t = totals.get(area);
-        if (t.files > 0) out[area] = Number(ratio(t).toFixed(3));
+        if (t.files === 0) continue;
+        // ONLY EVER TIGHTENS, as the header has always promised and the code did not do:
+        // it wrote the measured value unconditionally, so `--update` on a GROWN tree
+        // raised the ceiling to fit — measured here, `scripts` 0.586 -> 0.591, blessing
+        // the exact drift the ratchet exists to catch. Raising stays possible as a
+        // reviewed edit to the ledger, in the commit that needs it.
+        const measured = Number(ratio(t).toFixed(3));
+        const stored = previous[area];
+        out[area] = stored === undefined ? measured : Math.min(stored, measured);
+        if (out[area] !== stored) moved.push(`${area}: ${stored === undefined ? 'new' : stored} -> ${out[area]}`);
     }
     writeFileSync(BUDGET_FILE, `${JSON.stringify(out, null, 4)}\n`);
     process.stdout.write(`check-comment-budget: wrote ${BUDGET_FILE} (${Object.keys(out).length} areas)\n`);
+    for (const m of moved) process.stdout.write(`  ${m}\n`);
     process.exit(0);
 }
 
@@ -253,7 +276,9 @@ if (mode === 'warn') {
     for (const f of failures) {
         process.stdout.write(
             `::warning title=comment budget: ${f.area}::at ${f.have.toFixed(3)} per code line, over its ` +
-                `ceiling of ${f.ceiling.toFixed(3)} by ${f.comment - f.allowed} comment line(s). ` +
+                `ceiling of ${f.ceiling.toFixed(3)} by ${f.comment - f.allowed} comment line(s). Cut that many, ` +
+                `or reach ${codeToFit(f.comment, f.ceiling)} code lines — it is a RATIO, so DELETING CODE raises ` +
+                'it and a commit that removes dead code without adding a comment can land here. ' +
                 'Reported, not gated — run --check locally before a cleanup commit.\n',
         );
     }
@@ -268,8 +293,10 @@ for (const f of failures) {
             `over its committed ceiling of ${f.ceiling.toFixed(3)} — ${f.comment} comment lines against ` +
             `${f.code} code lines, ${f.comment - f.allowed} more than the ${f.allowed} that ceiling allows. ` +
             `Cutting ${f.comment - f.allowed} passes; cutting more than that is spending headroom you do not owe.\n` +
-            '  This is a RATIO, so DELETING CODE raises it: a commit that only removes dead code,\n' +
-            '  adding no comment at all, can land here. Check the code column before assuming otherwise.\n' +
+            `  Two levers, because it is a RATIO: CUT ${f.comment - f.allowed} COMMENT LINES, or reach\n` +
+            `  ${codeToFit(f.comment, f.ceiling)} CODE LINES (currently ${f.code}). Read backwards, that is why DELETING CODE\n` +
+            '  raises it: a commit that only removes dead code, adding no comment at all, can land\n' +
+            '  here. Check the code column before assuming a deletion is the safe direction.\n' +
             '  Comment WHY, not WHAT: a comment that restates the code is a second copy that drifts.\n' +
             '  What usually has to go: restatement, narrative history ("previously we…", "ported from…"),\n' +
             '  upstream source coordinates a reader cannot act on, and change-log entries git already has.\n' +

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -1,5 +1,5 @@
 {
-    "AGENTS.md": 20909,
+    "AGENTS.md": 21186,
     "packages/dom/AGENTS.md": 2081,
     "packages/framework/AGENTS.md": 21026,
     "packages/infra/AGENTS.md": 1131,

--- a/status/comment-budget.json
+++ b/status/comment-budget.json
@@ -10,7 +10,7 @@
     "packages/nativescript-bridge": 0.495,
     "packages/gjs": 0.399,
     "tests": 0.239,
-    "scripts": 0.586,
+    "scripts": 0.592,
     "examples": 0.182,
     "showcases": 0.158,
     "website": 0.17


### PR DESCRIPTION
## What #1157 asked, and what is left of it

The issue reported a whole-tree ratio behind a required check turning `main` red with
every PR green. **That specific defect is gone**, and not by this PR: #1166 moved
`check-comment-budget` to `--warn` and cited #1157 as one of its three reasons.

Verified on current `main` rather than assumed:

```
$ sed -n '176,186p' .github/workflows/audit-runtimes.yml
      - name: Report each tree's comment budget
        run: node scripts/check-comment-budget.mjs --warn
      ...
      - name: Check agent context file sizes
        run: node scripts/check-agent-context-size.mjs --check

$ node scripts/check-comment-budget.mjs --warn >/dev/null; echo $?
0                       # over-ceiling tree present, still exit 0
```

`main` is in fact over on `scripts/` right now — 5209/8811 = 0.591 against 0.586, 42
lines over — and nothing failed, which is the de-gating working as designed.

So this PR does not implement the margin the issue listed as its fourth option. It would
weaken the ratchet by exactly its own size to fix a problem #1166 already closed, and
#1166's own commit message names the same zero-headroom behaviour as a reason to stop
gating. Re-solving it more weakly is not an improvement.

## The scope sentence is the live part

> the same reasoning applies to any other whole-tree or whole-repo metric behind a
> required check, not only this one

Audited every script in `Detect runtime-triplet drift`, one at a time. **Exactly two
carry a committed number**; the other 25 fail per item on a fact about a diff and are
immune by construction — a fact stays true however the merge orders. The second one is
still a gate:

| check | shape | gated |
|---|---|---|
| `check-comment-budget` | whole-tree ratio, ~500 files per counter | no (#1166) |
| `check-agent-context-size` | per-file byte ceiling | **yes** |
| everything else in the job | per-item fact | yes, immune |

## Per-file ceilings do have it — probe-merged, not argued

Different files never contend, so this looked immune. It is not. Real git branches, real
merge, real script:

```
main: AGENTS.md 907 bytes, ceiling 955   (a cleanup that did not re-baseline)
  PR A  +35 B in one paragraph   -> --check GREEN
  PR B  +35 B in another         -> --check GREEN
  merge A, merge B               -> CLEAN, no ledger line touched by either
  main                           -> AGENTS.md 979 over 955   *** RED ***
```

Both PRs were honest and neither CI run was wrong. The 48-byte window was invisible to
each of them, because a required check reads `main` plus **one** branch and
`strict_required_status_checks_policy` is false.

**The window is always the slack itself.** So the ledger is now exact: a file *below* its
ceiling fails, with `--update` named in the message. At zero slack every size change must
edit that path's line in `status/agent-context-budget.json`, so concurrent changes to one
file collide there and **git** refuses the merge — the ledger is the interlock, and the
check no longer has to see a branch it was never run on.

```
+35 / +41  -> ledger 991 vs 997  -> merge CONFLICT in status/agent-context-budget.json
+35 / +35  -> ledger 943 vs 943  -> merge CLEAN, main over ceiling
```

**Residual, stated because it is real:** two PRs changing one file by the *identical*
number of bytes write the identical line and still land over. Byte-exact collisions are
narrow, not impossible. Closing that too needs `strict: true` or a merge queue, and both
lose to the arithmetic in § PR size — ~25 min a pass, every merge re-running every open PR.

**Cost, stated because everyone pays it:** change a context file by one byte and CI stays
red until `--update` runs. That friction is the mechanism, not a side effect.

The live instance is in this diff: the root `AGENTS.md` sat 8 bytes under its ceiling.

```
$ node scripts/check-agent-context-size.mjs --check     # before
AGENTS.md                            20901    20909  STALE -8
check-agent-context-size: AGENTS.md is 20901 bytes but its ceiling says 20909
(8 bytes of slack). Shrinking is the point, so this is not a complaint about the
file — the LEDGER is out of date, and unclaimed slack is what two concurrent PRs
can each spend in full while both stay green (#1157).
  Fix: node scripts/check-agent-context-size.mjs --update
```

## Both `--update`s contradicted their own headers

Not part of the issue; found while measuring, and the more serious half sits behind the
gate. Both scripts promise "the budget only tightens" and both wrote the measured value
unconditionally, so `--update` on a **grown** tree raised the ceiling to fit it:

```
$ node scripts/check-comment-budget.mjs --update        # before, on current main
-    "scripts": 0.586,
+    "scripts": 0.591,          # tree is 42 lines OVER; --update blessed it
```

A ratchet that re-baselines upward is a rubber stamp for exactly the drift it exists to
catch. `check-comment-budget --update` now only tightens, and prints what moved:

```
$ node scripts/check-comment-budget.mjs --update        # after
  packages/node: 0.186 -> 0.165
  packages/web: 0.292 -> 0.261
  ...                            # `scripts` absent: 0.591 measured, 0.586 kept
```

`check-agent-context-size --update` keeps writing both directions on purpose — there the
exact ledger *is* the interlock, and every raise is a reviewed line in the diff anyway.

I did not commit that re-baseline. Tightening 10 trees at once is precisely the
whole-tree move this issue says should not ride along with an unrelated change.

## The one cheap fix worth keeping

"Deleting code raises it" now appears in `--warn`, which is what CI actually runs — it was
only ever in the `--check` failure path — and both surfaces name the second lever off one
helper, so they cannot drift apart:

```
::warning title=comment budget: scripts::at 0.592 per code line, over its ceiling of
0.400 by 1696 comment line(s). Cut that many, or reach 13069 code lines — it is a RATIO,
so DELETING CODE raises it and a commit that removes dead code without adding a comment
can land here. Reported, not gated — run --check locally before a cleanup commit.
```

## `scripts` ceiling 0.586 -> 0.592

A raise, so it is stated rather than buried. Two causes: #1178 added a guard script and
left the tree 42 lines over three commits ago, seen by nobody because the check only
warns; this change adds 25 lines of incident on top. The alternative was trimming 53
lines out of a tree #1176 trimmed three commits ago, which risks the incidents AGENTS.md
says to keep. Worth noting on its own: this is the second unreviewed move of that tree in
three commits, which is what a warn-only check looks like in practice.

## Where the choice is now recorded

`docs/governance.md` § *Concurrent PRs and checks that score a shared number* — the
mechanism, what each of the two checks got and why they differ, both reproductions, the
residual, and the generalisation. Root AGENTS.md carries the rule and links to it.

## What I ruled out

- **The margin** (#1157's fourth option) — dead work for `check-comment-budget`, and
  actively wrong for `check-agent-context-size`: a margin *creates* slack, which is the
  window itself. Adding one there would have opened the defect, not closed it.
- **`strict_required_status_checks_policy: true`**, **a merge queue**, **a fourth required
  check** — out of scope by instruction, and the first two are weighed in the doc.

## Verification

```
node scripts/check-comment-budget.mjs --check       exit 0   (main: exit 1, scripts -42)
node scripts/check-comment-budget.mjs --warn        exit 0
node scripts/check-agent-context-size.mjs --check   exit 0   (before: exit 1, STALE -8)
node scripts/audit-runtimes.mjs --check --strict    exit 0
gjsify format --check + oxlint on both scripts      clean
7 adjacent required-job checks                      PASS
```

Failure paths exercised rather than assumed: `scripts` ceiling forced to 0.400 for the
`--warn` annotation, `tests/AGENTS.md` ceiling forced to 8000 for the grown-file message,
and the `STALE` path by the real 8-byte slack on `main`.

Refs #1157 — the reported defect was closed by #1166; this closes the residual it
pointed at.
