### PR TITLE
fix(scripts): empty a ledger the publish emptied

### DIFF
--- a/scripts/check-shipped-runtime-packages.mjs
+++ b/scripts/check-shipped-runtime-packages.mjs
@@ -106,15 +106,10 @@ const retryDelayMs = Math.max(0, Number(flag('--retry-delay-ms', '5000')) || 0);
 // packument exists, a stale entry here FAILS this check.
 // ---------------------------------------------------------------------------
 const PENDING_BOOTSTRAP = new Map([
-    [
-        '@gjsify/node-runtime-darwin-arm64',
-        'first publish queued — see docs/publishing.md § New @gjsify/* package (#1418)',
-    ],
-    [
-        '@gjsify/node-runtime-darwin-x64',
-        'first publish queued — see docs/publishing.md § New @gjsify/* package (#1418)',
-    ],
-    ['@gjsify/node-runtime-win32-x64', 'first publish queued — see docs/publishing.md § New @gjsify/* package (#1420)'],
+    // Empty, and that is the point rather than an oversight. Every by-name ship
+    // runtime package went live at 0.44.0 on 2026-08-30, and a name published while
+    // still listed here FAILS the check -- so this list empties itself on bootstrap
+    // instead of rotting into a permanent exemption nobody rereads.
 ]);
 
 // A file that declares a dependency on a pending name must contain one of these.


### PR DESCRIPTION
`main` is red on `Detect runtime-triplet drift`, and the gate is right.

All six by-name ship runtime packages went live at `0.44.0` today. `PENDING_BOOTSTRAP` still
listed three of them, and the rule fails a name that is published while still declared pending.

Verified against the registry, with `@gjsify/cli` as the control, checking each name for a
**packument and a `dist.tarball`** rather than just a version string:

```
@gjsify/cli                        0.44.0  tarball=yes   <- control
@gjsify/node-runtime-darwin-arm64  0.44.0  tarball=yes
@gjsify/node-runtime-darwin-x64    0.44.0  tarball=yes
@gjsify/node-runtime-win32-x64     0.44.0  tarball=yes
```

The two-field check is not caution for its own sake. Issue **#1407** records `onboard` reporting a
publish as done while npm had stored only the tarball and no packument, for about twenty minutes.
A version string alone would not have distinguished that state from this one.

## The ledger is now empty, and that is the design working

A gap that closes should empty its own declaration. The bidirectional rule is what makes that
happen: an absent name must be listed, and a listed name that is present fails. So the list cannot
rot into a permanent exemption nobody rereads, which is the usual fate of an allowlist.

That is also why the red on `main` is not a defect in the gate. Landing four first publishes
without this commit would leave a standing red that reads as noise, and a gate people learn to
scroll past has stopped being a gate.

## Checks

```
$ node scripts/check-shipped-runtime-packages.mjs
check-shipped-runtime-packages: 6 by-name ship runtime package(s) checked - 6 live on npm, 0 declared pending bootstrap.
EXIT=0
```

The negative control needs no setup: the same script on unmodified `main` is what is failing CI
right now, and the only difference between the two runs is the removed entries.
