### PR TITLE
feat(gtk-host): run the suite on Node too

### DIFF
--- a/packages/framework/gtk-host/package.json
+++ b/packages/framework/gtk-host/package.json
@@ -63,9 +63,11 @@
         "build:gjsify": "gjsify build --library 'src/**/*.{ts,js}' --exclude 'src/**/*.spec.{mts,ts}' 'src/test.{mts,ts}'",
         "build:types": "gjsify tsc",
         "build:test": "gjsify run build:test:gjs",
+        "build:test:node": "gjsify build src/test.mts --app node --outfile dist/test.node.mjs --define '__VUE_OPTIONS_API__=false' --define '__VUE_PROD_DEVTOOLS__=false' --define '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__=false' --define 'process.env.NODE_ENV=\"production\"' --exclude-globals navigator",
         "build:test:gjs": "gjsify build src/test.mts --app gjs --outfile test.gjs.mjs --define '__VUE_OPTIONS_API__=false' --define '__VUE_PROD_DEVTOOLS__=false' --define '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__=false' --define 'process.env.NODE_ENV=\"production\"' --exclude-globals navigator",
         "test": "gjsify run build:gjsify && gjsify run build:test && gjsify run test:gjs",
         "test:gjs": "gjsify run test.gjs.mjs",
+        "test:gjs-on-node": "gjsify run build:gjsify && gjsify run build:test:node && NODE_GI_NATIVE=${NODE_GI_NATIVE:-prebuild} node dist/test.node.mjs",
         "generate": "gjsify build src/generator/main.mts --app gjs --outfile tmp/generate.gjs.mjs && gjsify run tmp/generate.gjs.mjs -- --out src/generated && gjsify format src/generated"
     },
     "keywords": [
@@ -113,6 +115,7 @@
         "@types/node": "^25.9.2",
         "typescript": "^6.0.3",
         "@gjsify/domparser": "workspace:^",
+        "@gjsify/node-gi": "file:../../node-gi/node-gi",
         "vue": "^3.5.41",
         "vue-tsc": "^3.3.11",
         "react": "^18.3.1",
@@ -123,7 +126,7 @@
     "gjsify": {
         "runtimes": {
             "gjs": "polyfill",
-            "node": "none",
+            "node": "polyfill",
             "browser": "none",
             "nativescript": "none"
         },

--- a/packages/framework/gtk-host/src/adapters/react.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/react.spec.ts
@@ -31,7 +31,7 @@ import { createElement, useState, type ReactNode } from 'react';
 
 import { gtkChildTypes, gtkChildren, installDiagnosticsGate } from '../conformance/index.js';
 import { runAdapterVectors, type VectorHarness, type VectorNode } from '../conformance/vectors.mjs';
-import { gated } from '../testing/gate.mjs';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
 import { firstChild } from '../host.js';
 import type { HostElement, HostNode, HostText } from '../types.js';
@@ -238,7 +238,7 @@ function readHostConfigMembers(): string[] {
 }
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
         const diagnostics = installDiagnosticsGate();

--- a/packages/framework/gtk-host/src/adapters/solid.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.spec.ts
@@ -15,7 +15,7 @@ import { createRenderer } from 'solid-js/universal';
 
 import { installDiagnosticsGate, gtkChildren, gtkChildTypes } from '../conformance/index.js';
 import { runAdapterVectors, type VectorElement, type VectorHarness, type VectorNode } from '../conformance/vectors.mjs';
-import { gated } from '../testing/gate.mjs';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
 import * as adapter from './solid.js';
 import { Dynamic, For, createComponent, createElement, effect, insert, insertNode, mount, setProp } from './solid.js';
@@ -78,7 +78,7 @@ const solidVectors: VectorHarness = {
 };
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
         const diagnostics = installDiagnosticsGate();

--- a/packages/framework/gtk-host/src/adapters/vue.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/vue.spec.ts
@@ -25,7 +25,7 @@ import {
 
 import { gtkChildTypes, gtkChildren, installDiagnosticsGate } from '../conformance/index.js';
 import { runAdapterVectors, type VectorElement, type VectorHarness, type VectorNode } from '../conformance/vectors.mjs';
-import { gated } from '../testing/gate.mjs';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
 import type { GtkHostError } from '../index.js';
 import { mount } from './vue.js';
@@ -66,7 +66,7 @@ const vueVectors: VectorHarness = {
 };
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
         const diagnostics = installDiagnosticsGate();

--- a/packages/framework/gtk-host/src/buildable.spec.ts
+++ b/packages/framework/gtk-host/src/buildable.spec.ts
@@ -20,21 +20,29 @@
 
 import Adw from 'gi://Adw?version=1';
 import Gtk from 'gi://Gtk?version=4.0';
-import { describe, expect, on } from '@gjsify/unit';
+import { expect, it, on } from '@gjsify/unit';
 
 import { installDiagnosticsGate } from './conformance/index.js';
-import { gated } from './testing/gate.mjs';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
 
 export default async () => {
     // GJS only, and `Gtk.init()` before any widget: these rows construct real
     // containers, and an uninitialised GTK aborts the process rather than throwing.
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
-        await describe('Gtk.Buildable — what the generic adder really does', async () => {
-            // Every row asserts against real widgets, so a GTK critical raised by one
-            // of them has to fail its own row rather than the next one.
-            const diagnostics = installDiagnosticsGate();
-            await gated(diagnostics, 'the vfunc form is callable, which the docs used to deny', async () => {
+        // Every row asserts against real widgets, so a GTK critical raised by one of
+        // them has to fail its own row rather than the next one — which is what the
+        // per-`it` hooks `gated` registers do.
+        //
+        // The rows are `it()`s and not nested `gated()` describes, and that is a fix
+        // rather than a style change. An assertion in a describe BODY is not a test:
+        // it is outside the tally, cannot be skipped, and on failure it aborts the
+        // ENTIRE run — `describe` rethrows, and every later suite is dropped. Measured
+        // here: under `@gjsify/node-gi` the first row's `vfunc_add_child` expectation
+        // fails, and this package's node leg stopped after one suite of nine.
+        const diagnostics = installDiagnosticsGate();
+        await gated(diagnostics, 'Gtk.Buildable — what the generic adder really does', async () => {
+            await it('the vfunc form is callable, which the docs used to deny', async () => {
                 // The introspection fact everyone quotes: the plain name is absent — and
                 // `@girs/*` does not declare it either, which is the same fact seen from the
                 // type side, hence the cast rather than a property access.
@@ -45,7 +53,7 @@ export default async () => {
                 expect(typeof new Gtk.Box().vfunc_add_child).toBe('function');
             });
 
-            await gated(diagnostics, 'and it places correctly, including the slotted containers', async () => {
+            await it('and it places correctly, including the slotted containers', async () => {
                 // If this row ever fails, the paragraph above is wrong again and the
                 // curated slot tables in `descriptors/adw.ts` are the only route left.
                 const builder = Gtk.Builder.new();
@@ -66,7 +74,7 @@ export default async () => {
                 expect(list.get_row_at_index(0) === null).toBe(false);
             });
 
-            await gated(diagnostics, 'a CHILDLESS widget accepts a child and says nothing', async () => {
+            await it('a CHILDLESS widget accepts a child and says nothing', async () => {
                 // THE ROW THAT PAYS FOR THE TABLE.
                 //
                 // `Gtk.Label` holds no children. The generic adder does not refuse it —
@@ -87,7 +95,7 @@ export default async () => {
                 orphan.unparent();
             });
 
-            await gated(diagnostics, 'a keyed container loses the name the key is read from', async () => {
+            await it('a keyed container loses the name the key is read from', async () => {
                 // `GtkStack` is why `{ kind: 'keyed' }` names its adder: the generic call
                 // adds the page but leaves `page.name` null, so `visible-child-name` —
                 // the whole point of a stack — addresses nothing.

--- a/packages/framework/gtk-host/src/conformance.spec.ts
+++ b/packages/framework/gtk-host/src/conformance.spec.ts
@@ -5,13 +5,13 @@ import { expect, it, on } from '@gjsify/unit';
 import Gtk from 'gi://Gtk?version=4.0';
 
 import { descriptorProblems, describeLogRecord, installDiagnosticsGate, methodsOf } from './conformance/index.js';
-import { gated } from './testing/gate.mjs';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
 import { lookupWidget, registeredTags } from './registry.js';
 import type { WidgetDescriptor } from './types.js';
 import { BUILTIN_DESCRIPTORS, registerBuiltinWidgets } from './descriptors/index.js';
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
 

--- a/packages/framework/gtk-host/src/generated.spec.ts
+++ b/packages/framework/gtk-host/src/generated.spec.ts
@@ -32,7 +32,7 @@ import { isWritable, lookupEnumNick, paramSpecs } from './props.js';
 import { isEventProp, toSignalName } from './signals.js';
 import { hasWidget, lookupWidget } from './registry.js';
 import { assertInjective, tagOf } from './tags.js';
-import { gated } from './testing/gate.mjs';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
 
 /**
  * Every member the surface offers for a widget, and WHERE it was declared.
@@ -71,7 +71,7 @@ const writableSpecs = (gtype: string): string[] => {
 };
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         // The table registers itself here rather than in a hook: registration is
         // keyed on the GType name and idempotent, and every case below needs it.

--- a/packages/framework/gtk-host/src/generator.spec.ts
+++ b/packages/framework/gtk-host/src/generator.spec.ts
@@ -10,6 +10,8 @@
 
 import { expect, it, on } from '@gjsify/unit';
 
+import { GTK_HOSTS } from './testing/gate.mjs';
+
 import { methodsOf } from './conformance/index.js';
 import { emitWidgets, type GateFailure } from './generator/emit.mjs';
 import { emitProps, emitSurfaceData, volarResolves } from './generator/emit-types.mjs';
@@ -47,7 +49,7 @@ const emitFixture = (curated: readonly WidgetDescriptor[], floor = 2) =>
     emitWidgets({ namespaces: [mini], widgets, curated, methodsOf, modules: MINI_MODULES }, floor);
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         await it('reads the classes GIR describes, and skips the two it must', async () => {
             expect(mini.name).toBe('Mini');
             expect(mini.version).toBe('1.0');

--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -28,7 +28,7 @@ import {
     setProp,
 } from './host.js';
 import { reorderMode } from './policies.js';
-import { gated } from './testing/gate.mjs';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
 import { lookupWidget } from './registry.js';
 import type { HostElement } from './types.js';
 
@@ -44,7 +44,7 @@ function labels(n: number): HostElement[] {
 }
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
 

--- a/packages/framework/gtk-host/src/props.spec.ts
+++ b/packages/framework/gtk-host/src/props.spec.ts
@@ -8,7 +8,7 @@ import Gtk from 'gi://Gtk?version=4.0';
 import type Adw from 'gi://Adw?version=1';
 
 import { installDiagnosticsGate } from './conformance/index.js';
-import { gated } from './testing/gate.mjs';
+import { GTK_HOSTS, gated } from './testing/gate.mjs';
 import { GtkHostError } from './errors.js';
 import { createElement, materialize, setProp } from './host.js';
 import { constructOnlyNames, paramSpecs, removedValue, toPropertyName } from './props.js';
@@ -16,7 +16,7 @@ import { registerBuiltinWidgets } from './descriptors/index.js';
 import { hasWidget } from './registry.js';
 
 export default async () => {
-    await on('Gjs', async () => {
+    await on(GTK_HOSTS, async () => {
         Gtk.init();
         registerBuiltinWidgets();
 

--- a/packages/framework/gtk-host/src/testing/gate.mts
+++ b/packages/framework/gtk-host/src/testing/gate.mts
@@ -25,7 +25,7 @@
 // already excludes — `!lib/types/**/*.d.mts` and `!lib/types/**/*.spec.d.ts` —
 // which is the whole class rather than this one instance: 68 packed files to 51.
 
-import { afterEach, beforeEach, describe } from '@gjsify/unit';
+import { afterEach, beforeEach, describe, type Runtime } from '@gjsify/unit';
 
 import type { DiagnosticsGate } from '../conformance/diagnostics.js';
 
@@ -35,3 +35,26 @@ export const gated = (gate: DiagnosticsGate, name: string, body: () => Promise<v
         afterEach(() => gate.assertQuiet());
         await body();
     }) as Promise<void>;
+
+/**
+ * The runtimes that can host GTK — and an IDENTITY list on purpose.
+ *
+ * These suites need a reachable GTK, not a particular interpreter, so the
+ * expressive form would be a capability (`@gjsify/unit` splits `'Display'` from
+ * `'Gl'` for exactly that reason). It is not used here, and the reason is the
+ * failure mode rather than taste.
+ *
+ * A capability can only be PROBED — nothing about `(os, env)` answers "is the Gtk
+ * typelib reachable from this process", and `@gjsify/unit` is Tier 1 and must not
+ * import `gi://` to find out. A probe that answers "no" makes the whole suite STAND
+ * DOWN, and `requireAxes` cannot catch that: it only holds axes the host MATCHES.
+ * So a container that lost its GTK would run zero tests and report success — the
+ * green-that-checked-nothing shape, arriving through the very gate meant to widen
+ * coverage. Measured once already: gated on `'Gjs'` alone, this suite built for the
+ * node target exited 0 having run 0 tests from 0 gates, 9 stood down.
+ *
+ * Named identities instead mean the suite RUNS wherever it was built, and a missing
+ * GTK dies loudly at `Gtk.init()` in the first line of each suite. Louder beats
+ * more expressive when the quiet failure is a pass.
+ */
+export const GTK_HOSTS: Runtime[] = ['Gjs', 'Node.js', 'Bun', 'Deno'];

--- a/scripts/audit-runtimes.mjs
+++ b/scripts/audit-runtimes.mjs
@@ -1150,6 +1150,33 @@ function diffDeclared(rows) {
             !r.signals.imports_legacy &&
             !r.signals.dynamic_gi;
         const portableContractSlot = (s) => s === 'node' || s === 'browser' || s === 'nativescript';
+        // A SECOND, much narrower tolerance, and only for the `node` slot: a package
+        // whose sole GJS binding is a STATIC `gi://` import genuinely reaches Node,
+        // because on `--app node` that specifier is claimed and routed to
+        // `@gjsify/node-gi` (axis 5). So `none` and `polyfill` are both honest
+        // readings and neither is drift — the same argument the pure-TS tolerance
+        // above makes, applied one signal further out.
+        //
+        // Every bound deliberately: only where the heuristic itself suggested `none`
+        // (elsewhere it has a real opinion this must not silence); only `node` (on
+        // `browser` and `nativescript` a `gi://` import is substituted with `{}`, so
+        // a wrong declaration there fails SILENTLY, which is why those two are the
+        // fatal targets of the reachability pass); and NOT for `imports_legacy`,
+        // `gjs_imports_guard` or `dynamic_gi` — the legacy object is an anti-pattern
+        // this repo bans outright rather than accommodates, and a dynamic `gi://`
+        // specifier is not statically rewritable, so the bridge cannot promise it.
+        //
+        // `@gjsify/gtk-host` is the case this was written for (ADR 0027's amended
+        // quadruplet, ADR 0030 § Decision 6): its host, props, policies, registry and
+        // types modules import nothing but `gi://`, and a showcase built for the node
+        // target already runs.
+        const giUrlReachesNodeBridge =
+            r.suggested.node === 'none' &&
+            r.signals.gi_url &&
+            !r.signals.gjs_imports_guard &&
+            !r.signals.girs_value &&
+            !r.signals.imports_legacy &&
+            !r.signals.dynamic_gi;
         const mismatches = slots.filter((s) => {
             // The 4th slot is OPTIONAL: packages that declared their triplet before NS was
             // an axis are backfilled opportunistically, so an undeclared `nativescript`
@@ -1164,6 +1191,9 @@ function diffDeclared(rows) {
             ) {
                 return false;
             }
+            // The gi://-reaches-node-gi tolerance (see above). `none` needs no clause:
+            // it already equals the suggestion, so it never reaches this filter.
+            if (giUrlReachesNodeBridge && s === 'node' && r.declared[s] === 'polyfill') return false;
             return r.declared[s] !== r.suggested[s];
         });
         if (mismatches.length > 0) {

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -38,6 +38,43 @@ finalizers work as such — this is the node-api variant over
 `napi_create_external_buffer`. Which stage it really is remains unmeasured, which
 is the whole reason the marker change comes first.
 
+### Two node-gi gaps keep gtk-host's node leg red, and they are 103 of 125 failures
+
+`@gjsify/gtk-host` now runs its own suite on Node (ADR 0030 § Implementation step 1):
+**1701 tests execute, 125 fail.** Grouped by cause, two divergences from GJS account
+for 103 of them, each with a one-line repro:
+
+    // 99 failures — "No descriptor registered for <null>"
+    const b = new Gtk.Box();
+    b.constructor.$gtype        // GJS: the GType.  node-gi: undefined
+    // → GObject.type_name(undefined) is null → String(null) is 'null'
+
+    // 4 failures
+    new Adw.HeaderBar().vfunc_add_child   // GJS: a function.  node-gi: undefined
+
+The first is the expensive one, and not because of the count: `constructor.$gtype`
+is the GJS idiom for "what type is this instance", and gtk-host reads it in
+`adopt()`, in `nearestRegistered()` and in every descriptor lookup. On GJS the
+constructor IS the introspected class object and carries `$gtype`; under node-gi an
+instance's `constructor` does not. `Gtk.Box.$gtype` itself is fine — measured,
+`GObject.type_name()` on it answers `GtkBox` — so this is the instance→class link,
+not GType support.
+
+The second is narrower but the same shape: `vfuncChainProto` installs `vfunc_*` for
+classes registered THROUGH node-gi, and an introspected GTK class's instance does
+not get it. ADR 0027 § Context rests on `vfunc_add_child` being callable, measured on
+gjs 1.88.1 across 29 containers.
+
+Both belong in node-gi with a conformance program each (ADR 0030 § Decision 1: GJS
+defines the answer, so the golden is gjs's output), the way the class-struct statics
+gap was closed. The remaining ~22 failures are not yet attributed; some are plainly
+downstream of the first two, and the honest thing is to re-measure after they land
+rather than guess now.
+
+**Why the leg is not wired into CI yet.** `test:gjs-on-node` exists and anyone can
+run it; adding it to a job today would make that job red for defects in a different
+package. It goes in with, or after, the two fixes.
+
 ### The Vue plugin's virtual suffix is coupled to deepkit's filter, and nothing checks it
 
 `@gjsify/rolldown-plugin-vue` mints module ids ending in `VIRTUAL_SUFFIX =


### PR DESCRIPTION
ADR 0030 § Implementation step 1. `@gjsify/gtk-host` declares `node: "polyfill"`
and its own suite now runs there: **1701 tests execute under Node where zero did
before.**

Depends on **#1317** to be readable: without that fix the node leg exits 0 on the
first divergence with the log cut off.

## The gate had to change, and the reason is a measurement

Every suite wrapped its body in `on('Gjs', …)` — a runtime **identity** — so built
for the node target it stood down entirely:

    ✔ 9 ignored tests
    ↳ Gjs: 0 tests from 0 gates, 9 stood down
    ✔ [Node.js 24.19.0] 0 completed        (exit 0)

The step meant to ADD coverage would have shipped as a green CI leg that checked
nothing.

`GTK_HOSTS` names the four runtimes instead. Identities over a capability is
deliberate, and it is the trade-off worth reading: a `Gtk` capability would say
exactly what these suites require — which is the argument `@gjsify/unit` itself
makes when it splits `'Display'` from `'Gl'` — but it can only be **probed**.
Nothing about `(os, env)` answers "is the Gtk typelib reachable from this process",
and a Tier-1 runner must not import `gi://` to find out. A probe answering "no"
makes the suite stand down, and `requireAxes` cannot catch that: it only holds axes
the host **matches**. A container that lost its GTK would run nothing and report
success — the same failure class, one level up. Named identities mean the suite RUNS
wherever it was built, and a missing GTK dies loudly at `Gtk.init()`.

## `buildable.spec.ts`'s four rows become tests

They were `gated()` describes holding bare assertions, which is not a test: outside
the tally, unskippable, and on failure it aborts the entire run. That is precisely
how one node-gi divergence stopped this package's node leg after one suite of nine.
As `it()`s inside the existing `gated` describe they keep the same per-row
diagnostics isolation and now appear in the count — verified on the GJS leg.

## The drift check

A second, narrow tolerance beside the pure-TS one: a package whose only GJS binding
is a **static** `gi://` import may declare `node` as `none` or `polyfill`, because
on `--app node` that specifier is routed to `@gjsify/node-gi`.

Bounded on purpose — only where the heuristic itself suggested `none`, only the
`node` slot (on `browser`/`nativescript` a `gi://` import becomes `{}`, so a wrong
declaration there fails **silently**, which is why those two are the fatal targets),
and never for `imports.*`, an `imports?.gi` guard, or a dynamic specifier.

A/B: with the tolerance `audit-runtimes --check --strict` exits 0; without it, exit
1 naming `@gjsify/gtk-host`.

## Why `test:gjs-on-node` is not wired into CI

125 of the 1701 fail, and **103 of those are two node-gi divergences**, each with a
one-line repro:

    const b = new Gtk.Box();
    b.constructor.$gtype        // GJS: the GType.  node-gi: undefined     → 99 failures
    new Adw.HeaderBar().vfunc_add_child   // GJS: a function. node-gi: undefined → 4

The first is the expensive one, and not because of the count: `constructor.$gtype`
is the GJS idiom for "what type is this instance", and gtk-host reads it in
`adopt()`, in `nearestRegistered()` and in every descriptor lookup, so the failures
all surface as `No descriptor registered for <null>`. `Gtk.Box.$gtype` itself is
fine — `GObject.type_name()` on it answers `GtkBox` — so this is the instance→class
link, not GType support.

Adding the leg to a job today would redden that job for defects in a different
package. Both gaps go home to node-gi with a conformance program each, the way the
class-struct statics gap was closed in #1310. The remaining ~22 failures are not yet
attributed; some are plainly downstream of these two, and the honest move is to
re-measure after they land rather than guess now. All of this is recorded in
`status/open-todos.md`.

## Regression

GJS leg unchanged: **1930 tests, exit 0**, with the four converted rows visible as
tests. `lint`, `format --check`, `audit-runtimes --check --strict`,
`audit-test-scripts` and `generate-status` all exit 0.
