### PR TITLE
ci: run the runtime detector on the runtimes it detects

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -139,6 +139,15 @@ jobs:
       - name: Check every workflow `run:` block is valid shell
         run: node scripts/check-workflow-run-syntax.mjs
 
+      # The cross-runtime package list and the `if:` chain that decides whether its
+      # job runs are two copies of one set, and selective CI means the second one
+      # decides whether the first is ever read. They had already drifted: the runtime
+      # DETECTION package sat in neither for nine days, so the five assertions that
+      # read `globalThis` on a real bun/deno host — the only ones that cannot be
+      # checked anywhere else — were the ones never run.
+      - name: Check the cross-runtime list and its gate agree
+        run: node scripts/check-cross-runtime-gate.mjs
+
       # The PR-title linter inherits its type list from the action default
       # instead of carrying a second copy of `type-enum`. That is only sound
       # while the two agree — this is what says so out loud.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,9 +113,12 @@ env:
   # polyfill. Every entry below either imports its own package by name, or
   # imports a bare Web specifier that `ALIASES_WEB_FOR_NODE` routes to the
   # POLYFILL (`dom-events`-style), or is infra code that is nobody's builtin.
-  # All nine were run locally on node + bun + deno before being listed.
+  # Every entry is run locally on node + bun + deno BEFORE being listed — that is
+  # the bar for joining this list, and it is why there is no count here: a number
+  # in a comment is a second copy of the list's length that nothing checks.
   CROSS_RUNTIME_PACKAGES: >-
     packages/gjs/unit
+    packages/gjs/runtime
     packages/web/adwaita-core
     packages/framework/storybook-core
     packages/web/domparser
@@ -994,7 +997,7 @@ jobs:
   #      shape as the CLI: build ONE engine-agnostic bundle, run it three times.
   cross-runtime:
     needs: [changes, setup, build]
-    if: ${{ always() && needs.build.result == 'success' && needs.changes.outputs.skip-all != 'true' && (needs.changes.outputs.global == 'true' || needs.changes.outputs.global == '' || contains(needs.changes.outputs.include-args, '@gjsify/cli') || contains(needs.changes.outputs.include-args, '@gjsify/unit') || contains(needs.changes.outputs.include-args, '@gjsify/adwaita-core') || contains(needs.changes.outputs.include-args, '@gjsify/storybook-core') || contains(needs.changes.outputs.include-args, '@gjsify/domparser') || contains(needs.changes.outputs.include-args, '@gjsify/webstorage') || contains(needs.changes.outputs.include-args, '@gjsify/semver') || contains(needs.changes.outputs.include-args, '@gjsify/workspace') || contains(needs.changes.outputs.include-args, '@gjsify/npm-registry') || contains(needs.changes.outputs.include-args, '@gjsify/tar')) }}
+    if: ${{ always() && needs.build.result == 'success' && needs.changes.outputs.skip-all != 'true' && (needs.changes.outputs.global == 'true' || needs.changes.outputs.global == '' || contains(needs.changes.outputs.include-args, '@gjsify/cli') || contains(needs.changes.outputs.include-args, '@gjsify/unit') || contains(needs.changes.outputs.include-args, '@gjsify/runtime') || contains(needs.changes.outputs.include-args, '@gjsify/adwaita-core') || contains(needs.changes.outputs.include-args, '@gjsify/storybook-core') || contains(needs.changes.outputs.include-args, '@gjsify/domparser') || contains(needs.changes.outputs.include-args, '@gjsify/webstorage') || contains(needs.changes.outputs.include-args, '@gjsify/semver') || contains(needs.changes.outputs.include-args, '@gjsify/workspace') || contains(needs.changes.outputs.include-args, '@gjsify/npm-registry') || contains(needs.changes.outputs.include-args, '@gjsify/tar')) }}
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/check-cross-runtime-gate.mjs
+++ b/scripts/check-cross-runtime-gate.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// The cross-runtime package list and the gate that decides whether its job runs
+// are two copies of one set. This holds them to each other.
+//
+// THE DRIFT. `main.yml` names the packages whose suites run on node + bun + deno
+// in `env.CROSS_RUNTIME_PACKAGES`, and the `cross-runtime` job's `if:` repeats the
+// same set as a chain of `contains(include-args, '@gjsify/<name>')`. Selective CI
+// means the second list decides whether the first one is ever read: a package in
+// the env block but missing from the chain runs only when something ELSE in the
+// chain is affected, which reads as "it is covered" and is not.
+//
+// Measured: `packages/gjs/runtime` — the runtime DETECTION package, whose own spec
+// header records "That is how Bun read as Node while four legs were green" — was in
+// neither list for nine days after it grew the scripts. The five assertions that
+// read `globalThis` on a real host are the only ones that cannot be checked
+// anywhere else, and they were the ones never run.
+//
+// WHAT IT DOES NOT DO. It does not derive the list from the manifests. Membership
+// is a JUDGEMENT — the env block's own header spells out the rule (a spec must
+// import its own package by name, or a bare Web specifier the alias table routes
+// to the polyfill, or be infra nobody's builtin) and every entry is run on all
+// three runtimes by hand before being listed. A derived list would quietly enrol
+// packages whose "green" leg tests the host's builtin instead of our polyfill.
+// So: the human picks the set, and this makes the machine agree with itself.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = join(ROOT, '.github', 'workflows', 'main.yml');
+
+const yaml = readFileSync(WORKFLOW, 'utf-8');
+
+/** The `>-` folded block under `CROSS_RUNTIME_PACKAGES:`, as a list of paths. */
+function readPackageList() {
+    const m = /^\s*CROSS_RUNTIME_PACKAGES:\s*>-\s*$/m.exec(yaml);
+    if (!m) {
+        console.error('check-cross-runtime-gate: no `CROSS_RUNTIME_PACKAGES: >-` block in main.yml.');
+        process.exit(1);
+    }
+    const rest = yaml
+        .slice(m.index + m[0].length)
+        .split('\n')
+        .slice(1);
+    const out = [];
+    for (const line of rest) {
+        if (line.trim() === '') break;
+        if (!/^\s+\S/.test(line)) break;
+        out.push(line.trim());
+    }
+    return out;
+}
+
+/** Every `@gjsify/<name>` the `cross-runtime` job's `if:` mentions. */
+function readGateNames() {
+    const line = yaml.split('\n').find((l) => l.includes('@gjsify/storybook-core') && l.includes('contains('));
+    if (line === undefined) {
+        console.error("check-cross-runtime-gate: could not find the cross-runtime job's `if:` chain.");
+        process.exit(1);
+    }
+    return new Set(
+        [...line.matchAll(/contains\(needs\.changes\.outputs\.include-args,\s*'(@gjsify\/[^']+)'\)/g)].map((m) => m[1]),
+    );
+}
+
+const paths = readPackageList();
+const gated = readGateNames();
+const failures = [];
+
+for (const rel of paths) {
+    const manifest = join(ROOT, rel, 'package.json');
+    if (!existsSync(manifest)) {
+        failures.push(`${rel}: listed in CROSS_RUNTIME_PACKAGES but has no package.json`);
+        continue;
+    }
+    const { name } = JSON.parse(readFileSync(manifest, 'utf-8'));
+    if (typeof name !== 'string') {
+        failures.push(`${rel}: package.json declares no \`name\``);
+        continue;
+    }
+    if (!gated.has(name)) {
+        failures.push(
+            `${name} (${rel}): in CROSS_RUNTIME_PACKAGES but NOT in the cross-runtime job's \`if:\` chain, so a PR ` +
+                'touching only it never runs the bun/deno legs it was listed for. Add ' +
+                `\`|| contains(needs.changes.outputs.include-args, '${name}')\`.`,
+        );
+    }
+}
+
+// The reverse direction is not symmetric: `@gjsify/cli` is deliberately in the
+// chain without being in the list, because a CLI change rebuilds every bundle the
+// legs run. Only names that look like a stale list entry are reported.
+const listed = new Set(
+    paths
+        .map((rel) => join(ROOT, rel, 'package.json'))
+        .filter((f) => existsSync(f))
+        .map((f) => JSON.parse(readFileSync(f, 'utf-8')).name),
+);
+for (const name of gated) {
+    if (name === '@gjsify/cli') continue;
+    if (!listed.has(name)) {
+        failures.push(
+            `${name}: in the cross-runtime job's \`if:\` chain but not in CROSS_RUNTIME_PACKAGES, so the job is ` +
+                'triggered for it and then does not run its suite. Add it to the list, or drop it from the chain.',
+        );
+    }
+}
+
+if (failures.length > 0) {
+    console.error(`check-cross-runtime-gate: the list and its gate disagree on ${failures.length} package(s):`);
+    for (const f of failures) console.error(`  · ${f}`);
+    process.exit(1);
+}
+
+console.log(`check-cross-runtime-gate: ${paths.length} package(s) listed, and the job's gate names every one.`);


### PR DESCRIPTION
`@gjsify/runtime` decides which host the toolchain thinks it is on. **Its bun and deno legs had never run.**

The package declares `test:bun`, `test:deno` and `test:cross-runtime`. None was reachable from CI — it is in neither `main.yml`'s `CROSS_RUNTIME_PACKAGES` nor the `cross-runtime` job's `if:` chain, and has not been since it grew those scripts.

Its own spec header names the incident this leaves unguarded:

> That is how Bun read as Node while four legs were green.

The five assertions that read `globalThis` on a real host are the only ones that cannot be checked anywhere else. Those are exactly the ones that never ran — so every other bun/deno leg in the repo was green on an unmeasured foundation.

### Listed to the list's own bar

The env block's header demands each entry be run on all three runtimes before being listed. Done:

```
Node.js 24.15.0   26 completed
Bun 1.3.14        27 completed
Deno 2.9.4        27 completed
```

### Two places — and that is the real defect

The package list and the `if:` chain are two copies of one set, and under **selective CI the second decides whether the first is ever read**. A package in the env block but missing from the chain runs only when something *else* in the chain is affected — which reads as "covered" and is not. That is how this drifted in the first place.

`check-cross-runtime-gate.mjs` holds them to each other, in `audit-runtimes.yml` — the workflow with no paths filter, so the guard has a trigger.

**A/B-proved:**

```
$ node scripts/check-cross-runtime-gate.mjs          # as committed
check-cross-runtime-gate: 10 package(s) listed, and the job's gate names every one.

$ # …with the chain entry removed again:
check-cross-runtime-gate: the list and its gate disagree on 1 package(s):
  · @gjsify/runtime (packages/gjs/runtime): in CROSS_RUNTIME_PACKAGES but NOT in the
    cross-runtime job's `if:` chain, so a PR touching only it never runs the bun/deno
    legs it was listed for. Add `|| contains(needs.changes.outputs.include-args, '@gjsify/runtime')`.
```

### What it deliberately does not do

It does **not** derive the list from the manifests. Membership is a judgement the env block spells out — a spec must import its own package by name, or a bare Web specifier the alias table routes to the *polyfill*, or be infra nobody's builtin. A derived list would quietly enrol packages whose green leg tests the host's builtin instead of our polyfill, which is a worse failure than the one being fixed. The human picks the set; this makes the machine agree with itself.

The asymmetry is intentional too: `@gjsify/cli` is in the chain without being in the list, because a CLI change rebuilds every bundle the legs run.

### Also

Drops the `All nine were run locally…` count from the comment above the list. A count in prose is a second copy of the list's length that nothing checks — and this commit would have made it wrong.

### Validation

`check-cross-runtime-gate` ✅ (both directions) · `check-workflow-run-syntax` ✅ · `check-workflow-inline-scripts` ✅ · `audit-runtimes --check` ✅ · `gjsify lint` ✅ · `format --check` ✅