### PR TITLE
docs(react-native): routing, the second tier, and the build opt-in

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -139,6 +139,7 @@ export default defineConfig({
                         { slug: 'frameworks/vue', label: 'Vue' },
                         { slug: 'frameworks/react', label: 'React' },
                         { slug: 'frameworks/react-native', label: 'React Native' },
+                        { slug: 'frameworks/react-native-routing', label: 'React Native: routing' },
                         { slug: 'frameworks/styling', label: 'Styling on GTK' },
                     ],
                 },

--- a/website/src/content/docs/frameworks/react-native-routing.mdx
+++ b/website/src/content/docs/frameworks/react-native-routing.mdx
@@ -1,0 +1,207 @@
+---
+title: React Native routing
+description: expo-router's surface over Adw.NavigationView — the join key that makes a route a widget, the reverse direction a gesture needs, and the file convention that decides which module is a screen.
+---
+
+`@gjsify/react-native/router` is the `expo-router` surface, and it is the subpath a
+bundler aliases `expo-router` to the same way `.` is what it aliases `react-native` to.
+Five `expo-router` names are implemented: `router`, `usePathname`,
+`useLocalSearchParams`, `Stack` and `Tabs`.
+Everything else in the routing table is `planned` or `refused` and exported as a value
+that refuses with the table's own sentence, exactly as in the main entry.
+
+Two exports are not expo-router names and are public anyway. The first is
+`<RouterRoot manifest={…}/>`.
+`expo-router`'s entry is a module side effect that registers a root against a
+`require.context`, and neither half of that exists here — `require.context` is a Metro
+feature, and the root component is created by `AppRegistry` because on a desktop the
+application *is* the process. So the manifest arrives as a prop.
+
+The second is `navigationRef`, React Navigation's own imperative handle, re-exported
+rather than hidden: `router` covers the ordinary cases, and an application that needs
+something React Navigation can do and `expo-router` does not spell should reach the real
+object rather than a thinner copy of it.
+
+**Full `expo-router` compatibility is refused, and the reason is a dependency list.** It
+drags React Navigation's own peers — `react-native-screens`, `gesture-handler` — which
+nothing here imports. Reproducing a dependency cloud nobody calls is not compatibility.
+
+### React Navigation is a peer, not a dependency
+
+`@react-navigation/core ^7.21.13` and `@react-navigation/routers ^7.6.4`, both declared
+**optional peers** alongside `react` and `react-reconciler`. React Navigation 7's `core`
+and `routers` run unmodified without React Native, and they answer every state and URL
+question this layer has: the routers and actions, the contexts, `getStateFromPath`,
+`getPathFromState`, `getActionFromState`, `useNavigationBuilder`, `usePreventRemove`.
+Reusing them rather than writing a second router is the decision — a URL matcher with
+nested navigators, params and a wildcard fallback is the part of a router with the most
+edge cases and the least novelty.
+
+A peer rather than a dependency because there must be exactly one copy of it in the
+tree: the application's own React Navigation is what the container, the contexts and any
+`usePreventRemove` in application code all have to be. An optional peer is not enforced
+on install, so mind the ranges the same way the [React page](/gjsify/frameworks/react/)
+says to.
+
+It is `BaseNavigationContainer` and not `NavigationContainer`. The latter lives in
+`@react-navigation/native`, which depends on React Native — the dependency the design
+refuses. What it adds over the base is linking, theming and back-button handling for a
+phone: linking is the three upstream functions above, theming is Adwaita's, and the back
+button is `Adw.NavigationView`'s own.
+
+What this package writes is the file convention, the two widget bindings, and the three
+things upstream cannot know — which GTK operation a stack diff is, what the widget's own
+`popped` means, and how long a closing page has to stay mounted.
+
+### The file convention is four rules, and it lives in the runtime package
+
+```
+(group)      groups without contributing a URL segment
+[param]      a dynamic segment; its value lands in useLocalSearchParams()
+_layout      the file that OWNS its directory — it renders the navigator
++not-found   the fallback route
+```
+
+No fifth rule is inferred. A directory with **no** `_layout` is not a navigator: its
+routes flatten into the nearest ancestor that is one, under a slash-joined name, which
+is why `detail/[id].tsx` needs no `detail/_layout.tsx`. Recorded because the opposite
+guess — every directory is a navigator — reads as the simpler rule and produces a stack
+of empty navigators.
+
+The build-time half is a plugin that serves one virtual module:
+
+```ts
+gjsifyPlugin({ /* … */ }),
+rnRouteManifestPlugin({ routesDir: 'app' }),
+```
+```ts
+import { manifest } from 'virtual:gjsify-rn-routes';
+```
+
+It **walks** the directory rather than globbing one, and reports every file whatever its
+extension. A glob is blind to the first file that lands in a subdirectory it did not
+think to match, and a route file nobody imports is a screen that is simply not there —
+so filtering happens in the router, by name, with a message a reader can act on. The
+walk refuses past ten levels, loudly and naming the path at the bottom, because an
+unbounded walk turns a symlink cycle into a hang in the bundler where the failure is
+attributable to nothing. Entries are sorted in code-unit order and not with
+`localeCompare`: measured, ICU's default collation put `_layout.tsx` before `README.md`
+and `index.tsx` between them, and a build whose emitted module text depends on the
+host's collation data is a build cache that misses for no reason. Every route file
+becomes a watched dependency, so adding a screen invalidates the module in a watch build
+instead of needing a restart.
+
+The imports it emits are static, never `() => import(…)`. A lazy route needs a Suspense
+boundary, and `@gjsify/gtk-host/react`'s `render()` is synchronous by construction — a
+boundary that suspends on the first commit leaves the container empty and returns
+cleanly, which is the silent-empty-window failure that host exists to refuse. A desktop
+application also ships as one artifact, so there is no download for laziness to defer.
+
+:::note[The conventions are in the package, not in the plugin — and that has a cost]
+The plugin knows about a filesystem: which directory, which files, whether it exists. It
+knows nothing about what a name *means*. `buildRouteTree` owns all four rules, and it is
+exported so a consumer on another bundler — or one writing the nine-line manifest by
+hand — gets the same refusals, plus one parser instead of two truths.
+
+The cost is that a convention refusal is raised when the tree is built rather than when
+the bundle is written, which for a `RouterRoot` at the top of an application is its
+first render. Stated so nobody reads a runtime throw here as an oversight: it is the
+deliberate price of bundler independence.
+:::
+
+### `<Stack>`: two navigation stacks, one join key
+
+`Adw.NavigationView` owns a real navigation stack and React Navigation owns another, and
+neither is willing to be a mirror of the other — the widget animates, swipes and pops on
+Escape by itself, and React Navigation is the state a screen reads. The rule that makes
+them one thing is that **React declares membership and GTK owns ordering**, joined by a
+key: the pages are React children, so the widget's page *pool* is whatever React
+rendered, and the widget's *stack* is set imperatively by tag, where the tag is the route
+key.
+
+That split is measured rather than stylistic. With three pages `add`ed to an
+`Adw.NavigationView`, `get_navigation_stack().get_n_items()` is **1** — `add` puts a page
+in the pool and only the first one becomes the stack. There is no declarative way to say
+"these three, in this order"; `replace_with_tags` is it.
+
+**The stack diff is classified, not replayed.** Desired is a strict prefix of current →
+`pop_to_tag`, so the pop animates and the user sees a back transition. Current is a
+strict prefix of desired → set the base and `push_by_tag` the last one, so the push
+animates. Anything else → one `replace_with_tags`. Reaching for a `replace_with_tags` on
+every change would be correct and *silent*: every navigation becomes a cut, and nothing
+anywhere says so.
+
+**The reverse direction exists.** A swipe, Escape, Alt+Left or the mouse back button pops
+the widget without React Navigation being asked, so the widget's `popped` signal becomes
+a `StackActions.pop(delta)`. Without that bridge `usePreventRemove` is a lie on every
+gesture; with it, a prevented pop leaves React's state unchanged and the next sync pushes
+the page back onto the widget, which is what "prevented" means.
+
+The bridge is debounced, and the measurement says why: `pop_to_tag` over two pages emits
+`popped` **twice**, and both emissions see the stack already in its final state — so an
+undebounced handler computes the same delta twice and over-pops. In the other direction
+there is no echo to guard against, and that is measured too: a `replace_with_tags` emits
+no `popped` at all, which is why this layer carries no re-entrancy guard anywhere.
+
+**A popped page stays mounted until GTK has finished animating it out.** Its route is
+already gone from React Navigation's state, so React would otherwise unmount it
+mid-transition and the user would watch an empty page slide away. A popped page is still
+*in* the view — pooled, not destroyed, and `find_page` still answers for its tag — which
+is what makes "stays mounted until GTK is done" expressible at all. Two paths release it
+and each covers the other's gap. The first is the page's own `hidden` signal, which fires
+because GTK drives shown/hidden off the **navigation stack** and not off mapping: an
+`Adw.NavigationPage` emits `hidden` on a view that is in no window at all, which is what
+makes this a real path rather than a window-only one. The second is a sweep over pages
+that are not mapped, and it is what covers a pop that came *from* the widget — measured,
+a widget-driven pop emits `hidden` while it pops, before React has been told and
+therefore before that page is being tracked as closing, so the handler releases a key
+nothing is holding and `hidden` never fires again. Without the sweep that page is held
+for the life of the process.
+
+:::note[The page list is append-only, and that is a requirement]
+`AdwNavigationView` is declared `reorder: 'remove-all'` in the host's widget table
+because, measured on libadwaita 1.9.3, it has `add` and `remove` and **no `insert`**. So
+a renderer that reorders these children pays a tail rotation of `remove()` calls — and on
+this widget, unlike every other container in that table, `remove()` also takes the page
+**out of the navigation stack**. Reordering would therefore disturb navigation, not just
+paint order. The router keeps its page list append-only for exactly this reason: the list of
+rendered pages only ever grows at the end, and the stack order is set by tag afterwards.
+:::
+
+### `<Tabs>`: the switcher is the better widget
+
+Tabs render onto `Adw.ViewStack` behind an `Adw.ViewSwitcher`, and the switcher is not a
+substitute for a tab bar. A React Native tab bar is a fixed row of views the application
+lays out itself; the switcher is driven by the stack's own page model, so adding a route
+file adds a button with no tab-bar bookkeeping anywhere, the labels come from
+`Adw.ViewStackPage:title` — which is also what a screen reader announces, so the
+accessible name is the visible one by construction — and it carries a narrow and a wide
+policy, which lets an application's own breakpoint restyle it from the same declaration.
+Measured on libadwaita 1.9.3, the default policy is the narrow, phone-shaped one, so this
+layer sets wide explicitly: a switcher that defaults to the narrow layout in a 900 px
+window looks like a bug rather than a choice.
+
+One page is one `Adw.ViewStackPage`, addressed by route key — the same join key, for the
+same reason. `set_visible_child_name` is how focus is set and `notify::visible-child-name`
+is how the user's own click comes back, and that reverse direction is not optional here
+either: without it a click on the switcher changes the widget and not React's state, and
+every hook in the tab that just appeared reads the wrong route.
+
+Screen options are refused by name rather than dropped. `<Stack.Screen>` takes `title`,
+`headerShown` and `animation`; `<Tabs.Screen>` takes `title`. A `<X.Screen>` child is read
+as **data** and never rendered — in React Navigation a navigator's screens are its
+children, in `expo-router` they are the files in the directory the `_layout` owns, and
+both are true here at once.
+
+### The refusals have codes
+
+Everything the router refuses throws a `RouterError` carrying a stable `code` —
+`duplicate-route`, `param-without-name`, `unresolved-href`, `not-a-screen-child`,
+`unknown-screen-option`, `no-router-mounted` and the rest. Assert the code in a test and
+print the message to a human: the messages are long on purpose, and a spec that asserted
+a long sentence would pin its prose rather than its behaviour.
+
+It is a **separate class** from the primitives' `PrimitiveError`, not a re-export, and
+deliberately so. A `<Text numberOfLines>` refusal is about a widget mapping and a
+`[].tsx` refusal is about a file name; nothing that catches "my styling vocabulary is
+wrong" should also swallow "two of your files claim the same URL".

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -153,10 +153,28 @@ The primitives that render, each with the widget it becomes:
 | `ActivityIndicator` | `Adw.Spinner` |
 | `TextInput` | `Gtk.Entry`, or `Gtk.TextView` with `multiline` |
 | `Switch` | `Gtk.Switch` |
+| `FlatList`, `SectionList` | `Gtk.ListView` over a `Gio.ListStore` the component owns |
+| `VirtualizedList`, `VirtualizedSectionList` | `Gtk.ListView` — the same machinery under React Native's older names |
+| `Image` | `Gtk.Picture` |
+| `ImageBackground` | `Gtk.Picture` in a `Gtk.Overlay` |
+| `TouchableOpacity`, `TouchableHighlight` | `Gtk.Button`, flat |
+| `TouchableWithoutFeedback` | `Gtk.Box` with a `Gtk.GestureClick` — no button chrome |
+| `Button` | `Gtk.Button` |
+| `SafeAreaView`, `KeyboardAvoidingView` | `Gtk.Box` — a desktop window has neither notch nor soft keyboard |
 
-Plus `Linking`, `Platform`, `Share` and `useColorScheme`; `AppRegistry` and Expo's
+**One table, on purpose.** A separate "tier 2" list would be a second statement of what renders,
+and the second one is the one that drifts — which is the defect this page has already shipped
+once. Tiers are a roadmap concept and live in the generated README; what this table answers is
+"does it render".
+
+Plus the APIs: `Linking`, `Platform`, `Share`, `useColorScheme`, `StyleSheet`, `Dimensions`,
+`useWindowDimensions`, `Alert`, `Appearance`, `Keyboard` and `StatusBar`; `AppRegistry` and Expo's
 `registerRootComponent`; `EventEmitter`; and `unstable_batchedUpdates`, which is the identity call
 it already is under React 19 and is kept because application code still wraps in it.
+
+Everything in the second half of that table is `partial`, and every one of them names its refused
+props **in the table** rather than dropping them — the sections below are the shape of the
+answers, not the list of them.
 
 One export is **not** a React Native name and is part of the surface anyway: `configureStyle`
 installs your project's token scales. The class families are declared by the styling layer, the
@@ -170,6 +188,204 @@ defaults to horizontal. A React Native `Text` **wraps** and a `Gtk.Label` does n
 are set explicitly in the primitive descriptors, because both would otherwise be wrong in the same
 way in every ported layout, and wrong *silently*: the window renders, every widget is there, and
 the rows are columns.
+
+### Lists are not elements
+
+`FlatList`, `SectionList`, `VirtualizedList` and `VirtualizedSectionList` are one
+component that differs only in how it is handed its rows. It is not an ordinary element,
+and three measurements on GTK 4.22.4 / gjs 1.88.1 force that:
+
+A `Gtk.ListView` **takes no children** — no `append`, `add`, `insert`, `prepend`,
+`remove` or `set_child` on its prototype. The host's placement policies are data naming a
+method for the host to call, so for this widget there is no method to name; the generated
+table lists it uncurated and an attempted child insertion is refused by name. That
+refusal is correct, and it is the end of the road for "the list is an element whose
+children are the rows". A `Gtk.ListItem` is **not a `Gtk.Widget`** — `type_is_a` answers
+false — so a React root cannot be created over a list item; it is created over the widget
+the factory puts *into* it. And rows **bind the moment the view is rooted in a window**:
+a bare view produced nothing, a view inside a `Gtk.ScrolledWindow` produced nothing,
+`measure()` produced nothing, `allocate(400, 400)` produced nothing and fifty main-loop
+iterations produced nothing — putting the scroller into a `Gtk.Window` produced
+`setup, bind 0, setup, bind 1, setup, bind 2` immediately, with no `present()`, no map
+and no main loop.
+
+So the component owns its `Gtk.ListView`, drives the model imperatively from `data`, and
+React lives only inside the item factory. What is still an element is the frame — an outer
+`Gtk.Box` and an inner `Gtk.ScrolledWindow`, which is where `style`, `className`,
+`horizontal` and the scrollbar policies land through the ordinary routes.
+
+**A row's React tree is rendered on a microtask, never inline.** GTK binds rows from
+inside whatever call rooted or spliced the view, and under React that call is a commit or
+an effect — where a nested root cannot flush and `render()` refuses a re-entrant flush by
+name, correctly, on every row. Deferring is uniform, needs no `catch`, and costs nothing
+visible: GJS drains the microtask queue when the JS stack empties, which is before GTK's
+next frame, so a row is never painted empty.
+
+**A data change splices the rows whose keys changed, and re-renders the rest in place.**
+Measured, `items_changed(0, 1, 1)` over the same carrier object produced no rebind at all
+while `splice(0, 1, [fresh])` produced `setup, bind 0, unbind 0, teardown`: GTK re-binds a
+row when its model *object* changes, not when that object's contents do.
+
+:::note[Two list warts worth knowing before you meet them]
+**The header and footer are outside the scroller.** Measured with a 500-row model in a
+presented 400×300 window: with the list as the scroller's own child, `get_child()` is the
+`Gtk.ListView` and the adjustment's `upper` is 11 000 — GTK's own `Gtk.Scrollable` path is
+in use. Wrap the list in a `Gtk.Box` to put a header inside, and `get_child()` becomes a
+`GtkViewport`, `upper` becomes 11 018, and the list is allocated its whole 11 000 px
+content height while still realising only 205 of the 500 rows — rows with no widget
+inside the allocated area. So `ListHeaderComponent` and `ListFooterComponent` are siblings
+of the scroller and stay put while the rows scroll, which is a divergence from React
+Native and the only arrangement that keeps virtualisation honest.
+
+**Teardown is driven by `dispose()`, not by GTK's `teardown` signal.** Measured,
+destroying a window whose `Gtk.SignalListItemFactory` still had JS handlers connected
+produced six `Gjs-CRITICAL` lines — "Attempting to call back into JSAPI during the
+sweeping phase of GC … the offending signal was unbind/teardown" — and ran none of them.
+A per-item React root unmounted only from `teardown` would therefore never be unmounted,
+and every signal the host connected inside that row would stay connected for the life of
+the process.
+:::
+
+React Native's virtualisation knobs — `initialNumToRender`, `maxToRenderPerBatch`,
+`windowSize`, `updateCellsBatchingPeriod`, `removeClippedSubviews`, `getItemLayout` — are
+refused by name on all four names. `Gtk.ListView` creates and recycles rows itself and
+installs no property that changes the batching, measured at 205 of 500 rows realised in a
+400×300 window. `SectionList` flattens its sections into one model with header rows, so a
+header scrolls with its section and `stickySectionHeadersEnabled` is refused rather than
+silently false — GTK's own sticky headers exist (`Gtk.SectionModel` is present,
+`set_header_factory` is there, and a flatten model over two stores answered
+`get_section(0)` as `[0, 2]`) and reaching them needs a second factory and a model of
+models, which is not built.
+
+### Images, touchables and a button that refuses to be styled
+
+| Primitive | Becomes |
+|---|---|
+| `FlatList`, `SectionList`, `VirtualizedList`, `VirtualizedSectionList` | `Gtk.ListView` + `Gio.ListStore`, owned by the component |
+| `Image` | `Gtk.Picture` |
+| `ImageBackground` | `Gtk.Picture` as the main child of a `Gtk.Overlay` |
+| `TouchableOpacity`, `TouchableHighlight` | `Gtk.Button`, flat |
+| `TouchableWithoutFeedback` | `Gtk.Box` + `Gtk.GestureClick` |
+| `Button` | `Gtk.Button` |
+| `SafeAreaView`, `KeyboardAvoidingView` | `Gtk.Box` |
+| `StatusBar` | nothing — it renders `null` |
+
+`Image` inverts a default the same way `View` and `Text` do: React Native defaults to
+`cover` and a `Gtk.Picture` to `contain`, measured, so `resizeMode` is written out. It
+answers `cover`, `contain`, `stretch` and `center`; `repeat` is refused because
+`GtkContentFit` is `FILL`, `CONTAIN`, `COVER`, `SCALE_DOWN` and has no tiling member —
+tiling is a `Gdk.Paintable` implementation, not a property of the widget that draws one.
+`source` takes a local path, a `file:` URI or a `resource:` URI; `http:`/`https:`/`data:`
+need a fetch, a decoder and a cache that this layer does not own, and a `require()` id is
+an index into React Native's asset registry, which the build chain deliberately does not
+own either. The load callbacks are refused rather than stubbed for a measured reason:
+`Gtk.Picture` emits **no signals at all**, and a file that does not exist leaves
+`paintable` null with no diagnostic — so an `onError` that never fires would hide exactly
+the case it exists to report.
+
+`ImageBackground` is sized by its **picture**, not by its children, which is the opposite
+of React Native. Measured: a `Gtk.Overlay` measures only its main child — a 9 px main child
+beside a 266 px overlay child gave the overlay 9 px — and `gtk_overlay_set_measure_overlay()`
+is a per-child *method* rather than a property, so the host's data-driven placement has no
+way to name it. Give the element a size, or let its parent stretch it with `flex-1`.
+
+The touchables are `Pressable`'s machinery under other names, and each refuses the prop
+that would smuggle a raw value into the styling path: `activeOpacity` refuses and points
+at `active:opacity-70`, `underlayColor` refuses and points at `active:bg-<token>`. Both
+would otherwise put a value into the class vocabulary that did not come from the project's
+token scale. `TouchableWithoutFeedback` is a real box with a `Gtk.GestureClick` on it —
+measured, `Gtk.Button` emits `activate` and `clicked`, a `Gtk.Box` emits neither, and
+`Gtk.GestureClick` emits `pressed`/`released`/`stopped`/`unpaired-release` — so unlike
+React Native it does not clone its child and vanish; it lays out like a `View` and takes
+one row of the parent's box. Its `disabled` becomes `can-target: false` rather than
+`sensitive: false`, because `sensitive` greys out every descendant of a wrapper that is
+supposed to have no appearance of its own.
+
+`Button` refuses `style` and `className` **by name**, and that is faithful rather than
+missing: React Native's `Button` takes neither. An Adwaita button is painted by the theme
+and by its own classes, which an application stylesheet sets. Reach for `Pressable` when
+you need to style it.
+
+### The APIs a desktop can answer, and the ones it must refuse
+
+`Appearance` is the one fully `supported` name of the tier: it is the imperative sibling
+of `useColorScheme` over the same reader, and the split lines up exactly — `getColorScheme`
+reads `Adw.StyleManager:dark`, which is what the user is looking at, and `setColorScheme`
+writes `:color-scheme`, which is what the application asked for.
+
+`Dimensions.get('window')` is the **window**, not the screen, because a desktop
+application is not full-screen and the screen's number would be wrong in the ordinary
+case; `get('screen')` is the monitor, because that is what it asks for. It throws by name
+when there is no window yet — which includes every read at module scope, where there is no
+honest number and a zero divides. The size reported is the window's **allocation**, and
+deliberately not the `Gdk.Surface` size: measured, a 640×480 window has a 668×509 surface,
+which carries the client-side-decoration shadow. `fontScale` comes from
+`Gtk.Settings:gtk-xft-dpi` divided by 1024 and by 96.
+
+`useWindowDimensions` is the hook form, through `useSyncExternalStore` so a resize between
+render and commit cannot tear. Its notifier and its value are two different objects, and
+that is measured rather than chosen: `Gtk.Widget` installs no width or height property and
+emits no `size-allocate` signal — the same wall `<View onLayout>` is refused against —
+while `Gdk.Surface` installs read-only `width` and `height` and notifies on them. So the
+surface says *when* and the window says *what*.
+
+:::note[One precondition is recorded as unknown, on purpose]
+Whether the window's allocation is already updated inside that `notify` handler has **not
+been measured**. A compositor-driven resize cannot be triggered from a probe —
+`set_default_size` on a mapped window is a no-op, measured — so the entry records it as
+unknown rather than guessing. It is in the table as a limit, where a reader who runs into it will
+find it recorded, instead of nowhere.
+:::
+
+The rest of the tier is mostly the discipline of refusing loudly. `Keyboard.addListener`
+refuses **for every event**, because there is no on-screen keyboard to raise one and a
+subscription that resolves and then never fires is the silent drop this layer exists to
+remove — a `keyboardDidShow` handler that never runs looks like a bug in your own code,
+for ever. Its `dismiss()` and `removeAllListeners()` are honest no-ops, and `isVisible()`
+answers `false`, which is React Native's own answer for a keyboard that is not up.
+`StatusBar` renders `null` and says so — it is in the first ten lines of most React Native
+screens, so failing to import would be worse — its declarative props are accepted no-ops,
+every imperative static refuses by name, and `currentHeight` throws rather than answering
+`0`, because code reads it straight into a layout and a number here would inset every
+ported screen by a bar that is not there. `SafeAreaView` and `KeyboardAvoidingView` are
+both `Gtk.Box`: the *inset* and the *avoiding* are the no-ops, not the box, not the column
+and not the children — a component that rendered nothing would be a screen that silently
+disappeared.
+
+### `Alert` is buildable where `Modal` is not
+
+`Alert` maps to `Adw.AlertDialog` and is real; `Modal` maps to `Adw.Dialog` and stays
+`planned`. The difference between them is not effort, and it is measured on libadwaita
+1.9.3.
+
+A host inserts an element by calling its parent's adder, and `box.append(dialog)` calls
+`g_error()` — SIGABRT and a core dump, not a catchable exception — but *only* once the box
+is rooted in a window. A detached box accepts the append in silence, so a re-test on a
+bare box appears to disprove this and puts the primitive back. An `Adw.Dialog` is
+*presented against* a parent rather than parented by it, which makes `<Modal>` a portal,
+and the host has no portal seam. `Alert` never makes that call at all: it is a function,
+`present(parent)` takes an optional anchor, and `present(null)` from a plain function with
+no parent and no window returned with no diagnostic. A refusing export is strictly better
+than a `partial` that aborts the process the first time somebody renders one.
+
+`Alert`'s own mapping earns two notes. `cancel` becomes the dialog's **close response**,
+which is stronger than an appearance — it is what Escape and the compositor's close button
+both produce — and the first non-cancel button becomes the default response, which is
+Adwaita's convention and has no React Native counterpart. Response ids are positional
+rather than derived from the label, so two buttons with the same text do not collide into
+one response. `Alert.prompt` throws by name: it is iOS-only, and its contract — four
+overloads, a login/password variant, a callback whose arity depends on the type — is what
+makes it a refusal rather than a port. `Adw.AlertDialog:extra-child` is there if you want
+to build it.
+
+:::note[A measurement that was reporting the wrong thing]
+Presenting a dialog realises a real GDK surface, which is the first thing in that suite to
+make GSK bring up a renderer. On a CI container with no `/dev/dri` that emitted eight
+Vulkan warnings and turned the vector red, while a desktop with a working GPU stayed
+silent — the diagnostics gate was reporting a fact about the runner rather than about the
+dialog. It now classifies environment diagnostics apart, so what is asserted is what was
+always meant: libadwaita says nothing about this dialog.
+:::
 
 ## The divergences a porter hits first
 
@@ -215,12 +431,10 @@ scales installed first, with `configureStyle`. The default scale is deliberately
 a silently dropped class.
 
 **A dialog is presented against a parent, never parented by it.** `Modal` is tier P1 and stays
-`planned` for a measured reason: on libadwaita 1.9.3, `box.append(dialog)` calls `g_error()` —
-SIGABRT and a core dump, not a catchable exception — but *only* when the box is rooted in a
-window. A detached box accepts the append in silence, so a re-test on a bare box appears to
-disprove it. `<Modal>` is therefore a **portal**, and the host has no portal seam yet. A refusing
-export is strictly better than a `partial` that aborts the process the first time somebody renders
-one.
+`planned` for a measured reason, not a scheduling one — `box.append(dialog)` kills the process.
+`Alert`, which maps onto the same family of widgets, is real. The measurement and the difference
+between the two are written out once, under
+[`Alert` is buildable where `Modal` is not](#alert-is-buildable-where-modal-is-not).
 
 **Every `partial` primitive refuses some of its props by name, and its table entry lists which.**
 They share one shape, worth carrying with you: React Native puts the thing on the element as data,
@@ -298,6 +512,8 @@ to resolve.
 
 ## See also
 
+- [React Native routing](/gjsify/frameworks/react-native-routing/) for `expo-router`'s surface
+  over `Adw.NavigationView`, the file convention, and the reverse direction a back gesture needs
 - [Styling on GTK](/gjsify/frameworks/styling/) for `className`, `style={{…}}`, and the measured
   reasons a property lands in GTK CSS, on a widget, or nowhere until attach time
 - [React](/gjsify/frameworks/react/) for the `jsxImportSource` and the build defines underneath

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -71,9 +71,10 @@ That is what the support table is for.
 </CommandTabs>
 
 Your framework stays yours and arrives as a peer: `react` + `react-reconciler`, or `solid-js`.
-Every one of them is optional, so install the one you render with — and mind the version ranges,
-because an optional peer is not enforced on install and the
-[React page](/gjsify/frameworks/react/) carries the measurement behind them.
+Routing adds two more, `@react-navigation/core` and `@react-navigation/routers`. Every one of them
+is optional, so install the ones you actually use — and mind the version ranges, because an
+optional peer is not enforced on install and the [React page](/gjsify/frameworks/react/) carries
+the measurement behind them.
 
 The Solid binding (`@gjsify/react-native/solid`) renders the same primitives, and it exists for a
 reason worth stating: with one framework binding, "the layers below are framework-agnostic" is a
@@ -471,27 +472,119 @@ rules out.
 it is where the desktop chain will land, never as a second plugin. Until then, a GTK build reads
 the base file, and a `.gtk.tsx` beside it is a file nothing imports.
 
-## The toolchain, as it actually stands
+## The build opt-in: `--dialect react-native`
 
-Two pieces of ADR 0032 § 8's build-time story are declared and not wired up, and it is worth
-knowing which:
+One flag turns an ordinary `gjsify build` into a React Native port:
 
-- **The `'react-native'` → `'@gjsify/react-native'` alias.** Import the package by its own name
-  for now. The import surface is identical either way; what the alias buys is an *unmodified*
-  application tree building.
-- **The bundler gate** that would fail a build on an import the table marks unsupported, naming
-  the file and the line. Nothing in the build pipeline reads the support table today, so the
-  runtime refusal is the only reader that fires — a sentence at the right moment instead of a
-  sentence before the run.
+```bash
+gjsify build src/app.tsx --app gjs --outfile dist/app.gjs.mjs \
+  --dialect react-native \
+  --define 'process.env.NODE_ENV="production"' \
+  --exclude-globals navigator
+```
 
-What does hold today: the runtime refusals, the generated README section, and
-`scripts/check-rn-surface.mjs`. That last one compares the table against a committed snapshot of
-React Native's export list on every run, and against the *installed* `react-native` whenever one is
-resolvable — printing which of the two modes it ran in, because a gate that quietly degrades to the
-weaker half is worth less than one that says so.
+It composes exactly two plugins, on the `gjs` and `node` targets. The first is the alias
+line: `'react-native'` → `'@gjsify/react-native'`, so an unmodified application tree
+builds without a rename per file. The second is the build-time half of the gate — it
+fails the build on an import of a name the support table does not mark `supported` or
+`partial`, naming the importing file and the line before anything runs. That is the
+only thing it has over the runtime refusal, and it is the whole point: a sentence at
+build time rather than the same sentence the first time a code path is reached in a
+window.
 
-The **build recipe is React's, not this package's** — `--define 'process.env.NODE_ENV="production"'`
-and `--exclude-globals navigator`, with the reason each flag exists on the
+The flag is also readable as `gjsify.dialect` in `package.json#gjsify` or an
+`.gjsifyrc.*`. yargs' `choices` already rejects an unknown value typed on the command
+line, but a config-file value never passes through yargs — so the narrowing lives where
+both spellings meet, and it names the alternatives rather than ignoring what it did not
+understand.
+
+**It is opt-in and never inferred, and that is load-bearing rather than cautious.** A
+monorepo with a phone leg and a desktop leg has the real `react-native` installed *on
+purpose*; redirecting the specifier for every `gjsify build` in that tree changes what
+the phone build resolves. And `@gjsify/react-native` is an optional tier-3 package, so
+an unconditional alias would fail every build in every tree that does not have it — on
+a package nobody asked for, with a gjsify name in the error, which reads as our bug.
+
+### The four shapes it answers
+
+The alias is a `resolveId` hook rather than an entry in the alias table, because two of
+these cannot be expressed as a rewrite.
+
+**A subpath is a named refusal, not a rewrite.** `react-native/Libraries/Components/…`
+reaches into a module layout that exists because of Metro and the native bridge; the
+alias covers the package *root*, because the root is the export surface being mirrored.
+Resolving it to the real React Native source would build and then fail in the window on
+`NativeModules`, so the build says so with the importer named. The match on the root is
+exact and never a prefix — `react-native-web`, `react-native-reanimated` and
+`react-native-gesture-handler` share the first eleven characters and none of them is
+this package.
+
+**An unresolvable target is a named error, not a silent external.** The substitution
+*is* the promise, so its failure is the one thing that must not exit 0. It deliberately
+does not fall back to the real `react-native` for the reason above.
+
+**A namespace import warns and builds.** `import * as RN from 'react-native'` makes the
+names a runtime question, so the gate says which form it hit, and that the runtime
+refusal — reading the same table — still covers the module, just later. Guessing would
+be worse than saying so.
+
+**A type-only import costs nothing and is not refused.** That works because the gate is
+a `transform` hook at `order: 'pre'`: by the time a normal-order hook runs the
+annotations may already have been stripped, and the gate would then be unable to tell a
+type-only import from a value import and would fail a program that cannot fail.
+
+### It reads the table, never a copy
+
+The gate resolves `@gjsify/react-native/support-table` through the bundler's own
+resolver, from a module of the *project being built*, and imports it. So it states what
+this build's own copy of the layer supports, and a version skew between the plugin and
+the layer cannot make it lie in either direction. It is deliberately not a dependency:
+the bundler plugin is tier 1, the layer is tier 3, and a tier-1 package may not depend
+on a higher tier. Both spellings are watched — the ported application writes
+`react-native` and a gjsify-native one writes `@gjsify/react-native` — because the gate
+is about the surface, not about which name reached it.
+
+Every refused import in one module is reported as one message. An application importing
+three unsupported names from the same file has one porting decision to make, and three
+separate build failures would show it one third of that decision per run.
+
+:::note[One place the gate deliberately does not fail]
+A module the pinned parser cannot read produces a warning, per file, and the build goes
+on. `acorn-typescript` 1.4.13 cannot parse a `satisfies` expression or a `const` type
+parameter, both of which are ordinary TypeScript in a tree on `typescript ^6.0.3` —
+erroring there would refuse a correct program, and a false violation is how a checker
+teaches people to ignore it. The shape used instead is the one
+`scripts/check-rn-surface.mjs` already uses: degrade to the weaker half and say so out
+loud, rather than degrade quietly.
+:::
+
+:::note[`--dialect react-native` is not `gjsify.runtimes['react-native']`]
+They answer opposite questions, and the flag is spelled as it is so the two cannot be
+read as one.
+
+`gjsify.runtimes['react-native']` declares that **this package runs on** React Native.
+`--dialect react-native` declares that **this source is** a React Native application,
+being built for GTK.
+
+A package can truthfully be both — shipped to a phone through Metro *and* ported to the
+desktop through this build — and while the flag was also spelled `react-native`, those
+two true statements read as a contradiction. A reader could reasonably expect a manifest
+declaring `react-native: 'none'` to fail the build, and it never should: the two are
+unrelated facts. The closed runtime vocabulary keeps the name because it is the older,
+machine-checked one; the dialect is spelled as what it is. It is a union rather than a
+boolean because `nativescript` is the named follow-on and fits here without a second
+flag.
+:::
+
+All three readers of the table now fire: the build gate above, the runtime refusals, and the
+generated README section. `scripts/check-rn-surface.mjs` holds the key set from outside — against a
+committed snapshot of React Native's export list on every run, and against the *installed*
+`react-native` whenever one is resolvable, printing which of the two modes it ran in, because a
+gate that quietly degrades to the weaker half is worth less than one that says so.
+
+The rest of the **build recipe is React's, not this package's** —
+`--define 'process.env.NODE_ENV="production"'` and `--exclude-globals navigator`, with the reason
+each flag exists on the
 [React page](/gjsify/frameworks/react/#the-build-recipe-and-it-is-not-optional). It applies
 unchanged here, because `react-reconciler` is what is underneath.
 


### PR DESCRIPTION
The React Native page was written before M7 and M8 and had gone stale in the way it warns about two paragraphs into itself.

### It listed seven primitives while eighteen more had shipped

"What renders today" was the P1 set. `FlatList`, `SectionList`, `Image`, `ImageBackground`, the three touchables, `Button`, `SafeAreaView`, `KeyboardAvoidingView` and eight APIs landed in #1353 and were nowhere on the page.

**They join the existing table rather than getting one of their own.** A separate "tier 2" list would be a second statement of what renders, and the second one is the one that drifts — the defect #1357 just repaired. Tiers are a roadmap concept and live in the generated README; the table answers *"does it render"*.

### `Modal`'s measurement now lives in exactly one place

The paragraph under "the divergences a porter hits first" keeps the fact and links the subsection carrying the `g_error()` / detached-box / portal reasoning, instead of restating it beside `Alert`'s half of the same measurement.

### Routing gets its own page

Different subpath, different (optional) peer, different problem from "which widget does this component become" — and long enough that folding it in would bury the surface. The load-bearing measurements travel with it:

- `AdwNavigationView` has no `insert`, and its `remove()` **also takes the page out of the navigation stack** — so the page list is append-only, and a renderer that reorders these children disturbs navigation rather than paint order.
- A `replace` emits no `popped`, which is why the sync cannot echo.
- A popped page stays **pooled in the view** until GTK is done.
- `Adw.NavigationPage` emits `hidden` even on a **detached** view, which is what the sweep after a widget-driven pop is for.

### The build section said the feature was missing

"The toolchain, as it actually stands" opened with two bullets naming the alias and the build gate as declared and not wired up. Both shipped in #1350 — and this was the section a porter reads to find out how to build. It now documents `--dialect react-native` and the four shapes it answers, three of which are refusals.

Two notes carry what is easy to get wrong later: the gate deliberately does **not** fail on a module its pinned parser cannot read (`acorn-typescript` 1.4.13 cannot parse `satisfies` or a `const` type parameter, both ordinary on typescript `^6.0.3`, and a false violation is how a checker teaches people to ignore it); and `--dialect react-native` is **not** `gjsify.runtimes['react-native']` — opposite questions, a package can truthfully be both, and the flag is spelled as it is so the two cannot be read as one.

Routing's two peers are named in the install section, because an optional peer is not enforced on install and that is where an unnamed one bites.

---

**Every number traces to source**, checked against `main` rather than taken from the draft: 11 000 px for 500 rows against 205 realised, `upper` becoming 11 018 through a `GtkViewport`, the overlay measuring 9 px where its main child measures 266, 640×480 allocating 668×509, `gtk-xft-dpi` over 1024 over 96. Two things were dropped rather than shipped — an appeal to an unnamed measured application, and a five-name router list that omitted `navigationRef`.

`astro build` green, 62 pages, and the new cross-page anchor resolves in the built HTML.
