### PR TITLE
ci: retire the two bootstrap bridges

### DIFF
--- a/.github/workflows/macos-suites.yml
+++ b/.github/workflows/macos-suites.yml
@@ -203,29 +203,18 @@ jobs:
       - name: Install the workspace
         run: node "$RUNNER_TEMP/bootstrap-cli/node_modules/@gjsify/cli/lib/index.js" install --immutable
 
+      # This step used to carry an `env:` bridge — `GJSIFY_SHIM_DIR` plus
+      # `npm_config_user_agent=gjsify/bootstrap` — because `build:infra` is a
+      # compound script whose every clause is a nested `gjsify` resolved from
+      # PATH, where the install above has just put the tree's OWN not-yet-built
+      # shim. The published CLI now repairs that itself (`ensureGjsifyShimOnPath`
+      # covers a bootstrap CLI under Node, and `detectPackageManager()` returns
+      # `gjsify` for it so npm cannot re-prepend `node_modules/.bin` one level
+      # down). The bridge's own retirement condition was `latest > 0.30.0`; it is
+      # 0.39.0, and the fix is in the SHIPPED tarball, not merely in this tree.
+      # Removing it is not tidying: while it stood, a green leg here proved the
+      # workaround rather than the fix.
       - name: Bootstrap the toolchain
-        env:
-          # THE BOOTSTRAP BRIDGE — both variables retire together the moment a
-          # CLI carrying `usingSelfShim()` (>0.30.0) is `latest` on npm; the CLI
-          # then does this for itself and this `env:` block is deletable.
-          #
-          # `build:infra` is a compound script whose every clause is a nested
-          # `gjsify`, resolved from PATH — where the install above has just put
-          # the tree's OWN `node_modules/.bin/gjsify`, which dispatches to the
-          # build outputs this step is what produces. Two levers the published
-          # CLI already honours make it reach a CLI that exists instead:
-          #   GJSIFY_SHIM_DIR       is unshifted ahead of `node_modules/.bin`
-          #                         when the CLI runs a script;
-          #   npm_config_user_agent `gjsify/` makes it run package scripts
-          #                         ITSELF rather than delegating to npm, which
-          #                         re-prepends `node_modules/.bin` for every
-          #                         lifecycle script and would undo the first
-          #                         lever one level down.
-          # Both measured against the published 0.30.0 on a cold Linux tree with
-          # the build cache cleared: without them `build:infra` dies on its first
-          # clause with `Cannot find module …/packages/infra/cli/lib/index.js`.
-          GJSIFY_SHIM_DIR: ${{ runner.temp }}/bootstrap-cli/node_modules/.bin
-          npm_config_user_agent: gjsify/bootstrap
         run: node "$RUNNER_TEMP/bootstrap-cli/node_modules/@gjsify/cli/lib/index.js" run build:infra
 
       # `test:node` and `test:gjs` both only RUN a bundle; the bundle has to

--- a/.github/workflows/windows-suites.yml
+++ b/.github/workflows/windows-suites.yml
@@ -174,32 +174,21 @@ jobs:
       - name: Install the workspace
         run: node "%RUNNER_TEMP%\bootstrap-cli\node_modules\@gjsify\cli\lib\index.js" install --immutable
 
+      # This step used to carry an `env:` bridge — `GJSIFY_SHIM_DIR` plus
+      # `npm_config_user_agent=gjsify/bootstrap` — pointing PATH at npm's own
+      # `.bin` because `build:infra`'s nested `gjsify` clauses would otherwise
+      # resolve to the tree's not-yet-built shim. The published CLI now does
+      # that itself, and its retirement condition (`latest > 0.30.0`) is met at
+      # 0.39.0 with the fix in the SHIPPED tarball.
+      #
+      # WATCH THIS LEG SPECIFICALLY on the first run without the bridge. Windows
+      # is where the removal is a real test rather than a formality: the bridge
+      # always pointed at npm's shim trio, so the `.cmd`/`.ps1` pair that
+      # `buildLauncherShims` writes has never been exercised by
+      # `%COMSPEC%`/PATHEXT here.
+      # A red here is a CLI bug in `utils/bin-shim.ts`, not a reason to restore
+      # the `env:` block — restoring it would only re-hide the same gap.
       - name: Bootstrap the toolchain
-        env:
-          # THE BOOTSTRAP BRIDGE — both variables retire together the moment a
-          # CLI carrying `usingSelfShim()` (>0.30.0) is `latest` on npm; the CLI
-          # then does this for itself and this `env:` block is deletable.
-          #
-          # `build:infra` is a compound script whose every clause is a nested
-          # `gjsify`, resolved from PATH — where the install above has just put
-          # the tree's OWN `node_modules\.bin\gjsify.cmd`, which dispatches to
-          # the build outputs this step is what produces. Two levers the
-          # published CLI already honours make it reach a CLI that exists:
-          #   GJSIFY_SHIM_DIR       is unshifted ahead of `node_modules\.bin`
-          #                         when the CLI runs a script;
-          #   npm_config_user_agent `gjsify/` makes it run package scripts
-          #                         ITSELF rather than delegating to npm, which
-          #                         re-prepends `node_modules\.bin` for every
-          #                         lifecycle script and would undo the first
-          #                         lever one level down.
-          # Measured against the published 0.30.0 on a cold tree with the build
-          # cache cleared: without them `build:infra` dies on its first clause
-          # with `Cannot find module …\packages\infra\cli\lib\index.js`. That
-          # measurement was taken on LINUX — the mechanism is the package
-          # manager's PATH handling, not the OS — so what this leg adds is the
-          # `.cmd` half: npm's shim trio is what `%COMSPEC%` can actually run.
-          GJSIFY_SHIM_DIR: ${{ runner.temp }}\bootstrap-cli\node_modules\.bin
-          npm_config_user_agent: gjsify/bootstrap
         run: node "%RUNNER_TEMP%\bootstrap-cli\node_modules\@gjsify\cli\lib\index.js" run build:infra
 
       # `test:node` is only `node test.node.mjs` — it BUILDS nothing. The

--- a/packages/infra/cli/src/cli-app.ts
+++ b/packages/infra/cli/src/cli-app.ts
@@ -101,10 +101,13 @@ function runtimeLabel(): string {
  * exit before any async work runs.
  */
 export async function runCli(argv: readonly string[]): Promise<void> {
-    // Under GJS, make a GJS-runnable `gjsify` available on PATH for child
-    // processes (workspace/foreach orchestration + compound `gjsify run`
-    // scripts) so node-free builds don't fall back to the Node bin. No-op on
-    // Node.
+    // Make a runnable `gjsify` available on PATH for child processes
+    // (workspace/foreach orchestration + compound `gjsify run` scripts). TWO
+    // cases, not one — the "No-op on Node" this comment used to claim stopped
+    // being true when the bootstrap case landed: under GJS, so node-free builds
+    // don't fall back to the Node bin; and a BOOTSTRAP CLI under Node, where the
+    // tree's own `node_modules/.bin/gjsify` dangles until `build:infra` — which
+    // is what a cold macOS/Windows leg runs — has produced what it dispatches to.
     ensureGjsifyShimOnPath();
     const cli = yargs(argv as string[]);
     await cli

--- a/packages/infra/cli/src/commands/foreach.ts
+++ b/packages/infra/cli/src/commands/foreach.ts
@@ -26,7 +26,12 @@ import { findWorkspaceRoot } from '../utils/workspace-root.js';
 import { cliRuntimeClosure } from '../utils/cli-runtime-closure.js';
 import { prefixLines } from '../utils/prefixed-output.js';
 import { BuildCacheRunner, buildCacheEnabledByEnv } from '../utils/build-cache.js';
-import { isGjs } from '@gjsify/rolldown-plugin-gjsify/runtime';
+// The ONE runner-selection rule, shared rather than re-derived. This file used to
+// carry its own copy; `workspace.ts` grew the bootstrap-CLI branch and the copy
+// here did not, so a `gjsify foreach` reached from a cold-tree bootstrap would
+// have delegated to npm and lost the shim one level down — silently, and only on
+// the OS legs that bootstrap cold. `onboard.ts` already imports it from here.
+import { detectPackageManager } from './workspace.js';
 
 // Every child spawned by spawnPrefixed registers here so fail-fast can
 // terminate the whole in-flight set instead of waiting on it. On CI a
@@ -844,20 +849,6 @@ async function runOne(
     }
     await spawnPrefixed(runner, argv, ws.location, prefixOutput ? `[${ws.name}] ` : null);
     if (cache && before) cache.storeAfterSuccess(ws, before);
-}
-
-function detectPackageManager(): 'yarn' | 'npm' | 'gjsify' {
-    // Under GJS there is no Node — neither `npm` nor `yarn` can run scripts, so
-    // the runner is `gjsify` itself via the GJS shim on PATH
-    // (`ensureGjsifyShimOnPath`). Makes node-free `gjsify foreach` work.
-    if (isGjs()) return 'gjsify';
-    // `npm_config_user_agent` is set by npm/yarn/pnpm — first token is
-    // `<name>/<version>`. Reuse it so `gjsify foreach build` invoked
-    // through `yarn run` keeps using yarn, etc.
-    const ua = process.env.npm_config_user_agent ?? '';
-    if (ua.startsWith('yarn/')) return 'yarn';
-    if (ua.startsWith('gjsify/')) return 'gjsify';
-    return 'npm';
 }
 
 async function spawnPrefixed(cmd: string, args: readonly string[], cwd: string, prefix: string | null): Promise<void> {

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -77,34 +77,6 @@ they were deliberately left out of the binding fix rather than bundled into it.
 None of the three is reachable from `postbote`'s index today, which is why the binding fix
 did not wait for them.
 
-### The macOS/Windows cold-tree bootstrap still needs a two-variable bridge in the workflow
-
-`macos-suites.yml` and `windows-suites.yml` bootstrap from the PUBLISHED CLI,
-because ADR 0002 untracked both bundles and a cold tree therefore has no CLI of
-its own. After `install --immutable` the tree DOES have
-`node_modules/.bin/gjsify`, and it dispatches to build outputs that
-`build:infra` is what produces — so the first nested `gjsify` inside that
-compound script dies with `Cannot find module …/packages/infra/cli/lib/index.js`.
-
-Fixed at the core for the NEXT release: `ensureGjsifyShimOnPath()` now also
-covers a bootstrap CLI under Node (not only the node-free GJS case), and
-`detectPackageManager()` returns `gjsify` for it — the second half matters
-because npm re-prepends `node_modules/.bin` for every lifecycle script it
-starts, which puts the dead shim back one level down and undoes the first half.
-Measured on a cold Linux worktree with the build cache cleared: `build:infra`
-exits 0 with the fixed CLI and fails on its first clause without it.
-
-Until that CLI is `latest` on npm the two legs set `GJSIFY_SHIM_DIR` and
-`npm_config_user_agent=gjsify/bootstrap`, the two levers the published 0.30.0
-already honours (`lib/commands/run.js` unshifts the first; `lib/commands/
-workspace.js` reads the second). **RETIREMENT TRIGGER: delete both `env:` blocks
-once `npm view @gjsify/cli version` is >0.30.0** — they are inert from that
-point, not merely redundant, and leaving them hides whether the core fix works.
-
-Linux never needed either lever: its bootstrap runs the published GJS bundle,
-where `detectPackageManager()` already returns `gjsify`. That is also why a
-Linux-only pipeline could not see this — the same shape ADR 0018 § 5 predicts.
-
 ### `pathToFileURL` does not resolve a RELATIVE win32 path against the current drive
 
 Left over from the #1143 fix, which closed the win32 ABSOLUTE paths (drive-letter and


### PR DESCRIPTION
The retirement trigger fired. `status/open-todos.md` wrote the condition in advance:

> **RETIREMENT TRIGGER: delete both `env:` blocks once `npm view @gjsify/cli version` is >0.30.0** — they are inert from that point, not merely redundant, and **leaving them hides whether the core fix works**.

`npm view @gjsify/cli version` → **0.39.0**.

## The bridge, and why it is inert

`macos-suites.yml` and `windows-suites.yml` bootstrap from the published CLI (ADR 0002 untracked both bundles, so a cold tree has none). After `install --immutable` the tree *does* have `node_modules/.bin/gjsify` — pointing at the build outputs `build:infra` is what produces. So the first nested `gjsify` in that compound script died with `Cannot find module …/packages/infra/cli/lib/index.js`, and the two legs set `GJSIFY_SHIM_DIR` + `npm_config_user_agent=gjsify/bootstrap` to route around it.

The CLI now does that for itself, and I checked the **shipped tarball** rather than this tree:

```
$ npm pack @gjsify/cli@latest && tar xzf gjsify-cli-0.39.0.tgz
$ grep -rn 'usingSelfShim' package/lib/
package/lib/utils/gjsify-shim.js:61:export function usingSelfShim() {
package/lib/commands/workspace.js:27:import { usingSelfShim } from '../utils/gjsify-shim.js';
package/lib/commands/workspace.js:293:    if (usingSelfShim()) return 'gjsify';
```

Both halves matter, and both are there: `ensureGjsifyShimOnPath()` covers a bootstrap CLI under Node, and `detectPackageManager()` returns `gjsify` for it — the second half is what stops npm re-prepending `node_modules/.bin` for every lifecycle script and undoing the first one level down. `build:infra` is nothing but `gjsify workspace …` clauses plus one `node scripts/…`, so that is the entire path.

## Two things found beside it

**`foreach.ts` carried its own copy of `detectPackageManager()`** — and the copy is where the drift landed. `workspace.ts` grew the bootstrap-CLI branch; this one did not. A future `gjsify foreach` reached from a cold-tree bootstrap would have delegated to npm and lost the shim one level down, silently, and only on the OS legs that bootstrap cold. Deleted in favour of the shared export `onboard.ts` already imports. The second copy is where you lift, not where you patch.

**`cli-app.ts` documented `ensureGjsifyShimOnPath()` as "No-op on Node"** — which stopped being true when the bootstrap case landed. The comment described the behaviour this whole change depends on, backwards.

## Verified locally

- `gjsify workspace @gjsify/cli check` → exit 0
- `gjsify workspace @gjsify/cli build` → exit 0
- `gjsify lint` → 0 errors · `gjsify format --check` → clean, 2956 files
- `gjsify foreach check --include '@gjsify/semver'` → exit 0, i.e. `foreach` still resolves a runner and runs a package script through the shared function

## Watch the Windows leg

This is the half where removal is a real test rather than a formality. The bridge always pointed PATH at **npm's** shim trio, so the `.cmd`/`.ps1` pair `buildLauncherShims` writes has never been exercised by `%COMSPEC%`/PATHEXT on this leg.

**A red there is a bug in `packages/infra/cli/src/utils/bin-shim.ts`, not a reason to restore the `env:` block** — restoring it would only re-hide the gap the removal exists to expose.

Both workflows self-trigger on their own file via `pull_request.paths`, so this PR dispatches both legs by itself.