### PR TITLE
ci: trigger prebuilds on the suites its gate runs

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -124,6 +124,16 @@ on:
       - 'scripts/check-refs-pin.mjs'
       - 'scripts/check-prebuild-loader-path.mjs'
       - 'scripts/manifest-conformance/**'
+      # The four suites `gate-pushed-tree.sh` RUNS. Absent until now, so editing the
+      # gate's own content did not trigger the workflow that runs it — measured: the
+      # fix for a red `commit-prebuilds` touched `tests/e2e/prebuild-change-gate/` and
+      # produced no prebuilds run at all, on the PR or on the merge. Held by
+      # `prebuild-change-gate`'s own "its trigger covers what it runs" case.
+      - 'tests/e2e/platform-exemption-clearing/**'
+      - 'tests/e2e/prebuild-declaration-invariant/**'
+      - 'tests/e2e/prebuild-loader-path/**'
+      - 'tests/e2e/prebuild-change-gate/**'
+      - 'tests/e2e/stage-prebuild/**'
 
   # Repeated VERBATIM from `push` above — GitHub Actions supports no YAML
   # anchors, and the two lists MUST stay identical: a path that can change a
@@ -163,6 +173,16 @@ on:
       - 'scripts/check-refs-pin.mjs'
       - 'scripts/check-prebuild-loader-path.mjs'
       - 'scripts/manifest-conformance/**'
+      # The four suites `gate-pushed-tree.sh` RUNS. Absent until now, so editing the
+      # gate's own content did not trigger the workflow that runs it — measured: the
+      # fix for a red `commit-prebuilds` touched `tests/e2e/prebuild-change-gate/` and
+      # produced no prebuilds run at all, on the PR or on the merge. Held by
+      # `prebuild-change-gate`'s own "its trigger covers what it runs" case.
+      - 'tests/e2e/platform-exemption-clearing/**'
+      - 'tests/e2e/prebuild-declaration-invariant/**'
+      - 'tests/e2e/prebuild-loader-path/**'
+      - 'tests/e2e/prebuild-change-gate/**'
+      - 'tests/e2e/stage-prebuild/**'
 
 # Least privilege at the workflow level; each job adds only what it needs. This
 # is what keeps the new PR trigger from ever handing a write-capable token to a

--- a/tests/e2e/prebuild-change-gate/run.mjs
+++ b/tests/e2e/prebuild-change-gate/run.mjs
@@ -925,6 +925,27 @@ done`;
             ? { bin: 'bash', args: ['-n'], why: 'bash shebang' }
             : { bin: posixShell.bin, args: [...posixShell.args, '-n'], why: posixShell.why };
 
+    it('its trigger covers what it runs', () => {
+        // An allow-list that stops covering an input fails SILENT, and this one had
+        // stopped: `gate-pushed-tree.sh` runs four e2e suites, and `prebuilds.yml`'s
+        // `paths:` named none of them. Measured — the change that fixed a red
+        // `commit-prebuilds` edited THIS FILE and produced no prebuilds run at all,
+        // neither on the PR nor on the merge, so the repair could not be seen where it
+        // mattered. The gate's content and the gate's trigger are one claim; this
+        // derives the first from the script and holds the second to it.
+        const gate = readFileSync(gatePushedTree, 'utf8');
+        const suites = [...gate.matchAll(/tests\/e2e\/([a-z0-9-]+)\/run\.mjs/g)].map(([, name]) => name);
+        assert.ok(suites.length >= 4, `expected the gate to name several suites, found ${suites.length}`);
+        const triggers = readFileSync(workflow, 'utf8');
+        for (const name of new Set(suites)) {
+            assert.ok(
+                triggers.includes(`tests/e2e/${name}/**`),
+                `prebuilds.yml must trigger on tests/e2e/${name}/** — gate-pushed-tree.sh runs it, so a change ` +
+                    'there changes what the gate asserts, and nothing would rebuild',
+            );
+        }
+    });
+
     it('picks the parser from the shebang, in either bash spelling', () => {
         // The assertion that would have caught the original miss, and the reason it is
         // separate from the parse loop below: on a host where `sh` is bash, checking a


### PR DESCRIPTION
## The gap, found by the last fix failing to prove itself

`main` was red on `commit-prebuilds`. #1222 fixed the cause. Then **`prebuilds.yml` did not run at all** for that merge — not on the PR, not on `main` — because the fix touched `tests/e2e/prebuild-change-gate/` and `.docker/`, and neither is in the workflow's `paths:` allow-list.

`gate-pushed-tree.sh` runs **five** e2e suites:

```
tests/e2e/platform-exemption-clearing/run.mjs
tests/e2e/prebuild-change-gate/run.mjs
tests/e2e/prebuild-declaration-invariant/run.mjs
tests/e2e/prebuild-loader-path/run.mjs
tests/e2e/stage-prebuild/run.mjs
```

The allow-list named **none** of them. Editing what the gate asserts did not run the workflow that asserts it — and `docs/ci-selective.md` already records that an allow-list fails SILENT (#1028, #1149, #1173).

## What lands

Both trigger lists get the five paths, kept identical as the file's own comment requires.

**The mechanism matters more than the five lines.** `prebuild-change-gate` now derives the suite set from `gate-pushed-tree.sh` and holds `prebuilds.yml` to triggering on each. The gate's content and the gate's trigger are one claim, so a suite added to the script takes its path with it.

## It found something immediately

Written against a hand-written list of four, the new assertion **failed** and named a fifth: `tests/e2e/stage-prebuild/**`. That is the whole argument for deriving rather than listing, demonstrated on the first run.

## Verification

- New assertion against the tree before this change → **fails**, naming the uncovered suites.
- Remove any one path again → **fails**, naming it.
- With the paths in place → 37/37 pass.
- Both `push` and `pull_request` lists compared programmatically: identical.

Merging this also runs `prebuilds.yml` on `main` for the first time since #1222 — which is how the shell-parser fix finally gets exercised in `commit-prebuilds`, the only job that can show it.