### PR TITLE
fix(adwaita-web): make a toggle group one tab stop

### DIFF
--- a/packages/web/adwaita-web/src/adw-row-state.spec.ts
+++ b/packages/web/adwaita-web/src/adw-row-state.spec.ts
@@ -188,7 +188,12 @@ export const AdwRowStateTest = async () => {
             expect(buttons.length).toBe(3);
             expect(group.active).toBe(1);
             expect(buttons[1].classList.contains('active')).toBe(true);
-            expect(buttons[1].getAttribute('aria-pressed')).toBe('true');
+            // `aria-checked`, not `aria-pressed`: upstream declares the group a
+            // `RADIO_GROUP` and each toggle a `RADIO` (adw-toggle-group.c:1191, :860),
+            // and `aria-pressed` is the independent toolbar toggle-BUTTON pattern. This
+            // line pinned the wrong one until the roles landed.
+            expect(buttons[1].getAttribute('aria-checked')).toBe('true');
+            expect(buttons[1].getAttribute('role')).toBe('radio');
 
             buttons[2].click();
             expect(group.active).toBe(2);
@@ -205,6 +210,11 @@ export const AdwRowStateTest = async () => {
             group.active = 0;
             expect(group.active).toBe(0);
             expect(buttons[0].classList.contains('active')).toBe(true);
+            // The roving tabindex and the state attribute move with the pill. Reading
+            // only `classList` here would pass on a `_render` that repainted the group
+            // and left Tab entering on the toggle that is no longer active.
+            expect(buttons.map((btn) => btn.tabIndex)).toStrictEqual([0, -1, -1]);
+            expect(buttons.map((btn) => btn.getAttribute('aria-checked'))).toStrictEqual(['true', 'false', 'false']);
             expect(events.details.length).toBe(1);
 
             events.stop();

--- a/packages/web/adwaita-web/src/elements/adw-toggle-group.ts
+++ b/packages/web/adwaita-web/src/elements/adw-toggle-group.ts
@@ -7,7 +7,44 @@
 // The SELECTION state machine (the segment list plus the guarded, no-op-on-same active
 // index) is HEADLESS and lives in `@gjsify/adwaita-core` (ADR 0004) as
 // {@link ToggleGroupState}; this element keeps only the DOM half — the buttons, the active
-// pill / `aria-pressed` reflection and the event.
+// pill / checked reflection, the keyboard and the event.
+//
+// THE ROLE IS A RADIO GROUP, not a tab list, and the element had neither. Upstream
+// declares `GTK_ACCESSIBLE_ROLE_RADIO_GROUP` (adw-toggle-group.c:1191) and reads the
+// group's CURRENT role when it builds each toggle: a group already declared a tab list
+// gets `GTK_ACCESSIBLE_ROLE_TAB` children, everything else `GTK_ACCESSIBLE_ROLE_RADIO`
+// (:857-865, under the comment "Special case for AdwInlineViewSwitcher" — that switcher
+// builds exactly this widget with `TAB_LIST`, adw-inline-view-switcher.c:702). Both
+// branches are ported, in the same order, because a consumer that declares the tab list
+// upstream sanctions would otherwise get radios inside it.
+//
+// `aria-pressed` was the state before, and it belongs to NEITHER role — it is the
+// toolbar toggle-button pattern, where each button is independent. The state of one of
+// N mutually exclusive choices is `aria-checked` under `radio` and `aria-selected` under
+// `tab`, so a screen reader was told these were three separate on/off buttons.
+//
+// THE KEYBOARD is one tab stop and arrows inside, which is the roving tabindex
+// `elements/roving-focus.ts` implements — and `adw_toggle_group_focus`
+// (adw-toggle-group.c:1045) is the citation that module is built on. Tab in either
+// direction is PROPAGATED (:1059-1060), i.e. focus leaves the group; every other
+// direction goes to `adw_widget_focus_child` (:1062), i.e. moves within it. Which button
+// Tab enters on is `adw_toggle_group_grab_focus` (:1066): the ACTIVE toggle's button,
+// never the first. The web element had three plain tab stops and no arrow keys at all,
+// so it stayed operable — this change turns those three stops into one, which is visible
+// to anything that tabs through a toggle group.
+//
+// HORIZONTAL ONLY, and the reason is not the missing `orientation` property. The C looks
+// orientation-blind — `adw_toggle_group_focus` filters the two Tab directions and hands
+// every other one on without consulting `self->orientation` — but the axis is decided
+// one level down, GEOMETRICALLY. `adw_widget_focus_child` is `focus_move`
+// (adw-widget-utils.c:428), which sorts through `focus_sort` (:388), which dispatches
+// UP/DOWN into `focus_sort_up_down` (:298). That sorter DELETES every sibling with no
+// horizontal overlap with the focused child (:339-342) — which, in a row of toggles, is
+// all of them. The list is left holding only the focused button, `gtk_widget_child_focus`
+// on a leaf that already has focus returns FALSE, and the press PROPAGATES: upstream,
+// ArrowDown in a horizontal toggle group leaves the group. So `'horizontal'` is what the
+// C does for the only layout this element has, it matches the three sibling tab lists,
+// and it leaves ArrowUp/ArrowDown to the page instead of swallowing a scroll.
 //
 // Reference: refs/libadwaita/src/adw-toggle-group.c (AdwToggleGroup behaviour)
 // Reference: refs/libadwaita/src/stylesheet/widgets/_toggle-group.scss
@@ -20,6 +57,7 @@
 import { ToggleGroupState } from '@gjsify/adwaita-core';
 
 import { createAdwIcon } from './adw-icon.js';
+import { attachRovingFocus } from './roving-focus.js';
 
 /** A single toggle. Children of <adw-toggle-group>; consumed at connect time. */
 export class AdwToggle extends HTMLElement {
@@ -34,6 +72,8 @@ export class AdwToggleGroup extends HTMLElement {
     /** The headless segment list + guarded selection state machine (ADR 0004). */
     private readonly _state = new ToggleGroupState();
     private _initialized = false;
+    /** `aria-checked` under `radio`, `aria-selected` under `tab` — decided at connect. */
+    private _stateAttr: 'aria-checked' | 'aria-selected' = 'aria-checked';
 
     static get observedAttributes() {
         return ['active', 'flat', 'round'];
@@ -56,13 +96,48 @@ export class AdwToggleGroup extends HTMLElement {
         // subtree — their label / icon-name become the rendered buttons.
         const toggles = Array.from(this.querySelectorAll('adw-toggle')) as AdwToggle[];
 
+        // `gtk_widget_class_set_accessible_role` sets a CLASS DEFAULT that an instance's
+        // construct-time `accessible-role` overrides, and `add_toggle` then reads
+        // whatever the instance actually has. So a declared role is kept — only an
+        // undeclared one is filled in — and `tablist` is the single branch, exactly as
+        // in the C: any other role still gets radio children.
+        // `|| null`, not `?? null`: `role=""` is not a declared role, and treating it as
+        // one left the group with no role at all while its children were radios.
+        const declared = this.getAttribute('role')?.trim() || null;
+        if (declared === null) this.setAttribute('role', 'radiogroup');
+        const isTabList = declared === 'tablist';
+        const toggleRole = isTabList ? 'tab' : 'radio';
+        this._stateAttr = isTabList ? 'aria-selected' : 'aria-checked';
+        // Read ONCE, which is what upstream allows: `GtkAccessible:accessible-role` is
+        // writable but documented "The accessible role cannot be changed once set", and
+        // the only public setter is the CLASS-level `gtk_widget_class_set_accessible_role`
+        // — there is no instance setter at all. So a later `role=` change has no upstream
+        // meaning, and re-labelling the toggles on it would be behaviour this port
+        // invented. Declare it in markup, or before the element is connected.
+        //
+        // (It is NOT construct-only, which an earlier draft of this comment claimed:
+        // `Gtk-4.0.gir` marks the property `writable` with no construct flag at all. The
+        // rule is the documented one above, which is the stronger citation anyway.)
+
         this._innerEl = document.createElement('div');
         this._innerEl.className = 'adw-toggle-group-inner';
+        // The toggles are this element's own children upstream; the wrapper is a web-only
+        // flex box with no counterpart in the C at all. Without a role it is a `generic`
+        // sitting between a radio group and its radios, so it declares itself away.
+        //
+        // NO upstream precedent is claimed for this, and an earlier draft of this comment
+        // invented one: every `GTK_ACCESSIBLE_ROLE_PRESENTATION` in libadwaita is a leaf
+        // decoration (an icon, a gizmo), never a layout container between a role-bearing
+        // parent and role-bearing children — because GTK has no such container here to
+        // annotate. That is exactly why the attribute is needed on this side and nowhere
+        // in the C.
+        this._innerEl.setAttribute('role', 'none');
 
         this._buttons = toggles.map((toggle, index) => {
             const btn = document.createElement('button');
             btn.type = 'button';
             btn.className = 'adw-toggle';
+            btn.setAttribute('role', toggleRole);
 
             const label = toggle.getAttribute('label') ?? '';
             const icon = toggle.getAttribute('icon-name') ?? '';
@@ -87,6 +162,20 @@ export class AdwToggleGroup extends HTMLElement {
         this._state.subscribe(() => this._render());
         this._state.setSelected(this._readActiveAttr());
         this._render();
+
+        // No `disabled`/`hidden` filter, because no `<adw-toggle>` attribute can produce
+        // either — upstream's per-toggle `enabled` (adw-toggle-group.c:871) has no web
+        // counterpart yet, and a filter for a state this element cannot reach would be
+        // untestable. `AdwToggle.observedAttributes` is pinned in
+        // `keyboard-operable.spec.ts` so the day it grows, this decision has to be
+        // revisited instead of silently becoming a focus trap.
+        attachRovingFocus({
+            host: this,
+            orientation: 'horizontal',
+            items: () => this._buttons,
+            // Same path a click takes, so an arrow key cannot drift from a press.
+            select: (item) => this._selectIndex(this._buttons.findIndex((btn) => btn === item)),
+        });
     }
 
     attributeChangedCallback(name: string) {
@@ -124,7 +213,10 @@ export class AdwToggleGroup extends HTMLElement {
         this._buttons.forEach((btn, index) => {
             const isActive = index === active;
             btn.classList.toggle('active', isActive);
-            btn.setAttribute('aria-pressed', String(isActive));
+            btn.setAttribute(this._stateAttr, String(isActive));
+            // The roving tabindex: Tab enters on the ACTIVE toggle, the way
+            // `adw_toggle_group_grab_focus` grabs it, and leaves the group from there.
+            btn.tabIndex = isActive ? 0 : -1;
         });
     }
 }

--- a/packages/web/adwaita-web/src/keyboard-operable.spec.ts
+++ b/packages/web/adwaita-web/src/keyboard-operable.spec.ts
@@ -21,6 +21,7 @@
 import { describe, expect, it } from '@gjsify/unit';
 
 import type { AdwAlertDialog } from './elements/adw-alert-dialog.js';
+import { AdwToggle, AdwToggleGroup } from './elements/adw-toggle-group.js';
 
 /** Unique per element so a spec's `stack="…"` reference cannot pick up an earlier one. */
 let seq = 0;
@@ -115,7 +116,24 @@ interface RovingCase {
     items: (el: HTMLElement) => HTMLElement[];
     previous: string;
     next: string;
+    /**
+     * The arrow pair on the OTHER axis, which this widget must leave to the page.
+     *
+     * Asserted because the axis SEPARATION was held by nothing: `AXIS_KEYS` is one
+     * table, and widening a single row to both pairs kept every test green while
+     * every horizontal widget started swallowing the page scroll — `attachRovingFocus`
+     * calls `preventDefault()` before it checks whether anything moved.
+     */
+    inert: readonly [string, string];
 }
+
+/** By TAG, never by index: a case inserted mid-array repoints an index silently, and
+ *  the one test that would still PASS repointed is the one asserting the least. */
+const rovingCase = (tag: string): RovingCase => {
+    const found = ROVING_CASES.find((widget) => widget.tag === tag);
+    if (found === undefined) throw new Error(`no roving case for ${tag}`);
+    return found;
+};
 
 function makeStack(): HTMLElement {
     const stack = document.createElement('adw-view-stack');
@@ -145,6 +163,7 @@ const ROVING_CASES: RovingCase[] = [
         items: (el) => Array.from(el.querySelectorAll<HTMLElement>('[role="tab"]')),
         previous: 'ArrowLeft',
         next: 'ArrowRight',
+        inert: ['ArrowUp', 'ArrowDown'],
     },
     {
         tag: 'adw-view-switcher-bar',
@@ -161,6 +180,7 @@ const ROVING_CASES: RovingCase[] = [
         items: (el) => Array.from(el.querySelectorAll<HTMLElement>('[role="tab"]')),
         previous: 'ArrowLeft',
         next: 'ArrowRight',
+        inert: ['ArrowUp', 'ArrowDown'],
     },
     {
         tag: 'adw-inline-view-switcher',
@@ -177,6 +197,7 @@ const ROVING_CASES: RovingCase[] = [
         items: (el) => Array.from(el.querySelectorAll<HTMLElement>('[role="tab"]')),
         previous: 'ArrowLeft',
         next: 'ArrowRight',
+        inert: ['ArrowUp', 'ArrowDown'],
     },
     {
         tag: 'adw-sidebar',
@@ -193,6 +214,24 @@ const ROVING_CASES: RovingCase[] = [
         items: (el) => Array.from(el.querySelectorAll<HTMLElement>('[role="option"]')),
         previous: 'ArrowUp',
         next: 'ArrowDown',
+        inert: ['ArrowLeft', 'ArrowRight'],
+    },
+    {
+        // Upstream's fifth roving widget, and the one that had none of it: three plain
+        // tab stops, no role, and no arrow keys. `[role="radio"]` is the assertion —
+        // reading `.adw-toggle` would pass on buttons carrying no role at all.
+        tag: 'adw-toggle-group',
+        make: () => {
+            const el = document.createElement('adw-toggle-group');
+            el.innerHTML = ['One', 'Two', 'Three']
+                .map((label) => `<adw-toggle label="${label}"></adw-toggle>`)
+                .join('');
+            return el;
+        },
+        items: (el) => Array.from(el.querySelectorAll<HTMLElement>('[role="radio"]')),
+        previous: 'ArrowLeft',
+        next: 'ArrowRight',
+        inert: ['ArrowUp', 'ArrowDown'],
     },
 ];
 
@@ -380,11 +419,29 @@ export const AdwKeyboardOperableTest = async () => {
                     expect(document.activeElement).toBe(items[0]);
                 });
             });
+
+            await it(`${widget.tag} leaves the other axis to the page`, async () => {
+                withWidget(widget.make, (el) => {
+                    const items = widget.items(el);
+                    items[1].focus();
+
+                    for (const key of widget.inert) {
+                        const event = press(items[1], key);
+                        // Focus unmoved AND the key unclaimed: a widget that swallows an
+                        // off-axis arrow stops the page scrolling under a user who is
+                        // standing inside it, and `attachRovingFocus` calls
+                        // `preventDefault()` before it knows whether anything moved — so
+                        // asserting only the focus would miss half of it.
+                        expect(document.activeElement).toBe(items[1]);
+                        expect(event.defaultPrevented).toBe(false);
+                    }
+                });
+            });
         }
 
         await it('adw-sidebar arrow selects without activating', async () => {
-            withWidget(ROVING_CASES[3].make, (el) => {
-                const items = ROVING_CASES[3].items(el);
+            withWidget(rovingCase('adw-sidebar').make, (el) => {
+                const items = rovingCase('adw-sidebar').items(el);
                 const seen: string[] = [];
                 el.addEventListener('activated', () => seen.push('activated'));
                 el.addEventListener('notify::selected', (event) => {
@@ -455,6 +512,176 @@ export const AdwKeyboardOperableTest = async () => {
             expect(document.activeElement).toBe(rows[2]);
 
             el.remove();
+        });
+
+        await it('adw-toggle-group declares the radio group upstream defaults to', async () => {
+            withWidget(rovingCase('adw-toggle-group').make, (el) => {
+                // `GTK_ACCESSIBLE_ROLE_RADIO_GROUP` (adw-toggle-group.c:1191) and
+                // `GTK_ACCESSIBLE_ROLE_RADIO` per toggle (:860). The element declared
+                // neither, so nothing announced these three as one exclusive choice.
+                expect(el.getAttribute('role')).toBe('radiogroup');
+                const items = rovingCase('adw-toggle-group').items(el);
+                expect(items.length).toBe(3);
+                expect(items.map((item) => item.getAttribute('aria-checked'))).toStrictEqual([
+                    'true',
+                    'false',
+                    'false',
+                ]);
+                // `aria-pressed` belongs to the toolbar toggle-BUTTON pattern, where each
+                // button is independent. Announcing three separate on/off buttons is what
+                // the element did before, so its absence is the assertion.
+                expect(items.some((item) => item.hasAttribute('aria-pressed'))).toBe(false);
+                // The flex wrapper is web-only — upstream the toggles are the group's own
+                // children — so it declares itself out of the accessibility tree rather
+                // than sitting as a `generic` between a radio group and its radios.
+                expect(el.querySelector('.adw-toggle-group-inner')?.getAttribute('role')).toBe('none');
+
+                items[0].focus();
+                press(items[0], 'ArrowRight');
+                expect(document.activeElement).toBe(items[1]);
+                expect(items.map((item) => item.getAttribute('aria-checked'))).toStrictEqual([
+                    'false',
+                    'true',
+                    'false',
+                ]);
+                expect(el.getAttribute('active')).toBe('1');
+            });
+        });
+
+        await it('adw-toggle-group arrow moves focus even when the selection refuses', async () => {
+            withWidget(rovingCase('adw-toggle-group').make, (el) => {
+                const items = rovingCase('adw-toggle-group').items(el);
+                const seen: number[] = [];
+                el.addEventListener('notify::active', (event) => {
+                    seen.push((event as CustomEvent).detail.active as number);
+                });
+
+                items[0].focus();
+                // Focus and selection on DIFFERENT toggles, so the arrow targets the one
+                // that is ALREADY selected and `_selectIndex` genuinely refuses — the
+                // only shape that reaches the state machine's no-op guard through the
+                // keyboard. Without it the arrow tests only ever make real changes, and
+                // the guard could be deleted with the suite still green.
+                el.setAttribute('active', '1');
+                expect(items.map((item) => item.tabIndex)).toStrictEqual([-1, 0, -1]);
+                expect(document.activeElement).toBe(items[0]);
+
+                press(items[0], 'ArrowRight');
+                expect(document.activeElement).toBe(items[1]);
+                // No second notify for a selection that did not move.
+                expect(seen).toStrictEqual([]);
+            });
+        });
+
+        await it('adw-toggle-group keeps a role it did not choose', async () => {
+            withWidget(
+                () => {
+                    const el = document.createElement('adw-toggle-group');
+                    // Upstream writes no role at all: `gtk_widget_class_set_accessible_role`
+                    // (adw-toggle-group.c:1191) is a CLASS DEFAULT an instance overrides,
+                    // and `add_toggle` branches on `TAB_LIST` alone (:857) — so `GROUP`
+                    // stays `GROUP` and still gets radio children.
+                    el.setAttribute('role', 'group');
+                    el.innerHTML = '<adw-toggle label="One"></adw-toggle><adw-toggle label="Two"></adw-toggle>';
+                    return el;
+                },
+                (el) => {
+                    expect(el.getAttribute('role')).toBe('group');
+                    expect(el.querySelectorAll('[role="radio"]').length).toBe(2);
+                },
+            );
+        });
+
+        await it('adw-toggle-group treats an empty role as no role', async () => {
+            withWidget(
+                () => {
+                    const el = document.createElement('adw-toggle-group');
+                    // `role=""` is not a declared role. Reading it with `?? null` left the
+                    // group with NO role while its children were radios — a radio outside
+                    // any group.
+                    el.setAttribute('role', '   ');
+                    el.innerHTML = '<adw-toggle label="One"></adw-toggle><adw-toggle label="Two"></adw-toggle>';
+                    return el;
+                },
+                (el) => {
+                    expect(el.getAttribute('role')).toBe('radiogroup');
+                    expect(el.querySelectorAll('[role="radio"]').length).toBe(2);
+                },
+            );
+        });
+
+        await it('adw-toggle-group has no orientation yet, so one axis is the whole truth', async () => {
+            // The element is keyed to `'horizontal'`, and `inert` above pins ArrowUp/
+            // ArrowDown as the page's. Both become WRONG the day the group gains the
+            // `orientation` upstream already has — `AdwToggleGroup` implements
+            // `GtkOrientable` (adw-toggle-group.c:187), installs PROP_ORIENTATION (:202),
+            // reorients its layout (:929) and its separators (:873, :935), and
+            // `AdwInlineViewSwitcher` forwards it (:107). In a vertical group Up/Down moves
+            // inside and Left/Right propagates, so the axis has to follow the attribute.
+            //
+            // Prose cannot hold that: this line fails the commit that adds it.
+            // `<adw-inline-view-switcher>` has the same gap (status/open-todos.md).
+            expect([...AdwToggleGroup.observedAttributes]).toStrictEqual(['active', 'flat', 'round']);
+        });
+
+        await it('adw-toggle has no state a roving walk would have to skip', async () => {
+            // `<adw-toggle-group>` passes its buttons to `attachRovingFocus` UNFILTERED,
+            // which is only safe while no `<adw-toggle>` attribute can produce a disabled
+            // or hidden button. That is a decision recorded in two comments and a ledger
+            // entry, and this is the line that fails when it stops being true — the first
+            // disabled toggle is otherwise a `focus()` the browser refuses, with nothing
+            // in the walk to step over it. Grow this list and add the filter and its spec
+            // in the same change (status/open-todos.md, `<adw-toggle>` has no `enabled`).
+            expect([...AdwToggle.observedAttributes]).toStrictEqual(['label', 'icon-name']);
+        });
+
+        await it('adw-toggle-group notifies once per arrow, through the click path', async () => {
+            withWidget(rovingCase('adw-toggle-group').make, (el) => {
+                const seen: number[] = [];
+                el.addEventListener('notify::active', (event) => {
+                    seen.push((event as CustomEvent).detail.active as number);
+                });
+                const items = rovingCase('adw-toggle-group').items(el);
+
+                items[0].focus();
+                press(items[0], 'ArrowRight');
+                press(items[1], 'ArrowRight');
+                // One per real change, and none for the press at the end — which is the
+                // ROVING module's guard (`target === undefined`), not the state machine's:
+                // `_selectIndex` is never reached here. The no-op guard behind it is what
+                // the "selection refuses" case beside it presses on.
+                press(items[2], 'ArrowRight');
+
+                expect(seen).toStrictEqual([1, 2]);
+            });
+        });
+
+        await it('adw-toggle-group keeps a declared tab list a tab list', async () => {
+            withWidget(
+                () => {
+                    const el = document.createElement('adw-toggle-group');
+                    // The role upstream reads BEFORE it builds a toggle, under the comment
+                    // "Special case for AdwInlineViewSwitcher" (adw-toggle-group.c:856) —
+                    // that switcher builds exactly this widget with `TAB_LIST`
+                    // (adw-inline-view-switcher.c:702). Without the branch a consumer
+                    // following upstream gets radios inside a tab list.
+                    el.setAttribute('role', 'tablist');
+                    el.innerHTML = ['One', 'Two'].map((label) => `<adw-toggle label="${label}"></adw-toggle>`).join('');
+                    return el;
+                },
+                (el) => {
+                    expect(el.getAttribute('role')).toBe('tablist');
+                    const tabs = Array.from(el.querySelectorAll<HTMLElement>('[role="tab"]'));
+                    expect(tabs.length).toBe(2);
+                    expect(tabs.map((tab) => tab.getAttribute('aria-selected'))).toStrictEqual(['true', 'false']);
+                    expect(el.querySelectorAll('[role="radio"]').length).toBe(0);
+
+                    tabs[0].focus();
+                    press(tabs[0], 'ArrowRight');
+                    expect(document.activeElement).toBe(tabs[1]);
+                    expect(tabs.map((tab) => tab.getAttribute('aria-selected'))).toStrictEqual(['false', 'true']);
+                },
+            );
         });
     });
 

--- a/scripts/check-adwaita-keyboard-contract.mjs
+++ b/scripts/check-adwaita-keyboard-contract.mjs
@@ -86,6 +86,7 @@ const ROVING_LEDGER = {
     'packages/web/adwaita-web/src/elements/adw-sidebar.ts': 'via ./roving-focus.js',
     'packages/web/adwaita-web/src/elements/adw-split-button.ts': 'via <adw-popover>',
     'packages/web/adwaita-web/src/elements/adw-tab-view.ts': 'own keydown listener',
+    'packages/web/adwaita-web/src/elements/adw-toggle-group.ts': 'via ./roving-focus.js',
     'packages/web/adwaita-web/src/elements/adw-view-switcher-bar.ts': 'via ./roving-focus.js',
     'packages/web/adwaita-web/src/elements/adw-view-switcher.ts': 'via ./roving-focus.js',
     // Not a roving widget: `init.surface.tabIndex = -1` is the ONE box a dialog owns, and

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2182,31 +2182,82 @@ rather than adding a second one here.
 `packages/web/adwaita-web/src/keyboard-operable.spec.ts` awaits that microtask
 and says why.
 
-### `<adw-toggle-group>` is upstream's fifth roving widget and has none of it
+### `<adw-toggle>` has no `enabled`, so a toggle group cannot disable one segment
 
-The row-family half of this entry is CLOSED: `<adw-action-row>` (while `activatable`),
-`<adw-button-row>`, `<adw-expander-row>`'s header and `<adw-switch-row>` are tab stops that
-activate on Enter and Space, `<adw-preferences-group>` declares
-`GTK_ACCESSIBLE_ROLE_GROUP`, and `<adw-switch-row>`'s slider stopped being a focus target
-the way `adw_switch_row_init` does it. `<adw-combo-row>` was measured NOT to need it — its
-native `<select>` is already the combobox, already arrow-navigable, and already `disabled`
-at one option or fewer, which is `adw-combo-row.c:194` without a line of our own.
+Upstream's `AdwToggle` carries `enabled`, and `add_toggle` spends it immediately:
+`gtk_widget_set_sensitive (toggle->button, toggle->enabled)`
+(`adw-toggle-group.c:871`). The web `<adw-toggle>` observes `label` and `icon-name`
+and nothing else, so every rendered button is sensitive and there is no way to
+express "this view mode is unavailable right now" short of removing the toggle.
 
-What remains is the same blind spot from the other side. Upstream `<adw-toggle-group>` is
-the fifth member of the roving family: `AdwInlineViewSwitcher` builds exactly this widget
-with `GTK_ACCESSIBLE_ROLE_TAB_LIST` (`adw-inline-view-switcher.c:702`), and
-`adw_toggle_group_focus` (`adw-toggle-group.c:1045`) is the citation
-`elements/roving-focus.ts` is built on. The web element has none of it — no role, no roving
-tabindex, no arrow keys. Measured in Firefox: three toggles report `tabIndex` `[0, 0, 0]`,
-the host has no `role`, and ArrowRight/ArrowLeft/Home/End all leave `document.activeElement`
-exactly where it was.
+This surfaced while making the group keyboard-navigable. `elements/roving-focus.ts`
+documents that its caller must filter `hidden`/`disabled` items — leaving one in
+strands the user on a `focus()` the browser refuses, which is why
+`<adw-sidebar>` filters and has a spec for it. `<adw-toggle-group>` passes its
+buttons through UNFILTERED, deliberately: no `<adw-toggle>` attribute can produce
+a disabled or hidden button, so a filter would be a branch no test could reach.
+Adding `enabled` therefore means adding the filter and its spec in the same
+change, or the first disabled toggle is a focus trap — and that obligation is not
+left to this paragraph. `keyboard-operable.spec.ts` pins
+`AdwToggle.observedAttributes` to exactly `['label', 'icon-name']`, so the commit
+that adds `enabled` fails until someone reads this entry.
 
-It stays OPERABLE, every toggle being its own tab stop, so it is not the defect class
-`scripts/check-adwaita-keyboard-contract.mjs` was written against — and that gate
-structurally cannot see it either, since there is no negative tabindex to trigger on. Its
-zero finding there is a scope limit, not a clean bill. Closing it means giving the group the
-tab-list role and one roving tabindex, which turns three tab stops into one: a visible
-change to anything that tabs through a toggle group today.
+`orientation` is the second thing missing, and it is not cosmetic. `AdwToggleGroup`
+implements `GtkOrientable` (`adw-toggle-group.c:187`), installs `PROP_ORIENTATION`
+(`:202`), reorients its layout manager (`:929`) and every separator (`:873`,
+`:935`), and `AdwInlineViewSwitcher` forwards the property (`:107`). Neither web
+element has it, so both are hardcoded horizontal — `attachRovingFocus(…,
+orientation: 'horizontal')` in each — and the keyboard follows the layout
+GEOMETRICALLY upstream (`focus_sort_up_down`, `adw-widget-utils.c:339-342`), not
+from a property. A vertical group therefore needs Up/Down to move inside and
+Left/Right to propagate: the exact opposite of what both elements do today. The day
+`orientation` lands, the axis and the `inert` spec row move with it, and
+`keyboard-operable.spec.ts` pins `AdwToggleGroup.observedAttributes` so that commit
+cannot land quietly. `<adw-inline-view-switcher>` has no such pin yet.
+
+The same commit closed the roving half of this widget, and the entry it replaces
+got the ROLE wrong in a way worth keeping: it recommended "giving the group the
+tab-list role", generalised from `AdwInlineViewSwitcher` building this widget with
+`GTK_ACCESSIBLE_ROLE_TAB_LIST` (`adw-inline-view-switcher.c:702`). That is the one
+place upstream OVERRIDES the default — the C marks it `/* Special case for
+AdwInlineViewSwitcher */` (`adw-toggle-group.c:856`) — and `AdwToggleGroup` itself
+declares `GTK_ACCESSIBLE_ROLE_RADIO_GROUP` (`:1191`). Reading the widget that
+consumes a class instead of the class itself is how a ledger entry ends up
+prescribing the exception as the rule.
+
+### Nothing checks a `file.c:NNN` citation, and nothing checks the `refs/` pointer
+
+Three rounds of review on one PR produced FOUR wrong line numbers, each in a comment
+whose whole job was to ground a decision in the C: `adw-toggle-group.c:1058` for a
+filter that is at `:1059`, `:872` for a call at `:871`, `:1065` for a function whose
+name is at `:1066` (corrected in one file and left standing in another in the same
+PR), and `adw-widget-utils.c:399` for `focus_sort`, which is at `:388` — that last one
+inside the single paragraph carrying the argument that the previous draft had the axis
+backwards. A fifth claim named `adw-inline-view-switcher.c:294` as an inner layout
+container; the line resolves, and it is a `GtkImage`.
+
+`scripts/check-refs-citations.mjs` checks that a cited FILE exists. It cannot check a
+line, which is why every one of these passed. The shape that would catch them is
+narrow and mechanical: for each `<file>.c:NNN` in a comment that also names a
+backticked C symbol, assert the symbol occurs within a small window of that line. The
+window is the whole design question — a function is cited by its `static` line as
+often as by its name line, and this repo does both deliberately (`:428` and `:298` in
+one sentence) — so the reader has to accept a range rather than a point, and say which
+it accepted when it fails.
+
+The second half is smaller and equally invisible: the worktree's `refs/libadwaita`
+sat FIVE commits ahead of the pointer recorded in `HEAD` during that review. Citations
+are only meaningful against the pin, and checking it took a hand-run `md5sum` over
+three files to establish that the drift happened to be harmless. `check-refs-pin.mjs`
+does NOT cover it, checked: it dispatches to the `refs-pin` rule, which reads
+`gjsify.refsLockstep` — declared by exactly two packages, `rolldown-native` and
+`oxfmt-native`, both pinning Rust sources they compile. No package declares a
+lockstep for `refs/libadwaita`, so the tree every Adwaita citation is measured
+against is the one thing about them nothing holds.
+
+Both halves are worth one script, because the cost is already paid: four of these
+survived adversarial review by finding them one at a time, and the one that mattered
+most was the last one found.
 
 ### adwaita-core modules with no conformance vector table
 

--- a/tests/browser/specs/adwaita-keyboard.spec.ts
+++ b/tests/browser/specs/adwaita-keyboard.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { discoverBundles } from '../scripts/discover-bundles.mjs';
 
-// REAL key presses against adwaita-web's keyboard contracts — four reproductions, one
+// REAL key presses against adwaita-web's keyboard contracts — five reproductions, one
 // per shape measured broken.
 //
 // It exists beside `packages/web/adwaita-web/src/keyboard-operable.spec.ts` (which holds
@@ -222,4 +222,91 @@ async function driveKeys(page: Page, bundleUrl: string) {
     });
     // adw-expander-row.c:657 keeps GTK_ACCESSIBLE_STATE_EXPANDED on the header in step.
     expect(effects).toEqual({ activated: 2, expandedBefore: 'false', expandedAfter: 'true' });
+
+    // ---- Shape 5: a toggle group is ONE tab stop, entered on the active toggle ------
+    // Measured before the roving tabindex, same page and same keys: the Tab order was
+    // `toggle[0] → toggle[1] → toggle[2] → #after` — three separate stops — with the
+    // group role `null`, every item role `null`, `tabIndex` `[0, 0, 0]`, the state spelled
+    // `aria-pressed` and `aria-checked` absent, and ArrowRight, ArrowDown, Home and End
+    // all leaving focus on `toggle[0]`.
+    await page.evaluate(() => {
+        document.body.replaceChildren();
+        const before = document.createElement('button');
+        before.id = 'before';
+        before.textContent = 'Before';
+        const group = document.createElement('adw-toggle-group');
+        group.id = 'toggles';
+        group.setAttribute('active', '1');
+        group.innerHTML = ['One', 'Two', 'Three'].map((label) => `<adw-toggle label="${label}"></adw-toggle>`).join('');
+        const after = document.createElement('button');
+        after.id = 'after';
+        after.textContent = 'After';
+        document.body.append(before, group, after);
+        before.focus();
+    });
+
+    /** Which toggle has focus, plus the tabindex row and the checked row beside it. */
+    const toggleState = () =>
+        page.evaluate(() => {
+            const items = Array.from(document.querySelectorAll<HTMLElement>('#toggles [role="radio"]'));
+            const active = document.activeElement as HTMLElement | null;
+            return {
+                focus: items.indexOf(active as HTMLElement),
+                // Named only once focus has LEFT the group, so "still inside" and "landed
+                // on an unnamed element" cannot read the same.
+                outside: active === null || active.closest('#toggles') !== null ? null : active.id,
+                roving: items.map((item) => item.tabIndex),
+                checked: items.map((item) => item.getAttribute('aria-checked')),
+            };
+        });
+
+    await page.keyboard.press('Tab');
+    // Tab enters on the ACTIVE toggle, never the first — `adw_toggle_group_grab_focus`
+    // (adw-toggle-group.c:1066) grabs the active toggle's button.
+    expect(await toggleState()).toEqual({
+        focus: 1,
+        outside: null,
+        roving: [-1, 0, -1],
+        checked: ['false', 'true', 'false'],
+    });
+
+    // Tab from the MIDDLE toggle, before any arrow key moves it: this is the press that
+    // separates one tab stop from three, because at the last toggle a group with three
+    // stops would leave too. `adw_toggle_group_focus` propagates TAB_FORWARD and
+    // TAB_BACKWARD (adw-toggle-group.c:1059-1060) instead of walking to the next toggle.
+    await page.keyboard.press('Tab');
+    expect((await toggleState()).outside).toBe('after');
+
+    // And back in. Shift+Tab is the other half of the same C branch, and it re-enters on
+    // the ACTIVE toggle rather than the last one — the roving tabindex is the only thing
+    // the browser can see.
+    await page.keyboard.press('Shift+Tab');
+    expect(await toggleState()).toEqual({
+        focus: 1,
+        outside: null,
+        roving: [-1, 0, -1],
+        checked: ['false', 'true', 'false'],
+    });
+
+    await page.keyboard.press('ArrowRight');
+    expect(await toggleState()).toEqual({
+        focus: 2,
+        outside: null,
+        roving: [-1, -1, 0],
+        checked: ['false', 'false', 'true'],
+    });
+
+    // The other axis stays the page's: upstream `focus_sort_up_down`
+    // (adw-widget-utils.c:339-342) drops every sibling with no horizontal overlap, which
+    // in a row of toggles is all of them, so ArrowDown propagates out of the group.
+    const downMoved = await page.evaluate(() => {
+        const items = Array.from(document.querySelectorAll<HTMLElement>('#toggles [role="radio"]'));
+        const before = document.activeElement;
+        const event = new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true });
+        (before as HTMLElement).dispatchEvent(event);
+        return { moved: document.activeElement !== before, prevented: event.defaultPrevented, count: items.length };
+    });
+    expect(downMoved).toEqual({ moved: false, prevented: false, count: 3 });
+
+    expect(await page.evaluate(() => document.getElementById('toggles')?.getAttribute('role'))).toBe('radiogroup');
 }

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -25,8 +25,8 @@ follow its naming, and where one of them differs, its tab says so.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
-split button's popover, a toggle group's keyboard navigation) can be simplified
-here.
+split button's popover) can be simplified here. A toggle group's keyboard
+navigation is not: see below.
 :::
 
 ## Button Content
@@ -410,6 +410,18 @@ For a small set of mutually exclusive options, such as a view mode, use a
 **toggle group**: a linked row where exactly one toggle is active at a time. Each
 toggle takes an icon, a label, or both. The style classes `.flat` and `.round`
 adapt the group for a toolbar or give it a pill shape.
+
+A toggle group is a **single tab stop**, the way `Adw.ToggleGroup` routes focus:
+Tab enters on the active toggle and the next Tab leaves the group, while Left and
+Right move between toggles. Up and Down stay the page's, as they are upstream.
+Home and End jump to the ends — that pair is the WAI-ARIA pattern rather than
+anything GTK does, since GTK's focus directions have no Home or End. It announces itself as a radio group with one
+checked toggle — `GTK_ACCESSIBLE_ROLE_RADIO_GROUP` upstream — unless the element
+already carries a `role` when it connects, which it then keeps; `role="tablist"`
+additionally switches the toggles to tabs, the way `Adw.InlineViewSwitcher` does.
+Set it in markup or before the element is inserted: it is read once, which is all
+GTK allows too — `GtkAccessible:accessible-role` is documented "cannot be changed
+once set", and the only setter is class-level.
 
 <AdwWidget title="Adw.ToggleGroup">
   <Fragment slot="preview">


### PR DESCRIPTION
Closes the half of the `#1248` keyboard entry that `#1254` left open, and finds a second defect next to it: the role.

## Before / after, measured

Real Tab and real arrow keys in Firefox, on an `<adw-toggle-group active="1">` with three toggles and a button either side:

```
before   TAB       #before → toggle[0] → toggle[1] → toggle[2] → #after
         DECLARED  group role null · item roles [null, null, null] · tabIndex [0, 0, 0]
         STATE     aria-pressed ['false','true','false'] · aria-checked absent
         ARROWS    ArrowRight→0  ArrowDown→0  Home→0  End→0   (nothing moved)

after    TAB       #before → toggle[1] → #after
         DECLARED  group role radiogroup · wrapper role none · item roles [radio, radio, radio]
                   tabIndex [-1, 0, -1]
         STATE     aria-checked ['false','true','false'] · aria-pressed absent
         ARROWS    ArrowRight→1  Home→0  End→2
                   ArrowDown→1, unclaimed — the other axis stays the page's
```

Three tab stops become one. That is visible to anything that tabs through a toggle group today, which is why it is its own change.

## The role is a radio group, not a tab list

The ledger entry this closes recommended "giving the group the tab-list role". That is wrong, and the way it went wrong is worth keeping: it generalised from `AdwInlineViewSwitcher`, which builds exactly this widget with `GTK_ACCESSIBLE_ROLE_TAB_LIST` (`adw-inline-view-switcher.c:702`) — the one place upstream **overrides** the default. The C marks it `/* Special case for AdwInlineViewSwitcher */` (`adw-toggle-group.c:856`).

`AdwToggleGroup` itself declares `GTK_ACCESSIBLE_ROLE_RADIO_GROUP` (`:1191`) and reads the group's *current* role when building each toggle: `TAB_LIST` → `GTK_ACCESSIBLE_ROLE_TAB`, everything else → `GTK_ACCESSIBLE_ROLE_RADIO` (`:857-865`).

A role the host **already carries is kept**. `gtk_widget_class_set_accessible_role` sets a class DEFAULT that an instance's construct-time `accessible-role` overrides, so `role="group"` upstream stays `group` and still gets radio children; only an absent role is filled in. It is read once, which is all GTK allows: `GtkAccessible:accessible-role` is documented "cannot be changed once set" and has no instance setter — only the class-level `gtk_widget_class_set_accessible_role`. (It is *not* construct-only, which an earlier draft claimed; `Gtk-4.0.gir` marks it plain `writable`.) An empty `role=""` counts as no role, which `?? null` got wrong.

**`aria-pressed` belonged to neither role.** It is the toolbar toggle-button pattern, where each button is an independent on/off. A screen reader was told these three were separate buttons, not one of three exclusive choices.

The flex wrapper `div.adw-toggle-group-inner` is web-only — upstream the toggles are the group's own children — so it now declares itself out of the tree with `role="none"` rather than sitting as a `generic` between a radio group and its radios. **No upstream precedent is claimed** — an earlier draft invented one. Every `GTK_ACCESSIBLE_ROLE_PRESENTATION` in libadwaita is a leaf decoration (an icon, a gizmo), never a layout container between a role-bearing parent and role-bearing children, because GTK has no such container here to annotate. That is exactly why the attribute is needed on this side and nowhere in the C.

## Which keys, derived from the C

| behaviour | grounding |
|---|---|
| Tab **leaves** the group | `adw_toggle_group_focus` returns `GDK_EVENT_PROPAGATE` for `TAB_FORWARD`/`TAB_BACKWARD` (`adw-toggle-group.c:1059-1060`) |
| Tab **enters** on the active toggle | `adw_toggle_group_grab_focus` (`:1066`) grabs `toggle->button` of `self->active`, never the first |
| Left/Right move **inside** | every other direction goes to `adw_widget_focus_child` (`:1062`) |
| Up/Down stay the **page's** | see below |
| no wrap at the ends | `attachRovingFocus`, following `adw_widget_focus_child` |

**The C only looks orientation-blind, and a first draft of this change read it that way.** `adw_toggle_group_focus` hands every non-Tab direction on without consulting `self->orientation`, which reads like "both axes move inside". The axis is decided one level down and *geometrically*: `adw_widget_focus_child` is `focus_move` (`adw-widget-utils.c:428`) → `focus_sort` (`:388`) → `focus_sort_up_down` (`:298`), which **deletes every sibling with no horizontal overlap with the focused child** (`:339-342`). In a row of toggles that is all of them; the list is left holding only the focused button, `gtk_widget_child_focus` on a leaf that already has focus returns `FALSE`, and the press propagates. So upstream, ArrowDown in a horizontal toggle group leaves the group — and `'horizontal'` is both what the C does and what the three sibling tab lists pass.

## The mechanism that came out of it

**Nothing in the tree asserted the axis separation, for any of the five roving widgets.** `AXIS_KEYS` is one table; widening a single row would have kept every test green while every horizontal widget started swallowing the page scroll, because `attachRovingFocus` calls `preventDefault()` before it knows whether anything moved.

Every `RovingCase` now names the OTHER arrow pair and asserts, at each widget, that pressing it leaves focus unmoved **and** `defaultPrevented === false`.

**A/B:** making the walk `preventDefault` every arrow turns all five red at once — `adw-view-switcher`, `adw-view-switcher-bar`, `adw-inline-view-switcher`, `adw-sidebar`, `adw-toggle-group` — and nothing else. Restored, green.

`roving-focus.ts` itself ends up byte-identical to `main`.

## `<adw-toggle>` gets no `disabled` filter, and that is now held

`elements/roving-focus.ts` documents that a caller must filter `hidden`/`disabled` items. This one passes its buttons through unfiltered because **no `<adw-toggle>` attribute can produce a disabled or hidden button**: upstream's per-toggle `enabled` (`adw-toggle-group.c:871`) has no web counterpart yet, and a filter for a state the element cannot reach is a branch no test could enter.

A comment and a ledger entry are not a mechanism, so a spec pins `AdwToggle.observedAttributes` to exactly `['label', 'icon-name']`. The commit that adds `enabled` fails until someone reads the entry — which says the filter and its spec ship in the same change, or the first disabled toggle is a focus trap.

## What holds the rest

- `scripts/check-adwaita-keyboard-contract.mjs` — the file enters roving scope, so `ROVING_LEDGER` had to name the arm discharging it. **A/B:** with the entry removed the gate fails with `+ …/adw-toggle-group.ts entered roving scope`. Its `[roving]` arm could not see this widget before, because there was no negative tabindex to trigger on.
- `keyboard-operable.spec.ts` — the group is the fifth `ROVING_CASES` entry (addressed **by tag** now, not by index), plus: the roles, `aria-checked` row and wrapper role; one notify per real change; an arrow whose selection *refuses* still moving focus; a declared `role="group"` surviving with radio children; the `role="tablist"` branch end to end.
- `tests/browser/specs/adwaita-keyboard.spec.ts` — Shape 5 under real keys: Tab in, **Tab out from the middle toggle** (the press that separates one stop from three — at the last toggle both behave alike), **Shift+Tab back in on the active toggle**, ArrowRight, and ArrowDown neither moving nor claimed.
- `adw-row-state.spec.ts` pinned `aria-pressed`; it now pins `aria-checked`, the role, and the tabIndex row after a *programmatic* `active`, where reading only `classList` would pass on a repaint that left Tab entering on the wrong toggle.

**A/B:** reverting `adw-toggle-group.ts` to `main` turns the package suite and the real-key spec red together. 4558 package assertions green after; the real-key spec passes with the bundle staged, which the probe confirmed independently — that spec registers a *passing placeholder* when no adwaita-web bundle is present, so its "1 passed" is not on its own evidence that Shape 5 ran.

## Docs

`website/src/content/docs/adwaita/buttons.mdx` said the previews simplify "a toggle group's keyboard navigation". They no longer do, so the note says so and the Toggle Group section documents the tab stop, which arrows move, the two roles, and that the role is read once.


## Three review rounds, and what each cost

Worth recording, because the pattern is the finding:

| round | what it overturned |
|---|---|
| 1 | the `'both'` axis argument — `adw_toggle_group_focus` really never reads `self->orientation`, but `focus_sort_up_down` filters geometrically, so ArrowDown leaves a horizontal group upstream. `roving-focus.ts` reverted to byte-identical with `main`. |
| 2 | three C citations off by one; the unroled wrapper; the role clobber; five tests asserting less than their comments claimed |
| 3 | a **fourth** wrong line number (`:399` for `focus_sort`, which is at `:388`) — in the one paragraph carrying round 1's correction; `accessible-role` is not construct-only; the `PRESENTATION` precedent was invented; the `:1065`/`:1066` twin survived in the Playwright spec; and the `orientation` decision had no mechanism |

Four wrong line numbers across three rounds, each found by hand. `scripts/check-refs-citations.mjs` checks that a cited FILE exists and cannot check a line, and the worktree's `refs/libadwaita` was five commits ahead of the recorded pointer while all of this was being verified — `gjsify.refsLockstep` is declared by exactly two packages, neither of them for libadwaita. Both halves are now one entry in `status/open-todos.md` with the design and the evidence, because that is a script, not a sweep.
