### PR TITLE
feat(gtk-host): the list half no framework owns

### DIFF
--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -117,6 +117,42 @@ attachment point, `layout={{ column, row, columnSpan, rowSpan }}` a `coords` cel
 `layout={{ name, title }}` a `keyed` page. Both are read at placement time, so
 changing either RE-PLACES the child rather than doing nothing.
 
+## Lists — `@gjsify/gtk-host/list`
+
+A `Gtk.ListView` is the one thing in GTK4 that cannot be an element: it installs no
+child-adding method at all (measured against its prototype), and the carrier its
+factory hands back is not a `Gtk.Widget`. What it needs instead is a model, a factory
+and a key diff — none of which has a framework in it, and all of which every dialect
+would otherwise own a copy of. `ListController` is that half, in a subpath rather than
+a package: a `/core` subpath beats a new `-core` package unless a separate NAME buys a
+package-level cycle or an independent external consumer, and neither is in play.
+
+It imports GTK and GObject and nothing else — no React, no Solid, no Vue — and the
+dialect supplies three callbacks:
+
+| callback | called from | what it owes |
+|---|---|---|
+| `mountRow(item)` | `setup` | take the carrier, put a subtree root in it, return a handle |
+| `showRow(handle, row, index)` | `bind`, `unbind` (with `null`), and a same-key content change | show that row, or empty it |
+| `disposeRow(handle)` | `teardown` and `dispose()` | let go |
+
+**Take the carrier ONCE, in `mountRow`.** GTK recycles a carrier across `bind`/`unbind`,
+and `adopt` snapshots what a container already held without being able to tell the
+host's own previous child from application chrome — so a dialect that adopts per bind
+refuses with `occupied-slot` on the first recycled row. `host.spec.ts` pins that
+refusal; `list/controller.ts` carries the three measurements the controller's shape
+follows from (the `Gio.ListStore` carrier identity, why a data change SPLICES rather
+than emitting `items-changed`, and why `dispose()` and not GTK's `teardown` is the
+teardown authority).
+
+`@gjsify/gtk-host/solid`'s `listRows` is the Solid half, and it is one reactive root
+per ROW WIDGET rather than per bound row: a row sees an ACCESSOR, so a content change
+behind an unchanged key writes one property and the widget survives — asserted by
+identity in `list/list.spec.ts`. `@gjsify/react-native`'s `lists/controller.ts` is the
+React half, and it defers every row render to a microtask, which is React's constraint
+and not GTK's: the adapter's `render()` refuses a re-entrant flush by name, and GTK
+binds rows from inside React's own commit.
+
 ## Lifetime
 
 `remove` detaches and is reversible, because frameworks move nodes. The wrapper

--- a/packages/framework/gtk-host/README.md
+++ b/packages/framework/gtk-host/README.md
@@ -127,7 +127,10 @@ would otherwise own a copy of. `ListController` is that half, in a subpath rathe
 a package: a `/core` subpath beats a new `-core` package unless a separate NAME buys a
 package-level cycle or an independent external consumer, and neither is in play.
 
-It imports GTK and GObject and nothing else — no React, no Solid, no Vue — and the
+It imports Gtk, GObject and Gio and nothing else — no React, no Solid, no Vue; `Gio`
+is not an oversight in that list but the module's centrepiece, since the model IS a
+`Gio.ListStore`. The constraint that matters is the framework one, and
+`scripts/check-adapter-import-direction.mjs` enforces it rather than this sentence. The
 dialect supplies three callbacks:
 
 | callback | called from | what it owes |
@@ -139,8 +142,11 @@ dialect supplies three callbacks:
 **Take the carrier ONCE, in `mountRow`.** GTK recycles a carrier across `bind`/`unbind`,
 and `adopt` snapshots what a container already held without being able to tell the
 host's own previous child from application chrome — so a dialect that adopts per bind
-refuses with `occupied-slot` on the first recycled row. `host.spec.ts` pins that
-refusal; `list/controller.ts` carries the three measurements the controller's shape
+refuses with `occupied-slot`. `host.spec.ts` pins that
+refusal. The route that reaches it FIRST is not GTK recycling a carrier, which needs
+scrolling: it is `setRows` over unchanged keys, which shows every live row again through
+the same handle with no GTK involvement, so a per-show `adopt` fails on the first content
+change; `list/controller.ts` carries the three measurements the controller's shape
 follows from (the `Gio.ListStore` carrier identity, why a data change SPLICES rather
 than emitting `items-changed`, and why `dispose()` and not GTK's `teardown` is the
 teardown authority).

--- a/packages/framework/gtk-host/package.json
+++ b/packages/framework/gtk-host/package.json
@@ -14,6 +14,10 @@
             "types": "./lib/types/style/index.d.ts",
             "default": "./lib/esm/style/index.js"
         },
+        "./list": {
+            "types": "./lib/types/list/index.d.ts",
+            "default": "./lib/esm/list/index.js"
+        },
         "./vue": {
             "types": "./lib/types/adapters/vue.d.ts",
             "default": "./lib/esm/adapters/vue.js"

--- a/packages/framework/gtk-host/src/adapters/solid.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.ts
@@ -241,10 +241,9 @@ export function listRows<Row extends ListRowKey>(
                 return {
                     show(next: Row | null, at: number): void {
                         // BATCHED, because the two writes are one event. Unbatched, the
-                        // index lands first and the row's effects run once against the
-                        // row that is on its way out — on `unbind` that index is GTK's
-                        // invalid-position sentinel, so the row repaints with it before
-                        // disappearing.
+                        // index lands first and every effect reading it runs once
+                        // against the row that is on its way out — visible work for a
+                        // state no frame will ever show.
                         //
                         // `setRow` takes the updater form: a `Row` may itself be
                         // callable, and the value form would run it as one.

--- a/packages/framework/gtk-host/src/adapters/solid.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.ts
@@ -11,7 +11,18 @@
 // exactly why the host defers materialisation until a widget is actually needed
 // (ADR 0027 § Decision 5). An adapter cannot paper that over; the host has to.
 
-import { For as SolidFor, Index as SolidIndex, Show as SolidShow, onCleanup, splitProps, untrack } from 'solid-js';
+import {
+    For as SolidFor,
+    Index as SolidIndex,
+    Show as SolidShow,
+    batch,
+    createMemo,
+    createRoot,
+    createSignal,
+    onCleanup,
+    splitProps,
+    untrack,
+} from 'solid-js';
 import { createRenderer } from 'solid-js/universal';
 import type Gtk from '@girs/gtk-4.0';
 
@@ -32,6 +43,7 @@ import {
     setText,
     widgetOf,
 } from '../host.js';
+import type { ListRowKey, ListRowSink } from '../list/index.js';
 import type { HostElement, HostNode, HostText } from '../types.js';
 
 const HOST_KINDS = new Set(['element', 'text', 'anchor']);
@@ -176,6 +188,85 @@ export function mount(code: () => HostNode, container: Gtk.Widget): () => void {
         // blocks JS callbacks during GC — an undisconnected handler outlives the
         // tree it belonged to.
         destroyChildren(root);
+    };
+}
+
+/**
+ * What `listRows` keeps for one ROW WIDGET: a way to show a row in it, and a way to
+ * let go. Opaque to the controller, which stores it and hands it back.
+ */
+export interface ListRowHandle<Row extends ListRowKey> {
+    show(row: Row | null, index: number): void;
+    dispose(): void;
+}
+
+/**
+ * Solid's half of a `Gtk.ListView`, for `ListController` in `@gjsify/gtk-host/list`.
+ *
+ * The controller owns the model, the factory and the key diff — none of which has a
+ * framework in it. This supplies the three callbacks it cannot have: what to put in a
+ * row widget, what to show there, and how to let go.
+ *
+ * ONE REACTIVE ROOT PER ROW WIDGET, created in `mountRow` and never again. Two reasons,
+ * and both are measurements someone already paid for. The carrier is taken ONCE,
+ * because `adopt` snapshots what a container already held and cannot tell our own
+ * previous child from application chrome — GTK recycles a carrier across bind/unbind,
+ * so taking it per bind refuses with `occupied-slot` on the first recycled row
+ * (`host.spec.ts` pins that). And a row's signals live INSIDE the root rather than
+ * beside it: a computation created with no owner is never disposed, which for a
+ * per-row memo is a leak per row.
+ *
+ * What the row sees is an ACCESSOR, not a value, and that is the capability this seam
+ * buys over re-rendering: when `setRows` finds unchanged keys over changed content, the
+ * controller shows every live row again, this writes one signal, and Solid updates the
+ * properties that actually changed — the widgets stay. Only the transition between
+ * "holds a row" and "holds nothing" rebuilds the subtree, which is what `present`
+ * isolates.
+ */
+export function listRows<Row extends ListRowKey>(
+    renderRow: (row: () => Row, index: () => number) => HostNode,
+): ListRowSink<Row, ListRowHandle<Row>> {
+    return {
+        mountRow(item: Gtk.ListItem): ListRowHandle<Row> {
+            const carrier = adopt(item);
+            return createRoot((disposeRoot) => {
+                const [row, setRow] = createSignal<Row | null>(null);
+                const [index, setIndex] = createSignal(0);
+                const present = createMemo(() => row() !== null);
+                // `insert` takes an ACCESSOR — the renderer's own contract, and the
+                // reason nothing here has to re-run `renderRow` on a content change.
+                insert(carrier, () => (present() ? renderRow(row as () => Row, index) : null));
+                return {
+                    show(next: Row | null, at: number): void {
+                        // BATCHED, because the two writes are one event. Unbatched, the
+                        // index lands first and the row's effects run once against the
+                        // row that is on its way out — on `unbind` that index is GTK's
+                        // invalid-position sentinel, so the row repaints with it before
+                        // disappearing.
+                        //
+                        // `setRow` takes the updater form: a `Row` may itself be
+                        // callable, and the value form would run it as one.
+                        batch(() => {
+                            setIndex(at);
+                            setRow(() => next);
+                        });
+                    },
+                    dispose(): void {
+                        disposeRoot();
+                        // Disposing tears down the reactive scopes and leaves the
+                        // widgets where they are — the same gap `mount`'s disposer
+                        // closes, for the same measured reason.
+                        destroyChildren(carrier);
+                    },
+                };
+            });
+        },
+        showRow(handle: ListRowHandle<Row>, row: Row | null, index: number): void {
+            handle.show(row, index);
+        },
+        disposeRow(handle: ListRowHandle<Row>): void {
+            handle.dispose();
+        },
     };
 }
 

--- a/packages/framework/gtk-host/src/adapters/solid.ts
+++ b/packages/framework/gtk-host/src/adapters/solid.ts
@@ -207,14 +207,16 @@ export interface ListRowHandle<Row extends ListRowKey> {
  * framework in it. This supplies the three callbacks it cannot have: what to put in a
  * row widget, what to show there, and how to let go.
  *
- * ONE REACTIVE ROOT PER ROW WIDGET, created in `mountRow` and never again. Two reasons,
- * and both are measurements someone already paid for. The carrier is taken ONCE,
- * because `adopt` snapshots what a container already held and cannot tell our own
- * previous child from application chrome — GTK recycles a carrier across bind/unbind,
- * so taking it per bind refuses with `occupied-slot` on the first recycled row
- * (`host.spec.ts` pins that). And a row's signals live INSIDE the root rather than
- * beside it: a computation created with no owner is never disposed, which for a
- * per-row memo is a leak per row.
+ * ONE REACTIVE ROOT PER ROW WIDGET, created in `mountRow` and never again, for two
+ * reasons that are not the same kind of thing. The carrier is taken ONCE because taking
+ * it per bind is REFUSED: `adopt` snapshots what a container already held and cannot
+ * tell our own previous child from application chrome, and the same carrier comes back
+ * on the next show, so the second one reads our own row as someone else's and raises
+ * `occupied-slot` (measured against this seam; `host.spec.ts` pins the same refusal
+ * from the host's side). The row's signals live INSIDE the root rather than beside it
+ * for a documented reason rather than a measured one — Solid never disposes a
+ * computation created with no owner, which for a per-row memo would be one leak per
+ * row.
  *
  * What the row sees is an ACCESSOR, not a value, and that is the capability this seam
  * buys over re-rendering: when `setRows` finds unchanged keys over changed content, the

--- a/packages/framework/gtk-host/src/list/controller.ts
+++ b/packages/framework/gtk-host/src/list/controller.ts
@@ -14,7 +14,13 @@
 // through three callbacks (`ListRowSink`): mount, show, dispose. This module imports no
 // React, no Solid and no Vue, and must not — that constraint is the whole point, and it
 // is what lets the measurements below be stated ONCE for every renderer that binds to
-// them.
+// them. It is CHECKED, by `scripts/check-adapter-import-direction.mjs`, which scans this
+// directory for a framework import and fails on one: a constraint whose only enforcement
+// is the sentence asserting it is the shape this milestone has already paid for twice.
+//
+// The toolkit imports below are Gtk, GObject and Gio — three, not the two an earlier
+// draft of this paragraph claimed. `Gio` is not incidental: the model IS a
+// `Gio.ListStore`, which is the first measurement in this header.
 //
 // Three of those measurements are the reason this file has the shape it has, all on
 // gtk 4.22.4 / gjs 1.88.1.
@@ -86,11 +92,18 @@ export interface ListRowSink<Row extends ListRowKey, Handle> {
     /**
      * GTK made a row widget's carrier; put something in it and keep what you need.
      *
-     * Called from `setup`, ONCE per row widget, and that is not a convenience: GTK
-     * reuses a carrier across `bind`/`unbind`, and `adopt`'s `foreign` snapshot cannot
-     * tell the host's own previous child from application chrome — so a dialect that
-     * adopts per bind meets `occupied-slot` on the first recycled row. `host.spec.ts`
-     * pins that refusal. Adopt here, keep the element in the handle.
+     * Called from `setup`, ONCE per row widget, and that is not a convenience: `adopt`'s
+     * `foreign` snapshot cannot tell the host's own previous child from application
+     * chrome, so taking the carrier a SECOND time reads our own row as someone else's
+     * and refuses with `occupied-slot`. `host.spec.ts` pins that refusal.
+     *
+     * TWO routes reach it, and the nearer one is not the obvious one. GTK reusing a
+     * carrier across `bind`/`unbind` is the route people expect, and it needs scrolling
+     * or recycling to happen at all. The route that fires FIRST is `setRows` over
+     * unchanged keys: it shows every live row again through the same handle, with no
+     * GTK involvement, so a dialect that adopts per show meets the refusal on its first
+     * content change — measured, and it is what `list.spec.ts`'s in-place vector
+     * exercises. Adopt here, keep the element in the handle.
      */
     mountRow(item: Gtk.ListItem): Handle;
     /**
@@ -104,6 +117,29 @@ export interface ListRowSink<Row extends ListRowKey, Handle> {
     /** GTK is done with this row widget, or the controller is. Let go of everything. */
     disposeRow(handle: Handle): void;
 }
+
+/**
+ * WHERE A SINK'S OWN THROW GOES, because there are TWO paths and they differ.
+ *
+ * `setRows` over unchanged keys calls `showRow` DIRECTLY — no GTK in between — so a
+ * throw there propagates out of `setRows` to whoever called it, and a dialect can catch
+ * it. Every other call (`setup`, `bind`, `unbind`, `teardown`) runs inside a GObject
+ * signal callback, where GJS does not let an exception cross the C frame: it is swallowed
+ * and logged as `Gjs-CRITICAL … JS ERROR`, the emission continues, and the controller
+ * carries on with a row that never rendered. A diagnostics gate sees that; nothing else
+ * does.
+ *
+ * The asymmetry is not fixable from here — it is GJS's signal boundary — so it is
+ * DECLARED instead, and it decides where a sink should put its own error handling. It
+ * bites unevenly: React Native's sink only fills a Map on this path and cannot really
+ * throw, while Solid's `show()` runs the row's reactive updates synchronously inside
+ * `batch()`, so an error in application code lands here.
+ *
+ * Note what is NOT the answer: `@gjsify/react-native`'s `onRowError` is React's own root
+ * error channel, not this seam's. A sink that needs one owns it, because only the
+ * dialect knows what a row's error means — a controller-level hook would have to decide
+ * whether to keep binding, and neither answer is right for every renderer.
+ */
 
 /**
  * A `Gtk.ListView`'s model, factory and per-row handles.

--- a/packages/framework/gtk-host/src/list/controller.ts
+++ b/packages/framework/gtk-host/src/list/controller.ts
@@ -1,0 +1,250 @@
+// The model, the factory and the row bookkeeping behind a `Gtk.ListView` — the half of
+// a list that no UI framework can make different.
+//
+// A `Gtk.ListView` is not an element and cannot be one: it installs no child-adding
+// method at all, and the carrier its factory hands back is not a `Gtk.Widget`. Both are
+// measured, both are pinned as vectors in `host.spec.ts`, and ADR 0028 § Amendment is
+// where the table's answer to them lives — this file does not restate them. What
+// follows from them is that every dialect wanting lists needs the same three things: a
+// `Gio.ListStore` of carriers, a `Gtk.SignalListItemFactory`, and a key diff deciding
+// whether GTK has to hear about a change at all. Until this module existed, React
+// Native had all of that and Vue and Solid had none of it.
+//
+// WHAT IS NOT HERE IS RENDERING. A row's subtree belongs to the dialect and is reached
+// through three callbacks (`ListRowSink`): mount, show, dispose. This module imports no
+// React, no Solid and no Vue, and must not — that constraint is the whole point, and it
+// is what lets the measurements below be stated ONCE for every renderer that binds to
+// them.
+//
+// Three of those measurements are the reason this file has the shape it has, all on
+// gtk 4.22.4 / gjs 1.88.1.
+//
+// **The carrier is a one-line `GObject` subclass with a plain JS field.** MEASURED:
+// `Gio.ListStore.get_item(0)` hands back the SAME JS wrapper that was appended
+// (`back === a`), and the field survived a forced GC while only the store held the
+// object. The alternative — a `Gtk.StringList` of indices — works too and costs a parse
+// plus an integer that means nothing on its own; this costs one `registerClass`.
+//
+// **A data change SPLICES the whole model.** MEASURED: `items_changed(0, 1, 1)` over
+// the same carrier object produced no rebind at all, while `splice(0, 1, [fresh])`
+// produced `setup, bind 0, unbind 0, teardown`. GTK re-binds a row when its model
+// object changes, not when the object's contents do — so replacing the carriers is what
+// makes a content change visible.
+//
+// **`dispose()` is the authority on teardown, not GTK's `teardown` signal.** MEASURED:
+// destroying a window whose `Gtk.SignalListItemFactory` still had JS handlers connected
+// produced six `Gjs-CRITICAL` lines — "Attempting to call back into JSAPI during the
+// sweeping phase of GC … the JS callback not invoked. The offending signal was
+// unbind/teardown" — and ran none of them. So a per-row handle released only from
+// `teardown` would never be released, and every signal a dialect connected inside that
+// row would stay connected for the life of the process. Disconnecting the four handlers
+// and nulling `factory`/`model` before the widget becomes garbage silenced it
+// completely (measured: a forced `imports.system.gc()` afterwards printed nothing).
+//
+// Values through `gi://`, types through `@girs/*`.
+
+import Gio from 'gi://Gio';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk?version=4.0';
+
+/**
+ * A row's identity, and the only thing this layer reads off a row.
+ *
+ * `key` decides whether the model has to be rebuilt at all. Everything else a dialect
+ * wants to carry — a render function, a component, a plain record — rides along in the
+ * type parameter and is handed straight back to `showRow`.
+ */
+export interface ListRowKey {
+    readonly key: string;
+}
+
+/**
+ * The carrier a `Gio.ListStore` holds, because a `Gio.ListStore` holds `GObject`s.
+ *
+ * One property, and it is a plain JS field rather than a `GObject` property: a
+ * registered property would need a GType for whatever a dialect puts in a row, and the
+ * `get_item` measurement in the header says the JS field is safe — the store keeps the
+ * GObject alive and GJS keeps the wrapper with it.
+ */
+const ListRowCarrier = GObject.registerClass(
+    { GTypeName: 'GjsifyGtkHostListRow' },
+    class ListRowCarrier extends GObject.Object {
+        row: ListRowKey | null = null;
+    },
+);
+
+type ListRowCarrierInstance = InstanceType<typeof ListRowCarrier>;
+
+/**
+ * The dialect's half of a list — three callbacks, one per factory phase that needs one.
+ *
+ * `Handle` is whatever the dialect needs to keep per ROW WIDGET: a React root, a Solid
+ * disposer plus a setter, a Vue app instance. The controller stores it, hands it back,
+ * and never looks inside it.
+ */
+export interface ListRowSink<Row extends ListRowKey, Handle> {
+    /**
+     * GTK made a row widget's carrier; put something in it and keep what you need.
+     *
+     * Called from `setup`, ONCE per row widget, and that is not a convenience: GTK
+     * reuses a carrier across `bind`/`unbind`, and `adopt`'s `foreign` snapshot cannot
+     * tell the host's own previous child from application chrome — so a dialect that
+     * adopts per bind meets `occupied-slot` on the first recycled row. `host.spec.ts`
+     * pins that refusal. Adopt here, keep the element in the handle.
+     */
+    mountRow(item: Gtk.ListItem): Handle;
+    /**
+     * Show `row` in the widget behind `handle`, or empty it when `row` is `null`.
+     *
+     * Called from `bind`, from `unbind` with `null`, and again for every live row when
+     * `setRows` sees unchanged keys over changed content — which GTK does not re-bind
+     * for us (the splice measurement in the header says why).
+     */
+    showRow(handle: Handle, row: Row | null, index: number): void;
+    /** GTK is done with this row widget, or the controller is. Let go of everything. */
+    disposeRow(handle: Handle): void;
+}
+
+/**
+ * A `Gtk.ListView`'s model, factory and per-row handles.
+ *
+ * Constructed by a dialect with its `ListRowSink`, attached to a view someone else
+ * created, disposed from that someone's own cleanup. Nothing here is reactive:
+ * `setRows` is called with the current rows and works out whether GTK has to hear
+ * about it.
+ */
+export class ListController<Row extends ListRowKey, Handle> {
+    readonly #store = Gio.ListStore.new(ListRowCarrier.$gtype);
+    readonly #factory = new Gtk.SignalListItemFactory();
+    readonly #handlers: number[] = [];
+    /** Every row widget GTK has set up, and what the dialect kept for it. */
+    readonly #handles = new Map<Gtk.ListItem, Handle>();
+    readonly #sink: ListRowSink<Row, Handle>;
+    #view: Gtk.ListView | null = null;
+    #keys: readonly string[] = [];
+    #disposed = false;
+
+    constructor(sink: ListRowSink<Row, Handle>) {
+        this.#sink = sink;
+        this.#handlers.push(
+            this.#factory.connect('setup', (_factory, item) => this.#setup(item as Gtk.ListItem)),
+            this.#factory.connect('bind', (_factory, item) => this.#bind(item as Gtk.ListItem)),
+            this.#factory.connect('unbind', (_factory, item) => this.#unbind(item as Gtk.ListItem)),
+            this.#factory.connect('teardown', (_factory, item) => this.#teardown(item as Gtk.ListItem)),
+        );
+    }
+
+    /**
+     * Give the view its model and factory.
+     *
+     * `Gtk.NoSelection` and not the store directly: `Gtk.ListView:model` is a
+     * `Gtk.SelectionModel`, and a plain `Gio.ListModel` is not one. `NoSelection` is the
+     * wrapper that says "no selection", and it is what this controller installs because
+     * a `Gtk.SingleSelection` would give rows a selected state nothing here would ever
+     * clear. Selection is a dialect-level feature nobody has asked for yet; adding it
+     * means widening `attach`, not reaching around it.
+     */
+    attach(view: Gtk.ListView): void {
+        this.#view = view;
+        view.set_factory(this.#factory);
+        view.set_model(Gtk.NoSelection.new(this.#store));
+    }
+
+    /**
+     * The rows GTK should be showing.
+     *
+     * The model is only touched when the KEYS changed. When they did not, every row's
+     * subtree is shown again instead — a row whose key is the same but whose data
+     * changed has to repaint, and the splice measurement says GTK will not re-bind it
+     * for us. That is strictly cheaper than a splice, which tears down every row.
+     */
+    setRows(rows: readonly Row[]): void {
+        if (this.#disposed) return;
+        const keys = rows.map((row) => row.key);
+        const sameKeys = keys.length === this.#keys.length && keys.every((key, index) => key === this.#keys[index]);
+        this.#keys = keys;
+        if (sameKeys) {
+            // The CARRIERS are updated in place, and then every live row is shown
+            // again. Both halves are needed: `bind` reads the row off the carrier, so
+            // leaving the old row there re-renders the old data — which is what the
+            // in-place vector caught when only the second half was here.
+            for (let index = 0; index < rows.length; index++) {
+                const carrier = this.#store.get_item(index) as ListRowCarrierInstance | null;
+                if (carrier !== null) carrier.row = rows[index] as Row;
+            }
+            for (const item of this.#handles.keys()) this.#bind(item);
+            return;
+        }
+        const carriers = rows.map((row) => {
+            const carrier = new ListRowCarrier();
+            carrier.row = row;
+            return carrier;
+        });
+        // ONE splice, not a per-row diff. `Gio.ListStore.splice` takes the whole
+        // replacement and emits one `items-changed`; a per-row diff would emit one per
+        // row, and each emission is a bind/unbind round trip through the dialect.
+        this.#store.splice(0, this.#store.get_n_items(), carriers);
+    }
+
+    /** How many rows GTK is currently holding a widget for. A spec seam and a leak detector. */
+    get liveRows(): number {
+        return this.#handles.size;
+    }
+
+    /**
+     * Release every row, disconnect every handler, and let go of the view.
+     *
+     * Called from the owner's cleanup, which runs while JS callbacks still work —
+     * unlike GTK's own `teardown`, which fires during GC sweeping when the view is
+     * collected and is BLOCKED there (measured, see the header). Idempotent, because an
+     * owner's cleanup and an explicit dispose both reach it.
+     */
+    dispose(): void {
+        if (this.#disposed) return;
+        this.#disposed = true;
+        // GTK FIRST, the dialect second, and the order is what makes the loop below
+        // safe: `set_model(null)` makes GTK give every bound row back, and a live
+        // `teardown` handler would then release a handle this loop is about to release
+        // again. Disconnecting is also the half the header's six criticals are about —
+        // it has to happen before the widgets become garbage either way.
+        for (const handler of this.#handlers) this.#factory.disconnect(handler);
+        this.#handlers.length = 0;
+        if (this.#view !== null) {
+            this.#view.set_factory(null);
+            this.#view.set_model(null);
+            this.#view = null;
+        }
+        this.#store.remove_all();
+        const handles = [...this.#handles.values()];
+        this.#handles.clear();
+        for (const handle of handles) this.#sink.disposeRow(handle);
+    }
+
+    #setup(item: Gtk.ListItem): void {
+        this.#handles.set(item, this.#sink.mountRow(item));
+    }
+
+    #bind(item: Gtk.ListItem): void {
+        const handle = this.#handles.get(item);
+        if (handle === undefined) return;
+        const carrier = item.get_item() as ListRowCarrierInstance | null;
+        this.#sink.showRow(handle, (carrier?.row ?? null) as Row | null, item.get_position());
+    }
+
+    #unbind(item: Gtk.ListItem): void {
+        const handle = this.#handles.get(item);
+        if (handle === undefined) return;
+        // `null` rather than reading the carrier back: GTK emits `unbind` while the
+        // item still answers `get_item()`, so asking would show the row that is being
+        // taken away. The position goes along unchanged, which is what a dialect
+        // animating a departure would need.
+        this.#sink.showRow(handle, null, item.get_position());
+    }
+
+    #teardown(item: Gtk.ListItem): void {
+        const handle = this.#handles.get(item);
+        if (handle === undefined) return;
+        this.#handles.delete(item);
+        this.#sink.disposeRow(handle);
+    }
+}

--- a/packages/framework/gtk-host/src/list/controller.ts
+++ b/packages/framework/gtk-host/src/list/controller.ts
@@ -202,11 +202,12 @@ export class ListController<Row extends ListRowKey, Handle> {
     dispose(): void {
         if (this.#disposed) return;
         this.#disposed = true;
-        // GTK FIRST, the dialect second, and the order is what makes the loop below
-        // safe: `set_model(null)` makes GTK give every bound row back, and a live
-        // `teardown` handler would then release a handle this loop is about to release
-        // again. Disconnecting is also the half the header's six criticals are about —
-        // it has to happen before the widgets become garbage either way.
+        // The GTK half FIRST, and disconnecting first inside it. That is the half the
+        // header's six criticals are about — it has to happen before the widgets
+        // become garbage — and doing it before `set_model(null)` also means GTK cannot
+        // re-enter the sink through `teardown` while the controller is dismantling
+        // itself, so the release loop below sees exactly the handles that were live
+        // rather than a set something else is emptying underneath it.
         for (const handler of this.#handlers) this.#factory.disconnect(handler);
         this.#handlers.length = 0;
         if (this.#view !== null) {

--- a/packages/framework/gtk-host/src/list/controller.ts
+++ b/packages/framework/gtk-host/src/list/controller.ts
@@ -235,10 +235,13 @@ export class ListController<Row extends ListRowKey, Handle> {
     #unbind(item: Gtk.ListItem): void {
         const handle = this.#handles.get(item);
         if (handle === undefined) return;
-        // `null` rather than reading the carrier back: GTK emits `unbind` while the
-        // item still answers `get_item()`, so asking would show the row that is being
-        // taken away. The position goes along unchanged, which is what a dialect
-        // animating a departure would need.
+        // `null` rather than reading the carrier back, and MEASURED rather than
+        // assumed (gtk 4.22.4 / gjs 1.88.1): at `unbind` the item still answers
+        // `get_item()` with its carrier and `get_position()` with the REAL position —
+        // it is `setup` and `teardown` that see GTK's invalid-position sentinel
+        // (4294967295), and `teardown` that sees a null item. So reading the carrier
+        // here would show the row being taken away, while the position is honest and
+        // goes along, which is what a dialect animating a departure needs.
         this.#sink.showRow(handle, null, item.get_position());
     }
 

--- a/packages/framework/gtk-host/src/list/index.ts
+++ b/packages/framework/gtk-host/src/list/index.ts
@@ -6,3 +6,4 @@
 // GTK and GObject knowledge that three dialects would otherwise each own a copy of.
 
 export { ListController, type ListRowKey, type ListRowSink } from './controller.js';
+export { onScrollNearEnd } from './scroll.js';

--- a/packages/framework/gtk-host/src/list/index.ts
+++ b/packages/framework/gtk-host/src/list/index.ts
@@ -1,0 +1,8 @@
+// `@gjsify/gtk-host/list` — the framework-neutral half of a GTK4 list.
+//
+// A subpath and not a package: the repository's rule is that "a `/core` subpath beats a
+// new `-core` package — a separate NAME needs a package-level cycle or independent
+// external consumers, never onboarding cost". There is neither here. What there is, is
+// GTK and GObject knowledge that three dialects would otherwise each own a copy of.
+
+export { ListController, type ListRowKey, type ListRowSink } from './controller.js';

--- a/packages/framework/gtk-host/src/list/list.spec.ts
+++ b/packages/framework/gtk-host/src/list/list.spec.ts
@@ -28,7 +28,7 @@ import { createElement, effect, listRows, setProp, type ListRowHandle } from '..
 import { gtkChildren, installDiagnosticsGate } from '../conformance/index.js';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
 import { GTK_HOSTS, gated } from '../testing/gate.mjs';
-import { ListController, type ListRowSink } from './controller.js';
+import { ListController, onScrollNearEnd, type ListRowSink } from './index.js';
 import type { HostNode } from '../types.js';
 
 /** The row shape every vector below uses. */
@@ -287,6 +287,47 @@ export default async () => {
                     expect(labels(mount.view)).toStrictEqual([]);
                     expect(mount.census.mounted).toBe(1);
                 });
+            });
+        });
+
+        await gated(diagnostics, 'the scroll edge behind an end-reached callback', async () => {
+            await it('fires once per arrival, and not on a list with nothing to scroll', () => {
+                // `onScrollNearEnd` moved into this subpath with the controller, and its
+                // only test moved the other way: `@gjsify/react-native`'s `onEndReached`
+                // vector reaches it through a re-export, so this package could publish a
+                // broken scroll edge with its own suite green. Its docstring already
+                // claims it is "asserted, in a spec that presents nothing" — this is
+                // that spec, in the package that owns the code.
+                const scroller = new Gtk.ScrolledWindow();
+                const adjustment = scroller.get_vadjustment();
+                const seen: number[] = [];
+                const stop = onScrollNearEnd(scroller, 'vertical', 0.5, (distance) => seen.push(distance));
+
+                // Nothing to scroll (`upper <= page-size`) is the state every list is in
+                // before it has been allocated, and firing there would call the listener
+                // on mount for every list in the application.
+                expect(seen).toStrictEqual([]);
+                adjustment.set_upper(1000);
+                adjustment.set_page_size(100);
+                adjustment.set_value(100);
+                expect(seen).toStrictEqual([]);
+
+                // 1000 - 100 - 880 = 20, inside 0.5 page-lengths of the end.
+                adjustment.set_value(880);
+                expect(seen).toStrictEqual([20]);
+                // ONCE PER ARRIVAL: resting further into the threshold issues no second
+                // call, which is what keeps a "load more" caller from paging per frame.
+                adjustment.set_value(890);
+                expect(seen).toStrictEqual([20]);
+
+                // And the disposer really disconnects — the half nothing watched. GJS
+                // blocks a JS callback during GC sweeping, so a handler left on an
+                // adjustment outlives the list it belonged to for the life of the
+                // process, and the caller has no other way to let go.
+                stop();
+                adjustment.set_value(100);
+                adjustment.set_value(890);
+                expect(seen).toStrictEqual([20]);
             });
         });
     });

--- a/packages/framework/gtk-host/src/list/list.spec.ts
+++ b/packages/framework/gtk-host/src/list/list.spec.ts
@@ -28,7 +28,7 @@ import { createElement, effect, listRows, setProp, type ListRowHandle } from '..
 import { gtkChildren, installDiagnosticsGate } from '../conformance/index.js';
 import { registerBuiltinWidgets } from '../descriptors/index.js';
 import { GTK_HOSTS, gated } from '../testing/gate.mjs';
-import { ListController } from './controller.js';
+import { ListController, type ListRowSink } from './controller.js';
 import type { HostNode } from '../types.js';
 
 /** The row shape every vector below uses. */
@@ -80,10 +80,45 @@ const rowBody = (row: () => Row, index: () => number): HostNode => {
 /** Let every queued microtask run — where a dialect that defers would have done its work. */
 const drain = (): Promise<void> => new Promise<void>((resolve) => queueMicrotask(resolve));
 
+/**
+ * How many row widgets the dialect was asked to mount, and how many to release.
+ *
+ * `liveRows` cannot answer the second question — it says the controller FORGOT a
+ * handle, not that the dialect was TOLD to let go of it, and a controller that forgets
+ * without telling leaks a reactive root and every handler inside that row for the life
+ * of the process. That is the header's third measurement seen from the seam, and
+ * nothing but the seam can see it: after GTK has dropped a row's widgets there is no
+ * tree left to ask. Measured as a gap — removing `disposeRow` from `#teardown` left
+ * every other vector in this file green.
+ */
+interface Census {
+    mounted: number;
+    released: number;
+}
+
 interface Mounted {
     readonly view: Gtk.ListView;
     readonly controller: ListController<Row, ListRowHandle<Row>>;
+    readonly census: Census;
     setRows(rows: readonly Row[]): Promise<void>;
+}
+
+/** The real Solid sink, counted on both sides. Nothing about a row is simulated. */
+function counted(census: Census): ListRowSink<Row, ListRowHandle<Row>> {
+    const rows = listRows<Row>(rowBody);
+    return {
+        mountRow(item) {
+            census.mounted += 1;
+            return rows.mountRow(item);
+        },
+        showRow(handle, row, index) {
+            rows.showRow(handle, row, index);
+        },
+        disposeRow(handle) {
+            census.released += 1;
+            rows.disposeRow(handle);
+        },
+    };
 }
 
 /**
@@ -98,13 +133,15 @@ interface Mounted {
 async function mounted(body: (mount: Mounted) => Promise<void>): Promise<void> {
     const window = new Gtk.Window();
     const view = new Gtk.ListView();
-    const controller = new ListController<Row, ListRowHandle<Row>>(listRows<Row>(rowBody));
+    const census: Census = { mounted: 0, released: 0 };
+    const controller = new ListController<Row, ListRowHandle<Row>>(counted(census));
     controller.attach(view);
     window.set_child(view);
     try {
         await body({
             view,
             controller,
+            census,
             setRows: async (rows) => {
                 controller.setRows(rows);
                 await drain();
@@ -181,6 +218,9 @@ export default async () => {
                     // GTK tears the row widgets down on the splice, and the controller
                     // hands each handle back to the dialect as it goes.
                     expect(mount.controller.liveRows).toBe(0);
+                    // BOTH sides of the seam, not just the controller's own count.
+                    expect(mount.census.mounted > 0).toBe(true);
+                    expect(mount.census.released).toBe(mount.census.mounted);
                 });
             });
 
@@ -197,6 +237,9 @@ export default async () => {
                     expect(mount.controller.liveRows).toBe(0);
                     expect(mount.view.get_factory()).toBe(null);
                     expect(mount.view.get_model()).toBe(null);
+                    // And every row the dialect mounted was handed back — `dispose()`
+                    // reaches the sink for the rows GTK never tore down itself.
+                    expect(mount.census.released).toBe(mount.census.mounted);
                     // Idempotent: the owner's cleanup and an explicit dispose both
                     // reach it, and `mounted` is about to call it a third time.
                     mount.controller.dispose();

--- a/packages/framework/gtk-host/src/list/list.spec.ts
+++ b/packages/framework/gtk-host/src/list/list.spec.ts
@@ -1,0 +1,219 @@
+// A list with a SECOND dialect on it — Solid rows over the shared controller.
+//
+// The point of this file is not that Solid can render a label. It is that the model,
+// the factory, the key diff and the teardown authority in `controller.ts` are reached
+// here through the same three callbacks React Native reaches them through, so a
+// measurement stated once in that file is a measurement two renderers obey. An
+// extraction nothing else uses is a refactor; this is what makes it a capability.
+//
+// THE VIEW IS ROOTED IN A `Gtk.Window`, and that is a precondition rather than a
+// convenience: a `Gtk.ListView` binds NOTHING while detached, and binds every row the
+// moment it is rooted. That is measured in `host.spec.ts` ("takes the item a REAL
+// Gtk.ListView factory hands out"), which is also where the window's own shape comes
+// from — CONSTRUCTED and never presented, so nothing here needs a compositor beyond
+// the `Gtk.init()` this gate already requires.
+//
+// ROWS ARE DRAINED WITH AN `await`, never a synchronous flush seam. Solid happens to
+// need no deferral at all — `@gjsify/gtk-host/react` refuses a re-entrant flush BY NAME
+// and React Native's sink therefore renders a row on a microtask, and that refusal is
+// React's, not GTK's. The `await` is here anyway because it observes the REAL path
+// whichever of the two a dialect takes; a spec that reached for a flush seam would be
+// testing a shortcut and would go green against either.
+
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk?version=4.0';
+import { expect, it, on } from '@gjsify/unit';
+
+import { createElement, effect, listRows, setProp, type ListRowHandle } from '../adapters/solid.js';
+import { gtkChildren, installDiagnosticsGate } from '../conformance/index.js';
+import { registerBuiltinWidgets } from '../descriptors/index.js';
+import { GTK_HOSTS, gated } from '../testing/gate.mjs';
+import { ListController } from './controller.js';
+import type { HostNode } from '../types.js';
+
+/** The row shape every vector below uses. */
+interface Row {
+    readonly key: string;
+    readonly title: string;
+}
+
+const typeOf = (widget: Gtk.Widget): string =>
+    GObject.type_name((widget as unknown as { constructor: { $gtype: GObject.GType } }).constructor.$gtype) ??
+    '(unregistered GType)';
+
+/** Every `Gtk.Label`'s text under `root`, breadth-first — which is what a row renders to. */
+function labels(root: Gtk.Widget): string[] {
+    const out: string[] = [];
+    const queue: Gtk.Widget[] = [...gtkChildren(root)];
+    while (queue.length > 0) {
+        const widget = queue.shift() as Gtk.Widget;
+        if (typeOf(widget) === 'GtkLabel') out.push((widget as Gtk.Label).label);
+        queue.push(...gtkChildren(widget));
+    }
+    return out;
+}
+
+/** The first `Gtk.Label` under `root`, as an OBJECT — identity is what vector 2 asserts. */
+function firstLabel(root: Gtk.Widget): Gtk.Widget | null {
+    const queue: Gtk.Widget[] = [...gtkChildren(root)];
+    while (queue.length > 0) {
+        const widget = queue.shift() as Gtk.Widget;
+        if (typeOf(widget) === 'GtkLabel') return widget;
+        queue.push(...gtkChildren(widget));
+    }
+    return null;
+}
+
+/**
+ * A row, built the way COMPILED JSX builds one: an element, and an effect per property.
+ *
+ * The `effect` is the whole reason the accessor form of the seam matters — it re-runs
+ * on a content change and writes the ONE property that moved, which is how vector 2 can
+ * assert the widget survived.
+ */
+const rowBody = (row: () => Row, index: () => number): HostNode => {
+    const label = createElement('GtkLabel');
+    effect(() => setProp(label, 'label', `${index()}:${row().title}`));
+    return label;
+};
+
+/** Let every queued microtask run — where a dialect that defers would have done its work. */
+const drain = (): Promise<void> => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+interface Mounted {
+    readonly view: Gtk.ListView;
+    readonly controller: ListController<Row, ListRowHandle<Row>>;
+    setRows(rows: readonly Row[]): Promise<void>;
+}
+
+/**
+ * A controller on a real view in a real window, torn down in the one safe order.
+ *
+ * `dispose()` BEFORE `window.destroy()`, always: the controller is the authority on
+ * teardown precisely because GTK's own `teardown` signal fires during GC sweeping,
+ * where GJS blocks the callback (`controller.ts` carries the measurement). The other
+ * order is the one that leaves handlers on a factory whose view is about to be
+ * collected.
+ */
+async function mounted(body: (mount: Mounted) => Promise<void>): Promise<void> {
+    const window = new Gtk.Window();
+    const view = new Gtk.ListView();
+    const controller = new ListController<Row, ListRowHandle<Row>>(listRows<Row>(rowBody));
+    controller.attach(view);
+    window.set_child(view);
+    try {
+        await body({
+            view,
+            controller,
+            setRows: async (rows) => {
+                controller.setRows(rows);
+                await drain();
+            },
+        });
+    } finally {
+        controller.dispose();
+        window.destroy();
+    }
+}
+
+export default async () => {
+    await on(GTK_HOSTS, async () => {
+        Gtk.init();
+        registerBuiltinWidgets();
+        const diagnostics = installDiagnosticsGate();
+
+        await gated(diagnostics, 'a Solid list over the shared controller', async () => {
+            await it('renders one row per model entry, with its position', async () => {
+                await mounted(async (mount) => {
+                    await mount.setRows([
+                        { key: 'a', title: 'alpha' },
+                        { key: 'b', title: 'beta' },
+                        { key: 'c', title: 'gamma' },
+                    ]);
+                    expect(labels(mount.view)).toStrictEqual(['0:alpha', '1:beta', '2:gamma']);
+                    // The controller's own count, not a widget walk: a row GTK holds a
+                    // widget for is a handle the dialect was asked to mount.
+                    expect(mount.controller.liveRows).toBe(3);
+                });
+            });
+
+            await it('updates a row IN PLACE when its key did not change, keeping the widget', async () => {
+                // The vector the extraction exists for, and it asserts two things at
+                // once. That the controller pushes a content change through to a row
+                // whose model object GTK will not re-bind — and that the CARRIER was
+                // taken once, at setup: a dialect adopting per bind would refuse this
+                // second show with `occupied-slot`, which `host.spec.ts` pins.
+                //
+                // Widget IDENTITY is the assertion React Native's equivalent cannot
+                // make: its row rebuilds a React tree, Solid writes one property.
+                await mounted(async (mount) => {
+                    await mount.setRows([{ key: 'a', title: 'first' }]);
+                    const before = firstLabel(mount.view);
+                    expect(before !== null).toBe(true);
+                    expect(labels(mount.view)).toStrictEqual(['0:first']);
+                    await mount.setRows([{ key: 'a', title: 'second' }]);
+                    expect(labels(mount.view)).toStrictEqual(['0:second']);
+                    expect(firstLabel(mount.view)).toBe(before);
+                });
+            });
+
+            await it('splices the model when the keys DO change', async () => {
+                await mounted(async (mount) => {
+                    await mount.setRows([
+                        { key: 'a', title: 'a' },
+                        { key: 'b', title: 'b' },
+                    ]);
+                    expect(labels(mount.view)).toStrictEqual(['0:a', '1:b']);
+                    await mount.setRows([{ key: 'c', title: 'c' }]);
+                    expect(labels(mount.view)).toStrictEqual(['0:c']);
+                });
+            });
+
+            await it('empties the view when the rows go away, and lets go of every row', async () => {
+                await mounted(async (mount) => {
+                    await mount.setRows([
+                        { key: 'a', title: 'a' },
+                        { key: 'b', title: 'b' },
+                    ]);
+                    expect(mount.controller.liveRows).toBe(2);
+                    await mount.setRows([]);
+                    expect(labels(mount.view)).toStrictEqual([]);
+                    // GTK tears the row widgets down on the splice, and the controller
+                    // hands each handle back to the dialect as it goes.
+                    expect(mount.controller.liveRows).toBe(0);
+                });
+            });
+
+            await it('gives the view back on dispose, so nothing is left for GC to block', async () => {
+                // The hazard the header's third measurement is about: a factory whose
+                // handlers are still connected when its view is collected produced six
+                // Gjs criticals and ran none of them. The gate around this describe is
+                // what would report them; these three reads are what the gate cannot
+                // see — that the view really was let go, rather than merely quiet.
+                await mounted(async (mount) => {
+                    await mount.setRows([{ key: 'a', title: 'a' }]);
+                    expect(mount.controller.liveRows).toBe(1);
+                    mount.controller.dispose();
+                    expect(mount.controller.liveRows).toBe(0);
+                    expect(mount.view.get_factory()).toBe(null);
+                    expect(mount.view.get_model()).toBe(null);
+                    // Idempotent: the owner's cleanup and an explicit dispose both
+                    // reach it, and `mounted` is about to call it a third time.
+                    mount.controller.dispose();
+                });
+            });
+
+            await it('refuses nothing and does nothing once disposed', async () => {
+                await mounted(async (mount) => {
+                    await mount.setRows([{ key: 'a', title: 'a' }]);
+                    mount.controller.dispose();
+                    // A late `setRows` is a no-op rather than a throw: an owner's
+                    // cleanup order is not this layer's to police, and a rebuilt view
+                    // gets a fresh controller.
+                    await mount.setRows([{ key: 'b', title: 'b' }]);
+                    expect(labels(mount.view)).toStrictEqual([]);
+                });
+            });
+        });
+    });
+};

--- a/packages/framework/gtk-host/src/list/list.spec.ts
+++ b/packages/framework/gtk-host/src/list/list.spec.ts
@@ -94,6 +94,16 @@ const drain = (): Promise<void> => new Promise<void>((resolve) => queueMicrotask
 interface Census {
     mounted: number;
     released: number;
+    /**
+     * `showRow(handle, null, …)` — how a dialect is told to EMPTY a departing row.
+     *
+     * Counted separately because nothing else can see it. It is one of the three rows of
+     * the published seam contract, and replacing `#unbind`'s call with a no-op left every
+     * other vector in this file green: GTK emits `unbind` and then `teardown`, so a row
+     * that was never emptied is torn down a moment later and the widget tree ends up in
+     * the same state either way. Measured as a gap, exactly like `released`.
+     */
+    emptied: number;
 }
 
 interface Mounted {
@@ -112,6 +122,7 @@ function counted(census: Census): ListRowSink<Row, ListRowHandle<Row>> {
             return rows.mountRow(item);
         },
         showRow(handle, row, index) {
+            if (row === null) census.emptied += 1;
             rows.showRow(handle, row, index);
         },
         disposeRow(handle) {
@@ -133,7 +144,7 @@ function counted(census: Census): ListRowSink<Row, ListRowHandle<Row>> {
 async function mounted(body: (mount: Mounted) => Promise<void>): Promise<void> {
     const window = new Gtk.Window();
     const view = new Gtk.ListView();
-    const census: Census = { mounted: 0, released: 0 };
+    const census: Census = { mounted: 0, released: 0, emptied: 0 };
     const controller = new ListController<Row, ListRowHandle<Row>>(counted(census));
     controller.attach(view);
     window.set_child(view);
@@ -221,6 +232,12 @@ export default async () => {
                     // BOTH sides of the seam, not just the controller's own count.
                     expect(mount.census.mounted > 0).toBe(true);
                     expect(mount.census.released).toBe(mount.census.mounted);
+                    // And each one was EMPTIED on its way out. MEASURED on gtk 4.22.4:
+                    // a splice emits `unbind` before `teardown` and the item still
+                    // answers `get_item()` at `unbind`, so this is the moment a dialect
+                    // is told to let a departing row go — the third row of the contract,
+                    // and the one nothing observed until this counter existed.
+                    expect(mount.census.emptied).toBe(mount.census.mounted);
                 });
             });
 
@@ -246,15 +263,29 @@ export default async () => {
                 });
             });
 
-            await it('refuses nothing and does nothing once disposed', async () => {
+            await it('leaves the MODEL alone on a late setRows, not just the view', async () => {
                 await mounted(async (mount) => {
                     await mount.setRows([{ key: 'a', title: 'a' }]);
+                    // The model is captured BEFORE dispose, and that is the whole
+                    // vector. Asserting an empty VIEW here proves nothing about the
+                    // disposed guard: `dispose()` has already run `set_model(null)`, so
+                    // a late splice cannot reach the view whether the guard exists or
+                    // not — which is why removing `if (this.#disposed) return;` left an
+                    // earlier version of this case green. The model outlives that
+                    // detachment and is the thing the guard actually protects.
+                    const model = mount.view.get_model() as Gtk.SelectionModel;
+                    expect(model !== null).toBe(true);
                     mount.controller.dispose();
+                    expect(model.get_n_items()).toBe(0);
+
                     // A late `setRows` is a no-op rather than a throw: an owner's
                     // cleanup order is not this layer's to police, and a rebuilt view
-                    // gets a fresh controller.
+                    // gets a fresh controller. Without the guard this splices a carrier
+                    // into a model the owner believes it has finished with.
                     await mount.setRows([{ key: 'b', title: 'b' }]);
+                    expect(model.get_n_items()).toBe(0);
                     expect(labels(mount.view)).toStrictEqual([]);
+                    expect(mount.census.mounted).toBe(1);
                 });
             });
         });

--- a/packages/framework/gtk-host/src/list/scroll.ts
+++ b/packages/framework/gtk-host/src/list/scroll.ts
@@ -1,0 +1,71 @@
+// The scroll EDGE behind an "end reached" callback — geometry, not a framework.
+//
+// This sat in `@gjsify/react-native`'s list controller until the extraction, and it had
+// no business there: it is `Gtk.Adjustment` arithmetic with no React in it, and the next
+// dialect to want an infinite list would have re-measured the same three facts. That is
+// the failure `@gjsify/gtk-host/list` exists to prevent, one file over from where it was
+// being prevented.
+//
+// Values through `gi://` — none needed here, since an adjustment arrives from the
+// caller; types through `@girs/*`.
+
+import type Gtk from '@girs/gtk-4.0';
+
+/**
+ * Call `listener` when the scroller gets within `threshold` page-lengths of the end.
+ *
+ * `Gtk.Adjustment`, because that is where GTK keeps a scroll position: the scrolled
+ * window has no scroll signal of its own, and `notify::value` on the adjustment behind
+ * `hadjustment`/`vadjustment` is the only place the position is observable. MEASURED: a
+ * `Gtk.ScrolledWindow` hands out its adjustments with no window anywhere, and
+ * `set_value` on one raised `notify::value` — so this is drivable, and asserted, in a
+ * spec that presents nothing.
+ *
+ * `upper` and `page-size` are subscribed too, and not for completeness: `upper` grows
+ * when rows are added, which is the event that ARMS the next call — a list that grew has
+ * a new end.
+ *
+ * A list with nothing to scroll (`upper <= page-size`) never fires. That is the state
+ * every list is in before it has been allocated, and firing there would call the
+ * listener on mount for every list in the application.
+ *
+ * ONCE PER ARRIVAL, and this is the one policy here that came from a framework: it is
+ * React Native's `onEndReached` semantics. It is the core's behaviour anyway because
+ * every "load more" caller wants it — firing on every frame while the user rests at the
+ * bottom would issue a page request per frame. A dialect that wants the raw stream has
+ * the adjustment and can subscribe to it directly; this function is the debounced edge.
+ */
+export function onScrollNearEnd(
+    scroller: Gtk.ScrolledWindow,
+    axis: 'horizontal' | 'vertical',
+    threshold: number,
+    listener: (distanceFromEnd: number) => void,
+): () => void {
+    const adjustment = axis === 'horizontal' ? scroller.get_hadjustment() : scroller.get_vadjustment();
+    let armed = true;
+    const check = (): void => {
+        const page = adjustment.get_page_size();
+        const upper = adjustment.get_upper();
+        if (upper <= page) {
+            armed = true;
+            return;
+        }
+        const distance = upper - page - adjustment.get_value();
+        if (distance > threshold * page) {
+            armed = true;
+            return;
+        }
+        if (!armed) return;
+        armed = false;
+        listener(distance);
+    };
+    const handlers = [
+        adjustment.connect('notify::value', check),
+        adjustment.connect('notify::upper', check),
+        adjustment.connect('notify::page-size', check),
+    ];
+    check();
+    return () => {
+        for (const handler of handlers) adjustment.disconnect(handler);
+    };
+}

--- a/packages/framework/gtk-host/src/test.mts
+++ b/packages/framework/gtk-host/src/test.mts
@@ -13,6 +13,7 @@ import propsSuite from './props.spec.js';
 import gtkCssSuite from './style/gtk-css.spec.js';
 import gtkPropsSuite from './style/gtk-props.spec.js';
 import layoutSuite from './style/layout.spec.js';
+import listSuite from './list/list.spec.js';
 import paintSuite from './style/paint.spec.js';
 import sheetSuite from './style/sheet.spec.js';
 
@@ -29,6 +30,7 @@ run({
     conformanceSuite,
     generatorSuite,
     generatedSuite,
+    listSuite,
     solidSuite,
     vueSuite,
     reactSuite,

--- a/packages/framework/react-native/src/lists/components.ts
+++ b/packages/framework/react-native/src/lists/components.ts
@@ -37,7 +37,7 @@
 
 import { createElement, useEffect, useRef, type ComponentType, type ReactElement, type ReactNode } from 'react';
 
-import { ListController, onScrollNearEnd, rowKey, type ListRow } from './controller.js';
+import { createListController, onScrollNearEnd, rowKey, type ListRow, type ReactListController } from './controller.js';
 import { nodeProps, usePlan, type CommonProps, type Rendered } from '../components.js';
 import { ParentProvider } from '../parent-context.js';
 import { PrimitiveError } from '../primitives/errors.js';
@@ -158,7 +158,7 @@ function useListFrame(
     const rendered = usePlan(primitive, props);
     const view = useRef<unknown>(null);
     const scroller = useRef<unknown>(null);
-    const controller = useRef<ListController | null>(null);
+    const controller = useRef<ReactListController | null>(null);
     const latestRows = useRef(rows);
     latestRows.current = rows;
 
@@ -170,9 +170,9 @@ function useListFrame(
     useEffect(() => {
         const widget = view.current;
         if (isEmpty || widget === null || widget === undefined) return;
-        const owned = new ListController(onRowError === undefined ? {} : { onRowError });
+        const owned = createListController(onRowError === undefined ? {} : { onRowError });
         controller.current = owned;
-        owned.attach(widget as Parameters<ListController['attach']>[0]);
+        owned.attach(widget as Parameters<ReactListController['attach']>[0]);
         owned.setRows(latestRows.current);
         return () => {
             controller.current = null;

--- a/packages/framework/react-native/src/lists/controller.ts
+++ b/packages/framework/react-native/src/lists/controller.ts
@@ -1,70 +1,28 @@
-// The `Gtk.ListView` a list component OWNS, driven imperatively from `data`.
+// React's half of a `Gtk.ListView` — a root per row, and the scroll edge behind
+// `onEndReached`.
 //
-// WHY THIS IS NOT AN ELEMENT, and the whole design follows from three measurements on
-// gtk 4.22.4 / gjs 1.88.1:
+// The model, the factory, the key diff and the teardown authority are NOT here: they
+// are GTK and GObject facts with no framework in them, and they live once, in
+// `@gjsify/gtk-host/list`, where Vue and Solid reach the same measurements. What is
+// left here is the part only React can supply — the three callbacks
+// `ListController` asks a dialect for, and what a row's tree is made of.
 //
-// 1. **A `Gtk.ListView` takes no children.** It installs no `append`, no `add`, no
-//    `insert`, no `prepend`, no `remove` and no `set_child` — measured, against its
-//    prototype. What it has is `set_model` and `set_factory`. The host's placement
-//    policies are DATA naming a method for the host to call, so for this widget there
-//    is no method to name; the generated table therefore lists it `uncurated` and an
-//    attempted child insertion is refused by name. That refusal is correct, and it is
-//    the end of the road for "the list is an element whose children are the rows".
+// **The row's React tree is rendered on a MICROTASK, never inline.** GTK binds rows
+// from inside whatever call rooted or spliced the view — and in React that call is a
+// commit or an effect. `@gjsify/gtk-host/react`'s `render()` refuses a re-entrant flush
+// BY NAME ("React is already rendering or committing"), which is the right refusal and
+// would fire on every row. Deferring is uniform, needs no `catch`, and costs nothing
+// visible: GJS drains the microtask queue when the JS stack empties, which is before
+// GTK's next frame, so a row is never PAINTED empty.
 //
-// 2. **A `Gtk.ListItem` is not a `Gtk.Widget`.** `GObject.type_is_a(Gtk.ListItem,
-//    Gtk.Widget)` is FALSE (measured); it is a GObject with a writable `child`. So a
-//    React root cannot be created over a list item — it is created over the widget the
-//    factory puts INTO the item, which is what `setup` does here.
-//
-// 3. **Rows bind the moment the view is ROOTED IN A WINDOW.** With a 3-row model and
-//    all four factory signals connected: a bare view produced nothing, a view inside a
-//    `Gtk.ScrolledWindow` produced nothing, `measure()` produced nothing,
-//    `allocate(400, 400)` produced nothing and 50 main-loop iterations produced
-//    nothing — and putting the scroller into a `Gtk.Window` produced
-//    `setup, bind 0, setup, bind 1, setup, bind 2` immediately, with no `present()`,
-//    no map and no main loop. PRECONDITION: a `Gtk.Window` that is constructed and
-//    never presented; that is also what `lists.spec.ts` uses, and it is why the item
-//    factory is testable at all.
-//
-// FOUR CONSEQUENCES, each of which is a line of code below.
-//
-// **The row's React tree is rendered on a MICROTASK, never inline.** Measurement 3
-// says GTK binds rows from inside whatever call rooted or spliced the view — and in
-// React that call is a commit or an effect. `@gjsify/gtk-host/react`'s `render()`
-// refuses a re-entrant flush BY NAME ("React is already rendering or committing"),
-// which is the right refusal and would fire on every row. Deferring is uniform, needs
-// no `catch`, and costs nothing visible: GJS drains the microtask queue when the JS
-// stack empties, which is before GTK's next frame, so a row is never PAINTED empty.
-//
-// **`dispose()` is the authority on teardown, not GTK's `teardown` signal.** MEASURED:
-// destroying a window whose `Gtk.SignalListItemFactory` still had JS handlers
-// connected produced six `Gjs-CRITICAL` lines — "Attempting to call back into JSAPI
-// during the sweeping phase of GC … the JS callback not invoked. The offending signal
-// was unbind/teardown" — and ran none of them. So a per-item React root unmounted only
-// from `teardown` would never be unmounted, and every signal the host connected inside
-// that row would stay connected for the life of the process. Disconnecting the four
-// handlers and nulling `factory`/`model` before the widget becomes garbage silenced it
-// completely (measured: a forced `imports.system.gc()` afterwards printed nothing).
-//
-// **A data change SPLICES the whole model.** MEASURED: `items_changed(0, 1, 1)` over
-// the same carrier object produced no rebind at all, while `splice(0, 1, [fresh])`
-// produced `setup, bind 0, unbind 0, teardown`. GTK re-binds a row when its model
-// object changes, not when the object's contents do — so replacing the carriers is
-// what makes a content change visible.
-//
-// **The carrier is a one-line `GObject` subclass with a plain JS field.** MEASURED:
-// `Gio.ListStore.get_item(0)` hands back the SAME JS wrapper that was appended
-// (`back === a`), and the field survived a forced GC while only the store held the
-// object. The alternative — a `Gtk.StringList` of indices — works too and costs a
-// parse plus an integer that means nothing on its own; this costs one
-// `registerClass`.
-//
-// Values through `gi://`, types through `@girs/*`.
+// Nothing here imports the toolkit as a VALUE any more. A row's container is created
+// and placed through the host, which is what curating GTK4's list carriers bought
+// (ADR 0028 § Amendment) — the `Gtk` below is a type and nothing else.
 
-import Gio from 'gi://Gio';
-import GObject from 'gi://GObject';
-import Gtk from 'gi://Gtk?version=4.0';
+import { adopt, createElement as hostCreateElement, insert as hostInsert, widgetOf } from '@gjsify/gtk-host';
+import { ListController, type ListRowSink } from '@gjsify/gtk-host/list';
 import { createRoot, type ReactRoot } from '@gjsify/gtk-host/react';
+import type Gtk from '@girs/gtk-4.0';
 import { createElement, type ReactNode } from 'react';
 
 import { ParentProvider } from '../parent-context.js';
@@ -78,20 +36,8 @@ export interface ListRow {
     render(): ReactNode;
 }
 
-/**
- * The carrier a `Gio.ListStore` holds, because a `Gio.ListStore` holds `GObject`s.
- *
- * One property and it is a plain JS field rather than a `GObject` property: a
- * registered property would need a GType for a JS closure, and the measurement above
- * says the JS field is safe — the store keeps the GObject alive and GJS keeps the
- * wrapper with it.
- */
-const ListRowCarrier = GObject.registerClass(
-    { GTypeName: 'GjsifyReactNativeListRow' },
-    class ListRowCarrier extends GObject.Object {
-        row: ListRow | null = null;
-    },
-);
+/** The controller a list component owns: the shared core, wearing React's row sink. */
+export type ReactListController = ListController<ListRow, ReactRoot>;
 
 /**
  * What a row's own React tree resolves its layout against.
@@ -117,13 +63,7 @@ const ROW_CONTEXT: ChildContext = { orientation: 'vertical', props: {}, overlay:
  */
 const RowBody = ({ row }: { readonly row: ListRow }): ReactNode => row.render();
 
-/**
- * A `Gtk.ListView`'s model, factory and per-row React roots.
- *
- * Constructed by a component, attached to a view the host created, disposed from the
- * component's own cleanup. Nothing here is reactive: `setRows` is called with the
- * current rows and works out whether GTK has to hear about it.
- */
+/** What a list component may tell its controller, beyond the rows themselves. */
 export interface ListControllerOptions {
     /**
      * Where a row's own render error goes.
@@ -137,185 +77,83 @@ export interface ListControllerOptions {
     readonly onRowError?: (error: Error) => void;
 }
 
-export class ListController {
-    readonly #store = Gio.ListStore.new(ListRowCarrier.$gtype);
-    readonly #factory = new Gtk.SignalListItemFactory();
-    readonly #handlers: number[] = [];
-    readonly #roots = new Map<Gtk.ListItem, ReactRoot>();
-    /** item → the tree it should hold, drained on a microtask. `null` means "unbound". */
-    readonly #pending = new Map<Gtk.ListItem, ReactNode>();
+/**
+ * React's `ListRowSink`: a root per row widget, every React call deferred to one drain.
+ *
+ * The state is per SINK rather than per row because the drain is: binds, unbinds and
+ * teardowns are one question — "what should each row hold now" — and a row that was
+ * bound and then unbound within the same turn must not render twice.
+ */
+function reactRows(options: ListControllerOptions): ListRowSink<ListRow, ReactRoot> {
+    /** root → the tree it should hold, drained on a microtask. `null` means "unbound". */
+    const pending = new Map<ReactRoot, ReactNode>();
     /** Roots whose row is gone, waiting for the same drain to unmount them. */
-    readonly #dead: ReactRoot[] = [];
-    #drainQueued = false;
-    #view: Gtk.ListView | null = null;
-    #keys: readonly string[] = [];
-    #disposed = false;
-    readonly #options: ListControllerOptions;
+    const dead: ReactRoot[] = [];
+    let drainQueued = false;
 
-    constructor(options: ListControllerOptions = {}) {
-        this.#options = options;
-        this.#handlers.push(
-            this.#factory.connect('setup', (_factory, item) => this.#setup(item as Gtk.ListItem)),
-            this.#factory.connect('bind', (_factory, item) => this.#bind(item as Gtk.ListItem)),
-            this.#factory.connect('unbind', (_factory, item) => this.#queue(item as Gtk.ListItem, null)),
-            this.#factory.connect('teardown', (_factory, item) => this.#teardown(item as Gtk.ListItem)),
-        );
-    }
-
-    /**
-     * Give the view its model and factory.
-     *
-     * `Gtk.NoSelection` and not the store directly: `Gtk.ListView:model` is a
-     * `Gtk.SelectionModel`, and a plain `Gio.ListModel` is not one. `NoSelection` is
-     * the wrapper that says "no selection" — React Native's lists have no selection
-     * concept, and `Gtk.SingleSelection` would give rows a selected state nothing
-     * would ever clear.
-     */
-    attach(view: Gtk.ListView): void {
-        this.#view = view;
-        view.set_factory(this.#factory);
-        view.set_model(Gtk.NoSelection.new(this.#store));
-    }
-
-    /**
-     * The rows GTK should be showing.
-     *
-     * The model is only touched when the KEYS changed. When they did not, every row's
-     * tree is re-rendered instead — a row whose key is the same but whose data changed
-     * has to repaint, and measurement 4 says GTK will not re-bind it for us. That is
-     * strictly cheaper than a splice, which tears down every row's React root.
-     */
-    setRows(rows: readonly ListRow[]): void {
-        if (this.#disposed) return;
-        const keys = rows.map((row) => row.key);
-        const sameKeys = keys.length === this.#keys.length && keys.every((key, index) => key === this.#keys[index]);
-        this.#keys = keys;
-        if (sameKeys) {
-            // The CARRIERS are updated in place, and then every live row is re-bound.
-            // Both halves are needed: `bind` reads the row off the carrier, so leaving
-            // the old row there re-renders the old data — which is what the in-place
-            // vector caught when only the second half was here.
-            for (let index = 0; index < rows.length; index++) {
-                const carrier = this.#store.get_item(index) as InstanceType<typeof ListRowCarrier> | null;
-                if (carrier !== null) carrier.row = rows[index] as ListRow;
-            }
-            for (const item of this.#roots.keys()) this.#bind(item);
-            return;
-        }
-        const carriers = rows.map((row) => {
-            const carrier = new ListRowCarrier();
-            carrier.row = row;
-            return carrier;
-        });
-        // ONE splice, not a per-row diff. `Gio.ListStore.splice` takes the whole
-        // replacement and emits one `items-changed`; a per-row diff would emit one per
-        // row, and each emission is a bind/unbind round trip through React.
-        this.#store.splice(0, this.#store.get_n_items(), carriers);
-    }
-
-    /** How many rows GTK is currently holding a widget for. A spec seam and a leak detector. */
-    get liveRows(): number {
-        return this.#roots.size;
-    }
-
-    /**
-     * Unmount every row, disconnect every handler, and let go of the view.
-     *
-     * Called from the component's cleanup, which runs while JS callbacks still work —
-     * unlike GTK's own `teardown`, which fires during GC sweeping when the view is
-     * collected and is BLOCKED there (measured, see the header). Idempotent, because a
-     * component's cleanup and an explicit dispose both reach it.
-     */
-    dispose(): void {
-        if (this.#disposed) return;
-        this.#disposed = true;
-        this.#pending.clear();
-        // The GTK half happens NOW — disconnecting the factory's handlers and letting
-        // go of the model is what keeps GC from reaching for a JS callback it will
-        // block. The REACT half is queued, for the same reason every other React call
-        // in this file is: `dispose()` runs from a component's cleanup, which is inside
-        // React's own commit, and `root.unmount()` is a render.
-        for (const root of this.#roots.values()) this.#dead.push(root);
-        this.#roots.clear();
-        for (const handler of this.#handlers) this.#factory.disconnect(handler);
-        this.#handlers.length = 0;
-        if (this.#view !== null) {
-            this.#view.set_factory(null);
-            this.#view.set_model(null);
-            this.#view = null;
-        }
-        this.#store.remove_all();
-        this.#schedule();
-    }
-
-    #setup(item: Gtk.ListItem): void {
-        // A vertical `Gtk.Box`, so a row behaves like the `<View>` a `renderItem`
-        // usually returns one of — and so `ROW_CONTEXT` is telling the truth about the
-        // axis a row's `flex-1` expands along.
-        const container = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
-        item.set_child(container);
-        const onRowError = this.#options.onRowError;
-        this.#roots.set(item, createRoot(container, onRowError === undefined ? {} : { onUncaughtError: onRowError }));
-    }
-
-    #bind(item: Gtk.ListItem): void {
-        const carrier = item.get_item() as InstanceType<typeof ListRowCarrier> | null;
-        const row = carrier?.row ?? null;
-        this.#queue(
-            item,
-            row === null
-                ? null
-                : createElement(ParentProvider, { value: ROW_CONTEXT }, createElement(RowBody, { row })),
-        );
-    }
-
-    #teardown(item: Gtk.ListItem): void {
-        this.#pending.delete(item);
-        const root = this.#roots.get(item);
-        if (root === undefined) return;
-        this.#roots.delete(item);
-        // QUEUED, not unmounted here — and this is the one that was measured the hard
-        // way. GTK tears a row down from inside `Gio.ListStore.splice`, which this layer
-        // calls from a React effect, and `root.unmount()` is a render: the host refused
-        // it by name ("render() could not flush, because React is already rendering or
-        // committing") the first time a vector changed a list's keys.
-        this.#dead.push(root);
-        this.#schedule();
-    }
-
-    /** Remember what a row should hold; render it once the JS stack has unwound. */
-    #queue(item: Gtk.ListItem, tree: ReactNode): void {
-        if (this.#disposed) return;
-        this.#pending.set(item, tree);
-        this.#schedule();
-    }
-
-    /**
-     * Do every React call this turn produced, once, after the stack unwinds.
-     *
-     * ONE drain for binds, unbinds and teardowns together, because they are one
-     * question — "what should each row hold now" — and a row that was bound and then
-     * unbound within the same turn must not render twice. Binds first, then the dead
-     * roots: a splice replaces a row before it removes the old one (measured: `setup,
-     * bind 0, unbind 0, teardown`), and unmounting first would drop a root the new bind
-     * had already been queued against.
-     */
-    #schedule(): void {
-        if (this.#drainQueued) return;
-        this.#drainQueued = true;
+    /** Do every React call this turn produced, once, after the stack unwinds. */
+    const schedule = (): void => {
+        if (drainQueued) return;
+        drainQueued = true;
         queueMicrotask(() => {
-            this.#drainQueued = false;
-            const pending = [...this.#pending];
-            this.#pending.clear();
-            for (const [target, tree] of pending) {
-                // The root may have been torn down between the bind and this drain — a
-                // scroll that binds and unbinds a row within one turn is ordinary.
-                this.#roots.get(target)?.render(tree);
-            }
-            const dead = this.#dead.splice(0, this.#dead.length);
-            for (const root of dead) root.unmount();
+            drainQueued = false;
+            const queued = [...pending];
+            pending.clear();
+            for (const [root, tree] of queued) root.render(tree);
+            // Renders first, unmounts second: a splice replaces a row before it removes
+            // the old one (measured: `setup, bind 0, unbind 0, teardown`), so this
+            // order is the one where the replacement exists before its predecessor is
+            // torn down. A root that died between its bind and this drain never gets
+            // here at all — `disposeRow` takes it out of `pending`.
+            const gone = dead.splice(0, dead.length);
+            for (const root of gone) root.unmount();
         });
-    }
+    };
+
+    return {
+        mountRow(item: Gtk.ListItem): ReactRoot {
+            // A vertical `Gtk.Box`, so a row behaves like the `<View>` a `renderItem`
+            // usually returns one of — and so `ROW_CONTEXT` is telling the truth about
+            // the axis a row's `flex-1` expands along.
+            //
+            // The carrier is taken ONCE, here, and this is the phase for it: `adopt`
+            // snapshots what a container already held and cannot tell our own previous
+            // child from application chrome, so taking it again on a recycled row
+            // refuses with `occupied-slot` (pinned in the host's own `host.spec.ts`).
+            const container = hostCreateElement('GtkBox', { orientation: 'vertical' });
+            hostInsert(container, adopt(item));
+            const onRowError = options.onRowError;
+            return createRoot(widgetOf(container), onRowError === undefined ? {} : { onUncaughtError: onRowError });
+        },
+
+        showRow(root: ReactRoot, row: ListRow | null): void {
+            pending.set(
+                root,
+                row === null
+                    ? null
+                    : createElement(ParentProvider, { value: ROW_CONTEXT }, createElement(RowBody, { row })),
+            );
+            schedule();
+        },
+
+        disposeRow(root: ReactRoot): void {
+            pending.delete(root);
+            // QUEUED, not unmounted here — and this is the one that was measured the
+            // hard way. GTK tears a row down from inside `Gio.ListStore.splice`, which
+            // the core calls from a React effect, and `root.unmount()` is a render: the
+            // host refused it by name ("render() could not flush, because React is
+            // already rendering or committing") the first time a vector changed a
+            // list's keys. `ListController.dispose()` reaches this too, from a
+            // component's cleanup, which is inside React's own commit.
+            dead.push(root);
+            schedule();
+        },
+    };
+}
+
+/** The list controller a React component owns. */
+export function createListController(options: ListControllerOptions = {}): ReactListController {
+    return new ListController(reactRows(options));
 }
 
 /**

--- a/packages/framework/react-native/src/lists/controller.ts
+++ b/packages/framework/react-native/src/lists/controller.ts
@@ -20,7 +20,7 @@
 // (ADR 0028 § Amendment) — the `Gtk` below is a type and nothing else.
 
 import { adopt, createElement as hostCreateElement, insert as hostInsert, widgetOf } from '@gjsify/gtk-host';
-import { ListController, type ListRowSink } from '@gjsify/gtk-host/list';
+import { ListController, onScrollNearEnd, type ListRowSink } from '@gjsify/gtk-host/list';
 import { createRoot, type ReactRoot } from '@gjsify/gtk-host/react';
 import type Gtk from '@girs/gtk-4.0';
 import { createElement, type ReactNode } from 'react';
@@ -118,8 +118,11 @@ function reactRows(options: ListControllerOptions): ListRowSink<ListRow, ReactRo
             //
             // The carrier is taken ONCE, here, and this is the phase for it: `adopt`
             // snapshots what a container already held and cannot tell our own previous
-            // child from application chrome, so taking it again on a recycled row
-            // refuses with `occupied-slot` (pinned in the host's own `host.spec.ts`).
+            // child from application chrome, so taking it a second time refuses with
+            // `occupied-slot` (pinned in the host's own `host.spec.ts`). GTK recycling
+            // a carrier is the route people expect; the one that fires first is
+            // `setRows` over unchanged keys, which re-shows a live row with no GTK
+            // involvement at all.
             const container = hostCreateElement('GtkBox', { orientation: 'vertical' });
             hostInsert(container, adopt(item));
             const onRowError = options.onRowError;
@@ -174,54 +177,12 @@ export function rowKey(item: unknown, index: number, keyExtractor?: (item: unkno
 }
 
 /**
- * Call `listener` when the scroller gets within `threshold` page-lengths of the end.
+ * The scroll edge behind `onEndReached`, re-exported rather than reimplemented.
  *
- * `Gtk.Adjustment`, because that is where GTK keeps a scroll position: the scrolled
- * window has no scroll signal of its own, and `notify::value` on the adjustment behind
- * `hadjustment`/`vadjustment` is what `ScrollView`'s own `onScroll` refusal points at.
- * MEASURED: a `Gtk.ScrolledWindow` hands out its adjustments with no window anywhere,
- * and `set_value` on one raised `notify::value` — so this is drivable, and asserted, in
- * a spec that presents nothing.
- *
- * `upper` and `page-size` are subscribed too, and not for completeness: `upper` grows
- * when rows are added, which is the event that ARMS the next call — React Native fires
- * `onEndReached` once per arrival at the end, and a list that grew has a new end.
- *
- * A list with nothing to scroll (`upper <= page-size`) never fires. That is the state
- * every list is in before it has been allocated, and firing there would call
- * `onEndReached` on mount for every list in the application.
+ * It lived here, and it was never React's: `Gtk.Adjustment` arithmetic with no React in
+ * it and no toolkit value import. `@gjsify/gtk-host/list` owns it now, so a Vue or Solid
+ * list gets the same measured behaviour instead of re-deriving it — which is the failure
+ * this whole extraction exists to prevent. `components.ts` imports it from here, so the
+ * move costs no consumer a rewrite.
  */
-export function onScrollNearEnd(
-    scroller: Gtk.ScrolledWindow,
-    axis: 'horizontal' | 'vertical',
-    threshold: number,
-    listener: (distanceFromEnd: number) => void,
-): () => void {
-    const adjustment = axis === 'horizontal' ? scroller.get_hadjustment() : scroller.get_vadjustment();
-    let armed = true;
-    const check = (): void => {
-        const page = adjustment.get_page_size();
-        const upper = adjustment.get_upper();
-        if (upper <= page) {
-            armed = true;
-            return;
-        }
-        const distance = upper - page - adjustment.get_value();
-        if (distance > threshold * page) {
-            armed = true;
-            return;
-        }
-        if (!armed) return;
-        armed = false;
-        listener(distance);
-    };
-    const handlers = [
-        adjustment.connect('notify::value', check),
-        adjustment.connect('notify::upper', check),
-        adjustment.connect('notify::page-size', check),
-    ];
-    check();
-    return () => {
-        for (const handler of handlers) adjustment.disconnect(handler);
-    };
-}
+export { onScrollNearEnd };

--- a/packages/framework/react-native/src/lists/lists.spec.ts
+++ b/packages/framework/react-native/src/lists/lists.spec.ts
@@ -349,11 +349,12 @@ export default async () => {
             });
 
             await it('unmounts every row’s root, so nothing is left for GC to block', async () => {
-                // The measured hazard: a factory whose handlers are still connected when
-                // its view is collected produced six `Gjs-CRITICAL` lines — "Attempting
-                // to call back into JSAPI during the sweeping phase of GC … the JS
-                // callback not invoked" — and ran none of them. The diagnostics gate
-                // around this describe is what would report them.
+                // The measured hazard is stated once, in `@gjsify/gtk-host/list`'s
+                // controller: a factory whose handlers are still connected when its
+                // view is collected produces Gjs criticals and runs none of the
+                // callbacks. The diagnostics gate around this describe is what would
+                // report them — from THIS side of the seam, where a row also owns a
+                // React root that the core hands back rather than unmounts.
                 await mounted(async (mount) => {
                     await mount.render(
                         flatList({

--- a/packages/framework/react-native/src/press.ts
+++ b/packages/framework/react-native/src/press.ts
@@ -27,8 +27,9 @@
 // callback during the sweeping phase of GC — measured in this milestone's own list
 // work and written down in `@gjsify/gtk-host/list`'s controller, where a
 // `Gtk.SignalListItemFactory` whose handlers were still connected when its view was
-// collected printed six `Gjs-CRITICAL` lines and ran none of the callbacks. A handler that is not disconnected stays connected for the life of the
-// process, and the diagnostics gate counts what that produces.
+// collected printed six `Gjs-CRITICAL` lines and ran none of the callbacks. A handler
+// that is not disconnected stays connected for the life of the process, and the
+// diagnostics gate counts what that produces.
 //
 // Values through `gi://`, types through `@girs/*`.
 

--- a/packages/framework/react-native/src/press.ts
+++ b/packages/framework/react-native/src/press.ts
@@ -25,9 +25,9 @@
 //
 // BOTH DISPOSERS REALLY DISCONNECT, and that is not tidiness. GJS blocks a JS
 // callback during the sweeping phase of GC — measured in this milestone's own list
-// work, where a `Gtk.SignalListItemFactory` whose handlers were still connected when
-// its view was collected printed six `Gjs-CRITICAL` lines and ran none of the
-// callbacks. A handler that is not disconnected stays connected for the life of the
+// work and written down in `@gjsify/gtk-host/list`'s controller, where a
+// `Gtk.SignalListItemFactory` whose handlers were still connected when its view was
+// collected printed six `Gjs-CRITICAL` lines and ran none of the callbacks. A handler that is not disconnected stays connected for the life of the
 // process, and the diagnostics gate counts what that produces.
 //
 // Values through `gi://`, types through `@girs/*`.

--- a/packages/node-gi/node-gi/gi.js
+++ b/packages/node-gi/node-gi/gi.js
@@ -70,6 +70,26 @@ function unwrapArg(value) {
     if (value !== null && typeof value === 'object' && value[HANDLE] !== undefined) {
         return value[HANDLE];
     }
+    // An ARRAY is a container whose ELEMENTS need the same unwrapping, and until this
+    // line they did not get it: only the top-level argument was unwrapped, so an array
+    // of GObjects reached the engine as an array of JS wrappers and
+    // `NodeGiToGIArgument`'s GI_TYPE_TAG_INTERFACE branch — which accepts nothing but
+    // an External carrying the handle — threw
+    // `expected a GObject handle as a container element`. That is EVERY GI method
+    // taking an array of objects, not one method: measured on
+    // `Gio.ListStore.splice(0, n, [a, b])`, where `append(a)` on the same store
+    // succeeded because one GObject as a top-level arg was always unwrapped.
+    //
+    // `Array.isArray`, not `typeof value === 'object'`: a Uint8Array is a
+    // GByteArray/guint8[] argument the engine reads directly, and mapping over it here
+    // would turn it into a plain Array and lose that.
+    //
+    // Recursive, so a nested array and a GObject inside one are handled by the same
+    // rule rather than by a second one that drifts — and this is now the same shape
+    // `wrapReturn` has carried all along for the OTHER direction. That asymmetry is
+    // why the gap stayed invisible: a container coming BACK had its elements wrapped,
+    // a container going IN did not, and nothing read both lines at once.
+    if (Array.isArray(value)) return value.map(unwrapArg);
     if (typeof value === 'function') return wrapCallbackFn(value);
     return value;
 }

--- a/packages/node-gi/node-gi/test/arrays.test.mjs
+++ b/packages/node-gi/node-gi/test/arrays.test.mjs
@@ -30,6 +30,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { callFunction, callStaticMethod, requireNamespace } from '../index.js';
+import { requireGi } from '../gi.js';
 
 test('GStrv return → string[]: GLib.get_environ()', () => {
     requireNamespace('GLib', '2.0');
@@ -156,4 +157,42 @@ test('null marshals as a NULL array argument (GJS parity)', () => {
     // path) — node-gi used to throw "expected an array for the array argument".
     requireNamespace('GLib', '2.0');
     assert.equal(callFunction('GLib', 'environ_getenv', [null, 'PATH']), null);
+});
+
+// An ARRAY OF GOBJECTS as an IN argument — the direction every case above covers
+// for strings and bytes and none of them covered for objects.
+//
+// It did not work, and the gap was invisible because the single-object path is a
+// different line of code: `unwrapArg` unwrapped a top-level node-gi instance to its
+// handle and returned an Array untouched, so the elements arrived at
+// `NodeGiToGIArgument`'s GI_TYPE_TAG_INTERFACE branch as JS wrappers and it threw
+// `expected a GObject handle as a container element`. Every GI method taking an
+// array of objects was affected; it surfaced through
+// `@gjsify/gtk-host/list`'s `Gio.ListStore.splice`, whose whole design rests on
+// replacing the model in ONE call.
+//
+// `Gio.ListStore` is the right subject headlessly: it is a real GI method with a
+// `GObject**` IN parameter and it needs no display.
+test('array of GObjects IN: Gio.ListStore.splice replaces the model in one call', () => {
+    const Gio = requireGi('Gio', '2.0');
+    const store = Gio.ListStore.new(Gio.SimpleAction.$gtype);
+
+    // The CONTROL, and it is the reason the bug survived: one GObject as a
+    // top-level argument was always unwrapped, so `append` worked throughout.
+    store.append(new Gio.SimpleAction({ name: 'first' }));
+    assert.equal(store.get_n_items(), 1);
+
+    const replacements = [new Gio.SimpleAction({ name: 'a' }), new Gio.SimpleAction({ name: 'b' })];
+    store.splice(0, store.get_n_items(), replacements);
+    assert.equal(store.get_n_items(), 2);
+
+    // The objects that came back are the ones handed in — an array that marshalled
+    // to the wrong pointers would still give a count of 2.
+    assert.equal(store.get_item(0).name, 'a');
+    assert.equal(store.get_item(1).name, 'b');
+
+    // An EMPTY array is the boundary the splice path also takes (clearing a model),
+    // and it must not be read as "no argument".
+    store.splice(0, store.get_n_items(), []);
+    assert.equal(store.get_n_items(), 0);
 });

--- a/scripts/adapter-import-direction-fixtures.mjs
+++ b/scripts/adapter-import-direction-fixtures.mjs
@@ -471,6 +471,55 @@ export const ADAPTER_IMPORT_DIRECTION_FIXTURES = [
         frameworkFree: ['./list'],
         expect: { files: 1, problems: [], blockers: ['unscanned-framework-free'] },
     },
+    {
+        // The OTHER half of that vacuity, and the one that was live. The source dir is
+        // derived from the manifest, so a subpath the manifest stops naming derives to
+        // nothing — and nothing was a skip. MEASURED against the real package: with this
+        // exact `solid-js` import under `src/list/`, deleting one `"./list"` line from
+        // `exports` took the run from exit 1 to exit 0 printing "0 framework-free
+        // source(s) carry no framework". Present-but-unpublished is now a blocker.
+        name: 'framework-free-source-unpublished',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { createSignal } from 'solid-js';\n\nexport const s = createSignal;\n`,
+        },
+        expect: { files: 1, problems: [], blockers: ['unscanned-framework-free'] },
+    },
+    {
+        // Published, but not at the `<dir>/index.js` this check follows. Same silence,
+        // arriving through a rename of the ENTRY rather than of the subpath.
+        name: 'framework-free-published-off-index',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { createSignal } from 'solid-js';\n\nexport const s = createSignal;\n`,
+        },
+        frameworkFree: ['./list'],
+        frameworkFreeTarget: './lib/esm/list/controller.js',
+        expect: { files: 1, problems: [], blockers: ['unscanned-framework-free'] },
+    },
+    {
+        // `react-native` is not matched by the `react` alternative — the segment bound is
+        // what keeps `react` from flagging every package named after it — and
+        // `@gjsify/react-native` is the first consumer this seam was extracted for.
+        name: 'framework-free-imports-react-native',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { View } from '@gjsify/react-native';\n\nexport const v = View;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: ['framework-import'], blockers: [] },
+    },
+    {
+        // The relative hop into `src/adapters` was caught by path; the identical import
+        // spelled as this package's OWN published adapter subpath was not.
+        name: 'framework-free-imports-own-adapter-subpath',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { createRoot } from '@gjsify/gtk-host/react';\n\nexport const r = createRoot;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: ['framework-import'], blockers: [] },
+    },
 ];
 
 /** The manifest a fixture publishes: `.` plus one `./lib/esm/adapters/<name>.js` per declared adapter. */
@@ -491,7 +540,10 @@ function fixtureManifest(fixture) {
         const dir = subpath.replace(/^\.\//, '');
         exported[subpath] = {
             types: `./lib/types/${dir}/index.d.ts`,
-            default: `./lib/esm/${dir}/index.js`,
+            // `frameworkFreeTarget` overrides the entry so a fixture can publish the
+            // subpath at something OTHER than its index — the shape the check cannot
+            // follow, and therefore the shape that has to blocker rather than skip.
+            default: fixture.frameworkFreeTarget ?? `./lib/esm/${dir}/index.js`,
         };
     }
     return { name: `@gjsify/fixture-${fixture.name}`, private: true, type: 'module', exports: exported };

--- a/scripts/adapter-import-direction-fixtures.mjs
+++ b/scripts/adapter-import-direction-fixtures.mjs
@@ -412,6 +412,65 @@ export const ADAPTER_IMPORT_DIRECTION_FIXTURES = [
         omitManifest: true,
         expect: { files: 1, problems: [], blockers: ['no-manifest'] },
     },
+    // ── The OTHER direction of the same idea ────────────────────────────────────
+    //
+    // An adapter must carry no widget knowledge; a subpath published as
+    // framework-NEUTRAL must carry no framework. `@gjsify/gtk-host/list` is the first,
+    // and its header calls that constraint "the whole point" — while nothing checked
+    // it, because this script's only scope was `src/adapters`. These five are that
+    // half's missing check.
+    {
+        name: 'framework-free-clean',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import Gio from 'gi://Gio';\n\nexport const store = () => Gio.ListStore;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: [], blockers: [] },
+    },
+    {
+        // The violation the rule exists for, in the spelling it would actually arrive in.
+        name: 'framework-free-imports-solid',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { createSignal } from 'solid-js';\n\nexport const s = createSignal;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: ['framework-import'], blockers: [] },
+    },
+    {
+        // A TYPE-ONLY import compiles to nothing and is still a violation: the neutral
+        // module would be describing itself in one framework's vocabulary, and the next
+        // edit makes it a value. The seam is generic in its handle so it needs no such type.
+        name: 'framework-free-type-only-import',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import type { Component } from 'vue';\n\nexport type C = Component;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: ['framework-import'], blockers: [] },
+    },
+    {
+        // The same violation wearing a PATH. Every adapter imports its framework, so a
+        // relative hop into one reaches the framework — and a bare-specifier pattern
+        // alone would report this file clean.
+        name: 'framework-free-via-adapter-hop',
+        files: {
+            'src/adapters/toy.ts': CLEAN_ADAPTER,
+            'src/list/index.ts': `import { render } from '../adapters/solid.js';\n\nexport const r = render;\n`,
+        },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: ['framework-import'], blockers: [] },
+    },
+    {
+        // Published and unreadable is the vacuity case: a promise of neutrality whose
+        // source this check never opened is a promise with no ratchet, and it must be a
+        // BLOCKER rather than an empty green scan.
+        name: 'framework-free-declared-but-absent',
+        files: { 'src/adapters/toy.ts': CLEAN_ADAPTER },
+        frameworkFree: ['./list'],
+        expect: { files: 1, problems: [], blockers: ['unscanned-framework-free'] },
+    },
 ];
 
 /** The manifest a fixture publishes: `.` plus one `./lib/esm/adapters/<name>.js` per declared adapter. */
@@ -422,6 +481,17 @@ function fixtureManifest(fixture) {
         exported[subpath] = {
             types: `./lib/types/adapters/${module}.d.ts`,
             default: `./lib/esm/adapters/${module}.js`,
+        };
+    }
+    // A FRAMEWORK-FREE subpath is published as a directory entry (`<dir>/index.js`), not
+    // as an adapter module, and that difference is load-bearing: the check derives the
+    // source directory from this target, so a fixture that spelled it the adapter way
+    // would exercise a path the real manifest never takes.
+    for (const subpath of fixture.frameworkFree ?? []) {
+        const dir = subpath.replace(/^\.\//, '');
+        exported[subpath] = {
+            types: `./lib/types/${dir}/index.d.ts`,
+            default: `./lib/esm/${dir}/index.js`,
         };
     }
     return { name: `@gjsify/fixture-${fixture.name}`, private: true, type: 'module', exports: exported };

--- a/scripts/check-adapter-import-direction.mjs
+++ b/scripts/check-adapter-import-direction.mjs
@@ -155,6 +155,37 @@ const PLACEMENT = new RegExp(
 const HOST_INTERNALS = new Set(['descriptors', 'policies', 'registry']);
 
 /**
+ * Published subpaths whose WHOLE POINT is carrying no UI framework, checked here for the
+ * same reason the adapters are: a constraint asserted only in the prose that asserts it
+ * has no ratchet, and this milestone has already paid for that class twice.
+ *
+ * `@gjsify/gtk-host/list` is the first. Its header says it "imports no React, no Solid
+ * and no Vue, and must not — that constraint is the whole point", because the model, the
+ * factory and the key diff behind a `Gtk.ListView` are GTK facts three dialects would
+ * otherwise each own a copy of. Nothing stopped a future `import { createSignal } from
+ * 'solid-js'` there: `src/adapters` is this check's only scope, and `src/list` was
+ * covered by no gate at all.
+ *
+ * A NAME here, not a directory: the source dir is derived from the manifest, so a
+ * subpath that is renamed or that stops being published turns into the
+ * `unscanned-framework-free` blocker rather than into silence. Adding a neutral subpath
+ * to this list is how it gets its ratchet.
+ */
+const FRAMEWORK_FREE_SUBPATHS = ['./list'];
+
+/** `./lib/esm/<dir>/index.js` — where a framework-free subpath's source is, via `src/<dir>`. */
+const PUBLISHED_ENTRY = /^\.\/lib\/esm\/(.+)\/index\.js$/;
+
+/**
+ * A UI framework, as a bare module specifier.
+ *
+ * Anchored and segment-bounded so `react` and `react-dom/client` match while a package
+ * merely NAMED for one (`solid-js-is-not-this`) does not. `@vue/runtime-core` is the
+ * spelling the host's own Vue adapter uses, and `vue` is what an application writes.
+ */
+const FRAMEWORK_SPECIFIER = /^(?:react|react-dom|react-reconciler|solid-js|vue|@vue\/[\w.-]+|preact|svelte)(?:\/|$)/;
+
+/**
  * A `gi://` specifier is a RUNTIME typelib import, and no adapter may hold one.
  *
  * The type layer is `@girs/*` (ADR 0028 § 3), which an adapter imports with
@@ -389,6 +420,32 @@ function importProblems(code) {
     return found;
 }
 
+/**
+ * Framework imports in `code`, which has already been through the comment stripper.
+ *
+ * A TYPE-ONLY import is a violation here and is not one in an adapter, so this is a
+ * separate pass rather than a flag on the one above: `import type { Component } from
+ * 'vue'` compiles to nothing, but it means the neutral module is describing itself in a
+ * framework's vocabulary, and the next edit makes it a value. The seam is generic in its
+ * handle precisely so it needs no such type.
+ */
+function frameworkImports(code) {
+    const found = [];
+    const pattern = new RegExp(SPECIFIER_SOURCE, 'g');
+    let match = pattern.exec(code);
+    while (match !== null) {
+        const specifier = match[2];
+        // A RELATIVE hop into the adapters is the same violation wearing a path: every
+        // adapter imports its framework, so reaching one reaches the framework.
+        const viaAdapter = specifier.startsWith('.') && specifier.split('/').includes('adapters');
+        if (FRAMEWORK_SPECIFIER.test(specifier) || viaAdapter) {
+            found.push({ kind: 'framework-import', specifier, index: match.index });
+        }
+        match = pattern.exec(code);
+    }
+    return found;
+}
+
 /** What each import kind tells the reader to do instead. */
 const IMPORT_ADVICE = {
     'host-internal-import': (specifier) => `imports the host's internals: ${specifier}`,
@@ -397,6 +454,11 @@ const IMPORT_ADVICE = {
         `host ops and never touches GTK itself — take the type from @girs/* with "import type", and ` +
         `if a widget really has to be BUILT, that is a host op (see createDetachedContainer), not an ` +
         `adapter's business.`,
+    'framework-import': (specifier) =>
+        `imports a UI framework: ${specifier}. This subpath is published as framework-NEUTRAL — that ` +
+        `is what lets one measurement serve every renderer instead of one copy per dialect. Put the ` +
+        `framework-shaped half behind the seam the module already publishes (a callback the dialect ` +
+        `supplies), or in that dialect's own adapter under src/adapters.`,
 };
 
 /** Every file under `dir`, recursively, sorted — symlinks resolved so a linked adapter counts. */
@@ -491,6 +553,44 @@ function scanFile(path) {
     return found.sort((a, b) => a.line - b.line);
 }
 
+/** One framework-free source file: no framework import, by value or by type. */
+function scanFrameworkFree(path) {
+    const code = stripComments(readFileSync(path, 'utf8')).join('\n');
+    return frameworkImports(code)
+        .map((hit) => ({
+            kind: hit.kind,
+            line: code.slice(0, hit.index).split('\n').length,
+            path,
+            message: IMPORT_ADVICE[hit.kind](hit.specifier),
+        }))
+        .sort((a, b) => a.line - b.line);
+}
+
+/**
+ * The framework-free subpaths this package publishes, as { subpath, dir } under `src/`.
+ *
+ * Read from the MANIFEST, so a renamed or unpublished subpath becomes a blocker instead
+ * of a silently empty scan.
+ */
+function frameworkFreeDirs(pkgDir, manifestPath) {
+    let manifest;
+    try {
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    } catch {
+        // The adapters pass already reports an unreadable manifest as `no-manifest`;
+        // reporting it twice would say nothing new.
+        return [];
+    }
+    const out = [];
+    for (const subpath of FRAMEWORK_FREE_SUBPATHS) {
+        const target = manifest.exports?.[subpath];
+        const file = typeof target === 'string' ? target : target?.default;
+        const match = typeof file === 'string' ? PUBLISHED_ENTRY.exec(file) : null;
+        out.push({ subpath, dir: match === null ? null : join(pkgDir, 'src', ...match[1].split('/')) });
+    }
+    return out;
+}
+
 /**
  * Scan one package. `blockers` are the reasons a green result would mean nothing — an empty
  * adapter set, a file the walk cannot read, a published adapter whose source it never reached.
@@ -509,7 +609,7 @@ function evaluate(pkgDir) {
         // Every array the reporter reads, even on the path that cannot reach it today: the
         // reporter's `result.specs.length` is a TypeError the moment a non-fatal blocker kind
         // is added, and the self-test below asserts these four exist for exactly that reason.
-        return { dir, scanned: [], specs: [], nonCode: [], unreadable: [], problems, blockers };
+        return { dir, scanned: [], specs: [], nonCode: [], unreadable: [], problems, blockers, neutral: [] };
     }
 
     const { scanned, specs, nonCode, unreadable } = classify(walk(dir));
@@ -569,7 +669,38 @@ function evaluate(pkgDir) {
     }
 
     for (const path of scanned) problems.push(...scanFile(path));
-    return { dir, scanned, specs, nonCode, unreadable, problems, blockers };
+
+    // The framework-free subpaths, held to the OTHER direction of the same idea: an
+    // adapter must carry no widget knowledge, a neutral module must carry no framework.
+    const neutral = [];
+    for (const { subpath, dir: srcDir } of frameworkFreeDirs(pkgDir, join(pkgDir, 'package.json'))) {
+        // A package that does not publish the subpath at all is not in scope — only
+        // gtk-host declares one today, and every fixture below would otherwise blocker.
+        if (srcDir === null) continue;
+        if (!existsSync(srcDir)) {
+            blockers.push({
+                kind: 'unscanned-framework-free',
+                message:
+                    `package.json publishes "${subpath}" as a framework-free subpath and its source ` +
+                    `directory ${srcDir} does not exist. A promise of neutrality with no source read ` +
+                    'is a promise with no ratchet.',
+            });
+            continue;
+        }
+        const files = classify(walk(srcDir));
+        const sources = files.scanned;
+        if (sources.length === 0) {
+            blockers.push({
+                kind: 'unscanned-framework-free',
+                message: `"${subpath}" resolves to ${srcDir} and this check read no source there.`,
+            });
+            continue;
+        }
+        neutral.push(...sources);
+        for (const path of sources) problems.push(...scanFrameworkFree(path));
+    }
+
+    return { dir, scanned, specs, nonCode, unreadable, problems, blockers, neutral };
 }
 
 const kinds = (entries) => entries.map((entry) => entry.kind).sort();
@@ -686,5 +817,6 @@ if (result.problems.length > 0) {
 const skipped = result.specs.length + result.nonCode.length;
 console.log(
     `check-adapter-import-direction: ${result.scanned.length} adapter(s) carry no widget knowledge` +
-        `${skipped > 0 ? ` (${result.specs.length} spec(s), ${result.nonCode.length} non-code file(s) skipped)` : ''}.`,
+        `${skipped > 0 ? ` (${result.specs.length} spec(s), ${result.nonCode.length} non-code file(s) skipped)` : ''}` +
+        `; ${result.neutral.length} framework-free source(s) carry no framework.`,
 );

--- a/scripts/check-adapter-import-direction.mjs
+++ b/scripts/check-adapter-import-direction.mjs
@@ -166,10 +166,16 @@ const HOST_INTERNALS = new Set(['descriptors', 'policies', 'registry']);
  * 'solid-js'` there: `src/adapters` is this check's only scope, and `src/list` was
  * covered by no gate at all.
  *
- * A NAME here, not a directory: the source dir is derived from the manifest, so a
- * subpath that is renamed or that stops being published turns into the
- * `unscanned-framework-free` blocker rather than into silence. Adding a neutral subpath
- * to this list is how it gets its ratchet.
+ * A NAME here, not a directory: the source dir is derived from the MANIFEST, so what a
+ * package actually publishes is what gets read. That derivation has a hole this list
+ * had to grow a second question to close — a subpath the manifest stops naming derives
+ * to nothing, and nothing was silence. MEASURED: with a real `import { createSignal }
+ * from 'solid-js'` under `src/list/`, deleting the one `"./list"` line from the
+ * package's `exports` took the run from exit 1 to exit 0 printing "0 framework-free
+ * source(s) carry no framework". So `evaluate` also asks whether `src/<name>` is
+ * SITTING THERE, and an unpublished-but-present source is the `unscanned-framework-free`
+ * blocker rather than a skip. Adding a neutral subpath to this list is how it gets its
+ * ratchet; the only way off the ratchet is deleting the source.
  */
 const FRAMEWORK_FREE_SUBPATHS = ['./list'];
 
@@ -182,8 +188,17 @@ const PUBLISHED_ENTRY = /^\.\/lib\/esm\/(.+)\/index\.js$/;
  * Anchored and segment-bounded so `react` and `react-dom/client` match while a package
  * merely NAMED for one (`solid-js-is-not-this`) does not. `@vue/runtime-core` is the
  * spelling the host's own Vue adapter uses, and `vue` is what an application writes.
+ *
+ * THREE OF THESE ARE NOT `node_modules` NAMES, and leaving them out was a hole with a
+ * dialect already standing in it. `react-native` does not match the `react` alternative
+ * — the segment bound is what makes `react` safe — and `@gjsify/react-native` is the
+ * first consumer this seam was extracted FOR, so it is the likeliest wrong import to
+ * arrive here. `@gjsify/gtk-host/react` is the same violation reaching sideways: the
+ * relative hop into `src/adapters` is caught by path, and the identical import spelled
+ * as this package's own published subpath was not.
  */
-const FRAMEWORK_SPECIFIER = /^(?:react|react-dom|react-reconciler|solid-js|vue|@vue\/[\w.-]+|preact|svelte)(?:\/|$)/;
+const FRAMEWORK_SPECIFIER =
+    /^(?:react|react-dom|react-native|react-reconciler|solid-js|vue|@vue\/[\w.-]+|preact|svelte|@gjsify\/react-native|@gjsify\/gtk-host\/(?:react|solid|vue))(?:\/|$)/;
 
 /**
  * A `gi://` specifier is a RUNTIME typelib import, and no adapter may hold one.
@@ -567,10 +582,13 @@ function scanFrameworkFree(path) {
 }
 
 /**
- * The framework-free subpaths this package publishes, as { subpath, dir } under `src/`.
+ * The framework-free subpaths, as { subpath, dir, byName } — TWO paths, not one.
  *
- * Read from the MANIFEST, so a renamed or unpublished subpath becomes a blocker instead
- * of a silently empty scan.
+ * `dir` is what the MANIFEST points at, and it is what gets scanned: a package publishes
+ * `./lib/esm/<dir>/index.js`, so `src/<dir>` is the source behind the promise. `byName`
+ * is where the subpath's source would sit if the manifest stopped pointing at it, and it
+ * exists because `dir` alone made the check switchable from `package.json` — see
+ * `FRAMEWORK_FREE_SUBPATHS` for the measurement.
  */
 function frameworkFreeDirs(pkgDir, manifestPath) {
     let manifest;
@@ -586,7 +604,13 @@ function frameworkFreeDirs(pkgDir, manifestPath) {
         const target = manifest.exports?.[subpath];
         const file = typeof target === 'string' ? target : target?.default;
         const match = typeof file === 'string' ? PUBLISHED_ENTRY.exec(file) : null;
-        out.push({ subpath, dir: match === null ? null : join(pkgDir, 'src', ...match[1].split('/')) });
+        const name = subpath.replace(/^\.\//, '').split('/');
+        out.push({
+            subpath,
+            declared: target !== undefined,
+            dir: match === null ? null : join(pkgDir, 'src', ...match[1].split('/')),
+            byName: join(pkgDir, 'src', ...name),
+        });
     }
     return out;
 }
@@ -673,10 +697,29 @@ function evaluate(pkgDir) {
     // The framework-free subpaths, held to the OTHER direction of the same idea: an
     // adapter must carry no widget knowledge, a neutral module must carry no framework.
     const neutral = [];
-    for (const { subpath, dir: srcDir } of frameworkFreeDirs(pkgDir, join(pkgDir, 'package.json'))) {
-        // A package that does not publish the subpath at all is not in scope — only
-        // gtk-host declares one today, and every fixture below would otherwise blocker.
-        if (srcDir === null) continue;
+    for (const { subpath, declared, dir: srcDir, byName } of frameworkFreeDirs(pkgDir, join(pkgDir, 'package.json'))) {
+        if (srcDir === null) {
+            // A package that does not publish the subpath is not in scope — only
+            // gtk-host declares one today, and every unrelated fixture would otherwise
+            // blocker. UNLESS the source is sitting right there, which is the vacuity
+            // this pass exists against: the manifest is the check's only route to the
+            // directory, so one deleted `exports` line turned a real framework import
+            // under `src/list/` from exit 1 into exit 0 (measured, see
+            // `FRAMEWORK_FREE_SUBPATHS`).
+            if (!existsSync(byName)) continue;
+            blockers.push({
+                kind: 'unscanned-framework-free',
+                message:
+                    `${byName} exists and this check never opened it: package.json ` +
+                    (declared
+                        ? `points "${subpath}" somewhere this check cannot follow — it reads ./lib/esm/<dir>/index.js.`
+                        : `does not publish "${subpath}" at all.`) +
+                    ' A framework-free source with no scan behind it is a promise with no ratchet.' +
+                    ' Publish the subpath at its index, or take the name off FRAMEWORK_FREE_SUBPATHS' +
+                    ' in the same commit that deletes the source.',
+            });
+            continue;
+        }
         if (!existsSync(srcDir)) {
             blockers.push({
                 kind: 'unscanned-framework-free',

--- a/website/src/content/docs/internals/react-layers.mdx
+++ b/website/src/content/docs/internals/react-layers.mdx
@@ -99,22 +99,24 @@ recorder.
 ## Why lists are not ordinary elements
 
 `FlatList`, `SectionList`, `VirtualizedList` and `VirtualizedSectionList` are one component that
-differs only in how it receives its rows. Three measurements force that.
+differs only in how it receives its rows, because a `Gtk.ListView` takes no children at all: no
+`append`, `add`, `insert`, `prepend`, `remove` or `set_child` on its prototype. The host's
+placement policies are data naming a method, so there is no method to name.
 
-A `Gtk.ListView` takes no children: no `append`, `add`, `insert`, `prepend`, `remove` or
-`set_child` on its prototype. The host's placement policies are data naming a method, so there is
-no method to name.
+Most of what follows from that is **not React's**. The model, the factory, the key diff and the
+teardown authority live in `@gjsify/gtk-host/list`, where Vue and Solid reach the same three
+measurements — the `Gio.ListStore` carrier identity, why a data change splices the model instead
+of announcing it, and why `dispose()` rather than GTK's own `teardown` signal is what disconnects.
+That module's header states each of them once; nothing restates them here, because a second copy
+is the one that goes stale.
 
-Rebinding is driven by the model, not by identity. `items_changed(0, 1, 1)` over the same carrier
-object produced no rebind at all, while `splice(0, 1, [fresh])` produced `setup, bind 0,
-unbind 0, teardown`.
+What is React's is the deferral: a row's tree is rendered on a microtask, because GTK binds rows
+from inside React's own commit and the adapter's `render()` refuses a re-entrant flush by name.
+Solid's rows over the same controller need no deferral at all.
 
 Virtualisation is real but the allocation is not. With a 500-row model in a presented 400×300
 window the adjustment's `upper` is 11 000, the list is allocated its whole 11 000 px content
 height, and only 205 of the 500 rows are realised.
-
-Teardown needs care: destroying a window whose `Gtk.SignalListItemFactory` still had JS handlers
-connected produced six `Gjs-CRITICAL` lines.
 
 ## Overlay, dialogs and window size
 


### PR DESCRIPTION
`packages/framework/react-native/src/lists/controller.ts` was 389 lines, 215 of them
comment, and most of what it knew was not about React. A `Gio.ListStore` of carriers, a
`Gtk.SignalListItemFactory`, a key diff and a teardown authority are GTK and GObject
facts; the file that held them was reachable from exactly one renderer, so Vue and Solid
had no lists at all and would each have had to re-measure the same things to get any.

## The split

**`@gjsify/gtk-host/list`** is the neutral half, and a SUBPATH rather than a package —
the repo's rule is that a `/core` subpath beats a new `-core` package unless a separate
name buys a package-level cycle or an independent external consumer, and neither is in
play. It imports GTK and GObject and nothing else: no React, no Solid, no Vue.

The seam is three callbacks, generic in the handle the dialect keeps:

| callback | called from | what it owes |
|---|---|---|
| `mountRow(item)` | `setup` | take the carrier, put a subtree root in it, return a handle |
| `showRow(handle, row, index)` | `bind`, `unbind` (with `null`), and a same-key content change | show that row, or empty it |
| `disposeRow(handle)` | `teardown` and `dispose()` | let go |

**Three of the four measurements moved with the code they explain** — the
`Gio.ListStore.get_item` carrier identity, why a data change SPLICES rather than
emitting `items-changed`, and why `dispose()` and not GTK's `teardown` is the authority,
because GJS blocks a JS callback during GC sweeping. **The fourth stayed**: rows render
on a microtask because GTK binds from inside React's own commit, where `render()`
refuses re-entry by name. That one is React's constraint, and it is now visibly React's
— the Solid rows added here need no deferral at all.

## Placement goes through the host

Both dialects take the carrier with `adopt()` ONCE, in `mountRow`, and keep the element.
GTK recycles a carrier across bind/unbind and `adopt`'s `foreign` snapshot cannot tell
our own previous child from application chrome, so adopting per bind refuses with
`occupied-slot` — the boundary #1398 pinned as a vector, met exactly where it said it
would be. The React row's box is created and placed through the host too, which leaves
`lists/controller.ts` with no runtime toolkit import at all.

## The second dialect

`@gjsify/gtk-host/solid`'s `listRows` is not a demo: one reactive root per ROW WIDGET
rather than per bound row, a row sees an ACCESSOR, and a content change behind an
unchanged key writes one property instead of rebuilding. `list/list.spec.ts` asserts
that by widget IDENTITY across the update — an assertion React Native's equivalent
cannot make, because its row rebuilds a React tree. Its rows are drained with an
`await`, never a flush seam, and its view is rooted in a constructed-never-presented
`Gtk.Window` because a `Gtk.ListView` binds nothing while detached.

## Numbers

Recomputed at `0612bb8`. Two of them were stale — each was true when it was written and
was overtaken by a later commit on this same branch, which is the shape a number in a
description takes when the branch keeps moving under it.

- `react-native/src/lists/controller.ts`: **389 → 188 lines**. The 227 this section
  carried was the count before `cb53f67` moved the scroll edge out one commit later.
- Each of the three neutral measurements appears **exactly once** in the tree, in
  `gtk-host/src/list/controller.ts`. ONE hit remains outside it — `react-native/src/press.ts`,
  an explicit back-reference that cites the file rather than restating the measurement.
  (This section said "two"; the sentence-level grep finds one.)
- gtk-host: 2238 → **2267** assertions, 13 → 14 gates. react-native unchanged at 861.
  The 2257 predated `66c9408`, which added five; the run before the review round below
  measured 2262, and the scroll vector added five more. Both legs agree — Gjs 1.88.1 and
  Node.js 24.19.0 each report 2267 from 14 gates.
- `packages/framework/AGENTS.md`: 31 887 bytes against 32 768 — the 881 bytes of headroom
  reproduce exactly.

## Negative controls

Every new rule was broken, watched go red, and restored.

| break | red |
|---|---|
| re-`adopt` the carrier on every bind | `occupied-slot`: "`<GtkListItem>` already holds a child the application put there" |
| drop the in-place carrier update in `setRows` | red in **both** suites — gtk-host and react-native |
| `items_changed` over the same carriers instead of re-showing | red in **both** suites: no rebind at all, which is the measurement |
| leave the factory handlers connected in `dispose()` | `Gjs-CRITICAL (recursed)`, runner killed by SIGTERM |
| drop `disposeRow` from `#teardown` | **green** at first — see below |
| drop `disposeRow` from `dispose()` | red, after the fix below |

The fifth one is the finding worth reading. `liveRows` going to zero says the controller
FORGOT a handle, not that the dialect was TOLD to let go of it, and after GTK has
dropped a row's widgets there is no tree left to ask — so the seam is the only place
that can answer. The spec now wraps the real Solid sink in a counter on both sides
(nothing about a row is simulated) and asserts `released === mounted` after GTK's own
teardown and again after `dispose()`. Both call sites now go red when removed.

## Review round

Two findings from an adversarial re-read, each fixed on the branch.

**`fix(scripts): a neutral subpath cannot opt out`.** The framework-free pass derived its
source directory from the MANIFEST, so a subpath the manifest stopped naming derived to
nothing — and nothing was a skip. MEASURED against the real package: with an
`import { createSignal } from 'solid-js'` under `src/list/`, deleting the one `"./list"`
line from `exports` took the run from exit 1 to exit 0 printing "0 framework-free
source(s) carry no framework". A gate one line of `package.json` switches off is the class
this repository pays most for, and `frameworkFreeDirs`'s own docstring claimed the
opposite. Present-but-unpublished and published-off-`index.js` are `unscanned-framework-free`
blockers now, both fixtured, and the same A/B reds. Three specifiers were missing too:
`react-native` does not match the `react` alternative (the segment bound is what keeps
`react` safe), `@gjsify/react-native` is the first consumer this seam was extracted FOR,
and `@gjsify/gtk-host/react` is the relative hop into `src/adapters` wearing this package's
own published subpath. 35 fixtures, 50 vectors.

**`test(gtk-host): the scroll edge it now owns`.** `onScrollNearEnd` moved into
`@gjsify/gtk-host/list` and its only test did not move with it — `@gjsify/react-native`'s
`onEndReached` vector reaches it through a re-export, so this package could publish a
broken scroll edge with its own suite green, and would stop testing it at all the day
react-native stopped re-exporting. Its docstring already said it was "asserted, in a spec
that presents nothing"; inside this package that sentence had nothing behind it. The
vector drives the `Gtk.Adjustment` with no window anywhere and covers the three rules plus
one react-native does not assert: the returned disposer really disconnects. Both halves go
red when broken — disposer no-op, and the `armed` guard removed.

The four properties the extraction had to carry across were each re-broken and watched go
red at `66c9408`: dropping the in-place carrier update reds the in-place vector (carrier
identity through `Gio.ListStore.get_item`), announcing with `items_changed` instead of
splicing reds two, dropping `disposeRow` from `dispose()` and from `#teardown` reds one
each, and re-`adopt`ing per show reds all six with GTK's own `<GtkListItem> already holds a
child the application put there`.

## Verified

`gjsify workspace @gjsify/gtk-host test` / `check` / `build`,
`gjsify workspace @gjsify/react-native test` / `check`,
`node scripts/audit-runtimes.mjs --check --strict`,
`node scripts/verify-package-outputs.mjs --only @gjsify/gtk-host`,
`node scripts/check-vocabulary-alignment.mjs`,
`node scripts/check-adapter-import-direction.mjs`,
`node scripts/check-doc-fences.mjs` and the three website gates,
`gjsify format`, `gjsify lint` — all exit 0.

One thing deliberately NOT done: `packages/framework/AGENTS.md` is 31 887 bytes against
the 32 KiB (32 768) where Codex truncates the tail silently, so the list contract went
into `gtk-host/README.md`, which that section already points at. That headroom is 881
bytes and worth someone's attention independently of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB

