### PR TITLE
fix(scripts): a conformance table is driven only by a suite that runs

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -400,8 +400,10 @@ jobs:
       # name its coverage or be a ledgered GAP, fails a marker whose table has since
       # gained a driver, and holds every adwaita-core MODULE — not just every table —
       # to having a conformance file or a ledgered reason. "Driven" is a name used
-      # OUTSIDE a comment in a `*.spec.ts`: the second version read comments too, so a
-      # comment claiming coverage supplied its own evidence.
+      # OUTSIDE a comment in a `*.spec.ts` that RUNS: the second version read comments
+      # too, so a comment claiming coverage supplied its own evidence, and the third
+      # counted any spec naming the table — including one no `run({…})` registers, which
+      # executes nowhere (#1365).
       - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 
@@ -890,8 +892,10 @@ jobs:
       # name its coverage or be a ledgered GAP, fails a marker whose table has since
       # gained a driver, and holds every adwaita-core MODULE — not just every table —
       # to having a conformance file or a ledgered reason. "Driven" is a name used
-      # OUTSIDE a comment in a `*.spec.ts`: the second version read comments too, so a
-      # comment claiming coverage supplied its own evidence.
+      # OUTSIDE a comment in a `*.spec.ts` that RUNS: the second version read comments
+      # too, so a comment claiming coverage supplied its own evidence, and the third
+      # counted any spec naming the table — including one no `run({…})` registers, which
+      # executes nowhere (#1365).
       - name: Check every conformance table is driven and every reason is true
         run: node scripts/check-adwaita-conformance-drivers.mjs
 

--- a/.gitignore
+++ b/.gitignore
@@ -111,9 +111,12 @@ fs-*/
 foobar/
 symlink_tsconfig.json
 
-# Ad-hoc test/debug scripts in project root
-test-*.mjs
-test-*.js
+# Ad-hoc test/debug scripts in project root — ANCHORED, which is what "in project root"
+# always claimed. Unanchored, `test-*.mjs` matches at every depth, and it swallowed a new
+# `scripts/` module that a gate imports (#1365): `git add` said nothing, and CI would have
+# failed on the missing file only after the push. Nothing else in the tree matches.
+/test-*.mjs
+/test-*.js
 .shoot-*.mjs
 
 # Metafile

--- a/packages/web/adwaita-core/src/header-bar.spec.ts
+++ b/packages/web/adwaita-core/src/header-bar.spec.ts
@@ -3,9 +3,11 @@
 //
 // No renderer suite drives those tables yet; the tables say so themselves (CORE-ONLY GAP,
 // #1343), and this suite is their only driver until the NativeScript and web header bars
-// move onto `HeaderBarState`. That is a gap, not coverage. The sentence that stood here
-// claimed "every renderer suite asserts the SAME table" over three tables no renderer
-// names — a coverage promise the file itself contradicted four lines further down.
+// move onto `HeaderBarState`. That is a gap, not coverage. What stood here before was a
+// promise about the other suites that the file itself contradicted four lines further
+// down; it is gone rather than softened, and it is NOT restated here — quoting a false
+// claim to retract it puts the claim back in the file, where the gate that reads this
+// header cannot tell a quotation from an assertion. It caught exactly that.
 
 import { describe, it, expect } from '@gjsify/unit';
 

--- a/scripts/audit-test-scripts.mjs
+++ b/scripts/audit-test-scripts.mjs
@@ -63,6 +63,21 @@ function findPkgJsons(dir, out = []) {
     return out;
 }
 
+/**
+ * Does `test` invoke `leg` — as opposed to merely CONTAINING its name?
+ *
+ * `test.includes('test:node')` was the whole test, and `build:test:node` contains
+ * `test:node`. That pairing is the tree's dominant idiom
+ * (`"test": "gjsify run build:test:node && gjsify run test:node"`), so deleting the second
+ * half of it left this gate printing OK over a suite that no longer ran — measured on
+ * `packages/infra/cli`, the largest node suite in the repo. Building a bundle is not
+ * running it, which is the distinction this script's own founding incident is about
+ * ("abort-controller/adwaita-app/storybook-core built but never ran their node leg").
+ */
+function runsLeg(test, leg) {
+    return new RegExp(`(?<![\\w:-])${leg}(?![\\w:-])`).test(test);
+}
+
 const violations = [];
 for (const root of ROOTS) {
     for (const pkgPath of findPkgJsons(root)) {
@@ -76,7 +91,7 @@ for (const root of ROOTS) {
         const scripts = pkg.scripts || {};
         const test = scripts.test || '';
         for (const leg of LEGS) {
-            if (scripts[leg] && !test.includes(leg)) {
+            if (scripts[leg] && !runsLeg(test, leg)) {
                 violations.push({ name: pkg.name || pkgPath, pkgPath, leg });
             }
         }

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -25,7 +25,26 @@
 // adwaita-web drove none of the six. A reason left outside the check is prose,
 // and prose that says "covered" is worse than no reason at all.
 //
+// THE THIRD INCIDENT
+//
+// "Driven" then meant NAMED: any `*.spec.ts` under a renderer that spelled the table
+// outside a comment. Naming is not running. Measured on this tree for #1365 — delete the
+// one line `AdwCarouselNsTest,` from the `run({…})` of
+// `packages/nativescript-bridge/adwaita/src/test.mts`, leave the import above it alone —
+// and the NS carousel suite executes nowhere while this gate,
+// `check-node-test-registration.mjs` and `check-browser-test-registration.mjs` all exit
+// 0, still counting `CAROUSEL_NAVIGATE_VECTORS`, `CAROUSEL_REVEAL_VECTORS` and
+// `CAROUSEL_PROPERTY_DEFAULT_VECTORS` as renderer-driven. The two registration gates each
+// hold a WEAKER fact than "it runs" — one that some entry imports it, the other only in
+// browser-ONLY packages — and neither covers the gap this gate was reading through. So
+// the fact comes from `scripts/suite-registration.mjs` now, which both this file and
+// `check-node-test-registration.mjs` read, rather than from a third derivation here.
+//
 // WHAT IT CHECKS
+//
+// SUITE arm — for every `*.spec.ts` naming a table:
+//   0. it is LIVE — a test entry of its package hands its suite to `run({…})`  → pass
+//      otherwise it drives nothing, whoever else does                          → FAIL
 //
 // TABLE arm — for every `export const *_VECTORS` in `conformance/`:
 //   1. driven by at least one RENDERER suite            → pass
@@ -35,7 +54,8 @@
 //   4. driven by nothing at all                                            → FAIL
 //   5. renderer-driven AND still carrying `CORE-ONLY:`                     → FAIL
 //
-// "Driven" = a renderer `*.spec.ts` names the table OUTSIDE a comment (consumersUnder).
+// "Driven" = a LIVE renderer `*.spec.ts` names the table OUTSIDE a comment — the naming
+// is `namedPerSpec`, the liveness `suiteDrivers`.
 //
 // CLAIM arm — every comment CLAUSE in the core or either renderer that names a
 // vector table is resolved against reality (clause, not sentence — see clausesIn):
@@ -74,11 +94,12 @@
 //
 // Usage: node scripts/check-adwaita-conformance-drivers.mjs [--root <dir>]
 
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { readSuiteRegistration, walk as walkFiles } from './suite-registration.mjs';
 
 // Every repo-relative path below is COMPARED against a `/`-spelled literal and printed into a
 // finding. On win32 `relative()` hands back `packages\web\…`, so the module arm matched nothing
@@ -162,15 +183,7 @@ const GAP_REASON = /\bGAP\b/;
 const GAP_ANCHOR = /#\d+/;
 const COUNT_WORDS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
 
-function walk(dir) {
-    const out = [];
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        const path = join(dir, entry.name);
-        if (entry.isDirectory()) out.push(...walk(path));
-        else if (entry.name.endsWith('.ts')) out.push(path);
-    }
-    return out;
-}
+const walk = (dir) => walkFiles(dir, (name) => name.endsWith('.ts'));
 
 /**
  * Every exported vector table, with the text ABOVE its declaration — back to the
@@ -195,7 +208,7 @@ function tablesIn(file) {
 const withoutComments = (source) => source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
 /**
- * Which of `names` a suite under `dir` DRIVES: names used outside a comment, in a `*.spec.ts`.
+ * Which of `names` each `*.spec.ts` under `dir` NAMES, outside a comment.
  *
  * Outside a comment, because a claim must not supply its own evidence — this branch's own fix
  * spelled the five `DATA_GRID_*_VECTORS` out in an adwaita-web comment saying the browser drives
@@ -204,18 +217,48 @@ const withoutComments = (source) => source.replace(/\/\*[\s\S]*?\*\//g, ' ').rep
  * arm then demanded the true marker be deleted. `*.spec.ts`, because driving means ITERATING in
  * a test; every non-spec mention in either renderer is prose today, so that half only keeps the
  * first from being one file's move away from useless.
+ *
+ * Per FILE, not merged, because naming is only half of driving — see {@link suiteDrivers}.
  */
-function consumersUnder(dir, names) {
-    const seen = new Set();
+function namedPerSpec(dir, names) {
+    const perFile = new Map();
     for (const file of walk(dir)) {
         if (file.startsWith(CONFORMANCE_DIR) || !file.endsWith('.spec.ts')) continue;
         const source = withoutComments(readFileSync(file, 'utf8'));
-        for (const name of names) {
-            // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
-            if (!seen.has(name) && new RegExp(`\\b${name}\\b`).test(source)) seen.add(name);
-        }
+        // Word-boundary, so `FOO_VECTORS` does not match `FOO_VECTORS_2`.
+        const named = names.filter((name) => new RegExp(`\\b${name}\\b`).test(source));
+        if (named.length > 0) perFile.set(file, named);
     }
-    return seen;
+    return perFile;
+}
+
+/**
+ * Which of `names` a suite under `dir` DRIVES — named by a spec that RUNS.
+ *
+ * #1365: naming was the whole test, so a table stayed "driven" by a spec that executed nowhere.
+ * Measured on this tree by deleting one line — the `AdwCarouselNsTest,` key from the `run({…})`
+ * of `packages/nativescript-bridge/adwaita/src/test.mts`, its import left in place: the NS
+ * carousel suite stopped running and this gate, `check-node-test-registration.mjs` and
+ * `check-browser-test-registration.mjs` all stayed green over three tables nothing asserted.
+ *
+ * Liveness is read by `scripts/suite-registration.mjs` rather than re-derived here, because the
+ * cheap local version of it is what opened the hole: a second derivation of the same fact drifts
+ * from the first, and the weaker of the two is the one that keeps passing.
+ */
+function suiteDrivers(dir, names) {
+    const { live, opaque } = readSuiteRegistration(dirname(dir));
+    const driven = new Set();
+    const dead = [];
+    let drivers = 0;
+    for (const [file, named] of namedPerSpec(dir, names)) {
+        if (!live.has(file)) {
+            dead.push({ file, named });
+            continue;
+        }
+        drivers += 1;
+        for (const name of named) driven.add(name);
+    }
+    return { driven, dead, opaque, drivers };
 }
 
 /** Contiguous runs of comment lines, marker-stripped and joined — one prose block each. */
@@ -328,9 +371,13 @@ if (tables.length === 0) {
 
 const names = tables.map((table) => table.name);
 const declared = new Set(names);
-const byLabel = new Map(RENDERERS.map(({ label, dir }) => [label, consumersUnder(dir, names)]));
-const byRenderer = new Set([...byLabel.values()].flatMap((set) => [...set]));
-const byCore = consumersUnder(CORE_SUITE_DIR, names);
+const suites = [...RENDERERS, { label: 'adwaita-core', dir: CORE_SUITE_DIR }].map((suite) => ({
+    ...suite,
+    ...suiteDrivers(suite.dir, names),
+}));
+const byLabel = new Map(suites.map(({ label, driven }) => [label, driven]));
+const byRenderer = new Set(RENDERERS.flatMap(({ label }) => [...byLabel.get(label)]));
+const byCore = byLabel.get('adwaita-core');
 
 /** The `CORE-ONLY:` reason a table carries, as one line. */
 const reasons = new Map();
@@ -377,7 +424,30 @@ function reachesADriver(name, seen = new Set()) {
 
 const failures = [];
 /** What each arm actually resolved. A gate that reports only "green" cannot show it ran. */
-const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0 };
+const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0, specs: 0 };
+
+// SUITE arm. The arms below key off which tables are driven, so a spec that names a table
+// while running nowhere would otherwise surface one step downstream, as "driven only by the
+// core suite" pointing at the TABLE — sending the reader to the file that is fine. Name the
+// spec instead: it is the thing to fix, and it is a defect even where another live spec
+// happens to drive the same table.
+for (const { label, dead, opaque, drivers } of suites) {
+    resolved.specs += drivers;
+    for (const entry of opaque) {
+        failures.push(
+            `${rel(ROOT, entry)}: this gate cannot tell what the ${label} entry registers — no ` +
+                `\`run({…})\`, no delegation to a sibling entry, nothing called by hand. Until it can, ` +
+                `"driven" is unknowable here rather than false.`,
+        );
+    }
+    for (const { file, named } of dead) {
+        failures.push(
+            `${rel(ROOT, file)}: names ${named.join(', ')}, but no test entry of ${label} hands its ` +
+                `suite to \`run({…})\` — so it runs NOWHERE and drives nothing. Register it, or delete it.`,
+        );
+    }
+}
+
 for (const table of tables) {
     const where = `${rel(ROOT, table.file)}:${table.line} → ${table.name}`;
     if (byRenderer.has(table.name)) {
@@ -557,7 +627,8 @@ if (failures.length > 0) {
 }
 
 console.log(
-    `check-adwaita-conformance-drivers: ${tables.length} vector tables, ${resolved.exempted} core-only, ` +
+    `check-adwaita-conformance-drivers: ${tables.length} vector tables driven from ${resolved.specs} live ` +
+        `spec(s), ${resolved.exempted} core-only, ` +
         `${resolved.chains} coverage chain(s) walked to a driver. Read ${resolved.citations} prose citation(s), ` +
         `of which ${resolved.both} both-renderer claim(s), ${resolved.suite} single-suite claim(s) and ` +
         `${resolved.counted} counted glob(s) were resolved against the tree.`,

--- a/scripts/check-adwaita-conformance-drivers.mjs
+++ b/scripts/check-adwaita-conformance-drivers.mjs
@@ -70,11 +70,24 @@
 //  10. a `CORE-ONLY:` reason citing a table as its coverage, where no chain of
 //      citations from it reaches a renderer-driven table                   → FAIL
 //  11. a `CORE-ONLY:` reason that names no table and is not a ledgered GAP  → FAIL
+//  12. a SPEC whose every table reaches no renderer, promising renderer coverage
+//      in its own header                                                     → FAIL
 //
 // 10 reads only citations whose clause is PHRASED as coverage (COVERAGE_PHRASING); a
 // precedent citation is held by the TABLE arm instead, on the table it names. 11 is what
 // makes an exemption falsifiable — every other arm keys off a citation, so naming none
 // was the cheapest way to write one.
+//
+// 12 is the same idea for the OTHER side of the file. Arms 6-10 all begin at a citation,
+// so a promise that names no table is invisible to them, and `BOTH_CLAIM` knows "both"
+// and "the two" but not "every". Measured: "…so this suite and every renderer suite
+// assert the SAME table" stood at the top of two spec files whose vectors are exempted
+// `CORE-ONLY: GAP — no renderer drives this table yet`, and every arm passed it. It needs
+// no prose parsing to catch, because the file contradicts itself: what a spec is ABOUT is
+// readable from its CODE, and where nothing it touches reaches a renderer, a renderer
+// coverage claim anywhere in it is false. Widening `BOTH_CLAIM` to "every" would have
+// been true and would have caught neither — the clause cites no table, so arm 8 never
+// reaches it.
 //
 // MODULE arm — the table arm is TABLE-keyed, so core behaviour with no table at
 // all is invisible to it. Every module under `adwaita-core/src` that exports
@@ -178,6 +191,20 @@ const SUITE_CLAIMS = [
     { label: 'nativescript', pattern: /\bNativeScript\b/i },
 ];
 const COVERAGE_VERB = /\b(?:suite|drives?|driven by|held to|asserts)\b/i;
+/**
+ * A renderer named as a CLASS rather than by name — "every renderer suite", "both ports".
+ * SUITE_CLAIMS above knows the two renderers by name and is the arm for a claim that picks
+ * one; this is for a claim that gestures at all of them, which is how both measured false
+ * promises were written.
+ */
+const RENDERER_WORD = /\b(?:renderers?|ports?|browser|adwaita-web|NativeScript)\b/i;
+/**
+ * A clause the CLAUSE_TURN split has already headed with a negation states the ABSENCE of
+ * coverage — "no renderer drives these yet" is the true sentence to write in exactly the
+ * files arm 12 examines, and reading it as a promise would fail the honest wording. `only`
+ * is deliberately not here: "only the browser suite drives these" is a claim, not a denial.
+ */
+const DENIAL = /^\s*(?:no|not|none|neither|nor)\b/i;
 /** An exemption that offers no coverage is a GAP, and a GAP with no anchor has no retirement. */
 const GAP_REASON = /\bGAP\b/;
 const GAP_ANCHOR = /#\d+/;
@@ -424,7 +451,7 @@ function reachesADriver(name, seen = new Set()) {
 
 const failures = [];
 /** What each arm actually resolved. A gate that reports only "green" cannot show it ran. */
-const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0, specs: 0 };
+const resolved = { chains: 0, citations: 0, both: 0, suite: 0, counted: 0, exempted: 0, specs: 0, promises: 0 };
 
 // SUITE arm. The arms below key off which tables are driven, so a spec that names a table
 // while running nowhere would otherwise surface one step downstream, as "driven only by the
@@ -501,6 +528,33 @@ for (const table of tables) {
             `${where}: its reason cites ${name} as the coverage that makes this table redundant, but ` +
                 `no chain of citations from ${name} reaches a table any renderer drives.`,
         );
+    }
+}
+
+// PROMISE arm. Every arm below starts at a citation, so a header that promises renderer
+// coverage without naming a table reaches none of them. This one starts at the CODE
+// instead: the tables a spec IMPORTS are what it is about, and where not one of them
+// reaches a renderer — directly or through an exemption chain — any renderer coverage
+// claim in that file is false, whatever words it is written in. That is why it needs no
+// new prose matcher precise enough to be argued with: the condition is already decided
+// before a clause is read.
+for (const file of walk(CORE_SUITE_DIR)) {
+    if (file.startsWith(CONFORMANCE_DIR) || !file.endsWith('.spec.ts')) continue;
+    // From the code, with comments blanked — the same rule as the TABLE arm, and for the
+    // same reason: a claim must not supply its own evidence.
+    const code = withoutComments(readFileSync(file, 'utf8'));
+    const about = names.filter((name) => new RegExp(`\\b${name}\\b`).test(code));
+    if (about.length === 0 || about.some((name) => reachesADriver(name))) continue;
+    resolved.promises += 1;
+    for (const block of commentBlocks(file)) {
+        for (const clause of claimUnitsIn(block.text)) {
+            if (DENIAL.test(clause) || !RENDERER_WORD.test(clause) || !COVERAGE_PHRASING.test(clause)) continue;
+            failures.push(
+                `${rel(ROOT, file)}:${block.line}: promises renderer coverage — "${clause.trim()}" — while no ` +
+                    `renderer drives ${about.join(', ')} and no exemption chain from them reaches one. ` +
+                    `Drive them from a renderer, or say what is actually true here.`,
+            );
+        }
     }
 }
 
@@ -631,5 +685,6 @@ console.log(
         `spec(s), ${resolved.exempted} core-only, ` +
         `${resolved.chains} coverage chain(s) walked to a driver. Read ${resolved.citations} prose citation(s), ` +
         `of which ${resolved.both} both-renderer claim(s), ${resolved.suite} single-suite claim(s) and ` +
-        `${resolved.counted} counted glob(s) were resolved against the tree.`,
+        `${resolved.counted} counted glob(s) were resolved against the tree, and read the header of ` +
+        `${resolved.promises} spec(s) no renderer stands behind.`,
 );

--- a/scripts/check-browser-test-registration.mjs
+++ b/scripts/check-browser-test-registration.mjs
@@ -42,6 +42,8 @@ import { readdirSync, readFileSync, existsSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { registeredSymbols, resolveToSource, stripComments } from './suite-registration.mjs';
+
 const args = process.argv.slice(2);
 const rootIndex = args.indexOf('--root');
 const ROOT = rootIndex === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootIndex + 1];
@@ -53,45 +55,6 @@ const SHARED_ENTRY_NAMES = ['test.mts', 'test.ts'];
 function fail(lines) {
     console.error(`check-browser-test-registration: ${lines.join('\n  ')}`);
     process.exit(1);
-}
-
-/**
- * Comments out, string literals through untouched.
- *
- * Every scan below is LEXICAL, and a comment is the one place a suite name can appear
- * while registering nothing. Both directions were measured on a copy of the real
- * adwaita-web tree: a block-commented `{ AdwSwitchTest }` left as the last element of
- * the object passed GREEN over a suite that ran nowhere, a block comment anywhere inside
- * the object swallowed the following key and falsely accused it, and a line
- * `// e.g. run({ … })` above the real call captured the `run(` search outright and
- * reported every spec as unregistered.
- *
- * A regex pair would be shorter and WRONG: `packages/node/url/src/test.browser.mts` is
- * built out of `'http://example.com/…'` literals, and a `//`-to-end-of-line strip eats
- * the rest of every line one of them sits on — measured, it deletes real code from that
- * entry today. So this walks the source and skips quoted runs, because a check that
- * reads the file differently from the engine that runs it is the bug, not the guard.
- */
-function stripComments(source) {
-    let out = '';
-    let i = 0;
-    while (i < source.length) {
-        const c = source[i];
-        if (c === '/' && source[i + 1] === '/') {
-            while (i < source.length && source[i] !== '\n') i++;
-        } else if (c === '/' && source[i + 1] === '*') {
-            const end = source.indexOf('*/', i + 2);
-            i = end === -1 ? source.length : end + 2;
-        } else if (c === "'" || c === '"' || c === '`') {
-            const start = i++;
-            while (i < source.length && source[i] !== c) i += source[i] === '\\' ? 2 : 1;
-            out += source.slice(start, ++i);
-        } else {
-            out += c;
-            i++;
-        }
-    }
-    return out;
 }
 
 /**
@@ -163,41 +126,23 @@ const DEFAULT_IMPORT = /^import\s+([A-Za-z_$][\w$]*)\s*(?:,\s*\{[^}]*\})?\s+from
 /** Any relative import, in any binding form — used only to ask "does anything reach this file". */
 const RELATIVE_IMPORT = /(?:from|import)\s+['"](\.[^'"]+)['"]/g;
 
-/** An identifier in KEY position: preceded by `{` or `,`, never by `:`. */
-const KEY = /([A-Za-z_$][\w$]*)/g;
-
 /** The emitted specifier a TypeScript source imports by, back to the source file it names. */
-const resolveSpecifier = (fromFile, specifier) =>
-    join(dirname(fromFile), specifier.replace(/\.mjs$/, '.mts').replace(/\.js$/, '.ts'));
+const resolveSpecifier = (fromFile, specifier) => join(dirname(fromFile), resolveToSource(specifier));
 
 /**
- * The namespace keys of the FIRST `run({…})` in `source`, or `null` when there is none.
+ * The suites the FIRST `run({…})` in `source` registers, or `null` when there is none.
  *
- * Keys at every depth count: `runTests` recurses into a nested object, so a suite
- * grouped inside one is registered just as much as a top-level entry.
+ * The parse is `scripts/suite-registration.mjs`, shared with the driver gate and the node
+ * registration gate: three readers of one `run({…})` is three chances to disagree about
+ * what runs. `registered` and not `called` — this file's own arm fails an entry whose
+ * object registers NOTHING, and `run` is itself a called identifier.
  */
 function registeredKeys(source) {
-    const call = /\brun\s*\(\s*\{/.exec(source);
-    if (call === null) return null;
-    const open = source.indexOf('{', call.index);
-    let depth = 0;
-    let close = -1;
-    for (let i = open; i < source.length; i++) {
-        if (source[i] === '{') depth++;
-        else if (source[i] === '}' && --depth === 0) {
-            close = i;
-            break;
-        }
-    }
-    if (close === -1) return null;
-
-    const body = source.slice(open + 1, close);
-    const keys = new Set();
-    for (const match of body.matchAll(KEY)) {
-        const before = body.slice(0, match.index).trimEnd();
-        if (before === '' || before.endsWith('{') || before.endsWith(',')) keys.add(match[1]);
-    }
-    return keys;
+    const { registered, registers, properties } = registeredSymbols(source);
+    // `count` and not `named.size`: 23 entries register an INLINE suite by method shorthand
+    // (`run({ async DomExceptionTest() {…} })`), which registers a namespace while naming no
+    // module. The emptiness arm below asks the first question, the two arms after it the second.
+    return registers ? { named: registered, count: properties } : null;
 }
 
 /**
@@ -234,13 +179,13 @@ for (const { name, src, entry, browserOnly } of entries) {
             continue;
         }
         keys = registeredKeys(stripComments(readFileSync(delegate, 'utf8')));
-        if (keys === null || keys.size === 0) {
+        if (keys === null || keys.count === 0) {
             problems.push(`${where}: delegates to ${relative(ROOT, delegate)}, which registers nothing.`);
             continue;
         }
     }
 
-    if (keys.size === 0) {
+    if (keys.count === 0) {
         problems.push(`${where}: \`run({})\` registers no namespace — the bundle would report 0/0/0 and pass.`);
         continue;
     }
@@ -268,7 +213,7 @@ for (const { name, src, entry, browserOnly } of entries) {
         const binding = bindings.get(spec);
 
         if (suites.length > 0) {
-            const unregistered = suites.filter((symbol) => !keys.has(symbol));
+            const unregistered = suites.filter((symbol) => !keys.named.has(symbol));
             if (unregistered.length > 0)
                 problems.push(
                     `${rel}: ${unregistered.join(', ')} is not in the \`run({…})\` of ${where},`,
@@ -283,7 +228,7 @@ for (const { name, src, entry, browserOnly } of entries) {
                     `${rel}: default-exports a suite that ${where} does not import, and ${name} is`,
                     '  browser-only — so it runs NOWHERE. Import it there and register it.',
                 );
-            else if (!keys.has(binding))
+            else if (!keys.named.has(binding))
                 problems.push(
                     `${rel}: imported into ${where} as \`${binding}\`, but \`${binding}\` is not in its`,
                     `  \`run({…})\` — so that suite runs NOWHERE. Register it.`,

--- a/scripts/check-node-test-registration.mjs
+++ b/scripts/check-node-test-registration.mjs
@@ -29,21 +29,21 @@
 // path is enough — a spec belonging to the browser leg is not orphaned by being absent
 // from the node leg.
 //
-// Import specifiers are resolved the way the bundler resolves them, which means BOTH
-// spellings have to work: `'./x.spec.js'` (TS's ESM form, most of the repo) and
-// `'./x.spec'` (extensionless, `packages/web/dom-events`). Matching on the string
-// `.spec.js'` alone reports dom-events' four specs as orphans; that was the first
-// version of this script and it was wrong in exactly the direction that trains people
-// to ignore it.
-//
-// Files are found by WALKING `src/`, never by a glob: a glob is blind to the first spec
-// that lands in a subdirectory, and going blind is the failure this file removes.
+// Reading the entries — the walk, the four import spellings, the closure — is
+// `scripts/suite-registration.mjs`, which is also where the driver gate now gets its
+// answer from. It reports TWO facts about a spec, and this file asks for the weaker
+// one: `reachable`, "some entry imports it". The stronger one, `live` ("an entry hands
+// its suite to `run({…})`"), is deliberately not gated here — `packages/web/webrtc`
+// awaits its four spec defaults instead of registering them, and a package with several
+// entries registers a leg-appropriate subset in each. Gating reachability repo-wide and
+// liveness where a caller can justify it is the split that holds.
 //
 // Usage: node scripts/check-node-test-registration.mjs [--root <dir>]
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { packageDirs, readSuiteRegistration } from './suite-registration.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
@@ -56,105 +56,20 @@ const ROOT =
         ? resolve(dirname(fileURLToPath(import.meta.url)), '..')
         : resolve(process.cwd(), args[rootFlag + 1]);
 
-/** Directories that never hold first-party sources. */
-const SKIP = new Set(['node_modules', 'dist', 'lib', '.git', 'refs', 'tmp']);
-
-function walk(dir, match, out = []) {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (SKIP.has(entry.name)) continue;
-        const full = join(dir, entry.name);
-        if (entry.isDirectory()) walk(full, match, out);
-        else if (match(entry.name)) out.push(full);
-    }
-    return out;
-}
-
-/** Every directory holding a `package.json`, without descending into one. */
-function packages(dir, out = []) {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (SKIP.has(entry.name) || !entry.isDirectory()) continue;
-        const full = join(dir, entry.name);
-        if (existsSync(join(full, 'package.json'))) out.push(full);
-        else packages(full, out);
-    }
-    return out;
-}
-
-/**
- * The spec files one module imports, as absolute paths.
- *
- * Only relative specifiers are followed: a spec reached through a PACKAGE name is a
- * published entry point, not this package's own test file, and resolving those would
- * need the module graph rather than a regex.
- */
-function importedSpecs(file) {
-    const text = readFileSync(file, 'utf-8');
-    const out = [];
-    for (const match of text.matchAll(/from\s+'(\.[^']+)'|import\s*\(\s*'(\.[^']+)'/g)) {
-        const specifier = match[1] ?? match[2];
-        const candidate = resolveToSource(specifier);
-        if (!candidate.endsWith('.spec.ts')) continue;
-        const target = resolve(dirname(file), candidate);
-        if (existsSync(target)) out.push(target);
-    }
-    return out;
-}
-
-/**
- * A relative specifier as the file on disk.
- *
- * THREE spellings are in use and all three appear in test entries: `'./x.spec.js'`
- * (TS's ESM form, most of the repo), `'./x.spec'` (extensionless,
- * `packages/web/dom-events`) and `'./x.spec.ts'` (verbatim,
- * `packages/infra/tsc`). Handling only the first two reported that last package's one
- * spec as an orphan while it ran on every PR — a false violation is how a checker
- * teaches people to ignore it.
- */
-function resolveToSource(specifier) {
-    if (specifier.endsWith('.ts')) return specifier;
-    if (specifier.endsWith('.js')) return `${specifier.slice(0, -3)}.ts`;
-    return `${specifier}.ts`;
-}
-
-/**
- * `src/test.mts`, `src/test.browser.mts`, `src/test.node-gi.mts` — and `src/test.ts`,
- * which `packages/node/url` and `packages/node/util` use for the same job. Both
- * extensions, or those two packages' node specs are reported as orphans while they run
- * on every PR.
- */
-function isTestEntry(name) {
-    if (!name.startsWith('test') || name.endsWith('.spec.ts')) return false;
-    return name.endsWith('.mts') || name.endsWith('.ts');
-}
-
 const violations = [];
 let packagesChecked = 0;
 let specsChecked = 0;
 
-for (const pkg of packages(join(ROOT, 'packages'))) {
-    const src = join(pkg, 'src');
-    if (!existsSync(src) || !statSync(src).isDirectory()) continue;
-    const entries = readdirSync(src).filter(isTestEntry);
-    if (entries.length === 0) continue;
-
-    const specs = walk(src, (name) => name.endsWith('.spec.ts'));
-    if (specs.length === 0) continue;
+for (const pkg of packageDirs(join(ROOT, 'packages'))) {
+    const { entries, specs, reachable } = readSuiteRegistration(pkg);
+    if (entries.length === 0 || specs.length === 0) continue;
     packagesChecked++;
     specsChecked += specs.length;
 
-    // Closed over spec-to-spec imports: a helper spec is registered by whoever uses it.
-    const reachable = new Set();
-    const queue = entries.map((name) => join(src, name));
-    while (queue.length > 0) {
-        for (const target of importedSpecs(queue.pop())) {
-            if (reachable.has(target)) continue;
-            reachable.add(target);
-            queue.push(target);
-        }
-    }
-
     for (const spec of specs.sort()) {
-        if (!reachable.has(spec)) violations.push({ spec: relative(ROOT, spec), entries });
+        if (!reachable.has(spec)) {
+            violations.push({ spec: relative(ROOT, spec), entries: entries.map((entry) => relative(pkg, entry)) });
+        }
     }
 }
 

--- a/scripts/suite-registration.mjs
+++ b/scripts/suite-registration.mjs
@@ -160,14 +160,17 @@ export function relativeImports(file, source) {
     return found;
 }
 
-/** The local names an import clause introduces. `type` members bind no value. */
+/** The local names an import clause introduces. A type-only name binds no value. */
 function bindingsIn(clause) {
     const bindings = [];
     const text = clause.trim();
+    // `import type { AdwLengthUnit } from './x.js'` borrows a name for a field and runs
+    // nothing — the same distinction the driver gate's MODULE arm already turns on.
+    if (/^type\b/.test(text)) return bindings;
     const brace = text.indexOf('{');
     const head = (brace === -1 ? text : text.slice(0, brace)).replace(/,\s*$/, '').trim();
     if (head.startsWith('*')) bindings.push(head.replace(/^\*\s*as\s*/, ''));
-    else if (head && head !== 'type') bindings.push(head);
+    else if (head) bindings.push(head);
     if (brace !== -1) {
         for (const member of text.slice(brace + 1, text.indexOf('}', brace)).split(',')) {
             const part = member.trim();

--- a/scripts/suite-registration.mjs
+++ b/scripts/suite-registration.mjs
@@ -1,0 +1,352 @@
+// Which `*.spec.ts` a package REACHES, and which it actually RUNS — read once, for
+// every gate that needs either fact.
+//
+// THE INCIDENT
+//
+// `check-adwaita-conformance-drivers.mjs` called a conformance vector table "driven"
+// when any `*.spec.ts` under a renderer named it outside a comment. Naming is not
+// running, and the gap was measured on this tree (#1365): delete the single line
+// `AdwCarouselNsTest,` from the `run({…})` in
+// `packages/nativescript-bridge/adwaita/src/test.mts`, leave its import in place, and
+// `carousel.spec.ts` executes nowhere — while the driver gate, this repo's node
+// registration gate and its browser registration gate ALL stayed green, still counting
+// `CAROUSEL_NAVIGATE_VECTORS`, `CAROUSEL_REVEAL_VECTORS` and
+// `CAROUSEL_PROPERTY_DEFAULT_VECTORS` as renderer-driven. `runTests` in
+// `packages/gjs/unit/src/index.ts` iterates the object `run()` is handed and calls
+// nothing else, so a binding absent from that object is never invoked.
+//
+// TWO NOTIONS, AND WHY THEY LIVE IN ONE FILE
+//
+//   reachable — some `src/test*.{mts,ts}` entry imports it, directly or through
+//               another spec. A spec no entry reaches cannot run at all. The closure
+//               over spec-to-spec imports is what keeps helper specs
+//               (`packages/node/fs/src/capabilities.spec.ts`, shared by six siblings)
+//               from reading as orphans.
+//   live      — an entry binds its suite export AND hands that binding to `run({…})`,
+//               or calls it outright. Reachable is necessary and NOT sufficient: an
+//               imported-but-unregistered spec is reachable and runs nothing, which is
+//               exactly the shape above.
+//
+// Deriving the weaker one where the stronger was meant is how the hole opened, and two
+// gates deriving the same fact two ways is how they drift apart — so both notions come
+// from this reader and each caller says which it is asking for.
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/** Directories that never hold first-party sources. */
+export const SKIP = new Set(['node_modules', 'dist', 'lib', '.git', 'refs', 'tmp']);
+
+/**
+ * Files below `dir` whose basename `match` accepts, at any depth.
+ *
+ * Walking rather than globbing: a glob is blind to the first spec that lands in a
+ * subdirectory, and going blind is the failure every caller of this file removes.
+ */
+export function walk(dir, match, out = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP.has(entry.name)) continue;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full, match, out);
+        else if (match(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+/** Every directory holding a `package.json`, without descending into one. */
+export function packageDirs(dir, out = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP.has(entry.name) || !entry.isDirectory()) continue;
+        const full = join(dir, entry.name);
+        if (existsSync(join(full, 'package.json'))) out.push(full);
+        else packageDirs(full, out);
+    }
+    return out;
+}
+
+/**
+ * `src/test.mts`, `src/test.browser.mts`, `src/test.node-gi.mts` — and `src/test.ts`,
+ * which `packages/node/url` and `packages/node/util` use for the same job. Both
+ * extensions, or those two packages' node specs read as orphans while they run on
+ * every PR.
+ */
+export function isTestEntry(name) {
+    if (!name.startsWith('test') || name.endsWith('.spec.ts')) return false;
+    return name.endsWith('.mts') || name.endsWith('.ts');
+}
+
+/**
+ * Comments out, string literals through untouched.
+ *
+ * Every scan here is LEXICAL, and a comment is the one place a suite name can appear
+ * while registering nothing. Both directions were measured on a copy of the real
+ * adwaita-web tree: a block-commented `{ AdwSwitchTest }` left as the last element of
+ * the object passed GREEN over a suite that ran nowhere, a block comment anywhere
+ * inside the object swallowed the following key and falsely accused it, and a line
+ * `// e.g. run({ … })` above the real call captured the `run(` search outright and
+ * reported every spec as unregistered.
+ *
+ * A regex pair would be shorter and WRONG: `packages/node/url/src/test.browser.mts` is
+ * built out of `'http://example.com/…'` literals, and a `//`-to-end-of-line strip eats
+ * the rest of every line one of them sits on — measured, it deletes real code from that
+ * entry today. So this walks the source and skips quoted runs, because a check that
+ * reads the file differently from the engine that runs it is the bug, not the guard.
+ */
+export function stripComments(source) {
+    let out = '';
+    let i = 0;
+    while (i < source.length) {
+        const c = source[i];
+        if (c === '/' && source[i + 1] === '/') {
+            while (i < source.length && source[i] !== '\n') i++;
+        } else if (c === '/' && source[i + 1] === '*') {
+            const end = source.indexOf('*/', i + 2);
+            i = end === -1 ? source.length : end + 2;
+        } else if (c === "'" || c === '"' || c === '`') {
+            const start = i++;
+            while (i < source.length && source[i] !== c) i += source[i] === '\\' ? 2 : 1;
+            out += source.slice(start, ++i);
+        } else {
+            out += c;
+            i++;
+        }
+    }
+    return out;
+}
+
+/**
+ * A relative specifier as the file on disk.
+ *
+ * FOUR spellings are in use and all four appear in test entries: `'./x.spec.js'` (TS's
+ * ESM form, most of the repo), `'./x.spec'` (extensionless,
+ * `packages/web/dom-events`), `'./x.spec.ts'` (verbatim, `packages/infra/tsc`) and
+ * `'./test.mjs'` (an entry re-exporting the shared entry). Handling only the first two
+ * reported `packages/infra/tsc`'s one spec as an orphan while it ran on every PR — a
+ * false violation is how a checker teaches people to ignore it.
+ */
+export function resolveToSource(specifier) {
+    if (specifier.endsWith('.ts') || specifier.endsWith('.mts')) return specifier;
+    if (specifier.endsWith('.mjs')) return `${specifier.slice(0, -4)}.mts`;
+    if (specifier.endsWith('.js')) return `${specifier.slice(0, -3)}.ts`;
+    return `${specifier}.ts`;
+}
+
+/**
+ * Every relative import in `source`, as `{ target, bindings }`.
+ *
+ * `bindings` are the LOCAL names the module gets — a default import, the aliased or
+ * bare members of a brace clause, a namespace binding — because "is this suite
+ * registered" is asked of the local name, not of the exported one. A side-effect
+ * import (`import './x.spec.js'`) binds nothing and still reaches the file, so it
+ * yields an empty binding list rather than being dropped.
+ *
+ * Only RELATIVE specifiers: a spec reached through a package name is a published entry
+ * point, not this package's own test file, and resolving those would need the module
+ * graph rather than a regex.
+ */
+export function relativeImports(file, source) {
+    const found = [];
+    const pattern =
+        /(?:^|[\s;}])(?:import|export)\s+([^'"();]*?)\s*from\s*['"](\.[^'"]+)['"]|(?:^|[\s;}])import\s*['"](\.[^'"]+)['"]|\bimport\s*\(\s*['"](\.[^'"]+)['"]/g;
+    for (const match of source.matchAll(pattern)) {
+        const clause = match[1];
+        const specifier = match[2] ?? match[3] ?? match[4];
+        found.push({
+            target: resolve(dirname(file), resolveToSource(specifier)),
+            specifier,
+            bindings: clause === undefined ? [] : bindingsIn(clause),
+        });
+    }
+    return found;
+}
+
+/** The local names an import clause introduces. `type` members bind no value. */
+function bindingsIn(clause) {
+    const bindings = [];
+    const text = clause.trim();
+    const brace = text.indexOf('{');
+    const head = (brace === -1 ? text : text.slice(0, brace)).replace(/,\s*$/, '').trim();
+    if (head.startsWith('*')) bindings.push(head.replace(/^\*\s*as\s*/, ''));
+    else if (head && head !== 'type') bindings.push(head);
+    if (brace !== -1) {
+        for (const member of text.slice(brace + 1, text.indexOf('}', brace)).split(',')) {
+            const part = member.trim();
+            if (part === '' || part.startsWith('type ')) continue;
+            bindings.push(/\bas\s+([A-Za-z_$][\w$]*)$/.exec(part)?.[1] ?? part);
+        }
+    }
+    return bindings.filter((name) => /^[A-Za-z_$][\w$]*$/.test(name));
+}
+
+/** The body of the first `run({…})` in `source`, or `null` when there is none. */
+function runObjectBody(source) {
+    const call = /\brun\s*\(\s*\{/.exec(source);
+    if (call === null) return null;
+    const open = source.indexOf('{', call.index);
+    let depth = 0;
+    for (let i = open; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        else if (source[i] === '}' && --depth === 0) return source.slice(open + 1, i);
+    }
+    return null;
+}
+
+/** Split an object body on its own top-level commas — a nested literal is one part. */
+function topLevelParts(body) {
+    const parts = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < body.length; i++) {
+        const c = body[i];
+        if ('{(['.includes(c)) depth++;
+        else if ('})]'.includes(c)) depth--;
+        else if (c === ',' && depth === 0) {
+            parts.push(body.slice(start, i));
+            start = i + 1;
+        }
+    }
+    parts.push(body.slice(start));
+    return parts;
+}
+
+/** The offset of a property's own `:`, or -1 for shorthand. */
+function separatorIndex(part) {
+    let depth = 0;
+    for (let i = 0; i < part.length; i++) {
+        const c = part[i];
+        if ('{(['.includes(c)) depth++;
+        else if ('})]'.includes(c)) depth--;
+        else if (c === ':' && depth === 0) return i;
+    }
+    return -1;
+}
+
+/**
+ * The identifiers `source` registers as suites: the values of a `run({…})` property at
+ * any depth (`runTests` recurses into a nested object, so a suite grouped inside one is
+ * registered just as much as a top-level entry), plus anything the entry CALLS —
+ * `packages/web/webrtc/src/test.mts` awaits its four spec defaults directly instead of
+ * handing them to `run`, and that runs them.
+ *
+ * VALUE position, not key: `run({ Promise: promiseSuite })` registers `promiseSuite`,
+ * and it is the local binding a caller compares against. An inline `key: async () => {…}`
+ * registers no spec file and contributes nothing.
+ */
+export function registeredSymbols(source) {
+    const registered = new Set();
+    const body = runObjectBody(source);
+    const properties = body === null ? 0 : collectSuiteIdentifiers(body, registered);
+    const called = new Set();
+    for (const match of source.matchAll(/\b([A-Za-z_$][\w$]*)\s*\(/g)) called.add(match[1]);
+    // `registered` and `called` stay apart because one caller needs them apart:
+    // `check-browser-test-registration.mjs` fails an entry whose `run({})` registers NOTHING,
+    // and `run` is itself a called identifier — folded together, that arm could never fire.
+    // `properties` counts what the object registers; `registered` holds only what it
+    // registers BY NAME. They differ on the method shorthand 23 browser entries use —
+    // `run({ async DomExceptionTest() {…} })` registers a suite and names no module — so
+    // "does this object register anything" has to read the count, not the set.
+    return { registered, called, registers: body !== null, properties };
+}
+
+/** Adds the by-name registrations to `symbols`; returns how many properties there were. */
+function collectSuiteIdentifiers(body, symbols) {
+    let properties = 0;
+    for (const raw of topLevelParts(body)) {
+        const part = raw.trim();
+        if (part === '') continue;
+        const separator = separatorIndex(part);
+        if (separator === -1) {
+            properties += 1;
+            const shorthand = /^([A-Za-z_$][\w$]*)$/.exec(part);
+            if (shorthand) symbols.add(shorthand[1]);
+            continue;
+        }
+        const value = part.slice(separator + 1).trim();
+        const identifier = /^([A-Za-z_$][\w$]*)$/.exec(value);
+        if (identifier) {
+            properties += 1;
+            symbols.add(identifier[1]);
+        } else if (value.startsWith('{')) {
+            properties += collectSuiteIdentifiers(value.slice(1, value.lastIndexOf('}')), symbols);
+        } else {
+            properties += 1;
+        }
+    }
+    return properties;
+}
+
+/**
+ * What a package's test entries reach and what they run.
+ *
+ * `opaque` names entries whose registration could not be read at all — no `run({…})`,
+ * no delegation to a sibling entry, no spec called by hand. `live` is then INCOMPLETE
+ * for that package, so a caller that gates on `live` must fail on a non-empty `opaque`
+ * rather than report every spec dead: an unreadable entry is a limit of this reader,
+ * and a limit that reports itself as a finding about someone else's code is the
+ * expensive kind of wrong.
+ */
+export function readSuiteRegistration(pkgDir) {
+    const src = join(pkgDir, 'src');
+    const empty = { src, entries: [], specs: [], reachable: new Set(), live: new Set(), opaque: [] };
+    if (!existsSync(src) || !statSync(src).isDirectory()) return empty;
+    const entries = readdirSync(src)
+        .filter(isTestEntry)
+        .map((name) => join(src, name));
+    if (entries.length === 0) return empty;
+    const specs = walk(src, (name) => name.endsWith('.spec.ts'));
+    if (specs.length === 0) return { ...empty, entries };
+
+    const isSpec = new Set(specs);
+    const isEntry = new Set(entries);
+    const sources = new Map([...entries, ...specs].map((file) => [file, stripComments(readFileSync(file, 'utf8'))]));
+
+    const reachable = new Set();
+    const live = new Set();
+    const opaque = [];
+    const queue = [];
+
+    for (const entry of entries) {
+        const source = sources.get(entry);
+        const { registered, called, registers } = registeredSymbols(source);
+        const imports = relativeImports(entry, source);
+        let bound = false;
+        for (const { target, bindings } of imports) {
+            if (!isSpec.has(target)) continue;
+            if (!reachable.has(target)) {
+                reachable.add(target);
+                queue.push(target);
+            }
+            if (bindings.some((name) => registered.has(name) || called.has(name))) {
+                bound = true;
+                live.add(target);
+            }
+        }
+        // A re-export entry (`export * from './test.mjs'`) delegates to the sibling that
+        // owns the `run({…})`; that sibling is itself a seed here, so the delegation adds
+        // nothing to read and is not a gap in the reading.
+        const delegates = imports.some(({ target }) => isEntry.has(target));
+        if (!registers && !delegates && !bound) opaque.push(entry);
+    }
+
+    // Reachability closes over spec-to-spec imports; liveness closes over the same edges
+    // from the live specs only, because a helper is run by whoever imports it.
+    while (queue.length > 0) {
+        const file = queue.pop();
+        for (const { target } of relativeImports(file, sources.get(file))) {
+            if (!isSpec.has(target) || reachable.has(target)) continue;
+            reachable.add(target);
+            queue.push(target);
+        }
+    }
+    const liveQueue = [...live];
+    while (liveQueue.length > 0) {
+        const file = liveQueue.pop();
+        for (const { target } of relativeImports(file, sources.get(file))) {
+            if (!isSpec.has(target) || live.has(target)) continue;
+            live.add(target);
+            liveQueue.push(target);
+        }
+    }
+
+    return { src, entries, specs, reachable, live, opaque };
+}

--- a/scripts/suite-registration.mjs
+++ b/scripts/suite-registration.mjs
@@ -230,7 +230,7 @@ function separatorIndex(part) {
  *
  * VALUE position, not key: `run({ Promise: promiseSuite })` registers `promiseSuite`,
  * and it is the local binding a caller compares against. An inline `key: async () => {…}`
- * registers no spec file and contributes nothing.
+ * names no spec file, so it raises `properties` and adds no symbol.
  */
 export function registeredSymbols(source) {
     const registered = new Set();


### PR DESCRIPTION
Five libadwaita containers came from the GENERATED descriptor table, so `@gjsify/gtk-host` knew their tag and refused every child with `uncurated-placement` — in every JSX dialect this host serves, for the widgets libadwaita's own adaptive-layout advice reaches for first. `<adw-clamp>` with a child was an error today.

Four of them could not have been curated at all, and that is the substance of this PR.

## `slotted.remove` was mandatory, and two containers cannot satisfy it

Measured on libadwaita 1.9.3: `Adw.NavigationSplitView` and `Adw.OverlaySplitView` have `set_sidebar`/`set_content` and **no remove method of their own** — every `remove*` on them is `GtkWidget`'s (`remove_controller`, `remove_css_class`, `remove_mnemonic_label`, `remove_tick_callback`). Naming one would be a claim `descriptorProblems()` correctly rejects.

They never needed one. `detachChild` already empties a `set_`-prefixed slot by writing `null` back through the setter (`setterSlotOf` → `clearIfCurrent`); only an **adder**-backed slot (`add_top_bar`, `pack_start`) has nothing else that takes a child out.

So `remove` becomes optional — and the guarantee the type used to give is replaced by a checked rule rather than a comment: `policyProblems()` reports a policy whose slots include an adder and which names no remove, **naming the slots that forced it**. The runtime path keeps a named refusal too (`slot-needs-remove`): a built-in descriptor can no longer reach it, but `registerWidget` takes descriptors from applications and nothing checks those, where the alternative is `TypeError: host[undefined] is not a function` deep inside an unmount.

## The five descriptors

| gtype | policy | measured |
|---|---|---|
| `AdwClamp` | `single`, `set_child` | `set_child`/`get_child` |
| `AdwClampScrollable` | `single`, `set_child` | same |
| `AdwBreakpointBin` | `single`, `set_child` | plus `add_breakpoint`/`remove_breakpoint`, which are not a child policy |
| `AdwNavigationSplitView` | `slotted`, `set_sidebar`/`set_content`, no remove | no remove method exists |
| `AdwOverlaySplitView` | `slotted`, same | no remove method exists |

`AdwViewSwitcher` and `AdwViewSwitcherBar` stay uncurated deliberately: they answer `set_stack` and take no child, and `uncurated` costs a leaf nothing.

Two facts a descriptor cannot express, written where the next reader will be rather than left to be rediscovered:

- **An `Adw.Breakpoint` is a plain GObject** — measured, it answers `set_condition`/`add_setter` — so it is neither a child nor a slot of `AdwBreakpointBin` and reaches the widget through `add_breakpoint`. Putting it in a slot would send a non-widget through `addressOf()`.
- **`AdwClampScrollable` binds its four scroll properties onto whatever child it is given.** A child that is not a `GtkScrollable` is four `gbinding.c:1301` warnings at exit 0 — `The target object of type GtkLabel has no property called 'hadjustment'`, and three more — and scrolling that silently does not work.

## Held against deliberate defects

A rule measured only where it fires has not been measured, and making a field optional can turn a check into one that passes on everything. Each mutation was applied to a committed tree, run, and reverted:

| mutation | result |
|---|---|
| the new rule never fires (`if (false && …)`) | **1 test red** — `reports an adder-backed slot with nothing to remove it with` |
| the new rule fires on every slotted policy without remove | **2 red** — the `stays clean on an all-setter policy` control, and the tree-wide `every declared method and text sink exists` |
| a setter-backed slot is never cleared on detach | **3 red** — the split-view vector, once per adapter |
| unmodified tree | **green, 2053 tests** |

Three more fell on their own during development, which is why they are in the diff at all:

- the runtime-refusal test read an empty string until the parent was **materialized** — `attach` returns early on a parent with no widget, so the child was never attached and `remove()` returned before `detachChild`. It passed while measuring nothing.
- the `AdwClampScrollable` vector failed on those four `gbinding` warnings with a `GtkLabel` child, which is how the scroll-property constraint was found.
- the existing `every slotted descriptor survives a round trip through every slot` failed for `AdwNavigationSplitView`, because it used one child tag for every container and `set_sidebar` takes an `AdwNavigationPage`. Its overlay sibling takes any widget, so only the one container is listed — a blanket "use a page for both" would have hidden that difference behind a convention.

## Checks

`oxfmt --check .` 0 · `oxlint packages/framework/gtk-host/src` 0 · `gjsify tsc --noEmit` (gtk-host) 0 · `gjsify run test` (gtk-host) 0, 2053 tests from 12 gates.

There is no root `tsconfig.json`, so a bare `npx tsc` prints help and exits 1 regardless of the code; the repo's spelling is per package.

## Second hole in the same gate: a promise that names no table

Reported after the first fix landed on this branch, and measured here rather than taken at face value. Both conditions hold as described:

- the CLAIM arm (arms 6-10) begins at `citationsIn(clause, declared)` and `continue`s when the clause cites no table;
- `BOTH_CLAIM` matches `both <noun>` / `the two <noun>`, and `SUITE_CLAIMS` matches the two renderers **by name** — neither matches "every renderer suite", and both sit behind the citation guard anyway.

One correction to the report: the offending file is not in the merged tree. `// Breakpoint-bin specs — driven by the shared conformance vectors, so this suite and every renderer suite assert the SAME table.` is on **#1364's branch**, and the identical sentence heads `header-bar.spec.ts` on **#1359's branch** — a second instance nobody had reported. In both, every table the spec imports carries `CORE-ONLY: GAP — no renderer drives this table yet`, and neither renderer's `src` names them.

Widening `BOTH_CLAIM` to "every" would be true and would catch neither: the clause cites no table, so arm 8 never reaches it. Arm 12 therefore starts at the **code**. The tables a spec imports are what it is about; where not one of them reaches a renderer — directly or through an exemption chain — a renderer coverage claim anywhere in that file is false whatever words it is written in, so no prose matcher has to be precise enough to argue with. A clause the existing `CLAUSE_TURN` split has already headed with a negation is exempt, because "no renderer drives these rows yet" is the true sentence to write in exactly these files.

| case | expected | exit |
|---|---|---|
| `feat/breakpoint-bin` as it stands | red | **1** |
| `feat/headerbar-core` as it stands | red | **1** |
| the promise removed, tables still `GAP` | green | **0** |
| the honest negative "No renderer suite drives these rows yet" | green | **0** |
| the same promise moved to a comment block further down the file | red | **1** |
| a true renderer promise over renderer-**driven** tables | green | **0** |
| the promise intact, exemption chain reaching a driver | green | **0** |
| unmodified `main` | green | **0** |

Stated plainly: on `main` this arm examines **0** files, because no core spec there has all its tables undriven. The summary line reports that count rather than letting it read as coverage. It has subjects the moment such a spec lands, which is exactly when the defect appears — and it will turn #1359 and #1364 red until one comment line in each is corrected.
