### PR TITLE
feat(website): a window is a title and its panes

### DIFF
--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -69,7 +69,10 @@
 //      block of HTML for a widget the reader has not seen yet, and NOTHING else would
 //      notice: arm 8 still holds, both tabs still render, the fence is still authored
 //      once. It is a source-order read because the panes are laid out in the template,
-//      and this gate deliberately runs without a build.
+//      and this gate deliberately runs without a build — so it reads the file with its
+//      COMMENTS BLANKED OUT and counts the mount, because a marker named in prose above
+//      the tabs, or mounted twice, is how a source-text read goes green over the defect
+//      it is named after.
 //
 // The `title` IS the join: `Adw.ViewSwitcherBar` → `view-switcher-bar`, the same
 // bare name the widget files, the story metas and the ledgers are already spelled
@@ -183,21 +186,46 @@ const PREVIEW_MOUNT = 'adw-widget-preview-tpl';
 const TAB_MAP = 'tabs.map(';
 
 /**
- * Arm 9: the live preview is emitted BEFORE the code tabs, inside the tab view.
+ * The same file with its comments blanked out.
  *
- * Returns null when it is, or the reason it is not.
+ * Arm 9 is a SOURCE-TEXT read, and a source-text read that counts PROSE is how a
+ * check goes green while the thing it names is gone. That is not hypothetical here:
+ * `check-website-preview-not-content.mjs` shipped in exactly that state — its first
+ * cut asked whether a file CONTAINED the marker string, and `AdwGalleryCard.astro`
+ * carries an eight-line comment naming the marker, so deleting the marker from its
+ * markup left the check green. Measured again on this arm: move the preview after
+ * the code tabs and leave `adw-widget-preview-tpl` in a comment above them, and the
+ * unmasked read exits 0 on a window that opens on HTML.
+ *
+ * Line comments are anchored to the start of a line so that a `https://` inside an
+ * attribute is not read as one.
+ */
+const withoutComments = (text) => text.replaceAll(/\/\*[\s\S]*?\*\//g, '').replaceAll(/^[ \t]*\/\/.*$/gm, '');
+
+/**
+ * Arm 9: the live preview is emitted BEFORE the code tabs, inside the tab view, and
+ * exactly once.
+ *
+ * The COUNTS are part of the arm, not tidiness: two preview panes render the widget
+ * twice under two "Preview" tabs mounting the same markup, and the order read alone
+ * blesses it — the first mount still precedes the tabs. Measured by duplicating the
+ * pane: exit 0.
+ *
+ * Returns null when the file is right, or the reason it is not.
  */
 function previewPanePosition(root) {
-    const text = readFileSync(join(root, WINDOW_COMPONENT), 'utf8');
+    const text = withoutComments(readFileSync(join(root, WINDOW_COMPONENT), 'utf8'));
     const view = /<adw-tab-view\b[\s\S]*?<\/adw-tab-view>/.exec(text);
     if (view === null) {
         return `holds no <adw-tab-view> … </adw-tab-view>, so there is no pane order to read`;
     }
-    const mount = view[0].indexOf(PREVIEW_MOUNT);
-    const tabs = view[0].indexOf(TAB_MAP);
-    if (mount === -1) return `mounts no preview (\`${PREVIEW_MOUNT}\`) inside its tab view`;
-    if (tabs === -1) return `renders no code tabs (\`${TAB_MAP}\`) inside its tab view`;
-    if (mount > tabs) return `mounts the preview AFTER the code tabs`;
+    const mounts = view[0].split(PREVIEW_MOUNT).length - 1;
+    const maps = view[0].split(TAB_MAP).length - 1;
+    if (mounts === 0) return `mounts no preview (\`${PREVIEW_MOUNT}\`) inside its tab view`;
+    if (maps === 0) return `renders no code tabs (\`${TAB_MAP}\`) inside its tab view`;
+    if (mounts > 1) return `mounts ${mounts} previews inside its tab view, and a window runs the widget once`;
+    if (maps > 1) return `renders the code tabs ${maps} times inside its tab view`;
+    if (view[0].indexOf(PREVIEW_MOUNT) > view[0].indexOf(TAB_MAP)) return `mounts the preview AFTER the code tabs`;
     return null;
 }
 

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -42,8 +42,8 @@
 //      5 refuses a page naming a port the component has not got, 6 refuses a component
 //      naming a port no page has got.
 //   7. Every WINDOW has at least one tab, and at least one tab some block provides. A
-//      window is a header bar, a title and a subtitle around its tabs; declared with an
-//      empty `tabs` list it renders that chrome over nothing, on all 40 blocks, and arm
+//      window is a header bar, a title and its tabs; declared with an empty `tabs` list
+//      it announces a kind of implementation that renders on no block at all, and arm
 //      6 cannot see it because there is no slot to be unprovided. Same class as 6, one
 //      level up — the level the restructure added.
 //   8. Every block providing the MARKUP OVERRIDE is ledgered in
@@ -58,6 +58,18 @@
 //      across the 40 blocks 17 were byte-identical and 23 had already diverged, with
 //      nothing checking either way. One policed copy, named and reasoned, is the price
 //      of the widget whose API is imperative; a second one has to say why.
+//   9. The LIVE PREVIEW is the FIRST pane of the window that runs the widget, in
+//      {@link WINDOW_COMPONENT} — the file that draws a window, which is where pane
+//      order is decided.
+//
+//      The preview and the markup tab beside it are ONE source: the pane mounts the
+//      bytes the tab shows. Order is what makes that legible — the reader meets the
+//      widget, then the markup that painted it, which is the order every gallery page's
+//      prose promises ("The first one RUNS the widget"). Swapped, the window opens on a
+//      block of HTML for a widget the reader has not seen yet, and NOTHING else would
+//      notice: arm 8 still holds, both tabs still render, the fence is still authored
+//      once. It is a source-order read because the panes are laid out in the template,
+//      and this gate deliberately runs without a build.
 //
 // The `title` IS the join: `Adw.ViewSwitcherBar` → `view-switcher-bar`, the same
 // bare name the widget files, the story metas and the ledgers are already spelled
@@ -158,6 +170,36 @@ function widgetBlocks(root, pages) {
 
 /** The tab component: the one place a port is declared. */
 const WIDGET_COMPONENT = 'website/src/components/AdwWidget.astro';
+
+/**
+ * The component that DRAWS one window, as opposed to declaring it. Pane order is a
+ * fact about this file: `WINDOWS` says which tabs a window has, this file says where
+ * the live preview sits among them.
+ */
+const WINDOW_COMPONENT = 'website/src/components/AdwWidgetWindow.astro';
+
+/** The mounted preview's own element, and the expression that renders the code tabs. */
+const PREVIEW_MOUNT = 'adw-widget-preview-tpl';
+const TAB_MAP = 'tabs.map(';
+
+/**
+ * Arm 9: the live preview is emitted BEFORE the code tabs, inside the tab view.
+ *
+ * Returns null when it is, or the reason it is not.
+ */
+function previewPanePosition(root) {
+    const text = readFileSync(join(root, WINDOW_COMPONENT), 'utf8');
+    const view = /<adw-tab-view\b[\s\S]*?<\/adw-tab-view>/.exec(text);
+    if (view === null) {
+        return `holds no <adw-tab-view> … </adw-tab-view>, so there is no pane order to read`;
+    }
+    const mount = view[0].indexOf(PREVIEW_MOUNT);
+    const tabs = view[0].indexOf(TAB_MAP);
+    if (mount === -1) return `mounts no preview (\`${PREVIEW_MOUNT}\`) inside its tab view`;
+    if (tabs === -1) return `renders no code tabs (\`${TAB_MAP}\`) inside its tab view`;
+    if (mount > tabs) return `mounts the preview AFTER the code tabs`;
+    return null;
+}
 
 /**
  * Blocks whose `preview` fence is NOT the markup a reader should copy, so the
@@ -370,9 +412,9 @@ for (const window of windows) {
     if (window.slots.length === 0) {
         failures.push(
             `${WIDGET_COMPONENT} declares the window "${window.id}" with no tabs at all. A window is a\n` +
-                '    header bar, a title and a subtitle around its tabs, so an empty one renders that chrome\n' +
-                '    over nothing on every block — and arm 6 cannot see it, because there is no slot to be\n' +
-                '    unprovided. Give it a tab, or drop the window.',
+                '    header bar, a title and its tabs, so an empty one announces a kind of implementation\n' +
+                '    that renders on no block at all — and arm 6 cannot see it, because there is no slot to\n' +
+                '    be unprovided. Give it a tab, or drop the window.',
         );
         continue;
     }
@@ -407,6 +449,20 @@ for (const title of Object.keys(MARKUP_OVERRIDE_LEDGER)) {
     );
 }
 
+// --- arm 9: the live preview is the first pane of the window that runs the widget ---
+
+const panePosition = previewPanePosition(ROOT);
+if (panePosition !== null) {
+    failures.push(
+        `${WINDOW_COMPONENT} ${panePosition}. The preview and the markup tab beside it are ONE\n` +
+            '    source — the pane mounts the bytes the tab shows — and the order is what makes that\n' +
+            '    legible: the reader meets the widget, then the markup that painted it, which is the order\n' +
+            "    every gallery page's prose promises. Swapped, the window opens on a block of HTML for a\n" +
+            '    widget the reader has not seen yet, and nothing else here would notice: both tabs still\n' +
+            '    render and the fence is still authored once.',
+    );
+}
+
 if (failures.length > 0) {
     console.error(`check-website-adwaita-gallery: ${failures.length} gallery/storybook disagreement(s):\n`);
     for (const failure of failures) console.error(`  - ${failure}`);
@@ -428,5 +484,6 @@ console.log(
     `check-website-adwaita-gallery: ${windows.length} window(s) in ${WIDGET_COMPONENT} — ` +
         `${windows.map((w) => `${w.id} [${w.slots.join(' ')}]`).join(', ')} — each with a tab at least one ` +
         `of ${blocks.length} blocks provides, every fragment slot they write is one the component renders, ` +
-        `and ${overriding.size} block(s) override the markup tab, all ledgered.`,
+        `${overriding.size} block(s) override the markup tab, all ledgered, and ${WINDOW_COMPONENT} mounts ` +
+        'the live preview ahead of them.',
 );

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -376,10 +376,17 @@ for (const spec of WINDOWS) {
     const applyPreference = (impl: string | null, skip?: Element) => {
         if (!impl) return;
         for (const el of document.querySelectorAll<HTMLElement>('[data-impl-tabs]')) {
-            // The MARKED view, not the first one: a preview that is itself an
-            // `<adw-tab-view>` precedes it in DOM order, so `querySelector` handed
-            // back the preview and silently retargeted it whenever the reader picked
-            // an implementation on any other widget.
+            // The MARKED view, not just any: a mounted preview can itself be an
+            // `<adw-tab-view>` — the Adw.TabView block on /adwaita/view-switching/ is
+            // one — and an unmarked `querySelector` handed that one back and silently
+            // retargeted it whenever the reader picked an implementation on any other
+            // widget. It used to PRECEDE this view, back when the preview was a pane
+            // above the tab bar; now that the preview is the first TAB it is a
+            // DESCENDANT of this view (measured on the built page: the marked view at
+            // byte 784, the preview's own at 985), so an unmarked selector would
+            // happen to answer right today. The marker stays, because what makes it
+            // right is that it names the window's OWN view rather than where the
+            // preview currently sits.
             const view = el.querySelector('adw-tab-view[data-impl-view]');
             if (!view || view === skip) continue;
             const impls = (el.dataset.impls ?? '').split(',');

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -246,6 +246,21 @@ const decodeEcCode = (html: string): string | null => {
  */
 const LIVE_PANE = 'live';
 
+// That requirement, held rather than stated. `data-impls` is POSITIONAL and the
+// script below looks a pane up by name with `indexOf`, so a LIVE_PANE equal to a
+// slot name gives the live window two entries reading the same id and the first one
+// answers for both: the HTML tab could never be the remembered choice, and picking
+// it would move every OTHER preview window to its Preview pane instead. Nothing
+// else notices — the ids never leave `data-impls`, so the site builds, both tabs
+// render, and every gate stays green.
+const collidingSlot = WINDOWS.flatMap((win) => win.tabs.map((tab) => tab.slot)).find((slot) => slot === LIVE_PANE);
+if (collidingSlot !== undefined) {
+    throw new Error(
+        `AdwWidget: LIVE_PANE is "${LIVE_PANE}", which is also a tab slot. The pane ids in \`data-impls\` ` +
+            'are positional and looked up by name, so no two panes of one window can share an id.',
+    );
+}
+
 const rendered: {
     id: string;
     title: string;

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -262,13 +262,22 @@ for (const spec of WINDOWS) {
         let html = await Astro.slots.render(tab.slot);
         if (tab.slot === 'preview') {
             previewMarkup = decodeEcCode(html);
-            if (previewMarkup === null) {
-                // Loud, at build time, never at runtime: without the source there is
-                // no preview, and a silently empty stage on 40 blocks is exactly the
-                // failure this component was restructured to end.
+            // Loud, at build time, never at runtime: without the source there is no
+            // preview, and a silently empty stage on 40 blocks is exactly the failure
+            // this component was restructured to end.
+            //
+            // EMPTY counts as without. An empty ```html fence decodes to '' and not to
+            // null, so it walked past a `=== null` guard and mounted nothing: measured
+            // by emptying one fence — the site built at exit 0, this gate and
+            // `check-doc-fences.mjs` both stayed green, and /adwaita/controls/ shipped a
+            // "Preview" tab over an empty stage. That is the blank page at exit 0 with
+            // zero diagnostics that the throw below exists to prevent, so it has to
+            // cover the blank one too.
+            if (previewMarkup === null || previewMarkup.trim() === '') {
                 throw new Error(
-                    `AdwWidget(${title}): the preview slot rendered no single Expressive Code block to read ` +
-                        'its markup back from. It has to hold exactly one fenced ```html block.',
+                    `AdwWidget(${title}): the preview slot rendered no single NON-EMPTY Expressive Code ` +
+                        'block to read its markup back from. It has to hold exactly one fenced ```html ' +
+                        'block, with markup in it.',
                 );
             }
             // The one override: the markup a reader should copy, where the fence

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -6,9 +6,9 @@
 //
 //   1. LIVE PREVIEW — the real widget, painted by @gjsify/adwaita-web custom
 //      elements on an Adwaita "view" surface, with the markup that paints it as
-//      the window's one tab. No screenshots: the browser runs the component, the
-//      way the official Libadwaita widget gallery shows one, and it follows the
-//      site's light/dark toggle.
+//      the window's second tab. No screenshots: the browser runs the component,
+//      the way the official Libadwaita widget gallery shows one, and it follows
+//      the site's light/dark toggle.
 //   2. VANILLA TYPESCRIPT — `@girs` GObject-Introspection TypeScript and the
 //      matching Blueprint declaration: two FILES of one program, against the REAL
 //      libadwaita widget.
@@ -18,35 +18,37 @@
 // It used to be ONE window with those five as sibling tabs, and five siblings
 // cannot say any of it: `gjs`/`blueprint` ARE libadwaita, `web` and
 // `nativescript` are REIMPLEMENTATIONS of it, and a framework tab drives the real
-// one. A window can say it, in its title and its subtitle. {@link WINDOWS} is
-// that model and it is the one place a port is declared —
-// `scripts/check-website-adwaita-gallery.mjs` holds it against the pages in both
-// directions, and refuses a window no page fills.
+// one. A window can say it, in its title. {@link WINDOWS} is that model and it is
+// the one place a port is declared — `scripts/check-website-adwaita-gallery.mjs`
+// holds it against the pages in both directions, and refuses a window no page
+// fills.
 //
-// TWO CLAIMS THAT MOVED RATHER THAN DIED, both load-bearing:
+// TWO CLAIMS THE CHROME NO LONGER MAKES, both load-bearing, both still said:
 //
 //   · The first tab was labelled "GJS · Node · Bun · Deno" and not "GJS" on
 //     purpose: naming one runtime made the tab read as "the GJS variant", i.e. as
 //     if the other three needed a different program. They do not; that is the
-//     claim the whole site rests on. The window holding it is titled for its AXIS
-//     ("Vanilla TypeScript" — what two file tabs share), so the four runtimes are
-//     named in its SUBTITLE. Do not drop them from it.
+//     claim the whole site rests on. The window is titled for its AXIS ("Vanilla
+//     TypeScript" — what two file tabs share) and the four runtimes are named by
+//     the PAGE: every gallery page's intro says "the `@girs` program that runs
+//     unchanged on GJS, Node, Bun and Deno". A window subtitle repeating it under
+//     all 40 blocks was the second copy.
 //   · "React Native on GTK" carried its qualifier in the tab LABEL, because a
 //     plain "React Native" standing beside Web and NativeScript would have read as
 //     the port that runs on a phone — the one claim this repository must not make
-//     about code it has not written. NativeScript is its own window now, so the
-//     qualifier moved onto the window: "UI frameworks · on GTK, through
-//     @gjsify/gtk-host". Same claim, said once, covering every framework tab the
-//     window will grow.
+//     about code it has not written. The qualifier is now the page's:
+//     `layout.mdx`, the only page with that window, says it "renders a GTK window,
+//     not a phone screen — which is why it is not the NativeScript one".
 //
-// The header bar sits above BOTH panes of the preview window for the reason it
-// was put there: whatever a header bar sits on is what the reader takes the
-// window to be about. It once held the widget TITLE over a pane of code, and the
-// title read as belonging to the code. So the window carrying the widget's title
-// is the one that RUNS the widget, and every other window is titled for its kind.
+// So the header bar carries a title and nothing else. Whatever a header bar sits
+// on is what the reader takes the window to be about: it once held the widget
+// TITLE over a pane of code, and the title read as belonging to the code. The
+// window carrying the widget's title is therefore the one that RUNS the widget,
+// and every other window is titled for its kind.
 //
 // ONE SOURCE FOR THE MARKUP. The `preview` slot is a fenced ```html block: the
-// window SHOWS that fence (Expressive Code, exactly as authored) and MOUNTS it.
+// window SHOWS that fence on its HTML tab (Expressive Code, exactly as authored)
+// and MOUNTS it in the Preview tab beside it.
 // It used to be a fragment of MDX markup with a second, hand-kept `web` fence
 // beside it saying the same thing — measured across the 40 blocks, 17 were
 // byte-identical and 23 had already drifted, and nothing checked them. The drift
@@ -144,8 +146,10 @@ const attributes = ADWAITA_ATTRIBUTES[elementTag] ?? null;
 /**
  * The windows, in order, and every port this component renders.
  *
- * `subtitle` is not decoration: it is where a window says what KIND it is, and
- * two of them carry a claim that used to live in a tab label (see the header).
+ * A window says what KIND it is in its TITLE, and nothing else: the claims that
+ * used to sit under it as a subtitle are on the page (see the header). `live`
+ * marks the one window that runs the widget, whose first pane mounts the markup
+ * its next tab shows.
  */
 const WINDOWS = [
     {
@@ -154,18 +158,19 @@ const WINDOWS = [
         // one that runs the widget. See the header — a header bar names whatever
         // it sits on, and this one sits on the running component.
         title: null,
-        subtitle: '@gjsify/adwaita-web — import it once to register these elements',
-        // The pane above the tabs, where the tab's own markup is mounted and painted.
+        // The FIRST pane, where the markup of the tab beside it is mounted and
+        // painted. The reader meets the widget before its source, which is the
+        // order the page's own prose promises.
         live: true,
         tabs: [{ slot: 'preview', label: 'HTML' }],
     },
     {
         id: 'vanilla',
+        // Titled for the AXIS its two tabs share. The four runtimes that axis is
+        // about are named by every gallery page's intro, not here: the snippet is
+        // plain `@girs/*` GObject-Introspection TypeScript, which is exactly the
+        // code that runs unchanged on all four of them.
         title: 'Vanilla TypeScript',
-        // The four runtimes, verbatim from the tab label this window replaced. The
-        // snippet is plain `@girs/*` GObject-Introspection TypeScript, which is
-        // exactly the code that runs unchanged on all four of them.
-        subtitle: 'GJS · Node · Bun · Deno — one program, four runtimes',
         tabs: [
             { slot: 'gjs', label: 'TypeScript' },
             // Blueprint is a FILE of the same program, which is why it is a tab here
@@ -177,18 +182,18 @@ const WINDOWS = [
     },
     {
         id: 'frameworks',
-        title: 'UI frameworks',
         // `@gjsify/react-native` renders React Native components onto GTK 4
         // IN-PROCESS. There is no Adwaita widget set built out of React Native
         // primitives, so nothing under this window runs on a phone — which is why
-        // it is not filed with NativeScript, and why the window says GTK.
-        subtitle: 'on GTK, through @gjsify/gtk-host',
+        // it is not filed with NativeScript, and why `layout.mdx`, the only page
+        // that fills this window, says it renders a GTK window and not a phone
+        // screen.
+        title: 'UI frameworks',
         tabs: [{ slot: 'react-native', label: 'React Native' }],
     },
     {
         id: 'nativescript',
         title: 'NativeScript',
-        subtitle: '@gjsify/adwaita-nativescript — the port that runs on a phone',
         tabs: [{ slot: 'nativescript', label: 'TypeScript' }],
     },
 ];
@@ -229,10 +234,21 @@ const decodeEcCode = (html: string): string | null => {
         .replaceAll(/&#(\d+);/g, (_m, dec: string) => String.fromCodePoint(Number(dec)));
 };
 
+/**
+ * The pane id of the LIVE PREVIEW in `data-impls`.
+ *
+ * Not a slot: no page provides it, the component is it — which is why it is not
+ * in {@link WINDOWS}, where every entry is a port a page has to fill. It joins
+ * the same list as the slots because that list is POSITIONAL (index 0 is the
+ * first pane, and the preview is now a pane like any other), and it has to differ
+ * from every slot name or a reader picking "Preview" would move an unrelated
+ * window instead.
+ */
+const LIVE_PANE = 'live';
+
 const rendered: {
     id: string;
     title: string;
-    subtitle: string;
     live: boolean;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
@@ -262,12 +278,14 @@ for (const spec of WINDOWS) {
         tabs.push({ ...tab, html });
     }
     if (tabs.length === 0) continue;
+    // `previewMarkup` is already read by the time this runs: the live window is
+    // first in WINDOWS and its own `preview` tab is what sets it.
+    const live = spec.live === true && previewMarkup !== null;
     rendered.push({
         id: spec.id,
         title: spec.title ?? title,
-        subtitle: spec.subtitle,
-        live: spec.live === true,
-        impls: tabs.map((t) => t.slot).join(','),
+        live,
+        impls: [...(live ? [LIVE_PANE] : []), ...tabs.map((t) => t.slot)].join(','),
         tabs,
     });
 }
@@ -280,7 +298,6 @@ for (const spec of WINDOWS) {
         rendered.map((win, index) => (
             <AdwWidgetWindow
                 title={win.title}
-                subtitle={win.subtitle}
                 refHref={index === 0 ? refHref : null}
                 widget={title}
                 impls={win.impls}
@@ -380,12 +397,21 @@ for (const spec of WINDOWS) {
     // Headerbar copy button → forward to the ACTIVE page's hidden Expressive
     // Code copy button (EC handles the clipboard; the Adwaita toast listens on
     // that button's click).
+    const EC_COPY = '.copy button, .adw-code-headerbar-end button';
     document.addEventListener('click', (event) => {
         const btn = (event.target as HTMLElement).closest?.('.command-tabs-copy') as HTMLElement | null;
         if (!btn) return;
         const host = btn.closest('[data-impl-tabs]');
-        const active = host?.querySelector('.adw-tab-page:not([hidden])');
-        const ecButton = active?.querySelector<HTMLButtonElement>('.copy button, .adw-code-headerbar-end button');
+        // `.adw-tab-page` is applied by <adw-tab-view> as it adopts its pages, so
+        // a window with a single pane — no tab view — has none, and the pane is the
+        // window's own child.
+        const active = host?.querySelector('.adw-tab-page:not([hidden]), .adw-widget-window-pane');
+        // The preview pane holds a running widget, not code. Falling back to the
+        // window's own block copies the markup that PAINTS what the reader is
+        // looking at, which is the one thing they can take away from that tab —
+        // and it is the same bytes, since the pane mounts the block beside it.
+        const ecButton =
+            active?.querySelector<HTMLButtonElement>(EC_COPY) ?? host?.querySelector<HTMLButtonElement>(EC_COPY);
         if (!ecButton) return;
         ecButton.click();
         btn.classList.add('copied');
@@ -408,47 +434,29 @@ for (const spec of WINDOWS) {
     }
 
     /* One window per kind, stacked. They are separate windows, so they are spaced
-       like windows rather than joined like the two panes of the first one. */
+       like windows rather than joined like the panes inside one. */
     .adw-widget-window + .adw-widget-window {
         margin-top: 0.75rem;
     }
 
-    /* ── Window title + subtitle — an Adw.WindowTitle in the header bar. The
-          subtitle is where a window says what KIND it holds, which is the whole
-          reason there is more than one window (see the header comment). ── */
-    .command-tabs .command-tabs-headerbar-title {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        line-height: 1.2;
-        min-width: 0;
-    }
-
-    .adw-widget-window-title {
-        font-weight: bold;
-        font-size: 0.875rem;
-        white-space: nowrap;
+    /* ── A window with ONE pane ─────────────────────────────────────────
+          No tab bar, so no <adw-tab-view> and none of its surface either: this
+          stands in for `.adw-tab-view-pages`, the box a tabbed window's panes sit
+          in, so a lone pane is painted on the same view. `.command-tabs` clips at
+          radius 12px, so there is no corner to round here. */
+    .adw-widget-window-pane {
+        background-color: var(--view-bg-color);
+        color: var(--view-fg-color);
         overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-    .adw-widget-window-subtitle {
-        font-size: 0.7rem;
-        font-weight: normal;
-        opacity: 0.55;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
     }
 
     /* ── Live preview pane ──────────────────────────────────────────────
-       The first window's upper pane: an Adwaita "view" surface the real widget is
-       painted onto, directly under the header bar. It carries no frame of its
-       own — the window around it owns every edge — only the separator that
-       divides it from the editor tabs below, the way a paned split does. */
+       The first PANE of the window that runs the widget: an Adwaita "view"
+       surface the real widget is painted onto. It carries no frame and no
+       separator of its own — the window around it owns every edge, and the tab
+       bar above it is the only line the reader needs. */
     .adw-widget-preview {
         background: var(--adw-view-bg);
-        border-bottom: 1px solid var(--adw-card-border);
         overflow: hidden;
         /* Subtle GNOME-wallpaper-ish tint so a white row/card stays visible on
            the white view surface, mirroring the widget gallery's backdrop. */
@@ -495,9 +503,6 @@ for (const spec of WINDOWS) {
         justify-content: flex-start;
         overflow-x: auto;
     }
-
-    /* The preview is a PANE, inside the first window, so there is no second card
-       whose corners have to be squared off to fake a join. */
 
     /* Narrow viewports: stop stretching the tabs to equal widths and let the bar
        scroll instead — which is what Adw.TabBar itself does when its tabs no

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -1,33 +1,47 @@
 ---
 // AdwWidgetWindow — ONE window of an {@link AdwWidget} block: an Adwaita header
-// bar with a title and a subtitle, an optional live-preview pane under it, and an
-// Adw.TabBar holding this kind's tabs.
+// bar with this window's title, and under it the panes this kind of
+// implementation has to show.
+//
+// TWO OR MORE PANES are an Adw.TabBar. ONE pane is drawn directly under the
+// header bar, with no bar at all: a tab bar over a single tab is chrome that
+// offers no choice, and two windows had exactly that — NativeScript with a lone
+// "TypeScript" chip and UI frameworks with a lone "React Native" one. The branch
+// below reads the pane COUNT and nothing else, never a window's id or title: a
+// third window shrinking to one tab, or a fourth growing to two, has to come out
+// right without anyone editing this file. {@link AdwWidget} decides which windows
+// exist and what they claim; this file knows how a window is drawn.
+//
+// THE LIVE PREVIEW IS A PANE, and the FIRST one, on the window that runs the
+// widget. It used to sit between the header bar and the tab bar, with the markup
+// appended below it, which reads as two stacked things — a picture, and some code
+// under it. It is one thing shown two ways: this pane MOUNTS the fence the next
+// tab SHOWS, from the same bytes (see AdwWidget's header — the markup is authored
+// once, and `check-website-adwaita-gallery.mjs` holds the preview in first
+// position so "Preview | HTML" cannot silently become "HTML | Preview").
 //
 // It is a component rather than a loop body in `AdwWidget.astro` because the
-// Astro compiler cannot parse a JSX expression nested inside another one:
-// `windows.map((win) => (<div>{win.live && (<div/>)}</div>))` fails to compile with
-// `Expected "}" but found ")"`, measured on astro 6.4.5, and so does a `.map()`
-// inside a `.map()`. One level of JSX per expression is the budget, so the window
-// gets its own file — which is the right seam anyway: `AdwWidget` decides WHICH
-// windows exist and what they claim, this one knows how a window is drawn.
-//
-// The header bar sits above BOTH panes on purpose; the reasoning, and the two
-// claims the subtitles carry, are in AdwWidget.astro's header.
+// Astro compiler cannot parse a JSX expression nested inside a `.map()` CALLBACK:
+// `windows.map((win) => (<div>{win.live && (<div/>)}</div>))` fails to compile
+// with `Expected "}" but found ")"`, measured on astro 6.4.5 when this file was
+// split out, and so does a `.map()` inside a `.map()`. A conditional wrapping an
+// element that CONTAINS a `.map()` is a different shape and compiles — that is
+// the one below, measured the only way that counts, by building the site. An
+// isolated `@astrojs/compiler` call is NOT that measurement: asked the same
+// questions it accepts every shape here, the two failing ones included.
 
 interface Props {
     /** Window title. The live-preview window takes the WIDGET's; the rest name their kind. */
     title: string;
-    /** What kind of implementation this window holds — see AdwWidget's WINDOWS. */
-    subtitle: string;
     /** Canonical upstream docs for the widget, on the window that is about the widget. */
     refHref?: string | null;
     /** The widget, for the reference link's labels. */
     widget: string;
-    /** This window's tab slots, in order, for the cross-widget preference sync. */
+    /** This window's pane ids, in order, for the cross-widget preference sync. */
     impls: string;
     /** One tab per port this block filled: the Adw.TabBar label and the rendered snippet. */
     tabs: { label: string; html: string }[];
-    /** The markup to mount and paint above the tabs, or null on a window that only shows code. */
+    /** The markup the first pane mounts, or null on a window that only shows code. */
     preview?: string | null;
     /** Padding around the preview widget — see AdwWidget. */
     padding?: 'comfortable' | 'flush';
@@ -39,7 +53,6 @@ interface Props {
 
 const {
     title,
-    subtitle,
     refHref = null,
     widget,
     impls,
@@ -49,6 +62,22 @@ const {
     scroll = false,
     stage,
 } = Astro.props;
+
+/** The preview is a pane like any other, so it counts like one. */
+const panes = tabs.length + (preview === null ? 0 : 1);
+
+// A live window always has its markup tab beside the preview: AdwWidget renders
+// no window with zero tabs, and the live one declares the `preview` tab that both
+// mounts and shows the fence. So the single-pane case is only ever a lone code
+// tab — asserted rather than assumed, because the alternative is a preview
+// dropped on the floor with the window still drawing its chrome, which is exactly
+// the silence this gallery keeps being restructured to end.
+if (panes < 2 && preview !== null) {
+    throw new Error(
+        `AdwWidgetWindow(${title}): a live preview reached a window with no tab beside it. The preview ` +
+            'window declares its own markup tab, so this means AdwWidget stopped passing it.',
+    );
+}
 ---
 
 <div class="command-tabs adw-widget-window not-content" data-impl-tabs data-impls={impls}>
@@ -69,65 +98,77 @@ const {
                 )
             }
         </span>
-        <span class="command-tabs-headerbar-title">
-            <span class="adw-widget-window-title">{title}</span>
-            <span class="adw-widget-window-subtitle">{subtitle}</span>
-        </span>
+        <span class="command-tabs-headerbar-title">{title}</span>
         <span class="command-tabs-headerbar-end">
-            <button class="command-tabs-copy" aria-label="Copy active tab" type="button">
+            {/* Not "copy active tab": the active pane can be the live preview,
+                which has no code in it. The handler in AdwWidget falls back to
+                this window's own code block, which for the preview window is the
+                markup that paints what the reader is looking at. */}
+            <button class="command-tabs-copy" aria-label="Copy this window's code" type="button">
                 <span class="command-tabs-copy-icon" aria-hidden="true"></span>
             </button>
         </span>
     </div>
 
     {
-        preview !== null && (
-            <div class:list={['adw-widget-preview', 'not-content', `is-${padding}`, { 'is-scroll': scroll }]}>
-                {/* `not-content` for the same reason CommandTabs.astro states it, and
-                    it was missing HERE while the tabs below already carried it.
-                    Starlight gives every content element that FOLLOWS a sibling a
-                    `margin-top: 1rem`, exempting only `:where(.not-content *)`. Inside
-                    a preview that lands on the widgets: measured on the deployed page,
-                    the second button of a wrap box and every one after it took
-                    `margin-top: 16px` while the first took none — and in a flex line
-                    the first then STRETCHED by exactly that much, 50px against its
-                    siblings' 34px. The same rule pushed a header bar's trailing button
-                    below its own title and set the two panes of a split view onto
-                    baselines 16px apart, which clipped the sidebar's last row. A
-                    preview is a rendering of a widget, not prose: it has to be laid out
-                    by the widget's own stylesheet alone.
+        panes > 1 && (
+            <adw-tab-view no-close expand-tabs data-impl-view>
+                {preview !== null && (
+                    <adw-tab-page title="Preview">
+                        <div class:list={['adw-widget-preview', 'not-content', `is-${padding}`, { 'is-scroll': scroll }]}>
+                            {/* `not-content` for the same reason CommandTabs.astro states it, and
+                                it was missing HERE while the tabs beside it already carried it.
+                                Starlight gives every content element that FOLLOWS a sibling a
+                                `margin-top: 1rem`, exempting only `:where(.not-content *)`. Inside
+                                a preview that lands on the widgets: measured on the deployed page,
+                                the second button of a wrap box and every one after it took
+                                `margin-top: 16px` while the first took none — and in a flex line
+                                the first then STRETCHED by exactly that much, 50px against its
+                                siblings' 34px. The same rule pushed a header bar's trailing button
+                                below its own title and set the two panes of a split view onto
+                                baselines 16px apart, which clipped the sidebar's last row. A
+                                preview is a rendering of a widget, not prose: it has to be laid out
+                                by the widget's own stylesheet alone.
 
-                    It also carries what `check-website-preview-not-content.mjs` used to
-                    read off the gallery pages themselves. Their preview markup is a
-                    fenced block now and that scanner masks fences as code, so the
-                    marker stopped being restated on 40 blocks and became structural:
-                    one component mounts every preview, into this element. */}
-                {/* The preview is CLONED into the stage at runtime (see AdwWidget's
-                    script) rather than server-rendered directly: adwaita-web custom
-                    elements upgrade as the page is parsed, and a nested composite (a
-                    split view holding toolbar views) can lose its slotted children to
-                    an upgrade-order race. A <template> is inert, so cloning AFTER the
-                    elements are defined uses the reliable build-then-attach path.
+                                It also carries what `check-website-preview-not-content.mjs` used to
+                                read off the gallery pages themselves. Their preview markup is a
+                                fenced block now and that scanner masks fences as code, so the
+                                marker stopped being restated on 40 blocks and became structural:
+                                one component mounts every preview, into this element. */}
+                            {/* The preview is CLONED into the stage at runtime (see AdwWidget's
+                                script) rather than server-rendered directly: adwaita-web custom
+                                elements upgrade as the page is parsed, and a nested composite (a
+                                split view holding toolbar views) can lose its slotted children to
+                                an upgrade-order race. A <template> is inert, so cloning AFTER the
+                                elements are defined uses the reliable build-then-attach path.
 
-                    The markup is the preview tab's own fence, read back out of
-                    Expressive Code, so `slot="…"` needs no rewriting here: it never
-                    passes through the MDX compiler, which reads `slot` as its own
-                    slot-assignment directive and strips it. That is what retired
-                    `data-adw-slot` HERE; AdwGalleryCard still needs it, because the
-                    index page's cards mount MDX markup rather than a fence. */}
-                {/* NOT self-closing. `<template … set:html={…} />` compiles to a
-                    template element that swallows its following siblings and an
-                    unbalanced expression: measured on astro 6.4.5, the generated
-                    module ended `</div>`}</div>`;` and esbuild refused it with
-                    `Expected ")" but found "}"` pointing at a line that does not
-                    exist in this file. */}
-                <template class="adw-widget-preview-tpl" set:html={preview}></template>
-                <div class="adw-widget-preview-stage" style={stage} />
-            </div>
+                                The markup is the NEXT tab's own fence, read back out of Expressive
+                                Code, so `slot="…"` needs no rewriting here: it never passes through
+                                the MDX compiler, which reads `slot` as its own slot-assignment
+                                directive and strips it. That is what retired `data-adw-slot` HERE;
+                                AdwGalleryCard still needs it, because the index page's cards mount
+                                MDX markup rather than a fence. */}
+                            {/* NOT self-closing. `<template … set:html={…} />` compiles to a
+                                template element that swallows its following siblings and an
+                                unbalanced expression: measured on astro 6.4.5, the generated
+                                module ended `</div>`}</div>`;` and esbuild refused it with
+                                `Expected ")" but found "}"` pointing at a line that does not
+                                exist in this file. */}
+                            <template class="adw-widget-preview-tpl" set:html={preview}></template>
+                            <div class="adw-widget-preview-stage" style={stage} />
+                        </div>
+                    </adw-tab-page>
+                )}
+                {tabs.map((tab) => (
+                    <adw-tab-page title={tab.label} set:html={tab.html} />
+                ))}
+            </adw-tab-view>
         )
     }
 
-    <adw-tab-view no-close expand-tabs data-impl-view>
-        {tabs.map((tab) => <adw-tab-page title={tab.label} set:html={tab.html} />)}
-    </adw-tab-view>
+    {
+        panes === 1 && (
+            <div class="adw-widget-window-pane" set:html={tabs[0].html} />
+        )
+    }
 </div>

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -66,6 +66,21 @@ const {
 /** The preview is a pane like any other, so it counts like one. */
 const panes = tabs.length + (preview === null ? 0 : 1);
 
+// NO PANES AT ALL is a header bar over nothing, and it renders exactly that way at
+// exit 0. `AdwWidget` is what prevents it — it skips a window none of whose tab
+// slots this block filled — and nothing downstream restated the guard: measured by
+// deleting that one line, /adwaita/buttons/ built green with five extra empty
+// windows on it. Arm 7 of `check-website-adwaita-gallery.mjs` cannot see this one:
+// it refuses a window DECLARED with no tabs, while these are windows whose tabs are
+// simply unprovided on this block, which is the ordinary case (`frameworks` is
+// filled on one page of eight).
+if (panes === 0) {
+    throw new Error(
+        `AdwWidgetWindow(${title}): a window with no pane at all. AdwWidget renders a window only where ` +
+            'this block filled one of its tabs, so this means that skip stopped happening.',
+    );
+}
+
 // A live window always has its markup tab beside the preview: AdwWidget renders
 // no window with zero tabs, and the live one declares the `preview` tab that both
 // mounts and shows the fence. So the single-pane case is only ever a lone code

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -12,7 +12,8 @@ a drop-down, a button).
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -14,7 +14,8 @@ linked buttons should act as a single-choice selector.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/controls.mdx
+++ b/website/src/content/docs/adwaita/controls.mdx
@@ -18,7 +18,8 @@ with an `Adw` prefix are the row variants built on top.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/feedback.mdx
+++ b/website/src/content/docs/adwaita/feedback.mdx
@@ -13,7 +13,8 @@ dialogs every app is expected to have: About and Preferences.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/index.mdx
+++ b/website/src/content/docs/adwaita/index.mdx
@@ -12,11 +12,11 @@ and the same widget renders as a real Libadwaita widget on the desktop and as a
 custom element in the browser.
 
 Pick a category below. Every widget on those pages runs live in your browser, in a
-window whose tab holds the markup that paints it, followed by one window per kind of
-implementation: **Vanilla TypeScript**, the `@girs` program that runs unchanged on
-GJS, Node, Bun and Deno, with a Blueprint declaration beside it, and **NativeScript**,
-the port that runs on a phone. Choose a tab once and every widget block on the site
-follows it.
+window whose second tab holds the markup that paints it, followed by one window per
+kind of implementation: **Vanilla TypeScript**, the `@girs` program that runs
+unchanged on GJS, Node, Bun and Deno, with a Blueprint declaration beside it, and
+**NativeScript**, the port that runs on a phone. Choose a tab once and every widget
+block on the site follows it.
 
 Adwaita is one design system GJSify supports, not a requirement. Your app is an
 ordinary GTK 4 program, so you can mix in plain `Gtk.*` widgets or style your

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -13,7 +13,8 @@ inside and adapt as the space around them changes.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation, for every kind that can express this widget.
 Two are on all four widgets here — **Vanilla TypeScript**, the `@girs` program that
 runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint declaration

--- a/website/src/content/docs/adwaita/navigation.mdx
+++ b/website/src/content/docs/adwaita/navigation.mdx
@@ -13,7 +13,8 @@ build one structure, not two.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/presentation.mdx
+++ b/website/src/content/docs/adwaita/presentation.mdx
@@ -13,7 +13,8 @@ title** in a header bar.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.

--- a/website/src/content/docs/adwaita/view-switching.mdx
+++ b/website/src/content/docs/adwaita/view-switching.mdx
@@ -14,7 +14,8 @@ switcher and a narrow phone gets a collapsed one.
 
 Each block below is a stack of windows. The first one RUNS the widget: the preview
 is the live browser port, so it follows the light and dark toggle the way a real
-window would, and the tab under it holds the very markup that paints it. Then comes
+window would, and the HTML tab beside it holds the very markup that paints it —
+one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, and **NativeScript**, the port that runs on a phone.


### PR DESCRIPTION
Three changes to the Adwaita gallery's window chrome, asked for after looking at
the rendered site.

## No subtitles

Every window printed one under its title, and every one was a second copy of a
sentence the page had already written:

| Subtitle | Where the page already says it |
|---|---|
| `GJS · Node · Bun · Deno — one program, four runtimes` | all 8 block pages: "**Vanilla TypeScript**, the `@girs` program that runs unchanged on GJS, Node, Bun and Deno" |
| `on GTK, through @gjsify/gtk-host` | `layout.mdx`, the only page with that window: "`@gjsify/gtk-host` has no child policy for `AdwWrapBox` yet… That window renders a GTK window, not a phone screen" |
| `@gjsify/adwaita-nativescript — the port that runs on a phone` | all 8: "**NativeScript**, the port that runs on a phone", plus the package named in the "Libadwaita is the reference here" paragraph |
| `@gjsify/adwaita-web — import it once to register these elements` | package named on all 8; **the "import it once" half was said only on `adwaita/index.mdx`** |

That last half had no other home on the eight pages that carry blocks, so it
moved into their prose instead of dying with the chrome — one sentence, in the
paragraph that is already about the preview window.

## No tab bar over a single tab

NativeScript rendered a lone "TypeScript" chip and UI frameworks a lone "React
Native": a bar offering no choice. A window now draws a bar for two or more
panes and puts a single pane straight under the header bar. `AdwWidgetWindow`
reads the pane COUNT and never a window's id or title.

## The preview is the first tab

It was a pane above the tabs with the markup appended below it, which reads as
two stacked things. It is one thing shown two ways, so it is now
`[ Preview | HTML ]` in the same tab bar every other window uses. The markup is
still authored ONCE: the pane mounts the bytes the tab beside it shows, read
back off the same rendered fence.

## Evidence, from the built site

40 blocks over 8 pages:

- **0** subtitle elements
- **0** tab views with fewer than two tabs
- **0** blocks whose first pane is not the mounted preview
- **39/40** previews byte-identical to the markup their HTML tab displays — the
  40th is `Adw.Toast`, the one entry in `MARKUP_OVERRIDE_LEDGER`

Per-block counts, e.g. `/adwaita/layout/`:

```
Adw.Clamp        Adw.Clamp: 2 panes [Preview | HTML]
                 Vanilla TypeScript: 2 panes [TypeScript | Blueprint]
                 UI frameworks: 1 pane (no tab bar)
                 NativeScript: 1 pane (no tab bar)
Adw.WrapBox      Adw.WrapBox: 2 panes [Preview | HTML]
                 Vanilla TypeScript: 2 panes [TypeScript | Blueprint]
                 NativeScript: 1 pane (no tab bar)
```

In a browser: clicking Blueprint moves every Vanilla TypeScript window and
leaves the preview windows alone; clicking HTML moves every preview window and
leaves the rest; the header-bar copy button works on the live preview tab (it
falls back to the window's own block, which is the markup that paints what the
reader is looking at) and on a single-pane window.

## The mechanism

`check-website-adwaita-gallery.mjs` grows a ninth arm: the live preview is
emitted BEFORE the code tabs in the component that draws a window. Swapped, the
window opens on a block of HTML for a widget the reader has not seen yet, and
nothing else here would notice — arm 8 still holds, both tabs still render, the
fence is still authored once.

Every arm falsified, both directions:

| Mutation | Exit |
|---|---|
| baseline | 0 |
| arm 5 — `slot="gjs"` → `slot="gsj"` | 1 |
| arm 6 — a `fortran` port no page provides | 1 |
| arm 7 — a window declared with `tabs: []` | 1 |
| arm 8 — an unledgered `web` fragment | 1 |
| arm 8 — the ledgered `web` fragment removed | 1 |
| arm 9 — preview moved after the code tabs | 1 |
| arm 9 — the mounted template renamed | 1 |
| each one restored | 0 |

The four pre-existing window arms all still fire, so none of them was made
meaningless by the restructure.

## Checks

`npx oxfmt --check .`, `npx oxlint scripts website`,
`node scripts/check-website-adwaita-gallery.mjs`,
`node scripts/check-doc-fences.mjs`,
`node scripts/check-generated-website-data.mjs`,
`node scripts/audit-runtimes.mjs --check` — all exit 0, plus
`gjsify workspace @gjsify/website build`.

## One measurement worth recording

An isolated `@astrojs/compiler` call is NOT a test of what Astro accepts. Asked
whether a conditional may wrap an element containing a `.map()`, it said yes —
and it said yes to both shapes `AdwWidgetWindow.astro`'s header records as
FAILING, the self-closing `<template set:html>` included. The website build is
the only authority, and that is what says the new shape compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9HRKqQZskrYLVer1fuFvg
