### PR TITLE
feat(gtk-host): the paint half of the style partition

### DIFF
--- a/packages/framework/gtk-host/package.json
+++ b/packages/framework/gtk-host/package.json
@@ -10,6 +10,10 @@
             "types": "./lib/types/index.d.ts",
             "default": "./lib/esm/index.js"
         },
+        "./style": {
+            "types": "./lib/types/style/index.d.ts",
+            "default": "./lib/esm/style/index.js"
+        },
         "./vue": {
             "types": "./lib/types/adapters/vue.d.ts",
             "default": "./lib/esm/adapters/vue.js"

--- a/packages/framework/gtk-host/src/style/errors.ts
+++ b/packages/framework/gtk-host/src/style/errors.ts
@@ -1,0 +1,17 @@
+// The one error the style partition throws, in its own module because THREE
+// modules throw it and none of them owns the other two.
+//
+// It lived in `paint.ts` while paint was the only half. Leaving it there would
+// have made `layout.ts` import the paint half to get at an error class, which
+// reads as a dependency between the halves and is not one — the dispatch in
+// `resolve.ts` is what composes them, and it throws this too.
+
+/** A utility class, property or combination this vocabulary cannot answer for, and why. */
+export class UnknownUtilityError extends Error {
+    override readonly name = 'UnknownUtilityError';
+    readonly utility: string;
+    constructor(utility: string, detail: string) {
+        super(`@gjsify/gtk-host/style: "${utility}" — ${detail}`);
+        this.utility = utility;
+    }
+}

--- a/packages/framework/gtk-host/src/style/gtk-css.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.spec.ts
@@ -60,6 +60,17 @@ export default async () => {
                 expect(error === null).toBe(false);
                 expect(String(error)).toContain('text-align');
             });
+
+            await it('accepts the PHYSICAL spacings and refuses the LOGICAL ones, in one place', async () => {
+                // The pair the layout half is built on, asserted together because the
+                // decision is the CONTRAST rather than either half: `ml-*` has to go
+                // through CSS and `ms-*` cannot, and a table that listed only one
+                // side would read as an oversight rather than as a constraint.
+                const physical = ['margin-left', 'margin-right', 'padding-left', 'padding-right'];
+                const logical = ['margin-start', 'margin-end', 'padding-start', 'padding-end'];
+                expect(physical.filter((property) => parseError(property, '8px') !== null)).toStrictEqual([]);
+                expect(logical.filter((property) => parseError(property, '8px') === null)).toStrictEqual([]);
+            });
         });
     });
 };

--- a/packages/framework/gtk-host/src/style/gtk-css.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.spec.ts
@@ -1,0 +1,65 @@
+// The measured CSS table, re-measured against the GTK that is running.
+//
+// `gtk-css.ts` is a claim about another program. Committing it as data is what makes
+// the partition testable without a display, but data that nothing re-checks is a
+// claim that decays: a GTK upgrade that adds `text-align` or removes `line-height`
+// would leave the table describing a version nobody runs, and the partition would go
+// on emitting declarations GTK drops in silence.
+//
+// So this asserts BOTH directions against a real `Gtk.CssProvider`. The negative
+// direction is the load-bearing one: without it the table could list every property
+// in CSS and still pass.
+
+import Gtk from 'gi://Gtk?version=4.0';
+import { expect, it, on } from '@gjsify/unit';
+
+import { GTK_CSS_PROBES, NOT_GTK_CSS } from './gtk-css.js';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
+import { installDiagnosticsGate } from '../conformance/index.js';
+
+/** Load one declaration and report the parser's own verdict. */
+function parseError(property: string, value: string): string | null {
+    const provider = new Gtk.CssProvider();
+    let message: string | null = null;
+    const handler = provider.connect('parsing-error', (_provider, _section, error) => {
+        message = error.message;
+    });
+    provider.load_from_string(`.probe { ${property}: ${value}; }`);
+    provider.disconnect(handler);
+    return message;
+}
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+        const diagnostics = installDiagnosticsGate();
+
+        await gated(diagnostics, 'the measured GTK CSS table', async () => {
+            await it('GTK accepts every property the table claims it accepts', async () => {
+                const rejected = GTK_CSS_PROBES.filter(([property, value]) => parseError(property, value) !== null).map(
+                    ([property, value]) => `${property}: ${value}`,
+                );
+                expect(rejected).toStrictEqual([]);
+            });
+
+            await it('GTK refuses every property the table claims it refuses', async () => {
+                // Without this direction the table could name every property in CSS
+                // and the test above would still pass — which is the shape of a gate
+                // that looks alive and checks nothing.
+                const accepted = NOT_GTK_CSS.filter(([property, value]) => parseError(property, value) === null).map(
+                    ([property, value]) => `${property}: ${value}`,
+                );
+                expect(accepted).toStrictEqual([]);
+            });
+
+            await it('reports text-align as absent, which is the one that reads like paint', async () => {
+                // Called out on its own because it is the property most likely to be
+                // grouped with `color` and `font-size` by anyone reading a `text-*`
+                // utility family, and GTK drops it without a word.
+                const error = parseError('text-align', 'center');
+                expect(error === null).toBe(false);
+                expect(String(error)).toContain('text-align');
+            });
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/style/gtk-css.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.ts
@@ -11,8 +11,8 @@
 // disagrees with, and it cannot go stale against a GTK upgrade without a test going
 // red first.
 //
-// Measured on GTK 4.22.4. Two results are worth carrying, because both look like
-// mistakes:
+// Measured on GTK 4.22.4. Three results are worth carrying, because all three look
+// like mistakes:
 //
 //   1. `text-align` IS NOT GTK CSS. It reads like a paint property and belongs in
 //      the layout half, where it becomes `Gtk.Label:xalign`. A class compiler that
@@ -23,6 +23,14 @@
 //      are not equivalent (CSS margin sits outside the border, the widget property
 //      does not compose with it), and choosing between them is the layout half's
 //      decision, not this file's.
+//   3. GTK CSS margins and paddings are PHYSICAL ONLY: `margin-start`, `margin-end`,
+//      `padding-start` and `padding-end` are all refused. The widget's own margins
+//      are the exact opposite — `margin-start`/`margin-end` and no
+//      `margin-left`/`margin-right` (`gtk-props.ts`). So the two mechanisms of
+//      result 2 are not two routes to one place: each is the ONLY route to one half
+//      of the vocabulary, which is why `ml-*`/`mr-*` and `ms-*`/`me-*` land in
+//      different channels in `layout.ts`, and why the layout half refuses an element
+//      that spells both.
 //
 // Every entry carries a value that parses, because "is this a property" and "does
 // this value parse" are different questions and only the pair is testable.
@@ -69,8 +77,14 @@ export const GTK_CSS_PROBES: ReadonlyArray<readonly [property: string, value: st
     ['text-transform', 'uppercase'],
     ['margin', '8px'],
     ['margin-top', '8px'],
+    ['margin-right', '8px'],
+    ['margin-bottom', '8px'],
+    ['margin-left', '8px'],
     ['padding', '8px'],
     ['padding-top', '8px'],
+    ['padding-right', '8px'],
+    ['padding-bottom', '8px'],
+    ['padding-left', '8px'],
     ['min-width', '10px'],
     ['min-height', '10px'],
     ['transform', 'scale(1.1)'],
@@ -82,14 +96,16 @@ export const GTK_CSS_PROBES: ReadonlyArray<readonly [property: string, value: st
 /**
  * Property names GTK4 REFUSES, and the reason each one is here.
  *
- * Twelve of the thirteen are the layout model the web has and GTK does not — there
- * is no `display: flex`, no absolute positioning, no intrinsic `width`. They must
- * become widget selection and widget properties, which is the layout half.
+ * Most of them are the layout model the web has and GTK does not — there is no
+ * `display: flex`, no absolute positioning, no intrinsic `width`. They must become
+ * widget selection and widget properties, which is the layout half.
  *
- * `text-align` is the one that is not about layout at all, and it is why this list
- * exists as a list rather than as a comment: it is the property most likely to be
- * grouped with `color` and `font-size` by anyone reading a Tailwind `text-*`
- * vocabulary, and GTK drops it in silence.
+ * Two groups are not that, and both are here because a reader would assume the
+ * opposite. `text-align` is not about layout at all: it is the property most likely
+ * to be grouped with `color` and `font-size` by anyone reading a Tailwind `text-*`
+ * vocabulary, and GTK drops it in silence. The four logical spacings ARE spacing,
+ * whose physical spellings sit in the accepted table three lines up — the refusal
+ * is per NAME, not per concept, and that is the asymmetry `layout.ts` is built on.
  */
 export const NOT_GTK_CSS: ReadonlyArray<readonly [property: string, value: string]> = [
     ['text-align', 'center'],
@@ -104,7 +120,13 @@ export const NOT_GTK_CSS: ReadonlyArray<readonly [property: string, value: strin
     ['overflow', 'hidden'],
     ['z-index', '1'],
     ['top', '0'],
+    ['right', '0'],
+    ['bottom', '0'],
     ['left', '0'],
+    ['margin-start', '8px'],
+    ['margin-end', '8px'],
+    ['padding-start', '8px'],
+    ['padding-end', '8px'],
 ];
 
 /** The property names of {@link GTK_CSS_PROBES}, for a membership test. */

--- a/packages/framework/gtk-host/src/style/gtk-css.ts
+++ b/packages/framework/gtk-host/src/style/gtk-css.ts
@@ -1,0 +1,111 @@
+// Which CSS properties GTK4 actually accepts — measured, not read.
+//
+// The whole style partition rests on one question: does this property become GTK
+// CSS text, or must it become a widget property? Getting it wrong in the CSS
+// direction is silent — GTK's parser drops the declaration and paints the widget
+// without it, and nothing in a test run says so.
+//
+// So the answer is a MEASUREMENT. `gtk-css.spec.ts` loads every name below into a
+// real `Gtk.CssProvider` and asserts it parses, and loads every name in
+// `NOT_GTK_CSS` and asserts it does NOT. The table cannot claim something GTK
+// disagrees with, and it cannot go stale against a GTK upgrade without a test going
+// red first.
+//
+// Measured on GTK 4.22.4. Two results are worth carrying, because both look like
+// mistakes:
+//
+//   1. `text-align` IS NOT GTK CSS. It reads like a paint property and belongs in
+//      the layout half, where it becomes `Gtk.Label:xalign`. A class compiler that
+//      groups it with the other `text-*` utilities emits a declaration GTK silently
+//      drops, and the text stays left-aligned with no diagnostic anywhere.
+//   2. `margin` and `padding` ARE accepted, so spacing has TWO possible routes on
+//      GTK — a CSS declaration or the widget's own `margin-top`… properties. They
+//      are not equivalent (CSS margin sits outside the border, the widget property
+//      does not compose with it), and choosing between them is the layout half's
+//      decision, not this file's.
+//
+// Every entry carries a value that parses, because "is this a property" and "does
+// this value parse" are different questions and only the pair is testable.
+//
+// EVERY SIDE AND EVERY CORNER IS LISTED SEPARATELY, and that is not padding. The
+// first version of this table probed `border-top-left-radius` and `border-top-width`
+// and left the other three corners and three sides to the shorthand — while the
+// partition mapped all eight. The invariant spec caught it on its first run: a
+// mapping is only proven for the exact name it emits, and a shorthand parsing says
+// nothing about the longhand a class like `rounded-br` produces.
+
+/**
+ * Property names GTK4 accepts in a stylesheet, with a value that parses.
+ *
+ * The value matters: `border-radius: 8px` and `border-radius: 9999px` both parse,
+ * but a property is only provably present when some value for it is accepted.
+ */
+export const GTK_CSS_PROBES: ReadonlyArray<readonly [property: string, value: string]> = [
+    ['background-color', 'rgb(255 0 0)'],
+    ['color', '#112233'],
+    ['opacity', '0.7'],
+    ['border-radius', '8px'],
+    ['border-top-left-radius', '8px'],
+    ['border-top-right-radius', '8px'],
+    ['border-bottom-left-radius', '8px'],
+    ['border-bottom-right-radius', '8px'],
+    ['border-width', '1px'],
+    ['border-top-width', '1px'],
+    ['border-right-width', '1px'],
+    ['border-bottom-width', '1px'],
+    ['border-left-width', '1px'],
+    ['border-style', 'solid'],
+    ['border-color', '#abcdef'],
+    ['border', '1px solid #abcdef'],
+    ['border-bottom', '1px solid #abcdef'],
+    ['box-shadow', '0 1px 2px rgba(0,0,0,0.2)'],
+    ['font-size', '14px'],
+    ['font-weight', '700'],
+    ['font-family', 'Cantarell'],
+    ['font-style', 'italic'],
+    ['letter-spacing', '1px'],
+    ['line-height', '1.4'],
+    ['text-decoration-line', 'underline'],
+    ['text-transform', 'uppercase'],
+    ['margin', '8px'],
+    ['margin-top', '8px'],
+    ['padding', '8px'],
+    ['padding-top', '8px'],
+    ['min-width', '10px'],
+    ['min-height', '10px'],
+    ['transform', 'scale(1.1)'],
+    ['transition', 'all 100ms'],
+    ['caret-color', '#ff0000'],
+    ['outline-style', 'solid'],
+];
+
+/**
+ * Property names GTK4 REFUSES, and the reason each one is here.
+ *
+ * Twelve of the thirteen are the layout model the web has and GTK does not — there
+ * is no `display: flex`, no absolute positioning, no intrinsic `width`. They must
+ * become widget selection and widget properties, which is the layout half.
+ *
+ * `text-align` is the one that is not about layout at all, and it is why this list
+ * exists as a list rather than as a comment: it is the property most likely to be
+ * grouped with `color` and `font-size` by anyone reading a Tailwind `text-*`
+ * vocabulary, and GTK drops it in silence.
+ */
+export const NOT_GTK_CSS: ReadonlyArray<readonly [property: string, value: string]> = [
+    ['text-align', 'center'],
+    ['display', 'flex'],
+    ['flex-direction', 'row'],
+    ['gap', '8px'],
+    ['position', 'absolute'],
+    ['width', '100px'],
+    ['height', '100px'],
+    ['justify-content', 'center'],
+    ['align-items', 'center'],
+    ['overflow', 'hidden'],
+    ['z-index', '1'],
+    ['top', '0'],
+    ['left', '0'],
+];
+
+/** The property names of {@link GTK_CSS_PROBES}, for a membership test. */
+export const GTK_CSS_PROPERTIES: ReadonlySet<string> = new Set(GTK_CSS_PROBES.map(([property]) => property));

--- a/packages/framework/gtk-host/src/style/gtk-props.spec.ts
+++ b/packages/framework/gtk-host/src/style/gtk-props.spec.ts
@@ -1,0 +1,111 @@
+// The measured widget-property table, re-measured against the GTK that is running.
+//
+// `gtk-css.spec.ts`'s reasoning, one authority over: `gtk-props.ts` is a claim about
+// another program's type system, and a claim nothing re-checks is one that decays.
+// A GTK release that renamed `width-request` or gave `Gtk.Widget` a `padding` would
+// leave the layout half routing properties by a table describing a version nobody
+// runs.
+//
+// BOTH DIRECTIONS, and here the negative one is not merely load-bearing, it is the
+// whole point: every routing decision in `layout.ts` rests on an ABSENCE. Padding
+// is CSS because no widget has a padding property; `ml-*` is CSS because no widget
+// has `margin-left`; `flex-row` is an intent-adjacent property rather than a
+// universal one because `orientation` is not on `Gtk.Widget`. A table that only
+// asserted presences would agree with a GTK in which all three were false.
+
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk?version=4.0';
+import { expect, it, on } from '@gjsify/unit';
+
+import { GTK_WIDGET_PROPERTY_PROBES, NOT_GTK_WIDGET_PROPERTIES } from './gtk-props.js';
+import { paramSpecs } from '../props.js';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
+import { installDiagnosticsGate } from '../conformance/index.js';
+
+/**
+ * The GType names the table uses → the class object to read them from.
+ *
+ * `Gtk.Widget` is abstract and is read anyway: `list_properties()` is a CLASS
+ * operation, and the abstract base is exactly where the universal rows have to be
+ * proven — proving them on `Gtk.Box` would only show that a box has them.
+ */
+const CLASSES: Readonly<Record<string, GObject.ObjectClass>> = {
+    GtkWidget: Gtk.Widget as unknown as GObject.ObjectClass,
+    GtkBox: Gtk.Box as unknown as GObject.ObjectClass,
+    GtkLabel: Gtk.Label as unknown as GObject.ObjectClass,
+    GtkCenterBox: Gtk.CenterBox as unknown as GObject.ObjectClass,
+    GtkFlowBox: Gtk.FlowBox as unknown as GObject.ObjectClass,
+};
+
+/** The class's ParamSpecs by kebab name — the host's own reader, not a second one. */
+const specsOf = (gtype: string): Map<string, GObject.ParamSpec> => {
+    const klass = CLASSES[gtype];
+    if (klass === undefined) throw new Error(`gtk-props.ts names ${gtype}, which this spec cannot construct`);
+    return paramSpecs(klass, gtype);
+};
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+        const diagnostics = installDiagnosticsGate();
+
+        await gated(diagnostics, 'the measured GTK widget-property table', async () => {
+            await it('GTK installs every property the table claims, with the value type it claims', async () => {
+                // The value type travels with the name because the layout half acts
+                // on it: `margin-top` being a `gint` is why a `rem` spacing token is
+                // refused there and accepted in CSS.
+                const wrong = GTK_WIDGET_PROPERTY_PROBES.filter(([gtype, property, valueType]) => {
+                    const spec = specsOf(gtype).get(property);
+                    return spec === undefined || GObject.type_name(spec.value_type) !== valueType;
+                }).map(([gtype, property, valueType]) => `${gtype}:${property} is not ${valueType}`);
+                expect(wrong).toStrictEqual([]);
+            });
+
+            await it('GTK installs none of the properties the table claims are absent', async () => {
+                const present = NOT_GTK_WIDGET_PROPERTIES.filter(
+                    ([gtype, property]) => specsOf(gtype).get(property) !== undefined,
+                ).map(([gtype, property]) => `${gtype}:${property}`);
+                expect(present).toStrictEqual([]);
+            });
+
+            await it('the GtkWidget rows really are inherited by every class in the table', async () => {
+                // What lets the layout half emit `margin-start`, `hexpand` and
+                // `overflow` without knowing which tag an element becomes. Asserted
+                // rather than assumed: GObject inheritance makes it true, and this is
+                // the line that would go red if a row were filed under `GtkWidget`
+                // that is actually a subclass's.
+                const universal = GTK_WIDGET_PROPERTY_PROBES.filter(([gtype]) => gtype === 'GtkWidget');
+                const missing: string[] = [];
+                for (const gtype of Object.keys(CLASSES)) {
+                    const specs = specsOf(gtype);
+                    for (const [, property] of universal) {
+                        if (!specs.has(property)) missing.push(`${gtype}:${property}`);
+                    }
+                }
+                expect(missing).toStrictEqual([]);
+            });
+
+            await it('reports padding as absent everywhere, which is what makes it CSS-only', async () => {
+                // Called out on its own for the same reason `gtk-css.spec.ts` calls
+                // out `text-align`: it is the absence a reader is most likely to
+                // assume away. A widget has margins, so it looks like it must have
+                // paddings — and `p-*` would then have a channel it does not have.
+                const withPadding = Object.keys(CLASSES).filter((gtype) => {
+                    const specs = specsOf(gtype);
+                    return [...specs.keys()].some((name) => name === 'padding' || name.startsWith('padding-'));
+                });
+                expect(withPadding).toStrictEqual([]);
+            });
+
+            await it('reports the widget margins as LOGICAL and only logical', async () => {
+                // The other half of the sentence `gtk-css.spec.ts` proves: CSS has
+                // the physical names and not the logical ones, the widget has the
+                // logical names and not the physical ones. Neither file can state it
+                // alone, and the layout half is the two put together.
+                const specs = specsOf('GtkWidget');
+                expect(specs.has('margin-start') && specs.has('margin-end')).toBe(true);
+                expect(specs.has('margin-left') || specs.has('margin-right')).toBe(false);
+            });
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/style/gtk-props.ts
+++ b/packages/framework/gtk-host/src/style/gtk-props.ts
@@ -1,0 +1,108 @@
+// Which WIDGET properties exist, and on which class — measured, not read.
+//
+// `gtk-css.ts` answers the same question for GTK's CSS parser. This file is its
+// other half, and the layout partition needs both because the two authorities
+// disagree about exactly the properties layout cares about: GTK CSS has
+// `margin-left` and no `margin-start`; `Gtk.Widget` has `margin-start` and no
+// `margin-left`. A layer that knew only one of the two lists would route half its
+// input into a mechanism that does not have it.
+//
+// The failure mode is milder than the CSS one — the host's `applyProps` looks a
+// property up in the class's ParamSpecs and refuses an unknown name — but it is
+// milder in the wrong place: it fails at attach time, in a CONSUMER's window,
+// against a class this package chose. Committing the measurement moves that
+// failure into this package's own test run.
+//
+// Measured on GTK 4.22.4 via `list_properties()` on the class. THREE results
+// carry the layout partition, and all three are the NEGATIVE direction:
+//
+//   1. **No widget has `padding` of any kind.** Padding is CSS-only on GTK, with
+//      no second route. That is why `p-*` never becomes a widget property while
+//      `m-*` partly does.
+//   2. **No widget has `margin-left`/`margin-right`.** The widget's margins are
+//      LOGICAL (`margin-start`/`margin-end`, which flip under RTL); the physical
+//      spelling exists only in CSS. The two are not interchangeable, and the
+//      split in `layout.ts` is that sentence turned into code.
+//   3. **`orientation` and `spacing` are NOT on `Gtk.Widget`.** They are
+//      `Gtk.Box`'s (via `Gtk.Orientable` for the first), so `flex-row` and
+//      `gap-*` are properties L1 can name but only L2 can legally apply — a
+//      `Gtk.Label` has neither, and `Gtk.CenterBox` has `orientation` and no
+//      `spacing` at all.
+//
+// The value type is measured with the name because "the property exists" and
+// "this value fits" are different questions and only the pair is testable:
+// `margin-top` is a `gint` of device pixels, which is why a spacing token spelled
+// in `rem` reaches the CSS channel unchanged and is refused by this one.
+
+/**
+ * Properties GTK installs, with the GType of their value.
+ *
+ * `GtkWidget` rows are the universal set — every widget in the table inherits
+ * them, which is what lets `layout.ts` emit them without knowing the tag.
+ */
+export const GTK_WIDGET_PROPERTY_PROBES: ReadonlyArray<readonly [gtype: string, property: string, valueType: string]> =
+    [
+        ['GtkWidget', 'margin-top', 'gint'],
+        ['GtkWidget', 'margin-bottom', 'gint'],
+        ['GtkWidget', 'margin-start', 'gint'],
+        ['GtkWidget', 'margin-end', 'gint'],
+        ['GtkWidget', 'halign', 'GtkAlign'],
+        ['GtkWidget', 'valign', 'GtkAlign'],
+        ['GtkWidget', 'hexpand', 'gboolean'],
+        ['GtkWidget', 'vexpand', 'gboolean'],
+        ['GtkWidget', 'width-request', 'gint'],
+        ['GtkWidget', 'height-request', 'gint'],
+        ['GtkWidget', 'overflow', 'GtkOverflow'],
+        ['GtkWidget', 'visible', 'gboolean'],
+        ['GtkBox', 'orientation', 'GtkOrientation'],
+        ['GtkBox', 'spacing', 'gint'],
+        ['GtkLabel', 'xalign', 'gfloat'],
+        ['GtkLabel', 'justify', 'GtkJustification'],
+    ];
+
+/**
+ * Properties the class does NOT install, and the claim each one carries.
+ *
+ * Without this direction the table above could name every property in GTK and
+ * still pass — and every routing decision in `layout.ts` rests on an absence
+ * rather than on a presence.
+ */
+export const NOT_GTK_WIDGET_PROPERTIES: ReadonlyArray<readonly [gtype: string, property: string]> = [
+    // Physical margins and padding of every kind: CSS's, not the widget's.
+    ['GtkWidget', 'margin-left'],
+    ['GtkWidget', 'margin-right'],
+    ['GtkWidget', 'padding'],
+    ['GtkWidget', 'padding-top'],
+    ['GtkBox', 'padding'],
+    ['GtkBox', 'margin-left'],
+    // The web layout model, absent here exactly as it is absent from GTK CSS.
+    ['GtkWidget', 'gap'],
+    ['GtkBox', 'gap'],
+    ['GtkWidget', 'flex'],
+    // Not universal, which is the whole reason `flex-row` and `gap-*` cannot be
+    // applied without knowing the widget.
+    ['GtkWidget', 'orientation'],
+    ['GtkWidget', 'spacing'],
+    ['GtkLabel', 'orientation'],
+    ['GtkLabel', 'spacing'],
+    ['GtkCenterBox', 'spacing'],
+    ['GtkFlowBox', 'spacing'],
+    // Only a text widget aligns text, which is why `text-center` is an intent.
+    ['GtkWidget', 'xalign'],
+    ['GtkBox', 'xalign'],
+];
+
+/**
+ * The property NAMES of {@link GTK_WIDGET_PROPERTY_PROBES}, for a membership test.
+ *
+ * NAMES ONLY, deliberately weaker than the table: L1 does not know which widget a
+ * class list will land on, so the strongest guard it can run is "GTK installs a
+ * property by this name SOMEWHERE in the vocabulary". `orientation` passes it on
+ * an element that turns out to be a `Gtk.Label`, and refusing that is L2's job,
+ * with the tag in hand. Reading this set as "every widget has these" is the one
+ * mistake it invites, and `GTK_WIDGET_PROPERTY_PROBES` is the table that answers
+ * the per-class question.
+ */
+export const GTK_WIDGET_PROPERTIES: ReadonlySet<string> = new Set(
+    GTK_WIDGET_PROPERTY_PROBES.map(([, property]) => property),
+);

--- a/packages/framework/gtk-host/src/style/index.ts
+++ b/packages/framework/gtk-host/src/style/index.ts
@@ -6,12 +6,29 @@
 // binding can use, which is why it lives here rather than in the React Native
 // package — and why ADR 0027 rule 1 puts it inside `gtk-host` rather than beside it.
 //
-// Today it answers the PAINT half. The layout half — widget selection, `hexpand`,
-// alignment, spacing — is the next milestone, and reaching one of its utilities is a
-// named error rather than a silent drop.
+// It answers a utility in one of three ways and never in a fourth: a GTK CSS
+// declaration, a GTK widget property, or an INTENT that only the shadow tree can
+// resolve (ADR 0032 § 6). Anything it cannot answer is a named error — an unknown
+// utility, a token missing from a scale, or a combination GTK has no way to express.
+// There is no silent drop, because a styling layer that ignores part of its input is
+// invisible in CI and obvious on screen.
 
 export { GTK_CSS_PROBES, GTK_CSS_PROPERTIES, NOT_GTK_CSS } from './gtk-css.js';
-export { MINIMAL_TOKENS } from './tokens.js';
+export { GTK_WIDGET_PROPERTIES, GTK_WIDGET_PROPERTY_PROBES, NOT_GTK_WIDGET_PROPERTIES } from './gtk-props.js';
+export { MINIMAL_TOKENS, lookupToken, requireToken } from './tokens.js';
 export type { Scale, StyleTokens } from './tokens.js';
-export { UnknownUtilityError, partition, resolveUtilities, resolveUtility } from './paint.js';
-export type { PaintProps, Partitioned } from './paint.js';
+export { UnknownUtilityError } from './errors.js';
+export { PAINT_PROPERTIES, partitionPaint, resolvePaintUtility } from './paint.js';
+export type { PaintProps } from './paint.js';
+export { LAYOUT_PROPERTIES, partitionLayout, resolveLayoutUtility } from './layout.js';
+export type {
+    AlignValue,
+    Edge,
+    JustifyValue,
+    LayoutIntent,
+    LayoutPartition,
+    LayoutProps,
+    OverlayIntent,
+} from './layout.js';
+export { partition, resolveUtilities, resolveUtility } from './resolve.js';
+export type { Partitioned, StyleProps } from './resolve.js';

--- a/packages/framework/gtk-host/src/style/index.ts
+++ b/packages/framework/gtk-host/src/style/index.ts
@@ -1,0 +1,17 @@
+// `@gjsify/gtk-host/style` — the style partition, L1 of ADR 0032.
+//
+// Framework-agnostic and React-Native-agnostic: `class="flex-1"` in a Vue template
+// is the same question as `className="flex-1"` on a React element, and both are the
+// same question as a `style={{…}}` object. This is the half every current and future
+// binding can use, which is why it lives here rather than in the React Native
+// package — and why ADR 0027 rule 1 puts it inside `gtk-host` rather than beside it.
+//
+// Today it answers the PAINT half. The layout half — widget selection, `hexpand`,
+// alignment, spacing — is the next milestone, and reaching one of its utilities is a
+// named error rather than a silent drop.
+
+export { GTK_CSS_PROBES, GTK_CSS_PROPERTIES, NOT_GTK_CSS } from './gtk-css.js';
+export { MINIMAL_TOKENS } from './tokens.js';
+export type { Scale, StyleTokens } from './tokens.js';
+export { UnknownUtilityError, partition, resolveUtilities, resolveUtility } from './paint.js';
+export type { PaintProps, Partitioned } from './paint.js';

--- a/packages/framework/gtk-host/src/style/layout.spec.ts
+++ b/packages/framework/gtk-host/src/style/layout.spec.ts
@@ -1,0 +1,333 @@
+// The layout half — pure TypeScript, so it runs without a display or a widget.
+//
+// Same seam as `paint.spec.ts`: the partition's DECISIONS are data and testable
+// here, while the two claims about another program — which CSS properties GTK
+// parses, which widget properties GTK installs — are measured against the real
+// thing in `gtk-css.spec.ts` and `gtk-props.spec.ts`. A vector here that asserts
+// `margin-left` is emitted is only worth anything because another file proves GTK
+// accepts that name.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { UnknownUtilityError } from './errors.js';
+import { GTK_CSS_PROPERTIES } from './gtk-css.js';
+import { GTK_WIDGET_PROPERTIES } from './gtk-props.js';
+import { LAYOUT_PROPERTIES, type LayoutProps, partitionLayout, resolveLayoutUtility } from './layout.js';
+import { PAINT_PROPERTIES } from './paint.js';
+import { partition, resolveUtilities, resolveUtility } from './resolve.js';
+import { MINIMAL_TOKENS, type StyleTokens } from './tokens.js';
+
+// A token file's own vocabulary, not Tailwind's numbers: `2xs` and `s` are what the
+// measured application spells, and the point of the scales is that the compiler
+// never had to know them.
+const TOKENS: StyleTokens = {
+    ...MINIMAL_TOKENS,
+    spacing: { ...MINIMAL_TOKENS.spacing, '2xs': '4px', xs: '8px', s: '12px', m: '16px' },
+    width: { icon: '24px' },
+};
+
+const threw = (fn: () => unknown): UnknownUtilityError => {
+    try {
+        fn();
+    } catch (error) {
+        if (error instanceof UnknownUtilityError) return error;
+        throw error;
+    }
+    throw new Error('expected an UnknownUtilityError, nothing was thrown');
+};
+
+const of = (...utilities: string[]) => partition(resolveUtilities(utilities, TOKENS));
+
+export default async () => {
+    await describe('the layout vocabulary', async () => {
+        await it('splits the horizontal margin by the SOURCE spelling, not by convenience', async () => {
+            // The measurement this whole half is built on. GTK CSS has no
+            // `margin-start` and no widget has `margin-left`, so Tailwind's physical
+            // pair and its logical pair are forced into different mechanisms — and
+            // sending `ms-*` through CSS would produce a margin that does not flip
+            // under RTL, which is a bug nobody reading English ever sees.
+            expect(of('ml-xs').css).toStrictEqual(['margin-left: 8px']);
+            expect(of('mr-xs').css).toStrictEqual(['margin-right: 8px']);
+            expect(of('ms-xs').props).toStrictEqual({ 'margin-start': 8 });
+            expect(of('me-xs').props).toStrictEqual({ 'margin-end': 8 });
+            // Vertical margins have no such distinction to preserve, so they join
+            // the widget channel rather than splitting the family for nothing.
+            expect(of('mt-xs', 'mb-s').props).toStrictEqual({ 'margin-top': 8, 'margin-bottom': 12 });
+        });
+
+        await it('keeps m-* and mx-* on ONE key, so the common override still resolves', async () => {
+            // `m-4 mx-2` is ordinary authoring. It only works by last-wins while both
+            // spellings write the same key — which is why `m-*` puts its horizontal
+            // half in CSS with `mx-*` instead of taking the widget channel wholesale.
+            const { css, props } = of('m-s', 'mx-2xs');
+            expect(css).toStrictEqual(['margin-left: 4px', 'margin-right: 4px']);
+            expect(props).toStrictEqual({ 'margin-top': 12, 'margin-bottom': 12 });
+        });
+
+        await it('refuses a physical and a logical horizontal margin together', async () => {
+            // The case last-wins cannot save: the two land in different mechanisms
+            // and GTK applies BOTH, so `m-s ms-2xs` would silently be a 16px start
+            // margin. An approximation here is invisible until someone measures the
+            // window.
+            const error = threw(() => of('m-s', 'ms-2xs'));
+            expect(error.message).toContain('ADD');
+        });
+
+        await it('sends every padding to CSS, because there is no second route', async () => {
+            // No GTK class installs a padding property of any kind (measured), so
+            // this family has no channel to choose between — and a LOGICAL padding
+            // cannot be expressed at all, in either mechanism.
+            expect(of('p-xs').css).toStrictEqual([
+                'padding-top: 8px',
+                'padding-right: 8px',
+                'padding-bottom: 8px',
+                'padding-left: 8px',
+            ]);
+            expect(of('px-xs', 'py-2xs').css).toStrictEqual([
+                'padding-top: 4px',
+                'padding-right: 8px',
+                'padding-bottom: 4px',
+                'padding-left: 8px',
+            ]);
+            expect(threw(() => resolveUtility('ps-xs', TOKENS)).message).toContain('no logical padding');
+        });
+
+        await it('maps the box axis to orientation, as a NICK', async () => {
+            // A nick because the host coerces through the ParamSpec. Assigning the
+            // string directly is the documented silent failure — `box.orientation =
+            // 'vertical'` keeps HORIZONTAL with no diagnostic at all.
+            expect(of('flex-row').props).toStrictEqual({ orientation: 'horizontal' });
+            expect(of('flex-col').props).toStrictEqual({ orientation: 'vertical' });
+        });
+
+        await it('makes flex-1 an intent, because the axis is the PARENT’s', async () => {
+            // ADR 0032 § 6, and the reason intents exist: the same class compiles to
+            // `hexpand` in a row and `vexpand` in a column, and an element does not
+            // know which it is in.
+            expect(of('flex-1').intent).toStrictEqual({ expand: 'main-axis' });
+            expect(of('flex-1').props).toStrictEqual({});
+            expect(of('flex-1').css).toStrictEqual([]);
+        });
+
+        await it('names the widget a wrap would need, instead of approximating one', async () => {
+            const error = threw(() => resolveUtility('flex-wrap', TOKENS));
+            expect(error.message).toContain('Gtk.FlowBox');
+            // `Gtk.Box` never wraps, so the no-wrap spelling restates the platform.
+            // Declared and empty is not the same as unrecognised, and the difference
+            // is exactly what this assertion pins.
+            expect(resolveLayoutUtility('flex-nowrap', TOKENS)).toStrictEqual({});
+        });
+
+        await it('defers both axes of alignment to the shadow tree', async () => {
+            // `items-*` sets a property on every CHILD and `self-*` reads the
+            // PARENT's orientation; neither is knowable from one element's classes.
+            expect(of('items-center').intent).toStrictEqual({ alignChildren: 'center' });
+            expect(of('items-start').intent).toStrictEqual({ alignChildren: 'flex-start' });
+            expect(of('self-end').intent).toStrictEqual({ alignSelf: 'flex-end' });
+            expect(of('items-center').props).toStrictEqual({});
+        });
+
+        await it('defers justify-between and REFUSES the two no child count can save', async () => {
+            // `space-between` is a widget choice — `Gtk.CenterBox` for two or three
+            // children — so the child count decides and L2 holds it (ADR 0032 § 6).
+            // `space-around`/`space-evenly` are different: GTK has no per-gap
+            // distribution at ANY child count, so deferring them would only move the
+            // refusal somewhere later and less specific.
+            expect(of('justify-between').intent).toStrictEqual({ distribute: 'space-between' });
+            expect(of('justify-center').intent).toStrictEqual({ distribute: 'center' });
+            expect(threw(() => resolveUtility('justify-around', TOKENS)).message).toContain('no per-gap distribution');
+            expect(threw(() => resolveUtility('justify-evenly', TOKENS)).message).toContain('Gtk.CenterBox');
+        });
+
+        await it('gives a plain gap the box property and an axis-qualified one an intent', async () => {
+            // A `Gtk.Box` has ONE spacing, so `gap-x-*` is that spacing or nothing,
+            // and which it is depends on an orientation whose DEFAULTS disagree
+            // between the two vocabularies (Gtk.Box is horizontal, a View is a
+            // column) — there is not even a safe guess to fall back on.
+            expect(of('gap-xs').props).toStrictEqual({ spacing: 8 });
+            expect(of('gap-x-xs').intent).toStrictEqual({ axisSpacing: { axis: 'horizontal', pixels: 8 } });
+            expect(of('gap-y-s').intent).toStrictEqual({ axisSpacing: { axis: 'vertical', pixels: 12 } });
+            // Two spellings on one element ask for two spacings a box does not have.
+            expect(threw(() => of('gap-xs', 'gap-y-s')).message).toContain('ONE `spacing`');
+        });
+
+        await it('separates “fill what you are given” from “never be smaller than”', async () => {
+            // `w-full` is not a size at all: `hexpand` takes the space that is going,
+            // `width-request` sets a floor. Collapsing them would make `w-full` a
+            // fixed width, which looks right until the window is resized.
+            expect(of('w-full', 'h-full').props).toStrictEqual({ hexpand: true, vexpand: true });
+            expect(of('w-icon').props).toStrictEqual({ 'width-request': 24 });
+            // The width scale falls back to spacing, Tailwind's own layering.
+            expect(of('h-m').props).toStrictEqual({ 'height-request': 16 });
+            expect(threw(() => resolveUtility('w-1/2', TOKENS)).message).toContain('no percentage size');
+        });
+
+        await it('maps overflow to the real widget property, and scrolling to a widget', async () => {
+            // Not every layout utility is an intent: `overflow` is on `Gtk.Widget`
+            // and `GtkOverflow` has exactly VISIBLE and HIDDEN (measured), so this
+            // one is an ordinary property. `scroll` is not an overflow mode on GTK
+            // at all — it is a different widget around the element.
+            expect(of('overflow-hidden').props).toStrictEqual({ overflow: 'hidden' });
+            expect(of('overflow-visible').props).toStrictEqual({ overflow: 'visible' });
+            expect(threw(() => resolveUtility('overflow-scroll', TOKENS)).message).toContain('Gtk.ScrolledWindow');
+        });
+
+        await it('turns absolute positioning into a request against the PARENT', async () => {
+            // A widget cannot make its own parent a `Gtk.Overlay`, and the measured
+            // application only ever writes `absolute` on the child — so the intent
+            // travels up. `relative` is carried rather than dropped because it is
+            // the half L2 can hold the other half against.
+            expect(of('absolute', 'inset-0').intent).toStrictEqual({
+                overlay: { role: 'child', edges: { top: 0, right: 0, bottom: 0, left: 0 } },
+            });
+            expect(of('absolute', 'top-xs', 'left-2xs').intent).toStrictEqual({
+                overlay: { role: 'child', edges: { top: 8, left: 4 } },
+            });
+            expect(of('relative').intent).toStrictEqual({ overlay: { role: 'context' } });
+            // An offset with no positioning has nothing to offset from: GTK has no
+            // relative offset, only a margin.
+            expect(threw(() => of('top-xs')).message).toContain('no relative offset');
+        });
+
+        await it('sends text alignment to a widget only the tree can find', async () => {
+            // `xalign` and `justify` are `Gtk.Label`'s; `Gtk.Box` has neither
+            // (measured). And GTK aligns text PHYSICALLY, so the logical spellings
+            // have nothing to map onto — the mirror image of the margin story.
+            expect(of('text-center').intent).toStrictEqual({ textAlign: 'center' });
+            expect(of('text-justify').intent).toStrictEqual({ textAlign: 'justify' });
+            expect(threw(() => resolveUtility('text-start', TOKENS)).message).toContain('PHYSICALLY');
+        });
+
+        await it('maps hidden onto visibility, and refuses a growth factor', async () => {
+            expect(of('hidden').props).toStrictEqual({ visible: false });
+            // GTK's growth is a boolean, so there is no factor to carry and no basis.
+            expect(threw(() => resolveUtility('flex-2', TOKENS)).message).toContain('no growth factor');
+            expect(threw(() => resolveUtility('basis-xs', TOKENS)).message).toContain('no growth factor');
+        });
+
+        await it('names the scale a spacing token is missing from', async () => {
+            const error = threw(() => resolveUtility('mt-nonsuch', TOKENS));
+            expect(error.message).toContain('spacing scale');
+            expect(error.message).toContain('2xs');
+        });
+
+        await it('refuses a token whose unit the widget channel cannot store', async () => {
+            // A real wart, and a loud one. `padding` keeps its unit because it is
+            // CSS; `margin-top` is a `gint` of device pixels with no conversion
+            // behind it. So a `rem` scale pads and cannot margin — reported by name
+            // rather than silently rounded to 2px.
+            const rem: StyleTokens = { spacing: { m: '2rem' } };
+            expect(partition(resolveUtilities(['p-m'], rem)).css).toStrictEqual([
+                'padding-top: 2rem',
+                'padding-right: 2rem',
+                'padding-bottom: 2rem',
+                'padding-left: 2rem',
+            ]);
+            expect(threw(() => partition(resolveUtilities(['mt-m'], rem))).message).toContain('not a pixel length');
+        });
+
+        await it('reports an unknown utility as unknown, from the only place that knows', async () => {
+            // Neither half claimed it. Both halves returning null is the ONLY signal
+            // that distinguishes this from a bad token in a family that does exist.
+            expect(threw(() => resolveUtility('wibble-3', TOKENS)).message).toContain(
+                'not a utility this vocabulary declares',
+            );
+        });
+    });
+
+    await describe('the layout partition', async () => {
+        // One sample per routed property, so the invariants below cover the vocabulary
+        // rather than whatever the vectors above happened to touch.
+        const SAMPLES: LayoutProps = {
+            marginTop: '8px',
+            marginRight: '8px',
+            marginBottom: '8px',
+            marginLeft: '8px',
+            marginStart: '8px',
+            marginEnd: '8px',
+            paddingTop: '8px',
+            paddingRight: '8px',
+            paddingBottom: '8px',
+            paddingLeft: '8px',
+            flexDirection: 'row',
+            flexGrow: '1',
+            alignItems: 'center',
+            justifyContent: 'center',
+            alignSelf: 'center',
+            gap: '8px',
+            columnGap: '8px',
+            rowGap: '8px',
+            width: '48px',
+            height: '48px',
+            overflow: 'hidden',
+            display: 'none',
+            position: 'absolute',
+            top: '0px',
+            right: '0px',
+            bottom: '0px',
+            left: '0px',
+            textAlign: 'center',
+        };
+        const SAMPLED = Object.keys(SAMPLES) as (keyof LayoutProps)[];
+
+        const pick = (...keys: readonly (keyof LayoutProps)[]): LayoutProps => {
+            const out: LayoutProps = {};
+            for (const key of keys) (out as Record<string, unknown>)[key] = SAMPLES[key];
+            return out;
+        };
+
+        // Grouped so the CROSS-KEY refusals stay refusals: a physical and a logical
+        // horizontal margin cannot meet, and neither can two gap spellings. Splitting
+        // them here is the alternative to weakening the rules to make one big record
+        // partition, which would test the opposite of what the rules say.
+        const APART: readonly (keyof LayoutProps)[] = ['marginStart', 'marginEnd', 'columnGap', 'rowGap'];
+        const GROUPS: readonly LayoutProps[] = [
+            pick(...SAMPLED.filter((key) => !APART.includes(key))),
+            pick('marginStart', 'marginEnd', 'columnGap'),
+            pick('rowGap'),
+            // The `100%` branch, the only one that reaches hexpand/vexpand.
+            { width: '100%', height: '100%' },
+            { display: 'flex' },
+        ];
+
+        await it('has a sample for every property it routes', async () => {
+            // Without this the two invariants below would pass by testing less.
+            expect([...LAYOUT_PROPERTIES].filter((key) => !(key in SAMPLES)).sort()).toStrictEqual([]);
+            expect(SAMPLED.filter((key) => !LAYOUT_PROPERTIES.has(key)).sort()).toStrictEqual([]);
+        });
+
+        await it('emits only CSS properties GTK measurably accepts', async () => {
+            // The silence the whole partition exists against: GTK's parser drops an
+            // unknown declaration without a word, so a wrong name here is invisible
+            // in CI and obvious on screen.
+            const emitted = GROUPS.flatMap((group) => partitionLayout(group).css).map((rule) => rule.split(':')[0]);
+            expect([...new Set(emitted)].filter((name) => !GTK_CSS_PROPERTIES.has(name))).toStrictEqual([]);
+        });
+
+        await it('emits only widget properties some GTK class measurably installs', async () => {
+            const emitted = GROUPS.flatMap((group) => Object.keys(partitionLayout(group).props));
+            expect([...new Set(emitted)].filter((name) => !GTK_WIDGET_PROPERTIES.has(name))).toStrictEqual([]);
+        });
+
+        await it('claims no property the paint half also claims', async () => {
+            // The dispatch routes a key by asking paint first, so a key in both sets
+            // would be silently painted and never laid out — a class of bug that
+            // cannot be found by reading either file alone.
+            expect([...LAYOUT_PROPERTIES].filter((key) => PAINT_PROPERTIES.has(key))).toStrictEqual([]);
+        });
+
+        await it('carries paint and layout through one call, without either losing anything', async () => {
+            // The composed shape, which is what a renderer actually consumes.
+            const { css, props, intent } = of('bg-black', 'p-xs', 'mt-xs', 'flex-col', 'flex-1');
+            expect(css).toStrictEqual([
+                'background-color: rgb(0 0 0)',
+                'padding-top: 8px',
+                'padding-right: 8px',
+                'padding-bottom: 8px',
+                'padding-left: 8px',
+            ]);
+            expect(props).toStrictEqual({ 'margin-top': 8, orientation: 'vertical' });
+            expect(intent).toStrictEqual({ expand: 'main-axis' });
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/style/layout.ts
+++ b/packages/framework/gtk-host/src/style/layout.ts
@@ -1,0 +1,668 @@
+// The layout half of the style partition: utility classes → properties → the THREE
+// destinations GTK actually has.
+//
+// The paint half had one destination and one question. This half has three, and
+// which one a property takes is a MEASUREMENT rather than a taste (`gtk-css.ts`,
+// `gtk-props.ts`):
+//
+//   css     — GTK's CSS parser accepts the name (`padding-left`, `margin-left`).
+//   props   — some GTK class installs a property by that name (`margin-start`,
+//             `orientation`, `hexpand`, `overflow`).
+//   intent  — NEITHER can answer it here, because the answer needs the parent, the
+//             children, or the widget this element turns into. L2 resolves it
+//             against the shadow tree at attach time (ADR 0032 § 6).
+//
+// THE DECISIVE MEASUREMENT, and the one thing to keep if everything else is
+// rewritten: GTK CSS margins are PHYSICAL ONLY — `margin-left` parses,
+// `margin-start` does not — while the widget's own margins are LOGICAL ONLY —
+// `Gtk.Widget:margin-start` exists, `margin-left` does not. Tailwind splits its
+// vocabulary along the same line: `ml-*`/`mr-*` are physical, `ms-*`/`me-*` are
+// logical. So the two GTK mechanisms are not two ways to spell one thing that a
+// layer gets to choose between; each is the ONLY route for one half of the source
+// vocabulary, and routing `ms-*` through CSS would produce a margin that does not
+// flip under RTL — a bug visible only to a reader of Arabic or Hebrew.
+//
+// Padding has no second route at all: no GTK class installs a `padding` property of
+// any kind (measured), so every padding is CSS, and a logical one (`ps-*`) is a
+// named refusal rather than a physical approximation.
+//
+// `mt-*`/`mb-*` have no logical/physical distinction to preserve, so they take the
+// widget channel with `ms-*`/`me-*` — which leaves `m-*` straddling both, because
+// Tailwind's `m-*` is physical: its horizontal half is CSS and its vertical half is
+// widget properties. That looks like an inconsistency and is the opposite: it is
+// what keeps `m-4 mx-2` resolving by last-wins on ONE key instead of stacking a CSS
+// margin on top of a widget margin. `m-4 ms-2` cannot be saved that way and is
+// refused by name, because on GTK the two channels ADD where CSS would have let one
+// win.
+
+import { UnknownUtilityError } from './errors.js';
+import { GTK_CSS_PROPERTIES } from './gtk-css.js';
+import { GTK_WIDGET_PROPERTIES } from './gtk-props.js';
+import { requireToken, type Scale, type StyleTokens } from './tokens.js';
+
+/** React Native's own `alignItems`/`alignSelf` vocabulary. */
+export type AlignValue = 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline';
+/** React Native's own `justifyContent` vocabulary. */
+export type JustifyValue = 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
+/** The four physical edges an absolutely positioned element offsets from. */
+export type Edge = 'top' | 'right' | 'bottom' | 'left';
+
+/**
+ * The properties the layout half understands, in React Native's spelling.
+ *
+ * The VALUES are React Native's too — `alignItems: 'flex-start'`, not `'start'` —
+ * and that is the point of ADR 0032 § 4 rather than a detail. A class list and a
+ * `style={{…}}` object are one information set arriving by two routes, and 48 of
+ * the measured application's 57 style objects carry exactly these names and values.
+ * Normalising the classes into a third spelling would put a translation table
+ * between the two front ends and give the partition two truths to keep in step.
+ */
+export interface LayoutProps {
+    marginTop?: string;
+    marginRight?: string;
+    marginBottom?: string;
+    marginLeft?: string;
+    marginStart?: string;
+    marginEnd?: string;
+    paddingTop?: string;
+    paddingRight?: string;
+    paddingBottom?: string;
+    paddingLeft?: string;
+    flexDirection?: 'row' | 'column';
+    flexGrow?: string;
+    alignItems?: AlignValue;
+    justifyContent?: JustifyValue;
+    alignSelf?: AlignValue;
+    gap?: string;
+    columnGap?: string;
+    rowGap?: string;
+    width?: string;
+    height?: string;
+    overflow?: 'visible' | 'hidden' | 'scroll';
+    display?: 'flex' | 'none';
+    position?: 'relative' | 'absolute';
+    top?: string;
+    right?: string;
+    bottom?: string;
+    left?: string;
+    textAlign?: 'left' | 'center' | 'right' | 'justify';
+}
+
+/**
+ * What L1 could not answer, for L2 to resolve against the shadow tree.
+ *
+ * Every field here is a case where the same input compiles to DIFFERENT GTK
+ * depending on something no per-element function can see. Nothing is an intent for
+ * being hard: `overflow-hidden` needs the parent no more than `bg-red` does, and it
+ * is a widget property below rather than a field here.
+ */
+export interface LayoutIntent {
+    /**
+     * `flex-1` — `hexpand` on a row, `vexpand` on a column.
+     *
+     * ADR 0032 § 6, and the reason the intent mechanism exists at all: the axis is
+     * the PARENT's orientation, which an element does not know about itself.
+     */
+    readonly expand?: 'main-axis';
+    /**
+     * `items-*` — the cross-axis alignment of every CHILD.
+     *
+     * Two things missing at once. GTK has no `align-items`: the alignment lives on
+     * each child as `halign`/`valign`, so L2 must walk children this function has
+     * never seen. And WHICH of the two it is depends on this element's own
+     * orientation, which is `Gtk.Box`'s default when no `flex-row`/`flex-col` says
+     * otherwise — and the defaults disagree (`Gtk.Box` is horizontal, a React
+     * Native `View` is a column), so there is not even a safe fallback to guess.
+     */
+    readonly alignChildren?: AlignValue;
+    /**
+     * `justify-*` — main-axis distribution.
+     *
+     * `space-between` is a WIDGET CHOICE, not a property: `Gtk.CenterBox` for two or
+     * three children and a named refusal beyond that (ADR 0032 § 6). The child count
+     * decides, and L1 has no children. The other three are the box's own
+     * `halign`/`valign`, which needs the orientation for the same reason
+     * {@link LayoutIntent.alignChildren} does.
+     */
+    readonly distribute?: JustifyValue;
+    /**
+     * `self-*` — this element's own cross-axis alignment.
+     *
+     * `halign` or `valign` by the PARENT's orientation. Same shape as
+     * {@link LayoutIntent.expand}, same reason, one axis over.
+     */
+    readonly alignSelf?: AlignValue;
+    /**
+     * `gap-x-*` / `gap-y-*` — a spacing that is only valid on one orientation.
+     *
+     * `Gtk.Box` has ONE `spacing` (measured), so an axis-qualified gap is either
+     * that spacing or nothing at all, and which it is depends on the orientation
+     * L1 cannot see. Refusing the spelling outright was the alternative and is
+     * worse: `gap-x-2` on a row is ordinary, unambiguous authoring, and L2 answers
+     * it exactly.
+     */
+    readonly axisSpacing?: { readonly axis: 'horizontal' | 'vertical'; readonly pixels: number };
+    /**
+     * `absolute` / `relative` / `inset-*` / `top-*` — the parent must be a `Gtk.Overlay`.
+     *
+     * A widget cannot make its own parent a different class, so the child's
+     * `absolute` is a request L2 executes on the PARENT. The `context` role is
+     * `relative`'s: it sets nothing (an overlay establishes the context by being
+     * one) but it is carried rather than dropped, because it is the half of the
+     * pair L2 can hold the other half against — an `absolute` child under a parent
+     * that never declared `relative` is a real authoring bug, and a dropped
+     * `relative` would make it undetectable.
+     */
+    readonly overlay?: OverlayIntent;
+    /**
+     * `text-*` — only a text widget aligns text.
+     *
+     * `xalign` and `justify` are `Gtk.Label`'s; `Gtk.Box` has neither (measured).
+     * A `<View className="text-center">` wrapping a `<Text>` is ordinary React
+     * Native, and on GTK the property has to travel to the label, which is a tree
+     * walk and therefore L2's.
+     */
+    readonly textAlign?: 'left' | 'center' | 'right' | 'justify';
+}
+
+export type OverlayIntent =
+    | { readonly role: 'context' }
+    | { readonly role: 'child'; readonly edges: Readonly<Partial<Record<Edge, number>>> };
+
+/** What {@link partitionLayout} contributes to the partition. */
+export interface LayoutPartition {
+    readonly css: readonly string[];
+    readonly props: Readonly<Record<string, unknown>>;
+    readonly intent: LayoutIntent;
+}
+
+// One reason per refusal, shared by the two front ends that hit it. The class path
+// throws with the utility name because that is what the author wrote; the property
+// path throws with the property name because a `style={{…}}` object has no class.
+// The REASON is the same fact either way, and a second copy of it is a second thing
+// to keep true.
+const NO_FLEX_FACTOR =
+    'GTK expresses main-axis growth as the boolean `hexpand`/`vexpand`, so there is no growth factor, no shrink factor and no flex basis to carry. `flex-1` is the only spelling with a GTK meaning';
+const NO_SPACE_DISTRIBUTION =
+    "GTK's box gives leftover main-axis space to the children that expand; it has no per-gap distribution mode, and `Gtk.CenterBox` has exactly three slots. Unlike `justify-between`, no child count makes this expressible, so it is refused here rather than deferred to the shadow tree";
+const NO_SCROLL_OVERFLOW =
+    'scrolling is a WIDGET on GTK, not an overflow mode: wrap the element in a `Gtk.ScrolledWindow` (React Native `ScrollView`). `Gtk.Overflow` has exactly VISIBLE and HIDDEN (measured)';
+const NO_LOGICAL_PADDING =
+    'GTK has no logical padding in either mechanism — `padding-start` is not a CSS property (measured) and no GTK class installs a padding property at all — so it cannot be expressed even approximately. Use `pl-*`/`pr-*`';
+const NO_LOGICAL_TEXT_ALIGN =
+    'GTK aligns text PHYSICALLY: `Gtk.Label:xalign` is 0 = left, and `GtkJustification` has exactly LEFT, RIGHT, CENTER and FILL (measured). There is no start/end spelling to map onto. Use `text-left`/`text-right`';
+const NO_PERCENTAGE_SIZE =
+    'GTK has no percentage size: a widget requests a MINIMUM in pixels (`width-request`) or expands to fill what it is given (`hexpand`). `w-full`/`h-full` are the only fractions with an exact GTK meaning';
+
+/** Family → the {@link LayoutProps} keys one token fills. */
+const MARGIN_SIDES: Readonly<Record<string, readonly (keyof LayoutProps)[]>> = {
+    m: ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'],
+    mt: ['marginTop'],
+    mr: ['marginRight'],
+    mb: ['marginBottom'],
+    ml: ['marginLeft'],
+    mx: ['marginLeft', 'marginRight'],
+    my: ['marginTop', 'marginBottom'],
+    ms: ['marginStart'],
+    me: ['marginEnd'],
+};
+
+const PADDING_SIDES: Readonly<Record<string, readonly (keyof LayoutProps)[]>> = {
+    p: ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'],
+    pt: ['paddingTop'],
+    pr: ['paddingRight'],
+    pb: ['paddingBottom'],
+    pl: ['paddingLeft'],
+    px: ['paddingLeft', 'paddingRight'],
+    py: ['paddingTop', 'paddingBottom'],
+};
+
+const EDGE_KEYS: Readonly<Record<string, readonly Edge[]>> = {
+    inset: ['top', 'right', 'bottom', 'left'],
+    top: ['top'],
+    right: ['right'],
+    bottom: ['bottom'],
+    left: ['left'],
+};
+
+const ALIGN_TOKENS: Readonly<Record<string, AlignValue>> = {
+    start: 'flex-start',
+    end: 'flex-end',
+    center: 'center',
+    stretch: 'stretch',
+    baseline: 'baseline',
+};
+
+const JUSTIFY_TOKENS: Readonly<Record<string, JustifyValue>> = {
+    start: 'flex-start',
+    end: 'flex-end',
+    center: 'center',
+    between: 'space-between',
+    around: 'space-around',
+    evenly: 'space-evenly',
+};
+
+const fill = (keys: readonly (keyof LayoutProps)[], value: string): LayoutProps => {
+    const out: LayoutProps = {};
+    // Written through a string view: every key these three tables carry is a plain
+    // string-valued one, and narrowing the parameter type to prove it costs more
+    // mapped-type machinery than the assertion is worth.
+    for (const key of keys) (out as Record<string, string>)[key] = value;
+    return out;
+};
+
+/**
+ * `w-<token>` reads the `width` scale and falls back to `spacing`.
+ *
+ * Tailwind's own layering — its default `width` scale IS `spacing` plus a handful
+ * of extras — so a project that only declares `spacing` gets `w-4` for free, and a
+ * project that declares both keeps the override. The error names both scales,
+ * because "not in the width scale" would send a reader to the wrong file.
+ */
+function requireSize(tokens: StyleTokens, kind: 'width' | 'height', token: string, utility: string): string {
+    const own: Scale | undefined = tokens[kind];
+    const value = own?.[token] ?? tokens.spacing?.[token];
+    if (value !== undefined) return value;
+    const known = [...new Set([...Object.keys(own ?? {}), ...Object.keys(tokens.spacing ?? {})])].sort().join(', ');
+    throw new UnknownUtilityError(
+        utility,
+        `"${token}" is in neither the ${kind} nor the spacing scale. Known: ${known === '' ? '(neither scale is configured)' : known}`,
+    );
+}
+
+/**
+ * One utility class → the layout properties it sets, or `null` for "not mine".
+ *
+ * `null` rather than a throw is what lets `resolve.ts` try both halves without
+ * either of them knowing the other exists. A family this half DOES own with a bad
+ * token still throws, and that distinction is the whole point: `flex-2` is a
+ * refusal with a reason, `wibble-3` is an unknown name.
+ */
+export function resolveLayoutUtility(utility: string, tokens: StyleTokens): LayoutProps | null {
+    switch (utility) {
+        case 'flex-1':
+        case 'grow':
+            return { flexGrow: '1' };
+        case 'flex-row':
+            return { flexDirection: 'row' };
+        case 'flex-col':
+            return { flexDirection: 'column' };
+        case 'flex-nowrap':
+            // `Gtk.Box` never wraps, so this restates the platform. The empty record
+            // is not a dropped utility: the name is DECLARED here and asserted empty
+            // in the spec, which is what separates "means nothing on GTK" from "was
+            // never recognised".
+            return {};
+        case 'flex-wrap':
+        case 'flex-wrap-reverse':
+            throw new UnknownUtilityError(
+                utility,
+                'a `Gtk.Box` cannot wrap. Wrapping is a different widget — `Gtk.FlowBox` — and swapping the widget under an element is L2 widget selection, not a style property',
+            );
+        case 'flex-row-reverse':
+        case 'flex-col-reverse':
+            throw new UnknownUtilityError(
+                utility,
+                '`Gtk.Box` has no reversed orientation (`GtkOrientation` is HORIZONTAL and VERTICAL, measured). Reverse the children instead — the shadow tree is the order',
+            );
+        case 'absolute':
+            return { position: 'absolute' };
+        case 'relative':
+            return { position: 'relative' };
+        case 'hidden':
+            return { display: 'none' };
+        case 'overflow-hidden':
+            return { overflow: 'hidden' };
+        case 'overflow-visible':
+            return { overflow: 'visible' };
+        case 'overflow-scroll':
+        case 'overflow-auto':
+            throw new UnknownUtilityError(utility, NO_SCROLL_OVERFLOW);
+        // Before the `w`/`h` families below, so a project whose width scale happens
+        // to carry a `full` token cannot turn `w-full` into a width REQUEST — the
+        // one spelling that must stay an expand.
+        case 'w-full':
+            return { width: '100%' };
+        case 'h-full':
+            return { height: '100%' };
+    }
+
+    const dash = utility.indexOf('-');
+    const family = dash === -1 ? utility : utility.slice(0, dash);
+    const token = dash === -1 ? '' : utility.slice(dash + 1);
+
+    const marginSides = MARGIN_SIDES[family];
+    if (marginSides !== undefined) return fill(marginSides, requireToken(tokens.spacing, token, utility, 'spacing'));
+
+    const paddingSides = PADDING_SIDES[family];
+    if (paddingSides !== undefined) return fill(paddingSides, requireToken(tokens.spacing, token, utility, 'spacing'));
+
+    const edges = EDGE_KEYS[family];
+    if (edges !== undefined) return fill(edges, requireToken(tokens.spacing, token, utility, 'spacing'));
+
+    switch (family) {
+        case 'ps':
+        case 'pe':
+            throw new UnknownUtilityError(utility, NO_LOGICAL_PADDING);
+        case 'flex':
+        case 'grow':
+        case 'shrink':
+        case 'basis':
+            throw new UnknownUtilityError(utility, NO_FLEX_FACTOR);
+        case 'items': {
+            const value = ALIGN_TOKENS[token];
+            if (value === undefined) throw unknownToken(utility, token, ALIGN_TOKENS);
+            return { alignItems: value };
+        }
+        case 'self': {
+            // `self-baseline` is deliberately absent: `align-self: baseline` needs a
+            // shared baseline group, which GTK expresses as the BOX's
+            // `baseline-position` (measured on `Gtk.Box`, absent from `Gtk.Widget`)
+            // rather than per child. `items-baseline` is the spelling that maps.
+            const value = token === 'baseline' ? undefined : ALIGN_TOKENS[token];
+            if (value === undefined) {
+                throw token === 'baseline'
+                    ? new UnknownUtilityError(
+                          utility,
+                          'a baseline is shared by a whole row, so GTK carries it on the BOX as `baseline-position` (measured on `Gtk.Box`, absent from `Gtk.Widget`) rather than per child. Use `items-baseline` on the parent',
+                      )
+                    : unknownToken(utility, token, ALIGN_TOKENS);
+            }
+            return { alignSelf: value };
+        }
+        case 'justify': {
+            if (token === 'around' || token === 'evenly') {
+                throw new UnknownUtilityError(utility, NO_SPACE_DISTRIBUTION);
+            }
+            const value = JUSTIFY_TOKENS[token];
+            if (value === undefined) throw unknownToken(utility, token, JUSTIFY_TOKENS);
+            return { justifyContent: value };
+        }
+        case 'gap': {
+            // `gap-x-4` and `gap-y-4` are the axis-qualified spellings; anything else
+            // after the family is the token itself.
+            if (token.startsWith('x-')) {
+                return { columnGap: requireToken(tokens.spacing, token.slice(2), utility, 'spacing') };
+            }
+            if (token.startsWith('y-')) {
+                return { rowGap: requireToken(tokens.spacing, token.slice(2), utility, 'spacing') };
+            }
+            return { gap: requireToken(tokens.spacing, token, utility, 'spacing') };
+        }
+        case 'w':
+        case 'h': {
+            // `w-1/2` is Tailwind's fraction. It is the one `/` a layout utility
+            // carries, and the paint half's alpha modifier never reaches here.
+            if (token.includes('/')) throw new UnknownUtilityError(utility, NO_PERCENTAGE_SIZE);
+            const kind = family === 'w' ? 'width' : 'height';
+            return { [kind]: requireSize(tokens, kind, token, utility) } as LayoutProps;
+        }
+        case 'text': {
+            // The paint half owns `text-*` and hands these three back as unclaimed,
+            // because `text-align` is not GTK CSS at all (measured) — it is a widget
+            // property on a widget only L2 can find.
+            if (token === 'left' || token === 'center' || token === 'right' || token === 'justify') {
+                return { textAlign: token };
+            }
+            if (token === 'start' || token === 'end') throw new UnknownUtilityError(utility, NO_LOGICAL_TEXT_ALIGN);
+            // Every other `text-*` token is a size or a colour and the paint half
+            // has already answered it. Handing it back rather than throwing keeps
+            // this function independent of which tokens that filter lets through.
+            return null;
+        }
+    }
+
+    return null;
+}
+
+const unknownToken = (utility: string, token: string, table: Readonly<Record<string, string>>): UnknownUtilityError =>
+    new UnknownUtilityError(
+        utility,
+        `"${token}" is not a value of this family. Known: ${Object.keys(table).join(', ')}`,
+    );
+
+interface MutableIntent {
+    expand?: 'main-axis';
+    alignChildren?: AlignValue;
+    distribute?: JustifyValue;
+    alignSelf?: AlignValue;
+    axisSpacing?: { axis: 'horizontal' | 'vertical'; pixels: number };
+    overlay?: { role: 'context' } | { role: 'child'; edges: Partial<Record<Edge, number>> };
+    textAlign?: 'left' | 'center' | 'right' | 'justify';
+}
+
+interface Sink {
+    readonly css: string[];
+    readonly props: Record<string, unknown>;
+    readonly intent: MutableIntent;
+}
+
+/**
+ * Emit a CSS declaration, against the measured accepted set.
+ *
+ * Same guard as the paint half's, for the same reason: a name GTK does not accept
+ * is dropped by its parser without a diagnostic, so an edit to the table below is
+ * the only way this layer can go silently wrong.
+ */
+function emitCss(sink: Sink, property: string, value: string): void {
+    if (!GTK_CSS_PROPERTIES.has(property)) {
+        throw new UnknownUtilityError(property, 'is not a property GTK accepts in a stylesheet — see gtk-css.ts');
+    }
+    sink.css.push(`${property}: ${value}`);
+}
+
+/** Emit a widget property, against the measured installed set. */
+function emitProp(sink: Sink, property: string, value: unknown): void {
+    if (!GTK_WIDGET_PROPERTIES.has(property)) {
+        throw new UnknownUtilityError(property, 'is not a property any GTK class installs — see gtk-props.ts');
+    }
+    sink.props[property] = value;
+}
+
+const PIXELS = /^(-?\d+(?:\.\d+)?)(?:px)?$/;
+
+/**
+ * A token value → the integer a GTK property stores.
+ *
+ * `margin-top`, `spacing` and `width-request` are all `gint` of DEVICE pixels
+ * (measured), and GTK exposes no unit conversion behind them. So a spacing scale
+ * spelled in `rem` or `%` reaches padding — which is CSS, and keeps its unit —
+ * and is a named error the moment the same token is asked to become a margin.
+ * Refusing beats the alternative, which is a `2rem` margin silently becoming 2px.
+ */
+function pixels(value: string, property: string): number {
+    const match = PIXELS.exec(value.trim());
+    if (match === null) {
+        throw new UnknownUtilityError(
+            property,
+            `"${value}" is not a pixel length. GTK's "${property}" is a gint of device pixels (measured, gtk-props.ts) with no unit conversion behind it, so only "12px" and "12" can be stored`,
+        );
+    }
+    return Math.round(Number(match[1]));
+}
+
+function oneOf<T extends string>(value: string, allowed: readonly T[], property: string): T {
+    if ((allowed as readonly string[]).includes(value)) return value as T;
+    throw new UnknownUtilityError(
+        property,
+        `"${value}" is not a value this partition routes. Known: ${allowed.join(', ')}`,
+    );
+}
+
+type Route = (value: string, sink: Sink) => void;
+
+const edgeRoute =
+    (edge: Edge): Route =>
+    (value, sink) => {
+        // `position` is routed FIRST by the declaration order of this table, so an
+        // absolutely positioned element already carries its overlay intent here.
+        // Anything else reaching this line has an offset and no positioning, which
+        // GTK cannot express at all — there is no relative offset, only a margin.
+        const overlay = sink.intent.overlay;
+        if (overlay === undefined || overlay.role !== 'child') {
+            throw new UnknownUtilityError(
+                edge,
+                'only offsets an element that is absolutely positioned, and this one is not. GTK has no relative offset: add `absolute` (which makes the parent a `Gtk.Overlay`), or express the distance as a margin',
+            );
+        }
+        overlay.edges[edge] = pixels(value, edge);
+    };
+
+/**
+ * Property → destination, and WHY it is that destination.
+ *
+ * Typed as a TOTAL record of {@link LayoutProps} on purpose: adding a property
+ * without deciding where it goes is then a type error, rather than a value that
+ * partitions into nothing and shows up as a style that did not apply.
+ *
+ * ITERATED IN DECLARATION ORDER rather than in the record's own key order, which
+ * makes the emitted CSS deterministic and lets `position` land before the four
+ * edges that need it.
+ */
+const ROUTES: Readonly<Record<keyof LayoutProps, Route>> = {
+    // Vertical margins: no logical/physical distinction exists, so they join the
+    // logical pair in the widget channel rather than splitting the family across
+    // two mechanisms for nothing.
+    marginTop: (value, sink) => emitProp(sink, 'margin-top', pixels(value, 'margin-top')),
+    marginBottom: (value, sink) => emitProp(sink, 'margin-bottom', pixels(value, 'margin-bottom')),
+    // Logical horizontal margins — the widget's, and ONLY the widget's: GTK CSS has
+    // no `margin-start` (measured). These are the ones that flip under RTL.
+    marginStart: (value, sink) => emitProp(sink, 'margin-start', pixels(value, 'margin-start')),
+    marginEnd: (value, sink) => emitProp(sink, 'margin-end', pixels(value, 'margin-end')),
+    // Physical horizontal margins — CSS's, and ONLY CSS's: no widget installs
+    // `margin-left` (measured). Routing `ml-*` through `margin-start` would make it
+    // flip under RTL, which is the opposite of what the author asked for.
+    marginLeft: (value, sink) => emitCss(sink, 'margin-left', value),
+    marginRight: (value, sink) => emitCss(sink, 'margin-right', value),
+    // Padding has exactly one mechanism, so there is no choice to explain — and the
+    // value keeps its unit, which is why a `rem` scale pads and cannot margin.
+    paddingTop: (value, sink) => emitCss(sink, 'padding-top', value),
+    paddingRight: (value, sink) => emitCss(sink, 'padding-right', value),
+    paddingBottom: (value, sink) => emitCss(sink, 'padding-bottom', value),
+    paddingLeft: (value, sink) => emitCss(sink, 'padding-left', value),
+    // `orientation` is `Gtk.Box`'s, not `Gtk.Widget`'s (measured), so this is a
+    // property L1 may name and only L2 may apply — a `Gtk.Label` has none.
+    //
+    // The value is a NICK, not the numeric enum member: `applyProps` coerces it
+    // through the ParamSpec, and a nick is what a reader can check against the GIR.
+    // It is emphatically not something to assign directly — `box.orientation =
+    // 'vertical'` keeps HORIZONTAL with no diagnostic at all (measured, gjs 1.88.1),
+    // which is why `props` is documented as what the HOST applies.
+    flexDirection: (value, sink) =>
+        emitProp(
+            sink,
+            'orientation',
+            oneOf(value, ['row', 'column'], 'flexDirection') === 'row' ? 'horizontal' : 'vertical',
+        ),
+    flexGrow: (value, sink) => {
+        if (value !== '1') throw new UnknownUtilityError('flexGrow', NO_FLEX_FACTOR);
+        sink.intent.expand = 'main-axis';
+    },
+    alignItems: (value, sink) => {
+        sink.intent.alignChildren = oneOf(
+            value,
+            ['flex-start', 'flex-end', 'center', 'stretch', 'baseline'],
+            'alignItems',
+        );
+    },
+    justifyContent: (value, sink) => {
+        // The class path already refused these by name. This branch is the OTHER
+        // front end — a `style={{ justifyContent: 'space-around' }}` object — and
+        // ADR 0032 § 4 requires both to be loud, from one stated reason.
+        if (value === 'space-around' || value === 'space-evenly') {
+            throw new UnknownUtilityError('justifyContent', NO_SPACE_DISTRIBUTION);
+        }
+        sink.intent.distribute = oneOf(value, ['flex-start', 'flex-end', 'center', 'space-between'], 'justifyContent');
+    },
+    alignSelf: (value, sink) => {
+        sink.intent.alignSelf = oneOf(value, ['flex-start', 'flex-end', 'center', 'stretch', 'baseline'], 'alignSelf');
+    },
+    gap: (value, sink) => emitProp(sink, 'spacing', pixels(value, 'spacing')),
+    columnGap: (value, sink) => {
+        sink.intent.axisSpacing = { axis: 'horizontal', pixels: pixels(value, 'spacing') };
+    },
+    rowGap: (value, sink) => {
+        sink.intent.axisSpacing = { axis: 'vertical', pixels: pixels(value, 'spacing') };
+    },
+    // `100%` is the ONLY fraction with an exact GTK meaning, and it is not a size at
+    // all: `hexpand` says "take what is going", where `width-request` says "never
+    // less than this". Collapsing them would make `w-full` a fixed width.
+    width: (value, sink) =>
+        value === '100%'
+            ? emitProp(sink, 'hexpand', true)
+            : emitProp(sink, 'width-request', pixels(percentGuard(value, 'width'), 'width-request')),
+    height: (value, sink) =>
+        value === '100%'
+            ? emitProp(sink, 'vexpand', true)
+            : emitProp(sink, 'height-request', pixels(percentGuard(value, 'height'), 'height-request')),
+    overflow: (value, sink) => {
+        if (value === 'scroll') throw new UnknownUtilityError('overflow', NO_SCROLL_OVERFLOW);
+        emitProp(sink, 'overflow', oneOf(value, ['visible', 'hidden'], 'overflow'));
+    },
+    // `display: none` is `visible: false`, and `display: flex` is `visible: true`
+    // rather than nothing — an explicit round trip beats a branch that emits
+    // nothing, which is indistinguishable from a property that was never routed.
+    display: (value, sink) => emitProp(sink, 'visible', oneOf(value, ['flex', 'none'], 'display') === 'flex'),
+    position: (value, sink) => {
+        sink.intent.overlay =
+            oneOf(value, ['relative', 'absolute'], 'position') === 'absolute'
+                ? { role: 'child', edges: {} }
+                : { role: 'context' };
+    },
+    top: edgeRoute('top'),
+    right: edgeRoute('right'),
+    bottom: edgeRoute('bottom'),
+    left: edgeRoute('left'),
+    textAlign: (value, sink) => {
+        sink.intent.textAlign = oneOf(value, ['left', 'center', 'right', 'justify'], 'textAlign');
+    },
+};
+
+/**
+ * The {@link LayoutProps} keys, for the dispatch's ownership test.
+ *
+ * DERIVED from the route table rather than listed: a second list is a second thing
+ * to keep true, and the one that drifts is the one that decides whether a property
+ * is routed at all.
+ */
+export const LAYOUT_PROPERTIES: ReadonlySet<string> = new Set(Object.keys(ROUTES));
+
+/** A percentage that is not `100%` never reaches `pixels()`, so it gets the right reason. */
+function percentGuard(value: string, property: string): string {
+    if (value.endsWith('%')) throw new UnknownUtilityError(property, NO_PERCENTAGE_SIZE);
+    return value;
+}
+
+/**
+ * Layout properties → `{ css, props, intent }`.
+ *
+ * The two cross-key refusals run first, because both are cases where every
+ * individual property is fine and the COMBINATION is what GTK cannot express.
+ * They are the reason this is not a per-property `map`.
+ */
+export function partitionLayout(props: LayoutProps): LayoutPartition {
+    const physical = props.marginLeft !== undefined || props.marginRight !== undefined;
+    const logical = props.marginStart !== undefined || props.marginEnd !== undefined;
+    if (physical && logical) {
+        throw new UnknownUtilityError(
+            'margin',
+            'a physical horizontal margin (`ml-*`/`mr-*`/`mx-*`/`m-*`) becomes GTK CSS and a logical one (`ms-*`/`me-*`) becomes the widget property; GTK applies BOTH and they ADD, where CSS would have let one win. Spell the horizontal margin one way',
+        );
+    }
+
+    const gaps = ['gap', 'columnGap', 'rowGap'].filter((key) => props[key as keyof LayoutProps] !== undefined);
+    if (gaps.length > 1) {
+        throw new UnknownUtilityError(
+            gaps.join(' + '),
+            'a `Gtk.Box` has ONE `spacing` (measured), so two gap spellings on one element ask for two spacings. Keep one',
+        );
+    }
+
+    const sink: Sink = { css: [], props: {}, intent: {} };
+    for (const key of Object.keys(ROUTES) as (keyof LayoutProps)[]) {
+        const value = props[key];
+        if (value === undefined) continue;
+        ROUTES[key](value, sink);
+    }
+    return sink;
+}

--- a/packages/framework/gtk-host/src/style/paint.spec.ts
+++ b/packages/framework/gtk-host/src/style/paint.spec.ts
@@ -6,8 +6,15 @@
 
 import { describe, expect, it } from '@gjsify/unit';
 
+// THE IMPORTS MOVED WITH THE PARTITION REFACTOR, and nothing else here did. This
+// half no longer owns the whole vocabulary: `resolveUtility` (which now tries both
+// halves) and `partition` live in `resolve.ts`, the error class in `errors.ts`, and
+// what remains here is `resolvePaintUtility` — the same function under a name that
+// says which half it is.
 import { MINIMAL_TOKENS, type StyleTokens } from './tokens.js';
-import { CSS_NAME, UnknownUtilityError, partition, resolveUtilities, resolveUtility } from './paint.js';
+import { UnknownUtilityError } from './errors.js';
+import { CSS_NAME, resolvePaintUtility } from './paint.js';
+import { partition, resolveUtilities } from './resolve.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
 
 const TOKENS: StyleTokens = {
@@ -38,70 +45,77 @@ const threw = (fn: () => unknown): UnknownUtilityError => {
 export default async () => {
     await describe('the paint vocabulary', async () => {
         await it('resolves a colour, a radius, an opacity and a border', async () => {
-            expect(resolveUtility('bg-grey-100', TOKENS)).toStrictEqual({
+            expect(resolvePaintUtility('bg-grey-100', TOKENS)).toStrictEqual({
                 backgroundColor: 'rgb(var(--color-grey-100))',
             });
-            expect(resolveUtility('rounded-md', TOKENS)).toStrictEqual({ borderRadius: '6px' });
-            expect(resolveUtility('opacity-70', TOKENS)).toStrictEqual({ opacity: '0.7' });
-            expect(resolveUtility('border', TOKENS)).toStrictEqual({ borderWidth: '1px' });
-            expect(resolveUtility('border-b', TOKENS)).toStrictEqual({ borderBottomWidth: '1px' });
+            expect(resolvePaintUtility('rounded-md', TOKENS)).toStrictEqual({ borderRadius: '6px' });
+            expect(resolvePaintUtility('opacity-70', TOKENS)).toStrictEqual({ opacity: '0.7' });
+            expect(resolvePaintUtility('border', TOKENS)).toStrictEqual({ borderWidth: '1px' });
+            expect(resolvePaintUtility('border-b', TOKENS)).toStrictEqual({ borderBottomWidth: '1px' });
         });
 
         await it('lets the SCALES disambiguate text-*, not a hard-coded name list', async () => {
             // The same family answers two questions, and which one it is depends on
             // the project's tokens rather than on anything this file knows.
-            expect(resolveUtility('text-s', TOKENS)).toStrictEqual({ fontSize: '13px' });
-            expect(resolveUtility('text-grey-700', TOKENS)).toStrictEqual({ color: 'rgb(var(--color-grey-700))' });
+            expect(resolvePaintUtility('text-s', TOKENS)).toStrictEqual({ fontSize: '13px' });
+            expect(resolvePaintUtility('text-grey-700', TOKENS)).toStrictEqual({ color: 'rgb(var(--color-grey-700))' });
         });
 
         await it('reports a token that is in two scales as ambiguous, rather than picking one', async () => {
             const ambiguous: StyleTokens = { colors: { s: 'red' }, fontSize: { s: '13px' } };
-            expect(threw(() => resolveUtility('text-s', ambiguous)).message).toContain('ambiguous');
+            expect(threw(() => resolvePaintUtility('text-s', ambiguous)).message).toContain('ambiguous');
         });
 
         await it('composes an alpha modifier through GTK’s own alpha()', async () => {
             // `bg-always-dark/70` is ordinary, and the base colour is a token whose
             // value may be a `var()` expression — so the alpha has to COMPOSE rather
             // than parse the colour apart.
-            expect(resolveUtility('bg-always-dark/70', TOKENS)).toStrictEqual({
+            expect(resolvePaintUtility('bg-always-dark/70', TOKENS)).toStrictEqual({
                 backgroundColor: 'alpha(rgb(var(--color-always-dark)), 0.7)',
             });
         });
 
         await it('refuses an alpha modifier on something that is not a colour', async () => {
-            expect(threw(() => resolveUtility('rounded-md/70', TOKENS)).message).toContain('colour');
+            expect(threw(() => resolvePaintUtility('rounded-md/70', TOKENS)).message).toContain('colour');
         });
 
         await it('names the scale and its contents when a token is missing', async () => {
             // The message has to be actionable: "not in the borderRadius scale" plus
             // what IS in it turns a typo into a one-line fix.
-            const error = threw(() => resolveUtility('rounded-huge', TOKENS));
+            const error = threw(() => resolvePaintUtility('rounded-huge', TOKENS));
             expect(error.message).toContain('borderRadius');
             expect(error.message).toContain('full');
         });
 
-        await it('tells a layout utility apart from a typo', async () => {
-            // Both throw. Only one of them sends the reader looking for a spelling
-            // mistake that is not there.
-            expect(threw(() => resolveUtility('flex-1', TOKENS)).message).toContain('layout half');
-            expect(threw(() => resolveUtility('mt-2xs', TOKENS)).message).toContain('layout half');
-            expect(threw(() => resolveUtility('bg-nonsuch', TOKENS)).message).toContain('colors scale');
-            expect(threw(() => resolveUtility('wibble-3', TOKENS)).message).toContain(
-                'not a utility this vocabulary declares',
-            );
+        await it('hands a family it does not own back, rather than judging it', async () => {
+            // CHANGED BY THE REFACTOR, and this is the change: `flex-1` and `mt-2xs`
+            // used to throw "belongs to the layout half" from a copy of the layout
+            // vocabulary kept in this file. Returning null is what lets the two
+            // halves stay ignorant of each other — `resolve.ts` is the only module
+            // that knows both said no, so it is the only one that can say "unknown".
+            expect(resolvePaintUtility('flex-1', TOKENS)).toBeNull();
+            expect(resolvePaintUtility('mt-2xs', TOKENS)).toBeNull();
+            expect(resolvePaintUtility('wibble-3', TOKENS)).toBeNull();
+            // A family it DOES own, with a token no scale carries, is still ITS error
+            // — and keeping that difference is the entire point of the split.
+            expect(threw(() => resolvePaintUtility('bg-nonsuch', TOKENS)).message).toContain('colors scale');
         });
 
-        await it('refuses text-align by name, because it reads like paint and is not', async () => {
-            const error = threw(() => resolveUtility('text-center', TOKENS));
-            expect(error.message).toContain('not GTK CSS');
-            expect(error.message).toContain('xalign');
+        await it('does not claim text alignment, because it reads like paint and is not', async () => {
+            // Measured: `No property named "text-align"`. It is a widget property on
+            // a widget only the shadow tree can find, so this half hands it back —
+            // where it used to throw a bespoke message naming a milestone that has
+            // since arrived.
+            expect(resolvePaintUtility('text-center', TOKENS)).toBeNull();
+            // Still the same family, still settled by the scales.
+            expect(resolvePaintUtility('text-s', TOKENS)).toStrictEqual({ fontSize: '13px' });
         });
 
         await it('refuses a variant rather than silently dropping it', async () => {
             // `active:opacity-70` means "when pressed", which is a pseudo-class the
             // caller has to place. Resolving it as if it were unconditional would
             // paint the pressed style permanently.
-            expect(threw(() => resolveUtility('active:opacity-70', TOKENS)).message).toContain('variant');
+            expect(threw(() => resolvePaintUtility('active:opacity-70', TOKENS)).message).toContain('variant');
         });
 
         await it('lets a later class win, on the property record', async () => {
@@ -130,8 +144,13 @@ export default async () => {
         await it('refuses a property it does not route, instead of dropping it', async () => {
             // The silence this whole file exists against: an unrouted property that
             // simply vanishes leaves the widget unpainted and the run green.
-            expect(threw(() => partition({ textAlign: 'center' } as never)).message).toContain(
-                'not a property the paint partition routes',
+            //
+            // The VECTOR changed with the refactor — `textAlign` is a property the
+            // partition routes now, to an intent — so the probe is a React Native
+            // property nothing has mapped yet, which is the case that actually
+            // matters: a `style={{…}}` object has no class name to check.
+            expect(threw(() => partition({ zIndex: '1' } as never)).message).toContain(
+                'not a property the style partition routes',
             );
         });
 

--- a/packages/framework/gtk-host/src/style/paint.spec.ts
+++ b/packages/framework/gtk-host/src/style/paint.spec.ts
@@ -1,0 +1,148 @@
+// The paint half — pure TypeScript, so it runs without a display or a widget.
+//
+// That is the point of the seam: the partition's decisions are testable as data,
+// and the only thing that needs GTK is the claim about which properties GTK accepts
+// (`gtk-css.spec.ts`).
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { MINIMAL_TOKENS, type StyleTokens } from './tokens.js';
+import { CSS_NAME, UnknownUtilityError, partition, resolveUtilities, resolveUtility } from './paint.js';
+import { GTK_CSS_PROPERTIES } from './gtk-css.js';
+
+const TOKENS: StyleTokens = {
+    ...MINIMAL_TOKENS,
+    colors: {
+        ...MINIMAL_TOKENS.colors,
+        'grey-100': 'rgb(var(--color-grey-100))',
+        'grey-700': 'rgb(var(--color-grey-700))',
+        emphasis: 'rgb(var(--color-emphasis))',
+        'always-dark': 'rgb(var(--color-always-dark))',
+    },
+    fontSize: { ...MINIMAL_TOKENS.fontSize, s: '13px' },
+    letterSpacing: { wide: '0.5px' },
+    lineHeight: { snug: '1.3' },
+    fontFamily: { serif: 'Merriweather' },
+};
+
+const threw = (fn: () => unknown): UnknownUtilityError => {
+    try {
+        fn();
+    } catch (error) {
+        if (error instanceof UnknownUtilityError) return error;
+        throw error;
+    }
+    throw new Error('expected an UnknownUtilityError, nothing was thrown');
+};
+
+export default async () => {
+    await describe('the paint vocabulary', async () => {
+        await it('resolves a colour, a radius, an opacity and a border', async () => {
+            expect(resolveUtility('bg-grey-100', TOKENS)).toStrictEqual({
+                backgroundColor: 'rgb(var(--color-grey-100))',
+            });
+            expect(resolveUtility('rounded-md', TOKENS)).toStrictEqual({ borderRadius: '6px' });
+            expect(resolveUtility('opacity-70', TOKENS)).toStrictEqual({ opacity: '0.7' });
+            expect(resolveUtility('border', TOKENS)).toStrictEqual({ borderWidth: '1px' });
+            expect(resolveUtility('border-b', TOKENS)).toStrictEqual({ borderBottomWidth: '1px' });
+        });
+
+        await it('lets the SCALES disambiguate text-*, not a hard-coded name list', async () => {
+            // The same family answers two questions, and which one it is depends on
+            // the project's tokens rather than on anything this file knows.
+            expect(resolveUtility('text-s', TOKENS)).toStrictEqual({ fontSize: '13px' });
+            expect(resolveUtility('text-grey-700', TOKENS)).toStrictEqual({ color: 'rgb(var(--color-grey-700))' });
+        });
+
+        await it('reports a token that is in two scales as ambiguous, rather than picking one', async () => {
+            const ambiguous: StyleTokens = { colors: { s: 'red' }, fontSize: { s: '13px' } };
+            expect(threw(() => resolveUtility('text-s', ambiguous)).message).toContain('ambiguous');
+        });
+
+        await it('composes an alpha modifier through GTK’s own alpha()', async () => {
+            // `bg-always-dark/70` is ordinary, and the base colour is a token whose
+            // value may be a `var()` expression — so the alpha has to COMPOSE rather
+            // than parse the colour apart.
+            expect(resolveUtility('bg-always-dark/70', TOKENS)).toStrictEqual({
+                backgroundColor: 'alpha(rgb(var(--color-always-dark)), 0.7)',
+            });
+        });
+
+        await it('refuses an alpha modifier on something that is not a colour', async () => {
+            expect(threw(() => resolveUtility('rounded-md/70', TOKENS)).message).toContain('colour');
+        });
+
+        await it('names the scale and its contents when a token is missing', async () => {
+            // The message has to be actionable: "not in the borderRadius scale" plus
+            // what IS in it turns a typo into a one-line fix.
+            const error = threw(() => resolveUtility('rounded-huge', TOKENS));
+            expect(error.message).toContain('borderRadius');
+            expect(error.message).toContain('full');
+        });
+
+        await it('tells a layout utility apart from a typo', async () => {
+            // Both throw. Only one of them sends the reader looking for a spelling
+            // mistake that is not there.
+            expect(threw(() => resolveUtility('flex-1', TOKENS)).message).toContain('layout half');
+            expect(threw(() => resolveUtility('mt-2xs', TOKENS)).message).toContain('layout half');
+            expect(threw(() => resolveUtility('bg-nonsuch', TOKENS)).message).toContain('colors scale');
+            expect(threw(() => resolveUtility('wibble-3', TOKENS)).message).toContain(
+                'not a utility this vocabulary declares',
+            );
+        });
+
+        await it('refuses text-align by name, because it reads like paint and is not', async () => {
+            const error = threw(() => resolveUtility('text-center', TOKENS));
+            expect(error.message).toContain('not GTK CSS');
+            expect(error.message).toContain('xalign');
+        });
+
+        await it('refuses a variant rather than silently dropping it', async () => {
+            // `active:opacity-70` means "when pressed", which is a pseudo-class the
+            // caller has to place. Resolving it as if it were unconditional would
+            // paint the pressed style permanently.
+            expect(threw(() => resolveUtility('active:opacity-70', TOKENS)).message).toContain('variant');
+        });
+
+        await it('lets a later class win, on the property record', async () => {
+            // Not by emitting both declarations: GTK resolves equal specificity by
+            // SHEET ORDER, not by the order of names in `css-classes`, so "the later
+            // class wins" would be false the moment two generated classes met.
+            expect(resolveUtilities(['bg-grey-100', 'bg-emphasis'], TOKENS)).toStrictEqual({
+                backgroundColor: 'rgb(var(--color-emphasis))',
+            });
+        });
+    });
+
+    await describe('the partition', async () => {
+        await it('emits GTK CSS declarations for every paint property', async () => {
+            const props = resolveUtilities(['bg-emphasis', 'rounded-full', 'opacity-70', 'text-grey-700'], TOKENS);
+            const { css, props: widgetProps, intent } = partition(props);
+            expect(css.includes('background-color: rgb(var(--color-emphasis))')).toBe(true);
+            expect(css.includes('border-radius: 9999px')).toBe(true);
+            expect(css.includes('opacity: 0.7')).toBe(true);
+            expect(css.includes('color: rgb(var(--color-grey-700))')).toBe(true);
+            // The layout half is empty here, and saying so is part of the contract.
+            expect(widgetProps).toStrictEqual({});
+            expect(intent).toStrictEqual({});
+        });
+
+        await it('refuses a property it does not route, instead of dropping it', async () => {
+            // The silence this whole file exists against: an unrouted property that
+            // simply vanishes leaves the widget unpainted and the run green.
+            expect(threw(() => partition({ textAlign: 'center' } as never)).message).toContain(
+                'not a property the paint partition routes',
+            );
+        });
+
+        await it('maps every property onto a CSS name GTK actually accepts', async () => {
+            // The INVARIANT, asserted directly. `partition` also guards it per call,
+            // but that branch is unreachable while the table is correct — so a test
+            // driving it would be testing a path no input can reach. This one fails
+            // the moment someone adds a mapping to a property GTK drops in silence,
+            // which is the edit the guard exists for.
+            const unaccepted = Object.entries(CSS_NAME).filter(([, name]) => !GTK_CSS_PROPERTIES.has(name));
+            expect(unaccepted).toStrictEqual([]);
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/style/paint.ts
+++ b/packages/framework/gtk-host/src/style/paint.ts
@@ -1,0 +1,391 @@
+// The paint half of the style partition: utility classes → properties → GTK CSS.
+//
+// ADR 0032 § 4 puts ONE normalised property set between the two front ends. A class
+// list and a `style={{…}}` object are the same information arriving by different
+// routes, so both resolve into the same record and exactly one partition runs
+// behind it. Two partitions would be two truths about one question.
+//
+// The property spelling is React Native's (`backgroundColor`, `borderTopLeftRadius`)
+// rather than CSS's, because that is the shape the style objects already have and
+// the classes have to be translated either way.
+//
+// WHAT THIS FILE REFUSES TO DO. It does not touch the layout half — `flex`, `items`,
+// `justify`, `gap`, spacing, positioning. Those become widget selection and widget
+// properties, and the interesting one (`flex-1` resolving to `hexpand` or `vexpand`
+// depending on the PARENT) cannot be answered here at all. Reaching a layout utility
+// is therefore an ERROR naming the milestone, never a silent drop: a styling layer
+// that quietly ignores half its input is invisible in CI and obvious on screen.
+
+import { GTK_CSS_PROPERTIES } from './gtk-css.js';
+import type { Scale, StyleTokens } from './tokens.js';
+
+/** The properties the paint half understands, in React Native's spelling. */
+export interface PaintProps {
+    backgroundColor?: string;
+    color?: string;
+    opacity?: string;
+    borderRadius?: string;
+    borderTopLeftRadius?: string;
+    borderTopRightRadius?: string;
+    borderBottomLeftRadius?: string;
+    borderBottomRightRadius?: string;
+    borderWidth?: string;
+    borderTopWidth?: string;
+    borderRightWidth?: string;
+    borderBottomWidth?: string;
+    borderLeftWidth?: string;
+    borderColor?: string;
+    fontSize?: string;
+    fontWeight?: string;
+    fontFamily?: string;
+    fontStyle?: string;
+    letterSpacing?: string;
+    lineHeight?: string;
+    textDecorationLine?: string;
+    textTransform?: string;
+}
+
+/**
+ * React Native property name → the GTK CSS property it becomes.
+ *
+ * Exported so `paint.spec.ts` can assert the invariant this table rests on — that
+ * every value is a property GTK measurably accepts — directly, rather than through
+ * `partition`'s per-call guard, which no input can reach while the table is right.
+ */
+export const CSS_NAME: Readonly<Record<keyof PaintProps, string>> = {
+    backgroundColor: 'background-color',
+    color: 'color',
+    opacity: 'opacity',
+    borderRadius: 'border-radius',
+    borderTopLeftRadius: 'border-top-left-radius',
+    borderTopRightRadius: 'border-top-right-radius',
+    borderBottomLeftRadius: 'border-bottom-left-radius',
+    borderBottomRightRadius: 'border-bottom-right-radius',
+    borderWidth: 'border-width',
+    borderTopWidth: 'border-top-width',
+    borderRightWidth: 'border-right-width',
+    borderBottomWidth: 'border-bottom-width',
+    borderLeftWidth: 'border-left-width',
+    borderColor: 'border-color',
+    fontSize: 'font-size',
+    fontWeight: 'font-weight',
+    fontFamily: 'font-family',
+    fontStyle: 'font-style',
+    letterSpacing: 'letter-spacing',
+    lineHeight: 'line-height',
+    textDecorationLine: 'text-decoration-line',
+    textTransform: 'text-transform',
+};
+
+/**
+ * The utility families the LAYOUT half owns, so this one can name them.
+ *
+ * Without this list a layout class is indistinguishable from a typo, and the error
+ * a user gets says "unknown utility `flex-1`" — which sends them looking for a
+ * spelling mistake that is not there. The distinction costs one array.
+ */
+const LAYOUT_FAMILIES: ReadonlySet<string> = new Set([
+    'flex',
+    'items',
+    'justify',
+    'self',
+    'gap',
+    'm',
+    'mt',
+    'mr',
+    'mb',
+    'ml',
+    'mx',
+    'my',
+    'p',
+    'pt',
+    'pr',
+    'pb',
+    'pl',
+    'px',
+    'py',
+    'w',
+    'h',
+    'absolute',
+    'relative',
+    'top',
+    'right',
+    'bottom',
+    'left',
+    'inset',
+    'overflow',
+    'hidden',
+    'grow',
+    'shrink',
+    'basis',
+]);
+
+/** A utility class this vocabulary cannot answer for, and why. */
+export class UnknownUtilityError extends Error {
+    override readonly name = 'UnknownUtilityError';
+    readonly utility: string;
+    constructor(utility: string, detail: string) {
+        super(`@gjsify/gtk-host/style: "${utility}" — ${detail}`);
+        this.utility = utility;
+    }
+}
+
+const lookup = (scale: Scale | undefined, token: string): string | undefined => scale?.[token];
+
+/**
+ * Apply an `/alpha` modifier to a colour value.
+ *
+ * `bg-always-dark/70` is ordinary in a real vocabulary and cannot be pre-resolved:
+ * the base colour is a token and the alpha is per use site. GTK CSS has `alpha()`,
+ * which takes any colour expression — including the `rgb(var(--…))` shape a token
+ * file emits — so this composes rather than parsing the colour apart.
+ */
+const withAlpha = (value: string, alpha: string): string => {
+    const percent = Number(alpha);
+    if (!Number.isFinite(percent) || percent < 0 || percent > 100) {
+        throw new UnknownUtilityError(`${value}/${alpha}`, `the alpha modifier must be 0–100, got "${alpha}"`);
+    }
+    return `alpha(${value}, ${percent / 100})`;
+};
+
+/**
+ * One utility class → the properties it sets.
+ *
+ * Returns a partial record rather than mutating, so a caller can see what a single
+ * class contributed — which is what makes the conflict rule below testable.
+ */
+export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps {
+    // Variants (`active:opacity-70`, `dark:bg-x`) are not this function's business:
+    // they select WHEN a declaration applies, which is a CSS pseudo-class or a
+    // scheme, and the caller strips them before asking what the utility means.
+    if (utility.includes(':')) {
+        throw new UnknownUtilityError(
+            utility,
+            'strip the variant prefix before resolving; this resolves the utility itself',
+        );
+    }
+
+    const slash = utility.lastIndexOf('/');
+    const alpha = slash === -1 ? undefined : utility.slice(slash + 1);
+    const bare = slash === -1 ? utility : utility.slice(0, slash);
+
+    const colour = (value: string): string => (alpha === undefined ? value : withAlpha(value, alpha));
+    const noAlpha = (): void => {
+        if (alpha !== undefined)
+            throw new UnknownUtilityError(utility, 'an alpha modifier only applies to a colour utility');
+    };
+
+    // Bare families first: `border`, `rounded`, `underline` and friends carry no
+    // token and mean the scale's DEFAULT — Tailwind's own convention, and the one
+    // a token file already spells `DEFAULT`.
+    switch (bare) {
+        case 'underline':
+            noAlpha();
+            return { textDecorationLine: 'underline' };
+        case 'line-through':
+            noAlpha();
+            return { textDecorationLine: 'line-through' };
+        case 'no-underline':
+            noAlpha();
+            return { textDecorationLine: 'none' };
+        case 'uppercase':
+            noAlpha();
+            return { textTransform: 'uppercase' };
+        case 'lowercase':
+            noAlpha();
+            return { textTransform: 'lowercase' };
+        case 'capitalize':
+            noAlpha();
+            return { textTransform: 'capitalize' };
+        case 'normal-case':
+            noAlpha();
+            return { textTransform: 'none' };
+        case 'italic':
+            noAlpha();
+            return { fontStyle: 'italic' };
+        case 'not-italic':
+            noAlpha();
+            return { fontStyle: 'normal' };
+        case 'rounded':
+            noAlpha();
+            return { borderRadius: required(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius') };
+        case 'border':
+            noAlpha();
+            return { borderWidth: required(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') };
+    }
+
+    const dash = bare.indexOf('-');
+    const family = dash === -1 ? bare : bare.slice(0, dash);
+    const token = dash === -1 ? '' : bare.slice(dash + 1);
+
+    switch (family) {
+        case 'bg': {
+            return { backgroundColor: colour(required(tokens.colors, token, utility, 'colors')) };
+        }
+        case 'opacity': {
+            noAlpha();
+            return { opacity: required(tokens.opacity, token, utility, 'opacity') };
+        }
+        case 'rounded': {
+            noAlpha();
+            const corner = CORNERS[token];
+            if (corner !== undefined) {
+                return { [corner]: required(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius') } as PaintProps;
+            }
+            return { borderRadius: required(tokens.borderRadius, token, utility, 'borderRadius') };
+        }
+        case 'border': {
+            const side = BORDER_SIDES[token];
+            if (side !== undefined) {
+                noAlpha();
+                return { [side]: required(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') } as PaintProps;
+            }
+            // `border-<n>` is a width, `border-<colour>` is a colour, and the scales
+            // decide which — not a hard-coded list of colour names. A token in both
+            // scales is a project's own ambiguity and is reported as one.
+            const width = lookup(tokens.borderWidth, token);
+            const tint = lookup(tokens.colors, token);
+            if (width !== undefined && tint !== undefined) {
+                throw new UnknownUtilityError(
+                    utility,
+                    `"${token}" is in both the borderWidth and colors scales, so this utility is ambiguous`,
+                );
+            }
+            if (width !== undefined) {
+                noAlpha();
+                return { borderWidth: width };
+            }
+            if (tint !== undefined) return { borderColor: colour(tint) };
+            throw new UnknownUtilityError(utility, `"${token}" is in neither the borderWidth nor the colors scale`);
+        }
+        case 'text': {
+            // The genuinely ambiguous family, and the scales settle it: `text-sm` is
+            // a size, `text-grey-700` a colour — and `text-center` is NEITHER. It is
+            // alignment, which is not GTK CSS at all (measured: `No property named
+            // "text-align"`), so it belongs to the layout half.
+            if (ALIGNMENTS.has(token)) {
+                throw new UnknownUtilityError(
+                    utility,
+                    'text alignment is not GTK CSS — it becomes a widget property (Gtk.Label:xalign) and belongs to the layout half',
+                );
+            }
+            const size = lookup(tokens.fontSize, token);
+            const tint = lookup(tokens.colors, token);
+            if (size !== undefined && tint !== undefined) {
+                throw new UnknownUtilityError(
+                    utility,
+                    `"${token}" is in both the fontSize and colors scales, so this utility is ambiguous`,
+                );
+            }
+            if (size !== undefined) {
+                noAlpha();
+                return { fontSize: size };
+            }
+            if (tint !== undefined) return { color: colour(tint) };
+            throw new UnknownUtilityError(utility, `"${token}" is in neither the fontSize nor the colors scale`);
+        }
+        case 'font': {
+            noAlpha();
+            const weight = lookup(tokens.fontWeight, token);
+            const familyValue = lookup(tokens.fontFamily, token);
+            if (weight !== undefined && familyValue !== undefined) {
+                throw new UnknownUtilityError(
+                    utility,
+                    `"${token}" is in both the fontWeight and fontFamily scales, so this utility is ambiguous`,
+                );
+            }
+            if (weight !== undefined) return { fontWeight: weight };
+            if (familyValue !== undefined) return { fontFamily: familyValue };
+            throw new UnknownUtilityError(utility, `"${token}" is in neither the fontWeight nor the fontFamily scale`);
+        }
+        case 'tracking': {
+            noAlpha();
+            return { letterSpacing: required(tokens.letterSpacing, token, utility, 'letterSpacing') };
+        }
+        case 'leading': {
+            noAlpha();
+            return { lineHeight: required(tokens.lineHeight, token, utility, 'lineHeight') };
+        }
+    }
+
+    if (LAYOUT_FAMILIES.has(family) || LAYOUT_FAMILIES.has(bare)) {
+        throw new UnknownUtilityError(
+            utility,
+            'belongs to the layout half of the partition, which is not implemented yet',
+        );
+    }
+    throw new UnknownUtilityError(utility, 'is not a utility this vocabulary declares');
+}
+
+const CORNERS: Readonly<Record<string, keyof PaintProps>> = {
+    tl: 'borderTopLeftRadius',
+    tr: 'borderTopRightRadius',
+    bl: 'borderBottomLeftRadius',
+    br: 'borderBottomRightRadius',
+};
+
+const BORDER_SIDES: Readonly<Record<string, keyof PaintProps>> = {
+    t: 'borderTopWidth',
+    r: 'borderRightWidth',
+    b: 'borderBottomWidth',
+    l: 'borderLeftWidth',
+};
+
+const ALIGNMENTS: ReadonlySet<string> = new Set(['left', 'center', 'right', 'justify', 'start', 'end']);
+
+function required(scale: Scale | undefined, token: string, utility: string, scaleName: string): string {
+    const value = lookup(scale, token);
+    if (value !== undefined) return value;
+    const known = scale === undefined ? '(the scale is not configured)' : Object.keys(scale).sort().join(', ');
+    throw new UnknownUtilityError(utility, `"${token}" is not in the ${scaleName} scale. Known: ${known}`);
+}
+
+/**
+ * A class list → the properties it sets, later classes winning.
+ *
+ * Last-wins is CSS's own rule for equal specificity and the one authors expect from
+ * a utility vocabulary. It is done HERE, on the property record, rather than by
+ * emitting two declarations and letting GTK resolve them — GTK resolves equal
+ * specificity by SHEET ORDER, not by the order of names in `css-classes`, so
+ * "the later class wins" would be false the moment two generated classes met.
+ */
+export function resolveUtilities(utilities: readonly string[], tokens: StyleTokens): PaintProps {
+    const out: PaintProps = {};
+    for (const utility of utilities) Object.assign(out, resolveUtility(utility, tokens));
+    return out;
+}
+
+/** What the partition hands back. `props` and `intent` are the layout half's. */
+export interface Partitioned {
+    /** GTK CSS declarations, `property: value`, without the braces. */
+    readonly css: readonly string[];
+    /** Widget properties. Empty until the layout half exists. */
+    readonly props: Readonly<Record<string, unknown>>;
+    /** Placement intents L2 resolves against the parent. Empty until the layout half exists. */
+    readonly intent: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Properties → GTK CSS.
+ *
+ * Every emitted name is checked against the MEASURED accepted set rather than
+ * trusted: a property this table maps but GTK does not accept would be dropped by
+ * GTK's parser with no diagnostic, which is the exact silence the whole partition
+ * exists to avoid. The check is cheap and it has caught the one property that looks
+ * like paint and is not.
+ */
+export function partition(props: PaintProps): Partitioned {
+    const css: string[] = [];
+    for (const [key, value] of Object.entries(props)) {
+        if (value === undefined) continue;
+        const name = CSS_NAME[key as keyof PaintProps];
+        if (name === undefined) {
+            throw new UnknownUtilityError(key, 'is not a property the paint partition routes');
+        }
+        if (!GTK_CSS_PROPERTIES.has(name)) {
+            throw new UnknownUtilityError(key, `maps to "${name}", which GTK does not accept — see gtk-css.ts`);
+        }
+        css.push(`${name}: ${value}`);
+    }
+    return { css, props: {}, intent: {} };
+}

--- a/packages/framework/gtk-host/src/style/paint.ts
+++ b/packages/framework/gtk-host/src/style/paint.ts
@@ -12,12 +12,19 @@
 // WHAT THIS FILE REFUSES TO DO. It does not touch the layout half — `flex`, `items`,
 // `justify`, `gap`, spacing, positioning. Those become widget selection and widget
 // properties, and the interesting one (`flex-1` resolving to `hexpand` or `vexpand`
-// depending on the PARENT) cannot be answered here at all. Reaching a layout utility
-// is therefore an ERROR naming the milestone, never a silent drop: a styling layer
-// that quietly ignores half its input is invisible in CI and obvious on screen.
+// depending on the PARENT) cannot be answered here at all.
+//
+// It says so by returning `null`, NOT by throwing. The distinction is the whole
+// dispatch in `resolve.ts`: a family this half does not own is somebody else's
+// question, while a family it DOES own with a token no scale carries is an error
+// here and nowhere else. Collapsing the two would make `mt-2xs` and `bg-nonsuch`
+// the same diagnostic, and only one of them is a typo. What must never happen is
+// the third option — a silent drop — because a styling layer that quietly ignores
+// part of its input is invisible in CI and obvious on screen.
 
+import { UnknownUtilityError } from './errors.js';
 import { GTK_CSS_PROPERTIES } from './gtk-css.js';
-import type { Scale, StyleTokens } from './tokens.js';
+import { lookupToken, requireToken, type StyleTokens } from './tokens.js';
 
 /** The properties the paint half understands, in React Native's spelling. */
 export interface PaintProps {
@@ -78,61 +85,6 @@ export const CSS_NAME: Readonly<Record<keyof PaintProps, string>> = {
 };
 
 /**
- * The utility families the LAYOUT half owns, so this one can name them.
- *
- * Without this list a layout class is indistinguishable from a typo, and the error
- * a user gets says "unknown utility `flex-1`" — which sends them looking for a
- * spelling mistake that is not there. The distinction costs one array.
- */
-const LAYOUT_FAMILIES: ReadonlySet<string> = new Set([
-    'flex',
-    'items',
-    'justify',
-    'self',
-    'gap',
-    'm',
-    'mt',
-    'mr',
-    'mb',
-    'ml',
-    'mx',
-    'my',
-    'p',
-    'pt',
-    'pr',
-    'pb',
-    'pl',
-    'px',
-    'py',
-    'w',
-    'h',
-    'absolute',
-    'relative',
-    'top',
-    'right',
-    'bottom',
-    'left',
-    'inset',
-    'overflow',
-    'hidden',
-    'grow',
-    'shrink',
-    'basis',
-]);
-
-/** A utility class this vocabulary cannot answer for, and why. */
-export class UnknownUtilityError extends Error {
-    override readonly name = 'UnknownUtilityError';
-    readonly utility: string;
-    constructor(utility: string, detail: string) {
-        super(`@gjsify/gtk-host/style: "${utility}" — ${detail}`);
-        this.utility = utility;
-    }
-}
-
-const lookup = (scale: Scale | undefined, token: string): string | undefined => scale?.[token];
-
-/**
  * Apply an `/alpha` modifier to a colour value.
  *
  * `bg-always-dark/70` is ordinary in a real vocabulary and cannot be pre-resolved:
@@ -149,12 +101,12 @@ const withAlpha = (value: string, alpha: string): string => {
 };
 
 /**
- * One utility class → the properties it sets.
+ * One utility class → the paint properties it sets, or `null` for "not mine".
  *
  * Returns a partial record rather than mutating, so a caller can see what a single
- * class contributed — which is what makes the conflict rule below testable.
+ * class contributed — which is what makes the last-wins rule testable.
  */
-export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps {
+export function resolvePaintUtility(utility: string, tokens: StyleTokens): PaintProps | null {
     // Variants (`active:opacity-70`, `dark:bg-x`) are not this function's business:
     // they select WHEN a declaration applies, which is a CSS pseudo-class or a
     // scheme, and the caller strips them before asking what the utility means.
@@ -208,10 +160,10 @@ export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps
             return { fontStyle: 'normal' };
         case 'rounded':
             noAlpha();
-            return { borderRadius: required(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius') };
+            return { borderRadius: requireToken(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius') };
         case 'border':
             noAlpha();
-            return { borderWidth: required(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') };
+            return { borderWidth: requireToken(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') };
     }
 
     const dash = bare.indexOf('-');
@@ -220,31 +172,33 @@ export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps
 
     switch (family) {
         case 'bg': {
-            return { backgroundColor: colour(required(tokens.colors, token, utility, 'colors')) };
+            return { backgroundColor: colour(requireToken(tokens.colors, token, utility, 'colors')) };
         }
         case 'opacity': {
             noAlpha();
-            return { opacity: required(tokens.opacity, token, utility, 'opacity') };
+            return { opacity: requireToken(tokens.opacity, token, utility, 'opacity') };
         }
         case 'rounded': {
             noAlpha();
             const corner = CORNERS[token];
             if (corner !== undefined) {
-                return { [corner]: required(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius') } as PaintProps;
+                return {
+                    [corner]: requireToken(tokens.borderRadius, 'DEFAULT', utility, 'borderRadius'),
+                } as PaintProps;
             }
-            return { borderRadius: required(tokens.borderRadius, token, utility, 'borderRadius') };
+            return { borderRadius: requireToken(tokens.borderRadius, token, utility, 'borderRadius') };
         }
         case 'border': {
             const side = BORDER_SIDES[token];
             if (side !== undefined) {
                 noAlpha();
-                return { [side]: required(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') } as PaintProps;
+                return { [side]: requireToken(tokens.borderWidth, 'DEFAULT', utility, 'borderWidth') } as PaintProps;
             }
             // `border-<n>` is a width, `border-<colour>` is a colour, and the scales
             // decide which — not a hard-coded list of colour names. A token in both
             // scales is a project's own ambiguity and is reported as one.
-            const width = lookup(tokens.borderWidth, token);
-            const tint = lookup(tokens.colors, token);
+            const width = lookupToken(tokens.borderWidth, token);
+            const tint = lookupToken(tokens.colors, token);
             if (width !== undefined && tint !== undefined) {
                 throw new UnknownUtilityError(
                     utility,
@@ -262,15 +216,13 @@ export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps
             // The genuinely ambiguous family, and the scales settle it: `text-sm` is
             // a size, `text-grey-700` a colour — and `text-center` is NEITHER. It is
             // alignment, which is not GTK CSS at all (measured: `No property named
-            // "text-align"`), so it belongs to the layout half.
-            if (ALIGNMENTS.has(token)) {
-                throw new UnknownUtilityError(
-                    utility,
-                    'text alignment is not GTK CSS — it becomes a widget property (Gtk.Label:xalign) and belongs to the layout half',
-                );
-            }
-            const size = lookup(tokens.fontSize, token);
-            const tint = lookup(tokens.colors, token);
+            // "text-align"`), so it is the layout half's and is handed back
+            // UNCLAIMED. It used to throw a bespoke "belongs to the layout half"
+            // here, which was right while that half did not exist and is now a
+            // refusal of a utility the partition supports.
+            if (ALIGNMENTS.has(token)) return null;
+            const size = lookupToken(tokens.fontSize, token);
+            const tint = lookupToken(tokens.colors, token);
             if (size !== undefined && tint !== undefined) {
                 throw new UnknownUtilityError(
                     utility,
@@ -286,8 +238,8 @@ export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps
         }
         case 'font': {
             noAlpha();
-            const weight = lookup(tokens.fontWeight, token);
-            const familyValue = lookup(tokens.fontFamily, token);
+            const weight = lookupToken(tokens.fontWeight, token);
+            const familyValue = lookupToken(tokens.fontFamily, token);
             if (weight !== undefined && familyValue !== undefined) {
                 throw new UnknownUtilityError(
                     utility,
@@ -300,21 +252,15 @@ export function resolveUtility(utility: string, tokens: StyleTokens): PaintProps
         }
         case 'tracking': {
             noAlpha();
-            return { letterSpacing: required(tokens.letterSpacing, token, utility, 'letterSpacing') };
+            return { letterSpacing: requireToken(tokens.letterSpacing, token, utility, 'letterSpacing') };
         }
         case 'leading': {
             noAlpha();
-            return { lineHeight: required(tokens.lineHeight, token, utility, 'lineHeight') };
+            return { lineHeight: requireToken(tokens.lineHeight, token, utility, 'lineHeight') };
         }
     }
 
-    if (LAYOUT_FAMILIES.has(family) || LAYOUT_FAMILIES.has(bare)) {
-        throw new UnknownUtilityError(
-            utility,
-            'belongs to the layout half of the partition, which is not implemented yet',
-        );
-    }
-    throw new UnknownUtilityError(utility, 'is not a utility this vocabulary declares');
+    return null;
 }
 
 const CORNERS: Readonly<Record<string, keyof PaintProps>> = {
@@ -333,40 +279,11 @@ const BORDER_SIDES: Readonly<Record<string, keyof PaintProps>> = {
 
 const ALIGNMENTS: ReadonlySet<string> = new Set(['left', 'center', 'right', 'justify', 'start', 'end']);
 
-function required(scale: Scale | undefined, token: string, utility: string, scaleName: string): string {
-    const value = lookup(scale, token);
-    if (value !== undefined) return value;
-    const known = scale === undefined ? '(the scale is not configured)' : Object.keys(scale).sort().join(', ');
-    throw new UnknownUtilityError(utility, `"${token}" is not in the ${scaleName} scale. Known: ${known}`);
-}
+/** The {@link PaintProps} keys, for the dispatch's ownership test. */
+export const PAINT_PROPERTIES: ReadonlySet<string> = new Set(Object.keys(CSS_NAME));
 
 /**
- * A class list → the properties it sets, later classes winning.
- *
- * Last-wins is CSS's own rule for equal specificity and the one authors expect from
- * a utility vocabulary. It is done HERE, on the property record, rather than by
- * emitting two declarations and letting GTK resolve them — GTK resolves equal
- * specificity by SHEET ORDER, not by the order of names in `css-classes`, so
- * "the later class wins" would be false the moment two generated classes met.
- */
-export function resolveUtilities(utilities: readonly string[], tokens: StyleTokens): PaintProps {
-    const out: PaintProps = {};
-    for (const utility of utilities) Object.assign(out, resolveUtility(utility, tokens));
-    return out;
-}
-
-/** What the partition hands back. `props` and `intent` are the layout half's. */
-export interface Partitioned {
-    /** GTK CSS declarations, `property: value`, without the braces. */
-    readonly css: readonly string[];
-    /** Widget properties. Empty until the layout half exists. */
-    readonly props: Readonly<Record<string, unknown>>;
-    /** Placement intents L2 resolves against the parent. Empty until the layout half exists. */
-    readonly intent: Readonly<Record<string, unknown>>;
-}
-
-/**
- * Properties → GTK CSS.
+ * Paint properties → GTK CSS declarations.
  *
  * Every emitted name is checked against the MEASURED accepted set rather than
  * trusted: a property this table maps but GTK does not accept would be dropped by
@@ -374,7 +291,7 @@ export interface Partitioned {
  * exists to avoid. The check is cheap and it has caught the one property that looks
  * like paint and is not.
  */
-export function partition(props: PaintProps): Partitioned {
+export function partitionPaint(props: PaintProps): readonly string[] {
     const css: string[] = [];
     for (const [key, value] of Object.entries(props)) {
         if (value === undefined) continue;
@@ -387,5 +304,5 @@ export function partition(props: PaintProps): Partitioned {
         }
         css.push(`${name}: ${value}`);
     }
-    return { css, props: {}, intent: {} };
+    return css;
 }

--- a/packages/framework/gtk-host/src/style/resolve.ts
+++ b/packages/framework/gtk-host/src/style/resolve.ts
@@ -1,0 +1,112 @@
+// The dispatch: one utility vocabulary over two halves that do not know each other.
+//
+// `paint.ts` and `layout.ts` each answer for the families they own and return
+// `null` for everything else. Neither imports the other, and neither has a list of
+// the other's families — which is the point. The first version of this seam had
+// exactly that list (`LAYOUT_FAMILIES`, in the paint half) so that a layout utility
+// could get a better error than "unknown". It worked, and it was a second copy of
+// the layout vocabulary living in the file least likely to be edited when the
+// layout vocabulary changed.
+//
+// So the error moves here instead: a utility neither half claims is the only thing
+// this module throws, and it can say so because it is the only module that knows
+// both answers were `null`.
+
+import { UnknownUtilityError } from './errors.js';
+import {
+    LAYOUT_PROPERTIES,
+    type LayoutIntent,
+    type LayoutProps,
+    partitionLayout,
+    resolveLayoutUtility,
+} from './layout.js';
+import { PAINT_PROPERTIES, type PaintProps, partitionPaint, resolvePaintUtility } from './paint.js';
+import type { StyleTokens } from './tokens.js';
+
+/** One normalised property set, in React Native's spelling (ADR 0032 § 4). */
+export type StyleProps = PaintProps & LayoutProps;
+
+/** What the partition hands back — GTK's three destinations, all of them. */
+export interface Partitioned {
+    /** GTK CSS declarations, `property: value`, without the braces. */
+    readonly css: readonly string[];
+    /**
+     * Widget properties in GTK's own spelling, with values the host will apply.
+     *
+     * The values are what `applyProps` coerces through the ParamSpec — a nick for
+     * an enum, a boolean for a boolean, an integer for a `gint`. NOT what a raw
+     * GJS setter accepts: `box.orientation = 'vertical'` keeps HORIZONTAL with no
+     * diagnostic at all (measured, gjs 1.88.1), which is the whole reason the host
+     * has a coercion step.
+     */
+    readonly props: Readonly<Record<string, unknown>>;
+    /** What only the shadow tree can answer, for L2 at attach time. */
+    readonly intent: LayoutIntent;
+}
+
+/**
+ * One utility class → the properties it sets.
+ *
+ * Paint runs first, and the order is not arbitrary: the paint families are closed
+ * sets of scale names, so its `null` is a cheap "no such family here", while the
+ * layout half owns the open-ended spellings (`gap-x-4`, `w-1/2`) whose parsing is
+ * where a wrong claim would be expensive.
+ */
+export function resolveUtility(utility: string, tokens: StyleTokens): StyleProps {
+    const paint = resolvePaintUtility(utility, tokens);
+    if (paint !== null) return paint;
+    const layout = resolveLayoutUtility(utility, tokens);
+    if (layout !== null) return layout;
+    throw new UnknownUtilityError(utility, 'is not a utility this vocabulary declares');
+}
+
+/**
+ * A class list → the properties it sets, later classes winning.
+ *
+ * Last-wins is CSS's own rule for equal specificity and the one authors expect from
+ * a utility vocabulary. It is done HERE, on the property record, rather than by
+ * emitting two declarations and letting GTK resolve them — GTK resolves equal
+ * specificity by SHEET ORDER, not by the order of names in `css-classes`, so
+ * "the later class wins" would be false the moment two generated classes met.
+ *
+ * It is also why `m-*` puts its horizontal half in the same KEYS as `mx-*`: two
+ * spellings of one edge only resolve by last-wins while they are one key.
+ */
+export function resolveUtilities(utilities: readonly string[], tokens: StyleTokens): StyleProps {
+    const out: StyleProps = {};
+    for (const utility of utilities) Object.assign(out, resolveUtility(utility, tokens));
+    return out;
+}
+
+/**
+ * Properties → `{ css, props, intent }`.
+ *
+ * Splits the record by ownership and hands each half to its own partition, because
+ * the layout half's refusals are CROSS-KEY (a physical and a logical margin
+ * together, two gap spellings at once) and it can only see them with its whole
+ * share in hand.
+ *
+ * A property NEITHER half routes throws rather than being skipped. That is the same
+ * rule as an unknown utility, one layer down, and it is the one that catches a
+ * `style={{…}}` object carrying a React Native property nobody has mapped yet —
+ * the front end with no class name to check.
+ */
+export function partition(props: StyleProps): Partitioned {
+    const paint: PaintProps = {};
+    const layout: LayoutProps = {};
+    for (const [key, value] of Object.entries(props)) {
+        if (value === undefined) continue;
+        const half = PAINT_PROPERTIES.has(key) ? paint : LAYOUT_PROPERTIES.has(key) ? layout : null;
+        if (half === null) {
+            throw new UnknownUtilityError(key, 'is not a property the style partition routes');
+        }
+        (half as Record<string, unknown>)[key] = value;
+    }
+
+    const laidOut = partitionLayout(layout);
+    return {
+        css: [...partitionPaint(paint), ...laidOut.css],
+        props: laidOut.props,
+        intent: laidOut.intent,
+    };
+}

--- a/packages/framework/gtk-host/src/style/tokens.ts
+++ b/packages/framework/gtk-host/src/style/tokens.ts
@@ -1,0 +1,49 @@
+// The design-token scales a utility class resolves against.
+//
+// ADR 0032 § 3: the FAMILIES are enumerable and declared here; the VALUES are not,
+// because they belong to the project. `mt-2xs` and `bg-emphasis` are not Tailwind
+// defaults — they are a generated token file, and a compiler that hard-coded the
+// scales would cover one application and refuse the next one's vocabulary as a typo.
+//
+// So this module declares the SHAPE of the scales and nothing else. Where they come
+// from is the consumer's business: a Tailwind config, a token JSON, or a literal
+// written by hand. Nothing here reads a file.
+
+/** A scale: token name → the CSS value it stands for. */
+export type Scale = Readonly<Record<string, string>>;
+
+/**
+ * Every scale the paint half consults.
+ *
+ * All optional: a project that has no `letterSpacing` scale simply has no
+ * `tracking-*` utilities, and asking for one is an error naming the empty scale
+ * rather than a silent no-op.
+ */
+export interface StyleTokens {
+    readonly colors?: Scale;
+    readonly borderRadius?: Scale;
+    readonly borderWidth?: Scale;
+    readonly fontSize?: Scale;
+    readonly fontWeight?: Scale;
+    readonly fontFamily?: Scale;
+    readonly letterSpacing?: Scale;
+    readonly lineHeight?: Scale;
+    readonly opacity?: Scale;
+}
+
+/**
+ * A minimal set, for tests and for a consumer who has no token file yet.
+ *
+ * Deliberately SMALL rather than a copy of Tailwind's defaults. A large default
+ * scale would let a project's typo resolve against a value nobody chose, which is
+ * the failure the declared-vocabulary rule exists to prevent — and it would make
+ * "the values come from the project" false in the common case.
+ */
+export const MINIMAL_TOKENS: StyleTokens = {
+    colors: { transparent: 'transparent', black: 'rgb(0 0 0)', white: 'rgb(255 255 255)' },
+    borderRadius: { none: '0', sm: '2px', DEFAULT: '4px', md: '6px', lg: '8px', full: '9999px' },
+    borderWidth: { DEFAULT: '1px', '0': '0', '2': '2px', '4': '4px' },
+    fontSize: { sm: '12px', base: '14px', lg: '18px', xl: '24px' },
+    fontWeight: { normal: '400', medium: '500', semibold: '600', bold: '700' },
+    opacity: { '0': '0', '50': '0.5', '60': '0.6', '70': '0.7', '80': '0.8', '90': '0.9', '100': '1' },
+};

--- a/packages/framework/gtk-host/src/style/tokens.ts
+++ b/packages/framework/gtk-host/src/style/tokens.ts
@@ -5,21 +5,42 @@
 // defaults — they are a generated token file, and a compiler that hard-coded the
 // scales would cover one application and refuse the next one's vocabulary as a typo.
 //
-// So this module declares the SHAPE of the scales and nothing else. Where they come
-// from is the consumer's business: a Tailwind config, a token JSON, or a literal
-// written by hand. Nothing here reads a file.
+// So this module declares the SHAPE of the scales and how a token is READ out of
+// one, and nothing else. Where the scales come from is the consumer's business: a
+// Tailwind config, a token JSON, or a literal written by hand. Nothing here reads
+// a file.
+
+import { UnknownUtilityError } from './errors.js';
 
 /** A scale: token name → the CSS value it stands for. */
 export type Scale = Readonly<Record<string, string>>;
 
 /**
- * Every scale the paint half consults.
+ * Every scale the partition consults.
  *
  * All optional: a project that has no `letterSpacing` scale simply has no
  * `tracking-*` utilities, and asking for one is an error naming the empty scale
  * rather than a silent no-op.
  */
 export interface StyleTokens {
+    /**
+     * The one scale `m-*`, `p-*`, `gap-*`, `inset-*` and the edge utilities read.
+     *
+     * ONE scale for all of them because that is what a token file actually holds —
+     * `mt-2xs` and `gap-2xs` name the same 2xs — and splitting it would ask a
+     * project to repeat itself once per family.
+     *
+     * A value only reaches the WIDGET-PROPERTY channel if it is a pixel length:
+     * `margin-top` is a `gint` of device pixels (measured, `gtk-props.ts`) and GTK
+     * exposes no unit conversion there. A scale spelled in `rem` therefore still
+     * works for padding, which is CSS-only, and is a named error on a margin rather
+     * than a silently rounded one.
+     */
+    readonly spacing?: Scale;
+    /** `w-<token>`, falling back to {@link StyleTokens.spacing} — Tailwind's own layering. */
+    readonly width?: Scale;
+    /** `h-<token>`, falling back to {@link StyleTokens.spacing}. */
+    readonly height?: Scale;
     readonly colors?: Scale;
     readonly borderRadius?: Scale;
     readonly borderWidth?: Scale;
@@ -40,6 +61,9 @@ export interface StyleTokens {
  * "the values come from the project" false in the common case.
  */
 export const MINIMAL_TOKENS: StyleTokens = {
+    // Two entries, and both earn their place: `0` is what `inset-0` needs and `px`
+    // is what a hairline needs. Everything between them is the project's to name.
+    spacing: { '0': '0px', px: '1px' },
     colors: { transparent: 'transparent', black: 'rgb(0 0 0)', white: 'rgb(255 255 255)' },
     borderRadius: { none: '0', sm: '2px', DEFAULT: '4px', md: '6px', lg: '8px', full: '9999px' },
     borderWidth: { DEFAULT: '1px', '0': '0', '2': '2px', '4': '4px' },
@@ -47,3 +71,21 @@ export const MINIMAL_TOKENS: StyleTokens = {
     fontWeight: { normal: '400', medium: '500', semibold: '600', bold: '700' },
     opacity: { '0': '0', '50': '0.5', '60': '0.6', '70': '0.7', '80': '0.8', '90': '0.9', '100': '1' },
 };
+
+/** A token's value, or `undefined` when the scale is absent or does not carry it. */
+export const lookupToken = (scale: Scale | undefined, token: string): string | undefined => scale?.[token];
+
+/**
+ * A token's value, or a named error that lists what the scale DOES hold.
+ *
+ * Both halves of the partition read scales, so the reader lives with the scales
+ * rather than in whichever half needed it first. Listing the known keys is the
+ * whole value of the message: "not in the borderRadius scale" turns a typo into a
+ * search, "Known: full, lg, md, none, sm" turns it into a one-line fix.
+ */
+export function requireToken(scale: Scale | undefined, token: string, utility: string, scaleName: string): string {
+    const value = lookupToken(scale, token);
+    if (value !== undefined) return value;
+    const known = scale === undefined ? '(the scale is not configured)' : Object.keys(scale).sort().join(', ');
+    throw new UnknownUtilityError(utility, `"${token}" is not in the ${scaleName} scale. Known: ${known}`);
+}

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -9,8 +9,12 @@ import generatedSuite from './generated.spec.js';
 import generatorSuite from './generator.spec.js';
 import hostSuite from './host.spec.js';
 import propsSuite from './props.spec.js';
+import gtkCssSuite from './style/gtk-css.spec.js';
+import paintSuite from './style/paint.spec.js';
 
 run({
+    paintSuite,
+    gtkCssSuite,
     buildableSuite,
     propsSuite,
     hostSuite,

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -10,11 +10,15 @@ import generatorSuite from './generator.spec.js';
 import hostSuite from './host.spec.js';
 import propsSuite from './props.spec.js';
 import gtkCssSuite from './style/gtk-css.spec.js';
+import gtkPropsSuite from './style/gtk-props.spec.js';
+import layoutSuite from './style/layout.spec.js';
 import paintSuite from './style/paint.spec.js';
 
 run({
     paintSuite,
+    layoutSuite,
     gtkCssSuite,
+    gtkPropsSuite,
     buildableSuite,
     propsSuite,
     hostSuite,


### PR DESCRIPTION
**Stacked on #1347 → #1345 → #1344.** Re-target down the chain as each merges; do not merge a base with `--delete-branch`.

M3 of ADR 0032. `@gjsify/gtk-host/style` turns a utility class vocabulary into a normalised property record and partitions it into GTK CSS. Pure TypeScript — no display, no widget — which is the point of putting the seam here rather than in the React Native package.

## Which properties GTK accepts is measured, not read

`gtk-css.ts` holds the answer as data; `gtk-css.spec.ts` re-measures it against a real `Gtk.CssProvider` **in both directions**. The negative direction is the load-bearing one: without it the table could list every property in CSS and still pass.

Two results are carried because both look like mistakes:

- **`text-align` is not GTK CSS.** It reads like paint and is a widget property (`Gtk.Label:xalign`). A `text-*` vocabulary that groups it with `color` and `font-size` emits a declaration GTK drops in silence.
- **`margin` and `padding` *are* accepted**, so spacing has two routes on GTK — a CSS declaration or the widget's own properties. They are not equivalent, and choosing between them is the layout half's decision.

## Two measurement mistakes of mine, recorded rather than quietly fixed

1. The first probe used the **serialised round-trip** as its oracle and reported `border-radius` as rejected. GTK *expands* shorthands, so the substring was never going to be there. The `parsing-error` signal is the authority.
2. The invariant spec then caught the second on its first run: the table proved `border-top-left-radius` and left three corners and three sides to the shorthand, **while the partition mapped all eight**. A mapping is only proven for the exact name it emits.

## The scales belong to the project

Families are declared here; values come from the consumer's token file. So `text-s` is a size and `text-grey-700` a colour **because the scales say so** — and a token in both scales is reported as ambiguous rather than silently resolved one way. A missing token names the scale and lists its contents.

`bg-always-dark/70` composes through GTK's own `alpha()`, because the base colour may be a `rgb(var(--…))` expression a token file emitted and cannot be parsed apart.

## A layout utility is told apart from a typo

Both throw. Only one of them sends the reader looking for a spelling mistake that is not there.

1968 tests green; `verify-package-outputs` green with the new `./style` subpath.