### PR TITLE
fix(rolldown-native): keep resolve error cause chain

### DIFF
--- a/packages/infra/cli/src/bundler-pick.spec.ts
+++ b/packages/infra/cli/src/bundler-pick.spec.ts
@@ -514,6 +514,12 @@ export default async () => {
                 'MatchedAliasNotFound { alias: "x" }',
                 "@gjsify/rolldown-native: ctx.resolve('x') failed — parent req_id 7 unknown",
                 'rolldown: malformed context_resolve args JSON: expected value',
+                // anyhow's alternate Display — what the `Err(e)` arm of
+                // `gjsify_rolldown_session_context_resolve` sends once it stopped
+                // truncating the cause chain. A plugin failure surfaced through
+                // THAT arm must stay a rejection: fold it into `null` and a broken
+                // plugin is reported as the user's missing dependency.
+                'plugin `gjsify-alias` threw an error: plugin `gjsify-unresolved-workspace-import` threw an error: NotFound("@gjsify/dom-exception/register")',
             ]) {
                 expect(isResolveMiss(e)).toBe(false);
             }

--- a/packages/infra/rolldown-native/src/rust/src/session.rs
+++ b/packages/infra/rolldown-native/src/rust/src/session.rs
@@ -651,11 +651,28 @@ pub extern "C" fn gjsify_rolldown_session_context_resolve(
                 external: None,
                 error: Some(format!("{resolve_err:?}")),
             },
+            // `{e:#}`, NOT `{e}`. This arm carries an `anyhow::Error`, whose
+            // OUTERMOST message is never the interesting part — the cause chain
+            // underneath is, and that is where a user plugin's own error text
+            // lives. `{e}` printed the outer line alone, so a plugin that threw
+            // during a NESTED `this.resolve()` reached JS as a bare
+            // "plugin `gjsify-alias` threw an error" with the diagnostic that
+            // names the specifier, the substitution target and the importer
+            // discarded. The `Ok(Err(resolve_err))` arm above has always printed
+            // its full form; the two simply disagreed, and this is the arm a
+            // plugin failure takes.
+            //
+            // The alternate form reaches `isResolveMiss` in `../../ts/plugins.ts`,
+            // which folds a `context_resolve` error into "nothing there" only when
+            // it starts with `NotFound(`. A chain from THIS arm opens with the
+            // outer bundler/plugin message, never that — pinned by
+            // `@gjsify/cli`'s `bundler-pick.spec.ts`, so the two cannot drift into
+            // reporting a real plugin failure as the user's missing dependency.
             Err(e) => ContextResolveResponse {
                 child_id,
                 id: None,
                 external: None,
-                error: Some(format!("{e}")),
+                error: Some(format!("{e:#}")),
             },
         };
         let _ = shared.context_response_tx.send(resp);

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,6 +4,51 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
+### Nothing runs `build:infra` on a cold tree with no `node`
+
+The bootstrap ADR 0002 documents — `gjs -m install.mjs` → `gjsify install
+--immutable` → `gjsify run build:infra` — used to die at its THIRD step on a host
+with no `node`, from a fresh clone. Measured 2026-08-19 on postmarketOS v26.06 /
+aarch64 (OnePlus 6T, gjs 1.88.1, musl, no node) against `3ad411530`, in a
+`git worktree` with no `lib/esm` anywhere:
+
+    gjsify run --node-script: failed to bundle …/create-gjsify/scripts/process-template.mjs
+    [@gjsify/create-app] gjsify run build exited with code 1
+
+**Mechanism, and why the defect is closed.** `@gjsify/create-app`'s `build` runs
+`node scripts/process-template.mjs`. With no `node`, `ensureGjsifyShimOnPath()`
+re-enters the CLI as `gjsify run --node-script`, which bundles the script
+`--app gjs` under `--globals auto` — and auto-globals RESOLVES a
+`@gjsify/<pkg>/register[/…]` subpath per injected global (`--verbose` prints
+`closure map expanded 1 → 21 global(s)` for a one-line `export {}` entry, spanning
+`web-globals`, `abort-controller`, `buffer`, `web-streams`, `dom-exception`,
+`formdata`, `perf_hooks`, `webcrypto`). In a cold clone the workspace copies have
+no `lib/esm`, so every injection was unresolvable and `unresolved-workspace-import`
+(correctly) failed the build. #1232 closed that: a TOOLCHAIN bundle now falls back
+to the CLI's OWN directory once workspace resolution returns null. All 23 register
+packages sit in `@gjsify/cli`'s transitive dependency closure, so a self-contained
+install can answer — checked against `~/.local/share/gjsify/global`, where all 23
+are present and built.
+
+**What is still open is the MEASUREMENT.** No suite executes that third step.
+`bootstrap-cold-tree` asserts the `--print-plan` BRANCH and exits without
+spawning; `node-free-bootstrap` covers the install and a manifest invariant;
+`node-script-cold-workspace` (#1232) drives the real `--node-script` path against
+ONE planted unresolvable package rather than a whole cold tree. Every CI host has
+`node`, so these scripts run natively and are never bundled at all. Until a leg
+really runs `build:infra` on a tree with no `lib/esm` and `node` off PATH, the fix
+is argued rather than observed — and the failure returns unseen.
+
+It is worth recording what this is NOT, because both wrong turns were taken once.
+It is not a `build:infra` ORDERING bug: `create-app` is merely the first
+`node scripts/*.mjs` the chain reaches, and the same failure hit
+`check-refs-pin.mjs`, so `build:prebuilds` could not start either. And it is not
+fixable by dropping the EXPANDED half of the closure set — `auto-globals.spec.ts`
+("closure-map expansion vs generator bypass") pins that the expansion is a seed the
+pure iterative loop reaches anyway, so an expanded global is one the injected
+register genuinely references. Dropping it trades a build error for a runtime
+`ReferenceError`.
+
 ### No CI leg ever LAUNCHES a template on node, bun or deno
 
 `gjsify.example.runtimes` on the seven templates declares four runtimes, and
@@ -350,13 +395,18 @@ affects a caller that hands `pathToFileURL` a relative path ON win32. `node:url`
 
 ### sass under GJS: the SCRIPT path is closed, the BUNDLER path is not (#1053)
 
-The bootstrap chain itself is closed: `gjsify run --node-script <file>` bundles an
-unbundled `.mjs` that imports `node:*` and runs it, `ensureGjsifyShimOnPath()`
-puts a `node` on a package script's PATH that re-enters it when the host has none, and `build:infra`
-now goes end to end with no `node` at all — measured by putting `node`/`npm`/`npx`
-on PATH that exit 127 and announce themselves, then running the whole chain under
-`gjs -m …/cli.gjs.mjs`: exit 0 warm, and exit 0 COLD with both native facades
-deleted, which rebuilt them through the global CLI's own engine.
+The bootstrap chain itself is closed FOR A TREE THAT IS ALREADY BUILT:
+`gjsify run --node-script <file>` bundles an unbundled `.mjs` that imports `node:*`
+and runs it, `ensureGjsifyShimOnPath()` puts a `node` on a package script's PATH
+that re-enters it when the host has none, and `build:infra` goes end to end with no
+`node` at all — measured by putting `node`/`npm`/`npx` on PATH that exit 127 and
+announce themselves, then running the whole chain under `gjs -m …/cli.gjs.mjs`:
+exit 0 warm, and exit 0 with both native facades deleted, which rebuilt them
+through the global CLI's own engine. **That last measurement is NOT the cold case
+it reads as** — deleting the facades leaves every workspace `lib/esm` in place. On
+a tree that has none the same chain used to fail at its first `node scripts/*.mjs`;
+#1232 closed that, and what is left is that nothing measures it — see
+"Nothing runs `build:infra` on a cold tree with no `node`" above.
 `process-template.mjs`, `set-bin-mode.mjs`, `build-assets.mjs` and
 `bootstrap-native-facades.mjs` all run there now. The manifests still spell
 `node scripts/x.mjs` deliberately — `writeNodeShim` records why a NEW flag in a


### PR DESCRIPTION
## The one-character half

`gjsify_rolldown_session_context_resolve` has two error arms, and they disagreed about how much of the error reaches JS:

```rust
Ok(Err(resolve_err)) => format!("{resolve_err:?}")   // full form
Err(e)               => format!("{e}")               // outermost line only
```

The second carries an `anyhow::Error`, whose outermost message is never the interesting part — the cause chain underneath is, and that is where a user plugin's own error text lives. A plugin that throws during a **nested** `this.resolve()` therefore arrived as:

```
plugin `gjsify-alias` threw an error
Caused by:
    plugin `gjsify-unresolved-workspace-import` threw an error
```

`{e:#}` is anyhow's alternate `Display` and prints the chain — which is what the sibling arm has always done.

## Why it was worth a PR of its own

Measured on postmarketOS v26.06 / aarch64 (OnePlus 6T, gjs 1.88.1, musl, **no node**) against `3ad411530`: the guard that fires in a cold tree is `unresolved-workspace-import`, whose message names the specifier, the substitution target and the importer — the three facts that identify the bug. None of them survived this arm.

What that cost, concretely: rebuilding candidate packages one at a time did not converge after **sixteen** of them. With the name in hand the rest fell out mechanically — `dom-exception` → `abort-controller` → `perf_hooks` → `dom-events`, then `readline` — five iterations against sixteen packages and several hours. That ratio is the argument for the patch.

The asymmetry is also why it was so hard to see: a one-line `export {}` entry happens to take the `Ok(Err(resolve_err))` arm, which printed `NotFound("@gjsify/web-globals/register/performance")` on the first try, while the real scripts stayed mute.

## The guard that comes with it

The chain shape lands in the same channel `isResolveMiss` classifies, so `bundler-pick.spec.ts` gains it: a plugin failure carrying a `NotFound` **deep inside** must stay a rejection, not fold into "nothing there" — fold it and a broken plugin gets reported as the user's missing dependency.

A/B-checked rather than assumed: swapping `startsWith` for `includes` in the built `isResolveMiss` turns exactly that case red, and nothing else in the 2458-test suite.

No Rust test: `cargo test` is not run anywhere in CI, so one would be a test that cannot fail.

And the class is covered, not just this instance: `session.rs:658` is the only site in the crate that stringifies an `anyhow::Error` through `Display`. The two neighbouring `format!("… {e}")` sites (451, 722) carry a `serde_json::Error`, which has no chain, and every other stringification in the crate is `{:?}` on a non-anyhow value.

## Also in here

The branch originally added an `open-todos.md` entry describing the Node-less cold-tree failure as **open**, and listed as an unchosen alternative "*(b) resolve a node-script's globals against the CLI's OWN installed packages*".

#1232 shipped exactly that in the meantime. The entry would therefore have landed as a stale claim reading like live work, so it now says what is actually true: the mechanism, why #1232 closes it, and the one thing genuinely still open — **nothing measures it**. `bootstrap-cold-tree` asserts the `--print-plan` branch without spawning, `node-free-bootstrap` covers the install, `node-script-cold-workspace` drives one planted package rather than a whole cold tree, and every CI host has `node`.

Checked rather than assumed while rewriting it: all 23 register subpaths auto-globals injects are in `@gjsify/cli`'s transitive dependency closure, and all 23 are present **and built** in a real standalone install (`~/.local/share/gjsify/global`) — so the anchor can answer there.

It also corrects the neighbouring sass entry: its "exit 0 COLD" measurement deleted the two native facades, which leaves every workspace `lib/esm` in place, so it is not the cold case it reads as. Its cross-reference pointed "below" at an entry that is above it.

## Verification

**On the measuring host** (postmarketOS/aarch64, musl, no node): `meson setup` + `meson compile`, then the freshly built `.so` pair + typelib swapped into the global prefix's `@gjsify/rolldown-native-linux-arm64/prebuilds/linux-arm64`. Before and after are the two blocks above.

**Locally**: `gjsify workspace @gjsify/cli run test` — 2458 pass, plus the A/B above.

Note for reviewers: the committed prebuild stays the old binary until `commit-prebuilds` runs on `main`, so the improved message does not appear in this PR's own e2e output.

**Correction to an earlier revision of this description.** It claimed that building a native bridge on musl needs `-C target-feature=-crt-static` and that "nothing in the repo mentions it". Both halves are wrong, and the repo is right: `prebuilds.yml`, `musl-build.sh` and `emulated-build.sh` all document that rustup's `*-unknown-linux-musl` defaults `crt-static` ON and therefore cannot emit a cdylib at all, while Alpine's own `*-alpine-linux-musl` has it OFF and needs no flag. The local build hit that wall because its `rustc` came from `~/.cargo` rather than apk. The documented fix is Alpine's toolchain, not a flag.
