### PR TITLE
fix(gtk-host): close the two findings on the generated surface

### DIFF
--- a/docs/adr/0028-widget-table-provenance.md
+++ b/docs/adr/0028-widget-table-provenance.md
@@ -195,6 +195,29 @@ coercer and the verifier.**
    `<gtk-box orientation="vertical">` — the most-written GtkBox attribute there is —
    is a type error. The reader walks parents AND interfaces.
 
+10. **A table row is a claim that the widget can be BUILT, and one row was not.**
+    `AdwLayoutSlot` requires a construct-only `id`; without one, `constructed`
+    reaches `g_error()`, which is fatal by contract — SIGABRT, exit 134, a core
+    dump, and nothing to catch. GIR cannot tell that apart from any other
+    construct-only nullable property, and `descriptorProblems()` reads policy
+    without ever instantiating, so the row was green in a 1746-test suite that
+    constructed **none** of the 164. Bare-constructing all of them measures 163
+    clean and no throws at all, so the requirement is CURATED as one entry
+    (`REQUIRED_CONSTRUCT_PROPS`), refused in `materialize` by name, and the
+    construct-every-row test is what keeps the entry count honest.
+
+11. **A signal parameter has a DIRECTION, and three of them carry nothing.**
+    GIR marks `Gtk.SpinButton::input`, `Adw.SpinRow::input` and
+    `Gtk.Editable::insert-text` with a non-`in` parameter at
+    `caller-allocates="0"`. GJS still passes an argument there and it holds
+    uninitialised memory — measured, `new_value` arrives as `6.95e-310` and
+    `position` as `1711500784`, both perfectly ordinary numbers. Typing them from
+    the GIR type invites a reading that is garbage, and nothing warns. They are
+    emitted as `OutParam` instead: declared, so the following parameters do not
+    shift, and unreadable, so annotating `number` is an error at that position.
+    `caller-allocates="1"` is the opposite case and keeps its type —
+    `Gtk.Overlay::get-child-position` is handed a live `Gdk.Rectangle` to FILL.
+
 ## Consequences
 
 - The normal disagreement between table and runtime is **version skew** — a user's

--- a/packages/framework/gtk-host/src/attrs.ts
+++ b/packages/framework/gtk-host/src/attrs.ts
@@ -19,6 +19,28 @@ import type { HostNode } from './types.js';
  */
 export type NotifyHandler = (pspec: GObject.ParamSpec) => void;
 
+declare const outParam: unique symbol;
+
+/**
+ * A signal parameter GIR declares `out`/`inout` with `caller-allocates="0"`.
+ *
+ * GJS still passes an argument in that position, and what it holds is whatever
+ * was in the memory the marshaller allocated: measured on gjs 1.88.1 / GTK
+ * 4.22.4, a handler on `Gtk.SpinButton::input` receives `new_value` as
+ * `6.9526682391035e-310`, and one on `Gtk.Editable::insert-text` receives
+ * `position` as `1711500784`. Both arrive as ordinary numbers. Nothing warns.
+ *
+ * So the slot is DECLARED — dropping it would silently shift every parameter
+ * after it — and given a type nothing can be read out of, and nothing but
+ * itself assigns to. Annotating the parameter `number` is then a compile error
+ * naming the position, which is the only place a reader would have looked.
+ *
+ * `caller-allocates="1"` is a different thing and keeps its real type: there the
+ * callee is handed a live object to FILL, as `Gtk.Overlay::get-child-position`
+ * is handed a `Gdk.Rectangle`.
+ */
+export type OutParam = { readonly [outParam]: never };
+
 /**
  * What may appear as a child, mirroring Solid's own `JSX.Element`.
  *

--- a/packages/framework/gtk-host/src/conformance.spec.ts
+++ b/packages/framework/gtk-host/src/conformance.spec.ts
@@ -4,7 +4,7 @@ import { expect, it, on } from '@gjsify/unit';
 
 import Gtk from 'gi://Gtk?version=4.0';
 
-import { descriptorProblems, installDiagnosticsGate, methodsOf } from './conformance/index.js';
+import { descriptorProblems, describeLogRecord, installDiagnosticsGate, methodsOf } from './conformance/index.js';
 import { gated } from './testing/gate.mjs';
 import { lookupWidget, registeredTags } from './registry.js';
 import type { WidgetDescriptor } from './types.js';
@@ -20,6 +20,38 @@ export default async () => {
         // neighbour twelve tests later. `gated` registers the hooks INSIDE the
         // describe, where @gjsify/unit actually keeps them.
         const diagnostics = installDiagnosticsGate();
+
+        await it('describes every record it counts, MESSAGE field or not', async () => {
+            // `MESSAGE` is a structured field like any other and a record may arrive
+            // without one. The first version answered `String(raw ?? '')`, so such a
+            // record was COUNTED and then described as nothing: a CI run failed with
+            // "GTK reported 1 diagnostic(s) that would have passed at exit 0:" and a
+            // blank list, right after a test that had constructed 164 widgets. A
+            // count without a name sends the reader back to guessing, which is the
+            // state this module exists to end.
+            //
+            // Tested on the renderer directly rather than by emitting a real record:
+            // `GLib.log_structured_array` wants `GLib.LogField` structs GJS cannot
+            // build from object literals ("not a subclass of GObject_Struct").
+            const encode = (text: string) => new TextEncoder().encode(text);
+            expect(describeLogRecord({ MESSAGE: encode('a plain warning') })).toBe('a plain warning');
+            expect(describeLogRecord({ MESSAGE: 'already a string' })).toBe('already a string');
+            // The three shapes that used to render as the empty string.
+            const empties = [
+                { GLIB_DOMAIN: encode('gtk-host-probe') },
+                { MESSAGE: null, GLIB_DOMAIN: 'x' },
+                { MESSAGE: '' },
+            ];
+            for (const record of empties) {
+                const answer = describeLogRecord(record);
+                expect(answer.includes('no MESSAGE')).toBe(true);
+                expect(answer.trim().length > 0).toBe(true);
+            }
+            expect(describeLogRecord({ GLIB_DOMAIN: encode('gtk-host-probe') }).includes('gtk-host-probe')).toBe(true);
+            // A record with nothing at all still says so, rather than ''.
+            expect(describeLogRecord(null).length > 0).toBe(true);
+            expect(describeLogRecord({}).length > 0).toBe(true);
+        });
 
         await gated(diagnostics, 'descriptor table vs installed typelib', async () => {
             await it('every declared method and text sink exists', async () => {

--- a/packages/framework/gtk-host/src/conformance/diagnostics.ts
+++ b/packages/framework/gtk-host/src/conformance/diagnostics.ts
@@ -39,6 +39,37 @@ let installed: DiagnosticsGate | null = null;
  * what GLib's default writer does with `G_MESSAGES_DEBUG` unset: message-and-above
  * is printed, info/debug is not.
  */
+/**
+ * What a log record SAYS — and never the empty string.
+ *
+ * `MESSAGE` is a structured field like any other, and a record is allowed to
+ * arrive without one. The first version answered `String(raw ?? '')`, so such a
+ * record was counted and then described as nothing: a CI run failed with
+ * `GTK reported 1 diagnostic(s) that would have passed at exit 0:` followed by a
+ * BLANK LIST, over a test that had just constructed 164 widgets. A gate that can
+ * count a failure but not name it sends the reader back to guessing, which is the
+ * state this whole module exists to end.
+ *
+ * So a record with no `MESSAGE` is rendered from the fields it does carry.
+ */
+export function describeLogRecord(fields: unknown, decoder: TextDecoder = new TextDecoder()): string {
+    const text = (value: unknown): string => (value instanceof Uint8Array ? decoder.decode(value) : String(value));
+    const record = fields as Record<string, unknown> | null;
+    const raw = record?.MESSAGE;
+    if (raw !== undefined && raw !== null) {
+        const message = text(raw);
+        if (message !== '') return message;
+    }
+    const rest = record
+        ? Object.keys(record)
+              .filter((key) => key !== 'MESSAGE' && record[key] !== undefined && record[key] !== null)
+              .map((key) => `${key}=${text(record[key])}`)
+        : [];
+    return rest.length > 0
+        ? `<no MESSAGE field> ${rest.join(' ')}`
+        : '<a log record with no MESSAGE and no other field>';
+}
+
 export function installDiagnosticsGate(): DiagnosticsGate {
     if (installed) return installed;
 
@@ -49,8 +80,7 @@ export function installDiagnosticsGate(): DiagnosticsGate {
     GLib.log_set_writer_func((level, fields) => {
         // A throw in here is logged, which re-enters this function.
         try {
-            const raw = (fields as unknown as { MESSAGE?: unknown } | null)?.MESSAGE;
-            const message = raw instanceof Uint8Array ? decoder.decode(raw) : String(raw ?? '');
+            const message = describeLogRecord(fields, decoder);
             // MASK the level: `g_logv` ORs in `G_LOG_FLAG_FATAL` when the level is
             // in the fatal mask, so `WARNING|FATAL` is 18 and an unmasked `<= 16`
             // stops recording exactly the messages this exists to catch — under

--- a/packages/framework/gtk-host/src/conformance/index.ts
+++ b/packages/framework/gtk-host/src/conformance/index.ts
@@ -1,4 +1,4 @@
-export { installDiagnosticsGate, type DiagnosticsGate } from './diagnostics.js';
+export { describeLogRecord, installDiagnosticsGate, type DiagnosticsGate } from './diagnostics.js';
 // Conformance surface: the checks that keep the widget table honest, and the
 // GTK-side readers every vector asserts against.
 //

--- a/packages/framework/gtk-host/src/descriptors/index.ts
+++ b/packages/framework/gtk-host/src/descriptors/index.ts
@@ -32,6 +32,27 @@ export const CURATED_DESCRIPTORS: readonly WidgetDescriptor[] = [...GTK_DESCRIPT
  * and `set_child` all exist somewhere in GTK, and calling the wrong one is a
  * warning at exit 0.
  */
+/**
+ * Construct-only properties a GType ABORTS the process without.
+ *
+ * Not an exception: `adw_layout_slot_constructed` calls `g_error()`, which is
+ * fatal by contract — no catch, no diagnostic, SIGABRT and a core dump. A table
+ * that merely LISTS such a tag hands a renderer a way to kill the process, and
+ * `descriptorProblems()` cannot see it because it never instantiates anything.
+ *
+ * MEASURED bare-constructing all 164 generated rows on gjs 1.88.1 / GTK 4.22.4 /
+ * Adw 1.10, resuming past each abort: **163 construct, one does not**, and not a
+ * single row throws. So this map is one entry rather than a policy — and
+ * `constructsEveryDescriptor` in `generated.spec.ts` is what keeps it one entry.
+ *
+ * CURATED, like every other placement fact: the GIR says `id` is construct-only
+ * and nullable, which is exactly what it says about properties that construct
+ * fine. Only running it tells them apart (ADR 0028 § 1).
+ */
+export const REQUIRED_CONSTRUCT_PROPS: Readonly<Record<string, readonly string[]>> = {
+    AdwLayoutSlot: ['id'],
+};
+
 export function mergeGenerated(
     curated: readonly WidgetDescriptor[],
     generated: readonly GeneratedWidget[],
@@ -40,7 +61,13 @@ export function mergeGenerated(
     const known = new Set(curated.map((d) => d.gtype));
     for (const w of generated) {
         if (known.has(w.gtype)) continue;
-        out.push({ gtype: w.gtype, ctor: w.ctor, children: { kind: 'uncurated' } });
+        const requiresProps = REQUIRED_CONSTRUCT_PROPS[w.gtype];
+        out.push({
+            gtype: w.gtype,
+            ctor: w.ctor,
+            children: { kind: 'uncurated' },
+            ...(requiresProps ? { requiresProps } : {}),
+        });
     }
     return out;
 }

--- a/packages/framework/gtk-host/src/errors.ts
+++ b/packages/framework/gtk-host/src/errors.ts
@@ -26,6 +26,14 @@ export const err = {
             `No descriptor registered for <${tag}>. Register one with registerWidget({ gtype: '${tag}', … }) ` +
                 `or use a raw GType tag that is present in the installed typelib.`,
         ),
+    missingConstructProp: (tag: string, prop: string) =>
+        new GtkHostError(
+            'missing-construct-prop',
+            `<${tag}> cannot be constructed without ${prop}. In the installed library this is not an ` +
+                `exception but a g_error(): the process ABORTS (SIGABRT, exit 134, core dump) with no ` +
+                `catch and no diagnostic, so the host refuses here while a refusal is still reportable. ` +
+                `Author ${prop} on the element.`,
+        ),
     unknownProp: (tag: string, prop: string) =>
         new GtkHostError(
             'unknown-prop',

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -140,12 +140,20 @@ export default async () => {
                 // line names the tag instead of a core dump nobody attributes.
                 const required = new Map(Object.entries(REQUIRED_CONSTRUCT_PROPS));
                 const failed: string[] = [];
+                // Diagnostics are drained PER ROW, not left to the gate at the end
+                // of the test. Same assertion, with the one thing the gate cannot
+                // give: a name. Measured — a first CI run failed here with
+                // "GTK reported 1 diagnostic(s)" over 164 constructions and no way
+                // to tell which, while the same sweep is silent on a workstation
+                // both with and without a session bus.
+                const noisy: string[] = [];
                 for (const w of GENERATED_WIDGETS) {
                     // Through the HOST, not through `new w.ctor()`: `materialize` is
                     // where the refusal lives, so constructing around it would leave
                     // the guard itself unchecked.
                     const props: Record<string, unknown> = {};
                     for (const name of required.get(w.gtype) ?? []) props[name] = 'probe';
+                    diagnostics.reset();
                     try {
                         // Left alive on purpose — NOT destroyed, NOT `run_dispose()`d.
                         //
@@ -168,8 +176,11 @@ export default async () => {
                     } catch (error) {
                         failed.push(`${w.gtype}: ${(error as Error).message}`);
                     }
+                    if (diagnostics.seen.length > 0) noisy.push(`${w.gtype}: ${diagnostics.seen.join(' | ')}`);
+                    diagnostics.reset();
                 }
                 expect(failed).toStrictEqual([]);
+                expect(noisy).toStrictEqual([]);
                 expect(required.size).toBe(1);
             });
 

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -147,6 +147,25 @@ export default async () => {
                 // to tell which, while the same sweep is silent on a workstation
                 // both with and without a session bus.
                 const noisy: string[] = [];
+                // The ONE exemption, and it is about the machine rather than the
+                // widget. `GtkColorChooserDialog`'s eyedropper asks the Screenshot
+                // portal for its version; a CI container has a D-Bus session and no
+                // `xdg-desktop-portal` behind it, so GTK warns:
+                //
+                //   Cannot get portal org.freedesktop.portal.Screenshot version:
+                //   GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such
+                //   interface “org.freedesktop.portal.Screenshot”
+                //
+                // Measured, and the third state is why it took a CI run to see: with
+                // a portal it is silent, with NO session bus at all it is silent
+                // (GTK never asks), and only with a bus that answers without the
+                // interface does it warn. Stripping DBUS_SESSION_BUS_ADDRESS on a
+                // workstation reproduces the second state, not the container's.
+                //
+                // Scoped to the MESSAGE, not to the widget: any widget reaching a
+                // portal produces this, and `GtkColorChooserDialog` stays under test
+                // for everything else it might say.
+                const missingPortal = /^Cannot get portal org\.freedesktop\.portal\./;
                 for (const w of GENERATED_WIDGETS) {
                     // Through the HOST, not through `new w.ctor()`: `materialize` is
                     // where the refusal lives, so constructing around it would leave
@@ -176,12 +195,18 @@ export default async () => {
                     } catch (error) {
                         failed.push(`${w.gtype}: ${(error as Error).message}`);
                     }
-                    if (diagnostics.seen.length > 0) noisy.push(`${w.gtype}: ${diagnostics.seen.join(' | ')}`);
+                    const said = diagnostics.seen.filter((message) => !missingPortal.test(message));
+                    if (said.length > 0) noisy.push(`${w.gtype}: ${said.join(' | ')}`);
                     diagnostics.reset();
                 }
                 expect(failed).toStrictEqual([]);
                 expect(noisy).toStrictEqual([]);
                 expect(required.size).toBe(1);
+                // The exemption is NARROW — it must not swallow an ordinary GTK
+                // warning, which is the whole reason the sweep exists.
+                expect(missingPortal.test('Cannot get portal org.freedesktop.portal.Screenshot version: x')).toBe(true);
+                expect(missingPortal.test('Trying to snapshot GtkButton without a current allocation')).toBe(false);
+                expect(missingPortal.test('gtk_box_append: assertion failed')).toBe(false);
             });
 
             await it('refuses a fatal construction by name instead of aborting', async () => {

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -19,7 +19,13 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { installDiagnosticsGate } from './conformance/index.js';
-import { BUILTIN_DESCRIPTORS, CURATED_DESCRIPTORS, GENERATED_WIDGETS } from './descriptors/index.js';
+import {
+    BUILTIN_DESCRIPTORS,
+    CURATED_DESCRIPTORS,
+    GENERATED_WIDGETS,
+    REQUIRED_CONSTRUCT_PROPS,
+} from './descriptors/index.js';
+import { createElement, materialize } from './host.js';
 import { DECLS, ENUM_NICKS, OWN_PROPS, OWN_SIGNALS, SINCE, TAGS } from './generated/surface-data.mjs';
 import { camelOf, eventPropOf } from './generator/tsmap.mjs';
 import { isWritable, lookupEnumNick, paramSpecs } from './props.js';
@@ -119,6 +125,61 @@ export default async () => {
                     expect(hasWidget(w.tag)).toBe(true);
                     expect(lookupWidget(w.tag) === lookupWidget(w.gtype)).toBe(true);
                 }
+            });
+
+            await it('constructs every row it offers', async () => {
+                // The check the table did not have, and the reason it shipped a row
+                // that KILLS THE PROCESS. `descriptorProblems()` reads policy and
+                // never instantiates, so `AdwLayoutSlot` — whose `constructed` calls
+                // `g_error("AdwLayoutSlot %p created without an ID")`, fatal by
+                // contract, SIGABRT and a core dump — was green in a 1746-test suite.
+                //
+                // Measured bare over all 164 rows on gjs 1.88.1 / GTK 4.22.4 / Adw
+                // 1.10: 163 construct and not one throws. So a REGRESSION here is a
+                // new abort, and this test is what turns it into a failure whose last
+                // line names the tag instead of a core dump nobody attributes.
+                const required = new Map(Object.entries(REQUIRED_CONSTRUCT_PROPS));
+                const failed: string[] = [];
+                for (const w of GENERATED_WIDGETS) {
+                    // Through the HOST, not through `new w.ctor()`: `materialize` is
+                    // where the refusal lives, so constructing around it would leave
+                    // the guard itself unchecked.
+                    const props: Record<string, unknown> = {};
+                    for (const name of required.get(w.gtype) ?? []) props[name] = 'probe';
+                    try {
+                        // Left alive on purpose — NOT destroyed, NOT `run_dispose()`d.
+                        //
+                        // `installDiagnosticsGate` sets a process-global JS log writer
+                        // and never takes it back, so any widget GJS finalises during
+                        // SHUTDOWN prints `Gjs-CRITICAL: Attempting to run a JS callback
+                        // during shutdown` on stderr, after the summary. Severing a
+                        // widget's internals is what schedules that: measured one row
+                        // per process over all 164, disposing makes EIGHT of them do it
+                        // (AdwComboRow, GtkColumnView, GtkEditableLabel, GtkEmojiChooser,
+                        // GtkScrollbar, GtkColorChooserDialog, GtkColorChooserWidget,
+                        // GtkFileChooserWidget) and leaving them alone makes TWO
+                        // (GtkColorChooserWidget, GtkEmojiChooser).
+                        //
+                        // Two leaked-by-design lines beat eight, in a process that exits
+                        // seconds later; neither is the host's doing, and skipping the
+                        // two rows would trade the noise for the blindness this test
+                        // exists to remove.
+                        materialize(createElement(w.tag, props));
+                    } catch (error) {
+                        failed.push(`${w.gtype}: ${(error as Error).message}`);
+                    }
+                }
+                expect(failed).toStrictEqual([]);
+                expect(required.size).toBe(1);
+            });
+
+            await it('refuses a fatal construction by name instead of aborting', async () => {
+                // A/B for the guard above: without `requiresProps` this call does not
+                // throw — it ends the process. The assertion is that it is an ERROR.
+                expect(() => materialize(createElement('adw-layout-slot'))).toThrow(/cannot be constructed without id/);
+                // And the requirement is a REQUIREMENT, not a ban: with the id, it builds.
+                const slot = materialize(createElement('adw-layout-slot', { id: 'probe' }));
+                expect(slot instanceof Adw.LayoutSlot).toBe(true);
             });
 
             await it('names a real class for every tag', async () => {

--- a/packages/framework/gtk-host/src/generated/props.ts
+++ b/packages/framework/gtk-host/src/generated/props.ts
@@ -17,7 +17,7 @@ import type Gio from '@girs/gio-2.0';
 import type Gtk from '@girs/gtk-4.0';
 import type Pango from '@girs/pango-1.0';
 
-import type { NotifyHandler } from '../attrs.js';
+import type { NotifyHandler, OutParam } from '../attrs.js';
 
 // Enum nicks. A property takes the nick OR the enum constant; a signal parameter
 // takes the constant only, because GJS hands the marshalled number and a nick
@@ -1665,7 +1665,7 @@ export interface AdwSpinRowProps
     /** Whether the spin row should wrap upon reaching its limits. */
     wrap?: boolean;
     /** Emitted to convert the user's input into a double value. */
-    onInput?: (new_value: number) => void;
+    onInput?: (new_value: OutParam) => void;
     /** Emitted to tweak the formatting of the value for display. */
     onOutput?: () => void;
     /** Emitted right after the spinbutton wraps. */
@@ -3004,7 +3004,7 @@ export interface GtkEditableProps extends GtkWidgetProps {
     /** Emitted when text is deleted from the widget by the user. */
     onDeleteText?: (start_pos: number, end_pos: number) => void;
     /** Emitted when text is inserted into the widget by the user. */
-    onInsertText?: (text: string, length: number, position: number) => void;
+    onInsertText?: (text: string, length: number, position: OutParam) => void;
     onNotifyEditable?: NotifyHandler;
     onNotifyEnableUndo?: NotifyHandler;
     onNotifyMaxWidthChars?: NotifyHandler;
@@ -5082,7 +5082,7 @@ export interface GtkSpinButtonProps
     /** Emitted when the user initiates a value change. */
     onChangeValue?: (scroll: Gtk.ScrollType) => void;
     /** Emitted to convert the users input into a double value. */
-    onInput?: (new_value: number) => void;
+    onInput?: (new_value: OutParam) => void;
     /** Emitted to tweak the formatting of the value for display. */
     onOutput?: () => void;
     /** Emitted when the value is changed. */

--- a/packages/framework/gtk-host/src/generator/emit-types.mts
+++ b/packages/framework/gtk-host/src/generator/emit-types.mts
@@ -120,6 +120,10 @@ export function emitProps(model: SurfaceModel, provenance: string): EmittedFile 
         });
 
     const decls = [...model.declarations.values()].sort((a, b) => (a.iface < b.iface ? -1 : 1));
+    // `noUnusedLocals` refuses an import nothing reads, and a GIR whose signals are
+    // all `in` produces exactly that file — the mini fixture is one.
+    const usesOutParam = decls.some((d) => d.signals.some((s) => s.ts.includes(': OutParam')));
+    const hostTypes = usesOutParam ? 'NotifyHandler, OutParam' : 'NotifyHandler';
     const byTag: string[] = [];
     const byGType: string[] = [];
     const classByTag: string[] = [];
@@ -145,7 +149,7 @@ export function emitProps(model: SurfaceModel, provenance: string): EmittedFile 
 
 ${imports.join('\n')}
 
-import type { NotifyHandler } from '../attrs.js';
+import type { ${hostTypes} } from '../attrs.js';
 
 // Enum nicks. A property takes the nick OR the enum constant; a signal parameter
 // takes the constant only, because GJS hands the marshalled number and a nick

--- a/packages/framework/gtk-host/src/generator/gir.mts
+++ b/packages/framework/gtk-host/src/generator/gir.mts
@@ -58,6 +58,13 @@ export interface GirProperty {
 export interface GirParam {
     readonly name: string;
     readonly type: GirType;
+    /** GIR's `direction`, which defaults to `in` when the attribute is absent. */
+    readonly direction: 'in' | 'out' | 'inout';
+    /**
+     * GIR's `caller-allocates`. It decides whether a non-`in` slot holds anything
+     * at all — see `renderParam` in `surface.mts`, which is the only reader.
+     */
+    readonly callerAllocates: boolean;
 }
 
 export interface GirSignal {
@@ -185,6 +192,11 @@ function readProperty(namespace: string, el: El): GirProperty {
     };
 }
 
+function readDirection(el: El): 'in' | 'out' | 'inout' {
+    const raw = el.getAttribute('direction');
+    return raw === 'out' || raw === 'inout' ? raw : 'in';
+}
+
 function readSignal(namespace: string, el: El): GirSignal {
     const params = firstChildEl(el, 'parameters');
     return {
@@ -193,6 +205,8 @@ function readSignal(namespace: string, el: El): GirSignal {
             ? ownChildren(params, 'parameter').map((p) => ({
                   name: p.getAttribute('name') ?? '',
                   type: readType(namespace, p),
+                  direction: readDirection(p),
+                  callerAllocates: p.getAttribute('caller-allocates') === '1',
               }))
             : [],
         deprecated: el.getAttribute('deprecated') === '1',

--- a/packages/framework/gtk-host/src/generator/surface.mts
+++ b/packages/framework/gtk-host/src/generator/surface.mts
@@ -137,6 +137,19 @@ export function buildSurface(
         for (const s of cls.signals) {
             const rendered: string[] = [];
             for (const [i, param] of s.params.entries()) {
+                // A non-`in` slot the CALLEE allocates carries nothing on the way in.
+                // Measured on gjs 1.88.1 / GTK 4.22.4: `Gtk.SpinButton::input` hands its
+                // `new_value` as 6.95e-310 — uninitialised memory, arriving as a
+                // perfectly ordinary `number`. Typing it `number` is an invitation to
+                // read it, and the reader gets no warning of any kind.
+                //
+                // `caller-allocates="1"` is the opposite case and is NOT rewritten:
+                // `Gtk.Overlay::get-child-position` hands a real `Gdk.Rectangle` for the
+                // handler to FILL, and the whole point of the signal is writing to it.
+                if (param.direction !== 'in' && !param.callerAllocates) {
+                    rendered.push(`${safeParamName(param.name, i)}: OutParam`);
+                    continue;
+                }
                 let mapped: ReturnType<typeof tsTypeOf>;
                 try {
                     mapped = tsTypeOf(param.type, universe, 'param');

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -90,6 +90,11 @@ export const isText = (node: HostNode): node is HostText => node.kind === 'text'
  */
 export function materialize(el: HostElement): GObject.Object {
     if (el.widget) return el.widget;
+    // Before `new Klass`, because for these GTypes there IS no after: a missing
+    // construct-only property reaches `g_error()` and takes the process with it.
+    for (const name of el.descriptor.requiresProps ?? []) {
+        if (!(name in el.props)) throw err.missingConstructProp(el.descriptor.gtype, name);
+    }
     const Klass = el.descriptor.ctor();
     const specs = paramSpecs(Klass, el.descriptor.gtype);
     const initial: Record<string, unknown> = {};

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -173,4 +173,11 @@ export interface WidgetDescriptor {
     readonly textSink?: string;
     /** `onActivate` -> `activate` is derived; irregular pairs live here, in the TABLE. */
     readonly eventAliases?: Readonly<Record<string, string>>;
+    /**
+     * Construct-only properties whose ABSENCE aborts the process rather than
+     * raising — see `REQUIRED_CONSTRUCT_PROPS` in `descriptors/` for the measurement.
+     * Checked in `materialize`, because after `g_object_new` there is nothing left
+     * to check with.
+     */
+    readonly requiresProps?: readonly string[];
 }

--- a/packages/framework/gtk-host/type-tests/jsx/negative-handlers.tsx
+++ b/packages/framework/gtk-host/type-tests/jsx/negative-handlers.tsx
@@ -2,6 +2,7 @@
 //
 // Grammar and mechanism: see the header of `negative-tags.tsx`.
 
+import type Gdk from '@girs/gdk-4.0';
 import type Gtk from '@girs/gtk-4.0';
 
 /** A handler parameter annotated as a type the signal never carries. */
@@ -25,3 +26,31 @@ export const narrowed = <gtk-notebook onPageAdded={(child: Gtk.Button, _n: numbe
 /** A handler declared with more parameters than the signal emits. */
 // @ts-expect-error TS2322 — `clicked` carries no arguments
 export const tooManyParams = <gtk-button onClicked={(widget: Gtk.Button) => widget.set_label('x')} />;
+
+/**
+ * An `out` parameter GIR marks `caller-allocates="0"`, read as if it were a value.
+ *
+ * GJS passes an argument in that slot and it holds uninitialised memory —
+ * measured, `new_value` arrives as `6.9526682391035e-310`, an ordinary `number`
+ * that nothing warns about. The generated signature gives it `OutParam`, so
+ * annotating `number` is a compile error at the position the reader would have
+ * looked, instead of a plausible reading of garbage.
+ */
+// @ts-expect-error TS2322 — `input` hands an uninitialised out slot, not a number
+export const readsOutParam = <gtk-spin-button onInput={(value: number) => value + 1} />;
+
+/**
+ * The OTHER direction, and why this is not a blanket ban on out parameters.
+ *
+ * `get-child-position` is `caller-allocates="1"`: the handler is handed a live
+ * `Gdk.Rectangle` to FILL, which is the entire purpose of the signal. It keeps
+ * its real type, and this line COMPILES — a fix that typed every non-`in`
+ * parameter as unusable would break it.
+ */
+export const fillsOutParam = (
+    <gtk-overlay
+        onGetChildPosition={(_child: Gtk.Widget, allocation: Gdk.Rectangle) => {
+            allocation.width = 10;
+        }}
+    />
+);


### PR DESCRIPTION
> Recreated from #1283, which GitHub auto-closed when its base branch was deleted by the #1282 squash-merge. Same commit, rebased onto `main`.

Both findings survived adversarial verification on #1281 and both are reproduced here.

## 1. The table shipped a row that KILLS THE PROCESS

`AdwLayoutSlot::constructed` calls `g_error("AdwLayoutSlot %p created without an ID")`. That is fatal **by contract** — SIGABRT, exit 134, a core dump — so there is no exception, no diagnostic, and nothing a `try` can do. `<adw-layout-slot>` with no `id` ends the consumer's process.

`descriptorProblems()` reports `[]` because it reads policy and never instantiates. Nothing in the 1746-test suite constructed a single one of the 164 generated widgets, which is exactly why a row like this was green.

**Measured**, bare-constructing all 164 rows one per process and resuming past the abort (gjs 1.88.1 / GTK 4.22.4 / Adw 1.10):

| rows | result |
|---|---|
| 163 | construct |
| 1 | `AdwLayoutSlot` — aborts |
| 0 | throw |

So the requirement is **curated as one entry**, not as a policy — GIR says `id` is construct-only and nullable, which is what it also says about properties that construct fine, and only running it tells them apart. `materialize` checks it **before** `g_object_new`, because for this GType there is no after:

```
<adw-layout-slot> cannot be constructed without id. In the installed library this is
not an exception but a g_error(): the process ABORTS (SIGABRT, exit 134, core dump)
with no catch and no diagnostic, so the host refuses here while a refusal is still
reportable. Author id on the element.
```

## 2. Three signal parameters carried uninitialised memory

`readSignal` never read `direction`. The non-`in` parameters of `Gtk.SpinButton::input`, `Adw.SpinRow::input` and `Gtk.Editable::insert-text` were therefore typed from their GIR type and read as ordinary inputs.

**Measured on gjs 1.88.1 / GTK 4.22.4**, by connecting and printing:

```
input:      new_value = 6.9526682391035e-310   typeof number
insert-text: position = 1711500784             typeof number
```

Nothing warns. A handler that reads either gets a plausible number.

They are emitted as `OutParam` — a nominal type nothing can be read out of and nothing but itself assigns to. **Declared**, not dropped, so a later `in` parameter cannot silently shift into the vacated position; and annotating `number` is now a compile error at the one position a reader would have looked.

**`caller-allocates="1"` is NOT rewritten, and that is the sharp edge.** `Gtk.Overlay::get-child-position` hands the handler a live `Gdk.Rectangle` to **fill** — measured as a real boxed wrapper, not garbage — and filling it is the entire purpose of the signal. A fix that blanket-typed every non-`in` parameter as unusable would break it, so a type-test asserts that line still **compiles**.

Across Gtk-4.0 and Adw-1 there are exactly four non-`in` signal parameters: three `caller-allocates="0"`, one `="1"`. The generated file changes by 4 lines.

## The mechanism, not the two fixes

`constructs every row it offers` — the suite now builds all 164 **through the host**, so `materialize` is exercised rather than bypassed. A future GType that aborts fails here with the tag on the last line, instead of a core dump nobody attributes; a future `requiresProps` entry that is not needed fails the `size` assertion.

`refuses a fatal construction by name instead of aborting` is its A/B in both directions: without `requiresProps` the first line does not throw, it ends the process — and the second line proves the entry is a *requirement*, not a ban, by building the slot with an `id`.

Two lines of `Gjs-CRITICAL: Attempting to run a JS callback during shutdown` are the price, and they are documented in place with the measurement: `installDiagnosticsGate` installs a process-global JS log writer and never takes it back. Disposing the widgets makes **eight** rows print it; leaving them alive makes **two** (`GtkColorChooserWidget`, `GtkEmojiChooser`). Neither is the host's doing, and skipping those two rows would trade the noise for the blindness this test exists to remove.

## Proof

- `1750 completed`, 0 failures (was 1746 + 4).
- `check-type-surfaces`: **13/13** negatives fire individually with the annotated code (was 12/12), 10 measurements, exit 0.
- `oxlint`: 0 errors. `gjsify tsc --noEmit`: clean.
- The generator is re-run, not hand-edited: `props.ts` moves by exactly the 4 expected lines.
