### PR TITLE
fix(adwaita-web): adopt slotted children live

### DIFF
--- a/packages/web/adwaita-web/README.md
+++ b/packages/web/adwaita-web/README.md
@@ -53,6 +53,33 @@ Vite preset (or any Vite/bundler setup). Type declarations are shipped
 pre-built at `lib/types/index.d.ts`, so `gjsify tsc` consumers resolve the
 package's types without compiling its source.
 
+## Slots are live
+
+These are light-DOM custom elements, so `slot="…"` is emulated rather than native
+(see [ADR 0010](../../../docs/adr/0010-adwaita-web-style-isolation.md) for why the
+package stays out of the shadow DOM). The emulation is **live**: a child appended
+after the element is in the document lands in the same internal box as the
+identical child written in the markup.
+
+```typescript
+const row = document.querySelector('adw-action-row')!;
+const toggle = document.createElement('adw-switch');
+toggle.setAttribute('slot', 'suffix');
+row.append(toggle); // lands in the suffix section, exactly as a declared one does
+```
+
+Two limits are worth knowing:
+
+- **Append, not reorder.** A late child goes to the end of its slot's box. Once a
+  child has been adopted it is no longer a child of the host, so
+  `host.insertBefore(next, adopted)` throws in the DOM before this package sees
+  it — reorder inside the box you were handed (`row.prefixSection`,
+  `view.topBar`, …). Native `<slot>` is what would lift this, and it is part of
+  the shadow-DOM path ADR 0010 defers.
+- **An unknown slot name is assigned nowhere**, as in the native algorithm: a
+  `slot="sufix"` typo stays where you put it instead of quietly becoming default
+  content in the wrong box.
+
 ## Shared behaviour (`@gjsify/adwaita-core`)
 
 The widget *behaviour* — as opposed to the DOM rendering — comes from

--- a/packages/web/adwaita-web/src/adw-header-bar.spec.ts
+++ b/packages/web/adwaita-web/src/adw-header-bar.spec.ts
@@ -68,8 +68,10 @@ function mountSizedHeaderBar(width: number): HTMLElement {
             bar.appendChild(button);
         }
     }
-    // Appended LAST: the sections are built in `connectedCallback`, so the slotted
-    // children have to be in place before the bar enters the document.
+    // The bar enters the document last, so this geometry is measured on the PARSE-TIME
+    // path. It used to be the only path that worked — the sections were built in
+    // `connectedCallback` from a one-shot snapshot — and that is no longer a constraint:
+    // `slotted-children.spec.ts` requires the appended path to place a child identically.
     host.appendChild(bar);
     return bar;
 }

--- a/packages/web/adwaita-web/src/elements/adw-action-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-action-row.ts
@@ -17,6 +17,7 @@
 import { ActionRowState } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 import { type AdwRowActivation, attachRowActivation } from './row-activation.js';
 
 /**
@@ -90,12 +91,8 @@ export class AdwActionRow extends HTMLElement {
         }
         this._initialized = true;
 
-        const prefixChildren = Array.from(this.querySelectorAll(':scope > [slot="prefix"]'));
-        const suffixChildren = Array.from(this.querySelectorAll(':scope > [slot="suffix"]'));
-
         this._prefixEl = document.createElement('div');
         this._prefixEl.className = 'adw-action-row-prefix';
-        for (const child of prefixChildren) this._prefixEl.appendChild(child);
 
         const textEl = document.createElement('div');
         textEl.className = 'adw-action-row-text';
@@ -107,9 +104,14 @@ export class AdwActionRow extends HTMLElement {
 
         this._suffixEl = document.createElement('div');
         this._suffixEl.className = 'adw-action-row-suffix';
-        for (const child of suffixChildren) this._suffixEl.appendChild(child);
 
-        this.replaceChildren(this._prefixEl, textEl, this._suffixEl);
+        // The two slots stay LIVE — a control appended with `slot="suffix"` after connect
+        // has to land in the same section the declared one does, which a snapshot taken
+        // here cannot do. `src/slotted-children.ts` carries the incident.
+        bindSlottedChildren(this, [
+            { name: 'prefix', into: this._prefixEl },
+            { name: 'suffix', into: this._suffixEl },
+        ]).install(this._prefixEl, textEl, this._suffixEl);
         // `_render` runs from `attributeChangedCallback`, which a control appended into
         // `suffixSection` never triggers — the section stayed `hidden` and the control
         // measured 0x0. The observer is what keeps the two sections in step with what

--- a/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
@@ -45,6 +45,7 @@ import { AdwAlertResponses } from '@gjsify/adwaita-core';
 import type { AdwResponseAppearance } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 import { AdwModalSurface } from './modal-surface.js';
 
 /** Response button appearance — mirrors Adw.ResponseAppearance. */
@@ -141,12 +142,6 @@ export class AdwAlertDialog extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        // Declared <adw-alert-response> children are snapshotted before the element takes
-        // over the subtree; everything else becomes the extra child.
-        const declared = Array.from(this.querySelectorAll(':scope > adw-alert-response')) as AdwAlertResponse[];
-        const declaredSet = new Set<Node>(declared);
-        const extraChildren = Array.from(this.childNodes).filter((n) => !declaredSet.has(n));
-
         this._scrimEl = document.createElement('div');
         this._scrimEl.className = 'adw-alert-dialog-scrim';
         this._scrimEl.addEventListener('click', () => this._dismiss());
@@ -176,27 +171,34 @@ export class AdwAlertDialog extends HTMLElement {
 
         this._childEl = document.createElement('div');
         this._childEl.className = 'adw-alert-dialog-child';
-        for (const child of extraChildren) this._childEl.appendChild(child);
 
         messageArea.append(this._headingEl, this._bodyEl, this._childEl);
-        // `_render` runs from `attributeChangedCallback` and from the response API, and
-        // an extra child appended after connect triggers neither.
-        bindEmptySections(this._childEl);
 
         this._responseAreaEl = document.createElement('div');
         this._responseAreaEl.className = 'adw-alert-dialog-responses';
 
         this._dialogEl.append(messageArea, this._responseAreaEl);
-        this.replaceChildren(this._scrimEl, this._dialogEl);
 
-        for (const el of declared) {
-            const id = el.getAttribute('id');
-            if (!id) continue;
-            const appearance = (el.getAttribute('appearance') ?? 'default') as AdwResponseAppearance;
-            this.addResponse(id, (el.textContent ?? '').trim());
-            if (appearance !== 'default') this.setResponseAppearance(id, appearance);
-            if (el.getAttribute('enabled') === 'false') this.setResponseEnabled(id, false);
-        }
+        // Two slots, both LIVE. An `<adw-alert-response>` is DATA — read for its id, label
+        // and appearance and then gone, as GtkBuilder leaves nothing of a `<responses>`
+        // entry in the widget tree — so it is consumed rather than re-homed, and
+        // `adw_alert_dialog_add_response` is callable at any point in the dialog's life.
+        // Everything else is the extra child. `src/slotted-children.ts` has the incident.
+        // Installed AFTER the response area exists, because consuming a response fills it.
+        bindSlottedChildren(this, [
+            {
+                claims: (node) => node instanceof Element && node.localName === 'adw-alert-response',
+                consume: (node) => this._adoptResponse(node as AdwAlertResponse),
+            },
+            { into: this._childEl },
+        ]).install(this._scrimEl, this._dialogEl);
+
+        // `_render` runs from `attributeChangedCallback` and from the response API, and an
+        // extra child appended after connect triggers neither. AFTER the routing: this
+        // derives once synchronously, and a `hidden` child area is not focusable, so
+        // deriving it on the not-yet-filled box sent the initial focus to the default
+        // response instead of into the content.
+        bindEmptySections(this._childEl);
 
         // Seed the headless model's text from the parsed markup; the attributes stay the
         // source of truth for what is rendered.
@@ -204,6 +206,20 @@ export class AdwAlertDialog extends HTMLElement {
         this._model.body = this.body;
 
         this._render();
+    }
+
+    /**
+     * Take one declared `<adw-alert-response>` as a response. An entry with no `id` is
+     * skipped rather than given a generated one: the id is what `response` events carry, so
+     * inventing one would hand the consumer a name it never wrote.
+     */
+    private _adoptResponse(el: AdwAlertResponse): void {
+        const id = el.getAttribute('id');
+        if (!id) return;
+        const appearance = (el.getAttribute('appearance') ?? 'default') as AdwResponseAppearance;
+        this.addResponse(id, (el.textContent ?? '').trim());
+        if (appearance !== 'default') this.setResponseAppearance(id, appearance);
+        if (el.getAttribute('enabled') === 'false') this.setResponseEnabled(id, false);
     }
 
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {

--- a/packages/web/adwaita-web/src/elements/adw-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-dialog.ts
@@ -24,6 +24,7 @@
 // Copyright (c) 2023-2024 GNOME Foundation Inc. (libadwaita). LGPLv2.1+.
 // Modifications: Implemented as a Web Component for @gjsify/adwaita-web.
 
+import { bindSlottedChildren } from '../slotted-children.js';
 import { AdwModalSurface } from './modal-surface.js';
 
 /** Adaptive presentation of the dialog — mirrors Adw.DialogPresentationMode. */
@@ -141,10 +142,6 @@ export class AdwDialog extends HTMLElement {
 
         this.classList.add('adw-dialog');
 
-        // Snapshot before the subtree is replaced: everything the author placed inside
-        // becomes the dialog content.
-        const contentChildren = Array.from(this.childNodes);
-
         this._scrimEl = document.createElement('div');
         this._scrimEl.className = 'adw-dialog-scrim';
         this._scrimEl.addEventListener('click', () => this._attemptClose());
@@ -187,11 +184,13 @@ export class AdwDialog extends HTMLElement {
 
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-dialog-content';
-        for (const child of contentChildren) this._contentEl.appendChild(child);
 
         this._boxEl.append(this._headerEl, this._contentEl);
         this._scrimEl.appendChild(this._boxEl);
-        this.replaceChildren(this._scrimEl);
+        // Everything the author places inside is the dialog content — LIVE, because
+        // `Adw.Dialog:child` is a property and a dialog whose body is filled in after it
+        // was created is the ordinary case. `src/slotted-children.ts` has the incident.
+        bindSlottedChildren(this, [{ into: this._contentEl }]).install(this._scrimEl);
 
         this._render();
     }

--- a/packages/web/adwaita-web/src/elements/adw-entry-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-entry-row.ts
@@ -37,6 +37,7 @@ import {
     type EntryRowRenderState,
 } from '@gjsify/adwaita-core';
 
+import { bindSlottedChildren, type AdwSlottedChildren } from '../slotted-children.js';
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
 
 /**
@@ -71,8 +72,11 @@ export class AdwEntryRow extends HTMLElement {
     protected _prefixes!: HTMLDivElement;
     protected _suffixes!: HTMLDivElement;
     protected _initialized = false;
-    /** Light-DOM children captured at build time, adopted after `_onConnected`. */
-    private _authored: Element[] = [];
+    /**
+     * The two slots, installed after `_onConnected` rather than inside `_build`: the order
+     * IS the contract — see the `install` call in `connectedCallback`.
+     */
+    private _slots!: AdwSlottedChildren;
     private _lastText = '';
     private _lastLength = 0;
 
@@ -159,11 +163,20 @@ export class AdwEntryRow extends HTMLElement {
         if (this.hasAttribute('text')) this._state.setText(this.getAttribute('text') ?? '');
         this._renderTitle();
 
-        // Subclass parts first, THEN the author's children: `AdwPasswordEntryRow`
-        // installs its peek toggle from its own `init`, so a consumer
-        // suffix lands after it and both remain.
+        // Subclass parts first, THEN the author's children: `AdwPasswordEntryRow` installs
+        // its peek toggle from its own `init`, so a consumer suffix lands after it and both
+        // remain. That ordering is why the structure is installed HERE and not at the end of
+        // `_build` — `install` routes the author's children on its way, and doing it a phase
+        // earlier would put every declared suffix in front of the password row's toggle.
         this._onConnected();
-        this._adoptAuthored();
+        this._slots.install(
+            this._prefixes,
+            this._area,
+            this._indicator,
+            this._applyButton,
+            this._editIcon,
+            this._suffixes,
+        );
 
         this._lastText = this._state.text;
         this._lastLength = this._state.textLength;
@@ -254,12 +267,6 @@ export class AdwEntryRow extends HTMLElement {
     private _build(): void {
         const prefix = this._classPrefix;
 
-        // Author-supplied light-DOM children are KEPT: `replaceChildren` used to
-        // discard them silently, so `<adw-entry-row><adw-button>Go</adw-button>`
-        // rendered without its button. Elements only — GtkBuildable also only
-        // ever adopts widgets, and keeping stray whitespace would make an empty
-        // affordance box measure as non-empty.
-        this._authored = [...this.children];
         this._prefixes = document.createElement('div');
         this._prefixes.className = `${prefix}-prefixes`;
         this._suffixes = document.createElement('div');
@@ -322,32 +329,24 @@ export class AdwEntryRow extends HTMLElement {
         this._editIcon = createAdwIcon('document-edit', 'adw-row-edit', `${prefix}-edit`);
         this._editIcon.dataset.iconName = ENTRY_ROW_EDIT_ICON_NAME;
 
-        // Snapshot order: indicator → apply → edit icon inside the editable area, with
-        // the prefixes/suffixes boxes outside it.
-        this.replaceChildren(
-            this._prefixes,
-            this._area,
-            this._indicator,
-            this._applyButton,
-            this._editIcon,
-            this._suffixes,
-        );
+        // Author-supplied light-DOM children are KEPT and stay LIVE: `replaceChildren` used
+        // to discard them silently, so `<adw-entry-row><adw-button>Go</adw-button>` rendered
+        // without its button, and the snapshot that fixed that was still a one-shot read — a
+        // suffix appended after connect sat outside the affordance box. ELEMENTS only, on
+        // both paths: GtkBuildable also only ever adopts widgets, and keeping stray
+        // whitespace would make an empty affordance box measure as non-empty. Consumed
+        // through the two `add*` methods, because their insertion rules differ —
+        // `addPrefix` PREPENDS, mirroring `gtk_box_prepend`. Structure order:
+        // indicator → apply → edit icon inside the editable area, prefixes/suffixes outside.
+        // `src/slotted-children.ts` has the incident.
+        this._slots = bindSlottedChildren(this, [
+            { name: 'prefix', consume: (node) => this.addPrefix(node) },
+            { name: 'suffix', claims: (node) => node instanceof Element, consume: (node) => this.addSuffix(node) },
+        ]);
         setPartVisible(this._prefixes, false);
         setPartVisible(this._suffixes, false);
 
         this.addEventListener('click', (event) => this._maybeFocus(event));
-    }
-
-    /**
-     * Re-home the children the author wrote. libadwaita's buildable maps an untyped
-     * `<child>` to a suffix; `slot="prefix"` is the web spelling of `type="prefix"`.
-     */
-    private _adoptAuthored(): void {
-        for (const node of this._authored) {
-            if (node.getAttribute('slot') === 'prefix') this.addPrefix(node);
-            else this.addSuffix(node);
-        }
-        this._authored = [];
     }
 
     /**

--- a/packages/web/adwaita-web/src/elements/adw-expander-row.ts
+++ b/packages/web/adwaita-web/src/elements/adw-expander-row.ts
@@ -22,6 +22,7 @@
 import { ExpanderState, deriveRowLabels } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 
 // SIDE-EFFECT import, deliberately separate from the type import below: it guarantees
 // `adw-switch` is defined before this module's `customElements.define` can upgrade a
@@ -105,11 +106,6 @@ export class AdwExpanderRow extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        const prefixChildren = Array.from(this.querySelectorAll(':scope > [slot="prefix"]'));
-        const suffixChildren = Array.from(this.querySelectorAll(':scope > [slot="suffix"]'));
-        const claimed = new Set<Node>([...prefixChildren, ...suffixChildren]);
-        const rows = Array.from(this.childNodes).filter((node) => !claimed.has(node));
-
         this._headerEl = document.createElement('div');
         this._headerEl.className = 'adw-expander-row-header';
 
@@ -130,25 +126,33 @@ export class AdwExpanderRow extends HTMLElement {
 
         this._prefixEl = document.createElement('div');
         this._prefixEl.className = 'adw-expander-row-prefix';
-        for (const child of prefixChildren) this._prefixEl.appendChild(child);
 
         this._suffixEl = document.createElement('div');
         this._suffixEl.className = 'adw-expander-row-suffix';
-        for (const child of suffixChildren) this._suffixEl.appendChild(child);
-
-        // Same reason as the action row's: `_render` is attribute-driven, and a widget
-        // appended into `prefixSection` after connect is a childList change nothing else
-        // hears. `contentSection` is NOT in here — an empty disclosure is still the
-        // disclosure, and `.expanded` alone decides whether it shows.
-        bindEmptySections(this._prefixEl, this._suffixEl);
 
         this._headerEl.append(this._prefixEl, textEl, this._suffixEl, this._enableSwitch, this._chevronEl);
 
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-expander-row-content';
-        for (const row of rows) this._contentEl.appendChild(row);
 
-        this.replaceChildren(this._headerEl, this._contentEl);
+        // Three LIVE slots: the two header sections by name, and the disclosure rows as the
+        // unnamed default — `adw_expander_row_add_row` works at any point in the widget's
+        // life, so a row appended after connect must reach the content box rather than sit
+        // beside it. `src/slotted-children.ts` has the incident.
+        bindSlottedChildren(this, [
+            { name: 'prefix', into: this._prefixEl },
+            { name: 'suffix', into: this._suffixEl },
+            { into: this._contentEl },
+        ]).install(this._headerEl, this._contentEl);
+
+        // Same reason as the action row's: `_render` is attribute-driven, and a widget
+        // appended into `prefixSection` after connect is a childList change nothing else
+        // hears. `contentSection` is NOT in here — an empty disclosure is still the
+        // disclosure, and `.expanded` alone decides whether it shows.
+        //
+        // AFTER the routing: this derives once synchronously, so on a box the routing has
+        // not filled yet it hides a section that a declared child had already earned.
+        bindEmptySections(this._prefixEl, this._suffixEl);
 
         this._headerEl.addEventListener('click', (event) => {
             // Clicks on the enable switch toggle expansion-enable, not disclosure.

--- a/packages/web/adwaita-web/src/elements/adw-header-bar.ts
+++ b/packages/web/adwaita-web/src/elements/adw-header-bar.ts
@@ -16,6 +16,8 @@
 // Copyright (c) 2025 csm. MIT License.
 // Modifications: Reimplemented as Web Component for @gjsify/adwaita-web.
 
+import { bindSlottedChildren } from '../slotted-children.js';
+
 // Registers <adw-window-title>: the derived centre is one, so importing the bar
 // alone must still define it.
 import './adw-window-title.js';
@@ -56,35 +58,41 @@ export class AdwHeaderBar extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        // Capture any pre-existing slotted children before clearing
-        const startChildren = Array.from(this.querySelectorAll(':scope > [slot="start"]'));
-        const centerChildren = Array.from(this.querySelectorAll(':scope > [slot="center"]'));
-        const endChildren = Array.from(this.querySelectorAll(':scope > [slot="end"]'));
-
-        // Start section
         this._startEl = document.createElement('div');
         this._startEl.className = 'adw-header-bar-start';
-        for (const child of startChildren) this._startEl.appendChild(child);
 
-        // Center section — a `slot="center"` widget (title-widget) wins over the
-        // plain `title` text.
         this._centerEl = document.createElement('div');
         this._centerEl.className = 'adw-header-bar-center';
-        if (centerChildren.length > 0) {
-            for (const child of centerChildren) this._centerEl.appendChild(child);
-        } else {
+
+        this._endEl = document.createElement('div');
+        this._endEl.className = 'adw-header-bar-end';
+
+        // All three slots stay LIVE: a button appended with `slot="end"` after connect used
+        // to sit outside the end section, and `adw-header-bar.spec.ts` carried the
+        // workaround ("appended LAST") as a house rule. `src/slotted-children.ts` has the
+        // incident. The `onAdopt` hook keeps the title-widget either/or true afterwards —
+        // a centre widget that arrives late replaces the derived title, as setting
+        // `Adw.HeaderBar:title-widget` at any point does.
+        bindSlottedChildren(
+            this,
+            [
+                { name: 'start', into: this._startEl },
+                { name: 'center', into: this._centerEl },
+                { name: 'end', into: this._endEl },
+            ],
+            (_node, slot) => {
+                if (slot.name === 'center') this._dropDerivedTitle();
+            },
+        ).install(this._startEl, this._centerEl, this._endEl);
+
+        // Derived only when the centre is still free — the same either/or as
+        // `Adw.HeaderBar`, which builds an `AdwWindowTitle` exactly while no title-widget
+        // was given.
+        if (this._centerEl.childElementCount === 0) {
             this._titleEl = document.createElement('adw-window-title');
             this._titleEl.className = 'adw-header-bar-title';
             this._centerEl.appendChild(this._titleEl);
         }
-
-        // End section
-        this._endEl = document.createElement('div');
-        this._endEl.className = 'adw-header-bar-end';
-        for (const child of endChildren) this._endEl.appendChild(child);
-
-        // Replace all children atomically
-        this.replaceChildren(this._startEl, this._centerEl, this._endEl);
         this._renderTitle();
     }
 
@@ -96,6 +104,17 @@ export class AdwHeaderBar extends HTMLElement {
      */
     attributeChangedCallback() {
         if (this._initialized) this._renderTitle();
+    }
+
+    /**
+     * Give the centre up to a title-widget. `adw_header_bar_set_title_widget` destroys the
+     * derived `AdwWindowTitle` rather than stacking the two, so the late case has to remove
+     * it too — a bar showing both would be a shape neither GTK nor the declared markup can
+     * produce.
+     */
+    private _dropDerivedTitle() {
+        this._titleEl?.remove();
+        this._titleEl = null;
     }
 
     private _renderTitle() {

--- a/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-navigation-split-view.ts
@@ -36,6 +36,7 @@ import {
 } from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 
 /** Detail of the `navigation-push` / `navigation-pop` delegation event. */
 export interface NavigationDelegateDetail {
@@ -142,18 +143,24 @@ export class AdwNavigationSplitView extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        const sidebarChildren = Array.from(this.querySelectorAll(':scope > [slot="sidebar"]'));
-        const contentChildren = Array.from(this.querySelectorAll(':scope > [slot="content"]'));
-
         this._sidebarEl = document.createElement('div');
         this._sidebarEl.className = 'adw-nsv-sidebar';
-        for (const child of sidebarChildren) this._sidebarEl.appendChild(child);
 
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-nsv-content';
-        for (const child of contentChildren) this._contentEl.appendChild(child);
 
-        this.replaceChildren(this._sidebarEl, this._contentEl);
+        // Both panes stay LIVE. `adw_navigation_split_view_set_sidebar` is a property
+        // setter, callable whenever, so a pane appended after connect has to reach the
+        // pane box AND the state that decides the stack — which is what `_mountPane` does
+        // on the way. `src/slotted-children.ts` has the incident.
+        bindSlottedChildren(
+            this,
+            [
+                { name: 'sidebar', into: this._sidebarEl },
+                { name: 'content', into: this._contentEl },
+            ],
+            (_node, slot) => this._mountPane(slot.name === 'sidebar' ? 'sidebar' : 'content'),
+        ).install(this._sidebarEl, this._contentEl);
 
         // Parse-time attributes are the CONSTRUCTION properties, as in the overlay view:
         // applying them as sequential setters emits a transition for a state the markup
@@ -175,12 +182,28 @@ export class AdwNavigationSplitView extends HTMLElement {
         // Which children EXIST decides the stack, so the panes are mounted into the state
         // and not merely into the DOM — a lone child stays visible whatever
         // `show-content` says, which two CSS classes cannot express.
-        this._state.setSidebar(sidebarChildren.length > 0 ? { tag: this._tagOf(sidebarChildren) } : null);
-        this._state.setContent(contentChildren.length > 0 ? { tag: this._tagOf(contentChildren) } : null);
+        this._mountPane('sidebar');
+        this._mountPane('content');
         this._state.subscribe(() => {
             this._reflectShowContent();
             this._syncClasses();
         });
+    }
+
+    /**
+     * Mount whatever a pane box currently HOLDS into the state — `null` while it is empty.
+     *
+     * Re-mounting an unchanged pane re-emits the plan, because the state compares the page
+     * ref by identity. Both subscribers are idempotent reflections (an attribute and a
+     * class list), so a second child in the same pane costs a repaint decision and never a
+     * navigation event.
+     */
+    private _mountPane(pane: 'sidebar' | 'content'): void {
+        const box = pane === 'sidebar' ? this._sidebarEl : this._contentEl;
+        const children = Array.from(box.children);
+        const page = children.length > 0 ? { tag: this._tagOf(children) } : null;
+        if (pane === 'sidebar') this._state.setSidebar(page);
+        else this._state.setContent(page);
     }
 
     /** `Adw.NavigationPage:tag` off the slotted pane, or `null` when untagged. */

--- a/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-overlay-split-view.ts
@@ -26,6 +26,7 @@ import {
 } from '@gjsify/adwaita-core';
 
 import { bindBreakpointSetter } from '../breakpoints.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 
 /**
  * The reveal spring, as a CSS-timed animator: libadwaita animates with a spring
@@ -173,28 +174,26 @@ export class AdwOverlaySplitView extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        const sidebarChildren = Array.from(this.querySelectorAll('[slot="sidebar"]'));
-        const contentChildren = Array.from(this.querySelectorAll('[slot="content"]'));
-        const unslotted = Array.from(this.childNodes).filter(
-            (n) => !sidebarChildren.includes(n as Element) && !contentChildren.includes(n as Element),
-        );
-
-        this.replaceChildren();
-
         this._sidebarEl = document.createElement('div');
         this._sidebarEl.className = 'adw-osv-sidebar';
-        sidebarChildren.forEach((c) => this._sidebarEl.appendChild(c));
 
         this._contentEl = document.createElement('div');
         this._contentEl.className = 'adw-osv-content';
-        contentChildren.forEach((c) => this._contentEl.appendChild(c));
-        unslotted.forEach((c) => this._contentEl.appendChild(c));
 
         this._backdropEl = document.createElement('div');
         this._backdropEl.className = 'adw-osv-backdrop';
         this._backdropEl.addEventListener('click', () => this.hideSidebar());
 
-        this.append(this._sidebarEl, this._contentEl, this._backdropEl);
+        // Both panes stay LIVE, and the unnamed slot is the content — the
+        // Adw.OverlaySplitView buildable default. `src/slotted-children.ts` has the
+        // incident. The routing also stops at the DIRECT children, which the two
+        // selectors here did not: `[slot="sidebar"]` matched at any depth, so a nested
+        // split view's sidebar was stolen into the outer one's pane.
+        bindSlottedChildren(this, [
+            { name: 'sidebar', into: this._sidebarEl },
+            { name: 'content', into: this._contentEl },
+            { into: this._contentEl },
+        ]).install(this._sidebarEl, this._contentEl, this._backdropEl);
 
         // The attributes present at parse time ARE the construction options —
         // `Adw.OverlaySplitView` is built with its properties, not built and then

--- a/packages/web/adwaita-web/src/elements/adw-preferences-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-preferences-dialog.ts
@@ -50,6 +50,7 @@
 
 import type { PreferencesSearchResult, SearchPreferencesOptions } from '@gjsify/adwaita-core';
 import { searchPreferencesDom } from '../preferences-search.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 import { AdwModalSurface } from './modal-surface.js';
 
 const DEFAULT_CONTENT_WIDTH = 640;
@@ -207,12 +208,6 @@ export class AdwPreferencesDialog extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        // The page ELEMENTS move into the body intact — their title / name / icon-name
-        // are what a search result subtitle and a view switcher read — and any unwrapped
-        // children follow them (Adw.PreferencesDialog's buildable default adds a child
-        // as a page).
-        const declared = Array.from(this.childNodes);
-
         // Clicking the scrim dismisses the dialog, or raises close-attempt when locked.
         this._scrimEl = document.createElement('div');
         this._scrimEl.className = 'adw-preferences-dialog-scrim';
@@ -253,12 +248,16 @@ export class AdwPreferencesDialog extends HTMLElement {
 
         this._pagesEl = document.createElement('div');
         this._pagesEl.className = 'adw-preferences-dialog-pages';
-        for (const child of declared) this._pagesEl.appendChild(child);
         this._bodyEl.appendChild(this._pagesEl);
 
         this._dialogEl.append(header, this._bodyEl);
 
-        this.replaceChildren(this._scrimEl, this._dialogEl);
+        // The page ELEMENTS move into the body intact — their title / name / icon-name are
+        // what a search result subtitle and a view switcher read — and any unwrapped child
+        // follows them (the Adw.PreferencesDialog buildable default adds a child as a
+        // page). LIVE, because `adw_preferences_dialog_add` works at any point in the
+        // dialog's life. `src/slotted-children.ts` has the incident.
+        bindSlottedChildren(this, [{ into: this._pagesEl }]).install(this._scrimEl, this._dialogEl);
 
         // The role, `aria-modal`, Escape (Adw.Dialog's shortcut → `maybe_close_cb`), the
         // Tab trap and the return-focus.

--- a/packages/web/adwaita-web/src/elements/adw-preferences-group.ts
+++ b/packages/web/adwaita-web/src/elements/adw-preferences-group.ts
@@ -24,6 +24,8 @@
 
 import { derivePreferencesGroupHeader } from '@gjsify/adwaita-core';
 
+import { bindSlottedChildren } from '../slotted-children.js';
+
 /** A child that asked to sit in the header rather than in the boxed list. */
 function isHeaderSuffix(node: Node): boolean {
     return node instanceof Element && node.getAttribute('slot') === 'header-suffix';
@@ -36,6 +38,12 @@ export class AdwPreferencesGroup extends HTMLElement {
     private _suffixEl!: HTMLDivElement;
     private _listboxEl!: HTMLDivElement;
     private _initialized = false;
+    /**
+     * Watches the two BOXES, not the host: the routing of a host child is
+     * `src/slotted-children.ts`'s job now, and what is left here is the header derivation,
+     * whose inputs are the row count and whether a suffix exists. A removal straight out of
+     * the listbox changes both and reaches no other callback.
+     */
     private _observer: MutationObserver | null = null;
 
     static get observedAttributes() {
@@ -55,10 +63,11 @@ export class AdwPreferencesGroup extends HTMLElement {
      * `adw_preferences_group_add`: a row goes into the boxed list, a `header-suffix`
      * child into the header.
      *
-     * Exposed as a method AND wired to a `MutationObserver` on the host, because both
-     * spellings occur — `group.addRow(row)` in code, `group.append(row)` from a
-     * framework's rendering — and a bare child of the host would sit outside the card,
-     * invisible to the row count that decides whether the card is painted at all.
+     * Kept as a method as well as a slot, because both spellings occur —
+     * `group.addRow(row)` in code, `group.append(row)` from a framework's rendering — and a
+     * bare child of the host would sit outside the card, invisible to the row count that
+     * decides whether the card is painted at all. The `append` spelling is routed by
+     * `src/slotted-children.ts`, which every other slotted element now shares.
      */
     addRow(child: Node): void {
         if (isHeaderSuffix(child)) this._suffixEl.appendChild(child);
@@ -81,14 +90,10 @@ export class AdwPreferencesGroup extends HTMLElement {
 
     connectedCallback() {
         if (this._initialized) {
-            this._observeHost();
+            this._observeBoxes();
             return;
         }
         this._initialized = true;
-
-        const children = Array.from(this.childNodes);
-        const suffixChildren = children.filter(isHeaderSuffix);
-        const rowChildren = children.filter((child) => !suffixChildren.includes(child));
 
         this._headerEl = document.createElement('div');
         this._headerEl.className = 'adw-preferences-group-header';
@@ -106,26 +111,31 @@ export class AdwPreferencesGroup extends HTMLElement {
 
         this._suffixEl = document.createElement('div');
         this._suffixEl.className = 'adw-preferences-group-suffix';
-        for (const child of suffixChildren) this._suffixEl.appendChild(child);
 
         this._headerEl.append(labels, this._suffixEl);
 
         this._listboxEl = document.createElement('div');
         this._listboxEl.className = 'adw-preferences-group-listbox';
-        for (const child of rowChildren) this._listboxEl.appendChild(child);
 
-        this.replaceChildren(this._headerEl, this._listboxEl);
+        bindSlottedChildren(
+            this,
+            [{ name: 'header-suffix', into: this._suffixEl }, { into: this._listboxEl }],
+            // Redundant while this group is connected — the listbox record covers it — and
+            // the only thing that covers it while it is DETACHED, where `_observeBoxes` is
+            // deliberately off. A row appended to a parked group must be right when it
+            // comes back, not one derivation behind.
+            () => this._renderHeader(),
+        ).install(this._headerEl, this._listboxEl);
         // adw-preferences-group.c:319 — GTK_ACCESSIBLE_ROLE_GROUP. A GROUP, not a list:
         // that is why the rows inside carry no `listitem` role, which outside a list
         // would be worse than none.
         this.setAttribute('role', 'group');
 
-        this._renderHeader();
-        this._observeHost();
+        this._observeBoxes();
     }
 
     disconnectedCallback() {
-        // The observer holds this element alive through the host node; drop it
+        // The observer holds this element alive through the boxes it watches; drop it
         // with the connection that created it, not at some later "cleanup".
         this._observer?.disconnect();
         this._observer = null;
@@ -136,35 +146,26 @@ export class AdwPreferencesGroup extends HTMLElement {
     }
 
     /**
-     * Adopt children appended to the HOST after the subtree was built, so
-     * `group.append(row)` behaves like `adw_preferences_group_add`.
+     * Re-derive the header whenever the two boxes change, in EITHER direction.
      *
      * C gets this for free: `gtk_widget_observe_children` on the listbox drives
-     * `update_listbox_visibility` through `items-changed`. A DOM element needs the
-     * observer for the same rule to hold over time rather than only at connect.
+     * `update_listbox_visibility` through `items-changed`. A DOM element needs the observer
+     * for the same rule to hold over time rather than only at connect. Adoption is not what
+     * this watches — a row appended to the host reaches the listbox through the shared slot
+     * routing, and lands here as the listbox record it causes. A row REMOVED straight out
+     * of the listbox reaches no other callback at all, and it still changes the row count.
      */
-    private _observeHost(): void {
+    private _observeBoxes(): void {
         if (this._observer) return;
-        this._observer = new MutationObserver((records) => {
-            for (const record of records) {
-                // Only the HOST's own children need re-homing. Records from the listbox are
-                // the CONSEQUENCE of that move; re-adopting them would append each row a
-                // second time and reorder the list.
-                if (record.target !== this) continue;
-                for (const node of record.addedNodes) {
-                    if (!(node instanceof Element)) continue;
-                    if (node === this._headerEl || node === this._listboxEl) continue;
-                    this.addRow(node);
-                }
-            }
-            // A removal straight out of the listbox still changes the row count.
-            this._renderHeader();
-        });
-        this._observer.observe(this, { childList: true });
+        this._observer = new MutationObserver(() => this._renderHeader());
         this._observer.observe(this._listboxEl, { childList: true });
         // The suffix too: `hasHeaderSuffix` is an INPUT to the header derivation, so a
         // suffix appended after connect left the header hidden on a group with no title.
         this._observer.observe(this._suffixEl, { childList: true });
+        // Arming and deriving are ONE act, as in `src/empty-sections.ts`: a group that was
+        // parked, filled and re-attached would otherwise come back showing the header state
+        // it had when it left.
+        this._renderHeader();
     }
 
     private _renderHeader() {

--- a/packages/web/adwaita-web/src/elements/adw-status-page.ts
+++ b/packages/web/adwaita-web/src/elements/adw-status-page.ts
@@ -10,6 +10,7 @@
 import { stringIsNotEmpty } from '@gjsify/adwaita-core';
 
 import { bindEmptySections } from '../empty-sections.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 import { type AdwIcon, createAdwIcon } from './adw-icon.js';
 
 export class AdwStatusPage extends HTMLElement {
@@ -27,8 +28,6 @@ export class AdwStatusPage extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        const children = Array.from(this.childNodes);
-
         this._iconEl = createAdwIcon(null, 'adw-status-page-icon');
 
         this._titleEl = document.createElement('span');
@@ -39,9 +38,16 @@ export class AdwStatusPage extends HTMLElement {
 
         this._childEl = document.createElement('div');
         this._childEl.className = 'adw-status-page-child';
-        for (const child of children) this._childEl.appendChild(child);
 
-        this.replaceChildren(this._iconEl, this._titleEl, this._descEl, this._childEl);
+        // `Adw.StatusPage:child` is a property, so the action a status page offers can be
+        // set at any point — a button appended after connect has to land in the child box,
+        // not beside it. `src/slotted-children.ts` has the incident.
+        bindSlottedChildren(this, [{ into: this._childEl }]).install(
+            this._iconEl,
+            this._titleEl,
+            this._descEl,
+            this._childEl,
+        );
         // `_render` only ever runs from `attributeChangedCallback`, which an action
         // appended into the child slot after connect does not trigger.
         bindEmptySections(this._childEl);

--- a/packages/web/adwaita-web/src/elements/adw-toast-overlay.ts
+++ b/packages/web/adwaita-web/src/elements/adw-toast-overlay.ts
@@ -19,6 +19,7 @@
 
 import { AdwToast, AdwToastQueue } from '@gjsify/adwaita-core';
 
+import { bindSlottedChildren } from '../slotted-children.js';
 import { createAdwIcon } from './adw-icon.js';
 import type { ToastScheduler, ToastTimerHandle } from '@gjsify/adwaita-core';
 
@@ -86,16 +87,17 @@ export class AdwToastOverlay extends HTMLElement {
         if (this._initialized) return;
         this._initialized = true;
 
-        // The declared children become the wrapped content (Adw.ToastOverlay:child);
-        // the toast container is layered over the bottom edge.
+        // The children become the wrapped content (Adw.ToastOverlay:child); the toast
+        // container is layered over the bottom edge. LIVE, because the overlay is the
+        // outermost widget of a window and the app it wraps is very often appended to it
+        // after it exists. `src/slotted-children.ts` has the incident.
         const content = document.createElement('div');
         content.className = 'adw-toast-overlay-content';
-        for (const child of Array.from(this.childNodes)) content.appendChild(child);
 
         this._toasts = document.createElement('div');
         this._toasts.className = 'adw-toast-overlay-toasts';
 
-        this.replaceChildren(content, this._toasts);
+        bindSlottedChildren(this, [{ into: content }]).install(content, this._toasts);
     }
 
     /**

--- a/packages/web/adwaita-web/src/elements/adw-toolbar-view.ts
+++ b/packages/web/adwaita-web/src/elements/adw-toolbar-view.ts
@@ -32,6 +32,7 @@ import {
 } from '@gjsify/adwaita-core';
 import { bindEmptySections } from '../empty-sections.js';
 import { AdwScrollShading } from '../scroll-shading.js';
+import { bindSlottedChildren } from '../slotted-children.js';
 
 export class AdwToolbarView extends HTMLElement {
     private _topEl!: HTMLDivElement;
@@ -71,31 +72,35 @@ export class AdwToolbarView extends HTMLElement {
         if (!this._initialized) {
             this._initialized = true;
 
-            const topChildren = Array.from(this.querySelectorAll(':scope > [slot="top"]'));
-            const bottomChildren = Array.from(this.querySelectorAll(':scope > [slot="bottom"]'));
-            const contentChildren = Array.from(this.childNodes).filter(
-                (n) => !topChildren.includes(n as Element) && !bottomChildren.includes(n as Element),
-            );
-
             this._topEl = document.createElement('div');
             this._topEl.className = 'adw-toolbar-view-top';
-            for (const child of topChildren) this._topEl.appendChild(child);
 
             this._contentEl = document.createElement('div');
             this._contentEl.className = 'adw-toolbar-view-content';
-            for (const child of contentChildren) this._contentEl.appendChild(child);
 
             this._bottomEl = document.createElement('div');
             this._bottomEl.className = 'adw-toolbar-view-bottom';
-            for (const child of bottomChildren) this._bottomEl.appendChild(child);
+
+            // `topBar` invites an imperative append, and a DECLARED `slot="top"` bar has to
+            // reach the same box whenever it is written — including after connect, which a
+            // snapshot here cannot see. The unnamed slot is the content, the
+            // Adw.ToolbarView buildable default. `src/slotted-children.ts` has the incident.
+            bindSlottedChildren(this, [
+                { name: 'top', into: this._topEl },
+                { name: 'bottom', into: this._bottomEl },
+                { into: this._contentEl },
+            ]).install(this._topEl, this._contentEl, this._bottomEl);
 
             // A bar appended imperatively — which `topBar` invites — is a childList
             // change, not an attribute one, so the empty/non-empty decision cannot be a
             // one-shot read here. The ResizeObserver below then sees the bar go 0 → 48
             // and the undershoot classes follow on their own.
+            //
+            // AFTER the slot routing, and that order is load-bearing: this derives once
+            // SYNCHRONOUSLY, so on empty boxes it hides both and only un-hides them a
+            // microtask later — long after `_syncClasses` has measured a declared bar at
+            // `offsetHeight` 0 and dropped the undershoot classes for good.
             bindEmptySections(this._topEl, this._bottomEl);
-
-            this.replaceChildren(this._topEl, this._contentEl, this._bottomEl);
         }
 
         // `update_undershoots` runs from size_allocate, so the classes have to

--- a/packages/web/adwaita-web/src/slotted-children.spec.ts
+++ b/packages/web/adwaita-web/src/slotted-children.spec.ts
@@ -1,0 +1,227 @@
+// Slot adoption, driven in both directions — declared at parse time and appended after
+// connect — and required to reach the SAME place.
+//
+// The invariant this file exists for is an EQUALITY, not a presence: "the child is
+// somewhere in the subtree" was true of the bug too. Before `src/slotted-children.ts` a
+// `slot="suffix"` control appended after connect stayed a direct child of the host,
+// beside the internal sections rather than inside one — still in the subtree, still
+// findable by `querySelector`, and laid out somewhere else entirely. So every assertion
+// below compares the declared placement against the appended one, box path AND index.
+//
+// The second half is DERIVED, for the reason `connect-lifecycle.spec.ts` gives about its
+// own driver: a per-widget slot spec is one more spec per widget to forget. It reads the
+// bindings back off the registered elements (`slottedChildrenOf`), so an element that
+// gains a slot enrols itself, and one that stops binding drops out of the driver visibly
+// instead of silently.
+import { describe, expect, it } from '@gjsify/unit';
+
+import * as adwaitaWeb from './index.js';
+import { bindSlottedChildren, slottedChildrenOf } from './slotted-children.js';
+
+/** One microtask checkpoint — where a MutationObserver callback lands. */
+const settle = () => Promise.resolve();
+
+/** A host mounted in the document, since adoption is only interesting where a widget is. */
+function mounted<T extends HTMLElement>(el: T): T {
+    document.body.appendChild(el);
+    return el;
+}
+
+/**
+ * WHERE inside `host` a node sits: the chain of boxes down to its parent, plus its index
+ * among that parent's child nodes.
+ *
+ * The index is half the point. Two children that both reached the right box in the wrong
+ * order share a path, and a driver that stopped at the path would call that agreement.
+ */
+function placement(host: Element, node: Node): string {
+    if (node.parentNode === null) return 'detached';
+    if (!host.contains(node)) return 'outside';
+    const steps: string[] = [];
+    for (let el = node.parentElement; el !== null && el !== host; el = el.parentElement) {
+        const classes = [...el.classList].sort().join('.');
+        steps.unshift(classes === '' ? el.localName : `${el.localName}.${classes}`);
+    }
+    const index = Array.from(node.parentNode.childNodes).indexOf(node as ChildNode);
+    return `${steps.join(' > ')}[${index}]`;
+}
+
+/** A probe carrying a slot name, or none at all for the default slot. */
+function probe(slot: string | undefined, id: string): HTMLElement {
+    const el = document.createElement('div');
+    if (slot !== undefined) el.setAttribute('slot', slot);
+    el.dataset.probe = id;
+    return el;
+}
+
+export const AdwSlottedChildrenTest = async () => {
+    await describe('bindSlottedChildren', async () => {
+        await it('routes the children it was installed over, in document order', async () => {
+            const host = mounted(document.createElement('div'));
+            const first = probe('side', 'a');
+            const second = probe(undefined, 'b');
+            const third = probe('side', 'c');
+            host.append(first, second, third);
+
+            const side = document.createElement('div');
+            side.className = 'side';
+            const body = document.createElement('div');
+            body.className = 'body';
+            bindSlottedChildren(host, [{ name: 'side', into: side }, { into: body }]).install(side, body);
+
+            const report = [first, second, third].map((el) => placement(host, el)).join(' | ');
+            host.remove();
+            expect(report).toBe('div.side[0] | div.body[0] | div.side[1]');
+        });
+
+        await it('routes a child APPENDED after install to the same box, at the next index', async () => {
+            const host = mounted(document.createElement('div'));
+            const declared = probe('side', 'a');
+            host.append(declared);
+
+            const side = document.createElement('div');
+            side.className = 'side';
+            bindSlottedChildren(host, [{ name: 'side', into: side }]).install(side);
+
+            const late = probe('side', 'b');
+            host.append(late);
+            await settle();
+
+            const report = `${placement(host, declared)} | ${placement(host, late)}`;
+            host.remove();
+            expect(report).toBe('div.side[0] | div.side[1]');
+        });
+
+        await it('leaves a child whose slot name nothing declares where the author put it', async () => {
+            const host = mounted(document.createElement('div'));
+            const side = document.createElement('div');
+            side.className = 'side';
+            // No default slot: with one, an unmatched NAME would silently become default
+            // content and render in the wrong box looking deliberate. The native assignment
+            // algorithm assigns it nowhere, and so does this.
+            bindSlottedChildren(host, [{ name: 'side', into: side }]).install(side);
+
+            const typo = probe('sied', 'a');
+            host.append(typo);
+            await settle();
+
+            const report = placement(host, typo);
+            host.remove();
+            expect(report).toBe('[1]');
+        });
+
+        await it('re-adopts a child that was appended, removed and appended again', async () => {
+            const host = mounted(document.createElement('div'));
+            const side = document.createElement('div');
+            side.className = 'side';
+            bindSlottedChildren(host, [{ name: 'side', into: side }]).install(side);
+
+            const child = probe('side', 'a');
+            host.append(child);
+            await settle();
+            const first = `${placement(host, child)} n=${side.childElementCount}`;
+
+            child.remove();
+            await settle();
+            const gone = `${placement(host, child)} n=${side.childElementCount}`;
+
+            host.append(child);
+            await settle();
+            // n=1, not n=2: the node is MOVED back rather than copied, and the removal left
+            // no placeholder behind for it to be adopted alongside.
+            const again = `${placement(host, child)} n=${side.childElementCount}`;
+
+            host.remove();
+            expect(`${first} / ${gone} / ${again}`).toBe('div.side[0] n=1 / detached n=0 / div.side[0] n=1');
+        });
+
+        await it('hands a consumed child to the call and leaves nothing of it in the host', async () => {
+            const host = mounted(document.createElement('div'));
+            const taken: string[] = [];
+            const body = document.createElement('div');
+            body.className = 'body';
+            bindSlottedChildren(host, [
+                {
+                    claims: (node) => node instanceof Element && node.localName === 'meta',
+                    consume: (node) => taken.push((node as Element).getAttribute('name') ?? ''),
+                },
+                { into: body },
+            ]).install(body);
+
+            const data = document.createElement('meta');
+            data.setAttribute('name', 'late');
+            host.append(data);
+            await settle();
+
+            const report = `${taken.join(',')} | ${placement(host, data)} | body=${body.childElementCount}`;
+            host.remove();
+            expect(report).toBe('late | detached | body=0');
+        });
+    });
+
+    // Every registered element that binds a slot, both ways round. This is the driver the
+    // fix exists for: an element is asked for its own slots and then required to put a
+    // declared child and an appended one in the same place.
+    await describe('every slotted element adopts a late child where it adopts a declared one', async () => {
+        const tags: string[] = [];
+        for (const exported of Object.values(adwaitaWeb)) {
+            if (typeof exported !== 'function' || !(exported.prototype instanceof HTMLElement)) continue;
+            const tag = customElements.getName(exported as CustomElementConstructor);
+            if (tag !== null) tags.push(tag);
+        }
+        tags.sort();
+
+        /** The distinct slot names one element declares — `undefined` is its default slot. */
+        function slotNames(tag: string): Array<string | undefined> {
+            const el = mounted(document.createElement(tag));
+            const binding = slottedChildrenOf(el);
+            el.remove();
+            if (binding === undefined) return [];
+            const names = new Set<string | undefined>();
+            for (const slot of binding.slots) names.add(slot.name);
+            return [...names];
+        }
+
+        const slotted = tags.map((tag) => [tag, slotNames(tag)] as const).filter(([, names]) => names.length > 0);
+
+        await it('finds the elements that declare slots', () => {
+            // A driver that scans nothing passes vacuously and reports a green it never
+            // earned. A FLOOR, not an exact count: the point of deriving the list is that it
+            // grows without this file being edited.
+            expect(`slotted elements: ${slotted.length > 8}`).toBe('slotted elements: true');
+        });
+
+        for (const [tag, names] of slotted) {
+            for (const name of names) {
+                const label = name ?? '(default)';
+                await it(`<${tag}> slot="${label}"`, async () => {
+                    // TWO children per slot, so the comparison pins ORDER and not only the box.
+                    const declaredHost = document.createElement(tag);
+                    const declaredA = probe(name, 'a');
+                    const declaredB = probe(name, 'b');
+                    declaredHost.append(declaredA, declaredB);
+                    mounted(declaredHost);
+
+                    const lateHost = mounted(document.createElement(tag));
+                    const lateA = probe(name, 'a');
+                    const lateB = probe(name, 'b');
+                    lateHost.append(lateA);
+                    lateHost.append(lateB);
+                    await settle();
+
+                    const declared = [declaredA, declaredB].map((el) => placement(declaredHost, el)).join(' | ');
+                    const late = [lateA, lateB].map((el) => placement(lateHost, el)).join(' | ');
+                    // Measure, THEN tear down, THEN assert — the reason
+                    // `connect-lifecycle.spec.ts` gives: a host left on the page pushes every
+                    // later one down and turns one failure into a cascade naming the wrong
+                    // widget.
+                    declaredHost.remove();
+                    lateHost.remove();
+                    expect(`<${tag}> slot=${label} appended: ${late}`).toBe(
+                        `<${tag}> slot=${label} appended: ${declared}`,
+                    );
+                });
+            }
+        }
+    });
+};

--- a/packages/web/adwaita-web/src/slotted-children.ts
+++ b/packages/web/adwaita-web/src/slotted-children.ts
@@ -1,0 +1,212 @@
+// Light-DOM slot routing that stays LIVE — "where a `[slot=]` child lands", kept true
+// after connect instead of only at parse time.
+//
+// THE INCIDENT
+//
+// 42 of the element files under `src/elements/` install their own subtree with
+// `this.replaceChildren(…)`, and the ones with slots snapshot the author's children in
+// the line before it — ONCE, inside the `_initialized` guard. Every one of them is
+// therefore a parse-time-only slot. `row.append(icon)` with `slot="prefix"` after connect
+// leaves `icon` as a sibling of the three internal sections rather than inside
+// `prefixSection`, where the byte-identical DECLARED child lands; nothing throws and
+// nothing logs. `adw-header-bar.spec.ts` had the workaround written down as a test
+// convention — "Appended LAST: the sections are built in `connectedCallback`, so the
+// slotted children have to be in place before the bar enters the document" — which is
+// this bug recorded as a house rule.
+//
+// It is wrong for hand-written HTML that appends after load, and it is what ADR 0027 § 9
+// names as the obstacle to one widget vocabulary across GTK, Blueprint, JSX, Vue and this
+// pillar: a renderer mutates its tree after mount by definition, so the same authored
+// markup cannot drive both surfaces while a slot is a one-shot read.
+//
+// WHY A MutationObserver, and not either alternative
+//
+//   - **native `<slot>`** needs a shadow root, and ADR 0010 keeps this package light-DOM
+//     ON PURPOSE: a shadow boundary is symmetric, so it would block the host page's CSS
+//     from overriding IN, which is the overridability the `--adw-*` token contract sells.
+//     That ADR lists native `<slot>` as part of the deferred shadow path and gates it
+//     behind an ADR of its own — so it is not an option available to this fix. No element
+//     in the package calls `attachShadow` today.
+//   - **re-homing from the CHILD's `connectedCallback`** only reaches children that are
+//     themselves custom elements: a plain `<button slot="suffix">` and a bare text node
+//     have no callback, and both are slotted here today. It also inverts ownership —
+//     every child would have to know its parent's internal structure — so it cannot live
+//     in ONE place, which is the whole point of this module. And `connectedCallback`
+//     fires on every re-parent of the subtree, so it would re-home on a move that changed
+//     nothing.
+//
+// The observer is also the technique this package already reached for twice for the same
+// "evaluated once at connect time" class: `<adw-clamp>` for its child width, and
+// `src/empty-sections.ts` for the `hidden` derivation.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO: reorder.
+//
+// A late child is APPENDED to its destination, which is where a parse-time child in the
+// same position lands. Nothing finer is expressible: `host.insertBefore(child, ref)` with
+// an already-adopted `ref` throws `NotFoundError` in the DOM before this module is
+// reached, because `ref` is no longer a child of the host. Order fidelity under reordering
+// is a property of native `<slot>`, i.e. of the shadow path ADR 0010 § 3 defers — until
+// then a renderer that reorders must reorder inside the destination it was given, and
+// that divergence is written down here rather than absorbed.
+//
+// NOTHING TO TEAR DOWN, deliberately. The observed node is the HOST, so the observer is
+// unreachable the moment the element is and is collected with it — the same reasoning
+// `src/empty-sections.ts` writes above its own. Only a binding that reaches OUTSIDE
+// (document, window, a media query) has to be released on disconnect and re-established
+// on every connect, which is what `scripts/check-adwaita-connect-rebind.mjs` polices.
+// Staying bound while detached is also the better behaviour: a child appended to a parked
+// widget is already in the right place when it comes back.
+
+export interface AdwSlotClaim {
+    /** The `slot="…"` value claimed. Omit for the DEFAULT slot — everything else. */
+    readonly name?: string;
+    /**
+     * Claim by NODE as well as by slot name, for the typed-child spelling
+     * (`<adw-alert-response>` IS the slot) and for a default that takes only some node
+     * kinds (`<adw-entry-row>` adopts elements and drops stray whitespace, as GtkBuildable
+     * does). Tried after an explicit `slot=` name and before the default, so a claim can
+     * never swallow a child that named a different slot.
+     */
+    readonly claims?: (node: Node) => boolean;
+}
+
+/** A destination that RE-HOMES what it claims — the ordinary slot. */
+export interface AdwSlotInto extends AdwSlotClaim {
+    readonly into: HTMLElement;
+}
+
+/**
+ * A slot whose child is consumed by a CALL rather than by a move: either data —
+ * `<adw-alert-response id="ok">` is read for its id, label and appearance and then gone,
+ * exactly as GtkBuilder leaves nothing of a `<responses>` entry in the widget tree — or a
+ * widget whose insertion rule is the element's own (`addPrefix` PREPENDS, mirroring
+ * `gtk_box_prepend`). A node the call did not move out of the host is dropped, so a
+ * data-only child cannot linger as a stray sibling of the internal structure.
+ */
+export interface AdwSlotConsume extends AdwSlotClaim {
+    readonly consume: (node: Node) => void;
+}
+
+export type AdwSlot = AdwSlotInto | AdwSlotConsume;
+
+export interface AdwSlottedChildren {
+    /** The declared slots, so a driver can probe them without a hand-written ledger. */
+    readonly slots: readonly AdwSlot[];
+    /**
+     * Route the host's CURRENT children into their slots, then make `structure` the
+     * host's own children, then stay live.
+     *
+     * The three steps are one call because their ORDER is the invariant: the author's
+     * children have to leave the host before it is emptied, or `replaceChildren` destroys
+     * them — the bug `<adw-entry-row>` records above its own `_authored` snapshot. Passing
+     * `structure` here also means the set this module must never route is DERIVED from the
+     * call that installs it, rather than a second list to keep in sync.
+     *
+     * Call once per built subtree; a second call replaces the observer rather than
+     * stacking one.
+     */
+    install(...structure: readonly Node[]): void;
+    /** The slot `node` belongs to, or `null` when none claims it. */
+    slotFor(node: Node): AdwSlot | null;
+}
+
+/** Where a bound host's slots can be read back from — see {@link slottedChildrenOf}. */
+const BOUND = new WeakMap<Element, AdwSlottedChildren>();
+
+/**
+ * The slot binding `host` installed, if it has one.
+ *
+ * This is how `slotted-children.spec.ts` drives EVERY registered element rather than a
+ * list of the ones someone remembered: an element that binds a slot enrols itself in the
+ * placement driver, and one that stops binding drops out of it visibly.
+ */
+export function slottedChildrenOf(host: Element): AdwSlottedChildren | undefined {
+    return BOUND.get(host);
+}
+
+/**
+ * Bind `host`'s light-DOM children to `slots`.
+ *
+ * `onAdopt` fires for a child adopted AFTER {@link AdwSlottedChildren.install} and not
+ * during it: the install pass IS the element's own build, which seeds its state on the
+ * next line with everything that landed, so firing there would make every element's build
+ * order depend on how many children the author wrote.
+ */
+export function bindSlottedChildren(
+    host: HTMLElement,
+    slots: readonly AdwSlot[],
+    onAdopt?: (node: Node, slot: AdwSlot) => void,
+): AdwSlottedChildren {
+    const named = new Map<string, AdwSlot>();
+    const typed: Array<[(node: Node) => boolean, AdwSlot]> = [];
+    let fallback: AdwSlot | null = null;
+    for (const slot of slots) {
+        const claims = slot.claims;
+        if (slot.name !== undefined) named.set(slot.name, slot);
+        if (claims !== undefined) typed.push([claims, slot]);
+        if (slot.name === undefined && claims === undefined) fallback = slot;
+    }
+
+    /** The host's OWN children, installed by this module — never routed back into a slot. */
+    let structure: ReadonlySet<Node> = new Set();
+    let observer: MutationObserver | null = null;
+
+    const slotFor = (node: Node): AdwSlot | null => {
+        if (structure.has(node)) return null;
+        // An explicit `slot=` NAME is answered first and answered alone: `slot=""` is the
+        // default slot in the native assignment algorithm, and an unmatched name is
+        // assigned nowhere at all. Both are copied deliberately — a `slot="sufix"` typo
+        // that silently became default content would render in the wrong place and look
+        // intentional, where a child that visibly stays put does not.
+        const name = node instanceof Element ? (node.getAttribute('slot') ?? '') : '';
+        if (name !== '') return named.get(name) ?? null;
+        // Then the typed claims (`<adw-alert-response>` IS the slot), then the default.
+        for (const [claims, slot] of typed) if (claims(node)) return slot;
+        return fallback;
+    };
+
+    const route = (node: Node): AdwSlot | null => {
+        const slot = slotFor(node);
+        if (slot === null) return null;
+        if ('into' in slot) {
+            slot.into.appendChild(node);
+            return slot;
+        }
+        slot.consume(node);
+        // Data, not content: the call read what it needed and left the node where it was,
+        // so it has to go. A `consume` that MOVED the node (`addPrefix`) has already
+        // changed the parent and this is a no-op.
+        if (node.parentNode === host) host.removeChild(node);
+        return slot;
+    };
+
+    const binding: AdwSlottedChildren = {
+        slots,
+        slotFor,
+        install(...nodes: readonly Node[]) {
+            for (const node of Array.from(host.childNodes)) route(node);
+            structure = new Set(nodes);
+            host.replaceChildren(...nodes);
+            // Armed AFTER `replaceChildren`, so its own records are never delivered: an
+            // observer armed first would see the whole of `structure` as added nodes and
+            // spend a microtask rejecting them.
+            observer?.disconnect();
+            observer = new MutationObserver((records) => {
+                for (const record of records) {
+                    // Only the HOST's own child list. A destination's records are the
+                    // CONSEQUENCE of a move, and re-routing them appends each child a
+                    // second time — the reason `<adw-preferences-group>` filtered on
+                    // `record.target` back when it was the only element doing this.
+                    if (record.target !== host) continue;
+                    for (const node of record.addedNodes) {
+                        const slot = route(node);
+                        if (slot !== null) onAdopt?.(node, slot);
+                    }
+                }
+            });
+            observer.observe(host, { childList: true });
+        },
+    };
+    BOUND.set(host, binding);
+    return binding;
+}

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -49,6 +49,7 @@ import { AdwAccentTest } from './adw-accent.spec.js';
 import { AdwShortcutLabelTest } from './adw-shortcut-label.spec.js';
 import { AdwConnectLifecycleTest } from './connect-lifecycle.spec.js';
 import { AdwEmptySectionsTest } from './empty-sections.spec.js';
+import { AdwSlottedChildrenTest } from './slotted-children.spec.js';
 import { AdwKeyboardOperableTest } from './keyboard-operable.spec.js';
 import { AdwFontsTest } from './adw-fonts.spec.js';
 
@@ -56,6 +57,7 @@ run({
     AdwKeyboardOperableTest,
     AdwConnectLifecycleTest,
     AdwEmptySectionsTest,
+    AdwSlottedChildrenTest,
     AdwStyleClassesTest,
     AdwAccentTest,
     AdwShortcutLabelTest,


### PR DESCRIPTION
An element re-homed its `[slot=]` children once, in `connectedCallback`, so a child
appended afterwards was never adopted. That is wrong for hand-written HTML that
appends, and it is what ADR 0027 § 9 names as the obstacle to one widget vocabulary
across surfaces — a renderer mutates its tree after mount by definition.

## The published numbers were wrong, on both sides

`status/open-todos.md` and ADR 0027 § 9 both say *"42 of 51 element files … only two
adopt children appended later"*. Measured on this tree, and independently
re-measured against `origin/main`:

| | claimed | real |
|---|---|---|
| element files | 51 | **55 files, 50 defining elements** — 51 matches neither |
| re-home children once | 42 | **23** — 42 is the count of files calling `replaceChildren`, i.e. *"installs its own subtree"*, not *"has a slot"* |
| adopt a late child | 2 | **1** (`adw-preferences-group`). The other, `adw-clamp`, restyles children in place and never re-homes one |

A live count inside a comment, drifting exactly as the root AGENTS.md warns. A
follow-up corrects the two documents; they are outside this package's scope.

## The mechanism, and the two alternatives it beat

`src/slotted-children.ts` is the single owner. `bindSlottedChildren(host, slots)` →
`install(...structure)` routes, installs and observes in one call, and **`install`
owning the `replaceChildren` is the load-bearing part**: the set of nodes the router
must never re-route is *derived from the call that installs it*, instead of being a
second list to keep in sync. Assignment copies the native algorithm — an explicit
`slot=` name wins and, if unmatched, assigns nowhere; then typed claims; then the
default.

A `MutationObserver` on the host, because:

- **Native `<slot>` is unavailable.** No element has a shadow root, and that is a
  decision rather than an omission: ADR 0010 keeps this package light-DOM because a
  shadow boundary is symmetric and would block the host page's CSS from overriding
  *in* — the overridability the `--adw-*` token contract sells.
- **Re-homing from each child's own `connectedCallback`** reaches only children that
  are custom elements; a plain `<button slot="suffix">` and a bare text node are both
  slotted today. It also inverts ownership, so it structurally cannot live in one
  place.
- The observer is the technique this package already reached for twice for the same
  evaluated-once class (`adw-clamp`, `src/empty-sections.ts`).

## Scope

**13 files converted.** 10 left deliberately: 8 consume typed children into a state
model (pages, sections, selection, roving focus), where going live changes semantics
and wants its own conformance vectors rather than a blind conversion; `adw-checks`
routes conditionally on its `label` attribute, so adopting into a labelled checkbox
would render the caption twice; `adw-bottom-sheet` *unwraps* its wrapper elements,
which is a spread rather than a move.

## Two defects found on the way

- `adw-overlay-split-view` queried `[slot="sidebar"]` with no `:scope >`, a
  **descendant** match — a nested split view's sidebar was stolen into the outer
  one's pane. The shared router only ever looks at direct children.
- `adw-preferences-group` dropped its observer in `disconnectedCallback`, so a row
  appended to a parked group was never adopted and the header never re-derived on
  reconnect.

## Measured

    baseline (before any change)        4571 passed, 0 failed
    with the fix                        4604 passed, 0 failed
    fix with liveness disabled (A/B)    4572 passed, 31 FAILED

The A/B disables the single line `observer.observe(host, {childList: true})` and
changes nothing else. The 31 are 3 helper tests, all 27 derived per-element tests,
and one **pre-existing** test whose behaviour the shared router now provides.

The assertions compare a **placement string** — the box chain plus the index among
that parent's child nodes — for a declared child against an appended one, because
"it is in the subtree" was true of the bug too. The driver reads bindings back off
every registered element, so an element that gains a slot enrols itself: 27 tests
across 14 tags with no list written down, plus a floor test that refuses a vacuous
scan.

Exit codes: `check` 0, `build:test:browser` 0, Playwright chromium 0 (3 passed),
scoped `oxlint` 0 (verified non-vacuous with a deliberate probe), scoped `oxfmt`
clean, five `check-adwaita-*` scripts 0 each, comment budget 0.274 against a 0.292
ceiling.

## A trap for whoever converts the remaining 10

`bindEmptySections` derives **synchronously** on call. Routing after it hides a
section a declared child had already earned, and it only un-hides a microtask later —
after `_syncClasses` has measured a bar at `offsetHeight` 0. That cost 8 real
failures on the first run. `bindEmptySections` must come **after** `install`; the
three call sites now say so.
