### PR TITLE
fix(cli): make classifyInstall answer for the target platform

### DIFF
--- a/packages/infra/cli/src/utils/install-provenance.spec.ts
+++ b/packages/infra/cli/src/utils/install-provenance.spec.ts
@@ -111,6 +111,33 @@ export default async () => {
             expect(v.managedElsewhere).toBe(false);
         });
 
+        await it('answers for the TARGET platform, not the host it runs on', async () => {
+            // The four cases above are POSIX-shaped. They ran green on Linux and red
+            // on the win32 leg of `main`, because the implementation resolved paths
+            // with the HOST's `node:path`: `resolve('/app/lib')` is `C:\\app\\lib`
+            // there and `sep` is a backslash. Pinned here so a host-path regression
+            // fails on every runner rather than only on the one nobody's PR runs.
+            const v = classifyInstall({
+                selfDir: '/usr/lib/gjsify',
+                xdgPrefix: XDG,
+                env: {},
+                platform: 'linux',
+            });
+            expect(v.kind).toBe('system-package');
+        });
+
+        await it('reads a Windows layout with Windows separators', async () => {
+            const prefix = 'C:\\Users\\dev\\AppData\\Local\\gjsify\\global';
+            const v = classifyInstall({
+                selfDir: `${prefix}\\node_modules\\@gjsify\\cli`,
+                xdgPrefix: prefix,
+                env: {},
+                platform: 'win32',
+            });
+            expect(v.kind).toBe('xdg-global');
+            expect(v.managedElsewhere).toBe(false);
+        });
+
         await it('does not read a system prefix on win32, where those paths mean nothing', async () => {
             const v = classifyInstall({
                 selfDir: 'C:\\\\Users\\\\dev\\\\AppData\\\\gjsify',

--- a/packages/infra/cli/src/utils/install-provenance.ts
+++ b/packages/infra/cli/src/utils/install-provenance.ts
@@ -17,7 +17,7 @@
 // build-time constant: one tarball is unpacked by all of these routes, so a flag
 // baked at build time would describe the builder rather than the installation.
 
-import { isAbsolute, resolve, sep } from 'node:path';
+import { posix, win32 } from 'node:path';
 
 /** Where the running CLI came from. */
 export type InstallProvenanceKind =
@@ -48,11 +48,26 @@ const SYSTEM_PREFIXES = ['/usr/', '/opt/', '/snap/'];
 /** Inside a Flatpak the whole app tree lives under this prefix. */
 const FLATPAK_PREFIX = '/app/';
 
+/**
+ * The TARGET platform's path module, never the host's.
+ *
+ * Same rule as `pathFor` in `install-global.ts`, and for the same reason: this
+ * function ACCEPTS a `platform` and must therefore answer for it. Reading the
+ * host's `node:path` instead makes every POSIX-shaped case unanswerable from a
+ * Windows runner — which is exactly what happened. Four of these tests went red on
+ * the win32 leg, on `main`, because `resolve('/app/lib')` there is `C:\app\lib`
+ * and `sep` is a backslash.
+ */
+function pathFor(platform: NodeJS.Platform): typeof win32 {
+    return platform === 'win32' ? win32 : posix;
+}
+
 /** Does `child` sit inside `parent`? Both must be absolute and already resolved. */
-function isInside(child: string, parent: string): boolean {
-    if (!isAbsolute(child) || !isAbsolute(parent)) return false;
-    const p = parent.endsWith(sep) ? parent : parent + sep;
-    return child === parent || child.startsWith(p);
+function isInside(child: string, parent: string, platform: NodeJS.Platform): boolean {
+    const p = pathFor(platform);
+    if (!p.isAbsolute(child) || !p.isAbsolute(parent)) return false;
+    const withSep = parent.endsWith(p.sep) ? parent : parent + p.sep;
+    return child === parent || child.startsWith(withSep);
 }
 
 export interface ProvenanceInput {
@@ -81,9 +96,10 @@ export interface ProvenanceInput {
 export function classifyInstall(input: ProvenanceInput): InstallProvenance {
     const env = input.env ?? process.env;
     const platform = input.platform ?? process.platform;
-    const selfDir = resolve(input.selfDir);
+    const p = pathFor(platform);
+    const selfDir = p.resolve(input.selfDir);
 
-    if (env.FLATPAK_ID || isInside(selfDir, FLATPAK_PREFIX)) {
+    if (env.FLATPAK_ID || isInside(selfDir, FLATPAK_PREFIX, platform)) {
         const id = env.FLATPAK_ID ?? 'io.github.gjsify.Cli';
         return {
             kind: 'flatpak',
@@ -93,7 +109,7 @@ export function classifyInstall(input: ProvenanceInput): InstallProvenance {
         };
     }
 
-    if (isInside(selfDir, resolve(input.xdgPrefix))) {
+    if (isInside(selfDir, p.resolve(input.xdgPrefix), platform)) {
         return {
             kind: 'xdg-global',
             evidence: `running from the user-global prefix ${input.xdgPrefix}`,
@@ -101,7 +117,7 @@ export function classifyInstall(input: ProvenanceInput): InstallProvenance {
         };
     }
 
-    if (platform !== 'win32' && SYSTEM_PREFIXES.some((p) => isInside(selfDir, p))) {
+    if (platform !== 'win32' && SYSTEM_PREFIXES.some((pfx) => isInside(selfDir, pfx, platform))) {
         return {
             kind: 'system-package',
             evidence: `running from the system prefix ${selfDir}`,
@@ -116,7 +132,7 @@ export function classifyInstall(input: ProvenanceInput): InstallProvenance {
         };
     }
 
-    if (selfDir.split(sep).includes('node_modules')) {
+    if (selfDir.split(p.sep).includes('node_modules')) {
         return {
             kind: 'npm-global',
             evidence: `running from a node_modules tree at ${selfDir}`,


### PR DESCRIPTION
**`main`'s Windows leg has been red since #1209** — seven hours and six commits.

Four `classifyInstall` tests fail there and pass everywhere else, which is the signature of a function that takes a `platform` argument and then reads the **host** for path semantics.

That is what it did:

```
resolve('/app/lib/gjsify')   →  on win32:  C:\app\lib\gjsify
sep                          →  on win32:  \
```

So every POSIX-shaped case became unanswerable, whatever `platform` said.

### The repo already had the answer

`install-global.ts` carries `pathFor()`, with the rule written on it:

> The TARGET platform's path module, never the host's — see `pathFor` in `utils/install-global.ts` for why (`resolve('C:\\x')` on posix is wrong).

Adopted here. All five path operations now go through it, and nothing in the file reads `node:path` directly any more.

### Pinned so it cannot come back quietly

Two assertions, because the original four only failed on the one runner no PR executes:

| | |
|---|---|
| POSIX layout under `platform: 'linux'` | resolves to `system-package` |
| Windows layout with backslashes under `platform: 'win32'` | resolves to `xdg-global` |

A host-path regression now fails on **every** runner.

### Why this reached main

`windows-suites.yml` filters `pull_request` to changes in **itself**, so no PR runs it. A green PR therefore cannot predict a green main here — which is precisely the property `docs/ci-selective.md` names as required:

> **PR coverage parity — a green PR must predict a green main.** A cost control makes a PR cheaper; a job that runs ONLY post-merge makes it DISHONEST.

Widening that trigger is a real decision with real runner cost, so it is recorded in the commit message rather than smuggled into a bugfix. It is the obvious follow-up.

### Validation

`@gjsify/cli` suite **2272 tests, all green** (run from the package directory — running it from the repo root produces 14 spurious module-resolution failures, which is how it is invoked in CI too) · `tsc --noEmit` ✅ · `audit-runtimes --check` ✅ · `gjsify lint` ✅ · `format --check` ✅