### PR TITLE
test(vue): hold the deepkit filter coupling

### DIFF
--- a/packages/infra/rolldown-plugin-deepkit/src/index.ts
+++ b/packages/infra/rolldown-plugin-deepkit/src/index.ts
@@ -33,6 +33,22 @@ async function getLoader(): Promise<DeepkitLoader> {
 
 const FILTER = /\.(m|c)?tsx?$/;
 
+/**
+ * Whether `id` is inside the set this plugin reflects — the same `FILTER` the
+ * `transform` hook tests at runtime, not a second copy of the regex.
+ *
+ * Exists because that filter is also a load-bearing DEPENDENCY of anything that
+ * mints a virtual module id meant to be reflected: `@gjsify/rolldown-plugin-vue`
+ * appends a `.gjsify-vue.ts` tail to route `.vue` SFCs through TypeScript parsing,
+ * and the same tail is what makes deepkit see the id at all (`status/open-todos.md`
+ * § "The Vue plugin's virtual suffix is coupled to deepkit's filter"). A silent
+ * drift here switches reflection off for every consumer with no diagnostic — the
+ * build still exits 0.
+ */
+export function reflectsModuleId(id: string): boolean {
+    return FILTER.test(id);
+}
+
 function printDiagnostics(...args: unknown[]): void {
     console.log('[deepkit] printDiagnostics', inspect(args, false, 10, true));
 }
@@ -46,7 +62,7 @@ export function deepkitPlugin(options: DeepkitPluginOptions = {}): Plugin {
             order: 'pre' as const,
             async handler(code, id) {
                 if (!reflection) return null;
-                if (!FILTER.test(id)) return null;
+                if (!reflectsModuleId(id)) return null;
 
                 try {
                     const loader = await getLoader();

--- a/packages/infra/rolldown-plugin-vue/package.json
+++ b/packages/infra/rolldown-plugin-vue/package.json
@@ -58,6 +58,7 @@
     },
     "devDependencies": {
         "@gjsify/cli": "workspace:^",
+        "@gjsify/rolldown-plugin-deepkit": "workspace:^",
         "@gjsify/unit": "workspace:^",
         "@types/node": "^25.9.2",
         "rolldown": "^1.1.4"

--- a/packages/infra/rolldown-plugin-vue/src/plugin.spec.ts
+++ b/packages/infra/rolldown-plugin-vue/src/plugin.spec.ts
@@ -13,6 +13,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { reflectsModuleId } from '@gjsify/rolldown-plugin-deepkit';
 import { describe, expect, it } from '@gjsify/unit';
 
 import { vuePlugin } from './index.js';
@@ -78,6 +79,16 @@ export default async () => {
         await it('renames a .vue specifier to the resolved path plus the virtual suffix', async () => {
             const { ctx } = context(file);
             expect(idOf(await resolveId.call(ctx, './App.vue', join(dir, 'main.ts')))).toBe(`${file}${SUFFIX}`);
+        });
+
+        await it('mints an id that still lands inside the deepkit plugin’s reflection filter', async () => {
+            // The coupling `status/open-todos.md` names: `SUFFIX` exists so rolldown's
+            // extension-based parser selection reaches TypeScript, and the SAME tail is
+            // what makes `@gjsify/rolldown-plugin-deepkit` see a `.vue` id at all — its
+            // filter is `/\.(m|c)?tsx?$/`. Renaming either constant so this goes red is
+            // the failure the ledger entry describes: reflection switches off for every
+            // `.vue` file with no diagnostic, from a build that exits 0.
+            expect(reflectsModuleId(`/a/App.vue${SUFFIX}`)).toBe(true);
         });
 
         await it('hands an EXTERNAL .vue back unchanged', async () => {


### PR DESCRIPTION
Closes the first entry in `status/open-todos.md`, which stated the coupling and said
the mechanism it deserves is small but not free.

## The coupling

`@gjsify/rolldown-plugin-vue` mints module ids ending in
`VIRTUAL_SUFFIX = '.gjsify-vue.ts'` (`src/index.ts:61`) so rolldown's
extension-based parser selection reaches TypeScript. That tail also decides
something nobody checked: `@gjsify/rolldown-plugin-deepkit` filters on
`/\.(m|c)?tsx?$/` (`src/index.ts:34`), the `(m|c)?` group is optional, so the id
lands inside it and an SFC's `<script setup>` gets reflected.

**Rename the tail to `.js` and reflection switches off for every `.vue` file in the
project, with no diagnostic.** `typeOf()` with no argument then throws
`No type given` at runtime, from a build that exited 0. Until now the coupling was
stated in a comment at the constant, which is enforcement by review.

## The mechanism

deepkit exports `reflectsModuleId(id)`, and its own `transform` hook now calls it —
so the regex has exactly **one** call site rather than a predicate sitting beside a
copy of it. That was the part worth getting right: a predicate that duplicated the
pattern would be a second truth that drifts, and the drifted one is what the test
would trust.

No new `exports` subpath. The package already exposes a single `"."`, and a
dedicated subpath for one boolean function with no second consumer is public
surface bought for nothing.

The vue plugin's own suite asserts `reflectsModuleId('/a/App.vue' + SUFFIX)`, with
a `workspace:^` devDependency edge for it. The lockfile needs no change — it tracks
external registry deps only (checked), and workspace-to-workspace edges resolve
through the monorepo's linker.

## A/B, which is the whole point

    suffix '.gjsify-vue.js'  → exit 1, exactly this test red
                               (Expected: true, Actual: false), other 193 green
    suffix '.gjsify-vue.ts'  → exit 0, 194/194 on Node 24.19.0 and Gjs 1.88.1

Re-verified independently after the fact: `194 completed` on both runtimes, exit 0,
with the new test visible in both.

`rolldown-plugin-deepkit` has no spec files today, so it has no `test` script — its
`build` and `check` exit 0. Noted rather than silently skipped.
