### PR TITLE
fix(vite-plugin-blueprint): prove every OS branch

### DIFF
--- a/packages/infra/vite-plugin-blueprint/README.md
+++ b/packages/infra/vite-plugin-blueprint/README.md
@@ -14,7 +14,10 @@ npm install @gjsify/vite-plugin-blueprint
 yarn add @gjsify/vite-plugin-blueprint
 ```
 
-Requires `blueprint-compiler` to be installed on the system (e.g. `sudo dnf install blueprint-compiler`).
+Requires `blueprint-compiler` on the system (e.g. `sudo dnf install blueprint-compiler`). It is found on
+`PATH`, and on Windows also in an MSYS2 install that is not on `PATH`; set `BLUEPRINT_COMPILER` to point at
+one the plugin does not find. When there is none, the build error names the install command for the host it
+ran on rather than leaving you to guess — so this README does not repeat one per platform.
 
 ## Usage
 

--- a/packages/infra/vite-plugin-blueprint/package.json
+++ b/packages/infra/vite-plugin-blueprint/package.json
@@ -24,9 +24,12 @@
         "types"
     ],
     "scripts": {
-        "clear": "gjsify clear lib tsconfig.tsbuildinfo",
+        "clear": "gjsify clear lib tsconfig.tsbuildinfo test.node.mjs",
         "check": "gjsify tsc --noEmit",
-        "build": "gjsify tsc"
+        "build": "gjsify tsc -p tsconfig.build.json",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile test.node.mjs",
+        "test": "gjsify run build:test:node && gjsify run test:node",
+        "test:node": "node test.node.mjs"
     },
     "repository": {
         "type": "git",
@@ -63,6 +66,8 @@
         }
     },
     "devDependencies": {
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/unit": "workspace:^",
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3",
         "vite": "^8.1.3"

--- a/packages/infra/vite-plugin-blueprint/src/index.ts
+++ b/packages/infra/vite-plugin-blueprint/src/index.ts
@@ -1,39 +1,58 @@
 import { type Plugin } from 'vite';
 import { execa } from 'execa';
 import minifyXML from 'minify-xml';
-import { formatMissingBlueprintCompiler, resolveBlueprintCompiler } from './resolve-compiler.js';
+import {
+    BlueprintCompileError,
+    BlueprintCompilerNotFoundError,
+    type ResolvedBlueprintCompiler,
+    resolveBlueprintCompiler,
+} from './resolve-compiler.js';
 
 export interface BlueprintPluginOptions {
     minify?: boolean;
     verbose?: boolean;
 }
 
-export { resolveBlueprintCompiler, formatMissingBlueprintCompiler } from './resolve-compiler.js';
+export {
+    BlueprintCompileError,
+    BlueprintCompilerNotFoundError,
+    type BlueprintHost,
+    currentBlueprintHost,
+    formatMissingBlueprintCompiler,
+    type ResolvedBlueprintCompiler,
+    resolveBlueprintCompiler,
+} from './resolve-compiler.js';
 
 export default function blueprintPlugin(options: BlueprintPluginOptions = {}): Plugin {
     const { minify = false, verbose = false } = options;
+
+    // Cached only on SUCCESS, so the PATH walk costs one probe per plugin
+    // instance instead of one per `.blp`. A MISS is deliberately re-probed:
+    // installing the compiler and saving the file is how a watch session is
+    // meant to recover, and caching "absent" would make that need a restart.
+    let compiler: ResolvedBlueprintCompiler | null = null;
 
     return {
         name: 'vite-plugin-blueprint',
 
         async load(id) {
             if (id.endsWith('.blp')) {
-                // Resolved per load rather than once at plugin construction, so a
-                // compiler installed mid-watch is picked up without a restart —
-                // and so the "missing" diagnostic names the .blp that wanted it.
-                const compiler = resolveBlueprintCompiler();
+                compiler ??= resolveBlueprintCompiler();
                 if (!compiler) {
-                    throw new Error(`${id}: ${formatMissingBlueprintCompiler()}`);
+                    // Names the `.blp` that wanted it, so the diagnostic points at
+                    // a file the reader recognises rather than at the plugin.
+                    throw new BlueprintCompilerNotFoundError(id);
                 }
+                const resolved = compiler;
 
                 try {
                     // Compile .blp file and get XML output directly
-                    const { stdout } = await execa(compiler.file, [...compiler.prefixArgs, 'compile', id], {
+                    const { stdout } = await execa(resolved.file, [...resolved.prefixArgs, 'compile', id], {
                         // Only ever an overlay (an MSYS2 PATH prepend); undefined
                         // inherits the environment unchanged.
-                        env: compiler.env,
+                        env: resolved.env,
                     });
-                    if (verbose) console.log(`Compiled ${id} (blueprint-compiler via ${compiler.source})`);
+                    if (verbose) console.log(`Compiled ${id} (blueprint-compiler via ${resolved.source})`);
 
                     let xmlContent = stdout;
 
@@ -46,13 +65,9 @@ export default function blueprintPlugin(options: BlueprintPluginOptions = {}): P
                     // Return the XML content as a string
                     return `export default ${JSON.stringify(xmlContent)};`;
                 } catch (error) {
-                    // The compiler EXISTS and refused the file, so this is a
-                    // blueprint syntax/type error and its own stderr is the
-                    // useful part — surface that, not an install hint the reader
-                    // has already satisfied.
                     const detail =
                         error instanceof Error ? (error as { stderr?: string }).stderr || error.message : String(error);
-                    throw new Error(`${id}: blueprint-compiler failed (${compiler.file})\n${detail}`);
+                    throw new BlueprintCompileError(id, resolved.file, detail);
                 }
             }
         },

--- a/packages/infra/vite-plugin-blueprint/src/resolve-compiler.spec.ts
+++ b/packages/infra/vite-plugin-blueprint/src/resolve-compiler.spec.ts
@@ -1,0 +1,237 @@
+// Every case here drives INJECTED host facts, so the win32 and darwin branches
+// — which are most of this module, and the ones nobody can exercise from CI —
+// are decided on a Linux box. A test that read ambient `process.platform` could
+// only ever cover one third of the file, and it would be the third that has
+// never been the problem.
+
+import { join } from 'node:path';
+import { describe, expect, it } from '@gjsify/unit';
+import {
+    BlueprintCompileError,
+    BlueprintCompilerNotFoundError,
+    type BlueprintHost,
+    formatMissingBlueprintCompiler,
+    resolveBlueprintCompiler,
+} from './resolve-compiler.js';
+
+/** A host with nothing installed. A case overrides only what it is about. */
+function host(over: Partial<BlueprintHost> = {}): BlueprintHost {
+    return { platform: 'linux', env: {}, exists: () => false, ...over };
+}
+
+/** `exists` backed by an explicit set, so a case states its whole filesystem. */
+function withFiles(...paths: string[]): (path: string) => boolean {
+    const present = new Set(paths);
+    return (path) => present.has(path);
+}
+
+export default async () => {
+    await describe('resolveBlueprintCompiler', async () => {
+        await it('answers null on a host with nothing installed', async () => {
+            expect(resolveBlueprintCompiler(host())).toBe(null);
+        });
+
+        await it('finds a POSIX compiler on PATH', async () => {
+            const found = join('/usr/bin', 'blueprint-compiler');
+            const resolved = resolveBlueprintCompiler(
+                host({ env: { PATH: '/usr/local/bin:/usr/bin' }, exists: withFiles(found) }),
+            );
+            expect(resolved).toStrictEqual({ file: found, prefixArgs: [], source: 'path' });
+        });
+
+        await it('splits PATH on the separator the host uses, not the one we run on', async () => {
+            // A win32 PATH split on ':' would break at the drive letter and find
+            // nothing; a POSIX PATH split on ';' would yield one unusable entry.
+            const win = join('C:\\Program Files\\bp', 'blueprint-compiler.exe');
+            expect(
+                resolveBlueprintCompiler(
+                    host({
+                        platform: 'win32',
+                        env: { PATH: 'C:\\Windows\\System32;C:\\Program Files\\bp' },
+                        exists: withFiles(win),
+                    }),
+                )?.file,
+            ).toBe(win);
+
+            expect(
+                resolveBlueprintCompiler(
+                    host({ env: { PATH: '/a;/b' }, exists: withFiles(join('/a', 'blueprint-compiler')) }),
+                ),
+            ).toBe(null);
+        });
+
+        await it('tries the win32 executable suffixes, and only there', async () => {
+            const cmd = join('C:\\bin', 'blueprint-compiler.cmd');
+            expect(
+                resolveBlueprintCompiler(host({ platform: 'win32', env: { PATH: 'C:\\bin' }, exists: withFiles(cmd) }))
+                    ?.file,
+            ).toBe(cmd);
+
+            // The same filesystem on POSIX is a miss: `.cmd` is not an executable
+            // suffix there, and inventing one would find a file we cannot spawn.
+            expect(resolveBlueprintCompiler(host({ env: { PATH: 'C:\\bin' }, exists: withFiles(cmd) }))).toBe(null);
+        });
+
+        await it('finds an MSYS2 install that is deliberately NOT on PATH', async () => {
+            // The reason the MSYS2 probe exists: MSYS2 does not put its bin dirs
+            // on the system PATH, so a PATH-only answer reports "missing" on a
+            // host where every `.blp` would build.
+            const bin = join('C:\\msys64', 'ucrt64', 'bin');
+            const script = join(bin, 'blueprint-compiler');
+            const python = join(bin, 'python.exe');
+            const resolved = resolveBlueprintCompiler(
+                host({ platform: 'win32', env: { PATH: 'C:\\Windows\\System32' }, exists: withFiles(script, python) }),
+            );
+            expect(resolved).toStrictEqual({
+                file: python,
+                prefixArgs: [script],
+                env: { PATH: `${bin};C:\\Windows\\System32` },
+                source: 'msys2',
+            });
+        });
+
+        await it('spawns MSYS2 python rather than the shebang script Windows cannot execute', async () => {
+            // A script with no interpreter beside it is not a usable answer.
+            const bin = join('C:\\msys64', 'ucrt64', 'bin');
+            expect(
+                resolveBlueprintCompiler(
+                    host({ platform: 'win32', exists: withFiles(join(bin, 'blueprint-compiler')) }),
+                ),
+            ).toBe(null);
+        });
+
+        await it('honours MSYS2_ROOT and USERPROFILE installs', async () => {
+            const bin = join('D:\\dev\\msys64', 'mingw64', 'bin');
+            expect(
+                resolveBlueprintCompiler(
+                    host({
+                        platform: 'win32',
+                        env: { MSYS2_ROOT: 'D:\\dev\\msys64' },
+                        exists: withFiles(join(bin, 'blueprint-compiler'), join(bin, 'python.exe')),
+                    }),
+                )?.source,
+            ).toBe('msys2');
+
+            const userBin = join(join('C:\\Users\\p', 'msys64'), 'clang64', 'bin');
+            expect(
+                resolveBlueprintCompiler(
+                    host({
+                        platform: 'win32',
+                        env: { USERPROFILE: 'C:\\Users\\p' },
+                        exists: withFiles(join(userBin, 'blueprint-compiler'), join(userBin, 'python.exe')),
+                    }),
+                )?.source,
+            ).toBe('msys2');
+        });
+
+        await it('never probes MSYS2 off win32', async () => {
+            const bin = join('C:\\msys64', 'ucrt64', 'bin');
+            const files = withFiles(join(bin, 'blueprint-compiler'), join(bin, 'python.exe'));
+            expect(resolveBlueprintCompiler(host({ platform: 'darwin', exists: files }))).toBe(null);
+            expect(resolveBlueprintCompiler(host({ exists: files }))).toBe(null);
+        });
+
+        await it('takes BLUEPRINT_COMPILER as a path when it names one', async () => {
+            const resolved = resolveBlueprintCompiler(
+                host({ env: { BLUEPRINT_COMPILER: '/opt/bp/bin/bpc' }, exists: withFiles('/opt/bp/bin/bpc') }),
+            );
+            expect(resolved).toStrictEqual({ file: '/opt/bp/bin/bpc', prefixArgs: [], source: 'env' });
+        });
+
+        await it('looks a bare BLUEPRINT_COMPILER name up on PATH', async () => {
+            const found = join('/usr/bin', 'bpc');
+            expect(
+                resolveBlueprintCompiler(
+                    host({ env: { BLUEPRINT_COMPILER: 'bpc', PATH: '/usr/bin' }, exists: withFiles(found) }),
+                ),
+            ).toStrictEqual({ file: found, prefixArgs: [], source: 'env' });
+        });
+
+        await it('refuses a set-but-unusable override instead of silently searching past it', async () => {
+            // Returning the bad path sent its ENOENT into the "the compiler EXISTS
+            // and refused the file" branch, which then blamed the .blp for a typo
+            // in an environment variable. Falling through to PATH would instead
+            // run a different compiler than the one the caller demanded.
+            const onPath = join('/usr/bin', 'blueprint-compiler');
+            expect(
+                resolveBlueprintCompiler(
+                    host({
+                        env: { BLUEPRINT_COMPILER: '/typo/blueprint-compiler', PATH: '/usr/bin' },
+                        exists: withFiles(onPath),
+                    }),
+                ),
+            ).toBe(null);
+            expect(
+                resolveBlueprintCompiler(
+                    host({ env: { BLUEPRINT_COMPILER: 'bpc', PATH: '/usr/bin' }, exists: withFiles(onPath) }),
+                ),
+            ).toBe(null);
+        });
+    });
+
+    await describe('formatMissingBlueprintCompiler', async () => {
+        await it('says what the compiler is FOR, not just that it is absent', async () => {
+            expect(formatMissingBlueprintCompiler(host())).toContain('GtkBuilder XML');
+        });
+
+        await it('gives one Linux line that is right on every distro', async () => {
+            const message = formatMissingBlueprintCompiler(host());
+            expect(message).toContain('sudo dnf install blueprint-compiler');
+            for (const manager of ['apt', 'pacman', 'zypper', 'apk']) {
+                expect(message).toContain(manager);
+            }
+            expect(message).not.toContain('brew');
+        });
+
+        await it('names brew on darwin and MSYS2 on win32, and neither elsewhere', async () => {
+            expect(formatMissingBlueprintCompiler(host({ platform: 'darwin' }))).toContain(
+                'brew install blueprint-compiler',
+            );
+            const win = formatMissingBlueprintCompiler(host({ platform: 'win32' }));
+            expect(win).toContain('mingw-w64-ucrt-x86_64-blueprint-compiler');
+            // The conclusion this whole message exists to prevent — that the tool
+            // is simply unavailable on Windows — is answered in the message.
+            expect(win).toContain('no Windows wheel');
+            expect(win).toContain('does NOT need to be on PATH');
+            expect(win).not.toContain('sudo dnf');
+        });
+
+        await it('does not repeat "set BLUEPRINT_COMPILER" at someone who just set it', async () => {
+            const missingPath = formatMissingBlueprintCompiler(host({ env: { BLUEPRINT_COMPILER: '/typo/bpc' } }));
+            expect(missingPath).toContain('/typo/bpc');
+            expect(missingPath).toContain('not a file that exists');
+            expect(missingPath).not.toContain('sudo dnf');
+            expect(missingPath).not.toContain('Or set BLUEPRINT_COMPILER');
+
+            const missingName = formatMissingBlueprintCompiler(host({ env: { BLUEPRINT_COMPILER: 'bpc' } }));
+            expect(missingName).toContain('not on PATH');
+        });
+    });
+
+    await describe('the error classes', async () => {
+        await it('BlueprintCompilerNotFoundError names the .blp and carries the hint', async () => {
+            const error = new BlueprintCompilerNotFoundError('/src/main-window.blp', host());
+            expect(error.name).toBe('BlueprintCompilerNotFoundError');
+            expect(error.blueprintPath).toBe('/src/main-window.blp');
+            expect(error.message).toContain('/src/main-window.blp');
+            expect(error.message).toContain('sudo dnf install blueprint-compiler');
+        });
+
+        await it('BlueprintCompileError surfaces the compiler diagnostic and no install hint', async () => {
+            // The reader has the compiler; repeating how to install it buries the
+            // one line that tells them what is wrong with their template.
+            const error = new BlueprintCompileError(
+                '/src/main-window.blp',
+                '/usr/bin/blueprint-compiler',
+                'main-window.blp:3:1: expected `{`',
+            );
+            expect(error.name).toBe('BlueprintCompileError');
+            expect(error.compilerFile).toBe('/usr/bin/blueprint-compiler');
+            expect(error.message).toContain('/src/main-window.blp');
+            expect(error.message).toContain('/usr/bin/blueprint-compiler');
+            expect(error.message).toContain('expected `{`');
+            expect(error.message).not.toContain('install');
+            expect(error.message).not.toContain('BLUEPRINT_COMPILER');
+        });
+    });
+};

--- a/packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts
+++ b/packages/infra/vite-plugin-blueprint/src/resolve-compiler.ts
@@ -26,6 +26,44 @@ export interface ResolvedBlueprintCompiler {
 }
 
 /**
+ * The host facts this module decides on, taken as a PARAMETER rather than read
+ * from ambient `process.*`.
+ *
+ * Every unit-test leg in this repo runs on Linux, so an ambient
+ * `process.platform` puts the darwin and win32 branches — which are most of this
+ * module and the only ones anybody gets wrong — out of reach of any test. This
+ * is the purity `packages/infra/cli/src/utils/platform-check.ts` documents,
+ * applied to the module whose entire job is a per-OS answer.
+ */
+export interface BlueprintHost {
+    /** `process.platform` of the host being answered for. */
+    platform: NodeJS.Platform;
+    /** That host's environment. */
+    env: Record<string, string | undefined>;
+    /** Does this path exist? `existsSync` in production, a map in a test. */
+    exists: (path: string) => boolean;
+}
+
+/**
+ * `existsSync` throws rather than answering `false` when the argument is not a
+ * usable path at all (an embedded NUL, for one) — and an unreadable or malformed
+ * PATH entry is not an answer about the command we are looking for. Same catch,
+ * and same reason, as `isOnPath()` in `@gjsify/cli`'s `check-system-deps.ts`.
+ */
+function existsSafe(path: string): boolean {
+    try {
+        return existsSync(path);
+    } catch {
+        return false;
+    }
+}
+
+/** The running process as a {@link BlueprintHost}. */
+export function currentBlueprintHost(): BlueprintHost {
+    return { platform: process.platform, env: process.env, exists: existsSafe };
+}
+
+/**
  * MSYS2 install roots to probe on win32, in order.
  *
  * MSYS2 is the ONLY way to get blueprint-compiler onto Windows today, and not
@@ -39,13 +77,15 @@ export interface ResolvedBlueprintCompiler {
  * extracted-archive install, which is what a host without admin rights gets;
  * `C:\tools\msys64` is Chocolatey's.
  */
-const MSYS2_ROOTS = [
-    process.env.MSYS2_ROOT,
-    'C:\\msys64',
-    process.env.USERPROFILE && join(process.env.USERPROFILE, 'msys64'),
-    process.env.USERPROFILE && join(process.env.USERPROFILE, 'Tools', 'msys64'),
-    'C:\\tools\\msys64',
-].filter((root): root is string => typeof root === 'string' && root.length > 0);
+function msys2Roots(env: BlueprintHost['env']): string[] {
+    return [
+        env.MSYS2_ROOT,
+        'C:\\msys64',
+        env.USERPROFILE && join(env.USERPROFILE, 'msys64'),
+        env.USERPROFILE && join(env.USERPROFILE, 'Tools', 'msys64'),
+        'C:\\tools\\msys64',
+    ].filter((root): root is string => typeof root === 'string' && root.length > 0);
+}
 
 /**
  * MSYS2 environments, most-preferred first. `ucrt64` is MSYS2's own default for
@@ -55,22 +95,20 @@ const MSYS2_ROOTS = [
 const MSYS2_ENVS = ['ucrt64', 'mingw64', 'clang64'];
 
 /** Executable suffixes to try for a bare command name. Windows needs them; POSIX does not. */
-const EXE_SUFFIXES = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+function exeSuffixes(platform: NodeJS.Platform): string[] {
+    return platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+}
 
 /** First existing `<dir>/<cmd><suffix>`, or null. */
-function findOnPath(cmd: string): string | null {
-    const pathVar = process.env.PATH;
+function findOnPath(cmd: string, host: BlueprintHost): string | null {
+    const pathVar = host.env.PATH;
     if (!pathVar) return null;
-    const sep = process.platform === 'win32' ? ';' : ':';
+    const sep = host.platform === 'win32' ? ';' : ':';
     for (const dir of pathVar.split(sep)) {
         if (!dir) continue;
-        for (const suffix of EXE_SUFFIXES) {
+        for (const suffix of exeSuffixes(host.platform)) {
             const candidate = join(dir, cmd + suffix);
-            try {
-                if (existsSync(candidate)) return candidate;
-            } catch {
-                // An unreadable PATH entry is not an answer about `cmd`.
-            }
+            if (host.exists(candidate)) return candidate;
         }
     }
     return null;
@@ -92,27 +130,29 @@ function findOnPath(cmd: string): string | null {
  * on PATH) would load two GLib builds into one process, which is a worse problem
  * than the one it solves.
  */
-function findInMsys2(): ResolvedBlueprintCompiler | null {
-    if (process.platform !== 'win32') return null;
-    for (const root of MSYS2_ROOTS) {
+function findInMsys2(host: BlueprintHost): ResolvedBlueprintCompiler | null {
+    if (host.platform !== 'win32') return null;
+    for (const root of msys2Roots(host.env)) {
         for (const env of MSYS2_ENVS) {
             const bin = join(root, env, 'bin');
             const script = join(bin, 'blueprint-compiler');
             const python = join(bin, 'python.exe');
-            try {
-                if (!existsSync(script) || !existsSync(python)) continue;
-            } catch {
-                continue;
-            }
+            if (!host.exists(script) || !host.exists(python)) continue;
             return {
                 file: python,
                 prefixArgs: [script],
-                env: { PATH: `${bin};${process.env.PATH ?? ''}` },
+                // `;` is a win32 fact, not a host fact — this branch only runs there.
+                env: { PATH: `${bin};${host.env.PATH ?? ''}` },
                 source: 'msys2',
             };
         }
     }
     return null;
+}
+
+/** Does this override name a location, as opposed to a bare command to look up? */
+function looksLikePath(override: string): boolean {
+    return override.includes('/') || override.includes('\\');
 }
 
 /**
@@ -121,17 +161,32 @@ function findInMsys2(): ResolvedBlueprintCompiler | null {
  * Order: `BLUEPRINT_COMPILER` (an explicit answer always wins, and is the escape
  * hatch for an install none of the probes below know about) → `PATH` → an MSYS2
  * install on win32.
+ *
+ * A set-but-unusable override resolves to null rather than falling through to
+ * the probes. Handing back a path that is not there sent its `ENOENT` into the
+ * "the compiler EXISTS and refused the file" branch, which then blamed the
+ * `.blp` for a typo in an environment variable; and quietly ignoring an explicit
+ * instruction to run a second guess is not better. Null is what lets
+ * {@link formatMissingBlueprintCompiler} say which of the two actually happened.
  */
-export function resolveBlueprintCompiler(): ResolvedBlueprintCompiler | null {
-    const override = process.env.BLUEPRINT_COMPILER;
+export function resolveBlueprintCompiler(
+    host: BlueprintHost = currentBlueprintHost(),
+): ResolvedBlueprintCompiler | null {
+    const override = host.env.BLUEPRINT_COMPILER;
     if (override) {
-        return { file: override, prefixArgs: [], source: 'env' };
+        if (looksLikePath(override)) {
+            return host.exists(override) ? { file: override, prefixArgs: [], source: 'env' } : null;
+        }
+        // A bare command name is a legitimate override, and must still reach the
+        // child through the same PATH walk any other command name gets.
+        const onPath = findOnPath(override, host);
+        return onPath ? { file: onPath, prefixArgs: [], source: 'env' } : null;
     }
-    const onPath = findOnPath('blueprint-compiler');
+    const onPath = findOnPath('blueprint-compiler', host);
     if (onPath) {
         return { file: onPath, prefixArgs: [], source: 'path' };
     }
-    return findInMsys2();
+    return findInMsys2(host);
 }
 
 /**
@@ -139,22 +194,75 @@ export function resolveBlueprintCompiler(): ResolvedBlueprintCompiler | null {
  *
  * Names the install command for THIS platform rather than listing every one:
  * the reader is on one host and the other two lines are noise they have to
- * filter. `BLUEPRINT_COMPILER` is mentioned everywhere because it is the answer
- * for any install the probes miss.
+ * filter. The Linux arm is the exception that proves it — every Linux row of
+ * `PM_PACKAGES` in `@gjsify/cli`'s `check-system-deps.ts` spells the package
+ * identically, so splitting it per distro would be four lines carrying one word.
+ *
+ * `BLUEPRINT_COMPILER` is mentioned everywhere because it is the answer for any
+ * install the probes miss — except when it is itself the problem, which gets its
+ * own sentence: repeating "or set BLUEPRINT_COMPILER" at someone who just set it
+ * is how a diagnostic loses their trust.
  */
-export function formatMissingBlueprintCompiler(): string {
+export function formatMissingBlueprintCompiler(host: BlueprintHost = currentBlueprintHost()): string {
+    const override = host.env.BLUEPRINT_COMPILER;
+    if (override) {
+        return (
+            `BLUEPRINT_COMPILER is set to "${override}", which is not ${
+                looksLikePath(override) ? 'a file that exists' : 'on PATH'
+            }.\n` +
+            '  Point it at a blueprint-compiler executable, or unset it to search PATH\n' +
+            '  (and, on Windows, the usual MSYS2 install locations).'
+        );
+    }
     const install =
-        process.platform === 'win32'
+        host.platform === 'win32'
             ? 'MSYS2 packages it prebuilt (it needs PyGObject, which has no Windows wheel, so pip cannot):\n' +
               '    pacman -S mingw-w64-ucrt-x86_64-blueprint-compiler mingw-w64-ucrt-x86_64-gtk4 mingw-w64-ucrt-x86_64-libadwaita\n' +
               '  An MSYS2 install under C:\\msys64, %USERPROFILE%\\msys64, %USERPROFILE%\\Tools\\msys64 or\n' +
               '  C:\\tools\\msys64 is found automatically — it does NOT need to be on PATH.'
-            : process.platform === 'darwin'
+            : host.platform === 'darwin'
               ? 'brew install blueprint-compiler'
-              : 'sudo dnf install blueprint-compiler   (Debian/Ubuntu: sudo apt install blueprint-compiler)';
+              : 'sudo dnf install blueprint-compiler   (apt, pacman, zypper and apk package it under the same name)';
     return (
-        'blueprint-compiler was not found, so a .blp template cannot be compiled.\n' +
+        'blueprint-compiler was not found — @gjsify/vite-plugin-blueprint needs it to\n' +
+        '  compile .blp templates to GtkBuilder XML.\n' +
         `  ${install}\n` +
         '  Or set BLUEPRINT_COMPILER to its full path.'
     );
+}
+
+/**
+ * No usable compiler on this host.
+ *
+ * Carries the whole user-facing sentence so the wording has exactly one home and
+ * the plugin composes nothing: what this replaces was an `ExecaError` naming the
+ * COMMAND, in the guest's own language, from inside a rolldown plugin stack
+ * (#1098).
+ */
+export class BlueprintCompilerNotFoundError extends Error {
+    override readonly name = 'BlueprintCompilerNotFoundError';
+
+    constructor(
+        readonly blueprintPath: string,
+        host: BlueprintHost = currentBlueprintHost(),
+    ) {
+        super(`${blueprintPath}: ${formatMissingBlueprintCompiler(host)}`);
+    }
+}
+
+/**
+ * The compiler exists and refused the file, so this is a blueprint syntax or
+ * type error and its own stderr is the useful part — never an install hint the
+ * reader has already satisfied.
+ */
+export class BlueprintCompileError extends Error {
+    override readonly name = 'BlueprintCompileError';
+
+    constructor(
+        readonly blueprintPath: string,
+        readonly compilerFile: string,
+        detail: string,
+    ) {
+        super(`${blueprintPath}: blueprint-compiler failed (${compilerFile})\n${detail}`);
+    }
 }

--- a/packages/infra/vite-plugin-blueprint/src/test.mts
+++ b/packages/infra/vite-plugin-blueprint/src/test.mts
@@ -1,0 +1,5 @@
+import { run } from '@gjsify/unit';
+
+import resolveCompilerSuite from './resolve-compiler.spec.js';
+
+run({ resolveCompilerSuite });

--- a/packages/infra/vite-plugin-blueprint/tsconfig.build.json
+++ b/packages/infra/vite-plugin-blueprint/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": ["src/test.mts", "src/**/*.spec.ts", "src/**/*.spec.mts"]
+}

--- a/packages/infra/vite-plugin-blueprint/tsconfig.json
+++ b/packages/infra/vite-plugin-blueprint/tsconfig.json
@@ -11,5 +11,12 @@
         "skipLibCheck": true,
         "types": ["node"]
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*"],
+    "comment": [
+        "Specs stay INCLUDED here on purpose, so `check` type-checks them; only",
+        "`tsconfig.build.json` drops them, because `files` publishes `lib/` and an",
+        "emitted spec would ship. The test ENTRY is excluded from both: it is",
+        "compiled by the test task, which resolves `@gjsify/unit` for it."
+    ],
+    "exclude": ["src/test.mts"]
 }

--- a/tests/e2e/create-app/run.mjs
+++ b/tests/e2e/create-app/run.mjs
@@ -11,6 +11,10 @@ import { writeFileSync, readFileSync, existsSync, mkdtempSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+// The zero-dependency subpath, deliberately: the plugin root would pull vite,
+// execa and minify-xml into an e2e suite that only wants the answer.
+import { resolveBlueprintCompiler } from '@gjsify/vite-plugin-blueprint/resolve';
+
 import {
     MONOREPO_ROOT,
     createTestEnvironment,
@@ -33,16 +37,16 @@ const TEMPLATES = [
     'web-server-express',
 ];
 
-// Templates that compile `.blp` files — require blueprint-compiler on PATH.
+// Templates that compile `.blp` files — require a blueprint-compiler the BUILD
+// can find. Asking the resolver rather than probing PATH ourselves is the whole
+// point: on win32 MSYS2 does not put its bin dirs on PATH, so a `--version`
+// probe answers "missing" and skips three templates on a host where every one of
+// them builds. The resolver is what the plugin actually spawns, so it is the
+// only answer that predicts the build.
 const BLUEPRINT_TEMPLATES = new Set(['adw-canvas2d', 'adw-webgl', 'adw-game']);
 
 function hasBlueprintCompiler() {
-    try {
-        execFileSync('blueprint-compiler', ['--version'], { stdio: 'pipe' });
-        return true;
-    } catch {
-        return false;
-    }
+    return resolveBlueprintCompiler() !== null;
 }
 
 /**


### PR DESCRIPTION
Closes the first half of #1098 — and, more to the point, makes it *hold*.

## What was actually missing

The preflight the issue asks for (say how to install `blueprint-compiler` instead of dumping an `ExecaError`) landed in 0.36.0. What never landed is anything that keeps it true: the package had **no test runner at all**, and three of `resolve-compiler.ts`'s four decision points were ambient reads of `process.platform` / `process.env` — so the win32 and darwin branches, which are most of the file and the only ones anyone gets wrong, were unreachable from a Linux CI box.

`resolve-compiler.ts` now takes the host as a parameter: `BlueprintHost { platform, env, exists }`, defaulted to `currentBlueprintHost()`, so every existing caller is source-compatible and it is an additive optional parameter on a published tier-1 package. That is the purity `packages/infra/cli/src/utils/platform-check.ts` documents and `manifest-conformance`'s `os-axis.mjs` cites, applied to the module whose entire job is a per-OS answer.

## Four defects that only became visible once it was testable

| | |
|---|---|
| The Linux hint named **dnf and apt only** | `PM_PACKAGES` in `@gjsify/cli` proves pacman, zypper and apk spell the package identically — so one line is right on every distro, and four lines would carry one word |
| The message never said what the compiler is **for** | It now names GtkBuilder XML, which is the fact that makes the install worth doing |
| `BLUEPRINT_COMPILER` was returned **unchecked** | A typo'd path reached execa, and its `ENOENT` surfaced through the branch whose comment asserts *"the compiler EXISTS and refused the file"* — blaming the `.blp` for a mistake in an environment variable. A set-but-unusable override now resolves to `null` and gets its own sentence instead of an install hint the reader has already satisfied. A **bare** override name is still legitimate and goes through the same PATH walk. |
| `tests/e2e/create-app` had a **fourth probe** that disagreed with the resolver | `execFileSync('blueprint-compiler', ['--version'])` answers "missing" on a win32 host whose MSYS2 install is deliberately off PATH — skipping three templates that would have built. It now asks the resolver the build actually spawns. |

Both throw sites become named classes (`BlueprintCompilerNotFoundError`, `BlueprintCompileError`), defined in the zero-dependency `/resolve` module so they are testable without execa or vite, and re-exported from the root so a vite-config author can `instanceof` them. The compiler probe is cached on **success only** — a miss stays re-probed, because installing the compiler and saving the file is how a watch session is meant to recover.

## Verification

- 44 assertions in the new suite, and `gjsify foreach test --include "@gjsify/vite-plugin-blueprint"` proves the root aggregator reaches it.
- `@gjsify/cli`'s 2274 assertions still green, including its three blueprint rows.
- `check` type-checks the spec while `tsconfig.build.json` keeps it out of `lib/` — confirmed **after a `clear`**, so the empty result is not stale state.
- `audit-test-scripts` and `audit-runtimes --check` clean; the committed `affected.gjs.mjs` is byte-identical (rebuilt and compared).

**The tests were mutation-checked, not merely run.** Forcing the PATH separator to `':'` and letting a broken override fall through to PATH each turn the suite red — so it discriminates the two properties it exists to hold, rather than passing whatever the implementation does.

## Out of scope

The second half of #1098 — porting `blueprint-compiler` rather than requiring it, the axis-6 treatment — is untouched and the issue stays open for it.