### PR TITLE
feat(adwaita-app): bind an app's translations

### DIFF
--- a/packages/framework/adwaita-app/src/index.ts
+++ b/packages/framework/adwaita-app/src/index.ts
@@ -22,6 +22,12 @@ export { registerToastOverlay, showToast } from './toast.js';
 export { pickFile, saveFile } from './file-dialog.js';
 export type { FileFilterSpec, PickFileOptions } from './file-dialog.js';
 
+export { initLocale } from './locale.js';
+export type { InitLocaleOptions, Translator } from './locale.js';
+
+export { SYSTEM_LOCALE_DIR, resolveLocaleDir } from './locale-dir.js';
+export type { ResolveLocaleDirOptions } from './locale-dir.js';
+
 export { readAppDevHooks } from './dev-hooks.js';
 export type { AppDevHooks, ReadAppDevHooksOptions } from './dev-hooks.js';
 

--- a/packages/framework/adwaita-app/src/locale-dir.spec.ts
+++ b/packages/framework/adwaita-app/src/locale-dir.spec.ts
@@ -1,0 +1,42 @@
+// @gjsify/adwaita-app — resolveLocaleDir tests.
+// Runs on GJS + Node (pure logic, explicit env — no platform imports).
+
+import { describe, expect, it } from '@gjsify/unit';
+import { SYSTEM_LOCALE_DIR, resolveLocaleDir } from './locale-dir.js';
+
+export default async () => {
+    await describe('resolveLocaleDir', async () => {
+        await it('prefers an explicit directory over the environment', () => {
+            const dir = resolveLocaleDir({
+                localeDir: '/build/dist/locale',
+                env: { GJSIFY_LOCALE_DIR: '/usr/share/locale' },
+                fallbackDir: '/ignored',
+            });
+            expect(dir).toBe('/build/dist/locale');
+        });
+
+        await it('reads GJSIFY_LOCALE_DIR when no directory is passed', () => {
+            expect(resolveLocaleDir({ env: { GJSIFY_LOCALE_DIR: '/app/share/locale' } })).toBe('/app/share/locale');
+        });
+
+        await it('falls back to the caller directory, then to the system one', () => {
+            expect(resolveLocaleDir({ fallbackDir: '/opt/x/share/locale' })).toBe('/opt/x/share/locale');
+            expect(resolveLocaleDir()).toBe(SYSTEM_LOCALE_DIR);
+            expect(resolveLocaleDir({ env: {} })).toBe(SYSTEM_LOCALE_DIR);
+        });
+
+        // The launcher exports the variable only when it staged catalogues, but a wrapper script
+        // that sets it unconditionally passes ''. `bindtextdomain(domain, '')` binds to the CURRENT
+        // DIRECTORY, and a lookup there fails exactly like an app with no translation at all.
+        await it('treats an empty or blank value as unset', () => {
+            expect(resolveLocaleDir({ env: { GJSIFY_LOCALE_DIR: '' } })).toBe(SYSTEM_LOCALE_DIR);
+            expect(resolveLocaleDir({ env: { GJSIFY_LOCALE_DIR: '   ' } })).toBe(SYSTEM_LOCALE_DIR);
+            expect(resolveLocaleDir({ localeDir: '', env: { GJSIFY_LOCALE_DIR: '/from/env' } })).toBe('/from/env');
+            expect(resolveLocaleDir({ localeDir: '', fallbackDir: '' })).toBe(SYSTEM_LOCALE_DIR);
+        });
+
+        await it('trims surrounding whitespace off a real value', () => {
+            expect(resolveLocaleDir({ env: { GJSIFY_LOCALE_DIR: '  /app/share/locale\n' } })).toBe('/app/share/locale');
+        });
+    });
+};

--- a/packages/framework/adwaita-app/src/locale-dir.ts
+++ b/packages/framework/adwaita-app/src/locale-dir.ts
@@ -1,0 +1,43 @@
+// WHERE the compiled gettext catalogues live — decided without touching the platform.
+//
+// Free of imports for the same reason `dev-hooks.ts` is: the environment arrives as a plain
+// record, so the decision is exercised on Node as well as GJS. `locale.ts` supplies the real
+// environment and performs the binding.
+
+/** `bindtextdomain`'s directory for a system install, when nothing else names one. */
+export const SYSTEM_LOCALE_DIR = '/usr/share/locale';
+
+export interface ResolveLocaleDirOptions {
+    /** Wins over everything — a dev tree (`dist/locale`), or a test fixture. */
+    localeDir?: string;
+    /** Environment to read `GJSIFY_LOCALE_DIR` from. */
+    env?: Record<string, string | undefined>;
+    /** Used when neither the option nor the environment names a directory. */
+    fallbackDir?: string;
+}
+
+/**
+ * Resolve the directory to bind a text domain to.
+ *
+ * Precedence: explicit option, then `GJSIFY_LOCALE_DIR` (exported by the `gjsify ship` launcher,
+ * which is the only party that knows whether the payload became `/usr`, a `--prefix` tree or
+ * `/app`), then the caller's fallback, then the system directory.
+ */
+export function resolveLocaleDir(options: ResolveLocaleDirOptions = {}): string {
+    // An EMPTY value counts as unset. The launcher exports `GJSIFY_LOCALE_DIR` only when it
+    // actually staged catalogues, but a wrapper script that sets it unconditionally hands over
+    // `''` — and `bindtextdomain(domain, '')` binds to the CURRENT DIRECTORY, where the lookup
+    // finds nothing and reports it exactly as "this app has no translation".
+    return (
+        nonEmpty(options.localeDir) ??
+        nonEmpty(options.env?.GJSIFY_LOCALE_DIR) ??
+        nonEmpty(options.fallbackDir) ??
+        SYSTEM_LOCALE_DIR
+    );
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+    if (value === undefined) return undefined;
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+}

--- a/packages/framework/adwaita-app/src/locale.ts
+++ b/packages/framework/adwaita-app/src/locale.ts
@@ -1,0 +1,66 @@
+// BINDING an app's translations — the reading half of ADR 0024 § A8–A10.
+//
+// `gjsify ship` stages compiled catalogues into `share/locale/` and its launcher exports
+// `GJSIFY_LOCALE_DIR`, because only the launcher knows whether the payload became `/usr` in a
+// `.deb`, a `--prefix` tree, or `/app` in a Flatpak. This is the side that reads it, and it lives
+// here rather than in each app because the interesting part is not the four calls — it is their
+// ORDER and the default domain.
+//
+// WHY `textdomain()` IS SET, not only `dgettext()` used: GtkBuilder resolves every
+// `translatable="yes"` string — so everything coming out of a `.blp` file — in the DEFAULT domain,
+// inside GTK, where the app never gets the chance to pass one. Binding only via `dgettext` would
+// translate the TypeScript strings and leave the Blueprint ones in the source language, which
+// reads as a half-finished translation rather than as a missing call.
+
+// MEASURED against a real compiled catalogue (gettext 0.26, GJS 1.88.1), because "the calls did
+// not throw" is not evidence that a lookup resolves — an untranslated UI is indistinguishable from
+// an app that has no translation:
+//   de_DE.utf8 + a bound dir -> "Aufbau", and n=1/n=3 pick "%d Schicht"/"%d Schichten"
+//   en_US.utf8 + a bound dir -> the msgids, i.e. English needs no catalogue of its own
+//   no GJSIFY_LOCALE_DIR     -> /usr/share/locale, msgids returned (never the current directory)
+// A msgid absent from the catalogue came back unchanged in all three.
+
+import GLib from '@girs/glib-2.0';
+import Gettext from 'gettext';
+
+import { resolveLocaleDir, type ResolveLocaleDirOptions } from './locale-dir.js';
+
+export type InitLocaleOptions = Omit<ResolveLocaleDirOptions, 'env'>;
+
+/** A domain-bound lookup. Callable for the common case; `plural`/`context` for the rest. */
+export interface Translator {
+    (msgid: string): string;
+    /** `n`-aware lookup. Pass the untranslated singular and plural. */
+    plural(singular: string, plural: string, n: number): string;
+    /** Disambiguating lookup, for a msgid whose meaning depends on where it appears. */
+    context(context: string, msgid: string): string;
+    /** The bound directory and domain — for a diagnostic line, never for a lookup. */
+    readonly localeDir: string;
+    readonly domain: string;
+}
+
+/**
+ * Bind `domain` and return its lookup function.
+ *
+ * Safe to call when no catalogue exists: gettext then returns each msgid unchanged, which is why
+ * the msgids themselves must be the source language rather than keys.
+ */
+export function initLocale(domain: string, options: InitLocaleOptions = {}): Translator {
+    const localeDir = resolveLocaleDir({
+        ...options,
+        env: { GJSIFY_LOCALE_DIR: GLib.getenv('GJSIFY_LOCALE_DIR') ?? undefined },
+    });
+
+    // Adopt the environment's locale. `gtk_init()` does this too, but a CLI sharing the app's
+    // kernel translates before any GTK call exists and would otherwise stay in the C locale.
+    Gettext.setlocale(Gettext.LocaleCategory.ALL, '');
+    Gettext.bindtextdomain(domain, localeDir);
+    Gettext.textdomain(domain);
+
+    return Object.assign((msgid: string): string => Gettext.dgettext(domain, msgid), {
+        plural: (singular: string, plural: string, n: number): string => Gettext.dngettext(domain, singular, plural, n),
+        context: (context: string, msgid: string): string => Gettext.dpgettext(domain, context, msgid),
+        localeDir,
+        domain,
+    });
+}

--- a/packages/framework/adwaita-app/src/test.mts
+++ b/packages/framework/adwaita-app/src/test.mts
@@ -6,12 +6,14 @@ import { run } from '@gjsify/unit';
 
 import devHooksSuite from './dev-hooks.spec.js';
 import dialogModelSuite from './dialog-model.spec.js';
+import localeDirSuite from './locale-dir.spec.js';
 import navModelSuite from './nav-model.spec.js';
 import viewLoaderSuite from './view-loader.spec.js';
 
 run({
     devHooksSuite,
     dialogModelSuite,
+    localeDirSuite,
     navModelSuite,
     viewLoaderSuite,
 });


### PR DESCRIPTION
## What

`gjsify ship` learned to package compiled gettext catalogues in 0.42.0, and its launcher exports `GJSIFY_LOCALE_DIR` (ADR 0024 § A8–A10). Nothing read that variable. This adds the reading half:

```ts
import { initLocale } from '@gjsify/adwaita-app';

const _ = initLocale('bauplaner');
label.set_label(_('Assembly'));
status.set_label(_.plural('%d layer', '%d layers', n));
```

`initLocale` resolves the directory — explicit option → `GJSIFY_LOCALE_DIR` → caller fallback → `/usr/share/locale` — binds the domain, and returns a callable `Translator` with `plural` and `context`.

## Why it is shared code and not a snippet in each app

Two details are easy to get wrong and silent when you do:

- **`textdomain()` is set, not only `dgettext()` used.** GtkBuilder resolves every `translatable="yes"` string — so everything from a `.blp` file — in the **default** domain, inside GTK, where the app never gets to pass one. Binding only through `dgettext` translates the TypeScript strings and leaves the Blueprint ones in the source language. That reads as a half-finished translation, not as a missing call.
- **An empty `GJSIFY_LOCALE_DIR` counts as unset.** The launcher exports it only when it staged catalogues, but a wrapper that sets it unconditionally passes `''` — and `bindtextdomain(domain, '')` binds to the *current directory*, where the lookup fails exactly like an app that ships no translation.

## Structure

The path decision (`locale-dir.ts`) is pure and import-free, the way `dev-hooks.ts` is, so it is exercised on Node as well as GJS. The binding (`locale.ts`) is GJS-only, since it talks to glibc gettext.

## Verification

The automated suite covers the resolver (5 cases, in the existing dual-runtime entry; probed with a deliberate defect to confirm it can fail — `1 of 42 tests failed`, naming the test).

"The calls did not throw" is not evidence that a lookup resolves, so the binding was measured against a **real compiled catalogue** (gettext 0.26, GJS 1.88.1):

| environment | `_('Assembly')` | `plural(…, 1)` | `plural(…, 3)` | msgid absent from catalogue |
|---|---|---|---|---|
| `de_DE.utf8` + bound dir | **Aufbau** | **%d Schicht** | **%d Schichten** | unchanged |
| `en_US.utf8` + bound dir | Assembly | %d layer | %d layers | unchanged |
| no `GJSIFY_LOCALE_DIR` | Assembly | %d layer | %d layers | unchanged |

So German comes from the `.mo`, plural selection works, English needs no catalogue of its own (the msgid *is* the English), and an unset variable falls back to `/usr/share/locale` instead of the working directory.

`affected.gjs.mjs` is unaffected: the classifier does not reference `adwaita-app` and embeds no per-file list from it (checked, not assumed).