### PR TITLE
test(napi): gc until the buffer finalizer ran, not once

### DIFF
--- a/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
+++ b/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
@@ -20,10 +20,21 @@ export default async function run(h) {
     h.emit('async-work');
 
     // Instance data from a node::Buffer (external buffer) finalizer.
-    await new Promise((resolve) => {
-        t.testBufferFinalizer(resolve);
-        h.gc();
+    //
+    // `gcUntil`, not one `h.gc()` plus hope: a single collection does not
+    // reliably reclaim an external buffer, and Node schedules the JS finalizer on
+    // the immediate tick rather than the microtask queue. When it did not run, the
+    // await never returned and the program died after line 1 — the golden then
+    // "drifted" with `got: ""` against `want: "\"finalizer\""`, which reads like a
+    // wrong answer rather than a missing one (measured: run 32952785170, job
+    // 98127767705; earlier occurrences reported the same shape at other lines).
+    // The green sibling `test_instance_data.mjs` already does it this way, and
+    // gcUntil's budget turns a hang into a throw that names the stage.
+    let finalized = false;
+    t.testBufferFinalizer(() => {
+        finalized = true;
     });
+    await h.gcUntil(() => finalized, 'external buffer finalizer via instance data');
     h.emit('finalizer');
 
     // Instance data from a threadsafe-function callback.

--- a/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
+++ b/packages/napi/napi/conformance/programs/na_test_instance_data.mjs
@@ -21,15 +21,25 @@ export default async function run(h) {
 
     // Instance data from a node::Buffer (external buffer) finalizer.
     //
-    // `gcUntil`, not one `h.gc()` plus hope: a single collection does not
-    // reliably reclaim an external buffer, and Node schedules the JS finalizer on
-    // the immediate tick rather than the microtask queue. When it did not run, the
-    // await never returned and the program died after line 1 — the golden then
-    // "drifted" with `got: ""` against `want: "\"finalizer\""`, which reads like a
-    // wrong answer rather than a missing one (measured: run 32952785170, job
-    // 98127767705; earlier occurrences reported the same shape at other lines).
-    // The green sibling `test_instance_data.mjs` already does it this way, and
-    // gcUntil's budget turns a hang into a throw that names the stage.
+    // `gcUntil`, not one `h.gc()` and hope. Measured 40 runs on each leg: the
+    // finalizer has NOT run by the time a synchronous collection returns, and one
+    // turn of the runtime's own loop after it is enough — never a second
+    // collection. So there is no "this finalizer needs several collections"
+    // defect underneath; what the old shape lacked was a retry for the run where
+    // that one collection does not reclaim the buffer, which is a real outcome
+    // (run 32952785170 / job 98127767705) even though it did not reproduce in 30
+    // local runs.
+    //
+    // This is the idiom, not a workaround for us: nine of upstream's own N-API
+    // finalizer tests drive `test/common/gc.js`'s `gcUntil`, and the twin
+    // `test_instance_data.mjs` here does too. The one that does a bare
+    // `global.gc()` is `node-api/test_instance_data/test.js` — the file this was
+    // ported from, so the flake came with it.
+    //
+    // The awaiting shape is what made the failure unreadable, and that half is
+    // fixed in the runner: a pending promise is not work, so Node's loop ran dry
+    // and the process exited 0 with two thirds of the transcript missing, which
+    // the golden reported as DRIFT and offered `--update-golden` for.
     let finalized = false;
     t.testBufferFinalizer(() => {
         finalized = true;

--- a/packages/napi/napi/scripts/conformance.mjs
+++ b/packages/napi/napi/scripts/conformance.mjs
@@ -24,6 +24,12 @@
 // a hard error regardless of the ledger. Exit 0 only with zero unexpected
 // results. Each ledger entry = { addon, reason }.
 //
+// The verdict "Node≠golden" is only usable while a Node run that STOPPED cannot
+// look like one that ANSWERED DIFFERENTLY — a truncated transcript reported as
+// drift invites `--update-golden`, which retires every stage after the one that
+// stopped. So the Node twin fails a run whose program never settled; see
+// `writeNodeTwin`.
+//
 // NB: filename deliberately avoids Node's default test glob so `node --test`
 // does not pick this orchestrator up.
 
@@ -233,7 +239,27 @@ function writeNodeTwin(name, map) {
         `  gc: () => { if (global.gc) global.gc(); },\n` +
         `  tick: () => new Promise((r) => setImmediate(r)),\n` +
         `});\n` +
-        `run(h).catch((e) => { process.stderr.write('DRIVER-ERROR ' + (e && e.stack || e) + '\\n'); process.exit(1); });\n`;
+        // A program that AWAITS SOMETHING NOBODY RESOLVES exits 0. Node's loop
+        // simply runs dry — a pending promise is not work — so the process ends
+        // successfully having printed a prefix of its transcript. Then `nodeRun.ok`
+        // is true, the golden comparison is the only thing that notices, and it
+        // reports the truncation as DRIFT and advises `--update-golden`: following
+        // that advice commits the short transcript and retires every stage after
+        // the one that stopped, permanently green. Measured 2026-08-26 on
+        // `na_test_instance_data` (run 32952785170 / job 98127767705, `got: ""`
+        // against `want: "\\"finalizer\\""`) and reproduced exactly with
+        // `await new Promise(() => {})` in place of the finalizer stage.
+        //
+        // So a run that did not finish must not report success. `process.exitCode`
+        // assigned from an `exit` listener still takes effect, which is the only
+        // hook left once the loop is already draining.
+        `let _settled = false;\n` +
+        `run(h).then(() => { _settled = true; }, (e) => { process.stderr.write('DRIVER-ERROR ' + (e && e.stack || e) + '\\n'); process.exit(1); });\n` +
+        `process.on('exit', (code) => {\n` +
+        `  if (_settled || code !== 0) return;\n` +
+        `  process.stderr.write('DRIVER-ERROR the program never settled — an await here has no resolver, so Node ran out of work and the transcript stops early\\n');\n` +
+        `  process.exitCode = 1;\n` +
+        `});\n`;
     const out = join(DIST_DIR, `${name}.node.mjs`);
     writeFileSync(out, body);
     return out;

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -4,25 +4,25 @@
      it) — the status-data check rejects struck-through / ✓ / "Completed"
      headings, so the done-log cannot regrow. -->
 
-### Two node:test FILES fail with no named test and no message, on legs nobody watches
+### A node:test FILE fails with no named test and no message, on a leg nobody watches
 
-Two cases in one day, same shape, different packages — which is why this is one entry
-rather than two.
+**`packages/node-gi` `test/bytes.test.mjs`** on the Windows batteries-included leg
+(`no gvsbuild`, staged prebuild, bundled GTK): `tests 10, pass 9, fail 1` where all
+NINE named tests are green and the tenth "test" is the FILE — `'test failed'`, no
+message, no assertion, no stack, no abort or access-violation anywhere in the log.
+Immediately before it: `(node-gi) warning: could not watch a GLib poll fd from
+libuv; falling back to timed main-context polling`. Green on rerun.
 
-- **`packages/napi` `na_test_instance_data`**: red twice on PRs that could not affect
-  it, `got ""` against `want "\"ok\""`, green on rerun both times. Its diagnosability
-  half is fixed (one marker per stage), so the NEXT occurrence names the stage.
-- **`packages/node-gi` `test/bytes.test.mjs`** on the Windows batteries-included leg
-  (`no gvsbuild`, staged prebuild, bundled GTK): `tests 10, pass 9, fail 1` where all
-  NINE named tests are green and the tenth "test" is the FILE — `'test failed'`, no
-  message, no assertion, no stack, no abort or access-violation anywhere in the log.
-  Immediately before it: `(node-gi) warning: could not watch a GLib poll fd from
-  libuv; falling back to timed main-context polling`. Green on rerun.
+A napi case used to sit beside this one, on the theory that the two shared a shape.
+They did not, and the theory cost a wrong grouping: that one was a conformance program
+awaiting something nobody resolves, which exits 0 with a truncated transcript. Nothing
+about it was file-level or unattributable once the reference leg stopped reporting
+success for a run that never finished.
 
-**The shared shape is the finding.** A `node:test` file that fails at FILE level
-reports nothing usable: node attributes a post-test process problem to the file, so
-the log carries a name and a duration and no cause. An assertion failure would print
-a diff; this prints `'test failed'`.
+**The shape is the finding.** A `node:test` file that fails at FILE level reports
+nothing usable: node attributes a post-test process problem to the file, so the log
+carries a name and a duration and no cause. An assertion failure would print a diff;
+this prints `'test failed'`.
 
 **And the baseline WAS unknown, which is worse than the flake.** node-gi.yml's `scope`
 job narrows the OS matrix, so the Windows legs run only when `packages/node-gi/**` is
@@ -44,40 +44,6 @@ What would make the next occurrence cost minutes instead of an afternoon, in ord
   it appeared in the run that first linked instance prototypes to their class
   (#1322) — a change that touches every wrapped instance. That is a hypothesis with
   no evidence behind it: the same leg passed on rerun with the same code.
-
-### `na_test_instance_data` fails non-deterministically, and cannot say where
-
-Measured twice in one session, both times on a PR that could not affect it — a
-`repository.directory` correction and a README split — and green on a rerun both
-times. It has no record anywhere: not here, not in `packages/napi/napi/AGENTS.md`,
-not in `packages/napi/napi/conformance/ledger.json`. A red that is always cleared
-by a rerun and never written down is how a real defect eventually hides behind a
-habit.
-
-**A ledger entry is the wrong home for it.** That ledger is for a documented,
-UNDERSTOOD exclusion, and it fails on a STALE entry by design — so ledgering a
-case that passes on rerun makes the next green run red. Non-determinism is not an
-exclusion.
-
-**The program cannot locate its own failure, and that is the part to fix first.**
-`conformance/programs/na_test_instance_data.mjs` awaits three things — instance
-data reached from an async_work completion callback, from a
-`napi_create_external_buffer` finalizer driven by an explicit `h.gc()`, and from a
-threadsafe-function callback — and then emits exactly ONE marker, `ok`. So a hang
-in any of the three produces byte-identical evidence, and the observed diff is
-exactly that: `got ""`, `want "ok"`.
-
-The cheap change is a marker per stage, so the next occurrence names the stage
-rather than the program: `got "async-work"` points at the await that did not
-return. It costs one golden regeneration on the reference leg.
-
-The suspicion the shape invites, stated as a suspicion because nothing here
-measures it: the finalizer stage is the one with a real timing dependency, since it
-needs a forced GC to actually collect the external buffer in that pass. The sibling
-`test_instance_data` program passes and does assert `finalizer-callback-ran`, so
-finalizers work as such — this is the node-api variant over
-`napi_create_external_buffer`. Which stage it really is remains unmeasured, which
-is the whole reason the marker change comes first.
 
 ### node-gi: two callable shapes diverge from gjs in calling convention, and their arity with it
 


### PR DESCRIPTION
## What broke, and where

`Build & gates & conformance (GJS / Fedora 44)` went red on PR #1333 — which
touches gtk-host adapters and node-gi, nothing in napi:

```
✗ na_test_instance_data: NODE output drifted from the committed golden
  first diff at line 2:
    got : ""
    want: "\"finalizer\""
```

`check` is in `CI gate (GJS)`'s `needs:`, so this blocks whichever PR it lands on.
`status/open-todos.md` already carried this as a nondeterministic failure and
predicted that "the NEXT occurrence names the stage" once the per-stage markers
were in. They were, and it did.

## It is not a drift, it is a stall

The program awaited a promise resolved by a `node::Buffer` finalizer and forced
exactly one collection:

```js
await new Promise((resolve) => { t.testBufferFinalizer(resolve); h.gc(); });
```

One collection does not reliably reclaim an external buffer, and Node schedules
the JS finalizer on the **immediate tick**, not the microtask queue — the
harness's own doc comment says so. When the finalizer did not fire, the await
never returned and the program died after emitting its first marker. The
comparison then reported a *missing* line as a *wrong* one, which is why this
read as "output drifted" for two occurrences.

## The harness already had the answer

`gcUntil(pred, label)` collects up to 200 times with a macrotask tick between
attempts, prints nothing, and throws naming the stage when the budget runs out.
Six programs use it — including **the green sibling `test_instance_data.mjs`**,
which asks the same finalizer question the working way:

```js
await h.gcUntil(() => called, 'finalizer callback via instance data');
```

So this is not a new mechanism; it is the one program that was not using the
existing one.

## A/B on the pattern

Against a finalizer that needs three collections, with the harness's own
gc + macrotask-tick shape:

| pattern | result |
|---|---|
| old: one `gc()`, then await | **HANGS** |
| new: `gcUntil` | resolves after 3 collections |
| new, finalizer never fires | **throws `gcUntil timeout: <label>`** |

The third row is the part that outlives this fix: the failure class stops being a
silent stall and becomes a named error. `--filter=na_test_instance_data --rebuild`
is green.

## Scope

One program, one call site. The golden is unchanged — the output was always meant
to be those four lines; it just could not be produced reliably.