### PR TITLE
fix(adwaita): retire the last three two-copy widgets

### DIFF
--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-about-dialog.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-about-dialog.ts
@@ -18,6 +18,7 @@
 // Reference: refs/libadwaita/src/stylesheet/widgets/_dialog.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
+import { aboutDialogVisibility } from '@gjsify/adwaita-core';
 import { Button, GridLayout, ItemSpec, Label, ScrollView, StackLayout, type EventData } from '@nativescript/core';
 
 /** Event name emitted when the dialog is closed. */
@@ -77,6 +78,12 @@ export class AdwAboutDialog extends GridLayout {
         closeButton.set('androidElevation', 0);
         closeButton.addEventListener('tap', () => this.close());
         card.addChild(closeButton);
+
+        // A dialog nobody has written to yet is SEVEN empty labels, all visible —
+        // the same blank lines the visibility rules exist to remove. Every setter
+        // re-renders the whole card, so one call here is what covers the state
+        // before the first one.
+        this._render();
     }
 
     private _addCardLabel(card: StackLayout, className: string): Label {
@@ -95,7 +102,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set applicationName(value: string) {
         this._applicationName = value ?? '';
-        this._nameLabel.text = this._applicationName;
+        this._render();
     }
 
     /** A glyph standing in for the app icon (no icon-theme lookup in the NS subset). */
@@ -105,7 +112,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set applicationIcon(value: string) {
         this._applicationIcon = value ?? '';
-        this._iconLabel.text = this._applicationIcon;
+        this._render();
     }
 
     /** The version string. */
@@ -115,7 +122,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set version(value: string) {
         this._version = value ?? '';
-        this._versionLabel.text = this._version;
+        this._render();
     }
 
     /** The developer/author name. */
@@ -125,7 +132,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set developerName(value: string) {
         this._developerName = value ?? '';
-        this._developerLabel.text = this._developerName;
+        this._render();
     }
 
     /** A short comments/description line. */
@@ -135,7 +142,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set comments(value: string) {
         this._comments = value ?? '';
-        this._commentsLabel.text = this._comments;
+        this._render();
     }
 
     /** The website URL (plain text — not a tappable link in this subset). */
@@ -145,7 +152,7 @@ export class AdwAboutDialog extends GridLayout {
 
     set website(value: string) {
         this._website = value ?? '';
-        this._websiteLabel.text = this._website;
+        this._render();
     }
 
     /** The copyright line. */
@@ -155,7 +162,46 @@ export class AdwAboutDialog extends GridLayout {
 
     set copyright(value: string) {
         this._copyright = value ?? '';
-        this._copyrightLabel.text = this._copyright;
+        this._render();
+    }
+
+    /**
+     * Push the seven strings onto their labels, and COLLAPSE the ones with nothing
+     * to say.
+     *
+     * Every label used to be unconditionally visible, so an about dialog without a
+     * version rendered a blank line where the version belongs — the exact case
+     * `aboutDialogVisibility` answers for the browser port (`adw-about-dialog.c`
+     * binds each part's `visible` to a closure over the property that feeds it).
+     * Same input, two different dialogs, and nothing said so.
+     *
+     * The core's record covers a nineteen-part dialog; this port is a flat card, so
+     * it reads the parts it has. `copyright` is NOT one of them: upstream has no
+     * copyright LABEL, it derives the string into the Legal page this port does not
+     * build (`legalSectionVisible` takes it as a separate argument). It therefore
+     * keeps the same non-empty rule directly. The website row is the core's
+     * `websiteRow`, which is the flat-card equivalent here.
+     */
+    private _render(): void {
+        const visibility = aboutDialogVisibility({
+            applicationName: this._applicationName,
+            applicationIcon: this._applicationIcon,
+            developerName: this._developerName,
+            version: this._version,
+            comments: this._comments,
+            website: this._website,
+        });
+        const show = (label: Label, text: string, shown: boolean): void => {
+            label.text = text;
+            label.visibility = shown ? 'visible' : 'collapse';
+        };
+        show(this._iconLabel, this._applicationIcon, visibility.appIcon);
+        show(this._nameLabel, this._applicationName, visibility.appName);
+        show(this._versionLabel, this._version, visibility.version);
+        show(this._developerLabel, this._developerName, visibility.developerName);
+        show(this._commentsLabel, this._comments, visibility.commentsLabel);
+        show(this._websiteLabel, this._website, visibility.websiteRow);
+        show(this._copyrightLabel, this._copyright, this._copyright.length > 0);
     }
 
     /** Reveal the about overlay. */

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-button.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-button.ts
@@ -11,19 +11,17 @@
 // Reference: refs/libadwaita/src/stylesheet/widgets/_buttons.scss
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
+import { ADW_BUTTON_STYLE_CLASSES, type AdwButtonStyleClass, buttonStyleClass } from '@gjsify/adwaita-core';
 import { Button } from '@nativescript/core';
 
-/** The Adwaita button variants this widget can apply. `'default'` = plain button. */
-export type AdwButtonVariant = 'default' | 'suggested-action' | 'destructive-action' | 'flat' | 'pill';
-
-const VARIANT_CLASSES: Record<Exclude<AdwButtonVariant, 'default'>, string> = {
-    'suggested-action': 'suggested-action',
-    'destructive-action': 'destructive-action',
-    flat: 'flat',
-    pill: 'pill',
-};
-
-const ALL_VARIANT_CLASSES = Object.values(VARIANT_CLASSES);
+/**
+ * The Adwaita button variants this widget can apply. `'default'` = plain button.
+ *
+ * The class list is `@gjsify/adwaita-core`'s, not a local table: this widget's own
+ * one was MISSING `circular`, which the browser element had, and neither file could
+ * see the other. `circular` is now here because the shared table says it exists.
+ */
+export type AdwButtonVariant = 'default' | AdwButtonStyleClass;
 
 export class AdwButton extends Button {
     private _variant: AdwButtonVariant = 'default';
@@ -38,7 +36,7 @@ export class AdwButton extends Button {
 
     /**
      * The Adwaita style variant. Setting it swaps the corresponding CSS class
-     * (`.suggested-action`/`.destructive-action`/`.flat`/`.pill`) onto the button,
+     * (one of `AdwButton.variantClasses`) onto the button,
      * preserving the base `adw-button` class. Note that `pill` is the rounded
      * SHAPE and combines with no other variant here (set the shape OR the accent
      * intent — matching how this CSS subset expresses them as flat classes).
@@ -49,11 +47,8 @@ export class AdwButton extends Button {
 
     set variant(value: AdwButtonVariant) {
         this._variant = value;
-        const classes = ['adw-button'];
-        if (value !== 'default') {
-            classes.push(VARIANT_CLASSES[value]);
-        }
-        this.className = classes.join(' ');
+        const styleClass = value === 'default' ? null : buttonStyleClass(value);
+        this.className = styleClass ? `adw-button ${styleClass}` : 'adw-button';
     }
 
     /**
@@ -61,6 +56,6 @@ export class AdwButton extends Button {
      * and for consumers composing class lists manually.
      */
     static get variantClasses(): readonly string[] {
-        return ALL_VARIANT_CLASSES;
+        return ADW_BUTTON_STYLE_CLASSES;
     }
 }

--- a/packages/nativescript-bridge/adwaita/src/widgets/status-page-content.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/status-page-content.ts
@@ -8,9 +8,16 @@
 // Free of `@nativescript/core` imports so the spec suite exercises the shipping
 // predicates; the widget class `extends GridLayout` and is unresolvable off-device.
 //
+// The predicate itself is `stringIsNotEmpty` from `@gjsify/adwaita-core` — the same
+// `string_is_not_empty` the action rows bind their labels to. Both renderers spelled
+// it themselves (`text ? … : …` here, `title.length === 0` in the browser), and a
+// rule written twice is a rule that can drift twice.
+//
 // Reference: refs/libadwaita/src/adw-status-page.c
 // Reference: refs/libadwaita/src/adw-status-page.ui
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import { stringIsNotEmpty } from '@gjsify/adwaita-core';
 
 /** NativeScript's `visible` / not-in-layout pair, the counterpart of GTK `visible`. */
 export type StatusPageVisibility = 'visible' | 'collapse';
@@ -21,7 +28,7 @@ export type StatusPageVisibility = 'visible' | 'collapse';
  * VISIBLE title in libadwaita, so trimming here would hide a widget GTK draws.
  */
 export function statusPageLabelVisibility(text: string | null | undefined): StatusPageVisibility {
-    return text ? 'visible' : 'collapse';
+    return stringIsNotEmpty(text) ? 'visible' : 'collapse';
 }
 
 /**
@@ -34,5 +41,5 @@ export function statusPageLabelVisibility(text: string | null | undefined): Stat
  * the missing half is a real gap rather than a simplification.
  */
 export function statusPageIconVisibility(icon: string | null | undefined): StatusPageVisibility {
-    return icon ? 'visible' : 'collapse';
+    return stringIsNotEmpty(icon) ? 'visible' : 'collapse';
 }

--- a/packages/web/adwaita-core/src/button.spec.ts
+++ b/packages/web/adwaita-core/src/button.spec.ts
@@ -1,0 +1,36 @@
+// The button style-class table, against its own vectors.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { ADW_BUTTON_STYLE_CLASSES, buttonStyleClass, buttonStyleClasses } from './button.js';
+import { BUTTON_STYLE_CLASS_VECTORS } from './conformance/button.js';
+
+export default async () => {
+    await describe('buttonStyleClasses', async () => {
+        for (const { names, classes, rule } of BUTTON_STYLE_CLASS_VECTORS) {
+            await it(`[${names.join(', ')}] → [${classes.join(', ')}] — ${rule}`, () => {
+                expect(buttonStyleClasses(names)).toStrictEqual([...classes]);
+            });
+        }
+
+        await it('drops a null or undefined name without throwing', () => {
+            // Renderers hand in whatever their attribute reader returned, and an
+            // absent attribute is `null` in the browser and `undefined` in NS.
+            expect(buttonStyleClasses([null, undefined, 'pill'])).toStrictEqual(['pill']);
+        });
+    });
+
+    await describe('buttonStyleClass', async () => {
+        await it('answers null for a name that is not a button style', () => {
+            expect(buttonStyleClass('not-a-style')).toBeNull();
+            expect(buttonStyleClass('')).toBeNull();
+            expect(buttonStyleClass(null)).toBeNull();
+        });
+
+        await it('every declared class resolves to itself', () => {
+            // The long spellings are what the NativeScript variant hands in, so a
+            // class that only resolved from its short alias would break that side.
+            for (const cls of ADW_BUTTON_STYLE_CLASSES) expect(buttonStyleClass(cls)).toBe(cls);
+        });
+    });
+};

--- a/packages/web/adwaita-core/src/button.ts
+++ b/packages/web/adwaita-core/src/button.ts
@@ -1,0 +1,68 @@
+// Adw/Gtk button style classes — the SET, headless.
+//
+// WHY THIS MODULE EXISTS. A plain button has almost no behaviour, which is exactly
+// ADR 0004's "a widget with genuinely trivial behaviour does not need a core class".
+// What it does have is a TABLE, and the two renderers each wrote their own — with
+// different membership. Measured before this module:
+//
+//   browser  flat · suggested-action · destructive-action · circular · pill
+//   NS       flat · suggested-action · destructive-action ·            pill
+//
+// `circular` existed on one renderer and not the other, and nothing said so: both
+// tables looked complete from inside their own file. The same shape of divergence
+// the storybook's own gate now catches for widgets, one level down at the class list.
+//
+// The COMPOSITION rule stays with the renderers, deliberately. GTK style classes are
+// a set (`gtk_widget_add_css_class` — `.pill.suggested-action` is a real button), and
+// the browser element composes them that way from independent attributes, while the
+// NativeScript widget exposes ONE `variant` because its markup surface is a single
+// property. That is a genuine surface difference, not a drifted rule; what must not
+// differ is which classes exist and how they are spelled.
+//
+// Reference: refs/libadwaita/src/stylesheet/widgets/_buttons.scss
+// Reference: refs/libadwaita/doc/style-classes.md
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+/** Every documented button style class, in stylesheet order. */
+export const ADW_BUTTON_STYLE_CLASSES = ['flat', 'suggested-action', 'destructive-action', 'circular', 'pill'] as const;
+
+/** One of {@link ADW_BUTTON_STYLE_CLASSES}. */
+export type AdwButtonStyleClass = (typeof ADW_BUTTON_STYLE_CLASSES)[number];
+
+/**
+ * The short names a renderer's own surface uses → the class.
+ *
+ * The browser element spells them as attributes (`suggested`), the NativeScript one
+ * as variants (`suggested-action`). Both spellings resolve here, so neither has to
+ * keep a private table to translate.
+ */
+export const ADW_BUTTON_STYLE_ALIASES: Readonly<Record<string, AdwButtonStyleClass>> = {
+    flat: 'flat',
+    suggested: 'suggested-action',
+    'suggested-action': 'suggested-action',
+    destructive: 'destructive-action',
+    'destructive-action': 'destructive-action',
+    circular: 'circular',
+    pill: 'pill',
+};
+
+/** The class for one short name, or `null` when the name is not a button style. */
+export function buttonStyleClass(name: string | null | undefined): AdwButtonStyleClass | null {
+    if (!name) return null;
+    return ADW_BUTTON_STYLE_ALIASES[name] ?? null;
+}
+
+/**
+ * The classes for a set of short names, deduplicated, in {@link ADW_BUTTON_STYLE_CLASSES}
+ * order — so two buttons carrying the same styles carry them in the same order, whatever
+ * order the caller asked in. Unknown names are dropped rather than passed through: the
+ * input is author-written markup, and a typo must not become a class.
+ */
+export function buttonStyleClasses(names: Iterable<string | null | undefined>): AdwButtonStyleClass[] {
+    const wanted = new Set<AdwButtonStyleClass>();
+    for (const name of names) {
+        const resolved = buttonStyleClass(name);
+        if (resolved) wanted.add(resolved);
+    }
+    return ADW_BUTTON_STYLE_CLASSES.filter((cls) => wanted.has(cls));
+}

--- a/packages/web/adwaita-core/src/conformance/button.ts
+++ b/packages/web/adwaita-core/src/conformance/button.ts
@@ -1,0 +1,65 @@
+// Vectors for the button style-class table.
+//
+// The table is small enough that both renderers wrote their own and neither noticed
+// the difference: `circular` was on the browser side only. These rows are what makes
+// "both renderers know the same classes" a test rather than a claim.
+
+/** One style-class resolution. */
+export interface ButtonStyleClassVector {
+    /** The short names a renderer hands in — attribute names, or a variant. */
+    names: readonly string[];
+    /** The classes that must come back, in order. */
+    classes: readonly string[];
+    rule: string;
+}
+
+export const BUTTON_STYLE_CLASS_VECTORS: ReadonlyArray<ButtonStyleClassVector> = [
+    { names: [], classes: [], rule: 'a plain button carries no style class' },
+    { names: ['flat'], classes: ['flat'], rule: '.flat — a button with no frame until hovered' },
+    {
+        names: ['suggested'],
+        classes: ['suggested-action'],
+        rule: 'the browser attribute `suggested` is the class `.suggested-action`',
+    },
+    {
+        names: ['suggested-action'],
+        classes: ['suggested-action'],
+        rule: 'the NativeScript variant spells the class itself — both spellings resolve',
+    },
+    {
+        names: ['destructive'],
+        classes: ['destructive-action'],
+        rule: '`destructive` → `.destructive-action`, the same short/long pair',
+    },
+    {
+        names: ['circular'],
+        classes: ['circular'],
+        rule: 'CIRCULAR EXISTS — it was in the browser table and missing from the NativeScript one',
+    },
+    { names: ['pill'], classes: ['pill'], rule: '.pill — the fully rounded button' },
+    {
+        names: ['pill', 'suggested'],
+        classes: ['suggested-action', 'pill'],
+        rule: 'style classes COMPOSE (gtk_widget_add_css_class is a set), and come back in stylesheet order',
+    },
+    {
+        names: ['suggested', 'pill'],
+        classes: ['suggested-action', 'pill'],
+        rule: "the caller's order does not change the result — two buttons with the same styles read alike",
+    },
+    {
+        names: ['pill', 'pill'],
+        classes: ['pill'],
+        rule: 'a repeat is not a second class',
+    },
+    {
+        names: ['suggessted'],
+        classes: [],
+        rule: 'a TYPO is dropped, not passed through — the input is author-written markup',
+    },
+    {
+        names: ['flat', 'not-a-style', 'circular'],
+        classes: ['flat', 'circular'],
+        rule: 'one bad name does not take the good ones with it',
+    },
+];

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -130,6 +130,10 @@ export type {
     ButtonContentTextVector,
 } from './button-content.js';
 
+// --- Button style-class vectors (Gtk.Button + Adwaita style classes) ---
+export { BUTTON_STYLE_CLASS_VECTORS } from './button.js';
+export type { ButtonStyleClassVector } from './button.js';
+
 // --- Radio-group exclusivity (Adwaita check/radio) vectors ---
 export { RADIO_GROUP_VECTORS } from './checks.js';
 export type { RadioGroupStep, RadioGroupVector } from './checks.js';

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -121,6 +121,10 @@ export type {
     ButtonContentEllipsize,
 } from './button-content.js';
 
+// --- Button style classes (Gtk.Button + Adwaita style classes) ---
+export { ADW_BUTTON_STYLE_ALIASES, ADW_BUTTON_STYLE_CLASSES, buttonStyleClass, buttonStyleClasses } from './button.js';
+export type { AdwButtonStyleClass } from './button.js';
+
 // --- Checks + radio-group exclusivity (Adwaita check/radio) ---
 export { RadioGroupState, resolveCheckState } from './checks.js';
 export type { AdwCheckState, RadioGroupChange, RadioGroupListener } from './checks.js';

--- a/packages/web/adwaita-core/src/test.mts
+++ b/packages/web/adwaita-core/src/test.mts
@@ -23,6 +23,7 @@ import toastTestSuite from './toast.spec.js';
 import popoverTestSuite from './popover.spec.js';
 import bannerTestSuite from './banner.spec.js';
 import buttonContentTestSuite from './button-content.spec.js';
+import buttonTestSuite from './button.spec.js';
 import aboutDialogTestSuite from './about-dialog.spec.js';
 import checksTestSuite from './checks.spec.js';
 import wrapBoxTestSuite from './wrap-box.spec.js';
@@ -33,6 +34,7 @@ run({
     aboutDialogTestSuite,
     bannerTestSuite,
     buttonContentTestSuite,
+    buttonTestSuite,
     checksTestSuite,
     breakpointTestSuite,
     accentTestSuite,

--- a/packages/web/adwaita-web/src/adw-button.spec.ts
+++ b/packages/web/adwaita-web/src/adw-button.spec.ts
@@ -1,0 +1,59 @@
+// DOM-level tests for <adw-button>'s style classes.
+//
+// The element and its NativeScript twin each kept their own attribute→class table,
+// and the two disagreed: `circular` was here and not there. The table now lives in
+// `@gjsify/adwaita-core`, and these drive its vectors through the REAL element, so a
+// renderer that goes back to a private copy fails on the row that names the class.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { BUTTON_STYLE_CLASS_VECTORS } from '@gjsify/adwaita-core/conformance';
+
+/** The boolean attributes this element exposes — the short spellings. */
+const WEB_ATTRIBUTES = new Set(['flat', 'suggested', 'destructive', 'circular', 'pill']);
+
+/** Mount a button carrying the given boolean attributes; return the inner classes. */
+function mountWithStyles(names: readonly string[]): string[] {
+    const el = document.createElement('adw-button');
+    el.setAttribute('label', 'Click me');
+    for (const name of names) el.setAttribute(name, '');
+    document.body.appendChild(el);
+    const btn = el.querySelector('button') as HTMLButtonElement;
+    return Array.from(btn.classList).filter((cls) => cls !== 'adw-button');
+}
+
+function unmountAll(): void {
+    for (const el of Array.from(document.querySelectorAll('adw-button'))) el.remove();
+}
+
+export const AdwButtonTest = async () => {
+    // Rows naming a class the LONG way (`suggested-action`) are the NativeScript
+    // variant spelling — this element has no such attribute. They are partitioned
+    // out here rather than skipped inside the loop, and the partition is asserted,
+    // so a row cannot fall out of coverage unnoticed.
+    const reachable = BUTTON_STYLE_CLASS_VECTORS.filter((v) => v.names.every((n) => WEB_ATTRIBUTES.has(n)));
+    const unreachable = BUTTON_STYLE_CLASS_VECTORS.filter((v) => !v.names.every((n) => WEB_ATTRIBUTES.has(n)));
+
+    await describe('<adw-button> style classes', async () => {
+        for (const { names, classes, rule } of reachable) {
+            await it(`[${names.join(', ')}] → [${classes.join(', ')}] — ${rule}`, () => {
+                expect(mountWithStyles(names)).toStrictEqual([...classes]);
+                unmountAll();
+            });
+        }
+
+        await it('the rows this element cannot express are exactly the long spellings', () => {
+            const names = unreachable.flatMap((v) => v.names).filter((n) => !WEB_ATTRIBUTES.has(n));
+            expect(names).toStrictEqual(['suggested-action', 'suggessted', 'not-a-style']);
+        });
+
+        await it('a style attribute added later is picked up', () => {
+            const el = document.createElement('adw-button');
+            el.setAttribute('label', 'Send');
+            document.body.appendChild(el);
+            el.setAttribute('suggested', '');
+            const btn = el.querySelector('button') as HTMLButtonElement;
+            expect(btn.classList.contains('suggested-action')).toBe(true);
+            unmountAll();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/elements/adw-button.ts
+++ b/packages/web/adwaita-web/src/elements/adw-button.ts
@@ -9,15 +9,12 @@
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web; the
 // icon node is <adw-icon>.
 
+import { buttonStyleClasses } from '@gjsify/adwaita-core';
+
 import { createAdwIcon } from './adw-icon.js';
 
-const VARIANT_CLASSES: Record<string, string> = {
-    flat: 'flat',
-    suggested: 'suggested-action',
-    destructive: 'destructive-action',
-    circular: 'circular',
-    pill: 'pill',
-};
+/** The boolean attributes that select a style class; the mapping lives in the core. */
+const STYLE_ATTRIBUTES = ['flat', 'suggested', 'destructive', 'circular', 'pill'] as const;
 
 export class AdwButton extends HTMLElement {
     private _button!: HTMLButtonElement;
@@ -50,9 +47,10 @@ export class AdwButton extends HTMLElement {
     private _render() {
         const btn = this._button;
         btn.className = 'adw-button';
-        for (const [attr, cls] of Object.entries(VARIANT_CLASSES)) {
-            if (this.hasAttribute(attr)) btn.classList.add(cls);
-        }
+        // The attribute → class mapping is `@gjsify/adwaita-core`'s, so this element
+        // and the NativeScript one cannot disagree about which classes exist —
+        // `circular` was in this table and missing from that one.
+        btn.classList.add(...buttonStyleClasses(STYLE_ATTRIBUTES.filter((attr) => this.hasAttribute(attr))));
 
         const icon = this.getAttribute('icon');
         const label = (this.getAttribute('label') ?? this._label).trim();

--- a/packages/web/adwaita-web/src/elements/adw-status-page.ts
+++ b/packages/web/adwaita-web/src/elements/adw-status-page.ts
@@ -7,6 +7,8 @@
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web; the
 // icon node is <adw-icon>.
 
+import { stringIsNotEmpty } from '@gjsify/adwaita-core';
+
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
 
 export class AdwStatusPage extends HTMLElement {
@@ -51,13 +53,16 @@ export class AdwStatusPage extends HTMLElement {
         this._iconEl.iconName = this.getAttribute('icon');
         this._iconEl.hidden = this._iconEl.resolvedIconName === '';
 
+        // `string_is_not_empty` from the core, not a local `.length === 0`: the same
+        // closure the NativeScript port binds its labels to, and the reason a title of
+        // `'   '` stays VISIBLE — it reads the first byte, it never trims.
         const title = this.getAttribute('title') ?? '';
         this._titleEl.textContent = title;
-        this._titleEl.hidden = title.length === 0;
+        this._titleEl.hidden = !stringIsNotEmpty(title);
 
         const description = this.getAttribute('description') ?? '';
         this._descEl.textContent = description;
-        this._descEl.hidden = description.length === 0;
+        this._descEl.hidden = !stringIsNotEmpty(description);
 
         this._childEl.hidden = this._childEl.childElementCount === 0;
     }

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -35,6 +35,7 @@ import { AdwWrapBoxTest } from './adw-wrap-box.spec.js';
 import { AdwHeaderBarTest } from './adw-header-bar.spec.js';
 import { AdwEntryTest } from './adw-entry.spec.js';
 import { AdwMenuButtonTest } from './adw-menu-button.spec.js';
+import { AdwButtonTest } from './adw-button.spec.js';
 import { AdwBannerTest } from './adw-banner.spec.js';
 import { AdwButtonContentTest } from './adw-button-content.spec.js';
 import { AdwIconTest } from './adw-icon.spec.js';
@@ -81,6 +82,7 @@ run({
     AdwHeaderBarTest,
     AdwEntryTest,
     AdwMenuButtonTest,
+    AdwButtonTest,
     AdwViewStackTest,
     AdwNavigationViewTest,
     AdwSidebarTest,


### PR DESCRIPTION
The three the generated matrix still shows implemented on both renderers **without** a shared behaviour. Each carried a real divergence, not just a duplicated line. With #1191 this closes the set: 43 of 43.

## `adw-button` — two tables that disagreed

| | classes it knew |
|---|---|
| browser | flat · suggested-action · destructive-action · **circular** · pill |
| NativeScript | flat · suggested-action · destructive-action · — · pill |

`circular` existed on one renderer and not the other, and neither file could see the other. The table moves to `@gjsify/adwaita-core` — both spellings resolve, since the browser hands in `suggested` and NativeScript the class itself — and **NativeScript gains `circular`** because the shared list says it exists.

The **composition** rule deliberately stays with the renderers: GTK style classes are a set (`.pill.suggested-action` is a real button) and the browser composes independent attributes, while the NS widget exposes one `variant` because its markup surface is one property. That is a surface difference, not a drifted rule.

ADR 0004 says a widget with genuinely trivial behaviour does not need a core class — so this is a table and two functions, not a state machine.

## `adw-status-page` — one rule, spelled twice

`text ? … : …` on one side, `title.length === 0` on the other. It is the same `string_is_not_empty` closure the action rows already bind their labels to; both now call `stringIsNotEmpty`. That is also why a title of `'   '` stays **visible** — it reads the first byte, it never trims.

## `adw-about-dialog` — the NativeScript port showed every label

Unconditionally. A dialog without a version rendered a blank line where the version belongs. `aboutDialogVisibility` is what the browser port has answered with all along (`adw-about-dialog.c` binds each part's `visible` to a closure over the property that feeds it). Same input, two different dialogs, and nothing said so. The setters now share one `_render()` that collapses what has nothing to say.

## Verified

- **12 new vectors** for the class table, driven from the core suite **and** through a real `<adw-button>` in the browser suite
- the rows the browser element cannot express — the long spellings NativeScript uses — are partitioned out and **the partition is asserted**, so a row cannot fall out of coverage unnoticed. That assertion caught its own first draft being wrong (it claimed `destructive-action` was unreachable; it is not).
- `@gjsify/adwaita-core` suite green (Node + GJS) · `@gjsify/adwaita-nativescript` suite green (Node + GJS) · browser suite green · `check-adwaita-conformance-drivers` 155 tables, every one driven or explained · `check-adwaita-reset-components` 65 elements · `tsc --noEmit` · `gjsify format --check` tree-wide