### PR TITLE
docs(website): a placeholder name in the hello example

### DIFF
--- a/website/src/content/docs/guides/self-executing-package.md
+++ b/website/src/content/docs/guides/self-executing-package.md
@@ -93,7 +93,7 @@ file.
 
 ```bash
 yarn build
-./bin/my-tool hello Pascal       # Hello, Pascal!
+./bin/my-tool hello world        # Hello, world!
 ```
 
 ## Report the right version


### PR DESCRIPTION
The self-executing-package guide invoked its sample CLI with a real person's name:

```bash
./bin/my-tool hello Pascal       # Hello, Pascal!
```

Every other identifier on that page is a placeholder — `@me/my-tool`, `my-tool`, `__MY_TOOL_VERSION__` — so the one real name read as though it meant something. `hello world` matches the command's own idiom (`.command("hello [name]", …)`) and the rest of the page.

Swept `website/src/content/docs/` for the same shape. **One other hit, deliberately left**: `guides/flatpak-app.md:32` carries `"developer": { "id": "eu.jumplink", "name": "Pascal Garber" }`. That snippet is not an invented example — it is the real manifest of a real published app (`eu.jumplink.Learn6502`, github.com/JumpLink/easy6502), where the developer name is genuine authorship metadata that ships inside the Flatpak. Replacing it would make the documentation wrong rather than generic. Flagged so the decision is visible.

The remaining `Pascal` matches under `website/src/content/docs/` are `PascalCase` (`frameworks/index.mdx:337`), untouched.

## Checks

`check-doc-fences` → `OK across 12 source(s).`