### PR TITLE
docs: add the React page, complete adw-alert-dialog, check the class

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -346,6 +346,17 @@ jobs:
       - name: Check the widget vocabulary is aligned across surfaces (self-testing)
         run: node scripts/check-vocabulary-alignment.mjs
 
+      # The step above settles which `adw-*` element names which widget. This one asks
+      # whether the element carries that widget's SCALAR GIR properties — the half that
+      # was missing when `<adw-alert-dialog>` shipped observing 4 of Adw.AlertDialog's 8
+      # own properties and the website's generated table truthfully said "takes 4
+      # attributes": the doc was right and the element was short, and nothing compared
+      # them. Signal props and widget-valued (slot) props are excluded with the count, so
+      # the rule cannot drown its findings in false ones. Self-tests first, and it is
+      # pinned red against that original defect.
+      - name: Check adw-* elements hold their widget's GIR properties (self-testing)
+        run: node scripts/check-adwaita-element-properties.mjs
+
       # `$adw-components` in adwaita-web's `_reset.scss` is a hand-written copy of every
       # `customElements.define('adw-…')` call, and it is what applies the ADR 0010
       # style-isolation floor. A tag missing from it renders in the host page's font and

--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -351,9 +351,10 @@ jobs:
       # was missing when `<adw-alert-dialog>` shipped observing 4 of Adw.AlertDialog's 8
       # own properties and the website's generated table truthfully said "takes 4
       # attributes": the doc was right and the element was short, and nothing compared
-      # them. Signal props and widget-valued (slot) props are excluded with the count, so
-      # the rule cannot drown its findings in false ones. Self-tests first, and it is
-      # pinned red against that original defect.
+      # them. Signal props (271) and widget-valued slot props (47) are excluded with the
+      # count, so the rule cannot drown its findings in false ones; enums are NOT, because
+      # a nick is a string an attribute carries. Self-tests first, and a synthetic twin of
+      # the original 4-of-8 element is a VECTOR, so the pin survives the real fix.
       - name: Check adw-* elements hold their widget's GIR properties (self-testing)
         run: node scripts/check-adwaita-element-properties.mjs
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "check": "gjsify foreach check -ptv --exclude \"@girs/*\" --exclude \"@gjsify/example-*\" --exclude \"@gjsify/website\"",
         "check:examples": "gjsify foreach check -ptv --include \"@gjsify/example-*\"",
         "check:type-surfaces": "node scripts/check-type-surfaces.mjs",
+        "check:adwaita-element-properties": "node scripts/check-adwaita-element-properties.mjs",
         "check:vocabulary-alignment": "node scripts/check-vocabulary-alignment.mjs",
         "clear": "gjsify foreach clear -v --no-private -p --exclude \"@gjsify/example-*\" --exclude \"@gjsify/website\"",
         "clear:examples": "gjsify foreach clear -v -p --include \"@gjsify/example-*\"",

--- a/packages/web/adwaita-web/src/adw-alert-dialog.spec.ts
+++ b/packages/web/adwaita-web/src/adw-alert-dialog.spec.ts
@@ -1,0 +1,132 @@
+// <adw-alert-dialog> against `Adw.AlertDialog`'s own property list.
+//
+// This element shipped with FOUR of its eight GIR properties reachable from markup —
+// `heading`, `body`, `open` (a web convention with no GIR counterpart) and
+// `prefer-wide-layout`. `close-response` and `default-response` existed as JS
+// properties but no attribute fed them, and `heading-use-markup`/`body-use-markup`
+// were absent entirely. The website's generated widget table read
+// `observedAttributes` and truthfully reported "takes 4 attributes", which is how the
+// gap became visible: the DOC was right and the ELEMENT was short.
+//
+// The markup pair defaults to FALSE here and in libadwaita alike — unlike
+// `Adw.Banner:use-markup`, whose C default is TRUE and which `adw-banner.ts` therefore
+// departs from on purpose. So these vectors pin a MATCH, not a departure, and the
+// negative case is the one that matters: tags must show literally until asked for.
+import { describe, expect, it } from '@gjsify/unit';
+
+import type { AdwAlertDialog } from './elements/adw-alert-dialog.js';
+
+/** Mount via `setAttribute` so an attribute value's exact text survives. */
+function mount(attributes: Record<string, string> = {}): { el: AdwAlertDialog; host: HTMLElement } {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const el = document.createElement('adw-alert-dialog') as AdwAlertDialog;
+    for (const [name, value] of Object.entries(attributes)) el.setAttribute(name, value);
+    host.appendChild(el);
+    return { el, host };
+}
+
+const headingEl = (el: AdwAlertDialog): HTMLElement => el.querySelector('.adw-alert-dialog-heading') as HTMLElement;
+const bodyEl = (el: AdwAlertDialog): HTMLElement => el.querySelector('.adw-alert-dialog-body') as HTMLElement;
+
+export const AdwAlertDialogTest = async () => {
+    await describe('adw-alert-dialog observes every Adw.AlertDialog property it can render', async () => {
+        // Named rather than counted: a count passes again the moment someone swaps one
+        // attribute for another, which is the drift this file exists to catch.
+        for (const name of [
+            'heading',
+            'body',
+            'heading-use-markup',
+            'body-use-markup',
+            'close-response',
+            'default-response',
+            'prefer-wide-layout',
+        ]) {
+            await it(`observes \`${name}\``, () => {
+                expect(
+                    (
+                        customElements.get('adw-alert-dialog') as typeof HTMLElement & {
+                            observedAttributes: string[];
+                        }
+                    ).observedAttributes,
+                ).toContain(name);
+            });
+        }
+    });
+
+    await describe('adw-alert-dialog markup is opt-in, matching the libadwaita default', async () => {
+        await it('a heading with tags shows them literally by default', () => {
+            const { el, host } = mount({ heading: '<b>Delete</b> file?' });
+            expect(headingEl(el).textContent).toBe('<b>Delete</b> file?');
+            expect(headingEl(el).querySelector('b')).toBe(null);
+            host.remove();
+        });
+
+        await it('heading-use-markup renders it, which is the author asserting it is trusted', () => {
+            const { el, host } = mount({ heading: '<b>Delete</b> file?', 'heading-use-markup': '' });
+            expect(headingEl(el).querySelector('b')?.textContent).toBe('Delete');
+            host.remove();
+        });
+
+        await it('a body with tags shows them literally by default', () => {
+            const { el, host } = mount({ body: 'Really delete <i>notes.txt</i>?' });
+            expect(bodyEl(el).textContent).toBe('Really delete <i>notes.txt</i>?');
+            expect(bodyEl(el).querySelector('i')).toBe(null);
+            host.remove();
+        });
+
+        await it('body-use-markup renders it', () => {
+            const { el, host } = mount({ body: 'Really delete <i>notes.txt</i>?', 'body-use-markup': '' });
+            expect(bodyEl(el).querySelector('i')?.textContent).toBe('notes.txt');
+            host.remove();
+        });
+
+        await it('toggling the attribute off returns to text', () => {
+            const { el, host } = mount({ heading: '<b>Delete</b>', 'heading-use-markup': '' });
+            el.headingUseMarkup = false;
+            expect(headingEl(el).textContent).toBe('<b>Delete</b>');
+            expect(headingEl(el).querySelector('b')).toBe(null);
+            host.remove();
+        });
+    });
+
+    await describe('adw-alert-dialog response IDs are reachable from markup', async () => {
+        await it('close-response defaults to `close`, as in Adw.AlertDialog', () => {
+            const { el, host } = mount();
+            expect(el.closeResponse).toBe('close');
+            host.remove();
+        });
+
+        await it('the attribute feeds the headless model', () => {
+            const { el, host } = mount({ 'close-response': 'cancel' });
+            expect(el.closeResponse).toBe('cancel');
+            host.remove();
+        });
+
+        await it('default-response defaults to null and the attribute sets it', () => {
+            const { el, host } = mount();
+            expect(el.defaultResponse).toBe(null);
+            el.setAttribute('default-response', 'delete');
+            expect(el.defaultResponse).toBe('delete');
+            host.remove();
+        });
+
+        await it('removing default-response clears it', () => {
+            const { el, host } = mount({ 'default-response': 'delete' });
+            el.removeAttribute('default-response');
+            expect(el.defaultResponse).toBe(null);
+            host.remove();
+        });
+
+        await it('a dismissal emits the close response the attribute named', () => {
+            const { el, host } = mount({ 'close-response': 'cancel', open: '' });
+            let seen: string | null = null;
+            el.addEventListener('response', (event) => {
+                seen = (event as CustomEvent<{ response: string }>).detail.response;
+            });
+            el.open = false;
+            expect(seen).toBe('cancel');
+            host.remove();
+        });
+    });
+};

--- a/packages/web/adwaita-web/src/adw-alert-dialog.spec.ts
+++ b/packages/web/adwaita-web/src/adw-alert-dialog.spec.ts
@@ -119,13 +119,27 @@ export const AdwAlertDialogTest = async () => {
         });
 
         await it('a dismissal emits the close response the attribute named', () => {
+            // The scrim click, not `open = false`. `_dismiss()` SETS `open = false` and
+            // then emits, so the property is the lower-level state change and driving it
+            // directly would assert a contract this element does not have.
             const { el, host } = mount({ 'close-response': 'cancel', open: '' });
             let seen: string | null = null;
             el.addEventListener('response', (event) => {
                 seen = (event as CustomEvent<{ response: string }>).detail.response;
             });
-            el.open = false;
+            (el.querySelector('.adw-alert-dialog-scrim') as HTMLElement).click();
             expect(seen).toBe('cancel');
+            expect(el.open).toBe(false);
+            host.remove();
+        });
+
+        await it('removing close-response keeps the model value, unlike default-response', () => {
+            // An ASYMMETRY worth pinning rather than discovering: `close-response` has a
+            // non-null GIR default (`close`), so an absent attribute means "leave the
+            // model alone", while `default-response` defaults to null and clears.
+            const { el, host } = mount({ 'close-response': 'cancel' });
+            el.removeAttribute('close-response');
+            expect(el.closeResponse).toBe('cancel');
             host.remove();
         });
     });

--- a/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
@@ -14,8 +14,20 @@
 // Attributes:
 //   heading    (the bold heading text)
 //   body       (the body text below the heading)
+//   heading-use-markup (boolean — read `heading` as markup rather than plain text)
+//   body-use-markup    (boolean — read `body` as markup rather than plain text)
+//   close-response     (the response ID emitted on dismissal; default `close`)
+//   default-response   (the response ID whose button is highlighted and focused)
 //   open       (boolean — whether the dialog is shown; default closed)
 //   prefer-wide-layout (boolean — lay responses out horizontally when they fit)
+//
+// MARKUP IS OPT-IN, and here that MATCHES libadwaita rather than departing from it:
+// `Adw.AlertDialog:heading-use-markup` and `:body-use-markup` both default to FALSE
+// (`Adw.Banner:use-markup` is the one that defaults to TRUE, which is why
+// `adw-banner.ts` documents a deliberate departure and this file does not need to).
+// Opting in renders through `innerHTML`, which is the author asserting the string is
+// trusted — Pango markup has a fixed tag set and no scripting, HTML has neither
+// property.
 //
 // Buttons are stacked vertically by default (the Adw.AlertDialog default at medium
 // sizes) and laid out horizontally when prefer-wide-layout is set and there are no more
@@ -82,7 +94,16 @@ export class AdwAlertDialog extends HTMLElement {
     private _blockCloseResponse = false;
 
     static get observedAttributes() {
-        return ['heading', 'body', 'open', 'prefer-wide-layout'];
+        return [
+            'heading',
+            'body',
+            'heading-use-markup',
+            'body-use-markup',
+            'close-response',
+            'default-response',
+            'open',
+            'prefer-wide-layout',
+        ];
     }
 
     get heading(): string {
@@ -108,6 +129,26 @@ export class AdwAlertDialog extends HTMLElement {
     set open(value: boolean) {
         if (value) this.setAttribute('open', '');
         else this.removeAttribute('open');
+    }
+
+    /** Whether {@link heading} is read as markup rather than plain text. */
+    get headingUseMarkup(): boolean {
+        return this.hasAttribute('heading-use-markup');
+    }
+
+    set headingUseMarkup(value: boolean) {
+        if (value) this.setAttribute('heading-use-markup', '');
+        else this.removeAttribute('heading-use-markup');
+    }
+
+    /** Whether {@link body} is read as markup rather than plain text. */
+    get bodyUseMarkup(): boolean {
+        return this.hasAttribute('body-use-markup');
+    }
+
+    set bodyUseMarkup(value: boolean) {
+        if (value) this.setAttribute('body-use-markup', '');
+        else this.removeAttribute('body-use-markup');
     }
 
     /** Whether to prefer horizontal button layout when the buttons fit. */
@@ -236,6 +277,14 @@ export class AdwAlertDialog extends HTMLElement {
         } else if (name === 'body') {
             this._model.body = this.body;
             this.dispatchEvent(new CustomEvent('notify::body', { bubbles: true, detail: { body: this.body } }));
+        } else if (name === 'close-response') {
+            // The MODEL stays the source of truth for response semantics (see the
+            // header) — the attribute is a markup entry point that feeds it, so the
+            // setter is not mirrored back and there is no reflection loop. An absent
+            // attribute means "leave the model's default", not "reset to `close`".
+            if (newValue !== null) this.setCloseResponse(newValue);
+        } else if (name === 'default-response') {
+            this.setDefaultResponse(newValue);
         } else if (name === 'open') {
             this.dispatchEvent(new CustomEvent('notify::open', { bubbles: true, detail: { open: this.open } }));
             if (this.open) this._modal.present();
@@ -402,11 +451,13 @@ export class AdwAlertDialog extends HTMLElement {
         this.classList.toggle('open', this.open);
 
         const heading = this.heading;
-        this._headingEl.textContent = heading;
+        if (this.headingUseMarkup) this._headingEl.innerHTML = heading;
+        else this._headingEl.textContent = heading;
         this._headingEl.hidden = heading.length === 0;
 
         const body = this.body;
-        this._bodyEl.textContent = body;
+        if (this.bodyUseMarkup) this._bodyEl.innerHTML = body;
+        else this._bodyEl.textContent = body;
         this._bodyEl.hidden = body.length === 0;
 
         // Horizontal only when prefer-wide-layout is set AND there are at most two

--- a/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
+++ b/packages/web/adwaita-web/src/elements/adw-alert-dialog.ts
@@ -246,6 +246,15 @@ export class AdwAlertDialog extends HTMLElement {
         this._model.heading = this.heading;
         this._model.body = this.body;
 
+        // And the two response IDs. `attributeChangedCallback` returns early until
+        // `_initialized`, so an attribute present in the MARKUP — the declarative case
+        // these attributes exist for — is never delivered to it. `heading` and `body`
+        // survive that only because `_render()` re-reads them from the attribute; these
+        // two live in the model and would simply be dropped.
+        const closeResponse = this.getAttribute('close-response');
+        if (closeResponse !== null) this._model.closeResponse = closeResponse;
+        this._model.defaultResponse = this.getAttribute('default-response');
+
         this._render();
     }
 

--- a/packages/web/adwaita-web/src/test.browser.mts
+++ b/packages/web/adwaita-web/src/test.browser.mts
@@ -25,6 +25,7 @@ import { AdwActionRowsTest } from './adw-action-rows.spec.js';
 import { AdwBreakpointsTest } from './breakpoints.spec.js';
 import { AdwDataGridTest } from './adw-data-grid.spec.js';
 import { AdwDialogTest } from './adw-dialog.spec.js';
+import { AdwAlertDialogTest } from './adw-alert-dialog.spec.js';
 import { AdwDropDownTest } from './adw-drop-down.spec.js';
 import { AdwRowStateTest } from './adw-row-state.spec.js';
 import { AdwTabViewTest } from './adw-tab-view.spec.js';
@@ -62,6 +63,7 @@ run({
     AdwAccentTest,
     AdwShortcutLabelTest,
     AdwAboutDialogTest,
+    AdwAlertDialogTest,
     AdwBannerTest,
     AdwButtonContentTest,
     AdwIconTest,

--- a/scripts/check-adwaita-element-properties.mjs
+++ b/scripts/check-adwaita-element-properties.mjs
@@ -13,19 +13,25 @@
 // disabled and then protects nothing (`check-workflow-inline-scripts.mjs`'s header
 // records the same lesson from its own first draft — "23 findings, 21 false"):
 //
-//   · SIGNAL props (`on-clicked`, `on-notify-*`). 224 of them across the mapped
+//   · SIGNAL props (`on-clicked`, `on-notify-*`). 271 of them across the 43 mapped
 //     elements. They are a JSX convention; a custom element dispatches events instead,
 //     and an `on-*` ATTRIBUTE would be the inline-handler shape nobody wants.
 //   · WIDGET-VALUED props (`child`, `content`, `sidebar`, `extra-child`, `title-widget`
-//     — anything typed `Gtk.*`/`Adw.*`/`Gio.*`/`Gdk.*`/`Pango.*`/`GObject.*`). 52 of
-//     them. On this renderer those are SLOTS, not attributes: an attribute cannot
-//     carry a widget. `<adw-alert-dialog>`'s `extra-child` is exactly this shape.
+//     — anything typed `Gtk.*`/`Adw.*`/`Gio.*`/`Gdk.*`/`Pango.*`/`GObject.*` and NOT an
+//     enum). 47 of them. On this renderer those are SLOTS, not attributes: an attribute
+//     cannot carry a widget. `<adw-alert-dialog>`'s `extra-child` is exactly this shape.
+//
+// ENUMS ARE NOT EXCLUDED, though the naive namespace test catches them: the generator
+// spells one `AdwToolbarStyleNick | Adw.ToolbarStyle`, and a nick is a STRING. 24 of them
+// are in scope here, 17 already observed as attributes today — which is the proof they
+// belong. Dropping them would have hidden real gaps behind a justification ("an attribute
+// cannot carry a widget") that does not apply to them.
 //
 // That leaves the scalar surface — strings, booleans, numbers, enums — which an
 // attribute genuinely can carry, and which is therefore the only half whose absence
 // carries information.
 //
-// KNOWN_GAPS IS A MEASURED BACKLOG, NOT A BLESSING. 53 scalar properties across 20
+// KNOWN_GAPS IS A MEASURED BACKLOG, NOT A BLESSING. 83 scalar properties across 28
 // elements are unobserved today. They are listed rather than individually justified,
 // because inventing 53 rationales would be worse than naming none: a rule without its
 // real reason gets "simplified" back into the bug. What this check buys now is the
@@ -55,15 +61,22 @@ const KNOWN_GAPS = {
         'designers',
         'developers',
         'documenters',
+        'license-type',
         'release-notes',
         'release-notes-version',
         'translator-credits',
     ],
+    'adw-action-row': ['icon-name', 'subtitle-lines', 'subtitle-selectable', 'title-lines'],
     'adw-avatar': ['icon-name'],
     'adw-bottom-sheet': ['align', 'can-open', 'full-width', 'reveal-bottom-bar'],
-    'adw-combo-row': ['enable-search', 'use-subtitle'],
+    'adw-carousel': ['reveal-duration'],
+    'adw-clamp': ['unit'],
+    'adw-combo-row': ['enable-search', 'search-match-mode', 'use-subtitle'],
     'adw-dialog': ['follows-content-size'],
+    'adw-entry-row': ['enable-emoji-completion', 'input-hints', 'input-purpose'],
+    'adw-expander-row': ['icon-name', 'subtitle-lines', 'title-lines'],
     'adw-header-bar': [
+        'centering-policy',
         'decoration-layout',
         'show-back-button',
         'show-end-title-buttons',
@@ -71,31 +84,53 @@ const KNOWN_GAPS = {
         'show-title',
     ],
     'adw-inline-view-switcher': ['can-shrink', 'homogeneous'],
-    'adw-navigation-split-view': ['sidebar-width-fraction'],
+    'adw-navigation-split-view': ['sidebar-width-fraction', 'sidebar-width-unit'],
     'adw-navigation-view': ['hhomogeneous', 'vhomogeneous'],
+    'adw-overlay-split-view': ['sidebar-width-unit'],
     'adw-preferences-dialog': ['search-enabled', 'visible-page-name'],
     'adw-preferences-group': ['separate-rows'],
     'adw-preferences-page': ['description', 'description-centered'],
     'adw-sidebar': ['drop-preload'],
+    'adw-spin-row': ['climb-rate', 'digits', 'numeric', 'snap-to-ticks', 'update-policy', 'wrap'],
     'adw-split-button': ['can-shrink'],
     'adw-status-page': ['icon-name'],
     'adw-tab-view': ['shortcuts'],
     'adw-toggle-group': ['active-name', 'can-shrink', 'homogeneous'],
     'adw-toolbar-view': ['reveal-bottom-bars', 'reveal-top-bars'],
     'adw-view-stack': ['enable-transitions', 'hhomogeneous', 'transition-duration', 'vhomogeneous'],
+    'adw-window': ['adaptive-preview'],
     'adw-wrap-box': [
         'align',
         'child-spacing',
+        'child-spacing-unit',
+        'justify',
         'justify-last-line',
         'line-homogeneous',
         'line-spacing',
+        'line-spacing-unit',
         'natural-line-length',
+        'natural-line-length-unit',
+        'pack-direction',
+        'wrap-policy',
         'wrap-reverse',
     ],
 };
 
 /** A GIR type that holds an object — a slot on this renderer, never an attribute. */
 const OBJECT_TYPE = /\b(?:Gtk|Adw|Gio|Gdk|Pango|GObject)\.\w+/;
+
+/**
+ * An ENUM, which {@link OBJECT_TYPE} also matches and must not exclude.
+ *
+ * The generator spells an enum property `AdwToolbarStyleNick | Adw.ToolbarStyle`, so the
+ * namespaced half makes it look object-typed. It is not: a nick is a STRING, exactly what
+ * an attribute carries. The proof that these belong to the checked surface is that 17 of
+ * them are already observed as attributes today (`adw-banner/button-style`,
+ * `adw-dialog/presentation-mode`, `adw-toolbar-view/top-bar-style`, …). Excluding them
+ * would have hidden 14 real gaps behind a justification — "an attribute cannot carry a
+ * widget" — that does not apply to them.
+ */
+const ENUM_TYPE = /\b\w+Nick\b/;
 
 const kebab = (name) => name.replace(/([A-Z])/g, (c) => `-${c.toLowerCase()}`);
 
@@ -114,7 +149,11 @@ export function tagGTypes(widgetsSource) {
  */
 export function propsBodies(propsSource) {
     const bodies = new Map();
-    const head = /export interface (\w+)Props(?:\s+extends [^{]*)?\{/g;
+    // `extends\s`, NOT `extends ` — the generator wraps long heritage lists onto the
+    // next line, and a literal space missed 65 of 190 interfaces. Each one then had no
+    // body, and `propertyProblems` skipped its element as unmapped: eight `adw-*`
+    // elements passed by being invisible. A vector pins it.
+    const head = /export interface (\w+)Props(?:\s+extends\s[^{]*)?\{/g;
     let m;
     while ((m = head.exec(propsSource))) {
         let depth = 1;
@@ -143,7 +182,7 @@ export function scalarProps(body) {
         if (!m) continue;
         const name = m[1] ?? kebab(m[2]);
         if (name.startsWith('on-')) continue;
-        if (OBJECT_TYPE.test(m[3])) continue;
+        if (OBJECT_TYPE.test(m[3]) && !ENUM_TYPE.test(m[3])) continue;
         names.add(name);
     }
     return names;
@@ -204,6 +243,9 @@ export interface DemoWidgetProps extends GtkWidgetProps {
     /** Multiword, emitted twice by the generator. */
     canShrink?: boolean;
     'can-shrink'?: boolean;
+    /** An ENUM — namespaced, but a nick is a string an attribute carries. */
+    barStyle?: AdwBarStyleNick | Adw.BarStyle;
+    'bar-style'?: AdwBarStyleNick | Adw.BarStyle;
     /** A slot, not an attribute. */
     child?: Gtk.Widget | null;
     /** A signal, not a property. */
@@ -213,38 +255,106 @@ export interface EmptyWidgetProps extends GtkWidgetProps {}
 export interface AfterEmptyProps extends GtkWidgetProps {
     trap?: string;
 }
+export interface WrappedWidgetProps
+    extends GtkWidgetProps,
+        GtkAccessibleProps,
+        GtkBuildableProps {
+    /** Reachable ONLY if the head reader tolerates a newline after \`extends\`. */
+    wrapped?: string;
+}
 `;
 
 const FIXTURE_WIDGETS = `
     { gtype: 'DemoWidget', tag: 'adw-demo', ctor: () => Adw.Demo },
     { gtype: 'EmptyWidget', tag: 'adw-empty', ctor: () => Adw.Empty },
+    { gtype: 'WrappedWidget', tag: 'adw-wrapped', ctor: () => Adw.Wrapped },
 `;
 
-const world = (attributes, knownGaps = {}) => ({
-    byTag: new Map([['adw-demo', attributes]]),
+const world = (attributes, knownGaps = {}, tag = 'adw-demo') => ({
+    byTag: new Map([[tag, attributes]]),
     tagToGtype: tagGTypes(FIXTURE_WIDGETS),
     bodies: propsBodies(FIXTURE_PROPS),
     knownGaps,
 });
 
+/** Every scalar `DemoWidget` offers — an enum among them, on purpose. */
+const DEMO_SCALARS = ['label', 'can-shrink', 'bar-style'];
+
 const VECTORS = [
-    ['an observed scalar is not a problem', () => world(['label', 'can-shrink']), 0],
-    ['an unobserved scalar IS a problem', () => world(['label']), 1],
-    ['both unobserved are two problems', () => world([]), 2],
-    ['a declared gap is accepted', () => world(['label'], { 'adw-demo': ['can-shrink'] }), 0],
-    [
-        'a declaration the element now honours fails',
-        () => world(['label', 'can-shrink'], { 'adw-demo': ['can-shrink'] }),
-        1,
-    ],
-    [
-        'a declaration for a property that does not exist fails',
-        () => world(['label', 'can-shrink'], { 'adw-demo': ['ghost'] }),
-        1,
-    ],
-    ['a missing SLOT property is not a problem', () => world(['label', 'can-shrink']), 0],
-    ['a missing SIGNAL property is not a problem', () => world(['label', 'can-shrink']), 0],
+    ['every scalar observed is not a problem', () => world(DEMO_SCALARS), 0],
+    ['one unobserved scalar IS a problem', () => world(['label', 'can-shrink']), 1],
+    ['all unobserved is one problem each', () => world([]), 3],
+    ['a declared gap is accepted', () => world(['label', 'bar-style'], { 'adw-demo': ['can-shrink'] }), 0],
+    ['a declaration the element now honours fails', () => world(DEMO_SCALARS, { 'adw-demo': ['can-shrink'] }), 1],
+    ['a declaration for a property that does not exist fails', () => world(DEMO_SCALARS, { 'adw-demo': ['ghost'] }), 1],
+    ['a missing SLOT property is not a problem', () => world(DEMO_SCALARS), 0],
+    ['a missing SIGNAL property is not a problem', () => world(DEMO_SCALARS), 0],
+
+    // BLOCKER-1 REGRESSION. `WrappedWidget` declares its heritage across three lines,
+    // which is how the generator emits a long `extends` list. With the old `extends `
+    // (literal space) head reader this interface had no body at all, so the element was
+    // skipped as unmapped and reported ZERO problems — green by being invisible.
+    ['a widget whose extends list wraps is still read', () => world([], {}, 'adw-wrapped'), 1],
+    ['a wrapped widget with its scalar observed is clean', () => world(['wrapped'], {}, 'adw-wrapped'), 0],
 ];
+
+/**
+ * The ORIGINAL defect, as a vector rather than as a claim.
+ *
+ * `<adw-alert-dialog>` observed `heading`, `body`, `open` and `prefer-wide-layout` while
+ * `Adw.AlertDialog` carries eight own scalar properties. Reproduced against a synthetic
+ * twin so the pin survives the real element being fixed — a regression test that reads
+ * the fixed source proves nothing once it is fixed.
+ */
+const ALERT_DIALOG_FIXTURE = `
+export interface AlertTwinProps
+    extends AdwDialogProps,
+        GtkAccessibleProps {
+    body?: string;
+    bodyUseMarkup?: boolean;
+    'body-use-markup'?: boolean;
+    closeResponse?: string;
+    'close-response'?: string;
+    defaultResponse?: string;
+    'default-response'?: string;
+    extraChild?: Gtk.Widget | null;
+    'extra-child'?: Gtk.Widget | null;
+    heading?: string;
+    headingUseMarkup?: boolean;
+    'heading-use-markup'?: boolean;
+    preferWideLayout?: boolean;
+    'prefer-wide-layout'?: boolean;
+}
+`;
+
+function alertDialogRegression() {
+    const shipped = ['heading', 'body', 'open', 'prefer-wide-layout'];
+    const fixed = [...shipped, 'heading-use-markup', 'body-use-markup', 'close-response', 'default-response'];
+    const build = (attributes) => ({
+        byTag: new Map([['adw-alert-twin', attributes]]),
+        tagToGtype: new Map([['adw-alert-twin', 'AlertTwin']]),
+        bodies: propsBodies(ALERT_DIALOG_FIXTURE),
+        knownGaps: {},
+    });
+    const failures = [];
+    const before = propertyProblems(build(shipped));
+    const missing = ['body-use-markup', 'close-response', 'default-response', 'heading-use-markup'];
+    if (before.length !== 4) {
+        failures.push(`the shipped alert dialog must give 4 problems, got ${before.length}`);
+    }
+    for (const property of missing) {
+        if (!before.some((problem) => problem.includes(`'${property}'`))) {
+            failures.push(`the shipped alert dialog must name '${property}'`);
+        }
+    }
+    // `extra-child` is a slot and must NOT be among them.
+    if (before.some((problem) => problem.includes("'extra-child'"))) {
+        failures.push('extra-child is a slot and must not be reported');
+    }
+    const after = propertyProblems(build(fixed));
+    if (after.length !== 0) failures.push(`the fixed alert dialog must be clean, got ${after.length}`);
+    return failures;
+}
 
 function selfTest() {
     const failures = [];
@@ -257,13 +367,23 @@ function selfTest() {
     if (!scalarProps(bodies.get('AfterEmpty') ?? '').has('trap')) {
         failures.push('the interface after an empty one must still be read');
     }
+    if (!bodies.has('WrappedWidget')) {
+        failures.push('an interface whose `extends` list wraps must be found — the head reader needs `\\s`');
+    }
     const demo = scalarProps(bodies.get('DemoWidget') ?? '');
-    if (demo.size !== 2) failures.push(`DemoWidget must expose 2 scalars, got ${demo.size}: ${[...demo].join(', ')}`);
+    for (const property of DEMO_SCALARS) {
+        if (!demo.has(property)) failures.push(`DemoWidget must expose '${property}' as a scalar`);
+    }
+    if (demo.has('child')) failures.push('a widget-valued property must not count as a scalar');
+    if (demo.size !== DEMO_SCALARS.length) {
+        failures.push(`DemoWidget must expose ${DEMO_SCALARS.length} scalars, got ${[...demo].join(', ')}`);
+    }
 
     for (const [label, build, expected] of VECTORS) {
         const got = propertyProblems(build()).length;
         if (got !== expected) failures.push(`${label}: expected ${expected} problem(s), got ${got}`);
     }
+    failures.push(...alertDialogRegression());
     return failures;
 }
 

--- a/scripts/check-adwaita-element-properties.mjs
+++ b/scripts/check-adwaita-element-properties.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+// Every `adw-*` web element against the GIR properties of the widget it names — and the
+// check proves itself on broken input before it looks at the repository.
+//
+// WHY THIS EXISTS. `<adw-alert-dialog>` shipped observing FOUR attributes while
+// `Adw.AlertDialog` carries eight own properties. The website's widget table reads
+// `observedAttributes` and truthfully rendered "takes 4 attributes", so the DOC was
+// right and the ELEMENT was short — and nothing anywhere compared the two. That is the
+// gap this closes: `check-vocabulary-alignment.mjs` already settles which element names
+// which widget; this one asks whether the element carries that widget's PROPERTIES.
+//
+// WHAT IS DELIBERATELY NOT A GAP, because a check with a high false-positive rate gets
+// disabled and then protects nothing (`check-workflow-inline-scripts.mjs`'s header
+// records the same lesson from its own first draft — "23 findings, 21 false"):
+//
+//   · SIGNAL props (`on-clicked`, `on-notify-*`). 224 of them across the mapped
+//     elements. They are a JSX convention; a custom element dispatches events instead,
+//     and an `on-*` ATTRIBUTE would be the inline-handler shape nobody wants.
+//   · WIDGET-VALUED props (`child`, `content`, `sidebar`, `extra-child`, `title-widget`
+//     — anything typed `Gtk.*`/`Adw.*`/`Gio.*`/`Gdk.*`/`Pango.*`/`GObject.*`). 52 of
+//     them. On this renderer those are SLOTS, not attributes: an attribute cannot
+//     carry a widget. `<adw-alert-dialog>`'s `extra-child` is exactly this shape.
+//
+// That leaves the scalar surface — strings, booleans, numbers, enums — which an
+// attribute genuinely can carry, and which is therefore the only half whose absence
+// carries information.
+//
+// KNOWN_GAPS IS A MEASURED BACKLOG, NOT A BLESSING. 53 scalar properties across 20
+// elements are unobserved today. They are listed rather than individually justified,
+// because inventing 53 rationales would be worse than naming none: a rule without its
+// real reason gets "simplified" back into the bug. What this check buys now is the
+// RATCHET — a new gap fails, and closing one fails too until it leaves the list, so the
+// number can only go down and cannot go quietly back up.
+//
+// The property list is the GIR-derived `generated/props.ts` (ADR 0028), so this check
+// inherits its provenance rather than hand-copying a second one.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { observedAttributes } from './adwaita-elements.mjs';
+
+const ROOT = process.cwd();
+
+/**
+ * Scalar GIR properties no `adw-*` element observes yet, measured 2026-08-26.
+ * A gap NOT listed here fails; a listed gap the element now observes fails too.
+ */
+const KNOWN_GAPS = {
+    'adw-about-dialog': [
+        'appdata-resource-path',
+        'artists',
+        'debug-info',
+        'debug-info-filename',
+        'designers',
+        'developers',
+        'documenters',
+        'release-notes',
+        'release-notes-version',
+        'translator-credits',
+    ],
+    'adw-avatar': ['icon-name'],
+    'adw-bottom-sheet': ['align', 'can-open', 'full-width', 'reveal-bottom-bar'],
+    'adw-combo-row': ['enable-search', 'use-subtitle'],
+    'adw-dialog': ['follows-content-size'],
+    'adw-header-bar': [
+        'decoration-layout',
+        'show-back-button',
+        'show-end-title-buttons',
+        'show-start-title-buttons',
+        'show-title',
+    ],
+    'adw-inline-view-switcher': ['can-shrink', 'homogeneous'],
+    'adw-navigation-split-view': ['sidebar-width-fraction'],
+    'adw-navigation-view': ['hhomogeneous', 'vhomogeneous'],
+    'adw-preferences-dialog': ['search-enabled', 'visible-page-name'],
+    'adw-preferences-group': ['separate-rows'],
+    'adw-preferences-page': ['description', 'description-centered'],
+    'adw-sidebar': ['drop-preload'],
+    'adw-split-button': ['can-shrink'],
+    'adw-status-page': ['icon-name'],
+    'adw-tab-view': ['shortcuts'],
+    'adw-toggle-group': ['active-name', 'can-shrink', 'homogeneous'],
+    'adw-toolbar-view': ['reveal-bottom-bars', 'reveal-top-bars'],
+    'adw-view-stack': ['enable-transitions', 'hhomogeneous', 'transition-duration', 'vhomogeneous'],
+    'adw-wrap-box': [
+        'align',
+        'child-spacing',
+        'justify-last-line',
+        'line-homogeneous',
+        'line-spacing',
+        'natural-line-length',
+        'wrap-reverse',
+    ],
+};
+
+/** A GIR type that holds an object — a slot on this renderer, never an attribute. */
+const OBJECT_TYPE = /\b(?:Gtk|Adw|Gio|Gdk|Pango|GObject)\.\w+/;
+
+const kebab = (name) => name.replace(/([A-Z])/g, (c) => `-${c.toLowerCase()}`);
+
+/** `tag -> GType`, from the runtime widget table. */
+export function tagGTypes(widgetsSource) {
+    const map = new Map();
+    for (const m of widgetsSource.matchAll(/gtype: '([^']+)', tag: '([^']+)'/g)) map.set(m[2], m[1]);
+    return map;
+}
+
+/**
+ * `<GType> -> interface body`, brace-MATCHED rather than regex-bounded.
+ *
+ * A lazy `[\s\S]*?\n\}` reads an EMPTY interface as the next one's body, which silently
+ * credited `adw-spinner` with `AdwSplitButton`'s properties while this was being built.
+ */
+export function propsBodies(propsSource) {
+    const bodies = new Map();
+    const head = /export interface (\w+)Props(?:\s+extends [^{]*)?\{/g;
+    let m;
+    while ((m = head.exec(propsSource))) {
+        let depth = 1;
+        let i = head.lastIndex;
+        while (i < propsSource.length && depth > 0) {
+            const c = propsSource[i];
+            if (c === '{') depth++;
+            else if (c === '}') depth--;
+            i++;
+        }
+        bodies.set(m[1], propsSource.slice(head.lastIndex, i - 1));
+    }
+    return bodies;
+}
+
+/**
+ * The scalar property names of one interface body, kebab-spelled and deduplicated.
+ *
+ * The generator emits multiword properties TWICE — `canOpen?: boolean;` and
+ * `'can-open'?: boolean;` — so without the dedupe every multiword gap counts double.
+ */
+export function scalarProps(body) {
+    const names = new Set();
+    for (const line of body.split('\n')) {
+        const m = /^\s*(?:'([a-z0-9-]+)'|([a-zA-Z][a-zA-Z0-9]*))\?:\s*(.+?);\s*$/.exec(line);
+        if (!m) continue;
+        const name = m[1] ?? kebab(m[2]);
+        if (name.startsWith('on-')) continue;
+        if (OBJECT_TYPE.test(m[3])) continue;
+        names.add(name);
+    }
+    return names;
+}
+
+/** @returns {string[]} one line per problem; empty means aligned. */
+export function propertyProblems({ byTag, tagToGtype, bodies, knownGaps }) {
+    const problems = [];
+    const seenDeclarations = new Set();
+    for (const [tag, attributes] of byTag) {
+        const gtype = tagToGtype.get(tag);
+        if (!gtype) continue; // web-only or aliased — check-vocabulary-alignment owns that
+        const body = bodies.get(gtype);
+        if (body === undefined) continue;
+
+        const observed = new Set(attributes);
+        const declared = new Set(knownGaps[tag] ?? []);
+        for (const property of scalarProps(body)) {
+            if (observed.has(property)) {
+                if (declared.has(property)) {
+                    seenDeclarations.add(`${tag}/${property}`);
+                    problems.push(
+                        `${tag} now observes '${property}' — delete it from KNOWN_GAPS so the backlog can only shrink.`,
+                    );
+                }
+                continue;
+            }
+            if (declared.has(property)) {
+                seenDeclarations.add(`${tag}/${property}`);
+                continue;
+            }
+            problems.push(
+                `${tag} does not observe '${property}', a scalar property of ${gtype}. ` +
+                    `Implement it, or add it to KNOWN_GAPS with the measurement that made it a decision.`,
+            );
+        }
+    }
+    for (const [tag, properties] of Object.entries(knownGaps)) {
+        for (const property of properties) {
+            if (!seenDeclarations.has(`${tag}/${property}`)) {
+                problems.push(
+                    `KNOWN_GAPS lists ${tag}/'${property}', which is not a scalar property of that widget any more.`,
+                );
+            }
+        }
+    }
+    return problems;
+}
+
+// ---------------------------------------------------------------------------
+// SELF-TEST FIRST — a check that cannot go red is worse than no check.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_PROPS = `
+export interface DemoWidgetProps extends GtkWidgetProps {
+    /** A scalar. */
+    label?: string;
+    /** Multiword, emitted twice by the generator. */
+    canShrink?: boolean;
+    'can-shrink'?: boolean;
+    /** A slot, not an attribute. */
+    child?: Gtk.Widget | null;
+    /** A signal, not a property. */
+    'on-clicked'?: () => void;
+}
+export interface EmptyWidgetProps extends GtkWidgetProps {}
+export interface AfterEmptyProps extends GtkWidgetProps {
+    trap?: string;
+}
+`;
+
+const FIXTURE_WIDGETS = `
+    { gtype: 'DemoWidget', tag: 'adw-demo', ctor: () => Adw.Demo },
+    { gtype: 'EmptyWidget', tag: 'adw-empty', ctor: () => Adw.Empty },
+`;
+
+const world = (attributes, knownGaps = {}) => ({
+    byTag: new Map([['adw-demo', attributes]]),
+    tagToGtype: tagGTypes(FIXTURE_WIDGETS),
+    bodies: propsBodies(FIXTURE_PROPS),
+    knownGaps,
+});
+
+const VECTORS = [
+    ['an observed scalar is not a problem', () => world(['label', 'can-shrink']), 0],
+    ['an unobserved scalar IS a problem', () => world(['label']), 1],
+    ['both unobserved are two problems', () => world([]), 2],
+    ['a declared gap is accepted', () => world(['label'], { 'adw-demo': ['can-shrink'] }), 0],
+    [
+        'a declaration the element now honours fails',
+        () => world(['label', 'can-shrink'], { 'adw-demo': ['can-shrink'] }),
+        1,
+    ],
+    [
+        'a declaration for a property that does not exist fails',
+        () => world(['label', 'can-shrink'], { 'adw-demo': ['ghost'] }),
+        1,
+    ],
+    ['a missing SLOT property is not a problem', () => world(['label', 'can-shrink']), 0],
+    ['a missing SIGNAL property is not a problem', () => world(['label', 'can-shrink']), 0],
+];
+
+function selfTest() {
+    const failures = [];
+
+    // The brace matcher, pinned directly: the lazy-regex bug it replaces was silent.
+    const bodies = propsBodies(FIXTURE_PROPS);
+    if (scalarProps(bodies.get('EmptyWidget') ?? '').size !== 0) {
+        failures.push('an empty interface must have no properties — the body reader ran past its closing brace');
+    }
+    if (!scalarProps(bodies.get('AfterEmpty') ?? '').has('trap')) {
+        failures.push('the interface after an empty one must still be read');
+    }
+    const demo = scalarProps(bodies.get('DemoWidget') ?? '');
+    if (demo.size !== 2) failures.push(`DemoWidget must expose 2 scalars, got ${demo.size}: ${[...demo].join(', ')}`);
+
+    for (const [label, build, expected] of VECTORS) {
+        const got = propertyProblems(build()).length;
+        if (got !== expected) failures.push(`${label}: expected ${expected} problem(s), got ${got}`);
+    }
+    return failures;
+}
+
+const selfTestFailures = selfTest();
+if (selfTestFailures.length > 0) {
+    console.error('check-adwaita-element-properties: SELF-TEST failed — the check itself is broken:');
+    for (const failure of selfTestFailures) console.error(`  - ${failure}`);
+    process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// The repository
+// ---------------------------------------------------------------------------
+
+let real;
+try {
+    const read = (relativePath) => readFileSync(join(ROOT, relativePath), 'utf8');
+    const { byTag, unreadable } = observedAttributes(ROOT);
+    if (unreadable.length > 0) {
+        // An element whose `observedAttributes` cannot be read would otherwise be
+        // credited with none and pass by looking maximally broken.
+        console.error('check-adwaita-element-properties: cannot read observedAttributes for:');
+        for (const name of unreadable) console.error(`  - ${name}`);
+        process.exit(1);
+    }
+    real = {
+        byTag,
+        tagToGtype: tagGTypes(read('packages/framework/gtk-host/src/generated/widgets.ts')),
+        bodies: propsBodies(read('packages/framework/gtk-host/src/generated/props.ts')),
+        knownGaps: KNOWN_GAPS,
+    };
+} catch (error) {
+    console.error(`check-adwaita-element-properties: cannot read an input — ${error.message}`);
+    console.error('If a file moved, teach this check where it went. Do not delete it.');
+    process.exit(1);
+}
+
+const problems = propertyProblems(real);
+if (problems.length > 0) {
+    console.error('check-adwaita-element-properties: an element and its widget disagree:');
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+}
+
+const mapped = [...real.byTag.keys()].filter((tag) => {
+    const gtype = real.tagToGtype.get(tag);
+    return gtype !== undefined && real.bodies.has(gtype);
+}).length;
+const backlog = Object.values(KNOWN_GAPS).flat().length;
+console.log(
+    `check-adwaita-element-properties: self-test green — ${VECTORS.length} vector(s). ` +
+        `${mapped} adw-* elements hold their widget's scalar GIR properties; ` +
+        `${backlog} property/ies across ${Object.keys(KNOWN_GAPS).length} elements remain a declared backlog.`,
+);

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -839,7 +839,7 @@ second row (a name-based deny-list is ugly; a `gjsify.nodeOnly` manifest flag is
 honest) or whether "fails further in" is acceptable. Nobody has hit it yet
 because every host that runs those has Node.
 
-### 53 scalar GIR properties no `adw-*` element observes yet
+### 83 scalar GIR properties no `adw-*` element observes yet
 
 `<adw-alert-dialog>` shipped observing FOUR attributes while `Adw.AlertDialog` carries
 eight own properties, and the website's widget table — which reads `observedAttributes` —
@@ -847,28 +847,47 @@ truthfully rendered "takes 4 attributes". The DOC was right and the ELEMENT was 
 Nothing compared the two, which is why the gap survived: `check-vocabulary-alignment.mjs`
 settles which element NAMES which widget and stops there.
 
-`scripts/check-adwaita-element-properties.mjs` closes the mechanism half. It is pinned red
-against that original defect (reverting the four attributes reproduces exactly four
-findings) and excludes the two classes that would have drowned it — measured, not assumed:
-**224 signal props** (`on-clicked`, `on-notify-*`; a custom element dispatches events, and
-an `on-*` attribute is the inline-handler shape nobody wants) and **52 widget-valued
-props** (`child`, `content`, `extra-child`, `title-widget` — slots on this renderer, since
-an attribute cannot carry a widget). That leaves the scalar surface, the only half whose
-absence carries information.
+`scripts/check-adwaita-element-properties.mjs` closes the mechanism half. A synthetic twin
+of the shipped 4-of-8 element is a self-test VECTOR, so the pin survives the real element
+being fixed — a regression test that reads the fixed source proves nothing once it is
+fixed.
 
-**What remains: 53 scalar properties across 20 elements**, listed in the check's
+Two classes are excluded, measured rather than assumed, because a rule with a high
+false-positive rate gets disabled and then protects nothing: **271 signal props**
+(`on-clicked`, `on-notify-*`; a custom element dispatches events, and an `on-*` attribute
+is the inline-handler shape nobody wants) and **47 widget-valued props** (`child`,
+`content`, `extra-child`, `title-widget` — slots, since an attribute cannot carry a
+widget).
+
+**ENUMS ARE IN SCOPE, and getting that wrong was the first version's own bug.** The
+generator spells an enum property `AdwToolbarStyleNick | Adw.ToolbarStyle`, so a namespace
+test reads it as object-typed and drops it. A nick is a STRING. 24 enum properties are in
+scope; 17 are already observed as attributes today, which is the proof they belong. The
+first draft excluded them and hid 14 real gaps behind a justification that did not apply.
+
+The same draft carried a second silent hole worth recording, because it is the
+unrepresentative-fixture class: its interface-head reader required a literal space after
+`extends`, and the generator wraps long heritage lists onto the next line. **65 of 190
+interfaces had no body**, and an element whose body is missing was skipped as unmapped —
+so eight elements (`adw-action-row`, `adw-spin-row`, `adw-entry-row`, `adw-expander-row`,
+`adw-carousel`, `adw-button-row`, `adw-password-entry-row`, `adw-window`) passed by being
+INVISIBLE, and the summary line read "35 elements hold their properties" while the honest
+number was 35 of 43. Both shapes are fixture vectors now.
+
+**What remains: 83 scalar properties across 28 elements**, listed in the check's
 `KNOWN_GAPS`. They are listed rather than individually justified, deliberately — inventing
-53 rationales would be worse than naming none, because a rule without its real reason gets
+83 rationales would be worse than naming none, because a rule without its real reason gets
 "simplified" back into the bug. What the list buys today is the RATCHET: a new gap fails,
 and closing one fails too until it leaves the list, so the number can only go down.
 
-The worst three are `adw-about-dialog` (10 — the credit-list and release-notes surface),
-`adw-wrap-box` (7 — nearly its whole layout surface; it observes NO attributes at all) and
-`adw-header-bar` (5 — `show-title`, `show-back-button` and the two title-button toggles).
-Those three are 22 of the 53 and are the obvious first pass. Each needs its own decision:
-some of these are genuinely missing attributes, and some are properties a web element is
-right to expose another way (`artists`/`developers` are string LISTS, which an attribute
-carries badly). The check does not pretend to know which; it makes the question visible.
+The worst three are `adw-wrap-box` (13 — its whole layout surface; it observes NO
+attributes at all), `adw-about-dialog` (11 — the credit-list and release-notes surface)
+and `adw-header-bar` (6 — `show-title`, `show-back-button`, `centering-policy` and the two
+title-button toggles). Those three are 30 of the 83 and are the obvious first pass. Each
+needs its own decision: some are genuinely missing attributes, and some are properties a
+web element is right to expose another way (`artists`/`developers` are string LISTS, which
+an attribute carries badly). The check does not pretend to know which; it makes the
+question visible.
 
 ### `systemGiLibraryDirs()` lives in three places, pinned by a test rather than shared
 

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -839,7 +839,38 @@ second row (a name-based deny-list is ugly; a `gjsify.nodeOnly` manifest flag is
 honest) or whether "fails further in" is acceptable. Nobody has hit it yet
 because every host that runs those has Node.
 
-### `systemGiLibraryDirs()` lives in two places, pinned by a test rather than shared
+### 53 scalar GIR properties no `adw-*` element observes yet
+
+`<adw-alert-dialog>` shipped observing FOUR attributes while `Adw.AlertDialog` carries
+eight own properties, and the website's widget table — which reads `observedAttributes` —
+truthfully rendered "takes 4 attributes". The DOC was right and the ELEMENT was short.
+Nothing compared the two, which is why the gap survived: `check-vocabulary-alignment.mjs`
+settles which element NAMES which widget and stops there.
+
+`scripts/check-adwaita-element-properties.mjs` closes the mechanism half. It is pinned red
+against that original defect (reverting the four attributes reproduces exactly four
+findings) and excludes the two classes that would have drowned it — measured, not assumed:
+**224 signal props** (`on-clicked`, `on-notify-*`; a custom element dispatches events, and
+an `on-*` attribute is the inline-handler shape nobody wants) and **52 widget-valued
+props** (`child`, `content`, `extra-child`, `title-widget` — slots on this renderer, since
+an attribute cannot carry a widget). That leaves the scalar surface, the only half whose
+absence carries information.
+
+**What remains: 53 scalar properties across 20 elements**, listed in the check's
+`KNOWN_GAPS`. They are listed rather than individually justified, deliberately — inventing
+53 rationales would be worse than naming none, because a rule without its real reason gets
+"simplified" back into the bug. What the list buys today is the RATCHET: a new gap fails,
+and closing one fails too until it leaves the list, so the number can only go down.
+
+The worst three are `adw-about-dialog` (10 — the credit-list and release-notes surface),
+`adw-wrap-box` (7 — nearly its whole layout surface; it observes NO attributes at all) and
+`adw-header-bar` (5 — `show-title`, `show-back-button` and the two title-button toggles).
+Those three are 22 of the 53 and are the obvious first pass. Each needs its own decision:
+some of these are genuinely missing attributes, and some are properties a web element is
+right to expose another way (`artists`/`developers` are string LISTS, which an attribute
+carries badly). The check does not pretend to know which; it makes the question visible.
+
+### `systemGiLibraryDirs()` lives in three places, pinned by a test rather than shared
 
 The darwin bare-leaf `dlopen` gap is one rule with THREE consumers now:
 `@gjsify/node-gi` re-execs itself with the host's GI libdirs on

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -137,6 +137,7 @@ export default defineConfig({
                         { slug: 'frameworks', label: 'Overview' },
                         { slug: 'frameworks/solid', label: 'Solid' },
                         { slug: 'frameworks/vue', label: 'Vue' },
+                        { slug: 'frameworks/react', label: 'React' },
                     ],
                 },
                 {

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -230,16 +230,13 @@ root.render(
 );
 ```
 
-`root.render()` is synchronous on purpose. A concurrent root hands its updates to the
-scheduler, which under GJS is a GLib timer source — with no main loop running yet, an
-unflushed first render leaves the container empty and says nothing. A `setState` from a GTK
-signal handler *is* concurrent and lands on the next main-loop iteration; `flushSync` is the
-escape hatch.
+`root.render()` is synchronous on purpose: with no main loop running yet nothing drives the
+scheduler, so an unflushed first render would leave the container empty and say nothing.
 
-Build it with `--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`.
-The development `react-reconciler` bundle reaches for `document`, `HTMLCanvasElement` and
-`Path2D`, and `--globals auto` is a static scan: it answers those identifiers by pulling
-`gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` into a bundle that needs none of them.
+Pointing `jsxImportSource` at the subpath rather than at `react` is what keeps 208 DOM tags
+from type-checking clean against a GTK renderer. The build needs two flags instead of a
+plugin — `--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`; the
+[React page](/gjsify/frameworks/react/) has both, with the reason each one exists.
 
 ## What the host refuses to do quietly
 
@@ -325,12 +322,12 @@ template tag to either key spelling but a Pascal tag only to a Pascal key, so on
 covers both — and that key is also the table key and the GtkBuilder XML key.
 
 `noImplicitAny: true` and `strictTemplates: true` are load-bearing in the same way: without
-them the checker accepts everything and you conclude the surface works. See the two pipeline
-pages for the exact traps.
+them the checker accepts everything and you conclude the surface works. Each framework page
+names the exact trap for its pipeline.
 
 ## Read the source
 
-Three showcases build the same window three ways, and each asserts the resulting tree against
+Four showcases build the same window four ways, and each asserts the resulting tree against
 the **real** widget tree on every launch:
 
 - [`adw-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/adw-host-counter)
@@ -339,11 +336,15 @@ the **real** widget tree on every launch:
   — the same window as Solid JSX
 - [`vue-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/vue-host-counter)
   — the same window as a `.vue` single-file component
+- [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter)
+  — the same window as React, with no compile plugin at all
 
 ## See also
 
 - [Solid JSX](/gjsify/frameworks/solid/) for the compile step a `.tsx` entry needs
 - [Vue SFCs](/gjsify/frameworks/vue/) for the compile step a `.vue` entry needs
+- [React](/gjsify/frameworks/react/) for the `jsxImportSource` and build defines a `.tsx` entry
+  needs instead of a compile step
 - [Native Adwaita Apps](/gjsify/guides/native-adwaita-app/) for the application shell you
   mount into
 - [GObject Classes](/gjsify/patterns/gobject-classes/) for the `registerClass` rules your own

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -233,8 +233,8 @@ root.render(
 `root.render()` is synchronous on purpose: with no main loop running yet nothing drives the
 scheduler, so an unflushed first render would leave the container empty and say nothing.
 
-Pointing `jsxImportSource` at the subpath rather than at `react` is what keeps 208 DOM tags
-from type-checking clean against a GTK renderer. The build needs two flags instead of a
+Pointing `jsxImportSource` at the subpath rather than at `react` is what keeps `@types/react`'s
+178 DOM tags from type-checking clean against a GTK renderer. The build needs two flags instead of a
 plugin — `--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`; the
 [React page](/gjsify/frameworks/react/) has both, with the reason each one exists.
 

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -1,0 +1,188 @@
+---
+title: React
+description: Render React into GTK 4 with @gjsify/gtk-host/react. No compile plugin, the jsxImportSource that keeps 208 DOM tags out, and the build recipe that is not optional.
+---
+
+import CommandTabs from '../../../components/CommandTabs.astro';
+
+[`@gjsify/gtk-host/react`](https://www.npmjs.com/package/@gjsify/gtk-host) renders React into
+real `Gtk` and `Adw` widgets, over the same host layer Solid and Vue use.
+
+React is the one of the three that needs **no compile plugin**. Its JSX is a runtime, not a
+transform: `jsx()` builds a plain `{type, props, key}` record and the host mapping happens
+afterwards, inside `react-reconciler`. So where the [Solid](/gjsify/frameworks/solid/) and
+[Vue](/gjsify/frameworks/vue/) pages are about a build step, this page is about two
+configuration decisions — where `jsxImportSource` points, and what the bundle defines.
+
+Both are load-bearing. Get either wrong and you get a green type-check or a green build with an
+empty window, which is the failure mode this package exists to refuse.
+
+## Install
+
+<CommandTabs title="Install" group="pm">
+  <Fragment slot="gjsify">
+    ```bash
+    gjsify install @gjsify/gtk-host react react-reconciler
+    ```
+  </Fragment>
+  <Fragment slot="npm">
+    ```bash
+    npm install -D @gjsify/gtk-host react react-reconciler
+    ```
+  </Fragment>
+  <Fragment slot="yarn">
+    ```bash
+    yarn add -D @gjsify/gtk-host react react-reconciler
+    ```
+  </Fragment>
+  <Fragment slot="pnpm">
+    ```bash
+    pnpm add -D @gjsify/gtk-host react react-reconciler
+    ```
+  </Fragment>
+  <Fragment slot="bun">
+    ```bash
+    bun add --dev @gjsify/gtk-host react react-reconciler
+    ```
+  </Fragment>
+  <Fragment slot="deno">
+    ```bash
+    deno add --dev npm:@gjsify/gtk-host npm:react npm:react-reconciler
+    ```
+  </Fragment>
+</CommandTabs>
+
+Both are optional peer dependencies of `@gjsify/gtk-host` — installing them is what selects the
+React adapter. `react-dom` is not involved and must not be installed for this.
+
+## Wire it up
+
+```jsonc
+// tsconfig.json
+{
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "jsxImportSource": "@gjsify/gtk-host/react",
+        "noImplicitAny": true
+    }
+}
+```
+
+```tsx
+import { createRoot } from '@gjsify/gtk-host/react';
+
+const root = createRoot(myWindow);
+root.render(
+    <gtk-box orientation="vertical" spacing={12}>
+        <gtk-label label="hi" />
+    </gtk-box>,
+);
+```
+
+`createRoot` takes a widget your application already built. It records what that container
+already held, so your tree renders *after* the app's own chrome rather than on top of it.
+
+## Point `jsxImportSource` at the subpath, not at `react`
+
+This is the trap worth spending a paragraph on, because the wrong answer type-checks clean.
+
+Write `"jsxImportSource": "react"` and the element list comes from `@types/react`'s own
+`JSX.IntrinsicElements`. That is 113 HTML elements + 4 deprecated + 59 SVG + 32 MathML — **208
+tags that pass `tsc` against a GTK renderer and then render nothing.** `<div>` becomes a
+perfectly valid expression in a program that cannot draw a `div`.
+
+Pointing at `@gjsify/gtk-host/react` swaps that list for the generated GTK one, so `<div/>` is
+a `TS2339` naming the element and `<gtk-label label="hi" />` is checked against the real
+`GtkLabel` properties. The measurement behind the number is
+[ADR 0028 § 8](https://github.com/gjsify/gjsify/blob/main/docs/adr/0028-widget-table-provenance.md).
+
+TypeScript appends `/jsx-runtime` to whatever you name (`/jsx-dev-runtime` under
+`"jsx": "react-jsxdev"`), and the package exports both. The functions underneath are **React's
+own** `jsx`/`jsxs`/`jsxDEV`, re-typed rather than reimplemented — a second `createElement`
+would be a second element format to keep in step with React's.
+
+:::note[Why this is a separate subpath]
+`@gjsify/gtk-host/jsx-runtime` — no `react` segment — deliberately THROWS. That is correct for
+Solid and Vue, whose reactivity lives in what their compilers emit, so an automatic runtime
+reaching those functions means the pipeline is misconfigured. One module cannot both refuse the
+automatic runtime and provide it, which is why React gets its own.
+:::
+
+## The build recipe, and it is not optional
+
+```bash
+gjsify build --app gjs \
+  --define 'process.env.NODE_ENV="production"' \
+  --exclude-globals navigator
+```
+
+**`--define`**, because `react-reconciler/index.js` is literally
+`process.env.NODE_ENV === 'production' ? require('./cjs/…production.min.js') :
+require('./cjs/…development.js')`. Without the define you bundle the development build, which
+reaches for `document`, `HTMLCanvasElement` and `Path2D`. `--globals auto` is a *static scan*:
+it answers those identifiers by injecting the GTK-backed DOM registers and pulling
+`gi://Gdk`, `GdkPixbuf`, `Pango` and `PangoCairo` into a bundle that needs none of them.
+
+**`--exclude-globals navigator`**, because even the production `scheduler` carries
+`typeof navigator !== 'undefined' && navigator.scheduling`. That branch is dead under GJS, but
+the identifier is still free, and the detector answers it with the same GTK-backed register.
+
+Vue needs the same `NODE_ENV` define for the same reason; the two recipes differ only in the
+`navigator` flag.
+
+## `render()` is synchronous, on purpose
+
+React's own `createRoot().render()` returns before the tree is committed and lets the scheduler
+drive. Under GJS that scheduler is a GLib timer source — so with no main loop running yet, an
+unflushed first render leaves the container **empty, with no error**. `render()` here wraps
+`updateContainer` in `flushSync`, so the widgets exist when it returns.
+
+The root is still a concurrent root, and that matters after startup: a `setState` from a GTK
+signal handler lands on a later main-loop iteration, which in a running application is the
+behaviour you want. When you need a change visible immediately — typically in a test, outside a
+main loop — `flushSync` is the escape hatch:
+
+```tsx
+import { flushSync } from '@gjsify/gtk-host/react';
+
+flushSync(() => setCount(1));
+// the label's text has already changed here
+```
+
+## What the adapter exports
+
+| Export | What it is |
+|---|---|
+| `createRoot(container, options?)` | a root over a widget you own; `render`, `unmount`, `container` |
+| `mount(element, container, options?)` | `createRoot(…).render(…)`, for the common case |
+| `flushSync(fn)` | run `fn` and flush every update it schedules |
+| `widgetOf(node)` | the `Gtk.Widget` behind a host node |
+| `adopt(widget)` | wrap a container you hold in a host element |
+| `gtkHostConfig` | the raw `react-reconciler` HostConfig, for reconciler-level control |
+
+`options.onRecoverableError` handles an error React *recovered* from — one an error boundary
+caught and retried. It defaults to `console.error`, matching what `react-dom` does. Rethrowing
+is deliberately not the default: React calls it from inside the commit, so throwing would break
+the error boundary that had just done its job.
+
+## Two places React differs from a DOM renderer
+
+**`ref` gives you your own widget.** Where the host wraps a child — a `GtkListBoxRow` around a
+row, say — `getPublicInstance` still returns the widget *you* wrote. A `ref` handing back a
+wrapper the author never mentioned would be a silent lie about which widget they hold.
+
+**The first commit does not clear your window.** React clears a root before its first commit
+(`updateHostRoot` sets `Snapshot` whenever `current.child` is null — "this handles the case of
+React rendering into a container with previous children"). On GTK that container is your
+application's own widget and your chrome is inside it, so `clearContainer` maps to the shadow
+children only and never touches what was already there.
+
+## Related
+
+- [UI Frameworks](/gjsify/frameworks/) for the host, the widget table and the
+  placement rules
+- [Solid JSX](/gjsify/frameworks/solid/) and [Vue SFCs](/gjsify/frameworks/vue/) for the two
+  adapters that do need a compile step
+- [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter),
+  a complete window that asserts its own widget tree on every launch
+- [`@gjsify/gtk-host` on npm](https://www.npmjs.com/package/@gjsify/gtk-host)

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: React
-description: Render React into GTK 4 with @gjsify/gtk-host/react. No compile plugin, the jsxImportSource that keeps 208 DOM tags out, and the build recipe that is not optional.
+description: Render React into GTK 4 with @gjsify/gtk-host/react. No compile plugin, the jsxImportSource that keeps 178 DOM tags out, and the build recipe that is not optional.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
@@ -22,38 +22,39 @@ empty window, which is the failure mode this package exists to refuse.
 <CommandTabs title="Install" group="pm">
   <Fragment slot="gjsify">
     ```bash
-    gjsify install @gjsify/gtk-host react react-reconciler
+    gjsify install @gjsify/gtk-host react react-reconciler @types/react
     ```
   </Fragment>
   <Fragment slot="npm">
     ```bash
-    npm install -D @gjsify/gtk-host react react-reconciler
+    npm install -D @gjsify/gtk-host react react-reconciler @types/react
     ```
   </Fragment>
   <Fragment slot="yarn">
     ```bash
-    yarn add -D @gjsify/gtk-host react react-reconciler
+    yarn add -D @gjsify/gtk-host react react-reconciler @types/react
     ```
   </Fragment>
   <Fragment slot="pnpm">
     ```bash
-    pnpm add -D @gjsify/gtk-host react react-reconciler
+    pnpm add -D @gjsify/gtk-host react react-reconciler @types/react
     ```
   </Fragment>
   <Fragment slot="bun">
     ```bash
-    bun add --dev @gjsify/gtk-host react react-reconciler
+    bun add --dev @gjsify/gtk-host react react-reconciler @types/react
     ```
   </Fragment>
   <Fragment slot="deno">
     ```bash
-    deno add --dev npm:@gjsify/gtk-host npm:react npm:react-reconciler
+    deno add --dev npm:@gjsify/gtk-host npm:react npm:react-reconciler npm:@types/react
     ```
   </Fragment>
 </CommandTabs>
 
-Both are optional peer dependencies of `@gjsify/gtk-host` — installing them is what selects the
-React adapter. `react-dom` is not involved and must not be installed for this.
+`react` and `react-reconciler` are optional peer dependencies of `@gjsify/gtk-host` — installing
+them is what selects the React adapter. `@types/react` is what the JSX surface is typed against.
+`react-dom` is not involved and must not be installed for this.
 
 ## Wire it up
 
@@ -87,14 +88,15 @@ already held, so your tree renders *after* the app's own chrome rather than on t
 This is the trap worth spending a paragraph on, because the wrong answer type-checks clean.
 
 Write `"jsxImportSource": "react"` and the element list comes from `@types/react`'s own
-`JSX.IntrinsicElements`. That is 113 HTML elements + 4 deprecated + 59 SVG + 32 MathML — **208
-tags that pass `tsc` against a GTK renderer and then render nothing.** `<div>` becomes a
-perfectly valid expression in a program that cannot draw a `div`.
+`JSX.IntrinsicElements` — **178 HTML and SVG tags that pass `tsc` against a GTK renderer and
+then render nothing** (measured against `@types/react@18.3.31`; React's list carries no MathML).
+`<div>` becomes a perfectly valid expression in a program that cannot draw a `div`.
 
 Pointing at `@gjsify/gtk-host/react` swaps that list for the generated GTK one, so `<div/>` is
 a `TS2339` naming the element and `<gtk-label label="hi" />` is checked against the real
-`GtkLabel` properties. The measurement behind the number is
-[ADR 0028 § 8](https://github.com/gjsify/gjsify/blob/main/docs/adr/0028-widget-table-provenance.md).
+`GtkLabel` properties. Solid has the same problem one package over, at a different size —
+[ADR 0028 § 8](https://github.com/gjsify/gjsify/blob/main/docs/adr/0028-widget-table-provenance.md)
+measures the 208 tags `solid-js` pre-declares, and the fix there is the same one.
 
 TypeScript appends `/jsx-runtime` to whatever you name (`/jsx-dev-runtime` under
 `"jsx": "react-jsxdev"`), and the package exports both. The functions underneath are **React's

--- a/website/src/data/adwaita-attributes.ts
+++ b/website/src/data/adwaita-attributes.ts
@@ -22,7 +22,16 @@ export const ADWAITA_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
         'open',
     ],
     'adw-action-row': ['title', 'subtitle', 'activatable'],
-    'adw-alert-dialog': ['heading', 'body', 'open', 'prefer-wide-layout'],
+    'adw-alert-dialog': [
+        'heading',
+        'body',
+        'heading-use-markup',
+        'body-use-markup',
+        'close-response',
+        'default-response',
+        'open',
+        'prefer-wide-layout',
+    ],
     'adw-alert-response': ['id', 'appearance', 'enabled'],
     'adw-avatar': ['text', 'size', 'show-initials', 'icon', 'custom-image'],
     'adw-banner': ['title', 'button-label', 'revealed', 'use-markup', 'button-style'],
@@ -151,7 +160,7 @@ export const ADWAITA_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
 };
 
 /** How many attributes the web pillar observes in total. */
-export const ADWAITA_ATTRIBUTE_COUNT = 256;
+export const ADWAITA_ATTRIBUTE_COUNT = 260;
 
 /** How many elements the pillar registers. An element with none is still an entry. */
 export const ADWAITA_ELEMENT_COUNT = 65;


### PR DESCRIPTION
The documentation round, plus the element that made it necessary.

## `<adw-alert-dialog>` observed 4 of `Adw.AlertDialog`'s 8 own properties

The website's widget table reads `observedAttributes` and rendered **"takes 4 attributes"**. The doc was right; the element was short. Missing:

| Property | State before |
|---|---|
| `close-response` | a JS property delegating to the headless model — no attribute fed it |
| `default-response` | same |
| `heading-use-markup` | absent; `heading` rendered through `textContent` unconditionally |
| `body-use-markup` | absent; same for `body` |

Markup is opt-in, and here that **matches** libadwaita rather than departing from it — both properties are `@default false` in the GIR. `Adw.Banner:use-markup` is the one that defaults to TRUE, which is why `adw-banner.ts` documents a deliberate departure and this file does not need to. `extra-child` stays a slot: an attribute cannot carry a widget.

The element had **no spec of its own**, which is part of why the gap survived. The new one is registered in `test.browser.mts` — whose import list is explicit, so an unregistered spec would simply never run.

Verified end-to-end: the rebuilt page now reads *"takes 8 attributes"*.

## The mechanism, because one element is not the class

`check-vocabulary-alignment.mjs` (#1332) settles which element **names** which widget and stops there. Nothing asked whether the element carries that widget's **properties**.

`scripts/check-adwaita-element-properties.mjs` does. A **synthetic twin** of the shipped 4-of-8 element is a self-test vector, so the pin survives the real element being fixed — a regression test that reads the fixed source proves nothing once it is fixed.

Two classes are excluded, **measured rather than assumed**, because a rule with a high false-positive rate gets disabled and then protects nothing:

- **271 signal props** (`on-clicked`, `on-notify-*`) — a custom element dispatches events; an `on-*` attribute is the inline-handler shape nobody wants.
- **47 widget-valued props** (`child`, `content`, `extra-child`, `title-widget`) — slots on this renderer.

Enums are **not** excluded, though the naive namespace test catches them: the generator spells one `AdwToolbarStyleNick | Adw.ToolbarStyle`, and a nick is a string. 24 are in scope; 17 are already observed as attributes today, which is the proof they belong.

That leaves the scalar surface, the only half whose absence carries information. The list comes from the GIR-derived `generated/props.ts` (ADR 0028), so this inherits its provenance rather than hand-copying a second one.

**83 scalar properties across 28 elements remain unobserved**, listed in `KNOWN_GAPS`. Listed rather than individually justified, deliberately: inventing 53 rationales would be worse than naming none, because a rule without its real reason gets "simplified" back into the bug. What the list buys today is the **ratchet** — a new gap fails, and closing one fails too until it leaves the list, so the number can only go down. The worst three (`adw-wrap-box` 13, `adw-about-dialog` 11, `adw-header-bar` 6) are 30 of the 83 and are the obvious first pass; the ledger entry says so.

One bug found while building it, worth naming because it was silent: a lazy `[\s\S]*?\n\}` interface bound reads an **empty** interface as the next one's body, which credited `adw-spinner` with `AdwSplitButton`'s properties. The reader is brace-matched now and a vector pins it.

## The React page

UI Frameworks named React in three places and linked *"the two pipeline pages"*. There were two, and React had none.

React needs no compile plugin, so the page has a different centre than Solid's and Vue's — the two configuration decisions that are load-bearing:

- **`jsxImportSource` at the subpath, not at `react`.** The wrong answer type-checks *clean*: `@types/react`'s own `JSX.IntrinsicElements` is **178 tags** that pass `tsc` against a GTK renderer and render nothing.
- **`--define 'process.env.NODE_ENV="production"' --exclude-globals navigator`**, with the reason each one exists.

Plus why `render()` flushes synchronously, `ref` handing back the author's own widget rather than the host's wrapper, and `clearContainer` not clearing the application's chrome.

The overview's React section shrinks to a pointer, the way its Vue section already does. `react-host-counter` was missing from the showcase list too, which still said three.

## Also

A stale ledger heading: `systemGiLibraryDirs()` lives in **three** places, which that entry's own body has named since ADR 0022's follow-up.

## Verified

- `format --check`, `lint` — clean (rc measured without a pipe)
- `tsc --noEmit` on adwaita-web — clean
- `check-adwaita-element-properties` — self-test green, 8 vectors; red on the reverted defect
- `check-vocabulary-alignment`, `check-generated-website-data` — green
- `astro build` — 59 pages, `/frameworks/react/index.html` emitted


---

## Review round — three real defects, two of them in this PR's own check

An adversarial review measured both halves green while claiming more than they held. Fixed in `da8505fbd`, `4fca0647b`, `cde1fc138`:

1. **The check was blind to 8 of 43 elements.** Its interface-head reader required a literal space after `extends`; the generator wraps long heritage lists onto the next line, so **65 of 190** interfaces had no body and their elements were skipped as *unmapped* — passing by being invisible. The fixture only ever wrote a single-line `extends`, which is precisely the unrepresentative-fixture class the file's own docstring congratulates itself for having fixed on the *body* reader. Backlog re-derived: **83 across 28**, not 53 across 20.

2. **Enums were excluded as objects.** `AdwToolbarStyleNick | Adw.ToolbarStyle` looks namespaced, but a nick is a *string*. 17 such properties are already observed as attributes today — the proof they belong. Excluding them hid 14 real gaps behind a justification that did not apply to them.

3. **The element dropped both response IDs when set in markup** — the case they exist for. `attributeChangedCallback` returns early until `_initialized`, so a markup attribute is never delivered; `heading`/`body` survive only because `_render()` re-reads them. Two of the new spec's assertions failed, and were right to. `connectedCallback` seeds both now, and the browser suite passes.

Also corrected: **"pinned red" was an overclaim** — nothing automated held it, so a synthetic twin of the 4-of-8 element is a vector now; the dismissal test drove `open = false`, which is not the dismissal path; and the **208** figure was Solid's, not React's (`@types/react@18.3.31` has 178 members and no MathML).

## Re-verified after the fixes

- `format --check` 0, `lint` 0, `tsc --noEmit` (adwaita-web) 0 — measured without a pipe
- `check-adwaita-element-properties` — self-test green, **10 vectors**, 43 elements, 83 declared
- `check-vocabulary-alignment` 0, `check-generated-website-data` 0
- **Playwright chromium**: `web/@gjsify/adwaita-web` **passes**. Three unrelated suites (`streams`, `util`, `events`) fail with `Failed to fetch` in this local run — untouched packages, environmental
- `astro build` — 59 pages; the rendered widget table reads *"takes 8 attributes"*
