### PR TITLE
docs(release): add the UI-framework section

### DIFF
--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -32,9 +32,62 @@ https://github.com/gjsify/gjsify/releases/tag/v0.28.0
 
 ## What this release is about
 
-**Three things an app could not do, every one of which fails silently when you get it wrong.**
+**Four things an app could not do, every one of which fails silently when you get it wrong.**
 
 ---
+
+### A UI framework can drive GTK
+
+GTK could already describe a window instead of assembling it — that is what Blueprint is for, and it
+does property bindings too. What a template cannot do is change its own shape. A `.blp` is
+instantiated once; a list that grows, a page that swaps, a widget that appears when a checkbox is
+ticked all fall back to imperative code holding a reference to every widget it might later mutate.
+That is the code a UI framework exists to delete, and no UI framework could reach GTK from GJS.
+
+`@gjsify/gtk-host` is the layer that lets one: fourteen operations over GTK4/Adwaita widgets —
+create, insert, remove, set a property, read a parent — with no framework in them at all. Three
+adapters sit on top and share it, so a fix to how a child is parented reaches all three at once
+rather than being fixed once per renderer:
+
+```tsx
+import { render } from '@gjsify/gtk-host/solid';
+
+render(() => (
+    <gtk-box orientation="vertical">
+        <gtk-button label={label()} onClicked={() => setCount(count() + 1)} />
+    </gtk-box>
+), window);
+```
+
+Solid (`/solid`), Vue (`/vue`) and React (`/react`) are all real entry points, and two new packages
+compile what they are written in — `@gjsify/rolldown-plugin-solid` for Solid's JSX and
+`@gjsify/rolldown-plugin-vue` for single-file components.
+
+**Why the compile step is a package and not four lines of config.** Point rolldown's own transformer
+at a `.tsx` with no JSX configuration and it emits `import { jsx } from "react/jsx-runtime"`, reports
+the unresolved import as a WARNING, and exits 0. The build succeeds. The artifact throws at import,
+in a bundle nobody has reason to suspect, and the message names React — a dependency the project does
+not have and never asked for.
+
+The plugins are gated on their EMITTED CODE for the same reason, and one of those gates already
+caught something a running showcase could not. The Solid plugin cached its assembled Babel preset
+chain rather than the compiler modules, which made every option inert after the first plugin
+instance. A single build with a single instance never sees it; a process that builds two packages
+emits the first one's renderer imports into the second one's bundle, and that artifact fails at
+import with a module that is not there. A showcase asserts the real widget tree and is blind to it,
+because a showcase is one build.
+
+Two properties of the host are load-bearing enough to be pinned rather than described. The compiler
+emits `insertNode` BEFORE `setProp`, which is why the host defers materialising a widget — a
+construct-only property has to survive as a JSX attribute, and it can only do that if nothing has
+been constructed yet (ADR 0027 § Decision 5). And the renderer must never emit DOM: Solid's `dom`
+output cannot run under GJS at all, and it fails on an unresolved `document` at runtime, wherever the
+first render happens to be.
+
+The widget vocabulary is not hand-written. It is generated from the GIR, so a property that GTK has
+is a property the types have (ADR 0028) — and ADR 0029, landed in this release, proposes moving that
+vocabulary to `@girs/*`, where every GJS UI framework can share it instead of each generating its
+own.
 
 ### An app can find its own translations
 


### PR DESCRIPTION
## What was missing

`docs/release-notes/next.md` described three capabilities landing this cycle —
translations, MIME types, Blueprint in libraries. It said nothing about the largest
body of work in it: `@gjsify/gtk-host`, three framework adapters, and two packages
published to npm for the first time.

The generated changelog section lists those commits. What it cannot say is why they
matter, which is the whole job of the preamble.

## The section

Written in the frame this file already uses — a thing an app could not do, and the
way it fails silently when you get it wrong.

The capability: GTK could already *describe* a window rather than assemble it, which
is what Blueprint is for, bindings included. What a template cannot do is change its
own shape — a `.blp` is instantiated once, so a growing list or a swapped page falls
back to imperative code holding a reference to every widget it might later mutate.
That is the code a UI framework deletes, and none could reach GTK from GJS.

The silent failure: point rolldown's own transformer at a `.tsx` with no JSX
configuration and it emits `import { jsx } from "react/jsx-runtime"`, reports the
unresolved import as a **warning**, and exits 0. The build succeeds; the artifact
throws at import, naming a dependency the project never had.

It also records why the plugins are gated on their emitted code rather than by the
showcase — the preset-chain cache that made every option inert after the first
plugin instance is invisible to a single build with a single instance — and the two
host properties pinned rather than described (`insertNode` before `setProp`, and
never emitting DOM).

Header moves from three to four. No version is named: this file is deliberately
version-less, and the tag is where each release's copy lives.

## On verification

The reference detector could not be run end to end here. `--release-notes <version>`
asserts that `CHANGELOG.md`'s top section already names the version being cut, and
release-it regenerates that during the cut itself — so out of band it stops before
reading the prose at all (`rc=1`, "top section is 0.42.0 but the release is 0.43.0").

So the prose was scanned directly instead, with code fences, HTML comments and
inline code spans masked: no `#`-shaped tokens, no npm scopes, and no markdown links
sit outside backticks. There is nothing for the detector to resolve, which is why it
will pass at `before:git:beforeRelease`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011aWntfUqrzPzPhhVXmBGEP
