### PR TITLE
fix(audit): print every rule's notes, and name what the stylesheet rule cannot see

### DIFF
--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1531,19 +1531,31 @@ async function main() {
             console.log(coverage.summary);
             console.log(statusData.summary);
             console.log(platformPackages.summary);
-            // Printed on a PASSING run, not just a failing one: a claim below
-            // `supported` is a standing limitation, and the mandatory reason
-            // only does its job if somebody reads it. Same contract as
-            // `gjsify.platformsUncommitted`.
-            for (const note of osAxis.notes ?? []) console.log(`  · ${note}`);
-            // The bundler-plugin notes are the rule's ONLY honesty mechanism: the
-            // export half needs the plugin built, and this job builds nothing, so in
-            // CI every plugin produces a "not checked" note. Printing the summary
-            // without them turns "declared, export unverified" into a clean green
-            // line — a missing signal reading as a pass, inside the guard written to
-            // remove that class.
-            for (const note of bundlerPlugins.notes ?? []) console.log(`  · ${note}`);
-            for (const note of coverage.notes ?? []) console.log(`  · ${note}`);
+            // EVERY rule's notes, derived from the run rather than listed here.
+            //
+            // Printed on a PASSING run and not only a failing one: a note is what a
+            // rule says when it could not answer, and that has to reach a reader or
+            // the green line above overstates the coverage. Two rules paid for this
+            // already. `os-axis` records a claim below `supported`, whose mandatory
+            // reason only does its job if somebody reads it. `bundler-plugins` needs
+            // the plugin built and this job builds nothing, so in CI every plugin
+            // produces a "not checked" note, and dropping it turned "declared, export
+            // unverified" into a clean green line, a missing signal reading as a pass
+            // inside the guard written to remove that class.
+            //
+            // Both were fixed by adding a hand-written loop per rule, which is why
+            // the third rule to grow notes (`stylesheet-font-families`, whose subject
+            // only exists on a machine that has built) would have been silent again.
+            // Derived beats curated here: a rule that starts emitting notes cannot be
+            // forgotten.
+            //
+            // `prebuild-artifacts` and `prebuild-libc` are excluded because their own
+            // renderers already lay their notes out above.
+            const NOTES_RENDERED_ELSEWHERE = new Set(['prebuild-artifacts', 'prebuild-libc']);
+            for (const { rule, result } of run.results) {
+                if (NOTES_RENDERED_ELSEWHERE.has(rule.id)) continue;
+                for (const note of result.notes ?? []) console.log(`  · [${rule.id}] ${note}`);
+            }
             renderReachabilityNotes(reach);
             process.exit(0);
         }

--- a/scripts/manifest-conformance/rules/stylesheet-font-families.mjs
+++ b/scripts/manifest-conformance/rules/stylesheet-font-families.mjs
@@ -295,8 +295,36 @@ export function auditStylesheetFontFamilies(ctx) {
     const inspected = new Map();
     let sheetCount = 0;
 
+    /**
+     * Packages this run could not answer for, because their shipped tree is BUILD
+     * OUTPUT that is not on disk.
+     *
+     * The rule's subject is the tarball: `shipsPath` declines any stylesheet outside
+     * `package.json#files`. For a package whose `files` names `dist`, that means the
+     * only copy the rule may look at appears after a build, and `audit-runtimes.yml`
+     * never builds the showcases. So in CI the rule silently answers for fewer
+     * packages than it appears to, and the summary reads like a full pass either way.
+     * Measured on `@gjsify/example-node-express-webserver`: with `dist/` present the
+     * rule reports a finding, with `dist/` absent it reports nothing and the count of
+     * inspected packages just drops.
+     *
+     * That is a coverage gap, not a violation, so it is a NOTE with a number rather
+     * than a failure. Failing would red every clean checkout; staying silent is what
+     * let the gap sit. The source copy is deliberately NOT scanned instead: it is not
+     * shipped, so a claim there is outside what this rule means.
+     */
+    const unbuilt = [];
+
     for (const pkg of ctx.packages) {
         if (pkg.private) continue;
+        const declared = Array.isArray(pkg.manifest?.files) ? pkg.manifest.files : [];
+        const absentRoots = declared.filter((entry) => {
+            // Only plain directory/file entries answer this question. A glob may
+            // legitimately match nothing in a correct tree.
+            if (/[*?[\]{}!]/.test(entry)) return false;
+            return !existsSync(join(pkg.dir, entry.replace(/^\.\//, '')));
+        });
+        if (absentRoots.length > 0) unbuilt.push(`${pkg.manifest.name} (${absentRoots.join(', ')})`);
         const sheets = [];
         for (const absolute of findStylesheets(pkg.dir)) {
             const rel = toPosixPath(absolute.slice(pkg.dir.length + 1));
@@ -390,7 +418,20 @@ export function auditStylesheetFontFamilies(ctx) {
         );
     }
 
-    return { failures, stats: { packages: inspected.size, stylesheets: sheetCount, families: claimCount } };
+    const notes = [];
+    if (unbuilt.length > 0) {
+        notes.push(
+            `${unbuilt.length} package(s) declare shipped paths that are not on disk, so no stylesheet of theirs ` +
+                `was inspected: ${unbuilt.join(', ')}. Build them and re-run to answer for those, or read this ` +
+                `rule's green line as covering the rest only.`,
+        );
+    }
+
+    return {
+        failures,
+        notes,
+        stats: { packages: inspected.size, stylesheets: sheetCount, families: claimCount, unbuilt: unbuilt.length },
+    };
 }
 
 export const stylesheetFontFamiliesRule = defineRule({
@@ -401,13 +442,15 @@ export const stylesheetFontFamiliesRule = defineRule({
     fields: [],
     description: 'a shipped stylesheet only heads a font stack with a family it carries, or a listed reason',
     run(ctx) {
-        const { failures, stats } = auditStylesheetFontFamilies(ctx);
+        const { failures, notes, stats } = auditStylesheetFontFamilies(ctx);
         return {
             failures,
+            notes,
             stats,
             summary:
                 `stylesheet-font-families: ${stats.stylesheets} shipped stylesheet(s) in ${stats.packages} ` +
-                `package(s), ${stats.families} first-named family claim(s) checked`,
+                `package(s), ${stats.families} first-named family claim(s) checked` +
+                (stats.unbuilt > 0 ? `, ${stats.unbuilt} package(s) unbuilt and therefore unanswered` : ''),
         };
     },
 });


### PR DESCRIPTION
Two findings from the `stylesheet-font-families` asymmetry that came up in #1294, split by what each one is.

## The reporter printed a hand-listed four rules' notes

A note is what a rule says when it *could not answer*. The reporter printed them for four rules by name, so any rule that grew notes later was silent, and "could not check" read as a clean green line.

Two rules had already paid for exactly that, and each was fixed by adding one more loop:

- `os-axis` records a claim below `supported`, and its mandatory reason only does its job if somebody reads it.
- `bundler-plugins` needs the plugin built, and this job builds nothing, so in CI every plugin produced a "not checked" note that went nowhere. That one was mine, added in #1292 and fixed in #1296.

The third rule to grow notes would have been silent again, so this derives the loop from `run.results` rather than listing rules. It immediately surfaced notes from two rules whose notes had never reached a reader, `bundled-license` (3) and `field-coverage` (3), plus `platform-packages` (2). Each line now carries its rule id.

`prebuild-artifacts` and `prebuild-libc` stay excluded because their own renderers already lay their notes out above.

**A/B:** with the loop removed, all four rules print nothing.

## The stylesheet rule could not see ten packages and said so nowhere

The rule asks whether a **shipped** stylesheet heads a font stack with a family the package carries, and `shipsPath` declines anything outside `package.json#files`. For a package whose `files` names `dist`, the only copy the rule may look at appears after a build, and `audit-runtimes.yml` never builds the showcases.

Measured on `@gjsify/example-node-express-webserver`: with `dist/` present the rule reports a finding, with `dist/` absent it reports nothing and only the inspected count drops. That is why the same audit is green in CI and red for a developer who has built.

On this machine ten packages are in that state:

```
@gjsify/adwaita-fonts (lib), @gjsify/example-dom-canvas2d-fireworks (dist),
@gjsify/example-dom-excalibur-jelly-jumper (dist), @gjsify/example-dom-minimalist-browser (dist),
@gjsify/example-dom-three-geometry-teapot (dist), @gjsify/example-dom-three-loader-ldraw (dist),
@gjsify/example-dom-three-postprocessing-pixel (dist), @gjsify/example-dom-webrtc-loopback (dist),
@gjsify/example-gtk-adwaita-storybook (dist), @gjsify/example-node-express-webserver (dist)
```

`@gjsify/adwaita-fonts` is the one that stings: a package whose whole purpose is carrying faces, and the rule about faces cannot see it.

The count is now in the summary and the names are in a note. Deliberately not a failure, because failing reds every clean checkout and the gap is coverage rather than a violation.

**Scanning the source copy instead would answer a different question.** `src/public/style.css` is not in `files`, so a claim there is outside what this rule means. I considered it and rejected it.

**A/B:** creating one absent `dist/` moves the count 10 → 9, removing it moves it back.

## Not decided here

Whether the express-webserver stack should ship its face or record a reason in `status/stylesheet-font-families.json` is a licensing and tarball-size call plus a claim about intent. That belongs to Pascal, not to a commit. This PR removes the asymmetry that made the question invisible and leaves the question open.

## Verified

`audit-runtimes --check --strict` exit 0, `gjsify lint` and `gjsify format` clean over both files. The two lint warnings in `audit-runtimes.mjs` (`sep`, `fmtSlot`) are pre-existing on `main` and outside this diff.
