### PR TITLE
fix(ci): check the cancel selection out from the base

### DIFF
--- a/.github/workflows/cancel-pr-runs.yml
+++ b/.github/workflows/cancel-pr-runs.yml
@@ -49,12 +49,26 @@ name: Cancel superseded PR runs
 # itself fails and the branch above it says so and exits 0. Untested from a fork —
 # this repository has no fork PR on record — so neither path is claimed as THE one.
 #
-# The checkout follows from the same decision. It is pinned to the head SHA rather than
-# left on the default merge ref, which is not guaranteed to still resolve once the PR
-# is closed — the event this workflow has always served; and it is sparse to the one
-# script, so the job holding `actions: write` materialises as little head code as it
-# can. What that leaves is head code from a branch whose author already has write
-# access to this repository, or from a fork whose token cannot cancel anything.
+# The checkout follows from the same decision, and it is pinned to the BASE SHA. Two
+# reasons, one of which cost a red job before it was understood:
+#
+#   · A branch created before this script landed does not contain it. `set -euo
+#     pipefail` then kills the job on `Cannot find module` — measured on #1340, whose
+#     branch predated #1334 by hours and which therefore failed a job about its own
+#     obsolete runs. Every future branch cut before a change to this script has the
+#     same shape, so this is not a one-off transition cost.
+#   · It carries the write-token argument FURTHER than the head SHA did. The job needs
+#     `actions: write`, AGENTS.md forbids pairing a write token with head code, and the
+#     head SHA was a compromise justified by sparseness — one script, from a branch
+#     whose author already has write access. The base SHA is not a compromise: the job
+#     materialises NO head code at all, and a fork PR now runs this repository's own
+#     selection rather than the fork's.
+#
+# The base SHA is a real commit on the base branch and still resolves after the PR is
+# closed, which is what ruled out the default merge ref. What it gives up is the ability
+# for a PR to test a change to the selection ON ITSELF — that PR's own cancel job runs
+# main's copy. `tests/e2e/ci-cancel-superseded-runs` is where such a change is proven,
+# which is why it was put under fixtures rather than left in the `run:` block.
 
 on:
     pull_request:
@@ -73,7 +87,7 @@ jobs:
             - name: Check out the selection
               uses: actions/checkout@v6
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  ref: ${{ github.event.pull_request.base.sha }}
                   fetch-depth: 1
                   sparse-checkout: scripts/select-superseded-runs.mjs
                   sparse-checkout-cone-mode: false

--- a/tests/e2e/ci-cancel-superseded-runs/run.mjs
+++ b/tests/e2e/ci-cancel-superseded-runs/run.mjs
@@ -254,4 +254,22 @@ describe('the workflow that runs it', () => {
         assert.match(yaml, /types:\s*\[closed,\s*synchronize\]/);
         assert.match(yaml, /node scripts\/select-superseded-runs\.mjs/);
     });
+
+    it('checks the selection out from the BASE, not the head', () => {
+        // TWO failures ride on this one line, and the first one already happened.
+        //
+        // A branch created BEFORE this script landed does not contain it, so a head
+        // checkout gives `Cannot find module` and `set -euo pipefail` fails the job —
+        // measured on #1340, whose branch predated #1334 by hours and which therefore
+        // went red on a job about its own obsolete runs. That is not a transition cost:
+        // every branch cut before a later change to this script has the same shape.
+        //
+        // And the job holds `actions: write`, which AGENTS.md forbids pairing with head
+        // code. The base SHA is the only spelling that satisfies both.
+        const yaml = readFileSync(WORKFLOW, 'utf8');
+        const ref = /^\s*ref:\s*(\S.*)$/m.exec(yaml);
+        assert.ok(ref, 'the checkout must pin an explicit ref, not fall back to the merge ref');
+        assert.match(ref[1], /pull_request\.base\.sha/);
+        assert.doesNotMatch(ref[1], /head\.sha/);
+    });
 });


### PR DESCRIPTION
#1334 pinned the cancel job's sparse checkout to the PR **head**, and a branch created before that script landed does not contain it. `set -euo pipefail` then kills the job:

```
Error: Cannot find module '/home/runner/work/gjsify/gjsify/scripts/select-superseded-runs.mjs'
```

Measured on **#1340**, whose branch (`da181c264`) predates #1334 by hours: the script is absent on that head and present on `main` (8641 bytes). So the job went red on a PR *about its own obsolete runs*, and its cancellations never happened — which is the entire purpose of the workflow.

**This is not a transition cost.** Every branch cut before a *later* change to this script has the same shape.

## Why the base SHA rather than a `[ -f ]` guard

The base SHA carries the workflow's own argument further than the head SHA did. The job needs `actions: write`; AGENTS.md forbids pairing a write token with head code. The head SHA was a compromise justified by sparseness — one script, from a branch whose author already has write access. The base SHA is **not** a compromise:

- the job materialises **no head code at all**;
- a fork PR now runs this repository's own selection rather than the fork's.

The default merge ref stays ruled out for the reason the header already gave: it is not guaranteed to resolve once the PR is closed, and `closed` is one of the two events this workflow serves. `base.sha` is a real commit on the base branch and does resolve.

## What it gives up, stated rather than discovered

A PR can no longer test a change to the selection **on itself** — its own cancel job runs `main`'s copy. That is exactly why the selection lives under fixtures instead of in the `run:` block, and the header now says so.

## The mechanism

`tests/e2e/ci-cancel-superseded-runs` already reads the workflow file, in the `describe` that exists to stop "a selection no workflow calls". The ref assertion joins it there rather than becoming a second check.

Measured, both directions:

| | result |
|---|---|
| with `base.sha` | 18 tests, 18 pass |
| with `head.sha` | exactly **1** failure |
| restored | 18 pass |

The suite is in the `test:e2e` list, so it actually runs.

## Verified

`format --check` 0, `lint` 0, the e2e suite 18/18 — exit codes measured without a pipe.
