### PR TITLE
fix: point every package's repository at itself

### DIFF
--- a/packages/gjs/unit/package.json
+++ b/packages/gjs/unit/package.json
@@ -32,7 +32,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/unit.git"
+        "url": "git+https://github.com/gjsify/unit.git",
+        "directory": "packages/gjs/unit"
     },
     "keywords": [
         "gjs",

--- a/packages/gjs/unit/package.json
+++ b/packages/gjs/unit/package.json
@@ -32,7 +32,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/unit.git",
+        "url": "git+https://github.com/gjsify/gjsify.git",
         "directory": "packages/gjs/unit"
     },
     "keywords": [

--- a/packages/infra/manifest-conformance/lib/index.d.ts
+++ b/packages/infra/manifest-conformance/lib/index.d.ts
@@ -163,6 +163,7 @@ export declare const prebuildLibcRule: Rule;
 export declare const headlessRule: Rule;
 export declare const portableScriptsRule: Rule;
 export declare const fieldCoverageRule: Rule;
+export declare const repositoryDirectoryRule: Rule;
 
 /** POSIX-only utilities a script invokes in command position. Empty when portable. */
 export declare function unportableCommands(script: string): string[];

--- a/packages/infra/manifest-conformance/lib/index.mjs
+++ b/packages/infra/manifest-conformance/lib/index.mjs
@@ -86,3 +86,4 @@ export {
     collectPlatformVariants,
 } from './rules/nativescript-platforms.mjs';
 export { fieldCoverageRule, declaredGjsifyFields } from './rules/field-coverage.mjs';
+export { repositoryDirectoryRule, expectedDirectory, auditRepositoryDirectory } from './rules/repository-directory.mjs';

--- a/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
@@ -112,7 +112,50 @@ export function auditRepositoryDirectory(ctx) {
         ok++;
     }
 
-    return { failures, stats: { checked, ok } };
+    // ONE TREE, ONE URL. `directory` is a path INSIDE the repo that `url` names,
+    // so the two are a single claim and checking them separately checks neither.
+    // A package carrying a foreign `url` plus a local `directory` describes a path
+    // in somebody else's repository — and it renders on npm as an ordinary,
+    // confident link.
+    //
+    // MEASURED: `@gjsify/unit` shipped `git+https://github.com/gjsify/unit.git`,
+    // a repo whose last push was 2020-02-18, while the package is developed here
+    // in `packages/gjs/unit`. Published npm metadata carried it as far as 0.42.0.
+    // Adding `directory` to that manifest — which the first half of this rule
+    // demands — would have MANUFACTURED the exact defect the rest of it rejects.
+    //
+    // Deciding by disagreement rather than by a majority vote is deliberate: a
+    // tie needs no arbiter, and a rule that silently anoints the more popular URL
+    // would ratify a mass copy-paste. Every distinct value is reported.
+    const byUrl = new Map();
+    for (const pkg of ctx.allPackages) {
+        if (pkg.private) continue;
+        const repo = pkg.manifest.repository;
+        if (typeof repo !== 'object' || repo === null || Array.isArray(repo)) continue;
+        if (typeof repo.url !== 'string') continue;
+        const group = byUrl.get(repo.url);
+        if (group) group.push(pkg.name);
+        else byUrl.set(repo.url, [pkg.name]);
+    }
+    if (byUrl.size > 1) {
+        const groups = [...byUrl.entries()].sort((a, b) => b[1].length - a[1].length);
+        const rendered = groups
+            .map(([url, names]) => {
+                const shown = names.slice(0, 4).join(', ');
+                const more = names.length > 4 ? `, +${names.length - 4} more` : '';
+                return `    ${url}  —  ${names.length} package(s): ${shown}${more}`;
+            })
+            .join('\n');
+        failures.push(
+            'packages in one tree declare ' +
+                `${byUrl.size} different \`repository.url\` values. Every package here lives in ONE repository, ` +
+                'so one of these names a repo the package is not in — and its `directory` then points at a path ' +
+                'inside that other repo:\n' +
+                rendered,
+        );
+    }
+
+    return { failures, stats: { checked, ok, urls: byUrl.size } };
 }
 
 export const repositoryDirectoryRule = defineRule({
@@ -128,7 +171,7 @@ export const repositoryDirectoryRule = defineRule({
             stats,
             summary:
                 `repository-directory: OK. ${stats.checked} non-private package(s) checked; every declared ` +
-                '`repository.directory` matches its own path.',
+                `\`repository.directory\` matches its own path, under ${stats.urls} shared \`repository.url\`.`,
         };
     },
 });

--- a/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
@@ -1,0 +1,134 @@
+/**
+ * Rule `repository-directory` — a published package's `repository` must name
+ * ITS OWN subdirectory, not just the monorepo it lives in.
+ *
+ * THE DEFECT. npm renders a package page's "Repository" link, and `npm repo
+ * <pkg>` opens a browser, from `repository.url` plus `repository.directory`.
+ * Every package here shares one `url` (`github.com/gjsify/gjsify`), because
+ * every package lives in the same monorepo — so `directory` is the ONLY part
+ * of the field that tells a reader, or the tool, which of ~190 packages they
+ * are actually looking at. Omit it and the link still resolves: it lands on
+ * the repo ROOT instead of `packages/<pillar>/<name>`, which is wrong but not
+ * obviously so — a working link that opens the wrong page is not something a
+ * user reports, they just read the wrong README and move on. That is the
+ * failure mode this rule exists to catch: not a broken link, a *believable*
+ * one. Eleven packages shipped that way, discovered only because two of them
+ * (`@gjsify/rolldown-plugin-solid`, `@gjsify/rolldown-plugin-vue`) were about
+ * to be published to npm for the FIRST time — their npm page would have been
+ * every reader's first and only signpost, pointing at the wrong place from
+ * day one.
+ *
+ * THE HARDER HALF. A `directory` that is PRESENT but wrong is worse than one
+ * that is absent — it reads as authoritative and is a specific false claim
+ * instead of a missing one (the same shape `bundled-license` draws between a
+ * guessed SPDX expression and an honest gap). A package moved between
+ * pillars, copy-pasted from a sibling's manifest, or renamed on disk without
+ * its `repository` block following along would all produce exactly this: a
+ * value that looks correct and resolves to somebody else's package. So the
+ * check does not stop at "is `directory` present" — it recomputes the
+ * package's actual repo-relative path and compares.
+ *
+ * PORTABLE: reads only the manifest and the path `createContext()` already
+ * resolved for each package (`pkg.rel`, POSIX, relative to the tree root).
+ * Any repository with a git remote and a `directory` convention hits the same
+ * failure mode the same way, so this holds in a consumer's tree exactly as it
+ * does here.
+ */
+
+import { defineRule } from '../registry.mjs';
+
+/**
+ * The `directory` value a package's own manifest OWES — its own path,
+ * relative to the tree root, POSIX-separated. `pkg.rel` already is that value
+ * (see `context.mjs#toRecord`); named here so the comparison in
+ * {@link auditRepositoryDirectory} reads as a check against a computed fact,
+ * not a restatement of `pkg.rel`.
+ *
+ * @param {import('../context.mjs').PackageRecord} pkg
+ * @returns {string}
+ */
+export function expectedDirectory(pkg) {
+    return pkg.rel;
+}
+
+/**
+ * @param {import('../context.mjs').ConformanceContext} ctx
+ * @returns {{failures: string[], stats: Record<string, number>}}
+ */
+export function auditRepositoryDirectory(ctx) {
+    const failures = [];
+    let checked = 0;
+    let ok = 0;
+
+    for (const pkg of ctx.allPackages) {
+        // A private package makes no promise to a reader outside the tree —
+        // same carve-out as `os-axis` and `package-outputs`'s showcase check.
+        if (pkg.private) continue;
+        checked++;
+
+        const repo = pkg.manifest.repository;
+        const expected = expectedDirectory(pkg);
+
+        if (repo === undefined || repo === null) {
+            failures.push(
+                `${pkg.name} (${pkg.rel}): declares no \`repository\` at all. Without it npm has nothing to link a ` +
+                    `reader to, and \`npm repo ${pkg.name}\` has nowhere to open. Add ` +
+                    `{"type":"git","url":"git+https://github.com/gjsify/gjsify.git","directory":"${expected}"}.`,
+            );
+            continue;
+        }
+        if (typeof repo !== 'object' || Array.isArray(repo)) {
+            // npm's shorthand string form (`"github:owner/repo"`) has no room for a
+            // `directory`, so it is exactly the shape this rule exists to reject —
+            // not a different, acceptable spelling.
+            failures.push(
+                `${pkg.name} (${pkg.rel}): \`repository\` is ${JSON.stringify(repo)}, not an object. The shorthand ` +
+                    `string form has no \`directory\` field to hold, which is what a monorepo package needs to ` +
+                    `distinguish itself from the other ~190 sharing one \`url\`. Use ` +
+                    `{"type":"git","url":"git+https://github.com/gjsify/gjsify.git","directory":"${expected}"}.`,
+            );
+            continue;
+        }
+
+        const directory = repo.directory;
+        if (directory === undefined) {
+            failures.push(
+                `${pkg.name} (${pkg.rel}): \`repository\` names no \`directory\`. Every package in this monorepo ` +
+                    `shares one \`repository.url\`, so without \`directory\` npm's "Repository" link on this ` +
+                    `package's page — and \`npm repo ${pkg.name}\` — lands on the tree ROOT instead of this ` +
+                    `package: a link that resolves, and is wrong. Add "directory": "${expected}".`,
+            );
+            continue;
+        }
+        if (typeof directory !== 'string' || directory !== expected) {
+            failures.push(
+                `${pkg.name} (${pkg.rel}): \`repository.directory\` is ${JSON.stringify(directory)}, but this ` +
+                    `package's actual path is "${expected}". A directory that is present but WRONG is a worse ` +
+                    `defect than a missing one — it reads as authoritative and points a reader at a package that ` +
+                    `is not this one. Set "directory": "${expected}".`,
+            );
+            continue;
+        }
+        ok++;
+    }
+
+    return { failures, stats: { checked, ok } };
+}
+
+export const repositoryDirectoryRule = defineRule({
+    id: 'repository-directory',
+    scope: 'portable',
+    fields: ['repository'],
+    description:
+        "every non-private package's `repository.directory` is present and equals its own repo-relative path",
+    run(ctx) {
+        const { failures, stats } = auditRepositoryDirectory(ctx);
+        return {
+            failures,
+            stats,
+            summary:
+                `repository-directory: OK. ${stats.checked} non-private package(s) checked; every declared ` +
+                '`repository.directory` matches its own path.',
+        };
+    },
+});

--- a/packages/infra/nativescript-vite/package.json
+++ b/packages/infra/nativescript-vite/package.json
@@ -22,7 +22,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/nativescript-vite"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/rolldown-plugin-deepkit/package.json
+++ b/packages/infra/rolldown-plugin-deepkit/package.json
@@ -22,7 +22,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/rolldown-plugin-deepkit"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/rolldown-plugin-gjsify/package.json
+++ b/packages/infra/rolldown-plugin-gjsify/package.json
@@ -39,7 +39,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/rolldown-plugin-gjsify"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/rolldown-plugin-pnp/package.json
+++ b/packages/infra/rolldown-plugin-pnp/package.json
@@ -22,7 +22,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/rolldown-plugin-pnp"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/rolldown-plugin-solid/package.json
+++ b/packages/infra/rolldown-plugin-solid/package.json
@@ -28,7 +28,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/rolldown-plugin-solid"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/rolldown-plugin-vue/package.json
+++ b/packages/infra/rolldown-plugin-vue/package.json
@@ -28,7 +28,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/rolldown-plugin-vue"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/vite-plugin-blueprint/package.json
+++ b/packages/infra/vite-plugin-blueprint/package.json
@@ -33,7 +33,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/vite-plugin-blueprint"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/vite-plugin-gettext/package.json
+++ b/packages/infra/vite-plugin-gettext/package.json
@@ -22,7 +22,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/vite-plugin-gettext"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/infra/vite-plugin-gjsify/package.json
+++ b/packages/infra/vite-plugin-gjsify/package.json
@@ -22,7 +22,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gjsify/gjsify.git"
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/infra/vite-plugin-gjsify"
     },
     "bugs": {
         "url": "https://github.com/gjsify/gjsify/issues"

--- a/packages/node/browser-polyfills/package.json
+++ b/packages/node/browser-polyfills/package.json
@@ -55,5 +55,10 @@
     },
     "files": [
         "globals.mjs"
-    ]
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "packages/node/browser-polyfills"
+    }
 }

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1392,6 +1392,12 @@ const CHECK_RULES = [
     // manifest, then resolves each name from the DECLARING package. No build, no install
     // beyond the one this job already has.
     'bundler-plugins',
+    // Reads only `repository` out of each manifest, so no install and no build. It
+    // belongs on every PR: npm renders the "Repository" link (and `npm repo <pkg>`) from
+    // `repository.url` + `repository.directory`, every package here shares one `url`, and
+    // a missing or wrong `directory` still resolves — to the tree root or to a sibling
+    // package — which is a defect nobody reports because the link looks fine.
+    'repository-directory',
     'field-coverage',
     'status-data',
 ];
@@ -1508,6 +1514,7 @@ async function main() {
         // Fetched AND printed in both branches in the same edit — the two comments above
         // are what the other order cost twice.
         const bundlerPlugins = byId.get('bundler-plugins');
+        const repositoryDirectory = byId.get('repository-directory');
         const reach = reachability.reach;
 
         if (run.ok) {
@@ -1526,6 +1533,7 @@ async function main() {
             console.log(bundledLicense.summary);
             console.log(stylesheetFontFamilies.summary);
             console.log(bundlerPlugins.summary);
+            console.log(repositoryDirectory.summary);
             console.log(prTriggerParity.summary);
             console.log(workflowRevPin.summary);
             console.log(coverage.summary);
@@ -1889,6 +1897,21 @@ async function main() {
             );
             console.error('');
         }
+        if ((repositoryDirectory.failures ?? []).length > 0) {
+            console.error(`REPOSITORY-DIRECTORY FAILURES on ${repositoryDirectory.failures.length} finding(s):`);
+            for (const line of repositoryDirectory.failures) {
+                console.error(`  - ${line}`);
+            }
+            console.error('');
+            console.error(
+                "Every non-private package shares this monorepo's `repository.url`, so `directory` is the only " +
+                    'part of the field that says WHICH package a reader ends up on. Absent, npm\'s "Repository" link ' +
+                    'and `npm repo <pkg>` land on the tree root; present but wrong, they land on a different ' +
+                    "package — both look like working links. Set `repository.directory` to the package's own " +
+                    'repo-relative path.',
+            );
+            console.error('');
+        }
         for (const note of bundlerPlugins.notes ?? []) console.error(`  · ${note}`);
         for (const note of coverage.notes ?? []) console.error(`  · ${note}`);
         renderReachabilityNotes(reach);
@@ -1936,6 +1959,7 @@ async function main() {
             'workflow-rev-pin',
             'stylesheet-font-families',
             'bundler-plugins',
+            'repository-directory',
         ]);
         const unreported = run.results.filter(
             ({ rule, result }) => (result.failures ?? []).length > 0 && !REPORTED_RULE_IDS.has(rule.id),


### PR DESCRIPTION
## The defect

Every package in this monorepo shares one `repository.url`. That makes
`repository.directory` the **only** part of the field that says *which* of ~200
packages a reader is looking at — npm builds the package page's "Repository" link,
and `npm repo <pkg>`, from the two together.

Eleven packages shipped without it. The link still resolves; it just lands on the
tree root instead of the package. A working link that opens the wrong page is not
something anyone reports — they read the wrong README and move on.

It surfaced because two of the eleven, `@gjsify/rolldown-plugin-solid` and
`@gjsify/rolldown-plugin-vue`, were about to be published to npm for the first
time. Their npm page is every reader's first signpost, and it would have pointed
at the wrong place from day one.

## Two commits, because the second is the interesting one

**`fix: repository.directory + a rule to guard it`** fixes all eleven and adds a
portable `repository-directory` rule to `@gjsify/manifest-conformance`. It checks
more than presence: a `directory` that is present but **wrong** is the worse
defect, because it reads as authoritative and is a specific false claim rather
than a missing one. A package moved between pillars, or copy-pasted from a
sibling, produces exactly that.

**`fix: one tree, one repository url`** fixes what the first commit broke.

`@gjsify/unit` declared `github.com/gjsify/unit` — a repo that exists, last pushed
**2020-02-18**, while the package is developed here in `packages/gjs/unit`.
Published npm metadata carried that url as far as 0.42.0. Adding a `directory` to
that manifest, which the new rule demands, produced a path inside *somebody else's
repository* — manufacturing the precise defect the rest of the rule rejects.

It slipped through because the rule read `directory` and never `url`. They are
**one claim**: `directory` is a path inside the repo `url` names, so checking them
separately checks neither.

The rule now also requires a single `repository.url` across the tree. Disagreement
is **reported**, not settled by majority — a tie needs no arbiter, and anointing
the more popular value would ratify a mass copy-paste instead of catching one.

## A/B

With the url reverted:

```
packages in one tree declare 2 different `repository.url` values. Every package
here lives in ONE repository, so one of these names a repo the package is not in
— and its `directory` then points at a path inside that other repo:
    git+https://github.com/gjsify/gjsify.git  —  201 package(s): …, +197 more
    git+https://github.com/gjsify/unit.git    —  1 package(s): @gjsify/unit
rc=1
```

With it fixed:

```
repository-directory: OK. 202 non-private package(s) checked; every declared
`repository.directory` matches its own path, under 1 shared `repository.url`.
```

The already-published metadata is left alone — the next release carries the
correction, which is where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aWntfUqrzPzPhhVXmBGEP
