### PR TITLE
fix(assert): make require('assert') callable

### DIFF
--- a/packages/node/assert/src/cjs-interop.fixture.cjs
+++ b/packages/node/assert/src/cjs-interop.fixture.cjs
@@ -1,0 +1,27 @@
+// CJS fixture bundled into the assert test suite to guard the `require('assert')`
+// interop. A real npm dependency does exactly this — `@babel/helper-module-imports`
+// is the measured one: `const assert = require("assert")` at module scope, then
+// `assert(typeof importName === "string")` on the path of every Babel plugin that
+// injects an import.
+//
+// Under `--app gjs` the bundler resolves `require('assert')` to `@gjsify/assert`
+// and wraps it with the `__toCommonJS` helper. Without the `"module.exports"`
+// string-export in `@gjsify/assert` that yields the ESM NAMESPACE OBJECT instead of
+// the callable, and the first call throws `_assert is not a function` — which is how
+// `babel-preset-solid` became uncompilable by a GJS-hosted bundler.
+//
+// oxlint-disable unicorn/prefer-node-protocol -- intentional: this fixture reproduces how
+// real npm CJS deps require builtins by BARE name (`require('assert')`, not
+// `require('node:assert')`) — the exact path the fix guards.
+const assert = require('assert');
+const strict = require('assert/strict');
+
+// Calling at module scope makes merely IMPORTING this fixture the regression guard:
+// on a regressed build the module aborts at load instead of failing an assertion
+// later, and a bundle that cannot load is not a test that quietly passes.
+assert(true);
+assert.strictEqual(1, 1);
+strict(true);
+strict.strictEqual(1, 1);
+
+module.exports = { assert, strict };

--- a/packages/node/assert/src/index.spec.ts
+++ b/packages/node/assert/src/index.spec.ts
@@ -23,6 +23,9 @@ import {
 } from 'node:assert';
 import assert from 'node:assert';
 
+// Bundled CJS fixture — importing it IS the regression guard, see the file header.
+import cjsInterop from './cjs-interop.fixture.cjs';
+
 export default async () => {
     await describe('AssertionError', async () => {
         await it('should be an instance of Error', async () => {
@@ -490,6 +493,34 @@ export default async () => {
         await it('should work as a function (like ok)', async () => {
             expect(() => assert(true)).not.toThrow();
             expect(() => assert(false)).toThrow();
+        });
+    });
+
+    // CJS `require('assert')` interop — the bundler `__toCommonJS` +
+    // `"module.exports"` string-export path (regression guard).
+    //
+    // The A/B that produced it: with the string-export removed, this whole bundle
+    // aborts at LOAD with `_assert is not a function`, so the assertions below never
+    // run and the suite reports zero tests rather than one failure. That is the point
+    // — the defect is a load-time one, and a guard that could only report it as a
+    // failed assertion would be describing a milder bug than the real one.
+    await describe('CJS require() interop', async () => {
+        await it('require("assert") yields the callable function', async () => {
+            expect(typeof cjsInterop.assert).toBe('function');
+            expect(() => cjsInterop.assert(true)).not.toThrow();
+            expect(() => cjsInterop.assert(false)).toThrow();
+        });
+
+        await it('the callable still carries its named members', async () => {
+            expect(typeof cjsInterop.assert.strictEqual).toBe('function');
+            expect(typeof cjsInterop.assert.deepStrictEqual).toBe('function');
+        });
+
+        await it('require("assert/strict") yields the strict callable', async () => {
+            expect(typeof cjsInterop.strict).toBe('function');
+            expect(() => cjsInterop.strict(true)).not.toThrow();
+            // `equal` is `strictEqual` on the strict binding: 1 == '1' is not 1 === '1'.
+            expect(() => cjsInterop.strict.equal(1, '1')).toThrow();
         });
     });
 };

--- a/packages/node/assert/src/index.ts
+++ b/packages/node/assert/src/index.ts
@@ -566,3 +566,20 @@ export {
 };
 
 export default assert;
+
+// CJS-interop for bundled `require('assert')`. The Rolldown/esbuild `__toCommonJS`
+// helper special-cases a `"module.exports"` own-property on the module namespace and
+// returns it verbatim instead of building the namespace object, so exposing the
+// callable default under that string-export name makes a bundled CJS
+// `require('assert')` yield the FUNCTION (matching Node's `module.exports = assert`).
+// The `require`-condition `cjs-compat.cjs` shim cannot be selected here: `--app gjs`'s
+// esm `conditionNames` omit `require`. Same fix, same reason, as `@gjsify/stream` and
+// `@gjsify/events` — and the same failure without it, one layer deeper.
+//
+// MEASURED CONSUMER: `@babel/helper-module-imports` does `const assert =
+// require("assert")` and then `assert(typeof importName === "string")`. Bundled for
+// `--app gjs` that threw `_assert is not a function` inside `ImportInjector.addNamed`,
+// which is on the path of EVERY `babel-preset-solid` compile — so Solid JSX could not
+// be compiled by a GJS-hosted bundler at all. Normal ESM named/default imports were
+// unaffected, which is why nothing else noticed.
+export { assert as 'module.exports' };

--- a/packages/node/assert/src/strict/index.ts
+++ b/packages/node/assert/src/strict/index.ts
@@ -19,3 +19,8 @@ export {
     deepStrictEqual as deepEqual,
     notDeepStrictEqual as notDeepEqual,
 } from '../index.js';
+
+// The same CJS-interop as `../index.ts`, for `require('assert/strict')` — Node's
+// `module.exports` there is the strict callable. This subpath has no `require`
+// condition at all, so the string-export is the only path.
+export { strict as 'module.exports' } from '../index.js';


### PR DESCRIPTION
## The defect

A bundled `require('assert')` yields an **object** under `--app gjs`, where Node yields the **function**.

`setupForGjs` sets `conditionNames: format === 'esm' ? ['browser','import'] : ['browser','require','import']`. An `--app gjs` build emits ESM, so `require` is not an active condition and the `require`-condition shim `packages/node/assert/cjs-compat.cjs` can never be selected. Rolldown resolves the bare `require('assert')` to `@gjsify/assert`'s ESM entry and wraps it with `__toCommonJS`, which builds a namespace object.

`@gjsify/stream` and `@gjsify/events` were fixed for exactly this in 0.16.5, with a `"module.exports"` string-export that `__toCommonJS` returns verbatim instead of building a namespace. `@gjsify/assert` never got the same treatment, and `./strict` has no `require` condition at all.

## How it surfaced

`@babel/helper-module-imports` does `const assert = require("assert")` at module scope and then calls it in `ImportInjector.addNamed` — which is on the path of **every** Babel plugin that injects an import. Bundled for `--app gjs`, the GJS-hosted bundler threw:

```
plugin `gjsify-solid` threw an error
Caused by: _assert is not a function
  _applyDefaults@…/plugins/_gjsify_rolldown-plugin-solid-…/index.mjs:85485
  ImportInjector@…:85466
  addNamed@…:85624
  registerImportMethod@…:97856
  transformElement$1@…:99393
```

So `babel-preset-solid` — and with it Solid JSX — could not be compiled by gjsify at all. The stack trace names Babel, which is why the cause took a bundle read to find: the emitted binding is

```js
var _assert = (init_esm$8(), __toCommonJS(esm_exports$5));
```

## The fix

`export { assert as 'module.exports' };` in `src/index.ts`, and the same for the strict callable in `src/strict/index.ts`. ESM named and default imports are unaffected.

## Measurement

| | Node 24.19.0 | Gjs 1.88.1 |
|---|---|---|
| with the string-export | **125 completed** | **125 completed** |
| without it | 125 completed | **aborts at load**, `TypeError: n is not a function`, exit 1, **0 tests** |

The Node leg cannot detect this by construction — there `require('assert')` is the real builtin — which is why the guard is a **bundled CJS fixture** (`src/cjs-interop.fixture.cjs`, the same shape as `@gjsify/stream`'s) rather than an ESM import: on a regressed build the module aborts at load, so merely importing it is the assertion. That also means the failure mode is honest about itself — a regression reports *zero tests*, not one failed expectation.

Downstream A/B: with the fix, `showcases/gtk/solid-host-counter` builds (exit 0) and its probe passes; without it the build fails with `_assert is not a function`. That showcase arrives in the PR stacked on this one.

## Still open (not this PR)

The `conditionNames` defect itself — `--app gjs` leaving `require` out of the ESM condition set — is untouched. Every `require`-condition shim in the repo is still unreachable for that format, and each package that needs one needs this same string-export. Worth its own change; the memory note `gjsify-require-condition-cjs-compat-bug` records the inconclusive first investigation.
