### PR TITLE
docs(frameworks): install for every package manager

### DIFF
--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -3,6 +3,8 @@ title: UI Frameworks
 description: Write your GTK 4 window in Solid, Vue or React. One host layer underneath, real Gtk and Adw widgets on top.
 ---
 
+import CommandTabs from '../../../components/CommandTabs.astro';
+
 Write your GTK 4 window in Solid, Vue or React, and get real `Gtk` and `Adw` widgets.
 
 GTK can already describe a window rather than assemble it — that is what Blueprint is for, and
@@ -26,9 +28,38 @@ for a framework where the shape follows the data.
 
 ## Install
 
-```bash
-gjsify install @gjsify/gtk-host
-```
+<CommandTabs title="Install" group="pm">
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/gtk-host
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm install -D @gjsify/gtk-host
+    ```
+  </Fragment>
+  <Fragment slot="yarn">
+    ```bash
+    yarn add -D @gjsify/gtk-host
+    ```
+  </Fragment>
+  <Fragment slot="pnpm">
+    ```bash
+    pnpm add -D @gjsify/gtk-host
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun add --dev @gjsify/gtk-host
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno add --dev npm:@gjsify/gtk-host
+    ```
+  </Fragment>
+</CommandTabs>
 
 Your framework is a peer dependency and stays yours: `solid-js`, `@vue/runtime-core`, or
 `react` + `react-reconciler`. Install only the one you use.

--- a/website/src/content/docs/frameworks/solid.mdx
+++ b/website/src/content/docs/frameworks/solid.mdx
@@ -3,6 +3,8 @@ title: Solid JSX
 description: Compile SolidJS JSX for a GTK 4 build with @gjsify/rolldown-plugin-solid. Universal generate mode, the tsconfig half that goes with it, and the silent failure it exists to stop.
 ---
 
+import CommandTabs from '../../../components/CommandTabs.astro';
+
 [`@gjsify/rolldown-plugin-solid`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-solid)
 compiles SolidJS JSX during a gjsify build, in `universal` generate mode — the only mode whose
 output contains no DOM. It targets the renderer in
@@ -13,9 +15,38 @@ It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
 
 ## Install
 
-```bash
-gjsify install @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
-```
+<CommandTabs title="Install" group="pm">
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm install -D @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+    ```
+  </Fragment>
+  <Fragment slot="yarn">
+    ```bash
+    yarn add -D @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+    ```
+  </Fragment>
+  <Fragment slot="pnpm">
+    ```bash
+    pnpm add -D @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun add --dev @gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno add --dev npm:@gjsify/rolldown-plugin-solid npm:@gjsify/gtk-host npm:solid-js
+    ```
+  </Fragment>
+</CommandTabs>
 
 ## Wire it up
 

--- a/website/src/content/docs/frameworks/vue.mdx
+++ b/website/src/content/docs/frameworks/vue.mdx
@@ -3,6 +3,8 @@ title: Vue SFCs
 description: Compile Vue 3 single-file components for a GTK 4 build with @gjsify/rolldown-plugin-vue. The tag predicate, the build defines that keep the DOM out, and the vue-tsc trap that fakes a green check.
 ---
 
+import CommandTabs from '../../../components/CommandTabs.astro';
+
 [`@gjsify/rolldown-plugin-vue`](https://www.npmjs.com/package/@gjsify/rolldown-plugin-vue)
 compiles Vue 3 single-file components during a gjsify build, for the `@vue/runtime-core`
 custom renderer in [`@gjsify/gtk-host/vue`](/gjsify/frameworks/). Write your window
@@ -12,9 +14,38 @@ It is an ordinary Rolldown plugin, so it also loads under Rollup and Vite.
 
 ## Install
 
-```bash
-gjsify install @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
-```
+<CommandTabs title="Install" group="pm">
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm install -D @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+    ```
+  </Fragment>
+  <Fragment slot="yarn">
+    ```bash
+    yarn add -D @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+    ```
+  </Fragment>
+  <Fragment slot="pnpm">
+    ```bash
+    pnpm add -D @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun add --dev @gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno add --dev npm:@gjsify/rolldown-plugin-vue npm:@gjsify/gtk-host npm:@vue/runtime-core
+    ```
+  </Fragment>
+</CommandTabs>
 
 `vue` and `vue-tsc` are devDependencies for the type check; only `@vue/runtime-core` ends up
 in the bundle.


### PR DESCRIPTION
The three framework pages each showed a bare `gjsify install …` in a plain terminal block, while the rest of the site answers "how do I install this" with `CommandTabs` — one window, one tab per package manager, and the choice remembered across every block on the site.

So a reader who uses pnpm was told to run a CLI they may not have installed, **on the one page that is their entry point to the whole feature**. `guides/install` and `guides/vite-plugin` had it right; these did not — and I introduced that when I moved them out of `guides/` in #1302.

Six tabs each: **gjsify · npm · Yarn · pnpm · Bun · Deno**, with `deno add` taking the `npm:` specifier the others do not.

| page | packages |
|---|---|
| `frameworks/` | `@gjsify/gtk-host` |
| `frameworks/solid` | `@gjsify/rolldown-plugin-solid @gjsify/gtk-host solid-js` |
| `frameworks/vue` | `@gjsify/rolldown-plugin-vue @gjsify/gtk-host @vue/runtime-core` |

## `.md` → `.mdx`, and why the slugs are safe

`CommandTabs` is an Astro component, so the pages have to be MDX. **The slugs do not change** — Starlight resolves `.md` and `.mdx` to the same route, so the redirects added with the move in #1302 still land, and every internal link still resolves.

## Verified in the built output, not by inspection

```
tab-view: 1
gjsify install @gjsify/gtk-host            1
npm install -D @gjsify/gtk-host            1
yarn add -D @gjsify/gtk-host               1
pnpm add -D @gjsify/gtk-host               1
bun add --dev @gjsify/gtk-host             1
deno add --dev npm:@gjsify/gtk-host        1
```

`astro build` Complete, `dist/frameworks/{index,solid,vue}` all present alongside the `guides/ui-frameworks` redirect · `check-website-package-names` OK.