### PR TITLE
docs: describe the CLI the repo actually ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,14 @@ when the lockfile is missing or has drifted from `package.json`.
 ### Using the CLI directly
 
 ```bash
-gjsify build src/index.ts --outfile dist/app.js   # build a TS file for GJS
-gjsify run dist/app.js                             # run it (native prebuild paths auto-set)
-gjsify dlx <pkg>                                   # try a published GJS app without installing
+gjsify build src/index.ts --app gjs --outfile dist/app.js  # build a TS file for GJS
+gjsify run dist/app.js                                     # run it (prebuild paths auto-set)
+gjsify dlx <pkg>                                           # try a published app, no install
 ```
+
+`--app` is spelled out because it has no fixed default: it follows the runtime the CLI
+itself is running on — `gjs` via the bootstrap above, `node` via `npm install -g`. Omit it
+on a Node-installed CLI and you get a Node bundle, not a GJS one.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -93,16 +93,20 @@ remove. Already manage CLIs through Node? `npm install -g @gjsify/cli` works too
 **Create and run a project:**
 
 ```bash
-gjsify create my-app
+gjsify create my-app --template gtk-minimal
 cd my-app
-gjsify install --immutable   # resolves npm deps via the Node-free CLI bundle
-gjsify build                 # Rolldown-based, GJS target by default
-gjsify run start
+gjsify install      # resolves npm deps via the Node-free CLI bundle
+gjsify run build    # the template's own build script — Rolldown, GJS + Node bundles
+gjsify run start    # launch the GJS bundle
 ```
 
-`gjsify create` scaffolds a ready-to-run GTK 4 + TypeScript application. Pass
-`--immutable` to `install` for reproducible CI installs (gjsify-lock.json must
-match `package.json`).
+`gjsify create` scaffolds a ready-to-run GTK 4 + TypeScript application, build
+scripts included. `run build` emits a GJS bundle and a Node/Bun/Deno one from the
+same `src/index.ts`; `gjsify run dev` builds only the GJS half and launches it,
+which is the loop you want while editing. Leave `--template` off and the CLI asks
+which template you want. Once you commit the `gjsify-lock.json` that `install`
+writes, CI can use `gjsify install --immutable` for a reproducible tree — it fails
+when the lockfile is missing or has drifted from `package.json`.
 
 ### Using the CLI directly
 
@@ -135,15 +139,22 @@ Node.js 24+ is **optional** — needed only to run the cross-validation test tra
 
 ### Ship your own app
 
-- **A one-line installer:** `gjsify generate-installer` scaffolds an `install.mjs`
-  parameterised to your package, so your users install with a single
-  `curl … | gjs -m -` — no npm / Node on their machine.
+- **A `.deb` and an `.rpm`:** `gjsify ship` runs your project's `build` script,
+  stages one payload and wraps it per format — no packaging manifest in your repo,
+  and no `dpkg-deb` / `rpmbuild` on the machine. The package depends on the
+  distribution's own `gjs`, GTK and typelibs, worked out by reading your bundle.
+  Linux and `--app gjs` today; see [Ship your app](https://gjsify.github.io/gjsify/ship/).
 - **A Flatpak:** `gjsify flatpak init` generates the full Flathub asset set
   (manifest + MetaInfo + `.desktop` + `flathub.json`) from one `package.json`
   block; `gjsify flatpak check` runs `appstreamcli` + `flatpak-builder-lint`
   locally; `gjsify flatpak build` wraps `flatpak-builder`. See the
   [Flatpak app](https://gjsify.github.io/gjsify/guides/flatpak-app/) and
   [Flatpak CLI](https://gjsify.github.io/gjsify/guides/flatpak-cli-tool/) guides.
+- **A one-line installer:** `gjsify generate-installer` scaffolds an `install.mjs`
+  parameterised to your package, so your users install with a single
+  `curl … | gjs -m -` — no npm / Node on their machine.
+- **A single executable file:** `gjsify build --shebang` marks the bundle
+  executable with a target-appropriate shebang, to download and run as-is.
 
 ## Package status
 

--- a/packages/infra/cli/README.md
+++ b/packages/infra/cli/README.md
@@ -1,58 +1,84 @@
 # @gjsify/cli
 
-CLI tool for building and running GJS applications. Bundles TypeScript/JavaScript using esbuild with automatic Node.js to GJS module aliasing.
+CLI tool for building and running GJS applications. Bundles TypeScript/JavaScript with
+[Rolldown](https://rolldown.rs/), resolving each `node:*` import onto gjsify's
+GNOME-backed implementation for a GJS target and onto the runtime's own for a Node,
+Bun or Deno one — from unchanged source.
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
 ## Installation
 
-```bash
-gjsify install @gjsify/cli
+The CLI runs on GJS, Node.js, Bun and Deno, and it installs on all four. On a GNOME box
+`gjs` ≥ 1.86 and `curl` are enough — no Node.js at install time or ever after:
 
-# npm or yarn also work (e.g. adding it to an existing project):
-npm install @gjsify/cli
-yarn add @gjsify/cli
+```bash
+curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs \
+  -o /tmp/g.mjs && gjs -m /tmp/g.mjs && rm /tmp/g.mjs
 ```
+
+That lays the CLI down under `~/.local/share/gjsify/global/` with a launcher at
+`~/.local/bin/gjsify`; `gjsify self-update` refreshes it in place. Windows has no `gjs`
+binary, so take one of the other three there:
+
+```bash
+npm install -g @gjsify/cli
+bun add -g @gjsify/cli
+deno install -g -A -n gjsify npm:@gjsify/cli
+```
+
+Whichever route you pick you get the same `gjsify` command, and the runtime you installed
+with becomes the one it builds for by default. To pin the CLI per project instead of
+globally, add it as a dev dependency (`npm install -D @gjsify/cli`) — that is how every
+scaffolded template is wired. PATH notes and the update command for each route:
+[Install & Update](https://gjsify.github.io/gjsify/guides/install/).
 
 ## Usage
 
 ```bash
-# Build a GJS application
-npx @gjsify/cli build src/index.ts
-
-# Run a built GJS application (sets up the native-prebuild environment)
-npx @gjsify/cli run dist/index.js
-
-# Show environment info for a bundle
-npx @gjsify/cli info dist/index.js
+gjsify create my-app --template gtk-minimal   # scaffold a GTK 4 + TypeScript app
+cd my-app
+gjsify install                                # resolve npm deps, no npm required
+gjsify run dev                                # build the GJS bundle and launch it
 ```
+
+`create` writes the build scripts too, so `gjsify run build`, `run start` and `run check`
+work from there on. Reaching for the underlying commands directly:
+
+```bash
+gjsify build src/index.ts --app gjs --outfile dist/index.gjs.js
+gjsify run dist/index.gjs.js    # launch it, with the native-prebuild environment set
+gjsify info dist/index.gjs.js   # print that environment instead of launching
+gjsify ship                     # package the built app as a .deb and an .rpm
+```
+
+`ship` runs the project's own `build` script, stages one payload and wraps it per format,
+with no manifest to maintain — see [Ship your app](https://gjsify.github.io/gjsify/ship/).
+Every command and flag is in the
+[CLI Reference](https://gjsify.github.io/gjsify/cli-reference/).
+
+Without a global install, reach the CLI through your runtime's package runner instead:
+`npx @gjsify/cli@latest …`, `bunx @gjsify/cli@latest …` or
+`deno run -A npm:@gjsify/cli@latest …`.
 
 ## Native prebuilds
 
 Packages that ship compiled artifacts declare them with
 `"gjsify": { "prebuilds": "prebuilds", "platforms": ["linux-x64", "darwin-arm64", …] }`
-and stage them under `prebuilds/<os>-<arch>/`. `run`, `info`, `tsc` and the bin launchers
-`install` writes all resolve that directory for the running host.
+and stage them under `prebuilds/<os>-<arch>[-musl]/`. `run`, `info`, `tsc` and the bin
+launchers `install` writes all resolve that directory for the running host, and export
+`GI_TYPELIB_PATH` plus the library-search variable the host's dynamic loader actually
+reads — `LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on macOS (dyld ignores the Linux
+one), `PATH` on Windows (`LoadLibrary` has no dedicated variable).
 
-There is ONE `<os>-<arch>` spelling: `${process.platform}-${process.arch}` — `linux-x64`,
-`linux-arm64`, `darwin-arm64`, `win32-x64`. It is what a running process can compute about
-itself, so resolution needs no translation. (`ppc64`, `s390x` and `riscv64` are spelled the
-same in every vocabulary.) The resolver still probes a package's own `gjsify.platforms`
-entry first, and falls back to the retired uname spelling (`linux-x86_64`), so a tarball
-published before the rename keeps loading.
+The target is spelled `${process.platform}-${process.arch}`, which is what a running
+process can compute about itself, so resolution needs no translation table. A package with
+no artifact for your host is skipped — every native bridge is optional at runtime.
 
-The environment they export is `GI_TYPELIB_PATH` plus the library-search variable the host's
-dynamic loader actually reads:
-
-| host | variable | separator |
-|---|---|---|
-| Linux | `LD_LIBRARY_PATH` | `:` |
-| macOS | `DYLD_LIBRARY_PATH` (`dyld` ignores `LD_LIBRARY_PATH`) | `:` |
-| Windows | `PATH` (`LoadLibrary` has no dedicated variable) | `;` |
-
-A package with no artifact for your host is skipped — every native bridge is optional at
-runtime. Which artifacts exist per package is tracked in
-[Platform Support](https://gjsify.github.io/gjsify/platform-support/).
+- How the lookup works, and how to set the same environment by hand:
+  [How It Works](https://gjsify.github.io/gjsify/how-it-works/#native-prebuilds-and-gjsify-run)
+- Which artifacts exist per package:
+  [Platform Support](https://gjsify.github.io/gjsify/platform-support/)
 
 ## License
 

--- a/packages/infra/cli/README.md
+++ b/packages/infra/cli/README.md
@@ -19,11 +19,24 @@ curl -fsSL https://github.com/gjsify/gjsify/releases/latest/download/install.mjs
 
 That lays the CLI down under `~/.local/share/gjsify/global/` with a launcher at
 `~/.local/bin/gjsify`; `gjsify self-update` refreshes it in place. Windows has no `gjs`
-binary, so take one of the other three there:
+binary, so take one of the other three there. Pick a single route — each of them puts its
+own `gjsify` launcher on your PATH:
+
+**npm**
 
 ```bash
 npm install -g @gjsify/cli
+```
+
+**Bun**
+
+```bash
 bun add -g @gjsify/cli
+```
+
+**Deno**
+
+```bash
 deno install -g -A -n gjsify npm:@gjsify/cli
 ```
 
@@ -59,7 +72,12 @@ Every command and flag is in the
 
 Without a global install, reach the CLI through your runtime's package runner instead:
 `npx @gjsify/cli@latest …`, `bunx @gjsify/cli@latest …` or
-`deno run -A npm:@gjsify/cli@latest …`.
+`deno run -A --reload --min-dep-age=0 npm:@gjsify/cli@latest …`. Keep the `@latest` tag,
+and on Deno those two extra flags: all three runners reuse a cached copy of an unpinned
+bin, and Deno adds a second rule that refuses anything published in the last 24 hours.
+Neither one tells you it happened — the
+[measurement](https://gjsify.github.io/gjsify/guides/install/#which-version-do-npx-bunx-and-deno-run-give-you)
+is in the install guide.
 
 ## Native prebuilds
 
@@ -72,8 +90,10 @@ reads — `LD_LIBRARY_PATH` on Linux, `DYLD_LIBRARY_PATH` on macOS (dyld ignores
 one), `PATH` on Windows (`LoadLibrary` has no dedicated variable).
 
 The target is spelled `${process.platform}-${process.arch}`, which is what a running
-process can compute about itself, so resolution needs no translation table. A package with
-no artifact for your host is skipped — every native bridge is optional at runtime.
+process can compute about itself, so locating the directory needs no translation step. The
+resolver still probes a package's own declared spelling first and the retired uname one
+(`linux-x86_64`) last, so a tarball published before the rename keeps loading. A package
+with no artifact for your host is skipped — every native bridge is optional at runtime.
 
 - How the lookup works, and how to set the same environment by hand:
   [How It Works](https://gjsify.github.io/gjsify/how-it-works/#native-prebuilds-and-gjsify-run)


### PR DESCRIPTION
## What changed and why

Two READMEs are the first thing a newcomer reads — `README.md` on GitHub and
`packages/infra/cli/README.md` on the npm package page — and both described a CLI the repo
no longer ships. Neither is reachable from the docs site's navigation, so nothing kept them
honest: the CLI README still said esbuild, still told you to install with
`gjsify install @gjsify/cli` (which needs the CLI you do not have yet), and its usage block
predated `create`, `ship` and the GJS bootstrap installer entirely.

Both pages now say what `packages/infra/cli/src/commands/` implements, worded to agree with
`website/src/content/docs/` rather than inventing a third version:

- **CLI README, install:** the `gjs` bootstrap first (no Node at install time or after),
  then npm / Bun / Deno as three separate one-command routes, then the per-project dev
  dependency. Links to `guides/install/` for PATH notes.
- **CLI README, usage:** the `create` → `install` → `run dev` path, then the underlying
  `build` / `run` / `info` / `ship` commands, then the package-runner fallback.
- **CLI README, native prebuilds:** compressed to what a package author must do, with the
  lookup detail delegated to `how-it-works/`.
- **Root README:** `create` scaffolds build scripts, so the quickstart drives them
  (`run build`, `run start`, `run dev`) instead of calling `build` bare; `--immutable`
  moved to where it applies (CI, after a lockfile exists); `ship` and `build --shebang`
  added to "Ship your own app".

The last two commits address a review of the first.

## Measured

Every command and flag below was read out of the source in this branch, not recalled.

**`--app` has no default** — `packages/infra/cli/src/commands/build.ts:62-73`:

```
description: 'Build target for an application. Defaults to the target of the HOST runtime
running the CLI: gjs when run under gjs, node when run under node/bun/deno …'
// No yargs `default: 'gjs'` — a yargs default is indistinguishable from a user-set value
// and would clobber `package.json#gjsify.app` in config.ts
defaultDescription: 'host runtime target (gjs on gjs, else node)',
```

So the root README's `gjsify build src/index.ts --outfile dist/app.js  # build a TS file
for GJS` was wrong for anyone who took the `npm install -g @gjsify/cli` route offered two
headings above — it emits an `--app node` bundle. Fixed by passing `--app gjs` and stating
the rule.

**The Deno runner needs two more flags** — `website/src/content/docs/cli-reference.md:19-25`:

```
deno run -A --reload --min-dep-age=0 npm:@gjsify/cli@latest <command>
```

with the reason on the next line: all three runners reuse a cached copy of an unpinned bin,
and Deno additionally refuses anything published in the last 24 hours, neither of them
reporting it. `guides/install.mdx:295-325` carries the measurement. The README's short form
reintroduced exactly that trap on the page where a first-time reader lands.

**A translation table exists and is on the read path** — the README claimed "resolution
needs no translation table":

```
$ grep -n "linux-x86_64\|LEGACY_UNAME" packages/infra/cli/src/utils/detect-native-packages.ts
85: * into (`prebuilds/linux-x86_64/`).
91:const NODE_ARCH_TO_LEGACY_UNAME: Record<string, string> = {
154: * Canonical `<os>-<arch>[-musl]` (node spelling) so `linux-x86_64` and `linux-x64`
210: *      ships `linux-x86_64`, so probing its declaration first loads it without
214: *   2. **The legacy uname spelling.** Only reachable for a package that ships a
237:    const legacyArch = NODE_ARCH_TO_LEGACY_UNAME[arch] ?? arch;
258:    push(`${platform}-${legacyArch}`);
```

`prebuildDirCandidates` probes declared → canonical → legacy, so pre-rename tarballs
shipping `prebuilds/linux-x86_64/` still load. The canonical wording is "locating the
directory needs no translation **step**" (`how-it-works.mdx:221`) — the step is what is
absent, and adding "table" turned a qualified true statement into a false one. Restored
with the canonical wording, plus the legacy-fallback clause an earlier trim had dropped;
that fallback is true and the root `AGENTS.md` keeps it as a rule, so it should not vanish
silently.

**Three global installs in one fenced block** — on the npm page there are no `CommandTabs`,
so a reader who copies the block runs `npm install -g`, `bun add -g` and `deno install -g`
in sequence and ends up with three competing `gjsify` launchers on PATH.
`website/src/content/docs/guides/install.mdx` gives each route its own section (`## Node.js`
:64, `## Bun` :88, `## Deno` :102). Split so only one command is copyable at a time.

**Everything else written here exists**: `create --template gtk-minimal`
(`templates/gtk-minimal/`), whose `package.json` defines the `build`, `build:gjs`,
`start`, `check` and `dev` scripts the quickstart drives; `ship` (`commands/ship.ts`),
`info`, `dlx`, `self-update`, `generate-installer`, `flatpak init|check|build`; and
`build --shebang` (`commands/build.ts:135`).

## Deliberately left out

- **No build or test run.** This worktree has no `node_modules`, and the change is prose
  only — verification was reading the command sources and the website pages, not executing
  the CLI. The pre-commit bundle-freshness hook warned and skipped for the same reason; CI's
  `verify-committed-bundles.mjs` remains the exhaustive check, and no bundle input changed.
- **No live counts** in either README (package totals, command totals). A count drifts on
  the next merge and no test guards a README; the pages state what a number would have
  established instead.
- **No third copy of the install matrix.** PATH locations, per-route update commands,
  pinning and uninstall stay in `guides/install/`, linked once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
