### PR TITLE
docs(adr): a JSX namespace need not be global

### DIFF
--- a/docs/adr/0029-girs-widget-vocabulary.md
+++ b/docs/adr/0029-girs-widget-vocabulary.md
@@ -100,16 +100,45 @@ declares its own dialect on top.**
 
 ### 1. Data-shaped, never JSX-shaped
 
-A JSX namespace is a global declaration; two consumers declaring one is a merge,
-not two dialects. This is observed rather than feared: gtkx emits
-`declare global { namespace React.JSX { interface IntrinsicElements { … } } }`
-per namespace, with no module-scoped `JSX`, no `jsxImportSource` indirection and
-no opt-out. Importing one widget pulls the whole element table, React's DOM
+A JSX namespace does NOT have to be global. `gtk-host` ships TWO module-scoped
+ones — `src/jsx-runtime.ts:41` for Solid and `src/react-jsx-runtime.ts:97` for
+React — in ONE package, each reached through its own `jsxImportSource`, and they
+do not collide with each other or with anything else; the package contains no
+`declare global` at all. An earlier revision of this ADR said a JSX namespace *is*
+a global declaration; that is false as stated, and two dialects coexisting in one
+of our own packages is the counterexample.
+What is true is the PRACTICE: gtkx emits
+`declare global { namespace React.JSX { interface IntrinsicElements { … } } }` per
+namespace, with no module-scoped `JSX`, no `jsxImportSource` indirection and no
+opt-out — so importing one widget pulls the whole element table, React's DOM
 intrinsics stay in scope, and a second library augmenting the same interface
-collides hard on any shared tag.
+collides hard on any shared tag. That is the shape to avoid, not JSX itself.
 
-`@girs/*` is used by projects that want nothing to do with JSX, so it is exactly
-the package that must not do this.
+So the reason the surface is data-shaped is not that a JSX form is impossible
+here. It is that every JSX form is a DIALECT decision, and there are four of them:
+
+- **The tag spelling.** The GIR knows `AdwToolbarView`. Turning that into
+  `adw-toolbar-view` is a renderer's choice, and the constraint behind it is
+  Volar's resolution rule rather than anything in the GIR.
+- **The signal prop names.** `onClicked` in Solid and React, `@clicked` in a Vue
+  template. GObject itself says `clicked`.
+- **The shape each framework wants.** Solid wants a `JSX` namespace off its own
+  `jsxImportSource`, React wants `React.JSX`, Vue wants a `GlobalComponents`
+  interface. A package emitting all three would have to know all three.
+- **Bundler knowledge.** `jsx-runtime`'s four exports are throwing stubs whose
+  message names `babel-preset-solid` and the Vue SFC compiler. That is a statement
+  about the build, not about the type system.
+
+And the cost of leaving all four to the consumer is one line — `GtkIntrinsicElements`
+is a single mapped type over the maps this subpath emits. Everything expensive
+(properties per widget, enum nicks, construct-only unions, the GType map) is here;
+what stays with the consumer is the spelling. A second consumer with a different
+dialect writes its own line and duplicates nothing.
+
+`@girs/*` is used by projects that want nothing to do with JSX, so an opt-in
+data subpath is what serves both. Should a JSX surface ever be worth SHARING
+between consumers, the answer is a package layered ON `@girs/*` — never `@girs/*`
+itself, and never a global augment.
 
 ### 2. What the subpath exports
 


### PR DESCRIPTION
## The claim that was wrong

ADR 0029 § 1 justified the data-shaped `@girs/<ns>/surface` like this:

> A JSX namespace is a global declaration; two consumers declaring one is a merge,
> not two dialects.

The first clause is false, and the counterexample is in this repo. `gtk-host`
ships **two** module-scoped JSX namespaces in **one** package:

| file | dialect |
|---|---|
| `packages/framework/gtk-host/src/jsx-runtime.ts:41` | Solid (`jsx: "preserve"`) |
| `packages/framework/gtk-host/src/react-jsx-runtime.ts:97` | React (`jsx: "react-jsx"`) |

Each is reached through its own `jsxImportSource`, they do not collide with each
other, and `grep -rn 'declare global' packages/framework/gtk-host/src/` returns
nothing.

## What was actually observed, and stays

gtkx emits `declare global { namespace React.JSX { … } }` per namespace — no
module-scoped `JSX`, no `jsxImportSource` indirection, no opt-out. That is what
puts React's DOM intrinsics in scope, pulls the whole element table from one
widget import, and collides with any other library on a shared tag. The incident
is preserved; only its generalisation is withdrawn. **The shape to avoid is the
global augment, not JSX.**

## The reason, restated as what it is

Every JSX form is a *dialect* decision, and there are four:

- **Tag spelling** — the GIR knows `AdwToolbarView`; `adw-toolbar-view` is a
  renderer's choice, constrained by Volar's resolution rule rather than by GIR.
- **Signal prop names** — `onClicked` (Solid, React) vs `@clicked` (Vue template);
  GObject itself says `clicked`.
- **The shape each framework wants** — Solid a `JSX` off its own
  `jsxImportSource`, React `React.JSX`, Vue a `GlobalComponents` interface.
- **Bundler knowledge** — `jsx-runtime`'s four exports are throwing stubs whose
  message names `babel-preset-solid` and the Vue SFC compiler.

And leaving all four to the consumer costs **one line**: `GtkIntrinsicElements` is
a single mapped type over the maps the subpath already emits. Everything expensive
— properties per widget, enum nicks, construct-only unions, the GType map — is in
`@girs`. A second consumer with a different dialect writes its own line and
duplicates nothing.

The ADR now also says where a *shared* JSX surface would go if one is ever worth
having: a package layered **on** `@girs/*`, never `@girs/*` itself and never a
global augment.

## Why this is worth a PR of its own

A wrong reason inside an Accepted ADR is worse than no reason — it describes an
open path as closed, and the next person to want a fourth adapter reads it as a
prohibition. This repo already carries the note that an ADR which was false at
acceptance is an expensive class of mistake; this is that class, caught one day
later.

Docs only. `check-adr-index`, `check-doc-fences` and `check-agent-context-size
--check` all exit 0.