### PR TITLE
fix(adwaita): derive the web element set from what it registers

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -325,11 +325,7 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      # The same script also holds STATUS.md's widget matrix to the defines, per tag and
-      # both ways: that column was derived from `adw-*.ts` FILENAMES, so it published a
-      # phantom `adw-checks` widget and denied `adw-preferences-page` while consumers
-      # were using one — and a row-presence check could not see it, the row existed.
-      - name: Check every shared widget is storied and matches the matrix
+      - name: Check every shared widget is in the storybook or ledgered
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of
@@ -656,11 +652,7 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      # The same script also holds STATUS.md's widget matrix to the defines, per tag and
-      # both ways: that column was derived from `adw-*.ts` FILENAMES, so it published a
-      # phantom `adw-checks` widget and denied `adw-preferences-page` while consumers
-      # were using one — and a row-presence check could not see it, the row existed.
-      - name: Check every shared widget is storied and matches the matrix
+      - name: Check every shared widget is in the storybook or ledgered
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -279,8 +279,8 @@ jobs:
       - name: Check the ADR index lists every ADR
         run: node scripts/check-adr-index.mjs
 
-      # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of 58
-      # `customElements.define('adw-…')` calls, and it is what applies the ADR 0010
+      # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of every
+      # `customElements.define('adw-…')` call, and it is what applies the ADR 0010
       # style-isolation floor. A tag missing from it renders in the host page's font and
       # colour, silently. It had already drifted — `adw-source-view` was never listed —
       # and the spec ADR 0010 names as the guard instantiates exactly one element.
@@ -325,7 +325,11 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      - name: Check every shared widget is in the storybook or ledgered
+      # The same script also holds STATUS.md's widget matrix to the defines, per tag and
+      # both ways: that column was derived from `adw-*.ts` FILENAMES, so it published a
+      # phantom `adw-checks` widget and denied `adw-preferences-page` while consumers
+      # were using one — and a row-presence check could not see it, the row existed.
+      - name: Check every shared widget is storied and matches the matrix
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of
@@ -606,8 +610,8 @@ jobs:
       - name: Check the ADR index lists every ADR
         run: node scripts/check-adr-index.mjs
 
-      # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of 58
-      # `customElements.define('adw-…')` calls, and it is what applies the ADR 0010
+      # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of every
+      # `customElements.define('adw-…')` call, and it is what applies the ADR 0010
       # style-isolation floor. A tag missing from it renders in the host page's font and
       # colour, silently. It had already drifted — `adw-source-view` was never listed —
       # and the spec ADR 0010 names as the guard instantiates exactly one element.
@@ -652,7 +656,11 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      - name: Check every shared widget is in the storybook or ledgered
+      # The same script also holds STATUS.md's widget matrix to the defines, per tag and
+      # both ways: that column was derived from `adw-*.ts` FILENAMES, so it published a
+      # phantom `adw-checks` widget and denied `adw-preferences-page` while consumers
+      # were using one — and a row-presence check could not see it, the row existed.
+      - name: Check every shared widget is storied and matches the matrix
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-header-bar.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-header-bar.ts
@@ -7,6 +7,8 @@
 // `Adw.HeaderBar`: start/end packing + a centered title-widget. A `flat` option
 // drops the bottom hairline / background fill for the "flat" header style.
 //
+// CORE-VIA: ./adw-window-title.js — the centred title IS that widget, and title/subtitle run in its WindowTitleState.
+//
 // FIDELITY: faithful for the structural layout (start / center / end + flat).
 // The NS CSS subset has no box-shadow, so the non-flat header's bottom separator
 // is a 1px bottom border rather than libadwaita's subtle shadow — a close visual

--- a/packages/web/adwaita-web/src/elements/adw-header-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-header-bar.ts
@@ -9,6 +9,8 @@
 // subtitle at all. So a header bar could not show what its own NativeScript twin
 // could, and the fix is delegation rather than a fourth copy of the derivation.
 //
+// CORE-VIA: ./adw-window-title.js — the derived centre IS that element, and the three rules above run in its WindowTitleState.
+//
 // Reference: refs/libadwaita/src/adw-header-bar.c
 // Adapted from Adwaita Web UI Framework (https://github.com/mclellac/adwaita-web).
 // Copyright (c) 2025 csm. MIT License.

--- a/packages/web/adwaita-web/src/elements/adw-header-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-header-bar.ts
@@ -9,7 +9,7 @@
 // subtitle at all. So a header bar could not show what its own NativeScript twin
 // could, and the fix is delegation rather than a fourth copy of the derivation.
 //
-// CORE-VIA: ./adw-window-title.js — the derived centre IS that element, and the three rules above run in its WindowTitleState.
+// CORE-VIA: ./adw-window-title.js — the derived centre IS that element, so the three rules run in its WindowTitleState.
 //
 // Reference: refs/libadwaita/src/adw-header-bar.c
 // Adapted from Adwaita Web UI Framework (https://github.com/mclellac/adwaita-web).

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -74,11 +74,11 @@ export function adwaitaWebElements(root) {
     const src = join(root, ADWAITA_WEB_SRC);
     /** @type {Map<string, string>} */
     const defined = new Map();
-    let calls = 0;
-    let matched = 0;
+    const unreadable = [];
     for (const file of sourceFiles(src)) {
         const text = readFileSync(file, 'utf8');
-        calls += (text.match(DEFINE_CALL) ?? []).length;
+        const calls = (text.match(DEFINE_CALL) ?? []).length;
+        let matched = 0;
         for (const [, tag, registered] of text.matchAll(DEFINE_PATTERN)) {
             matched += 1;
             const expected = widgetClass(elementName(tag));
@@ -91,13 +91,14 @@ export function adwaitaWebElements(root) {
             }
             defined.set(tag, relative(root, file));
         }
+        if (matched < calls) unreadable.push(relative(root, file));
     }
 
-    if (matched < calls) {
+    if (unreadable.length > 0) {
         throw new Error(
-            `${calls - matched} customElements.define(…) call(s) under ${ADWAITA_WEB_SRC} that this ` +
-                'reader could not parse: a tag outside the `adw-` rule, or a spelling DEFINE_PATTERN ' +
-                'does not match. Either way the element has no matrix row and no ADR 0010 reset entry.',
+            `customElements.define(…) this reader could not parse, in ${unreadable.join(', ')}: a tag ` +
+                'outside the `adw-` rule, or a spelling DEFINE_PATTERN does not match. Either way that ' +
+                'element has no matrix row and no ADR 0010 reset entry, and nothing else would say so.',
         );
     }
 
@@ -117,8 +118,8 @@ export function adwaitaWebElements(root) {
 // other dotted name — `adw-button.d.ts` — is not a widget name and is not read as one.
 const NS_WIDGET_FILE = /^adw-([a-z0-9-]+)(?:\.(?:android|ios))?\.ts$/;
 
-/** Whether the file has a class AT ALL — the one thing that makes it a widget file. */
-const CLASS_DECLARATION = /\bclass\s+[A-Za-z0-9_]+/;
+/** Declaring a class AT ALL is what makes a file a widget file — the word in prose is not. */
+const CLASS_DECLARATION = /^\s*(?:export\s+)?(?:default\s+)?(?:abstract\s+)?class\s+[A-Za-z0-9_]+/m;
 
 /** The class must LEAVE the file; how it is spelled on the way out is free. */
 const exportsClass = (text, name) =>

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -17,9 +17,8 @@
 //
 // So this module is the ONE reader, of BOTH renderers: the NativeScript widget scan
 // was a second copy in the same two files, with the same drift ahead of it. `adw-` is
-// the whole naming rule the tree follows, which is what lets a tag address a matrix
-// row — {@link elementName} strips it, and the rest is the bare name the NativeScript
-// files and the `*.meta.ts` story names are already spelled in.
+// the whole naming rule the tree follows, and stripping it ({@link elementName}) leaves
+// the bare name widget files and `*.meta.ts` story names are already spelled in.
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join, relative } from 'node:path';
@@ -28,14 +27,12 @@ import { basename, join, relative } from 'node:path';
 export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
 export const ADWAITA_NS_WIDGETS = 'packages/nativescript-bridge/adwaita/src/widgets';
 
-// The registration WITH the class it registers, in any quote style. Reading the class
-// is what makes a HALF rename fail: rename the tag and leave `AdwAvatar` alone and the
-// widget silently leaves the set both renderers share, with every gate still green.
+// The registration WITH the class it registers, in any quote style: reading the class
+// is what makes a HALF rename fail instead of shrinking the set (see the throw below).
 const DEFINE_PATTERN = /customElements\s*\.\s*define\(\s*['"`](adw-[a-z0-9-]+)['"`]\s*,\s*([A-Za-z0-9_]+)/g;
 
-// The discriminator for the pattern itself. A call it cannot read — a tag held in a
-// variable, a template with a substitution — is an element with no matrix row and no
-// ADR 0010 isolation floor, and a reader that counts only what matched cannot see it.
+// The discriminator for the pattern itself: a call it cannot read is an element the
+// whole tree is blind to, and counting only what matched can never show that.
 const DEFINE_CALL = /customElements\s*\.\s*define\(/g;
 
 /** Every `.ts` under `dir` — elements live outside `elements/` too (`source-view/`). */
@@ -67,9 +64,8 @@ const widgetClass = (name) =>
  *
  * THROWS on an empty scan: nothing is missing from an empty set, so a reader that
  * finds nothing lets every consumer pass vacuously — which is exactly what a moved
- * package or a stale pattern produces. Throws the same way on a `define(` call it
- * could not read, and on a tag registering a class other than the `Adw<Tag>` its
- * name promises: both are the whole set shrinking with nothing to show for it.
+ * package or a stale pattern produces. An unreadable `define(` and a tag registering
+ * something other than its `Adw<Tag>` throw for the same reason: both shrink the set.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} tag → repo-relative defining file
@@ -116,9 +112,9 @@ export function adwaitaWebElements(root) {
     return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
 }
 
-// `adw-button.ts`, and the `.android`/`.ios` halves NativeScript splits a module into
-// (`icons.android.ts` beside `icons.ios.ts`): two files, one widget. Anything else
-// dotted — `adw-button.d.ts` — is not a widget name and must not be read as one.
+// `adw-button.ts`, plus the `.android`/`.ios` halves NativeScript splits a module into
+// (`icons.android.ts` beside `icons.ios.ts` here already): two files, one widget. Any
+// other dotted name — `adw-button.d.ts` — is not a widget name and is not read as one.
 const NS_WIDGET_FILE = /^adw-([a-z0-9-]+)(?:\.(?:android|ios))?\.ts$/;
 
 /** Whether the file has a class AT ALL — the one thing that makes it a widget file. */
@@ -138,11 +134,9 @@ const exportsClass = (text, name) =>
  * at `Application`: no view, nothing to place in a layout, and the directory listing
  * scored it as a NativeScript-only WIDGET the browser had yet to port.
  *
- * DECLARING NO CLASS is therefore the exemption and the only one: a file that declares
- * one and does not export it under the name its filename promises THROWS rather than
- * quietly leaving the widget set, which is how a rename would otherwise shrink every
- * consumer's input without failing anything. Same vacuous-scan contract as
- * {@link adwaitaWebElements}.
+ * DECLARING NO CLASS is therefore the exemption and the only one — a file that declares
+ * one and does not export it under the name its filename promises THROWS. Same
+ * vacuous-scan contract as {@link adwaitaWebElements}.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} bare widget name → repo-relative file

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -133,7 +133,7 @@ function valueImports(text) {
  * erased `import type` are not — both were counted: `adw-header-bar` imports core
  * NOWHERE and was published core-backed off a comment, `adw-menu-button` off a type.
  *
- * ONE HOP, and never into another renderer element. A renderer delegates through a
+ * ONE HOP, and never DERIVED into another renderer element. A renderer delegates through a
  * helper for a reason the tree makes visible: an NS spec cannot import a module that
  * `extends GridLayout`, so the pure half moves out (`chrome.ts`, `avatar-color.ts`)
  * and the helper is where the core edge lives. A transitive walk would report a

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -1,4 +1,4 @@
-// The adwaita-web element set, read from the calls that create it.
+// What each Adwaita renderer ships, read from the code that registers it.
 //
 // THE INCIDENT
 //
@@ -87,8 +87,28 @@ export function adwaitaWebElements(root) {
     return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
 }
 
+const EXPORTED_CLASS = /export\s+(?:abstract\s+)?class\s+([A-Za-z0-9_]+)/g;
+
+/** `preferences-page` → `AdwPreferencesPage`, the class `adw-preferences-page.ts` must export. */
+const widgetClass = (name) =>
+    `Adw${name
+        .split('-')
+        .map((part) => part[0].toUpperCase() + part.slice(1))
+        .join('')}`;
+
 /**
- * Every `adw-<name>.ts` the NativeScript Adwaita port ships → its repo-relative file.
+ * Every widget the NativeScript Adwaita port ships → its repo-relative file.
+ *
+ * NativeScript has no `customElements.define`. A widget here is a class extending a
+ * `@nativescript/core` view, named `Adw<Widget>` in `adw-<name>.ts` — 46 files out of
+ * 47. The 47th is `adw-accent.ts`, two functions that push CSS at `Application`: no
+ * view, nothing to place in a layout, and reading the directory as a widget list
+ * scored it as a NativeScript-only WIDGET the browser had yet to port.
+ *
+ * So NO CLASS is the exemption, and it is the only one — a file exporting classes
+ * but not the one its name promises THROWS instead of quietly dropping out of the
+ * widget set, which is how a rename would otherwise shrink every consumer's input
+ * without failing anything.
  *
  * Same vacuous-scan contract as {@link adwaitaWebElements}: nothing found is a
  * failure, because an empty widget set makes every consumer's question trivially
@@ -104,12 +124,22 @@ export function adwaitaNativeScriptWidgets(root) {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const match = entry.isFile() && !entry.name.endsWith('.spec.ts') && /^adw-(.+)\.ts$/.exec(entry.name);
         if (!match) continue;
-        widgets.set(match[1], relative(root, join(dir, entry.name)));
+        const file = join(dir, entry.name);
+        const classes = [...readFileSync(file, 'utf8').matchAll(EXPORTED_CLASS)].map(([, name]) => name);
+        const expected = widgetClass(match[1]);
+        if (classes.includes(expected)) widgets.set(match[1], relative(root, file));
+        else if (classes.length > 0) {
+            throw new Error(
+                `${relative(root, file)} exports ${classes.join(', ')} but not ${expected}. ` +
+                    'A widget file names its class after itself; without that this file drops out ' +
+                    'of the widget set silently, and every consumer of it shrinks with no failure.',
+            );
+        }
     }
 
     if (widgets.size === 0) {
         throw new Error(
-            `no adw-<name>.ts file found under ${ADWAITA_NS_WIDGETS}. ` +
+            `no adw-<name>.ts file under ${ADWAITA_NS_WIDGETS} exports an Adw* class. ` +
                 'Either the package moved or the naming convention changed — a scan that ' +
                 'finds nothing passes vacuously, so this is a failure, not a pass.',
         );

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -22,20 +22,28 @@
 // files and the `*.meta.ts` story names are already spelled in.
 
 import { readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { basename, join, relative } from 'node:path';
 
 /** Repo-relative source roots, so callers can name them in their own messages. */
 export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
 export const ADWAITA_NS_WIDGETS = 'packages/nativescript-bridge/adwaita/src/widgets';
 
-// Both quote styles: the formatter uses single, but a matcher that only sees one
-// is a matcher that misses a rename.
-const DEFINE_PATTERN = /customElements\s*\.\s*define\(\s*['"](adw-[a-z0-9-]+)['"]/g;
+// The registration WITH the class it registers, in any quote style. Reading the class
+// is what makes a HALF rename fail: rename the tag and leave `AdwAvatar` alone and the
+// widget silently leaves the set both renderers share, with every gate still green.
+const DEFINE_PATTERN = /customElements\s*\.\s*define\(\s*['"`](adw-[a-z0-9-]+)['"`]\s*,\s*([A-Za-z0-9_]+)/g;
+
+// The discriminator for the pattern itself. A call it cannot read — a tag held in a
+// variable, a template with a substitution — is an element with no matrix row and no
+// ADR 0010 isolation floor, and a reader that counts only what matched cannot see it.
+const DEFINE_CALL = /customElements\s*\.\s*define\(/g;
 
 /** Every `.ts` under `dir` — elements live outside `elements/` too (`source-view/`). */
 function sourceFiles(dir) {
     const found = [];
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        // A vendored copy under `src/` would register its own tags into a required check.
+        if (entry.name === 'node_modules') continue;
         const path = join(dir, entry.name);
         if (entry.isDirectory()) found.push(...sourceFiles(path));
         else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts')) found.push(path);
@@ -46,13 +54,22 @@ function sourceFiles(dir) {
 /** `adw-preferences-page` → `preferences-page`: the key rows, ledger entries and stories share. */
 export const elementName = (tag) => tag.slice('adw-'.length);
 
+/** `preferences-page` → `AdwPreferencesPage`: the class both renderers name it after. */
+const widgetClass = (name) =>
+    `Adw${name
+        .split('-')
+        .map((part) => part[0].toUpperCase() + part.slice(1))
+        .join('')}`;
+
 /**
  * Every custom element adwaita-web defines → the file defining it, so a failure
  * can name the file to open. Sorted by tag; several files define two or three.
  *
  * THROWS on an empty scan: nothing is missing from an empty set, so a reader that
  * finds nothing lets every consumer pass vacuously — which is exactly what a moved
- * package or a stale pattern produces.
+ * package or a stale pattern produces. Throws the same way on a `define(` call it
+ * could not read, and on a tag registering a class other than the `Adw<Tag>` its
+ * name promises: both are the whole set shrinking with nothing to show for it.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} tag → repo-relative defining file
@@ -61,9 +78,31 @@ export function adwaitaWebElements(root) {
     const src = join(root, ADWAITA_WEB_SRC);
     /** @type {Map<string, string>} */
     const defined = new Map();
+    let calls = 0;
+    let matched = 0;
     for (const file of sourceFiles(src)) {
         const text = readFileSync(file, 'utf8');
-        for (const match of text.matchAll(DEFINE_PATTERN)) defined.set(match[1], relative(root, file));
+        calls += (text.match(DEFINE_CALL) ?? []).length;
+        for (const [, tag, registered] of text.matchAll(DEFINE_PATTERN)) {
+            matched += 1;
+            const expected = widgetClass(elementName(tag));
+            if (registered !== expected) {
+                throw new Error(
+                    `${relative(root, file)} registers <${tag}> as ${registered}, not ${expected}. ` +
+                        'A tag and its class are renamed together or not at all: rename one alone and ' +
+                        'the widget drops out of the set both renderers share with no gate failing.',
+                );
+            }
+            defined.set(tag, relative(root, file));
+        }
+    }
+
+    if (matched < calls) {
+        throw new Error(
+            `${calls - matched} customElements.define(…) call(s) under ${ADWAITA_WEB_SRC} that this ` +
+                'reader could not parse: a tag outside the `adw-` rule, or a spelling DEFINE_PATTERN ' +
+                'does not match. Either way the element has no matrix row and no ADR 0010 reset entry.',
+        );
     }
 
     if (defined.size === 0) {
@@ -77,28 +116,33 @@ export function adwaitaWebElements(root) {
     return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
 }
 
-const EXPORTED_CLASS = /export\s+(?:abstract\s+)?class\s+([A-Za-z0-9_]+)/g;
+// `adw-button.ts`, and the `.android`/`.ios` halves NativeScript splits a module into
+// (`icons.android.ts` beside `icons.ios.ts`): two files, one widget. Anything else
+// dotted — `adw-button.d.ts` — is not a widget name and must not be read as one.
+const NS_WIDGET_FILE = /^adw-([a-z0-9-]+)(?:\.(?:android|ios))?\.ts$/;
 
-/** `preferences-page` → `AdwPreferencesPage`, the class `adw-preferences-page.ts` must export. */
-const widgetClass = (name) =>
-    `Adw${name
-        .split('-')
-        .map((part) => part[0].toUpperCase() + part.slice(1))
-        .join('')}`;
+/** Whether the file has a class AT ALL — the one thing that makes it a widget file. */
+const CLASS_DECLARATION = /\bclass\s+[A-Za-z0-9_]+/;
+
+/** The class must LEAVE the file; how it is spelled on the way out is free. */
+const exportsClass = (text, name) =>
+    new RegExp(`export\\s+(?:default\\s+)?(?:abstract\\s+)?class\\s+${name}\\b`).test(text) ||
+    new RegExp(`export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}`).test(text);
 
 /**
  * Every widget the NativeScript Adwaita port ships → its repo-relative file.
  *
  * NativeScript has no `customElements.define`. A widget here is a class extending a
- * `@nativescript/core` view, named `Adw<Widget>` in `adw-<name>.ts` — 46 files of 47.
- * The 47th is `adw-accent.ts`, two functions that push CSS at `Application`: no view,
- * nothing to place in a layout, and the directory listing scored it as a
- * NativeScript-only WIDGET the browser had yet to port.
+ * `@nativescript/core` view, named `Adw<Widget>` in `adw-<name>.ts`, and every file
+ * here but one is that. The exception is `adw-accent.ts`, two functions that push CSS
+ * at `Application`: no view, nothing to place in a layout, and the directory listing
+ * scored it as a NativeScript-only WIDGET the browser had yet to port.
  *
- * NO CLASS is therefore the exemption and the only one: a file exporting classes but
- * not the one its name promises THROWS rather than quietly leaving the widget set,
- * which is how a rename would otherwise shrink every consumer's input without failing
- * anything. Same vacuous-scan contract as {@link adwaitaWebElements}.
+ * DECLARING NO CLASS is therefore the exemption and the only one: a file that declares
+ * one and does not export it under the name its filename promises THROWS rather than
+ * quietly leaving the widget set, which is how a rename would otherwise shrink every
+ * consumer's input without failing anything. Same vacuous-scan contract as
+ * {@link adwaitaWebElements}.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} bare widget name → repo-relative file
@@ -107,20 +151,20 @@ export function adwaitaNativeScriptWidgets(root) {
     const dir = join(root, ADWAITA_NS_WIDGETS);
     /** @type {Map<string, string>} */
     const widgets = new Map();
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const match = entry.isFile() && !entry.name.endsWith('.spec.ts') && /^adw-(.+)\.ts$/.exec(entry.name);
+    for (const file of sourceFiles(dir)) {
+        const match = NS_WIDGET_FILE.exec(basename(file));
         if (!match) continue;
-        const file = join(dir, entry.name);
-        const classes = [...readFileSync(file, 'utf8').matchAll(EXPORTED_CLASS)].map(([, name]) => name);
+        const text = readFileSync(file, 'utf8');
+        if (!CLASS_DECLARATION.test(text)) continue;
         const expected = widgetClass(match[1]);
-        if (classes.includes(expected)) widgets.set(match[1], relative(root, file));
-        else if (classes.length > 0) {
+        if (!exportsClass(text, expected)) {
             throw new Error(
-                `${relative(root, file)} exports ${classes.join(', ')} but not ${expected}. ` +
+                `${relative(root, file)} declares a class but does not export ${expected}. ` +
                     'A widget file names its class after itself; without that this file drops out ' +
                     'of the widget set silently, and every consumer of it shrinks with no failure.',
             );
         }
+        widgets.set(match[1], relative(root, file));
     }
 
     if (widgets.size === 0) {

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -20,8 +20,8 @@
 // the whole naming rule the tree follows, and stripping it ({@link elementName}) leaves
 // the bare name widget files and `*.meta.ts` story names are already spelled in.
 
-import { readdirSync, readFileSync } from 'node:fs';
-import { basename, join, relative } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
 
 /** Repo-relative source roots, so callers can name them in their own messages. */
 export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
@@ -58,6 +58,125 @@ const widgetClass = (name) =>
         .map((part) => part[0].toUpperCase() + part.slice(1))
         .join('')}`;
 
+/** The shared headless behaviour both renderers are meant to delegate to. */
+const CORE_PACKAGE = '@gjsify/adwaita-core';
+
+// USING a sibling element and DELEGATING to one are the same import edge, so the
+// difference is not derivable and is declared instead — in the delegating file's own
+// header, where `CORE-ONLY:` already puts this kind of claim. Spelled with the
+// specifier the file imports, so declaration and code stay one vocabulary.
+const CORE_VIA = 'CORE-VIA:';
+const CORE_VIA_PATTERN = /CORE-VIA:\s*(\S+)\s*—\s*([^\n]*)/;
+
+/** Shortest reason that can name the sibling and say what it carries. */
+const MIN_REASON = 40;
+
+/** The leading comment block: a claim a reader of this file meets before the code. */
+function fileHeader(text) {
+    const header = [];
+    for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed !== '' && !trimmed.startsWith('//') && !trimmed.startsWith('/*') && !trimmed.startsWith('*')) break;
+        header.push(trimmed);
+    }
+    return header.join('\n');
+}
+
+/** What a module imports or re-exports AS VALUES — comments out, `import type` out. */
+function valueImports(text) {
+    const code = text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+    return [
+        ...code.matchAll(/(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]([^'"]+)['"]/g),
+        ...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g),
+    ].map(([, spec]) => spec);
+}
+
+/**
+ * Does a module reach `@gjsify/adwaita-core`? — the question the matrix's "core"
+ * cell asks, for `rendererFiles`, the element files of the renderer(s) in scope.
+ *
+ * "Backed by core" is an import edge we can SEE, which a sentence about core and an
+ * erased `import type` are not — both were counted: `adw-header-bar` imports core
+ * NOWHERE and was published core-backed off a comment, `adw-menu-button` off a type.
+ *
+ * ONE HOP, and never into another renderer element. A renderer delegates through a
+ * helper for a reason the tree makes visible: an NS spec cannot import a module that
+ * `extends GridLayout`, so the pure half moves out (`chrome.ts`, `avatar-color.ts`)
+ * and the helper is where the core edge lives. A transitive walk would report a
+ * widget as core-backed because something four modules away imports core, which is
+ * not the same claim; and `adw-source-view` embeds `adw-icon`, whose edge is not a
+ * claim about the source view. The verdict is per FILE: every tag
+ * `adw-alert-dialog.ts` registers carries that one file's edge, no finer.
+ *
+ * THROWS on a `CORE-VIA:` header that does not hold — see {@link CORE_VIA}. The
+ * named module must reach core BY IMPORT, not by a marker of its own: a chain of
+ * declarations is a ledger, and only the first link of it stays checkable.
+ *
+ * @param {Set<string>} rendererFiles absolute paths of the renderer element files
+ * @param {string} root repository root, for naming files in a failure
+ * @returns {(file: string) => boolean}
+ */
+export function coreReach(rendererFiles, root) {
+    const read = (file) => {
+        try {
+            return readFileSync(file, 'utf8');
+        } catch {
+            return '';
+        }
+    };
+    const importsCore = (text) => valueImports(text).some((spec) => spec.startsWith(CORE_PACKAGE));
+    // TS sources import the EMITTED `.js` sibling; the file on disk is `.ts`.
+    const sibling = (file, spec) => resolve(file, '..', spec.replace(/\.js$/, '.ts'));
+    const byImport = (file) => {
+        const text = read(file);
+        if (importsCore(text)) return true;
+        return valueImports(text).some(
+            (spec) =>
+                spec.startsWith('.') &&
+                !rendererFiles.has(sibling(file, spec)) &&
+                importsCore(read(sibling(file, spec))),
+        );
+    };
+
+    return (file) => {
+        const text = read(file);
+        const direct = byImport(file);
+        if (!text.includes(CORE_VIA)) return direct;
+
+        const where = `${relative(root, file)}: CORE-VIA`;
+        const marker = CORE_VIA_PATTERN.exec(fileHeader(text));
+        if (marker === null) {
+            throw new Error(
+                `${where} is not in the file header, or is not spelled \`CORE-VIA: <module> — <reason>\`. ` +
+                    'Nothing reads it where it stands, so the widget is scored as if it were not there.',
+            );
+        }
+        const [, spec, reason] = marker;
+        if (direct) {
+            throw new Error(
+                `${where} names ${spec}, but this file reaches ${CORE_PACKAGE} on its own. ` +
+                    'The marker carries nothing and outlives its reason — delete it.',
+            );
+        }
+        const target = sibling(file, spec);
+        if (!existsSync(target)) {
+            throw new Error(`${where} names ${spec}, which does not resolve to a module (${relative(root, target)}).`);
+        }
+        if (!byImport(target)) {
+            throw new Error(
+                `${where} names ${spec}, which does not reach ${CORE_PACKAGE} itself. ` +
+                    'Delegating to a second copy is still two copies.',
+            );
+        }
+        if (reason.trim().length < MIN_REASON) {
+            throw new Error(
+                `${where} names ${spec} with no real reason — say what behaviour runs there instead of here.`,
+            );
+        }
+        return true;
+    };
+}
+
 /**
  * Every custom element adwaita-web defines → the file defining it, so a failure
  * can name the file to open. Sorted by tag; several files define two or three.
@@ -75,7 +194,9 @@ export function adwaitaWebElements(root) {
     /** @type {Map<string, string>} */
     const defined = new Map();
     const unreadable = [];
-    for (const file of sourceFiles(src)) {
+    const files = sourceFiles(src);
+    const elements = new Set();
+    for (const file of files) {
         const text = readFileSync(file, 'utf8');
         const calls = (text.match(DEFINE_CALL) ?? []).length;
         let matched = 0;
@@ -90,6 +211,7 @@ export function adwaitaWebElements(root) {
                 );
             }
             defined.set(tag, relative(root, file));
+            elements.add(file);
         }
         if (matched < calls) unreadable.push(relative(root, file));
     }
@@ -110,7 +232,22 @@ export function adwaitaWebElements(root) {
         );
     }
 
+    verifyCoreVia(files, elements, root);
     return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * Every `CORE-VIA:` declaration in one renderer package, held against that package's
+ * tree — {@link coreReach} throws on one that does not.
+ *
+ * IT RUNS HERE because `generate-status.mjs`, the only consumer that asks about core
+ * edges, is not a gate: CI never runs it, so an arm living there could never fail a
+ * PR. This reader is what `check-adwaita-reset-components` and
+ * `check-storybook-widget-coverage` call, and both already refuse whatever it refuses.
+ */
+function verifyCoreVia(files, elements, root) {
+    const reach = coreReach(elements, root);
+    for (const file of files) reach(file);
 }
 
 // `adw-button.ts`, plus the `.android`/`.ios` halves NativeScript splits a module into
@@ -146,7 +283,9 @@ export function adwaitaNativeScriptWidgets(root) {
     const dir = join(root, ADWAITA_NS_WIDGETS);
     /** @type {Map<string, string>} */
     const widgets = new Map();
-    for (const file of sourceFiles(dir)) {
+    const files = sourceFiles(dir);
+    const elements = new Set();
+    for (const file of files) {
         const match = NS_WIDGET_FILE.exec(basename(file));
         if (!match) continue;
         const text = readFileSync(file, 'utf8');
@@ -160,6 +299,7 @@ export function adwaitaNativeScriptWidgets(root) {
             );
         }
         widgets.set(match[1], relative(root, file));
+        elements.add(file);
     }
 
     if (widgets.size === 0) {
@@ -170,5 +310,6 @@ export function adwaitaNativeScriptWidgets(root) {
         );
     }
 
+    verifyCoreVia(files, elements, root);
     return new Map([...widgets].sort(([a], [b]) => a.localeCompare(b)));
 }

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -2,28 +2,24 @@
 //
 // THE INCIDENT
 //
-// Three scripts need the same fact — which custom elements adwaita-web ships —
-// and three scripts derived it separately. `check-adwaita-reset-components.mjs`
-// scanned `customElements.define` over all of `src/`; `generate-status.mjs` and
-// `check-storybook-widget-coverage.mjs` each listed FILENAMES matching
-// `adw-*.ts` in `src/elements/`, non-recursively. In the same CI job the first
-// reported 65 elements and the other two 50, and the smaller number was the one
-// feeding the published widget matrix.
+// Three scripts needed one fact — which elements adwaita-web ships — and derived it
+// separately. `check-adwaita-reset-components.mjs` scanned `customElements.define`
+// over all of `src/`; `generate-status.mjs` and `check-storybook-widget-coverage.mjs`
+// each listed FILENAMES matching `adw-*.ts` in `src/elements/`, non-recursively. Same
+// CI job, 65 against 50, and the smaller answer fed the published widget matrix.
 //
 // A filename is not the element. `adw-checks.ts` defines `adw-checkbox` and
-// `adw-radio`, so the matrix scored a widget `adw-checks` that no page can use
-// and had no row for either that it can. `adw-preferences-dialog.ts` also
-// defines `adw-preferences-page`, so the matrix stated adwaita-web does not have
-// a preferences page while consumers were using one. `adw-source-view` lives in
-// `src/source-view/` and was invisible to both filename readers — the same
-// blindness that had already kept it out of the ADR 0010 reset list.
+// `adw-radio`: the matrix scored a widget no page can use, and none for either it can.
+// `adw-preferences-dialog.ts` also defines `adw-preferences-page`, so the matrix
+// published "adwaita-web does not have it" about an element consumers already use.
+// `adw-source-view` sits in `src/source-view/`, invisible to both filename readers —
+// the same blindness that had kept it out of the ADR 0010 reset list.
 //
-// So this module is the ONE reader — of both renderers, because the NativeScript
-// widget scan was a second copy in the same two files, with the same drift ahead of
-// it. `adw-` is the whole naming rule the tree follows, which is what lets a tag
-// address a matrix row: {@link elementName} strips it, and what is left is the bare
-// widget name the NativeScript widget files and the `*.meta.ts` story names are
-// already spelled in.
+// So this module is the ONE reader, of BOTH renderers: the NativeScript widget scan
+// was a second copy in the same two files, with the same drift ahead of it. `adw-` is
+// the whole naming rule the tree follows, which is what lets a tag address a matrix
+// row — {@link elementName} strips it, and the rest is the bare name the NativeScript
+// files and the `*.meta.ts` story names are already spelled in.
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -47,22 +43,16 @@ function sourceFiles(dir) {
     return found;
 }
 
-/**
- * The tag every matrix row, ledger entry and story name is keyed by.
- *
- * @param {string} tag e.g. `adw-preferences-page`
- * @returns {string} e.g. `preferences-page`
- */
+/** `adw-preferences-page` → `preferences-page`: the key rows, ledger entries and stories share. */
 export const elementName = (tag) => tag.slice('adw-'.length);
 
 /**
  * Every custom element adwaita-web defines → the file defining it, so a failure
  * can name the file to open. Sorted by tag; several files define two or three.
  *
- * THROWS on an empty scan. A reader that finds nothing lets every consumer pass
- * vacuously — the tag set is empty, so nothing is missing from anything — and
- * that is exactly the state a moved package or a stale pattern produces. It is
- * a failure, not a pass.
+ * THROWS on an empty scan: nothing is missing from an empty set, so a reader that
+ * finds nothing lets every consumer pass vacuously — which is exactly what a moved
+ * package or a stale pattern produces.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} tag → repo-relative defining file
@@ -100,19 +90,15 @@ const widgetClass = (name) =>
  * Every widget the NativeScript Adwaita port ships → its repo-relative file.
  *
  * NativeScript has no `customElements.define`. A widget here is a class extending a
- * `@nativescript/core` view, named `Adw<Widget>` in `adw-<name>.ts` — 46 files out of
- * 47. The 47th is `adw-accent.ts`, two functions that push CSS at `Application`: no
- * view, nothing to place in a layout, and reading the directory as a widget list
- * scored it as a NativeScript-only WIDGET the browser had yet to port.
+ * `@nativescript/core` view, named `Adw<Widget>` in `adw-<name>.ts` — 46 files of 47.
+ * The 47th is `adw-accent.ts`, two functions that push CSS at `Application`: no view,
+ * nothing to place in a layout, and the directory listing scored it as a
+ * NativeScript-only WIDGET the browser had yet to port.
  *
- * So NO CLASS is the exemption, and it is the only one — a file exporting classes
- * but not the one its name promises THROWS instead of quietly dropping out of the
- * widget set, which is how a rename would otherwise shrink every consumer's input
- * without failing anything.
- *
- * Same vacuous-scan contract as {@link adwaitaWebElements}: nothing found is a
- * failure, because an empty widget set makes every consumer's question trivially
- * satisfied.
+ * NO CLASS is therefore the exemption and the only one: a file exporting classes but
+ * not the one its name promises THROWS rather than quietly leaving the widget set,
+ * which is how a rename would otherwise shrink every consumer's input without failing
+ * anything. Same vacuous-scan contract as {@link adwaitaWebElements}.
  *
  * @param {string} root repository root
  * @returns {Map<string, string>} bare widget name → repo-relative file

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -19,6 +19,11 @@
 // was a second copy in the same two files, with the same drift ahead of it. `adw-` is
 // the whole naming rule the tree follows, and stripping it ({@link elementName}) leaves
 // the bare name widget files and `*.meta.ts` story names are already spelled in.
+//
+// It answers the core-edge question here too ({@link coreReach}), for the same reason
+// and one more: that derivation lived privately in `generate-status.mjs`, which CI
+// never runs, so nothing could fail on a `CORE-VIA:` declaration that had stopped
+// holding.
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { basename, join, relative, resolve } from 'node:path';

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -18,16 +18,19 @@
 // `src/source-view/` and was invisible to both filename readers — the same
 // blindness that had already kept it out of the ADR 0010 reset list.
 //
-// So this module is the ONE reader. `adw-` is the whole naming rule the tree
-// follows, which is what lets a tag address a matrix row: {@link elementName}
-// strips it, and what is left is the bare widget name the NativeScript widget
-// files and the storybook `*.meta.ts` names are already spelled in.
+// So this module is the ONE reader — of both renderers, because the NativeScript
+// widget scan was a second copy in the same two files, with the same drift ahead of
+// it. `adw-` is the whole naming rule the tree follows, which is what lets a tag
+// address a matrix row: {@link elementName} strips it, and what is left is the bare
+// widget name the NativeScript widget files and the `*.meta.ts` story names are
+// already spelled in.
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
-/** Repo-relative source root, so callers can name it in their own messages. */
+/** Repo-relative source roots, so callers can name them in their own messages. */
 export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
+export const ADWAITA_NS_WIDGETS = 'packages/nativescript-bridge/adwaita/src/widgets';
 
 // Both quote styles: the formatter uses single, but a matcher that only sees one
 // is a matcher that misses a rename.
@@ -82,4 +85,35 @@ export function adwaitaWebElements(root) {
     }
 
     return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
+}
+
+/**
+ * Every `adw-<name>.ts` the NativeScript Adwaita port ships → its repo-relative file.
+ *
+ * Same vacuous-scan contract as {@link adwaitaWebElements}: nothing found is a
+ * failure, because an empty widget set makes every consumer's question trivially
+ * satisfied.
+ *
+ * @param {string} root repository root
+ * @returns {Map<string, string>} bare widget name → repo-relative file
+ */
+export function adwaitaNativeScriptWidgets(root) {
+    const dir = join(root, ADWAITA_NS_WIDGETS);
+    /** @type {Map<string, string>} */
+    const widgets = new Map();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const match = entry.isFile() && !entry.name.endsWith('.spec.ts') && /^adw-(.+)\.ts$/.exec(entry.name);
+        if (!match) continue;
+        widgets.set(match[1], relative(root, join(dir, entry.name)));
+    }
+
+    if (widgets.size === 0) {
+        throw new Error(
+            `no adw-<name>.ts file found under ${ADWAITA_NS_WIDGETS}. ` +
+                'Either the package moved or the naming convention changed — a scan that ' +
+                'finds nothing passes vacuously, so this is a failure, not a pass.',
+        );
+    }
+
+    return new Map([...widgets].sort(([a], [b]) => a.localeCompare(b)));
 }

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -25,7 +25,7 @@
 // never runs, so nothing could fail on a `CORE-VIA:` declaration that had stopped
 // holding.
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { basename, join, relative, resolve } from 'node:path';
 
 /** Repo-relative source roots, so callers can name them in their own messages. */
@@ -71,9 +71,11 @@ const CORE_PACKAGE = '@gjsify/adwaita-core';
 // header, where `CORE-ONLY:` already puts this kind of claim. Spelled with the
 // specifier the file imports, so declaration and code stay one vocabulary.
 const CORE_VIA = 'CORE-VIA:';
-const CORE_VIA_PATTERN = /CORE-VIA:\s*(\S+)\s*—\s*([^\n]*)/;
+const CORE_VIA_PATTERN = /CORE-VIA:\s*(\S+)\s*—\s*([^\n]*)/g;
 
-/** Shortest reason that can name the sibling and say what it carries. */
+// A floor on length, not on meaning — filler clears it, and no check reads a sentence.
+// It is the LAST arm for that reason: what stands between an arbitrary sibling and a
+// published `✅ core` is the import arm in {@link coreReach}, never this one.
 const MIN_REASON = 40;
 
 /** The leading comment block: a claim a reader of this file meets before the code. */
@@ -87,13 +89,39 @@ function fileHeader(text) {
     return header.join('\n');
 }
 
-/** What a module imports or re-exports AS VALUES — comments out, `import type` out. */
+/**
+ * `{ type A, type B }` — a named clause with no value binding at all. Neither renderer
+ * sets `verbatimModuleSyntax`, so TypeScript erases such a statement whole; the web
+ * `adw-menu-button` carries a separate side-effect import for precisely that reason.
+ */
+function bindsOnlyTypes(clause) {
+    const named = /^\{([^}]*)\}$/.exec(clause.trim());
+    if (named === null) return false;
+    const entries = named[1]
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry !== '');
+    return entries.length > 0 && entries.every((entry) => /^type\s+\S/.test(entry));
+}
+
+/**
+ * What a module imports or re-exports AS VALUES — comments out, and BOTH `type`
+ * spellings out: the statement-level `import type { X } from` and the inline
+ * `import { type X } from`, which emits nothing either ({@link bindsOnlyTypes}).
+ *
+ * A clause this cannot read as a value binding counts as no edge. That direction is
+ * deliberate: an unseen edge under-claims a widget, which the matrix already words as
+ * "no path is VISIBLE", while a claimed edge nothing runs is the incident below.
+ */
 function valueImports(text) {
     const code = text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
-    return [
-        ...code.matchAll(/(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]([^'"]+)['"]/g),
-        ...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g),
-    ].map(([, spec]) => spec);
+    const specs = [...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g)].map(([, spec]) => spec);
+    for (const [, clause, spec] of code.matchAll(
+        /(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])([^'"]*)from\s*['"]([^'"]+)['"]/g,
+    )) {
+        if (!bindsOnlyTypes(clause)) specs.push(spec);
+    }
+    return specs;
 }
 
 /**
@@ -113,9 +141,13 @@ function valueImports(text) {
  * claim about the source view. The verdict is per FILE: every tag
  * `adw-alert-dialog.ts` registers carries that one file's edge, no finer.
  *
- * THROWS on a `CORE-VIA:` header that does not hold — see {@link CORE_VIA}. The
- * named module must reach core BY IMPORT, not by a marker of its own: a chain of
- * declarations is a ledger, and only the first link of it stays checkable.
+ * THROWS on a `CORE-VIA:` header that does not hold — see {@link CORE_VIA}. Held in
+ * order: the declaring file must IMPORT the specifier it names (a declaration whose
+ * own first edge is missing is the incident above, restored — the marker outlives the
+ * import and the widget stays core-backed off prose); the named module must be a
+ * SIBLING ELEMENT of this renderer, because a helper is what the one hop already
+ * covers and needs no marker; and it must reach core BY IMPORT, not by a marker of its
+ * own, since a chain of declarations is a ledger whose first link alone stays checkable.
  *
  * @param {Set<string>} rendererFiles absolute paths of the renderer element files
  * @param {string} root repository root, for naming files in a failure
@@ -149,34 +181,50 @@ export function coreReach(rendererFiles, root) {
         if (!text.includes(CORE_VIA)) return direct;
 
         const where = `${relative(root, file)}: CORE-VIA`;
-        const marker = CORE_VIA_PATTERN.exec(fileHeader(text));
-        if (marker === null) {
+        // EVERY occurrence is held, not the first one found: an unread marker is
+        // decoration, it can carry a second module that never gets checked, and a bare
+        // `TODO` parked in it hides from `gjsify/todo-needs-anchor` at the same time.
+        const markers = [...fileHeader(text).matchAll(CORE_VIA_PATTERN)];
+        if (markers.length !== text.split(CORE_VIA).length - 1) {
             throw new Error(
                 `${where} is not in the file header, or is not spelled \`CORE-VIA: <module> — <reason>\`. ` +
                     'Nothing reads it where it stands, so the widget is scored as if it were not there.',
             );
         }
-        const [, spec, reason] = marker;
         if (direct) {
             throw new Error(
-                `${where} names ${spec}, but this file reaches ${CORE_PACKAGE} on its own. ` +
+                `${where} declares a delegation, but this file reaches ${CORE_PACKAGE} on its own. ` +
                     'The marker carries nothing and outlives its reason — delete it.',
             );
         }
-        const target = sibling(file, spec);
-        if (!existsSync(target)) {
-            throw new Error(`${where} names ${spec}, which does not resolve to a module (${relative(root, target)}).`);
-        }
-        if (!byImport(target)) {
-            throw new Error(
-                `${where} names ${spec}, which does not reach ${CORE_PACKAGE} itself. ` +
-                    'Delegating to a second copy is still two copies.',
-            );
-        }
-        if (reason.trim().length < MIN_REASON) {
-            throw new Error(
-                `${where} names ${spec} with no real reason — say what behaviour runs there instead of here.`,
-            );
+        const imported = valueImports(text);
+        for (const [, spec, reason] of markers) {
+            if (!imported.includes(spec)) {
+                throw new Error(
+                    `${where} names ${spec}, which this file does not import as a value. ` +
+                        'A delegation with no import edge behind it is a sentence, and a sentence is ' +
+                        'what published this widget core-backed the first time.',
+                );
+            }
+            const target = sibling(file, spec);
+            if (!rendererFiles.has(target)) {
+                throw new Error(
+                    `${where} names ${spec} (${relative(root, target)}), which is not an element of ` +
+                        'this renderer. A helper is already the one hop above and needs no marker; a ' +
+                        'sibling ELEMENT is the only edge that hop deliberately refuses to see.',
+                );
+            }
+            if (!byImport(target)) {
+                throw new Error(
+                    `${where} names ${spec}, which does not reach ${CORE_PACKAGE} itself. ` +
+                        'Delegating to a second copy is still two copies.',
+                );
+            }
+            if (reason.trim().length < MIN_REASON) {
+                throw new Error(
+                    `${where} names ${spec} with no real reason — say what behaviour runs there instead of here.`,
+                );
+            }
         }
         return true;
     };

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -1,0 +1,85 @@
+// The adwaita-web element set, read from the calls that create it.
+//
+// THE INCIDENT
+//
+// Three scripts need the same fact — which custom elements adwaita-web ships —
+// and three scripts derived it separately. `check-adwaita-reset-components.mjs`
+// scanned `customElements.define` over all of `src/`; `generate-status.mjs` and
+// `check-storybook-widget-coverage.mjs` each listed FILENAMES matching
+// `adw-*.ts` in `src/elements/`, non-recursively. In the same CI job the first
+// reported 65 elements and the other two 50, and the smaller number was the one
+// feeding the published widget matrix.
+//
+// A filename is not the element. `adw-checks.ts` defines `adw-checkbox` and
+// `adw-radio`, so the matrix scored a widget `adw-checks` that no page can use
+// and had no row for either that it can. `adw-preferences-dialog.ts` also
+// defines `adw-preferences-page`, so the matrix stated adwaita-web does not have
+// a preferences page while consumers were using one. `adw-source-view` lives in
+// `src/source-view/` and was invisible to both filename readers — the same
+// blindness that had already kept it out of the ADR 0010 reset list.
+//
+// So this module is the ONE reader. `adw-` is the whole naming rule the tree
+// follows, which is what lets a tag address a matrix row: {@link elementName}
+// strips it, and what is left is the bare widget name the NativeScript widget
+// files and the storybook `*.meta.ts` names are already spelled in.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/** Repo-relative source root, so callers can name it in their own messages. */
+export const ADWAITA_WEB_SRC = 'packages/web/adwaita-web/src';
+
+// Both quote styles: the formatter uses single, but a matcher that only sees one
+// is a matcher that misses a rename.
+const DEFINE_PATTERN = /customElements\s*\.\s*define\(\s*['"](adw-[a-z0-9-]+)['"]/g;
+
+/** Every `.ts` under `dir` — elements live outside `elements/` too (`source-view/`). */
+function sourceFiles(dir) {
+    const found = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) found.push(...sourceFiles(path));
+        else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts')) found.push(path);
+    }
+    return found;
+}
+
+/**
+ * The tag every matrix row, ledger entry and story name is keyed by.
+ *
+ * @param {string} tag e.g. `adw-preferences-page`
+ * @returns {string} e.g. `preferences-page`
+ */
+export const elementName = (tag) => tag.slice('adw-'.length);
+
+/**
+ * Every custom element adwaita-web defines → the file defining it, so a failure
+ * can name the file to open. Sorted by tag; several files define two or three.
+ *
+ * THROWS on an empty scan. A reader that finds nothing lets every consumer pass
+ * vacuously — the tag set is empty, so nothing is missing from anything — and
+ * that is exactly the state a moved package or a stale pattern produces. It is
+ * a failure, not a pass.
+ *
+ * @param {string} root repository root
+ * @returns {Map<string, string>} tag → repo-relative defining file
+ */
+export function adwaitaWebElements(root) {
+    const src = join(root, ADWAITA_WEB_SRC);
+    /** @type {Map<string, string>} */
+    const defined = new Map();
+    for (const file of sourceFiles(src)) {
+        const text = readFileSync(file, 'utf8');
+        for (const match of text.matchAll(DEFINE_PATTERN)) defined.set(match[1], relative(root, file));
+    }
+
+    if (defined.size === 0) {
+        throw new Error(
+            `no customElements.define('adw-…') calls found under ${ADWAITA_WEB_SRC}. ` +
+                'Either the package moved or DEFINE_PATTERN stopped matching — a scan that ' +
+                'finds nothing passes vacuously, so this is a failure, not a pass.',
+        );
+    }
+
+    return new Map([...defined].sort(([a], [b]) => a.localeCompare(b)));
+}

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -69,7 +69,8 @@ const CORE_PACKAGE = '@gjsify/adwaita-core';
 // USING a sibling element and DELEGATING to one are the same import edge, so the
 // difference is not derivable and is declared instead — in the delegating file's own
 // header, where `CORE-ONLY:` already puts this kind of claim. Spelled with the
-// specifier the file imports, so declaration and code stay one vocabulary.
+// specifier the file imports and HELD to it, so a declaration cannot outlive the
+// edge it describes — which is how the last one survived its own deletion.
 const CORE_VIA = 'CORE-VIA:';
 const CORE_VIA_PATTERN = /CORE-VIA:\s*(\S+)\s*—\s*([^\n]*)/g;
 

--- a/scripts/check-adwaita-reset-components.mjs
+++ b/scripts/check-adwaita-reset-components.mjs
@@ -29,53 +29,31 @@
 //
 // Usage: node scripts/check-adwaita-reset-components.mjs [--root <dir>]
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { adwaitaWebElements } from './adwaita-elements.mjs';
 
 const args = process.argv.slice(2);
 const rootIndex = args.indexOf('--root');
 const ROOT = rootIndex === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootIndex + 1];
 
-const PACKAGE = join(ROOT, 'packages', 'web', 'adwaita-web');
-const SRC = join(PACKAGE, 'src');
-const RESET = join(PACKAGE, 'scss', '_reset.scss');
+const RESET = join(ROOT, 'packages', 'web', 'adwaita-web', 'scss', '_reset.scss');
 
 function fail(lines) {
     console.error(`check-adwaita-reset-components: ${lines.join('\n  ')}`);
     process.exit(1);
 }
 
-/** Every `.ts` under `src/` — elements live outside `elements/` too (`source-view/`). */
-function sourceFiles(dir) {
-    const found = [];
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const path = join(dir, entry.name);
-        if (entry.isDirectory()) found.push(...sourceFiles(path));
-        else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.spec.ts')) found.push(path);
-    }
-    return found;
-}
-
-// Both quote styles: the formatter uses single, but a matcher that only sees one
-// is a matcher that misses a rename.
-const DEFINE_PATTERN = /customElements\s*\.\s*define\(\s*['"](adw-[a-z0-9-]+)['"]/g;
-
 /** tag → the file that defines it, so a failure can name the file to open. */
-const defined = new Map();
-for (const file of sourceFiles(SRC)) {
-    const text = readFileSync(file, 'utf8');
-    for (const match of text.matchAll(DEFINE_PATTERN)) {
-        defined.set(match[1], relative(ROOT, file));
-    }
-}
-
-if (defined.size === 0) {
-    fail([
-        `no customElements.define('adw-…') calls found under ${relative(ROOT, SRC)}.`,
-        'Either the package moved or DEFINE_PATTERN stopped matching — a check that',
-        'finds nothing passes vacuously, so this is a failure, not a pass.',
-    ]);
+let defined;
+try {
+    defined = adwaitaWebElements(ROOT);
+} catch (error) {
+    // The reader throws on a vacuous scan by design; catching keeps this script's
+    // own `name: message` shape and exit code instead of a stack trace.
+    fail([error.message]);
 }
 
 let resetText;

--- a/scripts/check-adwaita-reset-components.mjs
+++ b/scripts/check-adwaita-reset-components.mjs
@@ -8,9 +8,8 @@
 // typography and the box model at each widget boundary, so a host page's inherited
 // `font-family`/`color`/`letter-spacing` and its `* { box-sizing }` reset stop
 // there. A tag missing from the list gets no floor — it renders in the host's font
-// and colour, and nothing fails. The list is hand-written, while the truth is
-// dozens of `customElements.define` calls scattered over as many files, several
-// defining two or three tags each.
+// and colour, and nothing fails. The list is hand-written; the truth is the defines
+// `scripts/adwaita-elements.mjs` reads.
 //
 // It had already drifted: `adw-source-view` was defined for its whole life and
 // never listed. The regression test ADR 0010 points at as the guard,
@@ -51,8 +50,7 @@ let defined;
 try {
     defined = adwaitaWebElements(ROOT);
 } catch (error) {
-    // The reader throws on a vacuous scan by design; catching keeps this script's
-    // own `name: message` shape and exit code instead of a stack trace.
+    // The reader throws on a vacuous scan by design; catch to keep this script's prefix.
     fail([error.message]);
 }
 

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -18,8 +18,8 @@
 // WHAT IT CHECKS
 //
 //   1. Every `adw-<name>` the browser DEFINES as a custom element and NativeScript
-//      ships as `adw-<name>.ts` has a `<name>.meta.ts` in the GTK showcase — or an
-//      entry below saying why not.
+//      ships as an `Adw*` view class has a `<name>.meta.ts` in the GTK showcase — or
+//      an entry below saying why not.
 //   2. No ledger entry names a widget that HAS a story (a stale exemption reads as
 //      considered when it is merely forgotten).
 //   3. No ledger entry names a widget the rule cannot reach — one renderer only, or

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -17,9 +17,9 @@
 //
 // WHAT IT CHECKS
 //
-//   1. Every `adw-<name>` present in BOTH `packages/web/adwaita-web/src/elements/` and
-//      `packages/nativescript-bridge/adwaita/src/widgets/` has a `<name>.meta.ts` in
-//      the GTK showcase — or an entry below saying why not.
+//   1. Every `adw-<name>` the browser DEFINES as a custom element and NativeScript
+//      ships as `adw-<name>.ts` has a `<name>.meta.ts` in the GTK showcase — or an
+//      entry below saying why not.
 //   2. No ledger entry names a widget that HAS a story (a stale exemption reads as
 //      considered when it is merely forgotten).
 //   3. No ledger entry names a widget the rule cannot reach — one renderer only, or
@@ -38,11 +38,12 @@ import { readdirSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { ADWAITA_WEB_SRC, adwaitaWebElements, elementName } from './adwaita-elements.mjs';
+
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
-const WEB_ELEMENTS = join(ROOT, 'packages/web/adwaita-web/src/elements');
 const NS_WIDGETS = join(ROOT, 'packages/nativescript-bridge/adwaita/src/widgets');
 const GTK_SRC = join(ROOT, 'showcases/gtk/adwaita-storybook/src');
 
@@ -57,6 +58,8 @@ const NO_STORY_OF_ITS_OWN = {
     button: 'Buttons/Button Styles IS the button story — its `component` is `Gtk.Button.$gtype`, and it renders the plain button beside .pill/.circular/.suggested-action/.destructive-action/.flat. A second story would show the same widget with fewer states.',
     'toast-overlay':
         'Feedback/Toast renders it. The overlay is only ever the surface a toast appears on, so the story is named after the thing the reader is looking for.',
+    'preferences-page':
+        'Feedback/Preferences Dialog renders it — the story builds an `Adw.PreferencesPage`, fills it with a group of rows and adds it to the dialog. A page only ever appears inside a preferences dialog, so the story is named after the thing the reader is looking for.',
     'view-stack':
         'A stack shows exactly one page and offers no way to change it — alone it is a blank preview. Every switcher story builds one and drives it: View Switcher, Inline View Switcher, View Switcher Bar.',
     icon: 'There is no Adwaita or GTK icon WIDGET to reference. GTK draws a `Gtk.Image` inline (the navigation stories do), and the browser element exists because CSS needs a box to hang a symbolic on. A story would demonstrate a GTK primitive, not an Adwaita widget.',
@@ -89,14 +92,25 @@ function storyNames(dir) {
     return found;
 }
 
-const web = widgetNames(WEB_ELEMENTS);
+/** @type {Map<string, string>} */
+let defines;
+try {
+    defines = adwaitaWebElements(ROOT);
+} catch (error) {
+    // The reader throws on a vacuous scan by design; catching keeps this script's
+    // own `name: message` shape and exit code instead of a stack trace.
+    console.error(`check-storybook-widget-coverage: ${error.message}`);
+    process.exit(1);
+}
+
+const web = new Set([...defines.keys()].map(elementName));
 const ns = widgetNames(NS_WIDGETS);
 const stories = storyNames(GTK_SRC);
 
-if (web.size === 0 || ns.size === 0 || stories.size === 0) {
+if (ns.size === 0 || stories.size === 0) {
     console.error(
-        'check-storybook-widget-coverage: one of the three scans came back empty ' +
-            `(web ${web.size}, nativescript ${ns.size}, stories ${stories.size}) — that is a broken scan, not a clean tree.`,
+        'check-storybook-widget-coverage: one of the scans came back empty ' +
+            `(nativescript ${ns.size}, stories ${stories.size}) — that is a broken scan, not a clean tree.`,
     );
     process.exit(1);
 }
@@ -131,7 +145,7 @@ if (failures.length > 0) {
         '\nThe GTK storybook is the reference the other two targets are aligned against, so a widget it\n' +
             'never shows is a widget with no reference — and story-set parity cannot see that, because a\n' +
             'story missing from all three targets is perfectly symmetric.\n' +
-            `  elements: ${relative(ROOT, WEB_ELEMENTS)}    widgets: ${relative(ROOT, NS_WIDGETS)}    stories: ${relative(ROOT, GTK_SRC)}`,
+            `  elements: ${ADWAITA_WEB_SRC}    widgets: ${relative(ROOT, NS_WIDGETS)}    stories: ${relative(ROOT, GTK_SRC)}`,
     );
     process.exit(1);
 }

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -49,14 +49,19 @@ import { readdirSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ADWAITA_WEB_SRC, adwaitaWebElements, elementName } from './adwaita-elements.mjs';
+import {
+    ADWAITA_NS_WIDGETS,
+    ADWAITA_WEB_SRC,
+    adwaitaNativeScriptWidgets,
+    adwaitaWebElements,
+    elementName,
+} from './adwaita-elements.mjs';
 import { collectAdwaitaCoverage } from './generate-status.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
-const NS_WIDGETS = join(ROOT, 'packages/nativescript-bridge/adwaita/src/widgets');
 const GTK_SRC = join(ROOT, 'showcases/gtk/adwaita-storybook/src');
 
 /**
@@ -79,17 +84,6 @@ const NO_STORY_OF_ITS_OWN = {
         'The one widget here with no GTK renderer at all — it is an original @gjsify widget, not a libadwaita port. A GTK story would have to hand-assemble a `Gtk.Grid`, i.e. put a fourth implementation in a showcase where no package owns it. If a GTK data grid is wanted it starts as a package (#1050).',
 };
 
-/** `adw-<name>.ts` files directly under `dir`. */
-function widgetNames(dir) {
-    const found = new Set();
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (!entry.isFile()) continue;
-        const match = entry.name.match(/^adw-(.+)\.ts$/);
-        if (match && !entry.name.endsWith('.spec.ts')) found.add(match[1]);
-    }
-    return found;
-}
-
 /** Story names — every `<name>.meta.ts` anywhere under the GTK showcase. */
 function storyNames(dir) {
     const found = new Set();
@@ -106,23 +100,24 @@ function storyNames(dir) {
 
 /** @type {Map<string, string>} */
 let defines;
+/** @type {Map<string, string>} */
+let ns;
 try {
     defines = adwaitaWebElements(ROOT);
+    ns = adwaitaNativeScriptWidgets(ROOT);
 } catch (error) {
-    // The reader throws on a vacuous scan by design; catching keeps this script's
+    // Both readers throw on a vacuous scan by design; catching keeps this script's
     // own `name: message` shape and exit code instead of a stack trace.
     console.error(`check-storybook-widget-coverage: ${error.message}`);
     process.exit(1);
 }
 
 const web = new Set([...defines.keys()].map(elementName));
-const ns = widgetNames(NS_WIDGETS);
 const stories = storyNames(GTK_SRC);
 
-if (ns.size === 0 || stories.size === 0) {
+if (stories.size === 0) {
     console.error(
-        'check-storybook-widget-coverage: one of the scans came back empty ' +
-            `(nativescript ${ns.size}, stories ${stories.size}) — that is a broken scan, not a clean tree.`,
+        'check-storybook-widget-coverage: the story scan came back empty — that is a broken scan, not a clean tree.',
     );
     process.exit(1);
 }
@@ -189,7 +184,7 @@ if (failures.length > 0) {
         '\nThe GTK storybook is the reference the other two targets are aligned against, so a widget it\n' +
             'never shows is a widget with no reference — and story-set parity cannot see that, because a\n' +
             'story missing from all three targets is perfectly symmetric.\n' +
-            `  elements: ${ADWAITA_WEB_SRC}    widgets: ${relative(ROOT, NS_WIDGETS)}    stories: ${relative(ROOT, GTK_SRC)}`,
+            `  elements: ${ADWAITA_WEB_SRC}    widgets: ${ADWAITA_NS_WIDGETS}    stories: ${relative(ROOT, GTK_SRC)}`,
     );
     process.exit(1);
 }

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -24,17 +24,14 @@
 //      considered when it is merely forgotten).
 //   3. No ledger entry names a widget the rule cannot reach — one renderer only, or
 //      no renderer at all. Same reason: it would look like cover it does not give.
-//   4. STATUS.md's widget matrix agrees with the defines, per tag, both ways.
 //
 // The both-renderers scope is deliberate. A widget on ONE renderer cannot have a
 // three-target story, so demanding one here would demand a port, and that is a
 // product decision this check has no business making.
 //
-// (4) asks the same question of the surface that PUBLISHES the answer, and its scoping
-// is measured. Forward: on the CELL, because `adw-preferences-page` HAD a row the whole
-// time — the NativeScript scan put it there — beside an empty adwaita-web cell, so row
-// presence stays green on the defect. Reverse: only a row CLAIMING a web cell with no
-// define, since rows without one are ordinary NativeScript-only widgets and GTK stories.
+// STATUS.md's widget matrix is NOT checked here: an arm that did was removed, because
+// its column and this check both call `adwaitaWebElements()` — `f(x)` against `f(x)`,
+// green for every tree, and only an EDIT to the generator could ever make it fire.
 //
 // Plain Node over the repo's own files — no install, no build — so it runs in
 // `audit-runtimes.yml` next to the other repo-scoped guards.
@@ -52,7 +49,6 @@ import {
     adwaitaWebElements,
     elementName,
 } from './adwaita-elements.mjs';
-import { collectAdwaitaCoverage } from './generate-status.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -117,37 +113,6 @@ if (stories.size === 0) {
     process.exit(1);
 }
 
-// Rule 4, first: a matrix that disagrees about what adwaita-web ships makes every
-// verdict below a claim about a different tree than the one readers are shown.
-const matrix = new Map(collectAdwaitaCoverage(ROOT).map((row) => [row.name, row]));
-const mismatches = [];
-
-for (const [tag, file] of defines) {
-    const row = matrix.get(elementName(tag));
-    if (row === undefined) {
-        mismatches.push(`${tag}: defined in ${file}, and the widget matrix has no row for it at all.`);
-    } else if (!row.web) {
-        mismatches.push(`${tag}: defined in ${file}, and the widget matrix leaves its adwaita-web cell empty.`);
-    }
-}
-
-for (const row of matrix.values()) {
-    if (!row.web || defines.has(`adw-${row.name}`)) continue;
-    mismatches.push(`adw-${row.name}: the widget matrix claims an adwaita-web cell, but nothing defines that tag.`);
-}
-
-if (mismatches.length > 0) {
-    console.error(`check-storybook-widget-coverage: ${mismatches.length} widget-matrix mismatch(es):\n`);
-    for (const mismatch of mismatches) console.error(`  - ${mismatch}`);
-    console.error(
-        '\nSTATUS.md is where this fact is published, and `collectAdwaitaCoverage()` in\n' +
-            'scripts/generate-status.mjs builds that column. It must read the same defines this check\n' +
-            `does (scripts/adwaita-elements.mjs, over ${ADWAITA_WEB_SRC}) — the two derivations disagreeing\n` +
-            'silently, one by define and one by filename, is the whole reason this arm exists.',
-    );
-    process.exit(1);
-}
-
 const onBothRenderers = [...web].filter((name) => ns.has(name)).sort();
 const failures = [];
 
@@ -186,6 +151,5 @@ if (failures.length > 0) {
 const exempt = Object.keys(NO_STORY_OF_ITS_OWN).length;
 console.log(
     `check-storybook-widget-coverage: ${onBothRenderers.length} widgets on both renderers — ` +
-        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason; ` +
-        `${defines.size} defined tags, each with its adwaita-web cell in the widget matrix.`,
+        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason.`,
 );

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -24,10 +24,21 @@
 //      considered when it is merely forgotten).
 //   3. No ledger entry names a widget the rule cannot reach — one renderer only, or
 //      no renderer at all. Same reason: it would look like cover it does not give.
+//   4. STATUS.md's widget matrix agrees with the defines, per tag, both ways.
 //
 // The both-renderers scope is deliberate. A widget on ONE renderer cannot have a
 // three-target story, so demanding one here would demand a port, and that is a
 // product decision this check has no business making.
+//
+// (4) is here because it is the same question — what does each renderer ship — asked
+// by the surface that PUBLISHES the answer. The matrix builds its browser column in a
+// different file, and for a long time it built it differently: filenames, not defines.
+// A ROW-PRESENCE check would not have caught that, and this scoping is measured, not
+// guessed: `adw-preferences-page` HAD a row the whole time, put there by the
+// NativeScript filename scan, with an empty adwaita-web cell beside it. So the
+// assertion is on the CELL. The reverse arm is deliberately narrower — a row CLAIMING
+// a web cell with no define behind it — because rows with no define are ordinary and
+// legitimate: a NativeScript-only widget, a GTK-only story.
 //
 // Plain Node over the repo's own files — no install, no build — so it runs in
 // `audit-runtimes.yml` next to the other repo-scoped guards.
@@ -39,6 +50,7 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ADWAITA_WEB_SRC, adwaitaWebElements, elementName } from './adwaita-elements.mjs';
+import { collectAdwaitaCoverage } from './generate-status.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -115,6 +127,38 @@ if (ns.size === 0 || stories.size === 0) {
     process.exit(1);
 }
 
+// Rule 4 — the published matrix's browser column IS the define set, both ways.
+// Runs first: a matrix that disagrees about what adwaita-web ships makes every
+// verdict below a claim about a different tree than the one readers are shown.
+const matrix = new Map(collectAdwaitaCoverage(ROOT).map((row) => [row.name, row]));
+const mismatches = [];
+
+for (const [tag, file] of defines) {
+    const row = matrix.get(elementName(tag));
+    if (row === undefined) {
+        mismatches.push(`${tag}: defined in ${file}, and the widget matrix has no row for it at all.`);
+    } else if (!row.web) {
+        mismatches.push(`${tag}: defined in ${file}, and the widget matrix leaves its adwaita-web cell empty.`);
+    }
+}
+
+for (const row of matrix.values()) {
+    if (!row.web || defines.has(`adw-${row.name}`)) continue;
+    mismatches.push(`adw-${row.name}: the widget matrix claims an adwaita-web cell, but nothing defines that tag.`);
+}
+
+if (mismatches.length > 0) {
+    console.error(`check-storybook-widget-coverage: ${mismatches.length} widget-matrix mismatch(es):\n`);
+    for (const mismatch of mismatches) console.error(`  - ${mismatch}`);
+    console.error(
+        '\nSTATUS.md is where this fact is published, and `collectAdwaitaCoverage()` in\n' +
+            'scripts/generate-status.mjs builds that column. It must read the same defines this check\n' +
+            `does (scripts/adwaita-elements.mjs, over ${ADWAITA_WEB_SRC}) — the two derivations disagreeing\n` +
+            'silently, one by define and one by filename, is the whole reason this arm exists.',
+    );
+    process.exit(1);
+}
+
 const onBothRenderers = [...web].filter((name) => ns.has(name)).sort();
 const failures = [];
 
@@ -153,5 +197,6 @@ if (failures.length > 0) {
 const exempt = Object.keys(NO_STORY_OF_ITS_OWN).length;
 console.log(
     `check-storybook-widget-coverage: ${onBothRenderers.length} widgets on both renderers — ` +
-        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason.`,
+        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason; ` +
+        `${defines.size} defined tags, each with its adwaita-web cell in the widget matrix.`,
 );

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -30,15 +30,11 @@
 // three-target story, so demanding one here would demand a port, and that is a
 // product decision this check has no business making.
 //
-// (4) is here because it is the same question — what does each renderer ship — asked
-// by the surface that PUBLISHES the answer. The matrix builds its browser column in a
-// different file, and for a long time it built it differently: filenames, not defines.
-// A ROW-PRESENCE check would not have caught that, and this scoping is measured, not
-// guessed: `adw-preferences-page` HAD a row the whole time, put there by the
-// NativeScript filename scan, with an empty adwaita-web cell beside it. So the
-// assertion is on the CELL. The reverse arm is deliberately narrower — a row CLAIMING
-// a web cell with no define behind it — because rows with no define are ordinary and
-// legitimate: a NativeScript-only widget, a GTK-only story.
+// (4) asks the same question of the surface that PUBLISHES the answer, and its scoping
+// is measured. Forward: on the CELL, because `adw-preferences-page` HAD a row the whole
+// time — the NativeScript scan put it there — beside an empty adwaita-web cell, so row
+// presence stays green on the defect. Reverse: only a row CLAIMING a web cell with no
+// define, since rows without one are ordinary NativeScript-only widgets and GTK stories.
 //
 // Plain Node over the repo's own files — no install, no build — so it runs in
 // `audit-runtimes.yml` next to the other repo-scoped guards.
@@ -106,8 +102,7 @@ try {
     defines = adwaitaWebElements(ROOT);
     ns = adwaitaNativeScriptWidgets(ROOT);
 } catch (error) {
-    // Both readers throw on a vacuous scan by design; catching keeps this script's
-    // own `name: message` shape and exit code instead of a stack trace.
+    // Both readers throw on a vacuous scan by design; catch to keep this script's prefix.
     console.error(`check-storybook-widget-coverage: ${error.message}`);
     process.exit(1);
 }
@@ -122,8 +117,7 @@ if (stories.size === 0) {
     process.exit(1);
 }
 
-// Rule 4 — the published matrix's browser column IS the define set, both ways.
-// Runs first: a matrix that disagrees about what adwaita-web ships makes every
+// Rule 4, first: a matrix that disagrees about what adwaita-web ships makes every
 // verdict below a claim about a different tree than the one readers are shown.
 const matrix = new Map(collectAdwaitaCoverage(ROOT).map((row) => [row.name, row]));
 const mismatches = [];

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -673,10 +673,11 @@ function table(header, rows) {
  * Render the derived per-widget coverage matrix.
  *
  * "Core" is not a claim about intent — it is whether that renderer's widget
- * reaches `@gjsify/adwaita-core`, itself or one hop through a helper of its own
- * package. A widget present on both sides with no core edge is a
- * duplicated-behaviour candidate, which is precisely the ADR-0004 backlog,
- * computed instead of remembered.
+ * reaches `@gjsify/adwaita-core`: itself, one hop through a helper of its own
+ * package, or the sibling element a `CORE-VIA:` header names. An import edge is
+ * the whole of what that measures, so the remainder is where ADR-0004
+ * duplication would sit, not a count of measured copies — and the sentence below
+ * says so, because it once said the opposite about a widget that delegates.
  *
  * Core-modelled DATA objects are listed apart from the widget table rather than
  * inside it: an `Adw.Toast` has no renderer element on either side by design, so
@@ -698,20 +699,28 @@ function adwaitaCoverageSection(coverage) {
     out.push(
         'Derived from the tree at generation time. One row per `adw-<name>`, read from',
         "what each renderer ships: browser `customElements.define('adw-…')` tags,",
-        'NativeScript `Adw*` view classes, storybook `<name>.meta.ts`, and the actual',
-        '`@gjsify/adwaita-core` import edges. None of it is maintained by hand; the',
-        'table this replaced drifted twelve widgets behind the code.',
+        'NativeScript `Adw*` view classes, storybook `<name>.meta.ts`, the actual',
+        '`@gjsify/adwaita-core` import edges, and the `CORE-VIA:` header a widget',
+        'carries when its edge runs through a sibling element. None of it is maintained',
+        'by hand; the table this replaced drifted twelve widgets behind the code.',
         '',
     );
     out.push(table(['Widget', 'GTK story', 'adwaita-web', 'adwaita-nativescript'], rows));
     out.push('');
-    // The backlog sentence is CONDITIONAL: naming a remainder that is empty is the
+    // The remainder sentence is CONDITIONAL: naming a remainder that is empty is the
     // same drift as any other stale claim — it reads as work outstanding when there
     // is none, and nobody re-reads a generated line to check.
+    const unshared = both.filter((w) => !w.webCore || !w.nsCore);
     out.push(
-        `**${shared.length} of ${both.length}** widgets implemented on BOTH renderers share their behaviour ` +
-            'through `@gjsify/adwaita-core`.' +
-            (shared.length < both.length ? ' The remainder still carry two copies (ADR 0004 backlog).' : ''),
+        `**${shared.length} of ${both.length}** widgets implemented on BOTH renderers have a value-import path ` +
+            'to `@gjsify/adwaita-core` from each side — direct, one hop through a helper of the same package, or ' +
+            'through the sibling element a `CORE-VIA:` header names.' +
+            (unshared.length > 0
+                ? ` No such path is visible from at least one side for ${unshared
+                      .map((w) => `\`adw-${w.name}\``)
+                      .join(', ')} — an import edge is all this measures, so those are ADR 0004 duplication` +
+                  ' candidates, not measured copies.'
+                : ''),
     );
     if (dataObjects.length) {
         out.push('');

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -247,7 +247,7 @@ function scanGnomeNamespaces(pkgDir) {
  *     guessed at, one hop through the package's own modules.
  */
 export function collectAdwaitaCoverage(root) {
-    const absolute = (entries) => new Map([...entries].map(([name, file]) => [name, join(root, file)]));
+    const absolute = (entries) => new Map([...entries].map(([name, file]) => [name, resolve(root, file)]));
 
     // `adw-sidebar.ts` defines three tags, so three rows point at the same file.
     const web = absolute([...adwaitaWebElements(root)].map(([tag, file]) => [elementName(tag), file]));
@@ -268,29 +268,45 @@ export function collectAdwaitaCoverage(root) {
             return null;
         }
     };
-    // "Backed by core" is not a claim — it is an import edge we can see.
-    const importsCore = (src) => src !== null && /@gjsify\/adwaita-core/.test(src);
+    /** What a module imports or re-exports AS VALUES — comments out, `import type` out. */
+    const valueImports = (src) => {
+        if (src === null) return [];
+        const code = src.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+        return [
+            ...code.matchAll(/(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]([^'"]+)['"]/g),
+            ...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g),
+        ].map(([, spec]) => spec);
+    };
+
+    // "Backed by core" is an import edge we can SEE, which a sentence about core and
+    // an erased `import type` are not — both were counted: `adw-header-bar` imports core
+    // NOWHERE and was published core-backed off a comment, `adw-menu-button` off a type.
+    const importsCore = (src) => valueImports(src).some((spec) => spec.startsWith('@gjsify/adwaita-core'));
+
+    // A hop lands in a HELPER, never in another renderer element: `adw-source-view`
+    // embeds `adw-icon`, and the icon's edge is not a claim about the source view.
+    const renderers = new Set([...web.values(), ...ns.values()]);
 
     /**
-     * Does this widget reach `@gjsify/adwaita-core` — itself, or through a module
-     * of its own package that it imports?
+     * Does this widget reach `@gjsify/adwaita-core` — itself, or through a helper
+     * module of its own package that it imports?
      *
      * ONE HOP, deliberately. A renderer delegates through a helper for a reason
      * the tree makes visible: an NS spec cannot import a module that
      * `extends GridLayout`, so the pure half moves out (`chrome.ts`,
-     * `avatar-color.ts`, `split-view-width.ts`), and that helper is where the core
-     * edge lives. One hop is the delegation; a transitive walk would report a
-     * widget as core-backed because something four modules away happens to import
-     * core, which is not the same claim.
+     * `avatar-color.ts`), and that helper is where the core edge lives. A transitive
+     * walk would report a widget as core-backed because something four modules away
+     * imports core, which is not the same claim. And the verdict is per FILE: every
+     * tag `adw-alert-dialog.ts` registers carries that one file's edge, no finer.
      */
     const reachesCore = (file) => {
         const src = read(file);
-        if (src === null) return false;
         if (importsCore(src)) return true;
-        for (const [, spec] of src.matchAll(/from\s+['"](\.[^'"]*)['"]/g)) {
+        for (const spec of valueImports(src)) {
+            if (!spec.startsWith('.')) continue;
             // TS sources import the EMITTED `.js` sibling; the file on disk is `.ts`.
             const helper = resolve(file, '..', spec.replace(/\.js$/, '.ts'));
-            if (importsCore(read(helper))) return true;
+            if (!renderers.has(helper) && importsCore(read(helper))) return true;
         }
         return false;
     };

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -75,6 +75,7 @@ import {
     prebuildOwnership,
 } from '../packages/infra/manifest-conformance/lib/platform-packages.mjs';
 import { posixRelative } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { adwaitaWebElements, elementName } from './adwaita-elements.mjs';
 
 // ─── Authored-data model ────────────────────────────────────────────────────
 
@@ -216,10 +217,21 @@ function scanGnomeNamespaces(pkgDir) {
  * maintained by hand. It WAS, in `status/sections/adwaita-web-roadmap.md`, and
  * it drifted: twelve widgets sat under "Planned" long after they shipped.
  *
- * Widgets align by their `adw-<name>` filename across all three, so this needs
- * no alias table. Upstream partials that no renderer has yet are a genuinely
- * authored judgement (three different naming conventions) and stay in the
- * roadmap section.
+ * ONE ROW PER `adw-<name>`, and `<name>` is read from a different thing on each
+ * renderer, because each renderer states what it ships in a different place: the
+ * browser column is one row per `customElements.define('adw-…')` tag, minus the
+ * prefix ({@link elementName}); the NativeScript column is one row per
+ * `adw-<name>.ts` widget file; the GTK column is one row per `<name>.meta.ts`
+ * story. The three vocabularies agree on the bare name, so this needs no alias
+ * table. Upstream partials that no renderer has yet are a genuinely authored
+ * judgement (three different naming conventions) and stay in the roadmap section.
+ *
+ * The browser column was a filename scan too, and a filename is not an element:
+ * it scored `adw-checks` (a file defining `adw-checkbox` and `adw-radio`, so a
+ * widget nobody can use and no row for either they can), it stated adwaita-web
+ * has no `adw-preferences-page` while `adw-preferences-dialog.ts` defines one,
+ * and it could not see `adw-source-view` at all — that file is not under
+ * `elements/`. Full incident: `scripts/adwaita-elements.mjs`.
  *
  * TWO false gaps this used to score, both fixed by DERIVING harder rather than
  * by an exception list — an allowlist here would reintroduce exactly the
@@ -238,7 +250,7 @@ function scanGnomeNamespaces(pkgDir) {
  *     while it was already sharing it. The edge is now followed instead of
  *     guessed at, one hop through the package's own modules.
  */
-function collectAdwaitaCoverage(root) {
+export function collectAdwaitaCoverage(root) {
     const names = (dir, re) => {
         if (!existsSync(dir)) return new Map();
         const out = new Map();
@@ -249,7 +261,9 @@ function collectAdwaitaCoverage(root) {
         return out;
     };
 
-    const web = names(join(root, 'packages/web/adwaita-web/src/elements'), /^adw-(.+)\.ts$/);
+    // A file may define three tags (`adw-sidebar.ts` → sidebar, sidebar-item,
+    // sidebar-section), so each gets its own row pointing at the same file.
+    const web = new Map([...adwaitaWebElements(root)].map(([tag, file]) => [elementName(tag), join(root, file)]));
     const ns = names(join(root, 'packages/nativescript-bridge/adwaita/src/widgets'), /^adw-(.+)\.ts$/);
 
     // The GTK renderer's coverage IS its story set (one `.meta.ts` per widget).
@@ -725,10 +739,11 @@ function adwaitaCoverageSection(coverage) {
     const shared = both.filter((w) => w.webCore && w.nsCore);
     const out = ['## Adwaita widget coverage', ''];
     out.push(
-        'Derived from the tree at generation time — element files, NativeScript widget',
-        'files, storybook `*.meta.ts`, and the actual `@gjsify/adwaita-core` import edges.',
-        'None of it is maintained by hand; the table this replaced drifted twelve widgets',
-        'behind the code.',
+        'Derived from the tree at generation time. One row per `adw-<name>`, read from',
+        "what each renderer ships: browser `customElements.define('adw-…')` tags,",
+        'NativeScript `adw-<name>.ts` widget files, storybook `<name>.meta.ts`, and the',
+        'actual `@gjsify/adwaita-core` import edges. None of it is maintained by hand;',
+        'the table this replaced drifted twelve widgets behind the code.',
         '',
     );
     out.push(table(['Widget', 'GTK story', 'adwaita-web', 'adwaita-nativescript'], rows));

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -246,7 +246,7 @@ function scanGnomeNamespaces(pkgDir) {
  *     while it was already sharing it. The edge is now followed instead of
  *     guessed at, one hop through the package's own modules.
  */
-export function collectAdwaitaCoverage(root) {
+function collectAdwaitaCoverage(root) {
     const absolute = (entries) => new Map([...entries].map(([name, file]) => [name, resolve(root, file)]));
 
     // `adw-sidebar.ts` defines three tags, so three rows point at the same file.

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -698,11 +698,14 @@ function adwaitaCoverageSection(coverage) {
     const out = ['## Adwaita widget coverage', ''];
     out.push(
         'Derived from the tree at generation time. One row per `adw-<name>`, read from',
-        "what each renderer ships: browser `customElements.define('adw-…')` tags,",
-        'NativeScript `Adw*` view classes, storybook `<name>.meta.ts`, the actual',
-        '`@gjsify/adwaita-core` import edges, and the `CORE-VIA:` header a widget',
-        'carries when its edge runs through a sibling element. None of it is maintained',
-        'by hand; the table this replaced drifted twelve widgets behind the code.',
+        "the FILE that registers it: browser `customElements.define('adw-…')` tags,",
+        'NativeScript `Adw*` view classes, storybook `<name>.meta.ts`, and the actual',
+        '`@gjsify/adwaita-core` import edges — so a file registering several tags gives',
+        'the same core verdict to each of them. The one AUTHORED input is the',
+        '`CORE-VIA:` header a widget carries when its edge runs through a sibling',
+        'element, and a CI gate rejects one whose import is not there. Nothing else is',
+        'maintained by hand; the table this replaced drifted twelve widgets behind the',
+        'code.',
         '',
     );
     out.push(table(['Widget', 'GTK story', 'adwaita-web', 'adwaita-nativescript'], rows));
@@ -719,7 +722,8 @@ function adwaitaCoverageSection(coverage) {
                 ? ` No such path is visible from at least one side for ${unshared
                       .map((w) => `\`adw-${w.name}\``)
                       .join(', ')} — an import edge is all this measures, so those are ADR 0004 duplication` +
-                  ' candidates, not measured copies.'
+                  ' candidates, not measured copies. A widget that does delegate to a sibling element says so' +
+                  ' in its own header (`CORE-VIA:`), and a missing one lands it here.'
                 : ''),
     );
     if (dataObjects.length) {

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -75,7 +75,7 @@ import {
     prebuildOwnership,
 } from '../packages/infra/manifest-conformance/lib/platform-packages.mjs';
 import { posixRelative } from '../packages/infra/manifest-conformance/lib/index.mjs';
-import { adwaitaNativeScriptWidgets, adwaitaWebElements, elementName } from './adwaita-elements.mjs';
+import { adwaitaNativeScriptWidgets, adwaitaWebElements, coreReach, elementName } from './adwaita-elements.mjs';
 
 // ─── Authored-data model ────────────────────────────────────────────────────
 
@@ -261,55 +261,9 @@ function collectAdwaitaCoverage(root) {
         stories.add(base.replace(/\.meta\.ts$/, ''));
     }
 
-    const read = (file) => {
-        try {
-            return readFileSync(file, 'utf8');
-        } catch {
-            return null;
-        }
-    };
-    /** What a module imports or re-exports AS VALUES — comments out, `import type` out. */
-    const valueImports = (src) => {
-        if (src === null) return [];
-        const code = src.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
-        return [
-            ...code.matchAll(/(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])[^'"]*from\s*['"]([^'"]+)['"]/g),
-            ...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g),
-        ].map(([, spec]) => spec);
-    };
-
-    // "Backed by core" is an import edge we can SEE, which a sentence about core and
-    // an erased `import type` are not — both were counted: `adw-header-bar` imports core
-    // NOWHERE and was published core-backed off a comment, `adw-menu-button` off a type.
-    const importsCore = (src) => valueImports(src).some((spec) => spec.startsWith('@gjsify/adwaita-core'));
-
-    // A hop lands in a HELPER, never in another renderer element: `adw-source-view`
-    // embeds `adw-icon`, and the icon's edge is not a claim about the source view.
-    const renderers = new Set([...web.values(), ...ns.values()]);
-
-    /**
-     * Does this widget reach `@gjsify/adwaita-core` — itself, or through a helper
-     * module of its own package that it imports?
-     *
-     * ONE HOP, deliberately. A renderer delegates through a helper for a reason
-     * the tree makes visible: an NS spec cannot import a module that
-     * `extends GridLayout`, so the pure half moves out (`chrome.ts`,
-     * `avatar-color.ts`), and that helper is where the core edge lives. A transitive
-     * walk would report a widget as core-backed because something four modules away
-     * imports core, which is not the same claim. And the verdict is per FILE: every
-     * tag `adw-alert-dialog.ts` registers carries that one file's edge, no finer.
-     */
-    const reachesCore = (file) => {
-        const src = read(file);
-        if (importsCore(src)) return true;
-        for (const spec of valueImports(src)) {
-            if (!spec.startsWith('.')) continue;
-            // TS sources import the EMITTED `.js` sibling; the file on disk is `.ts`.
-            const helper = resolve(file, '..', spec.replace(/\.js$/, '.ts'));
-            if (!renderers.has(helper) && importsCore(read(helper))) return true;
-        }
-        return false;
-    };
+    // The rule, its two incidents and the `CORE-VIA:` declaration it honours live with
+    // the reader — where the two CI gates inherit them (`scripts/adwaita-elements.mjs`).
+    const reachesCore = coreReach(new Set([...web.values(), ...ns.values()]), root);
 
     // Upstream data objects — `Adw.Toast` is state, not a widget, and the renderer
     // that draws it is a different one (`adw-toast-overlay`). Derived from the

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -217,22 +217,17 @@ function scanGnomeNamespaces(pkgDir) {
  * maintained by hand. It WAS, in `status/sections/adwaita-web-roadmap.md`, and
  * it drifted: twelve widgets sat under "Planned" long after they shipped.
  *
- * ONE ROW PER `adw-<name>`, and `<name>` is read from a different thing on each
- * renderer, because each renderer states what it ships in a different place: the
- * browser column is one row per `customElements.define('adw-…')` tag, minus the
- * prefix ({@link elementName}); the NativeScript column is one row per
- * `adw-<name>.ts` file that exports an `Adw*` view class; the GTK column is one
- * row per `<name>.meta.ts` story. The three vocabularies agree on the bare name,
- * so this needs no alias table. Upstream partials that no renderer has yet are a
- * genuinely authored judgement (three different naming conventions) and stay in
- * the roadmap section.
+ * ONE ROW PER `adw-<name>`, read from what each renderer REGISTERS, which is a
+ * different thing on each: `customElements.define('adw-…')` tags minus the prefix
+ * ({@link elementName}), NativeScript `Adw*` view classes, GTK `<name>.meta.ts`
+ * stories. The three vocabularies agree on the bare name, so this needs no alias
+ * table. Upstream partials that no renderer has yet are a genuinely authored
+ * judgement (three naming conventions) and stay in the roadmap section.
  *
- * The browser column was a filename scan too, and a filename is not an element:
- * it scored `adw-checks` (a file defining `adw-checkbox` and `adw-radio`, so a
- * widget nobody can use and no row for either they can), it stated adwaita-web
- * has no `adw-preferences-page` while `adw-preferences-dialog.ts` defines one,
- * and it could not see `adw-source-view` at all — that file is not under
- * `elements/`. Full incident: `scripts/adwaita-elements.mjs`.
+ * Both renderer columns were FILENAME scans, which is not the same question — the
+ * phantom `adw-checks`, the denied `adw-preferences-page`, the invisible
+ * `adw-source-view` and the accent function pair scored as a widget are the
+ * incident in `scripts/adwaita-elements.mjs`.
  *
  * TWO false gaps this used to score, both fixed by DERIVING harder rather than
  * by an exception list — an allowlist here would reintroduce exactly the
@@ -254,8 +249,7 @@ function scanGnomeNamespaces(pkgDir) {
 export function collectAdwaitaCoverage(root) {
     const absolute = (entries) => new Map([...entries].map(([name, file]) => [name, join(root, file)]));
 
-    // A file may define three tags (`adw-sidebar.ts` → sidebar, sidebar-item,
-    // sidebar-section), so each gets its own row pointing at the same file.
+    // `adw-sidebar.ts` defines three tags, so three rows point at the same file.
     const web = absolute([...adwaitaWebElements(root)].map(([tag, file]) => [elementName(tag), file]));
     const ns = absolute(adwaitaNativeScriptWidgets(root));
 

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -75,7 +75,7 @@ import {
     prebuildOwnership,
 } from '../packages/infra/manifest-conformance/lib/platform-packages.mjs';
 import { posixRelative } from '../packages/infra/manifest-conformance/lib/index.mjs';
-import { adwaitaWebElements, elementName } from './adwaita-elements.mjs';
+import { adwaitaNativeScriptWidgets, adwaitaWebElements, elementName } from './adwaita-elements.mjs';
 
 // ─── Authored-data model ────────────────────────────────────────────────────
 
@@ -222,9 +222,10 @@ function scanGnomeNamespaces(pkgDir) {
  * browser column is one row per `customElements.define('adw-…')` tag, minus the
  * prefix ({@link elementName}); the NativeScript column is one row per
  * `adw-<name>.ts` widget file; the GTK column is one row per `<name>.meta.ts`
- * story. The three vocabularies agree on the bare name, so this needs no alias
- * table. Upstream partials that no renderer has yet are a genuinely authored
- * judgement (three different naming conventions) and stay in the roadmap section.
+ * story. The three vocabularies agree on the bare name,
+ * so this needs no alias table. Upstream partials that no renderer has yet are a
+ * genuinely authored judgement (three different naming conventions) and stay in
+ * the roadmap section.
  *
  * The browser column was a filename scan too, and a filename is not an element:
  * it scored `adw-checks` (a file defining `adw-checkbox` and `adw-radio`, so a
@@ -251,20 +252,12 @@ function scanGnomeNamespaces(pkgDir) {
  *     guessed at, one hop through the package's own modules.
  */
 export function collectAdwaitaCoverage(root) {
-    const names = (dir, re) => {
-        if (!existsSync(dir)) return new Map();
-        const out = new Map();
-        for (const entry of readdirSync(dir)) {
-            const match = re.exec(entry);
-            if (match) out.set(match[1], join(dir, entry));
-        }
-        return out;
-    };
+    const absolute = (entries) => new Map([...entries].map(([name, file]) => [name, join(root, file)]));
 
     // A file may define three tags (`adw-sidebar.ts` → sidebar, sidebar-item,
     // sidebar-section), so each gets its own row pointing at the same file.
-    const web = new Map([...adwaitaWebElements(root)].map(([tag, file]) => [elementName(tag), join(root, file)]));
-    const ns = names(join(root, 'packages/nativescript-bridge/adwaita/src/widgets'), /^adw-(.+)\.ts$/);
+    const web = absolute([...adwaitaWebElements(root)].map(([tag, file]) => [elementName(tag), file]));
+    const ns = absolute(adwaitaNativeScriptWidgets(root));
 
     // The GTK renderer's coverage IS its story set (one `.meta.ts` per widget).
     const stories = new Set();
@@ -742,8 +735,8 @@ function adwaitaCoverageSection(coverage) {
         'Derived from the tree at generation time. One row per `adw-<name>`, read from',
         "what each renderer ships: browser `customElements.define('adw-…')` tags,",
         'NativeScript `adw-<name>.ts` widget files, storybook `<name>.meta.ts`, and the',
-        'actual `@gjsify/adwaita-core` import edges. None of it is maintained by hand;',
-        'the table this replaced drifted twelve widgets behind the code.',
+        '`@gjsify/adwaita-core` import edges. None of it is maintained by hand; the',
+        'table this replaced drifted twelve widgets behind the code.',
         '',
     );
     out.push(table(['Widget', 'GTK story', 'adwaita-web', 'adwaita-nativescript'], rows));

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -221,8 +221,8 @@ function scanGnomeNamespaces(pkgDir) {
  * renderer, because each renderer states what it ships in a different place: the
  * browser column is one row per `customElements.define('adw-…')` tag, minus the
  * prefix ({@link elementName}); the NativeScript column is one row per
- * `adw-<name>.ts` widget file; the GTK column is one row per `<name>.meta.ts`
- * story. The three vocabularies agree on the bare name,
+ * `adw-<name>.ts` file that exports an `Adw*` view class; the GTK column is one
+ * row per `<name>.meta.ts` story. The three vocabularies agree on the bare name,
  * so this needs no alias table. Upstream partials that no renderer has yet are a
  * genuinely authored judgement (three different naming conventions) and stay in
  * the roadmap section.
@@ -734,7 +734,7 @@ function adwaitaCoverageSection(coverage) {
     out.push(
         'Derived from the tree at generation time. One row per `adw-<name>`, read from',
         "what each renderer ships: browser `customElements.define('adw-…')` tags,",
-        'NativeScript `adw-<name>.ts` widget files, storybook `<name>.meta.ts`, and the',
+        'NativeScript `Adw*` view classes, storybook `<name>.meta.ts`, and the actual',
         '`@gjsify/adwaita-core` import edges. None of it is maintained by hand; the',
         'table this replaced drifted twelve widgets behind the code.',
         '',

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -1090,6 +1090,41 @@ The work: a darwin leg whose install+build steps go through the bootstrap the wa
 
 The style-isolation boundary reset (`scss/_reset.scss`) landed. Remaining: document the `--adw-*` / `--*` token set as the public theming contract on the website (the sanctioned external-override API — the counterpart to the isolation); if a second light-DOM Adwaita renderer ever appears, lift the boundary reset into `@gjsify/adwaita-core` (headless) so both share it; keep `$adw-components` in `_reset.scss` in sync with `src/elements/*` (guarded by `style-isolation.spec.ts`). Shadow DOM stays a documented FUTURE option, not adopted.
 
+### Three NS widgets hand-roll a sheet lookup the tree already solved
+
+`Dialogs.action()` returns the chosen STRING, so every NativeScript widget that
+substitutes a sheet for a popover has to map that string back to an entry. The
+tree has a correct answer for it and does not use it three times.
+
+`widgets/split-button.ts` exports `menuSheetActions()` + `resolveMenuChoice()`:
+the first seeds the used-label set with the dismiss text and appends zero-width
+spaces until every action is distinct, so a second entry with the same label and
+an entry literally called `Cancel` both stay addressable; the second returns `-1`
+for a dismissal. Both are spec'd (`split-button.spec.ts:144-174`, incl. the
+`Cancel` case). `adw-alert-dialog.ts` solves the same problem the other correct
+way, delegating to core's `resolveLabel`.
+
+`adw-menu-button.ts:85`, `adw-combo-row.ts:132` and `adw-drop-down.ts:116` each
+call `labels.indexOf(chosen)` over the raw labels with a bare
+`cancelButtonText: 'Cancel'` instead — the addressing core documents as wrong in
+`SplitButtonState.activateMenuEntry` ("silently dispatches the first of two
+identically named entries and cannot tell an entry called `Cancel` from a
+dismissed sheet"). `adw-menu-button` also carries its own `entry.id ?? entry.label`
+fallback, which the browser twin repeats at `adw-menu-button.ts:229`.
+
+Deferred rather than done here because the home is NOT the local helper: both
+renderers need it, so `menuSheetActions`/`resolveMenuChoice` belong in
+`@gjsify/adwaita-core` beside `parseMenuEntries`, with conformance vectors, and
+the web copies of the id-fallback go at the same time. That is a widget-behaviour
+change to four files across two renderers; it was found during a pass on the
+widget-coverage READER, and landing it there would have moved the published
+core-backed count for a reason that has nothing to do with how the count is read.
+
+It does move that count when it lands: `split-button.ts` imports
+`@gjsify/adwaita-core` for `splitButtonArrowIcon`, so `adw-menu-button` reaching
+the shared helper gives it the value edge the matrix asks for — flipping its row
+because it became true, not because a marker said so.
+
 ### Follow-up — adopt `@gjsify/adwaita-app` in the shell consumers (ADR 0009)
 
 Adoption is opportunistic, not a rewrite — wire each consumer onto the shell package on its next shell touch: `@gjsify/storybook` (re-base `StorybookApplication` onto `AdwaitaApp`/`runAdwaitaApp`), buchhaltung (`app/src/frontends/desktop` — replace its hand-rolled application/nav/loadIntoStack/toast/dialog code; follows the release train), eco-retrofit (`cli/src/app` — same; also fixes its latent `Adw.Application.run(null)` → `runAsync()` hang class).


### PR DESCRIPTION
Two derivations of one fact sat in the same CI job and disagreed by fifteen, and the smaller one fed the
published matrix.

`generate-status.mjs` and `check-storybook-widget-coverage.mjs` each enumerated `@gjsify/adwaita-web` by
FILENAME — `/^adw-(.+)\.ts$/`, one directory, non-recursive. That sees 50 names. `check-adwaita-reset-components.mjs`,
a step of the same job, already read what the package actually registers and reported 65.

## What that shipped

| row | before | after |
|---|---|---|
| `adw-preferences-page` | `\| — \| — \| ✅ core \|` — "adwaita-web does not have it" | `\| — \| ✅ core \| ✅ \|` |
| `adw-checks` | a row, scored | gone — the file registers `adw-checkbox` and `adw-radio`, and neither had one |
| `adw-checkbox` / `adw-radio` | no row | a row each |
| `adw-source-view` | invisible (lives outside `elements/`) | a row |
| `adw-accent` | scored as a NativeScript widget | gone — it is two functions that push CSS at `Application` |

`adw-preferences-page` is the one that was actively false: `adw-preferences-dialog.ts:313` registers it and
consumers use it. Issue #1195's browser-only / NativeScript-only lists were derived from this reading and are
wrong in four places as a result.

## One reader, three consumers

`scripts/adwaita-elements.mjs` holds the walk and the scan; all three consumers import it. The empty-scan guard
survives the move: a scan that finds nothing FAILS rather than passing vacuously.

Both halves are keyed by what the renderer registers, not by what a file is called — browser
`customElements.define('adw-…')` tags, NativeScript `Adw*` view classes. The NativeScript half throws when a
widget file exports classes but not the one its filename names, because a rename would otherwise shrink every
consumer's input with nothing failing.

## `CORE-VIA:` — the part that took two rounds

Fixing the reader surfaced a second defect. `reachesCore()` tested raw file text, so a COMMENT mentioning
`@gjsify/adwaita-core` counted as an edge: `adw-header-bar` was published core-backed off one sentence, and it
has no import statement at all. Correcting that dropped the headline to `41 of 44` and made the rendered
sentence claim the remainder "still carry two copies" — false for the header bars, which delegate their
title/subtitle to `<adw-window-title>` exactly as #1191 built them to.

An import edge cannot tell "delegates its behaviour to a sibling element" from "uses a sibling element"
(`adw-source-view` imports `createAdwIcon` purely to draw an icon). So the widget declares it, in its own
header, the way a conformance table carries `CORE-ONLY:`:

```ts
// CORE-VIA: ./adw-window-title.js — the derived centre IS that element, so the three rules run in its WindowTitleState.
```

The declaration is verified, not trusted. It fails when: the file does not import the module it names; the named
module does not resolve; the named module is not a sibling element; the named module does not itself reach the
core; the declarer already reaches the core directly (stale marker); the marker sits outside the file header; a
second marker hides behind a valid one; the reason is under 40 characters. The arms live in the shared reader,
which two steps of `Detect runtime-triplet drift` already call — no new script, no new workflow step.

Also fixed while proving those arms: `import { type X } from '@gjsify/adwaita-core'` was scored as a value edge
though TypeScript erases it. Verified over 14 spellings; it changed no current verdict.

## A/B

Eleven breaks, each run against both gates and restored. Five of them shipped a false `✅ core` past both gates
before this pass: a marker naming a module the file never imports; the declared import deleted with the marker
kept; a target in the other renderer package; a target that is a helper rather than an element; a second broken
marker behind a valid one.

Headline: **42 of 44**, and the arms behind it are now the ones the sentence claims. The two remainders fail for
different reasons and the PR should say so — `adw-menu-button` NS imports `AdwMenuEntry` as a type only, while
`adw-preferences-page` NS imports the core nowhere at all and reaches a core-backed local module only by type.

## Notes for the reviewer

- `.github/workflows/deploy-docs.yml` `paths:` omits `scripts/**` while `website/scripts/generate-coverage.mjs`
  imports `scripts/generate-status.mjs`. Pre-existing and recorded as an open decision in
  `scripts/manifest-conformance/rules/pr-trigger-parity.mjs:34`; this PR extends that import chain by one file.
- Ledgered in `status/open-todos.md`, not fixed here: three NativeScript widgets resolve a chosen action sheet
  entry BY LABEL, which core documents as wrong in `split-button.ts:608-613`, and the tree already has the right
  answer in `widgets/split-button.ts`'s `menuSheetActions()`. Its home is the core and both renderers.
