### PR TITLE
refactor(e2e): one mock registry, not twenty

### DIFF
--- a/scripts/check-e2e-harness-duplication.mjs
+++ b/scripts/check-e2e-harness-duplication.mjs
@@ -38,7 +38,28 @@ const SHARED_MODULE = 'mock-registry.mjs';
  *
  * @type {Array<{ suite: string, rule: string, why: string }>}
  */
-const ALLOWED = [];
+const ALLOWED = [
+    {
+        suite: 'publish',
+        rule: 'registry-server',
+        why: 'the SUBJECT is the publish HTTP layer, not a registry: it captures PUT bodies, the `@scope%2fname` escaping, the auth header and `npm-otp`, and stands up a 409 server. It serves no packument and no tarball.',
+    },
+    {
+        suite: 'onboard',
+        rule: 'registry-server',
+        why: 'serves the npm auth/trust API — /-/whoami, PUT /-/user/…, GET+POST /-/package/<name>/trust — as an OTP-challenge state machine. No packument, no tarball.',
+    },
+    {
+        suite: 'self-update',
+        rule: 'registry-server',
+        why: 'the assertion IS the URL the CLI asks for: every path but the escaped @gjsify/cli spellings gets a 406, which is the shape of the original defect. Its one packument is synthesised per request from a header and is never downloaded.',
+    },
+    {
+        suite: 'install-script',
+        rule: 'registry-server',
+        why: 'its subject is the BOOTSTRAP downloader — SHA-256 digest routes, the content-addressed cache and the retry on a dropped connection — with a packument registry only incidentally beside it. Migrating that half is tracked in status/open-todos.md, and is deferred because the suite could not be verified on the machine the migration was written on.',
+    },
+];
 
 const RULES = [
     {
@@ -63,6 +84,15 @@ const RULES = [
         id: 'run-cli',
         test: (src) => /\bfunction runCli\s*\(/.test(src),
         fix: `import \`runCli\` from ../${SHARED_MODULE} (pass \`timeoutMs\` where 30s is too short)`,
+    },
+    {
+        id: 'registry-server',
+        // Twenty suites stood up their own `node:http` registry beside the shared
+        // one, so its packument/tarball routing had twenty divergent siblings that
+        // no correction could reach. Matching the CALL rather than a helper name is
+        // what makes a renamed copy still fail.
+        test: (src) => /\bcreateServer\s*\(/.test(src),
+        fix: `serve fixtures with \`startMockRegistry(packages, { onRequest, onPackument })\` from ../${SHARED_MODULE}`,
     },
 ];
 

--- a/status/agent-context-budget.json
+++ b/status/agent-context-budget.json
@@ -11,5 +11,5 @@
     "packages/node-gi/AGENTS.md": 12113,
     "packages/node/AGENTS.md": 17721,
     "packages/web/AGENTS.md": 6056,
-    "tests/AGENTS.md": 8651
+    "tests/AGENTS.md": 8911
 }

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1134,6 +1134,33 @@ Two smaller consequences wait on the same record:
 - The report cannot distinguish "installed on purpose, nothing depends on it yet"
   from "left over". Without the record those look identical, and deleting the first
   kind is the failure that makes a prune untrustworthy.
+### Two e2e suites still owe the shared harness, for different reasons
+
+Sixteen of the twenty suites that stood up a private `node:http` registry now use
+`startMockRegistry`, and `check-e2e-harness-duplication.mjs` has a
+`registry-server` rule so a twenty-first copy fails. Its ALLOWED ledger is
+self-retiring, so each remaining entry has to be answered rather than forgotten.
+
+**`install-script` — the registry half is deferred, not exempt.** Its subject is
+the bootstrap downloader (SHA-256 digest routes, the content-addressed cache, the
+retry on a dropped connection), which `onRequest` expresses; the packument
+registry beside it is ordinary and would migrate with no option at all. It was
+NOT migrated because it could not be verified: on the workstation the migration
+was written on, two of its nine cases fail before any change, with
+`No version of @gjsify/cli satisfies 0.0.99-test` from a run that has its own
+`XDG_CACHE_HOME`, its own global prefix and its own registry. CI is green on
+`main`, so this is local — but a migration verified only by "the same two still
+fail" is not verified, and that is the whole reason the other sixteen were
+believed. Find the local cause first; the migration is then mechanical.
+
+**A SECOND duplication class sits in the same files and is deliberately not
+ruled on yet.** A spawn-and-collect helper — `runChild` / `runHarness` — is
+`runCli` minus the hardcoded CLI entry, and appears in eleven suites, only five
+of which were in this migration. `native-install`'s copy genuinely cannot fold
+in: it runs a temp harness file with `--no-warnings`, not the CLI entry. So the
+fix is a shared `runNode(file, args)` that `runCli` itself delegates to, and a
+checker rule for it would touch six suites unrelated to the registry work —
+which is why it is a task and not a line in that PR.
 
 ### `@gjsify/sqlite` exec() compound-statement (CREATE TRIGGER) splitting
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -39,9 +39,11 @@ One suite per directory (`run.mjs`, `node:test`), driving the built CLI from OUT
 modules, NEITHER re-implementable in a suite: `helpers.mjs` (repo paths, packing, project setup,
 `spawnUntilReady` — a suite that only BUILDS an app has not shown it runs) and
 `mock-registry.mjs` — the npm harness (`packageTar` · `packageTarball` · `sriSha512` ·
-`startMockRegistry` · `runCli`/`runCliSync`). A registry that must MISBEHAVE uses `onRequest`, never
-a private server. `scripts/check-e2e-harness-duplication.mjs` fails on a private copy and holds the
-incident. A suite-specific POLICY over the shared runner stays local (`build-cache`'s hermetic env);
+`startMockRegistry` · `runCli`/`runCliSync`). A registry that must MISBEHAVE uses `onRequest`
+(answer INSTEAD of the default routes) or `onPackument` (edit the document about to be sent), never
+a private server. `scripts/check-e2e-harness-duplication.mjs` fails on a private copy — a raw
+`createServer` included — and holds the incident; its ALLOWED ledger carries the suites whose
+subject IS a different npm API (publish, onboard, self-update) and is self-retiring. A suite-specific POLICY over the shared runner stays local (`build-cache`'s hermetic env);
 a second implementation does not. `runCli` defaults to 30 s — longer goes at the CALL SITE.
 
 ### Browser tests — `tests/browser/` (Playwright, Firefox/SpiderMonkey)

--- a/tests/e2e/dlx-version-pin/run.mjs
+++ b/tests/e2e/dlx-version-pin/run.mjs
@@ -14,9 +14,8 @@
 //        b. transitive native-typelib deps land in the cache and the
 //           walker (`computeNativeEnvForBundle`) finds them
 //
-// Strategy: in-process HTTP packument server (mirrors
-// `tests/e2e/native-install/run.mjs`) hosting two synthetic showcase
-// versions and one synthetic native-bridge package. Drive `gjsify dlx`
+// Strategy: the shared in-process mock registry hosting two synthetic
+// showcase versions and one synthetic native-bridge package. Drive `gjsify dlx`
 // through the workspace CLI binary against this registry, with
 // `XDG_CACHE_HOME` pointing at a temp dir so the test never touches the
 // real `~/.cache/gjsify/dlx`. No gjs run — the test asserts on install
@@ -27,12 +26,10 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, readdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { pathToFileURL, fileURLToPath } from 'node:url';
-import { packageTar, sriSha512 } from '../mock-registry.mjs';
+import { startMockRegistry } from '../mock-registry.mjs';
 
 // ---------------------------------------------------------------------------
 // Process helper.
@@ -82,8 +79,7 @@ const linuxArch = process.arch;
 // ---------------------------------------------------------------------------
 
 describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 60_000 }, () => {
-    let server;
-    let registryUrl;
+    let registry;
     let cacheRoot;
     let envForCli;
     let cliEntry;
@@ -96,115 +92,34 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
     //           runtime dep on @gjsify/http-soup-bridge.
     const PACKAGES = {
         '@synthetic/showcase': {
-            versions: {
-                '0.0.1': {
-                    dependencies: {},
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: '@synthetic/showcase',
-                            version: '0.0.1',
-                            type: 'module',
-                            gjsify: { main: 'dist/bundle.mjs' },
-                            dependencies: {},
-                        }),
-                        'dist/bundle.mjs': "console.log('synthetic showcase v0.0.1');\n",
-                    },
-                },
-                '0.0.2': {
-                    dependencies: { '@synthetic/bridge': '^0.0.1' },
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: '@synthetic/showcase',
-                            version: '0.0.2',
-                            type: 'module',
-                            gjsify: { main: 'dist/bundle.mjs' },
-                            dependencies: { '@synthetic/bridge': '^0.0.1' },
-                        }),
-                        'dist/bundle.mjs': "console.log('synthetic showcase v0.0.2');\n",
-                    },
-                },
+            '0.0.1': {
+                type: 'module',
+                gjsify: { main: 'dist/bundle.mjs' },
+                dependencies: {},
+                files: { 'dist/bundle.mjs': "console.log('synthetic showcase v0.0.1');\n" },
+            },
+            '0.0.2': {
+                type: 'module',
+                gjsify: { main: 'dist/bundle.mjs' },
+                dependencies: { '@synthetic/bridge': '^0.0.1' },
+                files: { 'dist/bundle.mjs': "console.log('synthetic showcase v0.0.2');\n" },
             },
         },
         '@synthetic/bridge': {
-            versions: {
-                '0.0.1': {
-                    dependencies: {},
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: '@synthetic/bridge',
-                            version: '0.0.1',
-                            type: 'module',
-                            gjsify: { prebuilds: 'prebuilds' },
-                        }),
-                        [`prebuilds/linux-${linuxArch}/Synthetic.typelib`]: Buffer.from('typelib stub'),
-                        [`prebuilds/linux-${linuxArch}/libsynthetic.so`]: Buffer.from('so stub'),
-                    },
+            '0.0.1': {
+                type: 'module',
+                gjsify: { prebuilds: 'prebuilds' },
+                dependencies: {},
+                files: {
+                    [`prebuilds/linux-${linuxArch}/Synthetic.typelib`]: Buffer.from('typelib stub'),
+                    [`prebuilds/linux-${linuxArch}/libsynthetic.so`]: Buffer.from('so stub'),
                 },
             },
         },
     };
 
     before(async () => {
-        // Build packument index keyed by package name.
-        const index = {};
-        for (const [name, info] of Object.entries(PACKAGES)) {
-            index[name] = { name, 'dist-tags': {}, versions: {} };
-            let lastVersion = '';
-            for (const [version, body] of Object.entries(info.versions)) {
-                const tar = packageTar(body.files);
-                const tgz = gzipSync(tar);
-                index[name].versions[version] = {
-                    name,
-                    version,
-                    dependencies: body.dependencies ?? {},
-                    dist: {
-                        tarball: `__BASE__/-/${encodeURIComponent(name)}/${version}.tgz`,
-                        integrity: sriSha512(tgz),
-                    },
-                    _tgz: tgz,
-                };
-                lastVersion = version;
-            }
-            index[name]['dist-tags'].latest = lastVersion;
-        }
-
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const pkgName = decodeURIComponent(tarMatch[1]);
-                    const v = index[pkgName]?.versions[tarMatch[2]];
-                    if (!v) {
-                        res.writeHead(404).end('not found');
-                        return;
-                    }
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    res.end(v._tgz);
-                    return;
-                }
-                // Packument: /<encoded-name>
-                const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-                const p = index[pkgName];
-                if (!p) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const wire = JSON.parse(JSON.stringify(p, (key, val) => (key === '_tgz' ? undefined : val)));
-                for (const v of Object.values(wire.versions)) {
-                    v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl);
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-
-        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-        const port = server.address().port;
-        registryUrl = `http://127.0.0.1:${port}/`;
+        registry = await startMockRegistry(PACKAGES);
 
         cacheRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-dlx-version-pin-'));
 
@@ -219,8 +134,8 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
         };
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (cacheRoot) rmSync(cacheRoot, { recursive: true, force: true });
     });
 
@@ -243,7 +158,7 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
         // about the gjs result; we assert on the install layout.
         const result = await runChild(
             process.execPath,
-            [cliEntry, 'dlx', '@synthetic/showcase@0.0.1', '--registry', registryUrl],
+            [cliEntry, 'dlx', '@synthetic/showcase@0.0.1', '--registry', registry.url],
             { env: envForCli, timeoutMs: 30_000 },
         );
 
@@ -276,7 +191,7 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
         // would shadow the v0.0.2 install for 7 days.
         const result = await runChild(
             process.execPath,
-            [cliEntry, 'dlx', '@synthetic/showcase@0.0.2', '--registry', registryUrl],
+            [cliEntry, 'dlx', '@synthetic/showcase@0.0.2', '--registry', registry.url],
             { env: envForCli, timeoutMs: 30_000 },
         );
 
@@ -374,7 +289,7 @@ describe('gjsify dlx version-pinned cache + transitive native deps', { timeout: 
         // spec string.)
         const result = await runChild(
             process.execPath,
-            [cliEntry, 'dlx', '@synthetic/showcase@0.0.2', '--registry', registryUrl],
+            [cliEntry, 'dlx', '@synthetic/showcase@0.0.2', '--registry', registry.url],
             { env: envForCli, timeoutMs: 30_000 },
         );
         const combined = result.stdout + result.stderr;

--- a/tests/e2e/global-install-engine/run.mjs
+++ b/tests/e2e/global-install-engine/run.mjs
@@ -34,11 +34,9 @@ import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { packageTar, sriSha512 } from '../mock-registry.mjs';
+import { startMockRegistry } from '../mock-registry.mjs';
 
 const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -52,8 +50,7 @@ const ARCH = process.arch;
 const PREBUILD_REL = `prebuilds/linux-${ARCH}`;
 
 /**
- * The files a synthetic package ships: its `package.json` and, optionally, a
- * prebuild directory.
+ * The extra files a synthetic engine package ships beside its `package.json`.
  *
  * The two prebuild files are stand-ins for the pair EVERY gjsify GI bridge ships —
  * content is irrelevant, presence is not. The `.typelib` is load-bearing for the
@@ -61,14 +58,10 @@ const PREBUILD_REL = `prebuilds/linux-${ARCH}`;
  * preamble takes a directory only when it holds one, and a fixture with just a
  * `.so` would be a prebuild the real launcher is right to skip.
  */
-function packageFiles(pkgJson, withPrebuild = false) {
-    const files = { 'package.json': JSON.stringify(pkgJson, null, 2) + '\n' };
-    if (withPrebuild) {
-        files[`${PREBUILD_REL}/libgjsify_engine.so`] = '\x7fELF stub';
-        files[`${PREBUILD_REL}/GjsifyEngine-1.0.typelib`] = 'GTYP stub';
-    }
-    return files;
-}
+const PREBUILD_FILES = {
+    [`${PREBUILD_REL}/libgjsify_engine.so`]: '\x7fELF stub',
+    [`${PREBUILD_REL}/GjsifyEngine-1.0.typelib`]: 'GTYP stub',
+};
 
 function runHarness(cmd, args, cwd, env = {}) {
     return new Promise((resolve, reject) => {
@@ -134,11 +127,10 @@ async function launcherEnv(launcherPath, tmpRoot, extraEnv = {}) {
 
 describe('global GJS install lays down the bundler engine', { timeout: 90_000 }, () => {
     const CLI_VERSION = '9.9.9';
-    let server;
+    let registry;
     let registryUrl;
     let tmpRoot;
     let cacheHome;
-    let index;
 
     before(async () => {
         if (!existsSync(CLI_ENTRY) || !existsSync(INSTALL_GLOBAL_JS)) {
@@ -152,76 +144,20 @@ describe('global GJS install lays down the bundler engine', { timeout: 90_000 },
         // engine ships a real prebuilds/linux-<arch>/ dir in its tarball so
         // detectNativePackages picks it up after extraction.
         const PACKAGES = {
-            '@gjsify/cli': { json: { name: '@gjsify/cli', version: CLI_VERSION }, withPrebuild: false },
+            '@gjsify/cli': { [CLI_VERSION]: { dependencies: {} } },
             '@gjsify/rolldown-native': {
-                json: { name: '@gjsify/rolldown-native', version: CLI_VERSION, gjsify: { prebuilds: 'prebuilds' } },
-                withPrebuild: true,
+                [CLI_VERSION]: { dependencies: {}, gjsify: { prebuilds: 'prebuilds' }, files: PREBUILD_FILES },
             },
             '@gjsify/lightningcss-native': {
-                json: { name: '@gjsify/lightningcss-native', version: CLI_VERSION, gjsify: { prebuilds: 'prebuilds' } },
-                withPrebuild: true,
+                [CLI_VERSION]: { dependencies: {}, gjsify: { prebuilds: 'prebuilds' }, files: PREBUILD_FILES },
             },
             '@gjsify/oxfmt-native': {
-                json: { name: '@gjsify/oxfmt-native', version: CLI_VERSION, gjsify: { prebuilds: 'prebuilds' } },
-                withPrebuild: true,
+                [CLI_VERSION]: { dependencies: {}, gjsify: { prebuilds: 'prebuilds' }, files: PREBUILD_FILES },
             },
         };
 
-        index = {};
-        for (const [name, info] of Object.entries(PACKAGES)) {
-            const tgz = gzipSync(packageTar(packageFiles(info.json, info.withPrebuild)));
-            index[name] = {
-                name,
-                'dist-tags': { latest: CLI_VERSION },
-                versions: {
-                    [CLI_VERSION]: {
-                        name,
-                        version: CLI_VERSION,
-                        dependencies: {},
-                        dist: {
-                            tarball: `__BASE__/-/${encodeURIComponent(name)}/${CLI_VERSION}.tgz`,
-                            integrity: sriSha512(tgz),
-                        },
-                        _tgz: tgz,
-                    },
-                },
-            };
-        }
-
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const name = decodeURIComponent(tarMatch[1]);
-                    const v = index[name]?.versions[tarMatch[2]];
-                    if (!v) {
-                        res.writeHead(404).end('not found');
-                        return;
-                    }
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    res.end(v._tgz);
-                    return;
-                }
-                const pkgName = decodeURIComponent(url.replace(/^\//, '').split('?')[0]);
-                const p = index[pkgName];
-                if (!p) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const wire = JSON.parse(JSON.stringify(p, (k, val) => (k === '_tgz' ? undefined : val)));
-                for (const v of Object.values(wire.versions)) {
-                    v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl);
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
+        registryUrl = registry.url;
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-global-engine-'));
         // Isolate the packument + tarball disk caches into this run's tmp dir.
         // Without this, a stale REAL @gjsify/rolldown-native packument from an
@@ -232,8 +168,8 @@ describe('global GJS install lays down the bundler engine', { timeout: 90_000 },
         mkdirSync(cacheHome, { recursive: true });
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-concurrent/run.mjs
+++ b/tests/e2e/install-concurrent/run.mjs
@@ -32,90 +32,41 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { LOCKFILE_VERSION } from '../helpers.mjs';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 // Mock registry graph: alpha depends on beta (transitive dep exercised);
 // gamma has two versions so a dep-range change forces a real re-resolve.
 const PACKAGES = {
     alpha: {
-        '1.0.0': { dependencies: { beta: '^1.0.0' } },
+        '1.0.0': {
+            main: 'index.js',
+            dependencies: { beta: '^1.0.0' },
+            files: { 'index.js': 'module.exports = { name: "alpha", version: "1.0.0" };\n' },
+        },
     },
     beta: {
-        '1.2.3': { dependencies: {} },
+        '1.2.3': {
+            main: 'index.js',
+            dependencies: {},
+            files: { 'index.js': 'module.exports = { name: "beta", version: "1.2.3" };\n' },
+        },
     },
     gamma: {
-        '1.0.0': { dependencies: {} },
-        '1.5.0': { dependencies: {} },
+        '1.0.0': {
+            main: 'index.js',
+            dependencies: {},
+            files: { 'index.js': 'module.exports = { name: "gamma", version: "1.0.0" };\n' },
+        },
+        '1.5.0': {
+            main: 'index.js',
+            dependencies: {},
+            files: { 'index.js': 'module.exports = { name: "gamma", version: "1.5.0" };\n' },
+        },
     },
 };
-
-function makeRegistry() {
-    const index = {};
-    for (const [name, versions] of Object.entries(PACKAGES)) {
-        index[name] = { name, 'dist-tags': {}, versions: {} };
-        let last = '';
-        for (const [version, body] of Object.entries(versions)) {
-            const tgz = gzipSync(
-                packageTar({
-                    'package.json': JSON.stringify({
-                        name,
-                        version,
-                        main: 'index.js',
-                        dependencies: body.dependencies,
-                    }),
-                    'index.js': `module.exports = { name: ${JSON.stringify(name)}, version: ${JSON.stringify(version)} };\n`,
-                }),
-            );
-            index[name].versions[version] = {
-                name,
-                version,
-                dependencies: body.dependencies ?? {},
-                dist: { tarball: `__BASE__/-/${name}/${version}.tgz`, integrity: sriSha512(tgz) },
-                _tgz: tgz,
-            };
-            last = version;
-        }
-        index[name]['dist-tags'].latest = last;
-    }
-
-    const server = createServer((req, res) => {
-        try {
-            const url = req.url ?? '';
-            const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-            if (tarMatch) {
-                const v = index[tarMatch[1]]?.versions[tarMatch[2]];
-                if (!v) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(v._tgz);
-                return;
-            }
-            const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-            const p = index[pkgName];
-            if (!p) {
-                res.writeHead(404).end('not found');
-                return;
-            }
-            const base = `http://127.0.0.1:${server.address().port}`;
-            const wire = JSON.parse(JSON.stringify(p, (k, v) => (k === '_tgz' ? undefined : v)));
-            for (const v of Object.values(wire.versions)) {
-                v.dist.tarball = v.dist.tarball.replace('__BASE__', base);
-            }
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.end(JSON.stringify(wire));
-        } catch (e) {
-            res.writeHead(500).end(String(e));
-        }
-    });
-    return server;
-}
 
 function installedVersion(projectDir, name) {
     const manifest = join(projectDir, 'node_modules', name, 'package.json');
@@ -140,14 +91,12 @@ function deadPid() {
 }
 
 describe('gjsify install — concurrent installs (per-prefix lock + atomic shared caches)', { timeout: 300_000 }, () => {
-    let server, registryUrl, fixtureRoot, cliEntry, envBase;
+    let registry, fixtureRoot, cliEntry, envBase;
     const N_PROJECTS = 6;
     const projects = [];
 
     before(async () => {
-        server = makeRegistry();
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         fixtureRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-concurrent-'));
@@ -159,7 +108,7 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
         envBase = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',
-            npm_config_registry: registryUrl,
+            npm_config_registry: registry.url,
             // ONE shared cache for every concurrent install — the soak target.
             XDG_CACHE_HOME: sharedXdgCache,
             // Hermetic: no user ~/.npmrc, no npm-cacache interop.
@@ -183,13 +132,13 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
                     2,
                 ) + '\n',
             );
-            writeFileSync(join(dir, '.npmrc'), `registry=${registryUrl}\n`);
+            writeFileSync(join(dir, '.npmrc'), `registry=${registry.url}\n`);
             projects.push(dir);
         }
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (fixtureRoot) rmSync(fixtureRoot, { recursive: true, force: true });
     });
 
@@ -244,7 +193,7 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
                 2,
             ) + '\n',
         );
-        writeFileSync(join(dir, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(dir, '.npmrc'), `registry=${registry.url}\n`);
 
         const results = await Promise.all(
             Array.from({ length: 5 }, () =>
@@ -272,7 +221,7 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
                 2,
             ) + '\n',
         );
-        writeFileSync(join(dir, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(dir, '.npmrc'), `registry=${registry.url}\n`);
 
         // Fabricate the crash residue: a lock dir owned by a pid that no
         // longer exists (a just-exited child process).
@@ -299,7 +248,7 @@ describe('gjsify install — concurrent installs (per-prefix lock + atomic share
                 2,
             ) + '\n',
         );
-        writeFileSync(join(dir, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(dir, '.npmrc'), `registry=${registry.url}\n`);
 
         // Hold the lock as THIS (alive) test-runner process, then release it
         // after 2s while the install is blocked on it.

--- a/tests/e2e/install-conflict-warning/run.mjs
+++ b/tests/e2e/install-conflict-warning/run.mjs
@@ -23,72 +23,18 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 const PACKAGES = {
-    'dep-x': { '1.9.0': {}, '2.5.0': {} },
-    'dep-y': { '1.9.0': {} },
+    'dep-x': {
+        '1.9.0': { main: 'index.js', dependencies: {}, files: { 'index.js': 'module.exports = "1.9.0";\n' } },
+        '2.5.0': { main: 'index.js', dependencies: {}, files: { 'index.js': 'module.exports = "2.5.0";\n' } },
+    },
+    'dep-y': {
+        '1.9.0': { main: 'index.js', dependencies: {}, files: { 'index.js': 'module.exports = "1.9.0";\n' } },
+    },
 };
-
-function makeRegistry() {
-    const index = {};
-    for (const [name, versions] of Object.entries(PACKAGES)) {
-        index[name] = { name, 'dist-tags': {}, versions: {} };
-        let last = '';
-        for (const version of Object.keys(versions)) {
-            const tgz = gzipSync(
-                packageTar({
-                    'package.json': JSON.stringify({ name, version, main: 'index.js' }),
-                    'index.js': `module.exports = ${JSON.stringify(version)};\n`,
-                }),
-            );
-            index[name].versions[version] = {
-                name,
-                version,
-                dependencies: {},
-                dist: { tarball: `__BASE__/-/${name}/${version}.tgz`, integrity: sriSha512(tgz) },
-                _tgz: tgz,
-            };
-            last = version;
-        }
-        index[name]['dist-tags'].latest = last;
-    }
-    const server = createServer((req, res) => {
-        try {
-            const url = req.url ?? '';
-            const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-            if (tarMatch) {
-                const v = index[tarMatch[1]]?.versions[tarMatch[2]];
-                if (!v) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(v._tgz);
-                return;
-            }
-            const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-            const p = index[pkgName];
-            if (!p) {
-                res.writeHead(404).end('not found');
-                return;
-            }
-            const base = `http://127.0.0.1:${server.address().port}`;
-            const wire = JSON.parse(JSON.stringify(p, (k, v) => (k === '_tgz' ? undefined : v)));
-            for (const v of Object.values(wire.versions)) {
-                v.dist.tarball = v.dist.tarball.replace('__BASE__', base);
-            }
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.end(JSON.stringify(wire));
-        } catch (e) {
-            res.writeHead(500).end(String(e));
-        }
-    });
-    return server;
-}
 
 function writeWorkspace(root, dirName, manifest) {
     const dir = join(root, 'packages', dirName);
@@ -97,12 +43,10 @@ function writeWorkspace(root, dirName, manifest) {
 }
 
 describe('gjsify install — version-conflict warning (ADR 0001 step 3)', { timeout: 120_000 }, () => {
-    let server, registryUrl, root, cliEntry, envForCli, result;
+    let registry, root, cliEntry, envForCli, result;
 
     before(async () => {
-        server = makeRegistry();
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
 
         root = mkdtempSync(join(tmpdir(), 'gjsify-e2e-conflict-warn-'));
@@ -111,7 +55,7 @@ describe('gjsify install — version-conflict warning (ADR 0001 step 3)', { time
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',
-            npm_config_registry: registryUrl,
+            npm_config_registry: registry.url,
             XDG_CACHE_HOME: join(root, 'xdg-cache'),
             HOME: homeDir,
             GJSIFY_NPM_CACHE: '0',
@@ -125,7 +69,7 @@ describe('gjsify install — version-conflict warning (ADR 0001 step 3)', { time
                 2,
             ) + '\n',
         );
-        writeFileSync(join(root, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(root, '.npmrc'), `registry=${registry.url}\n`);
         // ws-a and ws-b CONFLICT on dep-x (^1 vs ^2 — no version satisfies
         // both) and AGREE on dep-y (^1.2 and ^1.4 are both satisfied by 1.9.0).
         writeWorkspace(root, 'ws-a', {
@@ -142,8 +86,8 @@ describe('gjsify install — version-conflict warning (ADR 0001 step 3)', { time
         result = await runCli(cliEntry, ['install'], { timeoutMs: 60_000, cwd: root, env: envForCli });
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (root) rmSync(root, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-extract-stall/run.mjs
+++ b/tests/e2e/install-extract-stall/run.mjs
@@ -20,57 +20,25 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
-/** This suite's fixtures are all a bare `package.json`. */
-const packageTarFor = (pkgJson) => packageTar({ 'package.json': JSON.stringify(pkgJson, null, 2) + '\n' });
+// The registry is deliberately WELL-BEHAVED here: the stall under test lives in
+// the extract phase, reached only once resolution and fetch have both succeeded.
+const PACKAGES = {
+    'leaf-dep': { '1.0.0': { dependencies: {} } },
+};
 
 describe('gjsify install — per-extract stall guard', { timeout: 60_000 }, () => {
-    let server, registryUrl, cliEntry, tgz;
+    let registry, cliEntry;
 
     before(async () => {
-        const pkgJson = { name: 'leaf-dep', version: '1.0.0', dependencies: {} };
-        tgz = gzipSync(packageTarFor(pkgJson));
-        const integrity = sriSha512(tgz);
-
-        server = createServer((req, res) => {
-            const url = req.url ?? '';
-            if (/^\/-\/leaf-dep\/1\.0\.0\.tgz$/.test(url)) {
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(tgz);
-                return;
-            }
-            if (decodeURIComponent(url.replace(/^\//, '')) === 'leaf-dep') {
-                const base = `http://127.0.0.1:${server.address().port}`;
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(
-                    JSON.stringify({
-                        name: 'leaf-dep',
-                        'dist-tags': { latest: '1.0.0' },
-                        versions: {
-                            '1.0.0': {
-                                name: 'leaf-dep',
-                                version: '1.0.0',
-                                dependencies: {},
-                                dist: { tarball: `${base}/-/leaf-dep/1.0.0.tgz`, integrity },
-                            },
-                        },
-                    }),
-                );
-                return;
-            }
-            res.writeHead(404).end('not found');
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
     });
 
     it('exits non-zero with a "stalled" message when an extract never settles', async () => {
@@ -90,7 +58,7 @@ describe('gjsify install — per-extract stall guard', { timeout: 60_000 }, () =
                     2,
                 ) + '\n',
             );
-            writeFileSync(join(dir, '.npmrc'), `registry=${registryUrl}\n`);
+            writeFileSync(join(dir, '.npmrc'), `registry=${registry.url}\n`);
 
             const t0 = Date.now();
             const r = await runCli(cliEntry, ['install'], {
@@ -98,7 +66,7 @@ describe('gjsify install — per-extract stall guard', { timeout: 60_000 }, () =
                 env: {
                     ...process.env,
                     GJSIFY_INSTALL_BACKEND: 'native',
-                    npm_config_registry: registryUrl,
+                    npm_config_registry: registry.url,
                     // The extract that follows a successful fetch never settles...
                     GJSIFY_TEST_HANG_EXTRACT: '1',
                     // ...and the stall timer pulls the plug in ~1s (not the 120s default).

--- a/tests/e2e/install-incremental-extract/run.mjs
+++ b/tests/e2e/install-incremental-extract/run.mjs
@@ -27,19 +27,8 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
-
-function versionEntry(name, version, dependencies = {}) {
-    const files = {
-        'package.json': JSON.stringify({ name, version, main: 'index.js', dependencies }),
-        'index.js': `module.exports = ${JSON.stringify({ name, version })};\n`,
-    };
-    const tgz = gzipSync(packageTar(files));
-    return { name, version, dependencies, tgz, integrity: sriSha512(tgz) };
-}
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 /** Run the CLI under Node without blocking the in-process mock-registry loop. */
 
@@ -58,52 +47,45 @@ function markerSurvives(projectDir, name) {
 }
 
 describe('gjsify install — incremental extraction (skip already-extracted)', { timeout: 120_000 }, () => {
-    let server, registryUrl, projectDir, cliEntry, envForCli, cacheDir;
+    let registry, projectDir, cliEntry, envForCli, cacheDir;
 
     // root → mid → leaf ; root → leaf (so leaf is shared, mid + leaf are
     // transitive). After install #1 all three are on disk. Adding `extra`
     // (a fresh standalone dep) must re-extract ONLY `extra`, leaving root /
     // mid / leaf untouched.
     const ALL = {
-        leaf: { '1.0.0': versionEntry('leaf', '1.0.0') },
-        mid: { '1.0.0': versionEntry('mid', '1.0.0', { leaf: '^1.0.0' }) },
-        root: { '1.0.0': versionEntry('root', '1.0.0', { mid: '^1.0.0', leaf: '^1.0.0' }) },
-        extra: { '1.0.0': versionEntry('extra', '1.0.0') },
+        leaf: {
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: {},
+                files: { 'index.js': 'module.exports = {"name":"leaf","version":"1.0.0"};\n' },
+            },
+        },
+        mid: {
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: { leaf: '^1.0.0' },
+                files: { 'index.js': 'module.exports = {"name":"mid","version":"1.0.0"};\n' },
+            },
+        },
+        root: {
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: { mid: '^1.0.0', leaf: '^1.0.0' },
+                files: { 'index.js': 'module.exports = {"name":"root","version":"1.0.0"};\n' },
+            },
+        },
+        extra: {
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: {},
+                files: { 'index.js': 'module.exports = {"name":"extra","version":"1.0.0"};\n' },
+            },
+        },
     };
 
     before(async () => {
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const v = ALL[tarMatch[1]]?.[tarMatch[2]];
-                    if (!v) return void res.writeHead(404).end('not found');
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    return void res.end(v.tgz);
-                }
-                const name = decodeURIComponent(url.replace(/^\//, ''));
-                const versions = ALL[name];
-                if (!versions) return void res.writeHead(404).end('not found');
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const verNames = Object.keys(versions);
-                const wire = { name, 'dist-tags': { latest: verNames[verNames.length - 1] }, versions: {} };
-                for (const [version, e] of Object.entries(versions)) {
-                    wire.versions[version] = {
-                        name,
-                        version,
-                        dependencies: e.dependencies,
-                        dist: { tarball: `${baseUrl}/-/${name}/${version}.tgz`, integrity: e.integrity },
-                    };
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(ALL);
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-incremental-'));
         // Per-run cache root so a developer's warm ~/.cache doesn't change the
@@ -113,7 +95,7 @@ describe('gjsify install — incremental extraction (skip already-extracted)', {
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',
-            npm_config_registry: registryUrl,
+            npm_config_registry: registry.url,
             XDG_CACHE_HOME: cacheDir,
             // Don't read a co-developer's npm cacache during the test.
             GJSIFY_NPM_CACHE: '0',
@@ -133,11 +115,11 @@ describe('gjsify install — incremental extraction (skip already-extracted)', {
                 2,
             ) + '\n',
         );
-        writeFileSync(join(projectDir, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(projectDir, '.npmrc'), `registry=${registry.url}\n`);
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (projectDir) rmSync(projectDir, { recursive: true, force: true });
         if (cacheDir) rmSync(cacheDir, { recursive: true, force: true });
     });

--- a/tests/e2e/install-lock-preserve/run.mjs
+++ b/tests/e2e/install-lock-preserve/run.mjs
@@ -22,19 +22,16 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
-/** A package version entry's prebuilt tarball + integrity. */
-function versionEntry(name, version, dependencies = {}) {
-    const files = {
-        'package.json': JSON.stringify({ name, version, main: 'index.js', dependencies }),
-        'index.js': `module.exports = ${JSON.stringify({ name, version })};\n`,
+/** One version's manifest fields plus the file it ships. */
+function versionSpec(name, version) {
+    return {
+        main: 'index.js',
+        dependencies: {},
+        files: { 'index.js': `module.exports = ${JSON.stringify({ name, version })};\n` },
     };
-    const tgz = gzipSync(packageTar(files));
-    return { name, version, dependencies, tgz, integrity: sriSha512(tgz) };
 }
 
 /** Read the resolved version of `name` at the hoisted root path in the lockfile. */
@@ -44,65 +41,29 @@ function lockedVersion(projectDir, name) {
 }
 
 describe('gjsify install — lockfile preservation', { timeout: 90_000 }, () => {
-    let server, registryUrl, projectDir, cliEntry, envForCli;
+    let registry, registryUrl, projectDir, cliEntry, envForCli;
 
     // Mutable: when false, dep-a's packument hides 1.1.0 (only 1.0.0 visible).
     let exposeNewer = false;
 
-    const ALL = {
-        'dep-a': {
-            '1.0.0': versionEntry('dep-a', '1.0.0'),
-            '1.1.0': versionEntry('dep-a', '1.1.0'),
-        },
-        'dep-b': {
-            '1.0.0': versionEntry('dep-b', '1.0.0'),
-        },
+    const PACKAGES = {
+        'dep-a': { '1.0.0': versionSpec('dep-a', '1.0.0'), '1.1.0': versionSpec('dep-a', '1.1.0') },
+        'dep-b': { '1.0.0': versionSpec('dep-b', '1.0.0') },
     };
 
-    function visibleVersions(name) {
-        if (name === 'dep-a' && !exposeNewer) {
-            return { '1.0.0': ALL['dep-a']['1.0.0'] };
-        }
-        return ALL[name];
-    }
-
     before(async () => {
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const v = ALL[tarMatch[1]]?.[tarMatch[2]];
-                    if (!v) return void res.writeHead(404).end('not found');
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    return void res.end(v.tgz);
-                }
-                const name = decodeURIComponent(url.replace(/^\//, ''));
-                const versions = visibleVersions(name);
-                if (!versions) return void res.writeHead(404).end('not found');
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const verNames = Object.keys(versions);
-                const wire = {
-                    name,
-                    'dist-tags': { latest: verNames[verNames.length - 1] },
-                    versions: {},
-                };
-                for (const [version, e] of Object.entries(versions)) {
-                    wire.versions[version] = {
-                        name,
-                        version,
-                        dependencies: e.dependencies,
-                        dist: { tarball: `${baseUrl}/-/${name}/${version}.tgz`, integrity: e.integrity },
-                    };
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
+        registry = await startMockRegistry(PACKAGES, {
+            // Hiding a version in the DOCUMENT, not in the store: the tarball
+            // route keeps serving 1.1.0, which is what makes step 3's
+            // `--refresh-lockfile` install it the moment it becomes visible.
+            // `dist-tags` is recomputed after this hook, so `latest` falls back
+            // to 1.0.0 while 1.1.0 is hidden — the behaviour the hand-rolled
+            // `visibleVersions()` produced.
+            onPackument: (doc, { name }) => {
+                if (name === 'dep-a' && !exposeNewer) delete doc.versions['1.1.0'];
+            },
         });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registryUrl = registry.url;
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-preserve-'));
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
@@ -125,8 +86,8 @@ describe('gjsify install — lockfile preservation', { timeout: 90_000 }, () => 
         writeFileSync(join(projectDir, '.npmrc'), `registry=${registryUrl}\n`);
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (projectDir) rmSync(projectDir, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-non-destructive/run.mjs
+++ b/tests/e2e/install-non-destructive/run.mjs
@@ -28,78 +28,29 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 // Two independent registry packages, each a trivial CJS module. `@fixture/dep`
 // is the baseline dependency committed into every fixture; `@fixture/other` is
 // the package the add-package (`install <pkg>`) mode pulls in.
-function makeRegistry() {
-    const pkg = (name, version) => {
-        const tar = gzipSync(
-            packageTar({
-                'package.json': JSON.stringify({ name, version, main: 'index.js' }),
-                'index.js': `module.exports = ${JSON.stringify(name)};\n`,
-            }),
-        );
-        return { tar, sri: sriSha512(tar) };
-    };
-    const built = {
-        '@fixture/dep': pkg('@fixture/dep', '1.0.0'),
-        '@fixture/other': pkg('@fixture/other', '1.0.0'),
-    };
-    const index = {};
-    for (const [name, { tar, sri }] of Object.entries(built)) {
-        const slug = name.replace('@fixture/', '');
-        index[name] = {
-            name,
-            'dist-tags': { latest: '1.0.0' },
-            versions: {
-                '1.0.0': {
-                    name,
-                    version: '1.0.0',
-                    dependencies: {},
-                    dist: { tarball: `__BASE__/-/${slug}/1.0.0.tgz`, integrity: sri },
-                },
-            },
-        };
-    }
-    const server = createServer((req, res) => {
-        try {
-            const url = req.url ?? '';
-            const tgz = url.match(/^\/-\/([^/]+)\/1\.0\.0\.tgz$/);
-            if (tgz) {
-                const entry = built[`@fixture/${tgz[1]}`];
-                if (!entry) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(entry.tar);
-                return;
-            }
-            const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-            const p = index[pkgName];
-            if (!p) {
-                res.writeHead(404).end('not found');
-                return;
-            }
-            const base = `http://127.0.0.1:${server.address().port}`;
-            const wire = JSON.parse(JSON.stringify(p));
-            for (const v of Object.values(wire.versions)) {
-                v.dist.tarball = v.dist.tarball.replace('__BASE__', base);
-            }
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.end(JSON.stringify(wire));
-        } catch (e) {
-            res.writeHead(500).end(String(e));
-        }
-    });
-    return server;
-}
+const PACKAGES = {
+    '@fixture/dep': {
+        '1.0.0': {
+            main: 'index.js',
+            dependencies: {},
+            files: { 'index.js': 'module.exports = "@fixture/dep";\n' },
+        },
+    },
+    '@fixture/other': {
+        '1.0.0': {
+            main: 'index.js',
+            dependencies: {},
+            files: { 'index.js': 'module.exports = "@fixture/other";\n' },
+        },
+    },
+};
 
 // Committed build-artifact markers — if an install deletes or rewrites either,
 // the marker changes and git surfaces it.
@@ -145,18 +96,17 @@ function assertMarkers(checks) {
 }
 
 describe('gjsify install — non-destructive (ADR 0001)', { timeout: 120_000 }, () => {
-    let server, registryUrl, cliEntry, baseEnv;
+    let registry, registryUrl, cliEntry, baseEnv;
     const roots = [];
 
     before(async () => {
-        server = makeRegistry();
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
+        registryUrl = registry.url;
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         for (const r of roots) rmSync(r, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-platform-filter/run.mjs
+++ b/tests/e2e/install-platform-filter/run.mjs
@@ -34,15 +34,14 @@ import assert from 'node:assert/strict';
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
 import { LOCKFILE_VERSION } from '../helpers.mjs';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 /**
- * The published corpus. `libc` is deliberately NOT part of what the abbreviated
- * packument will report (see `wirePackument`) — that mirrors the live registry:
+ * The published corpus, as manifest fields per version. `libc` IS declared here
+ * and is stripped from the ABBREVIATED document on the way out (see the
+ * `onPackument` hook) — that mirrors the live registry:
  * `lightningcss-linux-x64-musl@1.33.0` returns `{os,cpu}` under the corgi accept
  * header and `{os,cpu,libc}` under `application/json`.
  */
@@ -63,76 +62,43 @@ const CORPUS = {
     'win-only': { '1.0.0': { os: ['win32'] } },
 };
 
-function buildIndex() {
-    const index = {};
-    for (const [name, versions] of Object.entries(CORPUS)) {
-        index[name] = {};
-        for (const [version, meta] of Object.entries(versions)) {
-            const pkgJson = {
-                name,
+/** The corpus with the fields every entry shares filled in. */
+const PACKAGES = Object.fromEntries(
+    Object.entries(CORPUS).map(([name, versions]) => [
+        name,
+        Object.fromEntries(
+            Object.entries(versions).map(([version, meta]) => [
                 version,
-                main: 'index.js',
-                dependencies: meta.dependencies ?? {},
-                optionalDependencies: meta.optionalDependencies ?? {},
-                ...(meta.os ? { os: meta.os } : {}),
-                ...(meta.cpu ? { cpu: meta.cpu } : {}),
-                ...(meta.libc ? { libc: meta.libc } : {}),
-            };
-            const tgz = gzipSync(
-                packageTar({
-                    'package.json': JSON.stringify(pkgJson),
-                    'index.js': `module.exports = ${JSON.stringify({ name, version })};\n`,
-                }),
-            );
-            index[name][version] = { ...meta, tgz, integrity: sriSha512(tgz) };
-        }
-    }
-    return index;
-}
+                {
+                    main: 'index.js',
+                    dependencies: {},
+                    optionalDependencies: {},
+                    ...meta,
+                    files: { 'index.js': `module.exports = ${JSON.stringify({ name, version })};\n` },
+                },
+            ]),
+        ),
+    ]),
+);
 
 describe('gjsify install — os/cpu/libc filtering', { timeout: 180_000 }, () => {
-    let server, registryUrl, cliEntry, tmpRoot, baseEnv;
-    const index = buildIndex();
+    let registry, registryUrl, cliEntry, tmpRoot, baseEnv;
     /** Which document shapes were requested per package name, for property (d). */
     let requestedShapes;
 
-    function wirePackument(name, shape, baseUrl) {
-        const versions = {};
-        for (const [version, entry] of Object.entries(index[name])) {
-            versions[version] = {
-                name,
-                version,
-                dependencies: entry.dependencies ?? {},
-                optionalDependencies: entry.optionalDependencies ?? {},
-                ...(entry.os ? { os: entry.os } : {}),
-                ...(entry.cpu ? { cpu: entry.cpu } : {}),
-                // THE POINT OF THIS FIXTURE: libc is served ONLY in the full
-                // document. A resolver that trusts the abbreviated one judges
-                // every musl-only package installable on glibc.
-                ...(shape === 'full' && entry.libc ? { libc: entry.libc } : {}),
-                dist: { tarball: `${baseUrl}/-/${name}/${version}.tgz`, integrity: entry.integrity },
-            };
-        }
-        const names = Object.keys(versions);
-        return { name, 'dist-tags': { latest: names[names.length - 1] }, versions };
-    }
-
     before(async () => {
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const entry = index[tarMatch[1]]?.[tarMatch[2]];
-                    if (!entry) return void res.writeHead(404).end('not found');
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    return void res.end(entry.tgz);
-                }
-                const name = decodeURIComponent(url.replace(/^\//, ''));
-                if (!index[name]) return void res.writeHead(404).end('not found');
+        requestedShapes = new Map();
+        registry = await startMockRegistry(PACKAGES, {
+            onRequest: (req, res) => {
+                const name = decodeURIComponent((req.url ?? '').replace(/^\//, '').split('?')[0]);
+                if (!PACKAGES[name]) return false;
 
-                const accept = String(req.headers.accept ?? '');
-                const shape = accept.includes('application/vnd.npm.install-v1+json') ? 'corgi' : 'full';
+                // Recorded BEFORE the 304 branch, so a conditional request still
+                // counts as a request for that shape — which is what property (d)
+                // is about.
+                const shape = String(req.headers.accept ?? '').includes('application/vnd.npm.install-v1+json')
+                    ? 'corgi'
+                    : 'full';
                 let shapes = requestedShapes.get(name);
                 if (!shapes) {
                     shapes = new Set();
@@ -149,17 +115,24 @@ describe('gjsify install — os/cpu/libc filtering', { timeout: 180_000 }, () =>
                 // cache hit. That is the failure this fixture pins.
                 const etag = `"rev-1-${name}"`;
                 if (req.headers['if-none-match'] === etag) {
-                    return void res.writeHead(304, { etag }).end();
+                    res.writeHead(304, { etag });
+                    res.end();
+                    return true;
                 }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                res.writeHead(200, { 'content-type': 'application/json', etag });
-                res.end(JSON.stringify(wirePackument(name, shape, baseUrl)));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
+                // Set and fall through: `writeHead` merges with headers already
+                // set, so the default packument route keeps this one.
+                res.setHeader('etag', etag);
+                return false;
+            },
+            onPackument: (doc, { req }) => {
+                const corgi = String(req.headers.accept ?? '').includes('application/vnd.npm.install-v1+json');
+                // THE POINT OF THIS FIXTURE: libc is served ONLY in the full
+                // document. A resolver that trusts the abbreviated one judges
+                // every musl-only package installable on glibc.
+                if (corgi) for (const v of Object.values(doc.versions)) delete v.libc;
+            },
         });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registryUrl = registry.url;
 
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-platform-'));
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
@@ -178,11 +151,10 @@ describe('gjsify install — os/cpu/libc filtering', { timeout: 180_000 }, () =>
             npm_config_libc: '',
             npm_config_force: '',
         };
-        requestedShapes = new Map();
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-timeout/run.mjs
+++ b/tests/e2e/install-timeout/run.mjs
@@ -18,30 +18,31 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
-import { runCli } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 describe('gjsify install --timeout — slow-registry safety net', { timeout: 60_000 }, () => {
-    let server, registryUrl, cliEntry, envForCli;
-    const liveSockets = new Set();
+    let registry, registryUrl, cliEntry, envForCli;
 
     before(async () => {
-        // Slow registry: writes partial headers then never finishes the body.
-        // From a TCP/HTTP perspective this is a valid response that simply
-        // never closes — the exact "reachable but slow" pathology that the
-        // per-request timeout exists to guard against.
-        server = createServer((req, res) => {
-            liveSockets.add(req.socket);
-            req.socket.on('close', () => liveSockets.delete(req.socket));
-            // Write partial headers + a few bytes of body, then hang.
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.write('{"name":"');
-            // Intentionally never call res.end() — the response stays open
-            // until the client aborts or the process dies.
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        // No packages at all: `onRequest` answers everything, so the default
+        // routes are never reached.
+        registry = await startMockRegistry(
+            {},
+            {
+                // Slow registry: writes partial headers then never finishes the
+                // body. From a TCP/HTTP perspective this is a valid response that
+                // simply never closes — the exact "reachable but slow" pathology
+                // that the per-request timeout exists to guard against.
+                onRequest: (_req, res) => {
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.write('{"name":"');
+                    // Intentionally never call res.end().
+                    return true;
+                },
+            },
+        );
+        registryUrl = registry.url;
 
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
@@ -51,14 +52,13 @@ describe('gjsify install --timeout — slow-registry safety net', { timeout: 60_
         };
     });
 
-    after(() => {
-        // Yank any still-open sockets so the test process exits cleanly.
-        for (const s of liveSockets) {
-            // net.Socket.destroy() never throws — errors surface on the
-            // socket's 'error' event, not synchronously.
-            s.destroy();
-        }
-        if (server) server.close();
+    // No hand-rolled socket drain: `close()` drops open connections before
+    // waiting for them, which is what a server holding a response it never ends
+    // requires. Keeping a second teardown beside it is the scattered-lifecycle
+    // shape — and this suite is precisely the one that proves the shared close()
+    // needs it, since a plain `server.close()` here never resolves.
+    after(async () => {
+        await registry?.close();
     });
 
     it('exits non-zero with a clear "timed out" message when the registry never responds', async () => {

--- a/tests/e2e/install-version-conflict/run.mjs
+++ b/tests/e2e/install-version-conflict/run.mjs
@@ -24,153 +24,57 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { LOCKFILE_VERSION } from '../helpers.mjs';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 describe('gjsify install — nested-node_modules version conflict (Phase D.7b)', { timeout: 90_000 }, () => {
-    let server, registryUrl, projectDir, cliEntry, envForCli;
+    let registry, projectDir, cliEntry, envForCli;
 
     // Mock packument graph: two `readable` majors, two consumers picking
     // different majors, one top-level pulling both.
     const PACKAGES = {
         readable: {
-            versions: {
-                '2.3.7': {
-                    dependencies: {},
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: 'readable',
-                            version: '2.3.7',
-                            main: 'index.js',
-                        }),
-                        'index.js': 'module.exports = { __major: 2 };\n',
-                    },
-                },
-                '3.6.2': {
-                    dependencies: {},
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: 'readable',
-                            version: '3.6.2',
-                            main: 'index.js',
-                        }),
-                        'index.js': 'module.exports = { __major: 3 };\n',
-                    },
-                },
+            '2.3.7': {
+                main: 'index.js',
+                dependencies: {},
+                files: { 'index.js': 'module.exports = { __major: 2 };\n' },
+            },
+            '3.6.2': {
+                main: 'index.js',
+                dependencies: {},
+                files: { 'index.js': 'module.exports = { __major: 3 };\n' },
             },
         },
         'bridge-pkg': {
-            versions: {
-                '1.0.0': {
-                    dependencies: { readable: '^2.0.0' },
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: 'bridge-pkg',
-                            version: '1.0.0',
-                            main: 'index.js',
-                            dependencies: { readable: '^2.0.0' },
-                        }),
-                        'index.js': 'module.exports = require("readable");\n',
-                    },
-                },
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: { readable: '^2.0.0' },
+                files: { 'index.js': 'module.exports = require("readable");\n' },
             },
         },
         'modern-pkg': {
-            versions: {
-                '1.0.0': {
-                    dependencies: { readable: '^3.0.0' },
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: 'modern-pkg',
-                            version: '1.0.0',
-                            main: 'index.js',
-                            dependencies: { readable: '^3.0.0' },
-                        }),
-                        'index.js': 'module.exports = require("readable");\n',
-                    },
-                },
+            '1.0.0': {
+                main: 'index.js',
+                dependencies: { readable: '^3.0.0' },
+                files: { 'index.js': 'module.exports = require("readable");\n' },
             },
         },
         'top-pkg': {
-            versions: {
-                '0.1.0': {
-                    dependencies: { 'bridge-pkg': '^1.0.0', 'modern-pkg': '^1.0.0' },
-                    files: {
-                        'package.json': JSON.stringify({
-                            name: 'top-pkg',
-                            version: '0.1.0',
-                            dependencies: { 'bridge-pkg': '^1.0.0', 'modern-pkg': '^1.0.0' },
-                        }),
-                    },
-                },
-            },
+            '0.1.0': { dependencies: { 'bridge-pkg': '^1.0.0', 'modern-pkg': '^1.0.0' } },
         },
     };
 
     before(async () => {
-        const index = {};
-        for (const [name, info] of Object.entries(PACKAGES)) {
-            index[name] = { name, 'dist-tags': {}, versions: {} };
-            let last = '';
-            for (const [version, body] of Object.entries(info.versions)) {
-                const tar = packageTar(body.files);
-                const tgz = gzipSync(tar);
-                index[name].versions[version] = {
-                    name,
-                    version,
-                    dependencies: body.dependencies ?? {},
-                    dist: { tarball: `__BASE__/-/${name}/${version}.tgz`, integrity: sriSha512(tgz) },
-                    _tgz: tgz,
-                };
-                last = version;
-            }
-            index[name]['dist-tags'].latest = last;
-        }
-
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const v = index[tarMatch[1]]?.versions[tarMatch[2]];
-                    if (!v) {
-                        res.writeHead(404).end('not found');
-                        return;
-                    }
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    res.end(v._tgz);
-                    return;
-                }
-                const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-                const p = index[pkgName];
-                if (!p) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const wire = JSON.parse(JSON.stringify(p, (k, v) => (k === '_tgz' ? undefined : v)));
-                for (const v of Object.values(wire.versions)) {
-                    v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl);
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
 
         projectDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-conflict-'));
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         envForCli = {
             ...process.env,
             GJSIFY_INSTALL_BACKEND: 'native',
-            npm_config_registry: registryUrl,
+            npm_config_registry: registry.url,
         };
 
         // Seed package.json with top-pkg as an existing dep so the no-arg
@@ -193,11 +97,11 @@ describe('gjsify install — nested-node_modules version conflict (Phase D.7b)',
                 2,
             ) + '\n',
         );
-        writeFileSync(join(projectDir, '.npmrc'), `registry=${registryUrl}\n`);
+        writeFileSync(join(projectDir, '.npmrc'), `registry=${registry.url}\n`);
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (projectDir) rmSync(projectDir, { recursive: true, force: true });
     });
 

--- a/tests/e2e/install-workspace-source-safety/run.mjs
+++ b/tests/e2e/install-workspace-source-safety/run.mjs
@@ -47,10 +47,8 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, relative } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 const SOURCE_MARKER = 'export const SOURCE = "WORKSPACE_SOURCE_PRESERVED";\n';
 
@@ -60,89 +58,22 @@ const SOURCE_MARKER = 'export const SOURCE = "WORKSPACE_SOURCE_PRESERVED";\n';
 // `@fixture/app@1.0.0` that DEPENDS on `@fixture/lib@^9.0.0` — used to drive
 // the transitive case where the same-named workspace must NOT be fetched even
 // though a registry consumer pulls it into the resolved tree.
-function makeRegistry() {
-    const libTar = gzipSync(
-        packageTar({
-            'package.json': JSON.stringify({ name: '@fixture/lib', version: '9.9.9', main: 'dist/index.js' }),
-            'dist/index.js': 'module.exports = "PUBLISHED_TARBALL";\n',
-        }),
-    );
-    const appTar = gzipSync(
-        packageTar({
-            'package.json': JSON.stringify({
-                name: '@fixture/app',
-                version: '1.0.0',
-                main: 'index.js',
-                dependencies: { '@fixture/lib': '^9.0.0' },
-            }),
-            'index.js': 'module.exports = require("@fixture/lib");\n',
-        }),
-    );
-    const libSri = sriSha512(libTar);
-    const appSri = sriSha512(appTar);
-    const index = {
-        '@fixture/lib': {
-            name: '@fixture/lib',
-            'dist-tags': { latest: '9.9.9' },
-            versions: {
-                '9.9.9': {
-                    name: '@fixture/lib',
-                    version: '9.9.9',
-                    dependencies: {},
-                    dist: { tarball: '__BASE__/-/lib/9.9.9.tgz', integrity: libSri },
-                    _tgz: libTar,
-                },
-            },
+const PACKAGES = {
+    '@fixture/lib': {
+        '9.9.9': {
+            main: 'dist/index.js',
+            dependencies: {},
+            files: { 'dist/index.js': 'module.exports = "PUBLISHED_TARBALL";\n' },
         },
-        '@fixture/app': {
-            name: '@fixture/app',
-            'dist-tags': { latest: '1.0.0' },
-            versions: {
-                '1.0.0': {
-                    name: '@fixture/app',
-                    version: '1.0.0',
-                    dependencies: { '@fixture/lib': '^9.0.0' },
-                    dist: { tarball: '__BASE__/-/app/1.0.0.tgz', integrity: appSri },
-                    _tgz: appTar,
-                },
-            },
+    },
+    '@fixture/app': {
+        '1.0.0': {
+            main: 'index.js',
+            dependencies: { '@fixture/lib': '^9.0.0' },
+            files: { 'index.js': 'module.exports = require("@fixture/lib");\n' },
         },
-    };
-    const server = createServer((req, res) => {
-        try {
-            const url = req.url ?? '';
-            if (/^\/-\/lib\/9\.9\.9\.tgz$/.test(url)) {
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(libTar);
-                return;
-            }
-            if (/^\/-\/app\/1\.0\.0\.tgz$/.test(url)) {
-                res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                res.end(appTar);
-                return;
-            }
-            const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-            const p = index[pkgName];
-            if (!p) {
-                res.writeHead(404).end('not found');
-                return;
-            }
-            const base = `http://127.0.0.1:${server.address().port}`;
-            const wire = JSON.parse(JSON.stringify(p, (k, v) => (k === '_tgz' ? undefined : v)));
-            for (const v of Object.values(wire.versions)) {
-                v.dist.tarball = v.dist.tarball.replace('__BASE__', base);
-            }
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.end(JSON.stringify(wire));
-        } catch (e) {
-            res.writeHead(500).end(String(e));
-        }
-    });
-    // Expose the integrity values so the --immutable test can hand-craft a
-    // lockfile that pins the same-named workspace as a registry entry.
-    server.__fixtures = { libSri, appSri };
-    return server;
-}
+    },
+};
 
 // Scaffold a fixture monorepo. `consumerSpec` is the version spec the consumer
 // uses for `@fixture/lib` (`workspace:^` or `^9.0.0`). `preseedRootSymlink`
@@ -219,13 +150,12 @@ function assertWorkspaceSymlink(linkPath, root, label) {
 }
 
 describe('gjsify install — never fetch/extract over workspace sources', { timeout: 90_000 }, () => {
-    let server, registryUrl, cliEntry, envForCli;
+    let registry, registryUrl, cliEntry, envForCli;
     const roots = [];
 
     before(async () => {
-        server = makeRegistry();
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
+        registryUrl = registry.url;
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
         // Fixture-local caches: the `fetch: @fixture/app` assertions below
         // require the tarball to actually come off the network — a shared
@@ -244,8 +174,8 @@ describe('gjsify install — never fetch/extract over workspace sources', { time
         };
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         for (const r of roots) rmSync(r, { recursive: true, force: true });
     });
 
@@ -371,23 +301,24 @@ describe('gjsify install — never fetch/extract over workspace sources', { time
         consumerPkg.dependencies['@fixture/app'] = '^1.0.0';
         writeFileSync(consumerPkgPath, JSON.stringify(consumerPkg, null, 2) + '\n');
 
-        const { libSri, appSri } = server.__fixtures;
+        // `resolved` is what the --immutable path downloads — it must be the URL
+        // this registry actually serves the tarball at, not a hand-spelled guess.
         const staleLock = {
             lockfileVersion: 2,
             requested: ['@fixture/app@^1.0.0'],
             packages: {
                 'node_modules/@fixture/app': {
                     version: '1.0.0',
-                    resolved: `${registryUrl}-/app/1.0.0.tgz`,
-                    integrity: appSri,
+                    resolved: registry.tarballUrl('@fixture/app', '1.0.0'),
+                    integrity: registry.integrity('@fixture/app', '1.0.0'),
                     dependencies: { '@fixture/lib': '^9.0.0' },
                 },
                 // The stale, destructive entry: a registry pin for a name that
                 // is actually a local workspace.
                 'node_modules/@fixture/lib': {
                     version: '9.9.9',
-                    resolved: `${registryUrl}-/lib/9.9.9.tgz`,
-                    integrity: libSri,
+                    resolved: registry.tarballUrl('@fixture/lib', '9.9.9'),
+                    integrity: registry.integrity('@fixture/lib', '9.9.9'),
                     dependencies: {},
                 },
             },

--- a/tests/e2e/mock-registry.mjs
+++ b/tests/e2e/mock-registry.mjs
@@ -10,11 +10,21 @@
 // exported none of it.
 //
 // SCOPE. This serves the COMMON registry shape: an index document per package,
-// `dist-tags.latest`, a gzipped tarball per version, 404 for anything unknown. A
-// suite that needs the registry to misbehave — stall mid-body, close early, count
-// requests — passes `onRequest`, which sees every request first and reports
-// whether it handled it. That hook exists so those suites keep the shared writer
-// instead of forking the whole module again, which is how this started.
+// `dist-tags.latest`, a gzipped tarball per version, 404 for anything unknown.
+//
+// Two hooks cover everything a suite has needed beyond that, and they answer
+// different questions:
+//
+//   onRequest(req, res, ctx)      — answer a request INSTEAD of the default routes.
+//                                   Return true when handled. This is where a stall,
+//                                   a 503, a 304, a dropped socket or a request
+//                                   counter goes.
+//   onPackument(doc, ctx)         — edit the document the default route is ABOUT to
+//                                   send. This is where "hide a version" or "the
+//                                   abbreviated shape omits libc" goes.
+//
+// They exist so a suite that needs the registry to misbehave keeps the shared
+// writer instead of forking the whole module again, which is how this started.
 
 import { createServer } from 'node:http';
 import { createHash } from 'node:crypto';
@@ -124,24 +134,32 @@ function splitVersionSpec(name, version, spec) {
  * Start an in-process npm registry over a fixture tree.
  *
  * @param {Record<string, Record<string, object>>} packages `name → version → manifest fields (+ optional `files`)`
- * @param {{ onRequest?: (req, res, ctx) => boolean, distTags?: Record<string, Record<string, string>> }} [options]
+ * @param {{ onRequest?: (req, res, ctx) => boolean,
+ *           onPackument?: (doc, ctx) => void,
+ *           distTags?: Record<string, Record<string, string>> }} [options]
  *        `onRequest` sees every request BEFORE the default routes and returns
- *        `true` when it has answered — the seam for suites testing a registry that
- *        stalls, truncates or fails.
+ *        `true` when it has answered — the seam for a registry that stalls,
+ *        truncates, 503s, 304s or counts. `onPackument` receives the document the
+ *        default route is about to send, so a suite can hide a version or strip a
+ *        field per request shape without re-implementing the route; `dist-tags` is
+ *        computed after it runs.
  * @returns {Promise<{ url: string, port: number, close: () => Promise<void>,
  *          tarball: (name: string, version: string) => Buffer,
  *          integrity: (name: string, version: string) => string,
+ *          tarballUrl: (name: string, version: string) => string,
  *          requests: string[] }>}
  */
 export async function startMockRegistry(packages, options = {}) {
-    const { onRequest, distTags = {} } = options;
+    const { onRequest, onPackument, distTags = {} } = options;
 
     /** name → { indexDoc, versions: Map<version, {tgz, integrity}> } */
     const store = new Map();
     for (const [name, versions] of Object.entries(packages)) {
-        const doc = { name, 'dist-tags': {}, versions: {} };
+        // No `dist-tags` here: it is computed on the WIRE path, after `onPackument`
+        // has had its say, so a hook that hides a version cannot leave `latest`
+        // pointing at one the document no longer offers.
+        const doc = { name, versions: {} };
         const built = new Map();
-        let last = '';
         for (const [version, spec] of Object.entries(versions)) {
             const { pkgJson, files } = splitVersionSpec(name, version, spec);
             const { tgz, integrity } = packageTarball(files);
@@ -150,9 +168,7 @@ export async function startMockRegistry(packages, options = {}) {
                 ...pkgJson,
                 dist: { tarball: `__BASE__/-/${name}/${version}.tgz`, integrity },
             };
-            last = version;
         }
-        doc['dist-tags'] = { latest: last, ...distTags[name] };
         store.set(name, { doc, versions: built });
     }
 
@@ -175,9 +191,15 @@ export async function startMockRegistry(packages, options = {}) {
             const entry = store.get(pkgName);
             if (!entry) return void res.writeHead(404).end('not found');
             const wire = JSON.parse(JSON.stringify(entry.doc));
+            onPackument?.(wire, { req, res, name: pkgName, store, baseUrl: baseUrl() });
+            // AFTER the hook, for the reason the store doc carries no dist-tags.
+            const offered = Object.keys(wire.versions);
+            wire['dist-tags'] = { latest: offered[offered.length - 1], ...distTags[pkgName] };
             for (const v of Object.values(wire.versions)) {
                 v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl());
             }
+            // `writeHead` MERGES with headers already set, so an `onRequest` that
+            // set one (an ETag, say) and fell through still has it here.
             res.writeHead(200, { 'content-type': 'application/json' });
             res.end(JSON.stringify(wire));
         } catch (e) {
@@ -197,7 +219,18 @@ export async function startMockRegistry(packages, options = {}) {
         requests,
         tarball: (name, version) => store.get(name)?.versions.get(version)?.tgz,
         integrity: (name, version) => store.get(name)?.versions.get(version)?.integrity,
-        close: () => new Promise((resolve) => server.close(resolve)),
+        /** The URL this registry serves a tarball at — for a suite hand-writing a lockfile's `resolved`. */
+        tarballUrl: (name, version) => `${baseUrl()}/-/${name}/${version}.tgz`,
+        close: () =>
+            new Promise((resolve) => {
+                // `server.close()` waits for every open connection, and a registry
+                // that deliberately never ENDS a response has one that never closes.
+                // Measured: plain `close()` did not fire its callback within 2 s
+                // against the partial-body server `install-timeout` needs, and
+                // resolved immediately once the connections were dropped first.
+                server.closeAllConnections();
+                server.close(resolve);
+            }),
     };
 }
 

--- a/tests/e2e/native-install/run.mjs
+++ b/tests/e2e/native-install/run.mjs
@@ -11,12 +11,10 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { LOCKFILE_VERSION } from '../helpers.mjs';
-import { packageTar, sriSha512 } from '../mock-registry.mjs';
+import { startMockRegistry } from '../mock-registry.mjs';
 
 /**
  * Run a child without blocking the test event loop — the in-process mock
@@ -52,107 +50,30 @@ function runHarness(cmd, args, cwd) {
     });
 }
 
-/** This suite's fixtures are all a bare `package.json`. */
-const packageTarFor = (pkgJson) => packageTar({ 'package.json': JSON.stringify(pkgJson, null, 2) + '\n' });
-
 describe('native install backend (in-process registry)', { timeout: 60_000 }, () => {
-    let server;
-    let registryUrl;
+    let registry;
     let prefix;
     const PACKAGES = {
-        leaf: {
-            versions: { '1.0.0': { dependencies: {} } },
-        },
-        middle: {
-            versions: { '1.2.3': { dependencies: { leaf: '^1.0.0' } } },
-        },
-        root: {
-            versions: { '0.1.0': { dependencies: { middle: '^1.0.0', leaf: '^1.0.0' } } },
-        },
+        leaf: { '1.0.0': { dependencies: {} } },
+        middle: { '1.2.3': { dependencies: { leaf: '^1.0.0' } } },
+        root: { '0.1.0': { dependencies: { middle: '^1.0.0', leaf: '^1.0.0' } } },
         // Conflict graph (second test): app → dep@^1 + mid@^1; mid → dep@^2.
         // Forces dep@2 to NEST under mid while dep@1 hoists to the root — the
         // order-sensitive hoist-vs-nest placement path. A regression in the
         // resolver's BFS ordering (e.g. the wave-based parallel rewrite) would
         // surface here as a wrong placement.
-        dep: {
-            versions: { '1.0.0': { dependencies: {} }, '2.0.0': { dependencies: {} } },
-        },
-        mid: {
-            versions: { '1.0.0': { dependencies: { dep: '^2.0.0' } } },
-        },
-        app: {
-            versions: { '1.0.0': { dependencies: { dep: '^1.0.0', mid: '^1.0.0' } } },
-        },
+        dep: { '1.0.0': { dependencies: {} }, '2.0.0': { dependencies: {} } },
+        mid: { '1.0.0': { dependencies: { dep: '^2.0.0' } } },
+        app: { '1.0.0': { dependencies: { dep: '^1.0.0', mid: '^1.0.0' } } },
     };
 
     before(async () => {
-        // Build tarballs and a packument index keyed by package name.
-        const index = {};
-        for (const [name, info] of Object.entries(PACKAGES)) {
-            index[name] = { name, 'dist-tags': {}, versions: {} };
-            let lastVersion = '';
-            for (const [version, body] of Object.entries(info.versions)) {
-                const pkgJson = { name, version, ...body };
-                const tar = packageTarFor(pkgJson);
-                const tgz = gzipSync(tar);
-                index[name].versions[version] = {
-                    name,
-                    version,
-                    dependencies: body.dependencies ?? {},
-                    dist: {
-                        tarball: `__BASE__/-/${name}/${version}.tgz`,
-                        integrity: sriSha512(tgz),
-                    },
-                    _tgz: tgz,
-                };
-                lastVersion = version;
-            }
-            index[name]['dist-tags'].latest = lastVersion;
-        }
-
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                // Tarball: /-/<pkg>/<version>.tgz
-                const tarMatch = url.match(/^\/-\/([^/]+)\/([^/]+)\.tgz$/);
-                if (tarMatch) {
-                    const v = index[tarMatch[1]]?.versions[tarMatch[2]];
-                    if (!v) {
-                        res.writeHead(404).end('not found');
-                        return;
-                    }
-                    res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                    res.end(v._tgz);
-                    return;
-                }
-                // Packument: /<encoded-name>
-                const pkgName = decodeURIComponent(url.replace(/^\//, ''));
-                const p = index[pkgName];
-                if (!p) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const wire = JSON.parse(JSON.stringify(p, (key, val) => (key === '_tgz' ? undefined : val)));
-                for (const v of Object.values(wire.versions)) {
-                    v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl);
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-
-        await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-        const port = server.address().port;
-        registryUrl = `http://127.0.0.1:${port}/`;
-
+        registry = await startMockRegistry(PACKAGES);
         prefix = mkdtempSync(join(tmpdir(), 'gjsify-native-install-'));
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (prefix) rmSync(prefix, { recursive: true, force: true });
     });
 
@@ -169,7 +90,7 @@ describe('native install backend (in-process registry)', { timeout: 60_000 }, ()
       await installPackagesNative({
         prefix: ${JSON.stringify(prefix)},
         specs: ['root@^0.1.0'],
-        registry: ${JSON.stringify(registryUrl)},
+        registry: ${JSON.stringify(registry.url)},
         verbose: false,
         lockfile: true,
       });
@@ -246,7 +167,7 @@ describe('native install backend (in-process registry)', { timeout: 60_000 }, ()
       await installPackagesNative({
         prefix: ${JSON.stringify(prefix2)},
         specs: ['app@^1.0.0'],
-        registry: ${JSON.stringify(registryUrl)},
+        registry: ${JSON.stringify(registry.url)},
         verbose: false,
         lockfile: true,
       });

--- a/tests/e2e/published-closure/run.mjs
+++ b/tests/e2e/published-closure/run.mjs
@@ -20,8 +20,8 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { createServer } from 'node:http';
 import { fileURLToPath } from 'node:url';
+import { startMockRegistry } from '../mock-registry.mjs';
 
 const SCRIPT = fileURLToPath(new URL('../../../scripts/verify-published-closure.mjs', import.meta.url));
 const VERSION = '1.2.3';
@@ -98,7 +98,7 @@ function writeTree(root, pkgs) {
 }
 
 describe('verify-published-closure (post-release registry assertion)', { timeout: 120_000 }, () => {
-    let server, registryUrl, tmp;
+    let registry, registryUrl, tmp;
     /** name → string[] of published versions. Missing name = 404. */
     let published = new Map();
     /** name → number of packument requests served (for the retry case). */
@@ -116,32 +116,47 @@ describe('verify-published-closure (post-release registry assertion)', { timeout
 
     before(async () => {
         tmp = mkdtempSync(join(tmpdir(), 'gjsify-e2e-closure-'));
-        server = createServer((req, res) => {
-            const name = decodeURIComponent((req.url ?? '/').replace(/^\//, '').split('?')[0]);
-            hits.set(name, (hits.get(name) ?? 0) + 1);
-            if (broken.has(name)) {
-                res.writeHead(503, { 'content-type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Service Unavailable' }));
-                return;
-            }
-            const hidden = revealAfter.has(name) && hits.get(name) < revealAfter.get(name);
-            const versions = hidden ? undefined : published.get(name);
-            if (!versions) {
-                res.writeHead(404, { 'content-type': 'application/json' });
-                res.end(JSON.stringify({ error: 'Not found' }));
-                return;
-            }
-            res.writeHead(200, { 'content-type': 'application/json' });
-            res.end(
-                JSON.stringify({ name, versions: Object.fromEntries(versions.map((v) => [v, { name, version: v }])) }),
-            );
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}`;
+        // Everything goes through `onRequest` rather than the shared module's
+        // fixture store: what each case publishes is MUTATED between cases
+        // (`published`, `broken`, `revealAfter` are reassigned per `it`), and a
+        // store fixed at construction cannot express that. The shared module is
+        // still what owns the socket and the teardown.
+        registry = await startMockRegistry(
+            {},
+            {
+                onRequest: (req, res) => {
+                    const name = decodeURIComponent((req.url ?? '/').replace(/^\//, '').split('?')[0]);
+                    hits.set(name, (hits.get(name) ?? 0) + 1);
+                    if (broken.has(name)) {
+                        res.writeHead(503, { 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Service Unavailable' }));
+                        return true;
+                    }
+                    const hidden = revealAfter.has(name) && hits.get(name) < revealAfter.get(name);
+                    const versions = hidden ? undefined : published.get(name);
+                    if (!versions) {
+                        res.writeHead(404, { 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ error: 'Not found' }));
+                        return true;
+                    }
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(
+                        JSON.stringify({
+                            name,
+                            versions: Object.fromEntries(versions.map((v) => [v, { name, version: v }])),
+                        }),
+                    );
+                    return true;
+                },
+            },
+        );
+        // `verify-published-closure.mjs` strips a trailing slash itself, so the
+        // shared module's `url` needs no adjustment.
+        registryUrl = registry.url;
     });
 
     after(async () => {
-        if (server) await new Promise((r) => server.close(r));
+        await registry?.close();
         if (tmp) rmSync(tmp, { recursive: true, force: true });
     });
 

--- a/tests/e2e/uninstall-global/run.mjs
+++ b/tests/e2e/uninstall-global/run.mjs
@@ -6,88 +6,32 @@
 //   - uninstall non-existing package → exit non-zero with clear msg
 //   - --dry-run leaves the filesystem alone
 //
-// Reuses the in-process mock-registry harness pattern from
-// tests/e2e/native-install-project/.
+// Uses the shared in-process mock registry, tests/e2e/mock-registry.mjs.
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createServer } from 'node:http';
-import { gzipSync } from 'node:zlib';
 import { fileURLToPath } from 'node:url';
-import { packageTar, runCli, sriSha512 } from '../mock-registry.mjs';
+import { runCli, startMockRegistry } from '../mock-registry.mjs';
 
 describe('Phase F.8 — gjsify uninstall -g', { timeout: 60_000 }, () => {
-    let server, registryUrl, tmpRoot, cliEntry, envForCli;
+    let registry, registryUrl, tmpRoot, cliEntry, envForCli;
 
     const PACKAGES = {
         'demo-tool': {
-            versions: {
-                '1.0.0': {
-                    name: 'demo-tool',
-                    version: '1.0.0',
-                    dependencies: {},
-                    bin: { 'demo-tool': './bin.js' },
-                },
+            '1.0.0': {
+                dependencies: {},
+                bin: { 'demo-tool': './bin.js' },
+                files: { 'bin.js': '#!/usr/bin/env node\nconsole.log("hi from demo-tool");\n' },
             },
         },
     };
 
     before(async () => {
-        const index = {};
-        for (const [name, info] of Object.entries(PACKAGES)) {
-            index[name] = { name, 'dist-tags': {}, versions: {} };
-            let last = '';
-            for (const [version, body] of Object.entries(info.versions)) {
-                const tar = packageTar({
-                    'package.json': JSON.stringify(body, null, 2) + '\n',
-                    'bin.js': '#!/usr/bin/env node\nconsole.log("hi from demo-tool");\n',
-                });
-                const tgz = gzipSync(tar);
-                index[name].versions[version] = {
-                    ...body,
-                    dist: { tarball: `__BASE__/${name}/-/${name}-${version}.tgz`, integrity: sriSha512(tgz) },
-                    _tgz: tgz,
-                };
-                last = version;
-            }
-            index[name]['dist-tags'].latest = last;
-        }
-
-        server = createServer((req, res) => {
-            try {
-                const url = req.url ?? '';
-                for (const [name, p] of Object.entries(index)) {
-                    for (const [version, v] of Object.entries(p.versions)) {
-                        const expected = `/${name}/-/${name}-${version}.tgz`;
-                        if (url === expected) {
-                            res.writeHead(200, { 'content-type': 'application/octet-stream' });
-                            res.end(v._tgz);
-                            return;
-                        }
-                    }
-                }
-                const pkgName = decodeURIComponent(url.replace(/^\//, '').replace(/%2[Ff]/g, '/'));
-                const p = index[pkgName];
-                if (!p) {
-                    res.writeHead(404).end('not found');
-                    return;
-                }
-                const baseUrl = `http://127.0.0.1:${server.address().port}`;
-                const wire = JSON.parse(JSON.stringify(p, (k, v) => (k === '_tgz' ? undefined : v)));
-                for (const v of Object.values(wire.versions)) {
-                    v.dist.tarball = v.dist.tarball.replace('__BASE__', baseUrl);
-                }
-                res.writeHead(200, { 'content-type': 'application/json' });
-                res.end(JSON.stringify(wire));
-            } catch (e) {
-                res.writeHead(500).end(String(e));
-            }
-        });
-        await new Promise((r) => server.listen(0, '127.0.0.1', r));
-        registryUrl = `http://127.0.0.1:${server.address().port}/`;
+        registry = await startMockRegistry(PACKAGES);
+        registryUrl = registry.url;
 
         tmpRoot = mkdtempSync(join(tmpdir(), 'gjsify-e2e-uninstall-'));
         cliEntry = fileURLToPath(new URL('../../../packages/infra/cli/lib/index.js', import.meta.url));
@@ -99,8 +43,8 @@ describe('Phase F.8 — gjsify uninstall -g', { timeout: 60_000 }, () => {
         };
     });
 
-    after(() => {
-        if (server) server.close();
+    after(async () => {
+        await registry?.close();
         if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
     });
 

--- a/tests/e2e/upgrade/run.mjs
+++ b/tests/e2e/upgrade/run.mjs
@@ -1,10 +1,10 @@
 // E2E test for `gjsify upgrade`.
 //
-// Strategy: stand up a mock npm registry in-process via `http.createServer()`,
-// generate packuments for a few synthetic packages, point `gjsify upgrade
-// --latest --dry-run` at the project via `--cwd`, set `npm_config_registry`
-// to our mock, and assert the candidate table shape + dry-run skip + actual
-// write-back behavior on a non-dry-run pass.
+// Strategy: stand up the shared in-process mock registry over a few synthetic
+// packages, point `gjsify upgrade --latest --dry-run` at the project via
+// `--cwd`, set `npm_config_registry` to our mock, and assert the candidate
+// table shape + dry-run skip + actual write-back behavior on a non-dry-run
+// pass.
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
@@ -12,37 +12,30 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-import { createServer } from 'node:http';
 import { writeFileSync, readFileSync, mkdirSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { startMockRegistry } from '../mock-registry.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MONOREPO_ROOT = join(__dirname, '..', '..', '..');
 const CLI_ENTRY = join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'lib', 'index.js');
 
+// Version keys with empty manifests: every case here runs a flavour of
+// `upgrade`, which only reads packuments and rewrites `package.json` — no
+// tarball is ever fetched, so there is nothing for a manifest to carry. The
+// last key of each package is what the registry offers as `dist-tags.latest`.
+const PACKAGES = {
+    'lib-a': { '1.0.0': {}, '1.1.0': {}, '1.2.3': {}, '2.0.0': {} },
+    'lib-b': { '0.4.0': {}, '0.5.0': {} },
+    'lib-c': { '3.2.0': {}, '3.2.1': {} },
+    'lib-uptodate': { '9.9.9': {} },
+};
+
 describe('CLI upgrade E2E', { timeout: 2 * 60 * 1000 }, () => {
     let tmpDir;
-    let registryServer;
-    let registryUrl;
-
-    /** Build a minimal packument body matching @gjsify/npm-registry's schema. */
-    function packument(name, versions, latest) {
-        const versionMap = {};
-        for (const v of versions) {
-            versionMap[v] = {
-                name,
-                version: v,
-                dist: { tarball: `${registryUrl}/${name}/-/${name}-${v}.tgz`, shasum: 'deadbeef' },
-            };
-        }
-        return JSON.stringify({
-            name,
-            'dist-tags': { latest },
-            versions: versionMap,
-        });
-    }
+    let registry;
 
     before(async () => {
         tmpDir = mkdtempSync(join(tmpdir(), 'gjsify-e2e-upgrade-'));
@@ -50,41 +43,11 @@ describe('CLI upgrade E2E', { timeout: 2 * 60 * 1000 }, () => {
             throw new Error(`CLI entry not built: ${CLI_ENTRY}`);
         }
 
-        registryServer = createServer((req, res) => {
-            // Decode the packument lookup: /<name> or /@scope/<name>
-            const path = decodeURIComponent(req.url ?? '/');
-            // Strip leading slash + trailing query.
-            const name = path.replace(/^\//, '').split('?')[0] ?? '';
-            switch (name) {
-                case 'lib-a':
-                    res.setHeader('content-type', 'application/json');
-                    res.end(packument('lib-a', ['1.0.0', '1.1.0', '1.2.3', '2.0.0'], '2.0.0'));
-                    return;
-                case 'lib-b':
-                    res.setHeader('content-type', 'application/json');
-                    res.end(packument('lib-b', ['0.4.0', '0.5.0'], '0.5.0'));
-                    return;
-                case 'lib-c':
-                    res.setHeader('content-type', 'application/json');
-                    res.end(packument('lib-c', ['3.2.0', '3.2.1'], '3.2.1'));
-                    return;
-                case 'lib-uptodate':
-                    res.setHeader('content-type', 'application/json');
-                    res.end(packument('lib-uptodate', ['9.9.9'], '9.9.9'));
-                    return;
-                default:
-                    res.statusCode = 404;
-                    res.end('{}');
-                    return;
-            }
-        });
-        await new Promise((resolve) => registryServer.listen(0, '127.0.0.1', resolve));
-        const addr = registryServer.address();
-        registryUrl = `http://127.0.0.1:${addr.port}`;
+        registry = await startMockRegistry(PACKAGES);
     });
 
-    after(() => {
-        registryServer?.close();
+    after(async () => {
+        await registry?.close();
         if (!process.env.GJSIFY_E2E_KEEP_TEMP) {
             rmSync(tmpDir, { recursive: true, force: true });
         }
@@ -124,7 +87,7 @@ describe('CLI upgrade E2E', { timeout: 2 * 60 * 1000 }, () => {
         const { stdout } = await execFileAsync('node', [CLI_ENTRY, 'upgrade', ...args], {
             timeout: opts.timeout ?? 30 * 1000,
             cwd: opts.cwd,
-            env: { ...process.env, npm_config_registry: registryUrl, ...opts.env },
+            env: { ...process.env, npm_config_registry: registry.url, ...opts.env },
             encoding: 'utf8',
         });
         return stdout;


### PR DESCRIPTION
The actionable half of #1044. (Its issue text is partly stale — the tar-writer half landed earlier; what was still duplicated is the registry SERVER.)

## The gap

`packageTar`, `sriSha512` and `runCli` have one home and a checker that fails a private copy. The **registry did not**: twenty suites stood up their own `node:http` server beside the shared `startMockRegistry`, which three suites used. Its packument/tarball routing had twenty divergent siblings that no correction could reach.

**Sixteen migrate.** Twelve needed no option at all — their servers were the default shape with a fixture attached. Three needed the existing `onRequest`. One needed a new hook.

## `onPackument` — a different question from `onRequest`

| hook | question |
|---|---|
| `onRequest` | **answer** a request instead of the default routes |
| `onPackument` | **edit** the document the default route is about to send |

`install-platform-filter` needs the second: its whole subject is that `libc` exists only in the FULL packument, and a resolver that trusts the abbreviated one judges every musl-only package installable on glibc. `install-lock-preserve` needs it to hide a version from the *document* while the tarball route keeps serving it.

`dist-tags` is now computed on the wire path **after** the hook, so hiding a version cannot leave `latest` pointing at one the document no longer offers.

## A real defect fell out of it

`close()` waits for every open connection — and a registry that deliberately never *ends* a response has one that never closes. Measured: plain `close()` did not fire its callback within 2 s against the partial-body server `install-timeout` needs, and resolved immediately once the connections were dropped first. That suite is exactly the one that could not migrate without the fix, and its hand-rolled socket-drain teardown is now deleted rather than kept beside the shared one.

## The mechanism

`check-e2e-harness-duplication.mjs` gains a `registry-server` rule matching the `createServer` **call** rather than a helper name, so a renamed copy still fails. Its ALLOWED ledger is self-retiring — an entry whose suite stops tripping its rule FAILS — and carries `publish`, `onboard` and `self-update`, whose subject is a *different* npm API (publish PUT bodies and OTP; the auth/trust state machine; the 406 path guard).

## `install-script` is deferred, not exempt

Its registry half is ordinary and its digest routes fit `onRequest`. It is not migrated because **two of its nine cases fail on this workstation before any change** — `No version of @gjsify/cli satisfies 0.0.99-test`, from a run that already isolates its cache, its prefix and its registry. CI is green on `main`, so it is local; but a migration verified only by *"the same two still fail"* is not verified, and that property is the entire reason the other sixteen are believable. Tracked in `status/open-todos.md`, together with the second duplication class this uncovered (a `runChild`/`runHarness` spawn helper in eleven suites, only five of them here).

## Verification

Every one of the sixteen ran **before and after** with an identical test count, and the three prior consumers of the shared registry are unchanged and green.

One check needed isolating, and this is worth knowing: `install-workspace-source-safety`'s `--immutable` case reads the lockfile's `resolved` **as** the tarball URL, and the suite-shared tarball cache means a *wrong* URL still passes in a full-suite run. Under `--test-name-pattern` it fails on the old shape and passes on `registry.tarballUrl()`. That masking is pre-existing — flagging it because anyone re-verifying that assertion must isolate the test.

Net **−652 lines**.