### PR TITLE
ci: fail the cut on an empty ship glob

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -256,6 +256,15 @@ jobs:
       - name: Check inline workflow scripts are not self-truncating
         run: node scripts/check-workflow-inline-scripts.mjs
 
+      # A release asset uploaded by GLOB with no `fail_on_unmatched_files` is the
+      # same failure one layer out: the glob matches nothing, the upload is empty,
+      # and the job is green. `release-cut.yml` is the only workflow that puts
+      # installable packages on a release and it never runs on a pull request, so
+      # this is the only place its upload gets read before a cut. Incident in the
+      # script header.
+      - name: Check release uploads cannot glob to nothing
+        run: node scripts/check-workflow-release-globs.mjs
+
       # An e2e suite on disk that no script names runs NOWHERE. 12 of 112 were in that
       # state, eleven of them by oversight — including the one written to cover the
       # release gate that let v0.28.0 publish half its packages, whose PR body claimed it
@@ -701,6 +710,15 @@ jobs:
       # a release. Incident + scope in the script header.
       - name: Check inline workflow scripts are not self-truncating
         run: node scripts/check-workflow-inline-scripts.mjs
+
+      # A release asset uploaded by GLOB with no `fail_on_unmatched_files` is the
+      # same failure one layer out: the glob matches nothing, the upload is empty,
+      # and the job is green. `release-cut.yml` is the only workflow that puts
+      # installable packages on a release and it never runs on a pull request, so
+      # this is the only place its upload gets read before a cut. Incident in the
+      # script header.
+      - name: Check release uploads cannot glob to nothing
+        run: node scripts/check-workflow-release-globs.mjs
 
       # An e2e suite on disk that no script names runs NOWHERE. 12 of 112 were in that
       # state, eleven of them by oversight — including the one written to cover the

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -370,6 +370,12 @@ jobs:
           # `body`): targeting an EXISTING release uploads the assets onto it and
           # leaves the release notes release-it computed alone.
           tag_name: ${{ steps.assets.outputs.tag }}
+          # The two `ship` entries are GLOBS, and this action's default for
+          # `fail_on_unmatched_files` is false — so without the flag, a renamed
+          # `outDir` or a format that stops being written uploads nothing and
+          # leaves this step green. `scripts/check-workflow-release-globs.mjs`
+          # keeps the shape from regrowing; the flag is what makes it fail here.
+          fail_on_unmatched_files: true
           files: |
             install.mjs
             packages/infra/cli/dist/cli.gjs.mjs
@@ -392,12 +398,33 @@ jobs:
           TAG: ${{ steps.assets.outputs.tag }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
           base="https://github.com/$REPO/releases"
+
+          # The packages are globbed onto the release, so "ship built nothing" and
+          # "everything uploaded" are indistinguishable from here unless the set is
+          # COUNTED first — and the URL loop below cannot count it, because a name
+          # carries the version and the arch label (`gjsify_1.2.3-1_all.deb`), so it
+          # has to be read off disk rather than written down. `gjsify self-update`
+          # refuses for a system-prefix install and points at exactly these assets,
+          # which is the sentence an empty upload would make false.
+          debs=(packages/infra/cli/ship/out/*.deb)
+          rpms=(packages/infra/cli/ship/out/*.rpm)
+          if [ "${#debs[@]}" -eq 0 ] || [ "${#rpms[@]}" -eq 0 ]; then
+            echo "::error::gjsify ship wrote ${#debs[@]} .deb and ${#rpms[@]} .rpm into packages/infra/cli/ship/out — expected at least one of each."
+            exit 1
+          fi
+
+          urls=("$base/latest/download/install.mjs" \
+                "$base/latest/download/cli.gjs.mjs" \
+                "$base/download/$TAG/install.mjs" \
+                "$base/download/$TAG/cli.gjs.mjs")
+          for package in "${debs[@]}" "${rpms[@]}"; do
+            urls+=("$base/download/$TAG/$(basename "$package")")
+          done
+
           fail=0
-          for url in "$base/latest/download/install.mjs" \
-                     "$base/latest/download/cli.gjs.mjs" \
-                     "$base/download/$TAG/install.mjs" \
-                     "$base/download/$TAG/cli.gjs.mjs"; do
+          for url in "${urls[@]}"; do
             code=""
             for attempt in 1 2 3 4 5 6; do
               code="$(curl -sILo /dev/null -w '%{http_code}' "$url" || echo 000)"

--- a/scripts/check-workflow-release-globs.mjs
+++ b/scripts/check-workflow-release-globs.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Refuse a release upload whose `files:` globs without `fail_on_unmatched_files`.
+//
+// THE INCIDENT — measured, not hypothetical
+//
+// `release-cut.yml`'s "Upload installer + bootstrap bundle to the release" step
+// hardcodes `packages/infra/cli/ship/out/*.deb` and `*.rpm` into
+// `softprops/action-gh-release`. That action's default for
+// `fail_on_unmatched_files` is FALSE, so a glob matching nothing uploads nothing and
+// exits 0: rename `gjsify.ship.outDir`, change an artifact filename, add a format that
+// silently stops being written — and the release carries no installable packages with
+// the cut job green. The gate that runs immediately after ("Assert the documented
+// install URLs resolve") checks only `install.mjs` and `cli.gjs.mjs`, so nothing else
+// in the pipeline can notice either.
+//
+// What it would cost: `gjsify self-update` REFUSES to run from a system prefix,
+// because writing the XDG prefix there would leave the user with two installs, and it
+// points at `releases/latest` instead — `utils/install-provenance.ts` says the release
+// assets "are the one answer that is true on every distribution". An empty upload
+// makes that sentence false for everyone who installed the `.deb` or the `.rpm`.
+//
+// The convention already exists everywhere else and this one upload does not use it:
+// `if-no-files-found: error` appears 33 times across `.github/workflows/`, while
+// `fail_on_unmatched_files` appeared 0 times in the whole repository before this check.
+//
+// WHAT IT CHECKS
+//
+// For every step using `softprops/action-gh-release`: if any `files:` entry contains a
+// glob metacharacter (`*`, `?`, `[`), the same step must carry
+// `fail_on_unmatched_files: true`. A literal file list needs no flag — a missing
+// literal path is already an error in that action — so the check is scoped to the one
+// shape whose failure is silent.
+//
+// No YAML parsing, by the same reasoning as `check-workflow-inline-scripts.mjs`: the
+// defect is lexical (one absent key beside one glob), a parser is a dependency this
+// script would have to justify, and the step boundaries are readable from indentation
+// alone. The cost is that a `files:` value produced by an expression is invisible to
+// it; that is a deliberate under-reach, not an oversight — a check with false
+// positives gets disabled, and then protects nothing.
+//
+// Usage: node scripts/check-workflow-release-globs.mjs [--root <dir>]
+// Exits 1 and names file:line + the offending entry on any finding.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const args = process.argv.slice(2);
+const rootIndex = args.indexOf('--root');
+const root = rootIndex === -1 ? process.cwd() : args[rootIndex + 1];
+const workflowDir = join(root, '.github', 'workflows');
+
+const RELEASE_ACTION = /uses:\s*softprops\/action-gh-release(?:[@\s]|$)/;
+const GLOB = /[*?[]/;
+
+/** Leading-space count; a line that is only whitespace has no meaningful indent. */
+function indentOf(line) {
+    return line.length - line.trimStart().length;
+}
+
+function isBlank(line) {
+    const trimmed = line.trim();
+    return trimmed === '' || trimmed.startsWith('#');
+}
+
+/**
+ * The line range of the step containing `usesLine`.
+ *
+ * A step is a YAML sequence item, so its first line is the nearest `- ` at an indent
+ * BELOW the keys it contains, and it ends at the next line that is not indented past
+ * that marker. Both bounds are read from the file rather than assumed, because
+ * `.github/workflows/` in this repo indents steps under both `jobs.<id>.steps` and
+ * inside composite `runs.steps`.
+ */
+function stepRange(lines, usesLine) {
+    const usesIndent = indentOf(lines[usesLine]);
+    let start = usesLine;
+    let markerIndent = usesIndent;
+    if (!lines[usesLine].trimStart().startsWith('- ')) {
+        for (let i = usesLine - 1; i >= 0; i--) {
+            if (isBlank(lines[i])) continue;
+            const indent = indentOf(lines[i]);
+            if (indent < usesIndent && lines[i].trimStart().startsWith('- ')) {
+                start = i;
+                markerIndent = indent;
+                break;
+            }
+            if (indent < usesIndent && !lines[i].trimStart().startsWith('- ')) break;
+        }
+    }
+    let end = lines.length;
+    for (let i = start + 1; i < lines.length; i++) {
+        if (isBlank(lines[i])) continue;
+        if (indentOf(lines[i]) <= markerIndent) {
+            end = i;
+            break;
+        }
+    }
+    return { start, end };
+}
+
+/** The `files:` entries of a step, as `{ line, text }`, inline and block forms alike. */
+function filesEntries(lines, start, end) {
+    const entries = [];
+    for (let i = start; i < end; i++) {
+        const match = /^\s*files:\s*(.*)$/.exec(lines[i]);
+        if (!match) continue;
+        const inline = match[1].trim();
+        if (inline !== '' && inline !== '|' && inline !== '>' && !inline.startsWith('|') && !inline.startsWith('>')) {
+            entries.push({ line: i + 1, text: inline });
+            continue;
+        }
+        const blockIndent = indentOf(lines[i]);
+        for (let j = i + 1; j < end; j++) {
+            if (lines[j].trim() === '') continue;
+            if (indentOf(lines[j]) <= blockIndent) break;
+            if (lines[j].trim().startsWith('#')) continue;
+            entries.push({ line: j + 1, text: lines[j].trim() });
+        }
+    }
+    return entries;
+}
+
+const findings = [];
+
+function checkFile(path) {
+    const rel = relative(root, path);
+    const lines = readFileSync(path, 'utf-8').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].trim().startsWith('#')) continue;
+        if (!RELEASE_ACTION.test(lines[i])) continue;
+
+        const { start, end } = stepRange(lines, i);
+        const globbed = filesEntries(lines, start, end).filter((entry) => GLOB.test(entry.text));
+        if (globbed.length === 0) continue;
+
+        const flag = lines.slice(start, end).find((line) => line.includes('fail_on_unmatched_files:'));
+        const value = flag === undefined ? undefined : /fail_on_unmatched_files:\s*(\S+)/.exec(flag)?.[1];
+        if (value === 'true') continue;
+
+        for (const entry of globbed) {
+            findings.push({
+                file: rel,
+                line: entry.line,
+                detail:
+                    value === undefined
+                        ? 'globbed release asset with no `fail_on_unmatched_files` — a glob matching nothing uploads nothing and exits 0'
+                        : `globbed release asset with \`fail_on_unmatched_files: ${value}\` — only \`true\` turns an empty match into a failure`,
+                text: entry.text,
+            });
+        }
+    }
+}
+
+let files;
+try {
+    files = readdirSync(workflowDir).filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'));
+} catch (error) {
+    console.error(`check-workflow-release-globs: cannot read ${workflowDir}: ${error.message}`);
+    process.exit(1);
+}
+
+for (const name of files.sort()) checkFile(join(workflowDir, name));
+
+if (findings.length) {
+    console.error(`check-workflow-release-globs: ${findings.length} silent-empty release upload(s)\n`);
+    for (const finding of findings) {
+        console.error(`  ${finding.file}:${finding.line} — ${finding.detail}`);
+        console.error(`    ${finding.text}\n`);
+    }
+    console.error(
+        'Fix by adding `fail_on_unmatched_files: true` beside `files:` in that step. A release\n' +
+            'that silently loses an asset is not visible anywhere downstream: the install-URL gate\n' +
+            'checks a fixed list, and `gjsify self-update` sends system-prefix installs to exactly\n' +
+            'the assets that were not uploaded.',
+    );
+    process.exit(1);
+}
+
+console.log(`check-workflow-release-globs: ${files.length} workflow(s) clean.`);


### PR DESCRIPTION
`release-cut.yml` globs the `.deb` and `.rpm` onto the release, and `softprops/action-gh-release` defaults `fail_on_unmatched_files` to **false**. So a renamed `gjsify.ship.outDir`, a changed artifact filename, or a format that silently stops being written uploads **nothing** and leaves the cut job green. The gate immediately after it checks only `install.mjs` and `cli.gjs.mjs`, so nothing downstream notices either.

What that costs: `gjsify self-update` refuses to run from a system prefix — writing the XDG prefix there would leave the user with two installs — and points at `releases/latest` instead. `utils/install-provenance.ts` calls those assets *"the one answer that is true on every distribution"*. An empty upload makes that sentence false for everyone who installed the package.

The convention already exists everywhere else and this one upload did not use it: `if-no-files-found: error` appears **33** times across `.github/workflows/`, while `fail_on_unmatched_files` appeared **0** times in the repository.

## Three parts, because the flag alone would only fix today's spelling

1. **`fail_on_unmatched_files: true`** on the upload step.
2. **The install-URL gate now counts what `ship` wrote** and asserts each package's release URL. The names are read off disk rather than written down, because they carry the version and the arch label (`gjsify_1.2.3-1_all.deb`); an empty `ship/out` fails with `::error::` before the loop.
3. **`scripts/check-workflow-release-globs.mjs`** refuses any `action-gh-release` step that globs without the flag, wired into both `audit-runtimes` jobs. `release-cut.yml` never runs on a pull request, so that is the only place its upload is read before a cut — the same reasoning as the sibling `check-workflow-inline-scripts.mjs`. No YAML parsing: the defect is lexical, one absent key beside one glob.

## Checked in both directions

The new script fails a glob with no flag and a glob with `fail_on_unmatched_files: false`, and passes a literal file list (with a glob in the *next* step, so the step boundary is exercised) and a flagged glob. The counting guard exits 1 on an empty `ship/out` and builds the four asset URLs when it is populated. `bash -n` clean on the edited `run:` block, both workflows parse as YAML, `oxfmt --check` and `oxlint` clean, `tests/e2e/ship-declaration` 7/7.

Sibling: #1253 — the ADR amendment that records why `ship` grows host-bound formats. Independent; either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECGLXroeGMkcKqRhcczXhX