### PR TITLE
ci: bake the freedesktop metadata oracles

### DIFF
--- a/.docker/ci-fedora.Dockerfile
+++ b/.docker/ci-fedora.Dockerfile
@@ -67,7 +67,24 @@ RUN dnf install -y \
 #
 # `glib2` (NOT just `glib2-devel`) ships the `glib-compile-resources` binary
 # that the `gjsify gresource` test hard-requires; `gettext` ships `msgfmt`
-# for the `gjsify gettext` test.
+# for the `gjsify gettext` test — and `msgunfmt`, which `gjsify ship` runs to
+# read a staged `.mo` back before folding it into the freedesktop metadata.
+#
+# `desktop-file-utils` and `appstream` are the two INDEPENDENT readers for the
+# metadata `gjsify ship` generates: `desktop-file-validate` parses the `.desktop`
+# entry and `appstreamcli validate` the AppStream component. Both were missing
+# here, so the only assertions those files ever had were our own — this repo's
+# green-CI-that-checked-nothing class, on the one part of the payload a user sees
+# first (the app menu entry and the Software listing).
+#
+# `appstream` also owns BOTH AppStream ITS files under `/usr/share/gettext/its/`
+# (`rpm -qf` on this image's Fedora: metainfo.its and metainfo.loc are
+# appstream's, not gettext's). gettext resolves AppStream rules only through that
+# pair — `xgettext` when it EXTRACTS msgids from a `*.metainfo.xml`, `msgfmt --xml`
+# when it merges them back — and the failure of the lookup is the measured
+# `cannot locate ITS rules for <file>` (exit 1). `findMetainfoItsPath()` in
+# `@gjsify/vite-plugin-gettext` only `console.warn`s when it cannot find the
+# file, so its absence would degrade extraction quietly.
 #
 # `weston` is Xvfb's WAYLAND twin, and it buys a display AXIS, not a second way
 # to do the same thing: GdkX11 holds no state between a GSource's prepare() and
@@ -86,6 +103,8 @@ RUN dnf install -y \
     glib2 \
     glib2-devel \
     gettext \
+    desktop-file-utils \
+    appstream \
     gobject-introspection-devel \
     gtk4-devel \
     libsoup3-devel \


### PR DESCRIPTION
Split out of #1411, because those two changes cannot land together.

## The ordering constraint

`build-ci-image.yml` pushes `ghcr.io/gjsify/ci-fedora:<major>` **only on a push to `main`**; its
pull-request leg builds and deliberately never pushes (a fork PR's token cannot hold
`packages: write`). `main.yml` consumes the published tag. So a single PR that both adds a
package to the image **and** adds a test that hard-requires it can never go green: the test needs
the image, the image needs the merge, the merge needs green.

Measured on #1411, `E2E 3/4 Fedora 44`:

```
✖ gjsify gettext --format desktop merges every catalogue into the template
  AssertionError: `desktop-file-validate` is required (package: desktop-file-utils).
```

That assertion is correct and should stay — it replaced a `if (hasCommand(…))` skip, which is
this repository's most expensive defect class: a test that passes on a machine without the tool
it exists to run. Making it honest is what exposed the ordering constraint.

So this PR carries the image change alone. It adds no test, so nothing here requires the packages
yet and it goes green on the current image. Once it is on `main`, `build-ci-image.yml` fires on
the `.docker/ci-fedora.Dockerfile` path filter and publishes the new tag; #1411 then re-runs
against an image that has its oracles.

## What is added, and why each

- **`desktop-file-utils`** → `desktop-file-validate`, and **`appstream`** → `appstreamcli validate`:
  the two INDEPENDENT readers for the `.desktop` entry and the AppStream component that
  `gjsify ship` generates. Neither was in the image, so the only assertions those files ever had
  were our own — on the one part of the payload a user sees first, the app-menu entry and the
  Software listing.
- `appstream` also owns both AppStream ITS files under `/usr/share/gettext/its/` (`rpm -qf` on
  this image's Fedora attributes `metainfo.its` and `metainfo.loc` to `appstream`, not to
  `gettext`). gettext resolves AppStream rules only through that pair, and a missing lookup is the
  measured `cannot locate ITS rules for <file>` at exit 1.

Also worth recording, and ledgered rather than fixed here: no gate could have caught the absence.
`scripts/check-ci-image-packages.mjs` asks its "does a job use a tool the image never carries"
question only for `NODE_TOOLS = ['node','npx','npm','corepack']`, so a tool invoked from inside a
`.mjs` is outside its corpus entirely.

## Checks

No source change, no test change — one Dockerfile edit. `build-ci-image.yml`'s pull-request leg
builds this Dockerfile on every supported Fedora major, which is the check that matters here.