### PR TITLE
docs(website): audit the site against the last day

### DIFF
--- a/docs/react-layers.md
+++ b/docs/react-layers.md
@@ -101,12 +101,13 @@ differs only in how it receives its rows, because a `Gtk.ListView` takes no chil
 `append`, `add`, `insert`, `prepend`, `remove` or `set_child` on its prototype. The host's
 placement policies are data naming a method, so there is no method to name.
 
-Most of what follows from that is **not React's**. The model, the factory, the key diff and the
-teardown authority live in `@gjsify/gtk-host/list`, where Vue and Solid reach the same three
-measurements — the `Gio.ListStore` carrier identity, why a data change splices the model instead
-of announcing it, and why `dispose()` rather than GTK's own `teardown` signal is what disconnects.
-That module's header states each of them once; nothing restates them here, because a second copy
-is the one that goes stale.
+Most of what follows from that is not React's. The model, the factory, the key diff and the
+teardown authority live in `@gjsify/gtk-host/list`, which imports GTK and GObject and no
+framework. Solid reaches it through `listRows`; Vue has no binding over it yet. That module's
+header states its three measurements once, the `Gio.ListStore` carrier identity, why a data
+change splices the model instead of announcing it, and why `dispose()` rather than GTK's own
+`teardown` signal is what disconnects. Nothing restates them here, because a second copy is the
+one that goes stale.
 
 What is React's is the deferral: a row's tree is rendered on a microtask, because GTK binds rows
 from inside React's own commit and the adapter's `render()` refuses a re-entrant flush by name.

--- a/docs/react-layers.md
+++ b/docs/react-layers.md
@@ -1,15 +1,13 @@
----
-title: How the React layers work
-description: The measurements and decisions behind the React adapter, the React Native primitives and the router.
----
+# How the React layers work
 
-This page is optional. You can build and ship a React or React Native app on gjsify without
-reading a line of it, and the [React](/gjsify/frameworks/react/) and
-[React Native](/gjsify/frameworks/react-native/) pages are the ones that tell you how.
-
-Read this when a rule on one of those pages looks arbitrary and you want the number behind it, or
-when you are changing this part of gjsify and need to know which decisions were paid for. Each
-section stands alone.
+> The measurements and decisions behind the React adapter, the React Native primitives and the
+> router. Detail for [ADR 0032](adr/0032-react-native-on-the-gtk-host.md).
+>
+> Nobody has to read this to build an app. The website's
+> [React](https://gjsify.github.io/gjsify/frameworks/react/) and
+> [React Native](https://gjsify.github.io/gjsify/frameworks/react-native/) pages carry every
+> rule an app author follows; this file carries the number behind each rule, for whoever
+> changes this part of gjsify. Each section stands alone.
 
 Versions matter here. Unless a section says otherwise, the measurements are GTK 4.22.4, gjs
 1.88.1, libadwaita 1.9.3 and `react-reconciler` 0.33.0.
@@ -27,7 +25,7 @@ React's.
 
 Solid has the same `jsxImportSource` trap one package over, and a worse one: its pre-declared
 element list includes MathML, which the React one does not.
-[ADR 0028, item 8](https://github.com/gjsify/gjsify/blob/main/docs/adr/0028-widget-table-provenance.md)
+[ADR 0028, item 8](adr/0028-widget-table-provenance.md)
 measures it.
 
 ## What holds the build recipe
@@ -206,7 +204,7 @@ because it is the older and machine-checked one.
 
 ## Platform files
 
-[ADR 0032 § 9](https://github.com/gjsify/gjsify/blob/main/docs/adr/0032-react-native-on-the-gtk-host.md)
+[ADR 0032 § 9](adr/0032-react-native-on-the-gtk-host.md)
 declares the resolution order a shared codebase should get:
 
 ```
@@ -229,7 +227,7 @@ the file, so an author's fork cannot become dead code with nothing saying so.
 
 ## Related
 
-- [ADR 0032](https://github.com/gjsify/gjsify/blob/main/docs/adr/0032-react-native-on-the-gtk-host.md)
+- [ADR 0032](adr/0032-react-native-on-the-gtk-host.md)
   for the decision record this page reports the measurements of
-- [How gjsify works](/gjsify/how-it-works/) for the global scanner and the build in general
-- [Contributing](/gjsify/contributing/development-setup/) if you want to change any of it
+- [How gjsify works](https://gjsify.github.io/gjsify/how-it-works/) for the global scanner and the build in general
+- [Contributing](https://gjsify.github.io/gjsify/contributing/development-setup/) if you want to change any of it

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -208,7 +208,6 @@ export default defineConfig({
                     collapsed: true,
                     items: [
                         { slug: 'how-it-works' },
-                        { slug: 'internals/react-layers', label: 'How the React layers work' },
                         { slug: 'projects/ts-for-gir' },
                         { slug: 'projects/node-gi' },
                         { slug: 'projects/napi' },

--- a/website/src/content/docs/adwaita/boxed-lists.mdx
+++ b/website/src/content/docs/adwaita/boxed-lists.mdx
@@ -19,7 +19,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/buttons.mdx
+++ b/website/src/content/docs/adwaita/buttons.mdx
@@ -21,7 +21,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/controls.mdx
+++ b/website/src/content/docs/adwaita/controls.mdx
@@ -25,7 +25,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/feedback.mdx
+++ b/website/src/content/docs/adwaita/feedback.mdx
@@ -20,7 +20,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/index.mdx
+++ b/website/src/content/docs/adwaita/index.mdx
@@ -16,8 +16,9 @@ window whose second tab holds the markup that paints it, followed by one window 
 kind of implementation: **Native TypeScript**, the `@girs` program that runs
 unchanged on GJS, Node, Bun and Deno, with a Blueprint declaration beside it, **UI
 frameworks**, the same widget written in Solid, Vue and React through
-`@gjsify/gtk-host`, and **NativeScript**, the port that runs on a phone. Choose a tab once and every widget
-block on the site follows it.
+`@gjsify/gtk-host`, and **NativeScript**, the port that runs on a phone, whose XML
+template holds the tree with the TypeScript beside it as the loader. Choose a tab once
+and every widget block on the site follows it.
 
 Adwaita is one design system GJSify supports, not a requirement. Your app is an
 ordinary GTK 4 program, so you can mix in plain `Gtk.*` widgets or style your

--- a/website/src/content/docs/adwaita/navigation.mdx
+++ b/website/src/content/docs/adwaita/navigation.mdx
@@ -20,7 +20,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/presentation.mdx
+++ b/website/src/content/docs/adwaita/presentation.mdx
@@ -20,7 +20,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/adwaita/view-switching.mdx
+++ b/website/src/content/docs/adwaita/view-switching.mdx
@@ -21,7 +21,8 @@ that runs unchanged on GJS, Node, Bun and Deno, with the matching Blueprint
 declaration beside it, **UI frameworks**, the same widget written in Solid, Vue and
 React through `@gjsify/gtk-host` — or, where the widget is built imperatively rather
 than declared, the recorded reason it has no such snippet — and **NativeScript**,
-the port that runs on a phone.
+the port that runs on a phone. That last window splits the way the first one does. An
+XML template holds the tree, and the TypeScript beside it is the loader.
 
 Libadwaita is the reference here, typed by
 [`@girs/adw-1`](https://www.npmjs.com/package/@girs/adw-1).

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -297,6 +297,72 @@ pays a tail re-append. Its near-identical sibling `Adw.PreferencesPage` does hav
 `insert(group, i)`, so it is `indexed` and places at the index directly. That is why the table
 is measured per widget rather than inherited.
 
+## Long lists
+
+A `Gtk.ListView` takes no children. It installs no `append`, no `add` and no `set_child`, so
+`<gtk-list-view>` is a tag with no adoption rule and it throws when you put a child in it. GTK
+recycles a small number of row widgets over a model instead, which is what keeps a list of
+50 000 rows the same size on screen as a list of 50.
+
+`@gjsify/gtk-host/list` drives that model. It has no framework in it, so one implementation
+serves every adapter:
+
+```ts
+import { ListController, onScrollNearEnd } from '@gjsify/gtk-host/list';
+```
+
+| Export | What it is |
+|---|---|
+| `new ListController(sink)` | the model, the row factory and the key diff behind one `Gtk.ListView` |
+| `ListRowKey` | the one thing a row must carry: a `key` string |
+| `ListRowSink` | the three callbacks your framework supplies: `mountRow`, `showRow`, `disposeRow` |
+| `onScrollNearEnd(scroller, axis, threshold, listener)` | fires once each time the view arrives near the end; returns a disposer |
+
+`setRows(rows)` compares keys. Same keys with changed content shows every live row again and
+leaves the widgets in place. Changed keys splice the model, and GTK rebuilds the rows. Call
+`dispose()` before the window goes away: it disconnects the factory's handlers and releases
+every row.
+
+Solid has the row half already, as `listRows`:
+
+```tsx
+import Gtk from 'gi://Gtk?version=4.0';
+
+import type { HostNode } from '@gjsify/gtk-host';
+import { ListController } from '@gjsify/gtk-host/list';
+import { listRows, type ListRowHandle } from '@gjsify/gtk-host/solid';
+
+type Row = { key: string; title: string };
+
+const body = (row: () => Row, index: () => number): HostNode =>
+    (<gtk-label label={`${index()}: ${row().title}`} />) as HostNode;
+
+const view = new Gtk.ListView();
+const list = new ListController<Row, ListRowHandle<Row>>(listRows<Row>(body));
+
+list.attach(view);
+list.setRows([
+    { key: 'a', title: 'alpha' },
+    { key: 'b', title: 'beta' },
+]);
+```
+
+A row body receives accessors rather than values, so a content change under an unchanged key
+writes one signal and updates one property. The row widget itself survives.
+
+What each adapter has today:
+
+| Adapter | Rows | How |
+|---|---|---|
+| Solid | yes | `listRows` from `@gjsify/gtk-host/solid` |
+| React | through React Native | `<FlatList>` in [`@gjsify/react-native`](/gjsify/frameworks/react-native/), which drives the same controller |
+| Vue | not yet | write a `ListRowSink` against the controller |
+
+Writing a sink is three functions and no GTK model code: `mountRow(item)` takes the carrier the
+factory hands you, `showRow(handle, row, index)` puts a row into it or clears it with `null`,
+and `disposeRow(handle)` lets go. Take the carrier with `adopt()` once, inside `mountRow`. GTK
+reuses a carrier across binds, and adopting the same one twice raises `occupied-slot`.
+
 ## Mount into a window you already own
 
 `adopt(container)` wraps a widget your application built as a host element and **records the

--- a/website/src/content/docs/frameworks/index.mdx
+++ b/website/src/content/docs/frameworks/index.mdx
@@ -316,12 +316,11 @@ of mounted roots; until something needs one, a string throws rather than renderi
 
 ## The widget table and the type surfaces
 
-164 concrete `GtkWidget` descendants (102 from Gtk, 62 from Adw) are generated from the GIR
-and committed with the package. 35 of them also carry a hand-written placement rule, and the
-generator may only ever add a tag, never contradict a curated one. A tag with no rule can be
-created, given properties and given handlers; inserting a child into it raises an error naming
-the tag that needs a policy. Guessing is not on offer — `add`, `append` and `set_child` all
-exist somewhere in GTK, and calling the wrong one is a warning at exit 0.
+168 concrete `GtkWidget` descendants (105 from Gtk, 63 from Adw) are generated from the GIR
+and committed with the package. 39 of them also carry a hand-written placement rule. A tag with
+no rule can be created, given properties and given handlers; inserting a child into it raises an
+error naming the tag that needs a policy. Nothing guesses, because `add`, `append` and
+`set_child` all exist somewhere in GTK and calling the wrong one is a warning at exit 0.
 
 The same generator emits the type surfaces, so a tag cannot mean one thing to the renderer and
 another to the type checker:

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -415,5 +415,5 @@ function Notes() {
   for the generated per-name support listing
 - [`rn-design-system`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/rn-design-system)
   for a design-system layer rendered unmodified into an Adwaita window
-- [How the React layers work](/gjsify/internals/react-layers/) for the measurements behind the
-  primitives, the lists and the router
+- [How the React layers work](https://github.com/gjsify/gjsify/blob/main/docs/react-layers.md)
+  for the measurement behind each rule about the primitives, the lists and the router

--- a/website/src/content/docs/frameworks/react-native.mdx
+++ b/website/src/content/docs/frameworks/react-native.mdx
@@ -246,10 +246,11 @@ Three rules hold there, and the layer states each of them by refusing rather tha
   element directly under one is the root of its React tree and is told so.
 - **The container needs a curated child policy.** gtk-host will not guess how a widget adopts a
   child: `add`, `append` and `set_child` all exist somewhere in GTK and the wrong one is a
-  warning at exit 0. 35 of the 164 tags carry such a rule — `tableProvenance()` reports the live
-  figure, and this count has drifted twice — with toolbar view, header bar, clamp, both split
-  views, status page, navigation view, preferences page and action row among them. Wrap box and
-  action bar are not, and refuse a child by name until someone writes their policy.
+  warning at exit 0. 39 of the 168 tags carry such a rule, among them toolbar view, header bar,
+  clamp, both split views, status page, navigation view, preferences page and action row. Wrap
+  box and action bar do not, and refuse a child by name until someone writes their policy. Call
+  `tableProvenance()` from `@gjsify/gtk-host` for the live figure; this count has now drifted
+  three times.
 
 The [Layout page](/gjsify/adwaita/layout/) of the Adwaita gallery carries this as a **React
 Native on GTK** tab beside the GJS, Blueprint, web and NativeScript ones — on the clamp, the

--- a/website/src/content/docs/frameworks/react.mdx
+++ b/website/src/content/docs/frameworks/react.mdx
@@ -196,5 +196,5 @@ Here that reaches your tree only and never touches chrome your application put t
 - [Styling on GTK](/gjsify/frameworks/styling/) for class names and token scales
 - [`react-host-counter`](https://github.com/gjsify/gjsify/tree/main/showcases/gtk/react-host-counter)
   for a complete window that asserts its own widget tree on every launch
-- [How the React layers work](/gjsify/internals/react-layers/) for the measurements and the
-  decisions behind the rules above
+- [How the React layers work](https://github.com/gjsify/gjsify/blob/main/docs/react-layers.md)
+  for the measurement behind each rule above, if you are changing this part of gjsify


### PR DESCRIPTION
An audit of the website against the ~22 PRs that merged in the last day, plus one
audience pass. The ship pages and `cli-reference.md`'s ship section are out of scope
here and belong to a separate branch.

## What landed, and whether the site said so

| Landed | Site said | Done |
|---|---|---|
| `@gjsify/gtk-host/list` + Solid `listRows` (#1406, #1398) | one clause, in an internals page about React | a **Long lists** section on the frameworks page |
| The widget table grew 164 → 168, curated rules 35 → 39 (#1398) | still 164 and 35, on two pages | re-measured both |
| NativeScript XML tab on all 40 blocks (#1400) | announced on `layout.mdx` only | announced on the other eight |
| Framework tabs, Native TypeScript rename, why-not pane (#1399, #1400) | accurate | nothing |
| Freedesktop metadata localisation, two `gettext` format fixes (#1411) | `cli-reference.md`'s gettext section is accurate | nothing; the `ship.localeDir` half is the other branch's |
| `GJSIFY_GI_LIBRARY_PATH` (#1410) | absent | reported, not written; `gjsify ship` sets it |
| ADR 0034 (#1415, #1417) | absent | correct as is; it is Proposed and nothing shipped |

## False claims found

**Vue reaches the list core.** `internals/react-layers.mdx` said "where Vue and Solid
reach the same three measurements". Only Solid does. `adapters/vue.ts` has no
`ListRowSink` and no equivalent. Introduced by #1406 on 2026-08-29, not pre-existing.

**164 tags, 35 placement rules.** True when written on 2026-08-25 (#1305). #1398 added
four carrier tags and a curated rule for each and touched no website page. Measured on
this tree: 168 gtypes (105 Gtk, 63 Adw), 39 curated descriptors, all 39 in the
generated table. `react-native.mdx` already said the count had drifted twice; three now.

## Written for the wrong reader

`internals/react-layers.mdx` moves whole to `docs/react-layers.md`. It opened by saying
nobody has to read it, and what it holds is HostConfig member counts, why `render()` is
synchronous, why a route walk sorts in code-unit order. The React and React Native pages
carry every rule it explains; their See-also entries now link the file on GitHub.

One paragraph left the site without moving: "the generator may only ever add a tag,
never contradict a curated one", from the frameworks page. It is a rule about the
generator, already recorded in ADR 0028 § 2 and in `descriptors/index.ts`.

## Gates

`check-doc-fences` (40 blueprint fences compiled, OK across 12 sources) ·
`check-website-adwaita-gallery` (40 blocks, 4 windows) · `check-generated-website-data` ·
`check-website-attr-samples` (190 cells) · `check-website-package-names` ·
`check-website-preview-not-content` · `check-vocabulary-alignment` (168 GTK tags) ·
`check-adr-index` · `check-agent-context-size --check` ·
`check-doc-revert --base origin/main` · `check-changelog-references` ·
`gjsify format --check` (3450 files). All exit 0.

`gjsify run docs:build`: 61 pages, complete, no warnings beyond the pre-existing Vite
chunk-size note. 62 before; the moved page is the difference.
