### PR TITLE
feat(website): the NativeScript window's XML template

### DIFF
--- a/docs/adr/0033-declarative-templates-preferred.md
+++ b/docs/adr/0033-declarative-templates-preferred.md
@@ -13,7 +13,7 @@ each of them the imperative form is also available and shorter to type:
 | runtime | declarative | imperative |
 |---|---|---|
 | GTK / GJS | Blueprint `.blp`, compiled to a `GtkBuilder` template | `new Adw.Clamp({ child: … })` |
-| NativeScript | XML markup over `registerElement`-registered classes | `new AdwWrapBox(); box.add(pill)` |
+| NativeScript | XML markup, resolved through an `xmlns` module barrel | `new AdwWrapBox(); box.add(pill)` |
 | Browser | `adw-*` custom elements in HTML | `document.createElement('adw-clamp')` |
 
 The two forms are not equivalent in what they cost a reader. A template is a tree
@@ -69,10 +69,23 @@ this project refuses hand-maintained tables elsewhere.
 - A reader comparing two runtimes compares two trees, not a tree against a script.
 - `Adw.init()` and the final-type constraint above become part of what an example has to
   get right — which is a cost, and is why they are recorded here rather than rediscovered.
-- **What is NOT yet proven:** NativeScript's XML path. `registerAdwaitaElements()` in
-  `@gjsify/adwaita-nativescript` registers every widget with the `registerElement` global,
-  so `<AdwSwitchRow title="…" />` should resolve — but this repository contains **zero**
-  XML views, and the storybook builds every view in code. The declarative NativeScript
-  form is therefore *declared and unrun*. It is being measured on an Android emulator
-  before any XML appears in the documentation; if it does not render, this ADR's table
-  loses a row rather than the documentation gaining a false example.
+- **NativeScript's XML path: measured, and the row stays** — by a different mechanism than
+  this ADR first wrote down, and only after a package fix. Android emulator, API 37,
+  `@nativescript/core` 9.1.0-alpha.11, `@nativescript/vite` 8.0.0-alpha.57, 2026-08-28.
+
+  `registerAdwaitaElements()` is not the way in. `typeof registerElement` is `undefined`
+  in a plain NativeScript app — `@nativescript/core` 9.1 does not contain the identifier
+  anywhere; it belongs to `@nativescript/angular` / `nativescript-vue` — so the function
+  took its documented no-op branch and `<AdwSwitchRow>` resolved to nothing. What does
+  work is NativeScript's own rule: a namespace is a MODULE, and the builder reads the
+  element name off its exports. `xmlns:adw="~/adwaita"` over an app-local barrel resolves;
+  `xmlns:adw="@gjsify/adwaita-nativescript"` does not.
+
+  Resolving the class was only half. Every child then went through
+  `LayoutBase._addChildFromBuilder`, which ignores the slot name and calls `addChild` —
+  so a toolbar view's top bar and content were painted on top of each other in row 0, a
+  header bar's buttons never reached `startBox`/`endBox`, a clamp's child left `child`
+  null and clamped nothing, and preferences rows landed beside the boxed list rather than
+  in it. All four rendered SOMETHING, which is why nothing caught them. Fixed in
+  `@gjsify/adwaita-nativescript`; the four Layout widgets are now documented from
+  templates that were rendered and screenshotted before they were written down.

--- a/packages/nativescript-bridge/adwaita/src/index.spec.ts
+++ b/packages/nativescript-bridge/adwaita/src/index.spec.ts
@@ -26,6 +26,9 @@ import {
 import { attachRowPressFeedback } from './widgets/row-press.js';
 import type { TouchGestureEventData, View } from '@nativescript/core';
 import { extractIconPaths, extractPathData, normalizeArcFlags } from './widgets/icon-path.js';
+// `builder-slots.js` is pure too — no `@nativescript/core` — so the rule the four
+// XML-inflating widgets share is driven HERE rather than through a mock of it.
+import { resolveBuilderSlot } from './widgets/builder-slots.js';
 import { DEFAULT_ICON_COLOR, DEFAULT_ICON_COLOR_DARK } from './widgets/icon-path.js';
 // Color scheme + breakpoints are HEADLESS in `@gjsify/adwaita-core` and specced THERE;
 // imported through the NS re-export shims to pin the no-consumer-break guarantee. The
@@ -343,6 +346,42 @@ export default async () => {
         await it('element registration is a safe no-op when registerElement is absent', () => {
             // registerElement global does not exist off NativeScript — must not throw.
             expect(() => registerAdwaitaElementsNoopProbe()).not.toThrow();
+        });
+    });
+
+    await describe('XML builder slots (the name a template child arrives under)', async () => {
+        // The widgets' own property names, as NativeScript's complex-property
+        // syntax spells them: `<AdwToolbarView.topBar>` -> `topBar`.
+        const TOOLBAR = ['topBar', 'bottomBar', 'content'] as const;
+
+        await it('a declared slot name selects that slot', () => {
+            expect(resolveBuilderSlot('topBar', TOOLBAR, 'content')).toBe('topBar');
+            expect(resolveBuilderSlot('bottomBar', TOOLBAR, 'content')).toBe('bottomBar');
+        });
+
+        await it('a bare child arrives under its ELEMENT name and takes the fallback', () => {
+            // This is the case that mattered on device: NativeScript passes the
+            // element name for an untyped child, so anything not a slot has to
+            // land somewhere deliberate rather than in the layout's first cell.
+            expect(resolveBuilderSlot('AdwHeaderBar', TOOLBAR, 'content')).toBe('content');
+            expect(resolveBuilderSlot('Label', TOOLBAR, 'content')).toBe('content');
+        });
+
+        await it('reduces a dotted name to its last segment', () => {
+            expect(resolveBuilderSlot('AdwToolbarView.topBar', TOOLBAR, 'content')).toBe('topBar');
+        });
+
+        await it('a non-string name is the fallback, not a crash', () => {
+            expect(resolveBuilderSlot(undefined, TOOLBAR, 'content')).toBe('content');
+            expect(resolveBuilderSlot(null, TOOLBAR, 'content')).toBe('content');
+        });
+
+        await it('matching is exact — a near-miss is NOT the slot', () => {
+            // A silent near-miss is the whole failure class here: `topbar` landing
+            // in the content would put a header bar where the content goes and
+            // report nothing.
+            expect(resolveBuilderSlot('topbar', TOOLBAR, 'content')).toBe('content');
+            expect(resolveBuilderSlot('top-bar', TOOLBAR, 'content')).toBe('content');
         });
     });
 

--- a/packages/nativescript-bridge/adwaita/src/ns-globals.d.ts
+++ b/packages/nativescript-bridge/adwaita/src/ns-globals.d.ts
@@ -1,12 +1,20 @@
 // Ambient declarations for the NativeScript runtime GLOBALS this package uses.
 //
 // `registerElement` / `registerModule` are NOT exported from `@nativescript/core`;
-// the NativeScript bundler context (`@nativescript/webpack`'s xml-namespace-loader
-// or `@nativescript/vite`'s ns-bundler-context) injects them as runtime globals
-// — exactly the way GJS injects `imports.gi.*`, and the way this workspace's
-// `@gjsify/native-{fs,platform}-bridge` key on the global `java` / `NSFileManager`.
-// We type them here so `registerAdwaitaElements()` can call them without an import
-// and the package still type-checks off-device (where they are `undefined`).
+// they are runtime globals, typed here so `registerAdwaitaElements()` can call
+// them without an import and the package still type-checks off-device (where they
+// are `undefined`) — the way this workspace's `@gjsify/native-{fs,platform}-bridge`
+// key on the global `java` / `NSFileManager`.
+//
+// THE TWO ARE NOT THE SAME KIND OF GLOBAL, and this file used to say they were.
+// `registerModule` is NativeScript's own (`@nativescript/core/globals`), always
+// there. `registerElement` is a FRAMEWORK integration's — `@nativescript/angular`,
+// `nativescript-vue` — and `@nativescript/core` 9.1 does not contain the
+// identifier anywhere: measured on an Android emulator 2026-08-28, `typeof
+// registerElement` is `undefined` in a plain app built with `@nativescript/vite`,
+// while `typeof registerModule` is `function`. Declaring both as "the bundler
+// context injects them" made `registerAdwaitaElements()`'s silent no-op read as a
+// cold-start guard rather than as the whole story on that runtime.
 
 import type { View } from '@nativescript/core';
 

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-clamp.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-clamp.ts
@@ -76,6 +76,20 @@ export class AdwClamp extends GridLayout {
         return this._child;
     }
 
+    /**
+     * XML inflation — every child a template declares is THE clamped child.
+     *
+     * Without this the `LayoutBase` default calls `addChild`, which puts the view
+     * in the grid and leaves `_child` null, so `_allocate` returns early: measured
+     * on Android, a clamp written in markup rendered its child at full width with
+     * no size class at all, i.e. as if there were no clamp around it. The name is
+     * ignored because there is only one destination — `<AdwClamp.child>` and a
+     * bare child mean the same thing.
+     */
+    _addChildFromBuilder(_name: string, view: View): void {
+        this.setChild(view);
+    }
+
     /** `Adw.Clamp:maximum-size` — the widest the child may ever get, in DIPs. */
     get maximumSize(): number {
         return this._props.maximumSize;

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-header-bar.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-header-bar.ts
@@ -25,6 +25,13 @@
 
 import { GridLayout, ItemSpec, StackLayout, View } from '@nativescript/core';
 import { AdwWindowTitle } from './adw-window-title.js';
+import { resolveBuilderSlot } from './builder-slots.js';
+
+/**
+ * The slots a template may name, spelled as this widget's own properties —
+ * `<AdwHeaderBar.titleWidget>`, `<AdwHeaderBar.startBox>`, `<AdwHeaderBar.endBox>`.
+ */
+const HEADER_BAR_SLOTS = ['titleWidget', 'startBox', 'endBox'] as const;
 
 export class AdwHeaderBar extends GridLayout {
     /** The start (left) slot — a horizontal stack. */
@@ -135,6 +142,30 @@ export class AdwHeaderBar extends GridLayout {
         GridLayout.setColumn(view, 1);
         this.addChild(view);
         this._titleWidget = view;
+    }
+
+    /**
+     * XML inflation — route a template's child through the packing API.
+     *
+     * NativeScript spells a slot as a complex property, so `<AdwHeaderBar.endBox>`
+     * arrives here as `endBox`; a bare child arrives under its element name and
+     * takes the fallback, `packStart`. Without this the `GridLayout` default added
+     * the view straight to the grid at column 0: measured on Android, a header bar
+     * written in markup left `startBox` and `endBox` empty while the button still
+     * appeared, so it LOOKED packed and was not — a second one would have been
+     * drawn on top of the first rather than beside it.
+     */
+    _addChildFromBuilder(name: string, view: View): void {
+        switch (resolveBuilderSlot(name, HEADER_BAR_SLOTS, 'startBox')) {
+            case 'titleWidget':
+                this.setTitleWidget(view);
+                return;
+            case 'endBox':
+                this.packEnd(view);
+                return;
+            default:
+                this.packStart(view);
+        }
     }
 
     /** The centered title widget. */

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-preferences-group.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-preferences-group.ts
@@ -20,8 +20,12 @@
 // Copyright (c) GNOME contributors (libadwaita). LGPLv2.1+.
 
 import { GridLayout, ItemSpec, Label, StackLayout, View } from '@nativescript/core';
+import { resolveBuilderSlot } from './builder-slots.js';
 import { PREFERENCES_GROUP_HEADER_CLASS, preferencesGroupVisuals } from './preferences-group-state.js';
 import type { NsSearchableGroup, NsSearchableRow } from './preferences-search.js';
+
+/** The one slot a template may name — everything else is a row. */
+const PREFERENCES_GROUP_SLOTS = ['headerSuffix'] as const;
 
 export class AdwPreferencesGroup extends StackLayout implements NsSearchableGroup {
     /** The header box: labels on the leading edge, suffix on the trailing one. */
@@ -146,6 +150,24 @@ export class AdwPreferencesGroup extends StackLayout implements NsSearchableGrou
         this._headerSuffix = view;
         if (this._headerSuffix) this._suffixHost.addChild(this._headerSuffix);
         this._applyVisuals();
+    }
+
+    /**
+     * XML inflation — a template's children are ROWS, not stray layout children.
+     *
+     * `<AdwPreferencesGroup.headerSuffix>` reaches the suffix host; everything
+     * else goes into the boxed list, which is where a row has to be to get the
+     * card, the rounded ends and the separators. Without this the `StackLayout`
+     * default appended each row NEXT TO the listbox: measured on Android, the
+     * rows rendered — unboxed, on the page background, with no `.boxed-list`
+     * around them — which is the failure that looks like a styling bug.
+     */
+    _addChildFromBuilder(name: string, view: View): void {
+        if (resolveBuilderSlot(name, PREFERENCES_GROUP_SLOTS, 'row') === 'headerSuffix') {
+            this.headerSuffix = view;
+            return;
+        }
+        this.addRow(view);
     }
 
     /** Append a row (or any view) to the boxed list. */

--- a/packages/nativescript-bridge/adwaita/src/widgets/adw-toolbar-view.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/adw-toolbar-view.ts
@@ -30,6 +30,7 @@ import {
     defaultToolbarViewProps,
     toolbarViewClassNames,
 } from './chrome.js';
+import { resolveBuilderSlot } from './builder-slots.js';
 import { observeWindowInsets } from './window-insets-source.js';
 import { NO_INSETS, type WindowInsets, toolbarViewInsetPadding } from './window-insets.js';
 
@@ -39,6 +40,12 @@ const BASE_CLASSES = {
     topBar: 'adw-toolbar-view-top',
     bottomBar: 'adw-toolbar-view-bottom',
 };
+
+/**
+ * The slots a template may name, spelled as this widget's own properties —
+ * `<AdwToolbarView.topBar>`, `<AdwToolbarView.bottomBar>`, `<AdwToolbarView.content>`.
+ */
+const TOOLBAR_VIEW_SLOTS = ['topBar', 'bottomBar', 'content'] as const;
 
 export class AdwToolbarView extends GridLayout {
     /** The top-bar slot (row 0) — stack of header bars / toolbars. */
@@ -124,6 +131,28 @@ export class AdwToolbarView extends GridLayout {
         }
         // The content was just added last, so it would paint over an extended bar.
         this._restackBars();
+    }
+
+    /**
+     * XML inflation — route a template's child through the slot API.
+     *
+     * `<AdwToolbarView.topBar>` / `.bottomBar` / `.content` arrive here as those
+     * names; anything else (a bare child) is the content, which is the one slot a
+     * toolbar view cannot do without. Without this the `GridLayout` default put
+     * every child in row 0: measured on Android, a top bar and the content were
+     * painted ON TOP OF EACH OTHER in the bar row while row 1 stayed empty.
+     */
+    _addChildFromBuilder(name: string, view: View): void {
+        switch (resolveBuilderSlot(name, TOOLBAR_VIEW_SLOTS, 'content')) {
+            case 'topBar':
+                this.addTopBar(view);
+                return;
+            case 'bottomBar':
+                this.addBottomBar(view);
+                return;
+            default:
+                this.setContent(view);
+        }
     }
 
     /** The currently-installed content view, or `null`. */

--- a/packages/nativescript-bridge/adwaita/src/widgets/builder-slots.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/builder-slots.ts
@@ -1,0 +1,48 @@
+// Which attachment an XML-inflated child asks for — the one rule every
+// `_addChildFromBuilder` in this package shares.
+//
+// WHY IT EXISTS
+//
+// NativeScript's XML Builder hands a parent its children through ONE method:
+// `_addChildFromBuilder(name, view)`. `name` is the complex-property name for
+// `<AdwToolbarView.topBar>` and the plain ELEMENT name (`AdwHeaderBar`) for a
+// bare child, and `LayoutBase`'s inherited implementation ignores it entirely and
+// calls `addChild`. Every composed widget here builds its own internal boxes in
+// its constructor and exposes `addTopBar` / `setContent` / `packStart` /
+// `setChild` to reach them, so that inherited default drops an XML child into the
+// layout's first cell instead — MEASURED on an Android emulator, 2026-08-28:
+// `<AdwToolbarView.topBar>` and `<AdwToolbarView.content>` both landed at row 0
+// and painted on top of each other, an `AdwHeaderBar` child left `startBox` empty,
+// and an `AdwClamp` child left `child` null so the clamp never allocated.
+//
+// The name is therefore the whole decision, and it is the same decision in four
+// widgets: is this one of the slots I expose, or the default one? Keeping it here
+// — free of `@nativescript/core` — is what lets the spec suite drive it off-device,
+// where the widget classes cannot even be imported (their modules pull
+// `@nativescript/core` at module scope).
+
+/**
+ * The slot an XML child asks for, or `fallback` when it asks for nothing this
+ * widget knows.
+ *
+ * `slots` are the widget's own property names, because that is what NativeScript's
+ * complex-property syntax spells: `<AdwToolbarView.topBar>` reaches
+ * `_addChildFromBuilder('topBar', …)`. A bare `<AdwHeaderBar>` child arrives under
+ * its ELEMENT name instead, which is never a slot name and so takes the fallback —
+ * the same shape as GtkBuildable's untyped `<child>`.
+ *
+ * A dotted `name` is reduced to its last segment first. NativeScript already does
+ * that before it calls us, but a caller that does not is the difference between
+ * "no slot" and "the wrong slot", and this returns the answer to a question about
+ * a widget's own tree.
+ */
+export function resolveBuilderSlot<Slot extends string, Fallback extends string>(
+    name: unknown,
+    slots: readonly Slot[],
+    fallback: Fallback,
+): Slot | Fallback {
+    if (typeof name !== 'string') return fallback;
+    const dot = name.lastIndexOf('.');
+    const wanted = dot === -1 ? name : name.slice(dot + 1);
+    return (slots as readonly string[]).includes(wanted) ? (wanted as Slot) : fallback;
+}

--- a/packages/nativescript-bridge/adwaita/src/widgets/index.ts
+++ b/packages/nativescript-bridge/adwaita/src/widgets/index.ts
@@ -1,11 +1,22 @@
 // Widget barrel for @gjsify/adwaita-nativescript.
 //
-// Re-exports every Adwaita NativeScript widget AND wires them into NativeScript's
-// XML element registry via the global `registerElement` so they can be used from
-// markup: `<AdwPreferencesGroup>`, `<AdwActionRow>`, `<AdwSwitchRow>`, etc. The
-// barrel itself has NO top-level side effects — registration is explicit via
-// `registerAdwaitaElements()` (mirroring the `/register` convention spirit), so
-// importing a widget class does not eagerly touch the runtime.
+// Re-exports every Adwaita NativeScript widget. The barrel has NO top-level side
+// effects, so importing a widget class does not eagerly touch the runtime.
+//
+// USING THESE FROM XML. A plain NativeScript app resolves `<ns:Widget>` by loading
+// the module its `xmlns` names and reading `Widget` off the exports
+// (`component-builder`'s `createComponentInstance`), so the way in is an
+// app-local barrel and a namespace:
+//
+//   // app/adwaita.ts
+//   export { AdwClamp, AdwWrapBox } from '@gjsify/adwaita-nativescript';
+//
+//   <adw:AdwWrapBox xmlns:adw="~/adwaita" childSpacing="8"> … </adw:AdwWrapBox>
+//
+// `@gjsify/vite-plugin-gjsify` registers exactly those `xmlns="~/MOD"` barrels
+// (see packages/nativescript-bridge/AGENTS.md). A BARE package specifier does not
+// work — measured on Android 2026-08-28, `xmlns:adw="@gjsify/adwaita-nativescript"`
+// fails with `Module 'AdwWrapBox' not found for element`.
 
 export { AdwPreferencesPage } from './adw-preferences-page.js';
 export { AdwPreferencesGroup } from './adw-preferences-group.js';
@@ -355,13 +366,20 @@ const ELEMENTS = {
 let registered = false;
 
 /**
- * Register all Adwaita widgets as NativeScript XML elements (idempotent).
+ * Register all Adwaita widgets as UNPREFIXED NativeScript XML elements, where a
+ * framework integration provides the `registerElement` global (idempotent).
  *
- * After calling this once at app bootstrap, markup like
- * `<AdwSwitchRow title="Dark mode" />` resolves to the corresponding class.
- * No-op (returns silently) when the `registerElement` runtime global is absent
- * — i.e. off NativeScript, or when the bundler context has not injected it yet —
- * so the call is safe to make unconditionally.
+ * That global is NOT part of NativeScript itself: `@nativescript/core` 9.1 does
+ * not contain the identifier at all, and it is `undefined` in a plain app built
+ * with `@nativescript/vite` — measured on an Android emulator, 2026-08-28, where
+ * this function therefore returned silently and `<AdwSwitchRow>` resolved to
+ * nothing. It comes from `@nativescript/angular` / `nativescript-vue`, which is
+ * where this call earns its keep; a plain XML app uses the `xmlns` barrel above
+ * instead and needs no registration at all.
+ *
+ * The no-op is the safe branch of that split, not a fallback: it is why the call
+ * can be made unconditionally, and why it must never be the only thing an app
+ * does before writing `<AdwSwitchRow>` in markup.
  */
 export function registerAdwaitaElements(): void {
     if (registered) return;

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -194,7 +194,15 @@ const WINDOWS = [
     {
         id: 'nativescript',
         title: 'NativeScript',
-        tabs: [{ slot: 'nativescript', label: 'TypeScript' }],
+        tabs: [
+            { slot: 'nativescript', label: 'TypeScript' },
+            // The XML template is a FILE of the same program, exactly as Blueprint
+            // is above it: NativeScript resolves `<adw:AdwClamp>` by loading the
+            // module the template's `xmlns` names, and the TypeScript beside it is
+            // the loader that mounts the template and does what markup cannot say.
+            // Standing alone, either half is not a program.
+            { slot: 'nativescript-xml', label: 'XML' },
+        ],
     },
 ];
 

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -18,7 +18,14 @@ one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation, for every kind that can express this widget.
 Two are on all four widgets here — **Vanilla TypeScript**, the `@girs` program that
 runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint declaration
-beside it, and **NativeScript**, the port that runs on a phone.
+beside it, and **NativeScript**, the port that runs on a phone, which splits the same
+way: an XML template holds the tree and the TypeScript beside it is the loader.
+
+A NativeScript template reaches these widgets through its `xmlns`, and the namespace
+is a MODULE: NativeScript loads it and reads the element name off its exports, so
+`xmlns:adw="~/adwaita"` needs an app-local `app/adwaita.ts` that re-exports what the
+markup names. A bare package specifier there does not resolve. The four templates
+below were rendered on an Android device before they were written down.
 
 The clamp, the header bar and the toolbar view carry a third, **UI frameworks**: the
 same widget written with [`@gjsify/react-native`](/gjsify/frameworks/react-native/)
@@ -135,14 +142,25 @@ at a comfortable measure on a large display without wasting room on a small one.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { AdwButtonContent, AdwClamp } from '@gjsify/adwaita-nativescript';
+    // app/adwaita.ts — the module the template's `xmlns:adw="~/adwaita"` resolves to.
+    // NativeScript reads `AdwClamp` off THIS module's exports; a bare package
+    // specifier in the xmlns does not resolve.
+    export { AdwClamp } from '@gjsify/adwaita-nativescript';
 
-    const inner = new AdwButtonContent();
-    inner.label = 'This content is clamped: it stops growing past the maximum size and stays centred.';
+    // app/views/clamp.ts — the loader. The template holds the tree; this holds the
+    // wiring, and here there is none beyond mounting it.
+    import { Builder } from '@nativescript/core';
 
-    const clamp = new AdwClamp();
-    clamp.setChild(inner);
-    clamp.maximumSize = 400;
+    export const clamp = Builder.load({ path: '~/views', name: 'clamp' });
+    ```
+  </Fragment>
+  <Fragment slot="nativescript-xml">
+    ```xml
+    <adw:AdwClamp xmlns="http://schemas.nativescript.org/tns.xsd" xmlns:adw="~/adwaita"
+      maximumSize="400" tighteningThreshold="300">
+      <Label class="card" textWrap="true"
+        text="This content is clamped: it stops growing past the maximum size and stays centred." />
+    </adw:AdwClamp>
     ```
   </Fragment>
 </AdwWidget>
@@ -237,24 +255,28 @@ the trailing one.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { AdwButton, AdwHeaderBar, AdwWindowTitle } from '@gjsify/adwaita-nativescript';
+    // app/adwaita.ts — the module the template's `xmlns:adw="~/adwaita"` resolves to.
+    export { AdwButton, AdwHeaderBar, AdwWindowTitle } from '@gjsify/adwaita-nativescript';
 
-    const title = new AdwWindowTitle();
-    title.title = 'Text Editor';
-    title.subtitle = 'notes.md';
+    // app/views/header-bar.ts — the loader.
+    import { Builder } from '@nativescript/core';
 
-    const headerBar = new AdwHeaderBar();
-    headerBar.setTitleWidget(title);
-
-    const backButton = new AdwButton();
-    backButton.text = '‹';
-    backButton.variant = 'flat';
-    headerBar.packStart(backButton);
-
-    const menuButton = new AdwButton();
-    menuButton.text = '≡';
-    menuButton.variant = 'flat';
-    headerBar.packEnd(menuButton);
+    export const headerBar = Builder.load({ path: '~/views', name: 'header-bar' });
+    ```
+  </Fragment>
+  <Fragment slot="nativescript-xml">
+    ```xml
+    <adw:AdwHeaderBar xmlns="http://schemas.nativescript.org/tns.xsd" xmlns:adw="~/adwaita">
+      <adw:AdwHeaderBar.startBox>
+        <adw:AdwButton text="&#8249;" variant="flat" />
+      </adw:AdwHeaderBar.startBox>
+      <adw:AdwHeaderBar.titleWidget>
+        <adw:AdwWindowTitle title="Text Editor" subtitle="notes.md" />
+      </adw:AdwHeaderBar.titleWidget>
+      <adw:AdwHeaderBar.endBox>
+        <adw:AdwButton text="&#8801;" variant="flat" />
+      </adw:AdwHeaderBar.endBox>
+    </adw:AdwHeaderBar>
     ```
   </Fragment>
 </AdwWidget>
@@ -419,50 +441,56 @@ the view moves.
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import {
+    // app/adwaita.ts — the module the template's `xmlns:adw="~/adwaita"` resolves to.
+    export {
         AdwHeaderBar,
         AdwImageButton,
         AdwStatusPage,
         AdwToolbarView,
         AdwWindowTitle,
     } from '@gjsify/adwaita-nativescript';
-    import { listAddSymbolic, listRemoveSymbolic, sendToSymbolic } from '@gjsify/adwaita-icons/actions';
+
+    // app/views/toolbar-view.ts — the loader, and the three things markup cannot say.
+    import { Builder } from '@nativescript/core';
+    import type { AdwImageButton, AdwStatusPage } from '@gjsify/adwaita-nativescript';
+    import { listAddSymbolic, sendToSymbolic } from '@gjsify/adwaita-icons/actions';
     import { folderSymbolic } from '@gjsify/adwaita-icons/places';
 
-    const view = new AdwToolbarView();
+    export const view = Builder.load({ path: '~/views', name: 'toolbar-view' });
 
-    const header = new AdwHeaderBar();
-    const title = new AdwWindowTitle();
-    title.title = 'Documents';
-    title.subtitle = '12 items';
-    header.setTitleWidget(title);
-    view.addTopBar(header);
-
-    const content = new AdwStatusPage();
-    content.icon = folderSymbolic;
-    content.title = 'Your library';
-    content.description = 'Content sits between the toolbars and scrolls independently of them.';
-    view.setContent(content);
-
-    const bottomBar = new AdwHeaderBar();
-
-    const addButton = new AdwImageButton();
-    addButton.icon = listAddSymbolic;
-    bottomBar.packStart(addButton);
-
-    const removeButton = new AdwImageButton();
-    removeButton.icon = listRemoveSymbolic;
-    bottomBar.packStart(removeButton);
-
-    const selectionLabel = new AdwWindowTitle();
-    selectionLabel.title = 'Selection: none';
-    bottomBar.setTitleWidget(selectionLabel);
-
-    const shareButton = new AdwImageButton();
-    shareButton.icon = sendToSymbolic;
-    bottomBar.packEnd(shareButton);
-
-    view.addBottomBar(bottomBar);
+    // An icon here is the SVG SOURCE, not a theme name — NativeScript's Image
+    // decodes no SVG, so the widget rasterises the markup itself. An XML attribute
+    // is a string, so the template declares the buttons and gives them ids, and the
+    // loader hands each one its glyph.
+    view.getViewById<AdwStatusPage>('library').icon = folderSymbolic;
+    view.getViewById<AdwImageButton>('add').icon = listAddSymbolic;
+    view.getViewById<AdwImageButton>('share').icon = sendToSymbolic;
+    ```
+  </Fragment>
+  <Fragment slot="nativescript-xml">
+    ```xml
+    <adw:AdwToolbarView xmlns="http://schemas.nativescript.org/tns.xsd" xmlns:adw="~/adwaita">
+      <adw:AdwToolbarView.topBar>
+        <adw:AdwHeaderBar title="Documents" subtitle="12 items" />
+      </adw:AdwToolbarView.topBar>
+      <adw:AdwToolbarView.content>
+        <adw:AdwStatusPage id="library" title="Your library"
+          description="Content sits between the toolbars and scrolls independently of them." />
+      </adw:AdwToolbarView.content>
+      <adw:AdwToolbarView.bottomBar>
+        <adw:AdwHeaderBar>
+          <adw:AdwHeaderBar.startBox>
+            <adw:AdwImageButton id="add" />
+          </adw:AdwHeaderBar.startBox>
+          <adw:AdwHeaderBar.titleWidget>
+            <adw:AdwWindowTitle title="Selection: none" />
+          </adw:AdwHeaderBar.titleWidget>
+          <adw:AdwHeaderBar.endBox>
+            <adw:AdwImageButton id="share" />
+          </adw:AdwHeaderBar.endBox>
+        </adw:AdwHeaderBar>
+      </adw:AdwToolbarView.bottomBar>
+    </adw:AdwToolbarView>
     ```
   </Fragment>
 </AdwWidget>
@@ -565,19 +593,28 @@ chips or filter pills. **Child spacing** sets the gap between items on a line,
   </Fragment>
   <Fragment slot="nativescript">
     ```ts
-    import { AdwButton, AdwWrapBox } from '@gjsify/adwaita-nativescript';
+    // app/adwaita.ts — the module the template's `xmlns:adw="~/adwaita"` resolves to.
+    export { AdwButton, AdwWrapBox } from '@gjsify/adwaita-nativescript';
 
-    const wrap = new AdwWrapBox();
-    wrap.childSpacing = 8;
-    wrap.lineSpacing = 8;
+    // app/views/wrap-box.ts — the loader. A fixed run of chips is a tree, so it is
+    // the template's; build the children here instead when the run comes from data.
+    import { Builder } from '@nativescript/core';
 
-    const tags = ['Design', 'Adwaita', 'GNOME', 'GTK', 'Typescript', 'Storybook', 'Wrapping', 'Layout'];
-    for (const tag of tags) {
-        const chip = new AdwButton();
-        chip.text = tag;
-        chip.variant = 'pill';
-        wrap.add(chip);
-    }
+    export const wrapBox = Builder.load({ path: '~/views', name: 'wrap-box' });
+    ```
+  </Fragment>
+  <Fragment slot="nativescript-xml">
+    ```xml
+    <adw:AdwWrapBox xmlns:adw="~/adwaita" childSpacing="8" lineSpacing="8">
+      <adw:AdwButton text="Design" variant="pill" />
+      <adw:AdwButton text="Adwaita" variant="pill" />
+      <adw:AdwButton text="GNOME" variant="pill" />
+      <adw:AdwButton text="GTK" variant="pill" />
+      <adw:AdwButton text="Typescript" variant="pill" />
+      <adw:AdwButton text="Storybook" variant="pill" />
+      <adw:AdwButton text="Wrapping" variant="pill" />
+      <adw:AdwButton text="Layout" variant="pill" />
+    </adw:AdwWrapBox>
     ```
   </Fragment>
 </AdwWidget>


### PR DESCRIPTION
Was stacked on #1378; that has merged, so this is now restacked onto `main` and its diff is only these three commits.

## What

The NativeScript window on `adwaita/layout` read `[ TypeScript ]` — one tab of imperative construction — so it claimed the port has no declarative form. It now reads `[ TypeScript | XML ]`, and the TypeScript tab is the **loader**, not a second way to build the same widgets: the template holds the tree, the loader mounts it and does what markup cannot say. Same split as `[ TypeScript | Blueprint ]` above it, and the same argument for why XML is a tab rather than a window.

This is ADR 0033's rule applied to the one runtime that ADR left open, so the third commit closes that question in the ADR itself.

1. **`feat(adwaita-nativescript): XML children find their slot`** — the package fix the docs change turned out to need.
2. **`feat(website): the NativeScript window's XML template`** — the slot, the four templates, the loaders.
3. **`docs(adr): NativeScript's XML path, measured`** — ADR 0033 said "declared and unrun, being measured before any XML reaches the documentation". It was.

## The measurement

Zero XML views existed anywhere in this repository, so the declarative path was **declared and unrun**. It was run before anything was written down: Android emulator, API 37, `@nativescript/core` 9.1.0-alpha.11, `@nativescript/vite` 8.0.0-alpha.57, each template inflated by `Builder.load`, screenshotted, and its inflated tree read back out of the app.

The first run found four defects at once, none of which reports anything:

| Written in XML | What happened |
|---|---|
| `<AdwToolbarView.topBar>` + `.content` | both landed in row 0, painted on top of each other, row 1 empty |
| `<AdwHeaderBar>` child | went into the grid at column 0 — `startBox`/`endBox` stayed empty, so it *looked* packed |
| `<AdwClamp>` child | `child` stayed null, `_allocate` returned early, the clamp clamped nothing |
| `<AdwPreferencesGroup>` rows | appended *next to* the boxed list — no card, no rounded ends, no separators |

One cause: NativeScript's Builder hands every child to `_addChildFromBuilder(name, view)`, and `LayoutBase`'s inherited version ignores the name and calls `addChild`. Every composed widget here builds its own boxes in its constructor and exposes `addTopBar` / `setContent` / `packStart` / `setChild` to reach them, so the inherited default could only be wrong. `AdwWrapBox` was already correct, and its own comment says why — it routes every entry path through `addChild`.

The name is the whole decision and it is the same decision in four widgets, so it lives in a pure `builder-slots.ts` with no `@nativescript/core` import — which is what lets the spec drive it off-device, where the widget classes cannot be imported at all.

## Two documented claims this measured false

- `registerAdwaitaElements()` is **not** the XML path in a plain NativeScript app. `typeof registerElement` is `undefined` there — `@nativescript/core` 9.1 does not contain the identifier anywhere — so the function took its documented silent no-op branch and `<AdwSwitchRow>` resolved to nothing. It belongs to Angular/Vue. The barrel header now says so, and says what a plain XML app does instead. ADR 0033's table row is corrected with it.
- A **bare package specifier** in the xmlns does not resolve: `xmlns:adw="@gjsify/adwaita-nativescript"` fails with `Module 'AdwWrapBox' not found for element`. The namespace is a MODULE, so it needs an app-local barrel — `xmlns:adw="~/adwaita"`, which `@gjsify/vite-plugin-gjsify` already registers.

## Scope

The four Layout widgets, because those are the four that were rendered. `AdwPreferencesGroup`'s hook is in the package fix (it was a real defect, proven in the same run) but no boxed-lists page changed here.

## Gate

`nativescript-xml` is a port like any other in `AdwWidget`'s `WINDOWS`, so `check-website-adwaita-gallery.mjs` holds it in both directions. Falsified on this base, every arm this touches, both ways:

| Mutation | Exit |
|---|---|
| slot declared in `WINDOWS`, no page provides it (arm 6) | 1 |
| page writes `slot="nativescript-xmls"` (arm 5) | 1 |
| slot removed from `WINDOWS` while four pages provide it (arm 5) | 1 |
| the NativeScript window given `tabs: []` (arm 7) | 1 |
| unmutated | 0 |

## Checks

All from the worktree root, redirected, `$?` read: `./node_modules/.bin/oxfmt --check .` 0 · `./node_modules/.bin/oxlint scripts website` 0 · `check-website-adwaita-gallery` 0 · `check-doc-fences` 0 · `check-generated-website-data` 0 · `audit-runtimes --check` 0 · `check-adr-index` 0 · `gjsify workspace @gjsify/website build` 0 · `@gjsify/adwaita-nativescript` `test` 0 (3447 completed) and `check` 0 · the three `check-nativescript-*` gates, `check-storybook-story-parity`, `check-storybook-widget-coverage`, `check-adwaita-element-properties`, `check-type-surfaces` all 0.

The new spec was falsified too: breaking `resolveBuilderSlot` to always return the fallback turns it red (exit 1, three assertions).

Built HTML, `dist/adwaita/layout/index.html` — every NativeScript window is `impls="nativescript,nativescript-xml"` with `tabs=['TypeScript', 'XML']`. #1378's count-driven branch still holds: on `buttons` (5), `boxed-lists` (9) and `controls` (2) the NativeScript window has zero tab pages and so no tab bar, and the UI-frameworks window on this page stays single-pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9HRKqQZskrYLVer1fuFvg