### PR TITLE
feat(gtk-host): move the React adapter to React 19

### DIFF
--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -63,10 +63,10 @@
     "solid-js@^1.9.0",
     "vue@^3.5.41",
     "vue-tsc@^3.3.11",
-    "react@^18.3.1",
-    "react-reconciler@^0.29.2",
-    "@types/react@^18.3.12",
-    "@types/react-reconciler@^0.28.9",
+    "react@^19.2.0",
+    "react-reconciler@^0.33.0",
+    "@types/react@^19.2.2",
+    "@types/react-reconciler@^0.33.0",
     "@girs/javascriptcore-6.0@^4.1.0",
     "@girs/gwebgl-0.1@0.1.0-4.0.0-rc.5",
     "bit-twiddle@^1.0.2",
@@ -2963,6 +2963,14 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
       "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ=="
     },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/inspector-client/node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
@@ -5607,11 +5615,6 @@
         "parse-torrent": "*"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
-    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -5623,18 +5626,17 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dependencies": {
-        "csstype": "^3.2.2",
-        "@types/prop-types": "*"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-reconciler": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
-      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg=="
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g=="
     },
     "node_modules/@types/sax": {
       "version": "1.2.7",
@@ -12732,12 +12734,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -12748,13 +12747,20 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/react-reconciler": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
-      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
-        "scheduler": "^0.23.2",
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
       }
     },
     "node_modules/react-remove-scroll": {
@@ -13406,12 +13412,9 @@
       "optional": true
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/scope-analyzer": {
       "version": "2.1.2",

--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -377,13 +377,28 @@ is not in this table because `@vue/runtime-core` does not export it at all
 READ instead of restated. `react-reconciler` is `module.exports = function
 $$$reconciler($$$hostConfig) { … }` and its body opens by destructuring the whole
 config, so a recording `Proxy` over the config reports exactly which members the
-installed version asks for. Measured on **0.29.2**, production bundle: **76**
-members read, **37** answered here, **39** switched off by three flags the config
-does declare (`supportsPersistence: false`, `supportsHydration: false`,
-`supportsTestSelectors` absent) plus `supportsMicrotasks`, and 4 more declared for
-the development bundle, which reads 94. `react.spec.ts` asserts all three
+installed version asks for. Measured on **0.33.0** (React 19.2), production bundle:
+**160** members read, **58** answered here, **102** switched off — by the four
+capability flags the config declares false (`supportsPersistence`,
+`supportsHydration`, `supportsResources`, `supportsSingletons`), by two it declares
+not at all (`supportsTestSelectors`, `supportsMicrotasks`), and by three families no
+flag gates and nothing here can mean (view transitions and the gesture timeline,
+fragment instances, DevTools metadata). `react.spec.ts` asserts all three
 directions, so a version bump that starts asking for something new fails a test
 instead of reading `undefined` inside a commit.
+
+**What the React 19 bump cost, because the numbers alone understate it.** 0.29.2 read
+76 members and the development bundle read 94, which made the count itself a guard
+against a lost `NODE_ENV=production` define; on 0.33.0 both bundles read 160 and that
+guard is gone — the "runs without a DOM at all" vector, which asserts `document`,
+`HTMLCanvasElement` and `Path2D` are absent, is now the only thing holding the build
+recipe. Three further changes were silent rather than typed: `flushSync(() =>
+updateContainer(…))` on a ConcurrentRoot mounts NOTHING under 19 (the sync path is
+`updateContainerSync` + `flushSyncWork`); `createContainer` grew two error callbacks
+*before* `onRecoverableError`, so the React 18 argument list keeps working and wires
+the wrong handler; and an error the host throws no longer propagates out of
+`render()` but goes to `onUncaughtError`, which is why `createRoot` holds the first
+one and rethrows it — a named refusal that only reaches a log has bought nothing.
 
 ```ts
 import { createRoot, flushSync } from '@gjsify/gtk-host/react';
@@ -396,11 +411,13 @@ root.render(createElement('GtkBox', null, createElement('GtkLabel', { label: 'hi
   `ConcurrentRoot`'s updates are DEFAULT-lane, so they are handed to `scheduler`,
   which under GJS is a GLib timer source — with no main loop running yet, an
   unflushed first render leaves the container empty and says nothing. `render()`
-  therefore wraps `updateContainer` in `flushSync`, which sets the current update
-  priority to `DiscreteEventPriority` and makes everything scheduled inside it a
-  sync lane the same call then flushes.
+  therefore calls `updateContainerSync`, which puts the work on the sync lane, and
+  then `flushSyncWork`, which drains it. Under React 18 this was
+  `flushSync(() => updateContainer(…))`; under 19 that combination on a
+  `ConcurrentRoot` mounts nothing at all, silently, so the two calls are spelled
+  separately and the reason is written down where they are.
 - **A `setState` from a GTK signal handler is concurrent** and lands on the next
-  main-loop iteration, because `getCurrentEventPriority` returns the default lane
+  main-loop iteration, because `resolveUpdatePriority` returns the default lane
   (there is no ambient DOM event to derive a priority from). `flushSync` is the
   escape hatch. A vector pumps `GLib.MainContext.default()` and proves the
   scheduled path works at all under GJS — it does, on gjs 1.88.1, with no

--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -383,7 +383,8 @@ capability flags the config declares false (`supportsPersistence`,
 `supportsHydration`, `supportsResources`, `supportsSingletons`), by two it declares
 not at all (`supportsTestSelectors`, `supportsMicrotasks`), and by three families no
 flag gates and nothing here can mean (view transitions and the gesture timeline,
-fragment instances, DevTools metadata). `react.spec.ts` asserts all three
+fragment instances, DevTools metadata, and the suspended-commit reason React reads
+only to name a commit in its own timeline). `react.spec.ts` asserts all three
 directions, so a version bump that starts asking for something new fails a test
 instead of reading `undefined` inside a commit.
 

--- a/packages/framework/gtk-host/package.json
+++ b/packages/framework/gtk-host/package.json
@@ -90,8 +90,8 @@
     "peerDependencies": {
         "@vue/runtime-core": "^3.5.0",
         "solid-js": "^1.9.0",
-        "react": "^18.3.1",
-        "react-reconciler": "^0.29.2"
+        "react": "^19.2.0",
+        "react-reconciler": "^0.33.0"
     },
     "peerDependenciesMeta": {
         "@vue/runtime-core": {
@@ -118,10 +118,10 @@
         "@gjsify/node-gi": "file:../../node-gi/node-gi",
         "vue": "^3.5.41",
         "vue-tsc": "^3.3.11",
-        "react": "^18.3.1",
-        "react-reconciler": "^0.29.2",
-        "@types/react": "^18.3.12",
-        "@types/react-reconciler": "^0.28.9"
+        "react": "^19.2.0",
+        "react-reconciler": "^0.33.0",
+        "@types/react": "^19.2.2",
+        "@types/react-reconciler": "^0.33.0"
     },
     "gjsify": {
         "runtimes": {

--- a/packages/framework/gtk-host/src/adapters/react.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/react.spec.ts
@@ -14,11 +14,13 @@
 //     bundle arrives and reaches for `document`, `HTMLCanvasElement` and `Path2D`
 //     — which makes `--globals auto` inject the GTK-backed DOM registers. The
 //     "runs without a DOM at all" vector is what notices.
-//  2. `flushSync`. A ConcurrentRoot's updates are DEFAULT-lane, so they are handed
-//     to `scheduler` and land on a later main-loop iteration. `flushSync` sets the
-//     current update priority to `DiscreteEventPriority`, which makes everything
-//     scheduled inside it a SYNC lane that the same call then flushes — that is
-//     why `render()` is synchronous. The scheduled path is not left unmeasured:
+//  2. The SYNCHRONOUS render path. A ConcurrentRoot's updates are DEFAULT-lane, so
+//     they are handed to `scheduler` and land on a later main-loop iteration.
+//     `updateContainerSync` puts the work on the sync lane and `flushSyncWork`
+//     drains it — that is why `render()` is synchronous. Under React 18 this was
+//     `flushSync(() => updateContainer(…))`; under 19 that same combination mounts
+//     NOTHING on a ConcurrentRoot, silently, which is why the two calls are spelled
+//     separately here and in `react.ts`. The scheduled path is not left unmeasured:
 //     one vector pumps the GLib main context and proves it works.
 
 import { expect, it, on } from '@gjsify/unit';
@@ -39,11 +41,12 @@ import { jsx as reactJsx } from '../react-jsx-runtime.js';
 import { jsx as refusedJsx } from '../jsx-runtime.js';
 import { adopt, createRoot, flushSync, gtkHostConfig, mount, widgetOf } from './react.js';
 
-/** The two reconciler entry points this suite drives directly. */
+/** The reconciler entry points this suite drives directly. */
 interface DirectReconciler {
     createContainer(...args: unknown[]): unknown;
     updateContainer(...args: unknown[]): unknown;
-    flushSync(fn: () => void): void;
+    updateContainerSync(...args: unknown[]): unknown;
+    flushSyncWork(): void;
 }
 
 const labelsOf = (w: Gtk.Widget) => gtkChildren(w).map((c) => (c as Gtk.Label).label);
@@ -120,28 +123,51 @@ function recordingRoot(container: Gtk.Widget, onRecoverableError: (error: Error)
             },
         }) as never,
     ) as unknown as DirectReconciler;
-    // The adopt/createContainer/flushSync sequence of `createRoot`, restated here
-    // because the point is to drive it through the INSTRUMENTED reconciler.
+    // The adopt/createContainer/render sequence of `createRoot`, restated here
+    // because the point is to drive it through the INSTRUMENTED reconciler. It
+    // must stay argument-for-argument identical to the real one: React 19 inserted
+    // `onUncaughtError`/`onCaughtError` BEFORE `onRecoverableError`, so a copy that
+    // kept React 18's eight-argument list would silently instrument a differently
+    // wired root than the one under test.
     const host = adopt(container);
-    const root = recorder.createContainer(host, ConcurrentRoot, null, false, null, '', onRecoverableError, null);
+    const root = recorder.createContainer(
+        host,
+        ConcurrentRoot,
+        null,
+        false,
+        null,
+        '',
+        onRecoverableError,
+        onRecoverableError,
+        onRecoverableError,
+        () => {},
+    );
     return {
         calls,
         container: host,
         render(element: ReactNode) {
-            recorder.flushSync(() => {
-                recorder.updateContainer(element, root, null, null);
-            });
+            // `flushSync(() => updateContainer(…))` mounts NOTHING on a
+            // ConcurrentRoot under React 19 — see `createRoot` in `react.ts`.
+            recorder.updateContainerSync(element, root, null, null);
+            recorder.flushSyncWork();
         },
     };
 }
 
 // --- the contract, as the installed react-reconciler states it ----------------
 //
-// Measured on react-reconciler 0.29.2, PRODUCTION bundle (the one the build recipe
-// mandates). The development bundle reads 94 members — the four
-// `*ActiveInstanceBlur`/scope ones below plus the `didNotFindHydratable*` dev
-// warnings — so a count of 94 here means the production define was lost.
-const READS = 76;
+// Measured on react-reconciler 0.33.0, PRODUCTION bundle (the one the build recipe
+// mandates). It was 76 on 0.29.2 — the jump is React 19 adding the resource,
+// singleton, view-transition, gesture, form-state and suspend-commit families.
+//
+// WHAT THIS NUMBER NO LONGER DOES. On 0.29.2 the development bundle read 94, so
+// pinning 76 also caught a lost `NODE_ENV=production` define. On 0.33.0 BOTH
+// bundles read 160 and the count cannot tell them apart at all. That job now
+// belongs entirely to the "runs without a DOM at all" vector below, which tests
+// the fact itself (`document` / `HTMLCanvasElement` / `Path2D` are absent) rather
+// than a proxy for it. Said here because a count that silently stopped
+// discriminating is worth more as a recorded loss than as a deleted line.
+const READS = 160;
 
 /**
  * What React asks for and this adapter deliberately does not answer, by family.
@@ -164,34 +190,116 @@ const GATED_OFF = {
         'replaceContainerChildren',
     ],
     // `supportsHydration: false` — hydration means adopting markup a server
-    // produced, and there is none.
+    // produced, and there is none. React 19 widened this family considerably:
+    // Activity boundaries, the form-state marker and the dev-warning differs are
+    // all new, while 18's two `didNotMatchHydrated*TextInstance` warners are gone.
     hydration: [
+        'canHydrateActivityInstance',
+        'canHydrateFormStateMarker',
         'canHydrateInstance',
         'canHydrateSuspenseInstance',
         'canHydrateTextInstance',
+        'clearActivityBoundary',
+        'clearActivityBoundaryFromContainer',
         'clearSuspenseBoundary',
         'clearSuspenseBoundaryFromContainer',
+        'commitHydratedActivityInstance',
         'commitHydratedContainer',
+        'commitHydratedInstance',
         'commitHydratedSuspenseInstance',
-        'didNotMatchHydratedContainerTextInstance',
-        'didNotMatchHydratedTextInstance',
+        'describeHydratableInstanceForDevWarnings',
+        'diffHydratedPropsForDevWarnings',
+        'diffHydratedTextForDevWarnings',
+        'finalizeHydratedChildren',
+        'flushHydrationEvents',
         'getFirstHydratableChild',
+        'getFirstHydratableChildWithinActivityInstance',
         'getFirstHydratableChildWithinContainer',
+        'getFirstHydratableChildWithinSingleton',
         'getFirstHydratableChildWithinSuspenseInstance',
+        'getNextHydratableInstanceAfterActivityInstance',
         'getNextHydratableInstanceAfterSuspenseInstance',
         'getNextHydratableSibling',
+        'getNextHydratableSiblingAfterSingleton',
         'getSuspenseInstanceFallbackErrorDetails',
+        'hideDehydratedBoundary',
+        'hydrateActivityInstance',
         'hydrateInstance',
         'hydrateSuspenseInstance',
         'hydrateTextInstance',
+        'isFormStateMarkerMatching',
         'isSuspenseInstanceFallback',
         'isSuspenseInstancePending',
         'registerSuspenseInstanceRetry',
         'shouldDeleteUnhydratedTailInstances',
+        'unhideDehydratedBoundary',
+        'validateHydratableInstance',
+        'validateHydratableTextInstance',
+    ],
+    // `supportsResources: false` — the DOM's `<link>`/`<script>` hoisting. There is
+    // no document head to hoist into and no GTK analogue of a shared, deduplicated
+    // external asset.
+    resources: [
+        'acquireResource',
+        'createHoistableInstance',
+        'getHoistableRoot',
+        'getResource',
+        'hydrateHoistable',
+        'isHostHoistableType',
+        'mayResourceSuspendCommit',
+        'mountHoistable',
+        'preloadResource',
+        'prepareToCommitHoistables',
+        'releaseResource',
+        'suspendResource',
+        'unmountHoistable',
+    ],
+    // `supportsSingletons: false` — `<html>`, `<head>`, `<body>`: the elements React
+    // adopts rather than creates because the document already owns them. Declaring
+    // a singleton here would mean deciding that some widget is the document.
+    singletons: [
+        'acquireSingletonInstance',
+        'isHostSingletonType',
+        'isSingletonScope',
+        'releaseSingletonInstance',
+        'resolveSingletonInstance',
+    ],
+    // View transitions and the gesture timeline: React 19 animating BETWEEN two
+    // committed states by cloning the old one and cross-fading. It rests on the
+    // browser's own View Transition API, which has no GTK counterpart — and the
+    // animation story here is `Adw.TimedAnimation`/`Adw.SpringAnimation`, driven by
+    // the app rather than by the reconciler.
+    viewTransitions: [
+        'cancelRootViewTransitionName',
+        'cancelViewTransitionName',
+        'cloneMutableInstance',
+        'cloneMutableTextInstance',
+        'cloneRootViewTransitionContainer',
+        'createViewTransitionInstance',
+        'getCurrentGestureOffset',
+        'hasInstanceAffectedParent',
+        'hasInstanceChanged',
+        'measureClonedInstance',
+        'removeRootViewTransitionClone',
+        'restoreRootViewTransitionName',
+        'startGestureTransition',
+        'startViewTransition',
+        'stopViewTransition',
+        'suspendOnActiveViewTransition',
+    ],
+    // `<Fragment ref={…}>` — a handle onto a fragment's host children, for event
+    // listeners and observers across nodes that share no parent element. It is a
+    // DOM-event-system affordance; GTK has no event target above the widget.
+    fragmentInstances: [
+        'commitNewChildToFragmentInstance',
+        'createFragmentInstance',
+        'deleteChildFromFragmentInstance',
+        'updateFragmentInstanceFiber',
     ],
     // `supportsTestSelectors` absent — `findAllNodes`/`focusWithin` are React's
     // own test API; this package's equivalent is `./conformance`, which reads the
-    // real GTK tree.
+    // real GTK tree. `warnsIfNotActing` belongs with them: it is `act()`'s warning
+    // switch, and `act()` is React's own test harness.
     testSelectors: [
         'findFiberRoot',
         'getBoundingRect',
@@ -201,26 +309,34 @@ const GATED_OFF = {
         'setFocusIfFocusable',
         'setupIntersectionObserver',
         'supportsTestSelectors',
+        'warnsIfNotActing',
     ],
     // `supportsMicrotasks` absent — see the note in `react.ts`: it would add a
     // second scheduling path without removing the first.
     microtasks: ['scheduleMicrotask', 'supportsMicrotasks'],
+    // Metadata React reads only to hand to the DevTools hook, which this adapter
+    // never installs (`injectIntoDevTools` is not called). Deliberately NOT
+    // answered: `rendererVersion` would have to be this package's version as a
+    // literal, and a literal version in a source file is a second truth that drifts
+    // from `package.json` the first time it is bumped.
+    devtools: ['bindToConsole', 'extraDevToolsConfig', 'rendererPackageName', 'rendererVersion'],
+    // Read only to name a suspended commit in a DevTools timeline; the commit path
+    // itself is answered (`waitForCommitToBeReady` returns `null`, i.e. never).
+    suspendedCommitReason: ['getSuspendedCommitReason'],
 };
 
 /**
- * Declared here, read only by the DEVELOPMENT bundle.
+ * Declared here, read only by the DEVELOPMENT bundle — and on 0.33.0 there are none.
  *
- * Not dead: a consumer who drops the production define gets a reconciler that
- * reads all four, and `beforeActiveInstanceBlur()` on `undefined` is a TypeError
- * inside a commit. They stay, and this list is why the "everything declared is
- * read" direction does not fail.
+ * On 0.29.2 this held four members: `afterActiveInstanceBlur` (deleted in React 19)
+ * plus `beforeActiveInstanceBlur`, `getInstanceFromScope` and `prepareScopeUpdate`,
+ * which the production bundle did not read. All three are now read in production
+ * too, so the list is empty rather than removed: an EMPTY expectation still fails
+ * the day a declared member stops being read, which is the direction that catches a
+ * misspelling — a wrong name would sit in the config, never be called, and React
+ * would read `undefined` for the correct spelling with nothing to show for it.
  */
-const DEV_BUNDLE_ONLY = [
-    'afterActiveInstanceBlur',
-    'beforeActiveInstanceBlur',
-    'getInstanceFromScope',
-    'prepareScopeUpdate',
-];
+const DEV_BUNDLE_ONLY: string[] = [];
 
 /** Every member the installed reconciler reads out of a HostConfig. */
 function readHostConfigMembers(): string[] {
@@ -265,12 +381,10 @@ export default async () => {
                 expect(read.length).toBe(READS);
 
                 const unanswered = read.filter((name) => !declared.includes(name));
-                const gatedOff = [
-                    ...GATED_OFF.persistence,
-                    ...GATED_OFF.hydration,
-                    ...GATED_OFF.testSelectors,
-                    ...GATED_OFF.microtasks,
-                ].sort();
+                // Every family, by iteration rather than by a hand-kept spread list:
+                // the spread version silently dropped a family the moment one was
+                // added, which turns a widening surface into a passing test.
+                const gatedOff = Object.values(GATED_OFF).flat().sort();
                 // Both directions: a member React starts asking for that no family
                 // claims, and a family entry React stopped asking for.
                 expect(unanswered).toStrictEqual(gatedOff);
@@ -338,7 +452,7 @@ export default async () => {
 
             await it('an unflushed update lands when the main loop runs — the scheduler works', async () => {
                 // The other half of the concurrency story, and the reason
-                // `getCurrentEventPriority` returns the DEFAULT lane rather than a
+                // `resolveUpdatePriority` returns the DEFAULT lane rather than a
                 // discrete one: a `setState` outside `flushSync` is handed to
                 // `scheduler`, which under GJS means a GLib timer source. If that
                 // path did not work, an app updating state from a signal handler

--- a/packages/framework/gtk-host/src/adapters/react.spec.ts
+++ b/packages/framework/gtk-host/src/adapters/react.spec.ts
@@ -46,7 +46,8 @@ interface DirectReconciler {
     createContainer(...args: unknown[]): unknown;
     updateContainer(...args: unknown[]): unknown;
     updateContainerSync(...args: unknown[]): unknown;
-    flushSyncWork(): void;
+    // `true` means React did NOT flush — see `renderSync` in `react.ts`.
+    flushSyncWork(): boolean;
 }
 
 const labelsOf = (w: Gtk.Widget) => gtkChildren(w).map((c) => (c as Gtk.Label).label);
@@ -479,6 +480,54 @@ export default async () => {
                 noRecovery();
             });
 
+            await it('a refusal on the CONCURRENT lane is reported, not swallowed', async () => {
+                // The hole the rethrow does not cover, and the reason `createRoot`'s
+                // default handler LOGS as well as holds.
+                //
+                // `resolveUpdatePriority` answers the default lane, so a `setState`
+                // made outside `render()` commits on a later main-loop iteration with
+                // no `render()` on the stack to throw from. React's own answer to an
+                // uncaught error there is to unmount the whole tree — so without the
+                // log the window goes blank, the held error is discarded by the next
+                // `render`, and nothing reaches stderr at all.
+                //
+                // `console.error` is the observable, because it is what the DEFAULT
+                // handler writes through. Passing a recorder as `onUncaughtError`
+                // would test a handler this file supplied and leave the default —
+                // the thing every consumer gets — unmeasured.
+                const container = new Gtk.Box();
+                let setOrientation: ((value: string) => void) | undefined;
+                function Subject() {
+                    const [orientation, set] = useState('vertical');
+                    setOrientation = set;
+                    return createElement('GtkBox', { orientation });
+                }
+                const root = mount(createElement(Subject), container);
+
+                const reported: string[] = [];
+                const realError = console.error;
+                console.error = (...args: unknown[]) => {
+                    reported.push(args.map((argument) => String(argument)).join(' '));
+                };
+                try {
+                    // An enum nick GtkOrientation does not have. The host refuses it
+                    // by name — in a commit no `render()` call is waiting on.
+                    setOrientation?.('sideways');
+                    pumpMainLoop(() => reported.length > 0);
+                } finally {
+                    console.error = realError;
+                }
+
+                // The assertion with teeth: React unmounted the tree AND nothing was
+                // said is the outcome this vector exists to forbid.
+                expect(reported.length > 0).toBe(true);
+                expect(reported.join(' ')).toContain('GtkOrientation');
+                root.unmount();
+                // The refusal was reported, not RECOVERED — `noRecovery` would fire
+                // on a recoverable error, which this is not.
+                noRecovery();
+            });
+
             await it("React clears the container first, and the application's chrome survives", async () => {
                 // `updateHostRoot` sets the `Snapshot` flag whenever the previous
                 // render produced no child, and `commitBeforeMutationEffects` then
@@ -615,7 +664,7 @@ export default async () => {
             });
 
             await it('a prop that disappears is reset, not set to null', async () => {
-                // React's `prepareUpdate` diff has to spell a removed key
+                // the diff in `commitUpdate` has to spell a removed key
                 // `undefined`: the host reads that as "back to what construction
                 // leaves behind", while `null` reaches `set_property` verbatim.
                 const container = new Gtk.Box();

--- a/packages/framework/gtk-host/src/adapters/react.ts
+++ b/packages/framework/gtk-host/src/adapters/react.ts
@@ -164,8 +164,13 @@ const HOST_CONTEXT: object = Object.freeze({});
  *
  * React 19 replaced the single `getCurrentEventPriority` read with a three-member
  * protocol the host has to STORE for: React writes the lane it is entering with
- * `setCurrentUpdatePriority` and reads it back. Module scope is correct here
- * because a process has one reconciler; `react-dom` keeps it the same way.
+ * `setCurrentUpdatePriority` and reads it back. Module scope is correct across
+ * ROOTS — `react-dom` keeps it the same way, and React saves and restores the value
+ * around every entry point, so nesting is LIFO-safe. It is deliberately NOT claimed
+ * to be correct across reconciler INSTANCES: `react.spec.ts` builds two more over a
+ * Proxy of this same config, and `gtkHostConfig` is documented below as the seam for
+ * a consumer who wants a differently configured one. They share this variable. No
+ * interleave that corrupts it is known, and none is ruled out either.
  */
 let currentUpdatePriority: number = NoEventPriority;
 
@@ -192,7 +197,7 @@ export const gtkHostConfig = {
 
     // React 19's two new capability gates, declared for the same reason the three
     // above are: answering `false` is what keeps their whole member families
-    // (fourteen for resources, eight for singletons) from being called at all,
+    // (thirteen for resources, five for singletons) from being called at all,
     // rather than leaving them `undefined` in a commit path. Resources are the
     // DOM's `<link>`/`<script>` hoisting and singletons are `<html>`/`<head>`/
     // `<body>` — neither has a GTK counterpart, and inventing one would mean
@@ -520,10 +525,24 @@ export interface ReactRootOptions {
     /**
      * An error NO error boundary caught. React 19 split this out of the single
      * callback React 18 had, and it is the one that means the tree is broken.
+     *
+     * SUPPLYING THIS TURNS OFF THE RETHROW. By default `render()` throws the first
+     * uncaught error rather than returning normally, because a host refusal that
+     * only reaches a log has bought nothing. An application with its own error
+     * surface should not also get a throw — but it then owns reporting entirely.
      */
     onUncaughtError?(error: Error): void;
 
-    /** An error an error boundary DID catch — reported, then handled by the boundary. */
+    /**
+     * An error an error boundary DID catch — reported, then handled by the boundary.
+     *
+     * The default reports through `console.error`, which under GJS routes into the
+     * GLib log system at CRITICAL — so `installDiagnosticsGate()` COUNTS it, and a
+     * spec that deliberately renders a failing boundary will be told GTK reported a
+     * diagnostic. Such a spec should pass its own recorder here. Left as
+     * `console.error` because that is the right channel for an application, and a
+     * quieter default would be the wrong trade for the common case.
+     */
     onCaughtError?(error: Error): void;
 }
 
@@ -567,11 +586,22 @@ export function createRoot(container: Gtk.Widget, options: ReactRootOptions = {}
      * the DEFAULT is to hold the first uncaught error and rethrow it from `render`,
      * where the caller is. Passing `onUncaughtError` opts out — an application with
      * its own error surface should not also get a throw.
+     *
+     * IT LOGS *AND* HOLDS, AND THE "AND" IS LOAD-BEARING. Holding alone reopens the
+     * hole one lane over: `resolveUpdatePriority` answers the default lane, so a
+     * `setState` from a GTK signal handler commits on a LATER main-loop iteration
+     * with no `render()` on the stack. React's own response to an uncaught error
+     * there is to unmount the whole tree — so the window goes blank, the held error
+     * is discarded by the next `render`, and nothing reaches stderr. React's floor
+     * is higher than that (`defaultOnUncaughtError` always reports), and a renderer
+     * must not lower it. The log is the one that fires in the concurrent case; the
+     * rethrow is the one that fires in the synchronous case; neither covers both.
      */
     let refusal: Error | null = null;
     const onUncaught = options.onUncaughtError
         ? report('React hit an error no boundary caught', options.onUncaughtError)
         : (error: Error): void => {
+              console.error('@gjsify/gtk-host/react: React hit an error no boundary caught', error);
               refusal ??= error;
           };
 
@@ -608,15 +638,36 @@ export function createRoot(container: Gtk.Widget, options: ReactRootOptions = {}
      * `updateContainerSync` schedules the work on the sync lane and
      * `flushSyncWork` drains it. Both are needed: the first alone leaves the work
      * queued.
+     *
+     * AND `flushSyncWork`'S RETURN IS NOT DECORATION. It answers `true` for "I did
+     * NOT flush" — React refuses to flush while it is already inside a render or a
+     * commit (`executionContext & 6`). That happens on a re-entrant render: a `ref`
+     * callback, a `useLayoutEffect`, or a GTK `notify::` handler that fires while
+     * the host is writing a property and renders a second root. Discarding the
+     * boolean makes `render()` return CLEANLY WITH AN EMPTY CONTAINER and the
+     * widgets appear later — which breaks this function's own documented promise
+     * and is worse than either honest outcome, because the caller has already read
+     * the empty tree. React 19 handed us this signal; refusing to look at it would
+     * be the same class of mistake as the `flushSync` rename above.
      */
     const renderSync = (element: ReactNode): void => {
         refusal = null;
         reconciler.updateContainerSync(element, root, null, null);
-        reconciler.flushSyncWork();
+        const notFlushed = reconciler.flushSyncWork();
         if (refusal !== null) {
             const error = refusal;
             refusal = null;
             throw error;
+        }
+        if (notFlushed === true) {
+            throw new Error(
+                '@gjsify/gtk-host/react: render() could not flush, because React is already ' +
+                    'rendering or committing — this call is re-entrant (a ref callback, a ' +
+                    'useLayoutEffect, or a GTK signal handler that fired during a commit). The ' +
+                    'widgets do NOT exist yet, which is what render() promises, so this throws ' +
+                    'rather than returning an empty container. Render the second tree from a ' +
+                    'useEffect or an idle callback instead.',
+            );
         }
     };
 

--- a/packages/framework/gtk-host/src/adapters/react.ts
+++ b/packages/framework/gtk-host/src/adapters/react.ts
@@ -17,10 +17,10 @@
 //     with previous children"). On GTK that container is the application's own
 //     widget, and the app's chrome is in it. So this maps to the SHADOW children
 //     only and never to `el.foreign` — a vector holds it.
-//   - `prepareUpdate` / `commitUpdate` are a two-phase diff: React expects the
-//     payload to be computed in the render phase and applied in the commit phase.
-//     Returning a constant "yes, changed" works and throws the diff away; the diff
-//     is computed where React asks for it.
+//   - `commitUpdate` is the whole diff. React 18 split it in two — `prepareUpdate`
+//     in the render phase, `commitUpdate` in the commit phase — and 19 deleted the
+//     render half outright, so the payload is computed and applied in one place.
+//     `diffProps` did not change; only the phase it runs in did.
 //   - `getPublicInstance` IS `ref`. It returns the author's own widget, never the
 //     `GtkListBoxRow` the host wrapped it in — a `ref` that hands back a wrapper
 //     the author never wrote is a silent lie about which widget they hold.
@@ -31,14 +31,22 @@
 //
 // BUILD RECIPE, and it is not optional. `--define 'process.env.NODE_ENV="production"'`,
 // exactly as the Vue adapter requires: `react-reconciler/index.js` is
-// `process.env.NODE_ENV === 'production' ? require('./cjs/…production.min.js') :
-// require('./cjs/…development.js')`, and the development bundle reaches for
-// `document`, `HTMLCanvasElement` and `Path2D`, which makes `--globals auto` inject
+// `process.env.NODE_ENV === 'production' ? require('./cjs/react-reconciler.production.js') :
+// require('./cjs/react-reconciler.development.js')`, and the development bundle reaches
+// for `document`, `HTMLCanvasElement` and `Path2D`, which makes `--globals auto` inject
 // the GTK-backed DOM registers and pull gi://Gdk, GdkPixbuf, Pango and PangoCairo
 // into a bundle that needs none of them. Add `--exclude-globals navigator`: even the
 // production `scheduler` carries `typeof navigator !== 'undefined' &&
 // navigator.scheduling`, which is dead code under GJS but still a free `navigator`
 // the detector answers with the same GTK-backed register.
+//
+// HOW THAT RECIPE IS HELD, and why the guard had to change shape. Until 0.29 the
+// member COUNT told the two bundles apart — production read 76, development 94 — so
+// `react.spec.ts` pinning 76 also caught a lost define. Measured on 0.33.0, both
+// bundles read 160, and the count can no longer distinguish them at all. The guard is
+// therefore on the BUNDLE CONTENT instead: the development bundle is the only one
+// carrying `document` / `HTMLCanvasElement` / `Path2D`, so their absence in the built
+// artifact is the fact we actually care about rather than a proxy for it.
 
 import Reconciler from 'react-reconciler';
 // `constants.js`, with the extension: `react-reconciler` ships no `exports` map,
@@ -46,7 +54,12 @@ import Reconciler from 'react-reconciler';
 // extensionless subpath of such a package does not resolve, and the error names
 // the module rather than the reason (`TS2307`). The `.js` spelling reaches both
 // `@types/react-reconciler/constants.d.ts` and the real file.
-import { ConcurrentRoot, DefaultEventPriority } from 'react-reconciler/constants.js';
+import { ConcurrentRoot, DefaultEventPriority, NoEventPriority } from 'react-reconciler/constants.js';
+// A VALUE import, for exactly one member. React 19 asks the host for a
+// `HostTransitionContext` and reads it at construction, and the only way to
+// produce a context is React's own factory. It costs nothing measurable: the
+// production `react` bundle is already in the graph through the peer.
+import { createContext } from 'react';
 import type { ReactNode } from 'react';
 import type Gtk from '@girs/gtk-4.0';
 
@@ -70,14 +83,21 @@ import type { HostElement, HostNode, HostText } from '../types.js';
 export type ReactProps = Record<string, unknown>;
 
 /**
- * `children` is React's own prop and not a GObject property.
+ * React's own props, which are not GObject properties.
  *
- * It arrives in `props` for every element — `React.createElement('gtk-box', null,
- * child)` produces `props.children` — while `key` and `ref` do not (React 18 lifts
- * both off the element before props exist). Forwarding it produced
+ * `children` arrives in `props` for every element — `React.createElement('gtk-box',
+ * null, child)` produces `props.children` — and forwarding it produced
  * `<GtkBox> has no property "children"` on the very first nested element.
+ *
+ * `ref` IS THE REACT 19 ADDITION, and it is measured rather than defensive. React 18
+ * lifted both `key` and `ref` off the element before props existed, so this set held
+ * `children` alone. React 19 made `ref` an ordinary prop — the change that removed
+ * `forwardRef` — and it now reaches `createInstance` for host elements too: the first
+ * run against 0.33.0 failed with `<GtkButton> has no property "ref". … or bind it as
+ * a signal with onRef`, which is the host correctly refusing a prop React had
+ * previously never handed it. `key` still never appears.
  */
-const RESERVED = new Set(['children']);
+const RESERVED = new Set(['children', 'ref']);
 
 /** One authored property that changed: name, next value, previous value. */
 type PropChange = readonly [key: string, next: unknown, prev: unknown];
@@ -86,10 +106,13 @@ type PropChange = readonly [key: string, next: unknown, prev: unknown];
 const ownProps = (props: ReactProps | null | undefined): ReactProps | undefined => withoutKeys(props, RESERVED);
 
 /**
- * The render-phase diff, in the phase React asks for it.
+ * The prop diff.
  *
- * `null` means "no update", and React then never schedules a commit for this
- * fiber — which is the only reason to diff here rather than in `commitUpdate`.
+ * It ran in the RENDER phase until React 18, where returning `null` from
+ * `prepareUpdate` also told React not to schedule a commit for the fiber at all.
+ * React 19 deleted that hook, so this runs inside `commitUpdate` and `null` now
+ * means only "nothing to write" — the bailout it used to buy is gone, and no
+ * amount of adapter code brings it back.
  * A key that DISAPPEARED becomes `undefined`, the host's spelling for "back to
  * what construction leaves behind". An AUTHORED `label={null}` is not translated
  * here and never was: the host reads `null` as removed too, which is what makes
@@ -124,6 +147,29 @@ const visibilityTargetOf = (el: HostElement): { set_visible(visible: boolean): v
 };
 
 /**
+ * The one host context, shared by every element in the tree.
+ *
+ * GTK has no namespace switch (the DOM's HTML/SVG/MathML boundary), so there is
+ * nothing to carry and a single frozen object serves the whole tree. Two reasons
+ * it is an object and not `null`. React compares the result by IDENTITY to decide
+ * whether to push a new context, so one shared instance is what makes that bailout
+ * work. And React 19 reads `null` as "no context was provided at all" and logs
+ * `Expected host context to exist` once per element — measured, non-fatal, and the
+ * tree still renders, which is precisely the kind of noise that gets normalised.
+ */
+const HOST_CONTEXT: object = Object.freeze({});
+
+/**
+ * The update priority React is currently working at.
+ *
+ * React 19 replaced the single `getCurrentEventPriority` read with a three-member
+ * protocol the host has to STORE for: React writes the lane it is entering with
+ * `setCurrentUpdatePriority` and reads it back. Module scope is correct here
+ * because a process has one reconciler; `react-dom` keeps it the same way.
+ */
+let currentUpdatePriority: number = NoEventPriority;
+
+/**
  * The HostConfig, exported because it IS the contract.
  *
  * `react.spec.ts` builds a second reconciler over a Proxy of this object to read
@@ -143,6 +189,16 @@ export const gtkHostConfig = {
     supportsPersistence: false,
     supportsHydration: false,
     isPrimaryRenderer: true,
+
+    // React 19's two new capability gates, declared for the same reason the three
+    // above are: answering `false` is what keeps their whole member families
+    // (fourteen for resources, eight for singletons) from being called at all,
+    // rather than leaving them `undefined` in a commit path. Resources are the
+    // DOM's `<link>`/`<script>` hoisting and singletons are `<html>`/`<head>`/
+    // `<body>` — neither has a GTK counterpart, and inventing one would mean
+    // deciding that some widget is the document.
+    supportsResources: false,
+    supportsSingletons: false,
 
     // Not declared: `supportsMicrotasks`. It only moves SYNC-lane flushing into a
     // microtask; default-lane work goes through `scheduler` either way, so it
@@ -188,12 +244,10 @@ export const gtkHostConfig = {
 
     // --- host context --------------------------------------------------------
     //
-    // GTK has no namespace switch (the DOM's HTML/SVG/MathML boundary), so there
-    // is nothing to carry. Returning the parent's own object rather than a fresh
-    // one is load-bearing: React compares the result by IDENTITY to decide whether
-    // to push a new context, and a new object per element defeats that bailout.
-    getRootHostContext: (): null => null,
-    getChildHostContext: (parentHostContext: null): null => parentHostContext,
+    // One object for the whole tree — see `HOST_CONTEXT` for why it is an object
+    // and not `null`, and why returning the parent's own is load-bearing.
+    getRootHostContext: (): object => HOST_CONTEXT,
+    getChildHostContext: (parentHostContext: object): object => parentHostContext,
 
     /**
      * What a `ref` receives — the author's widget, never the host's wrapper.
@@ -214,8 +268,20 @@ export const gtkHostConfig = {
     resetAfterCommit: (): void => {},
     preparePortalMount: (): void => {},
 
+    // --- update priority -----------------------------------------------------
+    //
+    // React 18 asked ONE question here (`getCurrentEventPriority`, deleted in 19)
+    // and 19 asks three, because the host now OWNS the current-lane variable
+    // instead of deriving it per read. The stored value lives in
+    // `currentUpdatePriority` above.
+
+    getCurrentUpdatePriority: (): number => currentUpdatePriority,
+    setCurrentUpdatePriority: (priority: number): void => {
+        currentUpdatePriority = priority;
+    },
+
     /**
-     * The priority every update outside React's own event system gets.
+     * The priority an update gets when React is not already inside a lane.
      *
      * React DOM derives this from the DOM event being handled (a click is
      * discrete, a scroll continuous). A GTK signal handler is not a DOM event and
@@ -226,7 +292,25 @@ export const gtkHostConfig = {
      * iteration. `flushSync` is the escape hatch, and the spec pumps the main
      * context to prove the scheduled path works at all under GJS.
      */
-    getCurrentEventPriority: (): number => DefaultEventPriority,
+    resolveUpdatePriority: (): number =>
+        currentUpdatePriority !== NoEventPriority ? currentUpdatePriority : DefaultEventPriority,
+
+    // React asks whether it may render a transition EAGERLY, before yielding, on
+    // the guess that the result is cheap. That guess is only ever right when the
+    // host can tell an idle moment from a busy one; GTK's main loop is not ours to
+    // ask. `false` is the answer every non-DOM renderer gives.
+    shouldAttemptEagerTransition: (): boolean => false,
+
+    // --- scheduler tracing ---------------------------------------------------
+    //
+    // The performance-track instrumentation React 19 emits for its own DevTools
+    // profiler. There is no event object to name and no DOM timeline to align
+    // against, so these answer honestly rather than fabricating a trace.
+    // `-1.1` is React's own sentinel for "this renderer has no timestamps" — a
+    // plain `-1` reads as a real, very early time.
+    trackSchedulerEvent: (): void => {},
+    resolveEventType: (): null => null,
+    resolveEventTimeStamp: (): number => -1.1,
 
     // --- mutation ------------------------------------------------------------
 
@@ -274,15 +358,20 @@ export const gtkHostConfig = {
         destroyChildren(container);
     },
 
-    prepareUpdate: (
-        _instance: HostElement,
-        _type: string,
-        oldProps: ReactProps,
-        newProps: ReactProps,
-    ): PropChange[] | null => diffProps(oldProps, newProps),
-
-    commitUpdate: (instance: HostElement, updatePayload: PropChange[]): void => {
-        for (const [key, next, prev] of updatePayload) setProp(instance, key, next, prev);
+    /**
+     * Diff AND apply — one phase, because React 19 deleted the other one.
+     *
+     * The argument list is the change with teeth: React 18 passed
+     * `(instance, updatePayload, type, prevProps, nextProps, handle)` and 19 passes
+     * `(instance, type, prevProps, nextProps, handle)`. The payload slot was
+     * removed from the FRONT, so an adapter that kept the old signature would read
+     * the type string as its payload and iterate a string — which is why this is
+     * spelled out rather than left to positional luck.
+     */
+    commitUpdate: (instance: HostElement, _type: string, prevProps: ReactProps, nextProps: ReactProps): void => {
+        const changes = diffProps(prevProps, nextProps);
+        if (changes === null) return;
+        for (const [key, next, prev] of changes) setProp(instance, key, next, prev);
     },
 
     commitTextUpdate: (textInstance: HostText, _oldText: string, newText: string): void => {
@@ -344,7 +433,44 @@ export const gtkHostConfig = {
     getInstanceFromScope: (): null => null,
     prepareScopeUpdate: (): void => {},
     beforeActiveInstanceBlur: (): void => {},
-    afterActiveInstanceBlur: (): void => {},
+
+    // --- suspending a commit (React 19) --------------------------------------
+    //
+    // React 19 lets a host DELAY a commit until an asynchronous resource it owns
+    // has arrived — the DOM uses it to hold a commit until a stylesheet or an
+    // image has loaded, so the frame that appears is never half-styled. A GTK
+    // widget tree has no such resource: every widget this host creates exists the
+    // moment `createInstance` returns.
+    //
+    // `waitForCommitToBeReady` returning `null` is the load-bearing one — it is
+    // React's "commit now", and any function returned instead would be awaited.
+    // The three `maySuspendCommit*` predicates are what keep the rest of the
+    // family unreached, and `preloadInstance` answering `true` means "already
+    // loaded", not "loading started".
+    maySuspendCommit: (): boolean => false,
+    maySuspendCommitOnUpdate: (): boolean => false,
+    maySuspendCommitInSyncRender: (): boolean => false,
+    preloadInstance: (): boolean => true,
+    startSuspendingCommit: (): void => {},
+    suspendInstance: (): void => {},
+    waitForCommitToBeReady: (): null => null,
+
+    // Paired with the above: React DOM schedules work for after the browser has
+    // painted. GJS has no paint callback that means the same thing, and calling
+    // back immediately would be a lie about when the frame reached the screen,
+    // so nothing is scheduled and nothing pretends to be.
+    requestPostPaintCallback: (): void => {},
+
+    // --- form state (React 19) -----------------------------------------------
+    //
+    // `useFormStatus` and `<form action={…}>` are DOM form semantics: React needs
+    // a context to publish the pending transition through and a way to reset a
+    // form element after an action. GTK has no form element — a `Gtk.Entry` is not
+    // part of a submittable group — so the context carries the "not pending"
+    // sentinel forever and the reset has nothing to reset.
+    NotPendingTransition: null,
+    HostTransitionContext: createContext(null),
+    resetFormInstance: (): void => {},
 
     // React nulls the fiber's `stateNode` right after this. `destroy` already ran
     // from `removeChild` for the whole subtree, so there is nothing left to
@@ -359,12 +485,15 @@ const reconciler = Reconciler(gtkHostConfig as never);
 /**
  * Run `fn` and flush every update it schedules before returning.
  *
- * The default lane is concurrent (see `getCurrentEventPriority`), so a `setState`
+ * The default lane is concurrent (see `resolveUpdatePriority`), so a `setState`
  * from a GTK signal handler lands on a later main-loop iteration. In an
  * application that is right — GTK is running a main loop. Outside one, and in a
  * test, this is how a change becomes visible without pumping.
+ *
+ * `reconciler.flushSync` was RENAMED to `flushSyncFromReconciler` in React 19.
+ * The rename is the harmless half; see `createRoot` for the half that is not.
  */
-export const flushSync = <T>(fn: () => T): T => reconciler.flushSync(fn) as T;
+export const flushSync = <T>(fn: () => T): T => reconciler.flushSyncFromReconciler(fn) as T;
 
 export interface ReactRoot {
     /** Render (or re-render) this tree. Synchronous — the widgets exist on return. */
@@ -387,6 +516,15 @@ export interface ReactRootOptions {
      * and asserts nothing arrived.
      */
     onRecoverableError?(error: Error): void;
+
+    /**
+     * An error NO error boundary caught. React 19 split this out of the single
+     * callback React 18 had, and it is the one that means the tree is broken.
+     */
+    onUncaughtError?(error: Error): void;
+
+    /** An error an error boundary DID catch — reported, then handled by the boundary. */
+    onCaughtError?(error: Error): void;
 }
 
 /**
@@ -406,23 +544,87 @@ export interface ReactRootOptions {
  */
 export function createRoot(container: Gtk.Widget, options: ReactRootOptions = {}): ReactRoot {
     const host = adopt(container);
-    const onRecoverableError =
-        options.onRecoverableError ??
-        ((error: Error) => {
-            console.error('@gjsify/gtk-host/react: React recovered from an error', error);
-        });
-    const root = reconciler.createContainer(host, ConcurrentRoot, null, false, null, '', onRecoverableError, null);
+    const report =
+        (what: string, override?: (error: Error) => void) =>
+        (error: Error): void => {
+            if (override) return override(error);
+            console.error(`@gjsify/gtk-host/react: ${what}`, error);
+        };
+
+    /**
+     * The error the host refused this render with — held so `render` can rethrow it.
+     *
+     * THE REGRESSION THIS EXISTS TO UNDO. Under React 18 an error thrown by the host
+     * during render propagated out of `render()`, so `createElement('GtkBox', null,
+     * 'stray')` threw `<GtkBox> has no text sink` at the call site. React 19 routes
+     * it to `onUncaughtError` instead and returns normally — measured: four
+     * conformance vectors that assert a named refusal all saw an empty message and a
+     * successful call, while the diagnostic went to the console.
+     *
+     * A refusal that only reaches a log is the failure mode ADR 0027 § 3 exists
+     * against: GTK's own wrong answer is already exit 0, and a host that refuses
+     * loudly only to have the refusal swallowed one layer up has bought nothing. So
+     * the DEFAULT is to hold the first uncaught error and rethrow it from `render`,
+     * where the caller is. Passing `onUncaughtError` opts out — an application with
+     * its own error surface should not also get a throw.
+     */
+    let refusal: Error | null = null;
+    const onUncaught = options.onUncaughtError
+        ? report('React hit an error no boundary caught', options.onUncaughtError)
+        : (error: Error): void => {
+              refusal ??= error;
+          };
+
+    // TEN arguments, and the two new ones were inserted in the MIDDLE. React 18
+    // took `(…, identifierPrefix, onRecoverableError, transitionCallbacks)`; 19
+    // takes `(…, identifierPrefix, onUncaughtError, onCaughtError,
+    // onRecoverableError, onDefaultTransitionIndicator)`. Passing the 18 list
+    // still runs: the recoverable-error handler simply becomes the UNCAUGHT one
+    // and the real recoverable slot stays undefined. No type error, no warning,
+    // and the symptom is a handler firing for the wrong class of error — so this
+    // call is written out one argument per line rather than kept compact.
+    const root = reconciler.createContainer(
+        host,
+        ConcurrentRoot,
+        null,
+        false,
+        null,
+        '',
+        onUncaught,
+        report('an error boundary caught an error', options.onCaughtError),
+        report('React recovered from an error', options.onRecoverableError),
+        () => {},
+    );
+
+    /**
+     * Render synchronously — and NOT through `flushSync`.
+     *
+     * React 18's `flushSync(() => updateContainer(…))` was the whole recipe. Under
+     * 19 that combination on a ConcurrentRoot MOUNTS NOTHING: the call returns
+     * cleanly, no error is raised, and the container is empty. Measured on
+     * react-reconciler 0.33.0 — the exact silent-empty-window failure this package
+     * exists to refuse, reintroduced by a rename that looked mechanical.
+     *
+     * `updateContainerSync` schedules the work on the sync lane and
+     * `flushSyncWork` drains it. Both are needed: the first alone leaves the work
+     * queued.
+     */
+    const renderSync = (element: ReactNode): void => {
+        refusal = null;
+        reconciler.updateContainerSync(element, root, null, null);
+        reconciler.flushSyncWork();
+        if (refusal !== null) {
+            const error = refusal;
+            refusal = null;
+            throw error;
+        }
+    };
+
     return {
         container: host,
-        render(element: ReactNode) {
-            reconciler.flushSync(() => {
-                reconciler.updateContainer(element, root, null, null);
-            });
-        },
+        render: renderSync,
         unmount() {
-            reconciler.flushSync(() => {
-                reconciler.updateContainer(null, root, null, null);
-            });
+            renderSync(null);
         },
     };
 }

--- a/showcases/gtk/react-host-counter/README.md
+++ b/showcases/gtk/react-host-counter/README.md
@@ -28,7 +28,7 @@ inside a `GApplication`. Three things only this file reaches:
   own `jsx`/`jsxs`/`Fragment`. There is no plugin under `gjsify.bundler.plugins` here and nothing
   for one to consume. The export **names** are the framework's contract — TypeScript emits those
   three literally, so a rename there is a `MISSING_EXPORT` in this bundle.
-- **The scheduled lane, under GJS, in an application.** `getCurrentEventPriority` returns the
+- **The scheduled lane, under GJS, in an application.** `resolveUpdatePriority` returns the
   DEFAULT lane, so a `setState` from a `clicked` handler is concurrent: it is handed to
   `scheduler`, which under GJS lands on a GLib timer source. The probe asserts **both** halves —
   the tree is unchanged the instant the signal returns, and it is patched once the main context

--- a/showcases/gtk/react-host-counter/package.json
+++ b/showcases/gtk/react-host-counter/package.json
@@ -35,9 +35,9 @@
         "@gjsify/cli": "workspace:^",
         "@gjsify/gtk-host": "workspace:^",
         "@types/node": "^25.9.2",
-        "@types/react": "^18.3.12",
-        "react": "^18.3.1",
-        "react-reconciler": "^0.29.2",
+        "@types/react": "^19.2.2",
+        "react": "^19.2.0",
+        "react-reconciler": "^0.33.0",
         "typescript": "^6.0.3"
     },
     "author": "Pascal Garber <pascal@artandcode.studio>",

--- a/showcases/gtk/react-host-counter/src/app.tsx
+++ b/showcases/gtk/react-host-counter/src/app.tsx
@@ -19,7 +19,7 @@
 //     re-exports React's OWN `jsx`/`jsxs`/`Fragment`. The export NAMES are the
 //     framework's contract: TypeScript emits those three literally, so a rename
 //     there is a `MISSING_EXPORT` in this bundle rather than a matter of taste.
-//   · THE SCHEDULED LANE, under GJS, in an application. `getCurrentEventPriority`
+//   · THE SCHEDULED LANE, under GJS, in an application. `resolveUpdatePriority`
 //     returns the DEFAULT lane (a GTK signal is not a DOM event, so there is no
 //     ambient event to derive a priority from), which means a `setState` from a
 //     `clicked` handler is CONCURRENT: it is handed to `scheduler`, which under
@@ -67,7 +67,10 @@ interface Row {
  * window is not a child of anything. An `adw-application-window` at the root of
  * this tree would ask GTK to parent a toplevel and earn a `Gtk-WARNING` at exit 0.
  */
-function Counter({ incrementRef }: { readonly incrementRef: RefObject<Gtk.Button> }) {
+// `RefObject<Gtk.Button | null>`, not `RefObject<Gtk.Button>`: React 19's
+// `createRef<T>()` is typed `RefObject<T | null>`, because a ref genuinely holds
+// null until the commit that fills it. React 18's types hid that.
+function Counter({ incrementRef }: { readonly incrementRef: RefObject<Gtk.Button | null> }) {
     const [count, setCount] = useState(0);
     const [rows, setRows] = useState<readonly Row[]>([]);
     const nextRow = useRef(1);
@@ -125,7 +128,7 @@ function Counter({ incrementRef }: { readonly incrementRef: RefObject<Gtk.Button
 interface Ui {
     readonly window: Adw.ApplicationWindow;
     readonly root: ReturnType<typeof createRoot>;
-    readonly incrementRef: RefObject<Gtk.Button>;
+    readonly incrementRef: RefObject<Gtk.Button | null>;
 }
 
 function buildUi(app: Adw.Application | null): Ui {


### PR DESCRIPTION
`react-reconciler` 0.29.2 → 0.33.0, `react` 18.3.1 → 19.2. Measured on the production bundle: **160** config members read where 0.29.2 read 76, **58** answered here, **102** gated off across ten families.

## Four changes that are silent rather than typed

Each carries its measurement at the call site, because none of them fails a build.

| Change | What it does with no fix |
|---|---|
| `flushSync(() => updateContainer(…))` | mounts **nothing** on a `ConcurrentRoot`. Returns cleanly, container empty — the silent-empty-window failure this package exists to refuse. The sync path is `updateContainerSync` + `flushSyncWork`. |
| `createContainer` grew `onUncaughtError`/`onCaughtError` **before** `onRecoverableError` | the React 18 argument list still runs and wires the recoverable handler into the uncaught slot |
| a host error no longer propagates out of `render()` | four conformance vectors asserting a named refusal saw an empty message and a successful call |
| `ref` is an ordinary prop in 19 | it reaches `createInstance`; the host correctly refused with `<GtkButton> has no property "ref"` |

The third is the one worth arguing about. `createRoot` now holds the first uncaught error and rethrows it from `render()`, unless the caller supplies its own `onUncaughtError`. A named refusal that only reaches a log has bought nothing — ADR 0027 § 3.

## Typed changes

- `prepareUpdate` is gone and `commitUpdate` lost its payload argument, so the diff moved into the commit phase. `diffProps` is unchanged; only its phase is.
- `getCurrentEventPriority` became the three-member `get`/`set`/`resolveUpdatePriority` protocol the host has to store for.
- `getRootHostContext` may no longer answer `null`.
- New capability flags declared false: `supportsResources`, `supportsSingletons` — which is what keeps their 18 members from being called.

## A guard that quietly stopped working

On 0.29.2 the member **count** discriminated the bundles: production read 76, development 94, so pinning 76 also caught a lost `NODE_ENV=production` define. On 0.33.0 both read **160**. The build recipe is now held only by the `runs without a DOM at all` vector, which asserts `document`/`HTMLCanvasElement`/`Path2D` are absent — the fact itself rather than a proxy for it. Recorded in both the adapter and the spec rather than deleted with the old number.

## Verification

- **1934 tests green** (5 failures → 1 → 0 across the fix rounds)
- **type surfaces green** — the `react-namespace` probe still fires, so React 19 moving `JSX` out of the global namespace did **not** blind it
- **showcase self-probe**: `PROBE: PASS` — 82 widgets, **0** GTK diagnostics, click-driven state lands
- `check-vocabulary-alignment` and `check-adapter-import-direction` green
- A/B'd the type gate: a deliberate error exits 1, the clean tree exits 0. An `exit 0` with no output is not evidence on its own.