### PR TITLE
docs(gtk-host): the header counts two maps, it emits four

### DIFF
--- a/packages/framework/gtk-host/src/generated/props.ts
+++ b/packages/framework/gtk-host/src/generated/props.ts
@@ -3,7 +3,7 @@
 // Provenance: Gtk-4.0 Adw-1 Gdk-4.0 GObject-2.0 Gio-2.0 GLib-2.0 Pango-1.0
 //
 // The type surface: one interface per GIR declaration, mirroring GIR's own
-// inheritance, plus the two tag maps the dialect adapters build on.
+// inheritance, plus the four tag maps the dialect adapters build on.
 //
 // 194 interfaces for 168 widgets — the widgets have 6789 writable
 // property slots between them and 564 distinct property names, which is the whole

--- a/packages/framework/gtk-host/src/generator/emit-types.mts
+++ b/packages/framework/gtk-host/src/generator/emit-types.mts
@@ -1,5 +1,5 @@
 /**
- * Emit the TYPE surfaces: one interface per GIR declaration, two tag maps.
+ * Emit the TYPE surfaces: one interface per GIR declaration, four tag maps.
  *
  * WHAT THE DIALECTS FORCED, all of it measured rather than assumed (ADR 0028 § 7,
  * and the numbers live there):
@@ -139,7 +139,7 @@ export function emitProps(model: SurfaceModel, provenance: string): EmittedFile 
 
     const text = `${HEADER(
         `The type surface: one interface per GIR declaration, mirroring GIR's own
-// inheritance, plus the two tag maps the dialect adapters build on.
+// inheritance, plus the four tag maps the dialect adapters build on.
 //
 // ${model.declarations.size} interfaces for ${model.widgets.length} widgets — the widgets have ${countSlots(model)} writable
 // property slots between them and ${countDistinct(model)} distinct property names, which is the whole


### PR DESCRIPTION
`emit-types.mts` emits **four** tag maps —

```
$ grep -c '^export interface Widget\(PropsByTag\|PropsByGType\|PropsVueAliases\|ClassByTag\)' \
      packages/framework/gtk-host/src/generated/props.ts
4
```

— while both its own header and the header it writes into `generated/props.ts` say *"two tag maps"*.

## Why this is worth a commit rather than a shrug

It is the explanation for a discrepancy that looked like a generator bug. `props.ts`'s header
claims **194 interfaces** and the file declares **198**; one revision back it claimed 190 against
194. Exactly four short, at both revisions — so it is not staleness, and it is not an off-by-one
that drifted. The four are the tag maps, which the header's own sentence already excludes from the
interface count. The number was never wrong about widgets; the sentence beside it was wrong about
how many maps it was not counting.

Found while reconciling a widget count that two sessions measured differently (#1415), where the
first hypothesis was a broken generator. Recording the real cause is what stops the next reader
reaching for that hypothesis again.

## The generated file

Both lines are the same sentence: `emit-types.mts:142` is inside the template literal that writes
`props.ts:6`, so the two have to move together. I applied the identical one-word substitution to
the generated file rather than running `npm run generate` — that script needs GJS plus the GIR
pool, and this worktree has no `node_modules`. The next regeneration produces byte-identical
output, because the changed text is emitted verbatim.

## Checks

`check-doc-fences` and `check-vocabulary-alignment` exit 0. `check-source-visibility` exits 2 in
this worktree with *"cannot resolve the pinned `oxlint`. Install dependencies first"* — **verified
pre-existing**: stashing the change and re-running on unmodified `origin/main` gives the same
exit 2. It is the missing `node_modules`, not this diff.