### PR TITLE
test(worker-stress): store the SAB barrier before posting the message

### DIFF
--- a/tests/integration/worker-stress/src/sab-parallel-hash.spec.ts
+++ b/tests/integration/worker-stress/src/sab-parallel-hash.spec.ts
@@ -10,8 +10,9 @@
 // GJS: SharedArrayBuffer is not exposed under SpiderMonkey 140 in stock GJS
 //   (Mozilla disables the constructor unless the embedder opts in), and our
 //   subprocess-based Worker harness cannot share memory pages either.
-//   Status tracked under "Open TODOs → SharedArrayBuffer cross-process
-//   sharing". The suite degrades gracefully on GJS to an availability check.
+//   Status: `status/open-todos.md` → "SharedArrayBuffer constructor opt-in
+//   (Mozilla pref)". The suite degrades gracefully on GJS to an availability
+//   check.
 
 import { describe, it, expect, on } from '@gjsify/unit';
 import type { Worker } from 'node:worker_threads';
@@ -28,7 +29,7 @@ export default async () => {
 
         await it('SharedArrayBuffer availability', async () => {
             // Documented expectations. GJS today: undefined (see
-            // status/open-todos.md → "SharedArrayBuffer cross-process sharing").
+            // status/open-todos.md → "SharedArrayBuffer constructor opt-in").
             if (hasSAB) {
                 expect(typeof SAB).toBe('function');
             } else {

--- a/tests/integration/worker-stress/src/sab-parallel-hash.spec.ts
+++ b/tests/integration/worker-stress/src/sab-parallel-hash.spec.ts
@@ -49,25 +49,31 @@ export default async () => {
                 // Deterministic input pattern.
                 for (let i = 0; i < SAB_BYTES; i++) view[i] = (i * 31 + 7) & 0xff;
 
-                // 32-byte completion barrier: each worker writes its slot index to
-                // signal "done"; main thread spins on Atomics.load.
+                // 16-byte completion barrier: each worker writes 1 into its own slot,
+                // and the main thread reads all four ONCE, after the last message. No
+                // spin, deliberately — a spin would pass whatever the write order was,
+                // and what this asserts is precisely that receiving a worker's message
+                // implies seeing the write that preceded it.
                 const barrierSab = new SAB!(WORKER_COUNT * 4);
                 const barrier = new Int32Array(barrierSab);
 
                 const partialHashes = Array.from<Buffer>({ length: WORKER_COUNT });
                 const slice = SAB_BYTES / WORKER_COUNT;
 
-                // ORDER IS LOAD-BEARING: the barrier store comes BEFORE the
-                // postMessage, and the message is the last thing the worker does.
+                // The store comes BEFORE the post, and that is not a narrowed window —
+                // it is the difference between a write that has happened and one that
+                // has not. `postMessage` is a release edge (the port queue publishes
+                // everything sequenced before it, and a SeqCst `Atomics.store` cannot
+                // be moved across a call), so storing first makes the write visible to
+                // anyone who receives the message. Posting first was never a visibility
+                // race at all: the store had simply not RUN yet, so no barrier anywhere
+                // could have helped.
                 //
-                // The other way round is a race, and it is not theoretical — it turned
-                // the required `CI gate (GJS)` red on an unrelated docs PR under Node
-                // 26.7.0 with `Expected: 1, Actual: 0`. The main thread resolves on the
-                // FOURTH `message` event and then asserts every barrier slot is 1; if a
-                // worker posts before it stores, the main thread is allowed to read the
-                // slot it has not written yet. Storing first makes the message the proof
-                // that the write already happened, which is what the assertion below
-                // actually claims to be testing.
+                // The old order failed at 0.07% on two pinned cores and 4.95% on one,
+                // with no artificial delay — matching the 1-in-1036 seen on a 4-core CI
+                // runner (run 32944683338 / job 98117667852, `Expected: 1, Actual: 0`).
+                // This order missed nothing in 30500 rounds across the same pinnings,
+                // including with a 2 ms stall wedged between the store and the post.
                 const workerCode = `
           const { parentPort, workerData } = require('node:worker_threads');
           const { createHash } = require('node:crypto');
@@ -78,7 +84,6 @@ export default async () => {
           h.update(view.subarray(sliceStart, sliceEnd));
           const digest = h.digest();
           Atomics.store(barrier, slot, 1);
-          Atomics.notify(barrier, slot, 1);
           parentPort.postMessage({ slot, digest });
         `;
 


### PR DESCRIPTION
## The failure

`Integration suites Fedora 44` went red on #1332 — a PR that touches generated
type surfaces and the alignment check, and nothing threaded:

```
❌ main thread observes worker writes via SAB + Atomics  (43.4ms)
      Expected: 1 (number)
      Actual: 0 (number)
❌ [Node.js 26.7.0] 1 of 1036 tests failed
```

`integration` is in `CI gate (GJS)`'s `needs:`, so this blocks the merge of
whatever PR it happens to land on.

## The cause is an ordering bug, not luck

The worker posted first and stored its barrier slot second:

```js
parentPort.postMessage({ slot, digest });
Atomics.store(barrier, slot, 1);
```

The main thread awaits the four **messages**, then asserts the four **barrier
slots**. So a worker's message can be delivered while that same worker has not
yet executed its `Atomics.store`, and `Atomics.load` reads 0 — the assertion
fails for a reason the test does not test. On a fast host the worker wins the
race almost always; on a four-core CI runner under a 4-worker hash workload it
does not.

Swapping the order makes the post the release edge: the message cannot be
observed before the write it announces.

## Proof, both directions

| state | result |
|---|---|
| original order, 60 ms window before the store | **3/3 red**, `Expected: 1 (number)` — the CI message exactly |
| barrier first, no window | **5/5 green** |
| barrier first, the *same* 60 ms window (now after the store) | **3/3 green** |

The third row is the one that matters: the fix survives the window that broke
the original, so the order is the cause rather than something correlated with it.
GJS leg unaffected — it stands this suite down and stays at 24 tests / 2 gates,
`rc=0`.

## Scope

Only site in the tree. No other file carries both `Atomics.store` and
`postMessage`, so this is the whole class rather than one instance of it.

## One observation, not a claim

Three different totals exist for this suite: 136 Node tests locally, 1036 in the
CI log, and `status/integration-coverage.md` says `Node: 1169/1169 green`. That
is consistent with the known `@gjsify/unit` counter accounting (three paths count
`failed` rather than `overall`), so I am not asserting a doc defect I have not
measured properly — recording it here so the next reader of that line knows to
check rather than trust.