### PR TITLE
fix(adwaita-nativescript): style what a showcase emits

### DIFF
--- a/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
+++ b/packages/nativescript-bridge/adwaita/src/theme/adwaita.css
@@ -74,6 +74,29 @@ Page.adw-window {
     margin: 0;
 }
 
+/* ===== Card (the documented `.card` style class) ===== */
+
+/* One surface, two spellings — the pattern `.boxed-list` above already uses.
+ * Upstream `.card` and the boxed list ARE the same recipe
+ * (stylesheet/widgets/_misc.scss:197-236); `@gjsify/adwaita-web` factors both out
+ * of a single `%card` placeholder, so this repeats the colours above rather than
+ * inventing a second card. `.adw-card` is the spelling a view copied from the
+ * browser twin carries, and it was styled by NOTHING here: a NativeScript view
+ * setting `className = 'adw-card'` rendered a transparent box with square corners.
+ *
+ * No box-shadow, no border: the NS CSS subset has neither, which is why
+ * `.boxed-list` has neither. The padding is the one thing the ELEMENT adds over
+ * the bare class in the browser port (`--spacing-l`, 18) — a bare `.card` in
+ * libadwaita deliberately has none, but every NS view reaching for this name is
+ * the element's analogue. */
+.card,
+.adw-card {
+    background-color: #ffffff;
+    color: rgba(0, 0, 6, 0.8);
+    border-radius: 12;
+    padding: 18;
+}
+
 /* ===== Rows ===== */
 
 .adw-row {
@@ -1528,6 +1551,12 @@ Page.ns-dark.adw-window {
  * (see the light `.adw-row` note) so the card's rounded corners show. */
 .ns-dark .boxed-list,
 .ns-dark .adw-preferences-group-listbox {
+    background-color: #34343a;
+    color: #ffffff;
+}
+
+.ns-dark .card,
+.ns-dark .adw-card {
     background-color: #34343a;
     color: #ffffff;
 }

--- a/scripts/check-nativescript-theme-classes.mjs
+++ b/scripts/check-nativescript-theme-classes.mjs
@@ -30,11 +30,31 @@
 // escape hatch, since a name is added to a list far more easily than a sentence
 // is written about it, and "unreviewed" is the state this file exists to end.
 //
+// THE SECOND INCIDENT, and why the showcase is in scope. The reader saw only the
+// PACKAGE's widget sources, so a class an APP sets went unchecked — and the
+// storybook showcase is an app. `carousel.ns.ts` builds every carousel page with
+// `className = 'adw-card …'` and nothing anywhere styled `.adw-card`, so three
+// pages that the browser twin draws as rounded white cards rendered as
+// transparent square boxes; `widgets.ns.ts` names `adw-action-buttons` on a
+// horizontal StackLayout whose browser twin carries `gap: 12px; margin: 6px 0`,
+// so its two buttons sat flush. Both were invisible here for the same reason the
+// keycap rename was invisible to the suite: nothing compared the two halves.
+//
+// SCOPES ARE PAIRED WITH WHAT LOADS THEM, because "styled" is not one question.
+// A consumer installs `@gjsify/adwaita-nativescript` and gets `theme/adwaita.css`
+// and nothing else, so a BRIDGE class satisfied by a showcase's own stylesheet
+// would be a rule that ships to nobody. A SHOWCASE class may be satisfied by any
+// of the three files its `app.css` imports. Hence {@link SCOPES}: same reader,
+// same ledger, different stylesheet set per source tree.
+//
 // SCOPE, AND WHY IT IS NARROW. Only the `adw-` namespace plus the handful of
 // unprefixed libadwaita names this port uses ({@link UNPREFIXED}). A bare-word
 // heuristic would sweep up every lowercase string in the tree; naming them is
 // reviewable, and a missing one shows up as a class nothing gates rather than as
-// a false failure.
+// a false failure. It is also why the unprefixed style classes the showcase's
+// carousel reaches for — `.title-1`, `.success`, `.warning` — are NOT held here
+// even though nothing styles them either; that gap is in `status/open-todos.md`
+// with its measurement.
 //
 // TEMPLATE LITERALS ARE READ TOO, interpolations blanked out first. `` `${b.className}
 // adw-entry-apply` `` is how a widget ADDS a class to an inherited list, the dominant
@@ -60,7 +80,31 @@ const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..
 
 const SRC = join(ROOT, 'packages/nativescript-bridge/adwaita/src');
 const THEME = join(SRC, 'theme/adwaita.css');
+const SHOWCASE = join(ROOT, 'showcases/dom/adwaita-storybook-nativescript');
 const LEDGER = join(ROOT, 'status/nativescript-theme-classes.json');
+
+/**
+ * Source tree → the stylesheets a view built from it can actually be styled by,
+ * and the file a missing rule belongs in.
+ *
+ * The showcase's three are exactly what its `app/app.css` imports: the bridge
+ * theme and the storybook chrome (both copied in by its `sync:theme` script,
+ * which is why they are read from the PACKAGES rather than from the gitignored
+ * copies) plus `app.css` itself.
+ */
+const SCOPES = [
+    { label: 'bridge widget', sources: SRC, stylesheets: [THEME], home: THEME },
+    {
+        label: 'showcase view',
+        sources: join(SHOWCASE, 'src'),
+        stylesheets: [
+            THEME,
+            join(ROOT, 'packages/nativescript-bridge/storybook/src/theme/storybook.css'),
+            join(SHOWCASE, 'app/app.css'),
+        ],
+        home: join(SHOWCASE, 'app/app.css'),
+    },
+];
 
 /** libadwaita's own unprefixed class names, which this port keeps verbatim. */
 const UNPREFIXED = new Set(['keycap', 'dimmed']);
@@ -70,7 +114,7 @@ const MIN_REASON = 40;
 
 const isTracked = (name) => name.startsWith('adw-') || UNPREFIXED.has(name);
 
-function widgetSources() {
+function widgetSources(root) {
     const found = [];
     const walk = (dir) => {
         for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -82,8 +126,17 @@ function widgetSources() {
             }
         }
     };
-    walk(SRC);
+    walk(root);
     return found;
+}
+
+/** Every `.name` a stylesheet selects on, across the set one scope may draw from. */
+function styledClasses(stylesheets) {
+    const styled = new Set();
+    for (const sheet of stylesheets) {
+        for (const match of readFileSync(sheet, 'utf8').matchAll(/\.([a-z][a-z0-9-]*)/g)) styled.add(match[1]);
+    }
+    return styled;
 }
 
 /** A literal holding one class, or several separated by spaces as NS holds them. */
@@ -124,11 +177,23 @@ function emittedClasses(files) {
     return emitted;
 }
 
-const theme = readFileSync(THEME, 'utf8');
-const styled = new Set([...theme.matchAll(/\.([a-z][a-z0-9-]*)/g)].map((match) => match[1]));
+/** Per scope: what it emits, and which of those names it can be styled by. */
+const scanned = SCOPES.map((scope) => {
+    const emitted = emittedClasses(widgetSources(scope.sources));
+    const styled = styledClasses(scope.stylesheets);
+    return { scope, emitted, unstyled: [...emitted.keys()].filter((name) => !styled.has(name)).sort() };
+});
 
-const emitted = emittedClasses(widgetSources());
-const unstyled = [...emitted.keys()].filter((name) => !styled.has(name)).sort();
+/** Union across scopes — the ratchet asks "does ANYTHING still emit this?". */
+const emitted = new Map();
+for (const { emitted: found } of scanned) {
+    for (const [name, files] of found) {
+        if (!emitted.has(name)) emitted.set(name, new Set());
+        for (const file of files) emitted.get(name).add(file);
+    }
+}
+/** Unstyled in ANY scope that emits it: one satisfied scope does not cover another. */
+const unstyled = [...new Set(scanned.flatMap((entry) => entry.unstyled))].sort();
 
 const ledger = JSON.parse(readFileSync(LEDGER, 'utf8'));
 const reviewed = ledger.reviewed ?? {};
@@ -136,9 +201,14 @@ const listed = new Set(Object.keys(reviewed));
 
 const failures = [];
 
-for (const name of unstyled) {
-    if (listed.has(name)) continue;
-    failures.push(`${name} — emitted by ${[...emitted.get(name)].join(', ')} and the theme has no \`.${name}\` rule.`);
+for (const { scope, emitted: found, unstyled: missing } of scanned) {
+    for (const name of missing) {
+        if (listed.has(name)) continue;
+        failures.push(
+            `${name} — emitted by ${scope.label} ${[...found.get(name)].join(', ')}, and none of ` +
+                `${scope.stylesheets.map((sheet) => relative(ROOT, sheet)).join(', ')} has a \`.${name}\` rule.`,
+        );
+    }
 }
 
 // The ratchet: a listed class that is now styled, or that nothing emits, has to
@@ -147,7 +217,7 @@ for (const name of unstyled) {
 for (const name of listed) {
     if (!emitted.has(name)) {
         failures.push(`${name} is listed, but no widget emits it any more — remove the entry.`);
-    } else if (styled.has(name)) {
+    } else if (!unstyled.includes(name)) {
         failures.push(`${name} is listed as unstyled, but the theme now styles it — remove the entry.`);
     } else if (typeof reviewed[name] !== 'string' || reviewed[name].trim().length < MIN_REASON) {
         // A placeholder entry is the unreviewed list again, one key at a time.
@@ -157,7 +227,8 @@ for (const name of listed) {
 }
 
 process.stdout.write(
-    `check-nativescript-theme-classes: ${emitted.size} classes emitted, ` +
+    `check-nativescript-theme-classes: ${emitted.size} classes emitted across ${SCOPES.length} scope(s) ` +
+        `(${scanned.map((entry) => `${entry.scope.label}: ${entry.emitted.size}`).join(', ')}), ` +
         `${emitted.size - unstyled.length} styled, ${Object.keys(reviewed).length} reviewed exemption(s).\n`,
 );
 
@@ -169,8 +240,8 @@ if (failures.length > 0) {
             `compares them — a rename leaves the suite green and the widget unstyled.\n` +
             `  If the class is a styling HOOK with no look of its own (the widget sets the property\n` +
             `  imperatively, or a parent selector carries the rule), add it to "reviewed" in\n` +
-            `  ${relative(ROOT, LEDGER)} with the reason. Otherwise give it a rule in\n` +
-            `  ${relative(ROOT, THEME)}.\n`,
+            `  ${relative(ROOT, LEDGER)} with the reason. Otherwise give it a rule in the\n` +
+            `  stylesheet its scope names above — ${SCOPES.map((scope) => relative(ROOT, scope.home)).join(' or ')}.\n`,
     );
     process.exit(1);
 }

--- a/scripts/check-storybook-widget-coverage.mjs
+++ b/scripts/check-storybook-widget-coverage.mjs
@@ -154,7 +154,7 @@ const ONE_RENDERER_ONLY = {
     card: {
         only: 'web',
         decision:
-            "`.card` is a libadwaita STYLE CLASS (stylesheet/widgets/_misc.scss:197) with no Adw type behind it. `<adw-card>` is a style class packaged as an element — its whole body is `classList.add('adw-card')` — and a NativeScript view sets `className` directly (showcases/dom/adwaita-storybook-nativescript/src/view-switching/carousel.ns.ts:28 already does), so a widget class there would carry no behaviour at all. The LOOK is a separate, open matter: no `.adw-card` rule exists in packages/nativescript-bridge/adwaita/src/theme/adwaita.css, so that className renders nothing today — a theme gap, not a widget one.",
+            "`.card` is a libadwaita STYLE CLASS (stylesheet/widgets/_misc.scss:197) with no Adw type behind it. `<adw-card>` is a style class packaged as an element — its whole body is `classList.add('adw-card')` — and a NativeScript view sets `className` directly (showcases/dom/adwaita-storybook-nativescript/src/view-switching/carousel.ns.ts:28 already does), so a widget class there would carry no behaviour at all. The LOOK was a separate gap and is closed: `.card, .adw-card` is now a rule in packages/nativescript-bridge/adwaita/src/theme/adwaita.css, both spellings on one selector the way `.boxed-list` already carries the same surface. It rendered NOTHING until then, and scripts/check-nativescript-theme-classes.mjs could not see it either — that reader saw only the package's own widget sources, never an app's.",
     },
     'carousel-indicator-dots': {
         only: 'web',

--- a/showcases/dom/adwaita-storybook-nativescript/app/app.css
+++ b/showcases/dom/adwaita-storybook-nativescript/app/app.css
@@ -23,3 +23,23 @@ Button,
 TextField {
     font-family: 'AdwaitaSans-Regular', 'Adwaita Sans';
 }
+
+/* Showcase chrome: the Overview story's button pair. `adw-action-buttons` is a
+   name this showcase invents — no libadwaita style class and no bridge widget
+   emits it — so its rule belongs here and not in adwaita.css. It styled NOTHING
+   until now, and the browser twin sets the same two properties inline
+   (`gap: 12px; margin: 6px 0`, widgets.web.ts:110-112), so the two rendered the
+   row differently: buttons flush against each other on Android, spaced in the
+   browser.
+
+   NativeScript has no `gap` and no `:last-child`, so the space between the
+   buttons is half a gap on each side. That leaves 6 at the outer edges the
+   browser twin does not have — the closest the CSS subset gets, and visible only
+   against the group's own padding. */
+.adw-action-buttons {
+    margin: 6 0 6 0;
+}
+
+.adw-action-buttons .adw-button {
+    margin: 0 6 0 6;
+}

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -2208,6 +2208,55 @@ zero finding there is a scope limit, not a clean bill. Closing it means giving t
 tab-list role and one roving tabindex, which turns three tab stops into one: a visible
 change to anything that tabs through a toggle group today.
 
+### The NativeScript theme ships none of libadwaita's label utility classes
+
+`scripts/check-nativescript-theme-classes.mjs` now reads the storybook showcase's
+views as well as the bridge's widgets, and closed the two `adw-`-prefixed gaps it
+found (`.adw-card`, `.adw-action-buttons`). What it still cannot see is the
+UNPREFIXED half, and the same showcase is full of it: `carousel.ns.ts` builds each
+page with `className = 'adw-card accent|success|warning'` and labels it `title-1`,
+`bottom-sheet.ns.ts` uses `title-2` — and **not one of those four has a rule** in
+any of the three stylesheets `app.css` imports. The pages render at body size in
+the default colour where the browser twin sets `font-size:24pt;font-weight:800`
+and a 14% accent tint (`carousel.web.ts:12-14,36`), inline, because the web
+storybook does not use the classes either.
+
+`bottom-sheet.ns.ts:43` is the one to read first, because it says the quiet part:
+"Match the GTK `.title-2` typography (bold heading) — NS has no typography utility
+class, so a plain bold Label stands in." There is no stand-in. The next three
+lines set `text` and `className = 'title-2'` and nothing else, so the label is
+neither bold nor larger — a comment describing a fallback that was never written,
+which is the same shape as every other claim in this ledger that nothing checked.
+
+Setting the two properties on the Label is NOT the fix, and this is the trap
+worth writing down: NativeScript drops a CSS value for any property a widget set
+as a LOCAL one (`properties/index.js:585-598`, the reason
+`status/nativescript-theme-classes.json` exempts `adw-icon`), so a local
+`fontWeight` would permanently shadow the `.title-2` rule this entry is asking
+for. The theme rule has to come first.
+
+The theme carries `.dimmed` (scoped to `.adw-shortcut-label`) and nothing else
+from `_labels.scss`, whose utility set — `.title-1`…`.title-4`, `.heading`,
+`.body`, `.caption`, `.caption-heading`, `.document`, `.monospace`, `.numeric`,
+`.accent`/`.error`/`.warning`/`.success` — `packages/web/adwaita-web` ships in
+full and `status/sections/adwaita-web-roadmap.md` calls "the gap consumers
+actually hit".
+
+WHY THE GATE DOES NOT HOLD IT YET, measured rather than assumed. Its tracked set
+is `adw-*` plus two named unprefixed classes, deliberately: a bare-word heuristic
+would sweep up every lowercase string in the tree. The obvious principled widening
+— take the names from `refs/libadwaita/doc/style-classes.md`, which
+`check-adwaita-style-classes.mjs` already reads — was tried and measured: 52
+documented classes, 15 emitted by the bridge or the showcase, **8 with no rule**.
+Three of the eight (`.content`, `.inline`, `.sidebar`) are not class emissions at
+all — they are slot names and property values in `split-view-base.ts`,
+`view-switcher-model.ts` and `adw-sidebar.ts` that happen to match a documented
+class name. A gate that accuses in three cases out of eight is a gate that gets
+routed around, so the widening waits until the reader can tell a `className`
+assignment from any other string. Closing the LOOK is separate again, and is a
+design port rather than a fix: NativeScript has no `rem`, no `text-transform` and
+no `color-mix`, so each of those classes needs its own literal.
+
 ### adwaita-core modules with no conformance vector table
 
 `breakpoint.ts`, `color-scheme.ts`, `scrolling.ts` and `toast.ts` export shared


### PR DESCRIPTION
`scripts/check-nativescript-theme-classes.mjs` exists because a widget's class name and the theme's selector are two halves of one decision and nothing compared them — renaming `keycap` to `adw-keycap` left 3221 tests green while every keycap lost its fill. The reader it added saw only `packages/nativescript-bridge/adwaita/src`. **An app is the other half**, and the storybook showcase is an app.

## What it was hiding

| class | emitted by | rendered |
|---|---|---|
| `.adw-card` | every carousel page, `carousel.ns.ts:28` | transparent, square-cornered box — the browser twin draws a rounded white card |
| `.adw-action-buttons` | the Overview story's button pair, `widgets.ns.ts:138` | buttons flush against each other — the browser twin carries `gap: 12px; margin: 6px 0` (`widgets.web.ts:110-112`) |

Both are the same shape as the incident the gate was written for: one half named something the other half never styled, and no suite compares them.

## The rules, and where each belongs

`.card, .adw-card` goes in the **bridge theme**, both spellings on one selector — the pattern `.boxed-list, .adw-preferences-group-listbox` above it already uses, for the same reason: upstream `.card` and the boxed list are literally one recipe (`stylesheet/widgets/_misc.scss:197-236`), and `@gjsify/adwaita-web` factors both out of a single `%card` placeholder. So the rule repeats the colours already there rather than inventing a second card. No `box-shadow` and no border, because the NativeScript CSS subset has neither — which is why `.boxed-list` has neither.

`.adw-action-buttons` goes in the **showcase's own `app/app.css`**. No libadwaita style class and no bridge widget emits it; it is a name this showcase invented, so a rule in the shipped theme would be a rule for nobody. NativeScript has no `gap` and no `:last-child`, so the space between the buttons is half a gap on each side — 6 at the outer edges the browser twin does not have, which the comment states.

## The mechanism: scopes paired with what loads them

"Styled" is not one question. A consumer installs `@gjsify/adwaita-nativescript` and gets `theme/adwaita.css` and **nothing else**, so a bridge class satisfied by a showcase's stylesheet would be a rule that ships to nobody. A showcase view may be satisfied by any of the three files its `app.css` imports — the bridge theme, the storybook chrome, and `app.css` itself (read from the packages, not from the gitignored `sync:theme` copies).

So the reader now carries `SCOPES`: same regexes, same ledger, different stylesheet set per source tree, and each failure names the sheets it looked in.

**A/B, both arms:**

```
rules removed          2 problems — adw-action-buttons and adw-card, each naming all three sheets
bridge class styled
ONLY from app.css      1 problem  — adw-scope-probe, naming just the bridge theme
restored               178 classes emitted across 2 scope(s) (bridge widget: 176,
                       showcase view: 9), 148 styled, 30 reviewed exemption(s)
```

The second arm is the one that matters: without it the widening would have quietly let a shipped widget be "styled" by a file no consumer has.

## The stale exemption that had said so

`check-storybook-widget-coverage.mjs`'s `card` entry already recorded *"no `.adw-card` rule exists … so that className renders nothing today — a theme gap, not a widget one."* It was right, and it sat there because the gate that should have failed on it structurally could not see the file. The entry now records the closure and why the reader missed it.

## Still open, measured

`status/open-todos.md` gains the unprefixed half: `.title-1`, `.title-2`, `.success` and `.warning` are emitted by the same showcase and styled by nothing in any of the three sheets. The obvious principled widening — take the names from `refs/libadwaita/doc/style-classes.md`, which another gate already reads — was **tried and measured**: 52 documented classes, 15 emitted, 8 unstyled, of which three (`.content`, `.inline`, `.sidebar`) are slot names and property values that merely collide with a class name. A gate that accuses in three cases out of eight gets routed around, so it waits for a reader that can tell a `className` assignment from any other string.

The entry also records what `bottom-sheet.ns.ts:43` says — *"NS has no typography utility class, so a plain bold Label stands in"* — next to the three lines that follow it, which set `text` and `className` and nothing else. There is no stand-in. And it records why setting the properties locally is not the fix: NativeScript drops a CSS value for any property a widget set as a local one, so a local `fontWeight` would permanently shadow the `.title-2` rule the entry is asking for.
