### PR TITLE
fix(website): the software that page calls unwritten

### DIFF
--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -35,10 +35,13 @@
 //     all 40 blocks was the second copy.
 //   · "React Native on GTK" carried its qualifier in the tab LABEL, because a
 //     plain "React Native" standing beside Web and NativeScript would have read as
-//     the port that runs on a phone — the one claim this repository must not make
-//     about code it has not written. The qualifier is now the page's:
-//     `layout.mdx`, the only page with that window, says it "renders a GTK window,
-//     not a phone screen — which is why it is not the NativeScript one".
+//     the port that runs on a phone — which is not what this window renders. (That
+//     reason once read "code it has not written"; `@gjsify/adwaita-react-native`
+//     was written in #1380, and the qualifier survives it, because what is at stake
+//     here is what THIS window shows, not what exists elsewhere in the tree.) The
+//     qualifier is now the page's: `layout.mdx`, the only page with that window,
+//     says it "renders a GTK window, not a phone screen — which is why it is not
+//     the NativeScript one".
 //
 // So the header bar carries a title and nothing else. Whatever a header bar sits
 // on is what the reader takes the window to be about: it once held the widget
@@ -203,12 +206,13 @@ const WINDOWS = [
         // screen.
         //
         // This comment used to give a different reason — "there is no Adwaita
-        // widget set built out of React Native primitives" — and that reason died
-        // with `@gjsify/adwaita-react-native` (#1380), which is exactly such a set.
-        // The decision survives it, because it never rested on that package's
-        // absence: what fills this window is direction A, and a direction-B package
-        // existing elsewhere in the tree does not put a phone on this page. It
-        // would take a TAB that renders one.
+        // widget set built out of React Native primitives, SO nothing under this
+        // window runs on a phone" — and that premise died with
+        // `@gjsify/adwaita-react-native` (#1380), which is exactly such a set. The
+        // `so` means the absence really was load-bearing as written; what survives
+        // is the CONCLUSION, on other grounds. What fills this window is direction
+        // A, and a direction-B package existing elsewhere in the tree does not put
+        // a phone on this page. It would take a TAB that renders one.
         title: 'UI frameworks',
         tabs: [{ slot: 'react-native', label: 'React Native' }],
     },

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -197,11 +197,18 @@ const WINDOWS = [
     {
         id: 'frameworks',
         // `@gjsify/react-native` renders React Native components onto GTK 4
-        // IN-PROCESS. There is no Adwaita widget set built out of React Native
-        // primitives, so nothing under this window runs on a phone — which is why
+        // IN-PROCESS, so nothing under this window runs on a phone — which is why
         // it is not filed with NativeScript, and why `layout.mdx`, the only page
         // that fills this window, says it renders a GTK window and not a phone
         // screen.
+        //
+        // This comment used to give a different reason — "there is no Adwaita
+        // widget set built out of React Native primitives" — and that reason died
+        // with `@gjsify/adwaita-react-native` (#1380), which is exactly such a set.
+        // The decision survives it, because it never rested on that package's
+        // absence: what fills this window is direction A, and a direction-B package
+        // existing elsewhere in the tree does not put a phone on this page. It
+        // would take a TAB that renders one.
         title: 'UI frameworks',
         tabs: [{ slot: 'react-native', label: 'React Native' }],
     },

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -264,17 +264,22 @@ otherwise.
 
 That is the distinction worth keeping, and it is a direction rather than a boundary: this layer
 takes React Native's *components* to GTK. The opposite direction — Adwaita's *components* rebuilt
-on React Native's primitives, so an Adwaita app could run on iOS and Android — is a different
-piece of software, and it is now written:
-[`@gjsify/adwaita-react-native`](https://github.com/gjsify/gjsify/blob/main/packages/framework/adwaita-react-native/README.md).
+on React Native's primitives — has been **started**, as
+[`@gjsify/adwaita-react-native`](https://github.com/gjsify/gjsify/blob/main/packages/framework/adwaita-react-native/README.md),
+and it is a walking skeleton rather than a way to run an Adwaita app on a phone.
 
-It is deliberately small, and the honest word for it is a walking skeleton: **two widgets**,
-`AdwBin` and `AdwClamp`, carrying the whole vertical rather than a widget set — both platform
-halves, the resolution mechanism, the manifest declaration, a gate and suites on each side. The
-phone half is not a `maxWidth` approximation: it runs `@gjsify/adwaita-core`'s port of
-`adw_clamp_layout_allocate`, libadwaita's own easing curve, so both halves are held to the same
-numbers. The two halves fork at the package's `exports` map on the `react-native` condition,
-never by file name.
+**Two widgets**, `AdwBin` and `AdwClamp`, carrying the whole vertical rather than a widget set —
+both platform halves, the resolution mechanism, the manifest declaration, a gate and suites on
+each side. The halves fork at the package's `exports` map on the `react-native` condition, never
+by file name.
+
+What it is honest about is more useful than what it claims. The phone half is not a `maxWidth`
+approximation — it runs `@gjsify/adwaita-core`'s port of `adw_clamp_layout_allocate`, libadwaita's
+own easing curve — but it **has never run on a device**: its numbers are asserted as instructions,
+not measured as pixels, because there is no Yoga and no phone in the loop. And three divergences
+are named in its README rather than smoothed over, the first of them on the very widget above:
+React Native has no measure pass, so `AdwClamp` passes the child's intrinsic minimum as `0`, and a
+child wider than the clamp is compressed there where GTK would widen the clamp instead.
 
 It is not on npm yet, and no gallery tab renders it — so nothing you see on this site is that
 package.

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -257,14 +257,27 @@ header bar and the toolbar view, and not on the wrap box, whose policy is still 
 
 ### What this is not
 
-**There is no Adwaita widget set built out of React Native primitives.** Not in this repository:
-no package, no export, no component. `<adw-toolbar-view>` above is `Adw.ToolbarView` — a GTK 4
-widget, in a GTK 4 window, on a machine where libadwaita is installed. Nothing on this page runs
-on a phone, and no tab in the gallery claims otherwise.
+**This layer does not put Adwaita on a phone.** `<adw-toolbar-view>` above is
+`Adw.ToolbarView` — a GTK 4 widget, in a GTK 4 window, on a machine where libadwaita is
+installed. Nothing on this page runs on Android or iOS, and no tab in the gallery claims
+otherwise.
 
-That is the distinction worth keeping: this layer takes React Native's *components* to GTK. The
-opposite direction — Adwaita's *components*, rebuilt on React Native's primitives, so an Adwaita
-app could run on iOS and Android — is a different piece of software, and it is not written.
+That is the distinction worth keeping, and it is a direction rather than a boundary: this layer
+takes React Native's *components* to GTK. The opposite direction — Adwaita's *components* rebuilt
+on React Native's primitives, so an Adwaita app could run on iOS and Android — is a different
+piece of software, and it is now written:
+[`@gjsify/adwaita-react-native`](https://github.com/gjsify/gjsify/blob/main/packages/framework/adwaita-react-native/README.md).
+
+It is deliberately small, and the honest word for it is a walking skeleton: **two widgets**,
+`AdwBin` and `AdwClamp`, carrying the whole vertical rather than a widget set — both platform
+halves, the resolution mechanism, the manifest declaration, a gate and suites on each side. The
+phone half is not a `maxWidth` approximation: it runs `@gjsify/adwaita-core`'s port of
+`adw_clamp_layout_allocate`, libadwaita's own easing curve, so both halves are held to the same
+numbers. The two halves fork at the package's `exports` map on the `react-native` condition,
+never by file name.
+
+It is not on npm yet, and no gallery tab renders it — so nothing you see on this site is that
+package.
 
 ## Two defaults that are inverted
 


### PR DESCRIPTION
Reported from the rendered page: the **"What this is not"** section of `frameworks/react-native.mdx` is no longer true.

## The claim, and when it died

> **There is no Adwaita widget set built out of React Native primitives.** Not in this repository: no package, no export, no component. […] The opposite direction […] is a different piece of software, and it is not written.

#1380 wrote it. `packages/framework/adwaita-react-native` is in the tree at `0.44.0`, not private, with `AdwBin` and `AdwClamp`, a `.gtk` and a `.native` implementation of each, a platform-split gate and suites on both sides.

## What replaces it, and what it deliberately does not promise

The distinction stays — it is the point of the section and it is still correct: this layer takes React Native's *components* to GTK; direction B takes Adwaita's *components* toward a phone. Only the non-existence claim goes.

A first draft of this PR then over-corrected, and review caught it. It said the opposite direction was written **"so an Adwaita app could run on iOS and Android"**, and that both halves are **"held to the same numbers"**. The package's own ledger refutes both:

- `status/status.json` — *"No Yoga and no device: the React Native half is type-checked and tree-checked and **has never run on a phone**, so `width: 400` is asserted as an instruction, never as a measured pixel."*
- the README carries **three named divergences**, the first on the very widget this page shows: React Native has no measure pass, so `AdwClamp` passes the child's intrinsic minimum as `0`, and **a child wider than the clamp is compressed there where GTK widens the clamp instead**.

The text now says *started*, names the two widgets, says it has never run on a device, and names that divergence — before the reader reaches anything that sounds like a capability. It also keeps the two facts that make the surrounding page's claims about the gallery true: not on npm, and no gallery tab renders it.

## The other two copies

The same sentence lived twice more in `website/src/components/AdwWidget.astro`, and both were load-bearing prose rather than decoration:

- **`:36-41`, the file header** — *"the one claim this repository must not make about code it has not written"*. Missed by this PR's first sweep, found by review, 165 lines above the edit in the same file.
- **`:199-211`, the `WINDOWS` entry** — the reason why the frameworks window is not filed under NativeScript.

The decision in the second survives its reason, but **not** in the way the first draft claimed. It said the comment "never rested on that package's absence"; the sentence it replaced reads *"there is no Adwaita widget set … **so** nothing under this window runs on a phone"*, and the `so` makes the absence the premise. What survives is the **conclusion**, on other grounds: what fills this window is direction A, and a direction-B package elsewhere in the tree does not put a phone on this page — it would take a *tab* that renders one. Both comments now name which reason died, so the next reader does not restore it as a simplification.

Swept the rest of the tree for further copies (`Adwaita widget set`, `rebuilt on React Native`, `opposite direction`): the remaining hits are about `@gjsify/adwaita-web` and `@gjsify/adwaita-nativescript` and are correct. ADR 0032 § *What this does not decide* was checked and is **not** stale — its "second dialect measured" is about the framework-neutral L2 primitive vocabulary, not about an Adwaita widget set.

## Checks

`check-doc-fences`, `check-website-package-names` (the new `@gjsify/adwaita-react-native` mention resolves), `check-doc-revert` — green locally. `.astro` is not a `CODE_SOURCE_EXTENSION`, so the added comment lines do not touch `status/comment-budget.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB