### PR TITLE
feat(cli): ship can define file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,9 @@ ship/
 # silent case above: both pages were written, `git status` showed nothing, and a
 # commit would have carried none of it.
 !website/src/content/docs/ship/
+# …and the e2e SUITE for that command. `run.mjs` predates the pattern and stayed
+# tracked, so `git add` on it still works and the collision looked harmless — but
+# it is the silent case again for anything NEW added beside it, which is a test
+# helper that gets lost rather than reviewed. Third instance of the same match, so
+# it is listed here rather than discovered a fourth time.
+!tests/e2e/ship/

--- a/docs/adr/0024-ship-installable-artifacts.md
+++ b/docs/adr/0024-ship-installable-artifacts.md
@@ -544,3 +544,36 @@ dead weight — nothing looks there.
 This is the same class as `ship` once staging the test suite: whatever lies next to the bundle is
 carried, whether or not it belongs in a package. The subtraction is targeted at the DECLARED locale
 directory only, so a package that legitimately ships assets beside its bundle keeps them.
+
+### A11. Handling a file type is not defining one
+
+`MimeType=` in a desktop entry says "I open this type". It does not say the type EXISTS.
+
+For a type the distribution already defines (`text/plain`, `application/pdf`) that distinction never
+comes up. For a type of the project's own it decides whether the feature works at all, and the
+failure mode is the quietest in this ADR:
+
+| what is declared | what happens |
+|---|---|
+| `provides.mimetypes` alone, for a custom type | nothing on the system knows the type exists, so the file manager never assigns it, `MimeType=` matches nothing, and a double-click does nothing — no error, no log line |
+| a shared-mime-info document with no cache refresh | detection reads the compiled cache under `share/mime`, not `share/mime/packages`, so the type stays unknown until something else happens to rebuild it |
+
+Both are indistinguishable from "the application is not installed".
+
+So `gjsify.ship.mimeTypes` DEFINES types — a shared-mime-info document staged as
+`share/mime/packages/<app-id>.xml`, named after the app id for the same reason the GSettings schema
+is (that directory is shared between packages, and a generic name is a collision) — and the package
+runs `update-mime-database` in its post-install, alongside the desktop, icon and schema refreshes
+§ A3 already established.
+
+Declared types are folded into `provides.mimetypes` during resolution rather than being a second
+list to keep in step. The desktop entry and the metainfo then need no knowledge of `mimeTypes` at
+all: they already render `MimeType=` (with the `%f` field code § 5 requires) and `<mediatype>` from
+that one field. Keeping the lists independent would make "defined but not handled" a state reachable
+by omission — and that state installs cleanly and does nothing.
+
+Discovery refuses four shapes, each of which would otherwise install and never resolve: a malformed
+type name (`update-mime-database` ignores it), a glob with no wildcard (`bauplan` matches only a file
+called exactly that), a type with neither a glob nor a parent (nothing can ever match it), and a
+duplicate definition (which comment wins would depend on document order). An empty `comment` is
+refused too, because a file manager then shows the user the raw type string.

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -32,61 +32,75 @@ https://github.com/gjsify/gjsify/releases/tag/v0.28.0
 
 ## What this release is about
 
-**`gjsify ship` did not work on a real app.** It shipped in 0.39.0, it was exercised by the repo's own tests, and the first two projects that pointed it at their own `package.json` both hit a wall inside the first minute. This release is what those two walls turned out to be, plus the gap that made one of them unfixable from the consumer side.
-
-If you have tried `ship` and given up, try it again.
+**Two things an app could not do, both of which fail silently when you get them wrong.**
 
 ---
 
-### `ship` could not find its own desktop template
+### An app can find its own translations
 
-`gjsify ship` died with `ENOENT … templates/app/desktop.tmpl` on **every** project, when run through the GJS entry point.
+`gjsify ship` learned to package compiled catalogues in 0.42.0, and its launcher exports
+`GJSIFY_LOCALE_DIR` because only the launcher knows whether the payload became `/usr` in a `.deb`, a
+`--prefix` tree, or `/app` in a Flatpak. Nothing read that variable. Every app was expected to write
+the same four calls, and the two that tried had no translation at all.
 
-The template was read with `readFileSync(new URL('../templates/app/desktop.tmpl', import.meta.url))`, and a comment above it stated that the `static-read-inliner` folds it into the bundle. It does not: the inliner's `shouldRewrite` requires the file to sit under `node_modules`, and the CLI bundles its own source. So the read survived into `dist/cli.gjs.mjs`, resolved `../templates/…` against `dist/`, and found nothing — while the Node `lib/` entry, where the relative path happens to be correct, worked fine. That split is why it went unnoticed for three releases: CI and `npm install -g` both take the Node path.
+`initLocale(domain)` in `@gjsify/adwaita-app` is the reading half:
 
-A ten-line skeleton is not worth a file the bundle has to locate. It is a template literal now: nothing to resolve, nothing to package, and the two entry points cannot disagree.
+```ts
+import { initLocale } from '@gjsify/adwaita-app';
 
-### `ship` can carry typelibs no distribution ships
-
-A GI library that arrives as a gjsify npm prebuild — `Gwebgl` is the one that surfaced this — has no `gir1.2-…` package anywhere, so `deriveDepends` refused the build and there was no honest way past it. Naming a package that does not exist would turn a clear refusal into an install that succeeds and an app that dies at its first import.
-
-`gjsify.ship.bundledTypelibs` takes directories whose `*.typelib` and `*.so` are staged into `lib/<app>/gi/` and put on `GI_TYPELIB_PATH` / `LD_LIBRARY_PATH` by the launcher:
-
-```json
-"gjsify": { "ship": { "bundledTypelibs": ["../node_modules/@gjsify/webgl-linux-x64/prebuilds/linux-x64"] } }
+const _ = initLocale('bauplaner');
+label.set_label(_('Assembly'));
+status.set_label(_.plural('%d layer', '%d layers', n));
 ```
 
-Both halves are staged from the same directory on purpose: a typelib without its shared library installs and then dies at the first import, which is the failure this feature exists to prevent.
+Two details are the reason this is shared code and not a snippet:
 
-### `ship` can package translations
+- **`textdomain()` is set, not only `dgettext()` used.** GtkBuilder resolves every
+  `translatable="yes"` string — so everything from a `.blp` file — in the DEFAULT domain, inside GTK,
+  where the app never gets to pass one. Binding only through `dgettext` translates the TypeScript
+  strings and leaves the Blueprint ones in the source language, which reads as a half-finished
+  translation rather than as a missing call.
+- **An empty `GJSIFY_LOCALE_DIR` counts as unset.** The launcher exports it only when it staged
+  catalogues, but a wrapper that sets it unconditionally hands over `''` — and
+  `bindtextdomain(domain, '')` binds to the *current directory*, where the lookup finds nothing and
+  reports it exactly as "this app has no German".
 
-`gjsify.ship.localeDir` names a directory of compiled catalogues and stages them into
-`share/locale/`, keeping the `<lang>/LC_MESSAGES/<domain>.mo` layout that `bindtextdomain` reads.
-The launcher then exports `GJSIFY_LOCALE_DIR`, so the app finds them without knowing which prefix
-it was installed under — the same division of labour § 3 of ADR 0024 already uses for icons and
-schemas.
+Measured against a real compiled catalogue, because "the calls did not throw" is not evidence that a
+lookup resolves: `de_DE.utf8` returns the translation and picks the right plural form, `en_US.utf8`
+returns the msgids (English needs no catalogue of its own), and an unset variable falls back to
+`/usr/share/locale`.
 
-Translations were simply not part of the payload before: an app with a working gettext setup
-packaged fine and showed English on a German desktop.
+### A package can define a file type, not just claim to open one
 
-Discovery refuses a `.po` left in place of a `.mo`, a catalogue outside `<lang>/LC_MESSAGES/`, and
-a declared directory holding no catalogue at all. All three are the same failure — a package that
-installs its translations and shows none of them — and it is the quietest kind, because an
-untranslated UI is indistinguishable from "this app has no German".
+`MimeType=` in a desktop entry says "I open this type". It does not say the type EXISTS. For
+`text/plain` that never matters — the distribution defines it. For a type of your own it decides
+whether the feature works, and nothing tells you when it does not: no component knows what a
+`.bauplan` file is, so the file manager never assigns the type, `MimeType=` matches nothing, and a
+double-click does nothing at all. No error, no log line. It is indistinguishable from the app not
+being installed.
 
-One thing found by reading the built `.rpm` rather than the config: `dist/locale/` sits beside the
-bundle, so the wholesale bundle staging shipped every catalogue a second time under
-`lib/<binary>/locale/`. The declared locale tree now drops out of that staging.
+`gjsify.ship.mimeTypes` defines types as a shared-mime-info document staged into
+`share/mime/packages/<app-id>.xml`, and the package refreshes the MIME cache on install — detection
+reads the compiled cache under `share/mime`, not the packages directory, so without that refresh the
+document installs and the type still does not exist.
 
-### Two smaller things `ship` got wrong
+```json
+"gjsify": {
+  "ship": {
+    "mimeTypes": [
+      { "type": "application/x-bauplan", "comment": "Bauplaner project", "globs": ["*.bauplan"] }
+    ]
+  }
+}
+```
 
-- **`Gda-6.0` had no entry in the typelib table**, so any app touching libgda was refused with an accurate but unhelpful message. It maps to `gir1.2-gda-6.0` / `libgda` now.
-- **`ship.description` as a plain string threw.** The field was documented as accepting either a string or an array of paragraphs, and only the array worked.
+Declared types are folded into `provides.mimetypes` automatically, so the desktop entry and the
+metainfo need no knowledge of the new field — they already render `MimeType=` (with the `%f` field
+code) and `<mediatype>` from that one list. Keeping the two independent would make "defined but not
+handled" reachable by omission, and that state installs cleanly and does nothing.
 
-### New package: `@gjsify/gtk-host`
-
-A framework-agnostic GTK4/Adwaita **element model** — the layer a UI-framework renderer binds to instead of talking to GTK directly. Tier 3 (experimental), GJS-only, with a conformance suite a renderer can run against itself. See ADR 0027.
-
-### Elsewhere
-
-`@gjsify/devtools` grew `FindWidget` and `SendKey`, so a headless rig can locate a widget by type and CSS class and deliver a real key press to it — a screenshot proves a widget was drawn, never that pressing it does anything.
+Four declarations are refused outright, each of which would otherwise install and never resolve: a
+malformed type name (`update-mime-database` ignores it), a glob with no wildcard (`bauplan` matches
+only a file called exactly that), a type with neither a glob nor a parent type (nothing can ever
+match it), and a duplicate definition (which comment wins would depend on document order). See
+ADR 0024 § A11.

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -12,6 +12,7 @@ import cliFailSuite from './cli-fail.spec.js';
 import shipPlanSuite from './utils/ship/plan.spec.js';
 import shipSettingsSuite from './utils/ship/settings.spec.js';
 import shipLocalesSuite from './utils/ship/discover-locales.spec.js';
+import shipMimeSuite from './utils/ship/mime.spec.js';
 import shipDependsSuite from './utils/ship/depends.spec.js';
 import installProvenanceSuite from './utils/install-provenance.spec.js';
 import shipArchivesSuite from './utils/ship/archives.spec.js';
@@ -198,6 +199,7 @@ run(
         shipPlanSuite,
         shipSettingsSuite,
         shipLocalesSuite,
+        shipMimeSuite,
         shipDependsSuite,
         installProvenanceSuite,
         shipArchivesSuite,

--- a/packages/infra/cli/src/types/config-data.ts
+++ b/packages/infra/cli/src/types/config-data.ts
@@ -325,6 +325,38 @@ export interface AppMetadata {
      */
     kudos?: string[];
     /**
+     * File types this package DEFINES for the whole system — a shared-mime-info
+     * document staged into `share/mime/packages/`.
+     *
+     * Distinct from `provides.mimetypes`, which only says the app HANDLES a type.
+     * For a standard type (`text/plain`, `application/pdf`) handling is all you
+     * need: the distribution already defines it. For a type of your own
+     * (`application/x-bauplan`) handling it is not enough and the failure is
+     * silent — nothing on the system knows the type exists, so a `.bauplan` file
+     * is never recognised as one, `MimeType=` in the desktop entry matches
+     * nothing, and double-clicking the file does nothing at all. No error, no
+     * log line: the association simply never fires.
+     *
+     * Every type declared here is added to the handled set automatically, because
+     * defining a file type in your own package and then not opening it is not a
+     * thing anyone means to do.
+     */
+    mimeTypes?: Array<{
+        /** `<media>/<subtype>`, e.g. `application/x-bauplan`. */
+        type: string;
+        /**
+         * What a file manager shows instead of the raw type string. Required:
+         * a type with no comment is listed to the user as `application/x-bauplan`.
+         */
+        comment: string;
+        /** Filename patterns, e.g. `["*.bauplan"]`. */
+        globs?: string[];
+        /** A registered type to inherit from, e.g. `application/zip` for a zip container. */
+        subClassOf?: string;
+        /** Fallback icon name when no type-specific icon is installed. */
+        genericIcon?: string;
+    }>;
+    /**
      * What this app provides to the system. `<binary>` is auto-included with the
      * value of `command` when omitted — AppStream needs it to register the binary
      * for both apps and CLIs.

--- a/packages/infra/cli/src/utils/ship/archives.spec.ts
+++ b/packages/infra/cli/src/utils/ship/archives.spec.ts
@@ -38,6 +38,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         section: 'gnome',
         group: 'Applications/System',
         kind: 'app',
+        mimeTypes: [],
         extraDepends: { deb: [], rpm: [] },
         bundlePath: '/p/dist/gjs.js',
         bundleDir: '/p/dist',

--- a/packages/infra/cli/src/utils/ship/mime.spec.ts
+++ b/packages/infra/cli/src/utils/ship/mime.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// MIME-type definitions, and — the half that matters — what they REFUSE.
+//
+// Every refusal covers one shape of the same failure: a file type that is registered and then never
+// resolves. That failure is silent by construction. Nothing on the system knows the type exists, so
+// the file manager never assigns it, `MimeType=` in the desktop entry matches nothing, and a
+// double-click does nothing at all — no error, no log line. It is indistinguishable from the app
+// not being installed, which is why it has to be refused at pack time rather than reported at
+// install time.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { renderMimePackage, validateMimeTypes } from './mime.js';
+import type { ShipMimeType } from './types.js';
+
+const BAUPLAN: ShipMimeType = {
+    type: 'application/x-bauplan',
+    comment: 'Bauplaner project',
+    globs: ['*.bauplan'],
+};
+
+/** The message of the error a call throws, or null when it does not throw. */
+function refusal(fn: () => void): string | null {
+    try {
+        fn();
+        return null;
+    } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+    }
+}
+
+export default async () => {
+    await describe('validateMimeTypes', async () => {
+        await it('accepts a well-formed definition', () => {
+            expect(refusal(() => validateMimeTypes([BAUPLAN]))).toBe(null);
+            expect(
+                refusal(() =>
+                    validateMimeTypes([
+                        { type: 'application/x-bauplan+zip', comment: 'Zipped', subClassOf: 'application/zip' },
+                    ]),
+                ),
+            ).toBe(null);
+        });
+
+        // update-mime-database ignores a malformed name, so the type installs and never resolves.
+        await it('refuses a type that is not <media>/<subtype>', () => {
+            for (const type of ['bauplan', 'application/', '/x-bauplan', 'application/x bauplan', 'App/X']) {
+                const message = refusal(() => validateMimeTypes([{ ...BAUPLAN, type }]));
+                expect(message !== null).toBe(true);
+                expect(message?.includes(type)).toBe(true);
+            }
+        });
+
+        await it('refuses a duplicate definition, whose winner would depend on order', () => {
+            const message = refusal(() => validateMimeTypes([BAUPLAN, { ...BAUPLAN, comment: 'Other' }]));
+            expect(message?.includes('twice')).toBe(true);
+        });
+
+        // A file manager falls back to showing the raw type string.
+        await it('refuses an empty comment', () => {
+            expect(refusal(() => validateMimeTypes([{ ...BAUPLAN, comment: '' }])) !== null).toBe(true);
+            expect(refusal(() => validateMimeTypes([{ ...BAUPLAN, comment: '   ' }])) !== null).toBe(true);
+        });
+
+        // `bauplan` as a glob matches a file called exactly `bauplan`, never `haus.bauplan`.
+        await it('refuses a glob with no wildcard, and suggests the pattern', () => {
+            const message = refusal(() => validateMimeTypes([{ ...BAUPLAN, globs: ['bauplan'] }]));
+            expect(message?.includes('*.bauplan')).toBe(true);
+            // A leading dot is stripped from the suggestion rather than doubled.
+            expect(refusal(() => validateMimeTypes([{ ...BAUPLAN, globs: ['.bauplan'] }]))?.includes('*.bauplan')).toBe(
+                true,
+            );
+        });
+
+        // Registered and unreachable: nothing can ever match it.
+        await it('refuses a type with neither globs nor a parent type', () => {
+            const message = refusal(() => validateMimeTypes([{ type: 'application/x-void', comment: 'Void' }]));
+            expect(message?.includes('never')).toBe(true);
+            expect(
+                refusal(() => validateMimeTypes([{ type: 'application/x-void', comment: 'V', globs: [] }])) !== null,
+            ).toBe(true);
+        });
+    });
+
+    await describe('renderMimePackage', async () => {
+        await it('writes the shared-mime-info document update-mime-database reads', () => {
+            const xml = renderMimePackage([BAUPLAN]);
+            expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+            // The namespace is not decoration: without it the document is skipped entirely.
+            expect(xml.includes('xmlns="http://www.freedesktop.org/standards/shared-mime-info"')).toBe(true);
+            expect(xml.includes('<mime-type type="application/x-bauplan">')).toBe(true);
+            expect(xml.includes('<comment>Bauplaner project</comment>')).toBe(true);
+            expect(xml.includes('<glob pattern="*.bauplan"/>')).toBe(true);
+            expect(xml.trimEnd().endsWith('</mime-info>')).toBe(true);
+        });
+
+        await it('carries sub-class-of and generic-icon when given', () => {
+            const xml = renderMimePackage([
+                {
+                    type: 'application/x-bauplan',
+                    comment: 'Bauplaner project',
+                    globs: ['*.bauplan'],
+                    subClassOf: 'application/zip',
+                    genericIcon: 'text-x-generic',
+                },
+            ]);
+            expect(xml.includes('<sub-class-of type="application/zip"/>')).toBe(true);
+            expect(xml.includes('<generic-icon name="text-x-generic"/>')).toBe(true);
+        });
+
+        // An unescaped `&` makes the document malformed, and update-mime-database then skips the
+        // WHOLE file — so one bad comment silently costs every type in the package.
+        await it('escapes XML metacharacters in text and attributes', () => {
+            const xml = renderMimePackage([
+                { type: 'application/x-a', comment: 'Plans & "sections" <draft>', globs: ['*.a&b'] },
+            ]);
+            expect(xml.includes('Plans &amp; &quot;sections&quot; &lt;draft&gt;')).toBe(true);
+            expect(xml.includes('pattern="*.a&amp;b"')).toBe(true);
+            expect(xml.includes('Plans & "')).toBe(false);
+        });
+
+        await it('emits every declared type in one document', () => {
+            const xml = renderMimePackage([
+                BAUPLAN,
+                { type: 'application/x-other', comment: 'Other', globs: ['*.oth'] },
+            ]);
+            expect((xml.match(/<mime-type /g) ?? []).length).toBe(2);
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/ship/mime.ts
+++ b/packages/infra/cli/src/utils/ship/mime.ts
@@ -1,0 +1,105 @@
+// Defining a file type for the system — the half `MimeType=` cannot do on its own.
+//
+// A desktop entry's `MimeType=` says "I open this type". It does NOT say the type EXISTS. For a
+// standard type that is fine, because the distribution's shared-mime-info already defines it; for a
+// type of the project's own it is not, and the failure is the quietest kind there is: nothing knows
+// what a `.bauplan` file is, so the file manager never assigns the type, `MimeType=` matches
+// nothing, and a double-click does nothing at all. No error is printed and no log line is written —
+// the association simply never fires, which is indistinguishable from "the app is not installed".
+//
+// So a project that invents a type also ships a shared-mime-info document, and the package refreshes
+// the MIME cache on install (see `scripts.ts`) — an unrefreshed cache is the same silence again.
+
+import type { ShipMimeType } from './types.js';
+
+/** XML text escaping. Only the five that matter in element content and attributes. */
+function esc(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}
+
+const TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/;
+
+/**
+ * Validate the declared types, throwing on anything that would install and then not work.
+ *
+ * Each refusal is a silent failure made loud:
+ *  - a malformed type name is written into the XML and ignored by `update-mime-database`;
+ *  - a glob without `*.` never matches (`bauplan` matches only a file called exactly that);
+ *  - a type with no glob and no parent type can never be DETECTED, so it is registered and unused;
+ *  - a duplicate definition makes which comment wins depend on document order.
+ */
+export function validateMimeTypes(types: readonly ShipMimeType[]): void {
+    const seen = new Set<string>();
+    for (const entry of types) {
+        if (!TYPE_RE.test(entry.type)) {
+            throw new Error(
+                `gjsify ship: \`gjsify.ship.mimeTypes\` has an invalid type "${entry.type}". ` +
+                    'Expected `<media>/<subtype>`, e.g. `application/x-bauplan` — update-mime-database ' +
+                    'ignores a malformed name, so the type would install and never resolve.',
+            );
+        }
+        if (seen.has(entry.type)) {
+            throw new Error(
+                `gjsify ship: \`gjsify.ship.mimeTypes\` defines ${entry.type} twice. ` +
+                    'Which comment and glob set win would depend on document order.',
+            );
+        }
+        seen.add(entry.type);
+        if (entry.comment.trim() === '') {
+            throw new Error(
+                `gjsify ship: ${entry.type} has an empty \`comment\`. A file manager then shows the ` +
+                    'user the raw type string instead of a name.',
+            );
+        }
+        for (const glob of entry.globs ?? []) {
+            if (!glob.includes('*') && !glob.includes('?') && !glob.includes('[')) {
+                throw new Error(
+                    `gjsify ship: ${entry.type} has the glob "${glob}", which matches only a file ` +
+                        `named exactly that. A suffix pattern is written \`*.${glob.replace(/^\.+/, '')}\`.`,
+                );
+            }
+        }
+        if ((entry.globs ?? []).length === 0 && entry.subClassOf === undefined) {
+            throw new Error(
+                `gjsify ship: ${entry.type} declares neither \`globs\` nor \`subClassOf\`, so nothing ` +
+                    'can ever match it. The type would be registered and then never assigned to a file.',
+            );
+        }
+    }
+}
+
+/**
+ * The shared-mime-info document for `types`.
+ *
+ * One file per package, named after the app id, because `share/mime/packages/` is shared: a generic
+ * name is a collision with whatever another package put there — the same reason the schema staging
+ * uses the app id.
+ */
+export function renderMimePackage(types: readonly ShipMimeType[]): string {
+    const body = types
+        .map((entry) => {
+            const lines = [`  <mime-type type="${esc(entry.type)}">`, `    <comment>${esc(entry.comment)}</comment>`];
+            if (entry.subClassOf !== undefined) {
+                lines.push(`    <sub-class-of type="${esc(entry.subClassOf)}"/>`);
+            }
+            for (const glob of entry.globs ?? []) {
+                lines.push(`    <glob pattern="${esc(glob)}"/>`);
+            }
+            if (entry.genericIcon !== undefined) {
+                lines.push(`    <generic-icon name="${esc(entry.genericIcon)}"/>`);
+            }
+            lines.push('  </mime-type>');
+            return lines.join('\n');
+        })
+        .join('\n');
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+${body}
+</mime-info>
+`;
+}

--- a/packages/infra/cli/src/utils/ship/packers.spec.ts
+++ b/packages/infra/cli/src/utils/ship/packers.spec.ts
@@ -37,6 +37,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         section: 'gnome',
         group: 'Applications/System',
         kind: 'cli',
+        mimeTypes: [],
         extraDepends: { deb: [], rpm: [] },
         typelibPackages: {},
         bundlePath: '/p/dist/gjs.js',

--- a/packages/infra/cli/src/utils/ship/plan.spec.ts
+++ b/packages/infra/cli/src/utils/ship/plan.spec.ts
@@ -31,6 +31,7 @@ function settings(overrides: Partial<ShipSettings> = {}): ShipSettings {
         section: 'gnome',
         group: 'Applications/System',
         kind: 'app',
+        mimeTypes: [],
         extraDepends: { deb: [], rpm: [] },
         bundlePath: '/project/dist/gjs.js',
         bundleDir: '/project/dist',

--- a/packages/infra/cli/src/utils/ship/plan.ts
+++ b/packages/infra/cli/src/utils/ship/plan.ts
@@ -3,6 +3,7 @@
 // as `utils/copy-targets.ts`, and for the same reason: a stager that discovers
 // its own inputs can only be tested by building a real project.
 
+import { renderMimePackage } from './mime.js';
 import { basename, extname, posix } from 'node:path';
 
 import type { FormatDescriptor, ShipSettings, StagedFile } from './types.js';
@@ -88,6 +89,16 @@ export function planStage(settings: ShipSettings, inputs: StageInputs): StagedFi
             // keeps the staged tree free of a distinction nothing downstream reads.
             mode: 0o755,
             source: { kind: 'file', path: file },
+        });
+    }
+    // A shared-mime-info document, when the project DEFINES a type rather than only handling one.
+    // `share/mime/packages/` is shared between packages, so the app id is the filename for the same
+    // reason it is for the GSettings schema: a generic name collides with another package's file.
+    if (settings.mimeTypes.length > 0) {
+        files.push({
+            path: `share/mime/packages/${settings.appId}.xml`,
+            mode: 0o644,
+            source: { kind: 'text', text: renderMimePackage(settings.mimeTypes) },
         });
     }
 

--- a/packages/infra/cli/src/utils/ship/scripts.ts
+++ b/packages/infra/cli/src/utils/ship/scripts.ts
@@ -36,6 +36,14 @@ export function cacheRefreshCommands(settings: ShipSettings, prefix: string): st
             run: `gtk-update-icon-cache -q -t -f ${prefix}/share/icons/hicolor`,
         });
     }
+    if (settings.mimeTypes.length > 0) {
+        // Without this the document is installed and the type still does not exist: detection runs
+        // off the compiled cache in `share/mime/`, not off the packages directory.
+        refreshes.push({
+            probe: 'update-mime-database',
+            run: `update-mime-database ${prefix}/share/mime`,
+        });
+    }
     if (settings.schemaFiles.length > 0) {
         refreshes.push({
             probe: 'glib-compile-schemas',

--- a/packages/infra/cli/src/utils/ship/settings.ts
+++ b/packages/infra/cli/src/utils/ship/settings.ts
@@ -10,6 +10,7 @@
 // only) > derived from package.json. Never a yargs `default:`, which is
 // indistinguishable from a value the user typed and would clobber the config.
 
+import { validateMimeTypes } from './mime.js';
 import { basename } from 'node:path';
 
 import type { AppMetadata, ConfigDataFlatpak, ConfigDataShip, DescriptionBlock } from '../../types/config-data.js';
@@ -86,6 +87,18 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
     // for. The non-metadata keys each block carries ride along unread.
     const metadata: AppMetadata = { ...flatpak, ...definedOnly(ship) };
 
+    // A type this package DEFINES is also a type it handles. Folding it into `provides.mimetypes`
+    // here means the desktop entry and the metainfo need no knowledge of `mimeTypes` at all: they
+    // already render `MimeType=` (with the `%f` field code) and `<mediatype>` from that one field.
+    // Doing it the other way — leaving the two lists independent — makes "defined but not handled"
+    // a state you can reach by omission, and that state installs cleanly and does nothing.
+    const mimeTypes = ship.mimeTypes ?? [];
+    if (mimeTypes.length > 0) {
+        validateMimeTypes(mimeTypes);
+        const handled = new Set([...(metadata.provides?.mimetypes ?? []), ...mimeTypes.map((m) => m.type)]);
+        metadata.provides = { ...metadata.provides, mimetypes: [...handled] };
+    }
+
     const binaryName = ship.binaryName ?? deriveBinaryName(pkg.name);
     const appId = ship.appId ?? flatpak.appId ?? reverseDnsOrThrow(pkg.name, binaryName);
     const name = metadata.name ?? titleCase(binaryName);
@@ -141,6 +154,7 @@ export function resolveShipSettings(input: SettingsInput): ResolvedSettings {
         section: ship.section ?? sections.section,
         group: ship.group ?? sections.group,
         kind,
+        mimeTypes,
         extraDepends: { deb: ship.depends?.deb ?? [], rpm: ship.depends?.rpm ?? [] },
         typelibPackages: ship.typelibPackages ?? {},
         bundlePath: discovered.bundlePath,

--- a/packages/infra/cli/src/utils/ship/types.ts
+++ b/packages/infra/cli/src/utils/ship/types.ts
@@ -61,6 +61,15 @@ export interface FormatDescriptor {
 }
 
 /** The resolved, fully defaulted configuration for one `gjsify ship` run. */
+/** One shared-mime-info type definition (`gjsify.ship.mimeTypes`). */
+export interface ShipMimeType {
+    type: string;
+    comment: string;
+    globs?: string[];
+    subClassOf?: string;
+    genericIcon?: string;
+}
+
 export interface ShipSettings {
     /** Absolute path to the project being shipped. */
     projectDir: string;
@@ -89,6 +98,11 @@ export interface ShipSettings {
     section: string;
     /** rpm `Group:`. */
     group: string;
+    /**
+     * File types this package defines system-wide (shared-mime-info). Empty for a package that only
+     * HANDLES existing types — that needs no document of its own.
+     */
+    mimeTypes: ShipMimeType[];
     /** `'app'` stages a desktop entry and an icon; `'cli'` stages neither. */
     kind: 'app' | 'cli';
     /** Extra runtime dependencies per format, appended to the derived set. */

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -71,6 +71,7 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
             `share/glib-2.0/schemas/${APP_ID}.gschema.xml`,
             `share/icons/hicolor/scalable/apps/${APP_ID}.svg`,
             `share/metainfo/${APP_ID}.metainfo.xml`,
+            `share/mime/packages/${APP_ID}.xml`,
         ]);
     });
 
@@ -123,7 +124,7 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         if (!probe('ar') || !probe('tar')) return;
         const md5sums = readControlFile('md5sums');
         const lines = md5sums.trimEnd().split('\n');
-        assert.equal(lines.length, 7); // 6 staged + the copyright overlay
+        assert.equal(lines.length, 8); // 7 staged + the copyright overlay
         for (const line of lines) {
             // Exactly two spaces, and no leading `./` — unlike every other
             // path in the package.
@@ -196,6 +197,7 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
             `/usr/share/applications/${APP_ID}.desktop`,
             `/usr/share/glib-2.0/schemas/${APP_ID}.gschema.xml`,
             `/usr/share/metainfo/${APP_ID}.metainfo.xml`,
+            `/usr/share/mime/packages/${APP_ID}.xml`,
             '/usr/share/licenses/ship-demo/LICENSE',
         ]) {
             assert.ok(files.includes(expected), `missing ${expected}`);
@@ -227,6 +229,9 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         if (!probe('rpm')) return;
         const scripts = execFileSync('rpm', ['-qp', '--scripts', rpmPath()], { encoding: 'utf-8' });
         assert.match(scripts, /glib-compile-schemas \/usr\/share\/glib-2\.0\/schemas/);
+        // Detection runs off the compiled cache in `share/mime`, not off `share/mime/packages`.
+        // Without this line the document is installed and the type still does not exist.
+        assert.match(scripts, /update-mime-database \/usr\/share\/mime/);
         // rpm's `$1` is a COUNT. A dpkg-shaped `[ "$1" = "configure" ]` here is
         // never true, so the scriptlet runs and does nothing — an artifact that
         // passes every structural check and still ships broken.
@@ -497,6 +502,16 @@ function scaffold(dir, mutate) {
                 license: { project: 'MIT' },
                 homepageUrl: 'https://example.org/ship-demo',
                 categories: ['Utility'],
+                // A type of the project's OWN, so the packer has to DEFINE it and not merely
+                // claim to handle it. Claiming an undefined type installs cleanly and never fires.
+                mimeTypes: [
+                    {
+                        type: 'application/x-ship-demo',
+                        comment: 'Ship Demo document',
+                        globs: ['*.shipdemo'],
+                        genericIcon: 'text-x-generic',
+                    },
+                ],
             },
         },
     };


### PR DESCRIPTION
## The distinction this adds

`MimeType=` in a desktop entry says **"I open this type"**. It does not say the type **exists**.

For a type the distribution already defines (`text/plain`, `application/pdf`) that never comes up. For a type of the project's own it decides whether the feature works at all — and the failure is the quietest one in ADR 0024:

| declared | what happens |
|---|---|
| `provides.mimetypes` alone, for a custom type | nothing on the system knows the type exists → the file manager never assigns it → `MimeType=` matches nothing → a double-click does nothing. No error, no log line. |
| a shared-mime-info document, no cache refresh | detection reads the compiled cache under `share/mime`, not `share/mime/packages` → the type stays unknown until something else rebuilds it |

Both are indistinguishable from *the application is not installed*.

## What it looks like

```json
"gjsify": {
  "ship": {
    "mimeTypes": [
      { "type": "application/x-bauplan", "comment": "Bauplaner project", "globs": ["*.bauplan"] }
    ]
  }
}
```

Staged as `share/mime/packages/<app-id>.xml` — named after the app id because that directory is shared between packages and a generic name is a collision, the same reason the GSettings schema is named that way — plus `update-mime-database` in the post-install, beside the desktop/icon/schema refreshes § A3 already established.

**Declared types are folded into `provides.mimetypes` during resolution**, so the desktop entry and the metainfo need no knowledge of the new field: they already render `MimeType=` (with the `%f` field code § 5 requires) and `<mediatype>` from that one list. Keeping the lists independent would make *defined but not handled* reachable by omission, and that state installs cleanly and does nothing.

Four declarations are refused, each of which would otherwise install and never resolve — a malformed type name (`update-mime-database` ignores it), a glob with no wildcard (`bauplan` matches only a file called exactly that), a type with neither glob nor parent (nothing can ever match it), and a duplicate (which comment wins would depend on document order). An empty `comment` is refused too, because a file manager then shows the raw type string.

## Verification — by the consumer, not by assertion

The generated document is handed to the **real `update-mime-database`**, which accepts it and compiles it:

```
globs2:  application/x-bauplan:*.bauplan
types:   application/x-bauplan
```

That is the system's own tool resolving the type. On top of it:

- **ship e2e against real artifacts** — the document in the staged tree, in the `.rpm` payload (read with the system `rpm`), and `update-mime-database` in the scriptlet. The `.deb` md5sums count went 7 → 8, which is the exhaustive assertion catching the new file rather than me telling it to.
- **10 unit tests** over the validator and the renderer, including XML escaping — an unescaped `&` makes the document malformed and `update-mime-database` then skips the **whole file**, so one bad comment silently costs every type in the package.
- Full CLI suite: **2525 pass, 0 fail**.

## A trap worth recording

`tsconfig.json` excludes `*.spec.ts`, so adding a **required** field to `ShipSettings` breaks the spec fixtures at runtime only: `tsc` stayed green while **17 tests failed**. Four fixtures needed the field by hand. Anyone adding a field to that interface should expect the same.

## Second commit

`.gitignore`'s `ship/` is unanchored on purpose (`outDir` defaults to `ship` beside any project, at any depth), so it also matches source directories of that name — and `tests/e2e/ship/` is the third, after the command's implementation and its docs. `run.mjs` predates the pattern and stayed tracked, so the collision looked harmless; it is not, because anything **new** beside it is silently unaddable. Verified both ways: the e2e path is no longer ignored, and `packages/infra/cli/ship/out/x.rpm` still is.