### PR TITLE
fix(gtk-host): the echo guard asked the wrong question

### DIFF
--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -384,8 +384,18 @@ export default async () => {
                 setProp(label, 'label', 'hello');
                 setProp(label, 'xalign', 0.25);
                 expect(widget.label).toBe('hello');
-                // Every property write reaches it, which is what `notify` means —
-                // and a `notify::`-shaped prop still selects exactly one.
+                // The host's OWN writes are an echo and stay silent — plain `notify`
+                // included. It did not, before the guard covered every signal rather
+                // than only the `notify::`-shaped ones, and the inconsistency was
+                // real: `onNotifyLabel` was suppressed on this write while `onNotify`
+                // re-entered on the same one.
+                expect(seen).toStrictEqual([]);
+                // The claim of this test is ROUTING, so it is observed the way routing
+                // has to be — from a write the host did not make. Every property
+                // reaches `notify`, which is what the bare signal means, and a
+                // `notify::`-shaped prop still selects exactly one.
+                widget.set_property('label', 'written by someone else');
+                widget.set_property('xalign', 0.75);
                 expect(seen.includes('label')).toBe(true);
                 expect(seen.includes('xalign')).toBe(true);
                 expect(label.handlers.has('notify')).toBe(true);
@@ -432,6 +442,69 @@ export default async () => {
                 // anywhere in the process would silence every notify::, greenly.
                 (label.widget as unknown as Gtk.Label).set_property('label', 'written by someone else');
                 expect(notified).toBe(1);
+            });
+
+            await it('does not report a NON-notify signal raised by our own write', async () => {
+                // The defect the widened guard closes, and the reason a consumer
+                // worked around it. MEASURED on gjs 1.88.1 / GTK 4.22.4:
+                // `gtk_editable_set_text` is delete-then-insert, so ONE host write
+                // over existing text emits `changed` TWICE — `["", "xyz"]`. A
+                // controlled input reads that empty string as the user clearing the
+                // field, which is why `@gjsify/react-native` binds `notify::text`
+                // rather than the signal that actually means "the text changed".
+                const entry = createElement('GtkEntry');
+                const widget = materialize(entry) as unknown as Gtk.Entry;
+                const seen: string[] = [];
+                // The emitter is NOT a parameter here: the host hands the callback
+                // `args.slice(1)`, so a DOM-shaped handler sees the signal's own
+                // arguments and nothing else. `changed` carries none, so the text is
+                // read from the widget. Getting this wrong throws INSIDE a GJS signal
+                // callback, where the throw is logged and swallowed — the array simply
+                // stays empty, which reads exactly like a guard that suppresses too
+                // much.
+                setEventHandler(entry, 'on:changed', () => {
+                    seen.push(widget.get_text());
+                });
+                setProp(entry, 'text', 'abc');
+                setProp(entry, 'text', 'xyz');
+                expect(seen).toStrictEqual([]);
+                expect(widget.get_text()).toBe('xyz'); // the write LANDED; only the echo is gone
+                // The positive control, and it has to be the path a KEYSTROKE takes:
+                // asserting only that our write is silent would pass just as well if
+                // the handler were never connected at all.
+                widget.get_buffer().insert_text(3, '!', 1);
+                expect(seen).toStrictEqual(['xyz!']);
+            });
+
+            await it('does not report an echo our write raised on ANOTHER object', async () => {
+                // Why the guard is a module-wide counter and not
+                // `g_signal_handler_block()` on the widget being written. MEASURED:
+                // writing `active` on one grouped `Gtk.CheckButton` makes the OTHER
+                // emit `notify::active` AND `toggled`. Blocking reaches only the
+                // object in hand, so it would leave this one re-entering.
+                const a = createElement('GtkCheckButton');
+                const b = createElement('GtkCheckButton');
+                materialize(a);
+                materialize(b);
+                // GTK state, not a host path: `group` is how the two become exclusive.
+                (b.widget as unknown as Gtk.CheckButton).set_group(a.widget as unknown as Gtk.CheckButton);
+                setProp(b, 'active', true);
+
+                let echoed = 0;
+                setEventHandler(b, 'onNotifyActive', () => {
+                    echoed += 1;
+                });
+                setEventHandler(b, 'onToggled', () => {
+                    echoed += 1;
+                });
+                setProp(a, 'active', true);
+                expect((b.widget as unknown as Gtk.CheckButton).get_active()).toBe(false);
+                expect(echoed).toBe(0);
+                // Positive control on the same pair: a change B did not get from us
+                // still reaches both handlers.
+                (a.widget as unknown as Gtk.CheckButton).set_active(false);
+                (b.widget as unknown as Gtk.CheckButton).set_active(true);
+                expect(echoed).toBe(2);
             });
 
             await it('refuses two props that resolve to one signal', async () => {

--- a/packages/framework/gtk-host/src/signals.ts
+++ b/packages/framework/gtk-host/src/signals.ts
@@ -90,9 +90,19 @@ export function isEventProp(prop: string): boolean {
 /**
  * Depth of property writes this host is currently performing.
  *
- * GObject emits `notify::` for our own writes, so a component that binds
- * `onNotifyText` and writes `text` in the handler re-enters itself. The counter
- * is module-wide because a nested write on a DIFFERENT object is still our write.
+ * GObject emits for our own writes, so a component that binds `onNotifyText` and
+ * writes `text` in the handler re-enters itself. The counter is module-wide
+ * because a nested write on a DIFFERENT object is still our write — and that is
+ * measured, not assumed: on gjs 1.88.1 / GTK 4.22.4, writing `active` on one
+ * grouped `Gtk.CheckButton` makes the OTHER one emit `notify::active` AND
+ * `toggled`, on an object the writer never touched.
+ *
+ * That measurement is also why this is a counter and not
+ * `g_signal_handler_block()` on the widget being written. Blocking is exact and
+ * leaves foreign handlers alone, which is attractive; it is also strictly weaker,
+ * because it can only reach handlers on the ONE object in hand, and the grouped
+ * check button above is a handler of ours on another. Both were measured before
+ * this comment was written.
  */
 let writeDepth = 0;
 export const beginHostWrite = () => {
@@ -124,12 +134,33 @@ export function setHandler(el: HostElement, prop: string, next: ((...args: unkno
     }
     if (!next) return;
 
-    const isNotify = signal.startsWith('notify::');
     const id = target.connect(signal, (...args: unknown[]) => {
-        // A `notify::` raised by our own patch is not a user event — and it must
+        // An emission raised by our own patch is not a user event — and it must
         // not spend a `.once` either, or the one emission the user asked for is
         // consumed by our own property write.
-        if (isNotify && inHostWrite()) return undefined;
+        //
+        // This used to read `isNotify && inHostWrite()`, and the narrowing was the
+        // defect: `notify::` is not the only signal a property write raises.
+        // MEASURED on gjs 1.88.1 / GTK 4.22.4 — `gtk_editable_set_text` is
+        // delete-then-insert, so ONE write over existing text emits
+        // `Gtk.Editable::changed` TWICE, carrying `["", "abc"]`. A controlled input
+        // reads that intermediate empty string as the user clearing the field, so
+        // the workaround was to bind `notify::text` instead of the signal that
+        // actually means "the text changed". `Gtk.ToggleButton::toggled` re-entered
+        // the same way. Both are covered now, because the guard asks who is
+        // WRITING rather than which signal arrived.
+        //
+        // The window is exactly one constructor call or one property write (the
+        // four `beginHostWrite` sites in `host.ts`) — child insertion is outside
+        // it — so nothing that a user could have caused is inside. One hazard to
+        // keep in view if the table grows: a handler the HOST installs on an
+        // object whose signals fire from inside a write would now be suppressed.
+        // `Gtk.SignalListItemFactory` is the near miss — its `setup`/`bind` do
+        // fire from inside a write — and it is safe today for a reason worth
+        // stating rather than rediscovering: it is not a curated element, and
+        // `@gjsify/react-native`'s list controller connects to it DIRECTLY, so
+        // those handlers never pass through here. Curating it would change that.
+        if (inHostWrite()) return undefined;
         if (once) {
             // Disconnect BEFORE calling: a callback that re-enters its own widget
             // would otherwise fire a second time, which is the whole point of


### PR DESCRIPTION
`signals.ts:132` read `if (isNotify && inHostWrite()) return undefined;`. The `isNotify` is the defect: a signal raised by the host's **own** property write was suppressed only when its name started with `notify::`. Every other signal a write raises re-entered the component that bound it.

## Measured, on gjs 1.88.1 / GTK 4.22.4

| what | result |
|---|---|
| host write over existing text, `on:changed` bound | `["", "xyz"]` — **two** emissions, the first an empty string |
| same, `Gtk.ToggleButton::toggled` | re-enters |
| host write, `onNotifyLabel` bound | silent (old guard covered it) |
| host write, plain `onNotify` bound | **fired** — the old guard did not cover the bare `notify` signal |

`gtk_editable_set_text` is delete-then-insert, which is where the `["", "xyz"]` comes from — and a controlled input reads that intermediate empty string as *the user clearing the field*. That is precisely why `@gjsify/react-native` binds `notify::text` rather than the signal that actually means "the text changed" (`primitives.spec.ts:544` pins the choice with the measurement). The last row is the one I did not expect: the old narrowing was not even self-consistent, so `onNotify` and `onNotifyLabel` disagreed about the same write.

The fix is **one condition fewer**. The guard now asks who is *writing* rather than which signal arrived.

## Handler blocking was the other candidate, and it is rejected on a measurement

`g_signal_handler_block()` on the widget being written is exact, counted, and leaves foreign handlers alone — all verified here. It is also **strictly weaker**, because it reaches only the object in hand:

```
two grouped Gtk.CheckButtons, write `active` on A with A's handler blocked
  -> A notified 0x, B notified 1x   (notify::active AND toggled, on B)
```

That is a handler of ours on an object the writer never touched. The module-wide counter already covers it; blocking would have been a regression. Both mechanisms were measured before this was decided.

## The near miss, recorded so it is not rediscovered

`Gtk.SignalListItemFactory::setup`/`bind` **do** fire from inside a host write — the rows bind the moment the view is rooted. They are unaffected here for a reason worth stating rather than assuming: the factory is **not a curated element**, and `@gjsify/react-native`'s list controller connects to it *directly*, so those handlers never pass through `setHandler`. Curating `GtkListItem` — which the list work would do — changes that, and the comment in the code says so.

The window is also narrow: exactly one constructor call or one property write (the four `beginHostWrite` sites in `host.ts`). Child insertion is outside it.

## Tests

Two vectors, **each with a positive control**, because "our write is silent" passes just as well when the handler was never connected at all:

- same-object, non-`notify` — `on:changed` on a `GtkEntry`; two host writes are silent, then a **buffer insert**, the path a keystroke takes, arrives once with the right value;
- cross-object — grouped `GtkCheckButton`s; a host write on A is silent on B, then a change B did not get from us reaches both handlers.

The existing routing test (`onNotify` binds `notify`, not `notify::`) observed its claim *through a host write*, which is now silent. Its claim is about **routing**, so it now observes a foreign write — the only honest way to observe routing once the host's own writes are quiet. Its assertion about the guard is added rather than removed.

One thing this PR paid for and is worth carrying: getting a handler signature wrong throws **inside** a GJS signal callback, where the throw is logged and swallowed, so the array simply stays empty — which reads exactly like a guard that suppresses too much. The host hands the callback `args.slice(1)`, so the emitter is not a parameter. The test comment says so.

## Follow-up this unblocks (not in this PR)

`@gjsify/react-native` can move `onChangeText` from `notify::text` to `Gtk.Editable::changed`, the semantically correct signal, and get one emission per user edit. It needs its own measurement round, and `primitives.spec.ts` pins the current choice deliberately.

## Verification

Fresh CLI (0.44.0 — the copied bundle was 0.42.0 and would have built a different tree):

- `gjsify workspace @gjsify/gtk-host test` — **2104 tests from 13 gates, 0 failures**
- `gjsify workspace @gjsify/gtk-host check` — clean
- `gjsify workspace @gjsify/react-native test` — **442 tests from 5 gates, 0 failures**
- `gjsify format` + `gjsify lint` on both files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB