### PR TITLE
fix(oxfmt): let the formatter see lib/ sources

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -32,7 +32,19 @@
         "**/*.gql",
         "**/node_modules",
         "**/dist",
-        "**/lib",
+        // NO `**/lib` here, deliberately, and for the same reason it is gone from
+        // `.oxlintrc.json`. `lib/` is this repo's build-output directory in 119
+        // packages and the root `.gitignore` already says so (`lib/`, line 53) —
+        // oxfmt honours .gitignore, MEASURED both inside a git checkout and in a
+        // tree with no `.git` at all, so the pattern bought nothing for build
+        // output. What it did buy was a blind spot: it OVERRODE the deliberate
+        // `!lib/` re-include in `@gjsify/manifest-conformance` and
+        // `@gjsify/resolve-npm`, whose `lib/` is hand-written committed ESM. 15 of
+        // those 26 tracked sources were unformatted while `oxfmt --check .` stayed
+        // green, because it never opened them. Letting .gitignore be the single
+        // reader for "is this build output" also makes the next such package right
+        // by default: committing source under `lib/` requires an explicit `!lib/`,
+        // and that same act now makes the file visible to the formatter.
         "**/build",
         "**/build-dir",
         "**/builddir",
@@ -51,6 +63,24 @@
         "**/test.node.mjs",
         "**/*.gresource",
         "**/*.compiled",
-        "**/*.metainfo.xml"
+        "**/*.metainfo.xml",
+        // The two things under a committed `lib/` that are OUTPUT, named one by one
+        // now that the blanket glob is gone.
+        //
+        // 108 verbatim copies of upstream TypeScript's default-library
+        // declarations, refreshed from `node_modules/typescript/lib` by this
+        // package's own `build-bundle.mjs` and re-included in `.gitignore` so a
+        // consumer without `typescript` resolves them. All 108 are unformatted
+        // against this config, and reformatting them would rewrite Microsoft's
+        // bytes into a diff the next refresh throws away.
+        "packages/infra/tsc/lib",
+        // A GENERATED map whose bytes already have an author:
+        // `packages/infra/cli/scripts/generate-register-closure.mjs` emits it as
+        // `JSON.stringify(closure, null, 4)` and its `--check` mode compares the
+        // committed file to that string EXACTLY. Formatting it (double → single
+        // quotes, 1140 lines) would make the two gates contradict each other, and
+        // the next legitimate regeneration would silently revert the formatting and
+        // turn `oxfmt --check .` red. One file, one writer.
+        "packages/infra/resolve-npm/lib/register-globals-closure.mjs"
     ]
 }

--- a/packages/infra/manifest-conformance/lib/index.mjs
+++ b/packages/infra/manifest-conformance/lib/index.mjs
@@ -14,7 +14,16 @@
  * wrong answers rather than no answer.
  */
 
-export { defineRule, allRules, portableRules, getRule, selectRules, runRules, claimedGjsifyFields, rulesClaimingField } from './registry.mjs';
+export {
+    defineRule,
+    allRules,
+    portableRules,
+    getRule,
+    selectRules,
+    runRules,
+    claimedGjsifyFields,
+    rulesClaimingField,
+} from './registry.mjs';
 export { createContext, readManifest, packagesUnder, toPosixPath, posixRelative } from './context.mjs';
 export {
     checkPrebuildDir,

--- a/packages/infra/manifest-conformance/lib/registry.mjs
+++ b/packages/infra/manifest-conformance/lib/registry.mjs
@@ -90,7 +90,9 @@ export function defineRule(rule) {
         }
     }
     if (rule.scope !== 'portable' && rule.scope !== 'repo') {
-        throw new TypeError(`manifest-conformance: rule "${rule.id}" has scope "${rule.scope}" (expected portable|repo)`);
+        throw new TypeError(
+            `manifest-conformance: rule "${rule.id}" has scope "${rule.scope}" (expected portable|repo)`,
+        );
     }
     if (!Array.isArray(rule.fields)) {
         throw new TypeError(

--- a/packages/infra/manifest-conformance/lib/rules/bundled-license.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/bundled-license.mjs
@@ -92,7 +92,7 @@ export function auditBundledLicense(packages) {
         if (typeof license !== 'string' || license.trim() === '') {
             failures.push(
                 `${pkg.name} (${pkg.path}): ships a third-party payload (${pkg.payload.join(', ')}) and declares no \`license\`. ` +
-                    'A package that redistributes other projects\' binaries must say so in the one field a scanner reads.',
+                    "A package that redistributes other projects' binaries must say so in the one field a scanner reads.",
             );
             continue;
         }
@@ -143,8 +143,7 @@ export const bundledLicenseRule = defineRule({
     id: 'bundled-license',
     scope: 'portable',
     fields: ['license'],
-    description:
-        "a package shipping another project's binaries declares a licence that says so, not just its own",
+    description: "a package shipping another project's binaries declares a licence that says so, not just its own",
     run(ctx) {
         const packages = collectBundlingPackages(ctx);
         const result = auditBundledLicense(packages);

--- a/packages/infra/manifest-conformance/lib/rules/headless.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/headless.mjs
@@ -222,20 +222,22 @@ export function renderReachPath(entryFile, file, parents, pkgDir, root) {
         chain.push(cur);
     }
     if (chain[chain.length - 1] !== entryFile) chain.push(entryFile);
-    return chain
-        .reverse()
-        // `relative` decides the containment, not a `/`-spelled string prefix:
-        // both `pkgDir` and `f` are host-native, so on Windows the prefix test
-        // was always false and every hop rendered root-relative
-        // (`packages\dom\foo\src\index.ts → …` instead of `src/index.ts → …`).
-        // Only the message degraded, but a diagnostic nobody can read is the
-        // part of a failing rule that has to work.
-        .map((f) => {
-            const rel = relative(pkgDir, f);
-            const inside = rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
-            return (inside ? rel : relative(root, f)).split(sep).join('/');
-        })
-        .join(' → ');
+    return (
+        chain
+            .reverse()
+            // `relative` decides the containment, not a `/`-spelled string prefix:
+            // both `pkgDir` and `f` are host-native, so on Windows the prefix test
+            // was always false and every hop rendered root-relative
+            // (`packages\dom\foo\src\index.ts → …` instead of `src/index.ts → …`).
+            // Only the message degraded, but a diagnostic nobody can read is the
+            // part of a failing rule that has to work.
+            .map((f) => {
+                const rel = relative(pkgDir, f);
+                const inside = rel !== '' && rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+                return (inside ? rel : relative(root, f)).split(sep).join('/');
+            })
+            .join(' → ')
+    );
 }
 
 /**

--- a/packages/infra/manifest-conformance/lib/rules/os-axis.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/os-axis.mjs
@@ -148,7 +148,13 @@ export function osDecisionSites(pkg) {
             // rule instead of reporting it twice in different words.
             continue;
         }
-        if (decidesOnOs(text)) sites.push(file.slice(pkg.dir.length + 1).split(/[\\/]/).join('/'));
+        if (decidesOnOs(text))
+            sites.push(
+                file
+                    .slice(pkg.dir.length + 1)
+                    .split(/[\\/]/)
+                    .join('/'),
+            );
     }
     return sites;
 }
@@ -191,7 +197,9 @@ function auditOsAxis(ctx) {
         declared++;
 
         if (typeof os !== 'object' || Array.isArray(os)) {
-            failures.push(`${pkg.rel}/package.json: \`gjsify.os\` must be an object keyed by operating system, got ${JSON.stringify(os)}.`);
+            failures.push(
+                `${pkg.rel}/package.json: \`gjsify.os\` must be an object keyed by operating system, got ${JSON.stringify(os)}.`,
+            );
             continue;
         }
 
@@ -271,7 +279,8 @@ export const osAxisRule = defineRule({
     id: 'os-axis',
     scope: 'portable',
     fields: ['gjsify.os', 'gjsify.osNotes'],
-    description: 'a package that branches on the operating system declares `gjsify.os`, and every claim below `supported` states why',
+    description:
+        'a package that branches on the operating system declares `gjsify.os`, and every claim below `supported` states why',
     run(ctx) {
         const { failures, notes, stats } = auditOsAxis(ctx);
         return {

--- a/packages/infra/manifest-conformance/lib/rules/package-outputs.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/package-outputs.mjs
@@ -415,8 +415,7 @@ export const packageOutputsRule = defineRule({
         'gjsify.main',
         'gjsify.example',
     ],
-    description:
-        'every path a package.json declares (main/exports/types/bin/gjsify.{bin,main,example}) exists on disk',
+    description: 'every path a package.json declares (main/exports/types/bin/gjsify.{bin,main,example}) exists on disk',
     run(ctx) {
         const results = inspectDeclaredOutputs(ctx);
         const broken = results.filter((r) => r.missing.length > 0);

--- a/packages/infra/manifest-conformance/lib/rules/portable-scripts.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/portable-scripts.mjs
@@ -163,7 +163,8 @@ export const portableScriptsRule = defineRule({
     id: 'portable-scripts',
     scope: 'portable',
     fields: ['scripts'],
-    description: 'every package script is portable — no `rm`/`cp`/… that cmd.exe lacks (use `gjsify clear` / `gjsify copy`)',
+    description:
+        'every package script is portable — no `rm`/`cp`/… that cmd.exe lacks (use `gjsify clear` / `gjsify copy`)',
     run(ctx) {
         const { failures, stats } = auditScripts(ctx);
         return {

--- a/packages/infra/manifest-conformance/lib/rules/prebuild-artifacts.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/prebuild-artifacts.mjs
@@ -247,7 +247,15 @@ export function dlopenProbe(file) {
 export function auditPrebuildArtifacts(nativePkgs, { girGaps = {} } = {}) {
     /** @type {string[]} */ const failures = [];
     /** @type {string[]} */ const notes = [];
-    const stats = { dirs: 0, packages: 0, loaded: 0, structuralOnly: 0, uncommitted: 0, hostSkipped: 0, girDeferred: 0 };
+    const stats = {
+        dirs: 0,
+        packages: 0,
+        loaded: 0,
+        structuralOnly: 0,
+        uncommitted: 0,
+        hostSkipped: 0,
+        girDeferred: 0,
+    };
     // Which ledger entries this run actually matched. The "stale entry" half of
     // the contract needs the WHOLE population to be sound, and this function is
     // also driven against single synthetic rows by the e2e suite — so it reports

--- a/packages/infra/manifest-conformance/lib/rules/prebuild-libc.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/prebuild-libc.mjs
@@ -615,19 +615,27 @@ export function auditPrebuildLibc(nativePkgs) {
                 `${pkg.name} (${pkg.path}): declares \`libc: ${JSON.stringify(declaredLibc)}\`, but its committed targets are ${
                     incompatible.length > 0 ? `musl-incompatible (${incompatible.join(', ')})` : ''
                 }${incompatible.length > 0 && undetermined.length > 0 ? ' and ' : ''}${
-                    undetermined.length > 0 ? `glibc-linked with musl-loadability undetermined (${undetermined.join(', ')})` : ''
+                    undetermined.length > 0
+                        ? `glibc-linked with musl-loadability undetermined (${undetermined.join(', ')})`
+                        : ''
                 }. The only defensible package-level value here is \`["glibc"]\` — a restriction a musl load test has proven — or none at all.`,
             );
         }
         if (declaredLibc === null) {
             notes.push(
                 `${pkg.name}: \`libc\` deliberately ABSENT. Per-target musl verdicts: ${[
-                    incompatible.length > 0 ? `${incompatible.join(', ')} incompatible (glibc loader in DT_NEEDED)` : null,
-                    undetermined.length > 0 ? `${undetermined.join(', ')} undetermined (glibc-linked, no glibc loader — musl aliases libc.so.6 to itself, so only a real dlopen on musl decides)` : null,
+                    incompatible.length > 0
+                        ? `${incompatible.join(', ')} incompatible (glibc loader in DT_NEEDED)`
+                        : null,
+                    undetermined.length > 0
+                        ? `${undetermined.join(', ')} undetermined (glibc-linked, no glibc loader — musl aliases libc.so.6 to itself, so only a real dlopen on musl decides)`
+                        : null,
                     agnostic.length > 0 ? `${agnostic.join(', ')} agnostic` : null,
                 ]
                     .filter(Boolean)
-                    .join('; ')}. npm's field has no per-target dimension and refusing the install everywhere would also refuse it where the artifact works; the bridge's own graceful no-native path covers the targets where it does not. Ship a \`${MUSL_SUFFIX}\` sibling for the constrained target(s) and this note goes away.`,
+                    .join(
+                        '; ',
+                    )}. npm's field has no per-target dimension and refusing the install everywhere would also refuse it where the artifact works; the bridge's own graceful no-native path covers the targets where it does not. Ship a \`${MUSL_SUFFIX}\` sibling for the constrained target(s) and this note goes away.`,
             );
         } else {
             notes.push(

--- a/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
+++ b/packages/infra/manifest-conformance/lib/rules/repository-directory.mjs
@@ -162,8 +162,7 @@ export const repositoryDirectoryRule = defineRule({
     id: 'repository-directory',
     scope: 'portable',
     fields: ['repository'],
-    description:
-        "every non-private package's `repository.directory` is present and equals its own repo-relative path",
+    description: "every non-private package's `repository.directory` is present and equals its own repo-relative path",
     run(ctx) {
         const { failures, stats } = auditRepositoryDirectory(ctx);
         return {

--- a/packages/infra/resolve-npm/lib/globals-map.mjs
+++ b/packages/infra/resolve-npm/lib/globals-map.mjs
@@ -28,133 +28,184 @@
  */
 export const GJS_GLOBALS_GROUPS = {
     node: [
-        'Buffer', 'Blob', 'File',
-        'process', 'setImmediate', 'clearImmediate', 'queueMicrotask',
-        'structuredClone', 'btoa', 'atob', 'URL', 'URLSearchParams',
+        'Buffer',
+        'Blob',
+        'File',
+        'process',
+        'setImmediate',
+        'clearImmediate',
+        'queueMicrotask',
+        'structuredClone',
+        'btoa',
+        'atob',
+        'URL',
+        'URLSearchParams',
     ],
     web: [
-        'fetch', 'Headers', 'Request', 'Response',
+        'fetch',
+        'Headers',
+        'Request',
+        'Response',
         'FormData',
-        'ReadableStream', 'WritableStream', 'TransformStream',
-        'ReadableStreamBYOBReader', 'ReadableStreamBYOBRequest',
-        'ReadableByteStreamController', 'ReadableStreamDefaultController',
+        'ReadableStream',
+        'WritableStream',
+        'TransformStream',
+        'ReadableStreamBYOBReader',
+        'ReadableStreamBYOBRequest',
+        'ReadableByteStreamController',
+        'ReadableStreamDefaultController',
         'ReadableStreamDefaultReader',
-        'TextEncoderStream', 'TextDecoderStream',
-        'ByteLengthQueuingStrategy', 'CountQueuingStrategy',
-        'CompressionStream', 'DecompressionStream',
+        'TextEncoderStream',
+        'TextDecoderStream',
+        'ByteLengthQueuingStrategy',
+        'CountQueuingStrategy',
+        'CompressionStream',
+        'DecompressionStream',
         'crypto',
-        'AbortController', 'AbortSignal',
-        'MessageChannel', 'MessagePort',
-        'Event', 'EventTarget', 'CustomEvent', 'MessageEvent',
-        'ErrorEvent', 'CloseEvent', 'ProgressEvent', 'UIEvent',
-        'MouseEvent', 'PointerEvent', 'KeyboardEvent', 'WheelEvent', 'FocusEvent',
+        'AbortController',
+        'AbortSignal',
+        'MessageChannel',
+        'MessagePort',
+        'Event',
+        'EventTarget',
+        'CustomEvent',
+        'MessageEvent',
+        'ErrorEvent',
+        'CloseEvent',
+        'ProgressEvent',
+        'UIEvent',
+        'MouseEvent',
+        'PointerEvent',
+        'KeyboardEvent',
+        'WheelEvent',
+        'FocusEvent',
         'EventSource',
         'WebSocket',
         'WebAssembly',
         'DOMException',
-        'performance', 'PerformanceObserver',
+        'performance',
+        'PerformanceObserver',
         'XMLHttpRequest',
         'XMLHttpRequestUpload',
         'DOMParser',
-        'AudioContext', 'webkitAudioContext', 'Audio', 'HTMLAudioElement',
+        'AudioContext',
+        'webkitAudioContext',
+        'Audio',
+        'HTMLAudioElement',
         'GamepadEvent',
         'MediaDevices',
-        'RTCPeerConnection', 'RTCSessionDescription', 'RTCIceCandidate',
-        'RTCPeerConnectionIceEvent', 'RTCDataChannel', 'RTCDataChannelEvent',
-        'RTCError', 'RTCErrorEvent',
-        'MediaStream', 'MediaStreamTrack', 'RTCTrackEvent',
+        'RTCPeerConnection',
+        'RTCSessionDescription',
+        'RTCIceCandidate',
+        'RTCPeerConnectionIceEvent',
+        'RTCDataChannel',
+        'RTCDataChannelEvent',
+        'RTCError',
+        'RTCErrorEvent',
+        'MediaStream',
+        'MediaStreamTrack',
+        'RTCTrackEvent',
     ],
     dom: [
-        'document', 'Image', 'HTMLCanvasElement', 'HTMLImageElement',
-        'HTMLElement', 'MutationObserver', 'ResizeObserver', 'IntersectionObserver',
-        'FontFace', 'matchMedia', 'location', 'navigator',
+        'document',
+        'Image',
+        'HTMLCanvasElement',
+        'HTMLImageElement',
+        'HTMLElement',
+        'MutationObserver',
+        'ResizeObserver',
+        'IntersectionObserver',
+        'FontFace',
+        'matchMedia',
+        'location',
+        'navigator',
     ],
 };
 
 export const GJS_GLOBALS_MAP = {
     // --- Node.js globals (granular register subpaths) ----------------------
-    Buffer:               '@gjsify/node-globals/register/buffer',
-    process:              '@gjsify/node-globals/register/process',
+    Buffer: '@gjsify/node-globals/register/buffer',
+    process: '@gjsify/node-globals/register/process',
     // setTimeout / setInterval ARE provided natively by GJS, but their return
     // value is a GLib.Source BoxedInstance whose deferred-GC finalize calls
     // g_source_unref on a possibly-freed source — silent SIGSEGV ~10 s after
     // any third-party library uses them. Our `register/timers` replacement
     // returns numeric IDs instead. Listing them here forces auto-globals to
     // inject the override on every bundle that calls setTimeout.
-    setTimeout:           '@gjsify/node-globals/register/timers',
-    setInterval:          '@gjsify/node-globals/register/timers',
-    clearTimeout:         '@gjsify/node-globals/register/timers',
-    clearInterval:        '@gjsify/node-globals/register/timers',
-    setImmediate:         '@gjsify/node-globals/register/timers',
-    clearImmediate:       '@gjsify/node-globals/register/timers',
-    queueMicrotask:       '@gjsify/node-globals/register/microtask',
-    structuredClone:      '@gjsify/node-globals/register/structured-clone',
-    btoa:                 '@gjsify/node-globals/register/encoding',
-    atob:                 '@gjsify/node-globals/register/encoding',
+    setTimeout: '@gjsify/node-globals/register/timers',
+    setInterval: '@gjsify/node-globals/register/timers',
+    clearTimeout: '@gjsify/node-globals/register/timers',
+    clearInterval: '@gjsify/node-globals/register/timers',
+    setImmediate: '@gjsify/node-globals/register/timers',
+    clearImmediate: '@gjsify/node-globals/register/timers',
+    queueMicrotask: '@gjsify/node-globals/register/microtask',
+    structuredClone: '@gjsify/node-globals/register/structured-clone',
+    btoa: '@gjsify/node-globals/register/encoding',
+    atob: '@gjsify/node-globals/register/encoding',
 
     // --- URL (shared Node + Web) -------------------------------------------
-    URL:                  '@gjsify/node-globals/register/url',
-    URLSearchParams:      '@gjsify/node-globals/register/url',
+    URL: '@gjsify/node-globals/register/url',
+    URLSearchParams: '@gjsify/node-globals/register/url',
 
     // --- Blob / File (exposed via node:buffer and Web File API) ------------
-    Blob:                 '@gjsify/buffer/register',
-    File:                 '@gjsify/buffer/register',
+    Blob: '@gjsify/buffer/register',
+    File: '@gjsify/buffer/register',
 
     // --- Fetch stack -------------------------------------------------------
-    fetch:                'fetch/register/fetch',
-    Headers:              'fetch/register/fetch',
-    Request:              'fetch/register/fetch',
-    Response:             'fetch/register/fetch',
+    fetch: 'fetch/register/fetch',
+    Headers: 'fetch/register/fetch',
+    Request: 'fetch/register/fetch',
+    Response: 'fetch/register/fetch',
 
     // --- FormData ----------------------------------------------------------
-    FormData:             '@gjsify/web-globals/register/formdata',
+    FormData: '@gjsify/web-globals/register/formdata',
 
     // --- WHATWG Streams (granular register subpaths) ------------------------
-    ReadableStream:       'web-streams/register/readable',
-    ReadableStreamBYOBReader:        'web-streams/register/readable',
-    ReadableStreamBYOBRequest:       'web-streams/register/readable',
-    ReadableByteStreamController:    'web-streams/register/readable',
+    ReadableStream: 'web-streams/register/readable',
+    ReadableStreamBYOBReader: 'web-streams/register/readable',
+    ReadableStreamBYOBRequest: 'web-streams/register/readable',
+    ReadableByteStreamController: 'web-streams/register/readable',
     ReadableStreamDefaultController: 'web-streams/register/readable',
-    ReadableStreamDefaultReader:     'web-streams/register/readable',
-    WritableStream:       'web-streams/register/writable',
-    TransformStream:      'web-streams/register/transform',
-    TextEncoderStream:    'web-streams/register/text-streams',
-    TextDecoderStream:    'web-streams/register/text-streams',
+    ReadableStreamDefaultReader: 'web-streams/register/readable',
+    WritableStream: 'web-streams/register/writable',
+    TransformStream: 'web-streams/register/transform',
+    TextEncoderStream: 'web-streams/register/text-streams',
+    TextDecoderStream: 'web-streams/register/text-streams',
     ByteLengthQueuingStrategy: 'web-streams/register/queuing',
     CountQueuingStrategy: 'web-streams/register/queuing',
 
     // --- Compression Streams -----------------------------------------------
-    CompressionStream:    'compression-streams/register',
-    DecompressionStream:  'compression-streams/register',
+    CompressionStream: 'compression-streams/register',
+    DecompressionStream: 'compression-streams/register',
 
     // --- WebCrypto ---------------------------------------------------------
-    crypto:               'webcrypto/register',
+    crypto: 'webcrypto/register',
 
     // --- Events + Abort (granular register subpaths) -----------------------
-    AbortController:      'abort-controller/register',
-    AbortSignal:          'abort-controller/register',
-    MessageChannel:       'message-channel/register',
-    MessagePort:          'message-channel/register',
-    Event:                'dom-events/register/event-target',
-    EventTarget:          'dom-events/register/event-target',
-    CustomEvent:          'dom-events/register/custom-events',
-    MessageEvent:         'dom-events/register/custom-events',
-    ErrorEvent:           'dom-events/register/custom-events',
-    CloseEvent:           'dom-events/register/custom-events',
-    ProgressEvent:        'dom-events/register/custom-events',
-    UIEvent:              'dom-events/register/ui-events',
-    MouseEvent:           'dom-events/register/ui-events',
-    PointerEvent:         'dom-events/register/ui-events',
-    KeyboardEvent:        'dom-events/register/ui-events',
-    WheelEvent:           'dom-events/register/ui-events',
-    FocusEvent:           'dom-events/register/ui-events',
-    EventSource:          'eventsource/register',
+    AbortController: 'abort-controller/register',
+    AbortSignal: 'abort-controller/register',
+    MessageChannel: 'message-channel/register',
+    MessagePort: 'message-channel/register',
+    Event: 'dom-events/register/event-target',
+    EventTarget: 'dom-events/register/event-target',
+    CustomEvent: 'dom-events/register/custom-events',
+    MessageEvent: 'dom-events/register/custom-events',
+    ErrorEvent: 'dom-events/register/custom-events',
+    CloseEvent: 'dom-events/register/custom-events',
+    ProgressEvent: 'dom-events/register/custom-events',
+    UIEvent: 'dom-events/register/ui-events',
+    MouseEvent: 'dom-events/register/ui-events',
+    PointerEvent: 'dom-events/register/ui-events',
+    KeyboardEvent: 'dom-events/register/ui-events',
+    WheelEvent: 'dom-events/register/ui-events',
+    FocusEvent: 'dom-events/register/ui-events',
+    EventSource: 'eventsource/register',
 
     // --- WebSocket ---------------------------------------------------------
     // Single register module sets globalThis.{WebSocket,MessageEvent,CloseEvent}.
     // MessageEvent is shared with dom-events in practice — whichever register
     // runs first installs it; both guard with typeof === 'undefined'.
-    WebSocket:            'websocket/register',
+    WebSocket: 'websocket/register',
 
     // --- WebAssembly Promise APIs ------------------------------------------
     // Reach via marker (see METHOD_MARKERS in detect-free-globals.ts):
@@ -162,58 +213,58 @@ export const GJS_GLOBALS_MAP = {
     // injection of the Promise polyfill. The synchronous `new WebAssembly.{Module,Instance}`
     // path also free-references `WebAssembly` and ends up here, but the
     // register module is a no-op when the natives already work.
-    WebAssembly:          'webassembly/register/promise',
+    WebAssembly: 'webassembly/register/promise',
 
     // --- Performance -------------------------------------------------------
-    performance:          '@gjsify/web-globals/register/performance',
-    PerformanceObserver:  '@gjsify/web-globals/register/performance',
+    performance: '@gjsify/web-globals/register/performance',
+    PerformanceObserver: '@gjsify/web-globals/register/performance',
 
     // --- DOMException ------------------------------------------------------
-    DOMException:         'dom-exception/register',
+    DOMException: 'dom-exception/register',
 
     // --- XMLHttpRequest (implemented in @gjsify/fetch) ---------------------
-    XMLHttpRequest:       'fetch/register/xhr',
+    XMLHttpRequest: 'fetch/register/xhr',
     XMLHttpRequestUpload: 'fetch/register/xhr',
 
     // --- DOMParser ---------------------------------------------------------
-    DOMParser:            '@gjsify/domparser/register',
+    DOMParser: '@gjsify/domparser/register',
 
     // --- Web Audio API (GStreamer backend) ----------------------------------
-    AudioContext:         '@gjsify/webaudio/register',
-    webkitAudioContext:   '@gjsify/webaudio/register',
-    Audio:                '@gjsify/webaudio/register',
-    HTMLAudioElement:     '@gjsify/webaudio/register',
+    AudioContext: '@gjsify/webaudio/register',
+    webkitAudioContext: '@gjsify/webaudio/register',
+    Audio: '@gjsify/webaudio/register',
+    HTMLAudioElement: '@gjsify/webaudio/register',
 
     // --- Gamepad API (libmanette backend) -----------------------------------
-    GamepadEvent:         '@gjsify/gamepad/register',
+    GamepadEvent: '@gjsify/gamepad/register',
 
     // --- WebRTC (GStreamer webrtcbin backend) -------------------------------
-    MediaDevices:               '@gjsify/webrtc/register/media-devices',
-    RTCPeerConnection:          '@gjsify/webrtc/register/peer-connection',
-    RTCSessionDescription:      '@gjsify/webrtc/register/peer-connection',
-    RTCIceCandidate:            '@gjsify/webrtc/register/peer-connection',
-    RTCPeerConnectionIceEvent:  '@gjsify/webrtc/register/peer-connection',
-    RTCDataChannel:             '@gjsify/webrtc/register/data-channel',
-    RTCDataChannelEvent:        '@gjsify/webrtc/register/data-channel',
-    RTCError:                   '@gjsify/webrtc/register/error',
-    RTCErrorEvent:              '@gjsify/webrtc/register/error',
-    MediaStream:                '@gjsify/webrtc/register/media',
-    MediaStreamTrack:           '@gjsify/webrtc/register/media',
-    RTCTrackEvent:              '@gjsify/webrtc/register/media',
+    MediaDevices: '@gjsify/webrtc/register/media-devices',
+    RTCPeerConnection: '@gjsify/webrtc/register/peer-connection',
+    RTCSessionDescription: '@gjsify/webrtc/register/peer-connection',
+    RTCIceCandidate: '@gjsify/webrtc/register/peer-connection',
+    RTCPeerConnectionIceEvent: '@gjsify/webrtc/register/peer-connection',
+    RTCDataChannel: '@gjsify/webrtc/register/data-channel',
+    RTCDataChannelEvent: '@gjsify/webrtc/register/data-channel',
+    RTCError: '@gjsify/webrtc/register/error',
+    RTCErrorEvent: '@gjsify/webrtc/register/error',
+    MediaStream: '@gjsify/webrtc/register/media',
+    MediaStreamTrack: '@gjsify/webrtc/register/media',
+    RTCTrackEvent: '@gjsify/webrtc/register/media',
 
     // --- DOM elements (granular register subpaths) -------------------------
-    document:             '@gjsify/dom-elements/register/document',
-    Image:                '@gjsify/dom-elements/register/image',
-    HTMLCanvasElement:    '@gjsify/dom-elements/register/canvas',
-    HTMLImageElement:     '@gjsify/dom-elements/register/image',
-    HTMLElement:          '@gjsify/dom-elements/register/document',
-    MutationObserver:     '@gjsify/dom-elements/register/observers',
-    ResizeObserver:       '@gjsify/dom-elements/register/observers',
+    document: '@gjsify/dom-elements/register/document',
+    Image: '@gjsify/dom-elements/register/image',
+    HTMLCanvasElement: '@gjsify/dom-elements/register/canvas',
+    HTMLImageElement: '@gjsify/dom-elements/register/image',
+    HTMLElement: '@gjsify/dom-elements/register/document',
+    MutationObserver: '@gjsify/dom-elements/register/observers',
+    ResizeObserver: '@gjsify/dom-elements/register/observers',
     IntersectionObserver: '@gjsify/dom-elements/register/observers',
-    FontFace:             '@gjsify/dom-elements/register/font-face',
-    matchMedia:           '@gjsify/dom-elements/register/match-media',
-    location:             '@gjsify/dom-elements/register/location',
-    navigator:            '@gjsify/dom-elements/register/navigator',
+    FontFace: '@gjsify/dom-elements/register/font-face',
+    matchMedia: '@gjsify/dom-elements/register/match-media',
+    location: '@gjsify/dom-elements/register/location',
+    navigator: '@gjsify/dom-elements/register/navigator',
 
     // --- Canvas 2D + IFrame + WebGL (GTK/WebKit-backed DOM classes) --------
     //
@@ -226,10 +277,10 @@ export const GJS_GLOBALS_MAP = {
     // second, WebKitGTK) as an installed dependency. Auto-detection injects them
     // only when the identifier is actually referenced in the bundled,
     // tree-shaken output.
-    ImageData:            '@gjsify/canvas2d/register',
-    Path2D:               '@gjsify/canvas2d/register',
-    HTMLIFrameElement:    '@gjsify/iframe/register',
-    WebGLRenderingContext:  '@gjsify/webgl/register',
+    ImageData: '@gjsify/canvas2d/register',
+    Path2D: '@gjsify/canvas2d/register',
+    HTMLIFrameElement: '@gjsify/iframe/register',
+    WebGLRenderingContext: '@gjsify/webgl/register',
     WebGL2RenderingContext: '@gjsify/webgl/register',
 };
 
@@ -258,9 +309,7 @@ export const GJS_GLOBALS_MAP = {
  * register bodies run, but ONLY for identifiers whose register is actually
  * injected (so no host global is deleted without a gjsify replacement).
  */
-export const REVERSE_BRIDGE_NATIVE_OVERRIDE_IDENTS = [
-    'fetch', 'Headers', 'Request', 'Response',
-];
+export const REVERSE_BRIDGE_NATIVE_OVERRIDE_IDENTS = ['fetch', 'Headers', 'Request', 'Response'];
 
 /**
  * Register subpaths whose module imports a GObject-Introspection typelib
@@ -282,14 +331,14 @@ export const REVERSE_BRIDGE_NATIVE_OVERRIDE_IDENTS = [
  */
 export const GJS_GI_BACKED_REGISTERS = {
     '@gjsify/dom-elements/register': ['Gdk', 'GdkPixbuf', 'Pango', 'PangoCairo'],
-    '@gjsify/webaudio/register':     ['Gst', 'GstApp'],
-    '@gjsify/webrtc/register':       ['Gst', 'GstWebRTC', 'GstSdp'],
-    '@gjsify/gamepad/register':      ['Manette'],
+    '@gjsify/webaudio/register': ['Gst', 'GstApp'],
+    '@gjsify/webrtc/register': ['Gst', 'GstWebRTC', 'GstSdp'],
+    '@gjsify/gamepad/register': ['Manette'],
     // Imports `@gjsify/dom-elements/register/canvas` (Gdk/GdkPixbuf/Pango/
     // PangoCairo) plus `@gjsify/canvas2d-core`, which uses the `cairo` foreign
     // struct module.
-    '@gjsify/canvas2d/register':     ['Gdk', 'GdkPixbuf', 'Pango', 'PangoCairo'],
-    '@gjsify/iframe/register':       ['WebKit'],
+    '@gjsify/canvas2d/register': ['Gdk', 'GdkPixbuf', 'Pango', 'PangoCairo'],
+    '@gjsify/iframe/register': ['WebKit'],
     // The WebGL context classes reach the GL driver through the `gwebgl` Vala
     // bridge shipped as this package's own prebuild, and decode `texImage2D`
     // sources via GdkPixbuf. Gtk/Gdk are NOT listed: they are pulled by
@@ -297,7 +346,7 @@ export const GJS_GI_BACKED_REGISTERS = {
     // import — its chain is the two context classes only. As with the entries
     // above, the always-present base namespaces (GLib) are omitted; only the
     // ones whose absence breaks a GTK-less host are worth naming.
-    '@gjsify/webgl/register':        ['GdkPixbuf', 'Gwebgl'],
+    '@gjsify/webgl/register': ['GdkPixbuf', 'Gwebgl'],
 };
 
 // ─── Browser target ────────────────────────────────────────────────────────
@@ -341,42 +390,95 @@ export const GJS_GI_BACKED_REGISTERS = {
  */
 export const BROWSER_NATIVE_IDENTS = new Set([
     // Web group — all browser-native
-    'fetch', 'Headers', 'Request', 'Response',
-    'FormData', 'Blob', 'File',
-    'ReadableStream', 'WritableStream', 'TransformStream',
-    'ReadableStreamBYOBReader', 'ReadableStreamBYOBRequest',
-    'ReadableByteStreamController', 'ReadableStreamDefaultController',
+    'fetch',
+    'Headers',
+    'Request',
+    'Response',
+    'FormData',
+    'Blob',
+    'File',
+    'ReadableStream',
+    'WritableStream',
+    'TransformStream',
+    'ReadableStreamBYOBReader',
+    'ReadableStreamBYOBRequest',
+    'ReadableByteStreamController',
+    'ReadableStreamDefaultController',
     'ReadableStreamDefaultReader',
-    'TextEncoderStream', 'TextDecoderStream',
-    'ByteLengthQueuingStrategy', 'CountQueuingStrategy',
-    'CompressionStream', 'DecompressionStream',
+    'TextEncoderStream',
+    'TextDecoderStream',
+    'ByteLengthQueuingStrategy',
+    'CountQueuingStrategy',
+    'CompressionStream',
+    'DecompressionStream',
     'crypto',
-    'AbortController', 'AbortSignal',
-    'MessageChannel', 'MessagePort',
-    'Event', 'EventTarget', 'CustomEvent', 'MessageEvent',
-    'ErrorEvent', 'CloseEvent', 'ProgressEvent',
-    'UIEvent', 'MouseEvent', 'PointerEvent', 'KeyboardEvent',
-    'WheelEvent', 'FocusEvent',
-    'EventSource', 'WebSocket', 'WebAssembly',
+    'AbortController',
+    'AbortSignal',
+    'MessageChannel',
+    'MessagePort',
+    'Event',
+    'EventTarget',
+    'CustomEvent',
+    'MessageEvent',
+    'ErrorEvent',
+    'CloseEvent',
+    'ProgressEvent',
+    'UIEvent',
+    'MouseEvent',
+    'PointerEvent',
+    'KeyboardEvent',
+    'WheelEvent',
+    'FocusEvent',
+    'EventSource',
+    'WebSocket',
+    'WebAssembly',
     'DOMException',
-    'performance', 'PerformanceObserver',
-    'XMLHttpRequest', 'XMLHttpRequestUpload',
+    'performance',
+    'PerformanceObserver',
+    'XMLHttpRequest',
+    'XMLHttpRequestUpload',
     'DOMParser',
-    'AudioContext', 'webkitAudioContext', 'Audio', 'HTMLAudioElement',
+    'AudioContext',
+    'webkitAudioContext',
+    'Audio',
+    'HTMLAudioElement',
     'GamepadEvent',
     'MediaDevices',
-    'RTCPeerConnection', 'RTCSessionDescription', 'RTCIceCandidate',
-    'RTCPeerConnectionIceEvent', 'RTCDataChannel', 'RTCDataChannelEvent',
-    'RTCError', 'RTCErrorEvent',
-    'MediaStream', 'MediaStreamTrack', 'RTCTrackEvent',
+    'RTCPeerConnection',
+    'RTCSessionDescription',
+    'RTCIceCandidate',
+    'RTCPeerConnectionIceEvent',
+    'RTCDataChannel',
+    'RTCDataChannelEvent',
+    'RTCError',
+    'RTCErrorEvent',
+    'MediaStream',
+    'MediaStreamTrack',
+    'RTCTrackEvent',
     // DOM group — all browser-native
-    'document', 'Image', 'HTMLCanvasElement', 'HTMLImageElement',
-    'HTMLElement', 'MutationObserver', 'ResizeObserver', 'IntersectionObserver',
-    'FontFace', 'matchMedia', 'location', 'navigator',
+    'document',
+    'Image',
+    'HTMLCanvasElement',
+    'HTMLImageElement',
+    'HTMLElement',
+    'MutationObserver',
+    'ResizeObserver',
+    'IntersectionObserver',
+    'FontFace',
+    'matchMedia',
+    'location',
+    'navigator',
     // Shared Node-group identifiers that are also browser-native
-    'queueMicrotask', 'structuredClone', 'btoa', 'atob',
-    'URL', 'URLSearchParams',
-    'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval',
+    'queueMicrotask',
+    'structuredClone',
+    'btoa',
+    'atob',
+    'URL',
+    'URLSearchParams',
+    'setTimeout',
+    'setInterval',
+    'clearTimeout',
+    'clearInterval',
 ]);
 
 /**
@@ -391,7 +493,7 @@ export const BROWSER_NATIVE_IDENTS = new Set([
  * land (browser polyfill wave 3-A onwards).
  */
 export const BROWSER_GLOBALS_MAP = {
-    Buffer:          '@gjsify/buffer/register',
+    Buffer: '@gjsify/buffer/register',
 };
 
 /**
@@ -412,7 +514,7 @@ export const BROWSER_GLOBALS_MAP = {
  * `runtimes.nativescript = "polyfill"` and need a specific global stubbed.
  */
 export const NATIVESCRIPT_GLOBALS_MAP = {
-    Buffer:          '@gjsify/buffer/register',
+    Buffer: '@gjsify/buffer/register',
 };
 
 /**

--- a/packages/infra/resolve-npm/lib/index.d.ts
+++ b/packages/infra/resolve-npm/lib/index.d.ts
@@ -5,38 +5,38 @@ export declare const EXTERNALS_NODE: string[];
 export declare const EXTERNALS_NPM: string[];
 
 /** General record of modules for Gjs */
-export declare const ALIASES_GENERAL_FOR_GJS: {[alias:string]: string}; 
+export declare const ALIASES_GENERAL_FOR_GJS: { [alias: string]: string };
 
 /** Record of Node.js modules (build in or not) and his replacement for Gjs */
-export declare const ALIASES_NODE_FOR_GJS: {[alias:string]: string};
+export declare const ALIASES_NODE_FOR_GJS: { [alias: string]: string };
 
 /**
  * Record of Node.js modules (build in or not) and his replacement for `--app browser`.
  * Unwired in this PR — exported for future consumption by browser.ts.
  */
-export declare const ALIASES_NODE_FOR_BROWSER: {[alias:string]: string};
-export declare const ALIASES_NODE_FOR_NATIVESCRIPT: {[alias:string]: string};
+export declare const ALIASES_NODE_FOR_BROWSER: { [alias: string]: string };
+export declare const ALIASES_NODE_FOR_NATIVESCRIPT: { [alias: string]: string };
 
 /** Record of Web modules and his replacement for Gjs */
-export declare const ALIASES_WEB_FOR_GJS: {[alias:string]: string}; 
+export declare const ALIASES_WEB_FOR_GJS: { [alias: string]: string };
 
 /** General record of modules for Deno */
-export declare const ALIASES_GENERAL_FOR_DENO: {[alias:string]: string};
+export declare const ALIASES_GENERAL_FOR_DENO: { [alias: string]: string };
 
 /** Record of Gjs modules (build in or not) and his replacement for Deno */
-export declare const ALIASES_GJS_FOR_DENO: {[alias:string]: string};
+export declare const ALIASES_GJS_FOR_DENO: { [alias: string]: string };
 
 /** Record of Node.js modules (build in or not) and his replacement for Deno */
-export declare const ALIASES_NODE_FOR_DENO: {[alias:string]: string};
+export declare const ALIASES_NODE_FOR_DENO: { [alias: string]: string };
 
 /** General record of modules for Node */
-export declare const ALIASES_GENERAL_FOR_NODE: {[alias:string]: string};
+export declare const ALIASES_GENERAL_FOR_NODE: { [alias: string]: string };
 
 /** Record of Gjs modules (build in or not) and his replacement for Node */
-export declare const ALIASES_GJS_FOR_NODE: {[alias:string]: string};
+export declare const ALIASES_GJS_FOR_NODE: { [alias: string]: string };
 
 /** Record of Web modules and his replacement for Node */
-export declare const ALIASES_WEB_FOR_NODE: {[alias:string]: string};
+export declare const ALIASES_WEB_FOR_NODE: { [alias: string]: string };
 
 /** Runtime-slot type carried by `package.json#gjsify.runtimes.<target>`. */
 export type RuntimeSlot = 'polyfill' | 'native' | 'partial' | 'none';
@@ -53,20 +53,27 @@ export interface RuntimeTriplet {
  * by each workspace package's declared `gjsify.runtimes` triplet. See
  * `runtime-aliases.mjs` for the routing semantics.
  */
-export declare function getDerivedAliasesSync(target: 'gjs' | 'node' | 'browser' | 'nativescript'): {[alias: string]: string};
+export declare function getDerivedAliasesSync(target: 'gjs' | 'node' | 'browser' | 'nativescript'): {
+    [alias: string]: string;
+};
 
 /** Async variant of {@link getDerivedAliasesSync}. */
 export declare function getDerivedAliases(
     target: 'gjs' | 'node' | 'browser' | 'nativescript',
-): Promise<{[alias: string]: string}>;
+): Promise<{ [alias: string]: string }>;
 
 /** Reset the in-memory cache. Test-only. */
 export declare function resetRuntimeAliasesCache(): void;
 
 /** Diagnostic — list every declared runtime triplet keyed by package name. */
-export declare function listDeclaredRuntimes(): Promise<Map<string, {
-    name: string;
-    dir: string;
-    runtimes: RuntimeTriplet;
-    hasGlobals: boolean;
-}>>;
+export declare function listDeclaredRuntimes(): Promise<
+    Map<
+        string,
+        {
+            name: string;
+            dir: string;
+            runtimes: RuntimeTriplet;
+            hasGlobals: boolean;
+        }
+    >
+>;

--- a/packages/infra/resolve-npm/lib/index.mjs
+++ b/packages/infra/resolve-npm/lib/index.mjs
@@ -83,12 +83,10 @@ function withDerivedSlotRouting(table, target) {
         return routed;
     };
     return new Proxy(table, {
-        get: (_t, prop) =>
-            typeof prop === 'string' ? materialise()[prop] : Reflect.get(table, prop),
+        get: (_t, prop) => (typeof prop === 'string' ? materialise()[prop] : Reflect.get(table, prop)),
         has: (_t, prop) => Reflect.has(materialise(), prop),
         ownKeys: () => Reflect.ownKeys(materialise()),
-        getOwnPropertyDescriptor: (_t, prop) =>
-            Reflect.getOwnPropertyDescriptor(materialise(), prop),
+        getOwnPropertyDescriptor: (_t, prop) => Reflect.getOwnPropertyDescriptor(materialise(), prop),
     });
 }
 
@@ -148,13 +146,10 @@ export const EXTERNALS_NODE = [
     'sqlite',
     'worker_threads',
     'zlib',
-]
+];
 
 /** Array of NPM module names for which we have our own implementation */
-export const EXTERNALS_NPM = [
-    'readable-stream',
-    'node-fetch'
-]
+export const EXTERNALS_NPM = ['readable-stream', 'node-fetch'];
 
 /** General record of modules for Gjs */
 export const ALIASES_GENERAL_FOR_GJS = {
@@ -163,7 +158,7 @@ export const ALIASES_GENERAL_FOR_GJS = {
     // DOMParser is not available; on GJS we provide DOMParser via
     // @gjsify/domparser, so jsdom and its whatwg-url/webidl-conversions
     // deps (which use SharedArrayBuffer — unavailable in GJS) are never needed.
-    'jsdom': '@gjsify/empty',
+    jsdom: '@gjsify/empty',
 
     // engine.io-client ships both polling-xhr.node.js (uses xmlhttprequest-ssl /
     // Node http.request) and polling-xhr.js (uses globalThis.XMLHttpRequest).
@@ -176,66 +171,65 @@ export const ALIASES_GENERAL_FOR_GJS = {
     './polling-xhr.node.js': './polling-xhr.js',
     './websocket.node.js': './websocket.js',
     './globals.node.js': './globals.js',
-
-}
+};
 
 /** Record of Node.js modules (build in or not) and his replacement for Gjs */
 export const ALIASES_NODE_FOR_GJS = {
     // Internal Node.js modules
-    'assert': '@gjsify/assert',
+    assert: '@gjsify/assert',
     'assert/strict': '@gjsify/assert/strict',
-    'async_hooks': '@gjsify/async_hooks',
-    'buffer': '@gjsify/buffer',
-    'child_process': '@gjsify/child_process',
-    'cluster': '@gjsify/cluster',
-    'console': '@gjsify/console',
-    'constants': '@gjsify/constants',
-    'crypto': '@gjsify/crypto',
-    'dgram': '@gjsify/dgram',
-    'diagnostics_channel': '@gjsify/diagnostics_channel',
-    'dns': '@gjsify/dns',
+    async_hooks: '@gjsify/async_hooks',
+    buffer: '@gjsify/buffer',
+    child_process: '@gjsify/child_process',
+    cluster: '@gjsify/cluster',
+    console: '@gjsify/console',
+    constants: '@gjsify/constants',
+    crypto: '@gjsify/crypto',
+    dgram: '@gjsify/dgram',
+    diagnostics_channel: '@gjsify/diagnostics_channel',
+    dns: '@gjsify/dns',
     'dns/promises': '@gjsify/dns/promises',
-    'domain': '@gjsify/domain',
-    'events': '@gjsify/events',
-    'fs': '@gjsify/fs',
+    domain: '@gjsify/domain',
+    events: '@gjsify/events',
+    fs: '@gjsify/fs',
     'fs/promises': '@gjsify/fs/promises',
-    'http': '@gjsify/http',
-    'http2': '@gjsify/http2',
-    'https': '@gjsify/https',
-    'inspector': '@gjsify/inspector',
-    'module': '@gjsify/module',
-    'net': '@gjsify/net',
-    'os': '@gjsify/os',
-    'path': '@gjsify/path',
+    http: '@gjsify/http',
+    http2: '@gjsify/http2',
+    https: '@gjsify/https',
+    inspector: '@gjsify/inspector',
+    module: '@gjsify/module',
+    net: '@gjsify/net',
+    os: '@gjsify/os',
+    path: '@gjsify/path',
     'path/posix': '@gjsify/path/posix',
     'path/win32': '@gjsify/path/win32',
-    'perf_hooks': '@gjsify/perf_hooks',
-    'process': '@gjsify/process',
-    'punycode': '@gjsify/punycode', // stub — deprecated, low priority
-    'querystring': '@gjsify/querystring',
-    'readline': '@gjsify/readline',
+    perf_hooks: '@gjsify/perf_hooks',
+    process: '@gjsify/process',
+    punycode: '@gjsify/punycode', // stub — deprecated, low priority
+    querystring: '@gjsify/querystring',
+    readline: '@gjsify/readline',
     'readline/promises': '@gjsify/readline/promises',
-    'repl': '@gjsify/repl', // stub — low priority
-    'stream': '@gjsify/stream',
+    repl: '@gjsify/repl', // stub — low priority
+    stream: '@gjsify/stream',
     'stream/web': '@gjsify/stream/web',
     'stream/consumers': '@gjsify/stream/consumers',
     'stream/promises': '@gjsify/stream/promises',
-    'string_decoder': '@gjsify/string_decoder',
-    'sys': '@gjsify/sys',
+    string_decoder: '@gjsify/string_decoder',
+    sys: '@gjsify/sys',
     // 'test': '@gjsify/test', // not planned — use @gjsify/unit instead
-    'timers': '@gjsify/timers',
+    timers: '@gjsify/timers',
     'timers/promises': '@gjsify/timers/promises',
-    'tls': '@gjsify/tls',
-    'tty': '@gjsify/tty',
-    'url': '@gjsify/url',
-    'util': '@gjsify/util',
+    tls: '@gjsify/tls',
+    tty: '@gjsify/tty',
+    url: '@gjsify/url',
+    util: '@gjsify/util',
     'util/types': '@gjsify/util/types',
-    'v8': '@gjsify/v8',
-    'vm': '@gjsify/vm',
-    'wasi': '@gjsify/wasi', // stub — low priority (WebAssembly System Interface)
-    'sqlite': '@gjsify/sqlite',
-    'worker_threads': '@gjsify/worker_threads',
-    'zlib': '@gjsify/zlib',
+    v8: '@gjsify/v8',
+    vm: '@gjsify/vm',
+    wasi: '@gjsify/wasi', // stub — low priority (WebAssembly System Interface)
+    sqlite: '@gjsify/sqlite',
+    worker_threads: '@gjsify/worker_threads',
+    zlib: '@gjsify/zlib',
 
     // Third party Node Modules
     'node-fetch': '@gjsify/fetch',
@@ -249,7 +243,7 @@ export const ALIASES_NODE_FOR_GJS = {
     // resolves to @gjsify/ws unchanged, including the `typeof ws ===
     // 'function'` heuristic used by @thaunknown/simple-websocket and
     // similar transitive users.
-    'ws': '@gjsify/ws',
+    ws: '@gjsify/ws',
 
     // isomorphic-ws's browser.js is literally `module.exports = WebSocket`
     // — just the native class. On GJS that native class is @gjsify/websocket
@@ -258,7 +252,7 @@ export const ALIASES_NODE_FOR_GJS = {
     // Consumers who do `import WS from 'isomorphic-ws'` get our class
     // unchanged — one less delegation hop than going through @gjsify/ws.
     'isomorphic-ws': '@gjsify/websocket',
-}
+};
 
 /**
  * Record of Node.js modules (built-in or 3rd-party) and their `@gjsify/<X>`
@@ -332,65 +326,65 @@ export const ALIASES_NODE_FOR_GJS = {
  * made the `crypto` / `zlib` root-body routing read as latent.)
  */
 const ALIASES_NODE_FOR_BROWSER_TABLE = {
-    'assert':              '@gjsify/assert',
-    'assert/strict':       '@gjsify/assert/strict',
-    'async_hooks':         '@gjsify/async_hooks',
-    'buffer':              '@gjsify/buffer',
-    'child_process':       '@gjsify/child_process/browser', // none slot — NAMED throwing stub
-    'cluster':             '@gjsify/empty',        // (B) simulatable over Web Workers — unbuilt
-    'console':             '@gjsify/console',
-    'constants':           '@gjsify/constants',
-    'crypto':              '@gjsify/crypto/browser',   // partial slot — name the platform entry
-    'dgram':               '@gjsify/empty',        // (B) simulatable over WebRTC data channels — unbuilt
-    'diagnostics_channel': '@gjsify/diagnostics_channel',
-    'dns':                 '@gjsify/dns/browser',      // partial slot — name the platform entry
-    'dns/promises':        '@gjsify/empty',        // (A) blocked: no ./browser/promises subpath yet
-    'domain':              '@gjsify/domain',
-    'events':              '@gjsify/events',
-    'fs':                  '@gjsify/fs/browser',       // partial slot — name the platform entry
-    'fs/promises':         '@gjsify/fs/browser/promises',
-    'http':                '@gjsify/http/browser',     // partial slot — name the platform entry
-    'http2':               '@gjsify/empty',        // (C) impossible — needs a named throwing stub
-    'https':               '@gjsify/https/browser',    // partial slot — name the platform entry
-    'inspector':           '@gjsify/empty',        // (C) impossible — needs a named throwing stub
-    'module':              '@gjsify/module/browser',   // partial slot — name the platform entry
-    'net':                 '@gjsify/net/browser',      // none slot — NAMED throwing stub
-    'os':                  '@gjsify/os',
-    'path':                '@gjsify/path',
-    'path/posix':          '@gjsify/path/posix',
-    'path/win32':          '@gjsify/path/win32',
-    'perf_hooks':          '@gjsify/perf_hooks',
-    'process':             '@gjsify/process',      // PR-D: flips today's `@gjsify/empty`
-    'punycode':            '@gjsify/punycode',
-    'querystring':         '@gjsify/querystring',
-    'readline':            '@gjsify/empty',        // (B) stream-generic; simulatable — unbuilt
-    'readline/promises':   '@gjsify/empty',        // (B) stream-generic; simulatable — unbuilt
-    'repl':                '@gjsify/empty',        // (C) impossible, and no @gjsify/repl package exists
-    'stream':              '@gjsify/stream',
-    'stream/web':          '@gjsify/stream/web',
-    'stream/consumers':    '@gjsify/stream/consumers',
-    'stream/promises':     '@gjsify/stream/promises',
-    'string_decoder':      '@gjsify/string_decoder',
-    'sys':                 '@gjsify/sys',
-    'timers':              '@gjsify/timers',
-    'timers/promises':     '@gjsify/timers/promises',
-    'tls':                 '@gjsify/tls/browser',      // none slot — NAMED throwing stub
-    'tty':                 '@gjsify/empty',        // (B) isatty()===false is honest — unbuilt
-    'url':                 '@gjsify/url',
-    'util':                '@gjsify/util',
-    'util/types':          '@gjsify/util/types',
-    'v8':                  '@gjsify/empty',        // (B) serialize/deserialize over structuredClone — unbuilt
-    'vm':                  '@gjsify/vm',
-    'wasi':                '@gjsify/empty',        // (C) impossible, and no @gjsify/wasi package exists
-    'sqlite':              '@gjsify/sqlite/browser',   // partial slot — name the platform entry
-    'worker_threads':      '@gjsify/worker_threads/browser', // partial slot — name the platform entry
-    'zlib':                '@gjsify/zlib/browser',     // partial slot — name the platform entry
+    assert: '@gjsify/assert',
+    'assert/strict': '@gjsify/assert/strict',
+    async_hooks: '@gjsify/async_hooks',
+    buffer: '@gjsify/buffer',
+    child_process: '@gjsify/child_process/browser', // none slot — NAMED throwing stub
+    cluster: '@gjsify/empty', // (B) simulatable over Web Workers — unbuilt
+    console: '@gjsify/console',
+    constants: '@gjsify/constants',
+    crypto: '@gjsify/crypto/browser', // partial slot — name the platform entry
+    dgram: '@gjsify/empty', // (B) simulatable over WebRTC data channels — unbuilt
+    diagnostics_channel: '@gjsify/diagnostics_channel',
+    dns: '@gjsify/dns/browser', // partial slot — name the platform entry
+    'dns/promises': '@gjsify/empty', // (A) blocked: no ./browser/promises subpath yet
+    domain: '@gjsify/domain',
+    events: '@gjsify/events',
+    fs: '@gjsify/fs/browser', // partial slot — name the platform entry
+    'fs/promises': '@gjsify/fs/browser/promises',
+    http: '@gjsify/http/browser', // partial slot — name the platform entry
+    http2: '@gjsify/empty', // (C) impossible — needs a named throwing stub
+    https: '@gjsify/https/browser', // partial slot — name the platform entry
+    inspector: '@gjsify/empty', // (C) impossible — needs a named throwing stub
+    module: '@gjsify/module/browser', // partial slot — name the platform entry
+    net: '@gjsify/net/browser', // none slot — NAMED throwing stub
+    os: '@gjsify/os',
+    path: '@gjsify/path',
+    'path/posix': '@gjsify/path/posix',
+    'path/win32': '@gjsify/path/win32',
+    perf_hooks: '@gjsify/perf_hooks',
+    process: '@gjsify/process', // PR-D: flips today's `@gjsify/empty`
+    punycode: '@gjsify/punycode',
+    querystring: '@gjsify/querystring',
+    readline: '@gjsify/empty', // (B) stream-generic; simulatable — unbuilt
+    'readline/promises': '@gjsify/empty', // (B) stream-generic; simulatable — unbuilt
+    repl: '@gjsify/empty', // (C) impossible, and no @gjsify/repl package exists
+    stream: '@gjsify/stream',
+    'stream/web': '@gjsify/stream/web',
+    'stream/consumers': '@gjsify/stream/consumers',
+    'stream/promises': '@gjsify/stream/promises',
+    string_decoder: '@gjsify/string_decoder',
+    sys: '@gjsify/sys',
+    timers: '@gjsify/timers',
+    'timers/promises': '@gjsify/timers/promises',
+    tls: '@gjsify/tls/browser', // none slot — NAMED throwing stub
+    tty: '@gjsify/empty', // (B) isatty()===false is honest — unbuilt
+    url: '@gjsify/url',
+    util: '@gjsify/util',
+    'util/types': '@gjsify/util/types',
+    v8: '@gjsify/empty', // (B) serialize/deserialize over structuredClone — unbuilt
+    vm: '@gjsify/vm',
+    wasi: '@gjsify/empty', // (C) impossible, and no @gjsify/wasi package exists
+    sqlite: '@gjsify/sqlite/browser', // partial slot — name the platform entry
+    worker_threads: '@gjsify/worker_threads/browser', // partial slot — name the platform entry
+    zlib: '@gjsify/zlib/browser', // partial slot — name the platform entry
 
     // Third-party
-    'node-fetch':          '@gjsify/empty',        // (A') native-available: wants @gjsify/fetch/globals
-    'ws':                  '@gjsify/ws/browser',       // partial slot — name the platform entry
-    'isomorphic-ws':       '@gjsify/empty',        // (A') native-available: wants a WebSocket re-export
-}
+    'node-fetch': '@gjsify/empty', // (A') native-available: wants @gjsify/fetch/globals
+    ws: '@gjsify/ws/browser', // partial slot — name the platform entry
+    'isomorphic-ws': '@gjsify/empty', // (A') native-available: wants a WebSocket re-export
+};
 
 /**
  * Bare Node-builtin specifier → polyfill / empty-stub mapping for `--app
@@ -399,10 +393,7 @@ const ALIASES_NODE_FOR_BROWSER_TABLE = {
  * and it exports a `./browser` subpath). See `withDerivedSlotRouting` above for
  * why the two-pass chain has to be collapsed here.
  */
-export const ALIASES_NODE_FOR_BROWSER = withDerivedSlotRouting(
-    ALIASES_NODE_FOR_BROWSER_TABLE,
-    'browser',
-);
+export const ALIASES_NODE_FOR_BROWSER = withDerivedSlotRouting(ALIASES_NODE_FOR_BROWSER_TABLE, 'browser');
 
 /**
  * Bare Node-builtin specifier → polyfill / empty-stub mapping for `--app
@@ -438,66 +429,66 @@ export const ALIASES_NODE_FOR_BROWSER = withDerivedSlotRouting(
  */
 export const ALIASES_NODE_FOR_NATIVESCRIPT = {
     // Server-only Node built-ins → empty stub
-    'child_process':       '@gjsify/empty',
-    'cluster':             '@gjsify/empty',
-    'dgram':               '@gjsify/empty',
-    'dns':                 '@gjsify/empty',
-    'dns/promises':        '@gjsify/empty',
-    'inspector':           '@gjsify/empty',
-    'net':                 '@gjsify/empty',
-    'tls':                 '@gjsify/empty',
-    'tty':                 '@gjsify/empty',
-    'http':                '@gjsify/empty',
-    'https':               '@gjsify/empty',
-    'http2':               '@gjsify/empty',
-    'readline':            '@gjsify/empty',
-    'repl':                '@gjsify/empty',
-    'v8':                  '@gjsify/empty',
-    'vm':                  '@gjsify/empty',
-    'worker_threads':      '@gjsify/empty',
-    'perf_hooks':          '@gjsify/empty',
-    'diagnostics_channel': '@gjsify/empty',
-    'domain':              '@gjsify/empty',
-    'sqlite':              '@gjsify/empty',
-    'sys':                 '@gjsify/empty',
-    'zlib':                '@gjsify/empty',
+    child_process: '@gjsify/empty',
+    cluster: '@gjsify/empty',
+    dgram: '@gjsify/empty',
+    dns: '@gjsify/empty',
+    'dns/promises': '@gjsify/empty',
+    inspector: '@gjsify/empty',
+    net: '@gjsify/empty',
+    tls: '@gjsify/empty',
+    tty: '@gjsify/empty',
+    http: '@gjsify/empty',
+    https: '@gjsify/empty',
+    http2: '@gjsify/empty',
+    readline: '@gjsify/empty',
+    repl: '@gjsify/empty',
+    v8: '@gjsify/empty',
+    vm: '@gjsify/empty',
+    worker_threads: '@gjsify/empty',
+    perf_hooks: '@gjsify/empty',
+    diagnostics_channel: '@gjsify/empty',
+    domain: '@gjsify/empty',
+    sqlite: '@gjsify/empty',
+    sys: '@gjsify/empty',
+    zlib: '@gjsify/empty',
 
     // Mobile-tractable Node built-ins → @gjsify/<X>
-    'assert':              '@gjsify/assert',
-    'assert/strict':       '@gjsify/assert',
-    'async_hooks':         '@gjsify/async_hooks',
-    'buffer':              '@gjsify/buffer',
+    assert: '@gjsify/assert',
+    'assert/strict': '@gjsify/assert',
+    async_hooks: '@gjsify/async_hooks',
+    buffer: '@gjsify/buffer',
     // `@gjsify/module` (not `@gjsify/empty`): provides the named exports
     // `createRequire` / `builtinModules` / `isBuiltin`, so `import { createRequire }
     // from 'module'` in deps (e.g. css-tree) resolves instead of failing the build.
-    'module':              '@gjsify/module',
-    'crypto':              '@gjsify/crypto',
-    'events':              '@gjsify/events',
+    module: '@gjsify/module',
+    crypto: '@gjsify/crypto',
+    events: '@gjsify/events',
     // @gjsify/fs uses gi://Gio (GJS-only). On NS, route to the native bridge.
-    'fs':                  '@gjsify/native-fs-bridge',
-    'fs/promises':         '@gjsify/native-fs-bridge',
-    'os':                  '@gjsify/os',
-    'path':                '@gjsify/path',
-    'path/posix':          '@gjsify/path/posix',
-    'path/win32':          '@gjsify/path/win32',
-    'process':             '@gjsify/process',
-    'stream':              '@gjsify/stream',
-    'stream/promises':     '@gjsify/stream/promises',
-    'stream/web':          '@gjsify/stream/web',
-    'string_decoder':      '@gjsify/string_decoder',
-    'url':                 '@gjsify/url',
-    'util':                '@gjsify/util',
-    'util/types':          '@gjsify/util/types',
-    'querystring':         '@gjsify/querystring',
-    'console':             '@gjsify/console',
-    'timers':              '@gjsify/timers',
-    'timers/promises':     '@gjsify/timers/promises',
+    fs: '@gjsify/native-fs-bridge',
+    'fs/promises': '@gjsify/native-fs-bridge',
+    os: '@gjsify/os',
+    path: '@gjsify/path',
+    'path/posix': '@gjsify/path/posix',
+    'path/win32': '@gjsify/path/win32',
+    process: '@gjsify/process',
+    stream: '@gjsify/stream',
+    'stream/promises': '@gjsify/stream/promises',
+    'stream/web': '@gjsify/stream/web',
+    string_decoder: '@gjsify/string_decoder',
+    url: '@gjsify/url',
+    util: '@gjsify/util',
+    'util/types': '@gjsify/util/types',
+    querystring: '@gjsify/querystring',
+    console: '@gjsify/console',
+    timers: '@gjsify/timers',
+    'timers/promises': '@gjsify/timers/promises',
 
     // Third-party
-    'node-fetch':          '@gjsify/empty',        // NS has native fetch
-    'ws':                  '@gjsify/empty',        // NS has its own WebSocket
-    'isomorphic-ws':       '@gjsify/empty',
-}
+    'node-fetch': '@gjsify/empty', // NS has native fetch
+    ws: '@gjsify/empty', // NS has its own WebSocket
+    'isomorphic-ws': '@gjsify/empty',
+};
 
 /** Record of Web modules and his replacement for Gjs */
 export const ALIASES_WEB_FOR_GJS = {
@@ -508,14 +499,14 @@ export const ALIASES_WEB_FOR_GJS = {
     'dom-exception': '@gjsify/dom-exception',
     'event-target-shim': '@gjsify/dom-events',
     'message-channel': '@gjsify/message-channel',
-    'eventsource': '@gjsify/eventsource',
-    'fetch': '@gjsify/fetch',
-    'formdata': '@gjsify/formdata',
+    eventsource: '@gjsify/eventsource',
+    fetch: '@gjsify/fetch',
+    formdata: '@gjsify/formdata',
     'html-image-element': '@gjsify/html-image-element',
-    'webcrypto': '@gjsify/webcrypto',
-    'webgl': '@gjsify/webgl',
-    'websocket': '@gjsify/websocket',
-    'webstorage': '@gjsify/webstorage',
+    webcrypto: '@gjsify/webcrypto',
+    webgl: '@gjsify/webgl',
+    websocket: '@gjsify/websocket',
+    webstorage: '@gjsify/webstorage',
 
     // /register subpaths (side-effect only — opt-in to global registration)
     'abort-controller/register': '@gjsify/abort-controller/register',
@@ -540,23 +531,23 @@ export const ALIASES_WEB_FOR_GJS = {
     'web-streams/register/queuing': '@gjsify/web-streams/register/queuing',
 
     // xmlhttprequest (implemented in @gjsify/fetch)
-    'xmlhttprequest': '@gjsify/fetch',
+    xmlhttprequest: '@gjsify/fetch',
     'xmlhttprequest/register': '@gjsify/fetch/register/xhr',
     '@gjsify/xmlhttprequest': '@gjsify/fetch',
     '@gjsify/xmlhttprequest/register': '@gjsify/fetch/register/xhr',
-    'domparser': '@gjsify/domparser',
+    domparser: '@gjsify/domparser',
     'domparser/register': '@gjsify/domparser/register',
 
     // Web Audio API (GStreamer backend)
-    'webaudio': '@gjsify/webaudio',
+    webaudio: '@gjsify/webaudio',
     'webaudio/register': '@gjsify/webaudio/register',
 
     // Gamepad API (libmanette backend)
-    'gamepad': '@gjsify/gamepad',
+    gamepad: '@gjsify/gamepad',
     'gamepad/register': '@gjsify/gamepad/register',
 
     // WebRTC API (GStreamer webrtcbin backend)
-    'webrtc': '@gjsify/webrtc',
+    webrtc: '@gjsify/webrtc',
     'webrtc/register': '@gjsify/webrtc/register',
     'webrtc/register/peer-connection': '@gjsify/webrtc/register/peer-connection',
     'webrtc/register/data-channel': '@gjsify/webrtc/register/data-channel',
@@ -567,10 +558,10 @@ export const ALIASES_WEB_FOR_GJS = {
     // WebAssembly Promise APIs polyfill — wraps the synchronous Module/Instance
     // constructors so WebAssembly.{compile,instantiate,validate,...} resolve
     // instead of throwing the SpiderMonkey 128 stub error.
-    'webassembly': '@gjsify/webassembly',
+    webassembly: '@gjsify/webassembly',
     'webassembly/register': '@gjsify/webassembly/register',
     'webassembly/register/promise': '@gjsify/webassembly/register/promise',
-}
+};
 
 /** General record of modules for Node */
 export const ALIASES_GENERAL_FOR_NODE = {
@@ -587,7 +578,7 @@ export const ALIASES_GENERAL_FOR_NODE = {
     '@gjsify/web-globals/register': '@gjsify/empty',
     '@gjsify/web-globals/register/performance': '@gjsify/empty',
     '@gjsify/web-globals/register/formdata': '@gjsify/empty',
-}
+};
 
 /**
  * Record of GJS built-in module specifiers and their replacement for the
@@ -611,10 +602,10 @@ export const ALIASES_GENERAL_FOR_NODE = {
  * the engine's foreign-struct seam knows about).
  */
 const ALIASES_GJS_FOR_NODE = {
-    'system': '@gjsify/node-gi/system',
-    'gettext': '@gjsify/node-gi/gettext',
-    'cairo': '@gjsify/node-gi/cairo',
-}
+    system: '@gjsify/node-gi/system',
+    gettext: '@gjsify/node-gi/gettext',
+    cairo: '@gjsify/node-gi/cairo',
+};
 
 export { ALIASES_GJS_FOR_NODE };
 
@@ -643,19 +634,19 @@ export const ALIASES_WEB_FOR_NODE = {
     // works without any GJS deps; routing to it gives consumers a working
     // EventSource on Node out of the box. Same fix pattern as the `dom-events`
     // entry above.
-    'eventsource': '@gjsify/eventsource',
+    eventsource: '@gjsify/eventsource',
     // 'fetch' routes to @gjsify/fetch/globals on Node — the globals.mjs
     // re-exports the native globalThis.{fetch,Request,Response,Headers,
     // FormData} as named exports. The dynamic resolver routes
     // @gjsify/fetch to the same /globals subpath via its runtimes
     // triplet declaration (`node:"native"`), so both entry forms converge.
-    'fetch': '@gjsify/fetch/globals',
-    'formdata': '@gjsify/formdata/globals',
+    fetch: '@gjsify/fetch/globals',
+    formdata: '@gjsify/formdata/globals',
     'html-image-element': '@gjsify/html-image-element',
-    'webcrypto': '@gjsify/webcrypto/globals',
-    'webgl': '@gjsify/webgl',
-    'websocket': '@gjsify/websocket/globals',
-    'webstorage': '@gjsify/webstorage',
+    webcrypto: '@gjsify/webcrypto/globals',
+    webgl: '@gjsify/webgl',
+    websocket: '@gjsify/websocket/globals',
+    webstorage: '@gjsify/webstorage',
 
     // /register subpaths — no-op on Node (native globals are already set)
     'abort-controller/register': '@gjsify/empty',
@@ -718,26 +709,26 @@ export const ALIASES_WEB_FOR_NODE = {
     '@gjsify/buffer/register': '@gjsify/empty',
 
     // xmlhttprequest + DOMParser — no-op on Node
-    'xmlhttprequest': '@gjsify/empty',
+    xmlhttprequest: '@gjsify/empty',
     'xmlhttprequest/register': '@gjsify/empty',
     '@gjsify/xmlhttprequest': '@gjsify/empty',
     '@gjsify/xmlhttprequest/register': '@gjsify/empty',
-    'domparser': '@gjsify/empty',
+    domparser: '@gjsify/empty',
     'domparser/register': '@gjsify/empty',
     '@gjsify/domparser/register': '@gjsify/empty',
 
     // Web Audio API — no-op on Node (experimental --experimental-web-audio not widely available)
-    'webaudio': '@gjsify/empty',
+    webaudio: '@gjsify/empty',
     'webaudio/register': '@gjsify/empty',
     '@gjsify/webaudio/register': '@gjsify/empty',
 
     // Gamepad API — no-op on Node
-    'gamepad': '@gjsify/empty',
+    gamepad: '@gjsify/empty',
     'gamepad/register': '@gjsify/empty',
     '@gjsify/gamepad/register': '@gjsify/empty',
 
     // WebRTC API — no-op on Node (Phase 1 is GStreamer-only, no fallback)
-    'webrtc': '@gjsify/empty',
+    webrtc: '@gjsify/empty',
     'webrtc/register': '@gjsify/empty',
     'webrtc/register/peer-connection': '@gjsify/empty',
     'webrtc/register/data-channel': '@gjsify/empty',
@@ -755,9 +746,9 @@ export const ALIASES_WEB_FOR_NODE = {
     // WebAssembly Promise APIs — native on Node (no polyfill needed); the
     // bare `webassembly` specifier maps to /globals so consumers can import
     // typed helpers without dragging the polyfill into the bundle.
-    'webassembly': '@gjsify/webassembly/globals',
+    webassembly: '@gjsify/webassembly/globals',
     'webassembly/register': '@gjsify/empty',
     'webassembly/register/promise': '@gjsify/empty',
     '@gjsify/webassembly/register': '@gjsify/empty',
     '@gjsify/webassembly/register/promise': '@gjsify/empty',
-}
+};

--- a/packages/infra/resolve-npm/lib/runtime-aliases.mjs
+++ b/packages/infra/resolve-npm/lib/runtime-aliases.mjs
@@ -182,13 +182,7 @@ async function ingestPackageDir(dir, out) {
         const json = JSON.parse(raw);
         const name = typeof json.name === 'string' ? json.name : null;
         const runtimes = json?.gjsify?.runtimes;
-        if (
-            name &&
-            name.startsWith('@gjsify/') &&
-            !out.has(name) &&
-            runtimes &&
-            typeof runtimes === 'object'
-        ) {
+        if (name && name.startsWith('@gjsify/') && !out.has(name) && runtimes && typeof runtimes === 'object') {
             /** @type {RuntimeTriplet} */
             const triplet = {};
             for (const t of VALID_TARGETS) {
@@ -218,13 +212,7 @@ function ingestPackageDirSync(dir, out) {
         const json = JSON.parse(raw);
         const name = typeof json.name === 'string' ? json.name : null;
         const runtimes = json?.gjsify?.runtimes;
-        if (
-            name &&
-            name.startsWith('@gjsify/') &&
-            !out.has(name) &&
-            runtimes &&
-            typeof runtimes === 'object'
-        ) {
+        if (name && name.startsWith('@gjsify/') && !out.has(name) && runtimes && typeof runtimes === 'object') {
             /** @type {RuntimeTriplet} */
             const triplet = {};
             for (const t of VALID_TARGETS) {


### PR DESCRIPTION
The formatter half of #1369. `.oxfmtrc.json` carried the **identical** `**/lib` line, so
`oxfmt --check .` had been exiting 0 over the same 26 hand-written sources it never opened
— including every rule module of `@gjsify/manifest-conformance`, the package holding the
manifest gates that block `main`.

## The measurement

I did not take #1369's facts on trust; the ones this PR rests on are re-measured here, and
one of them turned out to need a different answer.

**Does oxfmt honour `.gitignore`, and the per-package `!lib/`, the way oxlint does?** The
whole justification for *removing* the pattern rather than negating it rests on that, so it
was probed directly in a throwaway tree — root `.gitignore` with `lib/`, one package with a
nested `!lib/`, one without, all three files unformatted:

| tree | `pkg/lib/source.mjs` (nested `!lib/`) | `other/lib/output.mjs` (no re-include) |
|---|---|---|
| with `.git` | listed | skipped |
| **no `.git` directory at all** | listed | skipped |
| root `.gitignore` removed (control) | listed | **listed** |
| nested `!lib/` removed (control) | **skipped** | skipped |
| `ignorePatterns: ["**/lib"]` added | **skipped** | skipped |

Same semantics as oxlint on every row, including without a repository. Both controls fire,
so the "skipped" cells are the ignore rules and not something built in.

**Which tracked files does oxfmt skip?** oxfmt has no `--debug=files` and no `--no-ignore`,
so the visible set is not printable. It is recoverable, though: with explicit paths oxfmt
either accepts them (`Finished … on N files`) or refuses (`Expected at least one target
file`, exit 2), and the accepted **count** is exact — so the set falls out of bisecting on
the deficit. A one-off census (3131 oxfmt invocations over the 5525 tracked files) gives, on
`origin/main`:

```
TRACKED       5525
FORMATTABLE   4620   (oxfmt parses these; probed per extension, ignore layers off)
VISIBLE       3304
BLIND         1316
```

Of the 1316, exactly **150 are code** (`.ts .mts .mjs .js .cjs .tsx`); the other 1166 are
`.json/.md/.scss/.css/.html/.yml/.vue/.mdx/.toml`, which this config ignores by extension on
purpose. The 150:

| files | path | verdict |
|---|---|---|
| 108 | `packages/infra/tsc/lib` | vendored TypeScript default libraries — correctly skipped |
| **26** | `manifest-conformance/lib` (21) + `resolve-npm/lib` (5) | **the defect** |
| 14 | `templates/**` | declared `**/templates` |
| 1 | `packages/infra/cli/dist/affected.gjs.mjs` | committed bundle, `**/dist` |
| 1 | `webgl/src/ts/@types/glsl-tokenizer` | declared `**/@types` |

And the count behind the 26, with the pattern lifted: **15 unformatted**, confirming #1369's
second-hand number exactly.

```
$ git ls-files packages/infra/{manifest-conformance,resolve-npm}/lib | xargs npx oxfmt --check
Expected at least one target file. All matched files may have been excluded by ignore rules.
$ … same list, with a config carrying no ignorePatterns
Format issues found in above 15 files.
Finished in 111ms on 26 files using 12 threads.
```

One difference from #1369 worth recording, because it changes how the hole surfaces to a
human: `oxfmt <blind path>` says **"All matched files may have been excluded by ignore
rules"** and exits 2. oxlint's equivalent says "No files found to lint" and exits 1 — which
reads as *checked, and angry*. oxfmt's message is the honest one. What it cannot say is
anything at all during `oxfmt --check .`, which is the invocation CI runs.

## The fix, and why this mechanism

**`**/lib` is removed, not negated** — the measurement above is the whole argument: oxfmt
honours `.gitignore` with or without a `.git`, the root `.gitignore` already carries `lib/`,
so the pattern bought **nothing** for build output. Its only live effect was overriding the
two packages' deliberate `!lib/`. Letting `.gitignore` be the single reader for *"is this
build output"* also makes the next such package right by default: committing source under
`lib/` requires an explicit `!lib/`, and that same act now makes the file visible to the
formatter. Tree walk: **3304 → 3329 files**.

Two things under a committed `lib/` are genuinely output and are named one by one instead of
covered by a glob:

- **`packages/infra/tsc/lib`** — the same 108 vendored TypeScript declarations #1369 names.
  All 108 are unformatted against this config; reformatting them would rewrite Microsoft's
  bytes into a diff the next refresh throws away.
- **`resolve-npm/lib/register-globals-closure.mjs`** — *not* in #1369's list, and the reason
  is specific to the formatter. It is a GENERATED map: `generate-register-closure.mjs` emits
  it as `JSON.stringify(closure, null, 4)` and its `--check` mode compares the committed file
  to that string with `current === body`. Formatting it (double → single quotes, 1140 lines)
  would put two gates in direct contradiction, and the next legitimate regeneration would
  silently revert the formatting and turn `oxfmt --check .` red. One file, one writer. Making
  the generator emit oxfmt-shaped output instead is the other defensible answer; it couples a
  byte-exact freshness gate to a formatter version, which is a trade worth its own change.

## What was reformatted, and how I know it is behaviour-preserving

14 files, in a **separate commit containing nothing but `oxfmt --write` output** — committed
*before* the config change, so `oxfmt --check .` is green at every commit rather than only at
the pair. Four independent proofs, not an assertion:

**1. AST equivalence, per file.** TypeScript-AST signatures of `git show HEAD:<file>` against
the new bytes, with exactly three normalisations and no others: parentheses are transparent,
string literals compare by cooked **value** (`'a'` == `"a"`), and a member name compares the
same quoted or bare (`quoteProps: "as-needed"`). Comments are not in the AST at all, so they
are compared separately as a multiset of whitespace-collapsed texts. All 14 identical —
e.g. `prebuild-artifacts.mjs` 2293 nodes / 126 comments, `resolve-npm/index.mjs` 1301 / 137.

A raw token stream is the wrong oracle here and I measured that first: `trailingComma: "all"`
legitimately **adds** `,` tokens and `singleQuote` rewrites literal text, so 12 of 14 files
"failed" a token comparison while changing nothing.

The comparator was then falsified in both directions on `prebuild-libc.mjs`:

| mutation | expected | exit |
|---|---|---|
| rename an identifier (`isGlibc` → `isGlibcX`) | RED | **1** |
| change a string's value (`'glibc'` → `'gLibc'`) | RED | **1** |
| swap `.some(` for `.every(` | RED | **1** |
| delete one comment line | RED | **1** |
| change only a quote style | GREEN | **0** |
| drop a trailing comma | GREEN | **0** |
| control, restored | GREEN | **0** |

The comment arm earned that mutation: a first version built the comment list with a bare
`createScanner` loop, and deleting a whole `//` line changed nothing in its output — a
context-free scan mis-tokenises these files' template literals badly enough to lose comments
wholesale. It now takes the ranges from the parsed tree, which raised the counts on 9 of the
14 files (`prebuild-libc.mjs` 32 → 62).

**2. A behavioural oracle, byte-for-byte.** `node scripts/audit-runtimes.mjs --check` prints
**40243 bytes, identical** before and after — and an ESM load hook confirms that run actually
executes **13 of the 14** files rather than merely importing something near them.
`check-node-test-registration`, `check-adwaita-conformance-drivers` and
`check-e2e-suite-coverage` are byte-identical too.

**3. The 14th file** is `resolve-npm/lib/index.d.ts`, which is never executed. `tsc --strict`
reports the same (empty) diagnostics on the pre and post bytes.

**4. Bundler output.** Both packages bundled with the pinned rolldown at `minify: true` are
**byte-identical** pre/post (resolve-npm 17729 B, manifest-conformance 72572 B). That also
settles the pre-commit hook's warning that `globals-map.mjs` might stale
`packages/infra/cli/dist/affected.gjs.mjs`: the hook's four-path heuristic fires, but the
committed bundle contains none of these files' content (0 hits for `jsdom`, `@gjsify/empty`,
`polling-xhr.node.js`, `prebuild-libc`, …), and it is minified with every string normalised
to backticks, so source formatting cannot reach it. `verify-committed-bundles.mjs` has
nothing to flag.

## Deliberate-defect results for the config change itself

| mutation | expected | exit | files walked |
|---|---|---|---|
| clean tree | GREEN | **0** | 3329 |
| `**/lib` put back — i.e. this PR reverted | GREEN | **0** | **3304** |
| an unformatted tracked source under the re-included `lib/` | RED | **1** | 3330 |
| the same bytes under a gitignored `lib/` with no `!lib/` | GREEN | **0** | 3329 |
| clean again | GREEN | **0** | 3329 |

Row 2 is the point: reverting this PR does not fail, it goes green having walked 25 fewer
files, and the file count is the only tell. Row 4 is the control that the fix did not
over-widen onto real build output.

## The guard: a follow-up, and not a second script

`scripts/check-lint-visibility.mjs` lands in #1369, not on `main`, so it is not in this tree.
**This PR adds no formatter arm, deliberately**, and the reason is not only the merge:

- Writing my own copy of that 314-line file means an add/add conflict with #1369 on every
  line of it, and two copies that diverge the moment #1369 takes review feedback.
- A separate `check-format-visibility.mjs` would be a second guard of the same shape deriving
  a neighbouring fact a second way — the thing this repository keeps paying for.
- **It cannot be a copy-paste arm anyway.** #1369's oracle pair is `oxlint --debug=files .`
  and `oxlint --debug=files --no-ignore <tracked paths>`. oxfmt 0.61.0 has **neither** flag,
  and `--ignore-path=<empty file>` does *not* switch `.gitignore` off for a directory walk
  (measured: the sandbox's `other/lib/output.mjs` stayed skipped). The only exact oxfmt oracle
  is the accepted-count bisection this PR's census used — 3131 invocations, ~7 minutes for
  4620 candidates. Whether CI affords that, or whether the arm should assert the **count**
  plus a named allowlist, is a design decision that deserves its own diff instead of being
  smuggled into a config fix.

So it is a follow-up once #1369 lands, and it starts from measurement rather than scratch:
the census above, the accepted-count oracle, and the post-fix blind set it must reproduce —
125 code files: 108 `tsc/lib`, 14 `templates`, `affected.gjs.mjs`, the `@types` shim, and
`register-globals-closure.mjs`.

## Relationship to #1369

**They merge cleanly, in either order, and the merged result is green** — verified rather
than assumed. `git merge-tree` of this branch against `refs/pull/1369/head` produces a tree
with no conflicts, and in that tree:

- `prebuild-libc.mjs` carries **both** #1369's `startsWith` rewrite and `const { os, arch }`
  **and** this branch's formatting; `runtime-aliases.mjs` has lost its unused
  `eslint-disable` as #1369 intended.
- `oxfmt --check .` → **0** (3330 files) and `oxlint .` → **0**.
- #1369's `check-lint-visibility.mjs`, run against this branch's reformatted sources with
  #1369's `.oxlintrc.json`, → **0**: *"3348 of 3479 lintable tracked file(s) are read by
  oxlint; the remaining 131 are declared across 8 exemption(s), each of which still matches."*

One follow-through for whoever merges second: `check-lint-visibility.mjs`'s header ends with
*"KNOWN, AND NOT FIXED HERE: `.oxfmtrc.json` carries the same `**/lib` line … 15 of them are
unformatted."* That paragraph is correct today and false the moment this lands. It should
become a pointer to the formatter arm that is still owed, not a description of an open hole.

## Mandatory checks

Each run from the worktree root, output redirected to a file, exit code read from `$?` and
never through a pipe:

| Check | Exit |
|---|---|
| `npx oxfmt --check .` | 0 |
| `npx oxlint .` | 0 |
| `node scripts/audit-runtimes.mjs --check` | 0 |
| `node scripts/check-node-test-registration.mjs` | 0 |
| `node scripts/check-adwaita-conformance-drivers.mjs` | 0 |
| `node scripts/check-e2e-suite-coverage.mjs` | 0 |

Also green: `check-comment-budget`, `check-workflow-inline-scripts`, `check-agent-context-size`,
`check-source-control-bytes`, `check-adr-index`, `check-doc-revert`, `check-doc-fences`. Both
touched packages declare `"check": "echo no TypeScript sources to check"`.

The pre-commit hook was **not** bypassed. It warned once, as documented for an unbuilt
worktree: it flagged `globals-map.mjs` as possibly staling `affected.gjs.mjs`, tried to
rebuild, and failed on the missing `packages/infra/cli/lib/index.js`. Proof 4 above is the
answer to that warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9HRKqQZskrYLVer1fuFvg
