### PR TITLE
fix(gtk-runtime): declare the licence the tarball actually has

### DIFF
--- a/packages/infra/manifest-conformance/lib/index.mjs
+++ b/packages/infra/manifest-conformance/lib/index.mjs
@@ -79,6 +79,7 @@ export { osAxisRule, decidesOnOs, osDecisionSites, TARGET_OSES, OS_CLAIMS } from
 export { portableScriptsRule, unportableCommands } from './rules/portable-scripts.mjs';
 export { storybookRule, auditStorybook, countStoryFiles } from './rules/storybook.mjs';
 export { shipRule, auditShip } from './rules/ship.mjs';
+export { bundledLicenseRule, auditBundledLicense, collectBundlingPackages } from './rules/bundled-license.mjs';
 export {
     nativescriptPlatformsRule,
     auditNativescriptPlatforms,

--- a/packages/infra/manifest-conformance/lib/rules/bundled-license.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/bundled-license.mjs
@@ -1,0 +1,162 @@
+/**
+ * Rule `bundled-license` — a package that ships OTHER projects' binaries may not
+ * declare only its own licence.
+ *
+ * THE DEFECT. The three `@gjsify/gtk-runtime-*` packages each declared
+ * `"license": "MIT"` while their published tarball carries 37–45 relocated
+ * LGPL/MPL/GPL libraries — GTK, GLib, Pango, cairo, freetype, fontconfig,
+ * harfbuzz and the rest. MIT is the correct licence of the three source files in
+ * those packages and the wrong answer for the artifact npm hands a user.
+ *
+ * That mattered in a way a prose note could not fix. `bundle-licenses.mjs`
+ * already ships the licence TEXTS and a `THIRD-PARTY-NOTICES.md` that states
+ * plainly which half is which — but a licence scanner, an SBOM generator or a
+ * corporate policy gate reads `package.json#license` and nothing else. So the
+ * one machine-readable field said MIT-only about a tarball that is not, while
+ * everything a human would read was already correct.
+ *
+ * WHAT THIS CHECKS, and why it is shaped as a QUESTION rather than a list. The
+ * trigger is not a hard-coded package set — it is the same signal the licence
+ * bundler keys on: a package whose `files` ship a payload directory built from a
+ * third-party prefix. Hard-coding the three names would pass the day a fourth
+ * bundle is added, which is the failure mode this rule exists to prevent.
+ *
+ * The accepted answer is deliberately NOT a specific SPDX expression:
+ *
+ *   • On darwin the attribution is exact — every bundled dylib resolves into a
+ *     Homebrew keg, and `parseBrewLicenseStanza()` reads the terms out of the
+ *     keg's own formula. An expression is derivable there.
+ *   • On win32 it is NOT. The gvsbuild prefix is one flat `bin/`, the VERSIONINFO
+ *     resource is present in some DLLs and absent in others, and the builder says
+ *     so itself. An expression there would be a GUESS — and a guessed licence
+ *     expression is worse than an incomplete one, because it makes a specific
+ *     false claim instead of an unspecific one.
+ *
+ * So the rule requires either a compound SPDX expression or npm's own documented
+ * form for exactly this case, `SEE LICENSE IN <file>` — and, when that form is
+ * used, that the file it names is one the package actually ships.
+ */
+
+import { defineRule } from '../registry.mjs';
+
+/**
+ * Directories whose presence in `files` means "this tarball carries a payload
+ * built from a third-party prefix". Kept as a list of NAMES rather than of
+ * packages: a new bundle that ships `gtk/` is caught the day it is added.
+ */
+const PAYLOAD_DIRS = new Set(['gtk']);
+
+/** `SEE LICENSE IN <file>` — npm's documented form for a licence too complex to express. */
+const SEE_LICENSE_IN = /^SEE LICEN[CS]E IN\s+(.+)$/;
+
+/**
+ * Does this licence value acknowledge more than one project's terms?
+ *
+ * A bare identifier (`MIT`) does not. A compound SPDX expression (`A AND B`) does.
+ * `SEE LICENSE IN` does, and is handled by the caller because it also has a file
+ * to verify.
+ */
+function acknowledgesThirdParty(license) {
+    if (typeof license !== 'string') return false;
+    return /\b(AND|OR|WITH)\b/.test(license);
+}
+
+/**
+ * Packages whose `files` list names a payload directory. `files` rather than the
+ * filesystem on purpose: the payload is gitignored and built on a runner, so the
+ * directory is absent in a checkout and present in the tarball — and it is the
+ * TARBALL the licence field describes.
+ */
+export function collectBundlingPackages(ctx) {
+    const out = [];
+    for (const pkg of ctx.allPackages) {
+        const files = Array.isArray(pkg.manifest.files) ? pkg.manifest.files : [];
+        const payload = files.filter((f) => PAYLOAD_DIRS.has(String(f).replace(/\/+$/, '')));
+        if (payload.length === 0) continue;
+        out.push({ name: pkg.manifest.name, path: pkg.rel, license: pkg.manifest.license, files, payload });
+    }
+    return out;
+}
+
+/**
+ * @returns {{failures: string[], notes: string[], stats: Record<string, number>}}
+ */
+export function auditBundledLicense(packages) {
+    const failures = [];
+    const notes = [];
+    let compound = 0;
+    let seeLicenseIn = 0;
+
+    for (const pkg of packages) {
+        const license = pkg.license;
+        if (typeof license !== 'string' || license.trim() === '') {
+            failures.push(
+                `${pkg.name} (${pkg.path}): ships a third-party payload (${pkg.payload.join(', ')}) and declares no \`license\`. ` +
+                    'A package that redistributes other projects\' binaries must say so in the one field a scanner reads.',
+            );
+            continue;
+        }
+
+        const seeIn = SEE_LICENSE_IN.exec(license.trim());
+        if (seeIn) {
+            const named = seeIn[1].trim();
+            // The file must be one the tarball carries, or the field points at nothing
+            // for every consumer — the failure mode being fixed, one level down.
+            const shipped = pkg.files.some((f) => {
+                const entry = String(f).replace(/\/+$/, '');
+                return named === entry || named.startsWith(`${entry}/`);
+            });
+            if (!shipped) {
+                failures.push(
+                    `${pkg.name} (${pkg.path}): \`license\` is "${license}" but \`files\` does not ship "${named}". ` +
+                        `\`files\` lists: ${pkg.files.join(', ')}. A licence that names an unshipped file is unreadable ` +
+                        'by the consumer it exists for.',
+                );
+                continue;
+            }
+            seeLicenseIn++;
+            notes.push(`${pkg.name}: licence deferred to ${named} (shipped)`);
+            continue;
+        }
+
+        if (!acknowledgesThirdParty(license)) {
+            failures.push(
+                `${pkg.name} (${pkg.path}): declares \`"license": "${license}"\` while shipping a third-party payload ` +
+                    `(${pkg.payload.join(', ')}). That is the licence of this package's own sources and not of the ` +
+                    'tarball npm hands a user, which also carries relocated LGPL/MPL/GPL libraries. Use a compound ' +
+                    'SPDX expression, or `SEE LICENSE IN <file>` naming a notice the package ships.',
+            );
+            continue;
+        }
+        compound++;
+        notes.push(`${pkg.name}: compound SPDX expression`);
+    }
+
+    return {
+        failures,
+        notes,
+        stats: { bundling: packages.length, compound, seeLicenseIn },
+    };
+}
+
+export const bundledLicenseRule = defineRule({
+    id: 'bundled-license',
+    scope: 'portable',
+    fields: ['license'],
+    description:
+        "a package shipping another project's binaries declares a licence that says so, not just its own",
+    run(ctx) {
+        const packages = collectBundlingPackages(ctx);
+        const result = auditBundledLicense(packages);
+        return {
+            failures: result.failures,
+            notes: result.notes,
+            stats: result.stats,
+            summary:
+                packages.length === 0
+                    ? 'bundled-license: no package ships a third-party payload'
+                    : `bundled-license: ${packages.length} bundling package(s) — ` +
+                      `${result.stats.seeLicenseIn} defer to a shipped notice, ${result.stats.compound} declare a compound expression`,
+        };
+    },
+});

--- a/packages/node-gi/gtk-runtime-darwin-arm64/package.json
+++ b/packages/node-gi/gtk-runtime-darwin-arm64/package.json
@@ -3,7 +3,7 @@
   "version": "0.40.0",
   "description": "Batteries-included, relocated GTK/GObject-Introspection runtime bundle for macOS arm64 — lets @gjsify/node-gi load gi:// namespaces (GLib/GObject/Gio/cairo/Pango/Graphene/Gdk) with NO Homebrew GTK. Platform-gated (darwin/arm64 only).",
   "type": "module",
-  "license": "MIT",
+  "license": "SEE LICENSE IN gtk/THIRD-PARTY-NOTICES.md",
   "os": [
     "darwin"
   ],

--- a/packages/node-gi/gtk-runtime-darwin-x64/package.json
+++ b/packages/node-gi/gtk-runtime-darwin-x64/package.json
@@ -3,7 +3,7 @@
   "version": "0.40.0",
   "description": "Batteries-included, relocated GTK/GObject-Introspection runtime bundle for macOS Intel (x64) — lets @gjsify/node-gi load gi:// namespaces (GLib/GObject/Gio/cairo/Pango/Graphene/Gdk) with NO Homebrew GTK. Platform-gated (darwin/x64 only).",
   "type": "module",
-  "license": "MIT",
+  "license": "SEE LICENSE IN gtk/THIRD-PARTY-NOTICES.md",
   "os": [
     "darwin"
   ],

--- a/packages/node-gi/gtk-runtime-win32-x64/package.json
+++ b/packages/node-gi/gtk-runtime-win32-x64/package.json
@@ -3,7 +3,7 @@
   "version": "0.40.0",
   "description": "Batteries-included GTK/GObject-Introspection runtime bundle for Windows x64 — lets @gjsify/node-gi load gi:// namespaces (GLib/GObject/Gio/cairo/Pango/Graphene/Gdk) with NO gvsbuild/system GTK. Platform-gated (win32/x64 only).",
   "type": "module",
-  "license": "MIT",
+  "license": "SEE LICENSE IN gtk/THIRD-PARTY-NOTICES.md",
   "os": [
     "win32"
   ],

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1355,6 +1355,13 @@ const CHECK_RULES = [
     // There is no iOS CI anywhere in this repo, so "does the declared platform have an
     // implementation at all" is the only half of that promise any machine here can hold.
     'nativescript-platforms',
+    // Reads only `license` + `files` out of each manifest, so it needs no build and no
+    // payload on disk: the payload it asks about is gitignored and produced on a runner,
+    // and `files` is what says the tarball will carry it. Added the day three published
+    // packages were found declaring `"license": "MIT"` over 37-45 relocated LGPL/MPL/GPL
+    // libraries — the notice files were already correct, and the one machine-readable
+    // field was not.
+    'bundled-license',
     // Guards the apps EXCLUDED from `workspaces` — the set no other check can see.
     'release-train',
     'field-coverage',


### PR DESCRIPTION
The three `@gjsify/gtk-runtime-*` packages declared **`"license": "MIT"`** while their published tarball carries **37–45 relocated LGPL/MPL/GPL libraries** — GTK, GLib, Pango, cairo, freetype, fontconfig, harfbuzz and the rest.

MIT is the correct licence of the three source files in each package. It is the wrong answer for the artifact npm hands a user.

### What was already right, and what was not

`bundle-licenses.mjs` has shipped the licence texts and a `THIRD-PARTY-NOTICES.md` since it was written, and that notice says it plainly:

> `@gjsify/gtk-runtime-*` is MIT-licensed; **the binaries below are not** — they keep the terms of their own projects, reproduced here.

So everything a **human** reads was correct. The one **machine-readable** field — the only thing a licence scanner, an SBOM generator or a corporate policy gate looks at — said MIT-only.

### The fix

`"license": "SEE LICENSE IN gtk/THIRD-PARTY-NOTICES.md"` — npm's documented form for a licence too complex to express, naming the notice the builder already writes and `files` already ships.

**Deliberately not an SPDX expression**, and the reason is measured:

| | attribution | expression possible? |
|---|---|---|
| darwin | exact — every dylib resolves into a Homebrew keg, `parseBrewLicenseStanza()` reads the terms from the keg's own formula | yes |
| win32 | **not recoverable** — one flat gvsbuild `bin/`, VERSIONINFO present in some DLLs and absent in others (`build-gtk-runtime.mjs` says so itself) | no |

An expression on win32 would be a guess, and a guessed licence expression is worse than an incomplete one: it makes a *specific* false claim instead of an unspecific one.

### The rule that keeps it fixed

A prose correction would drift back, so `bundled-license` comes with it.

It keys on the **signal**, not on a package list: a package whose `files` ship a payload directory built from a third-party prefix. A fourth bundle is caught the day it is added rather than the day someone remembers to add it to a list.

`files` rather than the filesystem, deliberately — the payload is gitignored and produced on a runner, so the directory is absent in a checkout and present in the tarball, and it is the *tarball* the licence field describes.

### A/B, both branches

A rule that cannot fail is worse than none, so both failure paths were proved:

| state | audit |
|---|---|
| manifest reverted to `MIT` | **fails** — "declares `"license": "MIT"` while shipping a third-party payload (gtk)" |
| `SEE LICENSE IN docs/NOPE.md` (not in `files`) | **fails** — "`files` does not ship "docs/NOPE.md"" |
| as committed | passes |

**The first draft did not fire at all.** `audit-runtimes --check` runs an explicit `CHECK_RULES` allow-list and the new rule was not on it, so it reported green while measuring nothing — caught only because the A/B was run rather than assumed. That is the class this repository pays for most, arriving inside the fix for a different instance of it.

### Validation

`audit-runtimes --check` ✅ · `gjsify lint` ✅ · `format --check` ✅ · rule visible in `--rules` with its governed field (`license`) ✅ · both failure branches reproduced and reverted.