### PR TITLE
fix(gtk-host): drop the duplicated error constructor

### DIFF
--- a/packages/framework/gtk-host/src/errors.ts
+++ b/packages/framework/gtk-host/src/errors.ts
@@ -40,14 +40,6 @@ export const err = {
                 `catch and no diagnostic, so the host refuses here while a refusal is still reportable. ` +
                 `Author ${prop} on the element.`,
         ),
-    missingConstructProp: (tag: string, prop: string) =>
-        new GtkHostError(
-            'missing-construct-prop',
-            `<${tag}> cannot be constructed without ${prop}. In the installed library this is not an ` +
-                `exception but a g_error(): the process ABORTS (SIGABRT, exit 134, core dump) with no ` +
-                `catch and no diagnostic, so the host refuses here while a refusal is still reportable. ` +
-                `Author ${prop} on the element.`,
-        ),
     unknownProp: (tag: string, prop: string) =>
         new GtkHostError(
             'unknown-prop',


### PR DESCRIPTION
## main is red

`missingConstructProp` is declared **twice** in the same object literal in `errors.ts`. On `main`:

```
##[error]Duplicate key 'missingConstructProp'
Found 60 warnings and 1 error.
```

`Whole-tree checks` and `Build Fedora 44 (GJS 1.88 / SM 140)` fail, `CI gate (GJS)` fails with them, and **every open PR inherits it** — #1285, #1286 and #1288 are all red on a defect none of them contains.

## How two squash-merges produced it

#1287 introduced `missingConstructProp`. #1284 was stacked on #1287, so its branch carried #1287's **original** commits. Squashing #1287 put a *new* commit on `main` with the same content under a different SHA; squashing #1284 onto that `main` then re-applied the block instead of recognising it as already present.

**No conflict was raised, and none could be**: neither side edited a line the other side touched. The two halves of the identical-name rule are on different lines, so the three-way merge is clean and the result is invalid.

## tsc is the cheaper detector

```
src/errors.ts(43,5): error TS1117: An object literal cannot have multiple properties with the same name.
```

A duplicate key is a **type error**, not a lint opinion. `gjsify tsc --noEmit` catches it in the package in seconds, where `Whole-tree checks` needs a full container. The practical rule this leaves behind: run `tsc` after a **rebase**, not only after an edit — a rebase is precisely when a symbol can be duplicated without anyone writing it twice.

## Proof

`1791 completed`, 0 failures. `oxlint`: 1 error → **0**. `gjsify tsc --noEmit`: clean. `gjsify format --check`: clean.

The removed block is byte-identical to the one kept — `git show` on the diff is a pure deletion, so nothing about the error's text or code changes.