### PR TITLE
test(e2e): wait for the release before installing

### DIFF
--- a/tests/e2e/create-app/run.mjs
+++ b/tests/e2e/create-app/run.mjs
@@ -24,6 +24,7 @@ import {
     npmInstallWithRetry,
     spawnUntilReady,
     hasCommand,
+    awaitRegistryResolvable,
 } from '../helpers.mjs';
 // Imported, not re-spelled: a second copy of the globals vocabulary is the one that drifts.
 import { GJS_GLOBALS_GROUPS, GJS_GLOBALS_MAP } from '../../../packages/infra/resolve-npm/lib/globals-map.mjs';
@@ -41,6 +42,8 @@ const TEMPLATES = [
 ];
 
 const TEMPLATES_DIR = join(MONOREPO_ROOT, 'templates');
+/** What the scaffolder actually copies — `file:` edges already resolved to ranges. */
+const DIST_TEMPLATES_DIR = join(MONOREPO_ROOT, 'packages', 'infra', 'create-gjsify', 'dist-templates');
 
 /**
  * The registers an EXPLICIT `--globals` list injects, mirroring `resolveGlobalsList`. `auto`
@@ -267,6 +270,45 @@ function declaredArtifacts(projectDir) {
 }
 
 /**
+ * Every `@gjsify/*` range a scaffolded project will really ask the REGISTRY for.
+ *
+ * Two subtleties, and getting either wrong makes this wait for the wrong thing.
+ *
+ * The manifests are read off `dist-templates/` and not `templates/`, because that
+ * is the artifact the scaffolder copies: in `templates/` the same edge is still a
+ * checkout-relative `file:`/`workspace:` specifier that `process-template.mjs` has
+ * not yet resolved into a range.
+ *
+ * And a range there does NOT mean a registry install. `patchPackageJson` remaps
+ * every WORKSPACE member to a locally packed tarball, so `toFileRef` is the
+ * discriminator — the same call that does the remapping, asked here rather than a
+ * second hand-kept list of which packages are workspace members. MEASURED: reading
+ * `dist-templates` alone reports ELEVEN ranges, ten of which are answered by a
+ * tarball and would have made this wait on publishes the suite never touches.
+ * What is left is the deliberate exception — `@gjsify/node-gi` is not a workspace
+ * member (own CI, native addon) and four templates declare it.
+ */
+function registryGjsifyRanges(tarballsDir, tarballMap) {
+    const seen = new Map();
+    for (const template of TEMPLATES) {
+        const manifest = join(DIST_TEMPLATES_DIR, template, 'package.json');
+        if (!existsSync(manifest)) continue;
+        const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+        for (const field of ['dependencies', 'devDependencies']) {
+            for (const [name, spec] of Object.entries(pkg[field] ?? {})) {
+                if (!name.startsWith('@gjsify/') || typeof spec !== 'string') continue;
+                // A path, link, tarball or git edge needs no registry at all…
+                if (/^(?:file:|link:|https?:|git|portal:|\.|\/)/.test(spec)) continue;
+                // …and neither does one this suite is about to replace with a tarball.
+                if (toFileRef(name, tarballsDir, tarballMap)) continue;
+                seen.set(`${name}@${spec}`, [name, spec]);
+            }
+        }
+    }
+    return [...seen.values()];
+}
+
+/**
  * Patch the scaffolded package.json:
  * - Drop @girs/* (types-only; gi:// imports are externalized by esbuild).
  * - Remap @gjsify/* deps/devDeps to local tarballs.
@@ -460,6 +502,12 @@ describe('create-app E2E', { timeout: 60 * 60 * 1000 }, () => {
         tmpDir = env.tmpDir;
         tarballsDir = env.tarballsDir;
         tarballMap = env.tarballMap;
+
+        // AFTER the environment, because the tarball map is what decides which ranges
+        // are really registry-bound — and in the OUTER hook, because each template
+        // describe has its own 15-minute budget that a wait inside one would eat,
+        // while this describe has an hour. One wait covers every template.
+        awaitRegistryResolvable(registryGjsifyRanges(tarballsDir, tarballMap), { label: 'create-app' });
     });
 
     after(() => {

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -125,6 +125,88 @@ function isTransientInstallError(err) {
 }
 
 /**
+ * Block until the registry can resolve every `[name, range]` pair, or fail naming
+ * what never arrived.
+ *
+ * WHY THIS EXISTS, measured on v0.43.0. A release cut pushes `chore: release
+ * vX.Y.Z` to `main`, which starts `main.yml`, while the tag's `release: published`
+ * event starts `release.yml` — CONCURRENTLY. The bumper has already written the new
+ * version into every manifest, and `process-template.mjs` turns a template's
+ * `file:` edge on a non-workspace package into `^<that version>`. So this suite
+ * scaffolds a project asking the public registry for a version that `release.yml`
+ * has not published yet, and `npm install` dies with
+ * `ETARGET No matching version found for @gjsify/node-gi@^0.43.0`.
+ *
+ * The outcome was a coin toss rather than a bug: v0.43.0 red, v0.42.0 cancelled,
+ * v0.41.0 cancelled then green, v0.40.0 green. That is the worst shape a gate can
+ * have — a red that means nothing teaches everyone to ignore red on release
+ * commits.
+ *
+ * Waiting is the fix rather than pointing the dependency at a local tarball,
+ * because installing from the registry is exactly what this suite exists to prove:
+ * a user runs `npm create @gjsify/app` against npm, and making the install
+ * hermetic would delete the only coverage of the path that actually broke. The
+ * wait also turns the race into real coverage of the release — if the publish never
+ * lands, the deadline says so by name.
+ *
+ * On an ordinary commit every range resolves on the first probe, because the
+ * checkout's version is the last released one.
+ */
+export function awaitRegistryResolvable(
+    pending,
+    { label = 'e2e', deadlineMs = 30 * 60 * 1000, intervalMs = 20 * 1000 } = {},
+) {
+    const outstanding = pending.filter(([name, range]) => !registryResolves(name, range));
+    if (outstanding.length === 0) return;
+
+    const deadline = Date.now() + deadlineMs;
+    const budget =
+        deadlineMs >= 60_000 ? `${Math.round(deadlineMs / 60_000)} min` : `${Math.round(deadlineMs / 1000)} s`;
+    console.log(
+        `  [${label}] waiting for the registry to carry ${outstanding
+            .map(([n, r]) => `${n}@${r}`)
+            .join(', ')} (up to ${budget})…`,
+    );
+    for (let left = outstanding; left.length > 0;) {
+        if (Date.now() >= deadline) {
+            throw new Error(
+                `awaitRegistryResolvable: the registry still cannot resolve ` +
+                    `${left.map(([n, r]) => `${n}@${r}`).join(', ')} after ` +
+                    `${budget}. On a release commit that means the publish ` +
+                    `did not land; otherwise the range is wrong.`,
+            );
+        }
+        sleepSync(intervalMs);
+        left = left.filter(([name, range]) => !registryResolves(name, range));
+        if (left.length > 0)
+            console.log(`  [${label}] still waiting for ${left.map(([n, r]) => `${n}@${r}`).join(', ')}…`);
+    }
+    console.log(`  [${label}] the registry carries every range now.`);
+}
+
+/**
+ * Ask NPM ITSELF whether a range resolves — never a hand-rolled semver compare.
+ * `npm install` is the consumer, so `npm view` is the one resolver whose answer
+ * cannot disagree with it.
+ */
+function registryResolves(name, range) {
+    try {
+        const out = execFileSync('npm', ['view', `${name}@${range}`, 'version', '--json'], {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            encoding: 'utf8',
+            timeout: 60 * 1000,
+        });
+        const text = out.trim();
+        return text.length > 0 && text !== '[]';
+    } catch {
+        // `npm view` exits non-zero for "no matching version" (E404/ETARGET) and for a
+        // network hiccup alike, and here both mean the same thing: not resolvable yet,
+        // ask again. A permanent failure is what the deadline above is for.
+        return false;
+    }
+}
+
+/**
  * Run `npm install` in `projectDir`, retrying on transient failures. E2E templates pull
  * heavy `@girs/*` tarballs from the public registry in parallel and the registry
  * intermittently 404s a tarball that genuinely exists (observed: Fedora 43 passes while


### PR DESCRIPTION
`main` was red on the v0.43.0 release commit, and the failure was not a code
defect. It is a race in the release procedure, and its outcome is a coin toss:

| release commit | `main.yml` |
|---|---|
| v0.43.0 | **failure** |
| v0.42.0 | cancelled |
| v0.41.0 | cancelled, then success |
| v0.40.0 | success |

## The mechanism

A cut pushes `chore: release vX.Y.Z` to `main`, which starts `main.yml`, while
the tag's `release: published` event starts `release.yml` — concurrently. By then
`@release-it/bumper` has written the new version into every manifest, and
`process-template.mjs` turns a template's `file:` edge on a NON-workspace package
into `^<that version>`. So `tests/e2e/create-app` scaffolds a project that asks
the public registry for a version `release.yml` has not published yet:

    ETARGET No matching version found for @gjsify/node-gi@^0.43.0

`@gjsify/node-gi@0.43.0` is on npm now, and a re-run of that exact workflow went
green — which is the whole problem. **A red that means nothing teaches everyone
to ignore red on release commits**, which is the one place a release actually
needs watching.

## The fix

`awaitRegistryResolvable` blocks until every registry-bound range resolves, then
installs. It asks `npm view`, so the resolver is the same one `npm install` will
use and the two cannot disagree — no hand-rolled semver comparison. On an
ordinary commit every range resolves on the first probe, because the checkout's
version is the last released one.

**Waiting rather than pointing the dependency at a local tarball.** Installing
FROM THE REGISTRY is what this suite exists to prove: a user runs
`npm create @gjsify/app` against npm. Making the install hermetic would delete
the only coverage of the path that actually broke. The wait also turns the race
into real coverage of the release — if a publish never lands, the deadline fails
naming the package and version.

## What the collector has to get right

Two subtleties, and I got the second one wrong on the first pass:

- The manifests are read off `dist-templates/`, the artifact the scaffolder
  copies, because in `templates/` the same edge is still an unresolved
  `file:`/`workspace:` specifier.
- **A range there does not mean a registry install.** `patchPackageJson` remaps
  every workspace member to a locally packed tarball, so `toFileRef` is the
  discriminator — the same call that does the remapping, asked here rather than
  restated as a second hand-kept list of which packages are workspace members.
  Measured: reading `dist-templates` alone reports **eleven** ranges, ten of
  which a tarball answers, and waiting on those would have coupled this suite to
  publishes it never touches. Exactly **one** is registry-bound —
  `@gjsify/node-gi`, deliberately not a workspace member (own CI, native addon),
  declared by four templates.

The wait sits in the OUTER `before` hook and after the environment is created:
each template `describe` carries its own 15-minute budget that a wait inside one
would eat, while that `describe` has an hour, and one wait covers every template
because they all declare the same edge.

## Measured, both directions

    existing range   → returns in 951 ms (one npm view call)
    unresolvable     → waits, logs, throws naming @gjsify/node-gi@^99.0.0

`gjsify lint` and `gjsify format` clean.
