### PR TITLE
docs: track the integration suites the comment said were tracked

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1583,10 +1583,15 @@ jobs:
             echo
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # Integration tests are NOT wired into CI yet (opt-in; suites have
-  # CI-incompatible preconditions). The classifier still emits run-integration
-  # so the gate can be re-enabled per-suite once each is hardened. Tracked in
-  # status/open-todos.md.
+  # Integration tests are NOT wired into CI yet. Measured: all 35 suites under
+  # `tests/integration/` appear in every workflow only as an EXCLUSION, so no
+  # event runs any of them. The classifier still emits `run-integration` — the
+  # half that works — so re-enabling the gate per-suite stays a small change.
+  # "CI-incompatible preconditions" is true of SOME (privileged Podman, an
+  # Android device, registry egress, system GIRs) and is not measured for the
+  # rest; that per-suite measurement, and why a hermetic subset rather than all
+  # 35, is `status/open-todos.md`. This comment claimed that tracking before the
+  # entry existed.
 
   # The ONE job this workflow's verdict may be read from — the branch-protection
   # required check. Everything else here is either a matrix leg (its name carries

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1772,6 +1772,19 @@ spec one line after the first fix landed; and `AbortController` carried no
 `AbortSignal` sibling had one all along. Four commented lines had been hiding
 three shipped bugs.
 
+### 35 integration suites run on no event, and the pointer to this entry predates it
+
+`main.yml` said "Integration tests are NOT wired into CI yet (opt-in; suites have CI-incompatible preconditions) … Tracked in `status/open-todos.md`." No entry tracked it. This is that entry, written after measuring the claim rather than inheriting it.
+
+MEASURED: `tests/integration/` holds 35 suites. Every mention of them in every workflow is an EXCLUSION — `--exclude "@gjsify/integration-*"` in the test shard and in `upgrade --check`. No event runs any of them: not push, not pull_request, not the nightly. The `changes` job still emits `run-integration`, and its only consumer is the step-summary line, so the classifier half is ready and the gate half was never built.
+
+NOT MEASURED, and this is the gap between "wire it up" and knowing what that costs: WHICH of the 35 are hermetic. The blanket phrase "CI-incompatible preconditions" is true of some — privileged Podman, an Android device, registry egress, system GIRs — and is being used to cover all 35. The measurement that settles it is per-suite and small: for each, does it reach the network, a device, or a system service? Until someone does it, "opt-in" describes the status quo rather than deciding it.
+
+Two things that must NOT be done in place of that measurement:
+
+- **Do not delete `run-integration`.** It is the half that already works, and deleting it makes re-enabling the gate a bigger change than it is.
+- **Do not wire all 35 at once.** They pin upstream projects, so every pinned dependency becomes a PR blocker the day it breaks — real on-call surface for a solo maintainer, and the reason a hermetic SUBSET is the shape worth building. Estimated ~10–13 min per triggering run for that tier, on one runner, conditional on the classifier output that already exists.
+
 ### Some small API gaps are declared only in a source comment
 
 Also from `todo-needs-anchor`'s first run. None is a defect — each is a known


### PR DESCRIPTION
`main.yml` carried this:

> Integration tests are NOT wired into CI yet (opt-in; suites have CI-incompatible preconditions). … **Tracked in `status/open-todos.md`.**

No entry tracked it. A pointer at a record that does not exist — the shape this repository has been paying down all week.

### Measured, not inherited

Every mention of `tests/integration/` in every workflow is an **exclusion**:

```
main.yml:375   upgrade --check --exclude-workspace '@gjsify/integration-*'
main.yml:969   gjsify foreach test … --exclude "@gjsify/integration-*"
```

No event runs any of the **35** suites — not push, not pull_request, not the nightly.

The `changes` job still emits `run-integration`, and its only consumer is the step-summary line. So the classifier half is ready and the gate half was never built.

### What is *not* measured is named as such

**Which of the 35 are hermetic.** "CI-incompatible preconditions" is true of *some* — privileged Podman, an Android device, registry egress, system GIRs — and was doing duty for all 35. The measurement that settles it is per-suite and small: for each, does it reach the network, a device, or a system service?

Until someone does that, "opt-in" *describes* the status quo rather than deciding it. Saying so is the point of the entry.

### Two anti-actions, written down because both are tempting

- **Do not delete `run-integration`.** It is the half that already works; deleting it makes re-enabling the gate a bigger change than it is.
- **Do not wire all 35 at once.** They pin upstream projects, so every pinned dependency becomes a PR blocker the day it breaks — real on-call surface for a solo maintainer, and the reason a hermetic **subset** is the shape worth building. Estimated ~10–13 min per triggering run for that tier, on one runner, conditional on the classifier output that already exists.

No code. The comment now says what is true, and points at an entry that exists.

### Validation

`audit-runtimes --check` ✅ (includes `status-data`) · `check-workflow-run-syntax` ✅