### PR TITLE
test(e2e): reach the layer's own exports through the aliased specifier

### DIFF
--- a/tests/e2e/react-native-gate/run.mjs
+++ b/tests/e2e/react-native-gate/run.mjs
@@ -32,6 +32,27 @@ import { createTestEnvironment, cleanupTestEnvironment, setupProject } from '../
 const RN_PKG = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'packages', 'framework', 'react-native');
 
 /**
+ * Every name this layer adds on top of React Native's surface, read out of the
+ * generated module `isImportable` itself reads.
+ *
+ * `own.ts` already proves the gate accepts ONE of them — `configureStyle`, through
+ * the `@gjsify/react-native` spelling. This list is for the other axis. The gate
+ * watches BOTH specifiers, and the aliased one is what an unmodified ported
+ * application writes; an own export reaching the gate as `react-native` was the
+ * cell no vector occupied. Thirteen names rather than a sample, because the defect
+ * that put `own.ts` here was in the names nobody thought to write down.
+ */
+function ownExportNames() {
+    const source = readFileSync(join(RN_PKG, 'src', 'generated', 'own-exports.ts'), 'utf8');
+    const names = [...source.matchAll(/^ {4}'([A-Za-z_$][\w$]*)',$/gm)].map((match) => match[1]);
+    assert.ok(
+        names.length > 0,
+        'no own exports could be read from src/generated/own-exports.ts — the fixture would prove nothing',
+    );
+    return names;
+}
+
+/**
  * The refused name this suite builds against — DERIVED, never written down.
  *
  * It used to be `FlatList`, and that is exactly the bug: the fixture's premise is
@@ -89,6 +110,8 @@ describe('--app gjs react-native alias + support gate (ADR 0032 § 2, § 8)', { 
     let projectDir;
     /** `{ name, gtk }` of the planned entry this run builds against. */
     let planned;
+    /** Every name the layer adds on top of React Native's surface. */
+    let own;
 
     before(() => {
         planned = pickPlannedName();
@@ -99,15 +122,17 @@ describe('--app gjs react-native alias + support gate (ADR 0032 § 2, § 8)', { 
         const src = join(projectDir, 'src');
         mkdirSync(src, { recursive: true });
 
-        // Names whose support-table status is supported/partial. `View` and `Text`
-        // are the two the measured application uses most; `useColorScheme` is the
-        // only fully `supported` entry among them.
+        // Both populations, through the ALIASED specifier. React Native's own names
+        // on the first line; the layer's own on the second, where `own.ts` covers
+        // only the `@gjsify/react-native` spelling of one of them.
+        own = ownExportNames();
         writeFileSync(
             join(src, 'ok.ts'),
             [
                 "import { View, Text, useColorScheme } from 'react-native';",
+                `import { ${own.join(', ')} } from 'react-native';`,
                 "export const marker = 'RN_OK_BUILT';",
-                'export const parts = [View, Text, useColorScheme];',
+                `export const parts = [View, Text, useColorScheme, ${own.join(', ')}];`,
                 '',
             ].join('\n'),
         );
@@ -244,7 +269,7 @@ describe('--app gjs react-native alias + support gate (ADR 0032 § 2, § 8)', { 
         );
     });
 
-    it('WITH the opt-in, a supported-only import builds through the alias', () => {
+    it('WITH the opt-in, BOTH populations build through the alias', () => {
         const { status, output } = build(projectDir, [
             'src/ok.ts',
             '--app',
@@ -266,6 +291,14 @@ describe('--app gjs react-native alias + support gate (ADR 0032 § 2, § 8)', { 
             'no bare `react-native` import may survive into the bundle',
         );
         assert.ok(bundle.length > 100_000, `the layer must be bundled, got ${bundle.length} bytes`);
+        // Named individually: `exit 0` is also what a gate that stopped running
+        // produces. If an own export is refused again, this says WHICH.
+        for (const name of own) {
+            assert.ok(
+                !output.includes(`"${name}"`),
+                `the layer's own export ${name} must not be refused through the alias.\n${output}`,
+            );
+        }
     });
 
     // The one thing the gate has over the runtime backstop: the file and the line,


### PR DESCRIPTION
#1374 taught `isImportable` a second population and covered it here with `own.ts` — `import { configureStyle } from '@gjsify/react-native'`. That leaves **one cell of the matrix empty, and it is the cell the feature exists for**:

| | `react-native` | `@gjsify/react-native` |
|---|---|---|
| RN name, supported | ✅ | — |
| RN name, `planned` | ✅ | ✅ |
| **the layer's own exports** | **❌** | ✅ |
| neither population | ✅ | — |

The gate watches **both** specifiers, and the aliased one is what an unmodified ported application writes — the whole point of ADR 0032 § 2's alias line. An own export arriving at the gate spelled `react-native` was tested nowhere.

### What changes

The positive vector imports both populations through the alias, and the own half is **derived** from `src/generated/own-exports.ts` — the same module `isImportable` reads — rather than sampled. Thirteen names, not one: the defect that put `own.ts` here was in the names nobody thought to write down, and a hand-picked sample reproduces exactly that blind spot. It cannot rot either, for the same reason the refused-name fixture is derived.

The assertions name each own export individually. `exit 0` is also what a gate that stopped running produces, so *"the build succeeded"* is not the claim worth making; *"no own export was refused, and here is which one if it was"* is.

### A correction to the record

I reported this as *"#1374 fixed the unit level and left the e2e untouched"*. **That was wrong.** I read the RN-only positive vector, saw the old line, and stopped — `own.ts` and the neither-population vector were both already there, thirty lines further down. The real gap is one axis of one vector, not a missing layer.

Worth stating plainly because it is the same shape as the defect underneath all of this: a claim that was never checked against the thing it describes.

### Scope

Nothing outside `tests/e2e/react-native-gate/` changes. `isImportable` and its signature are untouched, so nothing that depends on it — including the in-flight `feat/adwaita-react-native` work — is affected.

Local: the full suite is **9/9 green** (`node --test tests/e2e/react-native-gate/run.mjs`, ~4 min), `gjsify lint` exit 0.
