### PR TITLE
fix(cli): let the packument decide whether a name exists

### DIFF
--- a/packages/infra/cli/src/utils/onboard-probe.spec.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.spec.ts
@@ -111,6 +111,10 @@ export default async () => {
             const plan = await probeTrustState(request, ws('@gjsify/foo'), ctx(), {
                 retryOn401: false,
                 sleep: noSleep,
+                // Same reason as the sibling above: a 401 now consults the
+                // packument, so what this case measures — that the RETRY is
+                // suppressed — needs existence pinned or it decides the outcome.
+                exists: async () => true,
             });
             expect(n).toBe(1);
             expect(plan.state).toBe('auth-required');
@@ -123,8 +127,53 @@ export default async () => {
                 n++;
                 return { status: 401, json: undefined, text: '' };
             };
-            const plan = await probeTrustState(request, ws('@gjsify/foo'), ctx(), { sleep: noSleep });
+            // `exists: true` is now load-bearing, and stating it is the point: a
+            // persistent 401 on a package that DOES exist is genuinely undecidable,
+            // so it stays blocked. Without the injection this reads the live
+            // registry — and `@gjsify/foo` is a name nobody published, so the test
+            // would flip to `publish-and-trust` for a reason that has nothing to do
+            // with what it is measuring.
+            const plan = await probeTrustState(request, ws('@gjsify/foo'), ctx(), {
+                sleep: noSleep,
+                exists: async () => true,
+            });
             expect(n).toBe(2); // initial + one retry, then give up
+            expect(plan.action).toBe('blocked');
+        });
+    });
+
+    await describe('probeTrustState — a 401 does not hide a missing package', async () => {
+        // The state a no-OTP `--dry-run` produces for the whole tree. Before this,
+        // 202 packages reported `unreadable` and the plan was empty — including for
+        // the two names that had never been published, which is the ONE thing the
+        // dry run was being consulted about.
+        await it('calls it UNPUBLISHED when the trust read 401s and no packument exists', async () => {
+            const request: TrustRequester = async (): Promise<TrustRequestResult> => ({
+                status: 401,
+                json: undefined,
+                text: '',
+            });
+            const plan = await probeTrustState(request, ws('@gjsify/never-published'), ctx(), {
+                sleep: noSleep,
+                exists: async () => false,
+            });
+            expect(plan.state).toBe('unpublished');
+            expect(plan.action).toBe('publish-and-trust');
+        });
+
+        await it('stays blocked when the packument read is itself undecided', async () => {
+            // Registry unreachable. Two failed reads are not evidence of absence,
+            // and publishing on them would create the package this command exists
+            // to notice was missing.
+            const request: TrustRequester = async (): Promise<TrustRequestResult> => ({
+                status: 401,
+                json: undefined,
+                text: '',
+            });
+            const plan = await probeTrustState(request, ws('@gjsify/unknown'), ctx(), {
+                sleep: noSleep,
+                exists: async () => null,
+            });
             expect(plan.action).toBe('blocked');
         });
     });

--- a/packages/infra/cli/src/utils/onboard-probe.spec.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.spec.ts
@@ -36,6 +36,55 @@ function trustedBody(): unknown {
 const noSleep = async (): Promise<void> => {};
 
 export default async () => {
+    await describe('probeTrustState — the packument decides existence', async () => {
+        // npm's trust endpoint answers 2xx with an EMPTY LIST for a name that was
+        // never published, which reads as `untrusted`. That is how `gjsify onboard`
+        // came to trust a package that did not exist, report `0 to publish+trust`
+        // and publish nothing — its own gap, reported as closed.
+        const emptyTrustList: TrustRequester = async () => ({ status: 200, json: [], text: '' });
+
+        await it('calls it UNPUBLISHED when the registry serves no packument', async () => {
+            const plan = await probeTrustState(emptyTrustList, ws('@gjsify/never-published'), ctx(), {
+                exists: async () => false,
+            });
+            expect(plan.state).toBe('unpublished');
+            expect(plan.action).toBe('publish-and-trust');
+        });
+
+        await it('leaves a real package untrusted, so the sweep only trusts it', async () => {
+            const plan = await probeTrustState(emptyTrustList, ws('@gjsify/real'), ctx(), {
+                exists: async () => true,
+            });
+            expect(plan.state).toBe('untrusted');
+            expect(plan.action).toBe('trust');
+        });
+
+        await it('does not publish on an UNDECIDED probe', async () => {
+            // Network failure is not evidence of absence, and a bootstrap that
+            // publishes on a failed read is worse than one that reports blocked.
+            const plan = await probeTrustState(emptyTrustList, ws('@gjsify/unknown'), ctx(), {
+                exists: async () => null,
+            });
+            expect(plan.state).toBe('untrusted');
+            expect(plan.action).toBe('trust');
+        });
+
+        await it('does not pay for the extra read when the name is already trusted', async () => {
+            // `trusted` cannot be a missing package, and `unpublished` already has
+            // its answer — so only the ambiguous case costs a second request.
+            let asked = 0;
+            const request: TrustRequester = async () => ({ status: 200, json: trustedBody(), text: '' });
+            const plan = await probeTrustState(request, ws('@gjsify/foo'), ctx(), {
+                exists: async () => {
+                    asked++;
+                    return true;
+                },
+            });
+            expect(plan.state).toBe('trusted');
+            expect(asked).toBe(0);
+        });
+    });
+
     await describe('probeTrustState — retry-on-401', async () => {
         await it('retries ONCE on a transient 401 and then classifies the 200', async () => {
             const calls: Array<{ method: string; url: string }> = [];

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -41,9 +41,49 @@ export interface ProbeOptions {
     retryDelayMs?: number;
     /** Injected delay (tests pass a no-op). Default: real `setTimeout`. */
     sleep?: (ms: number) => Promise<void>;
+    /**
+     * Does this name exist on the registry? The PACKUMENT oracle — see
+     * {@link packumentExists}. Tests inject it; production uses the real fetch.
+     */
+    exists?: (registry: string, name: string) => Promise<boolean | null>;
 }
 
 export const PROBE_RETRY_DELAY_MS = 400;
+
+/**
+ * Does the registry serve a packument for this name?
+ *
+ * THE ORACLE, and the reason it exists: npm's trust endpoint answers `2xx` with an
+ * EMPTY LIST for a name that was never published. `classifyTrustList` reads that as
+ * `untrusted`, so `gjsify onboard` planned "already on npm, just needs trust" for a
+ * package that did not exist — it trusted the name, reported `0 to publish+trust`
+ * and published NOTHING. A bootstrap command reporting its own gap as closed, and
+ * it is why the v0.36.0 repair failed twice before anyone looked at the registry.
+ *
+ * `GET <registry>/<name>` is unauthenticated and needs no OTP, so it answers in the
+ * one situation that matters: a `--dry-run` before the maintainer has an OTP to
+ * hand, where every trust read is `401` and the plan is otherwise empty.
+ *
+ * `null` means UNDECIDED (network or an unexpected status) — never "absent". A
+ * bootstrap that publishes on a failed probe is worse than one that reports blocked.
+ */
+export async function packumentExists(registry: string, name: string): Promise<boolean | null> {
+    const base = registry.endsWith('/') ? registry.slice(0, -1) : registry;
+    try {
+        // `Accept` narrows the response to the abbreviated packument: the full one
+        // for a package like `@gjsify/cli` is megabytes, and existence is all we ask.
+        const res = await fetch(`${base}/${name.replace('/', '%2f')}`, {
+            method: 'GET',
+            headers: { accept: 'application/vnd.npm.install-v1+json' },
+        });
+        if (res.status === 404) return false;
+        if (res.ok) return true;
+        return null;
+    } catch {
+        // A DNS or TLS failure is not evidence of absence.
+        return null;
+    }
+}
 
 /** Default probe concurrency — kept SMALL so a single token never bursts npm. */
 export const DEFAULT_PROBE_CONCURRENCY = 4;
@@ -91,6 +131,15 @@ export async function probeTrustState(
         await sleep(opts.retryDelayMs ?? PROBE_RETRY_DELAY_MS);
         res = await request('GET', url);
         state = classifyTrustList(res.status, res.json, classifyOpts);
+    }
+
+    // `untrusted` is the ONE ambiguous answer: the trust endpoint returns `2xx` with
+    // an empty list both for "published, nobody trusted it" and for "no such name".
+    // Only that case pays for the extra read — `trusted` cannot be a missing package
+    // and `unpublished` already has its answer.
+    if (state === 'untrusted') {
+        const exists = await (opts.exists ?? packumentExists)(registry, ws.name);
+        if (exists === false) state = 'unpublished';
     }
 
     return { ws, registry, url, state, httpStatus: res.status, action: actionForState(state) };

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -137,8 +137,27 @@ export async function probeTrustState(
     // an empty list both for "published, nobody trusted it" and for "no such name".
     // Only that case pays for the extra read — `trusted` cannot be a missing package
     // and `unpublished` already has its answer.
-    if (state === 'untrusted') {
+    // Two questions, two endpoints. The trust list answers "who may publish this",
+    // and onboard also needs "does this name exist at all" — which it can only
+    // INFER from the trust list, and infers wrongly in both ambiguous states:
+    //
+    //   untrusted      npm serves 2xx and an EMPTY list for a name that was never
+    //                  published — byte-identical to a real package that simply has
+    //                  no trusted publisher configured.
+    //   auth-required  a 401 says nothing whatsoever about existence. It is also
+    //                  where EVERY package lands in a `--dry-run` run before the
+    //                  maintainer has an OTP to hand, which is exactly the moment
+    //                  the plan is being read to decide whether to proceed.
+    //
+    // The packument answers the question directly and unauthenticated, and a 404
+    // there is proof no OTP could change. Only these two states pay for the extra
+    // read: `trusted` cannot be a missing package, and `unpublished` already has
+    // its answer from the endpoint it just asked.
+    if (state === 'untrusted' || state === 'auth-required') {
         const exists = await (opts.exists ?? packumentExists)(registry, ws.name);
+        // ONLY a definitive 404 reclassifies. `null` — network failure, unexpected
+        // status — leaves the state exactly as it was: a bootstrap that publishes
+        // on a failed read is worse than one that reports itself blocked.
         if (exists === false) state = 'unpublished';
     }
 

--- a/tests/e2e/onboard/run.mjs
+++ b/tests/e2e/onboard/run.mjs
@@ -59,6 +59,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
     // Mutable, reset per test.
     let pkgState; // name -> { published, trusted }
     let publishPuts; // [{ name, otp }]
+    let packumentGets; // names whose EXISTENCE was read from the packument
     let trustPosts; // [{ name, otp }]
     let loginHits; // count of PUT /-/user/...
 
@@ -105,7 +106,17 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
                 const name = decodeName(trustMatch[1]);
                 if (method === 'GET') {
                     const st = pkgState[name];
+                    // `emptyWhenAbsent` is what REAL npm does for a name nobody
+                    // published: `200` with an empty trust list, indistinguishable
+                    // from a published package that has no trusted publisher. The
+                    // plain `404` below is the easy shape this suite used to model
+                    // exclusively — and under it `onboard` never had a decision to
+                    // get wrong, so the defect could not appear here.
                     if (!st || !st.published) {
+                        if (st?.emptyWhenAbsent) {
+                            sendJson(200, []);
+                            return;
+                        }
                         sendJson(404, { error: 'package not found' });
                         return;
                     }
@@ -124,6 +135,24 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
                     });
                     return;
                 }
+            }
+            // PACKUMENT — the endpoint `onboard` reads to decide whether a name
+            // EXISTS. The trust endpoint cannot answer that: real npm serves
+            // `200 []` both for a published package with no trusted publisher and
+            // for a name nobody ever published. Modelled here because a stub that
+            // omits an endpoint the tool calls does not report "unimplemented" —
+            // it reports `404`, which reads as "this package does not exist", for
+            // every package at once.
+            if (method === 'GET' && !url.startsWith('/-/')) {
+                const name = decodeName(url.slice(1));
+                const st = pkgState[name];
+                if (!st || !st.published) {
+                    sendJson(404, { error: 'Not found' });
+                    return;
+                }
+                packumentGets.push(name);
+                sendJson(200, { name, 'dist-tags': { latest: '1.0.0' }, versions: { '1.0.0': { name } } });
+                return;
             }
             // publish PUT (any /<escaped-name> that is not an /-/ route).
             if (method === 'PUT' && !url.startsWith('/-/')) {
@@ -152,6 +181,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
 
     beforeEach(() => {
         publishPuts = [];
+        packumentGets = [];
         trustPosts = [];
         loginHits = 0;
     });
@@ -184,6 +214,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
         pkg('@onb/published-untrusted');
         pkg('@onb/unpublished-a');
         pkg('@onb/unpublished-b');
+        pkg('@onb/never-published-2xx');
         // A private package that must be EXCLUDED from the sweep.
         const privDir = join(root, 'packages', 'private-one');
         mkdirSync(privDir, { recursive: true });
@@ -204,6 +235,9 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             '@onb/published-untrusted': { published: true, trusted: false },
             '@onb/unpublished-a': { published: false, trusted: false },
             '@onb/unpublished-b': { published: false, trusted: false },
+            // The shape real npm produces and this suite never had: absent,
+            // but the trust read answers `200 []` instead of `404`.
+            '@onb/never-published-2xx': { published: false, trusted: false, emptyWhenAbsent: true },
         };
     }
 
@@ -274,7 +308,11 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
 
             // Only the two unpublished packages were published.
             const publishedNames = publishPuts.map((p) => p.name).sort();
-            assert.deepEqual(publishedNames, ['@onb/unpublished-a', '@onb/unpublished-b']);
+            // `never-published-2xx` is the regression gate. Its trust read is
+            // `200 []` — the answer a published-but-untrusted package gives —
+            // so deriving existence from that endpoint alone lands it in
+            // `trust`, and onboard reports success having published nothing.
+            assert.deepEqual(publishedNames, ['@onb/never-published-2xx', '@onb/unpublished-a', '@onb/unpublished-b']);
             // Every publish carried the shared OTP.
             assert.ok(
                 publishPuts.every((p) => p.otp === OTP_CODE),
@@ -283,7 +321,19 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
 
             // Trust was configured for the two new ones + the untrusted one, NOT the done one.
             const trustedNames = trustPosts.map((p) => p.name).sort();
-            assert.deepEqual(trustedNames, ['@onb/published-untrusted', '@onb/unpublished-a', '@onb/unpublished-b']);
+            assert.deepEqual(trustedNames, [
+                '@onb/never-published-2xx',
+                '@onb/published-untrusted',
+                '@onb/unpublished-a',
+                '@onb/unpublished-b',
+            ]);
+            // And the CONTROL in the row: `published-untrusted` has the SAME
+            // trust answer and must NOT be published. Without it this test
+            // would pass just as well if onboard published everything.
+            assert.ok(
+                !publishPuts.some((p) => p.name === '@onb/published-untrusted'),
+                'a published package must be trusted, never re-published',
+            );
             assert.ok(
                 !trustPosts.some((p) => p.name === '@onb/published-trusted'),
                 'the already-published+trusted package must be skipped',
@@ -304,6 +354,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             assert.equal(first.code, 0);
             // Everything is now published + trusted; reset counters and re-run.
             publishPuts = [];
+            packumentGets = [];
             trustPosts = [];
             const second = await runOnboard(root, npmrcPath);
             assert.equal(second.code, 0, `re-run should exit 0; stdout:\n${second.stdout}`);
@@ -336,6 +387,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             '@onb/published-untrusted': { published: true, trusted: true },
             '@onb/unpublished-a': { published: true, trusted: true },
             '@onb/unpublished-b': { published: true, trusted: true },
+            '@onb/never-published-2xx': { published: true, trusted: true },
         };
         const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
         try {
@@ -353,6 +405,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             '@onb/published-untrusted': { published: true, trusted: true },
             '@onb/unpublished-a': { published: true, trusted: true },
             '@onb/unpublished-b': { published: true, trusted: true },
+            '@onb/never-published-2xx': { published: true, trusted: true },
         };
         const { root, npmrcPath } = scaffoldMonorepo(DEAD_TOKEN);
         try {


### PR DESCRIPTION
## The defect

`gjsify onboard` decides "does this package already exist on npm?" from the **trust
endpoint** alone. For a name that was never published, npm answers **`2xx` with an empty
trust list** — indistinguishable, to `classifyTrustList`, from a real package that simply
has no trusted publisher configured.

So the sweep classifies a brand-new name as `untrusted`, plans *"already on npm, just needs
trust"*, configures trust for it, and reports `0 to publish+trust`. **It publishes nothing,
and says it is done.**

A bootstrap command reporting its own gap as closed — which is exactly the failure mode
`onboard` exists to prevent. It is why the v0.36.0 repair had to be run twice before anyone
thought to query the registry directly.

## It is live right now

Measured against the registry, unauthenticated:

```
@gjsify/rolldown-plugin-solid   HTTP 404   latest=-
@gjsify/rolldown-plugin-vue     HTTP 404   latest=-
@gjsify/gtk-host                HTTP 200   latest=0.41.0
@gjsify/cli                     HTTP 200   latest=0.42.0
```

Both new plugin packages from the framework-bindings work would have been trusted-and-skipped
by the next `onboard` run, and the release after it would then hit the v0.4.20 failure:
`release.yml`'s OIDC exchange 404s and exits 1, stalling every alphabetically later package.

## The fix

Ask the packument — `GET <registry>/<name>` — which is the only endpoint that actually
answers the question being asked.

Three properties made it worth doing this way:

- **Unauthenticated.** No OTP. This matters more than it first looks: npm challenges even
  the *trust-status read* with 2FA, so a `--dry-run` before the maintainer has a token to
  hand returns `401` for all 202 packages and produces an empty plan. The one question that
  could still be answered was not being asked.
- **Only the ambiguous state pays for it.** `trusted` cannot be a missing package, and
  `unpublished` already has its answer. The extra read happens precisely where the trust
  endpoint cannot distinguish.
- **An undecided probe changes nothing.** Network failure or an unexpected status returns
  `null` and leaves the classification alone. A bootstrap that publishes on a failed read is
  worse than one that reports blocked.

## Gate

Four cases in `onboard-probe.spec.ts`: unpublished when no packument, untrusted when the
package is real, no publish on an undecided probe, and no extra request when the name is
already trusted.

A/B run — removing the classification from `probeTrustState` turns **exactly one** of them
red:

```
✖ probeTrustState — the packument decides existence › calls it UNPUBLISHED when the registry serves no packument
❌ 1 of 2616 tests failed
```

and with it restored, `2617 completed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aWntfUqrzPzPhhVXmBGEP
