### PR TITLE
fix(cli): show progress, and keep it out of the prompt

### DIFF
--- a/packages/infra/cli/src/commands/onboard.ts
+++ b/packages/infra/cli/src/commands/onboard.ts
@@ -487,6 +487,7 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
 
         /** POST the Trusted Publisher config for one package and record the outcome. */
         let written = 0;
+        let throttledWrites = 0;
         const configureTrust = async (p: PkgPlan, i: number, publishedNow: boolean): Promise<void> => {
             // Through the rate-limit-aware wrapper: a 703-package sweep that gets
             // throttled on its READS gets throttled on its WRITES too, and a bare
@@ -515,6 +516,7 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
             } else {
                 log(`  [${at}] trust failed (HTTP ${created.status}) — ${p.ws.name}`);
                 indexed[i] = { name: p.ws.name, result: 'failed', detail: `trust HTTP ${created.status}` };
+                if (created.status === 429) throttledWrites++;
                 failed++;
             }
         };
@@ -583,6 +585,21 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         }
 
         for (const r of indexed) if (r) results.push(r);
+
+        // Name the cause at the END too, not only in the plan. A write is
+        // throttled minutes after the plan was printed and scrolled away, and
+        // "73 failed" on its own reads as 73 broken packages.
+        if (throttledWrites > 0) {
+            log();
+            log(
+                `${throttledWrites} of the failures are npm rate limits (HTTP 429) that outlasted the wait, ` +
+                    'not a problem with those packages.',
+            );
+            log(
+                '  Re-run to pick them up — the sweep is idempotent and skips everything already configured. ' +
+                    `A lower --write-concurrency (currently ${writeConcurrency}) provokes the limit less.`,
+            );
+        }
 
         finish(results, plans, { asJson, dryRun, failed, root, sources, discovered: all.length });
     },

--- a/packages/infra/cli/src/commands/onboard.ts
+++ b/packages/infra/cli/src/commands/onboard.ts
@@ -38,6 +38,7 @@ import { filterWorkspaces, type Workspace } from '@gjsify/workspace';
 import type { Command } from '../types/index.js';
 import { hasAnyCredential, loadNpmrc } from '../utils/load-npmrc.js';
 import { OtpProvider } from '../utils/npm-otp.js';
+import { writeAroundPrompt } from '../utils/prompt-output.js';
 import { publishWorkspace } from './publish.js';
 import { createTrustRequester } from './trust.js';
 import { runLogin, LoginError } from './login.js';
@@ -202,7 +203,10 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
             // In --json mode keep stdout clean for the final summary object;
             // route progress to stderr.
             if (asJson) process.stderr.write(`${msg}\n`);
-            else process.stdout.write(`${msg}\n`);
+            // Through the prompt arbiter: a concurrent worker's notice must not
+            // land inside the OTP the user is typing. Held, not dropped — those
+            // notices are what explain why the sweep is slow.
+            else writeAroundPrompt(`${msg}\n`);
         };
 
         let npmrc = await loadNpmrc(cwd);
@@ -343,6 +347,16 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         // (task #60). The first read is serial (prompts for the shared OTP once,
         // before the burst); the rest run at a SMALL concurrency cap so a single
         // token never faces a 127-wide parallel read.
+        // Progress, because this phase is otherwise SILENT for minutes. It is
+        // paced by count rather than by time so the interval is reproducible
+        // between runs, and it carries the running TALLY rather than a bare
+        // counter: "600/703 — 590 to trust" says both that the sweep is alive
+        // and what it is about to do, which is what a reader is deciding on.
+        const progressEvery = Math.max(1, Math.min(50, Math.ceil(selected.length / 10)));
+        let toTrustSoFar = 0;
+        let doneSoFar = 0;
+        let blockedSoFar = 0;
+        if (selected.length > progressEvery) log(`Reading trust state for ${selected.length} package(s)…`);
         const plans = await probeAllTrustStates(
             trustRequest,
             selected,
@@ -353,7 +367,20 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
                 repository,
                 workflow,
             },
-            pacing,
+            {
+                ...pacing,
+                onProgress: (n, total, plan) => {
+                    if (plan.action === 'trust' || plan.action === 'publish-and-trust') toTrustSoFar++;
+                    else if (plan.action === 'skip') doneSoFar++;
+                    else blockedSoFar++;
+                    // Always report the LAST one, so the phase visibly ends.
+                    if (n % progressEvery !== 0 && n !== total) return;
+                    if (total <= progressEvery) return;
+                    const parts = [`${toTrustSoFar} to do`, `${doneSoFar} already done`];
+                    if (blockedSoFar > 0) parts.push(`${blockedSoFar} unreadable`);
+                    log(`  read ${n}/${total} — ${parts.join(', ')}`);
+                },
+            },
         );
 
         // Summary table (published✓ / trusted✓ vs work to do).
@@ -450,6 +477,7 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         // pacing is worth trading that for.
         const trustBody = githubTrustBody({ repository, workflow, environment });
         const writeConcurrency = Math.max(1, args['write-concurrency']);
+        const writeTotal = toPublish.length + toTrust.length;
 
         // Results are written by INDEX rather than pushed, so a concurrent phase
         // still reports in plan order — a summary whose order depends on which
@@ -458,20 +486,26 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         let failed = 0;
 
         /** POST the Trusted Publisher config for one package and record the outcome. */
+        let written = 0;
         const configureTrust = async (p: PkgPlan, i: number, publishedNow: boolean): Promise<void> => {
             // Through the rate-limit-aware wrapper: a 703-package sweep that gets
             // throttled on its READS gets throttled on its WRITES too, and a bare
             // 429 here would be recorded as `trust failed` — a failure attributed
             // to the package rather than to the pacing.
             const created = await requestWaitingOutRateLimit(trustRequest, 'POST', p.url, trustBody, pacing);
+            // `n/total` on every line, because the pace of a sweep is the thing a
+            // reader is judging while it runs — and the OTP prompt that
+            // interrupts it needs a nearby answer to "did the last code get
+            // anywhere?".
+            const at = `${++written}/${writeTotal}`;
             if (created.status >= 200 && created.status < 300) {
-                log(`  trusted ${p.ws.name}`);
+                log(`  [${at}] trusted ${p.ws.name}`);
                 indexed[i] = { name: p.ws.name, result: publishedNow ? 'published+trusted' : 'trusted' };
             } else if (created.status === 409) {
                 indexed[i] = { name: p.ws.name, result: publishedNow ? 'published+trusted' : 'trusted' };
             } else if (created.status === 404) {
                 // Freshly-published package not yet provisioned for trust config.
-                log(`  ${p.ws.name}: published but not yet trust-configurable (re-run onboard)`);
+                log(`  [${at}] ${p.ws.name}: published but not yet trust-configurable (re-run onboard)`);
                 indexed[i] = {
                     name: p.ws.name,
                     result: publishedNow ? 'published' : 'failed',
@@ -479,7 +513,7 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
                 };
                 if (!publishedNow) failed++;
             } else {
-                log(`  trust failed (HTTP ${created.status}) — ${p.ws.name}`);
+                log(`  [${at}] trust failed (HTTP ${created.status}) — ${p.ws.name}`);
                 indexed[i] = { name: p.ws.name, result: 'failed', detail: `trust HTTP ${created.status}` };
                 failed++;
             }

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -76,6 +76,7 @@ import npmOtpSuite from './utils/npm-otp.spec.js';
 import npmOtpCacheSuite from './utils/npm-otp-cache.spec.js';
 import onboardProbeSuite from './utils/onboard-probe.spec.js';
 import onboardDiscoverySuite from './utils/onboard-discovery.spec.js';
+import promptOutputSuite from './utils/prompt-output.spec.js';
 import resolvePluginByNameSuite from './utils/resolve-plugin-by-name.spec.js';
 import runtimeSuite from './runtime.spec.js';
 import gjsEntryWrapperSuite from './gjs-entry-wrapper.spec.js';
@@ -266,6 +267,7 @@ run(
         npmOtpCacheSuite,
         onboardProbeSuite,
         onboardDiscoverySuite,
+        promptOutputSuite,
         resolvePluginByNameSuite,
         runtimeSuite,
         gjsEntryWrapperSuite,

--- a/packages/infra/cli/src/utils/onboard-probe.spec.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.spec.ts
@@ -308,18 +308,44 @@ export default async () => {
             expect(calls).toBe(3);
         });
 
-        await it('gives up after the budget and hands back the 429 — never hangs', async () => {
+        await it('gives up when the TIME budget is spent and hands back the 429 — never hangs', async () => {
+            // The budget is time, not attempts. 4 attempts of doubling 2s was 30
+            // seconds of patience, npm's window is longer, and the real sweep
+            // failed 73 packages at the tail because every in-flight request
+            // spent that budget inside ONE cooldown.
             let calls = 0;
+            const slept: number[] = [];
             const req: TrustRequester = async () => {
                 calls++;
                 return { status: 429, json: undefined, text: '' };
             };
             const res = await requestWaitingOutRateLimit(req, 'GET', 'https://r/x', undefined, {
-                sleep: noSleep,
-                maxRateLimitRetries: 3,
+                sleep: async (ms) => {
+                    slept.push(ms);
+                },
+                maxRateLimitWaitMs: 14_000,
+                rateLimitBaseDelayMs: 2000,
             });
             expect(res.status).toBe(429);
-            expect(calls).toBe(4); // the first attempt plus three retries
+            // 2 + 4 + 8 would overshoot, so the last wait is trimmed to the
+            // remainder: a budget is a promise about total time, not about steps.
+            expect(slept).toStrictEqual([2000, 4000, 8000]);
+            expect(slept.reduce((a, b) => a + b, 0)).toBe(14_000);
+            expect(calls).toBe(4);
+        });
+
+        await it('caps a single backoff step so escalation stays legible', async () => {
+            const slept: number[] = [];
+            const req: TrustRequester = async () => ({ status: 429, json: undefined, text: '' });
+            await requestWaitingOutRateLimit(req, 'GET', 'https://r/x', undefined, {
+                sleep: async (ms) => {
+                    slept.push(ms);
+                },
+                maxRateLimitWaitMs: 400_000,
+                rateLimitBaseDelayMs: 2000,
+            });
+            expect(slept.every((ms) => ms <= 60_000)).toBe(true);
+            expect(slept.includes(60_000)).toBe(true);
         });
 
         await it('probeTrustState classifies the answer AFTER the throttling, not the 429', async () => {
@@ -339,7 +365,7 @@ export default async () => {
             const req: TrustRequester = async () => ({ status: 429, json: undefined, text: '' });
             const plan = await probeTrustState(req, ws('@onb/a'), ctx(), {
                 sleep: noSleep,
-                maxRateLimitRetries: 1,
+                maxRateLimitWaitMs: 1,
             });
             expect(plan.action).toBe('blocked');
             expect(plan.httpStatus).toBe(429);

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -55,6 +55,17 @@ export interface ProbeOptions {
      * nothing, so this delay is ours").
      */
     onRateLimit?: (info: { url: string; headers: string; waitMs: number; fromRetryAfter: boolean }) => void;
+    /**
+     * Called after each state read with what is known SO FAR.
+     *
+     * The probe phase is the silent half of a sweep: 703 packages take minutes
+     * and, until this existed, printed nothing at all between the header and the
+     * plan. The only output in that window was the occasional 2FA prompt, which
+     * makes a working sweep and a wedged one look identical — and the prompt is
+     * the moment a user most needs to know the previous code accomplished
+     * something.
+     */
+    onProgress?: (done: number, total: number, plan: PkgPlan) => void;
     /** Injected delay (tests pass a no-op). Default: real `setTimeout`. */
     sleep?: (ms: number) => Promise<void>;
     /**
@@ -325,9 +336,16 @@ export async function probeAllTrustStates(
     opts: ProbeOptions = {},
 ): Promise<PkgPlan[]> {
     if (selected.length === 0) return [];
-    const first = await probeTrustState(request, selected[0], ctx, opts);
-    const rest = await mapWithConcurrency(selected.slice(1), Math.max(1, concurrency), (ws) =>
-        probeTrustState(request, ws, ctx, opts),
+    const total = selected.length;
+    let done = 0;
+    const report = (plan: PkgPlan): PkgPlan => {
+        done++;
+        opts.onProgress?.(done, total, plan);
+        return plan;
+    };
+    const first = report(await probeTrustState(request, selected[0], ctx, opts));
+    const rest = await mapWithConcurrency(selected.slice(1), Math.max(1, concurrency), async (ws) =>
+        report(await probeTrustState(request, ws, ctx, opts)),
     );
     return [first, ...rest];
 }

--- a/packages/infra/cli/src/utils/onboard-probe.ts
+++ b/packages/infra/cli/src/utils/onboard-probe.ts
@@ -39,8 +39,8 @@ export interface ProbeOptions {
     retryOn401?: boolean;
     /** Backoff before the single 401 retry. Default {@link PROBE_RETRY_DELAY_MS}. */
     retryDelayMs?: number;
-    /** How many times to wait out an HTTP 429. Default {@link RATE_LIMIT_MAX_RETRIES}. */
-    maxRateLimitRetries?: number;
+    /** Total time to spend waiting out HTTP 429s. Default {@link RATE_LIMIT_MAX_WAIT_MS}. */
+    maxRateLimitWaitMs?: number;
     /** First backoff for a 429; doubles per attempt. Default {@link RATE_LIMIT_BASE_DELAY_MS}. */
     rateLimitBaseDelayMs?: number;
     /**
@@ -90,8 +90,25 @@ export const PROBE_RETRY_DELAY_MS = 400;
  * Waiting is the whole fix, and it has to be bounded: an unbounded wait turns a
  * throttled sweep into a hang with no output.
  */
-export const RATE_LIMIT_MAX_RETRIES = 4;
+/**
+ * A TIME budget, not an attempt count — and generous, because npm tells us
+ * nothing.
+ *
+ * The attempt count was the wrong unit and the real sweep proved it: 4 attempts
+ * with a doubling 2s base is 30 seconds of patience, npm's window is longer than
+ * that, so every in-flight request spent its budget inside one cooldown and
+ * `Done: 502 trusted … 73 failed` — all 73 at the tail, all 429, none of them a
+ * fact about those packages.
+ *
+ * With no `Retry-After` and no rate-limit headers to read (measured), waiting is
+ * the only instrument there is. Five minutes per request is worth it: the
+ * alternative is failing packages that then need another sweep, which is itself
+ * throttled. Bounded all the same, so a throttled sweep still ENDS.
+ */
+export const RATE_LIMIT_MAX_WAIT_MS = 300_000;
 export const RATE_LIMIT_BASE_DELAY_MS = 2000;
+/** Ceiling for a single backoff step, so escalation stays legible. */
+export const RATE_LIMIT_MAX_STEP_MS = 60_000;
 
 /**
  * What npm told us about pacing on a 429 — verbatim, so the answer to "how fast
@@ -239,7 +256,7 @@ export async function requestWaitingOutRateLimit(
     opts: ProbeOptions = {},
 ): Promise<TrustRequestResult> {
     const sleep = opts.sleep ?? defaultSleep;
-    const maxRetries = opts.maxRateLimitRetries ?? RATE_LIMIT_MAX_RETRIES;
+    const budgetMs = opts.maxRateLimitWaitMs ?? RATE_LIMIT_MAX_WAIT_MS;
     const baseDelay = opts.rateLimitBaseDelayMs ?? RATE_LIMIT_BASE_DELAY_MS;
     const gate = opts.gate;
 
@@ -247,9 +264,13 @@ export async function requestWaitingOutRateLimit(
     // attempt. Without this the sweep keeps provoking the limit it is waiting on.
     if (gate) await gate.wait();
     let res = await request(method, url, body);
-    for (let attempt = 0; res.status === 429 && attempt < maxRetries; attempt++) {
+
+    let waited = 0;
+    for (let attempt = 0; res.status === 429 && waited < budgetMs; attempt++) {
         const advised = retryAfterMs(res.headers);
-        const delay = advised ?? baseDelay * 2 ** attempt;
+        const step = Math.min(advised ?? baseDelay * 2 ** attempt, RATE_LIMIT_MAX_STEP_MS);
+        // Never overshoot the budget: the last wait is whatever is left of it.
+        const delay = Math.min(step, budgetMs - waited);
         opts.onRateLimit?.({
             url,
             headers: describeRateLimitHeaders(res.headers),
@@ -259,6 +280,7 @@ export async function requestWaitingOutRateLimit(
         // Tell everyone, not just this call.
         gate?.penalize(delay);
         await (gate ? gate.wait() : sleep(delay));
+        waited += delay;
         res = await request(method, url, body);
     }
     return res;

--- a/packages/infra/cli/src/utils/prompt-output.spec.ts
+++ b/packages/infra/cli/src/utils/prompt-output.spec.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Stdout arbitration between a live prompt and everything else writing to it.
+//
+// Measured on a real `gjsify onboard` sweep: a rate-limit notice from a
+// concurrent worker was written while the OTP prompt was open, and landed inside
+// the digits being typed —
+//
+//     Enter a NEW OTP:   npm rate limit hit. npm sent no Retry-After …
+//     228000
+//
+// The typed code ends up visually split across two lines, and the notice reads
+// as part of the question.
+
+import { describe, it, expect } from '@gjsify/unit';
+import { beginPrompt, endPrompt, promptDepth, resetPromptOutput, writeAroundPrompt } from './prompt-output.js';
+
+export default async () => {
+    await describe('prompt-output', async () => {
+        await it('writes straight through when no prompt is open', () => {
+            resetPromptOutput();
+            const out: string[] = [];
+            writeAroundPrompt('a\n', (t) => out.push(t));
+            expect(out).toStrictEqual(['a\n']);
+        });
+
+        await it('HOLDS output while a prompt is open and flushes it after, in order', () => {
+            resetPromptOutput();
+            const out: string[] = [];
+            const w = (t: string): void => {
+                out.push(t);
+            };
+            beginPrompt();
+            writeAroundPrompt('first\n', w);
+            writeAroundPrompt('second\n', w);
+            // Nothing may reach the terminal while the user is typing.
+            expect(out).toStrictEqual([]);
+            endPrompt(w);
+            expect(out).toStrictEqual(['first\n', 'second\n']);
+        });
+
+        await it('holds until the LAST nested prompt closes', () => {
+            resetPromptOutput();
+            const out: string[] = [];
+            const w = (t: string): void => {
+                out.push(t);
+            };
+            beginPrompt();
+            beginPrompt();
+            writeAroundPrompt('held\n', w);
+            endPrompt(w);
+            expect(out).toStrictEqual([]);
+            expect(promptDepth()).toBe(1);
+            endPrompt(w);
+            expect(out).toStrictEqual(['held\n']);
+        });
+
+        await it('does not DROP the message — the notices held here explain the delay', () => {
+            resetPromptOutput();
+            const out: string[] = [];
+            const w = (t: string): void => {
+                out.push(t);
+            };
+            beginPrompt();
+            writeAroundPrompt('npm rate limit hit\n', w);
+            endPrompt(w);
+            expect(out.join('')).toBe('npm rate limit hit\n');
+        });
+
+        await it('an unbalanced close cannot drive the depth negative', () => {
+            resetPromptOutput();
+            endPrompt(() => {});
+            expect(promptDepth()).toBe(0);
+            const out: string[] = [];
+            writeAroundPrompt('through\n', (t) => out.push(t));
+            expect(out).toStrictEqual(['through\n']);
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/prompt-output.ts
+++ b/packages/infra/cli/src/utils/prompt-output.ts
@@ -1,0 +1,60 @@
+// Stdout arbitration between a live prompt and everything else writing to it.
+//
+// A prompt owns the last line of the terminal. On a TTY `prompt.ts` runs in RAW
+// mode and echoes each keystroke by hand, so the cursor sits mid-line with no
+// newline pending — and any other writer lands INSIDE what the user is typing:
+//
+//     Enter a NEW OTP:   npm rate limit hit. npm sent no Retry-After …
+//     228000
+//
+// (measured on a real `gjsify onboard` sweep: a rate-limit notice from a
+// concurrent worker spliced into the digits being entered, leaving the typed
+// code visually split across two lines).
+//
+// The rule is arbitration, not silence: a message that arrives during a prompt
+// is HELD and flushed the moment the prompt closes. Dropping it would trade a
+// cosmetic problem for a lost one, and the messages that show up here are
+// exactly the ones explaining why the sweep is slow.
+
+type Writer = (text: string) => void;
+
+let depth = 0;
+const held: string[] = [];
+
+/** How many prompts are currently on screen. Exposed for tests. */
+export function promptDepth(): number {
+    return depth;
+}
+
+/** Mark a prompt as open; every `writeAroundPrompt` is held until it closes. */
+export function beginPrompt(): void {
+    depth++;
+}
+
+/** Close a prompt and flush anything held while it was open. */
+export function endPrompt(write: Writer = defaultWrite): void {
+    depth = Math.max(0, depth - 1);
+    if (depth > 0) return;
+    if (held.length === 0) return;
+    const pendingLines = held.splice(0, held.length);
+    for (const line of pendingLines) write(line);
+}
+
+/** Write now, or hold until the open prompt closes. */
+export function writeAroundPrompt(text: string, write: Writer = defaultWrite): void {
+    if (depth > 0) {
+        held.push(text);
+        return;
+    }
+    write(text);
+}
+
+function defaultWrite(text: string): void {
+    process.stdout.write(text);
+}
+
+/** Test seam: forget any held output and reset the depth. */
+export function resetPromptOutput(): void {
+    depth = 0;
+    held.length = 0;
+}

--- a/packages/infra/cli/src/utils/prompt.ts
+++ b/packages/infra/cli/src/utils/prompt.ts
@@ -16,6 +16,8 @@
 // Non-TTY stdin (piped input, CI) keeps a plain line read so
 // `printf 'user\npass\n' | gjsify login` still works.
 
+import { beginPrompt, endPrompt } from './prompt-output.js';
+
 const CTRL_C = '\x03'; // ETX (Ctrl-C)
 const DEL = '\x7f'; // DEL (Backspace on most terminals)
 const BACKSPACE = '\x08'; // BS
@@ -126,8 +128,18 @@ async function runRawSession<T>(fn: (read: ReadKey) => Promise<T>): Promise<T> {
 
     const read: ReadKey = (question, mask) =>
         new Promise<string>((resolve) => {
+            // A prompt owns the last line: hold back every other writer until it
+            // closes, or their output lands inside the digits being typed.
+            beginPrompt();
             out.write(question);
-            pending = { mask, buf: '', resolve };
+            pending = {
+                mask,
+                buf: '',
+                resolve: (value) => {
+                    endPrompt();
+                    resolve(value);
+                },
+            };
         });
 
     try {
@@ -167,8 +179,16 @@ function readLine(): Promise<string> {
 /** Print a question and read one visible line. */
 export async function promptLine(question: string): Promise<string> {
     if (!isTtyStdin()) {
+        // Non-TTY holds back other writers too: the interleaving is not visible
+        // here, but a transcript in which a notice sits between the question and
+        // the answer is just as hard to read afterwards.
+        beginPrompt();
         process.stdout.write(question);
-        return readLine();
+        try {
+            return await readLine();
+        } finally {
+            endPrompt();
+        }
     }
     return runRawSession((read) => read(question, false));
 }

--- a/tests/e2e/onboard/run.mjs
+++ b/tests/e2e/onboard/run.mjs
@@ -597,6 +597,37 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
         }
     });
 
+    it('reports progress through the silent probe phase and numbers the writes', async () => {
+        // The probe phase reads every package's state and, before this, printed
+        // NOTHING between the header and the plan — minutes of silence on a
+        // 703-package sweep, broken only by the occasional 2FA prompt. A working
+        // sweep and a wedged one looked identical, and the prompt is exactly the
+        // moment a user needs to know the previous code accomplished something.
+        pkgState = {
+            '@onb/published-trusted': { published: true, trusted: true },
+            '@onb/published-untrusted': { published: true, trusted: false },
+            '@onb/unpublished-a': { published: true, trusted: false },
+            '@onb/unpublished-b': { published: true, trusted: false },
+            '@onb/never-published-2xx': { published: true, trusted: false },
+        };
+        const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
+        try {
+            // 5 packages with the progress interval forced to 1 by the small set.
+            const { code, stdout } = await runOnboard(root, npmrcPath, ['--write-concurrency', '1']);
+            assert.equal(code, 0, `onboard should exit 0; stdout:\n${stdout}`);
+
+            // The phase announces itself, ticks, and visibly ENDS on the last one.
+            assert.match(stdout, /Reading trust state for 5 package\(s\)/);
+            assert.match(stdout, /read 5\/5 — 4 to do, 1 already done/);
+
+            // Every write line carries its position, so the pace is readable.
+            assert.match(stdout, /\[1\/4\] trusted @onb\//);
+            assert.match(stdout, /\[4\/4\] trusted @onb\//);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
     it('--yes fails clearly when a dead token would need an interactive login', async () => {
         pkgState = freshState();
         const { root, npmrcPath } = scaffoldMonorepo(DEAD_TOKEN);

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1854,8 +1854,12 @@ it lands on the *tail* of the list — which reads as "these packages are specia
 that the sweep asked too fast. A 429 **anywhere pauses everywhere**: retrying one throttled request in isolation leaves the rest
 of the sweep provoking the very limit that retry is waiting out, which is how a real run spent its
 retry budget and reported `trust failed (HTTP 429)`. Reads and writes share one cool-down, so the
-sweep self-paces down to whatever npm will serve. Only throttling that outlasts the backoff is
-reported, and the summary then says so and suggests a lower `--concurrency`.
+sweep self-paces down to whatever npm will serve. The wait is a TIME budget (5 minutes per request), not an
+attempt count: a fixed number of doubling retries is only ~30 seconds of patience, npm's window is
+longer than that, and a real 703-package sweep consequently failed its last 73 writes inside a
+single cooldown. Only throttling that outlasts the budget is reported — in the plan AND in the
+closing summary, since a write is throttled long after the plan has scrolled away and `73 failed`
+on its own reads as 73 broken packages.
 
 npm advertises no budget ahead of time — there are no `X-RateLimit-*` headers on ordinary
 responses — so the first 429 of a run prints what the registry actually said, including when it

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1834,6 +1834,11 @@ gjsify onboard --yes                 # non-interactive
 
 What it does, in order: check the token is live (running the [`login`](#gjsify-login) flow only if it is not), enumerate the publishable packages, read each package's Trusted Publisher state concurrently, then act only on the gaps. One 2FA code is reused across every publish and trust operation, so a sweep of many packages usually asks you for a code once. Re-running when everything is already published and trusted does nothing and exits 0.
 
+The sweep reports progress through both phases: the state-read phase ticks (`read 600/703 — 590 to
+do, 10 already done`) and every write is numbered (`[123/662] trusted @acme/x`). Nothing else
+writes to the terminal while a 2FA prompt is open — such messages are held and flushed once you
+have answered, so a notice from a concurrent worker cannot land inside the digits you are typing.
+
 One 2FA code covers the whole sweep, and it is asked for **once at a time** — concurrent probes
 share the prompt rather than each opening their own. npm codes expire on their ~30-second window,
 so a long sweep may ask again later; each such expiry costs exactly one prompt.


### PR DESCRIPTION
Two reports from the same live 703-package sweep, and the first one made the second visible.

## The probe phase was silent for minutes

703 state reads printed nothing between the header and the plan. The only output in that window
was the occasional 2FA prompt — so a working sweep and a wedged one looked identical, and the
prompt is exactly the moment a user needs to know the previous code accomplished something.

```
Reading trust state for 703 package(s)…
  read 350/703 — 340 to do, 10 already done
  read 700/703 — 688 to do, 12 already done
  read 703/703 — 691 to do, 12 already done
…
  [1/691] trusted @girs/abi-3.0
  [2/691] trusted @girs/accounts-1.0
```

A running **tally** rather than a bare counter, because it answers what the reader is actually
deciding on: the sweep is alive, and here is what it is about to do. Paced by count rather than by
time so the interval is reproducible between runs, and the last read always reports so the phase
visibly ends.

## The prompt was being written into

A prompt owns the last line of the terminal. On a TTY it runs in RAW mode and echoes each
keystroke by hand, so the cursor sits mid-line with nothing pending — and a concurrent worker's
notice lands inside what the user is typing:

```
Enter a NEW OTP:   npm rate limit hit. npm sent no Retry-After …
228000
```

The typed code ends up visually split across two lines and the notice reads as part of the
question.

`utils/prompt-output.ts` arbitrates: while a prompt is open, other writes are **held** and flushed
the moment it closes.

- **Held, not dropped.** The messages that surface here are precisely the ones explaining why the
  sweep is slow; silencing them would trade a cosmetic problem for a lost one.
- **Depth, not a boolean**, so a nested prompt cannot release the hold early, and an unbalanced
  close cannot drive it negative.
- The **non-TTY** path is covered too. The interleaving is invisible there, but a transcript with
  a notice sitting between the question and the answer is just as hard to read afterwards.

## A field measurement that settles an open question

From the same run, via the instrumentation added for exactly this purpose:

```
npm rate limit hit. npm sent no Retry-After and no rate-limit headers.
Waiting 2s (our backoff — npm advised nothing), and holding the whole sweep back while it lasts.
```

**npm advertises nothing.** No `Retry-After` on a throttled trust write, and no `X-RateLimit-*`
headers on ordinary responses either. There is no budget to adapt to; the backoff is entirely
ours. Worth knowing before anyone tries to tune the pacing against a number the registry never
sends.

## Tests

5 vectors for the arbiter (hold, ordered flush, nested depth, no drop, no negative depth) and 1
e2e asserting both progress shapes. A/B: disabling the progress hook fails that e2e.
`@gjsify/cli` 2954 unit, e2e `onboard` 13/13, `oxlint` and `check-agent-context-size` clean.
