### PR TITLE
feat(storybook): show four widgets we already ship

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -277,6 +277,13 @@ jobs:
       - name: Check every storybook category is placed by the declaration
         run: node scripts/check-storybook-category-order.mjs
 
+      # Parity asks whether the three targets render the SAME stories; it is blind by
+      # construction to the story that exists NOWHERE — a widget with no meta at all is
+      # perfectly symmetric across three targets. Measured: nine widgets shipped on both
+      # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
+      - name: Check every shared widget is in the storybook or ledgered
+        run: node scripts/check-storybook-widget-coverage.mjs
+
       # A NativeScript widget's className and the theme's selector are two halves of
       # one decision that nothing compares. Renaming the shortcut-label keycap class
       # from `keycap` to `adw-keycap` was measured: 3221 tests stayed GREEN while
@@ -587,6 +594,13 @@ jobs:
       # reads as the overview being missing rather than as an ordering difference.
       - name: Check every storybook category is placed by the declaration
         run: node scripts/check-storybook-category-order.mjs
+
+      # Parity asks whether the three targets render the SAME stories; it is blind by
+      # construction to the story that exists NOWHERE — a widget with no meta at all is
+      # perfectly symmetric across three targets. Measured: nine widgets shipped on both
+      # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
+      - name: Check every shared widget is in the storybook or ledgered
+        run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of
       # one decision that nothing compares. Renaming the shortcut-label keycap class

--- a/packages/framework/storybook-core/src/category-order.ts
+++ b/packages/framework/storybook-core/src/category-order.ts
@@ -33,6 +33,7 @@ export const STORYBOOK_CATEGORY_ORDER: readonly string[] = [
     'Overview',
     'Presentation',
     'Boxed Lists',
+    'Controls',
     'Buttons',
     'Layout',
     'View Switching',

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Every widget both renderers ship is either IN the storybook or in this ledger.
+//
+// WHAT THIS ADDS TO PARITY
+//
+// `check-storybook-story-parity.mjs` asks whether the three targets render the SAME
+// stories. It is blind by construction to the story that exists nowhere: a widget with
+// no `*.meta.ts` at all is perfectly symmetric across three targets, so parity is
+// green and the reference storybook simply does not show it.
+//
+// Measured 2026-08-15, and the size of the hole is the argument for the check: of the
+// 43 widgets implemented on BOTH renderers, NINE had no story anywhere — including
+// `adw-entry`, `adw-drop-down`, `adw-menu-button` and `adw-view-switcher-bar`, four
+// ordinary widgets a reader would expect to find first. The GTK storybook is the
+// reference implementation the other two are aligned against; a widget it never shows
+// is a widget with no reference.
+//
+// WHAT IT CHECKS
+//
+//   1. Every `adw-<name>` present in BOTH `packages/web/adwaita-web/src/elements/` and
+//      `packages/nativescript-bridge/adwaita/src/widgets/` has a `<name>.meta.ts` in
+//      the GTK showcase — or an entry below saying why not.
+//   2. No ledger entry names a widget that HAS a story (a stale exemption reads as
+//      considered when it is merely forgotten).
+//   3. No ledger entry names a widget the rule cannot reach — one renderer only, or
+//      no renderer at all. Same reason: it would look like cover it does not give.
+//
+// The both-renderers scope is deliberate. A widget on ONE renderer cannot have a
+// three-target story, so demanding one here would demand a port, and that is a
+// product decision this check has no business making.
+//
+// Plain Node over the repo's own files — no install, no build — so it runs in
+// `audit-runtimes.yml` next to the other repo-scoped guards.
+//
+// Usage: node scripts/check-storybook-widget-coverage.mjs [--root <dir>]
+
+import { readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
+
+const WEB_ELEMENTS = join(ROOT, 'packages/web/adwaita-web/src/elements');
+const NS_WIDGETS = join(ROOT, 'packages/nativescript-bridge/adwaita/src/widgets');
+const GTK_SRC = join(ROOT, 'showcases/gtk/adwaita-storybook/src');
+
+/**
+ * Widgets on both renderers that deliberately have no story of their own, and why.
+ *
+ * The bar is: a reader looking for this widget in the storybook finds what they came
+ * for, under another name — or there is nothing a GTK story could honestly show. "It
+ * would be work" is not a reason; those get a story.
+ */
+const NO_STORY_OF_ITS_OWN = {
+    button: 'Buttons/Button Styles IS the button story — its `component` is `Gtk.Button.$gtype`, and it renders the plain button beside .pill/.circular/.suggested-action/.destructive-action/.flat. A second story would show the same widget with fewer states.',
+    'toast-overlay':
+        'Feedback/Toast renders it. The overlay is only ever the surface a toast appears on, so the story is named after the thing the reader is looking for.',
+    'view-stack':
+        'A stack shows exactly one page and offers no way to change it — alone it is a blank preview. Every switcher story builds one and drives it: View Switcher, Inline View Switcher, View Switcher Bar.',
+    icon: 'There is no Adwaita or GTK icon WIDGET to reference. GTK draws a `Gtk.Image` inline (the navigation stories do), and the browser element exists because CSS needs a box to hang a symbolic on. A story would demonstrate a GTK primitive, not an Adwaita widget.',
+    'data-grid':
+        'The one widget here with no GTK renderer at all — it is an original @gjsify widget, not a libadwaita port. A GTK story would have to hand-assemble a `Gtk.Grid`, i.e. put a fourth implementation in a showcase where no package owns it. If a GTK data grid is wanted it starts as a package (#1050).',
+};
+
+/** `adw-<name>.ts` files directly under `dir`. */
+function widgetNames(dir) {
+    const found = new Set();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isFile()) continue;
+        const match = entry.name.match(/^adw-(.+)\.ts$/);
+        if (match && !entry.name.endsWith('.spec.ts')) found.add(match[1]);
+    }
+    return found;
+}
+
+/** Story names — every `<name>.meta.ts` anywhere under the GTK showcase. */
+function storyNames(dir) {
+    const found = new Set();
+    const walk = (current) => {
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            const path = join(current, entry.name);
+            if (entry.isDirectory()) walk(path);
+            else if (entry.name.endsWith('.meta.ts')) found.add(entry.name.slice(0, -'.meta.ts'.length));
+        }
+    };
+    walk(dir);
+    return found;
+}
+
+const web = widgetNames(WEB_ELEMENTS);
+const ns = widgetNames(NS_WIDGETS);
+const stories = storyNames(GTK_SRC);
+
+if (web.size === 0 || ns.size === 0 || stories.size === 0) {
+    console.error(
+        'check-storybook-widget-coverage: one of the three scans came back empty ' +
+            `(web ${web.size}, nativescript ${ns.size}, stories ${stories.size}) — that is a broken scan, not a clean tree.`,
+    );
+    process.exit(1);
+}
+
+const onBothRenderers = [...web].filter((name) => ns.has(name)).sort();
+const failures = [];
+
+for (const name of onBothRenderers) {
+    if (stories.has(name)) continue;
+    if (name in NO_STORY_OF_ITS_OWN) continue;
+    failures.push(
+        `adw-${name}: shipped by both renderers, rendered by no story. Add ${name}.meta.ts + its three\n` +
+            '    renderings, or add it to NO_STORY_OF_ITS_OWN in this script with the reason.',
+    );
+}
+
+for (const name of Object.keys(NO_STORY_OF_ITS_OWN)) {
+    if (stories.has(name)) {
+        failures.push(`adw-${name}: exempted here, but ${name}.meta.ts exists — drop the stale exemption.`);
+    } else if (!web.has(name) || !ns.has(name)) {
+        const where = web.has(name) ? 'the browser only' : ns.has(name) ? 'NativeScript only' : 'neither renderer';
+        failures.push(
+            `adw-${name}: exempted here, but it is on ${where} — outside this check's scope, so the entry covers nothing.`,
+        );
+    }
+}
+
+if (failures.length > 0) {
+    console.error(`check-storybook-widget-coverage: ${failures.length} problem(s):\n`);
+    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(
+        '\nThe GTK storybook is the reference the other two targets are aligned against, so a widget it\n' +
+            'never shows is a widget with no reference — and story-set parity cannot see that, because a\n' +
+            'story missing from all three targets is perfectly symmetric.\n' +
+            `  elements: ${relative(ROOT, WEB_ELEMENTS)}    widgets: ${relative(ROOT, NS_WIDGETS)}    stories: ${relative(ROOT, GTK_SRC)}`,
+    );
+    process.exit(1);
+}
+
+const exempt = Object.keys(NO_STORY_OF_ITS_OWN).length;
+console.log(
+    `check-storybook-widget-coverage: ${onBothRenderers.length} widgets on both renderers — ` +
+        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason.`,
+);

--- a/showcases/dom/adwaita-storybook-nativescript/src/buttons/menu-button.ns.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/buttons/menu-button.ns.ts
@@ -1,0 +1,48 @@
+// NativeScript port of the Menu Button story. Shares metadata with the GTK
+// menu-button.story.ts and browser menu-button.web.ts (imported from the GTK
+// showcase's renderer-agnostic *.meta.ts barrel).
+
+import { StoryView, type StoryArgs, type StoryMeta, type NsStoryModule } from '@gjsify/storybook-nativescript';
+import { AdwMenuButton } from '@gjsify/adwaita-nativescript';
+import { documentOpenSymbolic, openMenuSymbolic, viewMoreSymbolic } from '@gjsify/adwaita-icons/actions';
+import { MENU_BUTTON_ITEMS, menuButtonMeta } from '@gjsify/example-gtk-adwaita-storybook/metas';
+
+// The GTK icon NAME the meta carries, resolved to the SVG string this renderer
+// draws — NativeScript has no icon theme to look a name up in.
+const ICONS: Record<string, string> = {
+    'open-menu-symbolic': openMenuSymbolic,
+    'view-more-symbolic': viewMoreSymbolic,
+    'document-open-symbolic': documentOpenSymbolic,
+};
+
+export class MenuButtonNsStory extends StoryView {
+    private _widget: AdwMenuButton | null = null;
+
+    constructor() {
+        super(MenuButtonNsStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return menuButtonMeta;
+    }
+
+    initialize(): void {
+        this._widget = new AdwMenuButton();
+        this._widget.menuItems = MENU_BUTTON_ITEMS.map((label) => ({ label }));
+        this._apply();
+        this.addContent(this._widget);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._widget) return;
+        const name = this.args.iconName as string;
+        this._widget.icon = ICONS[name] ?? openMenuSymbolic;
+        this._widget.menuTitle = this.args.menuTitle as string;
+    }
+}
+
+export const MenuButtonNsStories: NsStoryModule = { stories: [MenuButtonNsStory] };

--- a/showcases/dom/adwaita-storybook-nativescript/src/controls/drop-down.ns.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/controls/drop-down.ns.ts
@@ -1,0 +1,41 @@
+// NativeScript port of the Drop Down story. Shares metadata with the GTK
+// drop-down.story.ts and browser drop-down.web.ts (imported from the GTK showcase's
+// renderer-agnostic *.meta.ts barrel).
+
+import { StoryView, type StoryArgs, type StoryMeta, type NsStoryModule } from '@gjsify/storybook-nativescript';
+import { AdwDropDown } from '@gjsify/adwaita-nativescript';
+import { DROP_DOWN_OPTIONS, dropDownMeta } from '@gjsify/example-gtk-adwaita-storybook/metas';
+
+export class DropDownNsStory extends StoryView {
+    private _dropDown: AdwDropDown | null = null;
+
+    constructor() {
+        super(DropDownNsStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return dropDownMeta;
+    }
+
+    initialize(): void {
+        this._dropDown = new AdwDropDown();
+        this._dropDown.options = DROP_DOWN_OPTIONS.map((label) => ({ value: label, label }));
+        this._apply();
+        this.addContent(this._dropDown);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._dropDown) return;
+        this._dropDown.selected = this.args.selected as number;
+        // The list opens as the platform `action()` sheet, which has no search field —
+        // so `enableSearch` has no NativeScript equivalent (see the widget's own
+        // fidelity note). Read it so the control stays bound to this rendering too.
+        void (this.args.enableSearch as boolean);
+    }
+}
+
+export const DropDownNsStories: NsStoryModule = { stories: [DropDownNsStory] };

--- a/showcases/dom/adwaita-storybook-nativescript/src/controls/entry.ns.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/controls/entry.ns.ts
@@ -1,0 +1,38 @@
+// NativeScript port of the Entry story. Shares metadata with the GTK
+// entry.story.ts and browser entry.web.ts (imported from the GTK showcase's
+// renderer-agnostic *.meta.ts barrel).
+
+import { StoryView, type StoryArgs, type StoryMeta, type NsStoryModule } from '@gjsify/storybook-nativescript';
+import { AdwEntry } from '@gjsify/adwaita-nativescript';
+import { entryMeta } from '@gjsify/example-gtk-adwaita-storybook/metas';
+
+export class EntryNsStory extends StoryView {
+    private _entry: AdwEntry | null = null;
+
+    constructor() {
+        super(EntryNsStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return entryMeta;
+    }
+
+    initialize(): void {
+        this._entry = new AdwEntry();
+        this._apply();
+        this.addContent(this._entry);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._entry) return;
+        this._entry.text = this.args.text as string;
+        this._entry.placeholder = this.args.placeholder as string;
+        this._entry.editable = this.args.editable as boolean;
+    }
+}
+
+export const EntryNsStories: NsStoryModule = { stories: [EntryNsStory] };

--- a/showcases/dom/adwaita-storybook-nativescript/src/stories.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/stories.ts
@@ -14,8 +14,12 @@ import type { NsStoryModule } from '@gjsify/storybook-nativescript';
 // Buttons
 import { ButtonContentNsStories } from './buttons/button-content.ns.js';
 import { ButtonStylesNsStories } from './buttons/button-styles.ns.js';
+import { MenuButtonNsStories } from './buttons/menu-button.ns.js';
 import { SplitButtonNsStories } from './buttons/split-button.ns.js';
 import { ToggleGroupNsStories } from './buttons/toggle-group.ns.js';
+// Controls
+import { DropDownNsStories } from './controls/drop-down.ns.js';
+import { EntryNsStories } from './controls/entry.ns.js';
 // Feedback
 import { AboutDialogNsStories } from './feedback/about-dialog.ns.js';
 import { AlertDialogNsStories } from './feedback/alert-dialog.ns.js';
@@ -56,13 +60,18 @@ import { CarouselNsStories } from './view-switching/carousel.ns.js';
 import { InlineViewSwitcherNsStories } from './view-switching/inline-view-switcher.ns.js';
 import { TabViewNsStories } from './view-switching/tab-view.ns.js';
 import { ViewSwitcherNsStories } from './view-switching/view-switcher.ns.js';
+import { ViewSwitcherBarNsStories } from './view-switching/view-switcher-bar.ns.js';
 
 export const stories: NsStoryModule[] = [
     // Buttons
     ButtonContentNsStories,
     ButtonStylesNsStories,
+    MenuButtonNsStories,
     SplitButtonNsStories,
     ToggleGroupNsStories,
+    // Controls
+    EntryNsStories,
+    DropDownNsStories,
     // Feedback
     AboutDialogNsStories,
     AlertDialogNsStories,
@@ -103,4 +112,5 @@ export const stories: NsStoryModule[] = [
     InlineViewSwitcherNsStories,
     TabViewNsStories,
     ViewSwitcherNsStories,
+    ViewSwitcherBarNsStories,
 ];

--- a/showcases/dom/adwaita-storybook-nativescript/src/view-switching/view-switcher-bar.ns.ts
+++ b/showcases/dom/adwaita-storybook-nativescript/src/view-switching/view-switcher-bar.ns.ts
@@ -1,0 +1,67 @@
+// NativeScript port of the View Switcher Bar story. Shares metadata with the GTK
+// view-switcher-bar.story.ts and browser view-switcher-bar.web.ts (imported from
+// the GTK showcase's renderer-agnostic *.meta.ts barrel).
+
+import { StoryView, type StoryArgs, type StoryMeta, type NsStoryModule } from '@gjsify/storybook-nativescript';
+import { AdwStatusPage, AdwToolbarView, AdwViewStack, AdwViewSwitcherBar } from '@gjsify/adwaita-nativescript';
+import { folderSymbolic } from '@gjsify/adwaita-icons/places';
+import { mailUnreadSymbolic, starredSymbolic } from '@gjsify/adwaita-icons/status';
+import { VIEW_SWITCHER_BAR_PAGES, viewSwitcherBarMeta } from '@gjsify/example-gtk-adwaita-storybook/metas';
+
+// The GTK icon NAME the meta carries, resolved to the SVG string this renderer draws.
+const ICONS: Record<string, string> = {
+    'mail-unread-symbolic': mailUnreadSymbolic,
+    'starred-symbolic': starredSymbolic,
+    'folder-symbolic': folderSymbolic,
+};
+
+export class ViewSwitcherBarNsStory extends StoryView {
+    private _bar: AdwViewSwitcherBar | null = null;
+
+    constructor() {
+        super(ViewSwitcherBarNsStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return viewSwitcherBarMeta;
+    }
+
+    initialize(): void {
+        const stack = new AdwViewStack();
+        for (const page of VIEW_SWITCHER_BAR_PAGES) {
+            const status = new AdwStatusPage();
+            status.icon = ICONS[page.icon] ?? '';
+            status.title = page.title;
+            status.description = `The ${page.title.toLowerCase()} page.`;
+            stack.add(status, page.name, page.title, ICONS[page.icon]);
+        }
+
+        const bar = new AdwViewSwitcherBar();
+        bar.stack = stack;
+        // The NativeScript stack has no `items-changed`, so a bar bound before the
+        // pages exist would render no buttons. `refresh()` is that missing signal,
+        // spelled by hand — the widget's own header says so.
+        bar.refresh();
+        this._bar = bar;
+        this._apply();
+
+        // A toolbar view, so the bar sits at the bottom edge the way libadwaita
+        // places it — and because `addContent` REPLACES the stage, so the stack and
+        // the bar have to arrive as one view.
+        const view = new AdwToolbarView();
+        view.setContent(stack);
+        view.addBottomBar(bar);
+        this.addContent(view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._bar) return;
+        this._bar.reveal = this.args.reveal as boolean;
+    }
+}
+
+export const ViewSwitcherBarNsStories: NsStoryModule = { stories: [ViewSwitcherBarNsStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/buttons/menu-button.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/buttons/menu-button.web.ts
@@ -1,0 +1,37 @@
+// Browser port of the Menu Button story. Shares metadata with menu-button.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { MENU_BUTTON_ITEMS, menuButtonMeta } from '../../buttons/menu-button.meta.js';
+
+export class MenuButtonWebStory extends StoryElement {
+    private _widget: HTMLElement | null = null;
+
+    constructor() {
+        super(MenuButtonWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return menuButtonMeta;
+    }
+
+    initialize(): void {
+        this._widget = document.createElement('adw-menu-button');
+        this._widget.setAttribute('menu', JSON.stringify(MENU_BUTTON_ITEMS.map((label) => ({ label }))));
+        this._apply();
+        this.addContent(this._widget);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._widget) return;
+        // The element takes symbolic names WITHOUT the `-symbolic` suffix — its icon
+        // set is Adwaita's symbolic one, so the suffix would be part of every name.
+        this._widget.setAttribute('icon-name', (this.args.iconName as string).replace(/-symbolic$/, ''));
+        this._widget.setAttribute('menu-title', this.args.menuTitle as string);
+    }
+}
+
+export const MenuButtonWebStories: WebStoryModule = { stories: [MenuButtonWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/controls/drop-down.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/controls/drop-down.web.ts
@@ -1,0 +1,36 @@
+// Browser port of the Drop Down story. Shares metadata with drop-down.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { DROP_DOWN_OPTIONS, dropDownMeta } from '../../controls/drop-down.meta.js';
+
+export class DropDownWebStory extends StoryElement {
+    private _dropDown: HTMLElement | null = null;
+
+    constructor() {
+        super(DropDownWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return dropDownMeta;
+    }
+
+    initialize(): void {
+        this._dropDown = document.createElement('adw-drop-down');
+        this._dropDown.setAttribute('options', JSON.stringify(DROP_DOWN_OPTIONS));
+        this._apply();
+        this.addContent(this._dropDown);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._dropDown) return;
+        this._dropDown.setAttribute('selected', String(this.args.selected as number));
+        if (this.args.enableSearch as boolean) this._dropDown.setAttribute('enable-search', '');
+        else this._dropDown.removeAttribute('enable-search');
+    }
+}
+
+export const DropDownWebStories: WebStoryModule = { stories: [DropDownWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/controls/entry.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/controls/entry.web.ts
@@ -1,0 +1,40 @@
+// Browser port of the Entry story. Shares metadata with entry.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+import { entryMeta } from '../../controls/entry.meta.js';
+
+export class EntryWebStory extends StoryElement {
+    private _entry: HTMLElement | null = null;
+
+    constructor() {
+        super(EntryWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return entryMeta;
+    }
+
+    initialize(): void {
+        this._entry = document.createElement('adw-entry');
+        this._entry.style.minWidth = '280px';
+        this._apply();
+        this.addContent(this._entry);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._entry) return;
+        this._entry.setAttribute('value', this.args.text as string);
+        this._entry.setAttribute('placeholder', this.args.placeholder as string);
+        // `<adw-entry>` has no `editable`: the browser spelling of a field you may
+        // read but not change is `disabled`, which also greys it — the one place
+        // this rendering cannot match GtkEditable:editable exactly.
+        if (this.args.editable as boolean) this._entry.removeAttribute('disabled');
+        else this._entry.setAttribute('disabled', '');
+    }
+}
+
+export const EntryWebStories: WebStoryModule = { stories: [EntryWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/browser/stories.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/stories.ts
@@ -32,8 +32,11 @@ import { PasswordEntryRowWebStories } from './rows/password-entry-row.web.js';
 import { PreferencesGroupWebStories } from './rows/preferences-group.web.js';
 import { SpinRowWebStories } from './rows/spin-row.web.js';
 import { SwitchRowWebStories } from './rows/switch-row.web.js';
+import { DropDownWebStories } from './controls/drop-down.web.js';
+import { EntryWebStories } from './controls/entry.web.js';
 import { ButtonContentWebStories } from './buttons/button-content.web.js';
 import { ButtonStylesWebStories } from './buttons/button-styles.web.js';
+import { MenuButtonWebStories } from './buttons/menu-button.web.js';
 import { SplitButtonWebStories } from './buttons/split-button.web.js';
 import { ToggleGroupWebStories } from './buttons/toggle-group.web.js';
 import { ClampWebStories } from './layout/clamp.web.js';
@@ -44,6 +47,7 @@ import { CarouselWebStories } from './view-switching/carousel.web.js';
 import { InlineViewSwitcherWebStories } from './view-switching/inline-view-switcher.web.js';
 import { TabViewWebStories } from './view-switching/tab-view.web.js';
 import { ViewSwitcherWebStories } from './view-switching/view-switcher.web.js';
+import { ViewSwitcherBarWebStories } from './view-switching/view-switcher-bar.web.js';
 import { BottomSheetWebStories } from './navigation/bottom-sheet.web.js';
 import { NavigationSplitViewWebStories } from './navigation/navigation-split-view.web.js';
 import { NavigationViewWebStories } from './navigation/navigation-view.web.js';
@@ -71,8 +75,11 @@ export const stories: WebStoryModule[] = [
     PreferencesGroupWebStories,
     SpinRowWebStories,
     SwitchRowWebStories,
+    EntryWebStories,
+    DropDownWebStories,
     ButtonContentWebStories,
     ButtonStylesWebStories,
+    MenuButtonWebStories,
     SplitButtonWebStories,
     ToggleGroupWebStories,
     ClampWebStories,
@@ -83,6 +90,7 @@ export const stories: WebStoryModule[] = [
     InlineViewSwitcherWebStories,
     TabViewWebStories,
     ViewSwitcherWebStories,
+    ViewSwitcherBarWebStories,
     BottomSheetWebStories,
     NavigationSplitViewWebStories,
     NavigationViewWebStories,

--- a/showcases/gtk/adwaita-storybook/src/browser/view-switching/view-switcher-bar.web.ts
+++ b/showcases/gtk/adwaita-storybook/src/browser/view-switching/view-switcher-bar.web.ts
@@ -1,0 +1,67 @@
+// Browser port of the View Switcher Bar story. Shares metadata with
+// view-switcher-bar.story.ts.
+
+import { StoryElement, type StoryArgs, type StoryMeta, type WebStoryModule } from '@gjsify/adwaita-storybook';
+// TYPE-ONLY: the bar is driven through `setStack()`/`reveal`, not attributes, and a
+// hand-written structural interface here would be a second copy of that API that
+// nothing keeps in step. The import erases, so the bundle keeps no edge to the package.
+import type { AdwViewStack, AdwViewSwitcherBar } from '@gjsify/adwaita-web';
+import { VIEW_SWITCHER_BAR_PAGES, viewSwitcherBarMeta } from '../../view-switching/view-switcher-bar.meta.js';
+
+export class ViewSwitcherBarWebStory extends StoryElement {
+    private _bar: AdwViewSwitcherBar | null = null;
+
+    constructor() {
+        super(ViewSwitcherBarWebStory.getMetadata(), 'Default');
+    }
+
+    static getMetadata(): StoryMeta {
+        return viewSwitcherBarMeta;
+    }
+
+    initialize(): void {
+        const stack = document.createElement('adw-view-stack') as AdwViewStack;
+        stack.style.flex = '1';
+        for (const page of VIEW_SWITCHER_BAR_PAGES) {
+            const status = document.createElement('adw-status-page');
+            status.setAttribute('icon', page.icon.replace(/-symbolic$/, ''));
+            status.setAttribute('title', page.title);
+            status.setAttribute('description', `The ${page.title.toLowerCase()} page.`);
+            const child = document.createElement('adw-view-stack-page');
+            child.setAttribute('name', page.name);
+            child.setAttribute('title', page.title);
+            child.setAttribute('icon-name', page.icon.replace(/-symbolic$/, ''));
+            child.appendChild(status);
+            stack.appendChild(child);
+        }
+
+        const bar = document.createElement('adw-view-switcher-bar') as AdwViewSwitcherBar;
+        bar.setAttribute('slot', 'bottom');
+
+        // A toolbar view, so the bar sits where libadwaita puts it — at the bottom
+        // edge — rather than floating in the middle of the preview.
+        const view = document.createElement('adw-toolbar-view');
+        view.style.width = '360px';
+        view.style.height = '360px';
+        view.append(stack, bar);
+        this.addContent(view);
+
+        // Bound AFTER the stack is in the document: the bar derives its buttons from
+        // the stack's pages, and those only exist once the `<adw-view-stack-page>`
+        // children have upgraded.
+        bar.setStack(stack);
+        this._bar = bar;
+        this._apply();
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._bar) return;
+        this._bar.reveal = this.args.reveal as boolean;
+    }
+}
+
+export const ViewSwitcherBarWebStories: WebStoryModule = { stories: [ViewSwitcherBarWebStory] };

--- a/showcases/gtk/adwaita-storybook/src/buttons/menu-button.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/buttons/menu-button.meta.ts
@@ -1,0 +1,29 @@
+// Shared, renderer-agnostic metadata for the Menu Button story. Imported by the GTK
+// renderer (menu-button.story.ts), the browser renderer
+// (browser/buttons/menu-button.web.ts) and the NativeScript one.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+/** The menu all three renderings build, so the popover holds the same items everywhere. */
+export const MENU_BUTTON_ITEMS = ['Save as…', 'Export', 'Print'] as const;
+
+export const menuButtonMeta: StoryMeta = {
+    title: 'Buttons/Menu Button',
+    description:
+        'Gtk.MenuButton — a button whose only action is to open a menu. Where a Split Button has a primary ' +
+        'action beside its arrow, this one has none: every choice lives in the popover.',
+    controls: [
+        {
+            name: 'iconName',
+            label: 'Icon',
+            type: ControlType.SELECT,
+            options: [
+                { label: 'Hamburger', value: 'open-menu-symbolic' },
+                { label: 'More', value: 'view-more-symbolic' },
+                { label: 'Open', value: 'document-open-symbolic' },
+            ],
+            defaultValue: 'open-menu-symbolic',
+        },
+        { name: 'menuTitle', label: 'Menu title', type: ControlType.TEXT, defaultValue: 'Document' },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/buttons/menu-button.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/buttons/menu-button.story.ts
@@ -1,0 +1,60 @@
+// Gtk.MenuButton — a button whose only job is to open a menu.
+// original implementation.
+
+import Gio from '@girs/gio-2.0';
+import Gtk from '@girs/gtk-4.0';
+import GObject from '@girs/gobject-2.0';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { MENU_BUTTON_ITEMS, menuButtonMeta } from './menu-button.meta.js';
+
+/** Story: a Gtk.MenuButton over a Gio.Menu whose section carries the title. */
+export class MenuButtonStory extends StoryWidget {
+    private _widget: Gtk.MenuButton | null = null;
+
+    static {
+        GObject.registerClass({ GTypeName: 'AdwStorybookMenuButton' }, MenuButtonStory);
+    }
+
+    constructor() {
+        super(StoryWidget.fromMeta(MenuButtonStory.getMetadata(), 'Default'));
+    }
+
+    static getMetadata(): StoryMeta {
+        return { ...menuButtonMeta, component: Gtk.MenuButton.$gtype };
+    }
+
+    initialize(): void {
+        this._widget = new Gtk.MenuButton({ halign: Gtk.Align.CENTER });
+        this._apply();
+        this.addContent(this._widget);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    /**
+     * A Gio.Menu is immutable to the popover once shown, so the model is rebuilt
+     * rather than mutated — the title lives on the SECTION, which is how GTK
+     * spells a labelled group of items.
+     */
+    private _buildMenu(title: string): Gio.Menu {
+        const items = new Gio.Menu();
+        for (const label of MENU_BUTTON_ITEMS) {
+            items.append(label, `app.${label.toLowerCase().replace(/[^a-z]+/g, '-')}`);
+        }
+        const menu = new Gio.Menu();
+        menu.append_section(title.length > 0 ? title : null, items);
+        return menu;
+    }
+
+    private _apply(): void {
+        if (!this._widget) return;
+        this._widget.iconName = this.args.iconName as string;
+        this._widget.menuModel = this._buildMenu(this.args.menuTitle as string);
+    }
+}
+
+GObject.type_ensure(MenuButtonStory.$gtype);
+
+export const MenuButtonStories: StoryModule = { stories: [MenuButtonStory] };

--- a/showcases/gtk/adwaita-storybook/src/controls/drop-down.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/controls/drop-down.meta.ts
@@ -1,0 +1,25 @@
+// Shared, renderer-agnostic metadata for the Drop Down story. Imported by the GTK
+// renderer (drop-down.story.ts), the browser renderer
+// (browser/controls/drop-down.web.ts) and the NativeScript one.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+/** The one option list all three renderings drive, so a pick means the same thing everywhere. */
+export const DROP_DOWN_OPTIONS = ['Automatic', 'Always', 'Never', 'When busy'] as const;
+
+export const dropDownMeta: StoryMeta = {
+    title: 'Controls/Drop Down',
+    description:
+        'Gtk.DropDown — pick one value from a list. The button shows the selection; the list opens in a ' +
+        'popover. Adw.ComboRow is the same choice presented as a boxed-list row.',
+    controls: [
+        {
+            name: 'selected',
+            label: 'Selected',
+            type: ControlType.SELECT,
+            options: DROP_DOWN_OPTIONS.map((label, index) => ({ label, value: index })),
+            defaultValue: 0,
+        },
+        { name: 'enableSearch', label: 'Search field', type: ControlType.BOOLEAN, defaultValue: false },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/controls/drop-down.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/controls/drop-down.story.ts
@@ -1,0 +1,49 @@
+// Gtk.DropDown — pick one value from a list, shown in a popover.
+// original implementation.
+
+import Gtk from '@girs/gtk-4.0';
+import GObject from '@girs/gobject-2.0';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { DROP_DOWN_OPTIONS, dropDownMeta } from './drop-down.meta.js';
+
+/** Story: a Gtk.DropDown over a Gtk.StringList, with the search field toggled by an arg. */
+export class DropDownStory extends StoryWidget {
+    private _dropDown: Gtk.DropDown | null = null;
+
+    static {
+        GObject.registerClass({ GTypeName: 'AdwStorybookDropDown' }, DropDownStory);
+    }
+
+    constructor() {
+        super(StoryWidget.fromMeta(DropDownStory.getMetadata(), 'Default'));
+    }
+
+    static getMetadata(): StoryMeta {
+        return { ...dropDownMeta, component: Gtk.DropDown.$gtype };
+    }
+
+    initialize(): void {
+        this._dropDown = Gtk.DropDown.new_from_strings([...DROP_DOWN_OPTIONS]);
+        // Search needs to know WHICH string to match: a GtkDropDown over a
+        // GtkStringList holds GtkStringObjects, and without an expression the
+        // search field appears and matches nothing.
+        this._dropDown.expression = Gtk.PropertyExpression.new(Gtk.StringObject.$gtype, null, 'string');
+        this._dropDown.halign = Gtk.Align.CENTER;
+        this._apply();
+        this.addContent(this._dropDown);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._dropDown) return;
+        this._dropDown.selected = this.args.selected as number;
+        this._dropDown.enableSearch = this.args.enableSearch as boolean;
+    }
+}
+
+GObject.type_ensure(DropDownStory.$gtype);
+
+export const DropDownStories: StoryModule = { stories: [DropDownStory] };

--- a/showcases/gtk/adwaita-storybook/src/controls/entry.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/controls/entry.meta.ts
@@ -1,0 +1,18 @@
+// Shared, renderer-agnostic metadata for the Entry story. Imported by the GTK
+// renderer (entry.story.ts), the browser renderer (browser/controls/entry.web.ts)
+// and the NativeScript one, so all three expose identical controls.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+export const entryMeta: StoryMeta = {
+    title: 'Controls/Entry',
+    description:
+        'Gtk.Entry — a single-line text field. Libadwaita ships no AdwEntry; the Adwaita look is the ' +
+        'GTK entry styled by the stylesheet, which is why the row variants (Entry Row, Password Entry Row) ' +
+        'are the widgets with an Adw prefix.',
+    controls: [
+        { name: 'text', label: 'Text', type: ControlType.TEXT, defaultValue: '' },
+        { name: 'placeholder', label: 'Placeholder', type: ControlType.TEXT, defaultValue: 'Search files…' },
+        { name: 'editable', label: 'Editable', type: ControlType.BOOLEAN, defaultValue: true },
+    ],
+};

--- a/showcases/gtk/adwaita-storybook/src/controls/entry.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/controls/entry.story.ts
@@ -1,0 +1,47 @@
+// Gtk.Entry — the single-line text field the Adwaita stylesheet dresses.
+// original implementation.
+
+import Gtk from '@girs/gtk-4.0';
+import GObject from '@girs/gobject-2.0';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { entryMeta } from './entry.meta.js';
+
+/** Story: a Gtk.Entry with placeholder text and an editable toggle. */
+export class EntryStory extends StoryWidget {
+    private _entry: Gtk.Entry | null = null;
+
+    static {
+        GObject.registerClass({ GTypeName: 'AdwStorybookEntry' }, EntryStory);
+    }
+
+    constructor() {
+        super(StoryWidget.fromMeta(EntryStory.getMetadata(), 'Default'));
+    }
+
+    static getMetadata(): StoryMeta {
+        return { ...entryMeta, component: Gtk.Entry.$gtype };
+    }
+
+    initialize(): void {
+        this._entry = new Gtk.Entry({ widthRequest: 280, halign: Gtk.Align.CENTER });
+        this._apply();
+        this.addContent(this._entry);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._entry) return;
+        this._entry.text = this.args.text as string;
+        this._entry.placeholderText = this.args.placeholder as string;
+        // `editable` false keeps the entry focusable and selectable, which is what
+        // GtkEditable:editable means — NOT `sensitive`, which would grey it out.
+        this._entry.editable = this.args.editable as boolean;
+    }
+}
+
+GObject.type_ensure(EntryStory.$gtype);
+
+export const EntryStories: StoryModule = { stories: [EntryStory] };

--- a/showcases/gtk/adwaita-storybook/src/metas.ts
+++ b/showcases/gtk/adwaita-storybook/src/metas.ts
@@ -6,8 +6,11 @@
 
 export * from './buttons/button-content.meta.js';
 export * from './buttons/button-styles.meta.js';
+export * from './buttons/menu-button.meta.js';
 export * from './buttons/split-button.meta.js';
 export * from './buttons/toggle-group.meta.js';
+export * from './controls/drop-down.meta.js';
+export * from './controls/entry.meta.js';
 export * from './feedback/about-dialog.meta.js';
 export * from './feedback/alert-dialog.meta.js';
 export * from './feedback/preferences-dialog.meta.js';
@@ -40,4 +43,5 @@ export * from './rows/switch-row.meta.js';
 export * from './view-switching/carousel.meta.js';
 export * from './view-switching/inline-view-switcher.meta.js';
 export * from './view-switching/tab-view.meta.js';
+export * from './view-switching/view-switcher-bar.meta.js';
 export * from './view-switching/view-switcher.meta.js';

--- a/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher-bar.meta.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher-bar.meta.ts
@@ -1,0 +1,20 @@
+// Shared, renderer-agnostic metadata for the View Switcher Bar story. Imported by the
+// GTK renderer (view-switcher-bar.story.ts), the browser renderer
+// (browser/view-switching/view-switcher-bar.web.ts) and the NativeScript one.
+
+import { ControlType, type StoryMeta } from '@gjsify/stories';
+
+/** The three pages every rendering puts in its stack, so the bar has the same buttons. */
+export const VIEW_SWITCHER_BAR_PAGES: ReadonlyArray<{ name: string; title: string; icon: string }> = [
+    { name: 'inbox', title: 'Inbox', icon: 'mail-unread-symbolic' },
+    { name: 'starred', title: 'Starred', icon: 'starred-symbolic' },
+    { name: 'archive', title: 'Archive', icon: 'folder-symbolic' },
+];
+
+export const viewSwitcherBarMeta: StoryMeta = {
+    title: 'View Switching/View Switcher Bar',
+    description:
+        'Adw.ViewSwitcherBar — the narrow-window switcher, pinned to the bottom of a toolbar view. `reveal` ' +
+        'is a REQUEST, not a state: a stack with fewer than two pages stays collapsed however loudly it is asked.',
+    controls: [{ name: 'reveal', label: 'Reveal', type: ControlType.BOOLEAN, defaultValue: true }],
+};

--- a/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher-bar.story.ts
+++ b/showcases/gtk/adwaita-storybook/src/view-switching/view-switcher-bar.story.ts
@@ -1,0 +1,61 @@
+// Adw.ViewSwitcherBar — the narrow-window switcher, pinned to the bottom.
+// original implementation.
+
+import Adw from '@girs/adw-1';
+import GObject from '@girs/gobject-2.0';
+import { type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@gjsify/storybook';
+import { VIEW_SWITCHER_BAR_PAGES, viewSwitcherBarMeta } from './view-switcher-bar.meta.js';
+
+/** Story: an Adw.ViewSwitcherBar at the bottom of a toolbar view, driving its stack. */
+export class ViewSwitcherBarStory extends StoryWidget {
+    private _bar: Adw.ViewSwitcherBar | null = null;
+
+    static {
+        GObject.registerClass({ GTypeName: 'AdwStorybookViewSwitcherBar' }, ViewSwitcherBarStory);
+    }
+
+    constructor() {
+        super(StoryWidget.fromMeta(ViewSwitcherBarStory.getMetadata(), 'Default'));
+    }
+
+    static getMetadata(): StoryMeta {
+        return { ...viewSwitcherBarMeta, component: Adw.ViewSwitcherBar.$gtype };
+    }
+
+    initialize(): void {
+        const stack = new Adw.ViewStack({ vexpand: true });
+        for (const page of VIEW_SWITCHER_BAR_PAGES) {
+            const status = new Adw.StatusPage({
+                iconName: page.icon,
+                title: page.title,
+                description: `The ${page.title.toLowerCase()} page.`,
+                vexpand: true,
+            });
+            stack.add_titled_with_icon(status, page.name, page.title, page.icon);
+        }
+
+        this._bar = new Adw.ViewSwitcherBar({ stack });
+        this._apply();
+
+        // The bar belongs at an edge — a toolbar view is where libadwaita puts it,
+        // and it is what makes the story show the bar's real position rather than a
+        // widget floating in the middle of the preview.
+        const view = new Adw.ToolbarView({ content: stack, widthRequest: 360, heightRequest: 360 });
+        view.add_bottom_bar(this._bar);
+
+        this.addContent(view);
+    }
+
+    updateArgs(_args: StoryArgs): void {
+        this._apply();
+    }
+
+    private _apply(): void {
+        if (!this._bar) return;
+        this._bar.reveal = this.args.reveal as boolean;
+    }
+}
+
+GObject.type_ensure(ViewSwitcherBarStory.$gtype);
+
+export const ViewSwitcherBarStories: StoryModule = { stories: [ViewSwitcherBarStory] };


### PR DESCRIPTION
## The finding

The GTK storybook is the reference the browser and NativeScript targets are aligned against. Measured on the tree: of the **43 widgets implemented on both renderers, nine had no story anywhere** — including `adw-entry`, `adw-drop-down`, `adw-menu-button` and `adw-view-switcher-bar`.

## Why no gate saw it

`check-storybook-story-parity.mjs` asks whether the three targets render the *same* stories. A story that exists **nowhere** is perfectly symmetric across three targets — so parity is green and the widget is simply invisible. That is the gap this PR closes, mechanism first:

**`scripts/check-storybook-widget-coverage.mjs`** — every `adw-*` shipped by *both* renderers has a story, or a ledger entry with a reason.

A/B'd, each of its three rules failing alone:

| probe | result |
|---|---|
| widget with no story and no ledger entry | exit 1 — *"shipped by both renderers, rendered by no story"* |
| ledger entry for a widget that HAS a story | exit 1 — *"drop the stale exemption"* |
| ledger entry for a widget on one renderer only | exit 1 — *"outside this check's scope, so the entry covers nothing"* |
| clean tree | exit 0 — `43 widgets on both renderers — 38 with a story, 5 ledgered` |

## Four stories, three targets each

| story | GTK | browser | NativeScript |
|---|---|---|---|
| Controls/Entry | `Gtk.Entry` | `<adw-entry>` | `AdwEntry` |
| Controls/Drop Down | `Gtk.DropDown` + `Gtk.StringList` | `<adw-drop-down>` | `AdwDropDown` |
| Buttons/Menu Button | `Gtk.MenuButton` + `Gio.Menu` | `<adw-menu-button>` | `AdwMenuButton` |
| View Switching/View Switcher Bar | `Adw.ViewSwitcherBar` | `<adw-view-switcher-bar>` | `AdwViewSwitcherBar` |

Entry and Drop Down open a new **`Controls`** category — input widgets are neither presentation nor boxed lists, and Buttons already stretches to hold Toggle Group.

Where a target genuinely cannot honour a control, the rendering says so at the point of use instead of ignoring it silently (the precedent is `view-switcher`'s `policy`): `<adw-entry>` has no `editable` — the browser spelling is `disabled`, which also greys it — and the NativeScript drop-down opens the platform `action()` sheet, which has no search field.

## Five widgets are ledgered, not storied

- **button** — Buttons/Button Styles *is* the button story: its `component` is `Gtk.Button.$gtype` and it renders the plain button beside `.pill`/`.circular`/`.suggested-action`/`.destructive-action`/`.flat`.
- **toast-overlay** — Feedback/Toast renders it; the overlay is only ever the surface a toast appears on.
- **view-stack** — alone it shows one page and offers no way to change it. Every switcher story builds one and drives it.
- **icon** — there is no Adwaita or GTK icon *widget*. GTK draws a `Gtk.Image` inline; the browser element exists because CSS needs a box to hang a symbolic on.
- **data-grid** — the one with no GTK renderer at all: an original @gjsify widget, not a libadwaita port. A GTK story would hand-assemble a `Gtk.Grid`, i.e. a fourth implementation living in a showcase that owns none. If a GTK data grid is wanted it starts as a package (#1050).

## Verified

- `check-storybook-story-parity` — 41 metas, each on all three targets
- `check-storybook-category-order` — 9 categories declared, all 9 in use
- showcase `tsc --noEmit` green — **A/B'd with a deliberate type error** to prove the check reaches the new files (it does: `TS2322` at `src/controls/entry.story.ts`)
- browser bundle carries all four titles
- each story opened over the devtools D-Bus on a running GTK storybook and screenshotted
- `gjsify format --check` green over 2915 files (no path argument, on this branch)