### PR TITLE
docs: say why .blp uses the JavaScript lexer

### DIFF
--- a/packages/infra/vite-plugin-gettext/src/xgettext.ts
+++ b/packages/infra/vite-plugin-gettext/src/xgettext.ts
@@ -232,6 +232,11 @@ async function extractStrings(files: string[], options: XGettextPluginOptions, p
             // Add language-specific settings
             switch (group) {
                 case 'js':
+                // Blueprint deliberately shares the JavaScript lexer: xgettext has no Blueprint
+                // parser at all (0.26 rejects `--language=Blueprint` outright), and Blueprint's
+                // `_("…")` / `C_("ctx", "…")` are lexically calls, which is exactly what the
+                // JavaScript scanner looks for. Measured on a .blp: all marked strings come out,
+                // unmarked literals stay out.
                 case 'blp':
                     baseArgs.push('--language=JavaScript');
                     baseArgs.push(...keywords.map((k) => `--keyword=${k}`));


### PR DESCRIPTION
Blueprint files get their own extraction group in `xgettextPlugin`, and that group is handed to xgettext with `--language=JavaScript`. It reads like a copy-paste slip. It is not one, and the next reader deserves to know before they "fix" it.

Measured with xgettext 0.26 on a `.blp` holding `_("…")`, `C_("verb", "…")` and one deliberately unmarked literal:

| invocation | result |
|---|---|
| `--language=JavaScript` | all marked strings extracted, `msgctxt` preserved, unmarked literal correctly skipped |
| `--language=Blueprint` | exit 1 — xgettext has no Blueprint parser and rejects the name |
| `--language=Glade` | error — the Glade parser wants XML and a `.blp` is not XML |

Blueprint's translation markers are lexically function calls, which is exactly what the JavaScript scanner collects, so the pairing works by construction rather than by luck.

Comment only — no behaviour change.