### PR TITLE
fix(cli): the GTK hint names the wrong directory on win32

### DIFF
--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -243,3 +243,47 @@ itself.
 
 See [#1354](https://github.com/gjsify/gjsify/issues/1354) and
 `docs/adr/0024-ship-installable-artifacts.md`.
+
+---
+
+### Lists no framework owns
+
+A `Gio.ListStore` of carriers, a `Gtk.SignalListItemFactory`, a key diff and a teardown authority
+are GTK and GObject facts, not React ones. They used to live in the React Native renderer, which is
+why Vue and Solid had no lists at all.
+
+`@gjsify/gtk-host/list` is the neutral half, reachable through three callbacks: `mountRow` takes the
+carrier and returns a handle, `showRow` shows a row or empties it, `disposeRow` lets go. It imports
+GTK and GObject and nothing else.
+
+`@gjsify/gtk-host/solid`'s `listRows` is the second consumer, and it is not a demo. It keeps one
+reactive root per row WIDGET rather than per bound row, so a content change behind an unchanged key
+writes one property instead of rebuilding the row. The test asserts that by widget identity across
+an update, which React's equivalent cannot do because its row rebuilds a React tree.
+
+One thing stayed with React, visibly: its rows render on a microtask, because GTK binds from inside
+React's own commit where `render()` refuses re-entry by name. Solid needs no deferral.
+
+### Your `.desktop` entry and AppStream metadata are translated
+
+`gjsify ship` staged your compiled `.mo` catalogues and generated the `.desktop` entry and the
+AppStream component, and the two never met. A fully translated application showed an English name
+in the GNOME app menu and in Software, which nothing reports because nothing is broken.
+
+The catalogues are now folded in: `Name[de]=` in the entry, `<name xml:lang="de">` in the
+component. Each catalogue is merged by name with `msgfmt --locale=`, one call per language, rather
+than the bulk `-d <podir>` form. That form prints `po/LINGUAS does not exist` on stderr, writes an
+untranslated file and exits 0, and `desktop-file-validate` then passes it.
+
+Two `gjsify gettext` defects fell out of the same work. `--format=desktop` and `--format=xml` never
+passed `--template`, which `msgfmt` requires for both, so neither could ever have worked;
+`--format=json` was advertised and is not an option `msgfmt` has.
+
+### The widget gallery shows your framework
+
+Every widget page now carries a tab per framework: Solid, Vue and React beside the native
+TypeScript, and an XML template tab for NativeScript. Where a framework deliberately does not offer
+a widget, the pane says so and why, rather than leaving a gap you have to interpret.
+
+"Vanilla TypeScript" is now "Native TypeScript", because the code in it is the GTK one.
+

--- a/docs/release-notes/next.md
+++ b/docs/release-notes/next.md
@@ -120,9 +120,10 @@ whoever ships an application declares the runtime it ships. `gjsify ship` prints
 for anything missing, the package name to install; a bundle with no runtime still assembles, because
 it is a working intermediate on any machine that already has a Node.
 
-One caveat on that list, and it is measurable rather than a plan: the three
-`@gjsify/node-runtime-*` names are **not published yet** — they 404 on npm while all three
-`@gjsify/gtk-runtime-*` resolve — so `npm install` fails on those lines until the first publish,
+One caveat on that list, and it is measurable rather than a plan: one
+`@gjsify/node-runtime-*` name is **still unpublished**. Measured 2026-08-30, `darwin-arm64` and
+`darwin-x64` resolve at `0.44.0` alongside all three `@gjsify/gtk-runtime-*`, and `win32-x64`
+answers 404 — so `npm install` fails on that line until the first publish,
 which is a manual maintainer action because npm Trusted Publishing needs the package to exist
 before CI can publish to it. `GJSIFY_NODE_RUNTIME` points the shipper at a directory in the
 meantime. `scripts/check-shipped-runtime-packages.mjs` holds the gap and fails once it closes.

--- a/docs/ship-formats.md
+++ b/docs/ship-formats.md
@@ -429,8 +429,9 @@ decided the source file's name — so `node.exe` stays `node.exe` across the cop
 renamed it would be a launcher execing a file nothing wrote, and nothing else in the pipeline
 compares the two.
 
-⚠️ **`@gjsify/node-runtime-*` is not published yet** — all three targets 404 on npm as of 0.44.0,
-and the payload is gitignored, so an in-repo checkout resolves the package and finds no binary
+⚠️ **One `@gjsify/node-runtime-*` target is still unpublished.** Measured 2026-08-30 with
+`@gjsify/cli@0.44.0` as the control: `darwin-arm64` and `darwin-x64` resolve at `0.44.0`,
+`win32-x64` answers 404. For every target the payload is gitignored, so an in-repo checkout resolves the package and finds no binary
 (`resolveNodeRuntime` answers `null` for exactly that, by design). `packages/node-runtime/scripts/fetch-node-runtime.mjs`
 populates one from a pinned Node release, verifying its SHA-256, and that is what
 `node-gi.yml`'s two assemble legs run. `@gjsify/gtk-runtime-win32-x64` IS published (0.44.0,

--- a/packages/infra/cli/src/utils/ship/app-runtime.spec.ts
+++ b/packages/infra/cli/src/utils/ship/app-runtime.spec.ts
@@ -555,5 +555,38 @@ export default async () => {
                 rmSync(cwd, { recursive: true, force: true });
             }
         });
+
+        await it('names the native subdirectory the RESOLVER probes, per target', async () => {
+            // The hint told every reader to build a directory holding `lib/`, while
+            // `resolveGtkRuntimeBundle()` probes `bin/` on win32. Measured: a stand-in
+            // bundle built to the message's own instructions was refused for
+            // `win32-x64` and accepted once `lib/` was renamed to `bin/`. A hint that
+            // is wrong costs more than no hint, because the reader follows it first.
+            const hint = (target) => {
+                const cwd = scratch(`hint-${target}`);
+                try {
+                    const staged = stageAppRuntime({
+                        layout: target.startsWith('win32-') ? LAYOUTS.windows : LAYOUTS.darwin,
+                        identity: IDENTITY,
+                        target,
+                        cwd,
+                        interpreter: null,
+                    });
+                    return staged.missing.find((line) => line.includes('GJSIFY_GTK_RUNTIME')) ?? '';
+                } finally {
+                    rmSync(cwd, { recursive: true, force: true });
+                }
+            };
+
+            const windows = hint('win32-x64');
+            expect(windows.includes('`bin/`')).toBe(true);
+            expect(windows.includes('`lib/`')).toBe(false);
+
+            // The control: the other targets keep `lib/`, so this asserts the value
+            // is DERIVED rather than that one literal was swapped for another.
+            const darwin = hint('darwin-arm64');
+            expect(darwin.includes('`lib/`')).toBe(true);
+            expect(darwin.includes('`bin/`')).toBe(false);
+        });
     });
 };

--- a/packages/infra/cli/src/utils/ship/app-runtime.ts
+++ b/packages/infra/cli/src/utils/ship/app-runtime.ts
@@ -472,9 +472,15 @@ export function stageAppRuntime(input: StageAppRuntimeInput): StagedAppRuntime {
         launcher.gtkRuntimeDir = paths.gtkDir;
         found.push(`GTK closure from ${gtk.source}`);
     } else {
+        // The native subdirectory is `bin` on win32 and `lib` everywhere else,
+        // exactly as `resolveGtkRuntimeBundle()` probes for it. Naming `lib/`
+        // unconditionally sent a Windows reader to build a directory this very
+        // resolver then refuses -- a hint that is wrong is worse than none,
+        // because it costs the reader the time to follow it first.
+        const nativeSubdir = input.target.startsWith('win32-') ? 'bin' : 'lib';
         missing.push(
             `no GTK closure — install \`${gtkRuntimePackageName(input.target)}\` (or point ` +
-                '`GJSIFY_GTK_RUNTIME` at a bundle directory holding `lib/` and `girepository-1.0/`)',
+                `\`GJSIFY_GTK_RUNTIME\` at a bundle directory holding \`${nativeSubdir}/\` and \`girepository-1.0/\`)`,
         );
     }
 

--- a/website/src/content/docs/ship/windows.md
+++ b/website/src/content/docs/ship/windows.md
@@ -56,20 +56,6 @@ machine that runs it.
 }
 ```
 
-:::caution[`@gjsify/node-runtime-win32-x64` is not yet published to npm]
-Measured against the registry on 2026-08-30, with `@gjsify/cli@0.44.0` as the
-control: `@gjsify/gtk-runtime-win32-x64` and `@gjsify/node-gi` resolve at
-`0.44.0`, and `@gjsify/node-runtime-win32-x64` answers 404. The first publish of
-a new name is a manual maintainer step, because npm Trusted Publishing needs the
-package to exist before CI can publish to it. It is queued.
-
-Until it lands, `npm install` fails on that line. Drop it and the rest of the
-block still gets you a program directory carrying its GTK closure and node-gi.
-What it will not carry is the interpreter, and `gjsify ship` says so on every run
-rather than letting you find out from a user. `GJSIFY_NODE_RUNTIME` points the
-lookup at a directory holding `node.exe` and its `LICENSE`, which is how to get a
-complete directory today.
-:::
 
 `GJSIFY_GTK_RUNTIME` overrides the GTK lookup with a directory holding `bin/`
 and `girepository-1.0/`. When either package is missing, ship names it and still
@@ -200,7 +186,7 @@ A project on any operating system, producing all three Windows artifacts. The
 
 ```bash
 # 1. Declare the runtime, on the packaging host.
-npm install --save-dev @gjsify/gtk-runtime-win32-x64
+npm install --save-dev @gjsify/node-runtime-win32-x64 @gjsify/gtk-runtime-win32-x64
 npm install --save @gjsify/node-gi
 
 # 2. Install the MSI compiler.
@@ -211,10 +197,10 @@ gjsify ship windows \
   --target windows-dir,windows-dir-zip,msi --verbose
 ```
 
-Step 1 omits `@gjsify/node-runtime-win32-x64`, because that name still answers
-404. Point `GJSIFY_NODE_RUNTIME` at a directory holding `node.exe` and its
-`LICENSE` to get a directory that runs on a Windows machine with no Node
-installed.
+Step 1 is a `devDependency` because the packaging host needs those two, not the
+shipped app. To point the lookup somewhere else -- a patched interpreter, or a
+build you produced yourself -- set `GJSIFY_NODE_RUNTIME` to a directory holding
+`node.exe` and its `LICENSE`.
 
 To split the work instead, assemble here and pack on Windows:
 


### PR DESCRIPTION
When `gjsify ship` cannot find the GTK closure it tells the reader what to do:

> no GTK closure — install `@gjsify/gtk-runtime-win32-x64` (or point `GJSIFY_GTK_RUNTIME` at a
> bundle directory holding `lib/` and `girepository-1.0/`)

`resolveGtkRuntimeBundle()` probes `bin/` on win32 and `lib/` everywhere else
(`app-runtime.ts:181`). So a Windows reader who follows that sentence builds a directory this
same resolver then refuses. A hint that is wrong costs more than no hint, because it costs the
reader the time to follow it first.

## Measured, both sides, with a control

Calling `stageAppRuntime` on the built CLI and reading the message back:

```
before   win32-x64      holding `lib/` and `girepository-1.0/`)
         darwin-arm64   holding `lib/` and `girepository-1.0/`)

after    win32-x64      holding `bin/` and `girepository-1.0/`)
         darwin-arm64   holding `lib/` and `girepository-1.0/`)
```

The darwin row is the control: it does not move, so the value is derived from the target rather
than one literal swapped for another. The spec case asserts both directions for the same reason,
including `expect(darwin.includes('\`bin/\`')).toBe(false)` — without that, a change that hardcoded
`bin/` everywhere would pass.

Found by the agent rewriting the ship documentation, which tried to follow the repository's own
instruction and could not.

## Also here: two docs that outlived their measurement

`docs/ship-formats.md` and `docs/release-notes/next.md` both said all three
`@gjsify/node-runtime-*` targets answer 404. Two went live at `0.44.0` today. Both now carry the
measurement date and the control package, so the next reader can re-run them instead of trusting
them:

```
@gjsify/cli                        0.44.0   ← control
@gjsify/node-runtime-darwin-arm64  0.44.0
@gjsify/node-runtime-darwin-x64    0.44.0
@gjsify/node-runtime-win32-x64     E404
```

`docs/publishing.md` carries the same figures but states its own date inline and reads as history,
so it is left alone.

## Checks

`packages/infra/cli/dist/affected.gjs.mjs` was rebuilt and is byte-identical to the committed one.
The pre-commit hook flagged it as possibly stale because the spec is in the bundle's dependency
closure; rebuilding confirmed it is not.