### PR TITLE
feat(adwaita): ledger every one-renderer widget

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -384,7 +384,10 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      - name: Check every shared widget is in the storybook or ledgered
+      # The second ledger covers what the story rule deliberately cannot: a widget on
+      # ONE renderer, where the matrix shows the asymmetry and nothing said whether it
+      # was a gap or a decision (#1195).
+      - name: Check every widget is storyed, ledgered or verdicted
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of
@@ -774,7 +777,10 @@ jobs:
       # construction to the story that exists NOWHERE — a widget with no meta at all is
       # perfectly symmetric across three targets. Measured: nine widgets shipped on both
       # renderers had no story anywhere, `adw-entry` and `adw-drop-down` among them.
-      - name: Check every shared widget is in the storybook or ledgered
+      # The second ledger covers what the story rule deliberately cannot: a widget on
+      # ONE renderer, where the matrix shows the asymmetry and nothing said whether it
+      # was a gap or a decision (#1195).
+      - name: Check every widget is storyed, ledgered or verdicted
         run: node scripts/check-storybook-widget-coverage.mjs
 
       # A NativeScript widget's className and the theme's selector are two halves of

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -106,6 +106,18 @@ function bindsOnlyTypes(clause) {
 }
 
 /**
+ * A source with its comments blanked out, so a static reader claims only what the
+ * module RUNS. `[^:]` before `//` keeps a `https://` inside a string intact. Shared,
+ * because #1123 is what a reader without it costs: `.osd` and `.linked` read as
+ * implemented off a comment while the code spelled something else.
+ *
+ * @param {string} text
+ */
+export function stripComments(text) {
+    return text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/**
  * What a module imports or re-exports AS VALUES — comments out, and BOTH `type`
  * spellings out: the statement-level `import type { X } from` and the inline
  * `import { type X } from`, which emits nothing either ({@link bindsOnlyTypes}).
@@ -115,7 +127,7 @@ function bindsOnlyTypes(clause) {
  * "no path is VISIBLE", while a claimed edge nothing runs is the incident below.
  */
 function valueImports(text) {
-    const code = text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/(^|[^:])\/\/[^\n]*/g, '$1');
+    const code = stripComments(text);
     const specs = [...code.matchAll(/(?:^|[\n;])\s*import\s*['"]([^'"]+)['"]/g)].map(([, spec]) => spec);
     for (const [, clause, spec] of code.matchAll(
         /(?:^|[\n;])\s*(?:import|export)\s+(?!type[\s{])([^'"]*)from\s*['"]([^'"]+)['"]/g,

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -112,13 +112,23 @@ const NO_STORY_OF_ITS_OWN = {
  *
  * THE UPSTREAM FACT that settles most of them, read off `G_DECLARE_*_TYPE` in the
  * headers `src/meson.build` names: only `dialog`, `window`, `navigation-page` and the
- * two carousel indicators have an Adw WIDGET behind them at all. A handful more are
- * public Adw GObjects — DATA, which the browser needs a tag to declare in markup and
- * NativeScript passes as an object. The rest have no Adw type of any kind: they are
- * stylesheet partials over a GTK primitive (`.card` in `_misc.scss`, `_switch.scss`,
- * `_popovers.scss`, `_progress-bar.scss`, `_checks.scss`, `.image-button` in
- * `_buttons.scss`, `_scale.scss`), where WHICH renderer wrapped the primitive in an
- * element of its own is a rendering idiom, not a missing port.
+ * two carousel indicators have an Adw WIDGET behind them at all. Five more are public
+ * Adw GObjects — DATA, which the browser needs a tag to declare in markup and
+ * NativeScript passes as an object. The remaining thirteen have no Adw type of any
+ * kind, and they are not one bucket but two:
+ *
+ *   - EIGHT are stylesheet partials over a GTK primitive (`.card` in `_misc.scss`,
+ *     `_switch.scss`, `_popovers.scss`, `_progress-bar.scss`, `_checks.scss`,
+ *     `.image-button` in `_buttons.scss`, `_scale.scss`), where WHICH renderer wrapped
+ *     the primitive in an element of its own is a rendering idiom, not a missing port.
+ *   - FIVE have no upstream style class either, because they are not a rendered thing
+ *     at all: a GtkBuildable markup child (`alert-response`), a GtkWidget-typed
+ *     PROPERTY (the two bottom-sheet slots), a different library (`source-view`), and
+ *     one — `view-switcher-page` — with no upstream spelling whatsoever, since a view
+ *     switcher reads an AdwViewStack's own pages.
+ *
+ * Which bucket a widget is in is stated in ITS entry; this paragraph exists so the
+ * three are not collapsed into the first one, which reads as tidier than the tree is.
  *
  * `vectors` is optional and names conformance tables in `@gjsify/adwaita-core` that the
  * decision leaves driven from ONE side. It is checked (see {@link vectorFailures}), so
@@ -134,17 +144,17 @@ const ONE_RENDERER_ONLY = {
     'bottom-sheet-content': {
         only: 'web',
         decision:
-            '`adw_bottom_sheet_set_content()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:32), not a type. NativeScript calls the setter; HTML has no way to route one child into a named slot without a tag for it.',
+            '`adw_bottom_sheet_set_content()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:32), not a type. NativeScript calls the setter; the browser element is the markup spelling of GtkBuilder\'s `<child type="content">`, which leaves nothing in the tree. It is the markup form, not the only route: `_collectSlot` (packages/web/adwaita-web/src/elements/adw-bottom-sheet.ts:252) accepts a plain `slot="content"` child too.',
     },
     'bottom-sheet-sheet': {
         only: 'web',
         decision:
-            '`adw_bottom_sheet_set_sheet()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:38), not a type. NativeScript calls the setter; HTML has no way to route one child into a named slot without a tag for it.',
+            '`adw_bottom_sheet_set_sheet()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:38), not a type. NativeScript calls the setter; the browser element is the markup spelling of GtkBuilder\'s `<child type="sheet">`, which leaves nothing in the tree. It is the markup form, not the only route: `_collectSlot` (packages/web/adwaita-web/src/elements/adw-bottom-sheet.ts:252) accepts a plain `slot="sheet"` child too.',
     },
     card: {
         only: 'web',
         decision:
-            "`.card` is a libadwaita STYLE CLASS (stylesheet/widgets/_misc.scss:197) with no Adw type behind it. `<adw-card>` is a style class packaged as an element — its whole body is `classList.add('adw-card')` — and a NativeScript view sets `className` directly, so a widget class there would carry no behaviour at all.",
+            "`.card` is a libadwaita STYLE CLASS (stylesheet/widgets/_misc.scss:197) with no Adw type behind it. `<adw-card>` is a style class packaged as an element — its whole body is `classList.add('adw-card')` — and a NativeScript view sets `className` directly (showcases/dom/adwaita-storybook-nativescript/src/view-switching/carousel.ns.ts:28 already does), so a widget class there would carry no behaviour at all. The LOOK is a separate, open matter: no `.adw-card` rule exists in packages/nativescript-bridge/adwaita/src/theme/adwaita.css, so that className renders nothing today — a theme gap, not a widget one.",
     },
     'carousel-indicator-dots': {
         only: 'web',
@@ -167,7 +177,7 @@ const ONE_RENDERER_ONLY = {
     'image-button': {
         only: 'nativescript',
         decision:
-            'Recorded in adw-image-button.ts:6-7: "NativeScript\'s `Button` is text-only (it cannot host a child view), so an icon button is a tappable `GridLayout` holding a centered `Image`." Upstream `.image-button` is a style class (_buttons.scss:66), and the browser uses it as one — `<adw-split-button>` toggles it on a plain button.',
+            'Recorded in adw-image-button.ts:6-8: "NativeScript\'s `Button` is text-only (it cannot host a child view), so an icon button is a tappable `GridLayout` holding a centered `Image`." Upstream `.image-button` is a style class (_buttons.scss:66); on the browser it exists only as the split button\'s CSS-node-contract mirror (adw-split-button.ts:372 toggles it on the HOST, per `splitbutton[.image-button]`) and is styled in no adwaita-web stylesheet, so no browser element carries the idiom either.',
     },
     'navigation-page': {
         only: 'web',
@@ -177,7 +187,7 @@ const ONE_RENDERER_ONLY = {
     popover: {
         only: 'web',
         decision:
-            'Recorded in adw-drop-down.ts:14-16: "the NS subset has none, so the options open in the platform `action()` sheet, the same substitution `AdwComboRow`, `AdwSplitButton` and `AdwMenuButton` make." Upstream has no AdwPopover either — GtkPopover styled by _popovers.scss.',
+            'Recorded in packages/nativescript-bridge/adwaita/src/widgets/adw-drop-down.ts:14-16 — the NativeScript file, not the browser one of the same name: "the NS subset has none, so the options open in the platform `action()` sheet, the same substitution `AdwComboRow`, `AdwSplitButton` and `AdwMenuButton` make." Upstream has no AdwPopover either — GtkPopover styled by _popovers.scss.',
         vectors: ['POPOVER_SURFACE_VECTORS', 'POPOVER_KEY_VECTORS'],
     },
     'progress-bar': {
@@ -202,7 +212,7 @@ const ONE_RENDERER_ONLY = {
     'slider-row': {
         only: 'nativescript',
         decision:
-            'Recorded in adw-slider-row.ts:3-6: it is "the NS counterpart of the GTK storybook\'s `Gtk.Scale` RANGE card and the browser\'s `input[type=range]` `.sb-range-row`". Both renderers HAVE a range control; upstream has no AdwSliderRow (no such public header), and only NativeScript needed a widget class to get one that looks native.',
+            "Recorded in adw-slider-row.ts:3-6: it is \"the NS counterpart of the GTK storybook's `Gtk.Scale` RANGE card and the browser's `input[type=range]` `.sb-range-row`\". Both renderers SHOW a range control, but the browser's is the storybook's `.sb-range-row` (packages/web/adwaita-storybook/src/styles.ts:291), not an adwaita-web element — inside this ledger's universe the browser has none. Upstream has no AdwSliderRow (no such public header), and only NativeScript needed a widget class to get one that looks native.",
     },
     'source-view': {
         only: 'web',
@@ -237,7 +247,7 @@ const ONE_RENDERER_ONLY = {
     window: {
         only: 'web',
         decision:
-            'NativeScript\'s `Page` IS the window: the storybook\'s Page carries `class="adw-window"` (showcases/dom/adwaita-storybook-nativescript/app/storybook-page.xml) and the theme styles `Page.adw-window` (theme/adwaita.css:23-24). `<adw-window>` exists because a browser document has no page object to hang the frame on.',
+            'NativeScript\'s `Page` IS the window: the storybook\'s Page carries `class="adw-window"` (showcases/dom/adwaita-storybook-nativescript/app/storybook-page.xml) and the theme styles `Page.adw-window` (packages/nativescript-bridge/adwaita/src/theme/adwaita.css:23-24). `<adw-window>` exists because a browser document has no page object to hang the frame on.',
     },
 };
 

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -42,6 +42,10 @@
 //   7. An entry's `only` MATCHES the side the tree puts the widget on. Without this
 //      an asymmetry that FLIPPED — ported one way, dropped the other — keeps reading
 //      as covered while the reason next to it now describes the wrong renderer.
+//   8. A `gap` resolves to a `### ` section of the open-TODO ledger that NAMES the
+//      widget. Heading-only was not enough: every gap points at one shared section
+//      whose own closing line retires a bullet once an issue exists, so following it
+//      emptied the section while all five entries stayed green.
 //
 // STATUS.md's widget matrix is NOT checked here: an arm that did was removed, because
 // its column and this check both call `adwaitaWebElements()` — `f(x)` against `f(x)`,
@@ -63,7 +67,9 @@ import {
     adwaitaNativeScriptWidgets,
     adwaitaWebElements,
     elementName,
+    stripComments,
 } from './adwaita-elements.mjs';
+import { todoAnchorMatches, todoSections } from './generate-status.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -115,20 +121,14 @@ const NO_STORY_OF_ITS_OWN = {
  * two carousel indicators have an Adw WIDGET behind them at all. Five more are public
  * Adw GObjects — DATA, which the browser needs a tag to declare in markup and
  * NativeScript passes as an object. The remaining thirteen have no Adw type of any
- * kind, and they are not one bucket but two:
- *
- *   - EIGHT are stylesheet partials over a GTK primitive (`.card` in `_misc.scss`,
- *     `_switch.scss`, `_popovers.scss`, `_progress-bar.scss`, `_checks.scss`,
- *     `.image-button` in `_buttons.scss`, `_scale.scss`), where WHICH renderer wrapped
- *     the primitive in an element of its own is a rendering idiom, not a missing port.
- *   - FIVE have no upstream style class either, because they are not a rendered thing
- *     at all: a GtkBuildable markup child (`alert-response`), a GtkWidget-typed
- *     PROPERTY (the two bottom-sheet slots), a different library (`source-view`), and
- *     one — `view-switcher-page` — with no upstream spelling whatsoever, since a view
- *     switcher reads an AdwViewStack's own pages.
- *
- * Which bucket a widget is in is stated in ITS entry; this paragraph exists so the
- * three are not collapsed into the first one, which reads as tidier than the tree is.
+ * kind, in TWO shapes, and collapsing them into the first reads tidier than the tree
+ * is: eight are stylesheet partials over a GTK primitive (`.card` in `_misc.scss`,
+ * `_switch.scss`, `_popovers.scss`, `_progress-bar.scss`, `_checks.scss`,
+ * `.image-button` in `_buttons.scss`, `_scale.scss`), where WHICH renderer wrapped the
+ * primitive in an element is a rendering idiom, not a missing port; five are not a
+ * rendered thing at all — a GtkBuildable markup child, a GtkWidget-typed property, a
+ * different library, and `view-switcher-page`, which has no upstream spelling
+ * whatsoever. Which shape a widget is is stated in ITS entry.
  *
  * `vectors` is optional and names conformance tables in `@gjsify/adwaita-core` that the
  * decision leaves driven from ONE side. It is checked (see {@link vectorFailures}), so
@@ -265,7 +265,10 @@ function storyNames(dir) {
     return found;
 }
 
-/** The floor `check-nativescript-theme-classes.mjs` set: it refuses a blank, it judges nothing. */
+/**
+ * The floor `check-nativescript-theme-classes.mjs` set: it refuses a blank, it judges
+ * nothing. BOTH ledgers here buy an exemption with a sentence, so both apply it.
+ */
 const MIN_REASON = 40;
 
 /** Where a `gap` may point, in the two spellings `gjsify/todo-needs-anchor` already accepts. */
@@ -274,9 +277,10 @@ const GAP_TODO = /^open-todos: (\S.*)$/;
 const OPEN_TODOS = 'status/open-todos.md';
 
 /**
- * Every `### <title>` in the open-TODO ledger, so a `gap` pointing at one can be
- * resolved — matched by containment with markdown emphasis stripped, exactly the way
- * `generate-status.mjs` resolves a deferral marker that names that ledger.
+ * The open-TODO sections a `gap` may point at, via `generate-status.mjs`'s OWN resolver
+ * ({@link todoSections} / {@link todoAnchorMatches}) rather than a second copy — the
+ * copy this replaced stripped emphasis from the heading but not the anchor, so a `gap`
+ * quoting a heading verbatim was rejected here and accepted there.
  *
  * IT IS RESOLVED HERE rather than left to that rule, which does walk `scripts/`:
  * measured, its anchor pattern has to reach a `)` before the next `*`, which is the
@@ -289,8 +293,7 @@ const OPEN_TODOS = 'status/open-todos.md';
  * the shape is a dangling anchor. Measured on the first run — two findings, both prose.
  */
 function todoAnchors() {
-    const text = readFileSync(join(ROOT, OPEN_TODOS), 'utf8');
-    return [...text.matchAll(/^### ([^\n]+)$/gm)].map(([, heading]) => heading.replaceAll(/[`*_]/g, '').trim());
+    return todoSections(readFileSync(join(ROOT, OPEN_TODOS), 'utf8'));
 }
 
 /** Every `.ts` under `dir`, specs INCLUDED — a conformance table is driven from a spec. */
@@ -316,12 +319,20 @@ const RENDERER_SRC = {
 
 const OTHER_RENDERER = { web: 'nativescript', nativescript: 'web' };
 const SIDE_LABEL = { web: 'the browser only', nativescript: 'NativeScript only' };
+const SIDES = Object.keys(OTHER_RENDERER);
 
-/** @param {string} dir @param {RegExp} pattern @returns {Set<string>} */
+/**
+ * Table names matched in the CODE of `dir`, comments blanked out first — load-bearing
+ * on the `driven` side, where a MENTION is not a consumer: both trees name `_VECTORS`
+ * tables in prose, and `split-view-state.spec.ts` has a comment recording that a table
+ * has NO consumer there, the exact opposite of driving it.
+ *
+ * @param {string} dir @param {RegExp} pattern @returns {Set<string>}
+ */
 function tableNames(dir, pattern) {
     const found = new Set();
     for (const file of typescriptFiles(dir)) {
-        for (const [, name] of readFileSync(file, 'utf8').matchAll(pattern)) found.add(name);
+        for (const [, name] of stripComments(readFileSync(file, 'utf8')).matchAll(pattern)) found.add(name);
     }
     return found;
 }
@@ -345,6 +356,10 @@ function tableNames(dir, pattern) {
  */
 function vectorFailures(name, entry, exported) {
     if (entry.vectors === undefined) return [];
+    // Unchecked, a bare string spreads into 19 findings about the letter `R`.
+    if (!Array.isArray(entry.vectors)) {
+        return [`adw-${name}: \`vectors\` must be a LIST of conformance table names, not a ${typeof entry.vectors}.`];
+    }
     const problems = [];
     const other = OTHER_RENDERER[entry.only];
     const driven = tableNames(RENDERER_SRC[other], /\b([A-Z][A-Z0-9_]*_VECTORS)\b/g);
@@ -399,13 +414,20 @@ for (const name of onBothRenderers) {
     );
 }
 
-for (const name of Object.keys(NO_STORY_OF_ITS_OWN)) {
+for (const [name, reason] of Object.entries(NO_STORY_OF_ITS_OWN)) {
     if (stories.has(name)) {
         failures.push(`adw-${name}: exempted here, but ${name}.meta.ts exists — drop the stale exemption.`);
     } else if (!web.has(name) || !ns.has(name)) {
         const where = web.has(name) ? 'the browser only' : ns.has(name) ? 'NativeScript only' : 'neither renderer';
         failures.push(
             `adw-${name}: exempted here, but it is on ${where} — outside this check's scope, so the entry covers nothing.`,
+        );
+    } else if (reason.trim().length < MIN_REASON) {
+        // Without this, `icon: ''` bought a story exemption in silence while
+        // `decision: ''` did not — one file, two ledgers, one bar.
+        failures.push(
+            `adw-${name}: exempted here with no real reason — say where the reader finds this widget ` +
+                'instead, or why a GTK story could show nothing honest.',
         );
     }
 }
@@ -438,6 +460,15 @@ for (const [name, entry] of Object.entries(ONE_RENDERER_ONLY)) {
         unverdicted.push(`adw-${name}: ledgered as one-renderer-only, but it is ${where}. Drop the entry.`);
         continue;
     }
+    // BEFORE the side comparison: a missing or misspelled `only` is not a flipped
+    // asymmetry, and reporting it as one sends the author to re-read a sound reason.
+    if (!SIDES.includes(entry.only)) {
+        unverdicted.push(
+            `adw-${name}: \`only\` is \`${JSON.stringify(entry.only)}\` — it must be one of ${SIDES.map((s) => `'${s}'`).join(' / ')}, ` +
+                'the two renderers this ledger compares.',
+        );
+        continue;
+    }
     if (entry.only !== side) {
         unverdicted.push(
             `adw-${name}: ledgered as \`only: '${entry.only}'\`, but the tree has it on ${SIDE_LABEL[side]}. ` +
@@ -459,11 +490,20 @@ for (const [name, entry] of Object.entries(ONE_RENDERER_ONLY)) {
                 `adw-${name}: \`gap\` must be \`#<issue>\`, or the open-todos anchor — that word, a colon and ` +
                     `enough of a \`### \` heading in ${OPEN_TODOS} to name it. "${entry.gap}" points nowhere.`,
             );
-        } else if (todo !== null && !anchors.some((heading) => heading.includes(todo[1]))) {
-            unverdicted.push(
-                `adw-${name}: \`gap\` anchors to "${entry.gap}", but no \`### \` heading in ${OPEN_TODOS} ` +
-                    'contains that text — the entry was renamed or deleted, or it was never written.',
-            );
+        } else if (todo !== null) {
+            const matched = todoAnchorMatches(anchors, todo[1]);
+            if (matched.length === 0) {
+                unverdicted.push(
+                    `adw-${name}: \`gap\` anchors to "${entry.gap}", but no \`### \` heading in ${OPEN_TODOS} ` +
+                        'contains that text — the entry was renamed or deleted, or it was never written.',
+                );
+            } else if (!matched.some((section) => section.body.includes(`adw-${name}`))) {
+                unverdicted.push(
+                    `adw-${name}: \`gap\` anchors to "${entry.gap}", but that section of ${OPEN_TODOS} never ` +
+                        `names adw-${name}. A heading is not a record — either write what this gap is waiting ` +
+                        'on there, or re-point the `gap` at the issue that now tracks it.',
+                );
+            }
         }
     } else if (entry.decision.trim().length < MIN_REASON) {
         unverdicted.push(

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-// Every widget both renderers ship is either IN the storybook or in this ledger.
+// Every widget both renderers ship is either IN the storybook or in a ledger here,
+// and every widget only ONE of them ships says whether that is a gap or a decision.
 //
 // WHAT THIS ADDS TO PARITY
 //
@@ -15,11 +16,11 @@
 // reference implementation the other two are aligned against; a widget it never shows
 // is a widget with no reference.
 //
-// WHAT IT CHECKS
+// WHAT IT CHECKS — the story ledger
 //
 //   1. Every `adw-<name>` the browser DEFINES as a custom element and NativeScript
 //      ships as an `Adw*` view class has a `<name>.meta.ts` in the GTK showcase — or
-//      an entry below saying why not.
+//      an entry in `NO_STORY_OF_ITS_OWN` saying why not.
 //   2. No ledger entry names a widget that HAS a story (a stale exemption reads as
 //      considered when it is merely forgotten).
 //   3. No ledger entry names a widget the rule cannot reach — one renderer only, or
@@ -28,6 +29,19 @@
 // The both-renderers scope is deliberate. A widget on ONE renderer cannot have a
 // three-target story, so demanding one here would demand a port, and that is a
 // product decision this check has no business making.
+//
+// WHAT IT CHECKS — the asymmetry ledger
+//
+// Which is why the widgets that scope EXCLUDES need a ledger of their own
+// (`ONE_RENDERER_ONLY`, #1195): the derived matrix already shows each of them as an
+// asymmetric row, and a row cannot say whether the asymmetry is a GAP or a DECISION.
+//
+//   4. Every widget on exactly one renderer has an entry.
+//   5. No entry names a widget now on BOTH renderers — it landed, drop it.
+//   6. No entry names a widget on NEITHER — it went away, drop it.
+//   7. An entry's `only` MATCHES the side the tree puts the widget on. Without this
+//      an asymmetry that FLIPPED — ported one way, dropped the other — keeps reading
+//      as covered while the reason next to it now describes the wrong renderer.
 //
 // STATUS.md's widget matrix is NOT checked here: an arm that did was removed, because
 // its column and this check both call `adwaitaWebElements()` — `f(x)` against `f(x)`,
@@ -38,10 +52,11 @@
 //
 // Usage: node scripts/check-storybook-widget-coverage.mjs [--root <dir>]
 
-import { readdirSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
 import {
     ADWAITA_NS_WIDGETS,
     ADWAITA_WEB_SRC,
@@ -76,6 +91,156 @@ const NO_STORY_OF_ITS_OWN = {
         'The one widget here with no GTK renderer at all — it is an original @gjsify widget, not a libadwaita port. A GTK story would have to hand-assemble a `Gtk.Grid`, i.e. put a fourth implementation in a showcase where no package owns it. If a GTK data grid is wanted it starts as a package (#1050).',
 };
 
+/**
+ * Widgets on exactly ONE renderer, and what that asymmetry IS.
+ *
+ *   { only: 'web' | 'nativescript', decision: '<reason>' }   the other renderer has no
+ *       such concept, or expresses it differently;
+ *   { only: …, gap: '#123' | an open-todos anchor }         a port nobody has written,
+ *       pointing at where the work is tracked ({@link todoAnchors}).
+ *
+ * A DISCRIMINATED pair rather than one free-text field, because the whole value of the
+ * ledger is telling those two apart: the moment "we would have to build it" is allowed
+ * to sit in `decision`, every gap can be spelled as a reason and nothing is recorded.
+ *
+ * WHY THE ENTRIES READ LIKE CITATIONS. #1195 deliberately refused to fill this in from
+ * outside the ports — "guessing eleven verdicts into a ledger produces exactly the kind
+ * of confident-looking claim this repo has now deleted twice in one week (#1172,
+ * #1188)". So an entry here either MOVES a reason already recorded in a source header,
+ * or DERIVES one from `refs/libadwaita`; the ones that need a product decision nobody
+ * has made are gaps with a pointer, and stayed gaps.
+ *
+ * THE UPSTREAM FACT that settles most of them, read off `G_DECLARE_*_TYPE` in the
+ * headers `src/meson.build` names: only `dialog`, `window`, `navigation-page` and the
+ * two carousel indicators have an Adw WIDGET behind them at all. A handful more are
+ * public Adw GObjects — DATA, which the browser needs a tag to declare in markup and
+ * NativeScript passes as an object. The rest have no Adw type of any kind: they are
+ * stylesheet partials over a GTK primitive (`.card` in `_misc.scss`, `_switch.scss`,
+ * `_popovers.scss`, `_progress-bar.scss`, `_checks.scss`, `.image-button` in
+ * `_buttons.scss`, `_scale.scss`), where WHICH renderer wrapped the primitive in an
+ * element of its own is a rendering idiom, not a missing port.
+ *
+ * `vectors` is optional and names conformance tables in `@gjsify/adwaita-core` that the
+ * decision leaves driven from ONE side. It is checked (see {@link vectorFailures}), so
+ * the ledger doubles as the port-cost record: the tables a second renderer would
+ * inherit for free are exactly the ones listed here.
+ */
+const ONE_RENDERER_ONLY = {
+    'alert-response': {
+        only: 'web',
+        decision:
+            'No `AdwAlertResponse` type upstream — a response is an id passed to `adw_alert_dialog_add_response()`, whose MARKUP form is a GtkBuildable `<response>` child, which is what this element mirrors. NativeScript calls the method against the same `AdwAlertResponses` in adwaita-core, so only the browser needs a tag to declare one in.',
+    },
+    'bottom-sheet-content': {
+        only: 'web',
+        decision:
+            '`adw_bottom_sheet_set_content()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:32), not a type. NativeScript calls the setter; HTML has no way to route one child into a named slot without a tag for it.',
+    },
+    'bottom-sheet-sheet': {
+        only: 'web',
+        decision:
+            '`adw_bottom_sheet_set_sheet()` is a GtkWidget-typed PROPERTY on AdwBottomSheet (adw-bottom-sheet.h:38), not a type. NativeScript calls the setter; HTML has no way to route one child into a named slot without a tag for it.',
+    },
+    card: {
+        only: 'web',
+        decision:
+            "`.card` is a libadwaita STYLE CLASS (stylesheet/widgets/_misc.scss:197) with no Adw type behind it. `<adw-card>` is a style class packaged as an element — its whole body is `classList.add('adw-card')` — and a NativeScript view sets `className` directly, so a widget class there would carry no behaviour at all.",
+    },
+    'carousel-indicator-dots': {
+        only: 'web',
+        decision:
+            '`AdwCarouselIndicatorDots` is placeable anywhere in GTK, but the NativeScript carousel builds its own dot row (row 1 of its GridLayout) and projects the shared `CarouselState` onto it through `applyCarouselDots` in its carousel-state.ts. The indicator is present there, just not detachable — its FIDELITY note (3) records the look that costs.',
+    },
+    'carousel-indicator-lines': {
+        only: 'web',
+        gap: 'open-todos: Adwaita renderer asymmetries with no verdict',
+    },
+    checkbox: {
+        only: 'web',
+        gap: 'open-todos: Adwaita renderer asymmetries with no verdict',
+        vectors: ['RADIO_GROUP_VECTORS'],
+    },
+    dialog: {
+        only: 'web',
+        gap: 'open-todos: Adwaita renderer asymmetries with no verdict',
+    },
+    'image-button': {
+        only: 'nativescript',
+        decision:
+            'Recorded in adw-image-button.ts:6-7: "NativeScript\'s `Button` is text-only (it cannot host a child view), so an icon button is a tappable `GridLayout` holding a centered `Image`." Upstream `.image-button` is a style class (_buttons.scss:66), and the browser uses it as one — `<adw-split-button>` toggles it on a plain button.',
+    },
+    'navigation-page': {
+        only: 'web',
+        decision:
+            'The only widget here whose upstream type IS a widget and whose properties are already shared: tag/title/can-pop are `AdwNavigationPageProps` in adwaita-core, and NativeScript pushes any `View` with that object (`NsNavigationStack.push(viewOrTag, options)`). The page exists there as data plus a plain view; only the browser needs an element to carry the attributes.',
+    },
+    popover: {
+        only: 'web',
+        decision:
+            'Recorded in adw-drop-down.ts:14-16: "the NS subset has none, so the options open in the platform `action()` sheet, the same substitution `AdwComboRow`, `AdwSplitButton` and `AdwMenuButton` make." Upstream has no AdwPopover either — GtkPopover styled by _popovers.scss.',
+        vectors: ['POPOVER_SURFACE_VECTORS', 'POPOVER_KEY_VECTORS'],
+    },
+    'progress-bar': {
+        only: 'web',
+        gap: 'open-todos: Adwaita renderer asymmetries with no verdict',
+    },
+    radio: {
+        only: 'web',
+        gap: 'open-todos: Adwaita renderer asymmetries with no verdict',
+        vectors: ['RADIO_GROUP_VECTORS'],
+    },
+    'sidebar-item': {
+        only: 'web',
+        decision:
+            '`AdwSidebarItem` is declared against GObject, not GtkWidget (adw-sidebar-item.h) — it is DATA. NativeScript holds the same data as an `AdwSidebarItemSpec` in the shared `SidebarState`, so this element is the markup form of a model both renderers already run.',
+    },
+    'sidebar-section': {
+        only: 'web',
+        decision:
+            '`AdwSidebarSection` is declared against GObject, not GtkWidget (adw-sidebar-section.h) — it is DATA. NativeScript holds the same data as an `AdwSidebarSectionSpec` in the shared `SidebarState`, so this element is the markup form of a model both renderers already run.',
+    },
+    'slider-row': {
+        only: 'nativescript',
+        decision:
+            'Recorded in adw-slider-row.ts:3-6: it is "the NS counterpart of the GTK storybook\'s `Gtk.Scale` RANGE card and the browser\'s `input[type=range]` `.sb-range-row`". Both renderers HAVE a range control; upstream has no AdwSliderRow (no such public header), and only NativeScript needed a widget class to get one that looks native.',
+    },
+    'source-view': {
+        only: 'web',
+        decision:
+            'Not a libadwaita widget at all — the GTK twin is GtkSourceView, a separate library, and no Adw type exists. The element is an opt-in subpath (`@gjsify/adwaita-web/source-view`) binding CodeMirror 6, which renders into a DOM NativeScript does not have, so there is no port of THIS element to write.',
+    },
+    switch: {
+        only: 'web',
+        decision:
+            'Upstream has no AdwSwitch: _switch.scss styles the GtkSwitch node. `@nativescript/core` ships a real `Switch` view, which `AdwSwitchRow` installs directly; the browser has no such control, so `<adw-switch>` is the 44x24 track a hidden checkbox needs to look like one. Its own header records there is no behaviour to port either — "the state is one boolean with no derivation" (adw-switch.ts:7-8).',
+    },
+    'tab-page': {
+        only: 'web',
+        decision:
+            '`AdwTabPage` is declared against GObject, not GtkWidget (adw-tab-view.h) — it is DATA, held on NativeScript by `TabViewState` and projected through tab-view-state.ts. The browser element is that descriptor in markup, and doubles as the page panel the tab reveals.',
+    },
+    toggle: {
+        only: 'web',
+        decision:
+            '`AdwToggle` is declared against GObject, not GtkWidget (adw-toggle-group.h) — it is DATA. NativeScript passes the same labels and icons through `options` / `setToggles` into the shared `ToggleGroupState`, so only the browser needs a tag to declare one in.',
+    },
+    'view-stack-page': {
+        only: 'web',
+        decision:
+            '`AdwViewStackPage` is declared against GObject, not GtkWidget (adw-view-stack.h) — it is DATA. NativeScript passes the same page descriptors to `AdwViewSwitcherBase.setViews`, so only the browser needs a tag to declare one in.',
+    },
+    'view-switcher-page': {
+        only: 'web',
+        decision:
+            "There is no AdwViewSwitcherPage upstream at all: a view switcher takes an AdwViewStack and reads its AdwViewStackPages. This element is this port's markup form of that same page descriptor, and NativeScript passes the descriptors to `AdwViewSwitcherBase.setViews`.",
+    },
+    window: {
+        only: 'web',
+        decision:
+            'NativeScript\'s `Page` IS the window: the storybook\'s Page carries `class="adw-window"` (showcases/dom/adwaita-storybook-nativescript/app/storybook-page.xml) and the theme styles `Page.adw-window` (theme/adwaita.css:23-24). `<adw-window>` exists because a browser document has no page object to hang the frame on.',
+    },
+};
+
 /** Story names — every `<name>.meta.ts` anywhere under the GTK showcase. */
 function storyNames(dir) {
     const found = new Set();
@@ -88,6 +253,105 @@ function storyNames(dir) {
     };
     walk(dir);
     return found;
+}
+
+/** The floor `check-nativescript-theme-classes.mjs` set: it refuses a blank, it judges nothing. */
+const MIN_REASON = 40;
+
+/** Where a `gap` may point, in the two spellings `gjsify/todo-needs-anchor` already accepts. */
+const GAP_ISSUE = /^#\d+$/;
+const GAP_TODO = /^open-todos: (\S.*)$/;
+const OPEN_TODOS = 'status/open-todos.md';
+
+/**
+ * Every `### <title>` in the open-TODO ledger, so a `gap` pointing at one can be
+ * resolved — matched by containment with markdown emphasis stripped, exactly the way
+ * `generate-status.mjs` resolves a deferral marker that names that ledger.
+ *
+ * IT IS RESOLVED HERE rather than left to that rule, which does walk `scripts/`:
+ * measured, its anchor pattern has to reach a `)` before the next `*`, which is the
+ * shape of the `TODO(…)` comment markers it was written for. A pointer sitting in a
+ * data field reaches neither, so it matches nothing at all and passes in silence — and
+ * a pointer nothing resolves is precisely the failure this ledger exists to stop.
+ *
+ * Which is also why no comment or message in this file spells a WHOLE anchor: that rule
+ * reads any complete one it finds here as a marker of this file's own, so an EXAMPLE of
+ * the shape is a dangling anchor. Measured on the first run — two findings, both prose.
+ */
+function todoAnchors() {
+    const text = readFileSync(join(ROOT, OPEN_TODOS), 'utf8');
+    return [...text.matchAll(/^### ([^\n]+)$/gm)].map(([, heading]) => heading.replaceAll(/[`*_]/g, '').trim());
+}
+
+/** Every `.ts` under `dir`, specs INCLUDED — a conformance table is driven from a spec. */
+function typescriptFiles(dir) {
+    const found = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules') continue;
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) found.push(...typescriptFiles(path));
+        else if (entry.name.endsWith('.ts')) found.push(path);
+    }
+    return found;
+}
+
+/** The conformance tables `@gjsify/adwaita-core` publishes — what a `vectors` entry may name. */
+const CORE_CONFORMANCE = 'packages/web/adwaita-core/src/conformance';
+
+/** Each renderer's package source root, which is where its specs live too. */
+const RENDERER_SRC = {
+    web: join(ROOT, ADWAITA_WEB_SRC),
+    nativescript: resolve(ROOT, ADWAITA_NS_WIDGETS, '..'),
+};
+
+const OTHER_RENDERER = { web: 'nativescript', nativescript: 'web' };
+const SIDE_LABEL = { web: 'the browser only', nativescript: 'NativeScript only' };
+
+/** @param {string} dir @param {RegExp} pattern @returns {Set<string>} */
+function tableNames(dir, pattern) {
+    const found = new Set();
+    for (const file of typescriptFiles(dir)) {
+        for (const [, name] of readFileSync(file, 'utf8').matchAll(pattern)) found.add(name);
+    }
+    return found;
+}
+
+/**
+ * Hold a `vectors` claim: each table must EXIST in adwaita-core, and the renderer that
+ * does NOT have the widget must not drive it.
+ *
+ * Only that direction. The renderer that HAS the widget is not required to drive the
+ * table, because a table may legitimately be driven by core's own spec alone —
+ * `POPOVER_KEY_VECTORS` is, today. Requiring the positive arm would fail on the honest
+ * case and teach people to delete the claim.
+ *
+ * What it buys: the entry retires itself. The day a NativeScript checkbox spec drives
+ * `RADIO_GROUP_VECTORS`, the port has happened and this says so.
+ *
+ * @param {string} name widget name, for the message
+ * @param {{only: string, vectors?: string[]}} entry
+ * @param {() => Set<string>} exported
+ * @returns {string[]}
+ */
+function vectorFailures(name, entry, exported) {
+    if (entry.vectors === undefined) return [];
+    const problems = [];
+    const other = OTHER_RENDERER[entry.only];
+    const driven = tableNames(RENDERER_SRC[other], /\b([A-Z][A-Z0-9_]*_VECTORS)\b/g);
+    for (const table of entry.vectors) {
+        if (!exported().has(table)) {
+            problems.push(
+                `adw-${name}: \`vectors\` names ${table}, which ${CORE_CONFORMANCE} does not export. ` +
+                    'A table that is not there strands nothing.',
+            );
+        } else if (driven.has(table)) {
+            problems.push(
+                `adw-${name}: \`vectors\` claims ${table} is driven from one side, but the ${other} renderer ` +
+                    'drives it too — the asymmetry this entry describes is over, so re-read the entry.',
+            );
+        }
+    }
+    return problems;
 }
 
 /** @type {Map<string, string>} */
@@ -136,20 +400,104 @@ for (const name of Object.keys(NO_STORY_OF_ITS_OWN)) {
     }
 }
 
+/** Widget name → the side the TREE puts it on. The question `only` has to agree with. */
+const asymmetric = new Map();
+for (const name of web) if (!ns.has(name)) asymmetric.set(name, 'web');
+for (const name of ns.keys()) if (!web.has(name)) asymmetric.set(name, 'nativescript');
+
+const unverdicted = [];
+let exportedTables;
+const exported = () =>
+    (exportedTables ??= tableNames(join(ROOT, CORE_CONFORMANCE), /export const ([A-Z][A-Z0-9_]*_VECTORS)\b/g));
+const anchors = todoAnchors();
+
+for (const [name, side] of [...asymmetric].sort()) {
+    if (name in ONE_RENDERER_ONLY) continue;
+    const file = toPosixPath(defines.get(`adw-${name}`) ?? ns.get(name) ?? '');
+    unverdicted.push(
+        `adw-${name} (${file}): on ${SIDE_LABEL[side]}, and nothing says whether that is a gap or a\n` +
+            `    decision. Add it to ONE_RENDERER_ONLY as { only: '${side}', decision: '…' } — or, if the port\n` +
+            `    is simply unwritten, { only: '${side}', gap: '#<issue>' } — or an open-todos anchor.`,
+    );
+}
+
+for (const [name, entry] of Object.entries(ONE_RENDERER_ONLY)) {
+    const side = asymmetric.get(name);
+    if (side === undefined) {
+        const where = web.has(name) && ns.has(name) ? 'on BOTH renderers now — it landed' : 'on NEITHER renderer';
+        unverdicted.push(`adw-${name}: ledgered as one-renderer-only, but it is ${where}. Drop the entry.`);
+        continue;
+    }
+    if (entry.only !== side) {
+        unverdicted.push(
+            `adw-${name}: ledgered as \`only: '${entry.only}'\`, but the tree has it on ${SIDE_LABEL[side]}. ` +
+                'The asymmetry flipped, so the reason recorded here is about the wrong renderer — re-read it.',
+        );
+        continue;
+    }
+
+    const gap = typeof entry.gap === 'string';
+    if (gap === (typeof entry.decision === 'string')) {
+        unverdicted.push(
+            `adw-${name}: needs exactly one of \`decision\` (the other renderer expresses it differently) ` +
+                'and `gap` (a port nobody has written). Neither, or both, records nothing.',
+        );
+    } else if (gap) {
+        const todo = GAP_TODO.exec(entry.gap);
+        if (!GAP_ISSUE.test(entry.gap) && todo === null) {
+            unverdicted.push(
+                `adw-${name}: \`gap\` must be \`#<issue>\`, or the open-todos anchor — that word, a colon and ` +
+                    `enough of a \`### \` heading in ${OPEN_TODOS} to name it. "${entry.gap}" points nowhere.`,
+            );
+        } else if (todo !== null && !anchors.some((heading) => heading.includes(todo[1]))) {
+            unverdicted.push(
+                `adw-${name}: \`gap\` anchors to "${entry.gap}", but no \`### \` heading in ${OPEN_TODOS} ` +
+                    'contains that text — the entry was renamed or deleted, or it was never written.',
+            );
+        }
+    } else if (entry.decision.trim().length < MIN_REASON) {
+        unverdicted.push(
+            `adw-${name}: \`decision\` with no real reason — say what the other renderer does INSTEAD, or ` +
+                'why there is nothing there to do.',
+        );
+    }
+
+    unverdicted.push(...vectorFailures(name, entry, exported));
+}
+
+let failed = false;
+
 if (failures.length > 0) {
-    console.error(`check-storybook-widget-coverage: ${failures.length} problem(s):\n`);
+    failed = true;
+    console.error(`check-storybook-widget-coverage: ${failures.length} story problem(s):\n`);
     for (const failure of failures) console.error(`  - ${failure}`);
     console.error(
         '\nThe GTK storybook is the reference the other two targets are aligned against, so a widget it\n' +
             'never shows is a widget with no reference — and story-set parity cannot see that, because a\n' +
             'story missing from all three targets is perfectly symmetric.\n' +
-            `  elements: ${ADWAITA_WEB_SRC}    widgets: ${ADWAITA_NS_WIDGETS}    stories: ${relative(ROOT, GTK_SRC)}`,
+            `  elements: ${ADWAITA_WEB_SRC}    widgets: ${ADWAITA_NS_WIDGETS}    stories: ${toPosixPath(relative(ROOT, GTK_SRC))}`,
     );
-    process.exit(1);
 }
 
+if (unverdicted.length > 0) {
+    failed = true;
+    console.error(`\ncheck-storybook-widget-coverage: ${unverdicted.length} asymmetry problem(s):\n`);
+    for (const failure of unverdicted) console.error(`  - ${failure}`);
+    console.error(
+        '\nA widget on one renderer only is either a DECISION (the other has no such concept, or expresses\n' +
+            'it differently) or a GAP (a port nobody has written). The derived matrix shows the asymmetry and\n' +
+            'cannot tell you which, so the verdict is recorded next to the widget — and a gap may not be\n' +
+            'spelled as a reason, which is why the two are separate keys.\n' +
+            `  ledger: ONE_RENDERER_ONLY in ${toPosixPath(relative(ROOT, fileURLToPath(import.meta.url)))}`,
+    );
+}
+
+if (failed) process.exit(1);
+
 const exempt = Object.keys(NO_STORY_OF_ITS_OWN).length;
+const gaps = Object.values(ONE_RENDERER_ONLY).filter((entry) => typeof entry.gap === 'string').length;
 console.log(
     `check-storybook-widget-coverage: ${onBothRenderers.length} widgets on both renderers — ` +
-        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason.`,
+        `${onBothRenderers.length - exempt} with a story, ${exempt} ledgered with a reason; ` +
+        `${asymmetric.size} on one renderer — ${asymmetric.size - gaps} a decision, ${gaps} an open gap.`,
 );

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -128,7 +128,7 @@ const NO_STORY_OF_ITS_OWN = {
  * primitive in an element is a rendering idiom, not a missing port; five are not a
  * rendered thing at all — a GtkBuildable markup child, a GtkWidget-typed property, a
  * different library, and `view-switcher-page`, which has no upstream spelling
- * whatsoever. Which shape a widget is is stated in ITS entry.
+ * whatsoever. Which of the three a given widget is, its OWN entry states.
  *
  * `vectors` is optional and names conformance tables in `@gjsify/adwaita-core` that the
  * decision leaves driven from ONE side. It is checked (see {@link vectorFailures}), so

--- a/scripts/generate-status.mjs
+++ b/scripts/generate-status.mjs
@@ -388,6 +388,44 @@ export function collectPackageFacts(root) {
     return facts;
 }
 
+// ─── Open-TODO anchors ──────────────────────────────────────────────────────
+
+/**
+ * The `### <title>` sections of `status/open-todos.md`, each with the BODY up to the
+ * next heading.
+ *
+ * ONE parse, TWO consumers: this file resolves deferral markers against the headings,
+ * `check-storybook-widget-coverage.mjs` resolves a `gap` field the marker rule cannot
+ * structurally see. Its own copy had already drifted — emphasis stripped from the
+ * heading but not the anchor, so a `gap` quoting a heading VERBATIM was rejected there
+ * and accepted here.
+ *
+ * @param {string} text
+ * @returns {{heading: string, body: string}[]}
+ */
+export function todoSections(text) {
+    const headings = [...text.matchAll(/^### ([^\n]+)$/gm)];
+    return headings.map((match, index) => ({
+        heading: match[1].trim(),
+        body: text.slice(match.index, headings[index + 1]?.index ?? text.length),
+    }));
+}
+
+/**
+ * The sections `anchor` names, or an empty list. Emphasis stripped from BOTH sides — a
+ * heading may spell a symbol as `code`, a marker in a comment is plain text, and an
+ * anchor quoting the heading carries the punctuation along; all three must reach the
+ * same section. Containment, not equality: an anchor is a short handle against a whole
+ * sentence, so equality would force every marker to restate a title.
+ *
+ * @param {{heading: string, body: string}[]} sections
+ * @param {string} anchor
+ */
+export function todoAnchorMatches(sections, anchor) {
+    const plain = (text) => text.replaceAll(/[`*_]/g, '');
+    return sections.filter((section) => plain(section.heading).includes(plain(anchor)));
+}
+
 // ─── Authored-data loading + validation ─────────────────────────────────────
 
 /**
@@ -510,7 +548,8 @@ export function loadStatusData(root, facts) {
     // Open TODOs: `### <title>` sections; a resolved TODO is DELETED, never
     // struck through — that rule is now machine-checked instead of remembered.
     const todosMd = read('open-todos.md');
-    const todoHeadings = [...todosMd.matchAll(/^### ([^\n]+)$/gm)].map((m) => m[1].trim());
+    const todoSectionList = todoSections(todosMd);
+    const todoHeadings = todoSectionList.map((section) => section.heading);
     if (todosMd && todoHeadings.length === 0) {
         failures.push('status/open-todos.md has no `### <title>` sections — one heading per open TODO.');
     }
@@ -536,10 +575,7 @@ export function loadStatusData(root, facts) {
     // anchor is work with no heading. Both are the ledger disagreeing with
     // reality, so both belong here.
     //
-    // Matched by containment, not equality: an anchor is a short handle
-    // (`open-todos: 12 test sites are parked`) and the heading is the full
-    // sentence, so requiring equality would force every marker to restate a
-    // whole title and drift on the first reword.
+    // How an anchor reaches a heading is {@link todoAnchorMatches}, shared not restated.
     //
     // COST, measured rather than asserted, because this rule advertises itself as
     // cheap and runs on every PR with no install and no build: +0.27 s over three
@@ -584,12 +620,7 @@ export function loadStatusData(root, facts) {
                 for (const m of text.matchAll(ANCHOR)) {
                     const anchor = m[1].trim();
                     if (!anchor) continue;
-                    // Headings are markdown (backticks, emphasis); an anchor in
-                    // a code comment is plain text. Compare with the formatting
-                    // removed so a heading may name a symbol as `code` without
-                    // forcing every marker to reproduce the punctuation.
-                    const plain = (t) => t.replace(/[`*_]/g, '');
-                    if (todoHeadings.some((h) => plain(h).includes(plain(anchor)))) continue;
+                    if (todoAnchorMatches(todoSectionList, anchor).length > 0) continue;
                     const line = text.slice(0, m.index).split('\n').length;
                     failures.push(
                         `${relative(root, file)}:${line}: deferral marker anchors to "open-todos: ${anchor}", ` +

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2247,3 +2247,36 @@ because "driven by X" was a plain text scan over every `.ts` under X — comment
 included. The original defect was caught only because it used the glob spelling
 `DATA_GRID_*_VECTORS`, which contains no individual name. Fixed by resolving
 drivers from usage: names outside a comment, in a `*.spec.ts`.
+
+### Adwaita renderer asymmetries with no verdict yet
+
+`scripts/check-storybook-widget-coverage.mjs` demands a verdict for every widget only
+one renderer ships (#1195): a `decision` with its reason, or a `gap` pointing here.
+Most are decisions with a reason next to them. These are the ones nobody has settled
+from outside the port — each is a product question, not scheduled work, which is
+exactly why they must not be written as decisions.
+
+- **`adw-checkbox` and `adw-radio` on NativeScript.** The headless half already
+  exists: `@gjsify/adwaita-core` carries `RadioGroupState` and `RADIO_GROUP_VECTORS`,
+  driven today by the browser suite alone. What does not exist is the decision.
+  `@nativescript/core` ships no checkbox view, and libadwaita's own phone idiom for a
+  boolean is `AdwSwitchRow`, which this port already has — so the question is whether
+  a checkbox belongs on a touch target at all, not how to build one.
+- **`adw-progress-bar` on NativeScript.** libadwaita styles the GtkProgressBar node in
+  `stylesheet/widgets/_progress-bar.scss` and the browser ships the element; the
+  NativeScript port has no progress widget of any kind. `AdwSpinner` wraps
+  `ActivityIndicator`, which is indeterminate only, so determinate progress has no
+  Adwaita expression there today.
+- **`adw-dialog` on NativeScript.** `AdwDialog` is a real upstream widget
+  (`adw-dialog.h`) and the port has the three SPECIALISED dialogs — alert, about,
+  preferences — but no generic one. Every NativeScript dialog here is deliberately the
+  platform sheet ("There is NO custom in-app modal here", `adw-alert-dialog.ts`), and
+  a content-agnostic dialog has no platform sheet to be. Whether it becomes an in-app
+  card over the `AdwBottomSheet` overlay machinery, or is not offered at all, is the
+  open decision.
+- **`adw-carousel-indicator-lines` on NativeScript.** `AdwCarouselIndicatorLines` is a
+  public widget upstream (`adw-carousel-indicator-lines.h`). The NativeScript carousel
+  builds a DOT row inline and has no lines variant in any form.
+
+When an issue is opened for one of these, its ledger entry points at `#<number>`
+instead and the bullet is deleted from here.

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2258,15 +2258,22 @@ exactly why they must not be written as decisions.
 
 - **`adw-checkbox` and `adw-radio` on NativeScript.** The headless half already
   exists: `@gjsify/adwaita-core` carries `RadioGroupState` and `RADIO_GROUP_VECTORS`,
-  driven today by the browser suite alone. What does not exist is the decision.
-  `@nativescript/core` ships no checkbox view, and libadwaita's own phone idiom for a
+  driven today by core's own spec (`checks.spec.ts`) and the browser suite, by no
+  NativeScript spec. What does not exist is the decision. `@nativescript/core` ships no
+  checkbox view (nothing under its `ui/`), and libadwaita's own phone idiom for a
   boolean is `AdwSwitchRow`, which this port already has — so the question is whether
   a checkbox belongs on a touch target at all, not how to build one.
 - **`adw-progress-bar` on NativeScript.** libadwaita styles the GtkProgressBar node in
   `stylesheet/widgets/_progress-bar.scss` and the browser ships the element; the
-  NativeScript port has no progress widget of any kind. `AdwSpinner` wraps
-  `ActivityIndicator`, which is indeterminate only, so determinate progress has no
-  Adwaita expression there today.
+  NativeScript port has no progress widget. The PLATFORM half is not what is missing:
+  `@nativescript/core` ships a determinate `Progress` (`value`/`maxValue`, `ui/progress`),
+  exported from the same package root this port already takes `Switch`, `Slider` and
+  `ActivityIndicator` from — unlike the checkbox above, this is not a platform survey.
+  What is open is the Adwaita EXPRESSION: `progressbar > trough > progress` has no
+  equivalent in the NativeScript CSS subset this theme is confined to, and `.osd`, the
+  text label and the fraction have no counterpart at all. So the question is what a
+  determinate Adwaita progress bar should even look like there, not whether one is
+  buildable.
 - **`adw-dialog` on NativeScript.** `AdwDialog` is a real upstream widget
   (`adw-dialog.h`) and the port has the three SPECIALISED dialogs — alert, about,
   preferences — but no generic one. Every NativeScript dialog here is deliberately the

--- a/status/sections/adwaita-web-roadmap.md
+++ b/status/sections/adwaita-web-roadmap.md
@@ -58,5 +58,14 @@ than none.
 Which widget is missing from which renderer is an asymmetric row in the derived matrix, so it is
 not listed here — the copy that used to sit here named `adw-icon` as NativeScript-only and
 `adw-data-grid` as browser-only after both had shipped on both sides. What a matrix cannot say is
-whether an asymmetry is a GAP or a DECISION; when one is settled, the reason goes next to the
-widget, the way `.inline` carries its reason in the style-class ledger.
+whether an asymmetry is a GAP or a DECISION, so that verdict sits next to the widget in
+`ONE_RENDERER_ONLY` (`scripts/check-storybook-widget-coverage.mjs`), the way `.inline` carries its
+reason in the style-class ledger: a `decision` with its reason, or a `gap` pointing at where the
+work is tracked, and the gate fails on an asymmetric widget with neither.
+
+Most of those verdicts were settled by reading `refs/libadwaita` rather than judged: only
+`adw-dialog`, `adw-window`, `adw-navigation-page` and the two carousel indicators have an Adw
+WIDGET upstream at all. The rest are stylesheet partials over a GTK primitive, or public Adw
+GObjects that are DATA rather than views — and for both, which renderer wrapped the thing in an
+element of its own is a rendering idiom, not a missing port. The ones nobody can settle from
+outside the ports are gaps, and `status/open-todos.md` says what each is waiting on.

--- a/status/sections/adwaita-web-roadmap.md
+++ b/status/sections/adwaita-web-roadmap.md
@@ -65,7 +65,9 @@ work is tracked, and the gate fails on an asymmetric widget with neither.
 
 Most of those verdicts were settled by reading `refs/libadwaita` rather than judged: only
 `adw-dialog`, `adw-window`, `adw-navigation-page` and the two carousel indicators have an Adw
-WIDGET upstream at all. The rest are stylesheet partials over a GTK primitive, or public Adw
-GObjects that are DATA rather than views — and for both, which renderer wrapped the thing in an
-element of its own is a rendering idiom, not a missing port. The ones nobody can settle from
-outside the ports are gaps, and `status/open-todos.md` says what each is waiting on.
+WIDGET upstream at all. The rest fall into three buckets — stylesheet partials over a GTK
+primitive, public Adw GObjects that are DATA rather than views, and markup or property forms with
+no upstream type of any kind (a GtkBuildable `<response>` child, a GtkWidget-typed property, a
+different library) — and for all three, which renderer wrapped the thing in an element of its own
+is a rendering idiom, not a missing port. The ones nobody can settle from outside the ports are
+gaps, and `status/open-todos.md` says what each is waiting on.


### PR DESCRIPTION
Closes #1195 — but the issue's list was wrong by more than the four places #1238 accounted for.

## The set is 23, not 11

Re-derived from `scripts/adwaita-elements.mjs` (the one reader #1238 established): **23 asymmetric widgets** —
21 browser-only, 2 NativeScript-only, 44 on both.

The issue counted 7 + 4. Beyond the four errors #1238 already named (`adw-checks` is a filename whose file
defines `adw-checkbox` and `adw-radio`; `adw-source-view` lives outside `elements/`; `adw-accent` is not a
widget; `adw-preferences-page` IS on the browser), the filename reader **collapsed twelve child tags into their
parent file** and nobody had noticed:

`alert-response` · `bottom-sheet-content` · `bottom-sheet-sheet` · `carousel-indicator-dots` ·
`carousel-indicator-lines` · `navigation-page` · `sidebar-item` · `sidebar-section` · `tab-page` · `toggle` ·
`view-stack-page` · `view-switcher-page`

`adw-alert-dialog.ts` read as `alert-dialog`, which is symmetric — so `<adw-alert-response>` never appeared in
any list at all. Every one of the 23 now has an entry.

## Verdicts moved, derived, or refused — never invented

The issue's author refused to guess eleven verdicts. That constraint held.

**Five moved from source headers**, quoted rather than paraphrased: `popover` (the action-sheet substitution
recorded in the NativeScript `adw-drop-down.ts`), `image-button`, `slider-row`, `window` (the `<Page>` carries
`class="adw-window"` and the theme styles `Page.adw-window` — the Page *is* the window), and `switch`.

One caveat worth stating: `adw-switch.ts:7-8` does **not** say what the brief claimed. It says there is no core
state machine — a statement that there is no behaviour to port, not a statement about NativeScript. The entry
cites both halves separately rather than stretching one quote over both.

**The C source settled the rest, and it settled them into three buckets, not one.** Parsed `src_headers` out of
`refs/libadwaita/src/meson.build` (89 public headers) and every `G_DECLARE_*_TYPE` in them:

- **stylesheet partials over a GTK primitive** — `card`, `popover`, `progress-bar`, `switch`, `checkbox`,
  `radio`, `image-button`, `slider-row`. No `Adw*` type of any kind; which renderer wrapped the primitive is a
  rendering idiom, not a missing port.
- **public Adw GObjects that are DATA** — `AdwSidebarItem`, `AdwSidebarSection`, `AdwTabPage`, `AdwToggle`,
  `AdwViewStackPage`. The browser needs a *tag* to declare data in markup; NativeScript passes the object.
- **markup or property forms with no type at all** — a GtkBuildable `<response>` child, two GtkWidget-typed
  properties, a different library (`GtkSourceView`), and `view-switcher-page`, which has no upstream type at all.

Three are real `GtkWidget` types the brief did not anticipate: `AdwNavigationPage`,
`AdwCarouselIndicatorDots`, `AdwCarouselIndicatorLines`.

**Five refused — recorded as open gaps, not verdicts:** `checkbox`, `radio`, `progress-bar`, `dialog`,
`carousel-indicator-lines`. Each names the open question in `status/open-todos.md` rather than answering it.

## The mechanism

A second ledger in `check-storybook-widget-coverage.mjs`, symmetric with the first. Discriminated entries —
`{ only, decision }` or `{ only, gap }`, never both — with a 40-character reason floor (the
`check-nativescript-theme-classes.mjs` precedent) and a checked gap pointer: either `#<issue>` or an
`open-todos:` anchor that must be contained in a `###` heading, which is the vocabulary `gjsify/todo-needs-anchor`
already sanctions, so no issue number is fabricated.

Six rules, each A/B-proven: no entry for an asymmetric widget; an entry whose widget landed on both; an entry for
a widget on neither; **`only` must match the derived side**, so an asymmetry that FLIPS fails instead of reading
as still-covered; a dangling gap anchor; and — added in review — the anchored section's **body** must name the
widget, because deleting the section's bullets while keeping the heading left five widgets pointing at nothing,
green.

An optional `vectors:` field names tables a decision strands on one renderer, cross-checked, so the ledger
doubles as the port-cost record.

## What review caught

Two reasons over-claimed and were weakened to what their sources support: `bottom-sheet` (HTML *does* have slot
routing — the real reason is in the docstring six lines above, that `<child type="sheet">` leaves nothing in the
tree) and `image-button` (`.image-button` has zero hits under `scss/`; it is the split button's CSS-node mirror,
unstyled).

One factual claim in the brief was wrong and is corrected here: `@nativescript/core` **does** ship a determinate
`Progress` (`value`/`maxValue`), from the same import site the port already takes `Switch` and `Slider` from. So
`adw-progress-bar` on NativeScript is not "the platform cannot express it" — the platform half exists, and what
is open is the Adwaita expression (`progressbar > trough > progress` has no CSS-subset equivalent).

Two duplicated resolvers were merged rather than left to drift: the open-todos anchor resolver now has one
implementation, exported from `generate-status.mjs` and used by both callers, after the second copy was measured
falsely rejecting a heading quoted verbatim.

## Side-findings for a follow-up, not fixed here

`.adw-card` is emitted by the NativeScript showcase (`carousel.ns.ts:28`) and styled by **no** CSS rule anywhere
in the repo. `check-nativescript-theme-classes.mjs` scans only `packages/nativescript-bridge/adwaita/src`, so a
class emitted from a showcase is gated by nothing — the #1123 shape one directory over. Recorded in the entry;
closing it means deciding what an Adwaita card looks like in the NativeScript CSS subset.

## Scope

The upstream-type ledger (the libadwaita types no port ships at all) is deliberately **not** here. Same shape,
own PR.
