### PR TITLE
docs(adr): accept 0030, amend the 0027 quadruplet

### DIFF
--- a/docs/adr/0027-gtk-host-layer.md
+++ b/docs/adr/0027-gtk-host-layer.md
@@ -3,7 +3,7 @@
 - Status: **Accepted**
 - Date: 2026-08-22
 - Deciders: Pascal Garber
-- Related: [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0009 (native Adwaita app shell)](0009-native-adwaita-app-shell.md), [ADR 0003 (package tiering)](0003-package-tiering.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md)
+- Related: [ADR 0004 (headless Adwaita core)](0004-headless-adwaita-core.md), [ADR 0009 (native Adwaita app shell)](0009-native-adwaita-app-shell.md), [ADR 0003 (package tiering)](0003-package-tiering.md), [ADR 0028 (widget table provenance)](0028-widget-table-provenance.md), [ADR 0030 (one corpus, GJS as oracle)](0030-one-corpus-gjs-as-oracle.md)
 
 ## Context
 
@@ -63,7 +63,33 @@ Two further GTK facts shaped the contract, both measured on gjs 1.88.1:
 ## Decision
 
 gjsify owns a framework-agnostic GTK4/Adwaita host as a Tier-3 package,
-`@gjsify/gtk-host` (`{gjs: polyfill, node: none, browser: none, nativescript: none}`).
+`@gjsify/gtk-host` (`{gjs: polyfill, node: polyfill, browser: none, nativescript: none}`).
+
+**`node` was `none` in the first revision of this ADR, and that is amended rather
+than quietly corrected.** The host's own source reaches nothing but `gi://`, which
+the `--app node` target routes to `@gjsify/node-gi` — measured, a host showcase
+builds for that target with no warnings and the bundle carries
+`import "@gjsify/node-gi/globals"` and `@gjsify/node-gi/system`, so even the three
+GJS-only spellings left in the probe layer (`system`, `print`, `printerr`) are
+seeded rather than missing. What pinned the host to GJS was this declaration and a
+`test:gjs`-only script, not its code.
+
+`browser` and `nativescript` stay `none`, and that is not the same kind of claim:
+on those two targets `gi://` is substituted with `{}`, so a wrong declaration
+there fails SILENTLY — which is why the reachability check treats them as fatal
+and `node` only as a warning.
+
+The reason this matters most is not portability for its own sake. **There is no
+GJS host on Windows**, so `test:gjs` cannot run there at all; node-gi is the only
+way this host runs on win32. The enabling defect was in node-gi rather than here —
+a class-struct static (`Klass.list_properties()`) was unreachable, and
+`paramSpecs()` needs it on every element-creation path — and it is fixed at the
+core. Which suite a claim about that belongs in is settled by
+[ADR 0030](0030-one-corpus-gjs-as-oracle.md).
+
+This is a DECISION and not yet a description of the manifest: the slot flips in the
+same change that gives it a test leg, because a declared runtime with no suite
+behind it is exactly the defect ADR 0030 § Decision 6 names.
 
 1. **A shadow node tree.** `parent`/`first`/`next` are the host's own links, never
    `Gtk.Widget.get_parent()`/`get_first_child()`. Text nodes and anchors own no

--- a/docs/adr/0030-one-corpus-gjs-as-oracle.md
+++ b/docs/adr/0030-one-corpus-gjs-as-oracle.md
@@ -1,6 +1,6 @@
 # 30. One test corpus per claim, parameterised by runtime; GJS is the oracle
 
-- Status: **Proposed**
+- Status: **Accepted**
 - Date: 2026-08-25
 - Deciders: Pascal Garber
 - Related: [ADR 0027 (GTK host layer)](0027-gtk-host-layer.md), [ADR 0005 (node-gi scope)](0005-node-gi-scope.md), [ADR 0011 (N-API host in GJS)](0011-napi-host-in-gjs.md), [ADR 0018 (OS axis declaration)](0018-os-axis-declaration.md), [ADR 0008 (release versioning policy)](0008-release-versioning-policy.md)
@@ -166,9 +166,25 @@ columns are meant to close, not to stay printed.
 
 Not scheduled as one change. The order that follows from the risk in § Decision 4:
 
-1. gtk-host's declaration and test path — the smallest step with the largest
-   claim, because its code is already portable and only the manifest and the
-   script say otherwise.
+1. gtk-host's declaration and test path. Its code is already portable, so this
+   looks like a manifest edit and a new script — and it is not, because of one
+   thing measured while scoping it.
+
+   **Every gtk-host suite is gated on `on('Gjs', …)`, an interpreter IDENTITY, and
+   therefore stands down under Node.** Built for the node target and run, the suite
+   exits **0** having executed **0 tests from 0 gates, 9 stood down**. That is the
+   green-that-checked-nothing shape, produced by the very step meant to add
+   coverage — and it would have shipped as a passing CI leg.
+
+   `@gjsify/unit` already has the concept and its own reason for it: `Runtime` is
+   documented as "a runtime IDENTITY, or a host CAPABILITY", and `'Display'` and
+   `'Gl'` were split apart because "a gate must state the thing it actually
+   requires". These suites require a reachable GTK, not a particular interpreter.
+   So step 1 is: a `'Gtk'` capability beside those two, the suites gated on it, and
+   the node entry declaring `requireAxes: ['Gtk']` — the existing mechanism that
+   turns a stood-down run into a failure instead of a pass. The manifest flip and
+   the drift-check tolerance ride along, because a declaration without a suite is
+   what § Decision 6 refuses.
 2. The showcase columns, since the showcases already self-verify on every launch
    through `runHostProbeApp` and a `--app node` build already succeeds.
 3. node-gi's oracle-able tests, migrated in themed groups, highest binding risk

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,7 +50,7 @@ the TODO records the *what's left*.
 | [0027](0027-gtk-host-layer.md) | One GTK host layer, framework adapters on top | Accepted |
 | [0028](0028-widget-table-provenance.md) | GIR-generated widget table, runtime ParamSpec for values | Accepted |
 | [0029](0029-girs-widget-vocabulary.md) | The widget vocabulary ships from `@girs/*` under a `surface` subpath, with no JSX namespace | Proposed |
-| [0030](0030-one-corpus-gjs-as-oracle.md) | One test corpus per claim, parameterised by runtime; GJS is the oracle | Proposed |
+| [0030](0030-one-corpus-gjs-as-oracle.md) | One test corpus per claim, parameterised by runtime; GJS is the oracle | Accepted |
 
 Source review: [docs/reports/2026-07-01-architecture-review.md](../reports/2026-07-01-architecture-review.md)
 (condensed findings + prioritized backlog).


### PR DESCRIPTION
ADR 0030 moves to **Accepted**, and ADR 0027's Decision section — which writes the
old runtime quadruplet down verbatim — is amended so the two do not contradict.

## The rule, in one line

Whoever determines the expected value determines the harness. What **we design**
(an error code, a placement policy) is tested with `expect()` on every runtime the
package declares. What **GJS defines** (how a `GValue` marshals, what
`registerClass` installs) is tested against a golden whose content IS gjs's own
output.

Two green legs are not a comparison: `expect(x).toBe(y)` puts the expected value
inside the test, so two runtimes agreeing on the same wrong value pass twice, and
the suite reports agreement as correctness. A golden made of gjs's actual output
catches that, and catches drift in gjs itself.

## ADR 0027's quadruplet

`node` moves from `none` to `polyfill`. The host's own source reaches nothing but
`gi://`, which the `--app node` target routes to `@gjsify/node-gi` — measured, a
host showcase builds for that target with no warnings and the bundle carries
`@gjsify/node-gi/globals` and `@gjsify/node-gi/system`, so even the three GJS-only
spellings left in the probe layer are seeded rather than missing.

`browser` and `nativescript` stay `none` for a reason worth stating separately: on
those targets `gi://` is substituted with `{}`, so a wrong declaration there fails
**silently**. That asymmetry is why the reachability pass treats them as fatal and
`node` only as a warning.

Why it matters most is not portability for its own sake. **There is no GJS host on
Windows**, so `test:gjs` cannot run there at all — node-gi is the only way this
host runs on win32.

This is a DECISION, not a description of the manifest. The slot flips in the change
that gives it a test leg, because a declared runtime with no suite behind it is
exactly the defect ADR 0030 § Decision 6 names. Hence this PR touches no manifest.

## What scoping step 1 measured, and why it is in the ADR

Step 1 looked like a manifest edit plus a script. It is not.

**Every gtk-host suite is gated on `on('Gjs', …)` — an interpreter IDENTITY — so it
stands down under Node.** Built for the node target and run:

    Running on Node.js 24.19.0
    ✔ 9 ignored tests
    ↳ Gjs: 0 tests from 0 gates, 9 stood down
    ✔ [Node.js 24.19.0] 0 completed

Exit 0, zero tests. The step meant to ADD coverage would have shipped as a green CI
leg that checked nothing — which is the exact failure class ADR 0030 exists to
close, produced by ADR 0030's own first step.

`@gjsify/unit` already carries both the concept and the argument for it. `Runtime`
is documented as *"a runtime IDENTITY, or a host CAPABILITY"*, and `'Display'` and
`'Gl'` were deliberately split apart because *"a gate must state the thing it
actually requires"*. These suites require a reachable GTK, not a particular
interpreter.

So step 1 is: a `'Gtk'` capability beside those two, the suites gated on it, and the
node entry declaring `requireAxes: ['Gtk']` — the existing mechanism that turns a
stood-down run into a failure instead of a pass. The manifest flip and a narrow
drift-check tolerance ride along in that change, since neither is honest without
the other.

The tolerance is already written and A/B'd against the flipped manifest (with it,
`audit-runtimes --check --strict` exits 0; without it, exit 1 naming
`@gjsify/gtk-host`), and it is deliberately held back to that PR rather than landed
here as guard code nothing exercises.
