### PR TITLE
fix(cli): ask for one OTP at a time, wait out 429

### DIFF
--- a/packages/infra/cli/src/commands/onboard.ts
+++ b/packages/infra/cli/src/commands/onboard.ts
@@ -56,7 +56,12 @@ import {
     parseRepoFromGitRemote,
     validateRepository,
 } from '../utils/trust-registry.js';
-import { DEFAULT_PROBE_CONCURRENCY, probeAllTrustStates, type PkgPlan } from '../utils/onboard-probe.js';
+import {
+    DEFAULT_PROBE_CONCURRENCY,
+    probeAllTrustStates,
+    requestWaitingOutRateLimit,
+    type PkgPlan,
+} from '../utils/onboard-probe.js';
 
 interface OnboardOptions {
     repository?: string;
@@ -324,6 +329,17 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         log(
             `Plan: ${done.length} already done, ${toPublish.length} to publish+trust, ${toTrust.length} to trust, ${blocked.length} unreadable.`,
         );
+        // Name the cause when the unreadable ones are throttling rather than a
+        // property of those packages. It lands on the TAIL of an alphabetical
+        // sweep, which is exactly where it looks like "these packages are
+        // special" instead of "we asked too fast".
+        const throttled = blocked.filter((p) => p.httpStatus === 429).length;
+        if (throttled > 0) {
+            log(
+                `  ${throttled} of those are npm rate limits (HTTP 429) that outlasted the backoff — ` +
+                    'lower --concurrency and re-run; the sweep is idempotent and picks up where it left off.',
+            );
+        }
 
         const results: PkgResult[] = [];
 
@@ -419,8 +435,12 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
                 log(`  published ${pub.name}@${'version' in pub ? pub.version : ''}`);
             }
 
-            // Configure the Trusted Publisher.
-            const created = await trustRequest('POST', p.url, trustBody);
+            // Configure the Trusted Publisher. Through the rate-limit-aware
+            // wrapper: a 703-package sweep that gets throttled on its READS gets
+            // throttled on its WRITES too, and a bare 429 here would be recorded
+            // as `trust failed` — a failure attributed to the package rather
+            // than to the pacing.
+            const created = await requestWaitingOutRateLimit(trustRequest, 'POST', p.url, trustBody);
             if (created.status >= 200 && created.status < 300) {
                 log(`  trusted ${p.ws.name}`);
                 results.push({

--- a/packages/infra/cli/src/commands/onboard.ts
+++ b/packages/infra/cli/src/commands/onboard.ts
@@ -58,7 +58,9 @@ import {
 } from '../utils/trust-registry.js';
 import {
     DEFAULT_PROBE_CONCURRENCY,
+    mapWithConcurrency,
     probeAllTrustStates,
+    RateLimitGate,
     requestWaitingOutRateLimit,
     type PkgPlan,
 } from '../utils/onboard-probe.js';
@@ -70,6 +72,7 @@ interface OnboardOptions {
     registry?: string;
     otp?: string;
     concurrency: number;
+    'write-concurrency': number;
     packages?: string[];
     include?: string[];
     exclude?: string[];
@@ -80,6 +83,15 @@ interface OnboardOptions {
     json?: boolean;
     yes?: boolean;
 }
+
+/**
+ * How many Trusted-Publisher writes run in parallel by default.
+ *
+ * Deliberately the same small number as the read probe: one token, one registry,
+ * and a 429 costs a backoff. The win is not really throughput — it is that four
+ * writes per npm 2FA window means a quarter as many codes typed by hand.
+ */
+const DEFAULT_WRITE_CONCURRENCY = 4;
 
 /** Per-package outcome after the act phase (for the JSON summary). */
 interface PkgResult {
@@ -158,6 +170,12 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
                     'How many packages to probe (read state) in parallel (kept small so a single token does not burst npm; the first read is always serial to prompt for the shared OTP once).',
                 type: 'number',
                 default: DEFAULT_PROBE_CONCURRENCY,
+            })
+            .option('write-concurrency', {
+                description:
+                    "How many Trusted-Publisher writes to issue in parallel. It buys FEWER 2FA PROMPTS more than it buys speed: an npm code lives about 30 seconds, so a serial sweep crosses a code boundary every ~38 packages. Raising it does not beat npm's rate limit — a 429 anywhere now pauses the whole sweep, so it self-paces down to whatever the registry will serve. Publishes are unaffected: they stay serial, because publish ORDER is a correctness property.",
+                type: 'number',
+                default: DEFAULT_WRITE_CONCURRENCY,
             })
             .option('dry-run', {
                 description: 'Report the plan (what would be published / trusted) without changing anything.',
@@ -297,6 +315,27 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         });
         const trustRequest = createTrustRequester({ npmrc, otpProvider });
 
+        // ONE cool-down for the whole sweep: a 429 on any request holds back
+        // every other one. Retrying a throttled request in isolation is not
+        // enough — the rest of the sweep keeps provoking the very limit the
+        // retry is waiting out, which is how a 703-package run spent its retry
+        // budget and reported `trust failed (HTTP 429)`.
+        const gate = new RateLimitGate();
+        let rateLimitReported = false;
+        const onRateLimit = (info: { url: string; headers: string; waitMs: number; fromRetryAfter: boolean }): void => {
+            if (rateLimitReported) return;
+            rateLimitReported = true;
+            // Report the FIRST one only. It answers the question that matters —
+            // does npm tell us how fast we may go? — and repeating it per request
+            // would bury the sweep's own output.
+            log(
+                `  npm rate limit hit. ${info.headers}. Waiting ${Math.round(info.waitMs / 1000)}s ` +
+                    `(${info.fromRetryAfter ? "npm's Retry-After" : 'our backoff — npm advised nothing'}), ` +
+                    'and holding the whole sweep back while it lasts.',
+            );
+        };
+        const pacing = { gate, onRateLimit };
+
         // 3. Determine per-package state. Reads run through the SAME
         // `TrustRequester` path `gjsify trust` uses (identical endpoint + auth +
         // OTP handling) — so a 2FA-gated trust-state read is answered with the
@@ -304,12 +343,18 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         // (task #60). The first read is serial (prompts for the shared OTP once,
         // before the burst); the rest run at a SMALL concurrency cap so a single
         // token never faces a 127-wide parallel read.
-        const plans = await probeAllTrustStates(trustRequest, selected, Math.max(1, args.concurrency), {
-            registryOverride: args.registry,
-            npmrc,
-            repository,
-            workflow,
-        });
+        const plans = await probeAllTrustStates(
+            trustRequest,
+            selected,
+            Math.max(1, args.concurrency),
+            {
+                registryOverride: args.registry,
+                npmrc,
+                repository,
+                workflow,
+            },
+            pacing,
+        );
 
         // Summary table (published✓ / trusted✓ vs work to do).
         const toPublish = plans.filter((p) => p.action === 'publish-and-trust');
@@ -380,94 +425,130 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
             return;
         }
 
-        // 4. Act on the gaps, minimally. Publishes + trust POSTs run SERIALLY so
-        // the shared OTP is prompted at most once (and reused everywhere) —
-        // reusing the `otpProvider` + `trustRequest` built for the probe phase.
+        // 4. Act on the gaps, minimally.
+        //
+        // The two kinds of work are paced DIFFERENTLY, on purpose.
+        //
+        // A trust POST is independent of every other trust POST, so they run at
+        // `--write-concurrency`. They used to be serial for one reason — "so the
+        // shared OTP is prompted at most once" — and that reason is gone now
+        // that `OtpProvider.refresh()` is single-flight: concurrent writers share
+        // one prompt instead of stacking N of them.
+        //
+        // What this buys is PROMPTS, not throughput, and the distinction is
+        // measured rather than assumed: the real `gjsify/types` run was already
+        // being 429'd at SERIAL pace, so npm — not the loop — sets the ceiling.
+        // What serial cost was 2FA codes: one lives ~30 s, so the sweep crossed a
+        // code boundary every ~38 packages, ~18 codes typed by hand for 703
+        // packages. Fewer wall-clock seconds per code means fewer codes.
+        // The shared `RateLimitGate` is what makes raising this safe rather than
+        // merely faster-to-fail.
+        //
+        // A publish stays SERIAL. Publish order is a correctness property
+        // (docs/publishing.md: an aborted parallel sweep can leave a live bridge
+        // pinning a platform child that does not exist), and nothing about OTP
+        // pacing is worth trading that for.
         const trustBody = githubTrustBody({ repository, workflow, environment });
+        const writeConcurrency = Math.max(1, args['write-concurrency']);
 
+        // Results are written by INDEX rather than pushed, so a concurrent phase
+        // still reports in plan order — a summary whose order depends on which
+        // request happened to answer first is harder to diff between runs.
+        const indexed: (PkgResult | undefined)[] = Array.from({ length: plans.length });
         let failed = 0;
-        for (const p of plans) {
+
+        /** POST the Trusted Publisher config for one package and record the outcome. */
+        const configureTrust = async (p: PkgPlan, i: number, publishedNow: boolean): Promise<void> => {
+            // Through the rate-limit-aware wrapper: a 703-package sweep that gets
+            // throttled on its READS gets throttled on its WRITES too, and a bare
+            // 429 here would be recorded as `trust failed` — a failure attributed
+            // to the package rather than to the pacing.
+            const created = await requestWaitingOutRateLimit(trustRequest, 'POST', p.url, trustBody, pacing);
+            if (created.status >= 200 && created.status < 300) {
+                log(`  trusted ${p.ws.name}`);
+                indexed[i] = { name: p.ws.name, result: publishedNow ? 'published+trusted' : 'trusted' };
+            } else if (created.status === 409) {
+                indexed[i] = { name: p.ws.name, result: publishedNow ? 'published+trusted' : 'trusted' };
+            } else if (created.status === 404) {
+                // Freshly-published package not yet provisioned for trust config.
+                log(`  ${p.ws.name}: published but not yet trust-configurable (re-run onboard)`);
+                indexed[i] = {
+                    name: p.ws.name,
+                    result: publishedNow ? 'published' : 'failed',
+                    detail: 'trust config deferred (404)',
+                };
+                if (!publishedNow) failed++;
+            } else {
+                log(`  trust failed (HTTP ${created.status}) — ${p.ws.name}`);
+                indexed[i] = { name: p.ws.name, result: 'failed', detail: `trust HTTP ${created.status}` };
+                failed++;
+            }
+        };
+
+        // 4a. Bookkeeping-only rows, and the serial publish path.
+        const trustOnly: { p: PkgPlan; i: number }[] = [];
+        for (let i = 0; i < plans.length; i++) {
+            const p = plans[i];
             if (p.action === 'skip') {
-                results.push({ name: p.ws.name, result: 'already-done' });
+                indexed[i] = { name: p.ws.name, result: 'already-done' };
                 continue;
             }
             if (p.action === 'blocked') {
                 log(`→ ${p.ws.name}: cannot read trust state (HTTP ${p.httpStatus}) — skipped`);
-                results.push({ name: p.ws.name, result: 'failed', detail: `state HTTP ${p.httpStatus}` });
+                indexed[i] = { name: p.ws.name, result: 'failed', detail: `state HTTP ${p.httpStatus}` };
                 failed++;
                 continue;
             }
-
-            let publishedNow = false;
-            if (p.action === 'publish-and-trust') {
-                log(`→ ${p.ws.name}: building + publishing…`);
-                try {
-                    if (args.build !== false) await buildIfPresent(p.ws, log);
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    log(`  build failed: ${msg}`);
-                    results.push({ name: p.ws.name, result: 'failed', detail: `build: ${msg}` });
-                    failed++;
-                    continue;
-                }
-                const pub = await publishWorkspace({
-                    wsDir: p.ws.location,
-                    tag: 'latest',
-                    access: args.access,
-                    provenance: false,
-                    tolerate: true, // a concurrent/racey publish is harmless
-                    tolerateUntrustedNew: false,
-                    trustedFlag: undefined,
-                    registry: p.registry,
-                    verbose: false,
-                    json: false,
-                    otpProvider,
-                    seedOtpFirst: false,
-                });
-                if (!pub.ok) {
-                    const detail = describePublishFailure(pub);
-                    log(`  publish failed: ${detail}`);
-                    results.push({ name: p.ws.name, result: 'failed', detail: `publish: ${detail}` });
-                    failed++;
-                    continue;
-                }
-                publishedNow = pub.action !== 'skipped-untrusted-new';
-                log(`  published ${pub.name}@${'version' in pub ? pub.version : ''}`);
+            if (p.action === 'trust') {
+                trustOnly.push({ p, i });
+                continue;
             }
 
-            // Configure the Trusted Publisher. Through the rate-limit-aware
-            // wrapper: a 703-package sweep that gets throttled on its READS gets
-            // throttled on its WRITES too, and a bare 429 here would be recorded
-            // as `trust failed` — a failure attributed to the package rather
-            // than to the pacing.
-            const created = await requestWaitingOutRateLimit(trustRequest, 'POST', p.url, trustBody);
-            if (created.status >= 200 && created.status < 300) {
-                log(`  trusted ${p.ws.name}`);
-                results.push({
-                    name: p.ws.name,
-                    result: publishedNow ? 'published+trusted' : 'trusted',
-                });
-            } else if (created.status === 409) {
-                results.push({ name: p.ws.name, result: publishedNow ? 'published+trusted' : 'trusted' });
-            } else if (created.status === 404) {
-                // Freshly-published package not yet provisioned for trust config.
-                log(`  ${p.ws.name}: published but not yet trust-configurable (re-run onboard)`);
-                results.push({
-                    name: p.ws.name,
-                    result: publishedNow ? 'published' : 'failed',
-                    detail: 'trust config deferred (404)',
-                });
-                if (!publishedNow) failed++;
-            } else {
-                log(`  trust failed (HTTP ${created.status})`);
-                results.push({
-                    name: p.ws.name,
-                    result: 'failed',
-                    detail: `trust HTTP ${created.status}`,
-                });
+            // publish-and-trust — serial, see above.
+            log(`→ ${p.ws.name}: building + publishing…`);
+            try {
+                if (args.build !== false) await buildIfPresent(p.ws, log);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                log(`  build failed: ${msg}`);
+                indexed[i] = { name: p.ws.name, result: 'failed', detail: `build: ${msg}` };
                 failed++;
+                continue;
             }
+            const pub = await publishWorkspace({
+                wsDir: p.ws.location,
+                tag: 'latest',
+                access: args.access,
+                provenance: false,
+                tolerate: true, // a concurrent/racey publish is harmless
+                tolerateUntrustedNew: false,
+                trustedFlag: undefined,
+                registry: p.registry,
+                verbose: false,
+                json: false,
+                otpProvider,
+                seedOtpFirst: false,
+            });
+            if (!pub.ok) {
+                const detail = describePublishFailure(pub);
+                log(`  publish failed: ${detail}`);
+                indexed[i] = { name: p.ws.name, result: 'failed', detail: `publish: ${detail}` };
+                failed++;
+                continue;
+            }
+            log(`  published ${pub.name}@${'version' in pub ? pub.version : ''}`);
+            await configureTrust(p, i, pub.action !== 'skipped-untrusted-new');
         }
+
+        // 4b. The trust-only packages, concurrently.
+        if (trustOnly.length > 0) {
+            if (trustOnly.length > 1) {
+                log(`→ configuring ${trustOnly.length} Trusted Publisher(s), ${writeConcurrency} at a time…`);
+            }
+            await mapWithConcurrency(trustOnly, writeConcurrency, async ({ p, i }) => configureTrust(p, i, false));
+        }
+
+        for (const r of indexed) if (r) results.push(r);
 
         finish(results, plans, { asJson, dryRun, failed, root, sources, discovered: all.length });
     },

--- a/packages/infra/cli/src/commands/trust.ts
+++ b/packages/infra/cli/src/commands/trust.ts
@@ -294,6 +294,12 @@ export interface TrustRequestResult {
     status: number;
     json: unknown;
     text: string;
+    /**
+     * Response headers, so a caller can honour npm's own `Retry-After` on a 429
+     * instead of guessing a backoff. Optional because test doubles construct this
+     * shape by hand and a missing header is a well-defined "it said nothing".
+     */
+    headers?: Headers;
 }
 
 /** A `(method, url, body?) => TrustRequestResult` function bound to a registry auth + OTP context. */
@@ -325,7 +331,7 @@ export function createTrustRequester(ctx: { npmrc: NpmrcConfig; otpProvider: Otp
         } catch {
             /* non-JSON body — leave json undefined */
         }
-        return { status: res.status, json, text };
+        return { status: res.status, json, text, headers: res.headers };
     };
 }
 

--- a/packages/infra/cli/src/utils/npm-otp.spec.ts
+++ b/packages/infra/cli/src/utils/npm-otp.spec.ts
@@ -49,6 +49,22 @@ function scriptedPrompt(codes: string[]): { fn: (q: string) => Promise<string>; 
     };
 }
 
+/** A promptFn that records the QUESTION it was asked, not only how often. */
+function recordingPrompt(codes: string[]): {
+    fn: (q: string) => Promise<string>;
+    questions: string[];
+} {
+    let i = 0;
+    const questions: string[] = [];
+    return {
+        questions,
+        fn: async (q: string) => {
+            questions.push(q);
+            return codes[i++] ?? '';
+        },
+    };
+}
+
 /**
  * A promptFn that takes a tick to answer, so concurrent callers genuinely overlap.
  * An instant prompt would let each caller finish before the next begins and the
@@ -313,6 +329,45 @@ export default async () => {
             );
             expect(prompt.count()).toBe(1);
             expect(results.every((r) => r.status === 200)).toBe(true);
+        });
+    });
+
+    await describe('OtpProvider — the SECOND prompt says the first code aged out', async () => {
+        // A sweep long enough to outlive a ~30s TOTP window legitimately asks
+        // again. Repeating the first-time wording reads as "it did not take my
+        // code", so the user retypes the SAME digits — the one answer guaranteed
+        // not to work.
+        await it('asks the first time plainly and the next time as a RENEWAL', async () => {
+            const prompt = recordingPrompt(['111111', '222222']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            await provider.refresh();
+            provider.invalidate();
+            await provider.refresh();
+
+            expect(prompt.questions.length).toBe(2);
+            expect(prompt.questions[0].includes('requires a one-time password')).toBe(true);
+            expect(prompt.questions[0].includes('no longer valid')).toBe(false);
+            expect(prompt.questions[1].includes('no longer valid')).toBe(true);
+            expect(prompt.questions[1].includes('NEW OTP')).toBe(true);
+        });
+
+        await it('an explicit question from the caller still wins', async () => {
+            const prompt = recordingPrompt(['111111', '222222']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            await provider.refresh('custom: ');
+            provider.invalidate();
+            await provider.refresh('custom: ');
+            expect(prompt.questions).toStrictEqual(['custom: ', 'custom: ']);
+        });
+
+        await it('withOtpRetry lets the provider choose the wording', async () => {
+            const prompt = recordingPrompt(['wrong1', '246810']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            const reg = fakeRegistry('246810');
+            const res = await withOtpRetry(reg.doFetch, provider);
+            expect(res.status).toBe(200);
+            expect(prompt.questions[0].includes('no longer valid')).toBe(false);
+            expect(prompt.questions[1].includes('no longer valid')).toBe(true);
         });
     });
 };

--- a/packages/infra/cli/src/utils/npm-otp.spec.ts
+++ b/packages/infra/cli/src/utils/npm-otp.spec.ts
@@ -49,6 +49,24 @@ function scriptedPrompt(codes: string[]): { fn: (q: string) => Promise<string>; 
     };
 }
 
+/**
+ * A promptFn that takes a tick to answer, so concurrent callers genuinely overlap.
+ * An instant prompt would let each caller finish before the next begins and the
+ * pile-up under test could not occur.
+ */
+function slowPrompt(codes: string[]): { fn: (q: string) => Promise<string>; count: () => number } {
+    let i = 0;
+    let calls = 0;
+    return {
+        count: () => calls,
+        fn: async () => {
+            calls++;
+            await new Promise((r) => setTimeout(r, 5));
+            return codes[i++] ?? '';
+        },
+    };
+}
+
 export default async () => {
     await describe('isOtpChallenge', async () => {
         await it('is true for 401 + www-authenticate: otp', async () => {
@@ -218,6 +236,83 @@ export default async () => {
                 else process.env.GJSIFY_NO_OTP_CACHE = prevOptOut;
                 rmSync(dir, { recursive: true, force: true });
             }
+        });
+    });
+
+    await describe('OtpProvider — one prompt, ever (the concurrent sweep)', async () => {
+        // `gjsify onboard` probes at concurrency 4 and `promptLine` runs the terminal
+        // in RAW mode echoing each keystroke by hand, so two live prompts mean two
+        // stdin listeners and every digit is echoed twice. Measured on a real
+        // 703-package sweep: five stacked prompts and the typed code came back as
+        // `666644440000999944444444` — four echoes per keystroke.
+        await it('serves four concurrent refreshes from ONE prompt', async () => {
+            const prompt = slowPrompt(['111111', '222222', '333333', '444444']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            const codes = await Promise.all([
+                provider.refresh(),
+                provider.refresh(),
+                provider.refresh(),
+                provider.refresh(),
+            ]);
+            expect(prompt.count()).toBe(1);
+            expect(codes).toStrictEqual(['111111', '111111', '111111', '111111']);
+        });
+
+        await it('prompts AGAIN for a caller that arrives after the first prompt closed', async () => {
+            // Single-flight must not mean single-ever: a genuinely rejected code
+            // still has to be replaceable.
+            const prompt = slowPrompt(['111111', '222222']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            expect(await provider.refresh()).toBe('111111');
+            provider.invalidate();
+            expect(await provider.refresh()).toBe('222222');
+            expect(prompt.count()).toBe(2);
+        });
+
+        await it('hands the NEWER code to a caller whose own attempt used an older one', async () => {
+            const prompt = slowPrompt(['111111', '222222']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            const stale = provider.epoch();
+            expect(await provider.refresh()).toBe('111111');
+            // The stale caller's attempt failed against the pre-refresh state; it
+            // must take the code that now exists, not open a second prompt.
+            expect(await provider.refresh(undefined, stale)).toBe('111111');
+            expect(prompt.count()).toBe(1);
+        });
+    });
+
+    await describe('OtpProvider — invalidate() is scoped to the attempt', async () => {
+        await it('does NOT clear a code that replaced the one being rejected', async () => {
+            const prompt = slowPrompt(['111111', '222222']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            const epochOfFirst = provider.epoch();
+            await provider.refresh(); // 111111, epoch bumps
+            // A sibling worker still holding the PRE-111111 epoch reports failure.
+            provider.invalidate(epochOfFirst);
+            expect(provider.current()).toBe('111111');
+        });
+
+        await it('clears when the rejected code IS the current one', async () => {
+            const prompt = slowPrompt(['111111']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            await provider.refresh();
+            provider.invalidate(provider.epoch());
+            expect(provider.current()).toBe(undefined);
+        });
+    });
+
+    await describe('withOtpRetry — a concurrent burst asks once', async () => {
+        await it('four parallel operations share ONE prompt and all succeed', async () => {
+            const prompt = slowPrompt(['246810', 'unused-2', 'unused-3', 'unused-4']);
+            const provider = new OtpProvider(undefined, prompt.fn);
+            const results = await Promise.all(
+                Array.from({ length: 4 }, () => {
+                    const reg = fakeRegistry('246810');
+                    return withOtpRetry(reg.doFetch, provider);
+                }),
+            );
+            expect(prompt.count()).toBe(1);
+            expect(results.every((r) => r.status === 200)).toBe(true);
         });
     });
 };

--- a/packages/infra/cli/src/utils/npm-otp.ts
+++ b/packages/infra/cli/src/utils/npm-otp.ts
@@ -21,6 +21,17 @@ export type OtpPromptFn = (question: string) => Promise<string>;
 const DEFAULT_QUESTION = 'This operation requires a one-time password.\nEnter OTP: ';
 
 /**
+ * The question for every prompt AFTER the first one in a run.
+ *
+ * A long sweep outlives a TOTP window (npm codes last ~30 s), so it legitimately
+ * asks again — but repeating the first-time wording makes that read as "it did
+ * not take my code" rather than "that code has aged out". The user then retypes
+ * the SAME digits, which is the one answer guaranteed not to work.
+ */
+const RENEW_QUESTION =
+    'The previous one-time password is no longer valid (npm codes last about 30 seconds).\nEnter a NEW OTP: ';
+
+/**
  * True when a response is an npm OTP / 2FA challenge (401 + a `www-authenticate`
  * header naming `otp`, or a body mentioning a one-time password / `EOTP`).
  */
@@ -121,7 +132,7 @@ export class OtpProvider {
      * Prompt for a fresh code, cache it (in-process + file cache), and return the
      * trimmed input — `''` when nothing was entered, which callers read as "give up".
      */
-    async refresh(question: string = DEFAULT_QUESTION, sinceEpoch?: number): Promise<string> {
+    async refresh(question?: string, sinceEpoch?: number): Promise<string> {
         // Somebody supplied a newer code than this caller last saw. Its own attempt
         // failed against the OLD code, so the answer is that code, not a prompt.
         if (sinceEpoch !== undefined && this.generation > sinceEpoch && this.cached) {
@@ -131,7 +142,10 @@ export class OtpProvider {
         // stdin double every echoed keystroke, and the user is being asked twice
         // for a code that is shared anyway.
         if (this.pending) return this.pending;
-        this.pending = this.promptOnce(question);
+        // The provider is the only thing that knows whether a code has already
+        // been supplied in this run, so it owns the wording. An explicit
+        // `question` from the caller always wins.
+        this.pending = this.promptOnce(question ?? (this.generation > 0 ? RENEW_QUESTION : DEFAULT_QUESTION));
         try {
             return await this.pending;
         } finally {
@@ -197,7 +211,9 @@ export async function withOtpRetry(
     opts: OtpRetryOptions = {},
 ): Promise<Response> {
     const maxPrompts = opts.maxPrompts ?? 2;
-    const question = opts.question ?? DEFAULT_QUESTION;
+    // Deliberately NOT defaulted here: `undefined` is what lets the provider pick
+    // between the first-time wording and the "your previous code aged out" one.
+    const question = opts.question;
     const cached = provider.current();
     const seededFirst = opts.seedFirstAttempt === true && cached !== undefined;
 

--- a/packages/infra/cli/src/utils/npm-otp.ts
+++ b/packages/infra/cli/src/utils/npm-otp.ts
@@ -62,6 +62,23 @@ export class OtpProvider {
     private cached: string | undefined;
     private readonly promptFn: OtpPromptFn;
     private readonly registry: string | undefined;
+    /**
+     * Bumped every time a NEW code becomes current. Concurrent callers compare the
+     * epoch they last saw against this one to tell "my code was rejected" from
+     * "somebody already replaced it while I was waiting" — the second needs no
+     * prompt, it needs the other one's code.
+     */
+    private generation = 0;
+    /**
+     * The prompt currently on screen, if any. THE fix for a sweep that probes with
+     * concurrency > 1: `promptLine` puts the terminal in RAW mode and echoes each
+     * keystroke by hand (utils/prompt.ts), so two live prompts mean two `data`
+     * listeners on the same stdin and every digit is echoed TWICE. Measured on a
+     * real 703-package sweep at the default concurrency of 4: five prompts stacked
+     * up and the typed code came back as `666644440000999944444444` — four echoes
+     * per keystroke. Whoever arrives second awaits this promise instead.
+     */
+    private pending: Promise<string> | undefined;
 
     /**
      * @param seed     Initial cached code (from `--otp`), or undefined.
@@ -91,13 +108,42 @@ export class OtpProvider {
     }
 
     /**
+     * How many times a new code has become current. Capture it before an attempt
+     * and hand it back to {@link refresh} / {@link invalidate} so a concurrent
+     * caller neither prompts for a code somebody already typed nor throws that
+     * code away on its own stale rejection.
+     */
+    epoch(): number {
+        return this.generation;
+    }
+
+    /**
      * Prompt for a fresh code, cache it (in-process + file cache), and return the
      * trimmed input — `''` when nothing was entered, which callers read as "give up".
      */
-    async refresh(question: string = DEFAULT_QUESTION): Promise<string> {
+    async refresh(question: string = DEFAULT_QUESTION, sinceEpoch?: number): Promise<string> {
+        // Somebody supplied a newer code than this caller last saw. Its own attempt
+        // failed against the OLD code, so the answer is that code, not a prompt.
+        if (sinceEpoch !== undefined && this.generation > sinceEpoch && this.cached) {
+            return this.cached;
+        }
+        // Single-flight: one prompt at a time, ever. Two raw-mode prompts on one
+        // stdin double every echoed keystroke, and the user is being asked twice
+        // for a code that is shared anyway.
+        if (this.pending) return this.pending;
+        this.pending = this.promptOnce(question);
+        try {
+            return await this.pending;
+        } finally {
+            this.pending = undefined;
+        }
+    }
+
+    private async promptOnce(question: string): Promise<string> {
         const code = (await this.promptFn(question)).trim();
         if (code) {
             this.cached = code;
+            this.generation++;
             if (this.registry) writeCachedOtp(this.registry, code);
         }
         return code;
@@ -108,7 +154,12 @@ export class OtpProvider {
      * rejects it, so the NEXT command re-prompts instead of replaying a single-use
      * code the registry already burned.
      */
-    invalidate(): void {
+    invalidate(sinceEpoch?: number): void {
+        // Only the caller whose own code was rejected may clear it. Without this
+        // guard the first rejection in a concurrent burst wipes a code another
+        // worker just typed, and every remaining worker prompts again — the same
+        // stacked-prompt pile-up from the other direction.
+        if (sinceEpoch !== undefined && this.generation !== sinceEpoch) return;
         this.cached = undefined;
         if (this.registry) clearCachedOtp(this.registry);
     }
@@ -150,28 +201,37 @@ export async function withOtpRetry(
     const cached = provider.current();
     const seededFirst = opts.seedFirstAttempt === true && cached !== undefined;
 
+    // Every invalidate/refresh below is scoped to the epoch of the code THIS call
+    // actually tried. Concurrent callers share the provider, so an unscoped
+    // `invalidate()` discards a code a sibling typed a millisecond ago and sends
+    // everyone back to the prompt.
+    let epoch = provider.epoch();
     let res = await doFetch(seededFirst ? cached : undefined);
     if (!(await isOtpChallenge(res))) return res;
     // The seeded code was rejected/consumed — drop it so it is not replayed and the
     // cross-invocation cache entry is cleared.
-    if (seededFirst) provider.invalidate();
+    if (seededFirst) provider.invalidate(epoch);
 
     if (!seededFirst && provider.current() !== undefined) {
+        epoch = provider.epoch();
         res = await doFetch(provider.current());
         if (!(await isOtpChallenge(res))) return res;
         // Stale seed, or a sibling command already burned the file-cached single-use
         // code.
-        provider.invalidate();
+        provider.invalidate(epoch);
     }
 
     for (let i = 0; i < maxPrompts; i++) {
-        const fresh = await provider.refresh(question);
+        // `refresh` with the epoch: if another concurrent caller has already typed a
+        // newer code, this returns THAT code and shows no prompt.
+        const fresh = await provider.refresh(question, epoch);
         if (!fresh) return res; // no input — hand the challenge back to the caller
+        epoch = provider.epoch();
         res = await doFetch(fresh);
         if (!(await isOtpChallenge(res))) return res;
         // Clear a rejected fresh code before re-prompting, so a wedged sequence never
         // leaves a burned code in the file cache.
-        provider.invalidate();
+        provider.invalidate(epoch);
     }
     return res;
 }

--- a/packages/infra/cli/src/utils/onboard-probe.spec.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.spec.ts
@@ -14,8 +14,10 @@ import {
     mapWithConcurrency,
     probeAllTrustStates,
     probeTrustState,
+    RateLimitGate,
     requestWaitingOutRateLimit,
     retryAfterMs,
+    describeRateLimitHeaders,
     type ProbeContext,
 } from './onboard-probe.js';
 
@@ -341,6 +343,79 @@ export default async () => {
             });
             expect(plan.action).toBe('blocked');
             expect(plan.httpStatus).toBe(429);
+        });
+    });
+
+    await describe('RateLimitGate — a 429 anywhere pauses everywhere', async () => {
+        await it('holds a later caller back for the penalty another one earned', async () => {
+            let clock = 0;
+            const slept: number[] = [];
+            const gate = new RateLimitGate({
+                now: () => clock,
+                sleep: async (ms) => {
+                    slept.push(ms);
+                    clock += ms;
+                },
+            });
+            expect(gate.remainingMs()).toBe(0);
+            gate.penalize(5000);
+            expect(gate.remainingMs()).toBe(5000);
+            await gate.wait();
+            expect(slept).toStrictEqual([5000]);
+            // The cool-down is served, not re-served.
+            expect(gate.remainingMs()).toBe(0);
+        });
+
+        await it('takes the LONGEST outstanding penalty, never the latest', async () => {
+            let clock = 0;
+            const gate = new RateLimitGate({ now: () => clock, sleep: async () => {} });
+            gate.penalize(10_000);
+            gate.penalize(1000); // a shorter one must not shorten the wait
+            expect(gate.remainingMs()).toBe(10_000);
+        });
+
+        await it('a throttled request waits on the SHARED gate', async () => {
+            let clock = 0;
+            const slept: number[] = [];
+            const gate = new RateLimitGate({
+                now: () => clock,
+                sleep: async (ms) => {
+                    slept.push(ms);
+                    clock += ms;
+                },
+            });
+            let calls = 0;
+            const req: TrustRequester = async () => {
+                calls++;
+                return calls === 1
+                    ? { status: 429, json: undefined, text: '', headers: new Headers({ 'retry-after': '3' }) }
+                    : { status: 200, json: [], text: '[]' };
+            };
+            const res = await requestWaitingOutRateLimit(req, 'GET', 'https://r/x', undefined, { gate });
+            expect(res.status).toBe(200);
+            // npm asked for 3s and that is what the whole sweep waited.
+            expect(slept).toStrictEqual([3000]);
+        });
+
+        await it('reports what npm actually said, so the pacing is not a guess', async () => {
+            const seen: string[] = [];
+            let calls = 0;
+            const withHeader: TrustRequester = async () => {
+                calls++;
+                return calls === 1
+                    ? { status: 429, json: undefined, text: '', headers: new Headers({ 'retry-after': '2' }) }
+                    : { status: 200, json: [], text: '[]' };
+            };
+            await requestWaitingOutRateLimit(withHeader, 'GET', 'https://r/x', undefined, {
+                sleep: async () => {},
+                onRateLimit: (i) => seen.push(`${i.fromRetryAfter}|${i.headers}|${i.waitMs}`),
+            });
+            expect(seen).toStrictEqual(['true|retry-after: 2|2000']);
+
+            // And the honest report when npm advertises nothing: measured
+            // 2026-08-28, npm serves no X-RateLimit-* headers at all.
+            expect(describeRateLimitHeaders(new Headers())).toBe('npm sent no Retry-After and no rate-limit headers');
+            expect(describeRateLimitHeaders(undefined)).toBe('no headers captured');
         });
     });
 };

--- a/packages/infra/cli/src/utils/onboard-probe.spec.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.spec.ts
@@ -14,6 +14,8 @@ import {
     mapWithConcurrency,
     probeAllTrustStates,
     probeTrustState,
+    requestWaitingOutRateLimit,
+    retryAfterMs,
     type ProbeContext,
 } from './onboard-probe.js';
 
@@ -268,6 +270,77 @@ export default async () => {
             const plans = await probeAllTrustStates(request, [], 4, ctx(), { sleep: noSleep });
             expect(plans.length).toBe(0);
             expect(called).toBeFalsy();
+        });
+    });
+
+    await describe('onboard-probe — an HTTP 429 is not a state', async () => {
+        // Measured on the real 703-package sweep of `gjsify/types`: the first 662
+        // reads answered and the LAST 41 came back 429, so the plan reported
+        // `41 unreadable` for packages whose state nobody had failed to determine.
+        // A cumulative rate limit lands on the tail of an alphabetical list, which
+        // makes throttling look like a property of those packages.
+        const noSleep = async (): Promise<void> => {};
+
+        await it('retryAfterMs reads delta-seconds and refuses everything else', () => {
+            expect(retryAfterMs(new Headers({ 'retry-after': '7' }))).toBe(7000);
+            expect(retryAfterMs(new Headers({ 'retry-after': ' 0 ' }))).toBe(0);
+            // The HTTP-date form is legal and npm does not send it. Guessing at a
+            // date would be a second clock to get wrong, so it reads as "said
+            // nothing" and the exponential backoff decides.
+            expect(retryAfterMs(new Headers({ 'retry-after': 'Wed, 21 Oct 2026 07:28:00 GMT' }))).toBe(null);
+            expect(retryAfterMs(new Headers({ 'retry-after': '-3' }))).toBe(null);
+            expect(retryAfterMs(new Headers())).toBe(null);
+            expect(retryAfterMs(undefined)).toBe(null);
+        });
+
+        await it('waits out a 429 and returns the answer that follows it', async () => {
+            let calls = 0;
+            const req: TrustRequester = async () => {
+                calls++;
+                return calls <= 2
+                    ? { status: 429, json: undefined, text: '', headers: new Headers({ 'retry-after': '1' }) }
+                    : { status: 200, json: [], text: '[]' };
+            };
+            const res = await requestWaitingOutRateLimit(req, 'GET', 'https://r/x', undefined, { sleep: noSleep });
+            expect(res.status).toBe(200);
+            expect(calls).toBe(3);
+        });
+
+        await it('gives up after the budget and hands back the 429 — never hangs', async () => {
+            let calls = 0;
+            const req: TrustRequester = async () => {
+                calls++;
+                return { status: 429, json: undefined, text: '' };
+            };
+            const res = await requestWaitingOutRateLimit(req, 'GET', 'https://r/x', undefined, {
+                sleep: noSleep,
+                maxRateLimitRetries: 3,
+            });
+            expect(res.status).toBe(429);
+            expect(calls).toBe(4); // the first attempt plus three retries
+        });
+
+        await it('probeTrustState classifies the answer AFTER the throttling, not the 429', async () => {
+            let calls = 0;
+            const req: TrustRequester = async () => {
+                calls++;
+                return calls === 1
+                    ? { status: 429, json: undefined, text: '' }
+                    : { status: 404, json: undefined, text: '' };
+            };
+            const plan = await probeTrustState(req, ws('@onb/a'), ctx(), { sleep: noSleep });
+            expect(plan.state).toBe('unpublished');
+            expect(plan.action).toBe('publish-and-trust');
+        });
+
+        await it('still reports blocked when the throttling outlasts the budget', async () => {
+            const req: TrustRequester = async () => ({ status: 429, json: undefined, text: '' });
+            const plan = await probeTrustState(req, ws('@onb/a'), ctx(), {
+                sleep: noSleep,
+                maxRateLimitRetries: 1,
+            });
+            expect(plan.action).toBe('blocked');
+            expect(plan.httpStatus).toBe(429);
         });
     });
 };

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -11,7 +11,7 @@
 
 import { DEFAULT_REGISTRY, registryFor, type NpmrcConfig } from '@gjsify/npm-registry';
 import type { Workspace } from '@gjsify/workspace';
-import type { TrustRequester } from '../commands/trust.js';
+import type { TrustRequester, TrustRequestResult } from '../commands/trust.js';
 import { classifyTrustList, trustUrl, type TrustState } from './trust-registry.js';
 
 /** What a package needs, computed from its published + trust state. */
@@ -39,6 +39,10 @@ export interface ProbeOptions {
     retryOn401?: boolean;
     /** Backoff before the single 401 retry. Default {@link PROBE_RETRY_DELAY_MS}. */
     retryDelayMs?: number;
+    /** How many times to wait out an HTTP 429. Default {@link RATE_LIMIT_MAX_RETRIES}. */
+    maxRateLimitRetries?: number;
+    /** First backoff for a 429; doubles per attempt. Default {@link RATE_LIMIT_BASE_DELAY_MS}. */
+    rateLimitBaseDelayMs?: number;
     /** Injected delay (tests pass a no-op). Default: real `setTimeout`. */
     sleep?: (ms: number) => Promise<void>;
     /**
@@ -49,6 +53,33 @@ export interface ProbeOptions {
 }
 
 export const PROBE_RETRY_DELAY_MS = 400;
+
+/**
+ * A 429 is npm asking to be asked later — never an answer about the package.
+ *
+ * Measured on the real 703-package sweep of `gjsify/types` at the default
+ * concurrency: the first 662 reads answered and the LAST 41 came back `429`, so
+ * the plan said `41 unreadable` for packages whose state nobody had actually
+ * failed to determine. The tail of an alphabetical list is exactly where a
+ * cumulative rate limit lands, which makes the damage look like a property of
+ * those packages.
+ *
+ * Waiting is the whole fix, and it has to be bounded: an unbounded wait turns a
+ * throttled sweep into a hang with no output.
+ */
+export const RATE_LIMIT_MAX_RETRIES = 4;
+export const RATE_LIMIT_BASE_DELAY_MS = 2000;
+
+/** Seconds to wait per npm's `Retry-After`, or null when it said nothing usable. */
+export function retryAfterMs(headers: Headers | undefined): number | null {
+    const raw = headers?.get('retry-after');
+    if (!raw) return null;
+    const secs = Number.parseInt(raw.trim(), 10);
+    // Only the delta-seconds form. The HTTP-date form is legal and npm does not
+    // send it; guessing at a date here would be a second clock to get wrong.
+    if (!Number.isFinite(secs) || secs < 0) return null;
+    return secs * 1000;
+}
 
 /**
  * Does the registry serve a packument for this name?
@@ -108,6 +139,36 @@ function defaultSleep(ms: number): Promise<void> {
 }
 
 /**
+ * Issue a request, waiting out an HTTP 429 rather than reporting it as a state.
+ *
+ * Used by BOTH the probe GET and the act-phase trust POST, because a sweep long
+ * enough to be throttled on reads is long enough to be throttled on writes, and
+ * a throttled POST would otherwise be recorded as `trust failed (HTTP 429)` —
+ * a failure attributed to the package instead of to the pacing.
+ *
+ * Bounded on purpose: it returns the last 429 once the budget is spent, so the
+ * caller reports "unreadable" rather than hanging. `Retry-After` wins over the
+ * exponential backoff whenever npm sends a usable one.
+ */
+export async function requestWaitingOutRateLimit(
+    request: TrustRequester,
+    method: string,
+    url: string,
+    body?: unknown,
+    opts: ProbeOptions = {},
+): Promise<TrustRequestResult> {
+    const sleep = opts.sleep ?? defaultSleep;
+    const maxRetries = opts.maxRateLimitRetries ?? RATE_LIMIT_MAX_RETRIES;
+    const baseDelay = opts.rateLimitBaseDelayMs ?? RATE_LIMIT_BASE_DELAY_MS;
+    let res = await request(method, url, body);
+    for (let attempt = 0; res.status === 429 && attempt < maxRetries; attempt++) {
+        await sleep(retryAfterMs(res.headers) ?? baseDelay * 2 ** attempt);
+        res = await request(method, url, body);
+    }
+    return res;
+}
+
+/**
  * Read one package's published + trust state through the SHARED trust requester.
  * A surviving `auth-required` means the 401 was not an answerable OTP challenge —
  * a parallel-burst rejection or a lapsed 2FA-skip window — and both recover on a
@@ -123,11 +184,13 @@ export async function probeTrustState(
     const url = trustUrl(registry, ws.name);
     const classifyOpts = { repository: ctx.repository, workflow: ctx.workflow };
 
-    let res = await request('GET', url);
+    const sleep = opts.sleep ?? defaultSleep;
+
+    // A 429 is not an answer — wait it out BEFORE classifying anything.
+    let res = await requestWaitingOutRateLimit(request, 'GET', url, undefined, opts);
     let state = classifyTrustList(res.status, res.json, classifyOpts);
 
     if (state === 'auth-required' && opts.retryOn401 !== false) {
-        const sleep = opts.sleep ?? defaultSleep;
         await sleep(opts.retryDelayMs ?? PROBE_RETRY_DELAY_MS);
         res = await request('GET', url);
         state = classifyTrustList(res.status, res.json, classifyOpts);

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -43,6 +43,18 @@ export interface ProbeOptions {
     maxRateLimitRetries?: number;
     /** First backoff for a 429; doubles per attempt. Default {@link RATE_LIMIT_BASE_DELAY_MS}. */
     rateLimitBaseDelayMs?: number;
+    /**
+     * Cool-down shared across the sweep. Pass ONE instance to every call so a
+     * 429 anywhere holds back everywhere; omit for an isolated request.
+     */
+    gate?: RateLimitGate;
+    /**
+     * Called on every 429 with what npm actually sent and how long we will wait.
+     * The caller decides how loud to be; reporting the FIRST one is enough to
+     * turn "we got throttled" into "npm asked for N seconds" (or into "npm said
+     * nothing, so this delay is ours").
+     */
+    onRateLimit?: (info: { url: string; headers: string; waitMs: number; fromRetryAfter: boolean }) => void;
     /** Injected delay (tests pass a no-op). Default: real `setTimeout`. */
     sleep?: (ms: number) => Promise<void>;
     /**
@@ -69,6 +81,24 @@ export const PROBE_RETRY_DELAY_MS = 400;
  */
 export const RATE_LIMIT_MAX_RETRIES = 4;
 export const RATE_LIMIT_BASE_DELAY_MS = 2000;
+
+/**
+ * What npm told us about pacing on a 429 — verbatim, so the answer to "how fast
+ * may we go" comes from the registry rather than from a guess.
+ *
+ * Measured 2026-08-28: npm serves NO `X-RateLimit-*` headers on ordinary
+ * responses, so there is no budget to read ahead of time. `Retry-After` on the
+ * 429 itself is the only channel, and whether npm populates it on the trust
+ * endpoint is exactly what this reports the first time it happens.
+ */
+export function describeRateLimitHeaders(headers: Headers | undefined): string {
+    if (!headers) return 'no headers captured';
+    const seen: string[] = [];
+    headers.forEach((value, key) => {
+        if (/^retry-after$/i.test(key) || /ratelimit/i.test(key)) seen.push(`${key}: ${value}`);
+    });
+    return seen.length > 0 ? seen.join(', ') : 'npm sent no Retry-After and no rate-limit headers';
+}
 
 /** Seconds to wait per npm's `Retry-After`, or null when it said nothing usable. */
 export function retryAfterMs(headers: Headers | undefined): number | null {
@@ -139,6 +169,46 @@ function defaultSleep(ms: number): Promise<void> {
 }
 
 /**
+ * A cool-down shared by every in-flight request of a sweep.
+ *
+ * Retrying ONE throttled request in isolation is not enough, and the measured
+ * run shows why: at serial pace `gjsify/types` was already being 429'd, so every
+ * other worker kept hammering the registry through the very window the retry was
+ * waiting out — and the retry budget then expired against a limit nobody had
+ * stopped provoking. `trust failed (HTTP 429)` was the result.
+ *
+ * A 429 anywhere therefore pauses EVERYWHERE. That also makes concurrency safe
+ * to raise: the sweep self-paces down to whatever npm is willing to serve
+ * instead of the operator guessing a number.
+ */
+export class RateLimitGate {
+    private until = 0;
+    private readonly now: () => number;
+    private readonly sleeper: (ms: number) => Promise<void>;
+
+    constructor(opts: { now?: () => number; sleep?: (ms: number) => Promise<void> } = {}) {
+        this.now = opts.now ?? (() => Date.now());
+        this.sleeper = opts.sleep ?? defaultSleep;
+    }
+
+    /** Block while a cool-down is in effect. */
+    async wait(): Promise<void> {
+        const remaining = this.until - this.now();
+        if (remaining > 0) await this.sleeper(remaining);
+    }
+
+    /** Hold every request back for at least `ms` from now. */
+    penalize(ms: number): void {
+        this.until = Math.max(this.until, this.now() + ms);
+    }
+
+    /** Milliseconds still owed, for tests and for reporting. */
+    remainingMs(): number {
+        return Math.max(0, this.until - this.now());
+    }
+}
+
+/**
  * Issue a request, waiting out an HTTP 429 rather than reporting it as a state.
  *
  * Used by BOTH the probe GET and the act-phase trust POST, because a sweep long
@@ -160,9 +230,24 @@ export async function requestWaitingOutRateLimit(
     const sleep = opts.sleep ?? defaultSleep;
     const maxRetries = opts.maxRateLimitRetries ?? RATE_LIMIT_MAX_RETRIES;
     const baseDelay = opts.rateLimitBaseDelayMs ?? RATE_LIMIT_BASE_DELAY_MS;
+    const gate = opts.gate;
+
+    // Respect a cool-down somebody else is already serving BEFORE spending an
+    // attempt. Without this the sweep keeps provoking the limit it is waiting on.
+    if (gate) await gate.wait();
     let res = await request(method, url, body);
     for (let attempt = 0; res.status === 429 && attempt < maxRetries; attempt++) {
-        await sleep(retryAfterMs(res.headers) ?? baseDelay * 2 ** attempt);
+        const advised = retryAfterMs(res.headers);
+        const delay = advised ?? baseDelay * 2 ** attempt;
+        opts.onRateLimit?.({
+            url,
+            headers: describeRateLimitHeaders(res.headers),
+            waitMs: delay,
+            fromRetryAfter: advised !== null,
+        });
+        // Tell everyone, not just this call.
+        gate?.penalize(delay);
+        await (gate ? gate.wait() : sleep(delay));
         res = await request(method, url, body);
     }
     return res;

--- a/tests/e2e/onboard/run.mjs
+++ b/tests/e2e/onboard/run.mjs
@@ -547,6 +547,56 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
         }
     });
 
+    it('trust-only packages are configured CONCURRENTLY, publishes stay serial', async () => {
+        // Serial writes cost prompts, not just time: an npm code lives ~30s, so
+        // a serial sweep crosses a code boundary every ~38 packages (measured on
+        // the real 703-package `gjsify/types` run: ~18 codes typed by hand).
+        // Publishes stay serial because publish ORDER is a correctness property.
+        pkgState = {
+            '@onb/published-trusted': { published: true, trusted: true },
+            '@onb/published-untrusted': { published: true, trusted: false },
+            '@onb/unpublished-a': { published: true, trusted: false },
+            '@onb/unpublished-b': { published: true, trusted: false },
+            '@onb/never-published-2xx': { published: true, trusted: false },
+        };
+        const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
+        try {
+            const { code, stdout } = await runOnboard(root, npmrcPath, ['--write-concurrency', '4']);
+            assert.equal(code, 0, `onboard should exit 0; stdout:\n${stdout}`);
+            assert.equal(trustPosts.length, 4, 'the four untrusted packages must be configured');
+            assert.equal(publishPuts.length, 0, 'nothing needs publishing here');
+            // The concurrent path announces itself, so a reader can tell which
+            // pacing ran without inferring it from timings.
+            assert.match(stdout, /configuring 4 Trusted Publisher\(s\), 4 at a time/);
+            assert.ok(
+                !trustPosts.some((p) => p.name === '@onb/published-trusted'),
+                'the already-trusted package must be skipped',
+            );
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('--write-concurrency 1 keeps the writes serial', async () => {
+        pkgState = {
+            '@onb/published-trusted': { published: true, trusted: true },
+            '@onb/published-untrusted': { published: true, trusted: false },
+            '@onb/unpublished-a': { published: true, trusted: false },
+            '@onb/unpublished-b': { published: true, trusted: true },
+            '@onb/never-published-2xx': { published: true, trusted: true },
+        };
+        const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
+        try {
+            const { code, stdout } = await runOnboard(root, npmrcPath, ['--write-concurrency', '1']);
+            assert.equal(code, 0, `onboard should exit 0; stdout:\n${stdout}`);
+            assert.deepEqual(trustPosts.map((p) => p.name).sort(), ['@onb/published-untrusted', '@onb/unpublished-a']);
+            // Two writes at concurrency 1 — the banner still names the pacing.
+            assert.match(stdout, /configuring 2 Trusted Publisher\(s\), 1 at a time/);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
     it('--yes fails clearly when a dead token would need an interactive login', async () => {
         pkgState = freshState();
         const { root, npmrcPath } = scaffoldMonorepo(DEAD_TOKEN);

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1834,6 +1834,17 @@ gjsify onboard --yes                 # non-interactive
 
 What it does, in order: check the token is live (running the [`login`](#gjsify-login) flow only if it is not), enumerate the publishable packages, read each package's Trusted Publisher state concurrently, then act only on the gaps. One 2FA code is reused across every publish and trust operation, so a sweep of many packages usually asks you for a code once. Re-running when everything is already published and trusted does nothing and exits 0.
 
+One 2FA code covers the whole sweep, and it is asked for **once at a time** — concurrent probes
+share the prompt rather than each opening their own. npm codes expire on their ~30-second window,
+so a long sweep may ask again later; each such expiry costs exactly one prompt.
+
+An HTTP 429 is waited out, not reported. npm throttles a long sweep, and because it is cumulative
+it lands on the *tail* of the list — which reads as "these packages are special" when the truth is
+that the sweep asked too fast. Rate-limited reads and trust writes back off (honouring
+`Retry-After`) and retry; only throttling that outlasts the backoff is reported, and the summary
+then says so and suggests a lower `--concurrency`. Re-running is safe: the sweep is idempotent and
+skips whatever already landed.
+
 A package whose own `package.json` names a **different** `repository` than the one being
 configured is refused, with the foreign repo and the count. A workspace of a repo is not the same
 claim as a package published from it: `gjsify/ts-for-gir` has 703 generated `@girs/*` workspaces

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1838,11 +1838,23 @@ One 2FA code covers the whole sweep, and it is asked for **once at a time** — 
 share the prompt rather than each opening their own. npm codes expire on their ~30-second window,
 so a long sweep may ask again later; each such expiry costs exactly one prompt.
 
+Trusted-Publisher **writes** run at `--write-concurrency` (default 4); **publishes** stay serial,
+because publish order is a correctness property. Raising the write concurrency buys fewer 2FA
+prompts rather than raw speed — measured against a 703-package repo, npm rate-limits the sweep at
+serial pace already, so the registry sets the ceiling, not the loop. What serial cost was codes:
+one lives about 30 seconds, so the sweep crossed a code boundary roughly every 38 packages.
+
 An HTTP 429 is waited out, not reported. npm throttles a long sweep, and because it is cumulative
 it lands on the *tail* of the list — which reads as "these packages are special" when the truth is
-that the sweep asked too fast. Rate-limited reads and trust writes back off (honouring
-`Retry-After`) and retry; only throttling that outlasts the backoff is reported, and the summary
-then says so and suggests a lower `--concurrency`. Re-running is safe: the sweep is idempotent and
+that the sweep asked too fast. A 429 **anywhere pauses everywhere**: retrying one throttled request in isolation leaves the rest
+of the sweep provoking the very limit that retry is waiting out, which is how a real run spent its
+retry budget and reported `trust failed (HTTP 429)`. Reads and writes share one cool-down, so the
+sweep self-paces down to whatever npm will serve. Only throttling that outlasts the backoff is
+reported, and the summary then says so and suggests a lower `--concurrency`.
+
+npm advertises no budget ahead of time — there are no `X-RateLimit-*` headers on ordinary
+responses — so the first 429 of a run prints what the registry actually said, including when it
+said nothing and the delay is the CLI's own. Re-running is safe: the sweep is idempotent and
 skips whatever already landed.
 
 A package whose own `package.json` names a **different** `repository` than the one being


### PR DESCRIPTION
Both defects were found by running the new `--packages` sweep against the real `gjsify/types` —
703 packages, the first time this command has been asked to work at that scale.

## Five OTP prompts stacked up, and the typed code echoed four times

```
Enter OTP: 582460
This operation requires a one-time password.
Enter OTP: This operation requires a one-time password.
Enter OTP: This operation requires a one-time password.
Enter OTP: This operation requires a one-time password.
Enter OTP: 666644440000999944444444
```

`promptLine` runs the terminal in RAW mode and echoes each keystroke by hand
(`utils/prompt.ts`), so N live prompts mean N `data` listeners on one stdin and every digit is
printed N times — four here, one per concurrent probe worker.

`OtpProvider.refresh()` had no single-flight. The probe phase runs at `--concurrency 4`, all four
workers were challenged at once, and each opened its own prompt. The provider exists precisely so
that **one** code serves a whole sweep; asking four times for a code that is shared anyway is the
same defect seen from the user's side.

Two changes, because the pile-up had two sources:

- **`refresh()` is single-flight.** Concurrent callers await the one prompt already on screen.
- **`invalidate()` and `refresh()` are scoped to an EPOCH** — the version of the code the caller
  actually tried. Without it, the first rejection in a burst wipes a code another worker typed a
  millisecond earlier and sends *everyone* back to the prompt; and a worker that lost the race
  now receives the winner's code instead of opening a second prompt.

Single-flight does not mean single-ever: a genuinely rejected code is still replaceable, and a
long sweep still costs one prompt per ~30-second TOTP expiry. One prompt each time, not four.

## The last 41 packages were reported `unreadable (429)`

```
Plan: 0 already done, 0 to publish+trust, 662 to trust, 41 unreadable.
```

A 429 is npm asking to be asked later — never an answer about the package. It was reaching
`classifyTrustList`, which maps it to `error` → `blocked`, i.e. "this package's state could not be
determined". And because rate limiting is cumulative it lands on the **tail** of an alphabetical
sweep, so the damage looks like a property of those 41 packages rather than of the pacing.

Reads and trust **writes** now share one bounded wait-out (`Retry-After` when npm sends a usable
delta-seconds value, exponential backoff otherwise). The write path matters as much as the read
path: a sweep throttled on 703 reads gets throttled on 703 writes, and a bare 429 there would have
been recorded as `trust failed (HTTP 429)` — again a failure attributed to the package.

Bounded on purpose: throttling that outlasts the budget is still reported, because an unbounded
wait turns a throttled sweep into a hang with no output. The summary now names that case and
suggests a lower `--concurrency`, instead of leaving 41 packages looking broken:

```
  41 of those are npm rate limits (HTTP 429) that outlasted the backoff —
  lower --concurrency and re-run; the sweep is idempotent and picks up where it left off.
```

## Tests

3 vectors for the single-flight prompt, 2 for the epoch-scoped invalidate, 1 end-to-end through
`withOtpRetry`, 5 for the 429 path (including `Retry-After` parsing, which accepts delta-seconds
and refuses the HTTP-date form rather than introducing a second clock to get wrong).

A/B, both directions:

- removing the single-flight fails 2 of the new tests (`2 of 2910`);
- removing the probe's wait-out fails the one that asserts the state is read **after** the
  throttling (`1 of 2925`).

`@gjsify/cli` 2926 unit, e2e `onboard` 10/10, `check-agent-context-size` and `oxlint` clean.
`dist/affected.gjs.mjs` re-built and byte-identical — none of the touched files is in its closure.
