### PR TITLE
fix(adwaita): check what a core-only exemption claims

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -293,9 +293,12 @@ jobs:
       # that did not exist, which reads as a reason not to look. The first version of
       # this gate tested only that the marker was PRESENT, so three false "both
       # renderers drive it" claims landed in the PR that built it and passed. It now
-      # resolves the reason's citations against the tree, fails a marker whose table
-      # has since gained a driver, and holds every adwaita-core MODULE — not just
-      # every table — to having a conformance file or a ledgered reason.
+      # resolves the reason's citations against the tree, requires every exemption to
+      # name its coverage or be a ledgered GAP, fails a marker whose table has since
+      # gained a driver, and holds every adwaita-core MODULE — not just every table —
+      # to having a conformance file or a ledgered reason. "Driven" is a name used
+      # OUTSIDE a comment in a `*.spec.ts`: the second version read comments too, so a
+      # comment claiming coverage supplied its own evidence.
       - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 
@@ -625,9 +628,12 @@ jobs:
       # that did not exist, which reads as a reason not to look. The first version of
       # this gate tested only that the marker was PRESENT, so three false "both
       # renderers drive it" claims landed in the PR that built it and passed. It now
-      # resolves the reason's citations against the tree, fails a marker whose table
-      # has since gained a driver, and holds every adwaita-core MODULE — not just
-      # every table — to having a conformance file or a ledgered reason.
+      # resolves the reason's citations against the tree, requires every exemption to
+      # name its coverage or be a ledgered GAP, fails a marker whose table has since
+      # gained a driver, and holds every adwaita-core MODULE — not just every table —
+      # to having a conformance file or a ledgered reason. "Driven" is a name used
+      # OUTSIDE a comment in a `*.spec.ts`: the second version read comments too, so a
+      # comment claiming coverage supplied its own evidence.
       - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -290,8 +290,13 @@ jobs:
       # A conformance table with no RENDERER behind it asserts a derivation against
       # itself. A census (#1072) found 43 such tables, 16 of them silent gaps rather
       # than deliberate — and two headers in the same area were asserting coverage
-      # that did not exist, which reads as a reason not to look.
-      - name: Check every conformance table is driven or explains why not
+      # that did not exist, which reads as a reason not to look. The first version of
+      # this gate tested only that the marker was PRESENT, so three false "both
+      # renderers drive it" claims landed in the PR that built it and passed. It now
+      # resolves the reason's citations against the tree, fails a marker whose table
+      # has since gained a driver, and holds every adwaita-core MODULE — not just
+      # every table — to having a conformance file or a ledgered reason.
+      - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 
       # The style-class LEDGER against libadwaita's own style-classes.md. 21 documented
@@ -617,8 +622,13 @@ jobs:
       # A conformance table with no RENDERER behind it asserts a derivation against
       # itself. A census (#1072) found 43 such tables, 16 of them silent gaps rather
       # than deliberate — and two headers in the same area were asserting coverage
-      # that did not exist, which reads as a reason not to look.
-      - name: Check every conformance table is driven or explains why not
+      # that did not exist, which reads as a reason not to look. The first version of
+      # this gate tested only that the marker was PRESENT, so three false "both
+      # renderers drive it" claims landed in the PR that built it and passed. It now
+      # resolves the reason's citations against the tree, fails a marker whose table
+      # has since gained a driver, and holds every adwaita-core MODULE — not just
+      # every table — to having a conformance file or a ledgered reason.
+      - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 
       # The style-class LEDGER against libadwaita's own style-classes.md. 21 documented

--- a/packages/web/adwaita-core/src/conformance/about-dialog.ts
+++ b/packages/web/adwaita-core/src/conformance/about-dialog.ts
@@ -339,7 +339,12 @@ export interface TranslatorCreditsVector {
  * and no section is drawn, where JS `''.split('\n')` is `['']` and
  * draws the section with one blank row.
  *
- * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
+ * CORE-ONLY: GAP — `adw-about-dialog` has no `translator-credits` property, and the browser
+ * spec skips every row that sets one (`if (input.translatorCredits !== undefined) continue`, in
+ * adw-about-dialog.spec.ts). So the empty-string row above — the one this docblock singles out
+ * as what a port gets wrong — reaches nothing outside the core suite. It was exempted here as an
+ * internal step of ABOUT_DIALOG_CREDITS_LEGAL_VECTORS, a three-boolean visibility table with no
+ * translator input at all. Tracked in #1072
  */
 export const TRANSLATOR_CREDITS_VECTORS: ReadonlyArray<TranslatorCreditsVector> = [
     { value: 'Ada Lovelace', people: ['Ada Lovelace'], rule: 'one translator, one row' },
@@ -881,7 +886,11 @@ export interface AboutDialogLabelVector {
  * page "About <app>" AND labelling the dialog "About <app>" says the app's name
  * three times on one screen.
  *
- * CORE-ONLY: a string table the renderers read THROUGH ADW_ABOUT_DIALOG_LABELS; the rendered text is asserted by ABOUT_DIALOG_HEADER/DETAILS_VECTORS
+ * CORE-ONLY: GAP — the renderers read these strings THROUGH `ADW_ABOUT_DIALOG_LABELS`, so a
+ * spec reading them back would be circular with respect to the `.ui` fidelity this table exists
+ * to pin. ABOUT_DIALOG_HEADER/DETAILS_VECTORS are about icon and name visibility and row
+ * presence, never the label text, and `whatsNewRow` — the U+2019 row above — is filtered out of
+ * the browser spec. Tracked in #1072
  */
 export const ABOUT_DIALOG_LABEL_VECTORS: ReadonlyArray<AboutDialogLabelVector> = [
     {
@@ -938,7 +947,12 @@ export interface LicenseInfoVector {
  * - 1 == GTK_LICENSE_0BSD)` is the C's own drift check; this is that
  * assertion, ported.
  *
- * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
+ * CORE-ONLY: GAP — `adw-about-dialog` has no `license-type` property. It derives the type as
+ * CUSTOM or UNKNOWN from whether `license` is empty (elements/adw-about-dialog.ts), and nothing
+ * on either side reads an `spdxId` or a `url`, so rows 2, 7 and 18 reach no renderer; the
+ * NativeScript bridge ships the widget without a spec. It was exempted here as an internal step
+ * of ABOUT_DIALOG_CREDITS_LEGAL_VECTORS, a three-boolean visibility table whose only licence
+ * input is `hasLegal`. Tracked in #1072
  */
 export const LICENSE_INFO_VECTORS: ReadonlyArray<LicenseInfoVector> = [
     { licenseType: 0, spdxId: null, url: null, rule: 'unknown carries nothing (:216)' },
@@ -980,7 +994,8 @@ export interface LicenseSpdxVector {
 /**
  * The two lookup loops in `populate_from_appdata`.
  *
- * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (LICENSE_INFO_VECTORS → the legal section)
+ * CORE-ONLY: GAP — both lookups run inside `populate_from_appdata`, and neither renderer has an
+ * appdata path to route an SPDX id through. Tracked in #1072
  */
 export const LICENSE_SPDX_VECTORS: ReadonlyArray<LicenseSpdxVector> = [
     { spdxId: 'MIT', licenseType: 7, rule: 'an exact table match (:1227)' },
@@ -1006,7 +1021,10 @@ export interface LicenseTextVector {
 /**
  * `get_license_text`.
  *
- * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (ABOUT_DIALOG_CREDITS_LEGAL_VECTORS)
+ * CORE-ONLY: GAP — `getLicenseText` is called by no renderer. The browser element writes
+ * `this.license` straight into the Legal page and never builds the stock preamble with its URL
+ * and Pango markup, so the rows for types 7 and 18 reach nothing outside the core suite.
+ * Tracked in #1072
  */
 export const LICENSE_TEXT_VECTORS: ReadonlyArray<LicenseTextVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/about-dialog.ts
+++ b/packages/web/adwaita-core/src/conformance/about-dialog.ts
@@ -1068,7 +1068,10 @@ export interface LicenseSetterVector {
  * licence-type change DOES switch the type, while assigning `""` to an already
  * empty licence does not.
  *
- * CORE-ONLY: a property-ordering table with no rendered surface — the RESULT is ABOUT_DIALOG_CREDITS_LEGAL_VECTORS, which both renderers drive
+ * CORE-ONLY: a property-ordering table with no rendered surface — the RESULT is
+ * ABOUT_DIALOG_CREDITS_LEGAL_VECTORS, driven by the browser suite. ONE renderer, not two: the
+ * NativeScript bridge ships an `adw-about-dialog` widget and no spec for it, so nothing on that
+ * side is held to ANY about-dialog vector.
  */
 export const LICENSE_SETTER_VECTORS: ReadonlyArray<LicenseSetterVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/chrome.ts
+++ b/packages/web/adwaita-core/src/conformance/chrome.ts
@@ -38,6 +38,8 @@ export interface ClampThresholdsVector {
  * `lower`/`max`/`upper`.
  *
  * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CLAMP_ALLOCATE_VECTORS)
+ * Not for every row: both renderer suites filter that table to `params.childMin === 0`, so the
+ * three rows below that set a child minimum are asserted here alone. Tracked in #1072
  */
 export const CLAMP_THRESHOLD_VECTORS: ReadonlyArray<ClampThresholdsVector> = [
     {
@@ -99,6 +101,8 @@ const CLAMP_DEFAULT_PARAMS: ClampParams = {
  * `child_size_from_clamp`.
  *
  * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (CLAMP_ALLOCATE_VECTORS)
+ * Not for every row: one row below sets `childMin: 150`, and both renderer suites filter that
+ * table to `params.childMin === 0`, so that row is asserted here alone. Tracked in #1072
  */
 export const CLAMP_CHILD_SIZE_VECTORS: ReadonlyArray<ClampChildSizeVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/spinner.ts
+++ b/packages/web/adwaita-core/src/conformance/spinner.ts
@@ -61,8 +61,11 @@ export interface SpinnerArcShapeVector {
 /**
  * The moments worth naming in one arc cycle.
  *
- * CORE-ONLY: the arc is drawn per frame from `spinnerArc` and a renderer can only show
- * the RESULT — the browser suite asserts the drawn envelope and the round caps.
+ * CORE-ONLY: GAP — the arc is drawn per frame from `spinnerArc` and a renderer can only show the
+ * RESULT. What the browser suite checks is the round caps, and that the arc BREATHES at all
+ * (`spread > 0`, whose discriminator is the constant 90° chase this element used to draw). The
+ * envelope these rows pin — never outside [MIN_ARC_LENGTH, MAX_ARC_LENGTH] — is checked by no
+ * renderer. Tracked in #1072
  */
 export const SPINNER_ARC_PHASE_VECTORS: ReadonlyArray<SpinnerArcShapeVector> = [
     { phase: 0, rule: 'the cycle boundary — the arc is at MIN_ARC_LENGTH, its shortest' },

--- a/packages/web/adwaita-core/src/conformance/split-view.ts
+++ b/packages/web/adwaita-core/src/conformance/split-view.ts
@@ -39,7 +39,11 @@ export interface AdwLengthUnitVector {
 /**
  * `adw_length_unit_to_px`.
  *
- * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it separately would assert the same thing twice (SIDEBAR_BOUNDS_VECTORS, which both renderers drive)
+ * CORE-ONLY: an internal step of a pipeline whose COMPOSED result is renderer-driven — driving it
+ * separately would assert the same thing twice (SIDEBAR_BOUNDS_VECTORS, driven by the browser suite).
+ * ONE renderer, not two: NativeScript drives SIDEBAR_WIDTH_VECTORS instead, and works in DIPs, so
+ * `split-view-width.spec.ts` skips every row that sets a unit or a dpi — no NativeScript surface
+ * reaches this conversion at all.
  */
 export const ADW_LENGTH_UNIT_VECTORS: ReadonlyArray<AdwLengthUnitVector> = [
     { unit: 'px', value: 180, dpi: 96, px: 180, rule: 'px is a passthrough' },

--- a/packages/web/adwaita-core/src/conformance/split-view.ts
+++ b/packages/web/adwaita-core/src/conformance/split-view.ts
@@ -71,7 +71,11 @@ export interface GlibClampVector {
  * `high` there, and `allocate_uncollapsed` reaches inverted bounds whenever the
  * content pane's own minimum leaves less room than `min-sidebar-width`.
  *
- * CORE-ONLY: GLib’s CLAMP itself — a primitive with no widget surface; every widget that reaches it does so through a table that IS driven
+ * CORE-ONLY: GLib’s CLAMP itself, a primitive with no widget surface. What separates it from
+ * `Math.min`/`Math.max` is the inverted rows, and those ARE driven — `resolveNavigationSidebarWidth`
+ * inverts the bounds at 300px total width, which is a row of SIDEBAR_WIDTH_VECTORS.
+ * Its other reachers, `toolbarViewAllocate` and `carouselClampPosition`, do not reach a driven table;
+ * the earlier wording here claimed every reacher did, which was false in two places.
  */
 export const GLIB_CLAMP_VECTORS: ReadonlyArray<GlibClampVector> = [
     { x: 250, low: 180, high: 280, clamped: 250, rule: 'inside the range, untouched' },
@@ -392,7 +396,11 @@ export interface SplitViewMeasureVector {
  * Without this container minimum the content pane shrinks to nothing instead of the window
  * refusing to get narrower.
  *
- * CORE-ONLY: the container minimum lands as `min-width: min-content` on the content pane, which is CSS’s own spelling of the same rule — there is no computed number of ours to compare. Asserted in the renderer as "the pane is not crushable" instead
+ * CORE-ONLY: GAP — the container minimum lands as `min-width: min-content` on the content pane,
+ * CSS’s own spelling of the same rule, so there is no computed number of ours for a renderer to
+ * compare against. What the browser suite checks is the weaker property that the pane is not
+ * crushable (`getComputedStyle(content).minWidth !== '0px'`, split-views.spec.ts); the numbers in
+ * these rows reach no renderer. Tracked in #1072
  */
 export const SPLIT_VIEW_MEASURE_VECTORS: ReadonlyArray<SplitViewMeasureVector> = [
     {

--- a/packages/web/adwaita-core/src/conformance/tab-view.ts
+++ b/packages/web/adwaita-core/src/conformance/tab-view.ts
@@ -1446,7 +1446,7 @@ export interface TabTooltipVector {
  * browser sets `tab.title = tabTooltip(page)` (`elements/adw-tab-view.ts`),
  * NativeScript re-exports it as `tabTooltipText` (`widgets/tab-view-state.ts`) —
  * and neither is held to these rows. Both surfaces are readable from their own
- * suites, so wiring them is a loop, not new capability.
+ * suites, so wiring them is a loop, not new capability. Tracked in #1072
  */
 export const TAB_TOOLTIP_VECTORS: ReadonlyArray<TabTooltipVector> = [
     {

--- a/packages/web/adwaita-web/src/elements/adw-data-grid.ts
+++ b/packages/web/adwaita-web/src/elements/adw-data-grid.ts
@@ -52,8 +52,11 @@
 // column tracks, the cell classes, the two normalisers, the cell text and the activation
 // rule. `@gjsify/adwaita-nativescript` renders the same widget over `GridLayout`
 // `ItemSpec`s — NativeScript has no subgrid — so the TRACK rule is a renderer-neutral
-// descriptor and only the mapping onto `grid-template-columns` stays here. Both ports
-// are held to `@gjsify/adwaita-core/conformance`'s `DATA_GRID_*_VECTORS`.
+// descriptor and only the mapping onto `grid-template-columns` stays here. The NativeScript
+// suite is held to DATA_GRID_TRACK_VECTORS, DATA_GRID_COLUMN_CLASS_VECTORS,
+// DATA_GRID_VARIANT_VECTORS, DATA_GRID_CELL_TEXT_VECTORS and DATA_GRID_INTERACTIVE_VECTORS.
+// This element is held to none of them — the browser half of the shared derivation is
+// asserted only against itself, which is the gap, not the arrangement.
 // Reference: Gtk.Grid usage in the Buchhaltung BWA view (native financial grid).
 // Reference: refs/libadwaita/src/stylesheet/_colors.scss (separator / card tokens).
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -430,16 +430,16 @@ for (const table of tables) {
         .flatMap((citation) => citation.names)
         .filter((name) => name !== table.name);
     const coverage = coverageCitedIn(reason).filter((name) => name !== table.name);
-    if (named.length === 0) {
-        if (!GAP_REASON.test(reason)) {
-            failures.push(
-                `${where}: its ${CORE_ONLY_MARKER} reason names no table, so no part of it is checkable. ` +
-                    `Name the table whose coverage makes this one redundant, or spell it ` +
-                    `"${CORE_ONLY_MARKER} GAP — <why no renderer can drive it>. Tracked in #<issue>".`,
-            );
-        } else if (!GAP_ANCHOR.test(reason)) {
-            failures.push(`${where}: a ${CORE_ONLY_MARKER} GAP with no issue anchor has no owner and no retirement.`);
-        }
+    if (named.length === 0 && !GAP_REASON.test(reason)) {
+        failures.push(
+            `${where}: its ${CORE_ONLY_MARKER} reason names no table, so no part of it is checkable. ` +
+                `Name the table whose coverage makes this one redundant, or spell it ` +
+                `"${CORE_ONLY_MARKER} GAP — <why no renderer can drive it>. Tracked in #<issue>".`,
+        );
+    }
+    // Regardless of what a GAP cites — several name the table they USED to be exempted by.
+    if (GAP_REASON.test(reason) && !GAP_ANCHOR.test(reason)) {
+        failures.push(`${where}: a ${CORE_ONLY_MARKER} GAP with no issue anchor has no owner and no retirement.`);
     }
     for (const name of coverage) {
         resolved.chains += 1;

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -278,8 +278,8 @@ const CLAUSE_TURN = /(?=\b(?:but|unlike|neither|nor|rather than|instead|whereas|
 const clausesIn = (sentence) => sentence.split(CLAUSE_TURN);
 
 /**
- * The tables a citation names. `missing` is what the spelling promised and the tree
- * does not have; for a glob an empty `names` IS the miss.
+ * The tables a citation names. `missing` is what the spelling promised and the tree does not
+ * have — a name or a pair half. A glob that expands to nothing is not in `found` at all.
  */
 function citationsIn(text, declared) {
     const found = [];
@@ -572,7 +572,8 @@ if (failures.length > 0) {
 }
 
 console.log(
-    `check-adwaita-conformance-drivers: ${tables.length} vector tables, ${resolved.exempted} core-only. ` +
-        `Resolved ${resolved.citations} citation(s): ${resolved.chains} coverage chain(s), ${resolved.both} ` +
-        `both-renderer claim(s), ${resolved.suite} single-suite claim(s), ${resolved.counted} counted glob(s).`,
+    `check-adwaita-conformance-drivers: ${tables.length} vector tables, ${resolved.exempted} core-only, ` +
+        `${resolved.chains} coverage chain(s) walked to a driver. Read ${resolved.citations} prose citation(s), ` +
+        `of which ${resolved.both} both-renderer claim(s), ${resolved.suite} single-suite claim(s) and ` +
+        `${resolved.counted} counted glob(s) were resolved against the tree.`,
 );

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -154,12 +154,29 @@ function tablesIn(file) {
     return found;
 }
 
-/** Which of `names` appear anywhere under `dir`, excluding the tables' own file. */
+/** Comment bodies, blanked. `[^:]` before `//` keeps `https://` out of it. */
+const withoutComments = (source) => source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+/**
+ * Which of `names` a suite under `dir` DRIVES: names used outside a comment, in a
+ * `*.spec.ts`. Both halves are load-bearing, and a plain text scan had neither.
+ *
+ * Comments, because a claim must not supply its own evidence. This branch's own fix
+ * spelled the five `DATA_GRID_*_VECTORS` out in an adwaita-web comment saying the
+ * browser drives NONE of them — and thereby made all five read as browser-driven,
+ * silencing the gate on the exact defect it was built for. It cuts the other way too:
+ * a truthful cross-reference to an exempt table flipped it to "renderer-driven", and
+ * the staleness arm then demanded the true marker be deleted.
+ *
+ * `*.spec.ts`, because driving a table means ITERATING it in a test. Today every
+ * non-spec mention in either renderer is prose, so this changes nothing on its own —
+ * it is what keeps the comment rule from being one file's move away from useless.
+ */
 function consumersUnder(dir, names) {
     const seen = new Set();
     for (const file of walk(dir)) {
-        if (file.startsWith(CONFORMANCE_DIR)) continue;
-        const source = readFileSync(file, 'utf8');
+        if (file.startsWith(CONFORMANCE_DIR) || !file.endsWith('.spec.ts')) continue;
+        const source = withoutComments(readFileSync(file, 'utf8'));
         for (const name of names) {
             // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
             if (!seen.has(name) && new RegExp(`\\b${name}\\b`).test(source)) seen.add(name);

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -20,6 +20,7 @@
 //      section comment above it) carries a `CORE-ONLY:` line               → pass
 //   3. driven only by the core suite with no such line                     → FAIL
 //   4. driven by nothing at all                                            → FAIL
+//   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
 //
 // The `CORE-ONLY:` line belongs in the TABLE's own header, not a renderer's
 // source: #1072 found three `TOOLBAR_VIEW_*` tables whose reason lived in both
@@ -112,8 +113,16 @@ const byCore = consumersUnder([CORE_SUITE_DIR], names);
 
 const failures = [];
 for (const table of tables) {
-    if (byRenderer.get(table.name)) continue;
     const where = `${relative(ROOT, table.file)} → ${table.name}`;
+    if (byRenderer.get(table.name)) {
+        // The exemption is a claim about TODAY. Without this direction it only ever
+        // ratchets one way: a table that gains a driver keeps its excuse forever, and
+        // the next reader takes "CORE-ONLY" for the current state of the port.
+        if (table.header.includes(CORE_ONLY_MARKER)) {
+            failures.push(`${where}: renderer-driven, but still carries "${CORE_ONLY_MARKER}" — it landed, drop the marker.`);
+        }
+        continue;
+    }
     if (!byCore.get(table.name)) {
         failures.push(`${where}: driven by NOTHING — not even the core suite.`);
         continue;

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -35,17 +35,11 @@
 //   4. driven by nothing at all                                            → FAIL
 //   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
 //
-// "Driven" means a renderer's `*.spec.ts` names the table OUTSIDE a comment. Both
-// halves were bought: this branch's own corrective comment spelled five table names
-// out in a renderer file, and thereby made the gate read them as browser-driven.
+// "Driven" = a renderer `*.spec.ts` names the table OUTSIDE a comment (consumersUnder).
 //
 // CLAIM arm — every comment CLAUSE in the core or either renderer that names a
-// vector table is resolved against reality. The clause, not the sentence: "only
-// NativeScript drives X" and "…, unlike Y, which stays core-only" are how English
-// states single-renderer coverage, and both were rejected as false claims.
+// vector table is resolved against reality (clause, not sentence — see clausesIn):
 //   6. a `*_VECTORS` name or `A/B_VECTORS` pair that matches no declared table → FAIL
-//      (a `PREFIX_*` glob expanding to nothing is NOT a citation — these trees
-//      are ports of C and cite upstream enum families the same way)
 //   7. a counted citation ("the five OVERLAY_SWIPE_* tables") whose count is
 //      wrong. `OVERLAY_SWIPE_*` IS five real tables, so the arity is the whole
 //      question: a checker that rejected globs would reject a true sentence  → FAIL
@@ -57,16 +51,10 @@
 //      citations from it reaches a renderer-driven table                   → FAIL
 //  11. a `CORE-ONLY:` reason that names no table and is not a ledgered GAP  → FAIL
 //
-// 10 reads only citations whose own clause is PHRASED as coverage. A reason cites a
-// table for other reasons too — as a precedent (`TOOLBAR_VIEW_MEASURE_VECTORS` says
-// its reason is the one `TOOLBAR_VIEW_ALLOCATE_VECTORS` gives, which is not a claim
-// that ALLOCATE covers it), as a concession, as a contrast. Precedents are not left
-// unchecked by that: the cited table is a table, so the TABLE arm holds its header.
-//
-// 11 is what makes an exemption falsifiable at all. Without it the cheapest way to
-// write one is to name nothing — `CORE-ONLY: both renderers exercise this already
-// through their real widgets` passed every other arm, because they all key off a
-// citation. Three of the 43 exemptions were that shape.
+// 10 reads only citations whose clause is PHRASED as coverage (COVERAGE_PHRASING); a
+// precedent citation is held by the TABLE arm instead, on the table it names. 11 is what
+// makes an exemption falsifiable — every other arm keys off a citation, so naming none
+// was the cheapest way to write one.
 //
 // MODULE arm — the table arm is TABLE-keyed, so core behaviour with no table at
 // all is invisible to it. Every module under `adwaita-core/src` that exports
@@ -75,13 +63,10 @@
 // against the declared tables, against whether a renderer drives them, and against
 // the open-item ledger.
 //
-// WHAT IT DOES NOT CHECK: "driven" is a name used outside a comment in a spec, so a
-// spec that imports a table and filters the interesting rows away still counts as
-// driving it. Six tables are referenced only through a `.filter(` today. Measured
-// and ledgered under "A table can be 'driven' while the rows that matter are
-// skipped" rather than half-guarded: the `.filter(` form is mechanical, the
-// `continue`-guard form beside it is not, and a rule that catches two shapes of a
-// three-shape class reads as covering the class.
+// WHAT IT DOES NOT CHECK: a spec that imports a table and filters the interesting rows
+// away still counts as driving it. Measured (six tables) and ledgered under "A table can
+// be 'driven' while the rows that matter are skipped" rather than half-guarded — a rule
+// catching two shapes of a three-shape class reads as covering the class.
 //
 // The `CORE-ONLY:` line belongs in the TABLE's own header, not a renderer's
 // source: #1072 found three `TOOLBAR_VIEW_*` tables whose reason lived in both
@@ -111,11 +96,9 @@ const OPEN_TODOS = join(ROOT, 'status/open-todos.md');
 const CORE_ONLY_MARKER = 'CORE-ONLY:';
 
 /**
- * The open-item headings a module-level gap is ledgered under. Count-free ON PURPOSE: the
- * first spelling was "Four adwaita-core modules …", matched here as a literal string, so
- * closing one gap made the heading false and correcting it meant editing THIS FILE in the
- * same change. AGENTS.md forbids a live count in a comment; inside a required check it is
- * worse than drift.
+ * The open-item headings a module-level gap is ledgered under. Count-free ON PURPOSE: spelled
+ * "Four adwaita-core modules …" and matched here as a literal, closing one gap made the heading
+ * false and correcting it meant editing THIS FILE in the same change.
  */
 const NO_TABLE_LEDGER = 'adwaita-core modules with no conformance vector table';
 const NO_DRIVER_LEDGER = 'adwaita-core modules whose only vector table is core-only';
@@ -124,8 +107,8 @@ const NO_DRIVER_LEDGER = 'adwaita-core modules whose only vector table is core-o
  * Core modules with no conformance file named after them and none importing them for VALUE.
  * `table` — its vectors live in another file under that name; `gap` — the named `###` heading
  * must be an open item in `status/open-todos.md`, so the gap has a place to be closed from.
- * Both, where the vectors exist but no renderer drives THEM either: those are different facts
- * and the entry has to state both, or "explained" quietly means "unexamined".
+ * Both, where the vectors exist but no renderer drives THEM either — different facts, and an
+ * entry that states only the first reads as explained while the module is held to nothing.
  */
 const MODULE_REASONS = {
     breakpoint: { gap: NO_TABLE_LEDGER },
@@ -141,12 +124,9 @@ const MODULE_REASONS = {
 const CITATION =
     /\b([A-Z][A-Z0-9_]*_)\*(?:_VECTORS)?|\b([A-Z][A-Z0-9_]*)\/([A-Z][A-Z0-9_]*_VECTORS)|\b[A-Z][A-Z0-9_]*_VECTORS\b/g;
 /**
- * A citation is a COVERAGE claim only where the clause around it says so. The default is
- * the other way: a reason cites a table for lots of reasons — as a precedent ("same as X"),
- * as a concession ("its other reachers go through X, which stays core-only"), as a contrast.
- * This started as a four-phrase whitelist of precedent spellings, which reported "GAP for the
- * reason X gives" as a coverage claim: an unrecognised TRUE spelling became an accusation.
- * Naming the coverage spellings instead makes an unrecognised one silent.
+ * A citation is a COVERAGE claim only where its clause says so — a reason also cites a table as
+ * a precedent, a concession, a contrast. Naming the four PRECEDENT spellings instead, as this
+ * started out, made an unrecognised TRUE one ("GAP for the reason X gives") an accusation.
  */
 const COVERAGE_PHRASING = /\b(?:driven|drives?|driving|covered|asserted|asserts|held to|the RESULT is|same thing twice)\b/i;
 /**
@@ -196,23 +176,19 @@ function tablesIn(file) {
     return found;
 }
 
-/** Comment bodies, blanked. `[^:]` before `//` keeps `https://` out of it. */
+/** Comment bodies, blanked; `[^:]` keeps `https://` out of it. */
 const withoutComments = (source) => source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
 /**
- * Which of `names` a suite under `dir` DRIVES: names used outside a comment, in a
- * `*.spec.ts`. Both halves are load-bearing, and a plain text scan had neither.
+ * Which of `names` a suite under `dir` DRIVES: names used outside a comment, in a `*.spec.ts`.
  *
- * Comments, because a claim must not supply its own evidence. This branch's own fix
- * spelled the five `DATA_GRID_*_VECTORS` out in an adwaita-web comment saying the
- * browser drives NONE of them — and thereby made all five read as browser-driven,
- * silencing the gate on the exact defect it was built for. It cuts the other way too:
- * a truthful cross-reference to an exempt table flipped it to "renderer-driven", and
- * the staleness arm then demanded the true marker be deleted.
- *
- * `*.spec.ts`, because driving a table means ITERATING it in a test. Today every
- * non-spec mention in either renderer is prose, so this changes nothing on its own —
- * it is what keeps the comment rule from being one file's move away from useless.
+ * Outside a comment, because a claim must not supply its own evidence — this branch's own fix
+ * spelled the five `DATA_GRID_*_VECTORS` out in an adwaita-web comment saying the browser drives
+ * NONE of them, and thereby made all five read as browser-driven. It cut the other way too: a
+ * truthful cross-reference to an exempt table flipped it to "renderer-driven", and the staleness
+ * arm then demanded the true marker be deleted. `*.spec.ts`, because driving means ITERATING in
+ * a test; every non-spec mention in either renderer is prose today, so that half only keeps the
+ * first from being one file's move away from useless.
  */
 function consumersUnder(dir, names) {
     const seen = new Set();
@@ -259,20 +235,16 @@ const lineOf = (block, spelling) => block.segments.find((segment) => segment.tex
 const sentencesIn = (text) => text.split(/(?<=\.)\s+(?=[A-Z`(])/);
 
 /**
- * A sentence, cut where it turns: at the words that switch which side of a contrast you
- * are on. The claim arms read CLAUSES, not sentences, because a sentence is not one claim.
- * Three TRUE sentences were rejected while it was:
- *   "Both renderers consume the derivation … and NEITHER is held to TAB_TOOLTIP_VECTORS"
- *   "The browser works in CSS pixels …, so ONLY NativeScript drives SIDEBAR_WIDTH_VECTORS."
- *   "Both renderers drive TOOLBAR_VIEW_CLASS_VECTORS, UNLIKE TOOLBAR_VIEW_ALLOCATE_VECTORS…"
- * Every one names the OTHER renderer, or the table that is NOT covered, in the same
- * sentence — which is how you state single-renderer coverage in English. The tree was green
- * only because its reasons had been worded around this: the split-view fix puts browser and
- * NativeScript in separate sentences, and the TAB_TOOLTIP reason writes "these rows" rather
- * than naming its own table. Dodged by wording is not satisfied.
+ * A sentence, cut where it turns. The claim arms read CLAUSES because a sentence is not one
+ * claim: three TRUE ones were rejected while they read whole sentences, e.g. "The browser works
+ * in CSS pixels …, so ONLY NativeScript drives SIDEBAR_WIDTH_VECTORS", credited to the browser
+ * for naming it. Stating single-renderer coverage NAMES the other renderer, or the table that is
+ * not covered, in the same sentence. The tree was green only because its reasons had been worded
+ * around that — split browser and NativeScript into two sentences, write "these rows" instead of
+ * the table's name — and dodged by wording is not satisfied.
  *
- * The marker STARTS the next clause, so the contrasted half is still read — it just no
- * longer inherits the claim from the half before it.
+ * The marker STARTS the next clause, so the contrasted half is still read; it just stops
+ * inheriting the claim from the half before it.
  */
 const CLAUSE_TURN = /(?=\b(?:but|unlike|neither|nor|rather than|instead|whereas|while|except|not|no|none|only)\b)/i;
 const clausesIn = (sentence) => sentence.split(CLAUSE_TURN);
@@ -287,11 +259,9 @@ function citationsIn(text, declared) {
         const [spelling, globPrefix, pairHead, pairTail] = match;
         if (globPrefix) {
             const expanded = [...declared].filter((name) => name.startsWith(globPrefix));
-            // A glob that expands to NOTHING is not a citation. These trees are ports of C
-            // and cite upstream constant families the same way — `GTK_STATE_FLAG_*`,
-            // `ADW_TOAST_PRIORITY_*`, and `O_*`/`DH_CHECK_*` elsewhere in the repo. Reading
-            // those as broken table citations rejected true sentences, and this gate carries
-            // no `paths:` filter, so one such comment blocks every merge in the repo.
+            // A glob that expands to NOTHING is not a citation: these trees are ports of C and
+            // cite upstream constant families the same way (`GTK_STATE_FLAG_*`, `O_*`). Reading
+            // one as a broken citation blocked every merge — this gate has no `paths:` filter.
             if (expanded.length === 0) continue;
             found.push({ spelling, kind: 'glob', index: match.index, names: expanded, missing: [] });
         } else if (pairHead) {
@@ -319,12 +289,10 @@ function citationsIn(text, declared) {
 }
 
 /**
- * The count word immediately before a citation, if the sentence states one — for a spelling
- * that CAN expand to several tables. A plain name always expands to exactly one, so the only
- * count that ever passes is "one", and "the three TAB_TOOLTIP_VECTORS rows below" — counting
- * ROWS, which is ordinary prose here — reads as an arity of three and fails. The digit case
- * was already excluded for this reason ("at 96 dpi ADW_LENGTH_UNIT_VECTORS" is arithmetic);
- * the spelled-word path was left open.
+ * The count word immediately before a citation — only for a spelling that CAN expand to several
+ * tables. A plain name always expands to one, so the only count that passes is "one", and "the
+ * three TAB_TOOLTIP_VECTORS rows below" fails on an arity nobody stated. Digits were already
+ * excluded for that reason ("at 96 dpi ADW_LENGTH_UNIT_VECTORS" is arithmetic).
  */
 function statedCount(sentence, index, kind) {
     if (kind === 'name') return undefined;
@@ -364,7 +332,6 @@ for (const table of tables) {
     reasons.set(table.name, text);
 }
 
-/** The unit both claim arms read: one clause of one sentence. */
 const claimUnitsIn = (text) => sentencesIn(text).flatMap(clausesIn);
 
 /** The tables a reason offers AS ITS COVERAGE — a citation whose own clause says so. */
@@ -419,13 +386,11 @@ for (const table of tables) {
         continue;
     }
     resolved.exempted += 1;
-    // Every exemption is one of exactly two things, and it has to say which. A reason that
-    // rests on another table NAMES it — as coverage (chain-resolved below) or as a precedent,
-    // whose own header the table arm checks in its own right. A reason that rests on nothing
-    // is a GAP, and says so with somewhere to close it from. The third shape — prose that
-    // reads like coverage and names nothing — is the cheapest unfalsifiable exemption there
-    // is, and no arm can see it: `CORE-ONLY: both renderers exercise this through their real
-    // widgets` passed everything. Three of the 43 were that shape; two were measurably false.
+    // An exemption either rests on another table and NAMES it — as coverage (chain-resolved
+    // below) or as a precedent, whose own header the table arm holds — or rests on nothing and
+    // is a GAP with somewhere to close it from. The third shape reads like coverage and names
+    // nothing: `CORE-ONLY: both renderers exercise this through their real widgets` passed
+    // every arm. Three of the 43 were that shape; two were measurably false.
     const named = citationsIn(reason, declared)
         .flatMap((citation) => citation.names)
         .filter((name) => name !== table.name);
@@ -513,19 +478,18 @@ const openTodos = readFileSync(OPEN_TODOS, 'utf8');
 const HAS_BEHAVIOUR = /^export\s+(?:async\s+)?(?:const|function|class|let|var|enum|default)\b/m;
 
 for (const file of walk(CORE_SUITE_DIR)) {
-    // Recursive, unlike the readdir this arm started with — the arm exists because the table
-    // arm had an invisible set, and a non-recursive scan reproduces that one directory down.
+    // Recursive, unlike the readdir this arm started with: the arm exists because the table arm
+    // had an invisible set, and a non-recursive scan reproduces that one directory down.
     if (file.startsWith(CONFORMANCE_DIR) || file.endsWith('.spec.ts')) continue;
     const module = relative(CORE_SUITE_DIR, file).slice(0, -3);
     if (module === 'index') continue;
     const source = readFileSync(file, 'utf8');
-    // A module of pure types has no behaviour to vector, so demanding vectors for it would
-    // force the author to invent a table or a ledger item. Derived, not allowlisted.
+    // Skipping a types-only module is DERIVED, not allowlisted — there is nothing to vector, so
+    // demanding vectors forces the author to invent a table or a ledger item.
     if (!HAS_BEHAVIOUR.test(source)) continue;
     const where = `${relative(ROOT, file)}`;
-    // A VALUE import. `import type { AdwLengthUnit } from '../length-unit.js'` proves nothing
-    // about vectors — it borrows a name for a field — and that is the whole of what covered
-    // `length-unit.ts`.
+    // A VALUE import: `import type { AdwLengthUnit } from '../length-unit.js'` borrows a name
+    // for a field and proves nothing, and it was the whole of what covered `length-unit.ts`.
     const valueImport = new RegExp(`import\\s+(?!type\\b)[^;]*?from '\\.\\./${module}\\.js'`);
     const covered =
         conformanceFiles.some((candidate) => candidate.endsWith(`/${module}.ts`)) || valueImport.test(conformanceSource);
@@ -544,9 +508,8 @@ for (const file of walk(CORE_SUITE_DIR)) {
     if (reason.table && !declared.has(reason.table)) {
         failures.push(`${where}: MODULE_REASONS points at ${reason.table}, which no conformance file declares.`);
     }
-    // A `table:` naming a table no renderer drives explains where the vectors LIVE and nothing
-    // about who is held to them — which is the question this arm's finding text asks. Left at
-    // `declared.has()`, the entry reads as resolved while the module is held to nothing at all.
+    // A `table:` naming an undriven table says where the vectors LIVE and nothing about who is
+    // held to them. Left at `declared.has()`, the entry reads as resolved either way.
     if (reason.table && declared.has(reason.table) && !byRenderer.has(reason.table) && !reason.gap) {
         failures.push(
             `${where}: its vectors live in ${reason.table}, which no renderer drives either — so no ` +

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -39,7 +39,9 @@
 // vector table is resolved against reality:
 //   6. a name, `PREFIX_*` glob or `A/B_VECTORS` pair that matches no declared
 //      table                                                               → FAIL
-//   7. a counted glob ("the five OVERLAY_SWIPE_* tables") whose count is wrong → FAIL
+//   7. a counted citation ("the five OVERLAY_SWIPE_* tables") whose count is
+//      wrong. `OVERLAY_SWIPE_*` IS five real tables, so the arity is the whole
+//      question: a checker that rejected globs would reject a true sentence  → FAIL
 //   8. "both renderers / both ports / both drive" over tables one renderer
 //      does not drive                                                      → FAIL
 //   9. "the browser suite" / "the NativeScript suite" over tables THAT suite

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Every conformance vector table is either driven by a RENDERER, or says why not.
+// Every conformance vector table is either driven by a RENDERER, or says why not —
+// and the why-not is READ, not just counted.
 //
 // THE INCIDENT
 //
@@ -12,15 +13,50 @@
 // telling the two apart is the whole problem — and two headers here were found
 // asserting coverage that did not exist, which reads as a reason not to look.
 //
+// THE SECOND INCIDENT
+//
+// The first version of this gate tested that the literal `CORE-ONLY:` appeared in
+// the header and stopped there. THREE false coverage claims then landed in the
+// very PR that built it, and it passed all three: `SIDEBAR_BOUNDS_VECTORS` and
+// `ABOUT_DIALOG_CREDITS_LEGAL_VECTORS` were each called driven by "both
+// renderers" when only adwaita-web drives them (NativeScript drives a DIFFERENT
+// table, `SIDEBAR_WIDTH_VECTORS`, and has no about-dialog spec at all), and
+// `adw-data-grid.ts` said "Both ports are held to DATA_GRID_*_VECTORS" while
+// adwaita-web drove none of the six. A reason left outside the check is prose,
+// and prose that says "covered" is worse than no reason at all.
+//
 // WHAT IT CHECKS
 //
-// For every `export const *_VECTORS` in `conformance/`:
+// TABLE arm — for every `export const *_VECTORS` in `conformance/`:
 //   1. driven by at least one RENDERER suite            → pass
 //   2. driven only by the core suite, and its own header (the docblock or the
 //      section comment above it) carries a `CORE-ONLY:` line               → pass
 //   3. driven only by the core suite with no such line                     → FAIL
 //   4. driven by nothing at all                                            → FAIL
 //   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
+//
+// CLAIM arm — every comment SENTENCE in the core or either renderer that names a
+// vector table is resolved against reality:
+//   6. a name, `PREFIX_*` glob or `A/B_VECTORS` pair that matches no declared
+//      table                                                               → FAIL
+//   7. a counted glob ("the five OVERLAY_SWIPE_* tables") whose count is wrong → FAIL
+//   8. "both renderers / both ports / both drive" over tables one renderer
+//      does not drive                                                      → FAIL
+//   9. "the browser suite" / "the NativeScript suite" over tables THAT suite
+//      does not drive                                                      → FAIL
+//  10. a `CORE-ONLY:` reason citing a table as its coverage, where no chain of
+//      citations from it reaches a renderer-driven table                   → FAIL
+//
+// A citation is exempt from 10 when the sentence spells a PRECEDENT ("same as X")
+// rather than coverage: `TOOLBAR_VIEW_MEASURE_VECTORS` says its reason is the one
+// `TOOLBAR_VIEW_ALLOCATE_VECTORS` gives, which is not a claim that ALLOCATE covers
+// it. A checker that cannot tell those apart reports a true sentence as false.
+//
+// MODULE arm — the table arm is TABLE-keyed, so core behaviour with no table at
+// all is invisible to it. Every module in `adwaita-core/src` therefore needs a
+// conformance file of its own, a conformance file that imports it, or an entry in
+// MODULE_REASONS below — itself checked, against the declared tables and against
+// the open-item ledger.
 //
 // The `CORE-ONLY:` line belongs in the TABLE's own header, not a renderer's
 // source: #1072 found three `TOOLBAR_VIEW_*` tables whose reason lived in both
@@ -36,17 +72,51 @@ const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
-const CONFORMANCE_DIR = join(ROOT, 'packages/web/adwaita-core/src/conformance');
 /** Where the CORE drives its own tables. Not a renderer. */
 const CORE_SUITE_DIR = join(ROOT, 'packages/web/adwaita-core/src');
+const CONFORMANCE_DIR = join(CORE_SUITE_DIR, 'conformance');
 /** The renderer suites — driving a table from one of these is the point. */
-const RENDERER_DIRS = [
-    join(ROOT, 'packages/web/adwaita-web/src'),
-    join(ROOT, 'packages/nativescript-bridge/adwaita/src'),
+const RENDERERS = [
+    { label: 'adwaita-web', dir: join(ROOT, 'packages/web/adwaita-web/src') },
+    { label: 'nativescript', dir: join(ROOT, 'packages/nativescript-bridge/adwaita/src') },
 ];
+const OPEN_TODOS = join(ROOT, 'status/open-todos.md');
 
 /** The marker a core-only table must carry, in its own header. */
 const CORE_ONLY_MARKER = 'CORE-ONLY:';
+
+/** The open-item heading the four table-less core modules are ledgered under. */
+const NO_TABLE_LEDGER = 'Four adwaita-core modules have no conformance vector table';
+
+/**
+ * Core modules with no conformance file named after them and no conformance file
+ * importing them. `table` — its vectors live in another file under that name;
+ * `gap` — no vector table exists, and the named `###` heading must be an open item
+ * in `status/open-todos.md`, so the gap has a place to be closed from.
+ */
+const MODULE_REASONS = {
+    breakpoint: { gap: NO_TABLE_LEDGER },
+    'color-scheme': { gap: NO_TABLE_LEDGER },
+    easing: { table: 'SPINNER_ARC_PHASE_VECTORS' },
+    glib: { table: 'GLIB_CLAMP_VECTORS' },
+    scrolling: { gap: NO_TABLE_LEDGER },
+    toast: { gap: NO_TABLE_LEDGER },
+};
+
+/** `PREFIX_*[_VECTORS]` glob | `A/B_VECTORS` pair | a plain table name. */
+const CITATION =
+    /\b([A-Z][A-Z0-9_]*_)\*(?:_VECTORS)?|\b([A-Z][A-Z0-9_]*)\/([A-Z][A-Z0-9_]*_VECTORS)|\b[A-Z][A-Z0-9_]*_VECTORS\b/g;
+/** "for the same reason as X" — cites X as a precedent, not as coverage. */
+const PRECEDENT = /\bsame (?:as|reason as|rule as|gap as)\b/i;
+/** The three spellings that occur; two of the three false claims used the rarer two. */
+const BOTH_CLAIM = /\bboth\s+(?:renderer\s+suites?|renderers?|ports?|suites?|elements?|drive)\b/i;
+/** A named renderer plus a coverage verb — "driven by the browser suite", "NativeScript drives X". */
+const SUITE_CLAIMS = [
+    { label: 'adwaita-web', pattern: /\b(?:browser|adwaita-web)\b/i },
+    { label: 'nativescript', pattern: /\bNativeScript\b/i },
+];
+const COVERAGE_VERB = /\b(?:suite|drives?|driven by|held to|asserts)\b/i;
+const COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
 
 function walk(dir) {
     const out = [];
@@ -71,34 +141,105 @@ function tablesIn(file) {
         const match = /^export const ([A-Z0-9_]+_VECTORS)\b/.exec(line);
         if (!match) continue;
         let start = index - 1;
-        while (
-            start >= 0 &&
-            (lines[start].trim().startsWith('*') ||
-                lines[start].trim().startsWith('/') ||
-                lines[start].trim().startsWith('//'))
-        ) {
-            start--;
-        }
-        found.push({ name: match[1], header: lines.slice(start + 1, index).join('\n'), file });
+        while (start >= 0 && /^\s*(\*|\/)/.test(lines[start])) start--;
+        found.push({ name: match[1], header: lines.slice(start + 1, index).join('\n'), file, line: index + 1 });
     }
     return found;
 }
 
-/** Which of `names` appear anywhere under `dirs`, excluding the tables' own file. */
-function consumersUnder(dirs, names) {
-    const seen = new Map(names.map((name) => [name, false]));
-    for (const dir of dirs) {
-        for (const file of walk(dir)) {
-            if (file.startsWith(CONFORMANCE_DIR)) continue;
-            const source = readFileSync(file, 'utf8');
-            for (const name of names) {
-                if (seen.get(name)) continue;
-                // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
-                if (new RegExp(`\\b${name}\\b`).test(source)) seen.set(name, true);
-            }
+/** Which of `names` appear anywhere under `dir`, excluding the tables' own file. */
+function consumersUnder(dir, names) {
+    const seen = new Set();
+    for (const file of walk(dir)) {
+        if (file.startsWith(CONFORMANCE_DIR)) continue;
+        const source = readFileSync(file, 'utf8');
+        for (const name of names) {
+            // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
+            if (!seen.has(name) && new RegExp(`\\b${name}\\b`).test(source)) seen.add(name);
         }
     }
     return seen;
+}
+
+/** Contiguous runs of comment lines, marker-stripped and joined — one prose block each. */
+function commentBlocks(file) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    const blocks = [];
+    let current = null;
+    for (const [index, line] of lines.entries()) {
+        const trimmed = line.trim();
+        if (!/^(\/\/|\/\*|\*)/.test(trimmed)) {
+            current = null;
+            continue;
+        }
+        const text = trimmed
+            .replace(/^\/\*+|^\/\/+|^\*+\/?/, '')
+            .replace(/\*\/$/, '')
+            .trim();
+        if (current) {
+            current.text += ` ${text}`;
+            current.segments.push({ line: index + 1, text });
+        } else {
+            blocks.push((current = { file, line: index + 1, text, segments: [{ line: index + 1, text }] }));
+        }
+    }
+    return blocks;
+}
+
+/** The source line a citation sits on — a 50-line header is not an address. */
+const lineOf = (block, spelling) => block.segments.find((segment) => segment.text.includes(spelling))?.line ?? block.line;
+
+/** Split on sentence ends only where a new sentence plausibly starts — `adw-tab-view.ts` must not split. */
+const sentencesIn = (text) => text.split(/(?<=\.)\s+(?=[A-Z`(])/);
+
+/**
+ * The tables a citation names. `missing` is what the spelling promised and the tree
+ * does not have; for a glob an empty `names` IS the miss.
+ */
+function citationsIn(text, declared) {
+    const found = [];
+    for (const match of text.matchAll(CITATION)) {
+        const [spelling, globPrefix, pairHead, pairTail] = match;
+        if (globPrefix) {
+            found.push({
+                spelling,
+                kind: 'glob',
+                index: match.index,
+                names: [...declared].filter((name) => name.startsWith(globPrefix)),
+                missing: [],
+            });
+        } else if (pairHead) {
+            const shared = pairHead.slice(0, pairHead.lastIndexOf('_') + 1);
+            const expanded = [`${pairHead}_VECTORS`, `${shared}${pairTail}`];
+            found.push({
+                spelling,
+                kind: 'pair',
+                index: match.index,
+                names: expanded.filter((name) => declared.has(name)),
+                missing: expanded.filter((name) => !declared.has(name)),
+            });
+        } else {
+            const known = declared.has(spelling);
+            found.push({
+                spelling,
+                kind: 'name',
+                index: match.index,
+                names: known ? [spelling] : [],
+                missing: known ? [] : [spelling],
+            });
+        }
+    }
+    return found;
+}
+
+/** The count word immediately before a citation, if the sentence states one. */
+function statedCount(sentence, index) {
+    const before = sentence.slice(0, index).replace(/[`'"\s]+$/, '');
+    const word = /([A-Za-z]+|\d+)$/.exec(before)?.[1];
+    if (!word) return undefined;
+    if (/^\d+$/.test(word)) return Number(word);
+    const spelled = COUNT_WORDS.indexOf(word.toLowerCase());
+    return spelled === -1 ? undefined : spelled;
 }
 
 const tables = walk(CONFORMANCE_DIR).flatMap(tablesIn);
@@ -108,42 +249,190 @@ if (tables.length === 0) {
 }
 
 const names = tables.map((table) => table.name);
-const byRenderer = consumersUnder(RENDERER_DIRS, names);
-const byCore = consumersUnder([CORE_SUITE_DIR], names);
+const declared = new Set(names);
+const byLabel = new Map(RENDERERS.map(({ label, dir }) => [label, consumersUnder(dir, names)]));
+const byRenderer = new Set([...byLabel.values()].flatMap((set) => [...set]));
+const byCore = consumersUnder(CORE_SUITE_DIR, names);
+
+/** The `CORE-ONLY:` reason a table carries, as one line. */
+const reasons = new Map();
+for (const table of tables) {
+    const lines = table.header.split('\n');
+    const start = lines.findIndex((line) => line.includes(CORE_ONLY_MARKER));
+    if (start === -1) continue;
+    const text = lines
+        .slice(start)
+        .map((line) => line.trim().replace(/^\/\/+|^\*+\/?/, ''))
+        .join(' ')
+        .replace(/\*\/\s*$/, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    reasons.set(table.name, text);
+}
+
+/**
+ * Does the exemption chain from `name` end at a table a renderer actually drives?
+ * One hop is the common case (an intermediate step naming its composed result); the
+ * about-dialog licence tables are three hops deep, and a chain that only ever cites
+ * other exempt tables is the shape this arm exists to reject.
+ */
+function reachesADriver(name, seen = new Set()) {
+    if (byRenderer.has(name)) return true;
+    if (seen.has(name)) return false;
+    seen.add(name);
+    const reason = reasons.get(name);
+    if (!reason) return false;
+    for (const citation of citationsIn(reason, declared)) {
+        for (const cited of citation.names) {
+            if (cited !== name && reachesADriver(cited, seen)) return true;
+        }
+    }
+    return false;
+}
 
 const failures = [];
+/** What each arm actually resolved. A gate that reports only "green" cannot show it ran. */
+const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0 };
 for (const table of tables) {
-    const where = `${relative(ROOT, table.file)} → ${table.name}`;
-    if (byRenderer.get(table.name)) {
+    const where = `${relative(ROOT, table.file)}:${table.line} → ${table.name}`;
+    if (byRenderer.has(table.name)) {
         // The exemption is a claim about TODAY. Without this direction it only ever
         // ratchets one way: a table that gains a driver keeps its excuse forever, and
         // the next reader takes "CORE-ONLY" for the current state of the port.
-        if (table.header.includes(CORE_ONLY_MARKER)) {
+        if (reasons.has(table.name)) {
             failures.push(`${where}: renderer-driven, but still carries "${CORE_ONLY_MARKER}" — it landed, drop the marker.`);
         }
         continue;
     }
-    if (!byCore.get(table.name)) {
+    if (!byCore.has(table.name)) {
         failures.push(`${where}: driven by NOTHING — not even the core suite.`);
         continue;
     }
-    if (!table.header.includes(CORE_ONLY_MARKER)) {
+    const reason = reasons.get(table.name);
+    if (reason === undefined) {
         failures.push(
             `${where}: driven only by the core suite. Either drive it from a renderer, or state why not ` +
                 `with a "${CORE_ONLY_MARKER} <reason>" line in the table's own header.`,
         );
+        continue;
+    }
+    resolved.exempted += 1;
+    for (const sentence of sentencesIn(reason)) {
+        if (PRECEDENT.test(sentence)) continue;
+        const cited = citationsIn(sentence, declared).flatMap((citation) => citation.names);
+        for (const name of cited) {
+            if (name === table.name) continue;
+            resolved.chains += 1;
+            if (reachesADriver(name)) continue;
+            failures.push(
+                `${where}: its reason cites ${name} as the coverage that makes this table redundant, but ` +
+                    `no chain of citations from ${name} reaches a table any renderer drives.`,
+            );
+        }
+    }
+}
+
+// The CLAIM arm runs over the whole surface, not just table headers: two of the three
+// false claims #1072 shipped were in prose ABOUT a table rather than above one, and
+// `adw-data-grid.ts` put its "Both ports" a renderer-tree away from any conformance file.
+for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]) {
+    for (const block of walk(dir).flatMap(commentBlocks)) {
+        for (const sentence of sentencesIn(block.text)) {
+            const citations = citationsIn(sentence, declared);
+            if (citations.length === 0) continue;
+            for (const citation of citations) {
+                const where = `${relative(ROOT, block.file)}:${lineOf(block, citation.spelling)}`;
+                resolved.citations += 1;
+                for (const name of citation.missing) {
+                    failures.push(`${where}: names ${name}, which no conformance file declares.`);
+                }
+                if (citation.kind === 'glob' && citation.names.length === 0) {
+                    failures.push(`${where}: the glob ${citation.spelling} matches no declared table.`);
+                    continue;
+                }
+                const stated = statedCount(sentence, citation.index);
+                if (citation.kind === 'glob' && stated !== undefined) resolved.counted += 1;
+                if (citation.kind === 'glob' && stated !== undefined && stated !== citation.names.length) {
+                    failures.push(
+                        `${where}: says ${stated} ${citation.spelling} tables; the tree declares ${citation.names.length}.`,
+                    );
+                }
+                if (citation.names.length === 0) continue;
+                if (BOTH_CLAIM.test(sentence)) {
+                    resolved.both += 1;
+                    for (const { label } of RENDERERS) {
+                        const undriven = citation.names.filter((name) => !byLabel.get(label).has(name));
+                        if (undriven.length > 0) {
+                            failures.push(
+                                `${where}: claims BOTH renderers cover ${citation.spelling}, but ${label} drives ` +
+                                    `none of ${undriven.join(', ')}.`,
+                            );
+                        }
+                    }
+                }
+                for (const { label, pattern } of SUITE_CLAIMS) {
+                    if (!pattern.test(sentence) || !COVERAGE_VERB.test(sentence)) continue;
+                    resolved.suite += 1;
+                    const undriven = citation.names.filter((name) => !byLabel.get(label).has(name));
+                    if (undriven.length > 0) {
+                        failures.push(`${where}: credits the ${label} suite with ${undriven.join(', ')}, which it does not drive.`);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MODULE arm. Everything above is keyed by TABLE, so a core module with no table is
+// not under-covered by this gate — it is INVISIBLE to it. `breakpoint`, `color-scheme`,
+// `scrolling` and `toast` had no vector table at all, three of them named in
+// packages/web/AGENTS.md as the core's flagship shared behaviour, and the ledger that
+// reported "156 tables, every one driven or explained" said nothing about any of them.
+const conformanceSource = walk(CONFORMANCE_DIR)
+    .map((file) => readFileSync(file, 'utf8'))
+    .join('\n');
+const openTodos = readFileSync(OPEN_TODOS, 'utf8');
+
+for (const entry of readdirSync(CORE_SUITE_DIR, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.endsWith('.spec.ts')) continue;
+    const module = entry.name.slice(0, -3);
+    if (module === 'index') continue;
+    const where = `packages/web/adwaita-core/src/${entry.name}`;
+    const covered =
+        walk(CONFORMANCE_DIR).some((file) => file.endsWith(`/${entry.name}`)) ||
+        conformanceSource.includes(`from '../${module}.js'`);
+    const reason = MODULE_REASONS[module];
+    if (covered) {
+        if (reason) failures.push(`${where}: listed in MODULE_REASONS, but conformance covers it now — drop the entry.`);
+        continue;
+    }
+    if (!reason) {
+        failures.push(
+            `${where}: no conformance file names or imports it, so no renderer is held to any of its ` +
+                `behaviour. Add vectors for it, or a MODULE_REASONS entry saying which table carries them.`,
+        );
+    } else if (reason.table && !declared.has(reason.table)) {
+        failures.push(`${where}: MODULE_REASONS points at ${reason.table}, which no conformance file declares.`);
+    } else if (reason.gap && !openTodos.includes(`### ${reason.gap}`)) {
+        failures.push(`${where}: MODULE_REASONS calls this a gap under "${reason.gap}", which is not an open item.`);
     }
 }
 
 if (failures.length > 0) {
-    console.error(`check-adwaita-conformance-drivers: ${failures.length} table(s) need attention:\n`);
-    for (const failure of failures) console.error(`  - ${failure}`);
+    console.error(`check-adwaita-conformance-drivers: ${failures.length} finding(s):\n`);
+    for (const failure of [...new Set(failures)]) console.error(`  - ${failure}`);
     console.error(
         `\nA table with no renderer behind it asserts a derivation against itself. That is sometimes right —\n` +
             `an intermediate step whose composed result IS renderer-driven — and sometimes a silent gap. The\n` +
-            `marker is what tells a reader which, in the place they are already looking.`,
+            `marker is what tells a reader which, in the place they are already looking — so the marker's own\n` +
+            `reason is resolved against the tree, because a false "both renderers drive it" reads as a reason\n` +
+            `not to look.`,
     );
     process.exit(1);
 }
 
-console.log(`check-adwaita-conformance-drivers: ${tables.length} vector tables, every one driven or explained.`);
+console.log(
+    `check-adwaita-conformance-drivers: ${tables.length} vector tables, ${resolved.exempted} core-only. ` +
+        `Resolved ${resolved.citations} citation(s): ${resolved.chains} coverage chain(s), ${resolved.both} ` +
+        `both-renderer claim(s), ${resolved.suite} single-suite claim(s), ${resolved.counted} counted glob(s).`,
+);

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -35,8 +35,14 @@
 //   4. driven by nothing at all                                            → FAIL
 //   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
 //
-// CLAIM arm — every comment SENTENCE in the core or either renderer that names a
-// vector table is resolved against reality:
+// "Driven" means a renderer's `*.spec.ts` names the table OUTSIDE a comment. Both
+// halves were bought: this branch's own corrective comment spelled five table names
+// out in a renderer file, and thereby made the gate read them as browser-driven.
+//
+// CLAIM arm — every comment CLAUSE in the core or either renderer that names a
+// vector table is resolved against reality. The clause, not the sentence: "only
+// NativeScript drives X" and "…, unlike Y, which stays core-only" are how English
+// states single-renderer coverage, and both were rejected as false claims.
 //   6. a `*_VECTORS` name or `A/B_VECTORS` pair that matches no declared table → FAIL
 //      (a `PREFIX_*` glob expanding to nothing is NOT a citation — these trees
 //      are ports of C and cite upstream enum families the same way)
@@ -49,11 +55,18 @@
 //      does not drive                                                      → FAIL
 //  10. a `CORE-ONLY:` reason citing a table as its coverage, where no chain of
 //      citations from it reaches a renderer-driven table                   → FAIL
+//  11. a `CORE-ONLY:` reason that names no table and is not a ledgered GAP  → FAIL
 //
-// A citation is exempt from 10 when the sentence spells a PRECEDENT ("same as X")
-// rather than coverage: `TOOLBAR_VIEW_MEASURE_VECTORS` says its reason is the one
-// `TOOLBAR_VIEW_ALLOCATE_VECTORS` gives, which is not a claim that ALLOCATE covers
-// it. A checker that cannot tell those apart reports a true sentence as false.
+// 10 reads only citations whose own clause is PHRASED as coverage. A reason cites a
+// table for other reasons too — as a precedent (`TOOLBAR_VIEW_MEASURE_VECTORS` says
+// its reason is the one `TOOLBAR_VIEW_ALLOCATE_VECTORS` gives, which is not a claim
+// that ALLOCATE covers it), as a concession, as a contrast. Precedents are not left
+// unchecked by that: the cited table is a table, so the TABLE arm holds its header.
+//
+// 11 is what makes an exemption falsifiable at all. Without it the cheapest way to
+// write one is to name nothing — `CORE-ONLY: both renderers exercise this already
+// through their real widgets` passed every other arm, because they all key off a
+// citation. Three of the 43 exemptions were that shape.
 //
 // MODULE arm — the table arm is TABLE-keyed, so core behaviour with no table at
 // all is invisible to it. Every module in `adwaita-core/src` therefore needs a
@@ -109,8 +122,15 @@ const MODULE_REASONS = {
 /** `PREFIX_*[_VECTORS]` glob | `A/B_VECTORS` pair | a plain table name. */
 const CITATION =
     /\b([A-Z][A-Z0-9_]*_)\*(?:_VECTORS)?|\b([A-Z][A-Z0-9_]*)\/([A-Z][A-Z0-9_]*_VECTORS)|\b[A-Z][A-Z0-9_]*_VECTORS\b/g;
-/** "for the same reason as X" — cites X as a precedent, not as coverage. */
-const PRECEDENT = /\bsame (?:as|reason as|rule as|gap as)\b/i;
+/**
+ * A citation is a COVERAGE claim only where the clause around it says so. The default is
+ * the other way: a reason cites a table for lots of reasons — as a precedent ("same as X"),
+ * as a concession ("its other reachers go through X, which stays core-only"), as a contrast.
+ * This started as a four-phrase whitelist of precedent spellings, which reported "GAP for the
+ * reason X gives" as a coverage claim: an unrecognised TRUE spelling became an accusation.
+ * Naming the coverage spellings instead makes an unrecognised one silent.
+ */
+const COVERAGE_PHRASING = /\b(?:driven|drives?|driving|covered|asserted|asserts|held to|the RESULT is|same thing twice)\b/i;
 /**
  * Three spellings OCCUR — "both renderers", "both drive", "Both ports" — and two of the three
  * false claims used the rarer two, so a checker that knows one spelling misses most of them.
@@ -124,6 +144,9 @@ const SUITE_CLAIMS = [
     { label: 'nativescript', pattern: /\bNativeScript\b/i },
 ];
 const COVERAGE_VERB = /\b(?:suite|drives?|driven by|held to|asserts)\b/i;
+/** An exemption that offers no coverage is a GAP, and a GAP with no anchor has no retirement. */
+const GAP_REASON = /\bGAP\b/;
+const GAP_ANCHOR = /#\d+/;
 const COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
 
 function walk(dir) {
@@ -218,6 +241,25 @@ const lineOf = (block, spelling) => block.segments.find((segment) => segment.tex
 const sentencesIn = (text) => text.split(/(?<=\.)\s+(?=[A-Z`(])/);
 
 /**
+ * A sentence, cut where it turns: at the words that switch which side of a contrast you
+ * are on. The claim arms read CLAUSES, not sentences, because a sentence is not one claim.
+ * Three TRUE sentences were rejected while it was:
+ *   "Both renderers consume the derivation … and NEITHER is held to TAB_TOOLTIP_VECTORS"
+ *   "The browser works in CSS pixels …, so ONLY NativeScript drives SIDEBAR_WIDTH_VECTORS."
+ *   "Both renderers drive TOOLBAR_VIEW_CLASS_VECTORS, UNLIKE TOOLBAR_VIEW_ALLOCATE_VECTORS…"
+ * Every one names the OTHER renderer, or the table that is NOT covered, in the same
+ * sentence — which is how you state single-renderer coverage in English. The tree was green
+ * only because its reasons had been worded around this: the split-view fix puts browser and
+ * NativeScript in separate sentences, and the TAB_TOOLTIP reason writes "these rows" rather
+ * than naming its own table. Dodged by wording is not satisfied.
+ *
+ * The marker STARTS the next clause, so the contrasted half is still read — it just no
+ * longer inherits the claim from the half before it.
+ */
+const CLAUSE_TURN = /(?=\b(?:but|unlike|neither|nor|rather than|instead|whereas|while|except|not|no|none|only)\b)/i;
+const clausesIn = (sentence) => sentence.split(CLAUSE_TURN);
+
+/**
  * The tables a citation names. `missing` is what the spelling promised and the tree
  * does not have; for a glob an empty `names` IS the miss.
  */
@@ -259,11 +301,15 @@ function citationsIn(text, declared) {
 }
 
 /**
- * The count word immediately before a citation, if the sentence states one. Digits count only
- * for a glob: before a single name, "at 96 dpi ADW_LENGTH_UNIT_VECTORS" is arithmetic and not
- * arity, and reading it as arity is how a checker invents findings.
+ * The count word immediately before a citation, if the sentence states one — for a spelling
+ * that CAN expand to several tables. A plain name always expands to exactly one, so the only
+ * count that ever passes is "one", and "the three TAB_TOOLTIP_VECTORS rows below" — counting
+ * ROWS, which is ordinary prose here — reads as an arity of three and fails. The digit case
+ * was already excluded for this reason ("at 96 dpi ADW_LENGTH_UNIT_VECTORS" is arithmetic);
+ * the spelled-word path was left open.
  */
 function statedCount(sentence, index, kind) {
+    if (kind === 'name') return undefined;
     const before = sentence.slice(0, index).replace(/[`'"\s]+$/, '');
     const word = /([A-Za-z]+|\d+)$/.exec(before)?.[1];
     if (!word) return undefined;
@@ -300,6 +346,19 @@ for (const table of tables) {
     reasons.set(table.name, text);
 }
 
+/** The unit both claim arms read: one clause of one sentence. */
+const claimUnitsIn = (text) => sentencesIn(text).flatMap(clausesIn);
+
+/** The tables a reason offers AS ITS COVERAGE — a citation whose own clause says so. */
+function coverageCitedIn(reason) {
+    const cited = [];
+    for (const clause of claimUnitsIn(reason)) {
+        if (!COVERAGE_PHRASING.test(clause)) continue;
+        for (const citation of citationsIn(clause, declared)) cited.push(...citation.names);
+    }
+    return cited;
+}
+
 /**
  * Does the exemption chain from `name` end at a table a renderer actually drives?
  * One hop is the common case (an intermediate step naming its composed result); the
@@ -312,12 +371,7 @@ function reachesADriver(name, seen = new Set()) {
     seen.add(name);
     const reason = reasons.get(name);
     if (!reason) return false;
-    for (const citation of citationsIn(reason, declared)) {
-        for (const cited of citation.names) {
-            if (cited !== name && reachesADriver(cited, seen)) return true;
-        }
-    }
-    return false;
+    return coverageCitedIn(reason).some((cited) => cited !== name && reachesADriver(cited, seen));
 }
 
 const failures = [];
@@ -347,18 +401,35 @@ for (const table of tables) {
         continue;
     }
     resolved.exempted += 1;
-    for (const sentence of sentencesIn(reason)) {
-        if (PRECEDENT.test(sentence)) continue;
-        const cited = citationsIn(sentence, declared).flatMap((citation) => citation.names);
-        for (const name of cited) {
-            if (name === table.name) continue;
-            resolved.chains += 1;
-            if (reachesADriver(name)) continue;
+    // Every exemption is one of exactly two things, and it has to say which. A reason that
+    // rests on another table NAMES it — as coverage (chain-resolved below) or as a precedent,
+    // whose own header the table arm checks in its own right. A reason that rests on nothing
+    // is a GAP, and says so with somewhere to close it from. The third shape — prose that
+    // reads like coverage and names nothing — is the cheapest unfalsifiable exemption there
+    // is, and no arm can see it: `CORE-ONLY: both renderers exercise this through their real
+    // widgets` passed everything. Three of the 43 were that shape; two were measurably false.
+    const named = citationsIn(reason, declared)
+        .flatMap((citation) => citation.names)
+        .filter((name) => name !== table.name);
+    const coverage = coverageCitedIn(reason).filter((name) => name !== table.name);
+    if (named.length === 0) {
+        if (!GAP_REASON.test(reason)) {
             failures.push(
-                `${where}: its reason cites ${name} as the coverage that makes this table redundant, but ` +
-                    `no chain of citations from ${name} reaches a table any renderer drives.`,
+                `${where}: its ${CORE_ONLY_MARKER} reason names no table, so no part of it is checkable. ` +
+                    `Name the table whose coverage makes this one redundant, or spell it ` +
+                    `"${CORE_ONLY_MARKER} GAP — <why no renderer can drive it>. Tracked in #<issue>".`,
             );
+        } else if (!GAP_ANCHOR.test(reason)) {
+            failures.push(`${where}: a ${CORE_ONLY_MARKER} GAP with no issue anchor has no owner and no retirement.`);
         }
+    }
+    for (const name of coverage) {
+        resolved.chains += 1;
+        if (reachesADriver(name)) continue;
+        failures.push(
+            `${where}: its reason cites ${name} as the coverage that makes this table redundant, but ` +
+                `no chain of citations from ${name} reaches a table any renderer drives.`,
+        );
     }
 }
 
@@ -367,8 +438,8 @@ for (const table of tables) {
 // `adw-data-grid.ts` put its "Both ports" a renderer-tree away from any conformance file.
 for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]) {
     for (const block of walk(dir).flatMap(commentBlocks)) {
-        for (const sentence of sentencesIn(block.text)) {
-            const citations = citationsIn(sentence, declared);
+        for (const clause of claimUnitsIn(block.text)) {
+            const citations = citationsIn(clause, declared);
             if (citations.length === 0) continue;
             for (const citation of citations) {
                 const where = `${relative(ROOT, block.file)}:${lineOf(block, citation.spelling)}`;
@@ -376,7 +447,7 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                 for (const name of citation.missing) {
                     failures.push(`${where}: names ${name}, which no conformance file declares.`);
                 }
-                const stated = statedCount(sentence, citation.index, citation.kind);
+                const stated = statedCount(clause, citation.index, citation.kind);
                 if (stated !== undefined) {
                     resolved.counted += 1;
                     if (stated !== citation.names.length) {
@@ -386,7 +457,7 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                     }
                 }
                 if (citation.names.length === 0) continue;
-                if (BOTH_CLAIM.test(sentence)) {
+                if (BOTH_CLAIM.test(clause)) {
                     resolved.both += 1;
                     for (const { label } of RENDERERS) {
                         const undriven = citation.names.filter((name) => !byLabel.get(label).has(name));
@@ -399,7 +470,7 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                     }
                 }
                 for (const { label, pattern } of SUITE_CLAIMS) {
-                    if (!pattern.test(sentence) || !COVERAGE_VERB.test(sentence)) continue;
+                    if (!pattern.test(clause) || !COVERAGE_VERB.test(clause)) continue;
                     resolved.suite += 1;
                     const undriven = citation.names.filter((name) => !byLabel.get(label).has(name));
                     if (undriven.length > 0) {

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -108,8 +108,13 @@ const CITATION =
     /\b([A-Z][A-Z0-9_]*_)\*(?:_VECTORS)?|\b([A-Z][A-Z0-9_]*)\/([A-Z][A-Z0-9_]*_VECTORS)|\b[A-Z][A-Z0-9_]*_VECTORS\b/g;
 /** "for the same reason as X" — cites X as a precedent, not as coverage. */
 const PRECEDENT = /\bsame (?:as|reason as|rule as|gap as)\b/i;
-/** The three spellings that occur; two of the three false claims used the rarer two. */
-const BOTH_CLAIM = /\bboth\s+(?:renderer\s+suites?|renderers?|ports?|suites?|elements?|drive)\b/i;
+/**
+ * Three spellings OCCUR — "both renderers", "both drive", "Both ports" — and two of the three
+ * false claims used the rarer two, so a checker that knows one spelling misses most of them.
+ * "both sides" and "the two ports" say the same thing and are matched pre-emptively.
+ */
+const BOTH_CLAIM =
+    /\bboth\s+(?:renderer\s+suites?|renderers?|ports?|suites?|elements?|sides|drive)\b|\bthe two (?:renderers?|ports?|suites?)\b/i;
 /** A named renderer plus a coverage verb — "driven by the browser suite", "NativeScript drives X". */
 const SUITE_CLAIMS = [
     { label: 'adwaita-web', pattern: /\b(?:browser|adwaita-web)\b/i },
@@ -232,12 +237,16 @@ function citationsIn(text, declared) {
     return found;
 }
 
-/** The count word immediately before a citation, if the sentence states one. */
-function statedCount(sentence, index) {
+/**
+ * The count word immediately before a citation, if the sentence states one. Digits count only
+ * for a glob: before a single name, "at 96 dpi ADW_LENGTH_UNIT_VECTORS" is arithmetic and not
+ * arity, and reading it as arity is how a checker invents findings.
+ */
+function statedCount(sentence, index, kind) {
     const before = sentence.slice(0, index).replace(/[`'"\s]+$/, '');
     const word = /([A-Za-z]+|\d+)$/.exec(before)?.[1];
     if (!word) return undefined;
-    if (/^\d+$/.test(word)) return Number(word);
+    if (/^\d+$/.test(word)) return kind === 'glob' ? Number(word) : undefined;
     const spelled = COUNT_WORDS.indexOf(word.toLowerCase());
     return spelled === -1 ? undefined : spelled;
 }
@@ -350,12 +359,14 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                     failures.push(`${where}: the glob ${citation.spelling} matches no declared table.`);
                     continue;
                 }
-                const stated = statedCount(sentence, citation.index);
-                if (citation.kind === 'glob' && stated !== undefined) resolved.counted += 1;
-                if (citation.kind === 'glob' && stated !== undefined && stated !== citation.names.length) {
-                    failures.push(
-                        `${where}: says ${stated} ${citation.spelling} tables; the tree declares ${citation.names.length}.`,
-                    );
+                const stated = statedCount(sentence, citation.index, citation.kind);
+                if (stated !== undefined) {
+                    resolved.counted += 1;
+                    if (stated !== citation.names.length) {
+                        failures.push(
+                            `${where}: says ${stated} ${citation.spelling} table(s); the tree declares ${citation.names.length}.`,
+                        );
+                    }
                 }
                 if (citation.names.length === 0) continue;
                 if (BOTH_CLAIM.test(sentence)) {

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -37,8 +37,9 @@
 //
 // CLAIM arm — every comment SENTENCE in the core or either renderer that names a
 // vector table is resolved against reality:
-//   6. a name, `PREFIX_*` glob or `A/B_VECTORS` pair that matches no declared
-//      table                                                               → FAIL
+//   6. a `*_VECTORS` name or `A/B_VECTORS` pair that matches no declared table → FAIL
+//      (a `PREFIX_*` glob expanding to nothing is NOT a citation — these trees
+//      are ports of C and cite upstream enum families the same way)
 //   7. a counted citation ("the five OVERLAY_SWIPE_* tables") whose count is
 //      wrong. `OVERLAY_SWIPE_*` IS five real tables, so the arity is the whole
 //      question: a checker that rejected globs would reject a true sentence  → FAIL
@@ -225,13 +226,14 @@ function citationsIn(text, declared) {
     for (const match of text.matchAll(CITATION)) {
         const [spelling, globPrefix, pairHead, pairTail] = match;
         if (globPrefix) {
-            found.push({
-                spelling,
-                kind: 'glob',
-                index: match.index,
-                names: [...declared].filter((name) => name.startsWith(globPrefix)),
-                missing: [],
-            });
+            const expanded = [...declared].filter((name) => name.startsWith(globPrefix));
+            // A glob that expands to NOTHING is not a citation. These trees are ports of C
+            // and cite upstream constant families the same way — `GTK_STATE_FLAG_*`,
+            // `ADW_TOAST_PRIORITY_*`, and `O_*`/`DH_CHECK_*` elsewhere in the repo. Reading
+            // those as broken table citations rejected true sentences, and this gate carries
+            // no `paths:` filter, so one such comment blocks every merge in the repo.
+            if (expanded.length === 0) continue;
+            found.push({ spelling, kind: 'glob', index: match.index, names: expanded, missing: [] });
         } else if (pairHead) {
             const shared = pairHead.slice(0, pairHead.lastIndexOf('_') + 1);
             const expanded = [`${pairHead}_VECTORS`, `${shared}${pairTail}`];
@@ -373,10 +375,6 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                 resolved.citations += 1;
                 for (const name of citation.missing) {
                     failures.push(`${where}: names ${name}, which no conformance file declares.`);
-                }
-                if (citation.kind === 'glob' && citation.names.length === 0) {
-                    failures.push(`${where}: the glob ${citation.spelling} matches no declared table.`);
-                    continue;
                 }
                 const stated = statedCount(sentence, citation.index, citation.kind);
                 if (stated !== undefined) {

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -128,7 +128,8 @@ const CITATION =
  * a precedent, a concession, a contrast. Naming the four PRECEDENT spellings instead, as this
  * started out, made an unrecognised TRUE one ("GAP for the reason X gives") an accusation.
  */
-const COVERAGE_PHRASING = /\b(?:driven|drives?|driving|covered|asserted|asserts|held to|the RESULT is|same thing twice)\b/i;
+const COVERAGE_PHRASING =
+    /\b(?:driven|drives?|driving|covered|asserted|asserts|held to|the RESULT is|same thing twice)\b/i;
 /**
  * Three spellings OCCUR — "both renderers", "both drive", "Both ports" — and two of the three
  * false claims used the rarer two, so a checker that knows one spelling misses most of them.
@@ -229,7 +230,8 @@ function commentBlocks(file) {
 }
 
 /** The source line a citation sits on — a 50-line header is not an address. */
-const lineOf = (block, spelling) => block.segments.find((segment) => segment.text.includes(spelling))?.line ?? block.line;
+const lineOf = (block, spelling) =>
+    block.segments.find((segment) => segment.text.includes(spelling))?.line ?? block.line;
 
 /** Split on sentence ends only where a new sentence plausibly starts — `adw-tab-view.ts` must not split. */
 const sentencesIn = (text) => text.split(/(?<=\.)\s+(?=[A-Z`(])/);
@@ -369,7 +371,9 @@ for (const table of tables) {
         // ratchets one way: a table that gains a driver keeps its excuse forever, and
         // the next reader takes "CORE-ONLY" for the current state of the port.
         if (reasons.has(table.name)) {
-            failures.push(`${where}: renderer-driven, but still carries "${CORE_ONLY_MARKER}" — it landed, drop the marker.`);
+            failures.push(
+                `${where}: renderer-driven, but still carries "${CORE_ONLY_MARKER}" — it landed, drop the marker.`,
+            );
         }
         continue;
     }
@@ -457,7 +461,9 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
                     resolved.suite += 1;
                     const undriven = citation.names.filter((name) => !byLabel.get(label).has(name));
                     if (undriven.length > 0) {
-                        failures.push(`${where}: credits the ${label} suite with ${undriven.join(', ')}, which it does not drive.`);
+                        failures.push(
+                            `${where}: credits the ${label} suite with ${undriven.join(', ')}, which it does not drive.`,
+                        );
                     }
                 }
             }
@@ -492,10 +498,12 @@ for (const file of walk(CORE_SUITE_DIR)) {
     // for a field and proves nothing, and it was the whole of what covered `length-unit.ts`.
     const valueImport = new RegExp(`import\\s+(?!type\\b)[^;]*?from '\\.\\./${module}\\.js'`);
     const covered =
-        conformanceFiles.some((candidate) => candidate.endsWith(`/${module}.ts`)) || valueImport.test(conformanceSource);
+        conformanceFiles.some((candidate) => candidate.endsWith(`/${module}.ts`)) ||
+        valueImport.test(conformanceSource);
     const reason = MODULE_REASONS[module];
     if (covered) {
-        if (reason) failures.push(`${where}: listed in MODULE_REASONS, but conformance covers it now — drop the entry.`);
+        if (reason)
+            failures.push(`${where}: listed in MODULE_REASONS, but conformance covers it now — drop the entry.`);
         continue;
     }
     if (!reason) {

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -69,10 +69,19 @@
 // citation. Three of the 43 exemptions were that shape.
 //
 // MODULE arm — the table arm is TABLE-keyed, so core behaviour with no table at
-// all is invisible to it. Every module in `adwaita-core/src` therefore needs a
-// conformance file of its own, a conformance file that imports it, or an entry in
-// MODULE_REASONS below — itself checked, against the declared tables and against
+// all is invisible to it. Every module under `adwaita-core/src` that exports
+// behaviour therefore needs a conformance file of its own, a conformance file that
+// imports it FOR VALUE, or an entry in MODULE_REASONS below — itself checked,
+// against the declared tables, against whether a renderer drives them, and against
 // the open-item ledger.
+//
+// WHAT IT DOES NOT CHECK: "driven" is a name used outside a comment in a spec, so a
+// spec that imports a table and filters the interesting rows away still counts as
+// driving it. Six tables are referenced only through a `.filter(` today. Measured
+// and ledgered under "A table can be 'driven' while the rows that matter are
+// skipped" rather than half-guarded: the `.filter(` form is mechanical, the
+// `continue`-guard form beside it is not, and a rule that catches two shapes of a
+// three-shape class reads as covering the class.
 //
 // The `CORE-ONLY:` line belongs in the TABLE's own header, not a renderer's
 // source: #1072 found three `TOOLBAR_VIEW_*` tables whose reason lived in both
@@ -101,20 +110,29 @@ const OPEN_TODOS = join(ROOT, 'status/open-todos.md');
 /** The marker a core-only table must carry, in its own header. */
 const CORE_ONLY_MARKER = 'CORE-ONLY:';
 
-/** The open-item heading the four table-less core modules are ledgered under. */
-const NO_TABLE_LEDGER = 'Four adwaita-core modules have no conformance vector table';
+/**
+ * The open-item headings a module-level gap is ledgered under. Count-free ON PURPOSE: the
+ * first spelling was "Four adwaita-core modules …", matched here as a literal string, so
+ * closing one gap made the heading false and correcting it meant editing THIS FILE in the
+ * same change. AGENTS.md forbids a live count in a comment; inside a required check it is
+ * worse than drift.
+ */
+const NO_TABLE_LEDGER = 'adwaita-core modules with no conformance vector table';
+const NO_DRIVER_LEDGER = 'adwaita-core modules whose only vector table is core-only';
 
 /**
- * Core modules with no conformance file named after them and no conformance file
- * importing them. `table` — its vectors live in another file under that name;
- * `gap` — no vector table exists, and the named `###` heading must be an open item
- * in `status/open-todos.md`, so the gap has a place to be closed from.
+ * Core modules with no conformance file named after them and none importing them for VALUE.
+ * `table` — its vectors live in another file under that name; `gap` — the named `###` heading
+ * must be an open item in `status/open-todos.md`, so the gap has a place to be closed from.
+ * Both, where the vectors exist but no renderer drives THEM either: those are different facts
+ * and the entry has to state both, or "explained" quietly means "unexamined".
  */
 const MODULE_REASONS = {
     breakpoint: { gap: NO_TABLE_LEDGER },
     'color-scheme': { gap: NO_TABLE_LEDGER },
-    easing: { table: 'SPINNER_ARC_PHASE_VECTORS' },
-    glib: { table: 'GLIB_CLAMP_VECTORS' },
+    easing: { table: 'SPINNER_ARC_PHASE_VECTORS', gap: NO_DRIVER_LEDGER },
+    glib: { table: 'GLIB_CLAMP_VECTORS', gap: NO_DRIVER_LEDGER },
+    'length-unit': { table: 'ADW_LENGTH_UNIT_VECTORS', gap: NO_DRIVER_LEDGER },
     scrolling: { gap: NO_TABLE_LEDGER },
     toast: { gap: NO_TABLE_LEDGER },
 };
@@ -487,19 +505,30 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
 // `scrolling` and `toast` had no vector table at all, three of them named in
 // packages/web/AGENTS.md as the core's flagship shared behaviour, and the ledger that
 // reported "156 tables, every one driven or explained" said nothing about any of them.
-const conformanceSource = walk(CONFORMANCE_DIR)
-    .map((file) => readFileSync(file, 'utf8'))
-    .join('\n');
+const conformanceFiles = walk(CONFORMANCE_DIR);
+const conformanceSource = conformanceFiles.map((file) => readFileSync(file, 'utf8')).join('\n');
 const openTodos = readFileSync(OPEN_TODOS, 'utf8');
 
-for (const entry of readdirSync(CORE_SUITE_DIR, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.endsWith('.spec.ts')) continue;
-    const module = entry.name.slice(0, -3);
+/** Does this module export anything a renderer could be held to? */
+const HAS_BEHAVIOUR = /^export\s+(?:async\s+)?(?:const|function|class|let|var|enum|default)\b/m;
+
+for (const file of walk(CORE_SUITE_DIR)) {
+    // Recursive, unlike the readdir this arm started with — the arm exists because the table
+    // arm had an invisible set, and a non-recursive scan reproduces that one directory down.
+    if (file.startsWith(CONFORMANCE_DIR) || file.endsWith('.spec.ts')) continue;
+    const module = relative(CORE_SUITE_DIR, file).slice(0, -3);
     if (module === 'index') continue;
-    const where = `packages/web/adwaita-core/src/${entry.name}`;
+    const source = readFileSync(file, 'utf8');
+    // A module of pure types has no behaviour to vector, so demanding vectors for it would
+    // force the author to invent a table or a ledger item. Derived, not allowlisted.
+    if (!HAS_BEHAVIOUR.test(source)) continue;
+    const where = `${relative(ROOT, file)}`;
+    // A VALUE import. `import type { AdwLengthUnit } from '../length-unit.js'` proves nothing
+    // about vectors — it borrows a name for a field — and that is the whole of what covered
+    // `length-unit.ts`.
+    const valueImport = new RegExp(`import\\s+(?!type\\b)[^;]*?from '\\.\\./${module}\\.js'`);
     const covered =
-        walk(CONFORMANCE_DIR).some((file) => file.endsWith(`/${entry.name}`)) ||
-        conformanceSource.includes(`from '../${module}.js'`);
+        conformanceFiles.some((candidate) => candidate.endsWith(`/${module}.ts`)) || valueImport.test(conformanceSource);
     const reason = MODULE_REASONS[module];
     if (covered) {
         if (reason) failures.push(`${where}: listed in MODULE_REASONS, but conformance covers it now — drop the entry.`);
@@ -507,12 +536,24 @@ for (const entry of readdirSync(CORE_SUITE_DIR, { withFileTypes: true })) {
     }
     if (!reason) {
         failures.push(
-            `${where}: no conformance file names or imports it, so no renderer is held to any of its ` +
-                `behaviour. Add vectors for it, or a MODULE_REASONS entry saying which table carries them.`,
+            `${where}: no conformance file is named after it and none imports it for value, so nothing ` +
+                `tables its behaviour. Add vectors for it, or a MODULE_REASONS entry saying which table carries them.`,
         );
-    } else if (reason.table && !declared.has(reason.table)) {
+        continue;
+    }
+    if (reason.table && !declared.has(reason.table)) {
         failures.push(`${where}: MODULE_REASONS points at ${reason.table}, which no conformance file declares.`);
-    } else if (reason.gap && !openTodos.includes(`### ${reason.gap}`)) {
+    }
+    // A `table:` naming a table no renderer drives explains where the vectors LIVE and nothing
+    // about who is held to them — which is the question this arm's finding text asks. Left at
+    // `declared.has()`, the entry reads as resolved while the module is held to nothing at all.
+    if (reason.table && declared.has(reason.table) && !byRenderer.has(reason.table) && !reason.gap) {
+        failures.push(
+            `${where}: its vectors live in ${reason.table}, which no renderer drives either — so no ` +
+                `renderer is held to this module. That is a gap; give the entry a ledger heading too.`,
+        );
+    }
+    if (reason.gap && !openTodos.includes(`### ${reason.gap}`)) {
         failures.push(`${where}: MODULE_REASONS calls this a gap under "${reason.gap}", which is not an open item.`);
     }
 }

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -78,6 +78,14 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
+
+// Every repo-relative path below is COMPARED against a `/`-spelled literal and printed into a
+// finding. On win32 `relative()` hands back `packages\web\…`, so the module arm matched nothing
+// and reported all 18 core modules as untabled — a red gate saying the opposite of the truth.
+// `toPosixPath` and not `replaceAll('\', '/')`: a backslash is a legal POSIX filename character.
+const rel = (from, to) => toPosixPath(relative(from, to));
+
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
@@ -365,7 +373,7 @@ const failures = [];
 /** What each arm actually resolved. A gate that reports only "green" cannot show it ran. */
 const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0 };
 for (const table of tables) {
-    const where = `${relative(ROOT, table.file)}:${table.line} → ${table.name}`;
+    const where = `${rel(ROOT, table.file)}:${table.line} → ${table.name}`;
     if (byRenderer.has(table.name)) {
         // The exemption is a claim about TODAY. Without this direction it only ever
         // ratchets one way: a table that gains a driver keeps its excuse forever, and
@@ -429,7 +437,7 @@ for (const dir of [CORE_SUITE_DIR, ...RENDERERS.map((renderer) => renderer.dir)]
             const citations = citationsIn(clause, declared);
             if (citations.length === 0) continue;
             for (const citation of citations) {
-                const where = `${relative(ROOT, block.file)}:${lineOf(block, citation.spelling)}`;
+                const where = `${rel(ROOT, block.file)}:${lineOf(block, citation.spelling)}`;
                 resolved.citations += 1;
                 for (const name of citation.missing) {
                     failures.push(`${where}: names ${name}, which no conformance file declares.`);
@@ -487,18 +495,18 @@ for (const file of walk(CORE_SUITE_DIR)) {
     // Recursive, unlike the readdir this arm started with: the arm exists because the table arm
     // had an invisible set, and a non-recursive scan reproduces that one directory down.
     if (file.startsWith(CONFORMANCE_DIR) || file.endsWith('.spec.ts')) continue;
-    const module = relative(CORE_SUITE_DIR, file).slice(0, -3);
+    const module = rel(CORE_SUITE_DIR, file).slice(0, -3);
     if (module === 'index') continue;
     const source = readFileSync(file, 'utf8');
     // Skipping a types-only module is DERIVED, not allowlisted — there is nothing to vector, so
     // demanding vectors forces the author to invent a table or a ledger item.
     if (!HAS_BEHAVIOUR.test(source)) continue;
-    const where = `${relative(ROOT, file)}`;
+    const where = rel(ROOT, file);
     // A VALUE import: `import type { AdwLengthUnit } from '../length-unit.js'` borrows a name
     // for a field and proves nothing, and it was the whole of what covered `length-unit.ts`.
     const valueImport = new RegExp(`import\\s+(?!type\\b)[^;]*?from '\\.\\./${module}\\.js'`);
     const covered =
-        conformanceFiles.some((candidate) => candidate.endsWith(`/${module}.ts`)) ||
+        conformanceFiles.some((candidate) => toPosixPath(candidate).endsWith(`/${module}.ts`)) ||
         valueImport.test(conformanceSource);
     const reason = MODULE_REASONS[module];
     if (covered) {
@@ -531,7 +539,7 @@ for (const file of walk(CORE_SUITE_DIR)) {
 
 if (failures.length > 0) {
     console.error(`check-adwaita-conformance-drivers: ${failures.length} finding(s):\n`);
-    for (const failure of [...new Set(failures)]) console.error(`  - ${failure}`);
+    for (const failure of new Set(failures)) console.error(`  - ${failure}`);
     console.error(
         `\nA table with no renderer behind it asserts a derivation against itself. That is sometimes right —\n` +
             `an intermediate step whose composed result IS renderer-driven — and sometimes a silent gap. The\n` +

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2235,3 +2235,10 @@ change as this entry, since the browser half is held to none of them.
 normalisers from the core), so this is missing coverage rather than a known
 drift. Closing it is a browser-side spec over the five tables, in the shape
 `split-views.spec.ts` already uses.
+
+The correction BLINDED the gate that ledgered this, for one commit. Spelling the
+five names out in an `adwaita-web` comment made all five read as browser-driven,
+because "driven by X" was a plain text scan over every `.ts` under X — comments
+included. The original defect was caught only because it used the glob spelling
+`DATA_GRID_*_VECTORS`, which contains no individual name. Fixed by resolving
+drivers from usage: names outside a comment, in a `*.spec.ts`.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2137,3 +2137,52 @@ docblock stops calling itself shared and the field narrows to the NativeScript
 theming path it actually serves. Deferred out of the gate PR that measured it,
 because either direction is a behaviour change and would make a review of the
 gate impossible.
+
+### `AdwToastOverlay`'s `timeout` option means seconds on one port and milliseconds on the other
+
+Measured 2026-08-21, while checking a reported "the toast default is 5000 in the
+core and 5 in the browser element" — which is NOT a defect. `refs/libadwaita`
+settles the units: `adw-toast.c:385` documents `AdwToast:timeout` as "the timeout
+of the toast, **in seconds**" and `adw-toast.c:475` sets `self->timeout = 5`.
+adwaita-core counts MILLISECONDS and says so on every field, so
+`DEFAULT_TOAST_TIMEOUT = 5000` is 5 s and is right; `adw-toast-overlay.ts` takes
+SECONDS as its public unit, `DEFAULT_TIMEOUT_SECONDS = 5` mirrors
+`Adw.Toast:timeout` exactly, and it converts once at the boundary (`* 1000`,
+line 142) — also right. Nothing vanishes in 5 ms or lingers for 5000 s.
+
+The real divergence is one level out, between the two RENDERERS. Both export a
+class called `AdwToastOverlay` taking an options bag whose field is called
+`timeout`, and the two mean different things:
+
+- `adwaita-web` — `addToast(title, { timeout })` is SECONDS (its own
+  `AdwToastOptions` interface). Its spec writes `{ timeout: 3 }` for three seconds.
+- `@gjsify/adwaita-nativescript` — `showToast(title, { timeout })` passes the
+  bag straight to `new AdwToast(...)`, so it is the CORE's `AdwToastOptions`,
+  i.e. MILLISECONDS. Its spec writes `{ timeout: 3000 }` for the same three seconds.
+
+`{ timeout: 5 }` is therefore a five-second toast in the browser and a five-
+MILLISECOND toast on NativeScript. Each suite is internally consistent, which is
+why neither catches it, and no conformance vector table covers `toast.ts` at all
+(see the module-gap entry above), so nothing holds the two ports to one answer.
+
+Fixing it is a public-API change on one of the two ports and wants a decision
+first: libadwaita's own spelling is seconds, which argues for the browser being
+right and the NativeScript wrapper growing the same `* 1000` boundary — at the
+cost of breaking anyone passing milliseconds today. Deferred out of the gate PR
+that measured it; a behaviour change would have made that PR unreviewable.
+
+### Nothing holds `adwaita-web`'s data grid to the shared data-grid vectors
+
+`DATA_GRID_TRACK_VECTORS`, `DATA_GRID_COLUMN_CLASS_VECTORS`,
+`DATA_GRID_VARIANT_VECTORS`, `DATA_GRID_CELL_TEXT_VECTORS` and
+`DATA_GRID_INTERACTIVE_VECTORS` are driven by
+`packages/nativescript-bridge/adwaita/src/data-grid.spec.ts` alone. The string
+`DATA_GRID` occurred exactly once anywhere in `adwaita-web`, in a comment
+claiming "Both ports are held to `DATA_GRID_*_VECTORS`" — corrected in the same
+change as this entry, since the browser half is held to none of them.
+
+`adw-data-grid.ts` does delegate correctly (it imports `dataGridTracks`,
+`dataGridColumnClasses`, `dataGridCellText`, `dataGridRowInteractive` and both
+normalisers from the core), so this is missing coverage rather than a known
+drift. Closing it is a browser-side spec over the five tables, in the shape
+`split-views.spec.ts` already uses.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2087,7 +2087,7 @@ parsing out of the file it names, because a pasted structure is unambiguously a
 quote rather than a mention. There is about one such fragment here, so that
 machinery would be honest and nearly idle, which is the correct size for it.
 
-### Four adwaita-core modules have no conformance vector table
+### adwaita-core modules with no conformance vector table
 
 `breakpoint.ts`, `color-scheme.ts`, `scrolling.ts` and `toast.ts` export shared
 behaviour and are covered by nothing in `@gjsify/adwaita-core/conformance` — no
@@ -2108,6 +2108,52 @@ against `refs/libadwaita/src/adw-breakpoint.c`; scrolling wants the undershoot
 and overshoot arithmetic; the toast queue wants a scheduler seam both renderers
 already have. `color-scheme` is entangled with the divergence below and should be
 vectored after it is decided, not before.
+
+The heading carries no count on purpose. It named "Four" while four
+`MODULE_REASONS` entries matched it as a literal string, so closing one gap
+would have made the heading false and correcting it would have required editing
+`scripts/check-adwaita-conformance-drivers.mjs` in the same change — a live
+count, load-bearing inside a required check.
+
+### adwaita-core modules whose only vector table is core-only
+
+`easing.ts`, `glib.ts` and `length-unit.ts` DO have vectors — respectively
+`SPINNER_ARC_PHASE_VECTORS`, `GLIB_CLAMP_VECTORS` and `ADW_LENGTH_UNIT_VECTORS`
+— but every one of those tables is itself `CORE-ONLY:`, so no renderer suite is
+held to any of the three modules. `length-unit.ts` was worse than invisible: the
+module arm counted it covered because `conformance/split-view.ts` carries
+`import type { AdwLengthUnit } from '../length-unit.js'`, a type-only import
+that borrows a name for a field and proves nothing about vectors.
+
+Not the same gap as the four above, and it should not be filed under their
+heading: those modules have no table to drive, these have one nobody drives.
+`glibClamp` is the sharpest case — `adw-progress-bar.ts` calls it directly in
+the browser, so the seam exists; what is missing is a spec row that varies the
+bounds far enough to tell `CLAMP` from `Math.min`/`Math.max`. The
+`resolveNavigationSidebarWidth` path already does that through
+`SIDEBAR_WIDTH_VECTORS`, which is why `GLIB_CLAMP_VECTORS`' own exemption is a
+chain rather than a gap; the module is still held to nothing under its own name.
+
+### A table can be "driven" while the rows that matter are skipped
+
+`consumersUnder()` counts a table driven when a renderer's `*.spec.ts` names it
+outside a comment. That cannot distinguish iterating the table from importing it
+and filtering the interesting rows away, and six tables are only ever referenced
+through a `.filter(` today: `ABOUT_DIALOG_DETAILS_VECTORS`,
+`ABOUT_DIALOG_SUPPORT_VECTORS`, `ABOUT_DIALOG_CREDITS_LEGAL_VECTORS`,
+`BUTTON_STYLE_CLASS_VECTORS`, `CAROUSEL_PAGE_ALLOCATION_VECTORS` and
+`CLAMP_ALLOCATE_VECTORS`. Both renderer suites filter `CLAMP_ALLOCATE_VECTORS`
+to `params.childMin === 0`, and three `CLAMP_*` tables are exempted as an
+internal step of the pipeline it composes — a chain that does not carry the
+non-zero-`childMin` rows. `adw-about-dialog.spec.ts` does the same thing with a
+`continue` guard rather than a filter, which no textual rule sees at all.
+
+The measurable half (`X_VECTORS.filter(`) is about six lines of gate. It is
+deliberately NOT implemented yet, because it catches the filter form and not the
+`continue` form that motivated the finding, and a rule that covers two of three
+shapes of a class reads as covering the class. Closing this means deciding per
+chain whether the conceded rows matter, then either widening the specs or
+narrowing the reasons to the rows they really carry — reason work, not gate work.
 
 ### adwaita-web does not use the color-scheme singleton at all
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2145,8 +2145,13 @@ through a `.filter(` today: `ABOUT_DIALOG_DETAILS_VECTORS`,
 `CLAMP_ALLOCATE_VECTORS`. Both renderer suites filter `CLAMP_ALLOCATE_VECTORS`
 to `params.childMin === 0`, and three `CLAMP_*` tables are exempted as an
 internal step of the pipeline it composes — a chain that does not carry the
-non-zero-`childMin` rows. `adw-about-dialog.spec.ts` does the same thing with a
-`continue` guard rather than a filter, which no textual rule sees at all.
+non-zero-`childMin` rows. Two of the three now say so in their own reason
+(`CLAMP_THRESHOLD_VECTORS`, three rows; `CLAMP_CHILD_SIZE_VECTORS`, one);
+`CLAMP_SIZE_FROM_CHILD_VECTORS` needs nothing, every row of it runs at
+`childMin: 0`. `adw-about-dialog.spec.ts` does the same thing with a `continue`
+guard rather than a filter, which no textual rule sees at all — that is what put
+the `g_strsplit ("")` translator-credits trap behind a false chain, now re-filed
+as a GAP.
 
 The measurable half (`X_VECTORS.filter(`) is about six lines of gate. It is
 deliberately NOT implemented yet, because it catches the filter form and not the

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2086,3 +2086,54 @@ check — a JSON or YAML FRAGMENT an entry pastes verbatim can be held to still
 parsing out of the file it names, because a pasted structure is unambiguously a
 quote rather than a mention. There is about one such fragment here, so that
 machinery would be honest and nearly idle, which is the correct size for it.
+
+### Four adwaita-core modules have no conformance vector table
+
+`breakpoint.ts`, `color-scheme.ts`, `scrolling.ts` and `toast.ts` export shared
+behaviour and are covered by nothing in `@gjsify/adwaita-core/conformance` — no
+vector table names them, and no conformance file imports them. Three of the four
+are what `packages/web/AGENTS.md` advertises as the core's flagship shared
+behaviour ("Breakpoints (grammar/parser/evaluator + transition-only
+`AdwBreakpoint`), color-scheme observable, toast queue").
+
+They were invisible rather than under-covered: `check-adwaita-conformance-drivers.mjs`
+is keyed by TABLE, so it reported "156 vector tables, every one driven or
+explained" over a set none of these four is in. The gate now carries a
+module-keyed arm and these four are its declared exceptions
+(`MODULE_REASONS`), which is what makes them countable.
+
+Each needs its own vectors before a renderer can be held to it, and each is a
+different shape of work: the breakpoint grammar wants a parse/evaluate table
+against `refs/libadwaita/src/adw-breakpoint.c`; scrolling wants the undershoot
+and overshoot arithmetic; the toast queue wants a scheduler seam both renderers
+already have. `color-scheme` is entangled with the divergence below and should be
+vectored after it is decided, not before.
+
+### adwaita-web does not use the color-scheme singleton at all
+
+`packages/web/adwaita-core/src/color-scheme.ts` documents itself as "the single
+source of truth for the current Adwaita color scheme plus a change notifier,
+shared by every renderer (ADR 0004)". Measured 2026-08-21: `adwaita-web` calls
+none of its seven exports — not `adwaitaColorScheme`, `setAdwaitaColorScheme`,
+`toggleAdwaitaColorScheme`, `onAdwaitaColorSchemeChanged`, `themeIconColor`,
+`isThemeIconColor`, nor either `DEFAULT_ICON_COLOR*`. It answers the question
+itself in `src/accent.ts:55` (`isAdwaitaDark`), reading `.theme-dark` /
+`.theme-light` and falling back to `matchMedia('(prefers-color-scheme: dark)')`.
+The NativeScript bridge, by contrast, re-exports all of it and subscribes from
+`adw-icon` and `adw-image-button`.
+
+So `setAdwaitaColorScheme('dark')` is a no-op in the browser, and the two ports
+disagree about where the scheme lives while the core claims to be that place.
+Not obviously a bug in adwaita-web: a browser renderer that ignored
+`prefers-color-scheme` and the stylesheet's own manual override classes would be
+the wrong thing, and the core's own header already concedes that "applying the
+scheme to a surface is the renderer's job". What is wrong is the core's claim to
+be the SOURCE, which nothing holds it to on the browser side.
+
+The decision to make is which way the singleton points: either the browser
+element learns to seed and follow it (`isAdwaitaDark` becomes the platform half
+that feeds `setAdwaitaColorScheme`, media-query listener included), or the core
+docblock stops calling itself shared and the field narrows to the NativeScript
+theming path it actually serves. Deferred out of the gate PR that measured it,
+because either direction is a behaviour change and would make a review of the
+gate impossible.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2204,7 +2204,10 @@ class called `AdwToastOverlay` taking an options bag whose field is called
   `AdwToastOptions` interface). Its spec writes `{ timeout: 3 }` for three seconds.
 - `@gjsify/adwaita-nativescript` — `showToast(title, { timeout })` passes the
   bag straight to `new AdwToast(...)`, so it is the CORE's `AdwToastOptions`,
-  i.e. MILLISECONDS. Its spec writes `{ timeout: 3000 }` for the same three seconds.
+  i.e. MILLISECONDS. This wrapper has NO spec of its own: `widgets/adw-toast-overlay.ts`
+  is untested, and the `{ timeout: 3000 }` at `index.spec.ts:731` constructs
+  `AdwToast`/`AdwToastQueue` directly, never reaching the overlay. That makes the case
+  stronger, not weaker — the diverging wrapper is the untested one.
 
 `{ timeout: 5 }` is therefore a five-second toast in the browser and a five-
 MILLISECOND toast on NativeScript. Each suite is internally consistent, which is


### PR DESCRIPTION
`check-adwaita-conformance-drivers.mjs` is the largest Adwaita ledger and the one that checked least. It
reported *"156 vector tables, every one driven or explained"*. For the 43 exempt tables, "explained" meant only
that the literal string `CORE-ONLY:` appeared somewhere in the table's own header. **The reason text was never
read.**

This is precisely the incident the gate's own docblock says it was built to stop — and it recurred because the
reason was left outside the check. The false text landed in the same PR that built the gate.

## Three reasons asserted coverage that does not exist

Found by the new checker running against the tree **before** any of them was fixed — which is the proof it works
on a real defect rather than a synthetic one:

```
- conformance/about-dialog.ts:1071: claims BOTH renderers cover ABOUT_DIALOG_CREDITS_LEGAL_VECTORS,
  but nativescript drives none of it.
- conformance/split-view.ts:42: claims BOTH renderers cover SIDEBAR_BOUNDS_VECTORS,
  but nativescript drives none of it.
- elements/adw-data-grid.ts:56: claims BOTH renderers cover DATA_GRID_*_VECTORS,
  but adwaita-web drives none of the six.
```

`DATA_GRID` occurred exactly once in all of `adwaita-web` — inside that comment. Zero false positives across 84
citations.

## The arms

1. **Staleness** — a renderer-driven table still carrying `CORE-ONLY:` fails. *It landed, drop the marker.*
   Previously a table that gained a driver kept its exemption forever.
2. **Claim resolution** — every comment sentence naming a table is resolved against the tree: globs against
   declared names, arity checked, both-renderer and single-suite claims checked per renderer, and coverage
   citations required to reach a driver **transitively** (the about-dialog licence chain is three hops).
3. **Module-keyed** — the table-keyed gate is structurally blind to core behaviour with no table. Every module
   in `adwaita-core/src` now needs a conformance file, a conformance file importing it, or a `MODULE_REASONS`
   entry — and the entries are themselves checked (a `table:` reason must name a declared table, a `gap:` reason
   must name a heading that exists in `status/open-todos.md`, and an entry for a now-covered module fails).

Three things the checker had to get right to avoid rejecting true sentences:

- **Globs resolve with arity.** `OVERLAY_SWIPE_*` is a TRUE statement about five real tables; a checker that
  rejected globs would reject it.
- **Precedent is not coverage.** `chrome.ts:478` and `:610` say "for the same reason as X" — a naive citation
  check false-positives on both.
- **Three spellings occur** (`both renderers`, `both drive`, `Both ports`, plus `both suites/sides` and
  `the two ports`). Two of the three false claims used the rarer ones.

The output is no longer unfalsifiable — it now says what it resolved, so a reader can see the arms ran:

```
156 vector tables, 43 core-only, 29 coverage chain(s) walked to a driver. Read 83 prose citation(s),
of which 2 both-renderer claim(s), 17 single-suite claim(s) and 3 counted glob(s) were resolved.
```

## Two divergences measured, ledgered, deliberately NOT fixed here

Either is a behaviour change that would make a gate PR unreviewable. Both are in `status/open-todos.md` with the
measurement.

- **`AdwToastOverlay.timeout` means different units on the two renderers.** The browser takes SECONDS
  (`addToast`, spec writes `{timeout: 3}`); NativeScript passes the core bag straight through and takes
  MILLISECONDS (spec writes `{timeout: 3000}`). `{timeout: 5}` is five seconds in one and five milliseconds in
  the other. Each suite is internally consistent, so neither can see it — and `toast.ts` has no vector table at
  all, which is exactly the blindness arm 3 exists to surface.
- **`setAdwaitaColorScheme()` is a no-op in the browser.** adwaita-web calls none of the singleton's seven
  exports; it answers the question itself in `accent.ts:55`. The NativeScript bridge re-exports all of it and
  subscribes from two widgets. Meanwhile the core module's header calls itself *"the single source of truth …
  shared by every renderer"*.

A suspected third — the toast default spelled `5000` in the core and `5` in the browser element — was
**refuted**. `refs/libadwaita/src/adw-toast.c:385` documents `AdwToast:timeout` in seconds and `:475` sets 5;
the core counts milliseconds and says so on every field, and the browser element mirrors the upstream public
unit, converting once. Both are right.

## A/B

Thirteen breaks, each red on break and green on restore, with no misses among them: staleness; citation
resolution; arity (`five` → `four`); the both-claim in all three spellings including a glob inside a renderer
tree; single-suite crediting the wrong renderer; a coverage chain citing an exempt table that reaches nothing;
a module with no reason; a module reason naming a table that does not exist; a `gap:` heading absent from
open-todos; a stale `MODULE_REASONS` entry; and the original marker arm.

**Breaks it does not catch**, stated rather than left implied:

- A reason citing a real, driven, but *irrelevant* table. Semantic relevance is out of reach for a text checker.
- A `GAP` reason with no anchor — 6 of 7 say "Tracked in #1072", one anchors nothing. A cheap arm, but adding it
  forces an edit to that reason's text; left as a follow-up.
- Driver detection is a text scan, so a comment naming a table would count as "driven". Measured: no table today
  is driven by a comment mention only.

## Not runnable in this worktree

The adwaita-core / adwaita-web / NativeScript unit suites and any build — no `node_modules`, no `refs/`. Left
for CI rather than faked. `check-adwaita-style-classes` SKIPs here for the same reason (#1240 makes that skip
impossible on a runner).
