### PR TITLE
docs: retire what the tree already disproves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,13 +264,6 @@ jobs:
   #
   # `needs: publish` so @gjsify/cli@<release-version> is already on npm (this job
   # installs it to drive the OIDC publish) and the publish legs are serialized.
-  #
-  # MAINTAINER ACTION — @gjsify/gtk-runtime-darwin-x64 is a NEW npm name: npm Trusted
-  # Publishing (OIDC) cannot CREATE a package, only publish new versions of an
-  # existing one, so it needs a one-time `gjsify onboard` (first publish + Trusted
-  # Publisher) BEFORE the first release that runs this leg — otherwise the OIDC
-  # exchange 404s and stalls every alphabetically-later package. Same requirement the
-  # win32 job below documents.
   publish-gtk-runtime-darwin:
     name: Publish @gjsify/gtk-runtime-darwin-${{ matrix.arch }} (macOS bundle)
     needs: publish
@@ -444,14 +437,6 @@ jobs:
   # search path at LoadLibrary time), and NO addon build (the tarball ships only
   # gtk/{bin,girepository-1.0,manifest.json}; the addon prebuild is node-gi's own
   # concern in node-gi.yml).
-  #
-  # MAINTAINER ACTION — MANUAL FIRST PUBLISH REQUIRED (like the darwin package):
-  # npm Trusted Publishing (OIDC) cannot CREATE a package, only publish new versions
-  # of an existing one. So @gjsify/gtk-runtime-win32-x64 needs a one-time manual
-  # `gjsify publish --access public` + `gjsify trust @gjsify/gtk-runtime-win32-x64`
-  # (or `gjsify onboard`) from a maintainer machine BEFORE this job's first CI
-  # release — otherwise the OIDC exchange 404s. See AGENTS.md "New @gjsify/* package:
-  # first-publish + Trusted Publisher bootstrap".
   #
   # `needs: publish` so @gjsify/cli@<release-version> is already on npm and the two
   # publish legs are serialized.
@@ -1464,16 +1449,6 @@ jobs:
           path: packages/napi/napi-darwin-arm64/prebuilds/darwin-arm64
           if-no-files-found: error
 
-  # MAINTAINER ACTION — MANUAL FIRST PUBLISH REQUIRED (like the gtk-runtime and
-  # node-gi packages, but here it has never happened at all: `curl
-  # https://registry.npmjs.org/@gjsify/napi` still 404s). npm Trusted Publishing
-  # (OIDC) can only publish new versions of an EXISTING package, so @gjsify/napi
-  # needs a one-time manual `gjsify publish --access public` + `gjsify trust
-  # @gjsify/napi` (or `gjsify onboard`) from a maintainer machine BEFORE this
-  # job's first CI release — otherwise the OIDC exchange 404s and this job reds.
-  # See AGENTS.md "New @gjsify/* package: first-publish + Trusted Publisher
-  # bootstrap".
-  #
   # WHY THIS JOB BUILDS lib/ (unlike publish-node-gi): node-gi ships committed
   # hand-written JS, so its publish job only stages prebuilds. @gjsify/napi's
   # published entry points (`main`/`types` -> lib/esm/index.js,
@@ -1625,11 +1600,6 @@ jobs:
       # `optionalDependencies`, and an optional dependency that does not resolve
       # is skipped in silence. Publishing the bridge first would leave a window
       # in which an install succeeds and produces a bridge with no binary.
-      #
-      # MAINTAINER ACTION: `@gjsify/napi-linux-x64` and
-      # `@gjsify/napi-darwin-arm64` are NEW names. Like `@gjsify/napi` itself
-      # they need a one-time manual first publish + `gjsify trust` (or `gjsify
-      # onboard`) before this job's first CI release, or the OIDC exchange 404s.
       - name: Publish the @gjsify/napi platform packages (OIDC)
         env:
           GJSIFY_PUBLISH_DEBUG: '1'

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -1,6 +1,6 @@
 # 24. `gjsify ship` — one payload, a runtime policy per OS, several install formats
 
-- Status: **Accepted** — stages 2 and 3 of § Implementation have landed; see § Implementation status
+- Status: **Accepted** — stages 1, 2 and 3 of § Implementation have landed; see § Implementation status
 - Date: 2026-08-14 (accepted 2026-08-15)
 - Deciders: Pascal Garber
 - Related: [ADR 0017 (native distribution)](0017-native-package-distribution.md), [ADR 0018 (OS-axis declaration)](0018-os-axis-declaration.md), [ADR 0021 (in-process prebuild resolution)](0021-launcher-free-prebuild-resolution.md), [ADR 0023 (which GTK a process uses)](0023-gtk-source-precedence.md), [docs/publishing.md](../publishing.md), `status/open-todos.md` § *gjsify on Flatpak — remaining roadmap*
@@ -152,13 +152,21 @@ the silence. On macOS and Windows the question does not arise: the closure is in
 
 ### 7. The glibc floor is derived from the ELF, not authored
 
-`gjsify.glibcRequires` is authored today on the platform packages, and nothing checks it
-against the binary. The floor is readable: walk the section headers, read `DT_NEEDED` from
-`.dynamic`, take the highest `GLIBC_x.y` in `.dynstr`. No `readelf`, no `ldd`, ~150 lines.
+`gjsify.glibcRequires` must be measured from the binary rather than believed, because the
+dynamic linker enforces the measured number and a host below it gets
+`version 'GLIBC_x.y' not found` with no fallback. The floor is readable without `readelf` or
+`ldd`: walk the section headers, read `DT_NEEDED` from `.dynamic`, take the highest `GLIBC_x.y`
+in `.dynstr`.
 
-**This one is separable and should not wait for the rest.** It converts an authored
-declaration into a machine-checked one, which is what the `declarations` governance rule
-demands of every `gjsify.*` key, and it pays off even if no `ship` command is ever written.
+**Correction, 2026-08-15 — this section shipped already-false and is kept as the record.** As
+drafted it read "nothing checks it against the binary" and listed the work as separable stage 1.
+Both were wrong on the day the ADR was accepted: the reader landed 2026-08-01 in `7896c51b02`
+(#897) as `@gjsify/manifest-conformance`'s `binary.mjs` (`readElfNeeded`,
+`readElfGlibcRequires`, `compareGlibcVersions`), and the rule that holds the declaration against
+it is `prebuild-libc`'s Check B, selected by `scripts/audit-runtimes.mjs` and therefore already
+part of a required check. An ADR is a decision record, so the wrong claim is corrected here
+rather than deleted: a reader who took stage 1 as "the separable one, start there" would have
+rebuilt a rule that has been gating the tree for two weeks.
 
 ### 8. `gjsify flatpak` migrates under `gjsify ship`
 
@@ -240,7 +248,8 @@ who holds the Developer ID and the Authenticode certificate, and whether CI may 
 Staged, each stage independently useful and independently mergeable:
 
 1. **ELF glibc floor** + a `@gjsify/manifest-conformance` rule holding `gjsify.glibcRequires`
-   against the binary. Needs nothing else here (§ 7).
+   against the binary (§ 7). Already landed when this ADR was written — see § Implementation
+   status. The numbering is kept so stages 2–7 keep the numbers other documents cite.
 2. **The payload and the Linux layout** — `gjsify ship --stage` producing the tree and nothing
    else, proven by an e2e suite that inspects it.
 3. **deb + rpm**, plus the dependency derivation of § 6, with an e2e suite that installs the
@@ -261,14 +270,19 @@ Follow-up work lands in `status/open-todos.md` per governance; this ADR records 
 `-qpl`, `-qp --requires`, `-qp --scripts`, `-i --test`, `rpm2cpio | cpio -it`), GNU `ar` and GNU
 `tar`.
 
-**Stage 1 (the ELF glibc floor) is still OPEN**, and is now a smaller job than the ADR assumed: the
-reader it needs already exists — `@gjsify/manifest-conformance`'s `binary.mjs` exports
-`readElfNeeded`, `readElfGlibcRequires` and `compareGlibcVersions` — so what is missing is only the
-rule that holds `gjsify.glibcRequires` against the binary. It stayed out of this change because it
-is about the PLATFORM packages' declarations, not about `ship`: a `--app gjs` payload contains no
-ELF at all, so nothing here can exercise it. The `ship` rule added instead
-(`manifest-conformance/lib/rules/ship.mjs`) is what keeps `gjsify.ship` from being a fifth
-unchecked declaration.
+**Stage 1 (the ELF glibc floor) was already landed when this ADR was written**, and this paragraph
+previously said the opposite. Both halves are in the tree and have been since 2026-08-01,
+`7896c51b02` (#897): the reader is `@gjsify/manifest-conformance`'s `binary.mjs`
+(`readElfNeeded`, `readElfGlibcRequires`, `compareGlibcVersions`), and the rule holding
+`gjsify.glibcRequires` against it is `lib/rules/prebuild-libc.mjs` Check B, which fails a
+package whose committed artifacts outgrow their declared floor and, separately, one that
+measures a floor it never declared. `scripts/audit-runtimes.mjs` selects `prebuild-libc`, so it
+runs inside `Detect runtime-triplet drift` — a required check.
+
+Stage 1 is nonetheless correctly numbered *outside* `ship`: it is about the PLATFORM packages'
+declarations, and a `--app gjs` payload contains no ELF at all, so nothing in `ship` can
+exercise it. The `ship` rule added here (`manifest-conformance/lib/rules/ship.mjs`) is what
+keeps `gjsify.ship` from being a fifth unchecked declaration.
 
 **Four things the ADR left open, and how they were settled.**
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -686,30 +686,6 @@ The L1 `GObject.registerClass` no longer does: an entry `signalSpecToNative` can
 
 `node packages/infra/cli/scripts/generate-register-closure.mjs` (`--check` reports staleness). A stale map is fail-soft — builds stay correct but pay extra `--globals auto` analysis passes. (The related hazard — the committed CLI bundle inlining a stale map — is closed: `.githooks/pre-commit` triggers on `packages/infra/resolve-npm/lib/` and `packages/infra/rolldown-plugin-gjsify/src/`.)
 
-### `gjsify onboard` for `@gjsify/gtk-runtime-darwin-x64` — required before the release that ships it
-
-npm Trusted Publishing (OIDC) cannot CREATE a package, only publish new versions of an existing
-one, so the new name needs a one-time manual first publish + Trusted Publisher from a maintainer
-machine BEFORE `release.yml`'s `publish-gtk-runtime-darwin` matrix runs its `x64` leg. An
-unbootstrapped name 404s the OIDC exchange and stalls every alphabetically-later package (the
-v0.4.20 `@gjsify/tls-native` incident: 60+ packages stuck). One command:
-`gjsify onboard` (whoami-gated login, per-package state probe, publishes + trusts only the gaps,
-ONE shared OTP). The package itself, its builder and both CI chains are in place.
-
-### `gjsify onboard` for the three `@gjsify/webkit-native*` names — required before the release that ships them
-
-Same mechanism as the `gtk-runtime-darwin-x64` entry above, three names at once: `@gjsify/webkit-native`, `@gjsify/webkit-native-darwin-x64` and `@gjsify/webkit-native-darwin-arm64` are all published (none is `private`), all new as of ADR 0022, and none exists on npm. Trusted Publishing cannot CREATE a package, so an unbootstrapped name 404s the OIDC exchange and stalls every alphabetically-later package — the v0.4.20 incident left 60+ at 0.4.19, and `webkit-*` sits ahead of `websocket`, `webstorage` and `xmlhttprequest`. One `gjsify onboard` run covers all three (it probes per package and publishes only the gaps, one shared OTP).
-
-### `gjsify onboard` for `@gjsify/example-dom-three-loader-ldraw` — required before the release that ships it
-
-Same mechanism as the two entries above, one name. The LDraw viewer moved from
-`examples/` to `showcases/` and lost its `"private": true` in the process, so the
-publish sweep now includes it and the name does not exist on npm. It sorts
-between `example-dom-three-geometry-teapot` and
-`example-dom-three-postprocessing-pixel`, i.e. an unbootstrapped name would stall
-both the pixel showcase and every `@gjsify/*` after it. One `gjsify onboard` run
-covers it.
-
 ### `@gjsify/webgl` renders on darwin-x64, but no WebGL2 CONTENT can
 
 First rendering proof on darwin, measured 2026-08-03 on the Intel macOS 15.7.8 test VM
@@ -1556,19 +1532,6 @@ repository has the same "valac does not run on Windows" problem, and
 `prebuilt_vala_c` is a per-package option today rather than a shared mechanism.
 Lifting it is premature until a second bridge wants it — but the second one is
 where the helper gets lifted, not the third.
-
-### `gjsify onboard` for `@gjsify/webgl-win32-x64` — required before the release that ships it
-
-Same mechanism as the `gtk-runtime-darwin-x64` entry above. The name is new as of
-the win32 promotion, is not `private`, and does not exist on npm; Trusted
-Publishing (OIDC) cannot CREATE a package, so an unbootstrapped name 404s the
-exchange and stalls every alphabetically-later package (the v0.4.20 incident left
-60+ at 0.4.19, and `webgl-win32-x64` sits ahead of `webkit-*`, `websocket`,
-`webstorage` and `xmlhttprequest`). One `gjsify onboard` run covers it. Until it
-is bootstrapped the target is honestly declared and honestly unshipped: the
-package carries a `gjsify.platformsUncommitted` exemption that
-`clear-committed-platform-exemptions.mjs` drops the moment `commit-prebuilds`
-lands the directory.
 
 ### `win32-arm64` is blocked UPSTREAM, not on effort — measured
 


### PR DESCRIPTION
Four kinds of stale claim, each disproved by a command rather than by reading.

## `status/open-todos.md` — four `gjsify onboard` sections

Each says its npm name "does not exist on npm" and blocks the next release. All are published:

| name | `npm view … version` |
|---|---|
| `@gjsify/gtk-runtime-darwin-x64` | 0.39.0 |
| `@gjsify/webkit-native{,-darwin-x64,-darwin-arm64}` | 0.39.0 |
| `@gjsify/example-dom-three-loader-ldraw` | 0.39.0 |
| `@gjsify/webgl-win32-x64` | 0.39.0 |

The webgl entry additionally described a live `gjsify.platformsUncommitted` exemption; no `package.json` carries one for that package any more, and `packages/framework/webgl-win32-x64/prebuilds/win32-x64/` is committed.

Deleted rather than struck through, per the file's own header: *"A RESOLVED item is DELETED (its record is the commit + CHANGELOG that closed it)"*.

## `release.yml` — four `MAINTAINER ACTION` banners

Same names plus `@gjsify/napi`, `@gjsify/napi-linux-x64`, `@gjsify/napi-darwin-arm64` and `gtk-runtime-win32-x64`. One still asserted that `curl https://registry.npmjs.org/@gjsify/napi` 404s; it is 0.39.0. These were action items, not rules — the mechanism they explain stays in `docs/publishing.md` and `AGENTS.md`.

## ADR 0024 § 7 — corrected, not deleted

The ADR describes `gjsify.glibcRequires` as authored-and-unchecked and lists the ELF floor as *"separable and should not wait for the rest"*, stage 1 to start with. Both halves landed **two weeks before the ADR was accepted**, in `7896c51b02` (#897):

- reader — `packages/infra/manifest-conformance/lib/binary.mjs`: `readElfNeeded`, `readElfGlibcRequires`, `compareGlibcVersions`
- rule — `lib/rules/prebuild-libc.mjs` **Check B**, *"the measured glibc floor against the declaration"*
- selected by `scripts/audit-runtimes.mjs`, so it runs inside `Detect runtime-triplet drift` — a required check

An ADR is a record, so § 7 keeps its claim and carries a dated correction beneath it. Someone taking the ADR's advice ("start with the separable one") would have rebuilt a gate that has been holding the tree for two weeks.

## Closes

- Closes #1016 — `scripts/manifest-conformance/prebuild-gir-gaps.mjs` is deleted (`1c2be62f2e`, #1153); `scripts/clear-satisfied-gir-gaps.mjs` carries the recreate recipe the issue asked for.
- Closes #1045 — `release-cut.yml:48` declares the `runtime` input and forwards it to `release.yml`; both call `bootstrap-cold-tree.sh "${{ inputs.runtime || 'node' }}"`.
- Closes #1057 — `prebuilds.yml:405` carries `--disablerepo=fedora-cisco-openh264`, with its rationale at :391.

## Verification

`node scripts/generate-status.mjs` exits 0 — that runs both the corpse check and the dangling-anchor check. No `open-todos:` anchor in the tree names a deleted heading (checked: the surviving anchors are *logSignals has no test*, *10 small API gaps*, *Nine fixtures re-implement*). `release.yml` still parses, 12 jobs.