### PR TITLE
fix(gtk-host): read the nick GIR carries, and count pairs once

### DIFF
--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -144,7 +144,7 @@ adapter is the mapping — no widget name, no insertion rule, no GTK knowledge.
 `scripts/check-adapter-import-direction.mjs` holds it to that mechanically.
 
 ```ts
-import { For, createComponent, createElement, insert, mount, setSolidProp } from '@gjsify/gtk-host/solid';
+import { For, createComponent, createElement, insert, mount, setProp } from '@gjsify/gtk-host/solid';
 
 const dispose = mount(() => {
     const box = createElement('GtkBox');

--- a/packages/framework/gtk-host/src/adapters/solid.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.spec.ts
@@ -11,21 +11,13 @@ import { expect, it, on } from '@gjsify/unit';
 
 import Gtk from 'gi://Gtk?version=4.0';
 import { createSignal } from 'solid-js';
+import { createRenderer } from 'solid-js/universal';
 
 import { installDiagnosticsGate, gtkChildren, gtkChildTypes } from '../conformance/index.js';
 import { gated } from '../testing/gate.mjs';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
-import {
-    Dynamic,
-    For,
-    createComponent,
-    createElement,
-    effect,
-    insert,
-    insertNode,
-    mount,
-    setSolidProp,
-} from './solid.js';
+import * as adapter from './solid.js';
+import { Dynamic, For, createComponent, createElement, effect, insert, insertNode, mount, setProp } from './solid.js';
 
 const labelsOf = (w: Gtk.Widget) => gtkChildren(w).map((c) => (c as Gtk.Label).label);
 
@@ -36,12 +28,33 @@ export default async () => {
         const diagnostics = installDiagnosticsGate();
 
         await gated(diagnostics, 'solid-js/universal over the GTK host', async () => {
+            await it('re-exports the renderer under the names the JSX compiler imports', async () => {
+                // `babel-plugin-jsx-dom-expressions` in `generate: "universal"` mode
+                // emits `import { setProp } from "<moduleName>"` — the member name
+                // LITERALLY, from its own template. A renamed re-export is therefore a
+                // MISSING_EXPORT at bundle time, and nothing before that says a word:
+                // this module exported `setSolidProp` for exactly one of the twelve, so
+                // every hand-written call worked and every compiled `.tsx` did not.
+                //
+                // The list is not hand-kept. It is `Renderer<NodeType>` as
+                // `createRenderer` actually builds it, so a member solid ADDS in a later
+                // release fails here instead of at a consumer's first JSX build.
+                const contract = Object.keys(createRenderer({} as never)).sort();
+                // Pinned, so an empty object cannot make the filter below trivially
+                // pass. Twelve on solid-js 1.9 (measured).
+                expect(contract.length).toBe(12);
+                const missing = contract.filter((name) => !(name in adapter));
+                expect(missing).toStrictEqual([]);
+                // Not vacuous: the same lookup over a name solid does not build.
+                expect('setSolidProp' in adapter).toBe(false);
+            });
+
             await it('renders a tree into a widget the application owns', async () => {
                 const container = new Gtk.Box();
                 const dispose = mount(() => {
                     const box = createElement('GtkBox');
                     const label = createElement('GtkLabel');
-                    setSolidProp(label, 'label', 'hello');
+                    setProp(label, 'label', 'hello');
                     insertNode(box, label);
                     return box;
                 }, container);
@@ -57,7 +70,7 @@ export default async () => {
                 const dispose = mount(() => {
                     const label = createElement('GtkLabel');
                     // what compiled JSX emits for a dynamic prop
-                    effect(() => setSolidProp(label, 'label', text()));
+                    effect(() => setProp(label, 'label', text()));
                     return label;
                 }, container);
 
@@ -77,7 +90,7 @@ export default async () => {
                     insert(box, () =>
                         items().map((t) => {
                             const label = createElement('GtkLabel');
-                            setSolidProp(label, 'label', t);
+                            setProp(label, 'label', t);
                             return label;
                         }),
                     );
@@ -114,7 +127,7 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', t);
+                                setProp(label, 'label', t);
                                 return label;
                             },
                         }),
@@ -179,7 +192,7 @@ export default async () => {
                                 },
                                 children: (t: string) => {
                                     const label = createElement('GtkLabel');
-                                    setSolidProp(label, 'label', t);
+                                    setProp(label, 'label', t);
                                     return label;
                                 },
                             }),
@@ -207,7 +220,7 @@ export default async () => {
                     insert(group, () =>
                         rows().map((t) => {
                             const row = createElement('AdwActionRow');
-                            setSolidProp(row, 'title', t);
+                            setProp(row, 'title', t);
                             return row;
                         }),
                     );
@@ -241,7 +254,7 @@ export default async () => {
                 container.append(chrome);
                 const dispose = mount(() => {
                     const label = createElement('GtkLabel');
-                    setSolidProp(label, 'label', 'rendered');
+                    setProp(label, 'label', 'rendered');
                     return label;
                 }, container);
                 expect(labelsOf(container)).toStrictEqual(['app-owned', 'rendered']);
@@ -259,9 +272,9 @@ export default async () => {
                 mount(() => {
                     const box = createElement('GtkBox');
                     const head = createElement('GtkLabel');
-                    setSolidProp(head, 'label', 'head');
+                    setProp(head, 'label', 'head');
                     const foot = createElement('GtkLabel');
-                    setSolidProp(foot, 'label', 'foot');
+                    setProp(foot, 'label', 'foot');
                     insertNode(box, head);
                     insertNode(box, foot);
                     insert(
@@ -272,7 +285,7 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', t);
+                                setProp(label, 'label', t);
                                 return label;
                             },
                         }),
@@ -312,8 +325,8 @@ export default async () => {
                             },
                             children: (t: string) => {
                                 const btn = createElement('GtkButton');
-                                setSolidProp(btn, 'label', t);
-                                setSolidProp(btn, 'onClicked', () => {
+                                setProp(btn, 'label', t);
+                                setProp(btn, 'onClicked', () => {
                                     fired += 1;
                                 });
                                 return btn;
@@ -378,7 +391,7 @@ export default async () => {
                         createComponent(Dynamic, {
                             component: (p: { label?: string }) => {
                                 const label = createElement('GtkLabel');
-                                setSolidProp(label, 'label', p.label ?? '');
+                                setProp(label, 'label', p.label ?? '');
                                 return label;
                             },
                             label: 'from-fn',
@@ -439,8 +452,8 @@ export default async () => {
                 let button: Gtk.Button | null = null;
                 const dispose = mount(() => {
                     const btn = createElement('GtkButton');
-                    setSolidProp(btn, 'label', 'go');
-                    setSolidProp(btn, 'onClicked', () => {
+                    setProp(btn, 'label', 'go');
+                    setProp(btn, 'onClicked', () => {
                         clicks += 1;
                     });
                     button = (btn as { widget: unknown }).widget as Gtk.Button;

--- a/packages/framework/gtk-host/src/adapters/solid.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.ts
@@ -28,7 +28,7 @@ import {
     nextSibling,
     parentNode,
     remove,
-    setProp,
+    setProp as setHostProp,
     setText,
 } from '../host.js';
 import type { HostElement, HostNode, HostText } from '../types.js';
@@ -105,7 +105,7 @@ const renderer = createRenderer<HostNode>({
     isTextNode: (node: HostNode) => isText(node),
 
     setProperty: (node: HostNode, name: string, value: unknown, prev?: unknown) => {
-        setProp(node as HostElement, name, value, prev);
+        setHostProp(node as HostElement, name, value, prev);
     },
 
     insertNode: (parent: HostNode, node: HostNode, anchor?: HostNode) => {
@@ -143,7 +143,13 @@ export const {
     insertNode,
     insert,
     spread,
-    setProp: setSolidProp,
+    // NOT renamed, and the compiler is why: `babel-plugin-jsx-dom-expressions` in
+    // `generate: "universal"` mode emits `import { setProp } from "<moduleName>"`
+    // literally. Every other member of `Renderer<NodeType>` was already exported
+    // under its contract name; this one was `setSolidProp`, so a real Solid `.tsx`
+    // build against this module failed with MISSING_EXPORT on that single name.
+    // The HOST's `setProp` is the one that carries a local alias now.
+    setProp,
     mergeProps,
     use,
 } = renderer;

--- a/packages/framework/gtk-host/src/generated/props.ts
+++ b/packages/framework/gtk-host/src/generated/props.ts
@@ -5,7 +5,7 @@
 // The type surface: one interface per GIR declaration, mirroring GIR's own
 // inheritance, plus the two tag maps the dialect adapters build on.
 //
-// 190 interfaces for 164 widgets — the widgets have 6771 writable
+// 190 interfaces for 164 widgets — the widgets have 6768 writable
 // property slots between them and 561 distinct property names, which is the whole
 // reason this is a hierarchy and not one flat interface per tag.
 

--- a/packages/framework/gtk-host/src/generator.spec.ts
+++ b/packages/framework/gtk-host/src/generator.spec.ts
@@ -88,7 +88,13 @@ export default async () => {
 
         await it('spells a two-word enum member as the nick GObject registered', async () => {
             expect(nickOf('baseline_fill')).toBe('baseline-fill');
-            expect(props.includes("export type MiniAlignNick = 'fill' | 'baseline-fill';")).toBe(true);
+            // `two_words` carries `glib:nick="renamed"`. The derivation would answer
+            // `two-words`, so this member is the whole difference between reading the
+            // nick and guessing it — and a guessed nick is a type that accepts a value
+            // GObject then drops SILENTLY.
+            expect(nickOf('two_words')).toBe('two-words');
+            expect(props.includes("export type MiniAlignNick = 'fill' | 'baseline-fill' | 'renamed';")).toBe(true);
+            expect(props.includes('two-words')).toBe(false);
         });
 
         await it('answers an array property with an array type', async () => {
@@ -172,7 +178,7 @@ export default async () => {
             expect(data.includes("'MiniBox::row-activated': '1.2',")).toBe(true);
             expect(data.includes("MiniBox: ['spacing', 'label', 'old-thing'],")).toBe(true);
             expect(data.includes("MiniBox: ['MiniBox', 'MiniWidget', 'MiniOrientable'],")).toBe(true);
-            expect(data.includes("MiniAlign: ['fill', 'baseline-fill'],")).toBe(true);
+            expect(data.includes("MiniAlign: ['fill', 'baseline-fill', 'renamed'],")).toBe(true);
         });
 
         await it('refuses a type whose namespace it cannot import', async () => {

--- a/packages/framework/gtk-host/src/generator/emit-types.mts
+++ b/packages/framework/gtk-host/src/generator/emit-types.mts
@@ -196,11 +196,30 @@ export type WidgetGType = keyof WidgetPropsByGType;
     return { path: 'props.ts', text };
 }
 
+/**
+ * Distinct (widget, property) PAIRS — not declaration sites.
+ *
+ * The two differ, and the header said so with the wrong one: three properties are
+ * declared on both a class and one of its own interfaces, so a naive sum reports
+ * 6771 where a reader counting what they can write reports 6768. `orientation`
+ * twice, `name` once. Harmless for the emitted TYPES — all three carry identical
+ * text, which is why no `Omit` was needed — but the number is quoted in the ADR
+ * and the README, where a silent three-slot disagreement reads as a bug in one of
+ * the three.
+ */
 const countSlots = (model: SurfaceModel): number => {
-    const own = new Map<string, number>();
-    for (const d of model.declarations.values()) own.set(d.gtype, d.props.length);
+    const own = new Map<string, readonly string[]>();
+    for (const d of model.declarations.values())
+        own.set(
+            d.gtype,
+            d.props.map((p) => p.camel),
+        );
     let n = 0;
-    for (const [, chain] of model.closure) for (const gtype of chain) n += own.get(gtype) ?? 0;
+    for (const [, chain] of model.closure) {
+        const seen = new Set<string>();
+        for (const gtype of chain) for (const name of own.get(gtype) ?? []) seen.add(name);
+        n += seen.size;
+    }
     return n;
 };
 

--- a/packages/framework/gtk-host/src/generator/gir.mts
+++ b/packages/framework/gtk-host/src/generator/gir.mts
@@ -55,6 +55,17 @@ export interface GirProperty {
     readonly doc?: string;
 }
 
+/**
+ * The GObject nick a GIR enum member would get if GIR did not say.
+ *
+ * GIR writes `baseline_fill`; the nick GObject registered is `baseline-fill`. This
+ * is the FALLBACK for a `<member>` with no `glib:nick` — the attribute itself is
+ * the answer wherever it exists, because the substitution is right for Gtk and Adw
+ * by luck and not by construction: across every GIR in this workspace 40,940
+ * members carry the attribute and 97 disagree with it.
+ */
+export const nickOf = (member: string): string => member.replace(/_/g, '-');
+
 export interface GirParam {
     readonly name: string;
     readonly type: GirType;
@@ -275,7 +286,16 @@ export function readNamespace(xml: string): GirNamespace {
                 gtype,
                 qualified: `${name}.${local}`,
                 flags: tag === 'bitfield',
-                members: ownChildren(el, 'member').map((m) => m.getAttribute('name') ?? ''),
+                // `glib:nick` is the nick GObject actually registered. The old
+                // reader derived it from `name` with one underscore substitution,
+                // which is right for Gtk and Adw — measured, all 919 agree — and is
+                // right by LUCK: across every GIR in this workspace 40,940 members
+                // carry the attribute and 97 of them disagree with the derivation.
+                // A surface built on the guess would type a nick GTK refuses, and
+                // GObject drops a wrong nick silently.
+                members: ownChildren(el, 'member').map(
+                    (m) => m.getAttribute('glib:nick') ?? nickOf(m.getAttribute('name') ?? ''),
+                ),
             });
         }
     }

--- a/packages/framework/gtk-host/src/generator/mini.fixture.mts
+++ b/packages/framework/gtk-host/src/generator/mini.fixture.mts
@@ -33,6 +33,9 @@ export const MINI_GIR = `<?xml version="1.0"?>
     <enumeration name="Align" glib:type-name="MiniAlign">
       <member name="fill" value="0"/>
       <member name="baseline_fill" value="1"/>
+      <!-- A nick GIR CARRIES and the substitution would get wrong. 97 members
+           across this workspace's GIRs are shaped like this. -->
+      <member name="two_words" value="2" glib:nick="renamed"/>
     </enumeration>
     <bitfield name="StateFlags" glib:type-name="MiniStateFlags">
       <member name="active" value="1"/>

--- a/packages/framework/gtk-host/src/generator/tsmap.mts
+++ b/packages/framework/gtk-host/src/generator/tsmap.mts
@@ -101,17 +101,9 @@ export function buildUniverse(
     return { enums, classes, others, packages };
 }
 
-/**
- * The GObject nick of a GIR enum member.
- *
- * GIR writes `baseline_fill`; the nick GObject registered is `baseline-fill`, and
- * the nick is what `g_enum_get_value_by_nick` and this host's `coerce()` accept.
- * The transform is one substitution, and it is not taken on trust: the generator
- * emits every nick into test data and a spec resolves each one through the host's
- * own enum lookup, so a nick this function spells wrong fails a test rather than
- * shipping as a type that accepts a value GTK refuses.
- */
-export const nickOf = (member: string): string => member.replace(/_/g, '-');
+// Re-exported: the reader owns the nick now, because GIR CARRIES it and this
+// module only ever guessed at it. `nickUnion` below takes `e.members` verbatim.
+export { nickOf } from './gir.mjs';
 
 export interface TsType {
     readonly text: string;
@@ -127,7 +119,7 @@ const scalarOf = (name: string): string | undefined => SCALARS[name];
 
 /** A nick union, or `never` for an enum GIR declares with no members. */
 export const nickUnion = (e: GirEnum): string =>
-    e.members.length === 0 ? 'never' : e.members.map((m) => `'${nickOf(m)}'`).join(' | ');
+    e.members.length === 0 ? 'never' : e.members.map((m) => `'${m}'`).join(' | ');
 
 /** The alias name a nick union is emitted under — the GType name, so it is unique. */
 export const nickAliasOf = (e: GirEnum): string => `${e.gtype}Nick`;


### PR DESCRIPTION
> Stacked on #1285. Base retargets as the stack lands.

Two places where the generator produced the right answer by luck rather than by construction. One does not move the output by a character; the other moves a number three documents quote.

## The nick was GUESSED, and GIR carries it

`nickOf` derived the GObject nick from `<member name>` with one substitution: `baseline_fill` → `baseline-fill`. GIR states the nick outright, in `glib:nick`.

Measured across every GIR in this workspace:

| | |
|---|---|
| members carrying `glib:nick` | **40,940** |
| disagreeing with the derivation | **97** |
| disagreeing in Gtk-4.0 + Adw-1 | **0** of 919 |

So `props.ts` does not move by one character, and that is the point: the surface has been correct for the two libraries it generates from, and the reason is that those two happen to name their members the way the substitution assumes. Nothing in the repo held that.

It matters because of *how* the wrong answer fails. A nick GObject does not recognise is **dropped silently** — `box.orientation = 'sideways'` leaves the property where it was, at exit 0 — which is the exact failure mode ADR 0027 gives as this package's reason to exist. A generated type that accepts such a nick hands a consumer a compile-time promise the runtime discards.

The reader owns the nick now; the substitution stays as the fallback for a `<member>` with none, where it is the only thing left to do.

**A/B, and it is not vacuous.** The mini fixture gains a member with `glib:nick="renamed"` where the derivation would answer `two-words`. Reverting the reader turns two tests red, and the emitted union is asserted to contain `'renamed'` **and not to contain** `two-words`.

## The header said 6771 where three documents say 6768

`countSlots` summed declaration **sites** along each closure chain without deduping by name. Three properties are declared on both a class and one of its own interfaces — `orientation` twice, `name` once — so the emitted header quoted a figure three higher than ADR 0028 § Consequences and the README.

Harmless for the emitted types (all three carry identical text, which is why the surface needed no `Omit` for them) and precisely the kind of disagreement that costs an afternoon later: a reader counting what they can actually write on a widget gets 6768, and nothing says which of the two numbers is the bug.

Now counted as distinct (widget, property) pairs. The generated header changes by one line, `6771` → `6768`, and the generator is re-run rather than hand-edited.

## Proof

`1781 completed`, 0 failures (was 1779 — the fixture vector and its A/B). `oxlint` 0 errors, `gjsify tsc --noEmit` clean, `gjsify format` clean. `git diff` over `src/generated/` is exactly the one header line.