### PR TITLE
fix(cli): the ship subsystem read as one picture

### DIFF
--- a/packages/infra/cli/src/commands/ship.ts
+++ b/packages/infra/cli/src/commands/ship.ts
@@ -14,12 +14,14 @@
 // which is what a developer on one machine wants and what the e2e suite
 // compares the split against byte for byte.
 //
-// Scope today is Linux and `--app gjs`: no runtime is bundled, because GJS and
-// GTK come from the distribution and shipping ~100 MiB of them would be cargo
-// cult (ADR 0024 § 4). macOS and Windows layouts, and Flatpak as a target under
-// this command, are the later stages of the same ADR — and they are the reason
-// the split exists at all: a `.dmg` is a UDIF image over a real HFS+/APFS
-// volume and no Linux host in this tree can write one (§ A1).
+// THREE LAYOUTS AND NINE FORMATS as of #1354 M6, which is what the two-phase
+// split was built for. A Linux artifact bundles no runtime — GJS and GTK come
+// from the distribution and shipping ~100 MiB of them would be cargo cult (ADR
+// 0024 § 4) — while a `.app` and a Windows program directory CARRY theirs, since
+// neither OS ships one (`utils/ship/app-runtime.ts`). And the split earns itself
+// on the two rows that are host-bound: a `.dmg` is a UDIF image over a real
+// HFS+/APFS volume that no Linux host in this tree can write (§ A1), and a
+// signature is made where the identity lives (§ A14).
 
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
@@ -608,11 +610,11 @@ async function assemble(args: ShipOptions): Promise<void> {
 
     if (args.stage) {
         // `(none)` spelled out, because an empty list printed as nothing after
-        // "formats " reads as a truncated line rather than as a fact — and for
-        // windows it is still the whole story. WHICH fact it is now depends on the
-        // layout: darwin has two formats, so an empty list there means this project
-        // cannot use them, and printing "none yet" would have told a `--app gjs`
-        // author to wait for a milestone that has already landed.
+        // "formats " reads as a truncated line rather than as a fact. WHICH fact
+        // it is depends on the layout: all three now have formats — three rows each
+        // for darwin and windows — so an empty list means this project cannot use
+        // them, and printing "none yet" would tell a `--app gjs` author to wait for
+        // a milestone that has already landed.
         // Three reasons a list can be empty, and each names a different next step:
         // this project cannot use the formats that wrap the layout; the layout has
         // none; or the configured `targets` all wrap another one, which the branch
@@ -1102,7 +1104,6 @@ async function packOne(input: PackInput): Promise<ShipArtifact> {
             const volumeDir = dmgVolumeDir(outRoot);
             writePayload(volumeDir, payload, '');
             await buildDmgImage({
-                settings,
                 volumeName: dmgVolumeName(settings),
                 sourceDir: volumeDir,
                 target,
@@ -1255,6 +1256,34 @@ function assertPackable(
                 'the milestone that stages an interpreter is for (#1354 M2b).',
         );
     }
+    // A THIRD emptiness, and the one the last throw in this function used to
+    // mis-diagnose. A layout that HAS formats still reaches here with none
+    // SELECTED: `configuredFormats` filters `gjsify.ship.targets` to the layout
+    // being assembled and returns an empty list when they all wrap another one,
+    // and `--stage` records that empty list for the finishing host to read.
+    //
+    // MEASURED before this branch existed, on a `--app node` project carrying
+    // `targets: ["deb","rpm"]` — the key `packages/infra/cli/package.json` itself
+    // carries — with `gjsify ship darwin --stage` then `gjsify ship --from-stage`:
+    // "no format wraps the darwin layout … Keep it for the milestone that packs it
+    // … this is a layout added without a `FORMATS` row". Three rows wrap darwin,
+    // the milestone landed, and the cause was a configured list for another OS.
+    const wrapping = formatIdsFor(layout.os).sort();
+    if (wrapping.length > 0) {
+        // The assembling host is where the answer is, whichever caller got here:
+        // phase two cannot add a format the stage never rendered an overlay for
+        // (`assertFormatsStaged`), so `--target` HERE is not the fix.
+        const where = chosenBy === 'stage' ? `${layout.name} --stage --target` : `${layout.name} --target`;
+        throw new Error(
+            `gjsify ship: this run records no formats for the ${layout.name} layout, so there is nothing ` +
+                `to pack — and it is not that none exist: ${wrapping.join(', ')} wrap it.\n` +
+                '    An empty list means none were SELECTED. `gjsify.ship.targets` is filtered to the layout ' +
+                'being assembled,\n' +
+                "    so a configured list naming only another OS's formats leaves this one empty and says so " +
+                'at stage time.\n' +
+                `    Name one where the payload is assembled: \`gjsify ship ${where} ${wrapping[0]}\`.`,
+        );
+    }
     const linux = defaultFormatIds('linux').join(',');
     // Three callers, three different next steps. Telling a `--from-stage` caller
     // to run `gjsify ship <os> --stage` names the command that PRODUCED the stage
@@ -1272,12 +1301,17 @@ function assertPackable(
             'intermediate, not an artifact. Keep it for the milestone that packs it, or re-assemble with ' +
             '`gjsify ship linux --stage` if a Linux package is what you wanted.',
     }[chosenBy];
-    // UNREACHABLE FROM THE THREE LAYOUTS THAT EXIST, and kept rather than deleted:
-    // every one of them has formats as of #1354 M3, so a `--app gjs` project meets
-    // the INTERPRETER refusal above instead. This branch is what a fourth layout
-    // gets on the day it is added and before a format wraps it — the same state
-    // windows was in between M1 and M3 — and deleting it would make that day's
-    // failure a `TypeError` on an empty list.
+    // NOW ACTUALLY UNREACHABLE from the three layouts that exist — the branch
+    // above holds every one of them, because `formatIdsFor` answers non-empty for
+    // all three as of #1354 M5. Kept rather than deleted: this is what a fourth
+    // layout gets on the day it is added and before a `FORMATS` row wraps it, the
+    // state windows was in between M1 and M3, and deleting it would make that
+    // day's failure a `TypeError` on an empty list.
+    //
+    // It used to claim this for the whole function while the `targets`-elsewhere
+    // route reached it and got all three of its sentences wrong. A comment saying
+    // "unreachable" is a claim about a predicate; this one now has the predicate
+    // above it in code.
     throw new Error(
         `gjsify ship: no format wraps the ${layout.name} layout, so there is nothing to pack. ${advice}` +
             ' Every layout this gjsify knows has one (ADR 0024 stages 2-5), so this is a layout added ' +
@@ -1317,12 +1351,15 @@ function assertPackable(
  * WHY THIS REFUSES AND `Layout.runtimeGap` ONLY WARNS, since the two describe
  * neighbouring predicaments and get opposite treatment. A target this command
  * cannot package would leave here as an ARTIFACT — a `.deb` a stranger installs,
- * which then fails at startup, with no gate between here and their machine. A
- * windows stage cannot run on any Windows machine either, but it is not an
- * artifact: `assertPackable` refuses to pack it, so the only thing leaving this
- * command is a build intermediate whose consumer is the milestone that wraps it.
- * Refusing would ban assembling the layout at all, which is the whole of M1. The
- * day a Windows format exists, that warning has to become this refusal.
+ * which then fails at startup, with no gate between here and their machine. The
+ * `runtimeGap` warns about something that is not an artifact: it is printed over a
+ * staged tree, and only when that tree carries no interpreter of its own.
+ *
+ * This paragraph used to end "the day a Windows format exists, that warning has to
+ * become this refusal". #1354 M3 is that day, and the refusal it became is
+ * {@link assertFormatCanRunInterpreter} — per FORMAT rather than per layout,
+ * because what a runtime can execute is a property of the container and not of the
+ * tree it wraps. This function stayed exactly as wide as it was.
  *
  * Phase one only. Phase two does not re-read `gjsify.app` — it has no project —
  * but it is not unchecked either: `assertLauncherMatchesInterpreter` compares
@@ -1405,6 +1442,6 @@ async function runProjectBuild(projectDir: string): Promise<void> {
             ),
     });
     if (result.code !== 0) {
-        throw new Error(`gjsify ship: the project's build script failed${describeExit(result)}.`);
+        throw new Error(`gjsify ship: the project's build script failed with ${describeExit(result)}.`);
     }
 }

--- a/packages/infra/cli/src/utils/ship/app-runtime.ts
+++ b/packages/infra/cli/src/utils/ship/app-runtime.ts
@@ -10,11 +10,12 @@
 // run — which is what makes M2b (staging a runtime) the milestone that matters".
 // This module is that staging.
 //
-// THREE PIECES, THREE OWNERS, and none of them is a dependency of anything here:
+// FOUR PIECES, THREE OWNERS — `@gjsify/node-gi` supplies two of them — and none
+// is a dependency of anything here:
 //
 //   * the interpreter — `@gjsify/node-runtime-<target>`, resolved by
-//     {@link resolveNodeRuntime} in `node-runtime.ts`, whose header records that
-//     NOTHING called it. This module is the caller it was written for.
+//     {@link resolveNodeRuntime} in `node-runtime.ts`. This module is the caller
+//     that module was written for, and #1354 M3 gave it a second layout to serve.
 //   * the relocated GTK closure — `@gjsify/gtk-runtime-<target>`'s `gtk/`.
 //   * the node-gi addon built against that closure —
 //     `@gjsify/node-gi`'s `prebuilds/<target>/node_gi.node`, whose `@rpath` is
@@ -47,9 +48,10 @@
 // `…/node_modules/@gjsify/node-gi/prebuilds/<target>/node_gi.node` and
 // `resolveGtkRuntimeBundle()`'s candidate 2 for `…/prebuilds/<target>/gtk`, and
 // neither is where a `.app` may keep loadable code: `Contents/Frameworks` is, and
-// it is where `codesign` will be pointed at M6 (ADR 0024 § A4). Putting the
-// closure under `Resources` to save two `export` lines would trade a correct
-// bundle for a shorter launcher.
+// it is what `codesign` now reaches (ADR 0024 § A4) — M6 landed, and
+// `utils/ship/signing.ts` re-signs every Mach-O in the payload by magic number,
+// which is most of this closure. Putting it under `Resources` to save two
+// `export` lines would trade a correct bundle for a shorter launcher.
 //
 // WHY NOT `gjsify.ship.bundledTypelibs`. Because it FLATTENS. `plan.ts` stages
 // each such file as `posix.join(libDir, 'gi', basename(file))`, and

--- a/packages/infra/cli/src/utils/ship/dmg.ts
+++ b/packages/infra/cli/src/utils/ship/dmg.ts
@@ -58,12 +58,14 @@ export const DMG_TOOL = 'hdiutil';
 /**
  * Characters an HFS+ volume name may not contain.
  *
- * The same pair `layout.ts` refuses in a bundle DIRECTORY name and for the same
- * measured reason: `/` is the POSIX separator and `:` is HFS+'s, and the Finder
- * shows a stored `:` as a `/` and vice versa. A volume called `Ship/Demo` mounts
- * as `Ship:Demo`, so the name a user is told to look for is not the name they
- * see. `\` is not in this set — it is a perfectly ordinary character on HFS+,
- * and `windowsProgramDirName` is where it is forbidden, for Windows' reasons.
+ * Two of the three `layout.ts` refuses in a bundle DIRECTORY name — its
+ * `BUNDLE_NAME_FORBIDDEN` is `/[/:\\]/` — and for the same measured reason: `/`
+ * is the POSIX separator and `:` is HFS+'s, and the Finder shows a stored `:` as
+ * a `/` and vice versa. A volume called `Ship/Demo` mounts as `Ship:Demo`, so the
+ * name a user is told to look for is not the name they see. `\` is the one that
+ * is NOT here: it is an ordinary character in a volume name, while a bundle
+ * directory refuses it too and `windowsProgramDirName` refuses it for Windows'
+ * own reasons.
  */
 const VOLUME_NAME_FORBIDDEN = /[/:]/;
 
@@ -152,7 +154,6 @@ export function hdiutilCreateArgs(input: DmgCreateInput): string[] {
 }
 
 export interface DmgPackInput extends DmgCreateInput {
-    settings: PackSettings;
     verbose: boolean;
     /** Working root, so the log can name the directory that became the volume. */
     workDir: string;
@@ -161,9 +162,8 @@ export interface DmgPackInput extends DmgCreateInput {
 /**
  * Build the image at `input.target`.
  *
- * The second packer in this tree that execs anything, and — unlike the Flatpak
- * one — the tool cannot be installed where it is missing: `hdiutil` ships with
- * macOS and exists nowhere else. So the `notFound` branch does not say "install
+ * Unlike the Flatpak packer's tool, this one cannot be installed where it is
+ * missing: `hdiutil` ships with macOS and exists nowhere else. So the `notFound` branch does not say "install
  * it"; it says which host this belongs on and how the payload gets there, which
  * is the same two-phase sentence `assertHostCanFinish` prints one step earlier.
  * Reaching this branch at all means `process.platform` said darwin and `hdiutil`

--- a/packages/infra/cli/src/utils/ship/formats.ts
+++ b/packages/infra/cli/src/utils/ship/formats.ts
@@ -249,6 +249,42 @@ export function allRequiredTools(tools: RequiredTools): readonly string[] {
     return Object.values(tools as Readonly<Partial<Record<HostOs, readonly string[]>>>).flat();
 }
 
+/**
+ * Why a format's runtime provides the interpreters it does — one string per
+ * RUNTIME STORY, three stories under nine rows.
+ *
+ * These are PRINTED: `assertFormatCanRunInterpreter` puts the row's own sentence
+ * in front of an author whose project cannot ship this way. Per row they were
+ * five redundant copies of one paragraph, so a correction on one row would have
+ * left the two beside it telling that author something else about the same fact.
+ */
+// Neither interpreter is restricted on `deb`/`rpm`: `Depends: gjs` and
+// `Depends: nodejs` are both satisfiable from any distribution's own archive, so
+// the artifact's runtime is the machine's.
+const DISTRO_INTERPRETER_GAP =
+    'a distro package declares its interpreter as a dependency instead of carrying one, and every ' +
+    'distribution ships both';
+
+const MACOS_INTERPRETER_GAP =
+    'a `.app` a stranger downloads has to CARRY its interpreter, and there is no relocatable GJS to ' +
+    'put in one — `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs` records "GJS ships no ' +
+    'relocation", which is why ADR 0024 § 4 derives Node on macOS and stage 7 is what would change it';
+
+const WINDOWS_INTERPRETER_GAP =
+    'there is no GJS host on Windows at all (ADR 0024 § 4) — not a system one to depend on and not a ' +
+    'relocatable one to carry — so a `--app gjs` payload cannot be shipped this way. That is why ' +
+    '§ 4 derives Node here, and why `@gjsify/node-runtime-win32-x64` exists';
+
+/**
+ * rpm's `share/licenses/<name>/LICENSE` — eight of the nine rows.
+ *
+ * `deb` is the one that does not, and the one with a POLICY: Debian § 12.5 puts
+ * the copyright at `share/doc/<package>/copyright` and lintian errors without it.
+ * Nothing dictates a location for the other eight, so they share one shape and
+ * the layout map does the rest.
+ */
+const SHARE_LICENSE_DEST = (binaryName: string): string => `share/licenses/${binaryName}/LICENSE`;
+
 /** `.deb` and `.rpm` are written by this tree, so they exec nothing and read back with GNU tools. */
 const WRITTEN_HERE = (readWith: readonly string[]): FormatDescriptor['host'] => ({
     finishOn: 'any',
@@ -264,13 +300,7 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         host: WRITTEN_HERE(['ar', 'tar', 'dpkg-deb', 'lintian']),
         depends: 'deb',
         interpreters: ['gjs', 'node'],
-        // Neither is restricted, because a distro package DECLARES its
-        // interpreter rather than carrying one: `Depends: gjs` and
-        // `Depends: nodejs` are both satisfiable from any distribution's own
-        // archive, so the artifact's runtime is the machine's.
-        interpreterGap:
-            'a distro package declares its interpreter as a dependency instead of carrying one, and every ' +
-            'distribution ships both',
+        interpreterGap: DISTRO_INTERPRETER_GAP,
         // Debian policy § 12.5: every package ships its copyright in
         // /usr/share/doc/<package>/copyright, and lintian errors without it.
         licenseDest: (binaryName) => `share/doc/${binaryName}/copyright`,
@@ -286,14 +316,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         host: WRITTEN_HERE(['rpm', 'rpm2cpio', 'cpio']),
         depends: 'rpm',
         interpreters: ['gjs', 'node'],
-        // Neither is restricted, because a distro package DECLARES its
-        // interpreter rather than carrying one: `Depends: gjs` and
-        // `Depends: nodejs` are both satisfiable from any distribution's own
-        // archive, so the artifact's runtime is the machine's.
-        interpreterGap:
-            'a distro package declares its interpreter as a dependency instead of carrying one, and every ' +
-            'distribution ships both',
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: DISTRO_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: rpmArch,
         fileName: (s: PackSettings, archLabel: string) => `${s.binaryName}-${s.version}-${s.release}.${archLabel}.rpm`,
@@ -339,10 +363,7 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
             'a Flatpak runs against `org.gnome.Platform`, which ships `gjs` and no `node`. Node exists only ' +
             'as `org.freedesktop.Sdk.Extension.node2x`, and that extension puts node on the BUILD path, not ' +
             'in the runtime — so the artifact would install and then fail at `exec node`',
-        // No policy demands a location, so this follows rpm's — one fewer shape
-        // for a reader to learn, and `/app/share/licenses/<name>/LICENSE` is
-        // where the equivalent file sits in the `.rpm` built from the same stage.
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: flatpakArch,
         // Named after the APP ID, not the binary: the id is the ref the file
@@ -355,14 +376,16 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
     // TWO ROWS FOR ONE TREE, and the pair is what `layoutOs` was added for. The
     // bundle and the zip around it wrap the same staged `<App>.app`; they differ
     // only in whether the artifact is a directory a user drags or a file a user
-    // downloads. Both are `finishOn: 'any'` — the `.dmg` that is not is ADR 0024
-    // § A6 and milestone M6.
+    // downloads. Both are `finishOn: 'any'` — the `.dmg` that is not is the third
+    // row below (ADR 0024 § A6, #1354 M4).
     //
-    // NEITHER IS SIGNED, and that is a property of M2a rather than an omission
-    // this table hides: `codesign` is macOS-only, so a bundle assembled on Linux
-    // is unsigned by construction. Gatekeeper will quarantine it on a stranger's
-    // Mac. M6 is where a signing host enters, and § A4 already records what it
-    // costs (re-signing the whole Mach-O closure inside the stage).
+    // NEITHER IS SIGNED BY DEFAULT, and unsigned is a deliverable rather than an
+    // omission this table hides: `codesign` is macOS-only, so a bundle assembled
+    // on Linux is unsigned by construction and Gatekeeper quarantines it on a
+    // stranger's Mac. M6 has since landed and holds the other half — `gjsify ship
+    // --from-stage --sign <identity>` on a macOS host re-signs the whole Mach-O
+    // closure inside the stage (`utils/ship/signing.ts`, § A4). `SIGNERS` is keyed
+    // by LAYOUT, so these two rows cannot disagree about their signature.
     'macos-app': {
         id: 'macos-app',
         layoutOs: 'darwin',
@@ -411,15 +434,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // `assertFormatCanRunInterpreter` says so by name instead of producing a
         // bundle that dies at `exec gjs`.
         interpreters: ['node'],
-        interpreterGap:
-            'a `.app` a stranger downloads has to CARRY its interpreter, and there is no relocatable GJS to ' +
-            'put in one — `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs` records "GJS ships no ' +
-            'relocation", which is why ADR 0024 § 4 derives Node on macOS and stage 7 is what would change it',
-        // Inside `Contents/Resources`, which is where a `.app`'s non-executable
-        // files go. Following rpm's `share/licenses/<name>/LICENSE` shape keeps
-        // one fewer layout for a reader to learn — the layout map turns it into
-        // `Contents/Resources/share/licenses/<name>/LICENSE`.
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: MACOS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: macosArch,
         // The DISPLAY name, not the binary: this artifact is the thing a user
@@ -453,11 +469,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         },
         depends: null,
         interpreters: ['node'],
-        interpreterGap:
-            'a `.app` a stranger downloads has to CARRY its interpreter, and there is no relocatable GJS to ' +
-            'put in one — `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs` records "GJS ships no ' +
-            'relocation", which is why ADR 0024 § 4 derives Node on macOS and stage 7 is what would change it',
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: MACOS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: macosArch,
         // The BINARY name here and the display name above, deliberately. This one
@@ -544,11 +557,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // the image carries the same bundle, and there is no relocatable GJS to
         // put in one.
         interpreters: ['node'],
-        interpreterGap:
-            'a `.app` a stranger downloads has to CARRY its interpreter, and there is no relocatable GJS to ' +
-            'put in one — `packages/node-gi/scripts/build-gtk-runtime-darwin.mjs` records "GJS ships no ' +
-            'relocation", which is why ADR 0024 § 4 derives Node on macOS and stage 7 is what would change it',
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: MACOS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: macosArch,
         // The BINARY name, version and arch — the zip's convention and not the
@@ -577,11 +587,13 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
     //     (#1354 M5), which is why `Layout.metadata` answers `[]` here.
     //   * `x64` alone, and the blocker is upstream — see `WINDOWS_ARCH`.
     //
-    // NEITHER IS SIGNED, and Windows is the softer of the two asymmetries ADR 0024
-    // § A5 records: Gatekeeper BLOCKS an unsigned `.app`, while SmartScreen only
-    // WARNS until per-file download reputation accrues. So an unsigned program
-    // directory is a usable artifact in a way an unsigned `.app` is not. Signing is
-    // #1354 M6; the `.msi` around this tree is M5.
+    // NEITHER IS SIGNED BY DEFAULT, and Windows is the softer of the two asymmetries
+    // ADR 0024 § A5 records: Gatekeeper BLOCKS an unsigned `.app`, while SmartScreen
+    // only WARNS until per-file download reputation accrues. So an unsigned program
+    // directory is a usable artifact in a way an unsigned `.app` is not. `--sign`
+    // reaches these rows through `SIGNERS.win32` (signtool — argv unit-tested, the
+    // invocation itself UNVERIFIED, since no run here has ever held a certificate);
+    // the `.msi` around this tree is the third row below.
     'windows-dir': {
         id: 'windows-dir',
         layoutOs: 'win32',
@@ -631,14 +643,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // host on Windows at all (ADR 0024 § 4), so a `--app gjs` payload has
         // nothing anywhere that could run it.
         interpreters: ['node'],
-        interpreterGap:
-            'there is no GJS host on Windows at all (ADR 0024 § 4) — not a system one to depend on and not a ' +
-            'relocatable one to carry — so a `--app gjs` payload cannot be shipped this way. That is why ' +
-            '§ 4 derives Node here, and why `@gjsify/node-runtime-win32-x64` exists',
-        // rpm's `share/licenses/<name>/LICENSE` shape, the same one the macOS rows
-        // follow — one layout for a reader to learn, and the map turns it into
-        // `share\licenses\<name>\LICENSE` inside the program directory.
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: WINDOWS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: windowsArch,
         // The DISPLAY name: this artifact is the directory an installer lays down
@@ -675,11 +681,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         },
         depends: null,
         interpreters: ['node'],
-        interpreterGap:
-            'there is no GJS host on Windows at all (ADR 0024 § 4) — not a system one to depend on and not a ' +
-            'relocatable one to carry — so a `--app gjs` payload cannot be shipped this way. That is why ' +
-            '§ 4 derives Node here, and why `@gjsify/node-runtime-win32-x64` exists',
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: WINDOWS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: windowsArch,
         // The BINARY name here and the display name above, exactly as the macOS
@@ -781,11 +784,8 @@ export const FORMATS: Record<FormatId, FormatDescriptor> = {
         // installer does not change that; it moves the same self-contained tree.
         depends: null,
         interpreters: ['node'],
-        interpreterGap:
-            'there is no GJS host on Windows at all (ADR 0024 § 4) — not a system one to depend on and not a ' +
-            'relocatable one to carry — so a `--app gjs` payload cannot be shipped this way. That is why ' +
-            '§ 4 derives Node here, and why `@gjsify/node-runtime-win32-x64` exists',
-        licenseDest: (binaryName) => `share/licenses/${binaryName}/LICENSE`,
+        interpreterGap: WINDOWS_INTERPRETER_GAP,
+        licenseDest: SHARE_LICENSE_DEST,
         licenseKind: 'plain',
         archName: windowsArch,
         // The BINARY name, like the zip beside it and for the same reason: this is a

--- a/packages/infra/cli/src/utils/ship/layout.ts
+++ b/packages/infra/cli/src/utils/ship/layout.ts
@@ -343,11 +343,12 @@ export const LAYOUTS: Record<LayoutName, Layout> = {
         dirs: () => ({ launcher: '', bundle: 'app', native: 'lib', data: 'share', other: '' }),
         // Nothing, and this is the row that shows the field is not a macOS detail
         // wearing a general name: a Windows installer's metadata lives in the
-        // `.msi`'s own tables (#1354 M5), not in a file inside the program
-        // directory. Two format rows now wrap this layout and neither added one,
-        // which is the answer holding rather than the question being unasked. If
-        // the `.msi` turns out to need a file here, THIS is where it goes — not a
-        // branch in the stager.
+        // `.msi`'s own tables, not in a file inside the program directory. THREE
+        // format rows wrap this layout now, and the installer — the one that could
+        // have needed a file here — did not: `msi.ts` puts every such fact in the
+        // `Product`/`Package` attributes of the document it renders. So the answer
+        // held rather than the question going unasked, and if a fourth row ever
+        // needs a file, THIS is where it goes — not a branch in the stager.
         metadata: () => [],
         // ONE, and the blocker is a project we do not own. `wingtk/gvsbuild`
         // hardcodes `self.platform = "x64"` in `utils/base_project.py` and its last

--- a/packages/infra/cli/src/utils/ship/mime.ts
+++ b/packages/infra/cli/src/utils/ship/mime.ts
@@ -11,16 +11,7 @@
 // the MIME cache on install (see `scripts.ts`) — an unrefreshed cache is the same silence again.
 
 import type { ShipMimeType } from './types.js';
-
-/** XML text escaping. Only the five that matter in element content and attributes. */
-function esc(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&apos;');
-}
+import { xmlEscape as esc } from './xml.js';
 
 const TYPE_RE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/;
 

--- a/packages/infra/cli/src/utils/ship/msi.spec.ts
+++ b/packages/infra/cli/src/utils/ship/msi.spec.ts
@@ -22,8 +22,8 @@ import {
     msiUpgradeCode,
     renderWxs,
     uuid5,
-    xmlEscape,
 } from './msi.js';
+import { xmlEscape } from './xml.js';
 import type { PackSettings } from './types.js';
 
 const SETTINGS: PackSettings = {

--- a/packages/infra/cli/src/utils/ship/msi.ts
+++ b/packages/infra/cli/src/utils/ship/msi.ts
@@ -69,6 +69,7 @@ import { join, posix } from 'node:path';
 
 import { describeExit, spawnToCompletion } from '../spawn.js';
 import type { HostOs, PackSettings } from './types.js';
+import { xmlEscape } from './xml.js';
 
 /**
  * The UUID namespace every GUID in a generated `.msi` is derived under.
@@ -186,16 +187,6 @@ export function msiIdentifier(prefix: string, path: string): string {
     const safe = path.replace(/[^A-Za-z0-9_.]/g, '_');
     const room = 72 - prefix.length - 2 - digest.length;
     return `${prefix}_${safe.length > room ? safe.slice(safe.length - room) : safe}_${digest}`;
-}
-
-/** XML attribute/text escaping. `'` too, so the renderer may quote either way. */
-export function xmlEscape(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&apos;');
 }
 
 /**

--- a/packages/infra/cli/src/utils/ship/node-runtime.spec.ts
+++ b/packages/infra/cli/src/utils/ship/node-runtime.spec.ts
@@ -3,8 +3,9 @@
 // half of the three `@gjsify/node-runtime-*` packages.
 //
 // The claim these tests exist to hold up is a claim about somebody else's
-// project: an app author adds NOTHING to `package.json`, and the shipper finds
-// the interpreter by name. A test that only exercised this monorepo could not
+// project: the shipper finds the interpreter BY NAME in the consumer's own
+// `node_modules`, with no dependency edge from anything of gjsify's reaching it.
+// A test that only exercised this monorepo could not
 // distinguish that from "it works because it is sitting in our tree" — so every
 // case below builds a throwaway consumer whose `node_modules` contains exactly
 // one package and nothing of gjsify at all.

--- a/packages/infra/cli/src/utils/ship/node-runtime.ts
+++ b/packages/infra/cli/src/utils/ship/node-runtime.ts
@@ -10,9 +10,15 @@
 // stating: `verify-published-closure.mjs` has no edge to check here, so the
 // package's own publish job is the guard.
 //
-// For an app author that means **nothing to add to `package.json`**. The shipper
-// resolves the name for the target it is packaging and copies `nodePath` into the
-// artifact; `GJSIFY_NODE_RUNTIME` overrides it with a directory.
+// WHAT THE ABSENT EDGE DOES AND DOES NOT BUY, because this header used to claim
+// the app author had "nothing to add to `package.json`" and the shipped behaviour
+// says otherwise. What is absent is GJSIFY's edge: installing `@gjsify/cli` drags
+// in no interpreter for a platform nobody is shipping to. Finding one is still the
+// SHIPPER's job and it looks in the consumer's own `node_modules` — which is why
+// `stageAppRuntime` names the package when there is none: "no bundled interpreter
+// — install `@gjsify/node-runtime-<target>`". So an author who wants a
+// self-contained artifact installs, and therefore declares, the runtime for the
+// target they package; `GJSIFY_NODE_RUNTIME` is the override that skips it.
 //
 // LINUX IS ABSENT ON PURPOSE and is not an omission to be filled in later: a
 // `.deb`/`.rpm` declares a dependency on the distribution's Node instead
@@ -31,8 +37,8 @@
 //
 // The tests keep the by-name claim honest independently of any caller: they
 // resolve a real installed package out of a throwaway consumer tree holding
-// nothing of gjsify, so "an app author adds nothing to `package.json`" is checked
-// against a stranger's layout rather than against this monorepo's.
+// nothing of gjsify, so the resolution is checked against a stranger's layout
+// rather than against this monorepo's.
 
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';

--- a/packages/infra/cli/src/utils/ship/schemas.ts
+++ b/packages/infra/cli/src/utils/ship/schemas.ts
@@ -11,16 +11,19 @@
 // against.
 //
 // AT STAGE TIME, not at pack time, and that is the decision worth stating.
-// A stage is the deliverable for a layout no format wrapped until now, and the
-// warning `gjsify ship` prints about it is a claim about the TREE — leaving the
-// compile to a packer would keep `--stage` producing an aborting bundle while
-// the message said otherwise.
+// A stage is a deliverable in its own right — it is what crosses to the host
+// that finishes a `.dmg` or an `.msi` — and the warning `gjsify ship` prints
+// about it is a claim about the TREE. Leaving the compile to a packer would keep
+// `--stage` producing an aborting bundle while the message said otherwise.
 //
 // The cost is that assembly now execs one tool for a non-Linux layout with
 // schemas in the payload. That does not make assembly host-BOUND (ADR 0024 § A1):
 // `glib-compile-schemas` is GLib's and runs on all three OSes, which is why the
-// two macOS format rows stay `finishOn: 'any'` and declare the tool through
-// `requiredTools` instead.
+// four rows that ASSEMBLE a non-Linux tree — the `.app`, its zip, the Windows
+// program directory and its zip — stay `finishOn: 'any'` and declare the tool
+// through `requiredTools` instead. The `.dmg` and the `.msi` deliberately do not
+// declare it: they wrap a tree that is already assembled, so a `--from-stage`
+// pack of one needs no GLib at all (the `macos-app-dmg` row says so).
 
 import { execFile } from 'node:child_process';
 import { basename, join } from 'node:path';

--- a/packages/infra/cli/src/utils/ship/stage-manifest.ts
+++ b/packages/infra/cli/src/utils/ship/stage-manifest.ts
@@ -477,7 +477,12 @@ export function assertFormatsStaged(manifest: StageManifest, formats: readonly F
     const missing = formats.filter((format) => !manifest.formats.includes(format.id)).map((format) => format.id);
     if (missing.length === 0) return;
     throw new Error(
-        `gjsify ship: this stage was assembled for ${manifest.formats.join(', ')}, and --target names ` +
+        // `no format at all` and not an empty join: a stage CAN record zero formats
+        // (`gjsify.ship.targets` filtered to a layout none of them wrap), and the
+        // join printed that as nothing — "assembled for , and --target names …".
+        `gjsify ship: this stage was assembled for ${
+            manifest.formats.length === 0 ? 'no format at all' : manifest.formats.join(', ')
+        }, and --target names ` +
             `${missing.join(', ')}. Phase one renders each format's overlay — rpm wants the licence at ` +
             '`share/licenses/<pkg>/LICENSE`, deb wants a machine-readable copyright at ' +
             '`share/doc/<pkg>/copyright` — so a format the stage never saw would pack without it, and Debian ' +

--- a/packages/infra/cli/src/utils/ship/types.ts
+++ b/packages/infra/cli/src/utils/ship/types.ts
@@ -266,8 +266,8 @@ export interface FormatDescriptor {
      * suffix, because `packOne` reports a SIZE and `statSync` on a directory
      * answers 4096 on ext4 — a `.app` carrying a 20 MiB bundle would be printed
      * as "4096 bytes", which is not a rounding error but a different number
-     * entirely. A `.dmg` will be `'file'` again, so this is not "macOS is
-     * special", it is a property of the container.
+     * entirely. The `.dmg` over that same tree is `'file'` again, which is what
+     * makes this a property of the CONTAINER rather than "macOS is special".
      */
     artifactKind: 'file' | 'directory';
 }

--- a/packages/infra/cli/src/utils/ship/xml.ts
+++ b/packages/infra/cli/src/utils/ship/xml.ts
@@ -1,0 +1,26 @@
+// The XML escape `gjsify ship`'s document renderers share.
+//
+// TWO COPIES BECAME ONE. `mime.ts` and `msi.ts` each grew their own — five
+// replacements, same entities, same order, byte-identical bodies — one milestone
+// apart, by people who never saw the other file. The second copy is where the
+// helper goes.
+//
+// `plist.ts` keeps its own and that divergence CARRIES something: a plist value
+// lands only in element CONTENT, so `"` and `'` are left as themselves rather
+// than becoming entities a human reading `Info.plist` has to decode. This one is
+// used in ATTRIBUTES too — a `.wxs` is almost nothing else — so it escapes both.
+
+/**
+ * Escape a value for XML element content or an attribute value.
+ *
+ * `&` FIRST, or the ampersands the four later replacements introduce are escaped
+ * again and `Ship & Co` comes out as `Ship &amp;amp; Co`.
+ */
+export function xmlEscape(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&apos;');
+}

--- a/tests/e2e/ship-layout/run.mjs
+++ b/tests/e2e/ship-layout/run.mjs
@@ -34,7 +34,6 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { createHash } from 'node:crypto';
 import {
     copyFileSync,
     existsSync,
@@ -50,7 +49,16 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { runCli, runCliSync } from '../mock-registry.mjs';
-import { APP_ID, CLI_ENTRY, MONOREPO_ROOT, listPayload, scaffold, STAGE_MANIFEST_FILE } from '../ship/fixture.mjs';
+import {
+    APP_ID,
+    CLI_ENTRY,
+    listPayload,
+    MONOREPO_ROOT,
+    scaffold,
+    sha256,
+    shipExpectingFailure,
+    STAGE_MANIFEST_FILE,
+} from '../ship/fixture.mjs';
 
 const { readLibrary } = await import(
     pathToFileURL(join(MONOREPO_ROOT, 'packages', 'infra', 'manifest-conformance', 'lib', 'binary.mjs')).href
@@ -161,16 +169,6 @@ const UNPACKABLE = {
 /** `<os>` → the `${process.platform}-${process.arch}` string its stage manifest records. */
 const TARGET = { linux: `linux-${ARCH}`, darwin: `darwin-${ARCH}`, windows: `win32-${ARCH}` };
 
-const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex');
-
-/**
- * Run the CLI expecting a REFUSAL, and return everything it said.
- *
- * `runCliSync` throws on a non-zero exit and hangs the output off the error, so
- * a refusal has to be caught to be read. `assert.fail` inside the `try` is what
- * makes a run that unexpectedly SUCCEEDS fail the test — without it, a broken
- * gate reads as a passing assertion about an error that never happened.
- */
 /**
  * Run the CLI and return both streams plus the status.
  *
@@ -180,15 +178,6 @@ const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest(
  */
 function runCliCapture(args, cwd) {
     return runCli(CLI_ENTRY, args, { cwd });
-}
-
-function shipExpectingFailure(args, cwd) {
-    try {
-        runCliSync(CLI_ENTRY, args, { cwd });
-    } catch (error) {
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    assert.fail(`expected \`gjsify ${args.join(' ')}\` to fail`);
 }
 
 describe('CLI ship layout axis E2E', { timeout: 10 * 60 * 1000 }, () => {
@@ -539,14 +528,15 @@ describe('CLI ship layout axis E2E', { timeout: 10 * 60 * 1000 }, () => {
             );
             assert.match(output, /the payload is arm64, but the package would be labelled x64/);
         }
-        // WHAT THIS DOES NOT PROVE, and the windows row is the one to read
-        // carefully: the fixture's native file is a Mach-O, so all three legs
-        // exercise the LAYOUT and the same Mach-O branch of `readBinaryArch`.
-        // That reader returns `null` for PE by design (`payload.ts` says so), so
-        // a Windows payload whose only native file is a `.dll` cannot trip this
-        // check at all — the guard is silent there rather than wrong, and closing
-        // it means teaching `readBinaryArch` the COFF machine field.
-        // `status/open-todos.md` item 5 carries it.
+        // WHAT THIS DOES NOT PROVE: the fixture's native file is a Mach-O, so all
+        // three legs exercise the LAYOUT and the same Mach-O branch of
+        // `readBinaryArch`. When this was written that reader answered `null` for
+        // PE, so a Windows payload whose one native file is a `.dll` could not trip
+        // the check at all. #1354 M3 closed that: `readBinaryArch` reads the COFF
+        // machine field now, `payload.spec.ts` covers the three PE machines, and
+        // `tests/e2e/ship-windows` refuses an arm64 closure labelled x64 by name.
+        // So the gap this paragraph recorded is somebody else's test now, not an
+        // open item — what stays true is that THIS suite does not cover it.
     });
 
     it('classifies EVERY share/ entry the map carried, one severity apart', () => {

--- a/tests/e2e/ship-macos/run.mjs
+++ b/tests/e2e/ship-macos/run.mjs
@@ -88,12 +88,13 @@ const { buildZip } = await import(
 );
 
 /** The `--app node` project both phases of this suite pack. */
-function scaffoldNodeApp(dir) {
+function scaffoldNodeApp(dir, mutate) {
     return scaffold(dir, (pkg, at) => {
         pkg.gjsify.app = 'node';
         pkg.gjsify.main = 'dist/app.node.mjs';
         pkg.main = 'dist/app.node.mjs';
         writeFileSync(join(at, 'dist', 'app.node.mjs'), NODE_BUNDLE);
+        if (mutate) mutate(pkg, at);
     });
 }
 
@@ -321,6 +322,60 @@ describe('CLI ship macOS bundle E2E', { timeout: 10 * 60 * 1000 }, () => {
             readFileSync(join(projectDir, 'ship-default', 'stage', STAGE_MANIFEST_FILE), 'utf-8'),
         );
         assert.deepEqual(manifest.formats, ['deb', 'rpm']);
+    });
+
+    it('tells a stage with NO recorded formats what could pack it', () => {
+        // A REACHED "UNREACHABLE" BRANCH. `assertPackable`'s last throw is
+        // commented "UNREACHABLE FROM THE THREE LAYOUTS THAT EXIST … a layout
+        // added without a `FORMATS` row", and this is the two-command route into
+        // it: a `--app node` project whose `gjsify.ship.targets` name only Linux
+        // formats stages darwin with `formats: []`, and the finishing host has
+        // nothing but that empty list. MEASURED before the fix — three false
+        // sentences in one message:
+        //
+        //     gjsify ship: no format wraps the darwin layout, so there is nothing
+        //     to pack. This stage carries the darwin layout and nothing here can
+        //     wrap it … Keep it for the milestone that packs it … Every layout
+        //     this gjsify knows has one, so this is a layout added without a
+        //     `FORMATS` row.
+        //
+        // Three rows wrap darwin, the milestone that packs them landed, and the
+        // real cause — a configured target list for another layout — is nowhere in
+        // it. `packages/infra/cli/package.json` carries exactly that key, so this
+        // is reachable from inside this repository.
+        const dir = scaffoldNodeApp(join(tmpDir, 'targets-elsewhere'), (pkg) => {
+            pkg.gjsify.ship.targets = ['deb', 'rpm'];
+        });
+        runCliSync(CLI_ENTRY, ['ship', 'darwin', '--skip-build', '--arch', ARCH, '--stage'], { cwd: dir });
+        const manifest = JSON.parse(readFileSync(join(dir, 'ship', 'stage', STAGE_MANIFEST_FILE), 'utf-8'));
+        assert.deepEqual(manifest.formats, []);
+
+        const refusal = shipExpectingFailure(['ship', '--from-stage', 'ship/stage'], dir);
+        assert.doesNotMatch(refusal, /no format wraps the darwin layout/);
+        assert.doesNotMatch(refusal, /layout added without a `FORMATS` row/);
+        assert.match(refusal, /records no formats/);
+        // The three that DO wrap it, named — which is the only thing this host can
+        // say, since the reason the list is empty stayed on the assembling host.
+        assert.match(refusal, /macos-app, macos-app-dmg, macos-app-zip/);
+        assert.match(refusal, /--stage --target/);
+    });
+
+    it('names an EMPTY staged format list as empty, not as an blank gap', () => {
+        // The same stage one flag over. `assertFormatsStaged` renders
+        // `manifest.formats.join(', ')` straight into a sentence, so an empty list
+        // printed as nothing: MEASURED before the fix, `gjsify ship --from-stage
+        // ship/stage --target macos-app` began "this stage was assembled for , and
+        // --target names macos-app". The advice on the end was right; the clause
+        // that says WHY was a comma after a space.
+        const dir = scaffoldNodeApp(join(tmpDir, 'targets-elsewhere-target'), (pkg) => {
+            pkg.gjsify.ship.targets = ['deb', 'rpm'];
+        });
+        runCliSync(CLI_ENTRY, ['ship', 'darwin', '--skip-build', '--arch', ARCH, '--stage'], { cwd: dir });
+
+        const refusal = shipExpectingFailure(['ship', '--from-stage', 'ship/stage', '--target', 'macos-app'], dir);
+        assert.doesNotMatch(refusal, /assembled for , and/);
+        assert.match(refusal, /assembled for no format at all/);
+        assert.match(refusal, /gjsify ship --stage --target macos-app/);
     });
 
     it('refuses a `--app gjs` project by name, and still stages its layout', () => {

--- a/tests/e2e/ship-macos/run.mjs
+++ b/tests/e2e/ship-macos/run.mjs
@@ -60,8 +60,12 @@ import {
     listPayload,
     MONOREPO_ROOT,
     NODE_BUNDLE,
+    oracle,
+    oracleExpectingFailure,
     probe,
     scaffold,
+    sha256,
+    shipExpectingFailure,
     STAGE_MANIFEST_FILE,
 } from '../ship/fixture.mjs';
 
@@ -78,53 +82,10 @@ const BINARY = 'ship-demo';
 const ARCH = 'arm64';
 const ZIP_NAME = `${BINARY}-1.2.3-1.${ARCH}.zip`;
 
-const ORACLE = join(MONOREPO_ROOT, '.github', 'ship-oracle');
-
 /** The ZIP writer itself, for the two red runs no CLI invocation can produce. */
 const { buildZip } = await import(
     pathToFileURL(join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'lib', 'utils', 'ship', 'zip.js')).href
 );
-
-const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex');
-
-/**
- * Run one of the `.github/ship-oracle` scripts and return its output.
- *
- * `execFileSync` throws on a non-zero exit, which is what makes the GREEN calls
- * assertions in their own right: a `verify-*` script that starts failing fails
- * this suite without anything here having to inspect its words.
- */
-function oracle(script, args) {
-    const runner = script.endsWith('.py') ? 'python3' : 'bash';
-    return execFileSync(runner, [join(ORACLE, script), ...args], { encoding: 'utf-8' });
-}
-
-/**
- * Run an oracle expecting a REFUSAL, and return everything it printed.
- *
- * `assert.fail` inside the `try` is what makes a run that unexpectedly SUCCEEDS
- * fail the test. Without it, a `verify-*` that stopped checking would read here
- * as a passing assertion about an error that never happened — the exact shape
- * these discriminators exist to rule out.
- */
-function oracleExpectingFailure(script, args) {
-    try {
-        oracle(script, args);
-    } catch (error) {
-        assert.equal(error.status, 1, `${script} must exit 1, not ${error.status}`);
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    return assert.fail(`expected ${script} to refuse ${args.join(' ')}`);
-}
-
-function shipExpectingFailure(args, cwd, env) {
-    try {
-        runCliSync(CLI_ENTRY, args, { cwd, ...(env ? { env } : {}) });
-    } catch (error) {
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    return assert.fail(`expected \`gjsify ${args.join(' ')}\` to fail`);
-}
 
 /** The `--app node` project both phases of this suite pack. */
 function scaffoldNodeApp(dir) {
@@ -350,7 +311,7 @@ describe('CLI ship macOS bundle E2E', { timeout: 10 * 60 * 1000 }, () => {
     it('a bare `gjsify ship` on Linux still defaults to exactly deb and rpm', () => {
         // The regression these rows are most able to cause. Both are
         // `finishOn: 'any'`, so on that criterion alone a bare `gjsify ship` on
-        // Linux would emit four artifacts; `defaultFormatIds` filters on
+        // Linux would now emit SIX artifacts; `defaultFormatIds` filters on
         // `layoutOs` as a second criterion, which is what keeps this list at two.
         // `tests/e2e/ship-layout` asserts the same thing on a `--app gjs` project,
         // and this one adds the `--app node` half — the interpreter filter added

--- a/tests/e2e/ship-msi/run.mjs
+++ b/tests/e2e/ship-msi/run.mjs
@@ -43,11 +43,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { runCliSync } from '../mock-registry.mjs';
-import { CLI_ENTRY, listFiles, MONOREPO_ROOT, probe } from '../ship/fixture.mjs';
+import { CLI_ENTRY, listFiles, ORACLE, probe, shipExpectingFailure } from '../ship/fixture.mjs';
 import { APP_NAME, ARCH, BINARY, installRuntimePackages, scaffoldNodeApp } from '../ship/windows-fixture.mjs';
 
 const MSI_NAME = `${BINARY}-1.2.3-1.${ARCH}.msi`;
-const ORACLE = join(MONOREPO_ROOT, '.github', 'ship-oracle');
 
 /**
  * The two programs `msitools` ships, and they are REQUIRED on Linux rather than
@@ -76,15 +75,6 @@ function oracleExpectingFailure(args) {
         return `${error.stdout ?? ''}${error.stderr ?? ''}`;
     }
     return assert.fail(`expected verify-msi.sh to refuse ${args.join(' ')}`);
-}
-
-function shipExpectingFailure(args, cwd) {
-    try {
-        runCliSync(CLI_ENTRY, args, { cwd });
-    } catch (error) {
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    return assert.fail(`expected \`gjsify ${args.join(' ')}\` to fail`);
 }
 
 /**

--- a/tests/e2e/ship-windows/run.mjs
+++ b/tests/e2e/ship-windows/run.mjs
@@ -63,8 +63,12 @@ import {
     listFiles,
     listPayload,
     MONOREPO_ROOT,
+    oracle,
+    oracleExpectingFailure,
     probe,
     scaffold,
+    sha256,
+    shipExpectingFailure,
     STAGE_MANIFEST_FILE,
 } from '../ship/fixture.mjs';
 // The SUBJECT, shared with `tests/e2e/ship-msi`: one definition of the Windows
@@ -81,8 +85,6 @@ import {
 
 const ZIP_NAME = `${BINARY}-1.2.3-1.${ARCH}.zip`;
 
-const ORACLE = join(MONOREPO_ROOT, '.github', 'ship-oracle');
-
 /** The ZIP writer itself, for the red run no CLI invocation can produce. */
 const { buildZip } = await import(
     pathToFileURL(join(MONOREPO_ROOT, 'packages', 'infra', 'cli', 'lib', 'utils', 'ship', 'zip.js')).href
@@ -90,40 +92,6 @@ const { buildZip } = await import(
 
 const BINARY_READER = join(MONOREPO_ROOT, 'packages', 'infra', 'manifest-conformance', 'lib', 'binary.mjs');
 const { readLibrary } = await import(pathToFileURL(BINARY_READER).href);
-
-const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex');
-
-/**
- * Run one of the `.github/ship-oracle` scripts and return its output.
- *
- * `execFileSync` throws on a non-zero exit, which is what makes the GREEN calls
- * assertions in their own right: a `verify-*` script that starts failing fails
- * this suite without anything here having to inspect its words.
- */
-function oracle(script, args) {
-    const runner = script.endsWith('.py') ? 'python3' : 'bash';
-    return execFileSync(runner, [join(ORACLE, script), ...args], { encoding: 'utf-8' });
-}
-
-/** Run an oracle expecting a REFUSAL, and return everything it printed. */
-function oracleExpectingFailure(script, args) {
-    try {
-        oracle(script, args);
-    } catch (error) {
-        assert.equal(error.status, 1, `${script} must exit 1, not ${error.status}`);
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    return assert.fail(`expected ${script} to refuse ${args.join(' ')}`);
-}
-
-function shipExpectingFailure(args, cwd, env) {
-    try {
-        runCliSync(CLI_ENTRY, args, { cwd, ...(env ? { env } : {}) });
-    } catch (error) {
-        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
-    }
-    return assert.fail(`expected \`gjsify ${args.join(' ')}\` to fail`);
-}
 
 describe('CLI ship Windows program directory E2E', { timeout: 10 * 60 * 1000 }, () => {
     let tmpDir;

--- a/tests/e2e/ship/fixture.mjs
+++ b/tests/e2e/ship/fixture.mjs
@@ -4,12 +4,15 @@
 // scaffold would be a second definition of "a shippable project": the two suites would drift, and
 // the drifted one is the one that keeps passing while proving something else.
 
+import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { hasCommand } from '../helpers.mjs';
+import { runCliSync } from '../mock-registry.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -205,6 +208,71 @@ const REQUIRED_ON_LINUX = new Set([
     'desktop-file-validate',
     'appstreamcli',
 ]);
+
+/**
+ * The `.github/ship-oracle` scripts every packing suite reads its artifact back with.
+ *
+ * HERE rather than in each suite, and the four copies this replaced are the
+ * argument: `ORACLE`, `sha256`, `oracle` and `oracleExpectingFailure` were
+ * byte-identical in `ship-macos` and `ship-windows` (and `ORACLE` again in
+ * `ship-msi`), because each was written one milestone after the last by somebody
+ * who never saw the file beside it. An oracle helper is the worst thing to keep
+ * two copies of: a suite whose runner quietly stops discriminating still passes.
+ */
+export const ORACLE = join(MONOREPO_ROOT, '.github', 'ship-oracle');
+
+/** A file's SHA-256, for the two-artifacts-one-payload comparisons. */
+export const sha256 = (file) => createHash('sha256').update(readFileSync(file)).digest('hex');
+
+/**
+ * Run one of the `.github/ship-oracle` scripts and return its output.
+ *
+ * `execFileSync` throws on a non-zero exit, which is what makes the GREEN calls
+ * assertions in their own right: a `verify-*` script that starts failing fails
+ * the calling suite without anything there having to inspect its words.
+ */
+export function oracle(script, args) {
+    const runner = script.endsWith('.py') ? 'python3' : 'bash';
+    return execFileSync(runner, [join(ORACLE, script), ...args], { encoding: 'utf-8' });
+}
+
+/**
+ * Run an oracle expecting a REFUSAL, and return everything it printed.
+ *
+ * `assert.fail` after the `try` is what makes a run that unexpectedly SUCCEEDS
+ * fail the test. Without it, a `verify-*` that stopped checking would read as a
+ * passing assertion about an error that never happened — the exact shape these
+ * discriminators exist to rule out.
+ */
+export function oracleExpectingFailure(script, args) {
+    try {
+        oracle(script, args);
+    } catch (error) {
+        assert.equal(error.status, 1, `${script} must exit 1, not ${error.status}`);
+        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+    }
+    return assert.fail(`expected ${script} to refuse ${args.join(' ')}`);
+}
+
+/**
+ * Run the CLI expecting a REFUSAL, and return everything it said.
+ *
+ * `runCliSync` throws on a non-zero exit and hangs the output off the error, so a
+ * refusal has to be caught to be read. `assert.fail` after the `try` is what makes
+ * a run that unexpectedly SUCCEEDS fail the test — without it, a broken gate reads
+ * as a passing assertion about an error that never happened.
+ *
+ * `env` is optional because three of the four call sites that used to carry their
+ * own copy of this function never passed one.
+ */
+export function shipExpectingFailure(args, cwd, env) {
+    try {
+        runCliSync(CLI_ENTRY, args, { cwd, ...(env ? { env } : {}) });
+    } catch (error) {
+        return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+    }
+    return assert.fail(`expected \`gjsify ${args.join(' ')}\` to fail`);
+}
 
 export function probe(cmd) {
     if (hasCommand(cmd)) return true;

--- a/tests/e2e/ship/run.mjs
+++ b/tests/e2e/ship/run.mjs
@@ -41,6 +41,7 @@ import {
     plantCatalogue,
     probe,
     scaffold,
+    shipExpectingFailure,
     STAGE_MANIFEST_FILE,
     STAGE_SCHEMA_VERSION,
 } from './fixture.mjs';
@@ -552,6 +553,28 @@ describe('CLI ship E2E', { timeout: 10 * 60 * 1000 }, () => {
         }
         assert.match(output, /no `build` script/);
         assert.match(output, /--skip-build/);
+    });
+
+    it('names the exit code when the project build FAILS', () => {
+        // MEASURED before the fix: `gjsify ship: the project's build script
+        // failedcode 1.` The template was `failed${describeExit(result)}` with no
+        // space and no "with", so the one thing an author needs off this line was
+        // welded to the word before it. All 16 other `describeExit` call sites in
+        // this CLI spell it `... with ${...}`; this is the failure path `gjsify
+        // ship` reaches most often and the only one no test ever read.
+        //
+        // `code 1` and not `code 3`, deliberately: `ship` spawns `gjsify run
+        // build`, which prints the script's own status (the line above this one)
+        // and exits 1. The code named here is the CHILD's, which is what
+        // `describeExit` was handed.
+        const dir = scaffold(join(tmpDir, 'build-fails'), (pkg) => {
+            pkg.scripts.build = 'node -e "process.exit(3)"';
+        });
+        // NOT `runCliExpectingFailure`, which passes `--skip-build` — the one
+        // helper here that could never reach the line under test.
+        const output = shipExpectingFailure(['ship'], dir);
+        assert.match(output, /script "build" exited with code 3/);
+        assert.match(output, /the project's build script failed with code 1\./);
     });
 
     it('refuses a GI namespace it cannot map to a package', () => {


### PR DESCRIPTION
Eight PRs built `gjsify ship` over one session, written by five agents who each saw only their own milestone. Every PR was reviewed alone; nobody had read the result. This is that read, and the changes it can prove.

**Scope discipline.** A release is being cut from this code, so nothing here is speculative. Three defects are fixed and each has a test watched red; three duplications are merged and each is shown to change nothing; nine comments that describe a state the milestones overtook are corrected. Everything else found is listed at the bottom and left alone.

`git diff --shortstat 8182b6936..HEAD` → **20 files, +391 −273**.

## The defects (red, then green)

**1. The build-failure line had no space in it.** `failed${describeExit(result)}` — no `with`, no separator:

```
gjsify ship: the project's build script failedcode 1.
```

All 16 other `describeExit` call sites in this CLI spell it `... with ${...}`. This is the failure path `gjsify ship` reaches most often and the only one no test read (`grep -rn "build script" tests/e2e/ship*/` finds four hits, none on a failing build). New test in `tests/e2e/ship`, red against the string above.

**2. A branch commented `UNREACHABLE` that is reachable, and wrong in all three of its sentences.** Reproduced with two commands on an `--app node` project carrying `gjsify.ship.targets: ["deb","rpm"]` — the key `packages/infra/cli/package.json` itself carries:

```
$ gjsify ship darwin --skip-build --stage      # stage records formats: []
$ gjsify ship --from-stage ship/stage
gjsify ship: no format wraps the darwin layout, so there is nothing to pack. This stage
carries the darwin layout and nothing here can wrap it ... Keep it for the milestone that
packs it ... Every layout this gjsify knows has one, so this is a layout added without a
`FORMATS` row.
```

Three rows wrap darwin. The milestone that packs them landed at M2a/M4. And the real cause — a configured target list filtered to a layout none of its entries wrap — is nowhere in the message. `assertPackable` was missing the branch between *"the formats cannot run this interpreter"* and *"no format exists"*: **none were selected**. After:

```
gjsify ship: this run records no formats for the darwin layout, so there is nothing to pack
— and it is not that none exist: macos-app, macos-app-dmg, macos-app-zip wrap it.
    An empty list means none were SELECTED. ...
    Name one where the payload is assembled: `gjsify ship darwin --stage --target macos-app`.
```

That command works — verified end to end. The old throw stays for the fourth-layout case, now genuinely unreachable, with the predicate that makes it so in code rather than in a comment.

**3. An empty list printed as nothing.** One flag further down the same route, `assertFormatsStaged` joined `manifest.formats` straight into a sentence: `this stage was assembled for , and --target names macos-app`. A stage can legitimately record zero formats, so the empty case now reads `assembled for no format at all`.

Also drops `DmgPackInput.settings` — declared, passed by `commands/ship.ts`, never read.

**Runs.** 190 ship e2e tests green before, **192** after (three new, one pre-existing count unchanged); **3455** unit tests before and after.

## Duplication merged

Counted on the tree, not eyeballed.

| what | copies | measurement |
|---|---|---|
| `interpreterGap` prose in `FORMATS` | 3 macOS + 3 Windows + 2 distro | 5 redundant, verbatim |
| `licenseDest` arrow in `FORMATS` | 8 | 7 redundant, byte-identical |
| XML escaper (`mime.ts` `esc`, `msi.ts` `xmlEscape`) | 2 | `diff` over both bodies: empty |
| `oracle` (ship-macos / ship-windows) | 2 | 11/11 lines identical, doc included |
| `oracleExpectingFailure` | 2 | 9/9 identical |
| `shipExpectingFailure` | 4 | 8/8 identical in two, two near-copies |
| `sha256`, `ORACLE` | 3 each | `sort -u` → 1 |

The `interpreterGap` strings are the ones that mattered: they are **printed** — `assertFormatCanRunInterpreter` puts the row's own sentence in front of an author whose project cannot ship that way — so a correction on one row would have left the two beside it telling that same author something different about the same fact. That is the exact incident the field's own doc records, one level down. `WRITTEN_HERE` two lines above was already the precedent.

**Proving the `FORMATS` lift changes nothing:** a script dumps every observable value of all nine descriptors — `interpreterGap`, `licenseDest` over two names, `archName` over seven arches × `archIndependent`, `fileName`, `finishOn`, `requiredTools` resolved per host, the oracles, `defaultFormatIds`/`formatIdsFor` per OS, `windowsProgramDirName` over six names including its refusals — to 754 lines of JSON. Before and after: `diff` empty.

## Divergences kept, and what each carries

* **`requiredTools` is an array on eight rows and a per-OS map on `msi`.** Kept. The `.msi` is produced by `wixl` on Linux and WiX v3 on Windows out of one `.wxs`; a flat list demands `wixl` of a Windows host or silently says the other OS needs nothing. `requiredToolsOn` is the single resolver.
* **`finishOn` is `'any'`, `['darwin']`, `['linux','win32']`.** Three different facts: pure-JS writers, the only UDIF writer in existence, and two backends over one document.
* **`layoutOs` is not optional** — the prompt suggested some rows omit it; `grep -c 'layoutOs:'` over `formats.ts` is 9 for 9 rows. Nothing to reconcile.
* **Runtime staging is already one path.** `stageAppRuntime` has exactly one call site and derives every destination from `Layout.dirs`, so macOS and Windows share it and Linux stages none by design. There were never three stagers.
* **`plist.ts` keeps a three-entity XML escape** while the shared one has five: a plist value lands only in element content. The new module's header says so, which is what stops the next reader merging it too.
* **`SIGNERS` is a separate table from `FORMATS`,** keyed by layout: darwin has three format rows that must not be able to disagree about their signature.

## Seams closed

Each is a fact checkable in this tree.

* `node-runtime.ts` claimed an app author has **"nothing to add to `package.json`"**. No dependency edge exists anywhere (`@gjsify/cli` declares no `optionalDependencies` at all), so the shipper resolves the package out of the *consumer's* `node_modules` — which is why `stageAppRuntime` names it when absent: *"no bundled interpreter — install `@gjsify/node-runtime-<target>`"*. What is absent is gjsify's edge, not the author's declaration. The spec header repeated the claim.
* `app-runtime.ts` said **"THREE PIECES, THREE OWNERS"** above four bullets (four pieces, three owners — `@gjsify/node-gi` supplies two), and said `node-runtime.ts`'s header "records that NOTHING called it" when that header records the opposite.
* `app-runtime.ts`: `Contents/Frameworks` "is where `codesign` **will be** pointed at M6" — M6 landed.
* `formats.ts` called the `.dmg` **milestone M6**; it is M4. Both "NEITHER IS SIGNED" paragraphs predate signing.
* `types.ts`: "A `.dmg` **will be** `'file'` again" — it is.
* `layout.ts`: "**Two** format rows now wrap this layout" — three do, and the installer put its metadata in the `.wxs` rather than in a file.
* `schemas.ts`: "the **two** macOS format rows" — three, and the third declares `hdiutil`, not the schema compiler, deliberately.
* `dmg.ts` called `BUNDLE_NAME_FORBIDDEN` "the same **pair**" and said `\` "is not in this set". It is `/[/:\\]/`, and `git log -L` shows it never was anything else — right rule, invented reason.
* `commands/ship.ts`'s header described a command whose "scope today is Linux and `--app gjs`", with macOS, Windows and Flatpak as "later stages". Plus two counts ("darwin has two formats", "for windows it is still the whole story").
* `assertShippableTarget`'s doc ended "the day a Windows format exists, that warning has to become this refusal" — M3 is that day, and the refusal it became is `assertFormatCanRunInterpreter`, per format rather than per layout.
* `tests/e2e/ship-layout` said `readBinaryArch` "returns `null` for PE by design (`payload.ts` says so)" and pointed at an open-todos item. All four halves are false: `payload.ts` implements the PE branch, `payload.spec.ts` covers three PE machines, `tests/e2e/ship-windows` refuses an arm64 closure labelled x64 by name, and the ledger entry is struck through as CLOSED. The ledger was updated; the comment was not.
* `tests/e2e/ship-macos` and `tests/e2e/ship-windows` carry the *same* test with comments giving different counts — "four artifacts" vs "SIX". Six is right (`grep -c "finishOn: 'any'"` → 6).
* `tests/e2e/ship-layout` carried an **orphaned doc block**: the paragraph describing `shipExpectingFailure` sat above `runCliCapture`'s own doc, two functions away. Moving the function took its doc with it.

## Found, measured, and deliberately left alone

Each is real; none is small enough or safe enough to land hours before a release.

* **`appBundleDir` has no empty-name check.** `dmgVolumeName` and `windowsProgramDirName` both refuse an empty `settings.name` with a paragraph explaining why; the `.app` row does not, and `resolveShipSettings` derives the name as `metadata.name ?? titleCase(binaryName)` — `??` passes `''` straight through. `gjsify.ship.name: ""` produces an artifact literally called `.app`. **A new refusal is a behaviour change that can break somebody's pipeline**, which is the one thing this window cannot price. Worth a follow-up.
* **`msi.ts` claims `MSI_NAME_FORBIDDEN` is "A SUPERSET of `windowsProgramDirName`'s rules".** The character class is; the rules are not — it drops the reserved device names, the trailing dot/space and the control range. A payload file named `aux.js` renders into a `.wxs` for a file Windows cannot create. Different subject (payload segments vs the program directory), so it is a gap rather than a regression, and closing it means new refusals.
* **Five hand-written "run a tool and map its failure" wrappers.** `flatpak.ts:169-187` and `msi.ts:504-523` are the same 19-line function (six executable lines identical modulo `args` vs `[...args]`); `dmg.ts` inlines a sixth; `signing.ts` has two more with injected logging. A shared helper is the right answer and needs a parameterisation decision across five sites, three of which cannot be exercised on this workstation (no `hdiutil`, no `wixl`, and the flatpak build suite is off-limits).
* **`installRuntimePackages` is duplicated across `ship/windows-fixture.mjs` and `ship-macos/run.mjs`** — 31 identical lines, longest contiguous run 22. Lifting it means designing a platform-parameterised helper, which is restructuring rather than deletion.
* **`layout.os === 'linux'` is tested in three places** in `commands/ship.ts` for one predicate ("this layout has a package install step"). `Layout` already carries five such fields; this one never joined the table. A fourth OS would have to find all three.
* **The two zip arms of `packOne` differ only by a top level** that `windows-dir`'s own `fileName` already computes, and the three `writePayload` arms disagree about `stripPrefix` with a five-line comment where a descriptor field would do. The msi arm's `Source=` is correct only because `LAYOUTS.windows.root` returns `''`; nothing asserts it.
* **`--target`'s `--help` text hardcodes `linux`,** so none of the six non-Linux formats is ever named there, although `FORMAT_IDS` is used two fields up.
* **`payload.ts` carries a ~280-line `cmd.exe` batch parser** whose only job is to read back a launcher this tree just wrote, so a guard can compare it with a dependency this tree also derived. It caught a real defect once. It is also the largest "a guard that watches another mechanism" in the subsystem, and worth a design conversation rather than a pre-release edit.
* **Spec fixtures are never type-checked** (`tsconfig.json` excludes `src/**/*.spec.ts`), and `flatpak.spec.ts` builds a value annotated `: PackSettings` that is missing the required `name` — `...overrides` defeats the check.
* **No spawn in the subsystem has a timeout.** A hung `wixl`/`hdiutil`/`flatpak-builder` hangs the command.
* **`schemas.ts` uses `promisify(execFile)`,** which `check-spawn-teardown-contract.mjs` documents itself as not measuring, on a path awaited from a handler that returns rather than exiting.

## Verification

* `packages/infra/cli`: `gjsify tsc` exit 0; **3455** unit tests green (unchanged from baseline).
* `ship`, `ship-declaration`, `ship-from-stage`, `ship-layout`, `ship-macos`, `ship-signing`, `ship-windows`: **192/192**, exit 0.
* `ship-msi` cannot run on this workstation — no `msitools`, and the suite refuses rather than skipping. It produces the same 21 cancelled tests and the same single `wixl is not on PATH` error as at the merge base, so its module load and every import still resolve.
* `ship-flatpak` was read, never built.
* Gates, each in its gating mode, all exit 0: `check-ship-format-vocabulary`, `check-e2e-suite-coverage`, `check-e2e-harness-duplication`, `check-source-visibility`, `check-type-surfaces`, `check-doc-fences`, `check-spec-posix-literals`, `check-posix-path-slice`, `check-spawn-teardown-contract`, `check-lint-visibility`, `check-changelog-references`, `check-comment-budget`, `check-agent-context-size --check`, plus `gjsify lint` and `gjsify format --check` over `packages/infra/cli/src` and `tests/e2e`.
* One number moved the wrong way and is worth naming: `packages/infra/cli`'s comment-budget spare went from −3590 to −3641. The tree was already over; the two new refusal branches carry their measurements in comments. Non-blocking (`--warn` in CI), and stated rather than hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ptuk3enuQKoCy9akasnMfB
