### PR TITLE
fix(gtk-host): restore displaced text, unify the probe

### DIFF
--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -335,6 +335,33 @@ export default async () => {
                 expect(widget.label).toBe('authored');
             });
 
+            await it('gives back the label a child displaced', async () => {
+                // The mirror of the guard above, and it was live in a shipped
+                // release. GTK's text sink IS the one-child slot, measured on
+                // gtk 4.22.4 in this exact order: `new Gtk.Button({label:'Save'})`
+                // reads `label === 'Save'`; `set_child(img)` reads `null`;
+                // `set_child(null)` still reads `null` — a BLANK button — and only
+                // writing the property back brings it round, at which point GTK
+                // rebuilds its own internal GtkLabel as the child.
+                //
+                // That sequence is `<Button label="Save"><Show when={x}><Icon/>
+                // </Show></Button>` toggling off, with the host still holding
+                // `props.label === 'Save'` the whole time. Exit 0, no diagnostic.
+                const button = createElement('GtkButton', { label: 'Save' });
+                const widget = materialize(button) as unknown as Gtk.Button;
+                expect(widget.label).toBe('Save');
+
+                const icon = createElement('GtkImage');
+                insert(icon, button);
+                // GTK's own doing, asserted so the premise cannot rot in silence:
+                // if a future GTK stops clearing the sink, this line says so rather
+                // than the restore quietly becoming a no-op nobody notices.
+                expect(widget.label).toBe(null);
+
+                remove(icon);
+                expect(widget.label).toBe('Save');
+            });
+
             await it('refuses text on a widget with no sink, naming the tag', async () => {
                 const image = createElement('GtkImage');
                 materialize(image);

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -771,6 +771,52 @@ function restore(node: HostNode, parent: HostElement, before: HostNode | null): 
     }
 }
 
+/**
+ * Give back the text a child displaced.
+ *
+ * GTK's text sink IS the one-child slot, and putting a child in CLEARS the sink.
+ * Measured on gtk 4.22.4: `createElement('GtkButton', {label: 'Save'})` followed by
+ * `set_child(icon)` leaves `label` null, and taking the icon out again does not
+ * bring it back — so `<Button label="Save"><Show when={x}><Icon/></Show></Button>`
+ * toggling OFF renders a blank button while this host still holds
+ * `props.label === 'Save'`. Exit 0, no diagnostic.
+ *
+ * This is the mirror of the guard `writeTextSink` already carries in the other
+ * direction, where clearing the sink must not take an element child with it. Only
+ * the pair is complete: one direction alone means the loss just moves to the other
+ * axis, which is how this one survived the round that fixed its sibling.
+ */
+function restoreTextSink(el: HostElement): void {
+    const sink = el.descriptor.textSink;
+    if (!sink || el.destroyed || !el.widget) return;
+    const policy = el.descriptor.children;
+    // `single` is where the conflation lives, and `writeTextSink` reads the same
+    // narrowing: a `none` policy can hold no child to displace the text with.
+    if (policy.kind !== 'single') return;
+    // Only once the slot is genuinely free. Solid and React reconcile
+    // insert-then-remove (`solid-js/universal`'s `replaceNode`), so a sink written
+    // here would land ON TOP of the replacement that has already arrived.
+    if (holdsOursInSlot(el, null)) return;
+    if (slotOccupant(el.widget as unknown as Gtk.Widget, policy.set)) return;
+    // `setProp` records the AUTHORED key while `writeTextSink` records the kebab
+    // sink name. All four curated sinks are one word, so the two coincide today;
+    // asking both costs one lookup and does not go stale if a two-word sink is
+    // ever curated.
+    const camel = sink.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    const recorded = el.props[sink] ?? el.props[camel];
+    if (typeof recorded !== 'string' || recorded === '') return;
+    const spec = requireSpec(paramSpecs(el.descriptor.ctor(), el.descriptor.gtype), el.descriptor.gtype, sink);
+    beginHostWrite();
+    try {
+        (el.widget as unknown as { set_property(n: string, v: unknown): void }).set_property(
+            sink,
+            coerce(spec, recorded, el.descriptor.gtype),
+        );
+    } finally {
+        endHostWrite();
+    }
+}
+
 /** Detach only — reversible. Frameworks move nodes; `remove` must not destroy one. */
 export function remove(node: HostNode): void {
     const parent = node.parent;
@@ -784,6 +830,7 @@ export function remove(node: HostNode): void {
             (node.wrapper as unknown as { set_child(w: unknown): void }).set_child(null);
             node.wrapper = null;
         }
+        restoreTextSink(parent);
     }
     unlink(node);
     if (parent && node.kind === 'text') flushText(parent);

--- a/packages/framework/gtk-host/src/probe.ts
+++ b/packages/framework/gtk-host/src/probe.ts
@@ -37,6 +37,12 @@ import { installDiagnosticsGate, type DiagnosticsGate } from './conformance/diag
  * own result line a diagnostic it then counts.
  */
 declare const print: (message: string) => void;
+/**
+ * Same reason as `print` above, and one more: this is the only way to report from
+ * inside the failure path of the GUI entry, where the diagnostics gate has already
+ * replaced GLib's writer and `console.error` would route straight back into it.
+ */
+declare const printerr: (message: string) => void;
 
 /** Record one assertion. A `false` is a finding; nothing else is. */
 export type ProbeCheck = (what: string, ok: boolean) => void;
@@ -53,8 +59,28 @@ export interface HostProbe<T> {
      * and the exact getters, never the host's own bookkeeping, which would agree
      * with itself while the window is wrong. Return whatever belongs in the result
      * line; the harness adds the failure list and the diagnostic count.
+     *
+     * MAY BE ASYNC, and one adapter forces it: Vue flushes render jobs on a
+     * microtask, so an assertion after a click has to `await nextTick()` or it reads
+     * the pre-patch tree. Without this the Vue showcase hand-rolled the whole
+     * harness, and the copy carried the pre-`describeLogRecord` collector bug with
+     * it — a log record with no `MESSAGE` counted as a diagnostic and then described
+     * as the empty string.
      */
-    assert(ui: T, check: ProbeCheck): Record<string, unknown>;
+    assert(ui: T, check: ProbeCheck): Record<string, unknown> | Promise<Record<string, unknown>>;
+    /**
+     * Release what the assertions built, before the diagnostics are counted.
+     *
+     * ORDER IS THE POINT. Teardown is exactly where GTK reports a mis-parented tree
+     * — `Finalizing GtkLabel …, but it still has children left` arrives at finalize,
+     * at exit 0 (ADR 0027 § Context). A probe that counts diagnostics and THEN tears
+     * down cannot see the one class of defect that only surfaces there, which is
+     * what both hand-written probes did.
+     *
+     * Optional because a probe that owns nothing has nothing to release; the
+     * harness's own `build` result is reachable only from here.
+     */
+    teardown?(ui: T): void;
     /** Prefix of the machine-readable result line. Default `PROBE`. */
     label?: string;
 }
@@ -111,6 +137,15 @@ function recorderIsHonest(check: ProbeCheck, failures: string[]): string | null 
 /**
  * Run the showcase's assertions once and return the process exit code.
  *
+ * **The probe always builds HEADLESS, in both paths.** It is handed `null` rather
+ * than the `GApplication`, for two reasons that point the same way. It makes the two
+ * paths return the same verdict about the same tree — a probe whose GUI run differs
+ * from its headless run is two probes. And it keeps the GUI path from constructing
+ * and (now that `teardown` exists) destroying an `Adw.ApplicationWindow` INSIDE
+ * `activate`, which is the exact neighbourhood of the segfault recorded on
+ * `runHostProbeApp` below. Nothing a probe asserts needs an application; `present`
+ * gets the real one.
+ *
  * The diagnostics gate is reset first and asserted last, and both halves are the
  * harness's rather than the showcase's. Reset, because in the GUI path this runs
  * from `activate` — AFTER Adw startup, where a session-bus, portal, theme or a11y
@@ -119,7 +154,7 @@ function recorderIsHonest(check: ProbeCheck, failures: string[]): string | null 
  * failure mode is exit 0: a mis-parented widget floods `Gtk-WARNING` and the
  * process still succeeds.
  */
-export function runHostProbe<T>(probe: HostProbe<T>, app: Adw.Application | null = null): number {
+export async function runHostProbe<T>(probe: HostProbe<T>): Promise<number> {
     const label = probe.label ?? 'PROBE';
     const gate: DiagnosticsGate = installDiagnosticsGate();
     gate.reset();
@@ -138,7 +173,11 @@ export function runHostProbe<T>(probe: HostProbe<T>, app: Adw.Application | null
 
     let report: Record<string, unknown> = {};
     try {
-        report = probe.assert(probe.build(app), check);
+        const ui = probe.build(null);
+        report = await probe.assert(ui, check);
+        // Inside the same `try`: a throw here is a finding like any other, and a
+        // teardown that throws is itself a defect worth reporting by name.
+        probe.teardown?.(ui);
     } catch (error) {
         // A throw is a finding, not a crash. The hand-written probes let one
         // escape into GJS's `activate` handler, which LOGS the exception and
@@ -146,7 +185,7 @@ export function runHostProbe<T>(probe: HostProbe<T>, app: Adw.Application | null
         failures.push(`threw: ${(error as Error).message}`);
     }
 
-    // Last, so it covers the build AND the assertions.
+    // Last, so it covers the build, the assertions AND the teardown.
     const diagnostics = gate.seen.length;
     check(`no GTK diagnostics (saw ${diagnostics})`, diagnostics === 0);
 
@@ -170,13 +209,41 @@ export function runHostProbe<T>(probe: HostProbe<T>, app: Adw.Application | null
 export async function runHostProbeApp<T>(probe: HostProbeApp<T>): Promise<void> {
     if (probeEnabled()) {
         Gtk.init();
-        return system.exit(runHostProbe(probe, null));
+        return system.exit(await runHostProbe(probe));
     }
     const app = new Adw.Application({ application_id: probe.applicationId });
     app.connect('activate', () => {
-        const failed = runHostProbe(probe, app);
-        if (failed !== 0) system.exit(failed);
-        probe.present(probe.build(app));
+        // `activate` IS A GLIB CALLBACK AND CANNOT BE AWAITED, while the probe may
+        // be async. So the work is STARTED here, and `app.hold()` is what makes
+        // that legal.
+        //
+        // MEASURED, without the hold — in the Vue showcase, before this harness
+        // owned the path: `activate` returned having presented nothing,
+        // GApplication's hold count reached zero, and `gtk_application_shutdown`
+        // ran its own nested main loop. The probe's continuation was then dispatched
+        // from INSIDE that shutdown, constructed a window with `application: app`,
+        // and `gtk_application_window_added` segfaulted — `PROBE: PASS` on stdout,
+        // exit 139, and a stack ending in `gtk_application_shutdown ->
+        // g_main_loop_run -> PromiseJobDispatcher`. Nothing about the crash names
+        // the missing hold, which is why it is recorded here rather than rediscovered.
+        app.hold();
+        void (async () => {
+            try {
+                const failed = await runHostProbe(probe);
+                if (failed !== 0) return system.exit(failed);
+                probe.present(probe.build(app));
+            } catch (error) {
+                // A REAL throw path: the probe reaches into GTK and into a
+                // framework's scheduler. Caught because a rejected promise would
+                // leave the `hold()` above un-released forever, and an application
+                // that never exits is what `showcase-smoke` reads as "still up after
+                // the dwell" — a failure that reports itself as a pass.
+                printerr(`JS ERROR: ${probe.applicationId} probe threw: ${String(error)}`);
+                return system.exit(1);
+            } finally {
+                app.release();
+            }
+        })();
     });
     await app.runAsync([]);
 }

--- a/showcases/gtk/vue-host-counter/src/app.ts
+++ b/showcases/gtk/vue-host-counter/src/app.ts
@@ -31,36 +31,10 @@ import Adw from 'gi://Adw?version=1';
 import GLib from 'gi://GLib?version=2.0';
 import Gtk from 'gi://Gtk?version=4.0';
 
-/**
- * Every GLib/GTK diagnostic this process emits, captured rather than merely
- * printed — GTK's failure mode is exit 0, so a mis-parented tree has to be read
- * out of the log rather than out of the exit code. Identical mechanism to both
- * siblings; see `adw-host-counter/src/app.ts` for why the writer forwards instead
- * of swallowing.
- */
-const diagnostics: string[] = [];
-const decoder = new TextDecoder();
-const verboseLogging = GLib.getenv('G_MESSAGES_DEBUG') !== null;
-
-GLib.log_set_writer_func((level, fields) => {
-    try {
-        const raw = (fields as unknown as { MESSAGE?: unknown } | null)?.MESSAGE;
-        const message = raw instanceof Uint8Array ? decoder.decode(raw) : String(raw ?? '');
-        // MASK the level: `g_logv` ORs in `G_LOG_FLAG_FATAL`, so `WARNING|FATAL`
-        // is 18 and an unmasked `<= 16` misses it under `--g-fatal-warnings`.
-        const severity = level & GLib.LogLevelFlags.LEVEL_MASK;
-        if (severity <= GLib.LogLevelFlags.LEVEL_WARNING) diagnostics.push(message);
-        if (verboseLogging || severity <= GLib.LogLevelFlags.LEVEL_MESSAGE) printerr(message);
-    } catch {
-        printerr('<vue-host probe: a log message could not be decoded>');
-    }
-    return GLib.LogWriterOutput.HANDLED;
-});
-
 import { nextTick } from '@vue/runtime-core';
 
-import { registerBuiltinWidgets } from '@gjsify/gtk-host';
-import { dumpTree, gtkChildren } from '@gjsify/gtk-host/conformance';
+import { registerBuiltinWidgets, runHostProbeApp, type ProbeCheck } from '@gjsify/gtk-host';
+import { descendants, dumpTree, findDescendant, gtkChildren } from '@gjsify/gtk-host/conformance';
 import { mount } from '@gjsify/gtk-host/vue';
 
 import App from './App.vue';
@@ -90,27 +64,11 @@ function buildUi(app: Adw.Application | null) {
     return { window, vue };
 }
 
-/** First descendant matching `pred`, breadth-first over the REAL widget tree. */
-function findDescendant(root: Gtk.Widget, pred: (w: Gtk.Widget) => boolean): Gtk.Widget | null {
-    const queue: Gtk.Widget[] = [root];
-    while (queue.length > 0) {
-        const widget = queue.shift() as Gtk.Widget;
-        if (widget !== root && pred(widget)) return widget;
-        queue.push(...gtkChildren(widget));
-    }
-    return null;
-}
-
 /** Titles of the Adw.ActionRows GTK actually holds, in GTK's own order. */
-function rowTitles(root: Gtk.Widget): string[] {
-    const found: string[] = [];
-    const walk = (widget: Gtk.Widget) => {
-        if (widget instanceof Adw.ActionRow) found.push(widget.title);
-        for (const child of gtkChildren(widget)) walk(child);
-    };
-    walk(root);
-    return found;
-}
+const rowTitles = (root: Gtk.Widget): string[] =>
+    descendants(root)
+        .filter((w): w is Adw.ActionRow => w instanceof Adw.ActionRow)
+        .map((row) => row.title);
 
 /** A button by its label, from the real tree — never from Vue's own bookkeeping. */
 function buttonNamed(root: Gtk.Widget, label: string): Gtk.Button | null {
@@ -129,16 +87,21 @@ async function click(button: Gtk.Button | null): Promise<void> {
     await nextTick();
 }
 
-async function runProbe(): Promise<number> {
-    // Start from zero: in the GUI path this runs from `activate`, after Adw
-    // startup, where a portal/theme/a11y warning is routine in a container.
-    diagnostics.length = 0;
+type Ui = ReturnType<typeof buildUi>;
 
-    const failures: string[] = [];
-    const check = (what: string, ok: boolean) => {
-        if (!ok) failures.push(what);
-    };
-
+/**
+ * Everything this showcase claims, read back off the REAL widget tree.
+ *
+ * ASYNC, and that is why the shared harness grew an async `assert`: Vue flushes
+ * render jobs on a microtask, so an assertion after a click has to `await
+ * nextTick()` or it reads the tree as it was before the patch. This file used to
+ * hand-roll the whole harness for that one reason — the env gate, the diagnostics
+ * collector, the `check()` recorder, the `PROBE:` protocol and the `app.hold()`
+ * discipline — and the copy carried the pre-`describeLogRecord` collector bug with
+ * it, where a log record without a `MESSAGE` was counted and then described as the
+ * empty string.
+ */
+async function assertUi(ui: Ui, check: ProbeCheck): Promise<Record<string, unknown>> {
     // 0. The four production defines held. `@vue/runtime-core` is DOM-free in fact,
     //    but `--globals auto` is a STATIC scan: without the defines it injects a
     //    polyfill per identifier it sees in a dev-only branch and drags gi://Gdk,
@@ -148,7 +111,6 @@ async function runProbe(): Promise<number> {
     check('no DOM was injected (the production defines held)', typeof globals.document === 'undefined');
     check('no navigator was injected', typeof globals.navigator === 'undefined');
 
-    const ui = buildUi(null);
     const window = ui.window as unknown as Gtk.Widget;
 
     // 1. The string enum nick reached GTK. GObject would have kept HORIZONTAL, so
@@ -214,66 +176,28 @@ async function runProbe(): Promise<number> {
         JSON.stringify(rowTitles(window)) === JSON.stringify(['Row 2', 'Clicks']),
     );
 
-    // 7. …and none of it may have been reported to GLib.
-    check(`no GTK diagnostics (saw ${diagnostics.length})`, diagnostics.length === 0);
-
-    const report = {
+    return {
         rows: rowTitles(window),
         actions: actionLabels(),
-        diagnostics: diagnostics.length,
         tree: dumpTree(window).split('\n').length,
     };
-    // Cleanup beside creation: the probe built a real toplevel of its own, and
-    // `unmount` only tears down what Vue owns inside it.
-    ui.vue.unmount();
-    ui.window.destroy();
-    if (failures.length > 0) {
-        print(`PROBE: FAIL ${JSON.stringify({ failures, ...report })}`);
-        return 1;
-    }
-    print(`PROBE: PASS ${JSON.stringify(report)}`);
-    return 0;
 }
 
-if (GLib.getenv('GJSIFY_HOST_PROBE') === '1') {
-    // Headless one-shot: assert and exit, no window, no main loop.
-    Gtk.init();
-    imports.system.exit(await runProbe());
-} else {
-    const app = new Adw.Application({ application_id: 'eu.jumplink.VueHostCounter' });
-    app.connect('activate', () => {
-        // `activate` IS A GLIB CALLBACK AND CANNOT BE AWAITED, and the probe has to
-        // await Vue's scheduler. So the async work is started here — and
-        // `app.hold()` is what makes that legal.
-        //
-        // MEASURED, without the hold: `activate` returned having presented nothing,
-        // GApplication's hold count hit zero, and `gtk_application_shutdown` ran its
-        // own nested main loop. The probe's continuation was then dispatched FROM
-        // INSIDE that shutdown, constructed a window with `application: app`, and
-        // `gtk_application_window_added` segfaulted — `PROBE: PASS` on stdout, exit
-        // 139, and the stack ends in `gtk_application_shutdown ->
-        // g_main_loop_run -> PromiseJobDispatcher`. Nothing about the crash names
-        // the missing hold.
-        app.hold();
-        void (async () => {
-            try {
-                const failed = await runProbe();
-                if (failed !== 0) imports.system.exit(failed);
-
-                const ui = buildUi(app);
-                ui.window.present();
-            } catch (error) {
-                // A REAL throw path: the probe calls into GTK and into Vue's
-                // scheduler. Caught because a rejected promise would leave the
-                // `hold()` above forever un-released, and an application that never
-                // exits is what `showcase-smoke` reads as "still up after the dwell"
-                // — a failure that reports itself as a pass.
-                printerr(`JS ERROR: vue-host-counter probe threw: ${String(error)}`);
-                imports.system.exit(1);
-            } finally {
-                app.release();
-            }
-        })();
-    });
-    await app.runAsync([]);
-}
+await runHostProbeApp<Ui>({
+    applicationId: 'eu.jumplink.VueHostCounter',
+    // Ignores the application on purpose — and so does the harness, which always
+    // probes headless. A Vue mount asserts about the widget tree, and building an
+    // `Adw.ApplicationWindow` with `application: app` inside `activate` is the
+    // neighbourhood of the segfault recorded on `runHostProbeApp`.
+    build: () => buildUi(null),
+    assert: assertUi,
+    // The probe builds a real toplevel of its own. `unmount` releases what Vue
+    // owns inside it; `destroy` is what unparenting cannot reach. Run BEFORE the
+    // harness counts diagnostics, which is the point of the hook — a finalize-time
+    // `still has children left` is exactly the class that only appears here.
+    teardown: (ui) => {
+        ui.vue.unmount();
+        ui.window.destroy();
+    },
+    present: (ui) => ui.window.present(),
+});

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -75,7 +75,26 @@ measurement rather than shipped quietly.
   The root cause is the same insight the occupied-slot refusal already acts on —
   a composite's DIRECT children are not the list its `add()` addresses — but the
   getter that fixes it for one-child slots has no counterpart for appending
-  policies, so it needs its own round. Adder slots that are NOT composites are
+  policies, so it needs its own round.
+
+  **Located.** `adoptedChildren()` (`src/host.ts`) branches on
+  `setterSlots(descriptor.children)`: with setter slots it asks each slot's GETTER,
+  which is why the one-child case is right, and with none it falls through to
+  `directChildren(container)` — a raw child-list snapshot. `AdwPreferencesPage` has
+  no setter slot, so its internal `GtkScrolledWindow` is counted as application
+  content. The second half of the bug is what the index MEANS: `Adw.PreferencesPage`
+  is one of the few Adwaita containers that really has `insert`, and its `position`
+  addresses the page's GROUPS, not its direct children — so a `foreign` of length 1
+  offsets every position by one.
+
+  The shape of the fix follows from that, and it is a CURATED discriminator rather
+  than a derived one: for a container whose adder re-parents into an internal, the
+  direct children are never adder-addressed content, and nothing introspectable says
+  which containers those are (the internal child comes from a `.ui` template). So it
+  is a new field on the descriptor in the ADR 0028 § 2 sense — what the GIR cannot
+  express stays curated — plus the measurement of which of the 26 curated containers
+  need it. Deriving it by adding a probe child and reading `get_parent()` back would
+  mutate the very container being adopted, which is the application's. Adder slots that are NOT composites are
   fine: an adopted `AdwToolbarView` still renders `[app bar, host bar]`.
 
 - **Removing an element child does not restate the text it displaced.** GTK's

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -58,52 +58,42 @@ rendered through the GTK host and through `adwaita-web`, satisfies the same
 then the goal is a direction, not a claim — and the longer horizon it points at
 (NativeScript and browser builds from one native-authored source) needs its own ADR.
 
-### Two measured placement defects the adapters PR did NOT fix
+### An adopted composite offsets by its own internals
 
-Both surfaced while reviewing the Solid/Vue adapters, both are pre-existing in
-the host rather than introduced by them, and both are recorded here with the
-measurement rather than shipped quietly.
+Surfaced while reviewing the Solid/Vue adapters, pre-existing in the host rather than
+introduced by them, and recorded with the measurement rather than shipped quietly. Its
+sibling — a removed element child not restoring the text it displaced — is FIXED; this
+one is not, because its fix needs a curated descriptor field and a measurement round of
+its own.
 
-- **An adopted composite offsets by its own internals.** A fresh
-  `Adw.PreferencesPage` has one direct child — its internal `GtkScrolledWindow` —
-  so `adopt()` records `foreign.length === 1` and every subsequent `index` is off
-  by one. Measured on gtk 4.22.4 / libadwaita 1.9.3: `mountRoot` into an
-  `AdwPreferencesPage`, insert a group "one", then prepend "zero" before it, and
-  GTK renders **[one, zero]**; the identical tree in a NON-adopted page renders
-  **[zero, one]**. Exit 0, zero diagnostics. Reachable from any `<For>`/`v-for`
-  that prepends into the canonical Adwaita settings page.
-  The root cause is the same insight the occupied-slot refusal already acts on —
-  a composite's DIRECT children are not the list its `add()` addresses — but the
-  getter that fixes it for one-child slots has no counterpart for appending
-  policies, so it needs its own round.
+A fresh `Adw.PreferencesPage` has one direct child, its internal `GtkScrolledWindow`, so
+`adopt()` records `foreign.length === 1` and every subsequent `index` is off by one.
+Measured on gtk 4.22.4 / libadwaita 1.9.3: `mountRoot` into an `AdwPreferencesPage`,
+insert a group "one", then prepend "zero" before it, and GTK renders **[one, zero]**;
+the identical tree in a NON-adopted page renders **[zero, one]**. Exit 0, zero
+diagnostics. Reachable from any `<For>`/`v-for` that prepends into the canonical Adwaita
+settings page. Adder slots that are NOT composites are fine — an adopted
+`AdwToolbarView` still renders `[app bar, host bar]`.
 
-  **Located.** `adoptedChildren()` (`src/host.ts`) branches on
-  `setterSlots(descriptor.children)`: with setter slots it asks each slot's GETTER,
-  which is why the one-child case is right, and with none it falls through to
-  `directChildren(container)` — a raw child-list snapshot. `AdwPreferencesPage` has
-  no setter slot, so its internal `GtkScrolledWindow` is counted as application
-  content. The second half of the bug is what the index MEANS: `Adw.PreferencesPage`
-  is one of the few Adwaita containers that really has `insert`, and its `position`
-  addresses the page's GROUPS, not its direct children — so a `foreign` of length 1
-  offsets every position by one.
+**Located.** `adoptedChildren()` (`src/host.ts`) branches on
+`setterSlots(descriptor.children)`: with setter slots it asks each slot's GETTER, which
+is why the one-child case is right, and with none it falls through to
+`directChildren(container)`, a raw child-list snapshot. `AdwPreferencesPage` has no
+setter slot, so its internal `GtkScrolledWindow` is counted as application content. The
+second half of the bug is what the index MEANS: `Adw.PreferencesPage` is one of the few
+Adwaita containers that really has `insert`, and its `position` addresses the page's
+GROUPS, not its direct children — so a `foreign` of length 1 offsets every position by
+one.
 
-  The shape of the fix follows from that, and it is a CURATED discriminator rather
-  than a derived one: for a container whose adder re-parents into an internal, the
-  direct children are never adder-addressed content, and nothing introspectable says
-  which containers those are (the internal child comes from a `.ui` template). So it
-  is a new field on the descriptor in the ADR 0028 § 2 sense — what the GIR cannot
-  express stays curated — plus the measurement of which of the 26 curated containers
-  need it. Deriving it by adding a probe child and reading `get_parent()` back would
-  mutate the very container being adopted, which is the application's. Adder slots that are NOT composites are
-  fine: an adopted `AdwToolbarView` still renders `[app bar, host bar]`.
+The shape of the fix follows, and it is a CURATED discriminator rather than a derived
+one. For a container whose adder re-parents into an internal, the direct children are
+never adder-addressed content — and nothing introspectable says which containers those
+are, because the internal child comes from a `.ui` template. So it is a new descriptor
+field in the ADR 0028 § 2 sense (what the GIR cannot express stays curated), plus the
+measurement of which of the 26 curated containers need it. Deriving it by adding a probe
+child and reading `get_parent()` back would mutate the very container being adopted,
+which belongs to the application.
 
-- **Removing an element child does not restate the text it displaced.** GTK's
-  `set_child(icon)` clears `label` to null, so `createElement('GtkButton', {label:
-  'Save'})` + insert an icon + remove it leaves a BLANK button, while the host
-  still holds `props.label === 'Save'`. That is
-  `<Button label="Save"><Show when={x}><Icon/></Show></Button>` toggling off, or
-  the `v-if` equivalent — reachable, not theoretical, and the mirror image of the
-  text-side guard that IS in place.
 ### Nothing runs `build:infra` on a cold tree with no `node`
 
 The bootstrap ADR 0002 documents — `gjs -m install.mjs` → `gjsify install


### PR DESCRIPTION
One defect that shipped in 0.43.0, and the harness duplication that let a
sibling of it survive the round that fixed the other half.

## The shipped defect: text a child displaced never came back

GTK's text sink IS the one-child slot. Measured on gtk 4.22.4, in this order:

    new Gtk.Button({label:'Save'})   label === 'Save'
    set_child(img)                   label === null
    set_child(null)                  label === null   <- blank button
    set_property('label','Save')     label === 'Save', child = GtkLabel

The third line is `<Button label="Save"><Show when={x}><Icon/></Show></Button>`
toggling off: a blank button, exit 0, no diagnostic, while the host held
`props.label === 'Save'` the whole time.

`writeTextSink` already guarded the OPPOSITE direction — clearing the sink must
not take an element child with it — and only the pair is complete. One direction
alone means the loss moves to the other axis, which is exactly how this one
survived.

`restoreTextSink` re-applies the recorded value from `remove()`, the
reversible-detach path where the `<Show>`/`v-if` case lives. It refuses in three
situations rather than writing blindly: no `single` policy (a `none` policy can
hold no child to displace the text with), we still hold an element in the slot,
or GTK's slot is still occupied — because Solid and React reconcile
insert-then-remove, so a sink written here would land on top of a replacement
that has already arrived.

**A/B, measured both ways.** With the call removed the suite exits 1 and exactly
the new test fails; with it, 1930 tests from 9 gates, exit 0, and no other test
changes. The test also asserts the INTERMEDIATE `label === null`, so if a future
GTK stops clearing the sink it says so rather than the restore quietly becoming
a no-op nobody notices.

## The Vue showcase moves onto the shared probe

`probe.ts` says in its own header that it exists because two showcases
hand-rolled the same probe and "a third (Vue) is doing it again". It still was:
75 lines of harness, carrying the exact bug `describeLogRecord` was written to
end — `String(raw ?? '')` makes a log record with no MESSAGE count as a
diagnostic and then describe itself as the empty string, a gate that can count a
failure but not name it.

It had a real reason to diverge, so the capability goes to the core rather than
the copy staying: Vue flushes render jobs on a microtask, so an assertion after
a click must `await nextTick()`, and the harness was synchronous.

- `HostProbe.assert` may now return a promise.
- New optional `HostProbe.teardown(ui)`, run after the assertions and BEFORE the
  diagnostics are counted. Teardown is where GTK reports a mis-parented tree —
  `Finalizing GtkLabel …, but it still has children left` arrives at finalize,
  at exit 0 (ADR 0027 § Context) — and both hand-written probes counted first
  and tore down after. **Honest note: two A/B runs (dropping `unmount`, and
  reversing destroy/unmount) both stayed at 0 diagnostics, so this order is
  justified by GTK's documented behaviour and not by a case measured here.** It
  can only ever see more.
- The GUI path takes over the `app.hold()` discipline the Vue showcase carried
  alone, including the segfault it was written for: without the hold, `activate`
  returns, the hold count hits zero, `gtk_application_shutdown` runs a nested
  main loop, and the probe's continuation builds a window from inside it —
  `gtk_application_window_added` segfaults with `PROBE: PASS` already on stdout
  and exit 139.
- The probe now always builds HEADLESS in both paths. It makes the two paths
  return the same verdict about the same tree, and it keeps the GUI path from
  constructing and (now that teardown exists) destroying an
  `Adw.ApplicationWindow` inside `activate`, which is that segfault's
  neighbourhood. Nothing a probe asserts needs a GApplication; `present` still
  gets the real one.

`runHostProbe` is therefore async and lost its `app` parameter. Two callers
in-repo, both `runHostProbeApp`.

The showcase drops from 279 to 204 lines and gains the recorder self-check its
siblings had. All three probes: PASS, 0 diagnostics, exit 0.

## The sibling defect is located, not fixed

`status/open-todos.md` carried the measurement for the adopted-composite offset
but not the locus, so whoever picked it up would have started by measuring it
again. Now recorded: `adoptedChildren()` branches on
`setterSlots(descriptor.children)` — with setter slots it asks each slot's
getter, which is why the one-child case is right; with none it falls through to
`directChildren(container)`, a raw child-list snapshot, and
`AdwPreferencesPage` has no setter slot, so its internal `GtkScrolledWindow` is
counted as application content. The other half is what the index MEANS:
`AdwPreferencesPage` is one of the few Adwaita containers that really has
`insert`, and its `position` addresses the page's GROUPS.

Also recorded is why the fix is a curated descriptor field and not a derived
one: nothing introspectable says which containers re-parent into an internal,
because that child comes from a `.ui` template — and deriving it by adding a
probe child and reading `get_parent()` back would mutate the container being
adopted, which belongs to the application. That needs its own measurement round
over the 26 curated containers, so it stays open with its shape written down.
