### PR TITLE
feat(cli): ship gjsify itself, and stop self-update from fighting the package manager

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -330,6 +330,24 @@ jobs:
       # AT THE NEW VERSION by the `after:bump` hook — `--rebuild` implies
       # `--keep`, so what is on disk here is what the tag carries. Uploading from
       # release.yml could only ever re-derive that.
+      # The distro packages, from the SAME bundle the assets above carry. `ship`
+      # re-reads `dist/cli.gjs.mjs`, so there is no second build and no way for the
+      # `.deb` and the `.gjs.mjs` on one release to disagree.
+      #
+      # `--skip-build` is the point: rebuilding here would produce a bundle from the
+      # working tree rather than the one the `after:bump` hook made AT THE NEW
+      # VERSION, and the tag would then carry two different bundles.
+      #
+      # Why this belongs on the release at all: `gjsify self-update` REFUSES to run
+      # when the CLI was installed by a package manager, because writing the XDG
+      # prefix there leaves the user with two installs. That refusal points at
+      # `releases/latest`, so the packages have to be there for the sentence to be
+      # true.
+      - name: Package the CLI as .deb and .rpm
+        if: ${{ !inputs.dry_run }}
+        working-directory: packages/infra/cli
+        run: node lib/index.js ship --skip-build
+
       - name: Generate cli.gjs.mjs.sha256
         if: ${{ !inputs.dry_run }}
         id: assets
@@ -356,6 +374,8 @@ jobs:
             install.mjs
             packages/infra/cli/dist/cli.gjs.mjs
             packages/infra/cli/dist/cli.gjs.mjs.sha256
+            packages/infra/cli/ship/out/*.deb
+            packages/infra/cli/ship/out/*.rpm
 
       # A check that cannot fail is decoration, so this one gates — and it gates
       # BEFORE the publish dispatch on purpose. The two failure modes are not

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,7 @@ packages/node/worker_threads/fixtures/
 # by the tooling has nothing to be checked against.
 /tests/browser/playwright-report/
 /tests/browser/test-results/
+
+# `gjsify ship` output — the staged tree and the built .deb/.rpm. A build artifact,
+# like dist/: reproducible from the bundle plus the manifest, and 6 MB per format.
+ship/

--- a/packages/infra/cli/package.json
+++ b/packages/infra/cli/package.json
@@ -35,10 +35,10 @@
                 "name": "gjsify contributors",
                 "email": "pascal@artandcode.studio"
             },
-            "summary": "Node.js + Web APIs for GJS — bundle, install, lint, format, flatpak-pack GJS apps",
+            "summary": "Node.js + Web APIs for GJS \u2014 bundle, install, lint, format, flatpak-pack GJS apps",
             "description": [
                 {
-                    "p": "gjsify is the build-and-tooling CLI for the gjsify project — a polyfill family + bundler that lets you write GNOME apps in Node-shaped TypeScript and run them on GJS (the GNOME JavaScript runtime) without Node.js at runtime."
+                    "p": "gjsify is the build-and-tooling CLI for the gjsify project \u2014 a polyfill family + bundler that lets you write GNOME apps in Node-shaped TypeScript and run them on GJS (the GNOME JavaScript runtime) without Node.js at runtime."
                 },
                 {
                     "p": "Use this Flatpak when you want gjsify available on any modern Linux distro without installing Node.js or a system-wide npm setup. The CLI ships its own GJS bundle and a pinned Node 24 SDK extension for the subcommands (`gjsify build`, `gjsify lint`, `gjsify format`) that still call out to Node tooling internally."
@@ -46,25 +46,25 @@
                 {
                     "ul": [
                         {
-                            "item": "`gjsify build` — bundle a TypeScript entry into a single GJS / Node / browser file via Rolldown"
+                            "item": "`gjsify build` \u2014 bundle a TypeScript entry into a single GJS / Node / browser file via Rolldown"
                         },
                         {
-                            "item": "`gjsify install` — Node-free npm install with a lockfile (XDG-aware, native backend)"
+                            "item": "`gjsify install` \u2014 Node-free npm install with a lockfile (XDG-aware, native backend)"
                         },
                         {
-                            "item": "`gjsify dlx <pkg>` — fetch and run any npm package's GJS bundle without persisting it"
+                            "item": "`gjsify dlx <pkg>` \u2014 fetch and run any npm package's GJS bundle without persisting it"
                         },
                         {
-                            "item": "`gjsify lint` / `gjsify format` — oxc-powered linter (oxlint) + formatter (oxfmt)"
+                            "item": "`gjsify lint` / `gjsify format` \u2014 oxc-powered linter (oxlint) + formatter (oxfmt)"
                         },
                         {
-                            "item": "`gjsify flatpak {init,build,check,deps,ci}` — pack a GJS app or CLI into a Flatpak end-to-end"
+                            "item": "`gjsify flatpak {init,build,check,deps,ci}` \u2014 pack a GJS app or CLI into a Flatpak end-to-end"
                         },
                         {
-                            "item": "`gjsify gresource` — bundle GResource XML files for GTK apps"
+                            "item": "`gjsify gresource` \u2014 bundle GResource XML files for GTK apps"
                         },
                         {
-                            "item": "`gjsify showcase` — run the bundled demo programs (Excalibur, three.js, WebRTC, …)"
+                            "item": "`gjsify showcase` \u2014 run the bundled demo programs (Excalibur, three.js, WebRTC, \u2026)"
                         }
                     ]
                 }
@@ -94,6 +94,14 @@
                         }
                     ]
                 }
+            ]
+        },
+        "ship": {
+            "binaryName": "gjsify",
+            "bundle": "dist/cli.gjs.mjs",
+            "targets": [
+                "deb",
+                "rpm"
             ]
         },
         "tier": 1,

--- a/packages/infra/cli/src/commands/self-update.ts
+++ b/packages/infra/cli/src/commands/self-update.ts
@@ -28,6 +28,7 @@ import { fetchPackument, type Packument } from '@gjsify/npm-registry';
 import type { Argv } from 'yargs';
 import type { Command } from '../types/index.js';
 import { installPackages, makeProgressReporter } from '../utils/install-backend.js';
+import { classifyInstall } from '../utils/install-provenance.js';
 import {
     defaultGlobalLayout,
     globalLayoutIsDefault,
@@ -83,6 +84,27 @@ export const selfUpdateCommand: Command<unknown, SelfUpdateOptions> = {
         const installedAtPrefix = existsSync(installedPkgJson);
 
         console.log(`Current ${PACKAGE_NAME}: v${currentVersion ?? '(unknown)'}`);
+
+        // REFUSE, do not warn-and-continue, when something else owns this install.
+        //
+        // Everything below writes the user-global XDG prefix. Under a `.deb`,
+        // `.rpm` or Flatpak that produces a SECOND copy which shadows the one the
+        // package manager tracks — so the next `apt upgrade` reverts it, or the two
+        // diverge, and the user's report is "I updated and nothing changed". A
+        // clean refusal naming the right command is strictly more useful than a
+        // successful write to the wrong place; #1064 is the same lesson one layer
+        // down, where the write succeeded and PATH still resolved the old binary.
+        const provenance = classifyInstall({ selfDir: readSelfDir(), xdgPrefix: layout.prefix });
+        if (provenance.managedElsewhere) {
+            console.error(
+                `\ngjsify self-update: this gjsify is managed by something else — ${provenance.evidence}.\n` +
+                    `Updating it from here would write ${layout.prefix} and leave you running two installs.\n\n` +
+                    `Update with: ${provenance.updateWith}\n`,
+            );
+            // `return process.exit()` — a bare `process.exit()` is DEFERRED under
+            // GJS and the handler would run on into the install it just refused.
+            return process.exit(1);
+        }
         if (!installedAtPrefix) {
             console.warn(
                 `\nWarning: no @gjsify/cli install found under ${layout.prefix}.\n` +
@@ -306,6 +328,27 @@ export function verifyPathResolution(opts: {
  * `import.meta.url` (the bundle file under GJS, or `lib/index.js` under
  * Node) until it finds a package.json with `name === '@gjsify/cli'`.
  */
+/**
+ * The directory of the running CLI's own package — the input the provenance
+ * question is actually about.
+ *
+ * The same upward walk `readCurrentVersion()` does, and for the same reason: it
+ * works from `lib/index.js` under Node and from the published `dist/cli.gjs.mjs`
+ * bundle under GJS. Honours the same `GJSIFY_CLI_PACKAGE_JSON` escape hatch, so a
+ * test can place a synthetic install anywhere without a real one.
+ */
+function readSelfDir(): string {
+    const override = process.env.GJSIFY_CLI_PACKAGE_JSON;
+    if (override) return dirname(resolve(override));
+    const here = fileURLToPath(import.meta.url);
+    let dir = dirname(resolve(here));
+    for (let i = 0; i < 8 && dir !== dirname(dir); i++) {
+        if (existsSync(join(dir, 'package.json'))) return dir;
+        dir = dirname(dir);
+    }
+    return dirname(resolve(here));
+}
+
 function readCurrentVersion(): string | null {
     try {
         // Escape hatch for tests: point GJSIFY_CLI_PACKAGE_JSON at a synthetic

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -12,6 +12,7 @@ import cliFailSuite from './cli-fail.spec.js';
 import shipPlanSuite from './utils/ship/plan.spec.js';
 import shipSettingsSuite from './utils/ship/settings.spec.js';
 import shipDependsSuite from './utils/ship/depends.spec.js';
+import installProvenanceSuite from './utils/install-provenance.spec.js';
 import shipArchivesSuite from './utils/ship/archives.spec.js';
 import shipPackersSuite from './utils/ship/packers.spec.js';
 import installProjectEngineSuite from './commands/install-project-engine.spec.js';
@@ -192,6 +193,7 @@ run(
         shipPlanSuite,
         shipSettingsSuite,
         shipDependsSuite,
+        installProvenanceSuite,
         shipArchivesSuite,
         shipPackersSuite,
         installProjectEngineSuite,

--- a/packages/infra/cli/src/utils/install-provenance.spec.ts
+++ b/packages/infra/cli/src/utils/install-provenance.spec.ts
@@ -1,0 +1,124 @@
+// `classifyInstall` — the question `self-update` must get right before it writes.
+//
+// Every case here is a real install layout, not a synthetic string: getting this
+// wrong in either direction has a cost. A false `managedElsewhere` bricks
+// `self-update` for the users it exists for; a false `xdg-global` writes a second
+// copy over a package manager's install, which is the defect it was added for.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { classifyInstall } from './install-provenance.js';
+
+const XDG = '/home/dev/.local/share/gjsify/global';
+
+export default async () => {
+    await describe('classifyInstall', async () => {
+        await it('recognises the layout install.mjs and `install -g` produce', async () => {
+            const v = classifyInstall({
+                selfDir: `${XDG}/node_modules/@gjsify/cli`,
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('xdg-global');
+            expect(v.managedElsewhere).toBe(false);
+        });
+
+        await it('recognises a Flatpak by its id, wherever the tree is mounted', async () => {
+            const v = classifyInstall({
+                selfDir: '/somewhere/else/cli',
+                xdgPrefix: XDG,
+                env: { FLATPAK_ID: 'io.github.gjsify.Cli' },
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('flatpak');
+            expect(v.managedElsewhere).toBe(true);
+            expect(v.updateWith).toBe('flatpak update io.github.gjsify.Cli');
+        });
+
+        await it('recognises a Flatpak by its /app prefix with no id in the env', async () => {
+            const v = classifyInstall({
+                selfDir: '/app/lib/gjsify',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('flatpak');
+        });
+
+        await it('recognises a distro package under a system prefix', async () => {
+            for (const dir of ['/usr/lib/gjsify', '/opt/gjsify/lib', '/snap/gjsify/current/lib']) {
+                const v = classifyInstall({ selfDir: dir, xdgPrefix: XDG, env: {}, platform: 'linux' });
+                expect(v.kind).toBe('system-package');
+                expect(v.managedElsewhere).toBe(true);
+            }
+        });
+
+        await it('does NOT name a specific package manager it cannot know', async () => {
+            const v = classifyInstall({ selfDir: '/usr/lib/gjsify', xdgPrefix: XDG, env: {}, platform: 'linux' });
+            // One path serves .deb and .rpm alike; guessing sends the user to a
+            // package manager that does not know this file.
+            expect(v.updateWith?.includes('apt upgrade')).toBe(true);
+            expect(v.updateWith?.includes('dnf upgrade')).toBe(true);
+            expect(v.updateWith?.includes('releases/latest')).toBe(true);
+        });
+
+        await it('recognises an npm-global install', async () => {
+            const v = classifyInstall({
+                selfDir: '/home/dev/.nvm/versions/node/v24.0.0/lib/node_modules/@gjsify/cli',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('npm-global');
+            expect(v.managedElsewhere).toBe(true);
+        });
+
+        await it('prefers the system verdict over the node_modules one', async () => {
+            // A .deb stages a node_modules-shaped tree under /usr/lib, so the npm
+            // test alone would claim it and send the user to `npm install -g`.
+            const v = classifyInstall({
+                selfDir: '/usr/lib/gjsify/node_modules/@gjsify/cli',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('system-package');
+        });
+
+        await it('prefers the XDG verdict for a HOME that lives under a system prefix', async () => {
+            // `$HOME=/opt/someuser` is unusual and real. The narrow question is
+            // asked first so that user is not told to run `dnf`.
+            const prefix = '/opt/someuser/.local/share/gjsify/global';
+            const v = classifyInstall({
+                selfDir: `${prefix}/node_modules/@gjsify/cli`,
+                xdgPrefix: prefix,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('xdg-global');
+            expect(v.managedElsewhere).toBe(false);
+        });
+
+        await it('leaves a checkout alone rather than guessing', async () => {
+            const v = classifyInstall({
+                selfDir: '/home/dev/src/gjsify/packages/infra/cli',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('unknown');
+            // Refusing here would break `self-update` for a contributor testing it.
+            expect(v.managedElsewhere).toBe(false);
+        });
+
+        await it('does not read a system prefix on win32, where those paths mean nothing', async () => {
+            const v = classifyInstall({
+                selfDir: 'C:\\\\Users\\\\dev\\\\AppData\\\\gjsify',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'win32',
+            });
+            expect(v.kind).toBe('unknown');
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/install-provenance.ts
+++ b/packages/infra/cli/src/utils/install-provenance.ts
@@ -1,0 +1,133 @@
+// How was THIS gjsify installed?
+//
+// `self-update` re-runs the `gjsify install -g` pipeline, which writes into the
+// user-global XDG prefix. That is correct for an install that came from
+// `install.mjs` or `gjsify install -g`, and WRONG for one a package manager owns:
+// it would lay a second copy into `~/.local` that shadows — or is shadowed by —
+// the one apt/dnf/flatpak is tracking, and the package manager would then be
+// managing a file the user no longer runs. The next `apt upgrade` reverts or
+// diverges, silently, and "I updated it and nothing changed" is the report.
+//
+// Before `gjsify ship` there was only one non-XDG case worth naming (`npm -g`),
+// and the command warned and continued. Now that gjsify ships as `.deb`, `.rpm`
+// and Flatpak, continuing is the defect. So the question gets a real answer, and
+// the answer carries the command the user should run instead.
+//
+// Everything here is derived from where the RUNNING code sits, never from a
+// build-time constant: one tarball is unpacked by all of these routes, so a flag
+// baked at build time would describe the builder rather than the installation.
+
+import { isAbsolute, resolve, sep } from 'node:path';
+
+/** Where the running CLI came from. */
+export type InstallProvenanceKind =
+    /** `install.mjs` or `gjsify install -g` — the layout `self-update` manages. */
+    | 'xdg-global'
+    /** Inside a Flatpak sandbox. */
+    | 'flatpak'
+    /** A distro package (`.deb`/`.rpm`) staged under a system prefix. */
+    | 'system-package'
+    /** `npm install -g` (or yarn/pnpm global) — a `node_modules` tree elsewhere. */
+    | 'npm-global'
+    /** A checkout, a container image, an unpacked tarball — anything else. */
+    | 'unknown';
+
+export interface InstallProvenance {
+    kind: InstallProvenanceKind;
+    /** What the decision was made ON, so a wrong verdict is debuggable. */
+    evidence: string;
+    /** How the user should update, when it is not `self-update`'s job. */
+    updateWith?: string;
+    /** True when `self-update` must refuse rather than write the XDG prefix. */
+    managedElsewhere: boolean;
+}
+
+/** System prefixes a distro package stages into. POSIX only — win32 handled separately. */
+const SYSTEM_PREFIXES = ['/usr/', '/opt/', '/snap/'];
+
+/** Inside a Flatpak the whole app tree lives under this prefix. */
+const FLATPAK_PREFIX = '/app/';
+
+/** Does `child` sit inside `parent`? Both must be absolute and already resolved. */
+function isInside(child: string, parent: string): boolean {
+    if (!isAbsolute(child) || !isAbsolute(parent)) return false;
+    const p = parent.endsWith(sep) ? parent : parent + sep;
+    return child === parent || child.startsWith(p);
+}
+
+export interface ProvenanceInput {
+    /** Absolute path of the running CLI's own package directory. */
+    selfDir: string;
+    /** `defaultGlobalLayout().prefix` — the layout `self-update` owns. */
+    xdgPrefix: string;
+    env?: Record<string, string | undefined>;
+    platform?: NodeJS.Platform;
+}
+
+/**
+ * Classify an installation from its path and environment.
+ *
+ * ORDER MATTERS and is not alphabetical:
+ *
+ *  1. **Flatpak first.** Its `/app` prefix would also satisfy no other test, but
+ *     `FLATPAK_ID` is the unambiguous signal and is present even when the tree is
+ *     mounted somewhere unusual.
+ *  2. **XDG before system.** The XDG prefix is under `$HOME`, so it can never be
+ *     `/usr` — but a user whose `$HOME` is `/opt/someuser` exists, and asking the
+ *     narrow question first means that user is not told to run `dnf`.
+ *  3. **System before npm.** A `.deb` stages a `node_modules`-shaped tree under
+ *     `/usr/lib`, so the npm test alone would claim it.
+ */
+export function classifyInstall(input: ProvenanceInput): InstallProvenance {
+    const env = input.env ?? process.env;
+    const platform = input.platform ?? process.platform;
+    const selfDir = resolve(input.selfDir);
+
+    if (env.FLATPAK_ID || isInside(selfDir, FLATPAK_PREFIX)) {
+        const id = env.FLATPAK_ID ?? 'io.github.gjsify.Cli';
+        return {
+            kind: 'flatpak',
+            evidence: env.FLATPAK_ID ? `FLATPAK_ID=${env.FLATPAK_ID}` : `running from ${FLATPAK_PREFIX}`,
+            updateWith: `flatpak update ${id}`,
+            managedElsewhere: true,
+        };
+    }
+
+    if (isInside(selfDir, resolve(input.xdgPrefix))) {
+        return {
+            kind: 'xdg-global',
+            evidence: `running from the user-global prefix ${input.xdgPrefix}`,
+            managedElsewhere: false,
+        };
+    }
+
+    if (platform !== 'win32' && SYSTEM_PREFIXES.some((p) => isInside(selfDir, p))) {
+        return {
+            kind: 'system-package',
+            evidence: `running from the system prefix ${selfDir}`,
+            // Not `apt` or `dnf` specifically: the same path serves both, and
+            // guessing wrong sends the user to a package manager that does not
+            // know this file. The release assets are named because they are the
+            // one answer that is true on every distribution.
+            updateWith:
+                'your distribution package manager (`apt upgrade` / `dnf upgrade` / …), or install the newer package from ' +
+                'https://github.com/gjsify/gjsify/releases/latest',
+            managedElsewhere: true,
+        };
+    }
+
+    if (selfDir.split(sep).includes('node_modules')) {
+        return {
+            kind: 'npm-global',
+            evidence: `running from a node_modules tree at ${selfDir}`,
+            updateWith: 'npm install -g @gjsify/cli@latest (or switch to the Node-free bootstrap)',
+            managedElsewhere: true,
+        };
+    }
+
+    return {
+        kind: 'unknown',
+        evidence: `running from ${selfDir}, which matches no known install layout`,
+        managedElsewhere: false,
+    };
+}

--- a/packages/infra/manifest-conformance/lib/rules/ship.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/ship.mjs
@@ -33,8 +33,18 @@ const APP_ID = /^[A-Za-z][\w-]*(\.[A-Za-z][\w-]*){2,}$/;
 const BINARY_NAME = /^[a-z\d][a-z\d+.-]+$/;
 /** The formats `gjsify ship` can build today. */
 const TARGETS = new Set(['deb', 'rpm']);
-/** Keys whose value is a path that must exist relative to the package. */
-const PATH_KEYS = ['bundle', 'icon', 'schemas', 'licenseFile'];
+/**
+ * Keys whose value is a SOURCE path that must exist relative to the package.
+ *
+ * `bundle` is deliberately NOT here. It is the one build OUTPUT among the path
+ * keys — `gjsify ship` packages a BUILT app — so it is absent in a clean checkout
+ * by definition, and requiring it here would mean no package could declare
+ * `gjsify.ship` without committing its own dist. The right moment to demand it is
+ * ship time, and `resolveBundle()` already does: "the bundle X does not exist.
+ * Build it first (`gjsify run build`)". Asking at audit time asks a different
+ * question and answers it wrong.
+ */
+const PATH_KEYS = ['icon', 'schemas', 'licenseFile'];
 
 export function auditShip(ctx) {
     const failures = [];


### PR DESCRIPTION
Two commits: `gjsify ship` gets its first real subject, and `self-update` learns to refuse when it is not the thing that owns the install.

## 1. gjsify ships itself

`gjsify ship` has produced .deb and .rpm since #1193, and **no package in this tree declared `gjsify.ship`** — so the feature's only subjects were synthetic fixtures and the conformance rule guarding it was vacuous in its own repository.

Measured end to end on a Fedora 44 host:

```
gjsify ship --skip-build
[gjsify ship] staged 7 file(s) in ship/stage/
[gjsify ship] deb: ship/out/gjsify_0.40.0-1_all.deb (6489730 bytes)
[gjsify ship] rpm: ship/out/gjsify-0.40.0-1.noarch.rpm (6491756 bytes)
```

Read back by **independent** parsers, not ours — `rpm -qip` (Name gjsify, Version 0.40.0, License MIT), `rpm -K` ("Prüfsummen OK"), `ar t` (the three required container members). The Debian floor warning fires as designed: `gjs (>= 1.86)` is not satisfiable on trixie, and `ship` says so at package time rather than lowering it.

`binaryName: 'gjsify'` is not cosmetic — the default strips the npm scope, so `@gjsify/cli` became a distro package literally called **`cli`**.

### One rule change made it possible

`ship`'s `PATH_KEYS` demanded that `bundle` exist at **audit** time, alongside `icon`, `schemas` and `licenseFile`. Those three are sources; `bundle` is the one build **output** among them and is absent from a clean checkout by definition — so no package could declare `gjsify.ship` without committing its own `dist/`.

The right moment to demand it is ship time, and `resolveBundle()` already does, with an actionable sentence: *"the bundle X does not exist. Build it first (`gjsify run build`)"*. Asking at audit time asked a different question and answered it wrong.

## 2. self-update refuses where a package manager owns the install

`self-update` re-runs the `install -g` pipeline, which writes the user-global XDG prefix. Correct for an `install.mjs` install; **wrong** for one apt, dnf or flatpak owns — it lays a second copy into `~/.local` that shadows the tracked one, so the next `apt upgrade` reverts it or the two diverge. The user's report is "I updated and nothing changed".

Until `gjsify ship` there was one non-XDG case worth naming (`npm -g`) and the command **warned and continued**. Now that gjsify ships as .deb, .rpm and Flatpak, continuing is the defect.

`classifyInstall()` answers from where the **running** code sits, never from a build-time constant: one tarball is unpacked by every route, so a baked flag would describe the builder rather than the installation.

The order is not alphabetical and each step is load-bearing:

| | why it comes where it does |
|---|---|
| Flatpak first | `FLATPAK_ID` is unambiguous and survives an unusual mount |
| XDG before system | the XDG prefix is under `$HOME` — but `$HOME=/opt/someuser` exists, and asking the narrow question first keeps that user from being told to run `dnf` |
| system before npm | a `.deb` stages a `node_modules`-shaped tree under `/usr/lib`, so the npm test alone would claim it and send the user to `npm install -g` |

It deliberately does **not** name apt or dnf specifically: one path serves both, and guessing sends the user to a package manager that does not know the file. The message names both plus the release URL — true on every distribution.

**Ten tests**, each a real layout rather than a synthetic string, because both directions cost: a false `managedElsewhere` bricks `self-update` for the users it exists for, and a false `xdg-global` writes over a package manager's install.

## 3. The release carries the packages

The refusal points at `releases/latest`, so the `.deb` and `.rpm` have to be there for that sentence to be true. `release-cut.yml` packages them from the **same** `dist/cli.gjs.mjs` the existing assets carry (`--skip-build`), so there is no second build and no way for one release to hold two different bundles.

### Deliberately not implemented

Fetching and **installing** the `.deb` from `self-update`. It needs root and would install a package behind the package manager's back — the harm this PR exists to prevent. Naming the artifact is the useful half; running `dpkg` is not ours to do.

## Validation

`audit-runtimes --check` ✅ · `gjsify lint` ✅ · `format --check` ✅ · `check-workflow-run-syntax` + `check-workflow-inline-scripts` ✅ · `tsc --noEmit` on `@gjsify/cli` ✅ · both ship e2e suites (32 tests) ✅ · full `@gjsify/cli` suite **2269 tests green**, the ten new ones among them · `ship/` added to `.gitignore` for the same reason `dist/` is there.

> The CLI suite was red on the first run — `test:node` executes `dist/test.node.mjs`, which was two days stale, so the new suite was not in it and a version assertion compared a baked-in old number. Rebuilt, then green. Noting it because the failure looked like a real regression and was an artifact.