### PR TITLE
test(napi): make the instance-data probe self-locating

### DIFF
--- a/packages/napi/napi/conformance/golden/na_test_instance_data.txt
+++ b/packages/napi/napi/conformance/golden/na_test_instance_data.txt
@@ -1,1 +1,4 @@
+"async-work"
+"finalizer"
+"tsfn"
 "ok"

--- a/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
+++ b/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
@@ -11,17 +11,24 @@ export const meta = { dir: 'test_instance_data', targets: ['test_instance_data']
 export default async function run(h) {
     const t = h.loadAddon('test_instance_data');
 
+    // One marker per stage: a hang here reports which of the three awaits
+    // never returned, instead of a single 'ok' making all three
+    // indistinguishable in a stalled run (status/open-todos.md).
+
     // Instance data from an async_work completion callback.
     await new Promise((resolve) => t.asyncWorkCallback(resolve));
+    h.emit('async-work');
 
     // Instance data from a node::Buffer (external buffer) finalizer.
     await new Promise((resolve) => {
         t.testBufferFinalizer(resolve);
         h.gc();
     });
+    h.emit('finalizer');
 
     // Instance data from a threadsafe-function callback.
     await new Promise((resolve) => t.testThreadsafeFunction(() => {}, resolve));
+    h.emit('tsfn');
 
     h.emit('ok');
 }


### PR DESCRIPTION
Closes the diagnosability half of the entry added in #1315.

`na_test_instance_data` went red twice in one session on PRs that could not affect
it — a `repository.directory` correction and a README split — and passed on rerun
both times. The diff was always the same:

    ✗ na_test_instance_data: NODE output drifted from the committed golden
      got : ""
      want: "\"ok\""

`got ""` is not a clue. It is the absence of one.

## Why

The program awaits three things — instance data reached from an async_work
completion callback, from a `napi_create_external_buffer` finalizer driven by an
explicit `h.gc()`, and from a threadsafe-function callback — and then emitted
exactly **one** marker. A hang in any of the three produced byte-identical
evidence, so the failure could not say which stage stopped.

## The change

One marker per stage, in a stable order so a partial run reads as a prefix of a
full one:

    "async-work" → "finalizer" → "tsfn" → "ok"

A hang on the finalizer stage now shows `got "async-work"` as the last line and
names the await that did not return.

Nothing about **what** the program tests changed. The golden comes from the
harness's own `--update-golden` path on the reference leg, not by hand.

## Measured

Green on both legs, byte-identical across five consecutive runs, and re-verified
independently after the fact (`--filter=na_test_instance_data` → `pass: 1
ledgered: 0 fail: 0`, exit 0).

So this session did **not** reproduce the flake and therefore cannot say which
stage it blames — which is exactly the point of the change rather than an excuse
for it: the next occurrence will.

## Also checked

The sibling `test_instance_data` does not have the single-marker shape — it already
emits `increment`, `typeof obj` and `finalizer-callback-ran` at the points that
matter. Nothing to do there.
