### PR TITLE
fix(lint): exempt type-test fixtures from the caption rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -146,6 +146,11 @@
                 "**/test/**",
                 "**/*.test.*",
                 "**/*.spec.ts",
+                // A type-test fixture is COMPILE-ONLY: it is never constructed, never
+                // rendered, and its captions exist to be a type. `@ts-expect-error` makes
+                // the assertion, and a caption that had to route through `_()` would be
+                // asserting about gettext instead of about the type.
+                "**/type-tests/**",
                 "**/scripts/**",
                 "tests/**",
                 "examples/**",


### PR DESCRIPTION
## main is red

`gjsify(no-literal-widget-label)` errors on `packages/framework/gtk-host/type-tests/jsx/negative-handlers.tsx:27`, and `Whole-tree checks` has failed on every run of `main` since 68343022c — taking `CI gate (GJS)` with it, and every open PR's tree-checks along with it (#1276, #1277, #1279 all show the same single error).

## How two green PRs made a red main

The rule shipped in #1275 (12:22) with an exemption list — `**/test/**`, `**/*.spec.ts`, `tests/**`, `examples/**`, `showcases/**` — written against the tree **as it stood**. #1281 (12:24) added `packages/framework/gtk-host/type-tests/`, a directory that did not exist when that list was written.

Neither PR could see it. Each was linted against its own base; the interaction only exists in the merge of both. This is the same class as the comment-budget ratio: a whole-tree check plus two branches that each move a different half of the ratio.

## Why an exemption and not a rewrite of the fixture

The line is

```tsx
// @ts-expect-error TS2322 — `clicked` carries no arguments
export const tooManyParams = <gtk-button onClicked={(widget: Gtk.Button) => widget.set_label('x')} />;
```

`'x'` is not a caption. Nothing constructs this file — it is compiled by `scripts/check-type-surfaces.mjs` and thrown away, and its whole content is the `@ts-expect-error` above it. A caption routed through `_()` here would make the negative assert about gettext instead of about the parameter arity it exists to pin.

That is the same reason `**/test/**` and `tests/**` are already on the list, in the words of the list's own comment: *"a fixture or demo that exists to BE looked at … the second's captions are the test data."* `**/type-tests/**` belongs beside them, and covers the directory convention rather than this one file.

## Proof

`oxlint` over the whole tree: **1 error → 0 errors**, 60 warnings unchanged (the same 60 `main` reports). A/B: reverting the glob restores the error at the same file and column.

## What this does not fix

Nothing here stops the next instance. The general form — branch A enables a whole-tree check, branch B adds a file the check now rejects, both green — is only caught by requiring branches to be up to date before merge, which is a repository setting rather than a file in the tree.