### PR TITLE
feat(cli): ship can package translations

### DIFF
--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -492,3 +492,55 @@ runs anywhere"*, and that there is *"no packaging file to keep in your repo"*. B
 here: `--format dmg` refuses on Linux, and `gjsify ship ci` scaffolds a workflow into the
 consumer's repository. The honest replacement is A1's rule plus: *assemble anywhere, pack where the
 format's tool lives, and never claim a signature we could not make.*
+
+## Amendment, 2026-08-22 — translations are payload, and the prefix has to reach the app
+
+### A8. `localeDir`: compiled catalogues, staged in the only layout that is ever read
+
+§ 2 listed the payload as "the app bundle, its assets, its GSettings schemas, its icons and its
+metadata". Translations were not in it, and nothing else carried them: an app with a working
+gettext setup could be packaged and would show English on a German desktop, because the `.mo`
+files simply were not in the artifact.
+
+`gjsify.ship.localeDir` names a directory of COMPILED catalogues — `<lang>/LC_MESSAGES/<domain>.mo`,
+which is the default output of `@gjsify/vite-plugin-gettext`'s `gettextPlugin` — and they are
+staged into `share/locale/` with that structure preserved.
+
+The structure is not a stylistic choice: `bindtextdomain` looks in `<dir>/<lang>/LC_MESSAGES/` and
+nowhere else. So discovery REFUSES three shapes, all of them the same failure wearing different
+clothes — a package that installs its translations and shows none of them:
+
+| refused | why it would otherwise pass |
+|---|---|
+| a `.po` beside or instead of a `.mo` | `bindtextdomain` reads `.mo` only; a staged `.po` is a file nothing opens |
+| a `.mo` outside `<lang>/LC_MESSAGES/` | the commonest slip is `msgfmt` run without the `LC_MESSAGES` level |
+| a declared directory holding no `.mo` at all | a promise the package does not keep, and it packs green |
+
+That failure mode is why the refusals exist rather than warnings. An untranslated UI is
+indistinguishable from "this app has no German", so nobody reports it as a packaging bug — it is
+the quietest possible way for a release to be wrong.
+
+### A9. The launcher passes the locale directory, for the reason § 3 already gives
+
+§ 3 established that the launcher derives its prefix at runtime so ONE payload becomes `/usr` in a
+`.deb`, `/usr` in an `.rpm` and `/app` in a Flatpak. Catalogues inherit that problem exactly:
+`bindtextdomain` takes a directory, and there is no environment variable the *library* reads on its
+own (`TEXTDOMAINDIR` is honoured by the gettext command-line tools, not by glibc's
+`bindtextdomain`). A baked `/usr/share/locale` would be wrong in a Flatpak and in every
+`--prefix` tree.
+
+So the launcher exports `GJSIFY_LOCALE_DIR="$prefix"/share/locale` when — and only when — something
+was staged, and the app calls `bindtextdomain(domain, GLib.getenv('GJSIFY_LOCALE_DIR') ?? '/usr/share/locale')`.
+Same division of labour as `XDG_DATA_DIRS` for icons and schemas: the launcher knows the install
+layout, the app does not.
+
+### A10. The locale tree drops out of the wholesale bundle staging
+
+`discoverPayload` stages every file beside the bundle into `lib/<binary>/`, and `dist/locale/` sits
+beside `dist/app.gjs.mjs` in the layout above. Measured on a probe package: the same `.mo` came out
+at BOTH `share/locale/de/LC_MESSAGES/` and `lib/<binary>/locale/de/LC_MESSAGES/`. The second copy is
+dead weight — nothing looks there.
+
+This is the same class as `ship` once staging the test suite: whatever lies next to the bundle is
+carried, whether or not it belongs in a package. The subtraction is targeted at the DECLARED locale
+directory only, so a package that legitimately ships assets beside its bundle keeps them.

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -58,6 +58,26 @@ A GI library that arrives as a gjsify npm prebuild — `Gwebgl` is the one that 
 
 Both halves are staged from the same directory on purpose: a typelib without its shared library installs and then dies at the first import, which is the failure this feature exists to prevent.
 
+### `ship` can package translations
+
+`gjsify.ship.localeDir` names a directory of compiled catalogues and stages them into
+`share/locale/`, keeping the `<lang>/LC_MESSAGES/<domain>.mo` layout that `bindtextdomain` reads.
+The launcher then exports `GJSIFY_LOCALE_DIR`, so the app finds them without knowing which prefix
+it was installed under — the same division of labour § 3 of ADR 0024 already uses for icons and
+schemas.
+
+Translations were simply not part of the payload before: an app with a working gettext setup
+packaged fine and showed English on a German desktop.
+
+Discovery refuses a `.po` left in place of a `.mo`, a catalogue outside `<lang>/LC_MESSAGES/`, and
+a declared directory holding no catalogue at all. All three are the same failure — a package that
+installs its translations and shows none of them — and it is the quietest kind, because an
+untranslated UI is indistinguishable from "this app has no German".
+
+One thing found by reading the built `.rpm` rather than the config: `dist/locale/` sits beside the
+bundle, so the wholesale bundle staging shipped every catalogue a second time under
+`lib/<binary>/locale/`. The declared locale tree now drops out of that staging.
+
 ### Two smaller things `ship` got wrong
 
 - **`Gda-6.0` had no entry in the typelib table**, so any app touching libgda was refused with an accurate but unhelpful message. It maps to `gir1.2-gda-6.0` / `libgda` now.

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -11,6 +11,7 @@ import bundlerPickSuite from './bundler-pick.spec.js';
 import cliFailSuite from './cli-fail.spec.js';
 import shipPlanSuite from './utils/ship/plan.spec.js';
 import shipSettingsSuite from './utils/ship/settings.spec.js';
+import shipLocalesSuite from './utils/ship/discover-locales.spec.js';
 import shipDependsSuite from './utils/ship/depends.spec.js';
 import installProvenanceSuite from './utils/install-provenance.spec.js';
 import shipArchivesSuite from './utils/ship/archives.spec.js';
@@ -196,6 +197,7 @@ run(
         cliFailSuite,
         shipPlanSuite,
         shipSettingsSuite,
+        shipLocalesSuite,
         shipDependsSuite,
         installProvenanceSuite,
         shipArchivesSuite,

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -435,6 +435,19 @@ export interface ConfigDataShip extends AppMetadata {
      * the dependency check exists to prevent.
      */
     bundledTypelibs?: string[];
+    /**
+     * Directory holding COMPILED gettext catalogues in the layout `bindtextdomain` reads —
+     * `<lang>/LC_MESSAGES/<domain>.mo` — e.g. `"dist/locale"`, which is what
+     * `@gjsify/vite-plugin-gettext`'s `gettextPlugin` writes by default.
+     *
+     * Staged into `share/locale/` with that structure preserved, and the launcher then exports
+     * `GJSIFY_LOCALE_DIR` so the app can call `bindtextdomain(domain, dir)` without knowing which
+     * prefix it was installed under.
+     *
+     * `.po` sources are NOT accepted: `bindtextdomain` reads `.mo` only, and staging a `.po`
+     * produces a package that installs its translations and shows none of them.
+     */
+    localeDir?: string;
     /** Extra payload entries: prefix-relative destination → project-relative source. */
     extraFiles?: Record<string, string>;
     /** Arguments the launcher appends before the user's own. */

--- a/packages/infra/cli/src/utils/ship/archives.spec.ts
+++ b/packages/infra/cli/src/utils/ship/archives.spec.ts
@@ -44,6 +44,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         iconFiles: [],
         schemaFiles: [],
         typelibFiles: [],
+        localeFiles: [],
         extraFiles: {},
         execArgs: [],
         outDir: 'ship',

--- a/packages/infra/cli/src/utils/ship/discover-locales.spec.ts
+++ b/packages/infra/cli/src/utils/ship/discover-locales.spec.ts
@@ -141,7 +141,11 @@ export default async () => {
             });
             try {
                 const found = discover(root, { localeDir: 'dist/locale' });
-                expect(found.bundleFiles.sort()).toStrictEqual(['app.gjs.mjs', join('assets', 'logo.png')]);
+                // POSIX separator in the expectation, not `join`: `bundleFiles` is normalised to
+                // POSIX by `listFilesRecursive`, so a host-shaped expectation passes on Linux and
+                // fails on Windows with `assets\logo.png` — which is exactly how this test first
+                // went red in CI.
+                expect(found.bundleFiles.sort()).toStrictEqual(['app.gjs.mjs', 'assets/logo.png']);
             } finally {
                 rmSync(root, { recursive: true, force: true });
             }

--- a/packages/infra/cli/src/utils/ship/discover-locales.spec.ts
+++ b/packages/infra/cli/src/utils/ship/discover-locales.spec.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// Locale discovery, and — the half that matters — what it REFUSES.
+//
+// Every refusal here covers one shape of the same failure: a package that installs its
+// translations and shows none of them. That is the worst kind to ship, because it is
+// indistinguishable from "this app has no German", so nobody files it as a packaging bug.
+//
+// Exercised through `discoverPayload` against a real directory tree rather than a mocked fs: the
+// thing under test is what the filesystem layout means to `bindtextdomain`, and a mock would only
+// re-assert the assumption being checked.
+
+import { describe, expect, it } from '@gjsify/unit';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { discoverPayload } from './discover.js';
+import type { ConfigDataShip } from '../../types/config-data.js';
+
+/** A project dir with a built bundle, plus whatever locale tree the case needs. */
+function project(build: (root: string) => void): string {
+    const root = mkdtempSync(join(tmpdir(), 'gjsify-ship-locale-'));
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'dist', 'app.gjs.mjs'), '// bundle\n');
+    build(root);
+    return root;
+}
+
+function discover(root: string, ship: Partial<ConfigDataShip>) {
+    return discoverPayload({
+        projectDir: root,
+        pkg: { name: 'hello', version: '1.0.0' },
+        ship: ship as ConfigDataShip,
+        declaredBundle: 'dist/app.gjs.mjs',
+    });
+}
+
+function mo(root: string, rel: string): void {
+    const full = join(root, 'dist', 'locale', rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    // Content is irrelevant to discovery — the layout is what is under test.
+    writeFileSync(full, 'MO');
+}
+
+export default async () => {
+    await describe('discoverPayload — locales', async () => {
+        await it('finds nothing when no localeDir is declared', async () => {
+            const root = project(() => {});
+            try {
+                expect(discover(root, {}).localeFiles.length).toBe(0);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('collects every catalogue and keeps its layout', async () => {
+            const root = project((r) => {
+                mo(r, 'de/LC_MESSAGES/hello.mo');
+                mo(r, 'fr/LC_MESSAGES/hello.mo');
+                mo(r, 'pt_BR/LC_MESSAGES/hello.mo');
+            });
+            try {
+                const found = discover(root, { localeDir: 'dist/locale' }).localeFiles;
+                expect(found.map((f) => f.rel).sort()).toStrictEqual([
+                    'de/LC_MESSAGES/hello.mo',
+                    'fr/LC_MESSAGES/hello.mo',
+                    'pt_BR/LC_MESSAGES/hello.mo',
+                ]);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('refuses a declared directory that is not there', async () => {
+            const root = project(() => {});
+            try {
+                expect(() => discover(root, { localeDir: 'dist/locale' })).toThrow('does not exist');
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('refuses a directory that declares locales and ships none', async () => {
+            // An empty tree is a promise the package does not keep — and it packs green.
+            const root = project((r) => mkdirSync(join(r, 'dist', 'locale'), { recursive: true }));
+            try {
+                expect(() => discover(root, { localeDir: 'dist/locale' })).toThrow('no `.mo` catalogue');
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('refuses a .po left in place of a compiled catalogue', async () => {
+            // `bindtextdomain` reads `.mo` only. A staged `.po` is a file nothing ever opens.
+            const root = project((r) => {
+                mo(r, 'de/LC_MESSAGES/hello.mo');
+                const full = join(r, 'dist', 'locale', 'fr', 'LC_MESSAGES');
+                mkdirSync(full, { recursive: true });
+                writeFileSync(join(full, 'hello.po'), 'msgid ""\n');
+            });
+            try {
+                expect(() => discover(root, { localeDir: 'dist/locale' })).toThrow('.po source');
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('refuses a catalogue outside <lang>/LC_MESSAGES/', async () => {
+            // The commonest slip: msgfmt run without the LC_MESSAGES level. It installs, and the
+            // app stays English.
+            const root = project((r) => mo(r, 'de/hello.mo'));
+            try {
+                expect(() => discover(root, { localeDir: 'dist/locale' })).toThrow('LC_MESSAGES');
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('keeps the locale tree out of the wholesale bundle staging', async () => {
+            // `dist/locale/` sits BESIDE `dist/app.gjs.mjs`, and `bundleFiles` is "everything next
+            // to the bundle" — so without this the same `.mo` shipped twice: once correctly under
+            // `share/locale/`, once as dead weight under `lib/<binary>/locale/`. Measured on a real
+            // package before the fix; nothing ever looks in the second place.
+            const root = project((r) => mo(r, 'de/LC_MESSAGES/hello.mo'));
+            try {
+                const found = discover(root, { localeDir: 'dist/locale' });
+                expect(found.bundleFiles).toStrictEqual(['app.gjs.mjs']);
+                expect(found.localeFiles.length).toBe(1);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('still stages a sibling directory that is not the locale tree', async () => {
+            // The subtraction is targeted: only the DECLARED locale directory drops out, so a
+            // package that legitimately ships assets beside its bundle keeps them.
+            const root = project((r) => {
+                mo(r, 'de/LC_MESSAGES/hello.mo');
+                mkdirSync(join(r, 'dist', 'assets'), { recursive: true });
+                writeFileSync(join(r, 'dist', 'assets', 'logo.png'), 'PNG');
+            });
+            try {
+                const found = discover(root, { localeDir: 'dist/locale' });
+                expect(found.bundleFiles.sort()).toStrictEqual(['app.gjs.mjs', join('assets', 'logo.png')]);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+
+        await it('names the offending file, not just the directory', async () => {
+            // A refusal that says only "something is wrong in dist/locale" sends the reader
+            // hunting; the whole point is that the fix is obvious from the message.
+            const root = project((r) => mo(r, 'hello.mo'));
+            try {
+                expect(() => discover(root, { localeDir: 'dist/locale' })).toThrow('hello.mo');
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/ship/discover.ts
+++ b/packages/infra/cli/src/utils/ship/discover.ts
@@ -95,8 +95,12 @@ function withoutLocaleTree(
     const rel = relative(bundleDir, localeRoot);
     // Outside the bundle dir: `relative` climbs out (`..`) or returns an absolute path.
     if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return bundleFiles;
-    const prefix = `${rel.split(/[\\/]/).join('/')}/`;
-    return bundleFiles.filter((file) => !`${file.split(/[\\/]/).join('/')}/`.startsWith(prefix));
+    // Only `rel` needs normalising: it comes from `relative`, so it is host-shaped, while
+    // `bundleFiles` is POSIX by `listFilesRecursive`'s contract. Comparing a host-shaped prefix
+    // against POSIX entries matches nothing on Windows — and matching nothing here means the
+    // catalogues quietly ship twice again, on that platform only.
+    const prefix = `${rel.split(sep).join(posix.sep)}${posix.sep}`;
+    return bundleFiles.filter((file) => !`${file}${posix.sep}`.startsWith(prefix));
 }
 
 /**
@@ -126,9 +130,8 @@ function discoverLocales(projectDir: string, dir: string | undefined): { rel: st
             continue;
         }
         if (!rel.endsWith('.mo')) continue;
-        // POSIX separators: `listFilesRecursive` yields host-shaped paths, and the check is about
-        // the gettext LAYOUT, which is the same on every host.
-        const parts = rel.split(/[\\/]/);
+        // `listFilesRecursive` normalises to POSIX, so one separator is all there is to split on.
+        const parts = rel.split(posix.sep);
         if (parts.length !== 3 || parts[1] !== 'LC_MESSAGES') {
             strays.push(`${rel} (expected <lang>/LC_MESSAGES/<domain>.mo)`);
             continue;

--- a/packages/infra/cli/src/utils/ship/discover.ts
+++ b/packages/infra/cli/src/utils/ship/discover.ts
@@ -28,13 +28,24 @@ export function discoverPayload(input: DiscoverInput): DiscoveredPayload {
     const bundlePath = resolveBundle(input);
     const bundleDir = resolve(bundlePath, '..');
 
+    const localeFiles = discoverLocales(projectDir, ship.localeDir);
+
     return {
         bundlePath,
         bundleDir,
-        bundleFiles: listFilesRecursive(bundleDir),
+        // Everything beside the bundle, MINUS the locale tree when it lives there.
+        //
+        // `dist/locale/` sits next to `dist/app.gjs.mjs` in the layout
+        // `@gjsify/vite-plugin-gettext` writes by default, and the wholesale bundle staging would
+        // then put every catalogue in `lib/<binary>/locale/` as well as in `share/locale/`.
+        // Measured on a probe package: the same `.mo` appeared at both paths. The `lib/` copy is
+        // dead weight — nothing looks there — and it is the same failure that once shipped the test
+        // suite: whatever is beside the bundle gets carried whether or not it belongs in a package.
+        bundleFiles: withoutLocaleTree(listFilesRecursive(bundleDir), bundleDir, projectDir, ship.localeDir),
         iconFiles: discoverIcons(projectDir, ship.icon ?? input.flatpakIcon),
         schemaFiles: discoverSchemas(projectDir, ship.schemas),
         typelibFiles: discoverTypelibs(projectDir, ship.bundledTypelibs),
+        localeFiles,
         licenseFile: discoverLicense(projectDir, ship.licenseFile),
     };
 }
@@ -63,6 +74,80 @@ function discoverTypelibs(projectDir: string, dirs: string[] | undefined): strin
         for (const file of listFilesRecursive(root)) {
             if (/\.typelib$|\.so(\.\d+)*$/.test(file)) out.push(join(root, file));
         }
+    }
+    return out;
+}
+
+/**
+ * Drop the declared locale tree from the wholesale bundle staging.
+ *
+ * Only when it actually lies inside the bundle directory — a `localeDir` elsewhere in the project
+ * was never part of `bundleFiles` and there is nothing to subtract.
+ */
+function withoutLocaleTree(
+    bundleFiles: string[],
+    bundleDir: string,
+    projectDir: string,
+    localeDir: string | undefined,
+): string[] {
+    if (localeDir === undefined) return bundleFiles;
+    const localeRoot = resolve(projectDir, localeDir);
+    const rel = relative(bundleDir, localeRoot);
+    // Outside the bundle dir: `relative` climbs out (`..`) or returns an absolute path.
+    if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return bundleFiles;
+    const prefix = `${rel.split(/[\\/]/).join('/')}/`;
+    return bundleFiles.filter((file) => !`${file.split(/[\\/]/).join('/')}/`.startsWith(prefix));
+}
+
+/**
+ * Compiled gettext catalogues the project ships (`gjsify.ship.localeDir`).
+ *
+ * Only `.mo` files, and only in the layout `bindtextdomain` actually reads —
+ * `<lang>/LC_MESSAGES/<domain>.mo`. Both refusals cover the same failure, which is the quiet kind:
+ * a catalogue in the wrong place, or left as `.po`, installs perfectly and the app then shows the
+ * untranslated msgid forever. That is indistinguishable from "no translation exists", so it is not
+ * something a user or a maintainer would ever report as a packaging bug.
+ */
+function discoverLocales(projectDir: string, dir: string | undefined): { rel: string; abs: string }[] {
+    if (dir === undefined) return [];
+    const root = resolve(projectDir, dir);
+    if (!existsSync(root)) {
+        throw new Error(
+            `gjsify ship: \`gjsify.ship.localeDir\` names ${dir}, which does not exist. ` +
+                'Compile the catalogues first (msgfmt, or @gjsify/vite-plugin-gettext) — a missing ' +
+                'directory here means the package would install without the translations it promises.',
+        );
+    }
+    const out: { rel: string; abs: string }[] = [];
+    const strays: string[] = [];
+    for (const rel of listFilesRecursive(root)) {
+        if (rel.endsWith('.po') || rel.endsWith('.pot')) {
+            strays.push(`${rel} (a .po source; bindtextdomain reads .mo only)`);
+            continue;
+        }
+        if (!rel.endsWith('.mo')) continue;
+        // POSIX separators: `listFilesRecursive` yields host-shaped paths, and the check is about
+        // the gettext LAYOUT, which is the same on every host.
+        const parts = rel.split(/[\\/]/);
+        if (parts.length !== 3 || parts[1] !== 'LC_MESSAGES') {
+            strays.push(`${rel} (expected <lang>/LC_MESSAGES/<domain>.mo)`);
+            continue;
+        }
+        out.push({ rel: parts.join('/'), abs: join(root, rel) });
+    }
+    if (strays.length > 0) {
+        throw new Error(
+            `gjsify ship: \`gjsify.ship.localeDir\` (${dir}) holds files no catalogue lookup will find:\n` +
+                strays.map((s) => `  ${s}`).join('\n') +
+                '\nA misplaced catalogue installs and then shows nothing, which reads exactly like having ' +
+                'no translation at all. Lay them out as <lang>/LC_MESSAGES/<domain>.mo.',
+        );
+    }
+    if (out.length === 0) {
+        throw new Error(
+            `gjsify ship: \`gjsify.ship.localeDir\` (${dir}) contains no \`.mo\` catalogue. ` +
+                'Declaring a locale directory that ships nothing is a promise the package does not keep.',
+        );
     }
     return out;
 }

--- a/packages/infra/cli/src/utils/ship/launcher.ts
+++ b/packages/infra/cli/src/utils/ship/launcher.ts
@@ -52,6 +52,16 @@ export function renderLauncher(settings: ShipSettings, bundleRelPath: string): s
         }
     }
 
+    // Where the app's gettext catalogues landed. `bindtextdomain` takes a DIRECTORY and there is no
+    // standard environment variable it reads on its own (`TEXTDOMAINDIR` is honoured by the gettext
+    // command-line tools, not by the library), so the prefix has to reach the app somehow. Passing
+    // it from the launcher keeps the app free of install-layout knowledge, exactly as XDG_DATA_DIRS
+    // above does for icons and schemas — a baked `/usr/share/locale` would be wrong in a Flatpak
+    // and in any `--prefix` tree.
+    if (settings.localeFiles.length > 0) {
+        lines.push('GJSIFY_LOCALE_DIR="$prefix"/share/locale', 'export GJSIFY_LOCALE_DIR');
+    }
+
     lines.push(`exec gjs -m ${lib}/${bundleRelPath}${args ? ` ${args}` : ''} "$@"`, '');
     return lines.join('\n');
 }

--- a/packages/infra/cli/src/utils/ship/packers.spec.ts
+++ b/packages/infra/cli/src/utils/ship/packers.spec.ts
@@ -44,6 +44,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         iconFiles: [],
         schemaFiles: [],
         typelibFiles: [],
+        localeFiles: [],
         extraFiles: {},
         execArgs: [],
         outDir: 'ship',

--- a/packages/infra/cli/src/utils/ship/plan.spec.ts
+++ b/packages/infra/cli/src/utils/ship/plan.spec.ts
@@ -37,6 +37,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         iconFiles: [],
         schemaFiles: [],
         typelibFiles: [],
+        localeFiles: [],
         extraFiles: {},
         execArgs: [],
         outDir: 'ship',
@@ -125,6 +126,25 @@ export default async () => {
             const staged = files.map((file) => file.path);
             expect(staged.includes('lib/hello/gi/Gwebgl-0.1.typelib')).toBe(true);
             expect(staged.includes('lib/hello/gi/libgwebgl.so')).toBe(true);
+        });
+
+        await it('stages catalogues into share/locale, layout preserved', async () => {
+            // The LAYOUT is the point: `bindtextdomain` looks in
+            // `<dir>/<lang>/LC_MESSAGES/<domain>.mo` and nowhere else, so a catalogue staged by
+            // basename alone would install and never be found.
+            const files = planStage(
+                settings({
+                    localeFiles: [
+                        { rel: 'de/LC_MESSAGES/hello.mo', abs: '/p/dist/locale/de/LC_MESSAGES/hello.mo' },
+                        { rel: 'fr/LC_MESSAGES/hello.mo', abs: '/p/dist/locale/fr/LC_MESSAGES/hello.mo' },
+                    ],
+                }),
+                inputs(),
+            );
+            const staged = files.map((file) => file.path);
+            expect(staged.includes('share/locale/de/LC_MESSAGES/hello.mo')).toBe(true);
+            expect(staged.includes('share/locale/fr/LC_MESSAGES/hello.mo')).toBe(true);
+            expect(files.find((f) => f.path === 'share/locale/de/LC_MESSAGES/hello.mo')?.mode).toBe(0o644);
         });
 
         await it('refuses an extra file that escapes the prefix', async () => {

--- a/packages/infra/cli/src/utils/ship/plan.ts
+++ b/packages/infra/cli/src/utils/ship/plan.ts
@@ -91,6 +91,16 @@ export function planStage(settings: ShipSettings, inputs: StageInputs): StagedFi
         });
     }
 
+    // Compiled gettext catalogues, layout preserved: `share/locale/<lang>/LC_MESSAGES/<domain>.mo`
+    // is where `bindtextdomain` looks, and nowhere else.
+    for (const locale of settings.localeFiles) {
+        files.push({
+            path: posix.join('share/locale', locale.rel),
+            mode: 0o644,
+            source: { kind: 'file', path: locale.abs },
+        });
+    }
+
     for (const [dest, source] of Object.entries(settings.extraFiles)) {
         files.push({ path: assertInsidePrefix(dest), mode: 0o644, source: { kind: 'file', path: source } });
     }

--- a/packages/infra/cli/src/utils/ship/settings.spec.ts
+++ b/packages/infra/cli/src/utils/ship/settings.spec.ts
@@ -26,6 +26,7 @@ function input(overrides: Partial<SettingsInput> = {}): SettingsInput {
             iconFiles: ['/project/data/icon.svg'],
             schemaFiles: [],
             typelibFiles: [],
+            localeFiles: [],
         },
         ...overrides,
     };

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -41,6 +41,8 @@ export interface DiscoveredPayload {
     schemaFiles: string[];
     /** Absolute paths of the typelibs + shared libraries the project ships itself. */
     typelibFiles: string[];
+    /** Compiled gettext catalogues, each with its `<lang>/LC_MESSAGES/<domain>.mo` path. */
+    localeFiles: { rel: string; abs: string }[];
     licenseFile?: string;
 }
 
@@ -146,6 +148,7 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
         iconFiles: discovered.iconFiles,
         schemaFiles: discovered.schemaFiles,
         typelibFiles: discovered.typelibFiles,
+        localeFiles: discovered.localeFiles,
         extraFiles: ship.extraFiles ?? {},
         execArgs: ship.execArgs ?? [],
         outDir: input.cli.outDir ?? ship.outDir ?? 'ship',

--- a/packages/infra/cli/src/utils/ship/types.ts
+++ b/packages/infra/cli/src/utils/ship/types.ts
@@ -110,6 +110,15 @@ export interface ShipSettings {
      * has nothing to depend on and must ship the files — with the launcher pointing GI at them.
      */
     typelibFiles: string[];
+    /**
+     * Compiled gettext catalogues (`gjsify.ship.localeDir`), each keeping its
+     * `<lang>/LC_MESSAGES/<domain>.mo` path so `share/locale/` comes out in the layout
+     * `bindtextdomain` reads.
+     *
+     * `rel` rather than a bare list of absolute paths, because the LAYOUT is the whole point here:
+     * a `.mo` staged by basename alone lands where no catalogue lookup will ever look at it.
+     */
+    localeFiles: { rel: string; abs: string }[];
     /** `<dest relative to prefix>` → absolute source path. */
     extraFiles: Record<string, string>;
     /** Arguments appended to the launcher's `exec` line. */


### PR DESCRIPTION
Translations were not part of the payload. An app with a working gettext setup packaged fine and **showed English on a German desktop**, because the `.mo` files were simply not in the artifact — and nothing else carried them. ADR 0024 § 2 listed the payload as "the app bundle, its assets, its GSettings schemas, its icons and its metadata"; catalogues were never in that list.

## What this adds

`gjsify.ship.localeDir` names a directory of **compiled** catalogues and stages them into `share/locale/`, keeping the `<lang>/LC_MESSAGES/<domain>.mo` layout — which is the default output of `@gjsify/vite-plugin-gettext`'s `gettextPlugin`, so the two ends already agree.

The launcher then exports `GJSIFY_LOCALE_DIR="$prefix"/share/locale`, and the app calls
`bindtextdomain(domain, GLib.getenv('GJSIFY_LOCALE_DIR') ?? '/usr/share/locale')`.

That indirection is not decoration. `bindtextdomain` takes a *directory*, and there is no environment variable the **library** reads on its own — `TEXTDOMAINDIR` is honoured by the gettext command-line tools, not by glibc. A baked `/usr/share/locale` would be wrong in a Flatpak and in every `--prefix` tree. Same division of labour § 3 already uses for `XDG_DATA_DIRS`: the launcher knows the install layout, the app does not.

## Three refusals, one failure

| refused | why it would otherwise pass |
|---|---|
| a `.po` beside or instead of a `.mo` | `bindtextdomain` reads `.mo` only; a staged `.po` is a file nothing opens |
| a `.mo` outside `<lang>/LC_MESSAGES/` | the commonest slip is `msgfmt` run without the `LC_MESSAGES` level |
| a declared directory with no `.mo` at all | a promise the package does not keep, and it packs green |

All three produce the same artifact: a package that installs its translations and shows none of them. That is the quietest way for a release to be wrong, because an untranslated UI is **indistinguishable from "this app has no German"** — nobody files it as a packaging bug. Hence refusals rather than warnings, each naming the offending file.

## A defect found by reading the artifact, not the config

`dist/locale/` sits beside `dist/app.gjs.mjs`, and `bundleFiles` is "everything next to the bundle". Measured on a probe package:

```
/usr/lib/localeprobe/locale/de/LC_MESSAGES/localeprobe.mo   ← dead weight
/usr/share/locale/de/LC_MESSAGES/localeprobe.mo             ← the one that is read
```

Same class as `ship` once staging the test suite: whatever lies beside the bundle is carried whether or not it belongs. The declared locale tree now drops out of that staging — targeted, so a package that legitimately ships assets beside its bundle keeps them (there is a test for exactly that).

After the fix: 5 staged files → 4, and the payload carries the catalogue once.

## Verified

- The full gettext loop proven under GJS **before** any of this was written: English msgid → German with a real `.mo`, and a missing entry falling through to English rather than blank.
- A probe package shipped and its `.rpm` payload + generated launcher read by hand.
- **Nine tests** over a real temporary directory tree rather than a mocked fs — the thing under test is what a filesystem layout *means* to `bindtextdomain`, and a mock would only re-assert the assumption being checked.
- 2470 CLI tests green · `tsc` clean · lint unchanged (59 findings before and after, all pre-existing) · `affected.gjs.mjs` rebuilt and byte-identical across two consecutive rebuilds, so CI's compare will match.

ADR 0024 § A8–A10 record the decision; release notes for 0.42.0 updated.