### PR TITLE
ci: read the PowerShell blocks too, where a parser exists

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -131,6 +131,11 @@ jobs:
       # a truncated program, and v0.38.0 was cut, tagged and released without ever being
       # dispatched to npm. The release dry run cannot cover it either — that step is the
       # one thing a dry run skips. `bash -n` on every extracted block does, in milliseconds.
+      # It also NAMES the blocks no interpreter on this host can read, instead of
+      # counting them. "52 non-bash block(s) skipped" read as housekeeping and hid that
+      # every PowerShell block in `release.yml` is unread — on a workflow that has no
+      # `pull_request` trigger, which is the same structural hole the incident above
+      # came through. The Windows job below closes it.
       - name: Check every workflow `run:` block is valid shell
         run: node scripts/check-workflow-run-syntax.mjs
 
@@ -633,3 +638,26 @@ jobs:
       # the filter had shipped, with e2e coverage proving the filter itself worked.
       - name: Check the tracked lockfile carries current platform data
         run: node scripts/check-lockfile-current.mjs
+
+      # PowerShell's own parser, on the one host in this repo that has one.
+      #
+      # IN *THIS* WORKFLOW ON PURPOSE. `windows-suites.yml`, `napi.yml` and
+      # `prebuilds.yml` all have Windows runners, and all three filter `pull_request`
+      # by path — so a PR editing `release.yml`'s PowerShell would run none of them.
+      # `audit-runtimes.yml` runs on EVERY pull request with no paths filter, which is
+      # the property this check needs and the reason it is not next to the other
+      # Windows work. It is a step in the existing job rather than a job of its own:
+      # a second windows-latest runner would buy nothing.
+      #
+      # `release.yml` carries 11 of these blocks and has no `pull_request` trigger at
+      # all, so before this step their first execution was DURING a release — the same
+      # condition that let the v0.28.0 quote truncation through, one layer up.
+      #
+      # Parse-only, via `[Parser]::ParseFile`: the same front end that would reject the
+      # script at step start, and it only ever reads. `--require-pwsh` makes a missing
+      # interpreter FATAL, because without it the one leg that exists to read
+      # PowerShell would report green by skipping all of it. The script also self-tests
+      # its detector against a broken and a valid snippet, so a parser that accepted
+      # everything cannot pass either.
+      - name: Check every workflow `run:` block is valid PowerShell
+        run: node scripts/check-workflow-run-syntax.mjs --require-pwsh

--- a/scripts/check-workflow-run-syntax.mjs
+++ b/scripts/check-workflow-run-syntax.mjs
@@ -44,8 +44,45 @@ const ROOT = rootIndex === -1 ? join(dirname(fileURLToPath(import.meta.url)), '.
 const GHA_EXPR = /\$\{\{[^}]*\}\}/g;
 const EXPR_PLACEHOLDER = 'GHA_EXPR';
 
-/** Shells `bash -n` can speak for. `pwsh`/`python` blocks are someone else's grammar. */
+/** Shells `bash -n` can speak for. `python` blocks are someone else's grammar. */
 const BASH_LIKE = new Set([undefined, 'bash', 'sh', 'bash -e {0}', 'bash --noprofile --norc -eo pipefail {0}']);
+
+/** Shells PowerShell's own parser can speak for. */
+const PWSH_LIKE = new Set(['pwsh', 'powershell', 'pwsh -Command {0}', 'pwsh -File {0}']);
+
+/**
+ * Parse a PowerShell script WITHOUT running it.
+ *
+ * `[Parser]::ParseFile` is PowerShell's own front end — the same one that would reject the
+ * script at step start — and it only ever reads. There is no `-WhatIf`-style half-execution
+ * here and no dot-sourcing: a syntax error comes back as a diagnostic, not as a side effect.
+ *
+ * Returns null when the script parses, or the first diagnostics when it does not.
+ */
+function pwshParse(scriptPath) {
+    const probe =
+        '$e = $null; ' +
+        `[System.Management.Automation.Language.Parser]::ParseFile('${scriptPath}', [ref]$null, [ref]$e) > $null; ` +
+        'if ($e.Count -gt 0) { $e | ForEach-Object { $_.Message } ; exit 1 } else { exit 0 }';
+    const r = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-Command', probe], { encoding: 'utf-8' });
+    if (r.error !== undefined || r.status === null)
+        return { message: `pwsh could not run: ${r.error?.message ?? 'no status'}` };
+    if (r.status === 0) return null;
+    return { message: (r.stdout || r.stderr || '').trim().split('\n').slice(0, 3).join(' / ') };
+}
+
+const HAVE_PWSH =
+    spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.Major'], {
+        encoding: 'utf-8',
+    }).status === 0;
+
+/**
+ * The detector must DISCRIMINATE, or a green run means nothing. Same construction as
+ * `check-changelog-references.mjs`: a shape that must be rejected and one that must be
+ * accepted, run on every invocation that has an interpreter to run them with.
+ */
+const PWSH_MUST_REJECT = ['if ($true) { Write-Output "unclosed"', 'foreach ($x in 1..3 { $x }'];
+const PWSH_MUST_ACCEPT = ['if ($true) { Write-Output "ok" }', '$a = @(1,2,3); $a | ForEach-Object { $_ * 2 }'];
 
 function workflowFiles() {
     const out = [];
@@ -142,15 +179,30 @@ function collectRunSteps(text) {
     return steps;
 }
 
+const REQUIRE_PWSH = process.argv.includes('--require-pwsh');
 const tmp = mkdtempSync(join(tmpdir(), 'gjsify-run-syntax-'));
 const failures = [];
 let checked = 0;
-let skipped = 0;
+let pwshChecked = 0;
+/** Blocks no interpreter here can speak for — NAMED, never counted. */
+const unparsed = [];
 
 for (const file of workflowFiles()) {
     for (const step of collectRunSteps(readFileSync(file, 'utf-8'))) {
+        if (PWSH_LIKE.has(step.shell)) {
+            if (!HAVE_PWSH) {
+                unparsed.push({ file, name: step.name, shell: step.shell });
+                continue;
+            }
+            const psPath = join(tmp, `step-${pwshChecked}.ps1`);
+            writeFileSync(psPath, step.run.replace(GHA_EXPR, EXPR_PLACEHOLDER));
+            const bad = pwshParse(psPath);
+            pwshChecked++;
+            if (bad) failures.push({ file, name: step.name, message: bad.message });
+            continue;
+        }
         if (!BASH_LIKE.has(step.shell)) {
-            skipped++;
+            unparsed.push({ file, name: step.name, shell: step.shell });
             continue;
         }
         const script = step.run.replace(GHA_EXPR, EXPR_PLACEHOLDER);
@@ -168,10 +220,58 @@ for (const file of workflowFiles()) {
     }
 }
 
+// The detector proves it still discriminates, on every run that can run it. A parser
+// that accepts everything reports the same green as one that works.
+if (HAVE_PWSH) {
+    const selfFailures = [];
+    for (const [i, src] of PWSH_MUST_REJECT.entries()) {
+        const f = join(tmp, `selftest-bad-${i}.ps1`);
+        writeFileSync(f, src);
+        if (!pwshParse(f)) selfFailures.push(`accepted a broken script: ${src}`);
+    }
+    for (const [i, src] of PWSH_MUST_ACCEPT.entries()) {
+        const f = join(tmp, `selftest-ok-${i}.ps1`);
+        writeFileSync(f, src);
+        const bad = pwshParse(f);
+        if (bad) selfFailures.push(`rejected a valid script: ${src} — ${bad.message}`);
+    }
+    if (selfFailures.length > 0) {
+        console.error('run-syntax: the PowerShell detector does not discriminate — a green run would mean nothing:');
+        for (const f of selfFailures) console.error(`  · ${f}`);
+        rmSync(tmp, { recursive: true, force: true });
+        process.exit(1);
+    }
+}
+
 rmSync(tmp, { recursive: true, force: true });
 
+// `--require-pwsh` is what a Windows leg passes. Without it this host reports what it
+// could not read; with it, being unable to read them IS the failure — otherwise the one
+// leg that exists to check PowerShell would pass by skipping all of it, which is the
+// shape this repository has paid for most.
+if (REQUIRE_PWSH && !HAVE_PWSH) {
+    console.error(
+        `run-syntax: --require-pwsh was passed and no \`pwsh\` is on PATH, so ${unparsed.length} ` +
+            'PowerShell block(s) went unread. This flag exists so that cannot pass quietly.',
+    );
+    process.exit(1);
+}
+
 if (failures.length === 0) {
-    console.log(`OK — ${checked} \`run:\` block(s) parse as shell (${skipped} non-bash block(s) skipped).`);
+    const parts = [`${checked} shell`];
+    if (pwshChecked > 0) parts.push(`${pwshChecked} PowerShell`);
+    console.log(`OK — ${parts.join(' + ')} \`run:\` block(s) parse.`);
+    if (unparsed.length > 0) {
+        // NAMED, not counted: a bare "52 skipped" reads as housekeeping, and it hid that
+        // every `release.yml` PowerShell block is unread on a workflow with no PR trigger.
+        const byFile = new Map();
+        for (const u of unparsed) {
+            const k = u.file.replace(`${ROOT}/`, '');
+            byFile.set(k, (byFile.get(k) ?? 0) + 1);
+        }
+        console.log('   not read by any interpreter on this host:');
+        for (const [f, n] of [...byFile].sort()) console.log(`     ${f}: ${n} block(s)`);
+    }
     process.exit(0);
 }
 


### PR DESCRIPTION
`check-workflow-run-syntax.mjs` ended every run with **"52 non-bash block(s) skipped"**. A count reads as housekeeping. Named per file, the same fact is a finding:

| workflow | pwsh blocks | `pull_request` trigger |
|---|---|---|
| `node-gi.yml` | 20 | yes, **unfiltered** |
| `napi.yml` | 10 | path-filtered |
| `prebuilds.yml` | 10 | path-filtered |
| `windows-suites.yml` | 1 | path-filtered |
| **`release.yml`** | **11** | **none at all** |

Only the last row is exposed. The other four either run on every PR anyway, or run whenever their own file is edited — so a broken block there fails a job someone is already watching. `release.yml`'s eleven had their first execution *during a release*.

That is the condition `check-workflow-inline-scripts.mjs` already records for the v0.28.0 truncation:

> It survived review twice because the quote is visually inert … and `release.yml` triggers on `release`/`workflow_dispatch` only, **so no PR ever ran it**.

### What this is *not*

The v0.28.0 defect was a shell-quote truncation in a `node -e '…'` body — already covered by its own check, and **not a PowerShell block**. An audit put those two facts next to each other and I carried the implication into a recommendation before checking it. They are not the same defect. What they share is the structural hole, and that is what this closes.

The measurement also shrank the target from "51 unchecked blocks" to **11 that matter**.

### The check

PowerShell blocks are parsed with PowerShell's own front end — `[System.Management.Automation.Language.Parser]::ParseFile`, parse-only, the same parser that would reject the script at step start.

Two things keep it from becoming a check that passes by doing nothing:

**`--require-pwsh` makes a missing interpreter fatal.** Verified on the Linux host this was written on, where `pwsh` is absent:

```
$ node scripts/check-workflow-run-syntax.mjs --require-pwsh
run-syntax: --require-pwsh was passed and no `pwsh` is on PATH, so 52 PowerShell
block(s) went unread. This flag exists so that cannot pass quietly.
$ echo $?
1
```

**The detector self-tests on every run that can run it** — two scripts that must be rejected, two that must be accepted. A parser that accepted everything would report the same green as one that works. Same construction as `check-changelog-references.mjs`'s `detector verified — N artefact shape(s) rejected`.

### Where it runs, and why there

In `audit-runtimes.yml`'s **existing** `check-windows` job.

`windows-suites.yml`, `napi.yml` and `prebuilds.yml` all have Windows runners — and all three filter `pull_request` by path, so a PR editing `release.yml`'s PowerShell would run **none** of them. Putting the check in any of them would be a guard without a trigger, which is the defect being fixed. `audit-runtimes.yml` is the one workflow that runs on every pull request unfiltered.

A step in the existing job rather than a job of its own: a second `windows-latest` runner would buy nothing.

`pwsh` is deliberately **not** added to `ci-fedora`. That image is built to hold exactly what `main.yml` installs, and its own header says a job needing something absent from it is a CI failure naming the package. The check belongs where the interpreter already is.

### Linux output, unchanged in behaviour

```
OK — 429 shell `run:` block(s) parse.
   not read by any interpreter on this host:
     .github/workflows/napi.yml: 10 block(s)
     .github/workflows/node-gi.yml: 20 block(s)
     .github/workflows/prebuilds.yml: 10 block(s)
     .github/workflows/release.yml: 11 block(s)
     .github/workflows/windows-suites.yml: 1 block(s)
```

### Validation

`check-workflow-run-syntax` ✅ · `--require-pwsh` correctly exits 1 without an interpreter ✅ · `check-workflow-inline-scripts` ✅ · `audit-runtimes --check` ✅ · `gjsify lint` ✅ · `format --check` ✅ · both jobs re-read through a YAML parser to confirm the step landed on `windows-latest` and the Ubuntu job is unchanged.

### Measured on the Windows leg of this PR

The first execution of the new path — I have no `pwsh` locally, which is precisely why the self-test and `--require-pwsh` are in it rather than a promise that it works. It ran:

```
shell: C:\Program Files\PowerShell\7\pwsh.EXE
OK — 429 shell + 51 PowerShell `run:` block(s) parse.
   not read by any interpreter on this host:
     prebuilds.yml: 1 block(s)
```

So all 51 PowerShell blocks parse, the self-test passed (it is fatal, so a green run means the detector still discriminates), and exactly one block remains unread anywhere — a `python` block in `prebuilds.yml`, named rather than counted.
