### PR TITLE
fix(website): the attribute list belongs to one port

### DIFF
--- a/scripts/adwaita-elements.mjs
+++ b/scripts/adwaita-elements.mjs
@@ -224,11 +224,17 @@ export function stripComments(text) {
  * attributing it to every tag the file registers is the same mistake as reading
  * a FILENAME for the element set, which is the incident at the top of this file.
  *
- * The scan is deliberately literal-only. A class whose list is computed —
- * spread from a base, concatenated — is reported as UNREADABLE by
+ * A class whose list this cannot work out is reported as UNREADABLE by
  * {@link observedAttributes} rather than as empty: an element with no attributes
  * and an element this cannot read are different facts, and only one of them is a
- * reason to document nothing.
+ * reason to document nothing. EVERY shape therefore has to land in one of those
+ * two — the failure is a third outcome, a computed list read as the empty one,
+ * which is a silent wrong answer wearing the shape of a right one. Two did:
+ * `return [...PROPERTY_ATTRIBUTES];` (no quoted string in it, and not the bare
+ * `return NAME;` shape either) and a subclass that simply inherits its base's
+ * getter. `<adw-wrap-box>` published "observes nothing" over 14 attributes its own
+ * `attributeChangedCallback` serves, and the website rendered no attribute pane at
+ * all for it while every gate stayed green.
  */
 export function observedAttributesByClass(text) {
     const code = stripComments(text);
@@ -238,6 +244,9 @@ export function observedAttributesByClass(text) {
     const extendsBase = new Map();
     /** @type {Map<string, string>} */
     const pending = new Map();
+    /** Classes with NO getter of their own, which therefore use their base's. */
+    /** @type {Map<string, string>} */
+    const inherits = new Map();
     const unreadable = [];
 
     // A module-level `const NAME = ['a', 'b']` a getter can return by name.
@@ -261,7 +270,14 @@ export function observedAttributesByClass(text) {
         const getter = /static get observedAttributes\(\)\s*(?::[^{]*)?\{\s*return\s+([^;]+);/.exec(body);
         if (!getter) {
             if (/static get observedAttributes\(\)/.test(body)) unreadable.push(name);
-            else byClass.set(name, []);
+            else {
+                // No getter here is not "observes nothing" when there is a base to
+                // take one from — `AdwCarouselIndicatorDots` has neither and observed
+                // `for` through `AdwCarouselIndicator` all along. Recorded rather than
+                // resolved, because the base can live in another file.
+                byClass.set(name, []);
+                if (classes[i][2]) inherits.set(name, classes[i][2]);
+            }
             continue;
         }
         const expression = getter[1].trim();
@@ -273,16 +289,40 @@ export function observedAttributesByClass(text) {
             else unreadable.push(name);
             continue;
         }
-        const inner = literal[1];
-        const own = [...inner.matchAll(/'([^']+)'/g)].map(([, attr]) => attr);
-        // `[...AdwEntryRow.observedAttributes, 'revealed']` — resolved after the
-        // whole pillar is read, because the base can live in another file.
-        const spread = /\.\.\.\s*([A-Za-z0-9_]+)\.observedAttributes/.exec(inner);
-        if (spread) pending.set(name, spread[1]);
+        // Read the literal IN ORDER: the emitted list is documented as declaration
+        // order, and a spread can sit anywhere in it.
+        /** @type {string[]} */
+        const own = [];
+        let unresolvedSpread = null;
+        for (const [, quoted, spreadName, ofBase] of literal[1].matchAll(
+            /'([^']+)'|\.\.\.\s*([A-Za-z0-9_$]+)(\.observedAttributes)?/g,
+        )) {
+            if (quoted !== undefined) {
+                own.push(quoted);
+            } else if (ofBase) {
+                // `[...AdwEntryRow.observedAttributes, 'revealed']` — resolved after
+                // the whole pillar is read, because the base can live in another file.
+                pending.set(name, spreadName);
+            } else {
+                // `[...PROPERTY_ATTRIBUTES]` — a named list in this module, spread
+                // rather than returned by name. Unresolved it yields no attribute at
+                // all, which is why it is a failure and not an empty list.
+                const named = constants.get(spreadName);
+                if (named === undefined) unresolvedSpread = spreadName;
+                else own.push(...named);
+            }
+        }
+        // A literal with text in it that yielded no name is the third outcome again,
+        // in whatever shape comes next (a double-quoted string, a `.concat`): only
+        // `return [];` may read as none.
+        if (unresolvedSpread !== null || (own.length === 0 && !pending.has(name) && literal[1].trim() !== '')) {
+            unreadable.push(name);
+            continue;
+        }
         byClass.set(name, own);
     }
 
-    return { byClass, unreadable, pending, extendsBase };
+    return { byClass, unreadable, pending, inherits, extendsBase };
 }
 
 /**
@@ -306,12 +346,15 @@ export function observedAttributes(root) {
     const perClass = new Map();
     /** @type {Map<string, string>} */
     const spreads = new Map();
+    /** @type {Map<string, string>} */
+    const inherits = new Map();
     const badClasses = new Set();
     for (const file of new Set(tags.values())) {
         const read = observedAttributesByClass(readFileSync(join(root, file), 'utf8'));
         sources.set(file, read);
         for (const [klass, attrs] of read.byClass) perClass.set(klass, attrs);
         for (const [klass, base] of read.pending) spreads.set(klass, base);
+        for (const [klass, base] of read.inherits) inherits.set(klass, base);
         for (const klass of read.unreadable) badClasses.add(klass);
     }
     for (const [klass, base] of spreads) {
@@ -322,6 +365,21 @@ export function observedAttributes(root) {
         }
         // Base first, so the order matches what the class itself returns.
         perClass.set(klass, [...inherited, ...(perClass.get(klass) ?? [])]);
+    }
+    // A subclass with no getter of its own answers with its base's list, exactly as
+    // the platform does. `extends HTMLElement` resolves to nothing and stays empty,
+    // which is the one case where empty is the true answer. Iterated to a fixpoint so
+    // a two-step chain lands, and bounded so a cycle cannot spin.
+    for (let pass = 0; pass < inherits.size; pass++) {
+        let changed = false;
+        for (const [klass, base] of inherits) {
+            const inherited = perClass.get(base);
+            if (inherited === undefined || inherited.length === 0) continue;
+            if (perClass.get(klass)?.length) continue;
+            perClass.set(klass, [...inherited]);
+            changed = true;
+        }
+        if (!changed) break;
     }
 
     for (const [tag, file] of tags) {

--- a/scripts/check-adwaita-element-properties.mjs
+++ b/scripts/check-adwaita-element-properties.mjs
@@ -99,21 +99,6 @@ const KNOWN_GAPS = {
     'adw-toolbar-view': ['reveal-bottom-bars', 'reveal-top-bars'],
     'adw-view-stack': ['enable-transitions', 'hhomogeneous', 'transition-duration', 'vhomogeneous'],
     'adw-window': ['adaptive-preview'],
-    'adw-wrap-box': [
-        'align',
-        'child-spacing',
-        'child-spacing-unit',
-        'justify',
-        'justify-last-line',
-        'line-homogeneous',
-        'line-spacing',
-        'line-spacing-unit',
-        'natural-line-length',
-        'natural-line-length-unit',
-        'pack-direction',
-        'wrap-policy',
-        'wrap-reverse',
-    ],
 };
 
 /** A GIR type that holds an object — a slot on this renderer, never an attribute. */

--- a/scripts/check-generated-website-data.mjs
+++ b/scripts/check-generated-website-data.mjs
@@ -25,9 +25,10 @@
 //   1. Every generator listed in {@link GENERATORS} reproduces its committed
 //      output. Run with no argument they WRITE; `--check` compares and exits 1.
 //   2. Every `<AdwWidget title="…">` on a gallery page derives a tag that the web
-//      pillar actually registers — or sits in {@link NO_ELEMENT} with the reason
+//      pillar actually registers AND observes something — or sits in
+//      {@link NO_ATTRIBUTE_PANE} with the reason
 //      its widget has none.
-//   3. Nothing in {@link NO_ELEMENT} names a title that DOES resolve, so a stale
+//   3. Nothing in {@link NO_ATTRIBUTE_PANE} names a title that DOES get a pane, so a stale
 //      exemption cannot read as considered when it is merely forgotten.
 //   4. Every gallery block reaches the framework-snippet source: either a tree in
 //      `adwaita-gallery-trees.mjs` or a REFUSAL naming why it has none, never both
@@ -109,13 +110,21 @@ const GENERATORS = [
 ];
 
 /**
- * Gallery titles whose widget is not a custom element, with the reason.
+ * Gallery titles whose block renders NO attribute pane, with the reason.
  *
- * Not a convenience list: each entry is a claim that gets checked back, so an
- * element that later gains a tag turns this into a failure rather than a
+ * Not a convenience list: each entry is a claim that gets checked back, so a title
+ * that later gains an observing element turns this into a failure rather than a
  * permanently silent block.
+ *
+ * TWO ways to have no pane and only one used to be checked. A title that resolves to
+ * no element failed here; a title that resolved to an element observing NOTHING was
+ * counted and waved through, and this check printed its own contradiction — "40
+ * gallery block(s), 38 rendering a generated attribute table, 1 exemption(s)" — at
+ * exit 0. `<adw-wrap-box>` was the second: 14 attributes its own
+ * `attributeChangedCallback` serves, read as none because the reader could not see a
+ * `return [...PROPERTY_ATTRIBUTES];`, and one gallery block silently without a pane.
  */
-const NO_ELEMENT = {
+const NO_ATTRIBUTE_PANE = {
     'Adw.Toast': `A toast is not an element — \`AdwToast\` is a plain class the overlay takes, so its surface is constructor options (\`timeout\`, \`buttonLabel\`) rather than attributes. \`<adw-toast-overlay>\` IS an element and is documented on the same page; it observes nothing of its own.`,
 };
 
@@ -188,27 +197,37 @@ for (const page of readdirSync(DOCS_DIR).filter((f) => f.endsWith('.mdx'))) {
         seenTitles.add(title);
         const tag = toTag(title);
         if (byTag.has(tag)) {
-            if (byTag.get(tag).length > 0) tabled++;
-            if (NO_ELEMENT[title]) {
+            const observed = byTag.get(tag).length;
+            if (observed > 0) tabled++;
+            if (NO_ATTRIBUTE_PANE[title] && observed > 0) {
                 failures.push(
-                    `${page}: "${title}" is exempted in NO_ELEMENT and DOES resolve, to <${tag}>. ` +
-                        'Drop the exemption — a stale one reads as considered.',
+                    `${page}: "${title}" is exempted in NO_ATTRIBUTE_PANE and DOES get a pane, from ` +
+                        `<${tag}>. Drop the exemption — a stale one reads as considered.`,
+                );
+            } else if (observed === 0 && !NO_ATTRIBUTE_PANE[title]) {
+                failures.push(
+                    `${page}: "${title}" derives <${tag}>, which the pillar registers but which this\n` +
+                        '    reader says observes NOTHING, so its block renders no attribute pane and looks\n' +
+                        '    documented anyway. Either the reader cannot see the declaration (teach\n' +
+                        '    scripts/adwaita-elements.mjs the shape) or the element really has none — say\n' +
+                        '    so in NO_ATTRIBUTE_PANE.',
                 );
             }
             continue;
         }
-        if (NO_ELEMENT[title]) continue;
+        if (NO_ATTRIBUTE_PANE[title]) continue;
         failures.push(
             `${page}: "${title}" derives <${tag}>, which the web pillar does not register, so its\n` +
-                '    block renders no attribute table and looks documented anyway. Either the title or\n' +
-                '    the element name is wrong, or the widget has no element — say so in NO_ELEMENT.',
+                '    block renders no attribute pane and looks documented anyway. Either the title or\n' +
+                '    the element name is wrong, or the widget has no element — say so in\n' +
+                '    NO_ATTRIBUTE_PANE.',
         );
     }
 }
 
-for (const title of Object.keys(NO_ELEMENT)) {
+for (const title of Object.keys(NO_ATTRIBUTE_PANE)) {
     if (!seenTitles.has(title)) {
-        failures.push(`NO_ELEMENT names "${title}", which no gallery page uses. Drop the entry.`);
+        failures.push(`NO_ATTRIBUTE_PANE names "${title}", which no gallery page uses. Drop the entry.`);
     }
 }
 
@@ -421,7 +440,7 @@ if (ADWAITA_GALLERY_TREES.length === 0) failures.push('no framework tree at all 
 
 notes.push(
     `${blocks} gallery block(s), ${tabled} rendering a generated attribute table, ` +
-        `${byTag.size} registered element(s), ${Object.keys(NO_ELEMENT).length} exemption(s)`,
+        `${byTag.size} registered element(s), ${Object.keys(NO_ATTRIBUTE_PANE).length} exemption(s)`,
 );
 
 for (const note of notes) console.log(`check-generated-website-data: ${note}`);

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -299,7 +299,7 @@ const rendered: {
     id: string;
     title: string;
     live: boolean;
-    attributes: string[] | null;
+    attributes: { tag: string; names: string[] } | null;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
 }[] = [];
@@ -349,7 +349,7 @@ for (const spec of WINDOWS) {
     // that could not see the declaration, which is how `<adw-wrap-box>` shipped
     // paneless over 14 attributes. `check-generated-website-data.mjs` fails on it now,
     // so this arm is what that failure renders as rather than a silent policy.
-    const attrs = live && attributes !== null && attributes.length > 0 ? attributes : null;
+    const attrs = live && attributes !== null && attributes.length > 0 ? { tag: elementTag, names: attributes } : null;
     rendered.push({
         id: spec.id,
         title: spec.title ?? title,
@@ -381,7 +381,6 @@ for (const spec of WINDOWS) {
                 scroll={scroll}
                 stage={stage}
                 attributes={win.attributes}
-                elementTag={elementTag}
             />
         ))
     }

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -132,6 +132,16 @@ const refHref = docHref === false ? null : (docHref ?? deriveRef(title));
 // `<adw-toolbar-view>`'s, and eight of `<adw-overlay-split-view>`'s including the
 // `breakpoint` its own section is about. One component, every block, no hand.
 //
+// It rides in the LIVE window, as a pane beside that window's markup, and not as a
+// panel under the whole block. `observedAttributes` is read out of
+// `packages/web/adwaita-web/src` and nowhere else, so the list is one port's answer
+// — and `<adw-button-content>`'s four are not the NativeScript widget's five
+// (`icon`, `iconColor`, `iconIsFallback`, `hostButton`, `label`: a different
+// vocabulary, which `check-vocabulary-alignment.mjs` already holds as a repo fact for
+// 22 of the 65 element names). Under the last window it read as the block's summary,
+// which is a claim about all four ports that no generator here can make. The page's
+// own contract is that where a port differs, ITS window says so.
+//
 // A `Gtk.*` title resolves too: libadwaita ships no menu button, and the pillar
 // still spells that element `<adw-menu-button>`, so the namespace is dropped and
 // `adw-` prefixed. A title with no element (`Adw.Toast` is a plain class, not a
@@ -254,18 +264,30 @@ const decodeEcCode = (html: string): string | null => {
  */
 const LIVE_PANE = 'live';
 
+/**
+ * The pane id of the ATTRIBUTE LIST, the live window's last pane.
+ *
+ * Not a slot either, and for the same reason: no page provides it, the generated
+ * table is it. It joins {@link LIVE_PANE} in the positional list below.
+ */
+const ATTRS_PANE = 'attributes';
+
 // That requirement, held rather than stated. `data-impls` is POSITIONAL and the
-// script below looks a pane up by name with `indexOf`, so a LIVE_PANE equal to a
+// script below looks a pane up by name with `indexOf`, so a pane id equal to a
 // slot name gives the live window two entries reading the same id and the first one
 // answers for both: the HTML tab could never be the remembered choice, and picking
 // it would move every OTHER preview window to its Preview pane instead. Nothing
 // else notices — the ids never leave `data-impls`, so the site builds, both tabs
 // render, and every gate stays green.
-const collidingSlot = WINDOWS.flatMap((win) => win.tabs.map((tab) => tab.slot)).find((slot) => slot === LIVE_PANE);
+const OWN_PANES = [LIVE_PANE, ATTRS_PANE];
+const collidingSlot = WINDOWS.flatMap((win) => win.tabs.map((tab) => tab.slot)).find((slot) =>
+    OWN_PANES.includes(slot),
+);
 if (collidingSlot !== undefined) {
     throw new Error(
-        `AdwWidget: LIVE_PANE is "${LIVE_PANE}", which is also a tab slot. The pane ids in \`data-impls\` ` +
-            'are positional and looked up by name, so no two panes of one window can share an id.',
+        `AdwWidget: "${collidingSlot}" is both a tab slot and one of this component's own pane ids ` +
+            `(${OWN_PANES.join(', ')}). The pane ids in \`data-impls\` are positional and looked up by ` +
+            'name, so no two panes of one window can share an id.',
     );
 }
 
@@ -273,6 +295,7 @@ const rendered: {
     id: string;
     title: string;
     live: boolean;
+    attributes: string[] | null;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
 }[] = [];
@@ -313,11 +336,20 @@ for (const spec of WINDOWS) {
     // `previewMarkup` is already read by the time this runs: the live window is
     // first in WINDOWS and its own `preview` tab is what sets it.
     const live = spec.live === true && previewMarkup !== null;
+    // The attribute list is the LIVE window's, because that is the window running the
+    // element whose `observedAttributes` produced it. A widget with no custom element
+    // — `Adw.Toast` is a plain class — simply has no such pane.
+    const attrs = live && attributes !== null && attributes.length > 0 ? attributes : null;
     rendered.push({
         id: spec.id,
         title: spec.title ?? title,
         live,
-        impls: [...(live ? [LIVE_PANE] : []), ...tabs.map((t) => t.slot)].join(','),
+        attributes: attrs,
+        impls: [
+            ...(live ? [LIVE_PANE] : []),
+            ...tabs.map((t) => t.slot),
+            ...(attrs === null ? [] : [ATTRS_PANE]),
+        ].join(','),
         tabs,
     });
 }
@@ -338,26 +370,10 @@ for (const spec of WINDOWS) {
                 padding={padding}
                 scroll={scroll}
                 stage={stage}
+                attributes={win.attributes}
+                elementTag={elementTag}
             />
         ))
-    }
-
-    {
-        attributes && attributes.length > 0 && (
-            <details class="adw-widget-attrs not-content">
-                <summary>
-                    <code>{`<${elementTag}>`}</code> takes {attributes.length}{' '}
-                    {attributes.length === 1 ? 'attribute' : 'attributes'}
-                </summary>
-                <ul>
-                    {attributes.map((attr) => (
-                        <li>
-                            <code>{attr}</code>
-                        </li>
-                    ))}
-                </ul>
-            </details>
-        )
     }
 </div>
 
@@ -615,17 +631,20 @@ for (const spec of WINDOWS) {
 
     /* The generated attribute list. Collapsed by default: it is a reference a
        reader opens on purpose, not something to scroll past on every widget. */
+    /* The attribute pane of the live window — rendered by AdwWidgetWindow, styled
+       here, like every other class in that file: this block is `is:global`, which
+       is why no `:global()` wrapper belongs on these selectors. Written with one,
+       it survived the build as a LITERAL `:global(.adw-widget-attrs)` in the emitted
+       CSS — a selector that matches nothing, on a pane that still rendered. */
     .adw-widget-attrs {
-        margin-top: 0.5rem;
-        border: 1px solid var(--adw-border-color, rgba(0, 0, 0, 0.12));
-        border-radius: 8px;
-        padding: 0.4rem 0.75rem;
+        padding: 0.85rem 1rem 1rem;
         font-size: 0.9em;
     }
 
-    .adw-widget-attrs > summary {
-        cursor: pointer;
-        padding: 0.25rem 0;
+    .adw-widget-attrs > p {
+        margin: 0;
+        color: var(--sl-color-gray-2);
+        line-height: 1.5;
     }
 
     .adw-widget-attrs > ul {
@@ -633,11 +652,24 @@ for (const spec of WINDOWS) {
         flex-wrap: wrap;
         gap: 0.35rem 0.5rem;
         list-style: none;
-        margin: 0.5rem 0 0.25rem;
+        margin: 0.75rem 0 0;
         padding: 0;
     }
 
     .adw-widget-attrs > ul > li {
         margin: 0;
+    }
+
+    /* Chips, not a sentence. `not-content` opts these out of Starlight's inline-code
+       styling, so without this the four names ran together as one line of monospace
+       and read as prose rather than as a list of four things. A grey that is an alpha
+       over the page's own background works in both schemes without a second rule. */
+    .adw-widget-attrs > ul > li > code {
+        display: inline-block;
+        background: rgba(128, 128, 128, 0.12);
+        border: 1px solid rgba(128, 128, 128, 0.18);
+        border-radius: 6px;
+        padding: 0.1rem 0.45rem;
+        line-height: 1.5;
     }
 </style>

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -134,13 +134,17 @@ const refHref = docHref === false ? null : (docHref ?? deriveRef(title));
 //
 // It rides in the LIVE window, as a pane beside that window's markup, and not as a
 // panel under the whole block. `observedAttributes` is read out of
-// `packages/web/adwaita-web/src` and nowhere else, so the list is one port's answer
-// — and `<adw-button-content>`'s four are not the NativeScript widget's five
-// (`icon`, `iconColor`, `iconIsFallback`, `hostButton`, `label`: a different
-// vocabulary, which `check-vocabulary-alignment.mjs` already holds as a repo fact for
-// 22 of the 65 element names). Under the last window it read as the block's summary,
-// which is a claim about all four ports that no generator here can make. The page's
-// own contract is that where a port differs, ITS window says so.
+// `packages/web/adwaita-web/src` and nowhere else, so the list is ONE port's answer.
+// The NativeScript widget of the same name is a class of camelCase PROPERTIES rather
+// than attributes: `icon` where this element's attribute is `icon-name`, plus
+// `hostButton`, `iconColor`, `iconIsFallback` and `ellipsize`, none of which any
+// attribute here names — and it does carry `useUnderline` and `canShrink`, so the
+// two lists are neither the same set nor disjoint. A different surface, not the same
+// one renamed; `check-vocabulary-alignment.mjs` holds 22 of the 65 element names as
+// not sharing a spelling across the renderers. Under the last window this list read
+// as the block's SUMMARY, which is a claim about all four ports that no generator
+// here can make. The page's own contract is that where a port differs, ITS window
+// says so.
 //
 // A `Gtk.*` title resolves too: libadwaita ships no menu button, and the pillar
 // still spells that element `<adw-menu-button>`, so the namespace is dropped and
@@ -337,8 +341,14 @@ for (const spec of WINDOWS) {
     // first in WINDOWS and its own `preview` tab is what sets it.
     const live = spec.live === true && previewMarkup !== null;
     // The attribute list is the LIVE window's, because that is the window running the
-    // element whose `observedAttributes` produced it. A widget with no custom element
-    // — `Adw.Toast` is a plain class — simply has no such pane.
+    // element whose `observedAttributes` produced it.
+    //
+    // NO pane has exactly one legitimate cause, a title with no element at all
+    // (`Adw.Toast` is a plain class). The `length > 0` arm is the other, and it is not
+    // a widget fact: an element the pillar registers that observes NOTHING is a reader
+    // that could not see the declaration, which is how `<adw-wrap-box>` shipped
+    // paneless over 14 attributes. `check-generated-website-data.mjs` fails on it now,
+    // so this arm is what that failure renders as rather than a silent policy.
     const attrs = live && attributes !== null && attributes.length > 0 ? attributes : null;
     rendered.push({
         id: spec.id,
@@ -629,8 +639,6 @@ for (const spec of WINDOWS) {
         mask: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='16'%20height='16'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%23000'%20stroke-width='1.4'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M6.5%203.5H3.2A1.2%201.2%200%200%200%202%204.7v8.1A1.2%201.2%200%200%200%203.2%2014h8.1a1.2%201.2%200%200%200%201.2-1.2V9.5'/%3E%3Cpath%20d='M9.5%202H14v4.5'/%3E%3Cpath%20d='M7%209%2014%202'/%3E%3C/svg%3E") no-repeat center / contain;
     }
 
-    /* The generated attribute list. Collapsed by default: it is a reference a
-       reader opens on purpose, not something to scroll past on every widget. */
     /* The attribute pane of the live window — rendered by AdwWidgetWindow, styled
        here, like every other class in that file: this block is `is:global`, which
        is why no `:global()` wrapper belongs on these selectors. Written with one,

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -12,6 +12,11 @@
 // right without anyone editing this file. {@link AdwWidget} decides which windows
 // exist and what they claim; this file knows how a window is drawn.
 //
+// THE ATTRIBUTE LIST IS A PANE TOO, and the LAST one, on that same window. It is
+// the browser port's `observedAttributes` and no other port's, so it belongs to the
+// window running the browser port rather than under the block, where it read as a
+// summary of all four. See AdwWidget's header for the measurement.
+//
 // THE LIVE PREVIEW IS A PANE, and the FIRST one, on the window that runs the
 // widget. It used to sit between the header bar and the tab bar, with the markup
 // appended below it, which reads as two stacked things — a picture, and some code
@@ -49,6 +54,13 @@ interface Props {
     scroll?: boolean;
     /** Inline CSS for the preview stage: preview-only scaffolding — see AdwWidget. */
     stage?: string;
+    /**
+     * The attributes this widget's custom element observes, or null on a window
+     * that is not the browser port (and on a widget that has no element).
+     */
+    attributes?: string[] | null;
+    /** The element those attributes belong to, e.g. `adw-button-content`. */
+    elementTag?: string | null;
 }
 
 const {
@@ -61,10 +73,12 @@ const {
     padding = 'comfortable',
     scroll = false,
     stage,
+    attributes = null,
+    elementTag = null,
 } = Astro.props;
 
-/** The preview is a pane like any other, so it counts like one. */
-const panes = tabs.length + (preview === null ? 0 : 1);
+/** The preview is a pane like any other, so it counts like one. And so is the attribute list. */
+const panes = tabs.length + (preview === null ? 0 : 1) + (attributes === null ? 0 : 1);
 
 // NO PANES AT ALL is a header bar over nothing, and it renders exactly that way at
 // exit 0. `AdwWidget` is what prevents it — it skips a window none of whose tab
@@ -91,6 +105,18 @@ if (panes < 2 && preview !== null) {
     throw new Error(
         `AdwWidgetWindow(${title}): a live preview reached a window with no tab beside it. The preview ` +
             'window declares its own markup tab, so this means AdwWidget stopped passing it.',
+    );
+}
+
+// The attribute pane is the LIVE window's — it is that window's element being
+// described. Asserted because nothing downstream would notice: on a code-only window
+// the pane would simply render, and a reader would read one port's attributes off
+// another port's window. And the single-pane branch below reads `tabs[0]`, which a
+// lone attribute pane would not have.
+if (attributes !== null && preview === null) {
+    throw new Error(
+        `AdwWidgetWindow(${title}): an attribute list reached a window that does not run the widget. ` +
+            'It is the browser port\'s `observedAttributes`, so AdwWidget passes it to the live window only.',
     );
 }
 ---
@@ -177,6 +203,25 @@ if (panes < 2 && preview !== null) {
                 {tabs.map((tab) => (
                     <adw-tab-page title={tab.label} set:html={tab.html} />
                 ))}
+                {attributes !== null && (
+                    <adw-tab-page title="Attributes">
+                        <div class="adw-widget-attrs not-content">
+                            <p>
+                                <code>{`<${elementTag}>`}</code> observes {attributes.length}
+                                {attributes.length === 1 ? ' attribute' : ' attributes'} in the browser port. Set one and
+                                the element re-renders; set anything else and it never hears about it. The windows below
+                                name their own — GObject properties on GTK, NativeScript's own spelling on a phone.
+                            </p>
+                            <ul>
+                                {attributes.map((attr) => (
+                                    <li>
+                                        <code>{attr}</code>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </adw-tab-page>
+                )}
             </adw-tab-view>
         )
     }

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -55,12 +55,15 @@ interface Props {
     /** Inline CSS for the preview stage: preview-only scaffolding — see AdwWidget. */
     stage?: string;
     /**
-     * The attributes this widget's custom element observes, or null on a window
-     * that is not the browser port (and on a widget that has no element).
+     * The attribute list this window's element observes — the element's own tag and
+     * the names it watches — or null on a window that is not the browser port (and on
+     * a widget with no element).
+     *
+     * ONE prop and not a pair, so a list without the element it belongs to is not
+     * expressible: the pane prints `<tag>` above the names, and a tag left behind
+     * would have rendered `<null>` over a correct list, on a page that still builds.
      */
-    attributes?: string[] | null;
-    /** The element those attributes belong to, e.g. `adw-button-content`. */
-    elementTag?: string | null;
+    attributes?: { tag: string; names: string[] } | null;
 }
 
 const {
@@ -74,7 +77,6 @@ const {
     scroll = false,
     stage,
     attributes = null,
-    elementTag = null,
 } = Astro.props;
 
 /** The preview is a pane like any other, so it counts like one. And so is the attribute list. */
@@ -213,14 +215,14 @@ if (attributes !== null && preview === null) {
                                 row observes and which its `connectedCallback` reads anyway. An
                                 attribute taken once at connect is heard — just never again. */}
                             <p>
-                                <code>{`<${elementTag}>`}</code> observes {attributes.length}
-                                {attributes.length === 1 ? ' attribute' : ' attributes'} in the browser port:
+                                <code>{`<${attributes.tag}>`}</code> observes {attributes.names.length}
+                                {attributes.names.length === 1 ? ' attribute' : ' attributes'} in the browser port:
                                 change one on a live element and it re-renders. That is the list it watches, not every
                                 attribute it reads, and not another port's — the windows below name their own, GObject
                                 properties on GTK, NativeScript's own spelling on a phone.
                             </p>
                             <ul>
-                                {attributes.map((attr) => (
+                                {attributes.names.map((attr) => (
                                     <li>
                                         <code>{attr}</code>
                                     </li>

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -206,11 +206,18 @@ if (attributes !== null && preview === null) {
                 {attributes !== null && (
                     <adw-tab-page title="Attributes">
                         <div class="adw-widget-attrs not-content">
+                            {/* WHAT IT WATCHES, not everything it reads. "set anything else and it
+                                never hears about it" was the first wording, and the fence one tab to
+                                the LEFT refutes it: the `<adw-combo-row>` preview on
+                                /adwaita/boxed-lists/ sets `items`, which is none of the three that
+                                row observes and which its `connectedCallback` reads anyway. An
+                                attribute taken once at connect is heard — just never again. */}
                             <p>
                                 <code>{`<${elementTag}>`}</code> observes {attributes.length}
-                                {attributes.length === 1 ? ' attribute' : ' attributes'} in the browser port. Set one and
-                                the element re-renders; set anything else and it never hears about it. The windows below
-                                name their own — GObject properties on GTK, NativeScript's own spelling on a phone.
+                                {attributes.length === 1 ? ' attribute' : ' attributes'} in the browser port:
+                                change one on a live element and it re-renders. That is the list it watches, not every
+                                attribute it reads, and not another port's — the windows below name their own, GObject
+                                properties on GTK, NativeScript's own spelling on a phone.
                             </p>
                             <ul>
                                 {attributes.map((attr) => (

--- a/website/src/data/adwaita-attributes.ts
+++ b/website/src/data/adwaita-attributes.ts
@@ -50,8 +50,8 @@ export const ADWAITA_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
         'spacing',
         'position',
     ],
-    'adw-carousel-indicator-dots': [],
-    'adw-carousel-indicator-lines': [],
+    'adw-carousel-indicator-dots': ['for'],
+    'adw-carousel-indicator-lines': ['for'],
     'adw-checkbox': ['checked', 'indeterminate', 'disabled', 'label'],
     'adw-clamp': ['maximum-size', 'tightening-threshold'],
     'adw-combo-row': ['title', 'subtitle', 'selected'],
@@ -156,11 +156,26 @@ export const ADWAITA_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
     'adw-view-switcher-page': [],
     'adw-window': [],
     'adw-window-title': ['title', 'subtitle'],
-    'adw-wrap-box': [],
+    'adw-wrap-box': [
+        'child-spacing',
+        'child-spacing-unit',
+        'pack-direction',
+        'align',
+        'justify',
+        'justify-last-line',
+        'line-spacing',
+        'line-spacing-unit',
+        'line-homogeneous',
+        'natural-line-length',
+        'natural-line-length-unit',
+        'wrap-reverse',
+        'wrap-policy',
+        'orientation',
+    ],
 };
 
 /** How many attributes the web pillar observes in total. */
-export const ADWAITA_ATTRIBUTE_COUNT = 260;
+export const ADWAITA_ATTRIBUTE_COUNT = 276;
 
 /** How many elements the pillar registers. An element with none is still an entry. */
 export const ADWAITA_ELEMENT_COUNT = 65;


### PR DESCRIPTION
`<adw-button-content> takes 4 attributes` sat under the whole block, after the last window, with nothing in it naming a port. Read there it is a claim about **all four** implementations, and it is not one of them's answer — it is one port's.

## The claim it was making, and why it is wrong

The list is the browser port's by construction: `scripts/adwaita-elements.mjs:34` roots its reader at `packages/web/adwaita-web/src` and reads each element's own `observedAttributes`. Nothing about GTK or NativeScript reaches the generator.

And the ports genuinely disagree. `Adw.ButtonContent` on NativeScript (`packages/nativescript-bridge/adwaita/src/widgets/adw-button-content.ts`) carries eight accessors: the icon is `icon`, not `icon-name`, and `iconColor`, `iconIsFallback`, `hostButton` and `ellipsize` have no web counterpart at all. `scripts/check-vocabulary-alignment.mjs` already holds that divergence as a repo fact for 22 of the 65 element names.

## What changed

The list moves INTO the window that runs the browser port, as that window's last pane beside **Preview** and **HTML** — the mechanism every gallery page already promises in its own intro: *"where one of them differs, its own window says so"*.

A tab also answers the other half of the complaint. The old summary said how MANY attributes there were and never what one IS. The pane says what the list is, and — after review — what it is **not**:

> `<adw-button-content>` observes 4 attributes in the browser port: change one on a live element and it re-renders. That is the list it watches, not every attribute it reads.

That second sentence started life as "set anything else and it never hears about it", and the fence one tab to the left refutes it: `<adw-combo-row items='…'>` on /adwaita/boxed-lists/ sets `items`, which is none of its three observed attributes and which `adw-combo-row.ts:43` reads in `connectedCallback`. An attribute taken once at connect is heard — just never again.

Structurally the pane follows the live preview: one that no page provides, because the component is it. `ATTRS_PANE` joins `LIVE_PANE` in the positional `data-impls` list, and the collision check that guarded one now guards both by name. Built output: 39 × `data-impls="live,preview,attributes"`, 1 × `"live,preview"` — `Adw.Toast`, which has no custom element.

## Three defects found under it

The review round that followed found the reader feeding this pane was wrong, and the gate above it was printing its own contradiction at exit 0.

- **`observedAttributesByClass` read a computed list as an empty one.** It documents two outcomes — a list, or UNREADABLE — because "observes nothing" and "cannot be read" are different facts. Two shapes reached a silent third. `adw-wrap-box.ts:86` returns `[...PROPERTY_ATTRIBUTES]`, which has no quoted string in it, so it read as `[]` and /adwaita/layout/ rendered **no pane at all** for an element that observes 14 and has a working `attributeChangedCallback`. `adw-carousel-indicator-dots` and `-lines` inherit `['for']`, and `extendsBase` was computed, returned, and never read. The reader now walks the literal in order, resolves inheritance to a fixpoint, and treats a literal that yields no name as UNREADABLE — only `return [];` may read as none. 65 tags before and after, 0 unreadable, exactly 3 changed. The 13 phantom `adw-wrap-box` rows in `KNOWN_GAPS` went with it: backlog 83/28 → 70/27.
- **`check-generated-website-data` waved that through.** It printed *"40 gallery block(s), 38 rendering a generated attribute table, 65 registered element(s), 1 exemption(s)"* and exited 0 — its own arithmetic, 40−38≠1, on its own line. Registered-but-observes-nothing was counted and not judged. Both causes now fail unless declared.
- **A pair of props that only meant anything together.** `attributes` and `elementTag` were separate, and `elementTag` went to all four windows; a list arriving without its tag would render `<null>` over a correct list on a page that still builds. One `attributes?: { tag, names }` makes that unrepresentable instead of merely unasserted.

## Two things measured rather than assumed

- **The style block is `is:global`**, so `:global(.adw-widget-attrs)` is not a wrapper there — it is a LITERAL selector. Written that way first, it survived the build and shipped as `:global(.adw-widget-attrs){padding:…}` in the emitted CSS: a rule matching nothing, over a pane that rendered correctly anyway. The build was green throughout.
- **The chips.** `not-content` opts them out of Starlight's inline-code styling, so the four names ran together as one line of monospace and read as prose rather than as a list of four things.

## Checks

Driven in Chrome via Playwright, zero page errors. Clicking **Attributes** stores the choice and moves every other live window to that pane; `Adw.Toast`'s two-pane window correctly ignores it; the `Adw.TabView` preview's own inner `<adw-tab-view>` neither retargets nor writes to `localStorage`. Tab semantics come from `adw-tab-view` itself — `role=tablist/tab/tabpanel`, `aria-selected`, roving `tabindex`, ArrowRight reaches and activates it. Contrast: 11.7:1 light, 9.0:1 dark. At 390 px the chips wrap — 14 of them over seven rows for `<adw-wrap-box>` — with no horizontal overflow in either scheme.

`check-generated-website-data` · `check-website-adwaita-gallery` · `check-website-preview-not-content` · `check-website-package-names` · `check-doc-fences` · `check-adwaita-element-properties` · `check-vocabulary-alignment` · `lint` · `format --check` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW64WW51D4C5jd1iuXU9th