### PR TITLE
feat(gtk-host): export setProp under its compiler-contract name

### DIFF
--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -144,7 +144,7 @@ adapter is the mapping — no widget name, no insertion rule, no GTK knowledge.
 `scripts/check-adapter-import-direction.mjs` holds it to that mechanically.
 
 ```ts
-import { For, createComponent, createElement, insert, mount, setSolidProp } from '@gjsify/gtk-host/solid';
+import { For, createComponent, createElement, insert, mount, setProp } from '@gjsify/gtk-host/solid';
 
 const dispose = mount(() => {
     const box = createElement('GtkBox');

--- a/packages/framework/gtk-host/src/adapters/solid.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.spec.ts
@@ -11,21 +11,13 @@ import { expect, it, on } from '@gjsify/unit';
 
 import Gtk from 'gi://Gtk?version=4.0';
 import { createSignal } from 'solid-js';
+import { createRenderer } from 'solid-js/universal';
 
 import { installDiagnosticsGate, gtkChildren, gtkChildTypes } from '../conformance/index.js';
 import { gated } from '../testing/gate.mjs';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
-import {
-    Dynamic,
-    For,
-    createComponent,
-    createElement,
-    effect,
-    insert,
-    insertNode,
-    mount,
-    setSolidProp,
-} from './solid.js';
+import * as adapter from './solid.js';
+import { Dynamic, For, createComponent, createElement, effect, insert, insertNode, mount, setProp } from './solid.js';
 
 const labelsOf = (w: Gtk.Widget) => gtkChildren(w).map((c) => (c as Gtk.Label).label);
 
@@ -36,12 +28,33 @@ export default async () => {
         const diagnostics = installDiagnosticsGate();
 
         await gated(diagnostics, 'solid-js/universal over the GTK host', async () => {
+            await it('re-exports the renderer under the names the JSX compiler imports', async () => {
+                // `babel-plugin-jsx-dom-expressions` in `generate: "universal"` mode
+                // emits `import { setProp } from "<moduleName>"` — the member name
+                // LITERALLY, from its own template. A renamed re-export is therefore a
+                // MISSING_EXPORT at bundle time, and nothing before that says a word:
+                // this module exported `setSolidProp` for exactly one of the twelve, so
+                // every hand-written call worked and every compiled `.tsx` did not.
+                //
+                // The list is not hand-kept. It is `Renderer<NodeType>` as
+                // `createRenderer` actually builds it, so a member solid ADDS in a later
+                // release fails here instead of at a consumer's first JSX build.
+                const contract = Object.keys(createRenderer({} as never)).sort();
+                // Pinned, so an empty object cannot make the filter below trivially
+                // pass. Twelve on solid-js 1.9 (measured).
+                expect(contract.length).toBe(12);
+                const missing = contract.filter((name) => !(name in adapter));
+                expect(missing).toStrictEqual([]);
+                // Not vacuous: the same lookup over a name solid does not build.
+                expect('setSolidProp' in adapter).toBe(false);
+            });
+
             await it('renders a tree into a widget the application owns', async () => {
                 const container = new Gtk.Box();
                 const dispose = mount(() => {
                     const box = createElement('GtkBox');
                     const label = createElement('GtkLabel');
-                    setSolidProp(label, 'label', 'hello');
+                    setProp(label, 'label', 'hello');
                     insertNode(box, label);
                     return box;
                 }, container);
@@ -57,7 +70,7 @@ export default async () => {
                 const dispose = mount(() => {
                     const label = createElement('GtkLabel');
                     // what compiled JSX emits for a dynamic prop
-                    effect(() => setSolidProp(label, 'label', text()));
+                    effect(() => setProp(label, 'label', text()));
                     return label;
                 }, container);
 
@@ -77,7 +90,7 @@ export default async () => {
                     insert(box, () =>
                         items().map((t) => {
                             const label = createElement('GtkLabel');
-                            setSolidProp(label, 'label', t);
+                            setProp(label, 'label', t);
                             return label;
                         }),
                     );
@@ -114,7 +127,7 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', t);
+                                setProp(label, 'label', t);
                                 return label;
                             },
                         }),
@@ -179,7 +192,7 @@ export default async () => {
                                 },
                                 children: (t: string) => {
                                     const label = createElement('GtkLabel');
-                                    setSolidProp(label, 'label', t);
+                                    setProp(label, 'label', t);
                                     return label;
                                 },
                             }),
@@ -207,7 +220,7 @@ export default async () => {
                     insert(group, () =>
                         rows().map((t) => {
                             const row = createElement('AdwActionRow');
-                            setSolidProp(row, 'title', t);
+                            setProp(row, 'title', t);
                             return row;
                         }),
                     );
@@ -241,7 +254,7 @@ export default async () => {
                 container.append(chrome);
                 const dispose = mount(() => {
                     const label = createElement('GtkLabel');
-                    setSolidProp(label, 'label', 'rendered');
+                    setProp(label, 'label', 'rendered');
                     return label;
                 }, container);
                 expect(labelsOf(container)).toStrictEqual(['app-owned', 'rendered']);
@@ -259,9 +272,9 @@ export default async () => {
                 mount(() => {
                     const box = createElement('GtkBox');
                     const head = createElement('GtkLabel');
-                    setSolidProp(head, 'label', 'head');
+                    setProp(head, 'label', 'head');
                     const foot = createElement('GtkLabel');
-                    setSolidProp(foot, 'label', 'foot');
+                    setProp(foot, 'label', 'foot');
                     insertNode(box, head);
                     insertNode(box, foot);
                     insert(
@@ -272,7 +285,7 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', t);
+                                setProp(label, 'label', t);
                                 return label;
                             },
                         }),
@@ -312,8 +325,8 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const btn = createElement('GtkButton');
-                                setSolidProp(btn, 'label', t);
-                                setSolidProp(btn, 'onClicked', () => {
+                                setProp(btn, 'label', t);
+                                setProp(btn, 'onClicked', () => {
                                     fired += 1;
                                 });
                                 return btn;
@@ -378,7 +391,7 @@ export default async () => {
                         createComponent(Dynamic, {
                             component: (p: { label?: string }) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', p.label ?? '');
+                                setProp(label, 'label', p.label ?? '');
                                 return label;
                             },
                             label: 'from-fn',
@@ -439,8 +452,8 @@ export default async () => {
                 let button: Gtk.Button | null = null;
                 const dispose = mount(() => {
                     const btn = createElement('GtkButton');
-                    setSolidProp(btn, 'label', 'go');
-                    setSolidProp(btn, 'onClicked', () => {
+                    setProp(btn, 'label', 'go');
+                    setProp(btn, 'onClicked', () => {
                         clicks += 1;
                     });
                     button = (btn as { widget: unknown }).widget as Gtk.Button;

--- a/packages/framework/gtk-host/src/adapters/solid.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.ts
@@ -28,7 +28,7 @@ import {
     nextSibling,
     parentNode,
     remove,
-    setProp,
+    setProp as setHostProp,
     setText,
 } from '../host.js';
 import type { HostElement, HostNode, HostText } from '../types.js';
@@ -105,7 +105,7 @@ const renderer = createRenderer<HostNode>({
     isTextNode: (node: HostNode) => isText(node),
 
     setProperty: (node: HostNode, name: string, value: unknown, prev?: unknown) => {
-        setProp(node as HostElement, name, value, prev);
+        setHostProp(node as HostElement, name, value, prev);
     },
 
     insertNode: (parent: HostNode, node: HostNode, anchor?: HostNode) => {
@@ -143,7 +143,13 @@ export const {
     insertNode,
     insert,
     spread,
-    setProp: setSolidProp,
+    // NOT renamed, and the compiler is why: `babel-plugin-jsx-dom-expressions` in
+    // `generate: "universal"` mode emits `import { setProp } from "<moduleName>"`
+    // literally. Every other member of `Renderer<NodeType>` was already exported
+    // under its contract name; this one was `setSolidProp`, so a real Solid `.tsx`
+    // build against this module failed with MISSING_EXPORT on that single name.
+    // The HOST's `setProp` is the one that carries a local alias now.
+    setProp,
     mergeProps,
     use,
 } = renderer;


### PR DESCRIPTION
> Stacked on #1284. Base retargets as the stack lands; this diff touches only the Solid adapter and the README.

## The blocker for the JSX build step, and it is one export

`babel-plugin-jsx-dom-expressions` in `generate: "universal"` mode emits

```js
import { setProp } from "<moduleName>";
```

— the member name **literally**, out of its own template. It is not configurable and it is not resolved through anything.

Eleven of the twelve `Renderer<NodeType>` members were re-exported from `@gjsify/gtk-host/solid` under their contract name. The twelfth was `setProp: setSolidProp`.

So the failure shape is: every hand-written call works, all 1776 tests pass, the README compiles in a reader's head — and the first real `.tsx` build against this module dies with `MISSING_EXPORT` on one name. Nothing before that point says a word.

The host's own `setProp` takes the local alias instead (`setProp as setHostProp`), because that is the side with no contract to keep.

## The mechanism, not the rename

```ts
const contract = Object.keys(createRenderer({} as never)).sort();
expect(contract.length).toBe(12);
const missing = contract.filter((name) => !(name in adapter));
expect(missing).toStrictEqual([]);
expect('setSolidProp' in adapter).toBe(false);
```

The expected names come from **solid's own `createRenderer`**, not from a list in this repo — measured as twelve on solid-js 1.9: `render, insert, spread, createElement, createTextNode, insertNode, setProp, mergeProps, effect, memo, createComponent, use`. A member a later solid release adds now fails here instead of at a consumer's first JSX build.

Pinned at twelve, so an empty renderer cannot make the filter trivially pass; and the last line is the A/B — reverting the rename turns both it and `missing` red.

## What this unblocks

A consumer needs `moduleName: "@gjsify/gtk-host/solid"` and nothing else — no new subpath, no shim re-exporting one name. `babel-plugin-jsx-dom-expressions` itself is not a dependency of this repo yet, so the build step stays a separate change; this is the part of it that belongs in the adapter.

## Proof

`1779 completed`, 0 failures. `oxlint` 0 errors, `gjsify tsc --noEmit` clean, `gjsify format` clean. 16 call sites in `solid.spec.ts` and one README example follow the rename; `grep setSolidProp` over `packages/ showcases/ docs/ examples/` returns only the comment that explains it.