### PR TITLE
docs(website): give the framework bindings their own section

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,6 +19,11 @@ export default defineConfig({
     // and naming it after the design system leaves room for a second one
     // (Material, say) beside it rather than under it.
     redirects: {
+        // The framework pages moved out of `guides/` into their own section. They
+        // shipped days earlier, so the old paths are already in the wild.
+        '/guides/ui-frameworks': '/gjsify/frameworks/',
+        '/guides/solid-jsx': '/gjsify/frameworks/solid/',
+        '/guides/vue-sfc': '/gjsify/frameworks/vue/',
         '/framework/bridges': '/gjsify/patterns/bridges/',
         '/patterns': '/gjsify/patterns/gobject-classes/',
         '/widgets': '/gjsify/adwaita/',
@@ -119,14 +124,19 @@ export default defineConfig({
                     label: 'Guides',
                     items: [
                         { slug: 'guides/native-adwaita-app' },
-                        { slug: 'guides/ui-frameworks' },
-                        { slug: 'guides/solid-jsx' },
-                        { slug: 'guides/vue-sfc' },
                         { slug: 'patterns/gobject-classes' },
                         { slug: 'patterns/bridges', label: 'Bridge Widgets' },
                         { slug: 'guides/storybook' },
                         { slug: 'guides/devtools' },
                         { slug: 'guides/vite-plugin' },
+                    ],
+                },
+                {
+                    label: 'UI Frameworks',
+                    items: [
+                        { slug: 'frameworks', label: 'Overview' },
+                        { slug: 'frameworks/solid', label: 'Solid' },
+                        { slug: 'frameworks/vue', label: 'Vue' },
                     ],
                 },
                 {

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -136,8 +136,8 @@ JSX and `.vue` are compiler input, not runtime syntax, so the build needs a plug
 gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs
 ```
 
-- [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) for SolidJS JSX
-- [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) for Vue single-file components
+- [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) for SolidJS JSX
+- [`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) for Vue single-file components
 
 **`--app gjs` refuses a JSX entry that configures no transform**, and that refusal is the point. Left unset, the transformer applies its own default — the automatic React runtime — so the bundle imports `react/jsx-runtime`. GJS resolves no bare specifier, so the build would report the miss as a *warning*, exit 0, and the artifact would abort at load with `ImportError: Module not found: react/jsx-runtime`. On a project that does have React installed it is worse: the bundle builds React elements, which a GTK host does nothing with.
 

--- a/website/src/content/docs/contributing/architecture.md
+++ b/website/src/content/docs/contributing/architecture.md
@@ -59,6 +59,6 @@ GJSify treats the **Node.js API**, the **Web API**, the **DOM API** and the **Fr
 - `packages/node/`: Node.js builtins (`fs`, `http`, `crypto`, …)
 - `packages/web/`: Web platform APIs (`fetch`, `WebSocket`, `ReadableStream`, Web Crypto, …)
 - `packages/dom/`: DOM element classes (`HTMLCanvasElement`, `HTMLImageElement`, …) with headless Canvas 2D
-- `packages/framework/`: everything that glues DOM and GTK together without being a spec implementation: the [GTK host](/gjsify/guides/ui-frameworks/) (`@gjsify/gtk-host`) that UI-framework renderers target, the [bridge widgets](/gjsify/patterns/bridges/), the [storybook](/gjsify/guides/storybook/), the [devtools control plane](/gjsify/guides/devtools/) and the [Adwaita app shell](/gjsify/guides/native-adwaita-app/)
+- `packages/framework/`: everything that glues DOM and GTK together without being a spec implementation: the [GTK host](/gjsify/frameworks/) (`@gjsify/gtk-host`) that UI-framework renderers target, the [bridge widgets](/gjsify/patterns/bridges/), the [storybook](/gjsify/guides/storybook/), the [devtools control plane](/gjsify/guides/devtools/) and the [Adwaita app shell](/gjsify/guides/native-adwaita-app/)
 
 The DOM-element ↔ GTK-widget pairings are documented in [Bridge Widgets](/gjsify/patterns/bridges/).

--- a/website/src/content/docs/frameworks/index.md
+++ b/website/src/content/docs/frameworks/index.md
@@ -1,21 +1,28 @@
 ---
 title: UI Frameworks
-description: Describe your GTK 4 window instead of assembling it. One host layer under Solid, Vue and React, with the widget table, the placement rules and the type surfaces generated from the GIR.
+description: Write your GTK 4 window in Solid, Vue or React. One host layer underneath, real Gtk and Adw widgets on top.
 ---
 
-A GTK app is usually written imperatively: `new Gtk.Box()`, `append()`, `connect()`, and you
-keep the tree in your head. Every modern UI framework offers the opposite deal — describe the
-tree, let a renderer reconcile it. Solid, Vue and React each publish a contract for rendering
-into something that is not the DOM. What none of them ships is the *something*.
+Write your GTK 4 window in Solid, Vue or React, and get real `Gtk` and `Adw` widgets.
 
-[`@gjsify/gtk-host`](https://www.npmjs.com/package/@gjsify/gtk-host) is that something: an
-element model over GTK 4 and libadwaita that can create a widget, set a property, adopt a
-child and navigate the result. The three adapters sit on top of it and hold no widget
-knowledge at all.
+GTK can already describe a window rather than assemble it — that is what Blueprint is for, and
+it does property bindings too. What a template cannot do is change its own shape: a `.blp` is
+instantiated once, so anything that appears, disappears or reorders while the app runs goes
+back into imperative code.
 
-Nothing here hides `Gtk` or `Adw`. Every tag names a real GTK class, `on:<raw-signal-name>`
-reaches a signal whose spelling is irregular, and you mount into a window your application
-already built.
+Keeping a tree in sync with your state is exactly what a UI framework is for. Solid, Vue and
+React can all render somewhere other than a browser — they just need an object model to build
+against, and GTK's is not the DOM.
+
+[`@gjsify/gtk-host`](https://www.npmjs.com/package/@gjsify/gtk-host) is that object model.
+Nothing is hidden: every tag names a real GTK class, and you mount into a window your
+application already built.
+
+:::tip[Blueprint is not replaced]
+The two answer different questions and mix well. Blueprint is the better choice for a window
+whose shape is fixed — and it is the only one of the two that `xgettext` can translate. Reach
+for a framework where the shape follows the data.
+:::
 
 ## Install
 
@@ -30,19 +37,16 @@ Your framework is a peer dependency and stays yours: `solid-js`, `@vue/runtime-c
 
 | Adapter | Import | Framework contract | Compile step |
 |---|---|---|---|
-| Solid | `@gjsify/gtk-host/solid` | `solid-js/universal`, 10 methods | [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) |
-| Vue | `@gjsify/gtk-host/vue` | `@vue/runtime-core`, 10 required + 4 optional | [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) |
+| Solid | `@gjsify/gtk-host/solid` | `solid-js/universal`, 10 methods | [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) |
+| Vue | `@gjsify/gtk-host/vue` | `@vue/runtime-core`, 10 required + 4 optional | [`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) |
 | React | `@gjsify/gtk-host/react` | `react-reconciler` HostConfig | none — TypeScript's own automatic runtime |
 
-Three different renderer contracts satisfied by one descriptor table and one placement engine
-is what makes "framework-agnostic" a measurement rather than an intention. A check
-(`scripts/check-adapter-import-direction.mjs`) fails the build if an adapter reaches past the
-table for widget knowledge, so the split cannot erode.
+Pick one and the rest of this page is the same for all three.
 
 ## Solid JSX
 
 `registerBuiltinWidgets()` loads the generated table; after that the tags are available.
-Build with [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/), which is what turns
+Build with [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/), which is what turns
 the JSX into calls against the host.
 
 ```tsx
@@ -168,7 +172,7 @@ component instance.
 
 Both tag spellings work in a template. `<GtkLabel>` and `<gtk-label>` resolve to the same
 widget and to the same type-check key, so pick one and stay with it. The build needs
-[`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) and four `--define` flags; that page
+[`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) and four `--define` flags; that page
 has the recipe and the reason.
 
 ## React
@@ -307,8 +311,8 @@ the **real** widget tree on every launch:
 
 ## See also
 
-- [Solid JSX](/gjsify/guides/solid-jsx/) for the compile step a `.tsx` entry needs
-- [Vue SFCs](/gjsify/guides/vue-sfc/) for the compile step a `.vue` entry needs
+- [Solid JSX](/gjsify/frameworks/solid/) for the compile step a `.tsx` entry needs
+- [Vue SFCs](/gjsify/frameworks/vue/) for the compile step a `.vue` entry needs
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/) for the application shell you
   mount into
 - [GObject Classes](/gjsify/patterns/gobject-classes/) for the `registerClass` rules your own

--- a/website/src/content/docs/frameworks/solid.md
+++ b/website/src/content/docs/frameworks/solid.md
@@ -6,7 +6,7 @@ description: Compile SolidJS JSX for a GTK 4 build with @gjsify/rolldown-plugin-
 [`@gjsify/rolldown-plugin-solid`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)
 compiles SolidJS JSX during a gjsify build, in `universal` generate mode — the only mode whose
 output contains no DOM. It targets the renderer in
-[`@gjsify/gtk-host/solid`](/gjsify/guides/ui-frameworks/), and it is the whole compile step: a
+[`@gjsify/gtk-host/solid`](/gjsify/frameworks/), and it is the whole compile step: a
 `.tsx` entry plus this plugin is a GTK app.
 
 It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
@@ -145,9 +145,9 @@ untested, because nothing here has a DOM to render into.
 
 ## Related
 
-- [UI Frameworks](/gjsify/guides/ui-frameworks/) for the host, the widget table and the
+- [UI Frameworks](/gjsify/frameworks/) for the host, the widget table and the
   placement rules
-- [Vue SFCs](/gjsify/guides/vue-sfc/) for the same pipeline on `@vue/compiler-sfc`
+- [Vue SFCs](/gjsify/frameworks/vue/) for the same pipeline on `@vue/compiler-sfc`
 - [`solid-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/solid-host-counter),
   a complete window that asserts its own widget tree on every launch
 - [`@gjsify/rolldown-plugin-solid` on npm](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)

--- a/website/src/content/docs/frameworks/vue.md
+++ b/website/src/content/docs/frameworks/vue.md
@@ -5,7 +5,7 @@ description: Compile Vue 3 single-file components for a GTK 4 build with @gjsify
 
 [`@gjsify/rolldown-plugin-vue`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-vue)
 compiles Vue 3 single-file components during a gjsify build, for the `@vue/runtime-core`
-custom renderer in [`@gjsify/gtk-host/vue`](/gjsify/guides/ui-frameworks/). Write your window
+custom renderer in [`@gjsify/gtk-host/vue`](/gjsify/frameworks/). Write your window
 as `.vue`, build it for `--app gjs`, and the template's tags become real GTK widgets.
 
 It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
@@ -159,7 +159,7 @@ put the selector on the widget with `cssClasses`.
 **`<script lang="jsx">` and `lang="tsx"` are refused too.** Rolldown picks a parser from the
 module id's extension, and that choice happens before anything has read the file, so it cannot
 depend on the block's `lang`. Write JSX in a `.tsx` file and compile it with
-[`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) instead. A `<script>` with no
+[`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) instead. A `<script>` with no
 `lang` is parsed as TypeScript.
 
 **A split SFC is refused as well** — `<template src>` and `<script src>`, and a
@@ -175,9 +175,9 @@ and otherwise ignores it.
 
 ## Related
 
-- [UI Frameworks](/gjsify/guides/ui-frameworks/) for the host, the widget table and the
+- [UI Frameworks](/gjsify/frameworks/) for the host, the widget table and the
   placement rules
-- [Solid JSX](/gjsify/guides/solid-jsx/) for the same pipeline on `babel-preset-solid`
+- [Solid JSX](/gjsify/frameworks/solid/) for the same pipeline on `babel-preset-solid`
 - [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter),
   a complete window that asserts its own widget tree on every launch
 - [`@gjsify/rolldown-plugin-vue` on npm](https://www.npmjs.com/package/@gjsify/rolldown-plugin-vue)

--- a/website/src/content/docs/how-it-works.mdx
+++ b/website/src/content/docs/how-it-works.mdx
@@ -315,8 +315,8 @@ Four of them are useful on their own, with or without the gjsify CLI:
 |---|---|
 | `@gjsify/vite-plugin-blueprint` | Compiles `.blp` to an XML string via `blueprint-compiler`, so `import T from './window.blp'` works in Vite dev and in a production build |
 | `@gjsify/vite-plugin-gettext` | Runs the `xgettext` / `msgfmt` / `po2json` pipeline, the same plugin in both environments |
-| [`@gjsify/rolldown-plugin-solid`](/gjsify/guides/solid-jsx/) | Compiles SolidJS JSX in `universal` generate mode, so the output calls a GTK renderer instead of the DOM |
-| [`@gjsify/rolldown-plugin-vue`](/gjsify/guides/vue-sfc/) | Compiles Vue 3 single-file components for the `@vue/runtime-core` GTK renderer |
+| [`@gjsify/rolldown-plugin-solid`](/gjsify/frameworks/solid/) | Compiles SolidJS JSX in `universal` generate mode, so the output calls a GTK renderer instead of the DOM |
+| [`@gjsify/rolldown-plugin-vue`](/gjsify/frameworks/vue/) | Compiles Vue 3 single-file components for the `@vue/runtime-core` GTK renderer |
 
 The presets that mirror `gjsify build --app browser` and `--app nativescript` ship as `@gjsify/vite-plugin-gjsify`. The [Vite Plugin guide](/gjsify/guides/vite-plugin/) has the config.
 

--- a/website/src/content/docs/packages/overview.mdx
+++ b/website/src/content/docs/packages/overview.mdx
@@ -84,7 +84,7 @@ Four cases, all of them things that have no standard bare specifier:
 - **GTK bridge widgets.** `@gjsify/canvas2d`, `@gjsify/webgl`, `@gjsify/video` and `@gjsify/iframe` export widget classes you mount into a GTK tree. See [DOM & Graphics](/gjsify/packages/dom/).
 - **The Adwaita design system on the web.** `@gjsify/adwaita-web` gives you Adwaita as Web Components for `--app browser` builds. See the [Adwaita gallery](/gjsify/adwaita/).
 - **The native app shell.** `@gjsify/adwaita-app` wraps the `Adw.Application` boilerplate. See [Build a native Adwaita app](/gjsify/guides/native-adwaita-app/).
-- **The renderer host.** `@gjsify/gtk-host` is the element model Solid, Vue and React renderers bind to, so you describe a GTK window instead of assembling it. See [UI Frameworks](/gjsify/guides/ui-frameworks/).
+- **The renderer host.** `@gjsify/gtk-host` is the element model Solid, Vue and React renderers bind to, so you describe a GTK window instead of assembling it. See [UI Frameworks](/gjsify/frameworks/).
 
 <CommandTabs title="Install a GJSify package">
   <Fragment slot="gjsify">
@@ -116,7 +116,7 @@ Four cases, all of them things that have no standard bare specifier:
 | [Node.js Modules](/gjsify/packages/node/) | 41 plus 1 meta | `fs`, `net`, `http`, `crypto`, `stream`, `events`, `sqlite`, `ws` and more |
 | [Web APIs](/gjsify/packages/web/) | 19 plus 1 native bridge plus 1 meta | `fetch`, `XMLHttpRequest`, `WebSocket`, `WebRTC`, `WebAudio`, Streams, `DOMParser`, `MessageChannel`, `WebAssembly` and more |
 | [DOM & Graphics](/gjsify/packages/dom/) | 2 DOM plus 6 bridges | Canvas 2D, WebGL, DOM elements, and the GTK-backed Canvas / WebGL / Video / IFrame widgets |
-| Framework | renderer host, app shell plus tooling | [`@gjsify/gtk-host`](/gjsify/guides/ui-frameworks/), [`@gjsify/adwaita-app`](/gjsify/guides/native-adwaita-app/), [storybook](/gjsify/guides/storybook/), [devtools](/gjsify/guides/devtools/) |
+| Framework | renderer host, app shell plus tooling | [`@gjsify/gtk-host`](/gjsify/frameworks/), [`@gjsify/adwaita-app`](/gjsify/guides/native-adwaita-app/), [storybook](/gjsify/guides/storybook/), [devtools](/gjsify/guides/devtools/) |
 | Adwaita for the browser | 4 | `@gjsify/adwaita-web`, `@gjsify/adwaita-core`, `@gjsify/adwaita-fonts`, `@gjsify/adwaita-icons` |
 | Reverse bridge | 1 | [`@gjsify/node-gi`](/gjsify/projects/node-gi/), GObject-Introspection on Node.js, Bun and Deno |
 | Forward bridge | 1 | [`@gjsify/napi`](/gjsify/projects/napi/), native Node.js N-API `.node` addons in GJS |


### PR DESCRIPTION
Two things, both from Pascal's review of what shipped in #1298.

## Their own section, not three more guides

`UI Frameworks`, `Solid JSX` and `Vue SFCs` were sitting inside `Guides`, between "Native Adwaita Apps" and "Storybook" — as though choosing Solid over Vue were another how-to alongside "how do I use devtools". It is the decision about how you write the whole application.

They are now a **`UI Frameworks` section**, placed directly after `Guides`, and the slugs moved with them:

| was | is |
|---|---|
| `guides/ui-frameworks` | `frameworks/` |
| `guides/solid-jsx` | `frameworks/solid` |
| `guides/vue-sfc` | `frameworks/vue` |

All internal links updated across seven files, and the three old paths ship redirects — they were published days ago, so they are already in the wild. The section has room for `frameworks/react` when its showcase lands.

## The opening was wrong, and wrong against this project's own advice

It said:

> A GTK app is usually written imperatively: `new Gtk.Box()`, `append()`, `connect()`, and you keep the tree in your head. […] Solid, Vue and React each publish a contract for rendering into something that is not the DOM. What none of them ships is the *something*.

**GTK has had a declarative answer for years.** Blueprint compiles a `.blp` to a widget tree with property bindings, and this repository ships `gjsify/prefer-blueprint-template` as an oxlint rule precisely to stop people assembling interfaces in TypeScript — the documentation was contradicting the linter.

The real distinction is narrower and much easier to say: **a template cannot change its own shape.** A `.blp` is instantiated once, so anything that appears, disappears or reorders while the app runs goes back into imperative code. Keeping a tree in sync with state is what a UI framework is *for* — they just need an object model to build against, and GTK's is not the DOM.

The page now opens with that, in three short paragraphs instead of four dense ones, and adds the thing a reader needs immediately after: **Blueprint is not replaced.** The two mix, Blueprint is the better choice where the shape is fixed, and it is the only one of the two `xgettext` can translate — which is not a small footnote for an app that ships translations.

The contract-counting paragraph ("three renderer contracts satisfied by one descriptor table… a check fails the build if an adapter reaches past the table") came out of the opening. It is mechanism, and mechanism belongs after the reader knows what they are choosing between, not three paragraphs in.

## Verdicts

`astro build` **OK — the site builds, 58 pages**, including the moved section and the redirects · `check-website-package-names` OK · `check-generated-website-data --check` OK.