### PR TITLE
docs: correct the slot-adoption count, retire its half

### DIFF
--- a/docs/adr/0027-gtk-host-layer.md
+++ b/docs/adr/0027-gtk-host-layer.md
@@ -146,11 +146,20 @@ behind it is exactly the defect ADR 0030 § Decision 6 names.
    **What this is not yet: a promise that one component tree renders natively and in
    a browser.** ADR 0007 bought portability at the CONTROLLER layer because that was
    what the surfaces allowed at the time — before any framework renderer existed. The
-   measured obstacle at the markup layer is in the web pillar: 42 of 51
-   `adwaita-web` element files re-home `[slot=]` children exactly once, in
-   `connectedCallback`, so a child appended afterwards is never adopted. A renderer
-   mutates its tree after mount by definition, so that is an upstream fix, not a
-   renderer workaround.
+   measured obstacle at the markup layer was in the web pillar, and it is now FIXED:
+   an `adwaita-web` element re-homed its `[slot=]` children exactly once, in
+   `connectedCallback`, so a child appended afterwards was never adopted. A renderer
+   mutates its tree after mount by definition, so that was an upstream fix rather
+   than a renderer workaround, and it landed there — `src/slotted-children.ts` is the
+   single owner, and adoption is live.
+
+   **The numbers this paragraph used to carry were wrong on both sides, and the
+   correction is worth keeping.** It said "42 of 51 element files … only two adopt
+   late". Re-measured: the directory holds 55 files, 50 of which define elements, so
+   51 matched nothing; 42 was the count of files calling `replaceChildren`, which
+   means "installs its own subtree" rather than "has a slot"; and of the 23 that
+   really re-homed authored children, exactly ONE adopted a late child. A live count
+   inside prose, drifting exactly as the agent-context rules warn.
 
    The criterion that would turn this goal into a decision: **the same authored tree,
    rendered through this host and through `adwaita-web`, satisfies the same

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -101,33 +101,37 @@ Whoever picks it up: the A/B is renaming the suffix to `.gjsify-vue.js` and watc
 the new case go red. Related: the same `order: 'pre'` collision in the SOLID plugin
 was a real defect, fixed in #1296 by splitting `GjsifyConfig.prePlugins`.
 
-### `adwaita-web` adopts `[slot=]` children once, which blocks the shared-vocabulary goal
+### The one-vocabulary goal has no alignment check yet
 
 ADR 0027 § 9 makes one widget vocabulary across native GTK, Blueprint/XML, TSX/JSX,
-Vue templates and this pillar's `adw-*` elements an explicit goal, and names the
-obstacle that lives here: **42 of 51 element files under
-`packages/web/adwaita-web/src/elements/` re-home their `[slot=]` children exactly
-once, in `connectedCallback`.** Only two adopt children appended later. A renderer
-mutates its tree after mount by definition — that is what a renderer is — so the
-same authored markup cannot drive both surfaces while that holds.
+Vue templates and the web pillar's `adw-*` elements an explicit goal. **Its named
+obstacle is gone**: `adwaita-web` adopted `[slot=]` children exactly once, in
+`connectedCallback`, and adoption is now live through `src/slotted-children.ts`. A
+renderer mutates its tree after mount by definition, so that was an upstream fix and
+it landed upstream.
 
-Two pieces of work, in order:
+What is still missing is the mechanism, and it is cheap once the generator
+(ADR 0028 § 6) exists: assert that the emitted surfaces — `JSX.IntrinsicElements`,
+the Vue `GlobalComponents` interface, and the React intrinsics — name the same
+widgets, and that every `adw-*` custom element maps to exactly one of them or is
+listed as deliberately web-only. A name may then only diverge on purpose.
 
-- **The fix is upstream, in this pillar, not in a renderer.** Slot adoption has to be
-  live: observe childList (or re-home on each connected child), so a child appended
-  after mount lands in the same place it would have at parse time. That is also
-  simply correct for hand-written HTML that appends.
-- **Then the alignment mechanism**, which is cheap once the generator (ADR 0028 § 6)
-  exists: assert that the three emitted surfaces — `JSX.IntrinsicElements`, the Vue
-  `GlobalComponents` interface, and the Blueprint/XML tag validator — name the same
-  widgets, and that every `adw-*` custom element maps to exactly one of them or is
-  listed as deliberately web-only. A name may then only diverge on purpose.
+The criterion that closes the GOAL out is in ADR 0027 § 9 and is unchanged: the same
+authored tree, rendered through the GTK host and through `adwaita-web`, satisfies the
+same `@gjsify/adwaita-core/conformance` vectors with no per-surface markup branch.
+Until that is measured the goal stays a direction, not a claim — and the longer
+horizon it points at (NativeScript and browser builds from one native-authored
+source) needs its own ADR.
 
-The criterion that closes this out is in ADR 0027 § 9: the same authored tree,
-rendered through the GTK host and through `adwaita-web`, satisfies the same
-`@gjsify/adwaita-core/conformance` vectors with no per-surface markup branch. Until
-then the goal is a direction, not a claim — and the longer horizon it points at
-(NativeScript and browser builds from one native-authored source) needs its own ADR.
+Two things the slot work left for whoever picks this up. **Ten of the 23 re-homing
+elements are deliberately not converted**: eight consume typed children into a state
+model (pages, sections, selection, roving focus) where going live changes semantics
+and wants its own vectors, `adw-checks` routes conditionally on its `label`
+attribute, and `adw-bottom-sheet` unwraps its wrappers rather than moving children.
+And `bindEmptySections` derives SYNCHRONOUSLY, so it must run AFTER the router's
+`install` — routing first hides a section a declared child had already earned, and it
+only un-hides a microtask later, after `_syncClasses` has measured a bar at
+`offsetHeight` 0. That cost 8 real failures once; the three call sites now say so.
 
 ### An adopted composite offsets by its own internals
 


### PR DESCRIPTION
ADR 0027 § 9 and the matching ledger entry both said *"42 of 51 `adwaita-web` element
files re-home `[slot=]` children exactly once … only two adopt children appended
later"*. Wrong on both sides — and repeated several times before anyone measured it.

Re-measured, and verified independently against `origin/main`:

| | claimed | real |
|---|---|---|
| element files | 51 | **55 files, 50 defining elements** — 51 matched nothing |
| re-home children once | 42 | **23**. 42 is the count of files calling `replaceChildren`, i.e. *"installs its own subtree"*, not *"has a slot"* |
| adopt a late child | 2 | **1**. The other supposed adopter restyles children in place and never re-homes one |

A live count inside prose, drifting exactly as the agent-context rules warn about.
The correction stays visible in § 9 rather than being silently swapped, because the
wrong number is what a reader remembers.

## The obstacle is also gone, so the ledger entry changes shape

§ 9's named blocker is fixed: adoption is live, owned by `adwaita-web`'s
`src/slotted-children.ts` (#1321). Per the ledger's own rule a resolved item is
deleted, so the entry is rewritten to the half that is **still** open — the
cross-surface name-agreement check, which needs the ADR 0028 § 6 generator — instead
of being left describing a defect that no longer exists. Its closing criterion is
unchanged: the same authored tree through both surfaces satisfying the same
`adwaita-core/conformance` vectors with no per-surface markup branch.

## Two things carried forward, because they are what the next person needs

- **Ten of the 23 elements are deliberately not converted**, each with its reason:
  eight consume typed children into a state model (pages, sections, selection, roving
  focus) where going live changes semantics and wants its own vectors; `adw-checks`
  routes conditionally on its `label` attribute; `adw-bottom-sheet` unwraps its
  wrappers rather than moving children.
- **`bindEmptySections` must run AFTER the router's `install`.** It derives
  synchronously, so routing first hides a section a declared child had already
  earned, and it only un-hides a microtask later — after `_syncClasses` has measured
  a bar at `offsetHeight` 0. That cost 8 real failures once; the three call sites now
  say so.
