### PR TITLE
docs(status): the gate-fixture check is not a grep, measured

### DIFF
--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1366,6 +1366,22 @@ the rule cannot be "fixtures may not read the tree". A first cut that would have
 caught both instances: fail a gate-listed suite that reads a path the same job's
 clearing scripts print on stdout, which is a set the job already computes.
 
+**Measured 2026-08-16, before building it: the naive form of that cut is 3-for-3
+false.** The mutated set is derivable without running anything — both clearing
+scripts take `--dry-run`, and what they WRITE is fixed (`clear-satisfied-gir-gaps`
+→ `scripts/manifest-conformance/prebuild-gir-gaps.mjs`; `clear-committed-platform-exemptions`
+→ the package manifests). But matching those paths as strings against the five
+gate-listed suites flags `platform-exemption-clearing`, `prebuild-declaration-invariant`
+and `prebuild-change-gate`, and all three are hermetic: the two known instances were
+FIXED by moving to synthetic trees, and a fixed suite still names the path it builds a
+copy of. A check with a 100 % false-positive rate gets disabled, and then protects
+nothing — `check-workflow-inline-scripts.mjs`'s header records the same lesson from its
+own first draft ("23 findings, 21 false").
+
+So the discriminator is not the path, it is the ROOT: a read anchored at the
+repository (`MONOREPO_ROOT`, `ROOT`) versus one anchored at a tmpdir the suite
+made. That is what the check has to see, and it is why this is not a grep.
+
 ### What still writes to `main` unverified, after the bot push got a gate
 
 `commit-prebuilds` now runs the checks that read its own output on the tree it is


### PR DESCRIPTION
`status/open-todos.md` proposes a check on `gate-pushed-tree.sh`'s suite list — no gate-listed suite may read repository state the steps before it write. Twice is a class, and the entry is right that one is missing.

Its **first cut** was: *fail a gate-listed suite that reads a path the same job's clearing scripts print on stdout, which is a set the job already computes.*

I measured that before building it. **It is 3-for-3 false.**

### What is cheap, and what is not

The mutated set is derivable without running anything destructive — both clearing scripts take `--dry-run`, and what they *write* is fixed:

| script | writes |
|---|---|
| `clear-satisfied-gir-gaps.mjs` | `scripts/manifest-conformance/prebuild-gir-gaps.mjs` |
| `clear-committed-platform-exemptions.mjs` | the package manifests |

Matching those against the five gate-listed suites flags three:

```
platform-exemption-clearing        11 matches
prebuild-declaration-invariant      5 matches
prebuild-change-gate                2 matches
```

**All three are hermetic.** The two known instances were *fixed* by moving to synthetic trees — and a fixed suite still names the path it builds a copy of. So the naive check fires on exactly the suites that are already correct.

A check with a 100 % false-positive rate gets disabled, and then protects nothing. `check-workflow-inline-scripts.mjs` records the same lesson from its own first draft, in its header:

> A first draft did exactly that: 23 findings, 21 false. A check with false positives gets disabled, and then protects nothing.

### The discriminator

It is not the path — it is the **root**. A read anchored at the repository (`MONOREPO_ROOT`, `ROOT`) versus one anchored at a tmpdir the suite made. That is what the check has to see, and it is why this is not a grep.

Written down because the naive version is the one an implementer reaches for first, and the entry as it stood was inviting it. No code here; the entry now costs the next attempt one measurement less.

### Validation

`audit-runtimes --check` ✅ (includes `status-data`)