### PR TITLE
fix(website): the attribute pane as a table

### DIFF
--- a/.github/workflows/audit-runtimes.yml
+++ b/.github/workflows/audit-runtimes.yml
@@ -569,6 +569,15 @@ jobs:
       - name: Check the website's generated data is current
         run: node scripts/check-generated-website-data.mjs
 
+      # The attribute TABLE on those pages goes one step further than the generated
+      # list: its second column prints the value the block's own preview markup sets,
+      # read out of the fence by a hand-rolled scanner. That scanner lived in the one
+      # .astro file oxlint is told to skip, so nothing read it and nothing ran it —
+      # and it shipped `&lt;Control&gt;C` as a value, a blank cell for `x=""`, and an
+      # element inside an HTML comment scanned as markup.
+      - name: Check the gallery's attribute samples are read faithfully
+        run: node scripts/check-website-attr-samples.mjs
+
       # One meta drives all three panels, so the three ALWAYS look identical — which
       # is exactly why a control wired on one target and not the others cannot be
       # seen. `entry-row`'s `showApplyButton` switch rendered on all three and was
@@ -1079,6 +1088,15 @@ jobs:
       # as "this widget has no attributes" from the page's side.
       - name: Check the website's generated data is current
         run: node scripts/check-generated-website-data.mjs
+
+      # The attribute TABLE on those pages goes one step further than the generated
+      # list: its second column prints the value the block's own preview markup sets,
+      # read out of the fence by a hand-rolled scanner. That scanner lived in the one
+      # .astro file oxlint is told to skip, so nothing read it and nothing ran it —
+      # and it shipped `&lt;Control&gt;C` as a value, a blank cell for `x=""`, and an
+      # element inside an HTML comment scanned as markup.
+      - name: Check the gallery's attribute samples are read faithfully
+        run: node scripts/check-website-attr-samples.mjs
 
       # One meta drives all three panels, so the three ALWAYS look identical — which
       # is exactly why a control wired on one target and not the others cannot be

--- a/scripts/check-website-attr-samples.mjs
+++ b/scripts/check-website-attr-samples.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// The Adwaita gallery's attribute table reads REAL VALUES off preview markup, and
+// nothing held the reader that does it.
+//
+// THE INCIDENT
+//
+// `sampleAttributes()` shipped inside `website/src/components/AdwWidget.astro` — the
+// one .astro file `.oxlintrc.json` ignores, because oxlint's reader takes a `<script>`
+// inside a JSX comment there as a real opener and stops parsing. So a hand-rolled HTML
+// scanner sat in the only website file no linter reads, with no test, feeding a column
+// the page presents as fact. Three of its answers were wrong on the SHIPPED site
+// before this gate existed:
+//
+//   · `<adw-shortcut-label accelerator="&lt;Control&gt;C">` printed `&lt;Control&gt;C`
+//     in the cell. `getAttribute('accelerator')` returns `<Control>C`. Character
+//     references were never decoded, so the column showed source bytes as a value.
+//   · `accelerator=""` resolved to a value of `''` and rendered a BLANK cell — where
+//     the DOM cannot tell `x=""` from a bare `x` at all.
+//   · An element inside an HTML COMMENT was scanned like markup, and an unquoted
+//     value was reported as a bare attribute — i.e. as "set", losing the value.
+//
+// A wrong value in that column is worse than no column, because the column's whole
+// claim is that it was read off the sample.
+//
+// WHAT IT CHECKS
+//
+//   1. FIXTURES, against `parse5`-free expectations written out by hand: the shapes a
+//      quote-aware scan can get wrong — `>` inside a value, the other quote character,
+//      an unquoted value, a self-closing tag, a repeated name, a tag name that is a
+//      prefix of another, a commented-out element, a character reference, an empty
+//      value.
+//   2. EVERY preview fence the gallery actually ships: the sampled value for each
+//      observed attribute occurs, verbatim, in the fence it was read from — after
+//      decoding — so a scan that drifts into another element's attributes fails here
+//      rather than on the page.
+//
+// Plain Node over the repo's own files: no install, no build, no astro render.
+//
+// Usage: node scripts/check-website-attr-samples.mjs [--root <dir>]
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { attributeCells, sampleAttributes } from '../website/src/components/attr-sample.mjs';
+import { observedAttributes } from './adwaita-elements.mjs';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT = rootFlag === -1 ? join(dirname(fileURLToPath(import.meta.url)), '..') : process.argv[rootFlag + 1];
+const DOCS_DIR = join(ROOT, 'website/src/content/docs/adwaita');
+
+const failures = [];
+const fail = (what, expected, actual) => failures.push(`${what}\n      expected ${expected}\n      actual   ${actual}`);
+
+// ---------------------------------------------------------------- 1. fixtures
+
+/** @type {[string, string, string, Record<string, string>][]} name, markup, tag, expected cells */
+const FIXTURES = [
+    [
+        '`>` inside a quoted value',
+        `<adw-data-grid columns='[{"cmp":"x>y"}]' rows="2"></adw-data-grid>`,
+        'adw-data-grid',
+        { columns: '[{"cmp":"x>y"}]', rows: '2' },
+    ],
+    [
+        'the other quote character inside a value',
+        `<adw-button label="it's here" tooltip='say "hi"'></adw-button>`,
+        'adw-button',
+        { label: "it's here", tooltip: 'say "hi"' },
+    ],
+    [
+        'an UNQUOTED value',
+        '<adw-button label=Download can-shrink></adw-button>',
+        'adw-button',
+        {
+            label: 'Download',
+            'can-shrink': 'set',
+        },
+    ],
+    ['a self-closing tag', '<adw-avatar size="48" text="PG" />', 'adw-avatar', { size: '48', text: 'PG' }],
+    [
+        'a tag name that is a PREFIX of another tag',
+        '<adw-button-content-extra icon-name="wrong"></adw-button-content-extra>' +
+            '<adw-button-content label="right"></adw-button-content>',
+        'adw-button-content',
+        { 'icon-name': 'not used', label: 'right' },
+    ],
+    [
+        'an element inside an HTML COMMENT',
+        '<!-- <adw-button label="commented-out"></adw-button> -->\n<adw-button can-shrink></adw-button>',
+        'adw-button',
+        { label: 'not used', 'can-shrink': 'set' },
+    ],
+    [
+        'a name REPEATED on one tag',
+        '<adw-button label="first" label="second"></adw-button>',
+        'adw-button',
+        {
+            label: 'first',
+        },
+    ],
+    [
+        'CHARACTER REFERENCES in a value',
+        '<adw-shortcut-label accelerator="&lt;Control&gt;C &amp; &#x41;"></adw-shortcut-label>',
+        'adw-shortcut-label',
+        { accelerator: '<Control>C & A' },
+    ],
+    [
+        'an EMPTY value, which the DOM cannot tell from a bare attribute',
+        '<adw-button label=""></adw-button>',
+        'adw-button',
+        {
+            label: 'set',
+        },
+    ],
+    ['an UPPERCASE tag', '<ADW-BUTTON LABEL="x"></ADW-BUTTON>', 'adw-button', { label: 'x' }],
+    [
+        'the tag inside ANOTHER element, entity-escaped as a reader would write it',
+        '<adw-status-page description="use &lt;adw-button&gt;"></adw-status-page>' +
+            '<adw-button label="real"></adw-button>',
+        'adw-button',
+        { label: 'real' },
+    ],
+];
+
+for (const [what, markup, tag, expected] of FIXTURES) {
+    const names = Object.keys(expected);
+    const cells = attributeCells(names, sampleAttributes(markup, tag));
+    const got = Object.fromEntries(cells.map((c) => [c.name, c.text]));
+    for (const name of names) {
+        if (got[name] !== expected[name]) {
+            fail(`fixture — ${what}: \`${name}\``, JSON.stringify(expected[name]), JSON.stringify(got[name]));
+        }
+    }
+}
+
+// ------------------------------------------------- 2. every shipped preview fence
+
+/**
+ * The `preview` fence of every `<AdwWidget title="…">` block, paired with the element
+ * tag the component derives from that title — the same derivation `AdwWidget.astro`
+ * makes, because a second spelling of it here would be the drift this file is against.
+ */
+const elementTag = (title) =>
+    `adw-${title
+        .replace(/^(?:Adw|Gtk)\./, '')
+        .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+        .toLowerCase()}`;
+
+const { byTag } = observedAttributes(ROOT);
+let blocks = 0;
+let cellsSeen = 0;
+for (const page of readdirSync(DOCS_DIR).filter((f) => f.endsWith('.mdx'))) {
+    const text = readFileSync(join(DOCS_DIR, page), 'utf8');
+    for (const block of text.split('<AdwWidget').slice(1)) {
+        const title = /^[^>]*title="([^"]+)"/.exec(block)?.[1];
+        if (title === undefined) continue;
+        const tag = elementTag(title);
+        const names = byTag.get(tag);
+        if (names === undefined || names.length === 0) continue;
+        // The preview slot's ```html fence, up to the slot that follows it.
+        const slot = block.indexOf('slot="preview"');
+        if (slot === -1) continue;
+        const fenced = /```html\n([\s\S]*?)\n\s*```/.exec(block.slice(slot));
+        if (fenced === null) {
+            failures.push(`${page} — <AdwWidget title="${title}"> has a preview slot with no \`\`\`html fence`);
+            continue;
+        }
+        blocks++;
+        const markup = fenced[1];
+        for (const cell of attributeCells(names, sampleAttributes(markup, tag))) {
+            cellsSeen++;
+            if (cell.kind !== 'value') continue;
+            // The value the page prints has to be IN the fence the page shows. Compared
+            // after re-encoding the three references a fence can carry, so a decoded
+            // `<Control>C` still matches the `&lt;Control&gt;C` it was read from.
+            const encoded = cell.text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+            if (!markup.includes(cell.text) && !markup.includes(encoded)) {
+                fail(
+                    `${page} — <${tag}> \`${cell.name}\``,
+                    'a value present in the preview fence',
+                    JSON.stringify(cell.text),
+                );
+            }
+        }
+    }
+}
+
+if (blocks === 0 || cellsSeen === 0) {
+    // A scanner that finds nothing passes every assertion above it. That is the failure
+    // this repo keeps paying for, so it is an error rather than a quiet exit 0.
+    failures.push(`read ${blocks} gallery blocks and ${cellsSeen} cells — the fence reader found nothing to check`);
+}
+
+if (failures.length > 0) {
+    console.error(`check-website-attr-samples: ${failures.length} problem(s)\n`);
+    for (const f of failures) console.error('  · ' + f);
+    process.exit(1);
+}
+console.log(
+    `check-website-attr-samples: ${FIXTURES.length} fixtures and ${cellsSeen} cells across ${blocks} gallery blocks — ok`,
+);

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -107,6 +107,7 @@ interface Props {
 }
 
 import { ADWAITA_ATTRIBUTES } from '../data/adwaita-attributes';
+import { sampleAttributes } from './attr-sample.mjs';
 import AdwWidgetWindow from './AdwWidgetWindow.astro';
 
 const { title = 'Code', padding = 'comfortable', scroll = false, stage, docHref } = Astro.props;
@@ -295,53 +296,11 @@ if (collidingSlot !== undefined) {
     );
 }
 
-/**
- * What the block's own preview markup sets on this element, so the attribute table can
- * show a REAL value beside each name instead of asserting a type.
- *
- * The honest column would be "does this attribute take a value", and it is not available:
- * an element's own source answers it through `hasAttribute` vs `getAttribute`, and measured
- * across all 65 elements, 42 of the 260 attributes call neither or both. A column derived
- * from that would be a guess on one in six rows. The fence one tab to the left is not a
- * guess, and it is already on screen.
- *
- * It scans only the opening tags of THIS element. A quote-aware walk rather than
- * `/<tag[^>]*>/`, because an attribute value may contain `>` — `<adw-data-grid>`'s `columns`
- * carries JSON.
- *
- * A valueless attribute maps to `null`, which is the distinction HTML draws and the table
- * shows: `can-shrink` is written bare, `label` is written with a value.
- */
-const sampleAttributes = (markup: string | null, tag: string): Map<string, string | null> => {
-    const found = new Map<string, string | null>();
-    if (markup === null) return found;
-    for (let i = markup.indexOf(`<${tag}`); i !== -1; i = markup.indexOf(`<${tag}`, i + 1)) {
-        const after = markup[i + tag.length + 1];
-        // `<adw-button-content>` must not match `<adw-button-content-extra>`.
-        if (after !== undefined && !/[\s/>]/.test(after)) continue;
-        let end = i + tag.length + 1;
-        let quote = '';
-        while (end < markup.length && (quote !== '' || markup[end] !== '>')) {
-            const c = markup[end];
-            if (quote === '') {
-                if (c === '"' || c === "'") quote = c;
-            } else if (c === quote) quote = '';
-            end += 1;
-        }
-        for (const m of markup.slice(i + tag.length + 1, end).matchAll(/([a-zA-Z][\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g)) {
-            const name = m[1];
-            if (found.has(name)) continue;
-            found.set(name, m[2] ?? m[3] ?? null);
-        }
-    }
-    return found;
-};
-
 const rendered: {
     id: string;
     title: string;
     live: boolean;
-    attributes: { tag: string; names: string[]; sample: Map<string, string | null> } | null;
+    attributes: { tag: string; names: string[]; sample: Map<string, string> } | null;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
 }[] = [];
@@ -728,16 +687,19 @@ for (const spec of WINDOWS) {
         border-bottom: 0;
     }
 
-    /* Monospace by CLASS, not by a `<code>` element: the cell is resolved to a string in
-       the frontmatter (see AdwWidgetWindow — a JSX conditional cannot nest inside the
-       `.map()` that renders these rows), so the styling has to travel with it. */
+    /* Monospace by CLASS, not by a `<code>` element: `attr-sample.mjs` resolves each cell
+       to a string plus a class, so the styling has to travel with it. Starlight's own
+       inline-code styling is off in here anyway (`not-content`), so the element bought
+       nothing the class does not. */
     .adw-widget-attrs tbody th,
     .adw-widget-attrs .is-value {
         font-family: var(--__sl-font-mono);
         font-weight: 400;
     }
 
-    /* A row the preview does not exercise is the quieter fact of the two. */
+    /* Neither of these cells is a VALUE — one says the preview writes the attribute with
+       nothing after it, the other that it does not write it at all — so neither takes the
+       monospace above, and both step back from the cells that are. */
     .adw-widget-attrs .is-absent,
     .adw-widget-attrs .is-bare {
         color: var(--sl-color-gray-3);

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -295,11 +295,53 @@ if (collidingSlot !== undefined) {
     );
 }
 
+/**
+ * What the block's own preview markup sets on this element, so the attribute table can
+ * show a REAL value beside each name instead of asserting a type.
+ *
+ * The honest column would be "does this attribute take a value", and it is not available:
+ * an element's own source answers it through `hasAttribute` vs `getAttribute`, and measured
+ * across all 65 elements, 42 of the 260 attributes call neither or both. A column derived
+ * from that would be a guess on one in six rows. The fence one tab to the left is not a
+ * guess, and it is already on screen.
+ *
+ * It scans only the opening tags of THIS element. A quote-aware walk rather than
+ * `/<tag[^>]*>/`, because an attribute value may contain `>` — `<adw-data-grid>`'s `columns`
+ * carries JSON.
+ *
+ * A valueless attribute maps to `null`, which is the distinction HTML draws and the table
+ * shows: `can-shrink` is written bare, `label` is written with a value.
+ */
+const sampleAttributes = (markup: string | null, tag: string): Map<string, string | null> => {
+    const found = new Map<string, string | null>();
+    if (markup === null) return found;
+    for (let i = markup.indexOf(`<${tag}`); i !== -1; i = markup.indexOf(`<${tag}`, i + 1)) {
+        const after = markup[i + tag.length + 1];
+        // `<adw-button-content>` must not match `<adw-button-content-extra>`.
+        if (after !== undefined && !/[\s/>]/.test(after)) continue;
+        let end = i + tag.length + 1;
+        let quote = '';
+        while (end < markup.length && (quote !== '' || markup[end] !== '>')) {
+            const c = markup[end];
+            if (quote === '') {
+                if (c === '"' || c === "'") quote = c;
+            } else if (c === quote) quote = '';
+            end += 1;
+        }
+        for (const m of markup.slice(i + tag.length + 1, end).matchAll(/([a-zA-Z][\w-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'))?/g)) {
+            const name = m[1];
+            if (found.has(name)) continue;
+            found.set(name, m[2] ?? m[3] ?? null);
+        }
+    }
+    return found;
+};
+
 const rendered: {
     id: string;
     title: string;
     live: boolean;
-    attributes: { tag: string; names: string[] } | null;
+    attributes: { tag: string; names: string[]; sample: Map<string, string | null> } | null;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
 }[] = [];
@@ -349,7 +391,10 @@ for (const spec of WINDOWS) {
     // that could not see the declaration, which is how `<adw-wrap-box>` shipped
     // paneless over 14 attributes. `check-generated-website-data.mjs` fails on it now,
     // so this arm is what that failure renders as rather than a silent policy.
-    const attrs = live && attributes !== null && attributes.length > 0 ? { tag: elementTag, names: attributes } : null;
+    const attrs =
+        live && attributes !== null && attributes.length > 0
+            ? { tag: elementTag, names: attributes, sample: sampleAttributes(previewMarkup, elementTag) }
+            : null;
     rendered.push({
         id: spec.id,
         title: spec.title ?? title,
@@ -648,35 +693,53 @@ for (const spec of WINDOWS) {
         font-size: 0.9em;
     }
 
-    .adw-widget-attrs > p {
-        margin: 0;
+    .adw-widget-attrs table {
+        width: 100%;
+        border-collapse: collapse;
+        text-align: left;
+    }
+
+    /* The caption reads BEFORE the table for a screen reader, which is the order the
+       sentence wants: what the list is, then the list. */
+    .adw-widget-attrs caption {
+        text-align: left;
         color: var(--sl-color-gray-2);
         line-height: 1.5;
+        padding-bottom: 0.75rem;
     }
 
-    .adw-widget-attrs > ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.35rem 0.5rem;
-        list-style: none;
-        margin: 0.75rem 0 0;
-        padding: 0;
+    .adw-widget-attrs th,
+    .adw-widget-attrs td {
+        padding: 0.35rem 0.75rem 0.35rem 0;
+        border-bottom: 1px solid rgba(128, 128, 128, 0.16);
+        vertical-align: baseline;
     }
 
-    .adw-widget-attrs > ul > li {
-        margin: 0;
+    .adw-widget-attrs thead th {
+        font-size: 0.85em;
+        font-weight: 600;
+        color: var(--sl-color-gray-3);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
     }
 
-    /* Chips, not a sentence. `not-content` opts these out of Starlight's inline-code
-       styling, so without this the four names ran together as one line of monospace
-       and read as prose rather than as a list of four things. A grey that is an alpha
-       over the page's own background works in both schemes without a second rule. */
-    .adw-widget-attrs > ul > li > code {
-        display: inline-block;
-        background: rgba(128, 128, 128, 0.12);
-        border: 1px solid rgba(128, 128, 128, 0.18);
-        border-radius: 6px;
-        padding: 0.1rem 0.45rem;
-        line-height: 1.5;
+    .adw-widget-attrs tbody tr:last-child th,
+    .adw-widget-attrs tbody tr:last-child td {
+        border-bottom: 0;
+    }
+
+    /* Monospace by CLASS, not by a `<code>` element: the cell is resolved to a string in
+       the frontmatter (see AdwWidgetWindow — a JSX conditional cannot nest inside the
+       `.map()` that renders these rows), so the styling has to travel with it. */
+    .adw-widget-attrs tbody th,
+    .adw-widget-attrs .is-value {
+        font-family: var(--__sl-font-mono);
+        font-weight: 400;
+    }
+
+    /* A row the preview does not exercise is the quieter fact of the two. */
+    .adw-widget-attrs .is-absent,
+    .adw-widget-attrs .is-bare {
+        color: var(--sl-color-gray-3);
     }
 </style>

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -63,7 +63,7 @@ interface Props {
      * expressible: the pane prints `<tag>` above the names, and a tag left behind
      * would have rendered `<null>` over a correct list, on a page that still builds.
      */
-    attributes?: { tag: string; names: string[] } | null;
+    attributes?: { tag: string; names: string[]; sample: Map<string, string | null> } | null;
 }
 
 const {
@@ -109,6 +109,26 @@ if (panes < 2 && preview !== null) {
             'window declares its own markup tab, so this means AdwWidget stopped passing it.',
     );
 }
+
+/**
+ * One row per observed attribute, with its cell RESOLVED here rather than in the markup.
+ *
+ * Not a style choice. The Astro compiler cannot parse a JSX expression nested inside a
+ * `.map()` callback (this file's header records the measurement), and a cell that is either
+ * a value, the word "set", or the words "not used" is exactly that shape. Resolving it to a
+ * string plus a class keeps the table body one level deep, and the class carries the
+ * monospace a `<code>` would have.
+ */
+const attrRows =
+    attributes === null
+        ? []
+        : attributes.names.map((name) => {
+              if (!attributes.sample.has(name)) return { name, text: 'not used', kind: 'absent' };
+              const value = attributes.sample.get(name);
+              // HTML's own distinction: a bare attribute is present with no value, and that is
+              // how `can-shrink` is written where `label` is written with one.
+              return value === null ? { name, text: 'set', kind: 'bare' } : { name, text: value, kind: 'value' };
+          });
 
 // The attribute pane is the LIVE window's — it is that window's element being
 // described. Asserted because nothing downstream would notice: on a code-only window
@@ -208,26 +228,32 @@ if (attributes !== null && preview === null) {
                 {attributes !== null && (
                     <adw-tab-page title="Attributes">
                         <div class="adw-widget-attrs not-content">
-                            {/* WHAT IT WATCHES, not everything it reads. "set anything else and it
-                                never hears about it" was the first wording, and the fence one tab to
-                                the LEFT refutes it: the `<adw-combo-row>` preview on
-                                /adwaita/boxed-lists/ sets `items`, which is none of the three that
-                                row observes and which its `connectedCallback` reads anyway. An
-                                attribute taken once at connect is heard — just never again. */}
-                            <p>
-                                <code>{`<${attributes.tag}>`}</code> observes {attributes.names.length}
-                                {attributes.names.length === 1 ? ' attribute' : ' attributes'} in the browser port:
-                                change one on a live element and it re-renders. That is the list it watches, not every
-                                attribute it reads, and not another port's — the windows below name their own, GObject
-                                properties on GTK, NativeScript's own spelling on a phone.
-                            </p>
-                            <ul>
-                                {attributes.names.map((attr) => (
-                                    <li>
-                                        <code>{attr}</code>
-                                    </li>
-                                ))}
-                            </ul>
+                            {/* OBSERVES is the precise word and the caption spends one sentence on
+                                what it means, because the looser wording was wrong. "Set anything
+                                else and it never hears about it" was the first version, and the
+                                fence one tab to the LEFT refutes it: the `<adw-combo-row>` preview
+                                on /adwaita/boxed-lists/ sets `items`, which the row does not
+                                observe and which its `connectedCallback` reads anyway. */}
+                            <table>
+                                <caption>
+                                    <code>{`<${attributes.tag}>`}</code> observes these in the browser port. Changing
+                                    one re-renders the element. The other windows name their own properties.
+                                </caption>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Attribute</th>
+                                        <th scope="col">In this preview</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {attrRows.map((row) => (
+                                        <tr>
+                                            <th scope="row">{row.name}</th>
+                                            <td class={`is-${row.kind}`}>{row.text}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
                         </div>
                     </adw-tab-page>
                 )}

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -25,15 +25,18 @@
 // once, and `check-website-adwaita-gallery.mjs` holds the preview in first
 // position so "Preview | HTML" cannot silently become "HTML | Preview").
 //
-// It is a component rather than a loop body in `AdwWidget.astro` because the
-// Astro compiler cannot parse a JSX expression nested inside a `.map()` CALLBACK:
-// `windows.map((win) => (<div>{win.live && (<div/>)}</div>))` fails to compile
-// with `Expected "}" but found ")"`, measured on astro 6.4.5 when this file was
-// split out, and so does a `.map()` inside a `.map()`. A conditional wrapping an
-// element that CONTAINS a `.map()` is a different shape and compiles — that is
-// the one below, measured the only way that counts, by building the site. An
-// isolated `@astrojs/compiler` call is NOT that measurement: asked the same
-// questions it accepts every shape here, the two failing ones included.
+// It is a component rather than a loop body in `AdwWidget.astro` because a window is
+// a thing with a name, not four lines of markup repeated. This note used to give a
+// compiler reason instead — that the Astro compiler cannot parse a JSX expression
+// nested inside a `.map()` CALLBACK, `windows.map((win) => (<div>{win.live &&
+// (<div/>)}</div>))` failing with `Expected "}" but found ")"`. RE-MEASURED the way
+// that note itself demands, by building the site, on astro 6.4.5 with
+// @astrojs/compiler 4.0.0: that exact shape builds, a `.map()` inside a `.map()`
+// builds, and a conditional carrying a self-closing element inside a row builds.
+// Whatever the original failure was, it is not this rule — and a rule with a wrong
+// reason is thrown out together with its reason the first time someone checks it.
+
+import { attributeCells } from './attr-sample.mjs';
 
 interface Props {
     /** Window title. The live-preview window takes the WIDGET's; the rest name their kind. */
@@ -63,7 +66,7 @@ interface Props {
      * expressible: the pane prints `<tag>` above the names, and a tag left behind
      * would have rendered `<null>` over a correct list, on a page that still builds.
      */
-    attributes?: { tag: string; names: string[]; sample: Map<string, string | null> } | null;
+    attributes?: { tag: string; names: string[]; sample: Map<string, string> } | null;
 }
 
 const {
@@ -111,24 +114,16 @@ if (panes < 2 && preview !== null) {
 }
 
 /**
- * One row per observed attribute, with its cell RESOLVED here rather than in the markup.
+ * One row per observed attribute, resolved to a string plus a class by the same module
+ * that reads the markup — see `attr-sample.mjs`, which owns the "" means set rule.
  *
- * Not a style choice. The Astro compiler cannot parse a JSX expression nested inside a
- * `.map()` callback (this file's header records the measurement), and a cell that is either
- * a value, the word "set", or the words "not used" is exactly that shape. Resolving it to a
- * string plus a class keeps the table body one level deep, and the class carries the
- * monospace a `<code>` would have.
+ * Resolved rather than branched in the markup so the table body stays one level deep
+ * and the monospace can travel by class. (An earlier note here gave a compiler reason
+ * for that; measured on astro 6.4.5 with @astrojs/compiler 4.0.0 by building the site,
+ * a conditional carrying JSX inside this very `.map()` callback compiles fine, and so
+ * does a `.map()` inside a `.map()`. It is a shape choice, not a constraint.)
  */
-const attrRows =
-    attributes === null
-        ? []
-        : attributes.names.map((name) => {
-              if (!attributes.sample.has(name)) return { name, text: 'not used', kind: 'absent' };
-              const value = attributes.sample.get(name);
-              // HTML's own distinction: a bare attribute is present with no value, and that is
-              // how `can-shrink` is written where `label` is written with one.
-              return value === null ? { name, text: 'set', kind: 'bare' } : { name, text: value, kind: 'value' };
-          });
+const attrRows = attributes === null ? [] : attributeCells(attributes.names, attributes.sample);
 
 // The attribute pane is the LIVE window's — it is that window's element being
 // described. Asserted because nothing downstream would notice: on a code-only window
@@ -233,11 +228,20 @@ if (attributes !== null && preview === null) {
                                 else and it never hears about it" was the first version, and the
                                 fence one tab to the LEFT refutes it: the `<adw-combo-row>` preview
                                 on /adwaita/boxed-lists/ sets `items`, which the row does not
-                                observe and which its `connectedCallback` reads anyway. */}
+                                observe and which its `connectedCallback` reads anyway.
+
+                                ACROSS EVERY occurrence is the other sentence, and it is not
+                                padding. /adwaita/buttons/ paints five `<adw-button>`s, one per
+                                style, so the pane reports `flat`, `suggested`, `destructive`,
+                                `circular` and `pill` all set — true of the preview and true of no
+                                button in it. Unsaid, a reader takes the column for one element's
+                                own attribute list and concludes those five combine. */}
                             <table>
                                 <caption>
                                     <code>{`<${attributes.tag}>`}</code> observes these in the browser port. Changing
-                                    one re-renders the element. The other windows name their own properties.
+                                    one re-renders the element. The second column is what the preview one tab to the
+                                    left writes, read across every copy of the element in it. The other windows name
+                                    their own properties.
                                 </caption>
                                 <thead>
                                     <tr>

--- a/website/src/components/attr-sample.mjs
+++ b/website/src/components/attr-sample.mjs
@@ -1,0 +1,129 @@
+// What a gallery block's own preview markup sets on one element, so the attribute
+// table can show a REAL value beside each name instead of asserting a type.
+//
+// PLAIN JS ON PURPOSE, and in its own file. `website/src/components/AdwWidget.astro`
+// is the one .astro file `.oxlintrc.json` ignores (oxlint's reader takes a `<script>`
+// inside a JSX comment there as a real opener and stops parsing), so a hand-rolled
+// HTML scanner living in that frontmatter was the one piece of website logic no
+// linter read and no gate exercised. Out here it is linted, and
+// `scripts/check-website-attr-samples.mjs` holds it against fixtures for the shapes
+// below plus every preview fence the gallery actually ships.
+//
+// THE HONEST COLUMN would be "does this attribute take a value", and it is not
+// available: an element's own source answers it through `hasAttribute` vs
+// `getAttribute`, and measured over `packages/web/adwaita-web/src` that leaves
+// 43 of 276 attributes calling both or neither when each element is read in its own
+// module, 37 of 276 when the whole package is (child elements like `<adw-tab-page>`
+// are read by their PARENT, which is why the scope changes the answer and neither
+// scope makes it clean). A column derived from that is a guess on one row in six or
+// seven. The fence one tab to the left is not a guess, and it is already on screen.
+
+/**
+ * The character references a browser resolves while parsing an attribute value.
+ *
+ * The sampled value is read out of MARKUP TEXT, and the table presents it as the
+ * value the element carries — so it has to be decoded exactly once, the way the
+ * parser would. `<adw-shortcut-label accelerator="&lt;Control&gt;C">` is real markup
+ * on /adwaita/presentation/, and undecoded the cell printed `&lt;Control&gt;C` where
+ * `getAttribute('accelerator')` returns `<Control>C`.
+ *
+ * Only these five plus numeric refs. HTML's full named-reference table is 2000-odd
+ * entries and a partial one that GUESSES is worse than one that does not: an
+ * unrecognised `&…;` is left exactly as written, which is at worst the old
+ * behaviour on a value no gallery fence contains.
+ */
+const NAMED_REFS = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+
+/** @param {string} value */
+const decodeRefs = (value) =>
+    value.replaceAll(/&(?:#x([0-9a-fA-F]+)|#(\d+)|([a-zA-Z][a-zA-Z0-9]*));/g, (whole, hex, dec, name) => {
+        if (hex !== undefined) return String.fromCodePoint(Number.parseInt(hex, 16));
+        if (dec !== undefined) return String.fromCodePoint(Number(dec));
+        return Object.hasOwn(NAMED_REFS, name) ? NAMED_REFS[name] : whole;
+    });
+
+/** Half-open `[start, end)` ranges of every HTML comment, so a tag inside one is not markup. */
+const commentRanges = (markup) => {
+    /** @type {[number, number][]} */
+    const ranges = [];
+    for (let i = markup.indexOf('<!--'); i !== -1; i = markup.indexOf('<!--', i + 4)) {
+        const close = markup.indexOf('-->', i + 4);
+        const end = close === -1 ? markup.length : close + 3;
+        ranges.push([i, end]);
+        i = end - 4;
+    }
+    return ranges;
+};
+
+/**
+ * Every attribute the preview sets on `<tag>`, name -> value, `''` where the source
+ * writes the attribute with no value.
+ *
+ * `''` rather than a separate "bare" marker because that IS the distinction HTML
+ * draws: `<x can-shrink>` and `<x can-shrink="">` produce the same DOM, and
+ * `getAttribute` returns `''` for both. The table says "set" for either.
+ *
+ * A QUOTE-AWARE walk of the opening tags rather than `/<tag[^>]*>/`, because an
+ * attribute value may contain `>` — `<adw-data-grid>`'s `columns` carries JSON.
+ * Comments are skipped, the tag match is case-insensitive and anchored so
+ * `<adw-button-content>` cannot match `<adw-button-content-extra>`, and an unquoted
+ * value is read as a value rather than silently reported as a bare attribute.
+ *
+ * WHERE THE PREVIEW HAS SEVERAL of the element, the first value found wins and the
+ * result is a UNION across them: /adwaita/buttons/ paints five `<adw-button>`s, one
+ * per style, and the pane reports `flat`, `suggested`, `destructive`, `circular` and
+ * `pill` all set. That is true of the preview and true of no single button in it, so
+ * the caption says which of the two the column means.
+ *
+ * @param {string | null} markup
+ * @param {string} tag
+ * @returns {Map<string, string>}
+ */
+export const sampleAttributes = (markup, tag) => {
+    /** @type {Map<string, string>} */
+    const found = new Map();
+    if (markup === null) return found;
+    const comments = commentRanges(markup);
+    const opening = new RegExp(`<${tag.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=[\\s/>]|$)`, 'gi');
+    for (const start of markup.matchAll(opening)) {
+        const from = start.index + start[0].length;
+        if (comments.some(([a, b]) => start.index >= a && start.index < b)) continue;
+        let end = from;
+        let quote = '';
+        while (end < markup.length && (quote !== '' || markup[end] !== '>')) {
+            const c = markup[end];
+            if (quote === '') {
+                if (c === '"' || c === "'") quote = c;
+            } else if (c === quote) quote = '';
+            end += 1;
+        }
+        const inside = markup.slice(from, end);
+        for (const m of inside.matchAll(/([a-zA-Z_:][\w:.-]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g)) {
+            // Lower-cased because a parser lower-cases attribute names, and the list this
+            // is matched against is `observedAttributes`, which is always lower-case.
+            const name = m[1].toLowerCase();
+            // First wins, which is also what the parser does with a name repeated on one tag.
+            if (found.has(name)) continue;
+            found.set(name, decodeRefs(m[2] ?? m[3] ?? m[4] ?? ''));
+        }
+    }
+    return found;
+};
+
+/**
+ * One table cell per observed attribute: the text to print and the class that styles it.
+ *
+ * Resolved to a STRING here rather than with a conditional in the markup so the table
+ * body stays one level deep and the monospace can travel by class. It sits beside the
+ * scan rather than in the component so that ONE file decides what an empty value means,
+ * and so the gate can assert the cell a reader sees rather than the map behind it.
+ *
+ * @param {readonly string[]} names
+ * @param {Map<string, string>} sample
+ */
+export const attributeCells = (names, sample) =>
+    names.map((name) => {
+        const value = sample.get(name);
+        if (value === undefined) return { name, text: 'not used', kind: 'absent' };
+        return value === '' ? { name, text: 'set', kind: 'bare' } : { name, text: value, kind: 'value' };
+    });


### PR DESCRIPTION
The pane shipped as a paragraph over a row of chips, and Pascal was right about the paragraph. Three stacked clauses of hedging, then an em dash and two more appositives:

> `<adw-button-content>` observes 4 attributes in the browser port: change one on a live element and it re-renders. That is the list it watches, not every attribute it reads, and not another port's — the windows below name their own, GObject properties on GTK, NativeScript's own spelling on a phone.

It says what the list is *not* three times before saying what it is.

## The table, and why the second column earns it

Each attribute now shows the value the preview one tab to the left actually sets.

| Attribute | In this preview |
|---|---|
| `icon-name` | `folder-download` |
| `label` | `Download` |
| `use-underline` | not used |
| `can-shrink` | not used |

On `<adw-wrap-box>`, which observes fourteen, that is the difference between a wall of names and seeing at a glance that the sample sets `child-spacing` and `line-spacing` to 8 and touches nothing else.

## What the review round found, and why it was worth running

**The column's whole claim is "this was read off the sample", so a wrong cell is worse than no column.** An independent review ran the first scanner against 18 adversarial fixtures with **parse5 as the oracle** — the right oracle, because the preview is mounted with `set:html` into a `<template>`, so parse5's tree is literally what the element reads back. **Seven of eighteen disagreed with the DOM, and four of those classes occur in the shipped gallery.**

One was visible on the deployed page. `/adwaita/presentation/`, `<adw-shortcut-label>`, `accelerator`: the cell rendered the literal text `&lt;Control&gt;C` where `getAttribute('accelerator')` returns `<Control>C`. `decodeEcCode` decodes only numeric references, deliberately, so it cannot rewrite the author's markup — and the sampler then presented the undecoded source bytes as the element's value.

The other three, latent but real: `x=""` rendered a blank cell, an element inside an HTML comment was read as live markup (six fences carry comments), and an unquoted value read as `set` instead of its value.

**And three panes silently union across occurrences.** `/adwaita/buttons/` paints five `<adw-button>`s, one per style, and the pane reported `flat`, `suggested`, `destructive`, `circular` and `pill` all set at once. True of the preview, true of no button in it. The union is the right answer for that column heading; it just has to be stated, and the caption now states it.

**The scanner was living in a lint blind spot.** `AdwWidget.astro` is the one `.astro` file `.oxlintrc.json` ignores (`check-lint-visibility.mjs:135`). A hand-rolled HTML parser, in the only website file no linter reads, with no test and no gate.

So the scanner moved out to `website/src/components/attr-sample.mjs` and is now parser-faithful: character references decoded, `''` for both bare and empty values, comments skipped, unquoted values read, case-insensitive anchored tag match, attribute names lower-cased. `scripts/check-website-attr-samples.mjs` holds it with 11 fixtures plus provenance for all 190 cells across the 39 panes, wired into `audit-runtimes.yml`. **A/B'd: removing entity decoding, comment skipping, unquoted values, the empty-value rule or case-insensitivity each makes it exit 1** with a named fixture.

## Two claims of mine the review falsified

**The Astro compiler constraint is not real.** I wrote that the cell had to be resolved to a string in the frontmatter because a JSX expression cannot nest inside a `.map()` callback, citing the measurement in `AdwWidgetWindow.astro`'s own header. Re-measured the only way that header allows, by building the site on astro 6.4.5 with `@astrojs/compiler` 4.0.0: the literal failing shape from that header, a conditional carrying JSX inside the `.map()` callback, and a `.map()` inside a `.map()` all build at **exit 0, 62 pages**. The choices are still fine and lose nothing, since `not-content` turns off Starlight's inline-code styling anyway and the `<code>` bought nothing. But a rule with a wrong reason gets discarded along with its reason, so both statements are replaced by the re-measurement.

**"The distinction HTML itself draws between `can-shrink` and `label="Download"`" is not a thing.** `<x a>` and `<x a="">` produce the identical DOM and `getAttribute` returns `''` for both. It is a source-syntax distinction only, and modelling it as `null` is exactly what made `accelerator=""` render a blank cell.

## The column I wanted and did not ship

"Does this attribute take a value", from `hasAttribute` versus `getAttribute` in each element's own source. I measured before building and rejected it. The review re-derived it per class rather than with my global string search, and the conclusion holds while my numbers do not: **276 attributes, not 260**, and **43 of them (15.6 %) call both or neither** at per-class scope, 37 at package scope. Per-class is slightly *worse*, because child elements like `<adw-tab-page>` are read by their parent, so narrowing the scope moves rows into "neither". Still one row in six. It needs a real generator or nothing.

## Checks

70 value cells, 20 bare, 100 not used, 190 rows across 39 panes on 8 pages, unchanged by the fixes and hand-checked against their fences for `adw-about-dialog`, `adw-wrap-box`, `adw-drop-down` and `adw-button-content`. Contrast for the greyed cells measured in-page: **7.02:1 light, 4.71:1 dark**, both AA. No overflow at 390 px (`scrollWidth === clientWidth === 390`, table 326 px in a 358 px pane).

`lint` · `format --check` · `check-generated-website-data` · `check-website-adwaita-gallery` · `check-website-preview-not-content` · `check-website-package-names` · `check-doc-fences` · `check-lint-visibility` · **`check-website-attr-samples`** — all exit 0. Site build 62 pages.

## Known and named, not fixed

The union across occurrences is stated rather than changed: showing only the first would lose real information, since the preview genuinely exercises all five button styles. The `MARKUP_OVERRIDE` block samples the preview fence while its HTML tab shows the override, which is latent today because that block has no attributes pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW64WW51D4C5jd1iuXU9th
