### PR TITLE
fix(adwaita-web): delegate three widgets to the core

### DIFF
--- a/packages/web/adwaita-web/src/adw-entry.spec.ts
+++ b/packages/web/adwaita-web/src/adw-entry.spec.ts
@@ -1,0 +1,73 @@
+// DOM-level tests for <adw-entry>'s length arithmetic.
+//
+// The element had NO max length and no text length, while its NativeScript twin has
+// composed `@gjsify/adwaita-core`'s since it shipped — so the same consumer got a
+// limit on one renderer and none on the other. These drive the core's own vectors
+// against the real element, which is what makes the delegation checkable rather
+// than merely claimed: a re-implementation that counts UTF-16 units instead of code
+// points fails on the row that names it.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { ENTRY_MAX_LENGTH_VECTORS, ENTRY_TEXT_LENGTH_VECTORS } from '@gjsify/adwaita-core/conformance';
+
+import type { AdwEntry } from './elements/adw-entry.js';
+
+/** Mount an entry with the given attributes. */
+function mountEntry(attrs: Record<string, string> = {}): AdwEntry {
+    const entry = document.createElement('adw-entry') as AdwEntry;
+    for (const [name, value] of Object.entries(attrs)) entry.setAttribute(name, value);
+    document.body.appendChild(entry);
+    return entry;
+}
+
+function unmountAll(): void {
+    for (const entry of Array.from(document.querySelectorAll('adw-entry'))) entry.remove();
+}
+
+export const AdwEntryTest = async () => {
+    await describe('<adw-entry> text length', async () => {
+        for (const { text, length, rule } of ENTRY_TEXT_LENGTH_VECTORS) {
+            await it(`${JSON.stringify(text)} → ${length} — ${rule}`, () => {
+                const entry = mountEntry();
+                entry.value = text;
+                expect(entry.textLength).toBe(length);
+                unmountAll();
+            });
+        }
+    });
+
+    await describe('<adw-entry> max length', async () => {
+        for (const { text, maxLength, clamped, length, rule } of ENTRY_MAX_LENGTH_VECTORS) {
+            await it(`${JSON.stringify(text)} @ ${maxLength} — ${rule}`, () => {
+                const entry = mountEntry({ maxlength: String(maxLength) });
+                entry.value = text;
+                expect(entry.value).toBe(clamped);
+                expect(entry.textLength).toBe(length);
+                unmountAll();
+            });
+        }
+
+        await it('clamps what the ATTRIBUTE writes, not only the property', () => {
+            const entry = mountEntry({ maxlength: '5' });
+            entry.setAttribute('value', 'Ada Lovelace');
+            expect(entry.value).toBe('Ada L');
+            unmountAll();
+        });
+
+        await it('re-clamps when the limit is lowered under the current text', () => {
+            const entry = mountEntry();
+            entry.value = 'Ada Lovelace';
+            entry.maxLength = 3;
+            expect(entry.value).toBe('Ada');
+            unmountAll();
+        });
+
+        await it('an unusable limit means unlimited, never "truncate to empty"', () => {
+            const entry = mountEntry({ maxlength: 'nonsense' });
+            entry.value = 'Ada Lovelace';
+            expect(entry.maxLength).toBe(0);
+            expect(entry.value).toBe('Ada Lovelace');
+            unmountAll();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/adw-header-bar.spec.ts
+++ b/packages/web/adwaita-web/src/adw-header-bar.spec.ts
@@ -78,4 +78,39 @@ export const AdwHeaderBarTest = async () => {
             unmountAll();
         });
     });
+
+    // The centre is the `<adw-window-title>` Adw.HeaderBar itself derives, so the three
+    // rules that element holds through @gjsify/adwaita-core reach the header bar too.
+    // None of them did while the centre was a bare span.
+    await describe('<adw-header-bar> derives an <adw-window-title>', async () => {
+        await it('builds one rather than a bare span', () => {
+            const bar = mountHeaderBar({ title: 'Documents' });
+            expect(bar.querySelector('adw-window-title')).toBeTruthy();
+            unmountAll();
+        });
+
+        await it('renders a subtitle, which it could not before', () => {
+            const bar = mountHeaderBar({ title: 'Documents', subtitle: '12 items' });
+            expect(centerText(bar)).toContain('Documents');
+            expect(centerText(bar)).toContain('12 items');
+            unmountAll();
+        });
+
+        await it('hides the title line when the title is empty — the blank-line bug', () => {
+            // adw-window-title.c:207-208. A header bar with only a subtitle used to
+            // reserve an empty line above it, because the span was always there.
+            const bar = mountHeaderBar({ title: '', subtitle: 'Loading…' });
+            const titleEl = bar.querySelector('.adw-window-title-title') as HTMLElement | null;
+            expect(titleEl?.hidden).toBe(true);
+            unmountAll();
+        });
+
+        await it('a subtitle survives a title write', () => {
+            const bar = mountHeaderBar({ title: 'Documents', subtitle: '12 items' });
+            bar.setAttribute('title', 'Pictures');
+            expect(centerText(bar)).toContain('Pictures');
+            expect(centerText(bar)).toContain('12 items');
+            unmountAll();
+        });
+    });
 };

--- a/packages/web/adwaita-web/src/adw-menu-button.spec.ts
+++ b/packages/web/adwaita-web/src/adw-menu-button.spec.ts
@@ -1,0 +1,52 @@
+// DOM-level tests for <adw-menu-button>'s `menu` attribute.
+//
+// The element parsed the JSON itself, and the copy was weaker than the core parser
+// the split button next to it already used: it kept `id` and `icon` whatever their
+// runtime type, so author markup could put a number in a field typed `string` — and
+// `id` is exactly what the activation event reports. These drive the core's parse
+// vectors against the real element.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { SPLIT_BUTTON_MENU_PARSE_VECTORS } from '@gjsify/adwaita-core/conformance';
+
+/** Mount a menu button carrying `menu` as JSON, and return its rendered item labels. */
+function mountWithMenu(json: string): { el: HTMLElement; labels: string[] } {
+    const el = document.createElement('adw-menu-button');
+    el.setAttribute('menu', json);
+    document.body.appendChild(el);
+    const labels = Array.from(el.querySelectorAll('.adw-popover button')).map((b) => b.textContent?.trim() ?? '');
+    return { el, labels };
+}
+
+function unmountAll(): void {
+    for (const el of Array.from(document.querySelectorAll('adw-menu-button'))) el.remove();
+}
+
+export const AdwMenuButtonTest = async () => {
+    await describe('<adw-menu-button> menu attribute', async () => {
+        for (const { json, entries, rule } of SPLIT_BUTTON_MENU_PARSE_VECTORS) {
+            await it(`${rule}`, () => {
+                const { labels } = mountWithMenu(json ?? '');
+                expect(labels).toStrictEqual(entries.map((entry) => entry.label));
+                unmountAll();
+            });
+        }
+
+        await it('drops a non-string id instead of leaking a number into the event', () => {
+            const el = document.createElement('adw-menu-button');
+            el.setAttribute('menu', '[{"label":"Open","id":7}]');
+            document.body.appendChild(el);
+
+            let seen: unknown = 'not fired';
+            el.addEventListener('menu-item-activated', (e) => {
+                seen = (e as CustomEvent<{ id: string }>).detail.id;
+            });
+            (el.querySelector('.adw-popover button') as HTMLElement | null)?.click();
+
+            // `id` fell back to the label, which is the documented default — rather
+            // than arriving as the number 7 in a field every consumer reads as text.
+            expect(seen).toBe('Open');
+            unmountAll();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/elements/adw-entry.ts
+++ b/packages/web/adwaita-web/src/elements/adw-entry.ts
@@ -1,18 +1,33 @@
 // <adw-entry> — Adwaita single-line text entry (e.g. a browser URL bar).
-// Attributes: value, placeholder, type, disabled.
-// Property: value (get/set, proxies the inner input).
+// Attributes: value, placeholder, type, disabled, maxlength.
+// Properties: value (get/set, proxies the inner input), maxLength, textLength.
 // Events: native `input` bubbles from the inner input; `activate` (CustomEvent)
 //   fires on Enter — mirroring Gtk.Entry's `activate` signal.
+//
+// The character arithmetic is HEADLESS and lives in `@gjsify/adwaita-core`
+// (ADR 0004): `entryTextLength` counts CODE POINTS and `clampEntryText` truncates
+// on them. `@gjsify/adwaita-nativescript`'s AdwEntry has composed the same two
+// since it shipped; this element counted nothing at all, so the same consumer
+// got a max length on one renderer and none on the other — and the native
+// `maxlength` attribute would not have closed the gap, because the browser
+// counts UTF-16 code units: `'🔒é'` is 2 characters to GTK and to NativeScript,
+// and 3 to `input.maxLength`. That is why the clamp is applied here rather than
+// handed to the platform.
+//
 // Reference: refs/libadwaita/src/stylesheet/widgets/_entries.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
-// Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
+// Modifications: Implemented as a Web Component for @gjsify/adwaita-web; the
+// length arithmetic composed from @gjsify/adwaita-core.
+
+import { ENTRY_ROW_MAX_LENGTH_LIMIT, clampEntryText, entryTextLength } from '@gjsify/adwaita-core';
 
 export class AdwEntry extends HTMLElement {
     private _input!: HTMLInputElement;
     private _initialized = false;
+    private _maxLength = 0;
 
     static get observedAttributes() {
-        return ['value', 'placeholder', 'type', 'disabled'];
+        return ['value', 'placeholder', 'type', 'disabled', 'maxlength'];
     }
 
     get value(): string {
@@ -20,8 +35,26 @@ export class AdwEntry extends HTMLElement {
     }
 
     set value(v: string) {
-        if (this._input) this._input.value = v;
-        else this.setAttribute('value', v);
+        const clamped = clampEntryText(v ?? '', this._maxLength);
+        if (this._input) this._input.value = clamped;
+        else this.setAttribute('value', clamped);
+    }
+
+    /** `Gtk.Entry:max-length` — 0 means unlimited. Counted in CODE POINTS. */
+    get maxLength(): number {
+        return this._maxLength;
+    }
+
+    set maxLength(value: number) {
+        this._maxLength = Number.isFinite(value)
+            ? Math.min(ENTRY_ROW_MAX_LENGTH_LIMIT, Math.max(0, Math.trunc(value)))
+            : 0;
+        if (this._input) this._input.value = clampEntryText(this._input.value, this._maxLength);
+    }
+
+    /** `Gtk.Entry:text-length` — code points, not UTF-16 units. */
+    get textLength(): number {
+        return entryTextLength(this.value);
     }
 
     /** The inner native input (for focus/selection). */
@@ -33,12 +66,20 @@ export class AdwEntry extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
+        this.maxLength = Number(this.getAttribute('maxlength') ?? 0);
+
         const input = document.createElement('input');
         input.className = 'adw-entry';
         input.type = this.getAttribute('type') || 'text';
-        input.value = this.getAttribute('value') ?? '';
+        input.value = clampEntryText(this.getAttribute('value') ?? '', this._maxLength);
         input.placeholder = this.getAttribute('placeholder') ?? '';
         input.disabled = this.hasAttribute('disabled');
+        // Typing past the limit is clamped here, on the way in — the same place
+        // NativeScript clamps it, so both renderers refuse the same character.
+        input.addEventListener('input', () => {
+            const clamped = clampEntryText(input.value, this._maxLength);
+            if (clamped !== input.value) input.value = clamped;
+        });
         input.addEventListener('keydown', (e) => {
             if (e.key === 'Enter') {
                 this.dispatchEvent(new CustomEvent('activate', { bubbles: true, detail: { value: input.value } }));
@@ -50,8 +91,12 @@ export class AdwEntry extends HTMLElement {
     }
 
     attributeChangedCallback(name: string, _old: string | null, value: string | null) {
+        if (name === 'maxlength') {
+            this.maxLength = Number(value ?? 0);
+            return;
+        }
         if (!this._input) return;
-        if (name === 'value') this._input.value = value ?? '';
+        if (name === 'value') this._input.value = clampEntryText(value ?? '', this._maxLength);
         else if (name === 'placeholder') this._input.placeholder = value ?? '';
         else if (name === 'type') this._input.type = value || 'text';
         else if (name === 'disabled') this._input.disabled = value !== null;

--- a/packages/web/adwaita-web/src/elements/adw-header-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-header-bar.ts
@@ -1,7 +1,22 @@
 // <adw-header-bar> — Adwaita header bar with centered title and start/end button slots.
+//
+// The derived centre is an `<adw-window-title>`, which is what `Adw.HeaderBar`
+// itself puts there (`adw-header-bar.c`: the title widget it creates when none is
+// given IS an `AdwWindowTitle`). It used to be a bare span with
+// `textContent = title ?? ''`, and that span carried none of the three rules the
+// window title already held in `@gjsify/adwaita-core`: an EMPTY title still
+// reserved a blank line, re-setting the same value repainted, and there was no
+// subtitle at all. So a header bar could not show what its own NativeScript twin
+// could, and the fix is delegation rather than a fourth copy of the derivation.
+//
+// Reference: refs/libadwaita/src/adw-header-bar.c
 // Adapted from Adwaita Web UI Framework (https://github.com/mclellac/adwaita-web).
 // Copyright (c) 2025 csm. MIT License.
 // Modifications: Reimplemented as Web Component for @gjsify/adwaita-web.
+
+// Registers <adw-window-title>: the derived centre is one, so importing the bar
+// alone must still define it.
+import './adw-window-title.js';
 
 export class AdwHeaderBar extends HTMLElement {
     private _initialized = false;
@@ -9,14 +24,14 @@ export class AdwHeaderBar extends HTMLElement {
     private _centerEl: HTMLDivElement | null = null;
     private _endEl: HTMLDivElement | null = null;
     /**
-     * The generated title span, or `null` when a `slot="center"` title-widget
-     * took the centre. `Adw.HeaderBar` has the same either/or: setting
-     * `title-widget` replaces the derived `AdwWindowTitle` outright.
+     * The derived `<adw-window-title>`, or `null` when a `slot="center"`
+     * title-widget took the centre. `Adw.HeaderBar` has the same either/or:
+     * setting `title-widget` replaces the derived `AdwWindowTitle` outright.
      */
-    private _titleEl: HTMLSpanElement | null = null;
+    private _titleEl: HTMLElement | null = null;
 
     static get observedAttributes() {
-        return ['title'];
+        return ['title', 'subtitle'];
     }
 
     /** The start (left) section container — append buttons/widgets here. */
@@ -56,7 +71,7 @@ export class AdwHeaderBar extends HTMLElement {
         if (centerChildren.length > 0) {
             for (const child of centerChildren) this._centerEl.appendChild(child);
         } else {
-            this._titleEl = document.createElement('span');
+            this._titleEl = document.createElement('adw-window-title');
             this._titleEl.className = 'adw-header-bar-title';
             this._centerEl.appendChild(this._titleEl);
         }
@@ -77,15 +92,23 @@ export class AdwHeaderBar extends HTMLElement {
      * kept whatever it was created with. `Adw.HeaderBar`'s derived title widget
      * is bound to the property and re-renders on every change.
      */
-    attributeChangedCallback(name: string) {
-        if (this._initialized && name === 'title') this._renderTitle();
+    attributeChangedCallback() {
+        if (this._initialized) this._renderTitle();
     }
 
     private _renderTitle() {
         // A `slot="center"` widget replaced the derived title, so there is
         // nothing for the attribute to write to — the same either/or as
         // `Adw.HeaderBar:title-widget`.
-        if (this._titleEl) this._titleEl.textContent = this.getAttribute('title') ?? '';
+        if (!this._titleEl) return;
+        // Forwarded as ATTRIBUTES, so the window title's own change detection and
+        // empty-string collapse do the work. Removing rather than writing `''`
+        // keeps "unset" distinguishable from "set to empty" on the child.
+        for (const name of ['title', 'subtitle']) {
+            const value = this.getAttribute(name);
+            if (value === null) this._titleEl.removeAttribute(name);
+            else this._titleEl.setAttribute(name, value);
+        }
     }
 }
 

--- a/packages/web/adwaita-web/src/elements/adw-menu-button.ts
+++ b/packages/web/adwaita-web/src/elements/adw-menu-button.ts
@@ -20,8 +20,8 @@
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
-import { isSplitButtonDirection, menuButtonPopupDirection } from '@gjsify/adwaita-core';
-import type { SplitButtonDirection } from '@gjsify/adwaita-core';
+import { isSplitButtonDirection, menuButtonPopupDirection, parseMenuEntries } from '@gjsify/adwaita-core';
+import type { AdwMenuEntry, SplitButtonDirection } from '@gjsify/adwaita-core';
 
 // SIDE-EFFECT import, deliberately separate from the type import below: it guarantees
 // `adw-popover` is defined before this module's `customElements.define` can upgrade a
@@ -34,12 +34,15 @@ import type { AdwPopover } from './adw-popover.js';
 
 import { createAdwIcon } from './adw-icon.js';
 
-/** A menu entry. `id` defaults to `label` on activation; `icon` is optional. */
-export interface AdwMenuItem {
-    id?: string;
-    label: string;
-    icon?: string;
-}
+/**
+ * A menu entry — `@gjsify/adwaita-core`'s {@link AdwMenuEntry}, re-exported under the
+ * name this element has always used.
+ *
+ * It used to be a SECOND declaration of the same shape, and the NativeScript menu
+ * button declared a THIRD that was missing `icon` entirely. One type, so a consumer
+ * writing menu entries writes the same object for either renderer.
+ */
+export type AdwMenuItem = AdwMenuEntry;
 
 /**
  * Where the popover sits, per `GtkArrowType`. `menuButtonPopupDirection` folds `none`
@@ -152,18 +155,16 @@ export class AdwMenuButton extends HTMLElement {
         this._render();
     }
 
+    /**
+     * The `menu` attribute, through the core parser the split button already used.
+     *
+     * The copy this replaces was weaker in a way markup can reach: it kept `id` and
+     * `icon` WHATEVER their runtime type, so `{"label":"Open","id":7}` produced an
+     * entry whose `id` is a number in a field typed `string` — and `id` is what the
+     * activation event reports. The core parser keeps only string-typed extras.
+     */
     private _parseMenuAttr(): AdwMenuItem[] {
-        const raw = this.getAttribute('menu');
-        if (!raw) return [];
-        try {
-            const parsed: unknown = JSON.parse(raw);
-            if (!Array.isArray(parsed)) return [];
-            return parsed
-                .filter((e): e is AdwMenuItem => typeof e === 'object' && e !== null && 'label' in e)
-                .map((e) => ({ id: e.id, label: String(e.label), icon: e.icon }));
-        } catch {
-            return [];
-        }
+        return parseMenuEntries(this.getAttribute('menu'));
     }
 
     private _onPopoverToggled(open: boolean): void {

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -33,6 +33,8 @@ import { AdwViewSwitcherBarTest } from './adw-view-switcher-bar.spec.js';
 import { AdwStyleIsolationTest } from './style-isolation.spec.js';
 import { AdwWrapBoxTest } from './adw-wrap-box.spec.js';
 import { AdwHeaderBarTest } from './adw-header-bar.spec.js';
+import { AdwEntryTest } from './adw-entry.spec.js';
+import { AdwMenuButtonTest } from './adw-menu-button.spec.js';
 import { AdwBannerTest } from './adw-banner.spec.js';
 import { AdwButtonContentTest } from './adw-button-content.spec.js';
 import { AdwIconTest } from './adw-icon.spec.js';
@@ -77,6 +79,8 @@ run({
     AdwStyleIsolationTest,
     AdwWrapBoxTest,
     AdwHeaderBarTest,
+    AdwEntryTest,
+    AdwMenuButtonTest,
     AdwViewStackTest,
     AdwNavigationViewTest,
     AdwSidebarTest,


### PR DESCRIPTION
The generated matrix says **37 of 43** widgets implemented on both renderers share their behaviour through `@gjsify/adwaita-core`. Three of the six that don't are browser elements re-implementing — or simply missing — a derivation the core already holds and the NativeScript twin already uses. Each is a defect a consumer can reach.

## `<adw-header-bar>` — a bare span where libadwaita has a window title

`Adw.HeaderBar` builds an `AdwWindowTitle` for its derived centre. This element built a `<span>` and wrote `textContent`. The package **has** an `<adw-window-title>`, core-backed, holding three rules the span had none of:

- an **empty title hides its line** (`adw-window-title.c:207-208`) — a header bar with only a subtitle reserved a blank line above it
- re-setting the same value paints nothing (`C:203-204`)
- there is a **subtitle at all** — `<adw-header-bar subtitle="12 items">` did nothing

So the browser header bar could not show what its own NativeScript twin could. It now derives an `<adw-window-title>` and forwards the attributes.

## `<adw-entry>` — no length arithmetic at all

NativeScript's `AdwEntry` has composed `clampEntryText`/`entryTextLength`/`ENTRY_ROW_MAX_LENGTH_LIMIT` since it shipped. The browser element had **no max length and no text length**: the same consumer got a limit on one renderer and none on the other.

Handing it to the native `maxlength` would not have closed the gap — the browser counts **UTF-16 code units**:

| text | `input.maxLength` counts | GTK / NativeScript count |
|---|---|---|
| `'🔒é'` | 3 | **2** |

So the clamp is applied here, on the way in, which is also where NativeScript applies it — both renderers now refuse the same character.

## `<adw-menu-button>` — a weaker copy of the core parser

It parsed `menu` JSON itself, next to a split button already calling `parseMenuEntries`. The copy kept `id` and `icon` **whatever their runtime type**, so `{"label":"Open","id":7}` produced an entry whose `id` is a number — and `id` is exactly what `menu-item-activated` reports. `AdwMenuItem` is now the core's `AdwMenuEntry` rather than a second declaration of the same shape (NativeScript declared a third, missing `icon`).

## Verified

Tests drive the core's own vectors against the **real elements** — `ENTRY_TEXT_LENGTH_VECTORS` and `ENTRY_MAX_LENGTH_VECTORS` row by row, `SPLIT_BUTTON_MENU_PARSE_VECTORS` row by row, plus the three header-bar rules.

**A/B'd**: a deliberately wrong expectation fails the browser suite by name (`1 of 3988 tests failed: [<adw-entry> max length] an unusable limit means unlimited…`), so the new tests demonstrably run rather than being silently absent from the bundle.

Also green: `tsc --noEmit`, `check-adwaita-conformance-drivers` (154 vector tables), `check-adwaita-reset-components` (65 elements), `check-adwaita-style-classes` (52 classes), `gjsify format --check` tree-wide.