### PR TITLE
docs(website): document the UI framework bindings

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -119,6 +119,9 @@ export default defineConfig({
                     label: 'Guides',
                     items: [
                         { slug: 'guides/native-adwaita-app' },
+                        { slug: 'guides/ui-frameworks' },
+                        { slug: 'guides/solid-jsx' },
+                        { slug: 'guides/vue-sfc' },
                         { slug: 'patterns/gobject-classes' },
                         { slug: 'patterns/bridges', label: 'Bridge Widgets' },
                         { slug: 'guides/storybook' },

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -128,6 +128,29 @@ For `--app gjs` the JS target is `firefox140` (SpiderMonkey 140), and `gi://*`, 
 
 </details>
 
+#### Compile JSX and Vue templates
+
+JSX and `.vue` are compiler input, not runtime syntax, so the build needs a plugin that knows which framework you meant. Name one under `gjsify.bundler.plugins` ([below](#name-a-bundler-plugin-instead-of-writing-a-config-file)) and build the entry normally:
+
+```bash
+gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs
+```
+
+- [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) for SolidJS JSX
+- [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) for Vue single-file components
+
+**`--app gjs` refuses a JSX entry that configures no transform**, and that refusal is the point. Left unset, the transformer applies its own default — the automatic React runtime — so the bundle imports `react/jsx-runtime`. GJS resolves no bare specifier, so the build would report the miss as a *warning*, exit 0, and the artifact would abort at load with `ImportError: Module not found: react/jsx-runtime`. On a project that does have React installed it is worse: the bundle builds React elements, which a GTK host does nothing with.
+
+Answer the question one of three ways, and the error message lists all three:
+
+| Answer | How |
+|---|---|
+| Preserve the JSX for a framework compiler | `"jsx": "preserve"` in tsconfig or `gjsify.bundler.transform.jsx`, plus the plugin above. Pair with tsconfig `"jsxImportSource": "@gjsify/gtk-host"` for the types. |
+| Use an automatic runtime you actually have | `"jsx": "react-jsx"` + `"jsxImportSource": "<pkg exporting ./jsx-runtime>"`. **Not** `@gjsify/gtk-host` — its `/jsx-runtime` is a type surface and throws when called. |
+| Say the entry holds no JSX | `"jsx": false`, and the transformer reports the JSX itself. |
+
+`--app node` and `--app browser` are unaffected: the React default is a legitimate answer there, and refusing would break builds for a mistake they did not make.
+
 #### Bundle a third-party CLI that reads its own `package.json`
 
 Tools like `typedoc` and `prettier` read their own `package.json` during top-level evaluation, via something like `Path.join(fileURLToPath(import.meta.url), '../../../package.json')`. Once bundled, `import.meta.url` points at your bundle, the lookup escapes the package, and the tool crashes on startup.
@@ -460,7 +483,7 @@ Anything you would pass repeatedly on the command line can live in the `gjsify` 
 | Key | What it sets |
 |---|---|
 | `app` | Default `--app` target for this project. |
-| `bundler` | Rolldown options passed through. Most projects only set `output.file` or `output.dir`. |
+| `bundler` | Rolldown options passed through. Most projects only set `output.file`, `output.dir` or [`plugins`](#name-a-bundler-plugin-instead-of-writing-a-config-file). |
 | `globals` | Default `--globals` value. |
 | `excludeGlobals` | Identifiers to drop from the auto-detected set. |
 | `exclude` | Glob patterns to exclude from entry points and aliases. |
@@ -505,6 +528,37 @@ To pull a constant out of `package.json` or the environment instead, use the ded
 ```
 
 An unset variable with no `default` becomes the literal `undefined`, so you can guard with `typeof __PREFIX__ === 'undefined'`.
+
+### Name a bundler plugin instead of writing a config file
+
+`bundler.plugins` takes a list of plugin *entries*, so a project that needs one extra transform keeps its whole build in `package.json`:
+
+```jsonc
+{
+  "gjsify": {
+    "bundler": {
+      "plugins": [
+        { "name": "@gjsify/rolldown-plugin-solid" },
+        { "name": "./build/my-plugin.mjs", "export": "myPlugin", "options": { "verbose": true } }
+      ]
+    }
+  }
+}
+```
+
+| Field | Default | What it does |
+|---|---|---|
+| `name` | required | A package name, or a path relative to the project. Resolution is anchored at the project root, so the project's own `node_modules` wins over the CLI's. |
+| `export` | `default` | Which export to call. It has to be a function returning a Rolldown plugin. |
+| `options` | `{}` | Passed to that function. |
+
+`plugins` is an array, and every entry is an object with those fields — a bare `"@gjsify/rolldown-plugin-solid"` string is not the same thing and is not accepted.
+
+A named plugin must be a real dependency of the package that configures it — `dependencies`, `devDependencies` or `optionalDependencies`, any of the three. In a monorepo an undeclared one resolves anyway through the hoisted root `node_modules` and then stops resolving the moment the package is installed from npm, which is a declaration that is true in the tree and false everywhere else. `gjsify` conformance fails on it rather than letting it ship.
+
+Plugins run in the order listed.
+
+Under `--app gjs` the CLI bundles the plugin to one self-contained ESM file before importing it, because GJS's own ESM loader does not follow `package.json#exports` subpath maps. So the plugin's whole dependency tree has to load under GJS, not only its entry.
 
 ### Loading unusual file types
 

--- a/website/src/content/docs/contributing/architecture.md
+++ b/website/src/content/docs/contributing/architecture.md
@@ -59,6 +59,6 @@ GJSify treats the **Node.js API**, the **Web API**, the **DOM API** and the **Fr
 - `packages/node/`: Node.js builtins (`fs`, `http`, `crypto`, …)
 - `packages/web/`: Web platform APIs (`fetch`, `WebSocket`, `ReadableStream`, Web Crypto, …)
 - `packages/dom/`: DOM element classes (`HTMLCanvasElement`, `HTMLImageElement`, …) with headless Canvas 2D
-- `packages/framework/`: everything that glues DOM and GTK together without being a spec implementation: the GTK host (`@gjsify/gtk-host`) that UI-framework renderers target, the [bridge widgets](/gjsify/patterns/bridges/), the [storybook](/gjsify/guides/storybook/), the [devtools control plane](/gjsify/guides/devtools/) and the [Adwaita app shell](/gjsify/guides/native-adwaita-app/)
+- `packages/framework/`: everything that glues DOM and GTK together without being a spec implementation: the [GTK host](/gjsify/guides/ui-frameworks/) (`@gjsify/gtk-host`) that UI-framework renderers target, the [bridge widgets](/gjsify/patterns/bridges/), the [storybook](/gjsify/guides/storybook/), the [devtools control plane](/gjsify/guides/devtools/) and the [Adwaita app shell](/gjsify/guides/native-adwaita-app/)
 
 The DOM-element ↔ GTK-widget pairings are documented in [Bridge Widgets](/gjsify/patterns/bridges/).

--- a/website/src/content/docs/guides/solid-jsx.md
+++ b/website/src/content/docs/guides/solid-jsx.md
@@ -1,0 +1,153 @@
+---
+title: Solid JSX
+description: Compile SolidJS JSX for a GTK 4 build with @gjsify/rolldown-plugin-solid. Universal generate mode, the tsconfig half that goes with it, and the silent failure it exists to stop.
+---
+
+[`@gjsify/rolldown-plugin-solid`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)
+compiles SolidJS JSX during a gjsify build, in `universal` generate mode — the only mode whose
+output contains no DOM. It targets the renderer in
+[`@gjsify/gtk-host/solid`](/gjsify/guides/ui-frameworks/), and it is the whole compile step: a
+`.tsx` entry plus this plugin is a GTK app.
+
+It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
+
+## Install
+
+```bash
+gjsify install @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+```
+
+## Wire it up
+
+Name the plugin in `package.json#gjsify`. There is no JS-form config file to add:
+
+```jsonc
+{
+    "gjsify": {
+        "bundler": {
+            "plugins": [{ "name": "@gjsify/rolldown-plugin-solid" }]
+        }
+    }
+}
+```
+
+Then build the `.tsx` entry like any other:
+
+```bash
+gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs
+gjsify run dist/app.gjs.mjs
+```
+
+Or drop it into a Rolldown / Vite config directly:
+
+```ts
+// rolldown.config.ts
+import { solidPlugin } from '@gjsify/rolldown-plugin-solid';
+
+export default {
+    plugins: [solidPlugin({ moduleName: '@gjsify/gtk-host/solid' })],
+};
+```
+
+### Options
+
+| Option | Default | What it does |
+|---|---|---|
+| `moduleName` | `@gjsify/gtk-host/solid` | Module the compiler imports the renderer ops from. |
+| `generate` | `universal` | `babel-preset-solid` mode. `dom` emits `document.createElement`, which GJS does not have. |
+| `include` | `/\.(m\|c)?[jt]sx$/` | Which modules to compile. A `.ts` file cannot contain JSX, so widening this is a mistake. |
+
+## The TypeScript half, and both halves are required
+
+```jsonc
+{
+    "compilerOptions": {
+        "jsx": "preserve",
+        "jsxImportSource": "@gjsify/gtk-host",
+        "strict": true
+    }
+}
+```
+
+`jsx: "preserve"` is what this plugin needs — the JSX has to survive TypeScript so Babel can
+take it, and `"react"` is refused outright with `jsxImportSource` (TS5089).
+
+`noImplicitAny` — which `strict` turns on — is not optional either. With `jsx: "preserve"`, no
+`jsxImportSource` and `noImplicitAny` off, **every JSX element is implicitly `any` and `tsc`
+exits 0 having checked nothing**. A project in that state watches a clean type check go by and
+concludes the type surface works.
+
+One gap the surface cannot close: TypeScript exempts every hyphen-containing JSX attribute
+from excess-property checking, so `<gtk-box no-such={1} />` is accepted. Both spellings are
+generated, so a declared `can-focus="yes"` still fails on its *value* — but prefer `canFocus`,
+which is checked both ways.
+
+## Why Babel, in an oxc toolchain
+
+Solid's JSX is a **compiler**, not a runtime. `babel-plugin-jsx-dom-expressions` turns markup
+into straight-line calls against a renderer, and no oxc or SWC port of it exists. Rolldown's
+own transformer cannot stand in.
+
+That matters because of what happens when nothing is configured. Pointed at a `.tsx` with no
+JSX policy, the transformer defaults to the automatic React runtime and emits
+`import { jsx } from "react/jsx-runtime"`. GJS cannot resolve a bare specifier at all, so the
+build reports the miss as a **warning**, exits 0 — and the artifact dies at its first import
+under `gjs`. Measured end to end: exit 0, then exit 1.
+
+`gjsify build --app gjs` now refuses that case up front. Give it a `.tsx` entry with no
+`gjsify.bundler.transform.jsx` and no tsconfig `compilerOptions.jsx`, and the build stops with
+an error naming the file and the three ways to answer the question. The refusal is scoped to
+`--app gjs`: on `--app node` and `--app browser` the React default is a legitimate answer for a
+project that has React installed.
+
+Babel is loaded on the first matching module, so a build with no JSX in it never pays for it.
+
+## What the compiler emits
+
+Measured on real markup:
+
+```js
+var _el$ = _$createElement("adw-application-window"),
+    _el$2 = _$createElement("adw-toolbar-view");
+_$insertNode(_el$, _el$2);
+_$setProp(_el$, "title", "solid-host counter");
+```
+
+Three consequences, and each is a thing the host has to do rather than the adapter:
+
+- **Children are inserted before properties are set**, and `createElement` never sees a prop.
+  A construct-only property such as `cssName` therefore only survives because the host defers
+  materialisation and rebuilds when it has to.
+- **Handlers arrive through `setProp`** under their JSX spelling (`onClicked`), not through a
+  separate op.
+- **The renderer op names are emitted literally.** They are the member names of Solid's
+  `Renderer<NodeType>` — `createElement`, `createTextNode`, `insertNode`, `insert`, `spread`,
+  `setProp`, `mergeProps`, `effect`, `memo`, `createComponent`, `render`, `use` — so
+  `moduleName` must re-export all twelve under exactly those names. A renderer that exports
+  eleven builds fine and fails with `MISSING_EXPORT` on the twelfth, only for the JSX that
+  happens to need it.
+
+## Import control flow from the adapter
+
+`For`, `Index`, `Show` and `Dynamic` come from `@gjsify/gtk-host/solid`, never from
+`solid-js/web`. That package is Solid's DOM renderer: its components build DOM elements
+nothing here can place. Measured with `<Dynamic component="GtkLabel">` imported from
+`solid-js/web` into a GJS bundle — the box's children were just the static sibling, with no
+throw, no GTK diagnostic and exit 0. Importing it also makes `--globals auto` inject
+`document`, `HTMLCanvasElement` and `Path2D`, and pull `gi://Gdk`, `GdkPixbuf`, `Pango` and
+`PangoCairo` into the bundle.
+
+## What it does not do
+
+The plugin is the compile step and nothing else. No `<style>` or CSS handling — GTK styling is
+a `Gtk.CssProvider` concern. No dev or HMR mode. `generate: "dom"` and `"ssr"` are settable and
+untested, because nothing here has a DOM to render into.
+
+## Related
+
+- [UI Frameworks](/gjsify/guides/ui-frameworks/) for the host, the widget table and the
+  placement rules
+- [Vue SFCs](/gjsify/guides/vue-sfc/) for the same pipeline on `@vue/compiler-sfc`
+- [`solid-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/solid-host-counter),
+  a complete window that asserts its own widget tree on every launch
+- [`@gjsify/rolldown-plugin-solid` on npm](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)

--- a/website/src/content/docs/guides/ui-frameworks.md
+++ b/website/src/content/docs/guides/ui-frameworks.md
@@ -1,0 +1,317 @@
+---
+title: UI Frameworks
+description: Describe your GTK 4 window instead of assembling it. One host layer under Solid, Vue and React, with the widget table, the placement rules and the type surfaces generated from the GIR.
+---
+
+A GTK app is usually written imperatively: `new Gtk.Box()`, `append()`, `connect()`, and you
+keep the tree in your head. Every modern UI framework offers the opposite deal — describe the
+tree, let a renderer reconcile it. Solid, Vue and React each publish a contract for rendering
+into something that is not the DOM. What none of them ships is the *something*.
+
+[`@gjsify/gtk-host`](https://www.npmjs.com/package/@gjsify/gtk-host) is that something: an
+element model over GTK 4 and libadwaita that can create a widget, set a property, adopt a
+child and navigate the result. The three adapters sit on top of it and hold no widget
+knowledge at all.
+
+Nothing here hides `Gtk` or `Adw`. Every tag names a real GTK class, `on:<raw-signal-name>`
+reaches a signal whose spelling is irregular, and you mount into a window your application
+already built.
+
+## Install
+
+```bash
+gjsify install @gjsify/gtk-host
+```
+
+Your framework is a peer dependency and stays yours: `solid-js`, `@vue/runtime-core`, or
+`react` + `react-reconciler`. Install only the one you use.
+
+## One host, three adapters
+
+| Adapter | Import | Framework contract | Compile step |
+|---|---|---|---|
+| Solid | `@gjsify/gtk-host/solid` | `solid-js/universal`, 10 methods | [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) |
+| Vue | `@gjsify/gtk-host/vue` | `@vue/runtime-core`, 10 required + 4 optional | [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) |
+| React | `@gjsify/gtk-host/react` | `react-reconciler` HostConfig | none — TypeScript's own automatic runtime |
+
+Three different renderer contracts satisfied by one descriptor table and one placement engine
+is what makes "framework-agnostic" a measurement rather than an intention. A check
+(`scripts/check-adapter-import-direction.mjs`) fails the build if an adapter reaches past the
+table for widget knowledge, so the split cannot erode.
+
+## Solid JSX
+
+`registerBuiltinWidgets()` loads the generated table; after that the tags are available.
+Build with [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/), which is what turns
+the JSX into calls against the host.
+
+```tsx
+import Adw from 'gi://Adw?version=1';
+import { createRoot, createSignal } from 'solid-js';
+
+import { registerBuiltinWidgets, type HostNode } from '@gjsify/gtk-host';
+import { For, widgetOf } from '@gjsify/gtk-host/solid';
+
+registerBuiltinWidgets();
+
+function Counter(app: Adw.Application) {
+    const [count, setCount] = createSignal(0);
+    const [rows, setRows] = createSignal<readonly string[]>([]);
+
+    return (
+        <adw-application-window title="Counter" defaultWidth={480} application={app}>
+            <adw-toolbar-view>
+                <adw-header-bar slot="top" />
+                <adw-preferences-page slot="content">
+                    <adw-preferences-group title="Rows">
+                        <For each={rows()}>{(row) => <adw-action-row title={row} />}</For>
+                        <adw-action-row title="Clicks" subtitle={String(count())} />
+                    </adw-preferences-group>
+                    <adw-preferences-group title="Actions">
+                        <gtk-box orientation="vertical" spacing={12}>
+                            <gtk-button label="Increment" onClicked={() => setCount((n) => n + 1)} />
+                            <gtk-button
+                                label="Add row"
+                                onClicked={() => setRows((r) => [...r, `Row ${r.length + 1}`])}
+                            />
+                        </gtk-box>
+                    </adw-preferences-group>
+                </adw-preferences-page>
+            </adw-toolbar-view>
+        </adw-application-window>
+    ) as HostNode;
+}
+
+const app = new Adw.Application({ application_id: 'org.example.Counter' });
+app.connect('activate', () => {
+    const node = createRoot(() => Counter(app));
+    (widgetOf(node) as Adw.ApplicationWindow).present();
+});
+await app.runAsync([]);
+```
+
+`createRoot` rather than bare JSX: every `{count()}` compiles to a computation, and a
+computation created without an owner is never disposed. Solid says so on stderr.
+
+`widgetOf(node)` hands you the real widget behind a host node. It is exported from
+`@gjsify/gtk-host/solid` and `@gjsify/gtk-host/react` — the two adapters whose root *is* a
+node you hold. Vue's is not; see below.
+
+Import `For`, `Index`, `Show` and `Dynamic` from the **adapter**, never from `solid-js/web`.
+That package is Solid's DOM renderer; its components build DOM elements nothing here can
+place, and the measured result is a subtree that renders nothing, silently, at exit 0.
+
+## Vue single-file components
+
+Vue mounts *into* a container, and a toplevel window is not a child of anything. So the
+application owns the window and Vue owns everything inside it, which is the shape
+`mount(rootComponent, container)` documents.
+
+```vue
+<!-- src/App.vue -->
+<script setup lang="ts">
+import { ref } from '@vue/runtime-core';
+
+const count = ref(0);
+const rows = ref<readonly string[]>([]);
+
+const increment = () => { count.value += 1; };
+const addRow = () => { rows.value = [...rows.value, `Row ${rows.value.length + 1}`]; };
+</script>
+
+<template>
+    <adw-toolbar-view>
+        <adw-header-bar slot="top">
+            <GtkLabel label="Counter" slot="title" />
+        </adw-header-bar>
+        <adw-preferences-page slot="content">
+            <adw-preferences-group title="Rows">
+                <adw-action-row v-for="row in rows" :key="row" :title="row" />
+                <adw-action-row title="Clicks" :subtitle="String(count)" />
+            </adw-preferences-group>
+            <adw-preferences-group title="Actions">
+                <gtk-box orientation="vertical" :spacing="12">
+                    <gtk-button label="Increment" @clicked="increment" />
+                    <gtk-label v-if="count > 0" :label="`clicked ${count}x`" />
+                    <gtk-button label="Add row" @clicked="addRow" />
+                </gtk-box>
+            </adw-preferences-group>
+        </adw-preferences-page>
+    </adw-toolbar-view>
+</template>
+```
+
+```ts
+// src/app.ts
+import Adw from 'gi://Adw?version=1';
+
+import { registerBuiltinWidgets } from '@gjsify/gtk-host';
+import { mount } from '@gjsify/gtk-host/vue';
+
+import App from './App.vue';
+
+registerBuiltinWidgets();
+
+const app = new Adw.Application({ application_id: 'org.example.Counter' });
+app.connect('activate', () => {
+    const window = new Adw.ApplicationWindow({ application: app, title: 'Counter', default_width: 480 });
+    mount(App, window);
+    window.present();
+});
+await app.runAsync([]);
+```
+
+The Vue adapter exports `render`, `createApp`, `mount` and `adopt` — and deliberately no
+`widgetOf`. You already hold the window you mounted into, and everything below it belongs to
+Vue's own reconciler rather than to a node you can name. Reach for a widget inside the tree
+with a `ref` on the element, as you would in any Vue app.
+
+Both tag spellings work in a template. `<GtkLabel>` and `<gtk-label>` resolve to the same
+widget and to the same type-check key, so pick one and stay with it. The build needs
+[`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) and four `--define` flags; that page
+has the recipe and the reason.
+
+## React
+
+React needs no compile plugin — its JSX is a runtime, and the adapter ships the automatic
+runtime TypeScript expects. Point `jsxImportSource` at the subpath, not at `react`:
+
+```jsonc
+{
+    "jsx": "react-jsx",
+    "jsxImportSource": "@gjsify/gtk-host/react",
+    "noImplicitAny": true
+}
+```
+
+```tsx
+import { createRoot } from '@gjsify/gtk-host/react';
+
+const root = createRoot(myWindow);
+root.render(
+    <gtk-box orientation="vertical">
+        <gtk-label label="hi" />
+    </gtk-box>,
+);
+```
+
+`root.render()` is synchronous on purpose. A concurrent root hands its updates to the
+scheduler, which under GJS is a GLib timer source — with no main loop running yet, an
+unflushed first render leaves the container empty and says nothing. A `setState` from a GTK
+signal handler *is* concurrent and lands on the next main-loop iteration; `flushSync` is the
+escape hatch.
+
+Build it with `--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`.
+The development `react-reconciler` bundle reaches for `document`, `HTMLCanvasElement` and
+`Path2D`, and `--globals auto` is a static scan: it answers those identifiers by pulling
+`gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` into a bundle that needs none of them.
+
+## What the host refuses to do quietly
+
+GTK's failure mode is exit 0. A renderer that forwards authored values verbatim produces a
+wrong window and a green test run, so the host is loud instead. Measured on gjs 1.88.1:
+
+| What you write | What GObject does | What the host does |
+|---|---|---|
+| `orientation="vertical"` | keeps `HORIZONTAL`; the JS setter says nothing at all | resolves the nick against the enum's GType |
+| `orientation="sideways"` | the same silence | throws, naming `GtkOrientation` |
+| a read-only property | accepts the write, stores nothing | throws, naming the property |
+| a misspelled property | nothing | throws, naming the widget |
+| text inside `<gtk-image>` | nothing | throws, naming the tag and where the text could go |
+| a child under a childless widget | `Gtk-WARNING` at exit 0 | throws, naming the three fixes |
+| `selectable="false"` as a string | JS truthiness makes it `true` | honours `'true'`/`'false'`, throws on anything else |
+
+Values are coerced against the `GParamSpec` read from the **installed** GTK, so the table
+says a property exists and the ParamSpec says what a value may look like.
+
+## Where a child goes
+
+GTK 4 deleted `GtkContainer`, so there is no generic `add`. Each container's adoption rule is
+data, declared once and shared by all three adapters:
+
+| Kind | Example | How a child lands |
+|---|---|---|
+| `single` | `AdwBin`, `GtkWindow` | `set_child` / `set_content` |
+| `ordered` | `GtkBox` | `append` + `insert_child_after` |
+| `indexed` | `GtkListBox` | `insert(row, i)`, addressing a wrapper row |
+| `slotted` | `AdwHeaderBar` | `pack_start` / `pack_end` / `set_title_widget`, chosen by `slot` |
+| `keyed` | `GtkStack` | `add_titled(child, name, title)` |
+| `coords` | `GtkGrid` | `attach(child, column, row, …)` |
+| `none` | `GtkLabel` | rejected, with the three fixes named |
+
+`slot` and `layout` are props the **child** declares: `slot="end"` picks a slotted attachment
+point, `layout={{ column, row }}` a grid cell, `layout={{ name, title }}` a stack page.
+Changing either re-places the child rather than doing nothing.
+
+A container that cannot reorder in place says so instead of pretending. `Adw.PreferencesGroup`
+has `add` and `remove` and no `insert`, so it is `ordered` with `reorder: 'remove-all'` and
+pays a tail re-append. Its near-identical sibling `Adw.PreferencesPage` does have
+`insert(group, i)`, so it is `indexed` and places at the index directly. That is why the table
+is measured per widget rather than inherited.
+
+## Mount into a window you already own
+
+`adopt(container)` wraps a widget your application built as a host element and **records the
+children it already had**, so the rendered tree lands after your own chrome rather than above
+it. `mount()` in the Solid and Vue adapters and `createRoot()` in the React one all go through
+it; call it yourself when you need the explicit spelling, such as a Vue `<Teleport>` target:
+
+```ts
+import { adopt, mount } from '@gjsify/gtk-host/vue';
+
+mount(App, myWindow);           // adopts for you
+const target = adopt(mySidebar); // then `:to="target"`
+```
+
+A `<Teleport>` target must be a widget, never a string. Resolving a name would need a registry
+of mounted roots; until something needs one, a string throws rather than rendering nothing.
+
+## The widget table and the type surfaces
+
+164 concrete `GtkWidget` descendants (102 from Gtk, 62 from Adw) are generated from the GIR
+and committed with the package. 26 of them also carry a hand-written placement rule, and the
+generator may only ever add a tag, never contradict a curated one. A tag with no rule can be
+created, given properties and given handlers; inserting a child into it raises an error naming
+the tag that needs a policy. Guessing is not on offer — `add`, `append` and `set_child` all
+exist somewhere in GTK, and calling the wrong one is a warning at exit 0.
+
+The same generator emits the type surfaces, so a tag cannot mean one thing to the renderer and
+another to the type checker:
+
+| Dialect | tsconfig | Tag spelling |
+|---|---|---|
+| Solid / JSX | `"jsx": "preserve"`, `"jsxImportSource": "@gjsify/gtk-host"` | kebab (`gtk-box`) |
+| React / JSX | `"jsx": "react-jsx"`, `"jsxImportSource": "@gjsify/gtk-host/react"` | kebab (`gtk-box`) |
+| Vue | `import '@gjsify/gtk-host/vue-components'` + `"strictTemplates": true` | either (`GtkBox`, `gtk-box`) |
+
+The spellings are measured, not chosen. A capitalised `JSX.IntrinsicElements` key is never
+consulted, because `<GtkBox/>` is `TS2304: Cannot find name 'GtkBox'`. Volar resolves a kebab
+template tag to either key spelling but a Pascal tag only to a Pascal key, so one GType key
+covers both — and that key is also the table key and the GtkBuilder XML key.
+
+`noImplicitAny: true` and `strictTemplates: true` are load-bearing in the same way: without
+them the checker accepts everything and you conclude the surface works. See the two pipeline
+pages for the exact traps.
+
+## Read the source
+
+Three showcases build the same window three ways, and each asserts the resulting tree against
+the **real** widget tree on every launch:
+
+- [`adw-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/adw-host-counter)
+  — imperative, straight through the host ops
+- [`solid-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/solid-host-counter)
+  — the same window as Solid JSX
+- [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter)
+  — the same window as a `.vue` single-file component
+
+## See also
+
+- [Solid JSX](/gjsify/guides/solid-jsx/) for the compile step a `.tsx` entry needs
+- [Vue SFCs](/gjsify/guides/vue-sfc/) for the compile step a `.vue` entry needs
+- [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/) for the application shell you
+  mount into
+- [GObject Classes](/gjsify/patterns/gobject-classes/) for the `registerClass` rules your own
+  widget subclasses follow — the host resolves a subclass through its nearest registered
+  ancestor
+- [Adwaita gallery](/gjsify/adwaita/) for the widgets themselves

--- a/website/src/content/docs/guides/vue-sfc.md
+++ b/website/src/content/docs/guides/vue-sfc.md
@@ -1,0 +1,183 @@
+---
+title: Vue SFCs
+description: Compile Vue 3 single-file components for a GTK 4 build with @gjsify/rolldown-plugin-vue. The tag predicate, the build defines that keep the DOM out, and the vue-tsc trap that fakes a green check.
+---
+
+[`@gjsify/rolldown-plugin-vue`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-vue)
+compiles Vue 3 single-file components during a gjsify build, for the `@vue/runtime-core`
+custom renderer in [`@gjsify/gtk-host/vue`](/gjsify/guides/ui-frameworks/). Write your window
+as `.vue`, build it for `--app gjs`, and the template's tags become real GTK widgets.
+
+It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
+
+## Install
+
+```bash
+gjsify install @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+```
+
+`vue` and `vue-tsc` are devDependencies for the type check; only `@vue/runtime-core` ends up
+in the bundle.
+
+## Wire it up
+
+Name the plugin in `package.json#gjsify`. There is no JS-form config file to add:
+
+```jsonc
+{
+    "gjsify": {
+        "bundler": {
+            "plugins": [{ "name": "@gjsify/rolldown-plugin-vue" }]
+        }
+    }
+}
+```
+
+Then build the `.ts` entry that imports the SFC:
+
+```bash
+gjsify build src/app.ts --app gjs --outfile dist/app.gjs.mjs \
+  --define '__VUE_OPTIONS_API__=false' \
+  --define '__VUE_PROD_DEVTOOLS__=false' \
+  --define '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__=false' \
+  --define 'process.env.NODE_ENV="production"'
+```
+
+Those four defines are not optional; the section below says why.
+
+Or drop the plugin into a Rolldown / Vite config directly:
+
+```ts
+// rolldown.config.ts
+import { vuePlugin } from '@gjsify/rolldown-plugin-vue';
+
+export default {
+    plugins: [vuePlugin()],
+};
+```
+
+### Options
+
+| Option | Default | What it does |
+|---|---|---|
+| `isCustomElement` | `isGtkHostTag` | Which tags compile to an element vnode instead of a component lookup. |
+| `include` | `/\.vue$/` | Which modules to compile. |
+| `runtimeModuleName` | `@vue/runtime-core` | Module the generated code imports Vue's runtime from. `vue` — the compiler's own default — drags `@vue/runtime-dom` and the DOM renderer into a bundle with no DOM. |
+
+## The tag predicate, and why it is only a prefix rule
+
+`isGtkHostTag` accepts `gtk-`/`adw-` kebab **and** `Gtk`/`Adw` followed by a capital. Both
+spellings are required: `isCustomElement` is consulted for PascalCase tags too, and one
+`GlobalComponents` key answers both spellings — so a kebab-only rule leaves `<GtkBox>`
+type-checking and then resolving as a missing component.
+
+It decides "element vnode or component lookup", never whether the widget exists. An unknown
+tag is refused by name twice, and neither place is the plugin: the host's registry throws
+`unknown-tag` at render time, and `GlobalComponents` plus `strictTemplates` refuses it at
+type-check. Encoding the widget list here would be a third copy of a generated table and the
+first one to drift.
+
+Without the predicate the failure is silent in the direction that matters. Measured on one
+template: **7 of 7 tags compiled to `_resolveComponent(…)` and zero element vnodes were
+emitted.** Vue's resolver misses, warns once per tag — and that warning is `__DEV__`-only,
+which the production defines above strip. With the predicate: 0 `resolveComponent`, 6
+`createElementVNode` plus the root `createElementBlock`.
+
+## The build recipe
+
+`@vue/runtime-core` is DOM-free in fact — every `document`, `navigator` and `HTMLElement`
+reference sits in a dev, HMR or devtools branch behind `__DEV__` or a `typeof window` guard.
+But `--globals auto` is a static scan: it injects a polyfill for each identifier it *sees*,
+which made the bundle require `gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` at load. The
+four defines let dead-code elimination remove those branches first.
+
+One import the recipe cannot save is `Suspense`. `SuspenseImpl` carries `hydrate:
+hydrateSuspense`, which contains a literal `document.createElement("div")` that no define
+eliminates — hydration is never called here, but the identifier is still there. Measured, same
+entry plus one named import, `--app gjs`:
+
+| Import | Bytes | Typelibs |
+|---|---|---|
+| baseline (`createRenderer`) | 191 032 | `gi://GLib` |
+| `+ Teleport` | 194 907 | `gi://GLib` |
+| `+ KeepAlive` | 197 561 | `gi://GLib` |
+| `+ Suspense` | 274 177 | `+ Gdk, GdkPixbuf, Gio, Pango, PangoCairo` |
+| `+ Suspense`, `--exclude-globals document` | 196 614 | `gi://GLib` |
+
+So `--exclude-globals document` is the escape if you need `Suspense`. `Transition` is not in
+the table because `@vue/runtime-core` does not export it at all — it belongs to
+`runtime-dom`.
+
+## The type check, and the trap that fakes a green one
+
+```jsonc
+{
+    "compilerOptions": { "strict": true, "module": "NodeNext", "moduleResolution": "NodeNext" },
+    "vueCompilerOptions": { "strictTemplates": true },
+    "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"]
+}
+```
+
+```bash
+vue-tsc --noEmit
+```
+
+Three things on that config are load-bearing, and each has a measured silent-green mode
+behind it:
+
+- **`strictTemplates: true`.** Measured on `vue-tsc@3.3.11`: with it, an unknown prop, an
+  unknown tag, an unknown event, a wrong value type and a bad enum nick all fail. Without it,
+  the unknown prop, the unknown event and the unknown *tag* are silently accepted while wrong
+  value types still error — so a project without it sees type errors appear and concludes the
+  surface works.
+- **Set it in the base of your `extends` chain.** Measured, four cells, all four: the base
+  tsconfig's value wins and the child's is ignored outright, in *both* directions. In a
+  monorepo the shared base config therefore decides this for every package and a per-package
+  override does nothing. Confirm with `vue-tsc --showConfig`, never by reading the nearest
+  tsconfig.
+- **`src/**/*.vue` must be in `include` explicitly.** A tsconfig whose `include` lists only
+  `.ts` globs makes `vue-tsc` check **zero** SFCs and exit 0. An SFC reached through an
+  `import` is checked either way; the glob is what covers one nothing imports yet.
+
+The `GlobalComponents` augmentation applies only to a program that loads it, so the project
+needs the import somewhere. A `.d.ts` is the right home, because the module carries no runtime
+value:
+
+```ts
+// src/vue-components.d.ts
+import '@gjsify/gtk-host/vue-components';
+```
+
+## What it refuses, and what it ignores
+
+**`<style>` is refused with a named error.** GTK styling is a `Gtk.CssProvider` concern —
+there is no element a CSS rule could attach to, and `<style scoped>` compiles to an attribute
+selector GTK 4 CSS does not have. Load the CSS yourself with
+`Gtk.CssProvider.load_from_string()` plus `Gtk.StyleContext.add_provider_for_display()`, and
+put the selector on the widget with `cssClasses`.
+
+**`<script lang="jsx">` and `lang="tsx"` are refused too.** Rolldown picks a parser from the
+module id's extension, and that choice happens before anything has read the file, so it cannot
+depend on the block's `lang`. Write JSX in a `.tsx` file and compile it with
+[`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) instead. A `<script>` with no
+`lang` is parsed as TypeScript.
+
+**A split SFC is refused as well** — `<template src>` and `<script src>`, and a
+`<template lang>` other than `html`. Measured, each compiled to something that looked like a
+component and was not: an external template became `return null`, an external script became an
+empty object with the module never imported, and `lang="pug"` compiled to a render function
+returning the pug source as a text node. All three render blank or logic-less at exit 0.
+
+Out of scope and not attempted: HMR, asset-URL rewriting, custom blocks, SSR, `?query`
+suffixes on a `.vue` import, and watch-mode dependency registration. A custom block is the one
+thing neither compiled nor refused — the plugin reports it as a build warning naming the block
+and otherwise ignores it.
+
+## Related
+
+- [UI Frameworks](/gjsify/guides/ui-frameworks/) for the host, the widget table and the
+  placement rules
+- [Solid JSX](/gjsify/guides/solid-jsx/) for the same pipeline on `babel-preset-solid`
+- [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter),
+  a complete window that asserts its own widget tree on every launch
+- [`@gjsify/rolldown-plugin-vue` on npm](https://www.npmjs.com/package/@gjsify/rolldown-plugin-vue)

--- a/website/src/content/docs/how-it-works.mdx
+++ b/website/src/content/docs/how-it-works.mdx
@@ -309,12 +309,14 @@ On `--app node` there is nothing to arrange for a server, because it is the host
 
 Gjsify's build plugins are Rollup-shaped, so the same plugin objects load under Rolldown (which `gjsify build` drives) and under Vite. That is why a dev server with hot module reload and a production `gjsify build --app browser` produce the same output instead of two pipelines that drift apart.
 
-Two of them are useful on their own, with or without the gjsify CLI:
+Four of them are useful on their own, with or without the gjsify CLI:
 
 | Plugin | What it does |
 |---|---|
 | `@gjsify/vite-plugin-blueprint` | Compiles `.blp` to an XML string via `blueprint-compiler`, so `import T from './window.blp'` works in Vite dev and in a production build |
 | `@gjsify/vite-plugin-gettext` | Runs the `xgettext` / `msgfmt` / `po2json` pipeline, the same plugin in both environments |
+| [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) | Compiles SolidJS JSX in `universal` generate mode, so the output calls a GTK renderer instead of the DOM |
+| [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) | Compiles Vue 3 single-file components for the `@vue/runtime-core` GTK renderer |
 
 The presets that mirror `gjsify build --app browser` and `--app nativescript` ship as `@gjsify/vite-plugin-gjsify`. The [Vite Plugin guide](/gjsify/guides/vite-plugin/) has the config.
 

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -79,11 +79,12 @@ socket.addEventListener('message', (event) => console.log(event.data));
 
 ## When you do write `@gjsify/...` in an import
 
-Three cases, all of them things that have no standard bare specifier:
+Four cases, all of them things that have no standard bare specifier:
 
 - **GTK bridge widgets.** `@gjsify/canvas2d`, `@gjsify/webgl`, `@gjsify/video` and `@gjsify/iframe` export widget classes you mount into a GTK tree. See [DOM & Graphics](/gjsify/packages/dom/).
 - **The Adwaita design system on the web.** `@gjsify/adwaita-web` gives you Adwaita as Web Components for `--app browser` builds. See the [Adwaita gallery](/gjsify/adwaita/).
 - **The native app shell.** `@gjsify/adwaita-app` wraps the `Adw.Application` boilerplate. See [Build a native Adwaita app](/gjsify/guides/native-adwaita-app/).
+- **The renderer host.** `@gjsify/gtk-host` is the element model Solid, Vue and React renderers bind to, so you describe a GTK window instead of assembling it. See [UI Frameworks](/gjsify/guides/ui-frameworks/).
 
 <CommandTabs title="Install a GJSify package">
   <Fragment slot="gjsify">
@@ -115,7 +116,7 @@ Three cases, all of them things that have no standard bare specifier:
 | [Node.js Modules](/gjsify/packages/node/) | 41 plus 1 meta | `fs`, `net`, `http`, `crypto`, `stream`, `events`, `sqlite`, `ws` and more |
 | [Web APIs](/gjsify/packages/web/) | 19 plus 1 native bridge plus 1 meta | `fetch`, `XMLHttpRequest`, `WebSocket`, `WebRTC`, `WebAudio`, Streams, `DOMParser`, `MessageChannel`, `WebAssembly` and more |
 | [DOM & Graphics](/gjsify/packages/dom/) | 2 DOM plus 6 bridges | Canvas 2D, WebGL, DOM elements, and the GTK-backed Canvas / WebGL / Video / IFrame widgets |
-| Framework | renderer host, app shell plus tooling | [`@gjsify/adwaita-app`](/gjsify/guides/native-adwaita-app/), [storybook](/gjsify/guides/storybook/), [devtools](/gjsify/guides/devtools/) |
+| Framework | renderer host, app shell plus tooling | [`@gjsify/gtk-host`](/gjsify/guides/ui-frameworks/), [`@gjsify/adwaita-app`](/gjsify/guides/native-adwaita-app/), [storybook](/gjsify/guides/storybook/), [devtools](/gjsify/guides/devtools/) |
 | Adwaita for the browser | 4 | `@gjsify/adwaita-web`, `@gjsify/adwaita-core`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 | Reverse bridge | 1 | [`@gjsify/node-gi`](/gjsify/projects/node-gi/), GObject-Introspection on Node.js, Bun and Deno |
 | Forward bridge | 1 | [`@gjsify/napi`](/gjsify/projects/napi/), native Node.js N-API `.node` addons in GJS |

--- a/website/src/ec-plugins/adwaita-frames.mjs
+++ b/website/src/ec-plugins/adwaita-frames.mjs
@@ -137,6 +137,7 @@ const DEFAULT_FRAME_TITLES = {
     cjs: 'JavaScript',
     json: 'JSON',
     jsonc: 'JSON',
+    vue: 'Vue',
     yaml: 'YAML',
     yml: 'YAML',
     css: 'CSS',


### PR DESCRIPTION
Stacked on #1295, because it has to be: `scripts/check-website-package-names.mjs` runs on every PR with no `paths:` filter and resolves every `@gjsify/*` name the site quotes against the package manifests in the same tree, with an empty allowlist. A page quoting `@gjsify/rolldown-plugin-vue` fails CI until that package exists beside it.

## What the website said about this feature before

One clause, in `contributing/architecture.md`: *"the GTK host (`@gjsify/gtk-host`) that UI-framework renderers target."* Grep-verified zero substantive mentions of Solid, Vue, React, JSX or "UI framework" anywhere under `website/`. Every other `solid` hit was `1px solid`; every `react` hit was the English verb.

Three new pages, following the site's existing task-named guide convention (`guides/vite-plugin`, `guides/native-adwaita-app`) rather than inventing a per-package section:

- **`guides/ui-frameworks`** — the hub: what the host is, the three adapters against their three contracts, the placement policies, the refusals, and a runnable example in each of Solid and Vue.
- **`guides/solid-jsx`** — the compile step, its options, and why Babel rather than oxc.
- **`guides/vue-sfc`** — the SFC pipeline, its options, and everything it refuses by name.

Plus the sidebar, the `how-it-works` plugin table, `packages/overview`, and the architecture page's existing gtk-host mention, which now links somewhere.

## `gjsify.bundler.plugins` is documented for the first time

That field predates both plugin PRs and had never appeared in the CLI reference. The new section is checked against `resolve-plugin-by-name.ts` (relative paths resolve via `createRequire`, `export` defaults to `default`, order is preserved) **and** against the conformance rule as hardened in #1296 — so it shows only the object-in-an-array form and says outright that a bare string is not accepted, which is exactly what the gate now refuses.

## Eight corrections to the drafted copy

Each of these was a claim that read plausibly and was wrong against the source:

- **`widgetOf` is not on the Vue subpath.** It is exported from `adapters/solid.ts` and `adapters/react.ts` and absent from `adapters/vue.ts`. The intro's blanket "`widgetOf(node)` hands you the widget" is scoped to Solid and React, and the Vue section says what that adapter does export and to use a `ref` instead.
- "Two different renderer contracts" → **three**, counted: `solid-js/universal` at exactly 10 methods, Vue's `RendererOptions` at 10 required + 4 optional, react-reconciler's HostConfig.
- **`Adw.PreferencesPage` does not "reorder natively"** — that borrowed the `ordered` policy's vocabulary for a widget that is `indexed` and places at the index directly.
- **A custom block is not "named on stderr"** — it goes through `this.warn`, i.e. a Rolldown build warning.
- **Without `strictTemplates` an unknown *event* is silently accepted too**, not just an unknown prop and tag.
- **The split-SFC refusals were missing** — `<template src>`, `<script src>` and `<template lang>` ≠ html are all refused by name.
- `textNotAccepted` names two fixes, not one.
- The `check-adapter-import-direction` description was tightened to what the script does.

What held exactly, and was checked rather than assumed: `on:<raw-signal-name>` is a real typed escape hatch (`RawSignalAttributes`, consumed verbatim by `parseEventProp`); the `Adw.Application` + `activate` + `runAsync` bootstrap matches both showcases; 164 widgets / 102 Gtk / 62 Adw / 26 curated are exact counts from the generated table and the descriptors; every placement-table row matches its descriptor; every refusal-table row maps to a real factory in `errors.ts`; both option tables match their `DEFAULT_*` constants; and the three JSX answers in the CLI reference match `jsxConfigMissingError` word for word.

## Gates

| Gate | Verdict |
|---|---|
| `check-website-package-names` | PASS — every quoted `@gjsify/*` name resolves |
| `check-generated-website-data --check` | PASS — 3 generators current, 40 gallery blocks, 65 elements |
| `generate-coverage --check` | PASS (15 pillars) |
| `audit-runtimes --check` | PASS |
| `astro build` | **PASS — 58 pages in 10.8 s**, all three new pages rendered |
| `check-doc-fences`, `check-website-adwaita-gallery`, `check-website-preview-not-content` | PASS |
| `gjsify lint` / `format` on the two non-markdown files | PASS |

`astro check` **could not run** — `@astrojs/check` is not installed and installing it would dirty the lockfile. It runs in no workflow either, so that signal is missing; the `astro build` above is real.

**Link checking: there is none in CI**, so one was built for this change. All 61 `/gjsify/…` links across the three new pages and four edited files resolve to a built `dist/**/index.html`, and every `#fragment` resolves to a real `id=` in its target — including the new self-anchor on the bundler-plugins section. A standing link checker is worth its own PR; this one at least does not ship a broken link.

## Deliberately not added

**No `showcases/` pages for the two new showcases.** That section documents the `gjsify showcase <name>` catalog: `packages/infra/cli/showcases.json` holds 9 entries, and of the five GTK showcases only `adwaita-storybook` is among them. `showcases/index.mdx` hard-codes "ten below", "Nine of these ship in the CLI catalog" and "Seven of the ten" — adding two pages would mean editing three counts to describe things the CLI cannot run. The guides link the GitHub sources instead.
