### PR TITLE
ci: bake the MSI producer and reader

### DIFF
--- a/.docker/ci-fedora.Dockerfile
+++ b/.docker/ci-fedora.Dockerfile
@@ -86,6 +86,27 @@ RUN dnf install -y \
 # `@gjsify/vite-plugin-gettext` only `console.warn`s when it cannot find the
 # file, so its absence would degrade extraction quietly.
 #
+# `msitools` is the Windows-installer half of the same idea, and it is TWO
+# programs that must not be confused with each other. `wixl` COMPILES an authored
+# `.wxs` into an `.msi` — a second implementation of WiX v3's schema, so it
+# validates the document this tree writes against something Microsoft did not
+# write. `msiinfo` READS an `.msi` back: `tables`, `streams`, `export <table>`,
+# `suminfo`. Measured on `fedora:44`, `msitools-0.106.58-1.fc44` provides both
+# plus `msibuild`, and `msiinfo suminfo` prints the producer
+# (`Application: msitools 0.106.58-a155`), which is what lets a leg prove WHICH
+# implementation wrote the file it is reading.
+#
+# The pair is deliberately never used as writer-and-reader of the same file —
+# that is one package agreeing with itself, ADR 0024 § A3's `selfReading`. What
+# they are for is the cross-check #1354 M5 needs: `wixl` writes the `.msi` a
+# `windows-latest` leg installs with `msiexec`, and `msiinfo` reads back the one
+# WiX 3.14 produced on that runner from the SAME authored `.wxs`.
+#
+# Baked here rather than `dnf install`ed per job because `tests/e2e/ship-msi`
+# runs in the shared e2e shards, where a probed-and-skipped reader would leave
+# every assertion behind it vacuous — the same reason `desktop-file-utils` and
+# `appstream` are above and not optional.
+#
 # `weston` is Xvfb's WAYLAND twin, and it buys a display AXIS, not a second way
 # to do the same thing: GdkX11 holds no state between a GSource's prepare() and
 # check(), GdkWayland holds libwayland's reader slot there, so #1145 (the uv
@@ -105,6 +126,7 @@ RUN dnf install -y \
     gettext \
     desktop-file-utils \
     appstream \
+    msitools \
     gobject-introspection-devel \
     gtk4-devel \
     libsoup3-devel \


### PR DESCRIPTION
`gjsify ship`'s `.msi` target (#1354 M5) needs two programs out of one Fedora package, and needs them **present rather than probed**.

## What is added

One package — `msitools` — to `.docker/ci-fedora.Dockerfile`, beside `desktop-file-utils` and `appstream`, which are there for the same reason.

It is two programs, and they must not be confused with each other:

| program | role |
|---|---|
| `wixl` | **compiles** an authored `.wxs` into an `.msi`. A second implementation of WiX v3's schema, so it validates the document this tree writes against something Microsoft did not write. |
| `msiinfo` | **reads** an `.msi` back — `tables`, `streams`, `export <table>`, `suminfo`. |

The pair is deliberately never used as writer-and-reader of the *same* file. That is one package agreeing with itself — ADR 0024 § A3's `selfReading`, the thing the hand-written `.deb`/`.rpm` writers exist to avoid. What they are for is M5's cross-check: `wixl` writes the `.msi` a `windows-latest` leg installs with `msiexec`, and `msiinfo` reads back the one WiX 3.14 produced on that runner from the same authored `.wxs`.

## Why it is its own PR

`build-ci-image.yml` publishes the image only on a push to `main`; its PR leg builds and deliberately never pushes. So a PR that adds a package to the image **and** a test that hard-requires it can never go green — the test runs against the *published* image, which does not have the package until this lands. This half goes first.

`scripts/check-ci-image-packages.mjs` would not have caught the gap either way: it asks its "a job uses a tool the image lacks" question for `NODE_TOOLS` only.

## Measured

Every number below is from a command run for this PR.

```
$ podman run --rm fedora:44 sh -c 'dnf install -y msitools && rpm -q msitools && wixl --version && msiinfo -v'
msitools-0.106.58-1.fc44.x86_64
0.106.58-a155
msiinfo (msitools) version 0.106.58-a155

$ podman run --rm fedora:43 sh -c 'dnf install -y msitools && rpm -q msitools && wixl --version && msiinfo -v'
msitools-0.106.31-2.fc43.x86_64
0.106.31-bf14
msiinfo (msitools) version 0.106.31-bf14
```

Both Fedora majors in `setup`'s matrix resolve the package, both provide `wixl`, `msiinfo` and `msibuild`, and both compile the same authored `.wxs` (a probe document with `Product`, `Package`, `MajorUpgrade`, `Media`, a `ProgramFiles64Folder` tree, three `File` components and a `ProgramMenuFolder` `Shortcut`): `wixl -a x64 -o demo.msi demo.wxs` exits 0 on each, and `msiinfo export demo.msi Shortcut` prints the same row from both.

One byproduct worth recording because M5 depends on it: `msiinfo suminfo` prints the producer —

```
Application: msitools 0.106.58-a155
```

which is what lets a leg prove *which* implementation wrote the file it is reading, rather than assuming it.

## What this PR does not do

No workflow change, no test, no CLI change. The `.msi` format row, the `.wxs` renderer, the oracle script and the three CI jobs are the follow-up, which will target `main` once the image carrying this package has been published.

Refs #1354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB