### PR TITLE
fix(node-gi): reach class-struct statics

### DIFF
--- a/packages/node-gi/node-gi/conformance/golden/class-struct-statics.txt
+++ b/packages/node-gi/node-gi/conformance/golden/class-struct-statics.txt
@@ -1,0 +1,13 @@
+SimpleAction is array: true
+SimpleAction count: 5
+SimpleAction names: enabled,name,parameter-type,state,state-type
+GObject.Object count: 0
+BufferedInputStream count: 3
+BufferedInputStream names: base-stream,buffer-size,close-base-stream
+inherited find_property: base-stream
+inherited value_type: GInputStream
+own find_property: enabled
+own value_type: gboolean
+own owner_type: GSimpleAction
+own instanceof ParamSpec: true
+miss find_property: null

--- a/packages/node-gi/node-gi/conformance/programs/class-struct-statics.conf.mjs
+++ b/packages/node-gi/node-gi/conformance/programs/class-struct-statics.conf.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// CLASS-STRUCT statics: the GObjectClass functions gjs exposes as statics ON the
+// constructor — `Ns.Class.list_properties()`, `.find_property()`. They live on
+// GObject.ObjectClass and nowhere else, so nothing finds them on the class's own
+// GIObjectInfo; gjs reaches them through the constructor PROTOTYPE CHAIN, and
+// node-gi through a class-struct walk up the object-info parent chain. Before that
+// walk existed, every one of these calls threw "no static method '…' on Ns.Class",
+// which is every element-creation path in @gjsify/gtk-host (props.ts paramSpecs()).
+//
+// Headless on purpose (Gio + GObject, no GTK): the whole conformance corpus runs
+// without a display or a GTK typelib.
+//
+// NO camelCase spelling is exercised here, and that is deliberate: gjs defines
+// camelCase aliases for instance methods only, so `Gtk.Button.listProperties` is
+// `undefined` under gjs while node-gi's static proxy accepts it. A divergence, but
+// a PRE-EXISTING one about the static proxy rather than about class structs.
+import GObject from 'gi://GObject?version=2.0';
+import Gio from 'gi://Gio?version=2.0';
+
+// Sorted: g_object_class_list_properties' order is the class's installation order,
+// which is not a contract and shifts when a GLib/GTK release installs one earlier.
+const names = (klass) =>
+    klass
+        .list_properties()
+        .map((p) => p.get_name())
+        .sort();
+
+const direct = names(Gio.SimpleAction);
+print('SimpleAction is array:', Array.isArray(Gio.SimpleAction.list_properties()));
+print('SimpleAction count:', direct.length);
+print('SimpleAction names:', direct.join(','));
+
+// The base class itself installs no properties — so a leaf's pspecs cannot be
+// leaking in from a shared/declarer class by accident.
+print('GObject.Object count:', GObject.Object.list_properties().length);
+
+// Three levels of GIObjectInfo parent (BufferedInputStream → FilterInputStream →
+// InputStream → Object): proves the walk does not stop at the leaf's own class
+// struct, AND that the class the call runs on is the LEAF's — an inherited
+// property must be visible.
+const buffered = names(Gio.BufferedInputStream);
+print('BufferedInputStream count:', buffered.length);
+print('BufferedInputStream names:', buffered.join(','));
+
+const inherited = Gio.BufferedInputStream.find_property('base-stream');
+print('inherited find_property:', inherited.get_name());
+print('inherited value_type:', GObject.type_name(inherited.value_type));
+
+const own = Gio.SimpleAction.find_property('enabled');
+print('own find_property:', own.get_name());
+print('own value_type:', GObject.type_name(own.value_type));
+print('own owner_type:', GObject.type_name(own.owner_type));
+print('own instanceof ParamSpec:', own instanceof GObject.ParamSpec);
+
+// A miss is `null`, not a throw — GObject returns NULL and gjs marshals it through.
+print('miss find_property:', Gio.SimpleAction.find_property('no-such-property'));

--- a/packages/node-gi/node-gi/src/calls.cc
+++ b/packages/node-gi/node-gi/src/calls.cc
@@ -1291,6 +1291,60 @@ Napi::Value HasClassMethod(const Napi::CallbackInfo& info) {
   return Napi::Boolean::New(env, invocable);
 }
 
+// Resolve a CLASS-STRUCT method — one of the GObjectClass functions gjs exposes as a
+// STATIC on the constructor (`Gtk.Button.list_properties()`, `.find_property()`).
+// Absent from the object's own GIObjectInfo, which is why CallStaticMethod's three
+// find_method arms missed it and every such call threw "no static method '…' on
+// Ns.Class" — including @gjsify/gtk-host's paramSpecs(), on every element-creation
+// path. `list_properties` is declared on GObject.ObjectClass and NOWHERE else
+// (Gio.SimpleActionClass has no GIR record at all) and class structs carry no GI
+// inheritance, so the walk is over the object-info PARENT chain, each level's class
+// struct in turn — reproducing what gjs reaches through the CONSTRUCTOR PROTOTYPE
+// CHAIN, where gjs_define_static_methods put GObjectClass's methods on
+// GObject.Object's constructor and Gtk.Button inherits them. Returns a new ref or
+// nullptr; same shape as ResolveMethodByName's parent walk above.
+static GIFunctionInfo* ResolveClassStructMethod(GIObjectInfo* objInfo, const char* name) {
+  GIObjectInfo* walk =
+      reinterpret_cast<GIObjectInfo*>(gi_base_info_ref(reinterpret_cast<GIBaseInfo*>(objInfo)));
+  GIFunctionInfo* found = nullptr;
+  while (walk != nullptr) {
+    GIStructInfo* cs = gi_object_info_get_class_struct(walk);
+    if (cs != nullptr) {
+      if (gi_struct_info_is_gtype_struct(cs)) found = gi_struct_info_find_method(cs, name);
+      gi_base_info_unref(reinterpret_cast<GIBaseInfo*>(cs));
+    }
+    if (found != nullptr) break;
+    GIObjectInfo* parent = gi_object_info_get_parent(walk);
+    gi_base_info_unref(reinterpret_cast<GIBaseInfo*>(walk));
+    walk = parent;
+  }
+  if (walk != nullptr) gi_base_info_unref(reinterpret_cast<GIBaseInfo*>(walk));
+  return found;
+}
+
+// The GTypeClass a class-struct method runs ON: the LEAF type's class, never the
+// declarer's — list_properties() on GtkButton's class must return the button's 44
+// pspecs, not GObject's zero. gjs resolves the same way, reading the gtype off the
+// constructor the call went THROUGH (`this`), which is the leaf.
+//
+// gjs's GTypeStructInstanceIn uses g_type_class_peek and states its reason: "we use
+// peek here to simplify reference counting … GType classes are never really freed …
+// we know that the GType class is referenced at least once when the JS constructor
+// is initialized". node-gi's class proxy takes no such ref, so peek alone is nullptr
+// for a type nothing has instantiated yet — hence g_type_class_ref, to REALISE the
+// class (the same reason ConstructGObject refs it before reading its pspecs). That
+// ref is KEPT: it establishes gjs's invariant once per GType (bounded — every later
+// call is served by the peek), while unrefing is the one call that could invalidate
+// the GParamSpecs list_properties just handed out, which the class owns. Since GLib
+// 2.84 g_type_class_unref is a documented no-op, so pairing buys nothing anyway.
+static gpointer ClassStructInstance(GIObjectInfo* objInfo) {
+  GType gtype =
+      gi_registered_type_info_get_g_type(reinterpret_cast<GIRegisteredTypeInfo*>(objInfo));
+  if (gtype == G_TYPE_INVALID) return nullptr;
+  gpointer klass = g_type_class_peek(gtype);
+  return klass != nullptr ? klass : g_type_class_ref(gtype);
+}
+
 // callStaticMethod(namespace, typeName, methodName, args?) -> unknown
 // Invoke a type-level constructor/static function (e.g. Gio.File.new_for_path,
 // Gtk.Label.new) — a function found ON a type but taking no instance. The Node
@@ -1317,8 +1371,27 @@ Napi::Value CallStaticMethod(const Napi::CallbackInfo& info) {
     return env.Null();
   }
   GIFunctionInfo* func = nullptr;
+  // Non-null ONLY when the class-struct fallback is what resolved `func`: the
+  // GTypeClass to invoke it on. It doubles as the flag that the "is an instance
+  // method" rejection below must not fire — a class-struct method IS is_method,
+  // its instance is the class rather than an object.
+  gpointer classInstance = nullptr;
   if (GI_IS_OBJECT_INFO(typeInfo)) {
-    func = gi_object_info_find_method(reinterpret_cast<GIObjectInfo*>(typeInfo), method.c_str());
+    GIObjectInfo* objInfo = reinterpret_cast<GIObjectInfo*>(typeInfo);
+    func = gi_object_info_find_method(objInfo, method.c_str());
+    if (func == nullptr) {
+      func = ResolveClassStructMethod(objInfo, method.c_str());
+      if (func != nullptr) {
+        classInstance = ClassStructInstance(objInfo);
+        if (classInstance == nullptr) {
+          // No GType behind the info, so there is no class to call it on. Drop back
+          // to the plain "no static method" error rather than invoking with a null
+          // instance, which would hand the C function a null GObjectClass*.
+          gi_base_info_unref(reinterpret_cast<GIBaseInfo*>(func));
+          func = nullptr;
+        }
+      }
+    }
   } else if (GI_IS_INTERFACE_INFO(typeInfo)) {
     func = gi_interface_info_find_method(reinterpret_cast<GIInterfaceInfo*>(typeInfo), method.c_str());
   } else if (GI_IS_STRUCT_INFO(typeInfo)) {
@@ -1331,7 +1404,8 @@ Napi::Value CallStaticMethod(const Napi::CallbackInfo& info) {
         .ThrowAsJavaScriptException();
     return env.Null();
   }
-  if (gi_callable_info_is_method(reinterpret_cast<GICallableInfo*>(func))) {
+  const bool isMethod = gi_callable_info_is_method(reinterpret_cast<GICallableInfo*>(func));
+  if (isMethod && classInstance == nullptr) {
     gi_base_info_unref(func);
     g_object_unref(repo);
     Napi::TypeError::New(env, ns + "." + tn + "." + method +
@@ -1339,7 +1413,10 @@ Napi::Value CallStaticMethod(const Napi::CallbackInfo& info) {
         .ThrowAsJavaScriptException();
     return env.Null();
   }
-  Napi::Value result = InvokeFunctionInfo(env, func, nullptr, args, ns + "." + tn + "." + method);
+  // A class struct may also declare plain functions (no instance); only the
+  // is_method ones take the class.
+  Napi::Value result = InvokeFunctionInfo(env, func, isMethod ? classInstance : nullptr, args,
+                                          ns + "." + tn + "." + method);
   gi_base_info_unref(func);
   g_object_unref(repo);
   return result;


### PR DESCRIPTION
GJS defines a GObject class's class-struct methods as statics on the
constructor. Measured on gjs 1.88.1: `Gtk.Button.list_properties()` returns 44
ParamSpecs and `find_property('label')` answers `label`. node-gi threw
`no static method 'list_properties' on Gtk.Button`, and `list_properties`
appeared nowhere in the engine.

This is load-bearing for the UI-framework binding. `@gjsify/gtk-host`'s
`paramSpecs()` calls `klass.list_properties()` with the constructor, and it is
reached from `materialize()`, which sits on every element-creation path — so
seven of gtk-host's nine suites cannot run on node/bun/deno until this works.
That matters most on Windows, where `test:gjs` cannot run at all because there
is no GJS host: node-gi is the only way gtk-host runs there.

## The fix, and one correction to the obvious version

A single `gi_object_info_get_class_struct(objInfo)` lookup on the leaf would
also have missed. `GObject-2.0.gir`'s `<record name="ObjectClass"
glib:is-gtype-struct-for="Object">` declares `find_property`,
`install_properties`, `install_property`, `list_properties` and
`override_property` — and nowhere else does. `GtkButtonClass` declares none of
them.

So `CallStaticMethod` gains a fallback that walks the object-info PARENT CHAIN,
asking `gi_object_info_get_class_struct` at each level. That reproduces what GJS
gets for free through the constructor prototype chain, where
`gjs_define_static_methods` installed `GObjectClass`'s methods on
`GObject.Object`'s constructor and `Gtk.Button` inherits them.

The class to invoke on comes from the LEAF GType, never the declarer's —
otherwise `list_properties` would answer GObject's 0 instead of the button's 44.

No name is special-cased: `find_property`, `list_properties`,
`install_property`, `install_properties` and `override_property` all work from
the one mechanism, on any GObject class.

## Reference counting

The class ref is deliberately not paired, and the reason is in the code. GJS's
`GTypeStructInstanceIn` uses `g_type_class_peek` and explains why — GType
classes are never really freed, and the class is referenced at least once when
the JS constructor is initialised. node-gi's class proxy takes no such ref, so
`peek` alone returns null for a type nothing has instantiated. Hence: peek
first, `g_type_class_ref` only on the miss, and keep that ref. It is bounded at
one per GType, and unrefing is the one call that could invalidate the
`GParamSpec`s `list_properties` just handed out, which the class owns.
Everything else is paired on every path including the error paths.

## Verification

A conformance program rather than a `node:test`, per ADR 0030: this is GJS's
semantics, so the expected value is whatever GJS prints. Headless on Gio +
GObject like all 27 existing programs, so it runs on every leg. It covers
`list_properties()` (count, and the names SORTED — installation order is not a
contract), a three-level parent walk with an inherited property,
`find_property()` including the null miss, and `value_type`/`owner_type`.

`conformance/ledger.json` stays EMPTY.

    node scripts/conformance.mjs --filter=class-struct --runtimes=gjs,node,bun
    → gjs OK, node OK, bun OK, exit 0

Independently re-measured after the fact, on both sides:

    gjs   : Gtk.Button 44  find(label)=label  find(nope)=null
    node  : Gtk.Button 44  find(label)=label  find(nope)=null

deno is excluded from that invocation and nothing is ledgered for it, because
the failure is not this change: 26 of 28 programs fail on deno here with exit
139 (SIGSEGV), the documented #47 boxed-handle teardown crash, on a local deno
2.1.1. Stdout is byte-identical every time.

Full node suite: 570 tests, 555 pass, 2 fail, 13 skipped. The two failures
(`canvas2d-bridge`, `excalibur-webgl`, GL frame timeouts) were A/B'd against a
rebuilt baseline addon and fail identically without this change.

## Adjacent, deliberately untouched

- node-gi accepts camelCase statics (`Gtk.Button.listProperties`) where GJS
  gives `undefined` for all of them. Pre-existing, general to every static, a
  superset rather than a wrong answer. Kept out of the golden on purpose: a
  program testing it would need a ledger entry, and the entry would be about the
  static proxy, not this fix.
- `typeof Ns.Class.anything === 'function'` in node-gi, where gjs gives
  `undefined` for a static that does not exist. Same root — the proxy trap
  returns a thunk unconditionally. Its own decision, with its own program.
