### PR TITLE
feat(website): a gallery window per kind of implementation, and one markup

### DIFF
--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -35,12 +35,29 @@
 //      misspelled port is a snippet that is written, reviewed, committed and shown to
 //      nobody. Arms 1-4 cannot see it: the block has a title, the title has a meta,
 //      and the page is in the sidebar.
-//   6. Every port in `AdwWidget`'s `IMPLS` is provided by at least one block. The
-//      component renders a tab only for a slot a page actually gave it, so an entry
-//      nothing provides renders nowhere — a port declared to every reader of the
+//   6. Every port in `AdwWidget`'s {@link WINDOWS} is provided by at least one block.
+//      The component renders a tab only for a slot a page actually gave it, so an
+//      entry nothing provides renders nowhere — a port declared to every reader of the
 //      component and shipped to none of them. The two arms are each other's inverse:
 //      5 refuses a page naming a port the component has not got, 6 refuses a component
 //      naming a port no page has got.
+//   7. Every WINDOW has at least one tab, and at least one tab some block provides. A
+//      window is a header bar, a title and a subtitle around its tabs; declared with an
+//      empty `tabs` list it renders that chrome over nothing, on all 40 blocks, and arm
+//      6 cannot see it because there is no slot to be unprovided. Same class as 6, one
+//      level up — the level the restructure added.
+//   8. Every block providing the MARKUP OVERRIDE is ledgered in
+//      {@link MARKUP_OVERRIDE_LEDGER} with its reason, and every ledger entry names a
+//      block that provides it.
+//
+//      This is the arm that keeps the preview/markup unification honest. A block's
+//      `preview` fence is BOTH what mounts and what is shown, so for 39 of 40 blocks
+//      there is no second copy to drift. The override is the exception, and an
+//      exception nothing counts is how the rule was lost the first time: the `web`
+//      fence used to stand beside every preview saying the same thing, and measured
+//      across the 40 blocks 17 were byte-identical and 23 had already diverged, with
+//      nothing checking either way. One policed copy, named and reasoned, is the price
+//      of the widget whose API is imperative; a second one has to say why.
 //
 // The `title` IS the join: `Adw.ViewSwitcherBar` → `view-switcher-bar`, the same
 // bare name the widget files, the story metas and the ledgers are already spelled
@@ -143,24 +160,45 @@ function widgetBlocks(root, pages) {
 const WIDGET_COMPONENT = 'website/src/components/AdwWidget.astro';
 
 /**
- * The slots `AdwWidget` reads, split into the PORTS it renders a tab for and the
- * ones it renders some other way (`preview`, which is a live web component rather
- * than a snippet).
+ * Blocks whose `preview` fence is NOT the markup a reader should copy, so the
+ * component shows a hand-written `web` fragment on that tab instead — and why.
  *
- * Both are read out of the component for the same reason the widget title is
- * derived rather than tabled: a second hand-written list is the thing that drifts,
- * and this one would drift in the more expensive direction — a port named here and
- * absent from `IMPLS` would make this gate bless a tab that never renders.
+ * The bar is high on purpose. Every other block has ONE markup: the fence that the
+ * live preview mounts is the fence the tab shows, so there is nothing to keep in
+ * step. An entry here restores exactly the two-copies-one-hand arrangement that
+ * left 23 of 40 blocks quietly disagreeing with their own preview, and it earns
+ * that only where the widget cannot be expressed as markup at all.
  */
-function componentSlots(root) {
+const MARKUP_OVERRIDE_LEDGER = {
+    'Adw.Toast':
+        "`<adw-toast-overlay>` has no declarative toast child — `addToast()` is the whole API — so the markup that PAINTS a toast in a static preview is the overlay's own internal DOM (`.adw-toast.visible` and friends), which is the one thing a reader must not copy. The preview depicts the result; the tab teaches the call.",
+};
+
+/**
+ * The window model `AdwWidget` renders: each window's id and the tab slots under it,
+ * plus the one slot that is an override rather than a tab.
+ *
+ * Read out of the component for the same reason the widget title is derived rather
+ * than tabled: a second hand-written list is the thing that drifts, and this one
+ * would drift in the more expensive direction — a port named here and absent from
+ * `WINDOWS` would make this gate bless a tab that never renders.
+ */
+function componentWindows(root) {
     const text = readFileSync(join(root, WIDGET_COMPONENT), 'utf8');
-    const impls = /\bconst IMPLS = \[([\s\S]*?)\n\];/.exec(text);
-    const ports = impls === null ? [] : [...impls[1].matchAll(/\bslot:\s*'([a-z][a-z0-9-]*)'/g)].map(([, s]) => s);
-    const others = [
-        ...text.matchAll(/Astro\.slots\.has\('([a-z][a-z0-9-]*)'\)/g),
-        ...text.matchAll(/<slot name="([a-z][a-z0-9-]*)"/g),
-    ].map(([, s]) => s);
-    return { ports: new Set(ports), others: new Set(others) };
+    const decl = /\bconst WINDOWS = \[([\s\S]*?)\n\];/.exec(text);
+    const windows = [];
+    if (decl !== null) {
+        // Split on the `id:` that opens each window, so every `slot:` between two ids
+        // belongs to the window it follows. `split` with one capture group yields
+        // [preamble, id, chunk, id, chunk, …].
+        const parts = decl[1].split(/\bid:\s*'([a-z][a-z0-9-]*)',/);
+        for (let i = 1; i < parts.length; i += 2) {
+            const slots = [...parts[i + 1].matchAll(/\bslot:\s*'([a-z][a-z0-9-]*)'/g)].map(([, s]) => s);
+            windows.push({ id: parts[i], slots });
+        }
+    }
+    const override = /\bconst MARKUP_OVERRIDE = '([a-z][a-z0-9-]*)';/.exec(text);
+    return { windows, override: override === null ? null : override[1] };
 }
 
 /** Where the site's navigation is hand-written, and how a page is spelled in it. */
@@ -267,13 +305,22 @@ for (const page of pages) {
     );
 }
 
-// --- the tab arms: what a page provides against what the component renders ---
+// --- the window/tab arms: what a page provides against what the component renders ---
 
-const { ports, others } = componentSlots(ROOT);
-if (ports.size === 0) {
+const { windows, override } = componentWindows(ROOT);
+const ports = new Set(windows.flatMap((w) => w.slots));
+if (windows.length === 0 || ports.size === 0) {
     console.error(
-        `check-website-adwaita-gallery: no port found in the IMPLS array of ${WIDGET_COMPONENT} — that is\n` +
-            '  a broken scan, not a component with no tabs. Nothing is unprovided in an empty set.',
+        `check-website-adwaita-gallery: no window or no port found in the WINDOWS array of\n` +
+            `  ${WIDGET_COMPONENT} — that is a broken scan, not a component with no tabs. Nothing is\n` +
+            '  unprovided in an empty set, and no window is dead in one either.',
+    );
+    process.exit(1);
+}
+if (override === null) {
+    console.error(
+        `check-website-adwaita-gallery: no MARKUP_OVERRIDE declared in ${WIDGET_COMPONENT}. Without it\n` +
+            '  the override slot reads as an unknown one, and arm 8 would police an empty set.',
     );
     process.exit(1);
 }
@@ -288,18 +335,23 @@ if (blocks.length === 0) {
 }
 
 const provided = new Set();
+/** The blocks that override the preview window's markup tab — arm 8's input. */
+const overriding = new Map();
 for (const block of blocks) {
     for (const [, slot] of block.body.matchAll(/<Fragment slot="([^"]+)"/g)) {
         if (ports.has(slot)) {
             provided.add(slot);
             continue;
         }
-        if (others.has(slot)) continue;
+        if (slot === override) {
+            overriding.set(block.title, block.page);
+            continue;
+        }
         failures.push(
             `${block.page}: <AdwWidget title="${block.title}"> provides a "${slot}" fragment, and AdwWidget\n` +
                 '    renders no slot of that name. Astro drops an unmatched slot in SILENCE — no warning, no\n' +
                 '    build failure — so the snippet is written, reviewed, committed and shown to nobody.\n' +
-                `    Ports: ${[...ports].join(', ')}. Other slots: ${[...others].join(', ')}.`,
+                `    Ports: ${[...ports].join(', ')}. Markup override: ${override}.`,
         );
     }
 }
@@ -307,10 +359,51 @@ for (const block of blocks) {
 for (const port of ports) {
     if (provided.has(port)) continue;
     failures.push(
-        `${WIDGET_COMPONENT} declares the port "${port}" in IMPLS, and no <AdwWidget> block under\n` +
+        `${WIDGET_COMPONENT} declares the port "${port}" in WINDOWS, and no <AdwWidget> block under\n` +
             `    ${GALLERY} provides it. The component renders a tab only where a page gave it that slot, so\n` +
             '    the entry renders nowhere at all: a port declared to every reader of the component and\n' +
             '    shipped to none of them. Write the first snippet, or drop the entry.',
+    );
+}
+
+for (const window of windows) {
+    if (window.slots.length === 0) {
+        failures.push(
+            `${WIDGET_COMPONENT} declares the window "${window.id}" with no tabs at all. A window is a\n` +
+                '    header bar, a title and a subtitle around its tabs, so an empty one renders that chrome\n' +
+                '    over nothing on every block — and arm 6 cannot see it, because there is no slot to be\n' +
+                '    unprovided. Give it a tab, or drop the window.',
+        );
+        continue;
+    }
+    if (window.slots.some((slot) => provided.has(slot))) continue;
+    failures.push(
+        `${WIDGET_COMPONENT} declares the window "${window.id}" (${window.slots.join(', ')}), and no\n` +
+            `    <AdwWidget> block under ${GALLERY} provides any of its tabs. The window renders nowhere:\n` +
+            '    a kind of implementation announced to every reader of the component and shown to none.',
+    );
+}
+
+// --- arm 8: the markup override, and the reason it is allowed to exist ---
+
+for (const [title, page] of overriding) {
+    if (title in MARKUP_OVERRIDE_LEDGER) continue;
+    failures.push(
+        `${page}: <AdwWidget title="${title}"> provides a "${override}" fragment, which OVERRIDES the\n` +
+            "    markup tab of its own live preview. That is a second copy of the widget's markup, kept by\n" +
+            '    hand, next to the one that actually renders — the arrangement that left 23 of 40 blocks\n' +
+            '    disagreeing with their own preview. Delete it and let the preview fence be the tab, or add\n' +
+            `    "${title}" to MARKUP_OVERRIDE_LEDGER in this script with the reason it cannot be.`,
+    );
+}
+
+for (const title of Object.keys(MARKUP_OVERRIDE_LEDGER)) {
+    if (overriding.has(title)) continue;
+    failures.push(
+        `${title}: ledgered in MARKUP_OVERRIDE_LEDGER as needing a "${override}" fragment, and no block\n` +
+            '    under ' +
+            `${GALLERY} provides one. A stale exemption reads as considered when it is merely\n` +
+            '    forgotten, and this one would license the next hand-kept copy.',
     );
 }
 
@@ -332,7 +425,8 @@ console.log(
         `${exempt} ledgered with a reason.`,
 );
 console.log(
-    `check-website-adwaita-gallery: ${ports.size} port(s) in ${WIDGET_COMPONENT} — ` +
-        `${[...ports].join(', ')} — each provided by at least one of ${blocks.length} blocks, and every ` +
-        'fragment slot they write is one the component renders.',
+    `check-website-adwaita-gallery: ${windows.length} window(s) in ${WIDGET_COMPONENT} — ` +
+        `${windows.map((w) => `${w.id} [${w.slots.join(' ')}]`).join(', ')} — each with a tab at least one ` +
+        `of ${blocks.length} blocks provides, every fragment slot they write is one the component renders, ` +
+        `and ${overriding.size} block(s) override the markup tab, all ledgered.`,
 );

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -618,16 +618,23 @@ A/B-proven, and the slot rule proven in BOTH directions (a web-only glyph fails 
 it, and the honest answer for each is different:
 
 - **Whether a preview is INTERACTIVE.** `navigation.mdx` says "click **Open contact**
-  to push the detail page" and "the button underneath to bring it back"; the first
-  button carries no handler and `<adw-button>` has no action attribute, and the second
-  reads `data-adw-toggle-open`, which NOTHING in the repository reads — one grep hit,
-  the doc itself. Both need a browser to see, so no cheap static gate exists. The
-  storybook wires the first in JS (`navigation-view.web.ts:63-65`) and that line was
-  dropped when the sample was written.
-- **Whether four tabs build the SAME widget set.** A per-`<AdwWidget>` reader could
-  compare the tag/class set each of the four fences constructs and demand a ledger
-  line for a difference — that catches the counts (the Preferences Group block builds
-  three rows in two tabs and two in three) but not semantics: nothing static sees that
+  to push the detail page"; the button carries no handler and `<adw-button>` has no
+  action attribute. It needs a browser to see, so no cheap static gate exists. The
+  storybook wires it in JS (`navigation-view.web.ts:63-65`) and that line was dropped
+  when the sample was written. The bottom sheet's "Toggle sheet" button had the same
+  shape plus a `data-adw-toggle-open` attribute NOTHING in the repository read — one
+  grep hit, the doc itself — and that one is gone: the preview markup is now the
+  snippet, so a dead attribute would have been shipped to every reader who copied the
+  tab, and it was deleted rather than documented.
+- **Whether the remaining surfaces build the SAME widget set.** The `web` fence is
+  gone — the preview's own markup is what the browser window shows, so preview and
+  markup can no longer disagree, and `check-website-adwaita-gallery.mjs` arm 8 refuses
+  a second copy unless it is ledgered (one is: `Adw.Toast`). What is left is the four
+  remaining surfaces: markup, `@girs` TypeScript, Blueprint, NativeScript. A
+  per-`<AdwWidget>` reader could compare the tag/class set each fence constructs and
+  demand a ledger line for a difference — that catches the counts (the Preferences
+  Group block builds three rows in its markup and its Blueprint, two in its TypeScript
+  and its NativeScript) but not semantics: nothing static sees that
   `Adw.Clamp { maximumSize: 400 }` under a child with `widthRequest: 520` cannot
   demonstrate clamping, because the child's own minimum raises all three thresholds
   to 520.

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -1,44 +1,75 @@
 ---
 // AdwWidget — the documentation block for a single Adwaita component.
 //
-// Renders, top to bottom:
-//   1. A LIVE PREVIEW panel — the real widget rendered with
-//      @gjsify/adwaita-web custom elements on an Adwaita "view" surface. No
-//      screenshots: the browser paints the actual component, exactly like the
-//      official Libadwaita widget gallery shows one, and it follows the site's
-//      light/dark theme toggle.
-//   2. A WINDOW with IMPLEMENTATION TABS — one Adw.TabBar tab per port, each
-//      holding that port's code snippet. Native GJS is the primary
-//      implementation and always comes first; the rest are additional and
-//      optional. {@link IMPLS} is the list, and it is the one place a port is
-//      declared: `scripts/check-website-adwaita-gallery.mjs` holds it against the
-//      pages in both directions.
+// Renders a COLUMN OF WINDOWS, one per KIND of implementation, because the kind
+// is the distinction a reader cannot recover on their own:
 //
-// The tab window mirrors CommandTabs (the runtime tabs used elsewhere): an
-// Adwaita headerbar with a centered title + copy button, an <adw-tab-view>
-// below it, and the active tab's Expressive Code block beneath. The copy
-// button forwards to the active block's hidden EC copy button, so EC's
-// clipboard handling + the Adwaita toast keep working. The chosen
-// implementation is remembered (localStorage) and synced across every
-// AdwWidget on the site: pick "Web" once and all widget snippets follow.
+//   1. LIVE PREVIEW — the real widget, painted by @gjsify/adwaita-web custom
+//      elements on an Adwaita "view" surface, with the markup that paints it as
+//      the window's one tab. No screenshots: the browser runs the component, the
+//      way the official Libadwaita widget gallery shows one, and it follows the
+//      site's light/dark toggle.
+//   2. VANILLA TYPESCRIPT — `@girs` GObject-Introspection TypeScript and the
+//      matching Blueprint declaration: two FILES of one program, against the REAL
+//      libadwaita widget.
+//   3. UI FRAMEWORKS — that same real widget, driven through `@gjsify/gtk-host`.
+//   4. NATIVESCRIPT — the port that runs on a phone.
 //
-// Feed the snippets as named MDX slots (one fenced code block each). A tab
-// appears only where its slot was given, so a port that cannot express THIS
-// widget simply has no tab on it:
+// It used to be ONE window with those five as sibling tabs, and five siblings
+// cannot say any of it: `gjs`/`blueprint` ARE libadwaita, `web` and
+// `nativescript` are REIMPLEMENTATIONS of it, and a framework tab drives the real
+// one. A window can say it, in its title and its subtitle. {@link WINDOWS} is
+// that model and it is the one place a port is declared —
+// `scripts/check-website-adwaita-gallery.mjs` holds it against the pages in both
+// directions, and refuses a window no page fills.
+//
+// TWO CLAIMS THAT MOVED RATHER THAN DIED, both load-bearing:
+//
+//   · The first tab was labelled "GJS · Node · Bun · Deno" and not "GJS" on
+//     purpose: naming one runtime made the tab read as "the GJS variant", i.e. as
+//     if the other three needed a different program. They do not; that is the
+//     claim the whole site rests on. The window holding it is titled for its AXIS
+//     ("Vanilla TypeScript" — what two file tabs share), so the four runtimes are
+//     named in its SUBTITLE. Do not drop them from it.
+//   · "React Native on GTK" carried its qualifier in the tab LABEL, because a
+//     plain "React Native" standing beside Web and NativeScript would have read as
+//     the port that runs on a phone — the one claim this repository must not make
+//     about code it has not written. NativeScript is its own window now, so the
+//     qualifier moved onto the window: "UI frameworks · on GTK, through
+//     @gjsify/gtk-host". Same claim, said once, covering every framework tab the
+//     window will grow.
+//
+// The header bar sits above BOTH panes of the preview window for the reason it
+// was put there: whatever a header bar sits on is what the reader takes the
+// window to be about. It once held the widget TITLE over a pane of code, and the
+// title read as belonging to the code. So the window carrying the widget's title
+// is the one that RUNS the widget, and every other window is titled for its kind.
+//
+// ONE SOURCE FOR THE MARKUP. The `preview` slot is a fenced ```html block: the
+// window SHOWS that fence (Expressive Code, exactly as authored) and MOUNTS it.
+// It used to be a fragment of MDX markup with a second, hand-kept `web` fence
+// beside it saying the same thing — measured across the 40 blocks, 17 were
+// byte-identical and 23 had already drifted, and nothing checked them. The drift
+// was not cosmetic: `Adw.ToolbarView`'s preview carried a sizing wrapper its
+// snippet omitted, `Adw.Carousel`'s snippet was a different document from the one
+// the page renders, and eight rows previewed inside an `<adw-preferences-group>`
+// their snippet dropped. A reader copying the tab often did not get the widget
+// above it. One fence renders and is shown, so there is no second copy to keep.
+//
+// Feed the rest as named MDX slots (one fenced code block each). A tab appears
+// only where its slot was given, and a WINDOW only where at least one of its tabs
+// did, so a port that cannot express THIS widget simply has no tab, and a kind
+// with nothing to say has no window:
 //
 //   <AdwWidget title="Adw.SwitchRow">
-//     <Fragment slot="preview">
-//       <adw-preferences-group>
-//         <adw-switch-row title="Automatic updates" active></adw-switch-row>
-//       </adw-preferences-group>
-//     </Fragment>
+//     <Fragment slot="preview">```html …```</Fragment>
 //     <Fragment slot="gjs">```ts …```</Fragment>
-//     <Fragment slot="web">```ts …```</Fragment>
+//     <Fragment slot="blueprint">```blueprint …```</Fragment>
 //     <Fragment slot="nativescript">```ts …```</Fragment>
 //   </AdwWidget>
 
 interface Props {
-    /** Title shown centered in the tab-window headerbar, e.g. "Adw.SwitchRow". */
+    /** The widget, e.g. "Adw.SwitchRow". Titles the live-preview window. */
     title?: string;
     /**
      * Padding around the preview widget. Use "flush" for widgets that own their
@@ -49,6 +80,23 @@ interface Props {
     /** When set, the preview panel scrolls horizontally instead of clipping wide widgets. */
     scroll?: boolean;
     /**
+     * Inline CSS for the preview STAGE — the box the widget is mounted into.
+     *
+     * This is preview-only scaffolding, and it is a prop precisely so that it
+     * cannot be anything else. A widget that fills a window (a toolbar view, a
+     * split view, a dialog) has no height of its own, so the gallery gives it one;
+     * that height is a property of this PANEL, not of the widget, and every line
+     * of it that sat in the markup was a line the reader copied and did not need.
+     * Sixteen blocks wrapped their widget in a `<div style="height: …">` for it —
+     * five then repeated the wrapper in their snippet and eleven did not, which is
+     * the whole drift in one habit.
+     *
+     * Taken VERBATIM from the wrapper it replaces (`height: 340px; width: 100%;
+     * display: flex; overflow: hidden;`) so the computed layout is unchanged: it
+     * is an inline style on the element that wrapper's parent already was.
+     */
+    stage?: string;
+    /**
      * Canonical upstream reference for this widget. Omit to derive it from an
      * `Adw.*` / `Gtk.*` `title` (libadwaita / GTK 4 class docs); pass a URL for a
      * title that isn't a single class, or `false` to suppress the link.
@@ -57,8 +105,9 @@ interface Props {
 }
 
 import { ADWAITA_ATTRIBUTES } from '../data/adwaita-attributes';
+import AdwWidgetWindow from './AdwWidgetWindow.astro';
 
-const { title = 'Code', padding = 'comfortable', scroll = false, docHref } = Astro.props;
+const { title = 'Code', padding = 'comfortable', scroll = false, stage, docHref } = Astro.props;
 
 // Derive the upstream class-reference URL from a `Namespace.ClassName` title, so
 // each widget links to its canonical docs (the sources this gallery documents).
@@ -92,134 +141,157 @@ const elementTag = `adw-${title
     .toLowerCase()}`;
 const attributes = ADWAITA_ATTRIBUTES[elementTag] ?? null;
 
-// GJS is the primary implementation and always present; Web + NativeScript are
-// additional. Render only the slots that were actually provided.
-const IMPLS = [
-    // NOT "GJS". The snippet is plain `@girs/*` GObject-Introspection TypeScript,
-    // which is exactly the code that runs unchanged on all four runtimes — naming
-    // one of them made the tab read as "the GJS variant", i.e. as if the other
-    // three needed a different program. They do not; that is the claim the whole
-    // site rests on, so the tab that demonstrates it has to say so.
-    { slot: 'gjs', label: 'GJS · Node · Bun · Deno' },
-    // Blueprint sits next to GJS because it describes the SAME native widget
-    // tree — it is how a GTK UI is usually written, with the GJS side reduced to
-    // wiring. Web and NativeScript are the ports and follow.
-    //
-    // The tab holds the DECLARATION only, deliberately: a `.blp` file is a
-    // widget tree and nothing else, and padding it with a loader would make it
-    // look like a fourth complete program rather than the thing it is.
-    { slot: 'blueprint', label: 'Blueprint' },
-    // "on GTK" is load-bearing, not a decoration. `@gjsify/react-native` renders
-    // React Native components onto GTK 4 IN-PROCESS; there is no Adwaita widget set
-    // built out of React Native primitives, so nothing in this tab runs on a phone.
-    // A tab labelled plainly "React Native" beside Web and NativeScript would read
-    // as the port that does, which is the one claim this repository must not make
-    // about code it has not written.
-    //
-    // It sits third, with the two GTK tabs, because that is what it targets: `@girs`
-    // TypeScript, Blueprint and this all describe the SAME native widget tree, and
-    // Web and NativeScript are the ports away from it. The snippet is JSX over
-    // gtk-host's own Adwaita tags with React Native primitives inside them, so a
-    // widget can only carry this tab where gtk-host has a curated child policy for
-    // it — see the Layout page for the two there that have none, and why.
-    { slot: 'react-native', label: 'React Native on GTK' },
-    { slot: 'web', label: 'Web' },
-    { slot: 'nativescript', label: 'NativeScript' },
+/**
+ * The windows, in order, and every port this component renders.
+ *
+ * `subtitle` is not decoration: it is where a window says what KIND it is, and
+ * two of them carry a claim that used to live in a tab label (see the header).
+ */
+const WINDOWS = [
+    {
+        id: 'preview',
+        // No title of its own: this window takes the WIDGET's, because it is the
+        // one that runs the widget. See the header — a header bar names whatever
+        // it sits on, and this one sits on the running component.
+        title: null,
+        subtitle: '@gjsify/adwaita-web — import it once to register these elements',
+        // The pane above the tabs, where the tab's own markup is mounted and painted.
+        live: true,
+        tabs: [{ slot: 'preview', label: 'HTML' }],
+    },
+    {
+        id: 'vanilla',
+        title: 'Vanilla TypeScript',
+        // The four runtimes, verbatim from the tab label this window replaced. The
+        // snippet is plain `@girs/*` GObject-Introspection TypeScript, which is
+        // exactly the code that runs unchanged on all four of them.
+        subtitle: 'GJS · Node · Bun · Deno — one program, four runtimes',
+        tabs: [
+            { slot: 'gjs', label: 'TypeScript' },
+            // Blueprint is a FILE of the same program, which is why it is a tab here
+            // and not a window of its own: a `.blp` is a widget tree and nothing
+            // else, and the TypeScript beside it is the loader that mounts it.
+            // Standing alone it read as a fourth complete program, which it is not.
+            { slot: 'blueprint', label: 'Blueprint' },
+        ],
+    },
+    {
+        id: 'frameworks',
+        title: 'UI frameworks',
+        // `@gjsify/react-native` renders React Native components onto GTK 4
+        // IN-PROCESS. There is no Adwaita widget set built out of React Native
+        // primitives, so nothing under this window runs on a phone — which is why
+        // it is not filed with NativeScript, and why the window says GTK.
+        subtitle: 'on GTK, through @gjsify/gtk-host',
+        tabs: [{ slot: 'react-native', label: 'React Native' }],
+    },
+    {
+        id: 'nativescript',
+        title: 'NativeScript',
+        subtitle: '@gjsify/adwaita-nativescript — the port that runs on a phone',
+        tabs: [{ slot: 'nativescript', label: 'TypeScript' }],
+    },
 ];
 
-const present: { slot: string; label: string; html: string }[] = [];
-for (const impl of IMPLS) {
-    if (Astro.slots.has(impl.slot)) {
-        present.push({ ...impl, html: await Astro.slots.render(impl.slot) });
+/**
+ * The one slot that is an OVERRIDE rather than a tab: markup shown in place of the
+ * preview window's own fence.
+ *
+ * It exists for a single widget and the gate holds it there with its reason:
+ * `<adw-toast-overlay>` has no declarative toast child — `addToast()` is the whole
+ * API — so the markup that PAINTS a toast in a preview is the overlay's internal
+ * DOM, which is the one thing a reader must not copy. Everywhere else the fence
+ * that renders is the fence that is shown, and there is no second copy to keep.
+ */
+const MARKUP_OVERRIDE = 'web';
+
+/** U+007F — Expressive Code's own stand-in for a newline inside `data-code`. */
+const EC_NEWLINE = String.fromCharCode(0x7f);
+
+/**
+ * Expressive Code hands the raw source back on the copy button's `data-code`, with
+ * newlines as U+007F (its own copy script does the same `replace`). That is how the
+ * live preview gets the fence's bytes: rendered once, shown as code and mounted as
+ * markup.
+ *
+ * Only NUMERIC entities are decoded, in one pass. EC escapes `&` as `&#x26;` and
+ * leaves `<` raw, so `&#x26;lt;` is a literal `&lt;` in the source — decoding named
+ * entities as well would turn it into `<` and quietly rewrite the author's markup.
+ * `String.replace` never rescans what it substitutes, which is what makes one pass
+ * exact.
+ */
+const decodeEcCode = (html: string): string | null => {
+    const found = [...html.matchAll(/data-code="([^"]*)"/g)];
+    if (found.length !== 1) return null;
+    return found[0][1]
+        .replaceAll(EC_NEWLINE, '\n')
+        .replaceAll(/&#x([0-9a-fA-F]+);/g, (_m, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+        .replaceAll(/&#(\d+);/g, (_m, dec: string) => String.fromCodePoint(Number(dec)));
+};
+
+const rendered: {
+    id: string;
+    title: string;
+    subtitle: string;
+    live: boolean;
+    impls: string;
+    tabs: { slot: string; label: string; html: string }[];
+}[] = [];
+let previewMarkup: string | null = null;
+
+for (const spec of WINDOWS) {
+    const tabs: { slot: string; label: string; html: string }[] = [];
+    for (const tab of spec.tabs) {
+        if (!Astro.slots.has(tab.slot)) continue;
+        let html = await Astro.slots.render(tab.slot);
+        if (tab.slot === 'preview') {
+            previewMarkup = decodeEcCode(html);
+            if (previewMarkup === null) {
+                // Loud, at build time, never at runtime: without the source there is
+                // no preview, and a silently empty stage on 40 blocks is exactly the
+                // failure this component was restructured to end.
+                throw new Error(
+                    `AdwWidget(${title}): the preview slot rendered no single Expressive Code block to read ` +
+                        'its markup back from. It has to hold exactly one fenced ```html block.',
+                );
+            }
+            // The one override: the markup a reader should copy, where the fence
+            // that renders is not it.
+            if (Astro.slots.has(MARKUP_OVERRIDE)) html = await Astro.slots.render(MARKUP_OVERRIDE);
+        }
+        tabs.push({ ...tab, html });
     }
+    if (tabs.length === 0) continue;
+    rendered.push({
+        id: spec.id,
+        title: spec.title ?? title,
+        subtitle: spec.subtitle,
+        live: spec.live === true,
+        impls: tabs.map((t) => t.slot).join(','),
+        tabs,
+    });
 }
-const implsAttr = present.map((r) => r.slot).join(',');
-const hasPreview = Astro.slots.has('preview');
 ---
 
-{/* ONE window, shaped like a GNOME Workbench session: the header bar names the
-    widget, the pane under it RUNS it, and the editor tabs below hold the source
-    for each port.
-
-    It used to be two stacked cards — a free-floating preview, then a separate
-    Adwaita window for the code — and the header bar sat on the second one. So the
-    title read as belonging to the CODE rather than to the widget, and the pair
-    never fused: whatever a header bar sits on is what the reader takes the window
-    to be about. Putting it above BOTH panes is the whole fix. */}
+{/* One window per KIND, each shaped like a GNOME Workbench session. The first
+    names the WIDGET and runs it; the rest name what they are. */}
 <div class="adw-widget">
-    <div class="command-tabs adw-widget-window not-content" data-impl-tabs data-impls={implsAttr}>
-        <div class="command-tabs-headerbar">
-            <span class="command-tabs-headerbar-start">
-                {
-                    refHref && (
-                        <a
-                            class="command-tabs-ref"
-                            href={refHref}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            title={`Reference for ${title}`}
-                            aria-label={`Open the reference for ${title} in a new tab`}
-                        >
-                            <span class="command-tabs-ref-icon" aria-hidden="true" />
-                        </a>
-                    )
-                }
-            </span>
-            <span class="command-tabs-headerbar-title">{title}</span>
-            <span class="command-tabs-headerbar-end">
-                <button class="command-tabs-copy" aria-label="Copy active tab" type="button">
-                    <span class="command-tabs-copy-icon" aria-hidden="true"></span>
-                </button>
-            </span>
-        </div>
-
-        {
-            hasPreview && (
-                <div
-                    class:list={[
-                        'adw-widget-preview',
-                        'not-content',
-                        `is-${padding}`,
-                        { 'is-scroll': scroll },
-                    ]}
-                >
-                {/* `not-content` for the same reason CommandTabs.astro states it,
-                    and it was missing HERE while the tabs below already carried
-                    it. Starlight gives every content element that FOLLOWS a
-                    sibling a `margin-top: 1rem`, exempting only
-                    `:where(.not-content *)`. Inside a preview that lands on the
-                    widgets: measured on the deployed page, the second button of
-                    a wrap box and every one after it took `margin-top: 16px`
-                    while the first took none — and in a flex line the first then
-                    STRETCHED by exactly that much, 50px against its siblings'
-                    34px. The same rule pushed a header bar's trailing button
-                    below its own title and set the two panes of a split view
-                    onto baselines 16px apart, which clipped the sidebar's last
-                    row. A preview is a rendering of a widget, not prose: it has
-                    to be laid out by the widget's own stylesheet alone. */}
-                {/* The preview is cloned into the stage at runtime (see <script>),
-                    not server-rendered directly, for two reasons:
-                    1. adwaita-web custom elements upgrade as the page is parsed;
-                       a nested composite (a split view holding toolbar views) can
-                       lose its slotted children to an upgrade-order race. Cloning
-                       AFTER the elements are defined uses the reliable
-                       build-then-attach path instead.
-                    2. Astro's MDX compiler strips `slot="…"` attributes (it reads
-                       `slot` as its own slot-assignment directive), so the preview
-                       markup carries `data-adw-slot="…"`; the script maps it back
-                       to a real `slot` before attaching. */}
-                    <template class="adw-widget-preview-tpl">
-                        <slot name="preview" />
-                    </template>
-                    <div class="adw-widget-preview-stage" />
-                </div>
-            )
-        }
-
-        <adw-tab-view no-close expand-tabs data-impl-view>
-            {present.map((r) => <adw-tab-page title={r.label} set:html={r.html} />)}
-        </adw-tab-view>
-    </div>
+    {
+        rendered.map((win, index) => (
+            <AdwWidgetWindow
+                title={win.title}
+                subtitle={win.subtitle}
+                refHref={index === 0 ? refHref : null}
+                widget={title}
+                impls={win.impls}
+                tabs={win.tabs}
+                preview={win.live ? previewMarkup : null}
+                padding={padding}
+                scroll={scroll}
+                stage={stage}
+            />
+        ))
+    }
 
     {
         attributes && attributes.length > 0 && (
@@ -248,20 +320,14 @@ const hasPreview = Astro.slots.has('preview');
     import '@gjsify/adwaita-web';
 
     // Mount each preview: clone its inert <template> into the stage now that the
-    // custom elements are defined, mapping data-adw-slot back to the real slot
-    // attribute. Building the subtree and attaching it in one go (rather than
-    // letting the parser upgrade it in place) avoids the nested-composite
-    // upgrade-order race, and data-adw-slot survives Astro's slot stripping.
+    // custom elements are defined. Building the subtree and attaching it in one go
+    // (rather than letting the parser upgrade it in place) avoids the
+    // nested-composite upgrade-order race.
     for (const tpl of document.querySelectorAll<HTMLTemplateElement>('.adw-widget-preview-tpl')) {
         const stage = tpl.parentElement?.querySelector<HTMLElement>('.adw-widget-preview-stage');
         if (!stage || stage.dataset.mounted) continue;
         stage.dataset.mounted = '1';
-        const frag = tpl.content.cloneNode(true) as DocumentFragment;
-        for (const el of frag.querySelectorAll<HTMLElement>('[data-adw-slot]')) {
-            el.setAttribute('slot', el.getAttribute('data-adw-slot') ?? '');
-            el.removeAttribute('data-adw-slot');
-        }
-        stage.append(frag);
+        stage.append(tpl.content.cloneNode(true));
     }
 
     const KEY = 'gjsify-preferred-impl';
@@ -277,6 +343,9 @@ const hasPreview = Astro.slots.has('preview');
             if (!view || view === skip) continue;
             const impls = (el.dataset.impls ?? '').split(',');
             const index = impls.indexOf(impl);
+            // The windows hold disjoint tab sets, so a stored choice simply does not
+            // apply to most of them: picking "Blueprint" moves every Vanilla
+            // TypeScript window and leaves the others where the reader left them.
             if (index >= 0) view.setAttribute('selected', String(index));
         }
     };
@@ -338,8 +407,42 @@ const hasPreview = Astro.slots.has('preview');
         margin-top: 1.5rem;
     }
 
+    /* One window per kind, stacked. They are separate windows, so they are spaced
+       like windows rather than joined like the two panes of the first one. */
+    .adw-widget-window + .adw-widget-window {
+        margin-top: 0.75rem;
+    }
+
+    /* ── Window title + subtitle — an Adw.WindowTitle in the header bar. The
+          subtitle is where a window says what KIND it holds, which is the whole
+          reason there is more than one window (see the header comment). ── */
+    .command-tabs .command-tabs-headerbar-title {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        line-height: 1.2;
+        min-width: 0;
+    }
+
+    .adw-widget-window-title {
+        font-weight: bold;
+        font-size: 0.875rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .adw-widget-window-subtitle {
+        font-size: 0.7rem;
+        font-weight: normal;
+        opacity: 0.55;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
     /* ── Live preview pane ──────────────────────────────────────────────
-       The window's upper pane: an Adwaita "view" surface the real widget is
+       The first window's upper pane: an Adwaita "view" surface the real widget is
        painted onto, directly under the header bar. It carries no frame of its
        own — the window around it owns every edge — only the separator that
        divides it from the editor tabs below, the way a paned split does. */
@@ -369,6 +472,9 @@ const hasPreview = Astro.slots.has('preview');
         transform: translateZ(0);
     }
 
+    /* The box the widget is mounted into. The `stage` prop adds an inline style
+       here: the size a doc page has to give a widget that has none, kept out of
+       the markup the reader copies. */
     .adw-widget-preview-stage {
         display: flex;
         align-items: center;
@@ -390,15 +496,15 @@ const hasPreview = Astro.slots.has('preview');
         overflow-x: auto;
     }
 
-    /* The preview is a PANE now, inside the window, so there is no second card
+    /* The preview is a PANE, inside the first window, so there is no second card
        whose corners have to be squared off to fake a join. */
 
     /* Narrow viewports: stop stretching the tabs to equal widths and let the bar
        scroll instead — which is what Adw.TabBar itself does when its tabs no
        longer fit. Equal widths on a phone gave each of four tabs about 80px, and
-       "GJS · Node · Bun · Deno" then ellipsises down to something that names
-       nothing. The bar already has `overflow-x: auto`; it just needs tabs that
-       keep their own width. */
+       a label then ellipsises down to something that names nothing. The bar
+       already has `overflow-x: auto`; it just needs tabs that keep their own
+       width. */
     @media (max-width: 700px) {
         .adw-widget-window adw-tab-view[expand-tabs] .adw-tab {
             flex: 0 0 auto;

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -1,0 +1,133 @@
+---
+// AdwWidgetWindow — ONE window of an {@link AdwWidget} block: an Adwaita header
+// bar with a title and a subtitle, an optional live-preview pane under it, and an
+// Adw.TabBar holding this kind's tabs.
+//
+// It is a component rather than a loop body in `AdwWidget.astro` because the
+// Astro compiler cannot parse a JSX expression nested inside another one:
+// `windows.map((win) => (<div>{win.live && (<div/>)}</div>))` fails to compile with
+// `Expected "}" but found ")"`, measured on astro 6.4.5, and so does a `.map()`
+// inside a `.map()`. One level of JSX per expression is the budget, so the window
+// gets its own file — which is the right seam anyway: `AdwWidget` decides WHICH
+// windows exist and what they claim, this one knows how a window is drawn.
+//
+// The header bar sits above BOTH panes on purpose; the reasoning, and the two
+// claims the subtitles carry, are in AdwWidget.astro's header.
+
+interface Props {
+    /** Window title. The live-preview window takes the WIDGET's; the rest name their kind. */
+    title: string;
+    /** What kind of implementation this window holds — see AdwWidget's WINDOWS. */
+    subtitle: string;
+    /** Canonical upstream docs for the widget, on the window that is about the widget. */
+    refHref?: string | null;
+    /** The widget, for the reference link's labels. */
+    widget: string;
+    /** This window's tab slots, in order, for the cross-widget preference sync. */
+    impls: string;
+    /** One tab per port this block filled: the Adw.TabBar label and the rendered snippet. */
+    tabs: { label: string; html: string }[];
+    /** The markup to mount and paint above the tabs, or null on a window that only shows code. */
+    preview?: string | null;
+    /** Padding around the preview widget — see AdwWidget. */
+    padding?: 'comfortable' | 'flush';
+    /** Horizontal scrolling for a wide preview — see AdwWidget. */
+    scroll?: boolean;
+    /** Inline CSS for the preview stage: preview-only scaffolding — see AdwWidget. */
+    stage?: string;
+}
+
+const {
+    title,
+    subtitle,
+    refHref = null,
+    widget,
+    impls,
+    tabs,
+    preview = null,
+    padding = 'comfortable',
+    scroll = false,
+    stage,
+} = Astro.props;
+---
+
+<div class="command-tabs adw-widget-window not-content" data-impl-tabs data-impls={impls}>
+    <div class="command-tabs-headerbar">
+        <span class="command-tabs-headerbar-start">
+            {
+                refHref && (
+                    <a
+                        class="command-tabs-ref"
+                        href={refHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={`Reference for ${widget}`}
+                        aria-label={`Open the reference for ${widget} in a new tab`}
+                    >
+                        <span class="command-tabs-ref-icon" aria-hidden="true" />
+                    </a>
+                )
+            }
+        </span>
+        <span class="command-tabs-headerbar-title">
+            <span class="adw-widget-window-title">{title}</span>
+            <span class="adw-widget-window-subtitle">{subtitle}</span>
+        </span>
+        <span class="command-tabs-headerbar-end">
+            <button class="command-tabs-copy" aria-label="Copy active tab" type="button">
+                <span class="command-tabs-copy-icon" aria-hidden="true"></span>
+            </button>
+        </span>
+    </div>
+
+    {
+        preview !== null && (
+            <div class:list={['adw-widget-preview', 'not-content', `is-${padding}`, { 'is-scroll': scroll }]}>
+                {/* `not-content` for the same reason CommandTabs.astro states it, and
+                    it was missing HERE while the tabs below already carried it.
+                    Starlight gives every content element that FOLLOWS a sibling a
+                    `margin-top: 1rem`, exempting only `:where(.not-content *)`. Inside
+                    a preview that lands on the widgets: measured on the deployed page,
+                    the second button of a wrap box and every one after it took
+                    `margin-top: 16px` while the first took none — and in a flex line
+                    the first then STRETCHED by exactly that much, 50px against its
+                    siblings' 34px. The same rule pushed a header bar's trailing button
+                    below its own title and set the two panes of a split view onto
+                    baselines 16px apart, which clipped the sidebar's last row. A
+                    preview is a rendering of a widget, not prose: it has to be laid out
+                    by the widget's own stylesheet alone.
+
+                    It also carries what `check-website-preview-not-content.mjs` used to
+                    read off the gallery pages themselves. Their preview markup is a
+                    fenced block now and that scanner masks fences as code, so the
+                    marker stopped being restated on 40 blocks and became structural:
+                    one component mounts every preview, into this element. */}
+                {/* The preview is CLONED into the stage at runtime (see AdwWidget's
+                    script) rather than server-rendered directly: adwaita-web custom
+                    elements upgrade as the page is parsed, and a nested composite (a
+                    split view holding toolbar views) can lose its slotted children to
+                    an upgrade-order race. A <template> is inert, so cloning AFTER the
+                    elements are defined uses the reliable build-then-attach path.
+
+                    The markup is the preview tab's own fence, read back out of
+                    Expressive Code, so `slot="…"` needs no rewriting here: it never
+                    passes through the MDX compiler, which reads `slot` as its own
+                    slot-assignment directive and strips it. That is what retired
+                    `data-adw-slot` HERE; AdwGalleryCard still needs it, because the
+                    index page's cards mount MDX markup rather than a fence. */}
+                {/* NOT self-closing. `<template … set:html={…} />` compiles to a
+                    template element that swallows its following siblings and an
+                    unbalanced expression: measured on astro 6.4.5, the generated
+                    module ended `</div>`}</div>`;` and esbuild refused it with
+                    `Expected ")" but found "}"` pointing at a line that does not
+                    exist in this file. */}
+                <template class="adw-widget-preview-tpl" set:html={preview}></template>
+                <div class="adw-widget-preview-stage" style={stage} />
+            </div>
+        )
+    }
+
+    <adw-tab-view no-close expand-tabs data-impl-view>
+        {tabs.map((tab) => <adw-tab-page title={tab.label} set:html={tab.html} />)}
+    </adw-tab-view>
+</div>

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -1,6 +1,6 @@
 ---
 title: Boxed Lists
-description: "Adwaita boxed-list rows: preferences group, action, switch, entry, combo, spin, expander and button. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita boxed-list rows: preferences group, action, switch, entry, combo, spin, expander and button. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -10,16 +10,18 @@ of related rows gathered into one rounded card. The card is a **preferences
 group**, and each row is a small self-contained control (a toggle, a text field,
 a drop-down, a button).
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (an
@@ -36,12 +38,14 @@ preferences page.
 
 <AdwWidget title="Adw.PreferencesGroup">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group title="Account" description="Manage how this device signs in and syncs.">
-      <button data-adw-slot="header-suffix" class="adw-button flat">Sign out</button>
+      <button slot="header-suffix" class="adw-button flat">Sign out</button>
       <adw-entry-row title="Display name" text="Grace Hopper"></adw-entry-row>
       <adw-switch-row title="Sync over Wi-Fi only" subtitle="Avoid using mobile data for backups" active></adw-switch-row>
       <adw-combo-row title="Region" items='["Europe","Americas","Asia","Oceania"]' selected="0"></adw-combo-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -98,19 +102,6 @@ preferences page.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <adw-preferences-group
-        title="Account"
-        description="Manage how this device signs in and syncs."
-    >
-        <button slot="header-suffix" class="adw-button flat">Sign out</button>
-        <adw-entry-row title="Display name" text="Grace Hopper"></adw-entry-row>
-        <adw-switch-row title="Sync over Wi-Fi only" active></adw-switch-row>
-    </adw-preferences-group>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwPreferencesGroup, AdwEntryRow, AdwSwitchRow } from '@gjsify/adwaita-nativescript';
@@ -141,12 +132,14 @@ row responds to a click, which is how you open a detail page.
 
 <AdwWidget title="Adw.ActionRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-action-row title="Wi-Fi" subtitle="Connected to Highgarden 5GHz" activatable>
-        <span data-adw-slot="prefix" class="adw-icon adw-icon--network-wireless"></span>
-        <adw-button data-adw-slot="suffix" icon="go-next" flat></adw-button>
+        <span slot="prefix" class="adw-icon adw-icon--network-wireless"></span>
+        <adw-button slot="suffix" icon="go-next" flat></adw-button>
       </adw-action-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -192,14 +185,6 @@ row responds to a click, which is how you open a detail page.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-action-row title="Wi-Fi" subtitle="Connected to Highgarden 5GHz" activatable>
-        <span slot="prefix" class="adw-icon adw-icon--network-wireless"></span>
-        <adw-button slot="suffix" icon="go-next" flat></adw-button>
-    </adw-action-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwActionRow, AdwIcon } from '@gjsify/adwaita-nativescript';
@@ -228,9 +213,11 @@ the row you will use most in a preferences page.
 
 <AdwWidget title="Adw.SwitchRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-switch-row title="Automatic updates" subtitle="Download and install updates without asking" active></adw-switch-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -257,15 +244,6 @@ the row you will use most in a preferences page.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-switch-row
-        title="Automatic updates"
-        subtitle="Download and install updates without asking"
-        active
-    ></adw-switch-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwSwitchRow } from '@gjsify/adwaita-nativescript';
@@ -287,9 +265,11 @@ user types.
 
 <AdwWidget title="Adw.EntryRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-entry-row title="Display name" text="Ada Lovelace"></adw-entry-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -315,11 +295,6 @@ user types.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-entry-row title="Display name" text="Ada Lovelace"></adw-entry-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwEntryRow } from '@gjsify/adwaita-nativescript';
@@ -338,9 +313,11 @@ to reveal it. Use it anywhere a password or key is edited inline.
 
 <AdwWidget title="Adw.PasswordEntryRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-password-entry-row title="Password" text="correct-horse-battery"></adw-password-entry-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -365,11 +342,6 @@ to reveal it. Use it anywhere a password or key is edited inline.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-password-entry-row title="Password" text="correct-horse-battery"></adw-password-entry-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwPasswordEntryRow } from '@gjsify/adwaita-nativescript';
@@ -388,6 +360,7 @@ selection is an index into the model you gave it, not the string itself.
 
 <AdwWidget title="Adw.ComboRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-combo-row
         title="Accent colour"
@@ -396,6 +369,7 @@ selection is an index into the model you gave it, not the string itself.
         selected="1"
       ></adw-combo-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -428,16 +402,6 @@ selection is an index into the model you gave it, not the string itself.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-combo-row
-        title="Accent colour"
-        subtitle="Used to highlight selected items"
-        items='["Blue","Teal","Green","Orange","Purple"]'
-        selected="1"
-    ></adw-combo-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwComboRow } from '@gjsify/adwaita-nativescript';
@@ -459,9 +423,11 @@ size or a count.
 
 <AdwWidget title="Adw.SpinRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-spin-row title="Font size" min="0" max="100" value="16" step="1"></adw-spin-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -494,11 +460,6 @@ size or a count.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-spin-row title="Font size" min="0" max="100" value="16" step="1"></adw-spin-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwSpinRow } from '@gjsify/adwaita-nativescript';
@@ -521,12 +482,14 @@ whole section.
 
 <AdwWidget title="Adw.ExpanderRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-expander-row title="Proxy settings" subtitle="Route traffic through a custom proxy" expanded>
         <adw-entry-row title="Host" text="proxy.example.com"></adw-entry-row>
         <adw-switch-row title="Use authentication"></adw-switch-row>
       </adw-expander-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -565,14 +528,6 @@ whole section.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-expander-row title="Proxy settings" subtitle="Route traffic through a custom proxy" expanded>
-        <adw-entry-row title="Host" text="proxy.example.com"></adw-entry-row>
-        <adw-switch-row title="Use authentication"></adw-switch-row>
-    </adw-expander-row>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwExpanderRow, AdwEntryRow, AdwSwitchRow } from '@gjsify/adwaita-nativescript';
@@ -602,9 +557,11 @@ Adwaita style classes (`.suggested-action`, `.destructive-action`).
 
 <AdwWidget title="Adw.ButtonRow">
   <Fragment slot="preview">
+    ```html
     <adw-preferences-group>
       <adw-button-row title="Add account" start-icon-name="list-add" class="suggested-action"></adw-button-row>
     </adw-preferences-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -630,15 +587,6 @@ Adwaita style classes (`.suggested-action`, `.destructive-action`).
         styles ["suggested-action"]
       }
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-button-row
-        title="Add account"
-        start-icon-name="list-add"
-        class="suggested-action"
-    ></adw-button-row>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -1,6 +1,6 @@
 ---
 title: Buttons
-description: "Adwaita buttons: icon-plus-label content, the style classes, menu buttons, split buttons and toggle groups. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita buttons: icon-plus-label content, the style classes, menu buttons, split buttons and toggle groups. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -12,16 +12,18 @@ happens. This page covers the five things you will want from one. Give it an
 pair an action with a menu of alternatives, or a **toggle group** when a row of
 linked buttons should act as a single-choice selector.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
@@ -38,9 +40,11 @@ short.
 
 <AdwWidget title="Adw.ButtonContent">
   <Fragment slot="preview">
+    ```html
     <button class="adw-button suggested-action pill">
       <adw-button-content label="Download" icon-name="folder-download"></adw-button-content>
     </button>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -71,14 +75,6 @@ short.
 
       styles ["suggested-action", "pill"]
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <button class="adw-button suggested-action pill">
-        <adw-button-content label="Download" icon-name="folder-download"></adw-button-content>
-    </button>
     ```
   </Fragment>
   <Fragment slot="nativescript">
@@ -112,6 +108,7 @@ like one in a dialog.
 
 <AdwWidget title="Gtk.Button">
   <Fragment slot="preview">
+    ```html
     <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center;">
       <adw-button label="Pill" pill></adw-button>
       <adw-button icon="list-add" circular></adw-button>
@@ -119,6 +116,7 @@ like one in a dialog.
       <adw-button label="Delete" destructive></adw-button>
       <adw-button label="Flat" flat></adw-button>
     </div>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -190,17 +188,6 @@ like one in a dialog.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center;">
-        <adw-button label="Pill" pill></adw-button>
-        <adw-button icon="list-add" circular></adw-button>
-        <adw-button label="Suggested" suggested></adw-button>
-        <adw-button label="Delete" destructive></adw-button>
-        <adw-button label="Flat" flat></adw-button>
-    </div>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwButton, AdwWrapBox } from '@gjsify/adwaita-nativescript';
@@ -242,11 +229,13 @@ shape.
 
 <AdwWidget title="Gtk.MenuButton">
   <Fragment slot="preview">
+    ```html
     <adw-menu-button
       icon-name="open-menu"
       menu-title="Document"
       menu='[{"label":"Save as…"},{"label":"Export"},{"label":"Print"}]'
     ></adw-menu-button>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -298,15 +287,6 @@ shape.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-menu-button
-        icon-name="open-menu"
-        menu-title="Document"
-        menu='[{"label":"Save as…"},{"label":"Export"},{"label":"Print"}]'
-    ></adw-menu-button>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwMenuButton } from '@gjsify/adwaita-nativescript';
@@ -330,11 +310,13 @@ header bar or toolbar, where a raised button looks too heavy.
 
 <AdwWidget title="Adw.SplitButton">
   <Fragment slot="preview">
+    ```html
     <adw-split-button
       label="Save"
       icon-name="document-save"
       menu='[{"label":"Save as…","action":"app.save-as"},{"label":"Export","action":"app.export"},{"label":"Print","action":"app.print"}]'
     ></adw-split-button>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -383,15 +365,6 @@ header bar or toolbar, where a raised button looks too heavy.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-split-button
-        label="Save"
-        icon-name="document-save"
-        menu='[{"label":"Save as…","action":"app.save-as"},{"label":"Export","action":"app.export"},{"label":"Print","action":"app.print"}]'
-    ></adw-split-button>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwSplitButton } from '@gjsify/adwaita-nativescript';
@@ -434,11 +407,13 @@ once set", and the only setter is class-level.
 
 <AdwWidget title="Adw.ToggleGroup">
   <Fragment slot="preview">
+    ```html
     <adw-toggle-group active="0">
       <adw-toggle label="List" icon-name="view-list"></adw-toggle>
       <adw-toggle label="Grid" icon-name="view-grid"></adw-toggle>
       <adw-toggle label="Columns" icon-name="view-columns"></adw-toggle>
     </adw-toggle-group>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -474,15 +449,6 @@ once set", and the only setter is class-level.
         icon-name: "view-columns-symbolic";
       }
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-toggle-group active="0">
-        <adw-toggle label="List" icon-name="view-list"></adw-toggle>
-        <adw-toggle label="Grid" icon-name="view-grid"></adw-toggle>
-        <adw-toggle label="Columns" icon-name="view-columns"></adw-toggle>
-    </adw-toggle-group>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/controls.mdx
+++ b/website/src/content/docs/adwaita/controls.mdx
@@ -1,6 +1,6 @@
 ---
 title: Controls
-description: "Adwaita's standalone controls: the text entry and the drop down. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita's standalone controls: the text entry and the drop down. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -16,16 +16,18 @@ Libadwaita ships no entry and no drop down of its own. They are `Gtk.Entry` and
 `Gtk.DropDown`, and what makes them look Adwaita is the stylesheet. The widgets
 with an `Adw` prefix are the row variants built on top.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour the toolkits drive natively can
@@ -45,7 +47,15 @@ and the label doubles as the row title.
 
 <AdwWidget title="Gtk.Entry">
   <Fragment slot="preview">
-    <adw-entry placeholder="Search files…" style="min-width: 280px;"></adw-entry>
+    ```html
+    <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;align-items:center;">
+      <adw-entry placeholder="Search files…" style="min-width: 280px;"></adw-entry>
+
+      <!-- `<adw-entry>` has no `editable`: the browser spelling of a field you may
+           read but not change is `disabled`, which also greys it. -->
+      <adw-entry value="notes.md" disabled></adw-entry>
+    </div>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -72,15 +82,6 @@ and the label doubles as the row title.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-entry placeholder="Search files…" style="min-width: 280px;"></adw-entry>
-
-    <!-- `<adw-entry>` has no `editable`: the browser spelling of a field you may
-         read but not change is `disabled`, which also greys it. -->
-    <adw-entry value="notes.md" disabled></adw-entry>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwEntry } from '@gjsify/adwaita-nativescript';
@@ -102,7 +103,10 @@ presented as a boxed-list row, use [Combo Row](../boxed-lists/#combo-row).
 
 <AdwWidget title="Gtk.DropDown">
   <Fragment slot="preview">
+    ```html
+    <!-- `options` is a JSON array of strings, or of { label, value } objects. -->
     <adw-drop-down options='["Automatic","Always","Never","When busy"]' selected="0"></adw-drop-down>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -128,12 +132,6 @@ presented as a boxed-list row, use [Combo Row](../boxed-lists/#combo-row).
         strings [_("Automatic"), _("Always"), _("Never"), _("When busy")]
       };
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- `options` is a JSON array of strings, or of { label, value } objects. -->
-    <adw-drop-down options='["Automatic","Always","Never","When busy"]' selected="0"></adw-drop-down>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/feedback.mdx
+++ b/website/src/content/docs/adwaita/feedback.mdx
@@ -1,6 +1,6 @@
 ---
 title: Feedback
-description: "Adwaita feedback widgets: toast, alert dialog, about dialog and preferences dialog. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita feedback widgets: toast, alert dialog, about dialog and preferences dialog. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -11,16 +11,18 @@ happen next. A **dialog** puts a modal surface in front of the window and waits
 for an answer, so use it when something does. This page also covers the two
 dialogs every app is expected to have: About and Preferences.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews hold each dialog **open** and each toast **visible**, which is not
@@ -43,22 +45,27 @@ by its timeout, its close button, its action button or an explicit dismissal.
 Every port behaves the same way here, so a queue you tested in the browser holds
 on the desktop.
 
-<AdwWidget title="Adw.Toast" padding="flush">
+<AdwWidget title="Adw.Toast" padding="flush" stage="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
   <Fragment slot="preview">
-    <div style="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
-      <adw-toast-overlay style="width: 360px; height: 220px; position: relative;">
-        <adw-status-page title="Documents" description="Drag files here to organise them."></adw-status-page>
-        <div class="adw-toast-overlay-toasts">
-          <div class="adw-toast visible">
-            <div class="adw-toast-content-wrapper">
-              <span class="adw-toast-title">File moved to Trash</span>
-            </div>
-            <button type="button" class="adw-toast-action-button">Undo</button>
-            <button type="button" class="adw-toast-close-button" aria-label="Close"></button>
+    ```html
+    <!-- NOT the markup a reader copies, and the only block on the site where the
+         two differ: the `web` fragment below overrides this tab. `addToast()` is
+         the whole API — <adw-toast-overlay> has no declarative toast child — so a
+         preview can only DEPICT the result, which is the overlay's own internal
+         DOM. See AdwWidget.astro's MARKUP_OVERRIDE. -->
+    <adw-toast-overlay style="width: 360px; height: 220px; position: relative;">
+      <adw-status-page title="Documents" description="Drag files here to organise them."></adw-status-page>
+      <div class="adw-toast-overlay-toasts">
+        <div class="adw-toast visible">
+          <div class="adw-toast-content-wrapper">
+            <span class="adw-toast-title">File moved to Trash</span>
           </div>
+          <button type="button" class="adw-toast-action-button">Undo</button>
+          <button type="button" class="adw-toast-close-button" aria-label="Close"></button>
         </div>
-      </adw-toast-overlay>
-    </div>
+      </div>
+    </adw-toast-overlay>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -92,7 +99,6 @@ on the desktop.
   </Fragment>
   <Fragment slot="web">
     ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
     <adw-toast-overlay id="overlay" style="width: 360px; height: 220px;">
         <adw-status-page title="Documents" description="Drag files here to organise them."></adw-status-page>
     </adw-toast-overlay>
@@ -133,18 +139,18 @@ ID, and that ID is what reaches your code. Give one response a **destructive** o
 **suggested** appearance to mark the consequence, and set the **default** and
 **close** responses so Enter and Escape do the right thing.
 
-<AdwWidget title="Adw.AlertDialog" padding="flush">
+<AdwWidget title="Adw.AlertDialog" padding="flush" stage="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
   <Fragment slot="preview">
-    <div style="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
-      <adw-alert-dialog
-        open
-        heading="Delete Project?"
-        body="This will permanently remove the project and all of its files. This action cannot be undone."
-      >
-        <adw-alert-response id="cancel">Cancel</adw-alert-response>
-        <adw-alert-response id="delete" appearance="destructive">Delete</adw-alert-response>
-      </adw-alert-dialog>
-    </div>
+    ```html
+    <adw-alert-dialog
+      open
+      heading="Delete Project?"
+      body="This will permanently remove the project and all of its files. This action cannot be undone."
+    >
+      <adw-alert-response id="cancel">Cancel</adw-alert-response>
+      <adw-alert-response id="delete" appearance="destructive">Delete</adw-alert-response>
+    </adw-alert-dialog>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -183,18 +189,6 @@ ID, and that ID is what reaches your code. Give one response a **destructive** o
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-alert-dialog
-        open
-        heading="Delete Project?"
-        body="This will permanently remove the project and all of its files. This action cannot be undone."
-    >
-        <adw-alert-response id="cancel">Cancel</adw-alert-response>
-        <adw-alert-response id="delete" appearance="destructive">Delete</adw-alert-response>
-    </adw-alert-dialog>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwAlertDialog } from '@gjsify/adwaita-nativescript';
@@ -223,21 +217,23 @@ app metadata and the dialog builds the rest: a large **icon**, the application
 **name**, a **developer** line, a **version** pill, and Details, Credits and
 Legal sub-pages you never lay out yourself.
 
-<AdwWidget title="Adw.AboutDialog" padding="flush">
+<AdwWidget title="Adw.AboutDialog" padding="flush" stage="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
   <Fragment slot="preview">
-    <div style="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
-      <adw-about-dialog
-        open
-        application-name="Adwaita Storybook"
-        developer-name="A GJSify Project"
-        version="0.11.0"
-        comments="A live catalogue of native GTK and Adwaita widgets, rendered under GJS."
-        website="https://github.com/gjsify/gjsify"
-        issue-url="https://github.com/gjsify/gjsify/issues"
-        license="The MIT License (MIT)"
-        copyright="© 2026 The GJSify Project"
-      ></adw-about-dialog>
-    </div>
+    ```html
+    <!-- developers / designers are string arrays set as properties, e.g.
+         el.developers = ['Ada Lovelace', 'Grace Hopper']; -->
+    <adw-about-dialog
+      open
+      application-name="Adwaita Storybook"
+      developer-name="A GJSify Project"
+      version="0.11.0"
+      comments="A live catalogue of native GTK and Adwaita widgets, rendered under GJS."
+      website="https://github.com/gjsify/gjsify"
+      issue-url="https://github.com/gjsify/gjsify/issues"
+      license="The MIT License (MIT)"
+      copyright="© 2026 The GJSify Project"
+    ></adw-about-dialog>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -278,23 +274,6 @@ Legal sub-pages you never lay out yourself.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- developers / designers are string arrays set as properties, e.g.
-         el.developers = ['Ada Lovelace', 'Grace Hopper']; -->
-    <adw-about-dialog
-        open
-        application-name="Adwaita Storybook"
-        developer-name="A GJSify Project"
-        version="0.11.0"
-        comments="A live catalogue of native GTK and Adwaita widgets, rendered under GJS."
-        website="https://github.com/gjsify/gjsify"
-        issue-url="https://github.com/gjsify/gjsify/issues"
-        license="The MIT License (MIT)"
-        copyright="© 2026 The GJSify Project"
-    ></adw-about-dialog>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwAboutDialog } from '@gjsify/adwaita-nativescript';
@@ -322,19 +301,19 @@ spin buttons. Most apps need only one page, which is what the example shows. In 
 native window, extra pages sit behind a view switcher and you see one at a time;
 the web port renders them stacked instead.
 
-<AdwWidget title="Adw.PreferencesDialog" padding="flush">
+<AdwWidget title="Adw.PreferencesDialog" padding="flush" stage="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
   <Fragment slot="preview">
-    <div style="height: 360px; width: 100%; position: relative; overflow: hidden; display:flex; align-items:center; justify-content:center;">
-      <adw-preferences-dialog open title="Preferences">
-        <adw-preferences-page title="General" icon-name="preferences-system-symbolic">
-          <adw-preferences-group title="Appearance" description="Control how the application looks and behaves.">
-            <adw-switch-row title="Dark style" subtitle="Use a dark colour scheme" active></adw-switch-row>
-            <adw-combo-row title="Accent colour" items='["Blue","Teal","Green","Orange","Purple"]' selected="0"></adw-combo-row>
-            <adw-spin-row title="Font size" min="8" max="24" value="12" step="1"></adw-spin-row>
-          </adw-preferences-group>
-        </adw-preferences-page>
-      </adw-preferences-dialog>
-    </div>
+    ```html
+    <adw-preferences-dialog open title="Preferences">
+      <adw-preferences-page title="General" icon-name="preferences-system-symbolic">
+        <adw-preferences-group title="Appearance" description="Control how the application looks and behaves.">
+          <adw-switch-row title="Dark style" subtitle="Use a dark colour scheme" active></adw-switch-row>
+          <adw-combo-row title="Accent colour" items='["Blue","Teal","Green","Orange","Purple"]' selected="0"></adw-combo-row>
+          <adw-spin-row title="Font size" min="8" max="24" value="12" step="1"></adw-spin-row>
+        </adw-preferences-group>
+      </adw-preferences-page>
+    </adw-preferences-dialog>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -413,19 +392,6 @@ the web port renders them stacked instead.
         }
       }
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-preferences-dialog open title="Preferences">
-        <adw-preferences-page title="General" icon-name="preferences-system-symbolic">
-            <adw-preferences-group title="Appearance" description="Control how the application looks and behaves.">
-                <adw-switch-row title="Dark style" subtitle="Use a dark colour scheme" active></adw-switch-row>
-                <adw-combo-row title="Accent colour" items='["Blue","Teal","Green","Orange","Purple"]' selected="0"></adw-combo-row>
-                <adw-spin-row title="Font size" min="8" max="24" value="12" step="1"></adw-spin-row>
-            </adw-preferences-group>
-        </adw-preferences-page>
-    </adw-preferences-dialog>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/index.mdx
+++ b/website/src/content/docs/adwaita/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adwaita
-description: The Adwaita design system for GTK 4, one page per widget family, with a live preview and the code for GJS, Blueprint, the web and NativeScript.
+description: The Adwaita design system for GTK 4, one page per widget family, with a live preview and the TypeScript, Blueprint and NativeScript code.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
@@ -11,11 +11,12 @@ dialogs a GNOME app is made of. GJSify gives you the whole set from TypeScript,
 and the same widget renders as a real Libadwaita widget on the desktop and as a
 custom element in the browser.
 
-Pick a category below. Every widget on those pages runs live in your browser,
-followed by the code to build it four ways: `@girs` TypeScript (the same program
-on GJS, Node, Bun and Deno), a Blueprint declaration, the web port and the
-NativeScript port. Choose a tab once and every widget block on the site follows
-it.
+Pick a category below. Every widget on those pages runs live in your browser, in a
+window whose tab holds the markup that paints it, followed by one window per kind of
+implementation: **Vanilla TypeScript**, the `@girs` program that runs unchanged on
+GJS, Node, Bun and Deno, with a Blueprint declaration beside it, and **NativeScript**,
+the port that runs on a phone. Choose a tab once and every widget block on the site
+follows it.
 
 Adwaita is one design system GJSify supports, not a requirement. Your app is an
 ordinary GTK 4 program, so you can mix in plain `Gtk.*` widgets or style your

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -1,6 +1,6 @@
 ---
 title: Layout
-description: "Adwaita layout containers: Clamp, HeaderBar, ToolbarView and WrapBox. Live preview plus the code for GJS, Blueprint, React Native on GTK, the web and NativeScript."
+description: "Adwaita layout containers: Clamp, HeaderBar, ToolbarView and WrapBox. A live preview with its markup, plus the TypeScript, Blueprint, React Native on GTK and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -11,22 +11,23 @@ view** to frame content between fixed bars, and a **wrap box** to let a run of
 children flow onto new lines. None of them hold data: they position what you put
 inside and adapt as the space around them changes.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-in every target that can express it. Four of them are on all four widgets here:
-`@girs` TypeScript (one program, running on GJS, Node, Bun and Deno), the
-matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation, for every kind that can express this widget.
+Two are on all four widgets here — **Vanilla TypeScript**, the `@girs` program that
+runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint declaration
+beside it, and **NativeScript**, the port that runs on a phone.
 
-The clamp, the header bar and the toolbar view carry a fifth, **React Native on
-GTK**: the same widget written with
-[`@gjsify/react-native`](/gjsify/frameworks/react-native/) primitives inside it.
-The wrap box does not, because
+The clamp, the header bar and the toolbar view carry a third, **UI frameworks**: the
+same widget written with [`@gjsify/react-native`](/gjsify/frameworks/react-native/)
+primitives inside it. The wrap box does not, because
 [`@gjsify/gtk-host`](https://github.com/gjsify/gjsify/tree/main/packages/framework/gtk-host)
-has no child policy for `AdwWrapBox` yet, and a renderer that guessed one would
-call `add`, `append` or `set_child` and be wrong at exit 0. That tab renders a
-GTK window, not a phone screen — the [React Native
-page](/gjsify/frameworks/react-native/#adwaita-widgets) says what does and does
-not exist there.
+has no child policy for `AdwWrapBox` yet, and a renderer that guessed one would call
+`add`, `append` or `set_child` and be wrong at exit 0. That window renders a GTK window,
+not a phone screen — which is why it is not the NativeScript one, and the [React Native
+page](/gjsify/frameworks/react-native/#adwaita-widgets) says what does and does not
+exist there.
 
 Two of those three style with `className`, and both configure their token scales
 on the way in. That line is not decoration: the values behind a class name come
@@ -39,7 +40,7 @@ Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
@@ -56,11 +57,13 @@ at a comfortable measure on a large display without wasting room on a small one.
 
 <AdwWidget title="Adw.Clamp">
   <Fragment slot="preview">
+    ```html
     <adw-clamp maximum-size="400">
       <adw-card style="width: 100%; box-sizing: border-box; padding: 18px;">
         This content is clamped: it stops growing past the maximum size and stays centred.
       </adw-card>
     </adw-clamp>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -129,16 +132,6 @@ at a comfortable measure on a large display without wasting room on a small one.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <adw-clamp maximum-size="400">
-        <adw-card style="width: 100%; box-sizing: border-box; padding: 18px;">
-            This content is clamped: it stops growing past the maximum size and stays centred.
-        </adw-card>
-    </adw-clamp>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwButtonContent, AdwClamp } from '@gjsify/adwaita-nativescript';
@@ -162,11 +155,13 @@ the trailing one.
 
 <AdwWidget title="Adw.HeaderBar">
   <Fragment slot="preview">
+    ```html
     <adw-header-bar style="width: 100%;">
-      <adw-button data-adw-slot="start" icon="go-previous" flat></adw-button>
-      <adw-window-title data-adw-slot="center" title="Text Editor" subtitle="notes.md"></adw-window-title>
-      <adw-button data-adw-slot="end" icon="open-menu" flat></adw-button>
+      <adw-button slot="start" icon="go-previous" flat></adw-button>
+      <adw-window-title slot="center" title="Text Editor" subtitle="notes.md"></adw-window-title>
+      <adw-button slot="end" icon="open-menu" flat></adw-button>
     </adw-header-bar>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -239,15 +234,6 @@ the trailing one.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-header-bar style="width: 100%;">
-        <adw-button slot="start" icon="go-previous" flat></adw-button>
-        <adw-window-title slot="center" title="Text Editor" subtitle="notes.md"></adw-window-title>
-        <adw-button slot="end" icon="open-menu" flat></adw-button>
-    </adw-header-bar>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwButton, AdwHeaderBar, AdwWindowTitle } from '@gjsify/adwaita-nativescript';
@@ -279,26 +265,26 @@ bar above and an action bar below. Each set of bars reveals and hides
 independently, and the content scrolls underneath, so the chrome stays put while
 the view moves.
 
-<AdwWidget title="Adw.ToolbarView" padding="flush">
+{/* `width: 100%` on the stage because it is a flex row: without it the stage is
+    shrink-to-fit, so the toolbar view came out as wide as its widest bar and
+    floated inside a panel whose `flush` padding exists to let it sit edge to
+    edge. Every other fixed-height preview on these pages sets it too. */}
+<AdwWidget title="Adw.ToolbarView" padding="flush" stage="height: 300px; width: 100%; display: flex;">
   <Fragment slot="preview">
-    {/* `width: 100%` because the stage is a flex row: without it this wrapper is
-        shrink-to-fit, so the toolbar view came out as wide as its widest bar and
-        floated inside a panel whose `flush` padding exists to let it sit edge to
-        edge. Every other fixed-height preview on these pages already sets it. */}
-    <div style="height: 300px; width: 100%; display: flex;">
-      <adw-toolbar-view style="flex: 1;">
-        <adw-header-bar data-adw-slot="top">
-          <adw-window-title data-adw-slot="center" title="Documents" subtitle="12 items"></adw-window-title>
-        </adw-header-bar>
-        <adw-status-page icon="folder-documents" title="Your library" description="Content sits between the toolbars and scrolls independently of them."></adw-status-page>
-        <div data-adw-slot="bottom" class="toolbar" style="border-top: 1px solid var(--separator-color, rgba(0, 0, 0, 0.15));">
-          <adw-button icon="list-add" flat tooltip="Add"></adw-button>
-          <adw-button icon="list-remove" flat tooltip="Remove"></adw-button>
-          <span style="flex: 1 1 auto; text-align: center;">Selection: none</span>
-          <adw-button icon="send-to" flat tooltip="Share"></adw-button>
-        </div>
-      </adw-toolbar-view>
-    </div>
+    ```html
+    <adw-toolbar-view style="flex: 1;">
+      <adw-header-bar slot="top">
+        <adw-window-title slot="center" title="Documents" subtitle="12 items"></adw-window-title>
+      </adw-header-bar>
+      <adw-status-page icon="folder-documents" title="Your library" description="Content sits between the toolbars and scrolls independently of them."></adw-status-page>
+      <div slot="bottom" class="toolbar" style="border-top: 1px solid var(--separator-color, rgba(0, 0, 0, 0.15));">
+        <adw-button icon="list-add" flat tooltip="Add"></adw-button>
+        <adw-button icon="list-remove" flat tooltip="Remove"></adw-button>
+        <span style="flex: 1 1 auto; text-align: center;">Selection: none</span>
+        <adw-button icon="send-to" flat tooltip="Share"></adw-button>
+      </div>
+    </adw-toolbar-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -430,26 +416,6 @@ the view moves.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-toolbar-view style="flex: 1;">
-        <adw-header-bar slot="top">
-            <adw-window-title slot="center" title="Documents" subtitle="12 items"></adw-window-title>
-        </adw-header-bar>
-        <adw-status-page
-            icon="folder-documents"
-            title="Your library"
-            description="Content sits between the toolbars and scrolls independently of them."
-        ></adw-status-page>
-        <div slot="bottom" class="toolbar" style="border-top: 1px solid var(--separator-color, rgba(0, 0, 0, 0.15));">
-            <adw-button icon="list-add" flat tooltip="Add"></adw-button>
-            <adw-button icon="list-remove" flat tooltip="Remove"></adw-button>
-            <span style="flex: 1 1 auto; text-align: center;">Selection: none</span>
-            <adw-button icon="send-to" flat tooltip="Share"></adw-button>
-        </div>
-    </adw-toolbar-view>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import {
@@ -509,6 +475,7 @@ chips or filter pills. **Child spacing** sets the gap between items on a line,
 
 <AdwWidget title="Adw.WrapBox">
   <Fragment slot="preview">
+    ```html
     <adw-wrap-box child-spacing="8" line-spacing="8">
       <adw-button label="Design" pill></adw-button>
       <adw-button label="Adwaita" pill></adw-button>
@@ -519,6 +486,7 @@ chips or filter pills. **Child spacing** sets the gap between items on a line,
       <adw-button label="Wrapping" pill></adw-button>
       <adw-button label="Layout" pill></adw-button>
     </adw-wrap-box>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -592,20 +560,6 @@ chips or filter pills. **Child spacing** sets the gap between items on a line,
         styles ["pill"]
       }
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-wrap-box child-spacing="8" line-spacing="8">
-        <adw-button label="Design" pill></adw-button>
-        <adw-button label="Adwaita" pill></adw-button>
-        <adw-button label="GNOME" pill></adw-button>
-        <adw-button label="GTK" pill></adw-button>
-        <adw-button label="Typescript" pill></adw-button>
-        <adw-button label="Storybook" pill></adw-button>
-        <adw-button label="Wrapping" pill></adw-button>
-        <adw-button label="Layout" pill></adw-button>
-    </adw-wrap-box>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/navigation.mdx
+++ b/website/src/content/docs/adwaita/navigation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Navigation
-description: "Adwaita navigation widgets: navigation split view, overlay split view, navigation view, sidebar and bottom sheet. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita navigation widgets: navigation split view, overlay split view, navigation view, sidebar and bottom sheet. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -11,16 +11,18 @@ its content sit side by side. As the window narrows, the same structure folds
 into a stack you push and pop, or into a panel that overlays the content. You
 build one structure, not two.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 These are the widgets that lean hardest on Libadwaita: adaptive breakpoints,
@@ -37,31 +39,31 @@ narrow the view **collapses** into a single navigation stack, so selecting a
 sidebar row pushes the content page and a back button returns to the list. Give
 the sidebar and the content each their own navigation page and header bar.
 
-<AdwWidget title="Adw.NavigationSplitView" padding="flush">
+<AdwWidget title="Adw.NavigationSplitView" padding="flush" stage="height: 340px; width: 100%; display: flex; overflow: hidden;">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-      <adw-navigation-split-view show-content style="flex: 1;">
-        <adw-toolbar-view data-adw-slot="sidebar">
-          <adw-header-bar data-adw-slot="top">
-            <adw-window-title data-adw-slot="center" title="Mailboxes"></adw-window-title>
-          </adw-header-bar>
-          <adw-sidebar mode="sidebar" selected="0">
-            <adw-sidebar-section>
-              <adw-sidebar-item title="All Mail" subtitle="128 messages" icon-name="mail-unread-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Starred" subtitle="6 messages" icon-name="starred-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Drafts" subtitle="2 messages" icon-name="document-edit-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Archive" subtitle="512 messages" icon-name="folder-symbolic"></adw-sidebar-item>
-            </adw-sidebar-section>
-          </adw-sidebar>
-        </adw-toolbar-view>
-        <adw-toolbar-view data-adw-slot="content">
-          <adw-header-bar data-adw-slot="top">
-            <adw-window-title data-adw-slot="center" title="All Mail"></adw-window-title>
-          </adw-header-bar>
-          <adw-status-page icon="mail-unread-symbolic" title="All Mail" description="Select a conversation from the list to read it here."></adw-status-page>
-        </adw-toolbar-view>
-      </adw-navigation-split-view>
-    </div>
+    ```html
+    <adw-navigation-split-view show-content style="flex: 1;">
+      <adw-toolbar-view slot="sidebar">
+        <adw-header-bar slot="top">
+          <adw-window-title slot="center" title="Mailboxes"></adw-window-title>
+        </adw-header-bar>
+        <adw-sidebar mode="sidebar" selected="0">
+          <adw-sidebar-section>
+            <adw-sidebar-item title="All Mail" subtitle="128 messages" icon-name="mail-unread-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Starred" subtitle="6 messages" icon-name="starred-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Drafts" subtitle="2 messages" icon-name="document-edit-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Archive" subtitle="512 messages" icon-name="folder-symbolic"></adw-sidebar-item>
+          </adw-sidebar-section>
+        </adw-sidebar>
+      </adw-toolbar-view>
+      <adw-toolbar-view slot="content">
+        <adw-header-bar slot="top">
+          <adw-window-title slot="center" title="All Mail"></adw-window-title>
+        </adw-header-bar>
+        <adw-status-page icon="mail-unread-symbolic" title="All Mail" description="Select a conversation from the list to read it here."></adw-status-page>
+      </adw-toolbar-view>
+    </adw-navigation-split-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -165,34 +167,6 @@ the sidebar and the content each their own navigation page and header bar.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-        <adw-navigation-split-view show-content style="flex: 1;">
-            <adw-toolbar-view slot="sidebar">
-                <adw-header-bar slot="top">
-                    <adw-window-title slot="center" title="Mailboxes"></adw-window-title>
-                </adw-header-bar>
-                <adw-sidebar mode="sidebar" selected="0">
-                    <adw-sidebar-section>
-                        <adw-sidebar-item title="All Mail" subtitle="128 messages" icon-name="mail-unread-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Starred" subtitle="6 messages" icon-name="starred-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Drafts" subtitle="2 messages" icon-name="document-edit-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Archive" subtitle="512 messages" icon-name="folder-symbolic"></adw-sidebar-item>
-                    </adw-sidebar-section>
-                </adw-sidebar>
-            </adw-toolbar-view>
-            <adw-toolbar-view slot="content">
-                <adw-header-bar slot="top">
-                    <adw-window-title slot="center" title="All Mail"></adw-window-title>
-                </adw-header-bar>
-                <adw-status-page icon="mail-unread-symbolic" title="All Mail" description="Select a conversation from the list to read it here."></adw-status-page>
-            </adw-toolbar-view>
-        </adw-navigation-split-view>
-    </div>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import {
@@ -242,27 +216,27 @@ instead of replacing the content, the sidebar slides **over the top** of it as a
 temporary panel above a dimming scrim. Choose this one for a utility, filter or
 navigation pane that should not push the main content aside on a narrow window.
 
-<AdwWidget title="Adw.OverlaySplitView" padding="flush">
+<AdwWidget title="Adw.OverlaySplitView" padding="flush" stage="height: 340px; width: 100%; display: flex; overflow: hidden;">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-      <adw-overlay-split-view show-sidebar style="flex: 1;">
-        <adw-toolbar-view data-adw-slot="sidebar">
-          <adw-header-bar data-adw-slot="top"></adw-header-bar>
-          <adw-sidebar mode="sidebar" selected="0">
-            <adw-sidebar-section>
-              <adw-sidebar-item title="Home" icon-name="go-home-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Discover" icon-name="system-search-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Library" icon-name="folder-music-symbolic"></adw-sidebar-item>
-              <adw-sidebar-item title="Settings" icon-name="emblem-system-symbolic"></adw-sidebar-item>
-            </adw-sidebar-section>
-          </adw-sidebar>
-        </adw-toolbar-view>
-        <adw-toolbar-view data-adw-slot="content">
-          <adw-header-bar data-adw-slot="top"></adw-header-bar>
-          <adw-status-page icon="folder-music" title="Your Library" description="Toggle the sidebar to browse sections. Collapse it to overlay the content."></adw-status-page>
-        </adw-toolbar-view>
-      </adw-overlay-split-view>
-    </div>
+    ```html
+    <adw-overlay-split-view show-sidebar style="flex: 1;">
+      <adw-toolbar-view slot="sidebar">
+        <adw-header-bar slot="top"></adw-header-bar>
+        <adw-sidebar mode="sidebar" selected="0">
+          <adw-sidebar-section>
+            <adw-sidebar-item title="Home" icon-name="go-home-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Discover" icon-name="system-search-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Library" icon-name="folder-music-symbolic"></adw-sidebar-item>
+            <adw-sidebar-item title="Settings" icon-name="emblem-system-symbolic"></adw-sidebar-item>
+          </adw-sidebar-section>
+        </adw-sidebar>
+      </adw-toolbar-view>
+      <adw-toolbar-view slot="content">
+        <adw-header-bar slot="top"></adw-header-bar>
+        <adw-status-page icon="folder-music" title="Your Library" description="Toggle the sidebar to browse sections. Collapse it to overlay the content."></adw-status-page>
+      </adw-toolbar-view>
+    </adw-overlay-split-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -356,29 +330,6 @@ navigation pane that should not push the main content aside on a narrow window.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-        <adw-overlay-split-view show-sidebar style="flex: 1;">
-            <adw-toolbar-view slot="sidebar">
-                <adw-header-bar slot="top"></adw-header-bar>
-                <adw-sidebar mode="sidebar" selected="0">
-                    <adw-sidebar-section>
-                        <adw-sidebar-item title="Home" icon-name="go-home-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Discover" icon-name="system-search-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Library" icon-name="folder-music-symbolic"></adw-sidebar-item>
-                        <adw-sidebar-item title="Settings" icon-name="emblem-system-symbolic"></adw-sidebar-item>
-                    </adw-sidebar-section>
-                </adw-sidebar>
-            </adw-toolbar-view>
-            <adw-toolbar-view slot="content">
-                <adw-header-bar slot="top"></adw-header-bar>
-                <adw-status-page icon="folder-music" title="Your Library" description="Toggle the sidebar to browse sections. Collapse it to overlay the content."></adw-status-page>
-            </adw-toolbar-view>
-        </adw-overlay-split-view>
-    </div>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import {
@@ -426,30 +377,34 @@ when transitions are animated, and a back-swipe gesture takes the user back.
 The preview below is interactive: click **Open contact** on the root page to push
 the detail page and watch the back button appear.
 
-<AdwWidget title="Adw.NavigationView" padding="flush">
+<AdwWidget title="Adw.NavigationView" padding="flush" stage="height: 340px; width: 100%; display: flex; overflow: hidden;">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-      <adw-navigation-view animate-transitions="true" style="flex: 1;">
-        <adw-navigation-page tag="root" title="Contacts">
-          <adw-toolbar-view>
-            <adw-header-bar data-adw-slot="top">
-              <adw-window-title data-adw-slot="center" title="Contacts"></adw-window-title>
-            </adw-header-bar>
-            <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
-              <adw-button label="Open contact" pill suggested></adw-button>
-            </div>
-          </adw-toolbar-view>
-        </adw-navigation-page>
-        <adw-navigation-page tag="detail" title="Ada Lovelace">
-          <adw-toolbar-view>
-            <adw-header-bar data-adw-slot="top">
-              <adw-window-title data-adw-slot="center" title="Ada Lovelace"></adw-window-title>
-            </adw-header-bar>
-            <adw-status-page icon="avatar-default" title="Ada Lovelace" description="Mathematician and writer, the first computer programmer."></adw-status-page>
-          </adw-toolbar-view>
-        </adw-navigation-page>
-      </adw-navigation-view>
-    </div>
+    ```html
+    <adw-navigation-view animate-transitions="true" style="flex: 1;">
+      <adw-navigation-page tag="root" title="Contacts">
+        <adw-toolbar-view>
+          <adw-header-bar slot="top">
+            <adw-window-title slot="center" title="Contacts"></adw-window-title>
+          </adw-header-bar>
+          <!-- The toolbar view gives its content widget the whole rect, as
+               Adw.ToolbarView does, so a button that wants to sit in the middle
+               says so. This box is the web spelling of the TypeScript tab's
+               halign/valign: center. -->
+          <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
+            <adw-button label="Open contact" pill suggested></adw-button>
+          </div>
+        </adw-toolbar-view>
+      </adw-navigation-page>
+      <adw-navigation-page tag="detail" title="Ada Lovelace">
+        <adw-toolbar-view>
+          <adw-header-bar slot="top">
+            <adw-window-title slot="center" title="Ada Lovelace"></adw-window-title>
+          </adw-header-bar>
+          <adw-status-page icon="avatar-default" title="Ada Lovelace" description="Mathematician and writer, the first computer programmer."></adw-status-page>
+        </adw-toolbar-view>
+      </adw-navigation-page>
+    </adw-navigation-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -530,36 +485,6 @@ the detail page and watch the back button appear.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden;">
-        <adw-navigation-view animate-transitions="true" style="flex: 1;">
-            <adw-navigation-page tag="root" title="Contacts">
-                <adw-toolbar-view>
-                    <adw-header-bar slot="top">
-                        <adw-window-title slot="center" title="Contacts"></adw-window-title>
-                    </adw-header-bar>
-                    <!-- The toolbar view gives its content widget the whole rect, as
-                         Adw.ToolbarView does, so a button that wants to sit in the
-                         middle says so. This box is the web spelling of the GJS tab's
-                         halign/valign: center. -->
-                    <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
-                        <adw-button label="Open contact" pill suggested></adw-button>
-                    </div>
-                </adw-toolbar-view>
-            </adw-navigation-page>
-            <adw-navigation-page tag="detail" title="Ada Lovelace">
-                <adw-toolbar-view>
-                    <adw-header-bar slot="top">
-                        <adw-window-title slot="center" title="Ada Lovelace"></adw-window-title>
-                    </adw-header-bar>
-                    <adw-status-page icon="avatar-default" title="Ada Lovelace" description="Mathematician and writer, the first computer programmer."></adw-status-page>
-                </adw-toolbar-view>
-            </adw-navigation-page>
-        </adw-navigation-view>
-    </div>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwButton, AdwHeaderBar, AdwNavigationView, AdwStatusPage, AdwToolbarView } from '@gjsify/adwaita-nativescript';
@@ -606,20 +531,20 @@ Use this rather than a boxed list. A boxed list draws itself as a settings card,
 which looks wrong edge to edge in a pane; a sidebar is a flat selectable list and
 already knows how to be one.
 
-<AdwWidget title="Adw.Sidebar" padding="flush">
+<AdwWidget title="Adw.Sidebar" padding="flush" stage="height: 340px; width: 100%; display: flex; overflow: hidden; border: 1px solid var(--card-shade-color); border-radius: var(--card-radius, 12px);">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden; border: 1px solid var(--card-shade-color); border-radius: var(--card-radius, 12px);">
-      <adw-sidebar mode="sidebar" selected="0" style="width: 220px;">
-        <adw-sidebar-section title="Mailboxes">
-          <adw-sidebar-item title="Inbox" subtitle="3 unread" icon-name="mail-unread-symbolic"></adw-sidebar-item>
-          <adw-sidebar-item title="Starred" subtitle="Favourites" icon-name="starred-symbolic"></adw-sidebar-item>
-          <adw-sidebar-item title="Sent" subtitle="Outgoing mail" icon-name="mail-send-symbolic"></adw-sidebar-item>
-          <adw-sidebar-item title="Archive" subtitle="Older mail" icon-name="folder-symbolic"></adw-sidebar-item>
-        </adw-sidebar-section>
-      </adw-sidebar>
-      <div style="width: 1px; align-self: stretch; background-color: var(--separator-color, var(--card-shade-color));"></div>
-      <adw-status-page title="Inbox" icon="mail-unread" description="3 unread" style="flex: 1 1 auto;"></adw-status-page>
-    </div>
+    ```html
+    <adw-sidebar mode="sidebar" selected="0" style="width: 220px;">
+      <adw-sidebar-section title="Mailboxes">
+        <adw-sidebar-item title="Inbox" subtitle="3 unread" icon-name="mail-unread-symbolic"></adw-sidebar-item>
+        <adw-sidebar-item title="Starred" subtitle="Favourites" icon-name="starred-symbolic"></adw-sidebar-item>
+        <adw-sidebar-item title="Sent" subtitle="Outgoing mail" icon-name="mail-send-symbolic"></adw-sidebar-item>
+        <adw-sidebar-item title="Archive" subtitle="Older mail" icon-name="folder-symbolic"></adw-sidebar-item>
+      </adw-sidebar-section>
+    </adw-sidebar>
+    <div style="width: 1px; align-self: stretch; background-color: var(--separator-color, var(--card-shade-color));"></div>
+    <adw-status-page title="Inbox" icon="mail-unread" description="3 unread" style="flex: 1 1 auto;"></adw-status-page>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -696,22 +621,6 @@ already knows how to be one.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden; border: 1px solid var(--card-shade-color); border-radius: var(--card-radius, 12px);">
-        <adw-sidebar mode="sidebar" selected="0" style="width: 220px;">
-            <adw-sidebar-section title="Mailboxes">
-                <adw-sidebar-item title="Inbox" subtitle="3 unread" icon-name="mail-unread-symbolic"></adw-sidebar-item>
-                <adw-sidebar-item title="Starred" subtitle="Favourites" icon-name="starred-symbolic"></adw-sidebar-item>
-                <adw-sidebar-item title="Sent" subtitle="Outgoing mail" icon-name="mail-send-symbolic"></adw-sidebar-item>
-                <adw-sidebar-item title="Archive" subtitle="Older mail" icon-name="folder-symbolic"></adw-sidebar-item>
-            </adw-sidebar-section>
-        </adw-sidebar>
-        <div style="width: 1px; align-self: stretch; background-color: var(--separator-color, var(--card-shade-color));"></div>
-        <adw-status-page title="Inbox" icon="mail-unread" description="3 unread" style="flex: 1 1 auto;"></adw-status-page>
-    </div>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwSidebar, AdwStatusPage, NOTIFY_SIDEBAR_SELECTED } from '@gjsify/adwaita-nativescript';
@@ -761,35 +670,37 @@ which suits contextual actions and secondary content on a narrow window. Make it
 **modal** to dim the content behind it. `canClose` is on by default, so Escape or
 a click on the dimmed area dismisses the sheet; switch it off to keep the sheet
 up until your own code closes it. The preview starts with the sheet up: click the
-dimmed area to dismiss it, and the button underneath to bring it back.
+dimmed area to dismiss it. Bringing it back is a property set (`open = true`), which
+this static preview does not wire — the button under the sheet is there to show the
+content pane, not to work.
 
-<AdwWidget title="Adw.BottomSheet" padding="flush">
+<AdwWidget title="Adw.BottomSheet" padding="flush" stage="height: 340px; width: 100%; display: flex; overflow: hidden; position: relative;">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden; position: relative;">
-      <adw-bottom-sheet open modal can-close style="flex: 1;">
-        <adw-bottom-sheet-content>
-          <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
-            <adw-button pill suggested data-adw-toggle-open="adw-bottom-sheet">Toggle sheet</adw-button>
-          </div>
-        </adw-bottom-sheet-content>
-        <adw-bottom-sheet-sheet>
-          <div style="display: flex; flex-direction: column; gap: 12px; margin: 18px 18px 24px;">
-            <span style="font-size: 15pt; font-weight: 800;">Share track</span>
-            <adw-preferences-group>
-              <adw-action-row title="Copy link" activatable>
-                <span data-adw-slot="prefix" class="adw-icon adw-icon--edit-copy"></span>
-              </adw-action-row>
-              <adw-action-row title="Send to a friend" activatable>
-                <span data-adw-slot="prefix" class="adw-icon adw-icon--mail-send"></span>
-              </adw-action-row>
-              <adw-action-row title="Add to playlist" activatable>
-                <span data-adw-slot="prefix" class="adw-icon adw-icon--list-add"></span>
-              </adw-action-row>
-            </adw-preferences-group>
-          </div>
-        </adw-bottom-sheet-sheet>
-      </adw-bottom-sheet>
-    </div>
+    ```html
+    <adw-bottom-sheet open modal can-close style="flex: 1;">
+      <adw-bottom-sheet-content>
+        <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
+          <adw-button pill suggested>Toggle sheet</adw-button>
+        </div>
+      </adw-bottom-sheet-content>
+      <adw-bottom-sheet-sheet>
+        <div style="display: flex; flex-direction: column; gap: 12px; margin: 18px 18px 24px;">
+          <span style="font-size: 15pt; font-weight: 800;">Share track</span>
+          <adw-preferences-group>
+            <adw-action-row title="Copy link" activatable>
+              <span slot="prefix" class="adw-icon adw-icon--edit-copy"></span>
+            </adw-action-row>
+            <adw-action-row title="Send to a friend" activatable>
+              <span slot="prefix" class="adw-icon adw-icon--mail-send"></span>
+            </adw-action-row>
+            <adw-action-row title="Add to playlist" activatable>
+              <span slot="prefix" class="adw-icon adw-icon--list-add"></span>
+            </adw-action-row>
+          </adw-preferences-group>
+        </div>
+      </adw-bottom-sheet-sheet>
+    </adw-bottom-sheet>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -902,35 +813,6 @@ dimmed area to dismiss it, and the button underneath to bring it back.
         }
       };
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <div style="height: 340px; width: 100%; display: flex; overflow: hidden; position: relative;">
-        <adw-bottom-sheet open modal can-close style="flex: 1;">
-            <adw-bottom-sheet-content>
-                <div style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;">
-                    <adw-button pill suggested>Toggle sheet</adw-button>
-                </div>
-            </adw-bottom-sheet-content>
-            <adw-bottom-sheet-sheet>
-                <div style="display: flex; flex-direction: column; gap: 12px; margin: 18px 18px 24px;">
-                    <span style="font-size: 15pt; font-weight: 800;">Share track</span>
-                    <adw-preferences-group>
-                        <adw-action-row title="Copy link" activatable>
-                            <span slot="prefix" class="adw-icon adw-icon--edit-copy"></span>
-                        </adw-action-row>
-                        <adw-action-row title="Send to a friend" activatable>
-                            <span slot="prefix" class="adw-icon adw-icon--mail-send"></span>
-                        </adw-action-row>
-                        <adw-action-row title="Add to playlist" activatable>
-                            <span slot="prefix" class="adw-icon adw-icon--list-add"></span>
-                        </adw-action-row>
-                    </adw-preferences-group>
-                </div>
-            </adw-bottom-sheet-sheet>
-        </adw-bottom-sheet>
-    </div>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/presentation.mdx
+++ b/website/src/content/docs/adwaita/presentation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Presentation
-description: "Adwaita presentation widgets: avatar, banner, shortcut label, spinner, status page and window title. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita presentation widgets: avatar, banner, shortcut label, spinner, status page and window title. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -11,16 +11,18 @@ These widgets show state and identity rather than collect input. Use an
 work is running, a **status page** for an empty or error state, and a **window
 title** in a header bar.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so behaviour Libadwaita drives natively (a
@@ -38,7 +40,9 @@ full profile header.
 
 <AdwWidget title="Adw.Avatar">
   <Fragment slot="preview">
+    ```html
     <adw-avatar text="Ada Lovelace" size="96" show-initials icon="avatar-default"></adw-avatar>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -65,12 +69,6 @@ full profile header.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <adw-avatar text="Ada Lovelace" size="96" show-initials icon="avatar-default"></adw-avatar>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwAvatar } from '@gjsify/adwaita-nativescript';
@@ -93,7 +91,9 @@ space while the message applies.
 
 <AdwWidget title="Adw.Banner">
   <Fragment slot="preview">
+    ```html
     <adw-banner title="Metered connection: updates paused" button-label="Resume" revealed></adw-banner>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -123,11 +123,6 @@ space while the message applies.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-banner title="Metered connection: updates paused" button-label="Resume" revealed></adw-banner>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwBanner } from '@gjsify/adwaita-nativescript';
@@ -152,6 +147,7 @@ shows the **disabled-text** placeholder instead.
 
 <AdwWidget title="Adw.ShortcutLabel">
   <Fragment slot="preview">
+    ```html
     <div style="display:flex;flex-wrap:wrap;gap:24px;justify-content:center;align-items:center;">
       <adw-shortcut-label accelerator="&lt;Control&gt;C"></adw-shortcut-label>
       <adw-shortcut-label accelerator="&lt;Shift&gt;A Home"></adw-shortcut-label>
@@ -159,6 +155,7 @@ shows the **disabled-text** placeholder instead.
       <adw-shortcut-label accelerator="Control_L&amp;Control_R"></adw-shortcut-label>
       <adw-shortcut-label accelerator="" disabled-text="Disabled"></adw-shortcut-label>
     </div>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -209,15 +206,6 @@ shows the **disabled-text** placeholder instead.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-shortcut-label accelerator="&lt;Control&gt;C"></adw-shortcut-label>
-    <adw-shortcut-label accelerator="&lt;Shift&gt;A Home"></adw-shortcut-label>
-    <adw-shortcut-label accelerator="&lt;Alt&gt;1...9"></adw-shortcut-label>
-    <adw-shortcut-label accelerator="Control_L&amp;Control_R"></adw-shortcut-label>
-    <adw-shortcut-label accelerator="" disabled-text="Disabled"></adw-shortcut-label>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwShortcutLabel } from '@gjsify/adwaita-nativescript';
@@ -240,7 +228,9 @@ instead.
 
 <AdwWidget title="Adw.Spinner">
   <Fragment slot="preview">
+    ```html
     <adw-spinner size="48"></adw-spinner>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -266,11 +256,6 @@ instead.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-spinner size="48"></adw-spinner>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwSpinner } from '@gjsify/adwaita-nativescript';
@@ -287,13 +272,13 @@ Fill an empty, error or welcome screen with a centred placeholder: a large
 symbolic **icon**, a **title** and a **description**. Add a **child** widget to
 give the user a way out, such as a button that creates their first document.
 
-<AdwWidget title="Adw.StatusPage" padding="flush">
+<AdwWidget title="Adw.StatusPage" padding="flush" stage="height: 320px; display:flex;">
   <Fragment slot="preview">
-    <div style="height: 320px; display:flex;">
-      <adw-status-page icon="folder" title="No Documents" description="Documents you create or open will appear here.">
-        <adw-button label="New Document" pill suggested></adw-button>
-      </adw-status-page>
-    </div>
+    ```html
+    <adw-status-page icon="folder" title="No Documents" description="Documents you create or open will appear here.">
+      <adw-button label="New Document" pill suggested></adw-button>
+    </adw-status-page>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -333,13 +318,6 @@ give the user a way out, such as a button that creates their first document.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-status-page icon="folder" title="No Documents" description="Documents you create or open will appear here.">
-        <adw-button label="New Document" pill suggested></adw-button>
-    </adw-status-page>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwButton, AdwStatusPage } from '@gjsify/adwaita-nativescript';
@@ -366,7 +344,9 @@ so a single-line title stays vertically centred.
 
 <AdwWidget title="Adw.WindowTitle">
   <Fragment slot="preview">
+    ```html
     <adw-window-title title="Inbox" subtitle="3 unread messages"></adw-window-title>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -387,11 +367,6 @@ so a single-line title stays vertically centred.
       title: _("Inbox");
       subtitle: _("3 unread messages");
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-window-title title="Inbox" subtitle="3 unread messages"></adw-window-title>
     ```
   </Fragment>
   <Fragment slot="nativescript">

--- a/website/src/content/docs/adwaita/view-switching.mdx
+++ b/website/src/content/docs/adwaita/view-switching.mdx
@@ -1,6 +1,6 @@
 ---
 title: View Switching
-description: "Adwaita view-switching widgets: view switcher, view switcher bar, tab view, inline view switcher and carousel. Live preview plus the code for GJS, Blueprint, the web and NativeScript."
+description: "Adwaita view-switching widgets: view switcher, view switcher bar, tab view, inline view switcher and carousel. A live preview with its markup, plus the TypeScript, Blueprint and NativeScript code."
 ---
 
 import AdwWidget from '../../../components/AdwWidget.astro';
@@ -12,16 +12,18 @@ edge for a narrow window, a strip of tabs, a compact toolbar control and a
 swipeable pager. All of them adapt to the window, so a wide desktop gets the full
 switcher and a narrow phone gets a collapsed one.
 
-Each preview below is the live web component, so it follows the light and dark
-toggle the way a real window would. Under it, the tabs give you the same widget
-four ways: `@girs` TypeScript (one program, running on GJS, Node, Bun and Deno),
-the matching Blueprint declaration, the web port and the NativeScript port.
+Each block below is a stack of windows. The first one RUNS the widget: the preview
+is the live browser port, so it follows the light and dark toggle the way a real
+window would, and the tab under it holds the very markup that paints it. Then comes
+one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
+declaration beside it, and **NativeScript**, the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).
 [`@gjsify/adwaita-web`](https://github.com/gjsify/gjsify/tree/main/packages/web/adwaita-web)
 and [`@gjsify/adwaita-nativescript`](https://github.com/gjsify/gjsify/tree/main/packages/nativescript-bridge/adwaita)
-follow its naming, and where one of them differs, its tab says so.
+follow its naming, and where one of them differs, its own window says so.
 
 :::note
 The previews run the browser port, so gestures Libadwaita drives natively
@@ -38,21 +40,21 @@ button layout. `wide` puts the icon and label side by side; `narrow` stacks the
 icon above the label so the bar fits a slim window. An adaptive layout normally
 swaps between the two on a breakpoint.
 
-<AdwWidget title="Adw.ViewSwitcher" padding="flush">
+<AdwWidget title="Adw.ViewSwitcher" padding="flush" stage="height: 300px; width: 100%; display: flex; flex-direction: column;">
   <Fragment slot="preview">
-    <div style="height: 300px; width: 100%; display: flex; flex-direction: column;">
-      <adw-view-switcher policy="wide" style="flex: 1; width: 100%;">
-        <adw-view-switcher-page name="inbox" title="Inbox" icon-name="mail-unread">
-          <adw-status-page icon="mail-unread" title="Inbox" description="You have three unread conversations."></adw-status-page>
-        </adw-view-switcher-page>
-        <adw-view-switcher-page name="starred" title="Starred" icon-name="starred">
-          <adw-status-page icon="starred" title="Starred" description="Messages you have marked as important."></adw-status-page>
-        </adw-view-switcher-page>
-        <adw-view-switcher-page name="archive" title="Archive" icon-name="folder">
-          <adw-status-page icon="folder" title="Archive" description="Older conversations kept for reference."></adw-status-page>
-        </adw-view-switcher-page>
-      </adw-view-switcher>
-    </div>
+    ```html
+    <adw-view-switcher policy="wide" style="flex: 1; width: 100%;">
+      <adw-view-switcher-page name="inbox" title="Inbox" icon-name="mail-unread">
+        <adw-status-page icon="mail-unread" title="Inbox" description="You have three unread conversations."></adw-status-page>
+      </adw-view-switcher-page>
+      <adw-view-switcher-page name="starred" title="Starred" icon-name="starred">
+        <adw-status-page icon="starred" title="Starred" description="Messages you have marked as important."></adw-status-page>
+      </adw-view-switcher-page>
+      <adw-view-switcher-page name="archive" title="Archive" icon-name="folder">
+        <adw-status-page icon="folder" title="Archive" description="Older conversations kept for reference."></adw-status-page>
+      </adw-view-switcher-page>
+    </adw-view-switcher>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -140,22 +142,6 @@ swaps between the two on a breakpoint.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- import '@gjsify/adwaita-web' once to register the elements -->
-    <adw-view-switcher policy="wide">
-        <adw-view-switcher-page name="inbox" title="Inbox" icon-name="mail-unread">
-            <adw-status-page icon="mail-unread" title="Inbox" description="You have three unread conversations."></adw-status-page>
-        </adw-view-switcher-page>
-        <adw-view-switcher-page name="starred" title="Starred" icon-name="starred">
-            <adw-status-page icon="starred" title="Starred" description="Messages you have marked as important."></adw-status-page>
-        </adw-view-switcher-page>
-        <adw-view-switcher-page name="archive" title="Archive" icon-name="folder">
-            <adw-status-page icon="folder" title="Archive" description="Older conversations kept for reference."></adw-status-page>
-        </adw-view-switcher-page>
-    </adw-view-switcher>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwViewSwitcher, AdwStatusPage, type AdwViewPage } from '@gjsify/adwaita-nativescript';
@@ -190,24 +176,25 @@ stack. `reveal` is a **request, not a state**: a stack with fewer than two pages
 stays collapsed however loudly it is asked, so a bar over a one-page stack simply
 does not appear.
 
-<AdwWidget title="Adw.ViewSwitcherBar" padding="flush">
+<AdwWidget title="Adw.ViewSwitcherBar" padding="flush" stage="height: 340px; width: 100%; display: flex; flex-direction: column;">
   <Fragment slot="preview">
-    <div style="height: 340px; width: 100%; display: flex; flex-direction: column;">
-      <adw-toolbar-view style="flex: 1; width: 100%;">
-        <adw-view-stack id="gallery-switcher-bar-stack" style="flex: 1;">
-          <adw-view-stack-page name="inbox" title="Inbox" icon-name="mail-unread">
-            <adw-status-page icon="mail-unread" title="Inbox" description="The inbox page."></adw-status-page>
-          </adw-view-stack-page>
-          <adw-view-stack-page name="starred" title="Starred" icon-name="starred">
-            <adw-status-page icon="starred" title="Starred" description="The starred page."></adw-status-page>
-          </adw-view-stack-page>
-          <adw-view-stack-page name="archive" title="Archive" icon-name="folder">
-            <adw-status-page icon="folder" title="Archive" description="The archive page."></adw-status-page>
-          </adw-view-stack-page>
-        </adw-view-stack>
-        <adw-view-switcher-bar data-adw-slot="bottom" stack="gallery-switcher-bar-stack" reveal></adw-view-switcher-bar>
-      </adw-toolbar-view>
-    </div>
+    ```html
+    <!-- `stack` takes the id of the <adw-view-stack> to bind to. -->
+    <adw-toolbar-view style="flex: 1; width: 100%;">
+      <adw-view-stack id="gallery-switcher-bar-stack" style="flex: 1;">
+        <adw-view-stack-page name="inbox" title="Inbox" icon-name="mail-unread">
+          <adw-status-page icon="mail-unread" title="Inbox" description="The inbox page."></adw-status-page>
+        </adw-view-stack-page>
+        <adw-view-stack-page name="starred" title="Starred" icon-name="starred">
+          <adw-status-page icon="starred" title="Starred" description="The starred page."></adw-status-page>
+        </adw-view-stack-page>
+        <adw-view-stack-page name="archive" title="Archive" icon-name="folder">
+          <adw-status-page icon="folder" title="Archive" description="The archive page."></adw-status-page>
+        </adw-view-stack-page>
+      </adw-view-stack>
+      <adw-view-switcher-bar slot="bottom" stack="gallery-switcher-bar-stack" reveal></adw-view-switcher-bar>
+    </adw-toolbar-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -286,25 +273,6 @@ does not appear.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- `stack` takes the id of the <adw-view-stack> to bind to. -->
-    <adw-toolbar-view>
-        <adw-view-stack id="mail-stack">
-            <adw-view-stack-page name="inbox" title="Inbox" icon-name="mail-unread">
-                <adw-status-page icon="mail-unread" title="Inbox"></adw-status-page>
-            </adw-view-stack-page>
-            <adw-view-stack-page name="starred" title="Starred" icon-name="starred">
-                <adw-status-page icon="starred" title="Starred"></adw-status-page>
-            </adw-view-stack-page>
-            <adw-view-stack-page name="archive" title="Archive" icon-name="folder">
-                <adw-status-page icon="folder" title="Archive"></adw-status-page>
-            </adw-view-stack-page>
-        </adw-view-stack>
-        <adw-view-switcher-bar slot="bottom" stack="mail-stack" reveal></adw-view-switcher-bar>
-    </adw-toolbar-view>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwStatusPage, AdwToolbarView, AdwViewStack, AdwViewSwitcherBar } from '@gjsify/adwaita-nativescript';
@@ -345,21 +313,21 @@ draws one chip per page, each with a title and a close button, and raises the
 selected chip onto the view background. Turn on **autohide** and the bar
 disappears once a single page is left, so a one-tab document looks chrome-free.
 
-<AdwWidget title="Adw.TabView" padding="flush">
+<AdwWidget title="Adw.TabView" padding="flush" stage="height: 260px; width: 100%; display: flex;">
   <Fragment slot="preview">
-    <div style="height: 260px; width: 100%; display: flex;">
-      <adw-tab-view style="flex: 1; width: 100%;">
-        <adw-tab-page title="Overview">
-          <adw-status-page icon="view-paged" title="Overview" description="A summary of everything at a glance."></adw-status-page>
-        </adw-tab-page>
-        <adw-tab-page title="Details">
-          <adw-status-page icon="view-paged" title="Details" description="The specifics, broken down line by line."></adw-status-page>
-        </adw-tab-page>
-        <adw-tab-page title="History">
-          <adw-status-page icon="view-paged" title="History" description="A log of every change made so far."></adw-status-page>
-        </adw-tab-page>
-      </adw-tab-view>
-    </div>
+    ```html
+    <adw-tab-view style="flex: 1; width: 100%;">
+      <adw-tab-page title="Overview">
+        <adw-status-page icon="view-paged" title="Overview" description="A summary of everything at a glance."></adw-status-page>
+      </adw-tab-page>
+      <adw-tab-page title="Details">
+        <adw-status-page icon="view-paged" title="Details" description="The specifics, broken down line by line."></adw-status-page>
+      </adw-tab-page>
+      <adw-tab-page title="History">
+        <adw-status-page icon="view-paged" title="History" description="A log of every change made so far."></adw-status-page>
+      </adw-tab-page>
+    </adw-tab-view>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -402,21 +370,6 @@ disappears once a single page is left, so a one-tab document looks chrome-free.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-tab-view>
-        <adw-tab-page title="Overview">
-            <adw-status-page icon="view-paged" title="Overview" description="A summary of everything at a glance."></adw-status-page>
-        </adw-tab-page>
-        <adw-tab-page title="Details">
-            <adw-status-page icon="view-paged" title="Details" description="The specifics, broken down line by line."></adw-status-page>
-        </adw-tab-page>
-        <adw-tab-page title="History">
-            <adw-status-page icon="view-paged" title="History" description="A log of every change made so far."></adw-status-page>
-        </adw-tab-page>
-    </adw-tab-view>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwTabView, AdwStatusPage, type AdwViewPage } from '@gjsify/adwaita-nativescript';
@@ -447,21 +400,21 @@ from a linked toggle group and drives the same kind of view stack, but its
 **display mode** lets each toggle show **labels**, **icons** or **both**. That
 makes it fit a header bar or a tight toolbar.
 
-<AdwWidget title="Adw.InlineViewSwitcher" padding="flush">
+<AdwWidget title="Adw.InlineViewSwitcher" padding="flush" stage="height: 300px; width: 100%; display: flex; flex-direction: column;">
   <Fragment slot="preview">
-    <div style="height: 300px; width: 100%; display: flex; flex-direction: column;">
-      <adw-inline-view-switcher display-mode="both" style="flex: 1; width: 100%;">
-        <adw-view-stack-page title="Overview" icon-name="view-grid">
-          <adw-status-page id="overview" icon="view-grid" title="Overview" description="A quick summary of your project."></adw-status-page>
-        </adw-view-stack-page>
-        <adw-view-stack-page title="Activity" icon-name="document-edit">
-          <adw-status-page id="activity" icon="document-edit" title="Activity" description="Recent edits and changes."></adw-status-page>
-        </adw-view-stack-page>
-        <adw-view-stack-page title="Settings" icon-name="emblem-system">
-          <adw-status-page id="settings" icon="emblem-system" title="Settings" description="Configure how things behave."></adw-status-page>
-        </adw-view-stack-page>
-      </adw-inline-view-switcher>
-    </div>
+    ```html
+    <adw-inline-view-switcher display-mode="both" style="flex: 1; width: 100%;">
+      <adw-view-stack-page title="Overview" icon-name="view-grid">
+        <adw-status-page id="overview" icon="view-grid" title="Overview" description="A quick summary of your project."></adw-status-page>
+      </adw-view-stack-page>
+      <adw-view-stack-page title="Activity" icon-name="document-edit">
+        <adw-status-page id="activity" icon="document-edit" title="Activity" description="Recent edits and changes."></adw-status-page>
+      </adw-view-stack-page>
+      <adw-view-stack-page title="Settings" icon-name="emblem-system">
+        <adw-status-page id="settings" icon="emblem-system" title="Settings" description="Configure how things behave."></adw-status-page>
+      </adw-view-stack-page>
+    </adw-inline-view-switcher>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -548,21 +501,6 @@ makes it fit a header bar or a tight toolbar.
     }
     ```
   </Fragment>
-  <Fragment slot="web">
-    ```html
-    <adw-inline-view-switcher display-mode="both">
-        <adw-view-stack-page title="Overview" icon-name="view-grid">
-            <adw-status-page id="overview" icon="view-grid" title="Overview" description="A quick summary of your project."></adw-status-page>
-        </adw-view-stack-page>
-        <adw-view-stack-page title="Activity" icon-name="document-edit">
-            <adw-status-page id="activity" icon="document-edit" title="Activity" description="Recent edits and changes."></adw-status-page>
-        </adw-view-stack-page>
-        <adw-view-stack-page title="Settings" icon-name="emblem-system">
-            <adw-status-page id="settings" icon="emblem-system" title="Settings" description="Configure how things behave."></adw-status-page>
-        </adw-view-stack-page>
-    </adw-inline-view-switcher>
-    ```
-  </Fragment>
   <Fragment slot="nativescript">
     ```ts
     import { AdwInlineViewSwitcher, AdwStatusPage, type AdwViewPage } from '@gjsify/adwaita-nativescript';
@@ -612,28 +550,31 @@ them on to let one flick skip several pages — with the caveat that a *touchpad
 flick can already cross more than one page here, because that gesture is the
 browser's and it does not consult the setting.
 
-<AdwWidget title="Adw.Carousel" padding="flush">
+<AdwWidget title="Adw.Carousel" padding="flush" stage="height: 220px; width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px;">
   <Fragment slot="preview">
-    <div style="height: 220px; width: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px;">
-      <adw-carousel id="view-switching-carousel" style="width: 100%; max-width: 480px; height: 160px;">
-        {/* No `color` on these three on purpose. Each tints itself with 14% of an
-            accent over `--window-bg-color`, so in the LIGHT scheme the fill lands near
-            rgb(222, 234, 248), and the `#ffffff` they carried put white text on that
-            at about 1.2:1: the labels were invisible under the site's light toggle
-            while looking right in dark. Inherited, the label takes `--card-fg-color`,
-            near-black in light and `#ffffff` in dark, so dark is unchanged. */}
-        <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, var(--accent-bg-color) 14%, var(--window-bg-color));box-sizing:border-box;">
-          <span style="font-size:24pt;font-weight:800;">Welcome</span>
-        </adw-card>
-        <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, #2ec27e 14%, var(--window-bg-color));box-sizing:border-box;">
-          <span style="font-size:24pt;font-weight:800;">Discover</span>
-        </adw-card>
-        <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, #e5a50a 14%, var(--window-bg-color));box-sizing:border-box;">
-          <span style="font-size:24pt;font-weight:800;">Get started</span>
-        </adw-card>
-      </adw-carousel>
-      <adw-carousel-indicator-dots for="view-switching-carousel"></adw-carousel-indicator-dots>
-    </div>
+    ```html
+    <adw-carousel id="view-switching-carousel" style="width: 100%; max-width: 480px; height: 160px;">
+      <!-- The wheel pages the carousel by default; allow-scroll-wheel="false" opts out.
+           Bind an indicator with `for`; swap in adw-carousel-indicator-lines for lines.
+
+           No `color` on these three on purpose. Each tints itself with 14% of an
+           accent over `--window-bg-color`, so in the LIGHT scheme the fill lands near
+           rgb(222, 234, 248), and the `#ffffff` they carried put white text on that
+           at about 1.2:1: the labels were invisible under the site's light toggle
+           while looking right in dark. Inherited, the label takes `--card-fg-color`,
+           near-black in light and `#ffffff` in dark, so dark is unchanged. -->
+      <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, var(--accent-bg-color) 14%, var(--window-bg-color));box-sizing:border-box;">
+        <span style="font-size:24pt;font-weight:800;">Welcome</span>
+      </adw-card>
+      <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, #2ec27e 14%, var(--window-bg-color));box-sizing:border-box;">
+        <span style="font-size:24pt;font-weight:800;">Discover</span>
+      </adw-card>
+      <adw-card style="width:440px;height:140px;display:flex;align-items:center;justify-content:center;background-color:color-mix(in srgb, #e5a50a 14%, var(--window-bg-color));box-sizing:border-box;">
+        <span style="font-size:24pt;font-weight:800;">Get started</span>
+      </adw-card>
+    </adw-carousel>
+    <adw-carousel-indicator-dots for="view-switching-carousel"></adw-carousel-indicator-dots>
+    ```
   </Fragment>
   <Fragment slot="gjs">
     ```ts
@@ -698,18 +639,6 @@ browser's and it does not consult the setting.
         carousel: carousel;
       }
     }
-    ```
-  </Fragment>
-  <Fragment slot="web">
-    ```html
-    <!-- The wheel pages the carousel by default; allow-scroll-wheel="false" opts out. -->
-    <adw-carousel id="onboarding">
-        <adw-card>Welcome</adw-card>
-        <adw-card>Discover</adw-card>
-        <adw-card>Get started</adw-card>
-    </adw-carousel>
-    <!-- Bind an indicator via `for`; swap in adw-carousel-indicator-lines for lines. -->
-    <adw-carousel-indicator-dots for="onboarding"></adw-carousel-indicator-dots>
     ```
   </Fragment>
   <Fragment slot="nativescript">


### PR DESCRIPTION
Stacked on #1373 — it is the base branch, and its React Native tab is inherited here (as
the first tab of a new **UI frameworks** window). Review or merge that one first.

## The measured defect

Every one of the gallery's 40 `<AdwWidget>` blocks carried BOTH a `<Fragment slot="preview">`
(markup cloned and rendered live) and a `<Fragment slot="web">` (an HTML snippet). They were
the same thing written twice, and nothing checked them. Re-measured here, normalising
whitespace, comments and the `data-adw-slot`→`slot` rewrite:

| | |
|---|---|
| byte-identical | **17** |
| already diverged | **23** |

What the 23 actually were:

- **12 stage scaffolding.** A `<div style="height: 340px; …">` around a widget that fills a
  window. Sixteen blocks have one; five repeated it in the snippet and eleven did not. That
  is the whole drift in one habit.
- **9 a dropped host.** Eight rows previewed inside an `<adw-preferences-group>` and the
  snippet showed the bare row; `Adw.PreferencesGroup` itself previewed three rows and
  snipped two.
- **4 plain drift.** `Adw.ViewSwitcherBar` bound a different stack id and dropped three
  descriptions. `Adw.Carousel`'s snippet was a different document from the page.
  `Gtk.Entry`'s snippet had a second entry the preview never had. `Adw.BottomSheet`'s
  preview carried `data-adw-toggle-open`, which **nothing in the repository reads**.
- **1 genuinely different in kind.** `Adw.Toast`: the snippet is imperative JS, the preview
  is the overlay's internal DOM.

## What was built

**One preview window, then one window per KIND** — because the flat tab list erased a
distinction a reader cannot recover: `gjs`/`blueprint` ARE libadwaita, `web` and
`nativescript` are reimplementations, and the framework tabs drive the real one.

| Window | Subtitle | Tabs |
|---|---|---|
| *the widget's own name* | `@gjsify/adwaita-web — import it once to register these elements` | HTML |
| Vanilla TypeScript | `GJS · Node · Bun · Deno — one program, four runtimes` | TypeScript, Blueprint |
| UI frameworks | `on GTK, through @gjsify/gtk-host` | React Native |
| NativeScript | `@gjsify/adwaita-nativescript — the port that runs on a phone` | TypeScript |

Both claims that lived in tab labels moved onto a window rather than dying: the four
runtimes, so no one of them reads as "the variant"; and "on GTK", so a React Native tab
cannot read as the port that runs on a phone. The preview window carries the WIDGET's title,
because a header bar names whatever it sits on and this one sits on the running widget.

## The duplicate is gone, not policed

The `preview` slot is a fenced ` ```html ` block now. The window **shows** that fence
(Expressive Code, exactly as authored) and **mounts** it: Expressive Code hands the raw
source back on the copy button's `data-code`, with newlines as U+007F, so the markup is read
back out of the render. One fence, both surfaces.

Measured on the built site: **39 of 40 previews mount markup byte-identical to their own
HTML tab.** The 40th is `Adw.Toast`, ledgered with its reason — `<adw-toast-overlay>` has no
declarative toast child, so a static preview can only depict the result.

Two consequences worth naming:

- **`data-adw-slot` is retired here.** The fence never passes the MDX compiler, which reads
  `slot` as its own directive and strips it, so `slot="…"` survives as written.
  `AdwGalleryCard` still needs the workaround and says so.
- **Scaffolding is a prop.** The stage style is `stage="…"`, taken verbatim from the wrapper
  it replaces so the computed layout is unchanged — an inline style on the element that
  wrapper's parent already was.

## The gate

`check-website-adwaita-gallery.mjs` reads `WINDOWS` instead of `IMPLS`, and gains two arms:

- **7** — a window with no tabs, or no tab any page fills. Arm 6 cannot see a window declared
  with an empty `tabs` list: there is no slot to be unprovided.
- **8** — the markup override, held against a ledger in both directions. This is what keeps
  the unification honest: a second hand-kept copy of a widget's markup is refused unless it
  is named with a reason.

Every arm falsified, both directions:

| mutation | exit |
|---|---|
| baseline | 0 |
| arm 5 — page names a slot the component has not got | 1 |
| arm 6 — component names a port no page has got | 1 |
| arm 7 — window declared with `tabs: []` | 1 |
| arm 7 — window whose every tab is unprovided | 1 |
| arm 8 — unledgered block overrides its own markup | 1 |
| arm 8 — stale ledger entry | 1 |
| guard — `WINDOWS` unreadable | 1 |
| guard — `MARKUP_OVERRIDE` unreadable | 1 |
| baseline, restored | 0 |

## Rendered

`astro build` green, 62 pages. Counted in the built HTML: **122 windows over 162 tabs** —
3 windows / 4 tabs per widget, plus the UI frameworks window on the two Layout widgets that
have a React Native snippet. Layout: 14 windows, 18 tabs. Boxed Lists: 27 windows, 36 tabs.

## Checks

`oxfmt --check .` 0 · `oxlint scripts website` 0 · `check-website-adwaita-gallery` 0 ·
`check-doc-fences` 0 · `audit-runtimes --check` 0 · `check-website-preview-not-content` 0 ·
`check-generated-website-data` 0 · `astro build` 0.

## One thing this trades away

`check-website-preview-not-content.mjs` masks fenced code, so it no longer reads the gallery
pages' preview markup. That coverage became structural instead: one component mounts every
preview, into one `.not-content` element, and the component says so where the marker is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9HRKqQZskrYLVer1fuFvg
