### PR TITLE
fix(react-native): three claims about the table that the table disproves

### DIFF
--- a/packages/framework/react-native/src/support-table.ts
+++ b/packages/framework/react-native/src/support-table.ts
@@ -404,6 +404,9 @@ export const SUPPORT_TABLE: Readonly<Record<string, SupportEntry>> = {
         status: 'refused',
         reason: 'GTK has no pull-to-refresh idiom and should not grow one. Give the desktop build a refresh action instead.',
     },
+
+    // --- P3: the long tail ----------------------------------------------------
+
     AppState: {
         status: 'planned',
         tier: 'P3',
@@ -422,8 +425,6 @@ export const SUPPORT_TABLE: Readonly<Record<string, SupportEntry>> = {
         gtk: 'Adwaita named colours',
         reason: 'Maps unusually well — GTK’s palette is exactly this idea.',
     },
-
-    // --- P3: the long tail ----------------------------------------------------
 
     AccessibilityInfo: {
         status: 'planned',

--- a/scripts/check-rn-surface.mjs
+++ b/scripts/check-rn-surface.mjs
@@ -59,6 +59,51 @@ export function readTableKeys(source) {
     return keys;
 }
 
+/**
+ * Entries whose declared `tier` disagrees with the `// --- Pn: … ---` banner
+ * they sit under.
+ *
+ * The banners are the only thing a reader SKIMMING this file has to go on, and
+ * they are a second statement of the same fact — so they drift. Measured: three
+ * entries (`AppState`, `PixelRatio`, `PlatformColor`) carried `tier: 'P3'` while
+ * sitting above the P3 banner, so the data was right and the file read wrong.
+ * Nothing at runtime could see it: `explainUnsupported` reads the field, not the
+ * comment.
+ *
+ * Reported as a list rather than thrown, like every other comparison here.
+ */
+export function tierSectionMismatches(source) {
+    const out = [];
+    let section = null;
+    let open = null;
+    for (const line of source.split('\n')) {
+        const banner = /^\s*\/\/ --- (P\d+):/.exec(line);
+        if (banner !== null) {
+            section = banner[1];
+            open = null;
+            continue;
+        }
+        if (open === null) {
+            const start = /^ {4}(\w+): \{/.exec(line);
+            if (start === null) continue;
+            open = { name: start[1], tier: null };
+            // A one-line entry opens and closes on the same line.
+            const inline = /tier: '(P\d+)'/.exec(line);
+            if (inline !== null) open.tier = inline[1];
+            if (!/\},\s*$/.test(line)) continue;
+        } else {
+            const tier = /^\s*tier: '(P\d+)'/.exec(line);
+            if (tier !== null) open.tier = tier[1];
+            if (!/^ {4}\},\s*$/.test(line)) continue;
+        }
+        if (section !== null && open.tier !== null && open.tier !== section) {
+            out.push(`${open.name} declares tier ${open.tier} but sits under the ${section} banner`);
+        }
+        open = null;
+    }
+    return out;
+}
+
 // --- self-test ---------------------------------------------------------------
 //
 // Six vectors. The three negatives are what make this a gate rather than a
@@ -66,7 +111,13 @@ export function readTableKeys(source) {
 // would report a surface that does not exist and pass every real comparison.
 
 function selfTest() {
+    // COUNTED, never written down. The summary line below used to print a literal
+    // `7`, which is a claim about this function that this function does not make —
+    // add a vector and the gate reports the old number, remove one and it reports a
+    // vector that no longer runs. Both read as "the self-test is unchanged".
+    let vectors = 0;
     const ok = (name, actual, expected) => {
+        vectors++;
         const a = JSON.stringify(actual);
         const e = JSON.stringify(expected);
         if (a !== e) fail(`self-test ${name}: expected ${e}, got ${a}`);
@@ -102,7 +153,43 @@ function selfTest() {
     } catch {
         threw = true;
     }
+    vectors++;
     if (!threw) fail('self-test: a source without the declaration must throw, not return []');
+
+    // The banner check, both directions. The negatives matter more than the
+    // positive: a scanner that reported every entry, or none, would be green here
+    // and useless against the file.
+    const sectioned = (inner) => `    // --- P2: x ---\n${inner}\n    // --- P3: y ---\n`;
+    ok(
+        'a tier that disagrees with its banner is reported',
+        tierSectionMismatches(sectioned(`    Foo: {\n        tier: 'P3',\n    },`)),
+        ['Foo declares tier P3 but sits under the P2 banner'],
+    );
+    ok(
+        'a tier that agrees with its banner is not',
+        tierSectionMismatches(sectioned(`    Foo: {\n        tier: 'P2',\n    },`)),
+        [],
+    );
+    ok(
+        'an entry with no tier is not reported',
+        tierSectionMismatches(sectioned(`    Foo: {\n        status: 'refused',\n    },`)),
+        [],
+    );
+    ok('a one-line entry is read too', tierSectionMismatches(sectioned(`    Foo: { tier: 'P3' },`)), [
+        'Foo declares tier P3 but sits under the P2 banner',
+    ]);
+    ok(
+        'a tier inside a NESTED object is not the entry’s own',
+        tierSectionMismatches(sectioned(`    Foo: {\n        limits: { tier: 'P3' },\n        tier: 'P2',\n    },`)),
+        [],
+    );
+    ok(
+        'an entry before any banner is not judged',
+        tierSectionMismatches(`    Foo: {\n        tier: 'P3',\n    },\n`),
+        [],
+    );
+
+    return vectors;
 }
 
 // --- the comparisons ---------------------------------------------------------
@@ -142,10 +229,21 @@ function readInstalledExports() {
     return [...names];
 }
 
-selfTest();
+const selfTestVectors = selfTest();
 
 const snapshot = JSON.parse(readFileSync(SNAPSHOT, 'utf8'));
-const declared = readTableKeys(readFileSync(TABLE_TS, 'utf8'));
+const tableSource = readFileSync(TABLE_TS, 'utf8');
+const declared = readTableKeys(tableSource);
+
+// The banners are a second statement of each entry's tier, so they drift; nothing
+// at runtime can see it, because the sentence reads the field and not the comment.
+const misfiled = tierSectionMismatches(tableSource);
+if (misfiled.length > 0) {
+    fail(
+        `${misfiled.length} entr${misfiled.length === 1 ? 'y sits' : 'ies sit'} under the wrong tier banner — ` +
+            `${misfiled.join('; ')}\n  The data is right and the file READS wrong: move the entry, or move the banner.`,
+    );
+}
 const snapshotNames = snapshot.exports;
 
 compare(
@@ -207,6 +305,6 @@ if (problems.length > 0) {
     console.error(`${label}: FAILED — ${mode}`);
     process.exit(1);
 }
-console.log(`${label}: self-test green — 7 vector(s).`);
+console.log(`${label}: self-test green — ${selfTestVectors} vector(s).`);
 console.log(`${label}: ${declared.length} React Native export(s) all carry a support status.`);
 console.log(`${label}: ${mode}.`);

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -118,17 +118,21 @@ and the table is exported (`SUPPORT_TABLE`, `SUPPORTED_NAMES`, `explainUnsupport
 ### An unimplemented name refuses; it is not absent
 
 Omitting a name would already be loud — a bundler reports `MISSING_EXPORT`. But what it reports is
-"this package does not export `FlatList`", which sends you to check your spelling. The table knows
-something better: that `FlatList` is tier P2, that it maps onto `Gtk.ListView` with a real
-`Gio.ListStore` behind it, and that it is not built yet.
+"this package does not export `Animated`", which sends you to check your spelling. The table knows
+something better: that `Animated` is tier P3, that it maps onto `Adw.TimedAnimation` and
+`Adw.SpringAnimation`, and that it is not built yet.
 
 So every unimplemented name is exported as a value that refuses with the table's sentence:
 
 ```
-@gjsify/react-native: "FlatList" is not implemented yet (tier P2). GTK virtualises for
-real, so this fits better here than it does on the web. The GTK counterpart is
-Gtk.ListView + Gio.ListStore.
+@gjsify/react-native: "Animated" is not implemented yet (tier P3). Genuinely mappable,
+but it is a subsystem rather than a component. Doing it badly is worse than not doing
+it. The GTK counterpart is Adw.TimedAnimation / Adw.SpringAnimation.
 ```
+
+The example above used to be `FlatList`, which is the warning two paragraphs up making itself:
+`FlatList` shipped, its sentence became `"FlatList" is available.`, and the illustration was
+quietly false. **Any name on this page can move; the README's generated listing cannot.**
 
 It throws on **property access**, not only on call, because `Animated.timing` and
 `NativeModules.Foo` are property reads — and a module that reads one during its own evaluation


### PR DESCRIPTION
Three statements about `@gjsify/react-native`'s support table that the table disproves — two of them the same shape as the defects #1351 fixed: a claim about the table, kept somewhere the table cannot reach.

### 1. The website illustrated a refusal with a name that now ships

`frameworks/react-native.mdx` printed the refusal sentence for `FlatList` — *"is not implemented yet (tier P2) … The GTK counterpart is Gtk.ListView + Gio.ListStore"*. `FlatList` landed in #1353, so `explainUnsupported('FlatList')` now answers `"FlatList" is available.` and the whole subsection was quietly false.

Two paragraphs above it, the page says **"this page can go stale on its own"**. It then did. The example is now `Animated` — P3, and a subsystem rather than a component, so it will not move soon — the quoted sentence is the table's current one, and the rot is written down where the next reader hits it rather than deleted.

### 2. Three entries sat under the wrong tier banner

`AppState`, `PixelRatio` and `PlatformColor` carry `tier: 'P3'` while sitting above the `// --- P3 ---` banner. The data was right and the file **read** wrong, so nothing at runtime could see it: `explainUnsupported` reads the field, not the comment. Only a reader skimming the file is misled, and that is what the banners are for.

The banner moved, and `tierSectionMismatches()` in `check-rn-surface.mjs` now holds the two against each other.

**Control-probed** — with the banner where it was:

```
check-rn-surface: 3 entries sit under the wrong tier banner — AppState declares tier P3
  but sits under the P2 banner; PixelRatio declares tier P3 but sits under the P2 banner;
  PlatformColor declares tier P3 but sits under the P2 banner
  The data is right and the file READS wrong: move the entry, or move the banner.
```

### 3. The gate printed a self-test count it did not measure

`check-rn-surface.mjs` said `self-test green — 7 vector(s)` from a literal `7`. That is a claim about the self-test which the self-test does not make: add a vector and it reports the old number, remove one and it reports a vector that no longer runs — **both read as "unchanged"**. It counts now, and says 13, because this change adds six.

The six are the banner check in both directions, and the negatives are the point: a `tier:` inside a **nested** object is not the entry's own, an entry with no tier is not judged, and an entry before any banner is not judged either. A scanner that reported everything, or nothing, would be green against a positive-only self-test and useless against the real file.

---

Local gates: `check-rn-surface` green (13 vectors), `gjsify lint` exit 0, react-native 656 tests green. The generated README and `unsupported-exports.ts` are byte-identical after the move — the entries kept their order, only the comment travelled.
