### PR TITLE
fix(gtk-host): the echo guard asks whose object

### DIFF
--- a/packages/framework/gtk-host/src/host.spec.ts
+++ b/packages/framework/gtk-host/src/host.spec.ts
@@ -476,12 +476,20 @@ export default async () => {
                 expect(seen).toStrictEqual(['xyz!']);
             });
 
-            await it('does not report an echo our write raised on ANOTHER object', async () => {
-                // Why the guard is a module-wide counter and not
-                // `g_signal_handler_block()` on the widget being written. MEASURED:
-                // writing `active` on one grouped `Gtk.CheckButton` makes the OTHER
-                // emit `notify::active` AND `toggled`. Blocking reaches only the
-                // object in hand, so it would leave this one re-entering.
+            await it('drops the notify our write raised on ANOTHER object, not the rest', async () => {
+                // The two halves of the guard, on ONE pair, because the pair is what
+                // separates them. MEASURED on gjs 1.88.1 / GTK 4.22.4: writing
+                // `active` on one grouped `Gtk.CheckButton` makes the OTHER emit
+                // `notify::active` AND `toggled` — a handler of ours on an object the
+                // writer never touched.
+                //
+                // `notify::active` on B is an echo: it reports a property, and a
+                // property write is the whole of what it can report. `toggled` is
+                // not. It is the only notice B's component will ever get that B
+                // turned itself off, and that component wrote nothing to reconcile
+                // it with — dropping it leaves the component's state disagreeing
+                // with GTK for ever, silently, which is the failure this host
+                // exists to refuse.
                 const a = createElement('GtkCheckButton');
                 const b = createElement('GtkCheckButton');
                 materialize(a);
@@ -490,21 +498,118 @@ export default async () => {
                 (b.widget as unknown as Gtk.CheckButton).set_group(a.widget as unknown as Gtk.CheckButton);
                 setProp(b, 'active', true);
 
-                let echoed = 0;
+                const seen: string[] = [];
                 setEventHandler(b, 'onNotifyActive', () => {
-                    echoed += 1;
+                    seen.push('notify::active');
                 });
                 setEventHandler(b, 'onToggled', () => {
-                    echoed += 1;
+                    seen.push('toggled');
                 });
                 setProp(a, 'active', true);
                 expect((b.widget as unknown as Gtk.CheckButton).get_active()).toBe(false);
-                expect(echoed).toBe(0);
-                // Positive control on the same pair: a change B did not get from us
-                // still reaches both handlers.
+                expect(seen).toStrictEqual(['toggled']);
+                // The control, and it has to cover BOTH handlers: asserting that the
+                // notify half stayed quiet passes just as well when that handler was
+                // never connected. A change B did not get from us reaches both.
+                seen.length = 0;
                 (a.widget as unknown as Gtk.CheckButton).set_active(false);
                 (b.widget as unknown as Gtk.CheckButton).set_active(true);
-                expect(echoed).toBe(2);
+                expect(seen).toStrictEqual(['notify::active', 'toggled']);
+            });
+
+            await it('reports what our write did to a DESCENDANT', async () => {
+                // The quadrant nobody measured when the guard was widened from
+                // `notify::` to every signal: a consequence on an object we did not
+                // write. MEASURED, and the propagation needs no window at all —
+                // writing `sensitive` on a `Gtk.Box` emits `state-flags-changed` on
+                // every descendant, detached, because insensitivity is inherited.
+                //
+                // `visible` is the same shape and the more common one, and it was
+                // measured too: on a presented window a host `visible` write emits
+                // `unmap`/`map` on the descendants. It is not the vector here only
+                // because a mapped widget needs `present()`, and this suite stays off
+                // every question a compositor could ask.
+                const box = createElement('GtkBox');
+                const label = createElement('GtkLabel', { label: 'x' });
+                insert(label, box);
+                materialize(box);
+
+                const seen: string[] = [];
+                setEventHandler(label, 'onStateFlagsChanged', () => {
+                    seen.push('label');
+                });
+                setEventHandler(box, 'onStateFlagsChanged', () => {
+                    seen.push('box');
+                });
+                setProp(box, 'sensitive', false);
+                // The label really did change, and it is the only place that says so.
+                expect((label.widget as unknown as Gtk.Widget).is_sensitive()).toBe(false);
+                // The box's own emission IS the echo of the box's own write, so the
+                // same vector carries the negative control: one name, not two.
+                expect(seen).toStrictEqual(['label']);
+            });
+
+            await it('reports what our write did to a sibling over shared GTK state', async () => {
+                // A `Gtk.Adjustment` shared by two widgets is GTK's own idiom (a
+                // `Gtk.Scale` next to a `Gtk.SpinButton` over one range), and it puts
+                // the consequence on a sibling rather than a child. MEASURED: a
+                // `value` write on the first emits `value-changed` on the second.
+                const adjustment = new Gtk.Adjustment({ lower: 0, upper: 100, value: 0, stepIncrement: 1 });
+                const a = createElement('GtkSpinButton', { adjustment });
+                const b = createElement('GtkSpinButton', { adjustment });
+                materialize(a);
+                materialize(b);
+
+                const seen: string[] = [];
+                setEventHandler(a, 'onValueChanged', () => {
+                    seen.push(`a:${(a.widget as unknown as Gtk.SpinButton).get_value()}`);
+                });
+                setEventHandler(b, 'onValueChanged', () => {
+                    seen.push(`b:${(b.widget as unknown as Gtk.SpinButton).get_value()}`);
+                });
+                setProp(a, 'value', 42);
+                // A's own emission is the echo and stays silent; B's is the news.
+                expect(seen).toStrictEqual(['b:42']);
+                // The control for the half that was quiet: A's handler is connected,
+                // and a write A did not get from us reaches it.
+                seen.length = 0;
+                (a.widget as unknown as Gtk.SpinButton).set_value(7);
+                expect(seen).toStrictEqual(['a:7', 'b:7']);
+            });
+
+            await it('still drops a signal our write raised on the object we wrote, even about another property', async () => {
+                // The COST of the target leg, pinned rather than left to be
+                // rediscovered as a bug. MEASURED: writing `selection-mode` on a
+                // `Gtk.ListBox` clears the selection and emits `row-selected` — a
+                // different property from the one written, on the object we wrote,
+                // so the guard drops it and a component tracking the selection is
+                // left disagreeing with GTK.
+                //
+                // It is not special-cased, and that is the point: from inside this
+                // callback `row-selected` after a `selection-mode` write is
+                // indistinguishable from `Gtk.Editable::changed` after a `text`
+                // write, and THAT one has to stay dropped — it carries an
+                // intermediate empty string a controlled input reads as the user
+                // clearing the field. One of the two has to give, and the rule says
+                // which without asking the caller to know.
+                const list = createElement('GtkListBox');
+                const row = createElement('GtkListBoxRow');
+                insert(row, list);
+                const widget = materialize(list) as unknown as Gtk.ListBox;
+                widget.select_row(row.widget as unknown as Gtk.ListBoxRow);
+
+                let selections = 0;
+                setEventHandler(list, 'onRowSelected', () => {
+                    selections += 1;
+                });
+                setProp(list, 'selection-mode', 'none');
+                expect(widget.get_selected_row()).toBe(null); // GTK really did clear it
+                expect(selections).toBe(0);
+                // The control: the handler is live, and a selection we did not write
+                // reaches it.
+                setProp(list, 'selection-mode', 'single');
+                widget.select_row(row.widget as unknown as Gtk.ListBoxRow);
+                expect(selections).toBe(1);
             });
 
             await it('refuses two props that resolve to one signal', async () => {

--- a/packages/framework/gtk-host/src/host.ts
+++ b/packages/framework/gtk-host/src/host.ts
@@ -103,7 +103,11 @@ export function materialize(el: HostElement): GObject.Object {
         const spec = requireSpec(specs, el.descriptor.gtype, name);
         initial[name] = coerce(spec, value, el.descriptor.gtype);
     }
-    beginHostWrite();
+    // No target: the object does not exist yet, so no handler of ours can be on
+    // it. What CAN fire here is a knock-on on some other object — constructing a
+    // grouped `Gtk.CheckButton` deactivates its sibling — and that is news the
+    // sibling's component has no other way to get.
+    beginHostWrite(null);
     try {
         el.widget = new Klass(initial);
     } finally {
@@ -228,7 +232,7 @@ export function setProp(el: HostElement, key: string, next: unknown, _prev?: unk
     if (!el.widget) return; // buffered until materialisation
     if ((spec.flags & GObject.ParamFlags.CONSTRUCT_ONLY) !== 0) return rebuild(el, name, previouslyRecorded);
 
-    beginHostWrite();
+    beginHostWrite(el.widget);
     try {
         writeProperty(el.widget, name, value);
     } finally {
@@ -506,7 +510,7 @@ function writeTextSink(el: HostElement, text: string): void {
     }
     const specs = paramSpecs(el.descriptor.ctor(), el.descriptor.gtype);
     const spec = requireSpec(specs, el.descriptor.gtype, sink);
-    beginHostWrite();
+    beginHostWrite(el.widget);
     try {
         (el.widget as unknown as { set_property(n: string, v: unknown): void }).set_property(
             sink,
@@ -842,7 +846,7 @@ function restoreTextSink(el: HostElement): void {
     const recorded = el.props[sink] ?? el.props[camel];
     if (typeof recorded !== 'string' || recorded === '') return;
     const spec = requireSpec(paramSpecs(el.descriptor.ctor(), el.descriptor.gtype), el.descriptor.gtype, sink);
-    beginHostWrite();
+    beginHostWrite(el.widget);
     try {
         (el.widget as unknown as { set_property(n: string, v: unknown): void }).set_property(
             sink,

--- a/packages/framework/gtk-host/src/signals.ts
+++ b/packages/framework/gtk-host/src/signals.ts
@@ -88,30 +88,51 @@ export function isEventProp(prop: string): boolean {
 }
 
 /**
- * Depth of property writes this host is currently performing.
+ * The objects whose properties this host is writing right now, innermost last.
  *
- * GObject emits for our own writes, so a component that binds `onNotifyText` and
- * writes `text` in the handler re-enters itself. The counter is module-wide
- * because a nested write on a DIFFERENT object is still our write — and that is
- * measured, not assumed: on gjs 1.88.1 / GTK 4.22.4, writing `active` on one
- * grouped `Gtk.CheckButton` makes the OTHER one emit `notify::active` AND
- * `toggled`, on an object the writer never touched.
+ * A stack rather than a counter, because the echo guard needs two facts and not
+ * one: WHETHER a host write is open (`inHostWrite`) and WHICH object it is
+ * writing (`isHostWriteTarget`). A nested write on a different object is still
+ * our write, so the stack is what makes the depth right; `null` is the entry for
+ * a window that has no object yet, which is construction.
  *
- * That measurement is also why this is a counter and not
- * `g_signal_handler_block()` on the widget being written. Blocking is exact and
- * leaves foreign handlers alone, which is attractive; it is also strictly weaker,
- * because it can only reach handlers on the ONE object in hand, and the grouped
- * check button above is a handler of ours on another. Both were measured before
- * this comment was written.
+ * Why both facts, measured on gjs 1.88.1 / GTK 4.22.4 — an emission during a
+ * host write falls into one of two kinds, and only one of them is an echo:
+ *
+ *  - ON THE OBJECT BEING WRITTEN it is an echo, whatever it is called.
+ *    `gtk_editable_set_text` is delete-then-insert, so ONE write over existing
+ *    text emits `Gtk.Editable::changed` TWICE carrying `["", "abc"]`, and a
+ *    controlled input reads that intermediate empty string as the user clearing
+ *    the field. `Gtk.ToggleButton::toggled` echoes an `active` write the same way.
+ *  - ON ANY OTHER OBJECT it is a CONSEQUENCE, and the component that receives it
+ *    did not write anything. Writing `sensitive` on a `Gtk.Box` emits
+ *    `state-flags-changed` on every descendant; writing `visible` maps or unmaps
+ *    them; two `Gtk.SpinButton`s over one `Gtk.Adjustment` mean a `value` write on
+ *    the first emits `value-changed` on the second; and writing `active` on one
+ *    grouped `Gtk.CheckButton` makes the OTHER emit `notify::active` AND
+ *    `toggled`. Dropping those is not silencing an echo, it is withholding the
+ *    only notice a component will ever get that its widget changed.
+ *
+ * `notify` is the exception that stays module-wide, and it is the one GObject
+ * itself defines: it reports a property, so a property write is the whole of what
+ * it can be reporting. That is also what keeps `onNotify` and `onNotifyActive`
+ * agreeing about the same write.
+ *
+ * This is why the guard is not `g_signal_handler_block()` on the widget being
+ * written either. Blocking is exact and leaves foreign handlers alone, which is
+ * attractive; it cannot express the `notify` half at all, because that half is
+ * about an object the writer never touched.
  */
-let writeDepth = 0;
-export const beginHostWrite = () => {
-    writeDepth += 1;
+const writeTargets: (object | null)[] = [];
+export const beginHostWrite = (target: object | null = null) => {
+    writeTargets.push(target);
 };
 export const endHostWrite = () => {
-    writeDepth -= 1;
+    writeTargets.pop();
 };
-export const inHostWrite = () => writeDepth > 0;
+export const inHostWrite = () => writeTargets.length > 0;
+/** Is this object one whose property the host is writing at this instant? */
+export const isHostWriteTarget = (o: object): boolean => writeTargets.includes(o);
 
 export function setHandler(el: HostElement, prop: string, next: ((...args: unknown[]) => unknown) | null): void {
     const { signal, once } = parseEventProp(prop, el.descriptor.eventAliases);
@@ -134,33 +155,50 @@ export function setHandler(el: HostElement, prop: string, next: ((...args: unkno
     }
     if (!next) return;
 
+    // `notify` and `notify::<prop>` both, because they are one signal with one
+    // meaning: a property changed. Splitting them made `onNotify` and
+    // `onNotifyLabel` disagree about the SAME write, which is how the plain one
+    // used to re-enter.
+    const isNotify = signal === 'notify' || signal.startsWith('notify::');
+
     const id = target.connect(signal, (...args: unknown[]) => {
-        // An emission raised by our own patch is not a user event — and it must
-        // not spend a `.once` either, or the one emission the user asked for is
-        // consumed by our own property write.
+        // The echo of our own patch is not a user event — and it must not spend a
+        // `.once` either, or the one emission the user asked for is consumed by
+        // our own property write.
         //
-        // This used to read `isNotify && inHostWrite()`, and the narrowing was the
-        // defect: `notify::` is not the only signal a property write raises.
-        // MEASURED on gjs 1.88.1 / GTK 4.22.4 — `gtk_editable_set_text` is
-        // delete-then-insert, so ONE write over existing text emits
-        // `Gtk.Editable::changed` TWICE, carrying `["", "abc"]`. A controlled input
-        // reads that intermediate empty string as the user clearing the field, so
-        // the workaround was to bind `notify::text` instead of the signal that
-        // actually means "the text changed". `Gtk.ToggleButton::toggled` re-entered
-        // the same way. Both are covered now, because the guard asks who is
-        // WRITING rather than which signal arrived.
+        // Two conditions and not one, and the second is the narrow half on
+        // purpose. `inHostWrite() && isNotify` alone was too narrow: `notify::` is
+        // not the only signal a write raises, so `Gtk.Editable::changed` and
+        // `Gtk.ToggleButton::toggled` re-entered the component that had just
+        // written `text` or `active`. `inHostWrite()` alone is too WIDE: it drops
+        // every consequence a write has on some OTHER object, and a component
+        // holding that object never wrote anything to reconcile the news with.
+        // Measured, all four dropped and all four restored by
+        // `isHostWriteTarget` — `state-flags-changed` on a descendant of a
+        // `sensitive` write, `map`/`unmap` on a descendant of a `visible` write,
+        // `value-changed` on a second `Gtk.SpinButton` over one `Gtk.Adjustment`,
+        // and `toggled` on the other of two grouped `Gtk.CheckButton`s. The
+        // module-wide leg keeps only `notify`, which reports nothing but a
+        // property.
         //
         // The window is exactly one constructor call or one property write (the
         // four `beginHostWrite` sites in `host.ts`) — child insertion is outside
-        // it — so nothing that a user could have caused is inside. One hazard to
-        // keep in view if the table grows: a handler the HOST installs on an
-        // object whose signals fire from inside a write would now be suppressed.
-        // `Gtk.SignalListItemFactory` is the near miss — its `setup`/`bind` do
-        // fire from inside a write — and it is safe today for a reason worth
-        // stating rather than rediscovering: it is not a curated element, and
-        // `@gjsify/react-native`'s list controller connects to it DIRECTLY, so
-        // those handlers never pass through here. Curating it would change that.
-        if (inHostWrite()) return undefined;
+        // it — so nothing a user could have caused is inside. What IS inside is
+        // everything GTK does as a knock-on, which is why the target matters.
+        //
+        // One hazard to keep in view if the table grows: a handler the HOST
+        // installs on an object whose OWN signals fire from inside a write would
+        // be suppressed by the target leg. `Gtk.SignalListItemFactory` is the near
+        // miss — its `setup`/`bind` do fire from inside a write, measured — and it
+        // is safe today for a reason worth stating rather than rediscovering: it
+        // is not a curated element, and `@gjsify/react-native`'s list controller
+        // connects to it DIRECTLY, so those handlers never pass through here.
+        // Curating it would change that. Curating the CARRIERS it hands back does
+        // not: `Gtk.ListItem`, `Gtk.ListHeader`, `Gtk.ColumnViewCell` and
+        // `Adw.Toggle` declare no signals of their own at all (measured,
+        // `g_signal_list_ids` is empty for each), so `notify` is their whole
+        // surface and the target leg never sees them.
+        if (inHostWrite() && (isNotify || isHostWriteTarget(target))) return undefined;
         if (once) {
             // Disconnect BEFORE calling: a callback that re-enters its own widget
             // would otherwise fire a second time, which is the whole point of

--- a/packages/framework/react-native/src/primitives/table.ts
+++ b/packages/framework/react-native/src/primitives/table.ts
@@ -731,10 +731,19 @@ export const PRIMITIVES: Readonly<Record<string, PrimitiveSpec>> = {
             // emits `changed` TWICE — measured on gtk 4.22.4, `entry.text = 'abc'`
             // over `'xy'` gave `["", "abc"]`, an intermediate EMPTY string that a
             // controlled input would report as the user clearing the field.
-            // `notify::text` gave `["abc"]`. The host additionally suppresses a
-            // `notify::` raised by its OWN property write (`inHostWrite()` in
-            // `signals.ts`), which closes the render → set text → onChangeText →
-            // setState → render loop that `changed` would open.
+            // `notify::text` gave `["abc"]`. The host additionally suppresses an
+            // emission raised by its OWN property write (`signals.ts`), which
+            // closes the render → set text → onChangeText → setState → render loop
+            // that `changed` would open.
+            //
+            // That last sentence is NOT a reason to move the route, and the
+            // measurement that says so is here so the question stops being reopened:
+            // the host guard reaches the host's own writes and nothing else, so a
+            // write the host did not make still emits `changed` twice. Measured
+            // with the guard in place — `entry.set_text('pq')` over existing text
+            // gave `changed` `["", "pq"]` and `notify::text` `["pq"]`. Every
+            // imperative write through a ref is that path, and so is this layer's
+            // own `widgets.spec.ts` vector.
             onChangeText: { to: 'event', signal: 'notify::text', read: 'text' },
             onSubmitEditing: { to: 'event', signal: 'activate' },
         },


### PR DESCRIPTION
Post-merge review of #1397, which landed without one. The defect #1397 fixed is real
and it stays fixed; what this corrects is the half of the widening that nobody
measured.

`87740924b` changed `if (isNotify && inHostWrite())` to `if (inHostWrite())`. That
moved on **two axes at once** — WHICH SIGNAL (`notify::` only → every signal) and
WHICH OBJECT (already module-wide, now for every signal). Its measurements cover the
first axis, all same-object: `Gtk.Editable::changed` twice with `["", "xyz"]`,
`Gtk.ToggleButton::toggled`, the plain `notify` inconsistency. Its one cross-object
measurement — grouped `Gtk.CheckButton`s — is an argument for the **narrow `notify`
leg it removed**, not for the wide leg it added.

## The unmeasured quadrant, cross-object × non-notify

A/B against `87740924b^`, gjs 1.88.1 / GTK 4.22.4. All four delivered before, all four
silent after, each with a foreign-write control proving the handler is connected:

| host write | signal, and where it lands | before | after |
|---|---|---|---|
| `setProp(box, 'sensitive', false)` | `state-flags-changed` on every DESCENDANT | delivered | **silent** |
| `setProp(box, 'visible', false/true)` | `unmap`/`map` on every descendant; `hide`/`show` on the box | delivered | **silent** |
| `setProp(spinA, 'value', 42)`, two `Gtk.SpinButton`s over one `Gtk.Adjustment` | `value-changed` on **spinB**, carrying 42 | delivered | **silent** |
| `setProp(a, 'active', true)`, grouped `Gtk.CheckButton`s | `toggled` on **B**, which really did turn off | delivered | **silent** |

None of those is an echo. The component holding the descendant, the sibling spin
button or check button B **wrote nothing**, so there is nothing for it to reconcile
the news with — and for `map`/`unmap` there is no second chance: the emission happens
once and is gone. The last row is #1397's own headline: it drops the notice that B
turned off, so a controlled pair keeps rendering B checked while GTK has it clear.

This is a published surface, not a hypothetical. `generated/props.ts` offers `onMap`,
`onUnmap`, `onShow`, `onHide`, `onRealize`, `onUnrealize` and `onStateFlagsChanged` on
all 164 widgets, and `@gjsify/react-native` routes `ActivityIndicator`'s `animating`
straight onto `visible`.

## The rule

Suppress an emission during a host write when it is

- **`notify`-shaped**, anywhere — `notify` reports a property and nothing else, so a
  property write is the whole of what it can be reporting (this is also what keeps
  `onNotify` and `onNotifyLabel` agreeing, which #1397 rightly fixed); **or**
- **on the object being written** — an echo, whatever it is called. `changed` after a
  `text` write and `toggled` after an `active` write are exactly this.

`beginHostWrite` now takes that object and the counter becomes a stack; construction
passes `null`, having none yet. This is not `g_signal_handler_block()`: blocking
cannot express the `notify` leg at all, because that leg is about an object the writer
never touched.

## The cost, pinned rather than left to be rediscovered

`row-selected` after a `selection-mode` write on the `Gtk.ListBox` we wrote stays
suppressed, and GTK really does clear the selection. From inside the callback it is
indistinguishable from `changed` after a `text` write, and that one has to stay
dropped. A test asserts the silence and says why.

## Tests

Four vectors in the `signals` gate, every one watched red **twice**:

- with `inHostWrite()` alone (#1397's guard): the three cross-object rules fail, the
  same-object one holds — the fix is what makes them pass;
- with no guard at all: all seven signal rules fail, plus Vue's
  `.once is not spent by the host's own property write`.

Each carries its control in the same vector: the descendant test asserts one name and
not two (the box's own emission is the echo), the spin-button test asserts A silent
and B heard, the check-button test asserts `['toggled']` then `['notify::active',
'toggled']` from a foreign write.

`map`/`unmap` is measured but not a vector: a mapped widget needs `present()`, and
this suite stays off every question a compositor could ask. `sensitive` covers the
same class detached.

## Two claims from #1397, re-measured

**`feat/host-list-item` (#1398) does not change the answer.** It curates
`GtkListItem`, `GtkListHeader`, `GtkColumnViewCell` and `AdwToggle` — and
`g_signal_list_ids` is **empty for all four**, so `notify` is their entire surface and
the new target leg never sees them. `Gtk.SignalListItemFactory`, which owns the four
real signals, is still not curated, so #1397's near miss stands exactly as written.

**`@gjsify/react-native` cannot move `onChangeText` to `Gtk.Editable::changed`.**
#1397 lists that as a follow-up it unblocks. Measured with the guard in place: the
guard reaches the host's own writes and nothing else, so `entry.set_text('pq')` over
existing text still gives `changed` `["", "pq"]` against `notify::text` `["pq"]`.
Every imperative write through a ref is that path, and so is the layer's own
`widgets.spec.ts` vector. `primitives/table.ts` now records the measurement so the
question stops being reopened.

## Verification

- `gjsify workspace @gjsify/gtk-host test` — **2111 tests from 13 gates, 0 failures** (2104 before)
- `gjsify workspace @gjsify/gtk-host check` — clean
- `gjsify workspace @gjsify/react-native test` — **442 tests from 5 gates, 0 failures**; `check` clean
- `gjsify format` + `gjsify lint` on both packages — clean
- `check-comment-budget`, `check-vocabulary-alignment`, `check-source-visibility`, `check-lint-visibility` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB
