### PR TITLE
fix(website): the prose the window rename left behind

### DIFF
--- a/docs/adr/0033-declarative-templates-preferred.md
+++ b/docs/adr/0033-declarative-templates-preferred.md
@@ -64,7 +64,7 @@ this project refuses hand-maintained tables elsewhere.
 ## Consequences
 
 - Documentation examples show the template and its loader side by side, the way the
-  gallery's Vanilla TypeScript window already shows `.ts` beside `.blp`. Where a runtime
+  gallery's Native TypeScript window already shows `.ts` beside `.blp`. Where a runtime
   has a declarative form, the example uses it.
 - A reader comparing two runtimes compares two trees, not a tree against a script.
 - `Adw.init()` and the final-type constraint above become part of what an example has to

--- a/scripts/adwaita-gallery-trees.mjs
+++ b/scripts/adwaita-gallery-trees.mjs
@@ -513,8 +513,24 @@ export const ADWAITA_GALLERY_TREES = [
  */
 export const ADWAITA_GALLERY_REFUSALS = {
     // Measured by `showcases/gtk/adwaita-gallery-solid/src/refusals.ts`: the host
-    // raises `uncurated-placement` BY NAME when the child is materialised. 13 of 13,
-    // and the probe fails if any of them starts being accepted.
+    // raises `uncurated-placement` BY NAME when the child is materialised. Nine of
+    // them, which is every entry in this group, and the probe fails if any starts
+    // being accepted.
+    //
+    // COUNT THE GROUP, not the probe. This note read "13 of 13", and the probe has
+    // driven ELEVEN placements since it landed in #1376 — never thirteen. Two of the
+    // eleven are not entries here at all: a split view that raises `rejected-child`
+    // rather than `uncurated-placement`, and a `gtk-action-bar` that is no gallery
+    // block. Thirteen is the count from before two placements turned out to be
+    // ACCEPTED and left the list, restated beside a list that was already shorter —
+    // a number kept by hand next to the thing it counts.
+    //
+    // Nothing holds the two lists against each other, which is why neither the count
+    // nor a stale entry has a mechanism behind it. It is a plain-Node question: an
+    // `uncurated-placement` entry is one whose GType has no curated descriptor under
+    // `packages/framework/gtk-host/src/descriptors/`, and every placement the probe
+    // drives is either an entry here or ledgered in the probe with its own reason.
+    // That arm belongs beside the refusal arms of `check-generated-website-data.mjs`.
     'Adw.WrapBox': 'uncurated-placement: AdwWrapBox has no child policy.',
     'Adw.PreferencesDialog': 'uncurated-placement: a page cannot be a child of AdwPreferencesDialog.',
     'Adw.BottomSheet': 'uncurated-placement: no child policy for the sheet or the content.',

--- a/scripts/check-website-adwaita-gallery.mjs
+++ b/scripts/check-website-adwaita-gallery.mjs
@@ -58,6 +58,15 @@
 //      across the 40 blocks 17 were byte-identical and 23 had already diverged, with
 //      nothing checking either way. One policed copy, named and reasoned, is the price
 //      of the widget whose API is imperative; a second one has to say why.
+//  10. Every WINDOW a page draws is NAMED in that page's prose, and every window
+//      title the prose names is one that page draws. The window titles are the join
+//      between the chrome and the page: what a title cannot say — the four runtimes
+//      behind "Native TypeScript", the three dialects behind "UI frameworks" — the
+//      intro says instead, so the two are one explanation in two files. Renaming a
+//      window in the component alone left nine pages naming one that no longer
+//      exists, and growing the frameworks window from three blocks to forty left
+//      seven intros enumerating two windows where the reader meets three. Arms 1-9
+//      see neither: the strings never leave the prose.
 //   9. The LIVE PREVIEW is the FIRST pane of the window that runs the widget, in
 //      {@link WINDOW_COMPONENT} — the file that draws a window, which is where pane
 //      order is decided.
@@ -263,13 +272,45 @@ function componentWindows(root) {
         // [preamble, id, chunk, id, chunk, …].
         const parts = decl[1].split(/\bid:\s*'([a-z][a-z0-9-]*)',/);
         for (let i = 1; i < parts.length; i += 2) {
-            const slots = [...parts[i + 1].matchAll(/\bslot:\s*'([a-z][a-z0-9-]*)'/g)].map(([, s]) => s);
-            windows.push({ id: parts[i], slots });
+            const chunk = withoutComments(parts[i + 1]);
+            const slots = [...chunk.matchAll(/\bslot:\s*'([a-z][a-z0-9-]*)'/g)].map(([, s]) => s);
+            // The TITLE, read with the comments blanked out: every window's chunk is
+            // mostly prose, and the live window's own note names two other windows'
+            // titles inside it.
+            const title = /\btitle:\s*'([^']*)'/.exec(chunk);
+            // A window with DATA panes renders on every block, filled or refused —
+            // `code:` is the list of them. It is not conditional on a page: arm 4 of
+            // `check-generated-website-data.mjs` refuses a block that reaches neither
+            // the snippet map nor the refusal map, so the pane is always one or the
+            // other. That is what makes arm 10 able to decide, from the source alone,
+            // that such a window is on a page.
+            const data = /\bcode:\s*[A-Za-z_$]/.test(chunk);
+            windows.push({ id: parts[i], slots, title: title === null ? null : title[1], data });
         }
     }
     const override = /\bconst MARKUP_OVERRIDE = '([a-z][a-z0-9-]*)';/.exec(text);
     return { windows, override: override === null ? null : override[1] };
 }
+
+/**
+ * A gallery page's PROSE: no frontmatter, no fenced code.
+ *
+ * Arm 10 asks whether a page NAMES a window, and every gallery page carries fenced
+ * NativeScript and GJS snippets that say "NativeScript" and "TypeScript" inside them.
+ * Read unmasked, a page would satisfy the arm with a code sample — the same
+ * source-text-read failure arm 9 blanks comments for.
+ *
+ * Whitespace is COLLAPSED, because these files are hard-wrapped and Markdown reads a
+ * line break as a space: "**UI\nframeworks**" is one phrase to every reader and two
+ * to a naive `includes`. Measured while writing this — the arm's first run failed on
+ * a page that named the window correctly, wrapped.
+ */
+const pageProse = (text) =>
+    text
+        .replace(/^---\n[\s\S]*?\n---\n/, '')
+        .replaceAll(/```[\s\S]*?```/g, '')
+        .replaceAll(/`[^`\n]*`/g, '')
+        .replaceAll(/\s+/g, ' ');
 
 /** Where the site's navigation is hand-written, and how a page is spelled in it. */
 const SIDEBAR = 'website/astro.config.mjs';
@@ -489,6 +530,85 @@ if (panePosition !== null) {
             '    widget the reader has not seen yet, and nothing else here would notice: both tabs still\n' +
             '    render and the fence is still authored once.',
     );
+}
+
+// --- arm 10: a window a page SHOWS is a window the page's prose NAMES ---
+
+/**
+ * The window titles a page renders, and the ones its prose enumerates, held against
+ * each other in both directions.
+ *
+ * THE INCIDENT. `Vanilla TypeScript` was renamed to `Native TypeScript` in
+ * {@link WIDGET_COMPONENT} and nowhere else. Every gallery page's intro enumerates
+ * the windows BY THESE EXACT STRINGS — the component's own note says so and relies on
+ * it ("the four runtimes are named by the PAGE") — so nine pages were left naming a
+ * window no block on them draws. In the same commit the frameworks window went from
+ * three blocks to all forty, and seven of those intros still enumerated two windows
+ * where the reader now meets three. Nothing saw either: the strings never leave the
+ * prose, so the site builds and arms 1-9 stay green.
+ *
+ * WHICH WINDOWS A PAGE SHOWS, from the source alone. A window is on a page if some
+ * block there provides one of its tab slots, or if it declares DATA panes — those are
+ * looked up per block and, where a block has none, replaced by the recorded reason,
+ * so such a window is on every block (see `componentWindows`).
+ *
+ * A page with NO blocks is skipped, because it draws no window at all — with one
+ * exception that is not a special case so much as the same rule at section scope: the
+ * gallery's index page introduces the section, so what it must name is the union over
+ * the pages it introduces. It carried the stale name too, and skipping it would have
+ * left the one page a reader meets first outside the rule.
+ *
+ * MEASURED against the four ways it can be wrong, each restored afterwards:
+ *
+ *   · rename the window in the component alone — exit 1, on all 9 pages, which is
+ *     the defect this arm is named after
+ *   · drop "UI frameworks" from one page's intro — exit 1, on that page
+ *   · remove the two `nativescript` fragments from `controls.mdx`, so the page stops
+ *     drawing a window it still names — exit 1, the inverse direction
+ *   · break the title read (`title:` -> `heading:`) — exit 1 on the vacuity guard,
+ *     not a green run against an empty set
+ */
+const SECTION_INDEX = 'index.mdx';
+const titledWindows = windows.filter((window) => window.title !== null);
+if (titledWindows.length === 0) {
+    failures.push(
+        `${WIDGET_COMPONENT}: no window in WINDOWS has a title, so arm 10 would hold every page against\n` +
+            '    an empty set and pass vacuously. The title read is broken, not the component.',
+    );
+}
+
+/** page → the titled windows its own blocks draw. */
+const shownBy = new Map(pages.map((page) => [page, new Set()]));
+for (const block of blocks) {
+    const page = block.page.slice(`${GALLERY}/`.length);
+    const slots = new Set([...block.body.matchAll(/<Fragment slot="([^"]+)"/g)].map(([, slot]) => slot));
+    for (const window of titledWindows) {
+        if (window.data || window.slots.some((slot) => slots.has(slot))) shownBy.get(page).add(window.title);
+    }
+}
+const everywhere = new Set([...shownBy.values()].flatMap((titles) => [...titles]));
+
+for (const page of pages) {
+    const shown = page === SECTION_INDEX ? everywhere : shownBy.get(page);
+    // A page with no block draws nothing, and the index stands for the section.
+    if (shown.size === 0) continue;
+    const prose = pageProse(readFileSync(join(ROOT, GALLERY, page), 'utf8'));
+    for (const title of titledWindows.map((window) => window.title)) {
+        const named = prose.includes(title);
+        if (named === shown.has(title)) continue;
+        failures.push(
+            named
+                ? `${GALLERY}/${page} names the window "${title}" in its prose, and no block on it draws\n` +
+                      '    that window. A reader is told to look for a window that is not there — and the\n' +
+                      '    enumeration is the only place the window titles are explained, so being wrong\n' +
+                      '    there is worse than being silent.'
+                : `${GALLERY}/${page} draws the window "${title}" and its prose never names it. Every\n` +
+                      `    gallery page introduces the stack of windows by title, and ${WIDGET_COMPONENT}\n` +
+                      '    relies on that: what a window title cannot say (the four runtimes, the three\n' +
+                      '    dialects) the page says instead. Rename a window here and nowhere else, or grow\n' +
+                      '    the stack by one, and the intro describes a page that no longer exists.',
+        );
+    }
 }
 
 if (failures.length > 0) {

--- a/showcases/gtk/adwaita-gallery-solid/src/refusals.ts
+++ b/showcases/gtk/adwaita-gallery-solid/src/refusals.ts
@@ -66,10 +66,16 @@ for (const [parentTag, childTag] of PLACEMENTS) {
         insert(child, parent);
         // MATERIALISE, and this is the whole method. The host defers construction
         // (ADR 0027 § Decision 5), so `insert` alone only LINKS the node — measured:
-        // all thirteen placements below "succeeded" at insert and the probe reported
-        // the refusal list as stale, which is the green-that-checked-nothing shape in
-        // its red-that-measured-nothing form. The placement is performed when the
-        // parent becomes a widget, which is what a render does and what this now does.
+        // every placement above "succeeded" at insert and the probe reported the
+        // refusal list as stale, which is the green-that-checked-nothing shape in its
+        // red-that-measured-nothing form. The placement is performed when the parent
+        // becomes a widget, which is what a render does and what this now does.
+        //
+        // (That note said "all thirteen" and this list has held ELEVEN since the file
+        // landed — thirteen is the count from before the two ACCEPTED placements in
+        // the header left it. A number restated beside the list it counts is a copy,
+        // and this one was already wrong when it was written, so it now names the
+        // list instead of counting it.)
         materialize(parent);
         accepted.push(`${parentTag} < ${childTag}`);
         print(`ACCEPTED  <${parentTag}> took <${childTag}> — the refusal list is STALE`);

--- a/website/src/components/AdwWidget.astro
+++ b/website/src/components/AdwWidget.astro
@@ -9,7 +9,7 @@
 //      the window's second tab. No screenshots: the browser runs the component,
 //      the way the official Libadwaita widget gallery shows one, and it follows
 //      the site's light/dark toggle.
-//   2. VANILLA TYPESCRIPT — `@girs` GObject-Introspection TypeScript and the
+//   2. NATIVE TYPESCRIPT — `@girs` GObject-Introspection TypeScript and the
 //      matching Blueprint declaration: two FILES of one program, against the REAL
 //      libadwaita widget.
 //   3. UI FRAMEWORKS — that same real widget, driven through `@gjsify/gtk-host`.
@@ -28,7 +28,7 @@
 //   · The first tab was labelled "GJS · Node · Bun · Deno" and not "GJS" on
 //     purpose: naming one runtime made the tab read as "the GJS variant", i.e. as
 //     if the other three needed a different program. They do not; that is the
-//     claim the whole site rests on. The window is titled for its AXIS ("Vanilla
+//     claim the whole site rests on. The window is titled for its AXIS ("Native
 //     TypeScript" — what two file tabs share) and the four runtimes are named by
 //     the PAGE: every gallery page's intro says "the `@girs` program that runs
 //     unchanged on GJS, Node, Bun and Deno". A window subtitle repeating it under
@@ -219,9 +219,16 @@ const WINDOWS = [
         // code that runs unchanged on all four of them.
         //
         // NATIVE, not "Vanilla". Vanilla names a thing by what it is not — no
-        // framework — which was serviceable while the neighbouring window held one
-        // tab, and stopped being so once it held four. What this window actually
-        // shows is the GObject API itself, with no element model in between.
+        // framework — which was serviceable while the neighbouring window held a
+        // single React Native tab, and stopped being so once that window began
+        // naming Solid, Vue and React beside it. What this window actually shows is
+        // the GObject API itself, with no element model in between.
+        //
+        // The TITLE is the join with the pages: every gallery page's intro
+        // enumerates the windows by these exact strings, so renaming one here and
+        // nowhere else leaves nine pages naming a window that does not exist — which
+        // is what happened, and is what arm 10 of
+        // `scripts/check-website-adwaita-gallery.mjs` now refuses.
         title: 'Native TypeScript',
         tabs: [
             { slot: 'gjs', label: 'TypeScript' },
@@ -341,7 +348,6 @@ const ATTRS_PANE = 'attributes';
  */
 const REFUSAL_PANE = 'why-not';
 
-
 // That requirement, held rather than stated. `data-impls` is POSITIONAL and the
 // script below looks a pane up by name with `indexOf`, so a pane id equal to a
 // slot name gives the live window two entries reading the same id and the first one
@@ -412,18 +418,15 @@ for (const spec of WINDOWS) {
         .map((pane) => ({ ...pane, source: ADWAITA_FRAMEWORK_SNIPPETS[title]?.[pane.id] ?? '' }))
         .filter((pane) => pane.source !== '');
 
-    // Both halves, because a window can now be entirely data: the frameworks window
-    // fills on 40 blocks while only 3 of them provide its slot. Testing `tabs` alone
-    // is what kept it invisible.
     // A block with no snippet gets the RECORDED REASON, never silence. The two maps
     // partition the gallery, so exactly one of `code` and `refusal` is non-empty on
     // the frameworks window — and a block in NEITHER map leaves the window absent,
-    // which `check-generated-website-data.mjs` is what refuses.
+    // which arm 4 of `check-generated-website-data.mjs` is what refuses.
     const refusal = spec.refusals === true && code.length === 0 ? (ADWAITA_FRAMEWORK_REFUSALS[title] ?? null) : null;
 
-    // All three, because a window can now be entirely data: the frameworks window
-    // fills on all 40 blocks while only 3 of them provide its slot. Testing `tabs`
-    // alone is what kept it invisible.
+    // All three, because a window can now be entirely data: measured on the built
+    // site, the frameworks window fills on all 40 blocks while only 3 of them
+    // provide its slot. Testing `tabs` alone is what kept it invisible.
     if (tabs.length === 0 && code.length === 0 && refusal === null) continue;
     // `previewMarkup` is already read by the time this runs: the live window is
     // first in WINDOWS and its own `preview` tab is what sets it.
@@ -522,7 +525,7 @@ for (const spec of WINDOWS) {
             const impls = (el.dataset.impls ?? '').split(',');
             const index = impls.indexOf(impl);
             // The windows hold disjoint tab sets, so a stored choice simply does not
-            // apply to most of them: picking "Blueprint" moves every Vanilla
+            // apply to most of them: picking "Blueprint" moves every Native
             // TypeScript window and leaves the others where the reader left them.
             if (index >= 0) view.setAttribute('selected', String(index));
         }
@@ -609,6 +612,18 @@ for (const spec of WINDOWS) {
         background-color: var(--view-bg-color);
         color: var(--view-fg-color);
         overflow: hidden;
+    }
+
+    /* ── The header bar's trailing slot ─────────────────────────────────
+       Reserved whether or not the copy button is in it. A window whose panes
+       hold no code drops the button (AdwWidgetWindow's `copyable`), and the
+       trailing span is `flex-shrink: 0` with no width of its own — so an empty
+       one collapses from 40px to its 6px padding and the centred title of that
+       window slides 17px left of the titles stacked above and below it. Same
+       width, both ways: 34px button plus its 3px padding on each side. */
+    .adw-widget-window .command-tabs-headerbar-end {
+        box-sizing: border-box;
+        width: 40px;
     }
 
     /* ── Live preview pane ──────────────────────────────────────────────

--- a/website/src/components/AdwWidgetWindow.astro
+++ b/website/src/components/AdwWidgetWindow.astro
@@ -113,6 +113,25 @@ const {
 const panes =
     tabs.length + code.length + (refusal === null ? 0 : 1) + (preview === null ? 0 : 1) + (attributes === null ? 0 : 1);
 
+/**
+ * Whether this window holds any code at all, which is whether its header bar gets a
+ * COPY BUTTON.
+ *
+ * The button forwards to the active pane's hidden Expressive Code copy button and
+ * falls back to the window's own first one (see the handler in `AdwWidget`). A
+ * REFUSAL window has neither: its one pane is prose, so the handler finds nothing,
+ * returns, and does not even mark the press. Measured on the built site before this
+ * guard: 19 of 160 windows — every frameworks window carrying a recorded reason —
+ * rendered a button labelled "Copy this window's code" that could never copy
+ * anything. Nothing else noticed; the site builds and every gate stays green.
+ *
+ * Slot tabs and data panes are both Expressive Code blocks and nothing else is, so
+ * this counts the panes that hold code rather than asking a window what kind it is.
+ * The header bar's trailing span keeps the button's width either way, so the title
+ * stays centred against the windows above and below it.
+ */
+const copyable = tabs.length + code.length > 0;
+
 // NO PANES AT ALL is a header bar over nothing, and it renders exactly that way at
 // exit 0. `AdwWidget` is what prevents it — it skips a window none of whose tab
 // slots this block filled — and nothing downstream restated the guard: measured by
@@ -189,10 +208,13 @@ if (attributes !== null && preview === null) {
             {/* Not "copy active tab": the active pane can be the live preview,
                 which has no code in it. The handler in AdwWidget falls back to
                 this window's own code block, which for the preview window is the
-                markup that paints what the reader is looking at. */}
-            <button class="command-tabs-copy" aria-label="Copy this window's code" type="button">
-                <span class="command-tabs-copy-icon" aria-hidden="true"></span>
-            </button>
+                markup that paints what the reader is looking at — and where there
+                is no code block at all, there is no button, see {@link copyable}. */}
+            {copyable && (
+                <button class="command-tabs-copy" aria-label="Copy this window's code" type="button">
+                    <span class="command-tabs-copy-icon" aria-hidden="true" />
+                </button>
+            )}
         </span>
     </div>
 

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -14,9 +14,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -16,9 +16,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/controls.mdx
+++ b/website/src/content/docs/adwaita/controls.mdx
@@ -20,9 +20,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/feedback.mdx
+++ b/website/src/content/docs/adwaita/feedback.mdx
@@ -15,9 +15,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/index.mdx
+++ b/website/src/content/docs/adwaita/index.mdx
@@ -13,9 +13,10 @@ custom element in the browser.
 
 Pick a category below. Every widget on those pages runs live in your browser, in a
 window whose second tab holds the markup that paints it, followed by one window per
-kind of implementation: **Vanilla TypeScript**, the `@girs` program that runs
-unchanged on GJS, Node, Bun and Deno, with a Blueprint declaration beside it, and
-**NativeScript**, the port that runs on a phone. Choose a tab once and every widget
+kind of implementation: **Native TypeScript**, the `@girs` program that runs
+unchanged on GJS, Node, Bun and Deno, with a Blueprint declaration beside it, **UI
+frameworks**, the same widget written in Solid, Vue and React through
+`@gjsify/gtk-host`, and **NativeScript**, the port that runs on a phone. Choose a tab once and every widget
 block on the site follows it.
 
 Adwaita is one design system GJSify supports, not a requirement. Your app is an

--- a/website/src/content/docs/adwaita/layout.mdx
+++ b/website/src/content/docs/adwaita/layout.mdx
@@ -16,7 +16,7 @@ is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
 one window per kind of implementation, for every kind that can express this widget.
-Two are on all four widgets here — **Vanilla TypeScript**, the `@girs` program that
+Two of them name a file pair — **Native TypeScript**, the `@girs` program that
 runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint declaration
 beside it, and **NativeScript**, the port that runs on a phone, which splits the same
 way: an XML template holds the tree and the TypeScript beside it is the loader.
@@ -27,12 +27,13 @@ is a MODULE: NativeScript loads it and reads the element name off its exports, s
 markup names. A bare package specifier there does not resolve. The four templates
 below were rendered on an Android device before they were written down.
 
-The clamp, the header bar and the toolbar view carry a third, **UI frameworks**: the
-same widget written with [`@gjsify/react-native`](/gjsify/frameworks/react-native/)
-primitives inside it. The wrap box does not, because
-[`@gjsify/gtk-host`](https://github.com/gjsify/gjsify/tree/main/packages/framework/gtk-host)
-has no child policy for `AdwWrapBox` yet, and a renderer that guessed one would call
-`add`, `append` or `set_child` and be wrong at exit 0. That window renders a GTK window,
+The third, **UI frameworks**, is on all four as well. The clamp, the header bar and
+the toolbar view show the same widget written in Solid, Vue and React through
+[`@gjsify/gtk-host`](https://github.com/gjsify/gjsify/tree/main/packages/framework/gtk-host),
+with a [`@gjsify/react-native`](/gjsify/frameworks/react-native/) tab beside them. The
+wrap box shows the recorded reason instead: `@gjsify/gtk-host` has no child policy for
+`AdwWrapBox` yet, and a renderer that guessed one would call `add`, `append` or
+`set_child` and be wrong at exit 0. That window renders a GTK window,
 not a phone screen — which is why it is not the NativeScript one, and the [React Native
 page](/gjsify/frameworks/react-native/#adwaita-widgets) says what does and does not
 exist there.

--- a/website/src/content/docs/adwaita/navigation.mdx
+++ b/website/src/content/docs/adwaita/navigation.mdx
@@ -15,9 +15,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/presentation.mdx
+++ b/website/src/content/docs/adwaita/presentation.mdx
@@ -15,9 +15,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/view-switching.mdx
+++ b/website/src/content/docs/adwaita/view-switching.mdx
@@ -16,9 +16,12 @@ Each block below is a stack of windows. The first one RUNS the widget: the previ
 is the live browser port, so it follows the light and dark toggle the way a real
 window would, and the HTML tab beside it holds the very markup that paints it —
 one `import '@gjsify/adwaita-web'` registers every element in it. Then comes
-one window per kind of implementation — **Vanilla TypeScript**, the `@girs` program
+one window per kind of implementation — **Native TypeScript**, the `@girs` program
 that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
-declaration beside it, and **NativeScript**, the port that runs on a phone.
+declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
+React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
+than declared, the recorded reason it has no such snippet — and **NativeScript**,
+the port that runs on a phone.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).


### PR DESCRIPTION
Post-merge review of #1399 (`7511170bd`), which was merged without one. Four of the seven things it was reviewed for came back clean and are stated as measurements below; three did not.

## What held

Verified on the **built** HTML, not the source:

| claim | measured |
|---|---|
| `data-impls` is positional and the nth id is the nth pane | **160 windows, 0 mismatches** — 105 tabbed windows compared position-by-position against their `<adw-tab-page>` titles, 55 single-pane windows against their one id |
| the preference switcher moves every window to the pane with that id | **273 simulated moves, 0 wrong targets** — `indexOf` over every id on every page |
| 21 + 19 = 40 | **21 / 19 / 40**, and it is not aspirational: arm 4 of `check-generated-website-data.mjs` already refuses a block reaching neither map |
| the 19 refusal reasons | **19 of 19 sound.** All nine `uncurated-placement` GTypes still have no curated descriptor under `gtk-host/src/descriptors/`; every type and property the other ten cite (`stack`, `adjustment`, `menuModel`, `model`, `Gio.MenuModel`, `Gtk.StringList`) exists in the generated tables, and `Adw.Toast` really has no tag |
| `<Code>` vs a slot pane | **structurally identical** — same `div.expressive-code > figure.frame.adw-code-window` skeleton, same highlighting, `lang="vue"` resolves; the only difference is the `<link>`/`<script>` Astro injects, twice per page |
| the single-pane branch | **no hole.** `panes === 1` with a preview or an attribute pane both throw above it, so the three arms are exhaustive |

## Three things did not

### 1. The rename was applied to the component and nowhere else

`id: 'vanilla'` is genuinely unused — no `localStorage` key, no selector, no anchor, no test. The **title** is not. The component's own note says the four runtimes "are named by the PAGE, not here", and every gallery page's intro enumerates the windows *by these exact strings*. **Nine pages** were left naming `**Vanilla TypeScript**`, a window no block on them draws. Three comments in `AdwWidget.astro` and one line of ADR 0033 too.

### 2. `layout.mdx` tells a reader the wrap box does not have the window it has

> The clamp, the header bar and the toolbar view carry a third, **UI frameworks**. **The wrap box does not**, because `@gjsify/gtk-host` has no child policy for `AdwWrapBox` yet…

After #1399 the wrap box carries it — showing *that exact reason* as its refusal pane. The paragraph and the pane are now the same sentence in two files, which is the drift this gallery keeps paying for; the paragraph is the copy, so it points at the pane instead of restating it. Seven further intros enumerate two windows where the reader now meets three.

### 3. The copy button did nothing on 19 of 40 blocks

The handler forwards to the active pane's hidden Expressive Code button and falls back to the window's own first one. A refusal window has neither — one pane, and it is prose — so it found no button and returned before it even marked the press. **Measured: 19 of 160 windows** shipped a button labelled "Copy this window's code" that could never copy anything; before the frameworks window filled, there were none. The header bar's trailing slot now keeps the button's width when the button is gone, so those titles stay centred against the windows above and below them.

## Arm 10, and its negative controls

All three were invisible to arms 1–9 because the strings never leave the prose: the site builds, and every gate stayed green. So:

> **Every window a page draws is named in that page's prose, and every window title the prose names is one that page draws.**

Which windows a page draws is decided from the source: a window is on a page if a block there provides one of its tab slots, or if it declares DATA panes — those are per block and, where a block has none, replaced by the recorded reason, so such a window is on every block. Pages with no blocks are skipped; the section index is held against the union, because it carried the stale name too.

Measured against the four ways it can be wrong, each restored afterwards:

- rename the window in the component alone → **exit 1, on all 9 pages** — the defect it is named after
- drop `UI frameworks` from one page's intro → **exit 1**, on that page
- remove `controls.mdx`'s two `nativescript` fragments so the page stops drawing a window it still names → **exit 1**, the inverse direction
- break the title read (`title:` → `heading:`) → **exit 1 on the vacuity guard**, not a green run against an empty set

The prose read collapses whitespace and masks fences. Both were measured, not assumed: unmasked, a page satisfies the arm with a code sample, and the first run failed on a page that named the window correctly — wrapped across a line.

## Second commit: a count that was never right

The refusal ledger #1399 now publishes on 19 blocks carries its warrant in a comment: *"Measured by refusals.ts … 13 of 13."* The probe drives **eleven** placements and has since it landed in #1376 — thirteen is the count from before the two ACCEPTED placements named in the probe's own header left the list. Two of the eleven are not ledger entries at all. Comments only; both notes now name the list rather than counting it, and record where the arm that would hold the two lists together belongs.

## Overlap with #1400

#1400 also touches `AdwWidget.astro`, `AdwWidgetWindow.astro` and `layout.mdx`. The changes are in different regions except one: **#1400's `layout.mdx` hunk carries the wrap-box paragraph as trailing context**, so whichever lands second rebases. #1400 does not fix that paragraph.

**The refusal-verifying gate arm belongs in #1400, not here.** It already grows `check-generated-website-data.mjs` by three arms, one of which verifies the NativeScript refusal map the same way; the framework map's version is its sibling and would conflict with it as a separate PR. Its shape, measured here: an `uncurated-placement` entry is one whose GType has no curated descriptor under `gtk-host/src/descriptors/`, and every placement the probe drives is either a ledger entry or ledgered in the probe with its own reason.

## Verification

- `gjsify workspace @gjsify/website build` — 62 pages, exit 0
- `check-website-adwaita-gallery`, `check-website-attr-samples`, `check-website-package-names`, `check-website-preview-not-content`, `check-generated-website-data`, `check-doc-fences`, `check-doc-revert` — all exit 0
- `gjsify format --check` / `gjsify lint` over every touched non-Astro file — clean (Astro files are excluded from the formatter)
- On the rebuilt HTML: 40 blocks, 160 windows, pane order exact, 273 switches with no wrong target, dead copy buttons **19 → 0**, copy buttons 160 → 141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB
