### PR TITLE
feat(website): the framework tabs the data was waiting for

### DIFF
--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -110,6 +110,11 @@ interface Props {
 }
 
 import { ADWAITA_ATTRIBUTES } from '../data/adwaita-attributes';
+import {
+    ADWAITA_FRAMEWORK_REFUSALS,
+    ADWAITA_FRAMEWORK_SNIPPETS,
+    type FrameworkDialect,
+} from '../data/adwaita-framework-snippets';
 import { sampleAttributes } from './attr-sample.mjs';
 import AdwWidgetWindow from './AdwWidgetWindow.astro';
 
@@ -162,6 +167,30 @@ const elementTag = `adw-${title
 const attributes = ADWAITA_ATTRIBUTES[elementTag] ?? null;
 
 /**
+ * The framework panes: Solid, Vue and React, rendered from
+ * `data/adwaita-framework-snippets.ts` rather than written per page.
+ *
+ * Not slots, for the same reason the attribute table is not one — no page provides
+ * them and no page should, because the snippet a page would carry is a COPY. Each
+ * one here was compiled and run first: `showcases/gtk/adwaita-gallery-{solid,vue,react}`
+ * build this exact markup and assert the resulting widget tree against GTK with the
+ * diagnostics gate on, and `scripts/generate-adwaita-framework-snippets.mjs` extracts
+ * them from those programs. That data file has existed and been gated since it landed;
+ * until this component read it, nothing rendered it — 40 blocks' worth of generated,
+ * checked, invisible snippets.
+ *
+ * The order is the data file's own, and it puts the three host adapters together:
+ * they are one element model (`@gjsify/gtk-host`) behind three renderer APIs. The
+ * React Native tab beside them is a different layer and stays a slot, because it is
+ * written per page against what that page shows.
+ */
+const FRAMEWORK_PANES: readonly { id: FrameworkDialect; label: string; lang: string }[] = [
+    { id: 'solid', label: 'Solid', lang: 'tsx' },
+    { id: 'vue', label: 'Vue', lang: 'vue' },
+    { id: 'react', label: 'React', lang: 'tsx' },
+];
+
+/**
  * The windows, in order, and every port this component renders.
  *
  * A window says what KIND it is in its TITLE, and nothing else: the claims that
@@ -183,12 +212,17 @@ const WINDOWS = [
         tabs: [{ slot: 'preview', label: 'HTML' }],
     },
     {
-        id: 'vanilla',
+        id: 'native',
         // Titled for the AXIS its two tabs share. The four runtimes that axis is
         // about are named by every gallery page's intro, not here: the snippet is
         // plain `@girs/*` GObject-Introspection TypeScript, which is exactly the
         // code that runs unchanged on all four of them.
-        title: 'Vanilla TypeScript',
+        //
+        // NATIVE, not "Vanilla". Vanilla names a thing by what it is not — no
+        // framework — which was serviceable while the neighbouring window held one
+        // tab, and stopped being so once it held four. What this window actually
+        // shows is the GObject API itself, with no element model in between.
+        title: 'Native TypeScript',
         tabs: [
             { slot: 'gjs', label: 'TypeScript' },
             // Blueprint is a FILE of the same program, which is why it is a tab here
@@ -216,6 +250,13 @@ const WINDOWS = [
         // a phone on this page. It would take a TAB that renders one.
         title: 'UI frameworks',
         tabs: [{ slot: 'react-native', label: 'React Native' }],
+        // The Solid, Vue and React panes are DATA, filled from
+        // `ADWAITA_FRAMEWORK_SNIPPETS` for the 21 blocks that have an entry. The other
+        // 19 carry a recorded reason instead — see {@link FRAMEWORK_PANES} and
+        // {@link REFUSAL_PANE}. 21 + 19 is every block, which is the property that
+        // makes an empty frameworks window a bug rather than a gap.
+        code: FRAMEWORK_PANES,
+        refusals: true,
     },
     {
         id: 'nativescript',
@@ -288,6 +329,19 @@ const LIVE_PANE = 'live';
  */
 const ATTRS_PANE = 'attributes';
 
+/**
+ * The pane that says why a block has NO framework snippet.
+ *
+ * `ADWAITA_FRAMEWORK_REFUSALS` exists for this and says so in its own header: "a
+ * missing tab and a tab that cannot exist look identical, and only one of them is a
+ * fact". Nineteen of the forty blocks are the second kind — a `Gio.MenuModel` built
+ * imperatively, a dialog opened with `present()`, a container with no child policy —
+ * and rendering nothing there teaches a reader that the dialects are half-finished
+ * rather than that the widget is not markup.
+ */
+const REFUSAL_PANE = 'why-not';
+
+
 // That requirement, held rather than stated. `data-impls` is POSITIONAL and the
 // script below looks a pane up by name with `indexOf`, so a pane id equal to a
 // slot name gives the live window two entries reading the same id and the first one
@@ -295,7 +349,7 @@ const ATTRS_PANE = 'attributes';
 // it would move every OTHER preview window to its Preview pane instead. Nothing
 // else notices — the ids never leave `data-impls`, so the site builds, both tabs
 // render, and every gate stays green.
-const OWN_PANES = [LIVE_PANE, ATTRS_PANE];
+const OWN_PANES = [LIVE_PANE, ATTRS_PANE, REFUSAL_PANE, ...FRAMEWORK_PANES.map((pane) => pane.id)];
 const collidingSlot = WINDOWS.flatMap((win) => win.tabs.map((tab) => tab.slot)).find((slot) =>
     OWN_PANES.includes(slot),
 );
@@ -314,6 +368,8 @@ const rendered: {
     attributes: { tag: string; names: string[]; sample: Map<string, string> } | null;
     impls: string;
     tabs: { slot: string; label: string; html: string }[];
+    code: { id: string; label: string; lang: string; source: string }[];
+    refusal: string | null;
 }[] = [];
 let previewMarkup: string | null = null;
 
@@ -348,7 +404,27 @@ for (const spec of WINDOWS) {
         }
         tabs.push({ ...tab, html });
     }
-    if (tabs.length === 0) continue;
+    // The data panes, looked up by the block's own title — the same key the
+    // generator wrote. A block with no entry simply has none; a block whose entry
+    // is missing a dialect shows the dialects it has, because a pane rendering an
+    // empty fence is worse than an absent one.
+    const code = (spec.code ?? [])
+        .map((pane) => ({ ...pane, source: ADWAITA_FRAMEWORK_SNIPPETS[title]?.[pane.id] ?? '' }))
+        .filter((pane) => pane.source !== '');
+
+    // Both halves, because a window can now be entirely data: the frameworks window
+    // fills on 40 blocks while only 3 of them provide its slot. Testing `tabs` alone
+    // is what kept it invisible.
+    // A block with no snippet gets the RECORDED REASON, never silence. The two maps
+    // partition the gallery, so exactly one of `code` and `refusal` is non-empty on
+    // the frameworks window — and a block in NEITHER map leaves the window absent,
+    // which `check-generated-website-data.mjs` is what refuses.
+    const refusal = spec.refusals === true && code.length === 0 ? (ADWAITA_FRAMEWORK_REFUSALS[title] ?? null) : null;
+
+    // All three, because a window can now be entirely data: the frameworks window
+    // fills on all 40 blocks while only 3 of them provide its slot. Testing `tabs`
+    // alone is what kept it invisible.
+    if (tabs.length === 0 && code.length === 0 && refusal === null) continue;
     // `previewMarkup` is already read by the time this runs: the live window is
     // first in WINDOWS and its own `preview` tab is what sets it.
     const live = spec.live === true && previewMarkup !== null;
@@ -373,9 +449,13 @@ for (const spec of WINDOWS) {
         impls: [
             ...(live ? [LIVE_PANE] : []),
             ...tabs.map((t) => t.slot),
+            ...code.map((c) => c.id),
+            ...(refusal === null ? [] : [REFUSAL_PANE]),
             ...(attrs === null ? [] : [ATTRS_PANE]),
         ].join(','),
         tabs,
+        code,
+        refusal,
     });
 }
 ---
@@ -391,6 +471,8 @@ for (const spec of WINDOWS) {
                 widget={title}
                 impls={win.impls}
                 tabs={win.tabs}
+                code={win.code}
+                refusal={win.refusal}
                 preview={win.live ? previewMarkup : null}
                 padding={padding}
                 scroll={scroll}

--- a/website/src/components/AdwWidgetRefusal.astro
+++ b/website/src/components/AdwWidgetRefusal.astro
@@ -1,0 +1,47 @@
+---
+/**
+ * Why a gallery block has no Solid, Vue or React snippet.
+ *
+ * Its own component because it renders in TWO places in `AdwWidgetWindow` — as a tab
+ * page beside other panes, and as the whole window when it is the only pane, which is
+ * the ordinary case for the 19 blocks that carry a reason instead of a snippet. Two
+ * copies of this prose is exactly the drift the gallery keeps paying for elsewhere.
+ */
+interface Props {
+    /** The block's title, e.g. `Gtk.DropDown`. */
+    widget: string;
+    /** The recorded reason, from `ADWAITA_FRAMEWORK_REFUSALS`. */
+    reason: string;
+}
+
+const { widget, reason } = Astro.props;
+---
+
+<div class="adw-widget-refusal not-content">
+    <p>
+        No Solid, Vue or React snippet for <code>{widget}</code>: {reason}
+    </p>
+    <p>
+        Every snippet in this gallery was compiled and run before it was written down. Where a widget is built
+        imperatively rather than declared — a <code>Gio.MenuModel</code>, a dialog opened with <code>present()</code>,
+        a container with no child policy — there is nothing for the three dialects to differ about, so the reason is
+        recorded here rather than the tab being quietly absent.
+    </p>
+</div>
+
+<style>
+    .adw-widget-refusal {
+        padding: 1rem 1.25rem;
+    }
+
+    .adw-widget-refusal p {
+        margin: 0 0 0.75rem;
+        color: var(--sl-color-gray-2);
+        font-size: var(--sl-text-sm);
+        line-height: 1.6;
+    }
+
+    .adw-widget-refusal p:last-child {
+        margin-bottom: 0;
+    }
+</style>

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -36,6 +36,9 @@
 // Whatever the original failure was, it is not this rule — and a rule with a wrong
 // reason is thrown out together with its reason the first time someone checks it.
 
+import { Code } from '@astrojs/starlight/components';
+
+import AdwWidgetRefusal from './AdwWidgetRefusal.astro';
 import { attributeCells } from './attr-sample.mjs';
 
 interface Props {
@@ -49,6 +52,28 @@ interface Props {
     impls: string;
     /** One tab per port this block filled: the Adw.TabBar label and the rendered snippet. */
     tabs: { label: string; html: string }[];
+    /**
+     * Panes rendered from DATA rather than from a page's slot — the Solid, Vue and
+     * React snippets, which are generated from three running showcases.
+     *
+     * They carry SOURCE and not HTML, unlike {@link tabs}, because a page's slot has
+     * already been through Expressive Code by the time this component sees it and a
+     * data pane has not. Starlight's `<Code>` is that same renderer, so the two kinds
+     * of pane look identical to a reader — which is the point, and the reason this is
+     * not a `<pre>`.
+     */
+    code?: { id: string; label: string; lang: string; source: string }[];
+    /**
+     * Why this block has no framework snippet — rendered INSTEAD of {@link code},
+     * never beside it.
+     *
+     * Its own data file gives the reason: "a missing tab and a tab that cannot exist
+     * look identical, and only one of them is a fact". A `Gio.MenuModel` built
+     * imperatively is not markup in any dialect, and a reader who meets an absent
+     * window learns the wrong thing about the dialects instead of the right thing
+     * about the widget.
+     */
+    refusal?: string | null;
     /** The markup the first pane mounts, or null on a window that only shows code. */
     preview?: string | null;
     /** Padding around the preview widget — see AdwWidget. */
@@ -80,10 +105,13 @@ const {
     scroll = false,
     stage,
     attributes = null,
+    code = [],
+    refusal = null,
 } = Astro.props;
 
 /** The preview is a pane like any other, so it counts like one. And so is the attribute list. */
-const panes = tabs.length + (preview === null ? 0 : 1) + (attributes === null ? 0 : 1);
+const panes =
+    tabs.length + code.length + (refusal === null ? 0 : 1) + (preview === null ? 0 : 1) + (attributes === null ? 0 : 1);
 
 // NO PANES AT ALL is a header bar over nothing, and it renders exactly that way at
 // exit 0. `AdwWidget` is what prevents it — it skips a window none of whose tab
@@ -220,6 +248,21 @@ if (attributes !== null && preview === null) {
                 {tabs.map((tab) => (
                     <adw-tab-page title={tab.label} set:html={tab.html} />
                 ))}
+                {/* AFTER the slot tabs and BEFORE the attribute pane, because
+                    `data-impls` in AdwWidget is positional and lists them in exactly
+                    that order. The two have to be read together; a reader picking
+                    "Vue" would otherwise move every other window to a pane that is
+                    not its Vue one. */}
+                {code.map((pane) => (
+                    <adw-tab-page title={pane.label}>
+                        <Code code={pane.source} lang={pane.lang} />
+                    </adw-tab-page>
+                ))}
+                {refusal !== null && (
+                    <adw-tab-page title="Why not">
+                        <AdwWidgetRefusal widget={widget} reason={refusal} />
+                    </adw-tab-page>
+                )}
                 {attributes !== null && (
                     <adw-tab-page title="Attributes">
                         <div class="adw-widget-attrs not-content">
@@ -265,9 +308,19 @@ if (attributes !== null && preview === null) {
         )
     }
 
-    {
-        panes === 1 && (
-            <div class="adw-widget-window-pane" set:html={tabs[0].html} />
-        )
-    }
+    {/* The bare pane, with no tab bar over it. It used to read `tabs[0]` because
+        every pane was a slot; a window can now be one DATA pane — the frameworks
+        window on the 19 blocks that carry a reason instead of a snippet is exactly
+        that, and it is the ordinary case rather than an edge one. */}
+    {panes === 1 && tabs.length === 1 && <div class="adw-widget-window-pane" set:html={tabs[0].html} />}
+    {panes === 1 && code.length === 1 && (
+        <div class="adw-widget-window-pane">
+            <Code code={code[0].source} lang={code[0].lang} />
+        </div>
+    )}
+    {panes === 1 && refusal !== null && (
+        <div class="adw-widget-window-pane">
+            <AdwWidgetRefusal widget={widget} reason={refusal} />
+        </div>
+    )}
 </div>


### PR DESCRIPTION
Reported from the rendered gallery: the Drop Down block shows a web port, a "Vanilla TypeScript" window and a NativeScript window — and nothing about React, Vue or Solid.

## The data was already there. Nothing read it.

`website/src/data/adwaita-framework-snippets.ts` has held a **Solid, a Vue and a React snippet for every gallery block that can have one** since it landed. Generated from three running showcases (`showcases/gtk/adwaita-gallery-{solid,vue,react}`, which build this exact markup and assert the resulting widget tree against GTK with the diagnostics gate on), gated by `check-generated-website-data.mjs` — and read by **nothing**. Its own header says it is *"rendered by the component rather than written per page"*. No component rendered it.

Forty blocks' worth of generated, checked, invisible snippets. This PR is the reader.

## Coverage, measured on the built site

| | blocks |
|---|---|
| `data-impls="…solid,vue,react…"` | **21** |
| `data-impls="…why-not…"` | **19** |
| gallery blocks total | **40** |

The 19 are not a gap. `ADWAITA_FRAMEWORK_REFUSALS` records **why** each has no snippet, and its header asked for exactly this rendering:

> Exported so a page can say so rather than leaving a reader to wonder: a missing tab and a tab that cannot exist look identical, and only one of them is a fact.

A `Gio.MenuModel` built imperatively is not markup in any dialect; a dialog opened with `present()` renders nothing a reader would see. A reader who meets an absent window learns the wrong thing about the dialects instead of the right thing about the widget. **21 + 19 is every block**, so an empty frameworks window is now a bug rather than a gap.

## Why panes and not slots

Same reason the attribute table is not a slot: a snippet written per page is a *copy*, and this gallery has paid for that before. They render through Starlight's `<Code>` — the same Expressive Code renderer a page's own fence goes through — so a data pane and a slot pane are indistinguishable to a reader.

## `Vanilla TypeScript` → `Native TypeScript`

"Vanilla" names a thing by what it is *not*. That was serviceable while the window beside it held one tab; it stopped being so now that it holds four. What that window shows is the GObject API itself, with no element model in between.

## Two things this had to repair to work at all

- **`data-impls` is positional** and the cross-widget preference switcher looks a pane up by name. The new pane ids (`solid`, `vue`, `react`, `why-not`) join `OWN_PANES`, so the existing collision guard now refuses a future `slot="vue"` — which would otherwise give a window two entries reading the same id, silently, with every gate green.
- **The bare single-pane branch read `tabs[0]`**, which was safe while every pane was a slot. The 19 refusal windows are one *data* pane and nothing else, so it crashed on the first build. It now dispatches on which kind of pane it is. `AdwWidgetRefusal.astro` exists because that prose renders in two places, and two copies is the drift this gallery keeps paying for.

## Still open, and deliberately not faked here

**The NativeScript XML tab is filled on 4 blocks of 40.** The window declares it, `layout.mdx` provides it, and the other 36 blocks show only the TypeScript half. Hand-writing 36 templates would be exactly what this gallery forbids — every snippet in it was compiled and run first. The honest route is the one the Solid/Vue/React snippets already took: a running showcase plus a generator. Filed as follow-up rather than guessed at.

## Verification

- `gjsify workspace @gjsify/website build` — **62 pages**, exit 0
- Counted on the built HTML, not on the source: 21 / 19 / 40 as above
- `check-website-adwaita-gallery`, `check-generated-website-data`, `check-doc-fences`, `check-website-package-names`, `check-website-preview-not-content`, `check-doc-revert` — all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB