### PR TITLE
feat(cli): localise the freedesktop metadata

### DIFF
--- a/packages/infra/cli/src/commands/gettext.ts
+++ b/packages/infra/cli/src/commands/gettext.ts
@@ -55,10 +55,17 @@ async function fileExists(path: string): Promise<boolean> {
  * metadata it generates through the same function, and a second copy of those
  * constraints here would be the copy that drifts.
  *
- * What is local to this command: the output keeps the CALLER's filename. That
- * matters for `--format xml` because msgfmt finds its ITS rules by filename
- * pattern, so `--filename app.xml` for an AppStream component fails where
- * `app.metainfo.xml` succeeds (constraint 4 over there).
+ * What is local to this command: the output keeps the CALLER's `--filename`,
+ * while every INTERMEDIATE is named after the TEMPLATE. Those have to be two
+ * different names, because msgfmt finds its ITS rules by filename pattern
+ * (constraint 4 over there) and from the second catalogue on the intermediates
+ * ARE templates. Named after `--filename` instead, the command's answer depended
+ * on how many catalogues there were: measured, `--format xml --template
+ * app.metainfo.xml.in --filename out.xml` wrote a translated file for a one-language
+ * `po/` and died on a two-language one with `cannot locate ITS rules for
+ * <tmpdir>/0-out.xml` — naming an internal path over a rule the user could act on.
+ * The template's suffix is what msgfmt validated for call 1, so it is the one
+ * suffix known to work for calls 2..n.
  */
 async function compileMerged(opts: {
     poDir: string;
@@ -84,9 +91,10 @@ async function compileMerged(opts: {
             mergeCatalogues({
                 mode: `--${opts.format}`,
                 template: opts.template,
-                // `basename`, so an intermediate stays inside `workDir` even when the
-                // caller's `--filename` carries a directory part.
-                extension: `-${basename(opts.filename)}`,
+                // The TEMPLATE's name, minus the `.in` convention — see the header.
+                // `basename`, so an intermediate stays inside `workDir` rather than
+                // following the directory part of the path the user passed.
+                extension: `-${basename(opts.template).replace(/\.in$/, '')}`,
                 catalogues: languages.map((lang) => ({ locale: lang, po: join(opts.poDir, `${lang}.po`) })),
                 workDir,
                 onCall: opts.verbose ? (args) => console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`) : undefined,

--- a/packages/infra/cli/src/commands/gettext.ts
+++ b/packages/infra/cli/src/commands/gettext.ts
@@ -1,18 +1,21 @@
 import { execFile } from 'node:child_process';
-import { mkdir, readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { Command } from '../types/index.js';
+import { mergeCatalogues } from '../utils/msgfmt-merge.js';
 
 const execFileAsync = promisify(execFile);
 
-type GettextFormat = 'mo' | 'xml' | 'desktop' | 'json';
+type GettextFormat = 'mo' | 'xml' | 'desktop';
 
 interface GettextOptions {
     poDir: string;
     outDir: string;
     domain: string;
     format?: GettextFormat;
+    template?: string;
     metainfo?: string;
     filename?: string;
     removeXmlComments?: boolean;
@@ -44,41 +47,79 @@ async function fileExists(path: string): Promise<boolean> {
     }
 }
 
-async function compileBulkXml(opts: {
+/**
+ * Fold every catalogue into ONE template.
+ *
+ * The chain, and the four measured msgfmt constraints that shape it, live in
+ * `utils/msgfmt-merge.ts` — `gjsify ship` folds the catalogues it stages into the
+ * metadata it generates through the same function, and a second copy of those
+ * constraints here would be the copy that drifts.
+ *
+ * What is local to this command: the output keeps the CALLER's filename. That
+ * matters for `--format xml` because msgfmt finds its ITS rules by filename
+ * pattern, so `--filename app.xml` for an AppStream component fails where
+ * `app.metainfo.xml` succeeds (constraint 4 over there).
+ */
+async function compileMerged(opts: {
     poDir: string;
     outDir: string;
-    domain: string;
+    format: 'xml' | 'desktop';
     template: string;
     filename: string;
     removeXmlComments: boolean;
     verbose: boolean;
 }): Promise<void> {
+    const languages = await listLanguages(opts.poDir);
+    if (languages.length === 0) {
+        console.warn(`[gjsify gettext] no .po files found in ${opts.poDir}`);
+        return;
+    }
+
     const outputFile = join(opts.outDir, opts.filename);
     await ensureDir(opts.outDir);
 
-    const args = [`--output-file=${outputFile}`, '--xml', `--template=${opts.template}`, '-d', opts.poDir];
-
-    if (opts.verbose) {
-        console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`);
+    const workDir = await mkdtemp(join(tmpdir(), 'gjsify-gettext-'));
+    try {
+        const merged = await readFile(
+            mergeCatalogues({
+                mode: `--${opts.format}`,
+                template: opts.template,
+                // `basename`, so an intermediate stays inside `workDir` even when the
+                // caller's `--filename` carries a directory part.
+                extension: `-${basename(opts.filename)}`,
+                catalogues: languages.map((lang) => ({ locale: lang, po: join(opts.poDir, `${lang}.po`) })),
+                workDir,
+                onCall: opts.verbose ? (args) => console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`) : undefined,
+            }),
+            'utf-8',
+        );
+        await writeFile(
+            outputFile,
+            opts.removeXmlComments && opts.format === 'xml' ? stripXmlComments(merged) : merged,
+        );
+    } finally {
+        await rm(workDir, { recursive: true, force: true });
     }
 
-    await execFileAsync('msgfmt', args);
-
-    if (opts.removeXmlComments) {
-        const content = await readFile(outputFile, 'utf-8');
-        await writeFile(outputFile, stripXmlComments(content));
-    }
-
     if (opts.verbose) {
-        console.log(`[gjsify gettext] wrote ${outputFile}`);
+        console.log(`[gjsify gettext] merged ${languages.length} language(s) into ${outputFile}`);
     }
 }
 
-async function compilePerLanguage(opts: {
+/**
+ * Compile each `<lang>.po` into `<outDir>/<lang>/LC_MESSAGES/<filename>`.
+ *
+ * `mo` only. The other two formats SUBSTITUTE a template rather than producing a
+ * catalogue, and there is no per-language file for them to write — which is the
+ * defect this signature now makes unrepresentable: the old shared loop passed
+ * `--desktop`/`--xml` with no `--template`, and msgfmt refuses that outright
+ * (`--desktop requires a "--template template" specification`, exit 1). Every
+ * `gjsify gettext --format=desktop` invocation had therefore always failed; the
+ * only e2e coverage passes `--format mo`, so nothing ever ran the other branch.
+ */
+async function compileCatalogues(opts: {
     poDir: string;
     outDir: string;
-    domain: string;
-    format: GettextFormat;
     filename: string;
     verbose: boolean;
 }): Promise<void> {
@@ -89,18 +130,12 @@ async function compilePerLanguage(opts: {
     }
 
     for (const lang of languages) {
-        const poFile = join(opts.poDir, `${lang}.po`);
-        const langDir = opts.format === 'mo' ? join(opts.outDir, lang, 'LC_MESSAGES') : join(opts.outDir, lang);
+        const langDir = join(opts.outDir, lang, 'LC_MESSAGES');
         await ensureDir(langDir);
-        const outputFile = join(langDir, opts.filename);
 
-        // msgfmt produces the binary .mo format by default — there is no
-        // `--mo` flag (only --xml, --desktop, --properties-output, ...).
-        const args = [`--output-file=${outputFile}`];
-        if (opts.format !== 'mo') {
-            args.push(`--${opts.format}`);
-        }
-        args.push(poFile);
+        // msgfmt produces the binary .mo format by default — there is no `--mo`
+        // flag (only --xml, --desktop, --properties-output, ...).
+        const args = [`--output-file=${join(langDir, opts.filename)}`, join(opts.poDir, `${lang}.po`)];
 
         if (opts.verbose) {
             console.log(`[gjsify gettext] msgfmt ${args.join(' ')}`);
@@ -114,24 +149,22 @@ async function compilePerLanguage(opts: {
     }
 }
 
-function defaultFilename(domain: string, format: GettextFormat, metainfoTemplate?: string): string {
+function defaultFilename(domain: string, format: GettextFormat, template?: string): string {
     switch (format) {
         case 'mo':
             return `${domain}.mo`;
-        case 'json':
-            return `${domain}.json`;
         case 'desktop':
             return `${domain}.desktop`;
         case 'xml': {
             // Mirror the template filename but without the trailing `.in` (convention for
             // pre-processed metainfo templates: `org.foo.Bar.metainfo.xml.in`).
-            if (metainfoTemplate) {
+            if (template) {
                 // `basename`, not a hand-rolled `lastIndexOf('/')`: this is a path the USER
                 // passed, and on win32 it separates with `\`, which the slice read as part
                 // of the name (#1143). `node:path` is the right owner for host tooling —
                 // though it only answers correctly under Node until #1146 makes
                 // `@gjsify/path` select win32 per host.
-                return basename(metainfoTemplate.replace(/\.in$/, ''));
+                return basename(template.replace(/\.in$/, ''));
             }
             return `${domain}.xml`;
         }
@@ -141,7 +174,8 @@ function defaultFilename(domain: string, format: GettextFormat, metainfoTemplate
 export const gettextCommand: Command<unknown, GettextOptions> = {
     command: 'gettext <poDir> <outDir>',
     description:
-        'Compile gettext .po files to .mo (per-language locale tree) or substitute a metainfo template via msgfmt --xml.',
+        'Compile gettext .po files to .mo (per-language locale tree), or merge every catalogue into a ' +
+        '.desktop / AppStream template via msgfmt --desktop / --xml.',
     builder: (yargs) => {
         return yargs
             .positional('poDir', {
@@ -151,7 +185,7 @@ export const gettextCommand: Command<unknown, GettextOptions> = {
                 demandOption: true,
             })
             .positional('outDir', {
-                description: 'Output directory (locale tree for --format=mo, plain dir for xml/desktop/json)',
+                description: 'Output directory (locale tree for --format=mo, plain dir for xml/desktop)',
                 type: 'string',
                 normalize: true,
                 demandOption: true,
@@ -165,13 +199,22 @@ export const gettextCommand: Command<unknown, GettextOptions> = {
             .option('format', {
                 description: 'Output format',
                 type: 'string',
-                choices: ['mo', 'xml', 'desktop', 'json'] as const,
+                choices: ['mo', 'xml', 'desktop'] as const,
                 default: 'mo' as const,
             })
-            .option('metainfo', {
-                description: 'For --format=xml: path to the template (`.metainfo.xml.in`) used as msgfmt --template',
+            .option('template', {
+                description:
+                    'Required for --format=xml|desktop: the file msgfmt substitutes into. Its SUFFIX matters — ' +
+                    'msgfmt --xml finds its ITS rules by filename pattern, so an AppStream template must be ' +
+                    'named `*.metainfo.xml[.in]`.',
                 type: 'string',
                 normalize: true,
+            })
+            .option('metainfo', {
+                description: 'Deprecated alias for --template.',
+                type: 'string',
+                normalize: true,
+                hidden: true,
             })
             .option('filename', {
                 description: 'Override the output filename (defaults to <domain>.<ext>)',
@@ -194,8 +237,12 @@ export const gettextCommand: Command<unknown, GettextOptions> = {
         const outDir = resolve(args.outDir as string);
         const domain = args.domain as string;
         const format = (args.format as GettextFormat | undefined) ?? 'mo';
-        const metainfo = args.metainfo ? resolve(args.metainfo as string) : undefined;
-        const filename = args.filename ?? defaultFilename(domain, format, metainfo);
+        // `--metainfo` predates the option being useful for `.desktop` too. Kept as a
+        // hidden alias rather than removed: it is the spelling `cli-reference.md`
+        // documented, so removing it would break the invocation the docs taught.
+        const templateArg = (args.template as string | undefined) ?? (args.metainfo as string | undefined);
+        const template = templateArg ? resolve(templateArg) : undefined;
+        const filename = args.filename ?? defaultFilename(domain, format, template);
         const verbose = !!args.verbose;
         const removeXmlComments = !!args['remove-xml-comments'];
 
@@ -205,29 +252,36 @@ export const gettextCommand: Command<unknown, GettextOptions> = {
             return;
         }
 
+        // REFUSED, not worked around. `--xml` and `--desktop` substitute into a
+        // template, and msgfmt rejects both without one (`--desktop requires a
+        // "--template template" specification`, exit 1). The old code fell back to a
+        // per-language loop that passed no template at all, so the fallback could only
+        // ever reproduce that same error one layer further down — with the user's
+        // `--format` reported as the thing that failed rather than the missing template.
+        if (format !== 'mo' && template === undefined) {
+            console.error(
+                `[gjsify gettext] --format=${format} needs a template to substitute into: pass ` +
+                    '`--template <file>`. msgfmt has no way to produce this format from .po files alone.' +
+                    (format === 'xml'
+                        ? ' Name it `*.metainfo.xml[.in]` — msgfmt --xml finds its ITS rules by filename pattern.'
+                        : ''),
+            );
+            process.exitCode = 1;
+            return;
+        }
+
         try {
-            if (format === 'xml' && metainfo) {
-                await compileBulkXml({
+            if (format === 'mo') {
+                await compileCatalogues({ poDir, outDir, filename, verbose });
+            } else {
+                await compileMerged({
                     poDir,
                     outDir,
-                    domain,
-                    template: metainfo,
+                    format,
+                    // Narrowed by the refusal above.
+                    template: template as string,
                     filename,
                     removeXmlComments,
-                    verbose,
-                });
-            } else {
-                if (format === 'xml') {
-                    console.warn(
-                        '[gjsify gettext] --format=xml without --metainfo: falling back to per-language XML files',
-                    );
-                }
-                await compilePerLanguage({
-                    poDir,
-                    outDir,
-                    domain,
-                    format,
-                    filename,
                     verbose,
                 });
             }

--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -39,6 +39,7 @@ import { buildDeb } from '../utils/ship/deb.js';
 import { deriveDepends, warnAboutGjsFloor, warnAboutNodeFloor } from '../utils/ship/depends.js';
 import { discoverPayload } from '../utils/ship/discover.js';
 import { buildFlatpakBundle } from '../utils/ship/flatpak.js';
+import { localizeMetadata } from '../utils/ship/localize-metadata.js';
 import {
     assertHostCanFinish,
     assertToolsInstalled,
@@ -331,11 +332,24 @@ async function assemble(args: ShipOptions): Promise<void> {
         );
     }
 
+    // Rendered in English, then TRANSLATED with the catalogues this package
+    // already stages. Without this step the two halves never met: `share/locale/`
+    // shipped every `.mo` while `Name=` and `<name>` stayed English, so a fully
+    // translated app showed an English entry in the app menu and in Software.
+    // Both files stay valid either way, which is why nobody reported it.
+    const translated = localizeMetadata(
+        {
+            metainfo: settings.kind === 'app' ? renderMetainfoApp(metadataInputs) : renderMetainfoCli(metadataInputs),
+            desktopEntry: settings.kind === 'app' ? renderDesktopEntry(metadataInputs) : undefined,
+        },
+        settings.localeFiles,
+    );
+
     const stageInputs: StageInputs = {
         bundleFiles: discovered.bundleFiles,
         launcher: renderLauncher(settings, basename(settings.bundlePath), layout),
-        metainfo: settings.kind === 'app' ? renderMetainfoApp(metadataInputs) : renderMetainfoCli(metadataInputs),
-        desktopEntry: settings.kind === 'app' ? renderDesktopEntry(metadataInputs) : undefined,
+        metainfo: translated.metainfo,
+        desktopEntry: translated.desktopEntry,
         licenseText: settings.licenseFile === undefined ? undefined : readFileSync(settings.licenseFile, 'utf-8'),
     };
 

--- a/packages/infra/cli/src/test.mts
+++ b/packages/infra/cli/src/test.mts
@@ -16,6 +16,7 @@ import shipPayloadSuite from './utils/ship/payload.spec.js';
 import shipLauncherSuite from './utils/ship/launcher.spec.js';
 import shipSettingsSuite from './utils/ship/settings.spec.js';
 import shipLocalesSuite from './utils/ship/discover-locales.spec.js';
+import msgfmtMergeSuite from './utils/msgfmt-merge.spec.js';
 import shipTypelibsSuite from './utils/ship/discover-typelibs.spec.js';
 import shipMimeSuite from './utils/ship/mime.spec.js';
 import shipLicenseSuite from './utils/ship/discover-license.spec.js';
@@ -219,6 +220,7 @@ run(
         shipLauncherSuite,
         shipSettingsSuite,
         shipLocalesSuite,
+        msgfmtMergeSuite,
         shipMimeSuite,
         shipLicenseSuite,
         shipDependsSuite,

--- a/packages/infra/cli/src/utils/msgfmt-merge.spec.ts
+++ b/packages/infra/cli/src/utils/msgfmt-merge.spec.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// The two answers `mergeCatalogues` gives WITHOUT spawning anything.
+//
+// Both are here rather than in an e2e suite because both are decided before the
+// first `execFileSync`, so neither needs gettext on the host — and the guard is
+// the more important of the two: it is the only place that stops a caller from
+// reproducing constraint 5, whose whole difficulty is that msgfmt reports it as
+// two successes. `tests/e2e/ship` proves the SHIP path never trips it; this
+// proves the seam refuses anyone who would.
+
+import { describe, expect, it } from '@gjsify/unit';
+
+import { mergeCatalogues } from './msgfmt-merge.js';
+
+/** The message of the error a call throws, or null when it does not throw. */
+function refusal(fn: () => void): string | null {
+    try {
+        fn();
+        return null;
+    } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+    }
+}
+
+// A directory that does not exist, so a spawn that DID happen would fail loudly
+// instead of quietly succeeding somewhere. Nothing below may reach msgfmt.
+const NOWHERE = '/nonexistent/gjsify-msgfmt-merge-spec';
+
+export default async () => {
+    await describe('mergeCatalogues', async () => {
+        await it('returns the template untouched when there is nothing to fold', () => {
+            // The path `gjsify ship` takes for a project without a `localeDir`: no
+            // catalogues means no msgfmt, so a host without gettext still packs.
+            expect(
+                mergeCatalogues({
+                    mode: '--desktop',
+                    template: '/tmp/app.desktop',
+                    extension: '.desktop',
+                    catalogues: [],
+                    workDir: NOWHERE,
+                }),
+            ).toBe('/tmp/app.desktop');
+        });
+
+        await it('refuses two catalogues claiming the same locale', () => {
+            // Chained, this is two exit-0 msgfmt calls and a file both validators
+            // reject (`multiple keys named "Name[de]"`, `tag-duplicated`). The refusal
+            // has to NAME the locale — the caller holds several `.po` and cannot act
+            // on "a duplicate" alone.
+            const message = refusal(() =>
+                mergeCatalogues({
+                    mode: '--desktop',
+                    template: '/tmp/app.desktop',
+                    extension: '.desktop',
+                    catalogues: [
+                        { locale: 'de', po: '/tmp/app.po' },
+                        { locale: 'fr', po: '/tmp/lib-fr.po' },
+                        { locale: 'de', po: '/tmp/lib-de.po' },
+                    ],
+                    workDir: NOWHERE,
+                }),
+            );
+            expect(message).toMatch(/locale "de"/);
+            // And it names the way out, because there is one — the caller decides
+            // which translation wins and hands over a single catalogue.
+            expect(message).toMatch(/msgcat --use-first/);
+        });
+
+        await it('refuses BEFORE the first spawn', () => {
+            // Not cosmetic. Refusing mid-chain would leave intermediates behind and,
+            // worse, would make the guard depend on msgfmt being installed — so a host
+            // without gettext would get `ENOENT` for a call that was invalid anyway.
+            // `workDir` above is unwritable, so reaching a spawn cannot look like this.
+            expect(
+                refusal(() =>
+                    mergeCatalogues({
+                        mode: '--xml',
+                        template: '/tmp/app.metainfo.xml',
+                        extension: '.metainfo.xml',
+                        catalogues: [
+                            { locale: 'pt_BR', po: '/tmp/a.po' },
+                            { locale: 'pt_BR', po: '/tmp/b.po' },
+                        ],
+                        workDir: NOWHERE,
+                    }),
+                ),
+            ).toMatch(/^mergeCatalogues: /);
+        });
+
+        await it('lets distinct locales through to msgfmt', () => {
+            // The control for the guard: same shape, different locales, so whatever
+            // this reports is msgfmt's answer and not the guard's. Without it, a guard
+            // that refused EVERYTHING would pass all three cases above.
+            const message = refusal(() =>
+                mergeCatalogues({
+                    mode: '--desktop',
+                    template: '/tmp/app.desktop',
+                    extension: '.desktop',
+                    catalogues: [
+                        { locale: 'de', po: '/tmp/de.po' },
+                        { locale: 'fr', po: '/tmp/fr.po' },
+                    ],
+                    workDir: NOWHERE,
+                }),
+            );
+            // `?? ''` rather than asserting on a possibly-null value: what this checks
+            // is that the guard did not speak, and "no error at all" is one of the two
+            // ways for that to be true.
+            expect(message ?? '').not.toMatch(/^mergeCatalogues: /);
+        });
+    });
+};

--- a/packages/infra/cli/src/utils/msgfmt-merge.ts
+++ b/packages/infra/cli/src/utils/msgfmt-merge.ts
@@ -1,0 +1,97 @@
+// Merging gettext catalogues INTO a template — the `msgfmt --desktop` / `--xml` half.
+//
+// Two callers need this and they are not variants of each other: `gjsify gettext`
+// substitutes a template a user wrote, `gjsify ship` substitutes metadata it just
+// rendered. What they share is every constraint below, all four measured against
+// GNU gettext 0.26, and each one fails a DIFFERENT way — one of them silently.
+// Written twice, the silent one is the copy that loses them.
+//
+//  1. `--desktop` and `--xml` REQUIRE `--template`:
+//     `msgfmt: --desktop requires a "--template template" specification`, exit 1.
+//     Neither format can be produced from `.po` files alone, so a caller without a
+//     template has nothing to ask for.
+//
+//  2. The bulk form (`-d <podir>`) fails SILENTLY. With no `LINGUAS` file beside
+//     the `.po` files:
+//         msgfmt --desktop --template=app.desktop.in -d po -o out.desktop
+//         exit 0 · stderr `po/LINGUAS does not exist` · out.desktop UNTRANSLATED
+//     and `desktop-file-validate out.desktop` then exits 0 as well. Exit 0, an
+//     English file and a passing oracle is the worst of the three outcomes, which
+//     is why this module names each language with `--locale=` instead: that form
+//     needs no `LINGUAS` and cannot degrade to a no-op without a non-zero exit.
+//
+//  3. The template and the output must never be the SAME path. msgfmt truncates
+//     `--output-file` before it reads the template, so chaining in place destroys
+//     it: measured, `--desktop` wrote a 0-byte file and exited 0, `--xml` printed
+//     `cannot read <file>: Document is empty` and died on SIGSEGV (exit 139).
+//     Hence the numbered intermediates below rather than one file rewritten.
+//
+//  4. `--xml` finds its ITS rules by FILENAME PATTERN, not by reading the document.
+//     gettext walks `/usr/share/gettext/its/*.loc`, where each rule pairs a glob
+//     with a root element; AppStream's is `pattern="*.metainfo.xml"` +
+//     `localName="component"`, so the same bytes named `foo.xml` die with
+//     `msgfmt: cannot locate ITS rules for foo.xml` (exit 1). `extension` is
+//     therefore part of this function's contract, not a temp-file detail.
+//
+//     Stated as "`--xml` needs a `.metainfo.xml` name" the rule would be wrong in
+//     the direction that matters next: `shared-mime-info.loc` pairs `pattern="*.xml"`
+//     with `localName="mime-info"`, so a MIME package needs no suffix care at all.
+//     The constraint belongs to the AppStream rule, not to `--xml`.
+
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+
+/** Which of msgfmt's two template writers to run. */
+export type MsgfmtMergeMode = '--desktop' | '--xml';
+
+/** One catalogue: the language tag msgfmt is TOLD, and the `.po` holding it. */
+export interface MsgfmtCatalogue {
+    /** Passed as `--locale=`. Named explicitly so no `LINGUAS` file is needed — constraint 2. */
+    locale: string;
+    /** Path to a `.po`. msgfmt reads only this format here: a `.mo` gives `syntax error`, exit 1. */
+    po: string;
+}
+
+export interface MsgfmtMergeOptions {
+    mode: MsgfmtMergeMode;
+    /** The file the FIRST call substitutes into. Every later call substitutes into the previous output. */
+    template: string;
+    /** The suffix every intermediate keeps — load-bearing for `--xml`, see constraint 4. */
+    extension: string;
+    catalogues: readonly MsgfmtCatalogue[];
+    /** A directory this function may fill with intermediates; the caller owns its removal. */
+    workDir: string;
+    /** Called with each msgfmt argv, for `--verbose`. */
+    onCall?: (args: readonly string[]) => void;
+}
+
+/**
+ * Fold every catalogue into one file, chaining `msgfmt` once per language.
+ *
+ * Returns the PATH of the last file written — the caller decides whether to read
+ * it, post-process it or copy it. With no catalogues that is `template` itself,
+ * so a project with nothing to merge never spawns msgfmt at all.
+ *
+ * `stdio: 'pipe'` so a failure's stderr survives on the thrown error rather than
+ * going to the terminal and leaving the caller with an exit code.
+ */
+export function mergeCatalogues(options: MsgfmtMergeOptions): string {
+    let current = options.template;
+
+    for (const [index, catalogue] of options.catalogues.entries()) {
+        const next = join(options.workDir, `${index}${options.extension}`);
+        const args = [
+            options.mode,
+            `--template=${current}`,
+            `--locale=${catalogue.locale}`,
+            `--output-file=${next}`,
+            catalogue.po,
+        ];
+        options.onCall?.(args);
+        execFileSync('msgfmt', args, { stdio: 'pipe' });
+        // Every language after the first merges INTO what the previous one wrote.
+        current = next;
+    }
+
+    return current;
+}

--- a/packages/infra/cli/src/utils/msgfmt-merge.ts
+++ b/packages/infra/cli/src/utils/msgfmt-merge.ts
@@ -2,9 +2,9 @@
 //
 // Two callers need this and they are not variants of each other: `gjsify gettext`
 // substitutes a template a user wrote, `gjsify ship` substitutes metadata it just
-// rendered. What they share is every constraint below, all four measured against
-// GNU gettext 0.26, and each one fails a DIFFERENT way — one of them silently.
-// Written twice, the silent one is the copy that loses them.
+// rendered. What they share is every constraint below, all five measured against
+// GNU gettext 0.26, and each one fails a DIFFERENT way — two of them silently.
+// Written twice, the silent ones are the copies that lose them.
 //
 //  1. `--desktop` and `--xml` REQUIRE `--template`:
 //     `msgfmt: --desktop requires a "--template template" specification`, exit 1.
@@ -37,6 +37,22 @@
 //     the direction that matters next: `shared-mime-info.loc` pairs `pattern="*.xml"`
 //     with `localName="mime-info"`, so a MIME package needs no suffix care at all.
 //     The constraint belongs to the AppStream rule, not to `--xml`.
+//
+//  5. A locale may appear at most ONCE in a chain. Two calls naming the same
+//     `--locale` both APPEND — neither replaces the other's key — and the result
+//     is a file BOTH oracles reject, from two exit-0 msgfmt calls:
+//         msgfmt --desktop --template=app.desktop.in --locale=de -o d0 a.po  # 0
+//         msgfmt --desktop --template=d0             --locale=de -o d1 b.po  # 0
+//         desktop-file-validate d1
+//           → error: file contains multiple keys named "Name[de]"            # 1
+//         appstreamcli validate --no-net x1.metainfo.xml   (same shape, --xml)
+//           → E: tag-duplicated name (lang=de) · Validation failed           # 3
+//     So this is worse than constraint 2: not an untranslated file that installs
+//     fine, but an INVALID one, produced without a single non-zero exit. It is
+//     refused here rather than deduplicated here, because the caller holding two
+//     catalogues for one language is the only party that can say which
+//     translation wins — `utils/ship/localize-metadata.ts` answers it with
+//     `msgcat --use-first`.
 
 import { execFileSync } from 'node:child_process';
 import { join } from 'node:path';
@@ -74,9 +90,29 @@ export interface MsgfmtMergeOptions {
  *
  * `stdio: 'pipe'` so a failure's stderr survives on the thrown error rather than
  * going to the terminal and leaving the caller with an exit code.
+ *
+ * Throws when two catalogues name the same locale — constraint 5, which msgfmt
+ * itself reports as two successes and one invalid file.
  */
 export function mergeCatalogues(options: MsgfmtMergeOptions): string {
     let current = options.template;
+
+    // BEFORE the first spawn, so a caller that got this wrong is told rather than
+    // handed a half-written chain to clean up. `seen` is a Set of the locale, not
+    // of the catalogue: the same language reached through two `.po` files is
+    // exactly the case that produces the duplicate key.
+    const seen = new Set<string>();
+    for (const { locale } of options.catalogues) {
+        if (seen.has(locale)) {
+            throw new Error(
+                `mergeCatalogues: two catalogues both claim locale "${locale}". msgfmt APPENDS each ` +
+                    `--locale, so the chain would emit a duplicate key (desktop-file-validate: ` +
+                    `"multiple keys named Name[${locale}]"; appstreamcli: "tag-duplicated") from two ` +
+                    'exit-0 calls. Merge them into one .po first (msgcat --use-first) and pass that.',
+            );
+        }
+        seen.add(locale);
+    }
 
     for (const [index, catalogue] of options.catalogues.entries()) {
         const next = join(options.workDir, `${index}${options.extension}`);

--- a/packages/infra/cli/src/utils/ship/localize-metadata.ts
+++ b/packages/infra/cli/src/utils/ship/localize-metadata.ts
@@ -1,0 +1,123 @@
+// Folding the staged gettext catalogues into the generated freedesktop metadata.
+//
+// `gjsify ship` already discovered, validated and staged the compiled `.mo`
+// catalogues, and `app-metadata.ts` already rendered a `.desktop` entry and an
+// AppStream component. The two never met: no `Name[xx]=` and no `xml:lang=` was
+// emitted anywhere, so a fully translated app still showed an English name in
+// the GNOME app menu and in Software. Nobody reported it because both files
+// stay VALID without the translations — `desktop-file-validate` and
+// `appstreamcli validate` pass an untranslated file at exit 0, which is why the
+// tests for this assert the localised keys are PRESENT rather than trusting a
+// validator to notice they are gone.
+//
+// The msgfmt constraints this rests on live in `../msgfmt-merge.ts`, which runs
+// the chain for `gjsify gettext` too. One more is local to here: the catalogues
+// reach us as `.mo` and msgfmt reads `.po` — handing it a `.mo` gives
+// `de.mo:1:2: syntax error`, exit 1. `msgunfmt` (same `gettext` package, so no
+// new dependency) converts back, and the round trip is exact for the
+// msgid/msgstr pairs these two formats consume.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { type MsgfmtCatalogue, type MsgfmtMergeMode, mergeCatalogues } from '../msgfmt-merge.js';
+
+/** The generated metadata, before or after translation. */
+export interface LocalizableMetadata {
+    /** The rendered AppStream MetaInfo XML. */
+    metainfo: string;
+    /** The rendered desktop entry — `undefined` for `kind: 'cli'`. */
+    desktopEntry?: string;
+}
+
+/** A staged catalogue, in the `<lang>/LC_MESSAGES/<domain>.mo` shape `discoverLocales` guarantees. */
+export interface StagedCatalogue {
+    rel: string;
+    abs: string;
+}
+
+/**
+ * The locale a staged catalogue path declares.
+ *
+ * Read rather than re-validated: `discoverLocales` has already refused anything
+ * that is not `<lang>/LC_MESSAGES/<domain>.mo`, and a second validator here would
+ * be a second definition of the layout.
+ */
+function localeOf(rel: string): string {
+    return rel.split('/')[0] ?? '';
+}
+
+/** Chain one metadata file through every catalogue, and read the result back. */
+function fold(
+    mode: MsgfmtMergeMode,
+    source: string,
+    extension: string,
+    catalogues: readonly MsgfmtCatalogue[],
+    workDir: string,
+): string {
+    // The source is a STRING, so it has to become a file before msgfmt can be its
+    // template — and that file needs `extension` for the same reason the
+    // intermediates do (`msgfmt-merge.ts`, constraint 4).
+    const template = join(workDir, `source${extension}`);
+    writeFileSync(template, source);
+    return readFileSync(mergeCatalogues({ mode, template, extension, catalogues, workDir }), 'utf-8');
+}
+
+/**
+ * Translate the generated metadata with the catalogues the package ships.
+ *
+ * Returns the input unchanged when there is nothing to fold in, so a project
+ * without a `localeDir` never needs the gettext tools. A project WITH catalogues
+ * that lacks them is REFUSED rather than shipped in English: an untranslated
+ * `.desktop` is indistinguishable from a correct one at install time, and the
+ * package would have promised translations it does not deliver.
+ */
+export function localizeMetadata(
+    metadata: LocalizableMetadata,
+    localeFiles: readonly StagedCatalogue[],
+): LocalizableMetadata {
+    if (localeFiles.length === 0) return metadata;
+
+    const workDir = mkdtempSync(join(tmpdir(), 'gjsify-ship-l10n-'));
+    try {
+        // Sorted so the emitted `Name[xx]=` order — and therefore the artifact's
+        // bytes — does not depend on directory-read order. `listFilesRecursive`
+        // already sorts; relying on that from here would put the determinism of this
+        // file's output in another module's keeping.
+        const catalogues: MsgfmtCatalogue[] = [...localeFiles]
+            .sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0))
+            .map((file, index) => {
+                const po = join(workDir, `${index}.po`);
+                execFileSync('msgunfmt', [file.abs, '--output-file', po], { stdio: 'pipe' });
+                return { locale: localeOf(file.rel), po };
+            });
+
+        return {
+            metainfo: fold('--xml', metadata.metainfo, '.metainfo.xml', catalogues, workDir),
+            desktopEntry:
+                metadata.desktopEntry === undefined
+                    ? undefined
+                    : fold('--desktop', metadata.desktopEntry, '.desktop', catalogues, workDir),
+        };
+    } catch (error) {
+        throw new Error(describeFailure(error, localeFiles.length));
+    } finally {
+        rmSync(workDir, { recursive: true, force: true });
+    }
+}
+
+/** One actionable line for a failed merge, naming the tool the host is missing. */
+function describeFailure(error: unknown, count: number): string {
+    const e = error as { code?: unknown; stderr?: Buffer | string };
+    if (e?.code === 'ENOENT') {
+        return (
+            'gjsify ship: `msgfmt`/`msgunfmt` are not on PATH, but the package stages ' +
+            `${count} gettext catalogue(s). Install them (package: gettext) — shipping the metadata ` +
+            'untranslated would install an English app menu entry for a translated app, which nothing ' +
+            'downstream can detect.'
+        );
+    }
+    const stderr = e?.stderr === undefined ? '' : `\n${String(e.stderr).trim()}`;
+    return `gjsify ship: could not fold the gettext catalogues into the freedesktop metadata.${stderr}`;
+}

--- a/packages/infra/cli/src/utils/ship/localize-metadata.ts
+++ b/packages/infra/cli/src/utils/ship/localize-metadata.ts
@@ -11,11 +11,21 @@
 // validator to notice they are gone.
 //
 // The msgfmt constraints this rests on live in `../msgfmt-merge.ts`, which runs
-// the chain for `gjsify gettext` too. One more is local to here: the catalogues
-// reach us as `.mo` and msgfmt reads `.po` — handing it a `.mo` gives
-// `de.mo:1:2: syntax error`, exit 1. `msgunfmt` (same `gettext` package, so no
-// new dependency) converts back, and the round trip is exact for the
-// msgid/msgstr pairs these two formats consume.
+// the chain for `gjsify gettext` too. Two more are local to here, both from what
+// a STAGED locale tree may hold that a `po/` directory cannot:
+//
+//   * The catalogues reach us as `.mo` and msgfmt reads `.po` — handing it a
+//     `.mo` gives `de.mo:1:2: syntax error`, exit 1. `msgunfmt` converts back,
+//     and the round trip is exact for the msgid/msgstr pairs these two formats
+//     consume.
+//   * One language may arrive as SEVERAL catalogues, because the tree is keyed by
+//     `<lang>/LC_MESSAGES/<domain>.mo` and a package may ship more than one text
+//     domain. `msgcat --use-first` folds those into one before the chain sees
+//     them — the alternative is `msgfmt-merge.ts` constraint 5, an invalid file
+//     out of nothing but exit-0 calls.
+//
+// Both tools are in the same `gettext` package as `msgfmt`, so neither adds a
+// dependency the fold did not already have.
 
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -84,14 +94,34 @@ export function localizeMetadata(
         // Sorted so the emitted `Name[xx]=` order — and therefore the artifact's
         // bytes — does not depend on directory-read order. `listFilesRecursive`
         // already sorts; relying on that from here would put the determinism of this
-        // file's output in another module's keeping.
-        const catalogues: MsgfmtCatalogue[] = [...localeFiles]
-            .sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0))
-            .map((file, index) => {
-                const po = join(workDir, `${index}.po`);
-                execFileSync('msgunfmt', [file.abs, '--output-file', po], { stdio: 'pipe' });
-                return { locale: localeOf(file.rel), po };
-            });
+        // file's output in another module's keeping. The sort ALSO fixes which
+        // domain wins below, so `--use-first` is a choice and not a coin toss.
+        const sorted = [...localeFiles].sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+
+        // Grouped by LOCALE, not one entry per file. `discoverLocales` accepts every
+        // `<lang>/LC_MESSAGES/<domain>.mo`, and a package that ships two text domains
+        // (its own plus a bundled library's) therefore hands us two catalogues for one
+        // language. Chained as-is that is `msgfmt-merge.ts` constraint 5: two exit-0
+        // calls and a file both validators reject — `multiple keys named "Name[de]"`
+        // (exit 1) and `tag-duplicated name (lang=de)` (exit 3). Measured.
+        const byLocale = new Map<string, string[]>();
+        for (const [index, file] of sorted.entries()) {
+            const po = join(workDir, `${index}.po`);
+            execFileSync('msgunfmt', [file.abs, '--output-file', po], { stdio: 'pipe' });
+            const locale = localeOf(file.rel);
+            byLocale.set(locale, [...(byLocale.get(locale) ?? []), po]);
+        }
+
+        const catalogues: MsgfmtCatalogue[] = [...byLocale].map(([locale, files]) => ({
+            locale,
+            // `--use-first` rather than a plain concatenation: two domains translating
+            // the same source string is not an error a packager can act on, and the
+            // alternatives are both worse. msgfmt given both files at once refuses
+            // outright (`duplicate message definition`, 2 fatal errors, exit 1), and a
+            // plain `msgcat` writes `#-#-#-#-#` conflict markers straight into the
+            // `Name=` a user reads. First in the sort above wins, deterministically.
+            po: files.length === 1 ? (files[0] as string) : msgcat(files, join(workDir, `${locale}.merged.po`)),
+        }));
 
         return {
             metainfo: fold('--xml', metadata.metainfo, '.metainfo.xml', catalogues, workDir),
@@ -107,12 +137,18 @@ export function localizeMetadata(
     }
 }
 
+/** Fold several `.po` for ONE language into one, first translation wins. Returns its path. */
+function msgcat(files: readonly string[], out: string): string {
+    execFileSync('msgcat', ['--use-first', '--output-file', out, ...files], { stdio: 'pipe' });
+    return out;
+}
+
 /** One actionable line for a failed merge, naming the tool the host is missing. */
 function describeFailure(error: unknown, count: number): string {
     const e = error as { code?: unknown; stderr?: Buffer | string };
     if (e?.code === 'ENOENT') {
         return (
-            'gjsify ship: `msgfmt`/`msgunfmt` are not on PATH, but the package stages ' +
+            'gjsify ship: `msgfmt`/`msgunfmt`/`msgcat` are not on PATH, but the package stages ' +
             `${count} gettext catalogue(s). Install them (package: gettext) — shipping the metadata ` +
             'untranslated would install an English app menu entry for a translated app, which nothing ' +
             'downstream can detect.'

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -3710,6 +3710,18 @@ past the node tools is the mechanism this class wants; it needs a way to derive 
 from the SUITES rather than from the workflow `run:` lines, which is why it is a ledger
 entry and not a one-line change.
 
+What the gap is NOT, so the next reader does not over-buy the fix: an image missing one of
+these tools is a RED e2e run, never a green vacuous one. `tests/e2e/ship/fixture.mjs`'s
+`probe()` throws for every name in `REQUIRED_ON_LINUX`, and the two `cli-only` cases assert
+`hasCommand(...)` instead of branching on it, so no assertion behind them can quietly stop
+running. What is missing is only the EARLIER answer — at image-build time rather than at
+e2e time. That also names the shape of the fix: `REQUIRED_ON_LINUX` already IS the
+declaration, so a check reads it (the way `fixture.mjs` imports `STAGE_MANIFEST_FILE` out
+of the CLI rather than restating it) instead of growing a second list beside it. What it
+still needs is a binary→package answer that is not a hand-kept table — most plausibly a
+smoke step in `build-ci-image.yml` running `command -v` over that same imported set, which
+asks the built IMAGE and therefore cannot drift from what the image contains.
+
 The gap is not theoretical. Measured against a component `renderMetainfoApp` produced
 for the `ship` e2e fixture, using the flag the command actually passes:
 
@@ -3754,7 +3766,12 @@ implementation of the same wrapper:
     plugin cannot have compiled a `.mo` either. It has no test and no in-repo consumer —
     only `resolve-plugin-by-name.ts` documents the `{ "export": "msgfmtPlugin" }` spelling
     — which is how a wrapper that works for none of its formats stayed in a published
-    package.
+    package. Nor could a gate have said so: `scripts/audit-test-scripts.mjs` asks whether a
+    package's `test` script RUNS the per-runtime legs it ships, so a package with no `test`
+    script at all (this one has `clear`/`check`/`build` and nothing else) is outside its
+    question. Which fixes the ORDER of the repair: the test entry is the first commit, not
+    the wrapper. Without one `gjsify foreach test` never reaches the package, and the fix
+    would be green because unrun — the class it is repairing.
 
 `getOutputExtension` also returns `.xml` for the xml format, which trips a third measured
 constraint: gettext finds ITS rules by filename PATTERN (`/usr/share/gettext/its/*.loc`,

--- a/status/open-todos.md
+++ b/status/open-todos.md
@@ -3693,3 +3693,110 @@ So the decision to make first is a policy one: do published packages ship their
 specs at all? Once that has an answer, the check belongs in
 `verify-tarball-outputs.mjs`, which already computes the packed set per package
 from `gjsify pack`'s own oracle and needs no new CI step.
+
+### `gjsify flatpak check` has never run the real appstreamcli
+
+`flatpak check` shells out to `appstreamcli validate --strict`, and no test has ever
+fed it a component this repo actually GENERATED. `tests/e2e/flatpak/run.mjs` drives the
+command through `writeShim(stubBinDir, 'appstreamcli', 'APPSTREAMCLI_CALLS')` and hands
+it the string `<component/>` as the metainfo file, so the suite asserts the CALL SHAPE
+(`validate --strict …metainfo.xml.in`) and nothing about the XML. Both linters are
+stubbed the same way, and `appstreamcli` was absent from `.docker/ci-fedora.Dockerfile`
+until the commit that added this entry, so no CI job could have run the real one either.
+And no gate could have said so: `scripts/check-ci-image-packages.mjs` asks "does a job USE
+a tool the image never carries" only for `NODE_TOOLS = ['node', 'npx', 'npm', 'corepack']`,
+so a suite reaching for `appstreamcli` is outside what it looks at. Widening that question
+past the node tools is the mechanism this class wants; it needs a way to derive tool use
+from the SUITES rather than from the workflow `run:` lines, which is why it is a ledger
+entry and not a one-line change.
+
+The gap is not theoretical. Measured against a component `renderMetainfoApp` produced
+for the `ship` e2e fixture, using the flag the command actually passes:
+
+    appstreamcli validate --strict --no-net <stage>/share/metainfo/org.example.ShipDemo.metainfo.xml
+    I: org.example.ShipDemo:10: description-first-para-too-short
+    ✘ Validation failed: infos: 1, pedantic: 2      # exit 3
+
+`--strict` fails on anything above pedantic severity, so an INFO-level hint is enough.
+The same file passes plain `appstreamcli validate --no-net` at exit 0. Two things are
+therefore unknown: whether `gjsify flatpak check` passes on any real project, and
+whether `--strict` is the severity this command wants — a first description paragraph
+under a certain length is a house-style hint, not a defect that should block a build.
+
+Also worth folding in: the command validates the `.in` TEMPLATE rather than the merged
+output. Since `gjsify gettext --format=xml` now produces a real translated component
+(`msgfmt --xml`, per-catalogue `--locale=` chaining), the file worth validating is the
+merged one — the template is missing every `xml:lang` attribute the merge adds.
+
+Fix: drop the appstreamcli shim from that suite, scaffold a project through the real
+`flatpak init` renderer, and run the real binary with `--no-net` (its absence otherwise
+makes the assertion depend on resolving every `<url>`). Then decide `--strict` on the
+evidence that produces.
+
+### `@gjsify/vite-plugin-gettext`'s msgfmt plugin carries both gettext defects
+
+The two defects fixed in `gjsify gettext` (see `packages/infra/cli/src/commands/gettext.ts`)
+exist unchanged in `packages/infra/vite-plugin-gettext/src/msgfmt.ts`, which is a second
+implementation of the same wrapper:
+
+  * **Bulk mode, silent.** `msgfmtPlugin`'s `format === 'xml' && templateFile` branch builds
+    `['--output-file=' + outputFile, '--xml', '--template=' + templateFile, '-d', poDirectory]`.
+    With no `LINGUAS` file beside the `.po` files that exits 0, prints `<podir>/LINGUAS does
+    not exist`, and writes the template back untranslated. Measured on a probe tree with
+    gettext 0.26.
+  * **Per-language mode, impossible — for EVERY format, the default included.** The other
+    branch builds ``['--output-file=' + outputFile, `--${format}`, poFile]`` with no guard,
+    so it passes `--desktop`/`--xml` without a template
+    (`--desktop requires a "--template template" specification`, exit 1) and, for the
+    plugin's DEFAULT `format = 'mo'`, passes a flag that does not exist:
+    `msgfmt --mo` → `unrecognized option '--mo'`, exit 1 (gettext 0.26). The CLI's version
+    of this loop carried the `if (format !== 'mo')` guard; this copy never did, so the
+    plugin cannot have compiled a `.mo` either. It has no test and no in-repo consumer —
+    only `resolve-plugin-by-name.ts` documents the `{ "export": "msgfmtPlugin" }` spelling
+    — which is how a wrapper that works for none of its formats stayed in a published
+    package.
+
+`getOutputExtension` also returns `.xml` for the xml format, which trips a third measured
+constraint: gettext finds ITS rules by filename PATTERN (`/usr/share/gettext/its/*.loc`,
+AppStream's being `pattern="*.metainfo.xml"` + `localName="component"`), so a component not
+named `*.metainfo.xml` fails with `cannot locate ITS rules for <file>`.
+
+The fix is the one the CLI now uses: chain one `msgfmt --locale=<lang>` call per catalogue,
+each output becoming the next template, writing through intermediates so the template and
+the output are never the same path. msgfmt truncates `--output-file` before reading the
+template, so chaining in place destroys it: measured, `--desktop` writes a 0-byte file and
+exits 0, `--xml` prints `cannot read <file>: Document is empty` and dies on SIGSEGV
+(exit 139). Only the first is invisible to a caller that checks the exit code, which is the
+same shape as the `-d` defect above.
+
+Not folded into the CLI fix because it is a separate package with its own build and
+consumers; doing both in one change would have made the diff harder to review than the
+defect is to describe.
+
+### `gjsify ship` does not localise the MIME package it generates
+
+The freedesktop-metadata localisation added in `packages/infra/cli/src/utils/ship/localize-metadata.ts`
+covers the two files `commands/ship.ts` renders into `StageInputs` — the `.desktop` entry
+and the AppStream component. It does NOT cover the third generated file a user sees a
+string from: `renderMimePackage()` writes a shared-mime-info document whose `<comment>` is
+what a file manager shows in place of the raw type string (`mime.ts` refuses an empty one
+for exactly that reason), and it stays English for every language.
+
+It is not blocked on anything gettext cannot do. Measured with the same tools:
+
+    msgfmt --xml --template=mime.xml --locale=de --output-file=mime-de.xml po/de.po   # exit 0
+    →  <comment>A test application</comment>
+       <comment xml:lang="de">Eine Testanwendung</comment>
+
+Note the plain `.xml` name: `shared-mime-info.loc` pairs `pattern="*.xml"` with
+`localName="mime-info"`, so this file needs none of the `*.metainfo.xml` suffix care the
+AppStream template does. The `.its`/`.loc` pair belongs to the `shared-mime-info` package
+(`rpm -qf /usr/share/gettext/its/shared-mime-info.its`), which `.docker/ci-fedora.Dockerfile`
+does NOT install — so this cannot be tested in CI until that package is added, and adding a
+package for a capability nothing yet uses would be a dependency with no assertion behind it.
+
+Left out of the localisation change on scope: the MIME document is produced inside
+`utils/ship/plan.ts` (`source: { kind: 'text', text: renderMimePackage(...) }`) rather than
+passed through `StageInputs`, so folding it in means moving where that text is rendered —
+in the file that neighbours the layout/stage-writer work. Doing it later costs one call
+site; doing it in the same change would have crossed into a tree being rewritten.

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -445,17 +445,15 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
         execFileSync('desktop-file-validate', [join(outDir, 'com.test.app.desktop')], { stdio: 'pipe' });
     });
 
-    it('gjsify gettext --format xml merges every catalogue into an AppStream template', () => {
-        assert.ok(hasCommand('msgfmt'), '`msgfmt` is required (package: gettext).');
-
-        const gettextDir = join(projectDir, 'gettext-xml');
-        mkdirSync(gettextDir, { recursive: true });
-        const poDir = writeCatalogues(gettextDir);
-
-        // The `.metainfo.xml` suffix is LOAD-BEARING, not decoration: msgfmt --xml
-        // locates its ITS rules by filename. Named `app.xml.in` the same bytes die
-        // with `cannot locate ITS rules for app.xml` (exit 1).
-        const template = join(gettextDir, 'com.test.app.metainfo.xml.in');
+    /**
+     * A COMPLETE AppStream component under a name msgfmt's ITS lookup accepts.
+     *
+     * Shared by the two `--format xml` cases rather than written twice — and the
+     * second reason is the one that matters: a test that reads its template out of
+     * another test's directory passes only in the order they happen to run.
+     */
+    function writeMetainfoTemplate(root) {
+        const template = join(root, 'com.test.app.metainfo.xml.in');
         writeFileSync(
             template,
             // A COMPLETE component, not the two translatable elements this test is
@@ -485,6 +483,21 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
             ].join('\n'),
         );
 
+        return template;
+    }
+
+    it('gjsify gettext --format xml merges every catalogue into an AppStream template', () => {
+        assert.ok(hasCommand('msgfmt'), '`msgfmt` is required (package: gettext).');
+
+        const gettextDir = join(projectDir, 'gettext-xml');
+        mkdirSync(gettextDir, { recursive: true });
+        const poDir = writeCatalogues(gettextDir);
+
+        // The `.metainfo.xml` suffix is LOAD-BEARING, not decoration: msgfmt --xml
+        // locates its ITS rules by filename. Named `app.xml.in` the same bytes die
+        // with `cannot locate ITS rules for app.xml` (exit 1).
+        const template = writeMetainfoTemplate(gettextDir);
+
         const outDir = join(gettextDir, 'out');
         execFileSync(
             'npx',
@@ -502,6 +515,47 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
         execFileSync('appstreamcli', ['validate', '--no-net', join(outDir, 'com.test.app.metainfo.xml')], {
             stdio: 'pipe',
         });
+    });
+
+    it('gjsify gettext --format xml honours --filename for every catalogue count', () => {
+        // The output name and the ITS lookup are two different questions, and tying
+        // them together made the answer depend on how many `.po` files there were.
+        // msgfmt locates its rules by filename PATTERN, and from the second catalogue
+        // on the chain's own intermediates ARE the template — so intermediates named
+        // after `--filename` worked for one language and failed for two with
+        // `cannot locate ITS rules for <tmpdir>/0-out.xml`, a path the user cannot act
+        // on. `writeCatalogues` plants two languages, which is the case that broke.
+        const gettextDir = join(projectDir, 'gettext-xml-filename');
+        mkdirSync(gettextDir, { recursive: true });
+        const poDir = writeCatalogues(gettextDir);
+        const template = writeMetainfoTemplate(gettextDir);
+
+        const outDir = join(gettextDir, 'out');
+        execFileSync(
+            'npx',
+            [
+                'gjsify',
+                'gettext',
+                poDir,
+                outDir,
+                '--domain',
+                'com.test.app',
+                '--format',
+                'xml',
+                '--template',
+                template,
+                // NOT `*.metainfo.xml`: the name a caller wants the merged component
+                // written under is theirs to choose, and only the template's name has
+                // to satisfy msgfmt.
+                '--filename',
+                'out.xml',
+            ],
+            { cwd: projectDir, stdio: 'pipe', timeout: 60 * 1000 },
+        );
+
+        const produced = readFileSync(join(outDir, 'out.xml'), 'utf-8');
+        assert.match(produced, /<name xml:lang="de">Testanwendung<\/name>/);
+        assert.match(produced, /<name xml:lang="fr">Application de test<\/name>/);
     });
 
     it('gjsify gettext refuses a template-less --format=desktop', () => {

--- a/tests/e2e/cli-only/run.mjs
+++ b/tests/e2e/cli-only/run.mjs
@@ -344,6 +344,203 @@ describe('CLI-only E2E (no user polyfill deps)', { timeout: 10 * 60 * 1000 }, ()
         assert.ok(moSize > 0, 'compiled .mo file should be non-empty');
     });
 
+    // `--format=desktop` and `--format=xml` SUBSTITUTE into a template, and until now
+    // neither could ever have worked: the shared per-language loop passed no
+    // `--template`, and msgfmt refuses that outright (`--desktop requires a
+    // "--template template" specification`, exit 1). The suite above is the only
+    // coverage the command had, and it passes `--format mo` — so the broken branch
+    // was never executed by anything.
+    //
+    // The replacement chains one msgfmt call per catalogue with `--locale=`. The form
+    // it replaced (`-d <podir>`) fails SILENTLY when no LINGUAS file is present: exit
+    // 0, `po/LINGUAS does not exist` on stderr, and the template written back
+    // untranslated. Both assertions below therefore check the TRANSLATED keys rather
+    // than the exit code.
+
+    /** A `po/` directory with two catalogues translating the same two strings. */
+    function writeCatalogues(root) {
+        const poDir = join(root, 'po');
+        mkdirSync(poDir, { recursive: true });
+        for (const [lang, name, comment] of [
+            ['de', 'Testanwendung', 'Eine Testanwendung'],
+            ['fr', 'Application de test', 'Une application de test'],
+        ]) {
+            writeFileSync(
+                join(poDir, `${lang}.po`),
+                [
+                    'msgid ""',
+                    'msgstr ""',
+                    '"Content-Type: text/plain; charset=UTF-8\\n"',
+                    `"Language: ${lang}\\n"`,
+                    '',
+                    'msgid "Test App"',
+                    `msgstr "${name}"`,
+                    '',
+                    'msgid "A test application"',
+                    `msgstr "${comment}"`,
+                    '',
+                ].join('\n'),
+            );
+        }
+        return poDir;
+    }
+
+    it('gjsify gettext --format desktop merges every catalogue into the template', () => {
+        assert.ok(hasCommand('msgfmt'), '`msgfmt` is required (package: gettext).');
+
+        const gettextDir = join(projectDir, 'gettext-desktop');
+        mkdirSync(gettextDir, { recursive: true });
+        const poDir = writeCatalogues(gettextDir);
+
+        const template = join(gettextDir, 'app.desktop.in');
+        writeFileSync(
+            template,
+            [
+                '[Desktop Entry]',
+                'Type=Application',
+                'Name=Test App',
+                'Comment=A test application',
+                'Exec=test',
+                '',
+            ].join('\n'),
+        );
+
+        const outDir = join(gettextDir, 'out');
+        execFileSync(
+            'npx',
+            [
+                'gjsify',
+                'gettext',
+                poDir,
+                outDir,
+                '--domain',
+                'com.test.app',
+                '--format',
+                'desktop',
+                '--template',
+                template,
+            ],
+            { cwd: projectDir, stdio: 'pipe', timeout: 60 * 1000 },
+        );
+
+        const produced = readFileSync(join(outDir, 'com.test.app.desktop'), 'utf-8');
+        assert.match(produced, /^Name\[de\]=Testanwendung$/m);
+        assert.match(produced, /^Name\[fr\]=Application de test$/m);
+        assert.match(produced, /^Comment\[de\]=Eine Testanwendung$/m);
+        assert.match(produced, /^Comment\[fr\]=Une application de test$/m);
+
+        // An independent reader, from a different implementation family than ours.
+        // It cannot see a missing translation — it accepts the untranslated file at
+        // exit 0 — so it runs BESIDE the assertions above, never instead of them.
+        //
+        // REQUIRED, not probed. It is baked into `.docker/ci-fedora.Dockerfile` and
+        // this suite runs on that image only, so a silent `if (hasCommand(...))`
+        // would let the one independent reader disappear from the run without the
+        // result changing — the same vacuous-green shape `tests/e2e/ship/fixture.mjs`
+        // hard-fails on rather than skips.
+        assert.ok(
+            hasCommand('desktop-file-validate'),
+            '`desktop-file-validate` is required (package: desktop-file-utils).',
+        );
+        execFileSync('desktop-file-validate', [join(outDir, 'com.test.app.desktop')], { stdio: 'pipe' });
+    });
+
+    it('gjsify gettext --format xml merges every catalogue into an AppStream template', () => {
+        assert.ok(hasCommand('msgfmt'), '`msgfmt` is required (package: gettext).');
+
+        const gettextDir = join(projectDir, 'gettext-xml');
+        mkdirSync(gettextDir, { recursive: true });
+        const poDir = writeCatalogues(gettextDir);
+
+        // The `.metainfo.xml` suffix is LOAD-BEARING, not decoration: msgfmt --xml
+        // locates its ITS rules by filename. Named `app.xml.in` the same bytes die
+        // with `cannot locate ITS rules for app.xml` (exit 1).
+        const template = join(gettextDir, 'com.test.app.metainfo.xml.in');
+        writeFileSync(
+            template,
+            // A COMPLETE component, not the two translatable elements this test is
+            // about: `appstreamcli validate` rejects a partial one on
+            // `metadata-license-missing` before it ever looks at the translations,
+            // and an oracle that fails for an unrelated reason proves nothing about
+            // the merge.
+            [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<component type="desktop-application">',
+                '  <id>com.test.app</id>',
+                '  <metadata_license>CC0-1.0</metadata_license>',
+                '  <project_license>MIT</project_license>',
+                '  <name>Test App</name>',
+                '  <summary>A test application</summary>',
+                '  <description>',
+                '    <p>A small application used by the gjsify end-to-end suite to prove catalogue merging.</p>',
+                '  </description>',
+                '  <developer id="com.test">',
+                '    <name translate="no">Test Developer</name>',
+                '  </developer>',
+                '  <url type="homepage">https://example.org/test-app</url>',
+                '  <launchable type="desktop-id">com.test.app.desktop</launchable>',
+                '  <content_rating type="oars-1.1"/>',
+                '</component>',
+                '',
+            ].join('\n'),
+        );
+
+        const outDir = join(gettextDir, 'out');
+        execFileSync(
+            'npx',
+            ['gjsify', 'gettext', poDir, outDir, '--domain', 'com.test.app', '--format', 'xml', '--template', template],
+            { cwd: projectDir, stdio: 'pipe', timeout: 60 * 1000 },
+        );
+
+        const produced = readFileSync(join(outDir, 'com.test.app.metainfo.xml'), 'utf-8');
+        assert.match(produced, /<name xml:lang="de">Testanwendung<\/name>/);
+        assert.match(produced, /<summary xml:lang="fr">Une application de test<\/summary>/);
+
+        // Required for the same reason as `desktop-file-validate` above.
+        assert.ok(hasCommand('appstreamcli'), '`appstreamcli` is required (package: appstream).');
+        // `--no-net` so the assertion does not depend on resolving any `<url>`.
+        execFileSync('appstreamcli', ['validate', '--no-net', join(outDir, 'com.test.app.metainfo.xml')], {
+            stdio: 'pipe',
+        });
+    });
+
+    it('gjsify gettext refuses a template-less --format=desktop', () => {
+        const gettextDir = join(projectDir, 'gettext-no-template');
+        mkdirSync(gettextDir, { recursive: true });
+        const poDir = writeCatalogues(gettextDir);
+
+        // The failure has to NAME the missing template. Before this, the command
+        // reached msgfmt without one and reported the user's `--format` as the thing
+        // that failed, which is the one fact they did not get wrong.
+        let stderr = '';
+        assert.throws(
+            () => {
+                try {
+                    execFileSync(
+                        'npx',
+                        [
+                            'gjsify',
+                            'gettext',
+                            poDir,
+                            join(gettextDir, 'out'),
+                            '--domain',
+                            'com.test.app',
+                            '--format',
+                            'desktop',
+                        ],
+                        { cwd: projectDir, stdio: 'pipe', timeout: 60 * 1000 },
+                    );
+                } catch (error) {
+                    stderr = String(error.stderr ?? '');
+                    throw error;
+                }
+            },
+            undefined,
+            'a template-less --format=desktop must not exit 0',
+        );
+        assert.match(stderr, /--template/);
+    });
+
     // -- Phase C: gjsify dlx (local-path mode) -------------------------------
     // Registry mode (`gjsify dlx <name>`) hits the npm registry and is unsuitable
     // for offline CI. Local-path mode covers entry resolution + `gjs -m` dispatch

--- a/tests/e2e/ship-from-stage/run.mjs
+++ b/tests/e2e/ship-from-stage/run.mjs
@@ -44,6 +44,7 @@ import {
     CLI_ENTRY,
     listFiles,
     listPayload,
+    plantCatalogue,
     probe,
     scaffold,
     STAGE_MANIFEST_FILE,
@@ -127,10 +128,11 @@ describe('CLI ship --from-stage E2E', { timeout: 10 * 60 * 1000 }, () => {
         const project = scaffold(join(tmpDir, 'locale-project'), (pkg) => {
             pkg.gjsify.ship.localeDir = 'dist/locale';
         });
-        const catalogue = join(project, 'dist', 'locale', 'de', 'LC_MESSAGES', 'ship-demo.mo');
-        mkdirSync(dirname(catalogue), { recursive: true });
-        // A real `.mo` magic number, so nothing downstream can dismiss it as a stray file.
-        writeFileSync(catalogue, Buffer.from([0xde, 0x12, 0x04, 0x95, 0x00, 0x00, 0x00, 0x00]));
+        // A catalogue msgfmt COMPILED, not eight bytes of `.mo` magic. That stand-in
+        // worked until `ship` began folding the catalogues into the freedesktop
+        // metadata; it now reads these bytes, and the fake failed with
+        // `msgunfmt: … is truncated`. The suite kept its subject and gained a real file.
+        plantCatalogue(project, 'de', { 'Ship Demo': 'Schiffsdemo' }, 'ship-demo');
 
         runCliSync(CLI_ENTRY, ['ship', '--skip-build', '--stage'], { cwd: project, env: stamped() });
         const staged = join(project, 'ship', 'stage');

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -4,7 +4,8 @@
 // scaffold would be a second definition of "a shippable project": the two suites would drift, and
 // the drifted one is the one that keeps passing while proving something else.
 
-import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -120,6 +121,43 @@ export function scaffold(dir, mutate) {
     return dir;
 }
 
+/**
+ * Compile a REAL catalogue into `<dir>/dist/locale/<lang>/LC_MESSAGES/<domain>.mo`.
+ *
+ * Shared rather than written per suite for the reason this module exists at all —
+ * and, here, for a second one: `ship` READS these bytes now (it folds them into the
+ * `.desktop` entry and the AppStream component), so "a file with the right name" no
+ * longer stands in for a catalogue. `tests/e2e/ship-from-stage` used to plant eight
+ * bytes of `.mo` magic and that stopped working the moment the fold landed —
+ * `msgunfmt: … is truncated`. One planter, one definition of what counts.
+ */
+export function plantCatalogue(projectRoot, lang, entries, domain = APP_ID) {
+    const lcMessages = join(projectRoot, 'dist', 'locale', lang, 'LC_MESSAGES');
+    mkdirSync(lcMessages, { recursive: true });
+    const po = join(lcMessages, `${domain}.po`);
+    writeFileSync(
+        po,
+        [
+            'msgid ""',
+            'msgstr ""',
+            '"Content-Type: text/plain; charset=UTF-8\\n"',
+            `"Language: ${lang}\\n"`,
+            '',
+            ...Object.entries(entries).flatMap(([id, str]) => [
+                `msgid ${JSON.stringify(id)}`,
+                `msgstr ${JSON.stringify(str)}`,
+                '',
+            ]),
+        ].join('\n'),
+    );
+    const mo = join(lcMessages, `${domain}.mo`);
+    execFileSync('msgfmt', [po, '--output-file', mo], { stdio: 'pipe' });
+    // The `.po` source must not remain: `discoverLocales` refuses a locale tree
+    // holding anything `bindtextdomain` will not read.
+    rmSync(po);
+    return mo;
+}
+
 /** Every regular file under `root`, as POSIX-separated relative paths, sorted. */
 export function listFiles(root) {
     const out = [];
@@ -149,7 +187,20 @@ export function listPayload(root) {
  * which is exactly the class these suites exist to avoid.
  * `cpio`/`rpm2cpio` stay optional — they gate one extra cross-check.
  */
-const REQUIRED_ON_LINUX = new Set(['rpm', 'ar', 'tar']);
+const REQUIRED_ON_LINUX = new Set([
+    'rpm',
+    'ar',
+    'tar',
+    // The freedesktop-metadata tools, all four baked into `.docker/ci-fedora.Dockerfile`.
+    // `msgfmt`/`msgunfmt` BUILD the catalogues a localisation assertion needs, and the two
+    // validators are the independent readers for what `ship` generated from them. Required
+    // rather than probed for the usual reason: the interesting failure is metadata that is
+    // valid AND untranslated, so a skipped oracle leaves the suite green having read nothing.
+    'msgfmt',
+    'msgunfmt',
+    'desktop-file-validate',
+    'appstreamcli',
+]);
 
 export function probe(cmd) {
     if (hasCommand(cmd)) return true;

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -191,13 +191,17 @@ const REQUIRED_ON_LINUX = new Set([
     'rpm',
     'ar',
     'tar',
-    // The freedesktop-metadata tools, all four baked into `.docker/ci-fedora.Dockerfile`.
-    // `msgfmt`/`msgunfmt` BUILD the catalogues a localisation assertion needs, and the two
-    // validators are the independent readers for what `ship` generated from them. Required
-    // rather than probed for the usual reason: the interesting failure is metadata that is
-    // valid AND untranslated, so a skipped oracle leaves the suite green having read nothing.
+    // The freedesktop-metadata tools, all five baked into `.docker/ci-fedora.Dockerfile`
+    // (the three gettext ones arrive together in the `gettext` package). `msgfmt` BUILDS
+    // the catalogues a localisation assertion needs; `msgunfmt`/`msgcat` are what `ship`
+    // runs to read them back and to fold two text domains of one language into one; and
+    // the two validators are the independent readers for what `ship` generated from them.
+    // Required rather than probed for the usual reason: the interesting failure is metadata
+    // that is valid AND untranslated, so a skipped oracle leaves the suite green having
+    // read nothing.
     'msgfmt',
     'msgunfmt',
+    'msgcat',
     'desktop-file-validate',
     'appstreamcli',
 ]);

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -144,7 +144,7 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
     let localisedStage;
 
     before(() => {
-        for (const tool of ['msgfmt', 'msgunfmt', 'desktop-file-validate', 'appstreamcli']) probe(tool);
+        for (const tool of ['msgfmt', 'msgunfmt', 'msgcat', 'desktop-file-validate', 'appstreamcli']) probe(tool);
         localisedStage = stageLocalised('localised');
     });
 
@@ -234,6 +234,54 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         const staged = listPayload(localisedStage);
         assert.ok(staged.includes(`share/locale/de/LC_MESSAGES/${APP_ID}.mo`));
         assert.ok(staged.includes(`share/locale/fr/LC_MESSAGES/${APP_ID}.mo`));
+    });
+
+    it('folds ONE key per language when a project ships two text domains', () => {
+        // `discoverLocales` keys the tree on `<lang>/LC_MESSAGES/<domain>.mo` and puts
+        // no bound on the domain, so a package that carries its own catalogue AND a
+        // bundled library's hands the fold two catalogues for one language. Chained
+        // once per file, msgfmt APPENDS both — two exit-0 calls, and a file BOTH
+        // oracles reject: `multiple keys named "Name[de]"` (desktop-file-validate,
+        // exit 1) and `tag-duplicated name (lang=de)` (appstreamcli, exit 3).
+        //
+        // This is the one case in this block where the validators are the primary
+        // assertion rather than a companion: the defect ADDS a translated key, so the
+        // presence checks above all still pass on the broken file.
+        const dir = scaffold(join(tmpDir, 'two-domains'), (pkg, projectRoot) => {
+            pkg.gjsify.ship.localeDir = 'dist/locale';
+            plantCatalogue(projectRoot, 'de', TRANSLATIONS.de);
+            // A SECOND domain for the same language, translating the same source
+            // string differently — so a duplicate is visible in the bytes and not
+            // only in the key count.
+            plantCatalogue(projectRoot, 'de', { 'Ship Demo': 'Zweite Domäne' }, 'bundled-lib');
+        });
+        runCliSync(CLI_ENTRY, ['ship', '--skip-build', '--stage'], { cwd: dir });
+        const stage = join(dir, 'ship', 'stage');
+
+        const entry = readFileSync(join(stage, 'share', 'applications', `${APP_ID}.desktop`), 'utf-8');
+        assert.strictEqual(entry.match(/^Name\[de\]=/gm)?.length, 1, `two Name[de] keys in:\n${entry}`);
+        const xml = readFileSync(join(stage, 'share', 'metainfo', `${APP_ID}.metainfo.xml`), 'utf-8');
+        assert.strictEqual(xml.match(/<name xml:lang="de">/g)?.length, 1, `two <name xml:lang="de"> in:\n${xml}`);
+
+        // The sort in `localize-metadata.ts` decides WHICH domain wins, so assert the
+        // winner and not merely that there is one: `bundled-lib` sorts before the app
+        // id, and `--use-first` takes the first.
+        assert.match(entry, /^Name\[de\]=Zweite Domäne$/m);
+        // And the losing domain is still READ, not dropped — `msgcat` unions the
+        // msgids and only conflicts fall to `--use-first`. `Comment` exists in the app
+        // domain alone, so it survives only if both files reached msgfmt.
+        assert.match(entry, /^Comment\[de\]=Beweise, dass gjsify ship funktioniert$/m);
+
+        execFileSync('desktop-file-validate', [join(stage, 'share', 'applications', `${APP_ID}.desktop`)], {
+            stdio: 'pipe',
+        });
+        execFileSync(
+            'appstreamcli',
+            ['validate', '--no-net', join(stage, 'share', 'metainfo', `${APP_ID}.metainfo.xml`)],
+            {
+                stdio: 'pipe',
+            },
+        );
     });
 
     // ── the .deb ──────────────────────────────────────────────────────────

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -38,6 +38,7 @@ import {
     listFiles,
     NODE_BUNDLE,
     listPayload,
+    plantCatalogue,
     probe,
     scaffold,
     STAGE_MANIFEST_FILE,
@@ -108,6 +109,131 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         // Nothing in it may name the machine that assembled it — that path will not exist on the
         // host that packs the stage, and seven `ShipSettings` fields are absolute paths.
         assert.ok(!JSON.stringify(manifest).includes(projectDir), 'the manifest must not name the build tree');
+    });
+
+    // ── freedesktop metadata localisation ─────────────────────────────────
+    //
+    // `ship` has always staged the compiled `.mo` catalogues AND generated a
+    // `.desktop` entry and an AppStream component. The two never met: no
+    // `Name[xx]=`, no `xml:lang=`, so a fully translated app showed an English
+    // name in the app menu and in Software.
+    //
+    // Validation alone cannot cover this, and that is the point of the extra
+    // assertions below. Measured on a probe tree: `msgfmt --desktop
+    // --template=app.desktop.in -d po -o out.desktop` exits 0, writes the file
+    // back UNTRANSLATED, and `desktop-file-validate out.desktop` exits 0. An
+    // oracle that accepts the broken output is not an oracle for this defect —
+    // so each test asserts the localised keys are PRESENT, and the validators
+    // additionally prove the localisation did not corrupt the file.
+
+    const TRANSLATIONS = {
+        de: { 'Ship Demo': 'Schiffsdemo', 'Prove that gjsify ship works': 'Beweise, dass gjsify ship funktioniert' },
+        fr: { 'Ship Demo': 'Démo Ship', 'Prove that gjsify ship works': 'Prouver que gjsify ship fonctionne' },
+    };
+
+    /** A staged project whose catalogues translate the metadata strings. */
+    function stageLocalised(name) {
+        const dir = scaffold(join(tmpDir, name), (pkg, projectRoot) => {
+            pkg.gjsify.ship.localeDir = 'dist/locale';
+            for (const [lang, entries] of Object.entries(TRANSLATIONS)) plantCatalogue(projectRoot, lang, entries);
+        });
+        runCliSync(CLI_ENTRY, ['ship', '--skip-build', '--stage'], { cwd: dir });
+        return join(dir, 'ship', 'stage');
+    }
+
+    let localisedStage;
+
+    before(() => {
+        for (const tool of ['msgfmt', 'msgunfmt', 'desktop-file-validate', 'appstreamcli']) probe(tool);
+        localisedStage = stageLocalised('localised');
+    });
+
+    it('folds the staged catalogues into the .desktop entry', () => {
+        const entry = readFileSync(join(localisedStage, 'share', 'applications', `${APP_ID}.desktop`), 'utf-8');
+
+        // PRESENCE, not validity. The untranslated file is valid too.
+        assert.match(entry, /^Name\[de\]=Schiffsdemo$/m);
+        assert.match(entry, /^Name\[fr\]=Démo Ship$/m);
+        assert.match(entry, /^Comment\[de\]=Beweise, dass gjsify ship funktioniert$/m);
+        assert.match(entry, /^Comment\[fr\]=Prouver que gjsify ship fonctionne$/m);
+        // The untranslated keys survive as the C-locale fallback.
+        assert.match(entry, /^Name=Ship Demo$/m);
+        assert.match(entry, /^Comment=Prove that gjsify ship works$/m);
+    });
+
+    it('folds the staged catalogues into the AppStream component', () => {
+        const xml = readFileSync(join(localisedStage, 'share', 'metainfo', `${APP_ID}.metainfo.xml`), 'utf-8');
+
+        assert.match(xml, /<name xml:lang="de">Schiffsdemo<\/name>/);
+        assert.match(xml, /<name xml:lang="fr">Démo Ship<\/name>/);
+        assert.match(xml, /<summary xml:lang="de">Beweise, dass gjsify ship funktioniert<\/summary>/);
+        assert.match(xml, /<summary xml:lang="fr">Prouver que gjsify ship fonctionne<\/summary>/);
+        assert.match(xml, /<name>Ship Demo<\/name>/);
+    });
+
+    it('keeps both files readable by their independent validators', () => {
+        // desktop-file-utils and appstream — different implementation families from
+        // ours and from each other. They cannot detect a MISSING translation (see the
+        // section comment); what they prove is that adding one kept the file well-formed,
+        // which is the half a `grep` for `Name[de]` cannot see.
+        execFileSync('desktop-file-validate', [join(localisedStage, 'share', 'applications', `${APP_ID}.desktop`)], {
+            stdio: 'pipe',
+        });
+        // `--no-net`: without it appstreamcli resolves every `<url>` and the fixture's
+        // `https://example.org/ship-demo` returns 404, so the check reported
+        // `url-not-reachable` and exited 3 — a suite whose result depended on the
+        // network reaching a domain that is reserved for examples by definition.
+        execFileSync(
+            'appstreamcli',
+            ['validate', '--no-net', join(localisedStage, 'share', 'metainfo', `${APP_ID}.metainfo.xml`)],
+            { stdio: 'pipe' },
+        );
+    });
+
+    it('leaves the metadata untouched when the project ships no catalogues', () => {
+        // The default fixture declares no `localeDir`, so nothing runs msgfmt at all —
+        // a project without translations must not need the gettext tools.
+        const stage = join(projectDir, 'ship', 'stage');
+        assert.doesNotMatch(
+            readFileSync(join(stage, 'share', 'applications', `${APP_ID}.desktop`), 'utf-8'),
+            /^Name\[/m,
+        );
+        // BOTH files, because they take different code paths: `kind: 'cli'` renders a
+        // component and no desktop entry at all, so a regression that left the XML
+        // chain running unconditionally would be invisible in the entry alone.
+        assert.doesNotMatch(
+            readFileSync(join(stage, 'share', 'metainfo', `${APP_ID}.metainfo.xml`), 'utf-8'),
+            /xml:lang/,
+        );
+    });
+
+    it('folds the catalogues in reproducibly', () => {
+        // The chain runs through a `mkdtemp` directory and merges the catalogues in a
+        // sorted order `localize-metadata.ts` fixes itself. Both are ways for a
+        // run-to-run difference to reach the artifact, and `packs the same build twice
+        // into byte-identical artifacts` below never sees them: its project ships no
+        // catalogues, so its metadata never goes near msgfmt.
+        //
+        // What this does NOT prove: that the sort defends against a differently ordered
+        // `readdir`. Two runs on one machine see the same directory order, so only the
+        // sort's PRESENCE covers that.
+        const second = stageLocalised('localised-again');
+        for (const rel of [
+            join('share', 'applications', `${APP_ID}.desktop`),
+            join('share', 'metainfo', `${APP_ID}.metainfo.xml`),
+        ]) {
+            assert.strictEqual(
+                readFileSync(join(second, rel), 'utf-8'),
+                readFileSync(join(localisedStage, rel), 'utf-8'),
+                `${rel} differed between two runs of the same project`,
+            );
+        }
+    });
+
+    it('stages the catalogues alongside the localised metadata', () => {
+        const staged = listPayload(localisedStage);
+        assert.ok(staged.includes(`share/locale/de/LC_MESSAGES/${APP_ID}.mo`));
+        assert.ok(staged.includes(`share/locale/fr/LC_MESSAGES/${APP_ID}.mo`));
     });
 
     // ── the .deb ──────────────────────────────────────────────────────────

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1147,17 +1147,23 @@ Needs `glib-compile-schemas` (`glib2-devel` on Fedora, `libglib2.0-dev-bin` on D
 
 ### `gjsify gettext`
 
-Compile gettext `.po` files. It wraps `msgfmt` with the output shapes GNOME apps need: a per-language `.mo` locale tree, and metainfo template substitution.
+Compile gettext `.po` files. It wraps `msgfmt` with the output shapes GNOME apps need: a per-language `.mo` locale tree, and template substitution for a `.desktop` entry or an AppStream component.
 
 ```bash
 # Runtime .mo locale tree
 gjsify gettext translations dist/locale --domain org.example.App
 
-# Substitute a metainfo template
+# Merge every catalogue into an AppStream template
 gjsify gettext translations dist/metainfo \
   --domain org.example.App \
   --format xml \
-  --metainfo data/metainfo/org.example.App.metainfo.xml.in
+  --template data/metainfo/org.example.App.metainfo.xml.in
+
+# …or into a desktop entry
+gjsify gettext translations dist/applications \
+  --domain org.example.App \
+  --format desktop \
+  --template data/org.example.App.desktop.in
 ```
 
 | Option | Default | Description |
@@ -1165,13 +1171,19 @@ gjsify gettext translations dist/metainfo \
 | `<poDir>` | required | Directory holding `<lang>.po` files. |
 | `<outDir>` | required | Output directory. A locale tree for `--format mo`, a plain directory otherwise. |
 | `--domain <id>` | required | Text domain or application id. |
-| `--format <kind>` | `mo` | `mo`, `xml`, `desktop` or `json`. |
-| `--metainfo <path>` | none | For `--format xml`, the `.metainfo.xml.in` template used as `msgfmt --template`. |
+| `--format <kind>` | `mo` | `mo`, `xml` or `desktop`. |
+| `--template <path>` | none | Required for `--format xml` and `--format desktop`: the file `msgfmt` substitutes into. `--metainfo` is a deprecated alias. |
 | `--filename <name>` | `<domain>.<ext>` | Override the output filename. |
 | `--remove-xml-comments` | `true` | For `--format xml`, strip XML comments from the output. |
 | `--verbose` | `false` | Print each `msgfmt` call. |
 
 Needs `msgfmt` (the `gettext` package).
+
+`--format xml` and `--format desktop` **require** `--template`: `msgfmt` cannot produce either shape from `.po` files alone, and refuses with `--desktop requires a "--template template" specification`. The catalogues are merged one at a time with `msgfmt --locale=<lang>`, so no `LINGUAS` file is needed.
+
+For `--format xml`, the template's **filename** matters: `msgfmt --xml` finds its ITS rules by filename *pattern*, not by reading the document. gettext walks `/usr/share/gettext/its/*.loc`, and AppStream's rule there pairs `pattern="*.metainfo.xml"` with the root element `component` — so an AppStream template must be named `*.metainfo.xml` or `*.metainfo.xml.in`. Named `app.xml.in`, the same content fails with `cannot locate ITS rules for app.xml`. Both `metainfo.loc` and `metainfo.its` come from the `appstream` package.
+
+There is no `--format json`: `msgfmt` has no JSON writer. Use `@gjsify/vite-plugin-gettext`'s `po2jsonPlugin`, which parses the catalogues directly.
 
 ## Explore
 


### PR DESCRIPTION
## The gap

We render a `.desktop` entry and an AppStream MetaInfo XML (`utils/app-metadata.ts`), and
`gjsify ship` already discovers, validates and stages compiled `.mo` catalogues. **The two
never met.** No `Name[xx]=` and no `xml:lang=` was emitted anywhere in the tree, so a fully
translated app showed an English name in the GNOME app menu and in Software. Nobody reported
it because both files stay *valid* untranslated — see measurement 3.

Along the way: `gjsify gettext --format=xml|desktop|json` could never have produced a file at
all (measurement 2), and neither of the two independent validators for this payload was on the
CI image (measurement 6).

## Measurements

All against GNU gettext 0.26, appstream 1.1.3, desktop-file-utils 0.28, `LC_ALL=C`.

**1 — `--desktop` and `--xml` REQUIRE `--template`; there is no `--json` writer.**

```
$ msgfmt --output-file=o --desktop po/de.po
msgfmt: --desktop requires a "--template template" specification      # exit 1
$ msgfmt --output-file=o --xml po/de.po
msgfmt: --xml requires a "--template template" specification          # exit 1
$ msgfmt --output-file=o --json po/de.po
msgfmt: unrecognized option '--json'                                  # exit 1
```

**2 — therefore `gjsify gettext --format=xml|desktop|json` never worked.** `compilePerLanguage()`
on `main` builds `['--output-file=…', '--<format>', poFile]` and passes no `--template`, so every
such invocation hit the error above. The command's only e2e coverage is
`tests/e2e/cli-only/run.mjs`, and it passes `--format mo` — the broken branch was never executed
by anything.

**3 — the bulk `-d <podir>` form fails SILENTLY, and the oracle passes it.** This is the one that
sets the bar for the tests:

```
$ msgfmt --desktop --template=app.desktop.in -d po -o out.desktop
msgfmt: po/LINGUAS does not exist                                     # exit 0
$ grep -c 'Name\[de\]' out.desktop
0
$ desktop-file-validate out.desktop                                   # exit 0
```

Exit 0, an untranslated file, and a passing validator.

**4 — the per-catalogue chain works and needs no `LINGUAS`.** Each output feeds in as the next
template:

```
$ msgfmt --desktop --template=app.desktop.in  --locale=de --output-file=step0.desktop po/de.po   # 0
$ msgfmt --desktop --template=step0.desktop   --locale=fr --output-file=step1.desktop po/fr.po   # 0
$ cat step1.desktop
[Desktop Entry]
Type=Application
Name[de]=Testanwendung
Name[fr]=Application de test
Name=Test App
Comment[de]=Eine Testanwendung
Comment[fr]=Une application de test
Comment=A test application
Exec=test
$ desktop-file-validate step1.desktop                                 # exit 0
```

Same shape with `--xml`; `appstreamcli validate --no-net step1.metainfo.xml` → *Validation was
successful: pedantic: 1*, exit 0.

**5 — the `.metainfo.xml` name is load-bearing, and the reason is narrower than "by suffix".**

```
$ xgettext --force-po -o ext.pot com.test.app.metainfo.xml.in && grep -c '^msgid ' ext.pot
4
$ xgettext --force-po -o ext.pot plain.xml
xgettext: warning: file 'plain.xml' extension 'xml' is unknown; will try C
$ grep -c '^msgid ' ext.pot
1
$ msgfmt --xml --template=plain.xml --locale=de --output-file=out.xml po/de.po
msgfmt: cannot locate ITS rules for plain.xml                         # exit 1
```

The mechanism is `/usr/share/gettext/its/*.loc`: each rule pairs a filename glob with a root
element. AppStream's is `pattern="*.metainfo.xml"` + `localName="component"`, which is why the
same bytes fail under another name. Stated as *"`--xml` needs a `.metainfo.xml` name"* the rule
would be wrong in the direction that matters next — `shared-mime-info.loc` pairs
`pattern="*.xml"` with `localName="mime-info"`, so a MIME package needs no suffix care at all.
The comments and the docs now say the pattern version.

**6 — both validators were missing from the CI image.** On `origin/main`,
`.docker/ci-fedora.Dockerfile` names `gettext` (line 88) and `gtk4-devel` (line 90, the control
string) and neither `desktop-file-utils` nor `appstream`. No gate could have said so:
`scripts/check-ci-image-packages.mjs` asks "does a job USE a tool the image never carries" only
for `NODE_TOOLS = ['node', 'npx', 'npm', 'corepack']`. Both are added here, plus the note that
`appstream` — not gettext — owns `metainfo.its` *and* `metainfo.loc`
(`rpm -qf /usr/share/gettext/its/metainfo.its` → `appstream-1.1.3-1.fc44.x86_64`).

**7 — two more, found while reviewing.** The template and the output must never be the same
path, because msgfmt truncates `--output-file` before reading:

```
$ msgfmt --desktop --template=inplace.desktop --locale=de --output-file=inplace.desktop po/de.po
                                                     # exit 0, and the file is now 0 bytes
$ msgfmt --xml --template=inplace.metainfo.xml --locale=de --output-file=inplace.metainfo.xml po/de.po
msgfmt: cannot read inplace.metainfo.xml: Document is empty
                                                     # exit 139 (SIGSEGV), file 0 bytes
```

And `msgfmt --mo` is not an option (`unrecognized option '--mo'`, exit 1) — which matters for the
ledger entry below, not for this PR's code.

## What changed

| | |
|---|---|
| `utils/msgfmt-merge.ts` | **new.** The chain and its five measured constraints, in one place. Both callers below use it, because two copies of a constraint set where one member fails silently would lose that member first. |
| `commands/gettext.ts` | `--format xml\|desktop` now *require* `--template` and refuse without one, naming the missing flag. `--metainfo` survives as a hidden alias (it is the spelling the docs taught). `--format json` is gone: msgfmt has no JSON writer, so it was never a shape this wrapper could emit — `po2jsonPlugin` in `@gjsify/vite-plugin-gettext` is the answer for that output. |
| `utils/ship/localize-metadata.ts` | **new.** `msgunfmt` reads each staged `.mo` back to PO, then the chain folds every catalogue into both generated files. No `localeDir` → neither tool is spawned. Catalogues *without* the tools → refused, because an untranslated `.desktop` is indistinguishable from a correct one at install time. |
| `commands/ship.ts` | one call site, in `assemble()`. The format dispatch is untouched. |
| `.docker/ci-fedora.Dockerfile` | `desktop-file-utils` + `appstream`. |
| `status/open-todos.md` | three neighbouring gaps, below. |

## The tests, and why validation alone is not the oracle

Measurement 3 shows `desktop-file-validate` accepting an untranslated file at exit 0. So every
test asserts the localised keys are **present**, and the validators run *beside* those assertions
rather than instead of them. Both were silently optional (`if (hasCommand(…))`) in the WIP; they
are now required, since the image carries them and the suites are Linux-only.

**Negative control — ship.** `localizeMetadata` made a no-op in a scratch copy, rebuilt:

```
✖ folds the staged catalogues into the .desktop entry
    AssertionError: The input did not match /^Name\[de\]=Schiffsdemo$/m. Input:
    '[Desktop Entry]\n' + 'Name=Ship Demo\n' + …
✖ folds the staged catalogues into the AppStream component
✖ folds ONE key per language when a project ships two text domains
✔ keeps both files readable by their independent validators
ℹ tests 40   ℹ pass 37   ℹ fail 3
```

The validator test stays **green on the broken output** — measurement 3, reproduced at suite
level. Restored and rebuilt: `ℹ tests 40 ℹ pass 40 ℹ fail 0`.

**Negative control — gettext.** `compileMerged` reverted to the silent bulk `-d` form:

```
✔ gjsify gettext --format mo produces a per-language locale tree
✖ gjsify gettext --format desktop merges every catalogue into the template
    AssertionError: The input did not match /^Name\[de\]=Testanwendung$/m
✖ gjsify gettext --format xml merges every catalogue into an AppStream template
✔ gjsify gettext refuses a template-less --format=desktop
ℹ tests 4   ℹ pass 2   ℹ fail 2
```

msgfmt exits 0 there and the CLI succeeds; only the presence assertions see it —
`ℹ tests 5 ℹ pass 2 ℹ fail 3`. Restored: `ℹ pass 5 ℹ fail 0`.

**A fake that stopped being good enough.** `tests/e2e/ship-from-stage` planted eight bytes of
`.mo` magic as its catalogue. That was fine while nothing read the bytes; `ship` reads them now,
and the suite failed with `msgunfmt: … is truncated`. Both suites now build catalogues through
one `plantCatalogue()` in the shared fixture.

## Runs

| Suite | Result |
|---|---|
| `tests/e2e/ship` | 40 pass, 0 fail |
| `tests/e2e/ship-from-stage` | 20 pass, 0 fail |
| `tests/e2e/ship-layout` | 30 pass, 0 fail |
| `tests/e2e/ship-declaration` | 15 pass, 0 fail |
| `tests/e2e/stage-prebuild` | 22 pass, 0 fail |
| `tests/e2e/cli-only` (gettext) | 5 pass, 0 fail |
| `gjsify workspace @gjsify/cli test` | 3081 completed |
| `gjsify tsc --noEmit`, `oxfmt --check .`, `oxlint` | exit 0 |

Gates run green: `check-ci-image-packages`, `check-e2e-suite-coverage`, `check-e2e-harness-duplication`,
`check-node-test-registration`, `check-ship-format-vocabulary`, `check-refs-citations`,
`check-source-visibility`, `check-doc-fences`, `check-lint-visibility`, `check-workflow-inline-scripts`,
`check-source-control-bytes`.

The full `tests/e2e/cli-only` run is 26/27 here. The one failure, `system-check … gwebgl`, wants
a built `packages/framework/webgl` and this checkout has none.

That paragraph used to read *23/26*, and it named `packages/framework/webgl` for all three
failures. Two of them were the `build --shebang` pair, which actually died resolving
`@gjsify/web-streams/register/text-streams` — a different unbuilt package (`packages/web/streams`),
which the error text said and the summary did not. Both now pass, because a pre-commit hook
rebuilt that closure between the two runs. The count moving with the build state is what makes it
build state; it is recorded rather than quietly corrected, since a stale number in a Runs table is
the same defect as a stale comment.

## Ledgered, not fixed

1. **`gjsify flatpak check` has never run the real `appstreamcli`.** Confirmed:
   `tests/e2e/flatpak/run.mjs:623` installs `writeShim(stubBinDir, 'appstreamcli', …)` and feeds it
   the string `<component/>`, so the suite asserts the call shape and nothing about the XML. And
   the flag matters — against a component `renderMetainfoApp` actually produced:
   `appstreamcli validate --strict --no-net <stage>/share/metainfo/org.example.ShipDemo.metainfo.xml`
   → `I: org.example.ShipDemo:10: description-first-para-too-short`, *Validation failed*, **exit 3**;
   the same file passes plain `validate --no-net` at exit 0. Whether `--strict` is the severity this
   command wants is now an open question with evidence behind it.
2. **`@gjsify/vite-plugin-gettext`'s `msgfmtPlugin` carries the same two defects — and one more.**
   Its per-language branch builds `` `--${format}` `` unguarded, so for its *default* `format = 'mo'`
   it passes `--mo`, which does not exist. It cannot have compiled a `.mo` either. Separate package,
   separate build, no test and no in-repo consumer.
3. **`ship` still generates an untranslated MIME package.** `renderMimePackage()`'s `<comment>` is
   what a file manager shows instead of the raw type string. gettext handles it
   (`msgfmt --xml` on a plain-named `mime-info` document → exit 0, `<comment xml:lang="de">`), but the
   text is produced inside `utils/ship/plan.ts` rather than passed through `StageInputs`, and its ITS
   rules come from `shared-mime-info`, which the image does not install.

## Review round — two defects this branch introduced, now fixed

**A. One language, two text domains → an INVALID file, from nothing but exit-0 calls.**
`discoverLocales` accepts every `<lang>/LC_MESSAGES/<domain>.mo` and puts no bound on the domain,
so a package shipping its own catalogue plus a bundled library's handed the fold two catalogues
for one language. Chained once per file, msgfmt APPENDS both:

```
$ msgfmt --desktop --template=app.desktop.in --locale=de -o d0.desktop a.po   # 0
$ msgfmt --desktop --template=d0.desktop     --locale=de -o d1.desktop b.po   # 0
$ desktop-file-validate d1.desktop
d1.desktop: error: file contains multiple keys named "Name[de]" in group "Desktop Entry"   # 1
$ appstreamcli validate --no-net x1.metainfo.xml
E: com.test.app:8: tag-duplicated name (lang=de) · Validation failed: errors: 1            # 3
```

Reproduced through `gjsify ship` itself, not only through raw msgfmt: the staged entry carried
`Name[de]=Zweite Domäne` and `Name[de]=Schiffsdemo` on consecutive lines. This is strictly worse
than the untranslated entry the branch set out to fix — that one installs correctly and merely
reads English; this one is rejected by both readers — and it is the same *silent* shape as
measurement 3 one layer up.

Fixed in two places, because refusing and deciding are different jobs. `mergeCatalogues` refuses a
repeated locale before its first spawn (constraint 5), so no future caller can reproduce it.
`localizeMetadata` answers it with `msgcat --use-first` over the sorted catalogues — msgfmt handed
both files at once refuses outright (`duplicate message definition`, exit 1) and a plain `msgcat`
writes `#-#-#-#-#` conflict markers into the `Name=` a user reads. msgcat unions the msgids, so the
losing domain is still read; only a genuine conflict falls to the first in sort order.

**B. `--format xml` answered differently depending on how many catalogues it was given.**
`compileMerged` named its intermediates after the caller's `--filename`, but from the second
catalogue on the intermediates ARE the template, and msgfmt locates ITS rules by filename pattern:

```
# one language in po/
$ gjsify gettext po out --format xml --template com.test.app.metainfo.xml.in --filename out.xml
                                                                        # exit 0, translated
# two languages, same command
msgfmt: cannot locate ITS rules for <tmpdir>/0-out.xml                  # exit 1
```

An internal temp path reported in place of a rule the user could act on. The header comment stated
this as a flat rule (*"`--filename app.xml` fails"*), which was wrong in the direction that hides
it. Intermediates now take the TEMPLATE's suffix — the one msgfmt already accepted for call 1 — and
the output keeps `--filename`.

Both are covered by tests that go red without their fix (measured: A fails on two `Name[de]` keys
and both validators; B fails on the ITS lookup), plus `utils/msgfmt-merge.spec.ts` for the seam's
own refusal, with a distinct-locale control so a guard that refused everything could not pass.

## Verified, not accepted

Every measurement above was recomputed against the same tool versions (gettext 0.26,
desktop-file-utils 0.28, appstream 1.1.3) and reproduces, including the exit codes 0/1/3/139 and
the `pedantic: 1` from `appstreamcli`. The `metainfo.loc` mechanism is as stated — `pattern=
"*.metainfo.xml"` + `localName="component"`, owned by `appstream`, against `shared-mime-info.loc`'s
`pattern="*.xml"` + `localName="mime-info"` — with one detail the prose omits: the same rule file
also maps `*.appdata.xml` to `component`, so the legacy AppStream spelling needs no suffix care
either. Measurement 6's line numbers (`gettext` at 88, `gtk4-devel` at 90) and the `NODE_TOOLS`
scope of `check-ci-image-packages.mjs` both hold.

Two provisos on what is NOT verified here. `refs/gtkx` is not checked out in this tree —
`check-refs-citations` reports *"0 resolved in the 0 of 95 declared submodules checked out here"* —
so the reference read at the end of this body could not be confirmed locally; nothing in the code
depends on it, since every constraint was measured directly against gettext. And
`tests/e2e/ship-flatpak` was deliberately not run: `flatpak-builder` is present on this host, so
the suite would take its real-build arm. It consumes only `scaffold`/`APP_ID` from the shared
fixture — not `probe`, not `plantCatalogue` — and declares no `localeDir`, so nothing in this
branch reaches it.

Reference read (never modified): `refs/gtkx/packages/cli/src/deploy/freedesktop/localize.ts` at the
commit this repo pins — same chaining, same load-bearing extensions, catalogues taken as `.po`
where ours arrive as `.mo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB

