### PR TITLE
docs(website): one ship page per target OS

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -162,7 +162,10 @@ export default defineConfig({
                     label: 'Ship your app',
                     items: [
                         { slug: 'ship', label: 'Overview' },
-                        { slug: 'ship/linux-packages', label: 'deb & rpm' },
+                        { slug: 'ship/linux-packages', label: 'Linux' },
+                        { slug: 'ship/macos', label: 'macOS' },
+                        { slug: 'ship/windows', label: 'Windows' },
+                        { slug: 'ship/signing', label: 'Signing' },
                         { slug: 'guides/flatpak-app', label: 'Flatpak: GUI App' },
                         { slug: 'guides/flatpak-cli-tool', label: 'Flatpak: CLI Tool' },
                         { slug: 'guides/distributing-gjs-apps', label: 'One-Line Installer' },

--- a/website/src/content/docs/cli-reference.md
+++ b/website/src/content/docs/cli-reference.md
@@ -1315,40 +1315,41 @@ The browser is built on [`@gjsify/iframe`](https://www.npmjs.com/package/@gjsify
 
 ### `gjsify ship`
 
-Turn a built application into something a stranger can install. The payload is staged once, then wrapped per format.
+Turn a built application into something a stranger can install. The payload is staged once, then wrapped per format. Full walkthroughs live under [Ship your app](/gjsify/ship/), one page per operating system.
 
 ```bash
-gjsify ship                     # build the project, then a .deb and an .rpm
+gjsify ship                     # this host's layout; on Linux, a .deb and an .rpm
+gjsify ship linux               # the same two, from a Mac or from Windows
+gjsify ship linux --target flatpak         # a single-file Flatpak bundle (needs flatpak-builder)
+gjsify ship darwin --arch arm64            # a macOS <App>.app and a zip around it
+gjsify ship darwin --target macos-app-dmg  # a .dmg, on macOS only
+gjsify ship windows                        # a program directory and its zip
+gjsify ship windows --target msi           # a Windows Installer package (needs wixl or WiX v3)
 gjsify ship --skip-build        # package what is already built
-gjsify ship --target deb        # one format
-gjsify ship --target flatpak    # a single-file Flatpak bundle (needs flatpak-builder)
-gjsify ship darwin              # a macOS <App>.app and a zip around it (--app node)
-gjsify ship darwin --target macos-app-dmg   # a .dmg — on macOS only, see below
-gjsify ship windows             # a program directory + its zip
-gjsify ship windows --target msi  # …and a Windows Installer package (needs wixl or WiX v3)
 gjsify ship --stage             # produce the payload and stop
-gjsify ship --from-stage ./ship/stage   # pack a payload assembled elsewhere
-gjsify ship --from-stage ./stage --sign -   # ad-hoc sign the payload (macOS, no certificate needed)
-gjsify ship --arch arm64        # package for another architecture
+gjsify ship --from-stage ./ship/stage      # pack a payload assembled elsewhere
+gjsify ship --from-stage ./stage --sign -  # ad-hoc sign the payload (macOS, no certificate)
 ```
+
+The positional names the operating system whose LAYOUT to assemble: `linux`, `darwin`, `windows` (`win32` is accepted too). It defaults to this host. Assembling is not host-bound, so any layout can be staged anywhere.
 
 | Option | Default | Description |
 |---|---|---|
-| `--target <fmt..>` | `gjsify.ship.targets`, else every format wrapping the layout that needs no extra tooling | Formats to build. Comma-separated or repeated. On Linux that default is `deb,rpm`; `flatpak` is opt-in because it is the one format that needs a *different host*. `macos-app`/`macos-app-zip` wrap the darwin layout and `windows-dir`/`windows-dir-zip` the windows one; all four need `glib-compile-schemas` — a tool, not a host, which is why they are still in the default there. `macos-app-dmg` wraps the darwin layout too and is opt-in for the same reason `flatpak` is: it needs a different host. A UDIF image is written by `hdiutil`, which is macOS-only, so on any other host the route is `gjsify ship darwin --stage` here and `gjsify ship --from-stage <dir> --target macos-app-dmg` on a Mac. `msi` wraps the windows layout too and is opt-in for a third reason again: it needs a TOOL on either of two hosts — `wixl` from `msitools` on Linux, WiX Toolset v3.14 on Windows — so it is `finishOn: ['linux', 'win32']` rather than `'any'` or one OS. A format wrapping another layout is refused by name. |
+| `--target <fmt..>` | `gjsify.ship.targets`, else every format wrapping the target layout that needs no extra tooling | Formats to build. Comma-separated or repeated. Naming a format that wraps another layout is an error; a configured `gjsify.ship.targets` drops such a name with a printed note instead, because it is a project default rather than a claim about one run. |
 | `--out <dir>` | `gjsify.ship.outDir`, else `ship` | Output root, relative to the project. |
 | `--stage` | `false` | Produce the staged payload and stop, packing nothing. |
-| `--from-stage <dir>` | — | Pack a payload an earlier `--stage` run wrote. Needs no project: no `package.json`, no config, no built bundle. |
-| `--expect-target <os>-<arch>` | — | With `--from-stage`: refuse a stage assembled for a different matrix leg, e.g. `linux-arm64`. Compares against what the stage recorded, not against this host. |
+| `--from-stage <dir>` | none | Pack a payload an earlier `--stage` run wrote. It needs no project at all, so no `package.json`, no config and no built bundle. |
+| `--expect-target <os>-<arch>` | none | Used with `--from-stage`. Refuses a stage assembled for a different matrix leg, such as `linux-arm64`. Compares against what the stage recorded, not against this host. |
 | `--skip-build` | `false` | Do not run the project's `build` script first. |
-| `--arch <arch>` | this host | Target architecture, in `process.arch` spelling. |
-| `--sign <identity>` | `gjsify.ship.sign.<os>.identity` | Sign the payload with this identity — a NAME `codesign`/`signtool` looks the private key up by, never a certificate. `-` signs ad-hoc and needs no developer identity. Absent means unsigned, which is a legitimate output; the skip is printed to stderr. darwin and win32 only; on Linux the artifact is signed by the repository that serves it, so `--sign` there is refused. |
-| `--notarize <profile>` | — | Submit the signed artifact with `xcrun notarytool submit --keychain-profile`. Needs `--sign`; darwin only. |
+| `--arch <arch>` | this host | Target architecture, in `process.arch` spelling. Labels the artifact and picks the runtime packages; cross-builds nothing. |
+| `--sign <identity>` | `gjsify.ship.sign.<os>.identity` | Sign the payload with this identity, a NAME `codesign` or `signtool` looks the private key up by, never a certificate. `-` signs ad-hoc. Absent means unsigned, which is a legitimate output, and the skip is printed to stderr. darwin and win32 only. |
+| `--notarize <profile>` | none | Submit the signed artifact with `xcrun notarytool submit --keychain-profile <p> --wait`. Needs `--sign`, and runs on darwin only. |
 | `--verbose` | `false` | Print every staged file, the GI namespaces the bundle imports, and every tool invocation. |
 
 What lands under `ship/`:
 
 ```
-ship/stage/            the prefix-relative payload: bin/, lib/<name>/, share/
+ship/stage/            the payload for one layout
 ship/stage/.gjsify-ship-stage.json   the closure a packing host needs when it is not this one
 ship/overlay/<format>/ per-format additions, such as the licence where each format wants it
 ship/flatpak/          --target flatpak only: the generated manifest, the build dir, the export repo
@@ -1356,17 +1357,43 @@ ship/schemas/          off Linux only: where gschemas.compiled is built before i
 ship/out/              the artifacts
 ```
 
-`ship/out/` is packed by reading `ship/stage/` back, so what you inspect is what ships, and both artifacts carry the identical payload.
+`ship/out/` is packed by reading `ship/stage/` back, so what you inspect is what ships.
+
+#### The formats, and where each one packs
+
+| Format | Layout | In the default set | Packs on | Needs installed |
+|---|---|---|---|---|
+| `deb` | linux | yes | any host | nothing |
+| `rpm` | linux | yes | any host | nothing |
+| `flatpak` | linux | no | linux | `flatpak-builder`, `flatpak` |
+| `macos-app` | darwin | yes | any host | `glib-compile-schemas` |
+| `macos-app-zip` | darwin | yes | any host | `glib-compile-schemas` |
+| `macos-app-dmg` | darwin | no | darwin | `hdiutil`, part of macOS |
+| `windows-dir` | win32 | yes | any host | `glib-compile-schemas` |
+| `windows-dir-zip` | win32 | yes | any host | `glib-compile-schemas` |
+| `msi` | win32 | no | linux or win32 | `wixl` from `msitools`, or WiX Toolset v3.14 |
+
+`.deb`, `.rpm` and both zips are written by `ship` itself, with no `dpkg-deb`, no `rpmbuild` and no `zip`. `glib-compile-schemas` is a tool rather than a host, so the formats that declare it still pack anywhere; a non-Linux layout has no install step, so the schemas are compiled while the tree is assembled.
+
+Ask for a format this host cannot finish and you get a refusal naming the two-phase way across, never a broken file:
+
+```bash
+gjsify ship darwin --stage --target macos-app-dmg   # here, any OS, offline
+gjsify ship --from-stage ./ship/stage \
+            --target macos-app-dmg                  # there, on a Mac
+```
+
+Name the format in the `--stage` run as well: phase one renders one licence overlay per format, and a stage that never saw a format is refused when that format is asked for. A missing tool is a separate message from the wrong host, because the fixes differ, and both fire before your `build` script runs.
 
 #### What it works out for you
 
 - **Runtime dependencies** come from the `gi://` imports in your built bundle, mapped to the package that ships each typelib (`gir1.2-gtk-4.0` on Debian, `gtk4` on Fedora). A namespace the table does not know fails the build and names itself, because an undeclared runtime dependency otherwise fails on a user's machine after the download. Fill the gap with `gjsify.ship.typelibPackages`.
-- **Architecture** is `all` or `noarch` unless the payload contains a `.so` or `.node`. A pure-JS GJS app really does install everywhere, and claiming `amd64` would make apt refuse it on a machine it runs on.
-- **The launcher** works out its own prefix at runtime, so one payload works under `/usr`, under `/app`, or anywhere else. That is the entire difference between the `.rpm` and the Flatpak: the Flatpak module is `buildsystem: simple` plus `cp -a stage/. /app/`, with no meson and no build system inside the sandbox.
-- **`Section:` and `Group:`** follow from `categories`, and the version is normalised so a prerelease (`1.2.0-rc.1`) still sorts before the release in both package managers (`1.2.0~rc.1`).
+- **Architecture** is `all` or `noarch` unless the payload contains a `.so` or `.node`. A pure-JS app really does install everywhere, and claiming `amd64` would make apt refuse it on a machine it runs on. Where the payload does carry a native image, `ship` reads its ELF `e_machine` or Mach-O `cputype` back and refuses a label that contradicts it.
+- **The launcher** works out its own location at run time, so one payload works under `/usr`, under `/app`, inside a `.app` and inside a Windows program directory. It execs the interpreter your bundle was built for, and `ship` refuses a package whose launcher and dependency disagree.
+- **Localised metadata** is folded in from `gjsify.ship.localeDir`. The compiled `.mo` catalogues become `Name[xx]=` in the `.desktop` entry and `xml:lang` in the AppStream component.
 - **Metadata** falls back to `gjsify.flatpak`, so a project that already ships a Flatpak usually needs no `gjsify.ship` block at all.
 
-No runtime is bundled on Linux: GJS and GTK come from the distribution, so the package depends on `gjs` instead of carrying around 100 MiB of it. Packing the same build twice gives byte-identical files, which is explained in [How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts).
+Packing the same build twice gives byte-identical files, which is explained in [How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts).
 
 #### Configure it
 
@@ -1388,97 +1415,55 @@ No runtime is bundled on Linux: GJS and GTK come from the distribution, so the p
 
 | Key | Default | What it does |
 |---|---|---|
-| `appId` | `gjsify.flatpak.appId`, else `package.json#name` | Reverse-DNS id. Names the desktop entry, the AppStream component and the installed icon, so it cannot be guessed. |
-| `binaryName` | package name, scope stripped and lowercased | Package name and the `bin/` entry. |
-| `version` | `package.json#version` | Upstream version, normalised. |
+| `appId` | `gjsify.flatpak.appId`, else `package.json#name` | Reverse-DNS id. Names the desktop entry, the AppStream component, the installed icon, `CFBundleIdentifier` and the MSI upgrade code, so it cannot be guessed. |
+| `binaryName` | package name, scope stripped and lowercased | Package name and the launcher's filename. |
+| `name` | title-cased `binaryName` | Display name. The `.desktop` `Name=`, `CFBundleName`, the `<App>.app` directory and the Windows program directory. |
+| `version` | `package.json#version` | Upstream version, normalised. An `.msi` needs a plain `major.minor.build` and refuses a prerelease. |
 | `release` | `1` | Package revision within one upstream version. |
-| `maintainer` | `package.json#author` | `Maintainer:` and `Packager:`, as `Name <email>`. dpkg refuses a package without one. |
-| `targets` | every format wrapping the layout that needs no extra tooling (on Linux, `["deb", "rpm"]`) | Formats built when `--target` is not given. `flatpak` is deliberately not in the default: it needs `flatpak-builder`, i.e. a Linux host. A configured list is a project DEFAULT, so formats wrapping another layout are filtered out with a printed note rather than refused — unlike a typed `--target`, which is a claim about one run. |
+| `maintainer` | `package.json#author` | `Maintainer:`, `Packager:` and the MSI's `Publisher`, as `Name <email>`. dpkg refuses a package without one. |
+| `targets` | every format wrapping the target layout that needs no extra tooling | Formats built when `--target` is not given. |
 | `outDir` | `ship` | Output root. |
-| `bundle` | `gjsify.main`, else `package.json#main` | The built bundle `bin/<name>` executes. Its whole directory is staged into `lib/<name>/`. |
+| `bundle` | `gjsify.main`, else `package.json#main` | The built bundle the launcher executes. Its whole directory is staged. |
 | `icon` | `data/icons` or `data/icons/hicolor` | Icon file or directory. Sizes are read from the path or the filename. |
 | `schemas` | `data` | A `*.gschema.xml` file or a directory of them. |
 | `licenseFile` | first of `LICENSE`, `LICENSE.md`, `LICENSE.txt`, `COPYING` | Licence file to ship. |
 | `section` / `group` | derived from `categories` | deb `Section:` and rpm `Group:`. |
+| `mimeTypes` | `[]` | shared-mime-info types the app opens. Rendered into `share/mime/packages/` and into the desktop entry's `MimeType=`. |
 | `minGjsVersion` | `1.86` | Minimum GJS the emitted dependency asks for. |
-| `minNodeVersion` | `24` | Minimum Node the emitted dependency asks for. Only used when the payload is an `--app node` bundle — a `--app gjs` package declares no Node at all. |
+| `minNodeVersion` | `24` | Minimum Node the emitted dependency asks for. Only used when the payload is an `--app node` bundle on Linux. |
 | `depends` | `{}` | Extra runtime dependencies per format, appended to the derived set. For things that are not typelibs. |
 | `typelibPackages` | `{}` | GI namespace to the package shipping its typelib. This is what unblocks an unknown namespace. |
-| `bundledTypelibs` | `[]` | Directories whose `*.typelib` and `*.so` (with or without a numeric soversion) the package carries itself, for GI libraries that arrive as npm prebuilds rather than distro packages. Staged into `lib/<name>/gi/`, with the launcher pointing `GI_TYPELIB_PATH` and `LD_LIBRARY_PATH` there. |
-| `localeDir` | — | Directory of COMPILED gettext catalogues in `<lang>/LC_MESSAGES/<domain>.mo` layout. Staged into `share/locale/`; the launcher exports `GJSIFY_LOCALE_DIR`. `.po` sources are refused — `bindtextdomain` reads `.mo` only. |
+| `bundledTypelibs` | `[]` | Directories whose `*.typelib` and `*.so` the package carries itself, for GI libraries that arrive as npm prebuilds rather than distro packages. Staged into `lib/<name>/gi/`, with the launcher pointing `GI_TYPELIB_PATH` and `LD_LIBRARY_PATH` there. |
+| `localeDir` | none | Directory of COMPILED gettext catalogues in `<lang>/LC_MESSAGES/<domain>.mo` layout. Staged into `share/locale/`; the launcher exports `GJSIFY_LOCALE_DIR`. `.po` sources are refused, because `bindtextdomain` reads `.mo` only. |
 | `extraFiles` | `{}` | Extra payload entries: prefix-relative destination to project-relative source. |
 | `execArgs` | `[]` | Arguments the launcher appends before the user's own. |
 | `flatpak` | derived | The Flatpak half: `runtime` (`gnome`/`freedesktop`), `runtimeVersion`, `branch` (`stable`), `sdkExtensions`, `appendPath`, `finishArgs`, `cleanup`. |
-| `sign` | — | Default signing identity per OS: `{ "darwin": { "identity": "…" }, "win32": { "identity": "…" } }`. An IDENTITY only — there is no key here, and no path to one. `linux` is not a valid key and is refused, because a `.deb`/`.rpm` is signed by the repository that serves it. |
+| `sign` | none | Default signing identity per OS: `{ "darwin": { "identity": "…" }, "win32": { "identity": "…" } }`. An IDENTITY only. `linux` is not a valid key and is refused, because a `.deb` or `.rpm` is signed by the repository that serves it. |
 
 Metadata keys (`name`, `summary`, `description`, `developer`, `license`, `categories`, `keywords`, `homepageUrl`, `screenshots`, and the rest) are shared with `gjsify.flatpak` and listed under [`flatpak init`](#gjsify-flatpak-init).
 
 #### Signing
 
-`--sign` takes an **identity**, never a certificate. `codesign` and `signtool` are both handed a string and look the private key up themselves, so `gjsify ship` is never given a secret and there is nothing to redact from a log. Getting a key into a keychain or a certificate store is the signing host's job — a machine setup or a CI step, not this command.
-
-```bash
-gjsify ship darwin --stage --arch arm64                     # assemble anywhere
-gjsify ship --from-stage ./ship/stage --sign -              # ad-hoc, no developer identity
-gjsify ship --from-stage ./ship/stage \
-            --sign "Developer ID Application: You (TEAMID)" # on a macOS host with the key
-```
+`--sign` takes an **identity**, never a certificate. `codesign` and `signtool` are both handed a string and look the private key up themselves, so `gjsify ship` is never given a secret and there is nothing to redact from a log.
 
 | | darwin | win32 | linux |
 |---|---|---|---|
-| tool | `codesign` | `signtool` | — |
+| tool | `codesign` | `signtool` | none |
 | what it signs | every Mach-O image in the payload | every PE image in the payload | nothing |
-| runs on | macOS | Windows | — |
+| runs on | macOS | Windows | none |
 | project default | `gjsify.ship.sign.darwin.identity` | `gjsify.ship.sign.win32.identity` | refused |
 
-**With no identity the run skips, prints why on stderr, and exits 0.** An unsigned artifact is a legitimate deliverable; what is refused is the other direction — claiming a signature that was not made. `--sign` on the `--stage` phase is refused too: that phase produces no artifact, and the tree it writes is read back and repacked afterwards.
+With no identity the run skips, prints why on stderr, and exits 0. `--sign` on the `--stage` phase is refused, because that phase produces no artifact. `--sign -` signs ad-hoc and needs no Apple Developer Program membership.
 
-**Signing mutates the payload rather than wrapping it.** Under a hardened runtime a Developer-ID-signed executable will not load ad-hoc-signed libraries, and the GTK closure a macOS bundle carries arrives ad-hoc-signed — relocating a dylib invalidates whatever signature it had. So the darwin leg re-signs every image *inside* the payload, and the container is built from the signed bytes. The staged tree itself is never written to, so a `--from-stage --sign` run can be repeated.
+`--notarize <keychain-profile>` is darwin-only and needs `--sign`. It does not staple, and no run in this repository has ever invoked it against a real Apple account. [Sign your artifacts](/gjsify/ship/signing/) is the full picture.
 
-`--sign -` signs ad-hoc and needs no Apple Developer Program membership, which is how this project proves the pipeline in CI with no key anywhere: a macOS leg signs a real Mach-O payload, `codesign --verify` reads the signature back, and `.github/ship-oracle/verify-signed-arrival.mjs` checks the claim no verifier makes — every non-Mach-O file byte-identical, every Mach-O identical outside its signature.
+#### Where the interpreter comes from
 
-`--notarize <keychain-profile>` submits the signed artifact with `xcrun notarytool submit --keychain-profile <p> --wait`. It is darwin-only, needs `--sign`, and skips loudly when no credential is given. It has never been run against a real Apple account — notarisation needs one, and ad-hoc signing deliberately does not — so treat it as untested. The Windows invocation is in the same position: `signtool` has no ad-hoc mode.
+On **Linux** it is depended on, not shipped: `gjs (>= 1.86)`, or `nodejs (>= 24)` on deb and `nodejs(engine) >= 24` on rpm for an `--app node` bundle. Both floors exclude current Debian stable, and `gjsify ship` warns rather than lowering them; set `gjsify.ship.minGjsVersion` or `minNodeVersion` if your bundle genuinely runs on an older one.
 
-#### The GJS floor on Debian
+On **macOS and Windows** there is no system interpreter to depend on, so the artifact carries its own from `@gjsify/node-runtime-<target>`, with the GTK closure from `@gjsify/gtk-runtime-<target>` and the addon from `@gjsify/node-gi`. You declare all three yourself in the project you package. They are resolved **by name** out of your own `node_modules` at ship time, so they have to be installed there. `GJSIFY_NODE_RUNTIME` and `GJSIFY_GTK_RUNTIME` override the first two with a directory. `@gjsify/node-runtime-win32-x64` is not yet published to npm; the other five names are. [macOS app bundles](/gjsify/ship/macos/) and [Windows artifacts](/gjsify/ship/windows/) carry the copy-pasteable blocks.
 
-The emitted dependency is `gjs (>= 1.86)`, which is what the bundler targets. No released Debian satisfies it: Debian went from 1.82.3 (trixie) straight to 1.88.1 (forky). `gjsify ship` tells you rather than lowering the floor quietly, because a `.deb` that apt refuses beats one that installs and then dies on a syntax error. Set `gjsify.ship.minGjsVersion` if your bundle genuinely runs on an older GJS.
-
-#### The Node floor, and where the interpreter comes from
-
-`--app node` needs an interpreter, and where it comes from depends on the operating system.
-
-On **Linux** it is depended on, not shipped: the emitted dependency is `nodejs (>= 24)` on deb and `nodejs(engine) >= 24` on rpm. The two names genuinely differ, and the rpm one is not a style choice — `Requires: nodejs >= 24` is a **silent no-op on Fedora**, because the virtual `nodejs` Provide carries Epoch 1 and a bare `>= 24` desugars to `0:24`, which `1:22.23.1` satisfies. Measured with `dnf repoquery` on Fedora 44: `--whatprovides 'nodejs >= 24'` answers **nodejs22**.
-
-Which one is emitted comes from `gjsify.app`, the same field the build uses, and the launcher `gjsify ship` writes execs that one — `exec gjs -m <bundle>` or `exec node <bundle>`. A package that declared one and ran the other is refused before it is written.
-
-That floor excludes every current DEB stable and LTS — trixie ships 20, Ubuntu 24.04 ships 18, Ubuntu 26.04 ships 22; only forky has 24 — so `gjsify ship` warns about it, for the same reason it warns about the GJS floor. Set `gjsify.ship.minNodeVersion` if your bundle genuinely runs on an older Node.
-
-On **macOS and Windows** there is no system Node to depend on, so the artifact carries its own from `@gjsify/node-runtime-<target>`. You declare it yourself, as a `devDependency` of the project you package — *gjsify* adds no `optionalDependencies` edge to it, which is a different statement from "nothing to add": the package is resolved **by name** out of your project's own `node_modules` at ship time, the same rule the GTK runtime bundles follow, and it has to be installed there for the lookup to find it. [Ship](/gjsify/ship/) carries the copy-pasteable block. `GJSIFY_NODE_RUNTIME` overrides the lookup with a directory — which is also the way to get a complete artifact today, because the three `@gjsify/node-runtime-*` names are not published yet.
-
-#### Where each format can be packed
-
-Declared per format, and checked before your `build` script runs rather than after it.
-
-| Format | Packed by | Runs on | Read back with |
-|---|---|---|---|
-| `deb` | `ship` itself — no `dpkg-deb` | any host, offline | GNU `ar` + `tar`, `dpkg-deb`, `lintian` |
-| `rpm` | `ship` itself — no `rpmbuild` | any host, offline | `rpm` |
-| `flatpak` | `flatpak-builder` + `flatpak build-bundle` | Linux, tools installed | `flatpak build-import-bundle` + `ostree` |
-
-Ask for a format this host cannot finish and you get a refusal naming the two-phase way across, never a broken file:
-
-```bash
-gjsify ship --stage --target flatpak                          # here, any OS, offline
-gjsify ship --from-stage ./ship/stage --target flatpak        # there, on Linux
-```
-
-A missing tool is a separate message from the wrong OS, because the fixes differ.
-
-The six Flatpak build keys also resolve from a legacy `gjsify.flatpak` block, with one warning line naming what was inherited; they are removed from there in 1.0.0. `gjsify flatpak init` and `flatpak ci` read both spellings too, so moving them does not change the manifest those commands write. The app metadata in `gjsify.flatpak` is shared by design and is not deprecated.
-
-#### Scope today
-
-Linux and `--app gjs`. A project declaring any other `gjsify.app` is refused, because the launcher runs `gjs -m <bundle>`. macOS and Windows artifacts are later stages.
+That is also why the four macOS and Windows formats accept `gjsify.app: "node"` only. There is no relocatable GJS to put inside a downloadable bundle, and there is no GJS host on Windows at all.
 
 ### `gjsify flatpak`
 

--- a/website/src/content/docs/ship/index.mdx
+++ b/website/src/content/docs/ship/index.mdx
@@ -1,15 +1,12 @@
 ---
 title: Ship your app
-description: Turn a built GJS app into something other people can install. One command gives you a .deb and an .rpm, `gjsify ship darwin` gives you a macOS .app and a zip (and a .dmg on a Mac), `gjsify ship windows` gives you a program directory and a zip, and `--target flatpak` adds a Flatpak bundle; this page also points at the one-line installer, self-executing bundles and dlx.
+description: Turn a built app into something other people can install. One command per operating system gives you a .deb and an .rpm on Linux, a macOS .app with a zip and a .dmg, and a Windows program directory with a zip and an .msi.
 ---
 
 import CommandTabs from '../../../components/CommandTabs.astro';
 
 Your app runs on your machine. This section is about getting it onto someone
 else's.
-
-The shortest path is `gjsify ship`. Run it in your project and you get a `.deb`
-and an `.rpm`, ready to hand to a Linux user:
 
 <CommandTabs title="Ship it">
   <Fragment slot="gjsify">
@@ -35,415 +32,196 @@ and an `.rpm`, ready to hand to a Linux user:
 </CommandTabs>
 
 That runs your project's `build` script, collects everything the app needs into
-one payload, and wraps that payload once per format. There is no manifest to
-write, no meson, and no packaging file to keep in your repo.
+one payload under `ship/stage/`, and wraps that payload once per format into
+`ship/out/`. You write no manifest, no meson file and no spec file.
 
-Ask for a Flatpak and you get one out of the same payload:
+## One command per operating system
 
-```bash
-gjsify ship --target flatpak      # a single-file bundle, from the same stage
-```
+`gjsify ship <os>` names whose layout to assemble. A bare `gjsify ship`
+assembles the layout of the host you are sitting at, so name the operating
+system whenever you want one you are not on.
 
-That one is not in the default set, because it is the only format that needs
-tooling on your machine — `flatpak-builder` and `flatpak`. Everything below
-about assembling and packing separately exists for exactly that.
+| Command | What lands in `ship/out/` | Your app declares |
+|---|---|---|
+| `gjsify ship linux` | `my-app_1.2.3-1_all.deb`, `my-app-1.2.3-1.noarch.rpm` | `gjsify.app: "gjs"` or `"node"` |
+| `gjsify ship darwin` | `My App.app`, `my-app-1.2.3-1.arm64.zip` | `gjsify.app: "node"` |
+| `gjsify ship windows` | `My App/`, `my-app-1.2.3-1.x64.zip` | `gjsify.app: "node"` |
 
-## What comes out
+Assembling is never host-bound, so one workstation produces all three artifact
+sets. Packing is a different question, and two formats out of nine answer it
+differently. See [where each format can be packed](#where-each-format-can-be-packed).
 
-```
-ship/
-├── stage/              the payload: bin/, lib/<name>/, share/
-│   └── .gjsify-ship-stage.json   what a packing host needs, if it is not this one
-├── overlay/<format>/   what one format wants elsewhere (today: the licence)
-├── flatpak/            only with --target flatpak: the generated manifest, the build dir, the repo
-├── schemas/            only off Linux: where gschemas.compiled is built before staging
-└── out/
-    ├── my-app_1.2.3-1_all.deb
-    ├── my-app-1.2.3-1.noarch.rpm
-    ├── org.example.MyApp-1.2.3-1.x86_64.flatpak
-    ├── My App.app/                        gjsify ship darwin
-    ├── my-app-1.2.3-1.arm64.zip           the same bundle, zipped
-    ├── My App/                            gjsify ship windows
-    └── my-app-1.2.3-1.x64.zip             the same directory, zipped
-```
+A Linux package declares its interpreter and its GTK libraries as dependencies
+and takes them from the distribution. The macOS bundle and the Windows program
+directory carry a Node interpreter and a GTK closure inside themselves, because
+neither operating system ships one. That is why those two accept
+`gjsify.app: "node"` only, and why they need extra packages in your
+`package.json`.
 
-The payload in `ship/stage/` is built once, and both packers read it back off
-disk. Whatever you find in there is what a user gets, so it is worth a look
-before you publish anything.
+- [Linux packages](/gjsify/ship/linux-packages/) covers `.deb`, `.rpm` and the
+  Flatpak bundle.
+- [macOS app bundles](/gjsify/ship/macos/) covers the `.app`, its zip and the
+  `.dmg`.
+- [Windows artifacts](/gjsify/ship/windows/) covers the program directory, its
+  zip and the `.msi`.
+- [Sign your artifacts](/gjsify/ship/signing/) covers `--sign` and `--notarize`.
+
+## What ship reads from your package.json
+
+The same fields feed all three operating systems. Set these before the first
+run.
+
+| package.json | What it becomes | Override |
+|---|---|---|
+| `name` | the package name and the launcher's filename | `gjsify.ship.binaryName` |
+| `version` | the version in every artifact | `gjsify.ship.version` |
+| `license` (an SPDX id such as `"MIT"`) | a required field in `.deb` and `.rpm` | `gjsify.ship.license.project` |
+| `author` as `"Name <you@example.org>"` | `Maintainer:`, `Packager:` and the MSI's `Publisher` | `gjsify.ship.maintainer` |
+| `gjsify.main` (or `main`) | the built bundle the launcher runs | `gjsify.ship.bundle` |
+| `gjsify.app` | the interpreter the launcher execs, `gjs -m` or `node`. Ship refuses a package whose launcher and declared dependency disagree | none |
+| `scripts.build` | the build step ship runs first | pass `--skip-build` instead |
+
+Two more you have to set yourself, because nothing can derive them:
+
+- **`gjsify.ship.appId`**, a reverse-DNS id such as `org.example.MyApp`. It
+  names the desktop entry, the AppStream component, the installed icon, the
+  macOS `CFBundleIdentifier` and the MSI upgrade code. `gjsify.flatpak.appId`
+  is used when it is set, and a reverse-DNS package name is used after that.
+- **`gjsify.ship.name`**, the display name. It becomes the `.desktop` `Name=`,
+  the `<App>.app` directory, the Windows program directory and the Start-Menu
+  entry. Without it ship title-cases the binary name.
+
+Icons under `data/icons/`, GSettings schemas under `data/`, and a `LICENSE`,
+`COPYING` or `LICENSE.md` in the project root are found on their own.
+
+Your `version` is rewritten on the way in, because npm and dpkg disagree about
+prereleases. A leading `v` is dropped, `+buildmetadata` is dropped with a
+warning, and `1.2.0-rc.1` becomes `1.2.0~rc.1`. Both dpkg and rpm sort
+`1.2.0~rc.1` before `1.2.0`, the way npm does, while they read `1.2.0-rc.1` as
+release `rc.1` of version `1.2.0` and sort it after. A version neither format
+can spell stops the run.
+
+## Where each format can be packed
+
+Nine formats wrap three layouts. Seven of them pack on any host, offline, with
+no tool outside this CLI. Two do not, and ship refuses those on the wrong host
+rather than writing a broken file.
+
+| Format | Layout | In the default set | Packs on | Needs installed |
+|---|---|---|---|---|
+| `deb` | linux | yes | any host | nothing |
+| `rpm` | linux | yes | any host | nothing |
+| `flatpak` | linux | no | Linux | `flatpak-builder`, `flatpak` |
+| `macos-app` | darwin | yes | any host | `glib-compile-schemas` |
+| `macos-app-zip` | darwin | yes | any host | `glib-compile-schemas` |
+| `macos-app-dmg` | darwin | no | macOS | `hdiutil`, which is part of macOS |
+| `windows-dir` | windows | yes | any host | `glib-compile-schemas` |
+| `windows-dir-zip` | windows | yes | any host | `glib-compile-schemas` |
+| `msi` | windows | no | Linux or Windows | `wixl` from `msitools`, or WiX Toolset v3.14 |
+
+`glib-compile-schemas` ships in `glib2` on Fedora and `libglib2.0-bin` on
+Debian and Ubuntu. It is a tool rather than a host, so the four formats that
+declare it still pack anywhere. A layout other than Linux has no install step to
+compile your GSettings schemas later, so ship compiles them while it assembles.
+
+A missing tool and a wrong host are separate messages, because the fixes
+differ, and both fire before your `build` script runs. Asking for a format that
+wraps another operating system's layout is an error by name, so
+`gjsify ship darwin --target deb` stops immediately.
 
 ## Assemble here, pack there
 
-`gjsify ship --stage` stops after the payload and writes
-`ship/stage/.gjsify-ship-stage.json` beside it. That file is the closure the
-packing step needs — the file modes, the pre-rendered licence overlay, the GI
-namespaces read out of your bundle, and the build stamp — so the tree can be
-handed to another machine and packed there:
+The `.dmg` needs a Mac and the `.msi` needs `wixl` or WiX. `--stage` and
+`--from-stage` are how you produce them from a host that has neither.
 
 ```bash
-gjsify ship linux --stage                        # anywhere, under GJS, offline
-gjsify ship --from-stage ./stage                 # on the host the format needs
+gjsify ship darwin --stage --target macos-app,macos-app-zip,macos-app-dmg
+# move ship/stage/ to a Mac, then:
+gjsify ship --from-stage ./stage --target macos-app-dmg
 ```
 
-The `linux` there is the layout, and it is worth naming when you are not on
-Linux: without it `gjsify ship` assembles the layout of the host you are sitting
-at. `--from-stage` takes none — the stage already is one OS's layout, and
-`--expect-target` is how you assert which.
+`--stage` writes the payload and stops, plus `ship/stage/.gjsify-ship-stage.json`
+beside it. That file records the file modes, the pre-rendered licence overlays,
+the GI namespaces read out of your bundle and the build stamp, so a packing host
+needs nothing else. `--from-stage` reads no project at all. No `package.json`,
+no config, no built bundle. That is what lets one CI job assemble and another
+finish.
 
-`--from-stage` needs no project: no `package.json`, no config, no built bundle.
-That is what lets one CI job assemble and another finish on the host a format
-belongs to. The modes come from the recorded plan, so a stage that travelled
-through an artifact upload — which stores no POSIX mode at all — still installs
-an executable `bin/` entry.
+Name every format you intend to pack in the `--stage` run. Phase one renders one
+licence overlay per format, and a format the stage never saw is refused on the
+packing host:
 
-`--expect-target <os>-<arch>` is available on the finish step and does exactly
-one job: it refuses a stage assembled for a different matrix leg, so a job that
-downloaded the wrong artifact stops instead of packing it.
+```text
+gjsify ship: this stage was assembled for deb, and --target names rpm.
+```
+
+`--expect-target <os>-<arch>` on the finish step refuses a stage assembled for a
+different matrix leg, so a job that downloaded the wrong artifact stops instead
+of packing it. It compares against the value the stage recorded, not against the
+machine you are packing on, because packing an `arm64` stage on an `x64` runner
+is a supported path.
 
 ```bash
-gjsify ship --from-stage ./stage --expect-target linux-x64
+gjsify ship --from-stage ./stage --expect-target darwin-arm64
 ```
 
-It compares against the value the stage recorded, not against the machine you
-are packing on — packing an `arm64` stage on an `x64` runner is a supported
-path and a host check would refuse it. It is therefore **not** a check that the
-label matches the bytes. That one is unconditional and needs no flag: if the
-payload carries a native image whose ELF `e_machine` or Mach-O `cputype`
-contradicts the architecture the package is being labelled with, `gjsify ship`
-refuses and names the file and both architectures.
+One check needs no flag and cannot be turned off. If the payload carries a
+native image whose ELF `e_machine` or Mach-O `cputype` contradicts the
+architecture the artifact is being labelled with, ship refuses and names the
+file and both architectures.
 
-Note that `--arch` only reaches the label when the payload contains a native
-image at all. A pure-JS payload is `Architecture: all` / `BuildArch: noarch`
-whatever you pass, because that is what it honestly is.
+## Look at what you are about to publish
 
-## The Flatpak target
+Everything lands under `ship/`, which `--out <dir>` moves.
 
-The payload does not change. `ship` stages one prefix-relative tree — `bin/`,
-`lib/<name>/`, `share/` — and the launcher inside it works out its own prefix at
-run time, so the same tree is `/usr` in a `.deb` and `/app` in a Flatpak. That
-is the whole difference, and it is why the generated Flatpak module is three
-shell commands with no build system in it:
-
-```json
-{
-  "name": "my-app",
-  "buildsystem": "simple",
-  "build-commands": ["mkdir -p /app", "cp -a stage/. /app/", "cp -a overlay/. /app/"]
-}
+```text
+ship/
+├── stage/              the payload, exactly as a user gets it
+│   └── .gjsify-ship-stage.json
+├── overlay/<format>/   what one format wants elsewhere, today the licence
+├── schemas/            off Linux: where gschemas.compiled is built
+├── flatpak/            --target flatpak: the generated manifest and repo
+└── out/                the artifacts
 ```
 
-If you have written a Flatpak for a GJS app before, that is the meson glue gone.
-Learn6502 carried 158 lines of it whose only job was to call `gjsify build` and
-copy the results into a prefix, 66 of them setting `GI_TYPELIB_PATH` and
-`LD_LIBRARY_PATH` by hand.
-
-The runtime and the sandbox permissions are the only things left to configure,
-and every one has a default:
-
-```json
-"gjsify": {
-  "ship": {
-    "appId": "org.example.MyApp",
-    "flatpak": {
-      "runtime": "gnome",
-      "runtimeVersion": "50",
-      "branch": "stable",
-      "finishArgs": ["--device=dri", "--share=ipc", "--socket=wayland"]
-    }
-  }
-}
-```
-
-`finishArgs` defaults to that GUI set for an app and to nothing at all for a
-`kind: "cli"` tool. The app id names the exported ref, so the artifact is
-`org.example.MyApp-1.2.3-1.x86_64.flatpak` and installs with
-`flatpak install ./that-file`.
-
-**Already have a `gjsify.flatpak` block?** It keeps working. `runtime`,
-`runtimeVersion`, `sdkExtensions`, `appendPath`, `finishArgs` and `cleanup` are
-read from there too, and `ship` prints one line naming the keys it inherited and
-where to move them. Moving them is safe: `gjsify flatpak init` and `flatpak ci`
-read the new spelling as well, so the manifest those commands generate does not
-change under you. The app metadata — `name`, `summary`, `developer`,
-`categories`, `license` — is *not* deprecated: both blocks describe the same
-application, and either may carry it.
-
-## Give it to someone
-
-<CommandTabs title="Install the artifact" group="distro">
-  <Fragment slot="fedora">
-    ```bash
-    sudo dnf install ./ship/out/my-app-1.2.3-1.noarch.rpm
-    ```
-  </Fragment>
-  <Fragment slot="debian">
-    ```bash
-    sudo apt install ./ship/out/my-app_1.2.3-1_all.deb
-    ```
-  </Fragment>
-</CommandTabs>
-
-The app lands in `/usr/bin/my-app`, its desktop entry and icon show up in the
-menu, and `dnf remove` / `apt remove` takes it all away again. Nothing about
-GJSify needs to be on that machine: the package depends on the distribution's
-own `gjs`, GTK and typelib packages, and `gjsify ship` works out which ones by
-reading your built bundle.
-
-Full walkthrough, including every flag and what to do when the build refuses:
-[deb & rpm packages](/gjsify/ship/linux-packages/).
+Both packers read `ship/stage/` back off disk rather than keeping it in memory,
+so what you inspect there is what a user installs. `--verbose` prints every
+staged file, the GI namespaces the bundle imports, and every tool a packer runs.
 
 ## Pick your distribution channel
 
-`gjsify ship` is one option of several, and they answer different questions.
-They also stack: the same built bundle feeds all of them.
+`gjsify ship` is one option of several, and they stack. The same built bundle
+feeds all of them.
 
 | You want | Reach for | Guide |
 |---|---|---|
-| A file a Linux user installs with their own package manager | `gjsify ship` | [deb & rpm packages](/gjsify/ship/linux-packages/) |
-| A single Flatpak file, sandboxed, with a pinned GTK on every distro | `gjsify ship --target flatpak` | this page |
+| A file a Linux user installs with their own package manager | `gjsify ship linux` | [Linux packages](/gjsify/ship/linux-packages/) |
+| A single Flatpak file, sandboxed, with a pinned GTK on every distro | `gjsify ship linux --target flatpak` | [Linux packages](/gjsify/ship/linux-packages/#the-flatpak-bundle) |
+| An application a Mac user drags into `/Applications` | `gjsify ship darwin` | [macOS app bundles](/gjsify/ship/macos/) |
+| An installer a Windows user double-clicks | `gjsify ship windows --target msi` | [Windows artifacts](/gjsify/ship/windows/) |
 | A GUI app on Flathub, with the manifest and metadata files in your repo | `gjsify flatpak init` | [Flatpak: GUI app](/gjsify/guides/flatpak-app/) |
 | The same for a headless command-line tool | `gjsify flatpak init --kind cli` | [Flatpak: CLI tool](/gjsify/guides/flatpak-cli-tool/) |
 | A `curl … \| gjs` one-liner that installs into `~/.local`, no root | `gjsify generate-installer` | [One-line installer](/gjsify/guides/distributing-gjs-apps/) |
 | A single executable file people download, `chmod +x` and run | `gjsify build --shebang` | [Self-executing bundle](/gjsify/guides/self-executing-package/) |
 | No installation at all, run it straight from npm | publish a `dlx`-friendly package | [Run via dlx](/gjsify/guides/dlx-packaging/) |
 
-A rough rule of thumb. Choose **`gjsify ship`** when you want a user to type
-`dnf install` once, or to double-click one Flatpak file, and forget about it.
-Choose **`gjsify flatpak init`** on top of it when you are submitting to
-Flathub, which wants the manifest and the AppStream files committed in your
-repository. Choose the **one-line installer** while you are still iterating
-quickly and your users are early adopters. Choose **dlx** for a tool nobody
-wants permanently installed.
+Choose `gjsify ship` when you want a user to install once and forget about it.
+Choose `gjsify flatpak init` on top of it when you are submitting to Flathub,
+which wants the manifest and the AppStream files committed in your repository.
+Choose the one-line installer while you are still iterating and your users are
+early adopters. Choose dlx for a tool nobody wants permanently installed.
 
-**Looking for an AppImage?** There isn't one, and the nearest thing that exists
-is the Flatpak bundle above: one file, no repository, works offline.
-
-```bash
-gjsify ship --target flatpak
-flatpak install ./ship/out/org.example.MyApp-1.2.3-1.x86_64.flatpak
-```
-
-One thing to weigh before you promise a `.deb`: the dependency `gjsify ship`
-emits is `gjs (>= 1.86)`, and no released Debian satisfies that yet. Debian went
-from 1.82.3 in trixie straight to 1.88.1 in forky, skipping 1.84 and 1.86. Your
-package installs on forky, on sid, on Fedora and on anything else with a current
-GJS; on trixie apt will refuse it. `gjsify ship` prints this at package time, and
-[Choose the GJS floor](/gjsify/ship/linux-packages/#choose-the-gjs-floor) covers
-your options.
-
-## What ship covers today
-
-**Installable artifacts: Linux, macOS and Windows.** `.deb`, `.rpm` and a Flatpak
-bundle on Linux; a `<App>.app` bundle, a zip around it and a `.dmg` on macOS; a
-program directory, a zip and an `.msi` installer on Windows. All of them are
-assembled from this Linux workstation — the two that are not are the `.dmg`, which
-needs `hdiutil` on a Mac, and a signature, which needs the host holding the key.
-The build target is enforced rather than assumed:
-a project declaring anything but `gjsify.app: "gjs"` or `"node"` is refused with a
-message saying so, instead of producing a package that installs and then fails to
-start.
-
-**Staged layouts: all three.** `gjsify ship <os>` names which operating system's
-LAYOUT to assemble, and the payload is the same one either way — only the places
-differ:
-
-```bash
-gjsify ship                      # this host's layout; on Linux, deb + rpm
-gjsify ship darwin               # <App>.app + a zip, if the app is --app node
-gjsify ship darwin  --stage      # <App>.app/Contents/{MacOS,Resources,Frameworks}
-gjsify ship darwin --target macos-app-dmg   # a .dmg — needs a Mac, see below
-gjsify ship windows              # a program directory + a zip, if the app is --app node
-gjsify ship windows --stage      # app\, lib\, share\ and a .cmd launcher
-```
-
-The launcher each layout carries is that OS's — `/bin/sh` without `readlink -f`
-and without a `DYLD_*` inside a `.app`, a CRLF `.cmd` on Windows — and each execs
-the interpreter your bundle was BUILT for, `gjs -m` or `node`.
-
-**The macOS bundle is a real bundle.** `Contents/Info.plist` and
-`Contents/PkgInfo` are what make a directory ending in `.app` an application
-rather than a folder, and both are written from your `gjsify.ship` block: the app
-id becomes `CFBundleIdentifier`, the display name becomes the `.app` directory
-and `CFBundleName`, and the executable under `Contents/MacOS` is named by
-`CFBundleExecutable`. Your GSettings schemas are compiled into the bundle while
-it is assembled, because a `.app` has no install step to compile them and
-GSettings aborts on a schema directory that has only sources.
-
-**The Windows artifact is a program directory, not a bundle.** There is no
-metadata file in it: what a Windows installer says about an application lives in
-the `.msi`'s own tables. The `.cmd` at its root finds the directory from `%~dp0`,
-so the tree works unzipped anywhere and works again once an installer lays it into
-`C:\Program Files\<App>`. The ZIP carries a top level the staged tree does not —
-without it, unzipping would scatter `app\`, `share\` and a loose `.cmd` into
-whatever folder you were in.
-
-**And there is an installer around it.** `--target msi` wraps the same program
-directory in a Windows Installer package: it lands under `C:\Program Files\<App>`,
-adds one Start-Menu entry, and appears in Add/Remove Programs so a user can take it
-off again. Nothing about the payload changes — the installed tree is the same tree
-the zip expands to.
-
-```bash
-gjsify ship windows --target windows-dir,windows-dir-zip,msi
-```
-
-`msi` is opt-in rather than part of a bare `gjsify ship windows`, because it is the
-one format here that needs a tool: `msitools` on Linux (`sudo dnf install
-msitools`, `sudo apt install msitools`) or [WiX Toolset
-v3.14](https://github.com/wixtoolset/wix3/releases) on Windows. `ship` writes the
-installer's source document itself and lets whichever of those you have compile
-it, so you can build a Windows installer from a Linux workstation — or from
-Windows, without installing anything from the Linux side. Missing either one is a
-message naming the package, before your build runs.
-
-**Both artifacts carry their own runtime, and you say so in `package.json`.**
-An unzipped `.app` runs on a Mac with no Node and no Homebrew GTK, and an unzipped
-program directory runs on a Windows machine with no Node and no GTK at all — but
-only if the packages below are installed where you PACKAGE it. They are resolved by
-NAME at ship time, and none of them is an `optionalDependencies` edge on anything:
-whoever ships an app declares the runtime it ships, never the library that uses it.
-Put them in `devDependencies` — they are needed by the packaging host, not by your
-app at runtime:
-
-```jsonc
-{
-  "devDependencies": {
-    // The interpreter. `Contents/MacOS/node`, plus Node's own LICENSE.
-    "@gjsify/node-runtime-darwin-arm64": "^0.44.0",
-    "@gjsify/node-runtime-darwin-x64": "^0.44.0",
-    // The relocated GTK/GObject-Introspection closure, one per architecture.
-    "@gjsify/gtk-runtime-darwin-arm64": "^0.44.0",
-    "@gjsify/gtk-runtime-darwin-x64": "^0.44.0",
-    // Windows, if you ship there. `win32-x64` is the only target: gvsbuild
-    // publishes no arm64 GTK, so there is nothing to build a Windows/ARM
-    // runtime bundle out of.
-    "@gjsify/node-runtime-win32-x64": "^0.44.0",
-    "@gjsify/gtk-runtime-win32-x64": "^0.44.0"
-  },
-  "dependencies": {
-    // node-gi's JavaScript AND its `prebuilds/darwin-<arch>/node_gi.node`. A
-    // dependency rather than a devDependency, because a `--app node` bundle keeps
-    // `@gjsify/node-gi/*` external and `require`s it at runtime.
-    "@gjsify/node-gi": "^0.44.0"
-  }
-}
-```
-
-:::caution[The three `@gjsify/node-runtime-*` packages are not published yet]
-Measured against the registry on 2026-08-30, with `@gjsify/cli@0.44.0` as the control:
-all three `@gjsify/gtk-runtime-*` packages resolve at `0.44.0`, and all three
-`@gjsify/node-runtime-*` names answer **404**. Their first publish is a manual
-maintainer action — npm Trusted Publishing needs the package to exist before CI can
-publish to it — and it is queued, not forgotten.
-
-Until it lands, `npm install` fails on those three lines. Drop them, and the rest of
-the block still gets you a `.app` or a program directory that carries its own GTK
-closure and node-gi; what it will not carry is the interpreter, and `gjsify ship` says
-so on every stage rather than letting you find out. To get a complete artifact today,
-point `GJSIFY_NODE_RUNTIME` at a directory holding the binary — the repository's
-`packages/node-runtime/scripts/fetch-node-runtime.mjs` populates one from a pinned Node
-release and verifies its SHA-256 against the release's own `SHASUMS256.txt`.
-:::
-
-One architecture is enough if you only ship one — `gjsify ship darwin --arch x64`
-looks for the `darwin-x64` packages and nothing else, and `gjsify ship windows`
-looks for the `win32-x64` ones. `GJSIFY_NODE_RUNTIME` and
-`GJSIFY_GTK_RUNTIME` override the first two with a directory, for a maintainer
-holding an unpublished or patched build.
-
-`gjsify ship` names what it staged and what it did not, so an incomplete bundle is
-never a silent one:
-
-```
-[gjsify ship] carries its own interpreter from @gjsify/node-runtime-darwin-arm64
-[gjsify ship] carries its own GTK closure from @gjsify/gtk-runtime-darwin-arm64
-[gjsify ship] carries its own node-gi runtime (16 file(s)) from @gjsify/node-gi
-[gjsify ship] carries its own node-gi addon from @gjsify/node-gi
-```
-
-and, when a package is missing, the name to install instead. A bundle with no
-runtime still assembles — it is a working intermediate on any machine that has a
-Node — so nothing here fails your build; it tells you which artifact you got.
-
-**What it cannot do yet, and `gjsify ship` prints it rather than letting you find
-out:** macOS has GJS but no *relocatable* GJS, and Windows has no GJS host at
-all — which is why all four of those formats accept `gjsify.app: "node"` only, and
-why a `--app gjs` project can stage either layout and not pack it.
-
-One more thing to know before you hand a Windows build to a user: `node.exe` is a
-console program and the Node release ships no windowed variant, so starting the
-app from a shortcut leaves a console window open behind it — including the
-shortcut the `.msi` writes. Nothing here hides that; the artifact's own reader
-prints the subsystem it found.
-
-**Where each format can be packed is declared, and the command refuses rather
-than guessing.** `.deb` and `.rpm` are written by `ship` itself — plain
-JavaScript, no `dpkg-deb`, no `rpmbuild` — so those two really do pack
-anywhere, and `gjsify ship linux` on a Mac gets you a Linux package built on a
-Mac. The macOS `.app`, the Windows program directory and both zips are the same:
-`ship` writes the zips itself, so they pack anywhere too — which is also what keeps `zipinfo` an INDEPENDENT reader
-of them rather than the other half of a round trip. (Name the layout when you
-cross: a bare `gjsify ship` on a Mac assembles the macOS one, and says so.)
-Two formats are different and say so. A Flatpak bundle is an OSTree static
-delta, only `flatpak-builder` and `flatpak build-bundle` write one, and both are
-Linux tools. A `.dmg` is a UDIF image over a real HFS+ volume, and the only
-program that writes one is `hdiutil`, which ships with macOS and exists nowhere
-else. Ask for either on the wrong host and you get a refusal naming the
-two-phase way across, not a broken file:
-
-```bash
-gjsify ship linux --stage --target flatpak  # here, on any OS, offline
-gjsify ship --from-stage ./ship/stage \
-            --target flatpak                # there, on a Linux runner
-
-gjsify ship darwin --stage --target macos-app-dmg   # here, on any OS, offline
-gjsify ship --from-stage ./ship/stage \
-            --target macos-app-dmg                  # there, on a Mac
-```
-
-Name the format in the `--stage` run as well as in the pack run. The stage
-carries a licence overlay per format, rendered where your project is; a stage
-assembled without `macos-app-dmg` arrives on the Mac and is refused there, in a
-job that has no `LICENSE` to fix it with.
-
-Missing tooling is a separate message from the wrong OS, because the fixes
-differ, and both fire **before** your build script runs rather than after it.
-
-**Signing takes an identity, not a certificate.** `--sign <identity>` passes a
-NAME to `codesign` (macOS) or `signtool` (Windows) and lets the tool find the
-private key itself, so `gjsify ship` never sees a certificate: there is no
-`--certificate`, no `--p12` and no `--password`. Set a default in
-`gjsify.ship.sign.darwin.identity` / `.win32.identity`. Signing runs on the finish
-phase and on the host that holds the key:
-
-```bash
-gjsify ship darwin --stage --arch arm64    # here, on any OS, offline
-gjsify ship --from-stage ./ship/stage \
-            --sign "Developer ID Application: You (TEAMID)"   # there, on macOS
-```
-
-With no identity the run skips signing, says so on stderr, and exits 0 — an
-unsigned artifact is a legitimate output, and the thing that is refused is
-claiming a signature that was not made. On macOS the signature goes on every
-Mach-O image inside the payload, not on a wrapper around it: under a hardened
-runtime a Developer-ID-signed executable will not load ad-hoc-signed libraries,
-and the GTK closure a bundle carries is ad-hoc-signed when it arrives.
-
-`--sign -` signs ad-hoc, which needs no Apple Developer Program membership — it is
-how this project proves the whole pipeline in CI with no key anywhere.
-
-What is still missing is notarisation — every container the design named now
-exists. The two operating systems also differ in what an unsigned artifact costs
-you: Gatekeeper BLOCKS an
-unsigned `.app`, while SmartScreen only warns until a download builds reputation,
-so a Windows program directory is usable unsigned in a way the macOS bundle is
-not. See
-[Platform Support](/gjsify/platform-support/) for where gjsify apps run at all.
+There is no AppImage target. The nearest thing that exists is the Flatpak
+bundle, which is also one file, needs no repository and works offline.
 
 ## Next
 
-- [deb & rpm packages](/gjsify/ship/linux-packages/) walks through the
-  prerequisites, every flag, the staged tree and the configuration block.
+- [Linux packages](/gjsify/ship/linux-packages/), [macOS app bundles](/gjsify/ship/macos/)
+  and [Windows artifacts](/gjsify/ship/windows/) walk through one operating
+  system each.
+- [Sign your artifacts](/gjsify/ship/signing/) covers `--sign`, `--notarize`,
+  and why unsigned is a legitimate result.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) is the
-  terse version of the same material.
-- [How It Works](/gjsify/how-it-works/) explains what a `gjsify build` bundle
-  contains, which is what ends up inside the package.
+  terse flag and configuration reference.
+- [How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts) explains why
+  packing the same build twice gives byte-identical files.

--- a/website/src/content/docs/ship/linux-packages.md
+++ b/website/src/content/docs/ship/linux-packages.md
@@ -1,65 +1,32 @@
 ---
-title: deb & rpm packages
-description: "The practical guide to `gjsify ship`: prerequisites, every flag, what the staged payload looks like, how to install the result and how to pick the architecture."
+title: Linux packages
+description: "gjsify ship linux builds a .deb, an .rpm and a Flatpak bundle. What lands on disk, which dependencies are derived from your bundle, how to pick the architecture, and what to do when the build refuses."
 ---
 
-`gjsify ship` turns a built GJS app into a `.deb` and an `.rpm`. Run it in your
-project root:
+`gjsify ship linux` turns a built app into a `.deb` and an `.rpm`. Run it in
+your project root:
 
 ```bash
 gjsify ship
 ```
 
-It runs your `build` script, stages one payload, and packs that same payload
-into each format. Everything else on this page is about what it needs from you
-and what you can change.
+```text
+ship/out/my-app_1.2.3-1_all.deb
+ship/out/my-app-1.2.3-1.noarch.rpm
+```
 
-## Get your project ready
+A bare `gjsify ship` assembles the layout of the host you are on, so on a Linux
+machine those two are what you get. Name `linux` explicitly when you are
+packaging from a Mac or from Windows, which works: both packers are plain
+JavaScript and run anywhere.
 
-`gjsify ship` derives almost everything, but a few things it cannot guess.
-Check these before the first run:
+Nothing about gjsify needs to be on the user's machine. The package depends on
+the distribution's own `gjs` or `nodejs`, GTK and typelib packages, and
+`gjsify ship` works out which ones by reading your built bundle.
 
-| package.json | Needed for | Override |
-|---|---|---|
-| `name` | the package name and the `bin/` entry | `gjsify.ship.binaryName` |
-| `version` | `Version:` in both formats | `gjsify.ship.version` |
-| `license` (an SPDX id like `"MIT"`) | a required field in both formats | `gjsify.ship.license.project` |
-| `author` as `"Name <you@example.org>"` | `Maintainer:` / `Packager:`; dpkg refuses a package without one | `gjsify.ship.maintainer` |
-| `gjsify.main` (or `main`) | the bundle the launcher executes | `gjsify.ship.bundle` |
-| — | the human-readable display name: the `.desktop` `Name=`, the AppStream `<name>`, and the `<name>.app` directory a macOS layout is staged into | `gjsify.ship.name` (defaults to a title-cased `binaryName`) |
-| `scripts.build` | the build step that runs first | pass `--skip-build` instead |
-
-Your `version` is rewritten on the way in, because npm and dpkg disagree about
-what a prerelease is. A leading `v` is dropped, `+buildmetadata` is dropped with
-a warning, and `1.2.0-rc.1` becomes `1.2.0~rc.1`. That last one matters: both
-dpkg and rpm sort `1.2.0~rc.1` *before* `1.2.0`, the way npm does, while they
-read `1.2.0-rc.1` as release `rc.1` of version `1.2.0` and sort it *after*, so a
-prerelease published that way would never upgrade to the release. A version
-neither format can spell stops the run instead of being guessed at.
-
-You also need a reverse-DNS **app id**, because it names the desktop entry, the
-AppStream component and the installed icon. Set `gjsify.ship.appId`, or let it
-fall back to `gjsify.flatpak.appId` if you already ship a Flatpak. If your
-package name is itself reverse-DNS (`org.example.MyApp`), that is used.
-
-Two more things are picked up automatically when they follow the usual GNOME
-layout, and are worth having:
-
-- **Icons** from `data/icons/` or `data/icons/hicolor/`, or wherever
-  `gjsify.ship.icon` points (a single file or a directory). SVGs land in
-  `scalable`; for PNGs the size is read from a `128x128/` path component or from
-  a trailing number in the filename (`icon-128.png`). Without an icon your app
-  shows a placeholder in menus and app stores, and ship warns about it.
-- **GSettings schemas**: any `*.gschema.xml` under `data/`, or under
-  `gjsify.ship.schemas`. Every installed schema on the system shares one
-  directory, so each file's name has to start with your app id.
-
-A `LICENSE`, `LICENSE.md`, `LICENSE.txt`, `COPYING` or `COPYING.md` in the
-project root is found on its own and installed where each format expects it.
-
-Finally, your project has to build for GJS. If `gjsify.app` is set to anything
-other than `"gjs"`, ship refuses instead of producing a package that installs
-and then fails to start.
+Set up your `package.json` first. [Ship your app](/gjsify/ship/#what-ship-reads-from-your-packagejson)
+lists the fields all three operating systems share, and the two you have to set
+yourself.
 
 ## Build the packages
 
@@ -72,27 +39,27 @@ bundle, which is the quickest way to see whether the payload is what you think
 it is:
 
 ```text
-[gjsify ship] staged 6 file(s) in ship/stage/
+[gjsify ship] staged 7 file(s) for linux in ship/stage/
 [gjsify ship]   bin/my-app
 [gjsify ship]   lib/my-app/gjs.js
 [gjsify ship]   share/applications/org.example.MyApp.desktop
 [gjsify ship]   share/glib-2.0/schemas/org.example.MyApp.gschema.xml
 [gjsify ship]   share/icons/hicolor/scalable/apps/org.example.MyApp.svg
 [gjsify ship]   share/metainfo/org.example.MyApp.metainfo.xml
+[gjsify ship]   share/mime/packages/org.example.MyApp.xml
 [gjsify ship] gi namespaces: Adw-1, Gtk-4.0
-[gjsify ship] deb: ship/out/my-app_1.2.3-1_all.deb (2524 bytes)
-[gjsify ship] rpm: ship/out/my-app-1.2.3-1.noarch.rpm (5117 bytes)
+[gjsify ship] deb: ship/out/my-app_1.2.3-1_all.deb (2876 bytes)
+[gjsify ship] rpm: ship/out/my-app-1.2.3-1.noarch.rpm (5976 bytes)
 ```
 
 A real run prints more than this, and none of it is an error. Anything missing
-from the AppStream component (`gjsify.ship.developer`, `summary`, `description`,
-`license.project`, `homepageUrl`) is reported as a warning, because the package
-still installs and still runs; it is app *stores* that will object, which is a
-different day's problem. Fill them in before you submit anywhere. You will also
-see a warning about the GJS version this asks for on Debian; see
-[Choose the GJS floor](#choose-the-gjs-floor).
+from the AppStream component (`gjsify.ship.developer`, `summary`,
+`description`, `license.project`, `homepageUrl`) is a warning, because the
+package still installs and still runs. App stores are what will object. Fill
+those in before you submit anywhere. You will also see a warning about the GJS
+version this asks for on Debian; see [Choose the GJS floor](#choose-the-gjs-floor).
 
-Already built? Skip the build step:
+Already built? Skip the build step.
 
 ```bash
 gjsify ship --skip-build
@@ -105,13 +72,9 @@ gjsify ship --target deb     # one format
 gjsify ship --stage          # write ship/stage/ and stop
 ```
 
-The same payload also becomes a Flatpak — `gjsify ship --target flatpak`, opt-in
-because it is the only format that needs `flatpak-builder` on the packing host.
-That one is covered in [Ship your app](/gjsify/ship/#the-flatpak-target).
-
 ## Read the staged payload
 
-Everything lands under `ship/` (change it with `--out`):
+Everything lands under `ship/`, which `--out` moves.
 
 ```text
 ship/
@@ -127,27 +90,27 @@ ship/
     └── my-app-1.2.3-1.noarch.rpm
 ```
 
-`stage/` is the whole app: the launcher in `bin/`, your bundle in `lib/<name>/`,
-and the desktop entry, icon, AppStream metainfo and schemas in `share/`.
-`overlay/` holds what one format wants somewhere of its own, which today is the
-licence and nothing else. Debian policy puts it in `share/doc/<pkg>/copyright`,
-rewrapped as a machine-readable copyright file; RPM puts the plain text in
-`share/licenses/<pkg>/`. A project with no licence file gets no overlay at all.
+`stage/` is the whole app. The launcher in `bin/`, your bundle in
+`lib/<name>/`, and the desktop entry, icon, AppStream metainfo, MIME types and
+schemas in `share/`. `overlay/` holds what one format wants somewhere of its
+own, which today is the licence and nothing else. Debian policy puts it in
+`share/doc/<pkg>/copyright`, rewrapped as a machine-readable copyright file;
+RPM puts the plain text in `share/licenses/<pkg>/`. A project with no licence
+file gets no overlay at all.
 
 Both packers read `stage/` back off disk rather than keeping it in memory, so
-what you inspect is what a user installs. That also means `gjsify ship --stage`
-and a full run write the same `stage/` tree.
+what you inspect is what a user installs.
 
-Two details worth knowing:
+Two details worth knowing.
 
-**The whole bundle directory is staged.** `gjsify.main: "dist/gjs.js"` stages all
-of `dist/` into `lib/my-app/`. Keep build leftovers out of that directory, or
-point `gjsify.ship.bundle` at a clean one.
+**The whole bundle directory is staged.** `gjsify.main: "dist/gjs.js"` stages
+all of `dist/` into `lib/my-app/`. Keep build leftovers out of that directory,
+or point `gjsify.ship.bundle` at a clean one.
 
 **`bin/my-app` is a small shell launcher.** It works out its own install prefix
 from its own path, prepends `<prefix>/share` to `XDG_DATA_DIRS`, and then execs
-`gjs -m` on your bundle. Because no path is baked in, the same payload works
-installed under `/usr`, under `/app`, or anywhere else.
+`gjs -m` or `node` on your bundle. Because no path is baked in, the same
+payload works installed under `/usr`, under `/app`, or anywhere else.
 
 ## Install and check the result
 
@@ -157,12 +120,12 @@ sudo apt install ./ship/out/my-app_1.2.3-1_all.deb        # Debian, Ubuntu
 ```
 
 Then run `my-app`, or find it in your application menu. Uninstalling is
-`dnf remove my-app` / `apt remove my-app`, and the package refreshes the desktop
-database, the icon cache and the compiled GSettings schemas on the way in and
-out.
+`dnf remove my-app` or `apt remove my-app`, and the package refreshes the
+desktop database, the icon cache, the MIME database and the compiled GSettings
+schemas on the way in and out.
 
-Before publishing, it is worth reading the artifact back with the distro's own
-tools rather than trusting the packer:
+Before publishing, read the artifact back with the distribution's own tools
+rather than trusting the packer:
 
 ```bash
 rpm -qp --info     ship/out/my-app-1.2.3-1.noarch.rpm   # name, version, licence, summary
@@ -173,7 +136,7 @@ ar t               ship/out/my-app_1.2.3-1_all.deb      # the three .deb members
 ```
 
 For the app in the output above, `rpm -qp --requires` lists these first, ahead
-of the `/bin/sh` its scriptlets need and rpm's own `rpmlib` internals:
+of the `/bin/sh` its scriptlets need and rpm's own internals:
 
 ```text
 gjs >= 1.86
@@ -183,37 +146,113 @@ hicolor-icon-theme
 glib2
 ```
 
-None of that was configured. The GTK and libadwaita entries come from the
-`gi://` imports in the built bundle, `hicolor-icon-theme` because this is a GUI
-app rather than a `kind: "cli"` tool, and `glib2` (`libglib2.0-bin` on Debian)
+You configured none of it. The GTK and libadwaita entries come from the `gi://`
+imports in the built bundle, `hicolor-icon-theme` because this is a GUI app
+rather than a `kind: "cli"` tool, and `glib2` (`libglib2.0-bin` on Debian)
 because the payload installs a GSettings schema that has to be compiled at
 install time.
 
-### Build it reproducibly
+Packing the same build twice gives byte-identical artifacts, which
+[How It Works](/gjsify/how-it-works/#reproducible-ship-artifacts) explains.
 
-Packing the same build twice gives byte-identical artifacts. Timestamps come
-from your bundle's mtime, or from `SOURCE_DATE_EPOCH` when that is set, which is
-what makes two different checkouts of the same source produce identical bytes:
+## Translate the menu entry and the store listing
 
-```bash
-SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) gjsify ship
+Point `gjsify.ship.localeDir` at a directory of compiled gettext catalogues in
+`<lang>/LC_MESSAGES/<domain>.mo` layout, and `gjsify ship` folds them into the
+generated freedesktop metadata:
+
+```jsonc
+"gjsify": { "ship": { "localeDir": "dist/locale" } }
 ```
 
-This holds per JS runtime. The payload is gzipped through the Web
-`CompressionStream`, whose output is implementation-defined, so an artifact
-built under Node and one built under GJS need not match each other byte for
-byte.
+```text
+[Desktop Entry]
+Name[de]=Versand-Demo
+Name=My App
+Comment[de]=Beweist, dass gjsify ship funktioniert
+Comment=Prove that gjsify ship works
+```
+
+The AppStream component gets the matching `xml:lang` attributes. Both files stay
+valid without the translations, and `desktop-file-validate` and
+`appstreamcli validate` pass an untranslated file, so nothing else would have
+told you they were missing.
+
+`.po` sources are refused, because `bindtextdomain` reads `.mo` only. Compile
+them first with [`gjsify gettext`](/gjsify/cli-reference/#gjsify-gettext). The
+catalogues are staged into `share/locale/` and the launcher exports
+`GJSIFY_LOCALE_DIR`.
+
+## The Flatpak bundle
+
+The same payload also becomes a single-file Flatpak.
+
+```bash
+gjsify ship --target flatpak
+flatpak install ./ship/out/org.example.MyApp-1.2.3-1.x86_64.flatpak
+```
+
+It is not in the default set, because it is the one Linux format that needs
+tooling on your machine. Install `flatpak-builder` and `flatpak` first, on
+Fedora with `sudo dnf install flatpak flatpak-builder` and on Debian or Ubuntu
+with `sudo apt install flatpak flatpak-builder`. A missing tool is a message
+naming the package, before your build script runs.
+
+The payload does not change. Ship stages one prefix-relative tree and the
+launcher works out its own prefix at run time, so the same tree is `/usr` in a
+`.deb` and `/app` in a Flatpak. That is why the generated Flatpak module is
+three shell commands with no build system in it:
+
+```json
+{
+  "name": "my-app",
+  "buildsystem": "simple",
+  "build-commands": ["mkdir -p /app", "cp -a stage/. /app/", "cp -a overlay/. /app/"]
+}
+```
+
+The runtime and the sandbox permissions are the only things left to configure,
+and every one has a default:
+
+```jsonc
+"gjsify": {
+  "ship": {
+    "appId": "org.example.MyApp",
+    "flatpak": {
+      "runtime": "gnome",
+      "runtimeVersion": "50",
+      "branch": "stable",
+      "finishArgs": ["--device=dri", "--share=ipc", "--socket=fallback-x11", "--socket=wayland"]
+    }
+  }
+}
+```
+
+`finishArgs` defaults to that GUI set for an app and to nothing at all for a
+`kind: "cli"` tool. The app id names the exported ref, which is why the artifact
+is `org.example.MyApp-1.2.3-1.x86_64.flatpak`.
+
+An existing `gjsify.flatpak` block keeps working. `runtime`, `runtimeVersion`,
+`sdkExtensions`, `appendPath`, `finishArgs` and `cleanup` are read from there
+too, and ship prints one line naming the keys it inherited and where to move
+them. Moving them is safe, because `gjsify flatpak init` and `flatpak ci` read
+the new spelling as well. The app metadata (`name`, `summary`, `developer`,
+`categories`, `license`) is not deprecated. Both blocks describe the same
+application, and either may carry it.
+
+For a Flathub submission you want [`gjsify flatpak init`](/gjsify/guides/flatpak-app/)
+instead, which commits the manifest and the AppStream files to your repository.
 
 ## Pick the architecture
 
-You usually do not have to. `gjsify ship` looks at the bytes in the payload: if
-nothing in it is a native binary, the package is `Architecture: all` (deb) and
-`BuildArch: noarch` (rpm). A bundle of pure JavaScript really does install
-everywhere, and claiming `amd64` would make apt refuse it on an arm64 machine it
-runs on perfectly.
+You usually do not have to. `gjsify ship` looks at the bytes in the payload. If
+nothing in it is a native binary, the package is `Architecture: all` on deb and
+`BuildArch: noarch` on rpm. A bundle of pure JavaScript really does install
+everywhere, and claiming `amd64` would make apt refuse it on an arm64 machine
+it runs on perfectly.
 
 As soon as the payload carries a `.so`, a `.node` or any other native binary,
-the package is labelled for one architecture: this host by default, or whatever
+the package is labelled for one architecture. This host by default, or whatever
 `--arch` says.
 
 ```bash
@@ -232,22 +271,25 @@ gjsify ship --arch arm64
 | `ppc64` | `ppc64el` | `ppc64le` |
 | `s390x` | `s390x` | `s390x` |
 
-It labels the artifact; it does not cross-build the payload. Use it when you
-have already produced a payload for that architecture, typically from a CI job
-running on that machine.
+It labels the artifact and cross-builds nothing. Use it when you have already
+produced a payload for that architecture, typically from a CI job running on
+that machine.
 
 ## Look up a flag
 
 | Flag | Default | What it does |
 |---|---|---|
-| `--target <fmt..>` | `gjsify.ship.targets`, else `deb,rpm` | Formats to build. Comma-separated or repeated. An unknown name fails before anything is built, and so does a format belonging to another OS's layout — `gjsify ship darwin --target deb` is an error. `gjsify.ship.targets` is treated differently on purpose: it is a project default, so a name that wraps another layout is dropped with a printed note rather than failing the run. |
+| `--target <fmt..>` | `gjsify.ship.targets`, else `deb,rpm` | Formats to build. Comma-separated or repeated. An unknown name fails before anything is built, and so does a format belonging to another operating system's layout. |
 | `--out <dir>` | `gjsify.ship.outDir`, else `ship` | Output root, relative to the project. |
 | `--stage` | `false` | Write the staged payload and stop, packing nothing. |
-| `--from-stage <dir>` | — | Pack a payload an earlier `--stage` run wrote. Needs no project: no `package.json`, no config, no built bundle. |
-| `--expect-target <os>-<arch>` | — | With `--from-stage`: refuse a stage assembled for a different matrix leg. Compares against what the stage recorded, not against this host. |
+| `--from-stage <dir>` | none | Pack a payload an earlier `--stage` run wrote. Needs no project. |
+| `--expect-target <os>-<arch>` | none | With `--from-stage`, refuse a stage assembled for a different matrix leg. |
 | `--skip-build` | `false` | Package what is already built instead of running the project's `build` script. |
 | `--arch <arch>` | this host | Target architecture in `process.arch` spelling. |
-| `--verbose` | `false` | Print each staged file and the GI namespaces the bundle imports. |
+| `--verbose` | `false` | Print each staged file, the GI namespaces the bundle imports, and every tool a packer runs. |
+
+`--sign` and `--notarize` belong to the macOS and Windows layouts. See
+[Sign your artifacts](/gjsify/ship/signing/).
 
 ## Add a typelib ship does not know
 
@@ -258,11 +300,11 @@ a namespace the built-in table has never heard of, the build stops and names it:
 
 ```text
 gjsify ship: the bundle imports gi://Nautilus, and no deb package is known to
-ship that typelib. [...] Fill the gap in package.json: [...]
+ship that typelib.
 ```
 
-That is deliberate. A missing runtime dependency does not fail at package time;
-it fails on a user's machine, after the download, and reads like a bug in your
+That is deliberate. A missing runtime dependency does not fail at package time.
+It fails on a user's machine, after the download, and reads like a bug in your
 app. Add the row yourself:
 
 ```jsonc
@@ -275,19 +317,20 @@ app. Add the row yourself:
 }
 ```
 
-If you find a mapping that others will need too, a pull request adding it to
-gjsify's own table saves the next person the same detour.
+A mapping others will need too is worth a pull request against gjsify's own
+table, which saves the next person the same detour.
 
-`gjsify.ship.depends` is a different key for a different job: it appends
-dependencies that are not typelibs at all (`dconf`, a helper binary, a font).
-It does not silence the failure above.
+`gjsify.ship.depends` is a different key for a different job. It appends
+dependencies that are not typelibs at all (`dconf`, a helper binary, a font),
+and it does not silence the failure above.
 
 ## Choose the GJS floor
 
-The emitted dependency is `gjs (>= 1.86)`, which is the GJS the bundler targets.
-**No released Debian satisfies it.** Debian went from 1.82.3 in trixie straight
-to 1.88.1 in forky, skipping 1.84 and 1.86, so apt on trixie will refuse your
-`.deb`. Fedora, forky, sid and current rolling distributions are fine.
+The emitted dependency is `gjs (>= 1.86)`, which is the GJS the bundler
+targets. **No released Debian satisfies it.** Debian went from 1.82.3 in trixie
+straight to 1.88.1 in forky, skipping 1.84 and 1.86, so apt on trixie will
+refuse your `.deb`. Fedora, forky, sid and current rolling distributions are
+fine.
 
 `gjsify ship` prints this rather than quietly lowering the number, because a
 package apt refuses is a better outcome than one that installs and then dies on
@@ -299,64 +342,53 @@ If your bundle genuinely runs on an older GJS, say so:
 "gjsify": { "ship": { "minGjsVersion": "1.82.3" } }
 ```
 
-Test it on that version before you do. Lowering the floor to make apt happy,
-without checking, is how you turn a clean refusal into a crash on first launch.
+Test it on that version before you do. Lowering the floor to make apt happy
+without checking is how you turn a clean refusal into a crash on first launch.
 
-## Choose the Node floor — only for `--app node`
+## Choose the Node floor, for `--app node` only
 
 A `--app gjs` package declares no Node dependency at all, and this section does
-not apply to it. A **`--app node`** bundle needs an interpreter, and on Linux it
-is depended on rather than shipped:
+not apply to it. A `--app node` bundle needs an interpreter, and on Linux it is
+depended on rather than shipped:
 
-```
+```text
 Depends: nodejs (>= 24)          # deb
 Requires: nodejs(engine) >= 24   # rpm
 ```
 
-`gjsify ship` picks the interpreter from `gjsify.app` — the same field your build
-already uses — and the launcher it writes execs that one and no other. A package
-therefore declares exactly one interpreter, and `gjsify ship` refuses to build one
-whose launcher and dependency disagree.
+`gjsify ship` picks the interpreter from `gjsify.app`, the same field your build
+already uses, and the launcher it writes execs that one and no other. A package
+therefore declares exactly one interpreter, and ship refuses to build one whose
+launcher and dependency disagree.
 
-**The two names are not interchangeable, and getting rpm's wrong fails
-silently.** `Requires: nodejs >= 24` is a no-op on Fedora: the virtual `nodejs`
-Provide carries Epoch 1, so a bare `>= 24` desugars to `0:24` and is satisfied by
-`1:22.23.1`. Measured with `dnf repoquery` on Fedora 44 — `--whatprovides 'nodejs
->= 24'` answers **nodejs22**, while `--whatprovides 'nodejs(engine) >= 24'`
-answers nodejs24. `gjsify ship` emits the correct spelling for you; the reason is
-written down here because a hand-written spec file will get it wrong.
+The `>= 24` default excludes every current Debian stable and Ubuntu LTS:
 
-The `>= 24` default excludes **every current DEB stable and LTS**:
-
-| suite | Node |
+| Suite | Node |
 | --- | --- |
 | Debian 13 trixie (stable) | 20 |
 | Debian 14 forky (testing) | 24 |
 | Ubuntu 24.04 LTS | 18 |
 | Ubuntu 26.04 LTS | 22 |
-| Fedora 43 / 44 / 45 | 22 by default, 24 installable from the base repo |
+| Fedora 43, 44, 45 | 22 by default, 24 installable from the base repo |
 
-`gjsify ship` prints that rather than lowering the number quietly. If your bundle
-genuinely runs on an older Node, say so — and test it there first:
+`gjsify ship` prints that rather than lowering the number quietly. If your
+bundle genuinely runs on an older Node, say so, and test it there first:
 
 ```jsonc
 "gjsify": { "ship": { "minNodeVersion": "20" } }
 ```
 
-⚠️ **A satisfied `Requires:` is not the same as Node 24 on `PATH`.** Fedora's
+**A satisfied `Requires:` is not the same as Node 24 on `PATH`.** Fedora's
 streams are parallel-installable and `/usr/bin/node` is an alternatives symlink
-owned by whichever `nodejs<stream>-bin` package is installed — so
-`nodejs22-bin` plus `nodejs(engine) >= 24` is a perfectly valid state in which
-`node` is still 22. Measured with `dnf install --assumeno` on Fedora 44. No
-dependency any packager can emit closes that; an app that truly requires 24 has to
-check `process.versions.node` at startup and say so.
+owned by whichever `nodejs<stream>-bin` package is installed, so `nodejs22-bin`
+plus `nodejs(engine) >= 24` is a valid state in which `node` is still 22.
+Measured with `dnf install --assumeno` on Fedora 44. No dependency any packager
+can emit closes that. An app that truly requires 24 has to check
+`process.versions.node` at startup and say so.
 
 macOS and Windows have no system Node to depend on, so an artifact for those
-carries its own interpreter from `@gjsify/node-runtime-<target>`. You declare that
-package yourself, as a `devDependency`: it is resolved **by name** out of your own
-`node_modules` at ship time, and what gjsify does not add is an
-`optionalDependencies` edge, not the declaration. See [Ship](/gjsify/ship/) for the
-list and for the note that those three names are not published yet.
+carries its own. See [macOS app bundles](/gjsify/ship/macos/) and
+[Windows artifacts](/gjsify/ship/windows/).
 
 ## Configure it in package.json
 
@@ -378,6 +410,10 @@ already ships a Flatpak often needs no `gjsify.ship` block at all.
     "categories": ["Utility"],             // also decides deb Section: and rpm Group:
     "release": "1",                        // package revision within one app version
     "minGjsVersion": "1.86",
+    "localeDir": "dist/locale",            // compiled .mo catalogues
+    "mimeTypes": [                         // shared-mime-info types your app opens
+      { "type": "application/x-my-app", "comment": "My App document", "globs": ["*.myapp"] }
+    ],
     "depends": { "rpm": ["dconf"] },       // appended to the derived set
     "extraFiles": {                        // prefix-relative destination: project-relative source
       "share/my-app/data.json": "assets/data.json"
@@ -387,7 +423,7 @@ already ships a Flatpak often needs no `gjsify.ship` block at all.
 }
 ```
 
-`kind: "cli"` is the one switch that changes the shape of the payload: a console
+`kind: "cli"` is the one switch that changes the shape of the payload. A console
 AppStream component, no `.desktop` entry, and no icon requirement.
 
 ## Fix a failed run
@@ -397,24 +433,26 @@ to set. The ones you are most likely to meet:
 
 | Message says | Fix |
 |---|---|
-| no version / licence / maintainer | add `version`, `license`, `author` to package.json |
+| no version, licence or maintainer | add `version`, `license`, `author` to package.json |
 | not a usable package version | set `gjsify.ship.version` to something starting with a digit, using only letters, digits, `.`, `+` and `~` |
 | no application id | set `gjsify.ship.appId` to a reverse-DNS id |
-| no bundle to ship | nothing declares one: point `gjsify.main` (or `main`) at the built bundle |
-| the bundle … does not exist | it is declared but not built: run the build, or drop `--skip-build` |
+| no bundle to ship | point `gjsify.main` (or `main`) at the built bundle |
+| the bundle does not exist | it is declared but not built, so run the build or drop `--skip-build` |
 | no `build` script to run | add one, or pass `--skip-build` |
 | a schema must be named after the app id | rename it to `<app-id>.gschema.xml` |
 | cannot tell what size an icon is | use an SVG, a `128x128/` directory, or `icon-128.png` |
 | a file in the bundle directory is a symlink | replace it with the real file; the payload has to stand alone |
 | no package is known to ship a typelib | see [Add a typelib ship does not know](#add-a-typelib-ship-does-not-know) |
-| a `<fmt>` artifact is packed on … and this host is … | that format is host-bound: `--stage` here, `--from-stage` on the host it names |
-| packing a `<fmt>` needs … not on PATH | install the named tool, or drop that target — `deb` and `rpm` need none |
+| a `<fmt>` artifact is packed on … and this host is … | that format is host-bound, so `--stage` here and `--from-stage` there |
+| packing a `<fmt>` needs … not on PATH | install the named tool, or drop that target; `deb` and `rpm` need none |
 
 ## Where to next
 
-- [Ship your app](/gjsify/ship/) compares this with Flatpak, the one-line
-  installer, self-executing bundles and dlx.
+- [Ship your app](/gjsify/ship/) compares this with the one-line installer,
+  self-executing bundles and dlx.
+- [macOS app bundles](/gjsify/ship/macos/) and [Windows artifacts](/gjsify/ship/windows/)
+  cover the other two operating systems.
 - [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) is the
-  condensed flag and config reference.
+  condensed flag and configuration reference.
 - [Flatpak: GUI app](/gjsify/guides/flatpak-app/) if you also want a Flathub
   listing. It reads the same metadata fields, so nothing is duplicated.

--- a/website/src/content/docs/ship/macos.md
+++ b/website/src/content/docs/ship/macos.md
@@ -1,0 +1,224 @@
+---
+title: macOS app bundles
+description: "gjsify ship darwin builds a macOS .app that carries its own Node and GTK, a zip around it, and a .dmg. What lands on disk, what your package.json declares, and which host can produce which format."
+---
+
+`gjsify ship darwin` turns a built app into a macOS application bundle and a zip
+around it. Both assemble on any operating system, so a Linux or Windows
+workstation can produce them. Only the `.dmg` needs a Mac.
+
+```bash
+gjsify ship darwin --arch arm64
+```
+
+```text
+ship/out/My App.app
+ship/out/my-app-1.2.3-1.arm64.zip
+```
+
+The `.app` is the artifact a user drags into `/Applications`. The zip is the
+artifact a user downloads, so it carries the version and the architecture in its
+filename and avoids the spaces a display name may contain.
+
+`--arch` takes `x64` or `arm64` and defaults to the architecture of the host you
+run it on. It labels the artifact and picks which runtime packages are staged.
+It does not cross-compile your payload, so pass the architecture your bundle was
+built for.
+
+## Your project has to be a Node project
+
+Set `gjsify.app` to `"node"`. A `--app gjs` project can stage the darwin layout
+and cannot pack it:
+
+```text
+gjsify ship: macos-app and macos-app-zip wrap the darwin layout, and neither can
+run this project …
+```
+
+macOS does ship GJS through Homebrew, and that is a fact about a developer's
+machine rather than about a `.app` a stranger downloads. There is no relocatable
+GJS to put inside a bundle, so a downloadable macOS artifact runs on Node.
+
+## What your package.json declares
+
+The bundle carries its own interpreter and its own GTK closure. Both are
+resolved by name out of your `node_modules` when you run `gjsify ship`, so they
+have to be installed on the machine that packages the app, not on the machine
+that runs it.
+
+```jsonc
+{
+  "devDependencies": {
+    // The Node interpreter, plus Node's own LICENSE.
+    "@gjsify/node-runtime-darwin-arm64": "^0.44.0",
+    "@gjsify/node-runtime-darwin-x64": "^0.44.0",
+    // The relocated GTK and GObject-Introspection closure, one per architecture.
+    "@gjsify/gtk-runtime-darwin-arm64": "^0.44.0",
+    "@gjsify/gtk-runtime-darwin-x64": "^0.44.0"
+  },
+  "dependencies": {
+    // node-gi's JavaScript and its prebuilt addon. A dependency rather than a
+    // devDependency, because a --app node bundle keeps `@gjsify/node-gi/*`
+    // external and requires it at run time.
+    "@gjsify/node-gi": "^0.44.0"
+  }
+}
+```
+
+Ship one architecture and you need only its two packages. `--arch arm64` looks
+for the `darwin-arm64` pair and nothing else.
+
+An interpreter package is large. `@gjsify/node-runtime-darwin-arm64` unpacks to
+122 MB and its x64 sibling to 124 MB, because each one is a whole Node build.
+Install only the architecture you ship.
+
+`gjsify ship` names what it staged and what it did not, one line each:
+
+```text
+[gjsify ship] carries its own interpreter from @gjsify/node-runtime-darwin-arm64
+[gjsify ship] carries its own GTK closure from @gjsify/gtk-runtime-darwin-arm64
+[gjsify ship] carries its own node-gi runtime (16 file(s)) from @gjsify/node-gi
+[gjsify ship] carries its own node-gi addon from @gjsify/node-gi
+```
+
+When a package is missing you get the name to install instead, and the run still
+produces a bundle. That bundle works on any machine that already has Node, which
+is a useful intermediate and not something to hand to a user.
+
+Two environment variables override the lookups, for a maintainer holding an
+unpublished or patched build. `GJSIFY_NODE_RUNTIME` names a directory holding
+`node` and its `LICENSE`. `GJSIFY_GTK_RUNTIME` names one holding `lib/` and
+`girepository-1.0/`.
+
+## What lands inside the bundle
+
+```text
+My App.app/
+├── Contents/Info.plist           what makes this an application
+├── Contents/PkgInfo
+├── Contents/MacOS/my-app         the launcher
+├── Contents/MacOS/node           the carried interpreter
+├── Contents/Frameworks/node-gi/  the GTK closure and the node-gi addon
+└── Contents/Resources/
+    ├── lib/                      your built bundle
+    └── share/                    icon, metainfo, schemas, licences
+```
+
+`Contents/Info.plist` and `Contents/PkgInfo` are what make a directory ending in
+`.app` an application rather than a folder. Ship writes both from your
+`gjsify.ship` block. The app id becomes `CFBundleIdentifier`, the display name
+becomes the `.app` directory name and `CFBundleName`, `gjsify.ship.binaryName`
+becomes `CFBundleExecutable`, and your version becomes
+`CFBundleShortVersionString` with `version-release` in `CFBundleVersion`.
+
+The launcher walks up from `Contents/MacOS` to find the bundle, so the `.app`
+works wherever it sits. `/Applications` is a convention, not a path it needs.
+
+Your GSettings schemas are compiled into the bundle while it is assembled, which
+is why the darwin formats need `glib-compile-schemas` on the packaging host. A
+`.app` has no install step to compile them later, and GSettings aborts on a
+schema directory that holds only sources.
+
+Some of what a Linux package relies on its install step for has no macOS
+equivalent. The `.desktop` entry, the AppStream component and the shared MIME
+type document are carried and never read, because macOS reads none of them.
+`gjsify ship` lists every such file on each run, so the payload holds no
+surprise.
+
+**Your icon does not become the bundle icon.** The `Info.plist` carries no
+`CFBundleIconFile`, so the Finder and the Dock show the generic application
+icon. Your icon is still staged under `Contents/Resources/share/icons/`, where
+GTK finds it for in-app use.
+
+## Make a .dmg
+
+A `.dmg` is a UDIF image over a real HFS+ volume, and the only program that
+writes one is `hdiutil`, which ships with macOS and exists nowhere else. Ask for
+it anywhere else and you get a refusal naming the way across:
+
+```text
+gjsify ship: a macos-app-dmg artifact is packed on darwin and this host is linux …
+```
+
+So assemble on whichever machine you develop on and finish on a Mac. Name the
+format in both runs, because phase one renders one licence overlay per format:
+
+```bash
+# anywhere, offline
+gjsify ship darwin --stage --arch arm64 \
+  --target macos-app,macos-app-zip,macos-app-dmg
+
+# on a Mac, with ship/stage/ copied across
+gjsify ship --from-stage ./stage --target macos-app-dmg
+```
+
+The result is `my-app-1.2.3-1.arm64.dmg`, a volume named after your display
+name, holding the same `.app` the other two formats wrap.
+
+The image has no `/Applications` symlink, so a user drags the app out of the
+mounted volume to wherever they want it instead of onto an arrow.
+
+## Sign it, or say you did not
+
+Gatekeeper blocks an unsigned `.app` on a stranger's Mac. `--sign` runs on the
+finish phase, on the host that holds the key:
+
+```bash
+gjsify ship --from-stage ./stage \
+            --sign "Developer ID Application: You (TEAMID)"
+```
+
+With no identity the run skips signing, prints why, and exits 0. See
+[Sign your artifacts](/gjsify/ship/signing/) for what `--sign` takes, what
+`--notarize` does, and why unsigned is a legitimate result.
+
+## A worked example
+
+A project on any operating system, producing a signed arm64 bundle, a zip and a
+`.dmg`. Steps 1 and 2 run on a Linux or Windows workstation. Step 3 runs on a
+Mac that holds the Developer ID.
+
+```bash
+# 1. Declare the runtime, on the packaging host.
+npm install --save-dev @gjsify/node-runtime-darwin-arm64 \
+                       @gjsify/gtk-runtime-darwin-arm64
+npm install --save @gjsify/node-gi
+
+# 2. Assemble every darwin format you intend to pack.
+gjsify ship darwin --stage --arch arm64 \
+  --target macos-app,macos-app-zip,macos-app-dmg --verbose
+
+# 3. On a Mac, with ship/stage/ copied across.
+gjsify ship --from-stage ./stage \
+            --expect-target darwin-arm64 \
+            --sign "Developer ID Application: You (TEAMID)"
+```
+
+Add `--notarize <keychain-profile>` to step 3 once you have stored an Apple
+credential with `notarytool store-credentials`. Read
+[Sign your artifacts](/gjsify/ship/signing/#notarisation) first, because that
+flag has never been run against a real Apple account.
+
+Read step 2's output. The four `carries its own …` lines are what tell you the
+bundle will start on a Mac with neither Node nor Homebrew GTK installed.
+
+## Fix a failed run
+
+| Message says | Fix |
+|---|---|
+| `macos-app and macos-app-zip … neither can run this project` | set `gjsify.app` to `"node"` and rebuild the bundle for Node |
+| `a macos-app-dmg artifact is packed on darwin and this host is …` | `--stage` here, `--from-stage` on a Mac |
+| `packing a macos-app on … needs glib-compile-schemas` | Fedora `sudo dnf install glib2`, Debian or Ubuntu `sudo apt install libglib2.0-bin` |
+| `this stage was assembled for …, and --target names …` | re-run the `--stage` command with every format named |
+| `no bundled interpreter`, naming `@gjsify/node-runtime-darwin-<arch>` | install it, or set `GJSIFY_NODE_RUNTIME` |
+| `signing the darwin layout needs codesign` | sign on the finish phase, on a Mac |
+
+## Where to next
+
+- [Ship your app](/gjsify/ship/) has the shared `package.json` fields and the
+  table of which host packs which format.
+- [Sign your artifacts](/gjsify/ship/signing/) covers `--sign` and `--notarize`.
+- [Windows artifacts](/gjsify/ship/windows/) is the same shape one operating
+  system over.
+- [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists
+  every flag and configuration key.

--- a/website/src/content/docs/ship/signing.md
+++ b/website/src/content/docs/ship/signing.md
@@ -1,0 +1,172 @@
+---
+title: Sign your artifacts
+description: "--sign takes an identity, never a certificate. What codesign and signtool are handed, what happens with no identity, what --notarize submits, and why an unsigned artifact is a legitimate result."
+---
+
+macOS and Windows both treat a downloaded application differently once it
+carries a signature. `gjsify ship` can make one, on the host that holds the key.
+
+```bash
+gjsify ship --from-stage ./stage --sign "Developer ID Application: You (TEAMID)"
+```
+
+Linux is not part of this. A `.deb` and an `.rpm` carry no per-file signature.
+The artifact is signed as a whole by the repository that serves it, with
+`debsigs` or `rpmsign` and that repository's key. `--sign` on the Linux layout
+is refused rather than doing nothing.
+
+## `--sign` takes an identity, not a certificate
+
+The flag takes a NAME. `codesign` and `signtool` are both handed a string and
+look the private key up themselves, so `gjsify ship` is never given a secret and
+there is nothing to redact from a build log. There is no `--certificate`, no
+`--p12` and no `--password`.
+
+| | macOS | Windows |
+|---|---|---|
+| Tool | `codesign` | `signtool` |
+| What `--sign` names | a Developer ID name or a SHA-1 fingerprint | a certificate subject name in a store |
+| What gets signed | every Mach-O image in the payload | every PE image in the payload |
+| Runs on | macOS | Windows |
+| Project default | `gjsify.ship.sign.darwin.identity` | `gjsify.ship.sign.win32.identity` |
+
+Getting a key into a keychain or a certificate store is the signing host's job.
+That is a machine setup or a CI step, not something this command does.
+
+Set a project default so nobody has to remember the string:
+
+```jsonc
+"gjsify": {
+  "ship": {
+    "sign": {
+      "darwin": { "identity": "Developer ID Application: You (TEAMID)" },
+      "win32": { "identity": "Your Company Ltd" }
+    }
+  }
+}
+```
+
+`linux` is not a valid key there and is refused.
+
+## Unsigned is a legitimate result
+
+With no identity the run skips signing, prints why on stderr, and exits 0:
+
+```text
+[gjsify ship] no identity was given — skipping codesign. An unsigned artifact is
+the default path and a legitimate deliverable (ADR 0024 § A13). Pass
+`--sign <identity>` or set `gjsify.ship.sign.darwin.identity` to sign; `--sign -`
+signs ad-hoc and needs no developer identity.
+```
+
+What is refused is the other direction. Nothing here claims a signature that was
+not made, and a signing step that fails stops the run before anything is packed,
+because a half-signed artifact installs and is refused at first launch.
+
+What unsigned costs you differs by operating system. Gatekeeper blocks an
+unsigned `.app` on a stranger's Mac. SmartScreen only warns about an unsigned
+Windows download until it builds reputation, so a Windows program directory is
+usable unsigned in a way the macOS bundle is not.
+
+## Sign ad-hoc with no developer account
+
+`--sign -` signs ad-hoc on macOS. It needs no Apple Developer Program
+membership, and it is how the gjsify project proves this pipeline in CI with no
+key anywhere.
+
+```bash
+gjsify ship --from-stage ./stage --sign -
+```
+
+An ad-hoc signature does not satisfy Gatekeeper on someone else's machine. It
+proves the pipeline, not the provenance.
+
+Windows has no ad-hoc mode. `signtool` needs a real certificate.
+
+## Signing runs on the finish phase
+
+`--sign` on a `--stage` run is refused. That phase produces no artifact, and a
+signature over the tree it writes would be invalidated by the packer reading it
+back:
+
+```text
+gjsify ship: --sign belongs to the finish phase, and --stage produces no
+artifact to sign …
+```
+
+Signing also needs the host that has the tool, which is the same host that has
+the key:
+
+```text
+gjsify ship: signing the darwin layout needs codesign, which runs on darwin and
+this host is linux.
+```
+
+So the split is the same one the `.dmg` and the `.msi` use:
+
+```bash
+gjsify ship darwin --stage --arch arm64      # anywhere, offline
+# move ship/stage/ to a Mac, then:
+gjsify ship --from-stage ./stage \
+            --sign "Developer ID Application: You (TEAMID)"
+```
+
+The staged tree is never written to, so a `--from-stage --sign` run can be
+repeated.
+
+## What the signature covers, and what it does not
+
+The signature goes on every image inside the payload rather than on a wrapper
+around it. Under a hardened runtime a Developer-ID-signed executable will not
+load ad-hoc-signed libraries, and the GTK closure a macOS bundle carries arrives
+ad-hoc-signed. So `gjsify ship` re-signs the images and builds the container
+from the signed bytes.
+
+Each run prints how many of the payload's files it signed, under which
+identity, and what that signature still leaves open. On macOS what it leaves
+open is the `.app` bundle itself, which is not sealed, so there is no
+`Contents/_CodeSignature` and no entitlements are granted. On Windows it is the
+timestamp, which is not countersigned, so the signature expires when the
+certificate does.
+
+A payload with nothing to sign says so rather than reporting success. A
+`--app gjs` payload really is JavaScript and a launcher, and a run that asked
+for a signature and made none has to be distinguishable from one that made one.
+
+## Notarisation
+
+`--notarize <keychain-profile>` submits the signed artifact to Apple:
+
+```bash
+gjsify ship --from-stage ./stage \
+            --sign "Developer ID Application: You (TEAMID)" \
+            --notarize my-profile
+```
+
+It runs `xcrun notarytool submit --keychain-profile <profile> --wait`, where the
+profile is one a prior `notarytool store-credentials` put in that host's
+keychain. It is macOS only, and it needs `--sign`:
+
+```text
+gjsify ship: --notarize was given without an identity to sign with.
+```
+
+Three things to know before you rely on it.
+
+- **It has never been run against a real Apple account.** Notarisation needs
+  one, and ad-hoc signing deliberately does not, so no run in the gjsify
+  repository has exercised this call. Treat it as untested.
+- **It does not staple the ticket.** A stapled artifact validates offline; an
+  unstapled one asks Apple's servers at first launch.
+- **The `.app` itself is skipped.** `notarytool` submits an archive or an
+  installer, so a directory has no submittable form. The zip or the `.dmg`
+  beside it is what goes.
+
+## Where to next
+
+- [macOS app bundles](/gjsify/ship/macos/) for the artifacts `codesign` signs.
+- [Windows artifacts](/gjsify/ship/windows/) for the ones `signtool` signs.
+- [Ship your app](/gjsify/ship/#assemble-here-pack-there) for the two-phase
+  split every signed build uses.
+- [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) for the
+  flag table.

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -1,0 +1,249 @@
+---
+title: Windows artifacts
+description: "gjsify ship windows builds a program directory that carries its own Node and GTK, a zip around it, and an .msi installer. What lands on disk, what your package.json declares, and what the packing host needs installed."
+---
+
+`gjsify ship windows` turns a built app into a Windows program directory and a
+zip around it. Both assemble on any operating system, so a Linux or macOS
+workstation can produce them. The `.msi` needs one extra tool, on Linux or on
+Windows.
+
+```bash
+gjsify ship windows
+```
+
+```text
+ship/out/My App/
+ship/out/my-app-1.2.3-1.x64.zip
+```
+
+The program directory is what an installer lays down and a user browses to. The
+zip is what a user downloads, so it carries the version and the architecture in
+its filename.
+
+`x64` is the only architecture. `gvsbuild`, the project that builds GTK for
+Windows, publishes no arm64 binaries, so there is no GTK for a Windows on ARM
+artifact to load. `--arch arm64` is refused by name rather than producing a
+directory that cannot start.
+
+## Your project has to be a Node project
+
+Set `gjsify.app` to `"node"`. There is no GJS host on Windows at all, so nothing
+on that operating system can run a `--app gjs` payload. Ship says so before it
+packs anything.
+
+## What your package.json declares
+
+The program directory carries its own interpreter and its own GTK closure. Both
+are resolved by name out of your `node_modules` when you run `gjsify ship`, so
+they have to be installed on the machine that packages the app, not on the
+machine that runs it.
+
+```jsonc
+{
+  "devDependencies": {
+    // The Node interpreter, plus Node's own LICENSE.
+    "@gjsify/node-runtime-win32-x64": "^0.44.0",
+    // The relocated GTK and GObject-Introspection closure.
+    "@gjsify/gtk-runtime-win32-x64": "^0.44.0"
+  },
+  "dependencies": {
+    // node-gi's JavaScript and its prebuilt addon. A dependency rather than a
+    // devDependency, because a --app node bundle keeps `@gjsify/node-gi/*`
+    // external and requires it at run time.
+    "@gjsify/node-gi": "^0.44.0"
+  }
+}
+```
+
+:::caution[`@gjsify/node-runtime-win32-x64` is not yet published to npm]
+Measured against the registry on 2026-08-30, with `@gjsify/cli@0.44.0` as the
+control: `@gjsify/gtk-runtime-win32-x64` and `@gjsify/node-gi` resolve at
+`0.44.0`, and `@gjsify/node-runtime-win32-x64` answers 404. The first publish of
+a new name is a manual maintainer step, because npm Trusted Publishing needs the
+package to exist before CI can publish to it. It is queued.
+
+Until it lands, `npm install` fails on that line. Drop it and the rest of the
+block still gets you a program directory carrying its GTK closure and node-gi.
+What it will not carry is the interpreter, and `gjsify ship` says so on every run
+rather than letting you find out from a user. `GJSIFY_NODE_RUNTIME` points the
+lookup at a directory holding `node.exe` and its `LICENSE`, which is how to get a
+complete directory today.
+:::
+
+`GJSIFY_GTK_RUNTIME` overrides the GTK lookup with a directory holding `bin/`
+and `girepository-1.0/`. When either package is missing, ship names it and still
+produces a directory. That directory works on a machine that already has Node
+and GTK, which is a useful intermediate and not something to hand to a user.
+
+## What lands inside the program directory
+
+```text
+My App/
+├── my-app.cmd     the launcher
+├── node.exe       the carried interpreter
+├── app/           your built bundle
+├── lib/node-gi/   the GTK closure and the node-gi addon
+└── share/         icon, metainfo, schemas, licences
+```
+
+There is no metadata file in the directory. What a Windows installer says about
+an application lives in the `.msi`'s own tables, so the directory holds only the
+program.
+
+`my-app.cmd` finds its own directory from `%~dp0`, so the tree works unzipped
+anywhere and works again once an installer lays it into `C:\Program Files`. It
+runs `node.exe` from beside itself rather than a bare `node`, and it points
+`GJSIFY_GTK_RUNTIME` at the carried closure so node-gi loads that one. The file
+uses CRLF line endings, which is what `cmd.exe` reads.
+
+The zip carries a top level the staged tree does not. Without it, unzipping
+would scatter `app\`, `share\` and a loose `.cmd` into whatever folder the user
+was in.
+
+The directory is named after `gjsify.ship.name`. Windows reserves `< > : " / \
+| ? *`, the control characters, and the device names `CON`, `PRN`, `AUX`, `NUL`,
+`COM1` to `COM9` and `LPT1` to `LPT9` at every path, and it silently strips a
+trailing dot or space. Ship refuses a display name containing any of those
+rather than producing an archive that extracts under a different name than the
+launcher resolves against.
+
+Your GSettings schemas are compiled while the tree is assembled, which is why the
+windows formats need `glib-compile-schemas` on the packaging host. There is no
+install step to compile them later, and GSettings aborts on a schema directory
+that holds only sources.
+
+The `.desktop` entry and the AppStream component are carried and never read,
+because Windows reads neither. Ship lists every file in that state on each run.
+
+## Build the installer
+
+`--target msi` wraps the same program directory in a Windows Installer package.
+
+```bash
+gjsify ship windows --target windows-dir,windows-dir-zip,msi
+```
+
+That produces `ship/out/my-app-1.2.3-1.x64.msi` beside the other two artifacts.
+The installed tree is the tree the zip expands to. Nothing about the payload
+changes.
+
+What the installer adds is the three things a directory cannot do on its own:
+
+- It lays the program directory under `%ProgramFiles%\My App`, which
+  `msiexec INSTALLDIR=…` overrides.
+- It writes one Start-Menu shortcut, aimed at the same `.cmd` launcher.
+- It appears in Add/Remove Programs, taking its name, version and publisher from
+  the MSI, and `msiexec /x` removes every file it installed.
+
+The upgrade code is derived from your app id, so installing a newer version
+replaces the older one instead of leaving both on the machine. Keep the app id
+stable across releases.
+
+### The .msi needs a tool
+
+`msi` is not in the default set, because it is the one Windows format that needs
+a program this CLI does not carry. Ship writes the installer's source document
+itself and hands it to whichever compiler the host has:
+
+| Host | Install |
+|---|---|
+| Fedora | `sudo dnf install msitools` |
+| Debian, Ubuntu | `sudo apt install msitools` |
+| Windows | [WiX Toolset v3.14](https://github.com/wixtoolset/wix3/releases), with its `bin` directory on `PATH` |
+
+So you can build a Windows installer from a Linux workstation, or from Windows
+without installing anything from the Linux side. macOS cannot pack this format.
+
+A missing compiler is a message naming the package, before your build script
+runs:
+
+```text
+gjsify ship: packing a msi on linux needs glib-compile-schemas and wixl, and
+wixl is not on PATH.
+```
+
+### The .msi refuses a prerelease version
+
+Windows Installer's `ProductVersion` is `major.minor.build` and nothing else. No
+prerelease suffix, no build metadata. `major` and `minor` are at most 255 and
+`build` at most 65535, and a field over the limit is truncated by the installer
+rather than rejected.
+
+Ship refuses `1.2.0-rc.1` instead of dropping the suffix, because `1.2.0~rc.1`
+and `1.2.0` would then carry the same `ProductVersion`, the upgrade rule could
+not tell them apart, and installing one over the other would leave both on the
+machine. Set `gjsify.ship.version` to a plain `x.y.z`, or drop `msi` from the
+targets for prerelease builds.
+
+## One thing to know before you hand it to a user
+
+`node.exe` is a console-subsystem program and the Node release ships no windowed
+variant, so starting the app leaves a console window open behind it. That
+applies to the `.cmd` launcher and to the shortcut the `.msi` writes. Nothing
+here hides it.
+
+## Signing is optional here in a way it is not on macOS
+
+SmartScreen only warns about an unsigned download, until per-file reputation
+accrues. Gatekeeper blocks an unsigned macOS bundle outright. So an unsigned
+Windows program directory is a usable artifact in a way a `.app` is not.
+
+`--sign <identity>` passes a name to `signtool` on a Windows host. See
+[Sign your artifacts](/gjsify/ship/signing/), which also records that no run in
+the gjsify repository has ever invoked `signtool`.
+
+## A worked example
+
+A project on any operating system, producing all three Windows artifacts. The
+`.msi` step needs `msitools` on Linux, so it can run in the same place.
+
+```bash
+# 1. Declare the runtime, on the packaging host.
+npm install --save-dev @gjsify/gtk-runtime-win32-x64
+npm install --save @gjsify/node-gi
+
+# 2. Install the MSI compiler.
+sudo dnf install msitools glib2      # Fedora
+
+# 3. Build everything.
+gjsify ship windows \
+  --target windows-dir,windows-dir-zip,msi --verbose
+```
+
+Step 1 omits `@gjsify/node-runtime-win32-x64`, because that name still answers
+404. Point `GJSIFY_NODE_RUNTIME` at a directory holding `node.exe` and its
+`LICENSE` to get a directory that runs on a Windows machine with no Node
+installed.
+
+To split the work instead, assemble here and pack on Windows:
+
+```bash
+gjsify ship windows --stage --target windows-dir,windows-dir-zip,msi
+gjsify ship --from-stage ./stage --expect-target win32-x64 --target msi
+```
+
+`--expect-target` uses the `win32` spelling, because that is what a running
+process computes about itself. The positional accepts both `windows` and
+`win32`.
+
+## Fix a failed run
+
+| Message says | Fix |
+|---|---|
+| the windows layout cannot run a `gjs` app | set `gjsify.app` to `"node"` and rebuild the bundle for Node |
+| `the windows layout is not assemblable for --arch arm64` | use `--arch x64`; there is no Windows on ARM GTK to load |
+| `packing a msi on … needs … wixl` | install `msitools`, or WiX Toolset v3.14 on Windows |
+| `is not a version an .msi can carry` | set `gjsify.ship.version` to a plain `x.y.z` |
+| `the windows layout would put this app in a directory called …` | set `gjsify.ship.name` to a name Windows can hold |
+| `no bundled interpreter`, naming `@gjsify/node-runtime-win32-x64` | install it, or set `GJSIFY_NODE_RUNTIME` |
+
+## Where to next
+
+- [Ship your app](/gjsify/ship/) has the shared `package.json` fields and the
+  table of which host packs which format.
+- [Sign your artifacts](/gjsify/ship/signing/) covers `--sign` and `--notarize`.
+- [macOS app bundles](/gjsify/ship/macos/) is the same shape one operating
+  system over.
+- [CLI Reference → `gjsify ship`](/gjsify/cli-reference/#gjsify-ship) lists
+  every flag and configuration key.


### PR DESCRIPTION
## What changed

`gjsify ship` grew a positional operating system, nine formats, a carried Node
and GTK runtime, `--sign` and `--notarize`. The website described the Linux half
and answered none of the questions an app author asks about the other two: what
command do I run, what lands on disk, what goes in my `package.json`, what must
be installed where I package, and which host can produce which format.

The section is now one page per operating system, each with a worked example.

| Page | Covers |
|---|---|
| `ship/index.mdx` | one command per OS, the `package.json` fields all three read, the nine-format host table, `--stage` / `--from-stage`, the channel chooser |
| `ship/linux-packages.md` | `.deb`, `.rpm` and the Flatpak bundle, which moved here from the overview |
| `ship/macos.md` (new) | the `.app`, its zip and the `.dmg` |
| `ship/windows.md` (new) | the program directory, its zip and the `.msi` |
| `ship/signing.md` (new) | `--sign`, `--notarize`, and unsigned as a legitimate result |

`cli-reference.md`'s ship section is now a real reference for the shipped
surface. Its "Scope today: Linux and `--app gjs`" paragraph was false as of
#1412, and its host table listed three formats out of nine.

## What an app author gets that they did not have

- The `.app` layout, the `Info.plist` keys ship writes, and the fact that it
  writes **no `CFBundleIconFile`**, so the Finder shows the generic icon.
- The `.dmg` has **no `/Applications` symlink**, so there is no drag arrow.
- `node.exe` sits beside the `.cmd` at the program directory root, not in `lib/`.
- The `.msi` **refuses a prerelease version**, because Windows Installer's
  `ProductVersion` is `major.minor.build` and `1.2.0~rc.1` would collide with
  `1.2.0` under `MajorUpgrade`.
- `node.exe` is a console-subsystem image, so the shortcut the `.msi` writes
  leaves a console window open behind the GUI.
- `gjsify.ship.localeDir` folds compiled `.mo` catalogues into `Name[de]=` and
  the AppStream `xml:lang` attributes (#1411). Nothing documented this.
- `gjsify.ship.mimeTypes`, which stages `share/mime/packages/` and fills the
  desktop entry's `MimeType=`.

## Internals moved out, not deleted

The oracle argument, `finishOn`, `layoutOs`, `FORMAT_IDS`, `zipinfo` as an
independent reader, and the rpm Epoch measurement all live in
`docs/ship-formats.md` and `docs/adr/0024-ship-installable-artifacts.md`
already. The reproducibility rule lives on How It Works and is now linked
rather than restated. Nothing was removed from the repository; the website
stopped carrying a second copy.

## Two facts re-measured

Against the registry at 07:36 UTC on 2026-08-30, with `@gjsify/cli` as a
positive control and a nonexistent name as a negative one, each live name
checked for a packument **and** a `dist.tarball`:

```
@gjsify/cli                            0.44.0  tarball=yes
@gjsify/node-runtime-darwin-arm64      0.44.0  tarball=yes
@gjsify/node-runtime-darwin-x64        0.44.0  tarball=yes
@gjsify/node-runtime-win32-x64         E404 (no packument)
@gjsify/gtk-runtime-darwin-arm64       0.44.0  tarball=yes
@gjsify/gtk-runtime-darwin-x64         0.44.0  tarball=yes
@gjsify/gtk-runtime-win32-x64          0.44.0  tarball=yes
@gjsify/node-gi                        0.44.0  tarball=yes
```

So the caution covers one name, not three. `ship/windows.md` keeps the
disclosure `check-shipped-runtime-packages.mjs` obliges for
`@gjsify/node-runtime-win32-x64`; `ship/macos.md` carries none, because both
darwin names are live.

The default Flatpak `finishArgs` on the old page were
`["--device=dri", "--share=ipc", "--socket=wayland"]`.
`DEFAULT_GUI_FINISH_ARGS` in `utils/flatpak-runtime.ts` also has
`--socket=fallback-x11`. Corrected.

## How the commands were verified

The CLI was built from this branch's source and run against the shared
`tests/e2e/ship` fixture. Every command and every quoted refusal in these pages
came from one of these runs, or from reading the code that parses it where a
run needs a host this workstation is not.

```
gjsify ship --help
gjsify ship --skip-build --verbose                       # deb + rpm, --app gjs
gjsify ship darwin --skip-build --arch arm64             # .app + zip
gjsify ship windows --skip-build                         # program dir + zip
gjsify ship darwin --skip-build --arch arm64 --stage
gjsify ship --from-stage <dir> --expect-target darwin-arm64
gjsify ship linux --stage --target deb  →  --from-stage --target deb,rpm   # refusal
gjsify ship darwin --skip-build --target macos-app-dmg   # wrong-host refusal
gjsify ship windows --skip-build --target msi            # missing-wixl refusal
gjsify ship windows --skip-build --arch arm64            # no arm64 GTK refusal
gjsify ship --skip-build --sign -                        # refused on the linux layout
gjsify ship --from-stage <darwin stage> --sign -         # codesign runs on darwin
gjsify ship darwin --skip-build --arch arm64 --notarize p   # --notarize needs --sign
gjsify ship darwin --skip-build  (a --app gjs project)   # interpreter refusal
```

The staged layouts and both launchers were read off disk, with
`GJSIFY_NODE_RUNTIME` and `GJSIFY_GTK_RUNTIME` pointed at stand-in directories
so the carried-runtime paths are the real ones rather than a guess. The MSI
prerelease refusal and the `signtool` argv come from the code, because this
machine has neither `wixl` nor Windows.

## Gates

```
node scripts/check-agent-context-size.mjs --check          exit 0
node scripts/check-website-package-names.mjs               exit 0
node scripts/check-ship-format-vocabulary.mjs              exit 0
node scripts/check-website-preview-not-content.mjs         exit 0
node scripts/check-doc-fences.mjs                          exit 0
node scripts/check-doc-revert.mjs --base origin/main       exit 0
PR_TITLE=… PR_NUMBER=… node scripts/check-pr-title-length.mjs   exit 0  (50/100)
node scripts/check-pr-title-types.mjs                      exit 0
```

`check-shipped-runtime-packages.mjs` exits 1 on this branch **and on
`origin/main`**, measured in a detached worktree of `origin/main` for the
comparison. Both fail identically, on the two stale `PENDING_BOOTSTRAP` entries
for the darwin names published today. That file is untouched here and the fix
is in flight separately.

Every internal `/gjsify/…` link and anchor on the site was resolved against the
content collection: 0 broken links, including everything that used to point at
the overview's Flatpak section. `astro build` syncs the content collection and
generates types over the three new pages without a schema error; the build then
stops on unbuilt workspace packages, which is this checkout, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB
