### PR TITLE
ci: give each landed run a group of its own

### DIFF
--- a/.github/workflows/macos-suites.yml
+++ b/.github/workflows/macos-suites.yml
@@ -82,7 +82,7 @@ on:
       - '.github/workflows/macos-suites.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('macos-suites-pr-{0}', github.ref) || format('macos-suites-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,25 @@ on:
 # GitHub keeps one pending run per group. Measured 2026-08-14: the push run for
 # the #1170 merge sat pending behind a main run from 34 minutes earlier, a
 # `workflow_dispatch` on main joined the group, and the push run was cancelled 3 s
-# later with zero jobs ever started. So a LANDED COMMIT CAN END UP WITH NO RUN OF
-# ITS OWN, and the run list shows `cancelled`, which reads as noise rather than as
-# a gap. Before trusting "main is green", check that a run exists for main's
-# CURRENT sha — `gh run list --commit $(git rev-parse origin/main)` — rather than
-# reading the newest green run on the branch.
+# later with zero jobs ever started. So a LANDED COMMIT COULD END UP WITH NO RUN
+# OF ITS OWN, and the run list showed `cancelled`, which reads as noise rather
+# than as a gap. Until this is confirmed fixed, that gap is still detectable the
+# way it was found: `gh run list --commit $(git rev-parse origin/main)` shows
+# whether main's CURRENT sha has a run at all, which reading the newest green run
+# on the branch does not.
+#
+# Which is why the group key is now PER-RUN off a PR. Eviction is a property of
+# the group, so the fix is to stop putting independent runs in one. `github.sha`
+# is NOT enough and was the first attempt: in all four eviction pairs on record
+# the push and the `workflow_dispatch` are the SAME commit, so keying on the sha
+# leaves them competing exactly as before. `github.run_id` is unique per run, so
+# nothing off a PR ever shares a group. Same construction as `prebuilds.yml`,
+# which has keyed it this way all along.
+#
+# Pull requests deliberately keep the branch-wide key — there, superseding IS the
+# wanted behaviour, and `cancel-in-progress` above is what performs it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('main-pr-{0}', github.ref) || format('main-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Package lists shared between the job that BUILDS a bundle and the job that

--- a/.github/workflows/napi.yml
+++ b/.github/workflows/napi.yml
@@ -41,8 +41,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: napi-${{ github.ref }}
-  cancel-in-progress: true
+  # Per-RUN off a PR, so no two runs share a group and none can evict another while
+  # pending. `main.yml` carries the measured incident and why the sha is not enough.
+  group: ${{ github.event_name == 'pull_request' && format('napi-pr-{0}', github.ref) || format('napi-{0}', github.run_id) }}
+  # Was an unconditional `true` — the only one in the repo; every other workflow
+  # scopes it to `pull_request`. So a push to main KILLED the in-flight napi run of
+  # the commit before it, and what went uncovered is what nothing else covers
+  # (`packages/napi` is not a workspace member). PRs supersede their own runs; a
+  # landed commit finishes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # The pinned refs/node revision the conformance addon sources + committed
 # goldens are generated from. MUST match the refs/node submodule gitlink so the

--- a/.github/workflows/node-gi.yml
+++ b/.github/workflows/node-gi.yml
@@ -62,12 +62,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: node-gi-${{ github.ref }}
+  # Per-RUN off a PR, so no two runs share a group and none can evict another while
+  # pending. `main.yml` carries the measured incident and why the sha is not enough.
+  group: ${{ github.event_name == 'pull_request' && format('node-gi-pr-{0}', github.ref) || format('node-gi-{0}', github.run_id) }}
   # PRs cancel their own superseded runs; main pushes and the nightly complete on
-  # their own. `main.yml` carries the measured incident behind the expression — a
-  # still-PENDING run is evicted when a newer run joins the group, so a landed
-  # commit can end up with no run at all — and widening the trigger above puts
-  # more main pushes in this group, which is what made the difference matter here.
+  # their own.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/windows-suites.yml
+++ b/.github/workflows/windows-suites.yml
@@ -78,7 +78,7 @@ on:
       - '.github/workflows/windows-suites.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name == 'pull_request' && format('windows-suites-pr-{0}', github.ref) || format('windows-suites-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
A landed commit could end up with **no CI run of its own**, and the run list showed `cancelled` — which reads as noise rather than as a gap.

### The mechanism

`concurrency.group` keyed on `github.ref` puts every main push in one group, and GitHub keeps a single **pending** run per group. A newer run therefore evicts a queued one *whatever `cancel-in-progress` says* — that setting governs in-progress runs only.

Already measured and written down in `main.yml` (2026-08-14): the push run for the #1170 merge sat pending behind a main run from 34 minutes earlier, a `workflow_dispatch` joined the group, and the push run was cancelled 3 s later having started zero jobs. The comment then told the reader to check `gh run list --commit` before trusting "main is green". A procedure a human has to remember is not a fix.

### Per-RUN, not per-sha

The first draft of this PR keyed the group on `github.sha`. **Self-review measured that it would not have prevented the recorded incident**: in all four eviction pairs on record, the push and the `workflow_dispatch` are the *same commit*, so a sha key leaves them in one group competing exactly as before.

`github.run_id` is unique per run, so nothing off a PR ever shares a group:

```yaml
group: ${{ github.event_name == 'pull_request' && format('main-pr-{0}', github.ref) || format('main-{0}', github.run_id) }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Pull requests keep the branch-wide key deliberately — there, superseding *is* the wanted behaviour.

`prebuilds.yml` has keyed it this way all along, so this is neither a new idea nor a new spelling: the five workflows adopt its exact expression. `deploy-docs.yml` (Pages must serialize) and `release-cut.yml` (one global lock) stay deliberately different.

The detection procedure stays in the comment rather than being deleted along with the symptom — nothing *inside* a main.yml run can report that run's own absence.

### napi.yml had a second, separate defect

`cancel-in-progress: true`, unconditional — the only one in the repo. A push to main **killed the in-flight napi run of the commit before it**, and `packages/napi` is not a workspace member, so no other workflow covers what that run proves.

### Cost, stated rather than assumed

Roughly **+12 main.yml, +5 macos-suites, +4 windows-suites** runs over the visible window — runs that previously evicted each other — and peak concurrency during a burst goes from 1 to N. That is the price of every landed commit having a verdict, and those two OS suites are exactly where the evictions happened, so they are not candidates for keeping the old key.

### Validation

`check-workflow-run-syntax.mjs` ✅ (428 run blocks) · `check-workflow-inline-scripts.mjs` ✅ (14 workflows clean) · every `concurrency:` block re-read through a YAML parser: each expression parses and yields a non-empty key for every event type.

### Adjacent, deliberately not in this PR

`check-workflow-run-syntax.mjs` reports `52 non-bash block(s) skipped` — its `BASH_LIKE` set excludes `pwsh`, so **51 PowerShell blocks are never syntax-checked**, 11 of them in `release.yml`, the file whose truncated inline script half-published v0.28.0.

Left out on purpose: `pwsh` is not installed on the machine this was written on, so a checker for it could not be exercised here, and a guard that silently skips where its interpreter is absent is the failure mode this repository has paid for most. It wants a change that can prove it runs — a separate PR, with the CI image's `pwsh` availability established first.