### PR TITLE
fix(oxlint): lint the tracked sources under lib/

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,6 +357,22 @@ jobs:
       - name: Lint (oxlint, errors only)
         run: su testuser -c "gjs -m '$GJSIFY_BOOTSTRAP' lint"
 
+      # And the question the step above cannot ask about itself: did it SEE the code?
+      # `.oxlintrc.json`'s `**/lib` was written for build output and also hid 26
+      # hand-written sources in `@gjsify/{manifest-conformance,resolve-npm}` — the
+      # manifest gates that block this branch and the alias layer every build target
+      # routes through, neither ever linted. The lint step was green throughout,
+      # because a gate grades the files it was handed and the defect was in the
+      # handing. This one diffs `oxlint --debug=files .` against the same walker over
+      # `git ls-files` with `--no-ignore`, so both halves are oxlint's own answer, and
+      # every blind file is either declared with a reason or red.
+      #
+      # It runs HERE, next to the lint it audits, and not in `audit-runtimes.yml` with
+      # the other repo-scoped gates: that workflow deliberately installs nothing, and
+      # this needs the pinned `oxlint` from `node_modules`.
+      - name: Check the lint gate sees every tracked file
+        run: node scripts/check-lint-visibility.mjs
+
       # A formatter with a config and no gate formats nothing. `.oxfmtrc.json`
       # had been maintained all along while nothing enforced it, and the drift
       # just accumulated: 388 files were unformatted against the version the

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,8 +370,13 @@ jobs:
       # It runs HERE, next to the lint it audits, and not in `audit-runtimes.yml` with
       # the other repo-scoped gates: that workflow deliberately installs nothing, and
       # this needs the pinned `oxlint` from `node_modules`.
+      #
+      # As TESTUSER, unlike the `check-doc-fences.mjs` step below: `gjsify-setup` runs
+      # `chown -R testuser:testuser .`, and this script's subject is `git ls-files`, so
+      # as root it would meet git's dubious-ownership refusal against a tree owned by
+      # someone else. `check-doc-fences.mjs` touches no git and does not care.
       - name: Check the lint gate sees every tracked file
-        run: node scripts/check-lint-visibility.mjs
+        run: su testuser -c 'node scripts/check-lint-visibility.mjs'
 
       # A formatter with a config and no gate formats nothing. `.oxfmtrc.json`
       # had been maintained all along while nothing enforced it, and the drift

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -232,7 +232,22 @@
     "ignorePatterns": [
         "**/node_modules",
         "**/dist",
-        "**/lib",
+        // NO `**/lib` here, deliberately. `lib/` is this repo's build-output
+        // directory in 119 packages, and the root `.gitignore` already says so
+        // (`lib/`, line 53) — oxlint honours .gitignore, MEASURED both inside a
+        // git checkout and in a tree with no `.git` at all, so the pattern
+        // bought nothing for build output. What it did buy was a blind spot:
+        // it OVERRODE the deliberate `!lib/` re-include in
+        // `@gjsify/manifest-conformance` and `@gjsify/resolve-npm`, whose
+        // `lib/` is hand-written committed ESM (`build`/`clear` are both
+        // `echo 'nothing to do'`; there is no `src/`). 26 tracked source files
+        // — the manifest gates that block `main`, and the alias layer every
+        // build target routes through — had never been linted, and
+        // `oxlint packages/infra/resolve-npm` answered "No files found to lint"
+        // rather than "everything here is skipped". Letting .gitignore be the
+        // single reader for "is this build output" also makes the next such
+        // package correct by default: committing source under `lib/` requires
+        // an explicit `!lib/`, and that same act now makes it visible here.
         "**/build",
         "**/build-dir",
         "**/builddir",
@@ -243,6 +258,13 @@
         "**/refs",
         "tests/e2e/*/out",
         "packages/infra/lightningcss-wasm/src/napi-wasm.mjs",
+        // The one `lib/` that is committed but NOT ours: 108 verbatim copies of
+        // upstream TypeScript's default-library declarations, refreshed from
+        // `node_modules/typescript/lib` by `scripts/build-bundle.mjs` and
+        // re-included in `.gitignore` so a consumer without `typescript`
+        // resolves them. Linting vendored `lib.dom.d.ts` grades Microsoft's
+        // house style, and any finding is unfixable here by construction.
+        "packages/infra/tsc/lib",
         "packages/**/conformance.*.js",
         "**/@types",
         "**/src/generated",

--- a/packages/infra/manifest-conformance/lib/rules/prebuild-libc.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/prebuild-libc.mjs
@@ -196,7 +196,7 @@ export function hostPrebuildTarget(platform, arch, libc) {
  * @returns {string}
  */
 export function canonicalPrebuildTarget(token) {
-    const { os, arch, libc } = parsePrebuildTarget(token);
+    const { os, arch } = parsePrebuildTarget(token);
     if (!arch) return String(token);
     const canonical = `${os}-${ARCH_ALIASES[arch] ?? arch}`;
     return String(token).endsWith(MUSL_SUFFIX) ? `${canonical}${MUSL_SUFFIX}` : canonical;
@@ -229,7 +229,10 @@ export function canonicalPrebuildTarget(token) {
  */
 export function libcFlavourOfNeeded(needed) {
     const isGlibc = needed.some((n) => n === 'libc.so.6' || /^ld-linux(-|\.)/.test(n) || /^ld\d*\.so\.\d+$/.test(n));
-    const isMusl = needed.some((n) => /^libc\.musl-/.test(n) || /^ld-musl-/.test(n));
+    // Plain prefixes, so `startsWith` — unlike the glibc line above, whose two
+    // patterns carry an alternation and a digit class and stay regexes. The
+    // asymmetry is the signal: these two sonames have no variable part.
+    const isMusl = needed.some((n) => n.startsWith('libc.musl-') || n.startsWith('ld-musl-'));
     // Both cannot be true for a loadable image; report glibc and let the caller
     // fail on the contradiction, which it does with the full leaf list.
     if (isGlibc && isMusl) return 'glibc';

--- a/packages/infra/resolve-npm/lib/runtime-aliases.mjs
+++ b/packages/infra/resolve-npm/lib/runtime-aliases.mjs
@@ -393,7 +393,6 @@ function getCacheSync() {
 function warnOnce(key, message) {
     if (_warned.has(key)) return;
     _warned.add(key);
-    // eslint-disable-next-line no-console
     console.warn(`[@gjsify/resolve-npm] ${message}`);
 }
 

--- a/scripts/check-lint-visibility.mjs
+++ b/scripts/check-lint-visibility.mjs
@@ -55,11 +55,13 @@
 // undeclared blind files" also proves the differencing still finds the ~131 files it
 // is supposed to find. A broken oracle cannot come back green.
 //
-// KNOWN, AND NOT FIXED HERE: `.oxfmtrc.json` carries the same `**/lib` line, so the
-// FORMATTER is blind to the same 26 sources — measured with the pattern lifted, 15 of
-// them are unformatted. Closing that reformats load-bearing infra files, which is its
-// own change with its own diff to read, and this gate deliberately does not fail on it.
-// Written down so the second half stays a decision instead of becoming another silence.
+// THE FORMATTER HALF IS CLOSED, SEPARATELY: `.oxfmtrc.json` carried the same `**/lib`
+// line and hid the same 26 sources from oxfmt — 15 of them unformatted. That landed on
+// its own, because closing it reformats load-bearing infra and deserved its own diff to
+// read. This gate still says nothing about formatting: it answers "can the LINTER see
+// this file", and the equivalent question for oxfmt needs a different oracle (oxfmt has
+// no `--debug=files` and no `--no-ignore`, so its visible set is only recoverable by
+// bisecting an accepted-file count). That arm is owed and not written.
 //
 // Usage: node scripts/check-lint-visibility.mjs [--root <dir>] [--list]
 

--- a/scripts/check-lint-visibility.mjs
+++ b/scripts/check-lint-visibility.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+// Every file git tracks is one oxlint reads, or it is declared here with a reason.
+//
+// THE INCIDENT
+//
+// `.oxlintrc.json` carried `**/lib` in `ignorePatterns`, put there for build output:
+// `lib/` is where 119 packages compile `src/` to. Three packages COMMIT files under
+// that name, and the blanket pattern swallowed all of them — 134 tracked files, of
+// which 26 are hand-written ESM in `@gjsify/manifest-conformance` (the manifest gates
+// that block `main`) and `@gjsify/resolve-npm` (the alias layer every build target
+// routes through). Neither had ever had a line linted. The way it surfaced is the
+// part worth keeping: `oxlint packages/infra/resolve-npm` exits 1 with "No files
+// found to lint", so a reviewer who lints the package BY PATH is told the package is
+// empty rather than that all of it is skipped. Exit 1 read as "checked, and angry";
+// it meant "nothing was checked at all".
+//
+// That is this repository's most expensive recurring shape — a green check that
+// verified nothing — wearing an ignore pattern instead of a test. Nothing else in the
+// tree can report it: lint gates grade the files they were HANDED, and the defect is
+// in the handing.
+//
+// HOW THE SET IS DERIVED, and why neither half is this script's own opinion
+//
+// The obvious implementation re-reads `ignorePatterns` and re-implements gitignore
+// matching. That builds a SECOND matcher, which then has to agree with oxlint's about
+// `**/lib` vs `lib/`, about `.gitignore` inheritance, about negation — and the day it
+// disagrees, this script is confidently wrong in whichever direction its own bug
+// points. So both sides are asked of oxlint itself, with `--debug=files`, which prints
+// the walk result and exits:
+//
+//   WILL  = `oxlint --debug=files .`
+//           what the whole-tree lint actually visits — every ignore layer applied.
+//   COULD = `oxlint --debug=files --no-ignore <every tracked path>`
+//           the same walker over git's list with the ignore layers off, so the
+//           extension question ("is this a file you lint?") is answered by oxlint and
+//           not by a list of suffixes maintained here. Passing git's paths explicitly
+//           is also what keeps `node_modules` out of a `--no-ignore` walk.
+//
+// blind = COULD − WILL. Every member is a tracked file oxlint can read and does not.
+//
+// WHY THE EXEMPTIONS MUST MATCH SOMETHING
+//
+// A registry entry that matches nothing is the same claim as an unused
+// `eslint-disable`: it announces that a case was considered when the case is gone.
+// `.oxlintrc.json` already turns `reportUnusedDisableDirectives` to `error` over the
+// incident where such comments sat next to code for two months describing a review
+// that had never happened (#859/#861). The rule applies to this file's own registry,
+// so a stale entry is RED, and the entries retire themselves.
+//
+// It buys the control this script would otherwise lack. The failure mode of a
+// set-difference gate is that the difference silently becomes empty — `--no-ignore`
+// stops disabling anything, `--debug=files` changes its output, one oracle starts
+// returning nothing — and the gate then passes while measuring the empty set. Because
+// every exemption must match a real blind file, the same run that reports "no
+// undeclared blind files" also proves the differencing still finds the ~131 files it
+// is supposed to find. A broken oracle cannot come back green.
+//
+// KNOWN, AND NOT FIXED HERE: `.oxfmtrc.json` carries the same `**/lib` line, so the
+// FORMATTER is blind to the same 26 sources — measured with the pattern lifted, 15 of
+// them are unformatted. Closing that reformats load-bearing infra files, which is its
+// own change with its own diff to read, and this gate deliberately does not fail on it.
+// Written down so the second half stays a decision instead of becoming another silence.
+//
+// Usage: node scripts/check-lint-visibility.mjs [--root <dir>] [--list]
+
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+const rootFlag = args.indexOf('--root');
+if (rootFlag !== -1 && args[rootFlag + 1] === undefined) {
+    console.error('check-lint-visibility: --root needs a directory.');
+    process.exit(2);
+}
+const ROOT =
+    rootFlag === -1
+        ? resolve(dirname(fileURLToPath(import.meta.url)), '..')
+        : resolve(process.cwd(), args[rootFlag + 1]);
+const LIST = args.includes('--list');
+
+/**
+ * Tracked paths oxlint deliberately never reads. `prefix` matches a path or anything
+ * under it; `why` is the part that has to survive review, so it states what the files
+ * ARE and what linting them would grade.
+ *
+ * Adding an entry is a decision to stop checking real code. Committed SOURCE does not
+ * belong here — narrow the ignore instead, which is what `**\/lib`'s removal did.
+ */
+const EXEMPT = [
+    {
+        prefix: 'packages/infra/tsc/lib',
+        why:
+            "verbatim copies of upstream TypeScript's default-library declarations, refreshed from " +
+            "`node_modules/typescript/lib` by the package's own build and committed so a consumer " +
+            "without `typescript` can resolve them. Linting `lib.dom.d.ts` grades Microsoft's house " +
+            'style, and every finding would be unfixable here by construction.',
+    },
+    {
+        prefix: 'packages/infra/cli/dist/affected.gjs.mjs',
+        why:
+            'a committed BUNDLE, not a source: the Soup-free CI classifier the `changes` job boots ' +
+            'before any install. Its input lives in `packages/infra/cli/src`, which is linted; the ' +
+            'artifact is rebuilt, never edited.',
+    },
+    {
+        prefix: 'packages/infra/lightningcss-wasm/src/napi-wasm.mjs',
+        why: 'vendored upstream wasm-bindgen glue, replaced wholesale on every lightningcss bump.',
+    },
+    {
+        prefix: 'packages/framework/gtk-host/src/generated',
+        why: 'generated from the GTK/Adwaita GIR; findings belong to the generator, not the output.',
+    },
+    {
+        prefix: 'packages/framework/react-native/src/generated',
+        why: 'generated export stubs; same as gtk-host — fix the generator.',
+    },
+    {
+        prefix: 'packages/framework/webgl/src/ts/@types',
+        why: 'hand-copied ambient declarations for an untyped upstream package, kept as it was written.',
+    },
+    {
+        prefix: 'templates',
+        why:
+            'scaffolding copied into a NEW project by `gjsify create`, not compiled as part of this ' +
+            'tree. Measured 2026-08 with the ignore lifted: 2 findings, both ' +
+            '`gjsify/no-literal-widget-label` in `templates/gtk-minimal`, on the hello-world caption a ' +
+            'user replaces first — the same posture `.oxlintrc.json` already grants `examples/` and ' +
+            '`showcases/` for demo captions. Un-ignoring templates is a defensible separate change; it ' +
+            'wants that override extended, not a new blind spot.',
+    },
+    {
+        prefix: 'website/src/components/AdwWidget.astro',
+        why:
+            "oxlint's .astro reader finds `<script>` by text scan and takes the one inside this file's " +
+            'JSX comment as a real opener, then fails to parse the markup after it. Reasoned at length ' +
+            'in `.oxlintrc.json`; every other .astro file stays linted.',
+    },
+];
+
+const require = createRequire(import.meta.url);
+let OXLINT;
+try {
+    // Via `package.json`, not the bin path directly: the bin has no extension and the
+    // package's `exports` map does not expose it, so `require.resolve('oxlint/bin/oxlint')`
+    // throws even where the file is right there.
+    OXLINT = join(dirname(require.resolve('oxlint/package.json')), 'bin', 'oxlint');
+} catch {
+    // Not a "best effort" catch: without the pinned binary there is no oracle, and a
+    // gate that cannot measure must say so rather than pass.
+    console.error('check-lint-visibility: cannot resolve the pinned `oxlint`. Install dependencies first.');
+    process.exit(2);
+}
+
+/**
+ * Run oxlint's own walker and return the paths it reports, repo-relative and
+ * forward-slashed (Windows prints backslashes).
+ *
+ * `--debug=files` writes the list and exits 0 without linting; a non-zero status means
+ * the oracle did not answer, which must not be read as "nothing to report".
+ */
+function oxlintFiles(extraArgs, paths) {
+    let out;
+    try {
+        out = execFileSync(process.execPath, [OXLINT, '--debug=files', ...extraArgs, ...paths], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            maxBuffer: 64 * 1024 * 1024,
+            // `execFileSync` lets the child's stderr reach ours unless stdio is
+            // spelled out, which prints the failure twice around this script's
+            // explanation of it.
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    } catch (err) {
+        console.error(
+            `check-lint-visibility: \`oxlint --debug=files ${extraArgs.join(' ')}\` failed ` +
+                `(status ${err.status ?? '?'}). Without both file lists there is nothing to compare.`,
+        );
+        if (err.stderr) console.error(String(err.stderr).trimEnd());
+        process.exit(2);
+    }
+    return out
+        .split('\n')
+        .map((line) => line.trim().replaceAll('\\', '/'))
+        .filter(Boolean);
+}
+
+/** `git ls-files`, NUL-separated so a path with a newline in it cannot split a row. */
+function trackedFiles() {
+    let out;
+    try {
+        out = execFileSync('git', ['ls-files', '-z'], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            maxBuffer: 64 * 1024 * 1024,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    } catch (err) {
+        // Real throw paths, all of which produce an EMPTY subject rather than an error:
+        // no `git` on PATH, not a repository, or the container's "dubious ownership"
+        // refusal. Each would make this gate pass having listed nothing.
+        console.error(
+            `check-lint-visibility: \`git ls-files\` failed in ${ROOT} (status ${err.status ?? '?'}). ` +
+                'The tracked-file list is the subject of this check; without it there is nothing to check.',
+        );
+        if (err.stderr) console.error(String(err.stderr).trimEnd());
+        process.exit(2);
+    }
+    return out.split('\0').filter(Boolean);
+}
+
+/** argv has a length limit; the tracked list is ~5.5k paths, so hand it over in batches. */
+function chunked(paths, budget = 100_000) {
+    const chunks = [[]];
+    let size = 0;
+    for (const p of paths) {
+        if (size + p.length + 1 > budget && chunks.at(-1).length > 0) {
+            chunks.push([]);
+            size = 0;
+        }
+        chunks.at(-1).push(p);
+        size += p.length + 1;
+    }
+    return chunks;
+}
+
+const tracked = new Set(trackedFiles());
+const will = new Set(oxlintFiles([], ['.']));
+const could = new Set();
+for (const chunk of chunked([...tracked])) {
+    for (const file of oxlintFiles(['--no-ignore'], chunk)) could.add(file);
+}
+
+// Both oracles are the same binary and the same walker; if the ignore-free list does
+// not contain the ignored one, they are not answering the same question and the
+// difference below means nothing.
+if (will.size === 0 || could.size === 0) {
+    console.error(
+        `check-lint-visibility: an oracle came back empty (will=${will.size}, could=${could.size}). ` +
+            'A set difference against an empty set is not a measurement.',
+    );
+    process.exit(2);
+}
+// Restricted to TRACKED files on purpose. `will` comes from walking the tree, so on a
+// working copy it also holds files git has never seen — a new script, a scratch repro —
+// and `could` is built from `git ls-files`. Comparing the raw sets would report every
+// uncommitted file as an oracle disagreement, which is loud, wrong, and exactly the kind
+// of noise that trains people to stop reading a gate.
+const notASuperset = [...will].filter((f) => tracked.has(f) && !could.has(f));
+if (notASuperset.length > 0) {
+    console.error(
+        'check-lint-visibility: tracked files the tree lint reads are missing from the ignore-free ' +
+            'walk, so the two lists are not comparable:\n',
+    );
+    for (const f of notASuperset.slice(0, 10)) console.error(`  ${f}`);
+    process.exit(2);
+}
+
+const blind = [...could].filter((f) => !will.has(f)).sort();
+
+const matched = new Map(EXEMPT.map((e) => [e.prefix, []]));
+const undeclared = [];
+for (const file of blind) {
+    const hit = EXEMPT.find((e) => file === e.prefix || file.startsWith(`${e.prefix}/`));
+    if (hit) matched.get(hit.prefix).push(file);
+    else undeclared.push(file);
+}
+
+if (LIST) {
+    for (const { prefix } of EXEMPT) {
+        console.log(`${prefix}  (${matched.get(prefix).length} file(s))`);
+        for (const f of matched.get(prefix)) console.log(`    ${f}`);
+    }
+}
+
+const stale = EXEMPT.filter((e) => matched.get(e.prefix).length === 0);
+
+if (undeclared.length > 0 || stale.length > 0) {
+    if (undeclared.length > 0) {
+        console.error('check-lint-visibility: tracked files oxlint never reads.\n');
+        for (const file of undeclared) console.error(`  ${file}`);
+        console.error(
+            '\nEach of these is committed code the CI lint gate never grades, and checking one by\n' +
+                'hand does not reveal it — MEASURED, both answers mislead: a path excluded by\n' +
+                '`ignorePatterns` makes `oxlint <path>` print "No files found to lint" and exit 1,\n' +
+                'which reads as angry-but-checked; a path excluded by `.gitignore` gets linted on an\n' +
+                'explicit argument and looks covered, while `oxlint .` walks straight past it.\n' +
+                'Either narrow the ignore in `.oxlintrc.json` so the tree walk reaches the file, or\n' +
+                'add it to EXEMPT in this script with a reason that says what it IS.\n',
+        );
+    }
+    if (stale.length > 0) {
+        console.error('check-lint-visibility: EXEMPT entries that match nothing.\n');
+        for (const { prefix } of stale) console.error(`  ${prefix}`);
+        console.error(
+            '\nAn exemption matching no file claims a case was considered that no longer exists —\n' +
+                'the unused-disable-directive shape `.oxlintrc.json` makes an error. It is also this\n' +
+                "gate's only control: if the difference stopped finding anything, this is where it\n" +
+                'shows. Delete the entry, or find out why the file it named is no longer blind.\n',
+        );
+    }
+    process.exit(1);
+}
+
+// `will` also holds untracked files the tree walk found, so the headline counts the
+// intersection — otherwise the two numbers do not add up to `could.size` and the reader
+// has to guess which one is the lie.
+const read = [...will].filter((f) => tracked.has(f)).length;
+console.log(
+    `check-lint-visibility: ${read} of ${could.size} lintable tracked file(s) are read by ` +
+        `oxlint; the remaining ${blind.length} are declared across ${EXEMPT.length} exemption(s), ` +
+        'each of which still matches.',
+);


### PR DESCRIPTION
## The hole, measured

`.oxlintrc.json` carried `**/lib` in `ignorePatterns`. That pattern is there for build
output — `lib/` is the compile target of 119 packages in this workspace. Three packages
**commit** files under that name, and the blanket glob swallowed all of them:

```
$ git ls-files | grep -E "^packages/.*/lib/.*\.(mjs|js|ts|d\.ts)$" | wc -l
134
    108  packages/infra/tsc
     21  packages/infra/manifest-conformance
      5  packages/infra/resolve-npm
```

Of those 134, **26 are hand-written source**, not output — verified rather than assumed:
both packages' `build` and `clear` scripts are `echo 'nothing to do'`, neither has a
`src/`, and each carries an explicit `!lib/` in its own `.gitignore`
(manifest-conformance's says so in prose: *"`lib/` here is SOURCE, not a build output"*).
They are also the two least affordable packages to leave unlinted:
`@gjsify/manifest-conformance` holds the manifest gates that block `main`, and
`@gjsify/resolve-npm` is the alias layer every build target routes through. oxlint had
never read a line of either.

The remaining **108 are `packages/infra/tsc/lib/lib*.d.ts`** — verbatim copies of
upstream TypeScript's default-library declarations, refreshed from
`node_modules/typescript/lib` by that package's own `build-bundle.mjs` and committed so a
consumer without `typescript` can resolve them. Those are correctly ignored, so the fix is
narrowed accordingly and they are named explicitly instead of covered by a glob.

How it surfaced is the part worth keeping:

```
$ npx oxlint packages/infra/resolve-npm
No files found to lint. Please check your paths and ignore patterns.
$ echo $?
1
```

A reviewer linting the package by path is told the package is empty, not that all of it is
skipped. Exit 1 reads as *checked, and angry*; it meant *nothing was looked at*.

## The fix, and why this mechanism

**`**/lib` is removed, not negated.** The root `.gitignore` already carries `lib/` (line
53), and oxlint honours `.gitignore` — measured both inside a git checkout and in a
throwaway tree with no `.git` directory at all, where a gitignored `lib/` file was still
skipped. So the pattern bought **nothing** for build output; its only live effect was to
override the two packages' deliberate `!lib/` re-include.

Measured before/after with `oxlint --debug=files .`: 3322 → 3348 files, and the 26 new ones
are exactly the two packages' sources. A gitignored probe file placed in
`packages/web/fetch/lib/` stayed skipped throughout.

Considered and rejected:

- **A negated pattern / allowlist of the two paths.** Works, but leaves a list that has to
  be maintained, and the third package to commit source under `lib/` would be invisible
  until someone remembered to add it.
- **Replacing the glob with the specific generated paths.** 119 entries that drift with
  every new package.

Letting `.gitignore` be the single reader for *"is this build output"* is the shape that
fails safe: committing source under `lib/` **requires** an explicit `!lib/`, and that same
act now also makes the file visible to the linter. No second list, no second truth.

## What the linter found once it could see

**26 files, 10 findings, 3 of them errors — all three fixed here.**

| Rule | Count | Severity | Disposition |
|---|---|---|---|
| `unicorn/prefer-string-starts-ends-with` | 2 | error | fixed |
| unused `eslint-disable` directive | 1 | error | fixed |
| `typescript/no-explicit-any` | 6 | warn | left, see below |
| `eslint/no-unused-vars` | 1 | warn | fixed |

**The two `prefer-string-starts-ends-with`** are in `prebuild-libc.mjs`'s musl soname test.
Rewritten to `startsWith`, and *falsified rather than assumed equivalent*: held against the
original regexes over 19 named sonames plus 200 000 random strings drawn from an alphabet
that includes `\n` (0 mismatches), and `node scripts/audit-runtimes.mjs --check` — which
runs this rule over 53 shared libraries in 44 packages — prints **byte-identical** output
across the change, A/B'd against `git show HEAD:` of the same file. The neighbouring glibc
line keeps its regexes; it has an alternation and a digit class, and the asymmetry is now
the signal.

**The unused `eslint-disable`** is a `// eslint-disable-next-line no-console` in
`runtime-aliases.mjs` naming a rule this repo never enabled — the exact #859/#861 shape
`.oxlintrc.json`'s own comment describes: a directive announcing a review that never
happened. Removed.

**Left: the six `typescript/no-explicit-any`** on `manifest-conformance`'s
`Record<string, any>` manifest types. `no-explicit-any` is `warn` repo-wide (9 such
warnings already exist on `main`), and `unknown` would push a cast into every gate that
reads a `package.json` — a type-surface refactor with its own risk, not part of closing a
visibility hole.

## The guard

`scripts/check-lint-visibility.mjs`, wired into `main.yml`'s `tree-checks` job directly
below the lint step it audits. It is *not* in `audit-runtimes.yml` with the other
repo-scoped gates: that workflow deliberately installs nothing and this needs the pinned
`oxlint`.

It diffs two lists, and **neither is the script's own opinion**:

- `oxlint --debug=files .` — what the whole-tree lint actually visits.
- `oxlint --debug=files --no-ignore <every path from git ls-files>` — the same walker with
  the ignore layers off, so *"is this a file you lint?"* is answered by oxlint rather than
  by a suffix list maintained beside it. Passing git's paths explicitly is also what keeps
  `node_modules` out of a `--no-ignore` walk.

Re-implementing gitignore matching here would build a second matcher that has to agree with
oxlint's about `**/lib` vs `lib/`, about negation, about inheritance — and be confidently
wrong the day it does not. Asking oxlint twice cannot drift from oxlint.

The eight exemptions carry a reason each, and **every one must match at least one blind
file**. That is the unused-disable-directive rule turned on the script's own registry, and
it is the control the set-difference would otherwise lack: if an oracle degraded and the
difference silently went empty, all eight exemptions would go stale and the run goes **red**
rather than green-having-measured-nothing.

Clean tree: `3349 of 3480 lintable tracked file(s) are read by oxlint; the remaining 131 are
declared across 8 exemption(s), each of which still matches.`

## Deliberate-defect results

Four mutations, each run and then reverted:

| Mutation | Exit |
|---|---|
| tracked file committed under a gitignored `lib/` (`git add -f packages/web/fetch/lib/oops.mjs`) | **1** — named the file |
| `**/lib` put back into `.oxlintrc.json` (i.e. this PR reverted) | **1** — named exactly the 26 files |
| a stale `EXEMPT` entry matching nothing | **1** — named the entry |
| run against a directory that is not a git repo | **2** — refuses, rather than passing on an empty list |
| clean tree, all mutations reverted | **0** |

The first mutation also produced a finding worth recording: `oxlint <path>` on a
**`.gitignore`**-blind file *lints it and looks fine*, while `oxlint .` walks past it — the
opposite tell from an `ignorePatterns`-blind file, which says "No files found to lint". Both
mislead a reviewer checking by hand, in opposite directions. The guard's failure message
says so.

## Mandatory checks

Each run from the worktree root, output redirected to a file, exit code read from `$?`
(never through a pipe):

| Check | Exit |
|---|---|
| `npx oxfmt --check .` | 0 |
| `npx oxlint .` | 0 |
| `node scripts/audit-runtimes.mjs --check` | 0 |
| `node scripts/check-adwaita-conformance-drivers.mjs` | 0 |
| `node scripts/check-node-test-registration.mjs` | 0 |
| `node scripts/check-e2e-suite-coverage.mjs` | 0 |
| `node scripts/check-lint-visibility.mjs` (new) | 0 |

Also green: `check-comment-budget`, `check-workflow-inline-scripts`,
`check-agent-context-size`, `check-source-control-bytes`, `check-adr-index`,
`check-doc-revert`. Both touched packages declare `"check": "echo no TypeScript sources to
check"` — there is no TypeScript in either to type-check.

## Known and deliberately not fixed here

`.oxfmtrc.json` carries the **same** `**/lib` line, so the *formatter* is blind to the same
26 sources. Measured with the pattern lifted: 15 of them are unformatted. Closing that
reformats load-bearing infra files and deserves its own diff to read, so it is written down
in the new script's header rather than folded in silently.

`templates/` (14 files) stays ignored and is declared as an exemption with its measurement:
lifting it yields 2 findings, both `gjsify/no-literal-widget-label` on
`templates/gtk-minimal`'s hello-world caption — the same posture `.oxlintrc.json` already
grants `examples/` and `showcases/`. If that changes, it wants the existing override
extended, not a new blind spot.
