### PR TITLE
fix(gtk-host): restore the constructed default, not the declared one

### DIFF
--- a/docs/adr/0027-gtk-host-layer.md
+++ b/docs/adr/0027-gtk-host-layer.md
@@ -74,7 +74,9 @@ gjsify owns a framework-agnostic GTK4/Adwaita host as a Tier-3 package,
    rotation appends the new child FIRST — detaching the tail before an append that
    can throw destroyed already-rendered siblings.
 4. **Values are coerced against the installed GTK's `GParamSpec`,** and every
-   silent failure is refused by name — thirteen codes today. A string enum nick
+   silent failure is refused by name, one code each — `src/errors.ts` IS the list,
+   and carries no count, because a hand-kept one drifts (it said thirteen while the
+   file held eighteen). A string enum nick
    that resolves is APPLIED; one that does not is `bad-enum`. `bad-boolean` and
    `bad-flags` refuse the two other types GObject mis-stores silently
    (`Boolean('false')` is TRUE). A signal name is checked against the CLASS, so a

--- a/docs/adr/0028-widget-table-provenance.md
+++ b/docs/adr/0028-widget-table-provenance.md
@@ -195,6 +195,29 @@ coercer and the verifier.**
    `<gtk-box orientation="vertical">` — the most-written GtkBox attribute there is —
    is a type error. The reader walks parents AND interfaces.
 
+10. **A table row is a claim that the widget can be BUILT, and one row was not.**
+    `AdwLayoutSlot` requires a construct-only `id`; without one, `constructed`
+    reaches `g_error()`, which is fatal by contract — SIGABRT, exit 134, a core
+    dump, and nothing to catch. GIR cannot tell that apart from any other
+    construct-only nullable property, and `descriptorProblems()` reads policy
+    without ever instantiating, so the row was green in a 1746-test suite that
+    constructed **none** of the 164. Bare-constructing all of them measures 163
+    clean and no throws at all, so the requirement is CURATED as one entry
+    (`REQUIRED_CONSTRUCT_PROPS`), refused in `materialize` by name, and the
+    construct-every-row test is what keeps the entry count honest.
+
+11. **A signal parameter has a DIRECTION, and three of them carry nothing.**
+    GIR marks `Gtk.SpinButton::input`, `Adw.SpinRow::input` and
+    `Gtk.Editable::insert-text` with a non-`in` parameter at
+    `caller-allocates="0"`. GJS still passes an argument there and it holds
+    uninitialised memory — measured, `new_value` arrives as `6.95e-310` and
+    `position` as `1711500784`, both perfectly ordinary numbers. Typing them from
+    the GIR type invites a reading that is garbage, and nothing warns. They are
+    emitted as `OutParam` instead: declared, so the following parameters do not
+    shift, and unreadable, so annotating `number` is an error at that position.
+    `caller-allocates="1"` is the opposite case and keeps its type —
+    `Gtk.Overlay::get-child-position` is handed a live `Gdk.Rectangle` to FILL.
+
 ## Consequences
 
 - The normal disagreement between table and runtime is **version skew** — a user's

--- a/packages/framework/gtk-host/src/attrs.ts
+++ b/packages/framework/gtk-host/src/attrs.ts
@@ -19,6 +19,28 @@ import type { HostNode } from './types.js';
  */
 export type NotifyHandler = (pspec: GObject.ParamSpec) => void;
 
+declare const outParam: unique symbol;
+
+/**
+ * A signal parameter GIR declares `out`/`inout` with `caller-allocates="0"`.
+ *
+ * GJS still passes an argument in that position, and what it holds is whatever
+ * was in the memory the marshaller allocated: measured on gjs 1.88.1 / GTK
+ * 4.22.4, a handler on `Gtk.SpinButton::input` receives `new_value` as
+ * `6.9526682391035e-310`, and one on `Gtk.Editable::insert-text` receives
+ * `position` as `1711500784`. Both arrive as ordinary numbers. Nothing warns.
+ *
+ * So the slot is DECLARED — dropping it would silently shift every parameter
+ * after it — and given a type nothing can be read out of, and nothing but
+ * itself assigns to. Annotating the parameter `number` is then a compile error
+ * naming the position, which is the only place a reader would have looked.
+ *
+ * `caller-allocates="1"` is a different thing and keeps its real type: there the
+ * callee is handed a live object to FILL, as `Gtk.Overlay::get-child-position`
+ * is handed a `Gdk.Rectangle`.
+ */
+export type OutParam = { readonly [outParam]: never };
+
 /**
  * What may appear as a child, mirroring Solid's own `JSX.Element`.
  *

--- a/packages/framework/gtk-host/src/conformance.spec.ts
+++ b/packages/framework/gtk-host/src/conformance.spec.ts
@@ -4,7 +4,7 @@ import { expect, it, on } from '@gjsify/unit';
 
 import Gtk from 'gi://Gtk?version=4.0';
 
-import { descriptorProblems, installDiagnosticsGate, methodsOf } from './conformance/index.js';
+import { descriptorProblems, describeLogRecord, installDiagnosticsGate, methodsOf } from './conformance/index.js';
 import { gated } from './testing/gate.mjs';
 import { lookupWidget, registeredTags } from './registry.js';
 import type { WidgetDescriptor } from './types.js';
@@ -20,6 +20,38 @@ export default async () => {
         // neighbour twelve tests later. `gated` registers the hooks INSIDE the
         // describe, where @gjsify/unit actually keeps them.
         const diagnostics = installDiagnosticsGate();
+
+        await it('describes every record it counts, MESSAGE field or not', async () => {
+            // `MESSAGE` is a structured field like any other and a record may arrive
+            // without one. The first version answered `String(raw ?? '')`, so such a
+            // record was COUNTED and then described as nothing: a CI run failed with
+            // "GTK reported 1 diagnostic(s) that would have passed at exit 0:" and a
+            // blank list, right after a test that had constructed 164 widgets. A
+            // count without a name sends the reader back to guessing, which is the
+            // state this module exists to end.
+            //
+            // Tested on the renderer directly rather than by emitting a real record:
+            // `GLib.log_structured_array` wants `GLib.LogField` structs GJS cannot
+            // build from object literals ("not a subclass of GObject_Struct").
+            const encode = (text: string) => new TextEncoder().encode(text);
+            expect(describeLogRecord({ MESSAGE: encode('a plain warning') })).toBe('a plain warning');
+            expect(describeLogRecord({ MESSAGE: 'already a string' })).toBe('already a string');
+            // The three shapes that used to render as the empty string.
+            const empties = [
+                { GLIB_DOMAIN: encode('gtk-host-probe') },
+                { MESSAGE: null, GLIB_DOMAIN: 'x' },
+                { MESSAGE: '' },
+            ];
+            for (const record of empties) {
+                const answer = describeLogRecord(record);
+                expect(answer.includes('no MESSAGE')).toBe(true);
+                expect(answer.trim().length > 0).toBe(true);
+            }
+            expect(describeLogRecord({ GLIB_DOMAIN: encode('gtk-host-probe') }).includes('gtk-host-probe')).toBe(true);
+            // A record with nothing at all still says so, rather than ''.
+            expect(describeLogRecord(null).length > 0).toBe(true);
+            expect(describeLogRecord({}).length > 0).toBe(true);
+        });
 
         await gated(diagnostics, 'descriptor table vs installed typelib', async () => {
             await it('every declared method and text sink exists', async () => {

--- a/packages/framework/gtk-host/src/conformance/diagnostics.ts
+++ b/packages/framework/gtk-host/src/conformance/diagnostics.ts
@@ -39,6 +39,37 @@ let installed: DiagnosticsGate | null = null;
  * what GLib's default writer does with `G_MESSAGES_DEBUG` unset: message-and-above
  * is printed, info/debug is not.
  */
+/**
+ * What a log record SAYS — and never the empty string.
+ *
+ * `MESSAGE` is a structured field like any other, and a record is allowed to
+ * arrive without one. The first version answered `String(raw ?? '')`, so such a
+ * record was counted and then described as nothing: a CI run failed with
+ * `GTK reported 1 diagnostic(s) that would have passed at exit 0:` followed by a
+ * BLANK LIST, over a test that had just constructed 164 widgets. A gate that can
+ * count a failure but not name it sends the reader back to guessing, which is the
+ * state this whole module exists to end.
+ *
+ * So a record with no `MESSAGE` is rendered from the fields it does carry.
+ */
+export function describeLogRecord(fields: unknown, decoder: TextDecoder = new TextDecoder()): string {
+    const text = (value: unknown): string => (value instanceof Uint8Array ? decoder.decode(value) : String(value));
+    const record = fields as Record<string, unknown> | null;
+    const raw = record?.MESSAGE;
+    if (raw !== undefined && raw !== null) {
+        const message = text(raw);
+        if (message !== '') return message;
+    }
+    const rest = record
+        ? Object.keys(record)
+              .filter((key) => key !== 'MESSAGE' && record[key] !== undefined && record[key] !== null)
+              .map((key) => `${key}=${text(record[key])}`)
+        : [];
+    return rest.length > 0
+        ? `<no MESSAGE field> ${rest.join(' ')}`
+        : '<a log record with no MESSAGE and no other field>';
+}
+
 export function installDiagnosticsGate(): DiagnosticsGate {
     if (installed) return installed;
 
@@ -49,8 +80,7 @@ export function installDiagnosticsGate(): DiagnosticsGate {
     GLib.log_set_writer_func((level, fields) => {
         // A throw in here is logged, which re-enters this function.
         try {
-            const raw = (fields as unknown as { MESSAGE?: unknown } | null)?.MESSAGE;
-            const message = raw instanceof Uint8Array ? decoder.decode(raw) : String(raw ?? '');
+            const message = describeLogRecord(fields, decoder);
             // MASK the level: `g_logv` ORs in `G_LOG_FLAG_FATAL` when the level is
             // in the fatal mask, so `WARNING|FATAL` is 18 and an unmasked `<= 16`
             // stops recording exactly the messages this exists to catch — under

--- a/packages/framework/gtk-host/src/conformance/index.ts
+++ b/packages/framework/gtk-host/src/conformance/index.ts
@@ -1,4 +1,4 @@
-export { installDiagnosticsGate, type DiagnosticsGate } from './diagnostics.js';
+export { describeLogRecord, installDiagnosticsGate, type DiagnosticsGate } from './diagnostics.js';
 // Conformance surface: the checks that keep the widget table honest, and the
 // GTK-side readers every vector asserts against.
 //

--- a/packages/framework/gtk-host/src/descriptors/index.ts
+++ b/packages/framework/gtk-host/src/descriptors/index.ts
@@ -32,6 +32,27 @@ export const CURATED_DESCRIPTORS: readonly WidgetDescriptor[] = [...GTK_DESCRIPT
  * and `set_child` all exist somewhere in GTK, and calling the wrong one is a
  * warning at exit 0.
  */
+/**
+ * Construct-only properties a GType ABORTS the process without.
+ *
+ * Not an exception: `adw_layout_slot_constructed` calls `g_error()`, which is
+ * fatal by contract — no catch, no diagnostic, SIGABRT and a core dump. A table
+ * that merely LISTS such a tag hands a renderer a way to kill the process, and
+ * `descriptorProblems()` cannot see it because it never instantiates anything.
+ *
+ * MEASURED bare-constructing all 164 generated rows on gjs 1.88.1 / GTK 4.22.4 /
+ * Adw 1.10, resuming past each abort: **163 construct, one does not**, and not a
+ * single row throws. So this map is one entry rather than a policy — and
+ * `constructsEveryDescriptor` in `generated.spec.ts` is what keeps it one entry.
+ *
+ * CURATED, like every other placement fact: the GIR says `id` is construct-only
+ * and nullable, which is exactly what it says about properties that construct
+ * fine. Only running it tells them apart (ADR 0028 § 1).
+ */
+export const REQUIRED_CONSTRUCT_PROPS: Readonly<Record<string, readonly string[]>> = {
+    AdwLayoutSlot: ['id'],
+};
+
 export function mergeGenerated(
     curated: readonly WidgetDescriptor[],
     generated: readonly GeneratedWidget[],
@@ -40,7 +61,13 @@ export function mergeGenerated(
     const known = new Set(curated.map((d) => d.gtype));
     for (const w of generated) {
         if (known.has(w.gtype)) continue;
-        out.push({ gtype: w.gtype, ctor: w.ctor, children: { kind: 'uncurated' } });
+        const requiresProps = REQUIRED_CONSTRUCT_PROPS[w.gtype];
+        out.push({
+            gtype: w.gtype,
+            ctor: w.ctor,
+            children: { kind: 'uncurated' },
+            ...(requiresProps ? { requiresProps } : {}),
+        });
     }
     return out;
 }

--- a/packages/framework/gtk-host/src/errors.ts
+++ b/packages/framework/gtk-host/src/errors.ts
@@ -26,6 +26,14 @@ export const err = {
             `No descriptor registered for <${tag}>. Register one with registerWidget({ gtype: '${tag}', … }) ` +
                 `or use a raw GType tag that is present in the installed typelib.`,
         ),
+    missingConstructProp: (tag: string, prop: string) =>
+        new GtkHostError(
+            'missing-construct-prop',
+            `<${tag}> cannot be constructed without ${prop}. In the installed library this is not an ` +
+                `exception but a g_error(): the process ABORTS (SIGABRT, exit 134, core dump) with no ` +
+                `catch and no diagnostic, so the host refuses here while a refusal is still reportable. ` +
+                `Author ${prop} on the element.`,
+        ),
     unknownProp: (tag: string, prop: string) =>
         new GtkHostError(
             'unknown-prop',

--- a/packages/framework/gtk-host/src/errors.ts
+++ b/packages/framework/gtk-host/src/errors.ts
@@ -23,8 +23,14 @@ export const err = {
     unknownTag: (tag: string) =>
         new GtkHostError(
             'unknown-tag',
-            `No descriptor registered for <${tag}>. Register one with registerWidget({ gtype: '${tag}', … }) ` +
-                `or use a raw GType tag that is present in the installed typelib.`,
+            `No descriptor registered for <${tag}>. Register one with registerWidget({ gtype: '${tag}', … }). ` +
+                // NOT "or use a raw GType tag": `lookupWidget` is a Map.get and nothing
+                // else — there is no `GObject.type_from_name` anywhere in this package —
+                // so a real, installed GType name lands right back here. That is ADR
+                // 0028's decision, not an omission ("As a TAG it does not: createElement
+                // looks the GType name up exactly"), and the hierarchy walk that DOES
+                // exist, `nearestRegistered`, only ever answers for a mount container.
+                `Being a real GType in the installed typelib is not enough on its own.`,
         ),
     missingConstructProp: (tag: string, prop: string) =>
         new GtkHostError(

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -140,12 +140,20 @@ export default async () => {
                 // line names the tag instead of a core dump nobody attributes.
                 const required = new Map(Object.entries(REQUIRED_CONSTRUCT_PROPS));
                 const failed: string[] = [];
+                // Diagnostics are drained PER ROW, not left to the gate at the end
+                // of the test. Same assertion, with the one thing the gate cannot
+                // give: a name. Measured — a first CI run failed here with
+                // "GTK reported 1 diagnostic(s)" over 164 constructions and no way
+                // to tell which, while the same sweep is silent on a workstation
+                // both with and without a session bus.
+                const noisy: string[] = [];
                 for (const w of GENERATED_WIDGETS) {
                     // Through the HOST, not through `new w.ctor()`: `materialize` is
                     // where the refusal lives, so constructing around it would leave
                     // the guard itself unchecked.
                     const props: Record<string, unknown> = {};
                     for (const name of required.get(w.gtype) ?? []) props[name] = 'probe';
+                    diagnostics.reset();
                     try {
                         // Left alive on purpose — NOT destroyed, NOT `run_dispose()`d.
                         //
@@ -168,8 +176,11 @@ export default async () => {
                     } catch (error) {
                         failed.push(`${w.gtype}: ${(error as Error).message}`);
                     }
+                    if (diagnostics.seen.length > 0) noisy.push(`${w.gtype}: ${diagnostics.seen.join(' | ')}`);
+                    diagnostics.reset();
                 }
                 expect(failed).toStrictEqual([]);
+                expect(noisy).toStrictEqual([]);
                 expect(required.size).toBe(1);
             });
 

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -147,6 +147,25 @@ export default async () => {
                 // to tell which, while the same sweep is silent on a workstation
                 // both with and without a session bus.
                 const noisy: string[] = [];
+                // The ONE exemption, and it is about the machine rather than the
+                // widget. `GtkColorChooserDialog`'s eyedropper asks the Screenshot
+                // portal for its version; a CI container has a D-Bus session and no
+                // `xdg-desktop-portal` behind it, so GTK warns:
+                //
+                //   Cannot get portal org.freedesktop.portal.Screenshot version:
+                //   GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such
+                //   interface “org.freedesktop.portal.Screenshot”
+                //
+                // Measured, and the third state is why it took a CI run to see: with
+                // a portal it is silent, with NO session bus at all it is silent
+                // (GTK never asks), and only with a bus that answers without the
+                // interface does it warn. Stripping DBUS_SESSION_BUS_ADDRESS on a
+                // workstation reproduces the second state, not the container's.
+                //
+                // Scoped to the MESSAGE, not to the widget: any widget reaching a
+                // portal produces this, and `GtkColorChooserDialog` stays under test
+                // for everything else it might say.
+                const missingPortal = /^Cannot get portal org\.freedesktop\.portal\./;
                 for (const w of GENERATED_WIDGETS) {
                     // Through the HOST, not through `new w.ctor()`: `materialize` is
                     // where the refusal lives, so constructing around it would leave
@@ -176,12 +195,18 @@ export default async () => {
                     } catch (error) {
                         failed.push(`${w.gtype}: ${(error as Error).message}`);
                     }
-                    if (diagnostics.seen.length > 0) noisy.push(`${w.gtype}: ${diagnostics.seen.join(' | ')}`);
+                    const said = diagnostics.seen.filter((message) => !missingPortal.test(message));
+                    if (said.length > 0) noisy.push(`${w.gtype}: ${said.join(' | ')}`);
                     diagnostics.reset();
                 }
                 expect(failed).toStrictEqual([]);
                 expect(noisy).toStrictEqual([]);
                 expect(required.size).toBe(1);
+                // The exemption is NARROW — it must not swallow an ordinary GTK
+                // warning, which is the whole reason the sweep exists.
+                expect(missingPortal.test('Cannot get portal org.freedesktop.portal.Screenshot version: x')).toBe(true);
+                expect(missingPortal.test('Trying to snapshot GtkButton without a current allocation')).toBe(false);
+                expect(missingPortal.test('gtk_box_append: assertion failed')).toBe(false);
             });
 
             await it('refuses a fatal construction by name instead of aborting', async () => {

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -19,7 +19,13 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { installDiagnosticsGate } from './conformance/index.js';
-import { BUILTIN_DESCRIPTORS, CURATED_DESCRIPTORS, GENERATED_WIDGETS } from './descriptors/index.js';
+import {
+    BUILTIN_DESCRIPTORS,
+    CURATED_DESCRIPTORS,
+    GENERATED_WIDGETS,
+    REQUIRED_CONSTRUCT_PROPS,
+} from './descriptors/index.js';
+import { createElement, materialize } from './host.js';
 import { DECLS, ENUM_NICKS, OWN_PROPS, OWN_SIGNALS, SINCE, TAGS } from './generated/surface-data.mjs';
 import { camelOf, eventPropOf } from './generator/tsmap.mjs';
 import { isWritable, lookupEnumNick, paramSpecs } from './props.js';
@@ -119,6 +125,61 @@ export default async () => {
                     expect(hasWidget(w.tag)).toBe(true);
                     expect(lookupWidget(w.tag) === lookupWidget(w.gtype)).toBe(true);
                 }
+            });
+
+            await it('constructs every row it offers', async () => {
+                // The check the table did not have, and the reason it shipped a row
+                // that KILLS THE PROCESS. `descriptorProblems()` reads policy and
+                // never instantiates, so `AdwLayoutSlot` — whose `constructed` calls
+                // `g_error("AdwLayoutSlot %p created without an ID")`, fatal by
+                // contract, SIGABRT and a core dump — was green in a 1746-test suite.
+                //
+                // Measured bare over all 164 rows on gjs 1.88.1 / GTK 4.22.4 / Adw
+                // 1.10: 163 construct and not one throws. So a REGRESSION here is a
+                // new abort, and this test is what turns it into a failure whose last
+                // line names the tag instead of a core dump nobody attributes.
+                const required = new Map(Object.entries(REQUIRED_CONSTRUCT_PROPS));
+                const failed: string[] = [];
+                for (const w of GENERATED_WIDGETS) {
+                    // Through the HOST, not through `new w.ctor()`: `materialize` is
+                    // where the refusal lives, so constructing around it would leave
+                    // the guard itself unchecked.
+                    const props: Record<string, unknown> = {};
+                    for (const name of required.get(w.gtype) ?? []) props[name] = 'probe';
+                    try {
+                        // Left alive on purpose — NOT destroyed, NOT `run_dispose()`d.
+                        //
+                        // `installDiagnosticsGate` sets a process-global JS log writer
+                        // and never takes it back, so any widget GJS finalises during
+                        // SHUTDOWN prints `Gjs-CRITICAL: Attempting to run a JS callback
+                        // during shutdown` on stderr, after the summary. Severing a
+                        // widget's internals is what schedules that: measured one row
+                        // per process over all 164, disposing makes EIGHT of them do it
+                        // (AdwComboRow, GtkColumnView, GtkEditableLabel, GtkEmojiChooser,
+                        // GtkScrollbar, GtkColorChooserDialog, GtkColorChooserWidget,
+                        // GtkFileChooserWidget) and leaving them alone makes TWO
+                        // (GtkColorChooserWidget, GtkEmojiChooser).
+                        //
+                        // Two leaked-by-design lines beat eight, in a process that exits
+                        // seconds later; neither is the host's doing, and skipping the
+                        // two rows would trade the noise for the blindness this test
+                        // exists to remove.
+                        materialize(createElement(w.tag, props));
+                    } catch (error) {
+                        failed.push(`${w.gtype}: ${(error as Error).message}`);
+                    }
+                }
+                expect(failed).toStrictEqual([]);
+                expect(required.size).toBe(1);
+            });
+
+            await it('refuses a fatal construction by name instead of aborting', async () => {
+                // A/B for the guard above: without `requiresProps` this call does not
+                // throw — it ends the process. The assertion is that it is an ERROR.
+                expect(() => materialize(createElement('adw-layout-slot'))).toThrow(/cannot be constructed without id/);
+                // And the requirement is a REQUIREMENT, not a ban: with the id, it builds.
+                const slot = materialize(createElement('adw-layout-slot', { id: 'probe' }));
+                expect(slot instanceof Adw.LayoutSlot).toBe(true);
             });
 
             await it('names a real class for every tag', async () => {

--- a/packages/framework/gtk-host/src/generated/props.ts
+++ b/packages/framework/gtk-host/src/generated/props.ts
@@ -17,7 +17,7 @@ import type Gio from '@girs/gio-2.0';
 import type Gtk from '@girs/gtk-4.0';
 import type Pango from '@girs/pango-1.0';
 
-import type { NotifyHandler } from '../attrs.js';
+import type { NotifyHandler, OutParam } from '../attrs.js';
 
 // Enum nicks. A property takes the nick OR the enum constant; a signal parameter
 // takes the constant only, because GJS hands the marshalled number and a nick
@@ -1665,7 +1665,7 @@ export interface AdwSpinRowProps
     /** Whether the spin row should wrap upon reaching its limits. */
     wrap?: boolean;
     /** Emitted to convert the user's input into a double value. */
-    onInput?: (new_value: number) => void;
+    onInput?: (new_value: OutParam) => void;
     /** Emitted to tweak the formatting of the value for display. */
     onOutput?: () => void;
     /** Emitted right after the spinbutton wraps. */
@@ -3004,7 +3004,7 @@ export interface GtkEditableProps extends GtkWidgetProps {
     /** Emitted when text is deleted from the widget by the user. */
     onDeleteText?: (start_pos: number, end_pos: number) => void;
     /** Emitted when text is inserted into the widget by the user. */
-    onInsertText?: (text: string, length: number, position: number) => void;
+    onInsertText?: (text: string, length: number, position: OutParam) => void;
     onNotifyEditable?: NotifyHandler;
     onNotifyEnableUndo?: NotifyHandler;
     onNotifyMaxWidthChars?: NotifyHandler;
@@ -5082,7 +5082,7 @@ export interface GtkSpinButtonProps
     /** Emitted when the user initiates a value change. */
     onChangeValue?: (scroll: Gtk.ScrollType) => void;
     /** Emitted to convert the users input into a double value. */
-    onInput?: (new_value: number) => void;
+    onInput?: (new_value: OutParam) => void;
     /** Emitted to tweak the formatting of the value for display. */
     onOutput?: () => void;
     /** Emitted when the value is changed. */

--- a/packages/framework/gtk-host/src/generator/emit-types.mts
+++ b/packages/framework/gtk-host/src/generator/emit-types.mts
@@ -120,6 +120,10 @@ export function emitProps(model: SurfaceModel, provenance: string): EmittedFile 
         });
 
     const decls = [...model.declarations.values()].sort((a, b) => (a.iface < b.iface ? -1 : 1));
+    // `noUnusedLocals` refuses an import nothing reads, and a GIR whose signals are
+    // all `in` produces exactly that file — the mini fixture is one.
+    const usesOutParam = decls.some((d) => d.signals.some((s) => s.ts.includes(': OutParam')));
+    const hostTypes = usesOutParam ? 'NotifyHandler, OutParam' : 'NotifyHandler';
     const byTag: string[] = [];
     const byGType: string[] = [];
     const classByTag: string[] = [];
@@ -145,7 +149,7 @@ export function emitProps(model: SurfaceModel, provenance: string): EmittedFile 
 
 ${imports.join('\n')}
 
-import type { NotifyHandler } from '../attrs.js';
+import type { ${hostTypes} } from '../attrs.js';
 
 // Enum nicks. A property takes the nick OR the enum constant; a signal parameter
 // takes the constant only, because GJS hands the marshalled number and a nick

--- a/packages/framework/gtk-host/src/generator/gir.mts
+++ b/packages/framework/gtk-host/src/generator/gir.mts
@@ -58,6 +58,13 @@ export interface GirProperty {
 export interface GirParam {
     readonly name: string;
     readonly type: GirType;
+    /** GIR's `direction`, which defaults to `in` when the attribute is absent. */
+    readonly direction: 'in' | 'out' | 'inout';
+    /**
+     * GIR's `caller-allocates`. It decides whether a non-`in` slot holds anything
+     * at all — see `renderParam` in `surface.mts`, which is the only reader.
+     */
+    readonly callerAllocates: boolean;
 }
 
 export interface GirSignal {
@@ -185,6 +192,11 @@ function readProperty(namespace: string, el: El): GirProperty {
     };
 }
 
+function readDirection(el: El): 'in' | 'out' | 'inout' {
+    const raw = el.getAttribute('direction');
+    return raw === 'out' || raw === 'inout' ? raw : 'in';
+}
+
 function readSignal(namespace: string, el: El): GirSignal {
     const params = firstChildEl(el, 'parameters');
     return {
@@ -193,6 +205,8 @@ function readSignal(namespace: string, el: El): GirSignal {
             ? ownChildren(params, 'parameter').map((p) => ({
                   name: p.getAttribute('name') ?? '',
                   type: readType(namespace, p),
+                  direction: readDirection(p),
+                  callerAllocates: p.getAttribute('caller-allocates') === '1',
               }))
             : [],
         deprecated: el.getAttribute('deprecated') === '1',

--- a/packages/framework/gtk-host/src/generator/surface.mts
+++ b/packages/framework/gtk-host/src/generator/surface.mts
@@ -137,6 +137,19 @@ export function buildSurface(
         for (const s of cls.signals) {
             const rendered: string[] = [];
             for (const [i, param] of s.params.entries()) {
+                // A non-`in` slot the CALLEE allocates carries nothing on the way in.
+                // Measured on gjs 1.88.1 / GTK 4.22.4: `Gtk.SpinButton::input` hands its
+                // `new_value` as 6.95e-310 — uninitialised memory, arriving as a
+                // perfectly ordinary `number`. Typing it `number` is an invitation to
+                // read it, and the reader gets no warning of any kind.
+                //
+                // `caller-allocates="1"` is the opposite case and is NOT rewritten:
+                // `Gtk.Overlay::get-child-position` hands a real `Gdk.Rectangle` for the
+                // handler to FILL, and the whole point of the signal is writing to it.
+                if (param.direction !== 'in' && !param.callerAllocates) {
+                    rendered.push(`${safeParamName(param.name, i)}: OutParam`);
+                    continue;
+                }
                 let mapped: ReturnType<typeof tsTypeOf>;
                 try {
                     mapped = tsTypeOf(param.type, universe, 'param');

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -535,10 +535,13 @@ export default async () => {
                 expect((widget.get_child() as Gtk.Label).label).toBe('L1');
             });
 
-            await it('removing a prop resets it to the ParamSpec default', async () => {
+            await it('removing a prop resets it to what construction leaves behind', async () => {
                 // React hands `undefined` for a prop that disappeared, and
                 // set_property(name, undefined) throws "Could not guess
-                // unspecified GValue type".
+                // unspecified GValue type". `GtkLabel:label` is one of the
+                // properties where the ParamSpec and construction AGREE (both
+                // `''`), so this vector cannot tell the two sources apart — the
+                // ones that can are in props.spec.ts under `removedValue`.
                 const label = createElement('GtkLabel', { label: 'set' });
                 const widget = materialize(label) as unknown as Gtk.Label;
                 expect(widget.label).toBe('set');

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -90,6 +90,11 @@ export const isText = (node: HostNode): node is HostText => node.kind === 'text'
  */
 export function materialize(el: HostElement): GObject.Object {
     if (el.widget) return el.widget;
+    // Before `new Klass`, because for these GTypes there IS no after: a missing
+    // construct-only property reaches `g_error()` and takes the process with it.
+    for (const name of el.descriptor.requiresProps ?? []) {
+        if (!(name in el.props)) throw err.missingConstructProp(el.descriptor.gtype, name);
+    }
     const Klass = el.descriptor.ctor();
     const specs = paramSpecs(Klass, el.descriptor.gtype);
     const initial: Record<string, unknown> = {};

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -21,7 +21,7 @@ import {
     type Placement,
 } from './policies.js';
 import { beginHostWrite, clearHandlers, endHostWrite, isEventProp, setHandler, toSignalName } from './signals.js';
-import { coerce, defaultValue, paramSpecs, requireSpec, toPropertyName } from './props.js';
+import { coerce, paramSpecs, removedValue, requireSpec, toPropertyName } from './props.js';
 import { lookupWidget, nearestRegistered } from './registry.js';
 import type { HostAnchor, HostElement, HostNode, HostText, WidgetDescriptor } from './types.js';
 
@@ -199,8 +199,9 @@ export function setProp(el: HostElement, key: string, next: unknown, _prev?: unk
     const spec = requireSpec(specs, el.descriptor.gtype, name);
     // A renderer removing a prop hands `undefined`, which GObject cannot store:
     // `set_property(name, undefined)` throws "Could not guess unspecified GValue
-    // type" (measured). The ParamSpec's own default is what "removed" means.
-    const value = next === undefined ? defaultValue(spec) : coerce(spec, next, el.descriptor.gtype);
+    // type" (measured). What "removed" means is what CONSTRUCTION leaves behind
+    // — see `removedValue`, and the 104 places the ParamSpec disagrees with it.
+    const value = next === undefined ? removedValue(el.descriptor, spec) : coerce(spec, next, el.descriptor.gtype);
 
     const previouslyRecorded = name in el.props ? el.props[name] : undefined;
     if (next === undefined) delete el.props[name];

--- a/packages/framework/gtk-host/src/props.spec.ts
+++ b/packages/framework/gtk-host/src/props.spec.ts
@@ -3,12 +3,14 @@
 import { expect, it, on } from '@gjsify/unit';
 
 import Gtk from 'gi://Gtk?version=4.0';
+// Type position only — the descriptors pull Adw in for value use themselves.
+import type Adw from 'gi://Adw?version=1';
 
 import { installDiagnosticsGate } from './conformance/index.js';
 import { gated } from './testing/gate.mjs';
 import { GtkHostError } from './errors.js';
 import { createElement, materialize, setProp } from './host.js';
-import { constructOnlyNames, paramSpecs, toPropertyName } from './props.js';
+import { constructOnlyNames, paramSpecs, removedValue, toPropertyName } from './props.js';
 import { registerBuiltinWidgets } from './descriptors/index.js';
 
 export default async () => {
@@ -129,6 +131,21 @@ export default async () => {
                 expect(() => setProp(entry, 'input-hints', 'spellcheck')).toThrow('flags type');
             });
 
+            await it('refuses a real installed GType that carries no descriptor', async () => {
+                // `AdwClamp` is in the typelib and has no descriptor. It stays an
+                // `unknown-tag` — ADR 0028's decision — which is why the error text
+                // no longer offers "use a raw GType tag" as a way out.
+                expect(() => createElement('AdwClamp')).toThrow('registerWidget');
+                let caught: unknown;
+                try {
+                    createElement('AdwClamp');
+                } catch (e) {
+                    caught = e;
+                }
+                expect((caught as GtkHostError).code).toBe('unknown-tag');
+                expect((caught as GtkHostError).message.includes('raw GType tag')).toBe(false);
+            });
+
             await it('reports refusals as GtkHostError with a code', async () => {
                 const btn = createElement('GtkButton');
                 materialize(btn);
@@ -140,6 +157,69 @@ export default async () => {
                 }
                 expect(caught instanceof GtkHostError).toBe(true);
                 expect((caught as GtkHostError).code).toBe('unknown-prop');
+            });
+        });
+
+        await gated(diagnostics, 'removedValue', async () => {
+            // A descriptor is what `removedValue` keys on, so the vectors below go
+            // through the registry rather than hand-building one.
+            const descriptorFor = (gtype: string) => {
+                const el = createElement(gtype);
+                materialize(el);
+                return el.descriptor;
+            };
+
+            await it('answers with the CONSTRUCTED value where the ParamSpec disagrees', async () => {
+                // The four behavioural disagreements, named so a future GTK that
+                // changes one of them fails by name instead of drifting quietly.
+                // Measured on gjs 1.88.1 / GTK 4.22.4 / Adw 1.10.
+                const vectors: ReadonlyArray<readonly [string, string, unknown, unknown]> = [
+                    // gtype, property, ParamSpec says, construction says
+                    ['AdwActionRow', 'activatable', true, false],
+                    ['GtkWindow', 'visible', true, false],
+                    ['GtkToggleButton', 'receives-default', false, true],
+                    ['GtkListBox', 'focusable', false, true],
+                ];
+                for (const [gtype, prop, fromSpec, fromConstruction] of vectors) {
+                    const descriptor = descriptorFor(gtype);
+                    const spec = paramSpecs(descriptor.ctor(), descriptor.gtype).get(prop);
+                    expect(spec === undefined).toBe(false);
+                    // The premise: these two really do disagree on this GTK. Without
+                    // it the assertion below is satisfied by either implementation.
+                    expect((spec as unknown as { get_default_value(): unknown }).get_default_value()).toBe(fromSpec);
+                    expect(removedValue(descriptor, spec as never)).toBe(fromConstruction);
+                }
+            });
+
+            await it('falls back to the ParamSpec for a value construction cannot report', async () => {
+                // `child` is object-valued, so no probe reads it and the ParamSpec
+                // is the only answer. This is the arm that keeps a removal working
+                // rather than throwing when the probe has nothing to say.
+                const descriptor = descriptorFor('GtkFrame');
+                const spec = paramSpecs(descriptor.ctor(), descriptor.gtype).get('child');
+                expect(spec === undefined).toBe(false);
+                expect(removedValue(descriptor, spec as never)).toBe(null);
+            });
+
+            await it('removing `activatable` leaves the row NOT activatable', async () => {
+                // The end-to-end shape of the defect: with the ParamSpec as the
+                // source, `activatable={cond}` going undefined turned a row that had
+                // never been activatable INTO one, at exit 0.
+                const row = createElement('AdwActionRow', { activatable: true });
+                const widget = materialize(row) as unknown as Adw.ActionRow;
+                expect(widget.activatable).toBe(true);
+                setProp(row, 'activatable', undefined);
+                expect(widget.activatable).toBe(false);
+            });
+
+            await it('removing `receives-default` leaves a toggle button receiving it', async () => {
+                // The opposite polarity, so a fix that merely inverted the boolean
+                // cannot satisfy both vectors.
+                const btn = createElement('GtkToggleButton', { 'receives-default': false });
+                const widget = materialize(btn) as unknown as Gtk.ToggleButton;
+                expect(widget.receivesDefault).toBe(false);
+                setProp(btn, 'receives-default', undefined);
+                expect(widget.receivesDefault).toBe(true);
             });
         });
     });

--- a/packages/framework/gtk-host/src/props.spec.ts
+++ b/packages/framework/gtk-host/src/props.spec.ts
@@ -2,6 +2,7 @@
 
 import { expect, it, on } from '@gjsify/unit';
 
+import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk?version=4.0';
 // Type position only — the descriptors pull Adw in for value use themselves.
 import type Adw from 'gi://Adw?version=1';
@@ -12,6 +13,7 @@ import { GtkHostError } from './errors.js';
 import { createElement, materialize, setProp } from './host.js';
 import { constructOnlyNames, paramSpecs, removedValue, toPropertyName } from './props.js';
 import { registerBuiltinWidgets } from './descriptors/index.js';
+import { hasWidget } from './registry.js';
 
 export default async () => {
     await on('Gjs', async () => {
@@ -132,13 +134,19 @@ export default async () => {
             });
 
             await it('refuses a real installed GType that carries no descriptor', async () => {
-                // `AdwClamp` is in the typelib and has no descriptor. It stays an
-                // `unknown-tag` — ADR 0028's decision — which is why the error text
-                // no longer offers "use a raw GType tag" as a way out.
-                expect(() => createElement('AdwClamp')).toThrow('registerWidget');
+                // NOT `AdwClamp` — it is a concrete GtkWidget descendant, so the
+                // generated table has carried it since #1281 and pinning it here
+                // would assert the opposite of what it says. `GtkAdjustment` is
+                // real, installed, and not a widget, which is the durable version
+                // of the same claim: being in the typelib is not enough, and the
+                // error text no longer offers "use a raw GType tag" as a way out
+                // (ADR 0028 — `createElement` looks the GType up exactly).
+                expect(hasWidget('AdwClamp')).toBe(true);
+                expect(GObject.type_name(Gtk.Adjustment.$gtype)).toBe('GtkAdjustment');
+                expect(() => createElement('GtkAdjustment')).toThrow('registerWidget');
                 let caught: unknown;
                 try {
-                    createElement('AdwClamp');
+                    createElement('GtkAdjustment');
                 } catch (e) {
                     caught = e;
                 }
@@ -189,6 +197,23 @@ export default async () => {
                     expect((spec as unknown as { get_default_value(): unknown }).get_default_value()).toBe(fromSpec);
                     expect(removedValue(descriptor, spec as never)).toBe(fromConstruction);
                 }
+            });
+
+            await it('probes a fatal GType with the id it demands, not bare', async () => {
+                // The interaction the probe was one line away from: `AdwLayoutSlot`
+                // is legal to AUTHOR (`<adw-layout-slot id="…">`) and fatal to
+                // construct bare — `g_error()`, SIGABRT, exit 134, uncatchable, so
+                // the `try` around the probe is not a guard for it. Removing ANY
+                // prop on a slot the consumer built correctly would have ended the
+                // process, and no assertion in this file would have run to say so.
+                const el = createElement('AdwLayoutSlot', { id: 'probe', 'css-classes': ['x'] });
+                materialize(el);
+                const spec = paramSpecs(el.descriptor.ctor(), el.descriptor.gtype).get('css-classes');
+                expect(spec === undefined).toBe(false);
+                // Reaching this line at all IS the assertion — the probe ran.
+                expect(removedValue(el.descriptor, spec as never) !== undefined).toBe(true);
+                // And the premise: this GType really does declare a requirement.
+                expect(el.descriptor.requiresProps).toStrictEqual(['id']);
             });
 
             await it('falls back to the ParamSpec for a value construction cannot report', async () => {

--- a/packages/framework/gtk-host/src/props.ts
+++ b/packages/framework/gtk-host/src/props.ts
@@ -195,14 +195,23 @@ function constructedDefaults(descriptor: WidgetDescriptor): Map<string, unknown>
     const klass = descriptor.ctor();
     let probe: GObject.Object;
     try {
-        probe = new (klass as unknown as new () => GObject.Object)();
+        // Seeded with the construct-only properties this GType ABORTS without.
+        // A bare `new Adw.LayoutSlot()` does not throw — it reaches `g_error()`
+        // and takes the process with it, so the `catch` below would never run and
+        // a removal on an otherwise legal `<adw-layout-slot id="…">` would be
+        // fatal. The values are placeholders: the probe is read for what every
+        // OTHER property settled to, then dropped.
+        const seed: Record<string, unknown> = {};
+        for (const name of descriptor.requiresProps ?? []) seed[name] = '';
+        probe = new (klass as unknown as new (props?: Record<string, unknown>) => GObject.Object)(seed);
     } catch {
         // A consumer subclass registered through `registerWidget()` can have an
         // `_init` that refuses a bare construction. Falling back to the
         // ParamSpec is exactly the behaviour this function replaces, so the
         // fallback is signalled by an EMPTY map — never by a guessed value —
         // and a removal keeps working instead of throwing out of `setProp`.
-        // All 26 shipped descriptors construct; this path is for the registry.
+        // All 164 table rows construct (measured, one process per row); this path
+        // is for the registry.
         return values;
     }
 

--- a/packages/framework/gtk-host/src/props.ts
+++ b/packages/framework/gtk-host/src/props.ts
@@ -11,6 +11,7 @@ import Gdk from 'gi://Gdk?version=4.0';
 import Pango from 'gi://Pango';
 
 import { err } from './errors.js';
+import type { WidgetDescriptor } from './types.js';
 
 /** GType name prefix -> the GI namespace object that carries its enums. */
 const ENUM_NAMESPACES: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
@@ -147,14 +148,120 @@ export function coerce(spec: GObject.ParamSpec, value: unknown, tag: string): un
     return value;
 }
 
+/** The scalar value types a probe can be read through the JS accessor. */
+const SCALAR_VALUE_TYPES: readonly GObject.GType[] = [
+    GObject.TYPE_BOOLEAN,
+    GObject.TYPE_STRING,
+    GObject.TYPE_INT,
+    GObject.TYPE_UINT,
+    GObject.TYPE_INT64,
+    GObject.TYPE_UINT64,
+    GObject.TYPE_DOUBLE,
+    GObject.TYPE_FLOAT,
+];
+
+const isScalarSpec = (spec: GObject.ParamSpec) =>
+    GObject.type_is_a(spec.value_type, GObject.TYPE_ENUM) ||
+    SCALAR_VALUE_TYPES.some((t) => GObject.type_is_a(spec.value_type, t));
+
+/** `background-color` -> `backgroundColor`, the spelling GJS installs the accessor under. */
+const toAccessorName = (name: string) => name.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+
+const constructedCache = new Map<string, Map<string, unknown>>();
+
+/**
+ * What a FRESHLY CONSTRUCTED widget of this GType carries, by kebab name.
+ *
+ * One probe instance per GType, read once and dropped. There is no API for this
+ * question — a widget's `_init` runs arbitrary code, so constructing one is the
+ * only way to learn what construction leaves behind — and the value cannot be
+ * read off a `GValue` either: `probe.get_property(name)` is the raw
+ * two-argument GObject call under GJS ("At least 2 arguments required, but only
+ * 1 passed"), so the JS accessor is the channel.
+ *
+ * A `Gtk.Window` probe is destroyed explicitly. GTK holds a reference to every
+ * toplevel, so dropping the JS reference alone would leak one per window GType
+ * for the life of the process.
+ */
+function constructedDefaults(descriptor: WidgetDescriptor): Map<string, unknown> {
+    const cached = constructedCache.get(descriptor.gtype);
+    if (cached) return cached;
+
+    const values = new Map<string, unknown>();
+    // Recorded BEFORE the probe runs, so a GType whose construction throws pays
+    // for the attempt once rather than on every removal.
+    constructedCache.set(descriptor.gtype, values);
+
+    const klass = descriptor.ctor();
+    let probe: GObject.Object;
+    try {
+        probe = new (klass as unknown as new () => GObject.Object)();
+    } catch {
+        // A consumer subclass registered through `registerWidget()` can have an
+        // `_init` that refuses a bare construction. Falling back to the
+        // ParamSpec is exactly the behaviour this function replaces, so the
+        // fallback is signalled by an EMPTY map — never by a guessed value —
+        // and a removal keeps working instead of throwing out of `setProp`.
+        // All 26 shipped descriptors construct; this path is for the registry.
+        return values;
+    }
+
+    for (const [name, spec] of paramSpecs(klass, descriptor.gtype)) {
+        // Construct-only never reaches the removal path — `rebuild` replays
+        // `el.props` and gets the constructed value free. Worth saying because
+        // `css-name` is construct-only on all 26 descriptors and is 26 of the
+        // 104 disagreements below.
+        if (!isWritable(spec) || isConstructOnly(spec)) continue;
+        if (!isFlag(spec.flags, GObject.ParamFlags.READABLE)) continue;
+        // A DEPRECATED property warns on every READ under GJS: the probe read
+        // `Adw.ActionRow.icon-name` and the suite's diagnostics gate failed the
+        // test — correctly, since a host that exists because GTK fails at exit 0
+        // must not add noise to a consumer's render. Skipping costs nothing:
+        // `icon-name` is the only deprecated one of the 11 that disagree here,
+        // and `''` and `null` both mean no icon.
+        if (isFlag(spec.flags, GObject.ParamFlags.DEPRECATED)) continue;
+        if (!isScalarSpec(spec)) continue;
+        const accessor = toAccessorName(name);
+        if (!(accessor in probe)) continue;
+        values.set(name, (probe as unknown as Record<string, unknown>)[accessor]);
+    }
+
+    if (probe instanceof Gtk.Window) probe.destroy();
+    return values;
+}
+
 /**
  * The value a property falls back to when a renderer removes it.
  *
  * React hands `undefined` for a prop that disappeared, and GObject cannot store
  * that: `set_property(name, undefined)` throws "Could not guess unspecified
- * GValue type" (measured). The ParamSpec knows the right answer.
+ * GValue type" (measured). What "removed" means is the value the widget would
+ * have carried had the prop never been authored — and that is what CONSTRUCTION
+ * leaves behind, not what the ParamSpec declares.
+ *
+ * The two disagree far too often to treat the ParamSpec as an approximation.
+ * Measured on gjs 1.88.1 / GTK 4.22.4 / Adw 1.10 across the 26 shipped
+ * descriptors: 953 scalar properties are both readable and writable, and
+ * **104 of them disagree** — 78 once construct-only `css-name` is set aside.
+ * Twelve property names carry it, four of them behavioural:
+ *
+ *     GtkWindow.visible                 spec=true   constructed=false
+ *     AdwActionRow.activatable          spec=true   constructed=false
+ *     GtkToggleButton.receives-default  spec=false  constructed=true
+ *     GtkListBox.focusable              spec=false  constructed=true  (7 types)
+ *
+ * So `<AdwActionRow activatable={cond}>` with `cond` going `undefined` made a
+ * non-activatable row activatable, and removing `visible` SHOWED a window —
+ * silently, at exit 0, in the package that exists to refuse exactly that.
+ *
+ * `name` is kept as the probe reports it rather than as the ParamSpec's `null`:
+ * `gtk_widget_get_name` falls back to the type name when none was set, so the
+ * probe's answer is the one CSS `#id` matching already sees.
  */
-export function defaultValue(spec: GObject.ParamSpec): unknown {
+export function removedValue(descriptor: WidgetDescriptor, spec: GObject.ParamSpec): unknown {
+    const constructed = constructedDefaults(descriptor);
+    const name = spec.get_name();
+    if (constructed.has(name)) return constructed.get(name);
     return (spec as unknown as { get_default_value(): unknown }).get_default_value();
 }
 

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -173,4 +173,11 @@ export interface WidgetDescriptor {
     readonly textSink?: string;
     /** `onActivate` -> `activate` is derived; irregular pairs live here, in the TABLE. */
     readonly eventAliases?: Readonly<Record<string, string>>;
+    /**
+     * Construct-only properties whose ABSENCE aborts the process rather than
+     * raising — see `REQUIRED_CONSTRUCT_PROPS` in `descriptors/` for the measurement.
+     * Checked in `materialize`, because after `g_object_new` there is nothing left
+     * to check with.
+     */
+    readonly requiresProps?: readonly string[];
 }

--- a/packages/framework/gtk-host/type-tests/jsx/negative-handlers.tsx
+++ b/packages/framework/gtk-host/type-tests/jsx/negative-handlers.tsx
@@ -2,6 +2,7 @@
 //
 // Grammar and mechanism: see the header of `negative-tags.tsx`.
 
+import type Gdk from '@girs/gdk-4.0';
 import type Gtk from '@girs/gtk-4.0';
 
 /** A handler parameter annotated as a type the signal never carries. */
@@ -25,3 +26,31 @@ export const narrowed = <gtk-notebook onPageAdded={(child: Gtk.Button, _n: numbe
 /** A handler declared with more parameters than the signal emits. */
 // @ts-expect-error TS2322 — `clicked` carries no arguments
 export const tooManyParams = <gtk-button onClicked={(widget: Gtk.Button) => widget.set_label('x')} />;
+
+/**
+ * An `out` parameter GIR marks `caller-allocates="0"`, read as if it were a value.
+ *
+ * GJS passes an argument in that slot and it holds uninitialised memory —
+ * measured, `new_value` arrives as `6.9526682391035e-310`, an ordinary `number`
+ * that nothing warns about. The generated signature gives it `OutParam`, so
+ * annotating `number` is a compile error at the position the reader would have
+ * looked, instead of a plausible reading of garbage.
+ */
+// @ts-expect-error TS2322 — `input` hands an uninitialised out slot, not a number
+export const readsOutParam = <gtk-spin-button onInput={(value: number) => value + 1} />;
+
+/**
+ * The OTHER direction, and why this is not a blanket ban on out parameters.
+ *
+ * `get-child-position` is `caller-allocates="1"`: the handler is handed a live
+ * `Gdk.Rectangle` to FILL, which is the entire purpose of the signal. It keeps
+ * its real type, and this line COMPILES — a fix that typed every non-`in`
+ * parameter as unusable would break it.
+ */
+export const fillsOutParam = (
+    <gtk-overlay
+        onGetChildPosition={(_child: Gtk.Widget, allocation: Gdk.Rectangle) => {
+            allocation.width = 10;
+        }}
+    />
+);


### PR DESCRIPTION
> Replaces #1276, rebased onto #1283. The original commit is carried unchanged; a second commit fixes what only exists in the merge of the two. Stacked — base retargets as the stack lands.

## The original change (unchanged, from #1276)

A renderer that drops a prop hands `undefined`, and GObject cannot store it. `setProp` answered with the **ParamSpec's declared default**, which is the wrong source: what "removed" means is the value the widget would have carried had the prop never been authored, and that comes out of **construction**.

Measured on gjs 1.88.1 / GTK 4.22.4 / Adw 1.10 over the 26 curated descriptors: **953 scalar properties are both readable and writable, and 104 disagree** (78 once construct-only `css-name` is set aside). Four are behavioural:

| property | ParamSpec | constructed |
|---|---|---|
| `GtkWindow.visible` | `true` | `false` |
| `AdwActionRow.activatable` | `true` | `false` |
| `GtkToggleButton.receives-default` | `false` | `true` |
| `GtkListBox.focusable` (7 types) | `false` | `true` |

So `<AdwActionRow activatable={cond}>` with `cond` going `undefined` made a row that had never been activatable **into** one, and removing `visible` **showed a window** — at exit 0, in the package that exists to refuse exactly that.

## What only exists in the merge — and would have killed the process

The probe is `new klass()`, **bare**. `#1281` grew the table from 26 rows to 164, and one of those rows is fatal constructed that way: `AdwLayoutSlot::constructed` calls `g_error()` when it has no `id`. That is not an exception — SIGABRT, exit 134, a core dump — so the `try` the probe already had is not a guard for it, and the comment beneath it (*"All 26 shipped descriptors construct"*) was measured against a table that no longer exists.

`<adw-layout-slot id="slot">` is legal to author and materialises fine, because `materialize` passes construct properties. Removing **any** prop on one then reaches the bare probe. Neither PR can see this: #1276 is green because its table has 26 rows, and #1281 is green because nothing removes a prop.

The probe now seeds the construct-only properties the descriptor declares under `requiresProps` (added in #1283, where the measurement lives: 163 of 164 construct bare, one does not, and nothing throws). New vector: `probes a fatal GType with the id it demands, not bare` — reaching the end of it *is* the assertion, since the alternative is not a failure but a dead process.

## One stale test, repointed

`refuses a real installed GType that carries no descriptor` pinned **`AdwClamp`** as *"in the typelib and has no descriptor"*. `AdwClamp` is a concrete `GtkWidget` descendant, so the generated table has carried it since #1281 — the test asserted the opposite of its own comment, and failed on the merge.

Repointed at `GtkAdjustment`: real, installed, **not a widget**, and therefore the durable form of the claim the test is making. It now also asserts `hasWidget('AdwClamp') === true`, so the reason for the change cannot be lost.

## The two things #1276 found beside it, kept

- **`unknownTag` advised a route that cannot resolve it** — *"or use a raw GType tag that is present in the installed typelib"*. `lookupWidget` is a `Map.get` and there is no `GObject.type_from_name` in the package, so a real installed GType lands right back on the same error. The message now says being a real GType is not enough.
- **The probe skips `DEPRECATED` specs**, because reading `Adw.ActionRow.icon-name` emits a deprecation warning per read and `installDiagnosticsGate()` failed the test — correctly. `icon-name` is the only deprecated property among the 11 that disagree on this path, and there `''` and `null` both mean no icon.

## Proof

- **1776 completed**, 0 failures.
- The A/B from #1276 still holds: reverting `removedValue` to the ParamSpec turns all three new vectors red, and the two round-trip vectors are opposite polarities (`activatable` true→false, `receives-default` false→true) so an inverted boolean satisfies neither.
- `oxlint` 0 errors, `gjsify tsc --noEmit` clean.