### PR TITLE
fix(ship): refuse a payload that is not its label

### DIFF
--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -29,7 +29,7 @@ import { deriveDepends, warnAboutGjsFloor } from '../utils/ship/depends.js';
 import { discoverPayload } from '../utils/ship/discover.js';
 import { resolveFormats, FORMAT_IDS } from '../utils/ship/formats.js';
 import { scanGiNamespaces } from '../utils/ship/gi-namespaces.js';
-import { buildTimestamp, isArchIndependent } from '../utils/ship/payload.js';
+import { assertPayloadMatchesArch, buildTimestamp, isArchIndependent } from '../utils/ship/payload.js';
 import { planOverlay, planStage, type StageInputs } from '../utils/ship/plan.js';
 import { renderLauncher } from '../utils/ship/launcher.js';
 import { buildRpm } from '../utils/ship/rpm.js';
@@ -200,6 +200,10 @@ async function packOne(input: PackInput): Promise<ShipArtifact> {
     });
     for (const warning of warnAboutGjsFloor(format.id, settings.minGjsVersion)) console.warn(`${LOG} ${warning}`);
 
+    // Before the label is chosen, not after: `archName` collapses an
+    // arch-independent payload to `all`/`noarch`, and a mismatch only matters
+    // for a payload that IS architecture-specific.
+    assertPayloadMatchesArch(payload, settings.arch);
     const archLabel = format.archName(settings.arch, isArchIndependent(payload));
     const common = { settings, payload, prefix: format.prefix, depends, archLabel, mtime };
     const bytes = format.id === 'deb' ? await buildDeb(common) : await buildRpm(common);

--- a/packages/infra/cli/src/utils/ship/packers.spec.ts
+++ b/packages/infra/cli/src/utils/ship/packers.spec.ts
@@ -15,7 +15,7 @@ import { describe, expect, it } from '@gjsify/unit';
 import { buildDeb } from './deb.js';
 import { FORMATS } from './formats.js';
 import { buildRpm } from './rpm.js';
-import { isArchIndependent, type PayloadEntry } from './payload.js';
+import { assertPayloadMatchesArch, isArchIndependent, readBinaryArch, type PayloadEntry } from './payload.js';
 import type { ShipSettings } from './types.js';
 
 const encoder = new TextEncoder();
@@ -194,6 +194,68 @@ export default async () => {
                 expect(nativeName).toContain(format.id === 'deb' ? 'amd64' : 'x86_64');
                 expect(pureName).toContain(format.id === 'deb' ? 'all' : 'noarch');
             }
+        });
+    });
+
+    // `--arch` LABELS the payload and cross-compiles nothing, and until this
+    // guard the two were never compared. Reproduced on 0.41.0: a payload with one
+    // x86-64 `.so`, packed `--arch arm64` on an x86-64 host, produced
+    // `…_arm64.deb` and `….aarch64.rpm`; `rpm -qp --qf '%{ARCH}'` answered
+    // `aarch64` while the `.so` inside it was ELF `e_machine` 0x3e. The
+    // independent oracle confirms the lie, because the header it reads was
+    // written from the caller's claim.
+    await describe('the payload must match the label it is given', async () => {
+        /** A minimal ELF header — 20 bytes is all `readBinaryArch` needs. */
+        const elfFor = (machine: number): Uint8Array => {
+            const data = new Uint8Array(20);
+            data.set([0x7f, 0x45, 0x4c, 0x46, 2, 1, 1, 0], 0); // \x7fELF, 64-bit, little-endian
+            data[18] = machine & 0xff;
+            data[19] = machine >>> 8;
+            return data;
+        };
+
+        await it('reads the architecture an ELF records about itself', () => {
+            expect(readBinaryArch(elfFor(0x3e))).toBe('x64');
+            expect(readBinaryArch(elfFor(0xb7))).toBe('arm64');
+            expect(readBinaryArch(elfFor(0xf3))).toBe('riscv64');
+        });
+
+        await it('says nothing about a file whose architecture it cannot read', () => {
+            // Three reasons, all of which must stay silent rather than become a
+            // mismatch: not a binary at all, a machine constant nothing here
+            // emits, and a PE — whose COFF field this tree has never parsed.
+            expect(readBinaryArch(new TextEncoder().encode('#!/bin/sh\nexec gjs -m x\n'))).toBe(null);
+            expect(readBinaryArch(elfFor(0x9999))).toBe(null);
+            expect(readBinaryArch(Uint8Array.from([0x4d, 0x5a, ...Array.from({ length: 18 }, () => 0)]))).toBe(null);
+        });
+
+        await it('REFUSES an x86-64 payload labelled arm64 — the reproduced defect', () => {
+            const mixed = payload([
+                ['bin/demo', 0o755, '#!/bin/sh\n'],
+                ['lib/demo/libdemo.so', 0o755, elfFor(0x3e)],
+            ]);
+            let message = '';
+            try {
+                assertPayloadMatchesArch(mixed, 'arm64');
+            } catch (error) {
+                message = (error as Error).message;
+            }
+            expect(message).toContain('lib/demo/libdemo.so');
+            expect(message).toContain('does not cross-compile');
+        });
+
+        await it('accepts the cross-host case the two-phase split exists to allow', () => {
+            // An arm64 payload assembled on an x64 machine is legitimate: the
+            // packers are pure JavaScript (ADR 0024 § A1). A host comparison
+            // would refuse exactly this, which is why the check is
+            // payload-against-LABEL and never payload-against-host.
+            const arm = payload([['lib/demo/libdemo.so', 0o755, elfFor(0xb7)]]);
+            expect(() => assertPayloadMatchesArch(arm, 'arm64')).not.toThrow();
+        });
+
+        await it('accepts a payload with nothing architecture-specific in it', () => {
+            const pure = payload([['lib/demo/main.js', 0o644, 'print(1)']]);
+            expect(() => assertPayloadMatchesArch(pure, 'arm64')).not.toThrow();
         });
     });
 };

--- a/packages/infra/cli/src/utils/ship/payload.ts
+++ b/packages/infra/cli/src/utils/ship/payload.ts
@@ -53,6 +53,94 @@ export function isArchIndependent(payload: readonly PayloadEntry[]): boolean {
     return !payload.some((entry) => isNativeBinary(entry.data));
 }
 
+// `process.arch` tokens, keyed by what the image records about itself. Only the
+// values this repository can actually produce are listed; an unknown one reads
+// as "cannot tell" rather than as a mismatch, because refusing an artifact over
+// a machine constant nobody here emits would be a guess wearing a gate's clothes.
+const ELF_MACHINE_TO_ARCH: Record<number, string> = {
+    0x03: 'ia32',
+    0x15: 'ppc64',
+    0x16: 's390x',
+    0x28: 'arm',
+    0x3e: 'x64',
+    0xb7: 'arm64',
+    0xf3: 'riscv64',
+};
+
+const MACHO_CPUTYPE_TO_ARCH: Record<number, string> = {
+    0x00000007: 'ia32',
+    0x0000000c: 'arm',
+    0x01000007: 'x64',
+    0x0100000c: 'arm64',
+};
+
+/**
+ * The `process.arch` token an image says it is built for, or `null` when the
+ * question cannot be answered from the bytes.
+ *
+ * `null` covers three different things on purpose, and all three must stay
+ * silent: a file that is not a native binary at all (most of a payload), a PE
+ * (whose COFF machine field this tree has never parsed — `isNativeBinary` reads
+ * `MZ` and stops), and a Mach-O fat archive, which carries several
+ * architectures and therefore matches any label a caller could pass.
+ */
+export function readBinaryArch(data: Uint8Array): string | null {
+    if (data.byteLength < 20) return null;
+    const magic = ((data[0]! << 24) | (data[1]! << 16) | (data[2]! << 8) | data[3]!) >>> 0;
+    if (magic === 0x7f454c46) {
+        // ELF: EI_DATA at offset 5 says which end e_machine (offset 18) is written from.
+        const littleEndian = data[5] === 1;
+        const machine = littleEndian ? data[18]! | (data[19]! << 8) : (data[18]! << 8) | data[19]!;
+        return ELF_MACHINE_TO_ARCH[machine] ?? null;
+    }
+    if (magic === 0xfeedface || magic === 0xfeedfacf) {
+        return MACHO_CPUTYPE_TO_ARCH[((data[4]! << 24) | (data[5]! << 16) | (data[6]! << 8) | data[7]!) >>> 0] ?? null;
+    }
+    if (magic === 0xcefaedfe || magic === 0xcffaedfe) {
+        return MACHO_CPUTYPE_TO_ARCH[((data[7]! << 24) | (data[6]! << 16) | (data[5]! << 8) | data[4]!) >>> 0] ?? null;
+    }
+    return null;
+}
+
+/**
+ * Refuse a payload whose binaries disagree with the label the package will carry.
+ *
+ * THE INCIDENT, measured on 0.41.0 before this existed. A project whose payload
+ * carries one x86-64 `.so`, packed on this x86-64 host:
+ *
+ *     gjsify ship --skip-build --arch arm64
+ *     → xarch-demo_1.2.3-1_arm64.deb, xarch-demo-1.2.3-1.aarch64.rpm
+ *     rpm -qp --qf '%{ARCH}'  → aarch64
+ *     the .so inside it       → ELF e_machine 0x3e (x86-64)
+ *
+ * `--arch` LABELS the payload; it does not cross-compile it, and nothing
+ * compared the two. The result installs on an arm64 machine — apt and dnf both
+ * believe the header — and then fails to load, which is this tree's most
+ * expensive failure class with an independent oracle actively confirming the
+ * lie: `rpm` reads the header, and the header was written from the caller's
+ * claim.
+ *
+ * Payload against LABEL, never payload against HOST. Assembling an arm64
+ * artifact on an x64 machine is a supported path — the packers are pure
+ * JavaScript and ADR 0024 § A1 turns it into a design commitment — so a host
+ * comparison would refuse the very case the split exists to allow.
+ */
+export function assertPayloadMatchesArch(payload: readonly PayloadEntry[], arch: string): void {
+    for (const entry of payload) {
+        const found = readBinaryArch(entry.data);
+        if (found === null || found === arch) continue;
+        throw new Error(
+            `gjsify ship: the payload is ${found}, but the package would be labelled ${arch} — ` +
+                `${entry.path} is built for ${found}.\n` +
+                '    `--arch` names the architecture the PAYLOAD was built for; it does not cross-compile ' +
+                'anything.\n' +
+                `    A package labelled ${arch} installs on ${arch} and then fails to load. Build the payload ` +
+                `for ${arch}\n` +
+                '    (its own prebuild), or drop `--arch` and label the payload you actually have.',
+        );
+    }
+}
+
 /** ELF, Mach-O (both endiannesses, both widths, and a fat archive) or PE. */
 function isNativeBinary(data: Uint8Array): boolean {
     if (data.byteLength < 4) return false;


### PR DESCRIPTION
## What ships today

`--arch` **labels** the payload. It cross-compiles nothing, and until now the two were never compared. Reproduced on 0.41.0, on an x86-64 host, with a payload carrying one x86-64 `.so`:

```
$ gjsify ship --skip-build --arch arm64
[gjsify ship] deb: ship/out/xarch-demo_1.2.3-1_arm64.deb
[gjsify ship] rpm: ship/out/xarch-demo-1.2.3-1.aarch64.rpm

$ rpm -qp --qf '%{NAME} %{ARCH}\n' ship/out/*.rpm
xarch-demo aarch64

$ rpm2cpio … | cpio -i --to-stdout ./usr/lib/xarch-demo/libdemo.so | readelf -h
  Machine: Advanced Micro Devices X86-64
```

apt and dnf both believe the header, so the package installs on arm64 and then fails to load. **The independent oracle actively confirms the lie** — `rpm` reads the header, and the header was written from the caller's claim. That is the class `verify-bundle-manifest.mjs` names in its own comment: *"the emulated prebuild legs stage x86-64 into `prebuilds/linux-ppc64/` with every downstream check green."*

## The check

`readBinaryArch` reads two more bytes out of a file `isArchIndependent` already opens: ELF `e_machine` (offset 18, endianness from `EI_DATA`) and Mach-O `cputype`. `assertPayloadMatchesArch` runs in `packOne` **before** `archName` collapses an arch-independent payload to `all`/`noarch` — after it, the mismatch that matters is already hidden.

**Payload against LABEL, never payload against HOST.** Assembling an arm64 artifact on an x64 machine is a supported path — the packers are pure JavaScript, and ADR 0024 § A1 makes that a design commitment — so a host comparison would refuse the one case the two-phase split exists to allow.

`null` stays silent for three different reasons, all deliberate: a file that is not a native binary (most of a payload), a machine constant nothing in this repository emits, and a Mach-O fat archive, which carries several architectures and therefore matches any label a caller could pass.

## Proven in both directions, with the built CLI

Not only in the unit suite — the first run of this check passed 2480 unit tests while doing nothing at all, because `gjsify run test` builds the test bundle and not `lib/`, so the CLI I was probing did not contain it yet.

```
false label   → aborts, writes no artifact:
                "the payload is x64, but the package would be labelled arm64
                 — lib/xarch-demo/libdemo.so is built for x64"
honest label  → xarch-demo_1.2.3-1_amd64.deb, …x86_64.rpm
```

Five unit cases cover the reader (three architectures), the three silent cases, the refusal, the legitimate cross-host pack, and a payload with nothing architecture-specific in it.

## Scope

Independent of #1257 — different files, no shared lines. Found while reviewing the design for the stage/pack split, where an early draft claimed `--arch` was a legitimate cross-arch path; it is not, and this is why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECGLXroeGMkcKqRhcczXhX