### PR TITLE
fix(scripts): a tier banner belongs to its own table, not the next one

### DIFF
--- a/scripts/check-rn-surface.mjs
+++ b/scripts/check-rn-surface.mjs
@@ -73,6 +73,13 @@ export function readTableKeys(source, declaration = 'SUPPORT_TABLE') {
  * Nothing at runtime could see it: `explainUnsupported` reads the field, not the
  * comment.
  *
+ * SCOPED PER TABLE, and that is not a detail. This file holds two of them —
+ * `SUPPORT_TABLE` and `ROUTER_SUPPORT_TABLE` — and the second has no banners at
+ * all. A scanner that carried the last banner across the boundary judged all 13
+ * router entries against the main table's closing `// --- P3 ---` and reported
+ * them as misfiled. MEASURED: it turned `main` red, because the check landed in
+ * one PR and the router table in another and neither run saw both.
+ *
  * Reported as a list rather than thrown, like every other comparison here.
  */
 export function tierSectionMismatches(source) {
@@ -80,6 +87,13 @@ export function tierSectionMismatches(source) {
     let section = null;
     let open = null;
     for (const line of source.split('\n')) {
+        // A new top-level declaration starts a new scope: a banner belongs to the
+        // table it was written inside, and says nothing about the next one.
+        if (/^export const \w+/.test(line)) {
+            section = null;
+            open = null;
+            continue;
+        }
         const banner = /^\s*\/\/ --- (P\d+):/.exec(line);
         if (banner !== null) {
             section = banner[1];
@@ -190,6 +204,24 @@ function selfTest() {
         'an entry before any banner is not judged',
         tierSectionMismatches(`    Foo: {\n        tier: 'P3',\n    },\n`),
         [],
+    );
+    // The vector that was missing, and it cost a red `main`: a banner belongs to
+    // the table it was written inside. A SECOND table in the same file starts with
+    // no section, so nothing in it is judged.
+    ok(
+        'a banner does not reach into the next table',
+        tierSectionMismatches(
+            `    // --- P3: y ---\n    Old: {\n        tier: 'P3',\n    },\n};\n` +
+                `export const OTHER_TABLE = {\n    New: {\n        tier: 'P1',\n    },\n};\n`,
+        ),
+        [],
+    );
+    ok(
+        'a banner inside the SECOND table still judges it',
+        tierSectionMismatches(
+            `};\nexport const OTHER_TABLE = {\n    // --- P2: z ---\n    New: {\n        tier: 'P1',\n    },\n};\n`,
+        ),
+        ['New declares tier P1 but sits under the P2 banner'],
     );
 
     return vectors;


### PR DESCRIPTION
**`main` is red on `check-rn-surface`, and the check is wrong — not the table.**

```
check-rn-surface: 13 entries sit under the wrong tier banner — router declares tier P1
  but sits under the P3 banner; useLocalSearchParams declares tier P1 but sits under the
  P3 banner; … (11 more)
```

`tierSectionMismatches()` scanned the whole file and carried the last `// --- Pn ---` banner past the end of `SUPPORT_TABLE` into `ROUTER_SUPPORT_TABLE`, which has no banners of its own. Every router entry was judged against the main table's closing `// --- P3 ---`.

A new top-level declaration now ends the scope, so a table with no banners has no section and nothing in it is judged. Two vectors cover the boundary in **both** directions — a banner does not reach into the next table, and a banner written *inside* the second one still judges it. Self-test 13 → 15.

### The interleaving is the part worth keeping

The check landed in #1357 and the router table in #1352. Each PR's run saw its own change against a base without the other, so both were green and their merge was not. Nothing was skipped and nothing was misconfigured — this is the ordinary cost of two green PRs that were never built together, and exactly why the release pre-flight dispatches a full `main.yml` sweep on the ref being cut rather than trusting that a green PR implies a green `main`.

Verified locally against `origin/main` + this change: `check-rn-surface` green (15 vectors), `gjsify lint` exit 0.
