### PR TITLE
feat(adwaita-web): make every activatable row a tab stop

### DIFF
--- a/packages/web/adwaita-web/src/elements/adw-action-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-action-row.ts
@@ -17,6 +17,7 @@
 import { ActionRowState } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
+import { type AdwRowActivation, attachRowActivation } from './row-activation.js';
 
 /**
  * Attributes whose change means the activatable widget's sensitivity may have
@@ -41,6 +42,8 @@ export class AdwActionRow extends HTMLElement {
     /** Watches the activatable widget's `disabled`/`aria-disabled` — the live binding. */
     private _sensitivityObserver: MutationObserver | null = null;
     private _initialized = false;
+    /** Tab stop + Enter/Space, re-derived whenever `activatable` moves. */
+    private _activation?: AdwRowActivation;
 
     static get observedAttributes() {
         return ['title', 'subtitle', 'activatable'];
@@ -118,6 +121,9 @@ export class AdwActionRow extends HTMLElement {
         this._render();
 
         this.addEventListener('click', (event) => this._onClick(event));
+        // Only while `activatable` — a plain action row is a label, and a label that
+        // takes Tab makes every static row in a group a stop.
+        this._activation = attachRowActivation({ row: this, activatable: () => this._state.activatable });
     }
 
     /** Copy the declarative attributes into the headless state. */
@@ -186,6 +192,7 @@ export class AdwActionRow extends HTMLElement {
         this._subtitleEl.textContent = subtitle;
         this._subtitleEl.hidden = !subtitleVisible;
         this.classList.toggle('activatable', this._state.activatable);
+        this._activation?.sync();
     }
 }
 

--- a/packages/web/adwaita-web/src/elements/adw-button-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-button-row.ts
@@ -22,6 +22,7 @@
 import { BUTTON_ROW_ACTIVATABLE, ButtonRowState } from '@gjsify/adwaita-core';
 
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
+import { attachRowActivation } from './row-activation.js';
 
 export class AdwButtonRow extends HTMLElement {
     private _contentsEl!: HTMLDivElement;
@@ -58,6 +59,8 @@ export class AdwButtonRow extends HTMLElement {
         this.addEventListener('click', () => {
             this.dispatchEvent(new CustomEvent('activated', { bubbles: true }));
         });
+        // `BUTTON_ROW_ACTIVATABLE`, not an attribute read: there is no opt-out to read.
+        attachRowActivation({ row: this, activatable: () => BUTTON_ROW_ACTIVATABLE });
     }
 
     attributeChangedCallback() {

--- a/packages/web/adwaita-web/src/elements/adw-expander-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-expander-row.ts
@@ -32,6 +32,7 @@ import { bindEmptySections } from '../empty-sections.js';
 import './adw-switch.js';
 import type { AdwSwitch } from './adw-switch.js';
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
+import { attachRowActivation } from './row-activation.js';
 
 export class AdwExpanderRow extends HTMLElement {
     private _headerEl!: HTMLDivElement;
@@ -162,6 +163,11 @@ export class AdwExpanderRow extends HTMLElement {
             }
         });
 
+        // adw-expander-row.c:123 — `grab_focus` forwards to the header row, so the header
+        // is both the focus target and the disclosure control. Enter and Space go through
+        // its click handler, which is what a pointer already uses.
+        attachRowActivation({ row: this._headerEl, activatable: () => true });
+
         this._enableSwitch.addEventListener('notify::active', (event) => {
             // The switch's own notify stops at the row: the row publishes
             // `notify::enable-expansion`, and letting `notify::active` past would give
@@ -210,6 +216,9 @@ export class AdwExpanderRow extends HTMLElement {
         this._reflectingEnable = false;
 
         this.classList.toggle('expanded', this.expanded);
+        // adw-expander-row.c:657 keeps GTK_ACCESSIBLE_STATE_EXPANDED on the header row in
+        // step with the flag; `aria-expanded` is the same statement to the same reader.
+        this._headerEl.setAttribute('aria-expanded', String(this.expanded));
         this._contentEl.classList.toggle('expanded', this.expanded);
     }
 }

--- a/packages/web/adwaita-web/src/elements/adw-preferences-group.ts
+++ b/packages/web/adwaita-web/src/elements/adw-preferences-group.ts
@@ -115,6 +115,10 @@ export class AdwPreferencesGroup extends HTMLElement {
         for (const child of rowChildren) this._listboxEl.appendChild(child);
 
         this.replaceChildren(this._headerEl, this._listboxEl);
+        // adw-preferences-group.c:319 — GTK_ACCESSIBLE_ROLE_GROUP. A GROUP, not a list:
+        // that is why the rows inside carry no `listitem` role, which outside a list
+        // would be worse than none.
+        this.setAttribute('role', 'group');
 
         this._renderHeader();
         this._observeHost();

--- a/packages/web/adwaita-web/src/elements/adw-switch-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-switch-row.ts
@@ -25,6 +25,7 @@ import { SwitchRowState, deriveRowLabels } from '@gjsify/adwaita-core';
 // without `verbatimModuleSyntax`, so TypeScript would elide the statement and take the
 // registration with it.
 import './adw-switch.js';
+import { attachRowActivation } from './row-activation.js';
 import type { AdwSwitch } from './adw-switch.js';
 
 export class AdwSwitchRow extends HTMLElement {
@@ -62,6 +63,8 @@ export class AdwSwitchRow extends HTMLElement {
         text.append(this._titleEl, this._subtitleEl);
 
         this._switchEl = document.createElement('adw-switch') as AdwSwitch;
+        // adw-switch-row.c:159 — the slider is not a focus target; the ROW is.
+        this._switchEl.unfocusable = true;
 
         this.replaceChildren(text, this._switchEl);
 
@@ -85,6 +88,10 @@ export class AdwSwitchRow extends HTMLElement {
             if (event.target instanceof Node && this._switchEl.contains(event.target)) return;
             this._apply(this._state.activate());
         });
+
+        // adw-switch-row.c:160 makes the row itself activatable. Enter and Space run the
+        // same transition a click does, through the row's own click handler.
+        attachRowActivation({ row: this, activatable: () => true });
 
         this._renderText();
     }

--- a/packages/web/adwaita-web/src/elements/adw-switch.ts
+++ b/packages/web/adwaita-web/src/elements/adw-switch.ts
@@ -35,7 +35,23 @@ export class AdwSwitch extends HTMLElement {
     private _initialized = false;
 
     static get observedAttributes() {
-        return ['active', 'disabled'];
+        return ['active', 'disabled', 'unfocusable'];
+    }
+
+    /**
+     * `Gtk.Widget:can-focus` on the slider, inverted so the default stays "yes".
+     *
+     * `adw_switch_row_init` does `gtk_widget_set_can_focus (self->slider, FALSE)`
+     * (adw-switch-row.c:159) and makes the ROW activatable instead, so a switch row is ONE
+     * tab stop announced as its own title — not a bare checkbox followed by a label that
+     * cannot be reached. A standalone `<adw-switch>` keeps its checkbox focusable.
+     */
+    get unfocusable(): boolean {
+        return this.hasAttribute('unfocusable');
+    }
+
+    set unfocusable(value: boolean) {
+        this.toggleAttribute('unfocusable', !!value);
     }
 
     /** Whether the switch is on. */
@@ -103,6 +119,8 @@ export class AdwSwitch extends HTMLElement {
         const disabled = this.disabled;
         this._input.checked = this.active;
         this._input.disabled = disabled;
+        if (this.unfocusable) this._input.tabIndex = -1;
+        else this._input.removeAttribute('tabindex');
         this.classList.toggle('disabled', disabled);
     }
 }

--- a/packages/web/adwaita-web/src/elements/row-activation.ts
+++ b/packages/web/adwaita-web/src/elements/row-activation.ts
@@ -1,0 +1,92 @@
+// Tab stop and Enter/Space activation for the rows that libadwaita makes activatable.
+//
+// THE INCIDENT
+//
+// Measured in Firefox on an `<adw-preferences-group>` holding an activatable
+// `<adw-action-row>`, an `<adw-button-row>` and an `<adw-expander-row>`: Tab reached NONE
+// of them. Every one reported `tabIndex` `-1` and `role` `null` while all three activated
+// on click, so the whole group was operable by mouse and invisible to a keyboard. The only
+// things Tab did reach inside a group were the NATIVE controls a row happens to contain —
+// `<adw-switch-row>`'s bare checkbox and `<adw-combo-row>`'s `<select>` — i.e. the row was
+// never the thing that took focus, even where upstream says it is.
+//
+// GTK gives this free and the web renderer does not inherit it: every one of these extends
+// `GtkListBoxRow`, which is focusable by construction and activates on Enter and Space.
+//
+// WHICH ROWS, AND WHY EACH
+//
+// Derived from the C, not chosen — a row that is a tab stop it should not be turns every
+// static label into a stop, and one that is not becomes unreachable:
+//
+//   - `<adw-action-row>` only while `activatable`. A plain row is a label.
+//   - `<adw-button-row>` always: `adw-button-row.c:31` says "AdwButtonRow is always
+//     activatable", and the upstream template hardcodes it.
+//   - `<adw-expander-row>` always, on its HEADER — `adw_expander_row_grab_focus`
+//     (adw-expander-row.c:123) forwards focus to `priv->action_row`, so the header row is
+//     the focus target and the disclosure control at once.
+//   - `<adw-switch-row>` on the ROW, and its slider stops being a tab stop:
+//     `adw_switch_row_init` sets `gtk_widget_set_can_focus (self->slider, FALSE)`
+//     (adw-switch-row.c:159) and `gtk_list_box_row_set_activatable (…, TRUE)` (:160).
+//
+// `<adw-combo-row>` is deliberately NOT here. Its control is a native `<select>` stretched
+// over the row: already a tab stop, already a combobox to the accessibility tree, already
+// arrow-navigable, and already `disabled` at one option or fewer — which is exactly
+// `gtk_list_box_row_set_activatable (…, n_items > 1)` (adw-combo-row.c:194) without a line
+// of our own. Making the row the tab stop would take focus off it and put a SECOND
+// combobox in the tree.
+//
+// The key set is `GtkListBoxRow`'s: Enter and Space. Space is prevented because the
+// browser would otherwise scroll the page under the row the user just activated.
+
+/** What a row needs to become the keyboard's idea of one activatable thing. */
+export interface AdwRowActivationInit {
+    /** The element that becomes the tab stop and receives the keys. */
+    row: HTMLElement;
+    /** Re-read on every {@link AdwRowActivation.sync}: is the row activatable right now? */
+    activatable: () => boolean;
+    /**
+     * What Enter and Space do. Defaults to `row.click()` so a row keeps ONE activation
+     * path — the click handler it already has — rather than growing a second one that can
+     * drift from it.
+     */
+    activate?: () => void;
+}
+
+export interface AdwRowActivation {
+    /** Re-derive the tab stop after anything that can change `activatable()`. */
+    sync(): void;
+}
+
+/**
+ * Make `row` a tab stop while it is activatable, and activate it on Enter and Space.
+ *
+ * The listener is the element's OWN and is bound once, without teardown: it survives a
+ * re-parent and is collected with the element, so there is nothing here for
+ * `check-adwaita-connect-rebind.mjs` to hold. Only bindings that reach outside the element
+ * need releasing and re-arming.
+ */
+export function attachRowActivation(init: AdwRowActivationInit): AdwRowActivation {
+    const { row, activatable } = init;
+    const activate = init.activate ?? (() => row.click());
+
+    row.addEventListener('keydown', (event: KeyboardEvent) => {
+        // A child control owns its own keys: a `<select>`, an entry's `<input>` and a
+        // suffix button all use Enter or Space for something else, and swallowing them
+        // here would break the control to activate the row it sits in.
+        if (event.target !== row) return;
+        if (!activatable()) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        activate();
+    });
+
+    const sync = () => {
+        // `removeAttribute`, not `tabIndex = -1`: a row that is not activatable is not
+        // focusable at all upstream, and writing `-1` would make every static label
+        // programmatically focusable instead.
+        if (activatable()) row.tabIndex = 0;
+        else row.removeAttribute('tabindex');
+    };
+    sync();
+    return { sync };
+}

--- a/packages/web/adwaita-web/src/keyboard-operable.spec.ts
+++ b/packages/web/adwaita-web/src/keyboard-operable.spec.ts
@@ -457,4 +457,72 @@ export const AdwKeyboardOperableTest = async () => {
             el.remove();
         });
     });
+
+    await describe('the row family is a tab stop where libadwaita makes one', async () => {
+        const mount = (markup: string) => {
+            const host = document.createElement('div');
+            host.innerHTML = markup;
+            document.body.append(host);
+            return host;
+        };
+
+        await it('takes a tab stop only where the row is activatable', () => {
+            const host = mount(
+                '<adw-preferences-group title="G">' +
+                    '<adw-action-row id="k-act" title="Act" activatable></adw-action-row>' +
+                    '<adw-action-row id="k-plain" title="Plain"></adw-action-row>' +
+                    '<adw-button-row id="k-btn" title="Btn"></adw-button-row>' +
+                    '<adw-switch-row id="k-sw" title="Sw"></adw-switch-row>' +
+                    '</adw-preferences-group>',
+            );
+            const at = (id: string) => document.getElementById(id) as HTMLElement;
+            // `tabIndex` alone cannot tell "not a stop" from "not set": a custom element
+            // reports -1 for both. The ATTRIBUTE is the thing the row wrote.
+            expect(at('k-act').getAttribute('tabindex')).toBe('0');
+            expect(at('k-plain').hasAttribute('tabindex')).toBe(false);
+            expect(at('k-btn').getAttribute('tabindex')).toBe('0');
+            expect(at('k-sw').getAttribute('tabindex')).toBe('0');
+            // adw-switch-row.c:159 — the slider is not a focus target; the row is.
+            expect(at('k-sw').querySelector('input')?.tabIndex).toBe(-1);
+            host.remove();
+        });
+
+        await it('follows `activatable` when it moves', () => {
+            const host = mount('<adw-action-row id="k-move" title="Move"></adw-action-row>');
+            const row = document.getElementById('k-move') as HTMLElement;
+            expect(row.hasAttribute('tabindex')).toBe(false);
+            row.toggleAttribute('activatable', true);
+            expect(row.getAttribute('tabindex')).toBe('0');
+            row.toggleAttribute('activatable', false);
+            expect(row.hasAttribute('tabindex')).toBe(false);
+            host.remove();
+        });
+
+        await it('activates on Enter and Space, and lets a child keep its own keys', () => {
+            const host = mount(
+                '<adw-action-row id="k-keys" title="Keys" activatable></adw-action-row>' +
+                    '<adw-combo-row id="k-combo" title="Combo" items=\'["a","b"]\'></adw-combo-row>',
+            );
+            const row = document.getElementById('k-keys') as HTMLElement;
+            let activated = 0;
+            row.addEventListener('activated', () => activated++);
+            const press = (el: HTMLElement, key: string) =>
+                el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+            press(row, 'Enter');
+            press(row, ' ');
+            press(row, 'a');
+            expect(activated).toBe(2);
+
+            // A `<select>` uses Space itself; swallowing it to activate the row around it
+            // would break the control to reach the thing it sits in.
+            const select = document.getElementById('k-combo')?.querySelector('select') as HTMLElement;
+            let prevented: boolean | null = null;
+            select.addEventListener('keydown', (event) => {
+                prevented = event.defaultPrevented;
+            });
+            press(select, ' ');
+            expect(prevented).toBe(false);
+            host.remove();
+        });
+    });
 };

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2214,71 +2214,31 @@ rather than adding a second one here.
 `packages/web/adwaita-web/src/keyboard-operable.spec.ts` awaits that microtask
 and says why.
 
-### The adwaita-web row family is not keyboard-reachable at all
+### `<adw-toggle-group>` is upstream's fifth roving widget and has none of it
 
-Measured in Firefox against a built `dist/test.browser.mjs`, on a
-`<adw-preferences-group>` holding an activatable `<adw-action-row>`, an
-`<adw-button-row>` and an `<adw-expander-row>`, with a `<button>` before and after
-it: Tab went straight from the button before the group to the button after it.
-All three rows report `tabIndex` `-1` and `role` `null`, and the expander
-publishes no `aria-expanded` — while all three activate on click. The whole group
-is invisible to a keyboard.
+The row-family half of this entry is CLOSED: `<adw-action-row>` (while `activatable`),
+`<adw-button-row>`, `<adw-expander-row>`'s header and `<adw-switch-row>` are tab stops that
+activate on Enter and Space, `<adw-preferences-group>` declares
+`GTK_ACCESSIBLE_ROLE_GROUP`, and `<adw-switch-row>`'s slider stopped being a focus target
+the way `adw_switch_row_init` does it. `<adw-combo-row>` was measured NOT to need it — its
+native `<select>` is already the combobox, already arrow-navigable, and already `disabled`
+at one option or fewer, which is `adw-combo-row.c:194` without a line of our own.
 
-GTK gives this free and adwaita-web does not inherit it: every one of these
-extends `GtkListBoxRow`, which is focusable by construction and activates on
-Enter/Space. The pieces the C declares that the web renderer does not are exact —
-`adw-expander-row.c:657` updates `GTK_ACCESSIBLE_STATE_EXPANDED` on the header
-row on every toggle (i.e. `aria-expanded`), `adw-switch-row.c:147` declares
-`GTK_ACCESSIBLE_ROLE_SWITCH`, `adw-combo-row.c:734` `GTK_ACCESSIBLE_ROLE_COMBO_BOX`,
-and `adw-preferences-group.c:319` `GTK_ACCESSIBLE_ROLE_GROUP`. Action, button and
-preferences rows declare no role of their own and inherit the list-item one.
-
-DELIBERATELY NOT FIXED beside the modal trap and the roving tabindex (which are
-invisible until pressed, and were): this one MOVES TAB ORDER on every page that
-uses a row, and every row instance under `website/` — where they are concentrated
-— either becomes a new tab stop or has to be argued out of becoming one. Rolling
-it in would have made the two fixes that change nothing visible indistinguishable
-from the one that changes every page. (An earlier draft of this entry justified
-the deferral with a count in the hundreds; it had been taken over `website/dist`
-and `website/.astro`, Astro build output, i.e. the same source pages many times
-over. Over tracked sources it is well under a hundred. The decision does not turn
-on the number — it turns on the change being visible on every page — which is why
-the number is not restated here.)
-
-What it costs, in the order the questions have to be answered:
-
-- WHICH rows become tab stops. `<adw-action-row>` only when `activatable`;
-  `<adw-button-row>` always (`BUTTON_ROW_ACTIVATABLE`, no opt-out upstream);
-  `<adw-expander-row>` always, since its header is the disclosure control. A
-  non-activatable action row must stay out, or every static label becomes a stop.
-- WHAT each declares. `aria-expanded` on the expander header, kept live;
-  `role="switch"` / `role="combobox"` on the two rows the C names; a list-item
-  role for the rest only if `<adw-preferences-group>` gains the matching container
-  role, since a list item outside a list is worse than none.
-- WHICH keys activate. Enter and Space, the way `GtkListBoxRow` does — and Space
-  must not also scroll the page.
-- The before/after this deserves: a tab-stop count per showcase page, measured,
-  not asserted. `tests/browser/specs/adwaita-keyboard.spec.ts` already pins the
-  CURRENT behaviour (Tab skips the group entirely), so the day it changes that
-  spec says so instead of nothing.
-
-`scripts/check-adwaita-keyboard-contract.mjs` does not see this class: the rows
-assign no negative tabIndex, they assign nothing at all, which is exactly why it
-went unnoticed. A gate for it wants the container question answered first.
-
-`<adw-toggle-group>` is the same blind spot from the other side, and belongs in
-this entry rather than a new one. Upstream it is the fifth member of the roving
-family: `AdwInlineViewSwitcher` builds exactly this widget with
-`GTK_ACCESSIBLE_ROLE_TAB_LIST` (`adw-inline-view-switcher.c:702`), and
+What remains is the same blind spot from the other side. Upstream `<adw-toggle-group>` is
+the fifth member of the roving family: `AdwInlineViewSwitcher` builds exactly this widget
+with `GTK_ACCESSIBLE_ROLE_TAB_LIST` (`adw-inline-view-switcher.c:702`), and
 `adw_toggle_group_focus` (`adw-toggle-group.c:1045`) is the citation
-`elements/roving-focus.ts` is built on. The web element has none of it — no role,
-no roving tabindex, no arrow keys. Measured in Firefox: three toggles report
-`tabIndex` `[0, 0, 0]`, the host has no `role`, and ArrowRight/ArrowLeft/Home/End
-all leave `document.activeElement` exactly where it was. It stays OPERABLE, every
-toggle being its own tab stop, so it is not the defect class the gate was written
-against — and the gate structurally cannot see it either, since there is no
-negative tabindex to trigger on. Its zero finding there is a scope limit, not a
-clean bill.
+`elements/roving-focus.ts` is built on. The web element has none of it — no role, no roving
+tabindex, no arrow keys. Measured in Firefox: three toggles report `tabIndex` `[0, 0, 0]`,
+the host has no `role`, and ArrowRight/ArrowLeft/Home/End all leave `document.activeElement`
+exactly where it was.
+
+It stays OPERABLE, every toggle being its own tab stop, so it is not the defect class
+`scripts/check-adwaita-keyboard-contract.mjs` was written against — and that gate
+structurally cannot see it either, since there is no negative tabindex to trigger on. Its
+zero finding there is a scope limit, not a clean bill. Closing it means giving the group the
+tab-list role and one roving tabindex, which turns three tab stops into one: a visible
+change to anything that tabs through a toggle group today.
 
 ### adwaita-core modules with no conformance vector table
 

--- a/tests/browser/specs/adwaita-keyboard.spec.ts
+++ b/tests/browser/specs/adwaita-keyboard.spec.ts
@@ -154,9 +154,10 @@ async function driveKeys(page: Page, bundleUrl: string) {
     await page.keyboard.press('Home');
     expect(await rowState()).toEqual({ focus: 0, roving: [0, -1, -1] });
 
-    // ---- Shape 3: the rows are NOT reachable, and that is on the record -------------
-    // Ledgered in status/open-todos.md, not fixed here: making the row family focusable
-    // moves tab order on every consumer page. Asserted so the day it changes, this says so.
+    // ---- Shape 3: every activatable row is a tab stop, in order ---------------------
+    // This block used to assert the opposite — Tab from `#before` landed on `#after` and
+    // the whole group was invisible to a keyboard. The rows now carry the tab stop
+    // libadwaita gives them for free by extending GtkListBoxRow.
     await page.evaluate(() => {
         document.body.replaceChildren();
         const before = document.createElement('button');
@@ -166,8 +167,10 @@ async function driveKeys(page: Page, bundleUrl: string) {
         group.setAttribute('title', 'Group');
         group.innerHTML =
             '<adw-action-row title="Action" activatable></adw-action-row>' +
+            '<adw-action-row title="Label only"></adw-action-row>' +
             '<adw-button-row title="Button"></adw-button-row>' +
-            '<adw-expander-row title="Expander"></adw-expander-row>';
+            '<adw-expander-row title="Expander"></adw-expander-row>' +
+            '<adw-switch-row title="Switch"></adw-switch-row>';
         const after = document.createElement('button');
         after.id = 'after';
         after.textContent = 'After';
@@ -175,6 +178,48 @@ async function driveKeys(page: Page, bundleUrl: string) {
         before.focus();
     });
 
-    await page.keyboard.press('Tab');
-    expect(await page.evaluate(() => document.activeElement?.id)).toBe('after');
+    /** What has focus, named the way a reader can act on. */
+    const focused = () =>
+        page.evaluate(() => {
+            const el = document.activeElement as HTMLElement | null;
+            if (!el || el === document.body) return 'body';
+            if (el.id) return `#${el.id}`;
+            if (el.classList.contains('adw-expander-row-header')) return 'expander-header';
+            return el.localName;
+        });
+
+    const order: string[] = [];
+    for (let i = 0; i < 8; i++) {
+        await page.keyboard.press('Tab');
+        const where = await focused();
+        order.push(where);
+        if (where === '#after') break;
+    }
+    // The plain action row is absent ON PURPOSE — a label that takes Tab makes every
+    // static row in a group a stop. So is the group itself: it is a container.
+    expect(order).toEqual(['adw-action-row', 'adw-button-row', 'expander-header', 'adw-switch-row', '#after']);
+
+    // `<adw-preferences-group>` is a GROUP upstream (adw-preferences-group.c:319), which is
+    // why the rows inside carry no `listitem` role — outside a list that is worse than none.
+    expect(await page.evaluate(() => document.querySelector('adw-preferences-group')?.getAttribute('role'))).toBe(
+        'group',
+    );
+
+    // The keys GtkListBoxRow activates on, and the state the C keeps in step with them.
+    const effects = await page.evaluate(() => {
+        const row = document.querySelector('adw-action-row[activatable]') as HTMLElement;
+        let activated = 0;
+        row.addEventListener('activated', () => activated++);
+        row.focus();
+        for (const key of ['Enter', ' ']) {
+            row.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+        }
+        const header = document.querySelector('.adw-expander-row-header') as HTMLElement;
+        const expandedBefore = header.getAttribute('aria-expanded');
+        header.focus();
+        header.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }));
+        return { activated, expandedBefore, expandedAfter: header.getAttribute('aria-expanded') };
+    });
+    // adw-expander-row.c:657 keeps GTK_ACCESSIBLE_STATE_EXPANDED on the header in step.
+    expect(effects).toEqual({ activated: 2, expandedBefore: 'false', expandedAfter: 'true' });
 }


### PR DESCRIPTION
Closes the row half of the entry `#1248` ledgered rather than fixed, for the reason it gave: this one moves
tab order on every page that uses a row, so it wanted its own change with its own before/after.

## Before

Measured in real Firefox on an `<adw-preferences-group>` holding one activatable `<adw-action-row>`, a plain
one, an `<adw-button-row>`, an `<adw-expander-row>`, an `<adw-switch-row>` and two `<adw-combo-row>`s, with a
button either side:

```
TAB ORDER      #before → adw-switch-row > adw-switch > input → adw-combo-row > select → #after
DECLARED       every row tabIndex -1, role null; the group role null
```

Only the **native controls** a row happens to contain were ever reached — a bare unlabelled checkbox and a
`<select>`. The row itself was never the thing that took focus, even where upstream says it is. All of them
activate on click, so the group was fully operable by mouse and invisible to a keyboard.

More precise than the ledger's own note, which measured three rows and reported Tab jumping the group entirely:
with a switch row present, Tab does land inside — on the wrong element.

## After

```
#before → adw-action-row → adw-button-row → expander-header → adw-switch-row → adw-combo-row > select → #after
```

The plain action row and the one-option combo row stay out, on purpose.

## Which rows, derived from the C

Not chosen. A row that becomes a stop it should not be turns every static label into one; a row that does not
stays unreachable.

| element | tab stop | grounding |
|---|---|---|
| `<adw-action-row>` | only while `activatable` | a plain row is a label |
| `<adw-button-row>` | always | `adw-button-row.c:31` — "AdwButtonRow is always activatable"; the upstream template hardcodes it |
| `<adw-expander-row>` | its **header** | `adw_expander_row_grab_focus` (`adw-expander-row.c:123`) forwards to `priv->action_row`, so the header is focus target and disclosure control at once |
| `<adw-switch-row>` | the **row**, slider no longer focusable | `adw_switch_row_init` does `gtk_widget_set_can_focus (self->slider, FALSE)` (`:159`) and `gtk_list_box_row_set_activatable (…, TRUE)` (`:160`) |
| `<adw-combo-row>` | unchanged | see below |
| `<adw-preferences-group>` | no — `role="group"` | `adw-preferences-group.c:319`, `GTK_ACCESSIBLE_ROLE_GROUP` |

Every citation was opened and verified line-exact.

The switch row is the one where the web had it backwards: `role="switch"` sat on a non-focusable row while a
bare checkbox took focus, so a screen reader announced the checkbox and not the row's title. Now the row is the
single stop, announced as itself, and Space toggles it.

**`<adw-combo-row>` is deliberately untouched, and this was measured rather than assumed.** Its control is a
native `<select>` stretched over the row: already a tab stop, already a combobox in the accessibility tree,
already arrow-navigable — and its `<select>` is already `disabled` at one option or fewer, which is exactly
`gtk_list_box_row_set_activatable (…, n_items > 1)` (`adw-combo-row.c:194`) without a line of our own. I checked
that specifically after the one-option row failed to appear in the tab order, because "it happened not to be
reached" and "it is correctly excluded" look identical from the outside. Making the row the tab stop would take
focus off the select and put a **second** combobox in the tree.

Because upstream declares a GROUP and not a list, no row carries a `listitem` role — outside a list that is
worse than none. That answers the container question the ledger left open.

## Keys

Enter and Space, `GtkListBoxRow`'s set. Space is prevented so the page does not scroll under the row that was
just activated. Activation goes through the row's existing **click** handler rather than a second path that can
drift from it.

A key is only taken when `event.target` is the row itself: a `<select>`, an entry's `<input>` and a suffix
button all use Enter or Space for something of their own, and swallowing those would break the control in order
to reach the row it sits in. Asserted, not assumed — a spec presses Space on a combo row's `<select>` and
requires `defaultPrevented` to be false.

## The spec that said the opposite

`tests/browser/specs/adwaita-keyboard.spec.ts` pinned the old behaviour on purpose — *"asserted so the day it
changes, this says so"*. It now asserts the new tab order, the group role, and that Enter and Space each
activate once while `aria-expanded` flips with the disclosure (`adw-expander-row.c:657` keeps
`GTK_ACCESSIBLE_STATE_EXPANDED` in step).

## A/B

Removing the tab stop from the shared helper and rebuilding turns **both** browser tests red — the package suite
and the real-key Playwright spec. Restored, both green. `2 passed (15.3s)` under Firefox, CI's engine.

All fourteen Adwaita gates, `audit-runtimes --check --strict`, `oxfmt --check` repo-wide and `oxlint` are clean.

## Still open, and now the whole of that ledger entry

`<adw-toggle-group>` is upstream's fifth roving-family member — `AdwInlineViewSwitcher` builds exactly this
widget with `GTK_ACCESSIBLE_ROLE_TAB_LIST` — and the web element has no role, no roving tabindex and no arrow
keys. It stays **operable** (three toggles, three tab stops), so it is not this defect class, and
`check-adwaita-keyboard-contract.mjs` structurally cannot see it: there is no negative tabindex to trigger on.
Closing it turns three tab stops into one, which is a visible change of its own.
