### PR TITLE
fix(adwaita-web): adopt a slotted child that arrives late

### DIFF
--- a/packages/web/adwaita-web/src/connect-lifecycle.spec.ts
+++ b/packages/web/adwaita-web/src/connect-lifecycle.spec.ts
@@ -230,8 +230,19 @@ export const AdwConnectLifecycleTest = async () => {
                 });
                 await settle();
 
-                const report = probes.map(([name, child]) => `${name}: ${verdict(child)}`).join(' | ');
-                const wanted = probes.map(([name]) => `${name}: laid out`).join(' | ');
+                // An element with NO container getter made both strings empty, so the
+                // assertion below reduced to `expect('<tag> ').toBe('<tag> ')` — 40-odd
+                // of the 70 greens here were that. The aggregate floor above says SOME
+                // containers exist; it cannot say which tag contributed one. Naming the
+                // absence turns each of those into a statement.
+                const report =
+                    probes.length === 0
+                        ? 'no container getter'
+                        : probes.map(([name, child]) => `${name}: ${verdict(child)}`).join(' | ');
+                const wanted =
+                    probes.length === 0
+                        ? 'no container getter'
+                        : probes.map(([name]) => `${name}: laid out`).join(' | ');
                 // Measure, THEN tear down, THEN assert: a failing expectation throws, and
                 // a host left on the page pushes every later one down until the next
                 // widget is measured off-screen. That cascade turned one real failure
@@ -239,6 +250,100 @@ export const AdwConnectLifecycleTest = async () => {
                 host.remove();
                 expect(`<${tag}> ${report}`).toBe(`<${tag}> ${wanted}`);
             });
+        }
+    });
+
+    /**
+     * Which named slots each element ROUTES a child into.
+     *
+     * The one hand-written list in this file, and it is held rather than trusted:
+     * `scripts/check-adwaita-connect-rebind.mjs` reads the sources for `[slot="…"]`
+     * selectors and `getAttribute('slot')` comparisons and fails when this table and
+     * the tree disagree. A browser spec cannot read a `.ts` file, so the choice is a
+     * held table or no coverage at all.
+     *
+     * WHY IT IS WORTH THE TABLE. ADR 0027 § 9 names late slot adoption as the measured
+     * obstacle to one authored tree driving both this pillar and the GTK host — and
+     * the 70 greens above, each titled "lays out a child appended after connect",
+     * append only into containers the element BUILT. Not one of them appends a
+     * `[slot=]` child to the HOST after connect, which is the property the ADR is
+     * about. `adw-header-bar.spec.ts:71` even documents the workaround ("the slotted
+     * children have to be in place before the bar enters the document") without
+     * anything failing.
+     */
+    const SLOT_ROUTES: ReadonlyArray<readonly [string, readonly string[]]> = [
+        ['adw-action-row', ['prefix', 'suffix']],
+        ['adw-entry-row', ['prefix']],
+        ['adw-expander-row', ['prefix', 'suffix']],
+        ['adw-header-bar', ['start', 'center', 'end']],
+        ['adw-navigation-split-view', ['sidebar', 'content']],
+        ['adw-overlay-split-view', ['sidebar', 'content']],
+        ['adw-preferences-group', ['header-suffix']],
+        ['adw-toolbar-view', ['top', 'bottom']],
+    ];
+
+    /** A slotted probe: same shape both sides, so only WHEN it arrives differs. */
+    function slotted(slot: string): HTMLElement {
+        const child = probe();
+        child.setAttribute('slot', slot);
+        return child;
+    }
+
+    /**
+     * Where a child ended up, as a path of tags from the host down.
+     *
+     * The parent is the assertion, not the box: a child left in the light DOM is often
+     * still VISIBLE — it just sits in the wrong place, unstyled and unordered. So the
+     * reference is an identically-slotted child that was there at parse time, and the
+     * question is whether the two share a parent.
+     */
+    function placement(host: HTMLElement, child: HTMLElement): string {
+        const path: string[] = [];
+        for (let node = child.parentElement; node !== null && node !== host; node = node.parentElement) {
+            path.unshift(node.localName + (node.className === '' ? '' : `.${node.className.split(/\s+/)[0]}`));
+        }
+        return path.length === 0 ? '(light DOM)' : path.join(' > ');
+    }
+
+    await describe('slotted append after connect', async () => {
+        await it('drives every element that routes a named slot', async () => {
+            // The table has to describe elements that EXIST, or a rename empties this
+            // whole describe and every test in it reports a green it never earned.
+            const missing = SLOT_ROUTES.filter(([tag]) => !tags.includes(tag)).map(([tag]) => tag);
+            expect(`missing: ${missing.join(', ')}`).toBe('missing: ');
+            expect(SLOT_ROUTES.length > 5).toBe(true);
+        });
+
+        for (const [tag, slots] of SLOT_ROUTES) {
+            for (const slot of slots) {
+                await it(`<${tag}> adopts a [slot="${slot}"] child appended after connect`, async () => {
+                    // Reference: the same child, in place before the element connects.
+                    const control = visibleHost();
+                    const declared = document.createElement(tag);
+                    const early = slotted(slot);
+                    declared.appendChild(early);
+                    control.appendChild(declared);
+                    reveal(declared);
+
+                    // Subject: connected first, child appended afterwards — what a
+                    // renderer does by definition.
+                    const host = visibleHost();
+                    const el = document.createElement(tag);
+                    host.appendChild(el);
+                    reveal(el);
+                    const late = slotted(slot);
+                    el.appendChild(late);
+                    await settle();
+
+                    const wanted = placement(declared, early);
+                    const got = placement(el, late);
+                    const size = boxDelta(late, early);
+                    control.remove();
+                    host.remove();
+                    expect(`<${tag}> [slot=${slot}] -> ${got}`).toBe(`<${tag}> [slot=${slot}] -> ${wanted}`);
+                    expect(`<${tag}> [slot=${slot}] ${size}`).toBe(`<${tag}> [slot=${slot}] same box`);
+                });
+            }
         }
     });
 

--- a/packages/web/adwaita-web/src/elements/adw-action-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-action-row.ts
@@ -18,6 +18,7 @@ import { ActionRowState } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
 import { type AdwRowActivation, attachRowActivation } from './row-activation.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 /**
  * Attributes whose change means the activatable widget's sensitivity may have
@@ -110,6 +111,7 @@ export class AdwActionRow extends HTMLElement {
         for (const child of suffixChildren) this._suffixEl.appendChild(child);
 
         this.replaceChildren(this._prefixEl, textEl, this._suffixEl);
+        bindSlotAdoption(this, { prefix: this._prefixEl, suffix: this._suffixEl });
         // `_render` runs from `attributeChangedCallback`, which a control appended into
         // `suffixSection` never triggers — the section stayed `hidden` and the control
         // measured 0x0. The observer is what keeps the two sections in step with what

--- a/packages/web/adwaita-web/src/elements/adw-entry-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-entry-row.ts
@@ -38,6 +38,7 @@ import {
 } from '@gjsify/adwaita-core';
 
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 /**
  * Show/hide a rendered part. `hidden` carries the semantics and is what the conformance
@@ -164,6 +165,13 @@ export class AdwEntryRow extends HTMLElement {
         // suffix lands after it and both remain.
         this._onConnected();
         this._adoptAuthored();
+        // …and every later one. `addPrefix` PREPENDS (`gtk_box_prepend`), so the section
+        // cannot be handed over as a plain append target without reversing the order a
+        // declared prefix gets — the routes take the method instead.
+        bindSlotAdoption(this, {
+            prefix: (node) => this.addPrefix(node),
+            suffix: (node) => this.addSuffix(node),
+        });
 
         this._lastText = this._state.text;
         this._lastLength = this._state.textLength;

--- a/packages/web/adwaita-web/src/elements/adw-expander-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-expander-row.ts
@@ -33,6 +33,7 @@ import './adw-switch.js';
 import type { AdwSwitch } from './adw-switch.js';
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
 import { attachRowActivation } from './row-activation.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 export class AdwExpanderRow extends HTMLElement {
     private _headerEl!: HTMLDivElement;
@@ -149,6 +150,7 @@ export class AdwExpanderRow extends HTMLElement {
         for (const row of rows) this._contentEl.appendChild(row);
 
         this.replaceChildren(this._headerEl, this._contentEl);
+        bindSlotAdoption(this, { prefix: this._prefixEl, suffix: this._suffixEl });
 
         this._headerEl.addEventListener('click', (event) => {
             // Clicks on the enable switch toggle expansion-enable, not disclosure.

--- a/packages/web/adwaita-web/src/elements/adw-header-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-header-bar.ts
@@ -19,6 +19,7 @@
 // Registers <adw-window-title>: the derived centre is one, so importing the bar
 // alone must still define it.
 import './adw-window-title.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 export class AdwHeaderBar extends HTMLElement {
     private _initialized = false;
@@ -86,6 +87,12 @@ export class AdwHeaderBar extends HTMLElement {
         // Replace all children atomically
         this.replaceChildren(this._startEl, this._centerEl, this._endEl);
         this._renderTitle();
+        // A child appended after this point is routed the same way, or it sits in the
+        // light DOM looking placed. `_renderTitle` re-runs so a late `slot="center"`
+        // widget displaces the automatic title, as the declared form already does.
+        bindSlotAdoption(this, { start: this._startEl, center: this._centerEl, end: this._endEl }, () =>
+            this._renderTitle(),
+        );
     }
 
     /**

--- a/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
@@ -36,6 +36,7 @@ import {
 } from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 /** Detail of the `navigation-push` / `navigation-pop` delegation event. */
 export interface NavigationDelegateDetail {
@@ -154,6 +155,7 @@ export class AdwNavigationSplitView extends HTMLElement {
         for (const child of contentChildren) this._contentEl.appendChild(child);
 
         this.replaceChildren(this._sidebarEl, this._contentEl);
+        bindSlotAdoption(this, { sidebar: this._sidebarEl, content: this._contentEl });
 
         // Parse-time attributes are the CONSTRUCTION properties, as in the overlay view:
         // applying them as sequential setters emits a transition for a state the markup

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -26,6 +26,7 @@ import {
 } from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 /**
  * The reveal spring, as a CSS-timed animator: libadwaita animates with a spring
@@ -188,6 +189,7 @@ export class AdwOverlaySplitView extends HTMLElement {
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-osv-content';
         contentChildren.forEach((c) => this._contentEl.appendChild(c));
+        bindSlotAdoption(this, { sidebar: this._sidebarEl, content: this._contentEl });
         unslotted.forEach((c) => this._contentEl.appendChild(c));
 
         this._backdropEl = document.createElement('div');

--- a/packages/web/adwaita-web/src/elements/adw-toolbar-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-toolbar-view.ts
@@ -32,6 +32,7 @@ import {
 } from '@gjsify/adwaita-core';
 import { bindEmptySections } from '../empty-sections.js';
 import { AdwScrollShading } from '../scroll-shading.js';
+import { bindSlotAdoption } from '../slot-adoption.js';
 
 export class AdwToolbarView extends HTMLElement {
     private _topEl!: HTMLDivElement;
@@ -96,6 +97,10 @@ export class AdwToolbarView extends HTMLElement {
             bindEmptySections(this._topEl, this._bottomEl);
 
             this.replaceChildren(this._topEl, this._contentEl, this._bottomEl);
+            // Its sibling: `bindEmptySections` keeps the bar's `hidden` flag honest once
+            // a child is IN it, and this puts the child there. A late `slot="top"` bar
+            // had both problems and only one of them was fixed.
+            bindSlotAdoption(this, { top: this._topEl, bottom: this._bottomEl });
         }
 
         // `update_undershoots` runs from size_allocate, so the classes have to

--- a/packages/web/adwaita-web/src/slot-adoption.ts
+++ b/packages/web/adwaita-web/src/slot-adoption.ts
@@ -1,0 +1,108 @@
+// "Routed to its section at connect" — kept live, so a child that arrives later lands
+// in the same place.
+//
+// THE INCIDENT
+//
+// Eight elements re-home their `[slot="…"]` children into an internal section, exactly
+// once, inside the `_initialized` guard of `connectedCallback`. A child appended
+// AFTERWARDS is never moved: it stays a direct child of the host, unstyled and
+// unordered, and — because it is still visible — it looks placed. Measured in Firefox
+// against a parse-time control, 14 of the 15 (element, slot) pairs the pillar routes:
+//
+//     <adw-toolbar-view> [slot=top]   wanted div.adw-toolbar-view-top   got (light DOM)
+//     <adw-header-bar>   [slot=start] wanted div.adw-header-bar-start   got (light DOM)
+//     <adw-action-row>   [slot=prefix] wanted div.adw-action-row-prefix got (light DOM)
+//
+// The fifteenth is `<adw-preferences-group>`, which already observes its host's
+// childList — so it is both the exception and the proof the driver measures something.
+//
+// WHY IT MATTERS BEYOND HAND-WRITTEN HTML. ADR 0027 § 9 names exactly this as the
+// measured obstacle to one authored tree driving both this pillar and the GTK host: a
+// renderer mutates its tree after mount by definition, so a slot adopted once cannot
+// serve one. It is also simply wrong for `bar.append(button)`, which is the imperative
+// half of every one of these elements' documented surface.
+//
+// `bindEmptySections` is the sibling of this file and the same technique — the
+// MutationObserver `<adw-clamp>` paid for first, in ONE home rather than an eighth site
+// deriving it an eighth time. What differs is only the derivation: that one keeps a
+// `hidden` flag true, this one keeps a child in the right parent.
+//
+// NOTHING TO TEAR DOWN, for the reason `empty-sections.ts` states in full: the observed
+// node is the HOST, which owns the observer, so the two become unreachable together.
+// Only a binding that reaches outside (document, window, a media query) has to be
+// released on disconnect.
+
+/**
+ * Where each slot name routes: the section to append to, or a function that places the
+ * child itself.
+ *
+ * The function form is not a convenience. `<adw-entry-row>` PREPENDS a prefix —
+ * `adw_entry_row_add_prefix` mirrors `gtk_box_prepend`, so several prefixes stack in
+ * reverse call order — and a plain `appendChild` would silently reverse that for a
+ * late child while the parse-time path kept it. An element that already owns an
+ * `addPrefix`/`addSuffix` passes that method and stays the single authority on its own
+ * ordering.
+ */
+export type SlotRoute = HTMLElement | ((node: Element) => void);
+
+export interface SlotRoutes {
+    readonly [slot: string]: SlotRoute | undefined;
+}
+
+/**
+ * Route `[slot="…"]` children of `host` into `routes`, now and after every later
+ * childList change on the host.
+ *
+ * ONLY THE HOST'S OWN CHILDREN, and only ADDED ones. Both halves are load-bearing, and
+ * `<adw-preferences-group>._observeHost` learned each of them the hard way: a record
+ * whose target is a section is the CONSEQUENCE of a move this function just made, and
+ * re-routing it appends the same child a second time.
+ *
+ * A child whose `slot` names nothing in `routes` is LEFT ALONE. That is deliberate and
+ * it is the conservative half: an element's own parts (`this._startEl`) carry no `slot`
+ * attribute, and neither does a consumer's unslotted content, so neither is touched by
+ * a helper whose whole job is named placement.
+ */
+export function bindSlotAdoption(host: HTMLElement, routes: SlotRoutes, afterAdopt?: () => void): void {
+    const route = (node: Node): boolean => {
+        if (!(node instanceof Element)) return false;
+        const slot = node.getAttribute('slot');
+        if (slot === null) return false;
+        const destination = routes[slot];
+        if (destination === undefined) return false;
+        if (typeof destination === 'function') {
+            destination(node);
+            return true;
+        }
+        if (node.parentElement === destination) return false;
+        destination.appendChild(node);
+        return true;
+    };
+
+    const observer = new MutationObserver((records) => {
+        let adopted = false;
+        for (const record of records) {
+            if (record.target !== host) continue;
+            for (const node of record.addedNodes) adopted = route(node) || adopted;
+        }
+        // Only when something MOVED, and only once per batch. `<adw-header-bar>` uses it
+        // to drop the automatic title the moment a real `slot="center"` widget arrives —
+        // its parse-time path chooses one or the other, so a late child that merely sat
+        // BESIDE the auto title would render two titles where the declared form renders
+        // one.
+        if (adopted) afterAdopt?.();
+    });
+    observer.observe(host, { childList: true });
+
+    // The children present RIGHT NOW, so a caller that appends in the same task as the
+    // mount is not left waiting for the observer's microtask. `connectedCallback` has
+    // already re-homed the parse-time ones; this catches anything appended between the
+    // element being created and this call.
+    let adopted = false;
+    // SNAPSHOT, and the linter is wrong to call the spread useless here: `children` is a
+    // LIVE HTMLCollection, and routing a child moves it OUT of the host. Iterating the
+    // collection itself therefore renumbers under the loop and skips every second match.
+    // eslint-disable-next-line unicorn/no-useless-spread -- the collection is live and this loop mutates it
+    for (const child of [...host.children]) adopted = route(child) || adopted;
+    if (adopted) afterAdopt?.();
+}

--- a/scripts/check-adwaita-connect-rebind.mjs
+++ b/scripts/check-adwaita-connect-rebind.mjs
@@ -61,11 +61,11 @@
 //
 // Usage: node scripts/check-adwaita-connect-rebind.mjs [--root <dir>]
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { adwaitaWebElements } from './adwaita-elements.mjs';
+import { adwaitaWebElements, stripComments } from './adwaita-elements.mjs';
 
 const args = process.argv.slice(2);
 const rootIndex = args.indexOf('--root');
@@ -413,6 +413,101 @@ for (const file of files) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Second arm: the spec's SLOT_ROUTES table describes the tree it drives.
+// ---------------------------------------------------------------------------
+//
+// `connect-lifecycle.spec.ts` now appends a `[slot=]` child to the HOST after connect
+// — the property ADR 0027 § 9 names as the obstacle to one authored tree driving both
+// this pillar and the GTK host, and the one thing its 70 sibling greens never touched
+// (they append into containers the element BUILT). A browser spec cannot read a `.ts`
+// file, so which slots each element routes has to be written down there. Written down
+// and unheld, it is the drift this repo keeps paying for: a renamed slot leaves the
+// table naming one nothing routes, the test passes because the light-DOM placement
+// matches on both sides, and the coverage is gone with nothing saying so.
+//
+// So the table is read back out of the spec and compared against the sources, BOTH
+// WAYS. Same shape as `check-adwaita-keyboard-contract.mjs`'s ROVING_LEDGER.
+
+const SPEC = 'packages/web/adwaita-web/src/connect-lifecycle.spec.ts';
+const specPath = join(ROOT, SPEC);
+const slotProblems = [];
+
+if (!existsSync(specPath)) {
+    slotProblems.push(`${SPEC} is gone. The slot-adoption driver went with it.`);
+} else {
+    const specSource = readFileSync(specPath, 'utf8');
+    const table = /const SLOT_ROUTES[^=]*=\s*\[([\s\S]*?)\n {4}\];/.exec(specSource);
+    if (!table) {
+        slotProblems.push(
+            `${SPEC}: no SLOT_ROUTES table this reader can parse. A table it cannot read is a ` +
+                'table it cannot hold, and the driver would keep reporting green.',
+        );
+    } else {
+        /** tag -> declared slot names, as the spec has them. */
+        const declared = new Map();
+        for (const [, tag, list] of table[1].matchAll(/\['(adw-[a-z-]+)',\s*\[([^\]]*)\]\]/g)) {
+            declared.set(tag, new Set([...list.matchAll(/'([a-z-]+)'/g)].map(([, name]) => name)));
+        }
+
+        /** tag -> slot names its own source routes, from the two spellings in the tree. */
+        const actual = new Map();
+        for (const file of files) {
+            // COMMENTS only, not `maskNonCode`: that one blanks string CONTENTS too, and
+            // `querySelectorAll(':scope > [slot="start"]')` is a string. Read through it
+            // and every one of the eight elements reported routing no slot at all — a
+            // reader that finds nothing, reporting the tree as empty.
+            const code = stripComments(readFileSync(join(ROOT, file), 'utf8'));
+            const names = new Set();
+            for (const [, name] of code.matchAll(/\[slot="([a-z-]+)"\]/g)) names.add(name);
+            for (const [, name] of code.matchAll(/getAttribute\('slot'\)\s*===\s*'([a-z-]+)'/g)) names.add(name);
+            if (names.size === 0) continue;
+            for (const [, tag] of code.matchAll(/customElements\.define\('(adw-[a-z-]+)'/g)) {
+                actual.set(tag, new Set([...(actual.get(tag) ?? []), ...names]));
+            }
+        }
+
+        if (actual.size === 0) {
+            slotProblems.push(
+                'no element source routes a named slot, which cannot be true while the pillar ships ' +
+                    '<adw-header-bar>. The slot reader stopped matching, and an empty comparison ' +
+                    'passes against anything.',
+            );
+        }
+
+        for (const [tag, names] of actual) {
+            const inSpec = declared.get(tag);
+            if (!inSpec) {
+                slotProblems.push(
+                    `<${tag}> routes [${[...names].sort().join(', ')}] and SLOT_ROUTES does not list it, ` +
+                        'so no test appends a slotted child to it after connect.',
+                );
+                continue;
+            }
+            for (const name of names) {
+                if (!inSpec.has(name)) {
+                    slotProblems.push(`<${tag}> routes a "${name}" slot that SLOT_ROUTES does not drive.`);
+                }
+            }
+            for (const name of inSpec) {
+                if (!names.has(name)) {
+                    slotProblems.push(
+                        `SLOT_ROUTES drives <${tag}> [slot="${name}"] and no source routes that name — ` +
+                            'a renamed slot leaves the test comparing two light-DOM children, which match.',
+                    );
+                }
+            }
+        }
+        for (const tag of declared.keys()) {
+            if (!actual.has(tag)) {
+                slotProblems.push(`SLOT_ROUTES lists <${tag}>, whose source routes no named slot at all.`);
+            }
+        }
+    }
+}
+
+if (slotProblems.length > 0) fail(slotProblems);
+
 if (problems.length > 0) fail(problems);
 
 // A floor, not a count: the point is that it grows without this file being edited. Zero
@@ -430,3 +525,4 @@ if (inScope === 0) {
 console.log(
     `check-adwaita-connect-rebind: OK — ${inScope} element class(es) with a teardown, across ${files.length} files, re-establish everything it releases.`,
 );
+console.log(`check-adwaita-connect-rebind: OK — SLOT_ROUTES in ${SPEC} matches the tree, both ways.`);


### PR DESCRIPTION
> **Stacked on #1278** (the `main`-unblocking bundle refresh). Base is `fix/refresh-affected-bundle`.

## The driver came first, and it went red

`ADR 0027 § 9` names late slot adoption as the **measured obstacle** to one authored tree driving both this pillar and the GTK host. It was measured by *reading*. The 70 greens in `connect-lifecycle.spec.ts`, each titled *"`<tag>` lays out a child appended after connect"*, append only into containers the element **built** — **not one of them appends a `[slot=]` child to the host**, which is the property the ADR is about. `adw-header-bar.spec.ts:71` even documents the workaround (*"the slotted children have to be in place before the bar enters the document"*) with nothing failing.

So this PR adds the driver, and against a parse-time control in Firefox **14 of the 15 (element, slot) pairs the pillar routes failed**:

```
<adw-toolbar-view>       [slot=top]      wanted div.adw-toolbar-view-top
<adw-header-bar>         [slot=start]    wanted div.adw-header-bar-start
<adw-overlay-split-view> [slot=content]  wanted div.adw-osv-content
                                     …   got  (light DOM)
```

The fifteenth is `<adw-preferences-group>`, which already observes its host's childList — so it is **both the exception and the proof** the driver measures something rather than failing everything.

**Why it looked placed and was not:** the child stays *visible*. It is simply in the wrong parent, unstyled and unordered. That is why `placement()` asserts the **parent path** against the declared control rather than the box — a box comparison alone passes on a child that renders fine in the wrong place.

## The fix, in one home

`slot-adoption.ts` applies the MutationObserver technique `<adw-clamp>` paid for first and `empty-sections.ts` generalised — to *placement* instead of `hidden`. The two are siblings, and for `<adw-toolbar-view>` **both were wrong at once and only one had been fixed**: `bindEmptySections` keeps the bar's `hidden` flag honest once a child is in it; this puts the child there.

Three details each cost a measurement:

- **Routes take a function, not just a section.** `<adw-entry-row>.addPrefix` *prepends* (`adw_entry_row_add_prefix` mirrors `gtk_box_prepend`), so handing the section over as an append target would silently reverse the order a declared prefix gets.
- **`afterAdopt` fires only when something moved.** `<adw-header-bar>` uses it to drop the automatic title the moment a real `slot="center"` widget arrives; its parse-time path chooses one *or* the other, so a late child sitting *beside* the auto title would render two titles where the declared form renders one.
- **The snapshot is required, and the linter says otherwise.** `host.children` is a live `HTMLCollection` and routing moves a child out of it, so iterating the collection renumbers under the loop and skips every second match. Disabled by name, with the reason.

## Also closed: the tautology next door

The same spec's per-tag test asserted `expect('<tag> ').toBe('<tag> ')` for every element with **no container getter** — a large share of those 70 greens, guarded only by an *aggregate* floor that cannot say which tag contributed one. The absence is now named, so each of them is a statement.

## And the table is held

A browser spec cannot read a `.ts` file, so which slots each element routes has to be written down in `SLOT_ROUTES`. Written down and unheld, that is the drift this repo keeps paying for: a renamed slot leaves the table naming one nothing routes, and the test **passes** because both children sit in the light DOM and match.

`check-adwaita-connect-rebind.mjs` — the spec's static sibling by its own header — reads the table back out and compares it against the sources **both ways**. Same shape as `check-adwaita-keyboard-contract.mjs`'s `ROVING_LEDGER`.

Its slot reader uses `stripComments`, **not** the script's own `maskNonCode`: that one blanks string *contents* too, and `querySelectorAll(':scope > [slot="start"]')` is a string. Read through it, all eight elements reported routing no slot at all — a reader finding nothing and reporting the tree as empty.

## Proof

**14 red before, 5 specs green after**, in Firefox, with the bundles rebuilt between. Every Adwaita gate re-run green: `connect-rebind`, `keyboard-contract`, `style-classes`, `conformance-drivers`, `reset-components`, `icon-masks`, `website-adwaita-gallery`, `storybook-control-parity`. `gjsify format --check` and `gjsify lint` clean.