### PR TITLE
feat(showcases): ship the typeface the chrome names

### DIFF
--- a/showcases/dom/canvas2d-fireworks/src/browser/browser.ts
+++ b/showcases/dom/canvas2d-fireworks/src/browser/browser.ts
@@ -2,9 +2,19 @@
 // Mirrors the GJS/Adwaita UI using @gjsify/adwaita-web.
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwOverlaySplitView, AdwHeaderBar } from '@gjsify/adwaita-web';
 import { mediaPlaybackPauseSymbolic, mediaPlaybackStartSymbolic } from '@gjsify/adwaita-icons/actions';
 import { start, type FireworksDemo } from '../fireworks.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 /** Handle returned by `mount()` so hosts (e.g. the website slideshow) can pause and resume rendering. */
 export interface ShowcaseHandle {

--- a/showcases/dom/excalibur-jelly-jumper/src/browser/browser.ts
+++ b/showcases/dom/excalibur-jelly-jumper/src/browser/browser.ts
@@ -3,10 +3,20 @@
 // pause/resume button only (no sidebar: the game has no configurable params).
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwHeaderBar } from '@gjsify/adwaita-web';
 import { mediaPlaybackPauseSymbolic, mediaPlaybackStartSymbolic } from '@gjsify/adwaita-icons/actions';
 import { audioVolumeHighSymbolic, audioVolumeMutedSymbolic } from '@gjsify/adwaita-icons/status';
 import { startGame, type GameHandle } from '../game.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     /** Base URL for game assets (default: '/'). Used when embedded in the website. */

--- a/showcases/dom/minimalist-browser/src/browser/browser.ts
+++ b/showcases/dom/minimalist-browser/src/browser/browser.ts
@@ -4,8 +4,18 @@
 // through browser-main.ts.
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwEntry, AdwHeaderBar } from '@gjsify/adwaita-web';
 import { BrowserCore, BUILTIN_PAGE_URLS, DEFAULT_HOME_URL, type IFrameHandle } from '../browser-demo.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     /** Override the URL loaded on startup. */

--- a/showcases/dom/three-geometry-teapot/src/browser/browser.ts
+++ b/showcases/dom/three-geometry-teapot/src/browser/browser.ts
@@ -2,6 +2,12 @@
 // Mirrors the GJS/Adwaita UI from gjs/teapot-window.ts using @gjsify/adwaita-web.
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwOverlaySplitView, AdwHeaderBar } from '@gjsify/adwaita-web';
 import { mediaPlaybackPauseSymbolic, mediaPlaybackStartSymbolic } from '@gjsify/adwaita-icons/actions';
 import {
@@ -12,6 +18,10 @@ import {
     DEFAULT_SHADING_INDEX,
     type TeapotDemo,
 } from '../three-demo.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     /** Base path for loading texture assets (forwarded to three-demo). */

--- a/showcases/dom/three-loader-ldraw/src/browser/browser.ts
+++ b/showcases/dom/three-loader-ldraw/src/browser/browser.ts
@@ -10,8 +10,18 @@
 // side-effect import discards, and under a real CSS pipeline it injects the same
 // rules a SECOND time (`style.css.d.ts` says so).
 import '@gjsify/adwaita-web';
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwOverlaySplitView } from '@gjsify/adwaita-web';
 import { start, MODEL_LIST, DEFAULT_MODEL_INDEX, type LDrawDemo } from '../three-demo.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     assetBase?: string;

--- a/showcases/dom/three-postprocessing-pixel/src/browser/browser.ts
+++ b/showcases/dom/three-postprocessing-pixel/src/browser/browser.ts
@@ -4,9 +4,19 @@
 // Original: MIT license, three.js authors (https://threejs.org)
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import type { AdwOverlaySplitView, AdwHeaderBar } from '@gjsify/adwaita-web';
 import { mediaPlaybackPauseSymbolic, mediaPlaybackStartSymbolic } from '@gjsify/adwaita-icons/actions';
 import { start, type PixelDemo } from '../three-demo.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     assetBase?: string;

--- a/showcases/dom/webrtc-video/src/browser/browser.ts
+++ b/showcases/dom/webrtc-video/src/browser/browser.ts
@@ -7,7 +7,17 @@
 // showcase. Standalone runs go through `browser-main.ts` (`mount(document.body)`).
 
 import '@gjsify/adwaita-web'; // registers the custom elements + self-injects the stylesheet
+// A showcase is served to whatever browser opens it, so it cannot assume the host has
+// Adwaita Sans the way a GNOME desktop does. `import '@gjsify/adwaita-web'` names the
+// family and ships no `@font-face`, so without this call the chrome renders in the host's
+// default sans on macOS, on Windows and on any Linux that is not GNOME — and looks right
+// only on the machine it was written on.
+import { applyAdwaitaFonts } from '@gjsify/adwaita-web/fonts';
 import { startVideo } from '../video-demo.js';
+
+// Idempotent, and a no-op where there is no `document` — so a build-time import of this
+// module (the website slideshow does one) neither throws nor half-applies.
+applyAdwaitaFonts();
 
 export interface MountOptions {
     /** Override the header bar title. */

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -85,30 +85,38 @@ have it installed, and everything reading that token — `.monospace` labels, th
 data-grid mono cell, `<adw-source-view>` — falls through to `ui-monospace`
 everywhere else.
 
-### Nothing in this repo calls `applyAdwaitaFonts()`
+### `@gjsify/adwaita-storybook` still ships no typeface
 
-The opt-in works and is tested, but the count of in-repo CALL SITES is zero:
-`@gjsify/adwaita-web/fonts` is imported by `adw-fonts.spec.ts` and nothing else,
-and that suite removes the faces again when it finishes. Verified on real
-artifacts: a `--app browser` probe whose only statement is
-`import '@gjsify/adwaita-web';` has an EMPTY `document.fonts` (0 faces, 0
-`CSSFontFaceRule`) while `document.fonts.check("16px 'Adwaita Sans'")` still
-answers true from fontconfig; a freshly rebuilt
-`showcases/dom/three-loader-ldraw/dist/browser.js` (17.4 MB) carries 47 Adwaita
-stylesheet markers and ZERO `@font-face` — so dropping its dead `style.css`
-import regressed nothing, and it ships no typeface either.
+The seven DOM showcases now call `applyAdwaitaFonts()`. That was this entry's own
+recommendation — they are browser artifacts served to whatever opens them, so they
+are exactly the place the size decision belongs, and an app may make it where a
+library barrel may not.
 
-The one path that DOES ship the faces is the website, through
-`astro.config.mjs`'s Starlight `customCss` — a real CSS pipeline, so the `url()`
-form is enough there.
+Measured on `showcases/dom/canvas2d-fireworks/dist/browser.js`, rebuilt either way:
 
-This is a decision, not an accident, and it stays that way while the faces are
-unsubsetted desktop TTFs (the entry above). Two candidates when that changes:
-`@gjsify/adwaita-storybook`, whose whole purpose is to look like Adwaita, and the
-DOM showcases the website embeds as standalone pages. Neither gets it today,
-because at 1.18 MB gzip it is a size decision, and a library barrel is the wrong
-place to make one on a consumer's behalf. Whoever ships a browser artifact that
-must look like Adwaita off a GNOME host owns the call.
+    before   18 033 980 B   0 @font-face   names "Adwaita Sans" twice
+    after    20 421 448 B   2 @font-face   2 data: URIs      (+2 387 468 B, +13.2%)
+
+and in real Firefox against the served artifact, `document.fonts` holds two faces
+(`weight: 100 900`, normal + italic) with the normal one `status: "loaded"`. That
+reading is host-independent by construction: a system-installed family never
+appears in `document.fonts`, which is why the assertion is made there and not
+against a computed font — on this Fedora box every one of these pages looked
+correct before the change and will look identical after it. The difference is on
+macOS, on Windows, and on any Linux that is not GNOME.
+
+What still does not opt in is `@gjsify/adwaita-storybook`, whose whole purpose is
+to look like Adwaita. Its entry is a barrel, and 1.18 MB gzip inside a library is
+the size decision a consumer should be making, so it wants either a host that
+calls the opt-in or a subsetted woff2 (the entry above) before it changes.
+
+NO GATE holds "a showcase that renders Adwaita chrome must call the opt-in", and
+that is deliberate: `applyAdwaitaFonts` is a VALUE export precisely so the silent
+form cannot be written — an import that is never called does not compile away into
+a green build, it simply is not an opt-in. What remains is an omission, which is
+the ordinary shape of a missing feature rather than a check that passed while
+nothing was verified. A gate for it would cost an incident header in a `scripts`
+tree with ten lines of budget left, to catch someone not adding something.
 
 ### `<adw-source-view>` has no browser suite
 


### PR DESCRIPTION
#1247 made the Adwaita typeface an opt-in and then nothing opted in, so it still reached no built artifact. The
ledger entry for that named the DOM showcases as one of two candidates and said *"whoever ships a browser
artifact that must look like Adwaita off a GNOME host owns the call."* A showcase is exactly that, so it makes
the call.

## The defect this closes, measured

`showcases/dom/canvas2d-fireworks/dist/browser.js`, rebuilt either way:

```
before   18 033 980 B   0 @font-face   names "Adwaita Sans" twice
after    20 421 448 B   2 @font-face   2 data: URIs        (+2 387 468 B, +13.2 %)
```

Naming a family and shipping no face means the browser has nothing to load. All seven DOM showcases were in
that state.

In real Firefox against the served artifact, `document.fonts` now holds two faces — `weight: 100 900`, normal
and italic — with the normal one at `status: "loaded"`, i.e. actually fetched and parsed.

**That reading is host-independent by construction, and this is the point.** A system-installed family never
appears in `document.fonts`, so the measurement cannot be satisfied by fontconfig the way a computed
`font-family` can. On this Fedora box — `fc-list | grep -ci adwaita` = 24 — every one of these pages looked
correct *before* the change and looks identical after it. The difference is on macOS, on Windows, and on any
Linux that is not GNOME, which is where a showcase is most likely to be opened and where nobody here would have
noticed.

## Placement

The call sits at module top level, right under the `import '@gjsify/adwaita-web'` whose neighbouring comment
already says that import self-injects the stylesheet — same place, same kind of statement.

`applyAdwaitaFonts()` is **idempotent** (it returns early on its own `<style>` id) and a **no-op without a
document** (`typeof document === 'undefined'`), so the website's build-time import of these modules neither
throws nor half-applies. That was checked before choosing top level rather than a `mount()` body, because the
SSR trap is real — it is the one #1249's review found in `registerIcon`'s README recipe.

All seven typecheck.

## No gate, deliberately

Nothing holds "a showcase that renders Adwaita chrome must call the opt-in", and that is a decision rather than
an oversight.

`applyAdwaitaFonts` is a **value** export precisely so the silent form cannot be written — #1247 chose it over a
side-effect import because the side-effect form is what let the typeface vanish into a 0-byte bundle at exit 0.
An import that is never called is not a green build over an unverified claim; it is simply not an opt-in. What
remains is an ordinary omission.

A gate for that would cost an incident header in a `scripts` tree with **ten lines** of comment budget left, to
catch someone not adding something. The reasoning is in `status/open-todos.md` so the next person deciding has
it rather than having to re-derive it.

## Still not opted in

`@gjsify/adwaita-storybook`, whose whole purpose is to look like Adwaita. Its entry is a barrel, and 1.18 MB
gzip inside a library is the size decision a consumer should be making. It wants either a host that calls the
opt-in or the subsetted woff2 already ledgered — the faces here are unsubsetted desktop TTFs, and at 15–40 KB a
slice the default would flip.
