### PR TITLE
feat(adwaita-core): the breakpoint bin picks one

### DIFF
--- a/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
@@ -42,7 +42,7 @@ export default async () => {
                     const transition = bin.evaluate(size);
                     return transition === null ? null : transition.writes.map((w) => `${w.property}=${w.value}`);
                 });
-                expect(got).toEqual(vector.writes.map((w) => (w === null ? null : [...w])));
+                expect(got).toStrictEqual(vector.writes.map((w) => (w === null ? null : [...w])));
             });
         }
 
@@ -73,7 +73,7 @@ export default async () => {
             });
             bin.evaluate({ width: 500, height: 600 });
             const left = bin.evaluate({ width: 900, height: 600 });
-            expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toEqual(['a:origA', 'b:origB']);
+            expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toStrictEqual(['a:origA', 'b:origB']);
         });
     });
 

--- a/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
@@ -1,0 +1,110 @@
+// Breakpoint-bin specs — driven by the shared conformance vectors, so this suite and
+// every renderer suite assert the SAME table.
+
+import { describe, it, expect } from '@gjsify/unit';
+
+import { BreakpointBinState } from './breakpoint-bin.js';
+import type { BreakpointSetter } from './breakpoint-bin.js';
+import { BREAKPOINT_PICK_VECTORS, BREAKPOINT_TRANSITION_VECTORS } from './conformance/breakpoint-bin.js';
+
+/** `[property, value]` pairs into setters whose original is `orig:<property>`. */
+function setters(pairs: readonly (readonly [string, string])[]): BreakpointSetter<string>[] {
+    return pairs.map(([property, value]) => ({ object: 'w', property, value, originalValue: `orig:${property}` }));
+}
+
+await describe('BreakpointBinState picks one breakpoint', async () => {
+    for (const vector of BREAKPOINT_PICK_VECTORS) {
+        await it(vector.rule, async () => {
+            const bin = new BreakpointBinState<string>();
+            for (const condition of vector.conditions) bin.add({ condition, setters: [] });
+            bin.evaluate(vector.size);
+            expect(bin.current).toBe(vector.pick);
+        });
+    }
+
+    await it('add returns the index the transition reports', async () => {
+        const bin = new BreakpointBinState<string>();
+        expect(bin.add({ condition: 'max-width: 400sp', setters: [] })).toBe(0);
+        expect(bin.add({ condition: 'max-width: 720sp', setters: [] })).toBe(1);
+        expect(bin.length).toBe(2);
+    });
+});
+
+await describe('BreakpointBinState transitions', async () => {
+    for (const vector of BREAKPOINT_TRANSITION_VECTORS) {
+        await it(vector.rule, async () => {
+            const bin = new BreakpointBinState<string>();
+            for (const [condition, pairs] of vector.breakpoints) {
+                bin.add({ condition, setters: setters(pairs) });
+            }
+            const got = vector.sizes.map((size) => {
+                const transition = bin.evaluate(size);
+                return transition === null ? null : transition.writes.map((w) => `${w.property}=${w.value}`);
+            });
+            expect(got).toEqual(vector.writes.map((w) => (w === null ? null : [...w])));
+        });
+    }
+
+    await it('reports which breakpoint it left and which it entered', async () => {
+        const bin = new BreakpointBinState<string>();
+        bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
+        bin.add({ condition: 'max-width: 400sp', setters: setters([['collapsed', 'false']]) });
+
+        const entered = bin.evaluate({ width: 500, height: 600 });
+        expect(entered?.from).toBe(null);
+        expect(entered?.to).toBe(0);
+
+        const swapped = bin.evaluate({ width: 300, height: 600 });
+        expect(swapped?.from).toBe(0);
+        expect(swapped?.to).toBe(1);
+    });
+
+    await it('setters on DIFFERENT objects are both restored, even for the same property', async () => {
+        // The skip keys on object AND property. Two widgets whose `collapsed` a
+        // breakpoint sets are two setters, and leaving must restore both.
+        const bin = new BreakpointBinState<string>();
+        bin.add({
+            condition: 'max-width: 720sp',
+            setters: [
+                { object: 'a', property: 'collapsed', value: 'true', originalValue: 'origA' },
+                { object: 'b', property: 'collapsed', value: 'true', originalValue: 'origB' },
+            ],
+        });
+        bin.evaluate({ width: 500, height: 600 });
+        const left = bin.evaluate({ width: 900, height: 600 });
+        expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toEqual(['a:origA', 'b:origB']);
+    });
+});
+
+await describe('BreakpointBinState child and reset', async () => {
+    await it('a childless bin keeps the breakpoint it had', async () => {
+        const bin = new BreakpointBinState<string>();
+        bin.add({ condition: 'max-width: 720sp', setters: [] });
+        bin.evaluate({ width: 500, height: 600 });
+        bin.setHasChild(false);
+        expect(bin.evaluate({ width: 900, height: 600 })).toBe(null);
+        expect(bin.current).toBe(0);
+    });
+
+    await it('the change happens once the child is back', async () => {
+        const bin = new BreakpointBinState<string>();
+        bin.add({ condition: 'max-width: 720sp', setters: [] });
+        bin.evaluate({ width: 500, height: 600 });
+        bin.setHasChild(false);
+        bin.evaluate({ width: 900, height: 600 });
+        bin.setHasChild(true);
+        expect(bin.evaluate({ width: 900, height: 600 })?.to).toBe(null);
+    });
+
+    await it('reset drops the applied breakpoint without producing writes', async () => {
+        const bin = new BreakpointBinState<string>();
+        bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
+        bin.evaluate({ width: 500, height: 600 });
+        bin.reset();
+        expect(bin.current).toBe(null);
+        // The next evaluation is a first evaluation: it enters, it does not transition out.
+        const again = bin.evaluate({ width: 500, height: 600 });
+        expect(again?.from).toBe(null);
+        expect(again?.to).toBe(0);
+    });
+});

--- a/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
@@ -1,5 +1,10 @@
-// Breakpoint-bin specs — driven by the shared conformance vectors, so this suite and
-// every renderer suite assert the SAME table.
+// Breakpoint-bin specs — driven by the shared conformance vectors in
+// `./conformance/breakpoint-bin.js`.
+//
+// No renderer drives those tables yet; the tables say so themselves (CORE-ONLY GAP,
+// #1343), and this suite is their only driver until the NativeScript bin moves onto
+// `BreakpointBinState`. That is a gap, not coverage, and it is written here so a reader of
+// the spec is told the same thing as a reader of the table.
 
 import { describe, it, expect } from '@gjsify/unit';
 
@@ -7,10 +12,19 @@ import { BreakpointBinState } from './breakpoint-bin.js';
 import type { BreakpointSetter } from './breakpoint-bin.js';
 import { BREAKPOINT_PICK_VECTORS, BREAKPOINT_TRANSITION_VECTORS } from './conformance/breakpoint-bin.js';
 
-/** `[property, value]` pairs into setters whose original is `orig:<property>`. */
-function setters(pairs: readonly (readonly [string, string])[]): BreakpointSetter<string>[] {
-    return pairs.map(([property, value]) => ({ object: 'w', property, value, originalValue: `orig:${property}` }));
+/** `[object, property, value]` triples into setters whose original is `orig:<object>.<property>`. */
+function setters(triples: readonly (readonly [string, string, string])[]): BreakpointSetter<string>[] {
+    return triples.map(([object, property, value]) => ({
+        object,
+        property,
+        value,
+        originalValue: `orig:${object}.${property}`,
+    }));
 }
+
+/** A write, spelled the way {@link BREAKPOINT_TRANSITION_VECTORS} spells one. */
+const spell = (write: { object: string; property: string; value: unknown }) =>
+    `${write.object}.${write.property}=${write.value}`;
 
 export default async () => {
     await describe('BreakpointBinState picks one breakpoint', async () => {
@@ -35,12 +49,12 @@ export default async () => {
         for (const vector of BREAKPOINT_TRANSITION_VECTORS) {
             await it(vector.rule, async () => {
                 const bin = new BreakpointBinState<string>();
-                for (const [condition, pairs] of vector.breakpoints) {
-                    bin.add({ condition, setters: setters(pairs) });
+                for (const [condition, triples] of vector.breakpoints) {
+                    bin.add({ condition, setters: setters(triples) });
                 }
                 const got = vector.sizes.map((size) => {
                     const transition = bin.evaluate(size);
-                    return transition === null ? null : transition.writes.map((w) => `${w.property}=${w.value}`);
+                    return transition === null ? null : transition.writes.map(spell);
                 });
                 expect(got).toStrictEqual(vector.writes.map((w) => (w === null ? null : [...w])));
             });
@@ -48,8 +62,8 @@ export default async () => {
 
         await it('reports which breakpoint it left and which it entered', async () => {
             const bin = new BreakpointBinState<string>();
-            bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
-            bin.add({ condition: 'max-width: 400sp', setters: setters([['collapsed', 'false']]) });
+            bin.add({ condition: 'max-width: 720sp', setters: setters([['view', 'collapsed', 'true']]) });
+            bin.add({ condition: 'max-width: 400sp', setters: setters([['view', 'collapsed', 'false']]) });
 
             const entered = bin.evaluate({ width: 500, height: 600 });
             expect(entered?.from).toBe(null);
@@ -58,22 +72,6 @@ export default async () => {
             const swapped = bin.evaluate({ width: 300, height: 600 });
             expect(swapped?.from).toBe(0);
             expect(swapped?.to).toBe(1);
-        });
-
-        await it('setters on DIFFERENT objects are both restored, even for the same property', async () => {
-            // The skip keys on object AND property. Two widgets whose `collapsed` a
-            // breakpoint sets are two setters, and leaving must restore both.
-            const bin = new BreakpointBinState<string>();
-            bin.add({
-                condition: 'max-width: 720sp',
-                setters: [
-                    { object: 'a', property: 'collapsed', value: 'true', originalValue: 'origA' },
-                    { object: 'b', property: 'collapsed', value: 'true', originalValue: 'origB' },
-                ],
-            });
-            bin.evaluate({ width: 500, height: 600 });
-            const left = bin.evaluate({ width: 900, height: 600 });
-            expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toStrictEqual(['a:origA', 'b:origB']);
         });
     });
 
@@ -99,7 +97,7 @@ export default async () => {
 
         await it('reset drops the applied breakpoint without producing writes', async () => {
             const bin = new BreakpointBinState<string>();
-            bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
+            bin.add({ condition: 'max-width: 720sp', setters: setters([['view', 'collapsed', 'true']]) });
             bin.evaluate({ width: 500, height: 600 });
             bin.reset();
             expect(bin.current).toBe(null);

--- a/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect } from '@gjsify/unit';
 
 import { BreakpointBinState } from './breakpoint-bin.js';
-import type { BreakpointSetter } from './breakpoint-bin.js';
+import type { BreakpointDefinition, BreakpointSetter } from './breakpoint-bin.js';
 import { BREAKPOINT_PICK_VECTORS, BREAKPOINT_TRANSITION_VECTORS } from './conformance/breakpoint-bin.js';
 
 /** `[object, property, value]` triples into setters whose original is `orig:<object>.<property>`. */
@@ -75,7 +75,7 @@ export default async () => {
         });
     });
 
-    await describe('BreakpointBinState child and reset', async () => {
+    await describe('BreakpointBinState child and inheritance', async () => {
         await it('a childless bin keeps the breakpoint it had', async () => {
             const bin = new BreakpointBinState<string>();
             bin.add({ condition: 'max-width: 720sp', setters: [] });
@@ -95,16 +95,54 @@ export default async () => {
             expect(bin.evaluate({ width: 900, height: 600 })?.to).toBe(null);
         });
 
-        await it('reset drops the applied breakpoint without producing writes', async () => {
+        // The paid-for bug, at bin level: a renderer that REBUILDS the bin on reconnect
+        // (the browser rebinds its ResizeObserver after a re-parent) loses which breakpoint
+        // was applied. `evaluate` fires on a change only, so the 900px pass that should
+        // leave the breakpoint matches the fresh bin's own "none applied" starting state
+        // and writes nothing. Measured on `AdwBreakpoint`: 800 → 500 → 900 stayed collapsed
+        // at 900. The three sizes are the sequence, not a round number.
+        await it('a rebuilt bin that inherits the pick still restores on the way out', async () => {
+            const definition: BreakpointDefinition<string> = {
+                condition: 'max-width: 720sp',
+                setters: setters([['view', 'collapsed', 'true']]),
+            };
+
+            const first = new BreakpointBinState<string>();
+            first.add(definition);
+            expect(first.evaluate({ width: 800, height: 600 })).toBe(null);
+            expect(first.evaluate({ width: 500, height: 600 })?.writes.map(spell)).toStrictEqual([
+                'view.collapsed=true',
+            ]);
+
+            // The element reconnects: same definitions, a brand-new bin.
+            const rebuilt = new BreakpointBinState<string>();
+            rebuilt.add(definition);
+            rebuilt.inherit(first.current);
+
+            const widened = rebuilt.evaluate({ width: 900, height: 600 });
+            expect(widened?.from).toBe(0);
+            expect(widened?.to).toBe(null);
+            expect(widened?.writes.map(spell)).toStrictEqual(['view.collapsed=orig:view.collapsed']);
+        });
+
+        await it('inherit(null) starts with none applied, so the next evaluation enters', async () => {
             const bin = new BreakpointBinState<string>();
             bin.add({ condition: 'max-width: 720sp', setters: setters([['view', 'collapsed', 'true']]) });
             bin.evaluate({ width: 500, height: 600 });
-            bin.reset();
+            bin.inherit(null);
             expect(bin.current).toBe(null);
-            // The next evaluation is a first evaluation: it enters, it does not transition out.
             const again = bin.evaluate({ width: 500, height: 600 });
             expect(again?.from).toBe(null);
             expect(again?.to).toBe(0);
+        });
+
+        await it('inherit throws on an index this bin does not have', async () => {
+            const bin = new BreakpointBinState<string>();
+            bin.add({ condition: 'max-width: 720sp', setters: [] });
+            expect(() => bin.inherit(1)).toThrow();
+            // Loud beats quiet here: a swallowed stale index is the restore that never
+            // happens, which is the bug `inherit` exists to prevent.
+            expect(bin.current).toBe(null);
         });
     });
 };

--- a/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.spec.ts
@@ -12,99 +12,101 @@ function setters(pairs: readonly (readonly [string, string])[]): BreakpointSette
     return pairs.map(([property, value]) => ({ object: 'w', property, value, originalValue: `orig:${property}` }));
 }
 
-await describe('BreakpointBinState picks one breakpoint', async () => {
-    for (const vector of BREAKPOINT_PICK_VECTORS) {
-        await it(vector.rule, async () => {
-            const bin = new BreakpointBinState<string>();
-            for (const condition of vector.conditions) bin.add({ condition, setters: [] });
-            bin.evaluate(vector.size);
-            expect(bin.current).toBe(vector.pick);
-        });
-    }
-
-    await it('add returns the index the transition reports', async () => {
-        const bin = new BreakpointBinState<string>();
-        expect(bin.add({ condition: 'max-width: 400sp', setters: [] })).toBe(0);
-        expect(bin.add({ condition: 'max-width: 720sp', setters: [] })).toBe(1);
-        expect(bin.length).toBe(2);
-    });
-});
-
-await describe('BreakpointBinState transitions', async () => {
-    for (const vector of BREAKPOINT_TRANSITION_VECTORS) {
-        await it(vector.rule, async () => {
-            const bin = new BreakpointBinState<string>();
-            for (const [condition, pairs] of vector.breakpoints) {
-                bin.add({ condition, setters: setters(pairs) });
-            }
-            const got = vector.sizes.map((size) => {
-                const transition = bin.evaluate(size);
-                return transition === null ? null : transition.writes.map((w) => `${w.property}=${w.value}`);
+export default async () => {
+    await describe('BreakpointBinState picks one breakpoint', async () => {
+        for (const vector of BREAKPOINT_PICK_VECTORS) {
+            await it(vector.rule, async () => {
+                const bin = new BreakpointBinState<string>();
+                for (const condition of vector.conditions) bin.add({ condition, setters: [] });
+                bin.evaluate(vector.size);
+                expect(bin.current).toBe(vector.pick);
             });
-            expect(got).toEqual(vector.writes.map((w) => (w === null ? null : [...w])));
+        }
+
+        await it('add returns the index the transition reports', async () => {
+            const bin = new BreakpointBinState<string>();
+            expect(bin.add({ condition: 'max-width: 400sp', setters: [] })).toBe(0);
+            expect(bin.add({ condition: 'max-width: 720sp', setters: [] })).toBe(1);
+            expect(bin.length).toBe(2);
         });
-    }
-
-    await it('reports which breakpoint it left and which it entered', async () => {
-        const bin = new BreakpointBinState<string>();
-        bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
-        bin.add({ condition: 'max-width: 400sp', setters: setters([['collapsed', 'false']]) });
-
-        const entered = bin.evaluate({ width: 500, height: 600 });
-        expect(entered?.from).toBe(null);
-        expect(entered?.to).toBe(0);
-
-        const swapped = bin.evaluate({ width: 300, height: 600 });
-        expect(swapped?.from).toBe(0);
-        expect(swapped?.to).toBe(1);
     });
 
-    await it('setters on DIFFERENT objects are both restored, even for the same property', async () => {
-        // The skip keys on object AND property. Two widgets whose `collapsed` a
-        // breakpoint sets are two setters, and leaving must restore both.
-        const bin = new BreakpointBinState<string>();
-        bin.add({
-            condition: 'max-width: 720sp',
-            setters: [
-                { object: 'a', property: 'collapsed', value: 'true', originalValue: 'origA' },
-                { object: 'b', property: 'collapsed', value: 'true', originalValue: 'origB' },
-            ],
+    await describe('BreakpointBinState transitions', async () => {
+        for (const vector of BREAKPOINT_TRANSITION_VECTORS) {
+            await it(vector.rule, async () => {
+                const bin = new BreakpointBinState<string>();
+                for (const [condition, pairs] of vector.breakpoints) {
+                    bin.add({ condition, setters: setters(pairs) });
+                }
+                const got = vector.sizes.map((size) => {
+                    const transition = bin.evaluate(size);
+                    return transition === null ? null : transition.writes.map((w) => `${w.property}=${w.value}`);
+                });
+                expect(got).toEqual(vector.writes.map((w) => (w === null ? null : [...w])));
+            });
+        }
+
+        await it('reports which breakpoint it left and which it entered', async () => {
+            const bin = new BreakpointBinState<string>();
+            bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
+            bin.add({ condition: 'max-width: 400sp', setters: setters([['collapsed', 'false']]) });
+
+            const entered = bin.evaluate({ width: 500, height: 600 });
+            expect(entered?.from).toBe(null);
+            expect(entered?.to).toBe(0);
+
+            const swapped = bin.evaluate({ width: 300, height: 600 });
+            expect(swapped?.from).toBe(0);
+            expect(swapped?.to).toBe(1);
         });
-        bin.evaluate({ width: 500, height: 600 });
-        const left = bin.evaluate({ width: 900, height: 600 });
-        expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toEqual(['a:origA', 'b:origB']);
-    });
-});
 
-await describe('BreakpointBinState child and reset', async () => {
-    await it('a childless bin keeps the breakpoint it had', async () => {
-        const bin = new BreakpointBinState<string>();
-        bin.add({ condition: 'max-width: 720sp', setters: [] });
-        bin.evaluate({ width: 500, height: 600 });
-        bin.setHasChild(false);
-        expect(bin.evaluate({ width: 900, height: 600 })).toBe(null);
-        expect(bin.current).toBe(0);
-    });
-
-    await it('the change happens once the child is back', async () => {
-        const bin = new BreakpointBinState<string>();
-        bin.add({ condition: 'max-width: 720sp', setters: [] });
-        bin.evaluate({ width: 500, height: 600 });
-        bin.setHasChild(false);
-        bin.evaluate({ width: 900, height: 600 });
-        bin.setHasChild(true);
-        expect(bin.evaluate({ width: 900, height: 600 })?.to).toBe(null);
+        await it('setters on DIFFERENT objects are both restored, even for the same property', async () => {
+            // The skip keys on object AND property. Two widgets whose `collapsed` a
+            // breakpoint sets are two setters, and leaving must restore both.
+            const bin = new BreakpointBinState<string>();
+            bin.add({
+                condition: 'max-width: 720sp',
+                setters: [
+                    { object: 'a', property: 'collapsed', value: 'true', originalValue: 'origA' },
+                    { object: 'b', property: 'collapsed', value: 'true', originalValue: 'origB' },
+                ],
+            });
+            bin.evaluate({ width: 500, height: 600 });
+            const left = bin.evaluate({ width: 900, height: 600 });
+            expect(left?.writes.map((w) => `${w.object}:${w.value}`)).toEqual(['a:origA', 'b:origB']);
+        });
     });
 
-    await it('reset drops the applied breakpoint without producing writes', async () => {
-        const bin = new BreakpointBinState<string>();
-        bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
-        bin.evaluate({ width: 500, height: 600 });
-        bin.reset();
-        expect(bin.current).toBe(null);
-        // The next evaluation is a first evaluation: it enters, it does not transition out.
-        const again = bin.evaluate({ width: 500, height: 600 });
-        expect(again?.from).toBe(null);
-        expect(again?.to).toBe(0);
+    await describe('BreakpointBinState child and reset', async () => {
+        await it('a childless bin keeps the breakpoint it had', async () => {
+            const bin = new BreakpointBinState<string>();
+            bin.add({ condition: 'max-width: 720sp', setters: [] });
+            bin.evaluate({ width: 500, height: 600 });
+            bin.setHasChild(false);
+            expect(bin.evaluate({ width: 900, height: 600 })).toBe(null);
+            expect(bin.current).toBe(0);
+        });
+
+        await it('the change happens once the child is back', async () => {
+            const bin = new BreakpointBinState<string>();
+            bin.add({ condition: 'max-width: 720sp', setters: [] });
+            bin.evaluate({ width: 500, height: 600 });
+            bin.setHasChild(false);
+            bin.evaluate({ width: 900, height: 600 });
+            bin.setHasChild(true);
+            expect(bin.evaluate({ width: 900, height: 600 })?.to).toBe(null);
+        });
+
+        await it('reset drops the applied breakpoint without producing writes', async () => {
+            const bin = new BreakpointBinState<string>();
+            bin.add({ condition: 'max-width: 720sp', setters: setters([['collapsed', 'true']]) });
+            bin.evaluate({ width: 500, height: 600 });
+            bin.reset();
+            expect(bin.current).toBe(null);
+            // The next evaluation is a first evaluation: it enters, it does not transition out.
+            const again = bin.evaluate({ width: 500, height: 600 });
+            expect(again?.from).toBe(null);
+            expect(again?.to).toBe(0);
+        });
     });
-});
+};

--- a/packages/web/adwaita-core/src/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.ts
@@ -3,28 +3,40 @@
 // `AdwBreakpoint` (`./breakpoint.ts`) answers "does this condition hold" for ONE
 // breakpoint, independently of every other. The BIN is the part that was missing: it
 // owns a list of them, picks at most one, and works out what to write when the pick
-// changes. Three rules in it are not guessable, and all three come from the C source.
+// changes. Four rules in it are not guessable, and all four come from the C source.
 //
 //   1. **The last matching breakpoint added wins**, not the narrowest and not the best
 //      fit. `adw_breakpoint_bin_size_allocate` iterates the array backwards and takes
 //      the first match: "Iterate in reverse order since we prioritize breakpoints added
-//      last" (adw-breakpoint-bin.c:432). `./breakpoint.ts` describes this as "the best
+//      last" (adw-breakpoint-bin.c:432). `./breakpoint.ts` described this as "the best
 //      match", which is the intuitive reading and the wrong one.
 //   2. **A property both breakpoints set is never restored in between.**
 //      `adw_breakpoint_transition` skips a setter the incoming breakpoint also carries:
 //      "Don't unset the property if we'll immediately set it again afterwards"
 //      (adw-breakpoint.c:1799). Restoring it first would put the widget through a state
-//      neither breakpoint describes, once per resize across the boundary.
+//      neither breakpoint describes, once per resize across the boundary. The skip keys
+//      on OBJECT and property together (`setter_equal`, adw-breakpoint.c:1060), so the
+//      same property on a second widget is still restored.
 //   3. **The original value is captured when the setter is REGISTERED**, not when the
 //      breakpoint applies (`g_object_get_property` at adw-breakpoint.c:1627). A property
 //      changed by other code after registration is therefore restored to what it held at
 //      registration, which is surprising until you need it: it makes unapply the exact
 //      inverse of apply rather than a diff against a moving target.
+//   4. **Unapply is signalled BEFORE the writes, apply AFTER them.**
+//      `adw_breakpoint_transition` emits the outgoing breakpoint's `unapply`
+//      (adw-breakpoint.c:1793), then restores, then sets, then emits the incoming one's
+//      `apply` (:1819) — so a callback on either end sees the properties in the state its
+//      own breakpoint describes, never the other one's.
 //
 // The size SOURCE stays with the renderer, as it does for `AdwBreakpoint`. What this
 // module never does is write anything: `evaluate` returns the writes and the renderer
 // performs them, because a headless module has no property setter and should not pretend
 // to.
+//
+// One method has no C counterpart at all — `BreakpointBinState.inherit`, which seeds
+// the applied breakpoint. A GTK bin is never rebuilt; a browser element is, on every
+// reconnect, and a bin that restarts at "none applied" silently keeps the properties the
+// bin it replaced had set. Its docblock carries the measurement.
 //
 // Reference: refs/libadwaita/src/adw-breakpoint-bin.c
 // Reference: refs/libadwaita/src/adw-breakpoint.c (adw_breakpoint_transition)
@@ -61,7 +73,15 @@ export interface BreakpointWrite<O> {
     readonly value: unknown;
 }
 
-/** What changes when the applied breakpoint changes. */
+/**
+ * What changes when the applied breakpoint changes.
+ *
+ * `Adw.Breakpoint`'s apply/unapply signals have no field here, because the bin holds
+ * condition strings and setter DATA — never an `AdwBreakpoint` (`./breakpoint.ts`), whose
+ * callbacks it therefore cannot run. {@link from} and {@link to} are how a renderer that
+ * has callbacks gets the ORDER right, and rule 4 above is what that order is: the
+ * outgoing breakpoint's unapply, then {@link writes}, then the incoming one's apply.
+ */
 export interface BreakpointTransition<O> {
     /** Index of the breakpoint being left, or null when none was applied. */
     readonly from: number | null;
@@ -166,14 +186,40 @@ export class BreakpointBinState<O> {
     }
 
     /**
-     * Drop the applied breakpoint without producing writes.
+     * Take over the applied breakpoint from the bin this one REPLACES, or `null` to start
+     * with none applied.
      *
-     * For a renderer rebuilding the bin: the widget is going away, so restoring
-     * properties on it is pointless, and the next `evaluate` should behave as a first
-     * evaluation rather than transition out of a breakpoint nothing is applying.
+     * No `Adw.BreakpointBin` counterpart, because a GTK bin is never rebuilt — the widget
+     * outlives every resize. A browser element rebinds on every `connectedCallback`, and
+     * {@link evaluate} fires on a CHANGE only, so a fresh bin that starts at "none
+     * applied" reads the size that LEFT the old breakpoint's range as no change at all,
+     * produces no writes, and leaves the widget holding what the old bin set. This is the
+     * seed `AdwBreakpoint`'s `applied` parameter carries (`./breakpoint.ts`), one level
+     * up, and it was paid for once already: a `<adw-navigation-split-view>` driven
+     * 800px → 500px → 900px stayed collapsed at 900px, and only a narrow → wide cycle IN
+     * PLACE healed it.
+     *
+     * Call it after {@link add}, and read each setter's `originalValue` BEFORE the old bin
+     * applied anything: the restore this enables writes the NEW definitions' originals, so
+     * an original read off a widget the outgoing breakpoint has already changed restores
+     * it to the applied value, which is no restore at all.
+     *
+     * Throws on an index this bin does not have rather than quietly applying nothing — a
+     * stale index means the caller's breakpoint list moved, and the restore it would skip
+     * is the whole bug this method exists to prevent.
      */
-    reset(): void {
-        this._current = null;
+    inherit(current: number | null): void {
+        if (current === null) {
+            this._current = null;
+            return;
+        }
+        const breakpoint = this._breakpoints[current];
+        if (!breakpoint) {
+            throw new RangeError(
+                `BreakpointBinState.inherit: no breakpoint at index ${current}; ${this._breakpoints.length} added.`,
+            );
+        }
+        this._current = breakpoint;
     }
 }
 

--- a/packages/web/adwaita-core/src/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.ts
@@ -8,12 +8,12 @@
 //   1. **The last matching breakpoint added wins**, not the narrowest and not the best
 //      fit. `adw_breakpoint_bin_size_allocate` iterates the array backwards and takes
 //      the first match: "Iterate in reverse order since we prioritize breakpoints added
-//      last" (adw-breakpoint-bin.c:433). `./breakpoint.ts` describes this as "the best
+//      last" (adw-breakpoint-bin.c:432). `./breakpoint.ts` describes this as "the best
 //      match", which is the intuitive reading and the wrong one.
 //   2. **A property both breakpoints set is never restored in between.**
 //      `adw_breakpoint_transition` skips a setter the incoming breakpoint also carries:
 //      "Don't unset the property if we'll immediately set it again afterwards"
-//      (adw-breakpoint.c:1800). Restoring it first would put the widget through a state
+//      (adw-breakpoint.c:1799). Restoring it first would put the widget through a state
 //      neither breakpoint describes, once per resize across the boundary.
 //   3. **The original value is captured when the setter is REGISTERED**, not when the
 //      breakpoint applies (`g_object_get_property` at adw-breakpoint.c:1627). A property
@@ -144,7 +144,7 @@ export class BreakpointBinState<O> {
     evaluate(size: BreakpointSize): BreakpointTransition<O> | null {
         if (!this._hasChild) return null;
 
-        // Backwards: the LAST matching breakpoint wins (adw-breakpoint-bin.c:433).
+        // Backwards: the LAST matching breakpoint wins (adw-breakpoint-bin.c:432).
         let next: Compiled<O> | null = null;
         for (let i = this._breakpoints.length - 1; i >= 0; i--) {
             const candidate = this._breakpoints[i] as Compiled<O>;

--- a/packages/web/adwaita-core/src/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/breakpoint-bin.ts
@@ -1,0 +1,201 @@
+// AdwBreakpointBin — headless (ADR 0004).
+//
+// `AdwBreakpoint` (`./breakpoint.ts`) answers "does this condition hold" for ONE
+// breakpoint, independently of every other. The BIN is the part that was missing: it
+// owns a list of them, picks at most one, and works out what to write when the pick
+// changes. Three rules in it are not guessable, and all three come from the C source.
+//
+//   1. **The last matching breakpoint added wins**, not the narrowest and not the best
+//      fit. `adw_breakpoint_bin_size_allocate` iterates the array backwards and takes
+//      the first match: "Iterate in reverse order since we prioritize breakpoints added
+//      last" (adw-breakpoint-bin.c:433). `./breakpoint.ts` describes this as "the best
+//      match", which is the intuitive reading and the wrong one.
+//   2. **A property both breakpoints set is never restored in between.**
+//      `adw_breakpoint_transition` skips a setter the incoming breakpoint also carries:
+//      "Don't unset the property if we'll immediately set it again afterwards"
+//      (adw-breakpoint.c:1800). Restoring it first would put the widget through a state
+//      neither breakpoint describes, once per resize across the boundary.
+//   3. **The original value is captured when the setter is REGISTERED**, not when the
+//      breakpoint applies (`g_object_get_property` at adw-breakpoint.c:1627). A property
+//      changed by other code after registration is therefore restored to what it held at
+//      registration, which is surprising until you need it: it makes unapply the exact
+//      inverse of apply rather than a diff against a moving target.
+//
+// The size SOURCE stays with the renderer, as it does for `AdwBreakpoint`. What this
+// module never does is write anything: `evaluate` returns the writes and the renderer
+// performs them, because a headless module has no property setter and should not pretend
+// to.
+//
+// Reference: refs/libadwaita/src/adw-breakpoint-bin.c
+// Reference: refs/libadwaita/src/adw-breakpoint.c (adw_breakpoint_transition)
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+import { evaluateBreakpointCondition, parseBreakpointCondition } from './breakpoint.js';
+import type { BreakpointConditionNode, BreakpointSize } from './breakpoint.js';
+
+/**
+ * One property a breakpoint writes while it is applied.
+ *
+ * `originalValue` is supplied by the caller rather than read here, and it is read ONCE,
+ * when the setter is registered. That mirrors `adw_breakpoint_add_setter`, and it is
+ * also the only thing a headless module can do: it holds no widgets.
+ */
+export interface BreakpointSetter<O> {
+    readonly object: O;
+    readonly property: string;
+    readonly value: unknown;
+    readonly originalValue: unknown;
+}
+
+/** A condition plus the properties it writes. */
+export interface BreakpointDefinition<O> {
+    /** A Libadwaita condition string, e.g. `'max-width: 720sp'`. */
+    readonly condition: string;
+    readonly setters: readonly BreakpointSetter<O>[];
+}
+
+/** One property write a renderer performs. */
+export interface BreakpointWrite<O> {
+    readonly object: O;
+    readonly property: string;
+    readonly value: unknown;
+}
+
+/** What changes when the applied breakpoint changes. */
+export interface BreakpointTransition<O> {
+    /** Index of the breakpoint being left, or null when none was applied. */
+    readonly from: number | null;
+    /** Index of the breakpoint being entered, or null when none matches. */
+    readonly to: number | null;
+    /**
+     * The writes to perform, in order: restores first, then the incoming values.
+     *
+     * A property both breakpoints set appears ONCE, carrying the incoming value. It is
+     * not restored and then re-set, which would take the widget through a state neither
+     * breakpoint describes.
+     */
+    readonly writes: readonly BreakpointWrite<O>[];
+}
+
+/** A parsed definition plus its index, so the pick can report which one it took. */
+interface Compiled<O> {
+    readonly index: number;
+    readonly condition: BreakpointConditionNode | null;
+    readonly setters: readonly BreakpointSetter<O>[];
+}
+
+/**
+ * `Adw.BreakpointBin`'s pick-one-and-transition behaviour, over opaque objects.
+ *
+ * Generic in the object type because the core holds no widgets: `O` is whatever the
+ * renderer's handle is, and this class only ever compares them by identity.
+ */
+export class BreakpointBinState<O> {
+    private readonly _breakpoints: Compiled<O>[] = [];
+    private _current: Compiled<O> | null = null;
+    private _hasChild = true;
+
+    /**
+     * `adw_breakpoint_bin_add_breakpoint`. Returns the index, which is what
+     * {@link BreakpointTransition} reports.
+     *
+     * Order is meaningful: a later breakpoint beats an earlier one when both match.
+     */
+    add(definition: BreakpointDefinition<O>): number {
+        const index = this._breakpoints.length;
+        this._breakpoints.push({
+            index,
+            condition: parseBreakpointCondition(definition.condition),
+            setters: definition.setters,
+        });
+        return index;
+    }
+
+    /**
+     * Whether the bin has a child.
+     *
+     * `adw_breakpoint_bin_size_allocate` returns before picking anything when there is
+     * no child (adw-breakpoint-bin.c:427), so a childless bin keeps whatever breakpoint
+     * it had rather than dropping to none. Modelled rather than left to the renderer
+     * because "the applied breakpoint did not change while the child was away" is a
+     * behaviour, and the alternative is each renderer rediscovering it.
+     */
+    setHasChild(hasChild: boolean): void {
+        this._hasChild = hasChild;
+    }
+
+    /** The index of the applied breakpoint, or null when none is. */
+    get current(): number | null {
+        return this._current?.index ?? null;
+    }
+
+    /** How many breakpoints have been added. */
+    get length(): number {
+        return this._breakpoints.length;
+    }
+
+    /**
+     * Re-pick against `size` and return the writes, or `null` when nothing changed.
+     *
+     * Null rather than an empty transition, so a renderer driving this from every
+     * allocation can skip the whole path on the overwhelmingly common no-change case
+     * without inspecting an object.
+     */
+    evaluate(size: BreakpointSize): BreakpointTransition<O> | null {
+        if (!this._hasChild) return null;
+
+        // Backwards: the LAST matching breakpoint wins (adw-breakpoint-bin.c:433).
+        let next: Compiled<O> | null = null;
+        for (let i = this._breakpoints.length - 1; i >= 0; i--) {
+            const candidate = this._breakpoints[i] as Compiled<O>;
+            if (candidate.condition && evaluateBreakpointCondition(candidate.condition, size)) {
+                next = candidate;
+                break;
+            }
+        }
+
+        if (next === this._current) return null;
+
+        const from = this._current;
+        this._current = next;
+        return {
+            from: from?.index ?? null,
+            to: next?.index ?? null,
+            writes: transitionWrites(from, next),
+        };
+    }
+
+    /**
+     * Drop the applied breakpoint without producing writes.
+     *
+     * For a renderer rebuilding the bin: the widget is going away, so restoring
+     * properties on it is pointless, and the next `evaluate` should behave as a first
+     * evaluation rather than transition out of a breakpoint nothing is applying.
+     */
+    reset(): void {
+        this._current = null;
+    }
+}
+
+/** `adw_breakpoint_transition` as data: restores that survive the skip, then the new values. */
+function transitionWrites<O>(from: Compiled<O> | null, to: Compiled<O> | null): BreakpointWrite<O>[] {
+    const writes: BreakpointWrite<O>[] = [];
+    if (from) {
+        for (const setter of from.setters) {
+            // The skip: `to` setting the same property on the same object means the
+            // restore would be overwritten on the next line anyway, and performing it
+            // shows a value neither breakpoint asked for.
+            const alsoIncoming = to?.setters.some(
+                (other) => other.object === setter.object && other.property === setter.property,
+            );
+            if (alsoIncoming) continue;
+            writes.push({ object: setter.object, property: setter.property, value: setter.originalValue });
+        }
+    }
+    if (to) {
+        for (const setter of to.setters) {
+            writes.push({ object: setter.object, property: setter.property, value: setter.value });
+        }
+    }
+    return writes;
+}

--- a/packages/web/adwaita-core/src/breakpoint.ts
+++ b/packages/web/adwaita-core/src/breakpoint.ts
@@ -14,11 +14,16 @@
 // and CSS px effectively are). Conditions support `min-width` / `max-width` / `min-height` /
 // `max-height` leaves joined by `and` / `or` with optional parentheses.
 //
-// DIVERGENCE from `Adw.Breakpoint`: Adwaita keeps at most ONE breakpoint applied at a time
-// (the best match) and unapplies the others, because breakpoints there fight over the same
-// GObject properties. Here each breakpoint owns independent apply/unapply callbacks, so a
-// renderer evaluates each on its own merits — identical for the common single-breakpoint
-// case.
+// NOT A DIVERGENCE, A SPLIT. Adwaita keeps at most ONE breakpoint applied at a time,
+// because breakpoints there fight over the same GObject properties. That selection is not
+// `Adw.Breakpoint`'s job and it is not this class's either: it belongs to the BIN, and it
+// lives in `./breakpoint-bin.ts` with the two rules that make it non-obvious. This class
+// answers "does my condition hold" for one breakpoint, which is what
+// `adw_breakpoint_check_condition` does.
+//
+// The comment here used to say the bin picks "the best match". It does not: it picks the
+// one added LAST among those that match (adw-breakpoint-bin.c:433). The intuitive reading
+// and the wrong one, which is why it now has vectors.
 //
 // Reference: refs/libadwaita/src/adw-breakpoint.c (condition grammar, apply/unapply)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.

--- a/packages/web/adwaita-core/src/breakpoint.ts
+++ b/packages/web/adwaita-core/src/breakpoint.ts
@@ -22,7 +22,7 @@
 // `adw_breakpoint_check_condition` does.
 //
 // The comment here used to say the bin picks "the best match". It does not: it picks the
-// one added LAST among those that match (adw-breakpoint-bin.c:433). The intuitive reading
+// one added LAST among those that match (adw-breakpoint-bin.c:432). The intuitive reading
 // and the wrong one, which is why it now has vectors.
 //
 // Reference: refs/libadwaita/src/adw-breakpoint.c (condition grammar, apply/unapply)

--- a/packages/web/adwaita-core/src/breakpoint.ts
+++ b/packages/web/adwaita-core/src/breakpoint.ts
@@ -14,16 +14,22 @@
 // and CSS px effectively are). Conditions support `min-width` / `max-width` / `min-height` /
 // `max-height` leaves joined by `and` / `or` with optional parentheses.
 //
-// NOT A DIVERGENCE, A SPLIT. Adwaita keeps at most ONE breakpoint applied at a time,
-// because breakpoints there fight over the same GObject properties. That selection is not
-// `Adw.Breakpoint`'s job and it is not this class's either: it belongs to the BIN, and it
-// lives in `./breakpoint-bin.ts` with the two rules that make it non-obvious. This class
-// answers "does my condition hold" for one breakpoint, which is what
-// `adw_breakpoint_check_condition` does.
+// ONE DIVERGENCE, ONE SPLIT — they used to be one paragraph here, and the paragraph got
+// the second one wrong.
 //
-// The comment here used to say the bin picks "the best match". It does not: it picks the
-// one added LAST among those that match (adw-breakpoint-bin.c:432). The intuitive reading
-// and the wrong one, which is why it now has vectors.
+// The DIVERGENCE: `Adw.Breakpoint` carries SETTERS as well as apply/unapply signals
+// (`adw_breakpoint_add_setter`); this class carries only the callbacks, because a headless
+// module holds no widgets and has no property to set. `./breakpoint-bin.ts` models the
+// setter side as DATA instead — a transition returns the writes and the renderer performs
+// them — and it records there that the two objects do not compose today.
+//
+// The SPLIT: "at most ONE breakpoint applied at a time", which Adwaita needs because
+// breakpoints there fight over the same GObject properties, is not this class's rule at
+// all. It is the BIN's, together with the rule that makes it non-obvious: the winner is
+// the one added LAST among those that match (adw-breakpoint-bin.c:432), not the narrowest
+// and not the best fit. This comment used to say "the best match" — the intuitive reading
+// and the wrong one, which is why it now has vectors. This class answers "does my
+// condition hold" for one breakpoint, which is what `adw_breakpoint_check_condition` does.
 //
 // Reference: refs/libadwaita/src/adw-breakpoint.c (condition grammar, apply/unapply)
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.

--- a/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
@@ -80,13 +80,21 @@ export const BREAKPOINT_PICK_VECTORS: ReadonlyArray<BreakpointPickVector> = [
     },
 ];
 
-/** One transition expectation, written as property names rather than objects. */
+/**
+ * One transition expectation, written as object and property NAMES rather than real widgets.
+ *
+ * The object is spelled out on every setter rather than left implicit, because rule 2's skip
+ * keys on object AND property (`setter_equal`, adw-breakpoint.c:1060): a table with one
+ * object in it cannot tell a correct implementation from one that drops the object half.
+ * Measured — with every setter on a single object, blinding the skip to the object left the
+ * whole suite green.
+ */
 export interface BreakpointTransitionVector {
-    /** Each breakpoint as `[condition, [[property, value] …]]`; originals are `orig:<property>`. */
-    breakpoints: readonly [string, readonly (readonly [string, string])[]][];
+    /** Each breakpoint as `[condition, [[object, property, value] …]]`; originals are `orig:<object>.<property>`. */
+    breakpoints: readonly [string, readonly (readonly [string, string, string])[]][];
     /** Sizes to evaluate in order. */
     sizes: readonly { width: number; height: number }[];
-    /** Expected writes per evaluation, `property=value`; `null` is "no transition". */
+    /** Expected writes per evaluation, `object.property=value`; `null` is "no transition". */
     writes: readonly (readonly string[] | null)[];
     rule: string;
 }
@@ -103,39 +111,39 @@ export interface BreakpointTransitionVector {
  */
 export const BREAKPOINT_TRANSITION_VECTORS: ReadonlyArray<BreakpointTransitionVector> = [
     {
-        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        breakpoints: [['max-width: 720sp', [['view', 'collapsed', 'true']]]],
         sizes: [{ width: 500, height: 600 }],
-        writes: [['collapsed=true']],
+        writes: [['view.collapsed=true']],
         rule: 'entering a breakpoint writes its setters',
     },
     {
-        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        breakpoints: [['max-width: 720sp', [['view', 'collapsed', 'true']]]],
         sizes: [
             { width: 500, height: 600 },
             { width: 900, height: 600 },
         ],
-        writes: [['collapsed=true'], ['collapsed=orig:collapsed']],
+        writes: [['view.collapsed=true'], ['view.collapsed=orig:view.collapsed']],
         rule: 'leaving restores the ORIGINAL, which was captured when the setter was registered',
     },
     {
-        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        breakpoints: [['max-width: 720sp', [['view', 'collapsed', 'true']]]],
         sizes: [
             { width: 500, height: 600 },
             { width: 400, height: 600 },
         ],
-        writes: [['collapsed=true'], null],
+        writes: [['view.collapsed=true'], null],
         rule: 'staying inside the same breakpoint produces no transition at all',
     },
     {
         breakpoints: [
-            ['max-width: 720sp', [['collapsed', 'true']]],
-            ['max-width: 400sp', [['collapsed', 'false']]],
+            ['max-width: 720sp', [['view', 'collapsed', 'true']]],
+            ['max-width: 400sp', [['view', 'collapsed', 'false']]],
         ],
         sizes: [
             { width: 500, height: 600 },
             { width: 300, height: 600 },
         ],
-        writes: [['collapsed=true'], ['collapsed=false']],
+        writes: [['view.collapsed=true'], ['view.collapsed=false']],
         rule: 'a property BOTH set is written once, not restored and re-set',
     },
     {
@@ -143,29 +151,70 @@ export const BREAKPOINT_TRANSITION_VECTORS: ReadonlyArray<BreakpointTransitionVe
             [
                 'max-width: 720sp',
                 [
-                    ['collapsed', 'true'],
-                    ['title', 'narrow'],
+                    ['view', 'collapsed', 'true'],
+                    ['view', 'title', 'narrow'],
                 ],
             ],
-            ['max-width: 400sp', [['collapsed', 'false']]],
+            ['max-width: 400sp', [['view', 'collapsed', 'false']]],
         ],
         sizes: [
             { width: 500, height: 600 },
             { width: 300, height: 600 },
         ],
         writes: [
-            ['collapsed=true', 'title=narrow'],
-            ['title=orig:title', 'collapsed=false'],
+            ['view.collapsed=true', 'view.title=narrow'],
+            ['view.title=orig:view.title', 'view.collapsed=false'],
         ],
         rule: 'only the property the incoming breakpoint does NOT set is restored, and restores come first',
     },
     {
         breakpoints: [
-            ['max-width: 400sp', [['collapsed', 'true']]],
-            ['max-width: 720sp', [['title', 'wide']]],
+            [
+                'max-width: 720sp',
+                [
+                    ['sidebar', 'collapsed', 'true'],
+                    ['content', 'collapsed', 'true'],
+                ],
+            ],
+            ['max-width: 400sp', [['sidebar', 'collapsed', 'false']]],
+        ],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 300, height: 600 },
+        ],
+        writes: [
+            ['sidebar.collapsed=true', 'content.collapsed=true'],
+            ['content.collapsed=orig:content.collapsed', 'sidebar.collapsed=false'],
+        ],
+        rule: 'the skip keys on OBJECT and property: the incoming breakpoint sets `collapsed` on the sidebar only, so the content is still restored',
+    },
+    {
+        breakpoints: [
+            [
+                'max-width: 720sp',
+                [
+                    ['sidebar', 'collapsed', 'true'],
+                    ['content', 'collapsed', 'true'],
+                ],
+            ],
+        ],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 900, height: 600 },
+        ],
+        writes: [
+            ['sidebar.collapsed=true', 'content.collapsed=true'],
+            ['sidebar.collapsed=orig:sidebar.collapsed', 'content.collapsed=orig:content.collapsed'],
+        ],
+        rule: 'leaving to NO breakpoint restores every setter, one per object',
+    },
+    {
+        breakpoints: [
+            ['max-width: 400sp', [['view', 'collapsed', 'true']]],
+            ['max-width: 720sp', [['view', 'title', 'wide']]],
         ],
         sizes: [{ width: 300, height: 600 }],
-        writes: [['title=wide']],
+        writes: [['view.title=wide']],
         rule: 'the later breakpoint wins outright, so the earlier one never applies and never restores',
     },
 ];

--- a/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
@@ -1,0 +1,171 @@
+// Breakpoint-bin conformance vectors — the spec every renderer is held to.
+//
+// The three rules here are the ones a port gets wrong by guessing: which breakpoint
+// wins when two match, what happens to a property both of them set, and what the
+// restore restores to.
+//
+// Reference: refs/libadwaita/src/adw-breakpoint-bin.c
+// Reference: refs/libadwaita/src/adw-breakpoint.c
+// Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
+
+/** One pick expectation: which breakpoint a size selects. */
+export interface BreakpointPickVector {
+    /** Conditions, in the order they are added. */
+    conditions: readonly string[];
+    /** The size to evaluate against. */
+    size: { width: number; height: number };
+    /** Index of the expected pick, or null for none. */
+    pick: number | null;
+    rule: string;
+}
+
+/**
+ * `adw_breakpoint_bin_size_allocate` iterates backwards and takes the first match:
+ * "Iterate in reverse order since we prioritize breakpoints added last" (:433).
+ *
+ * CORE-ONLY: GAP — no renderer drives this table yet. The NativeScript bin binds
+ * breakpoints to a view's post-layout size and runs its own callbacks; moving it onto
+ * `BreakpointBinState` is a diff with its own spec surface, and the rule lands first so
+ * the React Native set is written against it. Tracked in #1343.
+ */
+export const BREAKPOINT_PICK_VECTORS: ReadonlyArray<BreakpointPickVector> = [
+    { conditions: [], size: { width: 800, height: 600 }, pick: null, rule: 'no breakpoints, no pick' },
+    {
+        conditions: ['max-width: 720sp'],
+        size: { width: 500, height: 600 },
+        pick: 0,
+        rule: 'one breakpoint, condition holds',
+    },
+    {
+        conditions: ['max-width: 720sp'],
+        size: { width: 900, height: 600 },
+        pick: null,
+        rule: 'one breakpoint, condition does not hold',
+    },
+    {
+        conditions: ['max-width: 720sp', 'max-width: 400sp'],
+        size: { width: 300, height: 600 },
+        pick: 1,
+        rule: 'both match: the one added LAST wins, which here is also the narrower',
+    },
+    {
+        conditions: ['max-width: 400sp', 'max-width: 720sp'],
+        size: { width: 300, height: 600 },
+        pick: 1,
+        rule: 'both match, added the other way round: the LAST still wins, and it is the WIDER one',
+    },
+    {
+        conditions: ['max-width: 400sp', 'max-width: 720sp'],
+        size: { width: 500, height: 600 },
+        pick: 1,
+        rule: 'only the second matches',
+    },
+    {
+        conditions: ['max-width: 720sp', 'max-height: 400sp'],
+        size: { width: 500, height: 300 },
+        pick: 1,
+        rule: 'the two axes are independent conditions, and the later one still wins',
+    },
+    {
+        conditions: ['max-width: 720sp and max-height: 400sp'],
+        size: { width: 500, height: 600 },
+        pick: null,
+        rule: 'an `and` needs both halves',
+    },
+    {
+        conditions: ['max-width: 400sp', 'not-a-condition'],
+        size: { width: 300, height: 600 },
+        pick: 0,
+        rule: 'an unparseable condition never matches, so the earlier valid one is picked',
+    },
+];
+
+/** One transition expectation, written as property names rather than objects. */
+export interface BreakpointTransitionVector {
+    /** Each breakpoint as `[condition, [[property, value] …]]`; originals are `orig:<property>`. */
+    breakpoints: readonly [string, readonly (readonly [string, string])[]][];
+    /** Sizes to evaluate in order. */
+    sizes: readonly { width: number; height: number }[];
+    /** Expected writes per evaluation, `property=value`; `null` is "no transition". */
+    writes: readonly (readonly string[] | null)[];
+    rule: string;
+}
+
+/**
+ * `adw_breakpoint_transition` (adw-breakpoint.c:1781): restore the outgoing setters to
+ * their originals, skipping any the incoming breakpoint also sets, then write the
+ * incoming values.
+ *
+ * CORE-ONLY: GAP — no renderer drives this table yet. The NativeScript bin binds
+ * breakpoints to a view's post-layout size and runs its own callbacks; moving it onto
+ * `BreakpointBinState` is a diff with its own spec surface, and the rule lands first so
+ * the React Native set is written against it. Tracked in #1343.
+ */
+export const BREAKPOINT_TRANSITION_VECTORS: ReadonlyArray<BreakpointTransitionVector> = [
+    {
+        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        sizes: [{ width: 500, height: 600 }],
+        writes: [['collapsed=true']],
+        rule: 'entering a breakpoint writes its setters',
+    },
+    {
+        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 900, height: 600 },
+        ],
+        writes: [['collapsed=true'], ['collapsed=orig:collapsed']],
+        rule: 'leaving restores the ORIGINAL, which was captured when the setter was registered',
+    },
+    {
+        breakpoints: [['max-width: 720sp', [['collapsed', 'true']]]],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 400, height: 600 },
+        ],
+        writes: [['collapsed=true'], null],
+        rule: 'staying inside the same breakpoint produces no transition at all',
+    },
+    {
+        breakpoints: [
+            ['max-width: 720sp', [['collapsed', 'true']]],
+            ['max-width: 400sp', [['collapsed', 'false']]],
+        ],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 300, height: 600 },
+        ],
+        writes: [['collapsed=true'], ['collapsed=false']],
+        rule: 'a property BOTH set is written once, not restored and re-set',
+    },
+    {
+        breakpoints: [
+            [
+                'max-width: 720sp',
+                [
+                    ['collapsed', 'true'],
+                    ['title', 'narrow'],
+                ],
+            ],
+            ['max-width: 400sp', [['collapsed', 'false']]],
+        ],
+        sizes: [
+            { width: 500, height: 600 },
+            { width: 300, height: 600 },
+        ],
+        writes: [
+            ['collapsed=true', 'title=narrow'],
+            ['title=orig:title', 'collapsed=false'],
+        ],
+        rule: 'only the property the incoming breakpoint does NOT set is restored, and restores come first',
+    },
+    {
+        breakpoints: [
+            ['max-width: 400sp', [['collapsed', 'true']]],
+            ['max-width: 720sp', [['title', 'wide']]],
+        ],
+        sizes: [{ width: 300, height: 600 }],
+        writes: [['title=wide']],
+        rule: 'the later breakpoint wins outright, so the earlier one never applies and never restores',
+    },
+];

--- a/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
+++ b/packages/web/adwaita-core/src/conformance/breakpoint-bin.ts
@@ -21,7 +21,7 @@ export interface BreakpointPickVector {
 
 /**
  * `adw_breakpoint_bin_size_allocate` iterates backwards and takes the first match:
- * "Iterate in reverse order since we prioritize breakpoints added last" (:433).
+ * "Iterate in reverse order since we prioritize breakpoints added last" (:432).
  *
  * CORE-ONLY: GAP — no renderer drives this table yet. The NativeScript bin binds
  * breakpoints to a view's post-layout size and runs its own callbacks; moving it onto
@@ -76,7 +76,7 @@ export const BREAKPOINT_PICK_VECTORS: ReadonlyArray<BreakpointPickVector> = [
         conditions: ['max-width: 400sp', 'not-a-condition'],
         size: { width: 300, height: 600 },
         pick: 0,
-        rule: 'an unparseable condition never matches, so the earlier valid one is picked',
+        rule: 'an unparseable condition never matches (adw_breakpoint_check_condition returns FALSE for a null one, adw-breakpoint.c:1831), so the earlier valid one is picked',
     },
 ];
 

--- a/packages/web/adwaita-core/src/conformance/index.ts
+++ b/packages/web/adwaita-core/src/conformance/index.ts
@@ -509,3 +509,6 @@ export type {
     WrapBoxSpacingNotifyVector,
     WrapBoxSpacingVector,
 } from './wrap-box.js';
+
+export { BREAKPOINT_PICK_VECTORS, BREAKPOINT_TRANSITION_VECTORS } from './breakpoint-bin.js';
+export type { BreakpointPickVector, BreakpointTransitionVector } from './breakpoint-bin.js';

--- a/packages/web/adwaita-core/src/index.ts
+++ b/packages/web/adwaita-core/src/index.ts
@@ -633,6 +633,15 @@ export type {
     ToolbarViewMeasureInput,
 } from './chrome.js';
 
+// --- Breakpoint bin (pick one, and what the change writes) ---
+export { BreakpointBinState } from './breakpoint-bin.js';
+export type {
+    BreakpointDefinition,
+    BreakpointSetter,
+    BreakpointTransition,
+    BreakpointWrite,
+} from './breakpoint-bin.js';
+
 // --- Scroll edge indicators (GtkScrolledWindow undershoot + overshoot) ---
 export {
     ADW_MAX_OVERSHOOT_DISTANCE,

--- a/packages/web/adwaita-core/src/test.mts
+++ b/packages/web/adwaita-core/src/test.mts
@@ -15,6 +15,7 @@ import dataGridTestSuite from './data-grid.spec.js';
 import avatarTestSuite from './avatar.spec.js';
 import actionRowTestSuite from './action-row.spec.js';
 import breakpointTestSuite from './breakpoint.spec.js';
+import breakpointBinTestSuite from './breakpoint-bin.spec.js';
 import accentTestSuite from './accent.spec.js';
 import colorSchemeTestSuite from './color-scheme.spec.js';
 import dialogTestSuite from './dialog.spec.js';
@@ -39,6 +40,7 @@ run({
     buttonTestSuite,
     checksTestSuite,
     breakpointTestSuite,
+    breakpointBinTestSuite,
     accentTestSuite,
     colorSchemeTestSuite,
     toastTestSuite,


### PR DESCRIPTION
`AdwBreakpoint` answers *"does my condition hold"* for one breakpoint, independently of every other. The **bin** is what was missing: it owns the list, picks at most one, and works out what to write when the pick changes.

Four rules in it are not guessable, and all four come from the C source. Line numbers are against the pinned `refs/libadwaita` (42f647ff).

## 1. The last matching breakpoint added wins

Not the narrowest, not the best fit. `adw_breakpoint_bin_size_allocate` iterates the array backwards and takes the first match:

> `/* Iterate in reverse order since we prioritize breakpoints added last */`
> — `adw-breakpoint-bin.c:432`

`breakpoint.ts` described this as *"the best match"*. That is the intuitive reading and the wrong one, so it is corrected there and has vectors here. The vector that shows the difference adds the **wider** breakpoint last and expects it to win.

## 2. A property both breakpoints set is never restored in between

`adw_breakpoint_transition` skips a setter the incoming breakpoint also carries:

> `/* Don't unset the property if we'll immediately set it again afterwards */`
> — `adw-breakpoint.c:1799`

Restoring first would put the widget through a state neither breakpoint describes, once per resize across the boundary.

The skip keys on **object AND property** (`setter_equal`, `adw-breakpoint.c:1060`), not property alone. That half is easy to write and impossible to test with one object in the table, so `BREAKPOINT_TRANSITION_VECTORS` spells the object on every setter and two of its rows have two objects in them.

## 3. The original value is captured when the setter is registered

`g_object_get_property` runs in `adw_breakpoint_add_setter` (`adw-breakpoint.c:1627`), not when the breakpoint applies. Surprising until you need it: it makes unapply the exact inverse of apply rather than a diff against a moving target.

The core takes it as a parameter, because a headless module cannot read a property. For the same reason `evaluate` returns the writes and the renderer performs them.

## 4. Unapply is signalled before the writes, apply after them

`adw_breakpoint_transition` emits the outgoing breakpoint's `unapply` (`adw-breakpoint.c:1793`), then restores, then sets, then emits the incoming one's `apply` (`:1819`) — so a callback on either end sees the properties in the state its own breakpoint describes, never the other one's.

The bin cannot run those callbacks: it holds condition strings and setter DATA, never an `AdwBreakpoint`, and the two objects do not compose today. `from` and `to` are how a renderer that has callbacks gets the order right, and `BreakpointTransition` says so.

## Shape

```ts
const bin = new BreakpointBinState<Gtk.Widget>();
bin.add({ condition: 'max-width: 720sp', setters: [
    { object: splitView, property: 'collapsed', value: true, originalValue: false },
]});

const change = bin.evaluate({ width: 500, height: 600 });
// change.writes → [{ object: splitView, property: 'collapsed', value: true }]
```

`evaluate` returns `null` rather than an empty transition when nothing changed, so a renderer driving this from every allocation skips the path without inspecting an object.

A childless bin keeps whatever breakpoint it had, because `adw_breakpoint_bin_size_allocate` returns before picking when there is no child (`:427`). Modelled rather than left to the renderer: *"the applied breakpoint did not change while the child was away"* is a behaviour, and the alternative is each renderer rediscovering it.

## `inherit`, the one thing with no C counterpart

A GTK bin is never rebuilt; a browser element is, on every `connectedCallback`. `evaluate` fires on a CHANGE only, so a fresh bin that starts at "none applied" reads the size that LEFT the breakpoint's range as no change at all, writes nothing, and leaves the widget holding what the bin it replaced had set.

That is the bug `AdwBreakpoint`'s `applied` parameter was added for one level down — measured there as a `<adw-navigation-split-view>` driven 800px → 500px → 900px staying collapsed at 900px. `bin.inherit(previous.current)` is the same seed, and `inherit(null)` is the start-fresh case. It throws on an index the bin does not have, because a swallowed stale index is precisely the restore that never happens.

## Verification

`@gjsify/adwaita-core`, both legs, on this branch:

| | |
|---|---|
| `test:node` | ✔ 12640 completed (Node.js 24.19.0) |
| `test:gjs` | ✔ 12640 completed (Gjs 1.88.1) |
| breakpoint-bin tests | 24 |

Every rule above was held against a deliberate defect — implementation broken on purpose, suite re-run, defect reverted. Failing tests per mutation:

| mutation | fails |
|---|---|
| iterate forwards, the intuitive way | 8 |
| drop the skip from rule 2 | 3 |
| skip keyed on property alone, ignoring the object | 1 |
| never restore on leaving | 5 |
| incoming writes before the restores | 3 |
| return a transition even when nothing changed | 2 |
| ignore `setHasChild(false)` | 2 |
| treat an unparseable condition as always matching | 1 |
| `inherit` seeds nothing | 1 |
| `inherit` swallows a stale index instead of throwing | 1 |

The suite runs, and that is measured the same way rather than assumed: `check-node-test-registration.mjs` exits 1 when `breakpoint-bin.spec.ts` is not registered in `test.mts`, and every mutation above turned it red by name.

`gjsify lint`, `gjsify format --check`, `audit-runtimes --check`, `check-adwaita-conformance-drivers`, `check-node-test-registration`, `check-refs-citations`, `check-adwaita-style-classes` and `gjsify tsc --noEmit` all exit 0. `@gjsify/adwaita-nativescript test` (3350, both legs) and `@gjsify/adwaita-web check` are green too — `breakpoint.ts` is shared, and its diff here is comment-only.

Worth recording: the `CORE-ONLY` gate moved this from **"driven by NOTHING"** to **"driven only by the core suite"** to green over two rounds. The marker has to sit in each table's own header, not the file's.

## Not in this PR

Moving the NativeScript bin onto `BreakpointBinState`. It binds breakpoints to a view's post-layout size and runs its own callbacks; that is a diff with its own spec surface. The rule lands first so the React Native set is written against it, which is the same order the header bar took.

Refs #1343
