### PR TITLE
feat(manifest-conformance): hold the ADR 0019 library boundary

### DIFF
--- a/docs/adr/0019-ts-for-gir-as-library.md
+++ b/docs/adr/0019-ts-for-gir-as-library.md
@@ -137,7 +137,9 @@ it: `@ts-for-gir/lib`, `@ts-for-gir/cli` and `@gi.ts/parser` all resolve
 `exports["."]` to `./src/index.ts`. So a **`dependencies` edge from a published
 `@gjsify/*` package onto one of them publishes raw TypeScript to everyone who installs
 the depending package.** The sanctioned seam is a `devDependency` that gjsify bundles,
-which is what all eight existing edges in this repo already are.
+which is what all seven published edges in this repo already are (all of them on
+`@ts-for-gir/cli`; `@ts-for-gir/lib` itself appears only under the private
+integration test, which declares no tier and publishes nothing).
 
 Nothing enforced that. `scripts/manifest-conformance/rules/tier.mjs` collects only
 `dep.startsWith('@gjsify/')`, so an external `@ts-for-gir/*` edge was invisible to it,

--- a/docs/adr/0019-ts-for-gir-as-library.md
+++ b/docs/adr/0019-ts-for-gir-as-library.md
@@ -129,6 +129,44 @@ is still open".
 Decision 2 is **independent** of this: declaring `gjsify.prebuilds` adds a `.gir`
 to the tarball, not a dependency edge.
 
+### 4. The boundary Decision 1 implies is now enforced, not trusted
+
+Added 2026-08-26, while auditing what else could move to ts-for-gir. Decision 1 keeps
+every `@ts-for-gir/*` and `@gi.ts/*` package build-step-free, and the registry confirms
+it: `@ts-for-gir/lib`, `@ts-for-gir/cli` and `@gi.ts/parser` all resolve
+`exports["."]` to `./src/index.ts`. So a **`dependencies` edge from a published
+`@gjsify/*` package onto one of them publishes raw TypeScript to everyone who installs
+the depending package.** The sanctioned seam is a `devDependency` that gjsify bundles,
+which is what all eight existing edges in this repo already are.
+
+Nothing enforced that. `scripts/manifest-conformance/rules/tier.mjs` collects only
+`dep.startsWith('@gjsify/')`, so an external `@ts-for-gir/*` edge was invisible to it,
+and no other conformance rule inspects external dependency names — a package could
+have taken that edge and passed `audit-runtimes --check` silently. The `tier` rule now
+also fails on it, by name, the same shape it already used for ADR 0005's node-gi
+isolation and for the same reason: these are external packages with no `gjsify.tier`,
+so the tier walk structurally cannot see them.
+
+**This does not restrict where GIR-derived DATA may flow.** `@girs/*` packages ship
+`.d.ts` plus runtime `.js` and are unaffected — which is why ADR 0029's migration of the
+widget vocabulary into `@gjsify/gtk-host` costs no new dependency edge at all: the
+surface arrives as generated types on a package gtk-host already depends on.
+
+### 5. What the boundary answers about migrating more code here
+
+The audit behind Decision 4 sorted every introspection-carrying module in gjsify on one
+question, recorded in `status/open-todos.md` § "What else could move to ts-for-gir":
+**ts-for-gir knows GIR as XML** — parsed headlessly, in CI, with no GTK installed and no
+typelib loaded — while **gjsify knows GI as a loaded runtime**. A module that needs an
+installed library cannot move to a generator that runs without one, so the whole
+typelib-loading cluster (`systemGiLibraryDirs()` and its two mirrors, `gi-typelib.ts`,
+the typelib binary-header parser, both `parseGiSpecifier` copies, `repo.cc`) stays,
+and ADR 0029's already-decided generator move is the only real candidate. The three
+`systemGiLibraryDirs()` copies are held apart by ADR 0005's tier rule rather than by a
+technical obstacle, and their home is a shared `@gjsify/*` package: answering "can it
+move to ts-for-gir" with yes would export a runtime concern into a generator to dodge a
+tier rule.
+
 ## Consequences
 
 - `@ts-for-gir/lib` gains a public programmatic surface, so it acquires a

--- a/packages/framework/gtk-host/src/generator/gir.mts
+++ b/packages/framework/gtk-host/src/generator/gir.mts
@@ -61,8 +61,16 @@ export interface GirProperty {
  * GIR writes `baseline_fill`; the nick GObject registered is `baseline-fill`. This
  * is the FALLBACK for a `<member>` with no `glib:nick` — the attribute itself is
  * the answer wherever it exists, because the substitution is right for Gtk and Adw
- * by luck and not by construction: across every GIR in this workspace 40,940
- * members carry the attribute and 97 disagree with it.
+ * by luck and not by construction: some nicks keep an underscore it would have
+ * replaced, and nothing but the attribute knows which one survived.
+ *
+ * The count that used to sit here is now `ts-for-gir/scripts/check-nick-derivation.mjs`,
+ * which owns the corpus this measures over. It also settles what looked like a
+ * contradiction: this file said 97 and ts-for-gir said 889 over the SAME 705 GIRs,
+ * and both were right — the derivations differ. 889 counts a fallback that also
+ * lowercases, which adds the 792 members whose GIR name carries uppercase and whose
+ * nick preserves it. This one does not lowercase, so 97 is its number. Quote a
+ * derived-nick count without naming its derivation and you get that pair back.
  */
 export const nickOf = (member: string): string => member.replace(/_/g, '-');
 

--- a/scripts/manifest-conformance/rules/tier.mjs
+++ b/scripts/manifest-conformance/rules/tier.mjs
@@ -12,6 +12,9 @@
  *      looseness and are exempt by design;
  *   3. no Tier-1/2 package hard-depends on `@gjsify/node-gi`. Subsumed by 2 while
  *      node-gi is Tier 3, but asserted by name so it survives a tier edit.
+ *   4. no published package hard-depends on `@ts-for-gir/*` or `@gi.ts/*` (ADR 0019
+ *      Decision 1). Same by-name shape as 3, and for the same reason: those packages
+ *      are deliberately build-step-free, so the edge is not a tier question at all.
  */
 
 import { defineRule, packagesUnder, readManifest } from '../../../packages/infra/manifest-conformance/lib/index.mjs';
@@ -19,6 +22,18 @@ import { relative, resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 
 const VALID_TIERS = new Set([1, 2, 3]);
+
+/**
+ * The scopes ts-for-gir publishes, which ADR 0019 Decision 1 keeps build-step-free:
+ * every one of them resolves `exports["."]` to `./src/index.ts`, verified on the
+ * registry rather than assumed. A `dependencies` edge on one therefore ships raw
+ * TypeScript to everyone who installs the depending package from npm.
+ *
+ * Checked by NAME, like the node-gi rule above, because it is not a tier question —
+ * these are external packages with no `gjsify.tier` at all, which is exactly why the
+ * tier walk below used to skip them and this boundary went unenforced.
+ */
+const isBuildStepFree = (dep) => dep.startsWith('@ts-for-gir/') || dep.startsWith('@gi.ts/');
 
 /**
  * Workspace roots that may contain published packages (root package.json
@@ -41,7 +56,7 @@ export function collectPublishedPackages(root) {
         const edges = [];
         for (const field of ['dependencies', 'optionalDependencies']) {
             for (const dep of Object.keys(pkg[field] ?? {})) {
-                if (dep.startsWith('@gjsify/')) edges.push({ dep, field });
+                if (dep.startsWith('@gjsify/') || isBuildStepFree(dep)) edges.push({ dep, field });
             }
         }
         published.set(pkg.name, { path: relative(root, dir), tier: pkg.gjsify?.tier, edges });
@@ -62,6 +77,12 @@ export function auditTiers(published) {
     for (const [name, info] of published) {
         if (!VALID_TIERS.has(info.tier)) continue; // already reported above
         for (const { dep, field } of info.edges) {
+            if (isBuildStepFree(dep)) {
+                failures.push(
+                    `${name} (${info.path}) → ${dep} via ${field}: forbidden by ADR 0019 Decision 1 — ${dep} exports \`./src/index.ts\`, so a hard edge publishes raw TypeScript to every consumer of ${name}. The sanctioned seam is a devDependency that gjsify BUNDLES (\`gjsify build --app node\`), which is what all existing edges in this repo are.`,
+                );
+                continue;
+            }
             const target = published.get(dep);
             // Not a published workspace package (private example, or an external
             // `@gjsify/*`) — out of tier-contract scope. A published package depending
@@ -96,7 +117,8 @@ export const tierRule = defineRule({
             stats: { published: published.size },
             summary:
                 `tier audit: OK. ${published.size} published package(s) declare a tier; ` +
-                'dependency-direction + ADR-0005 node-gi isolation hold on every deps/optionalDeps edge.',
+                'dependency-direction, ADR-0005 node-gi isolation and the ADR-0019 build-step-free ' +
+                'boundary hold on every deps/optionalDeps edge.',
             published,
         };
     },

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -260,19 +260,32 @@ library cannot move to a generator that runs without one.
 **Moves — and it is all one thing, already decided.** ADR 0029 steps 3–5, blocked on the
 release above:
 
-| module | code | GIR-generic | what holds it here |
-|---|---:|---:|---|
-| `gtk-host/src/generator/gir.mts` | 249 | 248 | one import, `@gjsify/domparser` |
-| `gtk-host/src/generator/surface.mts` | 196 | 196 | nothing — imports only its two siblings |
-| `gtk-host/src/generator/tsmap.mts` | 100 | 100 | nothing |
-| `gtk-host/src/generator/mini.fixture.mts` | 59 | 59 | nothing |
-| `gtk-host/src/generator/emit-types.mts` | 156 | ~151 | `tagOf` + the emitted `../attrs.js` import — the dialect half stays |
-| `gtk-host/src/generator/emit.mts` | 103 | 13 | the runtime table is gtk-host's model (ADR 0028 § 1) |
+ADR 0029 § "The seam, measured" owns the per-module counts and they are not restated
+here. What this audit adds is the second, different question — not "how many lines are
+GIR-generic" but **"how many lines mention gjsify at all"**, which is what decides
+whether a module can compile somewhere else:
 
-The first four are a closed subgraph: 604 code lines whose only edge outside
-`generator/` is a single XML-parser import. `tsmap.mts` is worth naming separately —
-its `GIRS_PACKAGES` table maps `Gtk` → `@girs/gtk-4.0`, which is **ts-for-gir's own
-naming convention, written down on the wrong side of the boundary.**
+| module | code (ADR 0029) | lines referencing gjsify | what holds it here |
+|---|---:|---:|---|
+| `generator/gir.mts` | 249 | 1 | `import { DOMParser } from '@gjsify/domparser'` |
+| `generator/surface.mts` | 196 | 0 | nothing — imports only its two siblings |
+| `generator/tsmap.mts` | 100 | 8 | the `@girs/*` package table, and see below |
+| `generator/mini.fixture.mts` | 59 | 0 | nothing |
+| `generator/emit-types.mts` | 156 | 5 | `tagOf` + the emitted `../attrs.js` import |
+| `generator/emit.mts` | 103 | 0 | the runtime table is gtk-host's MODEL (ADR 0028 § 1) |
+| `generator/main.mts` | 128 | 3 | `CURATED_DESCRIPTORS` + `methodsOf` wiring |
+
+Read the two questions together and the split is sharper than either alone. The first
+four modules are a closed subgraph — 604 code lines whose only edge outside `generator/`
+is a single XML-parser import — while `emit.mts` mentions gjsify **nowhere** and still
+must stay, because ADR 0029's own column shows only 13 of its 103 lines are GIR-generic:
+it is gtk-host's model expressed in pure TypeScript. A module can be free of gjsify
+imports and still be entirely about gjsify.
+
+`tsmap.mts`'s 8 lines are worth naming separately, because they are the one case where
+the reference points the other way: `GIRS_PACKAGES` maps `Gtk` → `@girs/gtk-4.0`, which
+is **ts-for-gir's own naming convention, written down on the wrong side of the
+boundary.**
 
 **Does not move, and the reason is the same reason each time.** These read as candidates
 because they are full of GI vocabulary, but every one of them needs something a headless
@@ -306,9 +319,10 @@ generator to dodge a tier rule.
 **The dependency-direction check, per ADR 0019, and one finding.** ADR 0019 Decision 1
 keeps ts-for-gir build-step-free — `@ts-for-gir/lib`'s `exports` is literally
 `{".": "./src/index.ts"}` — so a published `@gjsify/*` package taking a
-`dependencies` edge on it would hand raw TypeScript to every consumer. Today all eight
-`@ts-for-gir/*` edges in this repo are `devDependencies`, which is the sanctioned seam,
-and `@ts-for-gir/lib` itself appears only under the private integration test.
+`dependencies` edge on it would hand raw TypeScript to every consumer. Today all SEVEN
+published `@ts-for-gir/*` edges in this repo are `devDependencies` on `@ts-for-gir/cli`,
+which is the sanctioned seam; `@ts-for-gir/lib` itself appears only under the private
+integration test, which declares no tier and publishes nothing.
 
 Two things follow, and the first is the good news:
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -189,6 +189,42 @@ the runtime constants (`OWN_PROPS`, `OWN_SIGNALS`, `DECLS`, `ENUM_NICKS`,
 start. Until then a consumer-side branch could only resolve against a local
 ts-for-gir checkout, which is not something CI can reproduce.
 
+**Who unblocks it, and in what order.** Re-measured 2026-08-26: still four keys, so
+nothing below has happened yet. The whole chain hangs off ONE human action in the
+ts-for-gir repo — everything after it is automatic, and none of it is a gjsify action:
+
+1. **A ts-for-gir maintainer cuts a release** from `main` on a clean tree
+   (`yarn release:stable`; release-it has `requireBranch: main`). ts-for-gir is at
+   4.1.0 and tag `v4.1.0` already exists, so the surface — merged as ts-for-gir#438
+   on 2026-08-26 — is UNRELEASED code. #438 is a `feat`, so the cut is 4.2.0.
+   `.release-it.json` has `npm.publish: false`; the cut only tags and opens a GitHub
+   release.
+2. The `release: published` event fires `release-types.yml`, which runs
+   `build:types:release` and pushes the regenerated `@girs/*` to `gjsify/types@main`.
+   Nothing needs enabling: the config it uses, `.ts-for-gir.packages-all.rc.js`, already
+   sets `widgetSurface: true`, and `packages/templates/templates/package.json` emits the
+   `./surface` key conditionally on `girModule.hasWidgetSurface` — so the key appears for
+   the namespaces that declare a concrete `GtkWidget` descendant and nowhere else.
+3. That push fires `gjsify/types`' own `Release CI` (`on: push: branches: [main]`),
+   which publishes every `@girs/*` to npm. This is the step that makes the subpath
+   installable, and it is triggered by the push rather than by the release — so a cut
+   whose `release-types.yml` leg fails publishes `@ts-for-gir/*` and NO new `@girs/*`,
+   which looks like a successful release from the tag.
+4. Probe again. `npm view @girs/gtk-4.0 version` must read 4.2.0 AND
+   `npm view @girs/gtk-4.0 exports --json` must show the fifth key. Both, because
+   step 3 is where the two can come apart.
+
+Only then do ADR 0029 steps 3–5 become gjsify work. Nothing here is a gjsify PR, and
+there is no partial version of it worth landing first: a consumer-side branch pinned to
+a local ts-for-gir checkout is not something CI can resolve.
+
+**The same release retires a second thing.** `checkTypeSkew` in
+`packages/infra/cli/src/utils/check-system-deps.ts` carries `isDegenerate()`, which
+detects `@girs`' namespace-version-as-release fallback — the value ADR 0019 Decision 3
+removed in ts-for-gir#436, also unreleased. Once a released `@girs` omits
+`libraryVersion` where the library declares none, that detector is reading for a shape
+that can no longer be published, and it goes away rather than moving anywhere.
+
 **Two things to pin when it does arrive.** The `@girs` version must be EXACT, not a
 caret: `@gjsify/gtk-host` declares eight `@girs/*` packages at `^4.1.0`, and a minor
 `@girs` release moving the surface under a lockfile-less install is the hazard ADR
@@ -204,6 +240,87 @@ generated Gtk-4.0 surface: **12 of its 418 dashed keys** — `action-target`, `c
 the migration will surface fixtures that pass `null` to a property GIR does not mark
 nullable. That is a real narrowing and wants a decision — widen in the consumer dialect,
 or fix the fixtures — rather than a silent cast.
+
+### What else could move to ts-for-gir, and the line that decides it
+
+Asked directly: ts-for-gir is meant to be used as a LIBRARY (ADR 0019), ADR 0029 just
+moved the widget vocabulary there, so what else in gjsify is really ts-for-gir's? Audited
+2026-08-26 across every module in this repo that carries introspection knowledge. Code
+lines exclude comments and blanks, because several of these files are 60 % comment and
+counting prose measures the incident record, not the coupling.
+
+**The line, stated once so it does not have to be re-argued per file.** ts-for-gir knows
+**GIR as XML**: it parses `.gir` files headlessly, in CI, with no GTK installed and no
+typelib loaded. gjsify knows **GI as a loaded runtime**: which libdir girepository will
+search, what `gi://Gtk?version=4.0` resolves to on this host, whether the installed
+library actually has the member the types promise. Everything below sorts cleanly on that
+one question, and the sort is not a judgement call — a module that needs an installed
+library cannot move to a generator that runs without one.
+
+**Moves — and it is all one thing, already decided.** ADR 0029 steps 3–5, blocked on the
+release above:
+
+| module | code | GIR-generic | what holds it here |
+|---|---:|---:|---|
+| `gtk-host/src/generator/gir.mts` | 249 | 248 | one import, `@gjsify/domparser` |
+| `gtk-host/src/generator/surface.mts` | 196 | 196 | nothing — imports only its two siblings |
+| `gtk-host/src/generator/tsmap.mts` | 100 | 100 | nothing |
+| `gtk-host/src/generator/mini.fixture.mts` | 59 | 59 | nothing |
+| `gtk-host/src/generator/emit-types.mts` | 156 | ~151 | `tagOf` + the emitted `../attrs.js` import — the dialect half stays |
+| `gtk-host/src/generator/emit.mts` | 103 | 13 | the runtime table is gtk-host's model (ADR 0028 § 1) |
+
+The first four are a closed subgraph: 604 code lines whose only edge outside
+`generator/` is a single XML-parser import. `tsmap.mts` is worth naming separately —
+its `GIRS_PACKAGES` table maps `Gtk` → `@girs/gtk-4.0`, which is **ts-for-gir's own
+naming convention, written down on the wrong side of the boundary.**
+
+**Does not move, and the reason is the same reason each time.** These read as candidates
+because they are full of GI vocabulary, but every one of them needs something a headless
+generator does not have:
+
+| module | code | GIR-generic | why it stays |
+|---|---:|---:|---|
+| `gjs/utils/src/system-gi-dirs.ts` | 44 | 43 | `<libdir>/girepository-1.0` layout — a typelib-LOADING rule |
+| `infra/cli/src/utils/system-gi.ts` | 77 | 77 | same rule, plus `DYLD_FALLBACK_LIBRARY_PATH` composition |
+| `node-gi/node-gi/system-gi.js` | 70 | 70 | same rule, third copy |
+| `infra/cli/src/utils/gi-typelib.ts` | 80 | 80 | finds `Ns-Ver.typelib` on this host |
+| `node-gi/scripts/typelib-backers.mjs` | 170 | ~155 | parses the typelib BINARY header; ts-for-gir never opens one |
+| `parseGiSpecifier` (two copies) | 9 + 13 | 22 | `gi://` is a GJS import specifier, not a GIR concept |
+| `node-gi/src/repo.cc` | 245 | — | N-API binding; `gi_repository_require` IS the runtime |
+| `gtk-host/src/conformance/`, `registry.ts` | 165 + — | 0 | walks the LIVE GObject type system, not GIR |
+| `docs/gnome-mappings.md` | 12 | 0 | which GNOME lib backs which Node/Web API — a polyfill choice |
+
+`generated.spec.ts` belongs in this second list for the sharpest version of the reason:
+it asks the *installed* typelib whether every emitted name is real. ADR 0029 § Consequences
+already fixed it here, and that is what forces the surface to ship runtime data beside the
+types.
+
+**Three of those rows are a real duplicate, and ts-for-gir is not its home.**
+`systemGiLibraryDirs()` exists three times because ADR 0005 Decision 2 forbids a Tier-1
+package a `dependencies` edge on `@gjsify/node-gi` — a tier rule, not a technical
+obstacle. The already-tracked fix (§ "`systemGiLibraryDirs()` lives in two places") is a
+shared `@gjsify/system-gi`, and it stays right: the rule is about loading libraries.
+Answering "can it move to ts-for-gir" with yes would export a runtime concern into a
+generator to dodge a tier rule.
+
+**The dependency-direction check, per ADR 0019, and one finding.** ADR 0019 Decision 1
+keeps ts-for-gir build-step-free — `@ts-for-gir/lib`'s `exports` is literally
+`{".": "./src/index.ts"}` — so a published `@gjsify/*` package taking a
+`dependencies` edge on it would hand raw TypeScript to every consumer. Today all eight
+`@ts-for-gir/*` edges in this repo are `devDependencies`, which is the sanctioned seam,
+and `@ts-for-gir/lib` itself appears only under the private integration test.
+
+Two things follow, and the first is the good news:
+
+- **The prize costs no new dependency edge at all.** The surface arrives as generated
+  `@girs/*` — `.d.ts` plus a runtime `.js` — and `@gjsify/gtk-host` already declares
+  eight `@girs/*` packages. It is Tier 3, so the tier rule constrains it least of
+  anything here. ADR 0029 steps 3–5 add zero `@ts-for-gir` dependency.
+- **The rule that would catch the mistake does not exist.** `tier.mjs` collects only
+  `dep.startsWith('@gjsify/')`, so an external `@ts-for-gir/*` edge in `dependencies` is
+  invisible to it, and no other manifest-conformance rule inspects external dependency
+  names. ADR 0019's boundary is discipline-only today. Closed in this change by extending
+  the rule that already special-cases one package by name.
 
 ### An adopted composite offsets by its own internals
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -303,6 +303,20 @@ generator does not have:
 | `gtk-host/src/conformance/`, `registry.ts` | 165 + — | 0 | walks the LIVE GObject type system, not GIR |
 | `docs/gnome-mappings.md` | 12 | 0 | which GNOME lib backs which Node/Web API — a polyfill choice |
 
+**One of those rows is a latent bug, found while sorting them.** `parseGiSpecifier`
+exists twice under the same name with DIFFERENT accept sets:
+`packages/infra/cli/src/utils/ship/gi-namespaces.ts` validates the namespace against
+`/^[A-Za-z][A-Za-z0-9_]*$/` and returns `Ns-Version` as one string;
+`packages/infra/rolldown-plugin-gjsify/src/plugins/gjs-gi-node.ts` only checks
+non-empty and returns `{ namespace, version }`. So `gi://9Foo` is rejected by the
+first and accepted by the second, and the second is the one on the BUILD path — it
+would emit a `requireGi('9Foo', …)` shim for a specifier the ship path refuses to
+declare a `Depends:` for. Both are Tier 1, so a shared home is legal; it needs a
+decision about which accept set is right (the validating one, on the evidence that
+GObject namespaces are C identifiers) rather than a mechanical lift. Not done here:
+this audit was about the ts-for-gir boundary, and consolidating these is on the other
+side of it.
+
 `generated.spec.ts` belongs in this second list for the sharpest version of the reason:
 it asks the *installed* typelib whether every emitted name is real. ADR 0029 § Consequences
 already fixed it here, and that is what forces the surface to ship runtime data beside the


### PR DESCRIPTION
Answers a direct question — *ts-for-gir is meant to be used as a library, so can more of gjsify move there?* — with measurements, and lands the two things that were cheap and unambiguous. The ts-for-gir half is gjsify/ts-for-gir#439.

## The answer, in one line

**ts-for-gir knows GIR as XML** — parsed headlessly, in CI, with no GTK installed and no typelib loaded. **gjsify knows GI as a loaded runtime.** Every introspection-carrying module in this repo sorts cleanly on that one question, and the sort is not a judgement call: a module that needs an installed library cannot move to a generator that runs without one.

## Candidates, audited

Code lines exclude comments and blanks — several of these files are 60 % comment, and counting prose measures the incident record rather than the coupling.

**Moves, and it is all one thing already decided** (ADR 0029 steps 3–5):

| module | code | GIR-generic | what holds it here |
|---|---:|---:|---|
| `generator/gir.mts` | 249 | 248 | one import, `@gjsify/domparser` |
| `generator/surface.mts` | 196 | 196 | nothing — imports only its two siblings |
| `generator/tsmap.mts` | 100 | 100 | nothing |
| `generator/mini.fixture.mts` | 59 | 59 | nothing |
| `generator/emit-types.mts` | 156 | ~151 | `tagOf` + emitted `../attrs.js`; the dialect half stays |
| `generator/emit.mts` | 103 | 13 | the runtime table is gtk-host's model (ADR 0028 § 1) |

The first four are a closed subgraph — 604 code lines whose only edge outside `generator/` is a single XML-parser import. `tsmap.mts`'s `GIRS_PACKAGES` table (`Gtk` → `@girs/gtk-4.0`) is **ts-for-gir's own naming convention, written on the wrong side of the boundary.**

**Does not move, same reason each time** — full of GI vocabulary, but each needs something a headless generator does not have: `system-gi-dirs.ts` (44/43), `cli/utils/system-gi.ts` (77/77), `node-gi/system-gi.js` (70/70), `gi-typelib.ts` (80/80), `typelib-backers.mjs` (170/~155, parses the typelib *binary* header), both `parseGiSpecifier` copies (22/22 — `gi://` is a GJS import specifier, not a GIR concept), `repo.cc` (245, `gi_repository_require` *is* the runtime), `conformance/` + `registry.ts` (walk the live GObject type system), `docs/gnome-mappings.md` (0 — a polyfill choice table).

`generated.spec.ts` belongs in that second list for the sharpest version of the reason: it asks the *installed* typelib whether every emitted name is real.

**The three `systemGiLibraryDirs()` copies are a real duplicate, and ts-for-gir is not its home.** They exist three times because ADR 0005 Decision 2 forbids a Tier-1 package a `dependencies` edge on `@gjsify/node-gi` — a tier rule, not a technical obstacle. Answering "can it move to ts-for-gir" with yes would export a runtime concern into a generator to dodge a tier rule. The already-tracked shared `@gjsify/system-gi` stays right.

## The dependency-direction check found a hole

ADR 0019 Decision 1 keeps every `@ts-for-gir/*` and `@gi.ts/*` package build-step-free, and the registry confirms it — `@ts-for-gir/lib`, `@ts-for-gir/cli` and `@gi.ts/parser` all resolve `exports["."]` to `./src/index.ts`. So a `dependencies` edge from a published `@gjsify/*` package onto one of them **ships raw TypeScript to every consumer.**

Nothing enforced that. `tier.mjs` collects only `dep.startsWith('@gjsify/')`, so an external `@ts-for-gir/*` edge in `dependencies` was invisible to it, and no other manifest-conformance rule inspects external dependency names — the edge would have passed `audit-runtimes --check` in silence.

The `tier` rule now fails on it **by name**, the same shape it already uses for ADR 0005's node-gi isolation and for the same reason: these are external packages carrying no `gjsify.tier`, so the tier walk structurally cannot see them. Not a new rule and not a fourth required check — one more failure inside the rule that already special-cases a package by name.

- Green on all 202 published packages (whose eight existing `@ts-for-gir/*` edges are all `devDependencies`, the sanctioned seam).
- Red on an injected `dependencies` edge, naming the package, the field and the seam.

**And the good news it makes explicit:** the prize costs no new dependency edge at all. The widget surface arrives as generated `@girs/*` — `.d.ts` plus runtime `.js` — and `@gjsify/gtk-host` already declares eight `@girs/*` packages. ADR 0029 steps 3–5 add zero `@ts-for-gir` dependency.

## Is the rollback still blocked? Yes, and it is live-checkable

`npm view @girs/gtk-4.0 exports --json` re-measured today: still **four** keys, no `./surface`. ts-for-gir is at 4.1.0 with tag `v4.1.0` already cut, so ts-for-gir#438 is unreleased code.

`status/open-todos.md` said what was missing and how to detect arrival, but not how to *cause* it. It now carries the ordered sequence, which hangs off **one human action** — none of it a gjsify PR:

1. A ts-for-gir maintainer cuts 4.2.0 from `main`. `.release-it.json` has `npm.publish: false`; the cut only tags and opens a GitHub release.
2. `release: published` fires `release-types.yml` → `build:types:release` → pushes regenerated `@girs/*` to `gjsify/types@main`. Nothing needs enabling: `.ts-for-gir.packages-all.rc.js` already sets `widgetSurface: true`, and the package template emits `./surface` conditionally on `girModule.hasWidgetSurface`.
3. That push fires `gjsify/types`' own `Release CI` (`on: push: branches: [main]`), which publishes every `@girs/*` to npm. **This is the step that makes the subpath installable, and it is triggered by the push rather than by the release** — so a cut whose `release-types.yml` leg fails publishes `@ts-for-gir/*` and no new `@girs/*`, which looks like a successful release from the tag.
4. Probe *both*: `npm view @girs/gtk-4.0 version` must read 4.2.0 **and** `exports --json` must show the fifth key. Step 3 is where the two can come apart.

**The same release retires a second thing.** `checkTypeSkew`'s `isDegenerate()` detects the `@girs` namespace-version-as-release fallback that ADR 0019 Decision 3 removed in ts-for-gir#436, also unreleased. Once a released `@girs` omits `libraryVersion` where the library declares none, that detector reads for a shape that can no longer be published — it goes away rather than moving anywhere.

## The 97-vs-889 number

`gir.mts` said 97 and ts-for-gir said 889, over the *same* 705 GIRs — this repo's generator literally reads ts-for-gir's `girs/`. Measured both ways: **both are right**, and they differ by exactly the 792 members whose GIR name carries uppercase and whose nick preserves it, which disagree only with a derivation that also lowercases. `97 + 792 = 889`. `nickOf` does not lowercase, so 97 is its number; the pair only looked like a contradiction because the derivation was never named beside the count.

Per the convention #1328 set, the count moves to ts-for-gir — which owns the corpus and now asserts it in `check:girs` — and this comment keeps what it establishes: some nicks retain an underscore the substitution would have replaced, so only the attribute knows which one survived. Full detail, including the invariant that made ts-for-gir's `toLowerCase()` a measured defect, in gjsify/ts-for-gir#439.

## Checks

`audit-runtimes --check` ✅ (tier summary now names the ADR-0019 boundary) · `check-adr-index` ✅ · `check-doc-fences` ✅ · `check-agent-context-size --check` ✅ · `check-doc-revert` ✅. No AGENTS.md touched, so no budget move.
