### PR TITLE
fix(scripts): a story renders where its registration reaches it

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -503,7 +503,12 @@ jobs:
       # got — so the claim went, and this holds the part that IS true and checkable:
       # the three targets render the same story SET. A story on one target and not the
       # others is the one state where no comparison is possible at all.
-      - name: Check every storybook story exists on all three targets
+      #
+      # It read a FILENAME for its first life, and two of the three targets render what a
+      # hand-written list module imports: deleting one import and one array entry from
+      # browser/stories.ts dropped a story out of the browser storybook and out of the
+      # website embed with this step green. It reads the registration now.
+      - name: Check every storybook story is registered on all three targets
         run: node scripts/check-storybook-story-parity.mjs
 
       # Story-set parity says the same stories EXIST; it cannot say the reader meets
@@ -992,7 +997,12 @@ jobs:
       # got — so the claim went, and this holds the part that IS true and checkable:
       # the three targets render the same story SET. A story on one target and not the
       # others is the one state where no comparison is possible at all.
-      - name: Check every storybook story exists on all three targets
+      #
+      # It read a FILENAME for its first life, and two of the three targets render what a
+      # hand-written list module imports: deleting one import and one array entry from
+      # browser/stories.ts dropped a story out of the browser storybook and out of the
+      # website embed with this step green. It reads the registration now.
+      - name: Check every storybook story is registered on all three targets
         run: node scripts/check-storybook-story-parity.mjs
 
       # Story-set parity says the same stories EXIST; it cannot say the reader meets

--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -44,12 +44,19 @@ export const ADWAITA_NS_STORY_SRC = 'showcases/dom/adwaita-storybook-nativescrip
  * Four checks asked the same question of the same tree and each walked it itself.
  * The copies had not drifted yet, which is exactly the moment to lift one: it is
  * the same argument {@link elementName} above makes one level down.
+ *
+ * THE FILE SET IS NOT THE RENDERED SET. Two of the three targets register through a
+ * hand-written list module, so a file here can render nowhere; `storybookRegistration`
+ * in `storybook-registration.mjs` is the reader that answers that. The set-returning
+ * wrapper this used to carry is gone with the story-parity gate that leaned on it.
  */
 export function storyFilesWith(dir, suffix) {
     /** @type {Map<string, string>} */
     const found = new Map();
     const walk = (current) => {
         for (const entry of readdirSync(current, { withFileTypes: true })) {
+            // A vendored copy under `src/` would put its stories into a required check.
+            if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
             const child = join(current, entry.name);
             if (entry.isDirectory()) walk(child);
             else if (entry.name.endsWith(suffix)) found.set(entry.name.slice(0, -suffix.length), child);
@@ -58,9 +65,6 @@ export function storyFilesWith(dir, suffix) {
     walk(dir);
     return found;
 }
-
-/** {@link storyFilesWith} for a caller that only needs the story SET. */
-export const storyNamesWith = (dir, suffix) => new Set(storyFilesWith(dir, suffix).keys());
 
 // A story's category is the part of its title before the first `/` — the same split
 // StorybookController._groupByCategory makes. EVERY `title:` is read, not the first:

--- a/scripts/check-storybook-story-parity.mjs
+++ b/scripts/check-storybook-story-parity.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Every story exists on ALL THREE storybook targets.
+// Every story is RENDERED by all three storybook targets.
 //
 // THE CLAIM THIS REPLACES
 //
@@ -21,14 +21,32 @@
 // both renderer suites drive their real widgets with), and story-set parity is
 // held here.
 //
+// AND THE CLAIM THIS CHECK ITSELF GOT WRONG
+//
+// It read a FILENAME. `storyNamesWith(SRC, '.web.ts')` said the browser rendered
+// a story because a file with that name sat on disk — while the browser target,
+// like the NativeScript one, renders what a hand-written list module imports and
+// lists. Deleting `import { CarouselWebStories }` and its array entry from
+// `showcases/gtk/adwaita-storybook/src/browser/stories.ts` drops Carousel out of
+// the browser storybook AND out of the website embed that mounts the same list,
+// and this check printed "41 stories, each rendered by all three targets".
+// Measured on `origin/main` at 9d9db9376, exit 0; the NativeScript twin and a
+// `*.story.ts` whose story module lost its `export` keyword did the same.
+//
+// A gate that has never been seen failing has proven nothing, and "rendered by
+// all three targets" is precisely the sentence a FOURTH renderer is meant to earn.
+//
 // WHAT IT CHECKS
 //
-// For each renderer-agnostic `<name>.meta.ts` in the GTK showcase, all three
-// renderings must exist:
+// For each renderer-agnostic `<name>.meta.ts` in the GTK showcase, every target
+// must have a rendering AND reach it:
 //   `<name>.story.ts` (GTK) · `<name>.web.ts` (browser) — both alongside the meta
 //   `<name>.ns.ts` (NativeScript) — in the NativeScript showcase
-// and every rendering must have a meta behind it, so a story cannot be added to
-// one target alone in either direction.
+// where "reach it" is `storybookRegistration`'s two facts — the registry imports
+// the module, and hands it to the controller. Every rendering must have a meta
+// behind it, and every meta must leave through the barrel the NativeScript
+// renderings import it from, so a story cannot be added to one target alone in
+// either direction.
 //
 // Plain Node over the repo's own files — no install, no build — so it runs in
 // `audit-runtimes.yml` next to the other repo-scoped guards.
@@ -38,44 +56,128 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { ADWAITA_NS_STORY_SRC, ADWAITA_STORY_SRC, adwaitaStoryMetas, storyNamesWith } from './adwaita-elements.mjs';
+import { ADWAITA_NS_STORY_SRC, ADWAITA_STORY_SRC, adwaitaStoryMetas } from './adwaita-elements.mjs';
+import { META_BARREL, metaBarrelExports, showPath, storybookRegistration } from './storybook-registration.mjs';
 
 const args = process.argv.slice(2);
 const rootFlag = args.indexOf('--root');
 const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : args[rootFlag + 1];
 
-/** The GTK showcase owns the metas and both the GTK and browser renderings. */
-const GTK_SRC = join(ROOT, ADWAITA_STORY_SRC);
-/** The NativeScript showcase imports those metas and adds its own rendering. */
-const NS_SRC = join(ROOT, ADWAITA_NS_STORY_SRC);
+/**
+ * `<story>@<target id>` a target deliberately does not render, and why.
+ *
+ * Empty, and the bar for adding to it is high: the three targets exist to be
+ * compared, so an entry here is a story the reference storybook shows and one
+ * renderer answers for in prose instead. The reason names the file a reader opens
+ * to see what that renderer does instead — "would be work" is not one, and a widget
+ * only one renderer ships has no meta and never reaches this check at all (that is
+ * `check-storybook-widget-coverage.mjs`'s `ONE_RENDERER_ONLY`).
+ */
+const NOT_ON_THIS_TARGET = {};
+
+/** A floor on length, not on meaning — the same one the widget ledger uses. */
+const MIN_REASON = 40;
 
 /** @type {Map<string, {path: string, file: string, titles: string[], source: string}>} */
 let metaFiles;
+/** @type {Map<string, {label: string, files: Map<string, string>, reachable: Set<string>, live: Set<string>, dangling: string[]}>} */
+let registration;
+/** @type {Set<string>} */
+let barrel;
 try {
     metaFiles = adwaitaStoryMetas(ROOT);
+    registration = storybookRegistration(ROOT);
+    barrel = metaBarrelExports(ROOT);
 } catch (error) {
-    // The reader throws on a vacuous scan by design; catch to keep this script's prefix.
+    // The readers throw on a vacuous scan and on a registry they cannot parse, by
+    // design: reporting every story as unregistered would present the reader's own
+    // limit as the tree's defect. Catch to keep this script's prefix.
     console.error(`check-storybook-story-parity: ${error.message}`);
     process.exit(1);
 }
 
 const metas = new Set(metaFiles.keys());
-const targets = [
-    { label: 'GTK (*.story.ts)', names: storyNamesWith(GTK_SRC, '.story.ts') },
-    { label: 'browser (*.web.ts)', names: storyNamesWith(GTK_SRC, '.web.ts') },
-    { label: 'NativeScript (*.ns.ts)', names: storyNamesWith(NS_SRC, '.ns.ts') },
-];
-
 const failures = [];
-for (const target of targets) {
-    const missing = [...metas].filter((name) => !target.names.has(name)).sort();
-    const orphaned = [...target.names].filter((name) => !metas.has(name)).sort();
+/** Every `<story>@<target>` key the walk below reached, so a ledger entry can be held to one. */
+const visited = new Set();
 
-    if (missing.length > 0) {
-        failures.push(`${target.label}: no rendering for ${missing.join(', ')} — the other targets have one.`);
+for (const [id, target] of registration) {
+    const registry = target.registry === null ? '`gjsify storybook` (the *.story.ts glob)' : target.registry;
+
+    for (const name of [...metas].sort()) {
+        const key = `${name}@${id}`;
+        visited.add(key);
+        const ledgered = key in NOT_ON_THIS_TARGET;
+        const file = target.files.get(name);
+
+        if (file === undefined) {
+            if (ledgered) continue;
+            failures.push(`${target.label}: no rendering for ${name} — the other targets have one.`);
+            continue;
+        }
+        if (ledgered) {
+            failures.push(
+                `${key}: ledgered as deliberately not rendered here, and ${showPath(ROOT, file)} exists — ` +
+                    'drop the stale entry, or delete the rendering it says nothing renders.',
+            );
+            continue;
+        }
+        if (!target.reachable.has(name)) {
+            failures.push(
+                `${target.label}: ${showPath(ROOT, file)} exists and ${registry} never imports it, so this\n` +
+                    `    target renders ${name} nowhere. The file on disk is what this check used to read.`,
+            );
+            continue;
+        }
+        if (!target.live.has(name)) {
+            failures.push(
+                target.registry === null
+                    ? `${target.label}: ${showPath(ROOT, file)} is picked up by the glob and exports no story\n` +
+                          '    module, so `collectStoryModules` finds nothing in it. Export the `{ stories: [ … ] }`.'
+                    : `${target.label}: ${target.registry} imports ${name} and leaves it out of its \`stories\`\n` +
+                          '    array, so the module is bundled and the controller is never handed it.',
+            );
+        }
     }
-    if (orphaned.length > 0) {
-        failures.push(`${target.label}: ${orphaned.join(', ')} has no *.meta.ts, so no other target can render it.`);
+
+    for (const name of [...target.files.keys()].sort()) {
+        if (metas.has(name)) continue;
+        failures.push(`${target.label}: ${name} has no *.meta.ts, so no other target can render it.`);
+    }
+    // Only where the missing rendering has no meta to be reported against: a story with a
+    // meta already gets its "no rendering for X" line above, and one fix reading as two
+    // findings sends the author looking for a second defect.
+    for (const { name, specifier } of target.dangling) {
+        if (metas.has(name)) continue;
+        failures.push(`${target.label}: ${registry} imports ${specifier}, and there is no such rendering.`);
+    }
+}
+
+// The NativeScript renderings reach their meta only through this barrel: they import
+// `@gjsify/example-gtk-adwaita-storybook/metas` rather than across the package boundary.
+for (const name of [...metas].sort()) {
+    if (barrel.has(name)) continue;
+    failures.push(
+        `${META_BARREL}: ${metaFiles.get(name).file} is not re-exported, and that barrel is the only path\n` +
+            '    a NativeScript rendering has to its meta.',
+    );
+}
+for (const name of [...barrel].sort()) {
+    if (metas.has(name)) continue;
+    failures.push(`${META_BARREL}: re-exports ${name}.meta.js, which is not a *.meta.ts in ${ADWAITA_STORY_SRC}.`);
+}
+
+// Against the keys the walk REACHED, the way check-storybook-control-parity holds its
+// own ledger: an entry naming a deleted story or a misspelled target id reads as a
+// considered decision while covering nothing.
+for (const [key, reason] of Object.entries(NOT_ON_THIS_TARGET)) {
+    if (!visited.has(key)) {
+        failures.push(
+            `${key}: ledgered here, and no story of that name reaches that target — check the story name\n` +
+                `    and the target id against ${[...registration.keys()].join(', ')}.`,
+        );
+    } else if (reason.trim().length < MIN_REASON) {
+        failures.push(`${key}: ledgered with no real reason — name the file that shows what this target does instead.`);
     }
 }
 
@@ -85,10 +187,19 @@ if (failures.length > 0) {
     console.error(
         `\nThe three targets exist to be compared. A story on one of them and not the others is the one\n` +
             `state where no comparison is possible — which is exactly what the unimplemented screenshot\n` +
-            `harness was claimed to catch (#1052).\n` +
+            `harness was claimed to catch (#1052). A story whose FILE is there and whose registration is\n` +
+            `not is the same state, and it is the one this check spent its first life calling parity.\n` +
             `  metas: ${ADWAITA_STORY_SRC}    NativeScript: ${ADWAITA_NS_STORY_SRC}`,
     );
     process.exit(1);
 }
 
-console.log(`check-storybook-story-parity: ${metas.size} stories, each rendered by all three targets.`);
+const ledgered = Object.keys(NOT_ON_THIS_TARGET).length;
+// Per target and not a single total, because the totals are what a ledger entry makes
+// differ — and a summary that reads "all three" over a set one of them does not render
+// is the sentence this check was rewritten for.
+const where = [...registration.values()].map((target) => `${target.label} ${target.live.size}`).join(', ');
+console.log(
+    `check-storybook-story-parity: ${metas.size} stories, each reached by the registration of its ` +
+        `targets — ${where}${ledgered > 0 ? `; ${ledgered} ledgered as deliberately not rendered` : ''}.`,
+);

--- a/scripts/storybook-registration.mjs
+++ b/scripts/storybook-registration.mjs
@@ -1,0 +1,347 @@
+// What each storybook target actually renders, read from the code that registers it.
+//
+// THE INCIDENT
+//
+// `check-storybook-story-parity.mjs` held three targets to the same story set off a
+// FILENAME on disk — a set-of-basenames reader that is gone with it. A file is not a
+// story that renders. Two of the three targets register through a hand-written list
+// module, and the gate read neither:
+//
+//   deleting `import { CarouselWebStories }` and its array entry from
+//   `showcases/gtk/adwaita-storybook/src/browser/stories.ts` removes Carousel from
+//   the browser storybook AND from the website embed that mounts the same list,
+//   and the gate printed "41 stories, each rendered by all three targets".
+//
+// Measured against `origin/main` at 9d9db9376, together with the NativeScript twin
+// and a `*.story.ts` whose story module lost its `export` keyword: three targets,
+// three ways to stop rendering a story, exit 0 for all three.
+//
+// So this module is the ONE reader of the registration, the way
+// `adwaita-elements.mjs` is the one reader of the element set — same argument, one
+// domain over: a cheap local derivation beside a real one is how the weak answer
+// ends up being the one that passes. It reports TWO facts per target and the
+// caller says which it means, following `suite-registration.mjs` (#1367):
+//
+//   `reachable` — the target's registry IMPORTS the rendering module.
+//   `live`      — the registry also HANDS it to the controller: the binding is in
+//                 the exported `stories` array, or (GTK) the module exports a value
+//                 `collectStoryModules` will recognise as a story module.
+//
+// A registry this cannot parse THROWS. Reporting every story of that target as
+// unregistered would present the reader's own limit as the tree's defect, and that
+// is the expensive direction to be wrong in.
+//
+// A FOURTH TARGET is one entry in {@link STORYBOOK_TARGETS}: a suffix, a source
+// root and either a list module or the glob.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+
+import { toPosixPath } from '../packages/infra/manifest-conformance/lib/index.mjs';
+import { ADWAITA_NS_STORY_SRC, ADWAITA_STORY_SRC, storyFilesWith, stripComments } from './adwaita-elements.mjs';
+
+/** The showcase whose `gjsify.storybook.stories` decides what the GTK glob scans. */
+const GTK_SHOWCASE = 'showcases/gtk/adwaita-storybook';
+
+/**
+ * Every storybook target, with the code that decides which stories it renders.
+ *
+ * `registry: null` is the glob: `gjsify storybook` walks `gjsify.storybook.stories`
+ * for `*.story.{ts,js,mts,mjs}` and generates an entry that imports each one as a
+ * namespace, so for GTK the filename IS the import — but only what the module
+ * EXPORTS reaches `collectStoryModules`, which is the second fact below.
+ */
+export const STORYBOOK_TARGETS = [
+    { id: 'gtk', label: 'GTK (*.story.ts)', suffix: '.story.ts', src: ADWAITA_STORY_SRC, registry: null },
+    {
+        id: 'browser',
+        label: 'browser (*.web.ts)',
+        suffix: '.web.ts',
+        src: ADWAITA_STORY_SRC,
+        registry: `${GTK_SHOWCASE}/src/browser/stories.ts`,
+    },
+    {
+        id: 'nativescript',
+        label: 'NativeScript (*.ns.ts)',
+        suffix: '.ns.ts',
+        src: ADWAITA_NS_STORY_SRC,
+        registry: 'showcases/dom/adwaita-storybook-nativescript/src/stories.ts',
+    },
+];
+
+/** The barrel every renderer-agnostic meta must leave through — see {@link metaBarrelExports}. */
+export const META_BARREL = `${GTK_SHOWCASE}/src/metas.ts`;
+
+// `gjsify storybook` (packages/infra/cli/src/commands/storybook.ts) skips `node_modules`
+// and dot-names and matches these four extensions. Repeated here rather than
+// approximated, because a target's file set and the CLI's have to be the same set.
+const STORY_FILE = /\.story\.(ts|js|mts|mjs)$/;
+
+/** Every `import` statement, so a form the binding reader below cannot see can be counted. */
+const IMPORT_STATEMENT = /(?:^|[\n;])\s*import\b/g;
+
+/** `import './styles.css'` — it provably binds nothing, so it is read and contributes nothing. */
+const SIDE_EFFECT_IMPORT = /(?:^|[\n;])\s*import\s*['"][^'"]+['"]/g;
+
+/** `import { A, B } from './x/y.web.js'` — the named bindings and the specifier. */
+const NAMED_IMPORT = /(?:^|[\n;])\s*import\s+\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g;
+
+/** A statement TypeScript erases whole; it registers nothing and is not counted as an import. */
+const TYPE_IMPORT = /(?:^|[\n;])\s*import\s+type\b/g;
+
+/** `export const stories: WebStoryModule[] = [` — the list the controller is handed. */
+const STORY_LIST = /export\s+const\s+stories\s*(?::[^=]*)?=\s*\[/;
+
+/**
+ * `export const XStories: StoryModule = { stories: [ … ] }` — what `collectStoryModules`
+ * finds when it walks a namespace for values shaped like a story module (`isStoryModule`:
+ * an object with a `stories` array).
+ *
+ * Deliberately narrow. An export shape this cannot read is reported as NOT live, which
+ * fails the gate; the opposite default would pass a `*.story.ts` that registers nothing.
+ * Every GTK rendering in the tree is written this way.
+ */
+const STORY_MODULE_EXPORT = /export\s+const\s+[A-Za-z0-9_$]+\s*(?::[^=]*)?=\s*\{[^{}]*\bstories\s*:\s*\[/;
+
+/** `export * from './rows/action-row.meta.js'` — the barrel's one form. */
+const BARREL_EXPORT = /export\s+\*\s+from\s*['"]([^'"]+)['"]/g;
+
+/** Every re-export, so a form {@link BARREL_EXPORT} cannot see is counted rather than missed. */
+const BARREL_STATEMENT = /(?:^|[\n;])\s*export\b/g;
+
+/** `./view-switching/carousel.web.js` → `carousel`, the name metas and ledgers share. */
+function storyNameOf(specifier, suffix) {
+    const emitted = `${suffix.slice(0, -'ts'.length)}js`;
+    const file = basename(specifier);
+    return file.endsWith(emitted) ? file.slice(0, -emitted.length) : null;
+}
+
+/** A TS source importing its emitted `.js` sibling; the file on disk is `.ts`. */
+const onDisk = (from, specifier) => resolve(from, '..', specifier.replace(/\.js$/, '.ts'));
+
+/**
+ * {@link STORY_FILE} under `dir` — `name` → absolute path.
+ *
+ * Its own walk rather than {@link storyFilesWith}, because the GTK target's file set has
+ * to be the set the CLI imports and the CLI matches four extensions, not one suffix. A
+ * `carousel.story.mts` would be in the storybook and outside a `.story.ts` scan.
+ */
+function globStoryFiles(dir) {
+    /** @type {Map<string, string>} */
+    const found = new Map();
+    const walk = (current) => {
+        for (const entry of readdirSync(current, { withFileTypes: true })) {
+            if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+            const path = join(current, entry.name);
+            if (entry.isDirectory()) walk(path);
+            else if (STORY_FILE.test(entry.name)) found.set(entry.name.replace(STORY_FILE, ''), path);
+        }
+    };
+    if (existsSync(dir)) walk(dir);
+    return found;
+}
+
+/** The directory `gjsify storybook` scans, as the showcase's own package.json declares it. */
+function globRoot(root) {
+    const manifest = join(root, GTK_SHOWCASE, 'package.json');
+    let declared;
+    try {
+        declared = JSON.parse(readFileSync(manifest, 'utf8')).gjsify?.storybook?.stories ?? 'src';
+    } catch (error) {
+        throw new Error(
+            `${GTK_SHOWCASE}/package.json is unreadable (${error.message}), and it declares which ` +
+                'directory `gjsify storybook` scans. Without it nothing here knows what the GTK target renders.',
+        );
+    }
+    const dir = join(root, GTK_SHOWCASE, declared);
+    if (resolve(dir) !== resolve(join(root, ADWAITA_STORY_SRC))) {
+        throw new Error(
+            `${GTK_SHOWCASE}/package.json scans \`${declared}\`, which is not ${ADWAITA_STORY_SRC} — where ` +
+                'the metas are read from. The two have to be the same tree, or every GTK rendering reports ' +
+                'as missing against metas nothing renders.',
+        );
+    }
+    return dir;
+}
+
+/**
+ * The GTK arm: the glob imports every file, so `reachable` is the file set, and `live`
+ * is the subset whose story module LEAVES the module.
+ */
+function globRegistration(files) {
+    const live = new Set();
+    for (const [name, path] of files) {
+        if (STORY_MODULE_EXPORT.test(stripComments(readFileSync(path, 'utf8')))) live.add(name);
+    }
+    return { reachable: new Set(files.keys()), live, dangling: [] };
+}
+
+/**
+ * A hand-written list module: `reachable` is what it imports, `live` what it puts in
+ * the exported `stories` array.
+ *
+ * THROWS on a registry it cannot parse — a missing file, an import form it cannot read,
+ * no `stories` array, an empty one, or an array entry bound to no import. Each of those
+ * would otherwise report every story of the target as unregistered, which points the
+ * reader at every sound file in the tree instead of at the one that moved.
+ *
+ * `dangling` is an import whose rendering is not on disk. It is DATA rather than a throw
+ * because the missing file is a parity finding the caller already has a line for — the
+ * caller decides which of the two to say.
+ */
+function listRegistration(root, target, files) {
+    const path = join(root, target.registry);
+    let source;
+    try {
+        source = stripComments(readFileSync(path, 'utf8'));
+    } catch (error) {
+        throw new Error(
+            `${target.registry} is the ${target.label} story registry and could not be read (${error.message}). ` +
+                'Nothing else says which stories that target renders.',
+        );
+    }
+
+    /** binding identifier → story name, for the imports that resolve to a rendering. */
+    const bindings = new Map();
+    const dangling = [];
+    const reachable = new Set();
+    let parsed = 0;
+    for (const [, clause, specifier] of source.matchAll(NAMED_IMPORT)) {
+        parsed += 1;
+        const name = storyNameOf(specifier, target.suffix);
+        if (name === null) continue; // a type-only or helper import; it registers no story.
+        const identifiers = clause
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter((entry) => entry !== '' && !entry.startsWith('type '));
+        // Bound BEFORE the file check, so an import pointing at a deleted rendering leaves
+        // the array entry resolvable. Dropping the binding here would raise the
+        // no-such-binding throw below over what is really one missing file.
+        for (const identifier of identifiers) bindings.set(identifier, name);
+        if (files.get(name) !== onDisk(path, specifier)) {
+            dangling.push({ name, specifier });
+            continue;
+        }
+        if (identifiers.length > 0) reachable.add(name);
+    }
+
+    const statements =
+        (source.match(IMPORT_STATEMENT) ?? []).length -
+        (source.match(TYPE_IMPORT) ?? []).length -
+        (source.match(SIDE_EFFECT_IMPORT) ?? []).length;
+    if (parsed < statements) {
+        throw new Error(
+            `${target.registry} has ${statements - parsed} import statement(s) this reader cannot parse. ` +
+                'Every story it registers through one of them would report as unregistered, so the limit ' +
+                'is reported here rather than as a finding against each file that is fine.',
+        );
+    }
+
+    const opens = STORY_LIST.exec(source);
+    if (opens === null) {
+        throw new Error(
+            `${target.registry} exports no \`stories\` array this reader can find. That array is what the ` +
+                `${target.label} controller is handed; without reading it nothing here knows what renders.`,
+        );
+    }
+    const close = source.indexOf(']', opens.index + opens[0].length);
+    if (close === -1) {
+        throw new Error(`${target.registry}: the \`stories\` array is never closed — this reader cannot end it.`);
+    }
+    const listed = [...source.slice(opens.index + opens[0].length, close).matchAll(/[A-Za-z_$][A-Za-z0-9_$]*/g)].map(
+        ([identifier]) => identifier,
+    );
+    if (listed.length === 0) {
+        throw new Error(
+            `${target.registry}: the \`stories\` array is empty. An empty registry makes every story of ` +
+                'this target report as unregistered at once, which is a broken read, not one finding per story.',
+        );
+    }
+
+    const live = new Set();
+    for (const identifier of listed) {
+        const name = bindings.get(identifier);
+        if (name === undefined) {
+            throw new Error(
+                `${target.registry} lists \`${identifier}\` in its \`stories\` array, and imports no such ` +
+                    'binding from a rendering file. Either the import was removed and the entry left behind, ' +
+                    'or this reader misread the import — either way the array no longer says what renders.',
+            );
+        }
+        live.add(name);
+    }
+    return { reachable, live, dangling };
+}
+
+/**
+ * Every target with its renderings and the two registration facts about each.
+ *
+ * @param {string} root repository root
+ * @returns {Map<string, {label: string, suffix: string, src: string, registry: string|null,
+ *                        files: Map<string, string>, reachable: Set<string>, live: Set<string>,
+ *                        dangling: Array<{name: string, specifier: string}>}>} keyed by target id
+ */
+export function storybookRegistration(root) {
+    const registration = new Map();
+    for (const target of STORYBOOK_TARGETS) {
+        const files =
+            target.registry === null
+                ? globStoryFiles(globRoot(root))
+                : storyFilesWith(join(root, target.src), target.suffix);
+        if (files.size === 0) {
+            throw new Error(
+                `no ${target.suffix} file under ${target.src}. Either the showcase moved or the naming ` +
+                    'convention changed — a scan that finds nothing passes vacuously, so this is a ' +
+                    'failure, not a pass.',
+            );
+        }
+        const read = target.registry === null ? globRegistration(files) : listRegistration(root, target, files);
+        registration.set(target.id, { ...target, files, ...read });
+    }
+    return registration;
+}
+
+/**
+ * The story names {@link META_BARREL} re-exports — the only path a NativeScript rendering
+ * has to its meta, since it imports `@gjsify/example-gtk-adwaita-storybook/metas` rather
+ * than reaching across packages into the file.
+ *
+ * A meta missing here breaks the build rather than shipping a hole, but nothing in
+ * `audit-runtimes.yml` builds that showcase, so the first reader to find out is a person.
+ *
+ * @param {string} root repository root
+ * @returns {Set<string>} bare story names
+ */
+export function metaBarrelExports(root) {
+    const path = join(root, META_BARREL);
+    let source;
+    try {
+        source = stripComments(readFileSync(path, 'utf8'));
+    } catch (error) {
+        throw new Error(`${META_BARREL} could not be read (${error.message}) — it is what carries the metas out.`);
+    }
+    const names = new Set();
+    let parsed = 0;
+    for (const [, specifier] of source.matchAll(BARREL_EXPORT)) {
+        parsed += 1;
+        const file = basename(specifier);
+        if (file.endsWith('.meta.js')) names.add(file.slice(0, -'.meta.js'.length));
+    }
+    const statements = (source.match(BARREL_STATEMENT) ?? []).length;
+    if (parsed < statements) {
+        throw new Error(
+            `${META_BARREL} has ${statements - parsed} export statement(s) this reader cannot parse, so the ` +
+                'metas they carry would report as unexported. Fix the reader rather than the barrel.',
+        );
+    }
+    if (names.size === 0) {
+        throw new Error(
+            `${META_BARREL} re-exports no *.meta.js. An empty barrel reports every meta as unreachable from ` +
+                'NativeScript at once, which is a broken read, not a tree-wide defect.',
+        );
+    }
+    return names;
+}
+
+/** Repo-relative, for a message a reader can open. */
+export const showPath = (root, path) => toPosixPath(relative(root, path));

--- a/showcases/dom/adwaita-storybook-nativescript/README.md
+++ b/showcases/dom/adwaita-storybook-nativescript/README.md
@@ -2,7 +2,7 @@
 
 The full **Adwaita storybook** as a real **NativeScript-Android** app — the same component browser as the native **GTK** (`@gjsify/storybook`) and **browser** (`@gjsify/adwaita-storybook`) targets, rendered with **real native** `@gjsify/adwaita-nativescript` widgets (NOT a webview) via `@gjsify/storybook-nativescript`.
 
-All three targets share the renderer-agnostic `*.meta.ts` metadata: this app imports it from the GTK showcase's `@gjsify/example-gtk-adwaita-storybook/metas` barrel, so every story exposes identical controls on every target. What holds that together is machine-checked: `scripts/check-storybook-story-parity.mjs` fails the build when a story exists on one target and not the others. There is **no screenshot-comparison harness** (#1052) — behaviour parity is held by the `@gjsify/adwaita-core/conformance` vectors both renderer suites drive their real widgets with.
+All three targets share the renderer-agnostic `*.meta.ts` metadata: this app imports it from the GTK showcase's `@gjsify/example-gtk-adwaita-storybook/metas` barrel, so every story exposes identical controls on every target. What holds that together is machine-checked: `scripts/check-storybook-story-parity.mjs` fails the build when a story exists on one target and not the others, and when a target has the rendering and never registers it — `src/stories.ts` here, `src/browser/stories.ts` in the GTK showcase, and the `./metas` barrel this app imports from. There is **no screenshot-comparison harness** (#1052) — behaviour parity is held by the `@gjsify/adwaita-core/conformance` vectors both renderer suites drive their real widgets with.
 
 Part of the [gjsify](https://github.com/gjsify/gjsify) project — Node.js and Web APIs for GJS (GNOME JavaScript).
 
@@ -39,7 +39,7 @@ npm run run:android        # or: npm run debug:android  (serves the V8 CDP inspe
 - Native Adwaita widgets on NativeScript (`@gjsify/adwaita-nativescript`), styled with the Adwaita CSS theme + Adwaita Sans, with no webview anywhere
 - The narrow-width shell: a collapsed `AdwNavigationSplitView` (story list ↔ detail + back button), matching the GTK `NavigationSplitView` at phone width
 - The storybook control plane over a third transport — `installStorybookDevtools` exposes `ListStories` / `OpenStory` / `SetStoryArg` plus `DumpTree` / `Screenshot` to an MCP agent over the V8 CDP inspector, the same surface the GTK target serves over DBus
-- Story-set parity between the GTK, browser and Android renderings, enforced by `scripts/check-storybook-story-parity.mjs` (no screenshot comparison — see #1052)
+- Story-set parity between the GTK, browser and Android renderings — the rendering AND its registration — enforced by `scripts/check-storybook-story-parity.mjs` (no screenshot comparison — see #1052)
 
 ## MCP / devtools
 

--- a/showcases/gtk/adwaita-storybook/README.md
+++ b/showcases/gtk/adwaita-storybook/README.md
@@ -31,7 +31,8 @@ this package's `./metas` barrel and the shared logic lives in
 [`@gjsify/storybook-core`](../../../packages/framework/storybook-core), so each renderer is a
 thin adapter. That the sets really stay identical is machine-checked —
 `scripts/check-storybook-story-parity.mjs` fails when a story is missing a rendering on any
-target. There is no screenshot-comparison harness (#1052); behaviour parity across renderers is
+target, or when a target's registration does not reach the rendering it has: the browser list
+in `src/browser/stories.ts` and the NativeScript one decide what renders, not the filename. There is no screenshot-comparison harness (#1052); behaviour parity across renderers is
 held by the `@gjsify/adwaita-core/conformance` vectors.
 
 ## Prerequisites


### PR DESCRIPTION
Follow-up on the class #1367 named: a gate whose conclusion is stronger than what it reads.

## The hole, measured

`check-storybook-story-parity.mjs` decided "rendered by all three targets" from a FILENAME — `storyNamesWith(SRC, '.web.ts')` and its two siblings. A file on disk is not a story that renders. Only ONE of the three targets registers by filename:

| target | how it registers | read by the old gate |
|---|---|---|
| GTK `*.story.ts` | `gjsify storybook` globs the dir named in `gjsify.storybook.stories`, imports each file as a namespace, and `collectStoryModules` keeps the exported values with a `stories` array | filename only — never the export |
| browser `*.web.ts` | `showcases/gtk/adwaita-storybook/src/browser/stories.ts`, a hand-written import list + `export const stories: WebStoryModule[]` that both `main.ts` and the website's `embed.ts` mount | not at all |
| NativeScript `*.ns.ts` | `showcases/dom/adwaita-storybook-nativescript/src/stories.ts`, same shape, mounted by `app/storybook-page.ts` | not at all |

A fourth list nothing read: `src/metas.ts`. Every `*.ns.ts` imports its meta from `@gjsify/example-gtk-adwaita-storybook/metas`, so that barrel is the only path a NativeScript rendering has to the metadata all three share.

Measured against `origin/main` at `9d9db9376`, each mutation reverted after measuring:

| deliberate defect | story-parity | control-parity | category-order | widget-coverage | website-gallery |
|---|---|---|---|---|---|
| `CarouselWebStories` import + array entry deleted from `browser/stories.ts`, file kept | **0** | 0 | 0 | 0 | 0 |
| `SpinnerNsStories` deleted from the NativeScript list, file kept | **0** | — | — | — | — |
| `spinner.story.ts` story module loses its `export` keyword | **0** | — | — | — | — |
| a whole `probe-parity` quadruple whose four files exist and which nothing registers | **0**, "42 stories, each rendered by all three targets" | — | — | 0 | 0 |

Row 1 is not hypothetical damage: the browser list is what `embed.ts` mounts, so the story leaves the storybook AND the website embed, and five gates stay green over the sentence "41 stories, each rendered by all three targets" about 40.

## The fix

`scripts/storybook-registration.mjs` is one reader for what a storybook target reaches, in the shape `suite-registration.mjs` uses for test suites. Two facts per target, and each caller says which it means:

- **`reachable`** — the target's registry IMPORTS the rendering module. For a list module that is a named import resolving to a rendering on disk; for GTK it is the glob, whose file set is read with the CLI's own rule (four extensions, `node_modules` and dot-names skipped) rather than an approximation of it.
- **`live`** — the registry also HANDS it to the controller: the binding is in the exported `stories` array, or — GTK — the module exports a value `collectStoryModules` will recognise as a story module.

A separate module rather than an arm of `adwaita-elements.mjs`, because that file is the reader of what the two *renderers* ship and this is the reader of what the *targets* register; and because a fourth renderer is one entry in `STORYBOOK_TARGETS` — a suffix, a source root, and either a list module or the glob.

**A registry it cannot parse THROWS**, with one message. Reporting all 41 stories of that target as unregistered would present the reader's own limit as the tree's defect, which is the expensive direction to be wrong in. Five separate ways in: the module is unreadable, an import form the binding reader cannot see, no `stories` array, an empty one, an array entry bound to no import. A bare side-effect import (`import './x.css'`) provably binds nothing and is read, so it is not one of them.

`storyNamesWith` is deleted. Its only caller was this gate, and a filename reader left in reach is the derivation the next gate takes; `storyFilesWith` stays for `check-storybook-control-parity.mjs`, which wants the file because it reads the file's content, with the distinction spelled out on it. It also skips `node_modules` now — a vendored copy under `src/` would have put its stories into a required check.

`NOT_ON_THIS_TARGET` is the escape hatch, empty, held the way `check-storybook-control-parity.mjs` holds `CANNOT_HONOUR`: an entry naming a story that IS rendered fails, an entry naming nothing fails, and an entry under the 40-character reason floor fails.

## Falsification

Twelve deliberate defects, each reverted after measuring. `before` is the gate as `main` ships it, on the same mutated tree.

| deliberate defect | before | after |
|---|---|---|
| unmodified tree | 0 | **0** |
| browser: import + array entry removed, file stays | 0 | **1** |
| NativeScript: import + array entry removed, file stays | 0 | **1** |
| browser: imported, array entry dropped only | 0 | **1** |
| GTK: the story module loses its `export` | 0 | **1** |
| a meta dropped from the `./metas` barrel, file stays | 0 | **1** |
| a story quadruple registered nowhere | 0 | **1** |
| browser: the `stories` array renamed | 0 | **1** (one line, not 41) |
| browser: the registry module deleted | 0 | **1** (one line) |
| browser: array entry whose import was removed | 0 | **1** (one line) |
| browser: an import form the reader cannot parse | 0 | **1** (one line) |
| the GTK glob root moved in `package.json` | 0 | **1** (one line) |
| a bare side-effect import in the registry — must stay green | 0 | **0** |

Four more against the ledger, which `main` has no equivalent of: an entry naming a rendered story → 1; an entry with a misspelled target id → 1; an entry with a 5-character reason over a real gap → 1; a real gap with a real reason → **0**, and the summary line says `browser 40 … 1 ledgered` rather than claiming all three.

Two adjacent shapes, checked for double-reporting because one fix reading as two findings sends the author looking for a second defect: a rendering deleted with its import left behind reports **one** line ("no rendering for carousel"), and an import of a rendering that never existed reports **one** line naming the specifier.

## Tree sweep

Nothing to repair. 41 metas, 41 renderings per target, 41 registered per target, 41 barrel exports — the tree was consistent by discipline, which is exactly the state in which a gate's weakness is invisible. Nothing needed a ledger entry, so `NOT_ON_THIS_TARGET` ships empty like `CANNOT_HONOUR` next door.

The CI step name and both showcase READMEs said "exists on all three targets" / "fails when a story is missing a rendering" — true, and the weaker half of what is held now. Corrected in the second commit.

## A fourth renderer, and the two sibling gates

Not changed here, and worth deciding with the measurement rather than under time pressure:

- **`check-storybook-control-parity.mjs`** carries its own `TARGETS` array of the same three targets, so a fourth renderer is two arrays to edit and the one you forget covers less silently. It should take `STORYBOOK_TARGETS` from the shared reader. Its ledger key is already `<meta>.<control>@<label>`, so no schema change; what it needs is a widget reader for the new renderer, alongside `adwaitaWebElements` (keyed on `customElements.define`) and `adwaitaNativeScriptWidgets` (keyed on `adw-<name>.ts` exporting `Adw<Widget>`) — a third convention, and the `void`-read arm is inert without it, exactly as it is for GTK today. Its filename read is sound on its own terms: it asks what a file's code does, so the file is the right input.
- **`check-storybook-widget-coverage.mjs`** scopes itself to `[...web].filter((name) => ns.has(name))` — an INTERSECTION of two — and `OTHER_RENDERER`/`SIDE_LABEL`/`ONE_RENDERER_ONLY.only` are binary: "the other renderer" stops being a function the moment there are three. Its own header says the both-renderers scope is deliberate because demanding a story from a single-renderer widget "would demand a port, and that is a product decision this check has no business making". The consistent extension is therefore not to widen the intersection but to make the asymmetry ledger carry a SET (`only: ['web']` → the renderers that ship it), keeping the scope at "every renderer that ships it" and leaving the port decision where it is. Widening the intersection to all four instead would quietly demand a full React Native port of 43 widgets before the gate goes green again.

## Checks

`npx oxfmt --check .` 0 · `npx oxlint scripts` 0 · `check-storybook-story-parity` 0 · `check-storybook-control-parity` 0 · `check-storybook-category-order` 0 · `check-storybook-widget-coverage` 0 · `audit-runtimes --check` 0 · `check-node-test-registration` 0 · `check-adwaita-conformance-drivers` 0 · `check-website-adwaita-gallery` 0 · `check-generated-website-data` 0.

No TypeScript changed, so there is no package to type-check and no suite whose input moved; `npx tsc` is not this repo's spelling anyway (no root `tsconfig.json`). `check-comment-budget --check` is red on `main` too (report-only, over in `packages/infra/cli`, `packages/infra`, `packages/node-gi`); `scripts` stays under its ceiling, 0.571 → 0.572 against 0.592.
