### PR TITLE
fix(unit): a suite body that throws must fail

### DIFF
--- a/packages/gjs/unit/src/exit-code.spec.ts
+++ b/packages/gjs/unit/src/exit-code.spec.ts
@@ -1,0 +1,38 @@
+// Coverage for the rule that decides the process exit code.
+//
+// The regression it guards is measured rather than imagined: a throw out of a
+// suite BODY (an `expect()` in a `describe` callback, a failing import) rejected
+// `run()`'s promise chain, which had no `catch`. Both terminal steps were skipped,
+// so nothing printed and `process.exit` never ran — and Node, with nothing left
+// pending, exited **0** with the log cut off mid-suite. Every later suite was
+// silently dropped and CI read the run as a pass.
+//
+// gtk-host found it: its `buildable.spec.ts` asserts directly in a `describe` body,
+// that assertion holds on GJS and fails under `@gjsify/node-gi`, and the node leg
+// reported SUCCESS having run one suite out of nine.
+//
+// The tally alone cannot answer this, and that is the point of the second argument:
+// a suite body that threw says nothing about the tests that never started, so it
+// must not be counted as a test failure — but it must still fail the process.
+import { describe, expect, exitCodeFor, it } from '@gjsify/unit';
+
+export default async () => {
+    await describe('exit code', async () => {
+        await it('passes when nothing failed and no suite body threw', async () => {
+            expect(exitCodeFor(0, false)).toBe(0);
+        });
+
+        await it('fails on a counted test failure', async () => {
+            expect(exitCodeFor(3, false)).toBe(1);
+        });
+
+        await it('fails when a suite body threw, even with a clean tally', async () => {
+            // THE regression. Before the fix this answered 0.
+            expect(exitCodeFor(0, true)).toBe(1);
+        });
+
+        await it('fails on both at once without double-deciding', async () => {
+            expect(exitCodeFor(2, true)).toBe(1);
+        });
+    });
+};

--- a/packages/gjs/unit/src/index.ts
+++ b/packages/gjs/unit/src/index.ts
@@ -72,6 +72,15 @@ const mainloop: GLib.MainLoop | undefined =
 let countTestsOverall = 0;
 let countTestsFailed = 0;
 let countTestsIgnored = 0;
+/**
+ * Did a throw escape a suite BODY (rather than an `it()`)?
+ *
+ * Deliberately not part of `countTestsFailed`: the tally counts tests that RAN, and
+ * a suite body that threw says nothing about the suites that never started. But the
+ * process must still fail, and the summary must not read green — see the `.catch` in
+ * `run` for the incident.
+ */
+let suiteBodyThrew = false;
 /** Tests marked `it.failing` that failed as expected (see `it.failing`). */
 let countTestsXfail = 0;
 
@@ -1471,6 +1480,16 @@ const failUnexercisedAxes = async (declared: readonly Runtime[]): Promise<void> 
     }
 };
 
+/**
+ * The process exit code, as a pure function of the two things that decide it.
+ *
+ * Extracted for the same reason `formatFailureRecap` is: the two exit sites read
+ * module state and call `process.exit`, neither of which a spec can reach — and this
+ * rule is exactly where the regression lived. `bodyThrew` with a zero tally used to
+ * answer 0, so a run that dropped eight of nine suites reported success.
+ */
+export const exitCodeFor = (failed: number, bodyThrew: boolean): number => (failed > 0 || bodyThrew ? 1 : 0);
+
 const printResult = () => {
     const totalMs = runStartTime > 0 ? now() - runStartTime : 0;
     const durationStr = totalMs > 0 ? `  ${GRAY}(${formatDuration(totalMs)})` : '';
@@ -1529,6 +1548,15 @@ const printResult = () => {
     if (countTestsFailed) {
         printFailureRecap(rtTag);
         print(`\n${RED}❌ ${rtTag}${countTestsFailed} of ${countTestsOverall} tests failed${durationStr}${RESET}`);
+    } else if (suiteBodyThrew) {
+        // Every test that ran passed, and the run is still not a pass: a suite body
+        // threw, so later suites never started. Printing the green line here — with
+        // the process about to exit 1 — is the mixed signal a reader resolves in
+        // favour of the colour.
+        print(
+            `\n${RED}❌ ${rtTag}${countTestsOverall} test${countTestsOverall === 1 ? '' : 's'} passed, ` +
+                `then a suite body threw — the run is INCOMPLETE${durationStr}${RESET}`,
+        );
     } else {
         print(`\n${GREEN}✔ ${rtTag}${countTestsOverall} completed${durationStr}${RESET}`);
     }
@@ -1681,6 +1709,7 @@ export const run = async (namespaces: Namespaces, options?: RunOptions | number)
     axisLedger.clear();
     cwdReadable = probeCwd();
 
+    suiteBodyThrew = false;
     let requireAxes: readonly Runtime[] = [];
     if (options) {
         if (typeof options === 'number') {
@@ -1712,6 +1741,45 @@ export const run = async (namespaces: Namespaces, options?: RunOptions | number)
             }
         })
         .then(() => failUnexercisedAxes(requireAxes))
+        .catch((error: unknown) => {
+            // A throw that ESCAPED a suite body rather than an `it()` — an `expect()`
+            // called directly in a `describe` callback, a failing top-level import, a
+            // gate that threw. `describe` rethrows anything that is not a
+            // `TimeoutError`, deliberately, and until this `catch` existed that
+            // rejection simply broke the chain: the `.then` below was skipped, so
+            // `printResult()` never printed AND `process.exit(exitCode)` never ran —
+            // and Node, with nothing left pending, exited **0** with the log cut off
+            // mid-suite. Every remaining suite was silently dropped and CI read the
+            // run as a pass.
+            //
+            // MEASURED, and it is why this was found at all: gtk-host's
+            // `buildable.spec.ts` asserts directly in a `describe` body, that
+            // assertion holds on GJS and fails under node-gi (`vfunc_add_child` is
+            // `undefined` there), and the node leg reported SUCCESS having run one
+            // suite out of nine. Reproduced with no GTK involved: a two-describe
+            // fixture whose first body throws prints the first `it`, drops the second
+            // describe entirely, and exits 0.
+            //
+            // This branch deliberately touches NEITHER `countTestsFailed` NOR
+            // `testErrors`, and that is the second thing measured. An escaped
+            // ASSERTION is already owned by the assertion ledger, which drains it as
+            // a stray failure — counting it again here reported "2 of 2 tests failed"
+            // for one `expect()`. And the brand on a matcher error cannot be used to
+            // tell the two apart: it means "produced by our matchers", explicitly not
+            // "already counted". Pushing an entry without raising the tally is no
+            // better, because the recap's own consistency check reads that as a
+            // failure path hiding itself.
+            //
+            // So the ledger keeps the tally and this branch owns exactly one thing:
+            // the run must not be able to end at 0. The printed line sits directly
+            // above the recap, which is where a CI reader is already looking.
+            suiteBodyThrew = true;
+            const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+            print(
+                `\n${RED}❌ a suite body threw, so the run is INCOMPLETE and every later suite was skipped` +
+                    `${currentSuite ? ` (in "${currentSuite}")` : ''} — ${message}${RESET}`,
+            );
+        })
         .then(async () => {
             printResult();
             browserSignalDone();
@@ -1723,7 +1791,7 @@ export const run = async (namespaces: Namespaces, options?: RunOptions | number)
             // Node.js exits here: without a mainloop, the code after `mainloop?.run()`
             // below would already have run before any test did.
             if (!mainloop) {
-                const exitCode = countTestsFailed > 0 ? 1 : 0;
+                const exitCode = exitCodeFor(countTestsFailed, suiteBodyThrew);
                 try {
                     const process = globalThis.process || (await import('node:process'));
                     process.exit(exitCode);
@@ -1739,7 +1807,7 @@ export const run = async (namespaces: Namespaces, options?: RunOptions | number)
     // GJS exits only after the mainloop returns — `system.exit()` from inside a
     // mainloop callback does not terminate immediately.
     if (mainloop) {
-        const exitCode = countTestsFailed > 0 ? 1 : 0;
+        const exitCode = exitCodeFor(countTestsFailed, suiteBodyThrew);
         // Real-GJS-only path (see the `mainloop` gate above), where `imports.system`
         // is a native builtin that always resolves and `exit()` never throws.
         runtimeGlobals().imports?.system?.exit(exitCode);

--- a/packages/gjs/unit/src/test.mts
+++ b/packages/gjs/unit/src/test.mts
@@ -7,6 +7,7 @@ import callbackAssertionSuite from './callback-assertion.spec.js';
 import capabilitiesSuite from './capabilities.spec.js';
 import axisLedgerSuite from './axis-ledger.spec.js';
 import failureRecapSuite from './failure-recap.spec.js';
+import exitCodeSuite from './exit-code.spec.js';
 
 run(
     {
@@ -18,6 +19,7 @@ run(
         capabilitiesSuite,
         axisLedgerSuite,
         failureRecapSuite,
+        exitCodeSuite,
     },
     {
         // The runner's own legs are the one place this must hold end-to-end: every


### PR DESCRIPTION
A throw that escapes a suite **body** rather than an `it()` — an `expect()` called
directly in a `describe` callback, a failing top-level import, a gate that threw —
silently ended the whole run at **exit 0**.

## The mechanism

`describe` rethrows anything that is not a `TimeoutError`, deliberately. `run()`'s
promise chain had no `catch`, so that rejection skipped **both** terminal steps:
`printResult()` never printed and `process.exit(exitCode)` never ran. Node, with
nothing left pending, then exited 0 with the log cut off mid-suite — every later
suite silently dropped and reported as a pass. The `unhandledRejection` hook did
record a stray failure, into a ledger whose only reporter sat on the skipped branch.

## How it surfaced

`@gjsify/gtk-host` asserts directly in a `describe` body in `buildable.spec.ts`.
That assertion holds on GJS and fails under `@gjsify/node-gi`, and the package's
node leg reported **SUCCESS having run one suite out of nine**.

Reproduced with no GTK involved — a two-describe fixture whose first body throws:

    a describe whose BODY throws
      ✔ this one runs first
    (exit 0, second describe never ran, nothing printed)

## What the fix does, and the two things it deliberately does not

The `catch` touches neither `countTestsFailed` nor `testErrors`, and both halves of
that were measured rather than assumed:

- An escaped **assertion** is already owned by the assertion ledger, which drains it
  as a stray failure. Counting it again reported `2 of 2 tests failed` for one
  `expect()`.
- The brand on a matcher error cannot separate the two cases: it means "produced by
  our matchers", and its own doc says explicitly that it does **not** mean "already
  counted".
- Pushing an entry without raising the tally is no better — `formatFailureRecap`'s
  consistency check reads that as a failure path hiding itself.

So the ledger keeps the tally and this branch owns exactly one thing: **the run
cannot end at 0.** That needs a module-level flag, because two places read it — the
exit code, and the summary line, which otherwise printed a green `✔ N completed`
beside a process exiting 1.

## Now, both escape kinds

    assertion in a describe BODY  → exit 1, "1 of 2 tests failed", one recap entry
    plain throw in a describe BODY → exit 1, "1 test passed, then a suite body threw
                                      — the run is INCOMPLETE"

## Testability

`exitCodeFor(failed, bodyThrew)` is extracted for the reason `formatFailureRecap`
was: the two exit sites read module state and call `process.exit`, neither of which
a spec can reach — and this rule is exactly where the regression lived.
`exit-code.spec.ts` pins all four combinations, including `(0, true)`, which used to
answer 0.

Own suite: **319 tests on Node, 317 on GJS**, both green.

## Not in this PR

A throwing suite body still aborts the remaining suites — the run is now correctly
reported as INCOMPLETE rather than as a pass, but it stops. Making `describe` record
and continue would let sibling suites run, which is a larger change to this
package's contract and wants its own round.
