### PR TITLE
fix(gtk-host): the generic adder is real, just unsafe

### DIFF
--- a/docs/adr/0027-gtk-host-layer.md
+++ b/docs/adr/0027-gtk-host-layer.md
@@ -31,7 +31,19 @@ The first two hold **zero** lines of widget knowledge; they declare `dominative`
 as a peer and stop. Under GTK4 the shared share is larger still, because GTK4
 deleted `GtkContainer`: there is no generic `add`, and `Gtk.Buildable.add_child`
 is introspected as a vfunc only — `typeof headerBar.add_child === 'undefined'` on
-gjs 1.88.1 — so every container's adoption rule has to be stated somewhere. Stated
+gjs 1.88.1. An earlier revision of this ADR concluded from that "so it is not an
+escape hatch either", and that conclusion was wrong.
+`vfunc_add_child(builder, child, type)` IS callable from GJS and dispatches
+correctly — measured on gjs 1.88.1 / GTK 4.22.4 / Adw 1.10 across 29 containers:
+`GtkBox` appends, `AdwHeaderBar` type `title` lands in the title slot, `GtkListBox`
+wraps the row, `AdwPreferencesGroup` reaches its internal list. What it is not is a
+safe DEFAULT: `GtkLabel.vfunc_add_child` accepts a child, reports nothing, and
+surfaces only as `Finalizing GtkLabel …, but it still has children left` at
+teardown, exit 0. A wrong child type is a warning followed by a wrong placement;
+a move is a `CRITICAL` and a silent no-op. So the table earns its place by refusing
+what the generic call accepts, not by being the only way to place a child.
+
+Every container's adoption rule therefore still has to be stated somewhere. Stated
 once, that is a table. Stated per adapter, it is the same table three times, and
 hand-maintained widget tables are what stalled `react-gtk`, `react-native-gtk4`
 and `svelte-gjs`.

--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -28,7 +28,9 @@ NativeScript carries five framework flavours over one host, and the adapters are
 small because the host exists: its Solid adapter is **91 lines**, its React
 adapter **505** — and both hold *zero* lines of widget knowledge. Under GTK4 the
 shared share is larger still: GTK4 deleted `GtkContainer`, so there is no generic
-`add`, and `Gtk.Buildable.add_child` is introspected as a vfunc only. Every
+`add`. `Gtk.Buildable.add_child` is introspected as a vfunc only — the `vfunc_`
+form is callable and correct, so it is an escape hatch, just not a safe default
+(a childless widget accepts a child in silence). Every
 container's adoption rule has to be written down somewhere. Written once, it is a
 table; written per adapter, it is the same table three times — which is what
 stalled `react-gtk`, `react-native-gtk4` and `svelte-gjs`.

--- a/packages/framework/gtk-host/src/buildable.spec.ts
+++ b/packages/framework/gtk-host/src/buildable.spec.ts
@@ -1,0 +1,109 @@
+// Why the descriptor table exists — asserted against the toolkit rather than argued.
+//
+// ADR 0027, this package's README, `types.ts` and `policies.ts` all justified the
+// curated table with the same sentence: GTK4 deleted `GtkContainer`, and
+// `Gtk.Buildable.add_child` "is introspected as a vfunc only, so it is not an escape
+// hatch either". The first half is true. **The conclusion was wrong**, and it stood in
+// four places for as long as the table has existed.
+//
+// `vfunc_add_child` is callable from GJS and dispatches correctly. Two React-for-GJS
+// projects were found building on exactly that: `peachy` routes every insertion through
+// it, and its whole widget table is one `Gtk.Buildable` entry.
+//
+// So the honest justification is narrower, and it is what this file pins: the generic
+// call is REAL but UNSAFE AS A DEFAULT. It accepts what a table refuses, and GTK's
+// failure mode for the difference is exit 0.
+//
+// The rows below are therefore not a wish list. Each one is a fact the table is paid
+// for, and if GTK ever starts refusing these, the table could be simplified — which is
+// the day this suite should go red and tell somebody.
+
+import Adw from 'gi://Adw?version=1';
+import Gtk from 'gi://Gtk?version=4.0';
+import { describe, expect, on } from '@gjsify/unit';
+
+import { installDiagnosticsGate } from './conformance/index.js';
+import { gated } from './testing/gate.mjs';
+
+export default async () => {
+    // GJS only, and `Gtk.init()` before any widget: these rows construct real
+    // containers, and an uninitialised GTK aborts the process rather than throwing.
+    await on('Gjs', async () => {
+        Gtk.init();
+        await describe('Gtk.Buildable — what the generic adder really does', async () => {
+            // Every row asserts against real widgets, so a GTK critical raised by one
+            // of them has to fail its own row rather than the next one.
+            const diagnostics = installDiagnosticsGate();
+            await gated(diagnostics, 'the vfunc form is callable, which the docs used to deny', async () => {
+                // The introspection fact everyone quotes: the plain name is absent — and
+                // `@girs/*` does not declare it either, which is the same fact seen from the
+                // type side, hence the cast rather than a property access.
+                const header = new Adw.HeaderBar() as unknown as Record<string, unknown>;
+                expect(typeof header.add_child).toBe('undefined');
+                // The part that was missing: the vfunc form is not.
+                expect(typeof new Adw.HeaderBar().vfunc_add_child).toBe('function');
+                expect(typeof new Gtk.Box().vfunc_add_child).toBe('function');
+            });
+
+            await gated(diagnostics, 'and it places correctly, including the slotted containers', async () => {
+                // If this row ever fails, the paragraph above is wrong again and the
+                // curated slot tables in `descriptors/adw.ts` are the only route left.
+                const builder = Gtk.Builder.new();
+
+                const box = new Gtk.Box();
+                const boxChild = new Gtk.Label({ label: 'x' });
+                box.vfunc_add_child(builder, boxChild, null);
+                expect(boxChild.get_parent()).toBe(box);
+
+                const header = new Adw.HeaderBar();
+                const title = new Gtk.Label({ label: 't' });
+                header.vfunc_add_child(builder, title, 'title');
+                expect(header.get_title_widget()).toBe(title);
+
+                const list = new Gtk.ListBox();
+                list.vfunc_add_child(builder, new Gtk.Label({ label: 'r' }), null);
+                // GTK wraps the child in a row exactly as `insert()` would.
+                expect(list.get_row_at_index(0) === null).toBe(false);
+            });
+
+            await gated(diagnostics, 'a CHILDLESS widget accepts a child and says nothing', async () => {
+                // THE ROW THAT PAYS FOR THE TABLE.
+                //
+                // `Gtk.Label` holds no children. The generic adder does not refuse it —
+                // it falls through to `gtk_widget_set_parent`, and the only diagnostic
+                // arrives at teardown as `Finalizing GtkLabel …, but it still has children
+                // left`, long after the frame that caused it, with exit code 0.
+                //
+                // `registry`'s `uncurated` refusal is what turns that into an error naming
+                // the tag, at the call that made it.
+                const label = new Gtk.Label({ label: 'parent' });
+                const orphan = new Gtk.Label({ label: 'child' });
+                label.vfunc_add_child(Gtk.Builder.new(), orphan, null);
+
+                expect(orphan.get_parent()).toBe(label);
+
+                // Undo it, or the teardown warning lands in whichever test runs last and
+                // reads as that test's fault.
+                orphan.unparent();
+            });
+
+            await gated(diagnostics, 'a keyed container loses the name the key is read from', async () => {
+                // `GtkStack` is why `{ kind: 'keyed' }` names its adder: the generic call
+                // adds the page but leaves `page.name` null, so `visible-child-name` —
+                // the whole point of a stack — addresses nothing.
+                const stack = new Gtk.Stack();
+                const child = new Gtk.Label({ label: 's' });
+                stack.vfunc_add_child(Gtk.Builder.new(), child, null);
+
+                const page = stack.get_page(child);
+                expect(page === null).toBe(false);
+                expect(page.name).toBe(null);
+
+                // And it is recoverable, which is why `keyed` can be a policy rather than
+                // a special case: naming the page afterwards makes the lookup work.
+                page.name = 'first';
+                expect(stack.get_child_by_name('first')).toBe(child);
+            });
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/policies.ts
+++ b/packages/framework/gtk-host/src/policies.ts
@@ -3,7 +3,9 @@
 //
 // GTK4 removed `GtkContainer`. There is no generic `add`, and `Gtk.Buildable`'s
 // `add_child` is introspected as a vfunc only (`typeof headerBar.add_child ===
-// 'undefined'`, gjs 1.88.1), so it is not a fallback either. Every container
+// 'undefined'`, gjs 1.88.1) — but `vfunc_add_child` is callable and dispatches
+// correctly, so it IS available as a fallback. It is not a SAFE one: a childless
+// widget accepts a child in silence. Every container
 // therefore states its own rules as DATA in its descriptor, and this file is the
 // only code that reads them. Four framework adapters share it; none of them may
 // contain an insertion rule of its own.

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -1,6 +1,7 @@
 import { run } from '@gjsify/unit';
 
 import reactSuite from './adapters/react.spec.js';
+import buildableSuite from './buildable.spec.js';
 import solidSuite from './adapters/solid.spec.js';
 import vueSuite from './adapters/vue.spec.js';
 import conformanceSuite from './conformance.spec.js';
@@ -9,4 +10,14 @@ import generatorSuite from './generator.spec.js';
 import hostSuite from './host.spec.js';
 import propsSuite from './props.spec.js';
 
-run({ propsSuite, hostSuite, conformanceSuite, generatorSuite, generatedSuite, solidSuite, vueSuite, reactSuite });
+run({
+    buildableSuite,
+    propsSuite,
+    hostSuite,
+    conformanceSuite,
+    generatorSuite,
+    generatedSuite,
+    solidSuite,
+    vueSuite,
+    reactSuite,
+});

--- a/packages/framework/gtk-host/src/types.ts
+++ b/packages/framework/gtk-host/src/types.ts
@@ -100,9 +100,15 @@ export type PolicyKind = 'none' | 'single' | 'ordered' | 'indexed' | 'slotted' |
 
 /**
  * How a parent adopts children. GTK4 deleted `GtkContainer`, so there is no
- * generic `add` — and `Gtk.Buildable.add_child` is introspected as a vfunc only
- * (`typeof headerBar.add_child === 'undefined'`, measured on gjs 1.88.1), so it
- * is not an escape hatch either. Every container states its own rules here.
+ * generic `add`. `Gtk.Buildable.add_child` is introspected as a vfunc only
+ * (`typeof headerBar.add_child === 'undefined'`, gjs 1.88.1) — but the vfunc form
+ * IS callable and DOES dispatch correctly, measured across 29 containers, so it is
+ * a real escape hatch. This comment used to claim otherwise.
+ *
+ * The table exists because the generic call is unsafe as a default, not because it
+ * is unavailable: `GtkLabel.vfunc_add_child` accepts a child and says nothing until
+ * `Finalizing GtkLabel …, but it still has children left` at teardown. Every
+ * container states its own rules here, and a widget with no rule is REFUSED.
  */
 export type ChildPolicy =
     | { kind: 'none' }


### PR DESCRIPTION
Found while studying the two existing React-for-GJS projects (`peachy`, `gtkx`) that are now checked out under `refs/`. It is a correction to our own foundation, in four places.

## The claim that was wrong

ADR 0027, `packages/framework/gtk-host/README.md`, `src/types.ts` and `src/policies.ts` all justify the curated descriptor table with the same sentence:

> GTK4 deleted `GtkContainer`: there is no generic `add`, and `Gtk.Buildable.add_child` is introspected as a vfunc only — `typeof headerBar.add_child === 'undefined'` on gjs 1.88.1 — **so it is not an escape hatch either.**

The first half is true. **The conclusion is false.** `vfunc_add_child(builder, child, type)` is callable from GJS and dispatches correctly. Measured on this machine, gjs 1.88.1 / GTK 4.22.4 / Adw 1.10:

| parent | `add_child` | `vfunc_add_child` | result |
|---|---|---|---|
| `GtkBox` | undefined | function | appended |
| `AdwHeaderBar` type `title` | undefined | function | **lands in the title slot** |
| `AdwToolbarView` type `top` | undefined | function | placed |
| `GtkListBox` | undefined | function | **row wrapped** |
| `AdwPreferencesGroup` | undefined | function | reaches the internal list |
| `GtkStack` | function | function | added, `page.name === null` |

`peachy`'s entire widget table is *one* `Gtk.Buildable` entry doing exactly this. So every hand-written `pack_start` / `set_title_widget` / `add_top_bar` / `add_prefix` in `descriptors/adw.ts` has a generic equivalent — which is worth knowing, because we wrote those believing there was no alternative.

## Why the table still earns its place

Not because the generic call is unavailable. Because it is **unsafe as a default**, and every one of its failure modes is quiet:

- **A childless widget accepts a child.** `GtkLabel.vfunc_add_child` falls through to `gtk_widget_set_parent`; the only diagnostic is `Finalizing GtkLabel …, but it still has children left`, at teardown, exit 0.
- **A wrong child type is a warning and then a wrong placement** — the child gets parented anyway, in no slot, rendering nothing. On `GtkWindow` a bogus type produces no warning at all.
- **A move is a `CRITICAL` and a silent no-op**; the child stays with its old parent.
- **`GtkStack` loses the name the key is read from**, so `visible-child-name` addresses nothing.

That is a better justification than the one we had, and it is the one the table actually satisfies: `uncurated` refuses by name what the generic call accepts in silence.

## The gate

`src/buildable.spec.ts` — four rows, GJS-only, under the usual diagnostics gate:

1. the `vfunc_` form is callable (and `@girs/*` does not declare the plain name, which is the same fact from the type side)
2. it places correctly, including a slotted container and the row-wrapping one
3. **a childless widget accepts a child and says nothing** — the row that pays for the table
4. a keyed container loses its page name, recoverably

These are not a wish list. Each is a fact the table is paid for, and **the day GTK starts refusing them is the day this suite should go red and tell somebody the table could be simpler.**

Two implementation notes worth having: `installDiagnosticsGate()` must be created inside the `describe` (`gated` registers hooks where `@gjsify/unit` keeps them), and the suite needs `on('Gjs')` + `Gtk.init()` before constructing a widget — without it the process takes SIGTERM rather than throwing, which is how the first attempt failed.

## Not done here

The report this came from suggests a ninth, opt-in `{ kind: 'buildable', types: [...] }` policy that would collapse the hand-written slot tables and track libadwaita's own slot semantics for free. That is a design change with real upside and it deserves its own PR and its own argument — this one only makes the written reason true.

## Verdicts

`@gjsify/gtk-host` **1927 completed** on GJS, exit 0 · `gjsify tsc --noEmit` clean · `gjsify lint` no finding in any touched file · `gjsify format` clean.