### PR TITLE
style: format the prototype-chain conformance program

### DIFF
--- a/packages/node-gi/node-gi/conformance/programs/prototype-chain.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/prototype-chain.conf.mjs
@@ -66,4 +66,4 @@ print('after restore, count unchanged:', resets);
 // entry would excuse this whole program on node/bun/deno.)
 const other = new Gio.ZlibDecompressor({ format: Gio.ZlibCompressorFormat.GZIP });
 print('two instances share the method:', other.convert === decompressor.convert);
-print('the prototype is the instances\' resolver:', proto.convert === other.convert);
+print("the prototype is the instances' resolver:", proto.convert === other.convert);


### PR DESCRIPTION
**`main` is red on `Check Fedora 44` → `Format (oxfmt --check)`.** One file, one line:

```
packages/node-gi/node-gi/conformance/programs/prototype-chain.conf.mjs (0ms)
Format issues found in above 1 files.
Finished in 362ms on 2896 files using 4 threads.
```

An escaped apostrophe inside a single-quoted string that oxfmt rewrites to a double-quoted one. Verified locally before and after:

```
$ gjsify format --check
packages/node-gi/node-gi/conformance/programs/prototype-chain.conf.mjs (0ms)
Format issues found in above 1 files.
$ gjsify format && gjsify format --check
All matched files use the correct format.
```

## Why nothing caught it — and why this PR cannot catch it either

It landed with #1183, whose diff is `packages/node-gi/**`, `packages/node-gi/AGENTS.md` and `status/agent-context-budget.json`. Every one of those is on the classifier's IGNORE list (`packages/node-gi/**` — own CI; `**/*.md`; `status/`), so `changes` returned skip-all and **the entire GJS matrix skipped, including the job whose Format step scans 2894 files with `packages/node-gi/**` among them.**

That is a **whole-tree check sitting inside a per-workspace gate** — the same shape as #1173, one layer in: the guard's trigger is narrower than what the guard covers. `oxfmt` does not care which workspace a file belongs to; the job that runs it does.

**This PR touches only `packages/node-gi/**`, so its own `Check Fedora 44` will skip too.** Saying so rather than letting it read as green: the verification is the local run above plus `main`'s own push run, which is unconditional (the documented backstop — push-to-main and the nightly run the full suite).

## Not fixed here

The gate. Moving the whole-tree steps out of the selectively-gated `check` job is a change to `main.yml`'s job graph with its own cost (a job that runs `gjsify format` needs an install and the CLI, which is precisely why `audit-runtimes.yml` — where the other whole-tree checks live — states "no install, no build" as its own constraint). That belongs in its own PR, on a green `main`, not in a red-main fix.