### PR TITLE
docs(adr): the typelib is a subset, not a second source

### DIFF
--- a/docs/adr/0028-widget-table-provenance.md
+++ b/docs/adr/0028-widget-table-provenance.md
@@ -63,10 +63,35 @@ coercer and the verifier.**
    What a ParamSpec CANNOT do is enumerate the legal nicks, and the type surfaces
    need exactly that. Measured under gjs 1.88.1: `GEnumClass.values` is not
    introspectable from GJS (`ec.values` is `undefined`) and
-   `GObject.enum_to_string` returns the C identifier, not the nick. The GIR — and
-   the typelib, via `ValueInfo.get_name()` — is the only source of the nick list.
-   That does not contradict this item, it delimits it: the ParamSpec validates a
-   value, the GIR enumerates the vocabulary.
+   `GObject.enum_to_string` returns the C identifier, not the nick. **The GIR is the
+   only source of the nick list.** That does not contradict this item, it delimits
+   it: the ParamSpec validates a value, the GIR enumerates the vocabulary.
+
+   ~~"and the typelib, via `ValueInfo.get_name()`"~~ — **struck 2026-08-29, it was
+   backwards.** A `.typelib` is a LOSSY SUBSET of the `.gir`, never a supplement:
+   `g-ir-compiler` compiles the XML into it, so nothing can come out that did not go
+   in. Measured by decompiling one back with `g-ir-generate --includedir=girs`:
+
+   ```
+   Adw-1.gir                        2 310 423 B, glib:nick = 120
+   g-ir-generate < Adw-1.typelib      577 131 B, glib:nick =   0
+   ```
+
+   `Gtk-4.0.gir` carries 799 `glib:nick`, 18 327 `<doc>` and 986 `default-value`; the
+   typelib carries none of the three. The only attribute it has that the GIR lacks is
+   `offset=` (struct field byte offsets), which no type surface wants.
+
+   So `ValueInfo.get_name()` returns the typelib's member NAME — byte-identical to the
+   GIR's `name` attribute, because the compiler copied it there. That is the underscore
+   substitution, not the nick. It is a near-perfect proxy and not a source: over the
+   corpus, 40 940 members carry `glib:nick` and **97** of them contradict
+   `name.replace('_', '-')` (Avahi-0.6 35, AgsAudio-6.0 16, AgsAudio-8.0 16, GES-1.0 12,
+   Gom-1.0 7). That 97-over-40 940 is the same measurement issue #1338 already carries.
+
+   The real SECOND source is not the typelib file but the **runtime** — constructed
+   defaults, `ParamSpec` min/max, CSS name, accessible role, template children, and
+   whether the installed library has the member at all. Item 5 below already reads the
+   installed typelib for existence checks, which is a different question from provenance.
 5. The table is checked against the installed typelib on demand
    (`descriptorProblems()`), and it checks the CLAIMS, not only the names: a text
    sink must be writable and a string (a non-string one accepts the write and


### PR DESCRIPTION
ADR 0028 § 4 read:

> The GIR — and the typelib, via `ValueInfo.get_name()` — is the only source of the nick list.

The GIR half holds. **The typelib half is backwards**, and the error travelled: it is also in my
own working notes, from which I stated it twice today in the opposite direction ("nicks live only
in the typelib"). Raised by a peer session on #1415; verified here independently before adopting.

## A typelib cannot supplement the GIR it was compiled from

`g-ir-compiler` compiles the `.gir` **into** the typelib, so nothing can come out that did not go
in. Decompiling one back with `g-ir-generate --includedir=girs` shows what is dropped:

```
Adw-1.gir                        2 310 423 B, glib:nick = 120
g-ir-generate < Adw-1.typelib      577 131 B, glib:nick =   0
```

`Gtk-4.0.gir` carries **799** `glib:nick`, **18 327** `<doc>` and **986** `default-value`; the
typelib carries none of the three. The only attribute it has that the GIR lacks is `offset=`
(struct field byte offsets), which no type surface wants.

## What `ValueInfo.get_name()` actually returns

The typelib's member NAME — byte-identical to the GIR's `name` attribute, because the compiler
copied it there. That is the underscore substitution, not the nick. A near-perfect proxy, and not a
source: over the corpus, **40 940** members carry `glib:nick` and **97** contradict
`name.replace('_', '-')` — Avahi-0.6 35, AgsAudio-6.0 16, AgsAudio-8.0 16, GES-1.0 12, Gom-1.0 7.

That 97-over-40 940 is the same measurement **issue #1338** already carries (97 here, 889 in
ts-for-gir over the same corpus), so this correction lands on a discrepancy that is already open
rather than opening a new one.

**One number reported to me did not reproduce, and I am recording that rather than passing it on.**
The peer's comment states 84 contradictions, all in `AgsAudio-6.0`. I measure 97, spread across at
least five namespaces including `Avahi-0.6` with 35 — which would appear in either revision. My
corpus is one checkout behind theirs, which explains a differing total but not a differing
distribution. Worth reconciling under #1338; not blocking this correction, whose subject is the
direction of the claim, not the count.

## What the real second source is

Not the typelib file but the **runtime** — constructed defaults, `ParamSpec` min/max, CSS name,
accessible role, template children, and whether the installed library has the member at all. § 4's
own opening already says a ParamSpec validates a value while the GIR enumerates the vocabulary;
this only removes the sentence that put the typelib on the GIR's side of that line. Item 5 reads the
installed typelib for existence checks, which is a different question and is untouched.

The struck sentence is kept struck rather than deleted, per this ADR set's practice — a claim that
three design passes reasoned from should stay visible with its correction attached.

## Checks

`check-doc-fences`, `check-adr-index`, `check-doc-revert` — all exit 0.