### PR TITLE
feat(cli): let onboard select @girs/* via --include

### DIFF
--- a/packages/infra/cli/src/commands/onboard.ts
+++ b/packages/infra/cli/src/commands/onboard.ts
@@ -10,7 +10,14 @@
 //   1. Auth gate — `whoami` first. If the token is live, proceed without asking
 //      for credentials; only when it is dead/missing do we run the `gjsify
 //      login` flow (unless `--yes` on a non-TTY, which fails clearly).
-//   2. Enumerate publishable workspaces (non-private, excluding `@girs/*`).
+//   2. Enumerate publishable workspaces (non-private). `@girs/*` is excluded
+//      by DEFAULT, not by rule: in this repo those are third-party type
+//      packages nobody here publishes. `--include '@girs/*'` selects them,
+//      which is what ts-for-gir needs — its `@girs/*` workspaces ARE its
+//      publishables, a new GNOME cycle mints a dozen new npm names, and
+//      gjsify/types publishes them over OIDC, which cannot create a name that
+//      does not exist yet. The release script there names this command as the
+//      way to bootstrap them; until now the command could not select them.
 //   3. Determine each package's state (bounded concurrency) by reading npm's
 //      Trusted-Publisher config through the SAME requester path `gjsify trust`
 //      uses: unpublished (404) / published-but-untrusted / published-and-trusted.
@@ -47,6 +54,7 @@ import {
 import { DEFAULT_PROBE_CONCURRENCY, probeAllTrustStates, type PkgPlan } from '../utils/onboard-probe.js';
 
 interface OnboardOptions {
+    include?: string[];
     repository?: string;
     workflow: string;
     environment?: string;
@@ -72,6 +80,12 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         'Ensure every publishable @gjsify/* workspace is both published on npm and has a Trusted Publisher configured — publishing/trusting only what is missing, one shared OTP across the whole sweep. Idempotent.',
     builder: (yargs) =>
         yargs
+            .option('include', {
+                description:
+                    "Only onboard workspaces matching these name globs. Passing any pattern also lifts the default `@girs/*` exclusion, so `--include '@girs/*'` is how a ts-for-gir style repo bootstraps its generated type packages.",
+                type: 'array',
+                string: true,
+            })
             .option('repository', {
                 description: 'GitHub repo as `owner/repo`. Default: inferred from the `origin` git remote.',
                 type: 'string',
@@ -175,9 +189,19 @@ export const onboardCommand: Command<unknown, OnboardOptions> = {
         // merge the sweep reports "all done" while a package that was never
         // published is simply absent from the list.
         const all = mergePublishables(discoverWorkspaces(root, { includeRoot: true }), cwd);
-        const selected = filterWorkspaces(all, { noPrivate: true, exclude: ['@girs/*'] }).filter((ws) => ws.name);
+        // `@girs/*` is excluded by default because in THIS repo they are
+        // third-party dependencies. An explicit `--include` means the caller
+        // knows which packages are theirs, so the default no longer applies —
+        // otherwise `--include '@girs/*'` would silently select nothing, which
+        // is the failure mode a bootstrap command can least afford.
+        const include = args.include?.filter((pattern) => pattern.length > 0);
+        const exclude = include && include.length > 0 ? undefined : ['@girs/*'];
+        const selected = filterWorkspaces(all, { noPrivate: true, include, exclude }).filter((ws) => ws.name);
         if (selected.length === 0) {
-            const msg = 'gjsify onboard: no publishable workspace packages found.';
+            const msg =
+                include && include.length > 0
+                    ? `gjsify onboard: no publishable workspace matches --include ${include.join(' ')}.`
+                    : 'gjsify onboard: no publishable workspace packages found.';
             if (asJson) process.stdout.write(`${JSON.stringify({ ok: false, error: 'no-packages', message: msg })}\n`);
             else console.error(msg);
             return process.exit(1);

--- a/tests/e2e/onboard/run.mjs
+++ b/tests/e2e/onboard/run.mjs
@@ -215,6 +215,22 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
         pkg('@onb/unpublished-a');
         pkg('@onb/unpublished-b');
         pkg('@onb/never-published-2xx');
+        // A `@girs/*` package: excluded by DEFAULT (in the gjsify monorepo those
+        // are third-party dependencies), selectable with `--include '@girs/*'`
+        // (in ts-for-gir they are the repo's own publishables, and a GNOME cycle
+        // mints a dozen new npm names that OIDC cannot create).
+        const girsDir = join(root, 'packages', 'girs-thing');
+        mkdirSync(girsDir, { recursive: true });
+        writeFileSync(
+            join(girsDir, 'package.json'),
+            JSON.stringify(
+                { name: '@girs/thing-1.0', version: '1.0.0', type: 'module', main: 'index.js', files: ['index.js'] },
+                null,
+                2,
+            ) + '\n',
+        );
+        writeFileSync(join(girsDir, 'index.js'), 'export const ok = true;\n');
+
         // A private package that must be EXCLUDED from the sweep.
         const privDir = join(root, 'packages', 'private-one');
         mkdirSync(privDir, { recursive: true });
@@ -238,6 +254,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             // The shape real npm produces and this suite never had: absent,
             // but the trust read answers `200 []` instead of `404`.
             '@onb/never-published-2xx': { published: false, trusted: false, emptyWhenAbsent: true },
+            '@girs/thing-1.0': { published: false, trusted: false },
         };
     }
 
@@ -380,6 +397,32 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
         }
     });
 
+    it("skips @girs/* by default, and --include '@girs/*' selects it", async () => {
+        // Both halves matter. Without the default exclusion the gjsify monorepo
+        // would try to publish its dependencies; without the override,
+        // `--include '@girs/*'` would match nothing and the sweep would report
+        // "no publishable workspace packages found" — a bootstrap command
+        // announcing its own gap as closed.
+        pkgState = freshState();
+        const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
+        try {
+            const plain = await runOnboard(root, npmrcPath, ['--dry-run']);
+            assert.equal(plain.code, 0);
+            assert.doesNotMatch(plain.stdout, /@girs\/thing-1\.0/, '@girs/* must be excluded by default');
+
+            const included = await runOnboard(root, npmrcPath, ['--dry-run', '--include', '@girs/*']);
+            assert.equal(included.code, 0);
+            assert.match(included.stdout, /@girs\/thing-1\.0/, "--include '@girs/*' must select it");
+            assert.doesNotMatch(
+                included.stdout,
+                /@onb\//,
+                'an explicit --include is a whitelist: nothing else may come along',
+            );
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
     it('gates login on whoami — a LIVE token does not trigger login', async () => {
         // All packages already done → no OTP, no publishing; just the auth gate.
         pkgState = {
@@ -388,6 +431,7 @@ describe('gjsify onboard E2E — mock npm registry', { timeout: 3 * 60 * 1000 },
             '@onb/unpublished-a': { published: true, trusted: true },
             '@onb/unpublished-b': { published: true, trusted: true },
             '@onb/never-published-2xx': { published: true, trusted: true },
+            '@girs/thing-1.0': { published: true, trusted: true },
         };
         const { root, npmrcPath } = scaffoldMonorepo(LIVE_TOKEN);
         try {


### PR DESCRIPTION
`gjsify onboard` hard-excluded `@girs/*`. In this repo that is right — those are third-party type packages nobody here publishes. In ts-for-gir it is exactly backwards: its `@girs/*` workspaces **are** its publishables, and `gjsify/types` releases them over OIDC.

## The gap

npm Trusted Publishing cannot create a package that does not exist yet, so a new `@girs/*` name needs a first publish before it can be trusted. The release script in `gjsify/types` says so in a comment, and names this command as the way to do it:

> the first publish of a new `@girs/*` namespace needs this or a prior `gjsify onboard` sweep

A documented path the command could not walk.

Not hypothetical: GNOME 51 realigned Mutter's API version with the GNOME major (18 → 51 in one step), so a single cycle mints `@girs/{clutter,cogl,meta,metatest,mtk,shell,st}-51` plus whatever new libraries the release carries. Thirteen names this time. Each unbootstrapped one fails its publish with a 404 that reads like a broken trusted publisher.

## The change

`--include` takes name globs. Passing **any** pattern also lifts the default `@girs/*` exclusion — otherwise `--include '@girs/*'` would select nothing and the sweep would report *"no publishable workspace packages found"*, a bootstrap command announcing its own gap as closed. An explicit `--include` is a whitelist, so nothing else comes along either.

The empty-selection message now names the filter, so a mistyped glob says what it did not match instead of claiming the repo has no packages.

## Test

One E2E test asserts **both** halves against the mock registry: `@girs/thing-1.0` absent from the default sweep, present under `--include '@girs/*'`, and no `@onb/*` alongside it. 7/7 pass.

```
✔ publishes + trusts only the missing packages, reusing ONE OTP; skips the done one
✔ is idempotent — a second run does nothing and exits 0
✔ --dry-run reports the plan and changes nothing
✔ skips @girs/* by default, and --include '@girs/*' selects it
✔ gates login on whoami — a LIVE token does not trigger login
✔ gates login on whoami — a DEAD token triggers the login flow, then proceeds
✔ --yes fails clearly when a dead token would need an interactive login
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ci5gmUojZSbm5JXkgwYKj