### PR TITLE
feat(gtk-host): cover the React surface end to end

### DIFF
--- a/packages/framework/gtk-host/type-tests/react/negative-react-plumbing.tsx
+++ b/packages/framework/gtk-host/type-tests/react/negative-react-plumbing.tsx
@@ -1,0 +1,91 @@
+// THE REACT-SPECIFIC PLUMBING — the half of this surface nothing measured.
+//
+// `src/react-jsx-runtime.ts` declares its own `JSX` namespace, and four of its
+// members are React's rather than this repository's: `Element` is a
+// `ReactElement`, `ElementType` is `GtkElementType`, `IntrinsicAttributes` carries
+// only `key`, and `ref`/`children` are React's `Ref<T>`/`ReactNode` spellings. The
+// ADR-0028 § 8 measurements those four answer were taken on the SOLID surface, one
+// file over, and re-derived here by READING. This file re-measures them.
+//
+// Grammar and mechanism: see the header of `negative-tags.tsx`.
+//
+// NOTHING IN THIS FILE IMPORTS `react`, AND THAT IS LOAD-BEARING FOR THE PROBES.
+// `@types/react` declares a GLOBAL `JSX` namespace, so the moment any file in the
+// program imports React's types, all 208 tags it pre-declares become the fallback
+// surface — and probe `evaporate`, which takes `jsxImportSource` away, would land
+// on React's element list instead of on nothing at all. Measured: with a `react`
+// type import present, `evaporate` silences 1 of 8 assertions; without it, 6 of 8.
+// The two React types this file needs (`RefObject`, `ReactNode`) are therefore
+// spelled STRUCTURALLY below; the positives, which no probe compiles, use React's
+// own API.
+//
+// `HostNode` comes in RELATIVELY, and the depth is what makes it work in both
+// programs: this directory and the script's stripped-copy directory
+// (`<pkg>/tmp/type-surfaces`) are both two levels under the package root. If that
+// ever stops holding, the baseline run reports a `TS2307` no directive covers and
+// fails — the mechanism reports itself rather than silently checking less.
+
+import type Gtk from '@girs/gtk-4.0';
+
+import type { HostNode } from '../../src/types.js';
+
+/**
+ * `JSX.Element` is React's `ReactElement` and deliberately NOT a `HostNode`.
+ *
+ * The Solid surface next door declares `Element = HostNode`, because Solid's
+ * control-flow components are typed against host nodes and the first `<For>` in an
+ * application was otherwise a type error. React's control flow is plain JavaScript,
+ * and its `jsx()` builds a renderer-agnostic element record whose host mapping
+ * happens later, in `react-reconciler`. The two files answer different questions
+ * and will keep disagreeing on this line, which is why the disagreement is
+ * ASSERTED rather than left to whoever reaches for the one-line "consistency" fix.
+ */
+// @ts-expect-error TS2322 — a React JSX expression is a ReactElement, never a host node
+export const notAHostNode: HostNode = <gtk-box />;
+
+/**
+ * Only a GTK tag or a component may stand in a tag position.
+ *
+ * `needs=none`: TS2604 comes from TypeScript's own "a tag must be callable" rule
+ * and holds with no JSX surface at all — measured, it is one of the two assertions
+ * that survive `evaporate`. So this pins the tag position being CHECKED, not
+ * `JSX.ElementType` narrowing it; that narrowing is asserted from the positive
+ * side, where `positive-element-is-react.tsx` puts a function component in a tag
+ * position and only `ElementType` admitting `(props) => ReactNode` lets it compile.
+ */
+declare const NotAComponent: { nope: true };
+// @ts-expect-error TS2604 needs=none — a tag position takes a tag or a function, nothing else
+export const nonComponentTag = <NotAComponent />;
+
+/**
+ * `IntrinsicAttributes` carries `key` and NOTHING else.
+ *
+ * TypeScript unions it into the attributes of a COMPONENT and not of an intrinsic
+ * element — the measured reason `ref`, `children` and `key` are declared per
+ * element in `ReactWidgetAttributes` instead. A component therefore gets `key` for
+ * free (`positive-element-is-react.tsx`) and nothing more: an `IntrinsicAttributes`
+ * that had grown a catch-all would accept every misspelled prop on every component
+ * in a consumer's tree, in silence.
+ */
+declare function TakesNoProps(): null;
+// @ts-expect-error TS2322 — IntrinsicAttributes adds `key`, not an escape hatch
+export const unknownComponentProp = <TakesNoProps nope={1} />;
+
+/**
+ * React's `ref` is `Ref<T>` — a callback OR a `useRef`/`createRef` object — and the
+ * `T` is the element's own widget class.
+ *
+ * This is exactly why the React surface does not reuse `JsxAttributes` from
+ * `./attrs.js`: that one types `ref` as `T | ((el: T) => void)`, Solid's spelling,
+ * which rejects the single most common way a React author holds a widget. The
+ * OBJECT form is what this negative exercises, and it is per element — the
+ * diagnostic names `Ref<Box>` itself, so the structural stand-in below reaches the
+ * same type React's `RefObject<Gtk.Button>` would.
+ */
+declare const buttonRef: { readonly current: Gtk.Button | null };
+// @ts-expect-error TS2322 — Ref<T> is per element; a Gtk.Button ref cannot hold a Gtk.Box
+export const wrongRefTarget = <gtk-box ref={buttonRef} />;
+
+/** `children` is React's `ReactNode`, not an arbitrary value. */
+// @ts-expect-error TS2353 — an object literal is not a ReactNode
+export const badChild = <gtk-box children={{ deep: 'wrong' }} />;

--- a/packages/framework/gtk-host/type-tests/react/negative-tags.tsx
+++ b/packages/framework/gtk-host/type-tests/react/negative-tags.tsx
@@ -1,0 +1,46 @@
+// TAG negatives for the REACT dialect: what must NOT be an element.
+//
+// Each line carries a `@ts-expect-error` and is therefore its OWN assertion:
+// TypeScript reports an UNUSED `@ts-expect-error` as an error (TS2578), so the
+// half reduces to "exit code 0" and no error output has to be parsed. The
+// annotation grammar is
+//
+//     // @ts-expect-error TS<code>[ needs=<setting>] — <why>
+//
+// and `scripts/check-type-surfaces.mjs` reads it: it strips the directives into a
+// temp copy to prove each line errors WITH THE ANNOTATED CODE, and `needs=` names
+// the compiler settings whose absence makes that one negative go green — each of
+// which has a probe behind it.
+//
+// `needs=jsxSurface` is IMPLICIT on every negative in a JSX half.
+//
+// WHAT THIS FILE DOES AND DOES NOT DUPLICATE. The element LIST is shared: the
+// React surface's `GtkReactIntrinsicElements` is a mapped type over the same
+// generated `WidgetPropsByTag`/`WidgetClassByTag` the `jsx` half already gates
+// property by property, handler by handler, nick by nick. Re-stating that matrix
+// here would be a second copy that drifts. What is asserted here is that the
+// React runtime REACHES that list at all — the tag negatives below — plus the
+// React-specific plumbing in `negative-react-plumbing.tsx`, which is what had
+// never been measured.
+
+/** A tag no widget answers to. */
+// @ts-expect-error TS2339 — 'gtk-nonsuch' is not a key of JSX.IntrinsicElements
+export const unknownTag = <gtk-nonsuch />;
+
+/**
+ * A DOM tag — the negative that decides the whole design, in React's version of
+ * it.
+ *
+ * Pointing `jsxImportSource` at `"react"` takes the element list from
+ * `@types/react`, and all 208 tags it pre-declares (113 HTML + 4 deprecated HTML +
+ * 59 SVG + 32 MathML) become valid on a GTK renderer: `<div/>` type-checks and
+ * then renders NOTHING. `needs=ownRuntime` is that measurement kept executable —
+ * probe `react-namespace` repoints `jsxImportSource` at `react` and this line, and
+ * only this line, goes green.
+ */
+// @ts-expect-error TS2339 needs=ownRuntime — 'div' must not exist on a GTK surface
+export const domTag = <div />;
+
+/** A tag that is a real GType name but not the kebab spelling JSX consults. */
+// @ts-expect-error TS2304 needs=none — `GtkBox` reads as a value reference, never as an intrinsic
+export const pascalTag = <GtkBox />;

--- a/packages/framework/gtk-host/type-tests/react/positive-element-is-react.tsx
+++ b/packages/framework/gtk-host/type-tests/react/positive-element-is-react.tsx
@@ -1,0 +1,52 @@
+// WHAT A REACT JSX EXPRESSION EVALUATES TO, and what React itself adds to it.
+//
+// `positive.tsx` next door asserts what may go IN. This file asserts what comes
+// OUT and what surrounds it — the four members of the `JSX` namespace that are
+// React's rather than this repository's. `negative-react-plumbing.tsx` holds the
+// same four from the other side; both directions are needed, because a surface
+// that refuses everything scores perfect on negatives alone.
+
+import { Fragment, type ReactElement, type ReactNode } from 'react';
+
+/** A JSX element IS a `ReactElement` — `JSX.Element` says so. */
+export const element: ReactElement = <gtk-label label="a label" />;
+
+/** …and therefore a `ReactNode`, which is what `children` is typed as. */
+declare function render(node: ReactNode): void;
+render(<gtk-button label="Go" />);
+
+/**
+ * A component in a tag position, with `key` supplied by `IntrinsicAttributes`.
+ *
+ * `key` is NOT declared on this component's props. TypeScript unions
+ * `JSX.IntrinsicAttributes` into the attributes of a component, so this is exactly
+ * the one prop it may add — and `negative-react-plumbing.tsx` asserts it adds
+ * nothing else.
+ */
+function Caption({ text }: { readonly text: string }): ReactElement {
+    return <gtk-label label={text} />;
+}
+export const composed = <Caption text="composed" key="only-child" />;
+
+/** `key` on an INTRINSIC element, which `IntrinsicAttributes` does not reach. */
+export const keyedIntrinsic = <gtk-label label="x" key="k" />;
+
+/**
+ * The fragment, in both spellings.
+ *
+ * `<>…</>` compiles to the `Fragment` export of `<jsxImportSource>/jsx-runtime`,
+ * which is why that module re-exports React's own rather than declaring one: the
+ * export NAME is the framework's contract, and a rename is a `MISSING_EXPORT` in a
+ * consumer's build.
+ */
+export const shorthand = (
+    <>
+        <gtk-label label="one" />
+        <gtk-label label="two" />
+    </>
+);
+export const explicit = (
+    <Fragment>
+        <gtk-label label="one" />
+    </Fragment>
+);

--- a/packages/framework/gtk-host/type-tests/react/positive.tsx
+++ b/packages/framework/gtk-host/type-tests/react/positive.tsx
@@ -1,0 +1,71 @@
+// The REACT surface in its WORKING spellings — one per mechanism the negatives
+// then probe from the other side.
+//
+// A positive file cannot detect a misconfigured compiler (that is what
+// `sentinel.tsx` and the probes are for), and it is not here for that. It is here
+// so that a change which breaks a LEGAL spelling fails loudly instead of reading
+// as one more caught negative: every negative in this directory would still be
+// "caught" by a surface that rejects EVERYTHING.
+//
+// Consumers configure exactly what `tsconfig.json` next to this file configures:
+// `"jsx": "react-jsx"` + `"jsxImportSource": "@gjsify/gtk-host/react"`, and
+// TypeScript appends `/jsx-runtime` itself.
+
+import { createRef } from 'react';
+import type Gtk from '@girs/gtk-4.0';
+
+/** Nested children, camelCase props, a kebab-spelled prop and two enum nicks. */
+export const layout = (
+    <gtk-window title="Type surface" defaultWidth={640} heightRequest={200}>
+        <gtk-box orientation="vertical" spacing={6} baseline-child={0}>
+            <gtk-label label="a label" ellipsize="end" />
+            <gtk-button iconName="list-add-symbolic" onClicked={() => {}} />
+        </gtk-box>
+    </gtk-window>
+);
+
+/**
+ * A signal handler whose parameter is ANNOTATED against the GIR signature.
+ *
+ * The handler types are the generated ones the `jsx` half gates from the other
+ * side; what this asserts is that the React surface composes them at all, since
+ * `GtkReactIntrinsicElements` wraps `WidgetPropsByTag` in `WithOnce` and its own
+ * attributes.
+ */
+export const rows = <gtk-list-box onRowActivated={(row: Gtk.ListBoxRow) => row.set_selectable(false)} />;
+
+/** The `.once` spelling `WithOnce` derives for every `on*` prop. */
+export const once = <gtk-button onClickedOnce={() => {}} />;
+
+/** The `on:<raw-signal>` escape hatch, for names the camelCase derivation misses. */
+export const rawSignal = <gtk-button on:clicked={() => {}} />;
+
+/** `slot` routes a child into a container's named slot. */
+export const slotted = (
+    <adw-action-row title="Row">
+        <gtk-switch slot="suffix" />
+    </adw-action-row>
+);
+
+/**
+ * `ref` in BOTH of React's spellings, each carrying the element's own widget type.
+ *
+ * The callback parameter is `Gtk.Box | null` — `RefCallback<T>` is `(instance: T |
+ * null) => void`, so the optional call is React's shape and not defensiveness. The
+ * object form is the one a Solid-shaped `ref` type cannot express at all.
+ */
+export const refCallback = <gtk-box ref={(el) => el?.set_spacing(12)} />;
+export const refObject = <gtk-box ref={createRef<Gtk.Box>()} />;
+
+/**
+ * `children` is OPTIONAL and also assignable as a prop.
+ *
+ * Both halves are asserted deliberately: a `children` declared as REQUIRED makes
+ * every self-closing tag an error (TS2741), and a `children` not declared at all
+ * makes every NESTED element an error (TS2559).
+ */
+export const selfClosing = <gtk-box />;
+export const childrenAsProp = <gtk-box children={<gtk-label label="x" />} />;
+
+/** A widget whose GType carries adjacent capitals, in its JSX (kebab) spelling. */
+export const glArea = <gtk-gl-area hasStencilBuffer={true} />;

--- a/packages/framework/gtk-host/type-tests/react/sentinel.tsx
+++ b/packages/framework/gtk-host/type-tests/react/sentinel.tsx
@@ -1,0 +1,14 @@
+// The non-vacuity sentinel: a deliberate, UNSUPPRESSED type error.
+//
+// Everything else in this directory asserts "exit code 0", and exit 0 is exactly
+// what a compiler that never read a fixture also reports. `tsconfig.sentinel.json`
+// compiles this one file and `scripts/check-type-surfaces.mjs` requires it to FAIL
+// with the code named below — so a run that reports the React half green has
+// proved, in the same invocation, that the harness can still see an error at all.
+//
+// It is a separate program on purpose: kept in the main one it would need a
+// `@ts-expect-error`, and then it would be indistinguishable from the negatives it
+// exists to underwrite.
+
+// expect-error: TS2339 — the harness reports this file's error, or the gate is a no-op.
+export const sentinel = <gtk-this-tag-must-never-exist />;

--- a/packages/framework/gtk-host/type-tests/react/tsconfig.json
+++ b/packages/framework/gtk-host/type-tests/react/tsconfig.json
@@ -1,0 +1,54 @@
+{
+    // The REACT half of the type-surface gate — the third dialect, and the only one
+    // whose JSX runtime is the framework's OWN. Read `scripts/check-type-surfaces.mjs`
+    // for what the halves prove; this file pins only the settings this half REQUIRES,
+    // and each is proved load-bearing by a probe the script generates on every run.
+    //
+    //  - `jsx: "react-jsx"` — the AUTOMATIC runtime, the opposite of the `jsx` half's
+    //    `preserve`. React's `jsx()` builds a renderer-agnostic element record and the
+    //    host mapping happens later, in `react-reconciler`, so an automatic runtime is
+    //    correct here where it is a misconfiguration for Solid and Vue.
+    //  - `jsxImportSource: "@gjsify/gtk-host/react"` — the spelling a consumer writes;
+    //    TypeScript appends `/jsx-runtime`. Pointing it at `"react"` is the 208-tag
+    //    trap, and so is FORGETTING it: measured, an unset or empty `jsxImportSource`
+    //    under `jsx: "react-jsx"` defaults to `"react"`, so the two are one failure
+    //    (probe `react-namespace`).
+    //  - `noImplicitAny: true` — load-bearing TOGETHER with the setting above, which is
+    //    what probe `evaporate` removes as a pair. On its own it changes nothing here:
+    //    measured, with a valid `jsxImportSource` all eight negatives still error with
+    //    `noImplicitAny: false`. What it decides is whether the surface's ABSENCE is
+    //    loud — with no JSX namespace it reports `TS7026` per element, without it exit 0
+    //    and silence.
+    //
+    // NOT PINNED, deliberately: `strict`. Each setting here has a probe behind it, and a
+    // superset would smuggle in flags nothing measures. `strictFunctionTypes` is the one
+    // that would otherwise belong — the handler signatures it holds are the generated
+    // ones, and the `jsx` half already gates them over the same mapped types.
+    "compilerOptions": {
+        "noEmit": true,
+        "target": "es2020",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "skipLibCheck": true,
+        "noImplicitAny": true,
+        "jsx": "react-jsx",
+        "jsxImportSource": "@gjsify/gtk-host/react",
+        // Resolves the package's own subpath to SOURCE, for the same measured reason as
+        // the `jsx` half: without it TypeScript follows the `exports` map into `lib/`,
+        // which is a build output, and a stale `lib/types` reports the whole surface as
+        // an implicit `any` for a reason that has nothing to do with the surface. What
+        // this deliberately does NOT prove is that `package.json#exports` carries
+        // `./react/jsx-runtime` at all — that is `verify-package-outputs.mjs`.
+        "paths": {
+            "@gjsify/gtk-host/react/jsx-runtime": ["../../src/react-jsx-runtime.ts"]
+        },
+        "lib": ["es2015", "es2016", "es2017", "DOM"],
+        "types": []
+    },
+    // Every `.tsx` beside this file EXCEPT the sentinel, which is a deliberate error and
+    // has its own tsconfig. A file list that misses a fixture is the vacuous-green shape
+    // this whole directory exists to refuse, so the glob is wide and the exclusion is
+    // explicit.
+    "include": ["*.tsx"],
+    "exclude": ["sentinel.tsx"]
+}

--- a/packages/framework/gtk-host/type-tests/react/tsconfig.sentinel.json
+++ b/packages/framework/gtk-host/type-tests/react/tsconfig.sentinel.json
@@ -1,0 +1,8 @@
+{
+    // The sentinel program: same settings as the real one, one file, and the
+    // expectation is INVERTED — `check-type-surfaces.mjs` requires a non-zero exit
+    // carrying the sentinel's own error code.
+    "extends": "./tsconfig.json",
+    "include": ["sentinel.tsx"],
+    "exclude": []
+}

--- a/scripts/check-type-surfaces.mjs
+++ b/scripts/check-type-surfaces.mjs
@@ -5,8 +5,9 @@
 //
 // `src/generated/props.ts` is derived from the GTK/Adwaita GIR: 164 kebab tags, 164 GType
 // keys, every writable property in BOTH spellings, `on<Signal>` handlers carrying the GIR
-// signature, `*Nick` unions carrying the enum nicks. Two dialect surfaces sit on top of it
-// (`jsx-runtime.ts` for JSX/Solid, `vue-components.ts` for Vue's `GlobalComponents`). None of
+// signature, `*Nick` unions carrying the enum nicks. Dialect surfaces sit on top of it —
+// `jsx-runtime.ts` for JSX/Solid, `react-jsx-runtime.ts` for React, `vue-components.ts` for
+// Vue's `GlobalComponents`. None of
 // that is exercised by `gjsify tsc --noEmit` on the package: a type surface type-checks
 // against ITSELF whatever it says about `<gtk-box>`, and a surface that accepts everything is
 // indistinguishable from a correct one until something tries to write a wrong program.
@@ -19,11 +20,12 @@
 // checked NOTHING. That is the repository's most expensive shape — a green check that
 // verified nothing — so every claim this script makes has a negative behind it:
 //
-//   · JSX half: each negative carries a `@ts-expect-error`, and TypeScript reports an UNUSED
-//     `@ts-expect-error` as an error (TS2578). So each negative asserts ITS OWN failure and
-//     the half reduces to "exit code 0" with no error output to parse. A separate SENTINEL
-//     program then carries one deliberate, unsuppressed error, because exit 0 is also what a
-//     compiler that never read a fixture reports.
+//   · JSX halves (`jsx` for Solid, `react` for React — one mechanism, two dialects and two
+//     fixture directories): each negative carries a `@ts-expect-error`, and TypeScript reports
+//     an UNUSED `@ts-expect-error` as an error (TS2578). So each negative asserts ITS OWN
+//     failure and the half reduces to "exit code 0" with no error output to parse. A separate
+//     SENTINEL program then carries one deliberate, unsuppressed error, because exit 0 is also
+//     what a compiler that never read a fixture reports.
 //   · Vue half: `@ts-expect-error` does not work inside an SFC template, so each negative
 //     declares the error code it must produce in its own first line and the script asserts an
 //     EXPECTED SET — per file, both directions (a negative with no error, and an error in a
@@ -36,7 +38,15 @@
 // WHAT THIS DOES NOT PROVE
 //
 //   · Nothing about RUNTIME. This is a type-level gate; that GTK accepts the value a nick
-//     denotes is the package's conformance suite (`src/conformance/`).
+//     denotes is the package's conformance suite (`src/conformance/`), and that a real
+//     application compiles and renders is the four `showcases/gtk/*-host-counter` probes.
+//   · The `react` half does NOT re-state the element list. `GtkReactIntrinsicElements` is a
+//     mapped type over the same generated `WidgetPropsByTag`/`WidgetClassByTag` the `jsx` half
+//     already gates property by property, so a second copy of that matrix would only drift.
+//     What the `react` half adds is the React-specific plumbing — `JSX.Element`,
+//     `JSX.ElementType`, `JSX.IntrinsicAttributes` and React's `Ref<T>`/`ReactNode` spellings
+//     of `ref` and `children` — plus the two tag negatives that prove the React runtime
+//     reaches that shared list at all.
 //   · Not that a HYPHENATED unknown JSX attribute is refused — it is not, and cannot be.
 //     TypeScript exempts every hyphen-containing JSX attribute from excess-property checking,
 //     so `<gtk-box no-such={1}/>` is accepted. `type-tests/jsx/known-hole-hyphen.tsx` holds
@@ -53,7 +63,7 @@
 //     not, so the build-resolving variant reported the whole surface as an implicit `any` for
 //     a reason that had nothing to do with the surface.
 //
-// TWO MEASURED CONFIGURATION TRAPS, both of which silently produce a green half
+// MEASURED CONFIGURATION TRAPS, each of which silently produces a green half
 //
 //  1. `vue-tsc` (3.3.11 / @vue/language-core 3.3.11) lets the BASE of an `extends` chain win
 //     `vueCompilerOptions.strictTemplates` in BOTH directions: a child setting it `false`
@@ -64,11 +74,22 @@
 //     that `strictTemplates` changes nothing. The JSX probes DO use `extends`, where
 //     `compilerOptions` overrides were measured to apply.
 //  2. A tsconfig whose `include` lists only `.ts` globs makes `vue-tsc` check ZERO SFCs and
-//     exit 0. Both halves therefore assert the PROGRAM CONTENTS with `--listFiles`, not just
+//     exit 0. Every half therefore asserts the PROGRAM CONTENTS with `--listFiles`, not just
 //     the exit code: every fixture on disk must be in the program that claims to have checked
 //     it. Probe `ts-only-include` keeps the trap itself executable.
+//  3. The two JSX halves EVAPORATE DIFFERENTLY, and one probe table could not serve both.
+//     Under `jsx: "preserve"` (the `jsx` half) an unset `jsxImportSource` leaves no JSX
+//     namespace at all, so `noImplicitAny: false` turns the whole surface into `any`. Under
+//     `jsx: "react-jsx"` (the `react` half) an unset or EMPTY `jsxImportSource` falls back to
+//     `"react"` — measured byte-identical to naming it — so "drop it" and "point it at react"
+//     are ONE failure there, and the evaporating shape has to take `jsx` away too. Worse,
+//     `@types/react` declares a GLOBAL `JSX` namespace, so a program that imports React's
+//     types has React's 208 tags as its fallback surface: with a `react` type import in the
+//     probe program, `evaporate` silenced 1 of 8 assertions instead of 6. The `react`
+//     negatives are therefore deliberately free of `react` imports, and that is stated in
+//     their own header rather than only here.
 //
-// Usage: node scripts/check-type-surfaces.mjs [--help] [--root <dir>] [--only jsx|vue] [--no-probes]
+// Usage: node scripts/check-type-surfaces.mjs [--help] [--root <dir>] [--only jsx|react|vue] [--no-probes]
 
 import { spawnSync } from 'node:child_process';
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -76,17 +97,17 @@ import { createRequire } from 'node:module';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const HELP = `check-type-surfaces — hold @gjsify/gtk-host's generated type surface, both dialects.
+const HELP = `check-type-surfaces — hold @gjsify/gtk-host's generated type surface, every dialect.
 
   node scripts/check-type-surfaces.mjs [options]
 
   --root <dir>     repository root (default: the parent of scripts/)
-  --only jsx|vue   run one half only
+  --only <half>    run one half only: jsx, react or vue
   --no-probes      skip the load-bearing-setting probes (they are the half of this
                    gate that proves the settings matter; skip only when bisecting)
   --help           this text
 
-Exits 0 when both halves hold, 1 on any deviation or harness failure.`;
+Exits 0 when every half holds, 1 on any deviation or harness failure.`;
 
 const args = process.argv.slice(2);
 if (args.includes('--help') || args.includes('-h')) {
@@ -100,16 +121,24 @@ const onlyFlag = args.indexOf('--only');
 const ONLY = onlyFlag === -1 ? null : args[onlyFlag + 1];
 const PROBES = !args.includes('--no-probes');
 
-if (ONLY !== null && ONLY !== 'jsx' && ONLY !== 'vue') {
-    console.error(`check-type-surfaces: --only takes 'jsx' or 'vue', got ${JSON.stringify(ONLY)}`);
+const HALF_NAMES = ['jsx', 'react', 'vue'];
+if (ONLY !== null && !HALF_NAMES.includes(ONLY)) {
+    console.error(`check-type-surfaces: --only takes one of ${HALF_NAMES.join(', ')}, got ${JSON.stringify(ONLY)}`);
     process.exit(1);
 }
 
 const PKG = join(ROOT, 'packages', 'framework', 'gtk-host');
 const TYPE_TESTS = join(PKG, 'type-tests');
-const JSX_DIR = join(TYPE_TESTS, 'jsx');
 const VUE_DIR = join(TYPE_TESTS, 'vue');
-/** Under the package's gitignored `tmp/`, which `gjsify clear` already owns. */
+/**
+ * Under the package's gitignored `tmp/`, which `gjsify clear` already owns.
+ *
+ * TWO levels below the package root, exactly like `type-tests/<half>/`, and that is
+ * load-bearing rather than incidental: the stripped copies of the negatives are compiled from
+ * HERE, so a fixture's relative import (`../../src/types.js`, which the React plumbing
+ * negatives need) has to resolve to the same file from both places. It self-reports if it
+ * ever stops: the baseline run would raise a `TS2307` no directive covers.
+ */
 const WORK = join(PKG, 'tmp', 'type-surfaces');
 
 const require = createRequire(import.meta.url);
@@ -144,7 +173,10 @@ function fail(message) {
  */
 const CAPABILITIES = new Map([
     ['jsxSurface', 'the JSX surface being wired at all (`jsxImportSource` + `noImplicitAny`)'],
-    ['ownRuntime', 'shipping our OWN jsx-runtime instead of augmenting Solid’s namespace'],
+    // Shared by both JSX halves, because it is one claim asked of two dialects: the element
+    // list must be OURS. The probe that removes it differs — `jsx` repoints `jsxImportSource`
+    // at `solid-js`, `react` at `react` — and both land on the same 208 HTML/SVG/MathML tags.
+    ['ownRuntime', 'shipping our OWN jsx-runtime instead of borrowing the framework’s element list'],
     ['strictFunctionTypes', '`strictFunctionTypes` (without it a handler parameter is bivariant)'],
     ['strictTemplates', '`vueCompilerOptions.strictTemplates`'],
     ['none', 'nothing — the negative holds under every probe'],
@@ -229,10 +261,10 @@ function parseNeeds(raw, where, implicit) {
  * `known-hole-*` must carry NONE (it documents what is accepted); `sentinel` is a program of
  * its own with an inverted expectation.
  */
-function jsxInventory() {
+function jsxInventory(half) {
     const inventory = { positives: [], negatives: [], holes: [], sentinel: null, assertions: [] };
-    for (const name of listFixtures(JSX_DIR, '.tsx')) {
-        const file = join(JSX_DIR, name);
+    for (const name of listFixtures(half.dir, '.tsx')) {
+        const file = join(half.dir, name);
         const text = readFixture(file);
         if (text === null) continue;
         if (BLOCK_DIRECTIVE.test(text)) {
@@ -463,60 +495,106 @@ function writeWorkFile(name, contents) {
     return file;
 }
 
-// ── half 1: JSX / Solid ─────────────────────────────────────────────────
-
-const JSX_CONFIG = join(JSX_DIR, 'tsconfig.json');
-const JSX_SENTINEL_CONFIG = join(JSX_DIR, 'tsconfig.sentinel.json');
+// ── the JSX halves: Solid and React ─────────────────────────────────────
+//
+// ONE mechanism, one fixture grammar, one `checkJsxHalf`, two dialects. They are separate
+// HALVES rather than one directory because the compiler settings they pin are different in
+// kind — `jsx: "preserve"` handing JSX to a framework compiler versus `jsx: "react-jsx"`
+// naming an automatic runtime — and therefore so is every probe that removes one. Sharing the
+// table would have meant a `checkJsxHalf` that branches on the dialect, which is the same
+// second truth in a different place.
 
 /**
- * The probes that hold the JSX half's settings to being load-bearing.
+ * A JSX-dialect half: where its fixtures live and what removing each setting must do.
  *
- * Each removes ONE capability and is asserted from both sides: the negatives declaring it go
- * green, and every other negative still errors. `evaporate` is the incident — it is the exact
- * configuration in which the entire surface disappears in silence.
+ * `probes` remove ONE capability each and are asserted from both sides: the negatives
+ * declaring it go green, and every other negative still errors. The second half is what stops
+ * a probe from "passing" because the program broke. `configProbes` are settings TypeScript
+ * refuses at the config level, so they have no per-negative expectation.
  */
-const JSX_PROBES = [
+const JSX_HALVES = [
     {
-        name: 'evaporate',
-        disables: 'jsxSurface',
-        options: { noImplicitAny: false, jsxImportSource: '' },
-        why: 'jsx=preserve + no jsxImportSource + noImplicitAny=false — every element becomes implicitly `any`',
+        name: 'jsx',
+        dir: join(TYPE_TESTS, 'jsx'),
+        config: join(TYPE_TESTS, 'jsx', 'tsconfig.json'),
+        sentinelConfig: join(TYPE_TESTS, 'jsx', 'tsconfig.sentinel.json'),
+        probes: [
+            {
+                name: 'evaporate',
+                disables: 'jsxSurface',
+                options: { noImplicitAny: false, jsxImportSource: '' },
+                why: 'jsx=preserve + no jsxImportSource + noImplicitAny=false — every element becomes implicitly `any`',
+            },
+            {
+                name: 'solid-namespace',
+                disables: 'ownRuntime',
+                options: { jsxImportSource: 'solid-js', paths: {} },
+                why: "pointing at Solid's own namespace leaves its 208 HTML/SVG/MathML tags valid on a GTK renderer",
+            },
+            {
+                name: 'bivariant',
+                disables: 'strictFunctionTypes',
+                options: { strictFunctionTypes: false },
+                why: 'a handler parameter narrowed to a subtype stops being an error',
+            },
+        ],
+        configProbes: [
+            {
+                name: 'jsx-react',
+                options: { jsx: 'react' },
+                expect: 'TS5089',
+                why: '`jsx: "react"` cannot be combined with jsxImportSource — the setting a consumer reaches for first',
+            },
+        ],
     },
     {
-        name: 'solid-namespace',
-        disables: 'ownRuntime',
-        options: { jsxImportSource: 'solid-js', paths: {} },
-        why: "pointing at Solid's own namespace leaves its 208 HTML/SVG/MathML tags valid on a GTK renderer",
-    },
-    {
-        name: 'bivariant',
-        disables: 'strictFunctionTypes',
-        options: { strictFunctionTypes: false },
-        why: 'a handler parameter narrowed to a subtype stops being an error',
+        name: 'react',
+        dir: join(TYPE_TESTS, 'react'),
+        config: join(TYPE_TESTS, 'react', 'tsconfig.json'),
+        sentinelConfig: join(TYPE_TESTS, 'react', 'tsconfig.sentinel.json'),
+        probes: [
+            {
+                // NOT the `jsx` half's evaporating shape, and the difference is measured rather
+                // than stylistic. Under `jsx: "react-jsx"` an unset or EMPTY `jsxImportSource`
+                // DEFAULTS to `"react"` — byte-identical to the `react-namespace` probe below —
+                // so taking the surface away needs `jsx` itself. `noImplicitAny` is what makes
+                // the difference between loud and silent once it is gone: with it on, the same
+                // config reports `TS7026` on every element; with it off, exit 0 and nothing.
+                name: 'evaporate',
+                disables: 'jsxSurface',
+                options: { noImplicitAny: false, jsx: 'preserve', jsxImportSource: '' },
+                why: 'no jsxImportSource + noImplicitAny=false — TS7026 on every element becomes silence',
+            },
+            {
+                // Also the measurement for "the consumer forgot `jsxImportSource`": TypeScript
+                // defaults it to `"react"` under `jsx: "react-jsx"`, so forgetting it and naming
+                // it produce the same program, and the same 208 tags.
+                name: 'react-namespace',
+                disables: 'ownRuntime',
+                options: { jsxImportSource: 'react', paths: {} },
+                why: "pointing at React's own namespace brings @types/react's 208 HTML/SVG/MathML tags back onto a GTK renderer",
+            },
+        ],
+        // No config probe: `jsx: "react"` + `jsxImportSource` is TS5089 whatever the dialect,
+        // and the `jsx` half already holds it. The setting a React consumer gets wrong instead
+        // is `jsx: "preserve"` copied from the Solid recipe — which type-checks CLEAN here and
+        // fails at BUILD time, where `packages/infra/cli/src/utils/jsx-config.ts` and the
+        // post-bundle parse check own it.
+        configProbes: [],
     },
 ];
 
-/** A setting that is refused at the CONFIG level, so it has no per-negative expectation. */
-const JSX_CONFIG_PROBES = [
-    {
-        name: 'jsx-react',
-        options: { jsx: 'react' },
-        expect: 'TS5089',
-        why: '`jsx: "react"` cannot be combined with jsxImportSource — the setting a consumer reaches for first',
-    },
-];
-
-function writeJsxProbeConfig(name, options, includes) {
+function writeJsxProbeConfig(half, name, options, includes) {
     // `extends` with an absolute base was MEASURED to carry the base's relative `paths` and to
     // honour a child's compilerOptions overrides, which is what keeps the probes from being a
     // second copy of the committed settings.
     const config = {
-        extends: resolve(JSX_CONFIG),
+        extends: resolve(half.config),
         compilerOptions: options,
         include: includes.map((file) => resolve(file)),
         exclude: [],
     };
-    return writeWorkFile(`tsconfig.jsx-${name}.json`, `${JSON.stringify(config, null, 4)}\n`);
+    return writeWorkFile(`tsconfig.${half.name}-${name}.json`, `${JSON.stringify(config, null, 4)}\n`);
 }
 
 /**
@@ -527,46 +605,48 @@ function writeJsxProbeConfig(name, options, includes) {
  * gone the run reports the errors themselves, so the annotated code can be compared and an
  * error appearing anywhere ELSE is caught too.
  */
-function stripDirectives(names) {
+function stripDirectives(half, names) {
     const stripped = new Map();
     for (const name of names) {
-        const text = readFixture(join(JSX_DIR, name));
+        const text = readFixture(join(half.dir, name));
         if (text === null) continue;
         const bare = text
             .split('\n')
             .map((line) => (JSX_DIRECTIVE.test(line) ? '//' : line))
             .join('\n');
-        stripped.set(name, writeWorkFile(`_stripped-${name}`, bare));
+        stripped.set(name, writeWorkFile(`_stripped-${half.name}-${name}`, bare));
     }
     return stripped;
 }
 
-function checkJsxHalf() {
-    const inventory = jsxInventory();
+function checkJsxHalf(half) {
+    const inventory = jsxInventory(half);
     const gateFixtures = [...inventory.positives, ...inventory.negatives, ...inventory.holes].map((name) =>
-        join(JSX_DIR, name),
+        join(half.dir, name),
     );
 
     if (inventory.negatives.length === 0)
-        fail('jsx: no negative fixtures. A positive-only suite cannot detect a misconfigured compiler.');
+        fail(`${half.name}: no negative fixtures. A positive-only suite cannot detect a misconfigured compiler.`);
+    if (inventory.positives.length === 0)
+        fail(`${half.name}: no positive fixture. Without one, a surface that refuses everything scores perfect.`);
     if (inventory.sentinel === null)
-        fail('jsx: no sentinel.tsx. Without it, "exit 0" and "read nothing" are the same result.');
+        fail(`${half.name}: no sentinel.tsx. Without it, "exit 0" and "read nothing" are the same result.`);
 
     // (a) THE GATE. Exit code 0 — checked as a code, never as the absence of error lines —
     // means every positive compiled and every @ts-expect-error was consumed.
     const beforeGate = failures.length;
-    const gate = compile(TSC, JSX_CONFIG, ['--listFiles']);
+    const gate = compile(TSC, half.config, ['--listFiles']);
     if (gate !== null) {
-        assertProgramCovers('jsx gate', gate.program, gateFixtures);
+        assertProgramCovers(`${half.name} gate`, gate.program, gateFixtures);
         if (gate.code !== 0) {
             fail(
-                `jsx gate: tsc exited ${gate.code}, expected 0. Either a positive fixture broke or a ` +
+                `${half.name} gate: tsc exited ${gate.code}, expected 0. Either a positive fixture broke or a ` +
                     `@ts-expect-error went unused (TS2578 — the negative stopped being an error):\n${reportOutput(gate)}`,
             );
         } else {
             measureIfClean(
                 beforeGate,
-                `jsx gate: exit 0 over ${gateFixtures.length} fixture(s) — ` +
+                `${half.name} gate: exit 0 over ${gateFixtures.length} fixture(s) — ` +
                     `${inventory.positives.length} positive, ${inventory.negatives.length} negative ` +
                     `(${inventory.assertions.length} assertions), ${inventory.holes.length} documented hole(s)`,
             );
@@ -577,7 +657,7 @@ function checkJsxHalf() {
     // that reports the half green has shown, in the same invocation, that it can still see an
     // error at all.
     if (inventory.sentinel !== null) {
-        const sentinel = compile(TSC, JSX_SENTINEL_CONFIG);
+        const sentinel = compile(TSC, half.sentinelConfig);
         if (sentinel !== null) {
             const hit = sentinel.diagnostics.find(
                 (diagnostic) =>
@@ -585,13 +665,13 @@ function checkJsxHalf() {
             );
             if (sentinel.code === 0 || hit === undefined) {
                 fail(
-                    `jsx sentinel: expected a failing run reporting ${inventory.sentinel.code} in ` +
+                    `${half.name} sentinel: expected a failing run reporting ${inventory.sentinel.code} in ` +
                         `${relative(ROOT, inventory.sentinel.file)}, got exit ${sentinel.code}:\n${reportOutput(sentinel)}` +
                         '\n  A harness that cannot see THIS error cannot have seen the negatives either.',
                 );
             } else {
                 measured.push(
-                    `jsx sentinel: exit ${sentinel.code} carrying ${inventory.sentinel.code} — the harness reports errors`,
+                    `${half.name} sentinel: exit ${sentinel.code} carrying ${inventory.sentinel.code} — the harness reports errors`,
                 );
             }
         }
@@ -600,19 +680,19 @@ function checkJsxHalf() {
     if (inventory.assertions.length === 0) return;
 
     // (c) EVERY NEGATIVE, INDIVIDUALLY, with its annotated code.
-    const stripped = stripDirectives(inventory.negatives);
+    const stripped = stripDirectives(half, inventory.negatives);
     const strippedFiles = [...stripped.values()];
     const byStrippedFile = new Map([...stripped].map(([name, file]) => [resolve(file), name]));
-    const baselineConfig = writeJsxProbeConfig('baseline', {}, strippedFiles);
+    const baselineConfig = writeJsxProbeConfig(half, 'baseline', {}, strippedFiles);
     const baseline = compile(TSC, baselineConfig, ['--listFiles']);
     if (baseline === null) return;
-    assertProgramCovers('jsx negatives', baseline.program, strippedFiles);
+    assertProgramCovers(`${half.name} negatives`, baseline.program, strippedFiles);
 
     const located = new Map();
     for (const diagnostic of baseline.diagnostics) {
         if (diagnostic.file === null) {
             fail(
-                `jsx negatives: a diagnostic with no file — the program is wrong, not the fixtures: ${diagnostic.text}`,
+                `${half.name} negatives: a diagnostic with no file — the program is wrong, not the fixtures: ${diagnostic.text}`,
             );
             continue;
         }
@@ -646,12 +726,12 @@ function checkJsxHalf() {
         located.delete(key);
     }
     for (const [key, hits] of located) {
-        fail(`jsx negatives: unexpected error at ${key} — no @ts-expect-error covers it: ${hits[0].text}`);
+        fail(`${half.name} negatives: unexpected error at ${key} — no @ts-expect-error covers it: ${hits[0].text}`);
     }
     if (proven > 0) {
         const codes = [...new Set(inventory.assertions.map((assertion) => assertion.code))].sort();
         measured.push(
-            `jsx negatives: ${proven}/${inventory.assertions.length} fire individually with the annotated code (${codes.join(', ')})`,
+            `${half.name} negatives: ${proven}/${inventory.assertions.length} fire individually with the annotated code (${codes.join(', ')})`,
         );
     }
 
@@ -660,9 +740,10 @@ function checkJsxHalf() {
     // (d) THE SETTINGS. Each probe removes one capability; the negatives naming it must go
     // green and every other negative must stay red. The second half is what stops a probe
     // from passing because the program broke.
-    for (const probe of JSX_PROBES) {
+    for (const probe of half.probes) {
         const before = failures.length;
-        const configPath = writeJsxProbeConfig(probe.name, probe.options, strippedFiles);
+        const label = `probe ${half.name}/${probe.name}`;
+        const configPath = writeJsxProbeConfig(half, probe.name, probe.options, strippedFiles);
         const run = compile(TSC, configPath);
         if (run === null) continue;
         const erroring = new Set(
@@ -677,12 +758,12 @@ function checkJsxHalf() {
             const dependsOnProbe = assertion.needs.includes(probe.disables);
             if (dependsOnProbe && erroring.has(key)) {
                 fail(
-                    `probe ${probe.name}: ${key} declares needs=${probe.disables} but still errors without it. ` +
+                    `${label}: ${key} declares needs=${probe.disables} but still errors without it. ` +
                         'Either the setting is not what makes that negative work, or the annotation is wrong.',
                 );
             } else if (!dependsOnProbe && !erroring.has(key)) {
                 fail(
-                    `probe ${probe.name}: ${key} went green, and it does not declare needs=${probe.disables}. ` +
+                    `${label}: ${key} went green, and it does not declare needs=${probe.disables}. ` +
                         `Removing ${probe.disables} silently disabled more than it claims — add it to the ` +
                         'annotation, or the probe is measuring a broken program.',
                 );
@@ -692,34 +773,34 @@ function checkJsxHalf() {
         }
         if (silenced === 0) {
             fail(
-                `probe ${probe.name}: no negative declares needs=${probe.disables}, so the probe proves nothing. ` +
+                `${label}: no negative declares needs=${probe.disables}, so the probe proves nothing. ` +
                     'A setting nothing depends on is not load-bearing — drop the setting or add the negative.',
             );
         } else {
             measureIfClean(
                 before,
-                `probe ${probe.name} (removes ${probe.disables}): ${silenced} negative(s) go green, ${survived} still error — ${probe.why}`,
+                `${label} (removes ${probe.disables}): ${silenced} negative(s) go green, ${survived} still error — ${probe.why}`,
             );
         }
     }
 
-    for (const probe of JSX_CONFIG_PROBES) {
-        const configPath = writeJsxProbeConfig(probe.name, probe.options, strippedFiles);
+    for (const probe of half.configProbes) {
+        const label = `probe ${half.name}/${probe.name}`;
+        const configPath = writeJsxProbeConfig(half, probe.name, probe.options, strippedFiles);
         const run = compile(TSC, configPath);
         if (run === null) continue;
         const hit = run.diagnostics.some((diagnostic) => diagnostic.code === probe.expect);
         if (run.code === 0 || !hit) {
             fail(
-                `probe ${probe.name}: expected ${probe.expect}, got exit ${run.code}:\n${reportOutput(run)}` +
-                    `\n  ${probe.why}`,
+                `${label}: expected ${probe.expect}, got exit ${run.code}:\n${reportOutput(run)}` + `\n  ${probe.why}`,
             );
         } else {
-            measured.push(`probe ${probe.name}: refused with ${probe.expect} — ${probe.why}`);
+            measured.push(`${label}: refused with ${probe.expect} — ${probe.why}`);
         }
     }
 }
 
-// ── half 2: Vue SFC ─────────────────────────────────────────────────────
+// ── the Vue SFC half ────────────────────────────────────────────────────
 
 const VUE_CONFIG = join(VUE_DIR, 'tsconfig.json');
 /** The `GlobalComponents` augmentation only applies to a program that LOADS it. */
@@ -962,8 +1043,10 @@ function indent(text) {
 const started = Date.now();
 prepareWorkDir();
 try {
-    if (ONLY !== 'vue') checkJsxHalf();
-    if (ONLY !== 'jsx') checkVueHalf();
+    for (const half of JSX_HALVES) {
+        if (ONLY === null || ONLY === half.name) checkJsxHalf(half);
+    }
+    if (ONLY === null || ONLY === 'vue') checkVueHalf();
 } finally {
     rmSync(WORK, { recursive: true, force: true });
 }

--- a/showcases/gtk/react-host-counter/README.md
+++ b/showcases/gtk/react-host-counter/README.md
@@ -1,0 +1,104 @@
+# react-host-counter
+
+The [`adw-host-counter`](../adw-host-counter) window a **fourth** time — written as React JSX and
+rendered by a real `react-reconciler` over [`@gjsify/gtk-host/react`](../../../packages/framework/gtk-host).
+Same widgets, same assertions: one showcase imperative through the host ops, one through Solid's
+JSX compiler ([`solid-host-counter`](../solid-host-counter)), one through `@vue/compiler-sfc`
+([`vue-host-counter`](../vue-host-counter)), and this one through React's automatic JSX runtime.
+Four contracts over one host is what makes "framework-agnostic" a measurement instead of a
+decision — and the four report the same tree size and the same widget order, which is the point of
+keeping them identical.
+
+```bash
+gjsify run build:gjs && gjsify run start:gjs   # the window
+gjsify run probe                               # the assertions, headless
+gjsify run check                               # tsc over the JSX
+```
+
+## What only this showcase proves
+
+React was the one adapter with **no end-to-end evidence**. `src/adapters/react.spec.ts` drives the
+reconciler through `createElement` calls, and `scripts/check-type-surfaces.mjs` gates the element
+list — but nothing in the repository compiled a line of React JSX, and nothing ran a React tree
+inside a `GApplication`. Three things only this file reaches:
+
+- **The automatic runtime.** Unlike both siblings, this build does not preserve JSX for a framework
+  compiler: `jsx: "react-jsx"` + `jsxImportSource: "@gjsify/gtk-host/react"` makes oxc emit
+  `import { jsx } from "@gjsify/gtk-host/react/jsx-runtime"`, and that subpath re-exports React's
+  own `jsx`/`jsxs`/`Fragment`. There is no plugin under `gjsify.bundler.plugins` here and nothing
+  for one to consume. The export **names** are the framework's contract — TypeScript emits those
+  three literally, so a rename there is a `MISSING_EXPORT` in this bundle.
+- **The scheduled lane, under GJS, in an application.** `getCurrentEventPriority` returns the
+  DEFAULT lane, so a `setState` from a `clicked` handler is concurrent: it is handed to
+  `scheduler`, which under GJS lands on a GLib timer source. The probe asserts **both** halves —
+  the tree is unchanged the instant the signal returns, and it is patched once the main context
+  runs. Measured: wrapping the `emit('clicked')` in `flushSync` turns the first of those red, which
+  is what makes it an assertion about the lane rather than about the handler.
+- **React's own `ref` spelling.** The React surface types `ref` as `Ref<T>` — a callback *or* a
+  `useRef`/`createRef` object — which is why it does not reuse the Solid surface's `ref` type. The
+  probe holds a `createRef` and asserts the widget it receives is **identical** to the one found by
+  walking the real GTK tree; `getPublicInstance` returning something plausible is not the claim.
+
+## The window is the application's, the content is React's
+
+Same structural split as the Vue sibling, and for the same reason rather than by imitation:
+`createRoot(container)` renders *into* a widget, and a toplevel window is not a child of anything.
+An `adw-application-window` at the root of the tree would ask GTK to parent a toplevel and earn a
+`Gtk-WARNING` at exit 0. So the application owns the window and `adopt`s it, and the component's
+`adw-toolbar-view` lands through `Adw.ApplicationWindow.set_content()` — the `single` placement
+policy the descriptor table declares for that GType.
+
+## Build recipe, and it is not optional
+
+```
+--define 'process.env.NODE_ENV="production"'   --exclude-globals navigator
+```
+
+`react-reconciler/index.js` picks its bundle from `process.env.NODE_ENV`, and the development one
+reaches for `document`, `HTMLCanvasElement` and `Path2D` — which makes `--globals auto` inject the
+GTK-backed DOM registers and pull `gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` into a bundle
+that needs none of them. Even the production `scheduler` carries
+`typeof navigator !== 'undefined' && navigator.scheduling`, dead code under GJS but still a free
+identifier the detector answers with the same register. Two probe assertions hold the recipe: no
+`document` and no `navigator` exist at runtime.
+
+## The probe
+
+`runHostProbeApp` from `@gjsify/gtk-host` owns the harness — the env gate, the diagnostics
+collector, the `check()` recorder, the `PROBE: PASS|FAIL <json>` protocol, the `app.hold()`
+discipline and the rule that the GUI path runs the same assertions before presenting.
+
+`GJSIFY_HOST_PROBE=1` builds the tree headlessly, asserts it against the **real** widget tree
+(`get_first_child`/`get_next_sibling` and the exact getters, never the host's own bookkeeping),
+prints `PROBE: PASS <json>` — including the GLib diagnostic count — and exits 0, or
+`PROBE: FAIL <json>` and exits 1. The same assertions run from `activate` before the window is
+shown, so the existing `showcase-smoke` CI leg carries them; a throw inside a GLib callback prints
+`JS ERROR` and lets the process exit 0, and that marker is what the smoke gate greps for.
+
+**Every slot assertion is about PLACEMENT, not presence**, because the siblings measured what
+presence is worth: with the presence version, `slot="bottom"` on the header bar passed with the
+header genuinely rendered at the foot of the window, output byte-identical. Measured on this
+showcase, each of these turns the probe red on its own — deleting `slot="title"` (the label is
+still in the subtree; only `get_title_widget()` notices), flipping `orientation` to `horizontal`,
+moving `slot="content"` to `slot="bottom"`, dropping the `ref`, appending the conditional label
+instead of placing it in the middle, and swapping the list `key` from `row.id` to the array index
+(the surviving row is then a re-used widget with a patched title, not the same object).
+
+The probe drives the main loop itself: `scheduler`'s host callback is a GLib timer source, and
+nothing runs it inside a probe. The pump is **bounded**, because a scheduler that never runs has to
+fail an assertion rather than hang the process — an unbounded wait is what `showcase-smoke` reads
+as "still up after the dwell", a failure reporting itself as a pass.
+
+## The type half
+
+`check` is plain `tsc` (via `gjsify tsc --noEmit`), not a per-framework program checker: React JSX
+is TypeScript's own dialect, so unlike the Vue sibling there is no `.vue` file a compiler cannot
+read. The fixture-level gate for the same surface is
+`scripts/check-type-surfaces.mjs`'s **`react` half**, which holds it negative-first — including the
+measurement that matters most for a consumer: under `jsx: "react-jsx"`, an unset or empty
+`jsxImportSource` **defaults to `"react"`**, so forgetting it is the same failure as naming it, and
+`@types/react`'s 208 HTML/SVG/MathML tags type-check clean on a GTK renderer and render nothing.
+
+## License
+
+MIT

--- a/showcases/gtk/react-host-counter/package.json
+++ b/showcases/gtk/react-host-counter/package.json
@@ -1,0 +1,54 @@
+{
+    "name": "@gjsify/example-gtk-react-host-counter",
+    "version": "0.43.0",
+    "description": "The gtk-host counter written in React JSX — transformed by the automatic runtime and rendered by react-reconciler, with an in-process probe that asserts the real widget tree",
+    "type": "module",
+    "private": true,
+    "main": "dist/app.gjs.mjs",
+    "files": [
+        "dist",
+        "src"
+    ],
+    "scripts": {
+        "clear": "gjsify clear dist tsconfig.tsbuildinfo",
+        "check": "gjsify tsc --noEmit",
+        "build": "gjsify run build:gjs",
+        "build:gjs": "gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs --define 'process.env.NODE_ENV=\"production\"' --exclude-globals navigator",
+        "start:gjs": "gjs -m dist/app.gjs.mjs",
+        "probe": "gjsify run build:gjs && GJSIFY_HOST_PROBE=1 gjs -m dist/app.gjs.mjs"
+    },
+    "gjsify": {
+        "main": "dist/app.gjs.mjs",
+        "tier": 3,
+        "example": {
+            "runtimes": [
+                "gjs"
+            ]
+        }
+    },
+    "devDependencies": {
+        "@girs/adw-1": "^4.1.0",
+        "@girs/gjs": "^4.1.0",
+        "@girs/glib-2.0": "^4.1.0",
+        "@girs/gobject-2.0": "^4.1.0",
+        "@girs/gtk-4.0": "^4.1.0",
+        "@gjsify/cli": "workspace:^",
+        "@gjsify/gtk-host": "workspace:^",
+        "@types/node": "^25.9.2",
+        "@types/react": "^18.3.12",
+        "react": "^18.3.1",
+        "react-reconciler": "^0.29.2",
+        "typescript": "^6.0.3"
+    },
+    "author": "Pascal Garber <pascal@artandcode.studio>",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/gjsify/gjsify.git",
+        "directory": "showcases/gtk/react-host-counter"
+    },
+    "bugs": {
+        "url": "https://github.com/gjsify/gjsify/issues"
+    },
+    "homepage": "https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter#readme"
+}

--- a/showcases/gtk/react-host-counter/src/app.tsx
+++ b/showcases/gtk/react-host-counter/src/app.tsx
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+//
+// The `adw-host-counter` window a FOURTH time — now as React JSX rendered by
+// `react-reconciler`, so the four showcases are a deliberate A/B/C/D: same
+// widgets, same assertions, one imperative through the host ops, one through
+// Solid's JSX compiler, one through `@vue/compiler-sfc`, this one through React's
+// automatic JSX runtime and a real `HostConfig`.
+//
+// WHAT ONLY THIS SHOWCASE CAN PROVE. React was the one adapter with no end-to-end
+// evidence: `src/adapters/react.spec.ts` drives the reconciler through
+// `createElement` calls and the type gate held the ELEMENT LIST, but nothing
+// anywhere compiled a line of React JSX or ran a React tree inside a
+// GApplication. Three things only this file reaches:
+//
+//   · THE AUTOMATIC RUNTIME. Unlike both siblings, this build does NOT preserve
+//     JSX for a framework compiler — `jsx: "react-jsx"` +
+//     `jsxImportSource: "@gjsify/gtk-host/react"` makes oxc emit
+//     `import { jsx } from "@gjsify/gtk-host/react/jsx-runtime"`, and that subpath
+//     re-exports React's OWN `jsx`/`jsxs`/`Fragment`. The export NAMES are the
+//     framework's contract: TypeScript emits those three literally, so a rename
+//     there is a `MISSING_EXPORT` in this bundle rather than a matter of taste.
+//   · THE SCHEDULED LANE, under GJS, in an application. `getCurrentEventPriority`
+//     returns the DEFAULT lane (a GTK signal is not a DOM event, so there is no
+//     ambient event to derive a priority from), which means a `setState` from a
+//     `clicked` handler is CONCURRENT: it is handed to `scheduler`, which under
+//     GJS lands on a GLib timer source. The probe asserts both halves — the tree
+//     is unchanged the instant the signal returns, and it is patched after the
+//     main context runs — because "the handler was connected" and "React
+//     re-rendered" are two different facts and only the second one is the point.
+//   · REACT'S OWN `ref` SPELLING. The React surface types `ref` as `Ref<T>`, i.e. a
+//     callback OR a `useRef`/`createRef` OBJECT, which is why it is not the Solid
+//     surface's `ref` type. `createRef` is the object form, and the probe asserts
+//     the widget it receives is IDENTICAL to the one found by walking the real GTK
+//     tree — `getPublicInstance` returning something plausible is not the claim.
+//
+// SELF-VERIFYING ON EVERY LAUNCH, like all three siblings and through the SAME
+// harness: `runHostProbeApp` from `@gjsify/gtk-host` owns the env gate, the
+// diagnostics collector, the `check()` recorder, the `PROBE: PASS|FAIL <json>`
+// protocol, the `app.hold()` discipline and the rule that the GUI path runs the
+// same assertions before presenting. A throw inside a GLib callback prints
+// `JS ERROR` and lets the process exit 0, and that marker is what
+// `scripts/showcase-smoke.mjs` greps for.
+
+import Adw from 'gi://Adw?version=1';
+import GLib from 'gi://GLib?version=2.0';
+import Gtk from 'gi://Gtk?version=4.0';
+
+import { createRef, useCallback, useRef, useState, type RefObject } from 'react';
+
+import { registerBuiltinWidgets, runHostProbeApp, type ProbeCheck } from '@gjsify/gtk-host';
+import { descendants, dumpTree, findDescendant, gtkChildren } from '@gjsify/gtk-host/conformance';
+import { createRoot } from '@gjsify/gtk-host/react';
+
+registerBuiltinWidgets();
+
+interface Row {
+    readonly id: number;
+    readonly title: string;
+}
+
+/**
+ * The whole UI as one React component.
+ *
+ * The window is the APPLICATION's and the content is React's — the same
+ * structural split the Vue showcase documents, and for the same reason rather
+ * than by imitation: `createRoot(container)` renders INTO a widget, and a toplevel
+ * window is not a child of anything. An `adw-application-window` at the root of
+ * this tree would ask GTK to parent a toplevel and earn a `Gtk-WARNING` at exit 0.
+ */
+function Counter({ incrementRef }: { readonly incrementRef: RefObject<Gtk.Button> }) {
+    const [count, setCount] = useState(0);
+    const [rows, setRows] = useState<readonly Row[]>([]);
+    const nextRow = useRef(1);
+
+    const increment = useCallback(() => setCount((n) => n + 1), []);
+    const addRow = useCallback(() => {
+        const id = nextRow.current;
+        nextRow.current += 1;
+        setRows((current) => [...current, { id, title: `Row ${id}` }]);
+    }, []);
+    const removeFirstRow = useCallback(() => setRows((current) => current.slice(1)), []);
+
+    return (
+        <adw-toolbar-view>
+            <adw-header-bar slot="top">
+                <gtk-label label="Built by react-reconciler" slot="title" />
+            </adw-header-bar>
+            <adw-preferences-page slot="content">
+                <adw-preferences-group title="Rows">
+                    {/* Rendered BEFORE the counter row on purpose: Adw.PreferencesGroup
+                        has no `insert()`, so the placement policy degrades to
+                        `remove-all` and the host replays the tail. A keyed React list
+                        in front of a static sibling is what makes that path run. */}
+                    {rows.map((row) => (
+                        <adw-action-row key={row.id} title={row.title} subtitle="added at runtime" />
+                    ))}
+                    {/* `cssName` is CONSTRUCT-ONLY on every GtkWidget. React hands the
+                        vnode props to `createInstance`, so it arrives at `g_object_new`
+                        time and no rebuild is needed — the same adapter difference the
+                        Vue showcase records, and the opposite of the Solid path where
+                        the compiler sets every property after construction. */}
+                    <adw-action-row title="Clicks" subtitle={String(count)} cssName="row" />
+                </adw-preferences-group>
+                <adw-preferences-group title="Actions">
+                    {/* `orientation="vertical"` as a STRING is the case GObject drops
+                        silently; the host resolves the nick against GtkOrientation. */}
+                    <gtk-box orientation="vertical" spacing={12} marginTop={12}>
+                        <gtk-button label="Increment" halign="center" onClicked={increment} ref={incrementRef} />
+                        {/* A conditional in the MIDDLE. React renders `null` as no node
+                            at all — it creates no anchor, unlike Solid's and Vue's
+                            comment boundaries — so this is the host's `insertBefore`
+                            path rather than an anchor resolution. If the label were
+                            appended instead, "Add row" would sit one index too early
+                            and GTK would say nothing about it. */}
+                        {count > 0 ? <gtk-label label={`clicked ${count}x`} /> : null}
+                        <gtk-button label="Add row" halign="center" onClicked={addRow} />
+                        <gtk-button label="Remove first row" halign="center" onClicked={removeFirstRow} />
+                    </gtk-box>
+                </adw-preferences-group>
+            </adw-preferences-page>
+        </adw-toolbar-view>
+    );
+}
+
+interface Ui {
+    readonly window: Adw.ApplicationWindow;
+    readonly root: ReturnType<typeof createRoot>;
+    readonly incrementRef: RefObject<Gtk.Button>;
+}
+
+function buildUi(app: Adw.Application | null): Ui {
+    const window = new Adw.ApplicationWindow({
+        title: 'react-host counter',
+        default_width: 480,
+        default_height: 520,
+        ...(app ? { application: app } : {}),
+    });
+    const incrementRef = createRef<Gtk.Button>();
+    const root = createRoot(window as unknown as Gtk.Widget);
+    // `render` flushes synchronously (see `createRoot`): a ConcurrentRoot's first
+    // commit is default-lane, and with no main loop running yet an unflushed render
+    // leaves the container empty and says nothing.
+    root.render(<Counter incrementRef={incrementRef} />);
+    return { window, root, incrementRef };
+}
+
+/** Titles of the Adw.ActionRows GTK actually holds, in GTK's own order. */
+const rowTitles = (root: Gtk.Widget): string[] =>
+    descendants(root)
+        .filter((w): w is Adw.ActionRow => w instanceof Adw.ActionRow)
+        .map((row) => row.title);
+
+/** A button by its label, from the real tree — never from React's own bookkeeping. */
+const buttonNamed = (root: Gtk.Widget, label: string): Gtk.Button | null =>
+    findDescendant(root, (w) => w instanceof Gtk.Button && w.label === label) as Gtk.Button | null;
+
+/**
+ * Run the default main context until `done()` or the budget is spent.
+ *
+ * `scheduler`'s host callback is a GLib timer source, so nothing drives it inside a
+ * probe — an application has `Gtk.Application.run`, this has the loop below.
+ * BOUNDED on purpose: a scheduler that never runs has to fail an assertion rather
+ * than hang the process, which is how a probe turns into a `showcase-smoke`
+ * timeout that reports as "still up".
+ */
+function pump(done: () => boolean, budget = 200): boolean {
+    const context = GLib.MainContext.default();
+    for (let i = 0; i < budget; i++) {
+        if (done()) return true;
+        context.iteration(false);
+    }
+    return done();
+}
+
+/** Everything this showcase claims, read back off the REAL widget tree. */
+function assertUi(ui: Ui, check: ProbeCheck): Record<string, unknown> {
+    // 0. The build recipe held. `react-reconciler/index.js` picks its bundle from
+    //    `process.env.NODE_ENV`, and the DEVELOPMENT one reaches for `document`,
+    //    `HTMLCanvasElement` and `Path2D` — which makes `--globals auto` inject the
+    //    GTK-backed DOM registers and pull gi://Gdk, GdkPixbuf, Pango and PangoCairo
+    //    into a bundle that needs none of them. Even the production `scheduler`
+    //    carries `typeof navigator !== 'undefined'`, hence `--exclude-globals
+    //    navigator`. If either global exists here, the recipe was lost.
+    const globals = globalThis as unknown as Record<string, unknown>;
+    check('no DOM was injected (the production define held)', typeof globals.document === 'undefined');
+    check('no navigator was injected (--exclude-globals held)', typeof globals.navigator === 'undefined');
+
+    const window = ui.window as unknown as Gtk.Widget;
+
+    // 1. The string enum nick reached GTK. GObject would have kept HORIZONTAL, so
+    //    read the property back — materialisation always returns something.
+    //
+    //    Reached through the BUTTON, not as "the first Gtk.Box in the window":
+    //    Adw.ApplicationWindow, Adw.ToolbarView and Adw.PreferencesPage all nest
+    //    boxes of their own, and both siblings recorded the same measurement — the
+    //    search-by-type version passed for a box the markup never wrote.
+    const increment = buttonNamed(window, 'Increment');
+    check('the increment button was built', increment !== null);
+    const box = increment?.get_parent() as Gtk.Box | null;
+    check('the JSX box is the button parent', box instanceof Gtk.Box);
+    check("orientation='vertical' reached GTK", box?.orientation === Gtk.Orientation.VERTICAL);
+
+    // 2. Slotted placement authored as a JSX attribute — asserted as PLACEMENT, not
+    //    as presence: a slot that is never read is the whole point of the attribute,
+    //    so "it is somewhere in the subtree" asserts nothing (measured on the Solid
+    //    sibling, where the presence version passed with the header bar genuinely
+    //    rendered at the FOOT of the window).
+    const toolbarView = findDescendant(window, (w) => w instanceof Adw.ToolbarView) as Adw.ToolbarView | null;
+    check('AdwToolbarView is in the window', toolbarView !== null);
+    check('slot="content" placed the page', toolbarView?.get_content() instanceof Adw.PreferencesPage);
+
+    const headerBar = findDescendant(window, (w) => w instanceof Adw.HeaderBar) as Adw.HeaderBar | null;
+    check('AdwHeaderBar is in the window', headerBar !== null);
+    //    `slot="top"` has no getter — `add_top_bar` is write-only and the height
+    //    getters read 0 until the window is allocated, which a headless probe never
+    //    does. What IS readable is the style class Adwaita puts on the revealer it
+    //    wraps each bar in: `top-bar` or `bottom-bar`. Walking up to the toolbar view
+    //    and looking for it separates the two slots, which no subtree search can.
+    const topBarClassAbove = (widget: Gtk.Widget | null): boolean => {
+        for (let w = widget; w !== null && w !== toolbarView; w = w.get_parent()) {
+            if (w.get_css_classes().includes('top-bar')) return true;
+        }
+        return false;
+    };
+    check('slot="top" put the header in the TOP bar', topBarClassAbove(headerBar));
+    const titleWidget = headerBar?.get_title_widget();
+    check(
+        'slot="title" placed the header label',
+        titleWidget instanceof Gtk.Label && titleWidget.label === 'Built by react-reconciler',
+    );
+
+    // 3. A CONSTRUCT-ONLY property authored in JSX reached `g_object_new`. React
+    //    hands the vnode props to `createInstance`, so unlike the Solid path the host
+    //    never has to rebuild the widget to apply it — the adapter difference
+    //    ADR 0027 § Decision 5 predicts, from the other side.
+    const clicks = findDescendant(
+        window,
+        (w) => w instanceof Adw.ActionRow && w.title === 'Clicks',
+    ) as Adw.ActionRow | null;
+    check('the counter row was built', clicks !== null);
+    check('construct-only cssName reached g_object_new', clicks?.cssName === 'row');
+
+    // 4. React's OBJECT `ref` — the spelling the Solid surface's `ref` type cannot
+    //    express. Asserted as IDENTITY against the widget found by walking the real
+    //    tree, because `getPublicInstance` returning *a* widget proves nothing. The
+    //    other half of that op — that a ref never receives the `GtkListBoxRow` the
+    //    host wrapped a child in — needs a wrapping container this window does not
+    //    have, and is a vector in `adapters/react.spec.ts` instead.
+    check('createRef received the author’s own widget', ui.incrementRef.current === increment);
+
+    // 5. The closed conditional occupies no GTK slot. React creates no node for
+    //    `null` at all — no anchor to resolve past — so the box holds exactly the
+    //    three buttons.
+    const actionLabels = () => gtkChildren(box as Gtk.Widget).map((w) => (w as Gtk.Button | Gtk.Label).label);
+    check(
+        'a closed conditional does not occupy a GTK slot',
+        JSON.stringify(actionLabels()) === JSON.stringify(['Increment', 'Add row', 'Remove first row']),
+    );
+
+    // 6. The signal is connected to the real widget AND the update is CONCURRENT.
+    //    Emitted on GTK's side, not by calling the closure — calling it would prove
+    //    only that the closure exists. Both halves are the claim: default-lane work
+    //    goes through `scheduler`, so the tree is still the old one the instant the
+    //    signal returns, and it is patched once the main context runs. A `render()`
+    //    that had quietly become synchronous here would fail the FIRST of these.
+    increment?.emit('clicked');
+    check('a setState from a GTK handler has not landed yet (default lane)', clicks?.subtitle === '0');
+    check(
+        'the main context flushed the scheduled render',
+        pump(() => clicks?.subtitle === '1'),
+    );
+
+    // 7. The opened branch lands BETWEEN its siblings, through `insertBefore`.
+    check(
+        'the opened conditional lands between its siblings',
+        JSON.stringify(actionLabels()) === JSON.stringify(['Increment', 'clicked 1x', 'Add row', 'Remove first row']),
+    );
+
+    // 8. A keyed list inserts before the static sibling — through the `remove-all`
+    //    degradation of Adw.PreferencesGroup — and removal takes the right row out
+    //    while the survivor keeps its IDENTITY. Order alone is satisfied by
+    //    remove-all-and-re-append, which destroys focus and scroll position.
+    const addButton = buttonNamed(window, 'Add row');
+    addButton?.emit('clicked');
+    check(
+        'the first row arrived',
+        pump(() => rowTitles(window).length === 2),
+    );
+    addButton?.emit('clicked');
+    check(
+        'the second row arrived',
+        pump(() => rowTitles(window).length === 3),
+    );
+    check(
+        'keyed rows land before the counter row',
+        JSON.stringify(rowTitles(window)) === JSON.stringify(['Row 1', 'Row 2', 'Clicks']),
+    );
+
+    const survivor = findDescendant(window, (w) => w instanceof Adw.ActionRow && w.title === 'Row 2');
+    buttonNamed(window, 'Remove first row')?.emit('clicked');
+    check(
+        'the removal landed',
+        pump(() => rowTitles(window).length === 2),
+    );
+    check(
+        'removing the first row leaves the rest in order',
+        JSON.stringify(rowTitles(window)) === JSON.stringify(['Row 2', 'Clicks']),
+    );
+    check(
+        'the surviving row is the SAME widget, not a re-created one',
+        survivor !== null &&
+            findDescendant(window, (w) => w instanceof Adw.ActionRow && w.title === 'Row 2') === survivor,
+    );
+
+    return {
+        rows: rowTitles(window),
+        actions: actionLabels(),
+        tree: dumpTree(window).split('\n').length,
+    };
+}
+
+await runHostProbeApp<Ui>({
+    applicationId: 'eu.jumplink.ReactHostCounter',
+    // Ignores the application on purpose — and so does the harness, which always
+    // probes headless. Building an `Adw.ApplicationWindow` with `application: app`
+    // inside `activate` is the neighbourhood of the segfault recorded on
+    // `runHostProbeApp`.
+    build: () => buildUi(null),
+    assert: assertUi,
+    // The probe builds a real toplevel of its own. `unmount` tears down what React
+    // owns inside it; `destroy` is what unparenting cannot reach. Run BEFORE the
+    // harness counts diagnostics, which is the point of the hook — a finalize-time
+    // `still has children left` is exactly the class that only appears there.
+    teardown: (ui) => {
+        ui.root.unmount();
+        ui.window.destroy();
+    },
+    present: (ui) => ui.window.present(),
+});

--- a/showcases/gtk/react-host-counter/src/globals.d.ts
+++ b/showcases/gtk/react-host-counter/src/globals.d.ts
@@ -1,0 +1,9 @@
+// Editor/type-check-only ambient types for the `gi://` source. They surface the
+// `gi://…` module declarations and the GJS ambient globals (`print`, `imports`)
+// from the `@girs/*` packages WITHOUT importing any of them at runtime — the
+// bundle is built from `src/app.tsx` alone.
+/// <reference types="@girs/gjs/ambient" />
+/// <reference types="@girs/glib-2.0/ambient" />
+/// <reference types="@girs/gobject-2.0/ambient" />
+/// <reference types="@girs/gtk-4.0/ambient" />
+/// <reference types="@girs/adw-1/ambient" />

--- a/showcases/gtk/react-host-counter/tsconfig.json
+++ b/showcases/gtk/react-host-counter/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ESNext",
+        "outDir": "dist",
+        "rootDir": "src",
+        "strict": true,
+        "skipLibCheck": true,
+        "types": [],
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
+        // The JSX half of the contract, and this one is the AUTOMATIC runtime —
+        // the opposite of the two siblings, which both preserve JSX for a
+        // framework compiler. `react-jsx` is what makes oxc emit
+        // `import { jsx } from "@gjsify/gtk-host/react/jsx-runtime"`, and that
+        // subpath re-exports React's OWN factories: a React JSX expression is a
+        // renderer-agnostic element record, and the host mapping happens later in
+        // `react-reconciler`. So there is no plugin under `gjsify.bundler.plugins`
+        // here, and nothing for one to consume.
+        //
+        // `jsxImportSource` must NOT be `"react"` — that is the 208-tag trap ADR
+        // 0028 § 8 measured: the element list would come from `@types/react` and
+        // every HTML, SVG and MathML tag would type-check clean on a GTK renderer
+        // and render nothing.
+        //
+        // `strict` supplies `noImplicitAny`, without which every JSX element is
+        // implicitly `any` and `tsc` exits 0 having checked nothing at all.
+        "jsx": "react-jsx",
+        "jsxImportSource": "@gjsify/gtk-host/react"
+    },
+    "include": ["src/**/*"]
+}

--- a/website/src/data/coverage.ts
+++ b/website/src/data/coverage.ts
@@ -114,8 +114,8 @@ export const pillarCoverage: readonly PillarCoverage[] = [
     },
     {
         category: 'Showcases',
-        total: 16,
-        full: 16,
+        total: 17,
+        full: 17,
         partial: 0,
         stub: 0,
     },


### PR DESCRIPTION
React was the one adapter with no end-to-end evidence: three published subpaths
(`./react`, `./react/jsx-runtime`, `./react/jsx-dev-runtime`), no showcase, and no
half in the negative-first type gate.

## The showcase

`showcases/gtk/react-host-counter` renders the same window as its three siblings —
same `tree: 82`, same rows and actions as the Vue probe — so the four are a real
A/B/C/D rather than four different windows. It uses the shared harness rather than a
copy, including the async `assert` and the `teardown` that unmounts the root before
diagnostics are counted.

    PROBE: PASS {"diagnostics":0,"rows":["Row 2","Clicks"],
                 "actions":["Increment","clicked 1x","Add row","Remove first row"],
                 "tree":82}     exit 0

**Seven break tests, each failing on its own** with one edit and nothing else
changed, because a probe that still passes with its assertion deleted is worth
nothing:

| broken | reported |
|---|---|
| `orientation="vertical"` → `"horizontal"` | `orientation='vertical' reached GTK` |
| `slot="title"` deleted | `slot="title" placed the header label` — and the tree GROWS 82→83: the label is still in the subtree, only the getter notices |
| `ref={incrementRef}` deleted | `createRef received the author's own widget` |
| conditional child appended last | `the opened conditional lands between its siblings` |
| `emit('clicked')` in `flushSync` | `a setState from a GTK handler has not landed yet (default lane)` |
| `key={row.id}` → `key={index}` | `the surviving row is the SAME widget, not a re-created one` |
| `slot="content"` → `slot="bottom"` | `slot="content" placed the page` |

`showcase-smoke.mjs --only react-host-counter` → `ok … exited 0`, and nothing needed
registering: the matrix is derived from `showcases/*/*/package.json`, and
`packages/infra/cli/showcases.json` is the catalog for *published* showcases only —
all three siblings are deliberately absent from it too.

## The type-gate half

Generalised rather than copy-pasted: `checkJsxHalf`, `jsxInventory`,
`stripDirectives` and `writeJsxProbeConfig` now take a half descriptor and a
`JSX_HALVES` table holds `jsx` and `react`. The Vue half is untouched.

The half deliberately does not re-state the element/property/handler/nick matrix —
the `jsx` half already gates those same mapped types. It covers exactly what
`open-todos` named as unmeasured: `JSX.Element`, `JSX.ElementType`,
`JSX.IntrinsicAttributes`, `Ref<T>`, `ReactNode` children.

## Two measurements corrected the plan I was given

1. **Under `jsx: "react-jsx"`, an unset *or empty* `jsxImportSource` defaults to
   `"react"`** — measured byte-identical to naming it. So "drop it and every negative
   evaporates" is false for React; dropping it yields the 208-tag trap instead. The
   evaporating probe has to take `jsx` away too. And the negatives must carry **no**
   `react` import, because `@types/react` declares a *global* `JSX` namespace: with
   one present the probe silenced 1 of 8 rather than 6.
2. **`noImplicitAny: true` is not independently load-bearing here.** With a valid
   `jsxImportSource` all 8 negatives still fire with it off. It is load-bearing only
   jointly — it decides whether the surface's *absence* is loud. The gtk-host README
   lists it as if it stood alone; the fixture tsconfig now says the measured thing.

Both are written down at the fixtures rather than in a commit message nobody reads
again.

## Exit codes

    full run                              exit 0, 15 measurements
                                          (jsx 13 and vue 6 unchanged)
    jsxImportSource removed               exit 1, 6 problems
    jsxImportSource: "react"              exit 1, byte-identical to the row above
    noImplicitAny: false alone            exit 0  ← finding 2

Fixture-integrity breaks all report by name: a negative that stops being negative
(`TS2578` + "this line produces NO error"), a mis-annotated code ("annotated TS2322,
got TS2339/TS2786"), a missing `needs=` declaration.

## Left as a decision rather than cemented

`GtkElementType` refuses React **class** components — measured
`declare class C { render(): null }; <C/>` → `TS2786`, while `react-reconciler`
renders class components fine. No negative was added for it: that would cement what
may be a defect in `src/react-jsx-runtime.ts`.
