### PR TITLE
fix(adwaita-nativescript): share the menu-entry type

### DIFF
--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-menu-button.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-menu-button.ts
@@ -15,19 +15,23 @@
 // Reference: refs/libadwaita/src/menu-button (Adw.MenuButton)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
+import type { AdwMenuEntry } from '@gjsify/adwaita-core';
 import { action, type EventData } from '@nativescript/core';
 import { AdwImageButton } from './adw-image-button.js';
 
 /** Event name emitted when a menu item is chosen. */
 export const MENU_ITEM_ACTIVATED = 'menuItemActivated';
 
-/** One entry in an {@link AdwMenuButton}'s menu. */
-export interface AdwMenuItem {
-    /** Stable identifier reported on activation (defaults to {@link label}). */
-    id?: string;
-    /** The menu item's display label. */
-    label: string;
-}
+/**
+ * One entry in an {@link AdwMenuButton}'s menu — `@gjsify/adwaita-core`'s
+ * {@link AdwMenuEntry}, under the name this widget has always used.
+ *
+ * It used to be a THIRD declaration of the same shape (the browser element had a
+ * second, and the core the original), and this one was missing `icon` — so a menu
+ * written for one renderer was not the same object on the other. The browser side
+ * adopted the core type in #1191; this is its twin.
+ */
+export type AdwMenuItem = AdwMenuEntry;
 
 /** Payload of the {@link MENU_ITEM_ACTIVATED} event. */
 export interface MenuItemActivatedEventData extends EventData {

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -734,9 +734,13 @@ function adwaitaCoverageSection(coverage) {
     );
     out.push(table(['Widget', 'GTK story', 'adwaita-web', 'adwaita-nativescript'], rows));
     out.push('');
+    // The backlog sentence is CONDITIONAL: naming a remainder that is empty is the
+    // same drift as any other stale claim — it reads as work outstanding when there
+    // is none, and nobody re-reads a generated line to check.
     out.push(
         `**${shared.length} of ${both.length}** widgets implemented on BOTH renderers share their behaviour ` +
-            'through `@gjsify/adwaita-core`. The remainder still carry two copies (ADR 0004 backlog).',
+            'through `@gjsify/adwaita-core`.' +
+            (shared.length < both.length ? ' The remainder still carry two copies (ADR 0004 backlog).' : ''),
     );
     if (dataObjects.length) {
         out.push('');


### PR DESCRIPTION
**I claimed 43 of 43 in #1192. The derived matrix says 42.** This is the missing one, and the correction of the claim.

`adw-menu-button` reaches `@gjsify/adwaita-core` on the NativeScript side only through `AdwImageButton`'s helpers — **two hops**, which `generate-status.mjs` deliberately does not count. Its reasoning is right and worth keeping: a transitive walk would report a widget as core-backed because something four modules away happens to import core, which is a different claim from "this widget delegates".

The real duplicate is its own `AdwMenuItem` interface — a **third** declaration of a shape the core already owns (`AdwMenuEntry`), and the only one missing `icon`, so a menu written for one renderer was not the same object on the other. The browser element adopted the core type in #1191; this is its twin.

With it, the derived line reads **43 of 43**.

## One more stale claim, in generated text

`generate-status.mjs` printed *"The remainder still carry two copies (ADR 0004 backlog)"* unconditionally — so at 43 of 43 it names a backlog that does not exist. It is conditional now. A generated line is exactly where this survives longest: nobody re-reads it, because a script wrote it.

Verified: `@gjsify/adwaita-nativescript` build (tsc) + suite green on Node and GJS, `gjsify format --check` tree-wide, and the matrix regenerated to confirm the count rather than asserting it.